### PR TITLE
Remove target table indexes

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/transforms/incremental_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/incremental_test.clj
@@ -1,7 +1,6 @@
 (ns ^:mb/driver-tests ^:mb/transforms-python-test metabase-enterprise.transforms.incremental-test
   "Tests for incremental transforms functionality."
   (:require
-   [clojure.set :as set]
    [clojure.string :as str]
    [clojure.test :refer :all]
    [honey.sql :as sql]
@@ -693,99 +692,3 @@
             (testing "second increment"
               (transforms.execute/execute! (t2/select-one :model/Transform (:id transform)) {:run-method :manual})
               (is (= [{:id 42} {:id 43}] (pg-table-rows db-spec target-table))))))))))
-
-(deftest filter-column-indexed-test
-  (testing "Filter column is indexed"
-    (doseq [checkpoint-type [:integer]
-            transform-type  [:native :mbql :python]
-            :when (valid-checkpoint-transform-combo? checkpoint-type transform-type)]
-      (testing (format "with %s checkpoint on %s transform" (name checkpoint-type) (name transform-type))
-        (mt/test-drivers (set/intersection (test-drivers) (mt/normal-drivers-with-feature :transforms/index-ddl))
-          (mt/with-premium-features #{:transforms :transforms-python}
-            (mt/dataset transforms-dataset/transforms-test
-              (with-transform-cleanup! [target-table (target-table-gen "incremental_index")]
-                (let [checkpoint-config (get checkpoint-configs checkpoint-type)
-                      transform-payload (make-incremental-transform-payload "Incremental Transform" target-table transform-type checkpoint-config)]
-                  (mt/with-temp [:model/Transform transform transform-payload]
-                    (let [get-transform #(t2/select-one :model/Transform (:id transform))]
-                      (testing "First run creates index on checkpoint column"
-                        (execute-transform-with-ordering! transform transform-type (:field-name checkpoint-config) {:run-method :manual})
-                        (let [indexes    (driver/describe-table-indexes driver/*driver* (mt/id) target-table)
-                              field-name (:field-name checkpoint-config)]
-                          (testing "Index was created"
-                            (is (= 1 (count indexes)))
-                            (is (=? {:value field-name :index-name #"^mb_transform_idx_.*$"} (first indexes))))))
-                      (testing "Data was processed correctly"
-                        (is (= 10 (get-table-row-count target-table))))
-                      (testing "Second run succeeds with existing index"
-                        (execute-transform-with-ordering! (get-transform) transform-type (:field-name checkpoint-config) {:run-method :manual})
-                        (let [indexes    (driver/describe-table-indexes driver/*driver* (mt/id) target-table)
-                              field-name (:field-name checkpoint-config)]
-                          (testing "Index still exists"
-                            (is (= 1 (count indexes)))
-                            (is (=? {:value field-name :index-name #"^mb_transform_idx_.*$"} (first indexes)))))
-                        (testing "Data was processed correctly"
-                          (is (= 16 (get-table-row-count target-table))))))))))))))))
-
-(deftest index-cleanup-on-switch-to-non-incremental-test
-  (testing "Switching to non-incremental removes metabase-owned indexes"
-    (doseq [checkpoint-type [:integer]
-            transform-type  [:native :mbql :python]
-            :when (valid-checkpoint-transform-combo? checkpoint-type transform-type)]
-      (testing (format "with %s checkpoint on %s transform" (name checkpoint-type) (name transform-type))
-        (mt/test-drivers (set/intersection (test-drivers) (mt/normal-drivers-with-feature :transforms/index-ddl))
-          (mt/with-premium-features #{:transforms :transforms-python}
-            (mt/dataset transforms-dataset/transforms-test
-              (with-transform-cleanup! [target-table (target-table-gen "index_cleanup_non_incr")]
-                (let [checkpoint-config   (get checkpoint-configs checkpoint-type)
-                      {:keys [field-name]} checkpoint-config
-                      incremental-payload (make-incremental-transform-payload "Index Cleanup Transform" target-table transform-type checkpoint-config)]
-                  (mt/with-temp [:model/Transform transform incremental-payload]
-                    (testing "First incremental run creates index"
-                      (execute-transform-with-ordering! transform transform-type field-name {:run-method :manual})
-                      (let [indexes (driver/describe-table-indexes driver/*driver* (mt/id) target-table)]
-                        (is (=? {:value field-name :index-name #"^mb_transform_idx_.*$"} (first indexes)))))
-                    (testing "Switch to non-incremental via API"
-                      (let [non-incremental-payload (-> incremental-payload
-                                                        (update :source dissoc :source-incremental-strategy))
-                            updated                 (mt/user-http-request :crowberto :put 200 (format "transform/%d" (:id transform))
-                                                                          non-incremental-payload)]
-                        (is (nil? (:source-incremental-strategy (:source updated))))))
-                    (testing "Non-incremental run removes automatic indexes indexes"
-                      (let [transform (t2/select-one :model/Transform (:id transform))]
-                        (execute-transform-with-ordering! transform transform-type field-name {:run-method :manual})
-                        (let [indexes    (driver/describe-table-indexes driver/*driver* (mt/id) target-table)
-                              mb-indexes (filter #(str/starts-with? (:index-name %) "mb_transform_idx_") indexes)]
-                          (testing "Automatic indexes are dropped"
-                            (is (empty? mb-indexes))))))))))))))))
-
-(deftest index-cleanup-on-checkpoint-column-change-test
-  (testing "Changing checkpoint column removes old index and creates new one"
-    (mt/test-drivers (set/intersection (test-drivers) (mt/normal-drivers-with-feature :transforms/index-ddl))
-      (mt/with-premium-features #{:transforms}
-        (mt/dataset transforms-dataset/transforms-test
-          (with-transform-cleanup! [target-table (target-table-gen "icchange")]
-            (let [integer-config  (get checkpoint-configs :integer)
-                  float-config    (get checkpoint-configs :float)
-                  initial-field   (:field-name integer-config)
-                  new-field       (:field-name float-config)
-                  transform-type  :native
-                  initial-payload (make-incremental-transform-payload "Column Change Transform" target-table transform-type integer-config)]
-              (mt/with-temp [:model/Transform transform initial-payload]
-                (testing "First run with integer checkpoint creates index on id column"
-                  (execute-transform-with-ordering! transform transform-type initial-field {:run-method :manual})
-                  (let [indexes (driver/describe-table-indexes driver/*driver* (mt/id) target-table)]
-                    (is (= 1 (count indexes)))
-                    (is (=? {:value initial-field :index-name #"^mb_transform_idx_.*$"} (first indexes)))))
-                (testing "Switch checkpoint column via API"
-                  (let [new-payload (make-incremental-transform-payload "Column Change Transform" target-table transform-type float-config)
-                        updated     (mt/user-http-request :crowberto :put 200 (format "transform/%d" (:id transform))
-                                                          new-payload)]
-                    (is (= new-field (-> updated :source :source-incremental-strategy :checkpoint-filter)))))
-                (testing "Run with new checkpoint column updates indexes"
-                  (let [transform (t2/select-one :model/Transform (:id transform))]
-                    (execute-transform-with-ordering! transform transform-type new-field {:run-method :manual})
-                    (let [indexes            (driver/describe-table-indexes driver/*driver* (mt/id) target-table)]
-                      (testing "Old index removed, new checkpoint column is now indexed"
-                        (is (= 1 (count indexes)))
-                        (is (=? {:value new-field :index-name #"^mb_transform_idx_.*$"} (first indexes)))))))))))))))

--- a/src/metabase/transforms/util.clj
+++ b/src/metabase/transforms/util.clj
@@ -1,7 +1,5 @@
 (ns metabase.transforms.util
   (:require
-   [buddy.core.codecs :as codecs]
-   [buddy.core.hash :as buddy-hash]
    [clojure.core.async :as a]
    [clojure.string :as str]
    [java-time.api :as t]
@@ -719,94 +717,10 @@
     (filter #(some tag-ids (get-in % field-path)))
     identity))
 
-(def ^:private metabase-index-prefix "mb_transform_idx_")
-
-(defn- incremental-filter-index-name [schema table-name filter-column-name]
-  (let [prefix metabase-index-prefix
-        suffix (codecs/bytes->hex (buddy-hash/md5 (str/join "|" [schema table-name filter-column-name])))]
-    (str prefix suffix)))
-
-(defn- should-index-incremental-filter-column? [driver database]
-  (and (driver.u/supports? driver :describe-indexes database)
-       (driver.u/supports? driver :transforms/index-ddl database)))
-
-(defn- metabase-owned-index? [index]
-  (str/starts-with? (:index-name index) metabase-index-prefix))
-
-(defn- metabase-incremental-filter-index [filter-column target]
-  (let [table-name  (:name target)
-        schema      (:schema target)
-        filter-name (:name filter-column)]
-    ;; match the schema used by describe-table-indexes (:value denotes the column name, assumed leading column if a composite index)
-    {:index-name (incremental-filter-index-name schema table-name filter-name)
-     :value      filter-name}))
-
-(defn- decide-secondary-index-ddl
-  "Decides which indexes should be dropped/created on the target table.
-
-  e.g. Indexing the incremental :filter-column to accelerate MAX(target.checkpoint) queries on OLTP databases.
-
-  Indexes are represented as maps with at least the keys :index-name, :value.
-  This matches the form used by [[metabase.driver/describe-table-indexes]].
-
-  Returns a map:
-  :drop   - a vector of indexes that are redundant and should be dropped.
-  :create - a vector of desirable indexes that do not exist and that should be created.
-
-  Notes:
-  - If user covering indexes exist they should be reused.
-  - Will never drop user indexes.
-  - Indexes we previously created and are no longer required are dropped."
-  [{:keys [filter-column indexes target database]}]
-  (let [[mb-indexes user-indexes] ((juxt filter remove) metabase-owned-index? indexes)
-        default-mb-index    (when filter-column (metabase-incremental-filter-index filter-column target))
-        column-name         (:name filter-column)
-        existing-user-index (first (filter #(= (:value %) column-name) user-indexes))
-        existing-mb-index   (first (filter #(= (:index-name %) (:index-name default-mb-index)) mb-indexes))
-        driver              (:engine database)
-        intended-index      (when (should-index-incremental-filter-column? driver database)
-                              ;; Prefer reuse to not create redundant indexes
-                              (or existing-user-index default-mb-index))
-        drop                (if intended-index
-                              (remove #(= (:index-name intended-index) (:index-name %)) mb-indexes)
-                              mb-indexes)
-        create              (when (and intended-index
-                                       (not= (:index-name intended-index) (:index-name existing-user-index))
-                                       (not= (:index-name intended-index) (:index-name existing-mb-index)))
-                              [intended-index])]
-    {:drop   (vec drop)
-     :create (vec create)}))
-
-(defn execute-secondary-index-ddl-if-required!
-  "If target table index modifications are required, executes those CREATE/DROP commands.
-  See [[metabase.transforms-util/decide-secondary-index-ddl]] for details."
-  [transform run-id database target]
-  (when (driver.u/supports? (:engine database) :describe-indexes database)
-    (let [driver     (:engine database)
-          indexes    (driver/describe-table-indexes driver database target)
-          checkpoint (next-checkpoint transform)
-          {:keys [drop create]}
-          (decide-secondary-index-ddl
-           {:filter-column (:filter-column checkpoint)
-            :database      database
-            :target        target
-            :indexes       indexes})]
-      (doseq [{:keys [index-name value]} drop]
-        (transforms.instrumentation/with-stage-timing [run-id [:import :drop-incremental-filter-index]]
-          (log/infof "Dropping secondary index %s(%s) for target %s" index-name value (pr-str target))
-          (driver/drop-index! driver (:id database) (:schema target) (:name target) index-name)))
-      (doseq [{:keys [index-name value]} create]
-        (transforms.instrumentation/with-stage-timing [run-id [:import :create-incremental-filter-index]]
-          (log/infof "Creating secondary index %s(%s) for target %s" index-name value (pr-str target))
-          (driver/create-index! driver (:id database) (:schema target) (:name target) index-name [value]))))))
-
 (mu/defn handle-transform-complete!
   "Handles followup tasks for when a transform has completed.
 
-  Specifically, this syncs the target db, publishes a `:event/transform-run-complete` event, and potentially updates
-  the target table's index.
-
-  See [[metabase.transforms-util/decide-secondary-index-ddl]] for details on the index handling."
+  Specifically, this syncs the target db and publishes a `:event/transform-run-complete` event."
   [& {:keys [run-id transform db]}
    :- [:map
        [:run-id ::transforms.schema/run-id]
@@ -822,7 +736,4 @@
                                        :transform-id (:id transform)
                                        :transform-type (keyword (:type target))
                                        :output-schema (:schema target)
-                                       :output-table (qualified-table-name (:engine db) target)}})
-      ;; Creating an index after sync means the filter column is known in the appdb.
-      ;; The index would be synced the next time sync runs, but at time of writing, index sync is disabled.
-      (execute-secondary-index-ddl-if-required! transform run-id db target))))
+                                       :output-table (qualified-table-name (:engine db) target)}}))))

--- a/test/metabase/driver_test.clj
+++ b/test/metabase/driver_test.clj
@@ -17,6 +17,7 @@
    [metabase.test.data.interface :as tx]
    [metabase.util :as u]
    [metabase.util.json :as json]
+   [metabase.util.log :as log]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
@@ -481,3 +482,52 @@
 (deftest deps-flags-when-supported-driver-is-not-covered-test
   (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Database that supports :dependencies/native does not provide an implementation of driver/native-query-deps"
                         (driver/native-query-deps ::mock-deps-driver nil nil))))
+
+(defn- create-index-test-impl! [schema]
+  (let [driver      driver/*driver*
+        suffix      (str (System/currentTimeMillis))
+        table-name  (str "test_table_" suffix)
+        qualified-table-name (keyword schema table-name)
+        index-name  #(str "test_index_" % "_" suffix)
+        database-id (mt/id)
+        cleanup     (fn []
+                      (try
+                        (driver/drop-table! driver database-id qualified-table-name)
+                        (catch Throwable t
+                          (log/fatal t "Could not clean up test table!")
+                          (throw t))))]
+    (when schema
+      (driver/create-schema-if-needed! driver (driver/connection-spec driver database-id) schema))
+    (testing "Throws a driver-specific exception if the table does not exist"
+      (is (thrown? Throwable (driver/create-index! driver database-id schema table-name (index-name "a") [:a]))))
+    (try
+      (driver/create-table! driver database-id qualified-table-name {:a [:int], :b [:int], :c [:int]})
+      (testing "Create a single column index"
+        (is (nil? (driver/create-index! driver database-id schema table-name (index-name "a") [:a])))
+        (testing "Index now exists"
+          (is (= #{{:type       :normal-column-index
+                    :index-name (index-name "a")
+                    :value      "a"}}
+                 (driver/describe-table-indexes driver database-id {:schema schema :name table-name}))))
+        (testing "Drop the index"
+          (is (nil? (driver/drop-index! driver database-id schema table-name (index-name "a"))))
+          (testing "Index no longer exists"
+            (is (empty? (driver/describe-table-indexes driver database-id {:schema schema :name table-name}))))))
+      (testing "Create a multi column index"
+        (driver/create-index! driver database-id schema table-name (index-name "b_c") [:b :c])
+        (testing "Index now exists"
+          ;; single-part only as non-leading columns currently dropped by describe-table-indexes
+          (is (= #{{:type       :normal-column-index
+                    :index-name (index-name "b_c")
+                    :value      "b"}}
+                 (driver/describe-table-indexes driver database-id {:schema schema :name table-name})))))
+      (finally
+        (cleanup)))))
+
+(deftest create-index-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :transforms/index-ddl)
+    (create-index-test-impl! nil)))
+
+(deftest create-index-schema-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :transforms/index-ddl :schemas)
+    (create-index-test-impl! "flibble")))

--- a/test/metabase/transforms/util_test.clj
+++ b/test/metabase/transforms/util_test.clj
@@ -331,8 +331,7 @@
                                                          :status "running"
                                                          :run_method "manual"}]
           (with-redefs [transforms.util/sync-target!                       (constantly table)
-                        events/publish-event!                              (constantly nil)
-                        transforms.util/execute-secondary-index-ddl-if-required! (constantly nil)]
+                        events/publish-event!                              (constantly nil)]
             (transforms.util/handle-transform-complete! :run-id run-id :transform transform :db db)
             (is (= transform-id
                    (t2/select-one-fn :transform_id :model/Table :id table-id)))))))))


### PR DESCRIPTION
They no longer make sense if watermarking state is held in the appdb rather than the target.

Re-added driver tests which were removed for some reason (probably a bad rebase for workspaces somewhere)