### PR TITLE
Fix prettier failing on master on SDK components

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/content-translations-rerender-reproduction.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/content-translations-rerender-reproduction.cy.spec.tsx
@@ -1,4 +1,3 @@
-
 import { InteractiveQuestion } from "@metabase/embedding-sdk-react";
 
 import { popover } from "e2e/support/helpers";

--- a/e2e/test-component/scenarios/embedding-sdk/content-translations.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/content-translations.cy.spec.tsx
@@ -1,4 +1,3 @@
-
 import {
   CollectionBrowser,
   InteractiveQuestion,

--- a/e2e/test-component/scenarios/embedding-sdk/create-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/create-question.cy.spec.tsx
@@ -1,4 +1,3 @@
-
 import { InteractiveQuestion } from "@metabase/embedding-sdk-react";
 
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";

--- a/e2e/test-component/scenarios/embedding-sdk/data-picker.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/data-picker.cy.spec.tsx
@@ -1,4 +1,3 @@
-
 import { InteractiveQuestion } from "@metabase/embedding-sdk-react";
 
 import { popover } from "e2e/support/helpers";

--- a/e2e/test-component/scenarios/embedding-sdk/sdk-question-native.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/sdk-question-native.cy.spec.tsx
@@ -1,4 +1,3 @@
-
 import { InteractiveQuestion } from "@metabase/embedding-sdk-react";
 import { useState } from "react";
 

--- a/e2e/test-component/scenarios/embedding-sdk/sdk-question-theming.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/sdk-question-theming.cy.spec.tsx
@@ -1,4 +1,3 @@
-
 import {
   InteractiveQuestion,
   type MetabaseTheme,


### PR DESCRIPTION
Closes EMB-1406

Not sure what happened but I think prettier is removing the first empty line on master? Must be a recent PR.