### PR TITLE
Conceal JWT signing secret by default

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm/SettingsJWTForm.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm/SettingsJWTForm.unit.spec.tsx
@@ -61,9 +61,7 @@ describe("SettingsJWTForm", () => {
       ATTRS["jwt-identity-provider-uri"],
     );
     await userEvent.type(
-      await screen.findByRole("textbox", {
-        name: /String used by the JWT signing key/,
-      }),
+      await screen.findByLabelText(/String used by the JWT signing key/),
       ATTRS["jwt-shared-secret"],
     );
     await userEvent.type(
@@ -113,9 +111,7 @@ describe("SettingsJWTForm", () => {
       ATTRS["jwt-identity-provider-uri"],
     );
     await userEvent.type(
-      await screen.findByRole("textbox", {
-        name: /String used by the JWT signing key/,
-      }),
+      await screen.findByLabelText(/String used by the JWT signing key/),
       ATTRS["jwt-shared-secret"],
     );
 

--- a/frontend/src/metabase/forms/components/FormSecretKey/FormSecretKey.tsx
+++ b/frontend/src/metabase/forms/components/FormSecretKey/FormSecretKey.tsx
@@ -7,11 +7,11 @@ import { t } from "ttag";
 import { ConfirmModal } from "metabase/common/components/ConfirmModal";
 import CS from "metabase/css/core/index.css";
 import { UtilApi } from "metabase/services";
-import type { TextInputProps } from "metabase/ui";
-import { Button, Flex, TextInput } from "metabase/ui";
+import type { PasswordInputProps } from "metabase/ui";
+import { Button, Flex, PasswordInput } from "metabase/ui";
 
 export interface FormSecretKeyProps
-  extends Omit<TextInputProps, "value" | "error"> {
+  extends Omit<PasswordInputProps, "value" | "error"> {
   name: string;
   nullable?: boolean;
   confirmation: {
@@ -63,7 +63,7 @@ export const FormSecretKey = forwardRef(function FormSecretKey(
   return (
     <>
       <Flex align="end" gap="1rem">
-        <TextInput
+        <PasswordInput
           {...props}
           ref={ref}
           name={name}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/70328.

### Description

Use a password input to display the JWT shared secret, instead of a plain text box.

Triple backport because it's a simple change, and why not.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Run this branch with and without `MB_JWT_SHARED_SECRET` set
2. Visit `/admin/settings/authentication/jwt`
3. Observe that the JWT secret is concealed by default, but can still be viewed, modified and regenerated

### Demo

<img width="1352" height="843" alt="image" src="https://github.com/user-attachments/assets/87588978-f61d-4caa-af29-fd81ffc3e37d" />

<img width="1352" height="843" alt="image" src="https://github.com/user-attachments/assets/2cc50083-e5da-489d-b57d-a66d982a1dc8" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] ~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~
