### PR TITLE
Mark get embed snippet step as done when guest embed is published

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
@@ -1,5 +1,6 @@
 import { SAMPLE_DB_TABLES } from "e2e/support/cypress_data";
 import { ALL_EXTERNAL_USERS_GROUP_ID } from "e2e/support/cypress_sample_instance_data";
+import { enableJwtAuth } from "e2e/support/helpers/e2e-jwt-helpers";
 
 const { H } = cy;
 
@@ -161,6 +162,82 @@ describe("scenarios - embedding hub", () => {
         .within(() => {
           cy.findByText("Select your embed experience").should("be.visible");
         });
+    });
+
+    it('"Get embed snippet" step should be done when a guest embed is published', () => {
+      cy.intercept("GET", "/api/ee/embedding-hub/checklist").as("getChecklist");
+
+      cy.log("Create a dashboard to embed");
+      H.createDashboard({ name: "Test Dashboard" }).then(
+        ({ body: dashboard }) => {
+          cy.wrap(dashboard.id).as("dashboardId");
+        },
+      );
+
+      cy.visit("/admin/embedding/setup-guide");
+
+      cy.log("step should not be marked as done at first");
+      cy.findByTestId("admin-layout-content")
+        .findByText("Get embed snippet")
+        .closest("button")
+        .findByText("Done")
+        .should("not.exist");
+
+      cy.log("open embed wizard");
+      cy.findByTestId("admin-layout-content")
+        .findByText("Get embed snippet")
+        .click();
+
+      cy.log("choose dashboard experience");
+      H.modal()
+        .first()
+        .within(() => {
+          cy.findByText("Dashboard").click();
+          cy.findByText("Next").click();
+        });
+
+      cy.log("pick a dashboard");
+      H.modal().first().findByTestId("embed-browse-entity-button").click();
+      H.entityPickerModal().findByText("Test Dashboard").click();
+      H.modal().first().findByText("Next").click();
+
+      cy.log("publish the embed");
+      H.publishChanges("dashboard");
+
+      H.modal().first().findByText("Get code").click();
+      H.modal().first().findByText("Done").click();
+
+      cy.wait("@getChecklist");
+
+      cy.log("step should now be marked as done");
+      cy.findByTestId("admin-layout-content")
+        .findByText("Get embed snippet")
+        .closest("button")
+        .findByText("Done", { timeout: 10_000 })
+        .should("be.visible");
+    });
+
+    it("Embed in production step should be locked until JWT is enabled", () => {
+      cy.visit("/admin/embedding/setup-guide");
+
+      cy.findByTestId("admin-layout-content")
+        .findByText("Embed in production with SSO")
+        .scrollIntoView()
+        .should("be.visible")
+        .closest("button")
+        .icon("lock")
+        .should("be.visible");
+
+      enableJwtAuth();
+      cy.reload();
+
+      cy.findByTestId("admin-layout-content")
+        .findByText("Embed in production with SSO")
+        .scrollIntoView()
+        .should("be.visible")
+        .closest("button")
+        .icon("lock")
+        .should("not.exist");
     });
 
     it("embedding checklist should show up on the embedding homepage", () => {

--- a/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
@@ -165,14 +165,8 @@ describe("scenarios - embedding hub", () => {
     });
 
     it('"Get embed snippet" step should be done when a guest embed is published', () => {
-      cy.intercept("GET", "/api/ee/embedding-hub/checklist").as("getChecklist");
-
       cy.log("Create a dashboard to embed");
-      H.createDashboard({ name: "Test Dashboard" }).then(
-        ({ body: dashboard }) => {
-          cy.wrap(dashboard.id).as("dashboardId");
-        },
-      );
+      H.createDashboard({ name: "Test Dashboard" });
 
       cy.visit("/admin/embedding/setup-guide");
 
@@ -204,12 +198,11 @@ describe("scenarios - embedding hub", () => {
       cy.log("publish the embed");
       H.publishChanges("dashboard");
 
+      cy.log("close the wizard");
       H.modal().first().findByText("Get code").click();
-      H.modal().first().findByText("Done").click();
+      H.modal().first().findByLabelText("Close").click();
 
-      cy.wait("@getChecklist");
-
-      cy.log("step should now be marked as done");
+      cy.log("step should be marked as done");
       cy.findByTestId("admin-layout-content")
         .findByText("Get embed snippet")
         .closest("button")

--- a/enterprise/backend/src/metabase_enterprise/embedding_hub/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/embedding_hub/api.clj
@@ -70,6 +70,11 @@
       (t2/exists? :model/ConnectionImpersonation)
       (t2/exists? :model/DatabaseRouter)))
 
+(defn- has-published-guest-embed? []
+  ;; Check if at least one card or dashboard has embedding enabled (is published as a guest embed)
+  (or (t2/exists? :model/Card :enable_embedding true)
+      (t2/exists? :model/Dashboard :enable_embedding true)))
+
 (defn- embedding-hub-checklist []
   (let [enable-tenants?                  (and (perms/use-tenants)
                                               (has-shared-tenant-collections?))
@@ -80,7 +85,8 @@
      "create-dashboard"                  (has-user-created-dashboard?)
      "create-models"                     (has-user-created-models?)
      "configure-row-column-security"     (has-configured-sandboxes?)
-     "create-test-embed"                 (embedding.settings/embedding-hub-test-embed-snippet-created)
+     "create-test-embed"                 (or (has-published-guest-embed?)
+                                             (embedding.settings/embedding-hub-test-embed-snippet-created))
      "embed-production"                  (embedding.settings/embedding-hub-production-embed-snippet-created)
      "data-permissions-and-enable-tenants" (and enable-tenants?
                                                 create-tenants?

--- a/frontend/src/metabase/api/card.ts
+++ b/frontend/src/metabase/api/card.ts
@@ -40,7 +40,9 @@ export const cardApi = Api.injectEndpoints({
   endpoints: (builder) => {
     const updateCardPropertiesMutation = <
       PropertyKey extends keyof UpdateCardRequest,
-    >() =>
+    >(
+      additionalTags: ReturnType<typeof listTag>[] = [],
+    ) =>
       builder.mutation<Card, UpdateCardKeyRequest<PropertyKey>>({
         query: ({ id, ...body }) => ({
           method: "PUT",
@@ -52,6 +54,7 @@ export const cardApi = Api.injectEndpoints({
             listTag("card"),
             idTag("card", id),
             idTag("table", `card__${id}`),
+            ...additionalTags,
           ]),
       });
 
@@ -294,7 +297,7 @@ export const cardApi = Api.injectEndpoints({
       }),
       updateCardEnableEmbedding: updateCardPropertiesMutation<
         "enable_embedding" | "embedding_type"
-      >(),
+      >([listTag("embedding-hub-checklist")]),
       updateCardEmbeddingParams: updateCardPropertiesMutation<
         "embedding_params" | "embedding_type"
       >(),

--- a/frontend/src/metabase/api/dashboard.ts
+++ b/frontend/src/metabase/api/dashboard.ts
@@ -42,7 +42,9 @@ export const dashboardApi = Api.injectEndpoints({
   endpoints: (builder) => {
     const updateDashboardPropertiesMutation = <
       Key extends keyof UpdateDashboardRequest,
-    >() =>
+    >(
+      additionalTags: ReturnType<typeof listTag>[] = [],
+    ) =>
       builder.mutation<Dashboard, UpdateDashboardPropertyRequest<Key>>({
         query: ({ id, ...body }) => ({
           method: "PUT",
@@ -50,7 +52,11 @@ export const dashboardApi = Api.injectEndpoints({
           body,
         }),
         invalidatesTags: (_, error, { id }) =>
-          invalidateTags(error, [listTag("dashboard"), idTag("dashboard", id)]),
+          invalidateTags(error, [
+            listTag("dashboard"),
+            idTag("dashboard", id),
+            ...additionalTags,
+          ]),
       });
 
     return {
@@ -203,7 +209,7 @@ export const dashboardApi = Api.injectEndpoints({
       }),
       updateDashboardEnableEmbedding: updateDashboardPropertiesMutation<
         "enable_embedding" | "embedding_type"
-      >(),
+      >([listTag("embedding-hub-checklist")]),
       updateDashboardEmbeddingParams: updateDashboardPropertiesMutation<
         "embedding_params" | "embedding_type"
       >(),

--- a/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/ConnectionImpersonationStepContent.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/ConnectionImpersonationStepContent.tsx
@@ -11,7 +11,7 @@ import { useToast } from "metabase/common/hooks";
 import { Button, Flex, Stack, Text } from "metabase/ui";
 import type { Database, DatabaseId } from "metabase-types/api";
 
-import { useUpdateTenantGroupPermissions } from "./hooks/use-update-tenant-permissions";
+import { useUpdateAllTenantUsersGroupPermissions } from "./hooks/use-update-all-tenant-users-group-permissions";
 
 const supportsConnectionImpersonation = (db: Database) =>
   db.features?.includes("connection-impersonation") ?? false;
@@ -26,7 +26,7 @@ export const ConnectionImpersonationStepContent = ({
   const [isUpdatingPermissions, setUpdatingPermissions] = useState(false);
 
   const { data: databasesResponse } = useListDatabasesQuery();
-  const { updateDataAccess } = useUpdateTenantGroupPermissions();
+  const { updateDataAccess } = useUpdateAllTenantUsersGroupPermissions();
 
   const databases = useMemo(
     () => databasesResponse?.data ?? [],
@@ -94,7 +94,6 @@ export const ConnectionImpersonationStepContent = ({
       </Text>
 
       <DatabaseMultiSelect
-        databases={databases}
         value={selectedDatabaseIds}
         onChange={setSelectedDatabaseIds}
         isOptionDisabled={(db) => !supportsConnectionImpersonation(db)}

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/GetCodeStep.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/GetCodeStep.tsx
@@ -37,7 +37,11 @@ export const GetCodeStep = () => {
     trackSnippetCopied("frontend");
 
     // Embedding Hub: track step completion
-    const settingKey: SettingKey = settings.useExistingUserSession
+    // Test embed = guest or existing user session (for quick testing)
+    // Production embed = full SSO setup
+    const isTestEmbed = settings.isGuest || settings.useExistingUserSession;
+
+    const settingKey: SettingKey = isTestEmbed
       ? "embedding-hub-test-embed-snippet-created"
       : "embedding-hub-production-embed-snippet-created";
 

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SdkIframeEmbedSetupModal.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SdkIframeEmbedSetupModal.tsx
@@ -58,7 +58,11 @@ export const SdkIframeEmbedSetupContent = () => {
 
   function handleEmbedDone() {
     // Embedding Hub: track step completion
-    const settingKey: SettingKey = settings.useExistingUserSession
+    // Test embed = guest or existing user session (for quick testing)
+    // Production embed = full SSO setup
+    const isTestEmbed = settings.isGuest || settings.useExistingUserSession;
+
+    const settingKey: SettingKey = isTestEmbed
       ? "embedding-hub-test-embed-snippet-created"
       : "embedding-hub-production-embed-snippet-created";
 


### PR DESCRIPTION
Closes EMB-1180

### Description

Marks the get embed snippet step as done when guest embeds are published.

### How to verify

- Go to embedding hub
- Click on "Get embed snippet"
- Select **guest embeds** in the embed type
- Publish a guest embed
- Complete the flow
- Step should be marked as done

### Demo

<img width="1540" height="572" alt="CleanShot 2569-02-19 at 15 11 26@2x" src="https://github.com/user-attachments/assets/ee59cb3e-6597-445b-a68c-eb1dd5b9cf25" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR - e2e
