### PR TITLE
Fix computed transform tables being editable

### DIFF
--- a/resources/migrations/059_update_migrations.yaml
+++ b/resources/migrations/059_update_migrations.yaml
@@ -3594,6 +3594,7 @@ databaseChangeLog:
               WHERE data_authority = 'computed'
                 AND data_source = 'metabase-transform'
                 AND is_writable = TRUE;
+      rollback: # rolling back still leaves the fix in place
 
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/059_update_migrations.yaml
+++ b/resources/migrations/059_update_migrations.yaml
@@ -3573,7 +3573,7 @@ databaseChangeLog:
             dbms: h2
             path: instance_analytics_views/query_log/v2/h2-query_log.sql
             relativeToChangelogFile: true
-            
+
   - changeSet:
       id: v59.2026-03-04T00:00:00
       author: rileythompson

--- a/resources/migrations/059_update_migrations.yaml
+++ b/resources/migrations/059_update_migrations.yaml
@@ -3574,6 +3574,19 @@ databaseChangeLog:
             path: instance_analytics_views/query_log/v2/h2-query_log.sql
             relativeToChangelogFile: true
 
+  - changeSet:
+      id: v59.2026-03-06T00:00:00
+      author: qnkhuat
+      comment: Fix computed transform tables incorrectly marked as writable
+      changes:
+        - sql:
+            sql: >
+              UPDATE metabase_table
+              SET is_writable = FALSE
+              WHERE data_authority = 'computed'
+                AND data_source = 'metabase-transform'
+                AND is_writable = TRUE;
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/sync/sync_metadata/tables.clj
+++ b/src/metabase/sync/sync_metadata/tables.clj
@@ -222,7 +222,12 @@
                                    (some? (:visibility_type old-table))
                                    ;; noop
                                    (= (:visibility_type new-table) (:visibility_type old-table)))
-                                  (dissoc changes :visibility_type))]
+                                  (dissoc changes :visibility_type)
+
+                                  ;; don't mark computed tables as writable — they are derived
+                                  ;; and should never be editable, regardless of what the driver reports
+                                  (= :computed (:data_authority metabase-table))
+                                  (dissoc changes :is_writable))]
     (doseq [[k v] changes]
       (log/infof "%s of %s changed from %s to %s"
                  k
@@ -259,7 +264,7 @@
    & filters]
   (set (apply
         t2/select
-        (into [:model/Table :id :name :schema] keys-to-update)
+        (into [:model/Table :id :name :schema :data_authority] keys-to-update)
         :db_id (u/the-id database)
         filters)))
 

--- a/src/metabase/transforms_base/util.clj
+++ b/src/metabase/transforms_base/util.clj
@@ -323,7 +323,7 @@
   ([database target {:keys [create?]}]
    (when-let [table (or (target-table (:id database) target)
                         (when create?
-                          (sync/create-table! database (select-keys target [:schema :name :data_source :data_authority]))))]
+                          (sync/create-table! database (select-keys target [:schema :name :data_source :data_authority :is_writable]))))]
      (sync/sync-table! table)
      table)))
 
@@ -332,7 +332,8 @@
   [database target]
   (when-let [table (sync-table! database (assoc target
                                                 :data_authority :computed
-                                                :data_source :metabase-transform)
+                                                :data_source :metabase-transform
+                                                :is_writable false)
                                 {:create? true})]
     (when-not (:active table)
       (t2/update! :model/Table (:id table) {:active true}))

--- a/test/metabase/sync/sync_metadata/tables_test.clj
+++ b/test/metabase/sync/sync_metadata/tables_test.clj
@@ -276,6 +276,32 @@
           (is (= "sensitive_table" (:name new-table)))
           (is (nil? (:archived_at new-table))))))))
 
