### PR TITLE
chore: drop unnecessary react imports

### DIFF
--- a/enterprise/frontend/src/embedding/data-picker/DataSelectorSectionHeader/DataSelectorSectionHeader.tsx
+++ b/enterprise/frontend/src/embedding/data-picker/DataSelectorSectionHeader/DataSelectorSectionHeader.tsx
@@ -1,5 +1,3 @@
-import type * as React from "react";
-
 import { Box, Flex } from "metabase/ui";
 
 import DataSelectorSectionHeaderS from "./DataSelectorSectionHeader.module.css";

--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/components/EditSandboxingModal/EditSandboxingModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/components/EditSandboxingModal/EditSandboxingModal.tsx
@@ -1,5 +1,4 @@
 import cx from "classnames";
-import type * as React from "react";
 import { useState } from "react";
 import { useAsyncFn } from "react-use";
 import { c, jt, t } from "ttag";

--- a/frontend/src/embedding-sdk-bundle/test/__support__/ui.tsx
+++ b/frontend/src/embedding-sdk-bundle/test/__support__/ui.tsx
@@ -1,5 +1,4 @@
 import { render } from "@testing-library/react";
-import type * as React from "react";
 import _ from "underscore";
 
 import { getStore } from "__support__/entities-store";

--- a/frontend/src/metabase-types/guards/react.ts
+++ b/frontend/src/metabase-types/guards/react.ts
@@ -1,4 +1,3 @@
-import type * as React from "react";
 import * as ReactIs from "react-is";
 
 // checking to see if the `element` is in JSX.IntrinisicElements since they support refs

--- a/frontend/src/metabase/actions/components/ActionViz/ActionDashcardSettings.unit.spec.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/ActionDashcardSettings.unit.spec.tsx
@@ -1,5 +1,4 @@
 import userEvent from "@testing-library/user-event";
