### PR TITLE
Handle Data Analyst group name conflict

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/data_studio/api/permissions_groups_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_studio/api/permissions_groups_test.clj
@@ -36,11 +36,15 @@
                    (t2/select-one-fn :magic_group_type :model/PermissionsGroup :id data-analyst-group-id)))))))))
 
 (defmacro with-reset-data-analyst-group! [& body]
-  `(let [original# (t2/select-one-pk :model/PermissionsGroup :magic_group_type perms-group/data-analyst-magic-group-type)]
+  `(let [original-group# (t2/select-one :model/PermissionsGroup :magic_group_type perms-group/data-analyst-magic-group-type)]
      (try
        (mt/with-model-cleanup [:model/PermissionsGroup]
          (do ~@body))
-       (finally (t2/update! :model/PermissionsGroup :id original# {:magic_group_type perms-group/data-analyst-magic-group-type})))))
+       (finally
+         (with-bindings {(var perms-group/*allow-modifying-magic-groups*) true}
+           (t2/update! :model/PermissionsGroup :id (:id original-group#)
+                       {:magic_group_type perms-group/data-analyst-magic-group-type
+                        :name             (:name original-group#)}))))))
 
 (deftest sync-data-analyst-group-for-oss!-converts-with-members-test
   (testing "Without the premium feature, sync-data-analyst-group-for-oss! converts the Data Analysts group when it has members"
@@ -64,6 +68,26 @@
                 (is (some? new-magic-group))
                 (is (= "Data Analysts" (:name new-magic-group)))
                 (is (zero? (t2/count :model/PermissionsGroupMembership :group_id (:id new-magic-group))))))))))))
+
+(deftest sync-data-analyst-group-for-oss!-preserves-name-test
+  (testing "When the magic group has a non-default name (e.g. from a migration conflict), the new magic group keeps that name"
+    (mt/with-premium-features #{}
+      (with-reset-data-analyst-group!
+        (let [original-group-id (t2/select-one-pk :model/PermissionsGroup :magic_group_type perms-group/data-analyst-magic-group-type)]
+          ;; Simulate the migration conflict scenario: rename the magic group to the fallback name
+          (with-bindings {(var perms-group/*allow-modifying-magic-groups*) true}
+            (t2/update! :model/PermissionsGroup original-group-id {:name "Metabase Data Analysts"}))
+          (mt/with-temp [:model/User {user-id :id} {}]
+            (perms/add-user-to-group! user-id original-group-id)
+            (perms-group/sync-data-analyst-group-for-oss!)
+            (testing "Converted group should use the magic group's name as its base"
+              (let [converted-group (t2/select-one :model/PermissionsGroup :id original-group-id)]
+                (is (= "Metabase Data Analysts (converted)" (:name converted-group)))
+                (is (nil? (:magic_group_type converted-group)))))
+            (testing "New magic group should reuse the old magic group's name"
+              (let [new-magic-group (t2/select-one :model/PermissionsGroup
+                                                   :magic_group_type perms-group/data-analyst-magic-group-type)]
+                (is (= "Metabase Data Analysts" (:name new-magic-group)))))))))))
 
 (deftest sync-data-analyst-group-for-oss!-idempotent-empty-test
   (testing "In OSS, sync-data-analyst-group-for-oss! is idempotent when magic group is empty"

--- a/resources/migrations/058_update_migrations.yaml
+++ b/resources/migrations/058_update_migrations.yaml
@@ -1302,12 +1302,44 @@ databaseChangeLog:
                     nullable: false
 
   - changeSet:
-      id: v58.2026-01-09T12:00:00
+      id: v58.2026-01-09T11:30:00
       author: johnswanson
-      comment: Create data-analyst magic permissions group
+      comment: |
+        Migration `v58.2026-01-09T12:00:00` had an issue for some customers (where a user-defined Data Analysts group
+        already existed). We need to replace this migration with a new one, but don't want the old migration to still
+        exist in the `databasechangelog`, to avoid incorrectly reporting that the latest migration is a `v58`
+        migration (if someone downgrades to v57).
       changes:
         - sql:
-            sql: INSERT INTO permissions_group (name, magic_group_type) VALUES ('Data Analysts', 'data-analyst')
+            dbms: postgres,h2
+            sql: >-
+              DELETE FROM databasechangelog WHERE id = 'v58.2026-01-09T12:00:00';
+        - sql:
+            dbms: mysql,mariadb
+            sql: >-
+              DELETE FROM DATABASECHANGELOG WHERE id = 'v58.2026-01-09T12:00:00';
+      rollback: # not needed
+
+  - changeSet:
+      id: v58.2026-01-09T11:30:01
+      author: johnswanson
+      comment: Create data-analyst magic permissions group, handling name conflicts
+      validCheckSum: ANY
+      preConditions:
+        - onFail: MARK_RAN
+        - sqlCheck:
+            expectedResult: 0
+            sql: SELECT COUNT(*) FROM permissions_group WHERE magic_group_type = 'data-analyst'
+      changes:
+        - sql:
+            sql: >-
+              INSERT INTO permissions_group (name, magic_group_type)
+              SELECT
+                CASE WHEN EXISTS (SELECT 1 FROM permissions_group WHERE name = 'Data Analysts')
+                THEN 'Metabase Data Analysts'
+                ELSE 'Data Analysts'
+                END,
+                'data-analyst'
       rollback:
         - sql:
             sql: DELETE FROM permissions_group WHERE magic_group_type = 'data-analyst';

--- a/src/metabase/permissions/models/permissions_group.clj
+++ b/src/metabase/permissions/models/permissions_group.clj
@@ -220,10 +220,11 @@
 (defn- unique-converted-group-name
   "Generate a unique name for the converted Data Analysts group.
   Returns \"Data Analysts (converted)\", or \"Data Analysts (converted) (2)\", etc."
-  []
-  (let [existing-names (t2/select-fn-set :name :model/PermissionsGroup
-                                         :name [:like "Data Analysts (converted)%"])
-        base-name      "Data Analysts (converted)"]
+  [group-name]
+  (let [base-name (format "%s (converted)" group-name)
+        like-pattern (str base-name "%")
+        existing-names (t2/select-fn-set :name :model/PermissionsGroup
+                                         :name [:like like-pattern])]
     (if-not (contains? existing-names base-name)
       base-name
       (loop [n 2]
@@ -260,11 +261,11 @@
           (t2/with-transaction [_conn]
             ;; Rename and demote the existing group to a normal visible group
             (t2/update! :model/PermissionsGroup (:id existing-group)
-                        {:name             (unique-converted-group-name)
+                        {:name             (unique-converted-group-name (:name existing-group))
                          :magic_group_type nil})
-            ;; Create new empty magic group with default library permissions
+            ;; Create new empty magic group with default library permissions, reusing the old name
             (let [{new-group-id :id} (t2/insert-returning-instance! :model/PermissionsGroup
-                                                                    {:name             "Data Analysts"
+                                                                    {:name             (:name existing-group)
                                                                      :magic_group_type data-analyst-magic-group-type})]
               (grant-library-permissions! new-group-id))
             (t2/update! :model/User {:is_data_analyst true} {:is_data_analyst false})))))))


### PR DESCRIPTION
There are 30 instances on stats with groups named "Data Analysts". We need to handle this case.

First, we modify the migration:

- set `validCheckSum` to `ANY` to handle the case where this migration already ran

- skip if there's already a `data-analyst` magic group

- insert a group named "Data Analysts", if one doesn't already exist

- otherwise name it "Metabase Data Analysts" (there are 0 groups on with this name in cloud, theoretically it's possible but someone would have to have BOTH `Metabase Data Analysts` and `Data Analysts` for this to be an issue).

Similarly, we create a "Data Analysts" group on startup in OSS if one doesn't already exist. This group is an invisible placeholder, that will become visible if the instance ever upgrades. Adopt similar logic here: if the existing group for data analysts is called "Metabase Data Analysts", rename it to "Metabase Data Analysts (converted)" and create the new placeholder group as "Metabase Data Analysts".

Note: I also needed to create a migration that deletes the *old* version of this migration from `databasechangelog`. This is so that, if someone upgrades to this version, then downgrades to an older version of Metabase, we won't erroneously report that the most recent migration run was `v58.*`.
