### PR TITLE
fixed table width in guest embed

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/sdk-iframe-embedding.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/sdk-iframe-embedding.cy.spec.ts
@@ -81,6 +81,57 @@ describe("scenarios > embedding > modular embedding", () => {
     });
   });
 
+  it("table visualization should span the full width of the container (metabase#69831)", () => {
+    cy.signInAsAdmin();
+    H.createQuestion({
+      name: "Narrow table question",
+      query: {
+        "source-table": ORDERS_TABLE_ID,
+        fields: [
+          ["field", ORDERS.ID, { "base-type": "type/BigInteger" }],
+          ["field", ORDERS.QUANTITY, { "base-type": "type/Integer" }],
+        ],
+        limit: 5,
+      },
+    }).then(({ body: question }) => {
+      cy.signOut();
+
+      const frame = H.loadSdkIframeEmbedTestPage({
+        elements: [
+          {
+            component: "metabase-question",
+            attributes: {
+              questionId: question.id,
+            },
+          },
+        ],
+      });
+
+      cy.wait("@getCardQuery");
+
+      frame.within(() => {
+        // clientWidth excludes the scrollbar gutter, giving us the actual content area
+        H.tableInteractive()
+          .findByTestId("table-scroll-container")
+          .then(($scrollContainer) => {
+            const contentWidth = $scrollContainer[0].clientWidth;
+
+            const $headerCells = $scrollContainer.find(
+              '[data-testid="header-cell"]',
+            );
+            let totalHeaderWidth = 0;
+            $headerCells.each((_, el) => {
+              totalHeaderWidth += el.getBoundingClientRect().width;
+            });
+
+            expect(Math.round(totalHeaderWidth)).to.be.at.least(
+              Math.round(contentWidth),
+            );
+          });
+      });
+    });
+  });
+
   it("displays a dashboard using entity id", () => {
     const frame = H.loadSdkIframeEmbedTestPage({
       elements: [

--- a/frontend/src/embedding-sdk-bundle/components/public/SdkQuestion/SdkQuestion.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/SdkQuestion/SdkQuestion.unit.spec.tsx
@@ -17,6 +17,7 @@ import {
   act,
   mockGetBoundingClientRect,
   screen,
+  waitFor,
   waitForLoaderToBeRemoved,
   within,
 } from "__support__/ui";
@@ -186,14 +187,18 @@ describe("InteractiveQuestion", () => {
     it("should render loading state when rerunning the query", async () => {
       await setup({ withCustomLayout: true });
 
-      expect(
-        await within(screen.getByTestId("table-root")).findByText(
-          TEST_COLUMN.display_name,
-        ),
-      ).toBeInTheDocument();
-      expect(
-        await within(screen.getByRole("gridcell")).findByText("Test Row"),
-      ).toBeInTheDocument();
+      await waitFor(() => {
+        expect(
+          within(screen.getByTestId("table-root")).getByText(
+            TEST_COLUMN.display_name,
+          ),
+        ).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(
+          within(screen.getByRole("gridcell")).getByText("Test Row"),
+        ).toBeInTheDocument();
+      });
 
       expect(screen.queryByTestId("loading-indicator")).not.toBeInTheDocument();
 
@@ -202,9 +207,11 @@ describe("InteractiveQuestion", () => {
 
       expect(screen.queryByRole("alert")).not.toBeInTheDocument();
       expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
-      expect(
-        within(await screen.findByRole("gridcell")).getByText("Test Row"),
-      ).toBeInTheDocument();
+      await waitFor(() => {
+        expect(
+          within(screen.getByRole("gridcell")).getByText("Test Row"),
+        ).toBeInTheDocument();
+      });
     });
   });
 

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.tsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.tsx
@@ -707,8 +707,8 @@ export const TableInteractiveInner = forwardRef(function TableInteractiveInner(
   }, [height, settings]);
 
   const minGridWidth = useMemo(() => {
-    return isDashcardViewTable ? width : undefined;
-  }, [isDashcardViewTable, width]);
+    return isDashcardViewTable || isEmbeddingSdk ? width : undefined;
+  }, [isDashcardViewTable, isEmbeddingSdk, width]);
 
   const tableProps = useDataGridInstance({
     data: rows,


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #69831
Closes [EMB-1358: Table viz guest embeds don't span the whole width of the component (but static embeds did)](https://linear.app/metabase/issue/EMB-1358/table-viz-guest-embeds-dont-span-the-whole-width-of-the-component-but)

### Description

Checks whether we're in an embedding context before using the full width to render a table

### How to verify

1. Create any table question e.g. "Orders"
2. Share > Embed

<img width="1560" height="282" alt="Image" src="https://github.com/user-attachments/assets/13495173-5858-4636-a613-08ea6f46f25f" />
3. Put the embedding code in your site using the usual Guest embed approach, and also using an iframe on `/embed/question/${token}`:

```js
<script defer src="http://localhost:3073/app/embed.js"></script>
<script>
function defineMetabaseConfig(config) {
  window.metabaseConfig = config;
}
</script>

<script>
  defineMetabaseConfig({
    "isGuest": true,
    "instanceUrl": "http://localhost:3073",
  });
</script>

<h1>Guest embedding</h1>
  <metabase-question token="${token}" with-title="true" with-downloads="false" style="height: 300px;"></metabase-question>
<h1>iframe (static)</h1>
<iframe src="http://localhost:3073/embed/question/${token}" width="100%" height="400px"></iframe>
```

### Demo

<img width="1569" height="826" alt="image" src="https://github.com/user-attachments/assets/2adcfb3b-3ba4-4f82-80a4-fb09d72d8f5e" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
