### PR TITLE
BOT-1039 Add snowplow token_usage event tracking to the clojure agent

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/agent/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/agent/core.clj
@@ -200,7 +200,7 @@
                    :tools     (mapv (fn [[name _]] name) tools)}))
     (eduction (streaming/post-process-xf (get-in memory [:state :queries] {})
                                          (get-in memory [:state :charts] {}))
-              (self/call-llm model "agent" (:content system-msg) input-parts tools tracking-opts))))
+              (self/call-llm model (:content system-msg) input-parts tools tracking-opts))))
 
 ;;; Memory management
 

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/agent/profiles.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/agent/profiles.clj
@@ -33,6 +33,7 @@
   "Register new profile configuration.
 
   Each profile includes:
+  - :name - Keyword identifier for the profile (e.g. :internal)
   - :prompt-template - Selmer template name from resources/metabot/prompts/system/
   - :max-iterations - Maximum agent loop iterations
   - :temperature - LLM temperature setting
@@ -40,22 +41,23 @@
 
   Note: `:model` is resolved at runtime from the `ee-ai-metabot-provider` setting
   (see [[get-profile]]), not stored in the profile."
-  [name profile :- [:map
-                    [:prompt-template :string]
-                    [:max-iterations :int]
-                    [:temperature :float]
-                    [:tools [:vector :any]]]]
+  [profile :- [:map
+               [:name :keyword]
+               [:prompt-template :string]
+               [:max-iterations :int]
+               [:temperature :float]
+               [:tools [:vector :any]]]]
   (when-not (apply distinct? (map #(:tool-name (meta %)) (:tools profile)))
     (let [dups (->> (frequencies (map #(:tool-name (meta %)) (:tools profile)))
                     (filter (fn [[_ cnt]] (< 1 cnt))))]
       (throw (ex-info "Duplicate tool names in profile" {:tool-names (map first dups)}))))
   (doseq [tool (:tools profile)]
     (validate-tool-definition! tool))
-  (swap! *profiles assoc name profile))
+  (swap! *profiles assoc (:name profile) profile))
 
 (register-profile!
- :embedding_next
- {:prompt-template "embedding-next.selmer"
+ {:name            :embedding_next
+  :prompt-template "embedding-next.selmer"
   :max-iterations  10
   :temperature     0.3
   :tools           [#'agent-tools/construct-notebook-query-tool
@@ -63,8 +65,8 @@
                     #'agent-tools/list-available-data-sources-tool]})
 
 (register-profile!
- :internal
- {:prompt-template "internal.selmer"
+ {:name            :internal
+  :prompt-template "internal.selmer"
   :max-iterations  10
   :temperature     0.3
   :tools           [#'agent-tools/search-tool
@@ -81,8 +83,8 @@
                     #'agent-tools/find-outliers-tool]})
 
 (register-profile!
- :transforms_codegen
- {:prompt-template "transform-codegen.selmer"
+ {:name            :transforms_codegen
+  :prompt-template "transform-codegen.selmer"
   :max-iterations  30
   :temperature     0.3
   :tools           [#'agent-tools/transform-search-tool
@@ -98,8 +100,8 @@
                     #'agent-tools/todo-read-tool]})
 
 (register-profile!
- :sql
- {:prompt-template     "sql-querying-only.selmer"
+ {:name                :sql
+  :prompt-template     "sql-querying-only.selmer"
   :max-iterations      10
   :temperature         0.3
   :required-tool-call? true
@@ -111,8 +113,8 @@
                         #'agent-tools/ask-for-sql-clarification-tool]})
 
 (register-profile!
- :nlq
- {:prompt-template "natural-language-querying-only.selmer"
+ {:name            :nlq
+  :prompt-template "natural-language-querying-only.selmer"
   :max-iterations  10
   :temperature     0.3
   :tools           [#'agent-tools/nlq-search-tool
@@ -123,8 +125,8 @@
                     #'agent-tools/edit-chart-tool]})
 
 (register-profile!
- :document-generate-content
- {:prompt-template "document-generate-content.selmer"
+ {:name            :document-generate-content
+  :prompt-template "document-generate-content.selmer"
   :max-iterations  10
   :temperature     0.3
   :required-tool-call? true

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api.clj
@@ -174,10 +174,11 @@
           (transduce xf
                      (streaming-writer-rf os canceled-chan)
                      (agent/run-agent-loop
-                      (cond-> {:messages   messages
-                               :state      state
-                               :profile-id (keyword profile-id)
-                               :context    enriched-context}
+                      (cond-> {:messages         messages
+                               :state            state
+                               :profile-id       (keyword profile-id)
+                               :context          enriched-context
+                               :conversation-id  conversation-id}
                         debug? (assoc :debug? true))))
           (catch org.eclipse.jetty.io.EofException _
             (log/debug "Client disconnected during native agent streaming"))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/document.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/document.clj
@@ -114,11 +114,12 @@
                  (metabot-v3.context/create-context {:capabilities #{"permission:write_sql_queries"}})
                  :references references)
         parts (into [] (metabot-v3.agent/run-agent-loop
-                        {:messages   [{:role :user
-                                       :content instructions}]
-                         :profile-id :document-generate-content
-                         :state      {}
-                         :context    context}))
+                        {:messages      [{:role :user
+                                          :content instructions}]
+                         :profile-id    :document-generate-content
+                         :state         {}
+                         :context       context
+                         :tracking-opts {:source "document_generate_content"}}))
         chart-output (latest-chart-structured-output parts)
         draft-card (draft-card-from-chart-output chart-output)
         description (or (:description chart-output)

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/example_question_generator.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/example_question_generator.clj
@@ -106,7 +106,6 @@
   [rendered-prompt]
   (self/call-llm-structured
    (llm/ee-ai-metabot-provider)
-   "example-question-generation"
    [{:role "user" :content rendered-prompt}]
    questions-json-schema
    temperature

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/example_question_generator.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/example_question_generator.clj
@@ -110,7 +110,11 @@
    [{:role "user" :content rendered-prompt}]
    questions-json-schema
    temperature
-   300))
+   300
+   {:request-id (str (random-uuid))
+    ;; example_question_generation_batch was the name of the old ai-service api endpoint
+    :source     "example_question_generation_batch"
+    :tag        "example-question-generation"}))
 
 ;;; Per-item generation (mirrors Python generate_table_example_questions / generate_metric_example_questions)
 

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/self.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/self.clj
@@ -149,7 +149,7 @@
                (prometheus/inc! :metabase-metabot/llm-input-tokens labels prompt)
                (prometheus/inc! :metabase-metabot/llm-output-tokens labels completion)
                (prometheus/observe! :metabase-metabot/llm-tokens-per-call labels (+ prompt completion))
-               ;; The caller can omit snowplot opts to skip snowplow tracking.
+               ;; The caller can omit snowplow opts to skip snowplow tracking.
                (when request-id
                  (analytics/track-event! :snowplow/token_usage
                                          {:hashed_metabase_license_token (hashed-token-or-uuid)

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/self.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/self.clj
@@ -121,8 +121,8 @@
   (map (fn [part]
          (when (= (:type part) :error)
            (prometheus/inc! :metabase-metabot/llm-errors
-                            {:model      (:model tracking-opts)
-                             :source     (:tag tracking-opts)
+                            {:model      (:model tracking-opts "unknown")
+                             :source     (:tag tracking-opts "none")
                              :error-type "llm-sse-error"}))
          part)))
 

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/self.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/self.clj
@@ -138,7 +138,8 @@
   "Transducer that reports prometheus metrics and snowplow token_usage event
   for :usage parts in the aisdk stream."
   [{:keys [model profile-name request-id session-id source tag]}]
-  (let [start-ms (u/start-timer)]
+  (let [start-ms      (u/start-timer)
+        token-or-uuid (hashed-token-or-uuid)]
     (map (fn [part]
            (when (= (:type part) :usage)
              (let [usage      (:usage part)
@@ -152,7 +153,7 @@
                ;; The caller can omit snowplow opts to skip snowplow tracking.
                (when request-id
                  (analytics/track-event! :snowplow/token_usage
-                                         {:hashed_metabase_license_token (hashed-token-or-uuid)
+                                         {:hashed_metabase_license_token token-or-uuid
                                           :user_id                       api/*current-user-id*
                                           :model_id                      model
                                           :duration_ms                   (long (u/since-ms start-ms))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/self.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/self.clj
@@ -209,15 +209,18 @@
   and user messages (`{:role :user, :content ...}`).  Each adapter converts
   these into its own wire format.
 
-  `tracking-opts` is a map with analytics context. `:model` and `:tag` drive
-  Prometheus labels (`:tag` maps to the `:source` label). When non-empty,
-  also fires a `:snowplow/token_usage` event for each `:usage` part:
-    - `:model`        — model identifier, added automatically from the `model` arg
-    - `:tag`          — Prometheus source label + Snowplow tag (e.g. `\"agent\"`)
-    - `:source`       — Snowplow-only source string (e.g. `\"metabot_agent\"`)
+  `tracking-opts` is a map with analytics context for prometheus and snowplow events.
+
+   Prometheus + Snowplow:
     - `:profile-name` — keyword profile identifier (e.g. `:internal`)
-    - `:request-id`   — UUID string for this agent request
+    - `:model`        — model identifier, added automatically from the `model` arg.
+    - `:tag`          — the specific purpose for which the tokens were used (e.g. 'agent', 'sql-fixing')
+
+   Snowplow only:
+    - `:request-id`   — UUID string for this request
     - `:session-id`   — conversation UUID string
+    - `:source`       — the source of the request (e.g., 'metabot_agent', 'document_generate_content').
+                        Indicates which API endpoint or workflow initiated the LLM call.
 
   Returns a reducible that, when consumed, traces the full LLM round-trip
   (HTTP call + streaming response) as an OTel span. Retries transient errors

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/agent/profiles_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/agent/profiles_test.clj
@@ -11,6 +11,7 @@
     (testing "retrieves embedding_next profile with default provider"
       (let [profile (profiles/get-profile :embedding_next)]
         (is (some? profile))
+        (is (= :embedding_next (:name profile)))
         (is (= "openrouter/anthropic/claude-haiku-4-5" (:model profile)))
         (is (= 10 (:max-iterations profile)))
         (is (= 0.3 (:temperature profile)))
@@ -21,6 +22,7 @@
     (testing "retrieves internal profile with default provider"
       (let [profile (profiles/get-profile :internal)]
         (is (some? profile))
+        (is (= :internal (:name profile)))
         (is (= "openrouter/anthropic/claude-haiku-4-5" (:model profile)))
         (is (= 10 (:max-iterations profile)))
         (is (= 0.3 (:temperature profile)))
@@ -34,6 +36,7 @@
     (testing "retrieves transforms_codegen profile"
       (let [profile (profiles/get-profile :transforms_codegen)]
         (is (some? profile))
+        (is (= :transforms_codegen (:name profile)))
         (is (= "openrouter/anthropic/claude-haiku-4-5" (:model profile)))
         (is (= 30 (:max-iterations profile)))
         (is (= 0.3 (:temperature profile)))
@@ -45,6 +48,7 @@
     (testing "retrieves sql profile"
       (let [profile (profiles/get-profile :sql)]
         (is (some? profile))
+        (is (= :sql (:name profile)))
         (is (= "openrouter/anthropic/claude-haiku-4-5" (:model profile)))
         (is (= 10 (:max-iterations profile)))
         (is (= 0.3 (:temperature profile)))
@@ -54,6 +58,7 @@
     (testing "retrieves nlq profile"
       (let [profile (profiles/get-profile :nlq)]
         (is (some? profile))
+        (is (= :nlq (:name profile)))
         (is (= "openrouter/anthropic/claude-haiku-4-5" (:model profile)))
         (is (= 10 (:max-iterations profile)))
         (is (= 0.3 (:temperature profile)))
@@ -66,6 +71,7 @@
     (testing "all profiles have required keys"
       (doseq [profile-id [:embedding_next :internal :transforms_codegen :sql :nlq]]
         (let [profile (profiles/get-profile profile-id)]
+          (is (= profile-id (:name profile)))
           (is (contains? profile :model))
           (is (contains? profile :max-iterations))
           (is (contains? profile :temperature))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api/document_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api/document_test.clj
@@ -1,0 +1,66 @@
+(ns metabase-enterprise.metabot-v3.api.document-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase-enterprise.metabot-v3.self.openrouter :as openrouter]
+   [metabase-enterprise.metabot-v3.test-util :as mut]
+   [metabase.analytics.core :as analytics]
+   [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]))
+
+(set! *warn-on-reflection* true)
+
+(use-fixtures :once (fixtures/initialize :db :test-users))
+
+(deftest native-generate-content-prometheus-test
+  (mt/with-premium-features #{:metabot-v3}
+    (mt/with-prometheus-system! [_ system]
+      (with-redefs [openrouter/openrouter
+                    (fn [_]
+                      (mut/mock-llm-response
+                       [{:type :start :id "msg-1"}
+                        {:type :text :text "No chart available"}
+                        {:type :usage :usage {:promptTokens 100 :completionTokens 20}
+                         :model "test-model" :id "msg-1"}]))]
+        (mt/user-http-request :crowberto
+                              :post 200 "ee/metabot-v3/document/native-generate-content"
+                              {:instructions "Show me sales data"}))
+      (is (== 1 (mt/metric-value system :metabase-metabot/agent-requests
+                                 {:profile-id "document-generate-content"})))
+      (is (== 1 (:sum (mt/metric-value system :metabase-metabot/agent-iterations
+                                       {:profile-id "document-generate-content"}))))
+      (is (== 1 (mt/metric-value system :metabase-metabot/llm-requests
+                                 {:model "anthropic/claude-haiku-4-5" :source "agent"})))
+      (is (== 100 (mt/metric-value system :metabase-metabot/llm-input-tokens
+                                   {:model "test-model" :source "agent"})))
+      (is (== 20 (mt/metric-value system :metabase-metabot/llm-output-tokens
+                                  {:model "test-model" :source "agent"}))))))
+
+(deftest native-generate-content-snowplow-test
+  (mt/with-premium-features #{:metabot-v3}
+    (let [events   (atom [])
+          rasta-id (mt/user->id :rasta)]
+      (with-redefs [openrouter/openrouter
+                    (fn [_]
+                      (mut/mock-llm-response
+                       [{:type :start :id "msg-1"}
+                        {:type :text :text "No chart available"}
+                        {:type :usage :usage {:promptTokens 100 :completionTokens 20}
+                         :model "test-model" :id "msg-1"}]))
+                    analytics/track-event! (fn [schema data & _]
+                                             (swap! events conj {:schema schema :data data}))]
+        (mt/with-current-user rasta-id
+          (mt/user-http-request :rasta
+                                :post 200 "ee/metabot-v3/document/native-generate-content"
+                                {:instructions "Show me sales data"})))
+      (is (=? [{:schema :snowplow/token_usage
+                :data   {:hashed_metabase_license_token string?
+                         :user_id                       rasta-id
+                         :model_id                      "test-model"
+                         :total_tokens                  120
+                         :prompt_tokens                 100
+                         :completion_tokens             20
+                         :estimated_costs_usd           0.0
+                         :source                        "document_generate_content"
+                         :tag                           "agent"
+                         :request_id                    string?}}]
+              @events)))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/self_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/self_test.clj
@@ -534,7 +534,7 @@
       (let [labels {:model "test-model" :source "agent"}]
         (testing "increments llm-requests and observes duration on success"
           (with-redefs [openrouter/openrouter (constantly (test-util/mock-llm-response [{:type :start :id "m1"}]))]
-            (run! identity (self/call-llm "openrouter/test-model" "agent" nil [] {})))
+            (run! identity (self/call-llm "openrouter/test-model" "agent" nil [] {} {})))
           (is (== 1 (mt/metric-value system :metabase-metabot/llm-requests labels)))
           (is (== 0 (mt/metric-value system :metabase-metabot/llm-retries labels)))
           (is (== 0 (mt/metric-value system :metabase-metabot/llm-errors
@@ -555,7 +555,7 @@
                                   (if (< (swap! calls inc) 3)
                                     (throw (ex-info "rate limited" {:status 429}))
                                     (reduce rf init (test-util/mock-llm-response [{:type :start :id "m1"}]))))))]
-                (run! identity (self/call-llm "openrouter/test-model" "agent" nil [] {}))))
+                (run! identity (self/call-llm "openrouter/test-model" "agent" nil [] {} {}))))
             (is (== 3 (mt/metric-value system :metabase-metabot/llm-requests labels)))
             (is (== 2 (mt/metric-value system :metabase-metabot/llm-retries labels)))
             (is (== 0 (mt/metric-value system :metabase-metabot/llm-errors
@@ -572,7 +572,7 @@
                           (reify clojure.lang.IReduceInit
                             (reduce [_ _rf _init]
                               (throw (ex-info "unauthorized" {:status 401})))))]
-            (is (thrown? Exception (run! identity (self/call-llm "openrouter/test-model" "agent" nil [] {})))))
+            (is (thrown? Exception (run! identity (self/call-llm "openrouter/test-model" "agent" nil [] {} {})))))
           (is (== 1 (mt/metric-value system :metabase-metabot/llm-requests labels)))
           (is (== 0 (mt/metric-value system :metabase-metabot/llm-retries labels)))
           (is (== 1 (mt/metric-value system :metabase-metabot/llm-errors
@@ -586,7 +586,7 @@
         (testing "increments llm-errors with :error-type llm-sse-error on inline SSE errors"
           (with-redefs [openrouter/openrouter
                         (constantly (test-util/mock-llm-response [{:type :error :errorText "content policy violation"}]))]
-            (run! identity (self/call-llm "openrouter/test-model" "agent" nil [] {})))
+            (run! identity (self/call-llm "openrouter/test-model" "agent" nil [] {} {})))
           (is (== 1 (mt/metric-value system :metabase-metabot/llm-requests labels)))
           (is (== 1 (mt/metric-value system :metabase-metabot/llm-errors
                                      (assoc labels :error-type "llm-sse-error")))))
@@ -599,7 +599,7 @@
                                       {:type  :usage
                                        :usage {:promptTokens 100 :completionTokens 25}
                                        :model "test-model"}]))]
-            (run! identity (self/call-llm "openrouter/test-model" "agent" nil [] {})))
+            (run! identity (self/call-llm "openrouter/test-model" "agent" nil [] {} {})))
           (is (== 100 (mt/metric-value system :metabase-metabot/llm-input-tokens labels)))
           (is (==  25 (mt/metric-value system :metabase-metabot/llm-output-tokens labels)))
           (is (== 125 (:sum (mt/metric-value system :metabase-metabot/llm-tokens-per-call labels)))))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/self_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/self_test.clj
@@ -476,16 +476,14 @@
     (testing "succeeds on first attempt without retrying"
       (let [calls (atom 0)]
         (is (= :ok (#'self/with-retries
-                    "test-model"
-                    "agent"
+                    {:model "test-model" :tag "agent"}
                     (fn [] (swap! calls inc) :ok))))
         (is (= 1 @calls))))
     (testing "retries on retryable error and succeeds"
       (let [calls (atom 0)]
         (is (= :ok (mt/with-log-level [metabase-enterprise.metabot-v3.self :fatal]
                      (#'self/with-retries
-                      "test-model"
-                      "agent"
+                      {:model "test-model" :tag "agent"}
                       (fn []
                         (when (< (swap! calls inc) 3)
                           (throw (ex-info "rate limited" {:status 429})))
@@ -496,8 +494,7 @@
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo #"unauthorized"
              (#'self/with-retries
-              "test-model"
-              "agent"
+              {:model "test-model" :tag "agent"}
               (fn []
                 (swap! calls inc)
                 (throw (ex-info "unauthorized" {:status 401}))))))
@@ -508,8 +505,7 @@
              clojure.lang.ExceptionInfo #"overloaded"
              (mt/with-log-level [metabase-enterprise.metabot-v3.self :fatal]
                (#'self/with-retries
-                "test-model"
-                "agent"
+                {:model "test-model" :tag "agent"}
                 (fn []
                   (swap! calls inc)
                   (throw (ex-info "overloaded" {:status 529})))))))
@@ -518,8 +514,7 @@
       (let [calls (atom 0)]
         (is (= :ok (mt/with-log-level [metabase-enterprise.metabot-v3.self :fatal]
                      (#'self/with-retries
-                      "test-model"
-                      "agent"
+                      {:model "test-model" :tag "agent"}
                       (fn []
                         (when (< (swap! calls inc) 2)
                           (throw (java.net.ConnectException. "refused")))
@@ -534,7 +529,7 @@
       (let [labels {:model "test-model" :source "agent"}]
         (testing "increments llm-requests and observes duration on success"
           (with-redefs [openrouter/openrouter (constantly (test-util/mock-llm-response [{:type :start :id "m1"}]))]
-            (run! identity (self/call-llm "openrouter/test-model" "agent" nil [] {} {})))
+            (run! identity (self/call-llm "openrouter/test-model" nil [] {} {:tag "agent"})))
           (is (== 1 (mt/metric-value system :metabase-metabot/llm-requests labels)))
           (is (== 0 (mt/metric-value system :metabase-metabot/llm-retries labels)))
           (is (== 0 (mt/metric-value system :metabase-metabot/llm-errors
@@ -555,7 +550,7 @@
                                   (if (< (swap! calls inc) 3)
                                     (throw (ex-info "rate limited" {:status 429}))
                                     (reduce rf init (test-util/mock-llm-response [{:type :start :id "m1"}]))))))]
-                (run! identity (self/call-llm "openrouter/test-model" "agent" nil [] {} {}))))
+                (run! identity (self/call-llm "openrouter/test-model" nil [] {} {:tag "agent"}))))
             (is (== 3 (mt/metric-value system :metabase-metabot/llm-requests labels)))
             (is (== 2 (mt/metric-value system :metabase-metabot/llm-retries labels)))
             (is (== 0 (mt/metric-value system :metabase-metabot/llm-errors
@@ -572,7 +567,7 @@
                           (reify clojure.lang.IReduceInit
                             (reduce [_ _rf _init]
                               (throw (ex-info "unauthorized" {:status 401})))))]
-            (is (thrown? Exception (run! identity (self/call-llm "openrouter/test-model" "agent" nil [] {} {})))))
+            (is (thrown? Exception (run! identity (self/call-llm "openrouter/test-model" nil [] {} {:tag "agent"})))))
           (is (== 1 (mt/metric-value system :metabase-metabot/llm-requests labels)))
           (is (== 0 (mt/metric-value system :metabase-metabot/llm-retries labels)))
           (is (== 1 (mt/metric-value system :metabase-metabot/llm-errors
@@ -586,7 +581,7 @@
         (testing "increments llm-errors with :error-type llm-sse-error on inline SSE errors"
           (with-redefs [openrouter/openrouter
                         (constantly (test-util/mock-llm-response [{:type :error :errorText "content policy violation"}]))]
-            (run! identity (self/call-llm "openrouter/test-model" "agent" nil [] {} {})))
+            (run! identity (self/call-llm "openrouter/test-model" nil [] {} {:tag "agent"})))
           (is (== 1 (mt/metric-value system :metabase-metabot/llm-requests labels)))
           (is (== 1 (mt/metric-value system :metabase-metabot/llm-errors
                                      (assoc labels :error-type "llm-sse-error")))))
@@ -599,7 +594,7 @@
                                       {:type  :usage
                                        :usage {:promptTokens 100 :completionTokens 25}
                                        :model "test-model"}]))]
-            (run! identity (self/call-llm "openrouter/test-model" "agent" nil [] {} {})))
+            (run! identity (self/call-llm "openrouter/test-model" nil [] {} {:tag "agent"})))
           (is (== 100 (mt/metric-value system :metabase-metabot/llm-input-tokens labels)))
           (is (==  25 (mt/metric-value system :metabase-metabot/llm-output-tokens labels)))
           (is (== 125 (:sum (mt/metric-value system :metabase-metabot/llm-tokens-per-call labels)))))))))


### PR DESCRIPTION
Closes [BOT-1039: Add snowplow events](https://linear.app/metabase/issue/BOT-1039/add-snowplow-events)

### Description

Add token_usage snowplow event tracking to the clojure agent

- refactor `register-profile!` to single-arg form with `:name` now stored in the profile map and returned by get-profile
- `report-token-usage-xf` now emits a `:snowplow/token_usage event` per LLM call alongside existing prometheus metrics
- pass `tracking-opts` from `loop-step` through `call-llm` into the token-usage transducer
- likewise for callers of `call-llm-structured`
- `init-agent` generates a per-run request-id
- `run-agent-loop` accepts an optional `conversation-id` that turns into the snowplow token_usage session_id
- `run-agent-loop` accepts an optional `tracking-opts` map that contains context for prometheus and snowplow events

### How to verify

* start up snowplow micro container: `cd snowplow & docker compose up`
* start up metabase & use metabot
* visit snowplow micro ui at `http://localhost:9090/micro/ui/` and verify you get valid token_usage events for metabot agent and example question generation, e.g.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
