### PR TITLE
[Slackbot] Better static viz sizing

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot.clj
@@ -333,4 +333,3 @@
                                                   :thread_ts thread-ts})
 
   (def thread (slackbot.client/fetch-thread client message)))
-

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot.clj
@@ -333,3 +333,4 @@
                                                   :thread_ts thread-ts})
 
   (def thread (slackbot.client/fetch-thread client message)))
+

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot.clj
@@ -69,7 +69,8 @@
                     :provider "slack-connect"
                     :provider_id slack-user-id
                     {:join  [[:core_user :user] [:= :user.id :auth_identity.user_id]]
-                     :where [:= :user.is_active true]}))
+                     :where [:= :user.is_active true]
+                     :order-by [[:created_at :desc]]}))
 
 (defn- slack-user-authorize-link
   "Link to page where user can initiate SSO auth flow to authorize slackbot"

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/query.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/query.clj
@@ -160,10 +160,7 @@
       [table-block])))
 
 (def ^:private supported-png-display-types
-  "Display types that should render as PNG images rather than Slack tables.
-   These correspond to the render methods in channel.render.body and
-   frontend static-viz components. Map types (pin_map, state, country)
-   are explicitly unsupported per channel.render.card/detect-pulse-chart-type."
+  "Display types that should render as PNG images rather than Slack tables."
   #{:smartscalar :gauge :progress
     :bar :line :area :combo :row :pie
     :scatter :boxplot :waterfall :funnel})

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/query.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/query.clj
@@ -12,13 +12,33 @@
 
 (set! *warn-on-reflection* true)
 
-(def ^:private render-width-px
-  "Width in pixels used when rendering cards and ad-hoc queries to PNG for Slack."
-  1280)
+(def ^:private render-base-height-px
+  "Base height in pixels for rendered PNGs. Width is calculated from aspect ratio."
+  640)
 
 (def ^:private render-padding-x-px
   "Horizontal padding in pixels applied to rendered PNGs."
   32)
+
+(def ^:private display-aspect-ratios
+  "Non-default aspect ratios (width:height) for display types, derived from dashboard card size defaults.
+   Most display types use the default 2:1 ratio."
+  {:pie       3/2  ; 12:8
+   :waterfall 7/3  ; 14:6
+   :sankey    8/5}) ; 16:10
+
+(def ^:private default-aspect-ratio
+  "Default aspect ratio when display type not found."
+  2/1)
+
+(defn- render-dimensions
+  "Calculate render dimensions for a display type based on aspect ratios.
+   Keeps height consistent at render-base-height-px and scales width by aspect ratio."
+  [display]
+  (let [aspect-ratio (get display-aspect-ratios (keyword display) default-aspect-ratio)
+        render-width (long (* render-base-height-px aspect-ratio))]
+    {:width  render-width
+     :height render-base-height-px}))
 
 (defn- throw-on-failed-query!
   [results]
@@ -39,11 +59,12 @@
   "Render query results to PNG."
   [results display]
   (let [adhoc-card {:display                display
-                    :visualization_settings {}}]
+                    :visualization_settings {}}
+        {:keys [width]} (render-dimensions display)]
     (channel.render/render-adhoc-card-to-png
      adhoc-card
      results
-     render-width-px
+     width
      {:channel.render/padding-x render-padding-x-px})))
 
 ;;; ------------------------------------------ Slack Table Blocks ----------------------------------------------------
@@ -138,9 +159,14 @@
                     :text (format "Showing %d of %d rows" displayed-rows total-rows)}]}]
       [table-block])))
 
