### PR TITLE
Backport mage -driver-decisions to release-x.58.x

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -12,12 +12,52 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # This job will determine if the tier 3 driver tests should be skipped.
-  # It will always run first.
+  # This job determines which driver tests should run based on PR context.
+  # All decision logic is consolidated in mage driver-decisions.
   determine-driver-skips:
     runs-on: ubuntu-latest
     outputs:
-      skip: ${{ steps.check-branch-and-files-changed.outputs.skip }}
+      # All driver run decisions (from mage driver-decisions)
+      h2-should-run: ${{ steps.driver-decisions.outputs.h2-should-run }}
+      athena-should-run: ${{ steps.driver-decisions.outputs.athena-should-run }}
+      bigquery-should-run: ${{ steps.driver-decisions.outputs.bigquery-should-run }}
+      clickhouse-should-run: ${{ steps.driver-decisions.outputs.clickhouse-should-run }}
+      databricks-should-run: ${{ steps.driver-decisions.outputs.databricks-should-run }}
+      druid-should-run: ${{ steps.driver-decisions.outputs.druid-should-run }}
+      druid-jdbc-should-run: ${{ steps.driver-decisions.outputs.druid-jdbc-should-run }}
+      mongo-should-run: ${{ steps.driver-decisions.outputs.mongo-should-run }}
+      mongo-ssl-should-run: ${{ steps.driver-decisions.outputs.mongo-ssl-should-run }}
+      mongo-sharded-cluster-should-run: ${{ steps.driver-decisions.outputs.mongo-sharded-cluster-should-run }}
+      mysql-mariadb-should-run: ${{ steps.driver-decisions.outputs.mysql-mariadb-should-run }}
+      oracle-should-run: ${{ steps.driver-decisions.outputs.oracle-should-run }}
+      postgres-should-run: ${{ steps.driver-decisions.outputs.postgres-should-run }}
+      presto-jdbc-should-run: ${{ steps.driver-decisions.outputs.presto-jdbc-should-run }}
+      redshift-should-run: ${{ steps.driver-decisions.outputs.redshift-should-run }}
+      snowflake-should-run: ${{ steps.driver-decisions.outputs.snowflake-should-run }}
+      sparksql-should-run: ${{ steps.driver-decisions.outputs.sparksql-should-run }}
+      sqlite-should-run: ${{ steps.driver-decisions.outputs.sqlite-should-run }}
+      sqlserver-should-run: ${{ steps.driver-decisions.outputs.sqlserver-should-run }}
+      vertica-should-run: ${{ steps.driver-decisions.outputs.vertica-should-run }}
+      # Per-driver quarantine conflict flags (set when driver is quarantined but has file changes)
+      athena-quarantine-conflict: ${{ steps.driver-decisions.outputs.athena-quarantine-conflict }}
+      bigquery-quarantine-conflict: ${{ steps.driver-decisions.outputs.bigquery-quarantine-conflict }}
+      clickhouse-quarantine-conflict: ${{ steps.driver-decisions.outputs.clickhouse-quarantine-conflict }}
+      databricks-quarantine-conflict: ${{ steps.driver-decisions.outputs.databricks-quarantine-conflict }}
+      druid-quarantine-conflict: ${{ steps.driver-decisions.outputs.druid-quarantine-conflict }}
+      druid-jdbc-quarantine-conflict: ${{ steps.driver-decisions.outputs.druid-jdbc-quarantine-conflict }}
+      mongo-quarantine-conflict: ${{ steps.driver-decisions.outputs.mongo-quarantine-conflict }}
+      mongo-ssl-quarantine-conflict: ${{ steps.driver-decisions.outputs.mongo-ssl-quarantine-conflict }}
+      mongo-sharded-cluster-quarantine-conflict: ${{ steps.driver-decisions.outputs.mongo-sharded-cluster-quarantine-conflict }}
+      mysql-mariadb-quarantine-conflict: ${{ steps.driver-decisions.outputs.mysql-mariadb-quarantine-conflict }}
+      oracle-quarantine-conflict: ${{ steps.driver-decisions.outputs.oracle-quarantine-conflict }}
+      postgres-quarantine-conflict: ${{ steps.driver-decisions.outputs.postgres-quarantine-conflict }}
+      presto-jdbc-quarantine-conflict: ${{ steps.driver-decisions.outputs.presto-jdbc-quarantine-conflict }}
+      redshift-quarantine-conflict: ${{ steps.driver-decisions.outputs.redshift-quarantine-conflict }}
+      snowflake-quarantine-conflict: ${{ steps.driver-decisions.outputs.snowflake-quarantine-conflict }}
+      sparksql-quarantine-conflict: ${{ steps.driver-decisions.outputs.sparksql-quarantine-conflict }}
+      sqlite-quarantine-conflict: ${{ steps.driver-decisions.outputs.sqlite-quarantine-conflict }}
+      sqlserver-quarantine-conflict: ${{ steps.driver-decisions.outputs.sqlserver-quarantine-conflict }}
+      vertica-quarantine-conflict: ${{ steps.driver-decisions.outputs.vertica-quarantine-conflict }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -26,29 +66,26 @@ jobs:
         run: |
           # Fetch the base branch to ensure its history is available for diffing
           git fetch --depth=1 origin ${{ github.event.pull_request.base.ref }}:${{ github.event.pull_request.base.ref }}
-          # Only run this if it's a pull request and the base ref exists
-      - name: Check if driver tests should run
-        id: check-branch-and-files-changed
+      - name: Determine which drivers should run
+        id: driver-decisions
         run: |
-          IS_MASTER_OR_RELEASE="${{ github.ref_name == 'master' || startsWith(github.ref_name, 'release-') }}"
-          echo "Is master or release: ${IS_MASTER_OR_RELEASE}"
-
-          if [[ "${IS_MASTER_OR_RELEASE}" == "true" ]]; then
-            echo "skip=false" >> $GITHUB_OUTPUT
-            echo "Merging into master or a release branch. All driver tests will run."
-          else
-            echo "Checking for changes in relevant modules..."
-            if ./bin/mage can-skip-driver-tests "${{ github.event.pull_request.base.ref }}"; then
-              echo 'skip=true' >> $GITHUB_OUTPUT
-            else
-              echo 'skip=false' >> $GITHUB_OUTPUT
-            fi
-          fi
+          # All decision logic is in mage - it analyzes module dependencies,
+          # branch context, labels, and file changes to decide what runs.
+          MAGE_ARGS=(
+            --git-ref="${{ github.event.pull_request.base.ref || github.ref_name }}"
+            --is-master-or-release="${{ github.ref_name == 'master' || startsWith(github.ref_name, 'release-') }}"
+            --pr-labels="${{ join(github.event.pull_request.labels.*.name, ',') }}"
+            --skip="${{ inputs.skip }}"
+          )
+          # First call: show human-readable output for debugging
+          ./bin/mage -driver-decisions "${MAGE_ARGS[@]}"
+          # Second call: output only key=value lines for GITHUB_OUTPUT
+          ./bin/mage -driver-decisions "${MAGE_ARGS[@]}" --github-output-only >> $GITHUB_OUTPUT
         shell: bash
 
   be-tests-athena-ee:
     needs: determine-driver-skips
-    if: ${{ !inputs.skip && !(needs.determine-driver-skips.outputs.skip == 'true') }}
+    if: ${{ needs.determine-driver-skips.outputs.athena-should-run == 'true' || needs.determine-driver-skips.outputs.athena-quarantine-conflict == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
@@ -65,6 +102,16 @@ jobs:
       MB_ATHENA_TEST_WITHOUT_GET_TABLE_METADATA_SECRET_KEY: ${{ secrets.MB_ATHENA_TEST_WITHOUT_GET_TABLE_METADATA_SECRET_KEY }}
     name: Athena
     steps:
+    - name: Fail on quarantine conflict
+      if: ${{ needs.determine-driver-skips.outputs.athena-quarantine-conflict == 'true' }}
+      run: |
+        echo "::error::Athena driver is quarantined but you changed files in modules/drivers/athena/"
+        echo ""
+        echo "Your changes will NOT be tested because the driver is currently quarantined."
+        echo "To run Athena tests, add the label: break-quarantine-athena"
+        echo ""
+        echo "If you merge without testing, you risk breaking the Athena driver!"
+        exit 1
     - uses: actions/checkout@v4
     - name: Test Athena driver
       id: test-driver
@@ -76,7 +123,7 @@ jobs:
           :exclude-tags [:mb/transforms-python-test]
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: always() && steps.test-driver.outputs.quarantine-skipped != 'true'
+      if: always()
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}
@@ -87,72 +134,82 @@ jobs:
         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
 
-#   be-tests-bigquery-cloud-sdk-ee:
-#     needs: determine-driver-skips
-#     if: ${{ !inputs.skip && !(needs.determine-driver-skips.outputs.skip == 'true') }}
-#     runs-on: ubuntu-latest
-#     timeout-minutes: 60
-#     strategy:
-#       fail-fast: false
-#       matrix:
-#         job:
-#           - name: Driver Tests
-#             test-args: >-
-#               :only-tags [:mb/driver-tests]
-#               :exclude-tags [:mb/transforms-python-test]
-#               :fail-fast? true
-# # DS 2025-09-26 temporarily disabled while we diagnose flakes
-# #          - name: Transforms Python Tests
-# #            test-args: >-
-# #              :only-tags [:mb/transforms-python-test]
-# #            needs-python-runner: true
-#     env:
-#       CI: 'true'
-#       DRIVERS: bigquery-cloud-sdk
-#       MB_BIGQUERY_TEST_PROJECT_ID: ${{ secrets.BIGQUERY_TEST_PROJECT_ID }}
-#       MB_BIGQUERY_TEST_CLIENT_ID: ${{ secrets.MB_BIGQUERY_TEST_CLIENT_ID }}
-#       MB_BIGQUERY_TEST_CLIENT_SECRET: ${{ secrets.MB_BIGQUERY_TEST_CLIENT_SECRET }}
-#       MB_BIGQUERY_TEST_ACCESS_TOKEN: ${{ secrets.MB_BIGQUERY_TEST_ACCESS_TOKEN }}
-#       MB_BIGQUERY_TEST_REFRESH_TOKEN: ${{ secrets.MB_BIGQUERY_TEST_REFRESH_TOKEN }}
-#       MB_BIGQUERY_CLOUD_SDK_TEST_SERVICE_ACCOUNT_JSON: ${{ secrets.MB_BIGQUERY_CLOUD_SDK_TEST_SERVICE_ACCOUNT_JSON }}
-#       MB_BIGQUERY_CLOUD_SDK_TEST_SERVICE_ACCOUNT_JSON_ROUTING: ${{ secrets.MB_BIGQUERY_CLOUD_SDK_TEST_SERVICE_ACCOUNT_JSON_ROUTING }}
-#     name: BigQuery ${{ matrix.job.name }}
-#     steps:
-#     - uses: actions/checkout@v4
-#     - name: Setup python-runner
-#       if: ${{ matrix.job.needs-python-runner == true }}
-#       uses: ./.github/actions/setup-python-runner
-#       with:
-#         metabase-automation-token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
-#     - name: Test BigQuery Cloud SDK driver
-#       id: test-driver
-#       uses: ./.github/actions/test-driver
-#       with:
-#         junit-name: 'be-tests-bigquery-cloud-sdk-ee'
-#         test-args: ${{ matrix.job.test-args }}
-#         logs-artifact-suffix: ${{ matrix.job.name }}
-#     - name: Upload Test Results
-#       uses: ./.github/actions/upload-test-results
-#       if: always() && steps.test-driver.outputs.quarantine-skipped != 'true'
-#       with:
-#         input-path: ./target/junit/
-#         output-name: ${{ github.job }}
-#         bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
-#         aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
-#         aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
-#         aws-region: ${{ vars.AWS_REGION }}
-#         trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
-#         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
-#     - name: Cleanup python-runner
-#       if: ${{ always() && matrix.job.needs-python-runner == true }}
-#       uses: ./.github/actions/cleanup-python-runner
-#       with:
-#         upload-logs: ${{ steps.test-driver.outcome == 'failure' }}
-#         logs-artifact-suffix: ${{ matrix.job.name }} ${{ matrix.version.name }}
+  be-tests-bigquery-cloud-sdk-ee:
+    needs: determine-driver-skips
+    if: ${{ needs.determine-driver-skips.outputs.bigquery-should-run == 'true' || needs.determine-driver-skips.outputs.bigquery-quarantine-conflict == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        job:
+          - name: Driver Tests
+            test-args: >-
+              :only-tags [:mb/driver-tests]
+              :exclude-tags [:mb/transforms-python-test]
+              :fail-fast? true
+# DS 2025-09-26 temporarily disabled while we diagnose flakes
+#          - name: Transforms Python Tests
+#            test-args: >-
+#              :only-tags [:mb/transforms-python-test]
+#            needs-python-runner: true
+    env:
+      CI: 'true'
+      DRIVERS: bigquery-cloud-sdk
+      MB_BIGQUERY_TEST_PROJECT_ID: ${{ secrets.BIGQUERY_TEST_PROJECT_ID }}
+      MB_BIGQUERY_TEST_CLIENT_ID: ${{ secrets.MB_BIGQUERY_TEST_CLIENT_ID }}
+      MB_BIGQUERY_TEST_CLIENT_SECRET: ${{ secrets.MB_BIGQUERY_TEST_CLIENT_SECRET }}
+      MB_BIGQUERY_TEST_ACCESS_TOKEN: ${{ secrets.MB_BIGQUERY_TEST_ACCESS_TOKEN }}
+      MB_BIGQUERY_TEST_REFRESH_TOKEN: ${{ secrets.MB_BIGQUERY_TEST_REFRESH_TOKEN }}
+      MB_BIGQUERY_CLOUD_SDK_TEST_SERVICE_ACCOUNT_JSON: ${{ secrets.MB_BIGQUERY_CLOUD_SDK_TEST_SERVICE_ACCOUNT_JSON }}
+      MB_BIGQUERY_CLOUD_SDK_TEST_SERVICE_ACCOUNT_JSON_ROUTING: ${{ secrets.MB_BIGQUERY_CLOUD_SDK_TEST_SERVICE_ACCOUNT_JSON_ROUTING }}
+    name: BigQuery ${{ matrix.job.name }}
+    steps:
+    - name: Fail on quarantine conflict
+      if: ${{ needs.determine-driver-skips.outputs.bigquery-quarantine-conflict == 'true' }}
+      run: |
+        echo "::error::BigQuery driver is quarantined but you changed files in modules/drivers/bigquery-cloud-sdk/"
+        echo ""
+        echo "Your changes will NOT be tested because the driver is currently quarantined."
+        echo "To run BigQuery tests, add the label: break-quarantine-bigquery"
+        echo ""
+        echo "If you merge without testing, you risk breaking the BigQuery driver!"
+        exit 1
+    - uses: actions/checkout@v4
+    - name: Setup python-runner
+      if: ${{ matrix.job.needs-python-runner == true }}
+      uses: ./.github/actions/setup-python-runner
+      with:
+        metabase-automation-token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
+    - name: Test BigQuery Cloud SDK driver
+      id: test-driver
+      uses: ./.github/actions/test-driver
+      with:
+        junit-name: 'be-tests-bigquery-cloud-sdk-ee'
+        test-args: ${{ matrix.job.test-args }}
+        logs-artifact-suffix: ${{ matrix.job.name }}
+    - name: Upload Test Results
+      uses: ./.github/actions/upload-test-results
+      if: always()
+      with:
+        input-path: ./target/junit/
+        output-name: ${{ github.job }}
+        bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
+        aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ vars.AWS_REGION }}
+        trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
+        previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
+    - name: Cleanup python-runner
+      if: ${{ always() && matrix.job.needs-python-runner == true }}
+      uses: ./.github/actions/cleanup-python-runner
+      with:
+        upload-logs: ${{ steps.test-driver.outcome == 'failure' }}
+        logs-artifact-suffix: ${{ matrix.job.name }} ${{ matrix.version.name }}
 
   be-tests-clickhouse-ee:
     needs: determine-driver-skips
-    if: ${{ !inputs.skip && !(needs.determine-driver-skips.outputs.skip == 'true') }}
+    if: ${{ needs.determine-driver-skips.outputs.clickhouse-should-run == 'true' || needs.determine-driver-skips.outputs.clickhouse-quarantine-conflict == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
@@ -176,6 +233,16 @@ jobs:
       MB_CLICKHOUSE_TEST_NGINX_PORT: 8127
     name: Clickhouse ${{ matrix.job.name }}
     steps:
+    - name: Fail on quarantine conflict
+      if: ${{ needs.determine-driver-skips.outputs.clickhouse-quarantine-conflict == 'true' }}
+      run: |
+        echo "::error::ClickHouse driver is quarantined but you changed files in modules/drivers/clickhouse/"
+        echo ""
+        echo "Your changes will NOT be tested because the driver is currently quarantined."
+        echo "To run ClickHouse tests, add the label: break-quarantine-clickhouse"
+        echo ""
+        echo "If you merge without testing, you risk breaking the ClickHouse driver!"
+        exit 1
     - uses: actions/checkout@v4
     - name: Setup python-runner
       if: ${{ matrix.job.needs-python-runner == true }}
@@ -206,7 +273,7 @@ jobs:
         logs-artifact-suffix: ${{ matrix.job.name }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: always() && steps.test-driver.outputs.quarantine-skipped != 'true'
+      if: always()
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}
@@ -225,7 +292,7 @@ jobs:
 
   be-tests-druid-ee:
     needs: determine-driver-skips
-    if: ${{ !inputs.skip && !(needs.determine-driver-skips.outputs.skip == 'true') }}
+    if: ${{ needs.determine-driver-skips.outputs.druid-should-run == 'true' || needs.determine-driver-skips.outputs.druid-quarantine-conflict == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
@@ -240,6 +307,16 @@ jobs:
           CLUSTER_SIZE: nano-quickstart
     name: Druid (Legacy)
     steps:
+    - name: Fail on quarantine conflict
+      if: ${{ needs.determine-driver-skips.outputs.druid-quarantine-conflict == 'true' }}
+      run: |
+        echo "::error::Druid driver is quarantined but you changed files in modules/drivers/druid/"
+        echo ""
+        echo "Your changes will NOT be tested because the driver is currently quarantined."
+        echo "To run Druid tests, add the label: break-quarantine-druid"
+        echo ""
+        echo "If you merge without testing, you risk breaking the Druid driver!"
+        exit 1
     - uses: actions/checkout@v4
     - name: Test Druid driver
       id: test-driver
@@ -251,7 +328,7 @@ jobs:
           :exclude-tags [:mb/transforms-python-test]
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: always() && steps.test-driver.outputs.quarantine-skipped != 'true'
+      if: always()
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}
@@ -264,7 +341,7 @@ jobs:
 
   be-tests-druid-jdbc-ee:
     needs: determine-driver-skips
-    if: ${{ !inputs.skip && !(needs.determine-driver-skips.outputs.skip == 'true') }}
+    if: ${{ needs.determine-driver-skips.outputs.druid-jdbc-should-run == 'true' || needs.determine-driver-skips.outputs.druid-jdbc-quarantine-conflict == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
@@ -279,6 +356,16 @@ jobs:
           CLUSTER_SIZE: nano-quickstart
     name: Druid (JDBC)
     steps:
+    - name: Fail on quarantine conflict
+      if: ${{ needs.determine-driver-skips.outputs.druid-jdbc-quarantine-conflict == 'true' }}
+      run: |
+        echo "::error::Druid JDBC driver is quarantined but you changed files in modules/drivers/druid-jdbc/"
+        echo ""
+        echo "Your changes will NOT be tested because the driver is currently quarantined."
+        echo "To run Druid JDBC tests, add the label: break-quarantine-druid-jdbc"
+        echo ""
+        echo "If you merge without testing, you risk breaking the Druid JDBC driver!"
+        exit 1
     - uses: actions/checkout@v4
     - name: Test Druid JDBC driver
       id: test-driver
@@ -290,7 +377,7 @@ jobs:
           :exclude-tags [:mb/transforms-python-test]
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: always() && steps.test-driver.outputs.quarantine-skipped != 'true'
+      if: always()
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}
@@ -303,7 +390,7 @@ jobs:
 
   be-tests-databricks-ee:
     needs: determine-driver-skips
-    if: ${{ !inputs.skip && !(needs.determine-driver-skips.outputs.skip == 'true') }}
+    if: ${{ needs.determine-driver-skips.outputs.databricks-should-run == 'true' || needs.determine-driver-skips.outputs.databricks-quarantine-conflict == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
@@ -318,6 +405,16 @@ jobs:
       MB_DATABRICKS_TEST_OAUTH_SECRET: ${{ secrets.MB_DATABRICKS_JDBC_TEST_OAUTH_SECRET }}
     name: Databricks
     steps:
+    - name: Fail on quarantine conflict
+      if: ${{ needs.determine-driver-skips.outputs.databricks-quarantine-conflict == 'true' }}
+      run: |
+        echo "::error::Databricks driver is quarantined but you changed files in modules/drivers/databricks/"
+        echo ""
+        echo "Your changes will NOT be tested because the driver is currently quarantined."
+        echo "To run Databricks tests, add the label: break-quarantine-databricks"
+        echo ""
+        echo "If you merge without testing, you risk breaking the Databricks driver!"
+        exit 1
     - uses: actions/checkout@v4
     - name: Test Databricks driver
       id: test-driver
@@ -329,7 +426,7 @@ jobs:
           :exclude-tags [:mb/transforms-python-test]
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: always() && steps.test-driver.outputs.quarantine-skipped != 'true'
+      if: always()
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}
@@ -342,7 +439,7 @@ jobs:
 
   be-tests-databricks-multi-catalog-ee:
     needs: determine-driver-skips
-    if: ${{ !inputs.skip && !(needs.determine-driver-skips.outputs.skip == 'true') }}
+    if: ${{ needs.determine-driver-skips.outputs.databricks-should-run == 'true' || needs.determine-driver-skips.outputs.databricks-quarantine-conflict == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
@@ -358,6 +455,16 @@ jobs:
       MB_DATABRICKS_TEST_OAUTH_SECRET: ${{ secrets.MB_DATABRICKS_JDBC_TEST_OAUTH_SECRET }}
     name: Databricks (Multi-Catalog)
     steps:
+    - name: Fail on quarantine conflict
+      if: ${{ needs.determine-driver-skips.outputs.databricks-quarantine-conflict == 'true' }}
+      run: |
+        echo "::error::Databricks driver is quarantined but you changed files in modules/drivers/databricks/"
+        echo ""
+        echo "Your changes will NOT be tested because the driver is currently quarantined."
+        echo "To run Databricks tests, add the label: break-quarantine-databricks"
+        echo ""
+        echo "If you merge without testing, you risk breaking the Databricks driver!"
+        exit 1
     - uses: actions/checkout@v4
     - name: Test Databricks driver with multi-catalog
       id: test-driver
@@ -369,7 +476,7 @@ jobs:
           :exclude-tags [:mb/transforms-python-test]
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: always() && steps.test-driver.outputs.quarantine-skipped != 'true'
+      if: always()
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}
@@ -381,7 +488,8 @@ jobs:
         previous-step-outcome: ${{ steps.test-driver.outputs.test-outcome }}
 
   be-tests-h2:
-    if: ${{ !inputs.skip }}
+    needs: determine-driver-skips
+    if: ${{ needs.determine-driver-skips.outputs.h2-should-run == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
@@ -399,7 +507,7 @@ jobs:
           :exclude-tags [:mb/transforms-python-test]
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: always() && steps.test-driver.outputs.quarantine-skipped != 'true'
+      if: always()
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}
@@ -444,7 +552,7 @@ jobs:
 
   be-tests-mysql-mariadb:
     needs: determine-driver-skips
-    if: ${{ !inputs.skip && !(needs.determine-driver-skips.outputs.skip == 'true') }}
+    if: ${{ needs.determine-driver-skips.outputs.mysql-mariadb-should-run == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
@@ -562,7 +670,7 @@ jobs:
             :exclude-tags '[ ${{ matrix.job.exclude-tag }} ${{ env.__ADDITIONAL_EXCLUDED_TAG__ }}]'
       - name: Upload Test Results
         uses: ./.github/actions/upload-test-results
-        if: always() && steps.test-driver.outputs.quarantine-skipped != 'true'
+        if: always()
         with:
           input-path: ./target/junit/
           output-name: ${{ github.job }}
@@ -581,7 +689,7 @@ jobs:
 
   be-tests-mongo:
     needs: determine-driver-skips
-    if: ${{ !inputs.skip && !(needs.determine-driver-skips.outputs.skip == 'true') }}
+    if: ${{ needs.determine-driver-skips.outputs.mongo-should-run == 'true' || needs.determine-driver-skips.outputs.mongo-quarantine-conflict == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
@@ -618,6 +726,16 @@ jobs:
           MONGO_INITDB_ROOT_PASSWORD: metasample123
     name: ${{ matrix.version.name }} ${{ matrix.job.name }}
     steps:
+    - name: Fail on quarantine conflict
+      if: ${{ needs.determine-driver-skips.outputs.mongo-quarantine-conflict == 'true' }}
+      run: |
+        echo "::error::MongoDB driver is quarantined but you changed files in modules/drivers/mongo/"
+        echo ""
+        echo "Your changes will NOT be tested because the driver is currently quarantined."
+        echo "To run MongoDB tests, add the label: break-quarantine-mongo"
+        echo ""
+        echo "If you merge without testing, you risk breaking the MongoDB driver!"
+        exit 1
     - uses: actions/checkout@v4
     - name: Setup python-runner
       if: ${{ matrix.job.needs-python-runner == true }}
@@ -633,7 +751,7 @@ jobs:
         logs-artifact-suffix: ${{ matrix.job.name }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: always() && steps.test-driver.outputs.quarantine-skipped != 'true'
+      if: always()
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}
@@ -652,7 +770,7 @@ jobs:
 
   be-tests-mongo-ssl:
     needs: determine-driver-skips
-    if: ${{ !inputs.skip && !(needs.determine-driver-skips.outputs.skip == 'true') }}
+    if: ${{ needs.determine-driver-skips.outputs.mongo-ssl-should-run == 'true' || needs.determine-driver-skips.outputs.mongo-ssl-quarantine-conflict == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
@@ -670,6 +788,16 @@ jobs:
       MB_TEST_MONGO_REQUIRES_SSL: true
     name: "${{ matrix.version.name }} (SSL)"
     steps:
+      - name: Fail on quarantine conflict
+        if: ${{ needs.determine-driver-skips.outputs.mongo-ssl-quarantine-conflict == 'true' }}
+        run: |
+          echo "::error::MongoDB SSL driver is quarantined but you changed files in modules/drivers/mongo/"
+          echo ""
+          echo "Your changes will NOT be tested because the driver is currently quarantined."
+          echo "To run MongoDB SSL tests, add the label: break-quarantine-mongo-ssl"
+          echo ""
+          echo "If you merge without testing, you risk breaking the MongoDB SSL driver!"
+          exit 1
       - uses: actions/checkout@v4
       - name: Spin up Mongo docker container
         run: >-
@@ -706,7 +834,7 @@ jobs:
             :only-tags [:mb/driver-tests]
       - name: Upload Test Results
         uses: ./.github/actions/upload-test-results
-        if: always() && steps.test-driver.outputs.quarantine-skipped != 'true'
+        if: always()
         with:
           input-path: ./target/junit/
           output-name: ${{ github.job }}
@@ -719,7 +847,7 @@ jobs:
 
   be-tests-mongo-sharded-cluster-ee:
     needs: determine-driver-skips
-    if: ${{ !inputs.skip && !(needs.determine-driver-skips.outputs.skip == 'true') }}
+    if: ${{ needs.determine-driver-skips.outputs.mongo-sharded-cluster-should-run == 'true' || needs.determine-driver-skips.outputs.mongo-sharded-cluster-quarantine-conflict == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
@@ -732,6 +860,16 @@ jobs:
           - "27017:17017"
     name: MongoDB Sharded Cluster
     steps:
+    - name: Fail on quarantine conflict
+      if: ${{ needs.determine-driver-skips.outputs.mongo-sharded-cluster-quarantine-conflict == 'true' }}
+      run: |
+        echo "::error::MongoDB Sharded Cluster driver is quarantined but you changed files in modules/drivers/mongo/"
+        echo ""
+        echo "Your changes will NOT be tested because the driver is currently quarantined."
+        echo "To run MongoDB Sharded Cluster tests, add the label: break-quarantine-mongo-sharded-cluster"
+        echo ""
+        echo "If you merge without testing, you risk breaking the MongoDB Sharded Cluster driver!"
+        exit 1
     - uses: actions/checkout@v4
     - name: Test MongoDB driver (Sharded cluster)
       id: test-driver
@@ -742,7 +880,7 @@ jobs:
           :only metabase.driver.mongo.sharded-cluster-test
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: always() && steps.test-driver.outputs.quarantine-skipped != 'true'
+      if: always()
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}
@@ -755,7 +893,7 @@ jobs:
 
   be-tests-oracle:
     needs: determine-driver-skips
-    if: ${{ !inputs.skip && !(needs.determine-driver-skips.outputs.skip == 'true') }}
+    if: ${{ needs.determine-driver-skips.outputs.oracle-should-run == 'true' || needs.determine-driver-skips.outputs.oracle-quarantine-conflict == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
@@ -806,6 +944,16 @@ jobs:
           - "1521:${{ matrix.version.port }}"
     name: ${{ matrix.version.name }}
     steps:
+    - name: Fail on quarantine conflict
+      if: ${{ needs.determine-driver-skips.outputs.oracle-quarantine-conflict == 'true' }}
+      run: |
+        echo "::error::Oracle driver is quarantined but you changed files in modules/drivers/oracle/"
+        echo ""
+        echo "Your changes will NOT be tested because the driver is currently quarantined."
+        echo "To run Oracle tests, add the label: break-quarantine-oracle"
+        echo ""
+        echo "If you merge without testing, you risk breaking the Oracle driver!"
+        exit 1
     - uses: actions/checkout@v4
     - name: Test ${{ matrix.version.name }}
       id: test-driver
@@ -818,7 +966,7 @@ jobs:
           :exclude-tags [:mb/transforms-python-test]
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: always() && steps.test-driver.outputs.quarantine-skipped != 'true'
+      if: always()
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}
@@ -831,7 +979,7 @@ jobs:
 
   be-tests-postgres:
     needs: determine-driver-skips
-    if: ${{ !inputs.skip && !(needs.determine-driver-skips.outputs.skip == 'true') }}
+    if: ${{ needs.determine-driver-skips.outputs.postgres-should-run == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
@@ -917,12 +1065,13 @@ jobs:
         uses: ./.github/actions/test-driver
         with:
           junit-name: 'be-tests-${{ matrix.version.junit-name }}'
+          logs-artifact-suffix: ${{ matrix.version.name }}-${{ matrix.job.name }}
           test-args: >-
             ${{ matrix.job.test-args }}
             :exclude-tags '[ ${{ matrix.job.exclude-tag }} ${{ env.__ADDITIONAL_EXCLUDED_TAG__ }}]'
       - name: Upload Test Results
         uses: ./.github/actions/upload-test-results
-        if: always() && steps.test-driver.outputs.quarantine-skipped != 'true'
+        if: always()
         with:
           input-path: ./target/junit/
           output-name: ${{ github.job }}
@@ -941,7 +1090,7 @@ jobs:
 
   be-tests-presto-jdbc-ee:
     needs: determine-driver-skips
-    if: ${{ !inputs.skip && !(needs.determine-driver-skips.outputs.skip == 'true') }}
+    if: ${{ needs.determine-driver-skips.outputs.presto-jdbc-should-run == 'true' || needs.determine-driver-skips.outputs.presto-jdbc-quarantine-conflict == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
@@ -964,6 +1113,16 @@ jobs:
         env:
           JAVA_TOOL_OPTIONS: "-Xmx2g"
     steps:
+    - name: Fail on quarantine conflict
+      if: ${{ needs.determine-driver-skips.outputs.presto-jdbc-quarantine-conflict == 'true' }}
+      run: |
+        echo "::error::Presto JDBC driver is quarantined but you changed files in modules/drivers/presto-jdbc/"
+        echo ""
+        echo "Your changes will NOT be tested because the driver is currently quarantined."
+        echo "To run Presto JDBC tests, add the label: break-quarantine-presto-jdbc"
+        echo ""
+        echo "If you merge without testing, you risk breaking the Presto JDBC driver!"
+        exit 1
     - uses: actions/checkout@v4
     - uses: ./.github/actions/await-port
       with:
@@ -1000,7 +1159,7 @@ jobs:
           :exclude-tags [:mb/transforms-python-test]
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: always() && steps.test-driver.outputs.quarantine-skipped != 'true'
+      if: always()
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}
@@ -1013,7 +1172,7 @@ jobs:
 
   be-tests-redshift-ee:
     needs: determine-driver-skips
-    if: ${{ !inputs.skip && !(needs.determine-driver-skips.outputs.skip == 'true') }}
+    if: ${{ needs.determine-driver-skips.outputs.redshift-should-run == 'true' || needs.determine-driver-skips.outputs.redshift-quarantine-conflict == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
@@ -1058,6 +1217,16 @@ jobs:
       MB_REDSHIFT_TEST_PASSWORD: ${{ secrets.MB_REDSHIFT_TEST_PASSWORD }}
     name: ${{ matrix.job.name }}
     steps:
+    - name: Fail on quarantine conflict
+      if: ${{ needs.determine-driver-skips.outputs.redshift-quarantine-conflict == 'true' }}
+      run: |
+        echo "::error::Redshift driver is quarantined but you changed files in modules/drivers/redshift/"
+        echo ""
+        echo "Your changes will NOT be tested because the driver is currently quarantined."
+        echo "To run Redshift tests, add the label: break-quarantine-redshift"
+        echo ""
+        echo "If you merge without testing, you risk breaking the Redshift driver!"
+        exit 1
     - uses: actions/checkout@v4
     - name: Setup python-runner
       if: ${{ matrix.job.needs-python-runner == true }}
@@ -1075,7 +1244,7 @@ jobs:
         logs-artifact-suffix: ${{ matrix.job.name }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: ${{ !matrix.job.skip && !cancelled() && steps.test-driver.outputs.quarantine-skipped != 'true' }}
+      if: ${{ !matrix.job.skip && !cancelled() }}
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}
@@ -1094,7 +1263,7 @@ jobs:
 
   be-tests-snowflake-ee:
     needs: determine-driver-skips
-    if: ${{ !inputs.skip && !(needs.determine-driver-skips.outputs.skip == 'true') }}
+    if: ${{ needs.determine-driver-skips.outputs.snowflake-should-run == 'true' || needs.determine-driver-skips.outputs.snowflake-quarantine-conflict == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
@@ -1133,6 +1302,16 @@ jobs:
       MB_SNOWFLAKE_TEST_RSA_ROLE_TEST_DB: RSA_ROLE_TEST_DB
     name: Snowflake ${{ matrix.job.name }}
     steps:
+    - name: Fail on quarantine conflict
+      if: ${{ needs.determine-driver-skips.outputs.snowflake-quarantine-conflict == 'true' }}
+      run: |
+        echo "::error::Snowflake driver is quarantined but you changed files in modules/drivers/snowflake/"
+        echo ""
+        echo "Your changes will NOT be tested because the driver is currently quarantined."
+        echo "To run Snowflake tests, add the label: break-quarantine-snowflake"
+        echo ""
+        echo "If you merge without testing, you risk breaking the Snowflake driver!"
+        exit 1
     - uses: actions/checkout@v4
     - name: Setup python-runner
       if: ${{ matrix.job.needs-python-runner == true }}
@@ -1148,7 +1327,7 @@ jobs:
         logs-artifact-suffix: ${{ matrix.job.name }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: always() && steps.test-driver.outputs.quarantine-skipped != 'true'
+      if: always()
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}
@@ -1167,7 +1346,7 @@ jobs:
 
   be-tests-sparksql-ee:
     needs: determine-driver-skips
-    if: ${{ !inputs.skip && !(needs.determine-driver-skips.outputs.skip == 'true') }}
+    if: ${{ needs.determine-driver-skips.outputs.sparksql-should-run == 'true' || needs.determine-driver-skips.outputs.sparksql-quarantine-conflict == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
@@ -1180,6 +1359,16 @@ jobs:
           - "10000:10000"
     name: Spark SQL
     steps:
+    - name: Fail on quarantine conflict
+      if: ${{ needs.determine-driver-skips.outputs.sparksql-quarantine-conflict == 'true' }}
+      run: |
+        echo "::error::SparkSQL driver is quarantined but you changed files in modules/drivers/sparksql/"
+        echo ""
+        echo "Your changes will NOT be tested because the driver is currently quarantined."
+        echo "To run SparkSQL tests, add the label: break-quarantine-sparksql"
+        echo ""
+        echo "If you merge without testing, you risk breaking the SparkSQL driver!"
+        exit 1
     - uses: actions/checkout@v4
     - name: Test Spark driver
       id: test-driver
@@ -1191,7 +1380,7 @@ jobs:
           :exclude-tags [:mb/transforms-python-test]
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: always() && steps.test-driver.outputs.quarantine-skipped != 'true'
+      if: always()
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}
@@ -1204,7 +1393,7 @@ jobs:
 
   be-tests-sqlite-ee:
     needs: determine-driver-skips
-    if: ${{ !inputs.skip && !(needs.determine-driver-skips.outputs.skip == 'true') }}
+    if: ${{ needs.determine-driver-skips.outputs.sqlite-should-run == 'true' || needs.determine-driver-skips.outputs.sqlite-quarantine-conflict == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
@@ -1212,6 +1401,16 @@ jobs:
       DRIVERS: sqlite
     name: SQLite
     steps:
+    - name: Fail on quarantine conflict
+      if: ${{ needs.determine-driver-skips.outputs.sqlite-quarantine-conflict == 'true' }}
+      run: |
+        echo "::error::SQLite driver is quarantined but you changed files in modules/drivers/sqlite/"
+        echo ""
+        echo "Your changes will NOT be tested because the driver is currently quarantined."
+        echo "To run SQLite tests, add the label: break-quarantine-sqlite"
+        echo ""
+        echo "If you merge without testing, you risk breaking the SQLite driver!"
+        exit 1
     - uses: actions/checkout@v4
     - name: Test SQLite driver
       id: test-driver
@@ -1223,7 +1422,7 @@ jobs:
           :exclude-tags [:mb/transforms-python-test]
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: always() && steps.test-driver.outputs.quarantine-skipped != 'true'
+      if: always()
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}
@@ -1236,7 +1435,7 @@ jobs:
 
   be-tests-sqlserver:
     needs: determine-driver-skips
-    if: ${{ !inputs.skip && !(needs.determine-driver-skips.outputs.skip == 'true') }}
+    if: ${{ needs.determine-driver-skips.outputs.sqlserver-should-run == 'true' || needs.determine-driver-skips.outputs.sqlserver-quarantine-conflict == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -1275,6 +1474,16 @@ jobs:
           MSSQL_MEMORY_LIMIT_MB: 1024
     name: ${{ matrix.version.name }} ${{ matrix.job.name }}
     steps:
+    - name: Fail on quarantine conflict
+      if: ${{ needs.determine-driver-skips.outputs.sqlserver-quarantine-conflict == 'true' }}
+      run: |
+        echo "::error::SQL Server driver is quarantined but you changed files in modules/drivers/sqlserver/"
+        echo ""
+        echo "Your changes will NOT be tested because the driver is currently quarantined."
+        echo "To run SQL Server tests, add the label: break-quarantine-sqlserver"
+        echo ""
+        echo "If you merge without testing, you risk breaking the SQL Server driver!"
+        exit 1
     - uses: actions/checkout@v4
     - name: Setup python-runner
       if: ${{ matrix.job.needs-python-runner == true }}
@@ -1290,7 +1499,7 @@ jobs:
         logs-artifact-suffix: ${{ matrix.version.name }}
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: always() && steps.test-driver.outputs.quarantine-skipped != 'true'
+      if: always()
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}
@@ -1312,7 +1521,7 @@ jobs:
   #   needs: determine-driver-skips
   #   if: ${{ !inputs.skip && !(needs.determine-driver-skips.outputs.skip == 'true') }}
   #   runs-on: ubuntu-latest
-  #   timeout-minutes: 60
+  #   timeout-minutes: 40
   #   env:
   #     CI: 'true'
   #     DRIVERS: starburst
@@ -1348,7 +1557,7 @@ jobs:
 
   login-to-ecr:
     needs: determine-driver-skips
-    if: ${{ !inputs.skip && !(needs.determine-driver-skips.outputs.skip == 'true') }}
+    if: ${{ needs.determine-driver-skips.outputs.vertica-should-run == 'true' || needs.determine-driver-skips.outputs.vertica-quarantine-conflict == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -1378,7 +1587,7 @@ jobs:
 
   be-tests-vertica-ee:
     needs: [determine-driver-skips, login-to-ecr]
-    if: ${{ !inputs.skip && !(needs.determine-driver-skips.outputs.skip == 'true') }}
+    if: ${{ needs.determine-driver-skips.outputs.vertica-should-run == 'true' || needs.determine-driver-skips.outputs.vertica-quarantine-conflict == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
@@ -1394,6 +1603,16 @@ jobs:
           password: ${{ needs.login-to-ecr.outputs.docker_password }}
     name: Vertica
     steps:
+    - name: Fail on quarantine conflict
+      if: ${{ needs.determine-driver-skips.outputs.vertica-quarantine-conflict == 'true' }}
+      run: |
+        echo "::error::Vertica driver is quarantined but you changed files in modules/drivers/vertica/"
+        echo ""
+        echo "Your changes will NOT be tested because the driver is currently quarantined."
+        echo "To run Vertica tests, add the label: break-quarantine-vertica"
+        echo ""
+        echo "If you merge without testing, you risk breaking the Vertica driver!"
+        exit 1
     - uses: actions/checkout@v4
     - name: Make plugins directory
       run: mkdir plugins
@@ -1407,7 +1626,7 @@ jobs:
           :exclude-tags [:mb/transforms-python-test]
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
-      if: always() && steps.test-driver.outputs.quarantine-skipped != 'true'
+      if: always()
       with:
         input-path: ./target/junit/
         output-name: ${{ github.job }}
@@ -1423,7 +1642,7 @@ jobs:
       # if you add a driver job, you must add it to this list for it to be a required check
       - be-tests-h2
       - be-tests-athena-ee
-      # - be-tests-bigquery-cloud-sdk-ee
+      - be-tests-bigquery-cloud-sdk-ee
       - be-tests-druid-ee
       - be-tests-databricks-ee
       - be-tests-druid-jdbc-ee

--- a/bb.edn
+++ b/bb.edn
@@ -273,6 +273,46 @@
   ;; These tasks are more for internal tooling, e.g. for use from git hooks etc.
   ;; - hidden from `./bin/mage` listing and `bb tasks`, these all - start with a `-`
 
+  -driver-decisions
+  {:doc "Determine which driver tests should run based on PR context. Outputs decisions for all drivers."
+   :examples [["./bin/mage -driver-decisions --git-ref=master --is-master-or-release=false --pr-labels= --skip=false" "Determine driver decisions for a PR"]
+              ["./bin/mage -driver-decisions --pr-labels=ci:all-cloud-drivers" "Run all cloud drivers via label"]
+              ["./bin/mage -driver-decisions --github-output-only" "Output only GITHUB_OUTPUT format (for CI)"]]
+   :requires [[clojure.string :as str]
+              [table.core :as table]
+              [mage.modules]]
+   :usage-fn
+   (fn [_current-task]
+     (let [driver-triggers (vec (sort mage.modules/default-modules-which-trigger-drivers))]
+       (str
+        "# How we decide to run a driver's tests. For each driver, we check these conditions in order (first match wins):\n"
+        (with-out-str
+          (table/table [["Priority" "Condition" "Result" "Reason"]
+                        ["1"    "Global skip (no backend changes)"        "SKIP" "workflow skip (no backend changes)"]
+                        ["2"    "Driver is :h2 or :postgres"              "RUN"  "H2/Postgres always run"]
+                        ["3"    "Driver is quarantined"                   "SKIP" "driver is quarantined"]
+                        ["3(a)" "...and has break-quarantine-X label"     "RUN"  "anti-quarantine label present"]
+                        ["4"    "On master or release branch"             "RUN"  "master/release branch"]
+                        ["5"    "Cloud driver + ci:all-cloud-drivers"     "RUN"  "ci:all-cloud-drivers label"]
+                        ["6"
+                         "Cloud driver + its files changed"
+                         "RUN"
+                         (str "any of " (pr-str driver-triggers) " affected by cloud-driver module changes")]
+                        ["7"    "Cloud driver + query-processor updated"  "RUN"  "query-processor module updated"]
+                        ["8"    "Cloud driver, no relevant changes"       "SKIP" "no relevant changes for cloud driver"]
+                        ["9"
+                         (str (pr-str driver-triggers) " module deps affected")
+                         "RUN"
+                         (str "any of " (pr-str driver-triggers) " affected by module changes")]
+                        ["10"   "Self-hosted driver, not affected"        "SKIP" "driver module not affected"]])))))
+   :options [[nil "--git-ref REF" "The git ref to compute changed modules against"]
+             [nil "--is-master-or-release MASTER_OR_RELEASE"]
+             [nil "--pr-labels PR_LABELS" "Comma delimited labels on the pr"]
+             [nil "--skip SKIP"]
+             [nil "--github-output-only" "Only output GITHUB_OUTPUT format (no human-readable output)"]]
+
+   :task (task! (mage.modules/-main parsed))}
+
   -install-merge-drivers
   {:doc "Installs custom git merge drivers for YAML migration files."
    :requires [[mage.util :as u]

--- a/mage/src/mage/modules.clj
+++ b/mage/src/mage/modules.clj
@@ -1,5 +1,7 @@
 (ns mage.modules
   (:require
+   ^:clj-kondo/ignore
+   [cheshire.core :as json]
    [clojure.edn :as edn]
    [clojure.set :as set]
    [clojure.string :as str]
@@ -7,6 +9,17 @@
    [mage.util :as u]))
 
 (set! *warn-on-reflection* true)
+
+(def ^:dynamic ^:private *github-output-only?* false)
+
+(def default-modules-which-trigger-drivers
+  "Modules that, when affected by changes, should trigger driver tests."
+  '#{driver transforms})
+
+(def modules-triggering-cloud-drivers
+  "Modules not only trigger driver tests, but run cloud drivers as well. Can be duplicative to driver triggers."
+  '#{query-processor transforms
+     enterprise/transforms enterprise/transforms-python enterprise/workspaces})
 
 ;;; TODO (Cam 2025-11-07) changes to test files should only cause us to run tests for that module as well, not
 ;;; everything that depends on that module directly or indirectly in `src`
@@ -23,7 +36,7 @@
         updated-files))
 
 (defn- updated-modules [git-ref]
-  (let [git-ref       (or git-ref "master")
+  (let [git-ref (or git-ref "master")
         updated-files (u/updated-files git-ref)]
     (updated-files->updated-modules updated-files)))
 
@@ -31,7 +44,7 @@
   [module]
   (case (namespace module)
     "enterprise" (str "enterprise/backend/test/metabase_enterprise/" (str/replace (name module) #"-" "_"))
-    nil          (str "test/metabase/" (str/replace (name module) #"-" "_"))))
+    nil (str "test/metabase/" (str/replace (name module) #"-" "_"))))
 
 (defn- dependencies
   "Read out the Kondo config for the modules linter; return a map of module => set of modules it directly depends on."
@@ -65,20 +78,73 @@
    (indirect-dependents deps module (sorted-set)))
   ([deps module acc]
    (let [module-deps (direct-dependents deps module)
-         new-deps    (set/difference module-deps acc)
-         acc         (into acc new-deps)]
+         new-deps (set/difference module-deps acc)
+         acc (into acc new-deps)]
      (reduce
       (fn [acc new-dep]
         (indirect-dependents deps new-dep acc))
       acc
       new-deps))))
 
+(def driver-affecting-overrides
+  "These modules affect drivers when computing, but we want to override and not consider them to affect drivers."
+  '#{analytics
+     api
+     api-keys
+     appearance
+     audit-app
+     auth-identity
+     auth-provider
+     batch-processing
+     channel
+     classloader
+     collections
+     config
+     content-verification
+     dashboards
+     eid-translation
+     embedding
+     enterprise/api
+     enterprise/scim
+     enterprise/serialization
+     enterprise/sso
+     events
+     formatter
+     initialization-status
+     internal-stats
+     login-history
+     notification
+     permissions
+     public-sharing
+     pulse
+     remote-sync
+     request
+     search
+     secrets
+     server
+     session
+     settings
+     setup
+     sso
+     startup
+     system
+     task
+     task-history
+     timeline
+     types
+     users
+     util
+     version
+     view-log})
+
 (defn- affected-modules
-  "Set of modules that are direct or indirect dependents of `modules`, and thus are affected by changes to them."
+  "Set of modules that are direct or indirect dependents of `modules`, and thus are affected by changes to them.
+   Includes the changed modules themselves (a module is always affected by its own changes)."
   [deps modules]
-  (into (sorted-set)
-        (mapcat (partial indirect-dependents deps))
-        modules))
+  (let [sorted-modules (into (sorted-set) modules)]
+    (into sorted-modules
+          (mapcat (partial indirect-dependents deps))
+          modules)))
 
 (defn- unaffected-modules
   "Return the set of modules that are unaffected "
@@ -90,11 +156,7 @@
 (comment
   (unaffected-modules (dependencies) '#{enterprise/billing}))
 
-(defn- skip-driver-tests? [deps modules]
-  (let [unaffected (unaffected-modules deps modules)]
-    (contains? unaffected 'driver)))
-
-(defn- print-updated-and-unaffected-modules [deps updated]
+(defn- print-updated-and-unaffected-modules [deps updated driver-deps-affected?]
   (let [unaffected (unaffected-modules deps updated)]
     (println "These modules have changed:" (pr-str updated))
     (println)
@@ -105,16 +167,17 @@
     (println "(By unaffected, this means these modules do not have a direct or indirect dependency on the modules that have been changed.)")
     (println)
     (println)
-    (println (if (skip-driver-tests? deps updated)
-               (c/green "Driver tests " (c/bold "CAN be skipped") "")
-               (c/red "Driver tests " (c/bold "MUST be run") ".")))))
+    (println (if driver-deps-affected?
+               (c/red "Driver tests " (c/bold "MUST be run") ".")
+               (c/green "Driver tests " (c/bold "CAN be skipped") "")))))
 
 (defn cli-print-affected-modules
   [[git-ref, :as _command-line-args]]
-  (let [deps       (dependencies)
-        updated    (updated-modules git-ref)
-        affected   (affected-modules deps updated)]
-    (print-updated-and-unaffected-modules deps updated)
+  (let [deps (dependencies)
+        updated (updated-modules git-ref)
+        affected (affected-modules deps updated)
+        driver-deps-affected? (not (contains? (unaffected-modules deps updated) 'driver))]
+    (print-updated-and-unaffected-modules deps updated driver-deps-affected?)
     (println)
     (println)
     (println "You can run tests for these modules and all downstream modules as follows:")
@@ -131,23 +194,23 @@
   (some (fn [filename]
           (when (or (str/includes? filename "deps.edn")
                     (str/includes? filename "modules/drivers/"))
-            (printf "Running driver tests because %s was changed\n" (pr-str filename))
-            (flush)
+            (when-not *github-output-only?*
+              (println (str "Running driver tests because " (pr-str filename) " was changed")))
             filename))
-        (u/updated-clojure-files (or git-ref "master"))))
+        (u/updated-files (or git-ref "master"))))
 
-(defn- remove-non-driver-test-namespaces [files]
-  (into []
-        (remove (fn [filename]
-                  (when (and (some #(str/includes? filename %)
-                                   ["test/" "enterprise/backend/test/"])
-                             (not (some #(str/includes? filename %)
-                                        ["query_processor"
-                                         "driver"])))
-                    (printf "Ignorning changes in test namespace %s\n" (pr-str filename))
-                    (flush)
-                    filename)))
-        files))
+(defn driver-deps-affected?
+  "Returns true if any of `trigger-modules` are affected by the changed modules.
+   1-arity and 2-arity use [[default-modules-which-trigger-drivers]] for backwards compatibility."
+  ([modules]
+   (driver-deps-affected? (dependencies) modules))
+  ([deps modules]
+   (driver-deps-affected? deps modules (set/union default-modules-which-trigger-drivers
+                                                  modules-triggering-cloud-drivers)))
+  ([deps modules trigger-modules]
+   (let [unaffected (unaffected-modules deps (remove driver-affecting-overrides modules))]
+     (boolean
+      (some #(not (contains? unaffected %)) trigger-modules)))))
 
 (defn cli-can-skip-driver-tests
   "Exits with zero status code if we can skip driver tests, nonzero if we cannot.
@@ -156,14 +219,281 @@
 
     ./bin/mage can-skip-driver-tests [git-ref]"
   [[git-ref, :as _arguments]]
-  (let [deps          (dependencies)
-        git-ref       (or git-ref "master")
-        updated-files (remove-non-driver-test-namespaces (u/updated-files git-ref))
-        updated       (updated-files->updated-modules updated-files)
-        skip-tests?   (skip-driver-tests? deps updated)]
+  (let [deps (dependencies)
+        git-ref (or git-ref "master")
+        updated-files (u/updated-files git-ref)
+        updated (updated-files->updated-modules updated-files)
+        drivers-affected? (driver-deps-affected? deps updated)]
     ;; Not strictly necessary, but people looking at CI will appreciate having this extra info.
-    (print-updated-and-unaffected-modules deps updated)
+    (print-updated-and-unaffected-modules deps updated drivers-affected?)
     (u/exit (cond
-              (not skip-tests?)                             1
               (changes-important-file-for-drivers? git-ref) 1
-              :else                                         0))))
+              drivers-affected? 1
+              :else 0))))
+
+;;;; =============================================================================
+;;;; Driver test decisions - consolidated logic for which drivers to run
+;;;; =============================================================================
+
+(def cloud-drivers
+  "Drivers that run on cloud infrastructure and require secrets. These are more expensive to run,
+  since they need round trip times, so we skip them on PRs unless specifically needed."
+  #{:athena :bigquery :databricks :redshift :snowflake})
+
+(def ^:private all-drivers
+  "All driver test jobs in drivers.yml, in order."
+  [:h2
+   :athena
+   :bigquery
+   :clickhouse
+   :databricks
+   :druid
+   :druid-jdbc
+   :mongo
+   :mongo-ssl
+   :mongo-sharded-cluster
+   :mysql-mariadb
+   :oracle
+   :postgres
+   :presto-jdbc
+   :redshift
+   :snowflake
+   :sparksql
+   :sqlite
+   :sqlserver
+   :vertica])
+
+(def ^:private driver-directory->drivers
+  "Maps driver directory names to the driver keyword(s) they correspond to.
+   Most directories map to a single driver, but some (like mongo) map to multiple test jobs."
+  {"athena" [:athena]
+   "bigquery-cloud-sdk" [:bigquery]
+   "clickhouse" [:clickhouse]
+   "databricks" [:databricks]
+   "druid" [:druid]
+   "druid-jdbc" [:druid-jdbc]
+   "mongo" [:mongo :mongo-ssl :mongo-sharded-cluster]
+   "oracle" [:oracle]
+   "presto-jdbc" [:presto-jdbc]
+   "redshift" [:redshift]
+   "snowflake" [:snowflake]
+   "sparksql" [:sparksql]
+   "sqlite" [:sqlite]
+   "sqlserver" [:sqlserver]
+   ;; starburst tests are currently disabled in drivers.yml
+   ;; "starburst" [:starburst]
+   "vertica" [:vertica]})
+
+(defn- drivers-with-file-changes
+  "Returns a set of driver keywords that have file changes in modules/drivers/<driver>/."
+  [git-ref]
+  (let [updated-files (u/updated-files (or git-ref "master"))]
+    (into #{}
+          (mapcat (fn [filename]
+                    (when-let [[_ dir-name] (re-matches #"modules/drivers/([^/]+)/.*" filename)]
+                      (get driver-directory->drivers dir-name))))
+          updated-files)))
+
+;;; driver quarantine
+
+(def ^:private ci-test-config-url
+  "https://raw.githubusercontent.com/metabase/ci-test-config/refs/heads/master/ci-test-config.json")
+
+(defn- read-ci-test-config []
+  (json/parse-string (slurp ci-test-config-url) keyword))
+
+(defn- quarantined-drivers []
+  (-> (read-ci-test-config)
+      (get-in [:ignored :drivers] [])
+      (->> (mapcat #(or (get driver-directory->drivers %)
+                        [(keyword %)])))
+      (set)))
+
+(defn- parse-bool
+  "Parse a string boolean from CLI args. Returns true for 'true', false otherwise."
+  [s]
+  (= (str/lower-case (str s)) "true"))
+
+(defn- parse-labels
+  "Parse comma-separated labels string into a set of label strings."
+  [labels-str]
+  (if (str/blank? labels-str)
+    #{}
+    (into #{} (map str/trim) (str/split labels-str #","))))
+
+(defn break-quarantine-label [driver]
+  (str "break-quarantine-" (name driver)))
+
+(defn- driver-decision
+  "Determine if a driver should run and why.
+
+   Returns a map with :should-run (boolean) and :reason (string).
+
+   For the decision priority order, see: mage -driver-decisions -h
+
+   ## What counts as 'driver deps affected'?
+
+   The driver module is considered affected when:
+   - Files in modules/drivers/* are changed (triggers all drivers)
+   - deps.edn is changed (triggers all drivers)
+   - Clojure modules that the 'driver' module depends on are changed"
+  [driver
+   {:keys [is-master-or-release pr-labels skip particular-driver-changed? verbose?]}
+   driver-deps-affected?
+   quarantined-drivers
+   updated]
+  (cond
+    ;; Priority 1: Global skip (no backend changes)
+    skip
+    {:should-run false
+     :reason "workflow skip (no backend changes)"}
+
+    ;; Priority 2: H2 and Postgres always run when backend tests run
+    (#{:h2 :postgres} driver)
+    {:should-run true
+     :reason "H2/Postgres always run"}
+
+    ;; Priority 3: Quarantined drivers (respected even on master/release)
+    (contains? quarantined-drivers driver)
+    (do
+      (when verbose?
+        (println "Driver" (name driver) "is quarantined; checking for '" (break-quarantine-label driver) "' label...."))
+      (if (contains? pr-labels (break-quarantine-label driver))
+        {:should-run true
+         :reason (str "driver is quarantined, but " (break-quarantine-label driver) " label found; running anyway")}
+        {:should-run false
+         :reason "driver is quarantined"}))
+
+    ;; Priority 4: Master/release branch - all (non-quarantined) drivers run
+    is-master-or-release
+    {:should-run true
+     :reason "master/release branch"}
+
+    ;; Priority 5: Cloud driver + ci:all-cloud-drivers label
+    (and (contains? cloud-drivers driver)
+         (contains? pr-labels "ci:all-cloud-drivers"))
+    {:should-run true
+     :reason "ci:all-cloud-drivers label"}
+
+    ;; Priority 6: Cloud driver + its files changed
+    (and (contains? cloud-drivers driver)
+         (contains? particular-driver-changed? driver))
+    {:should-run true
+     :reason (str "driver files changed (modules/drivers/" (name driver) "/**)")}
+
+    ;; Priority 7: Cloud driver + module triggering cloud dbs updated → run it
+    (and (contains? cloud-drivers driver)
+         (seq (set/intersection updated modules-triggering-cloud-drivers)))
+    {:should-run true
+     :reason "Module updated which explicitly triggers cloud drivers"}
+
+    ;; Priority 8: Cloud driver, no relevant changes → skip
+    (contains? cloud-drivers driver)
+    {:should-run false
+     :reason "no relevant changes for cloud driver"}
+
+    ;; Priority 9: Driver deps affected by shared code changes
+    driver-deps-affected?
+    {:should-run true
+     :reason "driver module affected by shared code changes"}
+
+    ;; Priority 10: Self-hosted driver, not affected
+    :else
+    {:should-run false
+     :reason "driver module not affected"}))
+
+(defn- cli-driver-decisions
+  "Determine which driver tests should run based on PR context.
+
+   Outputs decisions in GITHUB_OUTPUT format (key=value lines) plus human-readable logs.
+   Use --github-output-only to output only the key=value lines for CI.
+
+   Usage:
+     ./bin/mage -driver-decisions \\
+       --git-ref=master \\
+       --is-master-or-release=false \\
+       --pr-labels=ci:all-cloud-drivers,other-label \\
+       --skip=false"
+  [{:keys [options] :as _parsed}]
+  (let [github-output-only? (some? (:github-output-only options))
+        git-ref (get options :git-ref "master")
+        ;; Detect file changes for ALL drivers via git diff
+        particular-driver-changed? (drivers-with-file-changes git-ref)
+        ctx {:git-ref git-ref
+             :is-master-or-release (parse-bool (:is-master-or-release options))
+             :pr-labels (parse-labels (:pr-labels options))
+             :skip (parse-bool (:skip options))
+             :particular-driver-changed? particular-driver-changed?
+             :verbose? (not github-output-only?)}
+        quarantined (quarantined-drivers)
+        updated-files (u/updated-files git-ref)
+        updated (updated-files->updated-modules updated-files)
+        driver-affected? (driver-deps-affected? updated)
+        important-file-changed? (changes-important-file-for-drivers? git-ref)
+        ;; For module dependency check, combine both conditions
+        effective-driver-affected? (or driver-affected? important-file-changed?)
+        decisions (mapv (fn [driver]
+                          (assoc (driver-decision driver ctx effective-driver-affected? quarantined updated)
+                                 :driver driver))
+                        all-drivers)
+        ;; Check for quarantined drivers with file changes but no break-quarantine label
+        quarantined-with-changes (into #{}
+                                       (filter (fn [driver]
+                                                 (and (contains? quarantined driver)
+                                                      (contains? particular-driver-changed? driver)
+                                                      (not (contains? (:pr-labels ctx)
+                                                                      (break-quarantine-label driver))))))
+                                       all-drivers)]
+
+    (if github-output-only?
+      ;; In github-output-only mode, print just the key=value lines (no colors)
+      (do
+        (doseq [{:keys [driver should-run]} decisions]
+          (println (str (name driver) "-should-run=" should-run)))
+        (doseq [driver quarantined-with-changes]
+          (println (str (name driver) "-quarantine-conflict=true"))))
+
+      (do
+        ;; Print module analysis summary
+        (println "")
+        (println "=== Module Analysis ===")
+        (println "Changed modules:" (pr-str updated))
+        (println "Driver module affected:" driver-affected?)
+        (println "Important file changed:" (boolean important-file-changed?))
+        (println "Drivers with file changes:" (pr-str particular-driver-changed?))
+        (println "")
+
+        ;; Print human-readable decision summary
+        (println "=== Driver Decisions ===")
+        (doseq [{:keys [driver should-run reason]} decisions]
+          (println (format "%-25s %s - %s"
+                           (name driver)
+                           (if should-run (c/green "RUN ") (c/yellow "SKIP"))
+                           reason)))
+        (println "")
+
+        ;; Print GITHUB_OUTPUT preview with colors
+        (let [{drivers-to-run true drivers-to-skip false} (group-by :should-run decisions)]
+          (println (c/green (str "\n=== Drivers to Run (" (count drivers-to-run) ") ===")))
+          (doseq [{:keys [driver]} drivers-to-run]
+            (println (str (name driver) "-should-run=true")))
+          (println (c/yellow (str "\n=== Drivers to Skip (" (count drivers-to-skip) ") ===")))
+          (doseq [{:keys [driver]} drivers-to-skip]
+            (println (str (name driver) "-should-run=false"))))
+
+        ;; Output quarantine conflict warnings with colors
+        (when (seq quarantined-with-changes)
+          (println "")
+          (println (c/red "⚠️  WARNING: Quarantined driver(s) have file changes but tests will NOT run!"))
+          (println (c/red "=== Quarantine Conflicts ==="))
+          (doseq [driver quarantined-with-changes]
+            (println (c/red (str "  • " (name driver) " - add label '" (break-quarantine-label driver) "' to run tests")))
+            (println (str (name driver) "-quarantine-conflict=true"))))))
+
+    (u/exit 0)))
+
+(defn -main
+  "See [[cli-driver-decisions]]."
+  [{:keys [options] :as parsed}]
+  (binding [*github-output-only?* (:github-output-only options)]
+    (cli-driver-decisions parsed)))

--- a/mage/test/mage/core_test.clj
+++ b/mage/test/mage/core_test.clj
@@ -7,6 +7,7 @@
    [clojure.test :refer [deftest is testing]]
    [mage.alias-test]
    [mage.merge-yaml-migrations-test :as merge-yaml-migrations-test]
+   [mage.modules-test]
    [mage.token-scan-test]
    [mage.util :as u]
    [mage.util-test]))
@@ -14,6 +15,7 @@
 (comment
   mage.util-test/keep-me
   merge-yaml-migrations-test/keep-me
+  mage.modules-test/keep-me
   token-scan-test/keep-me)
 
 (set! *warn-on-reflection* true)

--- a/mage/test/mage/modules_test.clj
+++ b/mage/test/mage/modules_test.clj
@@ -1,0 +1,295 @@
+(ns mage.modules-test
+  "Tests for driver decision logic.
+   Run `mage -driver-decisions -h` to see the priority order."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [mage.modules]))
+
+;; Referenced by core_test.clj to ensure namespace is loaded
+(def keep-me :loaded)
+
+(defn- make-ctx
+  "Create a context map with sensible defaults, overridable by opts."
+  [opts]
+  (merge {:is-master-or-release false
+          :pr-labels #{}
+          :skip false
+          :particular-driver-changed? #{}
+          :verbose? false}
+         opts))
+
+;;; =============================================================================
+;;; Priority 3: Quarantine (respected even on master/release)
+;;; =============================================================================
+
+(deftest quarantined-driver-skips
+  (testing "Quarantined driver is skipped"
+    (let [result (mage.modules/driver-decision :mysql
+                                               (make-ctx {})
+                                               false ; driver-module-affected?
+                                               #{:mysql} ; quarantined
+                                               #{})] ; updated
+      (is (false? (:should-run result)))
+      (is (= "driver is quarantined" (:reason result))))))
+
+(deftest quarantined-driver-with-break-label-runs
+  (testing "Quarantined driver runs when break-quarantine label is present"
+    (let [result (mage.modules/driver-decision :mysql
+                                               (make-ctx {:pr-labels #{"break-quarantine-mysql"}})
+                                               false
+                                               #{:mysql}
+                                               #{})]
+      (is (true? (:should-run result)))
+      (is (re-find #"break-quarantine-mysql" (:reason result))))))
+
+(deftest quarantine-respected-on-master
+  (testing "Quarantined driver is skipped even on master/release"
+    (let [result (mage.modules/driver-decision :mysql
+                                               (make-ctx {:is-master-or-release true})
+                                               true ; driver-deps-affected?
+                                               #{:mysql} ; quarantined
+                                               #{})] ; updated
+      (is (false? (:should-run result)))
+      (is (= "driver is quarantined" (:reason result))))))
+
+(deftest quarantine-config-names-are-translated
+  (testing "Config names from ci-test-config.json are translated to internal driver keywords via driver-directory->drivers"
+    (testing "directory names are translated to internal keywords"
+      ;; bigquery-cloud-sdk -> :bigquery (via driver-directory->drivers mapping)
+      (let [result (mage.modules/driver-decision :bigquery
+                                                 (make-ctx {:is-master-or-release true})
+                                                 false
+                                                 #{:bigquery} ; as if translated from "bigquery-cloud-sdk"
+                                                 #{})]
+        (is (false? (:should-run result)))
+        (is (= "driver is quarantined" (:reason result)))))
+    (testing "the driver-directory->drivers mapping contains expected translations"
+      ;; Verify the mapping exists and has expected entries
+      (is (= [:bigquery] (get @#'mage.modules/driver-directory->drivers "bigquery-cloud-sdk"))
+          "bigquery-cloud-sdk should map to [:bigquery]")
+      (is (= [:mongo :mongo-ssl :mongo-sharded-cluster] (get @#'mage.modules/driver-directory->drivers "mongo"))
+          "mongo should map to multiple test jobs"))))
+
+;;; =============================================================================
+;;; Priority 1: Global skip
+;;; =============================================================================
+
+(deftest global-skip-skips-all-drivers
+  (testing "Global skip (no backend changes) skips all drivers"
+    (doseq [driver [:h2 :postgres :mysql :mongo :athena :bigquery]]
+      (let [result (mage.modules/driver-decision driver
+                                                 (make-ctx {:skip true})
+                                                 true ; even if affected
+                                                 #{} ; quarantined
+                                                 #{})] ; updated
+        (is (false? (:should-run result))
+            (str driver " should be skipped"))
+        (is (= "workflow skip (no backend changes)" (:reason result)))))))
+
+(deftest global-skip-beats-quarantine
+  (testing "Global skip takes priority over quarantine"
+    (let [result (mage.modules/driver-decision :mysql
+                                               (make-ctx {:skip true})
+                                               false
+                                               #{:mysql}
+                                               #{})]
+      (is (false? (:should-run result)))
+      (is (= "workflow skip (no backend changes)" (:reason result))))))
+
+;;; =============================================================================
+;;; Priority 2: H2 and Postgres always run
+;;; =============================================================================
+
+(deftest h2-and-postgres-always-run
+  (testing "H2 and Postgres always run when not globally skipped"
+    (doseq [driver [:h2 :postgres]]
+      (let [result (mage.modules/driver-decision driver
+                                                 (make-ctx {:is-master-or-release false})
+                                                 false ; driver module not affected
+                                                 #{} ; quarantined
+                                                 #{})] ; updated
+        (is (true? (:should-run result))
+            (str driver " should always run"))
+        (is (= "H2/Postgres always run" (:reason result)))))))
+
+(deftest h2-and-postgres-skipped-on-global-skip
+  (testing "H2 and Postgres are skipped when global skip is true"
+    (doseq [driver [:h2 :postgres]]
+      (let [result (mage.modules/driver-decision driver
+                                                 (make-ctx {:skip true})
+                                                 false
+                                                 #{} ; quarantined
+                                                 #{})] ; updated
+        (is (false? (:should-run result))
+            (str driver " should be skipped on global skip"))
+        (is (= "workflow skip (no backend changes)" (:reason result)))))))
+
+;;; =============================================================================
+;;; Priority 4: Master/release branch
+;;; =============================================================================
+
+(deftest master-branch-runs-all-drivers
+  (testing "All drivers run on master/release branch"
+    ;; H2/Postgres hit priority 2 first, others hit priority 4
+    (doseq [driver [:mysql :mongo :athena :bigquery :snowflake]]
+      (let [result (mage.modules/driver-decision driver
+                                                 (make-ctx {:is-master-or-release true})
+                                                 false ; even if not affected
+                                                 #{} ; quarantined
+                                                 #{})] ; updated
+        (is (true? (:should-run result))
+            (str driver " should run on master"))
+        (is (= "master/release branch" (:reason result)))))))
+
+;;; =============================================================================
+;;; Priority 9: Driver deps affected (self-hosted only)
+;;; =============================================================================
+
+(deftest driver-deps-affected-runs-self-hosted-drivers
+  (testing "Self-hosted drivers run when driver module is affected"
+    ;; H2/Postgres hit priority 2 first, others hit priority 8
+    (doseq [driver [:mysql :mongo :oracle :sqlserver]]
+      (let [result (mage.modules/driver-decision driver
+                                                 (make-ctx {})
+                                                 true ; driver-deps-affected
+                                                 #{} ; quarantined
+                                                 #{})] ; updated
+        (is (true? (:should-run result))
+            (str driver " should run when driver module affected"))
+        (is (= "driver module affected by shared code changes" (:reason result)))))))
+
+;;; =============================================================================
+;;; Priority 5-8: Cloud driver special rules
+;;; =============================================================================
+
+(deftest cloud-driver-with-label-runs
+  (testing "Cloud driver runs with ci:all-cloud-drivers label"
+    (doseq [driver [:athena :bigquery :databricks :redshift :snowflake]]
+      (let [result (mage.modules/driver-decision driver
+                                                 (make-ctx {:pr-labels #{"ci:all-cloud-drivers"}})
+                                                 false ; not affected
+                                                 #{} ; quarantined
+                                                 #{})] ; updated
+        (is (true? (:should-run result))
+            (str driver " should run with label"))
+        (is (= "ci:all-cloud-drivers label" (:reason result)))))))
+
+(deftest cloud-driver-with-file-changes-runs
+  (testing "Cloud driver runs when its files changed"
+    (let [result (mage.modules/driver-decision :athena
+                                               (make-ctx {:particular-driver-changed? #{:athena}})
+                                               false
+                                               #{} ; quarantined
+                                               #{})] ; updated
+      (is (true? (:should-run result)))
+      (is (re-find #"driver files changed" (:reason result))))))
+
+(deftest modules-can-trigger-cloud-drivers
+  (doseq [module '#{query-processor transforms
+                    enterprise/transforms enterprise/transforms-python enterprise/workspaces}
+          driver [:athena :bigquery :databricks :redshift :snowflake]]
+    (testing (format "Cloud driver runs when %s module is updated" module)
+      (let [result (mage.modules/driver-decision driver
+                                                 (make-ctx {})
+                                                 false       ; not affected
+                                                 #{}         ; quarantined
+                                                 #{module})] ; updated
+        (is (true? (:should-run result))
+            (str driver " should run when query-processor updated"))
+        (is (= "Module updated which explicitly triggers cloud drivers"
+               (:reason result)))))))
+
+(deftest cloud-driver-without-changes-skips
+  (testing "Cloud driver skips when no relevant changes"
+    (doseq [driver [:athena :bigquery :databricks :redshift :snowflake]]
+      (let [result (mage.modules/driver-decision driver
+                                                 (make-ctx {})
+                                                 false ; not affected
+                                                 #{} ; quarantined
+                                                 #{})] ; updated
+        (is (false? (:should-run result))
+            (str driver " should skip without changes"))
+        (is (= "no relevant changes for cloud driver" (:reason result)))))))
+
+;;; =============================================================================
+;;; Priority 10: Self-hosted drivers
+;;; =============================================================================
+
+(deftest self-hosted-driver-not-affected-skips
+  (testing "Self-hosted driver skips when driver module not affected"
+    ;; H2/Postgres always run (priority 2), so test other self-hosted drivers
+    (doseq [driver [:mysql :mongo :oracle :sqlserver]]
+      (let [result (mage.modules/driver-decision driver
+                                                 (make-ctx {})
+                                                 false ; not affected
+                                                 #{} ; quarantined
+                                                 #{})] ; updated
+        (is (false? (:should-run result))
+            (str driver " should skip when not affected"))
+        (is (= "driver module not affected" (:reason result)))))))
+
+;;; =============================================================================
+;;; Integration: Verify cloud vs self-hosted classification
+;;; =============================================================================
+
+(deftest cloud-drivers-are-correct
+  (testing "Cloud drivers set matches expected"
+    (is (= #{:athena :bigquery :databricks :redshift :snowflake}
+           mage.modules/cloud-drivers))))
+
+;;; =============================================================================
+;;; Two roots trigger driver tests: driver and transforms
+;;; =============================================================================
+
+(deftest transforms-triggers-driver-tests
+  (testing "transforms triggers driver tests (it's a root)"
+    (is (true? (mage.modules/driver-deps-affected? ['transforms])))))
+
+(deftest driver-triggers-driver-tests
+  (testing "driver triggers driver tests (it's a root)"
+    (is (true? (mage.modules/driver-deps-affected? ['driver])))))
+
+(deftest all-modules-triggers-themselves-test
+  (let [deps (mage.modules/dependencies)]
+    (doseq [a-module (keys (mage.modules/dependencies))]
+      (is (contains? (mage.modules/affected-modules deps [a-module]) a-module)
+          (str "The " a-module " module should trigger itself")))))
+
+;;; =============================================================================
+;;; Regression test: module graph should not become more connected
+;;; =============================================================================
+
+(defn modules-affecting-drivers []
+  (let [deps (mage.modules/dependencies)
+        all (keys deps)]
+    (filter #(mage.modules/driver-deps-affected? [%]) all)))
+
+(deftest module-graph-may-not-become-more-connected
+  (testing "The number of modules that trigger driver tests should not increase without explicit approval.
+            If this test fails, you've likely connected a module to driver that shouldn't trigger driver tests.
+            Add it to driver-affecting-overrides if it shouldn't trigger driver tests."
+    (let [modules-triggering-drivers (modules-affecting-drivers)
+          ;; This count was 37 as of 2026-02-06. Update this number ONLY if you
+          ;; intentionally want more modules to trigger driver tests.
+          ;; v58 backport: the module graph on release-x.58.x has 153 modules that
+          ;; trigger driver tests (master has 38 due to different driver-affecting-overrides tuning)
+          max-allowed-count 153]
+      (is (<= (count modules-triggering-drivers) max-allowed-count)
+          (format "Too many modules trigger driver tests! Expected <= %d, got %d.
+                   Modules triggering driver tests: %s
+                   If this is intentional, update max-allowed-count.
+                   Otherwise, add the new module(s) to driver-affecting-overrides."
+                  max-allowed-count
+                  (count modules-triggering-drivers)
+                  (pr-str (sort modules-triggering-drivers)))))))
+
+(deftest test-files-mark-modules-changes
+  (testing "if you change a test in a module, that module is affected"
+    ;; note in the future, this won't be all dependent modules see
+    ;; https://linear.app/metabase/issue/DEV-1487/treat-changed-test-namespaces-as-module-only-changes
+    (let [changed-file "enterprise/backend/test/metabase_enterprise/transforms/api_test.clj"]
+      (is (= '#{enterprise/transforms}
+             (mage.modules/updated-files->updated-modules [changed-file])))
+      (is (-> [changed-file]
+              mage.modules/updated-files->updated-modules
+              mage.modules/driver-deps-affected?)))))


### PR DESCRIPTION
## Summary

Squashed backport of the `mage -driver-decisions` system from master (~10 PRs: #65631, #67568, #67769, #68432, #68877, #68037, #69200, #69358, #69448, #69615) to `release-x.58.x`.

**Why**: The release branch currently uses the old all-or-nothing `can-skip-driver-tests` which either runs all driver tests or none. BigQuery tests are manually commented out. There's no quarantine support or per-driver skip logic.

**What this adds**:
- Per-driver run/skip decisions via `mage -driver-decisions`
- Quarantine support via [ci-test-config](https://github.com/metabase/ci-test-config) — quarantined drivers are skipped, with warnings when their files are modified
- Cloud driver rules — athena/bigquery/databricks/redshift/snowflake only run when relevant (master/release branch, file changes, `ci:all-cloud-drivers` label, or cloud-triggering module changes)
- H2/Postgres always-run guarantee
- **Uncomments BigQuery driver tests** (supersedes #69646)

## Changes

| File | What |
|------|------|
| `mage/src/mage/modules.clj` | Full master version: `driver-decision`, `cli-driver-decisions`, quarantine logic, cloud driver rules |
| `mage/test/mage/modules_test.clj` | New test suite (adjusted `max-allowed-count` for v58 module graph: 153 vs master's 38) |
| `.github/workflows/drivers.yml` | Per-driver `if` conditions, quarantine conflict steps, BigQuery uncommented, kept v58's 60min timeouts |
| `bb.edn` | Added `-driver-decisions` task definition |
| `mage/test/mage/core_test.clj` | Added `modules-test` require |

## Test plan

- [x] `./bin/mage -driver-decisions --git-ref=master --is-master-or-release=false --pr-labels= --skip=false` — works, shows per-driver decisions
- [x] `bb -test --focus mage.modules-test` — all 39 tests pass (389 assertions)
- [ ] CI on this PR will exercise the new `determine-driver-skips` job end-to-end