### PR TITLE
[Slackbot] Better auth messages

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot.clj
@@ -86,24 +86,24 @@
    For DMs, always threads the reply. For channel @mentions, only threads
    if the original message was in a thread."
   [client event]
-  (slackbot.client/post-ephemeral-message
-   client
-   (merge (slackbot.events/event->reply-context event)
-          {:user (:user event)
-           ;; DMs: always thread. Channels: only thread if already in a thread.
-           :thread_ts (if (slackbot.events/dm? event)
-                        (or (:thread_ts event) (:ts event))
-                        (:thread_ts event))
-           :text "Connect your Slack account to Metabase. Once linked, I can use your permissions to query data on your behalf."
-           :blocks [{:type "section"
-                     :text {:type "mrkdwn"
-                            :text "Connect your Slack account to Metabase. Once linked, I can use your permissions to query data on your behalf."}}
-                    {:type "actions"
-                     :elements [{:type "button"
-                                 :text {:type "plain_text"
-                                        :text ":link: Connect to Metabase"
-                                        :emoji true}
-                                 :url (slack-user-authorize-link)}]}]})))
+  (let [user-mention (slackbot.events/user-mention (:user event))
+        msg-prefix (if (slackbot.events/dm? event) "" (str user-mention " "))
+        msg (str msg-prefix "Connect your Slack account to Metabase. Once linked, I can use your permissions to query data on your behalf.")]
+    (slackbot.client/post-message
+     client
+     (merge (slackbot.events/event->reply-context event)
+            { ;; DMs: always thread. Channels: only thread if already in a thread.
+             :thread_ts (or (:thread_ts event) (:ts event))
+             :text msg
+             :blocks [{:type "section"
+                       :text {:type "mrkdwn"
+                              :text msg}}
+                      {:type "actions"
+                       :elements [{:type "button"
+                                   :text {:type "plain_text"
+                                          :text ":link: Connect to Metabase"
+                                          :emoji true}
+                                   :url (slack-user-authorize-link)}]}]}))))
 
 (defn- require-authenticated-slack-user!
   "Returns Metabase user-id if authenticated, nil otherwise.
@@ -206,6 +206,7 @@
         ((some-fn
           slackbot.events/bot-message? ;; ignore the bot's own messages
           slackbot.events/edited-message? ;; ignore message edits
+          slackbot.events/message-deleted? ;; ignore message deletion notifications
           slackbot.events/app-mention-with-files?) ;; processed via the separate file_share event
          event)
         (ignore-event event)

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/events.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/events.clj
@@ -97,6 +97,11 @@
   (or (= (:subtype event) "message_changed")
       (some? (:edited event))))
 
+(defn message-deleted?
+  "True when event is a message deletion notification."
+  [event]
+  (= (:subtype event) "message_deleted"))
+
 (defn app-mention-with-files?
   "Check if event is an app_mention with file attachments.
    These are skipped because file_share events handle file uploads."
@@ -104,17 +109,17 @@
   (and (app-mention? event)
        (has-files? event)))
 
-(defn bot-tag
-  "Convert bot user id to a the tag template syntax used in message text"
-  [bot-user-id]
-  (str "<@" bot-user-id ">"))
+(defn user-mention
+  "Convert a Slack user id to the mention syntax used in message text."
+  [user-id]
+  (str "<@" user-id ">"))
 
 (defn mentions-bot?
   "Check if event @mentions the bot.
    Some events, like file uploads in channels, don't come through as app_mention."
   [event bot-user-id]
   (some-> (:text event)
-          (str/includes? (bot-tag bot-user-id))))
+          (str/includes? (user-mention bot-user-id))))
 
 (defn dm-or-channel-mention?
   "Check if event is an dm or channel w/ mention of the bot."
@@ -127,7 +132,7 @@
 (defn event->prompt
   "Prepare the message event as a prompt that can be sent to an agent"
   [event bot-user-id]
-  (str/replace (:text event) (bot-tag bot-user-id) "@Metabot"))
+  (str/replace (:text event) (user-mention bot-user-id) "@Metabot"))
 
 (defn event->reply-context
   "Extract the necessary context for a reply from the given `event`"
@@ -140,5 +145,5 @@
   "Remove bot mention prefix from text (e.g., '<@U123> hello' -> 'hello')"
   [text bot-user-id]
   (if bot-user-id
-    (str/replace text (re-pattern (str (bot-tag bot-user-id) "\\s?")) "")
+    (str/replace text (re-pattern (str (user-mention bot-user-id) "\\s?")) "")
     text))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
@@ -302,6 +302,20 @@
                   (is (= 0 (count @post-calls)))
                   (is (= 0 (count @ephemeral-calls))))))))))))
 
