### PR TITLE
Show segregation strategy specific data permissions in tenant summary

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
@@ -543,7 +543,7 @@ describe("scenarios - embedding hub", () => {
 
           cy.log("fill out the tenant form");
           cy.findByPlaceholderText("Tenant name").clear().type("Acme Corp");
-          cy.findByPlaceholderText("e.g. 1").type("acme-123");
+          cy.findByLabelText("tenant_identifier").type("acme-123");
           cy.findByPlaceholderText("tenant-slug")
             .clear()
             .type("acme-corp-slug");
@@ -560,7 +560,7 @@ describe("scenarios - embedding hub", () => {
             .clear()
             .type("Beta Inc");
 
-          cy.findAllByPlaceholderText("e.g. 1")
+          cy.findAllByLabelText("tenant_identifier")
             .should("have.length", 2)
             .last()
             .type("beta-456");
@@ -666,7 +666,7 @@ describe("scenarios - embedding hub", () => {
             .clear()
             .type("Another Tenant");
 
-          cy.findByPlaceholderText("e.g. 1").type("another-id");
+          cy.findByPlaceholderText("e.g. acme-corp").type("another-id");
 
           cy.findByPlaceholderText("tenant-slug")
             .clear()
@@ -761,6 +761,82 @@ describe("scenarios - embedding hub", () => {
           cy.findByRole("option", { name: "1" }).should("exist");
         });
       });
+    });
+
+    // Needs its own test case, as the RLS selected table and columns
+    // are only populated when the user goes through the "Select data" step
+    // in the UI. Without it, the data permissions description won't show.
+    it("shows RLS data permissions description in summary", () => {
+      H.restore("setup");
+      cy.signInAsAdmin();
+      H.activateToken("bleeding-edge");
+
+      cy.visit("/admin/embedding/setup-guide/permissions");
+
+      cy.log("enable tenants and create shared collection");
+      H.main()
+        .findByRole("button", {
+          name: "Enable tenants and create shared collection",
+        })
+        .click();
+
+      cy.log("wait for tenants to be enabled");
+      H.main()
+        .findByRole("listitem", {
+          name: "Enable multi-tenant user strategy",
+          timeout: 10_000,
+        })
+        .icon("check")
+        .should("exist");
+
+      cy.log("use row and column level security");
+      H.main()
+        .findByRole("radio", { name: /Row and column level security/ })
+        .scrollIntoView()
+        .click();
+
+      H.main()
+        .findByRole("button", { name: "Use row and column level security" })
+        .scrollIntoView()
+        .click();
+
+      cy.log("pick Orders table and User ID column");
+      H.main().findByText("Pick a table").click();
+      H.miniPicker().findByText("Sample Database").click();
+      H.miniPicker().findByText("Orders").click();
+
+      H.main().findByPlaceholderText("Pick a column").click();
+      H.popover().findByText("User ID").click();
+
+      cy.intercept("PUT", "/api/permissions/graph").as(
+        "updatePermissionsGraph",
+      );
+      H.main().findByRole("button", { name: "Next" }).click();
+      cy.wait("@updatePermissionsGraph");
+
+      cy.log("navigate to create tenants step");
+      H.main().findByRole("listitem", { name: "Create tenants" }).click();
+
+      cy.log("fill out the tenant form");
+      H.main().within(() => {
+        cy.findByPlaceholderText("Tenant name").clear().type("Acme Corp");
+        cy.findByPlaceholderText("e.g. 1").type("42");
+        cy.findByPlaceholderText("tenant-slug").clear().type("acme-corp");
+      });
+
+      H.main().findByRole("button", { name: "Next" }).click();
+
+      cy.log("success toast should show");
+      H.undoToast()
+        .findByText("Tenants created successfully")
+        .should("be.visible");
+
+      cy.log("data permissions description should show in summary");
+      H.main()
+        .contains(
+          "All users in Acme Corp can view rows in the Orders table where User ID field equals 42.",
+        )
+        .should("be.visible");
     });
 
     it("should create sandboxes for multiple tables via row-level security setup", () => {
@@ -1076,7 +1152,7 @@ describe("scenarios - embedding hub", () => {
         H.popover().findByText("QA Postgres12").click();
 
         cy.log("database should be selected in the multi-select pill");
-        H.main().findByLabelText("Remove QA Postgres12").should("exist");
+        H.main().findAllByLabelText("Remove").should("have.length", 1);
         H.main().findByText("QA Postgres12").should("be.visible");
 
         cy.log("setup connection impersonation for the database");
@@ -1245,6 +1321,13 @@ describe("scenarios - embedding hub", () => {
           database_role: "acme_role",
         });
       });
+
+      cy.log("data permissions description should show in summary");
+      H.main()
+        .contains(
+          "All users in Acme Corp will connect using the acme_role database role.",
+        )
+        .should("be.visible");
     });
   });
 
