### PR TITLE
add new variants to action icon and use it in Inspector Header cell

### DIFF
--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/JoinAnalysisSections/JoinAnalysisSection.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/JoinAnalysisSections/JoinAnalysisSection.tsx
@@ -92,6 +92,7 @@ export const JoinAnalysisSection = ({ cards }: JoinAnalysisSectionProps) => {
               card={row.original.card}
               severity={row.original.severity}
               transformId={transform.id}
+              isExpanded={row.getIsExpanded()}
               onToggleAlerts={() => row.toggleExpanded()}
             />
           ),

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/JoinAnalysisSections/components/JoinHeaderCell.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/JoinAnalysisSections/components/JoinHeaderCell.tsx
@@ -27,14 +27,14 @@ export const JoinHeaderCell = ({
   if (!severity) {
     return null;
   }
+
   return (
     <ActionIcon
-      variant="transparent"
-      color={match(severity)
+      variant={match(severity)
         .with("error", () => "error" as const)
         .with("warning", () => "warning" as const)
-        .with("info", () => "brand" as const)
-        .exhaustive()}
+        .with("info", () => "info" as const)
+        .otherwise(() => "subtle" as const)}
       size="lg"
       onClick={(e) => {
         e.stopPropagation();

--- a/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/JoinAnalysisSections/components/JoinHeaderCell.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformInspectPage/components/LensSections/JoinAnalysisSections/components/JoinHeaderCell.tsx
@@ -15,6 +15,7 @@ type JoinHeaderCellProps = {
   severity: InspectorAlertTrigger["severity"] | null;
   transformId: TransformId;
   onToggleAlerts?: () => void;
+  isExpanded: boolean;
 };
 
 export const JoinHeaderCell = ({
@@ -22,6 +23,7 @@ export const JoinHeaderCell = ({
   severity,
   transformId,
   onToggleAlerts,
+  isExpanded,
 }: JoinHeaderCellProps) => {
   useLensCardLoader({ card });
   if (!severity) {
@@ -36,6 +38,7 @@ export const JoinHeaderCell = ({
         .with("info", () => "info" as const)
         .otherwise(() => "subtle" as const)}
       size="lg"
+      data-is-active={isExpanded}
       onClick={(e) => {
         e.stopPropagation();
         trackTransformInspectAlertClicked({ transformId, cardId: card.id });

--- a/frontend/src/metabase/ui/components/buttons/ActionIcon/ActionButton.stories.tsx
+++ b/frontend/src/metabase/ui/components/buttons/ActionIcon/ActionButton.stories.tsx
@@ -9,8 +9,8 @@ export default {
     color: {
       control: {
         type: "select",
-        options: ["brand"],
       },
+      options: ["brand"],
     },
     disabled: {
       control: {
@@ -20,14 +20,22 @@ export default {
     size: {
       control: {
         type: "select",
-        options: ["xs", "sm", "md", "lg", "xl"],
       },
+      options: ["xs", "sm", "md", "lg", "xl"],
     },
     variant: {
       control: {
         type: "select",
-        options: ["filled", "subtle", "viewFooter", "viewHeader"],
       },
+      options: [
+        "filled",
+        "subtle",
+        "viewFooter",
+        "viewHeader",
+        "info",
+        "warning",
+        "error",
+      ],
     },
   },
 };

--- a/frontend/src/metabase/ui/components/buttons/ActionIcon/ActionIcon.module.css
+++ b/frontend/src/metabase/ui/components/buttons/ActionIcon/ActionIcon.module.css
@@ -20,7 +20,8 @@
     background-color: transparent;
 
     &:hover,
-    &:active {
+    &:active,
+    &[data-is-active="true"] {
       background-color: var(--mb-color-background-brand);
     }
   }
@@ -30,7 +31,8 @@
     background-color: transparent;
 
     &:hover,
-    &:active {
+    &:active,
+    &[data-is-active="true"] {
       background-color: var(--mb-color-background-warning);
     }
   }
@@ -40,7 +42,8 @@
     background-color: transparent;
 
     &:hover,
-    &:active {
+    &:active,
+    &[data-is-active="true"] {
       background-color: var(--mb-color-background-error);
     }
   }

--- a/frontend/src/metabase/ui/components/buttons/ActionIcon/ActionIcon.module.css
+++ b/frontend/src/metabase/ui/components/buttons/ActionIcon/ActionIcon.module.css
@@ -13,6 +13,38 @@
     }
   }
 
+  /* To be able to seamlessly support color property across variants we need
+      to implement variantColorResolver. Same thing is pointed out in Button component. */
+  &[data-variant="info"] {
+    color: var(--mb-color-brand);
+    background-color: transparent;
+
+    &:hover,
+    &:active {
+      background-color: var(--mb-color-background-brand);
+    }
+  }
+
+  &[data-variant="warning"] {
+    color: var(--mb-color-warning);
+    background-color: transparent;
+
+    &:hover,
+    &:active {
+      background-color: var(--mb-color-background-warning);
+    }
+  }
+
+  &[data-variant="error"] {
+    color: var(--mb-color-error);
+    background-color: transparent;
+
+    &:hover,
+    &:active {
+      background-color: var(--mb-color-background-error);
+    }
+  }
+
   &[data-variant="viewHeader"] {
     color: var(--mb-color-text-primary);
     background-color: transparent;


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-1789/fix-actionicon-subtle-and-use-it-in-for-the-warning-header

### Description

- New variants for ActionIcon that support designs
- Fixed Storybook config (wrong nesting of `argTypes` params resulted in no parameter controls).
- Use the new variants in `JoinHeaderCell`


### Demo

<img width="972" height="2162" alt="73753" src="https://github.com/user-attachments/assets/9af004a7-2b38-44da-b9f5-d48e9f818ea3" />

![CleanShot 2026-02-27 at 10 28 28@2x](https://github.com/user-attachments/assets/3d394aa0-b2aa-4ddc-a46d-bb2bc7ce0699)

before
![image](https://github.com/user-attachments/assets/6d90357c-109e-473c-a143-820f9566cc13)

after
![CleanShot 2026-02-27 at 09 36 06@2x](https://github.com/user-attachments/assets/ba24bd23-8e74-4e45-afb7-e6b6e6c6ad9a)
