### PR TITLE
[MBQL lib] Stop using ID-based refs for fields from joined cards

### DIFF
--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -1467,7 +1467,7 @@ function(bin) {
         (str/split (field-alias field-clause) #"\.")
 
         [:field (field-name :guard string?) _]
-        [field-name]
+        (str/split (field-alias field-clause) #"\.")
 
         [:expression expr-name _]
         [expr-name])

--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -446,6 +446,10 @@
                                  (when-not inherited-column?
                                    (select-renamed-keys metadata field-ref-propagated-keys-for-non-inherited-columns)))
         id-or-name        (or (lib.field.util/inherited-column-name metadata)
+                              ;; For card-sourced columns (even via joins), use the string name
+                              ;; instead of a numeric field ID. QUE2-383
+                              (when (:lib/card-id metadata)
+                                (:lib/source-column-alias metadata))
                               ((some-fn :id :lib/source-column-alias :lib/deduplicated-name :lib/original-name :name) metadata))]
     [:field options id-or-name]))
 


### PR DESCRIPTION
Fixes QUE2-383.

### Description

Uses `:lib/card-id` in metadata to check if a column came from a card at any point. If so, it should use a name-based `:field` ref rather than an ID-based one. This makes the refs to joined columns consistent with those to main source columns, based on whether the source is a table or card.

### How to verify

All tests are passing. To check it in the app:

1. Create a card which wraps a table, eg. Products
2. Join a card into a query, eg. Orders table joined to the Products Card from above.
3. Edit the join condition to something nonstandard, like `Orders.ID = Products.QUANTITY`
    - The join conditions should use name-based `:field` refs.
    - Note that *suggested* join conditions use a different code path that didn't show this bug.
4. Similarly, any downstream ref to a joined column, eg. in a filter on the same stage, would use an ID-based ref before but is now name-based.
    - Whether the join condition is suggested or strange.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
-  ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
