### PR TITLE
fix: metabot returns null for pasted question references

### DIFF
--- a/frontend/src/metabase/rich_text_editing/tiptap/extensions/SmartLink/SmartLinkNode.tsx
+++ b/frontend/src/metabase/rich_text_editing/tiptap/extensions/SmartLink/SmartLinkNode.tsx
@@ -439,7 +439,7 @@ export const useEntityData = (
 };
 
 export const SmartLinkComponent = memo(
-  ({ node }: NodeViewProps) => {
+  ({ node, updateAttributes }: NodeViewProps) => {
     const { entityId, model, label } = node.attrs;
 
     const {
@@ -455,9 +455,10 @@ export const SmartLinkComponent = memo(
       if (entity) {
         const name =
           "display_name" in entity ? entity.display_name : entity?.name;
+        updateAttributes({ label: name });
         dispatch(updateMentionsCache({ entityId, model, name }));
       }
-    }, [dispatch, entity, entityId, model]);
+    }, [updateAttributes, dispatch, entity, entityId, model]);
 
     const showLoading = isLoading && !entity;
     if (showLoading) {

--- a/frontend/src/metabase/rich_text_editing/tiptap/extensions/SmartLink/SmartLinkNode.unit.spec.tsx
+++ b/frontend/src/metabase/rich_text_editing/tiptap/extensions/SmartLink/SmartLinkNode.unit.spec.tsx
@@ -28,21 +28,27 @@ function createProps(
   model: SuggestionModel,
   entity: SmartLinkEntity | { id: number; label?: string },
   label?: string,
+  updateAttributes?: NodeViewProps["updateAttributes"],
 ) {
   const node = { attrs: { entityId: entity.id, model, label } };
-  return { node } as unknown as NodeViewProps;
+  return {
+    node,
+    updateAttributes: updateAttributes ?? jest.fn(),
+  } as unknown as NodeViewProps;
 }
 
 function setup({
   entity,
   model,
   label,
+  updateAttributes,
 }: {
   model: SuggestionModel;
   entity: SmartLinkEntity;
   label?: string;
+  updateAttributes?: NodeViewProps["updateAttributes"];
 }) {
-  const props = createProps(model, entity, label);
+  const props = createProps(model, entity, label, updateAttributes);
   renderWithProviders(<SmartLinkComponent {...props} />);
 }
 
@@ -60,6 +66,25 @@ describe("SmartLink", () => {
       // Eventually updates to network data
       expect(await screen.findByText("Network Card Name")).toBeInTheDocument();
       expect(screen.queryByText("Cached Card Name")).not.toBeInTheDocument();
+    });
+
+    it("updates missing labels for pasted smart links", async () => {
+      const card = createMockCard({ id: 123, name: "Network Card Name" });
+      const updateAttributes = jest.fn();
+
+      setupCardEndpoints(card);
+      setup({
+        model: "card",
+        entity: card,
+        label: undefined,
+        updateAttributes,
+      });
+
+      await waitFor(() => {
+        expect(updateAttributes).toHaveBeenCalledWith({
+          label: "Network Card Name",
+        });
+      });
     });
   });
 


### PR DESCRIPTION
Closes [BOT-1068: Metabot returns null for pasted question references](https://linear.app/metabase/issue/BOT-1068/metabot-returns-null-for-pasted-question-references)

### Description

The problem was that when pasting the text, we don't know the label, and the label is fetched inside the component, but never updated the label in the prosemirror node.

### How to verify

1. Copy a URL to some dashboard/question
2. Paste it in metabot sidebar
3. Press send

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
