### PR TITLE
Remove metadata re export from reference

### DIFF
--- a/frontend/src/metabase/browse/tables/TableBrowser/TableBrowser.jsx
+++ b/frontend/src/metabase/browse/tables/TableBrowser/TableBrowser.jsx
@@ -11,7 +11,7 @@ import { trackSimpleEvent } from "metabase/lib/analytics";
 import { useSelector } from "metabase/lib/redux";
 import { isSyncInProgress } from "metabase/lib/syncing";
 import { PLUGIN_TABLE_EDITING } from "metabase/plugins";
-import { getDatabases } from "metabase/reference/selectors";
+import { getShallowDatabases as getDatabases } from "metabase/selectors/metadata";
 import { getUserIsAdmin } from "metabase/selectors/user";
 import { ActionIcon, Group, Icon, Loader, Paper } from "metabase/ui";
 import { isVirtualCardId } from "metabase-lib/v1/metadata/utils/saved-questions";

--- a/frontend/src/metabase/reference/databases/DatabaseDetail.jsx
+++ b/frontend/src/metabase/reference/databases/DatabaseDetail.jsx
@@ -13,11 +13,11 @@ import Detail from "metabase/reference/components/Detail";
 import { EditHeader } from "metabase/reference/components/EditHeader";
 import EditableReferenceHeader from "metabase/reference/components/EditableReferenceHeader";
 import * as actions from "metabase/reference/reference";
+import { getShallowFields as getFields } from "metabase/selectors/metadata";
 
 import {
   getDatabase,
   getError,
-  getFields,
   getIsEditing,
   getIsFormulaExpanded,
   getLoading,

--- a/frontend/src/metabase/reference/databases/DatabaseList.jsx
+++ b/frontend/src/metabase/reference/databases/DatabaseList.jsx
@@ -12,9 +12,10 @@ import CS from "metabase/css/core/index.css";
 import { connect } from "metabase/lib/redux";
 import * as metadataActions from "metabase/redux/metadata";
 import { NoDatabasesEmptyState } from "metabase/reference/databases/NoDatabasesEmptyState";
+import { getShallowDatabases as getDatabases } from "metabase/selectors/metadata";
 
 import ReferenceHeader from "../components/ReferenceHeader";
-import { getDatabases, getError, getLoading } from "../selectors";
+import { getError, getLoading } from "../selectors";
 
 const mapStateToProps = (state, props) => ({
   entities: getDatabases(state, props),

--- a/frontend/src/metabase/reference/databases/TableDetail.jsx
+++ b/frontend/src/metabase/reference/databases/TableDetail.jsx
@@ -15,11 +15,13 @@ import { EditHeader } from "metabase/reference/components/EditHeader";
 import EditableReferenceHeader from "metabase/reference/components/EditableReferenceHeader";
 import UsefulQuestions from "metabase/reference/components/UsefulQuestions";
 import * as actions from "metabase/reference/reference";
-import { getMetadata } from "metabase/selectors/metadata";
+import {
+  getShallowFields as getFields,
+  getMetadata,
+} from "metabase/selectors/metadata";
 
 import {
   getError,
-  getFields,
   getHasSingleSchema,
   getIsEditing,
   getIsFormulaExpanded,

--- a/frontend/src/metabase/reference/segments/SegmentDetail.jsx
+++ b/frontend/src/metabase/reference/segments/SegmentDetail.jsx
@@ -16,12 +16,14 @@ import EditableReferenceHeader from "metabase/reference/components/EditableRefer
 import { Formula } from "metabase/reference/components/Formula";
 import UsefulQuestions from "metabase/reference/components/UsefulQuestions";
 import * as actions from "metabase/reference/reference";
-import { getMetadata } from "metabase/selectors/metadata";
+import {
+  getShallowFields as getFields,
+  getMetadata,
+} from "metabase/selectors/metadata";
 
 import S from "../components/Detail.module.css";
 import {
   getError,
-  getFields,
   getIsEditing,
   getIsFormulaExpanded,
   getLoading,

--- a/frontend/src/metabase/reference/segments/SegmentList/SegmentList.tsx
+++ b/frontend/src/metabase/reference/segments/SegmentList/SegmentList.tsx
@@ -9,11 +9,12 @@ import { ListItem } from "metabase/common/components/ListItem";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import CS from "metabase/css/core/index.css";
 import { useSelector } from "metabase/lib/redux";
+import { getShallowSegments } from "metabase/selectors/metadata";
 import { getDocsUrl } from "metabase/selectors/settings";
 import { getShowMetabaseLinks } from "metabase/selectors/whitelabel";
 
 import ReferenceHeader from "../../components/ReferenceHeader";
-import { getError, getLoading, getSegments } from "../../selectors";
+import { getError, getLoading } from "../../selectors";
 
 const emptyStateData = {
   get title() {
@@ -36,7 +37,7 @@ interface SegmentListProps {
 }
 
 export function SegmentList({ style }: SegmentListProps) {
-  const entities = useSelector(getSegments);
+  const entities = useSelector(getShallowSegments);
   const loading = useSelector(getLoading);
   const loadingError = useSelector(getError);
   const adminLink = useSelector((state) =>

--- a/frontend/src/metabase/reference/segments/SegmentRevisions.jsx
+++ b/frontend/src/metabase/reference/segments/SegmentRevisions.jsx
@@ -12,6 +12,7 @@ import CS from "metabase/css/core/index.css";
 import { assignUserColors } from "metabase/lib/formatting";
 import { connect } from "metabase/lib/redux";
 import * as metadataActions from "metabase/redux/metadata";
+import { getShallowTables as getTables } from "metabase/selectors/metadata";
 
 import ReferenceHeader from "../components/ReferenceHeader";
 import {
@@ -19,7 +20,6 @@ import {
   getLoading,
   getSegment,
   getSegmentRevisions,
-  getTables,
   getUser,
 } from "../selectors";
 

--- a/frontend/src/metabase/reference/selectors.js
+++ b/frontend/src/metabase/reference/selectors.js
@@ -12,15 +12,6 @@ import {
 
 import { idsToObjectMap } from "./utils";
 
-// import { getDatabases, getTables, getFields, getSegments } from "metabase/selectors/metadata";
-
-export {
-  getShallowDatabases as getDatabases,
-  getShallowTables as getTables,
-  getShallowFields as getFields,
-  getShallowSegments as getSegments,
-} from "metabase/selectors/metadata";
-
 export const getUser = (state, props) => state.currentUser;
 
 export const getSegmentId = (state, props) =>


### PR DESCRIPTION
The `reference` feature was re-exporting selectors from `metadata` and these were being used by other features, causing them to depend on `reference`