### PR TITLE
Use the search cluster lock for both init indexing and re-indexing

### DIFF
--- a/src/metabase/search/task/search_index.clj
+++ b/src/metabase/search/task/search_index.clj
@@ -18,6 +18,7 @@
 
 (def ^:private init-stem "metabase.task.search-index.init")
 (def ^:private reindex-stem "metabase.task.search-index.reindex")
+(def ^:private cluster-lock-name ::search-index-lock)
 
 (def init-job-key
   "Key used to define and trigger a job that ensures there is an active index."
@@ -33,13 +34,14 @@
   "Create a new index, if necessary"
   []
   (when (search/supports-index?)
-    (cluster-lock/with-cluster-lock ::search-init-lock
+    (cluster-lock/with-cluster-lock cluster-lock-name
       (search/init-index! {:force-reset? false, :re-populate? false}))))
 
 (task/defjob ^{DisallowConcurrentExecution true
                :doc                        "Populate a new Search Index"}
   SearchIndexReindex [_ctx]
-  (search/reindex! {:async? false}))
+  (cluster-lock/with-cluster-lock cluster-lock-name
+    (search/reindex! {:async? false})))
 
 (defmethod startup/def-startup-logic! ::SearchIndexInit [_]
   (doto (Thread. ^Runnable init!) .start))


### PR DESCRIPTION
### Description

We have an existing cluster-lock on initial indexing, but we can get deadlocks like below from re-indexing happening at the same time as init! and also from multiple nodes attempting to re-index concurrently.

This PR renames the cluster lock and re-uses it on re-index as well to help avoid the deadlocks.

Example error:
```
ERROR: deadlock detected\n  Detail: Process 27296 waits for ShareLock on transaction 2760446038; blocked by process 477.\nProcess 477 waits for ShareLock on transaction 2760447120; blocked by process 27296.\n  Hint: See server log for query details.\n  Where: while inserting index tuple (1330,2) in relation \"search_index__xpxorwkyddh2zn1p335ec\"
```

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
