### PR TITLE
[MBQL lib] Prefer calling exported versions of several `lib.util` fns

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/util.clj
@@ -9,7 +9,6 @@
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.types.isa :as lib.types.isa]
-   [metabase.lib.util :as lib.util]
    [metabase.premium-features.core :as premium-features]
    [metabase.util :as u]
    [toucan2.core :as t2]))
@@ -42,8 +41,9 @@
   (cond-> col
     (and (:fk-field-id col)
          (:table-id col))
-    (assoc :table-reference (-> (lib/display-name query (lib.metadata/field query (:fk-field-id col)))
-                                lib.util/strip-id))))
+    (assoc :table-reference (->> (lib.metadata/field query (:fk-field-id col))
+                                 (lib/display-name query)
+                                 lib/display-name-without-id))))
 
 (defn table-field-id-prefix
   "Return the field ID prefix for `table-id`."

--- a/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/sandboxing.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/sandboxing.clj
@@ -20,7 +20,6 @@
    [metabase.lib.schema.metadata :as lib.schema.metadata]
    [metabase.lib.schema.parameter :as lib.schema.parameter]
    [metabase.lib.schema.util :as lib.schema.util]
-   [metabase.lib.util :as lib.util]
    [metabase.lib.util.match :as lib.util.match]
    [metabase.lib.walk :as lib.walk]
    [metabase.premium-features.core :as premium-features :refer [defenterprise]]
@@ -206,8 +205,8 @@
   [query   :- ::lib.schema/query
    card-id :- [:maybe ::lib.schema.id/card]]
   (or (when (= (count (:stages query)) 1)
-        (let [first-stage (lib.util/query-stage query 0)]
-          (when (and (lib.util/native-stage? first-stage)
+        (let [first-stage (lib/query-stage query 0)]
+          (when (and (lib/native-stage? first-stage)
                      (not (:lib/stage-metadata first-stage)))
             (when-let [cols (not-empty (native-query-metadata query))]
               (when card-id

--- a/src/metabase/lib/core.cljc
+++ b/src/metabase/lib/core.cljc
@@ -574,3 +574,12 @@
   **Code Health:** Discouraged; there are few legitimate use cases for working with raw card IDs outside lib."
   [a-query :- :metabase.lib.schema/query]
   (lib.util/source-card-id a-query))
+
+(mu/defn display-name-without-id :- :string
+  "Given a display name like `\"Something ID\"`, remove the \"ID\" portion and trim whitespace.
+
+  Useful to turn a FK field's name into a pseudo table name, when doing an implicit join.
+
+  **Code Health:** Healthy."
+  [field-display-name :- :string]
+  (lib.util/strip-id field-display-name))

--- a/src/metabase/queries/models/query.clj
+++ b/src/metabase/queries/models/query.clj
@@ -5,7 +5,6 @@
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.schema.id :as lib.schema.id]
-   [metabase.lib.util :as lib.util]
    [metabase.models.interface :as mi]
    [metabase.queries.schema :as queries.schema]
    [metabase.util.honey-sql-2 :as h2x]
@@ -100,12 +99,12 @@
   Expects MBQL 5 queries."
   [{database-id :database, :as query} :- ::queries.schema/query]
   (when (seq query)
-    (if-let [source-card-id (lib.util/source-card-id query)]
+    (if-let [source-card-id (lib/primary-source-card-id query)]
       (let [card (or (lib.metadata/card query source-card-id)
                      ;; Card may belong to a different Database; fetch from the app DB
                      (t2/select-one [:model/Card [:database_id :database-id] [:table_id :table-id]] :id source-card-id))]
         (merge {:table-id nil, :database-id (:database query)} (select-keys card [:database-id :table-id])))
-      (let [table-id (lib.util/source-table-id query)]
+      (let [table-id (lib/primary-source-table-id query)]
         {:database-id database-id
          :table-id    table-id}))))
 

--- a/src/metabase/query_processor/middleware/add_default_temporal_unit.clj
+++ b/src/metabase/query_processor/middleware/add_default_temporal_unit.clj
@@ -5,7 +5,6 @@
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.schema :as lib.schema]
-   [metabase.lib.util :as lib.util]
    [metabase.lib.walk :as lib.walk]
    [metabase.util.malli :as mu]))
 
@@ -13,7 +12,7 @@
   (lib.walk/walk-clauses
    query
    (fn [query _path-type path clause]
-     (when (and (lib.util/clause-of-type? clause :field)
+     (when (and (lib/clause-of-type? clause :field)
                 (not (lib/raw-temporal-bucket clause))
                 (isa? (lib.walk/apply-f-for-stage-at-path lib/type-of query path clause) :type/Temporal))
        (lib/with-temporal-bucket clause :default)))))

--- a/src/metabase/query_processor/middleware/auto_bucket_datetimes.clj
+++ b/src/metabase/query_processor/middleware/auto_bucket_datetimes.clj
@@ -10,7 +10,6 @@
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.lib.schema.id :as lib.schema.id]
-   [metabase.lib.util :as lib.util]
    [metabase.lib.util.match :as lib.util.match]
    [metabase.lib.walk :as lib.walk]
    [metabase.util.log :as log]
@@ -65,13 +64,13 @@
 
 (defn- auto-bucketable-value? [v]
   (or (yyyy-MM-dd-date-string? v)
-      (lib.util/clause-of-type? v :relative-datetime)))
+      (lib/clause-of-type? v :relative-datetime)))
 
 (mu/defn- filter-clause?
   [query      :- ::lib.schema/query
    stage-path :- ::lib.walk/stage-path
    x]
-  (and (lib.util/clause? x)
+  (and (lib/clause? x)
        (when-let [expr-type (try
                               (lib.walk/apply-f-for-stage-at-path lib/type-of query stage-path x)
                               (catch Throwable e
@@ -84,7 +83,7 @@
    stage-path :- ::lib.walk/stage-path
    x]
   (and (filter-clause? query stage-path x)
-       (not (lib.util/clause-of-type? x #{:and :or :not}))))
+       (not (lib/clause-of-type? x #{:and :or :not}))))
 
 (mr/def ::do-not-bucket-reason
   [:and
@@ -105,7 +104,7 @@
     (cond
       ;; *  is not an equality or comparison filter. e.g. wouldn't make sense to bucket a field and then check if it is
       ;;    `NOT NULL`
-      (not (lib.util/clause-of-type? x #{:= :!= :< :> :<= :>= :between}))
+      (not (lib/clause-of-type? x #{:= :!= :< :> :<= :>= :between}))
       :do-not-bucket-reason/not-equality-or-comparison-filter
 
       ;; *  has arguments that aren't `yyyy-MM-dd` date strings. The only reason we auto-bucket datetime clauses in the
@@ -126,12 +125,12 @@
 
     ;; do not auto-bucket clauses inside a `:time-interval` filter: it already supplies its own unit
     ;; do not auto-bucket clauses inside a `:datetime-diff` clause: the precise timestamp is needed for the difference
-    (lib.util/clause-of-type? x #{:time-interval :datetime-diff})
+    (lib/clause-of-type? x #{:time-interval :datetime-diff})
     :do-not-bucket-reason/bucketed-or-precise-operation
 
     ;; do not autobucket clauses that already have a temporal unit, or have a binning strategy
-    (and (or (lib.util/clause-of-type? x :expression)
-             (lib.util/clause-of-type? x :field))
+    (and (or (lib/clause-of-type? x :expression)
+             (lib/clause-of-type? x :field))
          (let [[_tag opts _id-or-name] x]
            ((some-fn :temporal-unit :binning) opts)))
     :do-not-bucket-reason/field-with-bucketing-or-binning

--- a/src/metabase/query_processor/middleware/desugar.clj
+++ b/src/metabase/query_processor/middleware/desugar.clj
@@ -3,7 +3,6 @@
   (:require
    [metabase.lib.core :as lib]
    [metabase.lib.schema :as lib.schema]
-   [metabase.lib.util :as lib.util]
    [metabase.lib.util.match :as lib.util.match]
    [metabase.lib.walk :as lib.walk]
    [metabase.util.malli :as mu]
@@ -13,7 +12,7 @@
   [stage-or-join]
   (letfn [(desugar** [x]
             (lib.util.match/replace-lite x
-              (clause :guard lib.util/clause?)
+              (clause :guard lib/clause?)
               (lib/desugar-filter-clause clause)))]
     (merge
      (desugar** (dissoc stage-or-join :joins :stages :lib/stage-metadata :parameters))

--- a/src/metabase/query_processor/middleware/expand_aggregations.clj
+++ b/src/metabase/query_processor/middleware/expand_aggregations.clj
@@ -2,8 +2,8 @@
   (:refer-clojure :exclude [select-keys])
   (:require
    [medley.core :as m]
+   [metabase.lib.core :as lib]
    [metabase.lib.options :as lib.options]
-   [metabase.lib.util :as lib.util]
    [metabase.lib.walk :as lib.walk]
    [metabase.util.performance :refer [select-keys]]))
 
@@ -12,12 +12,12 @@
   (let [name-opts  (-> aggregation-ref lib.options/options (select-keys [:name :display-name]))]
     (-> aggregation
         (lib.options/update-options merge name-opts)
-        lib.util/fresh-uuids)))
+        lib/fresh-uuids)))
 
 (defn- unroll-form
   [form aggregations expanded expanding]
   (cond
-    (lib.util/clause-of-type? form :aggregation)
+    (lib/clause-of-type? form :aggregation)
     (let [ref (get form 2)
           expansion (get expanded ref)
           definition (get aggregations ref)]

--- a/src/metabase/query_processor/middleware/expand_macros.clj
+++ b/src/metabase/query_processor/middleware/expand_macros.clj
@@ -4,12 +4,12 @@
   (`:segment` forms are expanded into filter clauses.)"
   (:refer-clojure :exclude [mapv not-empty get-in])
   (:require
+   [metabase.lib.core :as lib]
    [metabase.lib.filter :as lib.filter]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.expression :as lib.schema.expression]
    [metabase.lib.schema.metadata :as lib.schema.metadata]
-   [metabase.lib.util :as lib.util]
    [metabase.lib.util.match :as lib.util.match]
    [metabase.lib.walk :as lib.walk]
    [metabase.query-processor.error-type :as qp.error-type]
@@ -63,7 +63,7 @@
 (mu/defn- legacy-macro-filters :- [:maybe [:sequential ::lib.schema.expression/boolean]]
   "Get the filter(s) associated with a Segment."
   [legacy-macro :- ::legacy-macro]
-  (mapv lib.util/fresh-uuids
+  (mapv lib/fresh-uuids
         (get-in legacy-macro [:definition :filters])))
 
 (mr/def ::id->legacy-macro

--- a/src/metabase/query_processor/middleware/fetch_source_query.clj
+++ b/src/metabase/query_processor/middleware/fetch_source_query.clj
@@ -125,7 +125,7 @@
           model?        (= (:type card) :model)
           native-model? (when model?
                           (-> (lib.card/card->underlying-query query card)
-                              (lib.util/native-stage? -1)))
+                              (lib/native-stage? -1)))
           ;; TODO this information WAS used
           ;; by [[metabase.query-processor.middleware.annotate/col-info-for-field-clause*]] which doesn't exist anymore
           ;; -- do we still need it? -- Cam

--- a/src/metabase/query_processor/middleware/measures.clj
+++ b/src/metabase/query_processor/middleware/measures.clj
@@ -14,7 +14,6 @@
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.options :as lib.options]
    [metabase.lib.schema :as lib.schema]
-   [metabase.lib.util :as lib.util]
    [metabase.lib.util.match :as lib.util.match]
    [metabase.lib.walk :as lib.walk]
    [metabase.query-processor.error-type :as qp.error-type]
@@ -30,7 +29,7 @@
   [query-or-clause]
   (let [found? (volatile! false)
         check-clause (fn [x]
-                       (when (lib.util/clause-of-type? x :metric)
+                       (when (lib/clause-of-type? x :metric)
                          (vreset! found? true))
                        nil)]
     (if (map? query-or-clause)
@@ -73,7 +72,7 @@
   Measure definitions are MBQL 5 queries with a single stage containing one aggregation."
   [{:keys [definition]}]
   (when-let [aggregation (-> definition :stages first :aggregation first)]
-    (lib.util/fresh-uuids aggregation)))
+    (lib/fresh-uuids aggregation)))
 
 (mu/defn- expand-measures-in-stage :- ::lib.schema/stage
   "Replace :measure clauses in a stage with their actual aggregation expressions."

--- a/src/metabase/query_processor/middleware/metrics.clj
+++ b/src/metabase/query_processor/middleware/metrics.clj
@@ -16,7 +16,7 @@
 (defn- filters->condition
   [filters]
   (when (seq filters)
-    (lib.util/fresh-uuids
+    (lib/fresh-uuids
      (if (next filters)
        (apply lib/and filters)
        (first filters)))))
@@ -48,7 +48,7 @@
         c2-maybe-unwrapped (cond-> c2
                              (= :and c2-operator) (subvec 2))
         c1-operator (first c1)]
-    (lib.util/fresh-uuids
+    (lib/fresh-uuids
      (if (= :and c1-operator)
        (if (= :and c2-operator)
          (into c1 c2-maybe-unwrapped)
@@ -148,7 +148,7 @@
                                           (lib/ref col)
                                           ;; This is probably due to a field-id where it shouldn't be
                                           &match))]
-                      (update (lib.util/fresh-uuids replacement)
+                      (update (lib/fresh-uuids replacement)
                               1
                               #(merge
                                 %
@@ -243,7 +243,7 @@
         query-with-joins (reduce #(lib/join %1 agg-stage-index %2)
                                  query
                                  new-joins)]
-    (lib.util/update-query-stage query-with-joins agg-stage-index add-join-aliases source-field->join-alias)))
+    (lib/update-query-stage query-with-joins agg-stage-index add-join-aliases source-field->join-alias)))
 
 (defn- splice-compatible-metrics
   "Splices in metric definitions that are compatible with the query."
@@ -261,7 +261,7 @@
                              (lib/expressions temp-query)))
             new-query (reduce
                        (fn [query [metric-id {metric-query :query}]]
-                         (if (and (= (lib.util/source-table-id query) (lib.util/source-table-id metric-query))
+                         (if (and (= (lib/primary-source-table-id query) (lib/primary-source-table-id metric-query))
                                   (or (= (lib/stage-count metric-query) 1)
                                       (= (:qp/stage-had-source-card (last (:stages metric-query)))
                                          (:qp/stage-had-source-card (lib/query-stage query agg-stage-index)))))

--- a/src/metabase/query_processor/middleware/optimize_temporal_filters.clj
+++ b/src/metabase/query_processor/middleware/optimize_temporal_filters.clj
@@ -9,7 +9,6 @@
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.lib.schema.expression :as lib.schema.expression]
    [metabase.lib.schema.mbql-clause :as lib.schema.mbql-clause]
-   [metabase.lib.util :as lib.util]
    [metabase.lib.util.match :as lib.util.match]
    [metabase.lib.walk :as lib.walk]
    [metabase.util :as u]
@@ -23,7 +22,7 @@
   #{:second :minute :hour :day :week :month :quarter :year})
 
 (defn- temporal-ref? [x]
-  (and (lib.util/clause-of-type? x #{:field :expression})
+  (and (lib/clause-of-type? x #{:field :expression})
        (or (lib/raw-temporal-bucket x)
            (let [[_field opts _id-or-name] x]
              (when-let [expr-type ((some-fn :effective-type :base-type) opts)]
@@ -292,7 +291,7 @@
   (set (keys (methods optimize-filter))))
 
 (defn- optimize-temporal-filters* [query path clause]
-  (when (lib.util/clause-of-type? clause optimizable-filter-types)
+  (when (lib/clause-of-type? clause optimizable-filter-types)
     (or (when (can-optimize-filter? clause)
           (u/prog1 (optimize-filter query path clause)
             (if <>

--- a/src/metabase/query_processor/middleware/reconcile_breakout_and_order_by_bucketing.clj
+++ b/src/metabase/query_processor/middleware/reconcile_breakout_and_order_by_bucketing.clj
@@ -41,7 +41,6 @@
    [metabase.lib.options :as lib.options]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.util :as lib.schema.util]
-   [metabase.lib.util :as lib.util]
    [metabase.lib.walk :as lib.walk]
    [metabase.util :as u]
    [metabase.util.malli :as mu]
@@ -63,7 +62,7 @@
   (-> order-bys
       (lib.walk/walk-clauses*
        (fn [clause]
-         (when (and (lib.util/clause-of-type? clause #{:field :expression})
+         (when (and (lib/clause-of-type? clause #{:field :expression})
                     (not (lib/raw-temporal-bucket clause))
                     (not (lib/binning clause)))
            (let [col (lib.walk/apply-f-for-stage-at-path lib/metadata query stage-path clause)]

--- a/src/metabase/query_processor/middleware/wrap_value_literals.clj
+++ b/src/metabase/query_processor/middleware/wrap_value_literals.clj
@@ -10,7 +10,6 @@
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.expression :as lib.schema.expression]
    [metabase.lib.types.isa :as lib.types.isa]
-   [metabase.lib.util :as lib.util]
    [metabase.lib.util.match :as lib.util.match]
    [metabase.lib.walk :as lib.walk]
    [metabase.query-processor.error-type :as qp.error-type]
@@ -42,7 +41,7 @@
   usually a `:field` clause; we use this info to wrap `rhs` if it's a raw value e.g. `1`."
   [query path clause]
   (merge
-   (when (lib.util/clause-of-type? clause :field)
+   (when (lib/clause-of-type? clause :field)
      (type-info-from-col (lib.walk/apply-f-for-stage-at-path lib/metadata query path clause)))
    (let [expr-type (lib.walk/apply-f-for-stage-at-path lib/type-of query path clause)
          [_ {:keys [base-type]}] clause]
@@ -224,7 +223,7 @@
 
 ;;; -------------------------------------------- wrap-literals-in-clause ---------------------------------------------
 
-(def ^:private raw-value? (complement lib.util/clause?))
+(def ^:private raw-value? (complement lib/clause?))
 
 (defn- wrap-value-literals-in-clause
   [query path clause]
@@ -294,7 +293,7 @@
   [clause]
   (let [expr-type (lib.schema.expression/type-of-resolved clause)]
     (merge
-     (when (and (lib.util/clause-of-type? clause :field)
+     (when (and (lib/clause-of-type? clause :field)
                 (qp.store/initialized?))
        (let [[_tag _opts id-or-name] clause]
          (when (pos-int? id-or-name)

--- a/src/metabase/query_processor/pivot.clj
+++ b/src/metabase/query_processor/pivot.clj
@@ -13,7 +13,6 @@
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.schema.info :as lib.schema.info]
-   [metabase.lib.util :as lib.util]
    [metabase.models.visualization-settings :as mb.viz]
    [metabase.query-processor :as qp]
    [metabase.query-processor.error-type :as qp.error-type]
@@ -186,7 +185,7 @@
    (fn [query [_tag _opts expr :as order-by]]
      ;; keep any order bys on :aggregation references. Remove all other clauses.
      (cond-> query
-       (not (lib.util/clause-of-type? expr :aggregation))
+       (not (lib/clause-of-type? expr :aggregation))
        (lib/remove-clause order-by)))
    query
    (lib/order-bys query)))

--- a/src/metabase/query_processor/util/transformations/nest_breakouts.clj
+++ b/src/metabase/query_processor/util/transformations/nest_breakouts.clj
@@ -10,7 +10,6 @@
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.metadata :as lib.schema.metadata]
    [metabase.lib.schema.util :as lib.schema.util]
-   [metabase.lib.util :as lib.util]
    [metabase.lib.util.match :as lib.util.match]
    [metabase.lib.walk :as lib.walk]
    [metabase.util.malli :as mu]
@@ -42,7 +41,7 @@
   (-> stage
       (dissoc :breakout :aggregation :order-by :limit :lib/stage-metadata)
       (assoc :fields (mapv
-                      lib.util/fresh-uuids
+                      lib/fresh-uuids
                       (fields-used-in-breakouts-aggregations-or-expressions stage)))))
 
 (defn- update-temporal-bucket
@@ -67,7 +66,7 @@
           update-temporal-bucket
           lib/ref
           (cond-> (:lib/external-remap col) (lib/update-options assoc ::externally-remapped-field true)))
-      (lib.util/fresh-uuids &match))))
+      (lib/fresh-uuids &match))))
 
 (def ^:private granularity
   {:time-unbucketed 0


### PR DESCRIPTION
Fixes QUE2-352.

### Description

- `lib.util/strip-id` is newly exported with the more self-documenting
  name `lib/display-name-without-id`.
- `lib.util/clause?` and `clause-of-type?` were already exported
- `lib.util/source-card-id` (and `source-table-id`) are exported as
  `lib/primary-source-card-id` (and likewise for tables).

This isn't all the escaped usages of `lib.util` functions, but other PRs
will handle those.

### How to verify

No visible changes. Tests are still passing.

### Checklist

- ~~Tests have been added/updated to cover changes in this PR~~
- ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
