### PR TITLE
Report QP errors to Slack, and run queries off the main thread

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot.clj
@@ -175,13 +175,13 @@
         (catch Exception e
           (log/errorf e "[slackbot] Error processing %s: %s" event-type (ex-message e)))))))
 
-(defn ignore-event
+(defn- ignore-event
   "Handle any event we don't care to process"
   [event]
   (log/debugf "[slackbot] Ignoring event type=%s channel_type=%s subtype=%s ts=%s"
               (:type event) (:channel_type event) (:subtype event) (:ts event)))
 
-(defn assert-setup-complete
+(defn- assert-setup-complete
   "Asserts that all required Slack settings have been configured."
   []
   (when-not (slackbot.config/setup-complete?)

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/client.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/client.clj
@@ -23,7 +23,7 @@
     {:body (json/decode (:body response) true)
      :headers (:headers response)}))
 
-(defn slack-post-json
+(defn- slack-post-json
   "POST to slack."
   [client endpoint payload]
   (let [response (http/post (str "https://slack.com/api" endpoint)

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/client.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/client.clj
@@ -9,37 +9,49 @@
 
 (set! *warn-on-reflection* true)
 
+(def ^:private streaming-connection-timeout-ms
+  "TCP connection timeout for streaming API calls."
+  5000)
+
+(def ^:private streaming-socket-timeout-ms
+  "Socket (read) timeout for streaming API calls (start/append/stop).
+   Streaming calls are in the hot path of text delivery — if they block, the agent queue
+   backs up and the request-handling thread hangs on `await`."
+  5000)
+
 (def SlackClient
   "Malli schema for a Slack client."
   [:map {:closed true}
    [:token ms/NonBlankString]])
 
 (defn- slack-get
-  "GET from slack"
+  "GET from slack."
   [client endpoint params]
   (let [response (http/get (str "https://slack.com/api" endpoint)
-                           {:headers {"Authorization" (str "Bearer " (:token client))}
+                           {:headers      {"Authorization" (str "Bearer " (:token client))}
                             :query-params params})]
     {:body (json/decode (:body response) true)
      :headers (:headers response)}))
 
 (defn- slack-post-json
   "POST to slack."
-  [client endpoint payload]
+  [client endpoint payload & {:keys [socket-timeout connection-timeout]}]
   (let [response (http/post (str "https://slack.com/api" endpoint)
-                            {:headers {"Authorization" (str "Bearer " (:token client))}
-                             :content-type "application/json; charset=utf-8"
-                             :body (json/encode payload)})]
+                            (cond-> {:headers      {"Authorization" (str "Bearer " (:token client))}
+                                     :content-type "application/json; charset=utf-8"
+                                     :body         (json/encode payload)}
+                              connection-timeout (assoc :connection-timeout connection-timeout)
+                              socket-timeout     (assoc :socket-timeout socket-timeout)))]
     {:body (json/decode (:body response) true)
      :headers (:headers response)}))
 
 (defn- slack-post-form
-  "POST form to slack"
+  "POST form to slack."
   [client endpoint payload]
   (-> (http/post (str "https://slack.com/api" endpoint)
-                 {:headers {"Authorization" (str "Bearer " (:token client))
-                            "Content-Type" "application/x-www-form-urlencoded; charset=utf-8"}
-                  :form-params payload})
+                 {:headers     {"Authorization" (str "Bearer " (:token client))}
+                  :content-type "application/x-www-form-urlencoded; charset=utf-8"
+                  :form-params  payload})
       :body
       (json/decode true)))
 
@@ -109,7 +121,7 @@
     (when ok
       (http/post upload_url
                  {:headers {"Content-Type" "image/png"}
-                  :body image-bytes})
+                  :body    image-bytes})
       (:body (slack-post-json client "/files.completeUploadExternal"
                               {:files [{:id file_id
                                         :title filename}]
@@ -127,7 +139,7 @@
    Returns byte array of file contents."
   [client url]
   (-> (http/get url {:headers {"Authorization" (str "Bearer " (:token client))}
-                     :as :byte-array})
+                     :as      :byte-array})
       :body))
 
 ;; -------------------- SLACK STREAMING API --------------------
@@ -141,7 +153,9 @@
                                      {:channel           channel
                                       :thread_ts         thread_ts
                                       :recipient_team_id team_id
-                                      :recipient_user_id user_id}))]
+                                      :recipient_user_id user_id}
+                                     :connection-timeout streaming-connection-timeout-ms
+                                     :socket-timeout     streaming-socket-timeout-ms))]
     (log/debugf "[slackbot] start-stream response: %s" (pr-str body))
     (if (:ok body)
       {:stream_ts (:ts body)
@@ -156,7 +170,9 @@
   (let [payload  {:channel channel
                   :ts      stream-ts
                   :chunks  chunks}
-        body (:body (slack-post-json client "/chat.appendStream" payload))]
+        body (:body (slack-post-json client "/chat.appendStream" payload
+                                     :connection-timeout streaming-connection-timeout-ms
+                                     :socket-timeout     streaming-socket-timeout-ms))]
     (when-not (:ok body)
       (log/warnf "[slackbot] append-stream failed: %s" (:error body)))
     body))
