### PR TITLE
Make a mage task to generate resolve-as XML from clj-kondo lint-as data

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -247,6 +247,14 @@
    :requires [[mage.util :as u]]
    :task (task! (u/print-tasks parsed))}
 
+  generate-cursive-resolve-as
+  {:doc "Generate XML configuration for Cursive's symbol resolution based on the current clj-kondo lint-as configuration."
+   :examples [["./bin/mage generate-cursive-resolve-as" "Generate resolve-as XML configuration"]
+              ["./bin/mage generate-cursive-resolve-as > /Users/bgrabow/Library/Application\\ Support/JetBrains/IntelliJIdea2025.3/options/ClojureResolveSettings.xml"
+              "Generate resolve-as XML configuration and install it in your global editor configuration"]]
+   :requires [[mage.cursive-resolve-as :as cursive-resolve-as]]
+   :task (task! (cursive-resolve-as/do-it))}
+
   analytics:setup
   {:doc "Set up usage analytics development mode"
    :examples [["./bin/mage analytics:setup" "Enable usage analytics dev mode and import content"]]
@@ -302,7 +310,7 @@
                     "If you see 'gh: command not found' or auth errors, run: gh auth login"))
    :requires [[mage.ci-report :as ci-report]]
    :task (task! (ci-report/generate-report! parsed))}
-  
+
   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
   ;; Private Tasks:
   ;; These tasks are more for internal tooling, e.g. for use from git hooks etc.

--- a/mage/src/mage/cursive_resolve_as.clj
+++ b/mage/src/mage/cursive_resolve_as.clj
@@ -1,0 +1,20 @@
+(ns mage.cursive-resolve-as
+  (:require [clojure.edn :as edn]
+            [clojure.string :as str]))
+
+(defn clj-kondo-lint-as->cursive-resolve-as
+  [lint-as]
+  (str/join \newline
+            (reduce concat
+                    []
+                    [["<application>" "  <component name=\"ClojureResolveSettings\">"]
+                     (for [[left right] lint-as]
+                       (format "    <item key=\"%s\" resolves-as=\"%s\" />" left right))
+                     ["  </component>" "</application>"]])))
+
+(defn do-it
+  []
+  (println (clj-kondo-lint-as->cursive-resolve-as
+            (:lint-as (edn/read-string (slurp ".clj-kondo/config.edn"))))))
+
+


### PR DESCRIPTION
### Description

In Intellij/Cursive, symbol resolution is managed in an XML file called `ClojureResolveSettings.xml`. Entries in this file can be manually updated, but generally they should mirror the `:lint-as` settings in `.clj-kondo/config.edn`.

This PR adds a new MAGE task to generate the `ClojureResolveSettings.xml` content from the `.clj-kondo/config.edn` `:lint-as` data.

```
Task Name: generate-cursive-resolve-as
  Generate XML configuration for Cursive's symbol resolution based on the current clj-kondo lint-as configuration.

Usages:
  generate-cursive-resolve-as

Examples:

 ./bin/mage generate-cursive-resolve-as 
 - Generate resolve-as XML configuration

 ./bin/mage generate-cursive-resolve-as > /Users/bgrabow/Library/Application\ Support/JetBrains/IntelliJIdea2025.3/options/ClojureResolveSettings.xml 
 - Generate resolve-as XML configuration and install it in your global editor configuration
```