### PR TITLE
GDGT-1872: Change transform metering to tier-based keys

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/transforms/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/core.clj
@@ -28,9 +28,9 @@
         advanced?      (feature-gating/python-transforms-enabled?)
         yesterday-runs (count-all-runs yesterday-utc)
         today-runs     (count-all-runs today-utc)]
-    {:basic-runs                   (if advanced? 0 yesterday-runs)
-     :advanced-runs                (if advanced? yesterday-runs 0)
+    {:transform-basic-runs                   (if advanced? 0 yesterday-runs)
+     :transform-advanced-runs                (if advanced? yesterday-runs 0)
      :transform-usage-date         (str (t/local-date yesterday-utc))
-     :rolling-basic-runs           (if advanced? 0 today-runs)
-     :rolling-advanced-runs        (if advanced? today-runs 0)
+     :transform-rolling-basic-runs           (if advanced? 0 today-runs)
+     :transform-rolling-advanced-runs        (if advanced? today-runs 0)
      :transform-rolling-usage-date (str (t/local-date today-utc))}))

--- a/enterprise/backend/src/metabase_enterprise/transforms/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/core.clj
@@ -8,6 +8,7 @@
   (:require
    [java-time.api :as t]
    [metabase.premium-features.core :refer [defenterprise]]
+   [metabase.transforms.feature-gating :as feature-gating]
    [toucan2.core :as t2]))
 
 (defenterprise transform-stats
@@ -15,20 +16,21 @@
   Rolling stats are included under :transform-rolling (up to date totals for today)"
   :feature :none
   []
-  (let [today-utc     (t/offset-date-time (t/zone-offset "+00"))
-        yesterday-utc (t/minus today-utc (t/days 1))
-        count-runs    (fn [source-types date]
-                        (or (:cnt (t2/query-one {:select [[[:count :r.id] :cnt]]
-                                                 :from   [[:transform_run :r]]
-                                                 :join   [[:transform :t] [:= :t.id :r.transform_id]]
-                                                 :where  [:and
-                                                          [:= :r.status "succeeded"]
-                                                          [:in :t.source_type source-types]
-                                                          [:= [:cast :r.end_time :date] [:cast date :date]]]}))
-                            0))]
-    {:transform-native-runs         (count-runs ["native" "mbql"] yesterday-utc)
-     :transform-python-runs         (count-runs ["python"] yesterday-utc)
-     :transform-usage-date          (str (t/local-date yesterday-utc))
-     :transform-rolling-native-runs (count-runs ["native" "mbql"] today-utc)
-     :transform-rolling-python-runs (count-runs ["python"] today-utc)
-     :transform-rolling-usage-date  (str (t/local-date today-utc))}))
+  (let [today-utc      (t/offset-date-time (t/zone-offset "+00"))
+        yesterday-utc  (t/minus today-utc (t/days 1))
+        count-all-runs (fn [date]
+                         (or (:cnt (t2/query-one {:select [[[:count :r.id] :cnt]]
+                                                  :from   [[:transform_run :r]]
+                                                  :where  [:and
+                                                           [:= :r.status "succeeded"]
+                                                           [:= [:cast :r.end_time :date] [:cast date :date]]]}))
+                             0))
+        advanced?      (feature-gating/python-transforms-enabled?)
+        yesterday-runs (count-all-runs yesterday-utc)
+        today-runs     (count-all-runs today-utc)]
+    {:basic-runs                   (if advanced? 0 yesterday-runs)
+     :advanced-runs                (if advanced? yesterday-runs 0)
+     :transform-usage-date         (str (t/local-date yesterday-utc))
+     :rolling-basic-runs           (if advanced? 0 today-runs)
+     :rolling-advanced-runs        (if advanced? today-runs 0)
+     :transform-rolling-usage-date (str (t/local-date today-utc))}))

--- a/enterprise/backend/src/metabase_enterprise/transforms/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/core.clj
@@ -7,8 +7,7 @@
   But we need a 'real' module, because all tests must belong to a module."
   (:require
    [java-time.api :as t]
-   [metabase.premium-features.core :refer [defenterprise]]
-   [metabase.transforms.feature-gating :as feature-gating]
+   [metabase.premium-features.core :as premium-features :refer [defenterprise]]
    [toucan2.core :as t2]))
 
 (defenterprise transform-stats
@@ -25,7 +24,8 @@
                                                            [:= :r.status "succeeded"]
                                                            [:= [:cast :r.end_time :date] [:cast date :date]]]}))
                              0))
