### PR TITLE
Support DB-local settings in the JVM and JS metadata-providers

### DIFF
--- a/src/metabase/lib/js/metadata.cljs
+++ b/src/metabase/lib/js/metadata.cljs
@@ -178,6 +178,7 @@
       :dbms-version       (js->clj v :keywordize-keys true)
       :features           (into #{} (map keyword) v)
       :native-permissions (keyword v)
+      :settings           (js->clj v :keywordize-keys true)
       v)))
 
 (defmethod parse-objects-default-key :database
@@ -589,7 +590,9 @@
        (metadatas [_this metadata-spec]
          (metadatas metadata database-id metadata-spec))
        (setting [_this setting-key]
-         (setting unparsed-metadata setting-key))
+         (get (:settings (database metadata database-id))
+              setting-key
+              (setting unparsed-metadata setting-key)))
 
       ;; for debugging: call [[clojure.datafy/datafy]] on one of these to parse all of our metadata and see the whole
       ;; thing at once.

--- a/src/metabase/lib_be/metadata/jvm.clj
+++ b/src/metabase/lib_be/metadata/jvm.clj
@@ -547,7 +547,10 @@
   (metadatas [_this metadata-spec]
     (metadatas database-id metadata-spec))
   (setting [_this setting-name]
-    (setting/get setting-name))
+    (if (setting/database-local-values)
+      (setting/get setting-name)
+      (setting/with-database (database database-id)
+        (setting/get setting-name))))
 
   pretty/PrettyPrintable
   (pretty [_this]

--- a/test/metabase/lib/js/metadata_test.cljs
+++ b/test/metabase/lib/js/metadata_test.cljs
@@ -89,3 +89,14 @@
   (testing "other lib/source values are handled correctly"
     (let [column (lib.js.metadata/parse-column #js {"name" "id", "lib/source" "source/table-defaults"})]
       (is (= :source/table-defaults (:lib/source column))))))
+
+(deftest ^:parallel database-local-settings-test
+  (testing "JS metadata provider should return database-local Settings over global ones"
+    (let [metadata #js {:databases #js {"1" #js {:id 1
+                                                 :engine "h2"
+                                                 :name "test-db"
+                                                 :settings #js {:unaggregated-query-row-limit 1234}}}
+                        :settings  #js {:unaggregated-query-row-limit 2000}}
+          mp (lib.js.metadata/metadata-provider 1 metadata)]
+      (is (= 1234
+             (lib.metadata/setting mp :unaggregated-query-row-limit))))))


### PR DESCRIPTION
Closes QUE2-292

### Description

Adds support in the JVM and JS metadata-providers for DB-local settings.

### How to verify

See the new tests.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
