### PR TITLE
Upgrade clickhouse jdbc driver to 0.9.7

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/impersonation/driver_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/impersonation/driver_test.clj
@@ -897,38 +897,8 @@
                                (mt/run-mbql-query venues
                                  {:aggregation [[:count]]}))))))))))))))))
 
-;; TODO(rileythomp, 2026-01-23): Enable this test when we upgrade ClickHouse JDBC driver past 0.8.4
-#_(deftest clickhouse-double-hyphen-test
-    (testing "can use impersonation on clickhouse with role containing a double hyphen (#57016)"
-      (mt/test-driver :clickhouse
-        (mt/with-premium-features #{:advanced-permissions}
-          (let [venues-table (sql.tx/qualify-and-quote driver/*driver* "test-data" "venues")
-                role-a "role--with--double--hyphens"]
-            (tx/with-temp-roles! driver/*driver*
-              (impersonation-granting-details driver/*driver* (mt/db))
-              {role-a {venues-table {}}}
-              (impersonation-default-user driver/*driver*)
-              (impersonation-default-role driver/*driver*)
-              (mt/with-temp [:model/Database database {:engine driver/*driver*,
-                                                       :details (impersonation-details driver/*driver* (mt/db))}]
-                (mt/with-db database
-                  (when (driver/database-supports? driver/*driver* :connection-impersonation-requires-role nil)
-                    (t2/update! :model/Database :id (mt/id) (assoc-in (mt/db) [:details :role] (impersonation-default-role driver/*driver*))))
-                  (sync/sync-database! database {:scan :schema})
-                  (impersonation.util-test/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
-                                                                 :attributes     {"impersonation_attr" role-a}}
-                    (is (= [[100]]
-                           (mt/formatted-rows [int]
-                                              (mt/run-mbql-query venues
-                                                {:aggregation [[:count]]}))))
-                    (is (thrown?
-                         java.lang.Exception
-                         (mt/run-mbql-query checkins
-                           {:aggregation [[:count]]}))))))))))))
-
-;; TODO(rileythomp, 2026-01-28): Verify this test can be removed after upgrading ClickHouse JDBC driver past 0.8.4
-(deftest clickhouse-double-hyphen-role-doesnt-break-all-queries-test
-  (testing "using an unknown role on clickhouse won't break queries for other users (68674)"
+(deftest clickhouse-double-hyphen-test
+  (testing "can use impersonation on clickhouse with role containing a double hyphen (#57016)"
     (mt/test-driver :clickhouse
       (mt/with-premium-features #{:advanced-permissions}
         (let [venues-table (sql.tx/qualify-and-quote driver/*driver* "test-data" "venues")
@@ -946,16 +916,11 @@
                 (sync/sync-database! database {:scan :schema})
                 (impersonation.util-test/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
                                                                :attributes     {"impersonation_attr" role-a}}
-                  (testing "using double hyphen role causes an error"
-                    (is (thrown?
-                         java.lang.Exception
-                         (mt/run-mbql-query venues
-                           {:aggregation [[:count]]}))))
-                  (testing "admin should still be able to query"
-                    (request/as-admin
-                      (is (= [100]
-                             (map
-                              long
-                              (mt/first-row
-                               (mt/run-mbql-query venues
-                                 {:aggregation [[:count]]}))))))))))))))))
+                  (is (= [[100]]
+                         (mt/formatted-rows [int]
+                                            (mt/run-mbql-query venues
+                                              {:aggregation [[:count]]}))))
+                  (is (thrown?
+                       java.lang.Exception
+                       (mt/run-mbql-query checkins
+                         {:aggregation [[:count]]}))))))))))))

--- a/modules/drivers/clickhouse/deps.edn
+++ b/modules/drivers/clickhouse/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src" "resources"]
  :deps
- {com.clickhouse/clickhouse-jdbc {:mvn/version "0.8.4"
+ {com.clickhouse/clickhouse-jdbc {:mvn/version "0.9.7"
                                   :exclusions [org.apache.commons/commons-lang3]}
   org.lz4/lz4-java {:mvn/version "1.8.0"}}}

--- a/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
+++ b/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
@@ -407,13 +407,5 @@
           (.addBatch ^Statement stmt ^String sql))
         (.executeBatch ^Statement stmt)))))
 
-(defmethod sql-jdbc.conn/data-warehouse-connection-pool-properties :clickhouse
-  [driver database]
-  (merge
-   ((get-method sql-jdbc.conn/data-warehouse-connection-pool-properties :sql-jdbc) driver database)
-   ;; TODO(rileythomp, 2026-01-29): Remove this once we upgrade past 0.8.4
-   ;; This is to work around 68674 where connections are being poisoned with bad roles
-   {"preferredTestQuery" "SELECT 1"}))
-
 (defmethod driver/llm-sql-dialect-resource :clickhouse [_]
   "llm/prompts/dialects/clickhouse.md")

--- a/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
+++ b/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
@@ -123,10 +123,11 @@
          :http_connection_provider       "HTTP_URL_CONNECTION"
          :jdbc_ignore_unsupported_values "true"
          :jdbc_schema_term               "schema"
-         :select_sequential_consistency  true
          :max_open_connections           (or max-open-connections 100)
          ;; see also: https://clickhouse.com/docs/en/integrations/java#configuration
-         :custom_http_params             (or clickhouse-settings "")}
+         :custom_http_params             (cond-> "select_sequential_consistency=1"
+                                           (not (str/blank? clickhouse-settings))
+                                           (str "," clickhouse-settings))}
         (sql-jdbc.common/handle-additional-options details :separator-style :url))))
 
 (defmethod driver/database-supports? [:clickhouse :uploads] [_driver _feature db]

--- a/modules/drivers/clickhouse/test/metabase/driver/clickhouse_data_types_test.clj
+++ b/modules/drivers/clickhouse/test/metabase/driver/clickhouse_data_types_test.clj
@@ -441,19 +441,19 @@
          [{:field-name "mystring" :base-type :type/Text}]
          [["foo"] ["bar"] ["   "] [""] [nil]]]])
       (testing "null strings count"
-        (is (= 2M
+        (is (= 2
                (-> (mt/run-mbql-query test-data-nullable-strings
                      {:filter [:is-null $mystring]
                       :aggregation [:count]})
                    mt/first-row last))))
       (testing "nullable strings not null filter"
-        (is (= 3M
+        (is (= 3
                (-> (mt/run-mbql-query test-data-nullable-strings
                      {:filter [:not-null $mystring]
                       :aggregation [:count]})
                    mt/first-row last))))
       (testing "filter nullable string by value"
-        (is (= 1M
+        (is (= 1
                (-> (mt/run-mbql-query test-data-nullable-strings
                      {:filter [:= $mystring "foo"]
                       :aggregation [:count]})

--- a/modules/drivers/clickhouse/test/metabase/driver/clickhouse_test.clj
+++ b/modules/drivers/clickhouse/test/metabase/driver/clickhouse_test.clj
@@ -61,7 +61,7 @@
              :user "bob"
              :password "qaz"
              :ssl true
-             :custom_http_params "max_threads=42,allow_experimental_analyzer=0"})
+             :custom_http_params "select_sequential_consistency=1,max_threads=42,allow_experimental_analyzer=0"})
            (sql-jdbc.conn/connection-details->spec
             :clickhouse
             {:host "myclickhouse"
@@ -100,7 +100,7 @@
 
 (deftest ^:parallel clickhouse-connection-string-select-sequential-consistency
   (testing "connection with no additional options"
-    (is (= (assoc ctd/default-connection-params :select_sequential_consistency true)
+    (is (= ctd/default-connection-params
            (sql-jdbc.conn/connection-details->spec
             :clickhouse
             {})))))
@@ -256,33 +256,33 @@
                                 :value  ["African"]}]}))))))))
 
 ;; TODO(rileythomp, 2026-01-21): Re-enable this test when the ClickHouse JDBC driver is upgraded
-#_(deftest ^:parallel ternary-with-variable-test
-    (mt/test-driver :clickhouse
-      (testing "a query with a ternary and a variable should work correctly (#56690)"
-        (is (= [[1 "African" 1]]
-               (mt/rows
-                (qp/process-query
-                 {:database (mt/id)
-                  :type :native
-                  :native {:query "SELECT *, true ? 1 : 0 AS foo
+(deftest ^:parallel ternary-with-variable-test
+  (mt/test-driver :clickhouse
+    (testing "a query with a ternary and a variable should work correctly (#56690)"
+      (is (= [[1 "African" 1]]
+             (mt/rows
+              (qp/process-query
+               {:database (mt/id)
+                :type :native
+                :native {:query "SELECT *, true ? 1 : 0 AS foo
                                  FROM test_data.categories
                                  WHERE name = {{category_name}};"
-                           :template-tags {"category_name" {:type         :text
-                                                            :name         "category_name"
-                                                            :display-name "Category Name"}}}
-                  :parameters [{:type   :category
-                                :target [:variable [:template-tag "category_name"]]
-                                :value  "African"}]})))))))
+                         :template-tags {"category_name" {:type         :text
+                                                          :name         "category_name"
+                                                          :display-name "Category Name"}}}
+                :parameters [{:type   :category
+                              :target [:variable [:template-tag "category_name"]]
+                              :value  "African"}]})))))))
 
 ;; TODO(rileythomp, 2026-01-21): Re-enable this test when the ClickHouse JDBC driver is upgraded
-#_(deftest ^:parallel line-comment-block-comment-test
-    (mt/test-driver :clickhouse
-      (testing "a query with a line comment followed by a block comment should work correctly (#57149, #62741)"
-        (is (= [[1]]
-               (mt/rows
-                (qp/process-query
-                 (mt/native-query
-                  {:query "-- foo
+(deftest ^:parallel line-comment-block-comment-test
+  (mt/test-driver :clickhouse
+    (testing "a query with a line comment followed by a block comment should work correctly (#57149, #62741)"
+      (is (= [[1]]
+             (mt/rows
+              (qp/process-query
+               (mt/native-query
+                {:query "-- foo
                          /* comment */
                          select 1;"}))))))))
 

--- a/modules/drivers/clickhouse/test/metabase/driver/clickhouse_test.clj
+++ b/modules/drivers/clickhouse/test/metabase/driver/clickhouse_test.clj
@@ -255,7 +255,6 @@
                                 :target [:dimension [:template-tag "category_name"]]
                                 :value  ["African"]}]}))))))))
 
