### PR TITLE
Fix click behavior sidebar font size being too large (#70242)

### DIFF
--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarComponents.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarComponents.tsx
@@ -7,7 +7,7 @@ import S from "./ClickBehaviorSidebar.module.css";
 export const Heading = (props: TitleProps) => {
   const { className, ...rest } = props;
 
-  return <Title order={4} className={cx(S.Heading, className)} {...rest} />;
+  return <Title order={5} className={cx(S.Heading, className)} {...rest} />;
 };
 
 export const SidebarContent = (

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/SidebarItem/SidebarItemComponents.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/SidebarItem/SidebarItemComponents.tsx
@@ -50,5 +50,5 @@ export const Content = (props: FlexProps) => {
 };
 
 export const Name = (props: TitleProps) => (
-  <Title order={4} ta="left" textWrap="wrap" {...props} />
+  <Title order={5} ta="left" textWrap="wrap" {...props} />
 );


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/70242

### Description

After #54750 bumped the global `h4` font size from 14px to 17px, the click behavior sidebar's `Heading` and `SidebarItem.Name` components became visually oversized. Both used `Title
order={4}`, which previously resolved to 14px but now resolves to 17px.
This PR changes them to `order={5}` (14px) to restore the intended font size.

### How to verify
1. Go to a dashboard with a question and a filter
2. Click the pencil icon to edit the dashboard
3. Hover over a card and click the "Click behavior" option
4. Observe the font sizes in the right sidebar — headings and option names should now be 14px instead of the oversized 17px

### Demo
_Before: sidebar text renders at 17px (h4), looking oversized_
<img width="331" height="853" alt="Screenshot 2026-03-04 at 15 53 13" src="https://github.com/user-attachments/assets/39ce36dc-5595-4711-9183-c8d534c48001" />

_After: sidebar text renders at 14px (h5), matching the intended design_
<img width="332" height="833" alt="Screenshot 2026-03-04 at 15 53 49" src="https://github.com/user-attachments/assets/e77edf4e-d735-4712-b0a2-031fed1855b8" />

### Checklist
- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)


