### PR TITLE
[Slackbot] Render unsupported static viz as tables

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot.clj
@@ -180,6 +180,15 @@
 
 ;; -------------------- VISUALIZATION GENERATION ---------------------------
 
+(def ^:private supported-png-display-types
+  "Display types that can be rendered as PNG images for Slack.
+   These correspond to the render methods in channel.render.body and
+   frontend static-viz components. Map types (pin_map, state, country)
+   are explicitly unsupported per channel.render.card/detect-pulse-chart-type."
+  #{:scalar :smartscalar :gauge :progress
+    :bar :line :area :combo :row :pie
+    :scatter :boxplot :waterfall :funnel :sankey})
+
 (defn- pulse-card-query-results
   {:arglists '([card])}
   [{query :dataset_query, card-id :id}]
@@ -228,13 +237,13 @@
   "Generate output for a saved card based on its display type.
    Returns a map with :type (:table or :image) and :content.
 
-   - Chart display types (bar, line, pie, etc.) render as PNG
-   - Table display renders as native Slack table blocks"
+   - `table` and display types not supported by static viz render as native Slack table blocks
+   - static viz chart types render as PNG"
   [card-id]
   (let [card (t2/select-one :model/Card :id card-id)]
     (when-not card
       (throw (ex-info "Card not found" {:card-id card-id :agent-error? true})))
-    (if-not (= (keyword (:display card)) :table)
+    (if (-> card :display keyword supported-png-display-types)
       {:type    :image
        :content (generate-card-png card-id)}
       (let [results (pulse-card-query-results card)]

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/query.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/query.clj
@@ -124,7 +124,7 @@
 
 (def ^:private chart-display-types
   "Display types that should render as PNG images rather than Slack tables."
-  #{:bar :line :pie :area :row :scatter :funnel :waterfall :combo :progress :gauge :map})
+  #{:bar :line :pie :area :row :scatter :funnel :waterfall :combo :progress :gauge})
 
 (defn generate-adhoc-output
   "Generate output for an ad-hoc query based on display type.

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
@@ -670,6 +670,31 @@
                      (set (filter #(str/starts-with? % "chart-") (map :filename @image-calls)))))
               (is (= 1 (count (filter #(str/starts-with? % "adhoc-") (map :filename @image-calls))))))))))))
 
+(deftest generate-card-output-display-type-test
+  (testing "generate-card-output returns correct type based on card display"
+    (let [fake-png-bytes (byte-array [0x89 0x50 0x4E 0x47])
+          mock-results {:data {:cols [{:name "x" :base_type :type/Integer}]
+                               :rows [[1] [2]]}}]
+      (mt/with-dynamic-fn-redefs
+        [slackbot/generate-card-png (constantly fake-png-bytes)
+         slackbot/pulse-card-query-results (constantly mock-results)]
+
+        (testing "supported display types return :image"
+          (doseq [display [:bar :line :pie :area :row :scatter :funnel
+                           :waterfall :combo :progress :gauge :scalar
+                           :smartscalar :boxplot :sankey]]
+            (testing (str "display type: " display)
+              (mt/with-temp [:model/Card {card-id :id} {:display display}]
+                (let [result (#'slackbot/generate-card-output card-id)]
+                  (is (= :image (:type result))))))))
+
+        (testing "unsupported display types return :table"
+          (doseq [display [:table :pin_map :state :country :map :pivot]]
+            (testing (str "display type: " display)
+              (mt/with-temp [:model/Card {card-id :id} {:display display}]
+                (let [result (#'slackbot/generate-card-output card-id)]
+                  (is (= :table (:type result))))))))))))
+
 ;; -------------------------------- CSV Upload Tests --------------------------------
 
 (defn- with-upload-mocks!


### PR DESCRIPTION
Closes [BOT-938](https://linear.app/metabase/issue/BOT-938/we-should-should-not-try-to-render-static-viz-for-unsupported)

### Description

This PR renders unsupported static viz types as tables
<img width="2998" height="2128" alt="CleanShot 2026-02-24 at 11 55 24@2x" src="https://github.com/user-attachments/assets/2f6b1799-b1e9-4bb2-8a1e-0138ccfd0675" />
<img width="1240" height="1038" alt="CleanShot 2026-02-24 at 11 55 10@2x" src="https://github.com/user-attachments/assets/fa5318d7-d6ef-48e1-944d-2c791badbd26" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR