### PR TITLE
feat(bigquery): add maximum-bytes-billed connection setting

### DIFF
--- a/docs/databases/connections/bigquery.md
+++ b/docs/databases/connections/bigquery.md
@@ -95,6 +95,20 @@ We suggest you leave this off unless you're doing manual [timezone](../../config
 
 This can be useful for [auditing](../../usage-and-performance-tools/usage-analytics.md) and debugging, but prevents BigQuery from caching results and may increase your costs.
 
+### Maximum bytes billed per query
+
+Set an upper limit on the number of bytes a single query can scan. If a query exceeds this limit, BigQuery will reject it before it runs, preventing accidental full-table scans on large tables from causing unexpected costs.
+
+The value is specified in **bytes**. For example:
+
+| Limit | Bytes                |
+|-------|----------------------|
+| 1 GB  | `1073741824`         |
+| 10 GB | `10737418240`        |
+| 1 TB  | `1099511627776`      |
+
+Leave blank for no limit (the default).
+
 ### Alternate hostname
 
 If you want to use a different hostname to connect to BigQuery. Format: `https://<hostname>:<port>`. If you're using a proxy service to connect to BigQuery (e.g. a privacy proxy that anonymizes PII), you should configure this field to the proxy hostname or IP. Remember to set the complete URI with protocol and port number.

--- a/modules/drivers/bigquery-cloud-sdk/resources/metabase/bigquery-cloud-sdk/metabase-plugin.yaml
+++ b/modules/drivers/bigquery-cloud-sdk/resources/metabase/bigquery-cloud-sdk/metabase-plugin.yaml
@@ -36,6 +36,14 @@ driver:
       type: boolean
       visible-if:
         advanced-options: true
+    - name: maximum-bytes-billed
+      display-name: Maximum bytes billed per query
+      helper-text: "Reject queries that would scan more than this many bytes (e.g. 1099511627776 for 1 TB). Queries exceeding the limit will fail before running, preventing unexpected costs. Leave blank for no limit."
+      required: false
+      type: integer
+      placeholder: "1099511627776"
+      visible-if:
+        advanced-options: true
     - name: host
       display-name: Alternate hostname
       helper-text: Alternate hostname used to connect to BigQuery

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -645,17 +645,27 @@
     (driver-api/system-timezone-id)
     "UTC"))
 
-(defn- build-bigquery-request [^String sql parameters]
-  (.build
-   (doto (QueryJobConfiguration/newBuilder sql)
-      ;; if the query contains a `#legacySQL` directive then use legacy SQL instead of standard SQL
-     (.setUseLegacySql (str/includes? (u/lower-case-en sql) "#legacysql"))
-     (bigquery.params/set-parameters! parameters)
-      ;; .setMaxResults is very misleading; it's actually the page size, and it only takes
-      ;; effect for RPC (a.k.a. "fast") calls
-      ;; there is no equivalent of .setMaxRows on a JDBC Statement; we rely on our middleware to stop
-      ;; realizing more rows as per the maximum result size
-     (.setMaxResults *page-size*))))
+(defn- build-bigquery-request [^String sql parameters database-details]
+  (let [builder (doto (QueryJobConfiguration/newBuilder sql)
+                    ;; if the query contains a `#legacySQL` directive then use legacy SQL instead of standard SQL
+                  (.setUseLegacySql (str/includes? (u/lower-case-en sql) "#legacysql"))
+                  (bigquery.params/set-parameters! parameters)
+                    ;; .setMaxResults is very misleading; it's actually the page size, and it only takes
+                    ;; effect for RPC (a.k.a. "fast") calls
+                    ;; there is no equivalent of .setMaxRows on a JDBC Statement; we rely on our middleware to stop
+                    ;; realizing more rows as per the maximum result size
+                  (.setMaxResults *page-size*))]
+    (when-let [max-bytes (let [v (:maximum-bytes-billed database-details)]
+                           (cond
+                             (integer? v) v
+                             (string? v)  (when-let [s (not-empty v)]
+                                            (try
+                                              (Long/parseLong s)
+                                              (catch NumberFormatException _
+                                                (log/warnf "Ignoring non-numeric :maximum-bytes-billed value %s" (pr-str s))
+                                                nil)))))]
+      (.setMaximumBytesBilled builder max-bytes))
+    (.build builder)))
 
 (defn- reducible-bigquery-results
   [^TableResult page cancel-chan attempt-job-cancel-fn]
@@ -738,7 +748,7 @@
   ;; - Running the BigQuery execution in another thread, since it's blocking.
   (let [^BigQuery client (database-details->client database-details)
         result-promise   (promise)
-        request          (build-bigquery-request sql parameters)
+        request          (build-bigquery-request sql parameters database-details)
         _                (driver.conn/track-connection-acquisition! database-details)
         job              (.create client (JobInfo/of request) (u/varargs BigQuery$JobOption))
         job-id           (.getJobId job)

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -31,7 +31,7 @@
    [metabase.warehouse-schema.models.field-values :as field-values]
    [toucan2.core :as t2])
   (:import
-   (com.google.cloud.bigquery BigQuery TableResult)
+   (com.google.cloud.bigquery BigQuery QueryJobConfiguration TableResult)
    (com.google.cloud.http HttpTransportOptions)))
 
 (set! *warn-on-reflection* true)
@@ -990,6 +990,43 @@
               (is (= "Query cancelled" (.getMessage e)))
               ;; make sure that the fake exception was thrown
               (is (true? @fake-execute-called)))))))))
