### PR TITLE
No "login from new device" emails for `to_session`

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
@@ -39,7 +39,7 @@
 (defn jwt->session
   "Given a JWT, return a valid session token for the associated user (creating the user if necessary)."
   [jwt request]
-  (-> (session-data jwt request) :session :key))
+  (-> (session-data jwt (assoc request :token-exchange? true)) :session :key))
 
 (defn- throw-react-sdk-embedding-disabled
   []

--- a/enterprise/backend/test/metabase_enterprise/sso/api/sso_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/api/sso_test.clj
@@ -3,6 +3,8 @@
    [buddy.sign.jwt :as jwt]
    [clojure.string :as str]
    [clojure.test :refer :all]
+   [metabase.channel.email.messages :as messages]
+   [metabase.config.core :as config]
    [metabase.request.core :as request]
    [metabase.server.instance :as server.instance]
    [metabase.session.core :as session]
@@ -109,4 +111,20 @@
                                                 :exp (+ (int (/ (System/currentTimeMillis) 1000)) 3600)}
                                                "wrong-secret")]
               (is (= "Message seems corrupt or manipulated"
-                     (mt/client :post 401 "/auth/sso/to_session" {:jwt wrong-secret-token}))))))))))
+                     (mt/client :post 401 "/auth/sso/to_session" {:jwt wrong-secret-token})))))
+          (testing "does not send new device login email"
+            (let [email-addr  "to-session-no-email@example.com"
+                  emails-sent (atom [])]
+              (mt/with-temp [:model/User {user-id :id} {:email      email-addr
+                                                        :first_name "Test"
+                                                        :last_name  "NoEmail"}
+                             ;; existing login history so it's not the user's first login ever
+                             :model/LoginHistory _ {:user_id   user-id
+                                                    :device_id "existing-device"}]
+                (with-redefs [messages/send-login-from-new-device-email! (fn [info]
+                                                                           (swap! emails-sent conj info))]
+                  (let [jwt-token (create-valid-jwt-token {:email email-addr})
+                        response  (mt/client :post 200 "/auth/sso/to_session" {:jwt jwt-token})]
+                    (is (string? (:session_token response)))
+                    (is (= [] @emails-sent)
+                        "to_session endpoint should not send new device login emails")))))))))))

--- a/enterprise/backend/test/metabase_enterprise/sso/api/sso_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/api/sso_test.clj
@@ -4,7 +4,6 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.channel.email.messages :as messages]
-   [metabase.config.core :as config]
    [metabase.request.core :as request]
    [metabase.server.instance :as server.instance]
    [metabase.session.core :as session]

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/ldap_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/ldap_test.clj
@@ -138,22 +138,23 @@
       (ldap.test/with-ldap-server!
         (testing "when creating a new user via provider/login!, user attributes should get synced"
           (let [result (auth-identity/login! :provider/ldap
-                                             {:username "jsmith1"
-                                              :password "strongpassword"
-                                              :device-info {:device_id "test-device"
+                                             {:username    "jsmith1"
+                                              :password    "strongpassword"
+                                              :device-info {:device_id          "test-device"
                                                             :device_description "Test Device"
-                                                            :ip_address "127.0.0.1"
-                                                            :embedded false}})]
+                                                            :ip_address         "127.0.0.1"
+                                                            :embedded           false
+                                                            :token_exchange     false}})]
             (is (true? (:success? result)))
-            (is (= {:first_name "John"
-                    :last_name "Smith"
-                    :email "john.smith@metabase.com"
-                    :login_attributes {"uid" "jsmith1"
-                                       "mail" "John.Smith@metabase.com"
+            (is (= {:first_name       "John"
+                    :last_name        "Smith"
+                    :email            "john.smith@metabase.com"
+                    :login_attributes {"uid"       "jsmith1"
+                                       "mail"      "John.Smith@metabase.com"
                                        "givenname" "John"
-                                       "sn" "Smith"
-                                       "cn" "John Smith"}
-                    :common_name "John Smith"}
+                                       "sn"        "Smith"
+                                       "cn"        "John Smith"}
+                    :common_name      "John Smith"}
                    (into {} (t2/select-one [:model/User :first_name :last_name :email :login_attributes]
                                            :email "john.smith@metabase.com"))))))))))
 
