### PR TITLE
[Fix#1953] Remove remote and use local setup static metabase logo

### DIFF
--- a/enterprise/backend/test/metabase/notification/payload/core_test.clj
+++ b/enterprise/backend/test/metabase/notification/payload/core_test.clj
@@ -20,7 +20,7 @@
                                :custom      {}}
                 :context     {:application_name     "Metabase Test"
                               :application_color    "#509EE3"
-                              :application_logo_url "http://static.metabase.com/email_logo.png"
+                              :application_logo_url "https://metabase.com/app/assets/img/logo.png"
                               :include_branding     false
                               :site_name            "Metabase Test"
                               :site_url             "https://metabase.com"

--- a/src/metabase/appearance/core.clj
+++ b/src/metabase/appearance/core.clj
@@ -5,6 +5,10 @@
 
 (comment metabase.appearance.settings/keep-me)
 
+(defn default-logo-path
+  []
+  "app/assets/img/logo.png")
+
 (p/import-vars
  [metabase.appearance.settings
   application-color

--- a/src/metabase/channel/email/logo.clj
+++ b/src/metabase/channel/email/logo.clj
@@ -1,7 +1,9 @@
 (ns metabase.channel.email.logo
   (:require
    [clojure.string :as str]
+   [metabase.appearance.core :as appearance]
    [metabase.channel.render.core :as channel.render]
+   [metabase.system.core :as system]
    [metabase.util.jvm :as u.jvm]))
 
 (set! *warn-on-reflection* true)
@@ -20,14 +22,14 @@
   "Create a logo bundle from the application logo URL.
    Returns {:image-src <url-or-cid> :attachment <attachment-map-or-nil>}.
    For data URIs, converts to an embedded attachment for email compatibility.
-   For the default logo asset path, uses the static Metabase logo URL."
+   For the default logo asset path, uses the logo served by the configured Metabase site URL."
   [logo-url]
   (cond
     (nil? logo-url)
     nil
 
     (= logo-url "app/assets/img/logo.svg")
-    {:image-src  "http://static.metabase.com/email_logo.png"
+    {:image-src  (str (system/site-url) "/" (appearance/default-logo-path))
      :attachment nil}
 
     (str/starts-with? logo-url "data:")

--- a/src/metabase/notification/payload/core.clj
+++ b/src/metabase/notification/payload/core.clj
@@ -102,12 +102,12 @@
     [:notification/testing   :map]]])
 
 (defn- logo-url
-  "Return the URL for the application logo. If the logo is the default, return a URL to the Metabase logo.
+  "Return the URL for the application logo. If the logo is the default, return a URL to the logo served by this Metabase instance.
    For data URIs, returns the raw data URI - the email channel will convert it to an attachment."
   []
   (let [url (appearance/application-logo-url)]
     (if (= url "app/assets/img/logo.svg")
-      "http://static.metabase.com/email_logo.png"
+      (str (system/site-url) "/" (appearance/default-logo-path))
       url)))
 
 (defn- button-style


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/1953

### Description

Created a function to return svg logo if present or else png logo by default and used the function across code where required

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Make sure email provide is done in your metabase setup
2. Run and open the local port in which your metabase setup is running in browser
3. New > Question
4. Search and Select Orders table for Sample Data
5. In Summarize filter select `Count of rows` and Group By select `CreatedAt` then click Visualize
6. Click `Visualization` button at the bottom left column in the page select `Pivot Table` from the opened modal and then click `Done` button at the bottom
7. Click setting icon on side of `Visualization` button select `Conditional Formatting` from opened modal click `Add a rule` then select `Color range` and then click `Done` button at the bottom.
8. `Save` the question by clicking right top side icon and name it however you like or leave it default.
9. After saving click on three dot icon (`...` ) in the same place as save icon select `Create an alert` after the modal box is open click send and check in your configure email provider in your metabase setup.
10. Open the configured email provider and check the recent email using developer tool to check the logo url in the browser

### Demo

#### Before fix:
<img width="2900" height="1156" alt="image" src="https://github.com/user-attachments/assets/a89f246e-2cb2-4ee6-a3d1-a6b3b05edcb3" />

#### After fix:
<img width="3452" height="1300" alt="image" src="https://github.com/user-attachments/assets/08de9d12-a65a-4114-a6b9-5b869ab6a386" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