-(def ^:private chart-display-types
-  "Display types that should render as PNG images rather than Slack tables."
-  #{:bar :line :pie :area :row :scatter :funnel :waterfall :combo :progress :gauge})
+(def ^:private supported-png-display-types
+  "Display types that should render as PNG images rather than Slack tables.
+   These correspond to the render methods in channel.render.body and
+   frontend static-viz components. Map types (pin_map, state, country)
+   are explicitly unsupported per channel.render.card/detect-pulse-chart-type."
+  #{:smartscalar :gauge :progress
+    :bar :line :area :combo :row :pie
+    :scatter :boxplot :waterfall :funnel})
 
 (defn generate-adhoc-output
   "Generate output for an ad-hoc query based on display type.
@@ -154,22 +180,13 @@
   (let [display (keyword display)
         results (execute-adhoc-query query)]
     (throw-on-failed-query! results)
-    (if (contains? chart-display-types display)
+    (if (contains? supported-png-display-types display)
       {:type    :image
        :content (generate-adhoc-png results display)}
       {:type    :table
        :content (format-results-as-table-blocks results)})))
 
 ;;; ------------------------------------------ Saved Card Visualization ----------------------------------------------------
-
-(def ^:private supported-png-display-types
-  "Display types that can be rendered as PNG images for Slack.
-   These correspond to the render methods in channel.render.body and
-   frontend static-viz components. Map types (pin_map, state, country)
-   are explicitly unsupported per channel.render.card/detect-pulse-chart-type."
-  #{:scalar :smartscalar :gauge :progress
-    :bar :line :area :combo :row :pie
-    :scatter :boxplot :waterfall :funnel :sankey})
 
 (defn pulse-card-query-results
   "Execute a query for a saved card, returning results suitable for rendering."
@@ -189,7 +206,8 @@
 (defn- render-saved-card-png
   "Render a saved card (already fetched from DB) to PNG bytes."
   [card]
-  (let [options {:channel.render/include-title? true
+  (let [{:keys [width]} (render-dimensions (:display card))
+        options {:channel.render/include-title? true
                  :channel.render/padding-x render-padding-x-px
                  :channel.render/padding-y 0}
         results (pulse-card-query-results card)]
@@ -198,7 +216,7 @@
     (channel.render/render-pulse-card-to-png (channel.render/defaulted-timezone card)
                                              card
                                              results
-                                             render-width-px
+                                             width
                                              options)))
 
 (defn generate-card-output
@@ -218,3 +236,4 @@
         (throw-on-failed-query! results)
         {:type    :table
          :content (format-results-as-table-blocks results)}))))
+

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/query.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/query.clj
@@ -163,7 +163,7 @@
   "Display types that should render as PNG images rather than Slack tables."
   #{:smartscalar :gauge :progress
     :bar :line :area :combo :row :pie
-    :scatter :boxplot :waterfall :funnel})
+    :scatter :boxplot :waterfall :funnel :sankey})
 
 (defn generate-adhoc-output
   "Generate output for an ad-hoc query based on display type.
@@ -233,4 +233,3 @@
         (throw-on-failed-query! results)
         {:type    :table
          :content (format-results-as-table-blocks results)}))))
-

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot/query_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot/query_test.clj
@@ -96,6 +96,18 @@
           (testing "returns parseable PNG"
             (is (some? image))))))))
 
+(deftest render-dimensions-test
+  (testing "render-dimensions calculates width from display type aspect ratios"
+    (testing "bar chart uses 2:1 ratio (12:6 default)"
+      (is (= {:width 1280 :height 640}
+             (#'slackbot.query/render-dimensions :bar))))
+    (testing "pie chart uses 3:2 ratio (12:8 default)"
+      (is (= {:width 960 :height 640}
+             (#'slackbot.query/render-dimensions :pie))))
+    (testing "unknown display type falls back to 2:1 ratio"
+      (is (= {:width 1280 :height 640}
+             (#'slackbot.query/render-dimensions :unknown-type))))))
+
 ;;; ------------------------------------------------ Table Blocks ----------------------------------------------------
 
 (deftest format-results-as-table-blocks-test

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
@@ -722,7 +722,7 @@
 
         (testing "supported display types return :image"
           (doseq [display [:bar :line :pie :area :row :scatter :funnel
-                           :waterfall :combo :progress :gauge :scalar
+                           :waterfall :combo :progress :gauge
                            :smartscalar :boxplot :sankey]]
             (testing (str "display type: " display)
               (mt/with-temp [:model/Card {card-id :id} {:display display}]
@@ -730,7 +730,7 @@
                   (is (= :image (:type result))))))))
 
         (testing "unsupported display types return :table"
-          (doseq [display [:table :pin_map :state :country :map :pivot]]
+          (doseq [display [:table :pin_map :state :country :map :pivot :scalar]]
             (testing (str "display type: " display)
               (mt/with-temp [:model/Card {card-id :id} {:display display}]
                 (let [result (#'slackbot.query/generate-card-output card-id)]


### PR DESCRIPTION
Render Slack PNG visualizations at aspect ratios matching dashboard card defaults instead of a fixed 1280px width. Also adds `smartscalar` and `boxplot` to supported PNG display types (fixing a PR I made that removed them accidentally).