@@ -164,18 +165,19 @@
         (testing "when creating a new user via provider/login! and attribute sync is disabled, attributes should not be synced"
           (mt/with-temporary-setting-values [ldap-sync-user-attributes false]
             (let [result (auth-identity/login! :provider/ldap
-                                               {:username "jsmith1"
-                                                :password "strongpassword"
-                                                :device-info {:device_id "test-device"
+                                               {:username    "jsmith1"
+                                                :password    "strongpassword"
+                                                :device-info {:device_id          "test-device"
                                                               :device_description "Test Device"
-                                                              :ip_address "127.0.0.1"
-                                                              :embedded false}})]
+                                                              :ip_address         "127.0.0.1"
+                                                              :embedded           false
+                                                              :token_exchange     false}})]
               (is (true? (:success? result)))
-              (is (= {:first_name "John"
-                      :last_name "Smith"
-                      :email "john.smith@metabase.com"
+              (is (= {:first_name       "John"
+                      :last_name        "Smith"
+                      :email            "john.smith@metabase.com"
                       :login_attributes nil
-                      :common_name "John Smith"}
+                      :common_name      "John Smith"}
                      (into {} (t2/select-one [:model/User :first_name :last_name :email :login_attributes]
                                              :email "john.smith@metabase.com")))))))))))
 
@@ -185,30 +187,32 @@
       (ldap.test/with-ldap-server!
         (testing "Existing user's attributes are updated via provider/login!"
           (let [result1 (auth-identity/login! :provider/ldap
-                                              {:username "jsmith1"
-                                               :password "strongpassword"
-                                               :device-info {:device_id "test-device"
+                                              {:username    "jsmith1"
+                                               :password    "strongpassword"
+                                               :device-info {:device_id          "test-device"
                                                              :device_description "Test Device"
-                                                             :ip_address "127.0.0.1"
-                                                             :embedded false}})
+                                                             :ip_address         "127.0.0.1"
+                                                             :embedded           false
+                                                             :token_exchange     false}})
                 result2 (auth-identity/login! :provider/ldap
-                                              {:username "jsmith1"
-                                               :password "strongpassword"
-                                               :device-info {:device_id "test-device"
+                                              {:username    "jsmith1"
+                                               :password    "strongpassword"
+                                               :device-info {:device_id          "test-device"
                                                              :device_description "Test Device"
-                                                             :ip_address "127.0.0.1"
-                                                             :embedded false}})]
+                                                             :ip_address         "127.0.0.1"
+                                                             :embedded           false
+                                                             :token_exchange     false}})]
             (is (true? (:success? result1)))
             (is (true? (:success? result2)))
-            (is (= {:first_name "John"
-                    :last_name "Smith"
-                    :common_name "John Smith"
-                    :email "john.smith@metabase.com"
-                    :login_attributes {"uid" "jsmith1"
-                                       "mail" "John.Smith@metabase.com"
+            (is (= {:first_name       "John"
+                    :last_name        "Smith"
+                    :common_name      "John Smith"
+                    :email            "john.smith@metabase.com"
+                    :login_attributes {"uid"       "jsmith1"
+                                       "mail"      "John.Smith@metabase.com"
                                        "givenname" "John"
-                                       "sn" "Smith"
-                                       "cn" "John Smith"}}
+                                       "sn"        "Smith"
+                                       "cn"        "John Smith"}}
                    (into {} (t2/select-one [:model/User :first_name :last_name :email :login_attributes]
                                            :email "john.smith@metabase.com"))))))))))
 
@@ -219,25 +223,27 @@
         (testing "Existing user's attributes are not updated via provider/login! when attribute sync is disabled"
           (mt/with-temporary-setting-values [ldap-sync-user-attributes false]
             (let [result1 (auth-identity/login! :provider/ldap
-                                                {:username "jsmith1"
-                                                 :password "strongpassword"
-                                                 :device-info {:device_id "test-device"
+                                                {:username    "jsmith1"
+                                                 :password    "strongpassword"
+                                                 :device-info {:device_id          "test-device"
                                                                :device_description "Test Device"
-                                                               :ip_address "127.0.0.1"
-                                                               :embedded false}})
+                                                               :ip_address         "127.0.0.1"
+                                                               :embedded           false
+                                                               :token_exchange     false}})
                   result2 (auth-identity/login! :provider/ldap
-                                                {:username "jsmith1"
-                                                 :password "strongpassword"
-                                                 :device-info {:device_id "test-device"
+                                                {:username    "jsmith1"
+                                                 :password    "strongpassword"
+                                                 :device-info {:device_id          "test-device"
                                                                :device_description "Test Device"
-                                                               :ip_address "127.0.0.1"
-                                                               :embedded false}})]
+                                                               :ip_address         "127.0.0.1"
+                                                               :embedded           false
+                                                               :token_exchange     false}})]
               (is (true? (:success? result1)))
               (is (true? (:success? result2)))
