### PR TITLE
fix stress tests for sdk component tests

### DIFF
--- a/e2e/support/cypress-stress-test.config.js
+++ b/e2e/support/cypress-stress-test.config.js
@@ -1,6 +1,9 @@
 const { defineConfig } = require("cypress");
 
-const { defaultConfig, embeddingSdkComponentTestConfig } = require("./config");
+const { defaultConfig } = require("./config");
+const {
+  component: embeddingSdkComponentTestConfig,
+} = require("./cypress-embedding-sdk-component-test.config");
 
 module.exports = defineConfig({
   e2e: { ...defaultConfig, retries: 0 },


### PR DESCRIPTION
closes EMB-1376

Fixes a bug introduced with  [remove sdk import error on core app e2e tests](https://github.com/metabase/metabase/pull/70188)


See stress test starting here: https://github.com/metabase/metabase/actions/runs/22581906431/job/65416043474

It was erroring like this here: https://github.com/metabase/metabase/actions/runs/22580057809/job/65409397279
<img width="978" height="601" alt="image" src="https://github.com/user-attachments/assets/f7e8ce46-1184-4eeb-8a83-c8424a674153" />
