### PR TITLE
Write Connections for Actions, Model Persistence, Uploads

### DIFF
--- a/e2e/test/scenarios/admin/database-routing/database-routing-admin.cy.spec.ts
+++ b/e2e/test/scenarios/admin/database-routing/database-routing-admin.cy.spec.ts
@@ -520,7 +520,9 @@ describe("admin > database > database routing", () => {
             cy.findByLabelText("Model actions").should("be.disabled");
             cy.findByText(
               "Model actions cannot be enabled when database routing is enabled.",
-            ).should("be.visible");
+            )
+              .scrollIntoView()
+              .should("be.visible");
           });
         });
 

--- a/e2e/test/scenarios/admin/database-routing/database-routing-admin.cy.spec.ts
+++ b/e2e/test/scenarios/admin/database-routing/database-routing-admin.cy.spec.ts
@@ -614,6 +614,43 @@ describe("admin > database > database routing", () => {
           });
         });
       });
+
+      describe("Table editing", () => {
+        it("should not be possible to enable table editing when database routing is enabled", () => {
+          configurDbRoutingViaAPI({
+            router_database_id: WRITABLE_DB_ID,
+            user_attribute: "role",
+          });
+
+          visitDatabaseAdminPage(WRITABLE_DB_ID);
+
+          tableEditingSection().within(() => {
+            cy.findByLabelText("Editable tables").should("be.disabled");
+            cy.findByText(
+              "Table editing cannot be enabled when database routing is enabled.",
+            )
+              .scrollIntoView()
+              .should("be.visible");
+          });
+        });
+
+        it("should not be possible to enable table editing when database routing is enabled", () => {
+          visitDatabaseAdminPage(WRITABLE_DB_ID);
+
+          tableEditingSection()
+            .findByLabelText("Editable tables")
+            .click({ force: true });
+
+          dbRoutingSection().within(() => {
+            cy.findByLabelText("Enable database routing").should("be.disabled");
+            cy.findByText(
+              "Database routing can't be enabled when table editing is enabled.",
+            )
+              .scrollIntoView()
+              .should("be.visible");
+          });
+        });
+      });
     });
   });
 
@@ -695,4 +732,8 @@ function enableGlobalModelPersistence() {
 
 function workspacesSection() {
   return cy.findByTestId("database-workspaces-section");
+}
+
+function tableEditingSection() {
+  return cy.findByTestId("database-table-editing-section");
 }

--- a/e2e/test/scenarios/admin/database-routing/database-routing-admin.cy.spec.ts
+++ b/e2e/test/scenarios/admin/database-routing/database-routing-admin.cy.spec.ts
@@ -577,6 +577,43 @@ describe("admin > database > database routing", () => {
           });
         });
       });
+
+      describe("workspaces", () => {
+        it("should not be possible to workspaces routing when database routing is are enabled", () => {
+          configurDbRoutingViaAPI({
+            router_database_id: WRITABLE_DB_ID,
+            user_attribute: "role",
+          });
+
+          visitDatabaseAdminPage(WRITABLE_DB_ID);
+
+          workspacesSection().within(() => {
+            cy.findByLabelText("Enable workspaces").should("be.disabled");
+            cy.findByText(
+              "Workspaces cannot be enabled when database routing is enabled.",
+            )
+              .scrollIntoView()
+              .should("be.visible");
+          });
+        });
+
+        it("should not be possible to enable database routing when workspaces are enabled", () => {
+          visitDatabaseAdminPage(WRITABLE_DB_ID);
+
+          workspacesSection()
+            .findByLabelText("Enable workspaces")
+            .click({ force: true });
+
+          dbRoutingSection().within(() => {
+            cy.findByLabelText("Enable database routing").should("be.disabled");
+            cy.findByText(
+              "Database routing can't be enabled when workspaces are enabled.",
+            )
+              .scrollIntoView()
+              .should("be.visible");
+          });
+        });
+      });
     });
   });
 
@@ -654,4 +691,8 @@ function enableModelActionsViaApi(databaseId: DatabaseId) {
 function enableGlobalModelPersistence() {
   cy.visit("/admin/performance/models");
   cy.findByText("Disabled").click();
+}
+
+function workspacesSection() {
+  return cy.findByTestId("database-workspaces-section");
 }

--- a/e2e/test/scenarios/admin/database-routing/database-routing-admin.cy.spec.ts
+++ b/e2e/test/scenarios/admin/database-routing/database-routing-admin.cy.spec.ts
@@ -653,6 +653,35 @@ describe("admin > database > database routing", () => {
           });
         });
       });
+      describe("Uploads", () => {
+        it("should not be possible to enable uploads when database routing is enabled", () => {
+          configureDbRoutingViaAPI({
+            router_database_id: WRITABLE_DB_ID,
+            user_attribute: "role",
+          });
+
+          visitUploadSettingsPage();
+
+          cy.findByLabelText("Database to use for uploads").click();
+          H.popover()
+            .findByText("Writable Postgres12 (DB Routing Enabled)")
+            .should("be.visible");
+        });
+
+        it("should not be possible to enable database routing when uploads are enabled", () => {
+          H.enableUploads("postgres");
+          visitDatabaseAdminPage(WRITABLE_DB_ID);
+
+          dbRoutingSection().within(() => {
+            cy.findByLabelText("Enable database routing").should("be.disabled");
+            cy.findByText(
+              "Database routing can't be enabled if uploads are enabled for this database.",
+            )
+              .scrollIntoView()
+              .should("be.visible");
+          });
+        });
+      });
     });
   });
 
