### PR TITLE
Filter transforms based on permissions GHY-3152

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
@@ -67,7 +67,7 @@
                                           (update :dashboard #(some-> % (select-keys [:id :name])))
                                           (update :document #(some-> % (select-keys [:id :name])))))))
                       broken-cards)
-     :bad_transforms (into [] broken-transforms)}))
+     :bad_transforms (into [] (filter mi/can-read?) broken-transforms)}))
 
 (api.macros/defendpoint :post "/check-card" :- ::broken-cards-response
   "Check a proposed edit to a card, and return the card IDs for those cards this edit will break."

--- a/enterprise/backend/test/metabase_enterprise/dependencies/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/api_test.clj
@@ -3,6 +3,7 @@
    [clojure.test :refer :all]
    [medley.core :as m]
    [metabase-enterprise.dependencies.api :as deps.api]
+   [metabase-enterprise.dependencies.core :as dependencies]
    [metabase-enterprise.dependencies.events]
    [metabase-enterprise.dependencies.findings :as dependencies.findings]
    [metabase-enterprise.dependencies.task.backfill :as dependencies.backfill]
@@ -679,6 +680,31 @@
                                         {:id (:id transform)
                                          :source (:source transform)
                                          :target (:target transform)}))))))))
+
+(deftest check-card-bad-transforms-filtered-by-can-read-test
+  (testing "POST /api/ee/dependencies/check-card filters bad_transforms by mi/can-read?"
+    (mt/dataset test-data
+      (mt/with-premium-features #{:dependencies :transforms}
+        (mt/with-temp [:model/User user {:email "test@test.com"}
+                       :model/Transform transform {}]
+          (mt/with-model-cleanup [:model/Card :model/Dependency]
+            (let [base-card (card/create-card! (basic-card) user)
+                  proposed-card {:id (:id base-card)
+                                 :type :question
+                                 :dataset_query (:dataset_query base-card)}]
+              ;; Mock errors-from-proposed-edits to report the transform as broken
+              (with-redefs [dependencies/errors-from-proposed-edits
+                            (constantly {:transform {(:id transform) #{:some-error}}})]
+                (testing "Admin sees broken transforms in response"
+                  (let [response (mt/user-http-request :crowberto :post 200 "ee/dependencies/check-card"
+                                                       proposed-card)]
+                    (is (false? (:success response)))
+                    (is (=? [{:id (:id transform)}]
+                            (:bad_transforms response)))))
+                (testing "Non-admin user cannot see broken transforms they lack read permission for"
+                  (let [response (mt/user-http-request :rasta :post 200 "ee/dependencies/check-card"
+                                                       proposed-card)]
+                    (is (= [] (:bad_transforms response)))))))))))))
 
 (deftest graph-permissions-test
   (testing "GET /api/ee/dependencies/graph requires read permissions on the starting entity"


### PR DESCRIPTION
Closes [GHY-3152](https://linear.app/metabase/issue/GHY-3152/add-permission-checks-for-transforms-in-dependencies-response)

 Summary                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                
  - Add mi/can-read? permission filter to :bad_transforms in broken-cards-response, matching the existing filter on :bad_cards                                                                                                                  
  - Previously, the /check-card, /check-transform, and /check-snippet endpoints returned broken transforms without any permission check, potentially leaking transform names/details to users who shouldn't see them                            
  - The metabot equivalent (metabot_v3/tools/dependencies.clj) already had this filter; this brings the API endpoint in line                                                                                                                    
                                                                                                                                                                                                                                                
  Test plan

  - Added check-card-bad-transforms-filtered-by-can-read-test that verifies:
    - Admin users see broken transforms in the response
    - Non-admin users without transform read permissions do not see broken transforms