### PR TITLE
[Slackbot] Prevent channel response

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot.clj
@@ -191,9 +191,7 @@
   (assert-setup-complete)
   (when (sso-settings/slack-connect-enabled)
     (let [client {:token (channel.settings/unobfuscated-slack-app-token)}
-          event (:event payload)
-          ;; TODO: cache this value somehow
-          bot-id (slackbot.client/get-bot-user-id client)]
+          event (:event payload)]
       (log/debugf "[slackbot] Event callback: event_type=%s user=%s channel=%s"
                   (:type event) (:user event) (:channel event))
       (cond
@@ -206,7 +204,7 @@
 
         (and
          (slackbot.events/file-share? event)
-         (slackbot.events/dm-or-channel-mention? event bot-id))
+         (slackbot.events/dm-or-channel-mention? event (slackbot.client/get-bot-user-id client)))
         (process-async handle-message-file-share client event)
 
         (slackbot.events/app-mention? event)

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/config.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/config.clj
@@ -7,8 +7,7 @@
    [metabase.channel.settings :as channel.settings]
    [metabase.premium-features.core :as premium-features]
    [metabase.system.core :as system]
-   [metabase.util.encryption :as encryption]
-   [metabase.util.i18n :refer [tru]]))
+   [metabase.util.encryption :as encryption]))
 
 (set! *warn-on-reflection* true)
 
@@ -70,12 +69,6 @@
         (metabot.settings/metabot-slack-signing-secret)
         (channel.settings/unobfuscated-slack-app-token)
         (encryption/default-encryption-enabled?))))
-
-(defn assert-setup-complete
-  "Asserts that all required Slack settings have been configured."
-  []
-  (when-not (setup-complete?)
-    (throw (ex-info (str (tru "Slack integration is not fully configured.")) {:status-code 503}))))
 
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn validate-bot-token!

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/events.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/events.clj
@@ -1,5 +1,6 @@
 (ns metabase-enterprise.metabot-v3.api.slackbot.events
-  "Event definitions for slackbot.")
+  "Event definitions for slackbot."
+  (:require    [clojure.string :as str]))
 
 (def SlackEventsResponse
   "Malli schema for Slack events API response"
@@ -120,6 +121,21 @@
   [event]
   (and (app-mention? event)
        (has-files? event)))
+
+(defn mentions-bot?
+  "Check if event @mentions the bot.
+   Some events, like file uploads in channels, don't come through as app_mention."
+  [event bot-user-id]
+  (some-> (:text event)
+          (str/includes? (str "<@" bot-user-id ">"))))
+
+(defn dm-or-channel-mention?
+  "Check if event is an dm or channel w/ mention of the bot."
+  [event bot-id]
+  (or
+   (dm? event)
+   (and (channel-message? event)
+        (mentions-bot? event bot-id))))
 
 (defn event->reply-context
   "Extract the necessary context for a reply from the given `event`"

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/events.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/events.clj
@@ -105,6 +105,20 @@
   (and (nil? (:bot_id event))
        (mr/validate SlackKnownMessageEvent event)))
 
+(defn dm-message?
+  "Check if event is a direct message from a user (not bot/system).
+   Returns true if the event matches SlackMessageImEvent and has no bot_id."
+  [event]
+  (and (nil? (:bot_id event))
+       (mr/validate SlackMessageImEvent event)))
+
+(defn file-share-message?
+  "Check if event is a file share message from a user (not bot/system).
+   Returns true if the event matches SlackMessageFileShareEvent and has no bot_id."
+  [event]
+  (and (nil? (:bot_id event))
+       (mr/validate SlackMessageFileShareEvent event)))
+
 (defn app-mention?
   "Check if event is an app_mention event (when bot is @mentioned)."
   [event]

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/events.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/events.clj
@@ -1,6 +1,7 @@
 (ns metabase-enterprise.metabot-v3.api.slackbot.events
   "Event definitions for slackbot."
-  (:require    [clojure.string :as str]))
+  (:require
+   [clojure.string :as str]))
 
 (def SlackEventsResponse
   "Malli schema for Slack events API response"
@@ -37,14 +38,6 @@
    [:event_ts :string]
    [:bot_id {:optional true} [:maybe :string]]])
 
-(def SlackMessageImEvent
-  "Schema for message.im events (direct messages)"
-  [:merge SlackMessageEvent
-   [:map
-    [:channel_type [:= "im"]]
-    [:text :string]
-    [:thread_ts {:optional true} [:maybe :string]]]])
-
 (def SlackMessageFileShareEvent
   "Schema for file_share message events"
   [:merge SlackMessageEvent
@@ -54,17 +47,6 @@
     [:files [:sequential SlackFile]]
     [:text {:optional true} [:maybe :string]]
     [:thread_ts {:optional true} [:maybe :string]]]])
-
-(def SlackAppMentionEvent
-  "Schema for app_mention events (when bot is @mentioned)"
-  [:map
-   [:type [:= "app_mention"]]
-   [:channel :string]
-   [:user :string]
-   [:text :string]
-   [:ts :string]
-   [:event_ts :string]
-   [:thread_ts {:optional true} [:maybe :string]]])
 
 (def SlackEventCallbackEvent
   "Malli schema for Slack event_callback event"

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
@@ -62,7 +62,8 @@
 (defmacro ^:private with-slackbot-setup
   "Wrap body with all required settings for slackbot to be fully configured."
   [& body]
-  `(with-redefs [slackbot.config/validate-bot-token! (constantly {:ok true})]
+  `(with-redefs [slackbot.config/validate-bot-token! (constantly {:ok true})
+                 slackbot.client/get-bot-user-id     (constantly "UBOT123")]
      (with-ensure-encryption
        (mt/with-premium-features #{:metabot-v3 :sso-slack}
          (mt/with-temporary-setting-values [site-url "https://localhost:3000"


### PR DESCRIPTION
This PR fixes replies that were happening in channels w/ files attached (this is the most recent reason we needed to disable the bot). While doing this, i tried to refactor the code to be easier to follow. The main fix has been called out in a comment and tests have been added to handle this case. I've also removed some usage of malli as it wasn't used in any meaningful way from what I could tell.