### PR TITLE
[MBQL lib] Unexport `lib.options` namespace

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -548,7 +548,7 @@
            metabase.driver.common.parameters
            metabase.driver.common.parameters.parse
            metabase.driver.connection
-          metabase.driver.connection.workspaces
+           metabase.driver.connection.workspaces
            metabase.driver.ddl.interface
            metabase.driver.h2
            metabase.driver.impl
@@ -741,7 +741,6 @@
            metabase.lib.init
            metabase.lib.metadata
            metabase.lib.metadata.protocols
-           metabase.lib.options
            metabase.lib.schema
            metabase.lib.schema.actions
            metabase.lib.schema.aggregation

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/filters.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/filters.clj
@@ -5,7 +5,6 @@
    [metabase.lib-be.core :as lib-be]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
-   [metabase.lib.options :as lib.options]
    [metabase.lib.types.isa :as lib.types.isa]
    [metabase.lib.util :as lib.util]
    [metabase.util :as u]
@@ -96,8 +95,7 @@
                                     (apply f expr values)
                                     (f expr value))))
           string-match (fn [match-fn]
-                         (-> (with-values-or-value match-fn)
-                             (lib.options/update-options assoc :case-sensitive false)))
+                         (-> match-fn with-values-or-value lib/ignore-case))
           filter
           (case operation
             :is-null                      (lib/is-null expr)

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
@@ -18,7 +18,6 @@
    [metabase.lib-be.core :as lib-be]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
-   [metabase.lib.options :as lib.options]
    [metabase.test :as mt]
    [metabase.util :as u]
    [metabase.util.malli.registry :as mr]
@@ -257,7 +256,7 @@
               rating-col (lib.metadata/field mp (mt/id :products :rating))
               created-at-col (lib.metadata/field mp (mt/id :products :created_at))
               expected-query (-> (lib/query mp (lib.metadata/table mp (mt/id :products)))
-                                 (lib/aggregate (lib.options/ensure-uuid [:metric {} metric-id]))
+                                 (lib/aggregate (lib/ensure-uuid [:metric {} metric-id]))
                                  (lib/breakout (lib/with-temporal-bucket created-at-col :week))
                                  (lib/breakout (lib/with-temporal-bucket created-at-col :day))
                                  (lib/filter (lib/> id-col 50))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/filters_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/filters_test.clj
@@ -10,7 +10,6 @@
    [metabase.lib.convert :as lib.convert]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
-   [metabase.lib.options :as lib.options]
    [metabase.lib.test-util :as lib.tu]
    [metabase.test :as mt]
    [metabase.util :as u]))
@@ -53,7 +52,7 @@
                            :group-by []})
                   actual-query (get-in result [:structured-output :query])
                   expected-query (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
-                                     (lib/aggregate (lib.options/ensure-uuid [:metric {} metric-id])))]
+                                     (lib/aggregate (lib/ensure-uuid [:metric {} metric-id])))]
               (is (= :query (get-in result [:structured-output :type])))
               (is (string? (get-in result [:structured-output :query-id])))
               (is (tools.tu/query= expected-query actual-query))))

--- a/modules/drivers/clickhouse/test/metabase/driver/clickhouse_data_types_test.clj
+++ b/modules/drivers/clickhouse/test/metabase/driver/clickhouse_data_types_test.clj
@@ -3,7 +3,6 @@
    [clojure.test :refer :all]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
-   [metabase.lib.options :as lib.options]
    [metabase.test :as mt]
    [metabase.test.data.clickhouse :as ctd]))
 
