### PR TITLE
Add query metadata to BigQuery Job Labels

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -1,6 +1,7 @@
 (ns metabase.driver.bigquery-cloud-sdk
   (:refer-clojure :exclude [mapv some empty? not-empty])
   (:require
+   [buddy.core.codecs :as codecs]
    [clojure.core.async :as a]
    [clojure.set :as set]
    [clojure.string :as str]
@@ -223,6 +224,7 @@
      database
      sql
      params
+     nil
      nil)))
 
 (defn- describe-database-tables
@@ -644,7 +646,36 @@
     (driver-api/system-timezone-id)
     "UTC"))
 
-(defn- build-bigquery-request [^String sql parameters]
+(defn- sanitize-label-value
+  "Sanitize a string for use as a BigQuery job label value.
+   Values can contain only lowercase letters, numeric characters, underscores, and dashes, max 63 chars."
+  [s]
+  (when s
+    (let [sanitized (-> (str s)
+                        u/lower-case-en
+                        (str/replace #"[^a-z0-9_-]" "_"))]
+      (subs sanitized 0 (min 63 (count sanitized))))))
+
+(defn- query->job-labels
+  "Build a map of BigQuery job labels from query info for attribution tracking."
+  [outer-query]
+  (let [{:keys [executed-by card-id card-name dashboard-id query-hash]} (:info outer-query)
+        query-type (case (keyword (:type outer-query))
+                     :query  "mbql"
+                     :native "native"
+                     nil)
+        hash-hex   (when query-hash (codecs/bytes->hex query-hash))]
+    (into {}
+          (remove (comp nil? val))
+          (cond-> {}
+            executed-by  (assoc "metabase-user-id"      (str executed-by))
+            query-type   (assoc "metabase-query-type"    query-type)
+            hash-hex     (assoc "metabase-query-hash"    (subs hash-hex 0 (min 63 (count hash-hex))))
+            card-id      (assoc "metabase-card-id"       (str card-id))
+            card-name    (assoc "metabase-card-name"     (sanitize-label-value card-name))
+            dashboard-id (assoc "metabase-dashboard-id"  (str dashboard-id))))))
+
+(defn- build-bigquery-request [^String sql parameters labels]
   (.build
    (doto (QueryJobConfiguration/newBuilder sql)
       ;; if the query contains a `#legacySQL` directive then use legacy SQL instead of standard SQL
@@ -654,7 +685,8 @@
       ;; effect for RPC (a.k.a. "fast") calls
       ;; there is no equivalent of .setMaxRows on a JDBC Statement; we rely on our middleware to stop
       ;; realizing more rows as per the maximum result size
-     (.setMaxResults *page-size*))))
+     (.setMaxResults *page-size*)
+     (cond-> (seq labels) (.setLabels labels)))))
 
 (defn- reducible-bigquery-results
   [^TableResult page cancel-chan attempt-job-cancel-fn]
@@ -730,14 +762,14 @@
     (respond cols results)))
 
 (defn- execute-bigquery
-  [respond database-details ^String sql parameters cancel-chan]
+  [respond database-details ^String sql parameters cancel-chan labels]
   {:pre [(not (str/blank? sql))]}
   ;; Kicking off two async jobs:
   ;; - Waiting for the cancel-chan to get either a cancel message or to be closed.
   ;; - Running the BigQuery execution in another thread, since it's blocking.
   (let [^BigQuery client (database-details->client database-details)
         result-promise   (promise)
-        request          (build-bigquery-request sql parameters)
+        request          (build-bigquery-request sql parameters labels)
         _                (driver.conn/track-connection-acquisition! database-details)
         job              (.create client (JobInfo/of request) (u/varargs BigQuery$JobOption))
         job-id           (.getJobId job)
@@ -780,7 +812,8 @@
    database :- [:map [:details :map]]
    sql
    parameters
-   cancel-chan]
+   cancel-chan
+   labels]
   {:pre [(map? database) (map? (:details database))]}
   ;; automatically retry the query if it times out or otherwise fails. This is on top of the auto-retry added by
   ;; `execute`
@@ -791,7 +824,8 @@
                    details
                    sql
                    parameters
-                   cancel-chan))]
+                   cancel-chan
+                   labels))]
     (try
       (thunk)
       (catch Throwable e
@@ -802,13 +836,16 @@
 
 (defmethod driver/execute-reducible-query :bigquery-cloud-sdk
   [_driver {{sql :query, :keys [params]} :native, :as outer-query} _context respond]
-  (let [database (driver-api/database (driver-api/metadata-provider))]
+  (let [database (driver-api/database (driver-api/metadata-provider))
+        include-tracking? (:include-user-id-and-hash (driver.conn/effective-details database) true)]
     (binding [bigquery.common/*bigquery-timezone-id* (effective-query-timezone-id database)]
       (log/tracef "Running BigQuery query in %s timezone" bigquery.common/*bigquery-timezone-id*)
-      (let [sql (if (:include-user-id-and-hash (driver.conn/effective-details database) true)
-                  (str "-- " (driver-api/query->remark :bigquery-cloud-sdk outer-query) "\n" sql)
-                  sql)]
-        (*process-native* respond database sql params (driver-api/canceled-chan))))))
+      (let [sql    (if include-tracking?
+                     (str "-- " (driver-api/query->remark :bigquery-cloud-sdk outer-query) "\n" sql)
+                     sql)
+            labels (when include-tracking?
+                     (query->job-labels outer-query))]
+        (*process-native* respond database sql params (driver-api/canceled-chan) labels)))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                           Other Driver Method Impls                                            |

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
@@ -235,7 +235,7 @@
 (defn- query->native [query]
   (let [native-query   (atom nil)
         done-exception (Exception. "Done.")]
-    (binding [bigquery/*process-native* (fn [_respond _database sql _parameters _cancel-chan]
+    (binding [bigquery/*process-native* (fn [_respond _database sql _parameters _cancel-chan _labels]
                                           (reset! native-query sql)
                                           (throw done-exception))]
       (try
@@ -302,6 +302,37 @@
                             :limit        1}
                  :info     {:executed-by 1000
                             :query-hash  (byte-array [1 2 3 4])}})))))))
+
+(deftest ^:parallel job-labels-test
+  (testing "query->job-labels builds correct labels from query info"
+    (is (= {"metabase-user-id"     "1000"
+            "metabase-query-type"   "mbql"
+            "metabase-query-hash"   "01020304"
+            "metabase-card-id"      "42"
+            "metabase-card-name"    "my_cool_question"
+            "metabase-dashboard-id" "7"}
+           (#'bigquery/query->job-labels
+            {:type :query
+             :info {:executed-by  1000
+                    :query-hash   (byte-array [1 2 3 4])
+                    :card-id      42
+                    :card-name    "My Cool Question"
+                    :dashboard-id 7}}))))
+  (testing "missing info keys are omitted from labels"
+    (is (= {"metabase-user-id"   "1000"
+            "metabase-query-type" "native"
+            "metabase-query-hash" "01020304"}
+           (#'bigquery/query->job-labels
+            {:type :native
+             :info {:executed-by 1000
+                    :query-hash  (byte-array [1 2 3 4])}}))))
+  (testing "card-name is sanitized for BigQuery label constraints"
+    (is (= "revenue_by_region__q1_2024_"
+           (get (#'bigquery/query->job-labels
+                 {:type :query
+                  :info {:card-id   1
+                         :card-name "Revenue by Region (Q1 2024)"}})
+                "metabase-card-name")))))
 
 (deftest ^:parallel query-with-params-test
   (testing "Can we execute queries with parameters? (EE #277)"

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/test/data/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/test/data/bigquery_cloud_sdk.clj
@@ -126,7 +126,7 @@
     (let [sql (apply format format-string args)]
       (log/infof "[BigQuery] %s\n" sql)
       (flush)
-      (#'bigquery/execute-bigquery execute-respond (test-db-details) sql [] nil))))
+      (#'bigquery/execute-bigquery execute-respond (test-db-details) sql [] nil nil))))
 
 (defn execute-params!
   "Execute arbitrary (presumably DDL) SQL statements against the test project. Waits for statement to complete, throwing
@@ -135,7 +135,7 @@
   (driver/with-driver :bigquery-cloud-sdk
     (log/infof "[BigQuery] %s\n" sql)
     (flush)
-    (#'bigquery/execute-bigquery execute-respond (test-db-details) sql params nil)))
+    (#'bigquery/execute-bigquery execute-respond (test-db-details) sql params nil nil)))
 
 (defn- destroy-dataset! [^String dataset-id]
   {:pre [(seq dataset-id)]}
@@ -217,7 +217,7 @@
 
 (defn- table-row-count ^Integer [^String dataset-id, ^String table-id]
   (let [sql (format "SELECT count(*) FROM `%s.%s.%s`" (project-id) dataset-id table-id)]
-    (ffirst (#'bigquery/execute-bigquery execute-respond (test-db-details) sql [] nil))))
+    (ffirst (#'bigquery/execute-bigquery execute-respond (test-db-details) sql [] nil nil))))
 
 (defprotocol ^:private Insertable
   (^:private ->insertable [this]


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/31219

### Description

I want to use the `INFORMATION_SCHEMA.JOBS` tables in BigQuery to understand my costs. We already embed some metadata in a comment when the `include-user-id-and-hash` option is selected, but it's easier to deal with if it's a real label on the job (https://docs.cloud.google.com/bigquery/docs/labels-intro).

I put it behind the `include-user-id-and-hash` option just in case some users may be concerned about the metadata leakage, but it may make sense to always submit, to allow users to track which queries are driving BigQuery costs without potentially interfering with the cachability of the query.

### How to verify

Run job, query `INFORMATION_SCHEMA.JOBS` and look at the labels column to make sure the relevant data is included.

### Demo

n/a

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
