### PR TITLE
SSO users can reset password if provider disabled

### DIFF
--- a/src/metabase/sso/core.clj
+++ b/src/metabase/sso/core.clj
@@ -25,7 +25,8 @@
   google-auth-enabled
   ldap-enabled
   send-new-sso-user-admin-email?
-  sso-enabled?])
+  sso-enabled?
+  sso-source-enabled?])
 
 #_{:clj-kondo/ignore [:missing-docstring]}
 (p/import-def metabase.sso.ldap.default-implementation/UserInfo LDAPUserInfo)


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #70171
Previously, password-reset-disabled? blocked password reset for all SSO users unconditionally (except Google when SSO was globally disabled). After a license downgrade, EE SSO users were locked out — they couldn't use SSO (no license) and couldn't reset their password either.

Introduce sso-source-enabled? which checks whether a user's specific SSO provider is currently active, using setting/get to respect the :feature guards on EE settings. password-reset-disabled? now delegates to this function, so password reset is only blocked when the provider is actually usable.