### PR TITLE
[match] Add :and syntax to match-lite

### DIFF
--- a/dev/src/dev/debug_qp.clj
+++ b/dev/src/dev/debug_qp.clj
@@ -7,8 +7,6 @@
     ;; run a query with debugging enabled
     (binding [metabase.query-processor.debug/*debug* true]
       (metabase.query-processor/process-query query))"
-  {:clj-kondo/config '{:linters
-                       {:discouraged-var {metabase.lib.util.match/replace {:level :off}}}}}
   (:require
    [clojure.java.io :as io]
    [clojure.string :as str]
@@ -131,16 +129,14 @@
                                                     (pos-int? (:source-field opts))
                                                     (update :source-field field-id->name-form))]
 
-             (m :guard (and (map? m) (pos-int? (:source-table m))))
+             (:and m {:source-table (_ :guard pos-int?)})
              (add-names* (update m :source-table add-table-id-name))
 
-             (m :guard (and (map? m) (pos-int? (:metabase.query-processor.util.add-alias-info/source-table m))))
+             (:and m {:metabase.query-processor.util.add-alias-info/source-table (_ :guard pos-int?)})
              (add-names* (update m :metabase.query-processor.util.add-alias-info/source-table add-table-id-name))
 
-             (m :guard (and (map? m) (pos-int? (:fk-field-id m))))
-             (-> m
-                 (update :fk-field-id field-id->name-form)
-                 add-names*)
+             (:and m {:fk-field-id (_ :guard pos-int?)})
+             (add-names* (update m :fk-field-id field-id->name-form))
 
              ;; don't recursively replace the `do` lists above, other we'll get vectors.
              (l :guard (and (seq? l) (= (first l) 'do)))
@@ -289,8 +285,9 @@
 
 (defn- expand [form table]
   (try
-    (lib.util.match/replace form
-      ([:field (id :guard pos-int?) nil] :guard can-symbolize?)
+    (lib.util.match/replace-lite form
+      (:and [:field (id :guard pos-int?) nil]
+            (_ :guard can-symbolize?))
       (let [[table-name field-name] (field-and-table-name id)
             field-name              (some-> field-name u/lower-case-en)
             table-name              (some-> table-name u/lower-case-en)]
@@ -298,25 +295,29 @@
           [::$ field-name]
           [::$ table-name field-name]))
 
-      ([:field (field-name :guard string?) (opts :guard #(= (set (keys %)) #{:base-type}))] :guard can-symbolize?)
-      [::* field-name (name (:base-type opts))]
+      (:and [:field (field-name :guard string?) (:and {:base-type base-type} (opts :guard (= (count opts) 1)))]
+            (_ :guard can-symbolize?))
+      [::* field-name (name base-type)]
 
-      ([:field _ (opts :guard :temporal-unit)] :guard can-symbolize?)
+      (:and [:field _ {:temporal-unit temporal-unit}]
+            (_ :guard can-symbolize?))
       (let [without-unit (mbql.u/update-field-options &match dissoc :temporal-unit)
             expansion    (expand without-unit table)]
-        [::! (name (:temporal-unit opts)) (strip-$ expansion)])
+        [::! (name temporal-unit) (strip-$ expansion)])
 
-      ([:field _ (opts :guard :source-field)] :guard can-symbolize?)
+      (:and [:field _ {:source-field source-field}]
+            (_ :guard can-symbolize?))
       (let [without-source-field   (mbql.u/update-field-options &match dissoc :source-field)
             expansion              (expand without-source-field table)
-            source-as-field-clause [:field (:source-field opts) nil]
+            source-as-field-clause [:field source-field nil]
             source-expansion       (expand source-as-field-clause table)]
         [::-> source-expansion expansion])
 
-      ([:field _ (opts :guard :join-alias)] :guard can-symbolize?)
+      (:and [:field _ {:join-alias join-alias}]
+            (_ :guard can-symbolize?))
       (let [without-join-alias (mbql.u/update-field-options &match dissoc :join-alias)
             expansion          (expand without-join-alias table)]
-        [::& (:join-alias opts) expansion])
+        [::& join-alias expansion])
 
       [:field (id :guard pos-int?) opts]
       (let [without-opts [:field id nil]
@@ -325,12 +326,12 @@
           &match
           [:field [::% (strip-$ expansion)] opts]))
 
-      (m :guard (every-pred map? (comp pos-int? :source-table)))
+      (:and m {:source-table (_ :guard pos-int?)})
       (-> (update m :source-table (fn [table-id]
                                     [::$$ (some-> (t2/select-one-fn :name :model/Table :id table-id) u/lower-case-en)]))
           (expand table))
 
-      (m :guard (every-pred map? (comp pos-int? :fk-field-id)))
+      (:and m {:fk-field-id (_ :guard pos-int?)})
       (-> (update m :fk-field-id (fn [fk-field-id]
                                    (let [[table-name field-name] (field-and-table-name fk-field-id)
                                          field-name              (some-> field-name u/lower-case-en)

--- a/enterprise/backend/src/metabase_enterprise/permission_debug/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/permission_debug/impl.clj
@@ -177,7 +177,7 @@
   [user-id card permissions-blocking permissions-granting]
   (let [query (-> card :dataset_query qp.preprocess/preprocess)
         query-tables (lib/all-source-table-ids query)
-        native? (boolean (lib.util.match/match-lite query {:native (_ :guard identity)} true))]
+        native? (lib.util.match/match-lite query {:native &truthy} true)]
     (->>
      (cond
        native?

--- a/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/sandboxing.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/sandboxing.clj
@@ -410,7 +410,7 @@
   [{::keys [original-metadata] :as query} rff]
   (fn merge-sandboxing-metadata-rff* [metadata]
     (let [metadata (assoc metadata :is_sandboxed (boolean (lib.util.match/match-lite query
-                                                            {:query-permissions/sandboxed-table sandboxed?} sandboxed?)))
+                                                            {:query-permissions/sandboxed-table &truthy} true)))
           metadata (if original-metadata
                      (merge-metadata original-metadata metadata)
                      metadata)]

--- a/modules/drivers/druid/src/metabase/driver/druid/query_processor.clj
+++ b/modules/drivers/druid/src/metabase/driver/druid/query_processor.clj
@@ -307,7 +307,7 @@
 (defn- parse-filter [filter-clause]
   ;; strip out all the filters against temporal fields. Those are handled separately, as intervals
   (-> (driver-api/replace-lite filter-clause
-        [_ [:field _ {:temporal-unit (_ :guard identity)}] & _]
+        [_ [:field _ {:temporal-unit &truthy}] & _]
         nil)
       ;; TODO (Cam 8/18/25) -- I am 90% sure this is serving no useful purpose.
       #_{:clj-kondo/ignore [:deprecated-var]}
@@ -356,7 +356,7 @@
   clauses, the methods are skipped entirely."
   {:arglists '([filter-clause])}
   (fn [filter-clause]
-    (when (driver-api/match-lite filter-clause [:field _ (_ :guard :temporal-unit)] true)
+    (when (driver-api/match-lite filter-clause [:field _ {:temporal-unit &truthy}] true)
       (driver-api/dispatch-by-clause-name-or-class filter-clause))))
 
 (defmethod filter-clause->intervals :default
@@ -1028,7 +1028,7 @@
   [field]
   (when field
     (driver-api/match-lite field
-      [:field _id-or-name (_opts :guard :temporal-unit)]
+      [:field _id-or-name {:temporal-unit &truthy}]
       true
 
       [:field (id :guard pos-int?) _opts]
@@ -1166,7 +1166,7 @@
         ts?       (boolean
                    (and
                     ;; Checks whether the query is a timeseries
-                    (driver-api/match-lite (first breakout-fields) [:field _ (_ :guard :temporal-unit)] true)
+                    (driver-api/match-lite (first breakout-fields) [:field _ {:temporal-unit &truthy}] true)
                     ;; (excludes x-of-y type breakouts)
                     (contains? timeseries-units (:unit (first breakout-fields)))
                     ;; (excludes queries with LIMIT)

--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -1765,10 +1765,9 @@ function(bin) {
       [:field & _]
       (update-field-ref &match)
 
-      (join :guard (and (map? join)
-                        (driver-api/qp.add.alias join)
-                        (not= (driver-api/qp.add.alias join) (:alias join))))
-      (&recur (assoc join :alias (driver-api/qp.add.alias join))))))
+      (:and join
+            {driver-api/qp.add.alias (add-alias :guard (and add-alias (not= add-alias (:alias join))))})
+      (&recur (assoc join :alias add-alias)))))
 
 (defn- preprocess
   [inner-query]

--- a/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
@@ -676,7 +676,7 @@
              (->> (magic/automagic-analysis (t2/select-one :model/Field :id (mt/id :venues :price)) {})
                   :dashcards
                   (mapcat (comp :breakout :query :dataset_query :card)))
-             [:field _ (_ :guard :binning)] true))))))
+             [:field _ {:binning &truthy}] true))))))
 
 (deftest no-values-test
   (mt/test-driver :mongo

--- a/src/metabase/driver/common/parameters/parse.clj
+++ b/src/metabase/driver/common/parameters/parse.clj
@@ -3,11 +3,11 @@
   replacement namespaces. The replacement for this namespace is [[metabase.lib.parameters.parse]]."
   {:deprecated "0.57.0"}
   (:require
-   [clojure.core.match :refer [match]]
    [clojure.string :as str]
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.driver.common.parameters :as params]
    [metabase.lib.core :as lib]
    [metabase.lib.schema.common :as lib.schema.common]
+   [metabase.lib.util.match :as lib.util.match]
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.util.malli :as mu])
   (:import
@@ -23,12 +23,15 @@
    (lib.schema.common/instance-of-class Optional)])
 
 (defn- ->param [value]
-  (match [value]
-    [s :guard string?] s
-    [{:type :metabase.lib.parse/param
-      :name name}] (params/->Param (or (lib/match-and-normalize-tag-name name) (str/trim name)))
-    [{:type :metabase.lib.parse/optional
-      :contents contents}] (params/->Optional (map ->param contents))))
+  (lib.util.match/match-lite value
+    (s :guard string?)
+    s
+
+    {:type :metabase.lib.parse/param, :name name}
+    (params/->Param (or (lib/match-and-normalize-tag-name name) (str/trim name)))
+
+    {:type :metabase.lib.parse/optional, :contents contents}
+    (params/->Optional (map ->param contents))))
 
 (mu/defn parse :- [:sequential ParsedToken]
   "Attempts to parse parameters in string `s`. Parses any optional clauses or parameters found, and returns a sequence

--- a/src/metabase/legacy_mbql/schema.cljc
+++ b/src/metabase/legacy_mbql/schema.cljc
@@ -954,12 +954,11 @@
     (into [:!= [:get-hour [:field id-or-name (not-empty (dissoc opts :temporal-unit))]]] args)
 
     [:!=
-     [:field id-or-name (opts :guard (#{:day-of-week :month-of-year :quarter-of-year} (:temporal-unit opts)))]
+     [:field id-or-name (:and opts {:temporal-unit (unit :guard #{:day-of-week :month-of-year :quarter-of-year})})]
      & (args :guard (every? u.time/timestamp-coercible? args))]
     (let [args (mapv u.time/coerce-to-timestamp args)]
       (if (every? u.time/valid? args)
-        (let [unit         (:temporal-unit opts)
-              field        [:field id-or-name (not-empty (dissoc opts :temporal-unit))]
+        (let [field        [:field id-or-name (not-empty (dissoc opts :temporal-unit))]
               extract-expr (case unit
                              :day-of-week     [:get-day-of-week field :iso]
                              :month-of-year   [:get-month field]

--- a/src/metabase/legacy_mbql/util.cljc
+++ b/src/metabase/legacy_mbql/util.cljc
@@ -231,13 +231,13 @@
     [:time-interval field-or-expression :last    unit options] (&recur [:time-interval field-or-expression -1 unit options])
     [:time-interval field-or-expression :next    unit options] (&recur [:time-interval field-or-expression  1 unit options])
 
-    [:time-interval field-or-expression (n :guard #{-1}) unit {:include-current identity}]
+    [:time-interval field-or-expression (n :guard #{-1}) unit {:include-current &truthy}]
     [:between
      (replace-field-or-expression field-or-expression unit)
      [:relative-datetime n unit]
      [:relative-datetime 0 unit]]
 
-    [:time-interval field-or-expression (n :guard #{1}) unit {:include-current identity}]
+    [:time-interval field-or-expression (n :guard #{1}) unit {:include-current &truthy}]
     [:between
      (replace-field-or-expression field-or-expression unit)
      [:relative-datetime 0 unit]
@@ -246,7 +246,7 @@
     [:time-interval field-or-expression (n :guard #{-1 0 1}) unit _]
     [:= (replace-field-or-expression field-or-expression unit) [:relative-datetime n unit]]
 
-    [:time-interval field-or-expression (n :guard neg?) unit {:include-current identity}]
+    [:time-interval field-or-expression (n :guard neg?) unit {:include-current &truthy}]
     [:between
      (replace-field-or-expression field-or-expression unit)
      [:relative-datetime n unit]
@@ -258,7 +258,7 @@
      [:relative-datetime n unit]
      [:relative-datetime -1 unit]]
 
-    [:time-interval field-or-expression n unit {:include-current identity}]
+    [:time-interval field-or-expression n unit {:include-current &truthy}]
     [:between
      (replace-field-or-expression field-or-expression unit)
      [:relative-datetime 0 unit]
@@ -384,7 +384,7 @@
   [m]
   #_{:clj-kondo/ignore [:deprecated-var]}
   (lib.util.match/replace-lite m
-    [clause field & (args :guard (some (partial = [:relative-datetime :current]) args))]
+    [clause field & (args :guard (some #{[:relative-datetime :current]} args))]
     (let [temporal-unit (or (lib.util.match/match-lite field
                               [:field _ {:temporal-unit temporal-unit}] temporal-unit)
                             :default)]

--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -569,7 +569,7 @@
 (defn- add-alias-to-join-refs [query stage-number form join-alias join-cols]
   (lib.util.match/replace-lite form
     (field :guard (and (lib.util/field-clause? field)
-                       (boolean (lib.equality/find-matching-column query stage-number field join-cols))))
+                       (lib.equality/find-matching-column query stage-number field join-cols)))
     (with-join-alias field join-alias)))
 
 (defn- add-alias-to-condition

--- a/src/metabase/lib/native.cljc
+++ b/src/metabase/lib/native.cljc
@@ -2,7 +2,6 @@
   "Functions for working with native queries."
   (:refer-clojure :exclude [some select-keys mapv every? empty? not-empty])
   (:require
-   [clojure.core.match :refer [match]]
    [clojure.set :as set]
    [clojure.string :as str]
    [medley.core :as m]
@@ -19,6 +18,7 @@
    [metabase.lib.schema.template-tag :as lib.schema.template-tag]
    [metabase.lib.template-tags :as lib.template-tags]
    [metabase.lib.util :as lib.util]
+   [metabase.lib.util.match :as lib.util.match]
    [metabase.lib.walk.util :as lib.walk.util]
    [metabase.util.humanization :as u.humanization]
    [metabase.util.i18n :as i18n]
@@ -49,20 +49,23 @@
   (let [parsed (lib.parse/parse {} query-text)]
     (loop [found            {}
            [current & more] parsed]
-      (match [current]
-        [nil]              found
-        [_ :guard string?] (recur found more)
+      (let [[found more] (lib.util.match/match-lite current
+                           (_ :guard string?) [found more]
 
-        [{:type ::lib.parse/param, :name tag-name}]
-        (let [normalized-name (lib.params.parse/match-and-normalize-tag-name tag-name)]
-          (recur (cond-> found
-                   (and normalized-name (not (found normalized-name)))
-                   (assoc normalized-name (fresh-tag normalized-name)))
-                 more))
+                           {:type ::lib.parse/param, :name tag-name}
+                           (let [normalized-name (lib.params.parse/match-and-normalize-tag-name tag-name)]
+                             [(cond-> found
+                                (and normalized-name (not (found normalized-name)))
+                                (assoc normalized-name (fresh-tag normalized-name)))
+                              more])
 
-        [{:type     ::lib.parse/optional
-          :contents contents}]
-        (recur found (into more contents))))))
+                           {:type ::lib.parse/optional, :contents contents}
+                           [found (into more contents)]
+
+                           _ [found nil])]
+        (if more
+          (recur found more)
+          found)))))
 
 (defn- rename-template-tag
   [existing-tags old-name new-name]

--- a/src/metabase/lib/schema.cljc
+++ b/src/metabase/lib/schema.cljc
@@ -409,7 +409,7 @@
         (or
          (when (map? stage)
            (lib.util.match/match-lite (dissoc stage :joins :lib/stage-metadata)
-             [:field {:join-alias (join-alias :guard (and (some? join-alias)
+             [:field {:join-alias (join-alias :guard (and join-alias
                                                           (not (visible-join-alias? join-alias))))} _id-or-name]
              (str "Invalid :field reference in stage " i ": no join named " (pr-str join-alias))))
          (when (seq more)

--- a/src/metabase/lib/util/match.clj
+++ b/src/metabase/lib/util/match.clj
@@ -234,6 +234,11 @@
     {:type :or
      :clauses (rest pattern)}
 
+    ;; (:and ...) pattern
+    (and (seq? pattern) (= (first pattern) :and) (>= (count pattern) 2))
+    {:type :and
+     :clauses (rest pattern)}
+
     ;; Vector pattern
     (vector? pattern)
     (let [[main-parts rest-parts] (vec (split-with (complement #{'&}) pattern))
@@ -278,16 +283,21 @@
                                                              `metabase.lib.util.match.impl/count=) s cnt)
                                                      {:depends-on s})))
                 (when rest-part
-                  (process-pattern rest-part (list `drop cnt s) bindings conditions false)))
+                  (process-pattern rest-part `(into [] (drop ~cnt) ~s) bindings conditions false)))
       :map (let [s (if (symbol? value) value (gensym "map"))]
              (vswap! bindings conj [s `(metabase.lib.util.match.impl/map! ~value)])
              (run! (fn [[k v]]
-                     (vswap! conditions conj (with-meta (list `contains? s k) {:depends-on s}))
-                     (process-pattern v (list `get s k) bindings conditions false))
+                     (condp = v
+                       '&truthy (vswap! conditions conj (with-meta (list `get s k) {:depends-on s}))
+                       '_ (vswap! conditions conj (with-meta (list `contains? s k) {:depends-on s}))
+                       (do (vswap! conditions conj (with-meta (list `contains? s k) {:depends-on s}))
+                           (process-pattern v (list `get s k) bindings conditions false))))
                    (:map parsed)))
       :or (let [or-clauses (:clauses parsed)
                 new-body (process-clauses (mapv vector (:clauses parsed) (repeat (count or-clauses) @return)) value nil)]
             (vreset! return (with-meta new-body {:nil-wrapped true})))
+      :and (let [and-clauses (:clauses parsed)]
+             (run! (fn [and-clause] (process-pattern and-clause value bindings conditions return)) and-clauses))
       :guard (let [s (:symbol parsed)
                    s (if (= s '_) (gensym "_") s)
                    ;; Treat symbol, keyword, or set predicates as functions to be called, and thus transform them
@@ -473,9 +483,15 @@
                                   function, keyword, set, or an invocation snippet (but not a lambda). Can optionally
                                   check for collection length.
   - vector - binds positional values inside a sequence against other patterns. Can have & to bind remaining elements.
-  - map - binds associative values inside a map against other patterns.
+  - map - binds associative values inside a map against other patterns. Special symbols can be used as patterns:
+          `&truthy` - matches if the map contains any truthy value for the key
+          `_` - matches if the map contains any value (including `nil`) for the key, but not if key is missing
+          In all other cases, the pattern will attempt to match only if the map contains the key.
   - (:or clause1 clause2 ...) - special syntax for grouping several alternative conditions that share the same
                                 return expression.
+  - (:and pattern1 pattern2 ...) - special syntax for providing multiple restictions on the same match. E.g., you can
+                                   describe the structure with one pattern, and provide a guard predicate for the whole
+                                   match as the second pattern.
   - `_` - matches anything. One usecase for this is to curtail recursive search, thus making the match non-recursive
           (because `_` will always match and its return expression will be returned).
 

--- a/src/metabase/lib/util/match/impl.cljc
+++ b/src/metabase/lib/util/match/impl.cljc
@@ -65,10 +65,10 @@
 
 (defn update-in-unless-empty
   "Like `update-in`, but only updates in the existing value is non-empty."
-  [m ks f & args]
+  [m ks f]
   (if-not (seq (get-in m ks))
     m
-    (apply update-in m ks f args)))
+    (update-in m ks f)))
 
 (defn vector!
   "Return nil if `obj` is not a vector, otherwise return `obj`."

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -56,7 +56,6 @@
   - If your data is coming in watered down by YAML (like strings instead of keywords), take a look at `:coerce`"
   (:refer-clojure :exclude [descendants])
   (:require
-   [clojure.core.match :refer [match]]
    [clojure.set :as set]
    [clojure.string :as str]
    [malli.core :as mc]
@@ -1352,30 +1351,37 @@
 (declare ^:private mbql-deps-map)
 
 (defn- mbql-deps-vector [entity]
-  (match entity
-    [:field     (opts :guard map?) (id :guard vector?)]      (into #{(field->path id)}            (mbql-deps-map opts))
-    ["field"    (opts :guard map?) (id :guard vector?)]      (into #{(field->path id)}            (mbql-deps-map opts))
-    [:metric    (opts :guard map?) (id :guard portable-id?)] (into #{[{:model "Card" :id id}]}    (mbql-deps-map opts))
-    ["metric"   (opts :guard map?) (id :guard portable-id?)] (into #{[{:model "Card" :id id}]}    (mbql-deps-map opts))
-    [:segment   (opts :guard map?) (id :guard portable-id?)] (into #{[{:model "Segment" :id id}]} (mbql-deps-map opts))
-    ["segment"  (opts :guard map?) (id :guard portable-id?)] (into #{[{:model "Segment" :id id}]} (mbql-deps-map opts))
-    [:measure   (opts :guard map?) (id :guard portable-id?)] (into #{[{:model "Measure" :id id}]} (mbql-deps-map opts))
-    ["measure"  (opts :guard map?) (id :guard portable-id?)] (into #{[{:model "Measure" :id id}]} (mbql-deps-map opts))
+  (lib.util.match/match-lite entity
+    [#{:field "field"} (opts :guard map?) (id :guard vector?)]
+    (into #{(field->path id)} (mbql-deps-map opts))
+
+    [(tag :guard #{:metric "metric" :segment "segment" :measure "measure"})
+     (opts :guard map?)
+     (field :guard portable-id?)]
+    (into #{[{:model (case tag
+                       (:metric "metric") "Card"
+                       (:segment "segment") "Segment"
+                       (:measure "measure") "Measure")
+              :id field}]}
+          (mbql-deps-map opts))
+
     ;; legacy (MBQL 4) refs
-    [:field     (id :guard vector?) opts] (into #{(field->path id)} (mbql-deps-map opts))
-    ["field"    (id :guard vector?) opts] (into #{(field->path id)} (mbql-deps-map opts))
-    [:metric    (id :guard portable-id?)] #{[{:model "Card" :id id}]}
-    ["metric"   (id :guard portable-id?)] #{[{:model "Card" :id id}]}
-    [:segment   (id :guard portable-id?)] #{[{:model "Segment" :id id}]}
-    ["segment"  (id :guard portable-id?)] #{[{:model "Segment" :id id}]}
-    [:measure   (id :guard portable-id?)] #{[{:model "Measure" :id id}]}
-    ["measure"  (id :guard portable-id?)] #{[{:model "Measure" :id id}]}
-    :else (reduce #(cond
-                     (map? %2)    (into %1 (mbql-deps-map %2))
-                     (vector? %2) (into %1 (mbql-deps-vector %2))
-                     :else %1)
-                  #{}
-                  entity)))
+    [#{:field "field" :field-id "field-id"} (id :guard vector?) opts]
+    (into #{(field->path id)} (mbql-deps-map opts))
+
+    [(tag :guard #{:metric "metric" :segment "segment" :measure "measure"}) (field :guard portable-id?)]
+    #{[{:model (case tag
+                 (:metric "metric") "Card"
+                 (:segment "segment") "Segment"
+                 (:measure "measure") "Measure")
+        :id field}]}
+
+    _ (reduce #(cond
+                 (map? %2)    (into %1 (mbql-deps-map %2))
+                 (vector? %2) (into %1 (mbql-deps-vector %2))
+                 :else %1)
+              #{}
+              entity)))
 
 (defn- mbql-deps-map [m]
   (into #{}
@@ -1673,13 +1679,7 @@
     [:field-id (*import-field-fk* fully-qualified-name) (import-visualizations opts)]
 
     [#{:field-id "field-id"} (fully-qualified-name :guard vector?)]
-    [:field-id (*import-field-fk* fully-qualified-name)]
-
-    (_ :guard map?)
-    (m/map-vals import-visualizations &match)
-
-    (_ :guard vector?)
-    (mapv import-visualizations &match)))
+    [:field-id (*import-field-fk* fully-qualified-name)]))
 
 (defn- import-column-settings [settings]
   (when settings

--- a/src/metabase/query_permissions/impl.clj
+++ b/src/metabase/query_permissions/impl.clj
@@ -127,28 +127,28 @@
      ;; already legacy MBQL
      (apply merge-with merge-source-ids
             (lib.util.match/match-many query
-              (m :guard (and (map? m) (:qp/stage-is-from-source-card m)))
+              (:and m {:qp/stage-is-from-source-card (id :guard identity)})
               (merge-with merge-source-ids
                           (when-not parent-source-card-id
-                            {:card-ids #{(:qp/stage-is-from-source-card m)}})
-                          (query->source-ids (dissoc m :qp/stage-is-from-source-card) (:qp/stage-is-from-source-card m) in-sandbox?))
+                            {:card-ids #{id}})
+                          (query->source-ids (dissoc m :qp/stage-is-from-source-card) id in-sandbox?))
 
-              (m :guard (and (map? m) (:query-permissions/sandboxed-table m)))
+              (:and m {:query-permissions/sandboxed-table (id :guard identity)})
               (merge-with merge-source-ids
-                          {:table-ids #{(:query-permissions/sandboxed-table m)}}
+                          {:table-ids #{id}}
                           (when-not (or parent-source-card-id in-sandbox?)
-                            {:table-query-ids #{(:query-permissions/sandboxed-table m)}})
+                            {:table-query-ids #{id}})
                           (query->source-ids (dissoc m :query-permissions/sandboxed-table :native) parent-source-card-id true))
 
-              {:native (_ :guard identity)}
+              {:native &truthy}
               (when-not parent-source-card-id
                 {:native? true})
 
-              (m :guard (and (map? m) (pos-int? (:source-table m))))
+              (:and m {:source-table (id :guard pos-int?)})
               (merge-with merge-source-ids
-                          {:table-ids #{(:source-table m)}}
+                          {:table-ids #{id}}
                           (when-not (or parent-source-card-id in-sandbox?)
-                            {:table-query-ids #{(:source-table m)}})
+                            {:table-query-ids #{id}})
                           (query->source-ids (dissoc m :source-table) parent-source-card-id in-sandbox?)))))))
 
 (mu/defn query->source-table-ids

--- a/src/metabase/query_processor/middleware/auto_bucket_datetimes.clj
+++ b/src/metabase/query_processor/middleware/auto_bucket_datetimes.clj
@@ -116,10 +116,10 @@
 
     ;; *  do not autobucket clauses that are updating the time interval
     (lib.util.match/match-lite x
-      [(_tag :guard #{:+ :-})
+      [#{:+ :-}
        _
        [#{:expression :field} _ _]
-       [:interval _ _n (unit :guard #{:minute :hour :second})]]
+       [:interval _ _n #{:minute :hour :second}]]
       true)
     :do-not-bucket-reason/bucket-between-relative-starting-from
 

--- a/src/metabase/query_processor/middleware/auto_parse_filter_values.clj
+++ b/src/metabase/query_processor/middleware/auto_parse_filter_values.clj
@@ -42,9 +42,7 @@
   [_query _path-type _path clause]
   (lib.util.match/match-lite clause
     [:value
-     (opts :guard (let [{:keys [effective-type]} opts]
-                    (and effective-type
-                         (not (isa? effective-type :type/Text)))))
+     (:and opts {:effective-type (et :guard (and et (not (isa? et :type/Text))))})
      (v :guard string?)]
     [:value opts (parse-value-for-base-type v (:effective-type opts))]
 

--- a/src/metabase/query_processor/middleware/binning.clj
+++ b/src/metabase/query_processor/middleware/binning.clj
@@ -101,11 +101,11 @@
        (when (= path-type :lib.walk/stage)
          (lib.util.match/match-lite clause
            ;; first update all the `:binning` options
-           [:field (_opts :guard :binning) _id-or-name]
+           [:field {:binning &truthy} _id-or-name]
            (update-binned-field query path (path->field-id-or-name->filters path) clause)
 
            ;; then do another pass and update `:lib/original-binning` options
-           [:field (_opts :guard :lib/original-binning) _id-or-name]
+           [:field {:lib/original-binning &truthy} _id-or-name]
            (propagate-original-binning query path clause)
 
            _ nil))))))

--- a/src/metabase/query_processor/middleware/optimize_temporal_filters.clj
+++ b/src/metabase/query_processor/middleware/optimize_temporal_filters.clj
@@ -44,7 +44,7 @@
   "Can `temporal-value` clause can be optimized?"
   [temporal-value]
   (lib.util.match/match-lite temporal-value
-    [:relative-datetime _opts (_n :guard #{0 :current})]
+    [:relative-datetime _opts #{0 :current}]
     true
 
     [(_tag :guard #{:absolute-datetime :relative-datetime}) _opts _n _unit]
@@ -57,10 +57,10 @@
   the filter clause they're in?"
   [field temporal-value]
   (lib.util.match/match-lite temporal-value
-    [:relative-datetime _opts (_n :guard #{0 :current})]
+    [:relative-datetime _opts #{0 :current}]
     true
 
-    [(_tag :guard #{:absolute-datetime :relative-datetime}) _opts _n _unit]
+    [#{:absolute-datetime :relative-datetime} _opts _n _unit]
     (let [field-unit (or (lib/raw-temporal-bucket field) :default)
           value-unit (or (lib/raw-temporal-bucket &match) :default)]
       (cond
@@ -115,7 +115,8 @@
      _opts
      [(_offset :guard #{:+ :-})
       _plus_minus_opts
-      (field :guard (and (vector? field) (#{:field :expression} (first field)) (optimizable-expr? field)))
+      (:and [#{:field :expression} & _]
+            (field :guard optimizable-expr?))
       [:interval _interval_opts _n _unit]]
      (temporal-value-1 :guard optimizable-temporal-value?)
      (temporal-value-2 :guard optimizable-temporal-value?)]
@@ -124,7 +125,8 @@
 
     [:between
      _opts
-     (field :guard (and (vector? field) (#{:field :expression} (first field)) (optimizable-expr? field)))
+     (:and [#{:field :expression} & _]
+           (field :guard optimizable-expr?))
      (temporal-value-1 :guard optimizable-temporal-value?)
      (temporal-value-2 :guard optimizable-temporal-value?)]
     (and (field-and-temporal-value-have-compatible-units? field temporal-value-1)

--- a/src/metabase/query_processor/middleware/persistence.clj
+++ b/src/metabase/query_processor/middleware/persistence.clj
@@ -14,9 +14,9 @@
   work, but for now we skip the cache in these cases."
   [query]
   (if (and api/*current-user-id*
-           (or (lib.util.match/match-lite query {:query-permissions/sandboxed-table (_ :guard identity)} true)
+           (or (lib.util.match/match-lite query {:query-permissions/sandboxed-table &truthy} true)
                (perms/impersonation-enforced-for-db? (:database query))))
     (lib.util.match/replace-lite query
-      {:persisted-info/native (_ :guard identity)}
+      {:persisted-info/native &truthy}
       (dissoc &match :persisted-info/native))
     query))

--- a/src/metabase/query_processor/middleware/validate_temporal_bucketing.clj
+++ b/src/metabase/query_processor/middleware/validate_temporal_bucketing.clj
@@ -19,9 +19,8 @@
      query
      (fn [query _path-type path clause]
        (lib.util.match/match-lite clause
-         [:field (opts :guard :temporal-unit) _id-or-name]
-         (let [temporal-unit  (:temporal-unit opts)
-               effective-type (lib.walk/apply-f-for-stage-at-path lib/type-of query path clause)
+         [:field (:and opts {:temporal-unit temporal-unit}) _id-or-name]
+         (let [effective-type (lib.walk/apply-f-for-stage-at-path lib/type-of query path clause)
                valid-units    (lib.temporal-bucket/valid-units-for-type effective-type)]
            (when-not (valid-units temporal-unit)
              (throw (ex-info (tru "Unsupported temporal bucketing: You can''t bucket a {0} Field by {1}."

--- a/test/metabase/lib/util/match_test.cljc
+++ b/test/metabase/lib/util/match_test.cljc
@@ -338,7 +338,7 @@
            (lib.util.match/match-lite "not a vector"
              x (str "fallback: " x))))
   ;; Rest with guard
-  (t/is (= "a=1 b=2 rest=(3 4 5)"
+  (t/is (= "a=1 b=2 rest=[3 4 5]"
            (lib.util.match/match-lite [1 2 3 4 5]
              [a b & (rst :guard (> (count rst) 2))] (str "a=" a " b=" b " rest=" rst))))
 
@@ -375,6 +375,47 @@
                  (:or [(a :guard even?) b]
                       [b a])
                  b)))))
+
+(t/deftest ^:parallel match-lite-and-syntax
+  (t/is (= 10 (lib.util.match/match-lite [1 2 3]
+                (:and [a b c] (_ :guard vector?)) (* a 10))))
+  (t/is (= nil (lib.util.match/match-lite [1 2 3]
+                 (:and [a b c] (_ :guard map?)) (* a 10))))
+  (t/is (= nil (lib.util.match/match-lite [1 2 3]
+                 (:and [a b] (_ :guard vector?)) (* a 10))))
+  (t/is (= 6 (lib.util.match/match-lite [1 2 3]
+               (:and [a b c] (v :guard vector?)) (reduce * 1 v))))
+  (t/testing "later patterns can refer to earlier bindings"
+    (t/is (= 20 (lib.util.match/match-lite [1 2 3]
+                  (:and [a b c]
+                        (_ :guard (and (odd? a) (even? b))))
+                  (* a b 10))))))
+
+(t/deftest ^:parallel match-lite-map-syntax
+  (t/is (= 200 (lib.util.match/match-lite {:a 10, :b 20}
+                 {:a a, :b b} (* a b))))
+  (t/is (= nil (lib.util.match/match-lite {:a 10}
+                 {:a a, :b b} (* a b))))
+  (t/testing "&truthy"
+    (t/is (= 123 (lib.util.match/match-lite {:a 10}
+                   {:a &truthy} 123)))
+    (t/is (= nil (lib.util.match/match-lite {:b 20}
+                   {:a &truthy} 123)))
+    (t/is (= 123 (lib.util.match/match-lite {:a true}
+                   {:a &truthy} 123)))
+    (t/is (= nil (lib.util.match/match-lite {:a false}
+                   {:a &truthy} 123)))
+    (t/is (= nil (lib.util.match/match-lite {:a nil}
+                   {:a &truthy} 123))))
+  (t/testing "_"
+    (t/is (= 123 (lib.util.match/match-lite {:a 10}
+                   {:a _} 123)))
+    (t/is (= nil (lib.util.match/match-lite {:b 20}
+                   {:a _} 123)))
+    (t/is (= 123 (lib.util.match/match-lite {:a true}
+                   {:a _} 123)))
+    (t/is (= 123 (lib.util.match/match-lite {:a false}
+                   {:a _} 123)))))
 
 (t/deftest ^:parallel same-result-with-different-bindings-test
   (t/testing "result here should not be treated as a common because it refers to different bindings in branches"

--- a/test/metabase/xrays/automagic_dashboards/core_test.clj
+++ b/test/metabase/xrays/automagic_dashboards/core_test.clj
@@ -624,7 +624,7 @@
                             :when    query
                             :let     [breakouts (lib/breakouts query)]
                             id       (lib.util.match/match-many breakouts
-                                       [:field {:binning _} (id :guard pos-int?)]
+                                       [:field {:binning &truthy} (id :guard pos-int?)]
                                        id)]
                         id)))))))))))
 
@@ -658,7 +658,7 @@
                                            :when    query
                                            :let     [breakouts (lib/breakouts query)]
                                            id       (lib.util.match/match-many breakouts
-                                                      [:field {:temporal-unit _} (id :guard pos-int?)]
+                                                      [:field {:temporal-unit &truthy} (id :guard pos-int?)]
                                                       id)]
                                        id)]
               (ensure-single-table-sourced (mt/id :products) dashboard)


### PR DESCRIPTION
Re-introduce `:and` syntax to match-lite (`match` also had it but it worked differently). `:and` allows, for example, matching a structure and capturing the whole expression into a variable with a guard.

Also, add special patterns for map value matching – `_` and `&truthy`.