### PR TITLE
Add debug echo to driver-decisions CI step

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -77,6 +77,9 @@ jobs:
             --pr-labels="${{ join(github.event.pull_request.labels.*.name, ',') }}"
             --skip="${{ inputs.skip }}"
           )
+          echo "Running:"
+          echo "./bin/mage -driver-decisions ${MAGE_ARGS[@]}"
+          echo ""
           # First call: show human-readable output for debugging
           ./bin/mage -driver-decisions "${MAGE_ARGS[@]}"
           # Second call: output only key=value lines for GITHUB_OUTPUT


### PR DESCRIPTION
Closes: DEV-1577

## Summary

- Adds echo lines before the `mage -driver-decisions` call in `drivers.yml` so CI logs show the exact command and args being passed. You could even run the same thing locally!
- Makes it easier to spot when labels or flags weren't picked up (e.g., the recent issue where `break-quarantine-x` labels were added after the run, (and before the re-run started!) but the decision step used the original labels

## [Sample Output](https://github.com/metabase/metabase/actions/runs/22162556424/job/64082499858?pr=69881#step:4:20)



## Test plan

- [x] Verify the workflow YAML is valid (CI will catch this)
- [x] Check a CI run to confirm the echo output appears before the mage output