-;; TODO(rileythomp, 2026-01-21): Re-enable this test when the ClickHouse JDBC driver is upgraded
 (deftest ^:parallel ternary-with-variable-test
   (mt/test-driver :clickhouse
     (testing "a query with a ternary and a variable should work correctly (#56690)"
@@ -274,7 +273,6 @@
                               :target [:variable [:template-tag "category_name"]]
                               :value  "African"}]})))))))
 
-;; TODO(rileythomp, 2026-01-21): Re-enable this test when the ClickHouse JDBC driver is upgraded
 (deftest ^:parallel line-comment-block-comment-test
   (mt/test-driver :clickhouse
     (testing "a query with a line comment followed by a block comment should work correctly (#57149, #62741)"

--- a/modules/drivers/clickhouse/test/metabase/test/data/clickhouse.clj
+++ b/modules/drivers/clickhouse/test/metabase/test/data/clickhouse.clj
@@ -56,8 +56,7 @@
    :max_open_connections           100
    :remember_last_set_roles        true
    :http_connection_provider       "HTTP_URL_CONNECTION"
-   :custom_http_params             ""
-   :select_sequential_consistency true})
+   :custom_http_params             "select_sequential_consistency=1"})
 
 (defmethod sql.tx/field-base-type->sql-type [:clickhouse :type/Boolean]         [_ _] "Boolean")
 (defmethod sql.tx/field-base-type->sql-type [:clickhouse :type/BigInteger]      [_ _] "Int64")


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #57149 closes #56690 closes #62741 closes #58691 closes #57016
Closes https://linear.app/metabase/issue/QUE2-267/metabase-seems-to-mix-filters-in-sql-queries-when-they-contain
Closes https://linear.app/metabase/issue/QUE2-266/c-style-comments-in-sql-questions-fail-on-clickhouse
Closes https://linear.app/metabase/issue/QUE2-272/native-questions-starting-with-block-commentary-started-to-crash
Closes https://linear.app/metabase/issue/QUE2-271/connection-impersonation-doesnt-work-with-clickhouse-and-roles-with-at
Closes https://linear.app/metabase/issue/QUE2-264/clickhouse-driver-incorrectly-marks-tables-inactive-and-truncates

### Description

Upgrade clickhouse jdbc driver to 0.9.7.

### How to verify

All tests should pass.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
