### PR TITLE
[Slackbot] Enrich chat history

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api.clj
@@ -12,46 +12,18 @@
    [metabase-enterprise.metabot-v3.config :as metabot-v3.config]
    [metabase-enterprise.metabot-v3.context :as metabot-v3.context]
    [metabase-enterprise.metabot-v3.envelope :as metabot-v3.envelope]
+   [metabase-enterprise.metabot-v3.persistence :as metabot-v3.persistence]
    [metabase-enterprise.metabot-v3.util :as metabot-v3.u]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.api.routes.common :refer [+auth]]
    [metabase.api.util.handlers :as handlers]
-   [metabase.app-db.core :as app-db]
    [metabase.premium-features.core :as premium-features]
    [metabase.store-api.core :as store-api]
-   [metabase.util :as u]
    [metabase.util.i18n :refer [deferred-tru]]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
-   [metabase.util.malli.schema :as ms]
-   [toucan2.core :as t2]))
-
-(defn- store-message! [conversation-id profile-id messages]
-  (let [finish   (let [m (u/last messages)]
-                   (when (= (:_type m) :FINISH_MESSAGE)
-                     m))
-        state    (u/seek #(and (= (:_type %) :DATA)
-                               (= (:type %) "state"))
-                         messages)
-        messages (-> (remove #(or (= % state) (= % finish)) messages)
-                     vec)]
-    (app-db/update-or-insert! :model/MetabotConversation {:id conversation-id}
-                              (constantly (cond-> {:user_id    api/*current-user-id*}
-                                            state (assoc :state state))))
-    ;; NOTE: this will need to be constrained at some point, see BOT-386
-    (t2/insert! :model/MetabotMessage
-                {:conversation_id conversation-id
-                 :data            messages
-                 :usage           (:usage finish)
-                 :role            (:role (first messages))
-                 :profile_id      profile-id
-                 :total_tokens    (->> (vals (:usage finish))
-                                       ;; NOTE: this filter is supporting backward-compatible usage format, can be
-                                       ;; removed when ai-service does not give us `completionTokens` in `usage`
-                                       (filter map?)
-                                       (map #(+ (:prompt %) (:completion %)))
-                                       (apply +))})))
+   [metabase.util.malli.schema :as ms]))
 
 (defn streaming-request
   "Handles an incoming request, making all required tool invocation, LLM call loops, etc."
@@ -60,7 +32,7 @@
         metabot-id (metabot-v3.config/resolve-dynamic-metabot-id metabot_id)
         profile-id (metabot-v3.config/resolve-dynamic-profile-id profile_id metabot-id)
         session-id (metabot-v3.client/get-ai-service-token api/*current-user-id* metabot-id)]
-    (store-message! conversation_id profile-id [message])
+    (metabot-v3.persistence/store-message! conversation_id profile-id [message])
     (metabot-v3.client/streaming-request
      {:context         (metabot-v3.context/create-context context)
       :metabot-id      metabot-id
@@ -71,7 +43,7 @@
       :history         history
       :state           state
       :on-complete     (fn [lines]
-                         (store-message! conversation_id profile-id (metabot-v3.u/aisdk->messages :assistant lines))
+                         (metabot-v3.persistence/store-message! conversation_id profile-id (metabot-v3.u/aisdk->messages :assistant lines))
                          :store-in-db)})))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/events.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/events.clj
@@ -135,3 +135,10 @@
   {:channel (:channel event)
    :thread_ts (or (:thread_ts event)
                   (:ts event))})
+
+(defn strip-bot-mention
+  "Remove bot mention prefix from text (e.g., '<@U123> hello' -> 'hello')"
+  [text bot-user-id]
+  (if bot-user-id
+    (str/replace text (re-pattern (str (bot-tag bot-user-id) "\\s?")) "")
+    text))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/persistence.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/persistence.clj
@@ -1,0 +1,41 @@
+(ns metabase-enterprise.metabot-v3.api.slackbot.persistence
+  "Slack-specific persistence: reconstruct conversation history from stored messages."
+  (:require
+   [metabase.util.log :as log]
+   [toucan2.core :as t2]))
+
+(def ^:private history-message-types
+  "Message types to include in history sent to ai-service."
+  #{"TOOL_CALL" "TOOL_RESULT"})
+
+(defn- normalize-history-message
+  "Keep only ai-service schema fields, keywordize role."
+  [msg]
+  (-> (select-keys msg [:role :content :tool_calls :tool_call_id])
+      (update :role keyword)))
+
+(defn- extract-history-messages
+  "Filter and normalize stored message data for history."
+  [message]
+  (->> (:data message)
+       (filter #(history-message-types (:_type %)))
+       (mapv normalize-history-message)))
+
+(defn get-message-history
+  "Fetch tool call history for Slack messages. Returns {slack-msg-id -> [messages...]}."
+  [conversation-id slack-msg-ids]
+  (when (seq slack-msg-ids)
+    (let [messages (t2/select :model/MetabotMessage
+                              :conversation_id conversation-id
+                              :role "assistant"
+                              :slack_msg_id [:in slack-msg-ids])]
+      (log/infof "[slackbot.persistence] Found %d messages for slack-msg-ids %s" (count messages) (pr-str slack-msg-ids))
+      (doseq [m messages]
+        (log/infof "[slackbot.persistence] Message slack_msg_id=%s, data types: %s"
+                   (:slack_msg_id m)
+                   (pr-str (mapv :_type (:data m)))))
+      (->> messages
+           (keep (fn [{:keys [slack_msg_id] :as msg}]
+                   (when-let [parts (seq (extract-history-messages msg))]
+                     [slack_msg_id parts])))
+           (into {})))))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/persistence.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/persistence.clj
@@ -20,8 +20,8 @@
        (filter #(history-message-types (:_type %)))
        (mapv normalize-history-message)))
 
-(defn get-message-history
-  "Fetch tool call history for Slack messages. Returns {slack-msg-id -> [messages...]}."
+(defn message-history
+  "Tool call history for Slack messages. Returns {slack-msg-id -> [messages...]}."
   [conversation-id slack-msg-ids]
   (when (seq slack-msg-ids)
     (->> (t2/select :model/MetabotMessage

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/persistence.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/persistence.clj
@@ -1,7 +1,6 @@
 (ns metabase-enterprise.metabot-v3.api.slackbot.persistence
   "Slack-specific persistence: reconstruct conversation history from stored messages."
   (:require
-   [metabase.util.log :as log]
    [toucan2.core :as t2]))
 
 (def ^:private history-message-types
@@ -25,17 +24,11 @@
   "Fetch tool call history for Slack messages. Returns {slack-msg-id -> [messages...]}."
   [conversation-id slack-msg-ids]
   (when (seq slack-msg-ids)
-    (let [messages (t2/select :model/MetabotMessage
-                              :conversation_id conversation-id
-                              :role "assistant"
-                              :slack_msg_id [:in slack-msg-ids])]
-      (log/infof "[slackbot.persistence] Found %d messages for slack-msg-ids %s" (count messages) (pr-str slack-msg-ids))
-      (doseq [m messages]
-        (log/infof "[slackbot.persistence] Message slack_msg_id=%s, data types: %s"
-                   (:slack_msg_id m)
-                   (pr-str (mapv :_type (:data m)))))
-      (->> messages
-           (keep (fn [{:keys [slack_msg_id] :as msg}]
-                   (when-let [parts (seq (extract-history-messages msg))]
-                     [slack_msg_id parts])))
-           (into {})))))
+    (->> (t2/select :model/MetabotMessage
+                    :conversation_id conversation-id
+                    :role "assistant"
+                    :slack_msg_id [:in slack-msg-ids])
+         (keep (fn [{:keys [slack_msg_id] :as msg}]
+                 (when-let [parts (seq (extract-history-messages msg))]
+                   [slack_msg_id parts])))
+         (into {}))))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/streaming.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/streaming.clj
@@ -45,14 +45,14 @@
   "_Thinking..._")
 
 (defn- ignore-msg?
-  "Skip messages that aren't useful to the chat history"
+  "True for messages that should be excluded from chat history."
   [msg]
   (and (slackbot.events/bot-message? msg)
        (or (= (:text msg) thinking-placeholder)
            (str/blank? (:text msg)))))
 
 (defn- thread->bot-msg-ids
-  "Slack message ids produced by our bot"
+  "Slack message ids produced by our bot."
   [thread]
   (->> (:messages thread)
        (filter slackbot.events/bot-message?)
@@ -66,7 +66,7 @@
    This preserves tool history that Slack doesn't store while respecting edits."
   [thread bot-user-id conversation-id]
   (let [bot-msg-ids (thread->bot-msg-ids thread)
-        msg-history (slackbot.persistence/get-message-history conversation-id bot-msg-ids)]
+        msg-history (slackbot.persistence/message-history conversation-id bot-msg-ids)]
     (->> (:messages thread)
          (filter :text)
          (remove ignore-msg?)

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/streaming.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/streaming.clj
@@ -441,12 +441,12 @@
                            bot-user-id
                            channel-id
                            extra-history
-                           {:on-text         on-text
-                            :on-tool-start   on-tool-start
-                            :on-tool-end     on-tool-end
-                            :on-data         on-data
-                            :slack-msg-id    (:ts event)
-                            :get-response-ts (fn [] (:stream_ts @stream-state))})]
+                           {:on-text             on-text
+                            :on-tool-start       on-tool-start
+                            :on-tool-end         on-tool-end
+                            :on-data             on-data
+                            :req-slack-msg-id    (:ts event)
+                            :get-res-slack-msg-id (fn [] (:stream_ts @stream-state))})]
            (request-flush!)
            (await slack-writer)
            (if-let [{:keys [stream_ts channel]} @stream-state]

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/streaming.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/streaming.clj
@@ -5,6 +5,7 @@
    [clojure.string :as str]
    [metabase-enterprise.metabot-v3.api.slackbot.client :as slackbot.client]
    [metabase-enterprise.metabot-v3.api.slackbot.events :as slackbot.events]
+   [metabase-enterprise.metabot-v3.api.slackbot.persistence :as slackbot.persistence]
    [metabase-enterprise.metabot-v3.api.slackbot.query :as slackbot.query]
    [metabase-enterprise.metabot-v3.client :as metabot-v3.client]
    [metabase-enterprise.metabot-v3.config :as metabot-v3.config]
@@ -71,7 +72,7 @@
                            set)
         _             (log/infof "[slackbot] Looking up message history for conversation %s, bot-msg-ids: %s"
                                  conversation-id (pr-str bot-msg-ids))
-        msg-history   (metabot-v3.persistence/get-message-history conversation-id bot-msg-ids)
+        msg-history   (slackbot.persistence/get-message-history conversation-id bot-msg-ids)
         _             (log/infof "[slackbot] Found message history for %d bot messages" (count msg-history))]
     (->> (:messages thread)
          (filter :text)

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/streaming.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/streaming.clj
@@ -66,14 +66,11 @@
    For bot messages: merges tool calls/data from DB with text from Slack.
    This preserves tool history that Slack doesn't store while respecting edits."
   [thread bot-user-id conversation-id]
-  (let [bot-msg-ids   (->> (:messages thread)
-                           (filter :bot_id)
-                           (keep :ts)
-                           set)
-        _             (log/infof "[slackbot] Looking up message history for conversation %s, bot-msg-ids: %s"
-                                 conversation-id (pr-str bot-msg-ids))
-        msg-history   (slackbot.persistence/get-message-history conversation-id bot-msg-ids)
-        _             (log/infof "[slackbot] Found message history for %d bot messages" (count msg-history))]
+  (let [bot-msg-ids (->> (:messages thread)
+                         (filter :bot_id)
+                         (keep :ts)
+                         set)
+        msg-history (slackbot.persistence/get-message-history conversation-id bot-msg-ids)]
     (->> (:messages thread)
          (filter :text)
          (mapcat (fn [{:keys [bot_id ts text] :as _msg}]
@@ -149,30 +146,28 @@
         capabilities   (compute-capabilities)
         thread-history (thread->history thread bot-user-id conversation-id)
         history        (into (vec thread-history) extra-history)
-        _              (log/infof "[slackbot] Sending history to agent:\n%s"
-                                  (pr-str history))
-        handle-line (fn [line]
-                      (when-let [[type content] (metabot-v3.u/parse-aisdk-line line)]
-                        (case type
-                          :TEXT
-                          (when (and on-text (seq content))
-                            (on-text content))
+        handle-line    (fn [line]
+                         (when-let [[type content] (metabot-v3.u/parse-aisdk-line line)]
+                           (case type
+                             :TEXT
+                             (when (and on-text (seq content))
+                               (on-text content))
 
-                          :TOOL_CALL
-                          (when on-tool-start
-                            (on-tool-start {:id        (:toolCallId content)
-                                            :tool-name (:toolName content)}))
+                             :TOOL_CALL
+                             (when on-tool-start
+                               (on-tool-start {:id        (:toolCallId content)
+                                               :tool-name (:toolName content)}))
 
-                          :TOOL_RESULT
-                          (when on-tool-end
-                            (on-tool-end {:id     (:toolCallId content)
-                                          :result (:result content)}))
+                             :TOOL_RESULT
+                             (when on-tool-end
+                               (on-tool-end {:id     (:toolCallId content)
+                                             :result (:result content)}))
 
-                          :DATA
-                          (when on-data
-                            (on-data (vswap! data-idx inc) content))
+                             :DATA
+                             (when on-data
+                               (on-data (vswap! data-idx inc) content))
 
-                          (log/debugf "Ignoring AI SDK line of type %s" type))))
+                             (log/debugf "Ignoring AI SDK line of type %s" type))))
 
         _              (metabot-v3.persistence/store-message! conversation-id profile-id [message]
                                                               :slack-msg-id slack-msg-id)

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/streaming.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/streaming.clj
@@ -10,12 +10,19 @@
    [metabase-enterprise.metabot-v3.config :as metabot-v3.config]
    [metabase-enterprise.metabot-v3.context :as metabot-v3.context]
    [metabase-enterprise.metabot-v3.envelope :as metabot-v3.envelope]
-   [metabase-enterprise.metabot-v3.util :as metabot-v3.util]
+   [metabase-enterprise.metabot-v3.persistence :as metabot-v3.persistence]
+   [metabase-enterprise.metabot-v3.util :as metabot-v3.u]
    [metabase.api.common :as api]
    [metabase.permissions.core :as perms]
    [metabase.util.log :as log])
   (:import
-   (java.util.concurrent Callable ExecutionException ExecutorService Executors Future ThreadFactory)))
+   (java.util.concurrent
+    Callable
+    ExecutionException
+    ExecutorService
+    Executors
+    Future
+    ThreadFactory)))
 
 (set! *warn-on-reflection* true)
 
@@ -39,19 +46,46 @@
     (str/replace text (re-pattern (str "<@" bot-user-id ">\\s?")) "")
     text))
 
+(def ^:private junk-message-patterns
+  "Patterns for bot messages that should be excluded from history.
+   These are Slack placeholder/error messages, not real assistant responses."
+  [#"^_Thinking\.\.\._$"
+   #"^Something went wrong"
+   #"^I wasn't able to generate"])
+
+(defn- junk-message?
+  "Returns true if the text matches a junk pattern or is empty."
+  [text]
+  (or (str/blank? text)
+      (some #(re-find % text) junk-message-patterns)))
+
 (defn- thread->history
   "Convert a Slack thread to an ai-service history object.
-   Strips bot mentions from user messages when bot-user-id is provided."
-  [thread bot-user-id]
-  (->> (:messages thread)
-       (filter :text)
-       (mapv (fn [msg]
-               (let [is-bot? (some? (:bot_id msg))
-                     content (if is-bot?
-                               (:text msg)
-                               (strip-bot-mention (:text msg) bot-user-id))]
-                 {:role    (if is-bot? :assistant :user)
-                  :content content})))))
+   For user messages: uses Slack text (respects edits), strips bot mentions.
+   For bot messages: merges tool calls/data from DB with text from Slack.
+   This preserves tool history that Slack doesn't store while respecting edits."
+  [thread bot-user-id conversation-id]
+  (let [bot-msg-ids   (->> (:messages thread)
+                           (filter :bot_id)
+                           (keep :ts)
+                           set)
+        _             (log/infof "[slackbot] Looking up message history for conversation %s, bot-msg-ids: %s"
+                                 conversation-id (pr-str bot-msg-ids))
+        msg-history   (metabot-v3.persistence/get-message-history conversation-id bot-msg-ids)
+        _             (log/infof "[slackbot] Found message history for %d bot messages" (count msg-history))]
+    (->> (:messages thread)
+         (filter :text)
+         (mapcat (fn [{:keys [bot_id ts text] :as _msg}]
+                   (if bot_id
+                     ;; For bot messages: tool parts from DB + text from Slack
+                     ;; This preserves tool call history while respecting Slack message edits
+                     (let [tool-parts (get msg-history ts)]
+                       (if (junk-message? text)
+                         tool-parts
+                         (conj (vec tool-parts) {:role :assistant :content text})))
+                     ;; For user messages, use Slack text (respects edits)
+                     [{:role :user :content (strip-bot-mention text bot-user-id)}])))
+         vec)))
 
 (defn- compute-capabilities
   "Compute capability strings for the current user based on their permissions."
@@ -101,19 +135,23 @@
    - on-text: Called with text content (ai-service already buffers markdown links)
    - on-tool-start: Called with {:id :name} when a tool starts
    - on-tool-end: Called with {:id :result} when a tool completes
-   - on-data: Called with (index, parsed-content) for each DATA line"
+   - on-data: Called with (index, parsed-content) for each DATA line
+   - slack-msg-id: The Slack message ts for the user's incoming message
+   - get-response-ts: Function that returns the Slack message ts for the bot's response"
   [conversation-id prompt thread bot-user-id channel-id extra-history
-   {:keys [on-text on-tool-start on-tool-end on-data]}]
+   {:keys [on-text on-tool-start on-tool-end on-data slack-msg-id get-response-ts]}]
   (let [data-idx       (volatile! -1)
         message        (metabot-v3.envelope/user-message prompt)
         metabot-id     (metabot-v3.config/resolve-dynamic-metabot-id nil)
         profile-id     (metabot-v3.config/resolve-dynamic-profile-id "slackbot" metabot-id)
         session-id     (metabot-v3.client/get-ai-service-token api/*current-user-id* metabot-id)
         capabilities   (compute-capabilities)
-        thread-history (thread->history thread bot-user-id)
+        thread-history (thread->history thread bot-user-id conversation-id)
         history        (into (vec thread-history) extra-history)
+        _              (log/infof "[slackbot] Sending history to agent:\n%s"
+                                  (pr-str history))
         handle-line (fn [line]
-                      (when-let [[type content] (metabot-v3.util/parse-aisdk-line line)]
+                      (when-let [[type content] (metabot-v3.u/parse-aisdk-line line)]
                         (case type
                           :TEXT
                           (when (and on-text (seq content))
@@ -135,7 +173,10 @@
 
                           (log/debugf "Ignoring AI SDK line of type %s" type))))
 
+        _              (metabot-v3.persistence/store-message! conversation-id profile-id [message]
+                                                              :slack-msg-id slack-msg-id)
         lines          (metabot-v3.client/streaming-request-with-callback
+
                         {:context         (metabot-v3.context/create-context
                                            {:current_time_with_timezone (str (java.time.OffsetDateTime/now))
                                             :capabilities               capabilities
@@ -147,8 +188,14 @@
                          :message         message
                          :history         history
                          :state           {}
-                         :on-line         handle-line})]
-    (->> (metabot-v3.util/aisdk->messages :assistant lines)
+                         :on-line         handle-line
+                         :on-complete     (fn [lines]
+                                            (metabot-v3.persistence/store-message!
+                                             conversation-id profile-id
+                                             (metabot-v3.u/aisdk->messages :assistant lines)
+                                             :slack-msg-id (when get-response-ts (get-response-ts)))
+                                            :store-in-db)})]
+    (->> (metabot-v3.u/aisdk->messages :assistant lines)
          (filter #(= (:_type %) :DATA)))))
 
 (def ^:private viz-data-types
@@ -405,10 +452,12 @@
                            bot-user-id
                            channel-id
                            extra-history
-                           {:on-text       on-text
-                            :on-tool-start on-tool-start
-                            :on-tool-end   on-tool-end
-                            :on-data       on-data})]
+                           {:on-text         on-text
+                            :on-tool-start   on-tool-start
+                            :on-tool-end     on-tool-end
+                            :on-data         on-data
+                            :slack-msg-id    (:ts event)
+                            :get-response-ts (fn [] (:stream_ts @stream-state))})]
            (request-flush!)
            (await slack-writer)
            (if-let [{:keys [stream_ts channel]} @stream-state]

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/streaming.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/streaming.clj
@@ -40,25 +40,24 @@
                       (.setDaemon true))))]
     (Executors/newFixedThreadPool viz-prefetch-pool-size factory)))
 
-(defn- strip-bot-mention
-  "Remove bot mention prefix from text (e.g., '<@U123> hello' -> 'hello')"
-  [text bot-user-id]
-  (if bot-user-id
-    (str/replace text (re-pattern (str "<@" bot-user-id ">\\s?")) "")
-    text))
+(def ^:private thinking-placeholder
+  "Displayed while waiting for AI response. Excluded from history."
+  "_Thinking..._")
 
-(def ^:private junk-message-patterns
-  "Patterns for bot messages that should be excluded from history.
-   These are Slack placeholder/error messages, not real assistant responses."
-  [#"^_Thinking\.\.\._$"
-   #"^Something went wrong"
-   #"^I wasn't able to generate"])
+(defn- ignore-msg?
+  "Skip messages that aren't useful to the chat history"
+  [msg]
+  (and (slackbot.events/bot-message? msg)
+       (or (= (:text msg) thinking-placeholder)
+           (str/blank? (:text msg)))))
 
-(defn- junk-message?
-  "Returns true if the text matches a junk pattern or is empty."
-  [text]
-  (or (str/blank? text)
-      (some #(re-find % text) junk-message-patterns)))
+(defn- thread->bot-msg-ids
+  "Slack message ids produced by our bot"
+  [thread]
+  (->> (:messages thread)
+       (filter slackbot.events/bot-message?)
+       (keep :ts)
+       set))
 
 (defn- thread->history
   "Convert a Slack thread to an ai-service history object.
@@ -66,23 +65,17 @@
    For bot messages: merges tool calls/data from DB with text from Slack.
    This preserves tool history that Slack doesn't store while respecting edits."
   [thread bot-user-id conversation-id]
-  (let [bot-msg-ids (->> (:messages thread)
-                         (filter :bot_id)
-                         (keep :ts)
-                         set)
+  (let [bot-msg-ids (thread->bot-msg-ids thread)
         msg-history (slackbot.persistence/get-message-history conversation-id bot-msg-ids)]
     (->> (:messages thread)
          (filter :text)
-         (mapcat (fn [{:keys [bot_id ts text] :as _msg}]
-                   (if bot_id
-                     ;; For bot messages: tool parts from DB + text from Slack
-                     ;; This preserves tool call history while respecting Slack message edits
-                     (let [tool-parts (get msg-history ts)]
-                       (if (junk-message? text)
-                         tool-parts
-                         (conj (vec tool-parts) {:role :assistant :content text})))
-                     ;; For user messages, use Slack text (respects edits)
-                     [{:role :user :content (strip-bot-mention text bot-user-id)}])))
+         (remove ignore-msg?)
+         (mapcat (fn [{:keys [ts text] :as msg}]
+                   (if (slackbot.events/bot-message? msg)
+                     ;; bot messages: merge on tool call info from db
+                     (conj (get msg-history ts []) {:role :assistant :content text})
+                     ;; user messages: user slack history instead to respect user edits
+                     [{:role :user :content (slackbot.events/strip-bot-mention text bot-user-id)}])))
          vec)))
 
 (defn- compute-capabilities
@@ -134,10 +127,10 @@
    - on-tool-start: Called with {:id :name} when a tool starts
    - on-tool-end: Called with {:id :result} when a tool completes
    - on-data: Called with (index, parsed-content) for each DATA line
-   - slack-msg-id: The Slack message ts for the user's incoming message
+   - req-slack-msg-id: The Slack message ts for the user's incoming message
    - get-response-ts: Function that returns the Slack message ts for the bot's response"
   [conversation-id prompt thread bot-user-id channel-id extra-history
-   {:keys [on-text on-tool-start on-tool-end on-data slack-msg-id get-response-ts]}]
+   {:keys [on-text on-tool-start on-tool-end on-data req-slack-msg-id get-res-slack-msg-id]}]
   (let [data-idx       (volatile! -1)
         message        (metabot-v3.envelope/user-message prompt)
         metabot-id     (metabot-v3.config/resolve-dynamic-metabot-id nil)
@@ -170,7 +163,7 @@
                              (log/debugf "Ignoring AI SDK line of type %s" type))))
 
         _              (metabot-v3.persistence/store-message! conversation-id profile-id [message]
-                                                              :slack-msg-id slack-msg-id)
+                                                              :slack-msg-id req-slack-msg-id)
         lines          (metabot-v3.client/streaming-request-with-callback
 
                         {:context         (metabot-v3.context/create-context
@@ -189,7 +182,7 @@
                                             (metabot-v3.persistence/store-message!
                                              conversation-id profile-id
                                              (metabot-v3.u/aisdk->messages :assistant lines)
-                                             :slack-msg-id (when get-response-ts (get-response-ts)))
+                                             :slack-msg-id (when get-res-slack-msg-id (get-res-slack-msg-id)))
                                             :store-in-db)})]
     (->> (metabot-v3.u/aisdk->messages :assistant lines)
          (filter #(= (:_type %) :DATA)))))
@@ -354,7 +347,7 @@
         start-with-thinking! (fn []
                                (let [response (slackbot.client/post-message client {:channel   channel
                                                                                     :thread_ts thread-ts
-                                                                                    :text      "_Thinking..._"})]
+                                                                                    :text      thinking-placeholder})]
                                  (when (:ok response)
                                    (reset! thinking-ts (:ts response)))))
 

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj
@@ -244,10 +244,10 @@
             (swap! lines conj line)
             (when on-line (on-line line))
             (recur (.readLine response-reader)))))
+      (when on-complete
+        (on-complete @lines))
       (catch java.io.IOException e
         (log/debugf e "Stream closed while reading AI response (%d lines collected)" (count @lines))))
-    (when on-complete
-      (on-complete @lines))
     @lines))
 
 (mu/defn select-metric-request

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/client.clj
@@ -224,7 +224,7 @@
    Unlike `streaming-request`, this doesn't return a StreamingResponse - it processes
    the stream internally and calls `on-line` for each line as it arrives.
    Returns the collected lines when complete."
-  [{:keys [on-line] :as opts}
+  [{:keys [on-line on-complete] :as opts}
    :- [:map
        [:context :map]
        [:message ::metabot-v3.client.schema/message]
@@ -233,7 +233,8 @@
        [:conversation-id :string]
        [:session-id :string]
        [:state :map]
-       [:on-line {:optional true} [:function [:=> [:cat :string] :any]]]]]
+       [:on-line {:optional true} [:function [:=> [:cat :string] :any]]]
+       [:on-complete {:optional true} [:function [:=> [:cat :any] :any]]]]]
   (let [response (open-ai-stream! opts)
         lines    (atom [])]
     (try
@@ -245,6 +246,8 @@
             (recur (.readLine response-reader)))))
       (catch java.io.IOException e
         (log/debugf e "Stream closed while reading AI response (%d lines collected)" (count @lines))))
+    (when on-complete
+      (on-complete @lines))
     @lines))
 
 (mu/defn select-metric-request

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/persistence.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/persistence.clj
@@ -1,60 +1,13 @@
 (ns metabase-enterprise.metabot-v3.persistence
-  "Persistence functions for MetaBot conversations and messages."
+  "Persistence for Metabot conversations and messages."
   (:require
    [metabase.api.common :as api]
    [metabase.app-db.core :as app-db]
    [metabase.util :as u]
-   [metabase.util.log :as log]
    [toucan2.core :as t2]))
 
-(def ^:private history-message-types
-  "Message types that should be included in history.
-   Excludes TEXT (comes from Slack), DATA (ephemeral for rendering), and FINISH_MESSAGE (metadata only)."
-  #{"TOOL_CALL" "TOOL_RESULT"})
-
-(defn- normalize-history-message
-  "Normalize a stored message to the format expected by ai-service.
-   Keeps only the fields defined in the schema: role, content, tool_calls, tool_call_id."
-  [{:keys [role content tool_calls tool_call_id]}]
-  (cond-> {:role (keyword role)}
-    content      (assoc :content content)
-    tool_calls   (assoc :tool_calls tool_calls)
-    tool_call_id (assoc :tool_call_id tool_call_id)))
-
-(defn- extract-history-messages
-  "Extract messages that should be included in conversation history.
-   Filters to TOOL_CALL and TOOL_RESULT types. Normalizes to schema format.
-   Preserves original ordering from stored data."
-  [message]
-  (->> (:data message)
-       (filter #(history-message-types (:_type %)))
-       (mapv normalize-history-message)))
-
-(defn get-message-history
-  "Fetch stored tool call/data history for a set of Slack message IDs.
-   Returns a map of {slack-msg-id -> [tool-parts...]}.
-   Excludes TEXT messages since those come from Slack (to respect edits)."
-  [conversation-id slack-msg-ids]
-  (when (seq slack-msg-ids)
-    (let [messages (t2/select :model/MetabotMessage
-                              :conversation_id conversation-id
-                              :role "assistant"
-                              :slack_msg_id [:in slack-msg-ids])]
-      (log/infof "[persistence] Found %d messages for slack-msg-ids %s" (count messages) (pr-str slack-msg-ids))
-      (doseq [m messages]
-        (log/infof "[persistence] Message slack_msg_id=%s, data types: %s"
-                   (:slack_msg_id m)
-                   (pr-str (mapv :_type (:data m)))))
-      (->> messages
-           (keep (fn [{:keys [slack_msg_id] :as msg}]
-                   (when-let [parts (seq (extract-history-messages msg))]
-                     [slack_msg_id parts])))
-           (into {})))))
-
 (defn store-message!
-  "Store messages for a conversation in the database.
-   Handles extracting finish/state metadata and persisting to MetabotConversation and MetabotMessage tables.
-   slack-msg-id is optional - only provided for Slack-originated messages."
+  "Persist messages to MetabotConversation and MetabotMessage tables."
   [conversation-id profile-id messages & {:keys [slack-msg-id]}]
   (let [finish   (let [m (u/last messages)]
                    (when (= (:_type m) :FINISH_MESSAGE)

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/persistence.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/persistence.clj
@@ -1,0 +1,83 @@
+(ns metabase-enterprise.metabot-v3.persistence
+  "Persistence functions for MetaBot conversations and messages."
+  (:require
+   [metabase.api.common :as api]
+   [metabase.app-db.core :as app-db]
+   [metabase.util :as u]
+   [metabase.util.log :as log]
+   [toucan2.core :as t2]))
+
+(def ^:private history-message-types
+  "Message types that should be included in history.
+   Excludes TEXT (comes from Slack), DATA (ephemeral for rendering), and FINISH_MESSAGE (metadata only)."
+  #{"TOOL_CALL" "TOOL_RESULT"})
+
+(defn- normalize-history-message
+  "Normalize a stored message to the format expected by ai-service.
+   Keeps only the fields defined in the schema: role, content, tool_calls, tool_call_id."
+  [{:keys [role content tool_calls tool_call_id]}]
+  (cond-> {:role (keyword role)}
+    content      (assoc :content content)
+    tool_calls   (assoc :tool_calls tool_calls)
+    tool_call_id (assoc :tool_call_id tool_call_id)))
+
+(defn- extract-history-messages
+  "Extract messages that should be included in conversation history.
+   Filters to TOOL_CALL and TOOL_RESULT types. Normalizes to schema format.
+   Preserves original ordering from stored data."
+  [message]
+  (->> (:data message)
+       (filter #(history-message-types (:_type %)))
+       (mapv normalize-history-message)))
+
+(defn get-message-history
+  "Fetch stored tool call/data history for a set of Slack message IDs.
+   Returns a map of {slack-msg-id -> [tool-parts...]}.
+   Excludes TEXT messages since those come from Slack (to respect edits)."
+  [conversation-id slack-msg-ids]
+  (when (seq slack-msg-ids)
+    (let [messages (t2/select :model/MetabotMessage
+                              :conversation_id conversation-id
+                              :role "assistant"
+                              :slack_msg_id [:in slack-msg-ids])]
+      (log/infof "[persistence] Found %d messages for slack-msg-ids %s" (count messages) (pr-str slack-msg-ids))
+      (doseq [m messages]
+        (log/infof "[persistence] Message slack_msg_id=%s, data types: %s"
+                   (:slack_msg_id m)
+                   (pr-str (mapv :_type (:data m)))))
+      (->> messages
+           (keep (fn [{:keys [slack_msg_id] :as msg}]
+                   (when-let [parts (seq (extract-history-messages msg))]
+                     [slack_msg_id parts])))
+           (into {})))))
+
+(defn store-message!
+  "Store messages for a conversation in the database.
+   Handles extracting finish/state metadata and persisting to MetabotConversation and MetabotMessage tables.
+   slack-msg-id is optional - only provided for Slack-originated messages."
+  [conversation-id profile-id messages & {:keys [slack-msg-id]}]
+  (let [finish   (let [m (u/last messages)]
+                   (when (= (:_type m) :FINISH_MESSAGE)
+                     m))
+        state    (u/seek #(and (= (:_type %) :DATA)
+                               (= (:type %) "state"))
+                         messages)
+        messages (-> (remove #(or (= % state) (= % finish)) messages)
+                     vec)]
+    (app-db/update-or-insert! :model/MetabotConversation {:id conversation-id}
+                              (constantly (cond-> {:user_id    api/*current-user-id*}
+                                            state (assoc :state state))))
+    ;; NOTE: this will need to be constrained at some point, see BOT-386
+    (t2/insert! :model/MetabotMessage
+                (cond-> {:conversation_id conversation-id
+                         :data            messages
+                         :usage           (:usage finish)
+                         :role            (:role (first messages))
+                         :profile_id      profile-id
+                         :total_tokens    (->> (vals (:usage finish))
+                                               ;; NOTE: this filter is supporting backward-compatible usage format, can be
+                                               ;; removed when ai-service does not give us `completionTokens` in `usage`
+                                               (filter map?)
+                                               (map #(+ (:prompt %) (:completion %)))
+                                               (apply +))}
+                  slack-msg-id (assoc :slack_msg_id slack-msg-id)))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
@@ -7,6 +7,7 @@
    [metabase-enterprise.metabot-v3.api.slackbot :as slackbot]
    [metabase-enterprise.metabot-v3.api.slackbot.client :as slackbot.client]
    [metabase-enterprise.metabot-v3.api.slackbot.config :as slackbot.config]
+   [metabase-enterprise.metabot-v3.api.slackbot.persistence :as slackbot.persistence]
    [metabase-enterprise.metabot-v3.api.slackbot.query :as slackbot.query]
    [metabase-enterprise.metabot-v3.api.slackbot.streaming :as slackbot.streaming]
    [metabase-enterprise.metabot-v3.api.slackbot.uploads :as slackbot.uploads]
@@ -22,7 +23,8 @@
    [metabase.upload.impl :as upload.impl]
    [metabase.util :as u]
    [metabase.util.encryption :as encryption]
-   [metabase.util.json :as json]))
+   [metabase.util.json :as json]
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -238,13 +240,18 @@
        (fn [opts]
          (swap! ai-request-calls conj opts)
          ;; Generate AISDK-format lines from text and data-parts
-         (let [text-lines (when ai-text [(str "0:" (json/encode ai-text))])
-               data-lines (map #(str "2:" (json/encode %)) data-parts)
-               mock-lines (vec (concat text-lines data-lines))]
+         (let [text-lines   (when ai-text [(str "0:" (json/encode ai-text))])
+               data-lines   (map #(str "2:" (json/encode %)) data-parts)
+               finish-line  (str "d:" (json/encode {:finishReason "stop"
+                                                    :usage        {"model" {:prompt 10 :completion 5}}}))
+               mock-lines   (vec (concat text-lines data-lines [finish-line]))]
            ;; Call on-line callback for each line if provided
            (when-let [on-line (:on-line opts)]
              (doseq [line mock-lines]
                (on-line line)))
+           ;; Call on-complete callback with collected lines
+           (when-let [on-complete (:on-complete opts)]
+             (on-complete mock-lines))
            mock-lines))
        slackbot.query/generate-card-output     (fn [card-id]
                                                  (swap! generate-card-output-calls conj {:card-id card-id})
@@ -442,6 +449,33 @@
                        (get-in opts [:message :content])))
                 (is (vector? (:history opts)))
                 (is (fn? (:on-line opts)))))))))))
+
+(deftest slack-msg-id-stored-test
+  (testing "User and bot messages are stored with their Slack ts as slack_msg_id"
+    (with-slackbot-setup
+      ;; Text must be > 50 chars to trigger stream start via request-flush!
+      (let [event-ts  "1709567890.000001"
+            long-text (apply str (repeat 60 "x"))]
+        (with-slackbot-mocks
+          {:ai-text long-text}
+          (fn [{:keys [stop-stream-calls]}]
+            (mt/with-model-cleanup [:model/MetabotMessage
+                                    [:model/MetabotConversation :created_at]]
+              (let [event (assoc-in base-dm-event [:event :ts] event-ts)]
+                (mt/client :post 200 "ee/metabot-v3/slack/events"
+                           (slack-request-options event) event)
+                (u/poll {:thunk #(>= (count @stop-stream-calls) 1)
+                         :done? true?
+                         :timeout-ms 5000})
+                ;; Filter by expected slack_msg_ids to avoid picking up messages from other tests
+                (let [user-msg (t2/select-one :model/MetabotMessage :slack_msg_id event-ts)
+                      bot-msg  (t2/select-one :model/MetabotMessage :slack_msg_id "stream123")]
+                  (testing "user message has event ts"
+                    (is (some? user-msg))
+                    (is (= event-ts (:slack_msg_id user-msg))))
+                  (testing "bot message has stream ts"
+                    (is (some? bot-msg))
+                    (is (= "stream123" (:slack_msg_id bot-msg)))))))))))))
 
 (deftest ^:parallel slack-thread-conversation-id-test
   (testing "Same thread produces same conversation ID"
@@ -1225,6 +1259,84 @@
         (is (str/includes? (:content (first result)) "Product"))
         (is (str/includes? (:content (first result)) "Widget"))
         (is (str/includes? (:content (first result)) "$100")))))
+
+;; -------------------------------- thread->history Unit Tests --------------------------------
+
+(deftest thread->history-strips-bot-mentions-test
+  (testing "User messages have bot mentions stripped"
+    (with-redefs [slackbot.persistence/message-history (constantly {})]
+      (let [thread {:messages [{:ts "1709567890.000001" :text "<@UBOT123> hello" :user "U123"}]}
+            result (#'slackbot.streaming/thread->history thread "UBOT123" "conv-123")]
+        (is (= [{:role :user :content "hello"}] result))))))
+
+(deftest thread->history-merges-tool-calls-test
+  (testing "Bot messages include tool call data from DB before text"
+    (with-redefs [slackbot.persistence/message-history
+                  (constantly {"1709567890.000002"
+                               [{:role :assistant :tool_calls [{:id "tc1" :name "run_query"}]}
+                                {:role :tool :tool_call_id "tc1" :content "42"}]})]
+      (let [thread {:messages [{:ts "1709567890.000002" :text "The answer is 42" :bot_id "B123"}]}
+            result (#'slackbot.streaming/thread->history thread "UBOT123" "conv-123")]
+        (is (= 3 (count result)))
+        (is (= [{:id "tc1" :name "run_query"}] (:tool_calls (first result))))
+        (is (= "tc1" (:tool_call_id (second result))))
+        (is (= {:role :assistant :content "The answer is 42"} (last result)))))))
+
+(deftest thread->history-excludes-thinking-test
+  (testing "Thinking placeholder messages are excluded from history"
+    (with-redefs [slackbot.persistence/message-history (constantly {})]
+      (let [thread {:messages [{:ts "1709567890.000001" :text "question" :user "U123"}
+                               {:ts "1709567890.000002" :text "_Thinking..._" :bot_id "B123"}]}
+            result (#'slackbot.streaming/thread->history thread "UBOT123" "conv-123")]
+        (is (= 1 (count result)))
+        (is (= :user (:role (first result))))))))
+
+(deftest thread->history-excludes-blank-bot-messages-test
+  (testing "Bot messages with blank text are excluded"
+    (with-redefs [slackbot.persistence/message-history (constantly {})]
+      (let [thread {:messages [{:ts "1709567890.000001" :text "" :bot_id "B123"}
+                               {:ts "1709567890.000002" :text "   " :bot_id "B123"}
+                               {:ts "1709567890.000003" :text "real" :bot_id "B123"}]}
+            result (#'slackbot.streaming/thread->history thread "UBOT123" "conv-123")]
+        (is (= [{:role :assistant :content "real"}] result))))))
+
+;; -------------------------------- Message Persistence Tests --------------------------------
+
+(deftest message-history-test
+  (let [conv-id (str (random-uuid))]
+    (mt/with-model-cleanup [:model/MetabotMessage [:model/MetabotConversation :created_at]]
+      (t2/insert! :model/MetabotConversation {:id conv-id :user_id (mt/user->id :rasta)})
+      ;; User message - should be excluded (query filters by role=assistant)
+      (t2/insert! :model/MetabotMessage
+                  {:conversation_id conv-id
+                   :slack_msg_id    "1709567890.000001"
+                   :role            "user"
+                   :profile_id      "test"
+                   :total_tokens    0
+                   :data            [{:_type "TEXT" :role "user" :content "what is 2+2?"}]})
+      ;; Assistant message with tool calls
+      (t2/insert! :model/MetabotMessage
+                  {:conversation_id conv-id
+                   :slack_msg_id    "1709567890.000002"
+                   :role            "assistant"
+                   :profile_id      "test"
+                   :total_tokens    10
+                   :data            [{:_type "TEXT" :role "assistant" :content "hi"}
+                                     {:_type "TOOL_CALL" :role "assistant" :tool_calls [{:id "x"}]}
+                                     {:_type "TOOL_RESULT" :role "tool" :tool_call_id "x" :content "y"}]})
+
+      (testing "only TOOL_CALL and TOOL_RESULT are included, TEXT is filtered out"
+        (let [result (slackbot.persistence/message-history conv-id #{"1709567890.000002"})]
+          (is (= 2 (count (get result "1709567890.000002"))))
+          (is (every? #(#{:assistant :tool} (:role %)) (get result "1709567890.000002")))))
+
+      (testing "user messages are excluded, only assistant role is queried"
+        (let [result (slackbot.persistence/message-history conv-id #{"1709567890.000001"})]
+          (is (empty? result))))
+
+      (testing "non-matching slack_msg_ids return empty map"
+        (let [result (slackbot.persistence/message-history conv-id #{"nonexistent-id"})]
+          (is (empty? result)))))))
 
 ;; -------------------------------- PUT /slack/settings Tests --------------------------------
 

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api_test.clj
@@ -6,9 +6,9 @@
    [clojure.test :refer :all]
    [compojure.response]
    [medley.core :as m]
-   [metabase-enterprise.metabot-v3.api :as api]
    [metabase-enterprise.metabot-v3.client :as client]
    [metabase-enterprise.metabot-v3.client-test :as client-test]
+   [metabase-enterprise.metabot-v3.persistence :as persistence]
    [metabase-enterprise.metabot-v3.util :as metabot.u]
    [metabase.search.test-util :as search.tu]
    [metabase.server.instance :as server.instance]
@@ -100,8 +100,8 @@
         (search.tu/with-index-disabled
           (mt/with-premium-features #{:metabot-v3}
             (with-redefs [client/ai-url      (constantly ai-url)
-                          api/store-message! (fn [_conv-id _prof-id msgs]
-                                               (reset! messages msgs))
+                          persistence/store-message! (fn [_conv-id _prof-id msgs]
+                                                       (reset! messages msgs))
                           sr/async-cancellation-poll-interval-ms 5]
               (testing "Closing body stream drops connection"
                 (let [body (mt/user-real-request :rasta :post 202 "ee/metabot-v3/agent-streaming"

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/client_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/client_test.clj
@@ -145,6 +145,24 @@
               (is (sequential? lines))
               (is (= lines @error-lines)))))))))
 
+(deftest streaming-request-with-callback-on-complete-test
+  (mt/with-premium-features #{:metabot-v3}
+    (let [mock-response (make-mock-text-stream-response ["a" "b"] {"m" {:prompt 1 :completion 1}})
+          req           {:context {} :message {:role :user :content "x"} :history []
+                         :profile-id "p" :conversation-id (str (random-uuid))
+                         :session-id "s" :state {}}]
+      (testing "on-complete receives collected lines"
+        (mt/with-dynamic-fn-redefs [http/post (mock-post! mock-response)]
+          (mt/with-current-user (mt/user->id :crowberto)
+            (let [result (atom nil)
+                  lines  (metabot-v3.client/streaming-request-with-callback
+                          (assoc req :on-complete #(reset! result %)))]
+              (is (= lines @result))))))
+      (testing "works without on-complete"
+        (mt/with-dynamic-fn-redefs [http/post (mock-post! mock-response)]
+          (mt/with-current-user (mt/user->id :crowberto)
+            (is (sequential? (metabot-v3.client/streaming-request-with-callback req)))))))))
+
 (deftest streaming-request-error-excludes-headers-test
   (testing "When streaming-request gets an error response, the exception should not include headers"
     (mt/with-premium-features #{:metabot-v3}

--- a/resources/migrations/059_update_migrations.yaml
+++ b/resources/migrations/059_update_migrations.yaml
@@ -3606,7 +3606,7 @@ databaseChangeLog:
               );
 
   - changeSet:
-      id: v59.2026-03-03T10:00:00
+      id: v59.2026-03-04T10:00:00
       author: sloan
       comment: Add slack_msg_id to metabot_message for tracking Slack message IDs
       changes:

--- a/resources/migrations/059_update_migrations.yaml
+++ b/resources/migrations/059_update_migrations.yaml
@@ -3574,6 +3574,21 @@ databaseChangeLog:
             path: instance_analytics_views/query_log/v2/h2-query_log.sql
             relativeToChangelogFile: true
 
+  - changeSet:
+      id: v59.2026-03-03T10:00:00
+      author: sloan
+      comment: Add slack_msg_id to metabot_message for tracking Slack message IDs
+      changes:
+        - addColumn:
+            tableName: metabot_message
+            columns:
+              - column:
+                  name: slack_msg_id
+                  type: varchar(255)
+                  remarks: Slack message ID (ts) for correlating with Slack thread history
+                  constraints:
+                    nullable: true
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################


### PR DESCRIPTION
Closes [BOT-1072](https://linear.app/metabase/issue/BOT-1072/enrich-slack-threads-with-metabot-message-context-before-making-agent)

### Description

This PR leverages the `metabot_message` table and adds any tool calls made by the agent back to the related slack messages. This required adding a new column to this table, so we can do look ups by the slack message id.

This seems to fix our issue with the agent no longer trying to issues queries as would think it had successfully done this before without using any tools, only showing the user a link.

### Demo

<img width="2638" height="6934" alt="CleanShot 2026-03-04 at 17 27 36@2x" src="https://github.com/user-attachments/assets/9dc333b5-bc37-4cc7-bab1-63206f574c22" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
