### PR TITLE
backport gitignore change for sdk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ cypress.env.json
 /resources/frontend_client/app/embed.js
 /resources/frontend_client/app/embedding-sdk.js
 /resources/frontend_client/app/embedding-sdk.js.map
+/resources/frontend_client/app/embedding-sdk/
 /resources/frontend_client/tmp-*/
 /resources/frontend_client/embed.html
 /resources/frontend_client/embed-sdk.html


### PR DESCRIPTION
This is to make sure we won't see dozens of files when switching from master to this release branch after https://github.com/metabase/metabase/pull/70015
Closes https://linear.app/metabase/issue/EMB-1402/backport-changes-to-gitignore-so-that-we-wont-see-dozens-files-in-the