### PR TITLE
support multiple join conditions in join-analysis lens

### DIFF
--- a/src/metabase/transforms_inspector/context.clj
+++ b/src/metabase/transforms_inspector/context.clj
@@ -215,9 +215,7 @@
    [:alias [:maybe :string]]
    [:source-table {:optional true} [:maybe pos-int?]]
    [:join-table :any]
-   [:join-condition :any]
-   [:lhs-column :any]
-   [:rhs-column :any]])
+   [:join-condition :any]])
 
 (mr/def ::mbql-context
   "MBQL-specific context."

--- a/src/metabase/transforms_inspector/lens/join_analysis.clj
+++ b/src/metabase/transforms_inspector/lens/join_analysis.clj
@@ -3,7 +3,7 @@
 
    Cards returned:
    - base-count: COUNT(*) with 0 joins
-   - join-step-N: [COUNT(*), COUNT(nullable_field)] for each join step
+   - join-step-N: [COUNT(*), COUNT(CASE WHEN join_condition THEN 1 END)] for each join step
    - table-N-count: COUNT(*) for each joined table (right-row-count)
 
    FE derives from card results:
@@ -18,6 +18,7 @@
    [metabase.lib-be.core :as lib-be]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
+   [metabase.lib.util :as lib.util]
    [metabase.transforms-inspector.lens.core :as lens.core]
    [metabase.transforms-inspector.lens.query-util :as query-util]
    [metabase.util.i18n :refer [tru trun]]))
@@ -31,32 +32,28 @@
   [ctx]
   (:join-structure (or (:mbql-context ctx) (:native-context ctx))))
 
