### PR TITLE
Stop using 2am in tests to avoid DST issues

### DIFF
--- a/e2e/test/scenarios/binning/correctness/shared/constants.js
+++ b/e2e/test/scenarios/binning/correctness/shared/constants.js
@@ -38,7 +38,7 @@ export const TIME_OPTIONS = {
   },
   "Hour of day": {
     selected: "by hour of day",
-    representativeValues: ["12:00 AM", "2:00 AM", "12:00 PM", "8:00 PM"],
+    representativeValues: ["12:00 AM", "3:00 AM", "12:00 PM", "8:00 PM"],
     isHiddenByDefault: true,
   },
   "Day of week": {

--- a/e2e/test/scenarios/binning/correctness/time-series.cy.spec.js
+++ b/e2e/test/scenarios/binning/correctness/time-series.cy.spec.js
@@ -78,7 +78,7 @@ function assertOnHeaderCells(bucketSize) {
 
 function assertOnTableValues(values) {
   values.map((v) => {
-    cy.findByText(v).scrollIntoView();
+    cy.get("[data-testid=cell-data]").contains(v).scrollIntoView();
   });
 }
 

--- a/e2e/test/scenarios/onboarding/notifications.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/notifications.cy.spec.js
@@ -167,7 +167,7 @@ describe("scenarios > account > notifications", () => {
           H.createQuestionAlert({
             admin_id,
             card_id,
-            cron_schedule: "0 0 2 * * ?",
+            cron_schedule: "0 0 3 * * ?",
             handlers: [
               {
                 channel_type: "channel/email",
@@ -187,11 +187,11 @@ describe("scenarios > account > notifications", () => {
       openUserNotifications();
 
       cy.findByTestId("notifications-list").within(() => {
-        cy.findByText("Check daily at 2:00 AM").should("exist");
+        cy.findByText("Check daily at 3:00 AM").should("exist");
 
         const notificationCard = () =>
           cy
-            .findByText("Check daily at 2:00 AM")
+            .findByText("Check daily at 3:00 AM")
             .closest("[data-testid=notification-alert-item]")
             .should("exist");
 


### PR DESCRIPTION
2am doesn't exist when the clocks change, which breaks a couple of our tests