@@ -174,7 +190,9 @@
    (let [body (:body (slack-post-json client "/chat.stopStream"
                                       (cond-> {:channel channel
                                                :ts      stream-ts}
-                                        blocks (assoc :blocks blocks))))]
+                                        blocks (assoc :blocks blocks))
+                                      :connection-timeout streaming-connection-timeout-ms
+                                      :socket-timeout     streaming-socket-timeout-ms))]
      (when-not (:ok body)
        (log/warnf "[slackbot] stop-stream failed: %s" (:error body)))
      body)))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/client.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/client.clj
@@ -14,9 +14,7 @@
   5000)
 
 (def ^:private streaming-socket-timeout-ms
-  "Socket (read) timeout for streaming API calls (start/append/stop).
-   Streaming calls are in the hot path of text delivery — if they block, the agent queue
-   backs up and the request-handling thread hangs on `await`."
+  "Socket (read) timeout for streaming API calls (start/append/stop)."
   5000)
 
 (def SlackClient

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/query.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/query.clj
@@ -194,30 +194,6 @@
                                              width
                                              options)))
 
-(defn generate-card-png
-  "Generate PNG for a card. Accepts either:
-   - card-id (integer) - fetches saved card from database
-   - adhoc-card (map) - renders ad-hoc card with :display, :visualization_settings, :results, :name"
-  [card-or-id & {:as opts}]
-  (if (integer? card-or-id)
-    (let [card (t2/select-one :model/Card :id card-or-id)]
-      (when-not card
-        (throw (ex-info "Card not found" {:card-id card-or-id :agent-error? true})))
-      (render-saved-card-png card opts))
-    (let [{:keys [width padding-x padding-y]
-           :or   {width 1280 padding-x 32 padding-y 0}} opts
-          options {:channel.render/include-title? true
-                   :channel.render/padding-x padding-x
-                   :channel.render/padding-y padding-y}
-          {:keys [display visualization_settings results name]} card-or-id]
-      (channel.render/render-adhoc-card-to-png
-       {:display                display
-        :visualization_settings visualization_settings
-        :name                   name}
-       results
-       width
-       options))))
-
 (defn generate-card-output
   "Generate output for a saved card based on its display type.
    Returns a map with :type (:table or :image) and :content.
@@ -227,7 +203,7 @@
   [card-id]
   (let [card (t2/select-one :model/Card :id card-id)]
     (when-not card
-      (throw (ex-info "Card not found" {:card-id card-id :agent-error? true})))
+      (throw (ex-info "Card not found" {:card-id card-id :type :card-not-found})))
     (if (-> card :display keyword supported-png-display-types)
       {:type    :image
        :content (render-saved-card-png card {})}

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/streaming.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/streaming.clj
@@ -19,13 +19,18 @@
 
 (set! *warn-on-reflection* true)
 
+(def ^:private viz-prefetch-pool-size
+  "Maximum number of visualization rendering threads. Limits concurrent query execution
+   during streaming so we don't overwhelm the QP or database connections."
+  8)
+
 (defonce ^:private ^ExecutorService viz-prefetch-executor
   (let [counter (atom 0)
         factory (reify ThreadFactory
                   (newThread [_ r]
                     (doto (Thread. r (str "viz-prefetch-" (swap! counter inc)))
                       (.setDaemon true))))]
-    (Executors/newFixedThreadPool 8 factory)))
+    (Executors/newFixedThreadPool viz-prefetch-pool-size factory)))
 
 (defn- strip-bot-mention
   "Remove bot mention prefix from text (e.g., '<@U123> hello' -> 'hello')"

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
@@ -735,7 +735,7 @@
                                                      (throw (ex-info "Unexpected render error" {})))]
               (mt/client :post 200 "ee/metabot-v3/slack/events"
                          (slack-request-options event-body) event-body)
