### PR TITLE
Add diagnostic logging for duplicate alert investigation

### DIFF
--- a/resources/quartz.properties
+++ b/resources/quartz.properties
@@ -18,12 +18,6 @@ org.quartz.jobStore.dataSource = db
 org.quartz.jobStore.isClustered = true
 # Added to see if we can prevent multiple firings (which should never happen). Source https://www.quartz-scheduler.org/documentation/quartz-1.8.6/configuration/ConfigJDBCJobStoreClustering.html
 org.quartz.jobStore.clusterCheckinInterval = 20000
-# Acquire the TRIGGER_ACCESS lock before selecting triggers to fire.
-# Without this, trigger acquisition runs without a lock, relying on an optimistic
-# UPDATE to prevent duplicate firing across cluster nodes. This has been observed
-# to fail in practice (GDGT-1833), likely due to interactions between autocommit
-# and Quartz's commit/retry logic.
-org.quartz.jobStore.acquireTriggersWithinLock = true
 
 # By default, Quartz will fire triggers up to a minute late without considering them to be misfired; if it cannot fire
 # anything within that period for one reason or another (such as all threads in the thread pool being tied up), the

--- a/resources/quartz.properties
+++ b/resources/quartz.properties
@@ -18,6 +18,12 @@ org.quartz.jobStore.dataSource = db
 org.quartz.jobStore.isClustered = true
 # Added to see if we can prevent multiple firings (which should never happen). Source https://www.quartz-scheduler.org/documentation/quartz-1.8.6/configuration/ConfigJDBCJobStoreClustering.html
 org.quartz.jobStore.clusterCheckinInterval = 20000
+# Acquire the TRIGGER_ACCESS lock before selecting triggers to fire.
+# Without this, trigger acquisition runs without a lock, relying on an optimistic
+# UPDATE to prevent duplicate firing across cluster nodes. This has been observed
+# to fail in practice (GDGT-1833), likely due to interactions between autocommit
+# and Quartz's commit/retry logic.
+org.quartz.jobStore.acquireTriggersWithinLock = true
 
 # By default, Quartz will fire triggers up to a minute late without considering them to be misfired; if it cannot fire
 # anything within that period for one reason or another (such as all threads in the thread pool being tied up), the

--- a/src/metabase/notification/task/send.clj
+++ b/src/metabase/notification/task/send.clj
@@ -159,11 +159,23 @@
   SendNotification
   [context]
   (let [{:strs [subscription-id]} (qc/from-job-data context)
-        fire-instance-id          (.getFireInstanceId ^JobExecutionContext context)
-        scheduler-instance-id     (.. ^JobExecutionContext context getScheduler getSchedulerInstanceId)]
-    (log/with-context {:quartz-fire-instance-id   fire-instance-id
-                       :quartz-scheduler-instance scheduler-instance-id}
-      (log/infof "SendNotification fired for subscription %d" subscription-id)
+        ^JobExecutionContext ctx  context
+        scheduled-fire-time       (.getScheduledFireTime ctx)
+        fire-time                 (.getFireTime ctx)
+        fire-instance-id          (.getFireInstanceId ctx)
+        recovering?               (.isRecovering ctx)
+        refire-count              (.getRefireCount ctx)
+        trigger-key               (.. ctx getTrigger getKey getName)
+        scheduler-id              (.. ctx getScheduler getSchedulerInstanceId)]
+    (log/with-context {:quartz-fire-instance-id    fire-instance-id
+                       :quartz-scheduled-fire-time (str scheduled-fire-time)
+                       :quartz-fire-time           (str fire-time)
+                       :quartz-recovering          recovering?
+                       :quartz-refire-count        refire-count
+                       :quartz-trigger-key         trigger-key
+                       :quartz-scheduler-id        scheduler-id}
+      (log/infof "SendNotification fired for subscription %d (trigger=%s, scheduled=%s, actual=%s, recovering=%s, refire=%d, scheduler=%s)"
+                 subscription-id trigger-key scheduled-fire-time fire-time recovering? refire-count scheduler-id)
       (send-notification* subscription-id))))
 
 (defn init-send-notification-triggers!

--- a/src/metabase/pulse/task/send_pulses.clj
+++ b/src/metabase/pulse/task/send_pulses.clj
@@ -23,7 +23,7 @@
    [toucan2.core :as t2])
   (:import
    (java.util TimeZone)
-   (org.quartz CronTrigger DisallowConcurrentExecution TriggerKey)))
+   (org.quartz CronTrigger DisallowConcurrentExecution JobExecutionContext TriggerKey)))
 
 (set! *warn-on-reflection* true)
 