-              (is (= {:first_name "John"
-                      :last_name "Smith"
-                      :common_name "John Smith"
-                      :email "john.smith@metabase.com"
+              (is (= {:first_name       "John"
+                      :last_name        "Smith"
+                      :common_name      "John Smith"
+                      :email            "john.smith@metabase.com"
                       :login_attributes nil}
                      (into {} (t2/select-one [:model/User :first_name :last_name :email :login_attributes]
                                              :email "john.smith@metabase.com")))))))))))
@@ -248,17 +254,18 @@
       (ldap.test/with-ldap-server!
         (testing "a new user is created via provider/login! when they don't already exist"
           (let [result (auth-identity/login! :provider/ldap
-                                             {:username "jsmith1"
-                                              :password "strongpassword"
-                                              :device-info {:device_id "test-device"
+                                             {:username    "jsmith1"
+                                              :password    "strongpassword"
+                                              :device-info {:device_id          "test-device"
                                                             :device_description "Test Device"
-                                                            :ip_address "127.0.0.1"
-                                                            :embedded false}})]
+                                                            :ip_address         "127.0.0.1"
+                                                            :embedded           false
+                                                            :token_exchange     false}})]
             (is (true? (:success? result)))
-            (is (= {:first_name "John"
-                    :last_name "Smith"
+            (is (= {:first_name  "John"
+                    :last_name   "Smith"
                     :common_name "John Smith"
-                    :email "john.smith@metabase.com"}
+                    :email       "john.smith@metabase.com"}
                    (into {} (t2/select-one [:model/User :first_name :last_name :email] :email "john.smith@metabase.com"))))))))))
 
 (deftest create-user-without-givenname-test
@@ -267,15 +274,16 @@
       (ldap.test/with-ldap-server!
         (testing "a user without a givenName attribute has nil for that attribute"
           (let [result (auth-identity/login! :provider/ldap
-                                             {:username "jmiller"
-                                              :password "n0peeking"
-                                              :device-info {:device_id "test-device"
+                                             {:username    "jmiller"
+                                              :password    "n0peeking"
+                                              :device-info {:device_id          "test-device"
                                                             :device_description "Test Device"
-                                                            :ip_address "127.0.0.1"
-                                                            :embedded false}})]
+                                                            :ip_address         "127.0.0.1"
+                                                            :embedded           false
+                                                            :token_exchange     false}})]
             (is (true? (:success? result)))
-            (is (= {:first_name nil
-                    :last_name "Miller"
+            (is (= {:first_name  nil
+                    :last_name   "Miller"
                     :common_name "Miller"}
                    (into {} (t2/select-one [:model/User :first_name :last_name] :email "jane.miller@metabase.com"))))))))))
 
@@ -285,14 +293,15 @@
       (ldap.test/with-ldap-server!
         (testing "an error is thrown when a new user attempts to login via provider/login! and user provisioning is not enabled"
           (with-redefs [sso-settings/ldap-user-provisioning-enabled? (constantly false)
-                        appearance.settings/site-name (constantly "test")]
+                        appearance.settings/site-name                (constantly "test")]
             (is (thrown-with-msg?
                  clojure.lang.ExceptionInfo
                  #"Sorry, but you'll need a test account to view this page. Please contact your administrator."
                  (auth-identity/login! :provider/ldap
-                                       {:username "jsmith1"
-                                        :password "strongpassword"
-                                        :device-info {:device_id "test-device"
+                                       {:username    "jsmith1"
+                                        :password    "strongpassword"
+                                        :device-info {:device_id          "test-device"
                                                       :device_description "Test Device"
-                                                      :ip_address "127.0.0.1"
-                                                      :embedded false}})))))))))
+                                                      :ip_address         "127.0.0.1"
+                                                      :embedded           false
+                                                      :token_exchange     false}})))))))))