-              (let [error-msg "Something went wrong while generating this visualization."]
+              (let [error-msg "Query execution failed, please try again."]
                 (u/poll {:thunk      #(and (>= (count @stop-stream-calls) 1)
                                            (some (fn [m] (= error-msg (:text m))) @post-calls))
                          :done?      true?
@@ -769,7 +769,7 @@
                        :done?      true?
                        :timeout-ms 5000})
               (testing "error message posted for failing viz"
-                (is (some #(= "Something went wrong while generating this visualization." (:text %))
+                (is (some #(= "Query execution failed, please try again." (:text %))
                           @post-calls)))
               (testing "second card still rendered"
                 (is (= 1 (count @image-calls)))))))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
@@ -376,12 +376,13 @@
                                         (slack-request-options event-body)
                                         event-body)]
                 (is (= "ok" response))
-                (u/poll {:thunk #(>= (count @post-calls) 1)
+                (u/poll {:thunk #(some (fn [m] (= "I wasn't able to generate a response. Please try again." (:text m)))
+                                       @post-calls)
                          :done? true?
                          :timeout-ms 5000})
                 (testing "fallback message is sent"
-                  (is (= "I wasn't able to generate a response. Please try again."
-                         (:text (first @post-calls)))))
+                  (is (some #(= "I wasn't able to generate a response. Please try again." (:text %))
+                            @post-calls)))
                 (testing "stop-stream is never called"
                   (is (= 0 (count @stop-stream-calls))))))))))))
 

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
@@ -740,7 +740,7 @@
           (fn [{:keys [post-calls stop-stream-calls]}]
             (mt/with-dynamic-fn-redefs
               [slackbot.query/generate-card-output (fn [_card-id]
-                                                     (throw (ex-info "Card not found" {})))]
+                                                     (throw (ex-info "Unexpected render error" {})))]
               (mt/client :post 200 "ee/metabot-v3/slack/events"
                          (slack-request-options event-body) event-body)
               (let [error-msg "Something went wrong while generating this visualization."]
@@ -768,7 +768,7 @@
             (mt/with-dynamic-fn-redefs
               [slackbot.query/generate-card-output (fn [card-id]
                                                      (if (= card-id 999999)
-                                                       (throw (ex-info "Card not found" {}))
+                                                       (throw (ex-info "Unexpected render error" {}))
                                                        {:type :image :content fake-png}))]
               (mt/client :post 200 "ee/metabot-v3/slack/events"
                          (slack-request-options event-body) event-body)

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/middleware/auth_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/middleware/auth_test.clj
@@ -4,7 +4,6 @@
    [buddy.core.codecs :as codecs]
    [buddy.core.mac :as mac]
    [clojure.test :refer :all]
-   [metabase-enterprise.metabot-v3.settings :as metabot.settings]
    [metabase.server.middleware.auth :as mw.auth]
    [metabase.test :as mt]
    [ring.mock.request :as ring.mock]))