+(defn- outer-join?
+  [strategy]
+  (contains? #{:left-join :right-join :full-join} strategy))
+
 ;;; -------------------------------------------------- MBQL Query Building --------------------------------------------------
 
 (defn- make-count-query
   [query]
   (lib/aggregate query (lib/count)))
 
-(defn- nullable-side-field-info
-  "For outer joins, return the field info for the side that becomes NULL on non-match.
-   LEFT  → RHS is nullable, RIGHT → LHS is nullable, FULL → RHS (detects left-unmatched)."
-  [join]
-  (let [strategy (or (:strategy join) :left-join)]
-    (case strategy
-      (:left-join :full-join) (query-util/get-rhs-field-info (:conditions join))
-      :right-join             (query-util/get-lhs-field-info (:conditions join))
-      nil)))
-
 (defn- make-join-step-query-mbql
-  "Query returning [COUNT(*), COUNT(nullable_field)] for outer joins, [COUNT(*)] otherwise."
+  "Query returning [COUNT(*), COUNT(CASE WHEN join_condition THEN 1 END)] for outer joins, [COUNT(*)] otherwise."
   [query step join]
-  (let [field-info (nullable-side-field-info join)
+  (let [strategy   (or (:strategy join) :left-join)
+        outer?     (outer-join? strategy)
         step-query (-> query (query-util/bare-query-with-n-joins step) make-count-query)]
-    (if field-info
-      (let [mp (lib-be/application-database-metadata-provider (:database query))
-            field-meta (-> (lib.metadata/field mp (:field-id field-info))
-                           (lib/with-join-alias (:join-alias field-info)))]
-        (lib/aggregate step-query (lib/count field-meta)))
+    (if outer?
+      (let [conditions (:conditions join)
+            combined   (if (= 1 (count conditions))
+                         (first conditions)
+                         (apply lib/and conditions))]
+        (lib/aggregate step-query (lib/count (lib/case [[(lib.util/fresh-uuids combined) 1]]))))
       step-query)))
 
 (defn- make-table-count-query
@@ -68,15 +65,6 @@
 
 ;;; -------------------------------------------------- Native SQL Building --------------------------------------------------
 
-(defn- nullable-side-column
-  "For outer joins, return the HoneySQL column ref for the side that becomes NULL on non-match.
-   LEFT/FULL → rhs-column, RIGHT → lhs-column."
-  [{:keys [strategy rhs-column lhs-column]}]
-  (case strategy
-    (:left-join :full-join) rhs-column
-    :right-join             lhs-column
-    nil))
-
 (def ^:private strategy->hsql-join-type
   "Map our join strategy keywords to HoneySQL :join-by type keywords.
    HoneySQL uses :join for INNER JOIN, not :inner-join."
@@ -87,15 +75,17 @@
    :cross-join :cross-join})
 
 (defn- build-native-join-step-hsql
-  "Build a HoneySQL map for [COUNT(*), COUNT(nullable_field)] with joins.
+  "Build a HoneySQL map for [COUNT(*), COUNT(CASE WHEN condition THEN 1 END)] with joins.
    Uses :join-by to preserve original join ordering across different join types."
   [from-table joins]
-  (let [col      (nullable-side-column (last joins))
-        join-by  (into [] (mapcat (fn [{:keys [strategy join-table join-condition]}]
-                                    [(strategy->hsql-join-type strategy) [join-table join-condition]]))
-                       joins)]
-    {:select (if col
-               [[[:count :*]] [[:count col]]]
+  (let [last-join  (last joins)
+        outer?     (outer-join? (:strategy last-join))
+        condition  (:join-condition last-join)
+        join-by    (into [] (mapcat (fn [{:keys [strategy join-table join-condition]}]
+                                      [(strategy->hsql-join-type strategy) [join-table join-condition]]))
+                         joins)]
+    {:select (if (and outer? condition)
+               [[[:count :*]] [[:count [:case condition 1]]]]
                [[[:count :*]]])
      :from   [from-table]
      :join-by join-by}))
@@ -196,8 +186,7 @@
 (defn- make-triggers
   "Generate alert and drill-lens triggers for join steps."
   [join-structure params]
-  (let [outer-joins (filter #(contains? #{:left-join :right-join :full-join}
-                                        (:strategy %))
+  (let [outer-joins (filter #(outer-join? (:strategy %))
                             (map-indexed #(assoc %2 :step (inc %1)) join-structure))]
     {:alert_triggers
      (for [{:keys [step alias strategy]} outer-joins]

--- a/src/metabase/transforms_inspector/lens/join_analysis.clj
+++ b/src/metabase/transforms_inspector/lens/join_analysis.clj
@@ -85,7 +85,7 @@
                                       [(strategy->hsql-join-type strategy) [join-table join-condition]]))
                          joins)]
     {:select (if (and outer? condition)
-               [[[:count :*]] [[:count [:case condition 1]]]]
+               [[[:count :*]] [[:count [:case condition [:inline 1]]]]]
                [[[:count :*]]])
      :from   [from-table]
      :join-by join-by}))

--- a/src/metabase/transforms_inspector/query_analysis.clj
+++ b/src/metabase/transforms_inspector/query_analysis.clj
@@ -144,20 +144,6 @@
           (when (and left-hsql right-hsql)
             [(keyword operator) left-hsql right-hsql]))))))
 
-(defn- column-from-ast
-  "Extract the column on `side` (:left or :right) from a single equality join condition.
-   Returns nil for compound (AND/OR) or multi-condition joins — we only analyze
-   simple single-condition joins."
-  [side conditions]
-  (let [conditions-list (if (sequential? conditions) conditions [conditions])
-        condition       (when (= 1 (count conditions-list)) (first conditions-list))]
-    (when (and condition
-               (= (:type condition) :macaw.ast/binary-expression)
-               (not (contains? #{"AND" "OR"} (u/upper-case-en (str (:operator condition))))))
-      (let [node (case side :left (:left condition) :right (:right condition))]
-        (when (= (:type node) :macaw.ast/column)
-          node)))))
-
 (defn- build-join-condition-hsql
   "Build a HoneySQL condition form from a macaw join node's conditions."
   [driver ast-node]
@@ -192,14 +178,11 @@
 
 (defn- extract-native-join-structure
   "Extract join structure from macaw AST as HoneySQL data.
-   Returns join info with :join-table, :join-condition, :lhs-column, :rhs-column as HoneySQL forms."
+   Returns join info with :join-table and :join-condition as HoneySQL forms."
   [ast table->id driver]
   (when-let [join-nodes (:join ast)]
     (mapv (fn [join-node]
-            (let [strategy (ast-join-type->strategy (:join-type join-node))
-                  is-outer? (contains? #{:left-join :right-join :full-join} strategy)
-                  lhs-col (when is-outer? (column-from-ast :left (:condition join-node)))
-                  rhs-col (when is-outer? (column-from-ast :right (:condition join-node)))]
+            (let [strategy (ast-join-type->strategy (:join-type join-node))]
               {:strategy       strategy
                :alias          (sql.normalize/normalize-name
                                 driver
@@ -209,9 +192,7 @@
                                            driver
                                            (get-in join-node [:source :table])))
                :join-table     (macaw-table->hsql driver (:source join-node))
-               :join-condition (build-join-condition-hsql driver join-node)
-               :lhs-column     (when lhs-col (macaw-column->hsql driver lhs-col))
-               :rhs-column     (when rhs-col (macaw-column->hsql driver rhs-col))}))
+               :join-condition (build-join-condition-hsql driver join-node)}))
           join-nodes)))
 
 (defn- resolve-native-visited-fields

--- a/test/metabase/transforms_inspector/lens/join_analysis_test.clj
+++ b/test/metabase/transforms_inspector/lens/join_analysis_test.clj
@@ -1,0 +1,101 @@
+(ns ^:mb/driver-tests metabase.transforms-inspector.lens.join-analysis-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
+   [metabase.query-processor.preprocess :as qp.preprocess]
+   [metabase.test :as mt]
+   [metabase.transforms-inspector.lens.join-analysis :as join-analysis]
+   [metabase.transforms.util :as transforms.util]))
+
+(set! *warn-on-reflection* true)
+
+(comment join-analysis/keep-me)
+
+;;; -------------------------------------------------- Native (HoneySQL) tests --------------------------------------------------
+
+(deftest build-native-join-step-hsql-single-condition-test
+  (testing "single-condition left join uses COUNT(CASE WHEN condition THEN 1 END)"
+    (let [joins [{:strategy       :left-join
+                  :join-table     :products
+                  :join-condition [:= :orders.product_id :products.id]}]]
+      (is (= {:select   [[[:count :*]] [[:count [:case [:= :orders.product_id :products.id] [:inline 1]]]]]
+              :from     [:orders]
+              :join-by  [:left-join [:products [:= :orders.product_id :products.id]]]}
+             (#'join-analysis/build-native-join-step-hsql :orders joins))))))
+
+(deftest build-native-join-step-hsql-multi-condition-test
+  (testing "multi-condition left join uses the full AND condition in CASE WHEN"
+    (let [condition [:and [:= :t1.id :t2.id] [:= :t1.foo :t2.foo]]
+          joins     [{:strategy       :left-join
+                      :join-table     :t2
+                      :join-condition condition}]]
+      (is (= {:select   [[[:count :*]] [[:count [:case condition [:inline 1]]]]]
+              :from     [:t1]
+              :join-by  [:left-join [:t2 condition]]}
+             (#'join-analysis/build-native-join-step-hsql :t1 joins))))))
+
+(deftest build-native-join-step-hsql-right-join-test
+  (testing "right join also uses CASE WHEN condition"
+    (let [joins [{:strategy       :right-join
+                  :join-table     :products
+                  :join-condition [:= :orders.product_id :products.id]}]]
+      (is (= {:select   [[[:count :*]] [[:count [:case [:= :orders.product_id :products.id] [:inline 1]]]]]
+              :from     [:orders]
+              :join-by  [:right-join [:products [:= :orders.product_id :products.id]]]}
+             (#'join-analysis/build-native-join-step-hsql :orders joins))))))
+
+;;; -------------------------------------------------- MBQL tests --------------------------------------------------
+
+(defn- preprocess-query-with-join
+  "Build and preprocess a query with a single left join between orders and products."
+  []
+  (let [mp (mt/metadata-provider)]
+    (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
+        (lib/join (-> (lib/join-clause
+                       (lib.metadata/table mp (mt/id :products))
+                       [(lib/= (lib.metadata/field mp (mt/id :orders :product_id))
+                               (-> (lib.metadata/field mp (mt/id :products :id))
+                                   (lib/with-join-alias "Products")))])
+                      (lib/with-join-alias "Products")
+                      (lib/with-join-fields :all)))
+        transforms.util/massage-sql-query
+        qp.preprocess/preprocess)))
+
+(defn- preprocess-query-with-multi-condition-join
+  "Build and preprocess a query with a multi-condition left join."
+  []
+  (let [mp (mt/metadata-provider)]
+    (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
+        (lib/join (-> (lib/join-clause
+                       (lib.metadata/table mp (mt/id :products))
+                       [(lib/= (lib.metadata/field mp (mt/id :orders :product_id))
+                               (-> (lib.metadata/field mp (mt/id :products :id))
+                                   (lib/with-join-alias "Products")))
+                        (lib/> (lib.metadata/field mp (mt/id :orders :quantity))
+                               (-> (lib.metadata/field mp (mt/id :products :rating))
+                                   (lib/with-join-alias "Products")))])
+                      (lib/with-join-alias "Products")
+                      (lib/with-join-fields :all)))
+        transforms.util/massage-sql-query
+        qp.preprocess/preprocess)))
+
+(deftest make-join-step-query-mbql-single-condition-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :left-join)
+    (testing "single-condition left join produces two aggregations: COUNT(*) and COUNT(CASE ...)"
+      (let [preprocessed (preprocess-query-with-join)
+            join         (first (lib/joins preprocessed 0))
+            result       (#'join-analysis/make-join-step-query-mbql preprocessed 1 join)
+            aggs         (lib/aggregations result 0)]
+        (is (= 2 (count aggs))
+            "should have COUNT(*) and COUNT(CASE WHEN condition THEN 1 END)")))))
+
+(deftest make-join-step-query-mbql-multi-condition-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :left-join)
+    (testing "multi-condition left join still produces two aggregations"
+      (let [preprocessed (preprocess-query-with-multi-condition-join)
+            join         (first (lib/joins preprocessed 0))
+            result       (#'join-analysis/make-join-step-query-mbql preprocessed 1 join)
+            aggs         (lib/aggregations result 0)]
+        (is (= 2 (count aggs))
+            "multi-condition join should still produce COUNT(*) + COUNT(CASE WHEN ... AND ... THEN 1 END)")))))


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-1868/deal-with-multi-join-conditions-for-inspector

Instead of `count (nullable_column)` and baling on join conditions with multiple expressions, emit `count(case when condition then 1 end)` instead