### PR TITLE
remove sdk import error on core app e2e tests

### DIFF
--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -14,7 +14,6 @@ import {
   removeDirectory,
   verifyDownloadTasks,
 } from "./commands/downloads/downloadUtils";
-import webpackConfig from "./component-webpack.config";
 import * as dbTasks from "./db_tasks";
 import { signJwt } from "./helpers/e2e-jwt-tasks";
 
@@ -206,29 +205,7 @@ const mainConfig = {
   },
 };
 
-const embeddingSdkComponentTestConfig = {
-  ...defaultConfig,
-  baseUrl: undefined, // baseUrl should not be set for component tests,
-  defaultCommandTimeout: 10000,
-  requestTimeout: 10000,
-  video: false,
-  specPattern: "e2e/test-component/scenarios/embedding-sdk/**/*.cy.spec.tsx",
-  indexHtmlFile: "e2e/support/component-index.html",
-  supportFile: "e2e/support/component-cypress.js",
-
-  reporter: mainConfig.reporter,
-  reporterOptions: mainConfig.reporterOptions,
-  retries: mainConfig.retries,
-
-  devServer: {
-    framework: "react",
-    bundler: "webpack",
-    webpackConfig: webpackConfig,
-  },
-};
-
 module.exports = {
   defaultConfig,
   mainConfig,
-  embeddingSdkComponentTestConfig,
 };

--- a/e2e/support/cypress-embedding-sdk-component-test.config.js
+++ b/e2e/support/cypress-embedding-sdk-component-test.config.js
@@ -1,4 +1,26 @@
-const { embeddingSdkComponentTestConfig } = require("./config");
+import webpackConfig from "./component-webpack.config";
+import { defaultConfig, mainConfig } from "./config";
+
+const embeddingSdkComponentTestConfig = {
+  ...defaultConfig,
+  baseUrl: undefined, // baseUrl should not be set for component tests,
+  defaultCommandTimeout: 10000,
+  requestTimeout: 10000,
+  video: false,
+  specPattern: "e2e/test-component/scenarios/embedding-sdk/**/*.cy.spec.tsx",
+  indexHtmlFile: "e2e/support/component-index.html",
+  supportFile: "e2e/support/component-cypress.js",
+
+  reporter: mainConfig.reporter,
+  reporterOptions: mainConfig.reporterOptions,
+  retries: mainConfig.retries,
+
+  devServer: {
+    framework: "react",
+    bundler: "webpack",
+    webpackConfig: webpackConfig,
+  },
+};
 
 module.exports = {
   component: {


### PR DESCRIPTION
refactor the imports so the base e2e tests don't import the sdk component test that has the error

closes [EMB-1371: remove the "Error: Cannot find module '(metabase/embedding-sdk-react'" from cypress logs](https://linear.app/metabase/issue/EMB-1371/remove-the-error-cannot-find-module-metabaseembedding-sdk-react-from)