### PR TITLE
fix: new SQL questions automatically open DataReference sidebar

### DIFF
--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -13,7 +13,7 @@ import { t } from "ttag";
 
 import { useListCollectionsQuery, useListSnippetsQuery } from "metabase/api";
 import { useSelector } from "metabase/lib/redux";
-import { PLUGIN_REMOTE_SYNC } from "metabase/plugins";
+import { PLUGIN_METABOT, PLUGIN_REMOTE_SYNC } from "metabase/plugins";
 import { SnippetFormModal } from "metabase/query_builder/components/template_tags/SnippetFormModal";
 import type { QueryModalType } from "metabase/query_builder/constants";
 import { useNotebookScreenSize } from "metabase/query_builder/hooks/use-notebook-screen-size";
@@ -193,7 +193,11 @@ export const NativeQueryEditor = forwardRef<
 
   // do not show reference sidebar on small screens automatically
   const screenSize = useNotebookScreenSize();
-  const shouldOpenDataReference = screenSize !== "small";
+  const isMetabotSidebarOpen = useSelector((state) =>
+    PLUGIN_METABOT.getMetabotVisible(state, "omnibot"),
+  );
+  const shouldOpenDataReference =
+    screenSize !== "small" && !isMetabotSidebarOpen;
 
   useMount(() => {
     setIsNativeEditorOpen?.(

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.unit.spec.tsx
@@ -1,0 +1,105 @@
+import { setupEnterpriseOnlyPlugin } from "__support__/enterprise";
+import {
+  setupCollectionsEndpoints,
+  setupNativeQuerySnippetEndpoints,
+} from "__support__/server-mocks";
+import { mockSettings } from "__support__/settings";
+import { renderWithProviders } from "__support__/ui";
+import { useNotebookScreenSize } from "metabase/query_builder/hooks/use-notebook-screen-size";
+import { createMockTokenFeatures } from "metabase-types/api/mocks";
+import { createMockState } from "metabase-types/store/mocks";
+
+import { NativeQueryEditor } from "./NativeQueryEditor";
+
+jest.mock("metabase/query_builder/hooks/use-notebook-screen-size", () => ({
+  useNotebookScreenSize: jest.fn(),
+}));
+
+type UseNotebookScreenSize = ReturnType<typeof useNotebookScreenSize>;
+
+const useNotebookScreenSizeMock = useNotebookScreenSize as jest.MockedFunction<
+  () => UseNotebookScreenSize
+>;
+
+const mockQuestion = {
+  isSaved: () => false,
+} as any;
+
+describe("NativeQueryEditor", () => {
+  beforeAll(() => {
+    mockSettings({
+      "token-features": createMockTokenFeatures({
+        metabot_v3: true,
+      }),
+    });
+
+    setupEnterpriseOnlyPlugin("metabot");
+  });
+
+  const createEditor = (
+    screenSize: Exclude<UseNotebookScreenSize, undefined>,
+    isMetabotSidebarOpen: boolean,
+  ) => {
+    const setIsNativeEditorOpen = jest.fn();
+
+    const metabotState = {
+      conversations: {
+        omnibot: {
+          visible: isMetabotSidebarOpen,
+        },
+      },
+    };
+
+    setupCollectionsEndpoints({
+      collections: [],
+    });
+    setupNativeQuerySnippetEndpoints();
+
+    useNotebookScreenSizeMock.mockReturnValue(screenSize);
+
+    renderWithProviders(
+      <NativeQueryEditor
+        availableHeight={700}
+        isNativeEditorOpen={false}
+        question={mockQuestion}
+        query={null as any}
+        setDatasetQuery={jest.fn()}
+        setIsNativeEditorOpen={setIsNativeEditorOpen}
+        isInitiallyOpen={false}
+        hasTopBar={false}
+      />,
+      {
+        storeInitialState: createMockState({
+          plugins: {
+            metabotPlugin: metabotState,
+          },
+        } as any),
+      },
+    );
+
+    return setIsNativeEditorOpen;
+  };
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    useNotebookScreenSizeMock.mockReset();
+  });
+
+  it("should not open data reference when metabot sidebar is open", () => {
+    const setIsNativeEditorOpen = createEditor("large", true);
+
+    expect(setIsNativeEditorOpen).toHaveBeenCalledWith(false, false);
+  });
+
+  it("should not open data reference on small screens", () => {
+    const setIsNativeEditorOpen = createEditor("small", false);
+
+    expect(setIsNativeEditorOpen).toHaveBeenCalledWith(false, false);
+  });
+
+  it("should open data reference when metabot is closed", () => {
+    const setIsNativeEditorOpen = createEditor("large", false);
+
+    expect(setIsNativeEditorOpen).toHaveBeenCalledWith(false, true);
+  });
+});


### PR DESCRIPTION
Closes [BOT-589: New SQL questions automatically open DataReference sidebar](https://linear.app/metabase/issue/BOT-589/new-sql-questions-automatically-open-datareference-sidebar)

### Description

Visiting the SQL editor automatically opens the data reference sidebar, this also happens when Metabot creates or edits a query for you, so this PR prevents showing the sidebar by default is the Metabot sidebar is already open.

### How to verify

1. Open metabot sidebar
2. Ask it to create some SQL

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
