### PR TITLE
[MBQL lib] Ignore `inherited-temporal-unit` on bucketed columns

### DIFF
--- a/src/metabase/lib/equality.cljc
+++ b/src/metabase/lib/equality.cljc
@@ -159,8 +159,12 @@ are known to be the same."
     ;; same bucketing
    (when (columns-not-equal-by-fn (comp ignore-default-temporal-bucket lib.temporal-bucket/raw-temporal-bucket) col-1 col-2)
      'temporal-bucket)
-    ;; check `:inherited-temporal-unit` as well if both columns have it.
-   (when (columns-not-equal-by-fn-when-non-nil-in-both (comp ignore-default-temporal-bucket :inherited-temporal-unit) col-1 col-2)
+    ;; check `:inherited-temporal-unit` as well if both columns have it, but only when neither column has an explicit
+    ;; temporal bucket. When both columns have the same explicit bucket (checked above), the inherited temporal unit is
+    ;; just historical metadata and shouldn't affect identity. See #70231.
+   (when (and (nil? (ignore-default-temporal-bucket (lib.temporal-bucket/raw-temporal-bucket col-1)))
+              (nil? (ignore-default-temporal-bucket (lib.temporal-bucket/raw-temporal-bucket col-2)))
+              (columns-not-equal-by-fn-when-non-nil-in-both (comp ignore-default-temporal-bucket :inherited-temporal-unit) col-1 col-2))
      :inherited-temporal-unit)
     ;; finally make sure they have the same `:lib/source-column-alias` (if both columns have it) or `:name` (if for
     ;; some reason they do not)

--- a/test/metabase/query_processor/util/add_alias_info_test.clj
+++ b/test/metabase/query_processor/util/add_alias_info_test.clj
@@ -1361,3 +1361,57 @@
               (-> (add-alias-info query)
                   lib/aggregations
                   first))))))
+
+(deftest ^:parallel inherited-temporal-unit-mismatch-in-nested-model-test
+  (testing "Breakout on a joined DateTime column in a nested model gets a ::desired-alias even when
+            :inherited-temporal-unit differs between field ref and returned column (#70231)"
+    (let [mp (lib.tu/mock-metadata-provider
+              meta/metadata-provider
+              ;; Model 1: orders joined with products, producing "Products__CREATED_AT"
+              {:cards [{:id            1
+                        :dataset-query (-> (lib/query meta/metadata-provider
+                                                      (lib.metadata/table meta/metadata-provider (meta/id :orders)))
+                                           (lib/join (lib/join-clause
+                                                      (lib.metadata/table meta/metadata-provider (meta/id :products))
+                                                      [(lib/= (lib.metadata/field meta/metadata-provider (meta/id :orders :product-id))
+                                                              (lib.metadata/field meta/metadata-provider (meta/id :products :id)))]))
+                                           lib/->legacy-MBQL)
+                        :database-id   (meta/id)
+                        :name          "Orders+Products"
+                        :type          :model}]})
+          ;; Model 2: queries model 1 with a breakout on Products__CREATED_AT bucketed by :day,
+          ;; plus an aggregation.
+          model-2-query (as-> (lib/query mp (lib.metadata/card mp 1)) $q
+                          (lib/breakout $q (-> (m/find-first (comp #{"Products__CREATED_AT"} :lib/source-column-alias)
+                                                             (lib/breakoutable-columns $q))
+                                               (lib/with-temporal-bucket :day)))
+                          (lib/aggregate $q (lib/count)))
+          ;; Inject stale :inherited-temporal-unit into the breakout field ref, simulating a card
+          ;; saved when the source column had :minute granularity.
+          ;; Legacy field refs are [:field name-or-id opts-map].
+          model-2-query (lib/update-query-stage
+                         model-2-query -1
+                         assoc-in [:breakouts 0 1 :inherited-temporal-unit] :minute)
+          mp (lib.tu/mock-metadata-provider
+              mp
+              {:cards [{:id            2
+                        :dataset-query model-2-query
+                        :database-id   (meta/id)
+                        :name          "Orders+Products Summary"
+                        :type          :model}]})
+          ;; Top-level query on model 2 — flattens stages and triggers the mismatch
+          query (lib/query mp (lib.metadata/card mp 2))]
+      (qp.store/with-metadata-provider mp
+        (driver/with-driver :h2
+          (let [with-aliases (-> query qp.preprocess/preprocess add/add-alias-info)
+                ;; The breakout lives in the inner flattened stage (from model 2)
+                breakout-stage (->> (:stages with-aliases)
+                                    (m/find-first :breakout))
+                created-at-brk (->> (:breakout breakout-stage)
+                                    (m/find-first (fn [[_tag _opts col-ref]]
+                                                    (and (string? col-ref)
+                                                         (str/includes? col-ref "CREATED_AT")))))]
+            (testing "breakout on joined CREATED_AT has non-nil ::add/desired-alias"
+              ;; Before the fix, ::add/desired-alias was nil because lib.equality/= failed
+              ;; due to :inherited-temporal-unit mismatch (:minute vs :day).
+              (is (some? (::add/desired-alias (second created-at-brk)))))))))))


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #70231
Fixes QUE2-394.

### Description

This issue was caused by losing the thread of a column between stages in
the case where it has a different `:inherited-temporal-unit` than its
proper `:temporal-unit`.

`lib.equality/=` was checking the `:temporal-unit`s, which match, and
then returning `false` because only one column had
`:inherited-temporal-unit` for a different, finer unit. That shouldn't
fail the match, since the `:inherited-temporal-unit` is obsolete when
the column has just been bucketed differently.

### How to verify

This is hard to reproduce based on the bug; the input query is a monster with numerous nested and joined models.
I tested this locally by preprocessing and compiling the user query based on an appdb dump, and the fix in this PR
fixes the syntax of their query. (Of course I couldn't run it for real, but the syntax checks out.)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
