### PR TITLE
Remove create models step from embedding onboarding checklist

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
@@ -116,39 +116,6 @@ describe("scenarios - embedding hub", () => {
         .should("be.visible");
     });
 
-    [
-      { dbId: 1, dbName: "sample db" },
-      { dbId: 2, dbName: "sqlite db" },
-    ].forEach(({ dbId, dbName }) => {
-      it(`"Create models" step should be marked in ${dbName} as done after creating a model`, () => {
-        if (dbId === 2) {
-          H.addSqliteDatabase(dbName);
-        }
-
-        cy.log("Create a native query model via API");
-        H.createNativeQuestion(
-          {
-            name: "Test Model",
-            type: "model",
-            database: dbId,
-            native: { query: "SELECT 1 as t" },
-          },
-          { visitQuestion: true },
-        );
-
-        cy.log("Navigate to embedding setup guide");
-        cy.visit("/admin/embedding/setup-guide");
-
-        cy.log("'Create models' should now be marked as done");
-        cy.findByTestId("admin-layout-content")
-          .findByText("Create models")
-          .closest("button")
-          .scrollIntoView()
-          .findByText("Done", { timeout: 10_000 })
-          .should("be.visible");
-      });
-    });
-
     it('"Get embed snippet" card should take you to the embed flow', () => {
       cy.visit("/admin/embedding/setup-guide");
 
@@ -221,7 +188,6 @@ describe("scenarios - embedding hub", () => {
         .should("be.visible");
 
       cy.get("main").within(() => {
-        cy.findByText("Create models").should("be.visible");
         cy.findByText("Create a dashboard").should("be.visible");
         cy.findByText("Connect a database").should("be.visible").click();
       });

--- a/frontend/src/metabase/api/embedding-hub.ts
+++ b/frontend/src/metabase/api/embedding-hub.ts
@@ -5,7 +5,6 @@ import { listTag } from "./tags";
 type CheckListApiStep =
   | "create-dashboard"
   | "add-data"
-  | "create-models"
   | "configure-row-column-security"
   | "create-test-embed"
   | "embed-production"

--- a/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHub.unit.spec.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHub.unit.spec.tsx
@@ -134,7 +134,6 @@ describe("EmbeddingHub", () => {
         "add-data": true,
         "create-dashboard": true,
         "create-test-embed": true,
-        "create-models": false,
         "configure-row-column-security": false,
         "embed-production": false,
         "sso-configured": false,

--- a/frontend/src/metabase/embedding/embedding-hub/hooks/use-completed-embedding-hub-steps.ts
+++ b/frontend/src/metabase/embedding/embedding-hub/hooks/use-completed-embedding-hub-steps.ts
@@ -26,7 +26,6 @@ export const useCompletedEmbeddingHubSteps = (): {
         "configure-row-column-security": false,
         "sso-configured": false,
         "embed-production": false,
-        "create-models": false,
         "data-permissions-and-enable-tenants": false,
 
         // "configure data permissions and enable tenants" sub-checklist

--- a/frontend/src/metabase/embedding/embedding-hub/hooks/use-get-embedding-hub-steps.ts
+++ b/frontend/src/metabase/embedding/embedding-hub/hooks/use-get-embedding-hub-steps.ts
@@ -71,13 +71,6 @@ export const useGetEmbeddingHubSteps = (): EmbeddingHubStep[] => {
           modal: { type: "xray-dashboard" },
           variant: "outline",
         },
-        {
-          title: t`Create models`,
-          description: t`Set up data models for your embedded analytics.`,
-          to: "/model/new",
-          optional: true,
-          stepId: "create-models",
-        },
       ],
     };
 

--- a/frontend/src/metabase/embedding/embedding-hub/types/embedding-checklist.ts
+++ b/frontend/src/metabase/embedding/embedding-hub/types/embedding-checklist.ts
@@ -7,7 +7,6 @@ export type EmbeddingHubStepId =
   | "configure-row-column-security"
   | "sso-configured"
   | "embed-production"
-  | "create-models"
   | "data-permissions-and-enable-tenants";
 
 export interface EmbeddingHubStep {


### PR DESCRIPTION
Closes EMB-1362

### Description

Removes the "Create models" step from the embedding hub checklist. Reason is that we are starting to encourage people to use transforms more and we want to phase out models, so we wanted to remove it from the onboarding checklist.

### How to verify

- Go to Embedding Hub
- The "Create models" step is gone from the checklist

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
