### PR TITLE
Modify French translations for date picker

### DIFF
--- a/locales/fr.po
+++ b/locales/fr.po
@@ -3887,7 +3887,7 @@ msgstr "Notre {0} est une chaîne de 5 champs, commençant par les minutes, sép
 #: frontend/src/metabase/admin/tools/components/LogLevelsModal/DurationInput.tsx:56
 #: frontend/src/metabase/common/components/CronExpressioInput/CronExpressionInput.tsx:112
 msgid "Minutes"
-msgstr "Procès-verbal"
+msgstr "Minutes"
 
 #: frontend/src/metabase/admin/tools/components/LogLevelsModal/DurationInput.tsx:57
 #: frontend/src/metabase/common/components/CronExpressioInput/CronExpressionInput.tsx:113
@@ -13109,7 +13109,7 @@ msgstr "Vérifiez toutes les {0}"
 msgid "Minute"
 msgid_plural "{0} Minutes"
 msgstr[0] "Minute"
-msgstr[1] "Procès-verbal"
+msgstr[1] "Minutes"
 
 #: frontend/src/metabase/lib/notifications.ts:264
 msgid "Check hourly"

--- a/locales/fr.po
+++ b/locales/fr.po
@@ -11799,7 +11799,7 @@ msgstr "A partir de..."
 
 #: frontend/src/metabase/querying/common/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/DateOffsetIntervalPicker.tsx:112
 msgid "Starting from"
-msgstr "À partir de"
+msgstr "À partir d'il y a"
 
 #: frontend/src/metabase/querying/common/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/DateOffsetIntervalPicker.tsx:115
 msgid "Starting from interval"
@@ -27512,7 +27512,7 @@ msgstr "Grouper par"
 #: frontend/src/metabase/querying/common/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/utils.ts:76
 #, javascript-format
 msgid "{0} ago"
-msgstr "Il y a {0} ans"
+msgstr "{0}"
 
 #: frontend/src/metabase/querying/common/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/utils.ts:76
 msgid "{0} from now"


### PR DESCRIPTION
Updated French translations for date-related strings.

> [!IMPORTANT]
> For those employed by Metabase: if you are merging into master, please add either a `backport` or a `no-backport` label to this PR. You will not be able to merge until you do this step. Refer to the section [Do I need to backport this PR?](https://www.notion.so/metabase/Metabase-Branching-Strategy-6eb577d5f61142aa960a626d6bbdfeb3?pvs=4#89f80d6f17714a0198aeb66c0efd1b71) in the Metabase Branching Strategy document for more details. If you're not employed by Metabase, this section does not apply to you, and the label will be taken care of by your reviewer.

> **Warning**
>
> If that is your first contribution to Metabase, please sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform). Also, if you're attempting to fix a translation issue, please submit your changes to our [Crowdin project](https://crowdin.com/project/metabase-i18n) instead of opening a PR.

Closes https://github.com/metabase/metabase/issues/[issue_number]

### Description

Describe the overall approach and the problem being solved.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> ...
2. ...

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
