### PR TITLE
remove noisy logs from sdk component tests

### DIFF
--- a/e2e/support/component-webpack.config.js
+++ b/e2e/support/component-webpack.config.js
@@ -1,6 +1,7 @@
 const fs = require("fs");
 const path = require("path");
 
+const chalk = require("chalk");
 const webpack = require("webpack");
 
 const {
@@ -14,7 +15,7 @@ const { isEmbeddingSdkPackageInstalled, embeddingSdkPath } =
   resolveEmbeddingSdkPackage();
 
 console.log(
-  `Embedding SDK is ${isEmbeddingSdkPackageInstalled ? "installed" : 'NOT installed, using locally built version from "resources/embedding-sdk"'}`,
+  `Embedding SDK is ${isEmbeddingSdkPackageInstalled ? chalk.green("installed") : `${chalk.red("NOT installed")}, ${chalk.bold("using locally built version")} from "resources/embedding-sdk"'}`}`,
 );
 
 console.log(`Embedding SDK path alias is resolved to ${embeddingSdkPath}`);
@@ -122,7 +123,7 @@ function resolveEmbeddingSdkPackage() {
       };
     }
   } catch (err) {
-    console.log(`Cannot resolve ${SDK_PACKAGE_NAME} via require.resolve:`, err);
+    console.log(`Cannot resolve ${SDK_PACKAGE_NAME} via require.resolve`);
   }
 
   const sdkLocalPackagePath = path.resolve(

--- a/e2e/support/helpers/embedding-sdk-component-testing/component-embedding-sdk-helpers.tsx
+++ b/e2e/support/helpers/embedding-sdk-component-testing/component-embedding-sdk-helpers.tsx
@@ -7,7 +7,6 @@ import React from "react";
 
 import { METABASE_INSTANCE_URL } from "e2e/support/helpers";
 import type { DeepPartial } from "metabase/embedding-sdk/types/utils";
-import { ThemeProvider } from "metabase/ui";
 
 export const DEFAULT_SDK_AUTH_PROVIDER_CONFIG = {
   metabaseInstanceUrl: METABASE_INSTANCE_URL,
@@ -46,17 +45,15 @@ export function mountSdkContent(
   }
 
   const reactNode = (
-    <ThemeProvider>
-      <MetabaseProvider
-        {...sdkProviderProps}
-        authConfig={{
-          ...DEFAULT_SDK_AUTH_PROVIDER_CONFIG,
-          ...sdkProviderProps?.authConfig,
-        }}
-      >
-        {children}
-      </MetabaseProvider>
-    </ThemeProvider>
+    <MetabaseProvider
+      {...sdkProviderProps}
+      authConfig={{
+        ...DEFAULT_SDK_AUTH_PROVIDER_CONFIG,
+        ...sdkProviderProps?.authConfig,
+      }}
+    >
+      {children}
+    </MetabaseProvider>
   );
 
   if (strictMode) {

--- a/e2e/test-component/scenarios/embedding-sdk/content-translations-rerender-reproduction.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/content-translations-rerender-reproduction.cy.spec.tsx
@@ -1,3 +1,4 @@
+import { Flex } from "@mantine/core";
 import { InteractiveQuestion } from "@metabase/embedding-sdk-react";
 
 import { popover } from "e2e/support/helpers";
@@ -8,7 +9,6 @@ import {
   mockAuthProviderAndJwtSignIn,
   signInAsAdminAndEnableEmbeddingSdk,
 } from "e2e/support/helpers/embedding-sdk-testing";
-import { Flex } from "metabase/ui";
 
 describe("scenarios > embedding-sdk > content-translations-rerender-reproduction", () => {
   const setupEditor = () => {

--- a/e2e/test-component/scenarios/embedding-sdk/content-translations-rerender-reproduction.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/content-translations-rerender-reproduction.cy.spec.tsx
@@ -1,4 +1,4 @@
-import { Flex } from "@mantine/core";
+
 import { InteractiveQuestion } from "@metabase/embedding-sdk-react";
 
 import { popover } from "e2e/support/helpers";
@@ -31,9 +31,9 @@ describe("scenarios > embedding-sdk > content-translations-rerender-reproduction
     mockAuthProviderAndJwtSignIn();
 
     mountSdkContent(
-      <Flex p="xl">
+      <div style={{ display: "flex", padding: "20px" }}>
         <InteractiveQuestion questionId="new" />
-      </Flex>,
+      </div>,
       {
         sdkProviderProps: {
           locale: "de",

--- a/e2e/test-component/scenarios/embedding-sdk/content-translations.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/content-translations.cy.spec.tsx
@@ -1,3 +1,4 @@
+import { Flex } from "@mantine/core";
 import {
   CollectionBrowser,
   InteractiveQuestion,
@@ -19,7 +20,6 @@ import {
   mockAuthProviderAndJwtSignIn,
   signInAsAdminAndEnableEmbeddingSdk,
 } from "e2e/support/helpers/embedding-sdk-testing";
-import { Flex } from "metabase/ui";
 import type { Card } from "metabase-types/api";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;

--- a/e2e/test-component/scenarios/embedding-sdk/content-translations.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/content-translations.cy.spec.tsx
@@ -1,4 +1,4 @@
-import { Flex } from "@mantine/core";
+
 import {
   CollectionBrowser,
   InteractiveQuestion,
@@ -120,9 +120,9 @@ describe("scenarios > embedding-sdk > content-translations", () => {
       mockAuthProviderAndJwtSignIn();
 
       mountSdkContent(
-        <Flex p="xl">
+        <div style={{ display: "flex", padding: "20px" }}>
           <InteractiveQuestion questionId="new" />
-        </Flex>,
+        </div>,
         {
           sdkProviderProps: {
             locale: "de",
@@ -677,9 +677,9 @@ describe("scenarios > embedding-sdk > content-translations", () => {
       mockAuthProviderAndJwtSignIn();
 
       mountSdkContent(
-        <Flex p="xl">
+        <div style={{ display: "flex", padding: "20px" }}>
           <InteractiveQuestion questionId="new" />
-        </Flex>,
+        </div>,
         {
           sdkProviderProps: {
             locale: "ar",
@@ -842,12 +842,12 @@ describe("scenarios > embedding-sdk > content-translations", () => {
 
       cy.get("@collectionId").then((collectionId) => {
         mountSdkContent(
-          <Flex p="xl">
+          <div style={{ display: "flex", padding: "20px" }}>
             <CollectionBrowser
               collectionId={collectionId as unknown as number}
               visibleColumns={["type", "name", "description"]}
             />
-          </Flex>,
+          </div>,
           {
             sdkProviderProps: {
               locale: "de",

--- a/e2e/test-component/scenarios/embedding-sdk/create-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/create-question.cy.spec.tsx
@@ -1,3 +1,4 @@
+import { Flex } from "@mantine/core";
 import { InteractiveQuestion } from "@metabase/embedding-sdk-react";
 
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
@@ -18,7 +19,6 @@ import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
 import { mountSdkContent } from "e2e/support/helpers/embedding-sdk-component-testing/component-embedding-sdk-helpers";
 import { signInAsAdminAndEnableEmbeddingSdk } from "e2e/support/helpers/embedding-sdk-testing";
 import { mockAuthProviderAndJwtSignIn } from "e2e/support/helpers/embedding-sdk-testing/embedding-sdk-helpers";
-import { Flex } from "metabase/ui";
 
 const { H } = cy;
 

--- a/e2e/test-component/scenarios/embedding-sdk/create-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/create-question.cy.spec.tsx
@@ -1,4 +1,4 @@
-import { Flex } from "@mantine/core";
+
 import { InteractiveQuestion } from "@metabase/embedding-sdk-react";
 
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
@@ -33,9 +33,9 @@ describe("scenarios > embedding-sdk > interactive-question > creating a question
     cy.intercept("POST", "/api/card").as("createCard");
 
     mountSdkContent(
-      <Flex p="xl">
+      <div style={{ display: "flex", padding: "20px" }}>
         <InteractiveQuestion questionId="new" />
-      </Flex>,
+      </div>,
     );
 
     assertSdkNotebookEditorUsable();
@@ -76,9 +76,9 @@ describe("scenarios > embedding-sdk > interactive-question > creating a question
     mockAuthProviderAndJwtSignIn();
 
     mountSdkContent(
-      <Flex p="xl">
+      <div style={{ display: "flex", padding: "20px" }}>
         <InteractiveQuestion questionId="new" />
-      </Flex>,
+      </div>,
     );
 
     getSdkRoot().within(() => {
@@ -118,9 +118,9 @@ describe("scenarios > embedding-sdk > interactive-question > creating a question
     cy.intercept("POST", "/api/card").as("createCard");
 
     mountSdkContent(
-      <Flex p="xl">
+      <div style={{ display: "flex", padding: "20px" }}>
         <InteractiveQuestion questionId="new" />
-      </Flex>,
+      </div>,
     );
 
     // Wait until the entity picker modal is visible
@@ -186,9 +186,9 @@ describe("scenarios > embedding-sdk > interactive-question > creating a question
 
     cy.log('1. `entityTypes` = ["table"]');
     mountSdkContent(
-      <Flex p="xl">
+      <div style={{ display: "flex", padding: "20px" }}>
         <InteractiveQuestion questionId="new" entityTypes={["table"]} />
-      </Flex>,
+      </div>,
     );
 
     // Wait until the entity picker modal is visible
@@ -202,9 +202,9 @@ describe("scenarios > embedding-sdk > interactive-question > creating a question
 
     cy.log('2. `entityTypes` = ["model"]');
     mountSdkContent(
-      <Flex p="xl">
+      <div style={{ display: "flex", padding: "20px" }}>
         <InteractiveQuestion questionId="new" entityTypes={["model"]} />
-      </Flex>,
+      </div>,
     );
 
     // Wait until the entity picker modal is visible
@@ -218,12 +218,12 @@ describe("scenarios > embedding-sdk > interactive-question > creating a question
 
     cy.log('3. `entityTypes` = ["model", "table]');
     mountSdkContent(
-      <Flex p="xl">
+      <div style={{ display: "flex", padding: "20px" }}>
         <InteractiveQuestion
           questionId="new"
           entityTypes={["model", "table"]}
         />
-      </Flex>,
+      </div>,
     );
 
     // Wait until the entity picker modal is visible
@@ -252,12 +252,12 @@ describe("scenarios > embedding-sdk > interactive-question > creating a question
       cy.intercept("POST", "/api/card").as("createCard");
 
       mountSdkContent(
-        <Flex p="xl">
+        <div style={{ display: "flex", padding: "20px" }}>
           <InteractiveQuestion
             questionId="new"
             targetCollection={targetCollectionId}
           />
-        </Flex>,
+        </div>,
       );
 
       assertSdkNotebookEditorUsable();
@@ -292,9 +292,9 @@ describe("scenarios > embedding-sdk > interactive-question > creating a question
     mockAuthProviderAndJwtSignIn();
 
     mountSdkContent(
-      <Flex p="xl">
+      <div style={{ display: "flex", padding: "20px" }}>
         <InteractiveQuestion questionId="new" />
-      </Flex>,
+      </div>,
     );
 
     popover().within(() => {

--- a/e2e/test-component/scenarios/embedding-sdk/data-picker.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/data-picker.cy.spec.tsx
@@ -1,3 +1,4 @@
+import { Flex } from "@mantine/core";
 import { InteractiveQuestion } from "@metabase/embedding-sdk-react";
 
 import { popover } from "e2e/support/helpers";
@@ -5,7 +6,6 @@ import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
 import { mountSdkContent } from "e2e/support/helpers/embedding-sdk-component-testing/component-embedding-sdk-helpers";
 import { signInAsAdminAndEnableEmbeddingSdk } from "e2e/support/helpers/embedding-sdk-testing";
 import { mockAuthProviderAndJwtSignIn } from "e2e/support/helpers/embedding-sdk-testing/embedding-sdk-helpers";
-import { Flex } from "metabase/ui";
 
 describe("scenarios > embedding-sdk > interactive-question > creating a question", () => {
   beforeEach(() => {

--- a/e2e/test-component/scenarios/embedding-sdk/data-picker.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/data-picker.cy.spec.tsx
@@ -1,4 +1,4 @@
-import { Flex } from "@mantine/core";
+
 import { InteractiveQuestion } from "@metabase/embedding-sdk-react";
 
 import { popover } from "e2e/support/helpers";
@@ -19,9 +19,9 @@ describe("scenarios > embedding-sdk > interactive-question > creating a question
       cy.intercept("POST", "/api/card").as("createCard");
 
       mountSdkContent(
-        <Flex p="xl">
+        <div style={{ display: "flex", padding: "20px" }}>
           <InteractiveQuestion questionId="new" />
-        </Flex>,
+        </div>,
       );
 
       // Wait until the entity picker modal is visible
@@ -61,9 +61,9 @@ describe("scenarios > embedding-sdk > interactive-question > creating a question
       cy.intercept("POST", "/api/card").as("createCard");
 
       mountSdkContent(
-        <Flex p="xl">
+        <div style={{ display: "flex", padding: "20px" }}>
           <InteractiveQuestion questionId="new" />
-        </Flex>,
+        </div>,
       );
 
       // Wait until the entity picker modal is visible

--- a/e2e/test-component/scenarios/embedding-sdk/interactive-dashboard.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/interactive-dashboard.cy.spec.tsx
@@ -1,4 +1,5 @@
 const { H } = cy;
+import { Stack } from "@mantine/core";
 import {
   InteractiveDashboard,
   InteractiveQuestion,
@@ -16,7 +17,6 @@ import { mountSdkContent } from "e2e/support/helpers/embedding-sdk-component-tes
 import { signInAsAdminAndEnableEmbeddingSdk } from "e2e/support/helpers/embedding-sdk-testing";
 import { mockAuthProviderAndJwtSignIn } from "e2e/support/helpers/embedding-sdk-testing/embedding-sdk-helpers";
 import { defer } from "metabase/lib/promise";
-import { Stack } from "metabase/ui";
 import type {
   ConcreteFieldReference,
   DashboardCard,

--- a/e2e/test-component/scenarios/embedding-sdk/interactive-dashboard.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/interactive-dashboard.cy.spec.tsx
@@ -1,5 +1,5 @@
 const { H } = cy;
-import { Stack } from "@mantine/core";
+
 import {
   InteractiveDashboard,
   InteractiveQuestion,
@@ -86,11 +86,11 @@ describe("scenarios > embedding-sdk > interactive-dashboard", () => {
         <InteractiveDashboard
           dashboardId={dashboardId}
           renderDrillThroughQuestion={() => (
-            <Stack>
+            <div style={{ display: "flex", flexDirection: "column" }}>
               <InteractiveQuestion.Title />
               <InteractiveQuestion.QuestionVisualization />
               <div>This is a custom question layout.</div>
-            </Stack>
+            </div>
           )}
         />,
       );

--- a/e2e/test-component/scenarios/embedding-sdk/sdk-question-native.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/sdk-question-native.cy.spec.tsx
@@ -1,3 +1,4 @@
+import { Box, Button } from "@mantine/core";
 import { InteractiveQuestion } from "@metabase/embedding-sdk-react";
 import { useState } from "react";
 
@@ -14,7 +15,6 @@ import {
 } from "e2e/support/helpers/embedding-sdk-component-testing";
 import { signInAsAdminAndEnableEmbeddingSdk } from "e2e/support/helpers/embedding-sdk-testing";
 import { mockAuthProviderAndJwtSignIn } from "e2e/support/helpers/embedding-sdk-testing/embedding-sdk-helpers";
-import { Box, Button } from "metabase/ui";
 import type { DatasetColumn, TemplateTags } from "metabase-types/api";
 import { createMockParameter } from "metabase-types/api/mocks";
 

--- a/e2e/test-component/scenarios/embedding-sdk/sdk-question-native.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/sdk-question-native.cy.spec.tsx
@@ -1,4 +1,4 @@
-import { Box, Button } from "@mantine/core";
+
 import { InteractiveQuestion } from "@metabase/embedding-sdk-react";
 import { useState } from "react";
 
@@ -86,13 +86,13 @@ describe("scenarios > embedding-sdk > interactive-question > native", () => {
         const [questionId, setQuestionId] = useState<string | number>("new");
 
         return (
-          <Box>
+          <div>
             <InteractiveQuestion questionId={questionId} />
 
-            <Button onClick={() => setQuestionId(nativeQuestionId)}>
+            <button onClick={() => setQuestionId(nativeQuestionId)}>
               use native question
-            </Button>
-          </Box>
+            </button>
+          </div>
         );
       };
 

--- a/e2e/test-component/scenarios/embedding-sdk/sdk-question-theming.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/sdk-question-theming.cy.spec.tsx
@@ -1,3 +1,4 @@
+import { Box } from "@mantine/core";
 import {
   InteractiveQuestion,
   type MetabaseTheme,
@@ -10,7 +11,6 @@ import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
 import { mountSdkContent } from "e2e/support/helpers/embedding-sdk-component-testing";
 import { signInAsAdminAndEnableEmbeddingSdk } from "e2e/support/helpers/embedding-sdk-testing";
 import { mockAuthProviderAndJwtSignIn } from "e2e/support/helpers/embedding-sdk-testing/embedding-sdk-helpers";
-import { Box } from "metabase/ui";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 

--- a/e2e/test-component/scenarios/embedding-sdk/sdk-question-theming.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/sdk-question-theming.cy.spec.tsx
@@ -1,4 +1,4 @@
-import { Box } from "@mantine/core";
+
 import {
   InteractiveQuestion,
   type MetabaseTheme,
@@ -236,9 +236,9 @@ function getColorDifferencePercentage(color1: string, color2: string) {
 function setupInteractiveQuestionWithTheme(theme: MetabaseTheme) {
   cy.get<number>("@questionId").then((questionId) => {
     mountSdkContent(
-      <Box bg={theme.colors?.background} h="100vh">
+      <div style={{ background: theme.colors?.background, height: "100vh" }}>
         <InteractiveQuestion questionId={questionId} />
-      </Box>,
+      </div>,
       { sdkProviderProps: { theme } },
     );
   });

--- a/e2e/test-component/scenarios/embedding-sdk/sdk-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/sdk-question.cy.spec.tsx
@@ -1,3 +1,4 @@
+import { Box, Button, Modal } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
 import {
   InteractiveQuestion,
@@ -30,7 +31,6 @@ import {
 } from "e2e/support/helpers/embedding-sdk-component-testing";
 import { signInAsAdminAndEnableEmbeddingSdk } from "e2e/support/helpers/embedding-sdk-testing";
 import { mockAuthProviderAndJwtSignIn } from "e2e/support/helpers/embedding-sdk-testing/embedding-sdk-helpers";
-import { Box, Button, Modal } from "metabase/ui";
 const { H } = cy;
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;

--- a/e2e/test-component/scenarios/embedding-sdk/sdk-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/sdk-question.cy.spec.tsx
@@ -1,5 +1,3 @@
-import { Box, Button, Modal } from "@mantine/core";
-import { useDisclosure } from "@mantine/hooks";
 import {
   InteractiveQuestion,
   type MetabaseQuestion,
@@ -253,14 +251,14 @@ describe("scenarios > embedding-sdk > interactive-question", () => {
     cy.intercept("POST", "/api/card/*/query").as("cardQuery");
 
     const TestSuiteComponent = ({ questionId }: { questionId: string }) => (
-      <Box p="lg">
+      <div style={{ padding: "16px" }}>
         <InteractiveQuestion questionId={questionId}>
-          <Box>
+          <div>
             <InteractiveQuestion.FilterDropdown />
             <InteractiveQuestion.QuestionVisualization />
-          </Box>
+          </div>
         </InteractiveQuestion>
-      </Box>
+      </div>
     );
 
     cy.get<string>("@questionId").then((questionId) => {
@@ -289,7 +287,9 @@ describe("scenarios > embedding-sdk > interactive-question", () => {
       onBeforeSave,
       onSave,
     }: InteractiveQuestionProps) => {
-      const [isSaveModalOpen, { toggle, close }] = useDisclosure(false);
+      const [isSaveModalOpen, setIsSaveModalOpen] = useState(false);
+      const toggle = () => setIsSaveModalOpen((v) => !v);
+      const close = () => setIsSaveModalOpen(false);
 
       const handleSave = (
         question: MetabaseQuestion | undefined,
@@ -309,14 +309,14 @@ describe("scenarios > embedding-sdk > interactive-question", () => {
           onBeforeSave={onBeforeSave}
           onSave={handleSave}
         >
-          <Box p="lg">
-            <Button onClick={toggle}>Save</Button>
-          </Box>
+          <div style={{ padding: "16px" }}>
+            <button onClick={toggle}>Save</button>
+          </div>
 
           {isSaveModalOpen && (
-            <Modal opened={isSaveModalOpen} onClose={close}>
+            <div role="dialog" data-testid="modal">
               <InteractiveQuestion.SaveQuestionForm onCancel={close} />
-            </Modal>
+            </div>
           )}
 
           {!isSaveModalOpen && <InteractiveQuestion.QuestionVisualization />}
@@ -550,10 +550,10 @@ describe("scenarios > embedding-sdk > interactive-question", () => {
       );
 
       return (
-        <Box>
+        <div>
           <InteractiveQuestion questionId={questionId} />
-          <Button onClick={() => setQuestionId("new")}>New Question</Button>
-        </Box>
+          <button onClick={() => setQuestionId("new")}>New Question</button>
+        </div>
       );
     };
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -462,6 +462,25 @@ const configs = [
     },
   },
   {
+    files: ["e2e/test-component/**/*.ts", "e2e/test-component/**/*.tsx"],
+    rules: {
+      "@typescript-eslint/no-restricted-imports": [
+        "warn",
+        {
+          patterns: [
+            {
+              // There might be things that we might benefit from importing, like `defer`, in those cases we can change the regex here to allow them
+              regex: "^metabase/(?!lib/promise$|embedding-sdk/test/).*",
+              allowTypeImports: true,
+              message:
+                "We should avoid importing `metabase/` code in the component tests, we might accidentally include CLJS in the dependencies and that can create issues. Component tests should only use the code it needs to test, which is in the package.",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
     files: ["frontend/test/**/*"],
     languageOptions: {
       globals: {


### PR DESCRIPTION
Closes [EMB-1373: CI shows MLv1/CLJS build warnings and missing modules](https://linear.app/metabase/issue/EMB-1373/ci-shows-mlv1cljs-build-warnings-and-missing-modules)

### Description

The issue was caused by the component tests importing/rendering code from `metabase/ui`, which is a barrel file that includes some code that end up importing clojurescript code.
This caused the errors and probably also slowed down the test setup too, you might have seen in the cypress console that it was deoptimizing some files because they were too big, those logs should now be gone.

I also changed part of the code we check if the package is installing, we were logging the entire stack track for a managed error. I removed that and used chalk to highlight some parts of the message.

I added a eslint rule to prevent us from importing from `metabase/`, with a couple of exceptions like the defer function that we often use to delay+resume some specific requests.

### How to verify

Look at the logs here: https://github.com/metabase/metabase/actions/runs/22767682728/job/66040841067?pr=70416

### Demo

Before:
Long stacktrace
<img width="1267" height="732" alt="image" src="https://github.com/user-attachments/assets/199a9177-9d0b-4f83-87a6-5357be0cd036" />

Lots of cljs errors
<img width="917" height="1501" alt="image" src="https://github.com/user-attachments/assets/12cac2a8-f830-47b9-aef5-3483ee75d369" />



Now:
No stacktrace
<img width="1060" height="91" alt="image" src="https://github.com/user-attachments/assets/c1ed1137-98f6-497e-a08d-aab265bc8e84" />
No cljs errors
<img width="646" height="398" alt="image" src="https://github.com/user-attachments/assets/488d69c1-1c3b-4f0e-ba16-fbacb8417076" />