@@ -152,8 +152,13 @@
 (task/defjob ^{:doc "Triggers that send a pulse to a list of channels at a specific time"}
   SendPulse
   [context]
-  (let [{:strs [pulse-id channel-ids]} (qc/from-job-data context)]
-    (send-pulse!* pulse-id channel-ids)))
+  (let [{:strs [pulse-id channel-ids]} (qc/from-job-data context)
+        fire-instance-id          (.getFireInstanceId ^JobExecutionContext context)
+        scheduler-instance-id     (.. ^JobExecutionContext context getScheduler getSchedulerInstanceId)]
+    (log/with-context {:quartz-fire-instance-id   fire-instance-id
+                       :quartz-scheduler-instance scheduler-instance-id}
+      (log/infof "SendPulse fired for pulse %d" pulse-id)
+      (send-pulse!* pulse-id channel-ids))))
 
 (declare update-send-pulse-trigger-if-needed!)
 

--- a/src/metabase/pulse/task/send_pulses.clj
+++ b/src/metabase/pulse/task/send_pulses.clj
@@ -153,11 +153,23 @@
   SendPulse
   [context]
   (let [{:strs [pulse-id channel-ids]} (qc/from-job-data context)
-        fire-instance-id          (.getFireInstanceId ^JobExecutionContext context)
-        scheduler-instance-id     (.. ^JobExecutionContext context getScheduler getSchedulerInstanceId)]
-    (log/with-context {:quartz-fire-instance-id   fire-instance-id
-                       :quartz-scheduler-instance scheduler-instance-id}
-      (log/infof "SendPulse fired for pulse %d" pulse-id)
+        ^JobExecutionContext ctx  context
+        scheduled-fire-time       (.getScheduledFireTime ctx)
+        fire-time                 (.getFireTime ctx)
+        fire-instance-id          (.getFireInstanceId ctx)
+        recovering?               (.isRecovering ctx)
+        refire-count              (.getRefireCount ctx)
+        trigger-key               (.. ctx getTrigger getKey getName)
+        scheduler-id              (.. ctx getScheduler getSchedulerInstanceId)]
+    (log/with-context {:quartz-fire-instance-id    fire-instance-id
+                       :quartz-scheduled-fire-time (str scheduled-fire-time)
+                       :quartz-fire-time           (str fire-time)
+                       :quartz-recovering          recovering?
+                       :quartz-refire-count        refire-count
+                       :quartz-trigger-key         trigger-key
+                       :quartz-scheduler-id        scheduler-id}
+      (log/infof "SendPulse fired for pulse %d (trigger=%s, scheduled=%s, actual=%s, recovering=%s, refire=%d, scheduler=%s)"
+                 pulse-id trigger-key scheduled-fire-time fire-time recovering? refire-count scheduler-id)
       (send-pulse!* pulse-id channel-ids))))
 
 (declare update-send-pulse-trigger-if-needed!)


### PR DESCRIPTION
Adds Quartz execution context logging to SendNotification and SendPulse jobs to diagnose duplicate alerts sent from multiple pods (GDGT-1833).

What we looked at

- Quartz's optimistic trigger acquisition should prevent this via UPDATE ... WHERE state='WAITING' — PostgreSQL row locking means only one pod should succeed. Somehow both do.
- ABA problem (quartz#107) — possible but timing doesn't clearly match
- Cluster recovery during scale-up — ruled out, shutdown is clean
- acquireTriggersWithinLock=true — might help but Quartz docs say it's unnecessary for our config, and we don't want to ship a fix we don't understand
- c3p0 DISCARD ALL on connection check-in — runs after Quartz commits, probably not the cause

What this adds

Logs scheduled-fire-time, fire-time, fire-instance-id, recovering, refire-count, trigger-key, and scheduler-id on every job fire. These propagate through the whole notification pipeline via
log/with-context.

Let's deploy this and based on our logs we can check if:

- Same scheduled-fire-time + different fire-instance-id → Quartz double-acquired, try acquireTriggersWithinLock=true
- recovering=true on one fire → cluster recovery issue during scale-up
- Different scheduled-fire-time → ABA problem, need acquireTriggersWithinLock=true or app-level dedup
- refire-count > 0 → job retry, not a clustering issue