### PR TITLE
Fix rollback when migration has moved

### DIFF
--- a/src/metabase/app_db/liquibase.clj
+++ b/src/metabase/app_db/liquibase.clj
@@ -26,7 +26,7 @@
    (liquibase Contexts LabelExpression Liquibase RuntimeEnvironment Scope Scope$Attr Scope$ScopedRunner UpdateSummaryOutputEnum)
    (liquibase.change.custom CustomChangeWrapper)
    (liquibase.changelog ChangeLogIterator ChangeSet ChangeSet$ExecType)
-   (liquibase.changelog.filter ChangeSetFilter ChangeSetFilterResult DbmsChangeSetFilter IgnoreChangeSetFilter)
+   (liquibase.changelog.filter AlreadyRanChangeSetFilter ChangeSetFilter ChangeSetFilterResult DbmsChangeSetFilter IgnoreChangeSetFilter)
    (liquibase.changelog.visitor AbstractChangeExecListener ChangeExecListener UpdateVisitor)
    (liquibase.command.core AbstractRollbackCommandStep)
    (liquibase.database Database DatabaseFactory)
@@ -540,6 +540,7 @@
            latest-available (latest-available-major-version liquibase)
            latest-applied   (latest-applied-major-version conn (.getDatabase liquibase))
            lb-db (.getDatabase liquibase)
+           ran-changesets (.getRanChangeSetList lb-db)
            changelog (.getDatabaseChangeLog liquibase)
            changeset-filter (proxy [ChangeSetFilter] []
                               (accepts [^ChangeSet changeSet]
@@ -583,19 +584,32 @@
                                                      changelog
                                                      change-listener))
            (let [remaining-query (-> (sql.helpers/select :id)
-                                     (sql.helpers/from (keyword (changelog-table-name liquibase)))
-                                     (sql.helpers/where [:in :id ids-to-drop]))
-                 formatted-sql (sql/format remaining-query)
-                 remaining-ids   (map :id (t2/query conn formatted-sql))]
-             (when (seq remaining-ids)
-               (if (seq @error-ids)
-                 (log/warnf "The following changesets were not rolled back due to errors (%s): %s"
-                            (str/join ", " @error-ids)
-                            (str/join ", " remaining-ids))
-                 ;; Rollback SQL ran (tables dropped), but removeRanStatus also matches by
-                 ;; (id, author, filepath) — mismatched filenames leave orphaned entries.
-                 (do
-                   (log/infof "Cleaning up %d changelog entries with mismatched filenames" (count remaining-ids))
-                   (let [delete-query (-> (sql.helpers/delete-from (keyword (changelog-table-name liquibase)))
-                                         (sql.helpers/where [:in :id (vec remaining-ids)]))]
-                     (jdbc/execute! {:connection conn} (sql/format delete-query)))))))))))))
+                                    (sql.helpers/from (keyword (changelog-table-name liquibase)))
+                                    (sql.helpers/where [:in :id ids-to-drop]))
+                formatted-sql (sql/format remaining-query)
+                remaining-ids (map :id (t2/query conn formatted-sql))]
+            (when (seq remaining-ids)
+              (if (seq @error-ids)
+                (log/warnf "The following changesets were not rolled back due to errors (%s): %s"
+                           (str/join ", " @error-ids)
+                           (str/join ", " remaining-ids))
+                ;; Rollback SQL ran (tables dropped), but removeRanStatus also matches by
+                ;; (id, author, filepath) — mismatched filenames leave orphaned entries.
+                ;; Use AlreadyRanChangeSetFilter to confirm which are truly filepath mismatches
+                ;; before deleting.
+                (let [already-ran-filter (AlreadyRanChangeSetFilter. ran-changesets)
+                      remaining-set     (set remaining-ids)
+                      remaining-cs      (filter #(contains? remaining-set (.getId ^ChangeSet %))
+                                                (.getChangeSets changelog))
+                      mismatched-ids    (->> remaining-cs
+                                             (remove #(.isAccepted (.accepts already-ran-filter %)))
+                                             (mapv #(.getId ^ChangeSet %)))]
+                  (when (seq mismatched-ids)
+                    (log/infof "Cleaning up %d changelog entries with mismatched filenames" (count mismatched-ids))
+                    (let [delete-query (-> (sql.helpers/delete-from (keyword (changelog-table-name liquibase)))
+                                          (sql.helpers/where [:in :id mismatched-ids]))]
+                      (jdbc/execute! {:connection conn} (sql/format delete-query))))
+                  (let [unexpected (remove (set mismatched-ids) remaining-ids)]
+                    (when (seq unexpected)
+                      (log/warnf "Unexpected: %d changesets remain after rollback with matching filenames: %s"
+                                 (count unexpected) (str/join ", " unexpected))))))))))))))

