### PR TITLE
Fix missing translation in guest embed filters

### DIFF
--- a/e2e/test/scenarios/admin/i18n/content-translation/dashboards.cy.spec.ts
+++ b/e2e/test/scenarios/admin/i18n/content-translation/dashboards.cy.spec.ts
@@ -805,6 +805,82 @@ describe("scenarios > content translation > static embeds > dashboards", () => {
           });
         });
       });
+
+      it("translates selected static-list filter label in guest embed", () => {
+        const staticListFilter = {
+          name: "Number",
+          slug: "number",
+          id: "static-list-id",
+          type: "number/=",
+          sectionId: "number",
+          values_source_type: "static-list" as const,
+          values_source_config: {
+            values: [
+              ["1", "Gadget"],
+              ["2", "Widget"],
+            ],
+          },
+        };
+
+        cy.signInAsAdmin();
+        H.createQuestionAndDashboard({
+          questionDetails: {
+            name: "Expression Question",
+            query: {
+              "source-table": PEOPLE_ID,
+            },
+          },
+          dashboardDetails: {
+            parameters: [staticListFilter as any], // current API isn't set to accept string[][] as values
+            enable_embedding: true,
+            embedding_params: {
+              [staticListFilter.slug]: "enabled",
+            },
+          },
+        }).then(({ body: { id, card_id, dashboard_id } }) => {
+          // Map the parameter to an expression column so the filter widget
+          // is visible, but hasFields() returns false (testing the tc()
+          // fix in FormattedParameterValue)
+          cy.request("PUT", `/api/dashboard/${dashboard_id}`, {
+            dashcards: [
+              {
+                id,
+                card_id,
+                row: 0,
+                col: 0,
+                size_x: 24,
+                size_y: 9,
+                parameter_mappings: [
+                  {
+                    parameter_id: staticListFilter.id,
+                    card_id,
+                    target: [
+                      "dimension",
+                      ["expression", "Thing", { "base-type": "type/Integer" }],
+                      { "stage-number": 0 },
+                    ],
+                  },
+                ],
+              },
+            ],
+          });
+
+          H.visitEmbeddedPage(
+            {
+              resource: { dashboard: dashboard_id as number },
+              params: {},
+            },
+            {
+              setFilters: { [staticListFilter.slug]: "1" },
+              additionalHashOptions: {
+                locale: "de",
+              },
+            },
+          );
+
+          H.filterWidget().findByText("Gerät").should("be.visible");
+        });
+      });
     });
   });
 

--- a/frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx
+++ b/frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx
@@ -2,11 +2,13 @@ import { t } from "ttag";
 
 import { Ellipsified } from "metabase/common/components/Ellipsified";
 import { useSetting } from "metabase/common/hooks";
+import { useTranslateContent } from "metabase/i18n/hooks";
 import { ParameterFieldWidgetValue } from "metabase/parameters/components/widgets/ParameterFieldWidget/ParameterFieldWidgetValue/ParameterFieldWidgetValue";
 import { formatParameterValue } from "metabase/parameters/utils/formatting";
 import type { UiParameter } from "metabase-lib/v1/parameters/types";
 import {
   getFields,
+  hasFields,
   isFieldFilterUiParameter,
 } from "metabase-lib/v1/parameters/utils/parameter-fields";
 import {
@@ -41,6 +43,7 @@ function FormattedParameterValue({
   placeholder,
   isPopoverOpen = false,
 }: FormattedParameterValueProps) {
+  const tc = useTranslateContent();
   const formattingSettings = useSetting("custom-formatting");
 
   if (parameterHasNoDisplayValue(value)) {
@@ -60,6 +63,7 @@ function FormattedParameterValue({
   const renderContent = () => {
     if (
       isFieldFilterUiParameter(parameter) &&
+      hasFields(parameter) &&
       !isDateParameter(parameter) &&
       !isTemporalUnitParameter(parameter)
     ) {
@@ -78,7 +82,7 @@ function FormattedParameterValue({
     if (label) {
       return (
         <span>
-          {formatParameterValue(label, parameter, formattingSettings)}
+          {formatParameterValue(tc(label), parameter, formattingSettings)}
         </span>
       );
     }

--- a/frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx
+++ b/frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx
@@ -7,7 +7,6 @@ import { formatParameterValue } from "metabase/parameters/utils/formatting";
 import type { UiParameter } from "metabase-lib/v1/parameters/types";
 import {
   getFields,
-  hasFields,
   isFieldFilterUiParameter,
 } from "metabase-lib/v1/parameters/utils/parameter-fields";
 import {
@@ -61,7 +60,6 @@ function FormattedParameterValue({
   const renderContent = () => {
     if (
       isFieldFilterUiParameter(parameter) &&
-      hasFields(parameter) &&
       !isDateParameter(parameter) &&
       !isTemporalUnitParameter(parameter)
     ) {


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #70433
Closes [EMB-1409: Translated guest/static embed doesn't translate selected filter option for filters connected to custom columns](https://linear.app/metabase/issue/EMB-1409/translated-gueststatic-embed-doesnt-translate-selected-filter-option)

### Description

Fixes translation in guest embeddings for filter labels

### How to verify

1. Create a question with a custom column with the expression `1`

<img width="730" height="672" alt="Image" src="https://github.com/user-attachments/assets/e3de2c81-247b-4dd0-acd1-ee0b4084b9b7" />

2. Add it to a dashboard, add a Number filter connected to it, with a custom list of options `1,Yes`

<img width="1589" height="532" alt="Image" src="https://github.com/user-attachments/assets/11136aee-22d6-4254-bd7c-478343ab6179" />

<img width="982" height="625" alt="Image" src="https://github.com/user-attachments/assets/b4ee89c2-d045-49ab-b6b9-f9da8edb6b4d" />

3. For comparison, add another filter and connect it to whatever number column (e.g. Quantity) and do the same list of options (1,Yes)

<img width="723" height="420" alt="Image" src="https://github.com/user-attachments/assets/4de01e28-db71-4790-b690-a8543a3acbf1" />

4. Go to Admin > Embedding > Settings > Get translation dictionary, add the line `cs,Yes,Ano` and upload it
5. Embed the dashboard with a guest embed, make both filters Editable, and use locale `cs`:
```js
  defineMetabaseConfig({
    "isGuest": true,
    "instanceUrl": "http://localhost:3001",
    "locale": "cs"
  });
```

<img width="880" height="708" alt="Image" src="https://github.com/user-attachments/assets/408de427-50a0-41af-b3d6-e7ab771c9e2b" />

6. Choose a value on the first filter, it correctly says Ano (translated)

<img width="336" height="244" alt="Image" src="https://github.com/user-attachments/assets/83ceaf34-33cb-4d0c-8533-b7c241f1a1b0" />

7. Choose a value on the second, it correctly says Ano too (translated)

<img width="321" height="243" alt="Image" src="https://github.com/user-attachments/assets/a87a5123-aed0-4631-b449-f0cea66e9f11" />

### Demo

<img width="1639" height="548" alt="image" src="https://github.com/user-attachments/assets/9d626bc2-262a-4f0b-be32-2bddad3b4b4d" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
