### PR TITLE
[Slackbot] Adds check to prevent replay attacks

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/middleware/auth_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/middleware/auth_test.clj
@@ -89,13 +89,13 @@
       (with-redefs [mw.auth/current-unix-timestamp (constantly test-timestamp)]
         (testing "Replay attack prevention - rejects timestamps outside 5 minute window"
           (doseq [[expected offset-or-val description]
-                  [[true  0       "current time"]
-                   [true  -300    "exactly 5 min ago"]
-                   [true  300     "exactly 5 min ahead"]
-                   [false -301    "5+ min ago"]
-                   [false 301     "5+ min ahead"]
-                   [false "abc"   "malformed"]
-                   [false nil     "missing"]]]
+                  [[true  0     "current time"]
+                   [true  -300  "exactly 5 min ago"]
+                   [true  300   "exactly 5 min ahead"]
+                   [false -301  "5+ min ago"]
+                   [false 301   "5+ min ahead"]
+                   [false "abc" "malformed"]
+                   [false nil   "missing"]]]
             (testing description
               (is (= expected (validate-request-with-timestamp
                                (if (number? offset-or-val)

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/middleware/auth_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/middleware/auth_test.clj
@@ -100,4 +100,4 @@
               (is (= expected (validate-request-with-timestamp
                                (if (number? offset-or-val)
                                  (str (+ test-timestamp offset-or-val))
-                                 offset-or-val))))))))))))
+                                 offset-or-val)))))))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/middleware/auth_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/middleware/auth_test.clj
@@ -14,6 +14,7 @@
 ;;; ------------------------------------------ TEST verify-slack-request middleware ------------------------------------------
 
 (def ^:private test-signing-secret "test-slack-signing-secret-12345")
+(def ^:private test-timestamp 1700000000)
 
 (defn- compute-slack-signature
   "Compute a valid Slack signature for testing"
@@ -42,33 +43,61 @@
 
 (deftest verify-slack-request-test
   (mt/with-premium-features #{:metabot-v3}
-    (testing "Valid signature w/ signing secret configured"
-      (mt/with-temporary-setting-values [metabot.settings/metabot-slack-signing-secret test-signing-secret]
-        (let [body      "test-body"
-              timestamp "1234567890"
-              signature (compute-slack-signature body timestamp test-signing-secret)
-              result    (wrapped-slack-handler (slack-request body timestamp signature))]
-          (is (true? (:slack/validated? result))))))
+    (with-redefs [mw.auth/current-unix-timestamp (constantly test-timestamp)]
+      (testing "Valid signature w/ signing secret configured"
+        (mt/with-temporary-setting-values [metabot.settings/metabot-slack-signing-secret test-signing-secret]
+          (let [body      "test-body"
+                timestamp (str test-timestamp)
+                signature (compute-slack-signature body timestamp test-signing-secret)
+                result    (wrapped-slack-handler (slack-request body timestamp signature))]
+            (is (true? (:slack/validated? result))))))
 
-    (testing "Invalid signature"
-      (mt/with-temporary-setting-values [metabot.settings/metabot-slack-signing-secret test-signing-secret]
-        (let [body      "test-body"
-              timestamp "1234567890"
-              signature "v0=invalid-signature"
-              result    (wrapped-slack-handler (slack-request body timestamp signature))]
-          (is (false? (:slack/validated? result))))))
+      (testing "Invalid signature"
+        (mt/with-temporary-setting-values [metabot.settings/metabot-slack-signing-secret test-signing-secret]
+          (let [body      "test-body"
+                timestamp (str test-timestamp)
+                signature "v0=invalid-signature"
+                result    (wrapped-slack-handler (slack-request body timestamp signature))]
+            (is (false? (:slack/validated? result))))))
 
-    (testing "No signature header present - request passes through unchanged"
-      (let [body    "test-body"
-            request (-> (ring.mock/request :post "/anyurl")
-                        (assoc :body (java.io.ByteArrayInputStream. (.getBytes ^String body "UTF-8"))))
-            result  (wrapped-slack-handler request)]
-        (is (not (contains? result :slack/validated?)))))
+      (testing "No signature header present - request passes through unchanged"
+        (let [body    "test-body"
+              request (-> (ring.mock/request :post "/anyurl")
+                          (assoc :body (java.io.ByteArrayInputStream. (.getBytes ^String body "UTF-8"))))
+              result  (wrapped-slack-handler request)]
+          (is (not (contains? result :slack/validated?)))))
 
-    (testing "No signing secret configured"
-      (mt/with-temporary-setting-values [metabot.settings/metabot-slack-signing-secret nil]
-        (let [body      "test-body"
-              timestamp "1234567890"
-              signature "v0=some-signature"
-              result    (wrapped-slack-handler (slack-request body timestamp signature))]
-          (is (nil? (:slack/validated? result))))))))
+      (testing "No signing secret configured"
+        (mt/with-temporary-setting-values [metabot.settings/metabot-slack-signing-secret nil]
+          (let [body      "test-body"
+                timestamp (str test-timestamp)
+                signature "v0=some-signature"
+                result    (wrapped-slack-handler (slack-request body timestamp signature))]
+            (is (nil? (:slack/validated? result)))))))))
+
+(defn- validate-request-with-timestamp
+  "Helper to test timestamp validation. Returns :slack/validated? result."
+  [timestamp]
+  (let [body      "test-body"
+        signature (compute-slack-signature body timestamp test-signing-secret)
+        result    (wrapped-slack-handler (slack-request body timestamp signature))]
+    (:slack/validated? result)))
+
+(deftest verify-slack-request-timestamp-validation-test
+  (mt/with-premium-features #{:metabot-v3}
+    (mt/with-temporary-setting-values [metabot.settings/metabot-slack-signing-secret test-signing-secret]
+      (with-redefs [mw.auth/current-unix-timestamp (constantly test-timestamp)]
+        (testing "Replay attack prevention - rejects timestamps outside 5 minute window"
+          (doseq [[expected offset-or-val description]
+                  [[true  0       "current time"]
+                   [true  -300    "exactly 5 min ago"]
+                   [true  300     "exactly 5 min ahead"]
+                   [false -301    "5+ min ago"]
+                   [false 301     "5+ min ahead"]
+                   [false "abc"   "malformed"]
+                   [false nil     "missing"]]]
+            (testing description
+              (is (= expected (validate-request-with-timestamp
+                               (if (number? offset-or-val)
+                                 (str (+ test-timestamp offset-or-val))
+                                 offset-or-val))))))))))))

