### PR TITLE
58 backport of "Always run Metabot-triggered refingerprinting in admin context to match sync behavior"

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/field_stats.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/field_stats.clj
@@ -5,6 +5,7 @@
    [metabase.api.common :as api]
    [metabase.lib.core :as lib]
    [metabase.parameters.field-values :as params.field-values]
+   [metabase.request.core :as request]
    [metabase.sync.core :as sync]
    [toucan2.core :as t2]))
 
@@ -19,7 +20,8 @@
 
 (defn- get-or-create-fingerprint! [{:keys [id fingerprint] :as field}]
   (or fingerprint
-      (and (pos? (:updated-fingerprints (sync/refingerprint-field! field)))
+      ;; Run with admin perms to match behavior during normal sync.
+      (and (pos? (:updated-fingerprints (request/as-admin (sync/refingerprint-field! field))))
            (t2/select-one-fn :fingerprint :model/Field :id id))))
 
 (defn- field-statistics

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/field_stats_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/field_stats_test.clj
@@ -174,3 +174,29 @@
             (is (= ["African" "American"] (get-in result [:structured-output :values])))))
         (finally
           (t2/delete! :model/FieldValues :field_id field-id :type :advanced))))))
+
+(deftest refingerprint-bypasses-sandboxing-test
+  (testing "When Metabot triggers re-fingerprinting for a missing fingerprint, the fingerprint reflects the full
+            (unsandboxed) data, not the sandboxed view of the current user."
+    (met/with-gtaps! {:gtaps {:categories {:query (sandboxed-query)}}}
+      (let [field-id            (mt/id :categories :name)
+            table-id            (mt/id :categories)
+            original-fp         (t2/select-one-fn :fingerprint :model/Field :id field-id)
+            full-distinct-count (get-in original-fp [:global :distinct-count])]
+        (testing "precondition: the field has a fingerprint with a distinct count greater than 0"
+          (is (> full-distinct-count 0)))
+        (try
+          ;; Clear the fingerprint to force re-fingerprinting via get-or-create-fingerprint!
+          (t2/update! :model/Field field-id {:fingerprint nil :fingerprint_version 0})
+          (let [mp             (mt/metadata-provider)
+                tq             (table-query mp table-id)
+                agent-field-id (visible-field-id tq (metabot-v3.tools.u/table-field-id-prefix table-id) "Name")]
+            (metabot-v3.tools.field-stats/field-values
+             {:entity-type "table", :entity-id table-id, :field-id agent-field-id})
+            (let [new-fp (t2/select-one-fn :fingerprint :model/Field :id field-id)]
+              (testing "fingerprint was saved"
+                (is (some? new-fp)))
+              (testing "fingerprint reflects full table data, not the sandboxed subset"
+                (is (= full-distinct-count (get-in new-fp [:global :distinct-count]))))))
+          (finally
+            (t2/update! :model/Field field-id {:fingerprint original-fp})))))))

--- a/src/metabase/warehouse_schema_rest/api/field.clj
+++ b/src/metabase/warehouse_schema_rest/api/field.clj
@@ -187,7 +187,8 @@
                  (field/hydrate-target-with-write-perms))
       (when (not= effective-type (:effective_type field))
         (analytics/track-event! :snowplow/simple_event {:event "field_effective_type_change" :target_id id})
-        (quick-task/submit-task! (fn [] (sync/refingerprint-field! <>)))))))
+        ;; Run with admin perms to match behavior during normal sync.
+        (quick-task/submit-task! (fn [] (request/as-admin (sync/refingerprint-field! <>))))))))
 
 ;;; ------------------------------------------------- Field Metadata -------------------------------------------------
 


### PR DESCRIPTION
https://github.com/metabase/metabase/pull/70087