### PR TITLE
fix: metabot has no context on the currently open transform

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/agent/prompts.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/agent/prompts.clj
@@ -75,8 +75,9 @@
   - template: Template string (from load-system-prompt-template)
   - context: Map of template variables
 
-  Common context variables:
-  - :current-time - User's current time string
+   Common context variables:
+   - :current-user-info - Formatted current user info and glossary
+   - :current-time - User's current time string
   - :first-day-of-week - Calendar week start (default \"Sunday\")
   - :sql-dialect - SQL dialect name
   - :sql-dialect-instructions - Dialect-specific guidance (markdown)
@@ -203,6 +204,8 @@
             dialect-instructions (when sql-dialect
                                    (get-cached-dialect-instructions sql-dialect))
             tool-instructions    (extract-tool-instructions tools)
+            current-user-info    (or (get context :current_user_info)
+                                     (get context :current-user-info))
             current-time         (or (get context :current_time)
                                      (get context :current-time))
             first-day-of-week    (or (get context :first_day_of_week)
@@ -212,6 +215,7 @@
             recent-views         (or (get context :recent_views)
                                      (get context :recent-views))
             template-context     {:current_time             current-time
+                                  :current_user_info        current-user-info
                                   :first_day_of_week        first-day-of-week
                                   :sql_dialect              sql-dialect
                                   :sql_dialect_instructions dialect-instructions

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/agent/user_context.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/agent/user_context.clj
@@ -170,16 +170,77 @@
                                       (map format-entity)
                                       te/lines)))))
 
+(defn- transform-query-source-text
+  [source]
+  (let [query (:query source)]
+    (cond
+      (string? query) query
+      (string? (:query-content query)) (:query-content query)
+      (string? (get-in query [:native :query])) (get-in query [:native :query])
+      (and (map? query) (:database query))
+      (try
+        (let [normalized (lib-be/normalize-query query)]
+          (if (lib/native-only-query? normalized)
+            (or (lib/raw-native-query normalized)
+                (some :native (:stages normalized))
+                (get-in normalized [:native :query]))
+            (u/pprint-to-str normalized)))
+        (catch Exception _
+          (u/pprint-to-str query)))
+      (map? query) (u/pprint-to-str query)
+      :else (some-> query str))))
+
+(defn- transform-source-type
+  [source]
+  (normalize-context-type (:type source)))
+
+(defmulti format-transform-source
+  "Format a transform source for LLM representation."
+  {:arglists '([source])}
+  transform-source-type)
+
+(defmethod format-transform-source :default
+  [source]
+  (log/warn "Unknown transform source type:" (:type source))
+  (te/lines "Transform source"
+            (te/field "Type" (transform-source-type source))
+            (te/field "Value" (u/pprint-to-str source))))
+
+(defmethod format-transform-source "query"
+  [source]
+  (let [source-text (transform-query-source-text source)]
+    (te/lines "Transform source"
+              (te/field "Type" (:type source))
+              (te/field "Query type" (:transform-source-type source))
+              (te/field "Source database ID" (or (:source-database source)
+                                                 (get-in source [:query :database])))
+              (te/field "Query" (te/code source-text (when (= "native" (normalize-context-type (:transform-source-type source)))
+                                                       "sql"))))))
+
+(defmethod format-transform-source "python"
+  [source]
+  (te/lines "Transform source"
+            (te/field "Type" (:type source))
+            (te/field "Source database ID" (:source-database source))
+            (te/field "Source tables" (some-> (:source-tables source) u/pprint-to-str))
+            (te/field "Source code" (te/code (:body source) "python"))))
+
 (defmethod format-entity "transform"
   [item]
   (te/lines "The user is currently viewing a Transform."
             (te/field "Transform ID" (:id item))
             (te/field "Transform name" (:name item))
+            (te/field "Transform description" (:description item))
             (te/field "Source type" (:source_type item))
+            (te/field "Source" (some-> (:source item)
+                                       (assoc :transform-source-type (:source_type item))
+                                       format-transform-source))
             (te/field "Transform error" (te/code (:error item)))
             (te/field "Tables used" (some->> (:used_tables item)
                                              (map format-entity)
-                                             te/lines))))
+                                             te/lines))
+            (te/field "Created at" (:created_at item))
+            (te/field "Updated at" (:updated_at item))))
 
 (defmethod format-entity "code_editor"
   [{:keys [buffers]}]

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/agent/user_context.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/agent/user_context.clj
@@ -6,6 +6,8 @@
   (:require
    [clojure.string :as str]
    [metabase-enterprise.metabot-v3.tmpl :as te]
+   [metabase-enterprise.metabot-v3.tools.entity-details :as entity-details]
+   [metabase-enterprise.metabot-v3.tools.llm-representations :as llm-rep]
    [metabase.lib-be.core :as lib-be]
    [metabase.lib.core :as lib]
    [metabase.util :as u]
@@ -296,6 +298,21 @@
                 "If any item seems relevant, try to fetch its full details using the appropriate tool."
                 "Otherwise, use the search tool to find relevant entities."))))
 
