### PR TITLE
GDGT-1859: Fix enabling Advanced Transforms

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/upsells/PythonTransformsUpsellModal/CloudPurchaseContent.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/upsells/PythonTransformsUpsellModal/CloudPurchaseContent.tsx
@@ -30,8 +30,8 @@ export const CloudPurchaseContent = (props: CloudPurchaseContentProps) => {
 
   const handleCloudPurchase = useCallback(async () => {
     trackUpsellClicked({ location: LOCATION, campaign: CAMPAIGN });
+
     settingUpModalHandlers.open();
-    handleModalClose();
     try {
       await purchaseCloudAddOn({
         product_type: "transforms-advanced",
@@ -41,7 +41,9 @@ export const CloudPurchaseContent = (props: CloudPurchaseContentProps) => {
       sendErrorToast(
         t`It looks like something went wrong. Please refresh the page and try again.`,
       );
+    } finally {
       settingUpModalHandlers.close();
+      handleModalClose();
     }
   }, [
     handleModalClose,

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/upsells/PythonTransformsUpsellModal/CloudPurchaseContent.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/upsells/PythonTransformsUpsellModal/CloudPurchaseContent.unit.spec.tsx
@@ -2,7 +2,7 @@ import userEvent from "@testing-library/user-event";
 import fetchMock from "fetch-mock";
 
 import { setupPropertiesEndpoints } from "__support__/server-mocks";
-import { renderWithProviders, screen } from "__support__/ui";
+import { act, renderWithProviders, screen, waitFor } from "__support__/ui";
 import {
   createMockSettings,
   createMockTokenFeatures,
@@ -71,7 +71,38 @@ describe("CloudPurchaseContent", () => {
     ).toBeInTheDocument();
   });
 
-  it("purchases transforms-advanced and closes parent modal on confirm", async () => {
+  it("shows setting up modal while purchase is in progress", async () => {
+    let resolveRequest!: (value: unknown) => void;
+    const pendingResponse = new Promise((resolve) => {
+      resolveRequest = resolve;
+    });
+
+    fetchMock.post(
+      "path:/api/ee/cloud-add-ons/transforms-advanced",
+      pendingResponse,
+    );
+
+    setup({
+      isTrialFlow: false,
+      pythonPrice: 250,
+    });
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Confirm purchase" }),
+    );
+
+    // While the request is in-flight, the setting up modal should be visible
+    expect(
+      screen.getByText("Setting up Python transforms, please wait"),
+    ).toBeInTheDocument();
+
+    // Resolve the request
+    await act(async () => {
+      resolveRequest(200);
+    });
+  });
+
+  it("calls the API and closes parent modal on successful purchase", async () => {
     fetchMock.post("path:/api/ee/cloud-add-ons/transforms-advanced", 200);
 
     const { handleModalClose } = setup({
@@ -83,22 +114,44 @@ describe("CloudPurchaseContent", () => {
       screen.getByRole("button", { name: "Confirm purchase" }),
     );
 
-    await fetchMock.callHistory.flush();
+    await waitFor(() => {
+      expect(
+        fetchMock.callHistory
+          .calls()
+          .some(
+            (call) =>
+              call.url.endsWith("/api/ee/cloud-add-ons/transforms-advanced") &&
+              call.options.method === "POST",
+          ),
+      ).toBe(true);
+    });
 
+    // After success, the finally block closes the parent modal
+    await waitFor(() => {
+      expect(handleModalClose).toHaveBeenCalled();
+    });
+  });
+
+  it("closes setting up modal and parent modal on error", async () => {
+    fetchMock.post("path:/api/ee/cloud-add-ons/transforms-advanced", 500);
+
+    const { handleModalClose } = setup({
+      isTrialFlow: false,
+      pythonPrice: 250,
+    });
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Confirm purchase" }),
+    );
+
+    // After error, finally block closes the parent modal
+    await waitFor(() => {
+      expect(handleModalClose).toHaveBeenCalled();
+    });
+
+    // Setting up modal should be closed (not visible)
     expect(
-      fetchMock.callHistory
-        .calls()
-        .some(
-          (call) =>
-            call.url.endsWith("/api/ee/cloud-add-ons/transforms-advanced") &&
-            call.options.method === "POST",
-        ),
-    ).toBe(true);
-
-    expect(handleModalClose).toHaveBeenCalled();
-
-    expect(
-      screen.getByText("Setting up Python transforms, please wait"),
-    ).toBeInTheDocument();
+      screen.queryByText("Setting up Python transforms, please wait"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/transforms/upsells/pages/TransformsUpsellPage/components/PricingSummary.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms/upsells/pages/TransformsUpsellPage/components/PricingSummary.tsx
@@ -6,6 +6,7 @@ import { useMetadataToasts } from "metabase/metadata/hooks";
 import { Button, Divider, Group, Text } from "metabase/ui";
 import { usePurchaseCloudAddOnMutation } from "metabase-enterprise/api";
 import { TransformsSettingUpModal } from "metabase-enterprise/transforms/upsells/components/TransformsSettingUpModal";
+import { Urls } from "metabase-enterprise/urls";
 
 import type { TransformTier } from "./TierSelection";
 
@@ -30,6 +31,7 @@ export const PricingSummary = (props: PricingSummaryProps) => {
       await purchaseCloudAddOn({
         product_type: productType,
       }).unwrap();
+      window.location.href = Urls.transformList(); // On success, do a full-page redirect to transforms list
     } catch {
       sendErrorToast(
         t`It looks like something went wrong. Please refresh the page and try again.`,


### PR DESCRIPTION
Closes #70109
Closes [GDGT-1859: Python transforms not enabled after adding to the trial](https://linear.app/metabase/issue/GDGT-1859/python-transforms-not-enabled-after-adding-to-the-trial)
Closes [GDGT-1859: Python transforms not enabled after adding to the trial](https://linear.app/metabase/issue/GDGT-1859/python-transforms-not-enabled-after-adding-to-the-trial)

### Description

Fix Python transforms not being enabled after adding to the trial or purchasing the add-on.

**Problem:** After a successful cloud add-on purchase, the `PLUGIN_*` objects still had stale values because `MetabaseSettings` was updated but plugins were never reinitialized. The upsell modals also had incorrect sequencing — the parent modal closed before the "Setting up" modal could display, and there was no page refresh to pick up the new feature flags.

**Changes:**

1. **`CloudPurchaseContent.tsx`** — Show the "Setting up" modal *before* the API call (not after), move `handleModalClose` to `finally` so it runs after both success and error, and redirect to transforms list on success via `window.location.href`
2. **`PricingSummary.tsx`** — Add `window.location.href` redirect to transforms list on successful purchase so the page reloads with fresh plugin state

The full-page redirect ensures that plugins reinitialize from scratch with the updated `token-features`, so upsell icons disappear and the transforms UI becomes available without requiring a manual reload.

### How to verify

1. Start a Metabase Cloud instance with transforms **not** enabled
2. Navigate to Data Studio → Transforms — verify the upsell gem icon is visible
3. Click on Transforms to see the upsell page
4. Purchase transforms (or add to trial)
5. Verify the "Setting up transforms" modal appears during the purchase
6. After success, verify the page redirects to the transforms list
7. Verify the upsell gem icon is no longer visible in the sidebar
8. Clicking Transforms should show the transforms list, not the upsell page

### Checklist

- [x] Tests have been added/updated to cover changes in this PR