### PR TITLE
Stop releasing older major versions as latest

### DIFF
--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -375,13 +375,6 @@ jobs:
           echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_RELEASE_TOKEN }} > .npmrc
           npm publish --tag 58-stable
 
-      # ⚠️ This step should only be executed on the latest stable (gold) release branch.
-      # Only uncomment this when the new release branch becomes stable (gold).
-      - name: Add `latest` tag to the latest release branch deployment
-        working-directory: sdk
-        run: |
-          npm dist-tag add @metabase/embedding-sdk-react@${{ env.sdk_version }} latest
-
   git-tag:
     needs: [publish-npm, determine-sdk-version]
     runs-on: ubuntu-22.04


### PR DESCRIPTION
[According to this comment](https://www.notion.so/Embedding-Checklist-What-to-do-after-cutting-a-new-release-branch-20269354c90180808329eab86e59f20d?d=2e169354c9018001b707001c4c5f4e5e&source=copy_link#2aa69354c90180d3be5ff48fbd444604)

After turning gold, we make the latest gold release branch tag as `latest` on npm, we also need to stop the previous release branch from doing so.
