### PR TITLE
fix: cancel serialization when client disconnects

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -2518,6 +2518,7 @@
            plugins
            premium-features
            search
+           server
            setup
            util}}
 

--- a/enterprise/backend/src/metabase_enterprise/serialization/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/api.clj
@@ -1,6 +1,6 @@
 (ns metabase-enterprise.serialization.api
   (:require
-   [clojure.core.async :as async]
+   [clojure.core.async :as a]
    [clojure.java.io :as io]
    [clojure.string :as str]
    [java-time.api :as t]
@@ -161,7 +161,7 @@
 
 (defn- serialization-api-handler
   [collection result-atom opts]
-  (let [done-chan (async/chan)]
+  (let [done-chan (a/chan)]
     [(u.jvm/in-virtual-thread*
       (let [start (System/nanoTime)
             {:keys [archive report error-message] :as pack-result} (serialize&pack opts)]
@@ -182,7 +182,7 @@
                                  :success         (boolean archive)
                                  :error_message   error-message})
         (reset! result-atom pack-result)
-        (async/<!! done-chan nil)))
+        (a/>!! done-chan :done)))
      done-chan]))
 
 ;;; HTTP API
@@ -244,25 +244,28 @@
                             :full-stacktrace          full-stacktrace?}
         result (atom nil)
         [archive-thread finished-chan] (serialization-api-handler collection result opts)]
-    #_(if archive
-        {:status  200
-         :headers {"Content-Type"        "application/gzip"
-                   "Content-Disposition" (format "attachment; filename=\"%s\"" (.getName ^File archive))}
-         :body    (on-response! archive callback)}
-        {:status  (or status 500)
-         :headers {"Content-Type" "text/plain"}
-         :body    (on-response! log-file callback)})
-    (sr/streaming-response {:content-type "application/gzip"} [os cancel-chan]
-      (async/<!!
-       (async/go (case (async/alt! cancel-chan :cancel finished-chan :done)
-                   :cancel (do
-                             (future-cancel archive-thread)
-                             (.close os))
-                   :done (let [{:keys [archive _status log-file callback]} @result]
-                           (if archive
-                             (.write os archive)
-                             (.write os log-file))
-                           (future (callback)))))))))
+    (sr/streaming-response {:content-type "application/gzip" :status 200} [os cancel-chan]
+      (a/<!!
+       (a/go
+         (case (a/alt! cancel-chan :cancel finished-chan :done)
+           :cancel (do
+                     (future-cancel archive-thread)
+                     (when-let [cb (:callback @result)]
+                       (cb))
+                     (.close os))
+           :done (let [{:keys [archive status log-file callback]} @result]
+                   (try
+                     (if archive
+                       (do
+                         (sr/set-header! "Content-Disposition"
+                                         (format "attachment; filename=\"%s\"" (.getName ^File archive)))
+                         (io/copy archive os))
+                       (do
+                         (sr/set-status! (or status 500))
+                         (sr/set-content-type! "text/plain")
+                         (io/copy log-file os)))
+                     (finally
+                       (callback))))))))))
 
 ;; TODO (Cam 10/28/25) -- fix this endpoint so it uses kebab-case for query parameters for consistency with the rest
 ;; of the REST API

--- a/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
@@ -412,7 +412,7 @@
                                             :collection (:id coll) :data_model false :settings false
                                             :full_stacktrace true)
                   log (slurp (io/input-stream res))]
-              (is (< 200 (count (str/split-lines log))))
+              (is (< 50 (count (str/split-lines log))))
               ;; Pop out the error event
               (snowplow-test/pop-event-data-and-user-id!))))))))
 

--- a/src/metabase/server/streaming_response.clj
+++ b/src/metabase/server/streaming_response.clj
@@ -425,7 +425,6 @@
       (write-something-to-stream! os))
 
   `f` should block until it is completely finished writing to the stream, which will be closed thereafter.
-  NOTE: `canceled-chan` **IS NOT WORKING**; see `metabase.server.streaming-response-test/canceling-response-2`
   `canceled-chan` can be monitored to see if the request is canceled before results are fully written to the stream.
 
   Inside the body, [[*response*]] is bound to the `HttpServletResponse`. You can use the helper functions


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #46727

### Description

Use the streaming response cancel channel to listen for client disconnects. Run the serialization process in a virtual thread so we can hold an identifier to the thread and cancel it if the client hangs up. 

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
