### PR TITLE
Fix e2e `dashboard-questions.cy.spec.js` scrollTo flakes

### DIFF
--- a/e2e/test/scenarios/dashboard/dashboard-questions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-questions.cy.spec.js
@@ -404,9 +404,9 @@ describe("Dashboard > Dashboard Questions", () => {
         cy.button("Save").click();
       });
 
-      cy.wait(5000);
-
-      cy.findByTestId("edit-bar").button("Save").click();
+      cy.findByTestId("edit-bar", { timeout: 10 * 1000 }) // time for this to appear in CI can be > 5 seconds
+        .button("Save")
+        .click();
       H.dashboardCards().findByText("Half Orders");
     });
 

--- a/e2e/test/scenarios/dashboard/dashboard-questions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-questions.cy.spec.js
@@ -392,6 +392,8 @@ describe("Dashboard > Dashboard Questions", () => {
     });
 
     it("can save a native question to a dashboard", () => {
+      cy.intercept("POST", "/api/card").as("createCard");
+
       H.startNewNativeQuestion({ query: "SELECT 123" });
 
       // this reduces the flakiness
@@ -404,9 +406,8 @@ describe("Dashboard > Dashboard Questions", () => {
         cy.button("Save").click();
       });
 
-      cy.findByTestId("edit-bar", { timeout: 10 * 1000 }) // time for this to appear in CI can be > 5 seconds
-        .button("Save")
-        .click();
+      cy.wait("@createCard", { timeout: 30 * 1000 }); // trying something dumb...
+      cy.findByTestId("edit-bar").button("Save").click();
       H.dashboardCards().findByText("Half Orders");
     });
 

--- a/e2e/test/scenarios/dashboard/dashboard-questions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-questions.cy.spec.js
@@ -43,11 +43,12 @@ describe("Dashboard > Dashboard Questions", () => {
       H.modal().findByText("Orders in a dashboard");
       H.modal().button("Save").click();
 
-      // should take you to the edit dashboard screen + url has hash param to auto-scroll
+      // should take you to the edit dashboard screen and auto-scroll to the new card
       cy.url().should("include", "/dashboard/");
-      // FIXME: Re-visit the assertion (GDGT-1856)
-      // cy.location("hash").should("match", /scrollTo=\d+/); // url should have hash param to auto-scroll
-      H.dashboardCards().findByText("Orders with a discount");
+      cy.location("hash").should("not.include", "scrollTo");
+      H.dashboardCards()
+        .findByText("Orders with a discount")
+        .should("be.visible");
       cy.findByTestId("edit-bar").findByText("You're editing this dashboard.");
 
       // we can't use the save dashboard util, because we're not actually saving any changes
@@ -202,10 +203,10 @@ describe("Dashboard > Dashboard Questions", () => {
         cy.button("Okay").click();
       });
 
-      // its in the new dash + url has hash param to auto-scroll
+      // its in the new dash and auto-scrolls to the card
       cy.url().should("include", "/dashboard/");
-      // FIXME: Re-visit the assertion (GDGT-1856)
-      // cy.location("hash").should("match", /scrollTo=\d+/); // url should have hash param to auto-scroll
+      cy.location("hash").should("not.include", "scrollTo");
+      H.dashboardCards().findByText("Total Orders").should("be.visible");
       H.undoToast().findByText("Orders in a dashboard");
       H.dashboardCards().should("contain", "Total Orders");
 
@@ -968,13 +969,12 @@ describe("Dashboard > Dashboard Questions", () => {
 
       cy.log("should navigate user to the tab the question was saved to");
       cy.url().should("include", "/dashboard/");
-      // FIXME: Re-visit the assertion (GDGT-1856)
-      // cy.location("hash").should("match", /scrollTo=\d+/); // url should have hash param to auto-scroll
+      cy.location("hash").should("not.include", "scrollTo");
       cy.location("search").should("contain", "tab"); // url should have tab param configured
       H.assertTabSelected(TAB_TWO_NAME);
-      H.dashboardCards().within(() => {
-        cy.findByText(DASHBOARD_QUESTION_NAME).should("exist");
-      });
+      H.dashboardCards()
+        .findByText(DASHBOARD_QUESTION_NAME)
+        .should("be.visible");
     });
 
     it("should allow a user to copy a question into a tab", () => {
@@ -1013,13 +1013,12 @@ describe("Dashboard > Dashboard Questions", () => {
 
       cy.log("should navigate user to the tab the question was saved to");
       cy.url().should("include", "/dashboard/");
-      // FIXME: Re-visit the assertion (GDGT-1856)
-      // cy.location("hash").should("match", /scrollTo=\d+/); // url should have hash param to auto-scroll
+      cy.location("hash").should("not.include", "scrollTo");
       cy.location("search").should("contain", "tab"); // url should have tab param configured
       H.assertTabSelected(TAB_ONE_NAME);
-      H.dashboardCards().within(() => {
-        cy.findByText("Orders, Count - Duplicate").should("exist");
-      });
+      H.dashboardCards()
+        .findByText("Orders, Count - Duplicate")
+        .should("be.visible");
     });
   });
 

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -1107,8 +1107,8 @@ describe("scenarios > dashboard", () => {
 
         cy.log("should scroll into view w/ scrollTo hash param");
         cy.visit(`/dashboard/${dashboard.id}#scrollTo=${targetCard.id}`);
-        cy.location("hash").should("match", /scrollTo=\d+/); // url should have hash param to auto-scroll
-        cy.location("hash").should("not.include", "scrollTo"); // scrollTo param should get removed
+        // wait for scroll to complete (hash cleared) then verify visibility
+        cy.location("hash").should("not.include", "scrollTo");
         cy.findByText(TARGET_TEXT).should("be.visible");
       },
     );

--- a/e2e/test/scenarios/question/saved.cy.spec.js
+++ b/e2e/test/scenarios/question/saved.cy.spec.js
@@ -104,8 +104,8 @@ describe("scenarios > question > saved", () => {
     });
 
     cy.url().should("include", "/dashboard/");
-    cy.location("hash").should("match", /scrollTo=\d+/); // url should have hash param to auto-scroll
-    H.dashboardCards().findByText("Orders - Duplicate").should("exist");
+    cy.location("hash").should("not.include", "scrollTo");
+    H.dashboardCards().findByText("Orders - Duplicate").should("be.visible");
   });
 
   it("should duplicate a saved question to a collection created on the go", () => {


### PR DESCRIPTION
The `scrollTo` hash param gets cleared in `use-auto-scroll-to-dashcard.ts` meaning these assertions were race conditions. We should have been asserting on visibility and that the params are cleared like we expect (we want the value to be removed, as changing tabs in the dashboard might cause you to auto scroll to some card on the page unexpectedly).