@@ -45,7 +44,7 @@
   (mt/with-premium-features #{:metabot-v3}
     (with-redefs [mw.auth/current-unix-timestamp (constantly test-timestamp)]
       (testing "Valid signature w/ signing secret configured"
-        (mt/with-temporary-setting-values [metabot.settings/metabot-slack-signing-secret test-signing-secret]
+        (mt/with-temporary-raw-setting-values [metabot-slack-signing-secret test-signing-secret]
           (let [body      "test-body"
                 timestamp (str test-timestamp)
                 signature (compute-slack-signature body timestamp test-signing-secret)
@@ -53,7 +52,7 @@
             (is (true? (:slack/validated? result))))))
 
       (testing "Invalid signature"
-        (mt/with-temporary-setting-values [metabot.settings/metabot-slack-signing-secret test-signing-secret]
+        (mt/with-temporary-raw-setting-values [metabot-slack-signing-secret test-signing-secret]
           (let [body      "test-body"
                 timestamp (str test-timestamp)
                 signature "v0=invalid-signature"
@@ -68,7 +67,7 @@
           (is (not (contains? result :slack/validated?)))))
 
       (testing "No signing secret configured"
-        (mt/with-temporary-setting-values [metabot.settings/metabot-slack-signing-secret nil]
+        (mt/with-temporary-raw-setting-values [metabot-slack-signing-secret nil]
           (let [body      "test-body"
                 timestamp (str test-timestamp)
                 signature "v0=some-signature"
@@ -85,7 +84,7 @@
 
 (deftest verify-slack-request-timestamp-validation-test
   (mt/with-premium-features #{:metabot-v3}
-    (mt/with-temporary-setting-values [metabot.settings/metabot-slack-signing-secret test-signing-secret]
+    (mt/with-temporary-raw-setting-values [metabot-slack-signing-secret test-signing-secret]
       (with-redefs [mw.auth/current-unix-timestamp (constantly test-timestamp)]
         (testing "Replay attack prevention - rejects timestamps outside 5 minute window"
           (doseq [[expected offset-or-val description]

--- a/src/metabase/core/core.clj
+++ b/src/metabase/core/core.clj
@@ -112,6 +112,7 @@
   (let [timeout-seconds 20]
     (mdb/release-migration-locks! timeout-seconds))
   (perf/stop-monitoring!)
+  (shutdown-agents)
   (log/info "Metabase Shutdown COMPLETE"))
 
 (defenterprise ensure-audit-db-installed!

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -524,9 +524,12 @@
 
 (defn- upsert-raw-setting!
   [original-value setting-k value]
-  (if original-value
-    (t2/update! :model/Setting setting-k {:value value})
-    (t2/insert! :model/Setting :key setting-k :value value))
+  (if (some? value)
+    (if original-value
+      (t2/update! :model/Setting setting-k {:value value})
+      (t2/insert! :model/Setting :key setting-k :value value))
+    (when original-value
+      (t2/delete! :model/Setting :key setting-k)))
   (setting.cache/restore-cache!))
 
 (defn- restore-raw-setting!


### PR DESCRIPTION
- Surfaces QP errors to Slack when generating visualizations
- Doesn't block query execution on response streaming - queries get run on a dedicated thread pool as soon as the relevant data parts come in to reduce e2e query latency
- Refactors/modularizes streaming internals a bit
- Some test fixes to avoid corrupting encrypted settings when running tests
- Misc other cleanup

One thing to note: in a [previous commit on the feature branch](https://github.com/metabase/metabase/pull/68473/changes/f6c9ee2eb7cfd4bd56bb360dd9feb83bb5e9edac) I switched the streaming approach to use an `agent` for serializing the slack API calls and running them asynchronously off the thread that's reading tokens from AI service. Feel free to review this approach as part of this PR — it was a quick fix to address some stuttering behavior I was seeing with blocking Slack API calls. An `agent` is kind of neat since it removes some boilerplate around task queuing, but technically we're not utilizing the agent's state at all, just the serialization guarantee, so we could also just switch this to a dedicated `ExecutorService`. Technically the agent also uses an unbounded thread pool (via `send-off`) which I'm not overly concerned about since we're just using it for I/O dispatch, and I've added timeouts to our slack API calls so nothing should hang indefinitely.