### PR TITLE
Fix bigquery routing test

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/test/data/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/test/data/bigquery_cloud_sdk.clj
@@ -64,8 +64,10 @@
     (str "sha_" (tx/hash-dataset db-def) "_" (normalize-name database-name))))
 
 (defn- test-db-details []
-  {:project-id (tx/db-test-env-var :bigquery-cloud-sdk :project-id)
-   :service-account-json (tx/db-test-env-var :bigquery-cloud-sdk :service-account-json)})
+  (if tx/*use-routing-details*
+    {:service-account-json (tx/db-test-env-var :bigquery-cloud-sdk :service-account-json-routing)}
+    {:project-id           (tx/db-test-env-var :bigquery-cloud-sdk :project-id)
+     :service-account-json (tx/db-test-env-var :bigquery-cloud-sdk :service-account-json)}))
 
 (defn- bigquery
   "Get an instance of a `Bigquery` client."

--- a/test/metabase/test/data/interface.clj
+++ b/test/metabase/test/data/interface.clj
@@ -130,7 +130,11 @@
 
 (defn- hash-dataset*
   [^DatabaseDefinition db-def]
-  (codecs/bytes->hex (buddy-hash/sha1 (str (into (sorted-map) (get-dataset-definition db-def))))))
+  (let [db-def' (get-dataset-definition db-def)
+        ;; for routing tests (where hashes need to match despite content being different)
+        ;; it is important to be able to override the hash key
+        hash-key (:hash-key db-def' db-def')]
+    (codecs/bytes->hex (buddy-hash/sha1 (str (into (sorted-map) hash-key))))))
 
 (def hash-dataset
   "Provides a consistent hash for the DatabaseDefinition"


### PR DESCRIPTION
- Was using wrong project / creds
- Was using two different table names which is incorrect for routed/router
- Using two different sha names only worked when shas were not used as qualifiers in the query (they are for bigquery)

Added the ability to override the hash-key used for tx/hash-dataset to support forcing a hash collision (as is required by routing).

---

The test was not correctly assigning a project-id or service account creds to the two branches. Fixing this you would find the routed table could still 'not be found':

Both table/schema names need to be shared for router/routed. In BigQuery datasets are used as schema qualifiers like so: `$project`.`$dataset`.`$table`. The QP does not subsitute the table schema on compilation with that of the routed table, it reuses the schema of the router table.

We now force a hash collision so the schemas are reused. In production we would expect router/routed schemas to be the same - this is a test quirk.

I think things only worked before because the tables were accidently in the wrong database. The sha was 'accidently working' because qualifiers were 'not a problem' (for the test, it was a problem in general) as we were not correctly using the dataset schema as a qualifier until: https://github.com/metabase/metabase/pull/69566. I haven't done the git spelunk / re-runs to find this out. Its just my hunch.