### PR TITLE
Embed wizard should default to newly created dashboards

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
@@ -1,6 +1,5 @@
 import { SAMPLE_DB_TABLES } from "e2e/support/cypress_data";
 import { ALL_EXTERNAL_USERS_GROUP_ID } from "e2e/support/cypress_sample_instance_data";
-import { enableJwtAuth } from "e2e/support/helpers/e2e-jwt-helpers";
 
 const { H } = cy;
 
@@ -208,29 +207,6 @@ describe("scenarios - embedding hub", () => {
         .closest("button")
         .findByText("Done", { timeout: 10_000 })
         .should("be.visible");
-    });
-
-    it("Embed in production step should be locked until JWT is enabled", () => {
-      cy.visit("/admin/embedding/setup-guide");
-
-      cy.findByTestId("admin-layout-content")
-        .findByText("Embed in production with SSO")
-        .scrollIntoView()
-        .should("be.visible")
-        .closest("button")
-        .icon("lock")
-        .should("be.visible");
-
-      enableJwtAuth();
-      cy.reload();
-
-      cy.findByTestId("admin-layout-content")
-        .findByText("Embed in production with SSO")
-        .scrollIntoView()
-        .should("be.visible")
-        .closest("button")
-        .icon("lock")
-        .should("not.exist");
     });
 
     it("embedding checklist should show up on the embedding homepage", () => {
@@ -584,6 +560,14 @@ describe("scenarios - embedding hub", () => {
       it("can create two tenants and show summary", () => {
         cy.visit("/admin/embedding/setup-guide/permissions");
 
+        cy.log("step 1 should be marked as done before navigating");
+        H.main()
+          .findByRole("listitem", {
+            name: "Enable multi-tenant user strategy",
+            timeout: 10_000,
+          })
+          .should("have.attr", "data-completed", "true");
+
         H.main().within(() => {
           cy.log("navigate to create tenants step");
 
@@ -593,7 +577,7 @@ describe("scenarios - embedding hub", () => {
 
           cy.log("fill out the tenant form");
           cy.findByPlaceholderText("Tenant name").clear().type("Acme Corp");
-          cy.findByPlaceholderText("tenant_id").type("acme-123");
+          cy.findByPlaceholderText("1").type("acme-123");
           cy.findByPlaceholderText("tenant-slug")
             .clear()
             .type("acme-corp-slug");
@@ -610,7 +594,7 @@ describe("scenarios - embedding hub", () => {
             .clear()
             .type("Beta Inc");
 
-          cy.findAllByPlaceholderText("tenant_id")
+          cy.findAllByPlaceholderText("1")
             .should("have.length", 2)
             .last()
             .type("beta-456");
@@ -693,7 +677,7 @@ describe("scenarios - embedding hub", () => {
             .clear()
             .type("Another Tenant");
 
-          cy.findByPlaceholderText("tenant_id").type("another-id");
+          cy.findByPlaceholderText("1").type("another-id");
 
           cy.findByPlaceholderText("tenant-slug")
             .clear()
@@ -1274,6 +1258,14 @@ describe("scenarios - embedding hub", () => {
       });
 
       cy.visit("/admin/embedding/setup-guide/sso");
+
+      cy.log("step 1 should be marked as done");
+      H.main()
+        .findByRole("listitem", {
+          name: "Set up JWT authentication",
+          timeout: 10_000,
+        })
+        .should("have.attr", "data-completed", "true");
 
       cy.log("navigate to step 3");
       H.main()

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-entity.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-entity.cy.spec.ts
@@ -1,3 +1,4 @@
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   ORDERS_BY_YEAR_QUESTION_ID,
   ORDERS_COUNT_QUESTION_ID,
@@ -80,17 +81,22 @@ describe(suiteTitle, () => {
       cy.findByText("Next").click();
       cy.findByText("Select a dashboard to embed").should("be.visible");
 
-      cy.log("first dashboard should be selected by default");
+      // see the "shows recently created dashboard at the top of the list (EMB-1179)"
+      // test below for why we prioritize new dashboards
+      cy.log(
+        "recently created dashboard should be selected by default (EMB-1179)",
+      );
       getRecentItemCards()
         .should("have.length", 2)
         .first()
+        .should("contain", SECOND_DASHBOARD_NAME)
         .should("have.attr", "data-selected", "true");
 
       cy.findByText(FIRST_DASHBOARD_NAME).should("be.visible");
       cy.findByText(SECOND_DASHBOARD_NAME).should("be.visible");
 
-      cy.log("second dashboard can be selected");
-      cy.findByText(SECOND_DASHBOARD_NAME).click();
+      cy.log("a different dashboard can be selected");
+      cy.findByText(FIRST_DASHBOARD_NAME).click();
 
       getRecentItemCards().eq(1).should("have.attr", "data-selected", "true");
     });
@@ -98,7 +104,7 @@ describe(suiteTitle, () => {
     cy.log("selected dashboard should be shown in the preview");
     cy.wait("@dashboard");
     H.getSimpleEmbedIframeContent().within(() => {
-      cy.findByText(SECOND_DASHBOARD_NAME).should("be.visible");
+      cy.findByText(FIRST_DASHBOARD_NAME).should("be.visible");
     });
 
     cy.log(
@@ -275,6 +281,14 @@ describe(suiteTitle, () => {
         recents: [],
       }).as("emptyRecentItems");
 
+      // The embed wizard calls the search API to find recently created
+      // dashboards. Without this, the snapshot's admin-owned dashboards
+      // would be returned and selected as the default.
+      cy.log("simulate that there are no recently created dashboards");
+      cy.intercept("GET", "/api/search?*", { data: [], total: 0 }).as(
+        "emptySearch",
+      );
+
       visitNewEmbedPage();
       cy.wait("@emptyRecentItems");
     });
@@ -349,3 +363,58 @@ const logRecent = (model: "dashboard" | "card", modelId: number | string) =>
     model: model,
     model_id: modelId,
   });
+
+describe("recently created dashboards", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+    H.activateToken("bleeding-edge");
+    H.updateSetting("enable-embedding-simple", true);
+
+    cy.intercept("GET", "/api/dashboard/**").as("dashboard");
+    cy.intercept("GET", "/api/activity/recents?*").as("recentActivity");
+    cy.intercept("GET", "/api/search?*").as("searchQuery");
+
+    mockEmbedJsToDevServer();
+  });
+
+  // When using x-rays to create your first dashboard in the onboarding
+  // flow, user expects that to be the default for the wizard,
+  // even if they have never visited that dashboard before.
+  it("shows recently created dashboard at the top of the list (EMB-1179)", () => {
+    const { ORDERS_ID } = SAMPLE_DATABASE;
+
+    cy.log("simulate existing recent activity");
+    logRecent("dashboard", ORDERS_DASHBOARD_ID);
+
+    cy.log("create a dashboard via x-ray");
+    cy.visit(`/auto/dashboard/table/${ORDERS_ID}`);
+    H.main()
+      .findByText("Total transactions", { timeout: 10_000 })
+      .should("be.visible");
+
+    cy.button("Save this").click();
+    H.undoToast().should("contain", "Your dashboard was saved");
+
+    visitNewEmbedPage();
+
+    getEmbedSidebar().within(() => {
+      cy.findByText("Next").click();
+      cy.findByText("Select a dashboard to embed").should("be.visible");
+
+      cy.log(
+        "recently created dashboard should show up even though it was never viewed",
+      );
+      const XRAY_DASHBOARD_NAME = "A look at Orders";
+      cy.findByText(XRAY_DASHBOARD_NAME, { timeout: 10_000 }).should(
+        "be.visible",
+      );
+
+      cy.log("the x-ray dashboard should be selected by default");
+      getRecentItemCards()
+        .first()
+        .should("contain", XRAY_DASHBOARD_NAME)
+        .should("have.attr", "data-selected", "true");
+    });
+  });
+});

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/select-embed-experience.cy.spec.ts
@@ -158,6 +158,14 @@ describe(suiteTitle, () => {
       cy.intercept("GET", "/api/activity/recents?*", { recents: [] }).as(
         "emptyRecentItems",
       );
+
+      // The embed wizard calls the search API to find recently created
+      // dashboards. Without this, the snapshot's admin-owned dashboards
+      // would be returned and selected as the default.
+      cy.log("simulate that there are no recently created dashboards");
+      cy.intercept("GET", "/api/search?*", { data: [], total: 0 }).as(
+        "emptySearch",
+      );
     });
 
     it("shows dashboard of id=1 when activity log is empty", () => {

--- a/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHub.unit.spec.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHub.unit.spec.tsx
@@ -128,20 +128,6 @@ describe("EmbeddingHub", () => {
     expect(mockPush).toHaveBeenCalledWith("/auto/dashboard/table/10");
   });
 
-  it("has correct href link for Configure SSO card", async () => {
-    setup();
-
-    const configureSsoLink = screen.getByRole("link", {
-      name: /configure sso/i,
-    });
-    expect(configureSsoLink).toBeInTheDocument();
-
-    expect(configureSsoLink).toHaveAttribute(
-      "href",
-      "https://www.metabase.com/docs/latest/embedding/embedded-analytics-js.html?utm_source=product&utm_medium=docs&utm_campaign=embedding_hub&utm_content=sso-configured&source_plan=oss#set-up-sso",
-    );
-  });
-
   it("shows success banner when first 3 steps are completed", async () => {
     setup({
       checklist: {

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-recent-items.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-recent-items.ts
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useState } from "react";
 import { match } from "ts-pattern";
+import _ from "underscore";
 
 import { useListRecentsQuery } from "metabase/api";
 import type { RecentItem } from "metabase-types/api";
@@ -7,11 +8,18 @@ import type { RecentItem } from "metabase-types/api";
 import { EMBED_RESOURCE_LIST_MAX_RECENTS } from "../constants";
 import type { SdkIframeEmbedSetupRecentItem } from "../types";
 
+import { useRecentlyCreatedDashboards } from "./use-recently-created-dashboards";
+
 export const useRecentItems = () => {
-  const { data: apiRecentItems, isLoading } = useListRecentsQuery(
+  const { data: recents, isLoading: isRecentsLoading } = useListRecentsQuery(
     { context: ["views", "selections"] },
     { refetchOnMountOrArgChange: true },
   );
+
+  const {
+    recentlyCreatedDashboards,
+    isLoading: isRecentlyCreatedDashboardsLoading,
+  } = useRecentlyCreatedDashboards();
 
   // Users can select dashboards from the dashboard picker.
   const [localRecentDashboards, setLocalRecentDashboards] = useState<
@@ -29,28 +37,31 @@ export const useRecentItems = () => {
   >([]);
 
   const recentDashboards = useMemo(() => {
+    // Recently created dashboards are prioritized first,
+    // then local selections, then recent views from the activity log.
+    const uniqueSuggestedDashboards = _.uniq(
+      [...recentlyCreatedDashboards, ...localRecentDashboards],
+      (recentItem) => recentItem.id,
+    );
+
     return getCombinedRecentItems(
       "dashboard",
-      localRecentDashboards,
-      apiRecentItems ?? [],
+      uniqueSuggestedDashboards,
+      recents ?? [],
     );
-  }, [apiRecentItems, localRecentDashboards]);
+  }, [recents, localRecentDashboards, recentlyCreatedDashboards]);
 
   const recentQuestions = useMemo(() => {
-    return getCombinedRecentItems(
-      "card",
-      localRecentQuestions,
-      apiRecentItems ?? [],
-    );
-  }, [apiRecentItems, localRecentQuestions]);
+    return getCombinedRecentItems("card", localRecentQuestions, recents ?? []);
+  }, [recents, localRecentQuestions]);
 
   const recentCollections = useMemo(() => {
     return getCombinedRecentItems(
       "collection",
       localRecentCollections,
-      apiRecentItems ?? [],
+      recents ?? [],
     );
-  }, [apiRecentItems, localRecentCollections]);
+  }, [recents, localRecentCollections]);
 
   const addRecentItem = useCallback(
     (
@@ -79,7 +90,7 @@ export const useRecentItems = () => {
     recentQuestions,
     recentCollections,
     addRecentItem,
-    isRecentsLoading: isLoading,
+    isRecentsLoading: isRecentsLoading || isRecentlyCreatedDashboardsLoading,
   };
 };
 

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-recently-created-dashboards.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-recently-created-dashboards.ts
@@ -1,0 +1,56 @@
+import { useMemo } from "react";
+import _ from "underscore";
+
+import { useSearchQuery } from "metabase/api";
+import { useSelector } from "metabase/lib/redux";
+import { getUserId } from "metabase/selectors/user";
+import type { SearchResult } from "metabase-types/api";
+
+import type { SdkIframeEmbedSetupRecentItem } from "../types";
+
+/**
+ * Hook to fetch dashboards created by the current user.
+ * Used for prioritize newly created dashboards in the embed wizard.
+ */
+export const useRecentlyCreatedDashboards = () => {
+  const currentUserId = useSelector(getUserId);
+
+  const { data: searchResults, isLoading } = useSearchQuery(
+    {
+      models: ["dashboard"],
+      created_by: currentUserId ? [currentUserId] : undefined,
+      limit: 5,
+
+      // If the dashboard is created more than 1 hour ago,
+      // it is likely stale and latest activity should take priority.
+      created_at: "past1hours~",
+    },
+    { refetchOnMountOrArgChange: true },
+  );
+
+  const recentlyCreatedDashboards: SdkIframeEmbedSetupRecentItem[] =
+    useMemo(() => {
+      if (!searchResults?.data) {
+        return [];
+      }
+
+      // The search API does not support sort_column, so we sort client-side.
+      return searchResults.data
+        .filter((result) => result.id !== undefined)
+        .sort(sortSearchResultByCreationTime)
+        .map((result) => _.pick(result, ["id", "name", "description"]));
+    }, [searchResults?.data]);
+
+  return {
+    recentlyCreatedDashboards,
+    isLoading,
+  };
+};
+
+const sortSearchResultByCreationTime = (a: SearchResult, b: SearchResult) => {
+  if (a.created_at === null || b.created_at === null) {
+    return 0;
+  }
+
+  return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
+};


### PR DESCRIPTION
Closes EMB-1179

### Description

When following the step from the wizard and using an x-ray to create a new dashboard, one would expect this to be the default for the wizard. Instead, the example dashboard is pre-selected and one needs to manually search the new dashboard.

Alessio's suggests that we should run a search query for **recently created x-ray dashboards** to show that one on top even if it wasn't viewed before. We define "recently created" as "[created within the last hour](https://github.com/metabase/metabase/pull/69907#discussion_r2828328697)".

### How to verify

- Go to Embedding Hub
- Click on "Create a dashboard"
- X-ray a random dashboard
- **DO NOT CLICK "See it" ON THE TOAST!** (That adds it to the activity log and already works without this PR)
- Go back to Embedding Hub
- Click on "Get embed snippet"
- Click "Next"
- **You should see your x-ray dashboard selected by default.**

### Demo

<img width="2458" height="1792" alt="CleanShot 2569-02-19 at 21 55 31@2x" src="https://github.com/user-attachments/assets/7581b446-5142-4c66-a721-350c698aa418" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR - E2E