-        advanced?      (feature-gating/python-transforms-enabled?)
+        advanced?      (and (premium-features/has-feature? :transforms)
+                            (premium-features/has-feature? :transforms-python))
         yesterday-runs (count-all-runs yesterday-utc)
         today-runs     (count-all-runs today-utc)]
     {:transform-basic-runs                   (if advanced? 0 yesterday-runs)

--- a/enterprise/backend/test/metabase_enterprise/transforms/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/core_test.clj
@@ -12,52 +12,52 @@
 
 (use-fixtures :once (fixtures/initialize :db))
 
-(deftest transform-stats-rolling-to-yesterday-test
-  (testing "completed runs appear in rolling stats, then move to yesterday's stats when end_time is backdated"
+(deftest transform-stats-tier-based-metering-test
+  (testing "all runs are bucketed into basic or advanced based on the transforms-python feature flag"
     (mt/with-temp [:model/Transform {native-id :id} {}
                    :model/Transform {python-id :id} {:source {:type            "python"
                                                               :source-database (mt/id)}
                                                      :target {:type     "table"
                                                               :name     (str "test_python_" (random-uuid))
                                                               :database (mt/id)}}]
-      (let [stats-before          (premium-features/transform-stats)
-            native-before         (:transform-native-runs stats-before)
-            rolling-native-before (:transform-rolling-native-runs stats-before)
-            python-before         (:transform-python-runs stats-before)
-            rolling-python-before (:transform-rolling-python-runs stats-before)
-            yesterday-utc         (t/minus (t/offset-date-time (t/zone-offset "+00")) (t/days 1))]
+      (let [stats-before    (premium-features/transform-stats)
+            basic-before    (:basic-runs stats-before)
+            advanced-before (:advanced-runs stats-before)
+            rolling-basic-before    (:rolling-basic-runs stats-before)
+            rolling-advanced-before (:rolling-advanced-runs stats-before)
+            yesterday-utc   (t/minus (t/offset-date-time (t/zone-offset "+00")) (t/days 1))]
 
-        (testing "native"
+        (testing "without advanced add-on, all runs go to basic-runs"
+          ;; run a native transform
           (let [{run-id :id} (transform-run/start-run! native-id {:run_method "manual"})]
             (transform-run/succeed-started-run! run-id)
 
-            (testing "completed run appears in rolling stats only"
+            (testing "completed run appears in rolling-basic-runs"
               (let [stats (premium-features/transform-stats)]
-                (is (= (inc rolling-native-before) (:transform-rolling-native-runs stats)))
-                (is (= native-before               (:transform-native-runs stats)))))
+                (is (= (inc rolling-basic-before) (:rolling-basic-runs stats)))
+                (is (= 0                         (:rolling-advanced-runs stats)))
+                (is (= basic-before               (:basic-runs stats)))))
 
-            (testing "a run for yesterday is visible under yesterday's stats only"
+            (testing "backdated run appears in basic-runs"
               (t2/update! :model/TransformRun :id run-id {:end_time yesterday-utc})
               (let [stats (premium-features/transform-stats)]
-                (is (= rolling-native-before (:transform-rolling-native-runs stats)))
-                (is (= (inc native-before)   (:transform-native-runs stats)))))))
+                (is (= rolling-basic-before (:rolling-basic-runs stats)))
+                (is (= (inc basic-before)   (:basic-runs stats)))
+                (is (= 0                   (:advanced-runs stats)))))))
 
-        (testing "python stats not modified by native runs"
-          (let [stats (premium-features/transform-stats)]
-            (is (= python-before (:transform-python-runs stats)))
-            (is (= rolling-python-before (:transform-rolling-python-runs stats)))))
+        (testing "with advanced add-on, all runs go to advanced-runs"
+          (mt/with-premium-features #{:transforms :transforms-python}
+            ;; run a python transform
+            (let [{run-id :id} (transform-run/start-run! python-id {:run_method "manual"})]
+              (transform-run/succeed-started-run! run-id)
 
-        (testing "python"
-          (let [{run-id :id} (transform-run/start-run! python-id {:run_method "manual"})]
-            (transform-run/succeed-started-run! run-id)
+              (testing "completed run appears in rolling-advanced-runs"
+                (let [stats (premium-features/transform-stats)]
+                  (is (= 0 (:rolling-basic-runs stats)))
+                  (is (pos? (:rolling-advanced-runs stats)))))
 
-            (testing "completed run appears in rolling stats only"
-              (let [stats (premium-features/transform-stats)]
-                (is (= (inc rolling-python-before)  (:transform-rolling-python-runs stats)))
-                (is (= python-before                (:transform-python-runs stats)))))
-
-            (testing "a run for yesterday is visible under yesterday's state only"
-              (t2/update! :model/TransformRun :id run-id {:end_time yesterday-utc})
-              (let [stats (premium-features/transform-stats)]
-                (is (= rolling-python-before (:transform-rolling-python-runs stats)))
-                (is (= (inc python-before)   (:transform-python-runs stats)))))))))))
+              (testing "backdated run appears in advanced-runs"
+                (t2/update! :model/TransformRun :id run-id {:end_time yesterday-utc})
+                (let [stats (premium-features/transform-stats)]
+                  (is (= 0     (:basic-runs stats)))
+                  (is (pos?    (:advanced-runs stats))))))))))))

