### PR TITLE
Tenant creation should differ the data isolation field by strategy

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
@@ -619,10 +619,11 @@ describe("scenarios - embedding hub", () => {
           const tenants = response.body.data;
 
           const acmeTenant = tenants.find(
-            (t: { slug: string }) => t.slug === "acme-corp-slug",
+            (tenant: { slug: string }) => tenant.slug === "acme-corp-slug",
           );
+
           const betaTenant = tenants.find(
-            (t: { slug: string }) => t.slug === "beta-inc-slug",
+            (tenant: { slug: string }) => tenant.slug === "beta-inc-slug",
           );
 
           expect(acmeTenant).to.exist;
@@ -683,6 +684,28 @@ describe("scenarios - embedding hub", () => {
 
         cy.log("we should still be on the create tenants step");
         H.main().findByPlaceholderText("Tenant name").should("be.visible");
+      });
+
+      it("reloads with strategy pre-selected and 'Select data' step unlocked when RLS is configured", () => {
+        cy.visit("/admin/embedding/setup-guide/permissions");
+
+        cy.log(
+          "'Select data' step should not be locked when RLS is configured",
+        );
+        H.main()
+          .findByRole("listitem", { name: "Select data to make available" })
+          .icon("lock")
+          .should("not.exist");
+
+        cy.log("strategy picker should show RLS pre-selected");
+        H.main()
+          .findByText("Which data segregation strategy does your database use?")
+          .scrollIntoView()
+          .click();
+
+        H.main()
+          .findByRole("radio", { name: /Row and column level security/ })
+          .should("have.attr", "aria-checked", "true");
       });
 
       it("shows autocomplete suggestions for tenant_identifier based on selected field values", () => {
@@ -1179,6 +1202,107 @@ describe("scenarios - embedding hub", () => {
       H.tooltip()
         .findByText("This database doesn't support connection impersonation")
         .should("be.visible");
+    });
+
+    it("creates a tenant with database_role attribute when using connection impersonation", () => {
+      cy.visit("/admin/embedding/setup-guide/permissions");
+
+      cy.log("select connection impersonation strategy");
+      H.main()
+        .findByRole("radio", { name: /Connection impersonation/ })
+        .scrollIntoView()
+        .click();
+
+      H.main()
+        .findByRole("button", { name: "Use connection impersonation" })
+        .scrollIntoView()
+        .click();
+
+      cy.log("navigate to create tenants step");
+      H.main().findByRole("listitem", { name: "Create tenants" }).click();
+
+      cy.log("fill out the tenant form");
+      H.main().within(() => {
+        cy.findByPlaceholderText("Tenant name").clear().type("Acme Corp");
+        cy.findByPlaceholderText("tenant_role").type("acme_role");
+        cy.findByPlaceholderText("tenant-slug").clear().type("acme-corp");
+      });
+
+      H.main().findByRole("button", { name: "Next" }).click();
+
+      cy.log("success toast should show");
+      H.undoToast()
+        .findByText("Tenants created successfully")
+        .should("be.visible");
+
+      cy.log("tenant should have database_role attribute");
+      cy.request("GET", "/api/ee/tenant").should((response) => {
+        const tenantBySlug = response.body.data.find(
+          (tenant: { slug: string }) => tenant.slug === "acme-corp",
+        );
+
+        expect(tenantBySlug.attributes).to.deep.equal({
+          database_role: "acme_role",
+        });
+      });
+    });
+  });
+
+  describe("database routing create tenants step", () => {
+    beforeEach(() => {
+      H.restore("setup");
+      cy.signInAsAdmin();
+      H.activateToken("bleeding-edge");
+
+      H.updateSetting("use-tenants", true);
+
+      cy.request("POST", "/api/collection", {
+        name: "Shared collection",
+        namespace: "shared-tenant-collection",
+      });
+    });
+
+    it("creates a tenant with database_slug attribute when using database routing", () => {
+      cy.visit("/admin/embedding/setup-guide/permissions");
+
+      cy.log("select database routing strategy");
+      H.main()
+        .findByRole("radio", { name: /Database routing/ })
+        .scrollIntoView()
+        .click();
+
+      H.main()
+        .findByRole("button", { name: "Use database routing" })
+        .scrollIntoView()
+        .click();
+
+      cy.log("navigate to create tenants step");
+      H.main().findByRole("listitem", { name: "Create tenants" }).click();
+
+      cy.log("fill out the tenant form");
+      H.main().within(() => {
+        cy.findByPlaceholderText("Tenant name").clear().type("Acme Corp");
+        cy.findByPlaceholderText("tenant-db-slug").type("acme-db");
+        cy.findByPlaceholderText("tenant-slug").clear().type("acme-corp");
+      });
+
+      H.main().findByRole("button", { name: "Next" }).click();
+
+      cy.log("success toast should show");
+      H.undoToast()
+        .findByText("Tenants created successfully")
+        .should("be.visible");
+
+      cy.log("tenant should have database_slug attribute");
+      cy.request("GET", "/api/ee/tenant").should((response) => {
+        const tenantBySlug = response.body.data.find(
+          (tenant: { slug: string }) => tenant.slug === "acme-corp",
+        );
+
+        expect(tenantBySlug.attributes).to.deep.equal({
+          database_slug: "acme-db",
+        });
+      });
     });
   });
 

--- a/enterprise/backend/src/metabase_enterprise/embedding_hub/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/embedding_hub/api.clj
@@ -70,6 +70,13 @@
       (t2/exists? :model/ConnectionImpersonation)
       (t2/exists? :model/DatabaseRouter)))
 
