### PR TITLE
More robust visualization settings normalization

### DIFF
--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -359,7 +359,6 @@
                     u/qualified-name
                     json/decode
                     ((fn [x]
-                       (println "x:" (pr-str x)) ; NOCOMMIT
                        (cond
                          (not (sequential? x)) x
                          (= (first x) "ref")   (lib/normalize ::viz-settings-ref x)

--- a/src/metabase/models/visualization_settings.cljc
+++ b/src/metabase/models/visualization_settings.cljc
@@ -18,7 +18,10 @@
 
   In general, conversion functions in this namespace (i.e. those that convert various pieces from one form to the other)
   will be prefixed with either `db->norm` or `norm->db`, depending on which direction they implement.
-  "
+
+  TODO (Cam 2026-02-18) move this out of the `models` module, it should either go into its own
+  `visualization-settings` module or into `queries` (so it can live with Saved Questions and friends). See
+  also [[metabase.models.interface/normalize-visualization-settings]]."
   (:require
    #?@(:clj [[metabase.util.json :as json]])
    [clojure.set :as set]

--- a/test/metabase/models/interface_test.clj
+++ b/test/metabase/models/interface_test.clj
@@ -176,6 +176,15 @@
             :graph.dimensions ["CREATED_AT"]}
            (mi/normalize-visualization-settings viz-settings)))))
 
+(deftest ^:parallel normalize-invalid-visualization-settings-test
+  (testing "Unknown keys in `:column_settings` should be removed rather than causing normalization to fail (#69626)"
+    (let [viz-settings {"column_settings" {"[\"ref\",[\"expression\",\"expression\"]]" {:number_style "x"}
+                                           "[\"REF\",[\"expression\",\"expression\"]]" {:number_style "y"}
+                                           "[\"bad-clause\",\"a\"]"                    {:number_style "z"}}}]
+      (is (= {:column_settings
+              {"[\"ref\",[\"expression\",\"expression\"]]" {:number_style "x"}}}
+             (mi/normalize-visualization-settings viz-settings))))))
+
 (deftest ^:parallel json-in-with-eliding
   (is (= "{}" (#'mi/json-in-with-eliding {})))
   (is (= (json/encode {:a "short"}) (#'mi/json-in-with-eliding {:a "short"})))

--- a/test/metabase/models/visualization_settings_test.cljc
+++ b/test/metabase/models/visualization_settings_test.cljc
@@ -1,5 +1,9 @@
 (ns metabase.models.visualization-settings-test
-  "Tests for the shared visualization-settings namespace functions"
+  "Tests for the shared visualization-settings namespace functions
+
+  TODO (Cam 2026-02-18) move this out of the `models` module, it should either go into its own
+  `visualization-settings` module or into `queries` (so it can live with Saved Questions and friends). See
+  also [[metabase.models.interface/normalize-visualization-settings]]."
   (:require #?@(:cljs [[goog.string :as gstring]]
                 :default [])
             [clojure.test :as t]


### PR DESCRIPTION
Don't throw an exception if viz settings `column_settings` contains invalid keys; remove those entries instead.

Fixes #69626