### PR TITLE
feat(embed-js): Add docs hint for additional wizard properties

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/guest-embed-ee.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/guest-embed-ee.cy.spec.ts
@@ -183,6 +183,12 @@ describe("scenarios > embedding > sdk iframe embed setup > guest-embed", () => {
         .should("be.visible")
         .should("be.disabled");
 
+      getEmbedSidebar().findByTestId("behavior-docs-link").should("be.visible");
+      getEmbedSidebar()
+        .findByTestId("behavior-docs-link")
+        .should("have.attr", "href")
+        .and("include", "embedding/guest-embedding");
+
       H.setEmbeddingParameter("Text", "Locked");
       cy.findAllByTestId("parameter-widget").find("input").type("Foo Bar Baz");
 

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
@@ -681,24 +681,27 @@ describe(suiteTitle, () => {
     codeBlock().should("contain", 'with-alerts="true"');
   });
 
-  it("shows a docs icon in behavior section for chart", () => {
+  it("shows a docs icon in behavior section depending on a component", () => {
     navigateToEmbedOptionsStep({
       experience: "chart",
       resourceName: QUESTION_NAME,
       preselectSso: true,
     });
 
-    getEmbedSidebar().findByTestId("behavior-docs-link").should("be.visible");
-    getEmbedSidebar()
-      .findByTestId("behavior-docs-link")
-      .should("have.attr", "href")
-      .and("include", "embedding/components.html#question");
-  });
+    getEmbedSidebar().within(() => {
+      cy.findByTestId("behavior-docs-link").should("be.visible");
+      cy.findByTestId("behavior-docs-link")
+        .should("have.attr", "href")
+        .and("include", "embedding/components.html#question");
 
-  it("does not show a docs icon in behavior section for metabot", () => {
-    navigateToEmbedOptionsStep({ experience: "metabot" });
+      cy.findByText("Back").click();
+      cy.findByText("Back").click();
 
-    getEmbedSidebar().findByTestId("behavior-docs-link").should("not.exist");
+      cy.findByText("Metabot").click();
+      cy.findByText("Next").click();
+
+      cy.findByTestId("behavior-docs-link").should("not.exist");
+    });
   });
 
   ["exploration", "chart"].forEach((experience) => {

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-options.cy.spec.ts
@@ -681,6 +681,26 @@ describe(suiteTitle, () => {
     codeBlock().should("contain", 'with-alerts="true"');
   });
 
+  it("shows a docs icon in behavior section for chart", () => {
+    navigateToEmbedOptionsStep({
+      experience: "chart",
+      resourceName: QUESTION_NAME,
+      preselectSso: true,
+    });
+
+    getEmbedSidebar().findByTestId("behavior-docs-link").should("be.visible");
+    getEmbedSidebar()
+      .findByTestId("behavior-docs-link")
+      .should("have.attr", "href")
+      .and("include", "embedding/components.html#question");
+  });
+
+  it("does not show a docs icon in behavior section for metabot", () => {
+    navigateToEmbedOptionsStep({ experience: "metabot" });
+
+    getEmbedSidebar().findByTestId("behavior-docs-link").should("not.exist");
+  });
+
   ["exploration", "chart"].forEach((experience) => {
     it(`toggles save button for ${experience}`, () => {
       navigateToEmbedOptionsStep(

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SelectEmbedOptionsStep.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SelectEmbedOptionsStep.tsx
@@ -48,7 +48,7 @@ const BehaviorSection = () => {
   const hasEmailSetup = useHasEmailSetup();
 
   const behaviorDocsParams = getBehaviorDocsUrlParams(settings);
-  // eslint-disable-next-line metabase/no-unconditional-metabase-links-render -- EmbedJS Wizard
+  // eslint-disable-next-line metabase/no-unconditional-metabase-links-render -- Only admins can see the EmbedJS Wizard
   const { url: behaviorDocsUrl } = useDocsUrl(behaviorDocsParams?.page ?? "", {
     anchor: behaviorDocsParams?.anchor,
   });

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SelectEmbedOptionsStep.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SelectEmbedOptionsStep.tsx
@@ -3,12 +3,13 @@ import { Link } from "react-router";
 import { P, match } from "ts-pattern";
 import { c, t } from "ttag";
 
-import { useHasEmailSetup } from "metabase/common/hooks";
+import { useDocsUrl, useHasEmailSetup } from "metabase/common/hooks";
 import type {
   MetabaseColors,
   MetabaseThemePreset,
 } from "metabase/embedding-sdk/theme";
 import {
+  Anchor,
   Card,
   Checkbox,
   Divider,
@@ -21,6 +22,7 @@ import {
 
 import { UPSELL_CAMPAIGN_BEHAVIOR } from "../analytics";
 import { useSdkIframeEmbedSetupContext } from "../context";
+import { getBehaviorDocsUrlParams } from "../utils/get-behavior-docs-url-params";
 
 import { ColorCustomizationSection } from "./Appearance/ColorCustomizationSection";
 import { SimpleThemeSwitcherSection } from "./Appearance/SimpleThemeSwitcherSection";
@@ -44,6 +46,12 @@ const BehaviorSection = () => {
   const { isSimpleEmbedFeatureAvailable, settings, updateSettings } =
     useSdkIframeEmbedSetupContext();
   const hasEmailSetup = useHasEmailSetup();
+
+  const behaviorDocsParams = getBehaviorDocsUrlParams(settings);
+  // eslint-disable-next-line metabase/no-unconditional-metabase-links-render -- EmbedJS Wizard
+  const { url: behaviorDocsUrl } = useDocsUrl(behaviorDocsParams?.page ?? "", {
+    anchor: behaviorDocsParams?.anchor,
+  });
 
   const behaviorSection = useMemo(() => {
     return match(settings)
@@ -253,9 +261,26 @@ const BehaviorSection = () => {
 
   return (
     <Card p="md">
-      <Text size="lg" fw="bold" mb="md">
-        {t`Behavior`}
-      </Text>
+      <Flex align="center" justify="space-between" gap="xs" mb="md">
+        <Text size="lg" fw="bold">
+          {t`Behavior`}
+        </Text>
+        {!!behaviorDocsParams?.page && (
+          <Anchor
+            href={behaviorDocsUrl}
+            target="_blank"
+            rel="noreferrer"
+            c="brand"
+            lh={1}
+          >
+            <Icon
+              name="book_open"
+              size={16}
+              tooltip={t`See all properties in the docs`}
+            />
+          </Anchor>
+        )}
+      </Flex>
 
       {behaviorSection}
     </Card>

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SelectEmbedOptionsStep.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SelectEmbedOptionsStep.tsx
@@ -267,6 +267,7 @@ const BehaviorSection = () => {
         </Text>
         {!!behaviorDocsParams?.page && (
           <Anchor
+            data-testid="behavior-docs-link"
             href={behaviorDocsUrl}
             target="_blank"
             rel="noreferrer"

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-behavior-docs-url-params.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-behavior-docs-url-params.ts
@@ -1,0 +1,25 @@
+import { match } from "ts-pattern";
+
+import type { SdkIframeEmbedSetupSettings } from "../types";
+
+export type BehaviorDocsParams = { page: string; anchor?: string } | null;
+
+export const getBehaviorDocsUrlParams = (
+  settings: SdkIframeEmbedSetupSettings,
+): BehaviorDocsParams => {
+  if (settings.isGuest) {
+    return { page: "embedding/guest-embedding" };
+  }
+
+  const anchor = match(settings.componentName)
+    .with("metabase-question", () => "question")
+    .with("metabase-dashboard", () => "dashboard")
+    .with("metabase-browser", () => "browser")
+    .otherwise(() => null);
+
+  if (!anchor) {
+    return null;
+  }
+
+  return { page: "embedding/components", anchor };
+};

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-behavior-docs-url-params.unit.spec.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-behavior-docs-url-params.unit.spec.ts
@@ -1,0 +1,53 @@
+import type { SdkIframeEmbedSetupSettings } from "../types";
+
+import {
+  type BehaviorDocsParams,
+  getBehaviorDocsUrlParams,
+} from "./get-behavior-docs-url-params";
+
+describe("getBehaviorDocsUrlParams", () => {
+  it.each<{
+    name: string;
+    settings: Partial<SdkIframeEmbedSetupSettings>;
+    expected: BehaviorDocsParams;
+  }>([
+    {
+      name: "guest settings",
+      settings: { isGuest: true, componentName: "metabase-question" },
+      expected: { page: "embedding/guest-embedding" },
+    },
+    {
+      name: "exploration template",
+      settings: {
+        isGuest: false,
+        componentName: "metabase-question",
+        template: "exploration",
+      },
+      expected: { page: "embedding/components", anchor: "question" },
+    },
+    {
+      name: "metabase-question component",
+      settings: { componentName: "metabase-question", questionId: 1 },
+      expected: { page: "embedding/components", anchor: "question" },
+    },
+    {
+      name: "metabase-dashboard component",
+      settings: { componentName: "metabase-dashboard", dashboardId: 1 },
+      expected: { page: "embedding/components", anchor: "dashboard" },
+    },
+    {
+      name: "metabase-browser component",
+      settings: { componentName: "metabase-browser" },
+      expected: { page: "embedding/components", anchor: "browser" },
+    },
+    {
+      name: "metabase-metabot component",
+      settings: { componentName: "metabase-metabot" },
+      expected: null,
+    },
+  ])("returns $expected for $name", ({ settings, expected }) => {
+    expect(
+      getBehaviorDocsUrlParams(settings as SdkIframeEmbedSetupSettings),
+    ).toEqual(expected);
+  });
+});


### PR DESCRIPTION
Add docs hint for additional wizard properties

Context:
- https://linear.app/metabase/issue/EMB-1325/add-docs-hint-for-additional-wizard-properties
- https://metaboat.slack.com/archives/C063Q3F1HPF/p1770660861724459?thread_ts=1770660861.724459&cid=C063Q3F1HPF

This PR adds a link icon to the behavior section of EmbedJS `options` page.
The URL different depending on SSO/Guest and for SSO - depending on a component.

SSO:
- chart/exploration
	- https://www.metabase.com/docs/latest/embedding/components#question 
- dashboard
	- https://www.metabase.com/docs/latest/embedding/components#dashboard 
- browser
	- https://www.metabase.com/docs/latest/embedding/components#browser 
- metabot
	- N/A as we don't have the behavior section there
	
Guest: 
- https://www.metabase.com/docs/latest/embedding/guest-embedding

How to test?
- via Admin/Embedding/New Embed EmbedJS Wizard check it for SSO/Guest embedding and different components

<img width="984" height="640" alt="image" src="https://github.com/user-attachments/assets/f11f72fb-fc38-4f74-9d4d-d0b1e9329fc1" />
