### PR TITLE
ignore linting issue in embedding test

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/static-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/static-question.cy.spec.tsx
@@ -16,6 +16,7 @@ import {
 } from "e2e/support/helpers/embedding-sdk-component-testing";
 import { signInAsAdminAndEnableEmbeddingSdk } from "e2e/support/helpers/embedding-sdk-testing";
 import { mockAuthProviderAndJwtSignIn } from "e2e/support/helpers/embedding-sdk-testing/embedding-sdk-helpers";
+//eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { ThemeProvider } from "metabase/ui";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;


### PR DESCRIPTION
### Description
There is still 1 embedding test that imports from `metabase/ui`. This change will ignore that import, and allow the embedding team to address this at a later time

### How to verify

In theory, green CI. But it's friday afternoon so anything can happen 🤷 