--- a/src/metabase/server/middleware/auth.clj
+++ b/src/metabase/server/middleware/auth.clj
@@ -12,6 +12,30 @@
   []
   nil)
 
+(def ^:private ^:const max-slack-timestamp-age-seconds
+  "Maximum age in seconds for a Slack request timestamp. Requests older than this are rejected
+   to prevent replay attacks. Slack recommends 5 minutes (300 seconds)."
+  300)
+
+(defn- current-unix-timestamp
+  "Returns current Unix timestamp in seconds. Extracted for testability."
+  []
+  (quot (System/currentTimeMillis) 1000))
+
+(defn- slack-timestamp-valid?
+  "Check if the Slack request timestamp is within the acceptable time window.
+   Returns false if timestamp is missing, malformed, or too old."
+  [timestamp]
+  (if timestamp
+    (try
+      (let [request-time (Long/parseLong timestamp)
+            current-time (current-unix-timestamp)
+            age (Math/abs (long (- current-time request-time)))]
+        (<= age max-slack-timestamp-age-seconds))
+      (catch NumberFormatException _
+        false))
+    false))
+
 (def ^:private ^:const ^String static-metabase-api-key-header "x-metabase-apikey")
 
 (defn- wrap-static-api-key* [{:keys [headers], :as request}]
@@ -33,13 +57,16 @@
       codecs/bytes->hex))
 
 (defn- verify-slack-signature
-  "Verify that the request came from Slack using signature verification"
+  "Verify that the request came from Slack using signature verification.
+   Returns nil if no signing secret is configured, false if timestamp is too old
+   (replay attack prevention) or signature is invalid, true if valid."
   [request-body timestamp slack-signature]
   (when-let [signing-secret (metabot-slack-signing-secret-setting)]
-    (let [message (str "v0:" timestamp ":" request-body)
-          computed-signature (hmac-sha256 signing-secret message)
-          expected-signature (str "v0=" computed-signature)]
-      (= expected-signature slack-signature))))
+    (and (slack-timestamp-valid? timestamp)
+         (let [message (str "v0:" timestamp ":" request-body)
+               computed-signature (hmac-sha256 signing-secret message)
+               expected-signature (str "v0=" computed-signature)]
+           (= expected-signature slack-signature)))))
 
 (defn verify-slack-request
   "Middleware that detects if an incoming request is from Slack and sets the `:slack/validated?` keyword on a request

--- a/src/metabase/server/middleware/auth.clj
+++ b/src/metabase/server/middleware/auth.clj
@@ -7,6 +7,8 @@
    [buddy.core.mac :as mac]
    [metabase.premium-features.core :refer [defenterprise]]))
 
+(set! *warn-on-reflection* true)
+
 (defenterprise metabot-slack-signing-secret-setting
   "Returns the Slack signing secret for Metabot (EE only)."
   metabase-enterprise.metabot-v3.settings
@@ -69,8 +71,8 @@
                computed-signature (hmac-sha256 signing-secret message)
                expected-signature (str "v0=" computed-signature)]
            ;; Use constant-time comparison to prevent timing attacks
-           (bytes/equals? (.getBytes expected-signature "UTF-8")
-                          (.getBytes slack-signature "UTF-8"))))))
+           (bytes/equals? (.getBytes ^String expected-signature "UTF-8")
+                          (.getBytes ^String slack-signature "UTF-8"))))))
 
 (defn verify-slack-request
   "Middleware that detects if an incoming request is from Slack and sets the `:slack/validated?` keyword on a request


### PR DESCRIPTION
We were validating messages were correctly signed, but we need to also check they are within a timeframe of 5 minutes to prevent replay attacks.