--- a/src/metabase/app_db/liquibase.clj
+++ b/src/metabase/app_db/liquibase.clj
@@ -26,7 +26,7 @@
    (liquibase Contexts LabelExpression Liquibase RuntimeEnvironment Scope Scope$Attr Scope$ScopedRunner UpdateSummaryOutputEnum)
    (liquibase.change.custom CustomChangeWrapper)
    (liquibase.changelog ChangeLogIterator ChangeSet ChangeSet$ExecType)
-   (liquibase.changelog.filter AlreadyRanChangeSetFilter ChangeSetFilter ChangeSetFilterResult DbmsChangeSetFilter IgnoreChangeSetFilter)
+   (liquibase.changelog.filter ChangeSetFilter ChangeSetFilterResult DbmsChangeSetFilter IgnoreChangeSetFilter)
    (liquibase.changelog.visitor AbstractChangeExecListener ChangeExecListener UpdateVisitor)
    (liquibase.command.core AbstractRollbackCommandStep)
    (liquibase.database Database DatabaseFactory)
@@ -540,7 +540,6 @@
            latest-available (latest-available-major-version liquibase)
            latest-applied   (latest-applied-major-version conn (.getDatabase liquibase))
            lb-db (.getDatabase liquibase)
-           ran-changesets   (.getRanChangeSetList lb-db)
            changelog (.getDatabaseChangeLog liquibase)
            changeset-filter (proxy [ChangeSetFilter] []
                               (accepts [^ChangeSet changeSet]
@@ -551,11 +550,16 @@
                                                                      (log/infof "Going to roll back changeset %s" id)
                                                                      (str "Changeset ID '" id "' is in target list"))
                                                                    (str "Changeset ID '" id "' is not in target list")) nil))))
-           changelog-iterator (ChangeLogIterator. ran-changesets changelog
+           ;; Use the simple ChangeLogIterator constructor to avoid the (ranChangeSets, changelog)
+           ;; constructor which silently drops changesets when the FILENAME column in
+           ;; databasechangelog doesn't match the current changelog filepath. This happens when
+           ;; migrations are moved between files (e.g., 058 -> 059). Our changeset-filter already
+           ;; limits rollback to IDs present in databasechangelog, making AlreadyRanChangeSetFilter
+           ;; redundant.
+           changelog-iterator (ChangeLogIterator. changelog
                                                   (doto (ArrayList.)
                                                     (.addAll
-                                                     [(AlreadyRanChangeSetFilter. ran-changesets)
-                                                      (IgnoreChangeSetFilter.)
+                                                     [(IgnoreChangeSetFilter.)
                                                       (DbmsChangeSetFilter. lb-db)
                                                       changeset-filter])))
            error-ids (atom [])]
@@ -587,8 +591,15 @@
                  formatted-sql (sql/format remaining-query)
                  remaining-ids   (map :id (t2/query conn formatted-sql))]
              (when (seq remaining-ids)
-               (log/warnf "The following changesets were not rolled back. Likely because %s: %s"
-                          (if (seq @error-ids)
-                            (format "there were errors in rollback (%s)" (str/join ", " @error-ids))
-                            "they are not in the changelog file")
-                          (str/join ", " remaining-ids))))))))))
+               (if (seq @error-ids)
+                 (log/warnf "The following changesets were not rolled back due to errors (%s): %s"
+                            (str/join ", " @error-ids)
+                            (str/join ", " remaining-ids))
+                 ;; Remaining entries are likely due to FILENAME mismatch in databasechangelog
+                 ;; (e.g., migrations moved between files). The rollback SQL already executed
+                 ;; via the changelog; clean up the stale databasechangelog entries.
+                 (do
+                   (log/infof "Cleaning up %d changelog entries with mismatched filenames" (count remaining-ids))
+                   (let [delete-query (-> (sql.helpers/delete-from (keyword (changelog-table-name liquibase)))
+                                         (sql.helpers/where [:in :id (vec remaining-ids)]))]
+                     (jdbc/execute! {:connection conn} (sql/format delete-query)))))))))))))

