### PR TITLE
Split slackbot DM and channel response paths, embed viz in message

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/channel.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/channel.clj
@@ -16,7 +16,7 @@
   (str "\n\n"
        "For this Slack channel response: the user already saw tool progress updates. "
        "Do not narrate the steps you took, do not recap tool calls, and do not include preambles like "
-       "\"I'll...\", \"Let me...\", or \"I found...\". Give a brief final answer focused on the result in "
+       "\"I'll...\", \"Let me...\", or \"I found...\". Give a brief final response in "
        "1-2 sentences before any table or chart."))
 
 (defn- channel-request-prompt

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/channel.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/channel.clj
@@ -1,0 +1,204 @@
+(ns metabase-enterprise.metabot-v3.api.slackbot.channel
+  "Visible Slack channel reply/update flow for metabot."
+  (:require
+   [clojure.string :as str]
+   [metabase-enterprise.metabot-v3.api.slackbot.client :as slackbot.client]
+   [metabase.util :as u]
+   [metabase.util.log :as log]))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private min-flush-interval-ms
+  "Minimum milliseconds between consecutive channel progress updates."
+  600)
+
+(def ^:private channel-response-style-suffix
+  (str "\n\n"
+       "For this Slack channel response: the user already saw tool progress updates. "
+       "Do not narrate the steps you took, do not recap tool calls, and do not include preambles like "
+       "\"I'll...\", \"Let me...\", or \"I found...\". Give a brief final answer focused on the result in "
+       "1-2 sentences before any table or chart."))
+
+(defn- channel-request-prompt
+  "Append channel-specific response style guidance without changing the stored user prompt."
+  [prompt]
+  (str prompt channel-response-style-suffix))
+
+(defn- final-text-blocks
+  "Build the leading text block(s) for a finalized non-streaming Slack message."
+  [text]
+  (if (str/blank? text)
+    []
+    [{:type "section"
+      :text {:type "mrkdwn"
+             :text text}}]))
+
+(defn- progress-text
+  "Build the in-progress text shown in a visible channel reply."
+  [thinking-placeholder status]
+  (if (seq status)
+    (str "_" status "_")
+    thinking-placeholder))
+
+(defn- progress-blocks
+  "Build blocks for an in-progress visible channel reply."
+  [thinking-placeholder status]
+  [{:type "section"
+    :text {:type "mrkdwn"
+           :text (progress-text thinking-placeholder status)}}])
+
+(defn- update-channel-message!
+  "Update an existing Slack message with the full intended payload."
+  [client channel message-ts op-label text blocks]
+  (let [res (slackbot.client/update-message client
+                                            (cond-> {:channel channel
+                                                     :ts      message-ts
+                                                     :text    text}
+                                              blocks (assoc :blocks blocks)))]
+    (when-not (:ok res)
+      (log/warnf "[slackbot] %s failed: %s (block_count=%d block_types=%s response_messages=%s)"
+                 op-label
+                 (:error res)
+                 (count (or blocks []))
+                 (pr-str (when blocks (mapv :type blocks)))
+                 (pr-str (get-in res [:response_metadata :messages]))))
+    res))
+
+(defn make-channel-callbacks
+  "Create callback functions that update a single visible threaded reply in channels.
+   Channel replies only surface tool-status updates progressively; text is accumulated
+   and sent once in the final message update."
+  [client {:keys [channel message-ts thinking-placeholder tool-name->friendly]}]
+  (let [rendered-text     (atom thinking-placeholder)
+        current-text      (atom "")
+        current-status    (atom nil)
+        update-failed?    (atom false)
+        slack-writer      (agent nil
+                                 :error-mode    :continue
+                                 :error-handler (fn [_ e] (log/warn e "[slackbot] Async Slack update failed")))
+        last-flush-timer  (volatile! nil)
+        flush-progress!   (fn []
+                            (when (and message-ts (not @update-failed?))
+                              (let [rendered (progress-text thinking-placeholder @current-status)]
+                                (when (not= rendered @rendered-text)
+                                  (let [res (slackbot.client/update-message client {:channel channel
+                                                                                    :ts      message-ts
+                                                                                    :text    rendered
+                                                                                    :blocks  (progress-blocks thinking-placeholder
+                                                                                                              @current-status)})]
+                                    (if (:ok res)
+                                      (reset! rendered-text rendered)
+                                      (do
+                                        (reset! update-failed? true)
+                                        (log/warnf "[slackbot] channel update failed: %s (channel=%s ts=%s)"
+                                                   (:error res) channel message-ts))))))))]
+    (letfn [(request-flush! ([] (request-flush! false))
+              ([force?]
+               (when (and message-ts (not @update-failed?))
+                 (when (or force?
+                           (nil? @last-flush-timer)
+                           (>= (u/since-ms @last-flush-timer) min-flush-interval-ms))
+                   (vreset! last-flush-timer (u/start-timer))
+                   (send-off slack-writer (bound-fn* (fn [_] (flush-progress!) nil)))))))
+            (set-status! [status]
+              (reset! current-status status)
+              (request-flush! true))]
+      {:on-text        (bound-fn* (fn [text]
+                                    (when (seq text)
+                                      (swap! current-text str text))))
+       :on-tool-start  (fn [{:keys [tool-name]}]
+                         (set-status! (str (tool-name->friendly tool-name "Thinking") "...")))
+       :request-flush! request-flush!
+       :set-status!    set-status!
+       :slack-writer   slack-writer
+       :current-text   current-text
+       :update-failed? update-failed?})))
+
+(defn send-channel-response
+  "Send a visible threaded reply/update flow for non-DM Slack conversations."
+  [client event extra-history {:keys [channel-id message-ctx channel thread-ts thread bot-user-id prompt conversation-id]}
+   {:keys [thinking-placeholder tool-name->friendly
+           make-streaming-ai-request collect-viz-blocks feedback-blocks post-viz-error!
+           make-viz-prefetch-callback cancel-prefetched-viz!]}]
+  (let [initial-response (slackbot.client/post-thread-reply client
+                                                            {:channel channel :thread_ts thread-ts}
+                                                            thinking-placeholder)
+        message-ts       (:ts initial-response)
+        {:keys [on-text on-tool-start
+                request-flush! set-status! slack-writer current-text update-failed?]}
+        (make-channel-callbacks client {:channel              channel
+                                        :message-ts           message-ts
+                                        :thinking-placeholder thinking-placeholder
+                                        :tool-name->friendly  tool-name->friendly})
+        prefetched-viz   (atom {})
+        on-data          (make-viz-prefetch-callback prefetched-viz)]
+    (when-not (:ok initial-response)
+      (log/warnf "[slackbot] initial channel reply failed: %s (channel=%s thread_ts=%s)"
+                 (:error initial-response) channel thread-ts))
+    (try
+      (let [_data-parts (make-streaming-ai-request
+                         conversation-id
+                         prompt
+                         thread
+                         bot-user-id
+                         channel-id
+                         extra-history
+                         {:on-text              on-text
+                          :on-tool-start        on-tool-start
+                          :on-tool-end          nil
+                          :on-data              on-data
+                          :req-slack-msg-id     (:ts event)
+                          :get-res-slack-msg-id (when message-ts (fn [] message-ts))
+                          :request-prompt       (channel-request-prompt prompt)})]
+        (request-flush! true)
+        (when (seq @prefetched-viz)
+          (set-status! "Rendering results..."))
+        (await slack-writer)
+        (let [{:keys [blocks errors]} (collect-viz-blocks @prefetched-viz)
+              answer-text             (str/trim @current-text)
+              final-text              (if (or (seq answer-text) (seq blocks))
+                                        answer-text
+                                        "I wasn't able to generate a response. Please try again.")
+              final-blocks            (into (into (final-text-blocks final-text) blocks)
+                                            (feedback-blocks conversation-id))]
+          (if (and message-ts (not @update-failed?))
+            (let [update-result (update-channel-message! client
+                                                         channel
+                                                         message-ts
+                                                         "channel update-message"
+                                                         final-text
+                                                         final-blocks)]
+              (when-not (:ok update-result)
+                (let [fallback-result (slackbot.client/post-thread-reply client
+                                                                         message-ctx
+                                                                         "I generated a response, but Slack could not render it. Please try again.")]
+                  (when-not (:ok fallback-result)
+                    (log/errorf "[slackbot] channel fallback post-message failed after update error: %s" (:error fallback-result))))))
+            (let [fallback-result (slackbot.client/post-thread-reply client
+                                                                     message-ctx
+                                                                     "I generated a response, but Slack could not render it. Please try again.")]
+              (when-not (:ok fallback-result)
+                (log/errorf "[slackbot] channel fallback post-message failed: %s" (:error fallback-result)))))
+          (doseq [e errors]
+            (post-viz-error! client channel thread-ts e))))
+      (catch Exception e
+        (cancel-prefetched-viz! prefetched-viz)
+        (log/error e "[slackbot] Error in channel response")
+        (set-status! nil)
+        (await slack-writer)
+        (let [error-text "Something went wrong. Please try again."]
+          (if (and message-ts (not @update-failed?))
+            (let [update-result (slackbot.client/update-message client {:channel channel
+                                                                        :ts      message-ts
+                                                                        :text    error-text})]
+              (when-not (:ok update-result)
+                (let [fallback-result (slackbot.client/post-thread-reply client
+                                                                         message-ctx
+                                                                         error-text)]
+                  (when-not (:ok fallback-result)
+                    (log/errorf "[slackbot] channel cleanup fallback post-message failed: %s" (:error fallback-result))))))
+            (let [fallback-result (slackbot.client/post-thread-reply client
+                                                                     message-ctx
+                                                                     error-text)]
+              (when-not (:ok fallback-result)
+                (log/errorf "[slackbot] channel cleanup fallback post-message failed: %s" (:error fallback-result))))))))))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/channel.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/channel.clj
@@ -64,7 +64,7 @@
                  (pr-str (get-in res [:response_metadata :messages]))))
     res))
 
