### PR TITLE
Tenant users are unable to query database after onboarding flow

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
@@ -972,6 +972,8 @@ describe("scenarios - embedding hub", () => {
         expect(viewData).to.exist;
         expect(viewData["PUBLIC"][STATIC_ORDERS_ID]).to.equal("sandboxed");
         expect(viewData["PUBLIC"][STATIC_PEOPLE_ID]).to.equal("sandboxed");
+
+        expect(permissions["create-queries"]).to.equal("query-builder");
       });
 
       H.main()
@@ -1194,6 +1196,7 @@ describe("scenarios - embedding hub", () => {
 
           expect(permissions).to.exist;
           expect(permissions["view-data"]).to.equal("impersonated");
+          expect(permissions["create-queries"]).to.equal("query-builder");
         });
       });
     });

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/guest-embed-ee.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/guest-embed-ee.cy.spec.ts
@@ -404,7 +404,10 @@ describe("scenarios > embedding > sdk iframe embed setup > guest-embed", () => {
           cy.findByText("Get code").click();
 
           codeBlock().first().should("contain", "dashboard-id=");
-          codeBlock().first().should("contain", "hidden-parameters=");
+
+          // hiddenParameters is reset to [] when switching from guest to SSO mode,
+          // so hidden-parameters= should not appear in the code.
+          codeBlock().first().should("not.contain", "hidden-parameters=");
 
           codeBlock().first().should("not.contain", "token=");
           codeBlock().first().should("not.contain", "locked-parameters=");

--- a/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHub.unit.spec.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHub.unit.spec.tsx
@@ -82,7 +82,10 @@ const setup = ({ isAdmin = true, checklist = {} } = {}) => {
     query: { include_only_uploadable: true },
     response: { data: [], total: 0 },
   });
-  fetchMock.get("path:/api/ee/embedding-hub/checklist", checklist);
+  fetchMock.get("path:/api/ee/embedding-hub/checklist", {
+    checklist,
+    "data-isolation-strategy": null,
+  });
 
   return renderWithProviders(<EmbeddingHub />, { storeInitialState: state });
 };

--- a/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/utils/permission-utils.ts
+++ b/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/utils/permission-utils.ts
@@ -51,7 +51,10 @@ export function buildPermissionsGraph(
 
   // Add database-level impersonation permissions
   for (const databaseId of impersonatedDatabaseIds) {
-    groupGraph[databaseId] = { "view-data": "impersonated" };
+    groupGraph[databaseId] = {
+      "view-data": "impersonated",
+      "create-queries": "query-builder",
+    };
   }
 
   // Add table-level sandbox permissions
@@ -60,7 +63,7 @@ export function buildPermissionsGraph(
     const schema = schemaName ?? "";
 
     if (!groupGraph[databaseId]) {
-      groupGraph[databaseId] = {};
+      groupGraph[databaseId] = { "create-queries": "query-builder" };
     }
 
     const dbPerms = groupGraph[databaseId];

--- a/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/utils/permission-utils.unit.spec.ts
+++ b/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/utils/permission-utils.unit.spec.ts
@@ -10,8 +10,8 @@ describe("buildPermissionsGraph", () => {
 
     expect(result).toEqual({
       [groupId]: {
-        1: { "view-data": "impersonated" },
-        2: { "view-data": "impersonated" },
+        1: { "view-data": "impersonated", "create-queries": "query-builder" },
+        2: { "view-data": "impersonated", "create-queries": "query-builder" },
       },
     });
   });
@@ -37,6 +37,7 @@ describe("buildPermissionsGraph", () => {
             public: { 100: "sandboxed", 101: "sandboxed" },
             private: { 200: "sandboxed" },
           },
+          "create-queries": "query-builder",
         },
       },
     });

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-common-embed-settings.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-common-embed-settings.ts
@@ -72,7 +72,11 @@ const GET_DISABLE_GUEST_EMBED_SETTINGS: (data: {
             !isSsoEnabledAndConfigured || useExistingUserSession,
         }),
     ...(isQuestionOrDashboardEmbed && {
-      // Reset hidden parameters when switching from guest to non-guest embed mode
+      // Reset hiddenParameters when switching from guest to SSO.
+      // This is needed because when recentlyCreatedDashboards populates the
+      // dashboardId or questionId, the embed wizard starts in guest mode and
+      // sets all parameters as disabled in hiddenParameters. Without this reset,
+      // the guest restrictions would carry over into SSO mode.
       hiddenParameters: [],
     }),
   };

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-common-embed-settings.unit.spec.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/get-common-embed-settings.unit.spec.ts
@@ -115,6 +115,7 @@ describe("getCommonEmbedSettings", () => {
             isSso: true,
             useExistingUserSession: true,
             drills: true,
+            hiddenParameters: [],
           },
         },
         {
@@ -126,6 +127,7 @@ describe("getCommonEmbedSettings", () => {
             isSso: true,
             useExistingUserSession: true,
             drills: true,
+            hiddenParameters: [],
           },
         },
         {
@@ -170,7 +172,11 @@ describe("getCommonEmbedSettings", () => {
         },
       );
 
-      it("should reset hiddenParameters for chart but not for dashboard in non-guest mode", () => {
+      it("should reset hiddenParameters for chart and dashboard when switching to non-guest (SSO) mode", () => {
+        // When recentlyCreatedDashboards/Questions populates a
+        // dashboardId or questionId, the embed wizard starts in guest mode and
+        // sets all parameters as disabled in hiddenParameters. This test ensures
+        // those guest mode restrictions are removed when switching to SSO mode.
         const chartResult = getCommonEmbedSettings({
           experience: "chart",
           isGuestEmbedsEnabled: false,
@@ -188,7 +194,7 @@ describe("getCommonEmbedSettings", () => {
         });
 
         expect(chartResult).toHaveProperty("hiddenParameters", []);
-        expect(dashboardResult).not.toHaveProperty("hiddenParameters");
+        expect(dashboardResult).toHaveProperty("hiddenParameters", []);
       });
 
       it("should handle `false` for isGuest and `useExistingUserSession`", () => {
@@ -205,6 +211,7 @@ describe("getCommonEmbedSettings", () => {
           isSso: true,
           useExistingUserSession: false,
           drills: true,
+          hiddenParameters: [],
         });
       });
 
@@ -235,6 +242,7 @@ describe("getCommonEmbedSettings", () => {
             isSso: true,
             useExistingUserSession: true,
             drills: true,
+            hiddenParameters: [],
           },
         },
         {


### PR DESCRIPTION
Closes EMB-1390

### Description

Tenant users with Row-Level Security (RLS) or Connection Impersonation setup could view embedded dashboards but were **unable to query the database directly**.

This happens because the permissions graph only set `view-data` (sandboxed/impersonated) without also granting `create-queries` access. The fix adds `"create-queries": "query-builder"` at the database level whenever sandboxed or impersonated permissions are configured for the all-tenant-users group.

### How to verify

1. Set up the embedding onboarding flow with RLS (row and column level security)
2. Select a table and column for sandboxing, then click **Next**
3. Via the API, confirm the permissions graph includes `"create-queries": "query-builder"` for the all-external-users group on that database
4. Log in as a tenant user and verify they can both view dashboards and run queries against the sandboxed tables
5. Repeat steps 1–4 using the **Connection impersonation** strategy

### Demo

<img width="486" height="440" alt="CleanShot 2569-03-06 at 20 41 36@2x" src="https://github.com/user-attachments/assets/8c41bb2c-5342-4135-864a-4c97d264ff91" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR