### PR TITLE
Replace deprecated test helpers in e2e tests

### DIFF
--- a/.claude/skills/rewrite-tests-to-lib/SKILL.md
+++ b/.claude/skills/rewrite-tests-to-lib/SKILL.md
@@ -1,0 +1,417 @@
+---
+name: rewrite-tests-to-lib
+description: |
+  Rewrite tests that rely on legacy MBQL to use the new lib-based
+  tests helpers like `Lib.createTestQuery` and `H.createCardWithTestQuery`.
+---
+
+# Rewrite tests to use the new Lib-based test helpers
+
+The legacy helpers take hand-written MBQL (`["field", id, opts]`, `"source-table"`,
+`aggregation`, etc.). The new helpers take a small, typed spec that Lib resolves into a
+real query on the backend. Columns are referenced by name instead of numeric field id,
+so the specs are shorter and survive schema changes.
+
+## Helper mapping
+
+| Legacy helper | New helper | Notes |
+| --- | --- | --- |
+| `H.createQuestion` (structured) | `H.createCardWithTestQuery` | async, chain `.then(H.visitCard)` to visit |
+| `H.createNativeQuestion` | `H.createCardWithTestNativeQuery` | async, chain `.then(H.visitCard)` to visit |
+| `H.visitQuestionAdhoc` (structured) | `H.visitAdHocQuestionWithTestQuery` | note the exact casing: legacy is `Adhoc`, new is `AdHoc` |
+| `H.visitQuestionAdhoc` (native) | `H.visitAdHocQuestionWithTestNativeQuery` | |
+| `H.createQuestionAndDashboard` | none yet | **not convertible** until a `createDashboardWithTestQuery` helper exists |
+| `H.createNativeQuestionAndDashboard` | none yet | same |
+
+Unit tests (in `metabase-lib`) use `Lib.createTestQuery(metadataProvider, spec)` and
+`Lib.createTestNativeQuery(metadataProvider, spec)`. These take a metadata provider as
+the first argument and return a `Query`, not a card.
+
+If you only need the raw `dataset_query` (no card, no visit), the e2e helpers
+`H.createTestQuery(spec)` and `H.createTestNativeQuery(spec)` return the opaque
+`dataset_query` directly.
+
+## Workflow
+
+1. Pick one file (or one scenario directory) at a time.
+2. Find every legacy helper call using the mapping above.
+3. Swap the helper name and rewrite the query into the new spec (sections below).
+4. `bun run type-check-pure`. The specs are fully typed, so most shape mistakes
+   surface here. Fix until clean.
+5. Run the affected specs (see the `e2e-test` skill). This is not optional: a spec that
+   references a wrong column or `sourceName` type-checks fine but resolves to a different
+   query, so it only fails at runtime.
+6. Self-review with the `e2e-test-review` skill before opening the PR.
+
+## The new spec
+
+The authoritative types live in `frontend/src/metabase-types/api/query.ts` (search for
+`Test*Spec`). A structured query is a non-empty list of stages:
+
+```ts
+dataset_query: {
+  database: SAMPLE_DB_ID,
+  stages: [
+    { source: { type: "table", id: ORDERS_ID }, /* clauses */ },
+    /* later stages have no source; the source is the previous stage */
+  ],
+}
+```
+
+A column is referenced by name, not field id:
+
+```ts
+{ type: "column", name: "TOTAL", sourceName: "ORDERS" }
+```
+
+- `name` is the column name (`ORDERS.TOTAL` → `"TOTAL"`).
+- `sourceName` disambiguates which source the column comes from. See the gotcha below:
+  it is **not** always the uppercase table constant.
+- `displayName` and `index` are further disambiguators when `name` + `sourceName` are not
+  unique.
+
+### Replacing the helper
+
+`H.createQuestion` with a structured `query`:
+
+```diff
+-H.createQuestion(
+-  { name: "Test", query: { "source-table": ORDERS_ID } },
+-  { visitQuestion: true },
+-);
++H.createCardWithTestQuery({
++  name: "Test",
++  dataset_query: {
++    database: SAMPLE_DB_ID,
++    stages: [{ source: { type: "table", id: ORDERS_ID } }],
++  },
++}).then(H.visitCard);
+```
+
+`H.createCardWithTestQuery` / `H.createCardWithTestNativeQuery` are async and resolve to
+the created `Card`. `H.visitCard` takes that card (`{ id, type }`) and visits it; it
+supports `question`, `model`, and `metric` types. It returns the card, so you can keep
+chaining.
+
+`H.visitQuestionAdhoc` maps directly, keeping its options (`{ mode?: "notebook",
+skipWaiting?, autorun? }`, where `autorun` is native-only):
+
+```diff
+-H.visitQuestionAdhoc({
+-  dataset_query: {
+-    type: "query",
+-    database: SAMPLE_DB_ID,
+-    query: { "source-table": ORDERS_ID, filter: ["=", ["field-id", ORDERS.USER_ID], 1] },
+-  },
+-});
++H.visitAdHocQuestionWithTestQuery({
++  dataset_query: {
++    database: SAMPLE_DB_ID,
++    stages: [
++      {
++        source: { type: "table", id: ORDERS_ID },
++        filters: [
++          {
++            type: "operator",
++            operator: "=",
++            args: [
++              { type: "column", name: "USER_ID", sourceName: "ORDERS" },
++              { type: "literal", value: 1 },
++            ],
++          },
++        ],
++      },
++    ],
++  },
++});
+```
+
+### wrapId
+
+The new helpers have no `wrapId`. Use the resolved card instead of a Cypress alias:
+
+```diff
+-H.createQuestion({ ... }, { wrapId: true });
+-cy.get("@questionId").then((questionId) => /* use questionId */);
++H.createCardWithTestQuery({ ... }).then((card) => /* use card.id */);
+```
+
+If chaining nests too deeply, `cy.wrap(card.id).as("questionId")` inside the `.then` keeps
+the alias.
+
+## Clause reference
+
+Each clause below lives inside a stage. `// ...` marks other stage clauses.
+
+### source
+
+```diff
+-{ "source-table": ORDERS_ID }
++{ source: { type: "table", id: ORDERS_ID } }
+```
+
+Cards were `"card__123"`, now they are explicit:
+
+```diff
+-{ "source-table": "card__123" }
++{ source: { type: "card", id: 123 } }
+```
+
+### aggregations
+
+An aggregation is an expression, optionally named (`{ name, value }`):
+
+```diff
+-{ aggregation: [["count"]] }
++{ aggregations: [{ type: "operator", operator: "count" }] }
+```
+
+```diff
+-{ aggregation: [["sum", ["field", ORDERS.TOTAL, null]]] }
++{
++  aggregations: [
++    {
++      name: "Sum of Total",
++      value: {
++        type: "operator",
++        operator: "sum",
++        args: [{ type: "column", name: "TOTAL", sourceName: "ORDERS" }],
++      },
++    },
++  ],
++}
+```
+
+### breakouts
+
+A breakout is a column plus optional binning (`unit`, `bins`, or `binWidth`):
+
+```diff
+-{ breakout: [["field", PRODUCTS.CREATED_AT, { "temporal-unit": "month" }]] }
++{ breakouts: [{ type: "column", name: "CREATED_AT", sourceName: "PRODUCTS", unit: "month" }] }
+```
+
+### filters
+
+A filter is an expression. `filter` (singular) becomes `filters` (plural, a list):
+
+```diff
+-{ filter: [">", ["field", ORDERS.TOTAL, null], 100] }
++{
++  filters: [
++    {
++      type: "operator",
++      operator: ">",
++      args: [
++        { type: "column", name: "TOTAL", sourceName: "ORDERS" },
++        { type: "literal", value: 100 },
++      ],
++    },
++  ],
++}
+```
+
+Nest operators for compound filters (`and`, `or`):
+
+```ts
+{
+  type: "operator",
+  operator: "and",
+  args: [
+    { type: "operator", operator: ">", args: [/* ... */] },
+    { type: "operator", operator: "<", args: [/* ... */] },
+  ],
+}
+```
+
+### expressions
+
+The legacy `expressions` map becomes a list of `{ name, value }`:
+
+```diff
+-{ expressions: { "Sum of Total": ["+", ORDERS.TOTAL, 1] } }
++{
++  expressions: [
++    {
++      name: "Sum of Total",
++      value: {
++        type: "operator",
++        operator: "+",
++        args: [
++          { type: "column", name: "TOTAL", sourceName: "ORDERS" },
++          { type: "literal", value: 1 },
++        ],
++      },
++    },
++  ],
++}
+```
+
+### joins
+
+Tables and columns are referenced by id/name, not field refs. `conditions` is optional:
+omit it to use the suggested (foreign-key) join conditions.
+
+```diff
+-{
+-  joins: [{
+-    alias: "Products",
+-    "source-table": PRODUCTS_ID,
+-    strategy: "left-join",
+-    condition: ["=", ["field", ORDERS.PRODUCT_ID, {}], ["field", PRODUCTS.ID, { "join-alias": "Products" }]],
+-  }],
+-}
++{
++  joins: [
++    {
++      source: { type: "table", id: PRODUCTS_ID },
++      strategy: "left-join",
++      conditions: [
++        {
++          operator: "=",
++          left: { type: "column", name: "PRODUCT_ID", sourceName: "ORDERS" },
++          right: { type: "column", name: "ID", sourceName: "PRODUCTS" },
++        },
++      ],
++    },
++  ],
++}
+```
+
+### order-by
+
+```diff
+-{ "order-by": [["asc", ["field", ORDERS.CREATED_AT, null]], ["desc", ["field", ORDERS.TOTAL, null]]] }
++{
++  orderBys: [
++    { type: "column", name: "CREATED_AT", sourceName: "ORDERS", direction: "asc" },
++    { type: "column", name: "TOTAL", sourceName: "ORDERS", direction: "desc" },
++  ],
++}
+```
+
+`direction` defaults to `"asc"`.
+
+### fields
+
+```diff
+-{ fields: [["field", ORDERS.ID, null], ["field", ORDERS.TOTAL, null]] }
++{
++  fields: [
++    { type: "column", name: "ID", sourceName: "ORDERS" },
++    { type: "column", name: "TOTAL", sourceName: "ORDERS" },
++  ],
++}
+```
+
+### limit
+
+```diff
+-{ limit: 10 }
++{ limit: 10 }
+```
+
+Same value, just inside a stage.
+
+## Multi-stage queries
+
+A `"source-query"` becomes an earlier stage. Later stages have no `source`, so the
+previous stage is the source. Reference columns produced by an earlier stage by name only
+(no `sourceName`):
+
+```diff
+-{
+-  "source-query": {
+-    "source-table": ORDERS_ID,
+-    aggregation: [["count"]],
+-    breakout: [["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }]],
+-  },
+-  filter: [">", ["field", "count", { "base-type": "type/Integer" }], 5],
+-}
++{
++  database: SAMPLE_DB_ID,
++  stages: [
++    {
++      source: { type: "table", id: ORDERS_ID },
++      aggregations: [{ type: "operator", operator: "count" }],
++      breakouts: [{ type: "column", name: "CREATED_AT", sourceName: "ORDERS", unit: "month" }],
++    },
++    {
++      filters: [
++        {
++          type: "operator",
++          operator: ">",
++          args: [
++            { type: "column", name: "count" },
++            { type: "literal", value: 5 },
++          ],
++        },
++      ],
++    },
++  ],
++}
+```
+
+## Native queries
+
+Native specs need only minor rewriting:
+
+- The `native: { query, "template-tags" }` wrapper is flattened: `query` and `templateTags`
+  move to the top level of `dataset_query`.
+- `template-tags` becomes camelCase `templateTags`.
+- Drop boilerplate like `id` on individual tags.
+- A field-filter tag's `dimension` changes from a field reference to a plain field id.
+
+```diff
+-H.createQuestion({
+-  query: {
+-    type: "native",
+-    database: SAMPLE_DB_ID,
+-    native: {
+-      query: "SELECT * FROM orders [[WHERE {{total}}]]",
+-      "template-tags": {
+-        total: {
+-          id: "abc123",
+-          name: "total",
+-          "display-name": "Total",
+-          type: "dimension",
+-          dimension: ["field", ORDERS.TOTAL, null],
+-          "widget-type": "number/=",
+-        },
+-      },
+-    },
+-  },
+-});
++H.createCardWithTestNativeQuery({
++  dataset_query: {
++    database: SAMPLE_DB_ID,
++    query: "SELECT * FROM orders [[WHERE {{total}}]]",
++    templateTags: {
++      total: {
++        type: "dimension",
++        name: "total",
++        "display-name": "Total",
++        dimension: ORDERS.TOTAL, // plain field id, not a field reference
++        "widget-type": "number/=",
++      },
++    },
++  },
++});
+```
+
+## Gotchas
+
+- **`sourceName` is not always the table constant.** For a directly-queried table it is the
+  table's name (`"ORDERS"`). For an implicitly-joined (foreign-key) column it is the target
+  table's display name, e.g. `["field", PEOPLE.ID, { "source-field": ORDERS.USER_ID }]`
+  becomes `{ type: "column", name: "ID", sourceName: "People" }`. When a conversion
+  type-checks but the test fails, this is the first thing to check.
+- **Drop `base-type` and field ids.** The spec resolves columns by name, so
+  `{ "base-type": ... }` options and numeric field ids are not needed.
+- **Silent failures.** A wrong `name`/`sourceName` still produces a valid query, just the
+  wrong one. Always run the affected specs (step 5), do not rely on type-check alone.
+- **Dates come from sample data.** Assertions on sample-data dates (e.g. `"April 2025"`)
+  are periodically shifted on master. Do not change them during a conversion. Keep the
+  existing expected values.
+- **`createQuestionAndDashboard` has no equivalent yet.** Leave those calls alone until a
+  dashboard test-query helper exists.