-(defn make-channel-callbacks
+(defn- make-channel-callbacks
   "Create callback functions that update a single visible threaded reply in channels.
    Channel replies only surface tool-status updates progressively; text is accumulated
    and sent once in the final message update."
@@ -161,24 +161,13 @@
                                         "I wasn't able to generate a response. Please try again.")
               final-blocks            (into (into (final-text-blocks final-text) blocks)
                                             (feedback-blocks conversation-id))]
-          (if (and message-ts (not @update-failed?))
-            (let [update-result (update-channel-message! client
-                                                         channel
-                                                         message-ts
-                                                         "channel update-message"
-                                                         final-text
-                                                         final-blocks)]
-              (when-not (:ok update-result)
-                (let [fallback-result (slackbot.client/post-thread-reply client
-                                                                         message-ctx
-                                                                         "I generated a response, but Slack could not render it. Please try again.")]
-                  (when-not (:ok fallback-result)
-                    (log/errorf "[slackbot] channel fallback post-message failed after update error: %s" (:error fallback-result))))))
-            (let [fallback-result (slackbot.client/post-thread-reply client
-                                                                     message-ctx
-                                                                     "I generated a response, but Slack could not render it. Please try again.")]
-              (when-not (:ok fallback-result)
-                (log/errorf "[slackbot] channel fallback post-message failed: %s" (:error fallback-result)))))
+          (when (or (nil? message-ts)
+                    @update-failed?
+                    (not (:ok (update-channel-message! client channel message-ts "channel update-message" final-text final-blocks))))
+            (let [res (slackbot.client/post-thread-reply client message-ctx
+                                                         "I generated a response, but Slack could not render it. Please try again.")]
+              (when-not (:ok res)
+                (log/errorf "[slackbot] channel fallback post-message failed: %s" (:error res)))))
           (doseq [e errors]
             (post-viz-error! client channel thread-ts e))))
       (catch Exception e
@@ -187,18 +176,11 @@
         (set-status! nil)
         (await slack-writer)
         (let [error-text "Something went wrong. Please try again."]
-          (if (and message-ts (not @update-failed?))
-            (let [update-result (slackbot.client/update-message client {:channel channel
-                                                                        :ts      message-ts
-                                                                        :text    error-text})]
-              (when-not (:ok update-result)
-                (let [fallback-result (slackbot.client/post-thread-reply client
-                                                                         message-ctx
-                                                                         error-text)]
-                  (when-not (:ok fallback-result)
-                    (log/errorf "[slackbot] channel cleanup fallback post-message failed: %s" (:error fallback-result))))))
-            (let [fallback-result (slackbot.client/post-thread-reply client
-                                                                     message-ctx
-                                                                     error-text)]
-              (when-not (:ok fallback-result)
-                (log/errorf "[slackbot] channel cleanup fallback post-message failed: %s" (:error fallback-result))))))))))
+          (when (or (nil? message-ts)
+                    @update-failed?
+                    (not (:ok (slackbot.client/update-message client {:channel channel
+                                                                      :ts      message-ts
+                                                                      :text    error-text}))))
+            (let [res (slackbot.client/post-thread-reply client message-ctx error-text)]
+              (when-not (:ok res)
+                (log/errorf "[slackbot] channel cleanup fallback post-message failed: %s" (:error res))))))))))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/client.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/client.clj
@@ -106,6 +106,13 @@
   [client message]
   (:body (slack-post-json client "/chat.postMessage" message)))
 
