### PR TITLE
Remove deprecated getCurrentUser selector

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveSyncStatus.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/google_drive/GdriveSyncStatus.tsx
@@ -3,11 +3,11 @@ import { usePrevious } from "react-use";
 import { match } from "ts-pattern";
 import { t } from "ttag";
 
-import { getCurrentUser } from "metabase/admin/datamodel/selectors";
 import { Api, skipToken } from "metabase/api";
 import { tag } from "metabase/api/tags";
 import { getErrorMessage } from "metabase/api/utils";
 import { useDispatch, useSelector } from "metabase/lib/redux";
+import { getUser } from "metabase/selectors/user";
 import StatusLarge from "metabase/status/components/StatusLarge";
 import { useGetGsheetsFolderQuery } from "metabase-enterprise/api";
 import { EnterpriseApi } from "metabase-enterprise/api/api";
@@ -28,7 +28,7 @@ export const GdriveSyncStatus = () => {
   const res = useGetGsheetsFolderQuery(!showGdrive ? skipToken : undefined);
   const { data: gdriveFolder, error: apiError } = res;
 
-  const currentUser = useSelector(getCurrentUser);
+  const currentUser = useSelector(getUser);
   const isCurrentUser = currentUser?.id === gdriveFolder?.created_by_id;
 
   const status = getStatus({ status: gdriveFolder?.status, error: apiError });

--- a/enterprise/frontend/src/metabase-enterprise/license/use-upsell-flow.ts
+++ b/enterprise/frontend/src/metabase-enterprise/license/use-upsell-flow.ts
@@ -1,10 +1,10 @@
 import { useEffect, useRef } from "react";
 import { t } from "ttag";
 
-import { getCurrentUser } from "metabase/admin/datamodel/selectors";
 import { useUpsellLink } from "metabase/admin/upsells/components/use-upsell-link";
 import { useSetting, useStoreUrl, useToast } from "metabase/common/hooks";
 import { useSelector } from "metabase/lib/redux";
+import { getUser } from "metabase/selectors/user";
 import { getIsHosted } from "metabase/setup/selectors";
 import { useLicense } from "metabase-enterprise/settings/hooks/use-license";
 
@@ -37,7 +37,7 @@ export function useUpsellFlow({
       sendMessageTokenActivation(true, storeWindowRef.current, storeOrigin);
     }
   });
