### PR TITLE
Slackbot test refactor + fix overwriting encrypted settings

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
@@ -27,6 +27,25 @@
 (def ^:private test-signing-secret "test-signing-secret")
 (def ^:private test-encryption-key (byte-array (repeat 64 42)))
 
+(def ^:private base-dm-event
+  {:type  "event_callback"
+   :event {:type         "message"
+           :text         "Hello!"
+           :user         "U123"
+           :channel      "C123"
+           :ts           "1234567890.000001"
+           :event_ts     "1234567890.000001"
+           :channel_type "im"}})
+
+(def ^:private base-mention-event
+  {:type  "event_callback"
+   :event {:type     "app_mention"
+           :text     "<@UBOT123> Hello!"
+           :user     "U123"
+           :channel  "C123"
+           :ts       "1234567890.000001"
+           :event_ts "1234567890.000001"}})
+
 (defmacro ^:private with-ensure-encryption
   "Use the existing encryption key if one is configured, otherwise set a test key.
    Avoids conflicts with encrypted settings in the DB that were written with the real key."
@@ -36,7 +55,7 @@
      (with-redefs [encryption/default-secret-key test-encryption-key]
        ~@body)))
 
-(defmacro with-slackbot-setup
+(defmacro ^:private with-slackbot-setup
   "Wrap body with all required settings for slackbot to be fully configured."
   [& body]
   `(with-redefs [slackbot/validate-bot-token! (constantly {:ok true})]
@@ -110,14 +129,9 @@
           (is (= "ok" response))))
 
       (testing "handles message.im events"
-        (let [body {:type "event_callback"
-                    :event {:type "message"
-                            :channel "D123"
-                            :user "U123"
-                            :ts "1234567890.000001"
-                            :event_ts "1234567890.000001"
-                            :channel_type "im"
-                            :text "Hello from DM"}}
+        (let [body     (-> base-dm-event
+                           (assoc-in [:event :channel] "D123")
+                           (assoc-in [:event :text] "Hello from DM"))
               response (mt/client :post 200 "ee/metabot-v3/slack/events"
                                   (slack-request-options body)
                                   body)]
@@ -134,17 +148,12 @@
 (deftest feature-flag-test
   (testing "POST /api/ee/metabot-v3/slack/events"
     (testing "ack events even when metabot-v3 feature is disabled to prevent Slack retries"
+      ;; with-slackbot-setup enables #{:metabot-v3 :sso-slack}; the inner with-premium-features
+      ;; overrides that to only #{:sso-slack}, verifying we still ACK when :metabot-v3 is absent.
       (with-slackbot-setup
         (with-redefs [mw.auth/metabot-slack-signing-secret-setting (constantly test-signing-secret)]
           (mt/with-premium-features #{:sso-slack}
-            (let [body {:type "event_callback"
-                        :event {:type "message"
-                                :text "Hello!"
-                                :user "U123"
-                                :channel "D123"
-                                :ts "1234567890.000001"
-                                :event_ts "1234567890.000001"
-                                :channel_type "im"}}
+            (let [body     (assoc-in base-dm-event [:event :channel] "D123")
                   response (mt/client :post 200 "ee/metabot-v3/slack/events"
                                       (slack-request-options body)
                                       body)]
@@ -263,15 +272,7 @@
       (doseq [[desc event-mod] [["with :edited key" {:edited {:user "U123" :ts "123"}}]
                                 ["with message_changed subtype" {:subtype "message_changed"}]]]
         (testing desc
-          (let [event-body {:type "event_callback"
-                            :event (merge {:type "message"
-                                           :text "Edited message"
-                                           :user "U123"
-                                           :channel "C123"
-                                           :ts "1234567890.000001"
-                                           :event_ts "1234567890.000001"
-                                           :channel_type "im"}
-                                          event-mod)}]
+          (let [event-body (update base-dm-event :event merge {:text "Edited message"} event-mod)]
             (with-slackbot-mocks
               {:ai-text "Should not be called"}
               (fn [{:keys [post-calls ephemeral-calls]}]
@@ -289,23 +290,8 @@
     (with-slackbot-setup
       (mt/with-temporary-setting-values [sso-settings/slack-connect-enabled false]
         (doseq [[desc event-body]
-                [["message.im event"
-                  {:type "event_callback"
-                   :event {:type "message"
-                           :text "Hello!"
-                           :user "U123"
-                           :channel "D123"
-                           :ts "1234567890.000001"
-                           :event_ts "1234567890.000001"
-                           :channel_type "im"}}]
-                 ["app_mention event"
-                  {:type "event_callback"
-                   :event {:type "app_mention"
-                           :text "<@UBOT123> Hello!"
-                           :user "U123"
-                           :channel "C123"
-                           :ts "1234567890.000001"
-                           :event_ts "1234567890.000001"}}]]]
+                [["message.im event"  (assoc-in base-dm-event [:event :channel] "D123")]
+                 ["app_mention event" base-mention-event]]]
           (testing desc
             (with-slackbot-mocks
               {:ai-text "Should not be called"}
@@ -324,14 +310,7 @@
   (testing "POST /events with user message triggers AI response via Slack streaming"
     (with-slackbot-setup
       (let [mock-ai-text "Here is your answer"
-            event-body {:type "event_callback"
-                        :event {:type "message"
-                                :text "Hello!"
-                                :user "U123"
-                                :channel "C123"
-                                :ts "1234567890.000001"
-                                :event_ts "1234567890.000001"
-                                :channel_type "im"}}]
+            event-body   base-dm-event]
         (with-slackbot-mocks
           {:ai-text mock-ai-text}
           (fn [{:keys [stream-calls append-text-calls stop-stream-calls]}]
@@ -355,13 +334,7 @@
   (testing "POST /events with app_mention triggers AI response via streaming"
     (with-slackbot-setup
       (let [mock-ai-text "Here is your answer"
-            event-body {:type "event_callback"
-                        :event {:type "app_mention"
-                                :text "<@UBOT123> Hello!"
-                                :user "U123"
-                                :channel "C123"
-                                :ts "1234567890.000001"
-                                :event_ts "1234567890.000001"}}]
+            event-body   base-mention-event]
         (with-slackbot-mocks
           {:ai-text mock-ai-text}
           (fn [{:keys [stream-calls append-text-calls stop-stream-calls]}]
@@ -384,14 +357,7 @@
 (deftest stream-start-failure-test
   (testing "When start-stream fails, falls back to a regular message"
     (with-slackbot-setup
-      (let [event-body {:type "event_callback"
-                        :event {:type "message"
-                                :text "Hello!"
-                                :user "U123"
-                                :channel "C123"
-                                :ts "1234567890.000001"
-                                :event_ts "1234567890.000001"
-                                :channel_type "im"}}]
+      (let [event-body base-dm-event]
         (with-slackbot-mocks
           {:ai-text "Here is your answer"}
           (fn [{:keys [post-calls stop-stream-calls]}]
@@ -414,14 +380,7 @@
 (deftest ai-request-error-stops-stream-test
   (testing "When the AI request throws after the stream has started, the stream is stopped"
     (with-slackbot-setup
-      (let [event-body {:type "event_callback"
-                        :event {:type "message"
-                                :text "Hello!"
-                                :user "U123"
-                                :channel "C123"
-                                :ts "1234567890.000001"
-                                :event_ts "1234567890.000001"
-                                :channel_type "im"}}]
+      (let [event-body base-dm-event]
         (with-slackbot-mocks
           {:ai-text "unused"}
           (fn [{:keys [stop-stream-calls stream-calls append-text-calls]}]
@@ -452,23 +411,8 @@
   (testing "POST /events passes correct arguments to streaming-request-with-callback"
     (with-slackbot-setup
       (doseq [[desc event-body]
-              [["DM message"
-                {:type "event_callback"
-                 :event {:type "message"
-                         :text "Hello!"
-                         :user "U123"
-                         :channel "D-MY-DM-CHANNEL"
-                         :ts "1234567890.000001"
-                         :event_ts "1234567890.000001"
-                         :channel_type "im"}}]
-               ["app_mention in channel"
-                {:type "event_callback"
-                 :event {:type "app_mention"
-                         :text "<@UBOT123> Hello!"
-                         :user "U123"
-                         :channel "C-PUBLIC-CHANNEL"
-                         :ts "1234567890.000001"
-                         :event_ts "1234567890.000001"}}]]]
+              [["DM message"            (assoc-in base-dm-event [:event :channel] "D-MY-DM-CHANNEL")]
+               ["app_mention in channel" (assoc-in base-mention-event [:event :channel] "C-PUBLIC-CHANNEL")]]]
         (testing desc
           (with-slackbot-mocks
             {:ai-text "response"}
@@ -499,15 +443,12 @@
                              {:type "static_viz" :value {:entity_id 202}}
                              ;; Include a non-viz data part to verify filtering
                              {:type "other_type" :value {:foo "bar"}}]
-            event-body {:type "event_callback"
-                        :event {:type "message"
-                                :text "Show me charts"
-                                :user "U123"
-                                :channel "C456"
-                                :ts "1234567890.000002"
-                                :event_ts "1234567890.000002"
-                                :channel_type "im"
-                                :thread_ts "1234567890.000000"}}]
+            event-body (update base-dm-event :event merge
+                               {:text      "Show me charts"
+                                :channel   "C456"
+                                :ts        "1234567890.000002"
+                                :event_ts  "1234567890.000002"
+                                :thread_ts "1234567890.000000"})]
         (with-slackbot-mocks
           {:ai-text mock-ai-text
            :data-parts mock-data-parts}
@@ -548,14 +489,7 @@
 (deftest user-not-linked-sends-auth-message-test
   (testing "POST /events with unlinked user sends ephemeral auth message"
     (with-slackbot-setup
-      (let [event-body {:type "event_callback"
-                        :event {:type "message"
-                                :text "Hello!"
-                                :user "U-UNKNOWN-USER"
-                                :channel "C123"
-                                :ts "1234567890.000001"
-                                :event_ts "1234567890.000001"
-                                :channel_type "im"}}]
+      (let [event-body (assoc-in base-dm-event [:event :user] "U-UNKNOWN-USER")]
         (with-slackbot-mocks
           {:ai-text "Should not be called"
            :user-id ::no-user} ;; Simulate no linked user
@@ -585,14 +519,11 @@
                ;; @mention in thread should thread (to keep context)
                ["@mention in thread" "1234567890.000001" "1234567890.000001"]]]
         (testing desc
-          (let [event-body {:type "event_callback"
-                            :event (cond-> {:type "app_mention"
-                                            :text "<@UBOT123> Hello!"
-                                            :user "U-UNKNOWN"
-                                            :channel "C123"
-                                            :ts "1234567890.000002"
-                                            :event_ts "1234567890.000002"}
-                                     thread-ts (assoc :thread_ts thread-ts))}]
+          (let [event-body (cond-> (update base-mention-event :event merge
+                                           {:user     "U-UNKNOWN"
+                                            :ts       "1234567890.000002"
+                                            :event_ts "1234567890.000002"})
+                             thread-ts (assoc-in [:event :thread_ts] thread-ts))]
             (with-slackbot-mocks
               {:ai-text "Should not be called"
                :user-id ::no-user}
@@ -610,14 +541,7 @@
 
 (deftest setup-complete-test
   (with-slackbot-setup
-    (let [request-body {:type  "event_callback"
-                        :event {:type         "message"
-                                :text         "test"
-                                :user         "U123"
-                                :channel      "C123"
-                                :ts           "1234567890.000001"
-                                :event_ts     "1234567890.000001"
-                                :channel_type "im"}}
+    (let [request-body (assoc-in base-dm-event [:event :text] "test")
           post-events  #(mt/client :post %1 "ee/metabot-v3/slack/events"
                                    (slack-request-options request-body) request-body)]
       (testing "succeeds when all settings are configured"
@@ -665,15 +589,12 @@
             mock-data-parts [{:type  "adhoc_viz"
                               :value {:query   mock-query
                                       :display "bar"}}]
-            event-body      {:type  "event_callback"
-                             :event {:type         "message"
-                                     :text         "Show me sales data"
-                                     :user         "U123"
-                                     :channel      "C789"
-                                     :ts           "1234567890.000003"
-                                     :event_ts     "1234567890.000003"
-                                     :channel_type "im"
-                                     :thread_ts    "1234567890.000000"}}]
+            event-body      (update base-dm-event :event merge
+                                    {:text      "Show me sales data"
+                                     :channel   "C789"
+                                     :ts        "1234567890.000003"
+                                     :event_ts  "1234567890.000003"
+                                     :thread_ts "1234567890.000000"})]
         (with-slackbot-mocks
           {:ai-text    mock-ai-text
            :data-parts mock-data-parts}
@@ -708,14 +629,10 @@
       (let [mock-query      {:database 1 :type "query" :query {:source-table 2}}
             mock-data-parts [{:type  "adhoc_viz"
                               :value {:query mock-query}}] ;; no :display
-            event-body      {:type  "event_callback"
-                             :event {:type         "message"
-                                     :text         "Show data"
-                                     :user         "U123"
-                                     :channel      "C123"
-                                     :ts           "1234567890.000004"
-                                     :event_ts     "1234567890.000004"
-                                     :channel_type "im"}}]
+            event-body      (update base-dm-event :event merge
+                                    {:text     "Show data"
+                                     :ts       "1234567890.000004"
+                                     :event_ts "1234567890.000004"})]
         (with-slackbot-mocks
           {:ai-text    "Here's your table"
            :data-parts mock-data-parts}
@@ -739,15 +656,12 @@
             mock-data-parts [{:type "static_viz" :value {:entity_id 101}}
                              {:type "adhoc_viz" :value {:query mock-query :display "line"}}
                              {:type "static_viz" :value {:entity_id 202}}]
-            event-body      {:type  "event_callback"
-                             :event {:type         "message"
-                                     :text         "Show me everything"
-                                     :user         "U123"
-                                     :channel      "C456"
-                                     :ts           "1234567890.000005"
-                                     :event_ts     "1234567890.000005"
-                                     :channel_type "im"
-                                     :thread_ts    "1234567890.000000"}}]
+            event-body      (update base-dm-event :event merge
+                                    {:text      "Show me everything"
+                                     :channel   "C456"
+                                     :ts        "1234567890.000005"
+                                     :event_ts  "1234567890.000005"
+                                     :thread_ts "1234567890.000000"})]
         (with-slackbot-mocks
           {:ai-text    "Here's everything"
            :data-parts mock-data-parts}
@@ -808,20 +722,14 @@
 (deftest csv-upload-disabled-test
   (testing "POST /events with file upload when uploads are disabled"
     (with-slackbot-setup
-      (let [event-body {:type "event_callback"
-                        :event {:type "message"
-                                :subtype "file_share"
-                                :text "Here's my data"
-                                :user "U123"
-                                :channel "C123"
-                                :channel_type "im"
-                                :ts "1234567890.000001"
-                                :event_ts "1234567890.000001"
-                                :files [{:id "F123"
-                                         :name "data.csv"
-                                         :filetype "csv"
-                                         :url_private "https://files.slack.com/files/data.csv"
-                                         :size 100}]}}]
+      (let [event-body (update base-dm-event :event merge
+                               {:subtype "file_share"
+                                :text    "Here's my data"
+                                :files   [{:id          "F123"
+                                           :name        "data.csv"
+                                           :filetype    "csv"
+                                           :url_private "https://files.slack.com/files/data.csv"
+                                           :size        100}]})]
         (with-upload-mocks!
           {:uploads-enabled? false}
           (fn [{:keys [upload-calls]}]
@@ -844,20 +752,14 @@
 (deftest csv-upload-success-test
   (testing "POST /events with successful CSV upload"
     (with-slackbot-setup
-      (let [event-body {:type "event_callback"
-                        :event {:type "message"
-                                :subtype "file_share"
-                                :text "Here's my data"
-                                :user "U123"
-                                :channel "C123"
-                                :channel_type "im"
-                                :ts "1234567890.000001"
-                                :event_ts "1234567890.000001"
-                                :files [{:id "F123"
-                                         :name "sales_data.csv"
-                                         :filetype "csv"
-                                         :url_private "https://files.slack.com/files/sales_data.csv"
-                                         :size 100}]}}]
+      (let [event-body (update base-dm-event :event merge
+                               {:subtype "file_share"
+                                :text    "Here's my data"
+                                :files   [{:id          "F123"
+                                           :name        "sales_data.csv"
+                                           :filetype    "csv"
+                                           :url_private "https://files.slack.com/files/sales_data.csv"
+                                           :size        100}]})]
         (with-upload-mocks!
           {:uploads-enabled? true
            :can-create-upload? true
@@ -887,20 +789,14 @@
 (deftest csv-upload-non-csv-skipped-test
   (testing "POST /events with non-CSV file is skipped"
     (with-slackbot-setup
-      (let [event-body {:type "event_callback"
-                        :event {:type "message"
-                                :subtype "file_share"
-                                :text "Here's my file"
-                                :user "U123"
-                                :channel "C123"
-                                :channel_type "im"
-                                :ts "1234567890.000001"
-                                :event_ts "1234567890.000001"
-                                :files [{:id "F123"
-                                         :name "document.pdf"
-                                         :filetype "pdf"
-                                         :url_private "https://files.slack.com/files/document.pdf"
-                                         :size 100}]}}]
+      (let [event-body (update base-dm-event :event merge
+                               {:subtype "file_share"
+                                :text    "Here's my file"
+                                :files   [{:id          "F123"
+                                           :name        "document.pdf"
+                                           :filetype    "pdf"
+                                           :url_private "https://files.slack.com/files/document.pdf"
+                                           :size        100}]})]
         (with-upload-mocks!
           {:uploads-enabled? true}
           (fn [{:keys [upload-calls download-calls]}]
@@ -925,20 +821,16 @@
 (deftest csv-upload-non-csv-no-text-test
   (testing "POST /events with non-CSV file and no text responds directly without AI"
     (with-slackbot-setup
-      (let [event-body {:type "event_callback"
-                        :event {:type "message"
-                                :subtype "file_share"
-                                ;; No :text field - user uploaded file without typing anything
-                                :user "U123"
-                                :channel "C123"
-                                :channel_type "im"
-                                :ts "1234567890.000001"
-                                :event_ts "1234567890.000001"
-                                :files [{:id "F123"
-                                         :name "query_result.xlsx"
-                                         :filetype "xlsx"
-                                         :url_private "https://files.slack.com/files/query_result.xlsx"
-                                         :size 100}]}}]
+      ;; No :text field - user uploaded file without typing anything
+      (let [event-body (-> base-dm-event
+                           (update :event merge
+                                   {:subtype "file_share"
+                                    :files   [{:id          "F123"
+                                               :name        "query_result.xlsx"
+                                               :filetype    "xlsx"
+                                               :url_private "https://files.slack.com/files/query_result.xlsx"
+                                               :size        100}]})
+                           (update :event dissoc :text))]
         (with-upload-mocks!
           {:uploads-enabled? true}
           (fn [{:keys [upload-calls download-calls]}]
@@ -970,30 +862,24 @@
 (deftest csv-upload-mixed-files-test
   (testing "POST /events with mix of CSV and non-CSV files"
     (with-slackbot-setup
-      (let [event-body {:type "event_callback"
-                        :event {:type "message"
-                                :subtype "file_share"
-                                :text "Here are my files"
-                                :user "U123"
-                                :channel "C123"
-                                :channel_type "im"
-                                :ts "1234567890.000001"
-                                :event_ts "1234567890.000001"
-                                :files [{:id "F1"
-                                         :name "data.csv"
-                                         :filetype "csv"
-                                         :url_private "https://files.slack.com/files/data.csv"
-                                         :size 100}
-                                        {:id "F2"
-                                         :name "report.pdf"
-                                         :filetype "pdf"
-                                         :url_private "https://files.slack.com/files/report.pdf"
-                                         :size 200}
-                                        {:id "F3"
-                                         :name "more_data.tsv"
-                                         :filetype "tsv"
-                                         :url_private "https://files.slack.com/files/more_data.tsv"
-                                         :size 150}]}}]
+      (let [event-body (update base-dm-event :event merge
+                               {:subtype "file_share"
+                                :text    "Here are my files"
+                                :files   [{:id          "F1"
+                                           :name        "data.csv"
+                                           :filetype    "csv"
+                                           :url_private "https://files.slack.com/files/data.csv"
+                                           :size        100}
+                                          {:id          "F2"
+                                           :name        "report.pdf"
+                                           :filetype    "pdf"
+                                           :url_private "https://files.slack.com/files/report.pdf"
+                                           :size        200}
+                                          {:id          "F3"
+                                           :name        "more_data.tsv"
+                                           :filetype    "tsv"
+                                           :url_private "https://files.slack.com/files/more_data.tsv"
+                                           :size        150}]})]
         (with-upload-mocks!
           {:uploads-enabled? true
            :upload-result {:id 789 :name "Uploaded Data"}}
@@ -1020,20 +906,14 @@
   (testing "POST /events with file exceeding size limit"
     (with-slackbot-setup
       (let [too-large-size (inc (* 1024 1024 1024)) ;; Just over 1GB
-            event-body {:type "event_callback"
-                        :event {:type "message"
-                                :subtype "file_share"
-                                :text "Here's my huge file"
-                                :user "U123"
-                                :channel "C123"
-                                :channel_type "im"
-                                :ts "1234567890.000001"
-                                :event_ts "1234567890.000001"
-                                :files [{:id "F123"
-                                         :name "huge_data.csv"
-                                         :filetype "csv"
-                                         :url_private "https://files.slack.com/files/huge_data.csv"
-                                         :size too-large-size}]}}]
+            event-body    (update base-dm-event :event merge
+                                  {:subtype "file_share"
+                                   :text    "Here's my huge file"
+                                   :files   [{:id          "F123"
+                                              :name        "huge_data.csv"
+                                              :filetype    "csv"
+                                              :url_private "https://files.slack.com/files/huge_data.csv"
+                                              :size        too-large-size}]})]
         (with-upload-mocks!
           {:uploads-enabled? true}
           (fn [{:keys [upload-calls download-calls]}]
@@ -1055,20 +935,14 @@
 (deftest csv-upload-no-permission-test
   (testing "POST /events with file upload when user lacks permission"
     (with-slackbot-setup
-      (let [event-body {:type "event_callback"
-                        :event {:type "message"
-                                :subtype "file_share"
-                                :text "Here's my data"
-                                :user "U123"
-                                :channel "C123"
-                                :channel_type "im"
-                                :ts "1234567890.000001"
-                                :event_ts "1234567890.000001"
-                                :files [{:id "F123"
-                                         :name "data.csv"
-                                         :filetype "csv"
-                                         :url_private "https://files.slack.com/files/data.csv"
-                                         :size 100}]}}]
+      (let [event-body (update base-dm-event :event merge
+                               {:subtype "file_share"
+                                :text    "Here's my data"
+                                :files   [{:id          "F123"
+                                           :name        "data.csv"
+                                           :filetype    "csv"
+                                           :url_private "https://files.slack.com/files/data.csv"
+                                           :size        100}]})]
         (with-upload-mocks!
           {:uploads-enabled? true
            :can-create-upload? false}
@@ -1143,14 +1017,10 @@
 (deftest channel-message-without-mention-no-auth-test
   (testing "POST /events with channel message (no @mention) from unlinked user should NOT send auth message"
     (with-slackbot-setup
-      (let [event-body {:type "event_callback"
-                        :event {:type "message"
-                                :text "Hello everyone!"
-                                :user "U-UNKNOWN-USER"
-                                :channel "C123"
-                                :ts "1234567890.000001"
-                                :event_ts "1234567890.000001"
-                                :channel_type "channel"}}]
+      (let [event-body (update base-dm-event :event merge
+                               {:text         "Hello everyone!"
+                                :user         "U-UNKNOWN-USER"
+                                :channel_type "channel"})]
         (with-slackbot-mocks
           {:ai-text "Should not be called"
            :user-id ::no-user}
@@ -1169,14 +1039,9 @@
 (deftest channel-message-without-mention-linked-user-test
   (testing "POST /events with channel message from linked user should be silently ignored"
     (with-slackbot-setup
-      (let [event-body {:type "event_callback"
-                        :event {:type "message"
-                                :text "Hello team!"
-                                :user "U123"
-                                :channel "C123"
-                                :ts "1234567890.000001"
-                                :event_ts "1234567890.000001"
-                                :channel_type "channel"}}]
+      (let [event-body (update base-dm-event :event merge
+                               {:text         "Hello team!"
+                                :channel_type "channel"})]
         (with-slackbot-mocks
           {:ai-text "Should not be called"}
           (fn [{:keys [post-calls ephemeral-calls]}]


### PR DESCRIPTION
* Fix issue where appdb setting values would get re-encrypted with the test encryption key when restored. We can just use the test key when no encryption key is actually set
* A variety of other no-op refactor/code deduplication in the slackbot test file