### PR TITLE
Fix TS failure - duplicated selectors

### DIFF
--- a/frontend/src/metabase-types/store/admin.ts
+++ b/frontend/src/metabase-types/store/admin.ts
@@ -30,9 +30,6 @@ export type TemporaryPasswordsState = Record<number, string | null>;
 
 export interface AdminState {
   app: AdminAppState;
-  people: {
-    temporaryPasswords: Record<number, string>;
-  };
   permissions: {
     dataPermissions: GroupsPermissions;
     originalDataPermissions: GroupsPermissions;

--- a/frontend/src/metabase-types/store/mocks/admin.ts
+++ b/frontend/src/metabase-types/store/mocks/admin.ts
@@ -4,9 +4,6 @@ export const createMockAdminState = (
   opts?: Partial<AdminState>,
 ): AdminState => ({
   app: createMockAdminAppState(),
-  people: {
-    temporaryPasswords: {},
-  },
   permissions: createMockPermissionsState(),
   databases: {
     deletionError: null,


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-1892/fix-broken-ci-on-master-type-check-issues-people-selectors

We have TS failure on `master` after https://github.com/metabase/metabase/pull/69431 was merged

```
Error: frontend/src/metabase-types/store/admin.ts(33,3): error TS2300: Duplicate identifier 'people'.
Error: frontend/src/metabase-types/store/admin.ts(63,3): error TS2300: Duplicate identifier 'people'.
Error: frontend/src/metabase-types/store/admin.ts(63,3): error TS2717: Subsequent property declarations must have the same type.  Property 'people' must be of type '{ temporaryPasswords: Record<number, string>; }', but here has type '{ temporaryPasswords: TemporaryPasswordsState; }'.
Error: frontend/src/metabase-types/store/mocks/admin.ts(18,3): error TS1117: An object literal cannot have multiple properties with the same name.
Error: Process completed with exit code 2.
```