+(deftest computed-tables-not-marked-writable-by-sync-test
+  (testing "Sync should not mark computed tables as writable, even if the driver reports them as writable"
+    (mt/with-temp [:model/Database db {:engine ::toucanery/toucanery}
+                   :model/Table computed-table {:name           "computed_table"
+                                                :db_id          (u/the-id db)
+                                                :data_authority :computed
+                                                :is_writable    false}
+                   :model/Table normal-table   {:name           "normal_table"
+                                                :db_id          (u/the-id db)
+                                                :data_authority :unconfigured
+                                                :is_writable    false}]
+      ;; Simulate what happens during sync: the driver reports both tables as writable
+      (let [select-cols (into [:model/Table :id :name :schema :data_authority] @#'sync-tables/keys-to-update)]
+        (#'sync-tables/update-table-metadata-if-needed!
+         {:name "computed_table" :schema nil :is_writable true}
+         (t2/select-one select-cols (:id computed-table))
+         db)
+        (#'sync-tables/update-table-metadata-if-needed!
+         {:name "normal_table" :schema nil :is_writable true}
+         (t2/select-one select-cols (:id normal-table))
+         db))
+      (testing "computed table should remain non-writable"
+        (is (false? (t2/select-one-fn :is_writable :model/Table (:id computed-table)))))
+      (testing "normal table should be updated to writable"
+        (is (true? (t2/select-one-fn :is_writable :model/Table (:id normal-table))))))))
+
 (deftest sample-database-tables-data-authority-test
   (testing "Tables from sample databases should be marked as :ingested"
     (mt/with-temp [:model/Database sample-db {:is_sample true}

--- a/test/metabase/transforms/util_test.clj
+++ b/test/metabase/transforms/util_test.clj
@@ -9,6 +9,7 @@
    [metabase.lib.core :as lib]
    [metabase.permissions.models.data-permissions :as data-perms]
    [metabase.permissions.models.permissions-group :as perms-group]
+   [metabase.sync.core :as sync]
    [metabase.test :as mt]
    [metabase.test.data.sql :as sql.tx]
    [metabase.transforms-base.interface :as transforms-base.i]
@@ -322,6 +323,32 @@
                       (binding [api/*current-user-id* (:id user)]
                         (is (false? (transforms.u/source-tables-readable? transform))
                             "User who cannot read all source tables should have source_readable=false")))))))))))))
+
+(deftest activate-table-and-mark-computed-sets-is-writable-false-test
+  (testing "activate-table-and-mark-computed! sets is_writable to false on computed transform tables"
+    (let [target {:type "table" :schema nil :name "test_computed_writable"}
+          synced-table (atom nil)]
+      (mt/with-temp [:model/Database db {:engine :h2}]
+        ;; Mock sync-table! to just create the table in Metabase without needing a real DB table
+        (with-redefs [sync/create-table! (fn [database table-map]
+                                           (let [created (t2/insert-returning-instance!
+                                                          :model/Table
+                                                          {:db_id          (:id database)
+                                                           :name           (:name table-map)
+                                                           :schema         (:schema table-map)
+                                                           :active         true
+                                                           :is_writable    (:is_writable table-map)
+                                                           :data_source    (:data_source table-map)
+                                                           :data_authority (:data_authority table-map)})]
+                                             (reset! synced-table created)
+                                             created))
+                      sync/sync-table!   (constantly nil)]
+          (transforms-base.u/activate-table-and-mark-computed! db target)
+          (is (some? @synced-table))
+          (let [table (t2/select-one :model/Table (:id @synced-table))]
+            (is (= :computed (:data_authority table)))
+            (is (false? (:is_writable table))
+                "Computed transform tables should have is_writable=false")))))))
 
 (deftest execute-sets-transform-id-on-target-table-test
   (testing "Executing a query transform sets transform_id on the target table"


### PR DESCRIPTION
Computed transform tables (`data_authority = 'computed'`) were incorrectly editable because `is_writable` was never set to `false` at creation time, and sync would overwrite it with whatever the driver reported (e.g. H2 always reports `true`).

- Set `is_writable false` when creating computed transform tables
- Skip `is_writable` sync updates for computed tables (same pattern as `description` and `visibility_type`)

Linear: https://linear.app/metabase/issue/GDGT-1081/bug-editable-computed-transforms-issue