### PR TITLE
lock a card display type for the VisualizationCard

### DIFF
--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/DefaultLensSections/components/VisualizationCard.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/DefaultLensSections/components/VisualizationCard.tsx
@@ -132,6 +132,7 @@ function buildRawSeries(
       card: createMockCard({
         name: card.title,
         display: vizDisplay,
+        displayIsLocked: true,
         dataset_query: card.dataset_query,
         visualization_settings: {
           "graph.y_axis.labels_enabled": false,


### PR DESCRIPTION
### Description
Restore a change that was gone due to git/cmd-Z issue in the Transform Inspector