### PR TITLE
add alerts and drill buttons test for default lens sections

### DIFF
--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/DefaultLensSections/DefaultLensSections.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/DefaultLensSections/DefaultLensSections.unit.spec.tsx
@@ -1,0 +1,145 @@
+import { setupRunInspectorQueryEndpoint } from "__support__/server-mocks/transform";
+import { renderWithProviders, screen } from "__support__/ui";
+import type {
+  TriggeredAlert,
+  TriggeredDrillLens,
+} from "metabase-lib/transforms-inspector";
+import type { InspectorCard, InspectorSection } from "metabase-types/api";
+import {
+  createMockColumn,
+  createMockDataset,
+  createMockInspectorCard,
+  createMockTransform,
+  createMockTransformInspectSource,
+} from "metabase-types/api/mocks";
+
+import { LensContentProvider } from "../../LensContent/LensContentContext";
+
+import { DefaultLensSections } from "./DefaultLensSections";
+
+jest.mock("metabase-lib/transforms-inspector", () => ({
+  ...jest.requireActual("metabase-lib/transforms-inspector"),
+  computeCardStats: () => null,
+}));
+
+const scalarCard1 = createMockInspectorCard({
+  id: "card-1",
+  title: "Row Count",
+  display: "scalar",
+});
+
+const scalarCard2 = createMockInspectorCard({
+  id: "card-2",
+  title: "Column Count",
+  display: "scalar",
+});
+
+const mockAlerts: TriggeredAlert[] = [
+  {
+    id: "alert-1",
+    severity: "warning",
+    message: "Row count dropped significantly",
+    condition: { name: "row_count_drop", card_id: "card-1" },
+  },
+  {
+    id: "alert-2",
+    severity: "error",
+    message: "Missing values detected",
+    condition: { name: "missing_values", card_id: "card-2" },
+  },
+];
+
+const mockDrillLenses: TriggeredDrillLens[] = [
+  {
+    lens_id: "drill-lens-1",
+    reason: "missing values",
+    condition: { name: "missing_values_drill", card_id: "card-1" },
+  },
+  {
+    lens_id: "drill-lens-2",
+    reason: "distribution anomaly",
+    condition: { name: "distribution_drill", card_id: "card-2" },
+  },
+];
+
+const defaultSections: InspectorSection[] = [
+  { id: "section-1", title: "Overview" },
+];
+
+function setup({
+  sections = defaultSections,
+  cardsBySection = { "section-1": [scalarCard1, scalarCard2] },
+  alertsByCardId = {} satisfies Record<string, TriggeredAlert[]>,
+  drillLensesByCardId = {} satisfies Record<string, TriggeredDrillLens[]>,
+}: {
+  sections?: InspectorSection[];
+  cardsBySection?: Record<string, InspectorCard[]>;
+  alertsByCardId?: Record<string, TriggeredAlert[]>;
+  drillLensesByCardId?: Record<string, TriggeredDrillLens[]>;
+} = {}) {
+  const lensId = "lens-1";
+  setupRunInspectorQueryEndpoint(
+    1,
+    lensId,
+    createMockDataset({
+      data: {
+        rows: [[42]],
+        cols: [createMockColumn({ name: "count" })],
+      },
+    }),
+  );
+
+  renderWithProviders(
+    <LensContentProvider
+      transform={createMockTransform()}
+      lens={{
+        id: lensId,
+        display_name: "Test Lens",
+        sections: [],
+        cards: [],
+      }}
+      lensHandle={{ id: lensId }}
+      alertsByCardId={alertsByCardId}
+      drillLensesByCardId={drillLensesByCardId}
+      collectedCardStats={{}}
+      navigateToLens={jest.fn()}
+      onStatsReady={jest.fn()}
+      onCardStartedLoading={jest.fn()}
+      onCardLoaded={jest.fn()}
+    >
+      <DefaultLensSections
+        sections={sections}
+        cardsBySection={cardsBySection}
+        sources={[createMockTransformInspectSource()]}
+      />
+    </LensContentProvider>,
+  );
+}
+
+describe("DefaultLensSections", () => {
+  it("renders alerts for cards that have triggered alerts", () => {
+    setup({
+      alertsByCardId: {
+        "card-1": [mockAlerts[0]],
+        "card-2": [mockAlerts[1]],
+      },
+    });
+
+    expect(
+      screen.getByText("Row count dropped significantly"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Missing values detected")).toBeInTheDocument();
+  });
+
+  it("renders drill buttons for cards that have triggered drill lenses", () => {
+    setup({
+      drillLensesByCardId: {
+        "card-1": [mockDrillLenses[0]],
+        "card-2": [mockDrillLenses[1]],
+      },
+    });
+
+    expect(screen.getByText(/missing values/)).toBeInTheDocument();
+    expect(screen.getByText(/distribution anomaly/)).toBeInTheDocument();
+  });
+});

--- a/frontend/test/__support__/server-mocks/transform.ts
+++ b/frontend/test/__support__/server-mocks/transform.ts
@@ -1,8 +1,11 @@
 import fetchMock from "fetch-mock";
 
 import type {
+  Dataset,
+  InspectorLensId,
   ListTransformRunsResponse,
   Transform,
+  TransformId,
   TransformJob,
   TransformJobId,
   TransformTag,
@@ -71,4 +74,15 @@ export function setupDeleteTransformJobEndpointWithError(
   jobId: TransformJobId,
 ) {
   fetchMock.delete(`path:/api/transform-job/${jobId}`, 500);
+}
+
+export function setupRunInspectorQueryEndpoint(
+  transformId: TransformId,
+  lensId: InspectorLensId,
+  response: Dataset,
+) {
+  fetchMock.post(
+    `path:/api/transform/${transformId}/inspect/${lensId}/query`,
+    response,
+  );
 }


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-1787/ensure-alertsdrill-lenses-triggers-are-rendered-in-the-generic-flat

### Description

- Unit test added that asserts that drill buttons and alerts are rendered for default lenses

- [x ] Tests have been added/updated to cover changes in this PR
- [x] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
