### PR TITLE
Always run Metabot-triggered refingerprinting in admin context to match sync behavior

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/field_stats.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/field_stats.clj
@@ -4,6 +4,7 @@
    [metabase-enterprise.metabot-v3.tools.util :as metabot-v3.tools.u]
    [metabase.lib.core :as lib]
    [metabase.parameters.field-values :as params.field-values]
+   [metabase.request.core :as request]
    [metabase.sync.core :as sync]
    [toucan2.core :as t2]))
 
@@ -18,7 +19,8 @@
 
 (defn- get-or-create-fingerprint! [{:keys [id fingerprint] :as field}]
   (or fingerprint
-      (and (pos? (:updated-fingerprints (sync/refingerprint-field! field)))
+      ;; Run with admin perms to match behavior during normal sync.
+      (and (pos? (:updated-fingerprints (request/as-admin (sync/refingerprint-field! field))))
            (t2/select-one-fn :fingerprint :model/Field :id id))))
 
 (defn- field-statistics

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/field_stats_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/field_stats_test.clj
@@ -179,10 +179,12 @@
   (testing "When Metabot triggers re-fingerprinting for a missing fingerprint, the fingerprint reflects the full
             (unsandboxed) data, not the sandboxed view of the current user."
     (met/with-gtaps! {:gtaps {:categories {:query (sandboxed-query)}}}
-      (let [field-id           (mt/id :categories :name)
-            table-id           (mt/id :categories)
-            original-fp        (t2/select-one-fn :fingerprint :model/Field :id field-id)
+      (let [field-id            (mt/id :categories :name)
+            table-id            (mt/id :categories)
+            original-fp         (t2/select-one-fn :fingerprint :model/Field :id field-id)
             full-distinct-count (get-in original-fp [:global :distinct-count])]
+        (testing "precondition: the field has a fingerprint with a distinct count greater than 0"
+          (is (> full-distinct-count 0)))
         (try
           ;; Clear the fingerprint to force re-fingerprinting via get-or-create-fingerprint!
           (t2/update! :model/Field field-id {:fingerprint nil :fingerprint_version 0})

--- a/src/metabase/llm/context.clj
+++ b/src/metabase/llm/context.clj
@@ -8,6 +8,7 @@
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.models.interface :as mi]
+   [metabase.request.core :as request]
    [metabase.sql-tools.core :as sql-tools]
    [metabase.sync.core :as sync]
    [metabase.util :as u]
@@ -179,7 +180,8 @@
     (when (seq missing-fp-ids)
       (let [fields (t2/select :model/Field :id [:in missing-fp-ids])]
         (doseq [field fields]
-          (sync/refingerprint-field! field))
+          ;; Run with admin perms to match behavior during normal sync.
+          (request/as-admin (sync/refingerprint-field! field)))
         (t2/select-pk->fn :fingerprint :model/Field :id [:in missing-fp-ids])))))
 
 ;;; ------------------------------------------- Fingerprint Formatting -------------------------------------------

--- a/src/metabase/warehouse_schema_rest/api/field.clj
+++ b/src/metabase/warehouse_schema_rest/api/field.clj
@@ -189,7 +189,8 @@
       (events/publish-event! :event/field-update {:object <> :user-id api/*current-user-id*})
       (when (not= effective-type (:effective_type field))
         (analytics/track-event! :snowplow/simple_event {:event "field_effective_type_change" :target_id id})
-        (quick-task/submit-task! (fn [] (sync/refingerprint-field! <>)))))))
+        ;; Run with admin perms to match behavior during normal sync.
+        (quick-task/submit-task! (fn [] (request/as-admin (sync/refingerprint-field! <>))))))))
 
 ;;; ------------------------------------------------- Field Metadata -------------------------------------------------
 


### PR DESCRIPTION
* Wraps Metabot calls to `sync/refingerprint-field!` with `as-admin!` to always refingerprint with admin perms + the default DB role (if impersonation is enabled) since fingerprints are global and we want to match the values that would be generated by a normal sync process
* Also adds this for one other call site in `warehouse-schema-rest` for consistency. This is used for re-fingerprinting when the effective type of a field is changed in the data model editor, from my understanding.
* Adds a Metabot test that uses sandboxing to ensure that we don't generate a sandboxed fingerprint (also applies to impersonation/other perms, but sandboxing better to use for a lightweight test)

Ultimately it would be nice to have user-scoped field fingerprints, but this should at least get things consistent according to the current product expectations