### PR TITLE
fix: better check for dirty collection state

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/remote_sync/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/api.clj
@@ -144,30 +144,42 @@
   (api/check-superuser)
   (api/check-400 (not (and (remote-sync.object/dirty?) (= :read-only remote-sync-type)))
                  "There are unsaved changes in the Remote Sync collection which will be overwritten switching to read-only mode.")
-  ;; Check if trying to change collections while in read-only mode
-  (let [effective-type (or remote-sync-type (settings/remote-sync-type))]
-    (api/check-400 (not (and (seq collections) (= :read-only effective-type)))
-                   "Cannot change synced collections when remote-sync-type is read-only."))
-  (when (seq collections)
+  ;; Filter out no-op collection changes before checking read-only mode or running bulk-set
+  (let [collections (when (seq collections)
+                      (let [current-states (into {}
+                                                 (map (juxt :id :is_remote_synced))
+                                                 (t2/select [:model/Collection :id :is_remote_synced]
+                                                            :id [:in (keys collections)]))]
+                        (not-empty
+                         (into {}
+                               (filter (fn [[id desired]]
+                                         (not= (boolean desired)
+                                               (boolean (get current-states id)))))
+                               collections))))]
+    ;; Check if trying to change collections while in read-only mode
+    (let [effective-type (or remote-sync-type (settings/remote-sync-type))]
+      (api/check-400 (not (and (seq collections) (= :read-only effective-type)))
+                     "Cannot change synced collections when remote-sync-type is read-only."))
+    (when (seq collections)
+      (try
+        (remote-sync.core/bulk-set-remote-sync collections)
+        (catch Exception e
+          (throw (ex-info (or (ex-message e) "Invalid collection settings")
+                          {:error       (ex-message e)
+                           :status-code 400} e)))))
     (try
-      (remote-sync.core/bulk-set-remote-sync collections)
+      (settings/check-and-update-remote-settings! (dissoc settings :collections))
       (catch Exception e
-        (throw (ex-info (or (ex-message e) "Invalid collection settings")
+        (throw (ex-info (or (ex-message e) "Invalid settings")
                         {:error       (ex-message e)
-                         :status-code 400} e)))))
-  (try
-    (settings/check-and-update-remote-settings! (dissoc settings :collections))
-    (catch Exception e
-      (throw (ex-info (or (ex-message e) "Invalid settings")
-                      {:error       (ex-message e)
-                       :status-code 400} e))))
-  (events/publish-event! :event/remote-sync-settings-update
-                         {:details {:remote-sync-type remote-sync-type}
-                          :user-id api/*current-user-id*})
-  (if-let [task-id (impl/finish-remote-config!)]
-    {:success true
-     :task_id task-id}
-    {:success true}))
+                         :status-code 400} e))))
+    (events/publish-event! :event/remote-sync-settings-update
+                           {:details {:remote-sync-type remote-sync-type}
+                            :user-id api/*current-user-id*})
+    (if-let [task-id (impl/finish-remote-config!)]
+      {:success true
+       :task_id task-id}
+      {:success true})))
 
 (api.macros/defendpoint :get "/branches" :- remote-sync.schema/BranchesResponse
   "Get list of branches from the configured source.

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/RemoteSyncSettingsForm.setup.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/RemoteSyncSettingsForm.setup.spec.tsx
@@ -8,7 +8,7 @@ import {
 } from "__support__/server-mocks";
 import { mockSettings } from "__support__/settings";
 import { renderWithProviders } from "__support__/ui";
-import type { Collection } from "metabase-types/api";
+import type { Collection, CollectionItem } from "metabase-types/api";
 import {
   createMockCollection,
   createMockSettings,
@@ -41,6 +41,8 @@ const setupEndpoints = ({
   remoteSyncTransforms = false,
   libraryCollection = null as Collection | null,
   dirty = [] as any[],
+  rootCollectionItems = [] as CollectionItem[],
+  settingsError,
 }: {
   remoteSyncEnabled?: boolean;
   remoteSyncUrl?: string;
@@ -51,6 +53,8 @@ const setupEndpoints = ({
   remoteSyncTransforms?: boolean;
   libraryCollection?: Collection | null;
   dirty?: any[];
+  rootCollectionItems?: CollectionItem[];
+  settingsError?: { status: number; message: string };
 } = {}) => {
   const settings = createMockSettings({
     "remote-sync-enabled": remoteSyncEnabled,
@@ -64,11 +68,17 @@ const setupEndpoints = ({
 
   setupPropertiesEndpoints(settings);
   setupSettingsEndpoints([]);
-  setupRemoteSyncEndpoints({ dirty, branches: [remoteSyncBranch] });
+  setupRemoteSyncEndpoints({
+    dirty,
+    branches: [remoteSyncBranch],
+    ...(settingsError && {
+      settingsResponse: { error: settingsError },
+    }),
+  });
 
   fetchMock.get("express:/api/ee/library", libraryCollection ?? { data: null });
 
-  setupRootCollectionItemsEndpoint({ rootCollectionItems: [] });
+  setupRootCollectionItemsEndpoint({ rootCollectionItems });
 };
 
 const createStoreState = ({
@@ -99,7 +109,9 @@ interface SetupOpts {
   remoteSyncTransforms?: boolean;
   libraryCollection?: Collection | null;
   dirty?: any[];
+  rootCollectionItems?: CollectionItem[];
   variant?: RemoteSyncSettingsFormProps["variant"];
+  settingsError?: { status: number; message: string };
 }
 
 export const setup = ({
@@ -112,7 +124,9 @@ export const setup = ({
   remoteSyncTransforms = false,
   libraryCollection = null,
   dirty = [],
+  rootCollectionItems = [],
   variant,
+  settingsError,
 }: SetupOpts = {}) => {
   setupEndpoints({
     remoteSyncEnabled,
@@ -123,6 +137,8 @@ export const setup = ({
     remoteSyncTransforms,
     libraryCollection,
     dirty,
+    rootCollectionItems,
+    settingsError,
   });
 
   renderWithProviders(

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/RemoteSyncSettingsForm.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/RemoteSyncAdminSettings/RemoteSyncSettingsForm.unit.spec.tsx
@@ -1,8 +1,9 @@
 import userEvent from "@testing-library/user-event";
-import fetchMock from "fetch-mock";
 
+import { findRequests } from "__support__/server-mocks";
 import { screen, waitFor } from "__support__/ui";
 import { PLUGIN_TRANSFORMS } from "metabase/plugins";
+import { createMockCollectionItemFromCollection } from "metabase-types/api/mocks";
 
 import {
   createMockLibraryCollection,
@@ -532,20 +533,8 @@ describe("RemoteSyncSettingsForm", () => {
         remoteSyncType: "read-only",
         remoteSyncUrl: "",
         remoteSyncEnabled: false,
+        settingsError: { status: 400, message: "Invalid branch name" },
       });
-
-      // Override the settings endpoint to return an error
-      fetchMock.removeRoute("remote-sync-settings");
-      fetchMock.put(
-        "path:/api/ee/remote-sync/settings",
-        {
-          status: 400,
-          body: {
-            message: "Invalid branch name",
-          },
-        },
-        { name: "remote-sync-settings" },
-      );
 
       const urlInput = screen.getByLabelText(/Repository URL/i);
       await userEvent.type(urlInput, "https://github.com/foo/bar.git");
@@ -557,6 +546,96 @@ describe("RemoteSyncSettingsForm", () => {
 
       await waitFor(() => {
         expect(screen.getByText(/Invalid branch name/)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("collection change filtering", () => {
+    it("should not send collections in request body when no collection sync states changed", async () => {
+      const syncedCollection = createMockCollectionItemFromCollection({
+        id: 10,
+        name: "Synced Collection",
+        is_remote_synced: true,
+        can_write: true,
+      });
+      const unsyncedCollection = createMockCollectionItemFromCollection({
+        id: 20,
+        name: "Unsynced Collection",
+        is_remote_synced: false,
+        can_write: true,
+      });
+
+      setup({
+        remoteSyncType: "read-write",
+        remoteSyncUrl: "https://github.com/test/repo.git",
+        remoteSyncEnabled: true,
+        rootCollectionItems: [syncedCollection, unsyncedCollection],
+      });
+
+      await waitFor(() => {
+        expect(screen.getByLabelText("Read-write")).toBeChecked();
+      });
+
+      // Change the URL to make the form dirty (but don't change collections)
+      const urlInput = screen.getByLabelText(/Repository URL/i);
+      await userEvent.clear(urlInput);
+      await userEvent.type(urlInput, "https://github.com/test/other-repo.git");
+
+      const submitButton = screen.getByRole("button", {
+        name: /Save changes/i,
+      });
+      await userEvent.click(submitButton);
+
+      const puts = await findRequests("PUT");
+      const settingsRequest = puts.find((r) =>
+        r.url.includes("/api/ee/remote-sync/settings"),
+      );
+      expect(settingsRequest).toBeDefined();
+      expect(settingsRequest?.body).not.toHaveProperty("collections");
+    });
+
+    it("should only send changed collections in request body", async () => {
+      const syncedCollection = createMockCollectionItemFromCollection({
+        id: 10,
+        name: "Synced Collection",
+        is_remote_synced: true,
+        can_write: true,
+      });
+      const unsyncedCollection = createMockCollectionItemFromCollection({
+        id: 20,
+        name: "Unsynced Collection",
+        is_remote_synced: false,
+        can_write: true,
+      });
+
+      setup({
+        remoteSyncType: "read-write",
+        remoteSyncUrl: "https://github.com/test/repo.git",
+        remoteSyncEnabled: true,
+        rootCollectionItems: [syncedCollection, unsyncedCollection],
+      });
+
+      await waitFor(() => {
+        expect(screen.getByLabelText("Read-write")).toBeChecked();
+      });
+
+      // Toggle the unsynced collection to synced
+      const unsyncedToggle = screen.getByLabelText("Sync Unsynced Collection");
+      await userEvent.click(unsyncedToggle);
+
+      const submitButton = screen.getByRole("button", {
+        name: /Save changes/i,
+      });
+      await userEvent.click(submitButton);
+
+      // Should only include collection 20 (changed), not collection 10 (unchanged)
+      const puts = await findRequests("PUT");
+      const settingsRequest = puts.find((r) =>
+        r.url.includes("/api/ee/remote-sync/settings"),
+      );
+      expect(settingsRequest).toBeDefined();
+      expect(settingsRequest?.body).toHaveProperty("collections", {
+        "20": true,
       });
     });
   });

--- a/frontend/test/__support__/server-mocks/remote-sync.ts
+++ b/frontend/test/__support__/server-mocks/remote-sync.ts
@@ -61,13 +61,24 @@ export interface RemoteSyncSettingsResponse {
 export const setupRemoteSyncSettingsEndpoint = ({
   success = true,
   task_id,
-}: Partial<RemoteSyncSettingsResponse> = {}) => {
+  error,
+}: Partial<RemoteSyncSettingsResponse> & {
+  error?: { status: number; message: string };
+} = {}) => {
   fetchMock.removeRoute("remote-sync-settings");
-  fetchMock.put(
-    "path:/api/ee/remote-sync/settings",
-    { success, ...(task_id !== undefined && { task_id }) },
-    { name: "remote-sync-settings" },
-  );
+  if (error) {
+    fetchMock.put(
+      "path:/api/ee/remote-sync/settings",
+      { status: error.status, body: { message: error.message } },
+      { name: "remote-sync-settings" },
+    );
+  } else {
+    fetchMock.put(
+      "path:/api/ee/remote-sync/settings",
+      { success, ...(task_id !== undefined && { task_id }) },
+      { name: "remote-sync-settings" },
+    );
+  }
 };
 
 /**
@@ -124,7 +135,9 @@ export const setupRemoteSyncEndpoints = ({
   changedCollections?: Record<number, boolean>;
   hasRemoteChanges?: boolean;
   hasRemoteChangesDelay?: number;
-  settingsResponse?: Partial<RemoteSyncSettingsResponse>;
+  settingsResponse?: Partial<RemoteSyncSettingsResponse> & {
+    error?: { status: number; message: string };
+  };
 } = {}) => {
   setupRemoteSyncBranchesEndpoint(branches);
   setupRemoteSyncDirtyEndpoint({ dirty, changedCollections });


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #69964
### Description

Our frontend code that prevents sending unchanged collections missed tenant collections being added to the payload. This fixes both the frontend to make sure we don't send when there are no changed collections and it updates the backend actually check if collections are being changed rather than just checking if the collections map exists.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
