### PR TITLE
[Slackbot] Stable conversation ids

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/streaming.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/streaming.clj
@@ -427,4 +427,4 @@
                (slackbot.client/stop-stream client channel stream_ts)
                (catch Exception stop-e
                  (log/debug stop-e "[slackbot] Failed to stop stream during error cleanup")))
-             (send-fallback "Something went wrong. Please try again."))))))
+             (send-fallback "Something went wrong. Please try again."))))))))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/streaming.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/streaming.clj
@@ -362,6 +362,13 @@
      :slack-writer         slack-writer
      :prefetched-viz       prefetched-viz}))
 
+(defn- slack-thread->conversation-id
+  "Generate deterministic conversation ID from Slack thread identifiers.
+   Same thread always produces the same UUID (v3)."
+  [team-id channel thread-ts]
+  (str (java.util.UUID/nameUUIDFromBytes
+        (.getBytes (str "slack:" team-id ":" channel ":" thread-ts)))))
+
 (defn send-response
   "Send a metabot response using Slack's streaming API for progressive updates.
    Shows tool execution status and streams text as it arrives."
@@ -392,7 +399,7 @@
                (slackbot.client/post-message client (merge message-ctx {:text text})))]
        (try
          (let [data-parts (make-streaming-ai-request
-                           (str (random-uuid))
+                           (slack-thread->conversation-id (:team_id auth-info) channel thread-ts)
                            prompt
                            thread
                            bot-user-id
@@ -420,4 +427,4 @@
                (slackbot.client/stop-stream client channel stream_ts)
                (catch Exception stop-e
                  (log/debug stop-e "[slackbot] Failed to stop stream during error cleanup")))
-             (send-fallback "Something went wrong. Please try again."))))))))
+             (send-fallback "Something went wrong. Please try again."))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
@@ -443,6 +443,27 @@
                 (is (vector? (:history opts)))
                 (is (fn? (:on-line opts)))))))))))
 
+(deftest slack-thread-conversation-id-test
+  (testing "Same thread produces same conversation ID"
+    (is (= (#'slackbot.streaming/slack-thread->conversation-id "T1" "C1" "123.456")
+           (#'slackbot.streaming/slack-thread->conversation-id "T1" "C1" "123.456"))))
+
+  (testing "Different threads produce different IDs"
+    (is (not= (#'slackbot.streaming/slack-thread->conversation-id "T1" "C1" "123.456")
+              (#'slackbot.streaming/slack-thread->conversation-id "T1" "C1" "789.012"))))
+
+  (testing "Different channels produce different IDs"
+    (is (not= (#'slackbot.streaming/slack-thread->conversation-id "T1" "C1" "123.456")
+              (#'slackbot.streaming/slack-thread->conversation-id "T1" "C2" "123.456"))))
+
+  (testing "Different workspaces produce different IDs"
+    (is (not= (#'slackbot.streaming/slack-thread->conversation-id "T1" "C1" "123.456")
+              (#'slackbot.streaming/slack-thread->conversation-id "T2" "C1" "123.456"))))
+
+  (testing "Result is valid UUID format"
+    (is (re-matches #"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+                    (#'slackbot.streaming/slack-thread->conversation-id "T1" "C1" "123.456")))))
+
 (deftest user-message-with-visualizations-test
   (testing "POST /events with visualizations uploads multiple images to Slack"
     (with-slackbot-setup
@@ -1255,3 +1276,4 @@
                                    {:slack-connect-client-id "id"
                                     :slack-connect-client-secret "secret"
                                     :metabot-slack-signing-secret "signing"}))))))
+

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
@@ -443,7 +443,7 @@
                 (is (vector? (:history opts)))
                 (is (fn? (:on-line opts)))))))))))
 
-(deftest slack-thread-conversation-id-test
+(deftest ^:parallel slack-thread-conversation-id-test
   (testing "Same thread produces same conversation ID"
     (is (= (#'slackbot.streaming/slack-thread->conversation-id "T1" "C1" "123.456")
            (#'slackbot.streaming/slack-thread->conversation-id "T1" "C1" "123.456"))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
@@ -1276,4 +1276,3 @@
                                    {:slack-connect-client-id "id"
                                     :slack-connect-client-secret "secret"
                                     :metabot-slack-signing-secret "signing"}))))))
-


### PR DESCRIPTION
In this PR I use `UUID.nameUUIDFromBytes` to hash `team_id`, `channel`, and `thread_ts` into a deterministic UUID we can use as the conversation id for specific slack threads. This should allow us to better track distinct conversations from our messages table downstream.

Note: I did not include user id. I think this could incorrectly attribute certain conversations to users for multi-user conversation threads. I suppose this could count towards user's limits if we ever reduce restrictions in the future. Punting for now unless someone thinks we should solve it.