### PR TITLE
Add snowplow events when creating new job

### DIFF
--- a/e2e/test/scenarios/data-studio/transforms/transforms.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/transforms/transforms.cy.spec.ts
@@ -2932,6 +2932,14 @@ describe("scenarios > admin > transforms > jobs", () => {
 
       H.DataStudio.Jobs.editor().button("Save").click();
       cy.wait("@createJob");
+
+      cy.log("verify transform_job_created event was tracked");
+      H.expectUnstructuredSnowplowEvent({
+        event: "transform_job_created",
+        triggered_from: "transform_job_new",
+        result: "success",
+      });
+
       H.undoToast().findByText("New job created").should("be.visible");
 
       H.DataStudio.Jobs.editor().within(() => {
@@ -2957,6 +2965,14 @@ describe("scenarios > admin > transforms > jobs", () => {
       H.popover().findByText("daily").click();
       H.DataStudio.Jobs.editor().button("Save").click();
       cy.wait("@createJob");
+
+      cy.log("verify transform_job_created event was tracked");
+      H.expectUnstructuredSnowplowEvent({
+        event: "transform_job_created",
+        triggered_from: "transform_job_new",
+        result: "success",
+      });
+
       H.undoToast().findByText("New job created").should("be.visible");
 
       H.DataStudio.Jobs.editor().within(() => {

--- a/e2e/test/scenarios/data-studio/transforms/transforms.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/transforms/transforms.cy.spec.ts
@@ -2916,6 +2916,7 @@ describe("scenarios > admin > transforms > jobs", () => {
   beforeEach(() => {
     H.restore("postgres-writable");
     H.resetTestTable({ type: "postgres", table: "many_schemas" });
+    H.resetSnowplow();
     cy.signInAsAdmin();
     H.activateToken("bleeding-edge");
     H.resyncDatabase({ dbId: WRITABLE_DB_ID, tableName: SOURCE_TABLE });

--- a/frontend/src/metabase-types/analytics/event.ts
+++ b/frontend/src/metabase-types/analytics/event.ts
@@ -308,6 +308,13 @@ export type TransformRunTagsUpdated = ValidateEvent<{
   target_id: number;
 }>;
 
+export type TransformJobCreatedEvent = ValidateEvent<{
+  event: "transform_job_created";
+  triggered_from: "transform_job_new";
+  result: "success" | "failure";
+  target_id: number | null;
+}>;
+
 export type TransformInspectLensLoadedEvent = ValidateEvent<{
   event: "transform_inspect_lens_loaded";
   target_id: TransformId;
@@ -719,6 +726,7 @@ export type SimpleEvent =
   | TransformCreatedEvent
   | TransformCreateEvent
   | TransformRunTagsUpdated
+  | TransformJobCreatedEvent
   | TransformInspectEvent
   | DocumentAddCardEvent
   | DocumentAddSmartLinkEvent

--- a/frontend/src/metabase/transforms/analytics.ts
+++ b/frontend/src/metabase/transforms/analytics.ts
@@ -70,6 +70,21 @@ export function trackTransformRunTagsUpdated({
   });
 }
 
+export function trackTransformJobCreated({
+  result,
+  jobId,
+}: {
+  result: "success" | "failure";
+  jobId?: TransformJobId;
+}) {
+  trackSimpleEvent({
+    event: "transform_job_created",
+    triggered_from: "transform_job_new",
+    result,
+    target_id: jobId ?? null,
+  });
+}
+
 export function trackTransformInspectLensLoaded({
   transformId,
   lensKey,

--- a/frontend/src/metabase/transforms/pages/NewJobPage/NewJobPage.tsx
+++ b/frontend/src/metabase/transforms/pages/NewJobPage/NewJobPage.tsx
@@ -15,6 +15,7 @@ import * as Urls from "metabase/lib/urls";
 import { useMetadataToasts } from "metabase/metadata/hooks";
 import type { ScheduleDisplayType, TransformTagId } from "metabase-types/api";
 
+import { trackTransformJobCreated } from "../../analytics";
 import { JobEditor, type TransformJobInfo } from "../../components/JobEditor";
 
 type NewJobPageProps = {
@@ -51,8 +52,10 @@ export function NewJobPage({ route }: NewJobPageProps) {
     const { data: newJob, error } = await createJob(job);
 
     if (error) {
+      trackTransformJobCreated({ result: "failure" });
       sendErrorToast(t`Failed to create a job`);
     } else if (newJob != null) {
+      trackTransformJobCreated({ result: "success", jobId: newJob.id });
       // prefetch the job to avoid the loader on the job details page
       await fetchJob(newJob.id);
       sendSuccessToast(t`New job created`);


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/UXW-3053/snowplow-jobs-creation-tracking

### Description

Trigger transform_job_created event when a new job is created.

### How to verify

1. Go to Data Studio > Jobs > New
2. When the new job is saved, observe that the transform_job_created event is triggered

### Demo
https://www.loom.com/share/5ab1f4319ee94277ae56cb7505c16cc5

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
