### PR TITLE
Fix broken e2e test for #68998

### DIFF
--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-text-category.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-text-category.cy.spec.js
@@ -213,22 +213,31 @@ GROUP BY PRODUCTS.CATEGORY`;
   });
 
   it("should show all available category options for combined dataset (metabase#68998)", () => {
-    H.createNativeQuestion({
-      name: "SQL- Postgres",
-      native: {
-        query: sqlQueryDetails,
-        "template-tags": {
-          field: {
-            "widget-type": "string/=",
-            name: "field",
-            "display-name": "Field",
-            id: "3db026c4-5ec6-4568-9a40-eb704bac2bde",
-            type: "dimension",
-            dimension: ["field", 1552, null], // 1552 - Products.Category
+    H.getTableId({
+      name: "products",
+    }).then((tableId) => {
+      return H.getFieldId({
+        tableId,
+        name: "category",
+      }).then((fieldId) => {
+        return H.createNativeQuestion({
+          name: "SQL- Postgres",
+          native: {
+            query: sqlQueryDetails,
+            "template-tags": {
+              field: {
+                "widget-type": "string/=",
+                name: "field",
+                "display-name": "Field",
+                id: "3db026c4-5ec6-4568-9a40-eb704bac2bde",
+                type: "dimension",
+                dimension: ["field", fieldId, null], // fieldId - Products.Category in Postgres DB
+              },
+            },
           },
-        },
-      },
-      database: PG_DB_ID,
+          database: PG_DB_ID,
+        });
+      });
     });
 
     H.createNativeQuestionAndDashboard({


### PR DESCRIPTION
Closes UXW-3102

### Description

This fixes a broken e2e test that I added in https://github.com/metabase/metabase/pull/69318 .
I used hardcoded `fieldId` for a writeable DB field, which seems have changed after some time, so I refactored the code to pick field id from the api.

### How to verify

1. Check CI
2. `should show all available category options for combined dataset (metabase#68998)` should pass without errors.
3. Also check stress-test - https://github.com/metabase/metabase/actions/runs/22861140518


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
