### PR TITLE
Use core.setFailed instead of throw for missing artifacts

### DIFF
--- a/.github/actions/fetch-artifact/action.yml
+++ b/.github/actions/fetch-artifact/action.yml
@@ -45,7 +45,8 @@ runs:
           });
 
           if (!artifacts.data?.artifacts?.[0]?.id) {
-            throw new Error(`No artifacts found for ${artifactName}`);
+            core.setFailed(`No artifacts found for ${artifactName}`);
+            return;
           }
 
           const artifact_id = artifacts.data.artifacts[0].id;


### PR DESCRIPTION
When an artifact doesn't exist (expected for new commits), the fetch-artifact action was using throw new Error() which causes GitHub Actions to report "Unhandled error" - confusing and noisy.

Example:

<img width="854" height="133" alt="image" src="https://github.com/user-attachments/assets/49d49a9b-fec2-48da-ba33-b2aba691e64e" />

Using `core.setFailed()` cleanly marks the step as failed without the scary error message.

Fixes: DEV-1581
