### PR TITLE
BOT-1085 Allow user-intent classification to be disabled

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/llm/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/llm/settings.clj
@@ -94,7 +94,7 @@
                 (setting/set-value-of-type! :string :ee-ai-metabot-provider new-value)))
 
 (defsetting ee-ai-metabot-provider-lite
-  (deferred-tru "The AI provider and model for lightweight Metabot tasks and internal bookkeeping (e.g. user intent classification snowplow metrics).")
+  (deferred-tru "The AI provider and model for lightweight Metabot tasks (e.g. user intent classification).")
   :type       :string
   :encryption :no
   :default    "openrouter/openai/gpt-oss-20b"
@@ -105,6 +105,14 @@
                 (when new-value
                   (validate-metabot-provider! new-value))
                 (setting/set-value-of-type! :string :ee-ai-metabot-provider-lite new-value)))
+
+(defsetting ee-ai-metabot-internal-tasks-enabled?
+  (deferred-tru "Controls whether Metabot performs internal tasks that might require background tasks or additional LLM calls (e.g. user intent classification).")
+  :type       :boolean
+  :visibility :settings-manager
+  :default    true
+  :export?    false
+  :doc        false)
 
 (defsetting ee-ai-features-enabled
   (deferred-tru "Enable AI features.")

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/agent/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/agent/core.clj
@@ -2,6 +2,7 @@
   "Main agent loop implementation using reducible streaming infrastructure."
   (:require
    [clojure.string :as str]
+   [metabase-enterprise.llm.settings :as llm.settings]
    [metabase-enterprise.metabot-v3.agent.analytics :as agent-analytics]
    [metabase-enterprise.metabot-v3.agent.memory :as memory]
    [metabase-enterprise.metabot-v3.agent.messages :as messages]
@@ -439,8 +440,9 @@
             [:debug? {:optional true} [:maybe :boolean]]]]
   (let [profile-id         (:profile-id opts)
         debug?             (:debug? opts)
-        track-user-intent? (some-> opts :tracking-opts :track-user-intent?)
-        labels             {:profile-id (name profile-id)}]
+        labels             {:profile-id (name profile-id)}
+        track-user-intent? (and (llm.settings/ee-ai-metabot-internal-tasks-enabled?)
+                                (some-> opts :tracking-opts :track-user-intent?))]
     (reify clojure.lang.IReduceInit
       (reduce [_ rf init]
         (with-span :info {:name       :metabot-v3.agent/run-agent-loop

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/agent/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/agent/core_test.clj
@@ -707,6 +707,28 @@
                           :tracking-opts   {:session-id "00000000-0000-0000-0000-000000000003"}})
         (is (false? @classify-called))))))
 
+(deftest user-intent-not-tracked-when-internal-tasks-disabled-test
+  (let [opts            {:messages      [{:role :user :content "Show sales by region"}]
+                         :state         {}
+                         :context       {}
+                         :profile-id    :internal
+                         :tracking-opts {:session-id         "00000000-0000-0000-0000-000000000005"
+                                         :track-user-intent? true}}
+        classify-called (atom 0)]
+    (with-redefs [openrouter/openrouter
+                  (fn [_] (mut/mock-llm-response mock-llm-response-for-intent))
+
+                  agent-analytics/classify-and-track-user-intent-async!
+                  (fn [_ _] (swap! classify-called inc))]
+      (testing "does not call classify-and-track-user-intent-async! when ee-ai-metabot-internal-tasks-enabled? is false"
+        (mt/with-temporary-setting-values [ee-ai-metabot-internal-tasks-enabled? false]
+          (run-agent-loop! opts)
+          (is (zero? @classify-called))))
+      (testing "calls classify-and-track-user-intent-async! when ee-ai-metabot-internal-tasks-enabled? is true"
+        (mt/with-temporary-setting-values [ee-ai-metabot-internal-tasks-enabled? true]
+          (run-agent-loop! opts)
+          (is (= 1 @classify-called)))))))
+
 (deftest user-intent-classifier-exception-swallowed-test
   (testing "does not propagate exception if classify-user-intent throws"
     (let [classify-called (atom false)]


### PR DESCRIPTION
Closes [BOT-1085: Ensure user-intent classification can be disabled for self-hosters](https://linear.app/metabase/issue/BOT-1085/ensure-user-intent-classification-can-be-disabled-for-self-hosters)

### Description

Small follow-up to #70351

Add a new `ee-ai-metabot-internal-tasks-enabled?` setting to allow disabling metabot internal "bookkeeping" tasks that might make additional llm calls, like user intent classification.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
