### PR TITLE
Fix PR envs cleaning

### DIFF
--- a/.github/workflows/pr-env-close-unlabel.yml
+++ b/.github/workflows/pr-env-close-unlabel.yml
@@ -5,8 +5,8 @@ on:
     types: [ closed, unlabeled ]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
 
 jobs:
   pr-env:

--- a/.github/workflows/pr-env-destroy-manual.yml
+++ b/.github/workflows/pr-env-destroy-manual.yml
@@ -1,0 +1,29 @@
+name: PR Env Destroy (Manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to destroy environment for'
+        required: true
+        type: string
+      self_hosting:
+        description: 'Self-hosting stack'
+        type: boolean
+        default: false
+
+jobs:
+  approve:
+    runs-on: ubuntu-latest
+    environment: pr-env-admin
+    steps:
+      - name: Approved
+        run: echo "Destroying PR environment for PR #${{ inputs.pr_number }}"
+
+  destroy:
+    needs: approve
+    uses: ./.github/workflows/pr-env-destroy.yml
+    secrets: inherit
+    with:
+      self_hosting: ${{ inputs.self_hosting }}
+      pr_number: ${{ inputs.pr_number }}

--- a/.github/workflows/pr-env-destroy.yml
+++ b/.github/workflows/pr-env-destroy.yml
@@ -9,6 +9,13 @@ on:
         required: false
         type: boolean
         default: false
+      pr_number:
+        description: 'PR number (required for manual dispatch)'
+        required: false
+        type: string
+
+env:
+  PR_NUMBER: ${{ inputs.pr_number || github.event.number }}
 
 jobs:
   destroy_pr:
@@ -62,8 +69,8 @@ jobs:
       - name: Destroy PR Review ENV
         if: ${{ !inputs.self_hosting }}
         run: |
-          kubectl delete metabase -n hosting-pr${{ github.event.number }} hosting-pr${{ github.event.number }}
-          kubectl delete ns hosting-pr${{ github.event.number }}
+          kubectl delete metabase -n hosting-pr${{ env.PR_NUMBER }} hosting-pr${{ env.PR_NUMBER }}
+          kubectl delete ns hosting-pr${{ env.PR_NUMBER }}
       - name: Setup Helm
         if: ${{ inputs.self_hosting }}
         uses: azure/setup-helm@v4
@@ -72,8 +79,8 @@ jobs:
       - name: Destroy PR Review ENV (self-hosting)
         if: ${{ inputs.self_hosting }}
         run: |
-          helm uninstall hosting-pr${{ github.event.number }} --namespace hosting-pr${{ github.event.number }} || true
-          kubectl delete ns hosting-pr${{ github.event.number }} || true
+          helm uninstall hosting-pr${{ env.PR_NUMBER }} --namespace hosting-pr${{ env.PR_NUMBER }} || true
+          kubectl delete ns hosting-pr${{ env.PR_NUMBER }} || true
       - name: Setup psql client
         run: |
           sudo apt-get update
@@ -85,4 +92,4 @@ jobs:
           -h ${{ secrets.PR_ENV_DB_HOST }} \
           -U ${{ secrets.PR_ENV_DB_USER }} \
           -d ${{ secrets.PR_ENV_DB_NAME }} \
-          -c "DROP DATABASE IF EXISTS hosting_pr${{ github.event.number }};"
+          -c "DROP DATABASE IF EXISTS hosting_pr${{ env.PR_NUMBER }};"


### PR DESCRIPTION
We have a [problem with cleaning PR envs](https://github.com/metabase/metabase/actions/workflows/pr-env-close-unlabel.yml) when > 1 PRs are closed or unlabeled at about the same time.

The root issue here is the fact that the concurrent group for the PR is a ref which is a destination of the PR (mostly head) which cause cancelling of cleaning for all the PRs in the group except last one. 

Changing the concurrency group to the PR number instead of ref and disabling a mechanism of cancel-in-progress of those group prevents from failed cleanings and cancelling cleaning jobs in the middle of the process.

Also, we have PR envs which created for PRs which merge to non-master branch. In this case automatic cleaning will not run. We cannot allow to automatically run this job because of security risks, so I added a protected environment (cloud and devex are admins) with approve requirement and a manual dispatch job which will allow to manually trigger cleaning for those PRs.