### PR TITLE
test(eajs): handleLink should prevent default behavior when returning `{handled:true}`

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/sdk-iframe-embedding.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/sdk-iframe-embedding.cy.spec.ts
@@ -499,16 +499,42 @@ describe("scenarios > embedding > modular embedding", () => {
 
       cy.wait("@getDashCardQuery");
 
+      // Spy on the iframe's anchor clicks and window.open
+      // so we can check the default behavior is prevented
+      cy.get("iframe").then(($iframe) => {
+        const iframeWin: any = $iframe[0].contentWindow;
+        expect(iframeWin).to.not.be.null;
+
+        iframeWin.__blankLinkClicks = [];
+        iframeWin.__windowOpenCalls = [];
+
+        iframeWin.HTMLAnchorElement.prototype.click = function () {
+          iframeWin.__blankLinkClicks.push(this.href);
+        };
+
+        iframeWin.open = function (...args: unknown[]) {
+          iframeWin.__windowOpenCalls.push(args);
+        };
+      });
+
       frame.within(() => {
         cy.findByText("Order 448").click();
       });
 
-      // Verify handleLink was called with the correct URL
+      cy.log("Verify handleLink was called with the correct URL");
       cy.window()
         .its("handleLinkCalls")
         .should("have.length", 1)
         .its(0)
         .should("include", "https://example.org/order/448");
+
+      cy.log("Verify that no default navigation happened");
+      cy.get("iframe")
+        .its("0.contentWindow.__blankLinkClicks")
+        .should("have.length", 0);
+      cy.get("iframe")
+        .its("0.contentWindow.__windowOpenCalls")
+        .should("have.length", 0);
     });
   });
 


### PR DESCRIPTION
Closes [EMB-1304: Check if we can check that the default behavior is not happening in eajs when handleLink returns `{ handled: true}`](https://linear.app/metabase/issue/EMB-1304/check-if-we-can-check-that-the-default-behavior-is-not-happening-in)

### Description

Adds a test that checks that we don't do the default behavior

### How to verify

Apply this patch that breaks the logic

```diff
diff --git a/e2e/test/scenarios/embedding/sdk-iframe-embedding/sdk-iframe-embedding.cy.spec.ts b/e2e/test/scenarios/embedding/sdk-iframe-embedding/sdk-iframe-embedding.cy.spec.ts
index 7f3b6dfe957..0d6821906f0 100644
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/sdk-iframe-embedding.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/sdk-iframe-embedding.cy.spec.ts
@@ -472,7 +472,7 @@ describe("scenarios > embedding > modular embedding", () => {
       cy.signOut();
     });
 
-    it("calls handleLink when a link is clicked and prevents navigation when handled: true", function () {
+    it.only("calls handleLink when a link is clicked and prevents navigation when handled: true", function () {
       const frame = H.loadSdkIframeEmbedTestPage({
         elements: [
           {
@@ -522,11 +522,11 @@ describe("scenarios > embedding > modular embedding", () => {
       });
 
       cy.log("Verify handleLink was called with the correct URL");
-      cy.window()
-        .its("handleLinkCalls")
-        .should("have.length", 1)
-        .its(0)
-        .should("include", "https://example.org/order/448");
+      // cy.window()
+      //   .its("handleLinkCalls")
+      //   .should("have.length", 1)
+      //   .its(0)
+      //   .should("include", "https://example.org/order/448");
 
       cy.log("Verify that no default navigation happened");
       cy.get("iframe")
diff --git a/frontend/src/metabase/lib/dom.ts b/frontend/src/metabase/lib/dom.ts
index 31827e086d6..d0a67598d5f 100644
--- a/frontend/src/metabase/lib/dom.ts
+++ b/frontend/src/metabase/lib/dom.ts
@@ -213,10 +213,10 @@ export async function open(
   // In the sdk, allow the host app to override how to open links
   if (isEmbeddingSdk()) {
     const result = await handleLinkSdkPlugin(url);
-    if (result.handled) {
-      // Plugin handled the link, don't continue with default behavior
-      return;
-    }
+    // if (result.handled) {
+    //   // Plugin handled the link, don't continue with default behavior
+    //   return;
+    // }
   }
 
   if (shouldOpenInBlankWindow(url, options)) {

```
You should see it errors
<img width="599" height="409" alt="image" src="https://github.com/user-attachments/assets/bb225138-c6dd-4efd-ae71-888bae0c75b2" />