--- a/src/metabase/app_db/liquibase.clj
+++ b/src/metabase/app_db/liquibase.clj
@@ -550,12 +550,9 @@
                                                                      (log/infof "Going to roll back changeset %s" id)
                                                                      (str "Changeset ID '" id "' is in target list"))
                                                                    (str "Changeset ID '" id "' is not in target list")) nil))))
-           ;; Use the simple ChangeLogIterator constructor to avoid the (ranChangeSets, changelog)
-           ;; constructor which silently drops changesets when the FILENAME column in
-           ;; databasechangelog doesn't match the current changelog filepath. This happens when
-           ;; migrations are moved between files (e.g., 058 -> 059). Our changeset-filter already
-           ;; limits rollback to IDs present in databasechangelog, making AlreadyRanChangeSetFilter
-           ;; redundant.
+           ;; Use the simple (changelog, filters) constructor — NOT the (ranChangeSets, changelog, filters)
+           ;; overload, which silently excludes changesets whose FILENAME in databasechangelog doesn't
+           ;; match the current YAML filepath. Our changeset-filter selects by ID alone, avoiding this.
            changelog-iterator (ChangeLogIterator. changelog
                                                   (doto (ArrayList.)
                                                     (.addAll
@@ -595,9 +592,8 @@
                  (log/warnf "The following changesets were not rolled back due to errors (%s): %s"
                             (str/join ", " @error-ids)
                             (str/join ", " remaining-ids))
-                 ;; Remaining entries are likely due to FILENAME mismatch in databasechangelog
-                 ;; (e.g., migrations moved between files). The rollback SQL already executed
-                 ;; via the changelog; clean up the stale databasechangelog entries.
+                 ;; Rollback SQL ran (tables dropped), but removeRanStatus also matches by
+                 ;; (id, author, filepath) — mismatched filenames leave orphaned entries.
                  (do
                    (log/infof "Cleaning up %d changelog entries with mismatched filenames" (count remaining-ids))
                    (let [delete-query (-> (sql.helpers/delete-from (keyword (changelog-table-name liquibase)))

--- a/test/metabase/app_db/liquibase_test.clj
+++ b/test/metabase/app_db/liquibase_test.clj
@@ -1,5 +1,6 @@
 (ns ^:mb/driver-tests metabase.app-db.liquibase-test
   (:require
+   [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.app-db.core :as mdb]
@@ -182,3 +183,87 @@
                                     (liquibase/rollback-major-version! conn liquibase false (dec actual-latest-available-version))))
               (testing "CAN downgrade if forced"
                 (liquibase/rollback-major-version! conn liquibase true (dec actual-latest-available-version))))))))))
