### PR TITLE
docs: start redirect

### DIFF
--- a/docs/data-studio/overview.md
+++ b/docs/data-studio/overview.md
@@ -1,6 +1,8 @@
 ---
 title: Data studio
 summary: Data Studio provides tools to shape and track your data so everyone can trust the numbers.
+redirect_from:
+  - /docs/latest/data-studio/start
 ---
 
 # Data Studio


### PR DESCRIPTION
i don't think there's a reason for the "start" page to exist, but the website disagrees with me (that's where category breadcrumbs link)