### PR TITLE
Use partial settings update when switching branches during Remote Sync conflict

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/SyncConflictModal/SyncConflictModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/SyncConflictModal/SyncConflictModal.tsx
@@ -1,10 +1,7 @@
 import { useCallback, useMemo, useState } from "react";
 import { t } from "ttag";
 
-import {
-  useGetAdminSettingsDetailsQuery,
-  useGetSettingsQuery,
-} from "metabase/api";
+import { useGetSettingsQuery } from "metabase/api";
 import { useSetting } from "metabase/common/hooks";
 import { useSelector } from "metabase/lib/redux";
 import { useMetadataToasts } from "metabase/metadata/hooks";
@@ -15,13 +12,9 @@ import {
 } from "metabase-enterprise/api";
 import { useGetLibraryCollection } from "metabase-enterprise/data-studio/library/utils";
 import {
-  BRANCH_KEY,
   COLLECTIONS_KEY,
   REMOTE_SYNC_KEY,
-  TOKEN_KEY,
   TRANSFORMS_KEY,
-  TYPE_KEY,
-  URL_KEY,
 } from "metabase-enterprise/remote_sync/constants";
 import { getIsRemoteSyncReadOnly } from "metabase-enterprise/remote_sync/selectors";
 import type {
@@ -60,7 +53,6 @@ export const SyncConflictModal = (props: UnsyncedWarningModalProps) => {
   const isRemoteSyncEnabled = !!useSetting(REMOTE_SYNC_KEY);
   const isRemoteSyncReadOnly = useSelector(getIsRemoteSyncReadOnly);
   const { data: settingValues } = useGetSettingsQuery();
-  const { data: settingDetails } = useGetAdminSettingsDetailsQuery();
   const { data: libraryCollection } = useGetLibraryCollection({
     skip: !isRemoteSyncEnabled,
   });
@@ -80,14 +72,9 @@ export const SyncConflictModal = (props: UnsyncedWarningModalProps) => {
   const markLibraryAndTransformsAsSynced = useCallback(async () => {
     try {
       const remoteSyncSettings: RemoteSyncConfigurationSettings = {
-        [URL_KEY]: settingDetails?.[URL_KEY]?.value || null,
-        [TOKEN_KEY]: settingDetails?.[TOKEN_KEY]?.value || null,
-        [BRANCH_KEY]: settingValues?.[BRANCH_KEY] || null,
-        [TYPE_KEY]: settingValues?.[TYPE_KEY] || null,
         [COLLECTIONS_KEY]: (settingValues as RemoteSyncConfigurationSettings)[
           COLLECTIONS_KEY
         ],
-        [REMOTE_SYNC_KEY]: true,
         [TRANSFORMS_KEY]: true,
       };
 
@@ -106,7 +93,6 @@ export const SyncConflictModal = (props: UnsyncedWarningModalProps) => {
   }, [
     libraryCollection?.id,
     sendErrorToast,
-    settingDetails,
     settingValues,
     updateRemoteSyncSettings,
   ]);


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/UXW-3112/remote-sync-cant-push-to-a-new-branch-when-conflicts-are-detected

### Description
When there is a switch branch conflict and we choose to create a new branch, we were passing the full remote sync config object to the `/api/ee/remote-sync/settings` endpoint, but we only need to update the synced collections list.
This PR changes make `/api/ee/remote-sync/settings` accept a partial update so that we can mark Library and Transforms as synced without passing the whole remote sync settings object.

### How to verify

1. Set up Remote Sync without Library and Transforms marked as synced
2. Have a few things in your Library and/or Transforms pages
3. Try to switch to a branch where they are marked as synced
4. If that would cause your data to be overwritten, the conflict modal will appear
5. Choose the "Create a new branch and push" option, choose a branch name and confirm. It should work.
  5.1 To achive that, the frontend makes two requests: one to change the Remote Sync settings to updated the synced collection list, and another to actually stash the changes into a new branch.

### Demo
https://www.loom.com/share/f970a397d70d4e4b94113a28ac6edf09

### Checklist

- [X] Tests have been added/updated to cover changes in this PR