### PR TITLE
feat: admin password reset link for users

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1783,6 +1783,7 @@
            premium-features
            request
            sso
+           system
            tenants
            users
            util

--- a/e2e/test/scenarios/admin-2/people.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/people.cy.spec.js
@@ -296,12 +296,50 @@ describe("scenarios > admin > people", () => {
       cy.findByText("Reset password").click();
       // eslint-disable-next-line metabase/no-unscoped-text-selectors -- deprecated usage
       cy.findByText(`Reset ${normalUserName}'s password?`);
-      clickButton("Reset password");
+
+      H.modal().within(() => {
+        cy.findByText("Are you sure you want to do this?");
+        cy.button("Cancel").should("exist");
+        cy.button("Get reset link").should("exist");
+        cy.button("Reset password").click();
+      });
+
       // eslint-disable-next-line metabase/no-unscoped-text-selectors -- deprecated usage
       cy.findByText(`${normalUserName}'s password has been reset`);
       // eslint-disable-next-line metabase/no-unscoped-text-selectors -- deprecated usage
       cy.findByText(/^temporary password$/i);
       clickButton("Done");
+      cy.location().should((loc) =>
+        expect(loc.pathname).to.eq("/admin/people"),
+      );
+    });
+
+    it("should generate a password reset link without SMTP set up", () => {
+      cy.intercept("POST", "/api/user/*/password-reset-url").as("getResetUrl");
+
+      cy.visit("/admin/people");
+      showUserOptions(normalUserName);
+      // eslint-disable-next-line metabase/no-unscoped-text-selectors -- deprecated usage
+      cy.findByText("Reset password").click();
+
+      H.modal().within(() => {
+        cy.findByText(`Reset ${normalUserName}'s password?`);
+        cy.button("Get reset link").click();
+      });
+
+      cy.wait("@getResetUrl");
+
+      H.modal().within(() => {
+        cy.findByText(`Password reset link for ${normalUserName}`);
+        cy.findByText(
+          "Share this link with the user. It will expire in 48 hours.",
+        );
+        cy.findByRole("textbox")
+          .invoke("val")
+          .should("contain", "password-reset");
+        cy.button("Done").click();
+      });
+
       cy.location().should((loc) =>
         expect(loc.pathname).to.eq("/admin/people"),
       );
@@ -335,7 +373,11 @@ describe("scenarios > admin > people", () => {
         cy.findByText("Reset password").click();
         // eslint-disable-next-line metabase/no-unscoped-text-selectors -- deprecated usage
         cy.findByText(`Reset ${normalUserName}'s password?`);
-        clickButton("Reset password");
+
+        H.modal().within(() => {
+          cy.button("Get reset link").should("exist");
+          cy.button("Reset password").click();
+        });
 
         H.undoToast().within(() => {
           cy.findByText(

--- a/e2e/test/scenarios/admin-2/people.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/people.cy.spec.js
@@ -336,7 +336,7 @@ describe("scenarios > admin > people", () => {
         );
         cy.findByRole("textbox")
           .invoke("val")
-          .should("contain", "password-reset");
+          .should("contain", "reset_password");
         cy.button("Done").click();
       });
 

--- a/frontend/src/metabase/admin/people/containers/UserPasswordResetModal.tsx
+++ b/frontend/src/metabase/admin/people/containers/UserPasswordResetModal.tsx
@@ -1,19 +1,22 @@
+import { useState } from "react";
 import { useUnmount } from "react-use";
 import { c, t } from "ttag";
 
 import {
   useForgotPasswordMutation,
+  useGetPasswordResetUrlMutation,
   useGetUserQuery,
   useUpdatePasswordMutation,
 } from "metabase/api";
 import { ConfirmModal } from "metabase/common/components/ConfirmModal";
+import { CopyButton } from "metabase/common/components/CopyButton";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { PasswordReveal } from "metabase/common/components/PasswordReveal";
 import { useToast } from "metabase/common/hooks/use-toast";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import { generatePassword } from "metabase/lib/security";
 import MetabaseSettings from "metabase/lib/settings";
-import { Text } from "metabase/ui";
+import { Button, Flex, Modal, Text, TextInput } from "metabase/ui";
 import type { User } from "metabase-types/api";
 
 import { clearTemporaryPassword } from "../people";
@@ -38,9 +41,12 @@ const UserPasswordResetModalInner = ({
     clearTemporaryPassword();
   });
 
+  const [resetUrl, setResetUrl] = useState<string | null>(null);
+
   const [sendToast] = useToast();
   const [updatePassword] = useUpdatePasswordMutation();
   const [resetPasswordEmail] = useForgotPasswordMutation();
+  const [getPasswordResetUrl] = useGetPasswordResetUrlMutation();
 
   const handleResetConfirm = async () => {
     if (emailConfigured) {
@@ -58,11 +64,41 @@ const UserPasswordResetModalInner = ({
     }
   };
 
+  const handleGetResetLink = async () => {
+    const result = await getPasswordResetUrl(user.id).unwrap();
+    setResetUrl(result.password_reset_url);
+  };
+
+  if (resetUrl) {
+    return (
+      <ConfirmModal
+        opened
+        title={t`Password reset link for ${user.common_name}`}
+        onConfirm={onClose}
+        confirmButtonProps={{ color: "brand", variant: "filled" }}
+        confirmButtonText={t`Done`}
+        closeButtonText={null}
+        onClose={onClose}
+        message={
+          <>
+            <Text pb="lg">{t`Share this link with the user. It will expire in 48 hours.`}</Text>
+            <TextInput
+              value={resetUrl}
+              readOnly
+              rightSection={<CopyButton value={resetUrl} />}
+              onClick={(e) => e.currentTarget.select()}
+            />
+          </>
+        }
+      />
+    );
+  }
+
   if (temporaryPassword) {
     return (
       <ConfirmModal
         opened
-        title={t`${user.common_name}'s password has been reset`}
+        title={t`${user.common_name}’s password has been reset`}
         onConfirm={onClose}
         confirmButtonProps={{ color: "brand", variant: "filled" }}
         confirmButtonText={t`Done`}
@@ -79,14 +115,29 @@ const UserPasswordResetModalInner = ({
   }
 
   return (
-    <ConfirmModal
+    <Modal
       opened
-      title={t`Reset ${user.common_name}'s password?`}
+      title={t`Reset ${user.common_name}’s password?`}
       onClose={onClose}
-      confirmButtonText={t`Reset password`}
-      onConfirm={handleResetConfirm}
-      message={t`Are you sure you want to do this?`}
-    />
+      size="lg"
+    >
+      <Flex direction="column" gap="lg" mt="md">
+        <Text>{t`Are you sure you want to do this?`}</Text>
+        <Flex align="center" justify="flex-end" gap="md">
+          <Button onClick={onClose}>{t`Cancel`}</Button>
+          <Button
+            variant="filled"
+            color="brand"
+            onClick={handleGetResetLink}
+          >{t`Get reset link`}</Button>
+          <Button
+            color="danger"
+            variant="filled"
+            onClick={handleResetConfirm}
+          >{t`Reset password`}</Button>
+        </Flex>
+      </Flex>
+    </Modal>
   );
 };
 

--- a/frontend/src/metabase/admin/people/containers/UserPasswordResetModal.tsx
+++ b/frontend/src/metabase/admin/people/containers/UserPasswordResetModal.tsx
@@ -19,11 +19,12 @@ import MetabaseSettings from "metabase/lib/settings";
 import { Button, Flex, Modal, Text, TextInput } from "metabase/ui";
 import type { User } from "metabase-types/api";
 
-import { clearTemporaryPassword } from "../people";
+import { clearTemporaryPassword, storeTemporaryPassword } from "../people";
 import { getUserTemporaryPassword } from "../selectors";
 
 interface UserPasswordResetModalInnerProps {
   clearTemporaryPassword: () => void;
+  storeTemporaryPassword: (id: number, password: string) => void;
   onClose: () => void;
   user: User;
   emailConfigured: boolean;
@@ -32,6 +33,7 @@ interface UserPasswordResetModalInnerProps {
 
 const UserPasswordResetModalInner = ({
   clearTemporaryPassword,
+  storeTemporaryPassword,
   emailConfigured,
   onClose,
   temporaryPassword,
@@ -61,6 +63,7 @@ const UserPasswordResetModalInner = ({
     } else {
       const password = generatePassword();
       await updatePassword({ id: user.id, password }).unwrap();
+      storeTemporaryPassword(user.id, password);
     }
   };
 
@@ -163,6 +166,9 @@ export const UserPasswordResetModal = (props: UserPasswordResetModalProps) => {
           {...props}
           clearTemporaryPassword={() =>
             dispatch(clearTemporaryPassword(user.id))
+          }
+          storeTemporaryPassword={(id, password) =>
+            dispatch(storeTemporaryPassword({ id, password }))
           }
           user={user}
           emailConfigured={MetabaseSettings.isEmailConfigured()}

--- a/frontend/src/metabase/admin/people/containers/UserPasswordResetModal.tsx
+++ b/frontend/src/metabase/admin/people/containers/UserPasswordResetModal.tsx
@@ -101,7 +101,7 @@ const UserPasswordResetModalInner = ({
     return (
       <ConfirmModal
         opened
-        title={t`${user.common_name}’s password has been reset`}
+        title={t`${user.common_name}'s password has been reset`}
         onConfirm={onClose}
         confirmButtonProps={{ color: "brand", variant: "filled" }}
         confirmButtonText={t`Done`}
@@ -109,7 +109,7 @@ const UserPasswordResetModalInner = ({
         onClose={onClose}
         message={
           <>
-            <Text pb="lg">{t`Here’s a temporary password they can use to log in and then change their password.`}</Text>
+            <Text pb="lg">{t`Here's a temporary password they can use to log in and then change their password.`}</Text>
             <PasswordReveal password={temporaryPassword} />
           </>
         }
@@ -120,7 +120,7 @@ const UserPasswordResetModalInner = ({
   return (
     <Modal
       opened
-      title={t`Reset ${user.common_name}’s password?`}
+      title={t`Reset ${user.common_name}'s password?`}
       onClose={onClose}
       size="lg"
     >

--- a/frontend/src/metabase/admin/people/containers/UserPasswordResetModal.unit.spec.tsx
+++ b/frontend/src/metabase/admin/people/containers/UserPasswordResetModal.unit.spec.tsx
@@ -1,0 +1,99 @@
+import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
+
+import { setupForgotPasswordEndpoint } from "__support__/server-mocks/session";
+import {
+  setupPasswordResetUrlEndpoint,
+  setupUpdatePasswordEndpoint,
+  setupUserEndpoints,
+} from "__support__/server-mocks/user";
+import { mockSettings } from "__support__/settings";
+import { renderWithProviders, screen } from "__support__/ui";
+import type { UserListResult } from "metabase-types/api";
+import { createMockSettings, createMockUser } from "metabase-types/api/mocks";
+import { createMockState } from "metabase-types/store/mocks";
+
+import { UserPasswordResetModal } from "./UserPasswordResetModal";
+
+const TEST_USER = createMockUser({
+  id: 42,
+  first_name: "Ash",
+  last_name: "Ketchum",
+  email: "ash@example.com",
+  common_name: "Ash Ketchum",
+});
+
+function setup({ emailConfigured = false } = {}) {
+  setupUserEndpoints(TEST_USER as unknown as UserListResult);
+  setupPasswordResetUrlEndpoint(TEST_USER.id);
+  setupForgotPasswordEndpoint();
+  setupUpdatePasswordEndpoint(TEST_USER.id);
+
+  const storeInitialState = createMockState({
+    settings: mockSettings(
+      createMockSettings({
+        "email-configured?": emailConfigured,
+      }),
+    ),
+  });
+
+  const onCloseSpy = jest.fn();
+  renderWithProviders(
+    <UserPasswordResetModal
+      params={{ userId: String(TEST_USER.id) }}
+      onClose={onCloseSpy}
+    />,
+    { storeInitialState },
+  );
+  return { onCloseSpy };
+}
+
+describe("UserPasswordResetModal", () => {
+  it("should render the confirmation dialog with 'Get reset link' button", async () => {
+    setup();
+    expect(
+      await screen.findByRole("button", { name: "Get reset link" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Reset password" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+  });
+
+  it("should show reset URL after clicking 'Get reset link'", async () => {
+    setup();
+    await screen.findByRole("button", { name: "Get reset link" });
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Get reset link" }),
+    );
+
+    expect(
+      await screen.findByText(
+        "Share this link with the user. It will expire in 48 hours.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Done" })).toBeInTheDocument();
+
+    const call = fetchMock.callHistory.lastCall(
+      `path:/api/user/${TEST_USER.id}/password-reset-url`,
+      { method: "POST" },
+    );
+    expect(call).toBeTruthy();
+  });
+
+  it("should call onClose when clicking Done after getting reset link", async () => {
+    const { onCloseSpy } = setup();
+    await screen.findByRole("button", { name: "Get reset link" });
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Get reset link" }),
+    );
+    await screen.findByText(
+      "Share this link with the user. It will expire in 48 hours.",
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Done" }));
+    expect(onCloseSpy).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/metabase/api/user.ts
+++ b/frontend/src/metabase/api/user.ts
@@ -116,6 +116,15 @@ export const userApi = Api.injectEndpoints({
           dispatch(userUpdated(user));
         }),
     }),
+    getPasswordResetUrl: builder.mutation<
+      { password_reset_url: string },
+      UserId
+    >({
+      query: (id) => ({
+        method: "POST",
+        url: `/api/user/${id}/password-reset-url`,
+      }),
+    }),
     listUserAttributes: builder.query<string[], void>({
       query: () => "/api/mt/user/attributes",
       providesTags: (response) => (response ? [listTag("user")] : []),
@@ -136,5 +145,6 @@ export const {
   useDeactivateUserMutation,
   useReactivateUserMutation,
   useUpdateUserMutation,
+  useGetPasswordResetUrlMutation,
   useListUserAttributesQuery,
 } = userApi;

--- a/frontend/test/__support__/server-mocks/user.ts
+++ b/frontend/test/__support__/server-mocks/user.ts
@@ -3,12 +3,26 @@ import fetchMock from "fetch-mock";
 import type {
   User,
   UserAttributeKey,
+  UserId,
   UserListResult,
 } from "metabase-types/api";
 
 export function setupUserEndpoints(user: UserListResult) {
   fetchMock.get(`path:/api/user/${user.id}`, user);
   fetchMock.put(`path:/api/user/${user.id}`, user);
+}
+
+export function setupPasswordResetUrlEndpoint(
+  userId: UserId,
+  resetUrl = `http://localhost:3000/auth/reset_password/${userId}_token`,
+) {
+  fetchMock.post(`path:/api/user/${userId}/password-reset-url`, {
+    password_reset_url: resetUrl,
+  });
+}
+
+export function setupUpdatePasswordEndpoint(userId: UserId) {
+  fetchMock.put(`path:/api/user/${userId}/password`, {});
 }
 
 export function setupUsersEndpoints(users: UserListResult[]) {

--- a/src/metabase/users_rest/api.clj
+++ b/src/metabase/users_rest/api.clj
@@ -16,6 +16,7 @@
    [metabase.premium-features.core :as premium-features]
    [metabase.request.core :as request]
    [metabase.sso.core :as sso]
+   [metabase.system.core :as system]
    [metabase.tenants.core :as tenants]
    [metabase.users.core :as users]
    [metabase.users.models.user :as user]
@@ -618,6 +619,26 @@
             response                        {:success    true
                                              :session_id (str session-key)}]
         (request/set-session-cookies request response session (t/zoned-date-time (t/zone-id "GMT")))))))
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                    Password Reset URL -- POST /api/user/:id/password-reset-url                                 |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+(api.macros/defendpoint :post "/:id/password-reset-url"
+  "Generate a password reset URL for a user. Admins can share this URL directly with the user.
+  The link expires in 48 hours."
+  [{:keys [id]} :- [:map
+                    [:id ms/PositiveInt]]]
+  :- [:map [:password_reset_url :string]]
+  (api/check-superuser)
+  (let [user (api/check-404 (t2/select-one [:model/User :id :is_active :type] :id id))]
+    (api/check-404 (:is_active user))
+    (api/check-404 (= :personal (:type user)))
+    (let [reset-token        (auth-identity/create-password-reset! id)
+          password-reset-url (str (system/site-url) "/auth/reset_password/" reset-token)]
+      (events/publish-event! :event/password-reset-initiated
+                             {:object (assoc user :token (t2/select-one-fn :reset_token :model/User :id id))})
+      {:password_reset_url password-reset-url})))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                             Deleting (Deactivating) a User -- DELETE /api/user/:id                             |

--- a/src/metabase/users_rest/api.clj
+++ b/src/metabase/users_rest/api.clj
@@ -624,12 +624,11 @@
 ;;; |                    Password Reset URL -- POST /api/user/:id/password-reset-url                                 |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(api.macros/defendpoint :post "/:id/password-reset-url"
+(api.macros/defendpoint :post "/:id/password-reset-url" :- [:map [:password_reset_url :string]]
   "Generate a password reset URL for a user. Admins can share this URL directly with the user.
   The link expires in 48 hours."
   [{:keys [id]} :- [:map
                     [:id ms/PositiveInt]]]
-  :- [:map [:password_reset_url :string]]
   (api/check-superuser)
   (let [user (api/check-404 (t2/select-one [:model/User :id :is_active :type] :id id))]
     (api/check-404 (:is_active user))

--- a/test/metabase/users_rest/api_test.clj
+++ b/test/metabase/users_rest/api_test.clj
@@ -1764,3 +1764,40 @@
                             :previous {:first_name "John"
                                        :last_name "Cena"}}}
                  (mt/latest-audit-log-entry :user-update id))))))))
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                  Password Reset URL -- POST /api/user/:id/password-reset-url                                    |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+(deftest password-reset-url-admin-can-generate-test
+  (testing "POST /api/user/:id/password-reset-url admin can generate a password reset URL"
+    (mt/with-temp [:model/User {user-id :id} {:first_name "Test"
+                                              :last_name "User"
+                                              :email "reseturl@test.com"}]
+      (let [response (mt/user-http-request :crowberto :post 200
+                                           (format "user/%d/password-reset-url" user-id))]
+        (is (contains? response :password_reset_url))
+        (is (string? (:password_reset_url response)))
+        (is (re-find #"/auth/reset_password/" (:password_reset_url response)))))))
+
+(deftest password-reset-url-non-admin-forbidden-test
+  (testing "POST /api/user/:id/password-reset-url non-admin gets 403"
+    (mt/with-temp [:model/User {user-id :id} {:first_name "Test"
+                                              :last_name "User"
+                                              :email "reseturl2@test.com"}]
+      (mt/user-http-request :rasta :post 403
+                            (format "user/%d/password-reset-url" user-id)))))
+
+(deftest password-reset-url-inactive-user-not-found-test
+  (testing "POST /api/user/:id/password-reset-url inactive user gets 404"
+    (mt/with-temp [:model/User {user-id :id} {:first_name "Test"
+                                              :last_name "User"
+                                              :email "reseturl3@test.com"
+                                              :is_active false}]
+      (mt/user-http-request :crowberto :post 404
+                            (format "user/%d/password-reset-url" user-id)))))
+
+(deftest password-reset-url-nonexistent-user-not-found-test
+  (testing "POST /api/user/:id/password-reset-url nonexistent user gets 404"
+    (mt/user-http-request :crowberto :post 404
+                          "user/999999/password-reset-url")))


### PR DESCRIPTION
### Description

Adds a way for administrators to get a password reset link for users if they want to be able to share it via non-email channels. 

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
