### PR TITLE
[Fix#69178] email no color in pivot table

### DIFF
--- a/src/metabase/channel/render/body.clj
+++ b/src/metabase/channel/render/body.clj
@@ -13,6 +13,7 @@
    [metabase.channel.settings :as channel.settings]
    [metabase.formatter.core :as formatter]
    [metabase.models.visualization-settings :as mb.viz]
+   [metabase.query-processor.pivot.postprocess :as qp.pivot.postprocess]
    [metabase.query-processor.streaming :as qp.streaming]
    [metabase.query-processor.streaming.common :as streaming.common]
    [metabase.timeline.core :as timeline]
@@ -239,6 +240,16 @@
    _dashcard
    {:keys [rows viz-settings format-rows?] :as unordered-data}]
   (let [[ordered-cols ordered-rows] (order-data unordered-data viz-settings)
+        selector-data               (if-let [pivot-grouping-idx (qp.pivot.postprocess/pivot-grouping-index (map :name (:cols unordered-data)))]
+                                      (update unordered-data :rows
+                                              (fn [pivot-rows]
+                                                (into []
+                                                      (filter (fn [row]
+                                                                (let [group (nth row pivot-grouping-idx nil)
+                                                                      group (or (:num-value group) group)]
+                                                                  (= qp.pivot.postprocess/non-pivot-row-group group))))
+                                                      pivot-rows)))
+                                      unordered-data)
         data                        (-> unordered-data
                                         (assoc :rows ordered-rows)
                                         (assoc :cols ordered-cols))
@@ -246,7 +257,7 @@
         minibar-cols                (minibar-columns (get-in unordered-data [:results_metadata :columns] []) viz-settings)
         table-body                  [:div
                                      (table/render-table
-                                      (js.color/make-color-selector unordered-data viz-settings)
+                                      (js.color/make-color-selector selector-data viz-settings)
                                       {:cols-for-color-lookup (mapv :name filtered-cols)
                                        :col-names             (streaming.common/column-titles filtered-cols viz-settings format-rows?)}
                                       (prep-for-html-rendering timezone-id card data)

--- a/src/metabase/channel/render/js/color.clj
+++ b/src/metabase/channel/render/js/color.clj
@@ -78,7 +78,10 @@
   ;; expensive. The JS code is written to deal with `rows` in it's native Nashorn format but since `cols` and
   ;; `viz-settings` are small, pass those as JSON so that they can be deserialized to pure JS objects once in JS
   ;; code. We do however need to handle BigDecimals as Graal won't convert these
-  (let [converted-rows (convert-bignumbers-by-column rows)]
+  (let [pivoted?       (some #(= "pivot-grouping" (:name %)) cols)
+        viz-settings   (cond-> viz-settings
+                         pivoted? (assoc :table.pivot true))
+        converted-rows (convert-bignumbers-by-column rows)]
     (js.engine/execute-fn-name (js-engine) "makeCellBackgroundGetter"
                                converted-rows
                                (json/encode cols)

--- a/src/metabase/channel/render/table.clj
+++ b/src/metabase/channel/render/table.clj
@@ -201,13 +201,13 @@
          (inc row-idx)])
       (for [[col-idx cell] (m/indexed row)]
         (let [column       (nth columns col-idx)
-              column-name  (get column-names col-idx)
+              column-name  (nth column-names col-idx nil)
               minibar-col  (first (filter #(= (:name column) (:name %)) minibar-cols))
               col-settings (get-in viz-settings [::mb.viz/column-settings {::mb.viz/column-name column-name}] {})]
           [:td {:style (style/style
                         (row-style-for-type cell)
                         (get col->styles (:name column))
-                        {:background-color (get-background-color cell (get column-names col-idx) row-idx)}
+                        {:background-color (get-background-color cell column-name row-idx)}
                         (when (= row-idx (dec (count rows)))
                           {:border-bottom 0})
                         (when (= col-idx (dec (count row)))
@@ -310,6 +310,9 @@
          pivot-grouping-idx (u/index-of #{"pivot-grouping"} col-names)
          col-names          (cond->> col-names
                               pivot-grouping-idx (m/remove-nth pivot-grouping-idx))
+         cols-for-color-lookup (cond->> cols-for-color-lookup
+                                 pivot-grouping-idx (m/remove-nth pivot-grouping-idx)
+                                 true               vec)
          header             (cond-> header
                               pivot-grouping-idx (update :row #(m/remove-nth pivot-grouping-idx %)))
          rows               (cond->> rows

--- a/test/metabase/channel/render/js/color_test.clj
+++ b/test/metabase/channel/render/js/color_test.clj
@@ -70,6 +70,66 @@
                                                                                                           :highlight_row true}]})
                                                 "any value" "test" 1))))))
 
+(deftest rgba-alpha-is-not-rewritten-for-email-test
+  (let [alpha-script "function makeCellBackgroundGetter(rows, colsJSON, settingsJSON) {
+                        return function(_value, _rowIndex, _columnName) {
+                          return \"rgba(100, 150, 200, 0.6500000000000001)\";
+                        }
+                      }"]
+    (with-test-js-engine! alpha-script
+      (let [color-selector (js.color/make-color-selector {:cols [{:name "test"}]
+                                                          :rows [[1]]}
+                                                         {})]
+        (is (= "rgba(100, 150, 200, 0.6500000000000001)"
+               (js.color/get-background-color color-selector "any value" "test" 0)))))))
+
+(deftest pivoted-email-preserves-column-formatting-rules-test
+  (let [pivot-script "function makeCellBackgroundGetter(rows, colsJSON, settingsJSON) {
+                        var settings = JSON.parse(settingsJSON);
+                        return function(_value, _rowIndex, _columnName) {
+                          var formats = settings[\"table.column_formatting\"] || [];
+                          if (settings[\"table.pivot\"] === true && formats.length > 0) {
+                            return \"rgba(10, 20, 30, 0.654321)\";
+                          }
+                          return null;
+                        }
+                      }"]
+    (with-test-js-engine! pivot-script
+      (let [color-selector (js.color/make-color-selector {:cols [{:name "category" :source "breakout"}
+                                                                 {:name "pivot-grouping" :source "breakout"}
+                                                                 {:name "sum" :source "aggregation"}]
+                                                          :rows [["A" 0 10]]}
+                                                         {:table.column_formatting [{:columns       ["sum"]
+                                                                                     :type          "single"
+                                                                                     :operator      ">"
+                                                                                     :value         5
+                                                                                     :color         "#ff0000"
+                                                                                     :highlight_row true}]})]
+        (is (= "rgba(10, 20, 30, 0.654321)"
+               (js.color/get-background-color color-selector 10 "sum" 0)))))))
+
+(deftest regular-email-does-not-set-pivot-flag-test
+  (let [regular-script "function makeCellBackgroundGetter(rows, colsJSON, settingsJSON) {
+                          var settings = JSON.parse(settingsJSON);
+                          return function(_value, _rowIndex, _columnName) {
+                            if (settings[\"table.pivot\"] !== true) {
+                              return \"rgba(1, 2, 3, 0.65)\";
+                            }
+                            return null;
+                          }
+                        }"]
+    (with-test-js-engine! regular-script
+      (let [color-selector (js.color/make-color-selector {:cols [{:name "sum" :source "aggregation"}]
+                                                          :rows [[10]]}
+                                                         {:table.column_formatting [{:columns       ["sum"]
+                                                                                     :type          "single"
+                                                                                     :operator      ">"
+                                                                                     :value         5
+                                                                                     :color         "#ff0000"
+                                                                                     :highlight_row true}]})]
+        (is (= "rgba(1, 2, 3, 0.65)"
+               (js.color/get-background-color color-selector 10 "sum" 0)))))))
+
 (deftest text-wrapper-null-empty-str-test
   (testing "get-background-color should correctly handle not-null operator for nulls and empty strings (VIZ-87)"
     (let [test-script "function makeCellBackgroundGetter(rows, colsJSON, settingsJSON) {

--- a/test/metabase/channel/render/table_test.clj
+++ b/test/metabase/channel/render/table_test.clj
@@ -89,6 +89,55 @@
                find-table-body
                cell-value->background-color)))))
 
+(deftest pivot-grouping-column-does-not-shift-color-lookup-test
+  (let [columns [{:name "category"} {:name "pivot-grouping"} {:name "metric"}]
+        rows    [{:row ["Category" "pivot-grouping" "Metric"]}
+                 {:row [(formatter/->TextWrapper "A" "A")
+                        (formatter/map->NumericWrapper {:num-str "0" :num-value 0})
+                        (formatter/map->NumericWrapper {:num-str "10" :num-value 10})]}
+                 {:row [(formatter/->TextWrapper "B" "B")
+                        (formatter/map->NumericWrapper {:num-str "1" :num-value 1})
+                        (formatter/map->NumericWrapper {:num-str "20" :num-value 20})]}]]
+    (with-redefs [js.color/get-background-color
+                  (fn [_color-selector _cell column-name row-idx]
+                    (when (= "metric" (some-> column-name str/lower-case))
+                      (if (zero? row-idx)
+                        "rgba(255, 0, 0, 0.65)"
+                        "rgba(255, 0, 0, 0.2)")))]
+      (is (= {"A" nil
+              "10" "rgba(255, 0, 0, 0.65)"}
+             (-> (#'table/render-table
+                  :unused-color-selector
+                  {:col-names             ["Category" "pivot-grouping" "Metric"]
+                   :cols-for-color-lookup ["category" "pivot-grouping" "metric"]}
+                  rows
+                  columns
+                  {}
+                  nil)
+                 find-table-body
+                 cell-value->background-color))))))
+
+(deftest cols-for-color-lookup-applies-colors-for-all-rows-test
+  (let [columns [{:name "metric"}]
+        rows    [{:row [(formatter/->TextWrapper "10" 10)]}
+                 {:row [(formatter/->TextWrapper "20" 20)]}]
+        body    (#'table/render-table-body
+                 (fn [_cell column-name row-idx]
+                   (when (= "metric" column-name)
+                     (if (zero? row-idx)
+                       "rgba(255, 0, 0, 0.65)"
+                       "rgba(255, 0, 0, 0.2)")))
+                 '("metric")
+                 rows
+                 columns
+                 {}
+                 nil
+                 {}
+                 false)]
+    (is (= {"10" "rgba(255, 0, 0, 0.65)"
+            "20" "rgba(255, 0, 0, 0.2)"}
+           (cell-value->background-color body)))))
+
 (deftest header-truncation-test []
   (let [[normal-heading long-heading :as row] ["Count" (apply str (repeat 120 "A"))]
         [normal-rendered long-rendered]       (->> (#'table/render-table-head row {:row row} nil {} false)


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/69178

### Description

Root cause of issue mentioned in commit description

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Make sure email provide is done in your metabase setup
2. Run and open the local port in which your metabase setup is running in browser
3. New > Question
4. Search and Select Orders table for Sample Data
5. In Summarize filter select `Count of rows` and Group By select `CreatedAt` then click Visualize
6. Click `Visualization` button at the bottom left column in the page select `Pivot Table` from the opened modal and then click `Done` button at the bottom
7. Click setting icon on side of `Visualization` button select `Conditional Formatting` from opened modal click `Add a rule` then select `Color range` and then click `Done` button at the bottom.
8. `Save` the question by clicking right top side icon and name it however you like or leave it default.
9. After saving click on three dot icon (`...` ) in the same place as save icon select `Create an alert` after the modal box is open click send and check in your configure email provider in your metabase setup.

### Demo

#### Before modification screenshot:
<img width="1780" height="2088" alt="image" src="https://github.com/user-attachments/assets/acfa6312-00a3-4332-99f5-4596e898f935" />

#### After modification screenshot:
<img width="1790" height="2074" alt="image" src="https://github.com/user-attachments/assets/ce5918dc-461b-4d60-8f09-e783b0d5a9ef" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR