### PR TITLE
Capitalize Jar -> JAR

### DIFF
--- a/docs/installation-and-operation/installing-metabase.md
+++ b/docs/installation-and-operation/installing-metabase.md
@@ -20,9 +20,9 @@ For an overview on how to self-host Metabase, check out [how to run Metabase in 
 
 Run Metabase in a [Docker container](./running-metabase-on-docker.md).
 
-### Running the Jar file
+### Running the JAR file
 
-If you're self-hosting but don’t use Docker, the JAR is the easiest way to get started, but it might make it more challenging to move to production. See [running the Metabase Jar](./running-the-metabase-jar-file.md).
+If you're self-hosting but don’t use Docker, the JAR is the easiest way to get started, but it might make it more challenging to move to production. See [running the Metabase JAR](./running-the-metabase-jar-file.md).
 
 ## Air-gapped Metabase
 

--- a/docs/installation-and-operation/running-the-metabase-jar-file.md
+++ b/docs/installation-and-operation/running-the-metabase-jar-file.md
@@ -58,7 +58,7 @@ If you want to install the [Pro or Enterprise editions](https://www.metabase.com
 
 ### 3. Create a new directory and move the Metabase JAR into it
 
-When you run Metabase, Metabase will create some new files, so it's important to put the Metabase Jar file in a new directory before running it (so move it out of your downloads folder and put it a new directory).
+When you run Metabase, Metabase will create some new files, so it's important to put the Metabase JAR file in a new directory before running it (so move it out of your downloads folder and put it a new directory).
 
 On posix systems, the commands would look something like this:
 

--- a/docs/installation-and-operation/upgrading-metabase.md
+++ b/docs/installation-and-operation/upgrading-metabase.md
@@ -136,7 +136,7 @@ Metabase will do all this automatically.
 
 If you need to downgrade after a major version upgrade, you'll either need to restore from a backup, or manually migrate to a lower version, otherwise Metabase may refuse to start (see the next section).
 
-During a **minor version upgrade** (e.g., 54.1 to 54.2), the new Metabase container or Jar will just work. Only in rare cases will it have to perform a migration, but, like with major version upgrades, Metabase will perform the migration automatically. And of course, you're backing up your application database each time you upgrade, right?
+During a **minor version upgrade** (e.g., 54.1 to 54.2), the new Metabase container or JAR will just work. Only in rare cases will it have to perform a migration, but, like with major version upgrades, Metabase will perform the migration automatically. And of course, you're backing up your application database each time you upgrade, right?
 
 ## Rolling back an upgrade or to an older version
 


### PR DESCRIPTION
JAR is the correct capitalization: https://docs.oracle.com/javase/8/docs/technotes/guides/jar/jarGuide.html, not Jar 🫙 