### PR TITLE
Potential fix for code scanning alert no. 604: Incomplete URL substring sanitization

### DIFF
--- a/frontend/src/metabase/visualizations/components/LeafletMap.tsx
+++ b/frontend/src/metabase/visualizations/components/LeafletMap.tsx
@@ -101,7 +101,12 @@ export class LeafletMap extends Component<LeafletMapProps> {
       try {
         mapTileHostname = new URL(mapTileUrl).host;
       } catch {}
-      const mapTileAttribution = mapTileHostname.includes("openstreetmap.org")
+      const openStreetMapHosts = [
+        "openstreetmap.org",
+        "www.openstreetmap.org",
+        "tile.openstreetmap.org",
+      ];
+      const mapTileAttribution = openStreetMapHosts.includes(mapTileHostname)
         ? 'Map data © <a href="http://openstreetmap.org">OpenStreetMap</a> contributors'
         : undefined;
 


### PR DESCRIPTION
Potential fix for [https://github.com/metabase/metabase/security/code-scanning/604](https://github.com/metabase/metabase/security/code-scanning/604)

In general, this kind of issue is fixed by avoiding substring checks on hostnames and instead performing exact host comparisons (optionally including an explicit list of allowed hosts and subdomains). For this case we only need to decide whether the tile server is the official OSM server; checking against known canonical hostnames is sufficient and keeps behavior predictable.

Concretely, in `frontend/src/metabase/visualizations/components/LeafletMap.tsx`, lines 99–106 compute `mapTileHostname` from the configured URL and then do `mapTileHostname.includes("openstreetmap.org")` to decide whether to set the OpenStreetMap attribution text. Replace the substring check with a whitelist of allowed OSM tile hosts (for example `tile.openstreetmap.org` and `www.openstreetmap.org`, and possibly `openstreetmap.org` itself), using exact equality. This leaves all other behavior unchanged: any non‑OSM host yields `undefined` attribution, as now, but we no longer incorrectly treat arbitrary hosts containing `openstreetmap.org` as OSM.

No new methods or external libraries are needed: we already use the standard `URL` constructor and string comparison. The only code change is the conditional assignment of `mapTileAttribution`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
