### PR TITLE
BOT-1054 Add snowplow events for user intent classification

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/llm/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/llm/settings.clj
@@ -93,6 +93,19 @@
                   (validate-metabot-provider! new-value))
                 (setting/set-value-of-type! :string :ee-ai-metabot-provider new-value)))
 
+(defsetting ee-ai-metabot-provider-lite
+  (deferred-tru "The AI provider and model for lightweight Metabot tasks and internal bookkeeping (e.g. user intent classification snowplow metrics).")
+  :type       :string
+  :encryption :no
+  :default    "openrouter/openai/gpt-oss-20b"
+  :visibility :settings-manager
+  :export?    false
+  :doc        false
+  :setter     (fn [new-value]
+                (when new-value
+                  (validate-metabot-provider! new-value))
+                (setting/set-value-of-type! :string :ee-ai-metabot-provider-lite new-value)))
+
 (defsetting ee-ai-features-enabled
   (deferred-tru "Enable AI features.")
   :type       :boolean

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/agent/analytics.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/agent/analytics.clj
@@ -6,6 +6,7 @@
    [metabase-enterprise.metabot-v3.self :as self]
    [metabase.analytics.core :as analytics]
    [metabase.api.common :as api]
+   [metabase.util.json :as json]
    [metabase.util.log :as log]))
 
 (set! *warn-on-reflection* true)
@@ -54,30 +55,15 @@
    {:description "User request doesn't fit standard categories"
     :examples    ["Any other request not covered above."]}})
 
