### PR TITLE
fix(EmbedJS): Downloads fail on guest embedded questions

### DIFF
--- a/e2e/support/helpers/e2e-downloads-helpers.ts
+++ b/e2e/support/helpers/e2e-downloads-helpers.ts
@@ -24,6 +24,7 @@ interface DownloadAndAssertParams {
   pivoting?: "pivoted" | "non-pivoted";
   /** Assert that parameters in request body match expected values */
   assertParameters?: any[];
+  waitForDismiss?: boolean;
 }
 
 export interface DownloadRequestData {
@@ -70,6 +71,7 @@ export function downloadAndAssert({
   enableFormatting = true,
   pivoting,
   assertParameters,
+  waitForDismiss = true,
 }: DownloadAndAssertParams) {
   const { method, endpoint } = downloadUrl
     ? { method: downloadMethod, endpoint: downloadUrl }
@@ -167,8 +169,12 @@ export function downloadAndAssert({
     cy.findByTestId("download-results-button").click();
   });
 
-  cy.wait("@fileDownload").then(() => {
-    ensureDownloadStatusDismissed();
+  cy.wait("@fileDownload").then(({ response }) => {
+    expect(response?.statusCode).to.eq(200);
+
+    if (waitForDismiss) {
+      ensureDownloadStatusDismissed();
+    }
   });
 }
 

--- a/e2e/support/helpers/e2e-downloads-helpers.ts
+++ b/e2e/support/helpers/e2e-downloads-helpers.ts
@@ -22,6 +22,7 @@ interface DownloadAndAssertParams {
   dashboardId?: number;
   enableFormatting?: boolean;
   pivoting?: "pivoted" | "non-pivoted";
+  assertStatusCode?: number;
   /** Assert that parameters in request body match expected values */
   assertParameters?: any[];
   waitForDismiss?: boolean;
@@ -70,6 +71,7 @@ export function downloadAndAssert({
   isEmbed = false,
   enableFormatting = true,
   pivoting,
+  assertStatusCode,
   assertParameters,
   waitForDismiss = true,
 }: DownloadAndAssertParams) {
@@ -170,7 +172,9 @@ export function downloadAndAssert({
   });
 
   cy.wait("@fileDownload").then(({ response }) => {
-    expect(response?.statusCode).to.eq(200);
+    if (assertStatusCode) {
+      expect(response?.statusCode).to.eq(assertStatusCode);
+    }
 
     if (waitForDismiss) {
       ensureDownloadStatusDismissed();

--- a/e2e/test-component/scenarios/embedding-sdk/guest-embed-reproductions.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/guest-embed-reproductions.cy.spec.tsx
@@ -8,7 +8,6 @@ import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
 import { mountGuestEmbedQuestion } from "e2e/support/helpers/embedding-sdk-component-testing";
 import { signInAsAdminAndSetupGuestEmbedding } from "e2e/support/helpers/embedding-sdk-testing";
 import type { Card } from "metabase-types/api";
-import { EMBED_JS_IFRAME_IDENTIFIER_QUERY_PARAMETER_NAME } from "metabase/embedding/embedding-iframe-sdk/constants";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 

--- a/e2e/test-component/scenarios/embedding-sdk/guest-embed-reproductions.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/guest-embed-reproductions.cy.spec.tsx
@@ -1,0 +1,71 @@
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import {
+  createQuestion,
+  downloadAndAssert,
+  getSignedJwtForResource,
+} from "e2e/support/helpers";
+import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
+import { mountGuestEmbedQuestion } from "e2e/support/helpers/embedding-sdk-component-testing";
+import { signInAsAdminAndSetupGuestEmbedding } from "e2e/support/helpers/embedding-sdk-testing";
+import type { Card } from "metabase-types/api";
+import { EMBED_JS_IFRAME_IDENTIFIER_QUERY_PARAMETER_NAME } from "metabase/embedding/embedding-iframe-sdk/constants";
+
+const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
+
+describe("scenarios > embedding-sdk > guest-embed reproductions", () => {
+  const setup = ({ display }: { display?: Card["display"] } = {}) => {
+    signInAsAdminAndSetupGuestEmbedding({
+      token: "pro-cloud",
+    });
+
+    createQuestion({
+      name: "Question for Guest Embed SDK",
+      enable_embedding: true,
+      embedding_type: "guest-embed",
+      query: {
+        "source-table": ORDERS_ID,
+        aggregation: [["max", ["field", ORDERS.QUANTITY, null]]],
+        breakout: [["field", ORDERS.PRODUCT_ID, null]],
+        limit: 2,
+      },
+      display,
+    }).then(({ body: question }) => {
+      cy.wrap(question.id).as("questionId");
+    });
+
+    cy.signOut();
+  };
+
+  it("should show question content with applied content translation", () => {
+    setup();
+
+    cy.get("@questionId").then(async (questionId) => {
+      const token = await getSignedJwtForResource({
+        resourceId: questionId as unknown as number,
+        resourceType: "question",
+      });
+
+      mountGuestEmbedQuestion({ token, title: true, withDownloads: true });
+
+      cy.window().then((win) => {
+        const url = new URL(win.location.href);
+
+        url.searchParams.set("foo", "bar");
+        win.history.replaceState(null, "", url);
+      });
+
+      getSdkRoot().within(() => {
+        downloadAndAssert({
+          isDashboard: false,
+          isEmbed: true,
+          enableFormatting: true,
+          assertStatusCode: 200,
+          waitForDismiss: false,
+          fileType: "csv",
+          downloadUrl: "/api/embed/card/*/query/csv*",
+          downloadMethod: "GET",
+        });
+      });
+    });
+  });
+});

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/guest-embed.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/guest-embed.cy.spec.ts
@@ -60,6 +60,42 @@ describe(
       });
     });
 
+    it("allows to download a static question as CSV", () => {
+      cy.get("@questionId").then(async (questionId) => {
+        const token = await getSignedJwtForResource({
+          resourceId: questionId as unknown as number,
+          resourceType: "question",
+        });
+
+        const frame = H.loadSdkIframeEmbedTestPage({
+          metabaseConfig: { isGuest: true },
+          elements: [
+            {
+              component: "metabase-question",
+              attributes: {
+                token,
+                "with-downloads": true,
+              },
+            },
+          ],
+        });
+
+        cy.wait("@getCardQuery");
+
+        frame.within(() => {
+          H.downloadAndAssert({
+            isDashboard: false,
+            isEmbed: true,
+            enableFormatting: true,
+            waitForDismiss: false,
+            fileType: "csv",
+            downloadUrl: "/api/embed/card/*/query/csv*",
+            downloadMethod: "GET",
+          });
+        });
+      });
+    });
+
     it("shows an error for a component without guest embed support", () => {
       const frame = H.loadSdkIframeEmbedTestPage({
         metabaseConfig: { isGuest: true },

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/guest-embed.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/guest-embed.cy.spec.ts
@@ -87,6 +87,7 @@ describe(
             isDashboard: false,
             isEmbed: true,
             enableFormatting: true,
+            assertStatusCode: 200,
             waitForDismiss: false,
             fileType: "csv",
             downloadUrl: "/api/embed/card/*/query/csv*",

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useMemo } from "react";
+import { type ReactNode, useEffect, useMemo } from "react";
 import { P, match } from "ts-pattern";
 
 import { PublicComponentStylesWrapper } from "embedding-sdk-bundle/components/private/PublicComponentStylesWrapper";
@@ -30,6 +30,7 @@ import { Stack } from "metabase/ui";
 import { useParamRerenderKey } from "../hooks/use-param-rerender-key";
 import { useSdkIframeEmbedEventBus } from "../hooks/use-sdk-iframe-embed-event-bus";
 import type { SdkIframeEmbedSettings } from "../types/embed";
+import { stripInternalIframeQueryParameters } from "../utils/strip-internal-iframe-query-parameters";
 
 import { MetabaseBrowser } from "./MetabaseBrowser";
 import SdkIframeEmbedRouteS from "./SdkIframeEmbedRoute.module.css";
@@ -57,6 +58,10 @@ export const SdkIframeEmbedRoute = () => {
     () => applyThemePreset(embedSettings?.theme),
     [embedSettings?.theme],
   );
+
+  useEffect(() => {
+    stripInternalIframeQueryParameters();
+  }, []);
 
   // The embed settings won't be available until the parent sends it via postMessage.
   // The SDK will show its own loading indicator, so we don't need to show it twice.

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/constants.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/constants.ts
@@ -137,3 +137,9 @@ export const DISABLE_UPDATE_FOR_KEYS = [
 ] as const satisfies AllowedEmbedSettingKey[];
 
 export const METABASE_CONFIG_IS_PROXY_FIELD_NAME = "__isProxy";
+
+/**
+ * Used to allow parallel loading of EmbedJS iframes
+ */
+export const EMBED_JS_IFRAME_IDENTIFIER_QUERY_PARAMETER_NAME =
+  "embed-js-identifier";

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.ts
@@ -10,6 +10,7 @@ import { debouncedReportAnalytics } from "./analytics";
 import {
   ALLOWED_EMBED_SETTING_KEYS_MAP,
   DISABLE_UPDATE_FOR_KEYS,
+  EMBED_JS_IFRAME_IDENTIFIER_QUERY_PARAMETER_NAME,
   METABASE_CONFIG_IS_PROXY_FIELD_NAME,
 } from "./constants";
 import type {
@@ -346,7 +347,7 @@ export abstract class MetabaseEmbedElement<T extends string[] = string[]>
     // Random query param is needed to allow parallel EmbedJS iframes loading.
     // Without it multiple EmbedJS iframes on a page loaded sequentially.
     // We don't cache the iframe content, so random query parameter does not break caching.
-    this._iframe.src = `${this.globalSettings.instanceUrl}/${EMBEDDING_ROUTE}?v=${_iframeCounter++}`;
+    this._iframe.src = `${this.globalSettings.instanceUrl}/${EMBEDDING_ROUTE}?${EMBED_JS_IFRAME_IDENTIFIER_QUERY_PARAMETER_NAME}=${_iframeCounter++}`;
     this._iframe.style.width = "100%";
     this._iframe.style.height = "100%";
     this._iframe.style.border = "none";

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.unit.spec.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.unit.spec.ts
@@ -190,7 +190,7 @@ describe("embed.js script tag for sdk iframe embedding", () => {
     }).not.toThrow();
   });
 
-  it("should include a counter as a query parameter in the iframe src for parallel loading", () => {
+  it("should include a component id as a query parameter in the iframe src for parallel loading", () => {
     defineMetabaseConfig({
       instanceUrl: "https://example.com",
     });
@@ -202,7 +202,7 @@ describe("embed.js script tag for sdk iframe embedding", () => {
     const iframe = embed.querySelector("iframe");
     expect(iframe).not.toBeNull();
     expect(iframe?.src).toMatch(
-      /^https:\/\/example\.com\/embed\/sdk\/v1\?v=\d+$/,
+      /^https:\/\/example\.com\/embed\/sdk\/v1\?embed-js-identifier=\d+$/,
     );
   });
 });

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/utils/strip-internal-iframe-query-parameters.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/utils/strip-internal-iframe-query-parameters.ts
@@ -1,0 +1,9 @@
+import { EMBED_JS_IFRAME_IDENTIFIER_QUERY_PARAMETER_NAME } from "../constants";
+
+export const stripInternalIframeQueryParameters = () => {
+  const url = new URL(window.location.href);
+
+  url.searchParams.delete(EMBED_JS_IFRAME_IDENTIFIER_QUERY_PARAMETER_NAME);
+
+  window.history.replaceState(null, "", url);
+};

--- a/frontend/src/metabase/redux/downloads.ts
+++ b/frontend/src/metabase/redux/downloads.ts
@@ -323,7 +323,11 @@ const getEmbedQuestionParams = (
   type: string,
   exportParams: ExportParams,
 ): DownloadQueryResultsParams => {
-  const params = new URLSearchParams(window.location.search);
+  const params = isEmbeddingSdk()
+    ? // For SDK/EmbedJS we must not read params from location search as in both cases
+      // additional params are not supported by a public endpoint
+      null
+    : new URLSearchParams(window.location.search);
 
   const convertSearchParamsToObject = (params: URLSearchParams) => {
     const object: Record<string, string | string[]> = {};
@@ -345,7 +349,9 @@ const getEmbedQuestionParams = (
     method: "GET",
     url: Urls.embedCard(token, type),
     params: new URLSearchParams({
-      parameters: JSON.stringify(convertSearchParamsToObject(params)),
+      parameters: params
+        ? JSON.stringify(convertSearchParamsToObject(params))
+        : "",
       ..._.mapObject(exportParams, (value) => String(value)),
     }),
   };

--- a/frontend/src/metabase/redux/downloads.ts
+++ b/frontend/src/metabase/redux/downloads.ts
@@ -349,9 +349,9 @@ const getEmbedQuestionParams = (
     method: "GET",
     url: Urls.embedCard(token, type),
     params: new URLSearchParams({
-      parameters: params
-        ? JSON.stringify(convertSearchParamsToObject(params))
-        : "",
+      ...(params && {
+        parameters: JSON.stringify(convertSearchParamsToObject(params)),
+      }),
       ..._.mapObject(exportParams, (value) => String(value)),
     }),
   };


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/69949

The issue was that I added `?v` query param to EmbedJS iframe to allow its parallel loading, but in the case of downloading we take window.location.search and pass is params to the API endpoint in addition with some other query params.

This causes the error.

The fix:
- i changed the name of the parameter to the more internal name
- i filter out this name when embedjs iframe is loaded

How to verify:
- open any embedJS wizard in guest mode for a question, select `with downloads` and try to download a question as CSV