### PR TITLE
Replace 'Set up git sync' with 'Set up remote sync' on Data Studio sidebar

### DIFF
--- a/e2e/test/scenarios/admin/remote-sync.cy.spec.ts
+++ b/e2e/test/scenarios/admin/remote-sync.cy.spec.ts
@@ -454,7 +454,7 @@ describe("Remote Sync", () => {
         .clear()
         .type(LOCAL_GIT_URL);
       cy.findByTestId("admin-layout-content").findByText("Read-write").click();
-      cy.button("Set up Remote Sync").click();
+      cy.button("Set up remote sync").click();
 
       H.expectUnstructuredSnowplowEvent({
         event: "remote_sync_settings_changed",
@@ -488,7 +488,7 @@ describe("Remote Sync", () => {
         .type(LOCAL_GIT_URL);
 
       cy.findByTestId("admin-layout-content").findByText("Read-only").click();
-      cy.button("Set up Remote Sync").click();
+      cy.button("Set up remote sync").click();
       cy.findByTestId("admin-layout-content")
         .findByText("Success")
         .should("exist");
@@ -504,16 +504,16 @@ describe("Remote Sync", () => {
       });
     });
 
-    it("should disable 'Set up Remote Sync' button if git url is not set (#65653)", () => {
+    it("should disable 'Set up remote sync' button if git url is not set (#65653)", () => {
       cy.visit("/admin/settings/remote-sync");
-      cy.button("Set up Remote Sync").should("be.disabled");
+      cy.button("Set up remote sync").should("be.disabled");
 
       cy.findByRole("switch", { name: "Auto-sync with git" }).click({
         force: true,
       });
 
       // Trivial dirty state should not be enough to enable the button
-      cy.button("Set up Remote Sync").should("be.disabled");
+      cy.button("Set up remote sync").should("be.disabled");
 
       cy.findByLabelText(/Access Token/i)
         .should("be.visible")
@@ -521,7 +521,7 @@ describe("Remote Sync", () => {
         .clear()
         .type("SecretToken");
       // Still disabled - url is not set
-      cy.button("Set up Remote Sync").should("be.disabled");
+      cy.button("Set up remote sync").should("be.disabled");
 
       cy.findByLabelText(/repository url/i)
         .scrollIntoView()
@@ -531,7 +531,7 @@ describe("Remote Sync", () => {
         .type(LOCAL_GIT_URL);
 
       // Enabled now - url is set
-      cy.button("Set up Remote Sync").should("be.enabled");
+      cy.button("Set up remote sync").should("be.enabled");
     });
 
     it("shows an error if git settings are invalid", () => {
@@ -542,7 +542,7 @@ describe("Remote Sync", () => {
         .click()
         .clear()
         .type("file://invalid-path");
-      cy.button("Set up Remote Sync").click();
+      cy.button("Set up remote sync").click();
 
       cy.wait("@saveSettings").its("response.statusCode").should("eq", 400);
       cy.findByTestId("admin-layout-content")

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/GitSyncSetupMenuItem/GitSyncSetupMenuItem.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/GitSyncSetupMenuItem/GitSyncSetupMenuItem.tsx
@@ -14,26 +14,26 @@ export const GitSyncSetupMenuItem = (props: GitSyncSetupMenuItemProps) => {
   const { isNavbarOpened, onClick } = props;
   const isAdmin = useSelector(getUserIsAdmin);
   const isRemoteSyncEnabled = useSetting("remote-sync-enabled");
-  // Only show the "Set up Git Sync" menu item when user is admin and remote sync is not yet enabled
+  // Only show the "Set up remote sync" menu item when user is admin and remote sync is not yet enabled
   const isVisible = isAdmin && !isRemoteSyncEnabled;
 
   if (isVisible) {
     return (
       <Tooltip
-        label={t`Set up git sync`}
+        label={t`Set up remote sync`}
         position="right"
         openDelay={TOOLTIP_OPEN_DELAY}
         disabled={isNavbarOpened}
       >
         <UnstyledButton
-          aria-label={t`Set up git sync`}
+          aria-label={t`Set up remote sync`}
           bdrs="md"
           className={S.tab}
           onClick={onClick}
           p="0.5rem"
         >
           <FixedSizeIcon name="gear" className={S.icon} />
-          {isNavbarOpened && <Text lh="sm">{t`Set up git sync`}</Text>}
+          {isNavbarOpened && <Text lh="sm">{t`Set up remote sync`}</Text>}
         </UnstyledButton>
       </Tooltip>
     );

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/RemoteSyncSettingsForm.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/RemoteSyncSettingsForm.tsx
@@ -543,7 +543,7 @@ export const RemoteSyncSettingsForm = (props: RemoteSyncSettingsFormProps) => {
                     label={
                       isRemoteSyncEnabled
                         ? t`Save changes`
-                        : t`Set up Remote Sync`
+                        : t`Set up remote sync`
                     }
                     variant="filled"
                     disabled={isRemoteSyncEnabled ? !dirty : !values?.[URL_KEY]}

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/RemoteSyncSettingsForm.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/RemoteSyncSettingsForm.unit.spec.tsx
@@ -81,10 +81,10 @@ describe("RemoteSyncSettingsForm", () => {
       });
     });
 
-    it("should show the 'Set up Remote Sync' button", async () => {
+    it("should show the 'Set up remote sync' button", async () => {
       // Verify the submit button shows correct text for new setup
       expect(
-        screen.getByRole("button", { name: /Set up Remote Sync/i }),
+        screen.getByRole("button", { name: /Set up remote sync/i }),
       ).toBeInTheDocument();
     });
 
@@ -551,7 +551,7 @@ describe("RemoteSyncSettingsForm", () => {
       await userEvent.type(urlInput, "https://github.com/foo/bar.git");
 
       const submitButton = screen.getByRole("button", {
-        name: /Set up Remote Sync/i,
+        name: /Set up remote sync/i,
       });
       await userEvent.click(submitButton);
 

--- a/frontend/src/metabase/data-studio/app/pages/DataStudioLayout/DataStudioLayout.tsx
+++ b/frontend/src/metabase/data-studio/app/pages/DataStudioLayout/DataStudioLayout.tsx
@@ -194,7 +194,7 @@ function DataStudioNav({ isNavbarOpened, onNavbarToggle }: DataStudioNavProps) {
             />
           ) : (
             <DataStudioTab
-              label={t`Set up git sync`}
+              label={t`Set up remote sync`}
               icon="gear"
               to={Urls.dataStudioGitSync()}
               isSelected={currentTab === "git-sync"}

--- a/frontend/src/metabase/data-studio/app/pages/DataStudioLayout/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/data-studio/app/pages/DataStudioLayout/tests/enterprise.unit.spec.tsx
@@ -20,18 +20,18 @@ describe("DataStudioLayout", () => {
     jest.restoreAllMocks();
   });
 
-  describe("Set up git sync button", () => {
-    it("should show Set up git sync button when git settings is visible", async () => {
+  describe("Set up remote sync button", () => {
+    it("should show Set up remote sync button when git settings is visible", async () => {
       setup({ remoteSyncEnabled: false });
 
       await waitFor(() => {
         expect(screen.getByTestId("data-studio-nav")).toBeInTheDocument();
       });
 
-      expect(screen.getByLabelText("Set up git sync")).toBeInTheDocument();
+      expect(screen.getByLabelText("Set up remote sync")).toBeInTheDocument();
     });
 
-    it("should hide Set up git sync button when git settings is not visible", async () => {
+    it("should hide Set up remote sync button when git settings is not visible", async () => {
       setup({ ...DEFAULT_EE_SETTINGS, remoteSyncEnabled: true });
 
       await waitFor(() => {
@@ -39,18 +39,18 @@ describe("DataStudioLayout", () => {
       });
 
       expect(
-        screen.queryByLabelText("Set up git sync"),
+        screen.queryByLabelText("Set up remote sync"),
       ).not.toBeInTheDocument();
     });
 
-    it("should open modal when Set up git sync button is clicked", async () => {
+    it("should open modal when Set up remote sync button is clicked", async () => {
       setup({ ...DEFAULT_EE_SETTINGS, remoteSyncEnabled: false });
 
       await waitFor(() => {
         expect(screen.getByTestId("data-studio-nav")).toBeInTheDocument();
       });
 
-      const gitSettingsButton = screen.getByLabelText("Set up git sync");
+      const gitSettingsButton = screen.getByLabelText("Set up remote sync");
       await userEvent.click(gitSettingsButton);
 
       await waitFor(() => {
@@ -68,7 +68,7 @@ describe("DataStudioLayout", () => {
       });
 
       // Open the modal
-      const gitSettingsButton = screen.getByLabelText("Set up git sync");
+      const gitSettingsButton = screen.getByLabelText("Set up remote sync");
       await userEvent.click(gitSettingsButton);
 
       await waitFor(() => {
@@ -87,7 +87,7 @@ describe("DataStudioLayout", () => {
       });
     });
 
-    it("should show Set up git sync text when sidebar is expanded", async () => {
+    it("should show Set up remote sync text when sidebar is expanded", async () => {
       setup({
         ...DEFAULT_EE_SETTINGS,
         remoteSyncEnabled: false,
@@ -98,7 +98,7 @@ describe("DataStudioLayout", () => {
         expect(screen.getByTestId("data-studio-nav")).toBeInTheDocument();
       });
 
-      expect(screen.getByText("Set up git sync")).toBeInTheDocument();
+      expect(screen.getByText("Set up remote sync")).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/UXW-3048/use-remote-sync-naming-in-data-studio-sidebar-cta

### Demo
Before:
<img width="517" height="299" alt="image" src="https://github.com/user-attachments/assets/e4a8fd7a-bbc1-404d-8325-445fbfee327f" />

After:
<img width="517" height="299" alt="image" src="https://github.com/user-attachments/assets/2ad52c24-2769-4a85-b846-073cf1490128" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