@@ -369,16 +368,16 @@
                            [2 #uuid "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"]]))
         (testing "can filter nullable uuids with contains"
           (are [filter-str case-sensitive exp-rows]
-               (= exp-rows (filter-rows (-> (lib/contains uuid-field filter-str)
-                                            (lib.options/update-options assoc :case-sensitive case-sensitive))))
+               (= exp-rows (filter-rows (cond-> (lib/contains uuid-field filter-str)
+                                          (not case-sensitive) lib/ignore-case)))
             "aaa" true  [[1 #uuid "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"]]
             "aaa" false [[1 #uuid "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"]]
             "AAA" true  []
             "AAA" false [[1 #uuid "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"]]))
         (testing "can filter nullable uuids with does not contain"
           (are [filter-str case-sensitive exp-rows]
-               (= exp-rows (filter-rows (-> (lib/does-not-contain uuid-field filter-str)
-                                            (lib.options/update-options assoc :case-sensitive case-sensitive))))
+               (= exp-rows (filter-rows (cond-> (lib/does-not-contain uuid-field filter-str)
+                                          (not case-sensitive) lib/ignore-case)))
             "aaa" true  [[2 #uuid "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"]
                          [3 nil]]
             "aaa" false [[2 #uuid "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"]
@@ -390,16 +389,16 @@
                          [3 nil]]))
         (testing "can filter nullable uuids with starts with"
           (are [filter-str case-sensitive exp-rows]
-               (= exp-rows (filter-rows (-> (lib/starts-with uuid-field filter-str)
-                                            (lib.options/update-options assoc :case-sensitive case-sensitive))))
+               (= exp-rows (filter-rows (cond-> (lib/starts-with uuid-field filter-str)
+                                          (not case-sensitive) lib/ignore-case)))
             "aaa" true  [[1 #uuid "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"]]
             "aaa" false [[1 #uuid "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"]]
             "AAA" true  []
             "AAA" false [[1 #uuid "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"]]))
         (testing "can filter nullable uuids with ends with"
           (are [filter-str case-sensitive exp-rows]
-               (= exp-rows (filter-rows (-> (lib/ends-with uuid-field filter-str)
-                                            (lib.options/update-options assoc :case-sensitive case-sensitive))))
+               (= exp-rows (filter-rows (cond-> (lib/ends-with uuid-field filter-str)
+                                          (not case-sensitive) lib/ignore-case)))
             "aaa" true  [[1 #uuid "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"]]
             "aaa" false [[1 #uuid "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"]]
             "AAA" true  []

--- a/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
+++ b/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
@@ -23,7 +23,6 @@
    [metabase.events.core :as events]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
-   [metabase.lib.options :as lib.options]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
    [metabase.query-processor :as qp]
@@ -1355,67 +1354,61 @@
                              (lib/with-fields [products-id products-name products-category])))]
       (doseq [[msg filter exp-filter exp-rows] [["case insensitive contains has rows"
                                                  (-> (lib/contains products-category "GET")
-                                                     (lib.options/update-options assoc :case-sensitive false))
+                                                     lib/ignore-case)
                                                  "CONTAINS(LOWER(\"PUBLIC\".\"products\".\"category\"), 'get')"
                                                  [[5 "Enormous Marble Wallet" "Gadget"]
                                                   [9 "Practical Bronze Computer" "Widget"]
                                                   [11 "Ergonomic Silk Coat" "Gadget"]]]
 
                                                 ["case sensitive contains has rows"
-                                                 (-> (lib/contains products-category "Gad")
-                                                     (lib.options/update-options assoc :case-sensitive true))
+                                                 (lib/contains products-category "Gad")
                                                  "CONTAINS(\"PUBLIC\".\"products\".\"category\", 'Gad')"
                                                  [[5 "Enormous Marble Wallet" "Gadget"]
                                                   [11 "Ergonomic Silk Coat" "Gadget"]
                                                   [16 "Incredible Bronze Pants" "Gadget"]]]
 
                                                 ["case sensitive contains with no rows"
-                                                 (-> (lib/contains products-category "gad")
-                                                     (lib.options/update-options assoc :case-sensitive true))
+                                                 (lib/contains products-category "gad")
                                                  "CONTAINS(\"PUBLIC\".\"products\".\"category\", 'gad')"
                                                  []]
 
                                                 ["case insensitive starts with has rows"
                                                  (-> (lib/starts-with products-category "GAD")
-                                                     (lib.options/update-options assoc :case-sensitive false))
+                                                     lib/ignore-case)
                                                  "STARTSWITH(LOWER(\"PUBLIC\".\"products\".\"category\"), 'gad')"
                                                  [[5 "Enormous Marble Wallet" "Gadget"]
                                                   [11 "Ergonomic Silk Coat" "Gadget"]
                                                   [16 "Incredible Bronze Pants" "Gadget"]]]
 
                                                 ["case sensitive starts with has rows"
-                                                 (-> (lib/starts-with products-category "Gad")
-                                                     (lib.options/update-options assoc :case-sensitive true))
+                                                 (lib/starts-with products-category "Gad")
                                                  "STARTSWITH(\"PUBLIC\".\"products\".\"category\", 'Gad')"
                                                  [[5 "Enormous Marble Wallet" "Gadget"]
                                                   [11 "Ergonomic Silk Coat" "Gadget"]
                                                   [16 "Incredible Bronze Pants" "Gadget"]]]
 
                                                 ["case sensitive starts with has no rows"
-                                                 (-> (lib/starts-with products-category "gad")
-                                                     (lib.options/update-options assoc :case-sensitive true))
+                                                 (lib/starts-with products-category "gad")
                                                  "STARTSWITH(\"PUBLIC\".\"products\".\"category\", 'gad')"
                                                  []]
 
                                                 ["case insensitive ends with has rows"
                                                  (-> (lib/ends-with products-category "GET")
-                                                     (lib.options/update-options assoc :case-sensitive false))
+                                                     lib/ignore-case)
                                                  "ENDSWITH(LOWER(\"PUBLIC\".\"products\".\"category\"), 'get')"
                                                  [[5 "Enormous Marble Wallet" "Gadget"]
                                                   [9 "Practical Bronze Computer" "Widget"]
                                                   [11 "Ergonomic Silk Coat" "Gadget"]]]
 
                                                 ["case sensitive ends with has rows"
-                                                 (-> (lib/ends-with products-category "get")
-                                                     (lib.options/update-options assoc :case-sensitive true))
+                                                 (lib/ends-with products-category "get")
                                                  "ENDSWITH(\"PUBLIC\".\"products\".\"category\", 'get')"
                                                  [[5 "Enormous Marble Wallet" "Gadget"]
                                                   [9 "Practical Bronze Computer" "Widget"]
                                                   [11 "Ergonomic Silk Coat" "Gadget"]]]
 
                                                 ["case sensitive ends with has no rows"
-                                                 (-> (lib/ends-with products-category "GET")
-                                                     (lib.options/update-options assoc :case-sensitive true))
+                                                 (lib/ends-with products-category "GET")
                                                  "ENDSWITH(\"PUBLIC\".\"products\".\"category\", 'GET')"
                                                  []]]]
         (testing msg

--- a/src/metabase/lib/core.cljc
+++ b/src/metabase/lib/core.cljc
@@ -41,7 +41,7 @@
    [metabase.lib.metric :as lib.metric]
    [metabase.lib.native :as lib.native]
    [metabase.lib.normalize :as lib.normalize]
-   [metabase.lib.options]
+   [metabase.lib.options :as lib.options]
    [metabase.lib.order-by :as lib.order-by]
    [metabase.lib.page]
    [metabase.lib.parameters]
@@ -52,6 +52,7 @@
    [metabase.lib.ref :as lib.ref]
    [metabase.lib.remove-replace :as lib.remove-replace]
    [metabase.lib.schema]
+   [metabase.lib.schema.expression :as lib.schema.expression]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.schema.util]
    [metabase.lib.segment :as lib.segment]
@@ -104,7 +105,7 @@
          lib.metric/keep-me
          lib.native/keep-me
          lib.normalize/keep-me
-         metabase.lib.options/keep-me
+         lib.options/keep-me
          lib.order-by/keep-me
          metabase.lib.parameters/keep-me
          lib.parse/keep-me
@@ -403,7 +404,7 @@
   with-native-extras
   with-native-query
   with-template-tags]
- [metabase.lib.options
+ [lib.options
   ensure-uuid
   options
   update-options]
@@ -583,3 +584,10 @@
   **Code Health:** Healthy."
   [field-display-name :- :string]
   (lib.util/strip-id field-display-name))
+
+(mu/defn ignore-case :- ::lib.schema.expression/boolean
+  "Given a boolean expression on strings, sets the options to ignore case.
+
+  Prefer this over setting the `:case-sensitive false` option directly."
+  [boolean-expression :- ::lib.schema.expression/boolean]
+  (lib.options/update-options boolean-expression assoc :case-sensitive false))

--- a/src/metabase/parameters/field/search_values_query.clj
+++ b/src/metabase/parameters/field/search_values_query.clj
@@ -36,8 +36,7 @@
           query-xform  (fn query-xform  [query]
                          (-> query
                              (cond-> (some? value)
-                               (lib/filter (-> (lib/contains search-field value)
-                                               (lib/update-options assoc :case-sensitive false))))
+                               (lib/filter (lib/ignore-case (lib/contains search-field value))))
                              ;; if both fields are the same then make sure not to refer to it twice in the `:breakout` clause.
                              ;; Otherwise this will break certain drivers like BigQuery that don't support duplicate
                              ;; identifiers/aliases


### PR DESCRIPTION
Fixes QUE2-351.

### Description

I added a new exported function `lib/ignore-case`, since some drivers,
test, and Metabot were using `lib.options/update-options` to set
`:case-sensitive false` on `:contains` et al clauses.

`lib.options` is only used by friends now (mostly QP).

### How to verify

No behaviour changes; tests are passing.

### Checklist

- ~~Tests have been added/updated to cover changes in this PR~~
- ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
