### PR TITLE
Ensure we respect slack api rate limits

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/streaming.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/streaming.clj
@@ -361,18 +361,17 @@
                            :team_id   team-id
                            :user_id   user-id}
 
-        last-flush-at  (volatile! 0)
+        last-flush-timer (volatile! (u/start-timer))
 
-        request-flush! (fn do-request-flush
-                         ([] (do-request-flush false))
-                         ([force?]
-                          (ensure-stream-started! client stream-opts stream-attempted? stream-state)
-                          (when @stream-state
-                            (let [elapsed (- (System/currentTimeMillis) @last-flush-at)]
-                              (when (or force? (>= elapsed min-flush-interval-ms))
-                                (vreset! last-flush-at (System/currentTimeMillis))
-                                (send-off slack-writer
-                                          (fn [_] (drain-pending-text! client stream-state pending-text thinking-ts) nil)))))))
+        request-flush!  (fn do-request-flush
+                          ([] (do-request-flush false))
+                          ([force?]
+                           (ensure-stream-started! client stream-opts stream-attempted? stream-state)
+                           (when @stream-state
+                             (when (or force? (>= (u/since-ms @last-flush-timer) min-flush-interval-ms))
+                               (vreset! last-flush-timer (u/start-timer))
+                               (send-off slack-writer
+                                         (fn [_] (drain-pending-text! client stream-state pending-text thinking-ts) nil))))))
 
         start-with-thinking! (fn []
                                (let [response (slackbot.client/post-message client {:channel   channel

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/streaming.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/streaming.clj
@@ -144,11 +144,11 @@
   "Minimum characters to accumulate before considering a flush."
   250)
 
-(def ^:private min-flush-interval-ns
-  "Minimum nanoseconds between consecutive text flushes to Slack.
+(def ^:private min-flush-interval-ms
+  "Minimum milliseconds between consecutive text flushes to Slack.
    At Slack's rate limit of ~100 calls/minute, 600ms spacing leaves
    headroom for tool-update and other non-text API calls."
-  (* 600 1000 1000))
+  600)
 
 (defn- make-streaming-ai-request
   "Make a streaming AI request with callbacks for each message type.
@@ -368,9 +368,9 @@
                          ([force?]
                           (ensure-stream-started! client stream-opts stream-attempted? stream-state)
                           (when @stream-state
-                            (let [elapsed (- (System/nanoTime) @last-flush-at)]
-                              (when (or force? (>= elapsed min-flush-interval-ns))
-                                (vreset! last-flush-at (System/nanoTime))
+                            (let [elapsed (- (System/currentTimeMillis) @last-flush-at)]
+                              (when (or force? (>= elapsed min-flush-interval-ms))
+                                (vreset! last-flush-at (System/currentTimeMillis))
                                 (send-off slack-writer
                                           (fn [_] (drain-pending-text! client stream-state pending-text thinking-ts) nil)))))))
 

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/streaming.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/streaming.clj
@@ -142,7 +142,13 @@
 
 (def ^:private min-text-batch-size
   "Minimum characters to accumulate before considering a flush."
-  50)
+  250)
+
+(def ^:private min-flush-interval-ns
+  "Minimum nanoseconds between consecutive text flushes to Slack.
+   At Slack's rate limit of ~100 calls/minute, 600ms spacing leaves
+   headroom for tool-update and other non-text API calls."
+  (* 600 1000 1000))
 
 (defn- make-streaming-ai-request
   "Make a streaming AI request with callbacks for each message type.
@@ -355,12 +361,18 @@
                            :team_id   team-id
                            :user_id   user-id}
 
-        ;; Schedule an agent drain. Cheap to call frequently — if the agent is already busy,
-        ;; text just accumulates in pending-text and gets coalesced into the next drain.
-        request-flush! (fn []
-                         (ensure-stream-started! client stream-opts stream-attempted? stream-state)
-                         (when @stream-state
-                           (send-off slack-writer (fn [_] (drain-pending-text! client stream-state pending-text thinking-ts) nil))))
+        last-flush-at  (volatile! 0)
+
+        request-flush! (fn do-request-flush
+                         ([] (do-request-flush false))
+                         ([force?]
+                          (ensure-stream-started! client stream-opts stream-attempted? stream-state)
+                          (when @stream-state
+                            (let [elapsed (- (System/nanoTime) @last-flush-at)]
+                              (when (or force? (>= elapsed min-flush-interval-ns))
+                                (vreset! last-flush-at (System/nanoTime))
+                                (send-off slack-writer
+                                          (fn [_] (drain-pending-text! client stream-state pending-text thinking-ts) nil)))))))
 
         start-with-thinking! (fn []
                                (let [response (slackbot.client/post-message client {:channel   channel
@@ -462,40 +474,40 @@
                                            :thread-ts thread-ts
                                            :team-id   (:team_id auth-info)
                                            :user-id   (:user event)})]
-     (start-with-thinking!)
-     (let [conversation-id (slack-thread->conversation-id (:team_id auth-info) channel thread-ts)]
-       (letfn [(send-fallback [text]
-                 (slackbot.client/post-message client (merge message-ctx {:text text})))]
-         (try
-           (let [_data-parts (make-streaming-ai-request
-                              conversation-id
-                              prompt
-                              thread
-                              bot-user-id
-                              channel-id
-                              extra-history
-                              {:on-text               on-text
-                               :on-tool-start         on-tool-start
-                               :on-tool-end           on-tool-end
-                               :on-data               on-data
-                               :req-slack-msg-id      (:ts event)
-                               :get-res-slack-msg-id  (fn [] (:stream_ts @stream-state))})]
-             (request-flush!)
-             (await slack-writer)
-             (if-let [{:keys [stream_ts channel]} @stream-state]
-               (do
-                 (slackbot.client/stop-stream client channel stream_ts (feedback-blocks conversation-id))
-                 (send-visualizations! client channel thread-ts @prefetched-viz))
-               (send-fallback "I wasn't able to generate a response. Please try again.")))
-           (catch Exception e
-             (run! #(.cancel ^Future (:future %) true) (vals @prefetched-viz))
-             (log/error e "[slackbot] Error in streaming response")
-             (await slack-writer)
-             (if-let [{:keys [stream_ts channel]} @stream-state]
-               (try
-                 (slackbot.client/append-markdown-text client channel stream_ts
-                                                       "\nSomething went wrong. Please try again.")
-                 (slackbot.client/stop-stream client channel stream_ts)
-                 (catch Exception stop-e
-                   (log/debug stop-e "[slackbot] Failed to stop stream during error cleanup")))
-               (send-fallback "Something went wrong. Please try again.")))))))))
+    (start-with-thinking!)
+    (let [conversation-id (slack-thread->conversation-id (:team_id auth-info) channel thread-ts)]
+      (letfn [(send-fallback [text]
+                (slackbot.client/post-message client (merge message-ctx {:text text})))]
+        (try
+          (let [_data-parts (make-streaming-ai-request
+                             conversation-id
+                             prompt
+                             thread
+                             bot-user-id
+                             channel-id
+                             extra-history
+                             {:on-text              on-text
+                              :on-tool-start        on-tool-start
+                              :on-tool-end          on-tool-end
+                              :on-data              on-data
+                              :req-slack-msg-id     (:ts event)
+                              :get-res-slack-msg-id (fn [] (:stream_ts @stream-state))})]
+            (request-flush! true)
+            (await slack-writer)
+            (if-let [{:keys [stream_ts channel]} @stream-state]
+              (do
+                (slackbot.client/stop-stream client channel stream_ts (feedback-blocks conversation-id))
+                (send-visualizations! client channel thread-ts @prefetched-viz))
+              (send-fallback "I wasn't able to generate a response. Please try again.")))
+          (catch Exception e
+            (run! #(.cancel ^Future (:future %) true) (vals @prefetched-viz))
+            (log/error e "[slackbot] Error in streaming response")
+            (await slack-writer)
+            (if-let [{:keys [stream_ts channel]} @stream-state]
+              (try
+                (slackbot.client/append-markdown-text client channel stream_ts
+                                                      "\nSomething went wrong. Please try again.")
+                (slackbot.client/stop-stream client channel stream_ts)
+                (catch Exception stop-e
+                  (log/debug stop-e "[slackbot] Failed to stop stream during error cleanup")))
+              (send-fallback "Something went wrong. Please try again."))))))))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/streaming.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/streaming.clj
@@ -361,17 +361,20 @@
                            :team_id   team-id
                            :user_id   user-id}
 
-        last-flush-timer (volatile! (u/start-timer))
+        ;; Nil means "no flush has happened yet", so the first flush should always pass.
+        last-flush-timer (volatile! nil)
 
         request-flush!  (fn do-request-flush
                           ([] (do-request-flush false))
                           ([force?]
                            (ensure-stream-started! client stream-opts stream-attempted? stream-state)
                            (when @stream-state
-                             (when (or force? (>= (u/since-ms @last-flush-timer) min-flush-interval-ms))
+                             (when (or force?
+                                       (nil? @last-flush-timer)
+                                       (>= (u/since-ms @last-flush-timer) min-flush-interval-ms))
                                (vreset! last-flush-timer (u/start-timer))
                                (send-off slack-writer
-                                         (fn [_] (drain-pending-text! client stream-state pending-text thinking-ts) nil))))))
+                                         (bound-fn* (fn [_] (drain-pending-text! client stream-state pending-text thinking-ts) nil)))))))
 
         start-with-thinking! (fn []
                                (let [response (slackbot.client/post-message client {:channel   channel
@@ -421,11 +424,11 @@
                               :filename filename
                               :title    title
                               :link     link}))))]
