### PR TITLE
[v55] Fix the embedding e2e test flaky assertion

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-reproductions.cy.spec.js
@@ -1224,7 +1224,7 @@ describe("issue 8490", () => {
       cy.log("assert the line chart");
       H.getDashboardCard(0).within(() => {
         // X-axis labels: Created at
-        cy.findByText(/월/).should("be.visible");
+        cy.findAllByText(/월/).should("be.visible");
         // Aggregation "count"
         cy.findByText("카운트").should("be.visible");
       });
@@ -1285,8 +1285,8 @@ describe("issue 8490", () => {
         .should("be.visible")
         .then(resolveQuestionLoaderPromise);
 
-      // X-axis labels: Jan 2023 (or some other year)
-      cy.findByText(/11월 20\d\d\b/).should("be.visible");
+      // X-axis labels: Created at
+      cy.findAllByText(/월/).should("be.visible");
       // Aggregation "count"
       cy.findByText("카운트").should("be.visible");
     });


### PR DESCRIPTION
Follow up after we merged https://github.com/metabase/metabase/pull/69918.

I DO NOT want to run the full CI again for this fix only, which is why I stress-tested it here:
https://github.com/metabase/metabase/actions/runs/22226655876