### PR TITLE
set `fail-fast` to false in sdk host/sample apps tests

### DIFF
--- a/.github/workflows/embedding-sdk-host-sample-apps-tests.yml
+++ b/.github/workflows/embedding-sdk-host-sample-apps-tests.yml
@@ -88,6 +88,7 @@ jobs:
   e2e-sample-apps-tests:
     needs: [get-sample-apps-data]
     strategy:
+      fail-fast: false
       matrix:
         test_suite: ${{ fromJSON(needs.get-sample-apps-data.outputs.matrix) }}
         environment: ["production", "development"]
@@ -194,6 +195,7 @@ jobs:
   e2e-shoppy-tests:
     needs: [get-sample-apps-data]
     strategy:
+      fail-fast: false
       matrix:
         environment: ["production", "development"]
     if: |
@@ -342,6 +344,7 @@ jobs:
   # For more details see `Embedding SDK integration tests with Host Apps` in `enterprise/frontend/src/embedding-sdk-package/dev.md`
   e2e-host-apps-tests:
     strategy:
+      fail-fast: false
       matrix:
         test_suite:
           [


### PR DESCRIPTION
I'm not sure if this was done on purpose, but our sdk sample/host app tests have fail-fast unset (which defaults to true) and it make sit very hard to debug stuff.
As soon as a job in the matrix fails (maybe for a connection error) all the other jobs are cancelled, making it difficult for us to understand if the tests are actually passing or not.
This also makes it hard to understand if a specific test is flaky, as as soon as it fails, everything gets cancelled and we cannot know if it passes on the other jobs.