### PR TITLE
Fix duplicate alerts/subscriptions firing in multi-pod clusters

### DIFF
--- a/resources/quartz.properties
+++ b/resources/quartz.properties
@@ -18,6 +18,12 @@ org.quartz.jobStore.dataSource = db
 org.quartz.jobStore.isClustered = true
 # Added to see if we can prevent multiple firings (which should never happen). Source https://www.quartz-scheduler.org/documentation/quartz-1.8.6/configuration/ConfigJDBCJobStoreClustering.html
 org.quartz.jobStore.clusterCheckinInterval = 20000
+# Acquire the TRIGGER_ACCESS lock before selecting triggers to fire.
+# Without this, trigger acquisition runs without a lock, relying on an optimistic
+# UPDATE to prevent duplicate firing across cluster nodes. This has been observed
+# to fail in practice (GDGT-1790), likely due to interactions between autocommit
+# and Quartz's commit/retry logic.
+org.quartz.jobStore.acquireTriggersWithinLock = true
 
 # By default, Quartz will fire triggers up to a minute late without considering them to be misfired; if it cannot fire
 # anything within that period for one reason or another (such as all threads in the thread pool being tied up), the

--- a/src/metabase/app_db/custom_migrations/util.clj
+++ b/src/metabase/app_db/custom_migrations/util.clj
@@ -5,6 +5,8 @@
    [metabase.classloader.core :as classloader]
    [metabase.task.bootstrap]))
 
+(set! *warn-on-reflection* true)
+
 (defn- set-jdbc-backend-properties! []
   (metabase.task.bootstrap/set-jdbc-backend-properties! (mdb.connection/db-type)))
 

--- a/src/metabase/app_db/custom_migrations/util.clj
+++ b/src/metabase/app_db/custom_migrations/util.clj
@@ -27,7 +27,19 @@
   (when *allow-temp-scheduling*
     (classloader/the-classloader)
     (set-jdbc-backend-properties!)
+    ;; quartz.properties sets acquireTriggersWithinLock=true to prevent duplicate trigger firing in
+    ;; multi-pod clusters (GDGT-1790). However, the temp migration scheduler is single-instance and
+    ;; doesn't need that lock. We must disable it here because on a fresh DB, Quartz's
+    ;; StdRowLockSemaphore lazily INSERTs into QRTZ_LOCKS, and if the row already exists (e.g. from a
+    ;; prior migration step), the INSERT fails. On Postgres, a failed INSERT poisons the entire
+    ;; transaction, causing subsequent operations to fail with
+    ;; "current transaction is aborted, commands ignored until end of transaction block".
+    ;; We use a System property override because StdSchedulerFactory merges system props on top of
+    ;; quartz.properties during initialize(), and we clear it immediately after so the main scheduler
+    ;; later picks up the correct `true` value from quartz.properties.
+    (System/setProperty "org.quartz.jobStore.acquireTriggersWithinLock" "false")
     (let [scheduler (qs/initialize)]
+      (System/clearProperty "org.quartz.jobStore.acquireTriggersWithinLock")
       (when (qs/started? scheduler)
         (throw (ex-info "Scheduler is already started, cannot start temporary one" {})))
 


### PR DESCRIPTION
Fixes alerts and subscriptions firing twice in multi-pod deployments (https://linear.app/metabase/issue/GDGT-1790/investigate-alertssubscriptions-firing-twice).

In clustered mode, Quartz's default trigger acquisition is optimistic — it selects candidate triggers **without holding a lock**, then uses an UPDATE to claim them. This is vulnerable to a well-documented [ABA race condition](https://github.com/quartz-scheduler/quartz/issues/107) where multiple nodes acquire and fire the same trigger. This is a known Quartz limitation ([#107](https://github.com/quartz-scheduler/quartz/issues/107), [#731](https://github.com/quartz-scheduler/quartz/issues/731), [#548](https://github.com/quartz-scheduler/quartz/issues/548)), made more likely by our c3p0 pool returning `autoCommit=true` connections which widens the race window.

Sets `acquireTriggersWithinLock = true` in `quartz.properties`, which forces pessimistic locking via `SELECT FOR UPDATE` on `QRTZ_LOCKS` before selecting triggers to fire. This makes trigger acquisition atomic across cluster nodes.

Performance impact is negligible — the lock is held for microseconds per acquisition cycle, and Metabase fires at most dozens of triggers per minute. This was actually the default Quartz behavior before version 1.6.3.

### Immediate workaround (no code change needed)

Affected instances can apply the fix immediately without waiting for a release by adding a JVM system property:

```
JAVA_OPTS="-Dorg.quartz.jobStore.acquireTriggersWithinLock=true"
```