### PR TITLE
Only switch to full-width native preview at small breakpoint

### DIFF
--- a/e2e/test/scenarios/question-reproductions/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/question-reproductions/reproductions.cy.spec.ts
@@ -1489,7 +1489,7 @@ describe("issue 66210", () => {
 
 describe("issue #67903", () => {
   beforeEach(() => {
-    cy.viewport(1000, 800);
+    cy.viewport(630, 800);
     H.restore();
     cy.signInAsAdmin();
   });
@@ -1501,6 +1501,29 @@ describe("issue #67903", () => {
     H.getNotebookStep("data").findByTestId("step-preview-button").click();
     H.queryBuilderHeader().findByLabelText("View SQL").click();
     cy.findByTestId("table-header").should("not.be.visible");
+  });
+});
+
+describe("issue #67767", () => {
+  const SCREEN_WIDTH = 630;
+
+  beforeEach(() => {
+    cy.viewport(SCREEN_WIDTH, 800);
+    H.restore();
+    cy.signInAsAdmin();
+  });
+
+  it("only show preview query at full width on small screens (metabase#67767)", () => {
+    H.startNewQuestion();
+    H.miniPickerBrowseAll().click();
+    H.pickEntity({ path: ["Databases", /Sample Database/, "Orders"] });
+    H.getNotebookStep("data").findByTestId("step-preview-button").click();
+    H.queryBuilderHeader().findByLabelText("View SQL").click();
+    H.sidebar()
+      .findByText("SQL for this question")
+      .then(($el) => {
+        expect($el.get(0).scrollWidth).to.eq(SCREEN_WIDTH);
+      });
   });
 });
 

--- a/frontend/src/metabase/query_builder/components/view/View/NotebookContainer/NotebookContainer.tsx
+++ b/frontend/src/metabase/query_builder/components/view/View/NotebookContainer/NotebookContainer.tsx
@@ -4,12 +4,12 @@ import type { ResizableBoxProps, ResizeCallbackData } from "react-resizable";
 import { ResizableBox } from "react-resizable";
 import { useWindowSize } from "react-use";
 
+import { useIsSmallScreen } from "metabase/common/hooks/use-is-small-screen";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import {
   setNotebookNativePreviewSidebarWidth,
   setUIControls,
 } from "metabase/query_builder/actions";
-import { useNotebookScreenSize } from "metabase/query_builder/hooks/use-notebook-screen-size";
 import { getUiControls } from "metabase/query_builder/selectors";
 import {
   Notebook,
@@ -82,7 +82,7 @@ export const NotebookContainer = ({
     dispatch(setNotebookNativePreviewSidebarWidth(width));
   };
 
-  const screenSize = useNotebookScreenSize();
+  const shouldShowFullWidthNativePreview = useIsSmallScreen();
   const transformStyle = isOpen ? "translateY(0)" : "translateY(-100%)";
 
   const Handle = forwardRef<
@@ -151,15 +151,13 @@ export const NotebookContainer = ({
         </Box>
       )}
 
-      {renderNativePreview && screenSize && (
+      {renderNativePreview && (
         <>
-          {screenSize === "small" && (
+          {shouldShowFullWidthNativePreview ? (
             <Box pos="absolute" inset={0}>
               <NotebookNativePreview />
             </Box>
-          )}
-
-          {screenSize === "large" && (
+          ) : (
             <ResizableBox
               width={sidebarWidth}
               minConstraints={[minSidebarWidth, 0]}


### PR DESCRIPTION
Closes #67767 

Uses the small window breakpoint for the sidebar to go to full-width.