### PR TITLE
Use array-format source-table-entry schema in BE

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/transforms_python/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms_python/api.clj
@@ -9,6 +9,7 @@
    [metabase.api.routes.common :refer [+auth]]
    [metabase.api.util.handlers :as handlers]
    [metabase.permissions.core :as perms]
+   [metabase.transforms-base.util :as transforms-base.u]
    [metabase.util.i18n :as i18n]
    [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2]))
@@ -63,10 +64,10 @@
            per_input_row_limit 100}}
    :- [:map
        [:code                                 :string]
-       [:source_tables                        [:map-of {:min 1} :string :int]]
+       [:source_tables                        [:sequential {:min 1} ::transforms-base.u/source-table-entry]]
        [:output_row_limit    {:optional true} [:and :int [:> 1] [:<= 100]]]
        [:per_input_row_limit {:optional true} [:and :int [:> 1] [:<= 100]]]]]
-  (let [db-ids (t2/select-fn-set :db_id [:model/Table :db_id] :id [:in (vals source_tables)])]
+  (let [db-ids (t2/select-fn-set :db_id [:model/Table :db_id] :id [:in (map :table_id source_tables)])]
     (api/check-400 (= (count db-ids) 1) (i18n/deferred-tru "All source tables must belong to the same database."))
     (api/check-403 (perms/has-db-transforms-permission? api/*current-user-id* (first db-ids))))
   ;; NOTE: we do not test database support, as there is no write target.

--- a/enterprise/backend/src/metabase_enterprise/transforms_python/base.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms_python/base.clj
@@ -234,7 +234,7 @@
              {:server-url     server-url
               :code           (:body source)
               :run-id         run-id
-              :table-name->id resolved-source-tables
+              :source-tables  resolved-source-tables
               :shared-storage @shared-storage-ref})
 
             output-manifest (python-runner/read-output-manifest @shared-storage-ref)

--- a/enterprise/backend/src/metabase_enterprise/transforms_python/python_runner.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms_python/python_runner.clj
@@ -200,12 +200,16 @@
 (defn execute-python-code-http-call!
   "Calls the /execute endpoint of the python runner. Blocks until the run either succeeds or fails and returns
   the response from the server."
-  [{:keys [server-url code request-id run-id table-name->id shared-storage timeout-secs]}]
+  [{:keys [server-url code request-id run-id source-tables shared-storage timeout-secs]}]
   (let [{:keys [objects]} shared-storage
         {:keys [output output-manifest events]} objects
         url-for-path             (fn [path] (:url (get objects path)))
-        table-name->url          (update-vals table-name->id #(url-for-path [:table % :data]))
-        table-name->manifest-url (update-vals table-name->id #(url-for-path [:table % :manifest]))
+        table-name->url          (into {} (map (fn [{:keys [alias table_id]}]
+                                                 [alias (url-for-path [:table table_id :data])]))
+                                       source-tables)
+        table-name->manifest-url (into {} (map (fn [{:keys [alias table_id]}]
+                                                 [alias (url-for-path [:table table_id :manifest])]))
+                                       source-tables)
         payload                  {:code                code
                                   :library             (t2/select-fn->fn :path :source :model/PythonLibrary)
                                   :timeout             (or timeout-secs (transforms-python.settings/python-runner-timeout-seconds))
@@ -293,21 +297,19 @@
   (when (and (:source-incremental-strategy source)
              (> (count (:source-tables source)) 1))
     (throw (ex-info "Incremental transforms for python only supports one source table" {})))
-  (doseq [[table-name v] (:source-tables source)
-          ;; TODO (Chris 2026-03-03) We should also handle the case where table-id has not been backfilled yet...
-          :let [table-id                                (if (int? v) v (:table_id v))
-                {:keys [s3-client bucket-name objects]} shared-storage
-                {data-path :path}                       (get objects [:table table-id :data])
-                {manifest-path :path}                   (get objects [:table table-id :manifest])]]
+  (doseq [{:keys [alias table_id]} (:source-tables source)
+          :let [{:keys [s3-client bucket-name objects]} shared-storage
+                {data-path :path}                       (get objects [:table table_id :data])
+                {manifest-path :path}                   (get objects [:table table_id :manifest])]]
     (let [tmp-data-file (File/createTempFile data-path "")
           tmp-meta-file (File/createTempFile manifest-path "")]
       (try
-        (let [db-id       (t2/select-one-fn :db_id (t2/table-name :model/Table) :id table-id)
+        (let [db-id       (t2/select-one-fn :db_id (t2/table-name :model/Table) :id table_id)
               driver      (t2/select-one-fn :engine :model/Database db-id)
-              fields-meta (fields-metadata driver table-id)
-              manifest    (generate-manifest table-id fields-meta)]
+              fields-meta (fields-metadata driver table_id)
+              manifest    (generate-manifest table_id fields-meta)]
           (transforms.instrumentation/with-stage-timing [run-id [:export :dwh-to-file]]
-            (let [query (build-table-query table-id (:source-incremental-strategy source) transform-id limit)]
+            (let [query (build-table-query table_id (:source-incremental-strategy source) transform-id limit)]
               (write-query-data-to-file!
                {:query       query
                 :fields-meta fields-meta
@@ -325,10 +327,10 @@
         (catch InterruptedException ie (throw ie))
         (catch Throwable t
           (throw (ex-info "An error occurred while copying table data to S3"
-                          {:table-id table-id
+                          {:table-id table_id
                            :transform-message (or (:transform-message (ex-data t))
                                                   ;; Cast table-id to string manually, to avoid thousands separators.
-                                                  (i18n/tru "Failed to copy table contents to shared storage: {0} ({1})" table-name (str table-id)))}
+                                                  (i18n/tru "Failed to copy table contents to shared storage: {0} ({1})" alias (str table_id)))}
                           t)))
         (finally
           (safe-delete tmp-data-file)
@@ -340,7 +342,7 @@
 
    Args:
      :code          - Python code to execute
-     :source-tables - Map of table-name -> table-id (already resolved)
+     :source-tables - Sequential of source-table entries [{:alias ... :table_id ...} ...]
      :row-limit     - Max rows to return (also limits input rows)
      :timeout-secs  - Optional timeout override
 
@@ -362,7 +364,7 @@
            {:server-url     server-url
             :code           code
             :request-id     (u/generate-nano-id)
-            :table-name->id source-tables
+            :source-tables  source-tables
             :timeout-secs   timeout-secs
             :shared-storage @shared-storage-ref})
           events (read-events @shared-storage-ref)]

--- a/enterprise/backend/src/metabase_enterprise/transforms_python/s3.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms_python/s3.clj
@@ -123,7 +123,7 @@
                     (.build))]
     (.toString (.url (.presignPutObject presigner request)))))
 
-(defn- s3-shared-storage [table-name->id]
+(defn- s3-shared-storage [source-tables]
   (let [work-dir-name       (working-dir-for-run)
         container-presigner (create-s3-presigner-for-container)
         bucket-name         (transforms-python.settings/python-storage-s-3-bucket)
@@ -142,9 +142,9 @@
       {:output          (ref :put "output.csv")
        :output-manifest (ref :put "output-manifest.json")
        :events          (ref :put "events.jsonl")}
-      (for [[table-name id] table-name->id]
-        {[:table id :manifest] (ref :get (str "table-" (name table-name) "-" id ".manifest.json"))
-         [:table id :data]     (ref :get (str "table-" (name table-name) "-" id ".jsonl"))}))}))
+      (for [{:keys [alias table_id]} source-tables]
+        {[:table table_id :manifest] (ref :get (str "table-" alias "-" table_id ".manifest.json"))
+         [:table table_id :data]     (ref :get (str "table-" alias "-" table_id ".jsonl"))}))}))
 
 (declare delete-many)
 
@@ -172,8 +172,8 @@
 
   When the value is closed, all the relevant keys will be deleted, but this is best-effort only.
   We rely on the bucket retention policy to ensure any stragglers are eventually deleted."
-  ^Closeable [table-name->id]
-  (let [shared-storage (s3-shared-storage table-name->id)]
+  ^Closeable [source-tables]
+  (let [shared-storage (s3-shared-storage source-tables)]
     (reify IDeref
       (deref [_] shared-storage)
       Closeable

--- a/enterprise/backend/src/metabase_enterprise/workspaces/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/api.clj
@@ -80,12 +80,7 @@
    [:python
     [:map {:closed true}
      [:source-database {:optional true} :int]
-     ;; TODO (Ngoc 2026-03-04) -- remove decode/normalize when FE sends array format for source-tables
-     [:source-tables   [:sequential {:decode/normalize (fn [st]
-                                                         (if (map? st)
-                                                           (transforms-base.u/source-tables-map->vec st)
-                                                           st))}
-                        [:map [:alias [:string {:min 1}]] [:table_id :int]]]]
+     [:source-tables   [:sequential ::transforms-base.u/source-table-entry]]
      [:type [:= "python"]]
      [:body :string]]]])
 
@@ -835,9 +830,7 @@
           transform (ws.common/add-to-changeset! api/*current-user-id* workspace :transform global-id body
                                                  :ref-id ref-id)]
       (-> (select-malli-keys WorkspaceTransform workspace-transform-alias transform)
-          attach-isolated-target
-          ;; TODO (Ngoc 2026-03-04) -- remove when FE sends/expects array format for source-tables
-          transforms/source-tables-vec->map-for-fe))))
+          attach-isolated-target))))
 
 (api.macros/defendpoint :post "/:ws-id/transform"
   :- WorkspaceTransform
@@ -885,9 +878,7 @@
   (-> (select-model-malli-keys :model/WorkspaceTransform WorkspaceTransform workspace-transform-alias)
       (t2/select-one :workspace_id ws-id :ref_id tx-id)
       api/check-404
-      attach-isolated-target
-      ;; TODO (Ngoc 2026-03-04) -- remove when FE sends/expects array format for source-tables
-      transforms/source-tables-vec->map-for-fe))
+      attach-isolated-target))
 
 (api.macros/defendpoint :get "/:ws-id/transform/:tx-id" :- WorkspaceTransform
   "Get a specific transform in a workspace."

--- a/enterprise/backend/test/metabase_enterprise/dependencies/calculation_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/calculation_test.clj
@@ -6,6 +6,7 @@
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.test-util.notebook-helpers :as lib.tu.notebook]
    [metabase.test :as mt]
+   [metabase.transforms.test-util :as transforms.tu]
    [toucan2.core :as t2]))
 
 (deftest ^:parallel upstream-deps-card-test
@@ -199,9 +200,8 @@
           orders-id (mt/id :orders)]
       (mt/with-temp [:model/Transform transform {:name "Test Transform"
                                                  :source {:type :python
-                                                          :source-tables [{:alias "PRODUCTS" :table_id products-id}
-                                                                          {:alias "ORDERS" :table_id orders-id}]
-                                                          ;; A problematic field, hopefully removed again.
+                                                          :source-tables [(transforms.tu/source-table-entry "PRODUCTS" products-id)
+                                                                          (transforms.tu/source-table-entry "ORDERS" orders-id)]
                                                           :source-database (mt/id)
                                                           :body "..."}
                                                  :target {:schema "PUBLIC"

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/api_test.clj
@@ -19,7 +19,6 @@
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.test :as mt]
-   [metabase.transforms.crud :as transforms.crud]
    [metabase.util :as u]
    [metabase.util.malli.registry :as mr]
    [toucan2.core :as t2]))
@@ -1303,9 +1302,7 @@
         (testing "With superuser permissions"
           (is (=? {:structured_output [(mt/obj->json->obj (select-keys t1 [:id :entity_id :name :description :source]))
                                          ;; note: t2 not included because it's a (non-native) MBQL query
-                                       ;; API converts source-tables from vec back to map for FE
-                                       (mt/obj->json->obj (transforms.crud/source-tables-vec->map-for-fe
-                                                           (select-keys t3 [:id :entity_id :name :description :source])))]
+                                       (mt/obj->json->obj (select-keys t3 [:id :entity_id :name :description :source]))]
                    :conversation_id conversation-id}
                   (-> (mt/user-http-request :rasta :post 200 "ee/metabot-tools/get-transforms"
                                             {:request-options {:headers {"x-metabase-session" crowberto-ai-token}}}
@@ -1350,9 +1347,7 @@
         (testing "With superuser permissions"
           (doseq [transform [t1 t2]]
             (testing (:name transform)
-              ;; API converts source-tables from vec back to map for FE
-              (is (=? {:structured_output (mt/obj->json->obj (transforms.crud/source-tables-vec->map-for-fe
-                                                              (select-keys transform [:id :entity_id :name :description :source :target])))
+              (is (=? {:structured_output (mt/obj->json->obj (select-keys transform [:id :entity_id :name :description :source :target]))
                        :conversation_id conversation-id}
                       (mt/user-http-request :rasta :post 200 "ee/metabot-tools/get-transform-details"
                                             {:request-options {:headers {"x-metabase-session" crowberto-ai-token}}}

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/dependencies_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/tools/dependencies_test.clj
@@ -7,6 +7,7 @@
    [metabase.permissions.models.permissions :as perms]
    [metabase.permissions.models.permissions-group :as perms-group]
    [metabase.test :as mt]
+   [metabase.transforms.test-util :as transforms.tu]
    [metabase.util :as u]
    [toucan2.core :as t2]))
 
@@ -251,13 +252,13 @@
                         :source {:type "python"
                                  :body "print('hello')"
                                  :source-database (mt/id)
-                                 :source-tables [{:alias "test" :table_id (t2/select-one-pk :model/Table :db_id (mt/id))}]}
+                                 :source-tables [(transforms.tu/source-table-entry "test" (t2/select-one-pk :model/Table :db_id (mt/id)))]}
                         :target {:type "table"
                                  :schema "public"
                                  :name "python_transform_table"}}]
           (let [modified-source {:type "python"
                                  :body "print('modified')"
-                                 :source-tables [{:alias "test" :table_id (t2/select-one-pk :model/Table :db_id (mt/id))}]}
+                                 :source-tables [(transforms.tu/source-table-entry "test" (t2/select-one-pk :model/Table :db_id (mt/id)))]}
                 result (metabot.dependencies/check-transform-dependencies
                         {:id python-transform-id
                          :source modified-source})]

--- a/enterprise/backend/test/metabase_enterprise/transforms/incremental_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/incremental_test.clj
@@ -153,7 +153,7 @@
                       :source-incremental-strategy {:type "checkpoint"
                                                     :checkpoint-filter-unique-key lib-column-key}}
                :python {:type "python"
-                        :source-tables [{:alias "transforms_products" :table_id (mt/id :transforms_products)}]
+                        :source-tables [(transforms.tu/source-table-entry "transforms_products" (mt/id :transforms_products))]
                         :limit 10
                         :body incremental-python-body
                         :source-incremental-strategy {:type "checkpoint"

--- a/enterprise/backend/test/metabase_enterprise/transforms/ordering_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/ordering_test.clj
@@ -4,6 +4,7 @@
    [metabase.test :as mt]
    [metabase.transforms-base.interface :as transforms-base.i]
    [metabase.transforms-base.ordering :as ordering]
+   [metabase.transforms.test-util :as transforms.tu]
    [toucan2.core :as t2]))
 
 (defn- make-python-transform
@@ -25,7 +26,7 @@
   (testing "Python transform with name-based source table ref resolves to producing transform"
     (mt/with-temp [;; Transform A produces table "intermediate_output"
                    :model/Transform {t-a :id} (make-python-transform
-                                               [{:alias "input" :table_id (mt/id :orders)}]
+                                               [(transforms.tu/source-table-entry "input" (mt/id :orders))]
                                                "intermediate_output")
                    ;; Transform B references intermediate_output by name (table doesn't exist yet)
                    :model/Transform {t-b :id} (make-python-transform
@@ -48,10 +49,10 @@
 (deftest python-transform-mixed-source-tables-test
   (testing "Python transform with mixed int and name-based refs"
     (mt/with-temp [:model/Transform {t-a :id} (make-python-transform
-                                               [{:alias "input" :table_id (mt/id :orders)}]
+                                               [(transforms.tu/source-table-entry "input" (mt/id :orders))]
                                                "output_a")
                    :model/Transform {t-b :id} (make-python-transform
-                                               [{:alias "existing" :table_id (mt/id :products)}
+                                               [(transforms.tu/source-table-entry "existing" (mt/id :products))
                                                 {:alias "from_transform"
                                                  :database_id (mt/id)
                                                  :schema "public"

--- a/enterprise/backend/test/metabase_enterprise/transforms_python/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms_python/api_test.clj
@@ -7,6 +7,7 @@
    [metabase.permissions.models.permissions-group :as perms-group]
    [metabase.test :as mt]
    [metabase.transforms.test-dataset :as transforms-dataset]
+   [metabase.transforms.test-util :as transforms.tu]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
@@ -97,8 +98,8 @@
                    "  print(\"out2\")"
                    "  print(\"err2\", file=sys.stderr)"
                    "  return pd.DataFrame({'x': [42, 43]})"]
-          table   (t2/select-one [:model/Table :id :db_id :schema] :db_id (mt/id))
-          body    {:source_tables [{:alias "test" :table_id (:id table) :database_id (:db_id table) :schema (:schema table)}]
+          table-id (t2/select-one-pk :model/Table :db_id (mt/id))
+          body    {:source_tables [(transforms.tu/source-table-entry "test" table-id)]
                    :code (str/join "\n" program)}
           {:keys [error logs output]} (mt/user-http-request :crowberto :post 200 "ee/transforms-python/test-run" body)]
       (is (nil? error))
@@ -110,8 +111,7 @@
                            user          :crowberto
                            features      #{:transforms :transforms-python}}}]
   (let [source-tables (or source-tables
-                          (let [table (t2/select-one [:model/Table :id :db_id :schema] :db_id (mt/id) :active true)]
-                            [{:alias "test" :table_id (:id table) :database_id (:db_id table) :schema (:schema table)}]))
+                          [(transforms.tu/source-table-entry "test" (t2/select-one-pk :model/Table :db_id (mt/id) :active true))])
         body (merge {:source_tables source-tables, :code (str/join "\n" program)} extra-opts)]
     (mt/with-premium-features features
       (mt/user-http-request-full-response user :post "ee/transforms-python/test-run" body))))
@@ -120,7 +120,7 @@
   (mt/test-drivers (mt/normal-drivers-with-feature :transforms/python)
     (mt/dataset transforms-dataset/transforms-test
       (let [program       ["def transform(customers):" "  return customers"]
-            source-tables [{:alias "customers" :table_id (mt/id :transforms_customers) :database_id (mt/id) :schema (:schema (t2/select-one [:model/Table :schema] (mt/id :transforms_customers)))}]
+            source-tables [(transforms.tu/source-table-entry "customers" (mt/id :transforms_customers))]
             {:keys [status body]} (test-run :program program :source-tables source-tables)]
         (is (= 200 status))
         (is (nil? (:error body)))
@@ -130,7 +130,7 @@
   (mt/test-drivers (mt/normal-drivers-with-feature :transforms/python)
     (mt/dataset transforms-dataset/transforms-test
       (let [program       ["import pandas as pd" "def transform(customers):" "  return pd.DataFrame()"]
-            source-tables [{:alias "customers" :table_id (mt/id :transforms_customers) :database_id (mt/id) :schema (:schema (t2/select-one [:model/Table :schema] (mt/id :transforms_customers)))}]
+            source-tables [(transforms.tu/source-table-entry "customers" (mt/id :transforms_customers))]
             {:keys [status body]} (test-run :program program :source-tables source-tables)]
         (is (= 200 status))
         (is (nil? (:error body)))
@@ -165,7 +165,7 @@
       (is (=? {:status 400} (test-run :extra-opts {:per_input_row_limit 0}))))
     (testing "truncates sources"
       (let [program       ["def transform(customers):" "  return customers"]
-            source-tables [{:alias "customers" :table_id (mt/id :transforms_customers) :database_id (mt/id) :schema (:schema (t2/select-one [:model/Table :schema] (mt/id :transforms_customers)))}]
+            source-tables [(transforms.tu/source-table-entry "customers" (mt/id :transforms_customers))]
             response      (test-run :program program :source-tables source-tables :extra-opts {:per_input_row_limit 2})]
         (is (=? {:body {:output {:rows #(= 2 (count %))}}} response))))))
 

--- a/enterprise/backend/test/metabase_enterprise/transforms_python/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms_python/api_test.clj
@@ -97,7 +97,9 @@
                    "  print(\"out2\")"
                    "  print(\"err2\", file=sys.stderr)"
                    "  return pd.DataFrame({'x': [42, 43]})"]
-          body    {:source_tables {:test (t2/select-one-pk :model/Table :db_id (mt/id))}, :code (str/join "\n" program)}
+          table   (t2/select-one [:model/Table :id :db_id :schema] :db_id (mt/id))
+          body    {:source_tables [{:alias "test" :table_id (:id table) :database_id (:db_id table) :schema (:schema table)}]
+                   :code (str/join "\n" program)}
           {:keys [error logs output]} (mt/user-http-request :crowberto :post 200 "ee/transforms-python/test-run" body)]
       (is (nil? error))
       (is (str/includes? logs "out1\nerr1\nout2\nerr2"))
@@ -106,9 +108,11 @@
 (defn- test-run [& {:keys [program user features source-tables extra-opts]
                     :or   {program       ["import pandas as pd" "def transform():" "  return pd.DataFrame()"]
                            user          :crowberto
-                           source-tables {:test (t2/select-one-pk :model/Table :db_id (mt/id) :active true)}
                            features      #{:transforms :transforms-python}}}]
-  (let [body (merge {:source_tables source-tables, :code (str/join "\n" program)} extra-opts)]
+  (let [source-tables (or source-tables
+                          (let [table (t2/select-one [:model/Table :id :db_id :schema] :db_id (mt/id) :active true)]
+                            [{:alias "test" :table_id (:id table) :database_id (:db_id table) :schema (:schema table)}]))
+        body (merge {:source_tables source-tables, :code (str/join "\n" program)} extra-opts)]
     (mt/with-premium-features features
       (mt/user-http-request-full-response user :post "ee/transforms-python/test-run" body))))
 
@@ -116,7 +120,7 @@
   (mt/test-drivers (mt/normal-drivers-with-feature :transforms/python)
     (mt/dataset transforms-dataset/transforms-test
       (let [program       ["def transform(customers):" "  return customers"]
-            source-tables {"customers" (mt/id :transforms_customers)}
+            source-tables [{:alias "customers" :table_id (mt/id :transforms_customers) :database_id (mt/id) :schema (:schema (t2/select-one [:model/Table :schema] (mt/id :transforms_customers)))}]
             {:keys [status body]} (test-run :program program :source-tables source-tables)]
         (is (= 200 status))
         (is (nil? (:error body)))
@@ -126,7 +130,7 @@
   (mt/test-drivers (mt/normal-drivers-with-feature :transforms/python)
     (mt/dataset transforms-dataset/transforms-test
       (let [program       ["import pandas as pd" "def transform(customers):" "  return pd.DataFrame()"]
-            source-tables {"customers" (mt/id :transforms_customers)}
+            source-tables [{:alias "customers" :table_id (mt/id :transforms_customers) :database_id (mt/id) :schema (:schema (t2/select-one [:model/Table :schema] (mt/id :transforms_customers)))}]
             {:keys [status body]} (test-run :program program :source-tables source-tables)]
         (is (= 200 status))
         (is (nil? (:error body)))
@@ -161,7 +165,7 @@
       (is (=? {:status 400} (test-run :extra-opts {:per_input_row_limit 0}))))
     (testing "truncates sources"
       (let [program       ["def transform(customers):" "  return customers"]
-            source-tables {"customers" (mt/id :transforms_customers)}
+            source-tables [{:alias "customers" :table_id (mt/id :transforms_customers) :database_id (mt/id) :schema (:schema (t2/select-one [:model/Table :schema] (mt/id :transforms_customers)))}]
             response      (test-run :program program :source-tables source-tables :extra-opts {:per_input_row_limit 2})]
         (is (=? {:body {:output {:rows #(= 2 (count %))}}} response))))))
 

--- a/enterprise/backend/test/metabase_enterprise/transforms_python/drivers_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms_python/drivers_test.clj
@@ -457,9 +457,9 @@
                                           "    # Return processed dataframe\n"
                                           "    return df")
 
-                      source-tables (cond-> [{:alias source-table-name :table_id source-table-id}]
+                      source-tables (cond-> [(transforms.tu/source-table-entry source-table-name source-table-id)]
                                       exotic-table-id
-                                      (conj {:alias (str source-table-name "_exotic") :table_id exotic-table-id}))
+                                      (conj (transforms.tu/source-table-entry (str source-table-name "_exotic") exotic-table-id)))
 
                       result (execute-e2e-transform! table-name transform-code source-tables)
                       {:keys [columns] result-rows :rows} result

--- a/enterprise/backend/test/metabase_enterprise/transforms_python/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms_python/e2e_test.clj
@@ -71,7 +71,7 @@
               (let [original           {:name   "Gadget Products"
                                         :source {:type  "python"
                                                  :source-database (mt/id)
-                                                 :source-tables [{:alias "transforms_customers" :table_id (mt/id :transforms_customers)}]
+                                                 :source-tables [(transforms.tu/source-table-entry "transforms_customers" (mt/id :transforms_customers))]
                                                  :body  (str "import pandas as pd\n"
                                                              "\n"
                                                              "def transform():\n"

--- a/enterprise/backend/test/metabase_enterprise/transforms_python/job_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms_python/job_test.clj
@@ -29,7 +29,7 @@
                  :model/Transform    {transform-id :id} {:name   "Gadget Products"
                                                          :source {:type  "python"
                                                                   :source-database (mt/id)
-                                                                  :source-tables [{:alias "transforms_customers" :table_id (mt/id :transforms_customers)}]
+                                                                  :source-tables [(transforms.tu/source-table-entry "transforms_customers" (mt/id :transforms_customers))]
                                                                   :body  (str "import pandas as pd\n"
                                                                               "\n"
                                                                               "def transform():\n"

--- a/enterprise/backend/test/metabase_enterprise/transforms_python/ordering_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms_python/ordering_test.clj
@@ -37,8 +37,8 @@
 
 (deftest python-transform-basic-dependencies-test
   (testing "Python transforms with source-tables dependencies are extracted correctly"
-    (mt/with-temp [:model/Transform {t1 :id} (make-python-transform [{:alias "orders"   :table_id (mt/id :orders)}
-                                                                     {:alias "products" :table_id (mt/id :products)}])]
+    (mt/with-temp [:model/Transform {t1 :id} (make-python-transform [(transforms.tu/source-table-entry "orders" (mt/id :orders))
+                                                                     (transforms.tu/source-table-entry "products" (mt/id :products))])]
       (is (= #{{:table (mt/id :orders)}
                {:table (mt/id :products)}}
              (transform-deps-for-db (t2/select-one :model/Transform :id t1)))))))
@@ -51,8 +51,8 @@
                                                   :name   "output_1"}
                        :model/Field _ {:table_id table1
                                        :name     "foo"}
-                       :model/Transform {t1 :id} (make-python-transform [{:alias "orders" :table_id (mt/id :orders)}] "output_1")
-                       :model/Transform {t2 :id} (make-python-transform [{:alias "output_1" :table_id table1}] "output_2")]
+                       :model/Transform {t1 :id} (make-python-transform [(transforms.tu/source-table-entry "orders" (mt/id :orders))] "output_1")
+                       :model/Transform {t2 :id} (make-python-transform [(transforms.tu/source-table-entry "output_1" table1)] "output_2")]
           (is (= {t1 #{}
                   t2 #{t1}}
                  (ordering/transform-ordering (t2/select :model/Transform :id [:in [t1 t2]])))))))))
@@ -69,10 +69,10 @@
                                                   :name "output_2"}
                        :model/Field _ {:table_id table2
                                        :name "bar"}
-                       :model/Transform {t1 :id} (make-python-transform [{:alias "orders" :table_id (mt/id :orders)}] "output_1")
-                       :model/Transform {t2 :id} (make-python-transform [{:alias "products" :table_id (mt/id :products)}] "output_2")
-                       :model/Transform {t3 :id} (make-python-transform [{:alias "output_1" :table_id table1}
-                                                                         {:alias "output_2" :table_id table2}] "final_output")]
+                       :model/Transform {t1 :id} (make-python-transform [(transforms.tu/source-table-entry "orders" (mt/id :orders))] "output_1")
+                       :model/Transform {t2 :id} (make-python-transform [(transforms.tu/source-table-entry "products" (mt/id :products))] "output_2")
+                       :model/Transform {t3 :id} (make-python-transform [(transforms.tu/source-table-entry "output_1" table1)
+                                                                         (transforms.tu/source-table-entry "output_2" table2)] "final_output")]
           (is (= {t1 #{}
                   t2 #{}
                   t3 #{t1 t2}}
@@ -97,7 +97,7 @@
                                                    :query {:source-table (mt/id :orders)}}
                                                   "sql_output")
                        ;; Python transform that depends on the SQL transform's output
-                       :model/Transform {t2 :id} (make-python-transform [{:alias "sql_output" :table_id table1}] "python_output")
+                       :model/Transform {t2 :id} (make-python-transform [(transforms.tu/source-table-entry "sql_output" table1)] "python_output")
                        ;; Another SQL transform that depends on the Python transform's output
                        :model/Transform {t3 :id} (make-transform
                                                   {:database (mt/id)

--- a/enterprise/backend/test/metabase_enterprise/transforms_python/python_runner_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms_python/python_runner_test.clj
@@ -55,29 +55,38 @@
 
 (defn- jsonl-output [expected] #(= expected (parse-jsonl %)))
 
+(defn- tables-map->source-tables
+  "Convert old test map format {\"alias\" table_id} to new source-table-entry format."
+  [tables]
+  (mapv (fn [[alias table-id]]
+          {:alias (name alias) :table_id table-id
+           :database_id (t2/select-one-fn :db_id (t2/table-name :model/Table) :id table-id)
+           :schema (t2/select-one-fn :schema :model/Table :id table-id)})
+        tables))
+
 (defn execute! [{:keys [code tables]}]
-  (with-open [shared-storage-ref (s3/open-shared-storage! (or tables {}))]
-    (let [server-url     (transforms-python.settings/python-runner-url)
-          cancel-chan    (a/promise-chan)
-          table-name->id (or tables {})
-          test-id        (next-job-run-id)
-          _              (python-runner/copy-tables-to-s3! {:run-id         test-id
-                                                            :shared-storage @shared-storage-ref
-                                                            :source         {:source-tables table-name->id}
-                                                            :cancel-chan    cancel-chan})
-          response       (python-runner/execute-python-code-http-call! {:server-url     server-url
-                                                                        :code           code
-                                                                        :run-id         test-id
-                                                                        :table-name->id table-name->id
-                                                                        :shared-storage @shared-storage-ref})
-          events (python-runner/read-events @shared-storage-ref)
-          output-manifest (python-runner/read-output-manifest @shared-storage-ref)]
+  (let [source-tables (if (seq tables) (tables-map->source-tables tables) [])]
+    (with-open [shared-storage-ref (s3/open-shared-storage! source-tables)]
+      (let [server-url     (transforms-python.settings/python-runner-url)
+            cancel-chan    (a/promise-chan)
+            test-id        (next-job-run-id)
+            _              (python-runner/copy-tables-to-s3! {:run-id         test-id
+                                                              :shared-storage @shared-storage-ref
+                                                              :source         {:source-tables source-tables}
+                                                              :cancel-chan    cancel-chan})
+            response       (python-runner/execute-python-code-http-call! {:server-url     server-url
+                                                                          :code           code
+                                                                          :run-id         test-id
+                                                                          :source-tables  source-tables
+                                                                          :shared-storage @shared-storage-ref})
+            events (python-runner/read-events @shared-storage-ref)
+            output-manifest (python-runner/read-output-manifest @shared-storage-ref)]
       ;; not sure about munging this all together but its what tests expect for now
-      (merge (:body response)
-             {:output          (when-some [in (python-runner/open-output @shared-storage-ref)] (with-open [in in] (slurp in)))
-              :output-manifest output-manifest
-              :stdout          (->> events (filter #(= "stdout" (:stream %))) (map :message) (str/join "\n"))
-              :stderr          (->> events (filter #(= "stderr" (:stream %))) (map :message) (str/join "\n"))}))))
+        (merge (:body response)
+               {:output          (when-some [in (python-runner/open-output @shared-storage-ref)] (with-open [in in] (slurp in)))
+                :output-manifest output-manifest
+                :stdout          (->> events (filter #(= "stdout" (:stream %))) (map :message) (str/join "\n"))
+                :stderr          (->> events (filter #(= "stderr" (:stream %))) (map :message) (str/join "\n"))})))))
 
 (defn ok-stdout [num-rows num-cols]
   (format (str "Successfully saved %d rows to S3\n"

--- a/enterprise/backend/test/metabase_enterprise/transforms_python/python_runner_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms_python/python_runner_test.clj
@@ -16,6 +16,7 @@
    [metabase.test.data.sql :as sql.tx]
    [metabase.test.util :as tu]
    [metabase.transforms-base.util :as transforms-base.u]
+   [metabase.transforms.test-util :as transforms.tu]
    [metabase.util :as u]
    [metabase.util.json :as json]
    [toucan2.core :as t2]))
@@ -59,9 +60,7 @@
   "Convert old test map format {\"alias\" table_id} to new source-table-entry format."
   [tables]
   (mapv (fn [[alias table-id]]
-          {:alias (name alias) :table_id table-id
-           :database_id (t2/select-one-fn :db_id (t2/table-name :model/Table) :id table-id)
-           :schema (t2/select-one-fn :schema :model/Table :id table-id)})
+          (transforms.tu/source-table-entry (name alias) table-id))
         tables))
 
 (defn execute! [{:keys [code tables]}]

--- a/enterprise/backend/test/metabase_enterprise/transforms_python/s3_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms_python/s3_test.clj
@@ -65,8 +65,8 @@
 (deftest open-s3-shared-storage-test
   (testing "open-s3-shared-storage! returns closeable derefable"
     (mt/with-premium-features #{:transforms-python :transforms}
-      (let [table-name->id {"users" 1}
-            storage-ref    (s3/open-shared-storage! table-name->id)
+      (let [source-tables [{:alias "users" :table_id 1 :database_id 1 :schema nil}]
+            storage-ref    (s3/open-shared-storage! source-tables)
             {:keys [s3-client bucket-name objects]} @storage-ref]
         (testing "can be dereferenced"
           (doseq [[k {:keys [method path url]}] objects

--- a/enterprise/backend/test/metabase_enterprise/transforms_python/transforms_api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms_python/transforms_api_test.clj
@@ -149,7 +149,7 @@
               (let [original           {:name   "Gadget Products"
                                         :source {:type  "python"
                                                  :source-database (mt/id)
-                                                 :source-tables [{:alias "transforms_customers" :table_id (mt/id :transforms_customers)}]
+                                                 :source-tables [(transforms.tu/source-table-entry "transforms_customers" (mt/id :transforms_customers))]
                                                  :body  (str "import pandas as pd\n"
                                                              "\n"
                                                              "def transform():\n"
@@ -223,7 +223,7 @@
                                           :source {:type            "python"
                                                    :body            (program->source program)
                                                    :source-database (mt/id)
-                                                   :source-tables   [{:alias "test" :table_id (t2/select-one-pk :model/Table :db_id (mt/id))}]}
+                                                   :source-tables   [(transforms.tu/source-table-entry "test" (t2/select-one-pk :model/Table :db_id (mt/id)))]}
                                           :target (assoc target :database (mt/id))})))
 
             (block-on-run [{:keys [expect-status]} target transform-id]
@@ -329,7 +329,7 @@
                      :model/Transform transform {:name "Python Transform Cross DB"
                                                  :source {:type "python"
                                                           :source-database (mt/id)
-                                                          :source-tables [{:alias "test" :table_id (t2/select-one-pk :model/Table :db_id (mt/id))}]
+                                                          :source-tables [(transforms.tu/source-table-entry "test" (t2/select-one-pk :model/Table :db_id (mt/id)))]
                                                           :body "def transform():\n    pass"}
                                                  :target {:type "table"
                                                           :schema "PUBLIC"
@@ -353,7 +353,7 @@
                                    :source {:type            "python"
                                             :body            (str/join "\n" program)
                                             :source-database (mt/id)
-                                            :source-tables   [{:alias "transforms_customers" :table_id (mt/id :transforms_customers)}]}
+                                            :source-tables   [(transforms.tu/source-table-entry "transforms_customers" (mt/id :transforms_customers))]}
                                    :target (assoc target :database (mt/id))}))
 
           ;; using clojure-ey coordination with promises (I know j.u.c could be better here)
@@ -526,7 +526,7 @@
               (let [initial-transform {:name   "Schema Change Integration Test"
                                        :source {:type            "python"
                                                 :source-database (mt/id)
-                                                :source-tables   [{:alias "test" :table_id (t2/select-one-pk :model/Table :db_id (mt/id))}]
+                                                :source-tables   [(transforms.tu/source-table-entry "test" (t2/select-one-pk :model/Table :db_id (mt/id)))]
                                                 :body            (str "import pandas as pd\n"
                                                                       "\n"
                                                                       "def transform():\n"
@@ -545,7 +545,7 @@
                 (let [updated-transform (assoc initial-transform
                                                :source {:type            "python"
                                                         :source-database (mt/id)
-                                                        :source-tables   [{:alias "test" :table_id (t2/select-one-pk :model/Table :db_id (mt/id))}]
+                                                        :source-tables   [(transforms.tu/source-table-entry "test" (t2/select-one-pk :model/Table :db_id (mt/id)))]
                                                         :body            (str "import pandas as pd\n"
                                                                               "\n"
                                                                               "def transform():\n"

--- a/enterprise/backend/test/metabase_enterprise/workspaces/dependencies_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/dependencies_test.clj
@@ -7,6 +7,7 @@
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.test :as mt]
+   [metabase.transforms.test-util :as transforms.tu]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
@@ -95,8 +96,8 @@
 (deftest ^:parallel analyze-entity-python-transform-test
   (testing "analyze-entity extracts dependencies from a python transform"
     (let [transform {:source {:type          "python"
-                              :source-tables [{:alias "orders"   :table_id (mt/id :orders)}
-                                              {:alias "products" :table_id (mt/id :products)}]
+                              :source-tables [(transforms.tu/source-table-entry "orders" (mt/id :orders))
+                                              (transforms.tu/source-table-entry "products" (mt/id :products))]
                               :body          "def transform(orders, products): return orders"}
                      :target {:database (mt/id)
                               :schema   "public"

--- a/enterprise/backend/test/metabase_enterprise/workspaces/execute_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/execute_test.clj
@@ -182,7 +182,7 @@
                                 :id     456}}
             source        {:type          "python"
                            :body          "import pandas as pd"
-                           :source-tables [{:alias "orders" :table_id 123}]}]
+                           :source-tables [{:alias "orders" :table_id 123 :database_id 1 :schema "public"}]}]
         (is (= [{:alias "orders" :database_id 1
                  :schema "ws_isolated_123" :table "orders_isolated" :table_id 456}]
                (:source-tables (remap-python-source table-mapping source))))))
@@ -221,7 +221,7 @@
                            :body          "import pandas as pd"
                            :source-tables [{:alias "orders" :database_id 1
                                             :schema "public" :table "orders" :table_id 123}
-                                           {:alias "customers" :table_id 789}]}]
+                                           {:alias "customers" :table_id 789 :database_id 1 :schema "public"}]}]
         (is (= [{:alias "orders" :database_id 1
                  :schema "ws_isolated_123" :table "orders_isolated" :table_id 456}
                 {:alias "customers" :database_id 1

--- a/src/metabase/transforms/core.clj
+++ b/src/metabase/transforms/core.clj
@@ -31,7 +31,6 @@
   add-source-readable
   is-temp-transform-table?]
  [metabase.transforms.crud
-  source-tables-vec->map-for-fe
   check-database-feature
   check-feature-enabled!
   extract-all-columns-from-query

--- a/src/metabase/transforms/crud.clj
+++ b/src/metabase/transforms/crud.clj
@@ -26,16 +26,6 @@
 
 (set! *warn-on-reflection* true)
 
-;; TODO(FE-source-tables): Remove this function and all call sites when FE adopts the array format for source-tables.
-(defn source-tables-vec->map-for-fe
-  "Convert source-tables from internal vec format to legacy map format for FE compatibility.
-  Remove this when FE adopts the array format."
-  [transform]
-  (if (transforms-base.u/python-transform? transform)
-    (update-in transform [:source :source-tables]
-               transforms-base.u/source-tables-vec->alias-id-map)
-    transform))
-
 (defn check-database-feature
   "Check that the target database supports the required features for this transform."
   [transform]
@@ -155,8 +145,7 @@
                        (transforms-base.u/->status-filter-xf [:last_run :status] last-run-statuses)
                        (transforms-base.u/->tag-filter-xf [:tag_ids] tag-ids)
                        (map #(update % :last_run transforms-base.u/localize-run-timestamps))
-                       (map transforms.u/add-source-readable)
-                       (map source-tables-vec->map-for-fe))))))) ;; TODO(FE-source-tables): remove
+                       (map transforms.u/add-source-readable)))))))
 
 (defn get-transform
   "Get a specific transform."
@@ -167,8 +156,7 @@
         (t2/hydrate :last_run :transform_tag_ids :creator :owner)
         (u/update-some :last_run transforms-base.u/localize-run-timestamps)
         (assoc :table target-table)
-        transforms.u/add-source-readable
-        source-tables-vec->map-for-fe))) ;; TODO(FE-source-tables): remove
+        transforms.u/add-source-readable)))
 
 (defn create-transform!
   "Create new transform in the appdb.
@@ -229,8 +217,7 @@
                     (t2/hydrate (t2/select-one :model/Transform id) :transform_tag_ids :creator :owner))]
     (events/publish-event! :event/transform-update {:object transform :user-id api/*current-user-id*})
     (-> transform
-        transforms.u/add-source-readable
-        source-tables-vec->map-for-fe))) ;; TODO(FE-source-tables): remove
+        transforms.u/add-source-readable)))
 
 (defn delete-transform!
   "Delete a transform and publish the delete event."

--- a/src/metabase/transforms/schema.clj
+++ b/src/metabase/transforms/schema.clj
@@ -31,12 +31,7 @@
     [:map
      [:source-database {:optional true} :int]
      ;; NB: if source is checkpoint, only one table allowed
-     ;; decode/normalize: convert FE map format to vec and enrich with DB metadata
-     [:source-tables   [:sequential {:decode/normalize (fn [st]
-                                                         (if (map? st)
-                                                           (transforms-base.u/source-tables-map->vec st)
-                                                           st))}
-                        ::transforms-base.u/source-table-entry]]
+     [:source-tables   [:sequential ::transforms-base.u/source-table-entry]]
      [:type {:decode/normalize lib.schema.common/normalize-keyword} [:= :python]]
      [:body :string]
      [:source-incremental-strategy {:optional true} ::source-incremental-strategy]]]])

--- a/src/metabase/transforms_base/util.clj
+++ b/src/metabase/transforms_base/util.clj
@@ -555,11 +555,6 @@
 
 ;;; ------------------------------------------------- Source Table Schemas -------------------------------------------------
 
-(mu/defn source-tables-vec->alias-id-map :- [:map-of :string [:maybe :int]]
-  "Convert source-table entries to `{alias -> table_id}` map."
-  [entries :- [:sequential ::source-table-entry]]
-  (into {} (map (juxt :alias :table_id)) entries))
-
 ;;; ------------------------------------------------- Source Table Resolution -------------------------------------------------
 
 (def ^:private ^:const batch-lookup-chunk-size
@@ -600,8 +595,8 @@
   "A source table entry in the array format. Combines alias with table reference."
   [:map
    [:alias :string]
-   [:database_id {:optional true} :int]
-   [:schema {:optional true} [:maybe :string]]
+   [:database_id :int]
+   [:schema [:maybe :string]]
    [:table {:optional true} :string]
    [:table_id {:optional true} [:maybe :int]]])
 
@@ -611,7 +606,7 @@
   For entries with only :database_id/:schema/:table, looks up :table_id.
   Throws if an integer table ID references a non-existent table.
   Map refs with non-existent tables get nil table_id (resolved later at execute time)."
-  [source-tables :- [:sequential ::source-table-entry]]
+  [source-tables :- [:sequential [:map [:alias :string]]]]
   (let [;; Entries that have table_id but lack table metadata need lookup
         needs-metadata   (filter (fn [e] (and (:table_id e) (not (:table e)))) source-tables)
         int-id->metadata (when (seq needs-metadata)
@@ -642,24 +637,23 @@
               :else entry))
           source-tables)))
 
-(mu/defn resolve-source-tables :- [:map-of :string :int]
-  "Resolve source-table entries to `{alias -> table_id}`. Throws if any table not found.
+(mu/defn resolve-source-tables :- [:sequential ::source-table-entry]
+  "Resolve source-table entries to entries with :table_id filled in. Throws if any table not found.
   For execute time — all entries must resolve to valid table IDs."
   [source-tables :- [:sequential ::source-table-entry]]
   (let [needs-lookup (filter missing-table-id? source-tables)
         lookup       (or (batch-lookup-table-ids needs-lookup) {})
-        resolved     (u/for-map [entry source-tables]
-                       [(:alias entry) (or (:table_id entry) (lookup (source-table-ref->key entry)))])
-        unresolved   (for [entry source-tables
-                           :let [table-id (or (:table_id entry) (lookup (source-table-ref->key entry)))]
-                           :when (nil? table-id)]
-                       {:alias (:alias entry)
-                        :table (if-let [schema (:schema entry)]
-                                 (str schema "." (:table entry))
-                                 (:table entry))
-                        :ref   entry})]
+        resolved     (mapv (fn [entry]
+                             (let [table-id (or (:table_id entry) (lookup (source-table-ref->key entry)))]
+                               (assoc entry :table_id table-id)))
+                           source-tables)
+        unresolved   (filter #(nil? (:table_id %)) resolved)]
     (when (seq unresolved)
-      (throw (ex-info (str "Tables not found: " (str/join ", " (map :table unresolved)))
+      (throw (ex-info (str "Tables not found: " (str/join ", " (map (fn [{:keys [alias schema table]}]
+                                                                      (if schema
+                                                                        (str schema "." table)
+                                                                        table))
+                                                                    unresolved)))
                       {:unresolved unresolved
                        :transform-message "Input table not found"})))
     resolved))

--- a/src/metabase/transforms_base/util.clj
+++ b/src/metabase/transforms_base/util.clj
@@ -649,7 +649,7 @@
                            source-tables)
         unresolved   (filter #(nil? (:table_id %)) resolved)]
     (when (seq unresolved)
-      (throw (ex-info (str "Tables not found: " (str/join ", " (map (fn [{:keys [alias schema table]}]
+      (throw (ex-info (str "Tables not found: " (str/join ", " (map (fn [{:keys [schema table]}]
                                                                       (if schema
                                                                         (str schema "." table)
                                                                         table))

--- a/src/metabase/transforms_rest/api/transform.clj
+++ b/src/metabase/transforms_rest/api/transform.clj
@@ -174,8 +174,7 @@
              403
              (deferred-tru "A table with that name already exists."))
   (-> (transforms.core/create-transform! body)
-      transforms.u/add-source-readable
-      transforms.core/source-tables-vec->map-for-fe)) ;; TODO(FE-source-tables): remove
+      transforms.u/add-source-readable))
 
 (api.macros/defendpoint :get "/:id" :- TransformResponse
   "Get a specific transform."
@@ -193,8 +192,7 @@
         dep-ids         (get global-ordering id)
         dependencies    (map id->transform dep-ids)]
     (->> (t2/hydrate dependencies :creator :owner)
-         transforms.u/add-source-readable
-         (mapv transforms.core/source-tables-vec->map-for-fe)))) ;; TODO(FE-source-tables): remove
+         transforms.u/add-source-readable)))
 
 (def ^:private MergeHistoryEntry
   [:map

--- a/test/metabase/transforms/test_util.clj
+++ b/test/metabase/transforms/test_util.clj
@@ -15,6 +15,12 @@
 
 (set! *warn-on-reflection* true)
 
+(defn source-table-entry
+  "Build a full source-table-entry from alias + table_id by looking up database_id and schema."
+  [alias table-id]
+  (let [{:keys [db_id schema]} (t2/select-one [:model/Table :db_id :schema] :id table-id)]
+    {:alias alias :table_id table-id :database_id db_id :schema schema}))
+
 (defn drop-target!
   "Drop transform target `target` and clean up its metadata.
    `target` can be a string or a map. If `target` is a string, type :table is assumed.

--- a/test/metabase/transforms/util_test.clj
+++ b/test/metabase/transforms/util_test.clj
@@ -223,17 +223,19 @@
           (is (= (:id t1) (:table_id (second result)))))))))
 
 (deftest resolve-source-tables-test
-  (testing "resolve-source-tables returns {alias -> table_id} map from vec input"
+  (testing "resolve-source-tables returns entries with :table_id filled in"
     (mt/with-temp [:model/Database db {}
                    :model/Table    t1 {:db_id (:id db) :name "table_one" :schema nil}
                    :model/Table    t2 {:db_id (:id db) :name "table_two" :schema nil}]
       (testing "resolves entry with table_id"
-        (let [source-tables [{:alias "t" :database_id (:id db) :schema nil :table "table_one" :table_id (:id t1)}]]
-          (is (= {"t" (:id t1)} (transforms-base.u/resolve-source-tables source-tables)))))
+        (let [source-tables [{:alias "t" :database_id (:id db) :schema nil :table "table_one" :table_id (:id t1)}]
+              result        (transforms-base.u/resolve-source-tables source-tables)]
+          (is (= (:id t1) (:table_id (first result))))))
 
       (testing "looks up table_id for entry without it"
-        (let [source-tables [{:alias "t" :database_id (:id db) :schema nil :table "table_one"}]]
-          (is (= {"t" (:id t1)} (transforms-base.u/resolve-source-tables source-tables)))))
+        (let [source-tables [{:alias "t" :database_id (:id db) :schema nil :table "table_one"}]
+              result        (transforms-base.u/resolve-source-tables source-tables)]
+          (is (= (:id t1) (:table_id (first result))))))
 
       (testing "throws for non-existent table"
         (let [source-tables [{:alias "t" :database_id (:id db) :schema nil :table "nonexistent"}]]
@@ -246,10 +248,11 @@
                                 (transforms-base.u/resolve-source-tables source-tables)))))
 
       (testing "handles multiple entries"
-        (let [source-tables [{:alias "t1" :table_id (:id t1)}
-                             {:alias "t2" :database_id (:id db) :schema nil :table "table_two"}]]
-          (is (= {"t1" (:id t1) "t2" (:id t2)}
-                 (transforms-base.u/resolve-source-tables source-tables))))))))
+        (let [source-tables [{:alias "t1" :table_id (:id t1) :database_id (:id db) :schema nil}
+                             {:alias "t2" :database_id (:id db) :schema nil :table "table_two"}]
+              result        (transforms-base.u/resolve-source-tables source-tables)]
+          (is (= (:id t1) (:table_id (first result))))
+          (is (= (:id t2) (:table_id (second result)))))))))
 
 (deftest source-tables-readable?-test
   (testing "source-tables-readable? function"


### PR DESCRIPTION
Continuation of #70298 to remove the translation between 2 formats in API (targeting the FE PR #70100).

Also found a few places where we still use the old format in the test run python transform api so updating there as well.