-  const currentUser = useSelector(getCurrentUser);
+  const currentUser = useSelector(getUser);
   const siteName = useSetting("site-name");
 
   const upsellLink = useUpsellLink({

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationReviewBanner/ModerationReviewBanner.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationReviewBanner/ModerationReviewBanner.tsx
@@ -1,8 +1,8 @@
-import { getCurrentUser } from "metabase/admin/datamodel/selectors";
 import { skipToken, useGetUserQuery } from "metabase/api";
 import { alpha } from "metabase/lib/colors";
 import { useSelector } from "metabase/lib/redux";
 import { getRelativeTime } from "metabase/lib/time-dayjs";
+import { getUser } from "metabase/selectors/user";
 import { FixedSizeIcon, Flex, Icon, Text as UIText } from "metabase/ui";
 import {
   getIconForReview,
@@ -31,7 +31,7 @@ export const ModerationReviewBanner = ({
   className,
 }: ModerationReviewBannerProps) => {
   const { data: moderator } = useGetUserQuery(moderationReview.moderator_id);
-  const currentUser = useSelector(getCurrentUser);
+  const currentUser = useSelector(getUser);
 
   if (!moderator) {
     return null;
@@ -98,7 +98,7 @@ const ModerationReviewText = ({
   const { data: moderator } = useGetUserQuery(
     latestModerationReview?.moderator_id ?? skipToken,
   );
-  const currentUser = useSelector(getCurrentUser);
+  const currentUser = useSelector(getUser);
 
   if (!latestModerationReview) {
     return null;

--- a/frontend/src/metabase/admin/datamodel/containers/RevisionHistoryApp.tsx
+++ b/frontend/src/metabase/admin/datamodel/containers/RevisionHistoryApp.tsx
@@ -5,12 +5,13 @@ import { Segments } from "metabase/entities/segments";
 import { Tables } from "metabase/entities/tables";
 import { connect } from "metabase/lib/redux";
 import { checkNotNull } from "metabase/lib/types";
+import { getUser } from "metabase/selectors/user";
 import type { Revision, RevisionId, Segment, User } from "metabase-types/api";
 import type { State } from "metabase-types/store";
 
 import { RevisionHistory } from "../components/revisions/RevisionHistory";
 import { fetchSegmentRevisions } from "../datamodel";
-import { getCurrentUser, getRevisions } from "../selectors";
+import { getRevisions } from "../selectors";
 
 type RevisionHistoryAppOwnProps = {
   params: {
@@ -38,7 +39,7 @@ const mapStateToProps = (
 ): RevisionHistoryAppStateProps => ({
   id: props.params.id,
   revisions: getRevisions(state),
-  user: checkNotNull(getCurrentUser(state)),
+  user: checkNotNull(getUser(state)),
 });
 
 const mapDispatchToProps: RevisionHistoryAppDispatchProps = {

--- a/frontend/src/metabase/admin/datamodel/selectors.ts
+++ b/frontend/src/metabase/admin/datamodel/selectors.ts
@@ -1,10 +1,5 @@
-import type { Revision, User } from "metabase-types/api";
+import type { Revision } from "metabase-types/api";
 import type { State } from "metabase-types/store";
 
 export const getRevisions = (state: State): Revision[] | null =>
   state.admin.datamodel.revisions;
-
-/**
- * @deprecated Use getUser from metabase/selectors/user.ts
- */
-export const getCurrentUser = (state: State): User | null => state.currentUser;

--- a/frontend/src/metabase/admin/people/components/GroupMembersTable/GroupMembersTable.tsx
+++ b/frontend/src/metabase/admin/people/components/GroupMembersTable/GroupMembersTable.tsx
@@ -2,7 +2,6 @@ import { useMemo } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
-import { getCurrentUser } from "metabase/admin/datamodel/selectors";
 import { AdminContentTable } from "metabase/common/components/AdminContentTable";
 import { Link } from "metabase/common/components/Link";
 import { PaginationControls } from "metabase/common/components/PaginationControls";
@@ -11,6 +10,7 @@ import { isAdminGroup, isDefaultGroup } from "metabase/lib/groups";
 import { useSelector } from "metabase/lib/redux";
 import { getFullName } from "metabase/lib/user";
 import { PLUGIN_GROUP_MANAGERS, PLUGIN_TENANTS } from "metabase/plugins";
+import { getUser } from "metabase/selectors/user";
 import { Box, Flex, Icon, Text, Tooltip, UnstyledButton } from "metabase/ui";
 import type { Group, Member, Membership } from "metabase-types/api";
 
@@ -117,7 +117,7 @@ const UserMemberRow = ({
   onMembershipUpdate,
 }: UserRowProps) => {
   // you can't remove people from Default and you can't remove the last user from Admin
-  const currentUser = useSelector(getCurrentUser);
+  const currentUser = useSelector(getUser);
   const isCurrentUser = member.user_id === currentUser?.id;
   const canRemove =
     !isDefaultGroup(group) &&

--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionCaption.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionCaption.tsx
@@ -1,7 +1,6 @@
 import { useCallback } from "react";
 import { t } from "ttag";
 
-import { getCurrentUser } from "metabase/admin/datamodel/selectors";
 import {
   isEditableCollection,
   isInstanceAnalyticsCollection,
@@ -12,7 +11,7 @@ import {
   PLUGIN_COLLECTIONS,
   PLUGIN_COLLECTION_COMPONENTS,
 } from "metabase/plugins";
-import { getIsTenantUser } from "metabase/selectors/user";
+import { getIsTenantUser, getUser } from "metabase/selectors/user";
 import { Icon } from "metabase/ui";
 import type { Collection } from "metabase-types/api";
 
@@ -32,7 +31,7 @@ export const CollectionCaption = ({
   collection,
   onUpdateCollection,
 }: CollectionCaptionProps): JSX.Element => {
-  const currentUser = useSelector(getCurrentUser);
+  const currentUser = useSelector(getUser);
   const isEditable = isEditableCollection(collection, { currentUser });
   const hasDescription = Boolean(collection.description);
 

--- a/frontend/src/metabase/comments/components/Discussion/Discussion.tsx
+++ b/frontend/src/metabase/comments/components/Discussion/Discussion.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { t } from "ttag";
 
-import { getCurrentUser } from "metabase/admin/datamodel/selectors";
 import {
   useCreateCommentMutation,
   useDeleteCommentMutation,
@@ -12,6 +11,7 @@ import { getCommentsUrl } from "metabase/comments/utils";
 import { useToast } from "metabase/common/hooks";
 import { setHoveredChildTargetId } from "metabase/documents/documents.slice";
 import { useDispatch, useSelector } from "metabase/lib/redux";
+import { getUser } from "metabase/selectors/user";
 import { Avatar, Stack, Timeline, rem } from "metabase/ui";
 import type {
   Comment,
@@ -40,7 +40,7 @@ export const Discussion = ({
   targetType,
   enableHoverHighlight = false,
 }: DiscussionProps) => {
-  const currentUser = useSelector(getCurrentUser);
+  const currentUser = useSelector(getUser);
   const dispatch = useDispatch();
   const [, setNewComment] = useState<DocumentContent>();
   const parentCommentId = comments[0].id;

--- a/frontend/src/metabase/comments/components/Discussion/DiscussionComment.tsx
+++ b/frontend/src/metabase/comments/components/Discussion/DiscussionComment.tsx
@@ -4,9 +4,9 @@ import { useCallback } from "react";
 import { useLocation } from "react-use";
 import { t } from "ttag";
 
-import { getCurrentUser } from "metabase/admin/datamodel/selectors";
 import { formatCommentDate, getCommentNodeId } from "metabase/comments/utils";
 import { useSelector } from "metabase/lib/redux";
+import { getUser } from "metabase/selectors/user";
 import { Avatar, Box, Group, Icon, Text, Timeline, Tooltip } from "metabase/ui";
 import type { Comment, DocumentContent } from "metabase-types/api";
 
@@ -44,7 +44,7 @@ export function DiscussionComment({
   onEdit,
   onCopyLink,
 }: DiscussionCommentProps) {
-  const currentUser = useSelector(getCurrentUser);
+  const currentUser = useSelector(getUser);
   const [isEditing, editingHandler] = useDisclosure(false);
   const location = useLocation();
   const hash = location.hash?.substring(1);

--- a/frontend/src/metabase/comments/components/Discussion/Reaction.tsx
+++ b/frontend/src/metabase/comments/components/Discussion/Reaction.tsx
@@ -1,8 +1,8 @@
 import cx from "classnames";
 import { useCallback, useMemo } from "react";
 
-import { getCurrentUser } from "metabase/admin/datamodel/selectors";
 import { useSelector } from "metabase/lib/redux";
+import { getUser } from "metabase/selectors/user";
 import { Flex, Text, Tooltip } from "metabase/ui";
 import type { CommentReaction } from "metabase-types/api";
 
@@ -15,7 +15,7 @@ interface Props {
 }
 
 export function Reaction({ reaction, onReaction, onReactionRemove }: Props) {
-  const currentUser = useSelector(getCurrentUser);
+  const currentUser = useSelector(getUser);
   const isCurrentUserReaction = useMemo(
     () => reaction.users.some((user) => user.id === currentUser?.id),
     [reaction.users, currentUser],

--- a/frontend/src/metabase/common/components/ErrorPages/use-error-info.ts
+++ b/frontend/src/metabase/common/components/ErrorPages/use-error-info.ts
@@ -1,9 +1,8 @@
 import { useAsync } from "react-use";
 import { t } from "ttag";
 
-import { getCurrentUser } from "metabase/admin/datamodel/selectors";
 import { useSelector } from "metabase/lib/redux";
-import { getUserIsAdmin } from "metabase/selectors/user";
+import { getUser, getUserIsAdmin } from "metabase/selectors/user";
 import { MetabaseApi, UtilApi } from "metabase/services";
 
 import type { ErrorPayload, ReportableEntityName } from "./types";
@@ -24,7 +23,7 @@ const maybeSerializeError = (key: string, value: any) => {
 export const useErrorInfo = (
   { enabled }: { enabled?: boolean } = { enabled: true },
 ) => {
-  const currentUser = useSelector(getCurrentUser);
+  const currentUser = useSelector(getUser);
   const isAdmin = useSelector(getUserIsAdmin);
   const location = window.location.href;
 

--- a/frontend/src/metabase/common/components/SaveQuestionForm/context.tsx
+++ b/frontend/src/metabase/common/components/SaveQuestionForm/context.tsx
@@ -11,7 +11,6 @@ import {
 import { usePrevious } from "react-use";
 import { isEqual } from "underscore";
 
-import { getCurrentUser } from "metabase/admin/datamodel/selectors";
 import { useListRecentsQuery } from "metabase/api";
 import { useGetDefaultCollectionId } from "metabase/collections/hooks";
 import {
@@ -22,6 +21,7 @@ import {
 import { FormProvider } from "metabase/forms";
 import { useSelector } from "metabase/lib/redux";
 import { isNotNull } from "metabase/lib/types";
+import { getUser } from "metabase/selectors/user";
 import type Question from "metabase-lib/v1/Question";
 import type { CollectionId, DashboardId } from "metabase-types/api";
 
@@ -78,7 +78,7 @@ export const SaveQuestionProvider = ({
     originalQuestion?.collectionId(),
   );
 
-  const currentUser = useSelector(getCurrentUser);
+  const currentUser = useSelector(getUser);
 
   const targetCollection =
     userTargetCollection === "personal" && currentUser

--- a/frontend/src/metabase/common/hooks/use-locale/use-locale.ts
+++ b/frontend/src/metabase/common/hooks/use-locale/use-locale.ts
@@ -1,9 +1,9 @@
 import { useContext } from "react";
 
-import { getCurrentUser } from "metabase/admin/datamodel/selectors";
 import { useInstanceLocale } from "metabase/common/hooks/use-instance-locale";
 import { useSelector } from "metabase/lib/redux";
 import { FrontendLocaleContext } from "metabase/public/LocaleProvider";
+import { getUser } from "metabase/selectors/user";
 
 /** Get the user's locale or, if that has not been set, the instance locale
  *
@@ -16,7 +16,7 @@ import { FrontendLocaleContext } from "metabase/public/LocaleProvider";
 export const useLocale = () => {
   const instanceLocale = useInstanceLocale();
   const userLocale: string | undefined =
-    useSelector(getCurrentUser)?.locale || undefined;
+    useSelector(getUser)?.locale || undefined;
 
   // locale used in the sdk and in public/static from the #locale parameter
   const { locale: frontendLocale, isLocaleLoading } = useContext(

--- a/frontend/src/metabase/notifications/AddEditSidebar/AddEditEmailSidebar.tsx
+++ b/frontend/src/metabase/notifications/AddEditSidebar/AddEditEmailSidebar.tsx
@@ -3,7 +3,6 @@ import { useEffect } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
-import { getCurrentUser } from "metabase/admin/datamodel/selectors";
 import { DataPermissionValue } from "metabase/admin/permissions/types";
 import {
   type ScheduleChangeProp,
@@ -19,7 +18,7 @@ import { useSelector } from "metabase/lib/redux";
 import { EmailAttachmentPicker } from "metabase/notifications/EmailAttachmentPicker";
 import { RecipientPicker } from "metabase/notifications/channels/RecipientPicker";
 import { PLUGIN_DASHBOARD_SUBSCRIPTION_PARAMETERS_SECTION_OVERRIDE } from "metabase/plugins";
-import { canAccessSettings } from "metabase/selectors/user";
+import { canAccessSettings, getUser } from "metabase/selectors/user";
 import { Icon, Title } from "metabase/ui";
 import type { UiParameter } from "metabase-lib/v1/parameters/types";
 import type {
@@ -83,7 +82,7 @@ export const AddEditEmailSidebar = ({
 }: AddEditEmailSidebarProps) => {
   const isValid = dashboardPulseIsValid(pulse, formInput.channels);
   const userCanAccessSettings = useSelector(canAccessSettings);
-  const currentUser = useSelector(getCurrentUser);
+  const currentUser = useSelector(getUser);
 
   // Return true if the results of all cards can be downloaded
   const allowDownload = pulse.cards?.every(


### PR DESCRIPTION
It also handily means `shared/common` doesn't depend on `feature/admin`