-    {:on-text              on-text
+    {:on-text              (bound-fn* on-text)
      :on-tool-start        on-tool-start
      :on-tool-end          on-tool-end
      :on-data              on-data
-     :request-flush!       request-flush!
+     :request-flush!       (bound-fn* request-flush!)
      :start-with-thinking! start-with-thinking!
      :stream-state         stream-state
      :slack-writer         slack-writer
@@ -478,6 +481,8 @@
        (letfn [(send-fallback [text]
                  (slackbot.client/post-message client (merge message-ctx {:text text})))]
          (try
+           ;; Start stream early so assistant persistence has :slack_msg_id.
+           (request-flush! true)
            (let [_data-parts (make-streaming-ai-request
                               conversation-id
                               prompt

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/streaming.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/streaming.clj
@@ -474,40 +474,40 @@
                                            :thread-ts thread-ts
                                            :team-id   (:team_id auth-info)
                                            :user-id   (:user event)})]
-    (start-with-thinking!)
-    (let [conversation-id (slack-thread->conversation-id (:team_id auth-info) channel thread-ts)]
-      (letfn [(send-fallback [text]
-                (slackbot.client/post-message client (merge message-ctx {:text text})))]
-        (try
-          (let [_data-parts (make-streaming-ai-request
-                             conversation-id
-                             prompt
-                             thread
-                             bot-user-id
-                             channel-id
-                             extra-history
-                             {:on-text              on-text
-                              :on-tool-start        on-tool-start
-                              :on-tool-end          on-tool-end
-                              :on-data              on-data
-                              :req-slack-msg-id     (:ts event)
-                              :get-res-slack-msg-id (fn [] (:stream_ts @stream-state))})]
-            (request-flush! true)
-            (await slack-writer)
-            (if-let [{:keys [stream_ts channel]} @stream-state]
-              (do
-                (slackbot.client/stop-stream client channel stream_ts (feedback-blocks conversation-id))
-                (send-visualizations! client channel thread-ts @prefetched-viz))
-              (send-fallback "I wasn't able to generate a response. Please try again.")))
-          (catch Exception e
-            (run! #(.cancel ^Future (:future %) true) (vals @prefetched-viz))
-            (log/error e "[slackbot] Error in streaming response")
-            (await slack-writer)
-            (if-let [{:keys [stream_ts channel]} @stream-state]
-              (try
-                (slackbot.client/append-markdown-text client channel stream_ts
-                                                      "\nSomething went wrong. Please try again.")
-                (slackbot.client/stop-stream client channel stream_ts)
-                (catch Exception stop-e
-                  (log/debug stop-e "[slackbot] Failed to stop stream during error cleanup")))
-              (send-fallback "Something went wrong. Please try again."))))))))
+     (start-with-thinking!)
+     (let [conversation-id (slack-thread->conversation-id (:team_id auth-info) channel thread-ts)]
+       (letfn [(send-fallback [text]
+                 (slackbot.client/post-message client (merge message-ctx {:text text})))]
+         (try
+           (let [_data-parts (make-streaming-ai-request
+                              conversation-id
+                              prompt
+                              thread
+                              bot-user-id
+                              channel-id
+                              extra-history
+                              {:on-text              on-text
+                               :on-tool-start        on-tool-start
+                               :on-tool-end          on-tool-end
+                               :on-data              on-data
+                               :req-slack-msg-id     (:ts event)
+                               :get-res-slack-msg-id (fn [] (:stream_ts @stream-state))})]
+             (request-flush! true)
+             (await slack-writer)
+             (if-let [{:keys [stream_ts channel]} @stream-state]
+               (do
+                 (slackbot.client/stop-stream client channel stream_ts (feedback-blocks conversation-id))
+                 (send-visualizations! client channel thread-ts @prefetched-viz))
+               (send-fallback "I wasn't able to generate a response. Please try again.")))
+           (catch Exception e
+             (run! #(.cancel ^Future (:future %) true) (vals @prefetched-viz))
+             (log/error e "[slackbot] Error in streaming response")
+             (await slack-writer)
+             (if-let [{:keys [stream_ts channel]} @stream-state]
+               (try
+                 (slackbot.client/append-markdown-text client channel stream_ts
+                                                       "\nSomething went wrong. Please try again.")
+                 (slackbot.client/stop-stream client channel stream_ts)
+                 (catch Exception stop-e
+                   (log/debug stop-e "[slackbot] Failed to stop stream during error cleanup")))
+               (send-fallback "Something went wrong. Please try again.")))))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
@@ -1694,3 +1694,62 @@
           @result
           (is (= 1 (count @harbormaster-calls)))
           (is (= "ui-bug" (get-in (first @harbormaster-calls) [:feedback :issue_type]))))))))
