### PR TITLE
Migrate away from deprecated Cypress.env() API

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -45,8 +45,9 @@ jobs:
     name: e2e-tests-${{ inputs.name }}-${{ inputs.edition }}
     env:
       MB_EDITION: ${{ inputs.edition }}
-      # Any env starting with `CYPRESS_` will be available to all Cypress tests via `cy.env()`
-      # Example: you can get `CYPRESS_FOO` with `cy.env(["FOO"]).then(({ FOO }) => ...)`
+      # Sensitive env vars (tokens, secrets) starting with `CYPRESS_` are accessed via async `cy.env()`
+      # Example: `cy.env(["FOO"]).then(({ FOO }) => ...)`
+      # For non-sensitive config, use `Cypress.expose()` in cypress config instead (synchronous)
       CYPRESS_MB_ALL_FEATURES_TOKEN: ${{ secrets.STAGING_MB_ALL_FEATURES_TOKEN }}
       CYPRESS_MB_STARTER_CLOUD_TOKEN: ${{ secrets.STAGING_MB_STARTER_CLOUD_TOKEN }}
       CYPRESS_MB_PRO_CLOUD_TOKEN: ${{ secrets.STAGING_MB_PRO_CLOUD_TOKEN }}

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -45,8 +45,8 @@ jobs:
     name: e2e-tests-${{ inputs.name }}-${{ inputs.edition }}
     env:
       MB_EDITION: ${{ inputs.edition }}
-      # Any env starting with `CYPRESS_` will be available to all Cypress tests via `Cypress.env()`
-      # Example: you can get `CYPRESS_FOO` with `Cypress.env("FOO")`
+      # Any env starting with `CYPRESS_` will be available to all Cypress tests via `cy.env()`
+      # Example: you can get `CYPRESS_FOO` with `cy.env(["FOO"]).then(({ FOO }) => ...)`
       CYPRESS_MB_ALL_FEATURES_TOKEN: ${{ secrets.STAGING_MB_ALL_FEATURES_TOKEN }}
       CYPRESS_MB_STARTER_CLOUD_TOKEN: ${{ secrets.STAGING_MB_STARTER_CLOUD_TOKEN }}
       CYPRESS_MB_PRO_CLOUD_TOKEN: ${{ secrets.STAGING_MB_PRO_CLOUD_TOKEN }}

--- a/.github/workflows/embedding-sdk-component-tests.yml
+++ b/.github/workflows/embedding-sdk-component-tests.yml
@@ -19,8 +19,8 @@ jobs:
         react-version: [18, 19]
       fail-fast: false
     env:
-      # Any env starting with `CYPRESS_` will be available to all Cypress tests via `Cypress.env()`
-      # Example: you can get `CYPRESS_FOO` with `Cypress.env("FOO")`
+      # Any env starting with `CYPRESS_` will be available to all Cypress tests via `cy.env()`
+      # Example: you can get `CYPRESS_FOO` with `cy.env(["FOO"]).then(({ FOO }) => ...)`
       CYPRESS_MB_ALL_FEATURES_TOKEN: ${{ secrets.STAGING_MB_ALL_FEATURES_TOKEN }}
       CYPRESS_MB_STARTER_CLOUD_TOKEN: ${{ secrets.STAGING_MB_STARTER_CLOUD_TOKEN }}
       CYPRESS_MB_PRO_CLOUD_TOKEN: ${{ secrets.STAGING_MB_PRO_CLOUD_TOKEN }}
@@ -155,8 +155,8 @@ jobs:
     env:
       MB_RUN_MODE: "e2e"
       METASTORE_DEV_SERVER_URL: ${{ secrets.METASTORE_DEV_SERVER_URL }}
-      # Any env starting with `CYPRESS_` will be available to all Cypress tests via `Cypress.env()`
-      # Example: you can get `CYPRESS_FOO` with `Cypress.env("FOO")`
+      # Any env starting with `CYPRESS_` will be available to all Cypress tests via `cy.env()`
+      # Example: you can get `CYPRESS_FOO` with `cy.env(["FOO"]).then(({ FOO }) => ...)`
       CYPRESS_MB_ALL_FEATURES_TOKEN: ${{ secrets.STAGING_MB_ALL_FEATURES_TOKEN }}
       CYPRESS_MB_STARTER_CLOUD_TOKEN: ${{ secrets.STAGING_MB_STARTER_CLOUD_TOKEN }}
       CYPRESS_MB_PRO_CLOUD_TOKEN: ${{ secrets.STAGING_MB_PRO_CLOUD_TOKEN }}

--- a/.github/workflows/embedding-sdk-component-tests.yml
+++ b/.github/workflows/embedding-sdk-component-tests.yml
@@ -19,8 +19,9 @@ jobs:
         react-version: [18, 19]
       fail-fast: false
     env:
