### PR TITLE
Don't call trial check EE endpoint in OSS for Remote Sync upsell

### DIFF
--- a/frontend/src/metabase/data-studio/upsells/components/UpsellCardContent.tsx
+++ b/frontend/src/metabase/data-studio/upsells/components/UpsellCardContent.tsx
@@ -43,7 +43,10 @@ export const UpsellCardContent = ({
   upgradeUrl,
   variant = "image-card",
 }: UpsellCardContentProps) => {
-  const { data: trialData } = useCheckTrialAvailableQuery();
+  const isHosted = useSelector(getIsHosted);
+  const { data: trialData } = useCheckTrialAvailableQuery(undefined, {
+    skip: !isHosted,
+  });
   const isTrialAvailable = trialData?.available ?? false;
 
   const leftSideSize = rem(280);
@@ -121,8 +124,8 @@ type UpsellCardLeftColumnContentProps = {
   title: string;
   description: string;
   bulletPoints?: string[];
-  upgradeOnClick: (() => void) | undefined;
-  upgradeUrl: string | undefined;
+  upgradeOnClick?: () => void;
+  upgradeUrl?: string;
 };
 
 const UpsellCardLeftColumnContent = ({

--- a/frontend/src/metabase/data-studio/upsells/components/UpsellCardContent.unit.spec.tsx
+++ b/frontend/src/metabase/data-studio/upsells/components/UpsellCardContent.unit.spec.tsx
@@ -1,0 +1,65 @@
+import fetchMock from "fetch-mock";
+
+import { setupTrialAvailableEndpoint } from "__support__/server-mocks";
+import { mockSettings } from "__support__/settings";
+import { renderWithProviders, screen } from "__support__/ui";
+import { createMockUser } from "metabase-types/api/mocks";
+import { createMockState } from "metabase-types/store/mocks";
+
+import type { UpsellCardContentProps } from "./UpsellCardContent";
+import { UpsellCardContent } from "./UpsellCardContent";
+
+const defaultProps: UpsellCardContentProps = {
+  campaign: "test-campaign",
+  location: "test-location",
+  title: "Test Title",
+  description: "Test description",
+};
+
+interface SetupOpts {
+  isHosted: boolean;
+}
+
+function setup({ isHosted }: SetupOpts) {
+  setupTrialAvailableEndpoint({
+    available: true,
+    plan_alias: "pro-cloud",
+  });
+
+  renderWithProviders(<UpsellCardContent {...defaultProps} />, {
+    storeInitialState: createMockState({
+      currentUser: createMockUser({ is_superuser: true }),
+      settings: mockSettings({
+        "is-hosted?": isHosted,
+      }),
+    }),
+  });
+}
+
+describe("UpsellCardContent", () => {
+  describe("trial availability check", () => {
+    it("should call trial availability endpoint when isHosted is true", async () => {
+      setup({ isHosted: true });
+
+      await screen.findByText("Test Title");
+
+      expect(
+        fetchMock.callHistory.called(
+          "path:/api/ee/cloud-proxy/mb-plan-trial-up-available",
+        ),
+      ).toBe(true);
+    });
+
+    it("should not call trial availability endpoint when isHosted is false", async () => {
+      setup({ isHosted: false });
+
+      await screen.findByText("Test Title");
+
+      expect(
+        fetchMock.callHistory.called(
+          "path:/api/ee/cloud-proxy/mb-plan-trial-up-available",
+        ),
+      ).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/UXW-3072/remote-sync-upsell-uses-ee-api-in-oss-instance

### How to verify

1. Spin up a OSS instance
2. Go to Data Studio > click "Set up remote sync"
3. No EE endpoint calls resulting in 404 should be observed

### Demo
| Header | Header |
|--------|--------|
| Before | After |
| <img width="2815" height="1423" alt="image" src="https://github.com/user-attachments/assets/6ed56c5f-e8f7-4f4b-b9eb-324d5133a136" /> | <img width="2815" height="1423" alt="image" src="https://github.com/user-attachments/assets/b718394f-f11a-4806-8529-e1c38553965f" /> | 

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