--- a/enterprise/backend/test/metabase_enterprise/support_access_grants/session_integration_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/support_access_grants/session_integration_test.clj
@@ -216,6 +216,7 @@
                                                                 :device-info {:device_id "test-device"
                                                                               :device_description "Test"
                                                                               :embedded false
+                                                                              :token_exchange false
                                                                               :ip_address "127.0.0.1"}})]
                         (is (:success? login-result) "Should be able to login with new password")))))))))))))
 

--- a/enterprise/backend/test/metabase_enterprise/support_access_grants/session_integration_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/support_access_grants/session_integration_test.clj
@@ -44,6 +44,7 @@
                                                             :device-info {:device_id "test-device"
                                                                           :device_description "Test"
                                                                           :embedded true
+                                                                          :token_exchange false
                                                                           :ip_address "127.0.0.1"}})]
                     (is (:success? login-result) "Should be able to login with new password")))))))))))
 
@@ -65,6 +66,7 @@
                                                         :device-info {:device_id "test-device"
                                                                       :device_description "Test"
                                                                       :ip_address "127.0.0.1"
+                                                                      :token_exchange false
                                                                       :embedded true}})]
                 (is (:success? login-result) "Should be able to login with new password")))))))))
 

--- a/src/metabase/login_history/models/login_history.clj
+++ b/src/metabase/login_history/models/login_history.clj
@@ -50,7 +50,7 @@
    device-info :- request/DeviceInfo]
   (let [login-history (merge {:user_id    user-id
                               :session_id session-id}
-                             (dissoc device-info :embedded))]
+                             (dissoc device-info :embedded :token_exchange))]
     (t2/insert! :model/LoginHistory login-history)
     login-history))
 

--- a/src/metabase/login_history/record.clj
+++ b/src/metabase/login_history/record.clj
@@ -37,7 +37,7 @@
                    [:last_login {:optional true} :any]]
    device-info :- request/DeviceInfo]
   (let [history-entry (login-history/record-login-history! session-id (u/the-id user) device-info)]
-    (when-not (:embedded device-info)
+    (when-not (or (:embedded device-info) (:token_exchange device-info))
       (maybe-send-login-from-new-device-email history-entry))
     (when-not (:last_login user)
       (snowplow/track-event! :snowplow/account {:event :new-user-created} (u/the-id user)))))

