### PR TITLE
Improved titles for slackbot visualizations; misc other fixes

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/client.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/client.clj
@@ -112,8 +112,9 @@
   (:body (slack-post-json client "/chat.postEphemeral" message)))
 
 (defn post-image
-  "Upload a PNG image and send in a message"
-  [client image-bytes filename channel thread-ts]
+  "Upload a PNG image and send in a message.
+   Optional initial-comment adds context text alongside the image."
+  [client image-bytes filename channel thread-ts & {:keys [initial-comment]}]
   (let [{:keys [ok upload_url file_id] :as res} (get-upload-url client {:filename filename
                                                                         :length (alength ^bytes image-bytes)})]
     (when ok
@@ -121,11 +122,17 @@
                  {:headers {"Content-Type" "image/png"}
                   :body    image-bytes})
       (:body (slack-post-json client "/files.completeUploadExternal"
-                              {:files [{:id file_id
-                                        :title filename}]
-                               :channel_id channel
-                               :thread_ts thread-ts}))
+                              (cond-> {:files      [{:id file_id
+                                                     :title filename}]
+                                       :channel_id channel
+                                       :thread_ts  thread-ts}
+                                initial-comment (assoc :initial_comment initial-comment))))
       res)))
+
+(defn update-message
+  "Update an existing Slack message."
+  [client message]
+  (:body (slack-post-json client "/chat.update" message)))
 
 (defn delete-message
   "Remove a Slack message"

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/client.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/client.clj
@@ -129,11 +129,6 @@
                                 initial-comment (assoc :initial_comment initial-comment))))
       res)))
 
-(defn update-message
-  "Update an existing Slack message."
-  [client message]
-  (:body (slack-post-json client "/chat.update" message)))
-
 (defn delete-message
   "Remove a Slack message"
   [client message]

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/query.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/query.clj
@@ -252,15 +252,16 @@
    - `table` and display types not supported by static viz render as native Slack table blocks
    - static viz chart types render as PNG"
   [card-id]
-  (let [card (t2/select-one :model/Card :id card-id)]
-    (when-not card
-      (throw (ex-info "Card not found" {:card-id card-id :type :card-not-found})))
-    (assoc
-     (if (-> card :display keyword supported-png-display-types)
-       {:type    :image
-        :content (render-saved-card-png card)}
-       (let [results (pulse-card-query-results card)]
-         (throw-on-failed-query! results)
-         {:type    :table
-          :content (format-results-as-table-blocks results)}))
-     :card-name (:name card))))
+  (let [card      (t2/select-one :model/Card :id card-id)
+        _         (when-not card
+                    (throw (ex-info "Card not found" {:card-id card-id :type :card-not-found})))
+        card-name (:name card)]
+    (if (-> card :display keyword supported-png-display-types)
+      {:type      :image
+       :content   (render-saved-card-png card)
+       :card-name card-name}
+      (let [results (pulse-card-query-results card)]
+        (throw-on-failed-query! results)
+        {:type      :table
+         :content   (format-results-as-table-blocks results)
+         :card-name card-name}))))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/query.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/query.clj
@@ -233,7 +233,7 @@
   "Render a saved card (already fetched from DB) to PNG bytes."
   [card]
   (let [{:keys [width]} (render-dimensions (:display card))
-        options {:channel.render/include-title? true
+        options {:channel.render/include-title? false
                  :channel.render/padding-x render-padding-x-px
                  :channel.render/padding-y 0}
         results (pulse-card-query-results card)]
@@ -247,7 +247,7 @@
 
 (defn generate-card-output
   "Generate output for a saved card based on its display type.
-   Returns a map with :type (:table or :image) and :content.
+   Returns a map with :type (:table or :image), :content, and :card-name.
 
    - `table` and display types not supported by static viz render as native Slack table blocks
    - static viz chart types render as PNG"
@@ -255,10 +255,12 @@
   (let [card (t2/select-one :model/Card :id card-id)]
     (when-not card
       (throw (ex-info "Card not found" {:card-id card-id :type :card-not-found})))
-    (if (-> card :display keyword supported-png-display-types)
-      {:type    :image
-       :content (render-saved-card-png card)}
-      (let [results (pulse-card-query-results card)]
-        (throw-on-failed-query! results)
-        {:type    :table
-         :content (format-results-as-table-blocks results)}))))
+    (assoc
+     (if (-> card :display keyword supported-png-display-types)
+       {:type    :image
+        :content (render-saved-card-png card)}
+       (let [results (pulse-card-query-results card)]
+         (throw-on-failed-query! results)
+         {:type    :table
+          :content (format-results-as-table-blocks results)}))
+     :card-name (:name card))))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/streaming.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/streaming.clj
@@ -64,26 +64,26 @@
       can-create-queries        (conj "permission:save_questions")
       can-create-native-queries (conj "permission:write_sql_queries"))))
 
