### PR TITLE
Make 58 resilient to 59 data_layer values, to avoid mid-upgrade crashes

### DIFF
--- a/src/metabase/warehouse_schema/models/table.clj
+++ b/src/metabase/warehouse_schema/models/table.clj
@@ -111,10 +111,25 @@
                                :status-code 400}))))
           (some-> value name))})
 
+(def ^:private transform-data-layer
+  "Tolerant data_layer transform that maps unknown values (e.g. from a v59 migration)
+   back to v58 medallion values. This prevents errors when v58 code is still running
+   during a rolling upgrade to v59."
+  {:in  (:in mi/transform-keyword)
+   :out (comp (some-fn data-layers
+                       ;; v59 renames the data_layer enum. During a rolling deploy, the v59 migration
+                       ;; may have already run while v58 pods are still serving requests.
+                       ;; Map v59 values back to their v58 equivalents.
+                       {:hidden   :copper
+                        :internal :copper
+                        :final    :gold}
+                       identity)
+              (:out mi/transform-keyword))})
+
 (t2/deftransforms :model/Table
   {:entity_type     mi/transform-keyword
    :visibility_type mi/transform-keyword
-   :data_layer      (mi/transform-validator mi/transform-keyword (partial mi/assert-optional-enum data-layers))
+   :data_layer      (mi/transform-validator transform-data-layer (partial mi/assert-optional-enum data-layers))
    :field_order     mi/transform-keyword
    :data_source     (mi/transform-validator mi/transform-keyword (partial mi/assert-optional-enum data-sources))
    ;; Warning: by using a transform to handle unexpected enum values, serialization becomes lossy

--- a/test/metabase/warehouse_schema/models/table_test.clj
+++ b/test/metabase/warehouse_schema/models/table_test.clj
@@ -562,3 +562,17 @@
         (is (= coll1-id (-> hydrated first :collection :id)))
         (is (= coll2-id (-> hydrated second :collection :id)))
         (is (nil? (-> hydrated (nth 2) :collection)))))))
+
+(deftest data-layer-tolerates-v59-values-test
+  (testing "v58 code can read data_layer values written by v59 migrations (#69158)"
+    (mt/with-temp [:model/Table {table-id :id} {}]
+      (doseq [[v59-value expected-v58-value] {"hidden"   :copper
+                                              "internal" :copper
+                                              "final"    :gold}]
+        (testing (format "v59 value %s maps to %s" v59-value expected-v58-value)
+          ;; Simulate v59 migration having written the new enum value
+          (t2/query-one {:update :metabase_table
+                         :set    {:data_layer v59-value}
+                         :where  [:= :id table-id]})
+          (is (= expected-v58-value
+                 (t2/select-one-fn :data_layer :model/Table :id table-id))))))))


### PR DESCRIPTION
reverse of https://github.com/metabase/metabase/pull/69158