-import type * as React from "react";
 
 import {
   setupActionsEndpoints,

--- a/frontend/src/metabase/actions/containers/ActionCreator/ActionCreatorHeader.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/ActionCreatorHeader.tsx
@@ -1,4 +1,3 @@
-import type * as React from "react";
 import { t } from "ttag";
 
 import type { WritebackActionType } from "metabase-types/api";

--- a/frontend/src/metabase/actions/containers/ActionCreator/ActionCreatorView.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/ActionCreatorView.tsx
@@ -1,4 +1,3 @@
-import type * as React from "react";
 import { useCallback, useState } from "react";
 import { t } from "ttag";
 

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/OptionEditor.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/OptionEditor.tsx
@@ -1,4 +1,3 @@
-import type * as React from "react";
 import { useEffect, useState } from "react";
 import { t } from "ttag";
 

--- a/frontend/src/metabase/admin/databases/components/ContentRemovalConfirmation/ContentRemovalConfirmation.tsx
+++ b/frontend/src/metabase/admin/databases/components/ContentRemovalConfirmation/ContentRemovalConfirmation.tsx
@@ -1,4 +1,3 @@
-import type * as React from "react";
 import { useState } from "react";
 import { msgid, ngettext } from "ttag";
 

--- a/frontend/src/metabase/admin/embedding/containers/AdminEmbeddingApp.tsx
+++ b/frontend/src/metabase/admin/embedding/containers/AdminEmbeddingApp.tsx
@@ -1,5 +1,3 @@
-import type * as React from "react";
-
 import { AdminSettingsLayout } from "metabase/common/components/AdminLayout/AdminSettingsLayout";
 
 import { EmbeddingNav } from "../components/EmbeddingNav";

--- a/frontend/src/metabase/admin/people/containers/AdminPeopleApp/AdminPeopleApp.tsx
+++ b/frontend/src/metabase/admin/people/containers/AdminPeopleApp/AdminPeopleApp.tsx
@@ -1,5 +1,3 @@
-import type * as React from "react";
-
 import { AdminSettingsLayout } from "metabase/common/components/AdminLayout/AdminSettingsLayout";
 
 import { PeopleNav } from "../../components/PeopleNav";

--- a/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/AddMappingRow/AddMappingRow.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/AddMappingRow/AddMappingRow.tsx
@@ -1,5 +1,4 @@
 import cx from "classnames";
-import type * as React from "react";
 import { useState } from "react";
 import { t } from "ttag";
 

--- a/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/MappingRow/MappingRow.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/MappingRow/MappingRow.tsx
@@ -1,6 +1,5 @@
 import { useDisclosure } from "@mantine/hooks";
 import cx from "classnames";
-import type * as React from "react";
 import { t } from "ttag";
 import _ from "underscore";
 

--- a/frontend/src/metabase/common/components/AutocompleteInput/AutocompleteInput.tsx
+++ b/frontend/src/metabase/common/components/AutocompleteInput/AutocompleteInput.tsx
@@ -1,4 +1,3 @@
-import type * as React from "react";
 import { useMemo, useRef } from "react";
 
 import { TippyPopoverWithTrigger } from "metabase/common/components/PopoverWithTrigger/TippyPopoverWithTrigger";

--- a/frontend/src/metabase/common/components/EntityMenuTrigger/EntityMenuTrigger.tsx
+++ b/frontend/src/metabase/common/components/EntityMenuTrigger/EntityMenuTrigger.tsx
@@ -1,5 +1,3 @@
-import type * as React from "react";
-
 import { Tooltip } from "metabase/ui";
 
 import type { EntityMenuIconButtonProps } from "./EntityMenuTrigger.styled";

--- a/frontend/src/metabase/common/components/EventSandbox/EventSandbox.tsx
+++ b/frontend/src/metabase/common/components/EventSandbox/EventSandbox.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useMemo } from "react";
-import * as React from "react";
 import _ from "underscore";
 type Options = {
   preventDefault?: boolean;
@@ -123,7 +122,7 @@ export function EventSandbox({
   ]);
 
   return disabled === true ? (
-    <React.Fragment>{children}</React.Fragment>
+    <>{children}</>
   ) : (
     <div className={className} {...sandboxProps}>
       {children}

--- a/frontend/src/metabase/common/components/HelpCard/HelpCard.tsx
+++ b/frontend/src/metabase/common/components/HelpCard/HelpCard.tsx
@@ -1,5 +1,3 @@
-import type * as React from "react";
-
 import {
   CardHeaderLink,
   CardHeaderStatic,

--- a/frontend/src/metabase/common/components/Modal/MaybeOnClickOutsideWrapper.tsx
+++ b/frontend/src/metabase/common/components/Modal/MaybeOnClickOutsideWrapper.tsx
@@ -1,5 +1,3 @@
-import type * as React from "react";
-
 import { OnClickOutsideWrapper } from "metabase/common/components/OnClickOutsideWrapper";
 
 export function MaybeOnClickOutsideWrapper({

--- a/frontend/src/metabase/common/components/PopoverWithTrigger/ControlledPopoverWithTrigger.tsx
+++ b/frontend/src/metabase/common/components/PopoverWithTrigger/ControlledPopoverWithTrigger.tsx
@@ -1,5 +1,4 @@
 import cx from "classnames";
-import type * as React from "react";
 import _ from "underscore";
 
 import type { ITippyPopoverProps } from "metabase/common/components/Popover/TippyPopover";

--- a/frontend/src/metabase/common/components/SegmentedControl/SegmentedControl.tsx
+++ b/frontend/src/metabase/common/components/SegmentedControl/SegmentedControl.tsx
@@ -1,4 +1,3 @@
-import type * as React from "react";
 import { useMemo } from "react";
 import _ from "underscore";
 

--- a/frontend/src/metabase/common/components/SelectList/SelectListItem.tsx
+++ b/frontend/src/metabase/common/components/SelectList/SelectListItem.tsx
@@ -1,5 +1,4 @@
 import cx from "classnames";
-import type * as React from "react";
 import _ from "underscore";
 
 import { Ellipsified } from "metabase/common/components/Ellipsified";

--- a/frontend/src/metabase/common/components/TokenField/TokenField.tsx
+++ b/frontend/src/metabase/common/components/TokenField/TokenField.tsx
@@ -1,5 +1,4 @@
 import cx from "classnames";
-import type * as React from "react";
 import { Component, createRef } from "react";
 import _ from "underscore";
 

--- a/frontend/src/metabase/common/components/Tooltip/Tooltip.tsx
+++ b/frontend/src/metabase/common/components/Tooltip/Tooltip.tsx
@@ -1,6 +1,5 @@
 import * as Tippy from "@tippyjs/react";
 import cx from "classnames";
-import * as React from "react";
 import { useMemo } from "react";
 import * as ReactIs from "react-is";
 
@@ -122,6 +121,6 @@ export function Tooltip({
       />
     );
   } else {
-    return <React.Fragment>{children}</React.Fragment>;
+    return <>{children}</>;
   }
 }

--- a/frontend/src/metabase/common/components/tree/Tree.tsx
+++ b/frontend/src/metabase/common/components/tree/Tree.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useState } from "react";
-import * as React from "react";
 import { usePrevious } from "react-use";
 import _ from "underscore";
 
@@ -73,7 +72,7 @@ function BaseTree<TData = unknown>({
   );
 
   if (data.length === 0) {
-    return <React.Fragment>{emptyState}</React.Fragment>;
+    return <>{emptyState}</>;
   }
 
   return (

--- a/frontend/src/metabase/common/components/tree/VirtualizedTree.tsx
+++ b/frontend/src/metabase/common/components/tree/VirtualizedTree.tsx
@@ -1,7 +1,6 @@
 import { useVirtualizer } from "@tanstack/react-virtual";
 import cx from "classnames";
 import { useCallback, useEffect, useRef, useState } from "react";
-import * as React from "react";
 import { usePrevious } from "react-use";
 
 import type { BoxProps } from "metabase/ui";
@@ -165,7 +164,7 @@ export function VirtualizedTree({
   }, [selectedId, previouslySelectedId, flatItems, virtualizer]);
 
   if (data.length === 0) {
-    return <React.Fragment>{emptyState}</React.Fragment>;
+    return <>{emptyState}</>;
   }
 
   return (

--- a/frontend/src/metabase/common/components/tree/types.ts
+++ b/frontend/src/metabase/common/components/tree/types.ts
@@ -1,5 +1,3 @@
-import type * as React from "react";
-
 import type { IconName, IconProps } from "metabase/ui";
 
 export interface ITreeNodeItem<TData = unknown> {

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarHeader/ClickBehaviorSidebarHeader.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarHeader/ClickBehaviorSidebarHeader.tsx
@@ -1,4 +1,3 @@
-import type * as React from "react";
 import { jt, t } from "ttag";
 
 import { isTableDisplay } from "metabase/lib/click-behavior";

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/SidebarItem/SidebarItem.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/SidebarItem/SidebarItem.tsx
@@ -1,5 +1,4 @@
 import cx from "classnames";
-import type * as React from "react";
 
 import type { IconProps } from "metabase/ui";
 import { Box, Flex, Icon } from "metabase/ui";

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/TableClickBehaviorView/Column.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/TableClickBehaviorView/Column.tsx
@@ -1,4 +1,3 @@
-import type * as React from "react";
 import { jt, msgid, ngettext, t } from "ttag";
 
 import { Dashboards } from "metabase/entities/dashboards";

--- a/frontend/src/metabase/forms/components/FormSection/FormSection.tsx
+++ b/frontend/src/metabase/forms/components/FormSection/FormSection.tsx
@@ -1,5 +1,3 @@
-import type * as React from "react";
-
 import { DisclosureTriangle } from "metabase/common/components/DisclosureTriangle";
 import { useToggle } from "metabase/common/hooks/use-toggle";
 import CS from "metabase/css/core/index.css";

--- a/frontend/src/metabase/hoc/ModalRoute.tsx
+++ b/frontend/src/metabase/hoc/ModalRoute.tsx
@@ -1,6 +1,5 @@
 import type { Location, LocationDescriptor } from "history";
-import { Component } from "react";
-import * as React from "react";
+import { Component, cloneElement } from "react";
 import { Route } from "react-router";
 import { push } from "react-router-redux";
 
@@ -110,7 +109,7 @@ class _ModalRoute extends Route {
     const { modal, modalProps, noWrap } = element.props;
 
     if (modal) {
-      element = React.cloneElement(element, {
+      element = cloneElement(element, {
         component: ModalWithRoute(modal, modalProps, noWrap),
       });
 

--- a/frontend/src/metabase/models/containers/ModelActions/ModelActions.tsx
+++ b/frontend/src/metabase/models/containers/ModelActions/ModelActions.tsx
@@ -1,5 +1,4 @@
 import type { LocationDescriptor } from "history";
-import type * as React from "react";
 import { useEffect, useMemo, useState } from "react";
 import { replace } from "react-router-redux";
 import { useMount } from "react-use";

--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/ListField/ListField.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/ListField/ListField.tsx
@@ -1,4 +1,3 @@
-import type * as React from "react";
 import { useCallback, useMemo, useState } from "react";
 import { t } from "ttag";
 import _ from "underscore";

--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/SingleSelectListField/SingleSelectListField.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/SingleSelectListField/SingleSelectListField.tsx
@@ -1,4 +1,3 @@
-import type * as React from "react";
 import { useMemo, useState } from "react";
 import { t } from "ttag";
 import _ from "underscore";

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorSectionHeader/DataSelectorSectionHeader.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorSectionHeader/DataSelectorSectionHeader.tsx
@@ -1,5 +1,3 @@
-import type * as React from "react";
-
 import { Box, Flex } from "metabase/ui";
 
 import DataSelectorSectionHeaderS from "./DataSelectorSectionHeader.module.css";

--- a/frontend/src/metabase/query_builder/components/LimitInput.tsx
+++ b/frontend/src/metabase/query_builder/components/LimitInput.tsx
@@ -1,5 +1,4 @@
 import cx from "classnames";
-import type * as React from "react";
 
 import ButtonsS from "metabase/css/components/buttons.module.css";
 import CS from "metabase/css/core/index.css";

--- a/frontend/src/metabase/visualizations/components/ClickActions/ClickActionsViewSection.tsx
+++ b/frontend/src/metabase/visualizations/components/ClickActions/ClickActionsViewSection.tsx
@@ -1,5 +1,3 @@
-import type * as React from "react";
-
 import {
   Section,
   SectionTitle,

--- a/frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesSingle.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesSingle.tsx
@@ -1,5 +1,4 @@
 import cx from "classnames";
-import type * as React from "react";
 
 import { ColorSelector } from "metabase/common/components/ColorSelector";
 import CS from "metabase/css/core/index.css";

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
@@ -1,5 +1,4 @@
 import type { EChartsCoreOption, EChartsType } from "echarts/core";
-import type * as React from "react";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 
 import {

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/partitions.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/partitions.tsx
@@ -1,4 +1,3 @@
-import type * as React from "react";
 import { t } from "ttag";
 
 import { isDimension } from "metabase-lib/v1/types/utils/isa";

--- a/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.tsx
@@ -1,4 +1,3 @@
-import type * as React from "react";
 import { useEffect, useMemo } from "react";
 import { t } from "ttag";
 

--- a/frontend/test/__support__/ui.tsx
+++ b/frontend/test/__support__/ui.tsx
@@ -11,7 +11,6 @@ import {
 import type { History } from "history";
 import { createMemoryHistory } from "history";
 import { KBarProvider } from "kbar";
-import type * as React from "react";
 import { useMemo } from "react";
 import { DragDropContextProvider } from "react-dnd";
 import HTML5Backend from "react-dnd-html5-backend";


### PR DESCRIPTION
we already have react types defined globally via `react.d.ts`