### PR TITLE
Remove Exit sidebar menu item now that app switcher exists

### DIFF
--- a/frontend/src/metabase/data-studio/app/pages/DataStudioLayout/DataStudioLayout.tsx
+++ b/frontend/src/metabase/data-studio/app/pages/DataStudioLayout/DataStudioLayout.tsx
@@ -220,12 +220,6 @@ function DataStudioNav({ isNavbarOpened, onNavbarToggle }: DataStudioNavProps) {
               showLabel={isNavbarOpened}
             />
           )}
-          <DataStudioTab
-            label={t`Exit`}
-            icon="exit"
-            to={"/"}
-            showLabel={isNavbarOpened}
-          />
         </Stack>
         <PLUGIN_REMOTE_SYNC.GitSettingsModal
           isOpen={isGitSettingsOpen}

--- a/frontend/src/metabase/data-studio/app/pages/DataStudioLayout/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/data-studio/app/pages/DataStudioLayout/tests/common.unit.spec.tsx
@@ -24,7 +24,6 @@ describe("DataStudioLayout", () => {
       });
 
       expect(screen.getByText("Data structure")).toBeInTheDocument();
-      expect(screen.getByText("Exit")).toBeInTheDocument();
     });
 
     it("should render content area", async () => {


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/UXW-2911/remove-exit-button-now-that-app-switcher-exists

### Demo
Before:
<img width="517" height="299" alt="image" src="https://github.com/user-attachments/assets/5bf4efb7-01cd-4452-bfd5-617464c696ce" />

After:
<img width="517" height="299" alt="image" src="https://github.com/user-attachments/assets/837f0715-d73e-49c5-92d4-e783fd9644c4" />


### Checklist

- [X] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