-(def ^:private user-intent-schema
-  {:type       "object"
-   :properties {:intent {:type "string"
-                         :enum (vec (keys user-intents))}}
-   :required             ["intent"]
-   :additionalProperties false})
-
 (defn- render-user-intents-table
   "Render user-intents as a plain-text table."
   []
-  (let [header "Intent | Description | Examples"
-        sep    "-------|-------------|--------"
+  (let [header "| Intent Category | Description | Examples |"
+        sep    "|-----------------|-------------|----------|"
         rows   (map (fn [[intent {:keys [description examples]}]]
-                      (str intent " | " description " | " (str/join "; " examples)))
+                      (str "| " intent " | " description " | " (str/join "; " examples) " |"))
                     user-intents)]
     (str/join "\n" (concat [header sep] rows))))
-
-(defn- extract-conversation-context
-  "Take the last 3 messages and serialize to a plain string."
-  [messages]
-  (->> (take-last 3 messages)
-       (map (fn [{:keys [role content]}]
-              (str (name role) ": " content)))
-       (str/join "\n")))
 
 (defn- build-intent-prompt [conversation-context]
   (str "You are a user intent classification engine for requests to an AI agent operating on top of Metabase.\n"
@@ -87,22 +73,31 @@
        "<conversation_context>\n"
        conversation-context
        "\n</conversation_context>\n\n"
-       "Return a JSON object with a single \"intent\" field containing the category name."))
+       "## Output format\n"
+       "Return the category wrapped in a <category> tag so that we can easily extract it from the string.\n"
+       "Only respond with the <category> tag including the intent category name - nothing else.\n\n"
+       "**Example:**\n"
+       "User: \"I want to see sales by region for Q1.\"\n"
+       "You: \"<category>query_data</category>\"\n\n"
+       "Classify the user's intent into one of the Intent Categories above.\n"))
 
 (defn- classify-user-intent!
   "Classify the user's message into one of the [[user-intent]] categories.
   Returns the intent string.
-  Raises an exception if the classified intent is not in the known intents."
-  [conversation-context]
-  (let [result (self/call-llm-structured
-                (llm/ee-ai-metabot-provider)
-                [{:role "user" :content (build-intent-prompt conversation-context)}]
-                user-intent-schema
-                0.0
-                50
-                {:tag "user-intent-classification"})
-        intent (:intent result)]
-    ;; The LLM's response should conform to the user-intent-schema. It's a bug if this check fails.
+  Raises an exception if the classified intent is not in the known intents.
+  Uses plain-text extraction (no tool calls) so it works with models that don't support function calling."
+  [messages]
+  (let [context (json/encode (take-last 3 messages))
+        text    (transduce (keep (fn [{:keys [type text]}] (when (= type :text) text)))
+                           str
+                           (self/call-llm (llm/ee-ai-metabot-provider-lite)
+                                          nil
+                                          [{:role "user" :content (build-intent-prompt context)}]
+                                          []
+                                          ;; Omit :request-id from tracking-opts to skip snowplow token_usage event
+                                          ;; since this is for internal usage.
+                                          {:tag "user-intent-classification"}))
+        intent  (second (re-find #"<category>([^<]+)</category>" text))]
     (when-not (contains? user-intents intent)
       (throw (ex-info (str "Classified intent '" intent "' not in known intents")
                       {:intent        intent
@@ -129,7 +124,6 @@
   (future
     (try
       (-> messages
-          extract-conversation-context
           classify-user-intent!
           (track-user-intent! tracking-opts))
       (catch Exception e

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/agent/analytics.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/agent/analytics.clj
@@ -1,0 +1,136 @@
+(ns metabase-enterprise.metabot-v3.agent.analytics
+  "Snowplow and Prometheus analytics and intent-classification helpers for the metabot agent."
+  (:require
+   [clojure.string :as str]
+   [metabase-enterprise.llm.settings :as llm]
+   [metabase-enterprise.metabot-v3.self :as self]
+   [metabase.analytics.core :as analytics]
+   [metabase.api.common :as api]
+   [metabase.util.log :as log]))
+
+(set! *warn-on-reflection* true)
+
+;;; User intent classification
+
+(def ^:private user-intents
+  {"create_or_modify_sql_query"
+   {:description "User wants to write new SQL from scratch or edit existing SQL"
+    :examples    ["Write a SQL query to find all orders from last month."
+                  "Edit the query to include customer email addresses (while looking at a SQL query)"]}
+   "fix_broken_sql_query"
+   {:description "User has broken SQL that needs fixing"
+    :examples    ["My SQL query is giving an error, can you fix it?"
+                  "Fix this query."]}
+   "query_data"
+   {:description "User wants to query data to get insights."
+    :examples    ["Show me sales by region for Q1."
+                  "How many users signed up last week?"]}
+   "data_discovery"
+   {:description "User looking for relevant tables/data or existing Metabase dashboards/questions"
+    :examples    ["Which table has customer information?"
+                  "What data can I use to analyze user behavior?"]}
+   "editing_visualizations"
+   {:description "User wants to build or edit visualizations"
+    :examples    ["Create a bar chart for revenue by product."
+                  "Turn this into a bar chart."]}
+   "interpret_results"
+   {:description "User needs help understanding data/charts"
+    :examples    ["What does this chart mean?"
+                  "Explain the results of this query."]}
+   "create_dashboard"
+   {:description "User wants to build dashboard"
+    :examples    ["Build a dashboard for sales KPIs."
+                  "Create a dashboard with multiple visualizations."]}
+   "navigation"
+   {:description "User wants to navigate to a specific Metabase UI location or feature"
+    :examples    ["Take me to the SQL editor."
+                  "Show me the admin settings."]}
+   "metabase_help"
+   {:description "User needs help using Metabase"
+    :examples    ["How do I share a dashboard?"
+                  "Help me set up a new database connection."
+                  "How do I use custom expressions?"]}
+   "other"
+   {:description "User request doesn't fit standard categories"
+    :examples    ["Any other request not covered above."]}})
+
+(def ^:private user-intent-schema
+  {:type       "object"
+   :properties {:intent {:type "string"
+                         :enum (vec (keys user-intents))}}
+   :required             ["intent"]
+   :additionalProperties false})
+
+(defn- render-user-intents-table
+  "Render user-intents as a plain-text table."
+  []
+  (let [header "Intent | Description | Examples"
+        sep    "-------|-------------|--------"
+        rows   (map (fn [[intent {:keys [description examples]}]]
+                      (str intent " | " description " | " (str/join "; " examples)))
+                    user-intents)]
+    (str/join "\n" (concat [header sep] rows))))
+
+(defn- extract-conversation-context
+  "Take the last 3 messages and serialize to a plain string."
+  [messages]
+  (->> (take-last 3 messages)
+       (map (fn [{:keys [role content]}]
+              (str (name role) ": " content)))
+       (str/join "\n")))
+
+(defn- build-intent-prompt [conversation-context]
+  (str "You are a user intent classification engine for requests to an AI agent operating on top of Metabase.\n"
+       "Given a conversation, classify the user's intent into one of the following categories:\n\n"
+       (render-user-intents-table)
+       "\n\nThis is the conversation context:\n"
+       "<conversation_context>\n"
+       conversation-context
+       "\n</conversation_context>\n\n"
+       "Return a JSON object with a single \"intent\" field containing the category name."))
+
+(defn- classify-user-intent!
+  "Classify the user's message into one of the [[user-intent]] categories.
+  Returns the intent string.
+  Raises an exception if the classified intent is not in the known intents."
+  [conversation-context]
+  (let [result (self/call-llm-structured
+                (llm/ee-ai-metabot-provider)
+                [{:role "user" :content (build-intent-prompt conversation-context)}]
+                user-intent-schema
+                0.0
+                50
+                {:tag "user-intent-classification"})
+        intent (:intent result)]
+    ;; The LLM's response should conform to the user-intent-schema. It's a bug if this check fails.
+    (when-not (contains? user-intents intent)
+      (throw (ex-info (str "Classified intent '" intent "' not in known intents")
+                      {:intent        intent
+                       :valid-intents (keys user-intents)})))
+    intent))
+
+(defn- track-user-intent!
+  "Fire user_intent :snowplow/ai_service_event synchronously."
+  [intent tracking-opts]
+  (analytics/track-event!
+   :snowplow/ai_service_event
+   {:hashed-metabase-license-token (analytics/hashed-metabase-token-or-uuid)
+    :request-id                    (analytics/uuid->ai-service-hex-uuid (:request-id tracking-opts))
+    :source                        (:source tracking-opts)
+    :event                         "user_intent"
+    :user-id                       api/*current-user-id*
+    :session-id                    (:session-id tracking-opts)
+    :profile                       (some-> (:profile-name tracking-opts) name)
+    :event-details                 {"intent" intent}}))
+
+(defn classify-and-track-user-intent-async!
+  "Classify and [[track-user-intent!]] in a background future."
+  [messages tracking-opts]
+  (future
+    (try
+      (-> messages
+          extract-conversation-context
+          classify-user-intent!
+          (track-user-intent! tracking-opts))
+      (catch Exception e
+        (log/warn e "Failed to track user intent")))))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/agent/analytics.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/agent/analytics.clj
@@ -115,7 +115,7 @@
     :event                         "user_intent"
     :user-id                       api/*current-user-id*
     :session-id                    (:session-id tracking-opts)
-    :profile                       (some-> (:profile-name tracking-opts) name)
+    :profile                       (some-> (:profile-id tracking-opts) name)
     :event-details                 {"intent" intent}}))
 
 (defn classify-and-track-user-intent-async!

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/agent/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/agent/core.clj
@@ -152,6 +152,14 @@
   "Profile identifier keyword."
   [:enum :embedding_next :internal :transforms_codegen :sql :nlq :document-generate-content])
 
+(mr/def ::tracking-opts
+  "Options for snowplow and prometheus analytics tracking."
+  [:map
+   [:session-id          {:optional true} [:maybe ms/UUIDString]]
+   [:source              {:optional true} [:maybe :string]]
+   [:tag                 {:optional true} [:maybe :string]]
+   [:track-user-intent?  {:optional true} [:maybe :boolean]]])
+
 ;;; Iteration control
 
 (defn- has-tool-calls?
@@ -425,11 +433,7 @@
             [:profile-id ::profile-id]
             [:state {:optional true} [:maybe ::state]]
             [:context {:optional true} [:maybe ::context]]
-            [:tracking-opts {:optional true} [:maybe [:map
-                                                      [:session-id {:optional true} [:maybe ms/UUIDString]]
-                                                      [:source {:optional true} [:maybe :string]]
-                                                      [:tag {:optional true} [:maybe :string]]
-                                                      [:track-user-intent? {:optional true} [:maybe :boolean]]]]]
+            [:tracking-opts {:optional true} [:maybe ::tracking-opts]]
             [:debug? {:optional true} [:maybe :boolean]]]]
   (let [profile-id         (:profile-id opts)
         debug?             (:debug? opts)

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/agent/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/agent/core.clj
@@ -321,10 +321,10 @@
      :tools         tools
      :context       context
      :memory-atom   memory-atom
-     :tracking-opts (merge {:profile-name (:name profile)
-                            :request-id   (str (random-uuid))
-                            :source       "metabot_agent"
-                            :tag          "agent"}
+     :tracking-opts (merge {:profile-id profile-id
+                            :request-id (str (random-uuid))
+                            :source     "metabot_agent"
+                            :tag        "agent"}
                            tracking-opts)}))
 
 (defn- initial-loop-state

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/agent/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/agent/core.clj
@@ -428,12 +428,12 @@
             [:tracking-opts {:optional true} [:maybe [:map
                                                       [:session-id {:optional true} [:maybe ms/UUIDString]]
                                                       [:source {:optional true} [:maybe :string]]
-                                                      [:tag {:optional true} [:maybe :string]]]]]
-            [:track-user-intent? {:optional true} [:maybe :boolean]]
+                                                      [:tag {:optional true} [:maybe :string]]
+                                                      [:track-user-intent? {:optional true} [:maybe :boolean]]]]]
             [:debug? {:optional true} [:maybe :boolean]]]]
   (let [profile-id         (:profile-id opts)
         debug?             (:debug? opts)
-        track-user-intent? (:track-user-intent? opts)
+        track-user-intent? (some-> opts :tracking-opts :track-user-intent?)
         labels             {:profile-id (name profile-id)}]
     (reify clojure.lang.IReduceInit
       (reduce [_ rf init]

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/agent/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/agent/core.clj
@@ -291,7 +291,7 @@
 
 (defn- init-agent
   "Initialize agent state."
-  [{:keys [messages state profile-id context conversation-id tracking-opts]}]
+  [{:keys [messages state profile-id context tracking-opts]}]
   (let [context      (assign-context-ids context)
         profile      (or (profiles/get-profile profile-id)
                          (throw (ex-info "Unknown profile" {:profile-id profile-id})))
@@ -315,7 +315,6 @@
      :memory-atom   memory-atom
      :tracking-opts (merge {:profile-name (:name profile)
                             :request-id   (str (random-uuid))
-                            :session-id   conversation-id
                             :source       "metabot_agent"
                             :tag          "agent"}
                            tracking-opts)}))
@@ -426,8 +425,8 @@
             [:profile-id ::profile-id]
             [:state {:optional true} [:maybe ::state]]
             [:context {:optional true} [:maybe ::context]]
-            [:conversation-id {:optional true} [:maybe ms/UUIDString]]
             [:tracking-opts {:optional true} [:maybe [:map
+                                                      [:session-id {:optional true} [:maybe ms/UUIDString]]
                                                       [:source {:optional true} [:maybe :string]]
                                                       [:tag {:optional true} [:maybe :string]]]]]
             [:track-user-intent? {:optional true} [:maybe :boolean]]

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/agent/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/agent/core.clj
@@ -2,6 +2,7 @@
   "Main agent loop implementation using reducible streaming infrastructure."
   (:require
    [clojure.string :as str]
+   [metabase-enterprise.metabot-v3.agent.analytics :as agent-analytics]
    [metabase-enterprise.metabot-v3.agent.memory :as memory]
    [metabase-enterprise.metabot-v3.agent.messages :as messages]
    [metabase-enterprise.metabot-v3.agent.profiles :as profiles]
@@ -308,13 +309,16 @@
                                 :tools    (count tools)
                                 :max-iter (:max-iterations profile)
                                 :msgs     (count messages)})
-    {:profile         profile
-     :tools           tools
-     :context         context
-     :memory-atom     memory-atom
-     :request-id      (str (random-uuid))
-     :conversation-id conversation-id
-     :tracking-opts   tracking-opts}))
+    {:profile       profile
+     :tools         tools
+     :context       context
+     :memory-atom   memory-atom
+     :tracking-opts (merge {:profile-name (:name profile)
+                            :request-id   (str (random-uuid))
+                            :session-id   conversation-id
+                            :source       "metabot_agent"
+                            :tag          "agent"}
+                           tracking-opts)}))
 
 (defn- initial-loop-state
   "Create initial loop state from agent config and reduction context."
@@ -353,15 +357,9 @@
   [{:keys [agent rf result iteration usage-atom] :as loop-state}]
   (with-span :debug {:name      :metabot-v3.agent/loop-step
                      :iteration iteration}
-    (let [{:keys [profile tools context memory-atom request-id conversation-id tracking-opts]} agent
+    (let [{:keys [profile tools context memory-atom tracking-opts]} agent
           max-iter      (:max-iterations profile 10)
-          tracking-opts (merge {:profile-name (:name profile)
-                                :iteration    iteration
-                                :request-id   request-id
-                                :session-id   conversation-id
-                                :source       "metabot_agent"
-                                :tag          "agent"}
-                               tracking-opts)
+          tracking-opts (assoc tracking-opts :iteration iteration)
           parts-atom    (atom [])
           llm-call      (call-llm @memory-atom context profile tools iteration tracking-opts)
           xf         (comp (accumulate-usage-xf usage-atom)
@@ -432,10 +430,12 @@
             [:tracking-opts {:optional true} [:maybe [:map
                                                       [:source {:optional true} [:maybe :string]]
                                                       [:tag {:optional true} [:maybe :string]]]]]
+            [:track-user-intent? {:optional true} [:maybe :boolean]]
             [:debug? {:optional true} [:maybe :boolean]]]]
-  (let [profile-id (:profile-id opts)
-        debug?     (:debug? opts)
-        labels     {:profile-id (name profile-id)}]
+  (let [profile-id         (:profile-id opts)
+        debug?             (:debug? opts)
+        track-user-intent? (:track-user-intent? opts)
+        labels             {:profile-id (name profile-id)}]
     (reify clojure.lang.IReduceInit
       (reduce [_ rf init]
         (with-span :info {:name       :metabot-v3.agent/run-agent-loop
@@ -445,10 +445,16 @@
           (let [start-ms (u/start-timer)]
             (binding [*debug-log* (when debug? (atom []))]
               (try
-                (let [{:keys [result iteration]} (->> (initial-loop-state (init-agent opts) rf init (atom {}))
-                                                      (iterate loop-step)
-                                                      (drop-while #(= :continue (:status %)))
-                                                      first)]
+                (let [agent              (init-agent opts)
+                      _                  (when track-user-intent?
+                                           (agent-analytics/classify-and-track-user-intent-async!
+                                            (:messages opts)
+                                            (:tracking-opts agent)))
+                      {result    :result
+                       iteration :iteration} (->> (initial-loop-state agent rf init (atom {}))
+                                                  (iterate loop-step)
+                                                  (drop-while #(= :continue (:status %)))
+                                                  first)]
                   (prometheus/observe! :metabase-metabot/agent-iterations labels iteration)
                   ;; Emit debug log as a data part if debug mode was active
                   (if (and debug? (seq @*debug-log*))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api.clj
@@ -174,12 +174,12 @@
           (transduce xf
                      (streaming-writer-rf os canceled-chan)
                      (agent/run-agent-loop
-                      (cond-> {:messages           messages
-                               :state              state
-                               :profile-id         (keyword profile-id)
-                               :context            enriched-context
-                               :tracking-opts      {:session-id conversation-id}
-                               :track-user-intent? true}
+                      (cond-> {:messages      messages
+                               :state         state
+                               :profile-id    (keyword profile-id)
+                               :context       enriched-context
+                               :tracking-opts {:session-id          conversation-id
+                                               :track-user-intent?  true}}
                         debug? (assoc :debug? true))))
           (catch org.eclipse.jetty.io.EofException _
             (log/debug "Client disconnected during native agent streaming"))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api.clj
@@ -178,7 +178,7 @@
                                :state              state
                                :profile-id         (keyword profile-id)
                                :context            enriched-context
-                               :conversation-id    conversation-id
+                               :tracking-opts      {:session-id conversation-id}
                                :track-user-intent? true}
                         debug? (assoc :debug? true))))
           (catch org.eclipse.jetty.io.EofException _

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api.clj
@@ -174,11 +174,12 @@
           (transduce xf
                      (streaming-writer-rf os canceled-chan)
                      (agent/run-agent-loop
-                      (cond-> {:messages         messages
-                               :state            state
-                               :profile-id       (keyword profile-id)
-                               :context          enriched-context
-                               :conversation-id  conversation-id}
+                      (cond-> {:messages           messages
+                               :state              state
+                               :profile-id         (keyword profile-id)
+                               :context            enriched-context
+                               :conversation-id    conversation-id
+                               :track-user-intent? true}
                         debug? (assoc :debug? true))))
           (catch org.eclipse.jetty.io.EofException _
             (log/debug "Client disconnected during native agent streaming"))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/document.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/document.clj
@@ -119,8 +119,8 @@
                          :profile-id         :document-generate-content
                          :state              {}
                          :context            context
-                         :track-user-intent? true
-                         :tracking-opts      {:source "document_generate_content"}}))
+                         :tracking-opts      {:source              "document_generate_content"
+                                              :track-user-intent?  true}}))
         chart-output (latest-chart-structured-output parts)
         draft-card (draft-card-from-chart-output chart-output)
         description (or (:description chart-output)

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/document.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/document.clj
@@ -114,12 +114,13 @@
                  (metabot-v3.context/create-context {:capabilities #{"permission:write_sql_queries"}})
                  :references references)
         parts (into [] (metabot-v3.agent/run-agent-loop
-                        {:messages      [{:role :user
-                                          :content instructions}]
-                         :profile-id    :document-generate-content
-                         :state         {}
-                         :context       context
-                         :tracking-opts {:source "document_generate_content"}}))
+                        {:messages           [{:role :user
+                                               :content instructions}]
+                         :profile-id         :document-generate-content
+                         :state              {}
+                         :context            context
+                         :track-user-intent? true
+                         :tracking-opts      {:source "document_generate_content"}}))
         chart-output (latest-chart-structured-output parts)
         draft-card (draft-card-from-chart-output chart-output)
         description (or (:description chart-output)

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/self.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/self.clj
@@ -127,16 +127,16 @@
   "Transducer that reports token_usage metrics for :usage parts in the aisdk stream.
 
   Prometheus + Snowplow:
-    - `:profile-name` — the profile name (e.g. `:internal`)
-    - `:model`        — the model (e.g. `anthropic/claude-haiku-4-5`)
-    - `:tag`          — the specific purpose for which the tokens were used (e.g. 'agent', 'sql-fixing')
+    - `:profile-id` — the profile id (e.g. `:internal`)
+    - `:model`      — the model (e.g. `anthropic/claude-haiku-4-5`)
+    - `:tag`        — the specific purpose for which the tokens were used (e.g. 'agent', 'sql-fixing')
 
    Snowplow only:
-    - `:request-id`   — UUID string for this request
-    - `:session-id`   — conversation UUID string
-    - `:source`       — the source of the request (e.g., 'metabot_agent', 'document_generate_content').
-                        Indicates which API endpoint or workflow initiated the LLM call."
-  [{:keys [model profile-name request-id session-id source tag]}]
+    - `:request-id` — UUID string for this request
+    - `:session-id` — conversation UUID string
+    - `:source`     — the source of the request (e.g., 'metabot_agent', 'document_generate_content').
+                      Indicates which API endpoint or workflow initiated the LLM call."
+  [{:keys [model profile-id request-id session-id source tag]}]
   (let [start-ms      (u/start-timer)]
     (map (fn [part]
            (when (= (:type part) :usage)
@@ -148,7 +148,7 @@
                 ;; The caller can omit request-id (and other snowplow opts) to skip snowplow tracking.
                 {:prometheus          true
                  :snowplow            (some? request-id)
-                 :profile             (some-> profile-name name)
+                 :profile             (some-> profile-id name)
                  :model-id            model
                  :prompt-tokens       prompt
                  :completion-tokens   completion
@@ -165,7 +165,7 @@
 (defn- report-tool-usage-xf
   "Transducer that fires an agent_used_tool :snowplow/ai_service_event per tool call.
   Only fires when :source and :request-id are present in tracking-opts."
-  [{:keys [request-id session-id source profile-name iteration]}]
+  [{:keys [request-id session-id source profile-id iteration]}]
   (map (fn [part]
          (when (and (some? source)
                     (some? request-id)
@@ -177,7 +177,7 @@
                                     :event                         "agent_used_tool"
                                     :user-id                       api/*current-user-id*
                                     :session-id                    session-id
-                                    :profile                       (some-> profile-name name)
+                                    :profile                       (some-> profile-id name)
                                     :duration-ms                   (some-> (:duration-ms part) long)
                                     :result                        (if (:error part) "error" "success")
                                     :event-details                 (cond-> {"tool_name" (:function part)}

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/agent/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/agent/core_test.clj
@@ -665,8 +665,8 @@
                              :state               {}
                              :context             {}
                              :profile-id          :internal
-                             :tracking-opts       {:session-id "00000000-0000-0000-0000-000000000002"}
-                             :track-user-intent?  true}))
+                             :tracking-opts       {:session-id          "00000000-0000-0000-0000-000000000002"
+                                                   :track-user-intent?  true}}))
             (tu/poll-until 5000
                            (some #(= "user_intent" (get-in % [:properties "data" "data" "event"]))
                                  @snowplow-test/*snowplow-collector*))
@@ -706,7 +706,7 @@
                          :state               {}
                          :context             {}
                          :profile-id          :internal
-                         :tracking-opts       {:session-id "00000000-0000-0000-0000-000000000004"}
-                         :track-user-intent?  true}))
+                         :tracking-opts       {:session-id          "00000000-0000-0000-0000-000000000004"
+                                               :track-user-intent?  true}}))
         (tu/poll-until 5000 @classify-called)
         (is (true? @classify-called))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/agent/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/agent/core_test.clj
@@ -27,6 +27,11 @@
 (def test-tools
   {"search" #'test-search-tool})
 
+(defn- run-agent-loop!
+  "run-agent-loop for side effects, discarding results"
+  [opts]
+  (reduce (fn [_ _]) nil (agent/run-agent-loop opts)))
+
 (deftest has-tool-calls-test
   (testing "detects tool calls in parts"
     (is (#'agent/has-tool-calls? [{:type :tool-input :id "t1"}]))
@@ -453,11 +458,10 @@
                             (mut/mock-llm-response
                              [{:type :text :text "Done"}]))))]
           (mt/with-log-level [metabase-enterprise.metabot-v3.agent.core :warn]
-            (run! identity (agent/run-agent-loop
-                            {:messages   [{:role :user :content "test"}]
-                             :state      {}
-                             :profile-id :internal
-                             :context    {}})))))
+            (run-agent-loop! {:messages   [{:role :user :content "test"}]
+                              :state      {}
+                              :profile-id :internal
+                              :context    {}}))))
       (is (== 1 (mt/metric-value system :metabase-metabot/agent-requests
                                  {:profile-id "internal"})))
       (is (== 2 (:sum (mt/metric-value system :metabase-metabot/agent-iterations
@@ -482,11 +486,10 @@
     (testing "records agent-errors on failure"
       (with-redefs [openrouter/openrouter (fn [_] (throw (ex-info "boom" {})))]
         (mt/with-log-level [metabase-enterprise.metabot-v3.agent.core :fatal]
-          (run! identity (agent/run-agent-loop
-                          {:messages   [{:role :user :content "test"}]
-                           :state      {}
-                           :profile-id :internal
-                           :context    {}}))))
+          (run-agent-loop! {:messages   [{:role :user :content "test"}]
+                            :state      {}
+                            :profile-id :internal
+                            :context    {}})))
       (is (== 1 (mt/metric-value system :metabase-metabot/agent-requests
                                  {:profile-id "internal"})))
       (is (== 0 (:sum (mt/metric-value system :metabase-metabot/agent-iterations
@@ -531,12 +534,11 @@
         (mt/with-log-level [metabase-enterprise.metabot-v3.agent.core :warn]
           (mt/with-current-user rasta-id
             (snowplow-test/with-fake-snowplow-collector
-              (run! identity (agent/run-agent-loop
-                              {:messages        [{:role :user :content "test"}]
-                               :state           {}
-                               :context         {}
-                               :profile-id      :internal
-                               :tracking-opts   {:session-id "00000000-0000-0000-0000-000000000001"}}))
+              (run-agent-loop! {:messages        [{:role :user :content "test"}]
+                                :state           {}
+                                :context         {}
+                                :profile-id      :internal
+                                :tracking-opts   {:session-id "00000000-0000-0000-0000-000000000001"}})
               ;; The collector also contains token_usage events; filter for just ai_service_events.
               (let [events (snowplow-test/pop-event-data-and-user-id!)
                     tool-events (filter #(= "agent_used_tool" (get-in % [:data "event"])) events)]
@@ -576,12 +578,11 @@
         (mt/with-log-level [metabase-enterprise.metabot-v3.agent.core :warn]
           (mt/with-current-user rasta-id
             (snowplow-test/with-fake-snowplow-collector
-              (run! identity (agent/run-agent-loop
-                              {:messages        [{:role :user :content "test"}]
-                               :state           {}
-                               :context         {}
-                               :profile-id      :internal
-                               :tracking-opts   {:session-id "00000000-0000-0000-0000-000000000002"}}))
+              (run-agent-loop! {:messages        [{:role :user :content "test"}]
+                                :state           {}
+                                :context         {}
+                                :profile-id      :internal
+                                :tracking-opts   {:session-id "00000000-0000-0000-0000-000000000002"}})
               (let [events (snowplow-test/pop-event-data-and-user-id!)
                     tool-events (filter #(= "agent_used_tool" (get-in % [:data "event"])) events)]
                 (is (=? [{:data {"event"  "agent_used_tool"
@@ -612,12 +613,11 @@
         (mt/with-log-level [metabase-enterprise.metabot-v3.agent.core :warn]
           (mt/with-current-user rasta-id
             (snowplow-test/with-fake-snowplow-collector
-              (run! identity (agent/run-agent-loop
-                              {:messages        [{:role :user :content "test"}]
-                               :state           {}
-                               :context         {}
-                               :profile-id      :internal
-                               :tracking-opts   {:session-id "00000000-0000-0000-0000-000000000001"}}))
+              (run-agent-loop! {:messages        [{:role :user :content "test"}]
+                                :state           {}
+                                :context         {}
+                                :profile-id      :internal
+                                :tracking-opts   {:session-id "00000000-0000-0000-0000-000000000001"}})
               ;; Filter for just token_usage events (other events may also be present)
               (let [events      (snowplow-test/pop-event-data-and-user-id!)
                     token-events (filter #(contains? (:data %) "total_tokens") events)]
@@ -660,13 +660,12 @@
                     self/call-llm       (fn [& _] [{:type :text :text "<category>query_data</category>"}])]
         (mt/with-current-user rasta-id
           (snowplow-test/with-fake-snowplow-collector
-            (run! identity (agent/run-agent-loop
-                            {:messages            [{:role :user :content "Show sales by region"}]
-                             :state               {}
-                             :context             {}
-                             :profile-id          :internal
-                             :tracking-opts       {:session-id          "00000000-0000-0000-0000-000000000002"
-                                                   :track-user-intent?  true}}))
+            (run-agent-loop! {:messages            [{:role :user :content "Show sales by region"}]
+                              :state               {}
+                              :context             {}
+                              :profile-id          :internal
+                              :tracking-opts       {:session-id          "00000000-0000-0000-0000-000000000002"
+                                                    :track-user-intent?  true}})
             (tu/poll-until 5000
                            (some #(= "user_intent" (get-in % [:properties "data" "data" "event"]))
                                  @snowplow-test/*snowplow-collector*))
@@ -685,12 +684,11 @@
     (let [classify-called (atom false)]
       (with-redefs [openrouter/openrouter                                   (fn [_] (mut/mock-llm-response mock-llm-response-for-intent))
                     agent-analytics/classify-and-track-user-intent-async! (fn [_ _] (reset! classify-called true))]
-        (run! identity (agent/run-agent-loop
-                        {:messages        [{:role :user :content "test"}]
-                         :state           {}
-                         :context         {}
-                         :profile-id      :internal
-                         :tracking-opts   {:session-id "00000000-0000-0000-0000-000000000003"}}))
+        (run-agent-loop! {:messages        [{:role :user :content "test"}]
+                          :state           {}
+                          :context         {}
+                          :profile-id      :internal
+                          :tracking-opts   {:session-id "00000000-0000-0000-0000-000000000003"}})
         (is (false? @classify-called))))))
 
 (deftest user-intent-classifier-exception-swallowed-test
@@ -701,12 +699,11 @@
                                           (reset! classify-called true)
                                           (throw (ex-info "LLM error" {})))]
         ;; Should not throw — exception is caught inside the background future
-        (run! identity (agent/run-agent-loop
-                        {:messages            [{:role :user :content "test"}]
-                         :state               {}
-                         :context             {}
-                         :profile-id          :internal
-                         :tracking-opts       {:session-id          "00000000-0000-0000-0000-000000000004"
-                                               :track-user-intent?  true}}))
+        (run-agent-loop! {:messages            [{:role :user :content "test"}]
+                          :state               {}
+                          :context             {}
+                          :profile-id          :internal
+                          :tracking-opts       {:session-id          "00000000-0000-0000-0000-000000000004"
+                                                :track-user-intent?  true}})
         (tu/poll-until 5000 @classify-called)
         (is (true? @classify-called))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/agent/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/agent/core_test.clj
@@ -656,8 +656,8 @@
 (deftest user-intent-snowplow-fires-event-test
   (testing "fires :snowplow/ai_service_event 'user_intent' when :track-user-intent? is true"
     (let [rasta-id (mt/user->id :rasta)]
-      (with-redefs [openrouter/openrouter    (fn [_] (mut/mock-llm-response mock-llm-response-for-intent))
-                    self/call-llm-structured (fn [& _] {:intent "query_data"})]
+      (with-redefs [openrouter/openrouter (fn [_] (mut/mock-llm-response mock-llm-response-for-intent))
+                    self/call-llm       (fn [& _] [{:type :text :text "<category>query_data</category>"}])]
         (mt/with-current-user rasta-id
           (snowplow-test/with-fake-snowplow-collector
             (run! identity (agent/run-agent-loop
@@ -696,10 +696,10 @@
 (deftest user-intent-classifier-exception-swallowed-test
   (testing "does not propagate exception if classify-user-intent throws"
     (let [classify-called (atom false)]
-      (with-redefs [openrouter/openrouter    (fn [_] (mut/mock-llm-response mock-llm-response-for-intent))
-                    self/call-llm-structured (fn [& _]
-                                               (reset! classify-called true)
-                                               (throw (ex-info "LLM error" {})))]
+      (with-redefs [openrouter/openrouter (fn [_] (mut/mock-llm-response mock-llm-response-for-intent))
+                    self/call-llm       (fn [& _]
+                                          (reset! classify-called true)
+                                          (throw (ex-info "LLM error" {})))]
         ;; Should not throw — exception is caught inside the background future
         (run! identity (agent/run-agent-loop
                         {:messages            [{:role :user :content "test"}]

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/agent/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/agent/core_test.clj
@@ -536,7 +536,7 @@
                                :state           {}
                                :context         {}
                                :profile-id      :internal
-                               :conversation-id "00000000-0000-0000-0000-000000000001"}))
+                               :tracking-opts   {:session-id "00000000-0000-0000-0000-000000000001"}}))
               ;; The collector also contains token_usage events; filter for just ai_service_events.
               (let [events (snowplow-test/pop-event-data-and-user-id!)
                     tool-events (filter #(= "agent_used_tool" (get-in % [:data "event"])) events)]
@@ -581,7 +581,7 @@
                                :state           {}
                                :context         {}
                                :profile-id      :internal
-                               :conversation-id "00000000-0000-0000-0000-000000000002"}))
+                               :tracking-opts   {:session-id "00000000-0000-0000-0000-000000000002"}}))
               (let [events (snowplow-test/pop-event-data-and-user-id!)
                     tool-events (filter #(= "agent_used_tool" (get-in % [:data "event"])) events)]
                 (is (=? [{:data {"event"  "agent_used_tool"
@@ -617,7 +617,7 @@
                                :state           {}
                                :context         {}
                                :profile-id      :internal
-                               :conversation-id "00000000-0000-0000-0000-000000000001"}))
+                               :tracking-opts   {:session-id "00000000-0000-0000-0000-000000000001"}}))
               ;; Filter for just token_usage events (other events may also be present)
               (let [events      (snowplow-test/pop-event-data-and-user-id!)
                     token-events (filter #(contains? (:data %) "total_tokens") events)]
@@ -665,7 +665,7 @@
                              :state               {}
                              :context             {}
                              :profile-id          :internal
-                             :conversation-id     "00000000-0000-0000-0000-000000000002"
+                             :tracking-opts       {:session-id "00000000-0000-0000-0000-000000000002"}
                              :track-user-intent?  true}))
             (tu/poll-until 5000
                            (some #(= "user_intent" (get-in % [:properties "data" "data" "event"]))
@@ -690,7 +690,7 @@
                          :state           {}
                          :context         {}
                          :profile-id      :internal
-                         :conversation-id "00000000-0000-0000-0000-000000000003"}))
+                         :tracking-opts   {:session-id "00000000-0000-0000-0000-000000000003"}}))
         (is (false? @classify-called))))))
 
 (deftest user-intent-classifier-exception-swallowed-test
@@ -706,7 +706,7 @@
                          :state               {}
                          :context             {}
                          :profile-id          :internal
-                         :conversation-id     "00000000-0000-0000-0000-000000000004"
+                         :tracking-opts       {:session-id "00000000-0000-0000-0000-000000000004"}
                          :track-user-intent?  true}))
         (tu/poll-until 5000 @classify-called)
         (is (true? @classify-called))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/agent/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/agent/core_test.clj
@@ -1,6 +1,7 @@
 (ns metabase-enterprise.metabot-v3.agent.core-test
   (:require
    [clojure.test :refer :all]
+   [metabase-enterprise.metabot-v3.agent.analytics :as agent-analytics]
    [metabase-enterprise.metabot-v3.agent.core :as agent]
    [metabase-enterprise.metabot-v3.agent.memory :as memory]
    [metabase-enterprise.metabot-v3.api :as api]
@@ -11,6 +12,7 @@
    [metabase.analytics.prometheus :as prometheus]
    [metabase.analytics.snowplow-test :as snowplow-test]
    [metabase.test :as mt]
+   [metabase.test.util :as tu]
    [metabase.util.malli :as mu]))
 
 (set! *warn-on-reflection* true)
@@ -451,11 +453,11 @@
                             (mut/mock-llm-response
                              [{:type :text :text "Done"}]))))]
           (mt/with-log-level [metabase-enterprise.metabot-v3.agent.core :warn]
-            (into [] (agent/run-agent-loop
-                      {:messages   [{:role :user :content "test"}]
-                       :state      {}
-                       :profile-id :internal
-                       :context    {}})))))
+            (run! identity (agent/run-agent-loop
+                            {:messages   [{:role :user :content "test"}]
+                             :state      {}
+                             :profile-id :internal
+                             :context    {}})))))
       (is (== 1 (mt/metric-value system :metabase-metabot/agent-requests
                                  {:profile-id "internal"})))
       (is (== 2 (:sum (mt/metric-value system :metabase-metabot/agent-iterations
@@ -480,11 +482,11 @@
     (testing "records agent-errors on failure"
       (with-redefs [openrouter/openrouter (fn [_] (throw (ex-info "boom" {})))]
         (mt/with-log-level [metabase-enterprise.metabot-v3.agent.core :fatal]
-          (into [] (agent/run-agent-loop
-                    {:messages   [{:role :user :content "test"}]
-                     :state      {}
-                     :profile-id :internal
-                     :context    {}}))))
+          (run! identity (agent/run-agent-loop
+                          {:messages   [{:role :user :content "test"}]
+                           :state      {}
+                           :profile-id :internal
+                           :context    {}}))))
       (is (== 1 (mt/metric-value system :metabase-metabot/agent-requests
                                  {:profile-id "internal"})))
       (is (== 0 (:sum (mt/metric-value system :metabase-metabot/agent-iterations
@@ -529,12 +531,12 @@
         (mt/with-log-level [metabase-enterprise.metabot-v3.agent.core :warn]
           (mt/with-current-user rasta-id
             (snowplow-test/with-fake-snowplow-collector
-              (into [] (agent/run-agent-loop
-                        {:messages        [{:role :user :content "test"}]
-                         :state           {}
-                         :context         {}
-                         :profile-id      :internal
-                         :conversation-id "00000000-0000-0000-0000-000000000001"}))
+              (run! identity (agent/run-agent-loop
+                              {:messages        [{:role :user :content "test"}]
+                               :state           {}
+                               :context         {}
+                               :profile-id      :internal
+                               :conversation-id "00000000-0000-0000-0000-000000000001"}))
               ;; The collector also contains token_usage events; filter for just ai_service_events.
               (let [events (snowplow-test/pop-event-data-and-user-id!)
                     tool-events (filter #(= "agent_used_tool" (get-in % [:data "event"])) events)]
@@ -574,12 +576,12 @@
         (mt/with-log-level [metabase-enterprise.metabot-v3.agent.core :warn]
           (mt/with-current-user rasta-id
             (snowplow-test/with-fake-snowplow-collector
-              (into [] (agent/run-agent-loop
-                        {:messages        [{:role :user :content "test"}]
-                         :state           {}
-                         :context         {}
-                         :profile-id      :internal
-                         :conversation-id "00000000-0000-0000-0000-000000000002"}))
+              (run! identity (agent/run-agent-loop
+                              {:messages        [{:role :user :content "test"}]
+                               :state           {}
+                               :context         {}
+                               :profile-id      :internal
+                               :conversation-id "00000000-0000-0000-0000-000000000002"}))
               (let [events (snowplow-test/pop-event-data-and-user-id!)
                     tool-events (filter #(= "agent_used_tool" (get-in % [:data "event"])) events)]
                 (is (=? [{:data {"event"  "agent_used_tool"
@@ -610,12 +612,12 @@
         (mt/with-log-level [metabase-enterprise.metabot-v3.agent.core :warn]
           (mt/with-current-user rasta-id
             (snowplow-test/with-fake-snowplow-collector
-              (into [] (agent/run-agent-loop
-                        {:messages        [{:role :user :content "test"}]
-                         :state           {}
-                         :context         {}
-                         :profile-id      :internal
-                         :conversation-id "00000000-0000-0000-0000-000000000001"}))
+              (run! identity (agent/run-agent-loop
+                              {:messages        [{:role :user :content "test"}]
+                               :state           {}
+                               :context         {}
+                               :profile-id      :internal
+                               :conversation-id "00000000-0000-0000-0000-000000000001"}))
               ;; Filter for just token_usage events (other events may also be present)
               (let [events      (snowplow-test/pop-event-data-and-user-id!)
                     token-events (filter #(contains? (:data %) "total_tokens") events)]
@@ -642,3 +644,69 @@
                                     "tag"                  "agent"
                                     "session_id"           "00000000-0000-0000-0000-000000000001"}}]
                         token-events))))))))))
+
+;;; ===================== User Intent Classification Tests =====================
+
+(def ^:private mock-llm-response-for-intent
+  [{:type :start :id "msg-1"}
+   {:type :text :text "Done"}
+   {:type :usage :usage {:promptTokens 10 :completionTokens 5}
+    :model "test-model" :id "msg-1"}])
+
+(deftest user-intent-snowplow-fires-event-test
+  (testing "fires :snowplow/ai_service_event 'user_intent' when :track-user-intent? is true"
+    (let [rasta-id (mt/user->id :rasta)]
+      (with-redefs [openrouter/openrouter    (fn [_] (mut/mock-llm-response mock-llm-response-for-intent))
+                    self/call-llm-structured (fn [& _] {:intent "query_data"})]
+        (mt/with-current-user rasta-id
+          (snowplow-test/with-fake-snowplow-collector
+            (run! identity (agent/run-agent-loop
+                            {:messages            [{:role :user :content "Show sales by region"}]
+                             :state               {}
+                             :context             {}
+                             :profile-id          :internal
+                             :conversation-id     "00000000-0000-0000-0000-000000000002"
+                             :track-user-intent?  true}))
+            (tu/poll-until 5000
+                           (some #(= "user_intent" (get-in % [:properties "data" "data" "event"]))
+                                 @snowplow-test/*snowplow-collector*))
+            (let [events        (snowplow-test/pop-event-data-and-user-id!)
+                  intent-events (filter #(= "user_intent" (get-in % [:data "event"])) events)]
+              (is (=? [{:user-id (str rasta-id)
+                        :data    {"event"         "user_intent"
+                                  "source"        "metabot_agent"
+                                  "profile"       "internal"
+                                  "session_id"    "00000000-0000-0000-0000-000000000002"
+                                  "event_details" {"intent" "query_data"}}}]
+                      intent-events)))))))))
+
+(deftest user-intent-not-tracked-when-disabled-test
+  (testing "does not fire user_intent event when :track-user-intent? is false"
+    (let [classify-called (atom false)]
+      (with-redefs [openrouter/openrouter                                   (fn [_] (mut/mock-llm-response mock-llm-response-for-intent))
+                    agent-analytics/classify-and-track-user-intent-async! (fn [_ _] (reset! classify-called true))]
+        (run! identity (agent/run-agent-loop
+                        {:messages        [{:role :user :content "test"}]
+                         :state           {}
+                         :context         {}
+                         :profile-id      :internal
+                         :conversation-id "00000000-0000-0000-0000-000000000003"}))
+        (is (false? @classify-called))))))
+
+(deftest user-intent-classifier-exception-swallowed-test
+  (testing "does not propagate exception if classify-user-intent throws"
+    (let [classify-called (atom false)]
+      (with-redefs [openrouter/openrouter    (fn [_] (mut/mock-llm-response mock-llm-response-for-intent))
+                    self/call-llm-structured (fn [& _]
+                                               (reset! classify-called true)
+                                               (throw (ex-info "LLM error" {})))]
+        ;; Should not throw — exception is caught inside the background future
+        (run! identity (agent/run-agent-loop
+                        {:messages            [{:role :user :content "test"}]
+                         :state               {}
+                         :context             {}
+                         :profile-id          :internal
+                         :conversation-id     "00000000-0000-0000-0000-000000000004"
+                         :track-user-intent?  true}))
+        (tu/poll-until 5000 @classify-called)
+        (is (true? @classify-called))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/agent/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/agent/core_test.clj
@@ -619,7 +619,7 @@
                                 :profile-id      :internal
                                 :tracking-opts   {:session-id "00000000-0000-0000-0000-000000000001"}})
               ;; Filter for just token_usage events (other events may also be present)
-              (let [events      (snowplow-test/pop-event-data-and-user-id!)
+              (let [events       (snowplow-test/pop-event-data-and-user-id!)
                     token-events (filter #(contains? (:data %) "total_tokens") events)]
                 (is (=? [{:user-id (str rasta-id)
                           :data    {"model_id"            "test-model"
@@ -657,7 +657,7 @@
   (testing "fires :snowplow/ai_service_event 'user_intent' when :track-user-intent? is true"
     (let [rasta-id (mt/user->id :rasta)]
       (with-redefs [openrouter/openrouter (fn [_] (mut/mock-llm-response mock-llm-response-for-intent))
-                    self/call-llm       (fn [& _] [{:type :text :text "<category>query_data</category>"}])]
+                    self/call-llm         (fn [& _] [{:type :text :text "<category>query_data</category>"}])]
         (mt/with-current-user rasta-id
           (snowplow-test/with-fake-snowplow-collector
             (run-agent-loop! {:messages            [{:role :user :content "Show sales by region"}]
@@ -682,8 +682,11 @@
 (deftest user-intent-not-tracked-when-disabled-test
   (testing "does not fire user_intent event when :track-user-intent? is false"
     (let [classify-called (atom false)]
-      (with-redefs [openrouter/openrouter                                   (fn [_] (mut/mock-llm-response mock-llm-response-for-intent))
-                    agent-analytics/classify-and-track-user-intent-async! (fn [_ _] (reset! classify-called true))]
+      (with-redefs [openrouter/openrouter
+                    (fn [_] (mut/mock-llm-response mock-llm-response-for-intent))
+
+                    agent-analytics/classify-and-track-user-intent-async!
+                    (fn [_ _] (reset! classify-called true))]
         (run-agent-loop! {:messages        [{:role :user :content "test"}]
                           :state           {}
                           :context         {}
@@ -695,9 +698,9 @@
   (testing "does not propagate exception if classify-user-intent throws"
     (let [classify-called (atom false)]
       (with-redefs [openrouter/openrouter (fn [_] (mut/mock-llm-response mock-llm-response-for-intent))
-                    self/call-llm       (fn [& _]
-                                          (reset! classify-called true)
-                                          (throw (ex-info "LLM error" {})))]
+                    self/call-llm         (fn [& _]
+                                            (reset! classify-called true)
+                                            (throw (ex-info "LLM error" {})))]
         ;; Should not throw — exception is caught inside the background future
         (run-agent-loop! {:messages            [{:role :user :content "test"}]
                           :state               {}


### PR DESCRIPTION
Closes [BOT-1054: Add snowplow events for user intent classification](https://linear.app/metabase/issue/BOT-1054/add-snowplow-events-for-user-intent-classification)

 ### Description

  Add snowplow events for user intent classification. This is a port of the `user_intent` events from ai-service to the native Clojure agent.

  * Create new `metabase-enterprise.metabot-v3.agent.analytics` namespace containing:
    - User intent categories (matching ai-service definitions) 
    - `classify-user-intent!` and `classify-and-track-user-intent-async!`
  * Add `track-user-intent?` flag to `run-agent-loop` (via `:tracking-opts`)
  * call `classify-and-track-user-intent-async!` from `run-agent-loop` when `track-user-intent?` is true
  * push `run-agent-loop`'s `:conversation-id` down into `:tracking-opts`
  * cleanup and simplify initialization of `:tracking-opts`
  * Add `ee-ai-metabot-provider-lite` in `metabase-enterprise.llm.settings`
    - allows using a lighter-weight model for classification tasks (defaults to `openrouter/openai/gpt-oss-20b`, matching ai-service)


### How to verify

* start up snowplow micro container: cd snowplow & docker compose up
* start up metabase & use metabot
* visit snowplow micro ui at http://localhost:9090/micro/ui/ and verify you get a valid user_intent ai_service_event for each metabot request

### Demo

![user-intent-query-data](https://github.com/user-attachments/assets/2b7eb78a-75a6-4ed6-8d9e-15cedcb36aba)
![user-intent-create-sql-query](https://github.com/user-attachments/assets/43c21ed8-4ea0-42a2-ad47-6f3348dd158b)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
