### PR TITLE
Preserve expression names when fixing bad field refs

### DIFF
--- a/src/metabase/query_processor/middleware/fix_bad_field_id_refs.clj
+++ b/src/metabase/query_processor/middleware/fix_bad_field_id_refs.clj
@@ -29,7 +29,9 @@
                                      (when-let [resolved (lib.walk/apply-f-for-stage-at-path
                                                           lib.field.resolution/resolve-field-ref
                                                           query path &match)]
-                                       (lib/ref resolved))))
+                                       (cond-> (lib/ref resolved)
+                                         (:lib/expression-name opts)
+                                         (lib/update-options assoc :lib/expression-name (:lib/expression-name opts))))))
                                  &match)))
         stage' (update-fields stage)]
     (when-not (= stage' stage)

--- a/test/metabase/query_processor/middleware/fix_bad_field_id_refs_test.clj
+++ b/test/metabase/query_processor/middleware/fix_bad_field_id_refs_test.clj
@@ -272,6 +272,49 @@
                                &Q2.*count/BigInteger]
                 :limit        3}))))))
 
+;; Regression test for bug #70232.
+;;
+;; This situation arises when stage 0 has no :source-table — either because the query is
+;; card-sourced (:source-card instead of :source-table) or because sandboxing middleware has
+;; substituted the source with a native subquery at runtime. In both cases fix-bad-field-id-refs
+;; would previously strip :lib/expression-name when rewriting a plain field-ref expression.
+(deftest ^:parallel bug-70232-card-sourced-plain-field-ref-expression-test
+  (testing "fix-bad-field-id-refs should preserve :lib/expression-name when rewriting a plain field-ref expression (#70232)"
+    (let [mp (lib.tu/mock-metadata-provider
+              {:database {:id 1, :engine :h2}
+               :tables   [{:id 10, :db-id 1, :name "MY_TABLE", :schema "PUBLIC"}]
+               :fields   [{:id 100, :table-id 10, :name "DATE_COL",  :base-type :type/DateTime}
+                          {:id 101, :table-id 10, :name "VALUE_COL", :base-type :type/Text}]})
+          legacy-query {:database 1
+                        :type     :query
+                        :query    {:source-query {:native "SELECT DATE_COL, VALUE_COL FROM MY_TABLE"}
+                                   :expressions  {"My Date" [:field 100 {:base-type "type/DateTime"}]}
+                                   :breakout     [[:expression "My Date" {:base-type "type/DateTime"}]
+                                                  [:field 101 {:base-type "type/Text"}]]
+                                   :aggregation  [[:cum-count]]}}
+          pmbql         (lib/query mp legacy-query)
+          pmbql-with-meta (assoc-in pmbql [:stages 0 :lib/stage-metadata]
+                                    {:lib/type :metadata/results
+                                     :columns  [{:lib/type  :metadata/column
+                                                 :name      "DATE_COL"
+                                                 :base-type :type/DateTime
+                                                 :id        100
+                                                 :table-id  10}
+                                                {:lib/type  :metadata/column
+                                                 :name      "VALUE_COL"
+                                                 :base-type :type/Text
+                                                 :id        101
+                                                 :table-id  10}]})
+          result (fix-bad-field-id-refs/fix-bad-field-id-refs pmbql-with-meta)]
+      (testing "expression definition must retain :lib/expression-name after fix-bad-field-id-refs"
+        (is (=? {:stages [{} {:expressions [[:field {:lib/expression-name "My Date"} "DATE_COL"]]}]}
+                result)))
+      (testing "->legacy-MBQL :expressions must have string keys, not nil"
+        (let [mbql4 (lib/->legacy-MBQL result)
+              exprs (get-in mbql4 [:query :expressions])]
+          (is (every? string? (keys exprs))
+              (str "Assert failed: :expressions should always use string keys, got: " (pr-str exprs))))))))
+
 (deftest ^:parallel resolve-join-conditions-test
   (testing "Resolve fields in join :conditions"
     (let [mp           (lib.tu/mock-metadata-provider


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #70232
Closes QUE2-397

### Description

The problem: when expressions are plain field references, and because of migration or sandboxing they become invalid, the `fix-bad-field-id-refs` removes `:lib/expression-name`. This PR makes sure expression names are preserved during fixing.

### How to verify

See the repro test.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