-      # Any env starting with `CYPRESS_` will be available to all Cypress tests via `cy.env()`
-      # Example: you can get `CYPRESS_FOO` with `cy.env(["FOO"]).then(({ FOO }) => ...)`
+      # Sensitive env vars (tokens, secrets) starting with `CYPRESS_` are accessed via async `cy.env()`
+      # Example: `cy.env(["FOO"]).then(({ FOO }) => ...)`
+      # For non-sensitive config, use `Cypress.expose()` in cypress config instead (synchronous)
       CYPRESS_MB_ALL_FEATURES_TOKEN: ${{ secrets.STAGING_MB_ALL_FEATURES_TOKEN }}
       CYPRESS_MB_STARTER_CLOUD_TOKEN: ${{ secrets.STAGING_MB_STARTER_CLOUD_TOKEN }}
       CYPRESS_MB_PRO_CLOUD_TOKEN: ${{ secrets.STAGING_MB_PRO_CLOUD_TOKEN }}
@@ -155,8 +156,9 @@ jobs:
     env:
       MB_RUN_MODE: "e2e"
       METASTORE_DEV_SERVER_URL: ${{ secrets.METASTORE_DEV_SERVER_URL }}
-      # Any env starting with `CYPRESS_` will be available to all Cypress tests via `cy.env()`
-      # Example: you can get `CYPRESS_FOO` with `cy.env(["FOO"]).then(({ FOO }) => ...)`
+      # Sensitive env vars (tokens, secrets) starting with `CYPRESS_` are accessed via async `cy.env()`
+      # Example: `cy.env(["FOO"]).then(({ FOO }) => ...)`
+      # For non-sensitive config, use `Cypress.expose()` in cypress config instead (synchronous)
       CYPRESS_MB_ALL_FEATURES_TOKEN: ${{ secrets.STAGING_MB_ALL_FEATURES_TOKEN }}
       CYPRESS_MB_STARTER_CLOUD_TOKEN: ${{ secrets.STAGING_MB_STARTER_CLOUD_TOKEN }}
       CYPRESS_MB_PRO_CLOUD_TOKEN: ${{ secrets.STAGING_MB_PRO_CLOUD_TOKEN }}

--- a/e2e/snapshot-creators/default.cy.snap.js
+++ b/e2e/snapshot-creators/default.cy.snap.js
@@ -38,7 +38,7 @@ const {
 } = USER_GROUPS;
 const { admin } = USERS;
 