+(defn- active-data-segregation-strategy []
+  (cond
+    (has-configured-sandboxes?)              "row-column-level-security"
+    (t2/exists? :model/ConnectionImpersonation) "connection-impersonation"
+    (t2/exists? :model/DatabaseRouter)       "database-routing"
+    :else                                    nil))
+
 (defn- has-published-guest-embed? []
   ;; Check if at least one card or dashboard has embedding enabled (is published as a guest embed)
   (or (t2/exists? :model/Card :enable_embedding true)
@@ -80,44 +87,51 @@
                                               (has-shared-tenant-collections?))
         create-tenants?                  (has-user-created-tenants?)
         setup-data-segregation-strategy? (has-configured-data-segregation-strategy?)]
-    ;; for the main embedding hub checklist
-    {"add-data"                          (has-user-added-database?)
-     "create-dashboard"                  (has-user-created-dashboard?)
-     "create-models"                     (has-user-created-models?)
-     "configure-row-column-security"     (has-configured-sandboxes?)
-     "create-test-embed"                 (or (has-published-guest-embed?)
-                                             (embedding.settings/embedding-hub-test-embed-snippet-created))
-     "embed-production"                  (embedding.settings/embedding-hub-production-embed-snippet-created)
-     "data-permissions-and-enable-tenants" (and enable-tenants?
-                                                create-tenants?
-                                                setup-data-segregation-strategy?)
+    {"checklist"
+     {;; for the main embedding hub checklist
+      "add-data"                          (has-user-added-database?)
+      "create-dashboard"                  (has-user-created-dashboard?)
+      "create-models"                     (has-user-created-models?)
+      "configure-row-column-security"     (has-configured-sandboxes?)
+      "create-test-embed"                 (or (has-published-guest-embed?)
+                                              (embedding.settings/embedding-hub-test-embed-snippet-created))
+      "embed-production"                  (embedding.settings/embedding-hub-production-embed-snippet-created)
+      "data-permissions-and-enable-tenants" (and enable-tenants?
+                                                 create-tenants?
+                                                 setup-data-segregation-strategy?)
 
-     ;; for the "configure data permissions and enable tenants" sub-checklist page
-     "enable-tenants"                    enable-tenants?
-     "create-tenants"                    create-tenants?
-     "setup-data-segregation-strategy"   setup-data-segregation-strategy?
+      ;; for the "configure data permissions and enable tenants" sub-checklist page
+      "enable-tenants"                    enable-tenants?
+      "create-tenants"                    create-tenants?
+      "setup-data-segregation-strategy"   setup-data-segregation-strategy?
 
-     ;; for the "configure SSO" sub-checklist page
-     "sso-configured"                     (has-configured-sso?)
-     "sso-auth-manual-tested"            (embedding.settings/embedding-hub-sso-auth-manual-tested)}))
+      ;; for the "configure SSO" sub-checklist page
+      "sso-configured"                    (has-configured-sso?)
+      "sso-auth-manual-tested"            (embedding.settings/embedding-hub-sso-auth-manual-tested)}
 
-(def ^:private EmbeddingHubChecklist
+     "data-isolation-strategy"           (active-data-segregation-strategy)}))
+
+(def ^:private EmbeddingHubChecklistResponse
   "Schema for the embedding hub checklist response."
   [:map {:closed true}
-   ["add-data"                             :boolean]
-   ["create-dashboard"                     :boolean]
-   ["create-models"                        :boolean]
-   ["configure-row-column-security"        :boolean]
-   ["create-test-embed"                    :boolean]
-   ["embed-production"                     :boolean]
-   ["sso-configured"                        :boolean]
-   ["data-permissions-and-enable-tenants"  :boolean]
-   ["enable-tenants"                       :boolean]
-   ["create-tenants"                       :boolean]
-   ["setup-data-segregation-strategy"      :boolean]
-   ["sso-auth-manual-tested"               :boolean]])
+   ["checklist"
+    [:map {:closed true}
+     ["add-data"                             :boolean]
+     ["create-dashboard"                     :boolean]
+     ["create-models"                        :boolean]
+     ["configure-row-column-security"        :boolean]
+     ["create-test-embed"                    :boolean]
+     ["embed-production"                     :boolean]
+     ["sso-configured"                       :boolean]
+     ["data-permissions-and-enable-tenants"  :boolean]
+     ["enable-tenants"                       :boolean]
+     ["create-tenants"                       :boolean]
+     ["setup-data-segregation-strategy"      :boolean]
+     ["sso-auth-manual-tested"               :boolean]]]
+   ["data-isolation-strategy"
+    [:maybe [:enum "row-column-level-security" "connection-impersonation" "database-routing"]]]])
 