+
+(deftest rollback-workspace-tables-test
+  (mt/test-drivers #{:h2 :mysql :postgres}
+    (mt/with-temp-empty-app-db [conn driver/*driver*]
+      (liquibase/with-liquibase [liquibase conn]
+        (.update liquibase "")
+        ;; H2 uppercases table names; MySQL/Postgres use lowercase
+        (let [wit-name (if (= driver/*driver* :h2) "WORKSPACE_INPUT_TRANSFORM" "workspace_input_transform")
+              wi-name  (if (= driver/*driver* :h2) "WORKSPACE_INPUT" "workspace_input")]
+          ;; Sanity check: workspace tables exist after migration
+          (is (liquibase/table-exists? wit-name conn))
+          (is (liquibase/table-exists? wi-name conn))
+          ;; Roll back to v58
+          (liquibase/rollback-major-version! conn liquibase false 58)
+          ;; workspace_input_transform must be gone (it has a FK to workspace_input)
+          (is (not (liquibase/table-exists? wit-name conn))
+              "workspace_input_transform should be dropped during rollback")
+          (is (not (liquibase/table-exists? wi-name conn))
+              "workspace_input should be dropped during rollback"))
+        ;; No v59 changesets should remain in databasechangelog
+        (let [changelog-table (liquibase/changelog-table-name liquibase)
+              remaining (jdbc/query {:connection conn}
+                                    [(format "SELECT id FROM %s WHERE id LIKE 'v59.%%'" changelog-table)])]
+          (is (empty? remaining)
+              (str "v59 changesets remaining: " (mapv :id remaining))))))))
+
+(deftest rollback-mark-ran-workspace-tables-test
+  (testing "Rollback works even when workspace table changesets were MARK_RAN (simulating prior state)"
+    (mt/test-drivers #{:h2 :postgres}
+      (mt/with-temp-empty-app-db [conn driver/*driver*]
+        (liquibase/with-liquibase [liquibase conn]
+          (.update liquibase "")
+          (let [changelog-table (liquibase/changelog-table-name liquibase)
+                wit-name (if (= driver/*driver* :h2) "WORKSPACE_INPUT_TRANSFORM" "workspace_input_transform")
+                wi-name  (if (= driver/*driver* :h2) "WORKSPACE_INPUT" "workspace_input")]
+            ;; Simulate the scenario: these changesets were MARK_RAN (table already existed
+            ;; from a prior branch version). Flip EXECTYPE in databasechangelog.
+            (jdbc/execute! {:connection conn}
+                           [(format "UPDATE %s SET EXECTYPE = 'MARK_RAN' WHERE ID IN ('v59.2026-02-09T12:00:07', 'v59.2026-01-31T12:00:41', 'v59.2026-02-09T12:00:01')"
+                                    changelog-table)])
+            ;; Tables still exist
+            (is (liquibase/table-exists? wit-name conn))
+            (is (liquibase/table-exists? wi-name conn))
+            ;; Roll back to v58 — this is where the bug would manifest
+            (liquibase/rollback-major-version! conn liquibase false 58)
+            (is (not (liquibase/table-exists? wit-name conn))
+                "workspace_input_transform should be dropped even when MARK_RAN")
+            (is (not (liquibase/table-exists? wi-name conn))
+                "workspace_input should be dropped even when MARK_RAN"))
+          ;; No v59 changesets should remain
+          (let [changelog-table (liquibase/changelog-table-name liquibase)
+                remaining (jdbc/query {:connection conn}
+                                      [(format "SELECT id FROM %s WHERE id LIKE 'v59.%%'" changelog-table)])]
+            (is (empty? remaining)
+                (str "v59 changesets remaining: " (mapv :id remaining)))))))))
+
+(deftest rollback-filename-mismatch-workspace-tables-test
+  (testing "Rollback works even when FILENAME in databasechangelog doesn't match current changelog"
+    (mt/test-drivers #{:h2 :postgres}
+      (mt/with-temp-empty-app-db [conn driver/*driver*]
+        (liquibase/with-liquibase [liquibase conn]
+          (.update liquibase "")
+          (let [changelog-table (liquibase/changelog-table-name liquibase)
+                wit-name (if (= driver/*driver* :h2) "WORKSPACE_INPUT_TRANSFORM" "workspace_input_transform")
+                wi-name  (if (= driver/*driver* :h2) "WORKSPACE_INPUT" "workspace_input")]
+            ;; Simulate: these changesets were originally applied from a different file
+            ;; (e.g., 058_update_migrations.yaml before being moved to 059)
+            (jdbc/execute! {:connection conn}
+                           [(format "UPDATE %s SET FILENAME = 'migrations/058_update_migrations.yaml' WHERE ID LIKE 'v59.2026-02-09T12:00:%%'"
+                                    changelog-table)])
+            (is (liquibase/table-exists? wit-name conn))
+            (is (liquibase/table-exists? wi-name conn))
+            ;; Roll back to v58
+            (liquibase/rollback-major-version! conn liquibase false 58)
+            (is (not (liquibase/table-exists? wit-name conn))
+                "workspace_input_transform should be dropped even with filename mismatch")
+            (is (not (liquibase/table-exists? wi-name conn))
+                "workspace_input should be dropped even with filename mismatch"))
+          (let [changelog-table (liquibase/changelog-table-name liquibase)
+                remaining (jdbc/query {:connection conn}
+                                      [(format "SELECT id FROM %s WHERE id LIKE 'v59.%%'" changelog-table)])]
+            (is (empty? remaining)
+                (str "v59 changesets remaining: " (mapv :id remaining)))))))))
+


### PR DESCRIPTION
## Summary

- Fixes rollback of migrations whose `FILENAME` in `databasechangelog` doesn't match the current changelog YAML filepath (e.g., when migrations move between files like `058 → 059`)
- The `ChangeLogIterator(ranChangeSets, changelog, filters)` constructor silently excludes changesets on filepath mismatch, causing tables with FK constraints to be left behind (e.g., `workspace_input_transform` blocking `DROP TABLE workspace_input`)
- Switches to the simple `ChangeLogIterator(changelog, filters)` constructor, which iterates all changelog changesets and relies on our custom `changeset-filter` (ID-based) to select what to roll back
- After rollback, cleans up orphaned `databasechangelog` entries that `removeRanStatus` couldn't delete (it also matches by `(id, author, filepath)`)

### Root cause detail

Liquibase's `ChangeLogIterator` has two constructors:

1. `(changelog, filters)` — iterates all changesets in the YAML changelog
2. `(ranChangeSets, changelog, filters)` — cross-references `ranChangeSets` with the changelog using `RanChangeSet.isSameAs(ChangeSet)`, which compares `(id, author, filepath)`

We were using constructor #2 with `AlreadyRanChangeSetFilter`. When a changeset's `FILENAME` in `databasechangelog` didn't match the current YAML filepath, it was silently excluded from the rollback iterator. Tables were left behind, and FK constraints caused subsequent `DROP TABLE` statements to fail.

Similarly, after rollback, `Database.removeRanStatus()` generates `DELETE FROM DATABASECHANGELOG WHERE ID = ? AND AUTHOR = ? AND FILENAME = ?` — the filepath mismatch causes this DELETE to match 0 rows, leaving orphaned entries.

The fix uses constructor #1 (no filepath matching) and adds a direct DELETE to clean up any orphaned entries after rollback.

## Test plan

- [x] `rollback-workspace-tables-test` — clean-state rollback on H2/MySQL/Postgres
- [x] `rollback-mark-ran-workspace-tables-test` — confirms MARK_RAN exec type doesn't cause skipping (H2/Postgres)
- [x] `rollback-filename-mismatch-workspace-tables-test` — **the reproducing test**: mutates FILENAME in databasechangelog, verifies rollback still works (H2/Postgres). Fails without the fix, passes with it.
- [x] Existing `rollback-major-version` test still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)