### PR TITLE
Improve types with entity ids

### DIFF
--- a/frontend/src/metabase-lib/transforms-inspector.ts
+++ b/frontend/src/metabase-lib/transforms-inspector.ts
@@ -1,14 +1,16 @@
 import * as INSPECTOR from "cljs/metabase.transforms_inspector.js";
 import type {
   InspectorCard,
+  InspectorCardId,
   InspectorLens,
+  InspectorLensId,
   LensParams,
   TransformInspectField,
 } from "metabase-types/api";
 
 export type TriggeredCondition = {
   name: string;
-  card_id: string;
+  card_id: InspectorCardId;
   [key: string]: unknown;
 };
 
@@ -20,7 +22,7 @@ export type TriggeredAlert = {
 };
 
 export type TriggeredDrillLens = {
-  lens_id: string;
+  lens_id: InspectorLensId;
   params?: LensParams;
   reason?: string;
   condition: TriggeredCondition;
@@ -53,7 +55,7 @@ export const evaluateTriggers = (
 ): TriggerResult => INSPECTOR.evaluateTriggers(lens, cardsStats);
 
 export const computeCardStats = (
-  lensId: string,
+  lensId: InspectorLensId,
   card: InspectorCard,
   rows: unknown[][] | undefined,
 ): CardStats | null => INSPECTOR.computeCardResult(lensId, card, rows ?? []);
@@ -64,7 +66,7 @@ export type DegeneracyResult = {
 };
 
 export const isDegenerate = (
-  cardId: string,
+  cardId: InspectorCardId,
   displayType: string,
   cardsStats: Record<string, CardStats>,
 ): DegeneracyResult => INSPECTOR.isDegenerate(cardId, displayType, cardsStats);

--- a/frontend/src/metabase-lib/transforms-inspector.ts
+++ b/frontend/src/metabase-lib/transforms-inspector.ts
@@ -2,10 +2,10 @@ import * as INSPECTOR from "cljs/metabase.transforms_inspector.js";
 import type {
   InspectorCard,
   InspectorCardId,
+  InspectorField,
   InspectorLens,
   InspectorLensId,
   LensParams,
-  TransformInspectField,
 } from "metabase-types/api";
 
 export type TriggeredCondition = {
@@ -38,10 +38,10 @@ export type CardStats = Record<string, unknown>;
 type VisitedFields = Record<string, unknown>;
 
 export const interestingFields = (
-  fields: TransformInspectField[],
+  fields: InspectorField[],
   visitedFields?: VisitedFields,
   options?: { threshold?: number; limit?: number },
-): Array<TransformInspectField & { interestingness: { score: number } }> =>
+): Array<InspectorField & { interestingness: { score: number } }> =>
   INSPECTOR.interestingFields(
     fields,
     visitedFields ?? null,

--- a/frontend/src/metabase-types/api/mocks/transform.ts
+++ b/frontend/src/metabase-types/api/mocks/transform.ts
@@ -1,10 +1,10 @@
 import type {
   DatabaseId,
   InspectorCard,
+  InspectorSource,
   ListTransformRunsResponse,
   PythonTransformTableAliases,
   Transform,
-  TransformInspectSource,
   TransformJob,
   TransformOwner,
   TransformRun,
@@ -175,8 +175,8 @@ export function createMockUpdateTransformRequest(
 }
 
 export function createMockTransformInspectSource(
-  opts?: Partial<TransformInspectSource>,
-): TransformInspectSource {
+  opts?: Partial<InspectorSource>,
+): InspectorSource {
   return {
     table_name: "Table",
     column_count: 0,

--- a/frontend/src/metabase-types/api/transform.ts
+++ b/frontend/src/metabase-types/api/transform.ts
@@ -514,6 +514,7 @@ export type InspectorLensSummary = {
   alerts?: unknown[];
 };
 
+// open schema with name key always present
 export type InspectorTriggerCondition = {
   name: string;
   [key: string]: unknown;

--- a/frontend/src/metabase-types/api/transform.ts
+++ b/frontend/src/metabase-types/api/transform.ts
@@ -526,7 +526,7 @@ export type InspectorAlertTrigger = {
   message: string;
 };
 
-export type LensParams = Record<string, string>;
+export type LensParams = Record<string, string | number>;
 
 export type InspectorDrillLensTrigger = {
   lens_id: InspectorLensId;
@@ -549,7 +549,7 @@ export type InspectorLens = {
 export type GetInspectorLensRequest = {
   transformId: TransformId;
   lensId: InspectorLensId;
-  lensParams?: unknown;
+  lensParams?: LensParams;
 };
 
 export type MetabotSuggestedTransform = SuggestedTransform & {

--- a/frontend/src/metabase-types/api/transform.ts
+++ b/frontend/src/metabase-types/api/transform.ts
@@ -391,26 +391,26 @@ export type TransformInspectJoin = {
 };
 
 export type TransformInspectSource = {
-  table_id?: number;
+  table_id?: ConcreteTableId;
   table_name: string;
-  schema?: string;
-  db_id?: number;
+  schema?: SchemaName;
+  db_id?: DatabaseId;
   row_count?: number;
   column_count: number;
   fields: TransformInspectField[];
 };
 
 export type TransformInspectTarget = {
-  table_id: number;
+  table_id: ConcreteTableId;
   table_name: string;
-  schema?: string;
+  schema?: SchemaName;
   row_count?: number;
   column_count: number;
   fields: TransformInspectField[];
 };
 
 export type TransformInspectComparisonCard = {
-  id: string;
+  id: InspectorCardId;
   source: "input" | "output";
   table_name: string;
   field_name: string;

--- a/frontend/src/metabase-types/api/transform.ts
+++ b/frontend/src/metabase-types/api/transform.ts
@@ -14,6 +14,10 @@ export type TransformTagId = number;
 export type TransformJobId = number;
 export type TransformRunId = number;
 
+export type InspectorLensId = string;
+export type InspectorCardId = string;
+export type InspectorSectionId = string;
+
 export type TransformOwner = Pick<
   UserInfo,
   "id" | "email" | "first_name" | "last_name"
@@ -447,7 +451,7 @@ export type InspectorLensComplexity = {
 };
 
 export type InspectorLensMetadata = {
-  id: string;
+  id: InspectorLensId;
   display_name: string;
   description?: string;
   complexity?: InspectorLensComplexity;
@@ -466,7 +470,7 @@ export type InspectorDiscoveryResponse = {
 export type InspectorLayoutType = "flat" | "comparison";
 
 export type InspectorSection = {
-  id: string;
+  id: InspectorSectionId;
   title: string;
   description?: string;
   layout?: InspectorLayoutType;
@@ -487,8 +491,8 @@ type InspectorCardMetadata = {
 };
 
 export type InspectorCard = {
-  id: string;
-  section_id?: string;
+  id: InspectorCardId;
+  section_id?: InspectorSectionId;
   title: string;
   display: InspectorCardDisplayType;
   dataset_query: DatasetQuery;
@@ -501,7 +505,7 @@ export type InspectorCard = {
 export type InspectorSummaryHighlight = {
   label: string;
   value?: unknown;
-  card_id?: string;
+  card_id?: InspectorCardId;
 };
 
 export type InspectorLensSummary = {
@@ -525,14 +529,14 @@ export type InspectorAlertTrigger = {
 export type LensParams = Record<string, string>;
 
 export type InspectorDrillLensTrigger = {
-  lens_id: string;
+  lens_id: InspectorLensId;
   condition: InspectorTriggerCondition;
   params?: LensParams;
   reason?: string;
 };
 
 export type InspectorLens = {
-  id: string;
+  id: InspectorLensId;
   display_name: string;
   summary?: InspectorLensSummary;
   sections: InspectorSection[];
@@ -544,7 +548,7 @@ export type InspectorLens = {
 
 export type GetInspectorLensRequest = {
   transformId: TransformId;
-  lensId: string;
+  lensId: InspectorLensId;
   lensParams?: unknown;
 };
 

--- a/frontend/src/metabase-types/api/transform.ts
+++ b/frontend/src/metabase-types/api/transform.ts
@@ -481,7 +481,7 @@ export type InspectorCardDisplayType = CardDisplayType | "hidden";
 type InspectorCardMetadata = {
   card_type: "join_step" | "table_count" | "base_count";
   dedup_key: Array<string | number>;
-  table_id?: number;
+  table_id?: ConcreteTableId;
   join_step?: number;
   join_alias?: string;
   join_strategy?: JoinStrategy;

--- a/frontend/src/metabase-types/api/transform.ts
+++ b/frontend/src/metabase-types/api/transform.ts
@@ -316,7 +316,7 @@ export type FieldStats =
   | FieldStatsNumeric
   | FieldStatsTemporal;
 
-export type TransformInspectFieldStats = {
+export type InspectorFieldStats = {
   distinct_count?: number;
   nil_percent?: number;
   // Numeric stats
@@ -349,7 +349,7 @@ export const NUMERIC_BASE_TYPES = [
   "type/Number",
 ] as const;
 
-export type TransformInspectField = {
+export type InspectorField = {
   id?: number;
   name: string;
   display_name?: string;
@@ -357,21 +357,21 @@ export type TransformInspectField = {
     | (typeof TEMPORAL_BASE_TYPES)[number]
     | (typeof NUMERIC_BASE_TYPES)[number];
   semantic_type?: string;
-  stats?: TransformInspectFieldStats;
+  stats?: InspectorFieldStats;
 };
 
-export type TransformInspectSummaryTable = {
+export type InspectorSummaryTable = {
   table_name: string;
   row_count?: number;
   column_count: number;
 };
 
-export type TransformInspectSummary = {
-  inputs: TransformInspectSummaryTable[];
-  output: TransformInspectSummaryTable;
+export type InspectorSummary = {
+  inputs: InspectorSummaryTable[];
+  output: InspectorSummaryTable;
 };
 
-export type TransformInspectJoin = {
+export type InspectorJoin = {
   strategy: JoinStrategy;
   alias?: string;
   source_table: ConcreteTableId;
@@ -390,26 +390,26 @@ export type TransformInspectJoin = {
   };
 };
 
-export type TransformInspectSource = {
+export type InspectorSource = {
   table_id?: ConcreteTableId;
   table_name: string;
   schema?: SchemaName;
   db_id?: DatabaseId;
   row_count?: number;
   column_count: number;
-  fields: TransformInspectField[];
+  fields: InspectorField[];
 };
 
-export type TransformInspectTarget = {
+export type InspectorTarget = {
   table_id: ConcreteTableId;
   table_name: string;
   schema?: SchemaName;
   row_count?: number;
   column_count: number;
-  fields: TransformInspectField[];
+  fields: InspectorField[];
 };
 
-export type TransformInspectComparisonCard = {
+export type InspectorComparisonCard = {
   id: InspectorCardId;
   source: "input" | "output";
   table_name: string;
@@ -419,28 +419,28 @@ export type TransformInspectComparisonCard = {
   dataset_query: DatasetQuery;
 };
 
-export type TransformInspectColumnComparison = {
+export type InspectorColumnComparison = {
   id: string;
   output_column: string;
-  cards: TransformInspectComparisonCard[];
+  cards: InspectorComparisonCard[];
 };
 
-export type TransformInspectStatus = "not-run" | "ready";
+export type InspectorStatus = "not-run" | "ready";
 
-export type TransformInspectVisitedFields = {
+export type InspectorVisitedFields = {
   all?: number[];
 };
 
-export type TransformInspectResponse = {
+export type InspectorResponse = {
   name: string;
   description: string;
-  status: TransformInspectStatus;
-  summary?: TransformInspectSummary;
-  joins?: TransformInspectJoin[];
-  sources: TransformInspectSource[];
-  target?: TransformInspectTarget;
-  column_comparisons?: TransformInspectColumnComparison[];
-  visited_fields?: TransformInspectVisitedFields;
+  status: InspectorStatus;
+  summary?: InspectorSummary;
+  joins?: InspectorJoin[];
+  sources: InspectorSource[];
+  target?: InspectorTarget;
+  column_comparisons?: InspectorColumnComparison[];
+  visited_fields?: InspectorVisitedFields;
 };
 
 export type InspectorLensComplexityLevel = "fast" | "slow" | "very-slow";
@@ -460,10 +460,10 @@ export type InspectorLensMetadata = {
 export type InspectorDiscoveryResponse = {
   name: string;
   description?: string;
-  status: TransformInspectStatus;
-  sources: TransformInspectSource[];
-  target?: TransformInspectTarget;
-  visited_fields?: TransformInspectVisitedFields;
+  status: InspectorStatus;
+  sources: InspectorSource[];
+  target?: InspectorTarget;
+  visited_fields?: InspectorVisitedFields;
   available_lenses: InspectorLensMetadata[];
 };
 

--- a/frontend/src/metabase/api/transform.ts
+++ b/frontend/src/metabase/api/transform.ts
@@ -9,6 +9,7 @@ import type {
   GetInspectorLensRequest,
   InspectorDiscoveryResponse,
   InspectorLens,
+  InspectorLensId,
   ListTransformRunsRequest,
   ListTransformRunsResponse,
   ListTransformsRequest,
@@ -254,7 +255,7 @@ export const transformApi = Api.injectEndpoints({
       Dataset,
       {
         transformId: TransformId;
-        lensId: string;
+        lensId: InspectorLensId;
         query: DatasetQuery;
         lensParams?: unknown;
       }

--- a/frontend/src/metabase/api/transform.ts
+++ b/frontend/src/metabase/api/transform.ts
@@ -10,6 +10,7 @@ import type {
   InspectorDiscoveryResponse,
   InspectorLens,
   InspectorLensId,
+  InspectorResponse,
   ListTransformRunsRequest,
   ListTransformRunsResponse,
   ListTransformsRequest,
@@ -17,7 +18,6 @@ import type {
   RunTransformResponse,
   Transform,
   TransformId,
-  TransformInspectResponse,
   UpdateTransformRequest,
 } from "metabase-types/api";
 
@@ -223,7 +223,7 @@ export const transformApi = Api.injectEndpoints({
         body: { query: queryString },
       }),
     }),
-    getTransformInspect: builder.query<TransformInspectResponse, TransformId>({
+    getTransformInspect: builder.query<InspectorResponse, TransformId>({
       query: (id) => ({
         method: "GET",
         url: `/api/transform/${id}/inspect`,

--- a/frontend/src/metabase/transforms/analytics.ts
+++ b/frontend/src/metabase/transforms/analytics.ts
@@ -1,5 +1,10 @@
 import { trackSimpleEvent } from "metabase/lib/analytics";
-import type { TransformId, TransformJobId } from "metabase-types/api";
+import type {
+  InspectorCardId,
+  InspectorLensId,
+  TransformId,
+  TransformJobId,
+} from "metabase-types/api";
 
 export function trackTransformTriggerManualRun({
   transformId,
@@ -69,7 +74,7 @@ export function trackTransformInspectLensLoaded({
   durationMs,
 }: {
   transformId: TransformId;
-  lensId: string;
+  lensId: InspectorLensId;
   durationMs: number;
 }) {
   trackSimpleEvent({
@@ -86,7 +91,7 @@ export function trackTransformInspectDrillLensClicked({
   triggeredFrom,
 }: {
   transformId: TransformId;
-  lensId: string;
+  lensId: InspectorLensId;
   triggeredFrom: "card_drills" | "join_analysis";
 }) {
   trackSimpleEvent({
@@ -102,7 +107,7 @@ export function trackTransformInspectAlertClicked({
   cardId,
 }: {
   transformId: TransformId;
-  cardId: string;
+  cardId: InspectorCardId;
 }) {
   trackSimpleEvent({
     event: "transform_inspect_alert_clicked",
@@ -116,7 +121,7 @@ export function trackTransformInspectDrillLensClosed({
   lensId,
 }: {
   transformId: TransformId;
-  lensId: string;
+  lensId: InspectorLensId;
 }) {
   trackSimpleEvent({
     event: "transform_inspect_drill_lens_closed",

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensContent/LensContentContext.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensContent/LensContentContext.tsx
@@ -10,7 +10,11 @@ import type {
   TriggeredAlert,
   TriggeredDrillLens,
 } from "metabase-lib/transforms-inspector";
-import type { InspectorLens, Transform } from "metabase-types/api";
+import type {
+  InspectorCardId,
+  InspectorLens,
+  Transform,
+} from "metabase-types/api";
 
 import type { LensHandle } from "../../types";
 
@@ -18,13 +22,13 @@ type LensContentContextValue = {
   transform: Transform;
   lens: InspectorLens;
   lensHandle: LensHandle;
-  alertsByCardId: Record<string, TriggeredAlert[]>;
-  drillLensesByCardId: Record<string, TriggeredDrillLens[]>;
-  collectedCardStats: Record<string, CardStats>;
+  alertsByCardId: Record<InspectorCardId, TriggeredAlert[]>;
+  drillLensesByCardId: Record<InspectorCardId, TriggeredDrillLens[]>;
+  collectedCardStats: Record<InspectorCardId, CardStats>;
   navigateToLens: (lensHandle: LensHandle) => void;
-  onStatsReady: (cardId: string, stats: CardStats | null) => void;
-  onCardStartedLoading: (cardId: string) => void;
-  onCardLoaded: (cardId: string) => void;
+  onStatsReady: (cardId: InspectorCardId, stats: CardStats | null) => void;
+  onCardStartedLoading: (cardId: InspectorCardId) => void;
+  onCardLoaded: (cardId: InspectorCardId) => void;
 };
 
 const LensEvaluationContext = createContext<

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensContent/useLensLoadedTracking.ts
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensContent/useLensLoadedTracking.ts
@@ -1,11 +1,11 @@
 import { useCallback, useRef } from "react";
 
 import { trackTransformInspectLensLoaded } from "metabase/transforms/analytics";
-import type { TransformId } from "metabase-types/api";
+import type { InspectorLensId, TransformId } from "metabase-types/api";
 
 export const useLensLoadedTracking = (
   transformId: TransformId,
-  lensId: string,
+  lensId: InspectorLensId,
 ) => {
   const lensStartTimeRef = useRef<number>(Date.now());
   const hasCalledRef = useRef(false);

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensNavigator/utils.ts
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensNavigator/utils.ts
@@ -21,7 +21,9 @@ export const getLensKey = (handle: LensHandle): string => {
   if (!handle.params) {
     return handle.id;
   }
-  const searchParams = new URLSearchParams(handle.params);
+  const searchParams = new URLSearchParams(
+    Object.entries(handle.params).map(([key, value]) => [key, String(value)]),
+  );
   searchParams.sort();
   return `${handle.id}?${searchParams.toString()}`;
 };

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/DefaultLensSections/DefaultLensSections.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/DefaultLensSections/DefaultLensSections.tsx
@@ -5,8 +5,8 @@ import type {
   InspectorCard,
   InspectorSection,
   InspectorSectionId,
-  TransformInspectSource,
-  TransformInspectVisitedFields,
+  InspectorSource,
+  InspectorVisitedFields,
 } from "metabase-types/api";
 
 import { ComparisonLayout } from "./components/ComparisonLayout/ComparisonLayout";
@@ -15,8 +15,8 @@ import { FlatLayout } from "./components/FlatLayout";
 type DefaultLensSectionsProps = {
   sections: InspectorSection[];
   cardsBySection: Record<InspectorSectionId, InspectorCard[]>;
-  sources: TransformInspectSource[];
-  visitedFields?: TransformInspectVisitedFields;
+  sources: InspectorSource[];
+  visitedFields?: InspectorVisitedFields;
 };
 
 export const DefaultLensSections = ({

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/DefaultLensSections/DefaultLensSections.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/DefaultLensSections/DefaultLensSections.tsx
@@ -4,6 +4,7 @@ import { Box, Stack, Title } from "metabase/ui";
 import type {
   InspectorCard,
   InspectorSection,
+  InspectorSectionId,
   TransformInspectSource,
   TransformInspectVisitedFields,
 } from "metabase-types/api";
@@ -13,7 +14,7 @@ import { FlatLayout } from "./components/FlatLayout";
 
 type DefaultLensSectionsProps = {
   sections: InspectorSection[];
-  cardsBySection: Record<string, InspectorCard[]>;
+  cardsBySection: Record<InspectorSectionId, InspectorCard[]>;
   sources: TransformInspectSource[];
   visitedFields?: TransformInspectVisitedFields;
 };

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/DefaultLensSections/components/ComparisonLayout/ComparisonLayout.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/DefaultLensSections/components/ComparisonLayout/ComparisonLayout.tsx
@@ -4,8 +4,8 @@ import { match } from "ts-pattern";
 import { SimpleGrid, Stack } from "metabase/ui";
 import type {
   InspectorCard,
-  TransformInspectSource,
-  TransformInspectVisitedFields,
+  InspectorSource,
+  InspectorVisitedFields,
 } from "metabase-types/api";
 
 import { ScalarCard } from "../ScalarCard";
@@ -15,8 +15,8 @@ import { groupCardsBySource, sortGroupsByScore } from "./utils";
 
 type ComparisonLayoutProps = {
   cards: InspectorCard[];
-  sources: TransformInspectSource[];
-  visitedFields?: TransformInspectVisitedFields;
+  sources: InspectorSource[];
+  visitedFields?: InspectorVisitedFields;
 };
 
 export const ComparisonLayout = ({

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/DefaultLensSections/components/ComparisonLayout/ComparisonLayout.unit.spec.ts
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/DefaultLensSections/components/ComparisonLayout/ComparisonLayout.unit.spec.ts
@@ -1,4 +1,4 @@
-import type { TransformInspectField } from "metabase-types/api";
+import type { InspectorField } from "metabase-types/api";
 import {
   createMockInspectorCard,
   createMockTransformInspectSource,
@@ -8,10 +8,10 @@ import { type CardGroup, sortGroupsByScore } from "./utils";
 
 jest.mock("metabase-lib/transforms-inspector", () => ({
   interestingFields: (
-    fields: TransformInspectField[],
+    fields: InspectorField[],
     _visitedFields: unknown,
     // we use field ID as the score for testing purposes
-  ): Array<TransformInspectField & { interestingness: { score: number } }> =>
+  ): Array<InspectorField & { interestingness: { score: number } }> =>
     fields.map((f) => ({ ...f, interestingness: { score: f.id ?? 0 } })),
 }));
 

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/DefaultLensSections/components/ComparisonLayout/utils.ts
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/DefaultLensSections/components/ComparisonLayout/utils.ts
@@ -1,8 +1,8 @@
 import { interestingFields } from "metabase-lib/transforms-inspector";
 import type {
   InspectorCard,
-  TransformInspectSource,
-  TransformInspectVisitedFields,
+  InspectorSource,
+  InspectorVisitedFields,
 } from "metabase-types/api";
 
 export type CardGroup = {
@@ -25,8 +25,8 @@ const parseTitleParts = (title: string): { field: string; table?: string } => {
 
 export function sortGroupsByScore(
   groups: CardGroup[],
-  sources: TransformInspectSource[],
-  visitedFields?: TransformInspectVisitedFields,
+  sources: InspectorSource[],
+  visitedFields?: InspectorVisitedFields,
 ): CardGroupWithScore[] {
   const allFields = sources.flatMap((s) => s.fields ?? []);
   const scoredFields = interestingFields(allFields, visitedFields);
@@ -43,7 +43,7 @@ export function sortGroupsByScore(
   return groupsWithScore.sort((a, b) => b.topScore - a.topScore);
 }
 
-const buildTableOrdersInSources = (sources: TransformInspectSource[]) => {
+const buildTableOrdersInSources = (sources: InspectorSource[]) => {
   const map = new Map<number | undefined, number>();
   for (let i = 0; i < sources.length; i++) {
     map.set(sources[i].table_id, i);
@@ -78,7 +78,7 @@ const groupCardsByGroupId = (
 
 export const groupCardsBySource = (
   cards: InspectorCard[],
-  sources: TransformInspectSource[],
+  sources: InspectorSource[],
 ): CardGroup[] => {
   const cardsByGroupId = groupCardsByGroupId(cards);
   const tableOrdersInSources = buildTableOrdersInSources(sources);

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/DefaultLensSections/components/VisualizationCard.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/DefaultLensSections/components/VisualizationCard.tsx
@@ -12,6 +12,7 @@ import type {
   InspectorCard,
   InspectorCardDisplayType,
   RawSeries,
+  VisualizationSettings,
 } from "metabase-types/api";
 import { createMockCard } from "metabase-types/api/mocks";
 
@@ -117,7 +118,7 @@ function buildRawSeries(
   dataset: Dataset | undefined,
   card: InspectorCard,
   displayType: InspectorCardDisplayType,
-  displaySettings: Record<string, unknown>,
+  displaySettings: Partial<VisualizationSettings>,
 ): RawSeries | undefined {
   if (!dataset) {
     return;

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/GenericSummarySections/GenericSummarySection.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/GenericSummarySections/GenericSummarySection.tsx
@@ -14,8 +14,8 @@ import {
 } from "metabase/ui";
 import type {
   InspectorCard,
-  TransformInspectSource,
-  TransformInspectTarget,
+  InspectorSource,
+  InspectorTarget,
 } from "metabase-types/api";
 
 import { FieldInfoSection } from "./components/FieldInfoSection/FieldInfoSection";
@@ -24,8 +24,8 @@ import { treeTableStyles } from "./styles";
 
 type GenericSummarySectionProps = {
   cards: InspectorCard[];
-  sources: TransformInspectSource[];
-  target?: TransformInspectTarget;
+  sources: InspectorSource[];
+  target?: InspectorTarget;
 };
 
 type TableRow = {
@@ -132,7 +132,7 @@ export const GenericSummarySection = ({
 
 function getTableName(
   tableId: number | undefined,
-  tables: Array<TransformInspectSource | TransformInspectTarget>,
+  tables: Array<InspectorSource | InspectorTarget>,
 ): string | undefined {
   if (!tableId) {
     return undefined;

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/GenericSummarySections/GenericSummarySections.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/GenericSummarySections/GenericSummarySections.tsx
@@ -1,6 +1,7 @@
 import type {
   InspectorCard,
   InspectorSection,
+  InspectorSectionId,
   TransformInspectSource,
   TransformInspectTarget,
 } from "metabase-types/api";
@@ -9,7 +10,7 @@ import { GenericSummarySection } from "./GenericSummarySection";
 
 type GenericSummarySectionsProps = {
   sections: InspectorSection[];
-  cardsBySection: Record<string, InspectorCard[]>;
+  cardsBySection: Record<InspectorSectionId, InspectorCard[]>;
   sources: TransformInspectSource[];
   target?: TransformInspectTarget;
 };

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/GenericSummarySections/GenericSummarySections.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/GenericSummarySections/GenericSummarySections.tsx
@@ -2,8 +2,8 @@ import type {
   InspectorCard,
   InspectorSection,
   InspectorSectionId,
-  TransformInspectSource,
-  TransformInspectTarget,
+  InspectorSource,
+  InspectorTarget,
 } from "metabase-types/api";
 
 import { GenericSummarySection } from "./GenericSummarySection";
@@ -11,8 +11,8 @@ import { GenericSummarySection } from "./GenericSummarySection";
 type GenericSummarySectionsProps = {
   sections: InspectorSection[];
   cardsBySection: Record<InspectorSectionId, InspectorCard[]>;
-  sources: TransformInspectSource[];
-  target?: TransformInspectTarget;
+  sources: InspectorSource[];
+  target?: InspectorTarget;
 };
 
 export const GenericSummarySections = ({

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/GenericSummarySections/components/FieldInfoSection/types.ts
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/GenericSummarySections/components/FieldInfoSection/types.ts
@@ -1,13 +1,13 @@
 import type {
-  TransformInspectField,
-  TransformInspectFieldStats,
-  TransformInspectSource,
-  TransformInspectTarget,
+  InspectorField,
+  InspectorFieldStats,
+  InspectorSource,
+  InspectorTarget,
 } from "metabase-types/api";
 
 export type FieldInfoSectionProps = {
-  sources: TransformInspectSource[];
-  target?: TransformInspectTarget;
+  sources: InspectorSource[];
+  target?: InspectorTarget;
 };
 
 export type FieldTreeNode = {
@@ -17,14 +17,14 @@ export type FieldTreeNode = {
   fieldName?: string;
   fieldCount?: number;
   baseType?: string;
-  stats?: TransformInspectFieldStats;
+  stats?: InspectorFieldStats;
   children?: FieldTreeNode[];
 };
 
 export type TableWithFields = {
   table_id?: number | null;
   table_name: string;
-  fields: TransformInspectField[];
+  fields: InspectorField[];
 };
 
 export type StatsColumn = "distinct_count" | "range_and_averages";

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/GenericSummarySections/components/FieldInfoSection/utils.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/GenericSummarySections/components/FieldInfoSection/utils.tsx
@@ -11,7 +11,7 @@ import {
   Text,
   type TreeTableColumnDef,
 } from "metabase/ui";
-import type { TransformInspectField } from "metabase-types/api";
+import type { InspectorField } from "metabase-types/api";
 
 import type { FieldTreeNode, TableWithFields } from "./types";
 
@@ -35,7 +35,7 @@ export function buildTableNodes(tables: TableWithFields[]): FieldTreeNode[] {
   });
 }
 
-export function formatType(field: TransformInspectField): string {
+export function formatType(field: InspectorField): string {
   return field.base_type?.replace("type/", "") ?? t`Unknown`;
 }
 

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/GenericSummarySections/components/FieldInfoSection/utils.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/GenericSummarySections/components/FieldInfoSection/utils.tsx
@@ -15,10 +15,6 @@ import type { TransformInspectField } from "metabase-types/api";
 
 import type { FieldTreeNode, TableWithFields } from "./types";
 
-export function isKey<T extends object>(x: T, k: PropertyKey): k is keyof T {
-  return k in x;
-}
-
 export function buildTableNodes(tables: TableWithFields[]): FieldTreeNode[] {
   return tables.map((table) => {
     const tableKey = table.table_id ?? table.table_name;
@@ -88,7 +84,7 @@ export function getColumns(): TreeTableColumnDef<FieldTreeNode>[] {
       id: "distinct_count",
       header: t`Distincts`,
       width: "auto",
-      accessorFn: getDitinctCount,
+      accessorFn: getDistinctCount,
       cell: renderEllipsified,
     },
     {
@@ -116,7 +112,7 @@ function renderEllipsified(props: CellContext<FieldTreeNode, unknown>) {
   return <Ellipsified>{String(props.getValue())}</Ellipsified>;
 }
 
-function getDitinctCount(node: FieldTreeNode) {
+function getDistinctCount(node: FieldTreeNode) {
   const distinctCount = node.stats?.distinct_count;
   return distinctCount !== undefined ? distinctCount.toLocaleString() : "";
 }

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/JoinAnalysisSections/JoinAnalysisSections.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/JoinAnalysisSections/JoinAnalysisSections.tsx
@@ -1,10 +1,14 @@
-import type { InspectorCard, InspectorSection } from "metabase-types/api";
+import type {
+  InspectorCard,
+  InspectorSection,
+  InspectorSectionId,
+} from "metabase-types/api";
 
 import { JoinAnalysisSection } from "./JoinAnalysisSection";
 
 type JoinAnalysisSectionsProps = {
   sections: InspectorSection[];
-  cardsBySection: Record<string, InspectorCard[]>;
+  cardsBySection: Record<InspectorSectionId, InspectorCard[]>;
 };
 
 export const JoinAnalysisSections = ({

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/hooks/useCardLoadingTracker.ts
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/hooks/useCardLoadingTracker.ts
@@ -1,14 +1,20 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 
-import type { InspectorLens } from "metabase-types/api";
+import type {
+  InspectorCardId,
+  InspectorLens,
+  InspectorLensId,
+} from "metabase-types/api";
 
 type CardState = "loading" | "loaded";
 
 export const useCardLoadingTracker = (
   lens: InspectorLens | undefined,
-  onAllCardsLoaded: (lensId: string) => void,
+  onAllCardsLoaded: (lensId: InspectorLensId) => void,
 ) => {
-  const [cardsStates, setCardsStates] = useState<Record<string, CardState>>({});
+  const [cardsStates, setCardsStates] = useState<
+    Record<InspectorCardId, CardState>
+  >({});
 
   useEffect(() => {
     if (!lens) {
@@ -22,7 +28,7 @@ export const useCardLoadingTracker = (
   }, [lens, cardsStates, onAllCardsLoaded]);
 
   const markCard = useCallback(
-    (state: CardState) => (cardId: string) => {
+    (state: CardState) => (cardId: InspectorCardId) => {
       setCardsStates((prev) =>
         prev[cardId] === state ? prev : { ...prev, [cardId]: state },
       );

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/hooks/useTriggerEvaluation.ts
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/hooks/useTriggerEvaluation.ts
@@ -6,15 +6,15 @@ import {
   type TriggeredDrillLens,
   evaluateTriggers,
 } from "metabase-lib/transforms-inspector";
-import type { InspectorLens } from "metabase-types/api";
+import type { InspectorCardId, InspectorLens } from "metabase-types/api";
 
 import type { CardStats } from "../types";
 
 type TriggerEvaluationResult = {
-  alertsByCardId: Record<string, TriggeredAlert[]>;
-  drillLensesByCardId: Record<string, TriggeredDrillLens[]>;
-  collectedCardStats: Record<string, CardStats>;
-  pushNewStats: (cardId: string, stats: CardStats | null) => void;
+  alertsByCardId: Record<InspectorCardId, TriggeredAlert[]>;
+  drillLensesByCardId: Record<InspectorCardId, TriggeredDrillLens[]>;
+  collectedCardStats: Record<InspectorCardId, CardStats>;
+  pushNewStats: (cardId: InspectorCardId, stats: CardStats | null) => void;
 };
 
 type TriggerEvaluationState = {
@@ -25,14 +25,16 @@ type TriggerEvaluationState = {
 export const useTriggerEvaluation = (
   lens: InspectorLens | undefined,
 ): TriggerEvaluationResult => {
-  const [cardsStats, setCardsStats] = useState<Record<string, CardStats>>({});
+  const [cardsStats, setCardsStats] = useState<
+    Record<InspectorCardId, CardStats>
+  >({});
   const [state, setState] = useState<TriggerEvaluationState>({
     alerts: [],
     drillLenses: [],
   });
 
   const pushNewStats = useCallback(
-    (cardId: string, stats: CardStats | null) => {
+    (cardId: InspectorCardId, stats: CardStats | null) => {
       if (stats) {
         setCardsStats((prev) => ({ ...prev, [cardId]: stats }));
       }

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/types.ts
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/types.ts
@@ -7,4 +7,4 @@ export type LensHandle = {
   params?: LensParams;
 };
 
-export type RouteParams = { transformId: string; lensId?: string };
+export type RouteParams = { transformId: string; lensId?: InspectorLensId };

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/types.ts
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/types.ts
@@ -1,9 +1,9 @@
-import type { LensParams } from "metabase-types/api";
+import type { InspectorLensId, LensParams } from "metabase-types/api";
 
 export type { CardStats } from "metabase-lib/transforms-inspector";
 
 export type LensHandle = {
-  id: string;
+  id: InspectorLensId;
   params?: LensParams;
 };
 


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-1827/improve-types-with-entity-ids

### Description

Create new entity type aliases (`InspectorCardId`, `InspectorLensId`, `InspectorSectionId`) and re-use other existing types (`TableId`, `SectionId`, etc).