+
+;;; ------------------------------------------------ Flush throttle tests ------------------------------------------------
+
+(defn- make-test-callbacks
+  "Create streaming callbacks with mocked Slack client functions.
+   Returns the callbacks map plus atoms tracking append calls."
+  []
+  (let [append-calls (atom [])
+        client       {:token "xoxb-test"}]
+    (mt/with-dynamic-fn-redefs
+      [slackbot.client/start-stream         (fn [_ opts]
+                                              {:stream_ts "s1" :channel (:channel opts) :thread_ts (:thread_ts opts)})
+       slackbot.client/append-stream        (constantly {:ok true})
+       slackbot.client/append-markdown-text (fn [_ _ _ text]
+                                              (swap! append-calls conj text)
+                                              {:ok true})
+       slackbot.client/delete-message       (constantly {:ok true})]
+      (let [cbs (#'slackbot.streaming/make-streaming-callbacks
+                 client {:channel "C1" :thread-ts "t1" :team-id "T1" :user-id "U1"})]
+        {:cbs          cbs
+         :append-calls append-calls}))))
+
+(deftest ^:parallel on-text-respects-batch-size-test
+  (testing "on-text does not flush until pending text reaches min-text-batch-size"
+    (let [{:keys [cbs append-calls]} (make-test-callbacks)
+          {:keys [on-text request-flush! slack-writer]} cbs
+          batch-size @#'slackbot.streaming/min-text-batch-size]
+      ;; Send text just under the threshold — should not trigger a flush
+      (on-text (apply str (repeat (dec batch-size) "a")))
+      (await slack-writer)
+      (is (= 0 (count @append-calls))
+          "No flush should occur when text is under the batch size threshold")
+      ;; Push over the threshold
+      (on-text "ab")
+      (await slack-writer)
+      (is (= 1 (count @append-calls))
+          "Flush should occur once text crosses the batch size threshold")
+      ;; Force-flush to clean up
+      (request-flush! true)
+      (await slack-writer))))
+
+(deftest ^:parallel flush-throttle-test
+  (testing "rapid flushes are throttled by min-flush-interval-ns"
+    (let [{:keys [cbs append-calls]} (make-test-callbacks)
+          {:keys [on-text request-flush! slack-writer]} cbs
+          batch-size @#'slackbot.streaming/min-text-batch-size
+          big-text   (apply str (repeat (inc batch-size) "x"))]
+      ;; First flush should go through immediately (last-flush-at starts at 0)
+      (on-text big-text)
+      (await slack-writer)
+      (is (= 1 (count @append-calls)) "First flush should succeed immediately")
+      ;; Second flush right after should be throttled
+      (on-text big-text)
+      (await slack-writer)
+      (is (= 1 (count @append-calls)) "Second flush should be throttled")
+      ;; Force flush bypasses throttle
+      (request-flush! true)
+      (await slack-writer)
+      (is (= 2 (count @append-calls)) "Force flush should bypass throttle"))))


### PR DESCRIPTION
- Gate flushes by time since the last flush so we hit the Slack API at least 600ms apart
- Increases minimum batch size to 250 chars