+(defn post-thread-reply
+  "Send a threaded Slack reply using an existing reply context plus text and optional blocks."
+  [client message-ctx text & {:keys [blocks]}]
+  (post-message client
+                (cond-> (assoc message-ctx :text text)
+                  blocks (assoc :blocks blocks))))
+
 (defn post-ephemeral-message
   "Send a Slack ephemeral message (visible only to the specified user)"
   [client message]
@@ -147,7 +154,7 @@
 (defn update-message
   "Update a Slack message"
   [client message]
-  (slack-post-json client "/chat.update" message))
+  (:body (slack-post-json client "/chat.update" message)))
 
 (defn open-view
   "Open a Slack modal view, triggered from an interaction."
@@ -170,19 +177,23 @@
 (defn start-stream
   "Start a Slack message stream. Returns the stream timestamp on success (acts as an identifier)."
   [client {:keys [channel thread_ts team_id user_id]}]
-  (let [body (:body (slack-post-json client "/chat.startStream"
-                                     {:channel           channel
-                                      :thread_ts         thread_ts
-                                      :recipient_team_id team_id
-                                      :recipient_user_id user_id}
-                                     :connection-timeout streaming-connection-timeout-ms
-                                     :socket-timeout     streaming-socket-timeout-ms))]
-    (log/debugf "[slackbot] start-stream response: %s" (pr-str body))
+  (let [payload {:channel           channel
+                 :thread_ts         thread_ts
+                 :recipient_team_id team_id
+                 :recipient_user_id user_id}
+        body    (:body (slack-post-json client "/chat.startStream"
+                                        payload
+                                        :connection-timeout streaming-connection-timeout-ms
+                                        :socket-timeout     streaming-socket-timeout-ms))]
     (if (:ok body)
       {:stream_ts (:ts body)
        :channel   (:channel body)
        :thread_ts thread_ts}
-      (log/warnf "[slackbot] start-stream failed: %s" (:error body)))))
+      (do
+        (log/warnf "[slackbot] start-stream failed: %s (channel=%s thread_ts=%s recipient_team_id=%s recipient_user_id=%s)"
+                   (:error body) channel thread_ts team_id user_id)
+        (log/debugf "[slackbot] start-stream failure body=%s payload=%s"
+                    (pr-str body) (pr-str payload))))))
 
 (defn append-stream
   "Append chunks to an active stream. Each chunk is a map with :type and type-specific keys,
@@ -208,12 +219,17 @@
   ([client channel stream-ts]
    (stop-stream client channel stream-ts nil))
   ([client channel stream-ts blocks]
-   (let [body (:body (slack-post-json client "/chat.stopStream"
-                                      (cond-> {:channel channel
-                                               :ts      stream-ts}
-                                        blocks (assoc :blocks blocks))
-                                      :connection-timeout streaming-connection-timeout-ms
-                                      :socket-timeout     streaming-socket-timeout-ms))]
+   (let [payload     (cond-> {:channel channel
+                              :ts      stream-ts}
+                       blocks (assoc :blocks blocks))
+         block-types (when blocks (mapv :type blocks))
+         body        (:body (slack-post-json client "/chat.stopStream"
+                                             payload
+                                             :connection-timeout streaming-connection-timeout-ms
+                                             :socket-timeout     streaming-socket-timeout-ms))]
      (when-not (:ok body)
-       (log/warnf "[slackbot] stop-stream failed: %s" (:error body)))
+       (log/warnf "[slackbot] stop-stream failed: %s (channel=%s stream_ts=%s block_count=%d block_types=%s)"
+                  (:error body) channel stream-ts (count (or blocks [])) (pr-str block-types))
+       (log/debugf "[slackbot] stop-stream failure body=%s payload=%s"
+                   (pr-str body) (pr-str (update payload :blocks #(when % "[redacted-blocks]")))))
      body)))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/query.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/query.clj
@@ -90,6 +90,12 @@
    to leave headroom for any structural overhead Slack may count."
   9500)
 
+(def ^:private no-data-table-blocks
+  [{:type            "table"
+    :rows            [[{:type "raw_text"
+                        :text "No data"}]]
+    :column_settings [{:align "left"}]}])
+
 (defn- normalize-column
   "Normalize column metadata from the wire format for use with formatters and type checks."
   [col]
@@ -181,11 +187,17 @@
                              :rows            all-rows
                              :column_settings column-settings}
         rows-truncated?     (> total-rows displayed-rows)]
-    (if rows-truncated?
+    (cond
+      (zero? total-rows)
+      no-data-table-blocks
+
+      rows-truncated?
       [table-block
        {:type     "context"
         :elements [{:type "mrkdwn"
                     :text (format "Showing %d of %d rows" displayed-rows total-rows)}]}]
+
+      :else
       [table-block])))
 
 (def ^:private supported-png-display-types
@@ -206,7 +218,8 @@
   (let [display (keyword display)
         results (execute-adhoc-query query)]
     (throw-on-failed-query! results)
-    (if (contains? supported-png-display-types display)
+    (if (and (contains? supported-png-display-types display)
+             (seq (get-in results [:data :rows])))
       {:type    :image
        :content (generate-adhoc-png results display)}
       {:type    :table
@@ -230,14 +243,12 @@
        :card-id     card-id}))))
 
 (defn- render-saved-card-png
-  "Render a saved card (already fetched from DB) to PNG bytes."
-  [card]
+  "Render a saved card (already fetched from DB) and pre-fetched results to PNG bytes."
+  [card results]
   (let [{:keys [width]} (render-dimensions (:display card))
-        options {:channel.render/include-title? false
-                 :channel.render/padding-x render-padding-x-px
-                 :channel.render/padding-y 0}
-        results (pulse-card-query-results card)]
-    (throw-on-failed-query! results)
+        options          {:channel.render/include-title? false
+                          :channel.render/padding-x      render-padding-x-px
+                          :channel.render/padding-y      0}]
     ;; TODO: should we use the user's timezone for this?
     (channel.render/render-pulse-card-to-png (channel.render/defaulted-timezone card)
                                              card
@@ -255,13 +266,14 @@
   (let [card      (t2/select-one :model/Card :id card-id)
         _         (when-not card
                     (throw (ex-info "Card not found" {:card-id card-id :type :card-not-found})))
-        card-name (:name card)]
-    (if (-> card :display keyword supported-png-display-types)
+        card-name (:name card)
+        results   (pulse-card-query-results card)]
+    (throw-on-failed-query! results)
+    (if (and (-> card :display keyword supported-png-display-types)
+             (seq (get-in results [:data :rows])))
       {:type      :image
-       :content   (render-saved-card-png card)
+       :content   (render-saved-card-png card results)
        :card-name card-name}
-      (let [results (pulse-card-query-results card)]
-        (throw-on-failed-query! results)
-        {:type      :table
-         :content   (format-results-as-table-blocks results)
-         :card-name card-name}))))
+      {:type      :table
+       :content   (format-results-as-table-blocks results)
+       :card-name card-name})))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/streaming.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/streaming.clj
@@ -114,14 +114,14 @@
 
 (defn- viz-output->blocks
   "Build blocks for a visualization to be included in the finalized stop-stream message."
-  [client {:keys [type content]} filename title link]
+  [{:keys [type content]} filename title link]
   (let [text (or (format-viz-title title link) "Query results")]
     (case type
       :table (let [title-block {:type "section"
                                 :text {:type "mrkdwn" :text text}}
                    blocks      (into [title-block] content)]
                blocks)
-      :image (let [{:keys [id]} (channel.slack/upload-file-with-token! (:token client) content (str filename ".png"))
+      :image (let [{:keys [id]} (channel.slack/upload-file! content (str filename ".png"))
                    blocks      [{:type "section"
                                  :text {:type "mrkdwn" :text text}}
                                 {:type       "image"
@@ -267,14 +267,14 @@
   "Wait for all in-flight visualization futures and return blocks to include in stop-stream.
    Returns {:blocks [...], :errors [Exception ...]}.
    For saved cards (static_viz), uses the actual card name as the title."
-  [client prefetched-viz]
+  [prefetched-viz]
   (reduce
    (fn [{:keys [blocks errors] :as acc} [idx {:keys [^Future future filename title link]}]]
      (try
        (let [output         (.get future)
              resolved-title (or (:card-name output) title)
              filename       (or (some-> resolved-title (u/slugify {:max-length 80})) filename)]
-         (assoc acc :blocks (into blocks (viz-output->blocks client output filename resolved-title link))))
+         (assoc acc :blocks (into blocks (viz-output->blocks output filename resolved-title link))))
        (catch ExecutionException e
          (let [cause (or (.getCause e) e)]
            (log/errorf cause "Visualization future %d failed" idx)
@@ -504,7 +504,7 @@
              (request-flush! true)
              (await slack-writer)
              (if-let [{:keys [stream_ts channel]} @stream-state]
-               (let [{:keys [blocks errors]} (collect-viz-blocks client @prefetched-viz)
+               (let [{:keys [blocks errors]} (collect-viz-blocks @prefetched-viz)
                      final-blocks            (into blocks (feedback-blocks conversation-id))]
                  (slackbot.client/stop-stream client channel stream_ts final-blocks)
                  (doseq [e errors]

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/streaming.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/streaming.clj
@@ -4,6 +4,7 @@
   (:require
    [clojure.string :as str]
    [java-time.api :as t]
+   [metabase-enterprise.metabot-v3.api.slackbot.channel :as slackbot.channel]
    [metabase-enterprise.metabot-v3.api.slackbot.client :as slackbot.client]
    [metabase-enterprise.metabot-v3.api.slackbot.events :as slackbot.events]
    [metabase-enterprise.metabot-v3.api.slackbot.persistence :as slackbot.persistence]
@@ -137,11 +138,6 @@
    "get_field_values"         "Getting field values"
    "static_viz"               "Running query"})
 
-(defn- tool-name->friendly
-  "Convert a tool name to a user-friendly status message (gerund form)."
-  [tool-name]
-  (get tool-friendly-names tool-name "Thinking"))
-
 (def ^:private min-text-batch-size
   "Minimum characters to accumulate before considering a flush."
   250)
@@ -164,60 +160,61 @@
    - req-slack-msg-id: The Slack message ts for the user's incoming message
    - get-response-ts: Function that returns the Slack message ts for the bot's response"
   [conversation-id prompt thread bot-user-id channel-id extra-history
-   {:keys [on-text on-tool-start on-tool-end on-data req-slack-msg-id get-res-slack-msg-id]}]
-  (let [data-idx       (volatile! -1)
-        message        (metabot-v3.envelope/user-message prompt)
-        metabot-id     (metabot-v3.config/resolve-dynamic-metabot-id nil)
-        profile-id     (metabot-v3.config/resolve-dynamic-profile-id "slackbot" metabot-id)
-        session-id     (metabot-v3.client/get-ai-service-token api/*current-user-id* metabot-id)
-        capabilities   (compute-capabilities)
-        thread-history (thread->history thread bot-user-id conversation-id)
-        history        (into (vec thread-history) extra-history)
-        handle-line    (fn [line]
-                         (when-let [[type content] (metabot-v3.u/parse-aisdk-line line)]
-                           (case type
-                             :TEXT
-                             (when (and on-text (seq content))
-                               (on-text content))
+   {:keys [on-text on-tool-start on-tool-end on-data req-slack-msg-id get-res-slack-msg-id request-prompt]}]
+  (let [data-idx        (volatile! -1)
+        message         (metabot-v3.envelope/user-message prompt)
+        request-message (metabot-v3.envelope/user-message (or request-prompt prompt))
+        metabot-id      (metabot-v3.config/resolve-dynamic-metabot-id nil)
+        profile-id      (metabot-v3.config/resolve-dynamic-profile-id "slackbot" metabot-id)
+        session-id      (metabot-v3.client/get-ai-service-token api/*current-user-id* metabot-id)
+        capabilities    (compute-capabilities)
+        thread-history  (thread->history thread bot-user-id conversation-id)
+        history         (into (vec thread-history) extra-history)
+        handle-line     (fn [line]
+                          (when-let [[type content] (metabot-v3.u/parse-aisdk-line line)]
+                            (case type
+                              :TEXT
+                              (when (and on-text (seq content))
+                                (on-text content))
 
-                             :TOOL_CALL
-                             (when on-tool-start
-                               (on-tool-start {:id        (:toolCallId content)
-                                               :tool-name (:toolName content)}))
+                              :TOOL_CALL
+                              (when on-tool-start
+                                (on-tool-start {:id        (:toolCallId content)
+                                                :tool-name (:toolName content)}))
 
-                             :TOOL_RESULT
-                             (when on-tool-end
-                               (on-tool-end {:id     (:toolCallId content)
-                                             :result (:result content)}))
+                              :TOOL_RESULT
+                              (when on-tool-end
+                                (on-tool-end {:id     (:toolCallId content)
+                                              :result (:result content)}))
 
-                             :DATA
-                             (when on-data
-                               (on-data (vswap! data-idx inc) content))
+                              :DATA
+                              (when on-data
+                                (on-data (vswap! data-idx inc) content))
 
-                             (log/debugf "Ignoring AI SDK line of type %s" type))))
+                              (log/debugf "Ignoring AI SDK line of type %s" type))))
 
-        _              (metabot-v3.persistence/store-message! conversation-id profile-id [message]
-                                                              :slack-msg-id req-slack-msg-id)
-        lines          (metabot-v3.client/streaming-request-with-callback
+        _               (metabot-v3.persistence/store-message! conversation-id profile-id [message]
+                                                               :slack-msg-id req-slack-msg-id)
+        lines           (metabot-v3.client/streaming-request-with-callback
 
-                        {:context         (metabot-v3.context/create-context
-                                           {:current_time_with_timezone (str (java.time.OffsetDateTime/now))
-                                            :capabilities               capabilities
-                                            :slack_channel_id           channel-id})
-                         :metabot-id      metabot-id
-                         :profile-id      profile-id
-                         :session-id      session-id
-                         :conversation-id conversation-id
-                         :message         message
-                         :history         history
-                         :state           {}
-                         :on-line         handle-line
-                         :on-complete     (fn [lines]
-                                            (metabot-v3.persistence/store-message!
-                                             conversation-id profile-id
-                                             (metabot-v3.u/aisdk->messages :assistant lines)
-                                             :slack-msg-id (when get-res-slack-msg-id (get-res-slack-msg-id)))
-                                            :store-in-db)})]
+                         {:context         (metabot-v3.context/create-context
+                                            {:current_time_with_timezone (str (java.time.OffsetDateTime/now))
+                                             :capabilities               capabilities
+                                             :slack_channel_id           channel-id})
+                          :metabot-id      metabot-id
+                          :profile-id      profile-id
+                          :session-id      session-id
+                          :conversation-id conversation-id
+                          :message         request-message
+                          :history         history
+                          :state           {}
+                          :on-line         handle-line
+                          :on-complete     (fn [lines]
+                                             (metabot-v3.persistence/store-message!
+                                              conversation-id profile-id
+                                              (metabot-v3.u/aisdk->messages :assistant lines)
+                                              :slack-msg-id (when get-res-slack-msg-id (get-res-slack-msg-id)))
+                                             :store-in-db)})]
     (->> (metabot-v3.u/aisdk->messages :assistant lines)
          (filter #(= (:_type %) :DATA)))))
 
@@ -324,6 +321,24 @@
                    "static_viz" (str "/question/" (:entity_id value)))]
     {:title title :filename filename :link link}))
 
+(defn- make-viz-prefetch-callback
+  "Create an `:on-data` callback that submits visualization rendering work eagerly."
+  [prefetched-viz]
+  (fn [idx content]
+    (when (viz-data-types (:type content))
+      (let [{:keys [title filename link]} (viz-metadata content)
+            task (bound-fn* #(generate-viz-output content))]
+        (swap! prefetched-viz assoc idx
+               {:future   (.submit viz-prefetch-executor ^Callable task)
+                :filename filename
+                :title    title
+                :link     link})))))
+
+(defn- cancel-prefetched-viz!
+  "Cancel any in-flight visualization futures."
+  [prefetched-viz]
+  (run! #(.cancel ^Future (:future %) true) (vals @prefetched-viz)))
+
 (defn- make-streaming-callbacks
   "Create streaming callback functions and associated control functions.
    Slack API writes are dispatched to a background agent so the AI stream reader is never
@@ -404,7 +419,7 @@
                                           (slackbot.client/append-stream client channel stream_ts
                                                                          [{:type   "task_update"
                                                                            :id     id
-                                                                           :title  (tool-name->friendly tool-name)
+                                                                           :title  (tool-friendly-names tool-name "Thinking")
                                                                            :status status}])
                                           (when (= status "complete")
                                             (slackbot.client/append-markdown-text client channel stream_ts "\n"))
@@ -420,15 +435,7 @@
                       (vswap! tool-id->name dissoc id))
 
         prefetched-viz (atom {})
-        on-data (fn [idx content]
-                  (when (viz-data-types (:type content))
-                    (let [{:keys [title filename link]} (viz-metadata content)
-                          task (bound-fn* #(generate-viz-output content))]
-                      (swap! prefetched-viz assoc idx
-                             {:future   (.submit viz-prefetch-executor ^Callable task)
-                              :filename filename
-                              :title    title
-                              :link     link}))))]
+        on-data        (make-viz-prefetch-callback prefetched-viz)]
     {:on-text              (bound-fn* on-text)
      :on-tool-start        on-tool-start
      :on-tool-end          on-tool-end
@@ -456,69 +463,114 @@
                 :negative_button {:text  {:type "plain_text" :text "Bad"}
                                   :value (json/encode {:conversation_id conversation-id :positive false})}}]}])
 
+(defn- prepare-response-context
+  "Fetch thread/auth context shared by DM and channel delivery paths."
+  [client event]
+  (let [channel-id      (:channel event)
+        message-ctx     (slackbot.events/event->reply-context event)
+        channel         (:channel message-ctx)
+        thread-ts       (:thread_ts message-ctx)
+        thread-future   (future (-> (slackbot.client/fetch-thread client event)
+                                    (update :messages #(remove (fn [m] (= (:ts m) (:ts event))) %))))
+        auth-future     (future (:body (slackbot.client/auth-test client)))
+        auth-info       @auth-future
+        thread          @thread-future
+        bot-user-id     (:user_id auth-info)
+        prompt          (slackbot.events/event->prompt event bot-user-id)
+        conversation-id (slack-thread->conversation-id (:team_id auth-info) channel thread-ts)]
+    {:channel-id      channel-id
+     :message-ctx     message-ctx
+     :channel         channel
+     :thread-ts       thread-ts
+     :auth-info       auth-info
+     :thread          thread
+     :bot-user-id     bot-user-id
+     :prompt          prompt
+     :conversation-id conversation-id}))
+
+(defn- send-dm-response
+  [client event extra-history {:keys [channel-id message-ctx channel thread-ts auth-info thread bot-user-id prompt conversation-id]}]
+  (let [{:keys [on-text on-tool-start on-tool-end on-data
+                request-flush! start-with-thinking! stream-state slack-writer prefetched-viz]}
+        (make-streaming-callbacks client {:channel   channel
+                                          :thread-ts thread-ts
+                                          :team-id   (:team_id auth-info)
+                                          :user-id   (:user event)})]
+    (start-with-thinking!)
+    (try
+      ;; Start stream early so assistant persistence has :slack_msg_id.
+      (request-flush! true)
+      (let [_data-parts (make-streaming-ai-request
+                         conversation-id
+                         prompt
+                         thread
+                         bot-user-id
+                         channel-id
+                         extra-history
+                         {:on-text              on-text
+                          :on-tool-start        on-tool-start
+                          :on-tool-end          on-tool-end
+                          :on-data              on-data
+                          :req-slack-msg-id     (:ts event)
+                          :get-res-slack-msg-id (fn [] (:stream_ts @stream-state))})]
+        (request-flush! true)
+        (await slack-writer)
+        (if-let [{:keys [stream_ts channel]} @stream-state]
+          ;; Hold stop-stream until all viz futures finish so text + viz + controls
+          ;; finalize as a single message.
+          (let [{:keys [blocks errors]} (collect-viz-blocks @prefetched-viz)
+                final-blocks            (into blocks (feedback-blocks conversation-id))
+                stop-result             (slackbot.client/stop-stream client channel stream_ts final-blocks)]
+            (log/debugf "[slackbot] stop-stream finalize attempt channel=%s thread_ts=%s stream_ts=%s block_count=%d block_types=%s"
+                        channel thread-ts stream_ts (count final-blocks) (pr-str (mapv :type final-blocks)))
+            (when-not (:ok stop-result)
+              (log/warnf "[slackbot] stop-stream fallback to post-message: %s" (:error stop-result))
+              (let [fallback-result (slackbot.client/post-thread-reply client
+                                                                       message-ctx
+                                                                       "I generated a response, but Slack could not render it. Please try again.")]
+                (when-not (:ok fallback-result)
+                  (log/errorf "[slackbot] fallback post-message failed after stop-stream error: %s" (:error fallback-result)))))
+            (doseq [e errors]
+              (post-viz-error! client channel thread-ts e)))
+          (slackbot.client/post-thread-reply client message-ctx "I wasn't able to generate a response. Please try again.")))
+      (catch Exception e
+        (cancel-prefetched-viz! prefetched-viz)
+        (log/error e "[slackbot] Error in streaming response")
+        (await slack-writer)
+        (if-let [{:keys [stream_ts channel]} @stream-state]
+          (try
+            (slackbot.client/append-markdown-text client channel stream_ts
+                                                  "\nSomething went wrong. Please try again.")
+            (let [stop-result (slackbot.client/stop-stream client channel stream_ts)]
+              (when-not (:ok stop-result)
+                (log/warnf "[slackbot] stop-stream during error cleanup failed: %s" (:error stop-result))
+                (let [fallback-result (slackbot.client/post-thread-reply client
+                                                                         message-ctx
+                                                                         "Something went wrong. Please try again.")]
+                  (when-not (:ok fallback-result)
+                    (log/errorf "[slackbot] cleanup fallback post-message failed: %s" (:error fallback-result))))))
+            (catch Exception stop-e
+              (log/debug stop-e "[slackbot] Failed to stop stream during error cleanup")))
+          (slackbot.client/post-thread-reply client message-ctx "Something went wrong. Please try again."))))))
+
 (defn send-response
-  "Send a metabot response using Slack's streaming API for progressive updates.
-   Shows tool execution status and streams text as it arrives."
+  "Send a metabot response using Slack delivery suited to the conversation type.
+   DMs stream progressively; non-DMs use a visible post/update flow."
   ([client event]
    (send-response client event nil))
   ([client event extra-history]
-   (let [channel-id    (:channel event)
-         message-ctx   (slackbot.events/event->reply-context event)
-         channel       (:channel message-ctx)
-         thread-ts     (:thread_ts message-ctx)
-         ;; Run both Slack API calls in parallel
-         thread-future (future (-> (slackbot.client/fetch-thread client event)
-                                   (update :messages #(remove (fn [m] (= (:ts m) (:ts event))) %))))
-         auth-future   (future (:body (slackbot.client/auth-test client)))
-         auth-info     @auth-future
-         thread        @thread-future
-         bot-user-id   (:user_id auth-info)
-         prompt        (slackbot.events/event->prompt event bot-user-id)
-
-         {:keys [on-text on-tool-start on-tool-end on-data
-                 request-flush! start-with-thinking! stream-state slack-writer prefetched-viz]}
-         (make-streaming-callbacks client {:channel   channel
-                                           :thread-ts thread-ts
-                                           :team-id   (:team_id auth-info)
-                                           :user-id   (:user event)})]
-     (start-with-thinking!)
-     (let [conversation-id (slack-thread->conversation-id (:team_id auth-info) channel thread-ts)]
-       (letfn [(send-fallback [text]
-                 (slackbot.client/post-message client (merge message-ctx {:text text})))]
-         (try
-           ;; Start stream early so assistant persistence has :slack_msg_id.
-           (request-flush! true)
-           (let [_data-parts (make-streaming-ai-request
-                              conversation-id
-                              prompt
-                              thread
-                              bot-user-id
-                              channel-id
-                              extra-history
-                              {:on-text              on-text
-                               :on-tool-start        on-tool-start
-                               :on-tool-end          on-tool-end
-                               :on-data              on-data
-                               :req-slack-msg-id     (:ts event)
-                               :get-res-slack-msg-id (fn [] (:stream_ts @stream-state))})]
-             (request-flush! true)
-             (await slack-writer)
-             (if-let [{:keys [stream_ts channel]} @stream-state]
-               (let [{:keys [blocks errors]} (collect-viz-blocks @prefetched-viz)
-                     final-blocks            (into blocks (feedback-blocks conversation-id))]
-                 (slackbot.client/stop-stream client channel stream_ts final-blocks)
-                 (doseq [e errors]
-                   (post-viz-error! client channel thread-ts e)))
-               (send-fallback "I wasn't able to generate a response. Please try again.")))
-           (catch Exception e
-             (run! #(.cancel ^Future (:future %) true) (vals @prefetched-viz))
-             (log/error e "[slackbot] Error in streaming response")
-             (await slack-writer)
-             (if-let [{:keys [stream_ts channel]} @stream-state]
-               (try
-                 (slackbot.client/append-markdown-text client channel stream_ts
-                                                       "\nSomething went wrong. Please try again.")
-                 (slackbot.client/stop-stream client channel stream_ts)
-                 (catch Exception stop-e
-                   (log/debug stop-e "[slackbot] Failed to stop stream during error cleanup")))
-               (send-fallback "Something went wrong. Please try again.")))))))))
+   (let [ctx (prepare-response-context client event)]
+     (if (slackbot.events/dm? event)
+       (send-dm-response client event extra-history ctx)
+       (slackbot.channel/send-channel-response client
+                                               event
+                                               extra-history
+                                               ctx
+                                               {:thinking-placeholder      thinking-placeholder
+                                                :tool-name->friendly       tool-friendly-names
+                                                :make-streaming-ai-request make-streaming-ai-request
+                                                :collect-viz-blocks        collect-viz-blocks
+                                                :feedback-blocks           feedback-blocks
+                                                :post-viz-error!           post-viz-error!
+                                                :make-viz-prefetch-callback make-viz-prefetch-callback
+                                                :cancel-prefetched-viz!    cancel-prefetched-viz!})))))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/streaming.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/streaming.clj
@@ -15,6 +15,7 @@
    [metabase-enterprise.metabot-v3.persistence :as metabot-v3.persistence]
    [metabase-enterprise.metabot-v3.util :as metabot-v3.u]
    [metabase.api.common :as api]
+   [metabase.channel.slack :as channel.slack]
    [metabase.permissions.core :as perms]
    [metabase.system.core :as system]
    [metabase.util :as u]
@@ -111,21 +112,22 @@
       full-link             (str "📊 <" full-link "|Open in Metabase>")
       :else                 nil)))
 
-(defn- deliver-viz!
-  "Post the visualization as a new message with a title and link.
-   Both tables and images follow the same pattern: post content with title."
-  [client channel thread-ts {:keys [type content]} filename title link]
+(defn- viz-output->blocks
+  "Build blocks for a visualization to be included in the finalized stop-stream message."
+  [client {:keys [type content]} filename title link]
   (let [text (or (format-viz-title title link) "Query results")]
     (case type
       :table (let [title-block {:type "section"
                                 :text {:type "mrkdwn" :text text}}
                    blocks      (into [title-block] content)]
-               (slackbot.client/post-message client {:channel   channel
-                                                     :thread_ts thread-ts
-                                                     :blocks    blocks
-                                                     :text      text}))
-      :image (slackbot.client/post-image client content (str filename ".png") channel thread-ts
-                                         :initial-comment text))))
+               blocks)
+      :image (let [{:keys [id]} (channel.slack/upload-file-with-token! (:token client) content (str filename ".png"))
+                   blocks      [{:type "section"
+                                 :text {:type "mrkdwn" :text text}}
+                                {:type       "image"
+                                 :slack_file {:id id}
+                                 :alt_text   (or title filename "Visualization")}]]
+               blocks))))
 
 (def ^:private tool-friendly-names
   "Map of tool names to user-friendly gerund descriptions for slackbot profile tools."
@@ -261,24 +263,27 @@
     (catch Exception post-e
       (log/error post-e "Failed to post visualization error"))))
 
-(defn- send-visualizations!
-  "Wait for all in-flight visualization futures and post results to Slack.
-   Called after stop-stream so results always appear after streamed text.
+(defn- collect-viz-blocks
+  "Wait for all in-flight visualization futures and return blocks to include in stop-stream.
+   Returns {:blocks [...], :errors [Exception ...]}.
    For saved cards (static_viz), uses the actual card name as the title."
-  [client channel thread-ts prefetched-viz]
-  (doseq [[idx {:keys [^Future future filename title link]}] (sort-by first prefetched-viz)]
-    (try
-      (let [output   (.get future)
-            title    (or (:card-name output) title)
-            filename (or (some-> title (u/slugify {:max-length 80})) filename)]
-        (deliver-viz! client channel thread-ts output filename title link))
-      (catch ExecutionException e
-        (let [cause (or (.getCause e) e)]
-          (log/errorf cause "Visualization future %d failed" idx)
-          (post-viz-error! client channel thread-ts cause)))
-      (catch Exception e
-        (log/errorf e "Visualization future %d failed" idx)
-        (post-viz-error! client channel thread-ts e)))))
+  [client prefetched-viz]
+  (reduce
+   (fn [{:keys [blocks errors] :as acc} [idx {:keys [^Future future filename title link]}]]
+     (try
+       (let [output         (.get future)
+             resolved-title (or (:card-name output) title)
+             filename       (or (some-> resolved-title (u/slugify {:max-length 80})) filename)]
+         (assoc acc :blocks (into blocks (viz-output->blocks client output filename resolved-title link))))
+       (catch ExecutionException e
+         (let [cause (or (.getCause e) e)]
+           (log/errorf cause "Visualization future %d failed" idx)
+           {:blocks blocks :errors (conj errors cause)}))
+       (catch Exception e
+         (log/errorf e "Visualization future %d failed" idx)
+         {:blocks blocks :errors (conj errors e)})))
+   {:blocks [] :errors []}
+   (sort-by first prefetched-viz)))
 
 (defn- ensure-stream-started!
   "Ensure the Slack stream has been started, attempting once if not already tried."
@@ -499,9 +504,11 @@
              (request-flush! true)
              (await slack-writer)
              (if-let [{:keys [stream_ts channel]} @stream-state]
-               (do
-                 (slackbot.client/stop-stream client channel stream_ts (feedback-blocks conversation-id))
-                 (send-visualizations! client channel thread-ts @prefetched-viz))
+               (let [{:keys [blocks errors]} (collect-viz-blocks client @prefetched-viz)
+                     final-blocks            (into blocks (feedback-blocks conversation-id))]
+                 (slackbot.client/stop-stream client channel stream_ts final-blocks)
+                 (doseq [e errors]
+                   (post-viz-error! client channel thread-ts e)))
                (send-fallback "I wasn't able to generate a response. Please try again.")))
            (catch Exception e
              (run! #(.cancel ^Future (:future %) true) (vals @prefetched-viz))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/streaming.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot/streaming.clj
@@ -566,11 +566,11 @@
                                                event
                                                extra-history
                                                ctx
-                                               {:thinking-placeholder      thinking-placeholder
-                                                :tool-name->friendly       tool-friendly-names
-                                                :make-streaming-ai-request make-streaming-ai-request
-                                                :collect-viz-blocks        collect-viz-blocks
-                                                :feedback-blocks           feedback-blocks
-                                                :post-viz-error!           post-viz-error!
+                                               {:thinking-placeholder       thinking-placeholder
+                                                :tool-name->friendly        tool-friendly-names
+                                                :make-streaming-ai-request  make-streaming-ai-request
+                                                :collect-viz-blocks         collect-viz-blocks
+                                                :feedback-blocks            feedback-blocks
+                                                :post-viz-error!            post-viz-error!
                                                 :make-viz-prefetch-callback make-viz-prefetch-callback
-                                                :cancel-prefetched-viz!    cancel-prefetched-viz!})))))
+                                                :cancel-prefetched-viz!     cancel-prefetched-viz!})))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot/query_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot/query_test.clj
@@ -180,11 +180,8 @@
     (let [results {:data {:rows []
                           :cols [{:name "count" :display_name "Count" :base_type :type/Integer}]}}
           blocks  (slackbot.query/format-results-as-table-blocks results)]
-      (testing "returns a table with only header row"
-        (let [table-block (first blocks)
-              rows        (:rows table-block)]
-          (is (= 1 (count rows))) ; header only
-          (is (= "Count" (get-in rows [0 0 :text])))))))
+      (testing "returns no-data block"
+        (is (= "No data" (get-in blocks [0 :rows 0 0 :text]))))))
 
   (testing "format-results-as-table-blocks truncates long cell values"
     (binding [slackbot.query/*slack-table-max-cell-length* 20]

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
@@ -240,14 +240,13 @@
        slackbot.client/delete-message (fn [_ msg]
                                         (swap! delete-calls conj msg)
                                         {:ok true})
-       channel.slack/upload-file-with-token! (fn [token image-bytes filename]
-                                               (let [file-id (format "FIMG-%d" (swap! file-counter inc))]
-                                                 (swap! image-calls conj {:token       token
-                                                                          :image-bytes image-bytes
-                                                                          :filename    filename
-                                                                          :file-id     file-id})
-                                                 {:url (str "https://files.slack.com/files/" filename)
-                                                  :id  file-id}))
+       channel.slack/upload-file! (fn [image-bytes filename]
+                                    (let [file-id (format "FIMG-%d" (swap! file-counter inc))]
+                                      (swap! image-calls conj {:image-bytes image-bytes
+                                                               :filename    filename
+                                                               :file-id     file-id})
+                                      {:url (str "https://files.slack.com/files/" filename)
+                                       :id  file-id}))
        ;; Mock the streaming client - returns AISDK-formatted lines
        metabot-v3.client/streaming-request-with-callback
        (fn [opts]

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
@@ -507,14 +507,12 @@
                 ;; Filter by expected slack_msg_ids to avoid picking up messages from other tests
                 (let [user-msg (t2/select-one :model/MetabotMessage :slack_msg_id event-ts)
                       bot-msg  (t2/select-one :model/MetabotMessage :slack_msg_id "stream123")]
-                  (testing "user message has event ts and channel_id"
+                  (testing "user message has event ts"
                     (is (some? user-msg))
-                    (is (= event-ts (:slack_msg_id user-msg)))
-                    (is (= "C123" (:channel_id user-msg))))
-                  (testing "bot message has stream ts and channel_id"
+                    (is (= event-ts (:slack_msg_id user-msg))))
+                  (testing "bot message has stream ts"
                     (is (some? bot-msg))
-                    (is (= "stream123" (:slack_msg_id bot-msg)))
-                    (is (= "C123" (:channel_id bot-msg)))))))))))))
+                    (is (= "stream123" (:slack_msg_id bot-msg)))))))))))))
 
 (deftest ^:parallel slack-thread-conversation-id-test
   (testing "Same thread produces same conversation ID"

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
@@ -188,7 +188,7 @@
                 Pass ::no-user to simulate an unlinked Slack user (returns nil).
 
    Calls body-fn with a map containing tracking atoms:
-   {:post-calls, :delete-calls, :image-calls, :generate-card-output-calls,
+   {:post-calls, :delete-calls, :update-calls, :image-calls, :generate-card-output-calls,
     :generate-adhoc-output-calls, :ephemeral-calls, :ai-request-calls,
     :fake-png-bytes, :stream-calls, :append-text-calls, :stop-stream-calls}"
   [{:keys [ai-text data-parts user-id]
@@ -197,6 +197,7 @@
    body-fn]
   (let [post-calls                  (atom [])
         delete-calls                (atom [])
+        update-calls                (atom [])
         image-calls                 (atom [])
         generate-card-output-calls  (atom [])
         generate-adhoc-output-calls (atom [])
@@ -240,6 +241,9 @@
        slackbot.client/delete-message (fn [_ msg]
                                         (swap! delete-calls conj msg)
                                         {:ok true})
+       slackbot.client/update-message (fn [_ msg]
+                                        (swap! update-calls conj msg)
+                                        {:ok true})
        channel.slack/upload-file! (fn [image-bytes filename]
                                     (let [file-id (format "FIMG-%d" (swap! file-counter inc))]
                                       (swap! image-calls conj {:image-bytes image-bytes
@@ -276,6 +280,7 @@
                                                 {:type :table :content [{:type "table" :rows [] :column_settings []}]}))]
       (body-fn {:post-calls                  post-calls
                 :delete-calls                delete-calls
+                :update-calls                update-calls
                 :image-calls                 image-calls
                 :generate-card-output-calls  generate-card-output-calls
                 :generate-adhoc-output-calls generate-adhoc-output-calls
@@ -368,28 +373,30 @@
                 (is (= 1 (count @stop-stream-calls)))))))))))
 
 (deftest app-mention-triggers-response-test
-  (testing "POST /events with app_mention triggers AI response via streaming"
+  (testing "POST /events with app_mention uses visible channel reply (not streaming)"
     (with-slackbot-setup
       (let [mock-ai-text "Here is your answer"
             event-body   base-mention-event]
         (with-slackbot-mocks
           {:ai-text mock-ai-text}
-          (fn [{:keys [stream-calls append-text-calls stop-stream-calls]}]
+          (fn [{:keys [post-calls stream-calls stop-stream-calls update-calls]}]
             (let [response (mt/client :post 200 "ee/metabot-v3/slack/events"
                                       (slack-request-options event-body)
                                       event-body)]
               (is (= "ok" response))
-              ;; Wait for streaming to complete
-              (u/poll {:thunk #(>= (count @stop-stream-calls) 1)
-                       :done? true?
+              (u/poll {:thunk  #(>= (count @update-calls) 1)
+                       :done?  true?
                        :timeout-ms 5000})
-              (testing "stream was started"
-                (is (= 1 (count @stream-calls)))
-                (is (= "C123" (:channel (first @stream-calls)))))
-              (testing "AI response was streamed"
-                (is (some #(= mock-ai-text %) @append-text-calls)))
-              (testing "stream was stopped"
-                (is (= 1 (count @stop-stream-calls)))))))))))
+              (testing "a visible threaded reply is posted immediately with thinking placeholder"
+                (is (= 1 (count @post-calls)))
+                (is (= "_Thinking..._" (:text (first @post-calls))))
+                (is (= "1234567890.000001" (:thread_ts (first @post-calls)))))
+              (testing "the visible reply is updated with the answer"
+                (is (= 1 (count @update-calls)))
+                (is (some #(str/includes? (:text %) mock-ai-text) @update-calls)))
+              (testing "streaming APIs are not used for app mentions"
+                (is (empty? @stream-calls))
+                (is (empty? @stop-stream-calls))))))))))
 
 (deftest stream-start-failure-test
   (testing "When start-stream fails, falls back to a regular message"
@@ -454,12 +461,14 @@
         (testing desc
           (with-slackbot-mocks
             {:ai-text "response"}
-            (fn [{:keys [ai-request-calls]}]
+            (fn [{:keys [ai-request-calls stop-stream-calls update-calls]}]
               (mt/client :post 200 "ee/metabot-v3/slack/events"
                          (slack-request-options event-body)
                          event-body)
-              (u/poll {:thunk #(= 1 (count @ai-request-calls))
-                       :done? true?
+              ;; Wait for response to fully complete (streaming: stop-stream; channel: update-message)
+              (u/poll {:thunk      #(or (>= (count @stop-stream-calls) 1)
+                                        (>= (count @update-calls) 1))
+                       :done?      true?
                        :timeout-ms 5000})
               (is (= 1 (count @ai-request-calls)))
               (let [opts (first @ai-request-calls)]
@@ -467,8 +476,14 @@
                 (is (map? (:context opts)))
                 (is (= (get-in event-body [:event :channel])
                        (get-in opts [:context :slack_channel_id])))
-                (is (= (get-in event-body [:event :text])
-                       (get-in opts [:message :content])))
+                ;; DMs send the raw prompt; channel mentions append a response-style suffix
+                (if (= "im" (get-in event-body [:event :channel_type]))
+                  (is (= (get-in event-body [:event :text])
+                         (get-in opts [:message :content])))
+                  (let [content (get-in opts [:message :content])]
+                    (is (str/includes? content "Hello!") "user message is included in prompt")
+                    (is (str/includes? content "Do not narrate the steps you took")
+                        "channel response-style suffix is appended")))
                 (is (vector? (:history opts)))
                 (is (fn? (:on-line opts)))))))))))
 
@@ -492,12 +507,14 @@
                 ;; Filter by expected slack_msg_ids to avoid picking up messages from other tests
                 (let [user-msg (t2/select-one :model/MetabotMessage :slack_msg_id event-ts)
                       bot-msg  (t2/select-one :model/MetabotMessage :slack_msg_id "stream123")]
-                  (testing "user message has event ts"
+                  (testing "user message has event ts and channel_id"
                     (is (some? user-msg))
-                    (is (= event-ts (:slack_msg_id user-msg))))
-                  (testing "bot message has stream ts"
+                    (is (= event-ts (:slack_msg_id user-msg)))
+                    (is (= "C123" (:channel_id user-msg))))
+                  (testing "bot message has stream ts and channel_id"
                     (is (some? bot-msg))
-                    (is (= "stream123" (:slack_msg_id bot-msg)))))))))))))
+                    (is (= "stream123" (:slack_msg_id bot-msg)))
+                    (is (= "C123" (:channel_id bot-msg)))))))))))))
 
 (deftest ^:parallel slack-thread-conversation-id-test
   (testing "Same thread produces same conversation ID"

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
@@ -16,6 +16,7 @@
    [metabase-enterprise.metabot-v3.settings :as metabot.settings]
    [metabase-enterprise.sso.settings :as sso-settings]
    [metabase.channel.settings :as channel.settings]
+   [metabase.channel.slack :as channel.slack]
    [metabase.premium-features.core :as premium-features]
    [metabase.server.middleware.auth :as mw.auth]
    [metabase.test :as mt]
@@ -177,6 +178,7 @@
                                       body)]
               (is (= "ok" response) "Should ACK the event with 200 OK"))))))))
 
+#_{:clj-kondo/ignore [:metabase/test-helpers-use-non-thread-safe-functions]}
 (defn- with-slackbot-mocks
   "Helper to set up common mocks for slackbot tests.
    Options:
@@ -204,6 +206,7 @@
         append-text-calls           (atom [])
         stop-stream-calls           (atom [])
         fake-png-bytes              (byte-array [0x89 0x50 0x4E 0x47])
+        file-counter                (atom 0)
         placeholder-counter         (atom 0)
         mock-user-id                (cond
                                       (= user-id ::default) (mt/user->id :rasta)
@@ -212,19 +215,19 @@
     (mt/with-dynamic-fn-redefs
       [slackbot/slack-id->user-id (constantly mock-user-id)
        slackbot.client/get-bot-user-id (constantly "UBOT123")
-       slackbot.client/auth-test            (constantly {:ok true :user_id "UBOT123" :team_id "T123"})
-       slackbot.client/fetch-thread         (constantly {:ok true, :messages []})
+       slackbot.client/auth-test (constantly {:ok true :user_id "UBOT123" :team_id "T123"})
+       slackbot.client/fetch-thread (constantly {:ok true, :messages []})
        ;; Mock Slack streaming APIs
-       slackbot.client/start-stream         (fn [_ opts]
-                                              (swap! stream-calls conj opts)
-                                              {:stream_ts "stream123" :channel (:channel opts) :thread_ts (:thread_ts opts)})
-       slackbot.client/append-stream        (constantly {:ok true})
+       slackbot.client/start-stream (fn [_ opts]
+                                      (swap! stream-calls conj opts)
+                                      {:stream_ts "stream123" :channel (:channel opts) :thread_ts (:thread_ts opts)})
+       slackbot.client/append-stream (constantly {:ok true})
        slackbot.client/append-markdown-text (fn [_ _channel _stream-ts text]
                                               (swap! append-text-calls conj text)
                                               {:ok true})
-       slackbot.client/stop-stream          (fn [_ channel stream-ts & [blocks]]
-                                              (swap! stop-stream-calls conj {:channel channel :stream_ts stream-ts :blocks blocks})
-                                              {:ok true})
+       slackbot.client/stop-stream (fn [_ channel stream-ts & [blocks]]
+                                     (swap! stop-stream-calls conj {:channel channel :stream_ts stream-ts :blocks blocks})
+                                     {:ok true})
        slackbot.client/post-message (fn [_ msg]
                                       (swap! post-calls conj msg)
                                       {:ok      true
@@ -237,14 +240,14 @@
        slackbot.client/delete-message (fn [_ msg]
                                         (swap! delete-calls conj msg)
                                         {:ok true})
-       slackbot.client/post-image     (fn [_client image-bytes filename channel thread-ts
-                                           & {:keys [initial-comment]}]
-                                        (swap! image-calls conj {:image-bytes     image-bytes
-                                                                 :filename        filename
-                                                                 :channel         channel
-                                                                 :thread-ts       thread-ts
-                                                                 :initial-comment initial-comment})
-                                        {:ok true :file_id "F123"})
+       channel.slack/upload-file-with-token! (fn [token image-bytes filename]
+                                               (let [file-id (format "FIMG-%d" (swap! file-counter inc))]
+                                                 (swap! image-calls conj {:token       token
+                                                                          :image-bytes image-bytes
+                                                                          :filename    filename
+                                                                          :file-id     file-id})
+                                                 {:url (str "https://files.slack.com/files/" filename)
+                                                  :id  file-id}))
        ;; Mock the streaming client - returns AISDK-formatted lines
        metabot-v3.client/streaming-request-with-callback
        (fn [opts]
@@ -263,12 +266,13 @@
            (when-let [on-complete (:on-complete opts)]
              (on-complete mock-lines))
            mock-lines))
-       slackbot.query/generate-card-output     (fn [card-id]
-                                                 (swap! generate-card-output-calls conj {:card-id card-id})
-                                                 {:type :image :content fake-png-bytes :card-name (str "Card " card-id)})
+       slackbot.query/generate-card-output (fn [card-id]
+                                             (swap! generate-card-output-calls conj {:card-id card-id})
+                                             {:type :image :content fake-png-bytes :card-name (str "Card " card-id)})
        slackbot.query/generate-adhoc-output (fn [query & {:keys [display]}]
                                               (swap! generate-adhoc-output-calls conj {:query query :display display})
-                                              (if (#{:bar :line :pie :area :row :scatter :funnel :waterfall :combo :progress :gauge :map} display)
+                                              (if (#{:bar :line :pie :area :row :scatter :funnel :waterfall :combo :progress :gauge :map}
+                                                   display)
                                                 {:type :image :content fake-png-bytes}
                                                 {:type :table :content [{:type "table" :rows [] :column_settings []}]}))]
       (body-fn {:post-calls                  post-calls
@@ -518,7 +522,7 @@
                     (#'slackbot.streaming/slack-thread->conversation-id "T1" "C1" "123.456")))))
 
 (deftest user-message-with-visualizations-test
-  (testing "POST /events with visualizations posts images"
+  (testing "POST /events with visualizations uploads images and finalizes them in stop-stream blocks"
     (with-slackbot-setup
       (let [mock-ai-text "Here are your charts"
             mock-data-parts [{:type "static_viz" :value {:entity_id 101}}
@@ -555,14 +559,18 @@
                 (is (= 2 (count @generate-card-output-calls)))
                 (is (= #{101 202} (set (map :card-id @generate-card-output-calls)))))
 
-              (testing "images posted"
+              (testing "rendered PNGs are uploaded to Slack"
                 (is (= 2 (count @image-calls)))
-                (is (every? #(= "C456" (:channel %)) @image-calls))
-                (is (every? #(= "1234567890.000000" (:thread-ts %)) @image-calls))
                 (is (= #{"card_101.png" "card_202.png"}
                        (set (map :filename @image-calls))))
                 (is (every? #(= (vec fake-png-bytes) (vec (:image-bytes %)))
-                            @image-calls))))))))))
+                            @image-calls)))
+
+              (testing "stop-stream includes both image blocks and feedback controls"
+                (let [blocks (:blocks (first @stop-stream-calls))]
+                  (is (= ["section" "image" "section" "image" "context_actions"]
+                         (mapv :type blocks)))
+                  (is (= "feedback_buttons" (get-in blocks [4 :elements 0 :type]))))))))))))
 
 (deftest user-not-linked-sends-auth-message-test
   (testing "POST /events with unlinked user sends auth message (DM, no user mention prefix)"
@@ -659,7 +667,7 @@
 ;; -------------------------------- Ad-Hoc Query Visualization Tests --------------------------------
 
 (deftest adhoc-viz-execution-test
-  (testing "POST /events with adhoc_viz executes query and posts image"
+  (testing "POST /events with adhoc_viz executes query and uploads image"
     (with-slackbot-setup
       (let [mock-ai-text    "Here's your data"
             mock-query      {:database 1
@@ -693,12 +701,16 @@
                 (is (= mock-query (:query (first @generate-adhoc-output-calls))))
                 (is (= :bar (:display (first @generate-adhoc-output-calls)))))
 
-              (testing "image posted with adhoc filename"
+              (testing "image uploaded with adhoc filename"
                 (is (= 1 (count @image-calls)))
-                (is (= "C789" (:channel (first @image-calls))))
-                (is (= "1234567890.000000" (:thread-ts (first @image-calls))))
                 (is (re-matches #"adhoc-\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}\.png" (:filename (first @image-calls))))
-                (is (= (vec fake-png-bytes) (vec (:image-bytes (first @image-calls)))))))))))))
+                (is (= (vec fake-png-bytes) (vec (:image-bytes (first @image-calls))))))
+
+              (testing "stop-stream includes the uploaded image and feedback controls"
+                (let [blocks (:blocks (first @stop-stream-calls))]
+                  (is (= ["section" "image" "context_actions"]
+                         (mapv :type blocks)))
+                  (is (re-matches #"FIMG-\d+" (get-in blocks [1 :slack_file :id]))))))))))))
 
 (deftest adhoc-viz-default-display-test
   (testing "POST /events with adhoc_viz uses :table when display not specified"
@@ -740,7 +752,7 @@
         (with-slackbot-mocks
           {:ai-text    "Here's everything"
            :data-parts mock-data-parts}
-          (fn [{:keys [image-calls generate-card-output-calls generate-adhoc-output-calls]}]
+          (fn [{:keys [image-calls stop-stream-calls generate-card-output-calls generate-adhoc-output-calls]}]
             (mt/client :post 200 "ee/metabot-v3/slack/events"
                        (slack-request-options event-body)
                        event-body)
@@ -752,11 +764,15 @@
             (testing "adhoc_viz query rendered"
               (is (= 1 (count @generate-adhoc-output-calls)))
               (is (= :line (:display (first @generate-adhoc-output-calls)))))
-            (testing "all images posted"
+            (testing "all images uploaded"
               (is (= 3 (count @image-calls)))
               (is (= #{"card_101.png" "card_202.png"}
                      (set (filter #(str/starts-with? % "card") (map :filename @image-calls)))))
-              (is (= 1 (count (filter #(str/starts-with? % "adhoc-") (map :filename @image-calls))))))))))))
+              (is (= 1 (count (filter #(str/starts-with? % "adhoc-") (map :filename @image-calls))))))
+            (testing "stop-stream includes all uploaded image blocks"
+              (let [blocks (:blocks (first @stop-stream-calls))]
+                (is (= ["section" "image" "section" "image" "section" "image" "context_actions"]
+                       (mapv :type blocks)))))))))))
 
 (deftest generate-card-output-display-type-test
   (testing "generate-card-output returns correct type based on card display"
@@ -837,7 +853,7 @@
               (testing "error message posted for failing viz"
                 (is (some #(= "Query execution failed, please try again." (:text %))
                           @post-calls)))
-              (testing "second card still rendered"
+              (testing "second card still uploads"
                 (is (= 1 (count @image-calls)))))))))))
 
 (deftest format-viz-title-test
@@ -886,46 +902,53 @@
                                        (>= (count @image-calls) 1))
                      :done?      true?
                      :timeout-ms 5000})
-            (let [img (first @image-calls)]
+            (let [img    (first @image-calls)
+                  blocks (:blocks (first @stop-stream-calls))]
               (testing "filename uses slugified card name"
                 (is (= "card_101.png" (:filename img))))
-              (testing "initial-comment uses card name with link, not AI caption"
-                (is (str/includes? (:initial-comment img) "Card 101"))
-                (is (not (str/includes? (:initial-comment img) "AI-generated caption")))
-                (is (str/includes? (:initial-comment img) "/question/101"))))))))))
+              (testing "caption block uses card name with link, not AI caption"
+                (let [caption-text (get-in blocks [0 :text :text])]
+                  (is (str/includes? caption-text "Card 101"))
+                  (is (not (str/includes? caption-text "AI-generated caption")))
+                  (is (str/includes? caption-text "/question/101"))))
+              (testing "image block references the uploaded Slack file"
+                (is (= (:file-id img) (get-in blocks [1 :slack_file :id]))))))))))
 
-(deftest table-viz-with-caption-test
-  (testing "table viz posts include caption block with link"
-    (with-slackbot-setup
-      (let [mock-query      {:database 1 :type "query" :query {:source-table 2}}
-            mock-data-parts [{:type  "adhoc_viz"
-                              :value {:query   mock-query
-                                      :title   "Sales Data"
-                                      :link    "/question#abc123"}}]
-            event-body      (update base-dm-event :event merge
-                                    {:text      "Show sales"
-                                     :ts        "1234567890.000021"
-                                     :event_ts  "1234567890.000021"
-                                     :thread_ts "1234567890.000000"})]
-        (with-slackbot-mocks
-          {:ai-text    "Here's your table"
-           :data-parts mock-data-parts}
-          (fn [{:keys [post-calls stop-stream-calls generate-adhoc-output-calls]}]
-            (mt/client :post 200 "ee/metabot-v3/slack/events"
-                       (slack-request-options event-body)
-                       event-body)
-            (u/poll {:thunk      #(and (>= (count @stop-stream-calls) 1)
-                                       (>= (count @generate-adhoc-output-calls) 1))
-                     :done?      true?
-                     :timeout-ms 5000})
-            (let [viz-post (some (fn [p] (when (:blocks p) p)) @post-calls)]
-              (testing "table viz posted as message with blocks"
-                (is (some? viz-post)))
-              (testing "first block is caption with mrkdwn text"
-                (let [caption-block (first (:blocks viz-post))]
-                  (is (= "section" (:type caption-block)))
-                  (is (= "mrkdwn" (get-in caption-block [:text :type])))
-                  (is (str/includes? (get-in caption-block [:text :text]) "Sales Data")))))))))))
+  (deftest table-viz-with-caption-test
+    (testing "table viz posts include caption block with link"
+      (with-slackbot-setup
+        (let [mock-query      {:database 1 :type "query" :query {:source-table 2}}
+              mock-data-parts [{:type  "adhoc_viz"
+                                :value {:query   mock-query
+                                        :title   "Sales Data"
+                                        :link    "/question#abc123"}}]
+              event-body      (update base-dm-event :event merge
+                                      {:text      "Show sales"
+                                       :ts        "1234567890.000021"
+                                       :event_ts  "1234567890.000021"
+                                       :thread_ts "1234567890.000000"})]
+          (with-slackbot-mocks
+            {:ai-text    "Here's your table"
+             :data-parts mock-data-parts}
+            (fn [{:keys [stop-stream-calls generate-adhoc-output-calls]}]
+              (mt/client :post 200 "ee/metabot-v3/slack/events"
+                         (slack-request-options event-body)
+                         event-body)
+              (u/poll {:thunk      #(and (>= (count @stop-stream-calls) 1)
+                                         (>= (count @generate-adhoc-output-calls) 1))
+                       :done?      true?
+                       :timeout-ms 5000})
+              (let [viz-blocks (:blocks (first @stop-stream-calls))]
+                (testing "table viz is finalized in stop-stream blocks"
+                  (is (seq viz-blocks)))
+                (testing "first block is caption with mrkdwn text"
+                  (let [caption-block (first viz-blocks)]
+                    (is (= "section" (:type caption-block)))
+                    (is (= "mrkdwn" (get-in caption-block [:text :type])))
+                    (is (str/includes? (get-in caption-block [:text :text]) "Sales Data"))))
+                (testing "feedback controls are appended after table blocks"
+                  (is (= "context_actions" (get-in viz-blocks [2 :type])))
+                  (is (= "feedback_buttons" (get-in viz-blocks [2 :elements 0 :type]))))))))))))
 
 (deftest generate-card-output-failed-qp-result-test
   (testing "throws when QP returns :status :failed for table card"

--- a/src/metabase/channel/slack.clj
+++ b/src/metabase/channel/slack.clj
@@ -262,11 +262,10 @@
 (defn complete!
   "Completes the file upload to a Slack channel by calling the `files.completeUploadExternal` endpoint, and polls the
    same endpoint until the file is uploaded to the channel. Returns the URL of the uploaded file."
-  [& {:keys [token file-id filename]}]
+  [& {:keys [file-id filename]}]
   (let [complete! (fn []
                     (POST "files.completeUploadExternal"
-                      {:query-params (cond-> {:files (json/encode [{:id file-id, :title filename}])}
-                                       token (assoc :token token))}))
+                      {:query-params {:files (json/encode [{:id file-id, :title filename}])}}))
         complete-response
         (try
           (complete!)
@@ -284,30 +283,15 @@
                             {:filename filename})))]
     (get-in complete-response [:files 0 :url_private])))
 
-(defn- get-upload-url! [filename file & {:keys [token]}]
-  (POST "files.getUploadURLExternal" {:query-params (cond-> {:filename filename
-                                                             :length   (count file)}
-                                                      token (assoc :token token))}))
+(defn- get-upload-url! [filename file]
+  (POST "files.getUploadURLExternal" {:query-params {:filename filename
+                                                     :length   (count file)}}))
 
 (defn- upload-file-to-url! [upload-url file]
   (let [response (http/post upload-url {:multipart [{:name "file", :content file}]})]
     (if (= (:status response) 200)
       response
       (throw (ex-info "Failed to upload file to Slack:" (select-keys response [:status :body]))))))
-
-(defn- upload-file*!
-  [token file filename]
-  (let [;; Step 1: Get the upload URL using files.getUploadURLExternal
-        {:keys [upload_url file_id]} (get-upload-url! filename file :token token)
-        ;; Step 2: Upload the file to the obtained upload URL
-        _ (upload-file-to-url! upload_url file)
-        ;; Step 3: Complete the upload using files.completeUploadExternal
-        file-url (complete! :token token
-                            :file-id file_id
-                            :filename filename)]
-    (u/prog1 {:url file-url
-              :id file_id}
-      (log/debug "Uploaded image" (:url <>)))))
 
 (mu/defn upload-file!
   "Calls Slack API `files.getUploadURLExternal` and `files.completeUploadExternal` endpoints to upload a file and returns
@@ -317,14 +301,16 @@
   {:pre [(channel.settings/slack-configured?)]}
   ;; TODO: we could make uploading files a lot faster by uploading the files in parallel.
   ;; Steps 1 and 2 can be done for all files in parallel, and step 3 can be done once at the end.
-  (upload-file*! nil file filename))
-
-(mu/defn upload-file-with-token!
-  "Variant of [[upload-file!]] that uses an explicit Slack token instead of the globally configured one."
-  [token      :- ms/NonBlankString
-   file       :- NonEmptyByteArray
-   filename   :- ms/NonBlankString]
-  (upload-file*! token file filename))
+  (let [;; Step 1: Get the upload URL using files.getUploadURLExternal
+        {:keys [upload_url file_id]} (get-upload-url! filename file)
+        ;; Step 2: Upload the file to the obtained upload URL
+        _ (upload-file-to-url! upload_url file)
+        ;; Step 3: Complete the upload using files.completeUploadExternal
+        file-url (complete! {:file-id    file_id
+                             :filename   filename})]
+    (u/prog1 {:url file-url
+              :id file_id}
+      (log/debug "Uploaded image" (:url <>)))))
 
 (mu/defn post-chat-message!
   "Calls Slack API `chat.postMessage` endpoint and posts a message to a channel.

--- a/src/metabase/channel/slack.clj
+++ b/src/metabase/channel/slack.clj
@@ -262,10 +262,11 @@
 (defn complete!
   "Completes the file upload to a Slack channel by calling the `files.completeUploadExternal` endpoint, and polls the
    same endpoint until the file is uploaded to the channel. Returns the URL of the uploaded file."
-  [& {:keys [file-id filename]}]
+  [& {:keys [token file-id filename]}]
   (let [complete! (fn []
                     (POST "files.completeUploadExternal"
-                      {:query-params {:files (json/encode [{:id file-id, :title filename}])}}))
+                      {:query-params (cond-> {:files (json/encode [{:id file-id, :title filename}])}
+                                       token (assoc :token token))}))
         complete-response
         (try
           (complete!)
@@ -283,15 +284,30 @@
                             {:filename filename})))]
     (get-in complete-response [:files 0 :url_private])))
 
-(defn- get-upload-url! [filename file]
-  (POST "files.getUploadURLExternal" {:query-params {:filename filename
-                                                     :length   (count file)}}))
+(defn- get-upload-url! [filename file & {:keys [token]}]
+  (POST "files.getUploadURLExternal" {:query-params (cond-> {:filename filename
+                                                             :length   (count file)}
+                                                      token (assoc :token token))}))
 
 (defn- upload-file-to-url! [upload-url file]
   (let [response (http/post upload-url {:multipart [{:name "file", :content file}]})]
     (if (= (:status response) 200)
       response
       (throw (ex-info "Failed to upload file to Slack:" (select-keys response [:status :body]))))))
+
+(defn- upload-file*!
+  [token file filename]
+  (let [;; Step 1: Get the upload URL using files.getUploadURLExternal
+        {:keys [upload_url file_id]} (get-upload-url! filename file :token token)
+        ;; Step 2: Upload the file to the obtained upload URL
+        _ (upload-file-to-url! upload_url file)
+        ;; Step 3: Complete the upload using files.completeUploadExternal
+        file-url (complete! :token token
+                            :file-id file_id
+                            :filename filename)]
+    (u/prog1 {:url file-url
+              :id file_id}
+      (log/debug "Uploaded image" (:url <>)))))
 
 (mu/defn upload-file!
   "Calls Slack API `files.getUploadURLExternal` and `files.completeUploadExternal` endpoints to upload a file and returns
@@ -301,16 +317,14 @@
   {:pre [(channel.settings/slack-configured?)]}
   ;; TODO: we could make uploading files a lot faster by uploading the files in parallel.
   ;; Steps 1 and 2 can be done for all files in parallel, and step 3 can be done once at the end.
-  (let [;; Step 1: Get the upload URL using files.getUploadURLExternal
-        {:keys [upload_url file_id]} (get-upload-url! filename file)
-        ;; Step 2: Upload the file to the obtained upload URL
-        _ (upload-file-to-url! upload_url file)
-        ;; Step 3: Complete the upload using files.completeUploadExternal
-        file-url (complete! {:file-id    file_id
-                             :filename   filename})]
-    (u/prog1 {:url file-url
-              :id file_id}
-      (log/debug "Uploaded image" (:url <>)))))
+  (upload-file*! nil file filename))
+
+(mu/defn upload-file-with-token!
+  "Variant of [[upload-file!]] that uses an explicit Slack token instead of the globally configured one."
+  [token      :- ms/NonBlankString
+   file       :- NonEmptyByteArray
+   filename   :- ms/NonBlankString]
+  (upload-file*! token file filename))
 
 (mu/defn post-chat-message!
   "Calls Slack API `chat.postMessage` endpoint and posts a message to a channel.


### PR DESCRIPTION
- Slackbot now finalizes visualizations inside the streamed Slack message instead of posting them as separate follow-up messages
- Splits the DM (streaming) response flow from the channel (non-streaming) flow
- Improves stop-stream error handling
- Misc refactor