-(api.macros/defendpoint :get "/checklist" :- EmbeddingHubChecklist
+(api.macros/defendpoint :get "/checklist" :- EmbeddingHubChecklistResponse
   "Get the embedding hub checklist status, indicating which setup steps have been completed."
   []
   (embedding-hub-checklist))

--- a/enterprise/backend/test/metabase_enterprise/embedding_hub/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/embedding_hub/api_test.clj
@@ -31,14 +31,14 @@
                                                                   :query {:source-table (mt/id :venues)}}}]
         (testing "returns true when there is a model not in any sample collection"
           (let [response (mt/user-http-request :crowberto :get 200 "/ee/embedding-hub/checklist")]
-            (is (true? (:create-models response))
+            (is (true? (get-in response [:checklist :create-models]))
                 "Should detect the user model with nil collection_id")))
 
         (testing "returns false when all models are in sample collections"
           ;; Temporarily archive the user model so only sample collection models remain active
           (mt/with-temp-vals-in-db :model/Card (:id user-model) {:archived true}
             (let [response (mt/user-http-request :crowberto :get 200 "/ee/embedding-hub/checklist")]
-              (is (false? (:create-models response))
+              (is (false? (get-in response [:checklist :create-models]))
                   "Should exclude models in both sample collections"))))))))
 
 (deftest has-user-created-tenants-test
@@ -46,7 +46,7 @@
     (mt/with-premium-features #{:embedding}
       (mt/with-temp [:model/Tenant _ {:name "Test Tenant" :slug "test-tenant"}]
         (let [response (mt/user-http-request :crowberto :get 200 "/ee/embedding-hub/checklist")]
-          (is (true? (:create-tenants response)))))))
+          (is (true? (get-in response [:checklist :create-tenants])))))))
 
   (testing "create-tenants returns false when tenant is inactive"
     (mt/with-premium-features #{:embedding}
@@ -54,12 +54,12 @@
                                       :slug "inactive-tenant"
                                       :is_active false}]
         (let [response (mt/user-http-request :crowberto :get 200 "/ee/embedding-hub/checklist")]
-          (is (false? (:create-tenants response)))))))
+          (is (false? (get-in response [:checklist :create-tenants])))))))
 
   (testing "create-tenants returns false when no tenants exist"
     (mt/with-premium-features #{:embedding}
       (let [response (mt/user-http-request :crowberto :get 200 "/ee/embedding-hub/checklist")]
-        (is (false? (:create-tenants response)))))))
+        (is (false? (get-in response [:checklist :create-tenants])))))))
 
 (deftest has-configured-data-segregation-strategy-test
   (testing "setup-data-segregation-strategy returns true when row-level security is configured"
@@ -68,7 +68,7 @@
                      :model/Sandbox _ {:group_id group-id
                                        :table_id (mt/id :venues)}]
         (let [response (mt/user-http-request :crowberto :get 200 "/ee/embedding-hub/checklist")]
-          (is (true? (:setup-data-segregation-strategy response)))))))
+          (is (true? (get-in response [:checklist :setup-data-segregation-strategy])))))))
 
   (testing "setup-data-segregation-strategy returns true when connection impersonation is configured"
     (mt/with-premium-features #{:embedding}
@@ -77,19 +77,19 @@
                                                        :group_id group-id
                                                        :attribute "test-attr"}]
         (let [response (mt/user-http-request :crowberto :get 200 "/ee/embedding-hub/checklist")]
-          (is (true? (:setup-data-segregation-strategy response)))))))
+          (is (true? (get-in response [:checklist :setup-data-segregation-strategy])))))))
 
   (testing "setup-data-segregation-strategy returns true when database routing is configured"
     (mt/with-premium-features #{:embedding :database-routing}
       (mt/with-temp [:model/DatabaseRouter _ {:database_id (mt/id)
                                               :user_attribute "test-attr"}]
         (let [response (mt/user-http-request :crowberto :get 200 "/ee/embedding-hub/checklist")]
-          (is (true? (:setup-data-segregation-strategy response)))))))
+          (is (true? (get-in response [:checklist :setup-data-segregation-strategy])))))))
 
   (testing "setup-data-segregation-strategy returns false when none are configured"
     (mt/with-premium-features #{:embedding}
       (let [response (mt/user-http-request :crowberto :get 200 "/ee/embedding-hub/checklist")]
-        (is (false? (:setup-data-segregation-strategy response)))))))
+        (is (false? (get-in response [:checklist :setup-data-segregation-strategy])))))))
 
 (deftest enable-tenants-requires-shared-collection-test
   (testing "enable-tenants returns true when use-tenants is true AND shared tenant collections exist"
@@ -98,13 +98,13 @@
         (mt/with-temp [:model/Collection _ {:name "Shared collection"
                                             :namespace "shared-tenant-collection"}]
           (let [response (mt/user-http-request :crowberto :get 200 "/ee/embedding-hub/checklist")]
-            (is (true? (:enable-tenants response))))))))
+            (is (true? (get-in response [:checklist :enable-tenants]))))))))
 
   (testing "enable-tenants returns false when use-tenants is true but no shared tenant collections exist"
     (mt/with-premium-features #{:embedding :tenants}
       (mt/with-temporary-setting-values [use-tenants true]
         (let [response (mt/user-http-request :crowberto :get 200 "/ee/embedding-hub/checklist")]
-          (is (false? (:enable-tenants response))))))))
+          (is (false? (get-in response [:checklist :enable-tenants]))))))))
 
 (deftest data-permissions-and-enable-tenants-test
   (testing "data-permissions-and-enable-tenants returns true when all three conditions are met"
@@ -117,7 +117,7 @@
                        :model/Sandbox _ {:group_id group-id
                                          :table_id (mt/id :venues)}]
           (let [response (mt/user-http-request :crowberto :get 200 "/ee/embedding-hub/checklist")]
-            (is (true? (:data-permissions-and-enable-tenants response))))))))
+            (is (true? (get-in response [:checklist :data-permissions-and-enable-tenants]))))))))
 
   (testing "returns false when data segregation is not configured even if tenants are created"
     (mt/with-premium-features #{:embedding :tenants}
@@ -126,7 +126,7 @@
                                             :namespace "shared-tenant-collection"}
                        :model/Tenant _ {:name "Test Tenant" :slug "test-tenant"}]
           (let [response (mt/user-http-request :crowberto :get 200 "/ee/embedding-hub/checklist")]
-            (is (false? (:data-permissions-and-enable-tenants response))))))))
+            (is (false? (get-in response [:checklist :data-permissions-and-enable-tenants]))))))))
 
   (testing "returns false when tenants are not created even if tenants and data segregation are configured"
     (mt/with-premium-features #{:embedding :sandboxes :tenants}
@@ -137,4 +137,34 @@
                        :model/Sandbox _ {:group_id group-id
                                          :table_id (mt/id :venues)}]
           (let [response (mt/user-http-request :crowberto :get 200 "/ee/embedding-hub/checklist")]
-            (is (false? (:data-permissions-and-enable-tenants response)))))))))
+            (is (false? (get-in response [:checklist :data-permissions-and-enable-tenants])))))))))
+
+(deftest data-isolation-strategy-test
+  (testing "data-isolation-strategy is nil when no strategy is configured"
+    (mt/with-premium-features #{:embedding}
+      (let [response (mt/user-http-request :crowberto :get 200 "/ee/embedding-hub/checklist")]
+        (is (nil? (:data-isolation-strategy response))))))
+
+  (testing "data-isolation-strategy is row-column-level-security when sandboxes are configured"
+    (mt/with-premium-features #{:embedding :sandboxes}
+      (mt/with-temp [:model/PermissionsGroup {group-id :id} {}
+                     :model/Sandbox _ {:group_id group-id
+                                       :table_id (mt/id :venues)}]
+        (let [response (mt/user-http-request :crowberto :get 200 "/ee/embedding-hub/checklist")]
+          (is (= "row-column-level-security" (:data-isolation-strategy response)))))))
+
+  (testing "data-isolation-strategy is connection-impersonation when connection impersonation is configured"
+    (mt/with-premium-features #{:embedding}
+      (mt/with-temp [:model/PermissionsGroup {group-id :id} {}
+                     :model/ConnectionImpersonation _ {:db_id (mt/id)
+                                                       :group_id group-id
+                                                       :attribute "test-attr"}]
+        (let [response (mt/user-http-request :crowberto :get 200 "/ee/embedding-hub/checklist")]
+          (is (= "connection-impersonation" (:data-isolation-strategy response)))))))
+
+  (testing "data-isolation-strategy is database-routing when database routing is configured"
+    (mt/with-premium-features #{:embedding :database-routing}
+      (mt/with-temp [:model/DatabaseRouter _ {:database_id (mt/id)
+                                              :user_attribute "test-attr"}]
+        (let [response (mt/user-http-request :crowberto :get 200 "/ee/embedding-hub/checklist")]
+          (is (= "database-routing" (:data-isolation-strategy response))))))))

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/CreateTenantsOnboardingStep/CreateTenantsOnboardingStep.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/CreateTenantsOnboardingStep/CreateTenantsOnboardingStep.module.css
@@ -1,0 +1,4 @@
+.TenantNameInput {
+  font-size: var(--mantine-font-size-lg);
+  padding: 0 var(--mantine-spacing-md);
+}

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/CreateTenantsOnboardingStep/CreateTenantsOnboardingStep.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/CreateTenantsOnboardingStep/CreateTenantsOnboardingStep.tsx
@@ -1,10 +1,9 @@
-/* eslint-disable metabase/no-literal-metabase-strings -- This string only shows for admins */
-
 import { useCallback, useState } from "react";
 import { t } from "ttag";
 
 import { getErrorMessage } from "metabase/api/utils";
 import { useToast } from "metabase/common/hooks";
