### PR TITLE
Polish tenant creation and SSO for embedding onboarding

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
@@ -543,7 +543,7 @@ describe("scenarios - embedding hub", () => {
 
           cy.log("fill out the tenant form");
           cy.findByPlaceholderText("Tenant name").clear().type("Acme Corp");
-          cy.findByLabelText("tenant_identifier").type("acme-123");
+          cy.findByLabelText("organization_id").type("acme-123");
           cy.findByPlaceholderText("tenant-slug")
             .clear()
             .type("acme-corp-slug");
@@ -560,7 +560,7 @@ describe("scenarios - embedding hub", () => {
             .clear()
             .type("Beta Inc");
 
-          cy.findAllByLabelText("tenant_identifier")
+          cy.findAllByLabelText("organization_id")
             .should("have.length", 2)
             .last()
             .type("beta-456");
@@ -573,7 +573,7 @@ describe("scenarios - embedding hub", () => {
         });
 
         cy.log("submit the tenant creation form");
-        H.main().findByRole("button", { name: "Next" }).click();
+        H.main().findByRole("button", { name: "Create tenants" }).click();
 
         cy.log("success toast should show");
         H.undoToast()
@@ -628,12 +628,12 @@ describe("scenarios - embedding hub", () => {
 
           expect(acmeTenant).to.exist;
           expect(acmeTenant.attributes).to.deep.equal({
-            tenant_identifier: "acme-123",
+            organization_id: "acme-123",
           });
 
           expect(betaTenant).to.exist;
           expect(betaTenant.attributes).to.deep.equal({
-            tenant_identifier: "beta-456",
+            organization_id: "beta-456",
           });
         });
 
@@ -673,7 +673,7 @@ describe("scenarios - embedding hub", () => {
             .type("existing-tenant");
         });
 
-        H.main().findByRole("button", { name: "Next" }).click();
+        H.main().findByRole("button", { name: "Create tenants" }).click();
 
         cy.log("error toast should be shown");
         H.undoToast()
@@ -708,7 +708,7 @@ describe("scenarios - embedding hub", () => {
           .should("have.attr", "aria-checked", "true");
       });
 
-      it("shows autocomplete suggestions for tenant_identifier based on selected field values", () => {
+      it("shows autocomplete suggestions for organization_id based on selected field values", () => {
         H.restore("setup");
         cy.signInAsAdmin();
         H.activateToken("bleeding-edge");
@@ -817,6 +817,11 @@ describe("scenarios - embedding hub", () => {
       cy.log("navigate to create tenants step");
       H.main().findByRole("listitem", { name: "Create tenants" }).click();
 
+      cy.log("should show dynamic description with the selected column name");
+      H.main()
+        .contains("Enter a value that matches the User ID column.")
+        .should("be.visible");
+
       cy.log("fill out the tenant form");
       H.main().within(() => {
         cy.findByPlaceholderText("Tenant name").clear().type("Acme Corp");
@@ -824,7 +829,7 @@ describe("scenarios - embedding hub", () => {
         cy.findByPlaceholderText("tenant-slug").clear().type("acme-corp");
       });
 
-      H.main().findByRole("button", { name: "Next" }).click();
+      H.main().findByRole("button", { name: "Create tenants" }).click();
 
       cy.log("success toast should show");
       H.undoToast()
@@ -949,11 +954,11 @@ describe("scenarios - embedding hub", () => {
         expect(peoplePolicy).to.exist;
 
         expect(orderPolicy.attribute_remappings).to.have.property(
-          "tenant_identifier",
+          "organization_id",
         );
 
         expect(peoplePolicy.attribute_remappings).to.have.property(
-          "tenant_identifier",
+          "organization_id",
         );
       });
 
@@ -1020,7 +1025,7 @@ describe("scenarios - embedding hub", () => {
           group_id: allExternalUsersGroup.id,
           card_id: null,
           attribute_remappings: {
-            tenant_identifier: ["dimension", ["field", 2, null]], // USER_ID field
+            organization_id: ["dimension", ["field", 2, null]], // USER_ID field
           },
         });
       });
@@ -1078,8 +1083,7 @@ describe("scenarios - embedding hub", () => {
         expect(orderPolicies.length).to.equal(1);
 
         const [orderPolicy] = orderPolicies;
-        const tenantFieldRef =
-          orderPolicy.attribute_remappings.tenant_identifier;
+        const tenantFieldRef = orderPolicy.attribute_remappings.organization_id;
 
         // attribute_remappings should reference field 3 (PRODUCT_ID),
         // not field 2 (USER_ID)
@@ -1307,7 +1311,7 @@ describe("scenarios - embedding hub", () => {
         cy.findByPlaceholderText("tenant-slug").clear().type("acme-corp");
       });
 
-      H.main().findByRole("button", { name: "Next" }).click();
+      H.main().findByRole("button", { name: "Create tenants" }).click();
 
       cy.log("success toast should show");
       H.undoToast()
@@ -1372,7 +1376,7 @@ describe("scenarios - embedding hub", () => {
         cy.findByPlaceholderText("tenant-slug").clear().type("acme-corp");
       });
 
-      H.main().findByRole("button", { name: "Next" }).click();
+      H.main().findByRole("button", { name: "Create tenants" }).click();
 
       cy.log("success toast should show");
       H.undoToast()

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/CreateTenantsOnboardingStep/CreateTenantsOnboardingStep.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/CreateTenantsOnboardingStep/CreateTenantsOnboardingStep.tsx
@@ -28,10 +28,12 @@ export const CreateTenantsOnboardingStep = ({
   onTenantsCreated,
   selectedFieldIds,
   strategy,
+  rlsColumnName,
 }: {
   onTenantsCreated?: (tenants: CreatedTenantData[]) => void;
   selectedFieldIds?: FieldId[];
   strategy?: DataSegregationStrategy | null;
+  rlsColumnName?: string | null;
 }) => {
   const [sendToast] = useToast();
 
@@ -143,6 +145,14 @@ export const CreateTenantsOnboardingStep = ({
                 )}
               </Group>
 
+              <TenantFormField
+                label={t`Tenant slug`}
+                description={t`Can't be changed later. Used to reference tenants via API and SSO.`}
+                value={tenant.slug}
+                onChange={(value) => updateTenantCard(index, "slug", value)}
+                placeholder="tenant-slug"
+              />
+
               {strategy === "row-column-level-security" && (
                 <TenantIdentifierInput
                   value={tenant.dataIsolationFieldValue}
@@ -150,6 +160,7 @@ export const CreateTenantsOnboardingStep = ({
                     updateTenantCard(index, "dataIsolationFieldValue", value)
                   }
                   selectedFieldIds={selectedFieldIds}
+                  columnName={rlsColumnName}
                 />
               )}
 
@@ -166,14 +177,6 @@ export const CreateTenantsOnboardingStep = ({
                     placeholder={fieldConfig.placeholder}
                   />
                 )}
-
-              <TenantFormField
-                label={t`Tenant slug`}
-                description={t`Can't be changed later. Used to reference tenants via API and SSO.`}
-                value={tenant.slug}
-                onChange={(value) => updateTenantCard(index, "slug", value)}
-                placeholder="tenant-slug"
-              />
             </Stack>
           </Paper>
         ))}
@@ -196,7 +199,7 @@ export const CreateTenantsOnboardingStep = ({
           loading={isLoading}
           disabled={!isValid}
         >
-          {t`Next`}
+          {t`Create tenants`}
         </Button>
       </Flex>
     </Stack>

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/CreateTenantsOnboardingStep/TenantIdentifierInput.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/CreateTenantsOnboardingStep/TenantIdentifierInput.tsx
@@ -1,4 +1,4 @@
-import { c, t } from "ttag";
+import { c, jt, t } from "ttag";
 
 import { Autocomplete, Stack, Text } from "metabase/ui";
 import type { FieldId } from "metabase-types/api";
@@ -10,10 +10,12 @@ export const TenantIdentifierInput = ({
   value,
   onChange,
   selectedFieldIds,
+  columnName,
 }: {
   value: string;
   onChange: (value: string) => void;
   selectedFieldIds?: FieldId[];
+  columnName?: string | null;
 }) => {
   // Fetch value from first field only.
   // We expect all tables to share the same multi-tenancy column,
@@ -29,6 +31,10 @@ export const TenantIdentifierInput = ({
         .t`e.g. ${suggestions[0]}`
     : c("example tenant identifier value").t`e.g. acme-corp`;
 
+  const description = columnName
+    ? jt`Enter a value that matches the ${(<strong key="col">{columnName}</strong>)} column.`
+    : config.description;
+
   return (
     <Stack gap="xs">
       <Text fw="bold" size="sm">
@@ -36,7 +42,7 @@ export const TenantIdentifierInput = ({
       </Text>
 
       <Text c="text-secondary" size="xs" mb="sm">
-        {config.description}
+        {description}
       </Text>
 
       <Autocomplete
@@ -44,7 +50,7 @@ export const TenantIdentifierInput = ({
         onChange={onChange}
         data={suggestions}
         placeholder={placeholder}
-        aria-label={t`tenant_identifier`}
+        aria-label={t`organization_id`}
       />
     </Stack>
   );

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/CreateTenantsOnboardingStep/isolation-field-config.ts
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/CreateTenantsOnboardingStep/isolation-field-config.ts
@@ -4,7 +4,7 @@ import { t } from "ttag";
 import type { DataSegregationStrategy } from "metabase/embedding/embedding-hub";
 
 export type IsolationFieldConfig = {
-  /** The attribute key sent to the API, e.g. tenant_identifier */
+  /** The attribute key sent to the API, e.g. organization_id */
   attributeKey: string;
 
   label: string;
@@ -17,8 +17,8 @@ export const getIsolationFieldConfig = (
 ): IsolationFieldConfig | null =>
   match(strategy)
     .with("row-column-level-security", () => ({
-      attributeKey: "tenant_identifier",
-      label: "tenant_identifier",
+      attributeKey: "organization_id",
+      label: "organization_id",
       description: t`Users will only see rows where this matches the value in the column you selected.`,
       placeholder: "1",
     }))

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantsSummaryOnboardingStep/TenantsSummaryOnboardingStep.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantsSummaryOnboardingStep/TenantsSummaryOnboardingStep.tsx
@@ -22,7 +22,7 @@ import { TenantSummaryCard } from "./TenantSummaryCard";
 const MAX_FETCHED_TENANTS_TO_SHOW = 3;
 
 const ISOLATION_ATTRIBUTE_KEYS = [
-  "tenant_identifier",
+  "organization_id",
   "database_role",
   "database_slug",
 ] as const;

--- a/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/RlsDataSelector/RlsDataSelector.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/RlsDataSelector/RlsDataSelector.tsx
@@ -99,7 +99,7 @@ export const RlsDataSelector = ({ onSuccess }: RlsDataSelectorProps) => {
   return (
     <Stack gap="md">
       <Text size="md" c="text-secondary" lh="lg">
-        {t`Select one or more tables to be made visible to tenant users, and the column to filter by. Only rows where the value in the selected column matches the tenant_identifier attribute will be visible to tenant users. You will create tenants and configure this attribute in the next step.`}
+        {t`Select one or more tables to be made visible to tenant users, and the column to filter by. Only rows where the value in the selected column matches the organization_id attribute will be visible to tenant users. You will create tenants and configure this attribute in the next step.`}
       </Text>
 
       <Text size="md" c="text-secondary" lh="lg">
@@ -130,7 +130,7 @@ export const RlsDataSelector = ({ onSuccess }: RlsDataSelectorProps) => {
         <UnstyledButton onClick={addTable} className={S.AddTableButton}>
           <Flex align="center" gap="xs">
             <Icon name="add" size={16} />
-            <Text fw="bold" size="md">{t`Add table`}</Text>
+            <Text fw="bold" size="md" c="inherit">{t`Add table`}</Text>
           </Flex>
         </UnstyledButton>
 

--- a/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/RlsDataSelector/TableColumnCard.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/RlsDataSelector/TableColumnCard.tsx
@@ -190,7 +190,7 @@ export const TableColumnCard = ({
           </Text>
 
           <Text size="sm" c="text-secondary" mb="sm">
-            {t`Tenant users will only see rows where this equals the tenant_identifier attribute.`}
+            {t`Tenant users will only see rows where this equals the organization_id attribute.`}
           </Text>
 
           <Select

--- a/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/SetupPermissionsAndTenantsPage.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/SetupPermissionsAndTenantsPage.tsx
@@ -182,6 +182,7 @@ export const SetupPermissionsAndTenantsPage = () => {
             onTenantsCreated={setCreatedTenants}
             selectedFieldIds={rlsSelection.fieldIds}
             strategy={activeStrategy}
+            rlsColumnName={rlsSelection.columnName}
           />
         </OnboardingStepper.Step>
 

--- a/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/utils/permission-utils.ts
+++ b/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/utils/permission-utils.ts
@@ -99,6 +99,6 @@ export const buildSandboxPolicies = (
     group_id: groupId,
     card_id: null,
     attribute_remappings: {
-      tenant_identifier: ["dimension", ["field", table.filterFieldId, null]],
+      organization_id: ["dimension", ["field", table.filterFieldId, null]],
     },
   }));

--- a/frontend/src/metabase/embedding/embedding-hub/components/SetupSsoPage/SetupJwtStep.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/SetupSsoPage/SetupJwtStep.tsx
@@ -48,13 +48,13 @@ export const SetupJwtStep = ({ onSuccess }: { onSuccess: () => void }) => {
   return (
     <Stack gap="lg">
       <Text size="md" c="text-secondary" lh="lg">
-        {t`You can connect Metabase to your identity provider using JSON Web Tokens (JWT) to authenticate people. Enabling JWT authentication will also create a signing key and enable group sync.`}
+        {t`To implement SSO you will need to add a new endpoint to your app. You can connect Metabase to your identity provider using JSON Web Tokens (JWT) to authenticate people. Enabling JWT authentication will also create a signing key and enable group sync.`}
       </Text>
 
       <TextInput
         label={t`JWT Identity Provider URI`}
         description={t`This is where Metabase will redirect login requests`}
-        placeholder="https://jwt.yourdomain.org"
+        placeholder="http://localhost:9090/metabase/sso"
         value={jwtIdentityProviderUri}
         onChange={(e) => setJwtIdentityProviderUri(e.target.value)}
         required


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/EMB-1391/polish-tenant-creation-and-sso-copy-and-ui

### Description

Pre-merge visual and copy polish for the embedding onboarding improvements. Renames the `tenant_identifier` attribute to `organization_id` everywhere, reorders tenant creation form fields for better UX, improves the tenant identifier description to dynamically reference the selected column name, and clarifies the SSO setup copy.

### How to verify

1. Go to `/admin/embedding/setup-guide` and start the setup flow with RLS (row-level security) strategy.
2. In the "Create tenants" step, verify: the slug field appears below tenant name (above the identifier), the identifier input label says "organization_id", and the description reads "Enter a value that matches the **<column name>** column."
3. Confirm the "+ Add table" text in the RLS data selector is blue.
4. Create tenants and verify the button says "Create tenants" (not "Next").
5. In the tenants summary, verify the attribute shown is `organization_id`.
6. Go to the SSO setup page (`/admin/embedding/setup-sso`) and verify the intro text clarifies adding a new endpoint, and the IdP URI placeholder is `http://localhost:9090/metabase/sso`.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR