### PR TITLE
Rewrite ERD endpoint: unified pipeline + lazy BFS

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/advanced_config/file/databases.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_config/file/databases.clj
@@ -74,7 +74,7 @@
         (throw (ex-info (format "To delete database %s set `delete` to %s" (pr-str (:name database)) (pr-str magic-request))
                         {:database-name (:name database)})))
       (when-let [existing-database-id (t2/select-one-pk :model/Database :engine (:engine database), :name (:name database))]
-        (log/debugf "debug: request of deletion for %s %s %s" (:engine database) (pr-str (:name database)) existing-database-id)
+        (log/debugf "Request of deletion for %s %s %s" (:engine database) (pr-str (:name database)) existing-database-id)
         (log/info (u/format-color :blue "Deleting Database %s %s" (:engine database) (pr-str (:name database))))
         #_(t2/delete! :model/Database existing-database-id)))
     (do

--- a/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
@@ -1222,6 +1222,116 @@
    [:nodes [:sequential ::erd-node]]
    [:edges [:sequential ::erd-edge]]])
 
+;;; ---------------------------------------- Phase 1: Resolve focal tables ----------------------------------------
+
+(def ^:private auto-focal-table-count
+  "Number of tables to auto-select as focal when none are specified."
+  3)
+
+(defn- auto-discover-focal-table-ids
+  "Find the top N tables by FK relationship count using a SQL aggregate query.
+   Only considers readable tables. Returns a set of table IDs."
+  [database-id schema]
+  (let [readable-tables (filter mi/can-read?
+                                (t2/select :model/Table
+                                           {:where (cond-> [:and
+                                                            [:= :db_id database-id]
+                                                            [:= :active true]]
+                                                     schema (conj [:= :schema schema]))}))
+        readable-ids    (set (map :id readable-tables))]
+    (when (empty? readable-ids)
+      (throw (ex-info (tru "No tables found in the specified database/schema")
+                      {:status-code 404
+                       :database-id database-id
+                       :schema      schema})))
+    (let [fk-counts (t2/query {:select   [[:f.table_id :tid]
+                                          [[:%count.* :cnt]]]
+                               :from     [[:metabase_field :f]]
+                               :where    [:and
+                                          [:in :f.table_id readable-ids]
+                                          [:not= :f.fk_target_field_id nil]
+                                          [:= :f.active true]
+                                          [:not= :f.visibility_type "retired"]]
+                               :group-by [:f.table_id]
+                               :order-by [[:cnt :desc]]
+                               :limit    auto-focal-table-count})
+          top-ids   (set (map :tid fk-counts))]
+      ;; If no tables have FKs, just pick the first N readable tables
+      (if (empty? top-ids)
+        (->> readable-tables (take auto-focal-table-count) (map :id) set)
+        top-ids))))
+
+;;; ---------------------------------------- Phase 2: Lazy BFS fetch ----------------------------------------
+
+(defn- fetch-readable-tables
+  "Fetch tables by IDs, filtering to only those the user can read.
+   Returns {:tables-by-id {id -> table}, :table-ids #{ids}}."
+  [table-ids]
+  (when (seq table-ids)
+    (let [tables   (filter mi/can-read?
+                           (t2/select :model/Table :id [:in table-ids] :active true))
+          by-id    (into {} (map (fn [t] [(:id t) t])) tables)]
+      {:tables-by-id by-id
+       :table-ids    (set (keys by-id))})))
+
+(defn- fetch-fields-for-tables
+  "Fetch all active, non-retired fields for the given table IDs.
+   Returns a vector of field maps."
+  [table-ids]
+  (when (seq table-ids)
+    (t2/select :model/Field
+               :table_id [:in table-ids]
+               :active true
+               :visibility_type [:not= "retired"])))
+
+(defn- discover-fk-targets
+  "Given a collection of fields, find FK target field IDs that point to tables
+   we haven't loaded yet. Returns the set of new table IDs to fetch."
+  [fields known-table-ids]
+  (let [target-field-ids (->> fields
+                               (keep :fk_target_field_id)
+                               set)]
+    (if (empty? target-field-ids)
+      #{}
+      (let [target-fields (t2/select :model/Field
+                                     :id [:in target-field-ids]
+                                     :active true
+                                     :visibility_type [:not= "retired"])]
+        (->> target-fields
+             (map :table_id)
+             set
+             (#(set/difference % known-table-ids)))))))
+
+(defn- fetch-erd-subgraph
+  "Iteratively expand from focal tables by following FK relationships for n hops.
+   Each hop fetches only newly-discovered tables and their fields.
+   Returns {:tables-by-id, :fields-by-table, :field->table, :all-table-ids}."
+  [focal-table-ids hops]
+  (loop [tables-by-id    {}
+         fields-by-table {}
+         field->table    {}
+         frontier        focal-table-ids
+         remaining-hops  (inc hops)] ;; inc because hop 0 = loading the focal tables themselves
+    (if (or (zero? remaining-hops) (empty? frontier))
+      {:tables-by-id  tables-by-id
+       :fields-by-table fields-by-table
+       :field->table  field->table
+       :all-table-ids (set (keys tables-by-id))}
+      (let [{new-tables-by-id :tables-by-id
+             new-table-ids    :table-ids}  (fetch-readable-tables frontier)
+            new-fields                     (fetch-fields-for-tables new-table-ids)
+            new-fields-by-table            (group-by :table_id new-fields)
+            new-field->table               (into {} (map (fn [f] [(:id f) (:table_id f)])) new-fields)
+            ;; Merge into accumulated state
+            tables-by-id'                  (merge tables-by-id new-tables-by-id)
+            fields-by-table'               (merge fields-by-table new-fields-by-table)
+            field->table'                  (merge field->table new-field->table)
+            ;; Discover next frontier: tables reachable via FKs not yet loaded
+            next-frontier                  (discover-fk-targets new-fields (set (keys tables-by-id')))]
+        (recur tables-by-id' fields-by-table' field->table' next-frontier (dec remaining-hops))))))
+
+;;; ---------------------------------------- Phase 3: Build response ----------------------------------------
+
 (defn- build-erd-field
   "Convert a field to the ERD field shape."
   [field field->table]
@@ -1244,346 +1354,67 @@
    :is_focal     is-focal
    :fields       (mapv #(build-erd-field % field->table) fields)})
 
-(defn- resolve-erd-table-id
-  "Resolve the focal table ID for ERD. If `model-id` is provided, look up the Card's
-  underlying `table_id`. Otherwise use `table-id` directly."
-  [table-id model-id]
-  (if model-id
-    (let [card (api/read-check :model/Card model-id)]
-      (or (:table_id card)
-          (throw (ex-info (tru "Model does not have an underlying table")
-                          {:status-code 400
-                           :model-id    model-id}))))
-    table-id))
-
-(defn- build-erd-connections-map
-  "Build a bidirectional map of table-id -> #{connected-table-ids} from fields.
-   Also returns field->table lookup map."
-  [fields]
-  (let [field->table (into {} (map (fn [f] [(:id f) (:table_id f)]) fields))
-        connections (reduce (fn [conns field]
-                              (if-let [target-field-id (:fk_target_field_id field)]
-                                (let [source-table (:table_id field)
-                                      target-table (field->table target-field-id)]
-                                  (if (and target-table
-                                           (not= source-table target-table))
-                                    (-> conns
-                                        (update source-table (fnil conj #{}) target-table)
-                                        (update target-table (fnil conj #{}) source-table))
-                                    conns))
-                                conns))
-                            {}
-                            fields)]
-    {:connections connections
-     :field->table field->table}))
-
-(defn- expand-tables-by-hops
-  "Expand a set of focal table IDs by following FK connections for n hops.
-   Returns the union of all table IDs reachable within n hops FROM THE FOCAL TABLES ONLY.
-   Hops are counted from focal tables, not from intermediate tables."
-  [focal-table-ids connections n]
-  (loop [all-ids focal-table-ids
-         frontier focal-table-ids
-         remaining-hops n]
-    (if (or (zero? remaining-hops) (empty? frontier))
-      all-ids
-      (let [;; Find tables connected to the current frontier
-            connected-ids (->> frontier
-                               (mapcat #(get connections % #{}))
-                               set)
-            ;; Only keep newly discovered tables
-            new-frontier (set/difference connected-ids all-ids)
-            new-all-ids (set/union all-ids new-frontier)]
-        (recur new-all-ids new-frontier (dec remaining-hops))))))
-
-(defn- resolve-cross-schema-fks
-  "Given fields already fetched for the current schema, find FK target fields that point
-   to tables in other schemas. Returns additional fields, tables-by-id entries, and an
-   extended field->table map that includes the cross-schema targets."
-  [fields known-field-ids]
-  (let [;; Collect fk_target_field_ids that we don't already have
-        missing-target-field-ids (->> fields
-                                      (keep :fk_target_field_id)
-                                      (remove known-field-ids)
-                                      set)]
-    (if (empty? missing-target-field-ids)
-      {:extra-fields   []
-       :extra-tables   {}
-       :extra-field->table {}}
-      (let [;; Fetch the missing target fields
-            extra-fields (t2/select :model/Field
-                                    :id [:in missing-target-field-ids]
-                                    :active true
-                                    :visibility_type [:not= "retired"])
-            ;; Fetch their parent tables
-            extra-table-ids (set (map :table_id extra-fields))
-            extra-tables (when (seq extra-table-ids)
-                           (t2/select :model/Table
-                                      :id [:in extra-table-ids]
-                                      :active true))
-            readable-extra-tables (filter mi/can-read? extra-tables)
-            readable-extra-table-ids (set (map :id readable-extra-tables))
-            ;; Also fetch all fields for those extra tables so edges + nodes are complete
-            extra-table-fields (when (seq readable-extra-table-ids)
-                                 (t2/select :model/Field
-                                            :table_id [:in readable-extra-table-ids]
-                                            :active true
-                                            :visibility_type [:not= "retired"]))
-            all-extra-fields (distinct (concat extra-fields extra-table-fields))]
-        {:extra-fields      all-extra-fields
-         :extra-tables      (into {} (map (fn [t] [(:id t) t]) readable-extra-tables))
-         :extra-field->table (into {} (map (fn [f] [(:id f) (:table_id f)]) all-extra-fields))}))))
-
-(defn- determine-relationship
-  "Determine the cardinality relationship between source and target fields.
-   For FK edges emitted by this endpoint (source FK -> target referenced field):
-   - one-to-one (1:1): Source FK field is also a PK (effectively unique per row)
-   - many-to-one (*:1): Default FK relationship"
-  [source-field target-field]
-  (let [source-is-pk (:database_is_pk source-field)
-        target-is-pk (:database_is_pk target-field)]
-    (cond
-      (and source-is-pk target-is-pk) "one-to-one"
-      :else "many-to-one")))
-
 (defn- build-erd-edges
   "Build ERD edges from fields, filtered to only include edges between visible tables."
-  [fields field->table visible-table-ids]
-  (let [field-by-id (into {} (map (fn [f] [(:id f) f]) fields))]
-    (->> fields
-         (filter :fk_target_field_id)
+  [fields-by-table field->table visible-table-ids]
+  (let [all-fields (mapcat val fields-by-table)
+        field-by-id (into {} (map (fn [f] [(:id f) f])) all-fields)]
+    (->> all-fields
          (keep (fn [field]
-                 (let [target-field-id (:fk_target_field_id field)
-                       target-table (field->table target-field-id)
-                       target-field (field-by-id target-field-id)]
-                   (when (and target-table
-                              target-field
-                              (contains? visible-table-ids (:table_id field))
-                              (contains? visible-table-ids target-table))
-                     {:source_table_id (:table_id field)
-                      :source_field_id (:id field)
-                      :target_table_id target-table
-                      :target_field_id target-field-id
-                      :relationship    (determine-relationship field target-field)}))))
-         distinct
+                 (when-let [target-field-id (:fk_target_field_id field)]
+                   (let [target-table (field->table target-field-id)
+                         target-field (field-by-id target-field-id)]
+                     (when (and target-table
+                                target-field
+                                (contains? visible-table-ids (:table_id field))
+                                (contains? visible-table-ids target-table))
+                       {:source_table_id (:table_id field)
+                        :source_field_id (:id field)
+                        :target_table_id target-table
+                        :target_field_id target-field-id
+                        :relationship    (if (and (:database_is_pk field)
+                                                  (:database_is_pk target-field))
+                                           "one-to-one"
+                                           "many-to-one")})))))
          vec)))
 
-(defn- build-erd-for-tables
-  "Build ERD for specific tables by their IDs within a database/schema."
-  [table-ids database-id schema hops]
-  (api/read-check :model/Database database-id)
-  (when (empty? table-ids)
-    (throw (ex-info (tru "At least one table-id must be provided")
-                    {:status-code 400})))
-  (let [;; Get all tables in the database/schema for FK traversal
-        all-db-tables (t2/select :model/Table
-                                 {:where (cond-> [:and
-                                                  [:= :db_id database-id]
-                                                  [:= :active true]]
-                                           schema (conj [:= :schema schema]))})
-        all-readable-tables (filter mi/can-read? all-db-tables)
-        all-table-ids (set (map :id all-readable-tables))
-        tables-by-id (into {} (map (fn [t] [(:id t) t]) all-readable-tables))
-
-        ;; Filter requested tables to only those that exist and are readable
-        focal-table-ids (set/intersection table-ids all-table-ids)
-        _ (when (empty? focal-table-ids)
-            (throw (ex-info (tru "No readable tables found")
-                            {:status-code 404
-                             :table-ids table-ids})))
-
-        ;; Get all fields for these tables
-        all-fields (when (seq all-table-ids)
-                     (t2/select :model/Field
-                                :table_id [:in all-table-ids]
-                                :active true
-                                :visibility_type [:not= "retired"]))
-
-        ;; Resolve cross-schema FK targets
-        known-field-ids (set (map :id all-fields))
-        {:keys [extra-fields extra-tables extra-field->table]}
-        (resolve-cross-schema-fks all-fields known-field-ids)
-
-        ;; Merge cross-schema data
-        all-fields    (concat all-fields extra-fields)
-        tables-by-id  (merge tables-by-id extra-tables)
-
-        ;; Build connections map (now includes cross-schema links)
-        {:keys [connections field->table]} (build-erd-connections-map all-fields)
-        field->table (merge field->table extra-field->table)
-
-        ;; Expand by N hops from focal tables
-        all-visible-table-ids (expand-tables-by-hops focal-table-ids connections hops)
-
-        ;; Get fields for all visible tables
-        visible-fields (filter #(contains? all-visible-table-ids (:table_id %)) all-fields)
-        fields-by-table (group-by :table_id visible-fields)
-
-        ;; Build nodes - focal tables are focal, others are not
-        all-nodes (->> all-visible-table-ids
-                       (keep #(when-let [t (tables-by-id %)]
-                                (build-erd-node t
-                                                (get fields-by-table (:id t) [])
-                                                (contains? focal-table-ids (:id t))
-                                                field->table)))
-                       vec)
-
-        ;; Build edges
-        edges (build-erd-edges visible-fields field->table all-visible-table-ids)]
-    {:nodes all-nodes
+(defn- build-erd-response
+  "Build the ERD response from fetched subgraph data."
+  [{:keys [tables-by-id fields-by-table field->table all-table-ids]} focal-table-ids]
+  (let [nodes (->> all-table-ids
+                   (keep (fn [tid]
+                           (when-let [table (tables-by-id tid)]
+                             (build-erd-node table
+                                            (get fields-by-table tid [])
+                                            (contains? focal-table-ids tid)
+                                            field->table))))
+                   vec)
+        edges (build-erd-edges fields-by-table field->table all-table-ids)]
+    {:nodes nodes
      :edges edges}))
 
-(defn- build-erd-for-database
-  "Build ERD for top 3 tables with most FK relationships in a database/schema."
-  [database-id schema hops]
-  (api/read-check :model/Database database-id)
-  (let [;; Get all tables in the database, optionally filtered by schema
-        tables (t2/select :model/Table
-                          {:where (cond-> [:and
-                                           [:= :db_id database-id]
-                                           [:= :active true]]
-                                    schema (conj [:= :schema schema]))})
-        readable-tables (filter mi/can-read? tables)
-        table-ids (set (map :id readable-tables))
-        tables-by-id (into {} (map (fn [t] [(:id t) t]) readable-tables))
-
-        ;; Get all fields for these tables
-        all-fields (when (seq table-ids)
-                     (t2/select :model/Field
-                                :table_id [:in table-ids]
-                                :active true
-                                :visibility_type [:not= "retired"]))
-
-        ;; Resolve cross-schema FK targets
-        known-field-ids (set (map :id all-fields))
-        {:keys [extra-fields extra-tables extra-field->table]}
-        (resolve-cross-schema-fks all-fields known-field-ids)
-
-        ;; Merge cross-schema data
-        all-fields    (concat all-fields extra-fields)
-        tables-by-id  (merge tables-by-id extra-tables)
-
-        ;; Build connections map (now includes cross-schema links)
-        {:keys [connections field->table]} (build-erd-connections-map all-fields)
-        field->table (merge field->table extra-field->table)
-
-        ;; Count unique connections per table
-        fk-counts (into {} (map (fn [[k v]] [k (count v)]) connections))
-
-        ;; Get top 3 tables by FK count (only from originally requested schema)
-        top-tables (->> readable-tables
-                        (sort-by #(get fk-counts (:id %) 0) >)
-                        (take 3))
-
-        _ (when (empty? top-tables)
-            (throw (ex-info (tru "No tables found in the specified database/schema")
-                            {:status-code 404
-                             :database-id database-id
-                             :schema schema})))
-
-        top-table-ids (set (map :id top-tables))
-
-        ;; Expand by N hops from top tables
-        all-visible-table-ids (expand-tables-by-hops top-table-ids connections hops)
-
-        ;; Get fields for all visible tables
-        visible-fields (filter #(contains? all-visible-table-ids (:table_id %)) all-fields)
-        fields-by-table (group-by :table_id visible-fields)
-
-        ;; Build nodes - top tables are focal, others are not
-        all-nodes (->> all-visible-table-ids
-                       (keep #(when-let [t (tables-by-id %)]
-                                (build-erd-node t
-                                                (get fields-by-table (:id t) [])
-                                                (contains? top-table-ids (:id t))
-                                                field->table)))
-                       vec)
-
-        ;; Build edges
-        edges (build-erd-edges visible-fields field->table all-visible-table-ids)]
-    {:nodes all-nodes
-     :edges edges}))
-
-(defn- build-erd-for-focal-table
-  "Build ERD for a focal table and its related tables within N hops."
-  [focal-table hops]
-  (let [database-id (:db_id focal-table)
-        focal-table-id (:id focal-table)
-
-        ;; Get all tables in the same database for N-hop traversal
-        tables (t2/select :model/Table
-                          :db_id database-id
-                          :active true)
-        readable-tables (filter mi/can-read? tables)
-        table-ids (set (map :id readable-tables))
-        tables-by-id (into {} (map (fn [t] [(:id t) t]) readable-tables))
-
-        ;; Get all fields for these tables
-        all-fields (when (seq table-ids)
-                     (t2/select :model/Field
-                                :table_id [:in table-ids]
-                                :active true
-                                :visibility_type [:not= "retired"]))
-
-        ;; Build connections map
-        {:keys [connections field->table]} (build-erd-connections-map all-fields)
-
-        ;; Expand by N hops from focal table
-        all-visible-table-ids (expand-tables-by-hops #{focal-table-id} connections hops)
-
-        ;; Get fields for all visible tables
-        visible-fields (filter #(contains? all-visible-table-ids (:table_id %)) all-fields)
-        fields-by-table (group-by :table_id visible-fields)
-
-        ;; Build nodes - focal table is focal, others are not
-        all-nodes (->> all-visible-table-ids
-                       (keep #(when-let [t (tables-by-id %)]
-                                (build-erd-node t
-                                                (get fields-by-table (:id t) [])
-                                                (= (:id t) focal-table-id)
-                                                field->table)))
-                       vec)
-
-        ;; Build edges
-        edges (build-erd-edges visible-fields field->table all-visible-table-ids)]
-    {:nodes all-nodes
-     :edges edges}))
+;;; ---------------------------------------- Endpoint ----------------------------------------
 
 (api.macros/defendpoint :get "/erd" :- ::erd-response
-  "Return an Entity Relationship Diagram (ERD) for a focal table and related tables within N hops.
-  Returns nodes (tables with columns) and edges (FK relationships).
-  Accepts either `model-id` (a Card with type model), or `database-id` (optionally with `schema` and/or `table-ids`).
-  When `model-id` is provided, the ERD is built for the model's underlying source table.
-  When `database-id` is provided without `table-ids`, returns ERD for the top 3 tables with most FK relationships.
-  When `database-id` is provided with `table-ids`, returns ERD for those specific tables.
-  The `hops` parameter controls how many relationship hops to traverse (default: 2).
-  When `hops` is 0, only the focal/selected tables are returned with no related tables."
+  "Return an Entity Relationship Diagram (ERD) for tables and their FK relationships.
+  When `table-ids` is provided, those tables are the focal points.
+  When only `database-id` is provided, auto-selects the most connected tables.
+  The `hops` parameter controls how many FK hops to traverse (default: 2, max: 5).
+  When `hops` is 0, only the focal tables are returned with no related tables."
   [_route-params
-   {:keys [model-id database-id table-ids schema hops]
-    :or {hops 2}} :- [:map
-                      [:model-id {:optional true} [:maybe ms/PositiveInt]]
-                      [:database-id {:optional true} [:maybe ms/PositiveInt]]
-                      [:table-ids {:optional true} [:maybe (ms/QueryVectorOf ms/PositiveInt)]]
-                      [:schema {:optional true} [:maybe :string]]
-                      [:hops {:optional true} [:maybe ms/IntGreaterThanOrEqualToZero]]]]
-  (when-not (or model-id database-id)
-    (throw (ex-info (tru "Either model-id or database-id must be provided")
-                    {:status-code 400})))
-  (when (and table-ids (not database-id))
-    (throw (ex-info (tru "database-id is required when table-ids is provided")
-                    {:status-code 400})))
-  (let [hops (or hops 2)]
-    (cond
-      model-id
-      (let [resolved-table-id (resolve-erd-table-id nil model-id)
-            focal-table (api/read-check :model/Table resolved-table-id)]
-        (build-erd-for-focal-table focal-table hops))
-
-      (seq table-ids)
-      (build-erd-for-tables (set table-ids) database-id schema hops)
-
-      :else
-      (build-erd-for-database database-id schema hops))))
+   {:keys [database-id table-ids schema hops]
+    :or   {hops 2}} :- [:map
+                         [:database-id ms/PositiveInt]
+                         [:table-ids {:optional true} [:maybe (ms/QueryVectorOf ms/PositiveInt)]]
+                         [:schema {:optional true} [:maybe :string]]
+                         [:hops {:optional true} [:maybe ms/IntGreaterThanOrEqualToZero]]]]
+  (api/read-check :model/Database database-id)
+  (let [hops            (min (or hops 2) 5)
+        focal-table-ids (if (seq table-ids)
+                          (set table-ids)
+                          (auto-discover-focal-table-ids database-id schema))
+        subgraph        (fetch-erd-subgraph focal-table-ids hops)]
+    (build-erd-response subgraph focal-table-ids)))
 
 (def ^{:arglists '([request respond raise])} routes
   "`/api/ee/dependencies` routes."

--- a/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
@@ -5,6 +5,7 @@
    [medley.core :as m]
    [metabase-enterprise.dependencies.core :as dependencies]
    [metabase-enterprise.dependencies.dependency-types :as deps.dependency-types]
+   [metabase-enterprise.dependencies.erd :as erd]
    [metabase-enterprise.dependencies.models.analysis-finding-error :as analysis-finding-error]
    [metabase-enterprise.dependencies.models.dependency :as dependency]
    [metabase.analyze.core :as analyze]
@@ -1189,213 +1190,7 @@
 
 ;;; -------------------------------------------------- ERD Endpoint --------------------------------------------------
 
-(mr/def ::erd-field
-  [:map
-   [:id :int]
-   [:name :string]
-   [:display_name :string]
-   [:database_type :string]
-   [:semantic_type {:optional true} [:maybe :string]]
-   [:fk_target_field_id {:optional true} [:maybe :int]]
-   [:fk_target_table_id {:optional true} [:maybe :int]]])
-
-(mr/def ::erd-node
-  [:map
-   [:table_id :int]
-   [:name :string]
-   [:display_name :string]
-   [:schema {:optional true} [:maybe :string]]
-   [:db_id :int]
-   [:is_focal :boolean]
-   [:fields [:sequential ::erd-field]]])
-
-(mr/def ::erd-edge
-  [:map
-   [:source_table_id :int]
-   [:source_field_id :int]
-   [:target_table_id :int]
-   [:target_field_id :int]
-   [:relationship [:enum "one-to-one" "many-to-one"]]])
-
-(mr/def ::erd-response
-  [:map
-   [:nodes [:sequential ::erd-node]]
-   [:edges [:sequential ::erd-edge]]])
-
-;;; ---------------------------------------- Phase 1: Resolve focal tables ----------------------------------------
-
-(def ^:private auto-focal-table-count
-  "Number of tables to auto-select as focal when none are specified."
-  3)
-
-(defn- auto-discover-focal-table-ids
-  "Find the top N tables by FK relationship count using a SQL aggregate query.
-   Only considers readable tables. Returns a set of table IDs."
-  [database-id schema]
-  (let [readable-tables (filter mi/can-read?
-                                (t2/select :model/Table
-                                           {:where (cond-> [:and
-                                                            [:= :db_id database-id]
-                                                            [:= :active true]]
-                                                     schema (conj [:= :schema schema]))}))
-        readable-ids    (set (map :id readable-tables))]
-    (when (empty? readable-ids)
-      (throw (ex-info (tru "No tables found in the specified database/schema")
-                      {:status-code 404
-                       :database-id database-id
-                       :schema      schema})))
-    (let [fk-counts (t2/query {:select   [[:f.table_id :tid]
-                                          [[:%count.* :cnt]]]
-                               :from     [[:metabase_field :f]]
-                               :where    [:and
-                                          [:in :f.table_id readable-ids]
-                                          [:not= :f.fk_target_field_id nil]
-                                          [:= :f.active true]
-                                          [:not= :f.visibility_type "retired"]]
-                               :group-by [:f.table_id]
-                               :order-by [[:cnt :desc]]
-                               :limit    auto-focal-table-count})
-          top-ids   (set (map :tid fk-counts))]
-      ;; If no tables have FKs, just pick the first N readable tables
-      (if (empty? top-ids)
-        (->> readable-tables (take auto-focal-table-count) (map :id) set)
-        top-ids))))
-
-;;; ---------------------------------------- Phase 2: Lazy BFS fetch ----------------------------------------
-
-(defn- fetch-readable-tables
-  "Fetch tables by IDs, filtering to only those the user can read.
-   Returns {:tables-by-id {id -> table}, :table-ids #{ids}}."
-  [table-ids]
-  (when (seq table-ids)
-    (let [tables   (filter mi/can-read?
-                           (t2/select :model/Table :id [:in table-ids] :active true))
-          by-id    (into {} (map (fn [t] [(:id t) t])) tables)]
-      {:tables-by-id by-id
-       :table-ids    (set (keys by-id))})))
-
-(defn- fetch-fields-for-tables
-  "Fetch all active, non-retired fields for the given table IDs.
-   Returns a vector of field maps."
-  [table-ids]
-  (when (seq table-ids)
-    (t2/select :model/Field
-               :table_id [:in table-ids]
-               :active true
-               :visibility_type [:not= "retired"])))
-
-(defn- discover-fk-targets
-  "Given a collection of fields, find FK target field IDs that point to tables
-   we haven't loaded yet. Returns the set of new table IDs to fetch."
-  [fields known-table-ids]
-  (let [target-field-ids (->> fields
-                               (keep :fk_target_field_id)
-                               set)]
-    (if (empty? target-field-ids)
-      #{}
-      (let [target-fields (t2/select :model/Field
-                                     :id [:in target-field-ids]
-                                     :active true
-                                     :visibility_type [:not= "retired"])]
-        (->> target-fields
-             (map :table_id)
-             set
-             (#(set/difference % known-table-ids)))))))
-
-(defn- fetch-erd-subgraph
-  "Iteratively expand from focal tables by following FK relationships for n hops.
-   Each hop fetches only newly-discovered tables and their fields.
-   Returns {:tables-by-id, :fields-by-table, :field->table, :all-table-ids}."
-  [focal-table-ids hops]
-  (loop [tables-by-id    {}
-         fields-by-table {}
-         field->table    {}
-         frontier        focal-table-ids
-         remaining-hops  (inc hops)] ;; inc because hop 0 = loading the focal tables themselves
-    (if (or (zero? remaining-hops) (empty? frontier))
-      {:tables-by-id  tables-by-id
-       :fields-by-table fields-by-table
-       :field->table  field->table
-       :all-table-ids (set (keys tables-by-id))}
-      (let [{new-tables-by-id :tables-by-id
-             new-table-ids    :table-ids}  (fetch-readable-tables frontier)
-            new-fields                     (fetch-fields-for-tables new-table-ids)
-            new-fields-by-table            (group-by :table_id new-fields)
-            new-field->table               (into {} (map (fn [f] [(:id f) (:table_id f)])) new-fields)
-            ;; Merge into accumulated state
-            tables-by-id'                  (merge tables-by-id new-tables-by-id)
-            fields-by-table'               (merge fields-by-table new-fields-by-table)
-            field->table'                  (merge field->table new-field->table)
-            ;; Discover next frontier: tables reachable via FKs not yet loaded
-            next-frontier                  (discover-fk-targets new-fields (set (keys tables-by-id')))]
-        (recur tables-by-id' fields-by-table' field->table' next-frontier (dec remaining-hops))))))
-
-;;; ---------------------------------------- Phase 3: Build response ----------------------------------------
-
-(defn- build-erd-field
-  "Convert a field to the ERD field shape."
-  [field field->table]
-  {:id                 (:id field)
-   :name               (:name field)
-   :display_name       (:display_name field)
-   :database_type      (:database_type field)
-   :semantic_type      (some-> (:semantic_type field) u/qualified-name)
-   :fk_target_field_id (:fk_target_field_id field)
-   :fk_target_table_id (some-> (:fk_target_field_id field) field->table)})
-
-(defn- build-erd-node
-  "Build an ERD node for a table with its fields."
-  [table fields is-focal field->table]
-  {:table_id     (:id table)
-   :name         (:name table)
-   :display_name (:display_name table)
-   :schema       (:schema table)
-   :db_id        (:db_id table)
-   :is_focal     is-focal
-   :fields       (mapv #(build-erd-field % field->table) fields)})
-
-(defn- build-erd-edges
-  "Build ERD edges from fields, filtered to only include edges between visible tables."
-  [fields-by-table field->table visible-table-ids]
-  (let [all-fields (mapcat val fields-by-table)
-        field-by-id (into {} (map (fn [f] [(:id f) f])) all-fields)]
-    (->> all-fields
-         (keep (fn [field]
-                 (when-let [target-field-id (:fk_target_field_id field)]
-                   (let [target-table (field->table target-field-id)
-                         target-field (field-by-id target-field-id)]
-                     (when (and target-table
-                                target-field
-                                (contains? visible-table-ids (:table_id field))
-                                (contains? visible-table-ids target-table))
-                       {:source_table_id (:table_id field)
-                        :source_field_id (:id field)
-                        :target_table_id target-table
-                        :target_field_id target-field-id
-                        :relationship    (if (and (:database_is_pk field)
-                                                  (:database_is_pk target-field))
-                                           "one-to-one"
-                                           "many-to-one")})))))
-         vec)))
-
-(defn- build-erd-response
-  "Build the ERD response from fetched subgraph data."
-  [{:keys [tables-by-id fields-by-table field->table all-table-ids]} focal-table-ids]
-  (let [nodes (->> all-table-ids
-                   (keep (fn [tid]
-                           (when-let [table (tables-by-id tid)]
-                             (build-erd-node table
-                                            (get fields-by-table tid [])
-                                            (contains? focal-table-ids tid)
-                                            field->table))))
-                   vec)
-        edges (build-erd-edges fields-by-table field->table all-table-ids)]
-    {:nodes nodes
-     :edges edges}))
-
-;;; ---------------------------------------- Endpoint ----------------------------------------
-
-(api.macros/defendpoint :get "/erd" :- ::erd-response
+(api.macros/defendpoint :get "/erd" :- ::erd/erd-response
   "Return an Entity Relationship Diagram (ERD) for tables and their FK relationships.
   When `table-ids` is provided, those tables are the focal points.
   When only `database-id` is provided, auto-selects the most connected tables.
@@ -1403,18 +1198,11 @@
   When `hops` is 0, only the focal tables are returned with no related tables."
   [_route-params
    {:keys [database-id table-ids schema hops]
-    :or   {hops 2}} :- [:map
-                         [:database-id ms/PositiveInt]
-                         [:table-ids {:optional true} [:maybe (ms/QueryVectorOf ms/PositiveInt)]]
-                         [:schema {:optional true} [:maybe :string]]
-                         [:hops {:optional true} [:maybe ms/IntGreaterThanOrEqualToZero]]]]
-  (api/read-check :model/Database database-id)
-  (let [hops            (min (or hops 2) 5)
-        focal-table-ids (if (seq table-ids)
-                          (set table-ids)
-                          (auto-discover-focal-table-ids database-id schema))
-        subgraph        (fetch-erd-subgraph focal-table-ids hops)]
-    (build-erd-response subgraph focal-table-ids)))
+    :or   {hops 2}} :- ::erd/erd-request]
+  (erd/erd {:database-id database-id
+            :table-ids   table-ids
+            :schema      schema
+            :hops        hops}))
 
 (def ^{:arglists '([request respond raise])} routes
   "`/api/ee/dependencies` routes."

--- a/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
@@ -1200,7 +1200,7 @@
    {:keys [database-id table-ids schema hops]} :- ::erd/erd-request]
   (erd/erd {:database-id database-id
             :table-ids   table-ids
-            :schema      schema
+            :schema      (not-empty schema)
             :hops        hops}))
 
 (def ^{:arglists '([request respond raise])} routes

--- a/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
@@ -1197,8 +1197,7 @@
   The `hops` parameter controls how many FK hops to traverse (default: 2, max: 5).
   When `hops` is 0, only the focal tables are returned with no related tables."
   [_route-params
-   {:keys [database-id table-ids schema hops]
-    :or   {hops 2}} :- ::erd/erd-request]
+   {:keys [database-id table-ids schema hops]} :- ::erd/erd-request]
   (erd/erd {:database-id database-id
             :table-ids   table-ids
             :schema      schema

--- a/enterprise/backend/src/metabase_enterprise/dependencies/erd.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/erd.clj
@@ -1,0 +1,244 @@
+(ns metabase-enterprise.dependencies.erd
+  "Entity Relationship Diagram (ERD) logic: resolving focal tables,
+   BFS subgraph expansion, and response building."
+  (:require
+   [clojure.set :as set]
+   [metabase.api.common :as api]
+   [metabase.models.interface :as mi]
+   [metabase.util :as u]
+   [metabase.util.i18n :refer [tru]]
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.malli.schema :as ms]
+   [toucan2.core :as t2]))
+
+;;; -------------------------------------------------- Schema --------------------------------------------------
+
+(mr/def ::erd-field
+  [:map
+   [:id :int]
+   [:name :string]
+   [:display_name :string]
+   [:database_type :string]
+   [:semantic_type {:optional true} [:maybe :string]]
+   [:fk_target_field_id {:optional true} [:maybe :int]]
+   [:fk_target_table_id {:optional true} [:maybe :int]]])
+
+(mr/def ::erd-node
+  [:map
+   [:table_id :int]
+   [:name :string]
+   [:display_name :string]
+   [:schema {:optional true} [:maybe :string]]
+   [:db_id :int]
+   [:is_focal :boolean]
+   [:fields [:sequential ::erd-field]]])
+
+(mr/def ::erd-edge
+  [:map
+   [:source_table_id :int]
+   [:source_field_id :int]
+   [:target_table_id :int]
+   [:target_field_id :int]
+   [:relationship [:enum "one-to-one" "many-to-one"]]])
+
+(mr/def ::erd-response
+  [:map
+   [:nodes [:sequential ::erd-node]]
+   [:edges [:sequential ::erd-edge]]])
+
+(mr/def ::erd-request
+  [:map
+   [:database-id ms/PositiveInt]
+   [:table-ids {:optional true} [:maybe (ms/QueryVectorOf ms/PositiveInt)]]
+   [:schema {:optional true} [:maybe :string]]
+   [:hops {:optional true} [:maybe ms/IntGreaterThanOrEqualToZero]]])
+
+;;; ---------------------------------------- Phase 1: Resolve focal tables ----------------------------------------
+
+(def ^:private auto-focal-table-count
+  "Number of tables to auto-select as focal when none are specified."
+  3)
+
+(defn- auto-discover-focal-table-ids
+  "Find the top N tables by FK relationship count using a SQL aggregate query.
+   Only considers readable tables. Returns a set of table IDs."
+  [database-id schema]
+  (let [readable-tables (filter mi/can-read?
+                                (t2/select :model/Table
+                                           {:where (cond-> [:and
+                                                            [:= :db_id database-id]
+                                                            [:= :active true]]
+                                                     schema (conj [:= :schema schema]))}))
+        readable-ids    (set (map :id readable-tables))]
+    (when (empty? readable-ids)
+      (throw (ex-info (tru "No tables found in the specified database/schema")
+                      {:status-code 404
+                       :database-id database-id
+                       :schema      schema})))
+    (let [fk-counts (t2/query {:select   [[:f.table_id :tid]
+                                          [:%count.* :cnt]]
+                               :from     [[:metabase_field :f]]
+                               :where    [:and
+                                          [:in :f.table_id readable-ids]
+                                          [:not= :f.fk_target_field_id nil]
+                                          [:= :f.active true]
+                                          [:not= :f.visibility_type "retired"]]
+                               :group-by [:f.table_id]
+                               :order-by [[:cnt :desc]]
+                               :limit    auto-focal-table-count})
+          top-ids   (set (map :tid fk-counts))]
+      ;; If no tables have FKs, just pick the first N readable tables
+      (if (empty? top-ids)
+        (->> readable-tables (take auto-focal-table-count) (map :id) set)
+        top-ids))))
+
+;;; ---------------------------------------- Phase 2: Lazy BFS fetch ----------------------------------------
+
+(defn- fetch-readable-tables
+  "Fetch tables by IDs, filtering to only those the user can read.
+   Returns {:tables-by-id {id -> table}, :table-ids #{ids}}."
+  [table-ids]
+  (when (seq table-ids)
+    (let [tables   (filter mi/can-read?
+                           (t2/select :model/Table :id [:in table-ids] :active true))
+          by-id    (into {} (map (fn [t] [(:id t) t])) tables)]
+      {:tables-by-id by-id
+       :table-ids    (set (keys by-id))})))
+
+(defn- fetch-fields-for-tables
+  "Fetch all active, non-retired fields for the given table IDs.
+   Returns a vector of field maps."
+  [table-ids]
+  (when (seq table-ids)
+    (t2/select :model/Field
+               :table_id [:in table-ids]
+               :active true
+               :visibility_type [:not= "retired"])))
+
+(defn- discover-fk-targets
+  "Given a collection of fields, find FK target field IDs that point to tables
+   we haven't loaded yet. Returns the set of new table IDs to fetch."
+  [fields known-table-ids]
+  (let [target-field-ids (->> fields
+                              (keep :fk_target_field_id)
+                              set)]
+    (if (empty? target-field-ids)
+      #{}
+      (let [target-fields (t2/select :model/Field
+                                     :id [:in target-field-ids]
+                                     :active true
+                                     :visibility_type [:not= "retired"])]
+        (->> target-fields
+             (map :table_id)
+             set
+             (#(set/difference % known-table-ids)))))))
+
+(defn- fetch-erd-subgraph
+  "Iteratively expand from focal tables by following FK relationships for n hops.
+   Each hop fetches only newly-discovered tables and their fields.
+   Returns {:tables-by-id, :fields-by-table, :field->table, :all-table-ids}."
+  [focal-table-ids hops]
+  (loop [tables-by-id    {}
+         fields-by-table {}
+         field->table    {}
+         frontier        focal-table-ids
+         remaining-hops  (inc hops)] ;; inc because hop 0 = loading the focal tables themselves
+    (if (or (zero? remaining-hops) (empty? frontier))
+      {:tables-by-id  tables-by-id
+       :fields-by-table fields-by-table
+       :field->table  field->table
+       :all-table-ids (set (keys tables-by-id))}
+      (let [{new-tables-by-id :tables-by-id
+             new-table-ids    :table-ids}  (fetch-readable-tables frontier)
+            new-fields                     (fetch-fields-for-tables new-table-ids)
+            new-fields-by-table            (group-by :table_id new-fields)
+            new-field->table               (into {} (map (fn [f] [(:id f) (:table_id f)])) new-fields)
+            ;; Merge into accumulated state
+            tables-by-id'                  (merge tables-by-id new-tables-by-id)
+            fields-by-table'               (merge fields-by-table new-fields-by-table)
+            field->table'                  (merge field->table new-field->table)
+            ;; Discover next frontier: tables reachable via FKs not yet loaded
+            next-frontier                  (discover-fk-targets new-fields (set (keys tables-by-id')))]
+        (recur tables-by-id' fields-by-table' field->table' next-frontier (dec remaining-hops))))))
+
+;;; ---------------------------------------- Phase 3: Build response ----------------------------------------
+
+(defn build-erd-field
+  "Convert a field to the ERD field shape."
+  [field field->table]
+  {:id                 (:id field)
+   :name               (:name field)
+   :display_name       (:display_name field)
+   :database_type      (:database_type field)
+   :semantic_type      (some-> (:semantic_type field) u/qualified-name)
+   :fk_target_field_id (:fk_target_field_id field)
+   :fk_target_table_id (some-> (:fk_target_field_id field) field->table)})
+
+(defn build-erd-node
+  "Build an ERD node for a table with its fields."
+  [table fields is-focal field->table]
+  {:table_id     (:id table)
+   :name         (:name table)
+   :display_name (:display_name table)
+   :schema       (:schema table)
+   :db_id        (:db_id table)
+   :is_focal     is-focal
+   :fields       (mapv #(build-erd-field % field->table) fields)})
+
+(defn build-erd-edges
+  "Build ERD edges from fields, filtered to only include edges between visible tables."
+  [fields-by-table field->table visible-table-ids]
+  (let [all-fields (mapcat val fields-by-table)
+        field-by-id (into {} (map (fn [f] [(:id f) f])) all-fields)]
+    (->> all-fields
+         (keep (fn [field]
+                 (when-let [target-field-id (:fk_target_field_id field)]
+                   (let [target-table (field->table target-field-id)
+                         target-field (field-by-id target-field-id)]
+                     (when (and target-table
+                                target-field
+                                (contains? visible-table-ids (:table_id field))
+                                (contains? visible-table-ids target-table))
+                       {:source_table_id (:table_id field)
+                        :source_field_id (:id field)
+                        :target_table_id target-table
+                        :target_field_id target-field-id
+                        :relationship    (if (and (:database_is_pk field)
+                                                  (:database_is_pk target-field))
+                                           "one-to-one"
+                                           "many-to-one")})))))
+         vec)))
+
+(defn build-erd-response
+  "Build the ERD response from fetched subgraph data."
+  [{:keys [tables-by-id fields-by-table field->table all-table-ids]} focal-table-ids]
+  (let [nodes (->> all-table-ids
+                   (keep (fn [tid]
+                           (when-let [table (tables-by-id tid)]
+                             (build-erd-node table
+                                             (get fields-by-table tid [])
+                                             (contains? focal-table-ids tid)
+                                             field->table))))
+                   vec)
+        edges (build-erd-edges fields-by-table field->table all-table-ids)]
+    {:nodes nodes
+     :edges edges}))
+
+;;; ---------------------------------------- Main entry point ----------------------------------------
+
+(def ^:private max-hops 5)
+(def ^:private default-hops 2)
+
+(defn erd
+  "Return an ERD for the given database, optionally scoped to specific tables/schema.
+   When `table-ids` is provided, those tables are the focal points.
+   When only `database-id` is provided, auto-selects the most connected tables.
+   The `hops` parameter controls how many FK hops to traverse (default: 2, max: 5)."
+  [{:keys [database-id table-ids schema hops]}]
+  (api/read-check :model/Database database-id)
+  (let [hops            (min (or hops default-hops) max-hops)
+        focal-table-ids (if (seq table-ids)
+                          (set table-ids)
+                          (auto-discover-focal-table-ids database-id schema))
+        subgraph        (fetch-erd-subgraph focal-table-ids hops)]
+    (build-erd-response subgraph focal-table-ids)))

--- a/enterprise/backend/src/metabase_enterprise/dependencies/erd.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/erd.clj
@@ -59,17 +59,23 @@
   "Number of tables to auto-select as focal when none are specified."
   3)
 
+(def ^:private ^{:doc "Columns needed for mi/can-read? permission checks on Table."}
+  table-perm-columns
+  [:id :db_id :is_published :collection_id])
+
 (defn- auto-discover-focal-table-ids
   "Find the top N tables by FK relationship count using a SQL aggregate query.
    Only considers readable tables. Returns a set of table IDs."
   [database-id schema]
-  (let [readable-tables (filter mi/can-read?
-                                (t2/select :model/Table
-                                           {:where (cond-> [:and
-                                                            [:= :db_id database-id]
-                                                            [:= :active true]]
-                                                     schema (conj [:= :schema schema]))}))
-        readable-ids    (set (map :id readable-tables))]
+  (let [readable-ids (->> (t2/select :model/Table
+                                     {:select table-perm-columns
+                                      :where  (cond-> [:and
+                                                       [:= :db_id database-id]
+                                                       [:= :active true]]
+                                                schema (conj [:= :schema schema]))})
+                          (filter mi/can-read?)
+                          (map :id)
+                          set)]
     (when (empty? readable-ids)
       (throw (ex-info (tru "No tables found in the specified database/schema")
                       {:status-code 404
@@ -87,9 +93,9 @@
                                :order-by [[:cnt :desc]]
                                :limit    auto-focal-table-count})
           top-ids   (set (map :tid fk-counts))]
-      ;; If no tables have FKs, just pick the first N readable tables
+      ;; If no tables have FKs, just pick the first N readable IDs
       (if (empty? top-ids)
-        (->> readable-tables (take auto-focal-table-count) (map :id) set)
+        (set (take auto-focal-table-count readable-ids))
         top-ids))))
 
 ;;; ---------------------------------------- Phase 2: Lazy BFS fetch ----------------------------------------
@@ -117,110 +123,115 @@
 
 (defn- discover-fk-targets
   "Given a collection of fields, find FK target field IDs that point to tables
-   we haven't loaded yet. Returns the set of new table IDs to fetch."
-  [fields known-table-ids]
-  (let [target-field-ids (->> fields
-                              (keep :fk_target_field_id)
-                              set)]
+   we haven't loaded yet. Returns the set of new table IDs to fetch.
+   Checks `field-by-id` first and only queries the DB for unknown target fields."
+  [fields known-table-ids field-by-id]
+  (let [target-field-ids (->> fields (keep :fk_target_field_id) set)]
     (if (empty? target-field-ids)
       #{}
-      (let [target-fields (t2/select :model/Field
-                                     :id [:in target-field-ids]
-                                     :active true
-                                     :visibility_type [:not= "retired"])]
-        (->> target-fields
-             (map :table_id)
-             set
-             (#(set/difference % known-table-ids)))))))
+      (let [unknown-fids (remove field-by-id target-field-ids)
+            ;; Resolve known targets from the accumulated map
+            table-ids    (into #{} (keep (comp :table_id field-by-id)) target-field-ids)
+            ;; Query DB only for truly unknown target fields
+            table-ids    (if (seq unknown-fids)
+                           (into table-ids
+                                 (map :table_id)
+                                 (t2/select :model/Field
+                                            :id [:in unknown-fids]
+                                            :active true
+                                            :visibility_type [:not= "retired"]))
+                           table-ids)]
+        (set/difference table-ids known-table-ids)))))
 
 (defn- fetch-erd-subgraph
   "Iteratively expand from focal tables by following FK relationships for n hops.
    Each hop fetches only newly-discovered tables and their fields.
-   Returns {:tables-by-id, :fields-by-table, :field->table, :all-table-ids}."
+   Returns {:tables-by-id, :fields-by-table, :field-by-id, :all-table-ids}."
   [focal-table-ids hops]
   (loop [tables-by-id    {}
          fields-by-table {}
-         field->table    {}
+         field-by-id     {}
          frontier        focal-table-ids
          remaining-hops  (inc hops)] ;; inc because hop 0 = loading the focal tables themselves
     (if (or (zero? remaining-hops) (empty? frontier))
-      {:tables-by-id  tables-by-id
+      {:tables-by-id   tables-by-id
        :fields-by-table fields-by-table
-       :field->table  field->table
-       :all-table-ids (set (keys tables-by-id))}
+       :field-by-id    field-by-id
+       :all-table-ids  (set (keys tables-by-id))}
       (let [{new-tables-by-id :tables-by-id
-             new-table-ids    :table-ids}  (fetch-readable-tables frontier)
+             new-table-ids    :table-ids}  (or (fetch-readable-tables frontier)
+                                               {:tables-by-id {} :table-ids #{}})
             new-fields                     (fetch-fields-for-tables new-table-ids)
             new-fields-by-table            (group-by :table_id new-fields)
-            new-field->table               (into {} (map (fn [f] [(:id f) (:table_id f)])) new-fields)
+            new-field-by-id                (into {} (map (fn [f] [(:id f) f])) new-fields)
             ;; Merge into accumulated state
             tables-by-id'                  (merge tables-by-id new-tables-by-id)
             fields-by-table'               (merge fields-by-table new-fields-by-table)
-            field->table'                  (merge field->table new-field->table)
+            field-by-id'                   (merge field-by-id new-field-by-id)
             ;; Discover next frontier: tables reachable via FKs not yet loaded
-            next-frontier                  (discover-fk-targets new-fields (set (keys tables-by-id')))]
-        (recur tables-by-id' fields-by-table' field->table' next-frontier (dec remaining-hops))))))
+            next-frontier                  (discover-fk-targets new-fields (set (keys tables-by-id')) field-by-id')]
+        (recur tables-by-id' fields-by-table' field-by-id' next-frontier (dec remaining-hops))))))
 
 ;;; ---------------------------------------- Phase 3: Build response ----------------------------------------
 
 (defn build-erd-field
-  "Convert a field to the ERD field shape."
-  [field field->table]
-  {:id                 (:id field)
-   :name               (:name field)
-   :display_name       (:display_name field)
-   :database_type      (:database_type field)
-   :semantic_type      (some-> (:semantic_type field) u/qualified-name)
-   :fk_target_field_id (:fk_target_field_id field)
-   :fk_target_table_id (some-> (:fk_target_field_id field) field->table)})
+  "Convert a field to the ERD field shape.
+   Nils out FK target references when the target table isn't in the visible graph,
+   so we don't leak field/table IDs the user can't access."
+  [field field-by-id]
+  (let [target-table-id (some-> (:fk_target_field_id field) field-by-id :table_id)]
+    {:id                 (:id field)
+     :name               (:name field)
+     :display_name       (:display_name field)
+     :database_type      (:database_type field)
+     :semantic_type      (some-> (:semantic_type field) u/qualified-name)
+     :fk_target_field_id (when target-table-id (:fk_target_field_id field))
+     :fk_target_table_id target-table-id}))
 
 (defn build-erd-node
   "Build an ERD node for a table with its fields."
-  [table fields is-focal field->table]
+  [table fields is-focal field-by-id]
   {:table_id     (:id table)
    :name         (:name table)
    :display_name (:display_name table)
    :schema       (:schema table)
    :db_id        (:db_id table)
    :is_focal     is-focal
-   :fields       (mapv #(build-erd-field % field->table) fields)})
+   :fields       (mapv #(build-erd-field % field-by-id) fields)})
 
 (defn build-erd-edges
   "Build ERD edges from fields, filtered to only include edges between visible tables."
-  [fields-by-table field->table visible-table-ids]
-  (let [all-fields (mapcat val fields-by-table)
-        field-by-id (into {} (map (fn [f] [(:id f) f])) all-fields)]
+  [fields-by-table field-by-id visible-table-ids]
+  (let [all-fields (mapcat val fields-by-table)]
     (->> all-fields
          (keep (fn [field]
                  (when-let [target-field-id (:fk_target_field_id field)]
-                   (let [target-table (field->table target-field-id)
-                         target-field (field-by-id target-field-id)]
-                     (when (and target-table
-                                target-field
-                                (contains? visible-table-ids (:table_id field))
-                                (contains? visible-table-ids target-table))
-                       {:source_table_id (:table_id field)
-                        :source_field_id (:id field)
-                        :target_table_id target-table
-                        :target_field_id target-field-id
-                        :relationship    (if (and (:database_is_pk field)
-                                                  (:database_is_pk target-field))
-                                           "one-to-one"
-                                           "many-to-one")})))))
+                   (when-let [target-field (field-by-id target-field-id)]
+                     (let [target-table (:table_id target-field)]
+                       (when (and (contains? visible-table-ids (:table_id field))
+                                  (contains? visible-table-ids target-table))
+                         {:source_table_id (:table_id field)
+                          :source_field_id (:id field)
+                          :target_table_id target-table
+                          :target_field_id target-field-id
+                          :relationship    (if (and (:database_is_pk field)
+                                                    (:database_is_pk target-field))
+                                             "one-to-one"
+                                             "many-to-one")}))))))
          vec)))
 
 (defn build-erd-response
   "Build the ERD response from fetched subgraph data."
-  [{:keys [tables-by-id fields-by-table field->table all-table-ids]} focal-table-ids]
+  [{:keys [tables-by-id fields-by-table field-by-id all-table-ids]} focal-table-ids]
   (let [nodes (->> all-table-ids
                    (keep (fn [tid]
                            (when-let [table (tables-by-id tid)]
                              (build-erd-node table
                                              (get fields-by-table tid [])
                                              (contains? focal-table-ids tid)
-                                             field->table))))
+                                             field-by-id))))
                    vec)
-        edges (build-erd-edges fields-by-table field->table all-table-ids)]
+        edges (build-erd-edges fields-by-table field-by-id all-table-ids)]
     {:nodes nodes
      :edges edges}))
 

--- a/enterprise/backend/test/metabase_enterprise/dependencies/erd_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/erd_test.clj
@@ -1,0 +1,240 @@
+(ns metabase-enterprise.dependencies.erd-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase-enterprise.dependencies.erd :as erd]
+   [metabase.test :as mt]))
+
+;;; ---------------------------------------- Pure function tests ----------------------------------------
+
+(deftest build-erd-field-test
+  (testing "basic field without FK"
+    (let [field        {:id 1 :name "id" :display_name "ID"
+                        :database_type "INTEGER" :semantic_type :type/PK
+                        :fk_target_field_id nil}
+          field->table {}]
+      (is (= {:id                 1
+              :name               "id"
+              :display_name       "ID"
+              :database_type      "INTEGER"
+              :semantic_type      "type/PK"
+              :fk_target_field_id nil
+              :fk_target_table_id nil}
+             (erd/build-erd-field field field->table)))))
+
+  (testing "FK field resolves target table"
+    (let [field        {:id 2 :name "product_id" :display_name "Product ID"
+                        :database_type "INTEGER" :semantic_type :type/FK
+                        :fk_target_field_id 10}
+          field->table {10 100}]
+      (is (= {:id                 2
+              :name               "product_id"
+              :display_name       "Product ID"
+              :database_type      "INTEGER"
+              :semantic_type      "type/FK"
+              :fk_target_field_id 10
+              :fk_target_table_id 100}
+             (erd/build-erd-field field field->table)))))
+
+  (testing "nil semantic_type stays nil"
+    (let [field {:id 3 :name "x" :display_name "X"
+                 :database_type "TEXT" :semantic_type nil
+                 :fk_target_field_id nil}]
+      (is (nil? (:semantic_type (erd/build-erd-field field {})))))))
+
+(deftest build-erd-node-test
+  (let [table        {:id 1 :name "ORDERS" :display_name "Orders"
+                      :schema "PUBLIC" :db_id 1}
+        fields       [{:id 10 :name "id" :display_name "ID"
+                       :database_type "INTEGER" :semantic_type :type/PK
+                       :fk_target_field_id nil}
+                      {:id 11 :name "product_id" :display_name "Product ID"
+                       :database_type "INTEGER" :semantic_type :type/FK
+                       :fk_target_field_id 20}]
+        field->table {20 2}
+        node         (erd/build-erd-node table fields true field->table)]
+    (testing "node has correct table metadata"
+      (is (= 1 (:table_id node)))
+      (is (= "ORDERS" (:name node)))
+      (is (= "Orders" (:display_name node)))
+      (is (= "PUBLIC" (:schema node)))
+      (is (= 1 (:db_id node)))
+      (is (true? (:is_focal node))))
+
+    (testing "node includes all fields"
+      (is (= 2 (count (:fields node)))))
+
+    (testing "FK field resolves target table in node context"
+      (let [fk-field (second (:fields node))]
+        (is (= 2 (:fk_target_table_id fk-field)))))))
+
+(deftest build-erd-edges-test
+  (let [;; Table 1 has a FK field (id=11) pointing to table 2's field (id=20)
+        fields-by-table {1 [{:id 10 :name "id" :table_id 1
+                             :database_type "INTEGER" :semantic_type :type/PK
+                             :fk_target_field_id nil :database_is_pk true}
+                            {:id 11 :name "product_id" :table_id 1
+                             :database_type "INTEGER" :semantic_type :type/FK
+                             :fk_target_field_id 20 :database_is_pk false}]
+                         2 [{:id 20 :name "id" :table_id 2
+                             :database_type "INTEGER" :semantic_type :type/PK
+                             :fk_target_field_id nil :database_is_pk true}]}
+        field->table    {10 1 11 1 20 2}
+        visible-ids     #{1 2}]
+
+    (testing "produces edge for FK relationship"
+      (let [edges (erd/build-erd-edges fields-by-table field->table visible-ids)]
+        (is (= 1 (count edges)))
+        (is (= {:source_table_id 1
+                :source_field_id 11
+                :target_table_id 2
+                :target_field_id 20
+                :relationship    "many-to-one"}
+               (first edges)))))
+
+    (testing "excludes edges to tables not in visible set"
+      (let [edges (erd/build-erd-edges fields-by-table field->table #{1})]
+        (is (empty? edges))))
+
+    (testing "one-to-one when both fields are PK"
+      (let [fields-both-pk {1 [{:id 11 :name "user_id" :table_id 1
+                                :database_type "INTEGER" :semantic_type :type/FK
+                                :fk_target_field_id 20 :database_is_pk true}]
+                            2 [{:id 20 :name "id" :table_id 2
+                                :database_type "INTEGER" :semantic_type :type/PK
+                                :fk_target_field_id nil :database_is_pk true}]}
+            edges          (erd/build-erd-edges fields-both-pk field->table visible-ids)]
+        (is (= "one-to-one" (:relationship (first edges))))))))
+
+(deftest build-erd-response-test
+  (let [table1   {:id 1 :name "ORDERS" :display_name "Orders" :schema "PUBLIC" :db_id 1}
+        table2   {:id 2 :name "PRODUCTS" :display_name "Products" :schema "PUBLIC" :db_id 1}
+        field1   {:id 10 :name "id" :table_id 1 :display_name "ID"
+                  :database_type "INT" :semantic_type :type/PK :fk_target_field_id nil}
+        field2   {:id 11 :name "product_id" :table_id 1 :display_name "Product ID"
+                  :database_type "INT" :semantic_type :type/FK :fk_target_field_id 20}
+        field3   {:id 20 :name "id" :table_id 2 :display_name "ID"
+                  :database_type "INT" :semantic_type :type/PK :fk_target_field_id nil}
+        subgraph {:tables-by-id    {1 table1 2 table2}
+                  :fields-by-table {1 [field1 field2] 2 [field3]}
+                  :field->table    {10 1 11 1 20 2}
+                  :all-table-ids   #{1 2}}
+        response (erd/build-erd-response subgraph #{1})]
+
+    (testing "response has nodes and edges"
+      (is (= 2 (count (:nodes response))))
+      (is (= 1 (count (:edges response)))))
+
+    (testing "focal table is marked correctly"
+      (let [nodes-by-id (into {} (map (fn [n] [(:table_id n) n])) (:nodes response))]
+        (is (true? (:is_focal (nodes-by-id 1))))
+        (is (false? (:is_focal (nodes-by-id 2))))))))
+
+;;; ---------------------------------------- Integration tests (via HTTP) ----------------------------------------
+
+(deftest erd-endpoint-with-explicit-tables-test
+  (mt/with-premium-features #{:dependencies}
+    (testing "GET /api/ee/dependencies/erd with explicit table-ids"
+      (let [orders-id   (mt/id :orders)
+            products-id (mt/id :products)
+            response    (mt/user-http-request :rasta :get 200 "ee/dependencies/erd"
+                                              :database-id (mt/id)
+                                              :table-ids   orders-id
+                                              :table-ids   products-id
+                                              :hops        0)]
+        (testing "returns exactly the requested tables when hops=0"
+          (is (= #{orders-id products-id}
+                 (set (map :table_id (:nodes response))))))
+
+        (testing "all nodes have required keys"
+          (doseq [node (:nodes response)]
+            (is (contains? node :table_id))
+            (is (contains? node :name))
+            (is (contains? node :display_name))
+            (is (contains? node :db_id))
+            (is (contains? node :is_focal))
+            (is (contains? node :fields))))
+
+        (testing "focal tables are marked correctly"
+          (doseq [node (:nodes response)]
+            (is (true? (:is_focal node)))))
+
+        (testing "edges have required keys"
+          (doseq [edge (:edges response)]
+            (is (contains? edge :source_table_id))
+            (is (contains? edge :source_field_id))
+            (is (contains? edge :target_table_id))
+            (is (contains? edge :target_field_id))
+            (is (contains? edge :relationship))))))))
+
+(deftest erd-endpoint-with-hops-test
+  (mt/with-premium-features #{:dependencies}
+    (testing "GET /api/ee/dependencies/erd with hops expands to related tables"
+      (let [orders-id (mt/id :orders)
+            response  (mt/user-http-request :rasta :get 200 "ee/dependencies/erd"
+                                            :database-id (mt/id)
+                                            :table-ids   orders-id
+                                            :hops        1)]
+        (testing "orders has FKs to products and people, so both should appear"
+          (let [table-ids (set (map :table_id (:nodes response)))]
+            (is (contains? table-ids orders-id))
+            (is (contains? table-ids (mt/id :products)))
+            (is (contains? table-ids (mt/id :people)))))
+
+        (testing "orders is focal, related tables are not"
+          (let [nodes-by-id (into {} (map (fn [n] [(:table_id n) n])) (:nodes response))]
+            (is (true? (:is_focal (nodes-by-id orders-id))))
+            (is (false? (:is_focal (nodes-by-id (mt/id :products)))))
+            (is (false? (:is_focal (nodes-by-id (mt/id :people)))))))
+
+        (testing "has edges connecting orders to products and people"
+          (let [edge-pairs (set (map (fn [e] [(:source_table_id e) (:target_table_id e)])
+                                     (:edges response)))]
+            (is (contains? edge-pairs [orders-id (mt/id :products)]))
+            (is (contains? edge-pairs [orders-id (mt/id :people)]))))))))
+
+(deftest erd-endpoint-auto-discover-test
+  (mt/with-premium-features #{:dependencies}
+    (testing "GET /api/ee/dependencies/erd auto-discovers focal tables when none specified"
+      (let [response (mt/user-http-request :rasta :get 200 "ee/dependencies/erd"
+                                           :database-id (mt/id))]
+        (testing "returns nodes and edges"
+          (is (seq (:nodes response)))
+          (is (seq (:edges response))))
+
+        (testing "some nodes are focal"
+          (is (some :is_focal (:nodes response))))
+
+        (testing "some nodes are non-focal (discovered via hops)"
+          (is (some (complement :is_focal) (:nodes response))))))))
+
+(deftest erd-endpoint-hops-zero-test
+  (mt/with-premium-features #{:dependencies}
+    (testing "hops=0 returns only focal tables with no expansion"
+      (let [orders-id (mt/id :orders)
+            response  (mt/user-http-request :rasta :get 200 "ee/dependencies/erd"
+                                            :database-id (mt/id)
+                                            :table-ids   orders-id
+                                            :hops        0)]
+        (is (= #{orders-id} (set (map :table_id (:nodes response)))))))))
+
+(deftest erd-endpoint-schema-filter-test
+  (mt/with-premium-features #{:dependencies}
+    (testing "schema param filters auto-discovery to that schema"
+      (let [response (mt/user-http-request :rasta :get 200 "ee/dependencies/erd"
+                                           :database-id (mt/id)
+                                           :schema      "PUBLIC")]
+        (testing "all nodes belong to the specified schema"
+          (doseq [node (:nodes response)]
+            (is (= "PUBLIC" (:schema node)))))))))
+
+(deftest erd-endpoint-requires-premium-feature-test
+  (testing "without :dependencies feature returns 402"
+    (mt/with-premium-features #{}
+      (mt/user-http-request :rasta :get 402 "ee/dependencies/erd"
+                            :database-id (mt/id)))))
+
+(deftest erd-endpoint-invalid-database-test
+  (mt/with-premium-features #{:dependencies}
+    (testing "non-existent database returns 404"
+      (mt/user-http-request :rasta :get 404 "ee/dependencies/erd"
+                            :database-id Integer/MAX_VALUE))))

--- a/enterprise/backend/test/metabase_enterprise/dependencies/erd_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/erd_test.clj
@@ -1,38 +1,30 @@
 (ns metabase-enterprise.dependencies.erd-test
   (:require
    [clojure.test :refer :all]
-   [metabase-enterprise.dependencies.erd :as erd]
    [metabase.permissions.core :as perms]
    [metabase.permissions.models.data-permissions :as data-perms]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [metabase.util :as u]))
 
 ;;; ---------------------------------------- Test helpers ----------------------------------------
 
-(defn- ->field-by-id
-  "Build a field-by-id map from a collection of fields."
-  [fields]
-  (into {} (map (fn [f] [(:id f) f])) fields))
-
-(defn- node-by-table
-  "Find an ERD node by table keyword (e.g. :orders) or table ID."
-  [response table-or-id]
-  (let [tid (if (keyword? table-or-id) (mt/id table-or-id) table-or-id)]
-    (some #(when (= tid (:table_id %)) %) (:nodes response))))
-
-(defn- edge-between
-  "Find an ERD edge from source to target (keywords or IDs)."
-  [response source-table target-table]
-  (let [src (if (keyword? source-table) (mt/id source-table) source-table)
-        tgt (if (keyword? target-table) (mt/id target-table) target-table)]
-    (some #(when (and (= src (:source_table_id %))
-                      (= tgt (:target_table_id %)))
-             %)
-          (:edges response))))
-
-(defn- table-ids
-  "Set of all table IDs in an ERD response."
+(defn- graph-shape
+  "Distill an ERD response into a readable topology map.
+   Returns e.g. {:orders  {:focal true  :fk [:people :products]}
+                 :people  {:focal false :fk []}}
+   Table names are lowercased keywords, FK targets are sorted."
   [response]
-  (set (map :table_id (:nodes response))))
+  (let [id->name    (into {} (map (fn [n] [(:table_id n)
+                                           (keyword (u/lower-case-en (:name n)))]))
+                          (:nodes response))
+        edges-by-src (group-by :source_table_id (:edges response))]
+    (into (sorted-map)
+          (map (fn [node]
+                 [(keyword (u/lower-case-en (:name node)))
+                  {:focal (:is_focal node)
+                   :fk    (vec (sort (keep #(id->name (:target_table_id %))
+                                           (edges-by-src (:table_id node)))))}]))
+          (:nodes response))))
 
 (defn- erd-request!
   "Make an ERD endpoint request. `opts` is a map with optional keys
@@ -46,289 +38,175 @@
                      [k v]))
                  opts)))
 
-;;; ---------------------------------------- Pure function tests ----------------------------------------
+(defn- grant-table-read!
+  "Grant view-data + create-queries on a table for a permission group."
+  [group-id table-id]
+  (data-perms/set-table-permission! group-id table-id :perms/view-data :unrestricted)
+  (data-perms/set-table-permission! group-id table-id :perms/create-queries :query-builder))
 
-(deftest ^:parallel build-erd-field-test
-  (testing "basic field without FK"
-    (let [field {:id 1 :name "id" :display_name "ID"
-                 :database_type "INTEGER" :semantic_type :type/PK
-                 :fk_target_field_id nil}]
-      (is (= {:id                 1
-              :name               "id"
-              :display_name       "ID"
-              :database_type      "INTEGER"
-              :semantic_type      "type/PK"
-              :fk_target_field_id nil
-              :fk_target_table_id nil}
-             (erd/build-erd-field field {})))))
+;;; ---------------------------------------- Graph tests (e2e) ----------------------------------------
 
-  (testing "FK field resolves target table"
-    (let [field        {:id 2 :name "product_id" :display_name "Product ID"
-                        :database_type "INTEGER" :semantic_type :type/FK
-                        :fk_target_field_id 10}
-          target-field {:id 10 :name "id" :table_id 100}
-          field-by-id  (->field-by-id [target-field])]
-      (is (= {:id                 2
-              :name               "product_id"
-              :display_name       "Product ID"
-              :database_type      "INTEGER"
-              :semantic_type      "type/FK"
-              :fk_target_field_id 10
-              :fk_target_table_id 100}
-             (erd/build-erd-field field field-by-id)))))
+;; Sample dataset FK graph:
+;;   orders → products  (via product_id)
+;;   orders → people    (via user_id)
+;;   reviews → products (via product_id)
 
-  (testing "nil semantic_type stays nil"
-    (let [field {:id 3 :name "x" :display_name "X"
-                 :database_type "TEXT" :semantic_type nil
-                 :fk_target_field_id nil}]
-      (is (nil? (:semantic_type (erd/build-erd-field field {}))))))
-
-  (testing "FK target not in visible graph nils out both FK references"
-    (let [field  {:id 2 :name "product_id" :display_name "Product ID"
-                  :database_type "INTEGER" :semantic_type :type/FK
-                  :fk_target_field_id 10}
-          result (erd/build-erd-field field {})]
-      (is (nil? (:fk_target_field_id result)))
-      (is (nil? (:fk_target_table_id result))))))
-
-(deftest ^:parallel build-erd-node-test
-  (testing "focal node with fields"
-    (let [table       {:id 1 :name "ORDERS" :display_name "Orders"
-                       :schema "PUBLIC" :db_id 1}
-          fields      [{:id 10 :name "id" :display_name "ID"
-                        :database_type "INTEGER" :semantic_type :type/PK
-                        :fk_target_field_id nil}
-                       {:id 11 :name "product_id" :display_name "Product ID"
-                        :database_type "INTEGER" :semantic_type :type/FK
-                        :fk_target_field_id 20}]
-          field-by-id (->field-by-id [{:id 20 :name "id" :table_id 2}])
-          node        (erd/build-erd-node table fields true field-by-id)]
-      (is (= {:table_id 1 :name "ORDERS" :display_name "Orders"
-              :schema "PUBLIC" :db_id 1 :is_focal true}
-             (dissoc node :fields)))
-      (is (= 2 (count (:fields node))))
-      (is (= 2 (:fk_target_table_id (second (:fields node)))))))
-
-  (testing "non-focal node"
-    (let [table {:id 2 :name "PRODUCTS" :display_name "Products"
-                 :schema "PUBLIC" :db_id 1}
-          node  (erd/build-erd-node table [] false {})]
-      (is (false? (:is_focal node)))))
-
-  (testing "table with no fields produces empty fields vector"
-    (let [table {:id 3 :name "EMPTY" :display_name "Empty" :schema nil :db_id 1}
-          node  (erd/build-erd-node table [] true {})]
-      (is (= [] (:fields node))))))
-
-(deftest ^:parallel build-erd-edges-test
-  (let [;; Table 1 has a FK field (id=11) pointing to table 2's field (id=20)
-        fields-by-table {1 [{:id 10 :name "id" :table_id 1
-                             :database_type "INTEGER" :semantic_type :type/PK
-                             :fk_target_field_id nil :database_is_pk true}
-                            {:id 11 :name "product_id" :table_id 1
-                             :database_type "INTEGER" :semantic_type :type/FK
-                             :fk_target_field_id 20 :database_is_pk false}]
-                         2 [{:id 20 :name "id" :table_id 2
-                             :database_type "INTEGER" :semantic_type :type/PK
-                             :fk_target_field_id nil :database_is_pk true}]}
-        field-by-id     (->field-by-id (mapcat val fields-by-table))
-        visible-ids     #{1 2}]
-
-    (testing "produces edge for FK relationship"
-      (let [edges (erd/build-erd-edges fields-by-table field-by-id visible-ids)]
-        (is (= 1 (count edges)))
-        (is (= {:source_table_id 1
-                :source_field_id 11
-                :target_table_id 2
-                :target_field_id 20
-                :relationship    "many-to-one"}
-               (first edges)))))
-
-    (testing "excludes edges when target table not in visible set"
-      (is (empty? (erd/build-erd-edges fields-by-table field-by-id #{1}))))
-
-    (testing "excludes edges when source table not in visible set"
-      (is (empty? (erd/build-erd-edges fields-by-table field-by-id #{2}))))
-
-    (testing "empty fields-by-table produces no edges"
-      (is (empty? (erd/build-erd-edges {} field-by-id visible-ids))))
-
-    (testing "one-to-one when both fields are PK"
-      (let [fields-both-pk {1 [{:id 11 :name "user_id" :table_id 1
-                                :database_type "INTEGER" :semantic_type :type/FK
-                                :fk_target_field_id 20 :database_is_pk true}]
-                            2 [{:id 20 :name "id" :table_id 2
-                                :database_type "INTEGER" :semantic_type :type/PK
-                                :fk_target_field_id nil :database_is_pk true}]}
-            field-by-id-pk (->field-by-id (mapcat val fields-both-pk))
-            edges          (erd/build-erd-edges fields-both-pk field-by-id-pk visible-ids)]
-        (is (= "one-to-one" (:relationship (first edges))))))))
-
-(deftest ^:parallel build-erd-response-test
-  (let [table1   {:id 1 :name "ORDERS" :display_name "Orders" :schema "PUBLIC" :db_id 1}
-        table2   {:id 2 :name "PRODUCTS" :display_name "Products" :schema "PUBLIC" :db_id 1}
-        field1   {:id 10 :name "id" :table_id 1 :display_name "ID"
-                  :database_type "INT" :semantic_type :type/PK :fk_target_field_id nil}
-        field2   {:id 11 :name "product_id" :table_id 1 :display_name "Product ID"
-                  :database_type "INT" :semantic_type :type/FK :fk_target_field_id 20}
-        field3   {:id 20 :name "id" :table_id 2 :display_name "ID"
-                  :database_type "INT" :semantic_type :type/PK :fk_target_field_id nil}
-        subgraph {:tables-by-id    {1 table1 2 table2}
-                  :fields-by-table {1 [field1 field2] 2 [field3]}
-                  :field-by-id     (->field-by-id [field1 field2 field3])
-                  :all-table-ids   #{1 2}}]
-
-    (testing "response has nodes and edges"
-      (let [response (erd/build-erd-response subgraph #{1})]
-        (is (= 2 (count (:nodes response))))
-        (is (= 1 (count (:edges response))))))
-
-    (testing "focal table is marked correctly"
-      (let [nodes-by-id (->> (erd/build-erd-response subgraph #{1})
-                             :nodes
-                             (into {} (map (fn [n] [(:table_id n) n]))))]
-        (is (true? (:is_focal (nodes-by-id 1))))
-        (is (false? (:is_focal (nodes-by-id 2))))))
-
-    (testing "focal table not in tables-by-id is silently excluded"
-      (let [response (erd/build-erd-response subgraph #{1 999})]
-        (is (= 2 (count (:nodes response))))
-        (is (true? (:is_focal (first (filter #(= 1 (:table_id %)) (:nodes response))))))))))
-
-;;; ---------------------------------------- Integration tests (via HTTP) ----------------------------------------
-
-(deftest erd-endpoint-with-explicit-tables-test
+(deftest erd-graph-single-focal-test
   (mt/with-premium-features #{:dependencies}
-    (testing "GET /api/ee/dependencies/erd with explicit table-ids, hops=0"
-      (let [response (erd-request! {:table-ids [(mt/id :orders) (mt/id :products)]
-                                    :hops      0})]
-        (testing "returns exactly the requested focal tables"
-          (is (= #{(mt/id :orders) (mt/id :products)} (table-ids response))))
+    (testing "single focal table with hops=1 expands to FK neighbors"
+      (is (= {:orders   {:focal true  :fk [:people :products]}
+              :people   {:focal false :fk []}
+              :products {:focal false :fk []}}
+             (graph-shape (erd-request! {:table-ids [(mt/id :orders)]
+                                         :hops      1})))))
 
-        (testing "nodes have correct shape"
-          (is (=? {:table_id     (mt/id :orders)
-                   :name         "ORDERS"
-                   :display_name "Orders"
-                   :db_id        (mt/id)
-                   :schema       "PUBLIC"
-                   :is_focal     true
-                   :fields       sequential?}
-                  (node-by-table response :orders)))
-          (is (=? {:table_id (mt/id :products)
-                   :is_focal true}
-                  (node-by-table response :products))))
+    (testing "hops=0 returns focal table alone with no edges"
+      (is (= {:orders {:focal true :fk []}}
+             (graph-shape (erd-request! {:table-ids [(mt/id :orders)]
+                                         :hops      0})))))
 
-        (testing "each field has the expected shape"
-          (is (=? {:id                 pos-int?
-                   :name               string?
-                   :display_name       string?
-                   :database_type      string?}
-                  (first (:fields (node-by-table response :orders))))))))))
+    (testing "table with no outbound FKs stays isolated regardless of hops"
+      (is (= {:products {:focal true :fk []}}
+             (graph-shape (erd-request! {:table-ids [(mt/id :products)]
+                                         :hops      2})))))))
 
-(deftest erd-endpoint-with-hops-test
+(deftest erd-graph-multi-focal-test
   (mt/with-premium-features #{:dependencies}
-    (testing "hops=1 from orders expands to products and people via outbound FKs"
-      (let [response (erd-request! {:table-ids [(mt/id :orders)]
-                                    :hops      1})]
-        (testing "focal + related tables present"
-          (is (=? {:table_id (mt/id :orders)  :is_focal true}  (node-by-table response :orders)))
-          (is (=? {:table_id (mt/id :products) :is_focal false} (node-by-table response :products)))
-          (is (=? {:table_id (mt/id :people)   :is_focal false} (node-by-table response :people))))
+    (testing "two focals sharing an FK target — target discovered once, both have edges"
+      (is (= {:orders   {:focal true  :fk [:people :products]}
+              :people   {:focal false :fk []}
+              :products {:focal false :fk []}
+              :reviews  {:focal true  :fk [:products]}}
+             (graph-shape (erd-request! {:table-ids [(mt/id :orders) (mt/id :reviews)]
+                                         :hops      1})))))
 
-        (testing "edges connect orders to its FK targets"
-          (is (=? {:source_table_id (mt/id :orders)
-                   :target_table_id (mt/id :products)
-                   :relationship    "many-to-one"}
-                  (edge-between response :orders :products)))
-          (is (=? {:source_table_id (mt/id :orders)
-                   :target_table_id (mt/id :people)
-                   :relationship    "many-to-one"}
-                  (edge-between response :orders :people))))))))
+    (testing "when FK target is also focal, is_focal reflects that"
+      (is (= {:orders   {:focal true :fk [:people :products]}
+              :people   {:focal false :fk []}
+              :products {:focal true :fk []}
+              :reviews  {:focal true :fk [:products]}}
+             (graph-shape (erd-request! {:table-ids [(mt/id :orders) (mt/id :products) (mt/id :reviews)]
+                                         :hops      1})))))))
 
-(deftest erd-endpoint-multi-hop-test
+(deftest erd-graph-field-shape-test
   (mt/with-premium-features #{:dependencies}
-    (testing "hops=2 from orders reaches tables two hops away via outbound FKs"
-      ;; orders → products (hop 1), orders → people (hop 1)
-      ;; products and people have no outbound FKs, so hop 2 discovers nothing new
-      (let [response (erd-request! {:table-ids [(mt/id :orders)]
-                                    :hops      2})]
-        (is (=? {:is_focal true}  (node-by-table response :orders)))
-        (is (=? {:is_focal false} (node-by-table response :products)))
-        (is (=? {:is_focal false} (node-by-table response :people)))))
+    (testing "FK fields on nodes carry resolved target IDs, PK fields have nil FK refs"
+      (let [response (erd-request! {:table-ids [(mt/id :orders)] :hops 1})
+            orders   (first (filter #(= (mt/id :orders) (:table_id %)) (:nodes response)))
+            fk-field (first (filter #(= "PRODUCT_ID" (:name %)) (:fields orders)))
+            pk-field (first (filter #(= "ID" (:name %)) (:fields orders)))]
+        (is (= (mt/id :products :id) (:fk_target_field_id fk-field)))
+        (is (= (mt/id :products)     (:fk_target_table_id fk-field)))
+        (is (= "type/FK"             (:semantic_type fk-field)))
+        (is (nil? (:fk_target_field_id pk-field)))
+        (is (nil? (:fk_target_table_id pk-field)))))
 
-    (testing "BFS only follows outbound FKs — a table with no FKs expands to nothing"
-      (let [response (erd-request! {:table-ids [(mt/id :products)]
-                                    :hops      2})]
-        (is (= #{(mt/id :products)} (table-ids response)))))))
+    (testing "FK field to excluded table has nil target IDs (no ID leak)"
+      (let [response (erd-request! {:table-ids [(mt/id :orders)] :hops 0})]
+        (doseq [field (mapcat :fields (:nodes response))
+                :when (= "type/FK" (:semantic_type field))]
+          (is (nil? (:fk_target_field_id field)))
+          (is (nil? (:fk_target_table_id field))))))))
 
-(deftest erd-endpoint-hops-clamped-test
+(deftest erd-graph-self-referential-fk-test
   (mt/with-premium-features #{:dependencies}
-    (testing "hops > max (5) is clamped — does not error or run unbounded"
-      (let [response (erd-request! {:table-ids [(mt/id :orders)]
-                                    :hops      99})]
-        (is (seq (:nodes response)))))))
+    (testing "self-referential FK produces edge from table to itself"
+      (mt/with-temp [:model/Database {db-id :id} {}
+                     :model/Table    {tid :id}   {:db_id db-id :name "categories" :schema "PUBLIC"}
+                     :model/Field    {pk-id :id} {:table_id tid :name "id"
+                                                  :database_type "INTEGER" :base_type :type/Integer
+                                                  :semantic_type :type/PK}
+                     :model/Field    _            {:table_id tid :name "parent_id"
+                                                   :database_type "INTEGER" :base_type :type/Integer
+                                                   :semantic_type :type/FK
+                                                   :fk_target_field_id pk-id}]
+        (let [response (mt/user-http-request :rasta :get 200 "ee/dependencies/erd"
+                                             :database-id db-id
+                                             :table-ids tid
+                                             :hops 1)]
+          (is (= {:categories {:focal true :fk [:categories]}}
+                 (graph-shape response))))))))
+
+;;; ---------------------------------------- Integration tests ----------------------------------------
+
+(deftest erd-endpoint-hops-clamping-test
+  (mt/with-premium-features #{:dependencies}
+    (testing "hops > max (5) is clamped — does not error"
+      (is (seq (:nodes (erd-request! {:table-ids [(mt/id :orders)]
+                                      :hops      99})))))))
 
 (deftest erd-endpoint-auto-discover-test
   (mt/with-premium-features #{:dependencies}
     (testing "auto-discovers focal tables when none specified"
-      (let [response (erd-request! {})]
-        (is (seq (:nodes response)))
-        (is (seq (:edges response)))
-        (is (some :is_focal (:nodes response)))
-        (is (some (complement :is_focal) (:nodes response)))))))
-
-(deftest erd-endpoint-hops-zero-test
-  (mt/with-premium-features #{:dependencies}
-    (testing "hops=0 returns only focal tables with no expansion"
-      (let [response (erd-request! {:table-ids [(mt/id :orders)]
-                                    :hops      0})]
-        (is (= #{(mt/id :orders)} (table-ids response)))))))
+      (let [shape (graph-shape (erd-request! {}))]
+        (is (some (fn [[_ v]] (:focal v)) shape))
+        (is (some (fn [[_ v]] (not (:focal v))) shape))))))
 
 (deftest erd-endpoint-schema-filter-test
   (mt/with-premium-features #{:dependencies}
     (testing "schema param filters auto-discovery to that schema"
-      (let [response (erd-request! {:schema "PUBLIC"})]
-        (doseq [node (:nodes response)]
-          (is (= "PUBLIC" (:schema node))))))))
+      (doseq [node (:nodes (erd-request! {:schema "PUBLIC"}))]
+        (is (= "PUBLIC" (:schema node)))))))
 
-(deftest erd-endpoint-requires-premium-feature-test
+(deftest erd-endpoint-guard-rails-test
   (testing "without :dependencies feature returns 402"
     (mt/with-premium-features #{}
       (mt/user-http-request :rasta :get 402 "ee/dependencies/erd"
-                            :database-id (mt/id)))))
+                            :database-id (mt/id))))
 
-(deftest erd-endpoint-invalid-database-test
   (mt/with-premium-features #{:dependencies}
     (testing "non-existent database returns 404"
       (mt/user-http-request :rasta :get 404 "ee/dependencies/erd"
                             :database-id Integer/MAX_VALUE))))
 
-;;; ---------------------------------------- Permission tests ----------------------------------------
+;;; ---------------------------------------- Permission graph tests ----------------------------------------
 
-(deftest erd-endpoint-excludes-unreadable-tables-test
+;; These tests verify that the graph topology changes correctly under
+;; different permission scenarios. We use with-no-data-perms-for-all-users!
+;; to revoke everything, then selectively grant table-level access.
+
+(deftest erd-permissions-unreadable-table-excluded-test
   (mt/with-premium-features #{:dependencies}
-    (testing "tables the user cannot read are excluded from ERD results"
-      (let [orders-id   (mt/id :orders)
-            products-id (mt/id :products)]
-        (mt/with-no-data-perms-for-all-users!
-          (mt/with-temp [:model/PermissionsGroup {group-id :id} {}]
-            (perms/add-user-to-group! (mt/user->id :rasta) group-id)
-            ;; Grant access to orders only — not products
-            (data-perms/set-table-permission! group-id orders-id :perms/view-data :unrestricted)
-            (data-perms/set-table-permission! group-id orders-id :perms/create-queries :query-builder)
-            (let [response (mt/user-http-request :rasta :get 200 "ee/dependencies/erd"
-                                                 :database-id (mt/id)
-                                                 :table-ids   orders-id
-                                                 :table-ids   products-id
-                                                 :hops        1)]
-              (testing "orders is included, products is excluded"
-                (is (some? (node-by-table response orders-id)))
-                (is (nil?  (node-by-table response products-id))))
-              (testing "no edges reference the excluded table"
-                (doseq [edge (:edges response)]
-                  (is (not= products-id (:source_table_id edge)))
-                  (is (not= products-id (:target_table_id edge)))))
-              (testing "FK fields pointing to excluded tables have nil target IDs"
-                (doseq [field (mapcat :fields (:nodes response))
-                        :when (some? (:fk_target_table_id field))]
-                  (is (contains? (table-ids response) (:fk_target_table_id field))))))))))))
+    (testing "unreadable table is excluded from graph, edges, and FK fields"
+      (mt/with-no-data-perms-for-all-users!
+        (mt/with-temp [:model/PermissionsGroup {gid :id} {}]
+          (perms/add-user-to-group! (mt/user->id :rasta) gid)
+          ;; Grant orders only — products is unreachable
+          (grant-table-read! gid (mt/id :orders))
+          (let [response (mt/user-http-request :rasta :get 200 "ee/dependencies/erd"
+                                               :database-id (mt/id)
+                                               :table-ids (mt/id :orders)
+                                               :table-ids (mt/id :products)
+                                               :hops 1)]
+            (testing "graph shows orders alone, no FK edges"
+              (is (= {:orders {:focal true :fk []}}
+                     (graph-shape response))))
+            (testing "no FK field leaks IDs of excluded tables"
+              (doseq [field (mapcat :fields (:nodes response))
+                      :when (:fk_target_table_id field)]
+                (is (contains? (set (map :table_id (:nodes response)))
+                               (:fk_target_table_id field)))))))))))
+
+(deftest erd-permissions-intermediate-table-blocks-bfs-test
+  (mt/with-premium-features #{:dependencies}
+    (testing "unreadable intermediate table blocks BFS — downstream tables are not discovered"
+      ;; Graph: orders → products, reviews → products
+      ;; Grant: orders + reviews, deny: products
+      ;; orders' FK to products is blocked, reviews' FK to products is blocked
+      ;; With orders as focal + hops=2, products is unreadable so nothing beyond orders is found
+      (mt/with-no-data-perms-for-all-users!
+        (mt/with-temp [:model/PermissionsGroup {gid :id} {}]
+          (perms/add-user-to-group! (mt/user->id :rasta) gid)
+          (grant-table-read! gid (mt/id :orders))
+          (grant-table-read! gid (mt/id :reviews))
+          (grant-table-read! gid (mt/id :people))
+          ;; products is NOT granted — it's the "intermediate" table
+          (let [response (mt/user-http-request :rasta :get 200 "ee/dependencies/erd"
+                                               :database-id (mt/id)
+                                               :table-ids (mt/id :orders)
+                                               :hops 2)]
+            (testing "orders reaches people (readable) but not products (unreadable)"
+              (is (= {:orders {:focal true  :fk [:people]}
+                      :people {:focal false :fk []}}
+                     (graph-shape response))))))))))
+

--- a/enterprise/backend/test/metabase_enterprise/dependencies/erd_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/erd_test.clj
@@ -2,16 +2,22 @@
   (:require
    [clojure.test :refer :all]
    [metabase-enterprise.dependencies.erd :as erd]
+   [metabase.permissions.core :as perms]
+   [metabase.permissions.models.data-permissions :as data-perms]
    [metabase.test :as mt]))
 
 ;;; ---------------------------------------- Pure function tests ----------------------------------------
 
-(deftest build-erd-field-test
+(defn- ->field-by-id
+  "Build a field-by-id map from a collection of fields."
+  [fields]
+  (into {} (map (fn [f] [(:id f) f])) fields))
+
+(deftest ^:parallel build-erd-field-test
   (testing "basic field without FK"
-    (let [field        {:id 1 :name "id" :display_name "ID"
-                        :database_type "INTEGER" :semantic_type :type/PK
-                        :fk_target_field_id nil}
-          field->table {}]
+    (let [field {:id 1 :name "id" :display_name "ID"
+                 :database_type "INTEGER" :semantic_type :type/PK
+                 :fk_target_field_id nil}]
       (is (= {:id                 1
               :name               "id"
               :display_name       "ID"
@@ -19,13 +25,14 @@
               :semantic_type      "type/PK"
               :fk_target_field_id nil
               :fk_target_table_id nil}
-             (erd/build-erd-field field field->table)))))
+             (erd/build-erd-field field {})))))
 
   (testing "FK field resolves target table"
     (let [field        {:id 2 :name "product_id" :display_name "Product ID"
                         :database_type "INTEGER" :semantic_type :type/FK
                         :fk_target_field_id 10}
-          field->table {10 100}]
+          target-field {:id 10 :name "id" :table_id 100}
+          field-by-id  (->field-by-id [target-field])]
       (is (= {:id                 2
               :name               "product_id"
               :display_name       "Product ID"
@@ -33,41 +40,52 @@
               :semantic_type      "type/FK"
               :fk_target_field_id 10
               :fk_target_table_id 100}
-             (erd/build-erd-field field field->table)))))
+             (erd/build-erd-field field field-by-id)))))
 
   (testing "nil semantic_type stays nil"
     (let [field {:id 3 :name "x" :display_name "X"
                  :database_type "TEXT" :semantic_type nil
                  :fk_target_field_id nil}]
-      (is (nil? (:semantic_type (erd/build-erd-field field {})))))))
+      (is (nil? (:semantic_type (erd/build-erd-field field {}))))))
 
-(deftest build-erd-node-test
-  (let [table        {:id 1 :name "ORDERS" :display_name "Orders"
-                      :schema "PUBLIC" :db_id 1}
-        fields       [{:id 10 :name "id" :display_name "ID"
-                       :database_type "INTEGER" :semantic_type :type/PK
-                       :fk_target_field_id nil}
-                      {:id 11 :name "product_id" :display_name "Product ID"
-                       :database_type "INTEGER" :semantic_type :type/FK
-                       :fk_target_field_id 20}]
-        field->table {20 2}
-        node         (erd/build-erd-node table fields true field->table)]
-    (testing "node has correct table metadata"
-      (is (= 1 (:table_id node)))
-      (is (= "ORDERS" (:name node)))
-      (is (= "Orders" (:display_name node)))
-      (is (= "PUBLIC" (:schema node)))
-      (is (= 1 (:db_id node)))
-      (is (true? (:is_focal node))))
+  (testing "FK target not in visible graph nils out both FK references"
+    (let [field  {:id 2 :name "product_id" :display_name "Product ID"
+                  :database_type "INTEGER" :semantic_type :type/FK
+                  :fk_target_field_id 10}
+          result (erd/build-erd-field field {})]
+      (is (nil? (:fk_target_field_id result)))
+      (is (nil? (:fk_target_table_id result))))))
 
-    (testing "node includes all fields"
-      (is (= 2 (count (:fields node)))))
+(deftest ^:parallel build-erd-node-test
+  (testing "focal node with fields"
+    (let [table       {:id 1 :name "ORDERS" :display_name "Orders"
+                       :schema "PUBLIC" :db_id 1}
+          fields      [{:id 10 :name "id" :display_name "ID"
+                        :database_type "INTEGER" :semantic_type :type/PK
+                        :fk_target_field_id nil}
+                       {:id 11 :name "product_id" :display_name "Product ID"
+                        :database_type "INTEGER" :semantic_type :type/FK
+                        :fk_target_field_id 20}]
+          field-by-id (->field-by-id [{:id 20 :name "id" :table_id 2}])
+          node        (erd/build-erd-node table fields true field-by-id)]
+      (is (= {:table_id 1 :name "ORDERS" :display_name "Orders"
+              :schema "PUBLIC" :db_id 1 :is_focal true}
+             (dissoc node :fields)))
+      (is (= 2 (count (:fields node))))
+      (is (= 2 (:fk_target_table_id (second (:fields node)))))))
 
-    (testing "FK field resolves target table in node context"
-      (let [fk-field (second (:fields node))]
-        (is (= 2 (:fk_target_table_id fk-field)))))))
+  (testing "non-focal node"
+    (let [table {:id 2 :name "PRODUCTS" :display_name "Products"
+                 :schema "PUBLIC" :db_id 1}
+          node  (erd/build-erd-node table [] false {})]
+      (is (false? (:is_focal node)))))
 
-(deftest build-erd-edges-test
+  (testing "table with no fields produces empty fields vector"
+    (let [table {:id 3 :name "EMPTY" :display_name "Empty" :schema nil :db_id 1}
+          node  (erd/build-erd-node table [] true {})]
+      (is (= [] (:fields node))))))
+
+(deftest ^:parallel build-erd-edges-test
   (let [;; Table 1 has a FK field (id=11) pointing to table 2's field (id=20)
         fields-by-table {1 [{:id 10 :name "id" :table_id 1
                              :database_type "INTEGER" :semantic_type :type/PK
@@ -78,11 +96,11 @@
                          2 [{:id 20 :name "id" :table_id 2
                              :database_type "INTEGER" :semantic_type :type/PK
                              :fk_target_field_id nil :database_is_pk true}]}
-        field->table    {10 1 11 1 20 2}
+        field-by-id     (->field-by-id (mapcat val fields-by-table))
         visible-ids     #{1 2}]
 
     (testing "produces edge for FK relationship"
-      (let [edges (erd/build-erd-edges fields-by-table field->table visible-ids)]
+      (let [edges (erd/build-erd-edges fields-by-table field-by-id visible-ids)]
         (is (= 1 (count edges)))
         (is (= {:source_table_id 1
                 :source_field_id 11
@@ -91,9 +109,14 @@
                 :relationship    "many-to-one"}
                (first edges)))))
 
-    (testing "excludes edges to tables not in visible set"
-      (let [edges (erd/build-erd-edges fields-by-table field->table #{1})]
-        (is (empty? edges))))
+    (testing "excludes edges when target table not in visible set"
+      (is (empty? (erd/build-erd-edges fields-by-table field-by-id #{1}))))
+
+    (testing "excludes edges when source table not in visible set"
+      (is (empty? (erd/build-erd-edges fields-by-table field-by-id #{2}))))
+
+    (testing "empty fields-by-table produces no edges"
+      (is (empty? (erd/build-erd-edges {} field-by-id visible-ids))))
 
     (testing "one-to-one when both fields are PK"
       (let [fields-both-pk {1 [{:id 11 :name "user_id" :table_id 1
@@ -102,10 +125,11 @@
                             2 [{:id 20 :name "id" :table_id 2
                                 :database_type "INTEGER" :semantic_type :type/PK
                                 :fk_target_field_id nil :database_is_pk true}]}
-            edges          (erd/build-erd-edges fields-both-pk field->table visible-ids)]
+            field-by-id-pk (->field-by-id (mapcat val fields-both-pk))
+            edges          (erd/build-erd-edges fields-both-pk field-by-id-pk visible-ids)]
         (is (= "one-to-one" (:relationship (first edges))))))))
 
-(deftest build-erd-response-test
+(deftest ^:parallel build-erd-response-test
   (let [table1   {:id 1 :name "ORDERS" :display_name "Orders" :schema "PUBLIC" :db_id 1}
         table2   {:id 2 :name "PRODUCTS" :display_name "Products" :schema "PUBLIC" :db_id 1}
         field1   {:id 10 :name "id" :table_id 1 :display_name "ID"
@@ -116,18 +140,25 @@
                   :database_type "INT" :semantic_type :type/PK :fk_target_field_id nil}
         subgraph {:tables-by-id    {1 table1 2 table2}
                   :fields-by-table {1 [field1 field2] 2 [field3]}
-                  :field->table    {10 1 11 1 20 2}
-                  :all-table-ids   #{1 2}}
-        response (erd/build-erd-response subgraph #{1})]
+                  :field-by-id     (->field-by-id [field1 field2 field3])
+                  :all-table-ids   #{1 2}}]
 
     (testing "response has nodes and edges"
-      (is (= 2 (count (:nodes response))))
-      (is (= 1 (count (:edges response)))))
+      (let [response (erd/build-erd-response subgraph #{1})]
+        (is (= 2 (count (:nodes response))))
+        (is (= 1 (count (:edges response))))))
 
     (testing "focal table is marked correctly"
-      (let [nodes-by-id (into {} (map (fn [n] [(:table_id n) n])) (:nodes response))]
+      (let [nodes-by-id (->> (erd/build-erd-response subgraph #{1})
+                             :nodes
+                             (into {} (map (fn [n] [(:table_id n) n]))))]
         (is (true? (:is_focal (nodes-by-id 1))))
-        (is (false? (:is_focal (nodes-by-id 2))))))))
+        (is (false? (:is_focal (nodes-by-id 2))))))
+
+    (testing "focal table not in tables-by-id is silently excluded"
+      (let [response (erd/build-erd-response subgraph #{1 999})]
+        (is (= 2 (count (:nodes response))))
+        (is (true? (:is_focal (first (filter #(= 1 (:table_id %)) (:nodes response))))))))))
 
 ;;; ---------------------------------------- Integration tests (via HTTP) ----------------------------------------
 
@@ -192,6 +223,40 @@
             (is (contains? edge-pairs [orders-id (mt/id :products)]))
             (is (contains? edge-pairs [orders-id (mt/id :people)]))))))))
 
+(deftest erd-endpoint-multi-hop-test
+  (mt/with-premium-features #{:dependencies}
+    (testing "hops=2 from orders reaches tables two hops away via outbound FKs"
+      ;; orders → products (hop 1), orders → people (hop 1)
+      ;; products and people have no outbound FKs, so hop 2 discovers nothing new
+      (let [orders-id (mt/id :orders)
+            response  (mt/user-http-request :rasta :get 200 "ee/dependencies/erd"
+                                            :database-id (mt/id)
+                                            :table-ids   orders-id
+                                            :hops        2)
+            table-ids (set (map :table_id (:nodes response)))]
+        (is (contains? table-ids orders-id))
+        (is (contains? table-ids (mt/id :products)))
+        (is (contains? table-ids (mt/id :people)))))
+
+    (testing "BFS only follows outbound FKs — a table with no FKs expands to nothing"
+      (let [products-id (mt/id :products)
+            response    (mt/user-http-request :rasta :get 200 "ee/dependencies/erd"
+                                              :database-id (mt/id)
+                                              :table-ids   products-id
+                                              :hops        2)
+            table-ids   (set (map :table_id (:nodes response)))]
+        (is (= #{products-id} table-ids))))))
+
+(deftest erd-endpoint-hops-clamped-test
+  (mt/with-premium-features #{:dependencies}
+    (testing "hops > max (5) is clamped — does not error or run unbounded"
+      (let [orders-id (mt/id :orders)
+            response  (mt/user-http-request :rasta :get 200 "ee/dependencies/erd"
+                                            :database-id (mt/id)
+                                            :table-ids   orders-id
+                                            :hops        99)]
+        (is (seq (:nodes response)))))))
+
 (deftest erd-endpoint-auto-discover-test
   (mt/with-premium-features #{:dependencies}
     (testing "GET /api/ee/dependencies/erd auto-discovers focal tables when none specified"
@@ -238,3 +303,36 @@
     (testing "non-existent database returns 404"
       (mt/user-http-request :rasta :get 404 "ee/dependencies/erd"
                             :database-id Integer/MAX_VALUE))))
+
+;;; ---------------------------------------- Permission tests ----------------------------------------
+
+(deftest erd-endpoint-excludes-unreadable-tables-test
+  (mt/with-premium-features #{:dependencies}
+    (testing "tables the user cannot read are excluded from ERD results"
+      (let [orders-id   (mt/id :orders)
+            products-id (mt/id :products)]
+        (mt/with-no-data-perms-for-all-users!
+          (mt/with-temp [:model/PermissionsGroup {group-id :id} {}]
+            (perms/add-user-to-group! (mt/user->id :rasta) group-id)
+            ;; Grant access to orders only — not products
+            (data-perms/set-table-permission! group-id orders-id :perms/view-data :unrestricted)
+            (data-perms/set-table-permission! group-id orders-id :perms/create-queries :query-builder)
+            (let [response  (mt/user-http-request :rasta :get 200 "ee/dependencies/erd"
+                                                  :database-id (mt/id)
+                                                  :table-ids   orders-id
+                                                  :table-ids   products-id
+                                                  :hops        1)
+                  table-ids (set (map :table_id (:nodes response)))]
+              (testing "orders is included (user has access)"
+                (is (contains? table-ids orders-id)))
+              (testing "products is excluded (user lacks access)"
+                (is (not (contains? table-ids products-id))))
+              (testing "no edges reference the excluded table"
+                (doseq [edge (:edges response)]
+                  (is (not= products-id (:source_table_id edge)))
+                  (is (not= products-id (:target_table_id edge)))))
+              (testing "FK fields pointing to excluded tables have nil target IDs"
+                (let [all-fields (mapcat :fields (:nodes response))]
+                  (doseq [field all-fields
+                          :when (some? (:fk_target_table_id field))]
+                    (is (contains? table-ids (:fk_target_table_id field)))))))))))))

--- a/enterprise/backend/test/metabase_enterprise/dependencies/erd_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/erd_test.clj
@@ -6,12 +6,47 @@
    [metabase.permissions.models.data-permissions :as data-perms]
    [metabase.test :as mt]))
 
-;;; ---------------------------------------- Pure function tests ----------------------------------------
+;;; ---------------------------------------- Test helpers ----------------------------------------
 
 (defn- ->field-by-id
   "Build a field-by-id map from a collection of fields."
   [fields]
   (into {} (map (fn [f] [(:id f) f])) fields))
+
+(defn- node-by-table
+  "Find an ERD node by table keyword (e.g. :orders) or table ID."
+  [response table-or-id]
+  (let [tid (if (keyword? table-or-id) (mt/id table-or-id) table-or-id)]
+    (some #(when (= tid (:table_id %)) %) (:nodes response))))
+
+(defn- edge-between
+  "Find an ERD edge from source to target (keywords or IDs)."
+  [response source-table target-table]
+  (let [src (if (keyword? source-table) (mt/id source-table) source-table)
+        tgt (if (keyword? target-table) (mt/id target-table) target-table)]
+    (some #(when (and (= src (:source_table_id %))
+                      (= tgt (:target_table_id %)))
+             %)
+          (:edges response))))
+
+(defn- table-ids
+  "Set of all table IDs in an ERD response."
+  [response]
+  (set (map :table_id (:nodes response))))
+
+(defn- erd-request!
+  "Make an ERD endpoint request. `opts` is a map with optional keys
+   :table-ids (coll), :schema, :hops."
+  [opts]
+  (apply mt/user-http-request :rasta :get 200 "ee/dependencies/erd"
+         :database-id (mt/id)
+         (mapcat (fn [[k v]]
+                   (if (= k :table-ids)
+                     (mapcat (fn [tid] [:table-ids tid]) v)
+                     [k v]))
+                 opts)))
+
+;;; ---------------------------------------- Pure function tests ----------------------------------------
 
 (deftest ^:parallel build-erd-field-test
   (testing "basic field without FK"
@@ -164,133 +199,97 @@
 
 (deftest erd-endpoint-with-explicit-tables-test
   (mt/with-premium-features #{:dependencies}
-    (testing "GET /api/ee/dependencies/erd with explicit table-ids"
-      (let [orders-id   (mt/id :orders)
-            products-id (mt/id :products)
-            response    (mt/user-http-request :rasta :get 200 "ee/dependencies/erd"
-                                              :database-id (mt/id)
-                                              :table-ids   orders-id
-                                              :table-ids   products-id
-                                              :hops        0)]
-        (testing "returns exactly the requested tables when hops=0"
-          (is (= #{orders-id products-id}
-                 (set (map :table_id (:nodes response))))))
+    (testing "GET /api/ee/dependencies/erd with explicit table-ids, hops=0"
+      (let [response (erd-request! {:table-ids [(mt/id :orders) (mt/id :products)]
+                                    :hops      0})]
+        (testing "returns exactly the requested focal tables"
+          (is (= #{(mt/id :orders) (mt/id :products)} (table-ids response))))
 
-        (testing "all nodes have required keys"
-          (doseq [node (:nodes response)]
-            (is (contains? node :table_id))
-            (is (contains? node :name))
-            (is (contains? node :display_name))
-            (is (contains? node :db_id))
-            (is (contains? node :is_focal))
-            (is (contains? node :fields))))
+        (testing "nodes have correct shape"
+          (is (=? {:table_id     (mt/id :orders)
+                   :name         "ORDERS"
+                   :display_name "Orders"
+                   :db_id        (mt/id)
+                   :schema       "PUBLIC"
+                   :is_focal     true
+                   :fields       sequential?}
+                  (node-by-table response :orders)))
+          (is (=? {:table_id (mt/id :products)
+                   :is_focal true}
+                  (node-by-table response :products))))
 
-        (testing "focal tables are marked correctly"
-          (doseq [node (:nodes response)]
-            (is (true? (:is_focal node)))))
-
-        (testing "edges have required keys"
-          (doseq [edge (:edges response)]
-            (is (contains? edge :source_table_id))
-            (is (contains? edge :source_field_id))
-            (is (contains? edge :target_table_id))
-            (is (contains? edge :target_field_id))
-            (is (contains? edge :relationship))))))))
+        (testing "each field has the expected shape"
+          (is (=? {:id                 pos-int?
+                   :name               string?
+                   :display_name       string?
+                   :database_type      string?}
+                  (first (:fields (node-by-table response :orders))))))))))
 
 (deftest erd-endpoint-with-hops-test
   (mt/with-premium-features #{:dependencies}
-    (testing "GET /api/ee/dependencies/erd with hops expands to related tables"
-      (let [orders-id (mt/id :orders)
-            response  (mt/user-http-request :rasta :get 200 "ee/dependencies/erd"
-                                            :database-id (mt/id)
-                                            :table-ids   orders-id
-                                            :hops        1)]
-        (testing "orders has FKs to products and people, so both should appear"
-          (let [table-ids (set (map :table_id (:nodes response)))]
-            (is (contains? table-ids orders-id))
-            (is (contains? table-ids (mt/id :products)))
-            (is (contains? table-ids (mt/id :people)))))
+    (testing "hops=1 from orders expands to products and people via outbound FKs"
+      (let [response (erd-request! {:table-ids [(mt/id :orders)]
+                                    :hops      1})]
+        (testing "focal + related tables present"
+          (is (=? {:table_id (mt/id :orders)  :is_focal true}  (node-by-table response :orders)))
+          (is (=? {:table_id (mt/id :products) :is_focal false} (node-by-table response :products)))
+          (is (=? {:table_id (mt/id :people)   :is_focal false} (node-by-table response :people))))
 
-        (testing "orders is focal, related tables are not"
-          (let [nodes-by-id (into {} (map (fn [n] [(:table_id n) n])) (:nodes response))]
-            (is (true? (:is_focal (nodes-by-id orders-id))))
-            (is (false? (:is_focal (nodes-by-id (mt/id :products)))))
-            (is (false? (:is_focal (nodes-by-id (mt/id :people)))))))
-
-        (testing "has edges connecting orders to products and people"
-          (let [edge-pairs (set (map (fn [e] [(:source_table_id e) (:target_table_id e)])
-                                     (:edges response)))]
-            (is (contains? edge-pairs [orders-id (mt/id :products)]))
-            (is (contains? edge-pairs [orders-id (mt/id :people)]))))))))
+        (testing "edges connect orders to its FK targets"
+          (is (=? {:source_table_id (mt/id :orders)
+                   :target_table_id (mt/id :products)
+                   :relationship    "many-to-one"}
+                  (edge-between response :orders :products)))
+          (is (=? {:source_table_id (mt/id :orders)
+                   :target_table_id (mt/id :people)
+                   :relationship    "many-to-one"}
+                  (edge-between response :orders :people))))))))
 
 (deftest erd-endpoint-multi-hop-test
   (mt/with-premium-features #{:dependencies}
     (testing "hops=2 from orders reaches tables two hops away via outbound FKs"
       ;; orders → products (hop 1), orders → people (hop 1)
       ;; products and people have no outbound FKs, so hop 2 discovers nothing new
-      (let [orders-id (mt/id :orders)
-            response  (mt/user-http-request :rasta :get 200 "ee/dependencies/erd"
-                                            :database-id (mt/id)
-                                            :table-ids   orders-id
-                                            :hops        2)
-            table-ids (set (map :table_id (:nodes response)))]
-        (is (contains? table-ids orders-id))
-        (is (contains? table-ids (mt/id :products)))
-        (is (contains? table-ids (mt/id :people)))))
+      (let [response (erd-request! {:table-ids [(mt/id :orders)]
+                                    :hops      2})]
+        (is (=? {:is_focal true}  (node-by-table response :orders)))
+        (is (=? {:is_focal false} (node-by-table response :products)))
+        (is (=? {:is_focal false} (node-by-table response :people)))))
 
     (testing "BFS only follows outbound FKs — a table with no FKs expands to nothing"
-      (let [products-id (mt/id :products)
-            response    (mt/user-http-request :rasta :get 200 "ee/dependencies/erd"
-                                              :database-id (mt/id)
-                                              :table-ids   products-id
-                                              :hops        2)
-            table-ids   (set (map :table_id (:nodes response)))]
-        (is (= #{products-id} table-ids))))))
+      (let [response (erd-request! {:table-ids [(mt/id :products)]
+                                    :hops      2})]
+        (is (= #{(mt/id :products)} (table-ids response)))))))
 
 (deftest erd-endpoint-hops-clamped-test
   (mt/with-premium-features #{:dependencies}
     (testing "hops > max (5) is clamped — does not error or run unbounded"
-      (let [orders-id (mt/id :orders)
-            response  (mt/user-http-request :rasta :get 200 "ee/dependencies/erd"
-                                            :database-id (mt/id)
-                                            :table-ids   orders-id
-                                            :hops        99)]
+      (let [response (erd-request! {:table-ids [(mt/id :orders)]
+                                    :hops      99})]
         (is (seq (:nodes response)))))))
 
 (deftest erd-endpoint-auto-discover-test
   (mt/with-premium-features #{:dependencies}
-    (testing "GET /api/ee/dependencies/erd auto-discovers focal tables when none specified"
-      (let [response (mt/user-http-request :rasta :get 200 "ee/dependencies/erd"
-                                           :database-id (mt/id))]
-        (testing "returns nodes and edges"
-          (is (seq (:nodes response)))
-          (is (seq (:edges response))))
-
-        (testing "some nodes are focal"
-          (is (some :is_focal (:nodes response))))
-
-        (testing "some nodes are non-focal (discovered via hops)"
-          (is (some (complement :is_focal) (:nodes response))))))))
+    (testing "auto-discovers focal tables when none specified"
+      (let [response (erd-request! {})]
+        (is (seq (:nodes response)))
+        (is (seq (:edges response)))
+        (is (some :is_focal (:nodes response)))
+        (is (some (complement :is_focal) (:nodes response)))))))
 
 (deftest erd-endpoint-hops-zero-test
   (mt/with-premium-features #{:dependencies}
     (testing "hops=0 returns only focal tables with no expansion"
-      (let [orders-id (mt/id :orders)
-            response  (mt/user-http-request :rasta :get 200 "ee/dependencies/erd"
-                                            :database-id (mt/id)
-                                            :table-ids   orders-id
-                                            :hops        0)]
-        (is (= #{orders-id} (set (map :table_id (:nodes response)))))))))
+      (let [response (erd-request! {:table-ids [(mt/id :orders)]
+                                    :hops      0})]
+        (is (= #{(mt/id :orders)} (table-ids response)))))))
 
 (deftest erd-endpoint-schema-filter-test
   (mt/with-premium-features #{:dependencies}
     (testing "schema param filters auto-discovery to that schema"
-      (let [response (mt/user-http-request :rasta :get 200 "ee/dependencies/erd"
-                                           :database-id (mt/id)
-                                           :schema      "PUBLIC")]
-        (testing "all nodes belong to the specified schema"
-          (doseq [node (:nodes response)]
-            (is (= "PUBLIC" (:schema node)))))))))
+      (let [response (erd-request! {:schema "PUBLIC"})]
+        (doseq [node (:nodes response)]
+          (is (= "PUBLIC" (:schema node))))))))
 
 (deftest erd-endpoint-requires-premium-feature-test
   (testing "without :dependencies feature returns 402"
@@ -317,22 +316,19 @@
             ;; Grant access to orders only — not products
             (data-perms/set-table-permission! group-id orders-id :perms/view-data :unrestricted)
             (data-perms/set-table-permission! group-id orders-id :perms/create-queries :query-builder)
-            (let [response  (mt/user-http-request :rasta :get 200 "ee/dependencies/erd"
-                                                  :database-id (mt/id)
-                                                  :table-ids   orders-id
-                                                  :table-ids   products-id
-                                                  :hops        1)
-                  table-ids (set (map :table_id (:nodes response)))]
-              (testing "orders is included (user has access)"
-                (is (contains? table-ids orders-id)))
-              (testing "products is excluded (user lacks access)"
-                (is (not (contains? table-ids products-id))))
+            (let [response (mt/user-http-request :rasta :get 200 "ee/dependencies/erd"
+                                                 :database-id (mt/id)
+                                                 :table-ids   orders-id
+                                                 :table-ids   products-id
+                                                 :hops        1)]
+              (testing "orders is included, products is excluded"
+                (is (some? (node-by-table response orders-id)))
+                (is (nil?  (node-by-table response products-id))))
               (testing "no edges reference the excluded table"
                 (doseq [edge (:edges response)]
                   (is (not= products-id (:source_table_id edge)))
                   (is (not= products-id (:target_table_id edge)))))
               (testing "FK fields pointing to excluded tables have nil target IDs"
-                (let [all-fields (mapcat :fields (:nodes response))]
-                  (doseq [field all-fields
-                          :when (some? (:fk_target_table_id field))]
-                    (is (contains? table-ids (:fk_target_table_id field)))))))))))))
+                (doseq [field (mapcat :fields (:nodes response))
+                        :when (some? (:fk_target_table_id field))]
+                  (is (contains? (table-ids response) (:fk_target_table_id field))))))))))))

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/components/SchemaViewer/SchemaViewer.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/components/SchemaViewer/SchemaViewer.tsx
@@ -28,7 +28,6 @@ import {
 } from "metabase/ui";
 import { useGetErdQuery } from "metabase-enterprise/api";
 import type {
-  CardId,
   ConcreteTableId,
   DatabaseId,
   GetErdRequest,
@@ -99,7 +98,6 @@ function CompactModeToggle({
 }
 
 interface SchemaViewerProps {
-  modelId: CardId | undefined;
   databaseId: DatabaseId | undefined;
   schema: string | undefined;
   initialTableIds: ConcreteTableId[] | undefined;
@@ -113,50 +111,39 @@ interface GetErdQueryParamsArgs extends SchemaViewerProps {
 }
 
 function getErdQueryParams({
-  modelId,
   databaseId,
   schema,
   hops,
   selectedTableIds,
   isUserModified,
 }: GetErdQueryParamsArgs): GetErdRequest | typeof skipToken {
-  if (modelId != null) {
-    return { "model-id": modelId, hops };
+  if (databaseId == null) {
+    return skipToken;
   }
-  if (databaseId != null) {
-    // User explicitly cleared all tables - show empty canvas
-    if (
-      isUserModified &&
-      selectedTableIds != null &&
-      selectedTableIds.length === 0
-    ) {
-      return skipToken;
-    }
-    // Include table-ids when user has made a custom selection
-    if (
-      isUserModified &&
-      selectedTableIds != null &&
-      selectedTableIds.length > 0
-    ) {
-      return schema != null
-        ? {
-            "database-id": databaseId,
-            schema,
-            "table-ids": selectedTableIds,
-            hops,
-          }
-        : { "database-id": databaseId, "table-ids": selectedTableIds, hops };
-    }
-    // Initial fetch or auto-initialized - let backend determine "most relationships"
-    return schema != null
-      ? { "database-id": databaseId, schema, hops }
-      : { "database-id": databaseId, hops };
+  // User explicitly cleared all tables - show empty canvas
+  if (
+    isUserModified &&
+    selectedTableIds != null &&
+    selectedTableIds.length === 0
+  ) {
+    return skipToken;
   }
-  return skipToken;
+  const params: GetErdRequest = { "database-id": databaseId, hops };
+  if (schema != null) {
+    params.schema = schema;
+  }
+  // Include table-ids when user has made a custom selection
+  if (
+    isUserModified &&
+    selectedTableIds != null &&
+    selectedTableIds.length > 0
+  ) {
+    params["table-ids"] = selectedTableIds;
+  }
+  return params;
 }
 
 export function SchemaViewer({
-  modelId,
   databaseId,
   schema,
   initialTableIds,
@@ -169,9 +156,7 @@ export function SchemaViewer({
 
   // Persist table selection + hops per database:schema
   const prefsKey =
-    modelId == null && databaseId != null
-      ? `${databaseId}:${schema ?? ""}`
-      : null;
+    databaseId != null ? `${databaseId}:${schema ?? ""}` : null;
 
   const {
     value: savedPrefs,
@@ -280,7 +265,6 @@ export function SchemaViewer({
     shouldWaitForPrefs
       ? skipToken
       : getErdQueryParams({
-          modelId,
           databaseId,
           schema,
           initialTableIds,
@@ -427,7 +411,7 @@ export function SchemaViewer({
     [],
   );
   const { colorScheme } = useColorScheme();
-  const hasEntry = modelId != null || databaseId != null;
+  const hasEntry = databaseId != null;
 
   // Set of currently visible table IDs on the canvas
   const visibleTableIds = useMemo(

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/pages/SchemaViewerPage/SchemaViewerPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/pages/SchemaViewerPage/SchemaViewerPage.tsx
@@ -9,13 +9,12 @@ import { usePageTitle } from "metabase/hooks/use-page-title";
 import { useDispatch } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
 import { Stack } from "metabase/ui";
-import type { CardId, ConcreteTableId, DatabaseId } from "metabase-types/api";
+import type { ConcreteTableId, DatabaseId } from "metabase-types/api";
 
 import { SchemaViewer } from "../../components/SchemaViewer";
 import { decodeSchemaViewerShareState } from "../../components/SchemaViewer/useSchemaViewerShareUrl";
 
 type SchemaViewerPageQuery = {
-  "model-id"?: string;
   "database-id"?: string;
   "table-ids"?: string | string[];
   schema?: string;
@@ -38,14 +37,11 @@ export function SchemaViewerPage({ location }: SchemaViewerPageProps) {
     [rawShare],
   );
 
-  const rawModelId = location?.query?.["model-id"];
   const rawDatabaseId = location?.query?.["database-id"];
   const rawTableIds = location?.query?.["table-ids"];
   const rawHops = location?.query?.hops;
   const schema = location?.query?.schema;
 
-  const modelId: CardId | undefined =
-    rawModelId != null ? Number(rawModelId) : undefined;
   const databaseId: DatabaseId | undefined =
     rawDatabaseId != null ? Number(rawDatabaseId) : undefined;
   const initialHops: number | undefined =
@@ -83,8 +79,7 @@ export function SchemaViewerPage({ location }: SchemaViewerPageProps) {
   const effectiveSchema = sharedState?.schema ?? schema;
 
   // Redirect to last opened database only on initial load (not when user clears selection)
-  const hasUrlSelection =
-    modelId != null || databaseId != null || rawShare != null;
+  const hasUrlSelection = databaseId != null || rawShare != null;
   const hasRedirectedRef = useRef(false);
 
   useEffect(() => {
@@ -144,7 +139,6 @@ export function SchemaViewerPage({ location }: SchemaViewerPageProps) {
   return (
     <Stack h="100%">
       <SchemaViewer
-        modelId={modelId}
         databaseId={effectiveDatabaseId}
         schema={effectiveSchema}
         initialTableIds={sharedState?.tableIds ?? initialTableIds}

--- a/frontend/src/metabase-types/api/erd.ts
+++ b/frontend/src/metabase-types/api/erd.ts
@@ -1,4 +1,4 @@
-import type { CardId, DatabaseId, FieldId, TableId } from "./";
+import type { DatabaseId, FieldId, TableId } from "./";
 
 export type ErdRelationship = "one-to-one" | "many-to-one";
 
@@ -35,6 +35,9 @@ export type ErdResponse = {
   edges: ErdEdge[];
 };
 
-export type GetErdRequest =
-  | { "model-id": CardId; "database-id"?: never; "table-ids"?: never; schema?: never; hops?: number }
-  | { "model-id"?: never; "database-id": DatabaseId; "table-ids"?: TableId[]; schema?: string; hops?: number };
+export type GetErdRequest = {
+  "database-id": DatabaseId;
+  "table-ids"?: TableId[];
+  schema?: string;
+  hops?: number;
+};


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #25956
Closes https://linear.app/metabase/issue/GDGT-1828/rewrite-vibe-coded-backend-code
## Summary

- Replaces three near-identical `build-erd-for-*` functions (~180 lines of duplication) with a unified three-phase pipeline: resolve focal tables → lazy BFS subgraph fetch → build response
- Cross-schema FKs are now handled naturally by the BFS traversal instead of a separate `resolve-cross-schema-fks` step (which was also missing from the focal-table path — a bug)
- Auto-discovery of focal tables uses a SQL aggregate query instead of loading all fields into Clojure to count connections
- Removes `model-id` param, makes `database-id` required, caps `hops` at 5 server-side
- Net **-188 lines**

## Performance

Old approach: loads ALL tables + ALL fields in the database upfront, builds connection graph in memory, then filters down to the visible subset. For a 2000-table database with `hops=1` selecting 3 tables, this loads ~30k fields to return ~150.

New approach: iteratively fetches only the tables/fields discovered at each hop. For the same scenario, loads ~150 fields across ~6 targeted queries.