+(defn format-current-user-info
+  "Format the current user and glossary for injection into the system message.
+
+  Returns XML for template variable {{current_user_info}}."
+  [_context]
+  (try
+    (when-let [{:keys [id name email-address glossary]} (:structured-output (entity-details/get-current-user nil))]
+      (llm-rep/user->xml {:id       id
+                          :name     name
+                          :email    email-address
+                          :glossary glossary}))
+    (catch Exception e
+      (log/error e "Error formatting current user info")
+      nil)))
+
 ;;; Context Enrichment
 
 (defn enrich-context-for-template
@@ -305,11 +322,13 @@
   - :current_time - Formatted user time string
   - :first_day_of_week - Calendar week start (default 'Sunday')
   - :sql_dialect - SQL dialect name (lowercase)
+  - :current_user_info - Formatted current user info and glossary
   - :viewing_context - Formatted viewing context
   - :recent_views - Formatted recent views"
   [context]
   {:current_time (format-current-time context)
    :first_day_of_week (get context :first_day_of_week "Sunday")
    :sql_dialect (extract-sql-dialect context)
+   :current_user_info (format-current-user-info context)
    :viewing_context (format-viewing-context context)
    :recent_views (format-recent-views context)})

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/agent/prompts_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/agent/prompts_test.clj
@@ -155,4 +155,19 @@
           content (prompts/build-system-message-content profile context tools)]
       (is (some? content))
       (is (string? content))
-      (is (> (count content) 1000))))) ; internal.selmer is large
+      (is (> (count content) 1000))))
+
+  (testing "renders transform codegen template with literal model syntax"
+    (let [profile {:prompt-template "transform-codegen.selmer"}
+          context {:current_time "2024-01-15 14:30:00"
+                   :sql-dialect "postgresql"}
+          tools {}
+          content (prompts/build-system-message-content profile context tools)]
+      (is (some? content))
+      (is (string? content))
+      (is (str/includes? content "{{#model_id-short-slug}}"))
+      (is (str/includes? content "{{#5-user-details}}"))
+      (is (str/includes? content "{{snippet: Snippet Name}}"))
+      (is (str/includes? content "{{snippet: recent orders}}"))
+      (is (not (str/includes? content "{%raw%}")))
+      (is (not (str/includes? content "{% safe %}"))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/agent/prompts_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/agent/prompts_test.clj
@@ -170,4 +170,14 @@
       (is (str/includes? content "{{snippet: Snippet Name}}"))
       (is (str/includes? content "{{snippet: recent orders}}"))
       (is (not (str/includes? content "{%raw%}")))
-      (is (not (str/includes? content "{% safe %}"))))))
+      (is (not (str/includes? content "{% safe %}")))))
+
+  (testing "includes current user info when provided"
+    (let [profile {:prompt-template "internal.selmer"}
+          context {:current_time "2024-01-15 14:30:00"
+                   :current_user_info "<user><name>Jane Doe</name></user>"}
+          tools {}
+          content (prompts/build-system-message-content profile context tools)]
+      (is (some? content))
+      (is (str/includes? content "Here is some information about the user:"))
+      (is (str/includes? content "<user><name>Jane Doe</name></user>")))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/agent/user_context_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/agent/user_context_test.clj
@@ -1,7 +1,9 @@
 (ns metabase-enterprise.metabot-v3.agent.user-context-test
   (:require
    [clojure.test :refer :all]
-   [metabase-enterprise.metabot-v3.agent.user-context :as user-context]))
+   [metabase-enterprise.metabot-v3.agent.user-context :as user-context]
+   [metabase-enterprise.metabot-v3.tools.entity-details :as entity-details]
+   [metabase-enterprise.metabot-v3.tools.llm-representations :as llm-rep]))
 
 (deftest format-current-time-test
   (testing "formats time from context with timezone"
@@ -273,27 +275,48 @@
           result (user-context/format-recent-views context)]
       (is (= "" result)))))
 