+(deftest message-deleted-ignored-test
+  (testing "POST /events ignores message_deleted events"
+    (with-slackbot-setup
+      (let [event-body (update base-dm-event :event merge {:subtype "message_deleted"})]
+        (with-slackbot-mocks
+          {:ai-text "Should not be called"}
+          (fn [{:keys [post-calls]}]
+            (let [response (mt/client :post 200 "ee/metabot-v3/slack/events"
+                                      (slack-request-options event-body)
+                                      event-body)]
+              (is (= "ok" response))
+              (Thread/sleep 200)
+              (is (= 0 (count @post-calls))))))))))
+
 (deftest slackbot-disabled-setting-test
   (testing "POST /events acks but does not process when slack-connect-enabled is false"
     (with-slackbot-setup
@@ -548,36 +562,35 @@
                             @image-calls))))))))))
 
 (deftest user-not-linked-sends-auth-message-test
-  (testing "POST /events with unlinked user sends ephemeral auth message (DMs always threaded)"
+  (testing "POST /events with unlinked user sends auth message (DM, no user mention prefix)"
     (with-slackbot-setup
       (let [event-body (assoc-in base-dm-event [:event :user] "U-UNKNOWN-USER")]
         (with-slackbot-mocks
           {:ai-text "Should not be called"
            :user-id ::no-user}
-          (fn [{:keys [post-calls ephemeral-calls]}]
+          (fn [{:keys [post-calls]}]
             (let [response (mt/client :post 200 "ee/metabot-v3/slack/events"
                                       (slack-request-options event-body)
                                       event-body)]
               (is (= "ok" response))
-              (u/poll {:thunk #(= 1 (count @ephemeral-calls))
+              (u/poll {:thunk #(= 1 (count @post-calls))
                        :done? true?
                        :timeout-ms 5000})
-              (testing "no regular messages should be posted"
-                (is (= 0 (count @post-calls))))
-              (testing "ephemeral auth message sent to user, threaded using message ts"
-                (is (=? [{:user "U-UNKNOWN-USER"
-                          :channel "C123"
+              (testing "auth message posted as regular message, threaded using message ts"
+                (is (=? [{:channel "C123"
                           :thread_ts "1234567890.000001"
                           :text #"(?i).*connect.*slack.*metabase.*"}]
-                        @ephemeral-calls))))))))))
+                        @post-calls)))
+              (testing "DM auth message does not include user mention prefix"
+                (is (not (str/starts-with? (:text (first @post-calls)) "<@")))))))))))
 
 (deftest app-mention-unlinked-user-test
   (testing "POST /events with app_mention from unlinked user sends auth message"
     (with-slackbot-setup
       (doseq [[desc thread-ts expected-thread-ts]
-              [;; top-level @mention should NOT thread (so users see the prompt)
-               ["top-level @mention" nil nil]
-               ;; @mention in thread should thread (to keep context)
+              [;; top-level @mention threads using the event ts
+               ["top-level @mention" nil "1234567890.000002"]
+               ;; @mention in thread threads using the thread ts
                ["@mention in thread" "1234567890.000001" "1234567890.000001"]]]
         (testing desc
           (let [event-body (cond-> (update base-mention-event :event merge
@@ -588,15 +601,18 @@
             (with-slackbot-mocks
               {:ai-text "Should not be called"
                :user-id ::no-user}
-              (fn [{:keys [post-calls ephemeral-calls]}]
+              (fn [{:keys [post-calls]}]
                 (is (= "ok" (mt/client :post 200 "ee/metabot-v3/slack/events"
                                        (slack-request-options event-body) event-body)))
-                (u/poll {:thunk #(= 1 (count @ephemeral-calls))
+                (u/poll {:thunk #(= 1 (count @post-calls))
                          :done? true?
                          :timeout-ms 5000})
-                (is (= 0 (count @post-calls)))
-                (is (=? {:user "U-UNKNOWN" :channel "C123" :thread_ts expected-thread-ts}
-                        (first @ephemeral-calls)))))))))))
+                (is (=? {:channel "C123"
+                         :thread_ts expected-thread-ts
+                         :text #"(?i).*connect.*slack.*metabase.*"}
+                        (first @post-calls)))
+                (testing "channel auth message includes user mention prefix"
+                  (is (str/starts-with? (:text (first @post-calls)) "<@U-UNKNOWN>")))))))))))
 
 ;; -------------------------------- Setup Complete Tests --------------------------------
 

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
@@ -305,16 +305,19 @@
 (deftest message-deleted-ignored-test
   (testing "POST /events ignores message_deleted events"
     (with-slackbot-setup
-      (let [event-body (update base-dm-event :event merge {:subtype "message_deleted"})]
-        (with-slackbot-mocks
-          {:ai-text "Should not be called"}
-          (fn [{:keys [post-calls]}]
-            (let [response (mt/client :post 200 "ee/metabot-v3/slack/events"
-                                      (slack-request-options event-body)
-                                      event-body)]
-              (is (= "ok" response))
-              (Thread/sleep 200)
-              (is (= 0 (count @post-calls))))))))))
+      (let [event-body (update base-dm-event :event merge {:subtype "message_deleted"})
+            ignored    (atom false)]
+        (with-redefs [slackbot/ignore-event  (fn [_] (reset! ignored true))
+                      slackbot/process-async (fn [& _] (throw (ex-info "process-async should not be called" {})))]
+          (with-slackbot-mocks
+            {:ai-text "Should not be called"}
+            (fn [{:keys [post-calls]}]
+              (let [response (mt/client :post 200 "ee/metabot-v3/slack/events"
+                                        (slack-request-options event-body)
+                                        event-body)]
+                (is (= "ok" response))
+                (is @ignored "Event should have been routed to ignore-event")
+                (is (= 0 (count @post-calls)))))))))))
 
 (deftest slackbot-disabled-setting-test
   (testing "POST /events acks but does not process when slack-connect-enabled is false"


### PR DESCRIPTION
### Description

It looks broken to other users when the slack bot does not reply to a user due to them not being authenticated. This PR makes it so the message is made top level.

DMs
<img width="1408" height="734" alt="CleanShot 2026-03-05 at 15 47 30@2x" src="https://github.com/user-attachments/assets/b186ce3a-e1e7-4667-8bda-0410c3b17c16" />

Channel
<img width="1164" height="856" alt="CleanShot 2026-03-05 at 15 47 45@2x" src="https://github.com/user-attachments/assets/6014cfe4-e514-4828-bfc5-838b4f851286" />


