### PR TITLE
Add tests for calculated display_name and fix nested name handling

### DIFF
--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -129,7 +129,15 @@
         (when (and parent-id
                    ;; check that we haven't nested yet
                    (or (nil? field-display-name)
-                       (= field-display-name humanized-name)))
+                       (= field-display-name humanized-name)
+                       ;; For card-metadata columns, :name may be the dotted form
+                       ;; (e.g. "grandparent.parent"). Humanizing it doesn't produce
+                       ;; the leaf display-name, so also check against the raw field's
+                       ;; display-name from the metadata provider.
+                       (when-let [field-id (when (pos-int? (:id col))
+                                             (:id col))]
+                         (when-let [raw-field (lib.metadata/field query field-id)]
+                           (= field-display-name (:display-name raw-field))))))
           (nest-display-name query col))
         (when-let [[source-index source-clause]
                    (and source-uuid

--- a/src/metabase/lib/metadata/result_metadata.cljc
+++ b/src/metabase/lib/metadata/result_metadata.cljc
@@ -389,6 +389,16 @@
         (lib.field.util/add-source-and-desired-aliases-xform query)
         cols))
 
+(defn- add-nested-display-names
+  "Compute nested display-names for columns with `:parent-id`. Raw field metadata from the metadata provider has leaf
+  display-names (e.g. \"Child\"), but QP results should have the full nested path (e.g. \"Grandparent: Parent: Child\")."
+  [query cols]
+  (mapv (fn [col]
+          (if (:parent-id col)
+            (assoc col :display-name (lib.metadata.calculation/display-name query -1 col))
+            col))
+        cols))
+
 (mu/defn- add-extra-metadata :- [:sequential ::kebab-cased-map]
   "Add extra metadata to the [[lib/returned-columns]] that only comes back with QP results metadata."
   [query        :- ::lib.schema/query
@@ -415,6 +425,7 @@
            deduplicate-names
            (add-legacy-field-refs query)
            (merge-model-metadata query)
+           (add-nested-display-names query)
            (add-source-and-desired-aliases query)))))
 
 (defn- add-unit [col]

--- a/test/metabase/lib/field_test.cljc
+++ b/test/metabase/lib/field_test.cljc
@@ -161,6 +161,148 @@
                        lib/visible-columns
                        (map #(lib/display-info base -1 %))))))))))
 
+(deftest ^:parallel nested-field-display-name-via-model-test
+  (testing "Nested field display names should not be doubled when querying a model (#QUE-XXXX)"
+    (let [;; Build a model whose result-metadata has the nested display-names (simulating what the QP produces)
+          model-id        100
+          model-card      {:lib/type        :metadata/card
+                           :id              model-id
+                           :database-id     (meta/id)
+                           :name            "Model with nested fields"
+                           :type            :model
+                           :dataset-query   {:database (meta/id)
+                                             :type     :query
+                                             :query    {:source-table (meta/id :venues)}}
+                           ;; result-metadata mimics what the QP stores: display-name is already
+                           ;; the nested form, and :name is the dotted form
+                           :result-metadata [{:lib/type     :metadata/column
+                                              :id           (grandparent-parent-child-id :grandparent)
+                                              :table-id     (meta/id :venues)
+                                              :name         "grandparent"
+                                              :display-name "Grandparent"
+                                              :base-type    :type/Text}
+                                             {:lib/type     :metadata/column
+                                              :id           (grandparent-parent-child-id :parent)
+                                              :table-id     (meta/id :venues)
+                                              :name         "grandparent.parent"
+                                              :display-name "Grandparent: Parent"
+                                              :base-type    :type/Text}
+                                             {:lib/type     :metadata/column
+                                              :id           (grandparent-parent-child-id :child)
+                                              :table-id     (meta/id :venues)
+                                              :name         "grandparent.parent.child"
+                                              :display-name "Grandparent: Parent: Child"
+                                              :base-type    :type/Text}]}
+          mp              (lib/composed-metadata-provider
+                           grandparent-parent-child-metadata-provider
+                           (lib.tu/mock-metadata-provider {:cards [model-card]}))
+          query           (lib/query mp (lib.metadata/card mp model-id))
+          cols            (lib/visible-columns query)
+          display-names   (mapv #(lib/display-name query %) cols)]
+      (testing "display-name should NOT include the parent prefix twice"
+        (is (= ["Grandparent"
+                "Grandparent: Parent"
+                "Grandparent: Parent: Child"]
+               display-names)))
+      (testing "display-info should also be correct"
+        (is (=? [{:display-name "Grandparent"}
+                 {:display-name "Grandparent: Parent"}
+                 {:display-name "Grandparent: Parent: Child"}]
+                (mapv #(lib/display-info query %) cols)))))))
+
+(deftest ^:parallel nested-field-display-name-via-saved-question-test
+  (testing "Nested field display names should not be doubled when querying a saved question"
+    (let [card-id         101
+          card            {:lib/type        :metadata/card
+                           :id              card-id
+                           :database-id     (meta/id)
+                           :name            "Question with nested fields"
+                           :type            :question
+                           :dataset-query   {:database (meta/id)
+                                             :type     :query
+                                             :query    {:source-table (meta/id :venues)}}
+                           :result-metadata [{:lib/type     :metadata/column
+                                              :id           (grandparent-parent-child-id :grandparent)
+                                              :table-id     (meta/id :venues)
+                                              :name         "grandparent"
+                                              :display-name "Grandparent"
+                                              :base-type    :type/Text}
+                                             {:lib/type     :metadata/column
+                                              :id           (grandparent-parent-child-id :parent)
+                                              :table-id     (meta/id :venues)
+                                              :name         "grandparent.parent"
+                                              :display-name "Grandparent: Parent"
+                                              :base-type    :type/Text}
+                                             {:lib/type     :metadata/column
+                                              :id           (grandparent-parent-child-id :child)
+                                              :table-id     (meta/id :venues)
+                                              :name         "grandparent.parent.child"
+                                              :display-name "Grandparent: Parent: Child"
+                                              :base-type    :type/Text}]}
+          mp              (lib/composed-metadata-provider
+                           grandparent-parent-child-metadata-provider
+                           (lib.tu/mock-metadata-provider {:cards [card]}))
+          query           (lib/query mp (lib.metadata/card mp card-id))
+          cols            (lib/visible-columns query)
+          display-names   (mapv #(lib/display-name query %) cols)]
+      (testing "display-name should NOT include the parent prefix twice"
+        (is (= ["Grandparent"
+                "Grandparent: Parent"
+                "Grandparent: Parent: Child"]
+               display-names))))))
+
+(deftest ^:parallel nested-field-display-name-returned-columns-test
+  (testing "returned-columns should produce correct nested display names when using lib/display-name"
+    (let [base  (lib/query grandparent-parent-child-metadata-provider (meta/table-metadata :venues))
+          cols  (lib/returned-columns base)]
+      (is (= ["Grandparent: Parent: Child"
+              "Grandparent"
+              "Grandparent: Parent"]
+             (mapv #(lib/display-name base %) cols))))))
+
+(deftest ^:parallel nested-field-display-name-via-model-with-leaf-display-names-test
+  (testing "model with leaf display-names in result-metadata (matching QP output) should still nest correctly"
+    (let [model-id        102
+          ;; This simulates what happens in practice: the QP stores leaf display-names in
+          ;; result-metadata, not the nested form
+          model-card      {:lib/type        :metadata/card
+                           :id              model-id
+                           :database-id     (meta/id)
+                           :name            "Model with nested fields (leaf display-names)"
+                           :type            :model
+                           :dataset-query   {:database (meta/id)
+                                             :type     :query
+                                             :query    {:source-table (meta/id :venues)}}
+                           :result-metadata [{:lib/type     :metadata/column
+                                              :id           (grandparent-parent-child-id :grandparent)
+                                              :table-id     (meta/id :venues)
+                                              :name         "grandparent"
+                                              :display-name "Grandparent"
+                                              :base-type    :type/Text}
+                                             {:lib/type     :metadata/column
+                                              :id           (grandparent-parent-child-id :parent)
+                                              :table-id     (meta/id :venues)
+                                              :name         "grandparent.parent"
+                                              :display-name "Parent"
+                                              :base-type    :type/Text}
+                                             {:lib/type     :metadata/column
+                                              :id           (grandparent-parent-child-id :child)
+                                              :table-id     (meta/id :venues)
+                                              :name         "grandparent.parent.child"
+                                              :display-name "Child"
+                                              :base-type    :type/Text}]}
+          mp              (lib/composed-metadata-provider
+                           grandparent-parent-child-metadata-provider
+                           (lib.tu/mock-metadata-provider {:cards [model-card]}))
+          query           (lib/query mp (lib.metadata/card mp model-id))
+          cols            (lib/visible-columns query)
+          display-names   (mapv #(lib/display-name query %) cols)]
+      (testing "display-names should be correctly nested"
+        (is (= ["Grandparent"
+                "Grandparent: Parent"
+                "Grandparent: Parent: Child"]
+               display-names))))))
+
 (deftest ^:parallel joined-field-display-name-test
   (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
                   (lib/join (lib/join-clause (meta/table-metadata :categories)


### PR DESCRIPTION
Closes QUE2-288

### Description

This PR adds test verifying that display name generation for nested fields works as expected and fixes two issues:

1. For card-metadata columns (models/saved questions) where `:name` is the dotted form (e.g., `"grandparent.parent"`), the humanization guard didn't match the leaf display-name, so `nest-display-name` was never called. Added a third condition that checks against the raw field's display-name from the metadata provider.
2. The `add-extra-metadata` pipeline (used by `annotate/expected-cols`) returns columns from `lib.metadata.calculation/returned-columns`, which has raw leaf display-names for nested fields. Added an `add-nested-display-names` step that calls `lib.metadata.calculation/display-name` on columns with `:parent-id` to compute the nested `"Grandparent: Parent: Child"` form.

### How to verify

See the tests.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