@@ -1303,6 +1386,13 @@ describe("scenarios - embedding hub", () => {
           database_slug: "acme-db",
         });
       });
+
+      cy.log("data permissions description should show in summary");
+      H.main()
+        .contains(
+          "All users in Acme Corp will be routed to the acme-db database.",
+        )
+        .should("be.visible");
     });
   });
 
@@ -1407,50 +1497,45 @@ describe("scenarios - embedding hub", () => {
     });
   });
 
-  [
-    { plan: "pro-cloud", expectedPath: "help-premium" },
-    { plan: "starter", expectedPath: "help" },
-  ].forEach(({ plan, expectedPath }) => {
-    it(`shows /${expectedPath} troubleshooting link for ${plan} plan in sso setup`, () => {
-      H.restore("setup");
-      cy.signInAsAdmin();
-      H.activateToken(plan as "pro-cloud" | "starter");
+  it("shows /help-premium troubleshooting link for pro-cloud plan in sso setup", () => {
+    H.restore("setup");
+    cy.signInAsAdmin();
+    H.activateToken("pro-cloud");
 
-      cy.log("enable JWT");
-      cy.request("PUT", "/api/setting", {
-        "jwt-enabled": true,
-        "jwt-identity-provider-uri": "https://jwt.example.com/auth",
-        "jwt-shared-secret": "0".repeat(64),
-      });
-
-      cy.visit("/admin/embedding/setup-guide/sso");
-
-      cy.log("step 1 should be marked as done");
-      H.main()
-        .findByRole("listitem", {
-          name: "Set up JWT authentication",
-          timeout: 10_000,
-        })
-        .should("have.attr", "data-completed", "true");
-
-      cy.log("navigate to step 3");
-      H.main()
-        .findByRole("listitem", {
-          name: "Test that JWT authentication is working correctly",
-        })
-        .click();
-
-      cy.log("click troubleshooting button");
-      H.main().findByRole("button", { name: "No, I couldn't log in" }).click();
-
-      cy.log("troubleshooting view should be shown");
-      H.main().findByText("Troubleshooting").should("be.visible");
-
-      cy.log(`help link should point to /${expectedPath}`);
-      H.main()
-        .findByRole("link", { name: "Contact customer support" })
-        .should("have.attr", "href")
-        .and("include", `metabase.com/${expectedPath}`);
+    cy.log("enable JWT");
+    cy.request("PUT", "/api/setting", {
+      "jwt-enabled": true,
+      "jwt-identity-provider-uri": "https://jwt.example.com/auth",
+      "jwt-shared-secret": "0".repeat(64),
     });
+
+    cy.visit("/admin/embedding/setup-guide/sso");
+
+    cy.log("step 1 should be marked as done");
+    H.main()
+      .findByRole("listitem", {
+        name: "Set up JWT authentication",
+        timeout: 10_000,
+      })
+      .should("have.attr", "data-completed", "true");
+
+    cy.log("navigate to step 3");
+    H.main()
+      .findByRole("listitem", {
+        name: "Test that JWT authentication is working correctly",
+      })
+      .click();
+
+    cy.log("click troubleshooting button");
+    H.main().findByRole("button", { name: "No, I couldn't log in" }).click();
+
+    cy.log("troubleshooting view should be shown");
+    H.main().findByText("Troubleshooting").should("be.visible");
+
+    cy.log("help link should point to /help-premium");
+    H.main()
+      .findByRole("link", { name: "Contact customer support" })
+      .should("have.attr", "href")
+      .and("include", "metabase.com/help-premium");
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/CreateTenantsOnboardingStep/hooks/use-field-distinct-values.ts
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/CreateTenantsOnboardingStep/hooks/use-field-distinct-values.ts
@@ -45,11 +45,12 @@ export function useFieldDistinctValues(fieldId: FieldId | undefined) {
         breakout,
         limit: DISTINCT_VALUES_LIMIT,
       },
+      ignore_error: true,
     };
   }, [fieldId, tableId, databaseId]);
 
   const { data: adhocQueryDataset, isLoading: isAdHocQueryLoading } =
-    useGetAdhocQueryQuery(query ?? skipToken, { ignore_error: true });
+    useGetAdhocQueryQuery(query ?? skipToken);
 
   // Extract row values from query results
   const values = useMemo(() => {

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantsSummaryOnboardingStep/TenantSummaryCard.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantsSummaryOnboardingStep/TenantSummaryCard.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { t } from "ttag";
 
 import { Grid, Paper, Stack, Text, Title } from "metabase/ui";
@@ -7,11 +8,13 @@ export const TenantSummaryCard = ({
   slug,
   isolationFieldLabel,
   isolationFieldValue,
+  dataPermissionsDescription,
 }: {
   name: string;
   slug: string;
   isolationFieldLabel: string | null;
   isolationFieldValue: string | null;
+  dataPermissionsDescription: ReactNode;
 }) => {
   return (
     <Paper withBorder p="lg" radius="md">
@@ -47,18 +50,19 @@ export const TenantSummaryCard = ({
             </Stack>
           </Grid.Col>
 
-          <Grid.Col span={4}>
-            <Stack gap={4}>
-              <Text size="xs" c="text-secondary">
-                {t`Data permissions`}
-              </Text>
+          {dataPermissionsDescription && (
+            <Grid.Col span={4}>
+              <Stack gap={4}>
+                <Text size="xs" c="text-secondary">
+                  {t`Data permissions`}
+                </Text>
 
-              <Text size="sm" c="text-primary">
-                {/* TODO(EMB-1268): Add data permissions info when available */}
-                {t`Configured via data segregation`}
-              </Text>
-            </Stack>
-          </Grid.Col>
+                <Text size="sm" c="text-primary">
+                  {dataPermissionsDescription}
+                </Text>
+              </Stack>
+            </Grid.Col>
+          )}
         </Grid>
       </Stack>
     </Paper>

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantsSummaryOnboardingStep/TenantsSummaryOnboardingStep.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantsSummaryOnboardingStep/TenantsSummaryOnboardingStep.tsx
@@ -1,15 +1,17 @@
+import type { ReactNode } from "react";
 import { useMemo } from "react";
 import { push } from "react-router-redux";
-import { match } from "ts-pattern";
-import { t } from "ttag";
+import { jt, msgid, ngettext, t } from "ttag";
 
 import { RelatedSettingCard } from "metabase/admin/components/RelatedSettingsSection";
 import type { DataSegregationStrategy } from "metabase/embedding/embedding-hub";
+import { conjunct } from "metabase/lib/formatting/strings";
 import { useDispatch } from "metabase/lib/redux";
 import type { CreatedTenantData } from "metabase/plugins/oss/tenants";
 import { Button, Flex, SimpleGrid, Stack, Text, Title } from "metabase/ui";
 
 import { useListTenantsQuery } from "../../../api/tenants";
+import { getIsolationFieldConfig } from "../CreateTenantsOnboardingStep/isolation-field-config";
 
 import { TenantSummaryCard } from "./TenantSummaryCard";
 
@@ -28,9 +30,13 @@ const ISOLATION_ATTRIBUTE_KEYS = [
 export const TenantsSummaryOnboardingStep = ({
   tenants,
   strategy,
+  rlsTableNames = [],
+  rlsColumnName = null,
 }: {
   tenants: CreatedTenantData[];
   strategy?: DataSegregationStrategy | null;
+  rlsTableNames?: string[];
+  rlsColumnName?: string | null;
 }) => {
   const dispatch = useDispatch();
 
@@ -66,7 +72,7 @@ export const TenantsSummaryOnboardingStep = ({
     });
   }, [tenants, tenantsData]);
 
-  const isolationFieldLabel = getIsolationFieldLabel(strategy);
+  const fieldConfig = getIsolationFieldConfig(strategy);
 
   return (
     <Stack gap="lg">
@@ -80,10 +86,19 @@ export const TenantsSummaryOnboardingStep = ({
             key={tenant.slug}
             name={tenant.name}
             isolationFieldLabel={
-              tenant.dataIsolationFieldValue ? isolationFieldLabel : null
+              tenant.dataIsolationFieldValue
+                ? (fieldConfig?.label ?? null)
+                : null
             }
             isolationFieldValue={tenant.dataIsolationFieldValue || null}
             slug={tenant.slug}
+            dataPermissionsDescription={getDataPermissionsDescription({
+              strategy,
+              tenantName: tenant.name,
+              tenantValue: tenant.dataIsolationFieldValue,
+              tableNames: rlsTableNames,
+              columnName: rlsColumnName,
+            })}
           />
         ))}
       </Stack>
@@ -131,11 +146,44 @@ const RelatedSettingsSection = () => (
   </SimpleGrid>
 );
 
-export const getIsolationFieldLabel = (
-  strategy: DataSegregationStrategy | null | undefined,
-): string | null =>
-  match(strategy)
-    .with("row-column-level-security", () => "tenant_identifier")
-    .with("connection-impersonation", () => "database_role")
-    .with("database-routing", () => "database_slug")
-    .otherwise(() => null);
+export function getDataPermissionsDescription({
+  strategy,
+  tenantName,
+  tenantValue,
+  tableNames,
+  columnName,
+}: {
+  strategy: DataSegregationStrategy | null | undefined;
+  tenantName: string;
+  tenantValue: string;
+  tableNames: string[];
+  columnName: string | null;
+}): ReactNode {
+  if (!tenantValue) {
+    return null;
+  }
+
+  const boldName = <strong key="tenant">{tenantName}</strong>;
+  const boldValue = <strong key="value">{tenantValue}</strong>;
+
+  if (strategy === "row-column-level-security") {
+    if (tableNames.length === 0 || !columnName) {
+      return null;
+    }
+
+    const tableList = conjunct(tableNames, t`and`);
+    const tableWord = ngettext(msgid`table`, `tables`, tableNames.length);
+
+    return jt`All users in ${boldName} can view rows in the ${(<strong key="tables">{tableList}</strong>)} ${tableWord} where ${(<strong key="column">{columnName}</strong>)} field equals ${boldValue}.`;
+  }
+
+  if (strategy === "connection-impersonation") {
+    return jt`All users in ${boldName} will connect using the ${boldValue} database role.`;
+  }
+
+  if (strategy === "database-routing") {
+    return jt`All users in ${boldName} will be routed to the ${boldValue} database.`;
+  }
+
+  return null;
+}

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantsSummaryOnboardingStep/TenantsSummaryOnboardingStep.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantsSummaryOnboardingStep/TenantsSummaryOnboardingStep.unit.spec.ts
@@ -1,0 +1,143 @@
+import { type ReactNode, isValidElement } from "react";
+
+import { getDataPermissionsDescription } from "./TenantsSummaryOnboardingStep";
+
+type Input = Parameters<typeof getDataPermissionsDescription>[0];
+
+const TENANT_NAME = "Acme Corp";
+const TENANT_VALUE = "42";
+
+const TEST_CASES: { name: string; input: Input; expected: string | null }[] = [
+  {
+    name: "RLS with one table",
+    input: {
+      strategy: "row-column-level-security",
+      tenantName: TENANT_NAME,
+      tenantValue: TENANT_VALUE,
+      tableNames: ["Orders"],
+      columnName: "company_id",
+    },
+    expected:
+      "All users in Acme Corp can view rows in the Orders table where company_id field equals 42.",
+  },
+  {
+    name: "RLS with two tables",
+    input: {
+      strategy: "row-column-level-security",
+      tenantName: TENANT_NAME,
+      tenantValue: TENANT_VALUE,
+      tableNames: ["Orders", "Products"],
+      columnName: "company_id",
+    },
+    expected:
+      "All users in Acme Corp can view rows in the Orders and Products tables where company_id field equals 42.",
+  },
+  {
+    name: "RLS with three tables (Oxford comma)",
+    input: {
+      strategy: "row-column-level-security",
+      tenantName: TENANT_NAME,
+      tenantValue: TENANT_VALUE,
+      tableNames: ["Orders", "Products", "Reviews"],
+      columnName: "company_id",
+    },
+    expected:
+      "All users in Acme Corp can view rows in the Orders, Products, and Reviews tables where company_id field equals 42.",
+  },
+  {
+    name: "RLS with empty tableNames → null",
+    input: {
+      strategy: "row-column-level-security",
+      tenantName: TENANT_NAME,
+      tenantValue: TENANT_VALUE,
+      tableNames: [],
+      columnName: "company_id",
+    },
+    expected: null,
+  },
+  {
+    name: "RLS with null columnName → null",
+    input: {
+      strategy: "row-column-level-security",
+      tenantName: TENANT_NAME,
+      tenantValue: TENANT_VALUE,
+      tableNames: ["Orders"],
+      columnName: null,
+    },
+    expected: null,
+  },
+  {
+    name: "connection-impersonation",
+    input: {
+      strategy: "connection-impersonation",
+      tenantName: TENANT_NAME,
+      tenantValue: "acme_role",
+      tableNames: [],
+      columnName: null,
+    },
+    expected:
+      "All users in Acme Corp will connect using the acme_role database role.",
+  },
+  {
+    name: "database-routing",
+    input: {
+      strategy: "database-routing",
+      tenantName: TENANT_NAME,
+      tenantValue: "acme-db",
+      tableNames: [],
+      columnName: null,
+    },
+    expected: "All users in Acme Corp will be routed to the acme-db database.",
+  },
+  {
+    name: "empty tenantValue → null",
+    input: {
+      strategy: "connection-impersonation",
+      tenantName: TENANT_NAME,
+      tenantValue: "",
+      tableNames: [],
+      columnName: null,
+    },
+    expected: null,
+  },
+  {
+    name: "unknown strategy → null",
+    input: {
+      strategy: null,
+      tenantName: TENANT_NAME,
+      tenantValue: TENANT_VALUE,
+      tableNames: [],
+      columnName: null,
+    },
+    expected: null,
+  },
+];
+
+describe("getDataPermissionsDescription", () => {
+  it.each(TEST_CASES)("$name", ({ input, expected }) => {
+    expect(textFromReactNode(getDataPermissionsDescription(input))).toBe(
+      expected,
+    );
+  });
+});
+
+/** Extracts plain text from a ReactNode, ignoring formatting elements. */
+function textFromReactNode(node: ReactNode): string | null {
+  if (node === null) {
+    return null;
+  }
+
+  if (typeof node === "string" || typeof node === "number") {
+    return String(node);
+  }
+
+  if (Array.isArray(node)) {
+    return node.map((n) => textFromReactNode(n) ?? "").join("");
+  }
+
+  if (isValidElement(node)) {
+    return textFromReactNode(node.props.children) ?? "";
+  }
+
+  return "";
+}

--- a/frontend/src/metabase/admin/routes.tsx
+++ b/frontend/src/metabase/admin/routes.tsx
@@ -195,11 +195,7 @@ export const getRoutes = (
                 component={SetupPermissionsAndTenantsPage}
               />
 
-              <Route
-                path="sso"
-                title={t`Configure SSO`}
-                component={SetupSsoPage}
-              />
+              <Route path="sso" component={SetupSsoPage} />
             </Route>
 
             {/* EE with non-starter plan has embedding settings on different pages */}

--- a/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/RlsDataSelector/RlsDataSelector.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/RlsDataSelector/RlsDataSelector.tsx
@@ -14,10 +14,19 @@ import { TableColumnCard } from "./TableColumnCard";
 export interface TableColumnSelection {
   tableId: TableId | null;
   columnId: FieldId | null;
+  /** Resolved by TableColumnCard once table metadata is loaded */
+  tableName?: string | null;
+  columnName?: string | null;
+}
+
+export interface RlsSelectionResult {
+  fieldIds: FieldId[];
+  tableNames: string[];
+  columnName: string | null;
 }
 
 interface RlsDataSelectorProps {
-  onSuccess: (selectedFieldIds: FieldId[]) => void;
+  onSuccess: (result: RlsSelectionResult) => void;
 }
 
 export const RlsDataSelector = ({ onSuccess }: RlsDataSelectorProps) => {
@@ -28,14 +37,25 @@ export const RlsDataSelector = ({ onSuccess }: RlsDataSelectorProps) => {
   ]);
 
   const { handleUpsertPolicies, isCreatingPolicy, isLoadingPolicies } =
-    useUpsertGroupTableAccessPolicies({
-      tableColumnSelections: selections,
-      onSuccess,
-    });
+    useUpsertGroupTableAccessPolicies({ tableColumnSelections: selections });
 
   const handleSubmit = useCallback(async () => {
     try {
       await handleUpsertPolicies();
+      onSuccess({
+        fieldIds: selections
+          .map((s) => s.columnId)
+          .filter((id): id is FieldId => id != null),
+
+        tableNames: selections
+          .map((s) => s.tableName)
+          .filter((name): name is string => name != null),
+
+        // We use the first selection's column name for the summary description.
+        // In practice, all tables in an RLS setup share the same tenant
+        // identifier column (e.g. tenant_id).
+        columnName: selections[0]?.columnName ?? null,
+      });
     } catch (error) {
       sendToast({
         icon: "warning",
@@ -46,7 +66,7 @@ export const RlsDataSelector = ({ onSuccess }: RlsDataSelectorProps) => {
         ),
       });
     }
-  }, [handleUpsertPolicies, sendToast]);
+  }, [handleUpsertPolicies, selections, onSuccess, sendToast]);
 
   const addTable = useCallback(() => {
     setSelections((prev) => [...prev, { tableId: null, columnId: null }]);

--- a/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/RlsDataSelector/TableColumnCard.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/RlsDataSelector/TableColumnCard.tsx
@@ -54,7 +54,12 @@ export const TableColumnCard = ({
   const handleTableSelect = useCallback(
     (item: MiniPickerPickableItem) => {
       if (item.model === "table") {
-        onChange({ tableId: item.id, columnId: null });
+        onChange({
+          tableId: item.id,
+          columnId: null,
+          tableName: null,
+          columnName: null,
+        });
         closePicker();
       }
     },
@@ -63,7 +68,7 @@ export const TableColumnCard = ({
 
   const handleModalSelect = useCallback(
     (tableId: TableId) => {
-      onChange({ tableId, columnId: null });
+      onChange({ tableId, columnId: null, tableName: null, columnName: null });
       closeBrowse();
     },
     [onChange, closeBrowse],
@@ -76,12 +81,17 @@ export const TableColumnCard = ({
 
   const handleColumnSelect = useCallback(
     (columnId: string | null) => {
+      const field = tableMetadata?.fields?.find(
+        (f) => String(f.id) === columnId,
+      );
       onChange({
         ...selection,
         columnId: columnId ? Number(columnId) : null,
+        tableName: tableMetadata?.display_name ?? null,
+        columnName: field?.display_name ?? null,
       });
     },
-    [selection, onChange],
+    [selection, onChange, tableMetadata],
   );
 
   const columnOptions =

--- a/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/RlsDataSelector/index.ts
+++ b/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/RlsDataSelector/index.ts
@@ -1,1 +1,5 @@
-export { RlsDataSelector, type TableColumnSelection } from "./RlsDataSelector";
+export {
+  RlsDataSelector,
+  type TableColumnSelection,
+  type RlsSelectionResult,
+} from "./RlsDataSelector";

--- a/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/SetupPermissionsAndTenantsPage.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/SetupPermissionsAndTenantsPage.tsx
@@ -11,7 +11,6 @@ import {
   PLUGIN_TENANTS,
 } from "metabase/plugins/oss/tenants";
 import { Group, Icon, Stack, Text, Title } from "metabase/ui";
-import type { FieldId } from "metabase-types/api";
 
 import { ConnectionImpersonationStepContent } from "./ConnectionImpersonationStepContent";
 import {
@@ -20,6 +19,7 @@ import {
 } from "./DataSegregationStrategyPicker";
 import { DatabaseRoutingStepContent } from "./DatabaseRoutingStepContent";
 import { EnableTenantsStepContent } from "./EnableTenantsStepContent";
+import type { RlsSelectionResult } from "./RlsDataSelector";
 import { RlsDataSelector } from "./RlsDataSelector";
 import S from "./SetupPermissionsAndTenantsPage.module.css";
 
@@ -41,8 +41,12 @@ export const SetupPermissionsAndTenantsPage = () => {
   // Track the tenants created in this onboarding flow
   const [createdTenants, setCreatedTenants] = useState<CreatedTenantData[]>([]);
 
-  // Track the selected field IDs from the RLS step (in-session only)
-  const [selectedFieldIds, setSelectedFieldIds] = useState<FieldId[]>([]);
+  // Track RLS selection from the "Select data" step (in-session only)
+  const [rlsSelection, setRlsSelection] = useState<RlsSelectionResult>({
+    fieldIds: [],
+    tableNames: [],
+    columnName: null,
+  });
 
   // Prefer in-session UI state; fall back to backend detection for reloads
   const activeStrategy =
@@ -152,8 +156,8 @@ export const SetupPermissionsAndTenantsPage = () => {
           {match(activeStrategy)
             .with("row-column-level-security", () => (
               <RlsDataSelector
-                onSuccess={(fieldIds) => {
-                  setSelectedFieldIds(fieldIds);
+                onSuccess={(result) => {
+                  setRlsSelection(result);
 
                   // User might had already created tenants before,
                   // so we allow jumping straight to the summary flow.
@@ -176,7 +180,7 @@ export const SetupPermissionsAndTenantsPage = () => {
         >
           <PLUGIN_TENANTS.CreateTenantsOnboardingStep
             onTenantsCreated={setCreatedTenants}
-            selectedFieldIds={selectedFieldIds}
+            selectedFieldIds={rlsSelection.fieldIds}
             strategy={activeStrategy}
           />
         </OnboardingStepper.Step>
@@ -189,6 +193,8 @@ export const SetupPermissionsAndTenantsPage = () => {
           <PLUGIN_TENANTS.TenantsSummaryOnboardingStep
             tenants={createdTenants}
             strategy={activeStrategy}
+            rlsTableNames={rlsSelection.tableNames}
+            rlsColumnName={rlsSelection.columnName}
           />
         </OnboardingStepper.Step>
       </OnboardingStepper>

--- a/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/hooks/use-upsert-group-table-access-policies.ts
+++ b/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/hooks/use-upsert-group-table-access-policies.ts
@@ -3,7 +3,6 @@ import { t } from "ttag";
 
 import { tableApi, useListGroupTableAccessPoliciesQuery } from "metabase/api";
 import { useDispatch } from "metabase/lib/redux";
-import type { FieldId } from "metabase-types/api";
 
 import type { TableColumnSelection } from "../RlsDataSelector";
 
@@ -11,7 +10,6 @@ import { useUpdateAllTenantUsersGroupPermissions } from "./use-update-all-tenant
 
 interface UseUpsertGroupTableAccessPoliciesProps {
   tableColumnSelections: TableColumnSelection[];
-  onSuccess?: (selectedFieldIds: FieldId[]) => void;
 }
 
 /**
@@ -20,7 +18,6 @@ interface UseUpsertGroupTableAccessPoliciesProps {
  */
 export const useUpsertGroupTableAccessPolicies = ({
   tableColumnSelections,
-  onSuccess,
 }: UseUpsertGroupTableAccessPoliciesProps) => {
   const dispatch = useDispatch();
 
@@ -78,18 +75,6 @@ export const useUpsertGroupTableAccessPolicies = ({
 
       const sandboxedTables = nextPolicies.filter((entry) => entry != null);
       await updateDataAccess({ sandboxedTables });
-
-      // Extract field IDs from policies that were actually created/updated,
-      // excluding entries that were skipped (e.g. table failed to fetch).
-      const selectedFieldIds = Array.from(
-        new Set(
-          sandboxedTables
-            .map((policy) => policy.filterFieldId)
-            .filter((id): id is FieldId => id != null),
-        ),
-      );
-
-      onSuccess?.(selectedFieldIds);
     } finally {
       setIsCreatingPolicy(false);
     }
@@ -97,7 +82,6 @@ export const useUpsertGroupTableAccessPolicies = ({
     tenantUsersGroupId,
     tableColumnSelections,
     updateDataAccess,
-    onSuccess,
     dispatch,
     existingPolicies,
   ]);

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-common-embed-settings.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-common-embed-settings.ts
@@ -55,7 +55,6 @@ const GET_DISABLE_GUEST_EMBED_SETTINGS: (data: {
   > = ({ experience, isSsoEnabledAndConfigured, useExistingUserSession }) => {
   const isQuestionOrDashboardEmbed =
     isQuestionOrDashboardExperience(experience);
-  const isQuestionEmbed = experience === "chart";
 
   return {
     ...(isQuestionOrDashboardEmbed
@@ -72,8 +71,8 @@ const GET_DISABLE_GUEST_EMBED_SETTINGS: (data: {
           useExistingUserSession:
             !isSsoEnabledAndConfigured || useExistingUserSession,
         }),
-    ...(isQuestionEmbed && {
-      // Currently, a chart should not have hidden parameters in non-guest embed mode
+    ...(isQuestionOrDashboardEmbed && {
+      // Reset hidden parameters when switching from guest to non-guest embed mode
       hiddenParameters: [],
     }),
   };

--- a/frontend/src/metabase/plugins/oss/tenants.ts
+++ b/frontend/src/metabase/plugins/oss/tenants.ts
@@ -45,6 +45,8 @@ const getDefaultPluginTenants = () => ({
   TenantsSummaryOnboardingStep: PluginPlaceholder as React.ComponentType<{
     tenants: CreatedTenantData[];
     strategy?: DataSegregationStrategy | null;
+    rlsTableNames?: string[];
+    rlsColumnName?: string | null;
   }>,
   EditUserStrategySettingsButton: PluginPlaceholder,
   FormTenantWidget: (_props: any) => null as React.ReactElement | null,
@@ -116,6 +118,8 @@ export const PLUGIN_TENANTS: {
   TenantsSummaryOnboardingStep: React.ComponentType<{
     tenants: CreatedTenantData[];
     strategy?: DataSegregationStrategy | null;
+    rlsTableNames?: string[];
+    rlsColumnName?: string | null;
   }>;
   EditUserStrategySettingsButton: (props: {
     page: "people" | "tenants";


### PR DESCRIPTION
Closes EMB-1351

### Description

The "Data permissions" section in the tenant creation summary now shows a strategy-specific sentence instead of the generic placeholder text. For RLS it shows which tables and column are filtered and with what value; for connection impersonation it shows the database role; for database routing it shows the destination database slug.

### How to verify

1. Go to `/admin/embedding/setup-guide/permissions`
2. Enable multi-tenant user strategy
3. Select **Row and column level security**, pick a table and column, click Next
4. Create a tenant with a `tenant_identifier` value and click Next
5. On the Summary screen, verify the "Data permissions" section shows: *"All users in [name] can view rows in the [table] tables where [column] field equals [value]."*
6. Repeat steps 2–5 with **Connection impersonation** — verify: *"All users in [name] will connect using the [role] database role."*
7. Repeat with **Database routing** — verify: *"All users in [name] will be routed to the [slug] database."*

### KNOWN ISSUES

- If you've already completed a data segregation step and try to set it up with a different strategy, it doesn't re-open the "create tenants" step for you to fill in a different segregation value e.g. database_role. I'll create a follow-up task.

### Demo

<img width="1376" height="1164" alt="CleanShot 2569-03-04 at 23 08 50@2x" src="https://github.com/user-attachments/assets/c36d6e40-9f82-42ba-8118-8a4f135bf214" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR