### PR TITLE
Increase debounce delay to 500ms

### DIFF
--- a/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
@@ -338,9 +338,7 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
           "readonly",
         ];
 
-        // client filter debounce
-        cy.wait(300);
-
+        cy.findAllByRole("menuitem").should("have.length", filteredGroups.length);
         H.assertSidebarItems(filteredGroups);
       });
 

--- a/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
@@ -338,7 +338,10 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
           "readonly",
         ];
 
-        cy.findAllByRole("menuitem").should("have.length", filteredGroups.length);
+        cy.findAllByRole("menuitem").should(
+          "have.length",
+          filteredGroups.length,
+        );
         H.assertSidebarItems(filteredGroups);
       });
 

--- a/frontend/src/metabase/lib/constants.ts
+++ b/frontend/src/metabase/lib/constants.ts
@@ -1,6 +1,6 @@
 import { t } from "ttag";
 
-export const SEARCH_DEBOUNCE_DURATION = 300;
+export const SEARCH_DEBOUNCE_DURATION = 500;
 
 export const DEFAULT_SEARCH_LIMIT = 50;
 


### PR DESCRIPTION
[UXW-3154: Increase debounce delay for search API calls](https://linear.app/metabase/issue/UXW-3154/increase-debounce-delay-for-search-api-calls)

The current delay (300ms) is a bit too short. Increasing it to 500ms should still be a snappy UX but send fewer requests while the user is typing.
