### PR TITLE
Skip cache auto-refresh attempts for routed dbs

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -2732,6 +2732,7 @@
    :model-imports #{:model/CacheConfig
                     :model/Card
                     :model/Dashboard
+                    :model/DatabaseRouter
                     :model/Query
                     :model/QueryCache
                     :model/QueryExecution}}


### PR DESCRIPTION
Currently we pollute the logs here, because we can't do anonymous queries against a routed DB.

Just skip cards that are against routed databases to avoid failing deeper down.
