### PR TITLE
Always show tooltip for cards with descriptions

### DIFF
--- a/frontend/src/metabase/visualizations/components/legend/LegendCaption/LegendCaption.tsx
+++ b/frontend/src/metabase/visualizations/components/legend/LegendCaption/LegendCaption.tsx
@@ -138,12 +138,7 @@ export const LegendCaption = ({
           }
           maw="22em"
         >
-          <LegendDescriptionIcon
-            name="info"
-            className={cx(CS.hoverChild, CS.hoverChildSmooth)}
-            mt="3px"
-            mr="md"
-          />
+          <LegendDescriptionIcon name="info" mt="3px" mr="md" />
         </Tooltip>
       )}
       <LegendRightContent>


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/70308

### Description

Easiest solution for #70308, by simply always showing the ℹ️ icon on dashboard cards that have descriptions.

### How to verify

Look at the E-commerce insights dashboard, observe all the ℹ️ icons being shown. Here, I've removed the description from the "Revenue per quarter" card to show that this does not affect cards without descriptions:

<img width="1393" height="1055" alt="image" src="https://github.com/user-attachments/assets/16c277cf-1f46-45c4-a4c6-99bdf5ea7375" />

### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~
- [ ] ~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~
