### PR TITLE
fix: NLQ profile incorrectly used for SQL editor requests

### DIFF
--- a/e2e/test/scenarios/metabot/metabot-query-builder.cy.spec.ts
+++ b/e2e/test/scenarios/metabot/metabot-query-builder.cy.spec.ts
@@ -149,6 +149,38 @@ describe("Metabot Query Builder", () => {
       H.assertChatVisibility("visible");
     });
 
+    it("should not reuse the nlq profile after falling back to notebook chat", () => {
+      cy.intercept("POST", "/api/ee/metabot-v3/agent-streaming", (req) => {
+        req.reply({
+          statusCode: 200,
+          body: mockTextOnlyResponse("ok"),
+          headers: {
+            "content-type": "text/event-stream; charset=utf-8",
+          },
+        });
+      }).as("metabotAgent");
+
+      cy.visit("/");
+      H.newButton("AI exploration").click();
+      cy.url().should("include", "/question/ask");
+
+      metabotPromptInput().type("Show me all orders");
+      cy.findByTestId("metabot-send-message").click();
+
+      cy.wait("@metabotAgent").then(({ request }) => {
+        expect(request.body.profile_id).to.eq("nlq");
+      });
+
+      cy.url().should("include", "/question/notebook");
+      H.assertChatVisibility("visible");
+
+      H.sendMetabotMessage("Try again");
+
+      cy.wait("@metabotAgent").then(({ request }) => {
+        expect(request.body.profile_id).to.be.undefined;
+      });
+    });
+
     it("should cancel requests if the user leaves the page", () => {
       // visit AI exploration page
       cy.visit("/question/ask");

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotQueryBuilder/MetabotQueryBuilder.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotQueryBuilder/MetabotQueryBuilder.tsx
@@ -57,7 +57,6 @@ export const MetabotQueryBuilder = () => {
   const dispatch = useDispatch();
   const {
     setVisible,
-    setProfileOverride,
     resetConversation,
     metabotId,
     isDoingScience,
@@ -82,14 +81,16 @@ export const MetabotQueryBuilder = () => {
   const handleSubmitPrompt = async (prompt: string) => {
     // start new nlq convo
     resetConversation();
-    setProfileOverride("nlq");
     setHasError(false);
 
     // work around to show prompt during loading state - this is due to
     // normally we want the prompt to be cleared in a conversation
     // but in this case we want to show it in the input while responding
     // so it looks like we're processing the prompt / suggested prompt
-    const req = submitInput(prompt, { preventOpenSidebar: true });
+    const req = submitInput(prompt, {
+      profile: "nlq",
+      preventOpenSidebar: true,
+    });
     setPrompt(prompt);
     const action = await req;
     setPrompt("");

--- a/enterprise/frontend/src/metabase-enterprise/metabot/hooks/use-metabot-agent.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/hooks/use-metabot-agent.ts
@@ -89,6 +89,7 @@ export const useMetabotAgent = (agentId: MetabotAgentId = "omnibot") => {
           context: await getChatContext(),
           agentId,
           metabot_id: metabotRequestId,
+          profile: options?.profile,
         }),
       );
 

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/actions.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/actions.ts
@@ -192,12 +192,13 @@ export const submitInput = createAsyncThunk<
     context: MetabotChatContext;
     agentId: MetabotAgentId;
     metabot_id?: string;
+    profile?: string;
   }
 >(
   "metabase-enterprise/metabot/submitInput",
   async (payload, { dispatch, getState, signal }) => {
     const state = getState();
-    const { agentId, message: rawPrompt, ...data } = payload;
+    const { agentId, message: rawPrompt, profile, ...data } = payload;
     const convo = getMetabotConversation(state, agentId);
 
     const prompt = rawPrompt.trim();
@@ -257,6 +258,7 @@ export const submitInput = createAsyncThunk<
           agentId,
           conversation_id: convo.conversationId,
           ...agentMetadata,
+          ...(profile ? { profile_id: profile } : {}),
         }),
       );
       signal.addEventListener("abort", () => {


### PR DESCRIPTION
Closes [BOT-814: NLQ profile incorrectly used for SQL editor requests](https://linear.app/metabase/issue/BOT-814/nlq-profile-incorrectly-used-for-sql-editor-requests)

### Description

Once we switch from NLQ page, we want to switch to default profile instead of NLQ. Instead of setting the profile override for the whole convo, set it only for the first prompt from the /ask page.

### How to verify

1. New -> AI Exploration
2. Enter some prompt
3. After navigation, send another message. 

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
