### PR TITLE
Adds a side by side modal for users to view what has changed from the history tab

### DIFF
--- a/frontend/src/metabase/common/components/Timeline/RevisionDiffModal.module.css
+++ b/frontend/src/metabase/common/components/Timeline/RevisionDiffModal.module.css
@@ -1,0 +1,190 @@
+.modalBody {
+  overflow-y: auto;
+  max-height: calc(80vh - 100px);
+  padding: 1rem;
+}
+
+.fieldSection {
+  margin-bottom: 1.25rem;
+  border: 1px solid var(--mb-color-border);
+  border-radius: 0.375rem;
+  overflow: hidden;
+}
+
+.fieldLabel {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 0.375rem 0.75rem;
+  background: var(--mb-color-bg-light);
+  border: none;
+  border-bottom: 1px solid var(--mb-color-border);
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--mb-color-text-medium);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  text-align: left;
+  cursor: pointer;
+}
+
+.fieldLabel:hover {
+  background: var(--mb-color-bg-medium);
+}
+
+.chevron {
+  font-size: 1rem;
+  line-height: 1;
+  transition: transform 0.15s ease;
+  transform: rotate(-90deg);
+}
+
+.chevron::after {
+  content: "▾";
+}
+
+.chevronOpen {
+  transform: rotate(0deg);
+}
+
+.sideBySide {
+  display: flex;
+  overflow-x: auto;
+}
+
+.panel {
+  flex: 1;
+  min-width: 0;
+}
+
+.panelHeader {
+  padding: 0.25rem 0.75rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  border-bottom: 1px solid var(--mb-color-border);
+}
+
+.panelHeaderBefore {
+  background: color-mix(
+    in srgb,
+    var(--mb-color-error) 8%,
+    var(--mb-color-background-primary)
+  );
+  color: var(--mb-color-error);
+}
+
+.panelHeaderAfter {
+  background: color-mix(
+    in srgb,
+    var(--mb-color-success) 8%,
+    var(--mb-color-background-primary)
+  );
+  color: var(--mb-color-success);
+}
+
+.panelDivider {
+  width: 1px;
+  background: var(--mb-color-border);
+  flex-shrink: 0;
+}
+
+.panelContent {
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
+    monospace;
+  font-size: 0.75rem;
+  line-height: 1.6;
+}
+
+.diffRow {
+  display: flex;
+  align-items: stretch;
+  min-height: 1.5rem;
+}
+
+.unchangedRow {
+  background: transparent;
+}
+
+.removedRow {
+  background: color-mix(
+    in srgb,
+    var(--mb-color-error) 8%,
+    var(--mb-color-background-primary)
+  );
+}
+
+.addedRow {
+  background: color-mix(
+    in srgb,
+    var(--mb-color-success) 8%,
+    var(--mb-color-background-primary)
+  );
+}
+
+.emptyRow {
+  background: var(--mb-color-background-secondary);
+  min-height: 1.5rem;
+}
+
+.lineNum {
+  min-width: 2.5rem;
+  padding: 0 0.5rem;
+  text-align: right;
+  color: var(--mb-color-text-light);
+  user-select: none;
+  border-right: 1px solid var(--mb-color-border);
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.removedRow .lineNum {
+  background: color-mix(
+    in srgb,
+    var(--mb-color-error) 22%,
+    var(--mb-color-background-primary)
+  );
+  color: var(--mb-color-error);
+}
+
+.addedRow .lineNum {
+  background: color-mix(
+    in srgb,
+    var(--mb-color-success) 22%,
+    var(--mb-color-background-primary)
+  );
+  color: var(--mb-color-success);
+}
+
+.lineSign {
+  min-width: 1rem;
+  text-align: center;
+  flex-shrink: 0;
+  padding: 0 0.25rem;
+  font-weight: 700;
+}
+
+.removedRow .lineSign {
+  color: var(--mb-color-error);
+}
+
+.addedRow .lineSign {
+  color: var(--mb-color-success);
+}
+
+.lineContent {
+  padding: 0 0.5rem;
+  white-space: pre-wrap;
+  word-break: break-all;
+  flex: 1;
+  min-width: 0;
+}
+
+.noChanges {
+  padding: 2rem;
+  text-align: center;
+}

--- a/frontend/src/metabase/common/components/Timeline/RevisionDiffModal.tsx
+++ b/frontend/src/metabase/common/components/Timeline/RevisionDiffModal.tsx
@@ -1,0 +1,453 @@
+import { useState } from "react";
+import { t } from "ttag";
+
+import { Box, Modal, Text } from "metabase/ui";
+import type { Revision, RevisionDiff } from "metabase-types/api";
+import { isCardOrDashboardRevisionDiff } from "metabase-types/guards";
+
+import S from "./RevisionDiffModal.module.css";
+
+// ---------------------------------------------------------------------------
+// Diff algorithm (pure, no external libraries)
+// Implements LCS-based line diff, outputs side-by-side row pairs.
+// ---------------------------------------------------------------------------
+
+interface DiffSideCell {
+  lineNumber: number;
+  content: string;
+  type: "unchanged" | "removed" | "added";
+}
+
+interface DiffRow {
+  left: DiffSideCell | null;
+  right: DiffSideCell | null;
+}
+
+// ---------------------------------------------------------------------------
+// SQL detection helpers
+// ---------------------------------------------------------------------------
+
+interface LegacyNativeDatasetQuery {
+  type: "native";
+  native: { query: string; [key: string]: unknown };
+  [key: string]: unknown;
+}
+
+interface StagedNativeDatasetQuery {
+  stages: [{ native: string; [key: string]: unknown }, ...unknown[]];
+  [key: string]: unknown;
+}
+
+/** Returns true when a value is a legacy native (SQL) DatasetQuery object. */
+function isLegacyNativeDatasetQuery(
+  value: unknown,
+): value is LegacyNativeDatasetQuery {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as Record<string, unknown>)["type"] === "native" &&
+    typeof (value as LegacyNativeDatasetQuery).native?.query === "string"
+  );
+}
+
+/** Returns true when a value is an MBQL-5 staged native DatasetQuery object. */
+function isStagedNativeDatasetQuery(
+  value: unknown,
+): value is StagedNativeDatasetQuery {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const stages = (value as Record<string, unknown>)["stages"];
+  return (
+    Array.isArray(stages) &&
+    stages.length > 0 &&
+    typeof (stages[0] as Record<string, unknown>)["native"] === "string"
+  );
+}
+
+/** Returns the raw SQL string from either DatasetQuery format, or null. */
+function extractSql(value: unknown): string | null {
+  if (isLegacyNativeDatasetQuery(value)) {
+    return value.native.query;
+  }
+  if (isStagedNativeDatasetQuery(value)) {
+    return (value.stages[0] as Record<string, unknown>)["native"] as string;
+  }
+  return null;
+}
+
+/**
+ * Converts a revision field value to an array of display lines.
+ *
+ * Native DatasetQuery objects (both legacy and MBQL-5 stages format) have
+ * their SQL extracted and split on real newlines so the diff shows readable
+ * SQL rather than a JSON blob with escaped `\n` characters.
+ * All other objects fall back to JSON.
+ */
+function valueToLines(value: unknown): string[] {
+  if (value === null || value === undefined) {
+    return ["(empty)"];
+  }
+  const sql = extractSql(value);
+  if (sql !== null) {
+    // Split on real newlines for readable line diffs.
+    // JSON.stringify would escape `\n` → `\\n`, making multi-line SQL unreadable.
+    return sql.length === 0 ? ["(empty)"] : sql.split("\n");
+  }
+  if (typeof value === "object") {
+    return JSON.stringify(value, null, 2).split("\n");
+  }
+  return String(value).split("\n");
+}
+
+type EditOp =
+  | { type: "unchanged"; content: string }
+  | { type: "removed"; content: string }
+  | { type: "added"; content: string };
+
+/** Build an edit script from two line arrays using LCS backtracking. */
+function buildEditScript(
+  beforeLines: string[],
+  afterLines: string[],
+): EditOp[] {
+  const m = beforeLines.length;
+  const n = afterLines.length;
+
+  // dp[i][j] = length of LCS of beforeLines[0..i-1] and afterLines[0..j-1]
+  const dp: number[][] = Array.from({ length: m + 1 }, () =>
+    new Array<number>(n + 1).fill(0),
+  );
+
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      dp[i][j] =
+        beforeLines[i - 1] === afterLines[j - 1]
+          ? dp[i - 1][j - 1] + 1
+          : Math.max(dp[i - 1][j], dp[i][j - 1]);
+    }
+  }
+
+  // Backtrack
+  const ops: EditOp[] = [];
+  let i = m;
+  let j = n;
+
+  while (i > 0 || j > 0) {
+    if (i > 0 && j > 0 && beforeLines[i - 1] === afterLines[j - 1]) {
+      ops.unshift({ type: "unchanged", content: beforeLines[i - 1] });
+      i--;
+      j--;
+    } else if (j > 0 && (i === 0 || dp[i][j - 1] >= dp[i - 1][j])) {
+      ops.unshift({ type: "added", content: afterLines[j - 1] });
+      j--;
+    } else {
+      ops.unshift({ type: "removed", content: beforeLines[i - 1] });
+      i--;
+    }
+  }
+
+  return ops;
+}
+
+/**
+ * Converts an edit script into side-by-side row pairs suitable for rendering.
+ * Consecutive removed/added blocks are paired up horizontally.
+ */
+function toSideBySideRows(ops: EditOp[]): DiffRow[] {
+  const rows: DiffRow[] = [];
+  let leftLineNum = 1;
+  let rightLineNum = 1;
+  let idx = 0;
+
+  while (idx < ops.length) {
+    const op = ops[idx];
+
+    if (op.type === "unchanged") {
+      rows.push({
+        left: {
+          lineNumber: leftLineNum++,
+          content: op.content,
+          type: "unchanged",
+        },
+        right: {
+          lineNumber: rightLineNum++,
+          content: op.content,
+          type: "unchanged",
+        },
+      });
+      idx++;
+    } else {
+      // Collect all adjacent removes then adds and pair them side-by-side
+      const removed: string[] = [];
+      const added: string[] = [];
+
+      while (idx < ops.length && ops[idx].type === "removed") {
+        removed.push(ops[idx].content);
+        idx++;
+      }
+      while (idx < ops.length && ops[idx].type === "added") {
+        added.push(ops[idx].content);
+        idx++;
+      }
+
+      const maxLen = Math.max(removed.length, added.length);
+      for (let k = 0; k < maxLen; k++) {
+        rows.push({
+          left:
+            k < removed.length
+              ? {
+                  lineNumber: leftLineNum++,
+                  content: removed[k],
+                  type: "removed",
+                }
+              : null,
+          right:
+            k < added.length
+              ? { lineNumber: rightLineNum++, content: added[k], type: "added" }
+              : null,
+        });
+      }
+    }
+  }
+
+  return rows;
+}
+
+function computeLineDiff(
+  beforeLines: string[],
+  afterLines: string[],
+): DiffRow[] {
+  return toSideBySideRows(buildEditScript(beforeLines, afterLines));
+}
+
+// ---------------------------------------------------------------------------
+// Diff normalizer: converts either RevisionDiff variant into flat key/value pairs
+// ---------------------------------------------------------------------------
+
+interface NormalizedFieldDiff {
+  key: string;
+  beforeValue: unknown;
+  afterValue: unknown;
+}
+
+function normalizeRevisionDiff(diff: RevisionDiff): NormalizedFieldDiff[] {
+  if (isCardOrDashboardRevisionDiff(diff)) {
+    const allKeys = Array.from(
+      new Set([...Object.keys(diff.before), ...Object.keys(diff.after)]),
+    );
+    return allKeys.map((key) => ({
+      key,
+      beforeValue: diff.before[key],
+      afterValue: diff.after[key],
+    }));
+  }
+  // SegmentRevisionDiff: { name?: FieldDiff, description?: FieldDiff, definition?: FieldDiff }
+  return Object.entries(diff).map(([key, fieldDiff]) => ({
+    key,
+    beforeValue: (fieldDiff as { before?: unknown } | undefined)?.before,
+    afterValue: (fieldDiff as { after?: unknown } | undefined)?.after,
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Rendering helpers
+// ---------------------------------------------------------------------------
+
+function formatFieldName(key: string): string {
+  return key.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+/**
+ * Returns the human-readable section header for a diff field, taking the
+ * actual value into account so that native SQL queries are labelled
+ * "SQL Query" rather than the raw key name ("Definition").
+ */
+function fieldDisplayName(
+  key: string,
+  beforeValue: unknown,
+  afterValue: unknown,
+): string {
+  if (extractSql(beforeValue) !== null || extractSql(afterValue) !== null) {
+    return t`SQL Query`;
+  }
+  return formatFieldName(key);
+}
+
+function rowClassName(
+  type: "unchanged" | "removed" | "added" | "empty",
+): string {
+  if (type === "removed") {
+    return `${S.diffRow} ${S.removedRow}`;
+  }
+  if (type === "added") {
+    return `${S.diffRow} ${S.addedRow}`;
+  }
+  if (type === "empty") {
+    return `${S.diffRow} ${S.emptyRow}`;
+  }
+  return `${S.diffRow} ${S.unchangedRow}`;
+}
+
+function lineSign(type: "unchanged" | "removed" | "added"): string {
+  if (type === "removed") {
+    return "-";
+  }
+  if (type === "added") {
+    return "+";
+  }
+  return " ";
+}
+
+interface DiffPanelProps {
+  rows: DiffRow[];
+  side: "left" | "right";
+}
+
+function DiffPanel({ rows, side }: DiffPanelProps) {
+  const isLeft = side === "left";
+  return (
+    <div className={S.panel}>
+      <div
+        className={`${S.panelHeader} ${isLeft ? S.panelHeaderBefore : S.panelHeaderAfter}`}
+      >
+        {isLeft ? t`Before` : t`After`}
+      </div>
+      <div className={S.panelContent}>
+        {rows.map((row, idx) => {
+          const cell = isLeft ? row.left : row.right;
+
+          if (!cell) {
+            return <div key={idx} className={rowClassName("empty")} />;
+          }
+
+          const { lineNumber, content, type } = cell;
+
+          return (
+            <div key={idx} className={rowClassName(type)}>
+              <span className={S.lineNum}>{lineNumber}</span>
+              <span className={S.lineSign}>{lineSign(type)}</span>
+              <span className={S.lineContent}>{content}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+interface FieldDiffSectionProps {
+  fieldKey: string;
+  beforeValue: unknown;
+  afterValue: unknown;
+}
+
+function FieldDiffSection({
+  fieldKey,
+  beforeValue,
+  afterValue,
+}: FieldDiffSectionProps) {
+  const [isOpen, setIsOpen] = useState(true);
+
+  const beforeLines = valueToLines(beforeValue);
+  const afterLines = valueToLines(afterValue);
+  const rows = computeLineDiff(beforeLines, afterLines);
+
+  const hasChanges = rows.some(
+    (row) => row.left?.type === "removed" || row.right?.type === "added",
+  );
+
+  if (!hasChanges) {
+    return null;
+  }
+
+  return (
+    <div className={S.fieldSection}>
+      <button
+        className={S.fieldLabel}
+        onClick={() => setIsOpen((o) => !o)}
+        aria-expanded={isOpen}
+      >
+        <span>{fieldDisplayName(fieldKey, beforeValue, afterValue)}</span>
+        <span
+          className={`${S.chevron} ${isOpen ? S.chevronOpen : ""}`}
+          aria-hidden="true"
+        />
+      </button>
+      {isOpen && (
+        <div className={S.sideBySide}>
+          <DiffPanel rows={rows} side="left" />
+          <div className={S.panelDivider} />
+          <DiffPanel rows={rows} side="right" />
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main exported component
+// ---------------------------------------------------------------------------
+
+interface RevisionDiffModalProps {
+  revision: Revision;
+  onClose: () => void;
+}
+
+export function RevisionDiffModal({
+  revision,
+  onClose,
+}: RevisionDiffModalProps) {
+  const { diff, user, timestamp, description } = revision;
+
+  const date = new Date(timestamp).toLocaleString();
+
+  const modalTitle = (
+    <div>
+      <Text fw={700} size="sm">
+        {t`Changes by ${user.common_name}`}
+      </Text>
+      <Text size="xs" c="text-secondary">
+        {description} &middot; {date}
+      </Text>
+    </div>
+  );
+
+  if (!diff) {
+    return (
+      <Modal opened onClose={onClose} title={modalTitle} size="lg">
+        <Box p="md" className={S.noChanges}>
+          <Text c="text-secondary">{t`No detailed diff available for this revision.`}</Text>
+        </Box>
+      </Modal>
+    );
+  }
+
+  const normalizedFields = normalizeRevisionDiff(diff);
+
+  return (
+    <Modal
+      opened
+      onClose={onClose}
+      title={modalTitle}
+      size={1050}
+      styles={{ body: { padding: 0 } }}
+    >
+      <Box className={S.modalBody}>
+        {normalizedFields.length === 0 ? (
+          <Box p="md" className={S.noChanges}>
+            <Text c="text-secondary">{t`No field-level changes to display.`}</Text>
+          </Box>
+        ) : (
+          normalizedFields.map(({ key, beforeValue, afterValue }) => (
+            <FieldDiffSection
+              key={key}
+              fieldKey={key}
+              beforeValue={beforeValue}
+              afterValue={afterValue}
+            />
+          ))
+        )}
+      </Box>
+    </Modal>
+  );
+}

--- a/frontend/src/metabase/common/components/Timeline/RevisionDiffModal.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/Timeline/RevisionDiffModal.unit.spec.tsx
@@ -1,0 +1,190 @@
+import userEvent from "@testing-library/user-event";
+
+import { render, screen } from "__support__/ui";
+import { createMockRevision } from "metabase-types/api/mocks/revision";
+
+import { RevisionDiffModal } from "./RevisionDiffModal";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function setup(opts?: Partial<Parameters<typeof RevisionDiffModal>[0]>) {
+  const onClose = jest.fn();
+  render(
+    <RevisionDiffModal
+      revision={createMockRevision({
+        is_creation: false,
+        description: "Updated title",
+        user: {
+          id: 1,
+          first_name: "Alice",
+          last_name: "Smith",
+          common_name: "Alice Smith",
+        },
+        diff: {
+          before: { title: "Old Title" },
+          after: { title: "New Title" },
+        },
+      })}
+      onClose={onClose}
+      {...opts}
+    />,
+  );
+  return { onClose };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("RevisionDiffModal", () => {
+  describe("modal header", () => {
+    it("shows the user name and revision description", () => {
+      setup();
+      expect(screen.getByText("Changes by Alice Smith")).toBeInTheDocument();
+      expect(screen.getByText(/Updated title/)).toBeInTheDocument();
+    });
+  });
+
+  describe("when diff is null", () => {
+    it("shows a fallback message", () => {
+      setup({
+        revision: createMockRevision({ is_creation: false, diff: null }),
+      });
+      expect(
+        screen.getByText("No detailed diff available for this revision."),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("when diff has no field keys", () => {
+    it("shows a no-changes message", () => {
+      setup({
+        revision: createMockRevision({
+          is_creation: false,
+          diff: { before: {}, after: {} },
+        }),
+      });
+      expect(
+        screen.getByText("No field-level changes to display."),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("field diff sections", () => {
+    it("renders a labelled section for each changed field", () => {
+      setup({
+        revision: createMockRevision({
+          is_creation: false,
+          diff: {
+            before: { title: "Old Title", description: "Old desc" },
+            after: { title: "New Title", description: "New desc" },
+          },
+        }),
+      });
+      expect(screen.getByText("Title")).toBeInTheDocument();
+      expect(screen.getByText("Description")).toBeInTheDocument();
+    });
+
+    it("shows 'Before' and 'After' panel headers", () => {
+      setup();
+      expect(screen.getByText("Before")).toBeInTheDocument();
+      expect(screen.getByText("After")).toBeInTheDocument();
+    });
+
+    it("does not render a section for fields with no actual changes", () => {
+      setup({
+        revision: createMockRevision({
+          is_creation: false,
+          diff: {
+            before: { title: "Same Title", description: "Old desc" },
+            after: { title: "Same Title", description: "New desc" },
+          },
+        }),
+      });
+      // "title" field is unchanged — its section header should not appear
+      expect(screen.queryByText("Title")).not.toBeInTheDocument();
+      // changed field still renders
+      expect(screen.getByText("Description")).toBeInTheDocument();
+    });
+
+    it("labels native SQL query fields as 'SQL Query'", () => {
+      setup({
+        revision: createMockRevision({
+          is_creation: false,
+          diff: {
+            before: {
+              dataset_query: {
+                type: "native",
+                native: { query: "SELECT 1 FROM orders" },
+              },
+            },
+            after: {
+              dataset_query: {
+                type: "native",
+                native: { query: "SELECT 2 FROM orders" },
+              },
+            },
+          },
+        }),
+      });
+      expect(screen.getByText("SQL Query")).toBeInTheDocument();
+      expect(screen.queryByText("Dataset Query")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("collapsible sections", () => {
+    it("sections are expanded by default", () => {
+      setup();
+      expect(screen.getByText("Before")).toBeInTheDocument();
+      expect(screen.getByText("After")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Title" })).toHaveAttribute(
+        "aria-expanded",
+        "true",
+      );
+    });
+
+    it("collapses a section when its header is clicked", async () => {
+      setup();
+      await userEvent.click(screen.getByRole("button", { name: "Title" }));
+      expect(screen.queryByText("Before")).not.toBeInTheDocument();
+      expect(screen.queryByText("After")).not.toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Title" })).toHaveAttribute(
+        "aria-expanded",
+        "false",
+      );
+    });
+
+    it("re-expands a collapsed section when its header is clicked again", async () => {
+      setup();
+      const header = screen.getByRole("button", { name: "Title" });
+      await userEvent.click(header);
+      await userEvent.click(header);
+      expect(screen.getByText("Before")).toBeInTheDocument();
+      expect(screen.getByText("After")).toBeInTheDocument();
+      expect(header).toHaveAttribute("aria-expanded", "true");
+    });
+
+    it("collapses each section independently", async () => {
+      setup({
+        revision: createMockRevision({
+          is_creation: false,
+          diff: {
+            before: { title: "Old Title", description: "Old desc" },
+            after: { title: "New Title", description: "New desc" },
+          },
+        }),
+      });
+      await userEvent.click(screen.getByRole("button", { name: "Title" }));
+      // Title section collapsed; Description section still expanded
+      expect(screen.getByRole("button", { name: "Title" })).toHaveAttribute(
+        "aria-expanded",
+        "false",
+      );
+      expect(
+        screen.getByRole("button", { name: "Description" }),
+      ).toHaveAttribute("aria-expanded", "true");
+    });
+  });
+});

--- a/frontend/src/metabase/common/components/Timeline/Timeline.module.css
+++ b/frontend/src/metabase/common/components/Timeline/Timeline.module.css
@@ -1,0 +1,21 @@
+.timestampRow {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.viewDiffButton {
+  font-size: 0.75rem;
+  padding: 0;
+  height: auto;
+  color: var(--mb-color-brand);
+  cursor: pointer;
+  background: none;
+  border: none;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.viewDiffButton:hover {
+  color: var(--mb-color-brand-hover);
+}

--- a/frontend/src/metabase/common/components/Timeline/Timeline.tsx
+++ b/frontend/src/metabase/common/components/Timeline/Timeline.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
@@ -8,6 +9,8 @@ import type { RevisionOrModerationEvent } from "metabase/plugins";
 import { Icon, Tooltip } from "metabase/ui";
 import type { Revision } from "metabase-types/api";
 
+import { RevisionDiffModal } from "./RevisionDiffModal";
+import S from "./Timeline.module.css";
 import {
   Border,
   EventBody,
@@ -35,47 +38,70 @@ export function Timeline({
   className,
   entity,
 }: TimelineProps) {
-  return (
-    <TimelineContainer className={className} data-testid={dataTestId}>
-      {events.map((event, index) => {
-        const { icon, title, description, timestamp, revision } = event;
-        const isNotLastEvent = index !== events.length - 1;
-        const isNotFirstEvent = index !== 0;
+  const [diffRevision, setDiffRevision] = useState<Revision | null>(null);
 
-        return (
-          <TimelineEvent key={revision?.id ?? `${title}-${timestamp}`}>
-            {isNotLastEvent && <Border />}
-            <EventIcon icon={icon} />
-            <EventBody>
-              <EventHeader>
-                <span>{title}</span>
-                {revision && canWrite && isNotFirstEvent && (
-                  <Tooltip label={t`Revert to this version`}>
-                    <Button
-                      icon="revert"
-                      onlyIcon
-                      borderless
-                      onClick={() => {
-                        trackVersionRevertClicked(entity);
-                        revert(revision);
-                      }}
-                      data-testid="question-revert-button"
-                      aria-label={t`revert to ${title}`}
-                    />
+  return (
+    <>
+      <TimelineContainer className={className} data-testid={dataTestId}>
+        {events.map((event, index) => {
+          const { icon, title, description, timestamp, revision } = event;
+          const isNotLastEvent = index !== events.length - 1;
+          const isNotFirstEvent = index !== 0;
+
+          return (
+            <TimelineEvent key={revision?.id ?? `${title}-${timestamp}`}>
+              {isNotLastEvent && <Border />}
+              <EventIcon icon={icon} />
+              <EventBody>
+                <EventHeader>
+                  <span>{title}</span>
+                  {revision && canWrite && isNotFirstEvent && (
+                    <Tooltip label={t`Revert to this version`}>
+                      <Button
+                        icon="revert"
+                        onlyIcon
+                        borderless
+                        onClick={() => {
+                          trackVersionRevertClicked(entity);
+                          revert(revision);
+                        }}
+                        data-testid="question-revert-button"
+                        aria-label={t`revert to ${title}`}
+                      />
+                    </Tooltip>
+                  )}
+                </EventHeader>
+                <div className={S.timestampRow}>
+                  <Tooltip
+                    position="bottom"
+                    label={getFormattedTime(timestamp)}
+                  >
+                    <Timestamp dateTime={timestamp}>
+                      {getRelativeTime(timestamp)}
+                    </Timestamp>
                   </Tooltip>
-                )}
-              </EventHeader>
-              <Tooltip position="bottom" label={getFormattedTime(timestamp)}>
-                <Timestamp dateTime={timestamp}>
-                  {getRelativeTime(timestamp)}
-                </Timestamp>
-              </Tooltip>
-              {revision?.has_multiple_changes && <div>{description}</div>}
-            </EventBody>
-          </TimelineEvent>
-        );
-      })}
-    </TimelineContainer>
+                  {revision?.diff && !revision.is_creation && (
+                    <button
+                      className={S.viewDiffButton}
+                      onClick={() => setDiffRevision(revision)}
+                    >
+                      {t`View diff`}
+                    </button>
+                  )}
+                </div>
+                {revision?.has_multiple_changes && <div>{description}</div>}
+              </EventBody>
+            </TimelineEvent>
+          );
+        })}
+      </TimelineContainer>
+      {diffRevision && (
+        <RevisionDiffModal
+          revision={diffRevision}
+          onClose={() => setDiffRevision(null)}
+        />
+      )}
+    </>
   );
 }
 


### PR DESCRIPTION
Closes (or attempts to address) https://github.com/metabase/metabase/issues/15763

### Description

At the moment, users only get minimal information what has changed on questions or dashboards. This pull request attempts to add a diff viewer that compares the changes side by side. It doesn't exactly address the feature request requested in issue 15763, which is asking for a full blown pre rendering of the previous version, similar to something Google doc/ Notion or Confluence have. 

This pull request aims to be more of a **proof of concept** (built with Claude Code), happy to address any feedback, comments and build it properly if the general direction is accepted!

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Create a question or dashboard
2. Edit the question/ dashboard (title, sql etc...)
3. Go to history from the information side panel.
4. See the clickable text (View diff) and see the differences displayed.

### Demo

https://github.com/user-attachments/assets/db14217e-fd81-4cc5-b517-5cf6130c4d51


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