+
+(deftest ^:parallel build-bigquery-request-maximum-bytes-billed-test
+  (let [build-fn @#'bigquery/build-bigquery-request]
+    (testing "maximum-bytes-billed is set when present in database details"
+      (let [^QueryJobConfiguration request (build-fn "SELECT 1" [] {:maximum-bytes-billed "1099511627776"})]
+        (is (= (Long/valueOf 1099511627776) (.getMaximumBytesBilled request)))))
+    (testing "maximum-bytes-billed is not set when absent from database details"
+      (let [^QueryJobConfiguration request (build-fn "SELECT 1" [] {})]
+        (is (nil? (.getMaximumBytesBilled request)))))
+    (testing "maximum-bytes-billed is not set when blank"
+      (let [^QueryJobConfiguration request (build-fn "SELECT 1" [] {:maximum-bytes-billed ""})]
+        (is (nil? (.getMaximumBytesBilled request)))))
+    (testing "maximum-bytes-billed accepts numeric values (e.g. from API clients)"
+      (let [^QueryJobConfiguration request (build-fn "SELECT 1" [] {:maximum-bytes-billed 1099511627776})]
+        (is (= (Long/valueOf 1099511627776) (.getMaximumBytesBilled request)))))
+    (testing "maximum-bytes-billed ignores non-numeric strings instead of throwing"
+      (let [^QueryJobConfiguration request (build-fn "SELECT 1" [] {:maximum-bytes-billed "not-a-number"})]
+        (is (nil? (.getMaximumBytesBilled request)))))))
+
+(deftest maximum-bytes-billed-query-execution-test
+  (mt/test-driver :bigquery-cloud-sdk
+    (testing "queries against a database with maximum-bytes-billed set actually pass the limit to BigQuery"
+      (testing "an unrealistically low limit causes BigQuery to reject the query"
+        (mt/with-temp [:model/Database db {:engine  :bigquery-cloud-sdk
+                                           :details (assoc (:details (mt/db))
+                                                           :maximum-bytes-billed 1)}]
+          (mt/with-db db
+            (let [result (qp/process-query (mt/mbql-query venues {:limit 1}))]
+              (is (= :failed (:status result)))
+              (is (re-find #"(?i)would be billed|maximum.*bytes.*billed|exceeded"
+                           (or (:error result) "")))))))
+      (testing "a generous limit lets the query run"
+        (mt/with-temp [:model/Database db {:engine  :bigquery-cloud-sdk
+                                           :details (assoc (:details (mt/db))
+                                                           :maximum-bytes-billed 1099511627776)}]
+          (mt/with-db db
+            (is (seq (mt/rows (mt/run-mbql-query venues {:limit 1}))))))))))
 
 (defn- future-thread-names []
   ;; kinda hacky but we don't control this thread pool


### PR DESCRIPTION
## Summary

Adds an optional `maximum-bytes-billed` connection setting for the BigQuery driver. When set, BigQuery rejects any query that would scan more than the given number of bytes before executing it, capping accidental cost blowups from full-scans on large tables.

## Changes

- New advanced connection field on the BigQuery database form (integer, optional).
- The value is forwarded to `QueryJobConfiguration.setMaximumBytesBilled` when building each query.
- Accepts both numeric and string inputs for robustness with API clients and serdes payloads; blank strings are treated as unset.
- Docs added under `databases/connections/bigquery.md`.

## Test plan

- Unit tests for `build-bigquery-request` covering: value present, absent, blank string, numeric input.
- Integration test that actually runs a query through the QP against BigQuery with the setting in play, asserting:
  - an unrealistically low limit causes BigQuery to reject the query
  - a generous limit lets the query run normally

## Review feedback addressed

- Codex P1: blank strings no longer reach `Long/parseLong`.
- Codex P2: numeric inputs accepted via `cond` on `integer?`/`string?`.
- @alexyarosh docs wording suggestion applied.
- @metamben: field type switched from `string` to `integer` in the plugin manifest, and a real query-execution test added.