### PR TITLE
Mention that the appdb schema must always be public

### DIFF
--- a/docs/installation-and-operation/installing-metabase.md
+++ b/docs/installation-and-operation/installing-metabase.md
@@ -53,7 +53,7 @@ See [Upgrading Metabase](upgrading-metabase.md).
 
 We currently do not distribute Metabase on AWS Marketplace or Azure Marketplace.
 
-Metabase doesn't have an officially supported helm chart.
+Metabase doesn't have an officially supported Helm chart.
 
 ## Connect with a Metabase Expert
 

--- a/src/metabase/cmd/resources/other-env-vars.md
+++ b/src/metabase/cmd/resources/other-env-vars.md
@@ -65,6 +65,8 @@ Default: `null`
 
 A JDBC-style connection URI that can be used instead of most of `MB_DB_*` like [MB_DB_HOST](#mb_db_host). Also used when certain Connection String parameters are required for the connection. The connection type requirement is the same as [MB_DB_TYPE](#mb_db_type).
 
+Note that the `currentSchema` JDBC parameter has no effect. [The schema used for PostgreSQL application databases must be `public`](https://github.com/metabase/metabase/issues/37836).
+
 Examples:
 
 ```


### PR DESCRIPTION
A known limitation of Metabase is that the Postgres schema for the application database must always be `public`, but this is not documented anywhere. See https://github.com/metabase/metabase/issues/37836