--- a/e2e/support/helpers/e2e-ad-hoc-question-helpers.js
+++ b/e2e/support/helpers/e2e-ad-hoc-question-helpers.js
@@ -126,7 +126,11 @@ export function startNewNativeModel(config) {
  * Visit any valid query in an ad-hoc manner.
  *
  * @param {import("./api").QuestionDetails} question
- * @param {{callback?: function, mode: (undefined|"notebook")}} config
+ * @param {object} [options]
+ * @param {function} [options.callback]
+ * @param {"notebook"|undefined} [options.mode]
+ * @param {boolean} [options.autorun]
+ * @param {boolean} [options.skipWaiting]
  */
 export function visitQuestionAdhoc(
   question,

--- a/e2e/support/helpers/e2e-card-helpers.ts
+++ b/e2e/support/helpers/e2e-card-helpers.ts
@@ -6,6 +6,7 @@ import type {
 
 import { createTestNativeQuery, createTestQuery } from "./api";
 import { type CardDetails as CardDetails_, createCard } from "./api/createCard";
+import { visitMetric, visitModel, visitQuestion } from "./e2e-misc-helpers";
 
 type CardDetails<T> = Omit<CardDetails_, "dataset_query"> & {
   dataset_query: T;
@@ -25,4 +26,15 @@ export function createCardWithTestNativeQuery(
   return createTestNativeQuery(details.dataset_query).then((dataset_query) =>
     createCard({ ...details, dataset_query }),
   );
+}
+
+export function visitCard(card: Pick<Card, "id" | "type">) {
+  switch (card.type) {
+    case "question":
+      return visitQuestion(card.id);
+    case "model":
+      return visitModel(card.id);
+    case "metric":
+      return visitMetric(card.id);
+  }
 }

--- a/e2e/support/helpers/e2e-card-helpers.ts
+++ b/e2e/support/helpers/e2e-card-helpers.ts
@@ -1,0 +1,28 @@
+import type {
+  Card,
+  TestNativeQuerySpecWithDatabase,
+  TestQuerySpecWithDatabase,
+} from "metabase-types/api";
+
+import { createTestNativeQuery, createTestQuery } from "./api";
+import { type CardDetails as CardDetails_, createCard } from "./api/createCard";
+
+type CardDetails<T> = Omit<CardDetails_, "dataset_query"> & {
+  dataset_query: T;
+};
+
+export function createCardWithTestQuery(
+  details: CardDetails<TestQuerySpecWithDatabase>,
+): Cypress.Chainable<Card> {
+  return createTestQuery(details.dataset_query).then((dataset_query) =>
+    createCard({ ...details, dataset_query }),
+  );
+}
+
+export function createCardWithTestNativeQuery(
+  details: CardDetails<TestNativeQuerySpecWithDatabase>,
+): Cypress.Chainable<Card> {
+  return createTestNativeQuery(details.dataset_query).then((dataset_query) =>
+    createCard({ ...details, dataset_query }),
+  );
+}

--- a/e2e/support/helpers/e2e-card-helpers.ts
+++ b/e2e/support/helpers/e2e-card-helpers.ts
@@ -29,14 +29,16 @@ export function createCardWithTestNativeQuery(
   );
 }
 
-export function visitCard(card: Pick<Card, "id" | "type">) {
+export function visitCard<C extends Pick<Card, "id" | "type">>(
+  card: C,
+): Cypress.Chainable<C> {
   switch (card.type) {
     case "question":
-      return visitQuestion(card.id);
+      return visitQuestion(card.id).then(() => card);
     case "model":
-      return visitModel(card.id);
+      return visitModel(card.id).then(() => card);
     case "metric":
-      return visitMetric(card.id);
+      return visitMetric(card.id).then(() => card);
   }
 }
 

--- a/e2e/support/helpers/e2e-card-helpers.ts
+++ b/e2e/support/helpers/e2e-card-helpers.ts
@@ -6,6 +6,7 @@ import type {
 
 import { createTestNativeQuery, createTestQuery } from "./api";
 import { type CardDetails as CardDetails_, createCard } from "./api/createCard";
+import { visitQuestionAdhoc } from "./e2e-ad-hoc-question-helpers";
 import { visitMetric, visitModel, visitQuestion } from "./e2e-misc-helpers";
 
 type CardDetails<T> = Omit<CardDetails_, "dataset_query"> & {
@@ -37,4 +38,41 @@ export function visitCard(card: Pick<Card, "id" | "type">) {
     case "metric":
       return visitMetric(card.id);
   }
+}
+
+export function visitAdHocQuestionWithTestQuery(
+  details: CardDetails<TestQuerySpecWithDatabase>,
+  options: {
+    mode?: "notebook";
+    skipWaiting?: boolean;
+  } = {},
+) {
+  return H.createTestQuery(details.dataset_query).then((dataset_query) => {
+    const question: Card = {
+      display: "table" as const,
+      ...details,
+      dataset_query,
+    };
+    return visitQuestionAdhoc(question, options);
+  });
+}
+
+export function visitAdHocQuestionWithTestNativeQuery(
+  details: CardDetails<TestNativeQuerySpecWithDatabase>,
+  options: {
+    mode?: "notebook";
+    autorun?: boolean;
+    skipWaiting?: boolean;
+  } = {},
+) {
+  return H.createTestNativeQuery(details.dataset_query).then(
+    (dataset_query) => {
+      const question: Card = {
+        display: "table" as const,
+        ...details,
+        dataset_query,
+      };
+      return visitQuestionAdhoc(question, options);
+    },
+  );
 }

--- a/e2e/support/helpers/e2e-card-helpers.ts
+++ b/e2e/support/helpers/e2e-card-helpers.ts
@@ -1,16 +1,30 @@
 import type {
   Card,
+  CardId,
+  Dashboard,
+  DashboardCard,
   TestNativeQuerySpecWithDatabase,
   TestQuerySpecWithDatabase,
 } from "metabase-types/api";
 
-import { createTestNativeQuery, createTestQuery } from "./api";
+import {
+  type DashboardDetails,
+  createDashboard,
+  createTestNativeQuery,
+  createTestQuery,
+} from "./api";
 import { type CardDetails as CardDetails_, createCard } from "./api/createCard";
 import { visitQuestionAdhoc } from "./e2e-ad-hoc-question-helpers";
 import { visitMetric, visitModel, visitQuestion } from "./e2e-misc-helpers";
 
 type CardDetails<T> = Omit<CardDetails_, "dataset_query"> & {
   dataset_query: T;
+};
+
+type QuestionAndDashboardDetails<T> = {
+  questionDetails: CardDetails<T>;
+  dashboardDetails?: DashboardDetails;
+  cardDetails?: Partial<DashboardCard>;
 };
 
 export function createCardWithTestQuery(
@@ -26,6 +40,70 @@ export function createCardWithTestNativeQuery(
 ): Cypress.Chainable<Card> {
   return createTestNativeQuery(details.dataset_query).then((dataset_query) =>
     createCard({ ...details, dataset_query }),
+  );
+}
+
+export function createQuestionAndDashboardWithTestQuery({
+  questionDetails,
+  dashboardDetails,
+  cardDetails,
+}: QuestionAndDashboardDetails<TestQuerySpecWithDatabase>) {
+  return createCardWithTestQuery(questionDetails).then((card) =>
+    addCardToNewDashboard(card, dashboardDetails, cardDetails),
+  );
+}
+
+export function createNativeQuestionAndDashboardWithTestQuery({
+  questionDetails,
+  dashboardDetails,
+  cardDetails,
+}: QuestionAndDashboardDetails<TestNativeQuerySpecWithDatabase>) {
+  return createCardWithTestNativeQuery(questionDetails).then((card) =>
+    addCardToNewDashboard(card, dashboardDetails, cardDetails),
+  );
+}
+
+function addCardToNewDashboard(
+  card: Card,
+  dashboardDetails: DashboardDetails | undefined,
+  cardDetails: Partial<DashboardCard> | undefined,
+): Cypress.Chainable<
+  Cypress.Response<Dashboard> & {
+    body: DashboardCard;
+    dashboardId: Dashboard["id"];
+    dashboardTabs: Dashboard["tabs"];
+    questionId: CardId;
+  }
+> {
+  const tabs = dashboardDetails?.tabs ?? [];
+  const dashboardTabId = tabs[0]?.id ?? null;
+
+  return createDashboard(dashboardDetails).then(
+    ({ body: { id: dashboardId } }) =>
+      cy
+        .request<Dashboard>("PUT", `/api/dashboard/${dashboardId}`, {
+          tabs,
+          dashcards: [
+            {
+              id: -1,
+              card_id: card.id,
+              dashboard_tab_id: dashboardTabId,
+              // Add sane defaults for the dashboard card size and position
+              row: 0,
+              col: 0,
+              size_x: 11,
+              size_y: 6,
+              ...cardDetails,
+            },
+          ],
+        })
+        .then((response) => ({
+          ...response,
+          body: response.body.dashcards[0],
+          dashboardId,
+          dashboardTabs: response.body.tabs,
+          questionId: card.id,
+        })),
   );
 }
 

--- a/e2e/support/helpers/e2e-misc-helpers.js
+++ b/e2e/support/helpers/e2e-misc-helpers.js
@@ -115,6 +115,8 @@ export function visitQuestion(questionIdOrAlias, { onBeforeLoad } = {}) {
       .get(questionIdOrAlias)
       .then((id) => visitQuestionById(id, { onBeforeLoad }));
   }
+
+  throw new Error("Invalid questionIdOrAlias");
 }
 
 function visitQuestionById(id, { onBeforeLoad } = {}) {
@@ -153,7 +155,7 @@ export function visitModel(id, { hasDataAccess = true } = {}) {
 
   cy.visit(`/model/${id}`);
 
-  cy.wait("@" + alias);
+  return cy.wait("@" + alias);
 }
 
 /**
@@ -168,7 +170,7 @@ export function visitMetric(id) {
 
   cy.visit(`/metric/${id}`);
 
-  cy.wait("@" + alias);
+  return cy.wait("@" + alias);
 }
 
 /**

--- a/e2e/support/helpers/index.ts
+++ b/e2e/support/helpers/index.ts
@@ -7,6 +7,7 @@ export * from "./e2e-boolean-helpers";
 export * from "./e2e-browser-helpers";
 export * from "./e2e-caching-helpers";
 export * from "./e2e-cloud-helpers";
+export * from "./e2e-card-helpers";
 export * from "./e2e-codemirror-helpers";
 export * from "./e2e-collection-helpers";
 export * from "./e2e-command-palette-helpers";

--- a/e2e/test/scenarios/joins/joins.cy.spec.js
+++ b/e2e/test/scenarios/joins/joins.cy.spec.js
@@ -2,7 +2,7 @@ const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
-const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
+const { ORDERS_ID, PRODUCTS_ID } = SAMPLE_DATABASE;
 
 describe("scenarios > question > joined questions", () => {
   beforeEach(() => {
@@ -160,23 +160,56 @@ describe("scenarios > question > joined questions", () => {
       "metadata",
     );
 
-    H.createQuestion({
+    H.createCardWithTestQuery({
       name: "Q1",
-      query: {
-        aggregation: ["sum", ["field", ORDERS.TOTAL, null]],
-        breakout: [["field", ORDERS.PRODUCT_ID, null]],
-        // Make sure it works if a question has sorted metric (metabase#13744)
-        "order-by": [["asc", ["aggregation", 0]]],
-        "source-table": ORDERS_ID,
+      dataset_query: {
+        database: SAMPLE_DB_ID,
+        stages: [
+          {
+            source: { type: "table", id: ORDERS_ID },
+            aggregations: [
+              {
+                type: "operator",
+                operator: "sum",
+                args: [{ type: "column", name: "TOTAL", sourceName: "ORDERS" }],
+              },
+            ],
+            breakouts: [
+              { type: "column", name: "PRODUCT_ID", sourceName: "ORDERS" },
+            ],
+            // Make sure it works if a question has sorted metric (metabase#13744)
+            orderBys: [
+              {
+                type: "column",
+                name: "sum",
+                displayName: "Sum of Total",
+                direction: "asc",
+              },
+            ],
+          },
+        ],
       },
     });
 
-    H.createQuestion({
+    H.createCardWithTestQuery({
       name: "Q2",
-      query: {
-        aggregation: ["sum", ["field", PRODUCTS.RATING, null]],
-        breakout: [["field", PRODUCTS.ID, null]],
-        "source-table": PRODUCTS_ID,
+      dataset_query: {
+        database: SAMPLE_DB_ID,
+        stages: [
+          {
+            source: { type: "table", id: PRODUCTS_ID },
+            aggregations: [
+              {
+                type: "operator",
+                operator: "sum",
+                args: [
+                  { type: "column", name: "RATING", sourceName: "PRODUCTS" },
+                ],
+              },
+            ],
+            breakouts: [{ type: "column", name: "ID", sourceName: "PRODUCTS" }],
+          },
+        ],
       },
     });
 
@@ -314,26 +347,36 @@ describe("scenarios > question > joined questions", () => {
   });
 
   it("should remove a join when changing the source table", () => {
-    H.visitQuestionAdhoc(
+    H.visitAdHocQuestionWithTestQuery(
       {
         dataset_query: {
-          type: "query",
           database: SAMPLE_DB_ID,
-          query: {
-            "source-table": ORDERS_ID,
-            joins: [
-              {
-                alias: "Products",
-                condition: [
-                  "=",
-                  ["field", ORDERS.PRODUCT_ID, null],
-                  ["field", PRODUCTS.ID, { "join-alias": "Products" }],
-                ],
-                fields: "all",
-                "source-table": PRODUCTS_ID,
-              },
-            ],
-          },
+          stages: [
+            {
+              source: { type: "table", id: ORDERS_ID },
+              joins: [
+                {
+                  source: { type: "table", id: PRODUCTS_ID },
+                  strategy: "left-join",
+                  conditions: [
+                    {
+                      operator: "=",
+                      left: {
+                        type: "column",
+                        name: "PRODUCT_ID",
+                        sourceName: "ORDERS",
+                      },
+                      right: {
+                        type: "column",
+                        name: "ID",
+                        sourceName: "Products",
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
         },
       },
       { mode: "notebook" },

--- a/e2e/test/scenarios/question-reproductions/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/question-reproductions/reproductions.cy.spec.ts
@@ -833,24 +833,22 @@ describe("54205", () => {
         });
       });
 
-      H.createTestQuery({
-        database: WRITABLE_DB_ID,
-        stages: [
-          {
-            source: {
-              type: "table",
-              id: tableId,
+      H.createCardWithTestQuery({
+        name: "Q 54205",
+        dataset_query: {
+          database: WRITABLE_DB_ID,
+          stages: [
+            {
+              source: {
+                type: "table",
+                id: tableId,
+              },
             },
-          },
-        ],
-      }).then((query) => {
-        H.createCard({
-          name: "Q 54205",
-          dataset_query: query,
-        }).then((card) => {
-          cy.wrap(card.id).as("questionId");
-          H.visitQuestion(card.id);
-        });
+          ],
+        },
+      }).then((card) => {
+        cy.wrap(card.id).as("questionId");
+        H.visitQuestion(card.id);
       });
     });
 

--- a/e2e/test/scenarios/question-reproductions/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/question-reproductions/reproductions.cy.spec.ts
@@ -846,10 +846,7 @@ describe("54205", () => {
             },
           ],
         },
-      }).then((card) => {
-        cy.wrap(card.id).as("questionId");
-        H.visitQuestion(card.id);
-      });
+      }).then(H.visitCard);
     });
 
     cy.findByTestId("query-visualization-root").contains("Name").click();

--- a/e2e/test/scenarios/question/column-compare.cy.spec.ts
+++ b/e2e/test/scenarios/question/column-compare.cy.spec.ts
@@ -3,143 +3,251 @@ import _ from "underscore";
 const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import type { FieldReference, StructuredQuery } from "metabase-types/api";
 
-const { PRODUCTS_ID, PRODUCTS, ORDERS, ORDERS_ID, PEOPLE } = SAMPLE_DATABASE;
+const { PRODUCTS_ID, PRODUCTS, ORDERS_ID } = SAMPLE_DATABASE;
 
-const FIELD_PRICE: FieldReference = [
-  "field",
-  PRODUCTS.PRICE,
-  { "base-type": "type/Float" },
-];
-
-const BREAKOUT_BINNED_DATETIME: FieldReference = [
-  "field",
-  PRODUCTS.CREATED_AT,
-  { "base-type": "type/DateTime", "temporal-unit": "month" },
-];
-
-const BREAKOUT_NON_BINNED_DATETIME: FieldReference = [
-  "field",
-  PRODUCTS.CREATED_AT,
-  { "base-type": "type/DateTime" },
-];
-
-const BREAKOUT_NON_DATETIME: FieldReference = [
-  "field",
-  PRODUCTS.CATEGORY,
-  { "base-type": "type/Text" },
-];
-
-const BREAKOUT_OTHER_DATETIME: FieldReference = [
-  "field",
-  PEOPLE.CREATED_AT,
-  {
-    "base-type": "type/DateTime",
-    "temporal-unit": "month",
-    "source-field": ORDERS.USER_ID,
-  },
-];
-
-const QUERY_NO_AGGREGATION: StructuredQuery = {
-  "source-table": PRODUCTS_ID,
-};
-
-const QUERY_SINGLE_AGGREGATION_NO_BREAKOUT: StructuredQuery = {
-  "source-table": PRODUCTS_ID,
-  aggregation: [["count"]],
-};
-
-const QUERY_MULTIPLE_AGGREGATIONS_NO_BREAKOUT: StructuredQuery = {
-  "source-table": PRODUCTS_ID,
-  aggregation: [["count"], ["sum", FIELD_PRICE]],
-};
-
-const QUERY_SINGLE_AGGREGATION_BINNED_DATETIME_BREAKOUT: StructuredQuery = {
-  "source-table": PRODUCTS_ID,
-  aggregation: [["count"]],
-  breakout: [BREAKOUT_BINNED_DATETIME],
-};
-
-const QUERY_SINGLE_AGGREGATION_OTHER_DATETIME: StructuredQuery = {
-  "source-table": ORDERS_ID,
-  aggregation: [["count"]],
-  breakout: [BREAKOUT_OTHER_DATETIME],
-};
-
-const QUERY_SINGLE_AGGREGATION_NON_BINNED_DATETIME_BREAKOUT: StructuredQuery = {
-  "source-table": PRODUCTS_ID,
-  aggregation: [["count"]],
-  breakout: [BREAKOUT_NON_BINNED_DATETIME],
-};
-
-const QUERY_SINGLE_AGGREGATION_NON_DATETIME_BREAKOUT: StructuredQuery = {
-  "source-table": PRODUCTS_ID,
-  aggregation: [["count"]],
-  breakout: [BREAKOUT_NON_DATETIME],
-};
-
-const QUERY_MULTIPLE_AGGREGATIONS_BINNED_DATETIME_BREAKOUT: StructuredQuery = {
-  "source-table": PRODUCTS_ID,
-  aggregation: [["count"], ["sum", FIELD_PRICE]],
-  breakout: [BREAKOUT_BINNED_DATETIME],
-};
-
-const QUERY_MULTIPLE_AGGREGATIONS_NON_BINNED_DATETIME_BREAKOUT: StructuredQuery =
-  {
-    "source-table": PRODUCTS_ID,
-    aggregation: [["count"], ["sum", FIELD_PRICE]],
-    breakout: [BREAKOUT_NON_BINNED_DATETIME],
-  };
-
-const QUERY_MULTIPLE_AGGREGATIONS_NON_DATETIME_BREAKOUT: StructuredQuery = {
-  "source-table": PRODUCTS_ID,
-  aggregation: [["count"], ["sum", FIELD_PRICE]],
-  breakout: [BREAKOUT_NON_DATETIME],
-};
-
-const QUERY_MULTIPLE_BREAKOUTS: StructuredQuery = {
-  "source-table": PRODUCTS_ID,
-  aggregation: [["count"]],
-  breakout: [BREAKOUT_NON_DATETIME, BREAKOUT_BINNED_DATETIME],
-};
-
-const QUERY_MULTIPLE_TEMPORAL_BREAKOUTS: StructuredQuery = {
-  "source-table": PRODUCTS_ID,
-  aggregation: [["count"]],
-  breakout: [
-    BREAKOUT_NON_DATETIME,
-    BREAKOUT_BINNED_DATETIME,
-    BREAKOUT_NON_BINNED_DATETIME,
+const QUERY_NO_AGGREGATION = {
+  database: SAMPLE_DB_ID,
+  stages: [
+    {
+      source: { type: "table" as const, id: PRODUCTS_ID },
+    },
   ],
 };
 
-const QUERY_TEMPORAL_EXPRESSION_BREAKOUT: StructuredQuery = {
-  "source-table": PRODUCTS_ID,
-  expressions: {
-    "Created At plus one month": [
-      "datetime-add",
-      [
-        "field",
-        PRODUCTS.CREATED_AT,
+const QUERY_SINGLE_AGGREGATION_NO_BREAKOUT = {
+  database: SAMPLE_DB_ID,
+  stages: [
+    {
+      source: { type: "table" as const, id: PRODUCTS_ID },
+      aggregations: [{ type: "operator" as const, operator: "count" }],
+    },
+  ],
+};
+
+const QUERY_MULTIPLE_AGGREGATIONS_NO_BREAKOUT = {
+  database: SAMPLE_DB_ID,
+  stages: [
+    {
+      source: { type: "table" as const, id: PRODUCTS_ID },
+      aggregations: [
+        { type: "operator" as const, operator: "count" },
         {
-          "base-type": "type/DateTime",
+          type: "operator" as const,
+          operator: "sum",
+          args: [
+            { type: "column" as const, name: "PRICE", sourceName: "PRODUCTS" },
+          ],
         },
       ],
-      1,
-      "month",
-    ],
-  },
-  aggregation: [["count"]],
-  breakout: [
-    [
-      "expression",
-      "Created At plus one month",
-      {
-        "base-type": "type/DateTime",
-        "temporal-unit": "month",
-      },
-    ],
+    },
+  ],
+};
+
+const QUERY_SINGLE_AGGREGATION_BINNED_DATETIME_BREAKOUT = {
+  database: SAMPLE_DB_ID,
+  stages: [
+    {
+      source: { type: "table" as const, id: PRODUCTS_ID },
+      aggregations: [{ type: "operator" as const, operator: "count" }],
+      breakouts: [
+        {
+          type: "column" as const,
+          name: "CREATED_AT",
+          sourceName: "PRODUCTS",
+          unit: "month" as const,
+        },
+      ],
+    },
+  ],
+};
+
+const QUERY_SINGLE_AGGREGATION_OTHER_DATETIME = {
+  database: SAMPLE_DB_ID,
+  stages: [
+    {
+      source: { type: "table" as const, id: ORDERS_ID },
+      aggregations: [{ type: "operator" as const, operator: "count" }],
+      breakouts: [
+        {
+          type: "column" as const,
+          name: "CREATED_AT",
+          sourceName: "People",
+          unit: "month" as const,
+        },
+      ],
+    },
+  ],
+};
+
+const QUERY_SINGLE_AGGREGATION_NON_BINNED_DATETIME_BREAKOUT = {
+  database: SAMPLE_DB_ID,
+  stages: [
+    {
+      source: { type: "table" as const, id: PRODUCTS_ID },
+      aggregations: [{ type: "operator" as const, operator: "count" }],
+      breakouts: [
+        { type: "column" as const, name: "CREATED_AT", sourceName: "PRODUCTS" },
+      ],
+    },
+  ],
+};
+
+const QUERY_SINGLE_AGGREGATION_NON_DATETIME_BREAKOUT = {
+  database: SAMPLE_DB_ID,
+  stages: [
+    {
+      source: { type: "table" as const, id: PRODUCTS_ID },
+      aggregations: [{ type: "operator" as const, operator: "count" }],
+      breakouts: [
+        { type: "column" as const, name: "CATEGORY", sourceName: "PRODUCTS" },
+      ],
+    },
+  ],
+};
+
+const QUERY_MULTIPLE_AGGREGATIONS_BINNED_DATETIME_BREAKOUT = {
+  database: SAMPLE_DB_ID,
+  stages: [
+    {
+      source: { type: "table" as const, id: PRODUCTS_ID },
+      aggregations: [
+        { type: "operator" as const, operator: "count" },
+        {
+          type: "operator" as const,
+          operator: "sum",
+          args: [
+            { type: "column" as const, name: "PRICE", sourceName: "PRODUCTS" },
+          ],
+        },
+      ],
+      breakouts: [
+        {
+          type: "column" as const,
+          name: "CREATED_AT",
+          sourceName: "PRODUCTS",
+          unit: "month" as const,
+        },
+      ],
+    },
+  ],
+};
+
+const QUERY_MULTIPLE_AGGREGATIONS_NON_BINNED_DATETIME_BREAKOUT = {
+  database: SAMPLE_DB_ID,
+  stages: [
+    {
+      source: { type: "table" as const, id: PRODUCTS_ID },
+      aggregations: [
+        { type: "operator" as const, operator: "count" },
+        {
+          type: "operator" as const,
+          operator: "sum",
+          args: [
+            { type: "column" as const, name: "PRICE", sourceName: "PRODUCTS" },
+          ],
+        },
+      ],
+      breakouts: [
+        { type: "column" as const, name: "CREATED_AT", sourceName: "PRODUCTS" },
+      ],
+    },
+  ],
+};
+
+const QUERY_MULTIPLE_AGGREGATIONS_NON_DATETIME_BREAKOUT = {
+  database: SAMPLE_DB_ID,
+  stages: [
+    {
+      source: { type: "table" as const, id: PRODUCTS_ID },
+      aggregations: [
+        { type: "operator" as const, operator: "count" },
+        {
+          type: "operator" as const,
+          operator: "sum",
+          args: [
+            { type: "column" as const, name: "PRICE", sourceName: "PRODUCTS" },
+          ],
+        },
+      ],
+      breakouts: [
+        { type: "column" as const, name: "CATEGORY", sourceName: "PRODUCTS" },
+      ],
+    },
+  ],
+};
+
+const QUERY_MULTIPLE_BREAKOUTS = {
+  database: SAMPLE_DB_ID,
+  stages: [
+    {
+      source: { type: "table" as const, id: PRODUCTS_ID },
+      aggregations: [{ type: "operator" as const, operator: "count" }],
+      breakouts: [
+        { type: "column" as const, name: "CATEGORY", sourceName: "PRODUCTS" },
+        {
+          type: "column" as const,
+          name: "CREATED_AT",
+          sourceName: "PRODUCTS",
+          unit: "month" as const,
+        },
+      ],
+    },
+  ],
+};
+
+const QUERY_MULTIPLE_TEMPORAL_BREAKOUTS = {
+  database: SAMPLE_DB_ID,
+  stages: [
+    {
+      source: { type: "table" as const, id: PRODUCTS_ID },
+      aggregations: [{ type: "operator" as const, operator: "count" }],
+      breakouts: [
+        { type: "column" as const, name: "CATEGORY", sourceName: "PRODUCTS" },
+        {
+          type: "column" as const,
+          name: "CREATED_AT",
+          sourceName: "PRODUCTS",
+          unit: "month" as const,
+        },
+        { type: "column" as const, name: "CREATED_AT", sourceName: "PRODUCTS" },
+      ],
+    },
+  ],
+};
+
+const QUERY_TEMPORAL_EXPRESSION_BREAKOUT = {
+  database: SAMPLE_DB_ID,
+  stages: [
+    {
+      source: { type: "table" as const, id: PRODUCTS_ID },
+      expressions: [
+        {
+          name: "Created At plus one month",
+          value: {
+            type: "operator" as const,
+            operator: "datetime-add",
+            args: [
+              {
+                type: "column" as const,
+                name: "CREATED_AT",
+                sourceName: "PRODUCTS",
+              },
+              { type: "literal" as const, value: 1 },
+              { type: "literal" as const, value: "month" },
+            ],
+          },
+        },
+      ],
+      aggregations: [{ type: "operator" as const, operator: "count" }],
+      breakouts: [
+        {
+          type: "column" as const,
+          name: "Created At plus one month",
+          unit: "month" as const,
+        },
+      ],
+    },
   ],
 };
 
@@ -197,9 +305,11 @@ describe("scenarios > question", { tags: "@skip" }, () => {
 
     describe("no aggregations", () => {
       it("does not show column compare shortcut", () => {
-        H.createQuestion(
-          { query: QUERY_NO_AGGREGATION },
-          { visitQuestion: true, wrapId: true, idAlias: "questionId" },
+        H.createCardWithTestQuery({ dataset_query: QUERY_NO_AGGREGATION }).then(
+          (card) => {
+            cy.wrap(card.id).as("questionId");
+            return H.visitCard(card);
+          },
         );
 
         cy.log("chill mode - summarize sidebar");
@@ -231,9 +341,11 @@ describe("scenarios > question", { tags: "@skip" }, () => {
       });
 
       it("no breakout", () => {
-        H.createQuestion(
-          { query: QUERY_NO_AGGREGATION },
-          { visitQuestion: true, wrapId: true, idAlias: "questionId" },
+        H.createCardWithTestQuery({ dataset_query: QUERY_NO_AGGREGATION }).then(
+          (card) => {
+            cy.wrap(card.id).as("questionId");
+            return H.visitCard(card);
+          },
         );
 
         cy.log("chill mode - summarize sidebar");
@@ -257,10 +369,12 @@ describe("scenarios > question", { tags: "@skip" }, () => {
       });
 
       it("one breakout", () => {
-        H.createQuestion(
-          { query: QUERY_SINGLE_AGGREGATION_NON_DATETIME_BREAKOUT },
-          { visitQuestion: true, wrapId: true, idAlias: "questionId" },
-        );
+        H.createCardWithTestQuery({
+          dataset_query: QUERY_SINGLE_AGGREGATION_NON_DATETIME_BREAKOUT,
+        }).then((card) => {
+          cy.wrap(card.id).as("questionId");
+          return H.visitCard(card);
+        });
 
         cy.log("chill mode - summarize sidebar");
         cy.button(/Summarize/).click();
@@ -285,10 +399,12 @@ describe("scenarios > question", { tags: "@skip" }, () => {
 
     describe("offset", () => {
       it("should be possible to change the temporal bucket through a preset", () => {
-        H.createQuestion(
-          { query: QUERY_SINGLE_AGGREGATION_NO_BREAKOUT },
-          { visitQuestion: true, wrapId: true, idAlias: "questionId" },
-        );
+        H.createCardWithTestQuery({
+          dataset_query: QUERY_SINGLE_AGGREGATION_NO_BREAKOUT,
+        }).then((card) => {
+          cy.wrap(card.id).as("questionId");
+          return H.visitCard(card);
+        });
 
         H.openNotebook();
         // eslint-disable-next-line metabase/no-unsafe-element-filtering
@@ -324,10 +440,12 @@ describe("scenarios > question", { tags: "@skip" }, () => {
       });
 
       it("should be possible to change the temporal bucket with a custom offset", () => {
-        H.createQuestion(
-          { query: QUERY_SINGLE_AGGREGATION_NO_BREAKOUT },
-          { visitQuestion: true, wrapId: true, idAlias: "questionId" },
-        );
+        H.createCardWithTestQuery({
+          dataset_query: QUERY_SINGLE_AGGREGATION_NO_BREAKOUT,
+        }).then((card) => {
+          cy.wrap(card.id).as("questionId");
+          return H.visitCard(card);
+        });
 
         H.openNotebook();
         // eslint-disable-next-line metabase/no-unsafe-element-filtering
@@ -373,10 +491,12 @@ describe("scenarios > question", { tags: "@skip" }, () => {
 
       describe("single aggregation", () => {
         it("no breakout", () => {
-          H.createQuestion(
-            { query: QUERY_SINGLE_AGGREGATION_NO_BREAKOUT },
-            { visitQuestion: true, wrapId: true, idAlias: "questionId" },
-          );
+          H.createCardWithTestQuery({
+            dataset_query: QUERY_SINGLE_AGGREGATION_NO_BREAKOUT,
+          }).then((card) => {
+            cy.wrap(card.id).as("questionId");
+            return H.visitCard(card);
+          });
 
           const info = {
             itemName: "Compare to the past",
@@ -424,10 +544,12 @@ describe("scenarios > question", { tags: "@skip" }, () => {
         });
 
         it("breakout on binned datetime column", () => {
-          H.createQuestion(
-            { query: QUERY_SINGLE_AGGREGATION_BINNED_DATETIME_BREAKOUT },
-            { visitQuestion: true, wrapId: true, idAlias: "questionId" },
-          );
+          H.createCardWithTestQuery({
+            dataset_query: QUERY_SINGLE_AGGREGATION_BINNED_DATETIME_BREAKOUT,
+          }).then((card) => {
+            cy.wrap(card.id).as("questionId");
+            return H.visitCard(card);
+          });
 
           const info = {
             itemName: "Compare to the past",
@@ -484,10 +606,13 @@ describe("scenarios > question", { tags: "@skip" }, () => {
         });
 
         it("breakout on non-binned datetime column", () => {
-          H.createQuestion(
-            { query: QUERY_SINGLE_AGGREGATION_NON_BINNED_DATETIME_BREAKOUT },
-            { visitQuestion: true, wrapId: true, idAlias: "questionId" },
-          );
+          H.createCardWithTestQuery({
+            dataset_query:
+              QUERY_SINGLE_AGGREGATION_NON_BINNED_DATETIME_BREAKOUT,
+          }).then((card) => {
+            cy.wrap(card.id).as("questionId");
+            return H.visitCard(card);
+          });
 
           const info = {
             itemName: "Compare to the past",
@@ -540,10 +665,12 @@ describe("scenarios > question", { tags: "@skip" }, () => {
         });
 
         it("breakout on non-datetime column", () => {
-          H.createQuestion(
-            { query: QUERY_SINGLE_AGGREGATION_NON_DATETIME_BREAKOUT },
-            { visitQuestion: true, wrapId: true, idAlias: "questionId" },
-          );
+          H.createCardWithTestQuery({
+            dataset_query: QUERY_SINGLE_AGGREGATION_NON_DATETIME_BREAKOUT,
+          }).then((card) => {
+            cy.wrap(card.id).as("questionId");
+            return H.visitCard(card);
+          });
 
           const info = {
             itemName: "Compare to the past",
@@ -611,10 +738,12 @@ describe("scenarios > question", { tags: "@skip" }, () => {
         });
 
         it("breakout on temporal column which is an expression", () => {
-          H.createQuestion(
-            { query: QUERY_TEMPORAL_EXPRESSION_BREAKOUT },
-            { visitQuestion: true, wrapId: true, idAlias: "questionId" },
-          );
+          H.createCardWithTestQuery({
+            dataset_query: QUERY_TEMPORAL_EXPRESSION_BREAKOUT,
+          }).then((card) => {
+            cy.wrap(card.id).as("questionId");
+            return H.visitCard(card);
+          });
 
           const info = {
             itemName: "Compare to the past",
@@ -672,10 +801,12 @@ describe("scenarios > question", { tags: "@skip" }, () => {
         });
 
         it("multiple breakouts", () => {
-          H.createQuestion(
-            { query: QUERY_MULTIPLE_BREAKOUTS },
-            { visitQuestion: true, wrapId: true, idAlias: "questionId" },
-          );
+          H.createCardWithTestQuery({
+            dataset_query: QUERY_MULTIPLE_BREAKOUTS,
+          }).then((card) => {
+            cy.wrap(card.id).as("questionId");
+            return H.visitCard(card);
+          });
 
           const info = {
             itemName: "Compare to the past",
@@ -729,10 +860,12 @@ describe("scenarios > question", { tags: "@skip" }, () => {
         });
 
         it("multiple temporal breakouts", () => {
-          H.createQuestion(
-            { query: QUERY_MULTIPLE_TEMPORAL_BREAKOUTS },
-            { visitQuestion: true, wrapId: true, idAlias: "questionId" },
-          );
+          H.createCardWithTestQuery({
+            dataset_query: QUERY_MULTIPLE_TEMPORAL_BREAKOUTS,
+          }).then((card) => {
+            cy.wrap(card.id).as("questionId");
+            return H.visitCard(card);
+          });
 
           const info = {
             itemName: "Compare to the past",
@@ -787,10 +920,12 @@ describe("scenarios > question", { tags: "@skip" }, () => {
         });
 
         it("one breakout on non-default datetime column", () => {
-          H.createQuestion(
-            { query: QUERY_SINGLE_AGGREGATION_OTHER_DATETIME },
-            { visitQuestion: true, wrapId: true, idAlias: "questionId" },
-          );
+          H.createCardWithTestQuery({
+            dataset_query: QUERY_SINGLE_AGGREGATION_OTHER_DATETIME,
+          }).then((card) => {
+            cy.wrap(card.id).as("questionId");
+            return H.visitCard(card);
+          });
 
           const info = {
             itemName: "Compare to the past",
@@ -853,10 +988,12 @@ describe("scenarios > question", { tags: "@skip" }, () => {
 
       describe("multiple aggregations", () => {
         it("no breakout", () => {
-          H.createQuestion(
-            { query: QUERY_MULTIPLE_AGGREGATIONS_NO_BREAKOUT },
-            { visitQuestion: true, wrapId: true, idAlias: "questionId" },
-          );
+          H.createCardWithTestQuery({
+            dataset_query: QUERY_MULTIPLE_AGGREGATIONS_NO_BREAKOUT,
+          }).then((card) => {
+            cy.wrap(card.id).as("questionId");
+            return H.visitCard(card);
+          });
 
           const info = {
             itemName: "Compare to the past",
@@ -904,10 +1041,12 @@ describe("scenarios > question", { tags: "@skip" }, () => {
         });
 
         it("breakout on binned datetime column", () => {
-          H.createQuestion(
-            { query: QUERY_MULTIPLE_AGGREGATIONS_BINNED_DATETIME_BREAKOUT },
-            { visitQuestion: true, wrapId: true, idAlias: "questionId" },
-          );
+          H.createCardWithTestQuery({
+            dataset_query: QUERY_MULTIPLE_AGGREGATIONS_BINNED_DATETIME_BREAKOUT,
+          }).then((card) => {
+            cy.wrap(card.id).as("questionId");
+            return H.visitCard(card);
+          });
 
           const info = {
             itemName: "Compare to the past",
@@ -961,10 +1100,13 @@ describe("scenarios > question", { tags: "@skip" }, () => {
         });
 
         it("breakout on non-binned datetime column", () => {
-          H.createQuestion(
-            { query: QUERY_MULTIPLE_AGGREGATIONS_NON_BINNED_DATETIME_BREAKOUT },
-            { visitQuestion: true, wrapId: true, idAlias: "questionId" },
-          );
+          H.createCardWithTestQuery({
+            dataset_query:
+              QUERY_MULTIPLE_AGGREGATIONS_NON_BINNED_DATETIME_BREAKOUT,
+          }).then((card) => {
+            cy.wrap(card.id).as("questionId");
+            return H.visitCard(card);
+          });
 
           const info = {
             itemName: "Compare to the past",
@@ -1018,10 +1160,12 @@ describe("scenarios > question", { tags: "@skip" }, () => {
         });
 
         it("breakout on non-datetime column", () => {
-          H.createQuestion(
-            { query: QUERY_MULTIPLE_AGGREGATIONS_NON_DATETIME_BREAKOUT },
-            { visitQuestion: true, wrapId: true, idAlias: "questionId" },
-          );
+          H.createCardWithTestQuery({
+            dataset_query: QUERY_MULTIPLE_AGGREGATIONS_NON_DATETIME_BREAKOUT,
+          }).then((card) => {
+            cy.wrap(card.id).as("questionId");
+            return H.visitCard(card);
+          });
 
           const info = {
             itemName: "Compare to the past",
@@ -1078,10 +1222,12 @@ describe("scenarios > question", { tags: "@skip" }, () => {
 
     describe("moving average", () => {
       it("should be possible to change the temporal bucket with a custom offset", () => {
-        H.createQuestion(
-          { query: QUERY_SINGLE_AGGREGATION_NO_BREAKOUT },
-          { visitQuestion: true, wrapId: true, idAlias: "questionId" },
-        );
+        H.createCardWithTestQuery({
+          dataset_query: QUERY_SINGLE_AGGREGATION_NO_BREAKOUT,
+        }).then((card) => {
+          cy.wrap(card.id).as("questionId");
+          return H.visitCard(card);
+        });
 
         H.openNotebook();
         // eslint-disable-next-line metabase/no-unsafe-element-filtering
@@ -1129,10 +1275,12 @@ describe("scenarios > question", { tags: "@skip" }, () => {
 
       describe("single aggregation", () => {
         it("no breakout", () => {
-          H.createQuestion(
-            { query: QUERY_SINGLE_AGGREGATION_NO_BREAKOUT },
-            { visitQuestion: true, wrapId: true, idAlias: "questionId" },
-          );
+          H.createCardWithTestQuery({
+            dataset_query: QUERY_SINGLE_AGGREGATION_NO_BREAKOUT,
+          }).then((card) => {
+            cy.wrap(card.id).as("questionId");
+            return H.visitCard(card);
+          });
 
           const info = {
             type: "moving-average" as const,
@@ -1187,10 +1335,12 @@ describe("scenarios > question", { tags: "@skip" }, () => {
         });
 
         it("breakout on binned datetime column", () => {
-          H.createQuestion(
-            { query: QUERY_SINGLE_AGGREGATION_BINNED_DATETIME_BREAKOUT },
-            { visitQuestion: true, wrapId: true, idAlias: "questionId" },
-          );
+          H.createCardWithTestQuery({
+            dataset_query: QUERY_SINGLE_AGGREGATION_BINNED_DATETIME_BREAKOUT,
+          }).then((card) => {
+            cy.wrap(card.id).as("questionId");
+            return H.visitCard(card);
+          });
 
           const info = {
             type: "moving-average" as const,
@@ -1249,10 +1399,13 @@ describe("scenarios > question", { tags: "@skip" }, () => {
         });
 
         it("breakout on non-binned datetime column", () => {
-          H.createQuestion(
-            { query: QUERY_SINGLE_AGGREGATION_NON_BINNED_DATETIME_BREAKOUT },
-            { visitQuestion: true, wrapId: true, idAlias: "questionId" },
-          );
+          H.createCardWithTestQuery({
+            dataset_query:
+              QUERY_SINGLE_AGGREGATION_NON_BINNED_DATETIME_BREAKOUT,
+          }).then((card) => {
+            cy.wrap(card.id).as("questionId");
+            return H.visitCard(card);
+          });
 
           const info = {
             type: "moving-average" as const,
@@ -1310,10 +1463,12 @@ describe("scenarios > question", { tags: "@skip" }, () => {
         });
 
         it("breakout on non-datetime column", () => {
-          H.createQuestion(
-            { query: QUERY_SINGLE_AGGREGATION_NON_DATETIME_BREAKOUT },
-            { visitQuestion: true, wrapId: true, idAlias: "questionId" },
-          );
+          H.createCardWithTestQuery({
+            dataset_query: QUERY_SINGLE_AGGREGATION_NON_DATETIME_BREAKOUT,
+          }).then((card) => {
+            cy.wrap(card.id).as("questionId");
+            return H.visitCard(card);
+          });
 
           const info = {
             type: "moving-average" as const,
@@ -1382,10 +1537,12 @@ describe("scenarios > question", { tags: "@skip" }, () => {
         });
 
         it("multiple breakouts", () => {
-          H.createQuestion(
-            { query: QUERY_MULTIPLE_BREAKOUTS },
-            { visitQuestion: true, wrapId: true, idAlias: "questionId" },
-          );
+          H.createCardWithTestQuery({
+            dataset_query: QUERY_MULTIPLE_BREAKOUTS,
+          }).then((card) => {
+            cy.wrap(card.id).as("questionId");
+            return H.visitCard(card);
+          });
 
           const info = {
             type: "moving-average" as const,
@@ -1440,10 +1597,12 @@ describe("scenarios > question", { tags: "@skip" }, () => {
         });
 
         it("multiple temporal breakouts", () => {
-          H.createQuestion(
-            { query: QUERY_MULTIPLE_TEMPORAL_BREAKOUTS },
-            { visitQuestion: true, wrapId: true, idAlias: "questionId" },
-          );
+          H.createCardWithTestQuery({
+            dataset_query: QUERY_MULTIPLE_TEMPORAL_BREAKOUTS,
+          }).then((card) => {
+            cy.wrap(card.id).as("questionId");
+            return H.visitCard(card);
+          });
 
           const info = {
             type: "moving-average" as const,
@@ -1498,10 +1657,12 @@ describe("scenarios > question", { tags: "@skip" }, () => {
         });
 
         it("one breakout on non-default datetime column", () => {
-          H.createQuestion(
-            { query: QUERY_SINGLE_AGGREGATION_OTHER_DATETIME },
-            { visitQuestion: true, wrapId: true, idAlias: "questionId" },
-          );
+          H.createCardWithTestQuery({
+            dataset_query: QUERY_SINGLE_AGGREGATION_OTHER_DATETIME,
+          }).then((card) => {
+            cy.wrap(card.id).as("questionId");
+            return H.visitCard(card);
+          });
 
           const info = {
             type: "moving-average" as const,
@@ -1565,10 +1726,12 @@ describe("scenarios > question", { tags: "@skip" }, () => {
 
       describe("multiple aggregations", () => {
         it("no breakout", () => {
-          H.createQuestion(
-            { query: QUERY_MULTIPLE_AGGREGATIONS_NO_BREAKOUT },
-            { visitQuestion: true, wrapId: true, idAlias: "questionId" },
-          );
+          H.createCardWithTestQuery({
+            dataset_query: QUERY_MULTIPLE_AGGREGATIONS_NO_BREAKOUT,
+          }).then((card) => {
+            cy.wrap(card.id).as("questionId");
+            return H.visitCard(card);
+          });
 
           const info = {
             type: "moving-average" as const,
@@ -1623,10 +1786,12 @@ describe("scenarios > question", { tags: "@skip" }, () => {
         });
 
         it("breakout on binned datetime column", () => {
-          H.createQuestion(
-            { query: QUERY_MULTIPLE_AGGREGATIONS_BINNED_DATETIME_BREAKOUT },
-            { visitQuestion: true, wrapId: true, idAlias: "questionId" },
-          );
+          H.createCardWithTestQuery({
+            dataset_query: QUERY_MULTIPLE_AGGREGATIONS_BINNED_DATETIME_BREAKOUT,
+          }).then((card) => {
+            cy.wrap(card.id).as("questionId");
+            return H.visitCard(card);
+          });
 
           const info = {
             type: "moving-average" as const,
@@ -1681,10 +1846,13 @@ describe("scenarios > question", { tags: "@skip" }, () => {
         });
 
         it("breakout on non-binned datetime column", () => {
-          H.createQuestion(
-            { query: QUERY_MULTIPLE_AGGREGATIONS_NON_BINNED_DATETIME_BREAKOUT },
-            { visitQuestion: true, wrapId: true, idAlias: "questionId" },
-          );
+          H.createCardWithTestQuery({
+            dataset_query:
+              QUERY_MULTIPLE_AGGREGATIONS_NON_BINNED_DATETIME_BREAKOUT,
+          }).then((card) => {
+            cy.wrap(card.id).as("questionId");
+            return H.visitCard(card);
+          });
 
           const info = {
             type: "moving-average" as const,
@@ -1739,10 +1907,12 @@ describe("scenarios > question", { tags: "@skip" }, () => {
         });
 
         it("breakout on non-datetime column", () => {
-          H.createQuestion(
-            { query: QUERY_MULTIPLE_AGGREGATIONS_NON_DATETIME_BREAKOUT },
-            { visitQuestion: true, wrapId: true, idAlias: "questionId" },
-          );
+          H.createCardWithTestQuery({
+            dataset_query: QUERY_MULTIPLE_AGGREGATIONS_NON_DATETIME_BREAKOUT,
+          }).then((card) => {
+            cy.wrap(card.id).as("questionId");
+            return H.visitCard(card);
+          });
 
           const info = {
             type: "moving-average" as const,

--- a/e2e/test/scenarios/question/detail-visualization-custom-column.cy.spec.ts
+++ b/e2e/test/scenarios/question/detail-visualization-custom-column.cy.spec.ts
@@ -1,3 +1,4 @@
+import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { H } = cy;
@@ -13,14 +14,14 @@ describe("scenarios > question > detail visualization + custom column preview", 
     const CUSTOM_COLUMN_NAME = "Tax custom column";
 
     // Create a simple question and set visualization to "Detail" (Object Detail)
-    H.createQuestion(
-      {
-        name: "Detail viz with custom column (preview)",
-        query: { "source-table": ORDERS_ID },
-        display: "object",
+    H.createCardWithTestQuery({
+      name: "Detail viz with custom column (preview)",
+      dataset_query: {
+        database: SAMPLE_DB_ID,
+        stages: [{ source: { type: "table", id: ORDERS_ID } }],
       },
-      { visitQuestion: true },
-    );
+      display: "object",
+    }).then(H.visitCard);
 
     // Go to notebook editor and add a simple custom column
     H.openNotebook();

--- a/e2e/test/scenarios/question/document-title.cy.spec.js
+++ b/e2e/test/scenarios/question/document-title.cy.spec.js
@@ -14,14 +14,11 @@ describe(
     it("should verify document title changes while loading a slow question (metabase#40051)", () => {
       cy.log("run a slow question");
 
-      H.visitQuestionAdhoc(
+      H.visitAdHocQuestionWithTestNativeQuery(
         {
           dataset_query: {
-            type: "native",
-            native: {
-              query: "select pg_sleep(60)",
-            },
             database: PG_DB_ID,
+            query: "select pg_sleep(60)",
           },
         },
         { skipWaiting: true },

--- a/e2e/test/scenarios/question/multiple-column-breakouts.cy.spec.ts
+++ b/e2e/test/scenarios/question/multiple-column-breakouts.cy.spec.ts
@@ -1,28 +1,33 @@
 const { H } = cy;
+import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import type {
-  DashboardDetails,
-  StructuredQuestionDetails,
-} from "e2e/support/helpers";
+import type { DashboardDetails } from "e2e/support/helpers";
 
-const { ORDERS_ID, ORDERS, PEOPLE_ID, PEOPLE } = SAMPLE_DATABASE;
+const { ORDERS_ID, PEOPLE_ID } = SAMPLE_DATABASE;
 
-const questionWith2TemporalBreakoutsDetails: StructuredQuestionDetails = {
+const questionWith2TemporalBreakoutsDetails = {
   name: "Test question",
-  query: {
-    "source-table": ORDERS_ID,
-    aggregation: [["count"]],
-    breakout: [
-      [
-        "field",
-        ORDERS.CREATED_AT,
-        { "base-type": "type/DateTime", "temporal-unit": "year" },
-      ],
-      [
-        "field",
-        ORDERS.CREATED_AT,
-        { "base-type": "type/DateTime", "temporal-unit": "month" },
-      ],
+  dataset_query: {
+    database: SAMPLE_DB_ID,
+    stages: [
+      {
+        source: { type: "table" as const, id: ORDERS_ID },
+        aggregations: [{ type: "operator" as const, operator: "count" }],
+        breakouts: [
+          {
+            type: "column" as const,
+            name: "CREATED_AT",
+            sourceName: "ORDERS",
+            unit: "year" as const,
+          },
+          {
+            type: "column" as const,
+            name: "CREATED_AT",
+            sourceName: "ORDERS",
+            unit: "month" as const,
+          },
+        ],
+      },
     ],
   },
   display: "table",
@@ -31,37 +36,68 @@ const questionWith2TemporalBreakoutsDetails: StructuredQuestionDetails = {
   },
 };
 
-const multiStageQuestionWith2TemporalBreakoutsDetails: StructuredQuestionDetails =
-  {
-    name: "Test question",
-    query: {
-      "source-query": questionWith2TemporalBreakoutsDetails.query,
-      filter: [">", ["field", "count", { "base-type": "type/Integer" }], 0],
-    },
-  };
-
-const questionWith2NumBinsBreakoutsDetails: StructuredQuestionDetails = {
+const multiStageQuestionWith2TemporalBreakoutsDetails = {
   name: "Test question",
-  query: {
-    "source-table": ORDERS_ID,
-    aggregation: [["count"]],
-    breakout: [
-      [
-        "field",
-        ORDERS.TOTAL,
-        {
-          "base-type": "type/Float",
-          binning: { strategy: "num-bins", "num-bins": 10 },
-        },
-      ],
-      [
-        "field",
-        ORDERS.TOTAL,
-        {
-          "base-type": "type/Float",
-          binning: { strategy: "num-bins", "num-bins": 50 },
-        },
-      ],
+  dataset_query: {
+    database: SAMPLE_DB_ID,
+    stages: [
+      {
+        source: { type: "table" as const, id: ORDERS_ID },
+        aggregations: [{ type: "operator" as const, operator: "count" }],
+        breakouts: [
+          {
+            type: "column" as const,
+            name: "CREATED_AT",
+            sourceName: "ORDERS",
+            unit: "year" as const,
+          },
+          {
+            type: "column" as const,
+            name: "CREATED_AT",
+            sourceName: "ORDERS",
+            unit: "month" as const,
+          },
+        ],
+      },
+      {
+        filters: [
+          {
+            type: "operator" as const,
+            operator: ">",
+            args: [
+              { type: "column" as const, name: "count" },
+              { type: "literal" as const, value: 0 },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+};
+
+const questionWith2NumBinsBreakoutsDetails = {
+  name: "Test question",
+  dataset_query: {
+    database: SAMPLE_DB_ID,
+    stages: [
+      {
+        source: { type: "table" as const, id: ORDERS_ID },
+        aggregations: [{ type: "operator" as const, operator: "count" }],
+        breakouts: [
+          {
+            type: "column" as const,
+            name: "TOTAL",
+            sourceName: "ORDERS",
+            bins: 10,
+          },
+          {
+            type: "column" as const,
+            name: "TOTAL",
+            sourceName: "ORDERS",
+            bins: 50,
+          },
+        ],
+      },
     ],
   },
   display: "table",
@@ -70,37 +106,68 @@ const questionWith2NumBinsBreakoutsDetails: StructuredQuestionDetails = {
   },
 };
 
-const multiStageQuestionWith2NumBinsBreakoutsDetails: StructuredQuestionDetails =
-  {
-    name: "Test question",
-    query: {
-      "source-query": questionWith2NumBinsBreakoutsDetails.query,
-      filter: [">", ["field", "count", { "base-type": "type/Integer" }], 0],
-    },
-  };
-
-const questionWith2BinWidthBreakoutsDetails: StructuredQuestionDetails = {
+const multiStageQuestionWith2NumBinsBreakoutsDetails = {
   name: "Test question",
-  query: {
-    "source-table": PEOPLE_ID,
-    aggregation: [["count"]],
-    breakout: [
-      [
-        "field",
-        PEOPLE.LATITUDE,
-        {
-          "base-type": "type/Float",
-          binning: { strategy: "bin-width", "bin-width": 20 },
-        },
-      ],
-      [
-        "field",
-        PEOPLE.LATITUDE,
-        {
-          "base-type": "type/Float",
-          binning: { strategy: "bin-width", "bin-width": 10 },
-        },
-      ],
+  dataset_query: {
+    database: SAMPLE_DB_ID,
+    stages: [
+      {
+        source: { type: "table" as const, id: ORDERS_ID },
+        aggregations: [{ type: "operator" as const, operator: "count" }],
+        breakouts: [
+          {
+            type: "column" as const,
+            name: "TOTAL",
+            sourceName: "ORDERS",
+            bins: 10,
+          },
+          {
+            type: "column" as const,
+            name: "TOTAL",
+            sourceName: "ORDERS",
+            bins: 50,
+          },
+        ],
+      },
+      {
+        filters: [
+          {
+            type: "operator" as const,
+            operator: ">",
+            args: [
+              { type: "column" as const, name: "count" },
+              { type: "literal" as const, value: 0 },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+};
+
+const questionWith2BinWidthBreakoutsDetails = {
+  name: "Test question",
+  dataset_query: {
+    database: SAMPLE_DB_ID,
+    stages: [
+      {
+        source: { type: "table" as const, id: PEOPLE_ID },
+        aggregations: [{ type: "operator" as const, operator: "count" }],
+        breakouts: [
+          {
+            type: "column" as const,
+            name: "LATITUDE",
+            sourceName: "PEOPLE",
+            binWidth: 20,
+          },
+          {
+            type: "column" as const,
+            name: "LATITUDE",
+            sourceName: "PEOPLE",
+            binWidth: 10,
+          },
+        ],
+      },
     ],
   },
   display: "table",
@@ -109,48 +176,88 @@ const questionWith2BinWidthBreakoutsDetails: StructuredQuestionDetails = {
   },
 };
 
-const multiStageQuestionWith2BinWidthBreakoutsDetails: StructuredQuestionDetails =
-  {
-    name: "Test question",
-    query: {
-      "source-query": questionWith2BinWidthBreakoutsDetails.query,
-      filter: [">", ["field", "count", { "base-type": "type/Integer" }], 0],
-    },
-  };
-
-const questionWith5TemporalBreakoutsDetails: StructuredQuestionDetails = {
+const multiStageQuestionWith2BinWidthBreakoutsDetails = {
   name: "Test question",
-  query: {
-    "source-table": ORDERS_ID,
-    aggregation: [["count"]],
-    breakout: [
-      [
-        "field",
-        ORDERS.CREATED_AT,
-        { "base-type": "type/DateTime", "temporal-unit": "year" },
-      ],
-      [
-        "field",
-        ORDERS.CREATED_AT,
-        { "base-type": "type/DateTime", "temporal-unit": "quarter" },
-      ],
-      [
-        "field",
-        ORDERS.CREATED_AT,
-        { "base-type": "type/DateTime", "temporal-unit": "month" },
-      ],
-      [
-        "field",
-        ORDERS.CREATED_AT,
-        { "base-type": "type/DateTime", "temporal-unit": "week" },
-      ],
-      [
-        "field",
-        ORDERS.CREATED_AT,
-        { "base-type": "type/DateTime", "temporal-unit": "day" },
-      ],
+  dataset_query: {
+    database: SAMPLE_DB_ID,
+    stages: [
+      {
+        source: { type: "table" as const, id: PEOPLE_ID },
+        aggregations: [{ type: "operator" as const, operator: "count" }],
+        breakouts: [
+          {
+            type: "column" as const,
+            name: "LATITUDE",
+            sourceName: "PEOPLE",
+            binWidth: 20,
+          },
+          {
+            type: "column" as const,
+            name: "LATITUDE",
+            sourceName: "PEOPLE",
+            binWidth: 10,
+          },
+        ],
+      },
+      {
+        filters: [
+          {
+            type: "operator" as const,
+            operator: ">",
+            args: [
+              { type: "column" as const, name: "count" },
+              { type: "literal" as const, value: 0 },
+            ],
+          },
+        ],
+      },
     ],
-    limit: 10,
+  },
+};
+
+const questionWith5TemporalBreakoutsDetails = {
+  name: "Test question",
+  dataset_query: {
+    database: SAMPLE_DB_ID,
+    stages: [
+      {
+        source: { type: "table" as const, id: ORDERS_ID },
+        aggregations: [{ type: "operator" as const, operator: "count" }],
+        breakouts: [
+          {
+            type: "column" as const,
+            name: "CREATED_AT",
+            sourceName: "ORDERS",
+            unit: "year" as const,
+          },
+          {
+            type: "column" as const,
+            name: "CREATED_AT",
+            sourceName: "ORDERS",
+            unit: "quarter" as const,
+          },
+          {
+            type: "column" as const,
+            name: "CREATED_AT",
+            sourceName: "ORDERS",
+            unit: "month" as const,
+          },
+          {
+            type: "column" as const,
+            name: "CREATED_AT",
+            sourceName: "ORDERS",
+            unit: "week" as const,
+          },
+          {
+            type: "column" as const,
+            name: "CREATED_AT",
+            sourceName: "ORDERS",
+            unit: "day" as const,
+          },
+        ],
+        limit: 10,
+      },
+    ],
   },
   display: "table",
   visualization_settings: {
@@ -158,53 +265,44 @@ const questionWith5TemporalBreakoutsDetails: StructuredQuestionDetails = {
   },
 };
 
-const questionWith5NumBinsBreakoutsDetails: StructuredQuestionDetails = {
+const questionWith5NumBinsBreakoutsDetails = {
   name: "Test question",
-  query: {
-    "source-table": ORDERS_ID,
-    aggregation: [["count"]],
-    breakout: [
-      [
-        "field",
-        ORDERS.TOTAL,
-        {
-          "base-type": "type/Float",
-        },
-      ],
-      [
-        "field",
-        ORDERS.TOTAL,
-        {
-          "base-type": "type/Float",
-          binning: { strategy: "default" },
-        },
-      ],
-      [
-        "field",
-        ORDERS.TOTAL,
-        {
-          "base-type": "type/Float",
-          binning: { strategy: "num-bins", "num-bins": 10 },
-        },
-      ],
-      [
-        "field",
-        ORDERS.TOTAL,
-        {
-          "base-type": "type/Float",
-          binning: { strategy: "num-bins", "num-bins": 50 },
-        },
-      ],
-      [
-        "field",
-        ORDERS.TOTAL,
-        {
-          "base-type": "type/Float",
-          binning: { strategy: "num-bins", "num-bins": 100 },
-        },
-      ],
+  dataset_query: {
+    database: SAMPLE_DB_ID,
+    stages: [
+      {
+        source: { type: "table" as const, id: ORDERS_ID },
+        aggregations: [{ type: "operator" as const, operator: "count" }],
+        breakouts: [
+          { type: "column" as const, name: "TOTAL", sourceName: "ORDERS" },
+          {
+            type: "column" as const,
+            name: "TOTAL",
+            sourceName: "ORDERS",
+            bins: "auto" as const,
+          },
+          {
+            type: "column" as const,
+            name: "TOTAL",
+            sourceName: "ORDERS",
+            bins: 10,
+          },
+          {
+            type: "column" as const,
+            name: "TOTAL",
+            sourceName: "ORDERS",
+            bins: 50,
+          },
+          {
+            type: "column" as const,
+            name: "TOTAL",
+            sourceName: "ORDERS",
+            bins: 100,
+          },
+        ],
+        limit: 10,
+      },
     ],
-    limit: 10,
   },
   display: "table",
   visualization_settings: {
@@ -239,8 +337,13 @@ const dashboardDetails: DashboardDetails = {
 function getNestedQuestionDetails(cardId: number) {
   return {
     name: "Nested question",
-    query: {
-      "source-table": `card__${cardId}`,
+    dataset_query: {
+      database: SAMPLE_DB_ID,
+      stages: [
+        {
+          source: { type: "card" as const, id: cardId },
+        },
+      ],
     },
     visualization_settings: {
       "table.pivot": false,
@@ -363,13 +466,11 @@ describe("scenarios > question > multiple column breakouts", () => {
           column1Name,
           column2Name,
         }: {
-          questionDetails: StructuredQuestionDetails;
+          questionDetails: Parameters<typeof H.createCardWithTestQuery>[0];
           column1Name: string;
           column2Name: string;
         }) {
-          H.createQuestion(questionDetails, {
-            visitQuestion: true,
-          });
+          H.createCardWithTestQuery(questionDetails).then(H.visitCard);
           H.openNotebook();
           H.getNotebookStep("summarize").findByText("Sort").click();
           H.popover().findByText(column1Name).click();
@@ -433,13 +534,13 @@ describe("scenarios > question > multiple column breakouts", () => {
           bucket1Name,
           bucket2Name,
         }: {
-          questionDetails: StructuredQuestionDetails;
+          questionDetails: Parameters<typeof H.createCardWithTestQuery>[0];
           columnPattern: RegExp;
           bucketLabel: string;
           bucket1Name: string;
           bucket2Name: string;
         }) {
-          H.createQuestion(questionDetails, { visitQuestion: true });
+          H.createCardWithTestQuery(questionDetails).then(H.visitCard);
           H.summarize();
           cy.findByTestId("pinned-dimensions")
             .findAllByLabelText(columnPattern)
@@ -505,9 +606,9 @@ describe("scenarios > question > multiple column breakouts", () => {
 
     describe("timeseries chrome", () => {
       it("should use the first breakout for the chrome in case there are multiple for this column", () => {
-        H.createQuestion(questionWith2TemporalBreakoutsDetails, {
-          visitQuestion: true,
-        });
+        H.createCardWithTestQuery(questionWith2TemporalBreakoutsDetails).then(
+          H.visitCard,
+        );
 
         cy.log("change the breakout");
         cy.findByTestId("timeseries-bucket-button")
@@ -564,11 +665,11 @@ describe("scenarios > question > multiple column breakouts", () => {
           column1Name,
           column2Name,
         }: {
-          questionDetails: StructuredQuestionDetails;
+          questionDetails: Parameters<typeof H.createCardWithTestQuery>[0];
           column1Name: string;
           column2Name: string;
         }) {
-          H.createQuestion(questionDetails, { visitQuestion: true });
+          H.createCardWithTestQuery(questionDetails).then(H.visitCard);
 
           cy.log("first breakout");
           tableHeaderClick(column1Name);
@@ -611,10 +712,10 @@ describe("scenarios > question > multiple column breakouts", () => {
           questionDetails,
           columnNamePattern,
         }: {
-          questionDetails: StructuredQuestionDetails;
+          questionDetails: Parameters<typeof H.createCardWithTestQuery>[0];
           columnNamePattern: RegExp;
         }) {
-          H.createQuestion(questionDetails, { visitQuestion: true });
+          H.createCardWithTestQuery(questionDetails).then(H.visitCard);
 
           cy.log("change display and assert the default settings");
           H.openVizTypeSidebar();
@@ -662,9 +763,9 @@ describe("scenarios > question > multiple column breakouts", () => {
       });
 
       it("should not be able to move columns items into measures and vice-versa", () => {
-        H.createQuestion(questionWith5TemporalBreakoutsDetails, {
-          visitQuestion: true,
-        });
+        H.createCardWithTestQuery(questionWith5TemporalBreakoutsDetails).then(
+          H.visitCard,
+        );
 
         const columnNamePattern = /^Created At/;
 
@@ -777,11 +878,11 @@ describe("scenarios > question > multiple column breakouts", () => {
           expression1,
           expression2,
         }: {
-          questionDetails: StructuredQuestionDetails;
+          questionDetails: Parameters<typeof H.createCardWithTestQuery>[0];
           expression1: string;
           expression2: string;
         }) {
-          H.createQuestion(questionDetails, { visitQuestion: true });
+          H.createCardWithTestQuery(questionDetails).then(H.visitCard);
           H.openNotebook();
 
           cy.log("add a post-aggregation expression for the first column");
@@ -902,7 +1003,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           column2MinValue,
           column2MaxValue,
         }: {
-          questionDetails: StructuredQuestionDetails;
+          questionDetails: Parameters<typeof H.createCardWithTestQuery>[0];
           column1Name: string;
           column1MinValue: string;
           column1MaxValue: string;
@@ -910,7 +1011,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           column2MinValue: string;
           column2MaxValue: string;
         }) {
-          H.createQuestion(questionDetails, { visitQuestion: true });
+          H.createCardWithTestQuery(questionDetails).then(H.visitCard);
           H.openNotebook();
 
           cy.log("add a filter for the first column");
@@ -964,7 +1065,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           column2MinValue,
           column2MaxValue,
         }: {
-          questionDetails: StructuredQuestionDetails;
+          questionDetails: Parameters<typeof H.createCardWithTestQuery>[0];
           column1Name: string;
           column1MinValue: number;
           column1MaxValue: number;
@@ -972,7 +1073,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           column2MinValue: number;
           column2MaxValue: number;
         }) {
-          H.createQuestion(questionDetails, { visitQuestion: true });
+          H.createCardWithTestQuery(questionDetails).then(H.visitCard);
           H.openNotebook();
 
           cy.log("add a filter for the first column");
@@ -1055,11 +1156,11 @@ describe("scenarios > question > multiple column breakouts", () => {
           column1Name,
           column2Name,
         }: {
-          questionDetails: StructuredQuestionDetails;
+          questionDetails: Parameters<typeof H.createCardWithTestQuery>[0];
           column1Name: string;
           column2Name: string;
         }) {
-          H.createQuestion(questionDetails, { visitQuestion: true });
+          H.createCardWithTestQuery(questionDetails).then(H.visitCard);
           H.openNotebook();
 
           cy.log("add an aggregation for the first column");
@@ -1122,11 +1223,11 @@ describe("scenarios > question > multiple column breakouts", () => {
           column1Name,
           column2Name,
         }: {
-          questionDetails: StructuredQuestionDetails;
+          questionDetails: Parameters<typeof H.createCardWithTestQuery>[0];
           column1Name: string;
           column2Name: string;
         }) {
-          H.createQuestion(questionDetails, { visitQuestion: true });
+          H.createCardWithTestQuery(questionDetails).then(H.visitCard);
           H.openNotebook();
 
           cy.log("add an aggregation");
@@ -1227,7 +1328,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           column2MinValue,
           column2MaxValue,
         }: {
-          questionDetails: StructuredQuestionDetails;
+          questionDetails: Parameters<typeof H.createCardWithTestQuery>[0];
           column1Name: string;
           column1MinValue: string;
           column1MaxValue: string;
@@ -1235,7 +1336,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           column2MinValue: string;
           column2MaxValue: string;
         }) {
-          H.createQuestion(questionDetails, { visitQuestion: true });
+          H.createCardWithTestQuery(questionDetails).then(H.visitCard);
 
           cy.log("add a filter for the first column");
           addDateBetweenFilter({
@@ -1287,7 +1388,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           column2MinValue,
           column2MaxValue,
         }: {
-          questionDetails: StructuredQuestionDetails;
+          questionDetails: Parameters<typeof H.createCardWithTestQuery>[0];
           column1Name: string;
           column1MinValue: number;
           column1MaxValue: number;
@@ -1295,7 +1396,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           column2MinValue: number;
           column2MaxValue: number;
         }) {
-          H.createQuestion(questionDetails, { visitQuestion: true });
+          H.createCardWithTestQuery(questionDetails).then(H.visitCard);
 
           cy.log("add a filter for the first column");
           addNumericBetweenFilter({
@@ -1387,13 +1488,13 @@ describe("scenarios > question > multiple column breakouts", () => {
           tableColumn1Name,
           tableColumn2Name,
         }: {
-          questionDetails: StructuredQuestionDetails;
+          questionDetails: Parameters<typeof H.createCardWithTestQuery>[0];
           queryColumn1Name: string;
           queryColumn2Name: string;
           tableColumn1Name: string;
           tableColumn2Name: string;
         }) {
-          H.createQuestion(questionDetails, { visitQuestion: true });
+          H.createCardWithTestQuery(questionDetails).then(H.visitCard);
           H.assertTableData({
             columns: [tableColumn1Name, tableColumn2Name, "Count"],
           });
@@ -1481,7 +1582,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           column2MinValue,
           column2MaxValue,
         }: {
-          questionDetails: StructuredQuestionDetails;
+          questionDetails: Parameters<typeof H.createCardWithTestQuery>[0];
           column1Name: string;
           column1MinValue: string;
           column1MaxValue: string;
@@ -1489,10 +1590,10 @@ describe("scenarios > question > multiple column breakouts", () => {
           column2MinValue: string;
           column2MaxValue: string;
         }) {
-          H.createQuestion(questionDetails).then(({ body: card }) => {
-            H.createQuestion(getNestedQuestionDetails(card.id), {
-              visitQuestion: true,
-            });
+          H.createCardWithTestQuery(questionDetails).then((card) => {
+            H.createCardWithTestQuery(getNestedQuestionDetails(card.id)).then(
+              H.visitCard,
+            );
           });
           H.openNotebook();
 
@@ -1547,7 +1648,7 @@ describe("scenarios > question > multiple column breakouts", () => {
           column2MinValue,
           column2MaxValue,
         }: {
-          questionDetails: StructuredQuestionDetails;
+          questionDetails: Parameters<typeof H.createCardWithTestQuery>[0];
           column1Name: string;
           column1MinValue: number;
           column1MaxValue: number;
@@ -1555,10 +1656,10 @@ describe("scenarios > question > multiple column breakouts", () => {
           column2MinValue: number;
           column2MaxValue: number;
         }) {
-          H.createQuestion(questionDetails).then(({ body: card }) => {
-            H.createQuestion(getNestedQuestionDetails(card.id), {
-              visitQuestion: true,
-            });
+          H.createCardWithTestQuery(questionDetails).then((card) => {
+            H.createCardWithTestQuery(getNestedQuestionDetails(card.id)).then(
+              H.visitCard,
+            );
           });
           H.openNotebook();
 
@@ -1640,14 +1741,14 @@ describe("scenarios > question > multiple column breakouts", () => {
           column1Name,
           column2Name,
         }: {
-          questionDetails: StructuredQuestionDetails;
+          questionDetails: Parameters<typeof H.createCardWithTestQuery>[0];
           column1Name: string;
           column2Name: string;
         }) {
-          H.createQuestion(questionDetails).then(({ body: card }) => {
-            H.createQuestion(getNestedQuestionDetails(card.id), {
-              visitQuestion: true,
-            });
+          H.createCardWithTestQuery(questionDetails).then((card) => {
+            H.createCardWithTestQuery(getNestedQuestionDetails(card.id)).then(
+              H.visitCard,
+            );
           });
           H.openNotebook();
 
@@ -1710,14 +1811,14 @@ describe("scenarios > question > multiple column breakouts", () => {
           column1Name,
           column2Name,
         }: {
-          questionDetails: StructuredQuestionDetails;
+          questionDetails: Parameters<typeof H.createCardWithTestQuery>[0];
           column1Name: string;
           column2Name: string;
         }) {
-          H.createQuestion(questionDetails).then(({ body: card }) => {
-            H.createQuestion(getNestedQuestionDetails(card.id), {
-              visitQuestion: true,
-            });
+          H.createCardWithTestQuery(questionDetails).then((card) => {
+            H.createCardWithTestQuery(getNestedQuestionDetails(card.id)).then(
+              H.visitCard,
+            );
           });
           H.openNotebook();
 
@@ -1802,13 +1903,13 @@ describe("scenarios > question > multiple column breakouts", () => {
           questionDetails,
           columnName,
         }: {
-          questionDetails: StructuredQuestionDetails;
+          questionDetails: Parameters<typeof H.createCardWithTestQuery>[0];
           columnName: string;
         }) {
-          H.createQuestion(questionDetails).then(({ body: card }) => {
-            H.createQuestion(getNestedQuestionDetails(card.id), {
-              visitQuestion: true,
-            });
+          H.createCardWithTestQuery(questionDetails).then((card) => {
+            H.createCardWithTestQuery(getNestedQuestionDetails(card.id)).then(
+              H.visitCard,
+            );
           });
           const columnNameYear = columnName + ": Year";
           const columnNameMonth = columnName + ": Month";

--- a/e2e/test/scenarios/question/multiple-column-breakouts.cy.spec.ts
+++ b/e2e/test/scenarios/question/multiple-column-breakouts.cy.spec.ts
@@ -817,7 +817,7 @@ describe("scenarios > question > multiple column breakouts", () => {
       it("should be able to use temporal-unit parameters with multiple temporal breakouts of a column", () => {
         cy.log("create dashboard");
         cy.signInAsAdmin();
-        H.createQuestionAndDashboard({
+        H.createQuestionAndDashboardWithTestQuery({
           dashboardDetails,
           questionDetails: questionWith2TemporalBreakoutsDetails,
         }).then(({ body: { dashboard_id } }) => {

--- a/e2e/test/scenarios/question/native-query-drill.cy.spec.ts
+++ b/e2e/test/scenarios/question/native-query-drill.cy.spec.ts
@@ -84,12 +84,12 @@ describe("scenarios > question > native query drill", () => {
 
   describe("query builder metadata", () => {
     it("should allow to save an ad-hoc native query when attempting to drill", () => {
-      H.visitQuestionAdhoc({
+      H.visitAdHocQuestionWithTestNativeQuery({
         display: "table",
         dataset_query: {
           database: SAMPLE_DB_ID,
-          type: "native",
-          native: peopleTableQuestionDetails.native,
+          query:
+            "SELECT ID, EMAIL, CREATED_AT FROM PEOPLE ORDER BY ID LIMIT 10",
         },
       });
       cy.wait("@dataset");

--- a/e2e/test/scenarios/question/native-query-drill.cy.spec.ts
+++ b/e2e/test/scenarios/question/native-query-drill.cy.spec.ts
@@ -1,24 +1,26 @@
 const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
-import type { NativeQuestionDetails } from "e2e/support/helpers";
 
-const ordersTableQuestionDetails: NativeQuestionDetails = {
+const ordersTableQuestionDetails = {
   display: "table",
-  native: {
+  dataset_query: {
+    database: SAMPLE_DB_ID,
     query: "SELECT ID, CREATED_AT, QUANTITY FROM ORDERS ORDER BY ID LIMIT 10",
   },
 };
 
-const peopleTableQuestionDetails: NativeQuestionDetails = {
+const peopleTableQuestionDetails = {
   display: "table",
-  native: {
+  dataset_query: {
+    database: SAMPLE_DB_ID,
     query: "SELECT ID, EMAIL, CREATED_AT FROM PEOPLE ORDER BY ID LIMIT 10",
   },
 };
 
-const timeseriesLineQuestionDetails: NativeQuestionDetails = {
+const timeseriesLineQuestionDetails = {
   display: "line",
-  native: {
+  dataset_query: {
+    database: SAMPLE_DB_ID,
     query: "SELECT CREATED_AT, QUANTITY FROM ORDERS ORDER BY ID LIMIT 10",
   },
   visualization_settings: {
@@ -27,9 +29,10 @@ const timeseriesLineQuestionDetails: NativeQuestionDetails = {
   },
 };
 
-const timeseriesWithCategoryLineQuestionDetails: NativeQuestionDetails = {
+const timeseriesWithCategoryLineQuestionDetails = {
   display: "line",
-  native: {
+  dataset_query: {
+    database: SAMPLE_DB_ID,
     query:
       "SELECT PRICE, CATEGORY, CREATED_AT FROM PRODUCTS ORDER BY ID LIMIT 10",
   },
@@ -39,9 +42,10 @@ const timeseriesWithCategoryLineQuestionDetails: NativeQuestionDetails = {
   },
 };
 
-const numericLineQuestionDetails: NativeQuestionDetails = {
+const numericLineQuestionDetails = {
   display: "line",
-  native: {
+  dataset_query: {
+    database: SAMPLE_DB_ID,
     query: "SELECT ID, QUANTITY FROM ORDERS ORDER BY ID LIMIT 10",
   },
   visualization_settings: {
@@ -50,9 +54,10 @@ const numericLineQuestionDetails: NativeQuestionDetails = {
   },
 };
 
-const pinMapQuestionDetails: NativeQuestionDetails = {
+const pinMapQuestionDetails = {
   display: "map",
-  native: {
+  dataset_query: {
+    database: SAMPLE_DB_ID,
     query: "SELECT LATITUDE, LONGITUDE FROM PEOPLE ORDER BY ID LIMIT 10",
   },
   visualization_settings: {
@@ -62,9 +67,10 @@ const pinMapQuestionDetails: NativeQuestionDetails = {
   },
 };
 
-const gridMapQuestionDetails: NativeQuestionDetails = {
+const gridMapQuestionDetails = {
   display: "map",
-  native: {
+  dataset_query: {
+    database: SAMPLE_DB_ID,
     query: "SELECT LATITUDE, LONGITUDE FROM PEOPLE ORDER BY ID LIMIT 10",
   },
   visualization_settings: {
@@ -118,10 +124,12 @@ describe("scenarios > question > native query drill", () => {
   describe("query builder drills", () => {
     it("column-extract drill", () => {
       cy.log("from column header");
-      H.createNativeQuestion(ordersTableQuestionDetails, {
-        visitQuestion: true,
-        wrapId: true,
-      });
+      H.createCardWithTestNativeQuery(ordersTableQuestionDetails).then(
+        (card) => {
+          cy.wrap(card.id).as("questionId");
+          H.visitCard(card);
+        },
+      );
       H.tableHeaderClick("CREATED_AT");
       H.popover().within(() => {
         cy.findByText("Extract day, month…").click();
@@ -156,10 +164,12 @@ describe("scenarios > question > native query drill", () => {
 
     it("combine-columns drill", () => {
       cy.log("from column header");
-      H.createNativeQuestion(peopleTableQuestionDetails, {
-        visitQuestion: true,
-        wrapId: true,
-      });
+      H.createCardWithTestNativeQuery(peopleTableQuestionDetails).then(
+        (card) => {
+          cy.wrap(card.id).as("questionId");
+          H.visitCard(card);
+        },
+      );
       H.tableHeaderClick("EMAIL");
       H.popover().findByText("Combine columns").click();
       H.popover().button("Done").click();
@@ -196,9 +206,9 @@ describe("scenarios > question > native query drill", () => {
     });
 
     it("column-filter drill", () => {
-      H.createNativeQuestion(ordersTableQuestionDetails, {
-        visitQuestion: true,
-      });
+      H.createCardWithTestNativeQuery(ordersTableQuestionDetails).then(
+        H.visitCard,
+      );
       H.assertQueryBuilderRowCount(10);
       H.tableHeaderClick("QUANTITY");
       H.popover().findByText("Filter by this column").click();
@@ -212,9 +222,9 @@ describe("scenarios > question > native query drill", () => {
     });
 
     it("distribution drill", () => {
-      H.createNativeQuestion(ordersTableQuestionDetails, {
-        visitQuestion: true,
-      });
+      H.createCardWithTestNativeQuery(ordersTableQuestionDetails).then(
+        H.visitCard,
+      );
       H.tableHeaderClick("QUANTITY");
       H.popover().findByText("Distribution").click();
       cy.wait("@dataset");
@@ -226,9 +236,9 @@ describe("scenarios > question > native query drill", () => {
     });
 
     it("quick-filter drill", () => {
-      H.createNativeQuestion(timeseriesLineQuestionDetails, {
-        visitQuestion: true,
-      });
+      H.createCardWithTestNativeQuery(timeseriesLineQuestionDetails).then(
+        H.visitCard,
+      );
       H.assertQueryBuilderRowCount(10);
       H.cartesianChartCircle().eq(0).click();
       H.popover().within(() => {
@@ -241,10 +251,12 @@ describe("scenarios > question > native query drill", () => {
 
     it("sort drill", () => {
       cy.log("ascending");
-      H.createNativeQuestion(ordersTableQuestionDetails, {
-        visitQuestion: true,
-        wrapId: true,
-      });
+      H.createCardWithTestNativeQuery(ordersTableQuestionDetails).then(
+        (card) => {
+          cy.wrap(card.id).as("questionId");
+          H.visitCard(card);
+        },
+      );
       H.tableHeaderClick("QUANTITY");
       H.popover().icon("arrow_up").click();
       cy.wait("@dataset");
@@ -266,10 +278,12 @@ describe("scenarios > question > native query drill", () => {
 
     it("summarize drill", () => {
       cy.log("distinct values");
-      H.createNativeQuestion(ordersTableQuestionDetails, {
-        visitQuestion: true,
-        wrapId: true,
-      });
+      H.createCardWithTestNativeQuery(ordersTableQuestionDetails).then(
+        (card) => {
+          cy.wrap(card.id).as("questionId");
+          H.visitCard(card);
+        },
+      );
       H.tableHeaderClick("QUANTITY");
       H.popover().findByText("Distinct values").click();
       cy.wait("@dataset");
@@ -300,9 +314,9 @@ describe("scenarios > question > native query drill", () => {
     });
 
     it("summarize-column-by-time drill", () => {
-      H.createNativeQuestion(ordersTableQuestionDetails, {
-        visitQuestion: true,
-      });
+      H.createCardWithTestNativeQuery(ordersTableQuestionDetails).then(
+        H.visitCard,
+      );
       H.tableHeaderClick("QUANTITY");
       H.popover().findByText("Sum over time").click();
       cy.wait("@dataset");
@@ -318,9 +332,9 @@ describe("scenarios > question > native query drill", () => {
 
     it("unsupported drills", () => {
       cy.log("aggregated cell click");
-      H.createNativeQuestion(timeseriesLineQuestionDetails, {
-        visitQuestion: true,
-      });
+      H.createCardWithTestNativeQuery(timeseriesLineQuestionDetails).then(
+        H.visitCard,
+      );
       H.assertQueryBuilderRowCount(10);
       H.cartesianChartCircle().eq(0).click();
       H.popover().within(() => {
@@ -330,9 +344,9 @@ describe("scenarios > question > native query drill", () => {
       });
 
       cy.log("legend item click");
-      H.createNativeQuestion(timeseriesWithCategoryLineQuestionDetails, {
-        visitQuestion: true,
-      });
+      H.createCardWithTestNativeQuery(
+        timeseriesWithCategoryLineQuestionDetails,
+      ).then(H.visitCard);
       cy.findByTestId("visualization-root").findByText("Gadget").click();
       cy.findByRole("tooltip").should("not.exist");
     });
@@ -340,9 +354,9 @@ describe("scenarios > question > native query drill", () => {
 
   describe("query builder brush filters", () => {
     it("timeseries filter", () => {
-      H.createNativeQuestion(timeseriesLineQuestionDetails, {
-        visitQuestion: true,
-      });
+      H.createCardWithTestNativeQuery(timeseriesLineQuestionDetails).then(
+        H.visitCard,
+      );
       H.assertQueryBuilderRowCount(10);
       applyBrushFilter({ left: 200, right: 800 });
       cy.wait("@dataset");
@@ -350,9 +364,9 @@ describe("scenarios > question > native query drill", () => {
     });
 
     it("numeric filter", () => {
-      H.createNativeQuestion(numericLineQuestionDetails, {
-        visitQuestion: true,
-      });
+      H.createCardWithTestNativeQuery(numericLineQuestionDetails).then(
+        H.visitCard,
+      );
       H.assertQueryBuilderRowCount(10);
       applyBrushFilter({ left: 200, right: 800 });
       cy.wait("@dataset");
@@ -361,7 +375,7 @@ describe("scenarios > question > native query drill", () => {
 
     it("coordinates filter", () => {
       cy.log("pin map");
-      H.createNativeQuestion(pinMapQuestionDetails, { visitQuestion: true });
+      H.createCardWithTestNativeQuery(pinMapQuestionDetails).then(H.visitCard);
       cy.findByTestId("visualization-root").realHover();
       cy.findByTestId("visualization-root").within(() => {
         cy.findByText("Set as default view").should("be.visible");
@@ -377,7 +391,7 @@ describe("scenarios > question > native query drill", () => {
       H.assertQueryBuilderRowCount(1);
 
       cy.log("grid map");
-      H.createNativeQuestion(gridMapQuestionDetails, { visitQuestion: true });
+      H.createCardWithTestNativeQuery(gridMapQuestionDetails).then(H.visitCard);
       cy.findByTestId("visualization-root").realHover();
       cy.findByTestId("visualization-root").within(() => {
         cy.findByText("Set as default view").should("be.visible");
@@ -389,7 +403,7 @@ describe("scenarios > question > native query drill", () => {
   describe("dashboard drills", () => {
     it("quick-filter drill", () => {
       cy.log("cell click");
-      H.createNativeQuestionAndDashboard({
+      H.createNativeQuestionAndDashboardWithTestQuery({
         questionDetails: ordersTableQuestionDetails,
       }).then(({ body }) => H.visitDashboard(body.dashboard_id));
       H.getDashboardCard().findByText("May 15, 2027, 8:04 AM").click();
@@ -401,7 +415,7 @@ describe("scenarios > question > native query drill", () => {
       H.assertQueryBuilderRowCount(1);
 
       cy.log("aggregated cell click");
-      H.createNativeQuestionAndDashboard({
+      H.createNativeQuestionAndDashboardWithTestQuery({
         questionDetails: timeseriesLineQuestionDetails,
       }).then(({ body }) => H.visitDashboard(body.dashboard_id));
       H.getDashboardCard().within(() => H.cartesianChartCircle().eq(0).click());
@@ -416,7 +430,7 @@ describe("scenarios > question > native query drill", () => {
 
   describe("dashboard brush filters", () => {
     it("timeseries filter", () => {
-      H.createNativeQuestionAndDashboard({
+      H.createNativeQuestionAndDashboardWithTestQuery({
         questionDetails: timeseriesLineQuestionDetails,
       }).then(({ body }) => H.visitDashboard(body.dashboard_id));
       H.getDashboardCard().within(() =>
@@ -427,7 +441,7 @@ describe("scenarios > question > native query drill", () => {
     });
 
     it("numeric filter", () => {
-      H.createNativeQuestionAndDashboard({
+      H.createNativeQuestionAndDashboardWithTestQuery({
         questionDetails: numericLineQuestionDetails,
       }).then(({ body }) => H.visitDashboard(body.dashboard_id));
       H.getDashboardCard().within(() =>

--- a/e2e/test/scenarios/question/nested.cy.spec.js
+++ b/e2e/test/scenarios/question/nested.cy.spec.js
@@ -4,18 +4,19 @@ import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
 
-const ordersJoinProductsQuery = {
-  "source-table": ORDERS_ID,
+const ordersJoinProductsStage = {
+  source: { type: "table", id: ORDERS_ID },
   joins: [
     {
-      fields: "all",
-      "source-table": PRODUCTS_ID,
-      condition: [
-        "=",
-        ["field", ORDERS.PRODUCT_ID, null],
-        ["field", PRODUCTS.ID, { "join-alias": "Products" }],
+      source: { type: "table", id: PRODUCTS_ID },
+      strategy: "left-join",
+      conditions: [
+        {
+          operator: "=",
+          left: { type: "column", name: "PRODUCT_ID", sourceName: "ORDERS" },
+          right: { type: "column", name: "ID", sourceName: "PRODUCTS" },
+        },
       ],
-      alias: "Products",
     },
   ],
 };
@@ -32,8 +33,9 @@ describe("scenarios > question > nested", () => {
     // Make sure it works for a GUI question
     const guiQuestionDetails = {
       name: "GH_12568: Simple",
-      query: {
-        "source-table": ORDERS_ID,
+      dataset_query: {
+        database: SAMPLE_DB_ID,
+        stages: [{ source: { type: "table", id: ORDERS_ID } }],
       },
       display: "line",
     };
@@ -69,7 +71,8 @@ describe("scenarios > question > nested", () => {
     // Make sure it works for a SQL question
     const sqlQuestionDetails = {
       name: "GH_12568: SQL",
-      native: {
+      dataset_query: {
+        database: SAMPLE_DB_ID,
         query:
           "SELECT date_trunc('year', CREATED_AT) as date, COUNT(*) as count FROM ORDERS GROUP BY date_trunc('year', CREATED_AT)",
       },
@@ -156,35 +159,67 @@ describe("scenarios > question > nested", () => {
       name: "Sum of discounts",
       description: "Discounted orders.",
       type: "metric",
-      query: {
-        "source-table": ORDERS_ID,
-        aggregation: [["count"]],
-        filter: ["!=", ["field", ORDERS.DISCOUNT, null], 0],
+      dataset_query: {
+        database: SAMPLE_DB_ID,
+        stages: [
+          {
+            source: { type: "table", id: ORDERS_ID },
+            aggregations: [{ type: "operator", operator: "count" }],
+            filters: [
+              {
+                type: "operator",
+                operator: "!=",
+                args: [
+                  { type: "column", name: "DISCOUNT", sourceName: "ORDERS" },
+                  { type: "literal", value: 0 },
+                ],
+              },
+            ],
+          },
+        ],
       },
     };
 
     cy.log("Create a metric with a filter");
-    H.createQuestion(metric, {
-      wrapId: true,
-      idAlias: "metricId",
+    H.createCardWithTestQuery(metric).then((card) => {
+      cy.wrap(card.id).as("metricId");
     });
 
     cy.get("@metricId").then((metricId) => {
       // "capture" the original query because we will need to re-use it later in a nested question as "source-query"
       const baseQuestionDetails = {
         name: "12507",
-        query: {
-          "source-table": `card__${metricId}`,
-          aggregation: [["metric", metricId]],
-          breakout: [
-            ["field", ORDERS.TOTAL, { binning: { strategy: "default" } }],
+        dataset_query: {
+          database: SAMPLE_DB_ID,
+          stages: [
+            {
+              source: { type: "card", id: metricId },
+              aggregations: [{ type: "metric", id: metricId }],
+              breakouts: [
+                {
+                  type: "column",
+                  name: "TOTAL",
+                  sourceName: "ORDERS",
+                  bins: "auto",
+                },
+              ],
+            },
           ],
         },
       };
 
       const nestedQuestionDetails = {
-        query: {
-          filter: [">", ["field", ORDERS.TOTAL, null], 50],
+        stage: {
+          filters: [
+            {
+              type: "operator",
+              operator: ">",
+              args: [
+                { type: "column", name: "TOTAL", sourceName: "ORDERS" },
+                { type: "literal", value: 50 },
+              ],
+            },
+          ],
         },
       };
 
@@ -210,7 +245,10 @@ describe("scenarios > question > nested", () => {
 
     const baseQuestionDetails = {
       name: "Orders (remapped)",
-      query: { "source-table": ORDERS_ID, limit: 5 },
+      dataset_query: {
+        database: SAMPLE_DB_ID,
+        stages: [{ source: { type: "table", id: ORDERS_ID }, limit: 5 }],
+      },
     };
 
     createNestedQuestion({ baseQuestionDetails });
@@ -221,7 +259,10 @@ describe("scenarios > question > nested", () => {
   it("nested questions based on a saved question with joins should work (metabase#14724)", () => {
     const baseQuestionDetails = {
       name: "14724",
-      query: ordersJoinProductsQuery,
+      dataset_query: {
+        database: SAMPLE_DB_ID,
+        stages: [ordersJoinProductsStage],
+      },
     };
 
     ["default", "remapped"].forEach((scenario) => {
@@ -254,7 +295,10 @@ describe("scenarios > question > nested", () => {
 
     const baseQuestionDetails = {
       name: "14787",
-      query: { ...ordersJoinProductsQuery, limit: 5 },
+      dataset_query: {
+        database: SAMPLE_DB_ID,
+        stages: [{ ...ordersJoinProductsStage, limit: 5 }],
+      },
     };
 
     createNestedQuestion({ baseQuestionDetails });
@@ -610,33 +654,34 @@ function createNestedQuestion(
     throw new Error("Please provide the base question details");
   }
 
-  createBaseQuestion(baseQuestionDetails).then(({ body: { id } }) => {
+  createBaseQuestion(baseQuestionDetails).then((baseCard) => {
     if (loadBaseQuestionMetadata) {
-      H.visitQuestion(id);
+      H.visitCard(baseCard);
     }
 
-    const { query: nestedQuery, ...details } = nestedQuestionDetails;
+    const { stage: nestedStage, ...details } = nestedQuestionDetails;
 
     const composite = {
       name: "Nested Question",
-      query: {
-        ...nestedQuery,
-        "source-table": `card__${id}`,
-      },
       ...details,
+      dataset_query: {
+        database: SAMPLE_DB_ID,
+        stages: [{ source: { type: "card", id: baseCard.id }, ...nestedStage }],
+      },
     };
 
-    return H.createQuestion(composite, {
-      visitQuestion: visitNestedQuestion,
-      wrapId: true,
-      idAlias: "nestedQuestionId",
+    return H.createCardWithTestQuery(composite).then((nestedCard) => {
+      if (visitNestedQuestion) {
+        H.visitCard(nestedCard);
+      }
+      cy.wrap(nestedCard.id).as("nestedQuestionId");
     });
   });
 
-  function createBaseQuestion(query) {
-    return query.native
-      ? H.createNativeQuestion(query)
-      : H.createQuestion(query);
+  function createBaseQuestion(details) {
+    return details.dataset_query.stages
+      ? H.createCardWithTestQuery(details)
+      : H.createCardWithTestNativeQuery(details);
   }
 }
 

--- a/e2e/test/scenarios/question/nested.cy.spec.js
+++ b/e2e/test/scenarios/question/nested.cy.spec.js
@@ -2,7 +2,7 @@ const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
-const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID, PEOPLE } = SAMPLE_DATABASE;
+const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
 
 const ordersJoinProductsQuery = {
   "source-table": ORDERS_ID,
@@ -106,27 +106,44 @@ describe("scenarios > question > nested", () => {
   });
 
   it("should handle duplicate column names in nested queries (metabase#10511)", () => {
-    H.createQuestion(
-      {
-        name: "10511",
-        query: {
-          filter: [">", ["field", "count", { "base-type": "type/Integer" }], 5],
-          "source-query": {
-            "source-table": ORDERS_ID,
-            aggregation: [["count"]],
-            breakout: [
-              ["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }],
-              [
-                "field",
-                PRODUCTS.CREATED_AT,
-                { "temporal-unit": "month", "source-field": ORDERS.PRODUCT_ID },
-              ],
+    H.createCardWithTestQuery({
+      name: "10511",
+      dataset_query: {
+        database: SAMPLE_DB_ID,
+        stages: [
+          {
+            source: { type: "table", id: ORDERS_ID },
+            aggregations: [{ type: "operator", operator: "count" }],
+            breakouts: [
+              {
+                type: "column",
+                name: "CREATED_AT",
+                sourceName: "ORDERS",
+                unit: "month",
+              },
+              {
+                type: "column",
+                name: "CREATED_AT",
+                sourceName: "Products",
+                unit: "month",
+              },
             ],
           },
-        },
+          {
+            filters: [
+              {
+                type: "operator",
+                operator: ">",
+                args: [
+                  { type: "column", name: "count" },
+                  { type: "literal", value: 5 },
+                ],
+              },
+            ],
+          },
+        ],
       },
-      { visitQuestion: true },
-    );
+    }).then(H.visitCard);
 
     // eslint-disable-next-line metabase/no-unscoped-text-selectors -- deprecated usage
     cy.findByText("10511");
@@ -316,12 +333,15 @@ describe("scenarios > question > nested", () => {
     it("should work with 'between' date filter (metabase#15352-1)", () => {
       assertOnFilter({
         name: "15352-1",
-        filter: [
-          "between",
-          ["field-id", ORDERS.CREATED_AT],
-          "2029-02-01",
-          "2029-02-29",
-        ],
+        filter: {
+          type: "operator",
+          operator: "between",
+          args: [
+            { type: "column", name: "CREATED_AT", sourceName: "ORDERS" },
+            { type: "literal", value: "2029-02-01" },
+            { type: "literal", value: "2029-02-29" },
+          ],
+        },
         value: "543",
       });
     });
@@ -329,11 +349,28 @@ describe("scenarios > question > nested", () => {
     it("should work with 'after/before' date filter (metabase#15352-2)", () => {
       assertOnFilter({
         name: "15352-2",
-        filter: [
-          "and",
-          [">", ["field-id", ORDERS.CREATED_AT], "2029-01-31"],
-          ["<", ["field-id", ORDERS.CREATED_AT], "2029-03-01"],
-        ],
+        filter: {
+          type: "operator",
+          operator: "and",
+          args: [
+            {
+              type: "operator",
+              operator: ">",
+              args: [
+                { type: "column", name: "CREATED_AT", sourceName: "ORDERS" },
+                { type: "literal", value: "2029-01-31" },
+              ],
+            },
+            {
+              type: "operator",
+              operator: "<",
+              args: [
+                { type: "column", name: "CREATED_AT", sourceName: "ORDERS" },
+                { type: "literal", value: "2029-03-01" },
+              ],
+            },
+          ],
+        },
         value: "543",
       });
     });
@@ -341,26 +378,37 @@ describe("scenarios > question > nested", () => {
     it("should work with 'on' date filter (metabase#15352-3)", () => {
       assertOnFilter({
         name: "15352-3",
-        filter: ["=", ["field-id", ORDERS.CREATED_AT], "2029-02-01"],
+        filter: {
+          type: "operator",
+          operator: "=",
+          args: [
+            { type: "column", name: "CREATED_AT", sourceName: "ORDERS" },
+            { type: "literal", value: "2029-02-01" },
+          ],
+        },
         value: "17",
       });
     });
 
     function assertOnFilter({ name, filter, value } = {}) {
-      H.createQuestion({
+      H.createCardWithTestQuery({
         name,
-        query: {
-          "source-table": ORDERS_ID,
-          filter,
-          aggregation: [["count"]],
+        dataset_query: {
+          database: SAMPLE_DB_ID,
+          stages: [
+            {
+              source: { type: "table", id: ORDERS_ID },
+              filters: [filter],
+              aggregations: [{ type: "operator", operator: "count" }],
+            },
+          ],
         },
-        type: "query",
         display: "scalar",
-      }).then(({ body: { id } }) => {
-        H.visitQuestion(id);
+      }).then((card) => {
+        H.visitQuestion(card.id);
         cy.findByTestId("scalar-value").findByText(value);
 
-        visitNestedQueryAdHoc(id);
+        visitNestedQueryAdHoc(card.id);
         cy.findByTestId("scalar-value").findByText(value);
       });
     }
@@ -503,15 +551,16 @@ describe("scenarios > question > nested", () => {
   });
 
   it("should create a nested question with post-aggregation filter (metabase#11561)", () => {
-    H.visitQuestionAdhoc({
+    H.visitAdHocQuestionWithTestQuery({
       dataset_query: {
         database: SAMPLE_DB_ID,
-        query: {
-          "source-table": ORDERS_ID,
-          aggregation: [["count"]],
-          breakout: [["field", PEOPLE.ID, { "source-field": ORDERS.USER_ID }]],
-        },
-        type: "query",
+        stages: [
+          {
+            source: { type: "table", id: ORDERS_ID },
+            aggregations: [{ type: "operator", operator: "count" }],
+            breakouts: [{ type: "column", name: "ID", sourceName: "People" }],
+          },
+        ],
       },
     });
 
@@ -585,11 +634,10 @@ function createNestedQuestion(
 }
 
 function visitNestedQueryAdHoc(id) {
-  return H.visitQuestionAdhoc({
+  return H.visitAdHocQuestionWithTestQuery({
     dataset_query: {
       database: SAMPLE_DB_ID,
-      type: "query",
-      query: { "source-table": `card__${id}` },
+      stages: [{ source: { type: "card", id } }],
     },
   });
 }

--- a/e2e/test/scenarios/question/nested.cy.spec.js
+++ b/e2e/test/scenarios/question/nested.cy.spec.js
@@ -300,13 +300,14 @@ describe("scenarios > question > nested", () => {
   });
 
   it("should be able to use aggregation functions on saved native question (metabase#15397)", () => {
-    H.createNativeQuestion({
+    H.createCardWithTestNativeQuery({
       name: "15397",
-      native: {
+      dataset_query: {
+        database: SAMPLE_DB_ID,
         query:
           "select count(*), orders.product_id from orders group by orders.product_id;",
       },
-    }).then(({ body: { id } }) => {
+    }).then(({ id }) => {
       H.visitQuestion(id);
 
       visitNestedQueryAdHoc(id);
@@ -417,9 +418,12 @@ describe("scenarios > question > nested", () => {
   describe("should not remove user defined metric when summarizing based on saved question (metabase#15725)", () => {
     beforeEach(() => {
       cy.intercept("POST", "/api/dataset").as("dataset");
-      H.createNativeQuestion({
+      H.createCardWithTestNativeQuery({
         name: "15725",
-        native: { query: "select 'A' as cat, 5 as val" },
+        dataset_query: {
+          database: SAMPLE_DB_ID,
+          query: "select 'A' as cat, 5 as val",
+        },
       });
       // Window object gets recreated for every `cy.visit`
       // See: https://stackoverflow.com/a/65218352/8815185
@@ -492,10 +496,13 @@ describe("scenarios > question > nested", () => {
   it("should properly work with native questions (metabase#15808, metabase#16938, metabase#18364)", () => {
     const questionDetails = {
       name: "15808",
-      native: { query: "select * from products limit 3" },
+      dataset_query: {
+        database: SAMPLE_DB_ID,
+        query: "select * from products limit 3",
+      },
     };
 
-    H.createNativeQuestion(questionDetails, { visitQuestion: true });
+    H.createCardWithTestNativeQuery(questionDetails).then(H.visitCard);
     cy.findAllByTestId("cell-data").should(
       "contain",
       "Swaniawski, Casper and Hilll",

--- a/e2e/test/scenarios/question/new.cy.spec.js
+++ b/e2e/test/scenarios/question/new.cy.spec.js
@@ -216,14 +216,24 @@ describe("scenarios > question > new", () => {
   });
 
   it("should handle ad-hoc question with old syntax (metabase#15372)", () => {
-    H.visitQuestionAdhoc({
+    H.visitAdHocQuestionWithTestQuery({
       dataset_query: {
-        type: "query",
-        query: {
-          "source-table": ORDERS_ID,
-          filter: ["=", ["field-id", ORDERS.USER_ID], 1],
-        },
         database: SAMPLE_DB_ID,
+        stages: [
+          {
+            source: { type: "table", id: ORDERS_ID },
+            filters: [
+              {
+                type: "operator",
+                operator: "=",
+                args: [
+                  { type: "column", name: "USER_ID", sourceName: "ORDERS" },
+                  { type: "literal", value: 1 },
+                ],
+              },
+            ],
+          },
+        ],
       },
     });
 
@@ -681,9 +691,12 @@ describe(
     });
 
     it("shows models and raw data options after creating a model", () => {
-      H.createQuestion({
+      H.createCardWithTestQuery({
         name: "Orders Model",
-        query: { "source-table": ORDERS_ID },
+        dataset_query: {
+          database: SAMPLE_DB_ID,
+          stages: [{ source: { type: "table", id: ORDERS_ID } }],
+        },
         type: "model",
       });
 

--- a/e2e/test/scenarios/question/notebook-data-source.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-data-source.cy.spec.ts
@@ -1,12 +1,11 @@
 const { H } = cy;
-import { WRITABLE_DB_ID } from "e2e/support/cypress_data";
+import { SAMPLE_DB_ID, WRITABLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   ORDERS_COUNT_QUESTION_ID,
   ORDERS_MODEL_ID,
   SECOND_COLLECTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import type { StructuredQuestionDetails } from "e2e/support/helpers";
 import { checkNotNull } from "metabase/utils/types";
 
 const { ORDERS_ID, PRODUCTS_ID, REVIEWS_ID } = SAMPLE_DATABASE;
@@ -227,11 +226,16 @@ describe("scenarios > notebook > data source", () => {
   });
 
   describe("saved entity as a source (aka the virtual table)", () => {
-    const modelDetails: StructuredQuestionDetails = {
+    const modelDetails = {
       name: "GUI Model",
-      query: { "source-table": REVIEWS_ID, limit: 1 },
-      display: "table",
-      type: "model",
+      dataset_query: {
+        database: SAMPLE_DB_ID,
+        stages: [
+          { source: { type: "table" as const, id: REVIEWS_ID }, limit: 1 },
+        ],
+      },
+      display: "table" as const,
+      type: "model" as const,
       collection_id: SECOND_COLLECTION_ID,
     };
 
@@ -241,7 +245,7 @@ describe("scenarios > notebook > data source", () => {
     });
 
     it("data selector should properly show a model as the source (metabase#39699)", () => {
-      H.createQuestion(modelDetails, { visitQuestion: true });
+      H.createCardWithTestQuery(modelDetails).then(H.visitCard);
       H.openNotebook();
       cy.findByTestId("data-step-cell")
         .should("have.text", modelDetails.name)
@@ -296,15 +300,13 @@ describe("scenarios > notebook > data source", () => {
         name: sourceQuestionName,
       });
 
-      const nestedQuestionDetails = {
+      H.createCardWithTestQuery({
         name: "Nested Question",
-        query: { "source-table": `card__${SOURCE_QUESTION_ID}` },
-      };
-
-      H.createQuestion(nestedQuestionDetails, {
-        wrapId: true,
-        idAlias: "nestedQuestionId",
-      });
+        dataset_query: {
+          database: SAMPLE_DB_ID,
+          stages: [{ source: { type: "card", id: SOURCE_QUESTION_ID } }],
+        },
+      }).then((card) => cy.wrap(card.id).as("nestedQuestionId"));
 
       cy.log("see nested question in our analytics");
 
@@ -436,11 +438,12 @@ describe("issue 32252", () => {
           throw new Error("collection.id is not a number");
         }
 
-        H.createQuestion({
+        H.createCardWithTestQuery({
           name: "My question",
           collection_id: collection.id,
-          query: {
-            "source-table": ORDERS_ID,
+          dataset_query: {
+            database: SAMPLE_DB_ID,
+            stages: [{ source: { type: "table", id: ORDERS_ID } }],
           },
         });
       },

--- a/e2e/test/scenarios/question/notebook-link-to-data-source.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-link-to-data-source.cy.spec.ts
@@ -7,7 +7,6 @@ import {
   ORDERS_COUNT_QUESTION_ID,
   ORDERS_MODEL_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import type { NativeQuestionDetails } from "e2e/support/helpers";
 import { DataPermissionValue } from "metabase/admin/permissions/types";
 import { METAKEY } from "metabase/utils/browser";
 
@@ -133,13 +132,13 @@ describe("scenarios > notebook > link to data source", () => {
     it("should open the source question from a nested question where the source is native question", () => {
       const source = {
         name: "Native source",
-        native: {
+        dataset_query: {
+          database: SAMPLE_DB_ID,
           query: "select 1 as foo",
-          "template-tags": {},
         },
       };
 
-      H.createNativeQuestion(source).then(({ body: sourceQuestion }) => {
+      H.createCardWithTestNativeQuery(source).then((sourceQuestion) => {
         H.createCardWithTestQuery({
           name: "Nested question based on a native question",
           dataset_query: {
@@ -202,16 +201,16 @@ describe("scenarios > notebook > link to data source", () => {
     });
 
     it("should open the source model from a nested question where the source is native model", () => {
-      const source: NativeQuestionDetails = {
+      const source = {
         name: "Native source",
-        native: {
+        dataset_query: {
+          database: SAMPLE_DB_ID,
           query: "select 1 as foo",
-          "template-tags": {},
         },
-        type: "model",
+        type: "model" as const,
       };
 
-      H.createNativeQuestion(source).then(({ body: sourceQuestion }) => {
+      H.createCardWithTestNativeQuery(source).then((sourceQuestion) => {
         H.createCardWithTestQuery({
           name: "Nested question based on a native question",
           dataset_query: {
@@ -298,16 +297,16 @@ describe("scenarios > notebook > link to data source", () => {
     });
 
     it("should open the underlying native model", () => {
-      const model: NativeQuestionDetails = {
+      const model = {
         name: "Native model",
-        native: {
+        dataset_query: {
+          database: SAMPLE_DB_ID,
           query: "select 1 as foo",
-          "template-tags": {},
         },
-        type: "model",
+        type: "model" as const,
       };
 
-      H.createNativeQuestion(model).then(({ body: { id, name } }) => {
+      H.createCardWithTestNativeQuery(model).then(({ id, name }) => {
         H.visitModel(id);
 
         H.openNotebook();

--- a/e2e/test/scenarios/question/notebook-link-to-data-source.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-link-to-data-source.cy.spec.ts
@@ -7,22 +7,12 @@ import {
   ORDERS_COUNT_QUESTION_ID,
   ORDERS_MODEL_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import type {
-  NativeQuestionDetails,
-  QuestionDetails,
-} from "e2e/support/helpers";
+import type { NativeQuestionDetails } from "e2e/support/helpers";
 import { DataPermissionValue } from "metabase/admin/permissions/types";
 import { METAKEY } from "metabase/utils/browser";
 
-const {
-  ORDERS,
-  ORDERS_ID,
-  PRODUCTS_ID,
-  REVIEWS,
-  REVIEWS_ID,
-  PEOPLE_ID,
-  PRODUCTS,
-} = SAMPLE_DATABASE;
+const { ORDERS, ORDERS_ID, PRODUCTS_ID, REVIEWS_ID, PEOPLE_ID } =
+  SAMPLE_DATABASE;
 
 describe("scenarios > notebook > link to data source", () => {
   beforeEach(() => {
@@ -109,13 +99,13 @@ describe("scenarios > notebook > link to data source", () => {
     });
 
     it("should open the source question from a nested question", () => {
-      H.createQuestion(
-        {
-          name: "Nested question based on a question",
-          query: { "source-table": `card__${ORDERS_COUNT_QUESTION_ID}` },
+      H.createCardWithTestQuery({
+        name: "Nested question based on a question",
+        dataset_query: {
+          database: SAMPLE_DB_ID,
+          stages: [{ source: { type: "card", id: ORDERS_COUNT_QUESTION_ID } }],
         },
-        { visitQuestion: true },
-      );
+      }).then(H.visitCard);
 
       H.openNotebook();
       H.getNotebookStep("data")
@@ -150,13 +140,13 @@ describe("scenarios > notebook > link to data source", () => {
       };
 
       H.createNativeQuestion(source).then(({ body: sourceQuestion }) => {
-        H.createQuestion(
-          {
-            name: "Nested question based on a native question",
-            query: { "source-table": `card__${sourceQuestion.id}` },
+        H.createCardWithTestQuery({
+          name: "Nested question based on a native question",
+          dataset_query: {
+            database: SAMPLE_DB_ID,
+            stages: [{ source: { type: "card", id: sourceQuestion.id } }],
           },
-          { visitQuestion: true },
-        );
+        }).then(H.visitCard);
 
         H.openNotebook();
         H.getNotebookStep("data").findByText(source.name).click(H.holdMetaKey);
@@ -184,13 +174,13 @@ describe("scenarios > notebook > link to data source", () => {
     });
 
     it("should open the source model from a nested question", () => {
-      H.createQuestion(
-        {
-          name: "Nested question based on a model",
-          query: { "source-table": `card__${ORDERS_MODEL_ID}` },
+      H.createCardWithTestQuery({
+        name: "Nested question based on a model",
+        dataset_query: {
+          database: SAMPLE_DB_ID,
+          stages: [{ source: { type: "card", id: ORDERS_MODEL_ID } }],
         },
-        { visitQuestion: true },
-      );
+      }).then(H.visitCard);
 
       H.openNotebook();
       H.getNotebookStep("data").findByText("Orders Model").click(H.holdMetaKey);
@@ -222,13 +212,13 @@ describe("scenarios > notebook > link to data source", () => {
       };
 
       H.createNativeQuestion(source).then(({ body: sourceQuestion }) => {
-        H.createQuestion(
-          {
-            name: "Nested question based on a native question",
-            query: { "source-table": `card__${sourceQuestion.id}` },
+        H.createCardWithTestQuery({
+          name: "Nested question based on a native question",
+          dataset_query: {
+            database: SAMPLE_DB_ID,
+            stages: [{ source: { type: "card", id: sourceQuestion.id } }],
           },
-          { visitQuestion: true },
-        );
+        }).then(H.visitCard);
 
         H.openNotebook();
         H.getNotebookStep("data")
@@ -253,10 +243,13 @@ describe("scenarios > notebook > link to data source", () => {
     });
 
     it('should open the "trash" if the source question has been archived', () => {
-      H.createQuestion({
+      H.createCardWithTestQuery({
         name: "Nested question based on a question",
-        query: { "source-table": `card__${ORDERS_COUNT_QUESTION_ID}` },
-      }).then(({ body: nestedQuestion }) => {
+        dataset_query: {
+          database: SAMPLE_DB_ID,
+          stages: [{ source: { type: "card", id: ORDERS_COUNT_QUESTION_ID } }],
+        },
+      }).then((nestedQuestion) => {
         cy.log("Move the source question to the trash");
         cy.request("PUT", `/api/card/${ORDERS_COUNT_QUESTION_ID}`, {
           archived: true,
@@ -335,14 +328,17 @@ describe("scenarios > notebook > link to data source", () => {
     });
 
     it("should open the nested model (based on a question) as the data source", () => {
-      H.createQuestion(
-        {
-          name: "Nested model based on a question",
-          query: { "source-table": `card__${ORDERS_COUNT_QUESTION_ID}` },
-          type: "model",
+      H.createCardWithTestQuery({
+        name: "Nested model based on a question",
+        dataset_query: {
+          database: SAMPLE_DB_ID,
+          stages: [{ source: { type: "card", id: ORDERS_COUNT_QUESTION_ID } }],
         },
-        { visitQuestion: true, wrapId: true, idAlias: "nestedModelId" },
-      );
+        type: "model",
+      }).then((card) => {
+        cy.wrap(card.id).as("nestedModelId");
+        return H.visitCard(card);
+      });
 
       H.openNotebook();
       H.getNotebookStep("data")
@@ -367,14 +363,17 @@ describe("scenarios > notebook > link to data source", () => {
     });
 
     it("should open the nested model (based on a model) as the data source", () => {
-      H.createQuestion(
-        {
-          name: "Nested model based on a model",
-          query: { "source-table": `card__${ORDERS_MODEL_ID}` },
-          type: "model",
+      H.createCardWithTestQuery({
+        name: "Nested model based on a model",
+        dataset_query: {
+          database: SAMPLE_DB_ID,
+          stages: [{ source: { type: "card", id: ORDERS_MODEL_ID } }],
         },
-        { visitQuestion: true, wrapId: true, idAlias: "nestedModelId" },
-      );
+        type: "model",
+      }).then((card) => {
+        cy.wrap(card.id).as("nestedModelId");
+        return H.visitCard(card);
+      });
 
       H.openNotebook();
       H.getNotebookStep("data")
@@ -402,10 +401,13 @@ describe("scenarios > notebook > link to data source", () => {
 
   context("permissions", () => {
     it("shouldn't show the source question if it lives in a collection that user can't see", () => {
-      H.createQuestion({
+      H.createCardWithTestQuery({
         name: "Nested question based on a question",
-        query: { "source-table": `card__${ORDERS_COUNT_QUESTION_ID}` },
-      }).then(({ body: nestedQuestion }) => {
+        dataset_query: {
+          database: SAMPLE_DB_ID,
+          stages: [{ source: { type: "card", id: ORDERS_COUNT_QUESTION_ID } }],
+        },
+      }).then((nestedQuestion) => {
         cy.log("Move the source question to admin's personal collection");
         cy.request("PUT", `/api/card/${ORDERS_COUNT_QUESTION_ID}`, {
           collection_id: ADMIN_PERSONAL_COLLECTION_ID,
@@ -447,10 +449,13 @@ describe("scenarios > notebook > link to data source", () => {
     });
 
     it("user with the curate collection permissions but without write query permissions shouldn't be able to see/open the source question", () => {
-      H.createQuestion({
+      H.createCardWithTestQuery({
         name: "Nested question based on a question",
-        query: { "source-table": `card__${ORDERS_COUNT_QUESTION_ID}` },
-      }).then(({ body: nestedQuestion }) => {
+        dataset_query: {
+          database: SAMPLE_DB_ID,
+          stages: [{ source: { type: "card", id: ORDERS_COUNT_QUESTION_ID } }],
+        },
+      }).then((nestedQuestion) => {
         cy.signIn("nodata");
         H.visitQuestion(nestedQuestion.id);
 
@@ -536,88 +541,86 @@ describe("scenarios > notebook > link to data source", () => {
   });
 
   context("joins", () => {
-    const getQuery = (id: number): QuestionDetails => {
-      return {
+    it("rhs joined data sources should open in a new tab on the meta/ctrl click", () => {
+      H.createCardWithTestQuery({
+        name: "People - Saved Question",
         dataset_query: {
           database: SAMPLE_DB_ID,
-          type: "query",
-          query: {
-            "source-table": PRODUCTS_ID,
-            joins: [
-              {
-                fields: "all",
-                strategy: "left-join",
-                alias: "Orders Model",
-                condition: [
-                  "=",
-                  ["field", PRODUCTS.ID, { "base-type": "type/BigInteger" }],
-                  [
-                    "field",
-                    "PRODUCT_ID",
+          stages: [{ source: { type: "table", id: PEOPLE_ID } }],
+        },
+      }).then((savedQuestion) => {
+        H.visitAdHocQuestionWithTestQuery(
+          {
+            dataset_query: {
+              database: SAMPLE_DB_ID,
+              stages: [
+                {
+                  source: { type: "table", id: PRODUCTS_ID },
+                  joins: [
                     {
-                      "base-type": "type/Integer",
-                      "join-alias": "Orders Model",
+                      source: { type: "card", id: ORDERS_MODEL_ID },
+                      strategy: "left-join",
+                      conditions: [
+                        {
+                          operator: "=",
+                          left: {
+                            type: "column",
+                            name: "ID",
+                            sourceName: "PRODUCTS",
+                          },
+                          right: {
+                            type: "column",
+                            name: "PRODUCT_ID",
+                            sourceName: "Orders Model",
+                          },
+                        },
+                      ],
+                    },
+                    {
+                      source: { type: "card", id: savedQuestion.id },
+                      strategy: "right-join",
+                      conditions: [
+                        {
+                          operator: "=",
+                          left: {
+                            type: "column",
+                            name: "USER_ID",
+                            sourceName: "Orders Model",
+                          },
+                          right: {
+                            type: "column",
+                            name: "ID",
+                            sourceName: "People - Saved Question",
+                          },
+                        },
+                      ],
+                    },
+                    {
+                      source: { type: "table", id: REVIEWS_ID },
+                      strategy: "inner-join",
+                      conditions: [
+                        {
+                          operator: "=",
+                          left: {
+                            type: "column",
+                            name: "ID",
+                            sourceName: "PRODUCTS",
+                          },
+                          right: {
+                            type: "column",
+                            name: "PRODUCT_ID",
+                            sourceName: "Reviews",
+                          },
+                        },
+                      ],
                     },
                   ],
-                ],
-                "source-table": `card__${ORDERS_MODEL_ID}`,
-              },
-              {
-                fields: "all",
-                strategy: "right-join",
-                alias: "People - User",
-                condition: [
-                  "=",
-                  [
-                    "field",
-                    ORDERS.USER_ID,
-                    {
-                      "base-type": "type/Integer",
-                      "join-alias": "Orders Model",
-                    },
-                  ],
-                  [
-                    "field",
-                    "ID",
-                    {
-                      "base-type": "type/BigInteger",
-                      "join-alias": "People - User",
-                    },
-                  ],
-                ],
-                "source-table": `card__${id}`,
-              },
-              {
-                fields: "all",
-                strategy: "inner-join",
-                alias: "Reviews",
-                condition: [
-                  "=",
-                  ["field", PRODUCTS.ID, { "base-type": "type/BigInteger" }],
-                  [
-                    "field",
-                    REVIEWS.PRODUCT_ID,
-                    { "base-type": "type/Integer", "join-alias": "Reviews" },
-                  ],
-                ],
-                "source-table": REVIEWS_ID,
-              },
-            ],
+                },
+              ],
+            },
           },
-          parameters: [],
-        },
-      };
-    };
-
-    it("rhs joined data sources should open in a new tab on the meta/ctrl click", () => {
-      H.createQuestion({
-        name: "People - Saved Question",
-        query: {
-          "source-table": PEOPLE_ID,
-        },
-      }).then(({ body: savedQuestion }) => {
-        const queryWithMultipleJoins = getQuery(savedQuestion.id);
-        H.visitQuestionAdhoc(queryWithMultipleJoins, { mode: "notebook" });
+          { mode: "notebook" },
+        );
 
         (function testModel() {
           cy.log("Model should open in a new tab");

--- a/e2e/test/scenarios/question/notebook-native-preview-sidebar.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-native-preview-sidebar.cy.spec.ts
@@ -6,7 +6,7 @@ import {
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
 
-const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
+const { ORDERS_ID } = SAMPLE_DATABASE;
 
 describe("scenarios > question > notebook > native query preview sidebar", () => {
   beforeEach(() => {
@@ -192,18 +192,24 @@ describe("converting question to SQL (metabase#12651, metabase#21615, metabase#3
   });
 
   it("should be possible to convert an ad-hoc time-series table query to SQL (metabase#21615)", () => {
-    H.visitQuestionAdhoc({
+    H.visitAdHocQuestionWithTestQuery({
       display: "table",
       dataset_query: {
-        type: "query",
         database: SAMPLE_DB_ID,
-        query: {
-          "source-table": ORDERS_ID,
-          aggregation: [["count"]],
-          breakout: [
-            ["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }],
-          ],
-        },
+        stages: [
+          {
+            source: { type: "table", id: ORDERS_ID },
+            aggregations: [{ type: "operator", operator: "count" }],
+            breakouts: [
+              {
+                type: "column",
+                name: "CREATED_AT",
+                sourceName: "ORDERS",
+                unit: "month",
+              },
+            ],
+          },
+        ],
       },
     });
 
@@ -232,10 +238,12 @@ describe("converting question to SQL (metabase#12651, metabase#21615, metabase#3
   });
 
   it("should be possible to save a question based on another question after converting to SQL (metabase#40422)", () => {
-    H.createQuestion(
-      { query: { "source-table": `card__${ORDERS_QUESTION_ID}` } },
-      { visitQuestion: true },
-    );
+    H.createCardWithTestQuery({
+      dataset_query: {
+        database: SAMPLE_DB_ID,
+        stages: [{ source: { type: "card", id: ORDERS_QUESTION_ID } }],
+      },
+    }).then(H.visitCard);
     convertToSql();
     H.saveSavedQuestion();
     cy.get("[data-testid=cell-data]").should("contain", "37.65");
@@ -318,24 +326,22 @@ describe(
         H.withDatabase(
           MONGO_DB_ID,
           ({ PRODUCTS_ID }: { PRODUCTS_ID: number }) => {
-            H.createQuestion({
+            H.createCardWithTestQuery({
               name: "Mongo Source",
-              query: {
-                "source-table": PRODUCTS_ID,
-                limit: 1,
+              dataset_query: {
+                database: MONGO_DB_ID,
+                stages: [
+                  { source: { type: "table", id: PRODUCTS_ID }, limit: 1 },
+                ],
               },
-              database: MONGO_DB_ID,
-            }).then(({ body: { id: sourceId } }) => {
-              H.createQuestion(
-                {
-                  name: "Mongo Nested",
-                  query: {
-                    "source-table": `card__${sourceId}`,
-                  },
+            }).then((card) => {
+              H.createCardWithTestQuery({
+                name: "Mongo Nested",
+                dataset_query: {
                   database: MONGO_DB_ID,
+                  stages: [{ source: { type: "card", id: card.id } }],
                 },
-                { visitQuestion: true },
-              );
+              }).then(H.visitCard);
             });
           },
         );

--- a/e2e/test/scenarios/question/notebook.cy.spec.js
+++ b/e2e/test/scenarios/question/notebook.cy.spec.js
@@ -523,22 +523,25 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
   it("should prompt to join with a model if the question is based on a model", () => {
     cy.intercept("GET", "/api/table/*/query_metadata").as("loadMetadata");
 
-    H.createQuestion({
+    H.createCardWithTestQuery({
       name: "Products model",
-      query: { "source-table": PRODUCTS_ID },
+      dataset_query: {
+        database: SAMPLE_DB_ID,
+        stages: [{ source: { type: "table", id: PRODUCTS_ID } }],
+      },
       type: "model",
       display: "table",
     });
 
-    H.createQuestion(
-      {
-        name: "Orders model",
-        query: { "source-table": ORDERS_ID },
-        type: "model",
-        display: "table",
+    H.createCardWithTestQuery({
+      name: "Orders model",
+      dataset_query: {
+        database: SAMPLE_DB_ID,
+        stages: [{ source: { type: "table", id: ORDERS_ID } }],
       },
-      { visitQuestion: true },
-    );
+      type: "model",
+      display: "table",
+    }).then(H.visitCard);
 
     H.openNotebook();
 

--- a/e2e/test/scenarios/question/notebook.cy.spec.js
+++ b/e2e/test/scenarios/question/notebook.cy.spec.js
@@ -6,7 +6,7 @@ import {
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
 
-const { ORDERS, ORDERS_ID, PEOPLE_ID, PRODUCTS_ID } = SAMPLE_DATABASE;
+const { ORDERS_ID, PEOPLE_ID, PRODUCTS_ID } = SAMPLE_DATABASE;
 
 describe("scenarios > question > notebook", { tags: "@slow" }, () => {
   beforeEach(() => {
@@ -896,33 +896,52 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
   });
 
   it("should not crash notebook when metric is used as an aggregation and breakout is applied (metabase#40553)", () => {
-    H.createQuestion(
-      {
-        query: {
-          "source-table": ORDERS_ID,
-          aggregation: [["sum", ["field", ORDERS.SUBTOTAL, null]]],
-        },
-        type: "metric",
-        name: "Revenue",
+    H.createCardWithTestQuery({
+      name: "Revenue",
+      type: "metric",
+      dataset_query: {
+        database: SAMPLE_DB_ID,
+        stages: [
+          {
+            source: { type: "table", id: ORDERS_ID },
+            aggregations: [
+              {
+                type: "operator",
+                operator: "sum",
+                args: [
+                  { type: "column", name: "SUBTOTAL", sourceName: "ORDERS" },
+                ],
+              },
+            ],
+          },
+        ],
       },
-      {
-        wrapId: true,
-        idAlias: "metricId",
-      },
-    );
+    }).then((card) => {
+      cy.wrap(card.id).as("metricId");
+    });
 
     cy.get("@metricId").then((metricId) => {
       const questionDetails = {
-        query: {
-          "source-table": ORDERS_ID,
-          breakout: [
-            ["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }],
+        dataset_query: {
+          database: SAMPLE_DB_ID,
+          stages: [
+            {
+              source: { type: "table", id: ORDERS_ID },
+              aggregations: [{ type: "metric", id: metricId }],
+              breakouts: [
+                {
+                  type: "column",
+                  name: "CREATED_AT",
+                  sourceName: "ORDERS",
+                  unit: "month",
+                },
+              ],
+            },
           ],
-          aggregation: ["metric", metricId],
         },
       };
 
-      H.createQuestion(questionDetails, { visitQuestion: true });
+      H.createCardWithTestQuery(questionDetails).then(H.visitCard);
 
       H.openNotebook();
 
@@ -936,31 +955,45 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
     "should be possible to sort by metric (metabase#8283,metabase#42392)",
     { tags: "@skip" },
     () => {
-      H.createQuestion(
-        {
-          name: "Revenue",
-          description: "Sum of orders subtotal",
-          type: "metric",
-          query: {
-            "source-table": ORDERS_ID,
-            aggregation: [["sum", ["field", ORDERS.SUBTOTAL, null]]],
-          },
+      H.createCardWithTestQuery({
+        name: "Revenue",
+        description: "Sum of orders subtotal",
+        type: "metric",
+        dataset_query: {
+          database: SAMPLE_DB_ID,
+          stages: [
+            {
+              source: { type: "table", id: ORDERS_ID },
+              aggregations: [
+                {
+                  type: "operator",
+                  operator: "sum",
+                  args: [
+                    { type: "column", name: "SUBTOTAL", sourceName: "ORDERS" },
+                  ],
+                },
+              ],
+            },
+          ],
         },
-        {
-          wrapId: true,
-          idAlias: "metricId",
-        },
-      );
+      }).then((card) => {
+        cy.wrap(card.id).as("metricId");
+      });
 
       cy.get("@metricId").then((metricId) => {
         const questionDetails = {
-          query: {
-            "source-table": `card__${metricId}`,
-            aggregation: ["metric", metricId],
+          dataset_query: {
+            database: SAMPLE_DB_ID,
+            stages: [
+              {
+                source: { type: "card", id: metricId },
+                aggregations: [{ type: "metric", id: metricId }],
+              },
+            ],
           },
         };
 
-        H.createQuestion(questionDetails, { visitQuestion: true });
+        H.createCardWithTestQuery(questionDetails).then(H.visitCard);
 
         H.openNotebook();
 

--- a/e2e/test/scenarios/question/notebook.cy.spec.js
+++ b/e2e/test/scenarios/question/notebook.cy.spec.js
@@ -6,8 +6,7 @@ import {
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
 
-const { ORDERS, ORDERS_ID, PEOPLE, PEOPLE_ID, PRODUCTS, PRODUCTS_ID } =
-  SAMPLE_DATABASE;
+const { ORDERS, ORDERS_ID, PEOPLE_ID, PRODUCTS_ID } = SAMPLE_DATABASE;
 
 describe("scenarios > question > notebook", { tags: "@slow" }, () => {
   beforeEach(() => {
@@ -115,16 +114,27 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
   });
 
   it("should show the original custom expression filter field on subsequent click (metabase#14726)", () => {
-    H.visitQuestionAdhoc({
+    H.visitAdHocQuestionWithTestQuery({
+      display: "table",
       dataset_query: {
         database: SAMPLE_DB_ID,
-        query: {
-          "source-table": ORDERS_ID,
-          filter: ["between", ["field", ORDERS.ID, null], 96, 97],
-        },
-        type: "query",
+        stages: [
+          {
+            source: { type: "table", id: ORDERS_ID },
+            filters: [
+              {
+                type: "operator",
+                operator: "between",
+                args: [
+                  { type: "column", name: "ID", sourceName: "ORDERS" },
+                  { type: "literal", value: 96 },
+                  { type: "literal", value: 97 },
+                ],
+              },
+            ],
+          },
+        ],
       },
-      display: "table",
     });
 
     // eslint-disable-next-line metabase/no-unscoped-text-selectors -- deprecated usage
@@ -188,14 +198,26 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
       },
     ).as("dataset");
 
-    const questionDetails = {
-      query: {
-        "source-table": ORDERS_ID,
-        filter: ["=", ["field", ORDERS.PRODUCT_ID, null], 2],
+    H.createCardWithTestQuery({
+      dataset_query: {
+        database: SAMPLE_DB_ID,
+        stages: [
+          {
+            source: { type: "table", id: ORDERS_ID },
+            filters: [
+              {
+                type: "operator",
+                operator: "=",
+                args: [
+                  { type: "column", name: "PRODUCT_ID", sourceName: "ORDERS" },
+                  { type: "literal", value: 2 },
+                ],
+              },
+            ],
+          },
+        ],
       },
-    };
-
-    H.createQuestion(questionDetails, { visitQuestion: true });
+    }).then(H.visitCard);
 
     // eslint-disable-next-line metabase/no-unscoped-text-selectors -- deprecated usage
     cy.contains("Showing 98 rows");
@@ -431,17 +453,28 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
   });
 
   it("should treat max/min on a name as a string filter (metabase#21973)", () => {
-    const questionDetails = {
+    H.createCardWithTestQuery({
       name: "21973",
-      query: {
-        "source-table": PEOPLE_ID,
-        aggregation: [["max", ["field", PEOPLE.NAME, null]]],
-        breakout: [["field", PEOPLE.SOURCE, null]],
-      },
       display: "table",
-    };
-
-    H.createQuestion(questionDetails, { visitQuestion: true });
+      dataset_query: {
+        database: SAMPLE_DB_ID,
+        stages: [
+          {
+            source: { type: "table", id: PEOPLE_ID },
+            aggregations: [
+              {
+                type: "operator",
+                operator: "max",
+                args: [{ type: "column", name: "NAME", sourceName: "PEOPLE" }],
+              },
+            ],
+            breakouts: [
+              { type: "column", name: "SOURCE", sourceName: "PEOPLE" },
+            ],
+          },
+        ],
+      },
+    }).then(H.visitCard);
 
     H.filter();
     H.popover().within(() => {
@@ -453,17 +486,30 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
   });
 
   it("should treat max/min on a category as a string filter (metabase#22154)", () => {
-    const questionDetails = {
+    H.createCardWithTestQuery({
       name: "22154",
-      query: {
-        "source-table": PRODUCTS_ID,
-        aggregation: [["min", ["field", PRODUCTS.VENDOR, null]]],
-        breakout: [["field", PRODUCTS.CATEGORY, null]],
-      },
       display: "table",
-    };
-
-    H.createQuestion(questionDetails, { visitQuestion: true });
+      dataset_query: {
+        database: SAMPLE_DB_ID,
+        stages: [
+          {
+            source: { type: "table", id: PRODUCTS_ID },
+            aggregations: [
+              {
+                type: "operator",
+                operator: "min",
+                args: [
+                  { type: "column", name: "VENDOR", sourceName: "PRODUCTS" },
+                ],
+              },
+            ],
+            breakouts: [
+              { type: "column", name: "CATEGORY", sourceName: "PRODUCTS" },
+            ],
+          },
+        ],
+      },
+    }).then(H.visitCard);
 
     H.filter();
     H.popover().within(() => {
@@ -721,37 +767,115 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
       cy.get(H.POPOVER_ELEMENT).should("not.exist");
     }
 
-    const questionDetails = {
-      query: {
-        "source-table": ORDERS_ID,
-        expressions: {
-          E1: ["+", ["field", ORDERS.ID, null], 1],
-          E2: ["+", ["field", ORDERS.ID, null], 2],
-        },
-        filter: [
-          "and",
-          ["=", ["field", ORDERS.ID, null], 1],
-          ["=", ["field", ORDERS.ID, null], 2],
-          ["=", ["field", ORDERS.ID, null], 3],
-        ],
-        breakout: [
-          ["field", ORDERS.ID, null],
-          ["field", ORDERS.PRODUCT_ID, null],
-        ],
-        aggregation: [
-          ["count"],
-          ["sum", ["field", ORDERS.TAX, null]],
-          ["sum", ["field", ORDERS.SUBTOTAL, null]],
-          ["sum", ["field", ORDERS.TOTAL, null]],
-          ["avg", ["field", ORDERS.TOTAL, null]],
-        ],
-        "order-by": [
-          ["asc", ["aggregation", 0]],
-          ["asc", ["aggregation", 4]],
+    H.createCardWithTestQuery({
+      dataset_query: {
+        database: SAMPLE_DB_ID,
+        stages: [
+          {
+            source: { type: "table", id: ORDERS_ID },
+            expressions: [
+              {
+                name: "E1",
+                value: {
+                  type: "operator",
+                  operator: "+",
+                  args: [
+                    { type: "column", name: "ID", sourceName: "ORDERS" },
+                    { type: "literal", value: 1 },
+                  ],
+                },
+              },
+              {
+                name: "E2",
+                value: {
+                  type: "operator",
+                  operator: "+",
+                  args: [
+                    { type: "column", name: "ID", sourceName: "ORDERS" },
+                    { type: "literal", value: 2 },
+                  ],
+                },
+              },
+            ],
+            filters: [
+              {
+                type: "operator",
+                operator: "and",
+                args: [
+                  {
+                    type: "operator",
+                    operator: "=",
+                    args: [
+                      { type: "column", name: "ID", sourceName: "ORDERS" },
+                      { type: "literal", value: 1 },
+                    ],
+                  },
+                  {
+                    type: "operator",
+                    operator: "=",
+                    args: [
+                      { type: "column", name: "ID", sourceName: "ORDERS" },
+                      { type: "literal", value: 2 },
+                    ],
+                  },
+                  {
+                    type: "operator",
+                    operator: "=",
+                    args: [
+                      { type: "column", name: "ID", sourceName: "ORDERS" },
+                      { type: "literal", value: 3 },
+                    ],
+                  },
+                ],
+              },
+            ],
+            breakouts: [
+              { type: "column", name: "ID", sourceName: "ORDERS" },
+              { type: "column", name: "PRODUCT_ID", sourceName: "ORDERS" },
+            ],
+            aggregations: [
+              { type: "operator", operator: "count" },
+              {
+                type: "operator",
+                operator: "sum",
+                args: [{ type: "column", name: "TAX", sourceName: "ORDERS" }],
+              },
+              {
+                type: "operator",
+                operator: "sum",
+                args: [
+                  { type: "column", name: "SUBTOTAL", sourceName: "ORDERS" },
+                ],
+              },
+              {
+                type: "operator",
+                operator: "sum",
+                args: [{ type: "column", name: "TOTAL", sourceName: "ORDERS" }],
+              },
+              {
+                type: "operator",
+                operator: "avg",
+                args: [{ type: "column", name: "TOTAL", sourceName: "ORDERS" }],
+              },
+            ],
+            orderBys: [
+              {
+                direction: "asc",
+                type: "column",
+                name: "count",
+                displayName: "Count",
+              },
+              {
+                direction: "asc",
+                type: "column",
+                name: "avg",
+                displayName: "Average of Total",
+              },
+            ],
+          },
         ],
       },
-    };
-    H.createQuestion(questionDetails, { visitQuestion: true });
+    }).then(H.visitCard);
     H.openNotebook();
     verifyDragAndDrop();
     verifyPopoverDoesNotMoveElement({
@@ -880,13 +1004,16 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
   );
 
   it("should open only one bucketing popover at a time (metabase#45036)", () => {
-    H.visitQuestionAdhoc(
+    H.visitAdHocQuestionWithTestQuery(
       {
         dataset_query: {
           database: SAMPLE_DB_ID,
-          type: "query",
-          query: { "source-table": PRODUCTS_ID, aggregation: [["count"]] },
-          parameters: [],
+          stages: [
+            {
+              source: { type: "table", id: PRODUCTS_ID },
+              aggregations: [{ type: "operator", operator: "count" }],
+            },
+          ],
         },
       },
       { mode: "notebook" },
@@ -964,21 +1091,54 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
     // The issue is reproducible on all viewports, but the smaller the viewport is,
     // the more likely the issue is going to occur.
     cy.viewport(300, 800);
-    H.createQuestion(
-      {
-        query: {
-          "source-table": ORDERS_ID,
-          expressions: {
-            [CUSTOM_COLUMN_LONG_NAME]: ["+", 1000, 1000],
+    H.createCardWithTestQuery({
+      dataset_query: {
+        database: SAMPLE_DB_ID,
+        stages: [
+          {
+            source: { type: "table", id: ORDERS_ID },
+            expressions: [
+              {
+                name: CUSTOM_COLUMN_LONG_NAME,
+                value: {
+                  type: "operator",
+                  operator: "+",
+                  args: [
+                    { type: "literal", value: 1000 },
+                    { type: "literal", value: 1000 },
+                  ],
+                },
+              },
+            ],
+            filters: [
+              {
+                type: "operator",
+                operator: "<",
+                args: [
+                  { type: "column", name: CUSTOM_COLUMN_LONG_NAME },
+                  { type: "literal", value: 1000000 },
+                ],
+              },
+            ],
+            aggregations: [
+              {
+                type: "operator",
+                operator: "avg",
+                args: [{ type: "column", name: CUSTOM_COLUMN_LONG_NAME }],
+              },
+            ],
+            breakouts: [{ type: "column", name: CUSTOM_COLUMN_LONG_NAME }],
+            orderBys: [
+              {
+                direction: "asc",
+                type: "column",
+                name: CUSTOM_COLUMN_LONG_NAME,
+              },
+            ],
           },
-          filter: ["<", ["expression", CUSTOM_COLUMN_LONG_NAME, null], 1000000],
-          aggregation: [["avg", ["expression", CUSTOM_COLUMN_LONG_NAME, null]]],
-          breakout: [["expression", CUSTOM_COLUMN_LONG_NAME, null]],
-          "order-by": [["asc", ["expression", CUSTOM_COLUMN_LONG_NAME, null]]],
-        },
+        ],
       },
-      { visitQuestion: true },
-    );
+    }).then(H.visitCard);
     H.openNotebook();
 
     H.verifyNotebookQuery("Orders", [
@@ -1124,10 +1284,16 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
 
   it("should support browser based navigation (metabase#55162)", () => {
     cy.intercept(`/api/table/${PRODUCTS_ID}/fks`).as("tableFK");
-    H.createQuestion(
-      { query: { "source-table": PRODUCTS_ID }, name: "products" },
-      { visitQuestion: true, wrapId: true },
-    );
+    H.createCardWithTestQuery({
+      name: "products",
+      dataset_query: {
+        database: SAMPLE_DB_ID,
+        stages: [{ source: { type: "table", id: PRODUCTS_ID } }],
+      },
+    }).then((card) => {
+      cy.wrap(card.id).as("questionId");
+      H.visitCard(card);
+    });
 
     cy.get("@questionId").then((PRODUCT_QUESTION_ID) => {
       cy.findByRole("button", { name: /Editor/ }).click();

--- a/e2e/test/scenarios/question/nulls.cy.spec.js
+++ b/e2e/test/scenarios/question/nulls.cy.spec.js
@@ -1,4 +1,5 @@
 const { H } = cy;
+import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
@@ -10,15 +11,25 @@ describe("scenarios > question > null", () => {
   });
 
   it("should display rows whose value is `null` (metabase#13571)", () => {
-    H.createQuestion({
+    H.createCardWithTestQuery({
       name: "13571",
-      query: {
-        "source-table": ORDERS_ID,
-        fields: [
-          ["field", ORDERS.ID, null],
-          ["field", ORDERS.DISCOUNT, null],
+      dataset_query: {
+        database: SAMPLE_DB_ID,
+        stages: [
+          {
+            source: { type: "table", id: ORDERS_ID },
+            filters: [
+              {
+                type: "operator",
+                operator: "=",
+                args: [
+                  { type: "column", name: "ID", sourceName: "ORDERS" },
+                  { type: "literal", value: 1 },
+                ],
+              },
+            ],
+          },
         ],
-        filter: ["=", ["field", ORDERS.ID, null], 1],
       },
     });
 

--- a/e2e/test/scenarios/question/nulls.cy.spec.js
+++ b/e2e/test/scenarios/question/nulls.cy.spec.js
@@ -48,23 +48,63 @@ describe("scenarios > question > null", () => {
 
   it("pie chart should handle `0`/`null` values (metabase#13626)", () => {
     // Preparation for the test: "Arrange and Act phase" - see repro steps in #13626
-    H.createQuestionAndDashboard({
+    H.createQuestionAndDashboardWithTestQuery({
       questionDetails: {
         name: "13626",
-        query: {
-          "source-table": ORDERS_ID,
-          aggregation: [["sum", ["expression", "NewDiscount"]]],
-          breakout: [["field", ORDERS.ID, null]],
-          expressions: {
-            NewDiscount: [
-              "case",
-              [[["=", ["field", ORDERS.ID, null], 2], 0]],
-              { default: ["field", ORDERS.DISCOUNT, null] },
-            ],
-          },
-          filter: ["=", ["field", ORDERS.ID, null], 1, 2, 3],
-        },
         display: "pie",
+        dataset_query: {
+          database: SAMPLE_DB_ID,
+          stages: [
+            {
+              source: { type: "table", id: ORDERS_ID },
+              expressions: [
+                {
+                  name: "NewDiscount",
+                  value: {
+                    type: "operator",
+                    operator: "case",
+                    args: [
+                      {
+                        type: "operator",
+                        operator: "=",
+                        args: [
+                          { type: "column", name: "ID", sourceName: "ORDERS" },
+                          { type: "literal", value: 2 },
+                        ],
+                      },
+                      { type: "literal", value: 0 },
+                      {
+                        type: "column",
+                        name: "DISCOUNT",
+                        sourceName: "ORDERS",
+                      },
+                    ],
+                  },
+                },
+              ],
+              aggregations: [
+                {
+                  type: "operator",
+                  operator: "sum",
+                  args: [{ type: "column", name: "NewDiscount" }],
+                },
+              ],
+              breakouts: [{ type: "column", name: "ID", sourceName: "ORDERS" }],
+              filters: [
+                {
+                  type: "operator",
+                  operator: "=",
+                  args: [
+                    { type: "column", name: "ID", sourceName: "ORDERS" },
+                    { type: "literal", value: 1 },
+                    { type: "literal", value: 2 },
+                    { type: "literal", value: 3 },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
       },
       dashboardDetails: {
         name: "13626D",
@@ -109,16 +149,16 @@ describe("scenarios > question > null", () => {
   });
 
   it("dashboard should handle cards with null values (metabase#13801)", () => {
-    H.createNativeQuestion({
+    H.createCardWithTestNativeQuery({
       name: "13801_Q1",
-      native: { query: "SELECT null", "template-tags": {} },
+      dataset_query: { database: SAMPLE_DB_ID, query: "SELECT null" },
       display: "scalar",
-    }).then(({ body: { id: Q1_ID } }) => {
-      H.createNativeQuestion({
+    }).then(({ id: Q1_ID }) => {
+      H.createCardWithTestNativeQuery({
         name: "13801_Q2",
-        native: { query: "SELECT 0", "template-tags": {} },
+        dataset_query: { database: SAMPLE_DB_ID, query: "SELECT 0" },
         display: "scalar",
-      }).then(({ body: { id: Q2_ID } }) => {
+      }).then(({ id: Q2_ID }) => {
         H.createDashboard().then(({ body: { id: DASHBOARD_ID } }) => {
           cy.log("Add both previously created questions to the dashboard");
 

--- a/e2e/test/scenarios/question/offset.cy.spec.ts
+++ b/e2e/test/scenarios/question/offset.cy.spec.ts
@@ -1,50 +1,10 @@
 const { H } = cy;
+import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import type { StructuredQuestionDetails } from "e2e/support/helpers";
-import { uuid } from "metabase/utils/uuid";
-import type {
-  Aggregation,
-  Breakout,
-  FieldReference,
-  StructuredQuery,
-} from "metabase-types/api";
 
-const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
-
-const ORDERS_ID_FIELD_REF: FieldReference = [
-  "field",
-  ORDERS.ID,
-  { "base-type": "type/BigInteger" },
-];
-
-const ORDERS_TOTAL_FIELD_REF: FieldReference = [
-  "field",
-  ORDERS.TOTAL,
-  { "base-type": "type/Float" },
-];
-
-const ORDERS_CREATED_AT_BREAKOUT: Breakout = [
-  "field",
-  ORDERS.CREATED_AT,
-  { "base-type": "type/DateTime", "temporal-unit": "month" },
-];
-
-const PRODUCTS_CATEGORY_BREAKOUT: Breakout = [
-  "field",
-  PRODUCTS.CATEGORY,
-  { "base-type": "type/Text", "source-field": ORDERS.PRODUCT_ID },
-];
-
-const SUM_TOTAL_AGGREGATION: Aggregation = ["sum", ORDERS_TOTAL_FIELD_REF];
+const { ORDERS, ORDERS_ID, PRODUCTS_ID } = SAMPLE_DATABASE;
 
 const OFFSET_SUM_TOTAL_AGGREGATION_NAME = "Offsetted sum of total";
-
-const OFFSET_SUM_TOTAL_AGGREGATION: Aggregation = [
-  "offset",
-  createOffsetOptions(OFFSET_SUM_TOTAL_AGGREGATION_NAME),
-  SUM_TOTAL_AGGREGATION,
-  -1,
-];
 
 describe("scenarios > question > offset", () => {
   beforeEach(() => {
@@ -60,14 +20,30 @@ describe("scenarios > question > offset", () => {
       const expression = "Offset([Total], -1)";
       const prefixLength = 3;
       const prefix = expression.substring(0, prefixLength);
-      const query: StructuredQuery = {
-        "source-table": ORDERS_ID,
-        fields: [ORDERS_ID_FIELD_REF, ORDERS_TOTAL_FIELD_REF],
-        limit: 5,
-        "order-by": [["asc", ORDERS_TOTAL_FIELD_REF]],
-      };
 
-      H.createQuestion({ query }, { visitQuestion: true });
+      H.createCardWithTestQuery({
+        dataset_query: {
+          database: SAMPLE_DB_ID,
+          stages: [
+            {
+              source: { type: "table", id: ORDERS_ID },
+              fields: [
+                { type: "column", name: "ID", sourceName: "ORDERS" },
+                { type: "column", name: "TOTAL", sourceName: "ORDERS" },
+              ],
+              limit: 5,
+              orderBys: [
+                {
+                  type: "column",
+                  name: "TOTAL",
+                  sourceName: "ORDERS",
+                  direction: "asc",
+                },
+              ],
+            },
+          ],
+        },
+      }).then(H.visitCard);
       H.openNotebook();
       cy.button("Custom column").click();
       H.enterCustomColumnDetails({ formula: prefix });
@@ -91,13 +67,22 @@ describe("scenarios > question > offset", () => {
       const expression = "Offset([Total], -1)";
       const prefixLength = 3;
       const prefix = expression.substring(0, prefixLength);
-      const query: StructuredQuery = {
-        "source-table": ORDERS_ID,
-        fields: [ORDERS_ID_FIELD_REF, ORDERS_TOTAL_FIELD_REF],
-        limit: 5,
-      };
 
-      H.createQuestion({ query }, { visitQuestion: true });
+      H.createCardWithTestQuery({
+        dataset_query: {
+          database: SAMPLE_DB_ID,
+          stages: [
+            {
+              source: { type: "table", id: ORDERS_ID },
+              fields: [
+                { type: "column", name: "ID", sourceName: "ORDERS" },
+                { type: "column", name: "TOTAL", sourceName: "ORDERS" },
+              ],
+              limit: 5,
+            },
+          ],
+        },
+      }).then(H.visitCard);
       H.openNotebook();
       cy.button("Custom column").click();
       H.enterCustomColumnDetails({ formula: prefix });
@@ -155,21 +140,39 @@ describe("scenarios > question > offset", () => {
         const expression = `Offset([${offsettedColumnName}], -1)`;
         const prefixLength = "Offset([x".length;
         const prefix = expression.substring(0, prefixLength);
-        const query: StructuredQuery = {
-          "source-table": ORDERS_ID,
-          expressions: {
-            [offsettedColumnName]: [
-              "offset",
-              createOffsetOptions(offsettedColumnName),
-              ORDERS_TOTAL_FIELD_REF,
-              -1,
+
+        H.createCardWithTestQuery({
+          dataset_query: {
+            database: SAMPLE_DB_ID,
+            stages: [
+              {
+                source: { type: "table", id: ORDERS_ID },
+                expressions: [
+                  {
+                    name: offsettedColumnName,
+                    value: {
+                      type: "operator",
+                      operator: "offset",
+                      args: [
+                        { type: "column", name: "TOTAL", sourceName: "ORDERS" },
+                        { type: "literal", value: -1 },
+                      ],
+                    },
+                  },
+                ],
+                orderBys: [
+                  {
+                    type: "column",
+                    name: "ID",
+                    sourceName: "ORDERS",
+                    direction: "asc",
+                  },
+                ],
+                limit: 5,
+              },
             ],
           },
-          "order-by": [["asc", ORDERS_ID_FIELD_REF]],
-          limit: 5,
-        };
-
-        H.createQuestion({ query }, { visitQuestion: true });
+        }).then(H.visitCard);
 
         cy.log("custom column drills");
         const rowIndex = 1;
@@ -213,12 +216,13 @@ describe("scenarios > question > offset", () => {
       const expression = "Offset([Total], -1) > 0";
       const prefixLength = 3;
       const prefix = expression.substring(0, prefixLength);
-      const query: StructuredQuery = {
-        "source-table": ORDERS_ID,
-        limit: 5,
-      };
 
-      H.createQuestion({ query }, { visitQuestion: true });
+      H.createCardWithTestQuery({
+        dataset_query: {
+          database: SAMPLE_DB_ID,
+          stages: [{ source: { type: "table", id: ORDERS_ID }, limit: 5 }],
+        },
+      }).then(H.visitCard);
       H.openNotebook();
       cy.button("Filter").click();
       H.popover().findByText("Custom Expression").click();
@@ -244,12 +248,13 @@ describe("scenarios > question > offset", () => {
       const expression = "Offset(Sum([Total]), -1)";
       const prefixLength = 3;
       const prefix = expression.substring(0, prefixLength);
-      const query: StructuredQuery = {
-        "source-table": ORDERS_ID,
-        limit: 5,
-      };
 
-      H.createQuestion({ query }, { visitQuestion: true });
+      H.createCardWithTestQuery({
+        dataset_query: {
+          database: SAMPLE_DB_ID,
+          stages: [{ source: { type: "table", id: ORDERS_ID }, limit: 5 }],
+        },
+      }).then(H.visitCard);
       H.openNotebook();
       cy.button("Summarize").click();
       H.getNotebookStep("summarize")
@@ -283,13 +288,40 @@ describe("scenarios > question > offset", () => {
       () => {
         cy.intercept("POST", "/api/dataset/native").as("sqlPreview");
 
-        const query: StructuredQuery = {
-          "source-table": ORDERS_ID,
-          aggregation: [OFFSET_SUM_TOTAL_AGGREGATION],
-          limit: 5,
-        };
-
-        H.createQuestion({ query }, { visitQuestion: true });
+        H.createCardWithTestQuery({
+          dataset_query: {
+            database: SAMPLE_DB_ID,
+            stages: [
+              {
+                source: { type: "table", id: ORDERS_ID },
+                aggregations: [
+                  {
+                    name: OFFSET_SUM_TOTAL_AGGREGATION_NAME,
+                    value: {
+                      type: "operator",
+                      operator: "offset",
+                      args: [
+                        {
+                          type: "operator",
+                          operator: "sum",
+                          args: [
+                            {
+                              type: "column",
+                              name: "TOTAL",
+                              sourceName: "ORDERS",
+                            },
+                          ],
+                        },
+                        { type: "literal", value: -1 },
+                      ],
+                    },
+                  },
+                ],
+                limit: 5,
+              },
+            ],
+          },
+        }).then(H.visitCard);
 
         H.openNotebook();
 
@@ -304,14 +336,48 @@ describe("scenarios > question > offset", () => {
     );
 
     it("works with a single breakout", () => {
-      const query: StructuredQuery = {
-        "source-table": ORDERS_ID,
-        aggregation: [OFFSET_SUM_TOTAL_AGGREGATION],
-        breakout: [ORDERS_CREATED_AT_BREAKOUT],
-        limit: 5,
-      };
-
-      H.createQuestion({ query }, { visitQuestion: true });
+      H.createCardWithTestQuery({
+        dataset_query: {
+          database: SAMPLE_DB_ID,
+          stages: [
+            {
+              source: { type: "table", id: ORDERS_ID },
+              aggregations: [
+                {
+                  name: OFFSET_SUM_TOTAL_AGGREGATION_NAME,
+                  value: {
+                    type: "operator",
+                    operator: "offset",
+                    args: [
+                      {
+                        type: "operator",
+                        operator: "sum",
+                        args: [
+                          {
+                            type: "column",
+                            name: "TOTAL",
+                            sourceName: "ORDERS",
+                          },
+                        ],
+                      },
+                      { type: "literal", value: -1 },
+                    ],
+                  },
+                },
+              ],
+              breakouts: [
+                {
+                  type: "column",
+                  name: "CREATED_AT",
+                  sourceName: "ORDERS",
+                  unit: "month",
+                },
+              ],
+              limit: 5,
+            },
+          ],
+        },
+      }).then(H.visitCard);
 
       verifyNoQuestionError();
       verifyTableContent([
@@ -324,15 +390,57 @@ describe("scenarios > question > offset", () => {
     });
 
     it("works with a single breakout and sorting by breakout", () => {
-      const query: StructuredQuery = {
-        "source-table": ORDERS_ID,
-        aggregation: [OFFSET_SUM_TOTAL_AGGREGATION],
-        breakout: [ORDERS_CREATED_AT_BREAKOUT],
-        limit: 5,
-        "order-by": [["desc", ORDERS_CREATED_AT_BREAKOUT]],
-      };
-
-      H.createQuestion({ query }, { visitQuestion: true });
+      H.createCardWithTestQuery({
+        dataset_query: {
+          database: SAMPLE_DB_ID,
+          stages: [
+            {
+              source: { type: "table", id: ORDERS_ID },
+              aggregations: [
+                {
+                  name: OFFSET_SUM_TOTAL_AGGREGATION_NAME,
+                  value: {
+                    type: "operator",
+                    operator: "offset",
+                    args: [
+                      {
+                        type: "operator",
+                        operator: "sum",
+                        args: [
+                          {
+                            type: "column",
+                            name: "TOTAL",
+                            sourceName: "ORDERS",
+                          },
+                        ],
+                      },
+                      { type: "literal", value: -1 },
+                    ],
+                  },
+                },
+              ],
+              breakouts: [
+                {
+                  type: "column",
+                  name: "CREATED_AT",
+                  sourceName: "ORDERS",
+                  unit: "month",
+                },
+              ],
+              limit: 5,
+              orderBys: [
+                {
+                  type: "column",
+                  name: "CREATED_AT",
+                  sourceName: "ORDERS",
+                  unit: "month",
+                  direction: "desc",
+                },
+              ],
+            },
+          ],
+        },
+      }).then(H.visitCard);
 
       verifyNoQuestionError();
       verifyTableContent([
@@ -342,15 +450,55 @@ describe("scenarios > question > offset", () => {
     });
 
     it("works with a single breakout and sorting by aggregation (metabase#42554)", () => {
-      const query: StructuredQuery = {
-        "source-table": ORDERS_ID,
-        aggregation: [OFFSET_SUM_TOTAL_AGGREGATION],
-        breakout: [ORDERS_CREATED_AT_BREAKOUT],
-        limit: 5,
-        "order-by": [["desc", ["aggregation", 0]]],
-      };
-
-      H.createQuestion({ query }, { visitQuestion: true });
+      H.createCardWithTestQuery({
+        dataset_query: {
+          database: SAMPLE_DB_ID,
+          stages: [
+            {
+              source: { type: "table", id: ORDERS_ID },
+              aggregations: [
+                {
+                  name: OFFSET_SUM_TOTAL_AGGREGATION_NAME,
+                  value: {
+                    type: "operator",
+                    operator: "offset",
+                    args: [
+                      {
+                        type: "operator",
+                        operator: "sum",
+                        args: [
+                          {
+                            type: "column",
+                            name: "TOTAL",
+                            sourceName: "ORDERS",
+                          },
+                        ],
+                      },
+                      { type: "literal", value: -1 },
+                    ],
+                  },
+                },
+              ],
+              breakouts: [
+                {
+                  type: "column",
+                  name: "CREATED_AT",
+                  sourceName: "ORDERS",
+                  unit: "month",
+                },
+              ],
+              limit: 5,
+              orderBys: [
+                {
+                  type: "column",
+                  name: OFFSET_SUM_TOTAL_AGGREGATION_NAME,
+                  direction: "desc",
+                },
+              ],
+            },
+          ],
+        },
+      }).then(H.visitCard);
 
       verifyNoQuestionError();
       verifyTableContent([
@@ -370,13 +518,48 @@ describe("scenarios > question > offset", () => {
     });
 
     it("works with multiple breakouts", () => {
-      const query: StructuredQuery = {
-        "source-table": ORDERS_ID,
-        aggregation: [OFFSET_SUM_TOTAL_AGGREGATION],
-        breakout: [ORDERS_CREATED_AT_BREAKOUT, PRODUCTS_CATEGORY_BREAKOUT],
-      };
-
-      H.createQuestion({ query }, { visitQuestion: true });
+      H.createCardWithTestQuery({
+        dataset_query: {
+          database: SAMPLE_DB_ID,
+          stages: [
+            {
+              source: { type: "table", id: ORDERS_ID },
+              aggregations: [
+                {
+                  name: OFFSET_SUM_TOTAL_AGGREGATION_NAME,
+                  value: {
+                    type: "operator",
+                    operator: "offset",
+                    args: [
+                      {
+                        type: "operator",
+                        operator: "sum",
+                        args: [
+                          {
+                            type: "column",
+                            name: "TOTAL",
+                            sourceName: "ORDERS",
+                          },
+                        ],
+                      },
+                      { type: "literal", value: -1 },
+                    ],
+                  },
+                },
+              ],
+              breakouts: [
+                {
+                  type: "column",
+                  name: "CREATED_AT",
+                  sourceName: "ORDERS",
+                  unit: "month",
+                },
+                { type: "column", name: "CATEGORY", sourceName: "PRODUCTS" },
+              ],
+            },
+          ],
+        },
+      }).then(H.visitCard);
 
       verifyNoQuestionError();
       verifyTableContent([
@@ -387,14 +570,56 @@ describe("scenarios > question > offset", () => {
     });
 
     it("works with multiple aggregations and breakouts", () => {
-      const query: StructuredQuery = {
-        "source-table": ORDERS_ID,
-        aggregation: [SUM_TOTAL_AGGREGATION, OFFSET_SUM_TOTAL_AGGREGATION],
-        breakout: [ORDERS_CREATED_AT_BREAKOUT, PRODUCTS_CATEGORY_BREAKOUT],
-        limit: 9,
-      };
-
-      H.createQuestion({ query }, { visitQuestion: true });
+      H.createCardWithTestQuery({
+        dataset_query: {
+          database: SAMPLE_DB_ID,
+          stages: [
+            {
+              source: { type: "table", id: ORDERS_ID },
+              aggregations: [
+                {
+                  type: "operator",
+                  operator: "sum",
+                  args: [
+                    { type: "column", name: "TOTAL", sourceName: "ORDERS" },
+                  ],
+                },
+                {
+                  name: OFFSET_SUM_TOTAL_AGGREGATION_NAME,
+                  value: {
+                    type: "operator",
+                    operator: "offset",
+                    args: [
+                      {
+                        type: "operator",
+                        operator: "sum",
+                        args: [
+                          {
+                            type: "column",
+                            name: "TOTAL",
+                            sourceName: "ORDERS",
+                          },
+                        ],
+                      },
+                      { type: "literal", value: -1 },
+                    ],
+                  },
+                },
+              ],
+              breakouts: [
+                {
+                  type: "column",
+                  name: "CREATED_AT",
+                  sourceName: "ORDERS",
+                  unit: "month",
+                },
+                { type: "column", name: "CATEGORY", sourceName: "PRODUCTS" },
+              ],
+              limit: 9,
+            },
+          ],
+        },
+      }).then(H.visitCard);
 
       verifyNoQuestionError();
       verifyTableContent([
@@ -508,11 +733,13 @@ describe("scenarios > question > offset", () => {
     it("should allow using OFFSET as a CASE argument (metabase#42377)", () => {
       const formula = "Sum(case([Total] > 0, Offset([Total], -1)))";
       const name = "Aggregation";
-      const query: StructuredQuery = {
-        "source-table": ORDERS_ID,
-      };
 
-      H.createQuestion({ query }, { visitQuestion: true });
+      H.createCardWithTestQuery({
+        dataset_query: {
+          database: SAMPLE_DB_ID,
+          stages: [{ source: { type: "table", id: ORDERS_ID } }],
+        },
+      }).then(H.visitCard);
       H.openNotebook();
       cy.button("Summarize").click();
       addCustomAggregation({ formula, name, isFirst: true });
@@ -581,25 +808,22 @@ describe("scenarios > question > offset", () => {
 
   describe("explicit joins", () => {
     it("offset expression not in the first place in aggregation", () => {
-      const query: StructuredQuery = {
-        "source-table": ORDERS_ID,
-        joins: [
-          {
-            fields: [
-              ["field", PRODUCTS.CATEGORY, { "join-alias": "Products" }],
-            ],
-            "source-table": PRODUCTS_ID,
-            condition: [
-              "=",
-              ["field", ORDERS.PRODUCT_ID, null],
-              ["field", PRODUCTS.ID, { "join-alias": "Products" }],
-            ],
-            alias: "Products",
-          },
-        ],
-      };
-
-      H.createQuestion({ query }, { visitQuestion: true });
+      H.createCardWithTestQuery({
+        dataset_query: {
+          database: SAMPLE_DB_ID,
+          stages: [
+            {
+              source: { type: "table", id: ORDERS_ID },
+              joins: [
+                {
+                  source: { type: "table", id: PRODUCTS_ID },
+                  strategy: "left-join",
+                },
+              ],
+            },
+          ],
+        },
+      }).then(H.visitCard);
       H.openNotebook();
 
       H.summarize({ mode: "notebook" });
@@ -636,25 +860,22 @@ describe("scenarios > question > offset", () => {
     });
 
     it("offset expression is in the first place in aggregation", () => {
-      const query: StructuredQuery = {
-        "source-table": ORDERS_ID,
-        joins: [
-          {
-            fields: [
-              ["field", PRODUCTS.CATEGORY, { "join-alias": "Products" }],
-            ],
-            "source-table": PRODUCTS_ID,
-            condition: [
-              "=",
-              ["field", ORDERS.PRODUCT_ID, null],
-              ["field", PRODUCTS.ID, { "join-alias": "Products" }],
-            ],
-            alias: "Products",
-          },
-        ],
-      };
-
-      H.createQuestion({ query }, { visitQuestion: true });
+      H.createCardWithTestQuery({
+        dataset_query: {
+          database: SAMPLE_DB_ID,
+          stages: [
+            {
+              source: { type: "table", id: ORDERS_ID },
+              joins: [
+                {
+                  source: { type: "table", id: PRODUCTS_ID },
+                  strategy: "left-join",
+                },
+              ],
+            },
+          ],
+        },
+      }).then(H.visitCard);
       H.openNotebook();
 
       H.summarize({ mode: "notebook" });
@@ -696,25 +917,22 @@ describe("scenarios > question > offset", () => {
     it("offset and avg function applied to custom column", () => {
       const customColumnName = "CC Product Rating";
 
-      const query: StructuredQuery = {
-        "source-table": ORDERS_ID,
-        joins: [
-          {
-            fields: [
-              ["field", PRODUCTS.CATEGORY, { "join-alias": "Products" }],
-            ],
-            "source-table": PRODUCTS_ID,
-            condition: [
-              "=",
-              ["field", ORDERS.PRODUCT_ID, null],
-              ["field", PRODUCTS.ID, { "join-alias": "Products" }],
-            ],
-            alias: "Products",
-          },
-        ],
-      };
-
-      H.createQuestion({ query }, { visitQuestion: true });
+      H.createCardWithTestQuery({
+        dataset_query: {
+          database: SAMPLE_DB_ID,
+          stages: [
+            {
+              source: { type: "table", id: ORDERS_ID },
+              joins: [
+                {
+                  source: { type: "table", id: PRODUCTS_ID },
+                  strategy: "left-join",
+                },
+              ],
+            },
+          ],
+        },
+      }).then(H.visitCard);
 
       H.openNotebook();
       addCustomColumn({
@@ -1232,48 +1450,30 @@ describe("scenarios > question > offset", () => {
 
   it("should work with metrics (metabase#47854)", () => {
     const metricName = "Count of orders";
-    const ORDERS_SCALAR_METRIC: StructuredQuestionDetails = {
+
+    H.createCardWithTestQuery({
       name: metricName,
       type: "metric",
       description: "A metric",
-      query: {
-        "source-table": ORDERS_ID,
-        aggregation: [["count"]],
-        breakout: [
-          [
-            "field",
-            ORDERS.CREATED_AT,
-            { "base-type": "type/DateTime", "temporal-unit": "month" },
-          ],
-        ],
-      },
       display: "scalar",
-    };
-
-    H.createQuestion(ORDERS_SCALAR_METRIC).then(({ body: metric }) => {
-      H.createQuestion(
-        {
-          name: "Question with metric",
-          type: "question",
-          query: {
-            "source-table": ORDERS_ID,
-            aggregation: [["metric", metric.id]],
-            breakout: [
-              [
-                "field",
-                ORDERS.CREATED_AT,
-                {
-                  "base-type": "type/DateTime",
-                  "temporal-unit": "month",
-                },
-              ],
+      dataset_query: {
+        database: SAMPLE_DB_ID,
+        stages: [
+          {
+            source: { type: "table", id: ORDERS_ID },
+            aggregations: [{ type: "operator", operator: "count" }],
+            breakouts: [
+              {
+                type: "column",
+                name: "CREATED_AT",
+                sourceName: "ORDERS",
+                unit: "month",
+              },
             ],
           },
-          display: "line",
-        },
-        { visitQuestion: true },
-      );
-    });
+        ],
+      },
+    }).then(H.visitCard);
 
     H.openNotebook();
 
@@ -1399,14 +1599,6 @@ function verifyInvalidColumnName(
     cy.findByText(`Unknown Field: ${columnName}`).should("be.visible");
     cy.button("Done").should("be.disabled");
   });
-}
-
-function createOffsetOptions(name = "offset") {
-  return {
-    "lib/uuid": uuid(),
-    name,
-    "display-name": name,
-  };
 }
 
 function addSorting({

--- a/e2e/test/scenarios/question/saved.cy.spec.js
+++ b/e2e/test/scenarios/question/saved.cy.spec.js
@@ -1,4 +1,5 @@
 const { H } = cy;
+import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   ORDERS_BY_YEAR_QUESTION_ID,
@@ -8,7 +9,7 @@ import {
   SECOND_COLLECTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
 
-const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
+const { ORDERS_ID, PRODUCTS_ID } = SAMPLE_DATABASE;
 
 describe("scenarios > question > saved", () => {
   beforeEach(() => {
@@ -169,15 +170,13 @@ describe("scenarios > question > saved", () => {
   });
 
   it("should not add scrollbar to duplicate modal if question name is long (metabase#53364)", () => {
-    H.createQuestion(
-      {
-        name: "A".repeat(240),
-        query: {
-          "source-table": ORDERS_ID,
-        },
+    H.createCardWithTestQuery({
+      name: "A".repeat(240),
+      dataset_query: {
+        database: SAMPLE_DB_ID,
+        stages: [{ source: { type: "table", id: ORDERS_ID } }],
       },
-      { visitQuestion: true },
-    );
+    }).then(H.visitCard);
     H.openQuestionActions();
     H.popover().findByText("Duplicate").click();
 
@@ -429,29 +428,38 @@ describe("scenarios > question > saved", () => {
       it(`should show a View-only tag when a joined table is marked as ${visibilityType}`, () => {
         cy.signInAsAdmin();
         hideTable({ name: "Products", id: PRODUCTS_ID, visibilityType });
-        H.createQuestion(
-          {
-            name: "Joined question",
-            query: {
-              "source-table": ORDERS_ID,
-              joins: [
-                {
-                  "source-table": PRODUCTS_ID,
-                  alias: "Orders",
-                  condition: [
-                    "=",
-                    ["field", ORDERS.PRODUCT_ID, null],
-                    ["field", PRODUCTS.ID, { "join-alias": "Products" }],
-                  ],
-                  fields: "all",
-                },
-              ],
-            },
+        H.createCardWithTestQuery({
+          name: "Joined question",
+          dataset_query: {
+            database: SAMPLE_DB_ID,
+            stages: [
+              {
+                source: { type: "table", id: ORDERS_ID },
+                joins: [
+                  {
+                    source: { type: "table", id: PRODUCTS_ID },
+                    strategy: "left-join",
+                    conditions: [
+                      {
+                        operator: "=",
+                        left: {
+                          type: "column",
+                          name: "PRODUCT_ID",
+                          sourceName: "ORDERS",
+                        },
+                        right: {
+                          type: "column",
+                          name: "ID",
+                          sourceName: "Products",
+                        },
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
           },
-          {
-            visitQuestion: true,
-          },
-        );
+        }).then(H.visitCard);
         H.queryBuilderHeader()
           .findByText("View-only")
           .should("be.visible")
@@ -474,38 +482,31 @@ describe("scenarios > question > saved", () => {
     }
 
     it("should show a View-only tag when one of the source cards is unavailable", () => {
-      H.createQuestion(
-        {
-          name: "Products Question + Orders",
-          query: {
-            "source-table": `card__${ORDERS_QUESTION_ID}`,
-            joins: [
-              {
-                "source-table": PRODUCTS_ID,
-                alias: "Orders Question",
-                fields: "all",
-                condition: [
-                  "=",
-                  ["field", PRODUCTS.PRODUCT_ID, null],
-                  ["field", ORDERS.ID, { "join-alias": "Orders" }],
-                ],
-              },
-            ],
-          },
+      H.createCardWithTestQuery({
+        name: "Products Question + Orders",
+        dataset_query: {
+          database: SAMPLE_DB_ID,
+          stages: [
+            {
+              source: { type: "card", id: ORDERS_QUESTION_ID },
+              joins: [
+                {
+                  source: { type: "table", id: PRODUCTS_ID },
+                  strategy: "left-join",
+                },
+              ],
+            },
+          ],
         },
-        {
-          wrapId: true,
-          idAlias: "questionId",
-        },
-      );
+      }).then((card) => {
+        H.visitQuestion(ORDERS_QUESTION_ID);
+        moveQuestionTo(/Personal Collection/);
 
-      H.visitQuestion(ORDERS_QUESTION_ID);
-      moveQuestionTo(/Personal Collection/);
+        cy.signInAsNormalUser();
+        H.visitCard(card);
 
-      cy.signInAsNormalUser();
-      cy.get("@questionId").then(H.visitQuestion);
-
-      H.queryBuilderHeader().findByText("View-only").should("be.visible");
+        H.queryBuilderHeader().findByText("View-only").should("be.visible");
+      });
     });
   });
 

--- a/e2e/test/scenarios/question/settings.cy.spec.js
+++ b/e2e/test/scenarios/question/settings.cy.spec.js
@@ -351,15 +351,13 @@ describe("scenarios > question > settings", () => {
     it("should show all options without text overflowing", () => {
       const longName =
         "SuperLongColumnNameSuperLongColumnNameSuperLongColumnNameSuperLongColumnNameSuperLongColumnName";
-      H.createNativeQuestion(
-        {
-          name: "Orders Model",
-          native: {
-            query: `SELECT total as "${longName}" FROM ORDERS`,
-          },
+      H.createCardWithTestNativeQuery({
+        name: "Orders Model",
+        dataset_query: {
+          database: SAMPLE_DB_ID,
+          query: `SELECT total as "${longName}" FROM ORDERS`,
         },
-        { visitQuestion: true },
-      );
+      }).then(H.visitCard);
 
       H.openVizSettingsSidebar();
 
@@ -379,16 +377,14 @@ describe("scenarios > question > settings", () => {
       const longColumnName2 =
         "very very very very very very very very very very very long column 2";
 
-      H.createNativeQuestion(
-        {
-          name: "52975",
-          native: {
-            query: `select 'foo' x, 10 "${regularColumnName}", 20 "${longColumnName1}", 20 "${longColumnName2}"`,
-          },
-          display: "bar",
+      H.createCardWithTestNativeQuery({
+        name: "52975",
+        display: "bar",
+        dataset_query: {
+          database: SAMPLE_DB_ID,
+          query: `select 'foo' x, 10 "${regularColumnName}", 20 "${longColumnName1}", 20 "${longColumnName2}"`,
         },
-        { visitQuestion: true },
-      );
+      }).then(H.visitCard);
 
       H.openVizSettingsSidebar();
 

--- a/e2e/test/scenarios/question/settings.cy.spec.js
+++ b/e2e/test/scenarios/question/settings.cy.spec.js
@@ -2,7 +2,7 @@ const { H } = cy;
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
-const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
+const { ORDERS, ORDERS_ID, PRODUCTS_ID } = SAMPLE_DATABASE;
 
 describe("scenarios > question > settings", () => {
   beforeEach(() => {
@@ -61,26 +61,35 @@ describe("scenarios > question > settings", () => {
     it("should allow you to re-order columns even when one has been removed (metabase #14238, #29287)", () => {
       cy.viewport(1600, 800);
 
-      H.visitQuestionAdhoc({
+      H.visitAdHocQuestionWithTestQuery({
         dataset_query: {
           database: SAMPLE_DB_ID,
-          query: {
-            "source-table": ORDERS_ID,
-            joins: [
-              {
-                fields: "all",
-                alias: "Products",
-                "source-table": PRODUCTS_ID,
-                strategy: "left-join",
-                condition: [
-                  "=",
-                  ["field", ORDERS.PRODUCT_ID, {}],
-                  ["field", PRODUCTS.ID, { "join-alias": "Products" }],
-                ],
-              },
-            ],
-          },
-          type: "query",
+          stages: [
+            {
+              source: { type: "table", id: ORDERS_ID },
+              joins: [
+                {
+                  source: { type: "table", id: PRODUCTS_ID },
+                  strategy: "left-join",
+                  conditions: [
+                    {
+                      operator: "=",
+                      left: {
+                        type: "column",
+                        name: "PRODUCT_ID",
+                        sourceName: "ORDERS",
+                      },
+                      right: {
+                        type: "column",
+                        name: "ID",
+                        sourceName: "PRODUCTS",
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
         },
       });
       H.openVizSettingsSidebar();
@@ -120,39 +129,36 @@ describe("scenarios > question > settings", () => {
     it("should preserve correct order of columns after column removal via sidebar (metabase#13455)", () => {
       cy.viewport(2000, 1600);
       // Orders join Products
-      H.visitQuestionAdhoc({
+      H.visitAdHocQuestionWithTestQuery({
         dataset_query: {
-          type: "query",
-          query: {
-            "source-table": ORDERS_ID,
-            joins: [
-              {
-                fields: "all",
-                "source-table": PRODUCTS_ID,
-                condition: [
-                  "=",
-                  [
-                    "field",
-                    ORDERS.PRODUCT_ID,
-                    {
-                      "base-type": "type/Integer",
-                    },
-                  ],
-                  [
-                    "field",
-                    PRODUCTS.ID,
-                    {
-                      "base-type": "type/BigInteger",
-                      "join-alias": "Products",
-                    },
-                  ],
-                ],
-                alias: "Products",
-              },
-            ],
-            limit: 5,
-          },
           database: SAMPLE_DB_ID,
+          stages: [
+            {
+              source: { type: "table", id: ORDERS_ID },
+              joins: [
+                {
+                  source: { type: "table", id: PRODUCTS_ID },
+                  strategy: "left-join",
+                  conditions: [
+                    {
+                      operator: "=",
+                      left: {
+                        type: "column",
+                        name: "PRODUCT_ID",
+                        sourceName: "ORDERS",
+                      },
+                      right: {
+                        type: "column",
+                        name: "ID",
+                        sourceName: "PRODUCTS",
+                      },
+                    },
+                  ],
+                },
+              ],
+              limit: 5,
+            },
+          ],
         },
         display: "table",
       });
@@ -222,18 +228,19 @@ describe("scenarios > question > settings", () => {
 
     it("should be okay showing an empty joined table (metabase#29140)", () => {
       // Orders join Products
-      H.visitQuestionAdhoc({
+      H.visitAdHocQuestionWithTestQuery({
         dataset_query: {
-          type: "query",
-          query: {
-            "source-table": ORDERS_ID,
-            fields: [
-              ["field", ORDERS.PRODUCT_ID, { "base-type": "type/Integer" }],
-              ["field", ORDERS.SUBTOTAL, { "base-type": "type/Float" }],
-            ],
-            limit: 5,
-          },
           database: SAMPLE_DB_ID,
+          stages: [
+            {
+              source: { type: "table", id: ORDERS_ID },
+              fields: [
+                { type: "column", name: "PRODUCT_ID", sourceName: "ORDERS" },
+                { type: "column", name: "SUBTOTAL", sourceName: "ORDERS" },
+              ],
+              limit: 5,
+            },
+          ],
         },
         display: "table",
       });
@@ -258,11 +265,10 @@ describe("scenarios > question > settings", () => {
     });
 
     it("should change to column formatting when sidebar is already open (metabase#16043)", () => {
-      H.visitQuestionAdhoc({
+      H.visitAdHocQuestionWithTestQuery({
         dataset_query: {
-          type: "query",
-          query: { "source-table": ORDERS_ID },
           database: SAMPLE_DB_ID,
+          stages: [{ source: { type: "table", id: ORDERS_ID } }],
         },
       });
 
@@ -292,11 +298,10 @@ describe("scenarios > question > settings", () => {
     it("should respect renamed column names in the settings sidebar (metabase#18476)", () => {
       const newColumnTitle = "Pre-tax";
 
-      const questionDetails = {
+      H.visitAdHocQuestionWithTestQuery({
         dataset_query: {
           database: SAMPLE_DB_ID,
-          query: { "source-table": ORDERS_ID },
-          type: "query",
+          stages: [{ source: { type: "table", id: ORDERS_ID } }],
         },
         display: "table",
         visualization_settings: {
@@ -306,9 +311,7 @@ describe("scenarios > question > settings", () => {
             },
           },
         },
-      };
-
-      H.visitQuestionAdhoc(questionDetails);
+      });
 
       // eslint-disable-next-line metabase/no-unscoped-text-selectors -- deprecated usage
       cy.findByText(newColumnTitle);
@@ -435,64 +438,59 @@ describe("scenarios > question > settings", () => {
       { tags: "@skip" },
       () => {
         // products joined to orders with breakouts on 3 product columns followed by a custom column
-        H.createQuestion(
-          {
-            name: "repro 22563",
-            query: {
-              "source-query": {
-                "source-table": ORDERS_ID,
+        H.createCardWithTestQuery({
+          name: "repro 22563",
+          dataset_query: {
+            database: SAMPLE_DB_ID,
+            stages: [
+              {
+                source: { type: "table", id: ORDERS_ID },
                 joins: [
                   {
-                    alias: "Products",
-                    condition: [
-                      "=",
-                      ["field", ORDERS.PRODUCT_ID, null],
-                      [
-                        "field",
-                        PRODUCTS.ID,
-                        {
-                          "join-alias": "Products",
+                    source: { type: "table", id: PRODUCTS_ID },
+                    strategy: "left-join",
+                    conditions: [
+                      {
+                        operator: "=",
+                        left: {
+                          type: "column",
+                          name: "PRODUCT_ID",
+                          sourceName: "ORDERS",
                         },
-                      ],
+                        right: {
+                          type: "column",
+                          name: "ID",
+                          sourceName: "PRODUCTS",
+                        },
+                      },
                     ],
-                    "source-table": PRODUCTS_ID,
                   },
                 ],
-                aggregation: [["count"]],
-                breakout: [
-                  [
-                    "field",
-                    PRODUCTS.CATEGORY,
-                    {
-                      "base-type": "type/Text",
-                      "join-alias": "Products",
-                    },
-                  ],
-                  [
-                    "field",
-                    PRODUCTS.TITLE,
-                    {
-                      "base-type": "type/Text",
-                      "join-alias": "Products",
-                    },
-                  ],
-                  [
-                    "field",
-                    PRODUCTS.VENDOR,
-                    {
-                      "base-type": "type/Text",
-                      "join-alias": "Products",
-                    },
-                  ],
+                aggregations: [{ type: "operator", operator: "count" }],
+                breakouts: [
+                  { type: "column", name: "CATEGORY", sourceName: "Products" },
+                  { type: "column", name: "TITLE", sourceName: "Products" },
+                  { type: "column", name: "VENDOR", sourceName: "Products" },
                 ],
               },
-              expressions: {
-                two: ["+", 1, 1],
+              {
+                expressions: [
+                  {
+                    name: "two",
+                    value: {
+                      type: "operator",
+                      operator: "+",
+                      args: [
+                        { type: "literal", value: 1 },
+                        { type: "literal", value: 1 },
+                      ],
+                    },
+                  },
+                ],
               },
-            },
+            ],
           },
-          { visitQuestion: true },
-        );
+        }).then(H.visitCard);
 
         const columnNames = [
           "Products → Category",

--- a/e2e/test/scenarios/question/summarization.cy.spec.js
+++ b/e2e/test/scenarios/question/summarization.cy.spec.js
@@ -216,45 +216,46 @@ describe("scenarios > question > summarize sidebar", () => {
   });
 
   it("should handle (removing) multiple metrics when one is sorted (metabase#12625)", () => {
-    H.createTestQuery({
-      database: SAMPLE_DB_ID,
-      stages: [
-        {
-          source: { type: "table", id: ORDERS_ID },
-          aggregations: [
-            { type: "operator", operator: "count" },
-            {
-              type: "operator",
-              operator: "sum",
-              args: [{ type: "column", name: "SUBTOTAL" }],
-            },
-            {
-              type: "operator",
-              operator: "sum",
-              args: [{ type: "column", name: "TOTAL" }],
-            },
-          ],
-          breakouts: [
-            {
-              type: "column",
-              name: "CREATED_AT",
-              sourceName: "ORDERS",
-              unit: "year",
-            },
-          ],
-          orderBys: [
-            {
-              direction: "desc",
-              type: "column",
-              name: "sum",
-              displayName: "Sum of Subtotal",
-            },
-          ],
-        },
-      ],
-    })
-      .then((dataset_query) => H.createCard({ name: "12625", dataset_query }))
-      .then((card) => H.visitQuestion(card.id));
+    H.createCardWithTestQuery({
+      name: "12625",
+      dataset_query: {
+        database: SAMPLE_DB_ID,
+        stages: [
+          {
+            source: { type: "table", id: ORDERS_ID },
+            aggregations: [
+              { type: "operator", operator: "count" },
+              {
+                type: "operator",
+                operator: "sum",
+                args: [{ type: "column", name: "SUBTOTAL" }],
+              },
+              {
+                type: "operator",
+                operator: "sum",
+                args: [{ type: "column", name: "TOTAL" }],
+              },
+            ],
+            breakouts: [
+              {
+                type: "column",
+                name: "CREATED_AT",
+                sourceName: "ORDERS",
+                unit: "year",
+              },
+            ],
+            orderBys: [
+              {
+                direction: "desc",
+                type: "column",
+                name: "sum",
+                displayName: "Sum of Subtotal",
+              },
+            ],
+          },
+        ],
+      },
+    }).then((card) => H.visitQuestion(card.id));
 
     H.summarize();
 

--- a/e2e/test/scenarios/question/summarization.cy.spec.js
+++ b/e2e/test/scenarios/question/summarization.cy.spec.js
@@ -5,7 +5,7 @@ import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
 
-const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
+const { ORDERS_ID } = SAMPLE_DATABASE;
 
 describe("scenarios > question > summarize sidebar", () => {
   beforeEach(() => {
@@ -112,32 +112,47 @@ describe("scenarios > question > summarize sidebar", () => {
   });
 
   it("should be able to do subsequent aggregation on a custom expression (metabase#14649)", () => {
-    H.createQuestion(
-      {
-        name: "14649_min",
-        query: {
-          "source-query": {
-            "source-table": ORDERS_ID,
-            aggregation: [
-              [
-                "aggregation-options",
-                ["sum", ["field", ORDERS.SUBTOTAL, null]],
-                { name: "Revenue", "display-name": "Revenue" },
-              ],
+    H.createCardWithTestQuery({
+      name: "14649_min",
+      dataset_query: {
+        database: SAMPLE_DB_ID,
+        stages: [
+          {
+            source: { type: "table", id: ORDERS_ID },
+            aggregations: [
+              {
+                name: "Revenue",
+                value: {
+                  type: "operator",
+                  operator: "sum",
+                  args: [
+                    { type: "column", name: "SUBTOTAL", sourceName: "ORDERS" },
+                  ],
+                },
+              },
             ],
-            breakout: [
-              ["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }],
+            breakouts: [
+              {
+                type: "column",
+                name: "CREATED_AT",
+                sourceName: "ORDERS",
+                unit: "month",
+              },
             ],
           },
-          aggregation: [
-            ["min", ["field", "Revenue", { "base-type": "type/Float" }]],
-          ],
-        },
-
-        display: "scalar",
+          {
+            aggregations: [
+              {
+                type: "operator",
+                operator: "min",
+                args: [{ type: "column", name: "Revenue" }],
+              },
+            ],
+          },
+        ],
       },
-      { visitQuestion: true },
-    );
+      display: "scalar",
+    }).then(H.visitCard);
 
     // eslint-disable-next-line metabase/no-unscoped-text-selectors -- deprecated usage
     cy.findByText("49.54");

--- a/e2e/test/scenarios/question/summarization.cy.spec.js
+++ b/e2e/test/scenarios/question/summarization.cy.spec.js
@@ -255,7 +255,7 @@ describe("scenarios > question > summarize sidebar", () => {
           },
         ],
       },
-    }).then((card) => H.visitQuestion(card.id));
+    }).then(H.visitCard);
 
     H.summarize();
 

--- a/frontend/src/metabase-types/api/query.ts
+++ b/frontend/src/metabase-types/api/query.ts
@@ -472,7 +472,15 @@ export type TestExpressionSpec =
 
 export type TestFilterSpec = TestExpressionSpec;
 
-export type TestAggregationSpec = TestExpressionSpec | TestNamedExpressionSpec;
+export type TestMetricSpec = {
+  type: "metric";
+  id: CardId;
+};
+
+export type TestAggregationSpec =
+  | TestMetricSpec
+  | TestExpressionSpec
+  | TestNamedExpressionSpec;
 
 export type TestNamedExpressionSpec = {
   name: string;

--- a/src/metabase/lib/query/test_spec.cljc
+++ b/src/metabase/lib/query/test_spec.cljc
@@ -276,9 +276,12 @@
   [query            :- ::lib.schema/query
    stage-number     :- :int
    aggregation-spec :- ::lib.schema.test-spec/test-aggregation-spec]
-  (->> (lib.aggregation/aggregable-columns query stage-number)
-       (expression-spec->expression-clause query stage-number aggregation-spec)
-       (lib.aggregation/aggregate query stage-number)))
+  (if (= :metric (:type aggregation-spec))
+    (->> (lib.metadata/metric query (:id aggregation-spec))
+         (lib.aggregation/aggregate query stage-number))
+    (->> (lib.aggregation/aggregable-columns query stage-number)
+         (expression-spec->expression-clause query stage-number aggregation-spec)
+         (lib.aggregation/aggregate query stage-number))))
 
 (mu/defn- append-aggregations  :- ::lib.schema/query
   [query             :- ::lib.schema/query

--- a/src/metabase/lib/schema/test_spec.cljc
+++ b/src/metabase/lib/schema/test_spec.cljc
@@ -110,8 +110,14 @@
    [:left [:ref ::test-join-source-spec]]
    [:right [:ref ::test-join-source-spec]]])
 
+(mr/def ::test-metric-spec
+  [:map
+   [:type [:= {:decode/normalize lib.schema.common/normalize-keyword} :metric]]
+   [:id [:ref ::lib.schema.id/card]]])
+
 (mr/def ::test-aggregation-spec
   [:or
+   [:ref ::test-metric-spec]
    [:ref ::test-expression-spec]
    [:ref ::test-named-expression-spec]])
 

--- a/test/metabase/lib/query/test_spec_test.cljc
+++ b/test/metabase/lib/query/test_spec_test.cljc
@@ -113,6 +113,17 @@
       (is (=? [[:count {}]]
               (lib/aggregations query))))))
 
+(deftest ^:parallel test-query-with-metric-aggregation-test
+  (testing "test-query adds a metric aggregation to the query"
+    (let [query (lib.query.test-spec/test-query
+                 lib.tu/metadata-provider-with-metric
+                 {:stages [{:source       {:type :table
+                                           :id   (meta/id :checkins)}
+                            :aggregations [{:type :metric
+                                            :id   1}]}]})]
+      (is (=? [[:metric {} 1]]
+              (lib/aggregations query))))))
+
 (deftest ^:parallel test-query-with-breakouts-test
   (testing "test-query adds breakouts to the query"
     (let [query (lib.query.test-spec/test-query


### PR DESCRIPTION
Closes GHY-2996

- Adds better helpers for writing e2e tests based on the lib helpers
- Adds a Claude skill to rewrite e2e tests to use the new lib helpers
- Rewrites lib helpers