### PR TITLE
BOT-1051 Fix provider in generate-example-questions

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/example_question_generator.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/example_question_generator.clj
@@ -15,6 +15,7 @@
   (:require
    [clojure.java.io :as io]
    [clojure.string :as str]
+   [metabase-enterprise.llm.settings :as llm]
    [metabase-enterprise.metabot-v3.self :as self]
    [metabase.util.log :as log]
    [selmer.parser :as selmer]))
@@ -104,7 +105,7 @@
   retry logic, error handling, and OTel tracing."
   [rendered-prompt]
   (self/call-llm-structured
-   "anthropic/claude-haiku-4-5"
+   (llm/ee-ai-metabot-provider)
    "example-question-generation"
    [{:role "user" :content rendered-prompt}]
    questions-json-schema


### PR DESCRIPTION
Closes [BOT-1051: Fix provider in generate-example-questions](https://linear.app/metabase/issue/BOT-1051/fix-provider-in-generate-example-questions)

### Description

After #70061 `call-llm-structured` now expects the model to include a provider prefix, so "anthropic/claude-haiku-4-5" was getting parsed as :provider "anthropic" :model "claude-haiku-4-5".

Update `metabase-enterprise.metabot-v3.example-question-generator/call-llm` to use the provider + model configured via `llm/ee-ai-metabot-provider` instead of hard-coded "anthropic/claude-haiku-4-5".

### How to verify

Start up metabase with fresh app db and only openrouter api key in env, no anthropic key.

#### before

```
2026-02-25 17:44:47,707 ERROR metabot-v3.suggested-prompts :: Native example question generation failed, falling back to Python ai-service {:error-class java.util.concurrent.ExecutionException, :error-msg clojure.lang.ExceptionInfo: No Anthropic API key is set {}} {mb-quartz-job-type=SuggestedPromptsGenerator}
java.util.concurrent.ExecutionException: clojure.lang.ExceptionInfo: No Anthropic API key is set {}
	at java.base/java.util.concurrent.FutureTask.report(FutureTask.java:122)
	at java.base/java.util.concurrent.FutureTask.get(FutureTask.java:191)
	at clojure.core$deref_future.invokeStatic(core.clj:2317)
	at clojure.core$future_call$reify__8578.deref(core.clj:7121)
	at clojure.core$deref.invokeStatic(core.clj:2337)
	at clojure.core$deref.invoke(core.clj:2323)
	at clojure.core$mapv$fn__8569.invoke(core.clj:7059)
	at clojure.lang.PersistentVector.reduce(PersistentVector.java:418)
	at clojure.core$reduce.invokeStatic(core.clj:6964)
	at clojure.core$mapv.invokeStatic(core.clj:7050)
	at clojure.core$mapv.invoke(core.clj:7050)
	at metabase_enterprise.metabot_v3.example_question_generator$process_batch_parallel$fn__190568.invoke(example_question_generator.clj:153)
```

#### after

```
2026-02-25 18:03:39,987 INFO metabot-v3.suggested-prompts :: Using native generator for example questions {:table-count 1, :metric-count 2} {mb-quartz-job-type=SuggestedPromptsGenerator}
2026-02-25 18:03:39,988 INFO metabot-v3.example-question-generator :: Generating example questions natively {:table-count 1, :metric-count 2} {mb-quartz-job-type=SuggestedPromptsGenerator}
2026-02-25 18:03:40,004 INFO metabot-v3.self :: Calling LLM (structured) {:provider openrouter, :model anthropic/claude-haiku-4-5, :msg-count 1}
2026-02-25 18:03:41,532 INFO self.openrouter :: :metabot-v3.openrouter/request (1524.759958ms) {:model "anthropic/claude-haiku-4-5", :msg-count 1, :tool-count 0}
2026-02-25 18:03:42,275 INFO metabot-v3.self :: :metabot-v3.agent/call-llm-structured (2270.292791ms) {:model "anthropic/claude-haiku-4-5", :msg-count 1}
2026-02-25 18:03:42,281 INFO metabot-v3.self :: Calling LLM (structured) {:provider openrouter, :model anthropic/claude-haiku-4-5, :msg-count 1}
2026-02-25 18:03:42,281 INFO metabot-v3.self :: Calling LLM (structured) {:provider openrouter, :model anthropic/claude-haiku-4-5, :msg-count 1}
2026-02-25 18:03:43,074 INFO self.openrouter :: :metabot-v3.openrouter/request (792.681083ms) {:model "anthropic/claude-haiku-4-5", :msg-count 1, :tool-count 0}
2026-02-25 18:03:43,379 INFO self.openrouter :: :metabot-v3.openrouter/request (1097.916ms) {:model "anthropic/claude-haiku-4-5", :msg-count 1, :tool-count 0}
2026-02-25 18:03:43,655 INFO metabot-v3.self :: :metabot-v3.agent/call-llm-structured (1374.338833ms) {:model "anthropic/claude-haiku-4-5", :msg-count 1}
2026-02-25 18:03:43,931 INFO metabot-v3.self :: :metabot-v3.agent/call-llm-structured (1649.986084ms) {:model "anthropic/claude-haiku-4-5", :msg-count 1}
2026-02-25 18:03:43,931 INFO metabot-v3.example-question-generator :: Native example question generation complete {:table-results 1, :metric-results 2} {mb-quartz-job-type=SuggestedPromptsGenerator}
2026-02-25 18:03:43,932 INFO metabot-v3.suggested-prompts :: Native example question generation succeeded {:table-results 1, :metric-results 2} {mb-quartz-job-type=SuggestedPromptsGenerator}
2026-02-25 18:03:43,936 INFO task.suggested-prompts-generator :: Suggested prompts generated successfully. {mb-quartz-job-type=SuggestedPromptsGenerator}
```

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
