### PR TITLE
Do not cache UV

### DIFF
--- a/.github/actions/prepare-backend/action.yml
+++ b/.github/actions/prepare-backend/action.yml
@@ -1,14 +1,13 @@
 name: Prepare back-end environment
 description: |
   Prepare the backend. Installs jdk, Clojure, and fetches the cache for m2.
-  The CI config fetches `ci-test-config.json` from master and lets us ignore tests at the var level if they are flaking.
 inputs:
   java-version:
     required: true
-    default: '21'
+    default: "21"
   clojure-version:
     required: true
-    default: '1.12.0.1488'
+    default: "1.12.0.1488"
 
 runs:
   using: "composite"
@@ -17,7 +16,7 @@ runs:
       uses: actions/setup-java@v4
       with:
         java-version: ${{ inputs.java-version }}
-        distribution: 'temurin'
+        distribution: "temurin"
     - name: Install Clojure CLI
       shell: bash
       continue-on-error: true
@@ -31,6 +30,9 @@ runs:
 
     - name: Install uv (for Python package installation)
       uses: astral-sh/setup-uv@v7
+      with:
+        enable-cache: false
+        version: "0.10.2" # keep in sync with mise.toml
 
     - name: Restore M2 cache
       uses: actions/cache/restore@v4

--- a/.github/actions/prepare-backend/action.yml
+++ b/.github/actions/prepare-backend/action.yml
@@ -33,6 +33,7 @@ runs:
       with:
         enable-cache: false
         version: "0.10.2" # keep in sync with mise.toml
+        github-token: ${{ github.token }}
 
     - name: Restore M2 cache
       uses: actions/cache/restore@v4


### PR DESCRIPTION
Resolves DEV-1582
> Commit 07fbc6997e41ed96b7609a9318f1141c23cb2119 significantly increased the prepare-backend setup time from 6 seconds to 1 minute 15 seconds.

1. We're back to sub 10 seconds `prepare-backend` time
2. Our caches are not riddled with countless uv entries
3. `uv` version is in sync with `mise.toml`

Screenshot from the current run showing the prepare-backend time
<img width="818" height="50" alt="image" src="https://github.com/user-attachments/assets/27ff7c20-aafc-4d1b-bc22-22e941fa5c92" />