@@ -738,4 +767,8 @@ function workspacesSection() {
 
 function tableEditingSection() {
   return cy.findByTestId("database-table-editing-section");
+}
+
+function visitUploadSettingsPage() {
+  cy.visit("/admin/settings/uploads");
 }

--- a/e2e/test/scenarios/admin/database-routing/database-routing-admin.cy.spec.ts
+++ b/e2e/test/scenarios/admin/database-routing/database-routing-admin.cy.spec.ts
@@ -12,7 +12,7 @@ import { interceptPerformanceRoutes } from "../performance/helpers/e2e-performan
 
 import {
   BASE_POSTGRES_DESTINATION_DB_INFO,
-  configurDbRoutingViaAPI,
+  configureDbRoutingViaAPI,
   createDestinationDatabasesViaAPI,
 } from "./helpers/e2e-database-routing-helpers";
 
@@ -214,7 +214,7 @@ describe("admin > database > database routing", () => {
       cy.visit("/admin/databases/2");
       cy.log("disable model actions");
       cy.findByLabelText("Model actions").click({ force: true });
-      configurDbRoutingViaAPI({
+      configureDbRoutingViaAPI({
         router_database_id: 2,
         user_attribute: "role",
       });
@@ -341,7 +341,7 @@ describe("admin > database > database routing", () => {
       cy.findAllByTestId("database-model-features-section")
         .findByLabelText("Model actions")
         .should("not.be.checked");
-      configurDbRoutingViaAPI({
+      configureDbRoutingViaAPI({
         router_database_id: 2,
         user_attribute: "role",
       });
@@ -382,7 +382,7 @@ describe("admin > database > database routing", () => {
       cy.request("PUT", "/api/database/2", {
         settings: { "database-enable-actions": false },
       });
-      configurDbRoutingViaAPI({
+      configureDbRoutingViaAPI({
         router_database_id: 2,
         user_attribute: "role",
       });
@@ -432,7 +432,7 @@ describe("admin > database > database routing", () => {
         cy.findAllByTestId("database-model-features-section")
           .findByLabelText("Model actions")
           .click({ force: true });
-        configurDbRoutingViaAPI({
+        configureDbRoutingViaAPI({
           router_database_id: 2,
           user_attribute: "role",
         });
@@ -509,7 +509,7 @@ describe("admin > database > database routing", () => {
 
       describe("model actions", () => {
         it("should not be possible to enable model actions when database routing is enabled", () => {
-          configurDbRoutingViaAPI({
+          configureDbRoutingViaAPI({
             router_database_id: WRITABLE_DB_ID,
             user_attribute: "role",
           });
@@ -547,7 +547,7 @@ describe("admin > database > database routing", () => {
         });
 
         it("should not be possible to enable model persistence when database routing is enabled", () => {
-          configurDbRoutingViaAPI({
+          configureDbRoutingViaAPI({
             router_database_id: WRITABLE_DB_ID,
             user_attribute: "role",
           });
@@ -582,7 +582,7 @@ describe("admin > database > database routing", () => {
 
       describe("workspaces", () => {
         it("should not be possible to workspaces routing when database routing is are enabled", () => {
-          configurDbRoutingViaAPI({
+          configureDbRoutingViaAPI({
             router_database_id: WRITABLE_DB_ID,
             user_attribute: "role",
           });
@@ -619,7 +619,7 @@ describe("admin > database > database routing", () => {
 
       describe("Table editing", () => {
         it("should not be possible to enable table editing when database routing is enabled", () => {
-          configurDbRoutingViaAPI({
+          configureDbRoutingViaAPI({
             router_database_id: WRITABLE_DB_ID,
             user_attribute: "role",
           });

--- a/e2e/test/scenarios/admin/database-routing/database-routing-admin.cy.spec.ts
+++ b/e2e/test/scenarios/admin/database-routing/database-routing-admin.cy.spec.ts
@@ -331,52 +331,6 @@ describe("admin > database > database routing", () => {
       assertDbRoutingDisabled();
     });
 
-    it("should not allow turning conflicting features if db routing is enabled", () => {
-      cy.log("setup");
-      setupModelPersistence();
-      visitDatabaseAdminPage(WRITABLE_DB_ID);
-      cy.findAllByTestId("database-model-features-section")
-        .findByLabelText("Model actions")
-        .click({ force: true });
-      cy.findAllByTestId("database-model-features-section")
-        .findByLabelText("Model actions")
-        .should("not.be.checked");
-      configureDbRoutingViaAPI({
-        router_database_id: 2,
-        user_attribute: "role",
-      });
-      cy.reload();
-
-      cy.log("should not allow enabling model features");
-      cy.findAllByTestId("database-model-features-section")
-        .findByLabelText("Model actions")
-        .trigger("mouseenter", { force: true });
-      H.tooltip()
-        .findByText(
-          "Model actions can not be enabled if database routing is enabled.",
-        )
-        .should("exist");
-
-      cy.findAllByTestId("database-model-features-section").within(() => {
-        cy.findByLabelText("Model actions")
-          .should("be.disabled")
-          .should("not.be.checked");
-        cy.findByLabelText("Model persistence")
-          .should("be.disabled")
-          .should("not.be.checked");
-      });
-
-      cy.log("should not allow enabling database for uploads");
-      cy.visit("/admin/settings/uploads");
-      cy.findByLabelText("Upload Settings Form")
-        .findByPlaceholderText("Select a database")
-        .click();
-      H.popover()
-        .findByText("Writable Postgres12 (DB Routing Enabled)")
-        .closest('[data-combobox-option="true"]')
-        .should("have.attr", "data-combobox-disabled", "true");
-    });
-
     it("should highlight that a dabtabase has routing enabled on the permissions pages", () => {
       cy.log("setup");
       cy.request("PUT", "/api/database/2", {

--- a/e2e/test/scenarios/admin/database-routing/database-routing-admin.cy.spec.ts
+++ b/e2e/test/scenarios/admin/database-routing/database-routing-admin.cy.spec.ts
@@ -519,7 +519,7 @@ describe("admin > database > database routing", () => {
           modelsSection().within(() => {
             cy.findByLabelText("Model actions").should("be.disabled");
             cy.findByText(
-              "Model actions cannot be enabled when database routing is enabled.",
+              "Model actions can't be enabled when database routing is enabled.",
             )
               .scrollIntoView()
               .should("be.visible");
@@ -556,7 +556,7 @@ describe("admin > database > database routing", () => {
           modelsSection().within(() => {
             cy.findByLabelText("Model persistence").should("be.disabled");
             cy.findByText(
-              "Model persistence cannot be enabled when database routing is enabled.",
+              "Model persistence can't be enabled when database routing is enabled.",
             )
               .scrollIntoView()
               .should("be.visible");
@@ -592,7 +592,7 @@ describe("admin > database > database routing", () => {
           workspacesSection().within(() => {
             cy.findByLabelText("Enable workspaces").should("be.disabled");
             cy.findByText(
-              "Workspaces cannot be enabled when database routing is enabled.",
+              "Workspaces can't be enabled when database routing is enabled.",
             )
               .scrollIntoView()
               .should("be.visible");
@@ -629,7 +629,7 @@ describe("admin > database > database routing", () => {
           tableEditingSection().within(() => {
             cy.findByLabelText("Editable tables").should("be.disabled");
             cy.findByText(
-              "Table editing cannot be enabled when database routing is enabled.",
+              "Table editing can't be enabled when database routing is enabled.",
             )
               .scrollIntoView()
               .should("be.visible");

--- a/e2e/test/scenarios/admin/database-routing/database-routing-usage.cy.spec.ts
+++ b/e2e/test/scenarios/admin/database-routing/database-routing-usage.cy.spec.ts
@@ -9,7 +9,7 @@ import { interceptPerformanceRoutes } from "../performance/helpers/e2e-performan
 import {
   BASE_POSTGRES_DESTINATION_DB_INFO,
   DB_ROUTER_USERS,
-  configurDbRoutingViaAPI,
+  configureDbRoutingViaAPI,
   createDbWithIdentifierTable,
   createDestinationDatabasesViaAPI,
   signInAs,
@@ -33,7 +33,7 @@ describe("admin > database > database routing", { tags: ["@external"] }, () => {
     });
 
     H.addPostgresDatabase("lead", false, "lead", "leadDbId").then(function () {
-      configurDbRoutingViaAPI({
+      configureDbRoutingViaAPI({
         router_database_id: this.leadDbId,
         user_attribute: "destination_database",
       });

--- a/e2e/test/scenarios/admin/database-routing/helpers/e2e-database-routing-helpers.ts
+++ b/e2e/test/scenarios/admin/database-routing/helpers/e2e-database-routing-helpers.ts
@@ -8,7 +8,7 @@ import type { DatabaseData, User } from "metabase-types/api";
 
 const { ALL_USERS_GROUP, COLLECTION_GROUP } = USER_GROUPS;
 
-export function configurDbRoutingViaAPI({
+export function configureDbRoutingViaAPI({
   router_database_id,
   user_attribute,
 }: {

--- a/e2e/test/scenarios/admin/databases/database-writable-connection.cy.spec.ts
+++ b/e2e/test/scenarios/admin/databases/database-writable-connection.cy.spec.ts
@@ -1,5 +1,5 @@
 import { WRITABLE_DB_CONFIG, WRITABLE_DB_ID } from "e2e/support/cypress_data";
-import type { DatabaseId, TableId, TransformTagId } from "metabase-types/api";
+import type { DatabaseId, TransformTagId } from "metabase-types/api";
 
 const { H } = cy;
 
@@ -133,15 +133,11 @@ describe("scenarios > admin > databases > writable connection", () => {
     visitDatabase(WRITABLE_DB_ID);
     enableTableEditing();
 
-    H.getTableId({ databaseId: WRITABLE_DB_ID, name: TABLE_NAME }).then(
-      (tableId) => {
-        updateMainConnection(READ_ONLY_USER);
-        performTableEdit(tableId).then(expectFailure);
+    updateMainConnection(READ_ONLY_USER);
+    performTableEdit().then(expectFailure);
 
-        createWritableConnection(DEFAULT_USER);
-        performTableEdit(tableId).then(expectSuccess);
-      },
-    );
+    createWritableConnection(DEFAULT_USER);
+    performTableEdit().then(expectSuccess);
   });
 });
 
@@ -302,18 +298,21 @@ function enableTableEditing() {
   cy.findByLabelText("Editable tables").scrollIntoView().click();
 }
 
-function performTableEdit(tableId: TableId) {
-  return cy.request({
-    failOnStatusCode: false,
-    method: "POST",
-    url: "/api/ee/action-v2/execute-bulk",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      action: "data-grid.row/create",
-      scope: { "table-id": tableId },
-      inputs: [{ ID: 42 }],
-    }),
-  });
+function performTableEdit() {
+  return H.getTableId({ databaseId: WRITABLE_DB_ID, name: TABLE_NAME }).then(
+    (tableId) =>
+      cy.request({
+        failOnStatusCode: false,
+        method: "POST",
+        url: "/api/ee/action-v2/execute-bulk",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          action: "data-grid.row/create",
+          scope: { "table-id": tableId },
+          inputs: [{ ID: 42 }],
+        }),
+      }),
+  );
 }

--- a/e2e/test/scenarios/admin/databases/database-writable-connection.cy.spec.ts
+++ b/e2e/test/scenarios/admin/databases/database-writable-connection.cy.spec.ts
@@ -325,7 +325,6 @@ function runAction(actionId: number) {
 
 function expectFailure(response: Cypress.Response<unknown>) {
   expect(response.status).to.be.gte(400);
-  expect(response.status).to.be.lt(500);
 }
 
 function expectSuccess(response: Cypress.Response<unknown>) {

--- a/e2e/test/scenarios/admin/databases/database-writable-connection.cy.spec.ts
+++ b/e2e/test/scenarios/admin/databases/database-writable-connection.cy.spec.ts
@@ -325,6 +325,7 @@ function runAction(actionId: number) {
 
 function expectFailure(response: Cypress.Response<unknown>) {
   expect(response.status).to.be.gte(400);
+  expect(response.status).to.be.lt(500);
 }
 
 function expectSuccess(response: Cypress.Response<unknown>) {

--- a/e2e/test/scenarios/admin/databases/database-writable-connection.cy.spec.ts
+++ b/e2e/test/scenarios/admin/databases/database-writable-connection.cy.spec.ts
@@ -1,5 +1,5 @@
 import { WRITABLE_DB_CONFIG, WRITABLE_DB_ID } from "e2e/support/cypress_data";
-import type { DatabaseId, TransformTagId } from "metabase-types/api";
+import type { DatabaseId, TableId, TransformTagId } from "metabase-types/api";
 
 const { H } = cy;
 
@@ -280,11 +280,11 @@ function runAction(actionId: number) {
   });
 }
 
-function expectFailure(response: Response) {
+function expectFailure(response: Cypress.Response<unknown>) {
   expect(response.status).to.be.gte(400);
 }
 
-function expectSuccess(response: Response) {
+function expectSuccess(response: Cypress.Response<unknown>) {
   expect(response.status).to.be.lt(400);
 }
 

--- a/e2e/test/scenarios/admin/databases/database-writable-connection.cy.spec.ts
+++ b/e2e/test/scenarios/admin/databases/database-writable-connection.cy.spec.ts
@@ -151,7 +151,7 @@ function createTransform({ tagIds = [] }: { tagIds?: TransformTagId[] } = {}) {
         database: WRITABLE_DB_ID,
         type: "native",
         native: {
-          query: "SELECT 1 as num",
+          query: "SELECT * FROM ORDERS LIMIT 5",
         },
       },
     },

--- a/e2e/test/scenarios/admin/databases/database-writable-connection.cy.spec.ts
+++ b/e2e/test/scenarios/admin/databases/database-writable-connection.cy.spec.ts
@@ -409,7 +409,7 @@ function performUpload() {
       return cy.request({
         url: "/api/upload/csv",
         method: "POST",
-        // failOnStatusCode: false,
+        failOnStatusCode: false,
         headers: {
           "content-type": "multipart/form-data",
         },

--- a/enterprise/backend/test/metabase_enterprise/impersonation/driver_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/impersonation/driver_test.clj
@@ -8,6 +8,7 @@
    [metabase-enterprise.impersonation.util-test :as impersonation.util-test]
    [metabase-enterprise.test :as met]
    [metabase.driver :as driver]
+   [metabase.driver.connection :as driver.conn]
    [metabase.driver.settings :as driver.settings]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
@@ -261,6 +262,94 @@
                      java.lang.Exception
                      (mt/run-mbql-query venues
                        {:aggregation [[:count]]})))))))))))
+
+(deftest conn-impersonation-with-write-connection-test
+  (testing "Impersonation works correctly when queries go through the write connection pool"
+    (mt/test-drivers (mt/normal-drivers-with-feature :connection-impersonation)
+      (mt/with-premium-features #{:advanced-permissions}
+        (let [venues-table (sql.tx/qualify-and-quote driver/*driver* "test-data" "venues")
+              role-name    (u/lower-case-en (mt/random-name))]
+          (tx/with-temp-roles! driver/*driver*
+            (impersonation-granting-details driver/*driver* (mt/db))
+            {role-name {venues-table {}}}
+            (impersonation-default-user driver/*driver*)
+            (impersonation-default-role driver/*driver*)
+            (let [details (impersonation-details driver/*driver* (mt/db))]
+              (mt/with-temp [:model/Database database {:engine             driver/*driver*
+                                                       :details            details
+                                                       :write_data_details details}]
+                (mt/with-db database
+                  (when (driver/database-supports? driver/*driver* :connection-impersonation-requires-role nil)
+                    (t2/update! :model/Database :id (mt/id)
+                                (assoc-in (mt/db) [:details :role] (impersonation-default-role driver/*driver*))))
+                  (sync/sync-database! database {:scan :schema})
+                  (impersonation.util-test/with-impersonations!
+                    {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+                     :attributes     {"impersonation_attr" role-name}}
+                    (testing "Read connection: impersonation restricts access as expected"
+                      (is (= [[100]]
+                             (mt/formatted-rows [int]
+                                                (mt/run-mbql-query venues {:aggregation [[:count]]})))))
+                    (testing "Write connection: impersonation still restricts access"
+                      (driver.conn/with-write-connection
+                        (is (= [[100]]
+                               (mt/formatted-rows [int]
+                                                  (mt/run-mbql-query venues {:aggregation [[:count]]}))))))
+                    (testing "Write connection: impersonation blocks disallowed tables"
+                      (driver.conn/with-write-connection
+                        (is (thrown?
+                             java.lang.Exception
+                             (mt/run-mbql-query checkins {:aggregation [[:count]]})))))))))))))))
+
+;; Proves `with-write-connection` actually routes to the write connection pool by using
+;; two different Postgres users: a readonly user (for read) who is NOT a member of the
+;; impersonation role, and the original superuser (for write) who can SET ROLE to anything.
+;; If the write path mistakenly used the read pool, the SET ROLE would fail.
+(deftest conn-impersonation-with-write-connection-test-2
+  (testing "Write connection is actually used: read-only user cannot SET ROLE, but write user can"
+    (mt/test-driver :postgres
+      (mt/with-premium-features #{:advanced-permissions}
+        (let [details       (:details (mt/db))
+              password      (:password details)
+              readonly-user (u/lower-case-en (mt/random-name))
+              spec          (sql-jdbc.conn/db->pooled-connection-spec (mt/id))
+              venues-table  (sql.tx/qualify-and-quote :postgres "test-data" "venues")
+              role-name     (u/lower-case-en (mt/random-name))]
+          (try
+            (driver/execute-raw-queries! :postgres spec
+                                         [[(format "CREATE ROLE %s WITH LOGIN PASSWORD '%s'" readonly-user password)]
+                                          [(format "GRANT USAGE ON SCHEMA public TO %s" readonly-user)]
+                                          [(format "GRANT SELECT ON ALL TABLES IN SCHEMA public TO %s" readonly-user)]])
+            ;; The impersonation role is granted to (:user details) — the superuser — not readonly-user.
+            (tx/with-temp-roles! :postgres
+              details
+              {role-name {venues-table {}}}
+              (:user details)
+              nil
+              (let [readonly-details (assoc details :user readonly-user)
+                    write-details    {:user     (:user details)
+                                      :password password}]
+                (mt/with-temp [:model/Database database {:engine             :postgres
+                                                         :details            readonly-details
+                                                         :write_data_details write-details}]
+                  (mt/with-db database
+                    (sync/sync-database! database {:scan :schema})
+                    (impersonation.util-test/with-impersonations!
+                      {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+                       :attributes     {"impersonation_attr" role-name}}
+                      (testing "Negative: read-only user fails because it cannot assume the impersonation role"
+                        (is (thrown?
+                             java.lang.Exception
+                             (mt/run-mbql-query venues {:aggregation [[:count]]}))))
+                      (testing "Positive: write user succeeds because it can assume the impersonation role"
+                        (driver.conn/with-write-connection
+                          (is (= [[100]]
+                                 (mt/formatted-rows [int]
+                                                    (mt/run-mbql-query venues {:aggregation [[:count]]})))))))))))
+            (finally
+              (driver/execute-raw-queries! :postgres spec
+                                           [[(format "DROP OWNED BY %s" readonly-user)]
+                                            [(format "DROP ROLE IF EXISTS %s" readonly-user)]]))))))))
 
 (deftest conn-impersonation-columns-test
   (mt/test-drivers (mt/normal-drivers-with-feature :test/column-impersonation)

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/workspaces/admin/AdminDatabaseWorkspacesSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/workspaces/admin/AdminDatabaseWorkspacesSection.tsx
@@ -187,7 +187,7 @@ export function AdminDatabaseWorkspacesSection({
             icon={<Icon name="info" />}
             mb="md"
           >
-            {t`Workspaces cannot be enabled when database routing is enabled.`}
+            {t`Workspaces can't be enabled when database routing is enabled.`}
           </Alert>
         )}
       </Stack>

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/workspaces/admin/AdminDatabaseWorkspacesSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/workspaces/admin/AdminDatabaseWorkspacesSection.tsx
@@ -7,10 +7,13 @@ import {
   Label,
 } from "metabase/admin/databases/components/DatabaseFeatureComponents";
 import { DatabaseInfoSection } from "metabase/admin/databases/components/DatabaseInfoSection";
-import { hasFeature } from "metabase/admin/databases/utils";
+import {
+  hasDbRoutingEnabled,
+  hasFeature,
+} from "metabase/admin/databases/utils";
 import { useCheckWorkspacePermissionsMutation } from "metabase/api";
 import { getErrorMessage } from "metabase/api/utils";
-import { Group, List, Loader, Stack, Switch } from "metabase/ui";
+import { Alert, Group, Icon, List, Loader, Stack, Switch } from "metabase/ui";
 import type {
   Database,
   DatabaseData,
@@ -35,6 +38,7 @@ export function AdminDatabaseWorkspacesSection({
   const workspacesSetting = settingsAvailable?.[DATABASE_WORKSPACES_SETTING];
   const isSettingDisabled = !workspacesSetting;
   const areWorkspacesSupported = hasFeature(database, "workspace");
+  const databaseHasRouting = hasDbRoutingEnabled(database);
 
   const [error, setError] = useState<string | null>(null);
   const [isCheckingPermissions, setIsCheckingPermissions] = useState(false);
@@ -134,7 +138,9 @@ export function AdminDatabaseWorkspacesSection({
 
             <Switch
               checked={isEnabled}
-              disabled={isCheckingPermissions}
+              disabled={
+                isCheckingPermissions || (!isEnabled && databaseHasRouting)
+              }
               id="workspaces-toggle"
               onChange={handleToggle}
             />
@@ -173,6 +179,17 @@ export function AdminDatabaseWorkspacesSection({
 
           {permissionsError && <Error>{permissionsError}</Error>}
         </Stack>
+
+        {databaseHasRouting && (
+          <Alert
+            variant="light"
+            color="info"
+            icon={<Icon name="info" />}
+            mb="md"
+          >
+            {t`Workspaces cannot be enabled when database routing is enabled.`}
+          </Alert>
+        )}
       </Stack>
     </DatabaseInfoSection>
   );

--- a/enterprise/frontend/src/metabase-enterprise/database_routing/DatabaseRoutingSection/utils.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/database_routing/DatabaseRoutingSection/utils.tsx
@@ -5,6 +5,7 @@ import { t } from "ttag";
 import {
   hasActionsEnabled,
   hasFeature,
+  hasTableEditingEnabled,
   hasWorkspacesEnabled,
   hasWritableConnectionDetails,
 } from "metabase/admin/databases/utils";
@@ -15,6 +16,7 @@ export const getDisabledFeatureMessage = (database: Database) => {
   return match({
     hasActionsEnabled: hasActionsEnabled(database),
     hasWorkspacesEnabled: hasWorkspacesEnabled(database),
+    hasTableEditingEnabled: hasTableEditingEnabled(database),
     isPersisted: hasFeature(database, "persist-models-enabled"),
     isUploadDb: database.uploads_enabled,
     supportsRouting: !!database.features?.includes("database-routing"),
@@ -51,6 +53,10 @@ export const getDisabledFeatureMessage = (database: Database) => {
     .with(
       { hasWorkspacesEnabled: true },
       () => t`Database routing can't be enabled when workspaces are enabled.`,
+    )
+    .with(
+      { hasTableEditingEnabled: true },
+      () => t`Database routing can't be enabled when table editing is enabled.`,
     )
     .otherwise(() => undefined);
 };

--- a/enterprise/frontend/src/metabase-enterprise/database_routing/DatabaseRoutingSection/utils.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/database_routing/DatabaseRoutingSection/utils.tsx
@@ -5,6 +5,7 @@ import { t } from "ttag";
 import {
   hasActionsEnabled,
   hasFeature,
+  hasWorkspacesEnabled,
   hasWritableConnectionDetails,
 } from "metabase/admin/databases/utils";
 import { Text } from "metabase/ui";
@@ -13,6 +14,7 @@ import type { Database } from "metabase-types/api";
 export const getDisabledFeatureMessage = (database: Database) => {
   return match({
     hasActionsEnabled: hasActionsEnabled(database),
+    hasWorkspacesEnabled: hasWorkspacesEnabled(database),
     isPersisted: hasFeature(database, "persist-models-enabled"),
     isUploadDb: database.uploads_enabled,
     supportsRouting: !!database.features?.includes("database-routing"),
@@ -45,6 +47,10 @@ export const getDisabledFeatureMessage = (database: Database) => {
       { hasWritableConnection: true },
       () =>
         t`Database routing can't be enabled when a Writable Connection is enabled.`,
+    )
+    .with(
+      { hasWorkspacesEnabled: true },
+      () => t`Database routing can't be enabled when workspaces are enabled.`,
     )
     .otherwise(() => undefined);
 };

--- a/enterprise/frontend/src/metabase-enterprise/table-editing/admin/AdminDatabaseTableEditingSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/admin/AdminDatabaseTableEditingSection.tsx
@@ -7,11 +7,12 @@ import {
   Label,
 } from "metabase/admin/databases/components/DatabaseFeatureComponents";
 import { DatabaseInfoSection } from "metabase/admin/databases/components/DatabaseInfoSection";
+import { hasDbRoutingEnabled } from "metabase/admin/databases/utils";
 import { Toggle } from "metabase/common/components/Toggle";
 import { ALLOWED_ENGINES_FOR_TABLE_EDITING } from "metabase/databases/constants";
 import { trackSimpleEvent } from "metabase/lib/analytics";
 import { getResponseErrorMessage } from "metabase/lib/errors";
-import { Box, Flex } from "metabase/ui";
+import { Alert, Box, Flex, Icon } from "metabase/ui";
 import type {
   Database,
   DatabaseData,
@@ -75,6 +76,8 @@ export function AdminDatabaseTableEditingSection({
     database.engine &&
     ALLOWED_ENGINES_FOR_TABLE_EDITING.includes(database.engine);
 
+  const databaseHasRouting = hasDbRoutingEnabled(database);
+
   const dataEditingSetting =
     settingsAvailable?.[DATABASE_TABLE_EDITING_SETTING];
   const isSettingDisabled =
@@ -96,6 +99,8 @@ export function AdminDatabaseTableEditingSection({
     return null;
   }
 
+  const isEnabled = isDatabaseTableEditingEnabled(database);
+
   return (
     <DatabaseInfoSection
       name={t`Editable table data`}
@@ -106,9 +111,9 @@ export function AdminDatabaseTableEditingSection({
         <Label htmlFor="table-editing-toggle">{t`Editable tables`}</Label>
         <Toggle
           id="table-editing-toggle"
-          value={isDatabaseTableEditingEnabled(database)}
+          value={isEnabled}
           onChange={handleToggle}
-          disabled={isSettingDisabled}
+          disabled={isSettingDisabled || (!isEnabled && databaseHasRouting)}
         />
       </Flex>
       <Box maw="22.5rem">
@@ -118,6 +123,12 @@ export function AdminDatabaseTableEditingSection({
             t`Your database connection will need Write permissions.`}
         </Description>
       </Box>
+
+      {databaseHasRouting && (
+        <Alert variant="light" color="info" icon={<Icon name="info" />} mb="md">
+          {t`Table editing cannot be enabled when database routing is enabled.`}
+        </Alert>
+      )}
     </DatabaseInfoSection>
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/table-editing/admin/AdminDatabaseTableEditingSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/admin/AdminDatabaseTableEditingSection.tsx
@@ -126,7 +126,7 @@ export function AdminDatabaseTableEditingSection({
 
       {databaseHasRouting && (
         <Alert variant="light" color="info" icon={<Icon name="info" />} mb="md">
-          {t`Table editing cannot be enabled when database routing is enabled.`}
+          {t`Table editing can't be enabled when database routing is enabled.`}
         </Alert>
       )}
     </DatabaseInfoSection>

--- a/frontend/src/metabase/admin/databases/components/DatabaseModelFeaturesSection/ModelActionsSection/ModelActionsSection.tsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseModelFeaturesSection/ModelActionsSection/ModelActionsSection.tsx
@@ -53,7 +53,7 @@ export function ModelActionsSection({
         <Description>
           {t`Allow actions from models created from this data to be run. Actions are able to read, write, and possibly delete data.`}
           <br />
-          {t`Note: Your database user will need write permissions.`}
+          {t`Note: Your database user will need write permissions, either through the main connection or through the write connection.`}
         </Description>
       </Box>
     </div>

--- a/frontend/src/metabase/admin/databases/components/DatabaseModelFeaturesSection/ModelActionsSection/ModelActionsSection.tsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseModelFeaturesSection/ModelActionsSection/ModelActionsSection.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { t } from "ttag";
 
 import { getResponseErrorMessage } from "metabase/lib/errors";
-import { Box, Flex, Switch, Tooltip } from "metabase/ui";
+import { Alert, Box, Flex, Icon, Switch } from "metabase/ui";
 
 import { Description, Error, Label } from "../../DatabaseFeatureComponents";
 
@@ -32,21 +32,16 @@ export function ModelActionsSection({
     <div>
       <Flex align="center" justify="space-between" mb="xs">
         <Label htmlFor="model-actions-toggle">{t`Model actions`}</Label>
-        <Tooltip
-          label={t`Model actions can not be enabled if database routing is enabled.`}
-          disabled={!disabled}
-        >
-          <Box>
-            <Switch
-              id="model-actions-toggle"
-              checked={hasModelActionsEnabled}
-              onChange={(e) =>
-                handleToggleModelActionsEnabled(e.currentTarget.checked)
-              }
-              disabled={disabled}
-            />
-          </Box>
-        </Tooltip>
+        <Box>
+          <Switch
+            id="model-actions-toggle"
+            checked={hasModelActionsEnabled}
+            onChange={(e) =>
+              handleToggleModelActionsEnabled(e.currentTarget.checked)
+            }
+            disabled={disabled}
+          />
+        </Box>
       </Flex>
       <Box maw="22.5rem">
         {error ? <Error>{error}</Error> : null}
@@ -56,6 +51,18 @@ export function ModelActionsSection({
           {t`Note: Your database user will need write permissions, either through the main connection or through the write connection.`}
         </Description>
       </Box>
+      {disabled && (
+        <Box>
+          <Alert
+            variant="light"
+            color="info"
+            icon={<Icon name="info" />}
+            mb="md"
+          >
+            {t`Model actions cannot be enabled when database routing is enabled.`}
+          </Alert>
+        </Box>
+      )}
     </div>
   );
 }

--- a/frontend/src/metabase/admin/databases/components/DatabaseModelFeaturesSection/ModelActionsSection/ModelActionsSection.tsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseModelFeaturesSection/ModelActionsSection/ModelActionsSection.tsx
@@ -59,7 +59,7 @@ export function ModelActionsSection({
             icon={<Icon name="info" />}
             mb="md"
           >
-            {t`Model actions cannot be enabled when database routing is enabled.`}
+            {t`Model actions can't be enabled when database routing is enabled.`}
           </Alert>
         </Box>
       )}

--- a/frontend/src/metabase/admin/databases/components/DatabaseModelFeaturesSection/ModelCachingControl/ModelCachingControl.tsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseModelFeaturesSection/ModelCachingControl/ModelCachingControl.tsx
@@ -96,7 +96,7 @@ export function ModelCachingControl({ database, disabled }: Props) {
             icon={<Icon name="info" />}
             mb="md"
           >
-            {t`Model persistence cannot be enabled when database routing is enabled.`}
+            {t`Model persistence can't be enabled when database routing is enabled.`}
           </Alert>
         </Box>
       )}

--- a/frontend/src/metabase/admin/databases/components/DatabaseModelFeaturesSection/ModelCachingControl/ModelCachingControl.tsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseModelFeaturesSection/ModelCachingControl/ModelCachingControl.tsx
@@ -8,7 +8,7 @@ import {
 } from "metabase/api";
 import { ExternalLink } from "metabase/common/components/ExternalLink";
 import { useDocsUrl, useSetting } from "metabase/common/hooks";
-import { Box, Flex, Switch, Tooltip } from "metabase/ui";
+import { Alert, Box, Flex, Icon, Switch } from "metabase/ui";
 import { getModelCacheSchemaName } from "metabase-lib/v1/metadata/utils/models";
 import type { Database } from "metabase-types/api";
 
@@ -68,19 +68,14 @@ export function ModelCachingControl({ database, disabled }: Props) {
     <div>
       <Flex align="center" justify="space-between" mb="xs">
         <Label htmlFor="model-persistence-toggle">{t`Model persistence`}</Label>
-        <Tooltip
-          label={t`Model persistence can not be enabled if database routing is enabled.`}
-          disabled={!disabled}
-        >
-          <Box>
-            <Switch
-              id="model-persistence-toggle"
-              checked={isEnabled}
-              onChange={handleCachingChange}
-              disabled={disabled}
-            />
-          </Box>
-        </Tooltip>
+        <Box>
+          <Switch
+            id="model-persistence-toggle"
+            checked={isEnabled}
+            onChange={handleCachingChange}
+            disabled={disabled}
+          />
+        </Box>
       </Flex>
       <Box maw="22.5rem">
         {error ? <Error>{error}</Error> : null}
@@ -93,6 +88,18 @@ export function ModelCachingControl({ database, disabled }: Props) {
           )}`}
         </Description>
       </Box>
+      {disabled && (
+        <Box>
+          <Alert
+            variant="light"
+            color="info"
+            icon={<Icon name="info" />}
+            mb="md"
+          >
+            {t`Model persistence cannot be enabled when database routing is enabled.`}
+          </Alert>
+        </Box>
+      )}
     </div>
   );
 }

--- a/frontend/src/metabase/admin/databases/utils.ts
+++ b/frontend/src/metabase/admin/databases/utils.ts
@@ -80,3 +80,7 @@ export const dashboardUsesRoutingEnabledDatabases = (
     return false;
   });
 };
+
+export function hasWorkspacesEnabled(database: Pick<Database, "settings">) {
+  return Boolean(database.settings?.["database-enable-workspaces"]);
+}

--- a/frontend/src/metabase/admin/databases/utils.ts
+++ b/frontend/src/metabase/admin/databases/utils.ts
@@ -84,3 +84,7 @@ export const dashboardUsesRoutingEnabledDatabases = (
 export function hasWorkspacesEnabled(database: Pick<Database, "settings">) {
   return Boolean(database.settings?.["database-enable-workspaces"]);
 }
+
+export function hasTableEditingEnabled(database: Pick<Database, "settings">) {
+  return Boolean(database.settings?.["database-enable-table-editing"]);
+}

--- a/src/metabase/model_persistence/task/persist_refresh.clj
+++ b/src/metabase/model_persistence/task/persist_refresh.clj
@@ -8,6 +8,7 @@
    [medley.core :as m]
    [metabase.app-db.core :as mdb]
    [metabase.driver :as driver]
+   [metabase.driver.connection :as driver.conn]
    [metabase.driver.ddl.interface :as ddl.i]
    [metabase.events.core :as events]
    [metabase.model-persistence.models.persisted-info :as persisted-info]
@@ -53,37 +54,38 @@
 
 (defn- refresh-with-stats! [refresher database stats persisted-info]
   ;; Since this could be long running, double check state just before refreshing
-  (when (contains? (persisted-info/refreshable-states) (t2/select-one-fn :state :model/PersistedInfo :id (:id persisted-info)))
-    (log/infof "Attempting to refresh persisted model %s." (:card_id persisted-info))
-    (let [card (t2/select-one :model/Card :id (:card_id persisted-info))
-          definition (persisted-info/metadata->definition (:result_metadata card)
-                                                          (:table_name persisted-info))
-          _ (t2/update! :model/PersistedInfo (u/the-id persisted-info)
-                        {:definition definition,
-                         :query_hash (persisted-info/query-hash (:dataset_query card))
-                         :active false,
-                         :refresh_begin :%now,
-                         :refresh_end nil,
-                         :state "refreshing"
-                         :state_change_at :%now})
-          {:keys [state error]} (try
-                                  (refresh! refresher database definition card)
-                                  (catch Exception e
-                                    (log/infof e "Error refreshing persisting model with card-id %s"
-                                               (:card_id persisted-info))
-                                    {:state :error :error (ex-message e)}))]
-      (t2/update! :model/PersistedInfo (u/the-id persisted-info)
-                  {:active (= state :success),
-                   :refresh_end :%now,
-                   :state (if (= state :success) "persisted" "error")
-                   :state_change_at :%now
-                   :error (when (= state :error) error)})
-      (if (= :success state)
-        (update stats :success inc)
-        (-> stats
-            (update :error-details conj {:persisted-info-id (:id persisted-info)
-                                         :error error})
-            (update :error inc))))))
+  (driver.conn/with-write-connection
+    (when (contains? (persisted-info/refreshable-states) (t2/select-one-fn :state :model/PersistedInfo :id (:id persisted-info)))
+      (log/infof "Attempting to refresh persisted model %s." (:card_id persisted-info))
+      (let [card                  (t2/select-one :model/Card :id (:card_id persisted-info))
+            definition            (persisted-info/metadata->definition (:result_metadata card)
+                                                                       (:table_name persisted-info))
+            _                     (t2/update! :model/PersistedInfo (u/the-id persisted-info)
+                                              {:definition      definition,
+                                               :query_hash      (persisted-info/query-hash (:dataset_query card))
+                                               :active          false,
+                                               :refresh_begin   :%now,
+                                               :refresh_end     nil,
+                                               :state           "refreshing"
+                                               :state_change_at :%now})
+            {:keys [state error]} (try
+                                    (refresh! refresher database definition card)
+                                    (catch Exception e
+                                      (log/infof e "Error refreshing persisting model with card-id %s"
+                                                 (:card_id persisted-info))
+                                      {:state :error :error (ex-message e)}))]
+        (t2/update! :model/PersistedInfo (u/the-id persisted-info)
+                    {:active          (= state :success),
+                     :refresh_end     :%now,
+                     :state           (if (= state :success) "persisted" "error")
+                     :state_change_at :%now
+                     :error           (when (= state :error) error)})
+        (if (= :success state)
+          (update stats :success inc)
+          (-> stats
+              (update :error-details conj {:persisted-info-id (:id persisted-info)
+                                           :error             error})
+              (update :error inc)))))))
 
 (defn- error-details
   [results]
@@ -124,30 +126,31 @@
   "Seam for tests to pass in specific deletables to drop."
   [refresher deletables]
   (when (seq deletables)
-    (let [db-id->db    (m/index-by :id (t2/select :model/Database :id [:in (map :database_id deletables)]))
-          unpersist-fn (fn []
-                         (reduce (fn [stats persisted-info]
+    (driver.conn/with-write-connection
+      (let [db-id->db    (m/index-by :id (t2/select :model/Database :id [:in (map :database_id deletables)]))
+            unpersist-fn (fn []
+                           (reduce (fn [stats persisted-info]
                                    ;; Since this could be long running, double check state just before deleting
-                                   (let [current-state (t2/select-one-fn :state :model/PersistedInfo :id (:id persisted-info))
-                                         card-info     (t2/select-one [:model/Card :archived :type :card_schema]
-                                                                      :id (:card_id persisted-info))]
-                                     (if (or (contains? (persisted-info/prunable-states) current-state)
-                                             (:archived card-info)
-                                             (not= (:type card-info) :model))
-                                       (let [database (-> persisted-info :database_id db-id->db)]
-                                         (log/infof "Unpersisting model with card-id %s" (:card_id persisted-info))
-                                         (try
-                                           (unpersist! refresher database persisted-info)
-                                           (when-not (= "off" current-state)
-                                             (t2/delete! :model/PersistedInfo :id (:id persisted-info)))
-                                           (update stats :success inc)
-                                           (catch Exception e
-                                             (log/infof e "Error unpersisting model with card-id %s" (:card_id persisted-info))
-                                             (update stats :error inc))))
-                                       (update stats :skipped inc))))
-                                 {:success 0, :error 0, :skipped 0}
-                                 deletables))]
-      (save-task-history! "unpersist-tables" nil unpersist-fn))))
+                                     (let [current-state (t2/select-one-fn :state :model/PersistedInfo :id (:id persisted-info))
+                                           card-info     (t2/select-one [:model/Card :archived :type :card_schema]
+                                                                        :id (:card_id persisted-info))]
+                                       (if (or (contains? (persisted-info/prunable-states) current-state)
+                                               (:archived card-info)
+                                               (not= (:type card-info) :model))
+                                         (let [database (-> persisted-info :database_id db-id->db)]
+                                           (log/infof "Unpersisting model with card-id %s" (:card_id persisted-info))
+                                           (try
+                                             (unpersist! refresher database persisted-info)
+                                             (when-not (= "off" current-state)
+                                               (t2/delete! :model/PersistedInfo :id (:id persisted-info)))
+                                             (update stats :success inc)
+                                             (catch Exception e
+                                               (log/infof e "Error unpersisting model with card-id %s" (:card_id persisted-info))
+                                               (update stats :error inc))))
+                                         (update stats :skipped inc))))
+                                   {:success 0, :error 0, :skipped 0}
+                                   deletables))]
+        (save-task-history! "unpersist-tables" nil unpersist-fn)))))
 
 (defn- deletable-models
   "Returns persisted info records that can be unpersisted. Will select records that have moved into a deletable state

--- a/src/metabase/upload/impl.clj
+++ b/src/metabase/upload/impl.clj
@@ -11,6 +11,7 @@
    [metabase.analytics.core :as analytics]
    [metabase.api.common :as api]
    [metabase.driver :as driver]
+   [metabase.driver.connection :as driver.conn]
    [metabase.driver.ddl.interface :as ddl.i]
    [metabase.driver.sync :as driver.s]
    [metabase.driver.util :as driver.u]
@@ -521,28 +522,29 @@
 (defn- create-from-csv-and-sync!
   "This is separated from `create-csv-upload!` for testing"
   [{:keys [db filename file schema table-name display-name]}]
-  (let [driver            (driver.u/database->driver db)
-        schema            (some->> schema (ddl.i/format-name driver))
-        table-name        (some->> table-name (ddl.i/format-name driver))
-        schema+table-name (table-identifier {:schema schema :name table-name})
-        {:keys [columns stats]} (create-from-csv! driver db schema+table-name filename file)
+  (driver.conn/with-write-connection
+    (let [driver                  (driver.u/database->driver db)
+          schema                  (some->> schema (ddl.i/format-name driver))
+          table-name              (some->> table-name (ddl.i/format-name driver))
+          schema+table-name       (table-identifier {:schema schema :name table-name})
+          {:keys [columns stats]} (create-from-csv! driver db schema+table-name filename file)
         ;; Sync immediately to create the Table and its Fields; the scan is settings-dependent and can be async
-        table             (sync/create-table! db {:name         table-name
-                                                  :schema       (not-empty schema)
-                                                  :display_name display-name})
-        _set_is_upload    (t2/update! :model/Table (:id table) {:is_upload true
-                                                                :data_authority :authoritative
-                                                                :data_source :upload
-                                                                :is_writable true})
-        _sync             (scan-and-sync-table! db table)
-        _set_names        (set-display-names! (:id table) columns)
+          table                   (sync/create-table! db {:name         table-name
+                                                          :schema       (not-empty schema)
+                                                          :display_name display-name})
+          _set_is_upload          (t2/update! :model/Table (:id table) {:is_upload      true
+                                                                        :data_authority :authoritative
+                                                                        :data_source    :upload
+                                                                        :is_writable    true})
+          _sync                   (scan-and-sync-table! db table)
+          _set_names              (set-display-names! (:id table) columns)
         ;; Set the display_name of the auto-generated primary key column to the same as its name, so that if users
         ;; download results from the table as a CSV and reupload, we'll recognize it as the same column
-        _ (when (auto-pk-column? driver db)
-            (let [auto-pk-field (table-id->auto-pk-column driver (:id table))]
-              (t2/update! :model/Field (:id auto-pk-field) {:display_name (:name auto-pk-field)})))]
-    {:table table
-     :stats stats}))
+          _                       (when (auto-pk-column? driver db)
+                                    (let [auto-pk-field (table-id->auto-pk-column driver (:id table))]
+                                      (t2/update! :model/Field (:id auto-pk-field) {:display_name (:name auto-pk-field)})))]
+      {:table table
+       :stats stats})))
 
 (defn- check-filetype [filename file]
   (let [extension (file-extension filename)]
@@ -773,96 +775,97 @@
    m))
 
 (defn- update-with-csv! [database table filename file & {:keys [replace-rows?]}]
-  (try
-    (let [parse (infer-parser filename file)]
-      (with-open [reader (->reader file)]
-        (let [timer              (u/start-timer)
-              driver             (driver.u/database->driver database)
-              auto-pk?           (auto-pk-column? driver database)
-              [header & rows]    (cond-> (parse reader)
-                                   auto-pk?
-                                   without-auto-pk-columns)
-              name->field        (m/index-by :name (t2/select :model/Field :table_id (:id table) :active true))
-              ;; Gotcha: Long column names, which get sanitized and truncated to the same string, will be match to the
-              ;; database columns based on their order. If their order in the new upload differs from that in previous
-              ;; uploads, they will be matched incorrectly.
-              ;; We accept this edge case (customers can reorder CSV columns to fix) rather than rejecting uploads
-              ;; with ambiguous column names even when the order is consistent (see #44926/#issuecomment-3524373073).
-              ;; Future idea: match on display names for smart re-ordering.
-              column-names       (map name (derive-column-names driver header))
-              display-names      (for [h header] (normalize-display-name h))
-              create-auto-pk?    (and
-                                  auto-pk?
-                                  (driver/create-auto-pk-with-append-csv? driver)
-                                  (not (contains? name->field auto-pk-column-name)))
-              name->field        (cond-> name->field auto-pk? (dissoc auto-pk-column-name))
-              _                  (check-schema (keys name->field) column-names header)
-              settings           (upload-parsing/get-settings)
-              ;; TODO: Add a method for drivers to override types here. See https://github.com/metabase/metabase/pull/55209.
-              old-types          (map (comp upload-types/base-type->upload-type :base_type name->field) column-names)
-              ;; in the happy, and most common, case all the values will match the existing types
-              ;; for now we just plan for the worst and perform a fairly expensive operation to detect any type changes
-              ;; we can come back and optimize this to an optimistic-with-fallback approach later.
-              detected-types     (upload-types/column-types-from-rows settings old-types rows)
-              allowed-promotions (translate-type-keywords (driver/allowed-promotions driver))
-              new-types          (map #(upload-types/new-type %1 %2 allowed-promotions) old-types detected-types)
-              ;; avoid any schema modification unless all the promotions required by the file are supported,
-              ;; choosing to not promote means that we will defer failure until we hit the first value that cannot
-              ;; be parsed as its existing type - there is scope to improve these error messages in the future.
-              modify-schema?     (and (not= old-types new-types) (= detected-types new-types))
-              _                  (when modify-schema?
-                                   (let [changes   (field-changes column-names old-types new-types)
-                                         old-types (old-column-types driver column-names old-types)]
-                                     (add-columns! driver database table (:added changes))
-                                     (alter-columns! driver database table (:updated changes) :old-types old-types)))
-              ;; this will fail if any of our required relaxations were rejected.
-              parsed-rows        (parse-rows settings new-types rows)
-              row-count          (count parsed-rows)
-              stats              {:num-rows          row-count
-                                  :num-columns       (count new-types)
-                                  :generated-columns (if create-auto-pk? 1 0)
-                                  :size-mb           (file-size-mb file)
-                                  :upload-seconds    (u/since-ms timer)}]
-          (try
-            (when replace-rows?
-              (driver/truncate! driver (:id database) (table-identifier table)))
-            (driver/insert-into! driver (:id database) (table-identifier table) column-names parsed-rows)
-            (catch Throwable e
-              (throw (ex-info (ex-message e) {:status-code 422}))))
+  (driver.conn/with-write-connection
+    (try
+      (let [parse (infer-parser filename file)]
+        (with-open [reader (->reader file)]
+          (let [timer              (u/start-timer)
+                driver             (driver.u/database->driver database)
+                auto-pk?           (auto-pk-column? driver database)
+                [header & rows]    (cond-> (parse reader)
+                                     auto-pk?
+                                     without-auto-pk-columns)
+                name->field        (m/index-by :name (t2/select :model/Field :table_id (:id table) :active true))
+                ;; Gotcha: Long column names, which get sanitized and truncated to the same string, will be match to the
+                ;; database columns based on their order. If their order in the new upload differs from that in previous
+                ;; uploads, they will be matched incorrectly.
+                ;; We accept this edge case (customers can reorder CSV columns to fix) rather than rejecting uploads
+                ;; with ambiguous column names even when the order is consistent (see #44926/#issuecomment-3524373073).
+                ;; Future idea: match on display names for smart re-ordering.
+                column-names       (map name (derive-column-names driver header))
+                display-names      (for [h header] (normalize-display-name h))
+                create-auto-pk?    (and
+                                    auto-pk?
+                                    (driver/create-auto-pk-with-append-csv? driver)
+                                    (not (contains? name->field auto-pk-column-name)))
+                name->field        (cond-> name->field auto-pk? (dissoc auto-pk-column-name))
+                _                  (check-schema (keys name->field) column-names header)
+                settings           (upload-parsing/get-settings)
+                ;; TODO: Add a method for drivers to override types here. See https://github.com/metabase/metabase/pull/55209.
+                old-types          (map (comp upload-types/base-type->upload-type :base_type name->field) column-names)
+                ;; in the happy, and most common, case all the values will match the existing types
+                ;; for now we just plan for the worst and perform a fairly expensive operation to detect any type changes
+                ;; we can come back and optimize this to an optimistic-with-fallback approach later.
+                detected-types     (upload-types/column-types-from-rows settings old-types rows)
+                allowed-promotions (translate-type-keywords (driver/allowed-promotions driver))
+                new-types          (map #(upload-types/new-type %1 %2 allowed-promotions) old-types detected-types)
+                ;; avoid any schema modification unless all the promotions required by the file are supported,
+                ;; choosing to not promote means that we will defer failure until we hit the first value that cannot
+                ;; be parsed as its existing type - there is scope to improve these error messages in the future.
+                modify-schema?     (and (not= old-types new-types) (= detected-types new-types))
+                _                  (when modify-schema?
+                                     (let [changes   (field-changes column-names old-types new-types)
+                                           old-types (old-column-types driver column-names old-types)]
+                                       (add-columns! driver database table (:added changes))
+                                       (alter-columns! driver database table (:updated changes) :old-types old-types)))
+                ;; this will fail if any of our required relaxations were rejected.
+                parsed-rows        (parse-rows settings new-types rows)
+                row-count          (count parsed-rows)
+                stats              {:num-rows          row-count
+                                    :num-columns       (count new-types)
+                                    :generated-columns (if create-auto-pk? 1 0)
+                                    :size-mb           (file-size-mb file)
+                                    :upload-seconds    (u/since-ms timer)}]
+            (try
+              (when replace-rows?
+                (driver/truncate! driver (:id database) (table-identifier table)))
+              (driver/insert-into! driver (:id database) (table-identifier table) column-names parsed-rows)
+              (catch Throwable e
+                (throw (ex-info (ex-message e) {:status-code 422}))))
 
-          (when create-auto-pk?
-            (add-columns! driver database table
-                          {auto-pk-column-keyword ::upload-types/auto-incrementing-int-pk}
-                          :primary-key [auto-pk-column-keyword]))
+            (when create-auto-pk?
+              (add-columns! driver database table
+                            {auto-pk-column-keyword ::upload-types/auto-incrementing-int-pk}
+                            :primary-key [auto-pk-column-keyword]))
 
-          (scan-and-sync-table! database table)
-          (set-display-names! (:id table) (zipmap column-names display-names))
+            (scan-and-sync-table! database table)
+            (set-display-names! (:id table) (zipmap column-names display-names))
 
-          (when create-auto-pk?
-            (let [auto-pk-field (table-id->auto-pk-column driver (:id table))]
-              (t2/update! :model/Field (:id auto-pk-field) {:display_name (:name auto-pk-field)})))
+            (when create-auto-pk?
+              (let [auto-pk-field (table-id->auto-pk-column driver (:id table))]
+                (t2/update! :model/Field (:id auto-pk-field) {:display_name (:name auto-pk-field)})))
 
-          (invalidate-cached-models! table)
+            (invalidate-cached-models! table)
 
-          (events/publish-event! (if replace-rows?
-                                   :event/upload-replace
-                                   :event/upload-append)
-                                 {:user-id  (:id @api/*current-user*)
-                                  :model-id (:id table)
-                                  :model    :model/Table
-                                  :details  {:db-id       (:id database)
-                                             :schema-name (:schema table)
-                                             :table-name  (:name table)
-                                             :stats       stats}})
+            (events/publish-event! (if replace-rows?
+                                     :event/upload-replace
+                                     :event/upload-append)
+                                   {:user-id  (:id @api/*current-user*)
+                                    :model-id (:id table)
+                                    :model    :model/Table
+                                    :details  {:db-id       (:id database)
+                                               :schema-name (:schema table)
+                                               :table-name  (:name table)
+                                               :stats       stats}})
 
-          (analytics/track-event! :snowplow/csvupload (assoc stats :event :csv-append-successful))
+            (analytics/track-event! :snowplow/csvupload (assoc stats :event :csv-append-successful))
 
-          {:row-count row-count})))
-    (catch Throwable e
-      (analytics/inc! :metabase-csv-upload/failed)
-      (analytics/track-event! :snowplow/csvupload (assoc (fail-stats filename file)
-                                                         :event :csv-append-failed))
-      (throw e))))
+            {:row-count row-count})))
+      (catch Throwable e
+        (analytics/inc! :metabase-csv-upload/failed)
+        (analytics/track-event! :snowplow/csvupload (assoc (fail-stats filename file)
+                                                           :event :csv-append-failed))
+        (throw e)))))
 
 (defn- can-update-error
   "Returns an ExceptionInfo object if the user cannot upload to the given database and schema. Returns nil otherwise."
@@ -923,7 +926,8 @@
     ;; Attempt to delete the underlying data from the customer database.
     ;; We perform this before marking the table as inactive in the app db so that even if it false, the table is still
     ;; visible to administrators, and the operation is easy to retry again later.
-    (driver/drop-table! driver (:id database) table-name)
+    (driver.conn/with-write-connection
+      (driver/drop-table! driver (:id database) table-name))
 
     ;; We mark the table as inactive synchronously, so that it will no longer shows up in the admin list.
     (t2/update! :model/Table :id (:id table) {:active false})

--- a/test/metabase/actions/actions_test.clj
+++ b/test/metabase/actions/actions_test.clj
@@ -836,3 +836,25 @@
                       (is (= 400 (:status-code result)))
                       (is (= actions.error/violate-permission-constraint (:type first-error)))
                       (is (= "You don't have permission to delete data from this table." (:message first-error))))))))))))))
+
+(deftest action-creates-write-pool-test
+  (mt/test-drivers (mt/normal-driver-select {:+parent :sql-jdbc, :+features [:actions]})
+    (mt/with-actions-test-data-and-actions-enabled
+      (let [db-id             (mt/id)
+            write-cache-key   [db-id :write-data]
+            old-write-details (:write_data_details (mt/db))]
+        (when-not old-write-details
+          (t2/update! :model/Database db-id {:write_data_details (:details (mt/db))}))
+        (try
+          (sql-jdbc.conn/invalidate-pool-for-db! (mt/db))
+          (testing "write pool does not exist before action execution"
+            (is (not (contains? @@#'sql-jdbc.conn/pool-cache-key->connection-pool write-cache-key))))
+          (binding [*current-user-permissions-set* (delay #{"/"})]
+            (actions/perform-action! :model.row/create
+                                     (assoc (mt/mbql-query categories)
+                                            :create-row {(format-field-name :name) "write_pool_test"})))
+          (testing "write pool is created during action execution"
+            (is (contains? @@#'sql-jdbc.conn/pool-cache-key->connection-pool write-cache-key)))
+          (finally
+            (t2/update! :model/Database db-id {:write_data_details old-write-details})
+            (sql-jdbc.conn/invalidate-pool-for-db! (mt/db))))))))

--- a/test/metabase/actions/actions_test.clj
+++ b/test/metabase/actions/actions_test.clj
@@ -9,6 +9,7 @@
    [metabase.actions.models :as action]
    [metabase.api.common :refer [*current-user-permissions-set*]]
    [metabase.driver :as driver]
+   [metabase.driver.connection :as driver.conn]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.test-util :as driver.tu]
    [metabase.query-processor :as qp]
@@ -840,21 +841,22 @@
 (deftest action-creates-write-pool-test
   (mt/test-drivers (mt/normal-driver-select {:+parent :sql-jdbc, :+features [:actions]})
     (mt/with-actions-test-data-and-actions-enabled
-      (let [db-id             (mt/id)
-            write-cache-key   [db-id :write-data]
-            old-write-details (:write_data_details (mt/db))]
-        (when-not old-write-details
-          (t2/update! :model/Database db-id {:write_data_details (:details (mt/db))}))
-        (try
-          (sql-jdbc.conn/invalidate-pool-for-db! (mt/db))
-          (testing "write pool does not exist before action execution"
-            (is (not (contains? @@#'sql-jdbc.conn/pool-cache-key->connection-pool write-cache-key))))
-          (binding [*current-user-permissions-set* (delay #{"/"})]
-            (actions/perform-action! :model.row/create
-                                     (assoc (mt/mbql-query categories)
-                                            :create-row {(format-field-name :name) "write_pool_test"})))
-          (testing "write pool is created during action execution"
-            (is (contains? @@#'sql-jdbc.conn/pool-cache-key->connection-pool write-cache-key)))
-          (finally
-            (t2/update! :model/Database db-id {:write_data_details old-write-details})
-            (sql-jdbc.conn/invalidate-pool-for-db! (mt/db))))))))
+      (let [db-id           (mt/id)
+            write-cache-key [db-id :write-data]]
+        (with-redefs [driver.conn/effective-connection-type
+                      (fn [_database]
+                        (if (= driver.conn/*connection-type* :write-data)
+                          :write-data
+                          :default))]
+          (try
+            (sql-jdbc.conn/invalidate-pool-for-db! (mt/db))
+            (testing "write pool does not exist before action execution"
+              (is (not (contains? @@#'sql-jdbc.conn/pool-cache-key->connection-pool write-cache-key))))
+            (binding [*current-user-permissions-set* (delay #{"/"})]
+              (actions/perform-action! :model.row/create
+                                       (assoc (mt/mbql-query categories)
+                                              :create-row {(format-field-name :name) "write_pool_test"})))
+            (testing "write pool is created during action execution"
+              (is (contains? @@#'sql-jdbc.conn/pool-cache-key->connection-pool write-cache-key)))
+            (finally
+              (sql-jdbc.conn/invalidate-pool-for-db! (mt/db)))))))))

--- a/test/metabase/actions/execution_write_pool_test.clj
+++ b/test/metabase/actions/execution_write_pool_test.clj
@@ -1,0 +1,32 @@
+(ns ^:mb/driver-tests metabase.actions.execution-write-pool-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.actions.execution :as actions.execution]
+   [metabase.actions.models :as action]
+   [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
+   [metabase.test :as mt]
+   [toucan2.core :as t2]))
+
+(deftest query-action-creates-write-pool-test
+  (mt/test-drivers (mt/normal-driver-select {:+parent :sql-jdbc, :+features [:actions/custom]})
+    (mt/with-actions-test-data-and-actions-enabled
+      (let [db-id             (mt/id)
+            write-cache-key   [db-id :write-data]
+            old-write-details (:write_data_details (mt/db))]
+        (when-not old-write-details
+          (t2/update! :model/Database db-id {:write_data_details (:details (mt/db))}))
+        (try
+          (sql-jdbc.conn/invalidate-pool-for-db! (mt/db))
+          (testing "write pool does not exist before query action execution"
+            (is (not (contains? @@#'sql-jdbc.conn/pool-cache-key->connection-pool write-cache-key))))
+          (mt/with-test-user :crowberto
+            (mt/with-actions [{_card-id :id} {:type :model :dataset_query (mt/mbql-query categories)}
+                              {action-id :action-id} {:type :query}]
+              (actions.execution/execute-action!
+               (action/select-action :id action-id)
+               {"id" 1})))
+          (testing "write pool is created during query action execution"
+            (is (contains? @@#'sql-jdbc.conn/pool-cache-key->connection-pool write-cache-key)))
+          (finally
+            (t2/update! :model/Database db-id {:write_data_details old-write-details})
+            (sql-jdbc.conn/invalidate-pool-for-db! (mt/db))))))))

--- a/test/metabase/actions/execution_write_pool_test.clj
+++ b/test/metabase/actions/execution_write_pool_test.clj
@@ -3,30 +3,31 @@
    [clojure.test :refer :all]
    [metabase.actions.execution :as actions.execution]
    [metabase.actions.models :as action]
+   [metabase.driver.connection :as driver.conn]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
-   [metabase.test :as mt]
-   [toucan2.core :as t2]))
+   [metabase.test :as mt]))
 
 (deftest query-action-creates-write-pool-test
   (mt/test-drivers (mt/normal-driver-select {:+parent :sql-jdbc, :+features [:actions/custom]})
     (mt/with-actions-test-data-and-actions-enabled
-      (let [db-id             (mt/id)
-            write-cache-key   [db-id :write-data]
-            old-write-details (:write_data_details (mt/db))]
-        (when-not old-write-details
-          (t2/update! :model/Database db-id {:write_data_details (:details (mt/db))}))
-        (try
-          (sql-jdbc.conn/invalidate-pool-for-db! (mt/db))
-          (testing "write pool does not exist before query action execution"
-            (is (not (contains? @@#'sql-jdbc.conn/pool-cache-key->connection-pool write-cache-key))))
-          (mt/with-test-user :crowberto
-            (mt/with-actions [{_card-id :id} {:type :model :dataset_query (mt/mbql-query categories)}
-                              {action-id :action-id} {:type :query}]
-              (actions.execution/execute-action!
-               (action/select-action :id action-id)
-               {"id" 1})))
-          (testing "write pool is created during query action execution"
-            (is (contains? @@#'sql-jdbc.conn/pool-cache-key->connection-pool write-cache-key)))
-          (finally
-            (t2/update! :model/Database db-id {:write_data_details old-write-details})
-            (sql-jdbc.conn/invalidate-pool-for-db! (mt/db))))))))
+      (let [db-id           (mt/id)
+            write-cache-key [db-id :write-data]]
+        (with-redefs [driver.conn/effective-connection-type
+                      (fn [_database]
+                        (if (= driver.conn/*connection-type* :write-data)
+                          :write-data
+                          :default))]
+          (try
+            (sql-jdbc.conn/invalidate-pool-for-db! (mt/db))
+            (testing "write pool does not exist before query action execution"
+              (is (not (contains? @@#'sql-jdbc.conn/pool-cache-key->connection-pool write-cache-key))))
+            (mt/with-test-user :crowberto
+              (mt/with-actions [{_card-id :id} {:type :model :dataset_query (mt/mbql-query categories)}
+                                {action-id :action-id} {:type :query}]
+                (actions.execution/execute-action!
+                 (action/select-action :id action-id)
+                 {"id" 1})))
+            (testing "write pool is created during query action execution"
+              (is (contains? @@#'sql-jdbc.conn/pool-cache-key->connection-pool write-cache-key)))
+            (finally
+              (sql-jdbc.conn/invalidate-pool-for-db! (mt/db)))))))))

--- a/test/metabase/model_persistence/task/persist_refresh_write_pool_test.clj
+++ b/test/metabase/model_persistence/task/persist_refresh_write_pool_test.clj
@@ -1,0 +1,61 @@
+(ns ^:mb/driver-tests metabase.model-persistence.task.persist-refresh-write-pool-test
+  (:require
+   [clojure.test :refer :all]
+   [java-time.api :as t]
+   [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
+   [metabase.model-persistence.task.persist-refresh :as task.persist-refresh]
+   [metabase.test :as mt]
+   [toucan2.core :as t2]))
+
+(deftest refresh-creates-write-pool-test
+  (mt/test-drivers (mt/normal-driver-select {:+parent :sql-jdbc, :+features [:persist-models]})
+    (let [db-id             (mt/id)
+          write-cache-key   [db-id :write-data]
+          old-write-details (:write_data_details (mt/db))]
+      (when-not old-write-details
+        (t2/update! :model/Database db-id {:write_data_details (:details (mt/db))}))
+      (try
+        (sql-jdbc.conn/invalidate-pool-for-db! (mt/db))
+        (testing "write pool does not exist before refresh"
+          (is (not (contains? @@#'sql-jdbc.conn/pool-cache-key->connection-pool write-cache-key))))
+        (let [test-refresher (reify task.persist-refresh/Refresher
+                               (refresh! [_ database _definition _card]
+                                 (sql-jdbc.conn/db->pooled-connection-spec (:id database))
+                                 {:state :success})
+                               (unpersist! [_ _database _persisted-info]))]
+          (mt/with-temp [:model/Card model {:type :model :database_id db-id}
+                         :model/PersistedInfo _pi {:card_id (:id model) :database_id db-id}]
+            (#'task.persist-refresh/refresh-tables! db-id test-refresher)))
+        (testing "write pool is created during refresh"
+          (is (contains? @@#'sql-jdbc.conn/pool-cache-key->connection-pool write-cache-key)))
+        (finally
+          (t2/update! :model/Database db-id {:write_data_details old-write-details})
+          (sql-jdbc.conn/invalidate-pool-for-db! (mt/db)))))))
+
+(deftest prune-creates-write-pool-test
+  (mt/test-drivers (mt/normal-driver-select {:+parent :sql-jdbc, :+features [:persist-models]})
+    (let [db-id             (mt/id)
+          write-cache-key   [db-id :write-data]
+          old-write-details (:write_data_details (mt/db))]
+      (when-not old-write-details
+        (t2/update! :model/Database db-id {:write_data_details (:details (mt/db))}))
+      (try
+        (sql-jdbc.conn/invalidate-pool-for-db! (mt/db))
+        (testing "write pool does not exist before prune"
+          (is (not (contains? @@#'sql-jdbc.conn/pool-cache-key->connection-pool write-cache-key))))
+        (let [test-refresher (reify task.persist-refresh/Refresher
+                               (refresh! [_ _database _definition _card]
+                                 {:state :success})
+                               (unpersist! [_ database _persisted-info]
+                                 (sql-jdbc.conn/db->pooled-connection-spec (:id database))))]
+          (mt/with-temp [:model/Card model {:type :model :database_id db-id}
+                         :model/PersistedInfo pi {:card_id         (:id model)
+                                                  :database_id     db-id
+                                                  :state           "deletable"
+                                                  :state_change_at (t/minus (t/local-date-time) (t/hours 2))}]
+            (#'task.persist-refresh/prune-deletables! test-refresher [pi])))
+        (testing "write pool is created during prune"
+          (is (contains? @@#'sql-jdbc.conn/pool-cache-key->connection-pool write-cache-key)))
+        (finally
+          (t2/update! :model/Database db-id {:write_data_details old-write-details})
+          (sql-jdbc.conn/invalidate-pool-for-db! (mt/db)))))))

--- a/test/metabase/model_persistence/task/persist_refresh_write_pool_test.clj
+++ b/test/metabase/model_persistence/task/persist_refresh_write_pool_test.clj
@@ -2,60 +2,62 @@
   (:require
    [clojure.test :refer :all]
    [java-time.api :as t]
+   [metabase.driver.connection :as driver.conn]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.model-persistence.task.persist-refresh :as task.persist-refresh]
-   [metabase.test :as mt]
-   [toucan2.core :as t2]))
+   [metabase.test :as mt]))
 
 (deftest refresh-creates-write-pool-test
   (mt/test-drivers (mt/normal-driver-select {:+parent :sql-jdbc, :+features [:persist-models]})
-    (let [db-id             (mt/id)
-          write-cache-key   [db-id :write-data]
-          old-write-details (:write_data_details (mt/db))]
-      (when-not old-write-details
-        (t2/update! :model/Database db-id {:write_data_details (:details (mt/db))}))
-      (try
-        (sql-jdbc.conn/invalidate-pool-for-db! (mt/db))
-        (testing "write pool does not exist before refresh"
-          (is (not (contains? @@#'sql-jdbc.conn/pool-cache-key->connection-pool write-cache-key))))
-        (let [test-refresher (reify task.persist-refresh/Refresher
-                               (refresh! [_ database _definition _card]
-                                 (sql-jdbc.conn/db->pooled-connection-spec (:id database))
-                                 {:state :success})
-                               (unpersist! [_ _database _persisted-info]))]
-          (mt/with-temp [:model/Card model {:type :model :database_id db-id}
-                         :model/PersistedInfo _pi {:card_id (:id model) :database_id db-id}]
-            (#'task.persist-refresh/refresh-tables! db-id test-refresher)))
-        (testing "write pool is created during refresh"
-          (is (contains? @@#'sql-jdbc.conn/pool-cache-key->connection-pool write-cache-key)))
-        (finally
-          (t2/update! :model/Database db-id {:write_data_details old-write-details})
-          (sql-jdbc.conn/invalidate-pool-for-db! (mt/db)))))))
+    (let [db-id           (mt/id)
+          write-cache-key [db-id :write-data]]
+      (with-redefs [driver.conn/effective-connection-type
+                    (fn [_database]
+                      (if (= driver.conn/*connection-type* :write-data)
+                        :write-data
+                        :default))]
+        (try
+          (sql-jdbc.conn/invalidate-pool-for-db! (mt/db))
+          (testing "write pool does not exist before refresh"
+            (is (not (contains? @@#'sql-jdbc.conn/pool-cache-key->connection-pool write-cache-key))))
+          (let [test-refresher (reify task.persist-refresh/Refresher
+                                 (refresh! [_ database _definition _card]
+                                   (sql-jdbc.conn/db->pooled-connection-spec (:id database))
+                                   {:state :success})
+                                 (unpersist! [_ _database _persisted-info]))]
+            (mt/with-temp [:model/Card model {:type :model :database_id db-id}
+                           :model/PersistedInfo _pi {:card_id (:id model) :database_id db-id}]
+              (#'task.persist-refresh/refresh-tables! db-id test-refresher)))
+          (testing "write pool is created during refresh"
+            (is (contains? @@#'sql-jdbc.conn/pool-cache-key->connection-pool write-cache-key)))
+          (finally
+            (sql-jdbc.conn/invalidate-pool-for-db! (mt/db))))))))
 
 (deftest prune-creates-write-pool-test
   (mt/test-drivers (mt/normal-driver-select {:+parent :sql-jdbc, :+features [:persist-models]})
-    (let [db-id             (mt/id)
-          write-cache-key   [db-id :write-data]
-          old-write-details (:write_data_details (mt/db))]
-      (when-not old-write-details
-        (t2/update! :model/Database db-id {:write_data_details (:details (mt/db))}))
-      (try
-        (sql-jdbc.conn/invalidate-pool-for-db! (mt/db))
-        (testing "write pool does not exist before prune"
-          (is (not (contains? @@#'sql-jdbc.conn/pool-cache-key->connection-pool write-cache-key))))
-        (let [test-refresher (reify task.persist-refresh/Refresher
-                               (refresh! [_ _database _definition _card]
-                                 {:state :success})
-                               (unpersist! [_ database _persisted-info]
-                                 (sql-jdbc.conn/db->pooled-connection-spec (:id database))))]
-          (mt/with-temp [:model/Card model {:type :model :database_id db-id}
-                         :model/PersistedInfo pi {:card_id         (:id model)
-                                                  :database_id     db-id
-                                                  :state           "deletable"
-                                                  :state_change_at (t/minus (t/local-date-time) (t/hours 2))}]
-            (#'task.persist-refresh/prune-deletables! test-refresher [pi])))
-        (testing "write pool is created during prune"
-          (is (contains? @@#'sql-jdbc.conn/pool-cache-key->connection-pool write-cache-key)))
-        (finally
-          (t2/update! :model/Database db-id {:write_data_details old-write-details})
-          (sql-jdbc.conn/invalidate-pool-for-db! (mt/db)))))))
+    (let [db-id           (mt/id)
+          write-cache-key [db-id :write-data]]
+      (with-redefs [driver.conn/effective-connection-type
+                    (fn [_database]
+                      (if (= driver.conn/*connection-type* :write-data)
+                        :write-data
+                        :default))]
+        (try
+          (sql-jdbc.conn/invalidate-pool-for-db! (mt/db))
+          (testing "write pool does not exist before prune"
+            (is (not (contains? @@#'sql-jdbc.conn/pool-cache-key->connection-pool write-cache-key))))
+          (let [test-refresher (reify task.persist-refresh/Refresher
+                                 (refresh! [_ _database _definition _card]
+                                   {:state :success})
+                                 (unpersist! [_ database _persisted-info]
+                                   (sql-jdbc.conn/db->pooled-connection-spec (:id database))))]
+            (mt/with-temp [:model/Card model {:type :model :database_id db-id}
+                           :model/PersistedInfo pi {:card_id         (:id model)
+                                                    :database_id     db-id
+                                                    :state           "deletable"
+                                                    :state_change_at (t/minus (t/local-date-time) (t/hours 2))}]
+              (#'task.persist-refresh/prune-deletables! test-refresher [pi])))
+          (testing "write pool is created during prune"
+            (is (contains? @@#'sql-jdbc.conn/pool-cache-key->connection-pool write-cache-key)))
+          (finally
+            (sql-jdbc.conn/invalidate-pool-for-db! (mt/db))))))))

--- a/test/metabase/upload/impl_test.clj
+++ b/test/metabase/upload/impl_test.clj
@@ -2642,7 +2642,7 @@
           (sql-jdbc.conn/invalidate-pool-for-db! (mt/db))
           (testing "write pool does not exist before upload create"
             (is (not (contains? @@#'sql-jdbc.conn/pool-cache-key->connection-pool write-cache-key))))
-          (with-upload-table! [table (create-from-csv-and-sync-with-defaults!)]
+          (with-upload-table! [_table (create-from-csv-and-sync-with-defaults!)]
             (testing "write pool is created during upload create"
               (is (contains? @@#'sql-jdbc.conn/pool-cache-key->connection-pool write-cache-key))))
           (finally


### PR DESCRIPTION
You're gonna want this:

<img width="166" height="38" alt="image" src="https://github.com/user-attachments/assets/06abb9c9-fa87-4371-ae58-db88a58ee0cc" />

Follow-on PR after #68883. Closes GHY-3146 and GHY-3147.

**_Adds write-connection support for Actions v1, Actions v2, Model Persistence, and Uploads_**.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
