### PR TITLE
fix test after out-of-order merge

### DIFF
--- a/test/metabase/transforms_inspector/lens/join_analysis_test.clj
+++ b/test/metabase/transforms_inspector/lens/join_analysis_test.clj
@@ -5,8 +5,8 @@
    [metabase.lib.metadata :as lib.metadata]
    [metabase.query-processor.preprocess :as qp.preprocess]
    [metabase.test :as mt]
-   [metabase.transforms-inspector.lens.join-analysis :as join-analysis]
-   [metabase.transforms.util :as transforms.util]))
+   [metabase.transforms-base.util :as transforms-base.util]
+   [metabase.transforms-inspector.lens.join-analysis :as join-analysis]))
 
 (set! *warn-on-reflection* true)
 
@@ -59,7 +59,7 @@
                                    (lib/with-join-alias "Products")))])
                       (lib/with-join-alias "Products")
                       (lib/with-join-fields :all)))
-        transforms.util/massage-sql-query
+        transforms-base.util/massage-sql-query
         qp.preprocess/preprocess)))
 
 (defn- preprocess-query-with-multi-condition-join
@@ -77,7 +77,7 @@
                                    (lib/with-join-alias "Products")))])
                       (lib/with-join-alias "Products")
                       (lib/with-join-fields :all)))
-        transforms.util/massage-sql-query
+        transforms-base.util/massage-sql-query
         qp.preprocess/preprocess)))
 
 (deftest make-join-step-query-mbql-single-condition-test

--- a/test/metabase/transforms_inspector/lens/join_analysis_test.clj
+++ b/test/metabase/transforms_inspector/lens/join_analysis_test.clj
@@ -5,7 +5,7 @@
    [metabase.lib.metadata :as lib.metadata]
    [metabase.query-processor.preprocess :as qp.preprocess]
    [metabase.test :as mt]
-   [metabase.transforms-base.util :as transforms-base.util]
+   [metabase.transforms-base.util :as transforms-base.u]
    [metabase.transforms-inspector.lens.join-analysis :as join-analysis]))
 
 (set! *warn-on-reflection* true)
@@ -59,7 +59,7 @@
                                    (lib/with-join-alias "Products")))])
                       (lib/with-join-alias "Products")
                       (lib/with-join-fields :all)))
-        transforms-base.util/massage-sql-query
+        transforms-base.u/massage-sql-query
         qp.preprocess/preprocess)))
 
 (defn- preprocess-query-with-multi-condition-join
@@ -77,7 +77,7 @@
                                    (lib/with-join-alias "Products")))])
                       (lib/with-join-alias "Products")
                       (lib/with-join-fields :all)))
-        transforms-base.util/massage-sql-query
+        transforms-base.u/massage-sql-query
         qp.preprocess/preprocess)))
 
 (deftest make-join-step-query-mbql-single-condition-test


### PR DESCRIPTION
https://github.com/metabase/metabase/pull/70247 was merged after https://github.com/metabase/metabase/pull/70245, without rebasing, so a new test referred to a moved function