### PR TITLE
Fix reflection warnings in tests + add linter

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -36,6 +36,18 @@ jobs:
       - run: clojure -X:dev:ee:ee-dev:drivers:drivers-dev:test:eastwood
         name: Run Eastwood linter
 
+  be-linter-eastwood-test:
+    if: ${{ !inputs.skip }}
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    name: Eastwood (test)
+    steps:
+      - uses: actions/checkout@v4
+      - name: Prepare back-end environment
+        uses: ./.github/actions/prepare-backend
+      - run: clojure -X:dev:ee:ee-dev:drivers:drivers-dev:test:eastwood/test
+        name: Run Eastwood linter on tests
+
   be-tests:
     if: ${{ !inputs.skip }}
     runs-on: ubuntu-22.04
@@ -184,6 +196,7 @@ jobs:
   be-tests-result:
     needs:
       - be-linter-eastwood
+      - be-linter-eastwood-test
       - be-linter-clj-kondo
       - be-cljfmt
       - be-check

--- a/deps.edn
+++ b/deps.edn
@@ -631,6 +631,29 @@
                ;; and a simple reproduction repo can be found here https://github.com/metabase/snowplow-eastwood-issue
                :exclude-namespaces [metabase.analytics.snowplow]}}
 
+  ;; Test counterpart of :eastwood. Starts with :reflection only; add more linters as we fix other eastwood
+  ;; issues in tests.
+  ;;
+  ;; clojure -X:dev:ee:ee-dev:drivers:drivers-dev:test:eastwood/test
+  :eastwood/test
+  {:exec-fn   metabase.linters.eastwood/eastwood
+   :exec-args {:source-paths ["test"
+                              "enterprise/backend/test"]
+               :linters      [:reflection]
+               :exclude-namespaces
+               [;; byte/1 dispatch value trips up Eastwood's reader
+                metabase.test.http-client
+                ;; Cookie/.getName qualified method trips up Eastwood's analyzer
+                metabase.server.middleware.settings-cache-test
+                ;; .cljc syntax error during Eastwood's analyze+eval phase
+                metabase.lib.query-test
+                ;; "count not supported on this type: Symbol" in Eastwood's analyzer
+                metabase.query-processor.parameters.temporal-units-test
+                ;; Syntax error compiling fn* in Eastwood's analyzer
+                metabase.sql-tools.macaw.references-test
+                ;; Method too large for Eastwood's analyzer
+                metabase.sql-tools.sqlglot.references-test]}}
+
   ;; clojure -T:whitespace-linter
   :whitespace-linter
   {:deps       {com.github.camsaul/whitespace-linter {:sha "e35bc252ccf5cc74f7d543ef95ad8a3e5131f25b"}}

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_metadata_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_metadata_test.clj
@@ -6,7 +6,9 @@
    [metabase-enterprise.semantic-search.index-metadata :as semantic.index-metadata]
    [metabase-enterprise.semantic-search.test-util :as semantic.tu]
    [metabase.test :as mt]
-   [metabase.util :as u]))
+   [metabase.util :as u])
+  (:import
+   (java.io Closeable)))
 
 (use-fixtures :once #'semantic.tu/once-fixture)
 
@@ -31,17 +33,17 @@
                          (semantic.index-metadata/create-tables-if-not-exists! %1 %2)
                          (fn [_] (semantic.index-metadata/drop-tables-if-exists! %1 %2)))]
     (testing "creates metadata and control tables when they don't exist"
-      (with-open [_ (sut pgvector index-metadata)]
+      (with-open [^Closeable _ (sut pgvector index-metadata)]
         (is (semantic.tu/table-exists-in-db? (:metadata-table-name index-metadata)))
         (is (semantic.tu/table-exists-in-db? (:control-table-name index-metadata)))
         (is (semantic.tu/table-exists-in-db? (:gate-table-name index-metadata)))))
     (testing "is idempotent when tables already exist"
-      (with-open [_ (sut pgvector index-metadata)]
+      (with-open [^Closeable _ (sut pgvector index-metadata)]
         (let [table-names-snap (semantic.tu/get-table-names pgvector)
               _                (sut pgvector index-metadata)]
           (is (= table-names-snap (semantic.tu/get-table-names pgvector))))))))
 