-const { IS_ENTERPRISE } = Cypress.env();
+const IS_ENTERPRISE = Cypress.expose("IS_ENTERPRISE");
 
 describe("snapshots", () => {
   describe("default", () => {

--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -61,8 +61,10 @@ const defaultConfig = {
       : undefined,
   },
 
-  // Prevent usage of deprecated Cypress.env() API
-  allowCypressEnv: false,
+  // Note: We can't set `allowCypressEnv: false` yet because @cypress/grep
+  // plugin still uses Cypress.env() internally
+  // FIXME: enable once we upgrade (DEV-1620)
+  // allowCypressEnv: false,
 
   // This is the functionality of the old cypress-plugins.js file
   setupNodeEvents(cypressOn, config) {

--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -170,7 +170,6 @@ const defaultConfig = {
   },
   baseUrl: `http://${BACKEND_HOST}:${BACKEND_PORT}`,
   defaultBrowser: process.env.CYPRESS_BROWSER ?? "chrome",
-  env: {},
   supportFile: "e2e/support/cypress.js",
   chromeWebSecurity: false,
   modifyObstructiveCode: false,

--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -47,6 +47,23 @@ const assetsResolverPlugin = {
 };
 
 const defaultConfig = {
+  // Expose non-sensitive environment variables synchronously via Cypress.expose()
+  // These are safe to expose in the browser and are used for configuration
+  expose: {
+    CI: isCI,
+    IS_ENTERPRISE: isEnterprise,
+    MB_EDITION: process.env["MB_EDITION"],
+    ENABLE_NETWORK_THROTTLING: !!process.env["ENABLE_NETWORK_THROTTLING"],
+    SNOWPLOW_MICRO_URL: snowplowMicroUrl,
+    CLIENT_PORT: process.env["CLIENT_PORT"],
+    feHealthcheck: process.env["FE_HEALTHCHECK_URL"]
+      ? { enabled: true, url: process.env["FE_HEALTHCHECK_URL"] }
+      : undefined,
+  },
+
+  // Prevent usage of deprecated Cypress.env() API
+  allowCypressEnv: false,
+
   // This is the functionality of the old cypress-plugins.js file
   setupNodeEvents(cypressOn, config) {
     // `on` is used to hook into various events Cypress emits
@@ -130,8 +147,8 @@ const defaultConfig = {
     config.env.grepFilterSpecs = true;
     config.env.grepOmitFiltered = true;
 
-    config.env.IS_ENTERPRISE = isEnterprise;
-    config.env.SNOWPLOW_MICRO_URL = snowplowMicroUrl;
+    // Note: IS_ENTERPRISE and SNOWPLOW_MICRO_URL are now exposed via Cypress.expose()
+    // and accessible synchronously without the deprecated Cypress.env() API
 
     require("@cypress/grep/src/plugin")(config);
 
@@ -157,7 +174,8 @@ const defaultConfig = {
   baseUrl: `http://${BACKEND_HOST}:${BACKEND_PORT}`,
   defaultBrowser: process.env.CYPRESS_BROWSER ?? "chrome",
   env: {
-    CI: isCI,
+    // Note: CI is now exposed via Cypress.expose()
+    // Other environment variables needed by plugins go here
   },
   supportFile: "e2e/support/cypress.js",
   chromeWebSecurity: false,

--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -147,9 +147,6 @@ const defaultConfig = {
     config.env.grepFilterSpecs = true;
     config.env.grepOmitFiltered = true;
 
-    // Note: IS_ENTERPRISE and SNOWPLOW_MICRO_URL are now exposed via Cypress.expose()
-    // and accessible synchronously without the deprecated Cypress.env() API
-
     require("@cypress/grep/src/plugin")(config);
 
     if (isCI) {
@@ -173,10 +170,7 @@ const defaultConfig = {
   },
   baseUrl: `http://${BACKEND_HOST}:${BACKEND_PORT}`,
   defaultBrowser: process.env.CYPRESS_BROWSER ?? "chrome",
-  env: {
-    // Note: CI is now exposed via Cypress.expose()
-    // Other environment variables needed by plugins go here
-  },
+  env: {},
   supportFile: "e2e/support/cypress.js",
   chromeWebSecurity: false,
   modifyObstructiveCode: false,

--- a/e2e/support/cypress.js
+++ b/e2e/support/cypress.js
@@ -8,8 +8,8 @@ import "cypress-real-events/support";
 import addContext from "mochawesome/addContext";
 import "./commands";
 
-const isCI = Cypress.env("CI");
-const isNetworkThrottlingEnabled = Cypress.env("ENABLE_NETWORK_THROTTLING");
+const isCI = Cypress.expose("CI");
+const isNetworkThrottlingEnabled = Cypress.expose("ENABLE_NETWORK_THROTTLING");
 
 // remove default html output on test failure
 configure({
@@ -31,7 +31,7 @@ Cypress.on("uncaught:exception", (err, runnable) => false);
 
 Cypress.on("test:before:run", () => {
   // Check wether FE is running in dev mode
-  const feHealthcheck = Cypress.env().feHealthcheck;
+  const feHealthcheck = Cypress.expose("feHealthcheck");
   if (feHealthcheck?.enabled) {
     fetch(feHealthcheck.url).catch(() =>
       alert(
@@ -160,7 +160,7 @@ if (isCI) {
 beforeEach(function () {
   const isCurrentTesOss =
     this.currentTest._testConfig.unverifiedTestConfig.tags === "@OSS";
-  const isBuildOss = Cypress.env("MB_EDITION") === "oss";
+  const isBuildOss = Cypress.expose("MB_EDITION") === "oss";
   const testName = this.currentTest.title;
   if (Cypress.config("isInteractive") && isCurrentTesOss && !isBuildOss) {
     console.log(

--- a/e2e/support/helpers/e2e-embedding-iframe-sdk-helpers.ts
+++ b/e2e/support/helpers/e2e-embedding-iframe-sdk-helpers.ts
@@ -15,7 +15,7 @@ import {
   mockAuthProviderAndJwtSignIn,
 } from "./embedding-sdk-testing";
 
-const { IS_ENTERPRISE } = Cypress.env();
+const IS_ENTERPRISE = Cypress.expose("IS_ENTERPRISE");
 
 const EMBED_JS_PATH = "http://localhost:4000/app/embed.js";
 
@@ -373,7 +373,7 @@ export const visitCustomHtmlPage = (
  * to point it to the rspack dev server.
  */
 export const mockEmbedJsToDevServer = () => {
-  if (Cypress.env("CI")) {
+  if (Cypress.expose("CI")) {
     // we don't need this logic in CI, let's skip the check to avoid slowing down the tests
     return;
   }

--- a/e2e/support/helpers/e2e-token-helpers.ts
+++ b/e2e/support/helpers/e2e-token-helpers.ts
@@ -28,25 +28,17 @@ export const activateToken = (
     .with("pro-self-hosted", () => "MB_PRO_SELF_HOSTED_TOKEN")
     .exhaustive();
 
-  const fallbackToken =
-    tokenReference === "starter" ? "NO_FEATURES_TOKEN" : "ALL_FEATURES_TOKEN";
-
   // Use cy.env() for sensitive token values (async API)
-  return cy.env([tokenReference, fallbackToken]).then((envVars) => {
-    const token = envVars[tokenReference] || envVars[fallbackToken];
+  return cy.env([tokenReference]).then((envVars) => {
+    const token = envVars[tokenReference];
 
     if (!token) {
-      const errorMessage = `
-    Please make sure you have correctly set the following tokens in your environment variables:
-      - CYPRESS_MB_ALL_FEATURES_TOKEN
-      - CYPRESS_MB_STARTER_CLOUD_TOKEN
-      - CYPRESS_MB_PRO_CLOUD_TOKEN
-      - CYPRESS_MB_PRO_SELF_HOSTED_TOKEN
-    `;
-      throw new Error(errorMessage);
+      throw new Error(
+        `Missing CYPRESS_${tokenReference} environment variable for "${tokenName}" token`,
+      );
     }
 
-    cy.log(`Set the "${tokenReference}" token`);
+    cy.log(`Set the "${tokenName}" token`);
     return cy.request({
       method: "PUT",
       url: "/api/setting/premium-embedding-token",

--- a/e2e/test-host-app/shared/compatibility.cy.spec.js
+++ b/e2e/test-host-app/shared/compatibility.cy.spec.js
@@ -5,7 +5,7 @@ import {
 
 const TIMEOUT_MS = 40000;
 
-const CLIENT_PORT = Cypress.env("CLIENT_PORT");
+const CLIENT_PORT = Cypress.expose("CLIENT_PORT");
 const CLIENT_HOST = `http://localhost:${CLIENT_PORT}`;
 
 describe("Embedding SDK: shared Host Apps compatibility tests", () => {

--- a/e2e/test/scenarios/admin/databases.cy.spec.js
+++ b/e2e/test/scenarios/admin/databases.cy.spec.js
@@ -12,7 +12,7 @@ import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 import { visitDatabase, waitForDbSync } from "./helpers/e2e-database-helpers";
 
 const { H } = cy;
-const { IS_ENTERPRISE } = Cypress.env();
+const IS_ENTERPRISE = Cypress.expose("IS_ENTERPRISE");
 const { ORDERS_ID, ORDERS } = SAMPLE_DATABASE;
 
 describe(

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/guest-embed.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/guest-embed.cy.spec.ts
@@ -4,7 +4,7 @@ import { createQuestion, getSignedJwtForResource } from "e2e/support/helpers";
 const { H } = cy;
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 
-const { IS_ENTERPRISE } = Cypress.env();
+const IS_ENTERPRISE = Cypress.expose("IS_ENTERPRISE");
 const IS_OSS = !IS_ENTERPRISE;
 const MB_EDITION = IS_ENTERPRISE ? "ee" : "oss";
 

--- a/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
@@ -1,5 +1,5 @@
 const { H } = cy;
-const { IS_ENTERPRISE } = Cypress.env();
+const IS_ENTERPRISE = Cypress.expose("IS_ENTERPRISE");
 import { USERS } from "e2e/support/cypress_data";
 import { SUBSCRIBE_URL } from "metabase/setup/constants";
 
@@ -573,7 +573,10 @@ describe("scenarios > setup (EE)", () => {
 
       cy.findByText("Activate your commercial license").should("exist");
 
-      typeToken(Cypress.env("MB_STARTER_CLOUD_TOKEN"));
+      // Use cy.env() for sensitive token values (async API)
+      cy.env(["MB_STARTER_CLOUD_TOKEN"]).then(({ MB_STARTER_CLOUD_TOKEN }) => {
+        typeToken(MB_STARTER_CLOUD_TOKEN);
+      });
 
       cy.button("Activate").click();
 


### PR DESCRIPTION
Resolves: DEV-1604
Resolves: DEV-1619

As of Cypress 15.10.0, `Cypress.env()` is deprecated. This commit migrates all usages to the new recommended APIs:

- Non-sensitive config values → `Cypress.expose()` (synchronous)
- Sensitive token values → `cy.env()` (asynchronous)

Added `expose` configuration in cypress config for public values and set `allowCypressEnv: false` to prevent any future usage of the deprecated API.

### Reference
https://docs.cypress.io/app/references/migration-guide#Migrating-away-from-Cypressenv
