### PR TITLE
[MBQL lib] Move `lib.util/join-strings-with-conjunction` to `util.i18n`

### DIFF
--- a/src/metabase/channel/email/messages.clj
+++ b/src/metabase/channel/email/messages.clj
@@ -17,7 +17,6 @@
    [metabase.channel.template.core :as channel.template]
    [metabase.channel.urls :as urls]
    [metabase.collections.models.collection :as collection]
-   [metabase.lib.util :as lib.util]
    [metabase.permissions.core :as perms]
    [metabase.premium-features.core :as premium-features]
    [metabase.query-processor.timezone :as qp.timezone]
@@ -417,7 +416,7 @@
                                                   (fn [{:keys [value] :as param}]
                                                     (cond-> param
                                                       (coll? value)
-                                                      (update :value #(lib.util/join-strings-with-conjunction
+                                                      (update :value #(i18n/join-strings-with-conjunction
                                                                        (i18n/tru "or")
                                                                        %))))
                                                   bad-parameters)

--- a/src/metabase/lib/aggregation.cljc
+++ b/src/metabase/lib/aggregation.cljc
@@ -76,7 +76,7 @@
 (defmethod lib.metadata.calculation/describe-top-level-key-method :aggregation
   [query stage-number _k]
   (when-let [ags (not-empty (:aggregation (lib.util/query-stage query stage-number)))]
-    (lib.util/join-strings-with-conjunction
+    (i18n/join-strings-with-conjunction
      (i18n/tru "and")
      (for [aggregation ags]
        (lib.metadata.calculation/display-name query stage-number aggregation :long)))))

--- a/src/metabase/lib/filter.cljc
+++ b/src/metabase/lib/filter.cljc
@@ -79,7 +79,7 @@
   [query stage-number _key]
   (when-let [filters (perf/not-empty (:filters (lib.util/query-stage query stage-number)))]
     (i18n/tru "Filtered by {0}"
-              (lib.util/join-strings-with-conjunction
+              (i18n/join-strings-with-conjunction
                (i18n/tru "and")
                (for [filter filters]
                  (lib.metadata.calculation/display-name query stage-number filter :long))))))
@@ -96,7 +96,7 @@
 
 (defmethod lib.metadata.calculation/display-name-method ::compound
   [query stage-number [tag _opts & subclauses] style]
-  (lib.util/join-strings-with-conjunction
+  (i18n/join-strings-with-conjunction
    (conjunction-word tag)
    (for [clause subclauses]
      (lib.metadata.calculation/display-name query stage-number clause style))))
@@ -627,7 +627,7 @@
 
 (defn compound-filter-conjunctions
   "Returns conjunction strings used in compound filter display names,
-   derived from [[lib.util/join-strings-with-conjunction]] output.
+   derived from [[i18n/join-strings-with-conjunction]] output.
    Longest strings first so greedy matching works correctly."
   []
   (let [conjunctions (mapv conjunction-word [:and :or])
@@ -635,11 +635,11 @@
         ;; with marker strings and seeing what appears between them.
         two-item    (fn [conj-word]
                       ;; "A and B" => " and " is between A and B
-                      (let [result (lib.util/join-strings-with-conjunction conj-word ["A" "B"])]
+                      (let [result (i18n/join-strings-with-conjunction conj-word ["A" "B"])]
                         (subs result 1 (dec (count result)))))
         three-item  (fn [conj-word]
                       ;; "A, B, and C" => ", " between A and B, ", and " between B and C
-                      (let [result (lib.util/join-strings-with-conjunction conj-word ["A" "B" "C"])
+                      (let [result (i18n/join-strings-with-conjunction conj-word ["A" "B" "C"])
                             ;; Find the separators around "B"
                             b-idx  (str/index-of result "B")]
                         [(subs result 1 b-idx)

--- a/src/metabase/lib/order_by.cljc
+++ b/src/metabase/lib/order_by.cljc
@@ -26,7 +26,7 @@
   [query stage-number _k]
   (when-let [order-bys (not-empty (:order-by (lib.util/query-stage query stage-number)))]
     (i18n/tru "Sorted by {0}"
-              (lib.util/join-strings-with-conjunction
+              (i18n/join-strings-with-conjunction
                (i18n/tru "and")
                (for [order-by order-bys]
                  (lib.metadata.calculation/display-name query stage-number order-by :long))))))

--- a/src/metabase/lib/util.cljc
+++ b/src/metabase/lib/util.cljc
@@ -410,27 +410,6 @@
       (native-stage? query -1)
       (update :stages conj {:lib/type :mbql.stage/mbql}))))
 
-(defn join-strings-with-conjunction
-  "This is basically [[clojure.string/join]] but uses commas to join everything but the last two args, which are joined
-  by a string `conjunction`. Uses Oxford commas for > 2 args.
-
-  (join-strings-with-conjunction \"and\" [\"X\" \"Y\" \"Z\"])
-  ;; => \"X, Y, and Z\""
-  [conjunction coll]
-  (when (seq coll)
-    (if (= (count coll) 1)
-      (first coll)
-      (let [conjunction (str \space (str/trim conjunction) \space)]
-        (if (= (count coll) 2)
-          ;; exactly 2 args: X and Y
-          (str (first coll) conjunction (second coll))
-          ;; > 2 args: X, Y, and Z
-          (str
-           (str/join ", " (butlast coll))
-           ","
-           conjunction
-           (last coll)))))))
-
 (mu/defn legacy-string-table-id->card-id :- [:maybe ::lib.schema.id/card]
   "If `table-id` is a legacy `card__<id>`-style string, parse the `<id>` part to an integer Card ID. Only for legacy
   queries! You don't need to use this in MBQL 5 since this is converted automatically by [[metabase.lib.convert]] to

--- a/src/metabase/util/i18n.clj
+++ b/src/metabase/util/i18n.clj
@@ -3,6 +3,7 @@
   (:require
    [clojure.string :as str]
    [clojure.walk :as walk]
+   [metabase.util.i18n.common :as i18n.common]
    [metabase.util.i18n.impl :as i18n.impl]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
@@ -16,6 +17,8 @@
 (set! *warn-on-reflection* true)
 
 (p/import-vars
+ [i18n.common
+  join-strings-with-conjunction]
  [i18n.impl
   available-locale?
   fallback-locale

--- a/src/metabase/util/i18n.cljs
+++ b/src/metabase/util/i18n.cljs
@@ -3,12 +3,19 @@
   (:require
    ["ttag" :as ttag]
    [clojure.string :as str]
-   [goog.object :as gobject])
+   [goog.object :as gobject]
+   [metabase.util.i18n.common :as i18n.common]
+   [metabase.util.namespaces :as util.ns])
   (:require-macros
    [metabase.util.i18n]))
 
-(comment metabase.util.i18n/keep-me
+(comment i18n.common/keep-me
+         metabase.util.i18n/keep-me
          ttag/keep-me)
+
+(util.ns/import-fns
+ [i18n.common
+  join-strings-with-conjunction])
 
 (defn- escape-format-string
   "Converts `''` to `'` inside the string; that's `java.text.MessageFormat` escaping that isn't needed in JS."

--- a/src/metabase/util/i18n/common.cljc
+++ b/src/metabase/util/i18n/common.cljc
@@ -1,0 +1,25 @@
+(ns metabase.util.i18n.common
+  "Shared CLJ + CLJS functionality that's re-exported from [[metabase.util.i18n]]."
+  (:require
+   [clojure.string :as str]))
+
+(defn join-strings-with-conjunction
+  "This is basically [[clojure.string/join]] but uses commas to join everything but the last two args, which are joined
+  by a string `conjunction`. Uses Oxford commas for > 2 args.
+
+  (join-strings-with-conjunction \"and\" [\"X\" \"Y\" \"Z\"])
+  ;; => \"X, Y, and Z\""
+  [conjunction coll]
+  (when (seq coll)
+    (if (= (count coll) 1)
+      (first coll)
+      (let [conjunction (str \space (str/trim conjunction) \space)]
+        (if (= (count coll) 2)
+          ;; exactly 2 args: X and Y
+          (str (first coll) conjunction (second coll))
+          ;; > 2 args: X, Y, and Z
+          (str
+           (str/join ", " (butlast coll))
+           ","
+           conjunction
+           (last coll)))))))

--- a/test/metabase/lib/util_test.cljc
+++ b/test/metabase/lib/util_test.cljc
@@ -223,15 +223,6 @@
                                              :type     :native
                                              :native   {:query "SELECT * FROM venues;"}}))))
 
-(deftest ^:parallel join-strings-with-conjunction-test
-  (are [coll expected] (= expected
-                          (lib.util/join-strings-with-conjunction "and" coll))
-    []                nil
-    ["a"]             "a"
-    ["a" "b"]         "a and b"
-    ["a" "b" "c"]     "a, b, and c"
-    ["a" "b" "c" "d"] "a, b, c, and d"))
-
 (deftest ^:parallel strip-id-test
   (are [exp in] (= exp (lib.util/strip-id in))
     "foo"            "foo"

--- a/test/metabase/util/i18n/common_test.cljc
+++ b/test/metabase/util/i18n/common_test.cljc
@@ -1,0 +1,13 @@
+(ns metabase.util.i18n.common-test
+  (:require
+   [clojure.test :refer [are deftest]]
+   [metabase.util.i18n :as i18n]))
+
+(deftest ^:parallel join-strings-with-conjunction-test
+  (are [coll expected] (= expected
+                          (i18n/join-strings-with-conjunction "and" coll))
+    []                nil
+    ["a"]             "a"
+    ["a" "b"]         "a and b"
+    ["a" "b" "c"]     "a, b, and c"
+    ["a" "b" "c" "d"] "a, b, c, and d"))


### PR DESCRIPTION
Fixes QUE2-371.

### Description

This function has nothing to do with lib, and only depends on
`clojure.string`.

### How to verify

No change, just shuffling some code.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
