### PR TITLE
Fix flakes

### DIFF
--- a/e2e/support/helpers/api/createTransform.ts
+++ b/e2e/support/helpers/api/createTransform.ts
@@ -39,12 +39,13 @@ export function createTransform(
       tag_ids,
       collection_id,
     })
-    .then(({ body }) => {
+    .then((response) => {
       if (wrapId) {
-        cy.wrap(body.id).as(idAlias);
+        cy.wrap(response.body.id).as(idAlias);
       }
       if (visitTransform) {
         cy.visit(`/data-studio/transforms/${body.id}`);
       }
+      return cy.wrap(response);
     });
 }

--- a/e2e/support/helpers/api/createTransform.ts
+++ b/e2e/support/helpers/api/createTransform.ts
@@ -44,7 +44,7 @@ export function createTransform(
         cy.wrap(response.body.id).as(idAlias);
       }
       if (visitTransform) {
-        cy.visit(`/data-studio/transforms/${body.id}`);
+        cy.visit(`/data-studio/transforms/${response.body.id}`);
       }
       return cy.wrap(response);
     });

--- a/e2e/support/helpers/e2e-dependency-helpers.ts
+++ b/e2e/support/helpers/e2e-dependency-helpers.ts
@@ -15,7 +15,11 @@ export const DependencyDiagnostics = {
   visitBrokenDependencies: () =>
     cy.visit("/data-studio/dependency-diagnostics/broken"),
   visitUnreferencedEntities: () => {
+    cy.intercept("GET", "/api/ee/dependencies/graph/unreferenced*").as(
+      "unreferencedEntities",
+    );
     cy.visit("/data-studio/dependency-diagnostics/unreferenced");
+    cy.wait("@unreferencedEntities");
     DependencyDiagnostics.list().should("be.visible");
   },
   list: () => cy.findByTestId("dependency-list"),

--- a/e2e/support/helpers/e2e-dependency-helpers.ts
+++ b/e2e/support/helpers/e2e-dependency-helpers.ts
@@ -1,6 +1,7 @@
 import type {
   DependencyNode,
   ListBreakingGraphNodesResponse,
+  ListUnreferencedGraphNodesResponse,
 } from "metabase-types/api";
 
 export const DependencyGraph = {
@@ -43,6 +44,27 @@ export const DependencyDiagnostics = {
 
 const WAIT_TIMEOUT = 10000;
 const WAIT_INTERVAL = 100;
+
+export function waitForUnreferencedEntities(
+  filter: (nodes: DependencyNode[]) => boolean,
+  timeout = WAIT_TIMEOUT,
+): Cypress.Chainable {
+  return cy
+    .request<ListUnreferencedGraphNodesResponse>(
+      "GET",
+      "/api/ee/dependencies/graph/unreferenced?include-personal-collections=true",
+    )
+    .then((response) => {
+      if (filter(response.body.data)) {
+        return cy.wrap(response);
+      } else if (timeout > 0) {
+        cy.wait(WAIT_INTERVAL);
+        return waitForUnreferencedEntities(filter, timeout - WAIT_INTERVAL);
+      } else {
+        throw new Error("Unreferenced entities analysis retry timeout");
+      }
+    });
+}
 
 export function waitForBreakingDependencies(
   filter: (nodes: DependencyNode[]) => boolean,

--- a/e2e/test/scenarios/data-studio/transforms/template-tags.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/transforms/template-tags.cy.spec.ts
@@ -98,25 +98,22 @@ describe("scenarios > admin > transforms", () => {
       query: "SELECT 1",
     })
       .then((query) =>
-        H.createTransform(
-          {
-            name: "MBQL",
-            source: {
-              type: "query",
-              query,
-            },
-            target: {
-              type: "table",
-              database: WRITABLE_DB_ID,
-              name: TARGET_TABLE,
-              schema: TARGET_SCHEMA,
-            },
+        H.createTransform({
+          name: "MBQL",
+          source: {
+            type: "query",
+            query,
           },
-          { wrapId: true },
-        ),
+          target: {
+            type: "table",
+            database: WRITABLE_DB_ID,
+            name: TARGET_TABLE,
+            schema: TARGET_SCHEMA,
+          },
+        }),
       )
-      .then((transformId) => {
-        cy.visit(`/data-studio/transforms/${transformId}`);
+      .then(({ body: transform }) => {
+        cy.visit(`/data-studio/transforms/${transform.id}`);
       });
 
     function testSimpleTemplateTag(

--- a/e2e/test/scenarios/dependencies/dependency-checks.cy.spec.ts
+++ b/e2e/test/scenarios/dependencies/dependency-checks.cy.spec.ts
@@ -394,6 +394,8 @@ function createSqlTransformWithDependentMbqlQuestions() {
 }
 
 function createMbqlTransformWithDependentMbqlTransforms() {
+  const targetTableName = "base_transform";
+
   H.getTableId({ name: "Animals", databaseId: WRITABLE_DB_ID }).then(
     (tableId) => {
       H.createTransform(
@@ -411,66 +413,70 @@ function createMbqlTransformWithDependentMbqlTransforms() {
           },
           target: {
             type: "table",
-            name: "base_transform",
+            name: targetTableName,
             schema: "public",
             database: WRITABLE_DB_ID,
           },
         },
         { wrapId: true },
-      );
-      cy.get<number>("@transformId").then((transformId) =>
-        H.runTransformAndWaitForSuccess(transformId),
-      );
-
-      H.getTableId({ databaseId: WRITABLE_DB_ID, name: "base_transform" }).then(
-        (tableId) => {
-          H.getFieldId({ tableId, name: "name" }).then((fieldId) => {
-            H.createTransform({
-              name: "Name transform",
-              source: {
-                type: "query",
-                query: {
-                  database: WRITABLE_DB_ID,
+      )
+        .then(({ body }) => H.runTransformAndWaitForSuccess(body.id))
+        .then(() => {
+          H.resyncDatabase({
+            dbId: WRITABLE_DB_ID,
+            tableName: targetTableName,
+          });
+          H.getTableId({
+            databaseId: WRITABLE_DB_ID,
+            name: targetTableName,
+          }).then((tableId) => {
+            H.getFieldId({ tableId, name: "name" }).then((fieldId) => {
+              H.createTransform({
+                name: "Name transform",
+                source: {
                   type: "query",
                   query: {
-                    "source-table": tableId,
-                    fields: [["field", fieldId, null]],
+                    database: WRITABLE_DB_ID,
+                    type: "query",
+                    query: {
+                      "source-table": tableId,
+                      fields: [["field", fieldId, null]],
+                    },
                   },
                 },
-              },
-              target: {
-                type: "table",
-                name: "name_transform",
-                schema: "public",
-                database: WRITABLE_DB_ID,
-              },
-            });
-          });
-
-          H.getFieldId({ tableId, name: "score" }).then((fieldId) => {
-            H.createTransform({
-              name: "Score transform",
-              source: {
-                type: "query",
-                query: {
+                target: {
+                  type: "table",
+                  name: "name_transform",
+                  schema: "public",
                   database: WRITABLE_DB_ID,
+                },
+              });
+            });
+
+            H.getFieldId({ tableId, name: "score" }).then((fieldId) => {
+              H.createTransform({
+                name: "Score transform",
+                source: {
                   type: "query",
                   query: {
-                    "source-table": tableId,
-                    filter: [">", ["field", fieldId, null], 1],
+                    database: WRITABLE_DB_ID,
+                    type: "query",
+                    query: {
+                      "source-table": tableId,
+                      filter: [">", ["field", fieldId, null], 1],
+                    },
                   },
                 },
-              },
-              target: {
-                type: "table",
-                name: "score_transform",
-                schema: "public",
-                database: WRITABLE_DB_ID,
-              },
+                target: {
+                  type: "table",
+                  name: "score_transform",
+                  schema: "public",
+                  database: WRITABLE_DB_ID,
+                },
+              });
             });
           });
-        },
-      );
+        });
     },
   );
 }

--- a/e2e/test/scenarios/dependencies/dependency-unreferenced-list.cy.spec.ts
+++ b/e2e/test/scenarios/dependencies/dependency-unreferenced-list.cy.spec.ts
@@ -206,6 +206,9 @@ describe("scenarios > dependencies > unreferenced list", () => {
 
     it("should persist filter changes after page reload", () => {
       setupEntities();
+      H.waitForUnreferencedEntities((entities) =>
+        entities.some((e) => e.data.name === MODEL_FOR_QUESTION_DATA_SOURCE),
+      );
       H.DependencyDiagnostics.visitUnreferencedEntities();
       checkList({ visibleEntities: MODEL_NAMES });
 
@@ -219,6 +222,9 @@ describe("scenarios > dependencies > unreferenced list", () => {
 
     it("should filter by location", () => {
       setupEntities();
+      H.waitForUnreferencedEntities((entities) =>
+        entities.some((e) => e.data.name === MODEL_FOR_MODEL_DATA_SOURCE),
+      );
       H.DependencyDiagnostics.visitUnreferencedEntities();
       checkList({
         visibleEntities: [

--- a/e2e/test/scenarios/metabot/transforms-codegen.cy.spec.ts
+++ b/e2e/test/scenarios/metabot/transforms-codegen.cy.spec.ts
@@ -308,7 +308,8 @@ describe(
             sourceQuery: "SELECT 1",
             targetTable: "table_a",
             targetSchema: "Schema A",
-          }).as("transformId");
+            wrapId: true,
+          });
 
           visitTransformListPage();
           getMetabotButton().click();
@@ -385,23 +386,21 @@ describe(
                   return pd.DataFrame({'value': [1]})
               `,
                 sourceTables: { foo: tableId },
-              }).then((transformId) => {
+              }).then(({ body: transform }) => {
                 visitTransformListPage();
                 getMetabotButton().click();
 
                 // Ask metabot for a change to existing transform
-                cy.get("@transformId").then((transformId) => {
-                  H.mockMetabotResponse({
-                    body: createMockTransformSuggestionResponse(
-                      "Let me make that update for you.",
-                      createMockPythonTransformJSON(
-                        Number(transformId),
-                        WRITABLE_DB_ID,
-                        { foo: tableId },
-                        "import pandas as pd\\n\\ndef transform(foo):\\n    return pd.DataFrame({'value': [2]})",
-                      ),
+                H.mockMetabotResponse({
+                  body: createMockTransformSuggestionResponse(
+                    "Let me make that update for you.",
+                    createMockPythonTransformJSON(
+                      Number(transform.id),
+                      WRITABLE_DB_ID,
+                      { foo: tableId },
+                      "import pandas as pd\\n\\ndef transform(foo):\\n    return pd.DataFrame({'value': [2]})",
                     ),
-                  });
+                  ),
                 });
                 sendCodgenBotMessage(
                   "Update my SQL transform to select 2 instead of 1.",
@@ -438,7 +437,7 @@ describe(
                   body: createMockTransformSuggestionResponse(
                     "Let me make that change for you.",
                     createMockPythonTransformJSON(
-                      Number(transformId),
+                      Number(transform.id),
                       WRITABLE_DB_ID,
                       { metabase_table_df: 152 },
                       "import pandas as pd\\n\\ndef transform(foo):\\n    return pd.DataFrame({'value': [4]})",


### PR DESCRIPTION
Closes [GHY-3173](https://linear.app/metabase/issue/GHY-3173/flaky-test-e2e-tests-transforms-scenarios-dependencies-dependency)
Closes [GHY-3188](https://linear.app/metabase/issue/GHY-3188/flaky-test-e2e-tests-selecting-entities-scenarios-dependencies)
Closes [GHY-3071](https://linear.app/metabase/issue/GHY-3071/flaky-test-e2e-tests-filters-scenarios-dependencies-unreferenced-list)
Closes [GHY-3072](https://linear.app/metabase/issue/GHY-3072/flaky-test-e2e-tests-filters-scenarios-dependencies-unreferenced-list)

[stress test GHY-3173](https://github.com/metabase/metabase/actions/runs/22647813153) 🟢
[stress test GHY-3188](https://github.com/metabase/metabase/actions/runs/22651185001) 🟢
[stress test GHY-3071](https://github.com/metabase/metabase/actions/runs/22651790987) 🟢
[stress test GHY-3072](https://github.com/metabase/metabase/actions/runs/22701172023) 🟢