-(defn- open-tables! [pgvector index-metadata]
+(defn- open-tables! ^Closeable [pgvector index-metadata]
   (semantic.tu/closeable
    (semantic.index-metadata/create-tables-if-not-exists! pgvector index-metadata)
    (fn [_] (semantic.tu/cleanup-index-metadata! pgvector index-metadata))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/cmd_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/cmd_test.clj
@@ -91,7 +91,7 @@
               (let [ingest-file @#'v2.ingest/ingest-file]
                 ;; overriding ingest-file is weird, but ingest-one is a protocol function and with-redefs won't
                 ;; override that reliably
-                (with-redefs [v2.ingest/ingest-file (fn [file]
+                (with-redefs [v2.ingest/ingest-file (fn [^java.io.File file]
                                                       (cond-> (ingest-file file)
                                                         (str/includes? (.getName file) (:entity_id card))
                                                         (assoc :collection_id "DoesNotExist")))]

--- a/enterprise/backend/test/metabase_enterprise/transforms/incremental_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/incremental_test.clj
@@ -192,7 +192,7 @@
   (case checkpoint-type
     :integer (= (bigint expected) (bigint actual))
     :float (and (number? actual)
-                (< (Math/abs (- expected actual)) 0.01))
+                (< (Math/abs (double (- expected actual))) 0.01))
     :temporal (and (string? actual)
                    (str/starts-with? actual expected))))
 

--- a/enterprise/backend/test/metabase_enterprise/workspaces/impl_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/impl_test.clj
@@ -654,7 +654,7 @@
           (let [workspace (t2/select-one :model/Workspace workspace-id)
                 graph     (ws.impl/get-or-calculate-graph! workspace)
                 result    (ws.impl/run-stale-ancestors! workspace graph t7-ref)
-                succeeded (:succeeded result)]
+                succeeded ^java.util.List (:succeeded result)]
             (testing "x1, x2 (transitively stale), and x4 run; x3, x5, x6 do not"
               (is (= (set [t1-ref t2-ref t4-ref]) (set succeeded)))
               (is (= [] (:failed result)))
@@ -742,7 +742,7 @@
           (let [workspace (t2/select-one :model/Workspace workspace-id)
                 graph     (ws.impl/get-or-calculate-graph! workspace)
                 result    (ws.impl/run-stale-ancestors! workspace graph x3-ref)
-                succeeded (:succeeded result)]
+                succeeded ^java.util.List (:succeeded result)]
             (testing "both workspace transform x1 and external transform x2 are run"
               (is (= #{x1-ref x2-global} (set succeeded)))
               (is (= [] (:failed result)))

--- a/test/metabase/lib/test_util.cljc
+++ b/test/metabase/lib/test_util.cljc
@@ -227,7 +227,9 @@
   (if (instance? #?(:clj  CachedProxyMetadataProvider
                     :cljs metabase.lib.metadata.cached-provider/CachedProxyMetadataProvider)
                  metadata-provider)
-    (.-metadata-provider metadata-provider)
+    (let [p #?(:clj  ^CachedProxyMetadataProvider metadata-provider
+               :cljs metadata-provider)]
+      (.-metadata-provider p))
     metadata-provider))
 
 (mu/defn make-mock-cards

--- a/test/metabase/query_processor/middleware/catch_exceptions_test.clj
+++ b/test/metabase/query_processor/middleware/catch_exceptions_test.clj
@@ -57,7 +57,7 @@
                                     (update cause :stacktrace sequential?))))))))))
   (testing "SQLExceptions that include stack traces should have them removed"
     (let [e1 (ex-info "mock databricks jdbc driver exception" {:level 1})
-          e2 (SQLException. "mock sql exception\n\tat line1\n\tat line2\n\tat line3" e1)
+          e2 (SQLException. "mock sql exception\n\tat line1\n\tat line2\n\tat line3" ^Throwable e1)
           e3 (ex-info "mock exception" {:level 3} e2)]
       (is (= {:status     :failed
               :class      clojure.lang.ExceptionInfo

--- a/test/metabase/sso/api/ldap_test.clj
+++ b/test/metabase/sso/api/ldap_test.clj
@@ -53,7 +53,7 @@
       (testing "Valid LDAP settings can still be saved if port is a integer (#18936)"
         (mt/user-http-request :crowberto :put 200 "ldap/settings"
                               (assoc (ldap-test-details)
-                                     :ldap-port (Integer. (ldap.test/get-ldap-port)))))
+                                     :ldap-port (int (ldap.test/get-ldap-port)))))
 
       (testing "Passing ldap-enabled=false will disable LDAP"
         (mt/user-http-request :crowberto :put 200 "ldap/settings" (ldap-test-details false))


### PR DESCRIPTION
Some might say it's harmless noise, but I say it's a sin.

In addition to purging these somewhat toothless reflections, it also paves way to progressively enabling the rest of the linters on our test code, which could find more serious defects.