+import type { DataSegregationStrategy } from "metabase/embedding/embedding-hub";
 import { slugify } from "metabase/lib/formatting";
 import type { CreatedTenantData } from "metabase/plugins/oss/tenants";
 import {
@@ -21,20 +20,18 @@ import type { FieldId } from "metabase-types/api";
 
 import { useCreateTenantMutation } from "../../../api/tenants";
 
+import S from "./CreateTenantsOnboardingStep.module.css";
 import { TenantIdentifierInput } from "./TenantIdentifierInput";
-
-const createEmptyTenant = (index: number): CreatedTenantData => ({
-  name: `Tenant ${index}`,
-  tenantIdentifier: "",
-  slug: `tenant-${index}`,
-});
+import { getIsolationFieldConfig } from "./isolation-field-config";
 
 export const CreateTenantsOnboardingStep = ({
   onTenantsCreated,
   selectedFieldIds,
+  strategy,
 }: {
   onTenantsCreated?: (tenants: CreatedTenantData[]) => void;
   selectedFieldIds?: FieldId[];
+  strategy?: DataSegregationStrategy | null;
 }) => {
   const [sendToast] = useToast();
 
@@ -74,16 +71,21 @@ export const CreateTenantsOnboardingStep = ({
     setTenants((prev) => prev.filter((_, i) => i !== index));
   }, []);
 
+  const fieldConfig = getIsolationFieldConfig(strategy);
+
   const handleCreateTenants = useCallback(async () => {
     try {
       // Create all tenants sequentially
       for (const tenant of tenants) {
+        const attributes =
+          fieldConfig && tenant.dataIsolationFieldValue
+            ? { [fieldConfig.attributeKey]: tenant.dataIsolationFieldValue }
+            : {};
+
         await createTenant({
           name: tenant.name,
           slug: tenant.slug,
-          attributes: {
-            tenant_identifier: tenant.tenantIdentifier,
-          },
+          attributes,
         }).unwrap();
       }
 
@@ -102,21 +104,17 @@ export const CreateTenantsOnboardingStep = ({
         message: getErrorMessage(error, t`Failed to create tenants`),
       });
     }
-  }, [tenants, createTenant, sendToast, onTenantsCreated]);
+  }, [tenants, fieldConfig, createTenant, sendToast, onTenantsCreated]);
 
   const isValid = tenants.every(
     (tenant) =>
       tenant.name.trim() &&
-      tenant.tenantIdentifier.trim() &&
-      tenant.slug.trim(),
+      tenant.slug.trim() &&
+      tenant.dataIsolationFieldValue.trim(),
   );
 
   return (
     <Stack gap="md">
-      <Text c="text-secondary" size="sm" lh="lg">
-        {t`Use tenants to isolate external organizations on the same Metabase instance. Tenant users will see rows in the tables you selected where the value in the columns you chose in the previous step equals the value you enter in this screen for the tenant_identifier attribute.`}
-      </Text>
-
       <Stack gap="md">
         {tenants.map((tenant, index) => (
           <Paper key={index} withBorder p="md" radius="md">
@@ -128,8 +126,9 @@ export const CreateTenantsOnboardingStep = ({
                     updateTenantCard(index, "name", e.target.value)
                   }
                   placeholder={t`Tenant name`}
-                  size="md"
                   flex={1}
+                  fw="bold"
+                  classNames={{ input: S.TenantNameInput }}
                 />
                 {tenants.length > 1 && (
                   <Button
@@ -144,13 +143,29 @@ export const CreateTenantsOnboardingStep = ({
                 )}
               </Group>
 
-              <TenantIdentifierInput
-                value={tenant.tenantIdentifier}
-                onChange={(value) =>
-                  updateTenantCard(index, "tenantIdentifier", value)
-                }
-                selectedFieldIds={selectedFieldIds}
-              />
+              {strategy === "row-column-level-security" && (
+                <TenantIdentifierInput
+                  value={tenant.dataIsolationFieldValue}
+                  onChange={(value) =>
+                    updateTenantCard(index, "dataIsolationFieldValue", value)
+                  }
+                  selectedFieldIds={selectedFieldIds}
+                />
+              )}
+
+              {(strategy === "connection-impersonation" ||
+                strategy === "database-routing") &&
+                fieldConfig && (
+                  <TenantFormField
+                    label={fieldConfig.label}
+                    description={fieldConfig.description}
+                    value={tenant.dataIsolationFieldValue}
+                    onChange={(value) =>
+                      updateTenantCard(index, "dataIsolationFieldValue", value)
+                    }
+                    placeholder={fieldConfig.placeholder}
+                  />
+                )}
 
               <TenantFormField
                 label={t`Tenant slug`}
@@ -217,3 +232,9 @@ const TenantFormField = ({
     />
   </Stack>
 );
+
+const createEmptyTenant = (index: number): CreatedTenantData => ({
+  name: `Tenant ${index}`,
+  dataIsolationFieldValue: "",
+  slug: `tenant-${index}`,
+});

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/CreateTenantsOnboardingStep/TenantIdentifierInput.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/CreateTenantsOnboardingStep/TenantIdentifierInput.tsx
@@ -4,6 +4,7 @@ import { Autocomplete, Stack, Text } from "metabase/ui";
 import type { FieldId } from "metabase-types/api";
 
 import { useFieldDistinctValues } from "./hooks/use-field-distinct-values";
+import { getIsolationFieldConfig } from "./isolation-field-config";
 
 export const TenantIdentifierInput = ({
   value,
@@ -21,6 +22,8 @@ export const TenantIdentifierInput = ({
 
   const { values: suggestions } = useFieldDistinctValues(firstFieldId);
 
+  const config = getIsolationFieldConfig("row-column-level-security")!;
+
   const placeholder = suggestions[0]
     ? c("example tenant identifier value from the database")
         .t`e.g. ${suggestions[0]}`
@@ -29,11 +32,11 @@ export const TenantIdentifierInput = ({
   return (
     <Stack gap="xs">
       <Text fw="bold" size="sm">
-        {t`tenant_identifier`}
+        {config.label}
       </Text>
 
       <Text c="text-secondary" size="xs" mb="sm">
-        {t`Users will only see rows where this matches the value in the column you selected.`}
+        {config.description}
       </Text>
 
       <Autocomplete

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/CreateTenantsOnboardingStep/isolation-field-config.ts
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/CreateTenantsOnboardingStep/isolation-field-config.ts
@@ -1,0 +1,37 @@
+import { match } from "ts-pattern";
+import { t } from "ttag";
+
+import type { DataSegregationStrategy } from "metabase/embedding/embedding-hub";
+
+export type IsolationFieldConfig = {
+  /** The attribute key sent to the API, e.g. tenant_identifier */
+  attributeKey: string;
+
+  label: string;
+  description: string;
+  placeholder: string;
+};
+
+export const getIsolationFieldConfig = (
+  strategy: DataSegregationStrategy | null | undefined,
+): IsolationFieldConfig | null =>
+  match(strategy)
+    .with("row-column-level-security", () => ({
+      attributeKey: "tenant_identifier",
+      label: "tenant_identifier",
+      description: t`Users will only see rows where this matches the value in the column you selected.`,
+      placeholder: "1",
+    }))
+    .with("connection-impersonation", () => ({
+      attributeKey: "database_role",
+      label: "database_role",
+      description: t`Users will access data based on the privileges granted to this role in the database.`,
+      placeholder: "tenant_role",
+    }))
+    .with("database-routing", () => ({
+      attributeKey: "database_slug",
+      label: "database_slug",
+      description: t`Match a slug for a destination DB as defined in the data source's DB routing settings.`,
+      placeholder: "tenant-db-slug",
+    }))
+    .otherwise(() => null);

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantsSummaryOnboardingStep/TenantSummaryCard.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantsSummaryOnboardingStep/TenantSummaryCard.tsx
@@ -5,11 +5,13 @@ import { Grid, Paper, Stack, Text, Title } from "metabase/ui";
 export const TenantSummaryCard = ({
   name,
   slug,
-  tenantIdentifier,
+  isolationFieldLabel,
+  isolationFieldValue,
 }: {
   name: string;
   slug: string;
-  tenantIdentifier: string | null;
+  isolationFieldLabel: string | null;
+  isolationFieldValue: string | null;
 }) => {
   return (
     <Paper withBorder p="lg" radius="md">
@@ -19,17 +21,19 @@ export const TenantSummaryCard = ({
         </Title>
 
         <Grid>
-          <Grid.Col span={4}>
-            <Stack gap={4}>
-              <Text size="xs" c="text-secondary">
-                {t`tenant_identifier`}
-              </Text>
+          {isolationFieldLabel && (
+            <Grid.Col span={4}>
+              <Stack gap={4}>
+                <Text size="xs" c="text-secondary">
+                  {isolationFieldLabel}
+                </Text>
 
-              <Text size="sm" fw="bold" c="text-primary">
-                {tenantIdentifier ?? "-"}
-              </Text>
-            </Stack>
-          </Grid.Col>
+                <Text size="sm" fw="bold" c="text-primary">
+                  {isolationFieldValue ?? "-"}
+                </Text>
+              </Stack>
+            </Grid.Col>
+          )}
 
           <Grid.Col span={4}>
             <Stack gap={4}>

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantsSummaryOnboardingStep/TenantsSummaryOnboardingStep.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantsSummaryOnboardingStep/TenantsSummaryOnboardingStep.tsx
@@ -1,8 +1,10 @@
 import { useMemo } from "react";
 import { push } from "react-router-redux";
+import { match } from "ts-pattern";
 import { t } from "ttag";
 
 import { RelatedSettingCard } from "metabase/admin/components/RelatedSettingsSection";
+import type { DataSegregationStrategy } from "metabase/embedding/embedding-hub";
 import { useDispatch } from "metabase/lib/redux";
 import type { CreatedTenantData } from "metabase/plugins/oss/tenants";
 import { Button, Flex, SimpleGrid, Stack, Text, Title } from "metabase/ui";
@@ -17,10 +19,18 @@ import { TenantSummaryCard } from "./TenantSummaryCard";
  */
 const MAX_FETCHED_TENANTS_TO_SHOW = 3;
 
+const ISOLATION_ATTRIBUTE_KEYS = [
+  "tenant_identifier",
+  "database_role",
+  "database_slug",
+] as const;
+
 export const TenantsSummaryOnboardingStep = ({
   tenants,
+  strategy,
 }: {
   tenants: CreatedTenantData[];
+  strategy?: DataSegregationStrategy | null;
 }) => {
   const dispatch = useDispatch();
 
@@ -41,12 +51,22 @@ export const TenantsSummaryOnboardingStep = ({
     const lastTenants =
       tenantsData?.data?.slice(-MAX_FETCHED_TENANTS_TO_SHOW) ?? [];
 
-    return lastTenants.map((tenant) => ({
-      name: tenant.name,
-      slug: tenant.slug,
-      tenantIdentifier: tenant.attributes?.tenant_identifier ?? "",
-    }));
+    return lastTenants.map((tenant) => {
+      // Detect which isolation attribute is set on the tenant
+      const dataIsolationFieldKey = ISOLATION_ATTRIBUTE_KEYS.find(
+        (key) => tenant.attributes?.[key] != null,
+      );
+
+      return {
+        name: tenant.name,
+        slug: tenant.slug,
+        dataIsolationFieldValue:
+          tenant.attributes?.[dataIsolationFieldKey ?? ""] ?? "",
+      };
+    });
   }, [tenants, tenantsData]);
+
+  const isolationFieldLabel = getIsolationFieldLabel(strategy);
 
   return (
     <Stack gap="lg">
@@ -59,7 +79,10 @@ export const TenantsSummaryOnboardingStep = ({
           <TenantSummaryCard
             key={tenant.slug}
             name={tenant.name}
-            tenantIdentifier={tenant.tenantIdentifier || null}
+            isolationFieldLabel={
+              tenant.dataIsolationFieldValue ? isolationFieldLabel : null
+            }
+            isolationFieldValue={tenant.dataIsolationFieldValue || null}
             slug={tenant.slug}
           />
         ))}
@@ -107,3 +130,12 @@ const RelatedSettingsSection = () => (
     />
   </SimpleGrid>
 );
+
+export const getIsolationFieldLabel = (
+  strategy: DataSegregationStrategy | null | undefined,
+): string | null =>
+  match(strategy)
+    .with("row-column-level-security", () => "tenant_identifier")
+    .with("connection-impersonation", () => "database_role")
+    .with("database-routing", () => "database_slug")
+    .otherwise(() => null);

--- a/frontend/src/metabase/api/embedding-hub.ts
+++ b/frontend/src/metabase/api/embedding-hub.ts
@@ -1,4 +1,5 @@
 import { Api } from "metabase/api";
+import type { DataSegregationStrategy } from "metabase/embedding/embedding-hub";
 
 import { listTag } from "./tags";
 
@@ -16,9 +17,17 @@ type CheckListApiStep =
   | "sso-auth-manual-tested";
 export type EmbeddingHubChecklist = Record<CheckListApiStep, boolean>;
 
+export type EmbeddingHubChecklistResponse = {
+  checklist: EmbeddingHubChecklist;
+  "data-isolation-strategy": DataSegregationStrategy | null;
+};
+
 export const embeddingHubApi = Api.injectEndpoints({
   endpoints: (builder) => ({
-    getEmbeddingHubChecklist: builder.query<EmbeddingHubChecklist, void>({
+    getEmbeddingHubChecklist: builder.query<
+      EmbeddingHubChecklistResponse,
+      void
+    >({
       query: () => ({
         method: "GET",
         url: "/api/ee/embedding-hub/checklist",

--- a/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/DataSegregationStrategyPicker.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/DataSegregationStrategyPicker.tsx
@@ -5,12 +5,11 @@ import { t } from "ttag";
 import type { IconName } from "metabase/ui";
 import { Button, Flex, Group, Icon, Radio, Stack, Text } from "metabase/ui";
 
+import type { DataSegregationStrategy } from "../../types";
+
 import S from "./DataSegregationStrategyPicker.module.css";
 
-export type DataSegregationStrategy =
-  | "row-column-level-security"
-  | "connection-impersonation"
-  | "database-routing";
+export type { DataSegregationStrategy };
 
 interface DataSegregationStrategyPickerProps {
   value: DataSegregationStrategy | null;

--- a/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/SetupPermissionsAndTenantsPage.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/SetupPermissionsAndTenantsPage.tsx
@@ -27,7 +27,9 @@ const SETUP_GUIDE_PATH = "/admin/embedding/setup-guide";
 
 export const SetupPermissionsAndTenantsPage = () => {
   const stepperRef = useRef<OnboardingStepperHandle>(null);
-  const { data: checklist } = useGetEmbeddingHubChecklistQuery();
+
+  const { data: checklistResponse } = useGetEmbeddingHubChecklistQuery();
+  const checklist = checklistResponse?.checklist;
 
   // The "Which data segregation strategy does your database use?"
   // is a purely UI step for choosing which strategy to use.
@@ -41,6 +43,10 @@ export const SetupPermissionsAndTenantsPage = () => {
 
   // Track the selected field IDs from the RLS step (in-session only)
   const [selectedFieldIds, setSelectedFieldIds] = useState<FieldId[]>([]);
+
+  // Prefer in-session UI state; fall back to backend detection for reloads
+  const activeStrategy =
+    selectedStrategy ?? checklistResponse?.["data-isolation-strategy"] ?? null;
 
   const isTenantsEnabled = checklist?.["enable-tenants"] ?? false;
 
@@ -73,9 +79,9 @@ export const SetupPermissionsAndTenantsPage = () => {
 
   const lockedSteps = useMemo(() => {
     return {
-      // Even if the data strategy step was completed before,
-      // UI needs to know which strategy to re-configure.
-      "select-data": !isStrategyConfirmed,
+      // Unlock once we know the strategy — either from in-session confirmation
+      // or from the backend on reload.
+      "select-data": activeStrategy === null,
       "create-tenants": !isPickDataStrategyDone,
       summary: !(
         isTenantsEnabled &&
@@ -85,7 +91,7 @@ export const SetupPermissionsAndTenantsPage = () => {
       ),
     };
   }, [
-    isStrategyConfirmed,
+    activeStrategy,
     isPickDataStrategyDone,
     isTenantsEnabled,
     isDataSegregationSetupDone,
@@ -122,7 +128,7 @@ export const SetupPermissionsAndTenantsPage = () => {
           title={t`Which data segregation strategy does your database use?`}
         >
           <DataSegregationStrategyPicker
-            value={selectedStrategy}
+            value={activeStrategy}
             onChange={(value) => {
               setSelectedStrategy(value);
               setIsStrategyConfirmed(false);
@@ -141,9 +147,9 @@ export const SetupPermissionsAndTenantsPage = () => {
           stepId="select-data"
           title={t`Select data to make available`}
           // Database routing step links to documentation
-          hideTitleOnActive={selectedStrategy === "database-routing"}
+          hideTitleOnActive={activeStrategy === "database-routing"}
         >
-          {match(selectedStrategy)
+          {match(activeStrategy)
             .with("row-column-level-security", () => (
               <RlsDataSelector
                 onSuccess={(fieldIds) => {
@@ -171,6 +177,7 @@ export const SetupPermissionsAndTenantsPage = () => {
           <PLUGIN_TENANTS.CreateTenantsOnboardingStep
             onTenantsCreated={setCreatedTenants}
             selectedFieldIds={selectedFieldIds}
+            strategy={activeStrategy}
           />
         </OnboardingStepper.Step>
 
@@ -181,6 +188,7 @@ export const SetupPermissionsAndTenantsPage = () => {
         >
           <PLUGIN_TENANTS.TenantsSummaryOnboardingStep
             tenants={createdTenants}
+            strategy={activeStrategy}
           />
         </OnboardingStepper.Step>
       </OnboardingStepper>

--- a/frontend/src/metabase/embedding/embedding-hub/components/SetupSsoPage/SetupSsoPage.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/SetupSsoPage/SetupSsoPage.tsx
@@ -17,7 +17,8 @@ const SETUP_GUIDE_PATH = "/admin/embedding/setup-guide";
 export const SetupSsoPage = () => {
   const stepperRef = useRef<OnboardingStepperHandle>(null);
 
-  const { data: checklist } = useGetEmbeddingHubChecklistQuery();
+  const { data: checklistResponse } = useGetEmbeddingHubChecklistQuery();
+  const checklist = checklistResponse?.checklist;
 
   // UI-only confirmation state for step 2
   const [isAddEndpointConfirmed, setIsAddEndpointConfirmed] = useState(false);

--- a/frontend/src/metabase/embedding/embedding-hub/hooks/use-completed-embedding-hub-steps.ts
+++ b/frontend/src/metabase/embedding/embedding-hub/hooks/use-completed-embedding-hub-steps.ts
@@ -11,13 +11,15 @@ export const useCompletedEmbeddingHubSteps = (): {
   data: Record<EmbeddingHubStepId, boolean>;
   isLoading: boolean;
 } => {
-  const { data: embeddingHubChecklist, isLoading } =
+  const { data: checklistResponse, isLoading } =
     useGetEmbeddingHubChecklistQuery(undefined, {
       refetchOnMountOrArgChange: true,
     });
 
   const data = useMemo(() => {
-    if (isLoading || !embeddingHubChecklist) {
+    const checklist = checklistResponse?.checklist;
+
+    if (isLoading || !checklist) {
       return {
         // main checklist
         "create-test-embed": false,
@@ -41,12 +43,11 @@ export const useCompletedEmbeddingHubSteps = (): {
     // For the main embedding hub, the SSO step is only complete if both
     // SSO is configured AND the user has manually acknowledged it works
     return {
-      ...embeddingHubChecklist,
+      ...checklist,
       "sso-configured":
-        embeddingHubChecklist["sso-configured"] &&
-        embeddingHubChecklist["sso-auth-manual-tested"],
+        checklist["sso-configured"] && checklist["sso-auth-manual-tested"],
     };
-  }, [embeddingHubChecklist, isLoading]);
+  }, [checklistResponse, isLoading]);
 
   return { data, isLoading };
 };

--- a/frontend/src/metabase/embedding/embedding-hub/types/embedding-checklist.ts
+++ b/frontend/src/metabase/embedding/embedding-hub/types/embedding-checklist.ts
@@ -1,5 +1,10 @@
 import type { AddDataTab } from "metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/utils";
 
+export type DataSegregationStrategy =
+  | "row-column-level-security"
+  | "connection-impersonation"
+  | "database-routing";
+
 export type EmbeddingHubStepId =
   | "create-test-embed"
   | "add-data"

--- a/frontend/src/metabase/embedding/embedding-hub/types/index.ts
+++ b/frontend/src/metabase/embedding/embedding-hub/types/index.ts
@@ -1,4 +1,5 @@
 export type {
+  DataSegregationStrategy,
   EmbeddingHubStep,
   EmbeddingHubStepId,
   EmbeddingHubAction,

--- a/frontend/src/metabase/plugins/oss/tenants.ts
+++ b/frontend/src/metabase/plugins/oss/tenants.ts
@@ -4,6 +4,7 @@ import type {
   OmniPickerCollectionItem,
   OmniPickerItem,
 } from "metabase/common/components/Pickers";
+import type { DataSegregationStrategy } from "metabase/embedding/embedding-hub";
 import type { CollectionTreeItem } from "metabase/entities/collections/utils";
 import type {
   Collection,
@@ -19,7 +20,7 @@ import { PluginPlaceholder } from "../components/PluginPlaceholder";
 export type CreatedTenantData = {
   name: string;
   slug: string;
-  tenantIdentifier: string;
+  dataIsolationFieldValue: string;
 };
 
 export type TenantCollectionPathItem = {
@@ -39,9 +40,11 @@ const getDefaultPluginTenants = () => ({
   CreateTenantsOnboardingStep: PluginPlaceholder as React.ComponentType<{
     onTenantsCreated?: (tenants: CreatedTenantData[]) => void;
     selectedFieldIds?: number[];
+    strategy?: DataSegregationStrategy | null;
   }>,
   TenantsSummaryOnboardingStep: PluginPlaceholder as React.ComponentType<{
     tenants: CreatedTenantData[];
+    strategy?: DataSegregationStrategy | null;
   }>,
   EditUserStrategySettingsButton: PluginPlaceholder,
   FormTenantWidget: (_props: any) => null as React.ReactElement | null,
@@ -108,9 +111,11 @@ export const PLUGIN_TENANTS: {
   CreateTenantsOnboardingStep: React.ComponentType<{
     onTenantsCreated?: (tenants: CreatedTenantData[]) => void;
     selectedFieldIds?: number[];
+    strategy?: DataSegregationStrategy | null;
   }>;
   TenantsSummaryOnboardingStep: React.ComponentType<{
     tenants: CreatedTenantData[];
+    strategy?: DataSegregationStrategy | null;
   }>;
   EditUserStrategySettingsButton: (props: {
     page: "people" | "tenants";


### PR DESCRIPTION
Closes EMB-1336

### Description

The _create tenant_ form in the embedding onboarding checklist should use a strategy-aware data isolation field instead of a hardcoded `tenant_identifier`.

Each data segregation strategy maps to a different tenant attribute:

- **Row/column level security** → `tenant_identifier`
- **Connection impersonation** → `database_role`
- **Database routing** → `database_slug`

The checklist API response is restructured to return `{ checklist: {...}, "data-isolation-strategy": "..." }` so the frontend can restore the selected strategy and unlock the correct steps on page reload.

### How to verify

1. Go to `/admin/embedding/setup-guide/permissions`
2. Enable tenants, select a data segregation strategy, and proceed to "Create tenants"
3. Verify the data isolation field label/placeholder matches the strategy
4. Create a tenant and confirm the correct attribute is saved (e.g. `database_role` for connection impersonation)
5. Reload the page.
6. Verify the strategy is pre-selected and "select data" step is unlocked

### Checklist

- [x] Tests have been added/updated to cover changes in this PR