-(defn- format-viz-caption
-  "Build the caption text for a visualization message.
-   Combines the AI-generated caption with a link to the query in Metabase."
-  [caption link]
+(defn- format-viz-title
+  "Build the title text for a visualization message.
+   Combines the title with a link to the query in Metabase."
+  [title link]
   (let [full-link (when link (str (system/site-url) link))]
     (cond
-      (and caption full-link) (str "📊 <" full-link "|" caption ">")
-      caption                 caption
-      full-link               (str "📊 <" full-link "|Open in Metabase>")
-      :else                   nil)))
+      (and title full-link) (str "📊 <" full-link "|" title ">")
+      title                 title
+      full-link             (str "📊 <" full-link "|Open in Metabase>")
+      :else                 nil)))
 
 (defn- deliver-viz!
-  "Post the visualization as a new message with a caption and link.
-   Both tables and images follow the same pattern: post content with caption."
-  [client channel thread-ts {:keys [type content]} filename caption link]
-  (let [text (or (format-viz-caption caption link) "Query results")]
+  "Post the visualization as a new message with a title and link.
+   Both tables and images follow the same pattern: post content with title."
+  [client channel thread-ts {:keys [type content]} filename title link]
+  (let [text (or (format-viz-title title link) "Query results")]
     (case type
-      :table (let [caption-block {:type "section"
-                                  :text {:type "mrkdwn" :text text}}
-                   blocks        (into [caption-block] content)]
+      :table (let [title-block {:type "section"
+                                :text {:type "mrkdwn" :text text}}
+                   blocks      (into [title-block] content)]
                (slackbot.client/post-message client {:channel   channel
                                                      :thread_ts thread-ts
                                                      :blocks    blocks
@@ -211,15 +211,14 @@
 (defn- send-visualizations!
   "Wait for all in-flight visualization futures and post results to Slack.
    Called after stop-stream so results always appear after streamed text.
-   For saved cards (static_viz), uses the actual card name as the caption."
+   For saved cards (static_viz), uses the actual card name as the title."
   [client channel thread-ts prefetched-viz]
-  (doseq [[idx {:keys [^Future future filename caption link]}] prefetched-viz]
+  (doseq [[idx {:keys [^Future future filename title link]}] prefetched-viz]
     (try
       (let [output   (.get future)
-            ;; For saved cards, prefer the actual card name over the AI-generated caption
-            caption  (or (:card-name output) caption)
-            filename (or (some-> caption (u/slugify {:max-length 80})) filename)]
-        (deliver-viz! client channel thread-ts output filename caption link))
+            title    (or (:card-name output) title)
+            filename (or (some-> title (u/slugify {:max-length 80})) filename)]
+        (deliver-viz! client channel thread-ts output filename title link))
       (catch ExecutionException e
         (let [cause (or (.getCause e) e)]
           (log/errorf cause "Visualization future %d failed" idx)
@@ -278,7 +277,7 @@
    - `:request-flush!` — schedules a drain of pending text to Slack
    - `:stream-state` — volatile holding `{:stream_ts :channel}` once started, nil before
    - `:slack-writer` — agent; callers should `(await slack-writer)` before stopping the stream
-   - `:prefetched-viz` — atom holding `{index -> {:future Future :filename str :caption str :link str}}` for in-flight visualizations"
+   - `:prefetched-viz` — atom holding `{index -> {:future Future :filename str :title str :link str}}` for in-flight visualizations"
   [client {:keys [channel thread-ts team-id user-id]}]
   (let [stream-state      (volatile! nil)
         stream-attempted? (volatile! false)
@@ -345,8 +344,8 @@
         on-data (fn [idx content]
                   (when (viz-data-types (:type content))
                     (let [value    (:value content)
-                          caption  (:caption value)
-                          filename (or (some-> caption (u/slugify {:max-length 80}))
+                          title    (:title value)
+                          filename (or (some-> title (u/slugify {:max-length 80}))
                                        (case (:type content)
                                          "static_viz" (str "chart-" (:entity_id value))
                                          "adhoc_viz"  (str "adhoc-" (System/currentTimeMillis))))
@@ -357,7 +356,7 @@
                       (swap! prefetched-viz assoc idx
                              {:future   (.submit viz-prefetch-executor ^Callable task)
                               :filename filename
-                              :caption  caption
+                              :title    title
                               :link     link}))))]
     {:on-text              on-text
      :on-tool-start        on-tool-start

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/streaming.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/streaming.clj
@@ -212,11 +212,15 @@
 
 (defn- send-visualizations!
   "Wait for all in-flight visualization futures and post results to Slack.
-   Called after stop-stream so results always appear after streamed text."
+   Called after stop-stream so results always appear after streamed text.
+   For saved cards (static_viz), uses the actual card name as the caption."
   [client channel thread-ts prefetched-viz]
   (doseq [[idx {:keys [^Future future filename caption link]}] prefetched-viz]
     (try
-      (let [output (.get future)]
+      (let [output   (.get future)
+            ;; For saved cards, prefer the actual card name over the AI-generated caption
+            caption  (or (:card-name output) caption)
+            filename (or (some-> caption (u/slugify {:max-length 80})) filename)]
         (deliver-viz! client channel thread-ts output filename caption link))
       (catch ExecutionException e
         (let [cause (or (.getCause e) e)]

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/streaming.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/streaming.clj
@@ -13,6 +13,8 @@
    [metabase-enterprise.metabot-v3.util :as metabot-v3.util]
    [metabase.api.common :as api]
    [metabase.permissions.core :as perms]
+   [metabase.system.core :as system]
+   [metabase.util :as u]
    [metabase.util.log :as log])
   (:import
    (java.util.concurrent Callable ExecutionException ExecutorService Executors Future ThreadFactory)))
@@ -62,24 +64,32 @@
       can-create-queries        (conj "permission:save_questions")
       can-create-native-queries (conj "permission:write_sql_queries"))))
 
-(defn- update-viz-placeholder
-  "Replace a loading placeholder with the actual visualization content.
-   Tables update the message in-place with blocks. Images post the file as a new message
-   (Slack's chat.update doesn't support file_ids) then delete the placeholder.
-   description is included with image posts as context."
-  [client channel thread-ts placeholder-ts {:keys [type content]} filename description]
-  (case type
-    :table (let [response (slackbot.client/update-message client {:channel channel
-                                                                  :ts      placeholder-ts
-                                                                  :blocks  content
-                                                                  :text    "Query results"})]
-             (when-not (:ok response)
-               (log/errorf "Slack table update error: %s" (pr-str response)))
-             response)
-    :image (let [filename (str filename ".png")]
-             (slackbot.client/post-image client content filename channel thread-ts
-                                         :initial-comment description)
-             (slackbot.client/delete-message client {:channel channel :ts placeholder-ts}))))
+(defn- format-viz-caption
+  "Build the caption text for a visualization message.
+   Combines the AI-generated caption with a link to the query in Metabase."
+  [caption link]
+  (let [full-link (when link (str (system/site-url) link))]
+    (cond
+      (and caption full-link) (str "📊 <" full-link "|" caption ">")
+      caption                 caption
+      full-link               (str "📊 <" full-link "|Open in Metabase>")
+      :else                   nil)))
+
+(defn- deliver-viz!
+  "Post the visualization as a new message with a caption and link.
+   Both tables and images follow the same pattern: post content with caption."
+  [client channel thread-ts {:keys [type content]} filename caption link]
+  (let [text (or (format-viz-caption caption link) "Query results")]
+    (case type
+      :table (let [caption-block {:type "section"
+                                  :text {:type "mrkdwn" :text text}}
+                   blocks        (into [caption-block] content)]
+               (slackbot.client/post-message client {:channel   channel
+                                                     :thread_ts thread-ts
+                                                     :blocks    blocks
+                                                     :text      text}))
+      :image (slackbot.client/post-image client content (str filename ".png") channel thread-ts
+                                         :initial-comment text))))
 
 (def ^:private tool-friendly-names
   "Map of tool names to user-friendly gerund descriptions for slackbot profile tools."
@@ -107,7 +117,7 @@
    - on-tool-start: Called with {:id :name} when a tool starts
    - on-tool-end: Called with {:id :result} when a tool completes
    - on-data: Called with (index, parsed-content) for each DATA line"
-  [conversation-id prompt thread bot-user-id channel-id extra-history
+  [conversation-id prompt thread bot-user-id channel-id slack-user-id extra-history
    {:keys [on-text on-tool-start on-tool-end on-data]}]
   (let [data-idx       (volatile! -1)
         message        (metabot-v3.envelope/user-message prompt)
@@ -144,7 +154,9 @@
                         {:context         (metabot-v3.context/create-context
                                            {:current_time_with_timezone (str (java.time.OffsetDateTime/now))
                                             :capabilities               capabilities
-                                            :slack_channel_id           channel-id})
+                                            :slack_channel_id           channel-id
+                                            :slack_user_mention         (when slack-user-id
+                                                                          (str "<@" slack-user-id ">"))})
                          :metabot-id      metabot-id
                          :profile-id      profile-id
                          :session-id      session-id
@@ -188,28 +200,31 @@
       :else
       "Query execution failed, please try again.")))
 
-(defn- update-viz-error
-  "Update a placeholder message with a user-friendly error, logging on failure."
-  [client channel placeholder-ts e]
+(defn- post-viz-error!
+  "Post a user-friendly error message for a failed visualization."
+  [client channel thread-ts e]
   (try
-    (slackbot.client/update-message client {:channel channel
-                                            :ts      placeholder-ts
-                                            :text    (viz-error-message e)})
-    (catch Exception update-e
-      (log/error update-e "Failed to update placeholder with visualization error"))))
+    (slackbot.client/post-message client {:channel   channel
+                                          :thread_ts thread-ts
+                                          :text      (viz-error-message e)})
+    (catch Exception post-e
+      (log/error post-e "Failed to post visualization error"))))
 
-(defn- await-visualizations
-  "Wait for all in-flight visualization futures to complete. Each future is self-contained
-   (generates the viz and updates the placeholder in-place), so this just acts as a sync point
-   for error logging."
-  [prefetched-viz]
-  (doseq [[idx ^Future fut] prefetched-viz]
+(defn- send-visualizations!
+  "Wait for all in-flight visualization futures and post results to Slack.
+   Called after stop-stream so results always appear after streamed text."
+  [client channel thread-ts prefetched-viz]
+  (doseq [[idx {:keys [^Future future filename caption link]}] prefetched-viz]
     (try
-      (.get fut)
+      (let [output (.get future)]
+        (deliver-viz! client channel thread-ts output filename caption link))
       (catch ExecutionException e
-        (log/errorf (or (.getCause e) e) "Visualization future %d failed" idx))
+        (let [cause (or (.getCause e) e)]
+          (log/errorf cause "Visualization future %d failed" idx)
+          (post-viz-error! client channel thread-ts cause)))
       (catch Exception e
-        (log/errorf e "Visualization future %d failed" idx)))))
+        (log/errorf e "Visualization future %d failed" idx)
+        (post-viz-error! client channel thread-ts e)))))
 
 (defn- ensure-stream-started!
   "Ensure the Slack stream has been started, attempting once if not already tried."
@@ -261,7 +276,7 @@
    - `:request-flush!` — schedules a drain of pending text to Slack
    - `:stream-state` — volatile holding `{:stream_ts :channel}` once started, nil before
    - `:slack-writer` — agent; callers should `(await slack-writer)` before stopping the stream
-   - `:prefetched-viz` — atom holding `{index -> Future<output>}` for in-flight visualizations"
+   - `:prefetched-viz` — atom holding `{index -> {:future Future :filename str :caption str :link str}}` for in-flight visualizations"
   [client {:keys [channel thread-ts team-id user-id]}]
   (let [stream-state      (volatile! nil)
         stream-attempted? (volatile! false)
@@ -327,23 +342,21 @@
         prefetched-viz (atom {})
         on-data (fn [idx content]
                   (when (viz-data-types (:type content))
-                    (let [placeholder (slackbot.client/post-message client {:channel   channel
-                                                                            :thread_ts thread-ts
-                                                                            :text      "_Loading visualization..._"})
-                          placeholder-ts (:ts placeholder)
-                          task (bound-fn*
-                                #(try
-                                   (let [output   (generate-viz-output content)
-                                         filename (case (:type content)
-                                                    "static_viz" (str "chart-" (:entity_id (:value content)))
-                                                    "adhoc_viz"  (str "adhoc-" (System/currentTimeMillis)))]
-                                     (update-viz-placeholder client channel thread-ts placeholder-ts output filename
-                                                             (:description (:value content))))
-                                   (catch Exception e
-                                     (log/errorf e "Failed to generate visualization for %s" (:type content))
-                                     (update-viz-error client channel placeholder-ts e))))]
+                    (let [value    (:value content)
+                          filename (or (some-> (:description value) (u/slugify {:max-length 80}))
+                                       (case (:type content)
+                                         "static_viz" (str "chart-" (:entity_id value))
+                                         "adhoc_viz"  (str "adhoc-" (System/currentTimeMillis))))
+                          caption  (:caption value)
+                          link     (case (:type content)
+                                     "adhoc_viz"  (:link value)
+                                     "static_viz" (str "/question/" (:entity_id value)))
+                          task     (bound-fn* #(generate-viz-output content))]
                       (swap! prefetched-viz assoc idx
-                             (.submit viz-prefetch-executor ^Callable task)))))]
+                             {:future   (.submit viz-prefetch-executor ^Callable task)
+                              :filename filename
+                              :caption  caption
+                              :link     link}))))]
     {:on-text              on-text
      :on-tool-start        on-tool-start
      :on-tool-end          on-tool-end
@@ -396,6 +409,7 @@
                            thread
                            bot-user-id
                            channel-id
+                           (when-not (slackbot.events/dm? event) (:user event))
                            extra-history
                            {:on-text       on-text
                             :on-tool-start on-tool-start
@@ -406,10 +420,10 @@
            (if-let [{:keys [stream_ts channel]} @stream-state]
              (do
                (slackbot.client/stop-stream client channel stream_ts)
-               (await-visualizations @prefetched-viz))
+               (send-visualizations! client channel thread-ts @prefetched-viz))
              (send-fallback "I wasn't able to generate a response. Please try again.")))
          (catch Exception e
-           (run! #(.cancel ^Future % true) (vals @prefetched-viz))
+           (run! #(.cancel ^Future (:future %) true) (vals @prefetched-viz))
            (log/error e "[slackbot] Error in streaming response")
            (await slack-writer)
            (if-let [{:keys [stream_ts channel]} @stream-state]

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/streaming.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/streaming.clj
@@ -64,13 +64,22 @@
       can-create-queries        (conj "permission:save_questions")
       can-create-native-queries (conj "permission:write_sql_queries"))))
 
+(defn- escape-slack-link-text
+  "Escape characters that have structural meaning inside Slack mrkdwn links (`<URL|label>`)."
+  [s]
+  (-> s
+      (str/replace "&" "&amp;")
+      (str/replace "<" "&lt;")
+      (str/replace ">" "&gt;")
+      (str/replace "|" "\u2502")))
+
 (defn- format-viz-title
   "Build the title text for a visualization message.
    Combines the title with a link to the query in Metabase."
   [title link]
   (let [full-link (when link (str (system/site-url) link))]
     (cond
-      (and title full-link) (str "📊 <" full-link "|" title ">")
+      (and title full-link) (str "📊 <" full-link "|" (escape-slack-link-text title) ">")
       title                 title
       full-link             (str "📊 <" full-link "|Open in Metabase>")
       :else                 nil)))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/streaming.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/streaming.clj
@@ -343,11 +343,11 @@
         on-data (fn [idx content]
                   (when (viz-data-types (:type content))
                     (let [value    (:value content)
-                          filename (or (some-> (:description value) (u/slugify {:max-length 80}))
+                          caption  (:caption value)
+                          filename (or (some-> caption (u/slugify {:max-length 80}))
                                        (case (:type content)
                                          "static_viz" (str "chart-" (:entity_id value))
                                          "adhoc_viz"  (str "adhoc-" (System/currentTimeMillis))))
-                          caption  (:caption value)
                           link     (case (:type content)
                                      "adhoc_viz"  (:link value)
                                      "static_viz" (str "/question/" (:entity_id value)))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/streaming.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/streaming.clj
@@ -3,6 +3,7 @@
    (startStream/appendStream/stopStream)."
   (:require
    [clojure.string :as str]
+   [java-time.api :as t]
    [metabase-enterprise.metabot-v3.api.slackbot.client :as slackbot.client]
    [metabase-enterprise.metabot-v3.api.slackbot.events :as slackbot.events]
    [metabase-enterprise.metabot-v3.api.slackbot.query :as slackbot.query]
@@ -269,7 +270,7 @@
         filename (or (some-> title (u/slugify {:max-length 80}))
                      (case type
                        "static_viz" (str "chart-" (:entity_id value))
-                       "adhoc_viz"  (str "adhoc-" (random-uuid))))
+                       "adhoc_viz"  (str "adhoc-" (t/format "yyyy-MM-dd_HH-mm-ss" (t/zoned-date-time)))))
         link     (case type
                    "adhoc_viz"  (:link value)
                    "static_viz" (str "/question/" (:entity_id value)))]

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/streaming.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/streaming.clj
@@ -213,7 +213,7 @@
    Called after stop-stream so results always appear after streamed text.
    For saved cards (static_viz), uses the actual card name as the title."
   [client channel thread-ts prefetched-viz]
-  (doseq [[idx {:keys [^Future future filename title link]}] prefetched-viz]
+  (doseq [[idx {:keys [^Future future filename title link]}] (sort-by first prefetched-viz)]
     (try
       (let [output   (.get future)
             title    (or (:card-name output) title)
@@ -252,6 +252,19 @@
       (when (seq text)
         (dismiss-thinking-msg! client channel thinking-ts)
         (slackbot.client/append-markdown-text client channel stream_ts text)))))
+
+(defn- viz-metadata
+  "Extract title, filename, and link metadata from a visualization data-part."
+  [{:keys [type value]}]
+  (let [title    (:title value)
+        filename (or (some-> title (u/slugify {:max-length 80}))
+                     (case type
+                       "static_viz" (str "chart-" (:entity_id value))
+                       "adhoc_viz"  (str "adhoc-" (random-uuid))))
+        link     (case type
+                   "adhoc_viz"  (:link value)
+                   "static_viz" (str "/question/" (:entity_id value)))]
+    {:title title :filename filename :link link}))
 
 (defn- make-streaming-callbacks
   "Create streaming callback functions and associated control functions.
@@ -343,16 +356,8 @@
         prefetched-viz (atom {})
         on-data (fn [idx content]
                   (when (viz-data-types (:type content))
-                    (let [value    (:value content)
-                          title    (:title value)
-                          filename (or (some-> title (u/slugify {:max-length 80}))
-                                       (case (:type content)
-                                         "static_viz" (str "chart-" (:entity_id value))
-                                         "adhoc_viz"  (str "adhoc-" (System/currentTimeMillis))))
-                          link     (case (:type content)
-                                     "adhoc_viz"  (:link value)
-                                     "static_viz" (str "/question/" (:entity_id value)))
-                          task     (bound-fn* #(generate-viz-output content))]
+                    (let [{:keys [title filename link]} (viz-metadata content)
+                          task (bound-fn* #(generate-viz-output content))]
                       (swap! prefetched-viz assoc idx
                              {:future   (.submit viz-prefetch-executor ^Callable task)
                               :filename filename

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/streaming.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/streaming.clj
@@ -62,19 +62,24 @@
       can-create-queries        (conj "permission:save_questions")
       can-create-native-queries (conj "permission:write_sql_queries"))))
 
-(defn- send-viz-output
-  "Send visualization output to Slack as either table blocks or image."
-  [client channel thread-ts {:keys [type content]} filename]
+(defn- update-viz-placeholder
+  "Replace a loading placeholder with the actual visualization content.
+   Tables update the message in-place with blocks. Images post the file as a new message
+   (Slack's chat.update doesn't support file_ids) then delete the placeholder.
+   description is included with image posts as context."
+  [client channel thread-ts placeholder-ts {:keys [type content]} filename description]
   (case type
-    :table (let [response (slackbot.client/post-message client {:channel   channel
-                                                                :thread_ts thread-ts
-                                                                :blocks    content
-                                                                :text      "Query results"})]
+    :table (let [response (slackbot.client/update-message client {:channel channel
+                                                                  :ts      placeholder-ts
+                                                                  :blocks  content
+                                                                  :text    "Query results"})]
              (when-not (:ok response)
-               (log/errorf "Slack table blocks error: %s" (pr-str response)))
+               (log/errorf "Slack table update error: %s" (pr-str response)))
              response)
     :image (let [filename (str filename ".png")]
-             (slackbot.client/post-image client content filename channel thread-ts))))
+             (slackbot.client/post-image client content filename channel thread-ts
+                                         :initial-comment description)
+             (slackbot.client/delete-message client {:channel channel :ts placeholder-ts}))))
 
 (def ^:private tool-friendly-names
   "Map of tool names to user-friendly gerund descriptions for slackbot profile tools."
@@ -156,8 +161,7 @@
   #{"static_viz" "adhoc_viz"})
 
 (defn- generate-viz-output
-  "Generate visualization output for a data-part. Called both by the prefetch executor (during streaming)
-   and synchronously by [[resolve-viz-output]] when no prefetched result exists."
+  "Generate visualization output for a data-part. Called by the prefetch executor during streaming."
   [{:keys [type value]}]
   (case type
     "static_viz"
@@ -184,54 +188,28 @@
       :else
       "Query execution failed, please try again.")))
 
-(defn- resolve-viz-output
-  "Get the result of a prefetched visualization Future, or generate synchronously if none exists.
-   Unwraps ExecutionException so callers see the original error."
-  [data-part ^Future prefetched-future]
-  (if prefetched-future
-    (try
-      (.get prefetched-future)
-      (catch ExecutionException e
-        (throw (or (.getCause e) e))))
-    (generate-viz-output data-part)))
-
-(defn- post-viz-error
-  "Post a user-friendly visualization error message to Slack, logging on failure."
-  [client channel thread-ts e]
+(defn- update-viz-error
+  "Update a placeholder message with a user-friendly error, logging on failure."
+  [client channel placeholder-ts e]
   (try
-    (slackbot.client/post-message client {:channel   channel
-                                          :thread_ts thread-ts
-                                          :text      (viz-error-message e)})
-    (catch Exception post-e
-      (log/error post-e "Failed to post visualization error message to Slack"))))
+    (slackbot.client/update-message client {:channel channel
+                                            :ts      placeholder-ts
+                                            :text    (viz-error-message e)})
+    (catch Exception update-e
+      (log/error update-e "Failed to update placeholder with visualization error"))))
 
-(defn- send-visualizations
-  "Send visualization data-parts as separate Slack messages after the stream ends.
-   Uses prefetched results when available (submitted during streaming) to reduce latency.
-   Posts a temporary indicator message while visualizations are being generated."
-  [client channel thread-ts data-parts prefetched-viz]
-  (let [vizs (keep-indexed (fn [idx part]
-                             (when (viz-data-types (:type part))
-                               [idx part]))
-                           data-parts)]
-    (when (seq vizs)
-      (let [indicator (slackbot.client/post-message client {:channel   channel
-                                                            :thread_ts thread-ts
-                                                            :text      "_Generating visualizations..._"})]
-        (try
-          (doseq [[idx data-part] vizs]
-            (try
-              (let [output   (resolve-viz-output data-part (get prefetched-viz idx))
-                    filename (case (:type data-part)
-                               "static_viz" (str "chart-" (:entity_id (:value data-part)))
-                               "adhoc_viz"  (str "adhoc-" (System/currentTimeMillis)))]
-                (send-viz-output client channel thread-ts output filename))
-              (catch Exception e
-                (log/errorf e "Failed to generate visualization for %s" (:type data-part))
-                (post-viz-error client channel thread-ts e))))
-          (finally
-            (when-let [ts (:ts indicator)]
-              (slackbot.client/delete-message client {:channel channel :ts ts}))))))))
+(defn- await-visualizations
+  "Wait for all in-flight visualization futures to complete. Each future is self-contained
+   (generates the viz and updates the placeholder in-place), so this just acts as a sync point
+   for error logging."
+  [prefetched-viz]
+  (doseq [[idx ^Future fut] prefetched-viz]
+    (try
+      (.get fut)
+      (catch ExecutionException e
+        (log/errorf (or (.getCause e) e) "Visualization future %d failed" idx))
+      (catch Exception e
+        (log/errorf e "Visualization future %d failed" idx)))))
 
 (defn- ensure-stream-started!
   "Ensure the Slack stream has been started, attempting once if not already tried."
@@ -349,7 +327,21 @@
         prefetched-viz (atom {})
         on-data (fn [idx content]
                   (when (viz-data-types (:type content))
-                    (let [task (bound-fn* #(generate-viz-output content))]
+                    (let [placeholder (slackbot.client/post-message client {:channel   channel
+                                                                            :thread_ts thread-ts
+                                                                            :text      "_Loading visualization..._"})
+                          placeholder-ts (:ts placeholder)
+                          task (bound-fn*
+                                #(try
+                                   (let [output   (generate-viz-output content)
+                                         filename (case (:type content)
+                                                    "static_viz" (str "chart-" (:entity_id (:value content)))
+                                                    "adhoc_viz"  (str "adhoc-" (System/currentTimeMillis)))]
+                                     (update-viz-placeholder client channel thread-ts placeholder-ts output filename
+                                                             (:description (:value content))))
+                                   (catch Exception e
+                                     (log/errorf e "Failed to generate visualization for %s" (:type content))
+                                     (update-viz-error client channel placeholder-ts e))))]
                       (swap! prefetched-viz assoc idx
                              (.submit viz-prefetch-executor ^Callable task)))))]
     {:on-text              on-text
@@ -414,7 +406,7 @@
            (if-let [{:keys [stream_ts channel]} @stream-state]
              (do
                (slackbot.client/stop-stream client channel stream_ts)
-               (send-visualizations client channel thread-ts data-parts @prefetched-viz))
+               (await-visualizations @prefetched-viz))
              (send-fallback "I wasn't able to generate a response. Please try again.")))
          (catch Exception e
            (run! #(.cancel ^Future % true) (vals @prefetched-viz))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/streaming.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/streaming.clj
@@ -117,7 +117,7 @@
    - on-tool-start: Called with {:id :name} when a tool starts
    - on-tool-end: Called with {:id :result} when a tool completes
    - on-data: Called with (index, parsed-content) for each DATA line"
-  [conversation-id prompt thread bot-user-id channel-id slack-user-id extra-history
+  [conversation-id prompt thread bot-user-id channel-id extra-history
    {:keys [on-text on-tool-start on-tool-end on-data]}]
   (let [data-idx       (volatile! -1)
         message        (metabot-v3.envelope/user-message prompt)
@@ -154,9 +154,7 @@
                         {:context         (metabot-v3.context/create-context
                                            {:current_time_with_timezone (str (java.time.OffsetDateTime/now))
                                             :capabilities               capabilities
-                                            :slack_channel_id           channel-id
-                                            :slack_user_mention         (when slack-user-id
-                                                                          (str "<@" slack-user-id ">"))})
+                                            :slack_channel_id           channel-id})
                          :metabot-id      metabot-id
                          :profile-id      profile-id
                          :session-id      session-id
@@ -407,18 +405,17 @@
      (letfn [(send-fallback [text]
                (slackbot.client/post-message client (merge message-ctx {:text text})))]
        (try
-         (let [data-parts (make-streaming-ai-request
-                           (slack-thread->conversation-id (:team_id auth-info) channel thread-ts)
-                           prompt
-                           thread
-                           bot-user-id
-                           channel-id
-                           (when-not (slackbot.events/dm? event) (:user event))
-                           extra-history
-                           {:on-text       on-text
-                            :on-tool-start on-tool-start
-                            :on-tool-end   on-tool-end
-                            :on-data       on-data})]
+         (let [_data-parts (make-streaming-ai-request
+                            (slack-thread->conversation-id (:team_id auth-info) channel thread-ts)
+                            prompt
+                            thread
+                            bot-user-id
+                            channel-id
+                            extra-history
+                            {:on-text       on-text
+                             :on-tool-start on-tool-start
+                             :on-tool-end   on-tool-end
+                             :on-data       on-data})]
            (request-flush!)
            (await slack-writer)
            (if-let [{:keys [stream_ts channel]} @stream-state]

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/entity_details.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/entity_details.clj
@@ -406,10 +406,14 @@
       (let [options (cond-> arguments
                       (= (:with-field-values? arguments) false) (assoc :field-values-fn identity))
             details (if (int? report-id)
-                      (let [details (card-details report-id options)]
+                      (let [card    (t2/hydrate (metabot-v3.tools.u/get-card report-id)
+                                                :average_query_time)
+                            mp      (lib-be/application-database-metadata-provider (:database_id card))
+                            details (card-details card mp options)]
                         (-> details
                             (select-keys [:id :type :description :name :verified])
-                            (assoc :result-columns (:fields details))))
+                            (assoc :result-columns (:fields details))
+                            (m/assoc-some :average_query_time (:average_query_time card))))
                       (throw (ex-info "Invalid report_id format"
                                       {:agent-error? true :status-code 400})))]
         {:structured-output details}))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
@@ -792,6 +792,122 @@
               (testing "second card still rendered"
                 (is (= 1 (count @image-calls)))))))))))
 
+(deftest format-viz-caption-test
+  (testing "format-viz-caption builds correct caption text"
+    (mt/with-temporary-setting-values [site-url "https://metabase.example.com"]
+      (testing "caption + link"
+        (is (= "📊 <https://metabase.example.com/question/42|My Chart>"
+               (#'slackbot.streaming/format-viz-caption "My Chart" "/question/42"))))
+      (testing "caption only"
+        (is (= "My Chart"
+               (#'slackbot.streaming/format-viz-caption "My Chart" nil))))
+      (testing "link only"
+        (is (= "📊 <https://metabase.example.com/question/42|Open in Metabase>"
+               (#'slackbot.streaming/format-viz-caption nil "/question/42"))))
+      (testing "neither"
+        (is (nil? (#'slackbot.streaming/format-viz-caption nil nil)))))))
+
+(deftest viz-caption-and-link-on-image-test
+  (testing "image viz posts include caption with link as initial-comment"
+    (with-slackbot-setup
+      (let [mock-data-parts [{:type  "static_viz"
+                              :value {:entity_id 101
+                                      :caption   "Revenue by Month"}}]
+            event-body      (update base-dm-event :event merge
+                                    {:text      "Show revenue"
+                                     :channel   "C456"
+                                     :ts        "1234567890.000020"
+                                     :event_ts  "1234567890.000020"
+                                     :thread_ts "1234567890.000000"})]
+        (with-slackbot-mocks
+          {:ai-text    "Here's your chart"
+           :data-parts mock-data-parts}
+          (fn [{:keys [image-calls stop-stream-calls]}]
+            (mt/client :post 200 "ee/metabot-v3/slack/events"
+                       (slack-request-options event-body)
+                       event-body)
+            (u/poll {:thunk      #(and (>= (count @stop-stream-calls) 1)
+                                       (>= (count @image-calls) 1))
+                     :done?      true?
+                     :timeout-ms 5000})
+            (let [img (first @image-calls)]
+              (testing "filename uses slugified caption"
+                (is (= "revenue_by_month.png" (:filename img))))
+              (testing "initial-comment contains caption with link"
+                (is (str/includes? (:initial-comment img) "Revenue by Month"))
+                (is (str/includes? (:initial-comment img) "/question/101"))))))))))
+
+(deftest table-viz-with-caption-test
+  (testing "table viz posts include caption block with link"
+    (with-slackbot-setup
+      (let [mock-query      {:database 1 :type "query" :query {:source-table 2}}
+            mock-data-parts [{:type  "adhoc_viz"
+                              :value {:query   mock-query
+                                      :caption "Sales Data"
+                                      :link    "/question#abc123"}}]
+            event-body      (update base-dm-event :event merge
+                                    {:text      "Show sales"
+                                     :ts        "1234567890.000021"
+                                     :event_ts  "1234567890.000021"
+                                     :thread_ts "1234567890.000000"})]
+        (with-slackbot-mocks
+          {:ai-text    "Here's your table"
+           :data-parts mock-data-parts}
+          (fn [{:keys [post-calls stop-stream-calls generate-adhoc-output-calls]}]
+            (mt/client :post 200 "ee/metabot-v3/slack/events"
+                       (slack-request-options event-body)
+                       event-body)
+            (u/poll {:thunk      #(and (>= (count @stop-stream-calls) 1)
+                                       (>= (count @generate-adhoc-output-calls) 1))
+                     :done?      true?
+                     :timeout-ms 5000})
+            (let [viz-post (some (fn [p] (when (:blocks p) p)) @post-calls)]
+              (testing "table viz posted as message with blocks"
+                (is (some? viz-post)))
+              (testing "first block is caption with mrkdwn text"
+                (let [caption-block (first (:blocks viz-post))]
+                  (is (= "section" (:type caption-block)))
+                  (is (= "mrkdwn" (get-in caption-block [:text :type])))
+                  (is (str/includes? (get-in caption-block [:text :text]) "Sales Data")))))))))))
+
+(deftest slack-user-mention-context-test
+  (testing "slack_user_mention is set for channel messages but not DMs"
+    (with-slackbot-setup
+      (testing "channel message includes user mention"
+        (let [event-body (update base-mention-event :event merge
+                                 {:text      "<@UBOT123> Show data"
+                                  :channel   "C456"
+                                  :ts        "1234567890.000030"
+                                  :event_ts  "1234567890.000030"
+                                  :thread_ts "1234567890.000000"})]
+          (with-slackbot-mocks
+            {:ai-text "Here's your data"}
+            (fn [{:keys [ai-request-calls stop-stream-calls]}]
+              (mt/client :post 200 "ee/metabot-v3/slack/events"
+                         (slack-request-options event-body)
+                         event-body)
+              (u/poll {:thunk      #(>= (count @stop-stream-calls) 1)
+                       :done?      true?
+                       :timeout-ms 5000})
+              (let [context (:context (first @ai-request-calls))]
+                (is (= "<@U123>" (:slack_user_mention context))))))))
+      (testing "DM does not include user mention"
+        (let [event-body (update base-dm-event :event merge
+                                 {:text      "Show data"
+                                  :ts        "1234567890.000031"
+                                  :event_ts  "1234567890.000031"})]
+          (with-slackbot-mocks
+            {:ai-text "Here's your data"}
+            (fn [{:keys [ai-request-calls stop-stream-calls]}]
+              (mt/client :post 200 "ee/metabot-v3/slack/events"
+                         (slack-request-options event-body)
+                         event-body)
+              (u/poll {:thunk      #(>= (count @stop-stream-calls) 1)
+                       :done?      true?
+                       :timeout-ms 5000})
+              (let [context (:context (first @ai-request-calls))]
+                (is (nil? (:slack_user_mention context)))))))))))
+
 (deftest generate-card-output-failed-qp-result-test
   (testing "throws when QP returns :status :failed for table card"
     (mt/with-temp [:model/Card {card-id :id} {:display :table}]

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
@@ -792,20 +792,20 @@
               (testing "second card still rendered"
                 (is (= 1 (count @image-calls)))))))))))
 
-(deftest format-viz-caption-test
-  (testing "format-viz-caption builds correct caption text"
+(deftest format-viz-title-test
+  (testing "format-viz-title builds correct title text"
     (mt/with-temporary-setting-values [site-url "https://metabase.example.com"]
-      (testing "caption + link"
+      (testing "title + link"
         (is (= "📊 <https://metabase.example.com/question/42|My Chart>"
-               (#'slackbot.streaming/format-viz-caption "My Chart" "/question/42"))))
-      (testing "caption only"
+               (#'slackbot.streaming/format-viz-title "My Chart" "/question/42"))))
+      (testing "title only"
         (is (= "My Chart"
-               (#'slackbot.streaming/format-viz-caption "My Chart" nil))))
+               (#'slackbot.streaming/format-viz-title "My Chart" nil))))
       (testing "link only"
         (is (= "📊 <https://metabase.example.com/question/42|Open in Metabase>"
-               (#'slackbot.streaming/format-viz-caption nil "/question/42"))))
+               (#'slackbot.streaming/format-viz-title nil "/question/42"))))
       (testing "neither"
-        (is (nil? (#'slackbot.streaming/format-viz-caption nil nil)))))))
+        (is (nil? (#'slackbot.streaming/format-viz-title nil nil)))))))
 
 (deftest viz-caption-and-link-on-image-test
   (testing "image viz for static_viz uses the card name as caption, not the AI-provided caption"

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
@@ -183,9 +183,10 @@
                 Pass ::no-user to simulate an unlinked Slack user (returns nil).
 
    Calls body-fn with a map containing tracking atoms:
-   {:post-calls, :delete-calls, :image-calls, :generate-card-output-calls,
-    :generate-adhoc-output-calls, :ephemeral-calls, :ai-request-calls,
-    :fake-png-bytes, :stream-calls, :append-text-calls, :stop-stream-calls}"
+   {:post-calls, :delete-calls, :image-calls, :update-calls,
+    :generate-card-output-calls, :generate-adhoc-output-calls, :ephemeral-calls,
+    :ai-request-calls, :fake-png-bytes, :stream-calls, :append-text-calls,
+    :stop-stream-calls}"
   [{:keys [ai-text data-parts user-id]
     :or   {data-parts []
            user-id    ::default}}
@@ -193,6 +194,7 @@
   (let [post-calls                  (atom [])
         delete-calls                (atom [])
         image-calls                 (atom [])
+        update-calls                (atom [])
         generate-card-output-calls  (atom [])
         generate-adhoc-output-calls (atom [])
         ephemeral-calls             (atom [])
@@ -201,6 +203,7 @@
         append-text-calls           (atom [])
         stop-stream-calls           (atom [])
         fake-png-bytes              (byte-array [0x89 0x50 0x4E 0x47])
+        placeholder-counter         (atom 0)
         mock-user-id                (cond
                                       (= user-id ::default) (mt/user->id :rasta)
                                       (= user-id ::no-user) nil
@@ -223,8 +226,8 @@
                                               {:ok true})
        slackbot.client/post-message (fn [_ msg]
                                       (swap! post-calls conj msg)
-                                      {:ok true
-                                       :ts "123"
+                                      {:ok      true
+                                       :ts      (str "placeholder-" (swap! placeholder-counter inc))
                                        :channel (:channel msg)
                                        :message msg})
        slackbot.client/post-ephemeral-message (fn [_ msg]
@@ -232,6 +235,17 @@
                                                 {:ok true, :message_ts "1234567890.123456"})
        slackbot.client/delete-message (fn [_ msg]
                                         (swap! delete-calls conj msg)
+                                        {:ok true})
+       slackbot.client/post-image     (fn [_client image-bytes filename channel thread-ts
+                                           & {:keys [initial-comment]}]
+                                        (swap! image-calls conj {:image-bytes     image-bytes
+                                                                 :filename        filename
+                                                                 :channel         channel
+                                                                 :thread-ts       thread-ts
+                                                                 :initial-comment initial-comment})
+                                        {:ok true :file_id "F123"})
+       slackbot.client/update-message (fn [_ msg]
+                                        (swap! update-calls conj msg)
                                         {:ok true})
        ;; Mock the streaming client - returns AISDK-formatted lines
        metabot-v3.client/streaming-request-with-callback
@@ -248,23 +262,16 @@
            mock-lines))
        slackbot.query/generate-card-output     (fn [card-id]
                                                  (swap! generate-card-output-calls conj {:card-id card-id})
-                                           ;; Mock returns image by default (simulating a chart card)
                                                  {:type :image :content fake-png-bytes})
        slackbot.query/generate-adhoc-output (fn [query & {:keys [display]}]
                                               (swap! generate-adhoc-output-calls conj {:query query :display display})
-                                              ;; Chart display types return images, others return table
                                               (if (#{:bar :line :pie :area :row :scatter :funnel :waterfall :combo :progress :gauge :map} display)
                                                 {:type :image :content fake-png-bytes}
-                                                {:type :table :content [{:type "table" :rows [] :column_settings []}]}))
-       slackbot.client/post-image               (fn [_client image-bytes filename channel thread-ts]
-                                                  (swap! image-calls conj {:image-bytes image-bytes
-                                                                           :filename    filename
-                                                                           :channel     channel
-                                                                           :thread-ts   thread-ts})
-                                                  {:ok true :file_id "F123"})]
+                                                {:type :table :content [{:type "table" :rows [] :column_settings []}]}))]
       (body-fn {:post-calls                  post-calls
                 :delete-calls                delete-calls
                 :image-calls                 image-calls
+                :update-calls                update-calls
                 :generate-card-output-calls  generate-card-output-calls
                 :generate-adhoc-output-calls generate-adhoc-output-calls
                 :ephemeral-calls             ephemeral-calls
@@ -465,13 +472,11 @@
                     (#'slackbot.streaming/slack-thread->conversation-id "T1" "C1" "123.456")))))
 
 (deftest user-message-with-visualizations-test
-  (testing "POST /events with visualizations uploads multiple images to Slack"
+  (testing "POST /events with visualizations posts images and cleans up placeholders"
     (with-slackbot-setup
       (let [mock-ai-text "Here are your charts"
-            ;; Multiple static_viz data parts to test image uploads
             mock-data-parts [{:type "static_viz" :value {:entity_id 101}}
                              {:type "static_viz" :value {:entity_id 202}}
-                             ;; Include a non-viz data part to verify filtering
                              {:type "other_type" :value {:foo "bar"}}]
             event-body (update base-dm-event :event merge
                                {:text      "Show me charts"
@@ -482,13 +487,13 @@
         (with-slackbot-mocks
           {:ai-text mock-ai-text
            :data-parts mock-data-parts}
-          (fn [{:keys [stream-calls append-text-calls stop-stream-calls image-calls generate-card-output-calls fake-png-bytes]}]
+          (fn [{:keys [stream-calls append-text-calls stop-stream-calls image-calls delete-calls
+                       generate-card-output-calls fake-png-bytes]}]
             (let [response (mt/client :post 200 "ee/metabot-v3/slack/events"
                                       (slack-request-options event-body)
                                       event-body)]
               (is (= "ok" response))
 
-              ;; Wait for streaming to complete AND image uploads
               (u/poll {:thunk #(and (>= (count @stop-stream-calls) 1)
                                     (>= (count @image-calls) 2))
                        :done? true?
@@ -504,17 +509,16 @@
                 (is (= 2 (count @generate-card-output-calls)))
                 (is (= #{101 202} (set (map :card-id @generate-card-output-calls)))))
 
-              (testing "images uploaded with correct parameters"
+              (testing "images posted and placeholders deleted"
                 (is (= 2 (count @image-calls)))
-                ;; Check channel and thread
                 (is (every? #(= "C456" (:channel %)) @image-calls))
                 (is (every? #(= "1234567890.000000" (:thread-ts %)) @image-calls))
-                ;; Check filenames
                 (is (= #{"chart-101.png" "chart-202.png"}
                        (set (map :filename @image-calls))))
-                ;; Check image bytes match fake PNG
                 (is (every? #(= (vec fake-png-bytes) (vec (:image-bytes %)))
-                            @image-calls))))))))))
+                            @image-calls))
+                ;; Placeholders deleted after image posted (plus Thinking... = 3 deletes)
+                (is (>= (count @delete-calls) 2))))))))))
 
 (deftest user-not-linked-sends-auth-message-test
   (testing "POST /events with unlinked user sends ephemeral auth message (DMs always threaded)"
@@ -609,10 +613,9 @@
 ;; -------------------------------- Ad-Hoc Query Visualization Tests --------------------------------
 
 (deftest adhoc-viz-execution-test
-  (testing "POST /events with adhoc_viz executes query and uploads PNG"
+  (testing "POST /events with adhoc_viz executes query and posts image"
     (with-slackbot-setup
       (let [mock-ai-text    "Here's your data"
-            ;; Note: :type uses string "query" because JSON round-trip converts keywords to strings
             mock-query      {:database 1
                              :type     "query"
                              :query    {:source-table 2}}
@@ -634,7 +637,6 @@
                                       event-body)]
               (is (= "ok" response))
 
-              ;; Wait for streaming to complete AND image upload
               (u/poll {:thunk      #(and (>= (count @stop-stream-calls) 1)
                                          (>= (count @image-calls) 1))
                        :done?      true?
@@ -645,7 +647,7 @@
                 (is (= mock-query (:query (first @generate-adhoc-output-calls))))
                 (is (= :bar (:display (first @generate-adhoc-output-calls)))))
 
-              (testing "image uploaded with adhoc filename"
+              (testing "image posted with adhoc filename"
                 (is (= 1 (count @image-calls)))
                 (is (= "C789" (:channel (first @image-calls))))
                 (is (= "1234567890.000000" (:thread-ts (first @image-calls))))
@@ -655,10 +657,9 @@
 (deftest adhoc-viz-default-display-test
   (testing "POST /events with adhoc_viz uses :table when display not specified"
     (with-slackbot-setup
-      ;; Note: :type uses string "query" because JSON round-trip converts keywords to strings
       (let [mock-query      {:database 1 :type "query" :query {:source-table 2}}
             mock-data-parts [{:type  "adhoc_viz"
-                              :value {:query mock-query}}] ;; no :display
+                              :value {:query mock-query}}]
             event-body      (update base-dm-event :event merge
                                     {:text     "Show data"
                                      :ts       "1234567890.000004"
@@ -666,13 +667,13 @@
         (with-slackbot-mocks
           {:ai-text    "Here's your table"
            :data-parts mock-data-parts}
-          (fn [{:keys [generate-adhoc-output-calls stop-stream-calls post-calls]}]
+          (fn [{:keys [generate-adhoc-output-calls stop-stream-calls update-calls]}]
             (mt/client :post 200 "ee/metabot-v3/slack/events"
                        (slack-request-options event-body)
                        event-body)
-            ;; Wait for streaming to complete and table rendering (table output uses post after stream)
+            ;; Wait for streaming to complete and table rendering (table updates placeholder in-place)
             (u/poll {:thunk      #(and (>= (count @stop-stream-calls) 1)
-                                       (>= (count @post-calls) 1))
+                                       (>= (count @update-calls) 1))
                      :done?      true?
                      :timeout-ms 5000})
             (testing "display defaults to :table"
@@ -681,7 +682,6 @@
 (deftest mixed-viz-types-test
   (testing "POST /events handles both static_viz and adhoc_viz in same response"
     (with-slackbot-setup
-      ;; Note: :type uses string "query" because JSON round-trip converts keywords to strings
       (let [mock-query      {:database 1 :type "query" :query {:source-table 2}}
             mock-data-parts [{:type "static_viz" :value {:entity_id 101}}
                              {:type "adhoc_viz" :value {:query mock-query :display "line"}}
@@ -707,7 +707,7 @@
             (testing "adhoc_viz query rendered"
               (is (= 1 (count @generate-adhoc-output-calls)))
               (is (= :line (:display (first @generate-adhoc-output-calls)))))
-            (testing "all images uploaded"
+            (testing "all images posted"
               (is (= 3 (count @image-calls)))
               (is (= #{"chart-101.png" "chart-202.png"}
                      (set (filter #(str/starts-with? % "chart-") (map :filename @image-calls)))))
@@ -738,8 +738,8 @@
 
 ;; -------------------------------- Visualization Error Handling Tests --------------------------------
 
-(deftest viz-error-posts-message-test
-  (testing "posts error to Slack when visualization generation fails"
+(deftest viz-error-updates-placeholder-test
+  (testing "updates placeholder with error when visualization generation fails"
     (with-slackbot-setup
       (let [event-body (update base-dm-event :event merge
                                {:text      "Show me a chart"
@@ -750,7 +750,7 @@
         (with-slackbot-mocks
           {:ai-text    "Here's your chart"
            :data-parts [{:type "static_viz" :value {:entity_id 999999}}]}
-          (fn [{:keys [post-calls stop-stream-calls]}]
+          (fn [{:keys [update-calls stop-stream-calls]}]
             (mt/with-dynamic-fn-redefs
               [slackbot.query/generate-card-output (fn [_card-id]
                                                      (throw (ex-info "Unexpected render error" {})))]
@@ -758,10 +758,10 @@
                          (slack-request-options event-body) event-body)
               (let [error-msg "Query execution failed, please try again."]
                 (u/poll {:thunk      #(and (>= (count @stop-stream-calls) 1)
-                                           (some (fn [m] (= error-msg (:text m))) @post-calls))
+                                           (some (fn [m] (= error-msg (:text m))) @update-calls))
                          :done?      true?
                          :timeout-ms 5000})
-                (is (some #(= error-msg (:text %)) @post-calls))))))))))
+                (is (some #(= error-msg (:text %)) @update-calls))))))))))
 
 (deftest viz-error-does-not-block-other-vizs-test
   (testing "a failing viz does not prevent subsequent vizs from rendering"
@@ -777,7 +777,7 @@
           {:ai-text    "Here are your charts"
            :data-parts [{:type "static_viz" :value {:entity_id 999999}}
                         {:type "static_viz" :value {:entity_id 123}}]}
-          (fn [{:keys [post-calls image-calls stop-stream-calls]}]
+          (fn [{:keys [update-calls image-calls stop-stream-calls]}]
             (mt/with-dynamic-fn-redefs
               [slackbot.query/generate-card-output (fn [card-id]
                                                      (if (= card-id 999999)
@@ -789,9 +789,9 @@
                                          (>= (count @image-calls) 1))
                        :done?      true?
                        :timeout-ms 5000})
-              (testing "error message posted for failing viz"
+              (testing "error message updated on placeholder for failing viz"
                 (is (some #(= "Query execution failed, please try again." (:text %))
-                          @post-calls)))
+                          @update-calls)))
               (testing "second card still rendered"
                 (is (= 1 (count @image-calls)))))))))))
 

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
@@ -799,7 +799,15 @@
         (is (= "📊 <https://metabase.example.com/question/42|Open in Metabase>"
                (#'slackbot.streaming/format-viz-title nil "/question/42"))))
       (testing "neither"
-        (is (nil? (#'slackbot.streaming/format-viz-title nil nil)))))))
+        (is (nil? (#'slackbot.streaming/format-viz-title nil nil))))
+      (testing "special characters in title are escaped"
+        (is (= "📊 <https://metabase.example.com/question/42|Sales &amp; Revenue>"
+               (#'slackbot.streaming/format-viz-title "Sales & Revenue" "/question/42")))
+        (is (= "📊 <https://metabase.example.com/question/42|Foo &lt;Bar&gt; \u2502 Baz>"
+               (#'slackbot.streaming/format-viz-title "Foo <Bar> | Baz" "/question/42"))))
+      (testing "title-only does not escape (no link syntax)"
+        (is (= "Sales & Revenue"
+               (#'slackbot.streaming/format-viz-title "Sales & Revenue" nil)))))))
 
 (deftest viz-caption-and-link-on-image-test
   (testing "image viz for static_viz uses the card name as caption, not the AI-provided caption"

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
@@ -871,44 +871,6 @@
                   (is (= "mrkdwn" (get-in caption-block [:text :type])))
                   (is (str/includes? (get-in caption-block [:text :text]) "Sales Data")))))))))))
 
-(deftest slack-user-mention-context-test
-  (testing "slack_user_mention is set for channel messages but not DMs"
-    (with-slackbot-setup
-      (testing "channel message includes user mention"
-        (let [event-body (update base-mention-event :event merge
-                                 {:text      "<@UBOT123> Show data"
-                                  :channel   "C456"
-                                  :ts        "1234567890.000030"
-                                  :event_ts  "1234567890.000030"
-                                  :thread_ts "1234567890.000000"})]
-          (with-slackbot-mocks
-            {:ai-text "Here's your data"}
-            (fn [{:keys [ai-request-calls stop-stream-calls]}]
-              (mt/client :post 200 "ee/metabot-v3/slack/events"
-                         (slack-request-options event-body)
-                         event-body)
-              (u/poll {:thunk      #(>= (count @stop-stream-calls) 1)
-                       :done?      true?
-                       :timeout-ms 5000})
-              (let [context (:context (first @ai-request-calls))]
-                (is (= "<@U123>" (:slack_user_mention context))))))))
-      (testing "DM does not include user mention"
-        (let [event-body (update base-dm-event :event merge
-                                 {:text      "Show data"
-                                  :ts        "1234567890.000031"
-                                  :event_ts  "1234567890.000031"})]
-          (with-slackbot-mocks
-            {:ai-text "Here's your data"}
-            (fn [{:keys [ai-request-calls stop-stream-calls]}]
-              (mt/client :post 200 "ee/metabot-v3/slack/events"
-                         (slack-request-options event-body)
-                         event-body)
-              (u/poll {:thunk      #(>= (count @stop-stream-calls) 1)
-                       :done?      true?
-                       :timeout-ms 5000})
-              (let [context (:context (first @ai-request-calls))]
-                (is (nil? (:slack_user_mention context)))))))))))
-
 (deftest generate-card-output-failed-qp-result-test
   (testing "throws when QP returns :status :failed for table card"
     (mt/with-temp [:model/Card {card-id :id} {:display :table}]

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
@@ -643,7 +643,7 @@
                 (is (= 1 (count @image-calls)))
                 (is (= "C789" (:channel (first @image-calls))))
                 (is (= "1234567890.000000" (:thread-ts (first @image-calls))))
-                (is (re-matches #"adhoc-\d+\.png" (:filename (first @image-calls))))
+                (is (re-matches #"adhoc-\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}\.png" (:filename (first @image-calls))))
                 (is (= (vec fake-png-bytes) (vec (:image-bytes (first @image-calls)))))))))))))
 
 (deftest adhoc-viz-default-display-test

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
@@ -472,7 +472,7 @@
                     (#'slackbot.streaming/slack-thread->conversation-id "T1" "C1" "123.456")))))
 
 (deftest user-message-with-visualizations-test
-  (testing "POST /events with visualizations posts images and cleans up placeholders"
+  (testing "POST /events with visualizations posts images"
     (with-slackbot-setup
       (let [mock-ai-text "Here are your charts"
             mock-data-parts [{:type "static_viz" :value {:entity_id 101}}
@@ -487,7 +487,7 @@
         (with-slackbot-mocks
           {:ai-text mock-ai-text
            :data-parts mock-data-parts}
-          (fn [{:keys [stream-calls append-text-calls stop-stream-calls image-calls delete-calls
+          (fn [{:keys [stream-calls append-text-calls stop-stream-calls image-calls
                        generate-card-output-calls fake-png-bytes]}]
             (let [response (mt/client :post 200 "ee/metabot-v3/slack/events"
                                       (slack-request-options event-body)
@@ -509,16 +509,14 @@
                 (is (= 2 (count @generate-card-output-calls)))
                 (is (= #{101 202} (set (map :card-id @generate-card-output-calls)))))
 
-              (testing "images posted and placeholders deleted"
+              (testing "images posted"
                 (is (= 2 (count @image-calls)))
                 (is (every? #(= "C456" (:channel %)) @image-calls))
                 (is (every? #(= "1234567890.000000" (:thread-ts %)) @image-calls))
                 (is (= #{"chart-101.png" "chart-202.png"}
                        (set (map :filename @image-calls))))
                 (is (every? #(= (vec fake-png-bytes) (vec (:image-bytes %)))
-                            @image-calls))
-                ;; Placeholders deleted after image posted (plus Thinking... = 3 deletes)
-                (is (>= (count @delete-calls) 2))))))))))
+                            @image-calls))))))))))
 
 (deftest user-not-linked-sends-auth-message-test
   (testing "POST /events with unlinked user sends ephemeral auth message (DMs always threaded)"
@@ -667,13 +665,12 @@
         (with-slackbot-mocks
           {:ai-text    "Here's your table"
            :data-parts mock-data-parts}
-          (fn [{:keys [generate-adhoc-output-calls stop-stream-calls update-calls]}]
+          (fn [{:keys [generate-adhoc-output-calls stop-stream-calls]}]
             (mt/client :post 200 "ee/metabot-v3/slack/events"
                        (slack-request-options event-body)
                        event-body)
-            ;; Wait for streaming to complete and table rendering (table updates placeholder in-place)
             (u/poll {:thunk      #(and (>= (count @stop-stream-calls) 1)
-                                       (>= (count @update-calls) 1))
+                                       (>= (count @generate-adhoc-output-calls) 1))
                      :done?      true?
                      :timeout-ms 5000})
             (testing "display defaults to :table"
@@ -738,8 +735,8 @@
 
 ;; -------------------------------- Visualization Error Handling Tests --------------------------------
 
-(deftest viz-error-updates-placeholder-test
-  (testing "updates placeholder with error when visualization generation fails"
+(deftest viz-error-posts-error-message-test
+  (testing "posts error message when visualization generation fails"
     (with-slackbot-setup
       (let [event-body (update base-dm-event :event merge
                                {:text      "Show me a chart"
@@ -750,7 +747,7 @@
         (with-slackbot-mocks
           {:ai-text    "Here's your chart"
            :data-parts [{:type "static_viz" :value {:entity_id 999999}}]}
-          (fn [{:keys [update-calls stop-stream-calls]}]
+          (fn [{:keys [post-calls stop-stream-calls]}]
             (mt/with-dynamic-fn-redefs
               [slackbot.query/generate-card-output (fn [_card-id]
                                                      (throw (ex-info "Unexpected render error" {})))]
@@ -758,10 +755,10 @@
                          (slack-request-options event-body) event-body)
               (let [error-msg "Query execution failed, please try again."]
                 (u/poll {:thunk      #(and (>= (count @stop-stream-calls) 1)
-                                           (some (fn [m] (= error-msg (:text m))) @update-calls))
+                                           (some (fn [m] (= error-msg (:text m))) @post-calls))
                          :done?      true?
                          :timeout-ms 5000})
-                (is (some #(= error-msg (:text %)) @update-calls))))))))))
+                (is (some #(= error-msg (:text %)) @post-calls))))))))))
 
 (deftest viz-error-does-not-block-other-vizs-test
   (testing "a failing viz does not prevent subsequent vizs from rendering"
@@ -777,7 +774,7 @@
           {:ai-text    "Here are your charts"
            :data-parts [{:type "static_viz" :value {:entity_id 999999}}
                         {:type "static_viz" :value {:entity_id 123}}]}
-          (fn [{:keys [update-calls image-calls stop-stream-calls]}]
+          (fn [{:keys [post-calls image-calls stop-stream-calls]}]
             (mt/with-dynamic-fn-redefs
               [slackbot.query/generate-card-output (fn [card-id]
                                                      (if (= card-id 999999)
@@ -789,9 +786,9 @@
                                          (>= (count @image-calls) 1))
                        :done?      true?
                        :timeout-ms 5000})
-              (testing "error message updated on placeholder for failing viz"
+              (testing "error message posted for failing viz"
                 (is (some #(= "Query execution failed, please try again." (:text %))
-                          @update-calls)))
+                          @post-calls)))
               (testing "second card still rendered"
                 (is (= 1 (count @image-calls)))))))))))
 

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
@@ -183,10 +183,9 @@
                 Pass ::no-user to simulate an unlinked Slack user (returns nil).
 
    Calls body-fn with a map containing tracking atoms:
-   {:post-calls, :delete-calls, :image-calls, :update-calls,
-    :generate-card-output-calls, :generate-adhoc-output-calls, :ephemeral-calls,
-    :ai-request-calls, :fake-png-bytes, :stream-calls, :append-text-calls,
-    :stop-stream-calls}"
+   {:post-calls, :delete-calls, :image-calls, :generate-card-output-calls,
+    :generate-adhoc-output-calls, :ephemeral-calls, :ai-request-calls,
+    :fake-png-bytes, :stream-calls, :append-text-calls, :stop-stream-calls}"
   [{:keys [ai-text data-parts user-id]
     :or   {data-parts []
            user-id    ::default}}
@@ -194,7 +193,6 @@
   (let [post-calls                  (atom [])
         delete-calls                (atom [])
         image-calls                 (atom [])
-        update-calls                (atom [])
         generate-card-output-calls  (atom [])
         generate-adhoc-output-calls (atom [])
         ephemeral-calls             (atom [])
@@ -244,9 +242,6 @@
                                                                  :thread-ts       thread-ts
                                                                  :initial-comment initial-comment})
                                         {:ok true :file_id "F123"})
-       slackbot.client/update-message (fn [_ msg]
-                                        (swap! update-calls conj msg)
-                                        {:ok true})
        ;; Mock the streaming client - returns AISDK-formatted lines
        metabot-v3.client/streaming-request-with-callback
        (fn [opts]
@@ -271,7 +266,6 @@
       (body-fn {:post-calls                  post-calls
                 :delete-calls                delete-calls
                 :image-calls                 image-calls
-                :update-calls                update-calls
                 :generate-card-output-calls  generate-card-output-calls
                 :generate-adhoc-output-calls generate-adhoc-output-calls
                 :ephemeral-calls             ephemeral-calls

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
@@ -812,7 +812,7 @@
     (with-slackbot-setup
       (let [mock-data-parts [{:type  "static_viz"
                               :value {:entity_id 101
-                                      :caption   "AI-generated caption"}}]
+                                      :title     "AI-generated caption"}}]
             event-body      (update base-dm-event :event merge
                                     {:text      "Show revenue"
                                      :channel   "C456"
@@ -844,7 +844,7 @@
       (let [mock-query      {:database 1 :type "query" :query {:source-table 2}}
             mock-data-parts [{:type  "adhoc_viz"
                               :value {:query   mock-query
-                                      :caption "Sales Data"
+                                      :title   "Sales Data"
                                       :link    "/question#abc123"}}]
             event-body      (update base-dm-event :event merge
                                     {:text      "Show sales"

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
@@ -69,20 +69,20 @@
 
 (defmacro ^:private with-slackbot-setup
   "Wrap body with all required settings for slackbot to be fully configured.
-   Uses `with-temporary-raw-setting-values` for secrets whose getters mask the value,
-   since `with-temporary-setting-values` would save and restore the masked value."
+   Uses `with-temporary-raw-setting-values` to avoid settings with masking getters
+   saving/restoring the obfuscated value instead of the original."
   [& body]
   `(with-redefs [slackbot.config/validate-bot-token! (constantly {:ok true})
                  slackbot.client/get-bot-user-id     (constantly "UBOT123")]
      (with-ensure-encryption
        (mt/with-premium-features #{:metabot-v3 :sso-slack}
-         (mt/with-temporary-setting-values [site-url "https://localhost:3000"
-                                            sso-settings/slack-connect-client-id "test-client-id"
-                                            sso-settings/slack-connect-enabled true]
-           (mt/with-temporary-raw-setting-values [metabot-slack-signing-secret test-signing-secret
-                                                  slack-app-token "xoxb-test"
-                                                  slack-connect-client-secret "test-secret"]
-             ~@body))))))
+         (mt/with-temporary-raw-setting-values [site-url "https://localhost:3000"
+                                                slack-connect-client-id "test-client-id"
+                                                slack-connect-enabled "true"
+                                                metabot-slack-signing-secret test-signing-secret
+                                                slack-app-token "xoxb-test"
+                                                slack-connect-client-secret "test-secret"]
+           ~@body)))))
 
 (defn- compute-slack-signature
   "Compute a valid Slack signature for testing"
@@ -262,7 +262,7 @@
            mock-lines))
        slackbot.query/generate-card-output     (fn [card-id]
                                                  (swap! generate-card-output-calls conj {:card-id card-id})
-                                                 {:type :image :content fake-png-bytes})
+                                                 {:type :image :content fake-png-bytes :card-name (str "Card " card-id)})
        slackbot.query/generate-adhoc-output (fn [query & {:keys [display]}]
                                               (swap! generate-adhoc-output-calls conj {:query query :display display})
                                               (if (#{:bar :line :pie :area :row :scatter :funnel :waterfall :combo :progress :gauge :map} display)
@@ -513,7 +513,7 @@
                 (is (= 2 (count @image-calls)))
                 (is (every? #(= "C456" (:channel %)) @image-calls))
                 (is (every? #(= "1234567890.000000" (:thread-ts %)) @image-calls))
-                (is (= #{"chart-101.png" "chart-202.png"}
+                (is (= #{"card_101.png" "card_202.png"}
                        (set (map :filename @image-calls))))
                 (is (every? #(= (vec fake-png-bytes) (vec (:image-bytes %)))
                             @image-calls))))))))))
@@ -604,7 +604,7 @@
           (is (= "Slack integration is not fully configured." (post-events 503)))))
 
       (testing "returns 503 when signing-secret missing (can't sign request)"
-        (mt/with-temporary-setting-values [metabot.settings/metabot-slack-signing-secret nil]
+        (mt/with-temporary-raw-setting-values [metabot-slack-signing-secret nil]
           (is (= "Slack integration is not fully configured."
                  (mt/client :post 503 "ee/metabot-v3/slack/events" request-body))))))))
 
@@ -706,8 +706,8 @@
               (is (= :line (:display (first @generate-adhoc-output-calls)))))
             (testing "all images posted"
               (is (= 3 (count @image-calls)))
-              (is (= #{"chart-101.png" "chart-202.png"}
-                     (set (filter #(str/starts-with? % "chart-") (map :filename @image-calls)))))
+              (is (= #{"card_101.png" "card_202.png"}
+                     (set (filter #(str/starts-with? % "card") (map :filename @image-calls)))))
               (is (= 1 (count (filter #(str/starts-with? % "adhoc-") (map :filename @image-calls))))))))))))
 
 (deftest generate-card-output-display-type-test
@@ -779,7 +779,7 @@
               [slackbot.query/generate-card-output (fn [card-id]
                                                      (if (= card-id 999999)
                                                        (throw (ex-info "Unexpected render error" {}))
-                                                       {:type :image :content fake-png}))]
+                                                       {:type :image :content fake-png :card-name (str "Card " card-id)}))]
               (mt/client :post 200 "ee/metabot-v3/slack/events"
                          (slack-request-options event-body) event-body)
               (u/poll {:thunk      #(and (>= (count @stop-stream-calls) 1)
@@ -808,11 +808,11 @@
         (is (nil? (#'slackbot.streaming/format-viz-caption nil nil)))))))
 
 (deftest viz-caption-and-link-on-image-test
-  (testing "image viz posts include caption with link as initial-comment"
+  (testing "image viz for static_viz uses the card name as caption, not the AI-provided caption"
     (with-slackbot-setup
       (let [mock-data-parts [{:type  "static_viz"
                               :value {:entity_id 101
-                                      :caption   "Revenue by Month"}}]
+                                      :caption   "AI-generated caption"}}]
             event-body      (update base-dm-event :event merge
                                     {:text      "Show revenue"
                                      :channel   "C456"
@@ -831,10 +831,11 @@
                      :done?      true?
                      :timeout-ms 5000})
             (let [img (first @image-calls)]
-              (testing "filename uses slugified caption"
-                (is (= "revenue_by_month.png" (:filename img))))
-              (testing "initial-comment contains caption with link"
-                (is (str/includes? (:initial-comment img) "Revenue by Month"))
+              (testing "filename uses slugified card name"
+                (is (= "card_101.png" (:filename img))))
+              (testing "initial-comment uses card name with link, not AI caption"
+                (is (str/includes? (:initial-comment img) "Card 101"))
+                (is (not (str/includes? (:initial-comment img) "AI-generated caption")))
                 (is (str/includes? (:initial-comment img) "/question/101"))))))))))
 
 (deftest table-viz-with-caption-test
@@ -1350,26 +1351,26 @@
                  :slack-connect-client-secret nil
                  :metabot-slack-signing-secret nil}]
       (testing "set all credentials"
-        (mt/with-temporary-setting-values [sso-settings/slack-connect-client-id nil
-                                           sso-settings/slack-connect-client-secret nil
-                                           metabot.settings/metabot-slack-signing-secret nil
-                                           sso-settings/slack-connect-enabled false]
-          (is (= {:ok true} (mt/user-http-request :crowberto :put 200 "ee/metabot-v3/slack/settings" creds)))
-          (is (every? some? [(sso-settings/slack-connect-client-id)
-                             (sso-settings/slack-connect-client-secret)
-                             (metabot.settings/metabot-slack-signing-secret)]))
-          (is (true? (sso-settings/slack-connect-enabled)))))
+        (mt/with-temporary-setting-values [sso-settings/slack-connect-enabled false]
+          (mt/with-temporary-raw-setting-values [slack-connect-client-id nil
+                                                 slack-connect-client-secret nil
+                                                 metabot-slack-signing-secret nil]
+            (is (= {:ok true} (mt/user-http-request :crowberto :put 200 "ee/metabot-v3/slack/settings" creds)))
+            (is (every? some? [(sso-settings/slack-connect-client-id)
+                               (sso-settings/slack-connect-client-secret)
+                               (metabot.settings/metabot-slack-signing-secret)]))
+            (is (true? (sso-settings/slack-connect-enabled))))))
 
       (testing "clear all credentials"
-        (mt/with-temporary-setting-values [sso-settings/slack-connect-client-id "x"
-                                           sso-settings/slack-connect-client-secret "x"
-                                           metabot.settings/metabot-slack-signing-secret "x"
-                                           sso-settings/slack-connect-enabled true]
-          (is (= {:ok true} (mt/user-http-request :crowberto :put 200 "ee/metabot-v3/slack/settings" clear)))
-          (is (every? nil? [(sso-settings/slack-connect-client-id)
-                            (sso-settings/slack-connect-client-secret)
-                            (metabot.settings/metabot-slack-signing-secret)]))
-          (is (false? (sso-settings/slack-connect-enabled)))))
+        (mt/with-temporary-setting-values [sso-settings/slack-connect-enabled true]
+          (mt/with-temporary-raw-setting-values [slack-connect-client-id "x"
+                                                 slack-connect-client-secret "x"
+                                                 metabot-slack-signing-secret "x"]
+            (is (= {:ok true} (mt/user-http-request :crowberto :put 200 "ee/metabot-v3/slack/settings" clear)))
+            (is (every? nil? [(sso-settings/slack-connect-client-id)
+                              (sso-settings/slack-connect-client-secret)
+                              (metabot.settings/metabot-slack-signing-secret)]))
+            (is (false? (sso-settings/slack-connect-enabled))))))
 
       (testing "partial credentials returns 400"
         (doseq [partial [(assoc creds :slack-connect-client-id nil)


### PR DESCRIPTION
- Ad-hoc query results include a title with a LLM-generated description linking to Metabase
- Card results include their title from Metabase, also linked
- Fast viz results now appear after the bot's streamed message finishes, instead of racing ahead of it
- Disabled chart titles baked into the static viz images (since we now have titles above them)
- Entity details tool returns average query time so that the AI can set timing expectations for a very slow query (experimental, we can strip this out if needed)
- Fixes more test infra bugs that were corrupting slack settings