+(deftest format-current-user-info-test
+  (testing "formats the current user as XML"
+    (with-redefs [entity-details/get-current-user (fn [_]
+                                                    {:structured-output {:id            1
+                                                                         :name          "Jane Doe"
+                                                                         :email-address "jane@example.com"
+                                                                         :glossary      {"ARR" "Annual Recurring Revenue"}}})]
+      (is (= (llm-rep/user->xml {:id       1
+                                 :name     "Jane Doe"
+                                 :email    "jane@example.com"
+                                 :glossary {"ARR" "Annual Recurring Revenue"}})
+             (user-context/format-current-user-info {})))))
+
+  (testing "returns nil when there is no current user"
+    (with-redefs [entity-details/get-current-user (fn [_]
+                                                    {:output "current user not found"})]
+      (is (nil? (user-context/format-current-user-info {}))))))
+
 (deftest enrich-context-for-template-test
   (testing "enriches context with all template variables (legacy type: native)"
-    (let [context {:current_time_with_timezone "2024-01-15T14:30:00-05:00"
-                   :first_day_of_week "Monday"
-                   :user_is_viewing [{:type "native"
-                                      :sql_engine "PostgreSQL"
-                                      :query "SELECT * FROM users"}]
-                   :user_recently_viewed [{:type "table"
-                                           :id 123
-                                           :name "users"}]}
-          result (user-context/enrich-context-for-template context)]
-      (is (contains? result :current_time))
-      (is (contains? result :first_day_of_week))
-      (is (contains? result :sql_dialect))
-      (is (contains? result :viewing_context))
-      (is (contains? result :recent_views))
-      (is (string? (:current_time result)))
-      (is (= "Monday" (:first_day_of_week result)))
-      (is (= "postgresql" (:sql_dialect result)))
-      (is (string? (:viewing_context result)))
-      (is (string? (:recent_views result)))))
+    (with-redefs [user-context/format-current-user-info (constantly "<user>Jane Doe</user>")]
+      (let [context {:current_time_with_timezone "2024-01-15T14:30:00-05:00"
+                     :first_day_of_week "Monday"
+                     :user_is_viewing [{:type "native"
+                                        :sql_engine "PostgreSQL"
+                                        :query "SELECT * FROM users"}]
+                     :user_recently_viewed [{:type "table"
+                                             :id 123
+                                             :name "users"}]}
+            result (user-context/enrich-context-for-template context)]
+        (is (contains? result :current_time))
+        (is (contains? result :first_day_of_week))
+        (is (contains? result :sql_dialect))
+        (is (contains? result :current_user_info))
+        (is (contains? result :viewing_context))
+        (is (contains? result :recent_views))
+        (is (string? (:current_time result)))
+        (is (= "Monday" (:first_day_of_week result)))
+        (is (= "postgresql" (:sql_dialect result)))
+        (is (= "<user>Jane Doe</user>" (:current_user_info result)))
+        (is (string? (:viewing_context result)))
+        (is (string? (:recent_views result))))))
 
   (testing "enriches context from frontend adhoc native query payload"
     (let [context {:current_time_with_timezone "2024-01-15T14:30:00-05:00"

--- a/resources/metabot/prompts/system/internal.selmer
+++ b/resources/metabot/prompts/system/internal.selmer
@@ -544,7 +544,16 @@ Here's your [Sales Metric Cube](metabase://query/456).
 
 Current date: {{ current_time }}
 In the system, the first day of the week (index 1) is: {{ first_day_of_week }}
+{% if current_user_info %}
+
+<user_context>
+Here is some information about the user:
+{{ current_user_info|safe }}
 {% if viewing_context %}
+{{ viewing_context|safe }}
+{% endif %}
+</user_context>
+{% elif viewing_context %}
 
 <user_context>
 {{ viewing_context|safe }}

--- a/resources/metabot/prompts/system/natural-language-querying-only.selmer
+++ b/resources/metabot/prompts/system/natural-language-querying-only.selmer
@@ -509,7 +509,16 @@ Key Rules:
 Current date and time: {{current_time}}
 
 In the system, the first day of the week (index 1) is: {{ first_day_of_week }}
+{% if current_user_info %}
+
+<user_context>
+Here is some information about the user:
+{{ current_user_info|safe }}
 {% if viewing_context %}
+{{ viewing_context|safe }}
+{% endif %}
+</user_context>
+{% elif viewing_context %}
 
 <user_context>
 {{ viewing_context|safe }}

--- a/resources/metabot/prompts/system/sql-querying-only.selmer
+++ b/resources/metabot/prompts/system/sql-querying-only.selmer
@@ -276,7 +276,16 @@ If you are fixing SQL errors it is FORBIDDEN to replace referenced models and ta
 Current date and time: {{current_time}}
 
 In the system, the first day of the week (index 1) is: {{ first_day_of_week }}
+{% if current_user_info %}
+
+<user_context>
+Here is some information about the user:
+{{ current_user_info|safe }}
 {% if viewing_context %}
+{{ viewing_context|safe }}
+{% endif %}
+</user_context>
+{% elif viewing_context %}
 
 <user_context>
 {{ viewing_context|safe }}

--- a/resources/metabot/prompts/system/transform-codegen.selmer
+++ b/resources/metabot/prompts/system/transform-codegen.selmer
@@ -188,7 +188,7 @@ There are three types of transforms based on their type field:
 - **Query builder Transforms** (type="mbql"): Use queries created through the Query builder notebook UI. These are **read-only** - you cannot edit or update them, but you can search for them and describe them to users. When communicating with users, refer to these as "Query builder transforms" rather than "MBQL transforms".
 - **Python Transforms** (type="python"): Use Python functions to process data. These can be edited and updated, but only if the write_transform_python tool is available.
 
-**Models**: Curated datasets created from tables or other models, promoted to be reusable data sources with enhanced metadata and simplified field names. In transform SQL, reference models using the template syntax {%raw%}`{{#model_id-short-slug}}`{%endraw%} with an alias (e.g., `SELECT * FROM {%raw%}{{#5-user-details}}{%endraw%} as user_details`).
+**Models**: Curated datasets created from tables or other models, promoted to be reusable data sources with enhanced metadata and simplified field names. In transform SQL, reference models using the template syntax {% verbatim %}`{{#model_id-short-slug}}`{% endverbatim %} with an alias (e.g., {% verbatim %}`SELECT * FROM {{#5-user-details}} as user_details`{% endverbatim %}).
 
 **Tables**: Raw data tables from connected databases that contain the actual records and fields. These are your base data sources that transforms query and transform into more useful structures.
 
@@ -211,11 +211,11 @@ Use snippet tools when users explicitly request:
 **How to Use Snippets:**
 1. Use `list_snippets` to see available options
 2. Use `get_snippet_details` to view snippet content
-3. Reference snippets using {% safe %}`{{snippet: Snippet Name}}`{% endsafe %} syntax
+3. Reference snippets using {% verbatim %}`{{snippet: Snippet Name}}`{% endverbatim %} syntax
 4. Verify the final SQL will be syntactically correct
 
 **Essential Rules:**
-- Always reference by name: {% safe %}`{{snippet: Name}}`{% endsafe %} - never copy/paste content
+- Always reference by name: {% verbatim %}`{{snippet: Name}}`{% endverbatim %} - never copy/paste content
 - Only use snippets that fit without modification
 - Snippets work in SQL transforms only, not Python transforms
 - If a snippet needs changes, write custom SQL instead
@@ -224,7 +224,7 @@ Use snippet tools when users explicitly request:
 If there's a snippet called "recent orders":
 
 ```sql
-SELECT * FROM orders WHERE {% safe %}`{{snippet: recent orders}}`{% endsafe %}
+SELECT * FROM orders WHERE {% verbatim %}`{{snippet: recent orders}}`{% endverbatim %}
 ```
 
 ## Task execution
@@ -233,7 +233,7 @@ You are a coding agent, the assumed task is that you're helping modify the sourc
 Autonomously resolve the relevant transforms, queries, tables, etc. to the best of your ability, using the tools available to you, before coming back to the user. Do NOT guess or make up an answer.
 
 When working with SQL queries, you can query both tables and Metabase models.
-Models use the template syntax {{'{{#model_id-short-slug}}'}} (e.g., SELECT * FROM {{'{{#5-user-details}} as user_details'}}).
+Models use the template syntax {% verbatim %}{{#model_id-short-slug}}{% endverbatim %} (e.g., {% verbatim %}SELECT * FROM {{#5-user-details}} as user_details{% endverbatim %}).
 When querying models, always provide an alias for the model, even if the not required by the SQL dialect ({{dialect}}). This
 ensures clarity and consistency, and prevents errors in dialects that require it.
 

--- a/resources/metabot/prompts/system/transform-codegen.selmer
+++ b/resources/metabot/prompts/system/transform-codegen.selmer
@@ -390,7 +390,16 @@ The following tools have specific behavioral requirements that you must follow:
 Current date and time: {{current_time}}
 
 In the system, the first day of the week (index 1) is: {{ first_day_of_week }}
+{% if current_user_info %}
+
+<user_context>
+Here is some information about the user:
+{{ current_user_info|safe }}
 {% if viewing_context %}
+{{ viewing_context|safe }}
+{% endif %}
+</user_context>
+{% elif viewing_context %}
 
 <user_context>
 {{ viewing_context|safe }}


### PR DESCRIPTION
Closes [BOT-1082: Metabot has no context on the currently open transform](https://linear.app/metabase/issue/BOT-1082/metabot-has-no-context-on-the-currently-open-transform)

### Description

Clojure port of ai-service didn't include some of the context that ai-service did.

### How to verify

1. Go to a python transform
2. Edit it
3. Ask metabot to make some edits

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
