### PR TITLE
Add cache restore keys for M2 and Node modules

### DIFF
--- a/.github/actions/get-cache-keys/action.yml
+++ b/.github/actions/get-cache-keys/action.yml
@@ -7,9 +7,15 @@ outputs:
   m2-cache-key:
     description: "The cache key for the Maven cache."
     value: ${{ steps.keys-factory.outputs.m2-cache-key }}
+  m2-restore-key:
+    description: "The fallback restore key prefix for the Maven cache."
+    value: ${{ steps.keys-factory.outputs.m2-restore-key }}
   node-cache-key:
     description: "The cache key for the Node.js cache."
     value: ${{ steps.keys-factory.outputs.node-cache-key }}
+  node-restore-key:
+    description: "The fallback restore key prefix for the Node.js cache."
+    value: ${{ steps.keys-factory.outputs.node-restore-key }}
   eslint-cache-key:
     description: "The cache key for Eslint cache"
     value: ${{ steps.keys-factory.outputs.eslint-cache-key }}
@@ -31,7 +37,9 @@ runs:
         CACHE_SUFFIX="${{ runner.os }}-$WEEK_OF_YEAR"
 
         echo "m2-cache-key=$M2_CACHE_PREFIX-$CACHE_SUFFIX" >> $GITHUB_OUTPUT
+        echo "m2-restore-key=$M2_CACHE_PREFIX-" >> $GITHUB_OUTPUT
         echo "node-cache-key=$NODE_CACHE_PREFIX-$CACHE_SUFFIX" >> $GITHUB_OUTPUT
+        echo "node-restore-key=$NODE_CACHE_PREFIX-" >> $GITHUB_OUTPUT
         echo "eslint-cache-key=$ESLINT_CACHE_PREFIX-$CACHE_SUFFIX" >> $GITHUB_OUTPUT
         echo "cypress-cache-key=$CYPRESS_CACHE_PREFIX-$CACHE_SUFFIX" >> $GITHUB_OUTPUT
       shell: bash

--- a/.github/actions/prepare-backend/action.yml
+++ b/.github/actions/prepare-backend/action.yml
@@ -42,3 +42,5 @@ runs:
           ~/.m2
           ~/.gitlibs
         key: ${{ steps.get-cache-keys.outputs.m2-cache-key }}
+        restore-keys: |
+          ${{ steps.get-cache-keys.outputs.m2-restore-key }}

--- a/.github/actions/prepare-frontend/action.yml
+++ b/.github/actions/prepare-frontend/action.yml
@@ -34,6 +34,8 @@ runs:
           ~/.m2
           ~/.gitlibs
         key: ${{ steps.get-cache-keys.outputs.m2-cache-key }}
+        restore-keys: |
+          ${{ steps.get-cache-keys.outputs.m2-restore-key }}
 
     - name: Get bun cache directory
       id: bun-cache
@@ -51,6 +53,8 @@ runs:
           ${{ steps.bun-cache.outputs.dir }}
           node_modules
         key: ${{ steps.get-cache-keys.outputs.node-cache-key }}
+        restore-keys: |
+          ${{ steps.get-cache-keys.outputs.node-restore-key }}
 
     # postinstall lifecycle hook can be dangerous in CI so we only run it locally (see package.json)
     # If a job wants to patch packages, it does so explicitly in the CI. This setting is opt-out.


### PR DESCRIPTION
Resolves DEV-1626
Originally reported by Mendral here: https://app.mendral.com/insights/01KJQYMABR0QJ26AXKP5SGQPR2

Mendral's own attempt at implementing this: #70369

I didn't like their approach because they hard-code the keys. That can easily get out of sync if the cache prefix key changes.

My approach is slightly more verbose but safer.