### PR TITLE
feat: Add goal line to waterfall chart

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/waterfall.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/waterfall.cy.spec.js
@@ -477,6 +477,20 @@ describe("scenarios > visualizations > waterfall", () => {
         .click({ force: true });
       H.echartsContainer().get("text").contains("(4.56)").should("be.visible");
     });
+
+    it("should display goal line when configured", () => {
+      // eslint-disable-next-line metabase/no-unscoped-text-selectors -- deprecated usage
+      cy.contains("Display").click();
+      cy.findByText("Goal line").click();
+
+      H.leftSidebar().within(() => {
+        cy.findByLabelText("Goal value").clear().type("100");
+        cy.findByLabelText("Goal label").clear().type("Target");
+      });
+
+      H.echartsContainer().findByText("Target").should("exist");
+      H.goalLine().should("exist");
+    });
   });
 });
 

--- a/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/option/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/option/index.ts
@@ -35,6 +35,10 @@ import type { ChartMeasurements } from "../../chart-measurements/types";
 import { isCategoryAxis } from "../../model/guards";
 import { getSharedEChartsOptions } from "../../option";
 import { buildAxes } from "../../option/axis";
+import {
+  getGoalLineParams,
+  getGoalLineSeriesOption,
+} from "../../option/goal-line";
 import { getTimelineEventsSeries } from "../../timeline-events/option";
 import type { TimelineEventsModel } from "../../timeline-events/types";
 
@@ -234,9 +238,15 @@ export const getWaterfallChartOption = (
     chartModel.waterfallLabelFormatter,
     renderingContext,
   );
+  const goalSeriesOption = getGoalLineSeriesOption(
+    getGoalLineParams(chartModel),
+    settings,
+    renderingContext,
+  );
 
   const seriesOption: WaterfallSeriesOption[] = [
     dataSeriesOptions,
+    goalSeriesOption,
     timelineEventsSeries,
   ].flatMap((option) => option ?? []);
 

--- a/frontend/src/metabase/visualizations/visualizations/WaterfallChart/WaterfallChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/WaterfallChart/WaterfallChart.tsx
@@ -2,6 +2,7 @@ import Color from "color";
 import { t } from "ttag";
 
 import { color, staticVizOverrides } from "metabase/lib/colors";
+import { GRAPH_GOAL_SETTINGS } from "metabase/visualizations/lib/settings/goal";
 import {
   GRAPH_AXIS_SETTINGS,
   GRAPH_DATA_SETTINGS,
@@ -49,6 +50,7 @@ Object.assign(
     supportsVisualizer: false,
     settings: {
       ...GRAPH_AXIS_SETTINGS,
+      ...GRAPH_GOAL_SETTINGS,
       "waterfall.increase_color": {
         // eslint-disable-next-line ttag/no-module-declaration -- see metabase#55045
         section: t`Display`,


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/70429

### Description

Enable goal line for waterfall chart in the visualization settings display tab.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> Orders -> Visualization -> Waterfall -> Summarize -> Group by Orders.Total -> Done
2. Visualization Gear -> Display -> Goal line (switch should be there)
3. Set goal value to 10,000, text to Target, verify it shows up.


### Checklist

- [x ] Tests have been added/updated to cover changes in this PR