--- a/enterprise/backend/test/metabase_enterprise/transforms/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/core_test.clj
@@ -34,16 +34,16 @@
 
             (testing "completed run appears in rolling-basic-runs"
               (let [stats (premium-features/transform-stats)]
-                (is (= (inc rolling-basic-before) (:transform-rolling-basic-runs stats)))
-                (is (= 0                         (:transform-rolling-advanced-runs stats)))
-                (is (= basic-before               (:transform-basic-runs stats)))))
+                (is (= (inc rolling-basic-before)    (:transform-rolling-basic-runs stats)))
+                (is (= rolling-advanced-before        (:transform-rolling-advanced-runs stats)))
+                (is (= basic-before                   (:transform-basic-runs stats)))))
 
             (testing "backdated run appears in basic-runs"
               (t2/update! :model/TransformRun :id run-id {:end_time yesterday-utc})
               (let [stats (premium-features/transform-stats)]
                 (is (= rolling-basic-before (:transform-rolling-basic-runs stats)))
                 (is (= (inc basic-before)   (:transform-basic-runs stats)))
-                (is (= 0                   (:transform-advanced-runs stats)))))))
+                (is (= advanced-before      (:transform-advanced-runs stats)))))))
 
         (testing "with advanced add-on, all runs go to advanced-runs"
           (mt/with-premium-features #{:transforms :transforms-python}

--- a/enterprise/backend/test/metabase_enterprise/transforms/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/core_test.clj
@@ -21,10 +21,10 @@
                                                               :name     (str "test_python_" (random-uuid))
                                                               :database (mt/id)}}]
       (let [stats-before    (premium-features/transform-stats)
-            basic-before    (:basic-runs stats-before)
-            advanced-before (:advanced-runs stats-before)
-            rolling-basic-before    (:rolling-basic-runs stats-before)
-            rolling-advanced-before (:rolling-advanced-runs stats-before)
+            basic-before    (:transform-basic-runs stats-before)
+            advanced-before (:transform-advanced-runs stats-before)
+            rolling-basic-before    (:transform-rolling-basic-runs stats-before)
+            rolling-advanced-before (:transform-rolling-advanced-runs stats-before)
             yesterday-utc   (t/minus (t/offset-date-time (t/zone-offset "+00")) (t/days 1))]
 
         (testing "without advanced add-on, all runs go to basic-runs"
@@ -34,16 +34,16 @@
 
             (testing "completed run appears in rolling-basic-runs"
               (let [stats (premium-features/transform-stats)]
-                (is (= (inc rolling-basic-before) (:rolling-basic-runs stats)))
-                (is (= 0                         (:rolling-advanced-runs stats)))
-                (is (= basic-before               (:basic-runs stats)))))
+                (is (= (inc rolling-basic-before) (:transform-rolling-basic-runs stats)))
+                (is (= 0                         (:transform-rolling-advanced-runs stats)))
+                (is (= basic-before               (:transform-basic-runs stats)))))
 
             (testing "backdated run appears in basic-runs"
               (t2/update! :model/TransformRun :id run-id {:end_time yesterday-utc})
               (let [stats (premium-features/transform-stats)]
-                (is (= rolling-basic-before (:rolling-basic-runs stats)))
-                (is (= (inc basic-before)   (:basic-runs stats)))
-                (is (= 0                   (:advanced-runs stats)))))))
+                (is (= rolling-basic-before (:transform-rolling-basic-runs stats)))
+                (is (= (inc basic-before)   (:transform-basic-runs stats)))
+                (is (= 0                   (:transform-advanced-runs stats)))))))
 
         (testing "with advanced add-on, all runs go to advanced-runs"
           (mt/with-premium-features #{:transforms :transforms-python}
@@ -53,11 +53,11 @@
 
               (testing "completed run appears in rolling-advanced-runs"
                 (let [stats (premium-features/transform-stats)]
-                  (is (= 0 (:rolling-basic-runs stats)))
-                  (is (pos? (:rolling-advanced-runs stats)))))
+                  (is (= 0 (:transform-rolling-basic-runs stats)))
+                  (is (pos? (:transform-rolling-advanced-runs stats)))))
 
               (testing "backdated run appears in advanced-runs"
                 (t2/update! :model/TransformRun :id run-id {:end_time yesterday-utc})
                 (let [stats (premium-features/transform-stats)]
-                  (is (= 0     (:basic-runs stats)))
-                  (is (pos?    (:advanced-runs stats))))))))))))
+                  (is (= 0     (:transform-basic-runs stats)))
+                  (is (pos?    (:transform-advanced-runs stats))))))))))))

