### PR TITLE
Don't fail on unknown settings when calling set-many

### DIFF
--- a/src/metabase/settings/models/setting.clj
+++ b/src/metabase/settings/models/setting.clj
@@ -1401,7 +1401,8 @@
   ;; to revert any changes in the cache
   (try
     (t2/with-transaction [_conn]
-      (doseq [[k v] settings]
+      (doseq [[k v] settings
+              :when (registered? k)]
         (metabase.settings.models.setting/set! k v)))
     settings
     (catch Throwable e

--- a/src/metabase/settings/models/setting.clj
+++ b/src/metabase/settings/models/setting.clj
@@ -1401,9 +1401,10 @@
   ;; to revert any changes in the cache
   (try
     (t2/with-transaction [_conn]
-      (doseq [[k v] settings
-              :when (registered? k)]
-        (metabase.settings.models.setting/set! k v)))
+      (doseq [[k v] settings]
+        (if (registered? k)
+          (metabase.settings.models.setting/set! k v)
+          (log/infof "Skipping unregistered setting: %s" (name k)))))
     settings
     (catch Throwable e
       (setting.cache/restore-cache!)

--- a/test/metabase/settings/models/setting_test.clj
+++ b/test/metabase/settings/models/setting_test.clj
@@ -302,6 +302,13 @@
     (is (= "For realz"
            (db-fetch-setting :test-setting-2))))
 
+  (testing "unregistered settings should be silently skipped"
+    (setting/set-many! {:test-setting-1 "known value"
+                        :totally-fake-setting "unknown value"})
+    (is (= "known value"
+           (db-fetch-setting :test-setting-1)))
+    (is (not (setting/registered? :totally-fake-setting))))
+
   (testing "if one change fails, the entire set of changes should be reverted"
     (mt/with-temporary-setting-values [test-setting-1 "123"
                                        test-setting-2 "123"]


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #70262
### Description

`ldap-group-membership-filter` but the frontend `LDAP_SCHEMA` includes this setting for all editions and all default values are sent to `PUT /api/setting` on deactivation which throws throws on unregistered settings.

This PR updates the `set-many!` function to not fail on unknown settings.

This does loose the ability to be catching via errors any mis-typed settings. But it also keeps the frontend from having to know (and be updated on changes) for any settings that are only in the EE edition. The alternative would be to update `constants.ts` (and possibly elsewhere) to know the differences in settings and exclude this from what is sent on an OSS version.

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
