### PR TITLE
Fix incomplete URL substring sanitization in LeafletMap

### DIFF
--- a/frontend/src/metabase/visualizations/components/LeafletMap.tsx
+++ b/frontend/src/metabase/visualizations/components/LeafletMap.tsx
@@ -101,7 +101,10 @@ export class LeafletMap extends Component<LeafletMapProps> {
       try {
         mapTileHostname = new URL(mapTileUrl).host;
       } catch {}
-      const mapTileAttribution = mapTileHostname.includes("openstreetmap.org")
+      const isOpenStreetMap =
+        mapTileHostname === "openstreetmap.org" ||
+        mapTileHostname.endsWith(".openstreetmap.org");
+      const mapTileAttribution = isOpenStreetMap
         ? 'Map data © <a href="http://openstreetmap.org">OpenStreetMap</a> contributors'
         : undefined;
 

--- a/frontend/src/metabase/visualizations/components/LeafletMap.tsx
+++ b/frontend/src/metabase/visualizations/components/LeafletMap.tsx
@@ -16,6 +16,17 @@ import type { Series } from "metabase-types/api";
 import type { Point } from "metabase-types/api/dataset";
 import { isObject } from "metabase-types/guards/common";
 
+/**
+ * Checks if a hostname belongs to openstreetmap.org or one of its subdomains.
+ * Uses exact matching to prevent bypass via malicious domains like
+ * "openstreetmap.org.evil.com" or "fake-openstreetmap.org".
+ */
+export function isOpenStreetMapHost(hostname: string): boolean {
+  return (
+    hostname === "openstreetmap.org" || hostname.endsWith(".openstreetmap.org")
+  );
+}
+
 type MapSettings = {
   "map.latitude_column"?: string;
   "map.longitude_column"?: string;
@@ -101,10 +112,7 @@ export class LeafletMap extends Component<LeafletMapProps> {
       try {
         mapTileHostname = new URL(mapTileUrl).host;
       } catch {}
-      const isOpenStreetMap =
-        mapTileHostname === "openstreetmap.org" ||
-        mapTileHostname.endsWith(".openstreetmap.org");
-      const mapTileAttribution = isOpenStreetMap
+      const mapTileAttribution = isOpenStreetMapHost(mapTileHostname)
         ? 'Map data © <a href="http://openstreetmap.org">OpenStreetMap</a> contributors'
         : undefined;
 

--- a/frontend/src/metabase/visualizations/components/LeafletMap.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/LeafletMap.unit.spec.tsx
@@ -10,7 +10,11 @@ import {
   createMockDatasetData,
 } from "metabase-types/api/mocks";
 
-import { LeafletMap, type LeafletMapProps } from "./LeafletMap";
+import {
+  LeafletMap,
+  type LeafletMapProps,
+  isOpenStreetMapHost,
+} from "./LeafletMap";
 
 describe("LeafletMap", () => {
   const createProps = (
@@ -100,5 +104,35 @@ describe("LeafletMap", () => {
       expect(setZoomSpy).toHaveBeenCalled();
       expect(setViewSpy).toHaveBeenCalled();
     });
+  });
+});
+
+describe("isOpenStreetMapHost", () => {
+  it("should return true for openstreetmap.org", () => {
+    expect(isOpenStreetMapHost("openstreetmap.org")).toBe(true);
+  });
+
+  it("should return true for valid subdomains", () => {
+    expect(isOpenStreetMapHost("tile.openstreetmap.org")).toBe(true);
+    expect(isOpenStreetMapHost("a.tile.openstreetmap.org")).toBe(true);
+    expect(isOpenStreetMapHost("b.tile.openstreetmap.org")).toBe(true);
+    expect(isOpenStreetMapHost("c.tile.openstreetmap.org")).toBe(true);
+  });
+
+  it("should return false for domains that contain openstreetmap.org as a substring", () => {
+    expect(isOpenStreetMapHost("fakeopenstreetmap.org")).toBe(false);
+    expect(isOpenStreetMapHost("not-openstreetmap.org")).toBe(false);
+    expect(isOpenStreetMapHost("myopenstreetmap.org")).toBe(false);
+  });
+
+  it("should return false for domains where openstreetmap.org is a subdomain", () => {
+    expect(isOpenStreetMapHost("openstreetmap.org.evil.com")).toBe(false);
+    expect(isOpenStreetMapHost("tile.openstreetmap.org.evil.com")).toBe(false);
+  });
+
+  it("should return false for unrelated domains", () => {
+    expect(isOpenStreetMapHost("example.com")).toBe(false);
+    expect(isOpenStreetMapHost("google.com")).toBe(false);
+    expect(isOpenStreetMapHost("")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- Fixes incomplete URL substring sanitization in `LeafletMap.tsx`
- The previous check used `.includes("openstreetmap.org")` which could be bypassed by malicious domains like `openstreetmap.org.evil.com` or `fake-openstreetmap.org`
- The fix validates that the hostname is either exactly `openstreetmap.org` or a legitimate subdomain ending with `.openstreetmap.org`

Resolves https://github.com/metabase/metabase/security/code-scanning/604


🤖 Generated with [Claude Code](https://claude.com/claude-code)