--- a/src/metabase/premium_features/token_check.clj
+++ b/src/metabase/premium_features/token_check.clj
@@ -130,12 +130,12 @@
   "Stats for Transforms"
   metabase-enterprise.transforms.core
   []
-  {:transform-native-runs         0
-   :transform-python-runs         0
-   :transform-usage-date          (yesterday)
-   :transform-rolling-native-runs 0
-   :transform-rolling-python-runs 0
-   :transform-rolling-usage-date  (today)})
+  {:basic-runs                   0
+   :advanced-runs                0
+   :transform-usage-date         (yesterday)
+   :rolling-basic-runs           0
+   :rolling-advanced-runs        0
+   :transform-rolling-usage-date (today)})
 
 (defn metering-stats
   "Collect metering statistics for billing purposes. Used by both token check and metering task. "

--- a/src/metabase/premium_features/token_check.clj
+++ b/src/metabase/premium_features/token_check.clj
@@ -130,11 +130,11 @@
   "Stats for Transforms"
   metabase-enterprise.transforms.core
   []
-  {:basic-runs                   0
-   :advanced-runs                0
+  {:transform-basic-runs                   0
+   :transform-advanced-runs                0
    :transform-usage-date         (yesterday)
-   :rolling-basic-runs           0
-   :rolling-advanced-runs        0
+   :transform-rolling-basic-runs           0
+   :transform-rolling-advanced-runs        0
    :transform-rolling-usage-date (today)})
 
 (defn metering-stats

--- a/src/metabase/transforms/core.clj
+++ b/src/metabase/transforms/core.clj
@@ -92,9 +92,9 @@
         advanced?      (feature-gating/python-transforms-enabled?)
         yesterday-runs (count-all-runs yesterday-utc)
         today-runs     (count-all-runs today-utc)]
-    {:basic-runs                   (if advanced? 0 yesterday-runs)
-     :advanced-runs                (if advanced? yesterday-runs 0)
+    {:transform-basic-runs                   (if advanced? 0 yesterday-runs)
+     :transform-advanced-runs                (if advanced? yesterday-runs 0)
      :transform-usage-date         (str (t/local-date yesterday-utc))
-     :rolling-basic-runs           (if advanced? 0 today-runs)
-     :rolling-advanced-runs        (if advanced? today-runs 0)
+     :transform-rolling-basic-runs           (if advanced? 0 today-runs)
+     :transform-rolling-advanced-runs        (if advanced? today-runs 0)
      :transform-rolling-usage-date (str (t/local-date today-utc))}))

--- a/src/metabase/transforms/core.clj
+++ b/src/metabase/transforms/core.clj
@@ -12,6 +12,7 @@
    [metabase.transforms.canceling]
    [metabase.transforms.crud]
    [metabase.transforms.execute]
+   [metabase.transforms.feature-gating :as feature-gating]
    [metabase.transforms.jobs]
    [metabase.transforms.schedule]
    [metabase.transforms.settings]
@@ -79,20 +80,21 @@
   "Calculate successful transform runs over a window of the previous UTC day 00:00-23:59.
     Rolling stats are included under :transform-rolling (up to date totals for today)"
   []
