### PR TITLE
fix: Metabot not receiving transform errors from transforms

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformEditor.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformEditor.tsx
@@ -3,6 +3,7 @@ import { useEffect } from "react";
 import { usePrevious } from "react-use";
 
 import type { PythonTransformEditorProps } from "metabase/plugins";
+import { useRegisterMetabotTransformContext } from "metabase/transforms/hooks/use-register-transform-metabot-context";
 import { Flex, Stack } from "metabase/ui";
 import type {
   DatabaseId,
@@ -34,6 +35,12 @@ export function PythonTransformEditor({
 }: PythonTransformEditorProps) {
   const { isRunning, cancel, run, executionResult, isDirty } =
     useTestPythonTransform(source);
+
+  useRegisterMetabotTransformContext(
+    transform,
+    source,
+    executionResult?.error?.message,
+  );
 
   const wasRunning = usePrevious(isRunning);
 

--- a/frontend/src/metabase-types/api/metabot.ts
+++ b/frontend/src/metabase-types/api/metabot.ts
@@ -152,9 +152,9 @@ export type MetabotDocumentInfo = {
 };
 
 export type MetabotTransformInfo =
-  | ({ type: "transform" } & Transform) // edit
-  | ({ type: "transform" } & SuggestedTransform) // edit saved suggested
-  | ({ type: "transform" } & DraftTransform); // edit unsaved suggested
+  | ({ type: "transform"; error?: string } & Transform) // edit
+  | ({ type: "transform"; error?: string } & SuggestedTransform) // edit saved suggested
+  | ({ type: "transform"; error?: string } & DraftTransform); // edit unsaved suggested
 
 export type MetabotEntityInfo =
   | MetabotCardInfo

--- a/frontend/src/metabase/transforms/hooks/use-register-transform-metabot-context.ts
+++ b/frontend/src/metabase/transforms/hooks/use-register-transform-metabot-context.ts
@@ -1,5 +1,6 @@
 import { useRegisterMetabotContextProvider } from "metabase/metabot";
 import type {
+  DatasetError,
   DraftTransformSource,
   MetabotTransformInfo,
   SuggestedTransform,
@@ -16,23 +17,63 @@ type AnyTransform =
   | UnsavedTransform
   | SuggestedTransform;
 
+const getTransformErrorMessage = (
+  error: DatasetError | undefined,
+): string | undefined => {
+  if (!error) {
+    return undefined;
+  }
+
+  if (typeof error === "string") {
+    return error;
+  }
+
+  if (typeof error === "object") {
+    const data = error.data;
+
+    if (typeof data === "string") {
+      return data;
+    }
+
+    return JSON.stringify(error);
+  }
+
+  return String(error);
+};
+
+export const registerTransformMetabotContextFn = ({
+  transform,
+  source,
+  error,
+}: {
+  transform: AnyTransform | undefined;
+  source?: DraftTransformSource;
+  error?: DatasetError;
+}) => {
+  if (!transform && !source) {
+    return {};
+  }
+
+  const errorMessage = getTransformErrorMessage(error);
+
+  return {
+    user_is_viewing: [
+      {
+        ...transform,
+        type: "transform",
+        ...(source !== undefined && { source }),
+        ...(errorMessage !== undefined && { error: errorMessage }),
+      } as MetabotTransformInfo,
+    ],
+  };
+};
+
 export const useRegisterMetabotTransformContext = (
   transform: AnyTransform | undefined,
   source?: DraftTransformSource,
+  error?: DatasetError,
 ) => {
   useRegisterMetabotContextProvider(async () => {
-    if (!transform && !source) {
-      return {};
-    }
-
-    return {
-      user_is_viewing: [
-        {
-          ...transform,
-          type: "transform",
-          ...(source !== undefined && { source }),
-        } as MetabotTransformInfo,
-      ],
-    };
-  }, [transform, source]);
+    return registerTransformMetabotContextFn({ transform, source, error });
+  }, [transform, source, error]);
 };

--- a/frontend/src/metabase/transforms/hooks/use-register-transform-metabot-context.ts
+++ b/frontend/src/metabase/transforms/hooks/use-register-transform-metabot-context.ts
@@ -1,3 +1,5 @@
+import { P, match } from "ts-pattern";
+
 import { useRegisterMetabotContextProvider } from "metabase/metabot";
 import type {
   DatasetError,
@@ -19,27 +21,16 @@ type AnyTransform =
 
 const getTransformErrorMessage = (
   error: DatasetError | undefined,
-): string | undefined => {
-  if (!error) {
-    return undefined;
-  }
-
-  if (typeof error === "string") {
-    return error;
-  }
-
-  if (typeof error === "object") {
-    const data = error.data;
-
-    if (typeof data === "string") {
-      return data;
-    }
-
-    return JSON.stringify(error);
-  }
-
-  return String(error);
-};
+): string | undefined =>
+  match(error)
+    .with(P.nullish, () => undefined)
+    .with(P.string, (message) => message)
+    .with({ data: P.string }, ({ data }) => data)
+    .with(
+      P.when((value) => typeof value === "object" && value !== null),
+      (datasetError) => JSON.stringify(datasetError),
+    )
+    .otherwise((value) => String(value));
 
 export const registerTransformMetabotContextFn = ({
   transform,

--- a/frontend/src/metabase/transforms/hooks/use-register-transform-metabot-context.unit.spec.ts
+++ b/frontend/src/metabase/transforms/hooks/use-register-transform-metabot-context.unit.spec.ts
@@ -1,0 +1,56 @@
+import {
+  createMockTransform,
+  createMockTransformSource,
+} from "metabase-types/api/mocks";
+
+import { registerTransformMetabotContextFn } from "./use-register-transform-metabot-context";
+
+describe("registerTransformMetabotContextFn", () => {
+  it("returns empty context when transform and source are missing", () => {
+    expect(
+      registerTransformMetabotContextFn({
+        transform: undefined,
+        source: undefined,
+      }),
+    ).toEqual({});
+  });
+
+  it("includes transform runtime errors in metabot context", () => {
+    const transform = createMockTransform();
+
+    const result = registerTransformMetabotContextFn({
+      transform,
+      source: transform.source,
+      error: "column does not exist",
+    });
+
+    expect(result).toEqual({
+      user_is_viewing: [
+        expect.objectContaining({
+          type: "transform",
+          id: transform.id,
+          error: "column does not exist",
+        }),
+      ],
+    });
+  });
+
+  it("normalizes object-shaped query errors to a string", () => {
+    const source = createMockTransformSource();
+
+    const result = registerTransformMetabotContextFn({
+      transform: undefined,
+      source,
+      error: { status: 400, data: "syntax error at or near FROM" },
+    });
+
+    expect(result).toEqual({
+      user_is_viewing: [
+        expect.objectContaining({
+          type: "transform",
+          error: "syntax error at or near FROM",
+        }),
+      ],
+    });
+  });
+});

--- a/frontend/src/metabase/transforms/pages/TransformQueryPage/TransformQueryPage.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformQueryPage/TransformQueryPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useState } from "react";
 import type { Route, RouteProps } from "react-router";
 import { push } from "react-router-redux";
 import { useLatest } from "react-use";
@@ -120,7 +120,16 @@ function TransformQueryPageBody({
   const { sendSuccessToast, sendErrorToast } = useMetadataToasts();
   const isEditMode = !readOnly && !!route.path?.includes("/edit");
 
-  useRegisterMetabotTransformContext(transform, source);
+  const lastRunError = useMemo(() => {
+    if (!transform.last_run) {
+      return undefined;
+    }
+    return transform.last_run.status === "failed"
+      ? (transform.last_run.message ?? undefined)
+      : undefined;
+  }, [transform.last_run]);
+
+  useRegisterMetabotTransformContext(transform, source, lastRunError);
 
   const { confirmIfQueryIsComplex, modal } = useQueryComplexityChecks();
 


### PR DESCRIPTION
Closes [BOT-553: Metabot not receiving transform errors from transforms](https://linear.app/metabase/issue/BOT-553/metabot-not-receiving-transform-errors-from-transforms)

### Description

`error` field was missing from the `UserIsViewingTransform`.

Relevant `ai-service` PR: https://github.com/metabase/ai-service/pull/622

### How to verify

1. Go to some transform
2. Make it fail
3. Run it
4. Ask metabot what was the error

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