--- a/src/metabase/request/util.clj
+++ b/src/metabase/request/util.clj
@@ -87,14 +87,15 @@
 (def DeviceInfo
   "Schema for the device info returned by `device-info`."
   [:map {:closed true}
-   [:device_id          ms/NonBlankString]
-   [:device_description ms/NonBlankString]
-   [:embedded           ms/BooleanValue]
-   [:ip_address         ms/NonBlankString]])
+   [:device_id                           ms/NonBlankString]
+   [:device_description                  ms/NonBlankString]
+   [:embedded                            ms/BooleanValue]
+   [:ip_address                          ms/NonBlankString]
+   [:token_exchange                      ms/BooleanValue]])
 
 (mu/defn device-info :- DeviceInfo
   "Information about the device that made this request, as recorded by the `LoginHistory` table."
-  [{{:strs [user-agent]} :headers, :keys [browser-id], :as request}]
+  [{{:strs [user-agent]} :headers, :keys [browser-id token-exchange?], :as request}]
   (let [id          (or browser-id
                         (log/warn "Login request is missing device ID information"))
         description (or user-agent
@@ -106,7 +107,8 @@
     {:device_id          (or id (trs "unknown"))
      :device_description (or description (trs "unknown")),
      :embedded           (embed.util/is-modular-embedding-request? request)
-     :ip_address         (or ip-address (trs "unknown"))}))
+     :ip_address         (or ip-address (trs "unknown"))
+     :token_exchange     (boolean token-exchange?)}))
 
 (defn describe-user-agent
   "Format a user-agent string from a request in a human-friendly way."

--- a/test/metabase/auth_identity/session_test.clj
+++ b/test/metabase/auth_identity/session_test.clj
@@ -18,6 +18,7 @@
       (let [password-auth (t2/select-one :model/AuthIdentity :user_id (:id user) :provider "password")
             device-info {:device_id "test-device-123"
                          :embedded false
+                         :token_exchange false
                          :device_description "Test Browser"
                          :ip_address "127.0.0.1"}
             session (auth-identity/create-session-with-auth-tracking!
@@ -36,6 +37,7 @@
                                                     :metadata {:sso_source "google"}}]
       (let [device-info {:device_id "test-device-456"
                          :embedded false
+                         :token_exchange false
                          :device_description "Chrome Browser"
                          :ip_address "127.0.0.1"}
             session (auth-identity/create-session-with-auth-tracking! user device-info :provider/google)]
@@ -52,6 +54,7 @@
                                                   :metadata {:login_attributes {:uid "testuser"}}}]
       (let [device-info {:device_id "test-device-789"
                          :embedded false
+                         :token_exchange false
                          :device_description "Firefox Browser"
                          :ip_address "127.0.0.1"}
             session (auth-identity/create-session-with-auth-tracking! user device-info :provider/ldap)]
@@ -66,6 +69,7 @@
       (let [password-auth (t2/select-one :model/AuthIdentity :user_id (:id user) :provider "password")
             device-info {:device_id "test-device-last-used"
                          :embedded false
+                         :token_exchange false
                          :device_description "Test Browser"
                          :ip_address "127.0.0.1"}
             original-last-used (:last_used_at password-auth)]
@@ -80,10 +84,12 @@
       (let [password-auth (t2/select-one :model/AuthIdentity :user_id (:id user) :provider "password")
             device-info-1 {:device_id "device-1"
                            :embedded false
+                           :token_exchange false
                            :device_description "Browser 1"
                            :ip_address "127.0.0.1"}
             device-info-2 {:device_id "device-2"
                            :embedded false
+                           :token_exchange false
                            :device_description "Browser 2"
                            :ip_address "127.0.0.1"}
             session-1 (auth-identity/create-session-with-auth-tracking!
@@ -102,6 +108,7 @@
       (let [password-auth (t2/select-one :model/AuthIdentity :user_id (:id user) :provider "password")
             device-info {:device_id "test-device-cascade"
                          :embedded false
+                         :token_exchange false
                          :device_description "Test Browser"
                          :ip_address "127.0.0.1"}
             session (auth-identity/create-session-with-auth-tracking!
@@ -119,6 +126,7 @@
       (let [password-auth (t2/select-one :model/AuthIdentity :user_id (:id user) :provider "password")
             device-info {:device_id "test-device-multi"
                          :embedded false
+                         :token_exchange false
                          :device_description "Test Browser"
                          :ip_address "127.0.0.1"}
             password-session (auth-identity/create-session-with-auth-tracking!
@@ -135,6 +143,7 @@
     (mt/with-temp [:model/User user {}]
       (let [device-info {:device_id "test-device-type"
                          :embedded false
+                         :token_exchange false
                          :device_description "Test Browser"
                          :ip_address "127.0.0.1"}
             session (auth-identity/create-session-with-auth-tracking! user device-info :provider/password)]
@@ -148,6 +157,7 @@
       (mt/with-temp [:model/User user {}]
         (let [device-info {:device_id "test-device-type"
                            :embedded false
+                           :token_exchange false
                            :device_description "Test Browser"
                            :ip_address "127.0.0.1"}
               session (auth-identity/create-session-with-auth-tracking! user device-info :provider/password)]
@@ -163,6 +173,7 @@
         (t2/update! :model/AuthIdentity (:id password-auth) {:expires_at expires-at})
         (let [device-info {:device_id "test-device-expires"
                            :embedded false
+                           :token_exchange false
                            :device_description "Test Browser"
                            :ip_address "127.0.0.1"}
               session (auth-identity/create-session-with-auth-tracking! user device-info :provider/password)]
@@ -179,6 +190,7 @@
       (let [password-auth (t2/select-one :model/AuthIdentity :user_id (:id user) :provider "password")
             device-info {:device_id "test-device-no-expires"
                          :embedded false
+                         :token_exchange false
                          :device_description "Test Browser"
                          :ip_address "127.0.0.1"}
             session (auth-identity/create-session-with-auth-tracking! user device-info :provider/password)]

--- a/test/metabase/request/util_test.clj
+++ b/test/metabase/request/util_test.clj
@@ -53,19 +53,22 @@
     (is (= {:device_id          "129d39d1-6758-4d2c-a751-35b860007002"
             :device_description "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.72 Safari/537.36"
             :embedded           false
-            :ip_address         "0:0:0:0:0:0:0:1"}
+            :ip_address         "0:0:0:0:0:0:0:1"
+            :token_exchange     false}
            (req.util/device-info @mock-request))))
   (testing "SDK request"
     (is (= {:device_id          "129d39d1-6758-4d2c-a751-35b860007002"
             :device_description "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.72 Safari/537.36"
             :embedded           true
-            :ip_address         "0:0:0:0:0:0:0:1"}
+            :ip_address         "0:0:0:0:0:0:0:1"
+            :token_exchange     false}
            (req.util/device-info (update @mock-request :headers assoc "x-metabase-client" "embedding-sdk-react")))))
   (testing "Modular embedding request"
     (is (= {:device_id          "129d39d1-6758-4d2c-a751-35b860007002"
             :device_description "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.72 Safari/537.36"
             :embedded           true
-            :ip_address         "0:0:0:0:0:0:0:1"}
+            :ip_address         "0:0:0:0:0:0:0:1"
+            :token_exchange     false}
            (req.util/device-info (update @mock-request :headers assoc "x-metabase-client" "embedding-simple"))))))
 
 (deftest ^:parallel describe-user-agent-test

--- a/test/metabase/session/api_test.clj
+++ b/test/metabase/session/api_test.clj
@@ -728,7 +728,8 @@
       (t2/update! :model/User (u/the-id user) {:password nil, :password_salt nil})
       (let [device-info {:device_id          "Cam's Computer"
                          :device_description "The computer where Cam wrote this test"
-                         :embedded            false
+                         :embedded           false
+                         :token_exchange     false
                          :ip_address         "192.168.1.1"}]
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo

--- a/test/metabase/sso/providers/slack_connect_test.clj
+++ b/test/metabase/sso/providers/slack_connect_test.clj
@@ -229,7 +229,7 @@
                          :state "test-state"
                          :redirect-uri "https://metabase.example.com/auth/sso/slack-connect/callback"
                          :authenticated-user (delay user)
-                         :device-info {:device_id "test-device" :device_description "Test Device" :ip_address "127.0.0.1" :embedded false}}
+                         :device-info {:device_id "test-device" :device_description "Test Device" :ip_address "127.0.0.1" :embedded false :token_exchange false}}
                 result (auth-identity/login! :provider/slack-connect request)]
             (is (true? (:success? result)) "Login should succeed")
             (is (nil? (:session result)) "Result should not contain a session")
@@ -276,7 +276,7 @@
             (let [request {:code "test-code"
                            :state "test-state"
                            :redirect-uri "https://metabase.example.com/auth/sso/slack-connect/callback"
-                           :device-info {:device_id "test-device" :device_description "Test Device" :ip_address "127.0.0.1" :embedded false}}
+                           :device-info {:device_id "test-device" :device_description "Test Device" :ip_address "127.0.0.1" :embedded false :token_exchange false}}
                   result (auth-identity/login! :provider/slack-connect request)]
               (is (true? (:success? result)) "Login should succeed")
               (is (some? (:user result)) "Result should contain a user")
@@ -327,7 +327,7 @@
             (let [request {:code "test-code"
                            :state "test-state"
                            :redirect-uri "https://metabase.example.com/auth/sso/slack-connect/callback"
-                           :device-info {:device_id "test-device" :device_description "Test Device" :ip_address "127.0.0.1" :embedded false}}
+                           :device-info {:device_id "test-device" :device_description "Test Device" :ip_address "127.0.0.1" :embedded false :token_exchange false}}
                   result (auth-identity/login! :provider/slack-connect request)]
               (is (true? (:success? result)) "Login should succeed")
               ;; Verify AuthIdentity was created
@@ -375,7 +375,7 @@
                            :state "test-state"
                            :redirect-uri "https://metabase.example.com/auth/sso/slack-connect/callback"
                            :authenticated-user (delay user)
-                           :device-info {:device_id "test-device" :device_description "Test Device" :ip_address "127.0.0.1" :embedded false}}
+                           :device-info {:device_id "test-device" :device_description "Test Device" :ip_address "127.0.0.1" :embedded false :token_exchange false}}
                   result (auth-identity/login! :provider/slack-connect request)]
               (is (true? (:success? result)) "Login should succeed")
               (is (nil? (:session result)) "No session should be created in link-only mode")


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #68220
Prevent the /api/sso/to_session endpoint from sending "login from new device" emails. This endpoint is used for programmatic JWT-to-session token exchange, so new device notifications are noise. Login history is still recorded for audit purposes.
