### PR TITLE
Fix e2e retry mechanism for failed specs WIP

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -97,13 +97,20 @@ jobs:
         uses: actions/download-artifact@v4
         if: github.run_attempt != '1'
         continue-on-error: true
-        id: failed-specs
+        id: download-failed-specs
         with:
           name: failed-tests-${{ inputs.name }}-${{ inputs.edition }}
 
       - name: Get failed specs
-        if: github.run_attempt != '1'
-        run: echo "specs=$(cat failed-specs)" >> $GITHUB_ENV
+        if: github.run_attempt != '1' && steps.download-failed-specs.outcome == 'success'
+        run: |
+          if [ -f "./failed-specs" ]; then
+            SPECS=$(cat ./failed-specs)
+            echo "specs=${SPECS}" >> $GITHUB_ENV
+            echo "Retrying only failed specs: ${SPECS}"
+          else
+            echo "No failed-specs file found, will run all tests"
+          fi
 
       - name: Compile CLJS
         run: bun run build-pure:cljs

--- a/e2e/support/collectFailedTests.js
+++ b/e2e/support/collectFailedTests.js
@@ -18,12 +18,12 @@ const collectFailingTests = (on, config) => {
       .map((run) => run.spec.relative);
 
     if (failedSpecs.length > 0) {
-      const failedTestFilePath = "./cypress/test-results/";
-      fs.mkdirSync(failedTestFilePath, { recursive: true });
-      fs.writeFileSync(
-        path.join(failedTestFilePath, "failed-specs"),
-        failedSpecs.join(","),
-      );
+      const repoRoot = path.resolve(__dirname, "../..");
+      const failedTestDir = path.join(repoRoot, "cypress", "test-results");
+      const failedSpecsPath = path.join(failedTestDir, "failed-specs");
+
+      fs.mkdirSync(failedTestDir, { recursive: true });
+      fs.writeFileSync(failedSpecsPath, failedSpecs.join(","));
       console.log(
         `Saved ${failedSpecs.length} failed specs for retry: ${failedSpecs.join(", ")}`,
       );

--- a/e2e/support/collectFailedTests.js
+++ b/e2e/support/collectFailedTests.js
@@ -18,11 +18,14 @@ const collectFailingTests = (on, config) => {
       .map((run) => run.spec.relative);
 
     if (failedSpecs.length > 0) {
-      const failedTestFilePath = "../../cypress/test-results/";
+      const failedTestFilePath = "./cypress/test-results/";
       fs.mkdirSync(failedTestFilePath, { recursive: true });
       fs.writeFileSync(
         path.join(failedTestFilePath, "failed-specs"),
         failedSpecs.join(","),
+      );
+      console.log(
+        `Saved ${failedSpecs.length} failed specs for retry: ${failedSpecs.join(", ")}`,
       );
     }
   });


### PR DESCRIPTION
Resolves DEV-1578

The retry mechanism that runs only failed specs on re-run was broken:

1. collectFailedTests.js wrote to wrong path (../../cypress/test-results/ instead of ./cypress/test-results/) - the file was created outside the repo root

2. The workflow's "Get failed specs" step ran even when artifact download failed, causing errors

Now when you click "Re-run failed jobs", only the failed specs will execute instead of the entire chunk.