-  (let [today-utc     (t/offset-date-time (t/zone-offset "+00"))
-        yesterday-utc (t/minus today-utc (t/days 1))
-        count-runs    (fn [source-types date]
-                        (or (:cnt (t2/query-one {:select [[[:count :r.id] :cnt]]
-                                                 :from   [[:transform_run :r]]
-                                                 :join   [[:transform :t] [:= :t.id :r.transform_id]]
-                                                 :where  [:and
-                                                          [:= :r.status "succeeded"]
-                                                          [:in :t.source_type source-types]
-                                                          [:= [:cast :r.end_time :date] [:cast date :date]]]}))
-                            0))]
-    {:transform-native-runs         (count-runs ["native" "mbql"] yesterday-utc)
-     :transform-python-runs         (count-runs ["python"] yesterday-utc)
-     :transform-usage-date          (str (t/local-date yesterday-utc))
-     :transform-rolling-native-runs (count-runs ["native" "mbql"] today-utc)
-     :transform-rolling-python-runs (count-runs ["python"] today-utc)
-     :transform-rolling-usage-date  (str (t/local-date today-utc))}))
+  (let [today-utc      (t/offset-date-time (t/zone-offset "+00"))
+        yesterday-utc  (t/minus today-utc (t/days 1))
+        count-all-runs (fn [date]
+                         (or (:cnt (t2/query-one {:select [[[:count :r.id] :cnt]]
+                                                  :from   [[:transform_run :r]]
+                                                  :where  [:and
+                                                           [:= :r.status "succeeded"]
+                                                           [:= [:cast :r.end_time :date] [:cast date :date]]]}))
+                             0))
+        advanced?      (feature-gating/python-transforms-enabled?)
+        yesterday-runs (count-all-runs yesterday-utc)
+        today-runs     (count-all-runs today-utc)]
+    {:basic-runs                   (if advanced? 0 yesterday-runs)
+     :advanced-runs                (if advanced? yesterday-runs 0)
+     :transform-usage-date         (str (t/local-date yesterday-utc))
+     :rolling-basic-runs           (if advanced? 0 today-runs)
+     :rolling-advanced-runs        (if advanced? today-runs 0)
+     :transform-rolling-usage-date (str (t/local-date today-utc))}))

--- a/src/metabase/transforms/core.clj
+++ b/src/metabase/transforms/core.clj
@@ -72,4 +72,3 @@
  [metabase.models.transforms.transform-tag
   tag-name-exists?
   tag-name-exists-excluding?])
-

--- a/src/metabase/transforms/core.clj
+++ b/src/metabase/transforms/core.clj
@@ -1,7 +1,6 @@
 (ns metabase.transforms.core
   "API namespace for the `metabase.transforms` module."
   (:require
-   [java-time.api :as t]
    [metabase.models.transforms.transform]
    [metabase.models.transforms.transform-job]
    [metabase.models.transforms.transform-run]
@@ -12,13 +11,11 @@
    [metabase.transforms.canceling]
    [metabase.transforms.crud]
    [metabase.transforms.execute]
-   [metabase.transforms.feature-gating :as feature-gating]
    [metabase.transforms.jobs]
    [metabase.transforms.schedule]
    [metabase.transforms.settings]
    [metabase.transforms.util]
-   [potemkin :as p]
-   [toucan2.core :as t2]))
+   [potemkin :as p]))
 
 (p/import-vars
  [metabase.transforms.settings
@@ -76,25 +73,3 @@
   tag-name-exists?
   tag-name-exists-excluding?])
 
-(defn transform-stats
-  "Calculate successful transform runs over a window of the previous UTC day 00:00-23:59.
-    Rolling stats are included under :transform-rolling (up to date totals for today)"
-  []
-  (let [today-utc      (t/offset-date-time (t/zone-offset "+00"))
-        yesterday-utc  (t/minus today-utc (t/days 1))
-        count-all-runs (fn [date]
-                         (or (:cnt (t2/query-one {:select [[[:count :r.id] :cnt]]
-                                                  :from   [[:transform_run :r]]
-                                                  :where  [:and
-                                                           [:= :r.status "succeeded"]
-                                                           [:= [:cast :r.end_time :date] [:cast date :date]]]}))
-                             0))
-        advanced?      (feature-gating/python-transforms-enabled?)
-        yesterday-runs (count-all-runs yesterday-utc)
-        today-runs     (count-all-runs today-utc)]
-    {:transform-basic-runs                   (if advanced? 0 yesterday-runs)
-     :transform-advanced-runs                (if advanced? yesterday-runs 0)
-     :transform-usage-date         (str (t/local-date yesterday-utc))
-     :transform-rolling-basic-runs           (if advanced? 0 today-runs)
-     :transform-rolling-advanced-runs        (if advanced? today-runs 0)
-     :transform-rolling-usage-date (str (t/local-date today-utc))}))


### PR DESCRIPTION
## Summary
- Rename metering event keys from language-based (`transform-native-runs`/`transform-python-runs`) to tier-based (`transform-basic-runs`/`transform-advanced-runs`) for consumption-based pricing
- Tier is now determined by the customer's add-on state: if `:transforms-python` feature is enabled, all runs report as `transform-advanced-runs`; otherwise all as `transform-basic-runs`

Closes GDGT-1872