### PR TITLE
BOT-1058 analyze chart add support for non timeseries charts

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/agent/tools/analyze_chart.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/agent/tools/analyze_chart.clj
@@ -34,11 +34,20 @@ BAD: \"The mean is 45.2 with std dev 12.8. The trend shows -15% overall change..
 
 Do not use headers (##). Do not list statistics. Do not analyze series separately.")
 
+(defn- stringify-series-keys
+  "Ensure series map keys are strings, not keywords.
+  JSON parsing keywordizes all keys, but series names (e.g. \"Revenue by Region\") should be strings."
+  [chart-config]
+  (if-let [series (:series chart-config)]
+    (assoc chart-config :series (update-keys series name))
+    chart-config))
+
 (defn- resolve-chart-config-from-memory
   "Resolve a chart-config-id from agent memory into chart configuration.
   Chart configs are seeded from viewing context during agent initialization."
   [chart-config-id]
-  (get (shared/current-chart-configs-state) chart-config-id))
+  (some-> (get (shared/current-chart-configs-state) chart-config-id)
+          stringify-series-keys))
 
 (mu/defn ^{:tool-name "analyze_chart"
            :prompt "analyze_chart"}

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/categorical.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/categorical.clj
@@ -2,7 +2,7 @@
   "Categorical chart statistics computation."
   (:require
    [metabase-enterprise.metabot-v3.stats.outliers :as outliers]
-   [metabase-enterprise.metabot-v3.stats.time-series :as time-series]))
+   [metabase-enterprise.metabot-v3.stats.util :as stats.u]))
 
 (set! *warn-on-reflection* true)
 
@@ -25,7 +25,7 @@
        :category_count 0
        :top_categories []
        :outliers       []}
-      (let [summary  (time-series/compute-summary ys)
+      (let [summary  (stats.u/compute-summary ys)
             outliers (when (>= n min-outlier-points)
                        (outliers/find-outliers ys (mapv str xs)))
             total    (reduce + 0.0 ys)
@@ -47,17 +47,6 @@
   "Compute categorical stats for all series in a chart.
    series-data: map of series-name -> {:x_values [...] :y_values [...] :x {:name ...} :y {:name ...}}"
   [series-data opts]
-  (let [series-stats (into {}
-                           (for [[series-name {:keys [x_values y_values x y]}] series-data]
-                             [series-name (-> (compute-series-stats x_values y_values)
-                                              (assoc :x_name (some-> x :name))
-                                              (assoc :y_name (some-> y :name)))]))
-        correlation-series (if-let [max-k (:max-correlation-series opts)]
-                             (into {} (take max-k series-data))
-                             series-data)
-        correlations (when (and (:deep? opts) (> (count correlation-series) 1))
-                       (time-series/compute-correlations correlation-series))]
-    (cond-> {:chart_type   :categorical
-             :series_count (count series-data)
-             :series       series-stats}
-      correlations (assoc :correlations correlations))))
+  (let [series-stats (stats.u/compute-series-with-labels series-data compute-series-stats)
+        correlations (stats.u/maybe-compute-correlations series-data opts)]
+    (stats.u/make-chart-result :categorical series-data series-stats correlations)))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/categorical.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/categorical.clj
@@ -15,31 +15,34 @@
 
 (defn- compute-series-stats
   "Compute categorical stats for a single series.
-  x-values are category names (strings), y-values are numeric values."
+  x-values are category names (strings), y-values are numeric values.
+  Duplicate category names are merged by summing their values."
   [x-values y-values]
-  (let [pairs (map vector x-values y-values)
-        valid (filter (fn [[_ v]] (some? v)) pairs)
-        n     (count valid)
-        ys    (mapv second valid)
-        xs    (mapv first valid)]
+  (let [pairs   (map vector x-values y-values)
+        valid   (filter (fn [[k v]] (and (some? k) (some? v))) pairs)
+        grouped (reduce (fn [acc [k v]] (update acc k (fnil + 0) v)) {} valid)
+        agg     (vec grouped)
+        n       (count agg)]
     (if (zero? n)
       {:summary        nil
        :category_count 0
        :top_categories []
        :outliers       []}
-      (let [summary  (stats.u/compute-summary ys)
+      (let [ys       (mapv second agg)
+            xs       (mapv first agg)
+            summary  (stats.u/compute-summary ys)
             outliers (when (>= n min-outlier-points)
                        (outliers/find-outliers ys (mapv str xs)))
             total    (reduce + 0.0 ys)
-            sorted   (sort-by (fn [[_ v]] (- v)) valid)
+            sorted   (sort-by (fn [[_ v]] (- v)) agg)
             make-cat (fn [[cat-name value]]
                        {:name       (str cat-name)
                         :value      value
                         :percentage (if (pos? total) (* 100.0 (/ value total)) 0.0)})
-            bottom   (when (> (count sorted) many-categories-threshold)
+            bottom   (when (> n many-categories-threshold)
                        (mapv make-cat (take-last bottom-n-categories sorted)))]
         (cond-> {:summary        summary
-                 :category_count (count (distinct (remove nil? xs)))
+                 :category_count n
                  :top_categories (mapv make-cat (take top-n-categories sorted))
                  :outliers       (or outliers [])}
           bottom (assoc :bottom_categories bottom))))))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/categorical.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/categorical.clj
@@ -45,11 +45,13 @@
 
 (defn compute-categorical-stats
   "Compute categorical stats for all series in a chart.
-   series-data: map of series-name -> {:x_values [...] :y_values [...]}"
+   series-data: map of series-name -> {:x_values [...] :y_values [...] :x {:name ...} :y {:name ...}}"
   [series-data opts]
   (let [series-stats (into {}
-                           (for [[series-name {:keys [x_values y_values]}] series-data]
-                             [series-name (compute-series-stats x_values y_values)]))
+                           (for [[series-name {:keys [x_values y_values x y]}] series-data]
+                             [series-name (-> (compute-series-stats x_values y_values)
+                                              (assoc :x_name (some-> x :name))
+                                              (assoc :y_name (some-> y :name)))]))
         correlations (when (and (:deep? opts) (> (count series-data) 1))
                        (time-series/compute-correlations series-data))]
     (cond-> {:chart_type   :categorical

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/categorical.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/categorical.clj
@@ -52,8 +52,11 @@
                              [series-name (-> (compute-series-stats x_values y_values)
                                               (assoc :x_name (some-> x :name))
                                               (assoc :y_name (some-> y :name)))]))
-        correlations (when (and (:deep? opts) (> (count series-data) 1))
-                       (time-series/compute-correlations series-data))]
+        correlation-series (if-let [max-k (:max-correlation-series opts)]
+                             (into {} (take max-k series-data))
+                             series-data)
+        correlations (when (and (:deep? opts) (> (count correlation-series) 1))
+                       (time-series/compute-correlations correlation-series))]
     (cond-> {:chart_type   :categorical
              :series_count (count series-data)
              :series       series-stats}

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/categorical.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/categorical.clj
@@ -11,7 +11,7 @@
 (def ^:private bottom-n-categories 5)
 (def ^:private many-categories-threshold 15)
 
-(defn compute-series-stats
+(defn- compute-series-stats
   "Compute categorical stats for a single series.
   x-values are category names (strings), y-values are numeric values."
   [x-values y-values]

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/categorical.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/categorical.clj
@@ -1,5 +1,5 @@
 (ns metabase-enterprise.metabot-v3.stats.categorical
-  "Categorical chart statistics computation."
+  "Categorical chart statistics."
   (:require
    [metabase-enterprise.metabot-v3.stats.outliers :as outliers]
    [metabase-enterprise.metabot-v3.stats.util :as stats.u]))
@@ -13,13 +13,13 @@
 
 (defn compute-series-stats
   "Compute categorical stats for a single series.
-   x-values = category names (strings), y-values = numeric values."
+  x-values are category names (strings), y-values are numeric values."
   [x-values y-values]
-  (let [pairs   (map vector x-values y-values)
-        valid   (filter (fn [[_ v]] (some? v)) pairs)
-        n       (count valid)
-        ys      (mapv second valid)
-        xs      (mapv first valid)]
+  (let [pairs (map vector x-values y-values)
+        valid (filter (fn [[_ v]] (some? v)) pairs)
+        n     (count valid)
+        ys    (mapv second valid)
+        xs    (mapv first valid)]
     (if (zero? n)
       {:summary        nil
        :category_count 0
@@ -30,22 +30,20 @@
                        (outliers/find-outliers ys (mapv str xs)))
             total    (reduce + 0.0 ys)
             sorted   (sort-by (fn [[_ v]] (- v)) valid)
-            make-cat (fn [[cat-name val]]
+            make-cat (fn [[cat-name value]]
                        {:name       (str cat-name)
-                        :value      val
-                        :percentage (if (pos? total) (* 100.0 (/ val total)) 0.0)})
-            top-cats (mapv make-cat (take top-n-categories sorted))
-            bot-cats (when (> (count sorted) many-categories-threshold)
+                        :value      value
+                        :percentage (if (pos? total) (* 100.0 (/ value total)) 0.0)})
+            bottom   (when (> (count sorted) many-categories-threshold)
                        (mapv make-cat (take-last bottom-n-categories sorted)))]
         (cond-> {:summary        summary
                  :category_count (count (distinct (remove nil? xs)))
-                 :top_categories top-cats
+                 :top_categories (mapv make-cat (take top-n-categories sorted))
                  :outliers       (or outliers [])}
-          bot-cats (assoc :bottom_categories bot-cats))))))
+          bottom (assoc :bottom_categories bottom))))))
 
 (defn compute-categorical-stats
-  "Compute categorical stats for all series in a chart.
-   series-data: map of series-name -> {:x_values [...] :y_values [...] :x {:name ...} :y {:name ...}}"
+  "Compute categorical stats for all series in a chart."
   [series-data opts]
   (let [series-stats (stats.u/compute-series-with-labels series-data compute-series-stats)
         correlations (stats.u/maybe-compute-correlations series-data opts)]

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/categorical.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/categorical.clj
@@ -1,0 +1,58 @@
+(ns metabase-enterprise.metabot-v3.stats.categorical
+  "Categorical chart statistics computation."
+  (:require
+   [metabase-enterprise.metabot-v3.stats.outliers :as outliers]
+   [metabase-enterprise.metabot-v3.stats.time-series :as time-series]))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private min-outlier-points 5)
+(def ^:private top-n-categories 10)
+(def ^:private bottom-n-categories 5)
+(def ^:private many-categories-threshold 15)
+
+(defn compute-series-stats
+  "Compute categorical stats for a single series.
+   x-values = category names (strings), y-values = numeric values."
+  [x-values y-values]
+  (let [pairs   (map vector x-values y-values)
+        valid   (filter (fn [[_ v]] (some? v)) pairs)
+        n       (count valid)
+        ys      (mapv second valid)
+        xs      (mapv first valid)]
+    (if (zero? n)
+      {:summary        nil
+       :category_count 0
+       :top_categories []
+       :outliers       []}
+      (let [summary  (time-series/compute-summary ys)
+            outliers (when (>= n min-outlier-points)
+                       (outliers/find-outliers ys (mapv str xs)))
+            total    (reduce + 0.0 ys)
+            sorted   (sort-by (fn [[_ v]] (- v)) valid)
+            make-cat (fn [[cat-name val]]
+                       {:name       (str cat-name)
+                        :value      val
+                        :percentage (if (pos? total) (* 100.0 (/ val total)) 0.0)})
+            top-cats (mapv make-cat (take top-n-categories sorted))
+            bot-cats (when (> (count sorted) many-categories-threshold)
+                       (mapv make-cat (take-last bottom-n-categories sorted)))]
+        (cond-> {:summary        summary
+                 :category_count (count (distinct (remove nil? xs)))
+                 :top_categories top-cats
+                 :outliers       (or outliers [])}
+          bot-cats (assoc :bottom_categories bot-cats))))))
+
+(defn compute-categorical-stats
+  "Compute categorical stats for all series in a chart.
+   series-data: map of series-name -> {:x_values [...] :y_values [...]}"
+  [series-data opts]
+  (let [series-stats (into {}
+                           (for [[series-name {:keys [x_values y_values]}] series-data]
+                             [series-name (compute-series-stats x_values y_values)]))
+        correlations (when (and (:deep? opts) (> (count series-data) 1))
+                       (time-series/compute-correlations series-data))]
+    (cond-> {:chart_type   :categorical
+             :series_count (count series-data)
+             :series       series-stats}
+      correlations (assoc :correlations correlations))))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/categorical.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/categorical.clj
@@ -25,6 +25,7 @@
         n       (count agg)]
     (if (zero? n)
       {:summary        nil
+       :data_points    0
        :category_count 0
        :top_categories []
        :outliers       []}
@@ -43,6 +44,7 @@
             bottom   (when (> n many-categories-threshold)
                        (mapv make-cat (take-last bottom-n-categories sorted)))]
         (cond-> {:summary        summary
+                 :data_points    (count valid)
                  :category_count n
                  :top_categories (mapv make-cat (take top-n-categories sorted))
                  :outliers       (or outliers [])}

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/categorical.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/categorical.clj
@@ -2,7 +2,9 @@
   "Categorical chart statistics."
   (:require
    [metabase-enterprise.metabot-v3.stats.outliers :as outliers]
-   [metabase-enterprise.metabot-v3.stats.util :as stats.u]))
+   [metabase-enterprise.metabot-v3.stats.types :as stats.types]
+   [metabase-enterprise.metabot-v3.stats.util :as stats.u]
+   [metabase.util.malli :as mu]))
 
 (set! *warn-on-reflection* true)
 
@@ -42,9 +44,10 @@
                  :outliers       (or outliers [])}
           bottom (assoc :bottom_categories bottom))))))
 
-(defn compute-categorical-stats
+(mu/defn compute-categorical-stats :- ::stats.types/categorical-stats
   "Compute categorical stats for all series in a chart."
-  [series-data opts]
+  [series-data :- [:map-of :string ::stats.types/series-config]
+   opts        :- ::stats.types/options]
   (let [series-stats (stats.u/compute-series-with-labels series-data compute-series-stats)
         correlations (stats.u/maybe-compute-correlations series-data opts)]
     (stats.u/make-chart-result :categorical series-data series-stats correlations)))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/categorical.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/categorical.clj
@@ -33,12 +33,13 @@
             summary  (stats.u/compute-summary ys)
             outliers (when (>= n min-outlier-points)
                        (outliers/find-outliers ys (mapv str xs)))
-            total    (reduce + 0.0 ys)
-            sorted   (sort-by (fn [[_ v]] (- v)) agg)
-            make-cat (fn [[cat-name value]]
-                       {:name       (str cat-name)
-                        :value      value
-                        :percentage (if (pos? total) (* 100.0 (/ value total)) 0.0)})
+            all-non-negative? (every? #(not (neg? %)) ys)
+            total             (when all-non-negative? (reduce + 0.0 ys))
+            sorted            (sort-by (fn [[_ v]] (- v)) agg)
+            make-cat          (fn [[cat-name value]]
+                                (cond-> {:name  (str cat-name)
+                                         :value value}
+                                  total (assoc :percentage (* 100.0 (/ value total)))))
             bottom   (when (> n many-categories-threshold)
                        (mapv make-cat (take-last bottom-n-categories sorted)))]
         (cond-> {:summary        summary

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/core.clj
@@ -2,6 +2,7 @@
   "Chart type detection and statistics routing."
   (:require
    [metabase-enterprise.metabot-v3.stats.categorical :as categorical]
+   [metabase-enterprise.metabot-v3.stats.histogram :as histogram]
    [metabase-enterprise.metabot-v3.stats.scatter :as scatter]
    [metabase-enterprise.metabot-v3.stats.time-series :as time-series]))
 
@@ -89,6 +90,7 @@
       :time-series  (time-series/compute-time-series-stats (:series chart-config) opts)
       :categorical  (categorical/compute-categorical-stats (:series chart-config) opts)
       :scatter      (scatter/compute-scatter-stats (:series chart-config) opts)
+      :histogram    (histogram/compute-histogram-stats (:series chart-config) opts)
       {:chart_type   chart-type
        :series_count (count (:series chart-config))
        :message      (str "Statistics for " (name chart-type) " charts not yet implemented")})))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/core.clj
@@ -69,12 +69,12 @@
 (defn- temporal-column-type?
   "Check if column type indicates temporal data."
   [col-type]
-  (contains? #{:datetime :date :time "datetime" "date" "time"} col-type))
+  (contains? #{"datetime" "date" "time"} col-type))
 
 (defn- numeric-column-type?
   "Check if column type indicates numeric data."
   [col-type]
-  (contains? #{:number "number"} col-type))
+  (contains? #{"number"} col-type))
 
 (defn- looks-like-date-string?
   "Heuristic check if a string value looks like a date."

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/core.clj
@@ -92,7 +92,7 @@
       (every? looks-like-date-string? sample) :datetime
       :else :string)))
 
-(defn detect-chart-type
+(defn- detect-chart-type
   "Detect the chart type from chart configuration.
 
   Priority:
@@ -102,29 +102,36 @@
   4. Default to categorical"
   [{:keys [display_type series]}]
   (or
-   ;; 1. Check explicit display type
    (get explicit-display-types display_type)
 
-   ;; 2/3. Check first series x-column
    (when-let [[_ first-series] (first series)]
      (let [x-type (get-in first-series [:x :type])
-           x-values (:x_values first-series)]
+           x-values (:x_values first-series)
+           inferred-type (infer-type-from-sample x-values)]
        (cond
-         (temporal-column-type? x-type) :time-series
+         (temporal-column-type? x-type)
+         :time-series
+
          (and (numeric-column-type? x-type)
-              (= display_type "bar"))  :histogram
-         (numeric-column-type? x-type) :scatter
-         ;; 3. Heuristic from sample values
-         (= :datetime (infer-type-from-sample x-values)) :time-series
-         (and (= :number (infer-type-from-sample x-values))
-              (= display_type "bar"))  :histogram
-         (= :number (infer-type-from-sample x-values)) :scatter
+              (= display_type "bar"))
+         :histogram
+
+         (numeric-column-type? x-type)
+         :scatter
+
+         (= :datetime inferred-type)
+         :time-series
+
+         (and (= :number inferred-type)
+              (= display_type "bar"))
+         :histogram
+
+         (= :number inferred-type)
+         :scatter
+
          :else :categorical)))
 
-   ;; 4. Default
    :categorical))
-
-;;; ---------------------------------------------------- Routing -----------------------------------------------------
 
 (defn compute-chart-stats
   "Compute statistics for a chart based on its detected type.
@@ -138,24 +145,23 @@
     opts         - options map:
                    :deep? - compute additional statistics"
   [chart-config opts]
-  (let [chart-type (detect-chart-type chart-config)
+  (let [chart-type                   (detect-chart-type chart-config)
         [limited-series limits-info] (apply-data-limits (:series chart-config))
-        too-many-series? (> (count limited-series) max-series-for-correlations)
-        opts (if too-many-series?
-               (assoc opts :max-correlation-series max-series-for-correlations)
-               opts)
-        limits-info (if too-many-series?
-                      (assoc limits-info
-                             :correlations_capped {:total_series (count limited-series)
-                                                   :max_correlated max-series-for-correlations})
-                      limits-info)
-        stats (case chart-type
-                :time-series  (time-series/compute-time-series-stats limited-series opts)
-                :categorical  (categorical/compute-categorical-stats limited-series opts)
-                :scatter      (scatter/compute-scatter-stats limited-series opts)
-                :histogram    (histogram/compute-histogram-stats limited-series opts)
-                {:chart_type   chart-type
-                 :series_count (count limited-series)
-                 :message      (str "Statistics for " (name chart-type) " charts not yet implemented")})]
+        too-many-series?             (> (count limited-series) max-series-for-correlations)
+        opts                         (cond-> opts
+                                       too-many-series? (assoc :max-correlation-series max-series-for-correlations))
+        limits-info                  (cond-> limits-info
+                                       too-many-series? (assoc :correlations_capped
+                                                               {:total_series   (count limited-series)
+                                                                :max_correlated max-series-for-correlations}))
+        stats                        (case chart-type
+                                       :time-series (time-series/compute-time-series-stats limited-series opts)
+                                       :categorical (categorical/compute-categorical-stats limited-series opts)
+                                       :scatter     (scatter/compute-scatter-stats limited-series opts)
+                                       :histogram   (histogram/compute-histogram-stats limited-series opts)
+                                       {:chart_type   chart-type
+                                        :series_count (count limited-series)
+                                        :message      (str "Statistics for " (name chart-type)
+                                                           " charts not yet implemented")})]
     (cond-> stats
       limits-info (assoc :limits limits-info))))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/core.clj
@@ -4,7 +4,9 @@
    [metabase-enterprise.metabot-v3.stats.categorical :as categorical]
    [metabase-enterprise.metabot-v3.stats.histogram :as histogram]
    [metabase-enterprise.metabot-v3.stats.scatter :as scatter]
-   [metabase-enterprise.metabot-v3.stats.time-series :as time-series]))
+   [metabase-enterprise.metabot-v3.stats.time-series :as time-series]
+   [metabase-enterprise.metabot-v3.stats.types :as stats.types]
+   [metabase.util.malli :as mu]))
 
 (set! *warn-on-reflection* true)
 
@@ -133,7 +135,7 @@
 
    :categorical))
 
-(defn compute-chart-stats
+(mu/defn compute-chart-stats :- ::stats.types/chart-stats
   "Compute statistics for a chart based on its detected type.
 
   Applies data limits before computation:
@@ -144,7 +146,8 @@
     chart-config - the full chart configuration
     opts         - options map:
                    :deep? - compute additional statistics"
-  [chart-config opts]
+  [chart-config :- ::stats.types/chart-config
+   opts         :- ::stats.types/options]
   (let [chart-type                   (detect-chart-type chart-config)
         [limited-series limits-info] (apply-data-limits (:series chart-config))
         too-many-series?             (> (count limited-series) max-series-for-correlations)

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/core.clj
@@ -10,12 +10,12 @@
 
 ;;; ------------------------------------------------- Data Limits --------------------------------------------------
 
-(def max-data-points-per-series
+(def ^:private max-data-points-per-series
   "Maximum number of data points per series. Series exceeding this limit are downsampled to keep memory and CPU usage
   bounded."
   10000)
 
-(def max-series-for-correlations
+(def ^:private max-series-for-correlations
   "Maximum number of series to include in pairwise correlation computation."
   10)
 

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/core.clj
@@ -2,6 +2,7 @@
   "Chart type detection and statistics routing."
   (:require
    [metabase-enterprise.metabot-v3.stats.categorical :as categorical]
+   [metabase-enterprise.metabot-v3.stats.scatter :as scatter]
    [metabase-enterprise.metabot-v3.stats.time-series :as time-series]))
 
 (set! *warn-on-reflection* true)
@@ -87,6 +88,7 @@
     (case chart-type
       :time-series  (time-series/compute-time-series-stats (:series chart-config) opts)
       :categorical  (categorical/compute-categorical-stats (:series chart-config) opts)
+      :scatter      (scatter/compute-scatter-stats (:series chart-config) opts)
       {:chart_type   chart-type
        :series_count (count (:series chart-config))
        :message      (str "Statistics for " (name chart-type) " charts not yet implemented")})))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/core.clj
@@ -8,6 +8,52 @@
 
 (set! *warn-on-reflection* true)
 
+;;; ------------------------------------------------- Data Limits --------------------------------------------------
+
+(def max-data-points-per-series
+  "Maximum number of data points per series. Series exceeding this limit are downsampled to keep memory and CPU usage
+  bounded."
+  10000)
+
+(def max-series-for-correlations
+  "Maximum number of series to include in pairwise correlation computation."
+  10)
+
+(defn- downsample-series
+  "Randomly downsample x_values and y_values to approximately `max-n` points.
+  Preserves the first and last points to maintain range. Returns the series
+  config with updated x_values/y_values, or unchanged if already within limit."
+  [series-config max-n]
+  (let [{:keys [x_values y_values]} series-config
+        n (count y_values)]
+    (if (<= n max-n)
+      series-config
+      (let [prob           (/ (double max-n) n)
+            sampled        (random-sample prob (range 1 (dec n)))
+            sorted-indices (into [0] cat [sampled [(dec n)]])
+            x-vec          (vec x_values)
+            y-vec          (vec y_values)]
+        (assoc series-config
+               :x_values (mapv #(nth x-vec %) sorted-indices)
+               :y_values (mapv #(nth y-vec %) sorted-indices))))))
+
+(defn- apply-data-limits
+  "Apply data limits to series data, returning [limited-series-data limits-info].
+  - Downsamples each series to `max-data-points-per-series` data points
+  - Records which series were downsampled and from how many points"
+  [series-data]
+  (let [original-counts (into {} (for [[name {:keys [y_values]}] series-data]
+                                   [name (count y_values)]))
+        limited-series  (into {} (for [[name config] series-data]
+                                   [name (downsample-series config max-data-points-per-series)]))
+        downsampled     (into {} (for [[name orig-count] original-counts
+                                       :let [new-count (count (get-in limited-series [name :y_values]))]
+                                       :when (< new-count orig-count)]
+                                   [name {:original_count orig-count :sampled_count new-count}]))]
+    [limited-series
+     (when (seq downsampled)
+       {:downsampled_series downsampled})]))
+
 ;;; ----------------------------------------------- Chart Type Detection ---------------------------------------------
 
 (def ^:private explicit-display-types
@@ -83,17 +129,33 @@
 (defn compute-chart-stats
   "Compute statistics for a chart based on its detected type.
 
+  Applies data limits before computation:
+  - Each series is downsampled to at most [[max-data-points-per-series]] points
+  - Correlation computation is limited to [[max-series-for-correlations]] series
+
   Arguments:
     chart-config - the full chart configuration
     opts         - options map:
                    :deep? - compute additional statistics"
   [chart-config opts]
-  (let [chart-type (detect-chart-type chart-config)]
-    (case chart-type
-      :time-series  (time-series/compute-time-series-stats (:series chart-config) opts)
-      :categorical  (categorical/compute-categorical-stats (:series chart-config) opts)
-      :scatter      (scatter/compute-scatter-stats (:series chart-config) opts)
-      :histogram    (histogram/compute-histogram-stats (:series chart-config) opts)
-      {:chart_type   chart-type
-       :series_count (count (:series chart-config))
-       :message      (str "Statistics for " (name chart-type) " charts not yet implemented")})))
+  (let [chart-type (detect-chart-type chart-config)
+        [limited-series limits-info] (apply-data-limits (:series chart-config))
+        too-many-series? (> (count limited-series) max-series-for-correlations)
+        opts (if too-many-series?
+               (assoc opts :max-correlation-series max-series-for-correlations)
+               opts)
+        limits-info (if too-many-series?
+                      (assoc limits-info
+                             :correlations_capped {:total_series (count limited-series)
+                                                   :max_correlated max-series-for-correlations})
+                      limits-info)
+        stats (case chart-type
+                :time-series  (time-series/compute-time-series-stats limited-series opts)
+                :categorical  (categorical/compute-categorical-stats limited-series opts)
+                :scatter      (scatter/compute-scatter-stats limited-series opts)
+                :histogram    (histogram/compute-histogram-stats limited-series opts)
+                {:chart_type   chart-type
+                 :series_count (count limited-series)
+                 :message      (str "Statistics for " (name chart-type) " charts not yet implemented")})]
+    (cond-> stats
+      limits-info (assoc :limits limits-info))))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/core.clj
@@ -1,6 +1,7 @@
 (ns metabase-enterprise.metabot-v3.stats.core
   "Chart type detection and statistics routing."
   (:require
+   [metabase-enterprise.metabot-v3.stats.categorical :as categorical]
    [metabase-enterprise.metabot-v3.stats.time-series :as time-series]))
 
 (set! *warn-on-reflection* true)
@@ -84,8 +85,8 @@
   [chart-config opts]
   (let [chart-type (detect-chart-type chart-config)]
     (case chart-type
-      :time-series (time-series/compute-time-series-stats (:series chart-config) opts)
-      ;; For MVP, other types return minimal info
-      {:chart_type chart-type
+      :time-series  (time-series/compute-time-series-stats (:series chart-config) opts)
+      :categorical  (categorical/compute-categorical-stats (:series chart-config) opts)
+      {:chart_type   chart-type
        :series_count (count (:series chart-config))
-       :message (str "Statistics for " (name chart-type) " charts not yet implemented")})))
+       :message      (str "Statistics for " (name chart-type) " charts not yet implemented")})))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/core.clj
@@ -12,8 +12,7 @@
 
 (def ^:private explicit-display-types
   "Display types that map directly to chart types."
-  {"histogram" :histogram
-   "scatter"   :scatter
+  {"scatter"   :scatter
    "scalar"    :unknown
    "waterfall" :unknown
    "funnel"    :categorical
@@ -66,9 +65,13 @@
            x-values (:x_values first-series)]
        (cond
          (temporal-column-type? x-type) :time-series
+         (and (numeric-column-type? x-type)
+              (= display_type "bar"))  :histogram
          (numeric-column-type? x-type) :scatter
          ;; 3. Heuristic from sample values
          (= :datetime (infer-type-from-sample x-values)) :time-series
+         (and (= :number (infer-type-from-sample x-values))
+              (= display_type "bar"))  :histogram
          (= :number (infer-type-from-sample x-values)) :scatter
          :else :categorical)))
 

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/core.clj
@@ -60,11 +60,13 @@
 
 (def ^:private explicit-display-types
   "Display types that map directly to chart types."
-  {"scatter"   :scatter
-   "scalar"    :unknown
-   "waterfall" :unknown
-   "funnel"    :categorical
-   "pie"       :categorical})
+  {"scatter"     :scatter
+   "scalar"      :unknown
+   "smartscalar" :unknown
+   "waterfall"   :categorical
+   "funnel"      :categorical
+   "pie"         :categorical
+   "row"         :categorical})
 
 (defn- temporal-column-type?
   "Check if column type indicates temporal data."

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/histogram.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/histogram.clj
@@ -29,7 +29,7 @@
   (when-not (Double/isNaN (double x))
     x))
 
-(defn compute-series-stats
+(defn- compute-series-stats
   "Compute histogram stats for a single series.
   x_values are (bin edges/centers) and y_values are (counts/frequencies).
   Single-arity form uses sequential indices as x_values."

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/histogram.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/histogram.clj
@@ -1,5 +1,5 @@
 (ns metabase-enterprise.metabot-v3.stats.histogram
-  "Histogram chart statistics computation."
+  "Histogram chart statistics."
   (:require
    [metabase-enterprise.metabot-v3.stats.util :as stats.u]
    [tech.v3.datatype.functional :as dfn]))
@@ -24,15 +24,15 @@
      :iqr    (- q3 q1)}))
 
 (defn- nan->nil
-  "Convert NaN to nil so cond-> predicates work correctly."
+  "Convert NaN to nil."
   [x]
-  (when-not (Double/isNaN (double x)) x))
+  (when-not (Double/isNaN (double x))
+    x))
 
 (defn compute-series-stats
-  "Compute histogram stats for a single series using its y_values (counts/frequencies)
-  and x_values (bin edges/centers) for display.
-
-  Single-arity form accepts only y_values and uses sequential indices as x_values."
+  "Compute histogram stats for a single series.
+  x_values are (bin edges/centers) and y_values are (counts/frequencies).
+  Single-arity form uses sequential indices as x_values."
   ([y-values]
    (compute-series-stats (range (count y-values)) y-values))
   ([x-values y-values]
@@ -61,8 +61,7 @@
                           kurtosis (assoc :kurtosis kurtosis))})))))
 
 (defn compute-histogram-stats
-  "Compute statistics for histogram data. Uses y_values (counts/frequencies per bin).
-  series-data: map of series-name -> {:x_values [...] :y_values [...] :x {:name ...} :y {:name ...}}"
+  "Compute statistics for histogram data."
   [series-data _opts]
   (let [series-stats (stats.u/compute-series-with-labels series-data compute-series-stats)]
     (stats.u/make-chart-result :histogram series-data series-stats nil)))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/histogram.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/histogram.clj
@@ -1,7 +1,9 @@
 (ns metabase-enterprise.metabot-v3.stats.histogram
   "Histogram chart statistics."
   (:require
+   [metabase-enterprise.metabot-v3.stats.types :as stats.types]
    [metabase-enterprise.metabot-v3.stats.util :as stats.u]
+   [metabase.util.malli :as mu]
    [tech.v3.datatype.functional :as dfn]))
 
 (set! *warn-on-reflection* true)
@@ -60,8 +62,9 @@
                           skewness (assoc :skewness skewness)
                           kurtosis (assoc :kurtosis kurtosis))})))))
 
-(defn compute-histogram-stats
+(mu/defn compute-histogram-stats :- ::stats.types/histogram-stats
   "Compute statistics for histogram data."
-  [series-data _opts]
+  [series-data :- [:map-of :string ::stats.types/series-config]
+   _opts       :- ::stats.types/options]
   (let [series-stats (stats.u/compute-series-with-labels series-data compute-series-stats)]
     (stats.u/make-chart-result :histogram series-data series-stats nil)))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/histogram.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/histogram.clj
@@ -1,65 +1,32 @@
 (ns metabase-enterprise.metabot-v3.stats.histogram
   "Histogram chart statistics computation."
   (:require
-   [metabase-enterprise.metabot-v3.stats.util :as stats.u]))
+   [metabase-enterprise.metabot-v3.stats.util :as stats.u]
+   [tech.v3.datatype.functional :as dfn]))
 
 (set! *warn-on-reflection* true)
 
 (def ^:private min-shape-metrics-points 8)
-(def ^:private skewness-threshold 0.5)
-
-(defn- compute-percentile
-  "Compute a percentile of sorted values using linear interpolation. pct: 0-100."
-  [sorted-vals pct]
-  (let [n (count sorted-vals)]
-    (if (= n 1)
-      (first sorted-vals)
-      (let [idx   (* (/ pct 100.0) (dec n))
-            lower (int (Math/floor idx))
-            upper (int (Math/ceil idx))
-            frac  (- idx lower)]
-        (+ (* (- 1.0 frac) (nth sorted-vals lower))
-           (* frac (nth sorted-vals upper)))))))
 
 (defn- compute-percentiles
-  "Compute percentiles map for a sorted sequence of values."
-  [sorted-vals]
-  (into {}
-        (for [pct [25 50 75 90 95 99]]
-          [pct (compute-percentile sorted-vals pct)])))
+  "Compute percentiles map for a sequence of values."
+  [values]
+  (let [pcts [25 50 75 90 95 99]]
+    (zipmap pcts (dfn/percentiles values pcts))))
 
 (defn- compute-quartiles
-  "Compute quartile stats from sorted values."
-  [sorted-vals]
-  (let [q1  (compute-percentile sorted-vals 25)
-        med (compute-percentile sorted-vals 50)
-        q3  (compute-percentile sorted-vals 75)]
+  "Compute quartile stats from values."
+  [values]
+  (let [[_min q1 med q3 _max] (dfn/quartiles values)]
     {:q1     q1
      :median med
      :q3     q3
      :iqr    (- q3 q1)}))
 
-(defn- compute-skewness
-  "Compute adjusted Fisher-Pearson skewness coefficient."
-  [values mean-val std-dev n]
-  (when (and (>= n 3) (pos? std-dev))
-    (let [cubed-zscores (map (fn [x] (Math/pow (/ (- (double x) mean-val) std-dev) 3)) values)
-          sum-cubed     (reduce + 0.0 cubed-zscores)]
-      (* (/ (* n (double sum-cubed))
-            (* (dec n) (- n 2)))
-         1.0))))
-
-(defn- compute-excess-kurtosis
-  "Compute Fisher's excess kurtosis (normal distribution = 0)."
-  [values mean-val std-dev n]
-  (when (and (>= n 4) (pos? std-dev))
-    (let [fourth-zscores (map (fn [x] (Math/pow (/ (- (double x) mean-val) std-dev) 4)) values)
-          sum-fourth     (reduce + 0.0 fourth-zscores)
-          term1          (/ (* n (inc n) sum-fourth)
-                            (* (dec n) (- n 2) (- n 3)))
-          term2          (/ (* 3.0 (Math/pow (dec n) 2))
-                            (* (- n 2) (- n 3)))]
-      (- term1 term2))))
+(defn- nan->nil
+  "Convert NaN to nil so cond-> predicates work correctly."
+  [x]
+  (when-not (Double/isNaN (double x)) x))
 
 (defn compute-series-stats
   "Compute histogram stats for a single series using its y_values (counts/frequencies)
@@ -79,15 +46,12 @@
         :bin_data     []
         :distribution {:percentiles {} :quartiles {:q1 0 :median 0 :q3 0 :iqr 0}}}
        (let [summary     (stats.u/compute-summary valid)
-             sorted-vals (sort valid)
-             percentiles (compute-percentiles sorted-vals)
-             quartiles   (compute-quartiles sorted-vals)
-             mean-val    (:mean summary)
-             std-dev     (:std_dev summary)
+             percentiles (compute-percentiles valid)
+             quartiles   (compute-quartiles valid)
              skewness    (when (>= n min-shape-metrics-points)
-                           (compute-skewness valid mean-val std-dev n))
+                           (nan->nil (dfn/skew valid)))
              kurtosis    (when (>= n min-shape-metrics-points)
-                           (compute-excess-kurtosis valid mean-val std-dev n))]
+                           (nan->nil (dfn/kurtosis valid)))]
          {:summary      summary
           :data_points  n
           :bin_data     (mapv vector valid-xs valid)

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/histogram.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/histogram.clj
@@ -3,61 +3,184 @@
   (:require
    [metabase-enterprise.metabot-v3.stats.types :as stats.types]
    [metabase-enterprise.metabot-v3.stats.util :as stats.u]
-   [metabase.util.malli :as mu]
-   [tech.v3.datatype.functional :as dfn]))
+   [metabase.util.malli :as mu]))
 
 (set! *warn-on-reflection* true)
 
 (def ^:private min-shape-metrics-points 8)
 
-(defn- compute-percentiles
-  "Compute percentiles map for a sequence of values."
-  [values]
-  (let [pcts [25 50 75 90 95 99]]
-    (zipmap pcts (dfn/percentiles values pcts))))
+;;; ------------------------------------------ Weighted Distribution Stats -------------------------------------------
 
-(defn- compute-quartiles
-  "Compute quartile stats from values."
-  [values]
-  (let [[_min q1 med q3 _max] (dfn/quartiles values)]
-    {:q1     q1
-     :median med
-     :q3     q3
-     :iqr    (- q3 q1)}))
+(defn- weighted-moment
+  "Weighted moment: Σ(count_i × (f x_i)) / Σ(count_i), where f transforms each value."
+  [xs counts total f]
+  (/ (double (reduce + (map (fn [x c]
+                              (* c (f (double x))))
+                            xs
+                            counts)))
+     (double total)))
+
+(defn- weighted-mean
+  "Weighted mean: Σ(x_i × count_i) / Σ(count_i)."
+  [xs counts total]
+  (weighted-moment xs counts total identity))
+
+(defn- weighted-variance
+  "Weighted variance: Σ(count_i × (x_i - mean)²) / Σ(count_i)."
+  [xs counts total wmean]
+  (weighted-moment xs counts total #(Math/pow (- % wmean) 2)))
+
+(defn- weighted-skewness
+  "Weighted skewness using bin centers. Returns nil when std_dev is zero."
+  [xs counts total wmean wstd]
+  (when (pos? wstd)
+    (weighted-moment xs counts total #(Math/pow (/ (- % wmean) wstd) 3))))
+
+(defn- weighted-kurtosis
+  "Weighted excess kurtosis using bin centers. Returns nil when std_dev is zero."
+  [xs counts total wmean wstd]
+  (when (pos? wstd)
+    (- (weighted-moment xs counts total #(Math/pow (/ (- % wmean) wstd) 4))
+       3.0)))
+
+;;; ----------------------------------------- Cumulative Percentile Estimation ----------------------------------------
+
+(defn- cumulative-percentile
+  "Estimate a percentile from sorted bins using linear interpolation between bin centers.
+  `sorted-xs` and `cum-counts` are parallel vectors; `total` is the sum of all counts."
+  [sorted-xs cum-counts total target-frac]
+  (let [n (count sorted-xs)]
+    (loop [i 0]
+      (if (>= i n)
+        (double (nth sorted-xs (dec n)))
+        (let [cum-frac (/ (double (nth cum-counts i))
+                          (double total))]
+          (if (>= cum-frac target-frac)
+            (if (zero? i)
+              (double (nth sorted-xs 0))
+              (let [prev-frac (/ (double (nth cum-counts (dec i)))
+                                 (double total))
+                    x-prev    (double (nth sorted-xs (dec i)))
+                    x-curr    (double (nth sorted-xs i))
+                    t         (if (== cum-frac prev-frac)
+                                0.5
+                                (/ (- target-frac prev-frac)
+                                   (- cum-frac prev-frac)))]
+                (+ x-prev (* t (- x-curr x-prev)))))
+            (recur (inc i))))))))
+
+(defn- compute-estimated-percentiles
+  "Compute estimated percentiles from binned data using cumulative interpolation."
+  [sorted-xs cum-counts total]
+  (let [pcts [25 50 75 90 95 99]]
+    (zipmap pcts
+            (mapv #(cumulative-percentile sorted-xs cum-counts total (/ (double %) 100.0))
+                  pcts))))
+
+;;; -------------------------------------------- Structural Metrics ---------------------------------------------------
+
+(defn- count-peaks
+  "Count local maxima (peaks) in a sequence of counts."
+  [counts]
+  (let [n (count counts)]
+    (if (<= n 2)
+      (if (pos? n) 1 0)
+      (count
+       (for [i (range n)
+             :let [prev (if (zero? i) -1 (nth counts (dec i)))
+                   curr (nth counts i)
+                   nxt  (if (= i (dec n)) -1 (nth counts (inc i)))]
+             :when (and (> curr prev) (>= curr nxt))]
+         i)))))
+
+(defn- count-gaps
+  "Count zero-count bins between non-zero bins."
+  [counts]
+  (let [n (count counts)]
+    (if (<= n 2)
+      0
+      (let [first-nz (some #(when (pos? (nth counts %)) %) (range n))
+            last-nz  (some #(when (pos? (nth counts %)) %) (reverse (range n)))]
+        (if (or (nil? first-nz) (nil? last-nz) (>= first-nz last-nz))
+          0
+          (count (filter #(zero? (nth counts %))
+                         (range (inc first-nz) last-nz))))))))
+
+;;; --------------------------------------------- Series Stats -------------------------------------------------------
 
 (defn- compute-series-stats
-  "Compute histogram stats for a single series.
-  x_values are (bin edges/centers) and y_values are (counts/frequencies).
+  "Compute histogram stats for a single series using weighted approximations.
+  x_values are bin edges/centers and y_values are counts/frequencies.
   Single-arity form uses sequential indices as x_values."
   ([y-values]
    (compute-series-stats (range (count y-values)) y-values))
   ([x-values y-values]
    (let [valid-pairs (filter (fn [[_ y]] (some? y)) (map vector x-values y-values))
-         valid       (mapv (comp double second) valid-pairs)
-         valid-xs    (mapv first valid-pairs)
-         n           (count valid)]
-     (if (zero? n)
-       {:summary      {:min 0 :max 0 :mean 0 :median 0 :std_dev 0 :range 0}
-        :data_points  0
-        :bin_data     []
-        :distribution {:percentiles {} :quartiles {:q1 0 :median 0 :q3 0 :iqr 0}}}
-       (let [summary     (stats.u/compute-summary valid)
-             percentiles (compute-percentiles valid)
-             quartiles   (compute-quartiles valid)
-             skewness    (when (>= n min-shape-metrics-points)
-                           (stats.u/nan->nil (dfn/skew valid)))
-             kurtosis    (when (>= n min-shape-metrics-points)
-                           (stats.u/nan->nil (dfn/kurtosis valid)))]
-         {:summary      summary
-          :data_points  n
-          :bin_data     (mapv vector valid-xs valid)
-          :distribution (cond-> {:percentiles percentiles
-                                 :quartiles   quartiles}
-                          skewness (assoc :skewness skewness)
-                          kurtosis (assoc :kurtosis kurtosis))})))))
+         valid-xs    (mapv (comp double first) valid-pairs)
+         valid-ys    (mapv (comp double second) valid-pairs)
+         n           (count valid-pairs)
+         total       (reduce + 0.0 valid-ys)]
+     (if (or (zero? n)
+             (zero? total))
+       {:estimated_summary {:weighted_mean 0 :weighted_std_dev 0 :data_range 0}
+        :total_count       0
+        :data_points       n
+        :bin_data          []
+        :distribution      {:estimated_percentiles {}
+                            :estimated_quartiles   {:q1 0 :median 0 :q3 0 :iqr 0}}
+        :structure         {:mode_bin           nil
+                            :peak_count         0
+                            :concentration_top3 0.0
+                            :gap_count          0
+                            :empty_bin_ratio    0.0
+                            :bin_count          n}}
+       (let [;; Sort by x for cumulative operations
+             sorted-pairs (sort-by first (map vector valid-xs valid-ys))
+             sorted-xs    (mapv first sorted-pairs)
+             sorted-ys    (mapv second sorted-pairs)
+             cum-counts   (vec (reductions + sorted-ys))
+             ;; Weighted summary
+             wmean        (weighted-mean sorted-xs sorted-ys total)
+             wvar         (weighted-variance sorted-xs sorted-ys total wmean)
+             wstd         (Math/sqrt wvar)
+             min-x        (first sorted-xs)
+             max-x        (last sorted-xs)
+             ;; Distribution estimates
+             percentiles  (compute-estimated-percentiles sorted-xs cum-counts total)
+             q1           (get percentiles 25)
+             med          (get percentiles 50)
+             q3           (get percentiles 75)
+             ;; Shape metrics (weighted)
+             wskew        (when (>= n min-shape-metrics-points)
+                            (stats.u/nan->nil (or (weighted-skewness sorted-xs sorted-ys total wmean wstd) ##NaN)))
+             wkurt        (when (>= n min-shape-metrics-points)
+                            (stats.u/nan->nil (or (weighted-kurtosis sorted-xs sorted-ys total wmean wstd) ##NaN)))
+             ;; Structural metrics
+             max-count    (apply max sorted-ys)
+             mode-idx     (.indexOf ^java.util.List sorted-ys max-count)
+             top3         (reduce + (take 3 (sort > sorted-ys)))
+             zero-bins    (count (filter zero? sorted-ys))]
+         {:estimated_summary {:weighted_mean    wmean
+                              :weighted_std_dev wstd
+                              :data_range       (- max-x min-x)}
+          :total_count       (long total)
+          :data_points       n
+          :bin_data          (mapv vector sorted-xs sorted-ys)
+          :distribution      (cond-> {:estimated_percentiles percentiles
+                                      :estimated_quartiles   {:q1 q1 :median med :q3 q3 :iqr (- q3 q1)}}
+                               wskew (assoc :weighted_skewness wskew)
+                               wkurt (assoc :weighted_kurtosis wkurt))
+          :structure         {:mode_bin           [(nth sorted-xs mode-idx) max-count]
+                              :peak_count         (count-peaks sorted-ys)
+                              :concentration_top3 (/ top3 total)
+                              :gap_count          (count-gaps sorted-ys)
+                              :empty_bin_ratio    (/ (double zero-bins) n)
+                              :bin_count          n}})))))
 
 (mu/defn compute-histogram-stats :- ::stats.types/histogram-stats
-  "Compute statistics for histogram data."
+  "Compute statistics for histogram data.
+  Computes weighted approximations of distribution statistics from binned (bin_position, count) data, plus structural
+  metrics about the histogram shape."
   [series-data :- [:map-of :string ::stats.types/series-config]
    _opts       :- ::stats.types/options]
   (let [series-stats (stats.u/compute-series-with-labels series-data compute-series-stats)]

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/histogram.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/histogram.clj
@@ -1,7 +1,7 @@
 (ns metabase-enterprise.metabot-v3.stats.histogram
   "Histogram chart statistics computation."
   (:require
-   [metabase-enterprise.metabot-v3.stats.time-series :as time-series]))
+   [metabase-enterprise.metabot-v3.stats.util :as stats.u]))
 
 (set! *warn-on-reflection* true)
 
@@ -78,7 +78,7 @@
         :data_points  0
         :bin_data     []
         :distribution {:percentiles {} :quartiles {:q1 0 :median 0 :q3 0 :iqr 0}}}
-       (let [summary     (time-series/compute-summary valid)
+       (let [summary     (stats.u/compute-summary valid)
              sorted-vals (sort valid)
              percentiles (compute-percentiles sorted-vals)
              quartiles   (compute-quartiles sorted-vals)
@@ -100,11 +100,5 @@
   "Compute statistics for histogram data. Uses y_values (counts/frequencies per bin).
   series-data: map of series-name -> {:x_values [...] :y_values [...] :x {:name ...} :y {:name ...}}"
   [series-data _opts]
-  (let [series-stats (into {}
-                           (for [[series-name {:keys [x_values y_values x y]}] series-data]
-                             [series-name (-> (compute-series-stats x_values y_values)
-                                              (assoc :x_name (some-> x :name))
-                                              (assoc :y_name (some-> y :name)))]))]
-    {:chart_type   :histogram
-     :series_count (count series-data)
-     :series       series-stats}))
+  (let [series-stats (stats.u/compute-series-with-labels series-data compute-series-stats)]
+    (stats.u/make-chart-result :histogram series-data series-stats nil)))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/histogram.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/histogram.clj
@@ -62,38 +62,49 @@
       (- term1 term2))))
 
 (defn compute-series-stats
-  "Compute histogram stats for a single series using its y_values (counts/frequencies)."
-  [y-values]
-  (let [valid (mapv double (filter some? y-values))
-        n     (count valid)]
-    (if (zero? n)
-      {:summary     {:min 0 :max 0 :mean 0 :median 0 :std_dev 0 :range 0}
-       :data_points 0
-       :distribution {:percentiles {} :quartiles {:q1 0 :median 0 :q3 0 :iqr 0}}}
-      (let [summary     (time-series/compute-summary valid)
-            sorted-vals (sort valid)
-            percentiles (compute-percentiles sorted-vals)
-            quartiles   (compute-quartiles sorted-vals)
-            mean-val    (:mean summary)
-            std-dev     (:std_dev summary)
-            skewness    (when (>= n min-shape-metrics-points)
-                          (compute-skewness valid mean-val std-dev n))
-            kurtosis    (when (>= n min-shape-metrics-points)
-                          (compute-excess-kurtosis valid mean-val std-dev n))]
-        {:summary     summary
-         :data_points n
-         :distribution (cond-> {:percentiles percentiles
-                                :quartiles   quartiles}
-                         skewness (assoc :skewness skewness)
-                         kurtosis (assoc :kurtosis kurtosis))}))))
+  "Compute histogram stats for a single series using its y_values (counts/frequencies)
+  and x_values (bin edges/centers) for display.
+
+  Single-arity form accepts only y_values and uses sequential indices as x_values."
+  ([y-values]
+   (compute-series-stats (range (count y-values)) y-values))
+  ([x-values y-values]
+   (let [valid-pairs (filter (fn [[_ y]] (some? y)) (map vector x-values y-values))
+         valid       (mapv (comp double second) valid-pairs)
+         valid-xs    (mapv first valid-pairs)
+         n           (count valid)]
+     (if (zero? n)
+       {:summary      {:min 0 :max 0 :mean 0 :median 0 :std_dev 0 :range 0}
+        :data_points  0
+        :bin_data     []
+        :distribution {:percentiles {} :quartiles {:q1 0 :median 0 :q3 0 :iqr 0}}}
+       (let [summary     (time-series/compute-summary valid)
+             sorted-vals (sort valid)
+             percentiles (compute-percentiles sorted-vals)
+             quartiles   (compute-quartiles sorted-vals)
+             mean-val    (:mean summary)
+             std-dev     (:std_dev summary)
+             skewness    (when (>= n min-shape-metrics-points)
+                           (compute-skewness valid mean-val std-dev n))
+             kurtosis    (when (>= n min-shape-metrics-points)
+                           (compute-excess-kurtosis valid mean-val std-dev n))]
+         {:summary      summary
+          :data_points  n
+          :bin_data     (mapv vector valid-xs valid)
+          :distribution (cond-> {:percentiles percentiles
+                                 :quartiles   quartiles}
+                          skewness (assoc :skewness skewness)
+                          kurtosis (assoc :kurtosis kurtosis))})))))
 
 (defn compute-histogram-stats
   "Compute statistics for histogram data. Uses y_values (counts/frequencies per bin).
-  series-data: map of series-name -> {:x_values [...] :y_values [...]}"
+  series-data: map of series-name -> {:x_values [...] :y_values [...] :x {:name ...} :y {:name ...}}"
   [series-data _opts]
   (let [series-stats (into {}
-                           (for [[series-name {:keys [y_values]}] series-data]
-                             [series-name (compute-series-stats y_values)]))]
+                           (for [[series-name {:keys [x_values y_values x y]}] series-data]
+                             [series-name (-> (compute-series-stats x_values y_values)
+                                              (assoc :x_name (some-> x :name))
+                                              (assoc :y_name (some-> y :name)))]))]
     {:chart_type   :histogram
      :series_count (count series-data)
      :series       series-stats}))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/histogram.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/histogram.clj
@@ -25,12 +25,6 @@
      :q3     q3
      :iqr    (- q3 q1)}))
 
-(defn- nan->nil
-  "Convert NaN to nil."
-  [x]
-  (when-not (Double/isNaN (double x))
-    x))
-
 (defn- compute-series-stats
   "Compute histogram stats for a single series.
   x_values are (bin edges/centers) and y_values are (counts/frequencies).
@@ -51,9 +45,9 @@
              percentiles (compute-percentiles valid)
              quartiles   (compute-quartiles valid)
              skewness    (when (>= n min-shape-metrics-points)
-                           (nan->nil (dfn/skew valid)))
+                           (stats.u/nan->nil (dfn/skew valid)))
              kurtosis    (when (>= n min-shape-metrics-points)
-                           (nan->nil (dfn/kurtosis valid)))]
+                           (stats.u/nan->nil (dfn/kurtosis valid)))]
          {:summary      summary
           :data_points  n
           :bin_data     (mapv vector valid-xs valid)

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/histogram.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/histogram.clj
@@ -1,0 +1,99 @@
+(ns metabase-enterprise.metabot-v3.stats.histogram
+  "Histogram chart statistics computation."
+  (:require
+   [metabase-enterprise.metabot-v3.stats.time-series :as time-series]))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private min-shape-metrics-points 8)
+(def ^:private skewness-threshold 0.5)
+
+(defn- compute-percentile
+  "Compute a percentile of sorted values using linear interpolation. pct: 0-100."
+  [sorted-vals pct]
+  (let [n (count sorted-vals)]
+    (if (= n 1)
+      (first sorted-vals)
+      (let [idx   (* (/ pct 100.0) (dec n))
+            lower (int (Math/floor idx))
+            upper (int (Math/ceil idx))
+            frac  (- idx lower)]
+        (+ (* (- 1.0 frac) (nth sorted-vals lower))
+           (* frac (nth sorted-vals upper)))))))
+
+(defn- compute-percentiles
+  "Compute percentiles map for a sorted sequence of values."
+  [sorted-vals]
+  (into {}
+        (for [pct [25 50 75 90 95 99]]
+          [pct (compute-percentile sorted-vals pct)])))
+
+(defn- compute-quartiles
+  "Compute quartile stats from sorted values."
+  [sorted-vals]
+  (let [q1  (compute-percentile sorted-vals 25)
+        med (compute-percentile sorted-vals 50)
+        q3  (compute-percentile sorted-vals 75)]
+    {:q1     q1
+     :median med
+     :q3     q3
+     :iqr    (- q3 q1)}))
+
+(defn- compute-skewness
+  "Compute adjusted Fisher-Pearson skewness coefficient."
+  [values mean-val std-dev n]
+  (when (and (>= n 3) (pos? std-dev))
+    (let [cubed-zscores (map (fn [x] (Math/pow (/ (- (double x) mean-val) std-dev) 3)) values)
+          sum-cubed     (reduce + 0.0 cubed-zscores)]
+      (* (/ (* n (double sum-cubed))
+            (* (dec n) (- n 2)))
+         1.0))))
+
+(defn- compute-excess-kurtosis
+  "Compute Fisher's excess kurtosis (normal distribution = 0)."
+  [values mean-val std-dev n]
+  (when (and (>= n 4) (pos? std-dev))
+    (let [fourth-zscores (map (fn [x] (Math/pow (/ (- (double x) mean-val) std-dev) 4)) values)
+          sum-fourth     (reduce + 0.0 fourth-zscores)
+          term1          (/ (* n (inc n) sum-fourth)
+                            (* (dec n) (- n 2) (- n 3)))
+          term2          (/ (* 3.0 (Math/pow (dec n) 2))
+                            (* (- n 2) (- n 3)))]
+      (- term1 term2))))
+
+(defn compute-series-stats
+  "Compute histogram stats for a single series using its y_values (counts/frequencies)."
+  [y-values]
+  (let [valid (mapv double (filter some? y-values))
+        n     (count valid)]
+    (if (zero? n)
+      {:summary     {:min 0 :max 0 :mean 0 :median 0 :std_dev 0 :range 0}
+       :data_points 0
+       :distribution {:percentiles {} :quartiles {:q1 0 :median 0 :q3 0 :iqr 0}}}
+      (let [summary     (time-series/compute-summary valid)
+            sorted-vals (sort valid)
+            percentiles (compute-percentiles sorted-vals)
+            quartiles   (compute-quartiles sorted-vals)
+            mean-val    (:mean summary)
+            std-dev     (:std_dev summary)
+            skewness    (when (>= n min-shape-metrics-points)
+                          (compute-skewness valid mean-val std-dev n))
+            kurtosis    (when (>= n min-shape-metrics-points)
+                          (compute-excess-kurtosis valid mean-val std-dev n))]
+        {:summary     summary
+         :data_points n
+         :distribution (cond-> {:percentiles percentiles
+                                :quartiles   quartiles}
+                         skewness (assoc :skewness skewness)
+                         kurtosis (assoc :kurtosis kurtosis))}))))
+
+(defn compute-histogram-stats
+  "Compute statistics for histogram data. Uses y_values (counts/frequencies per bin).
+  series-data: map of series-name -> {:x_values [...] :y_values [...]}"
+  [series-data _opts]
+  (let [series-stats (into {}
+                           (for [[series-name {:keys [y_values]}] series-data]
+                             [series-name (compute-series-stats y_values)]))]
+    {:chart_type   :histogram
+     :series_count (count series-data)
+     :series       series-stats}))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/outliers.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/outliers.clj
@@ -48,24 +48,24 @@
   "Find outliers in a dataset with their details.
 
   Arguments:
-    values     - sequence of numeric values
-    dates      - sequence of date/dimension values (same length as values)
+    values     - sequence of numeric values to analyze for outliers
+    labels     - sequence of corresponding labels (same length as values)
 
   Returns a sequence of outlier maps with:
     :index           - position in the original sequence
-    :date            - the date/dimension value at that position
+    :label           - the label at that position
     :value           - the numeric value
     :modified_z_score - the modified Z-score"
   [values :- [:sequential number?]
-   dates  :- [:sequential :any]]
+   labels :- [:sequential :any]]
   (when-let [z-scores (compute-modified-z-scores values)]
     (let [indices (vec (argops/argfilter #(> (Math/abs (double %)) modified-z-threshold) z-scores))
           values-vec (vec values)
-          dates-vec (vec dates)
+          labels-vec (vec labels)
           z-scores-vec (vec z-scores)]
       (mapv (fn [idx]
               {:index idx
-               :date (nth dates-vec idx)
+               :label (nth labels-vec idx)
                :value (nth values-vec idx)
                :modified_z_score (nth z-scores-vec idx)})
             indices))))
@@ -78,19 +78,19 @@
   the destination point (i.e., the point that received the unusual increase).
 
   Arguments:
-    values     - sequence of numeric values (cumulative data)
-    dates      - sequence of date/dimension values (same length as values)
+    values     - sequence of numeric values (cumulative data) to analyze
+    labels     - sequence of corresponding labels (same length as values)
 
   Returns a sequence of outlier maps with:
     :index           - position in the original sequence
-    :date            - the date/dimension value at that position
+    :label           - the label at that position
     :value           - the numeric value at that position
     :diff            - the period-over-period change that was flagged
     :modified_z_score - the modified Z-score of the diff"
   [values :- [:sequential number?]
-   dates  :- [:sequential :any]]
+   labels :- [:sequential :any]]
   (let [values-vec (vec values)
-        dates-vec (vec dates)
+        labels-vec (vec labels)
         diffs (mapv - (rest values-vec) values-vec)]
     (when-let [z-scores (compute-modified-z-scores diffs)]
       (let [outlier-diff-indices (vec (argops/argfilter #(> (Math/abs (double %)) modified-z-threshold) z-scores))
@@ -98,7 +98,7 @@
         (mapv (fn [diff-idx]
                 (let [point-idx (inc diff-idx)]
                   {:index point-idx
-                   :date (nth dates-vec point-idx)
+                   :label (nth labels-vec point-idx)
                    :value (nth values-vec point-idx)
                    :diff (nth diffs diff-idx)
                    :modified_z_score (nth z-scores-vec diff-idx)}))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/outliers.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/outliers.clj
@@ -44,16 +44,6 @@
             scaled (dfn// centered mad)]
         (dfn/* scaled mad-normalization-constant)))))
 
-(defn- find-outlier-indices
-  "Find indices of outlier values using the Modified Z-score method.
-
-  Returns a vector of indices where |modified_z| > 3.5.
-  Returns empty vector if no outliers found or if MAD is zero."
-  [values]
-  (if-let [z-scores (compute-modified-z-scores values)]
-    (vec (argops/argfilter #(> (Math/abs (double %)) modified-z-threshold) z-scores))
-    []))
-
 (mu/defn find-outliers :- [:maybe [:sequential ::stats.types/outlier]]
   "Find outliers in a dataset with their details.
 

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/outliers.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/outliers.clj
@@ -5,6 +5,8 @@
   because it uses median and MAD (Median Absolute Deviation) instead of mean
   and standard deviation, making it resistant to outliers in the calculation itself."
   (:require
+   [metabase-enterprise.metabot-v3.stats.types :as stats.types]
+   [metabase.util.malli :as mu]
    [tech.v3.datatype.argops :as argops]
    [tech.v3.datatype.functional :as dfn]))
 
@@ -52,7 +54,7 @@
     (vec (argops/argfilter #(> (Math/abs (double %)) modified-z-threshold) z-scores))
     []))
 
-(defn find-outliers
+(mu/defn find-outliers :- [:maybe [:sequential ::stats.types/outlier]]
   "Find outliers in a dataset with their details.
 
   Arguments:
@@ -64,7 +66,8 @@
     :date            - the date/dimension value at that position
     :value           - the numeric value
     :modified_z_score - the modified Z-score"
-  [values dates]
+  [values :- [:sequential number?]
+   dates  :- [:sequential :any]]
   (when-let [z-scores (compute-modified-z-scores values)]
     (let [indices (vec (argops/argfilter #(> (Math/abs (double %)) modified-z-threshold) z-scores))
           values-vec (vec values)
@@ -77,7 +80,7 @@
                :modified_z_score (nth z-scores-vec idx)})
             indices))))
 
-(defn find-outliers-cumulative
+(mu/defn find-outliers-cumulative :- [:maybe [:sequential ::stats.types/cumulative-outlier]]
   "Find outliers in cumulative data by analyzing period-over-period diffs.
 
   For cumulative (monotonically increasing) data, outliers are detected in the
@@ -94,7 +97,8 @@
     :value           - the numeric value at that position
     :diff            - the period-over-period change that was flagged
     :modified_z_score - the modified Z-score of the diff"
-  [values dates]
+  [values :- [:sequential number?]
+   dates  :- [:sequential :any]]
   (let [values-vec (vec values)
         dates-vec (vec dates)
         diffs (mapv - (rest values-vec) values-vec)]

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/outliers.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/outliers.clj
@@ -42,7 +42,7 @@
             scaled (dfn// centered mad)]
         (dfn/* scaled mad-normalization-constant)))))
 
-(defn find-outlier-indices
+(defn- find-outlier-indices
   "Find indices of outlier values using the Modified Z-score method.
 
   Returns a vector of indices where |modified_z| > 3.5.

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/repr.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/repr.clj
@@ -350,33 +350,46 @@
 
 (defn- render-histogram-series
   "Render stats for a single histogram series."
-  [series-name {:keys [x_name y_name summary data_points bin_data distribution] :as series-stats}]
-  (let [{:keys [skewness kurtosis percentiles quartiles]} distribution
-        p-str     (when (seq percentiles)
-                    (str "**Percentiles**: "
-                         "P25=" (format-number (get percentiles 25))
-                         ", P50=" (format-number (get percentiles 50))
-                         ", P75=" (format-number (get percentiles 75))
-                         ", P90=" (format-number (get percentiles 90))))
-        iqr-str   (when quartiles
-                    (str "**IQR**: " (format-number (:iqr quartiles))
-                         " (Q1=" (format-number (:q1 quartiles))
-                         " to Q3=" (format-number (:q3 quartiles)) ")"))
-        shape-str (when skewness
-                    (let [k-desc (when kurtosis (kurtosis-description kurtosis))]
-                      (str "**Distribution Shape**: " (skewness-description skewness)
-                           (when k-desc (str ", " k-desc)))))
-        sections  [(str "## Series: " series-name)
-                   (when x_name (str "**X-axis**: " x_name))
-                   (when y_name (str "**Y-axis**: " y_name))
-                   (str "**Data Points**: " data_points)
-                   (render-data-characteristics-note series-stats)
-                   (when (seq bin_data)
-                     (let [xs (mapv first bin_data)]
-                       (render-axis-range "X-axis" {:min (apply min xs) :max (apply max xs)})))
-                   (render-axis-range "Y-axis" summary)
-                   p-str iqr-str shape-str
-                   (render-sample-data bin_data)]]
+  [series-name {:keys [x_name y_name estimated_summary total_count data_points
+                       bin_data distribution structure] :as series-stats}]
+  (let [{:keys [weighted_skewness weighted_kurtosis estimated_percentiles estimated_quartiles]} distribution
+        {:keys [weighted_mean weighted_std_dev data_range]} estimated_summary
+        {:keys [mode_bin peak_count concentration_top3 gap_count empty_bin_ratio bin_count]} structure
+        summary-str (str "**Estimated Distribution** (from " bin_count " bins, " total_count " total observations): "
+                         "mean≈" (format-number weighted_mean)
+                         ", std_dev≈" (format-number weighted_std_dev)
+                         ", range=" (format-number data_range))
+        p-str       (when (seq estimated_percentiles)
+                      (str "**Estimated Percentiles**: "
+                           "P25≈" (format-number (get estimated_percentiles 25))
+                           ", P50≈" (format-number (get estimated_percentiles 50))
+                           ", P75≈" (format-number (get estimated_percentiles 75))
+                           ", P90≈" (format-number (get estimated_percentiles 90))))
+        iqr-str     (when estimated_quartiles
+                      (str "**Estimated IQR**: " (format-number (:iqr estimated_quartiles))
+                           " (Q1≈" (format-number (:q1 estimated_quartiles))
+                           " to Q3≈" (format-number (:q3 estimated_quartiles)) ")"))
+        shape-str   (when weighted_skewness
+                      (let [k-desc (when weighted_kurtosis (kurtosis-description weighted_kurtosis))]
+                        (str "**Distribution Shape**: " (skewness-description weighted_skewness)
+                             (when k-desc (str ", " k-desc)))))
+        struct-str  (str "**Structure**: "
+                         (when mode_bin (str "mode bin at " (format-number (first mode_bin))
+                                             " (count=" (format-number (second mode_bin)) ")"))
+                         (when (> peak_count 1) (str ", " peak_count " peaks (multimodal)"))
+                         ", top 3 bins contain " (format "%.0f%%" (* 100.0 concentration_top3)) " of data"
+                         (when (pos? gap_count) (str ", " gap_count " gap(s)"))
+                         (when (pos? empty_bin_ratio) (str ", " (format "%.0f%%" (* 100.0 empty_bin_ratio)) " empty bins")))
+        sections    [(str "## Series: " series-name)
+                     (when x_name (str "**X-axis**: " x_name))
+                     (when y_name (str "**Y-axis**: " y_name))
+                     (str "**Bins**: " data_points)
+                     (render-data-characteristics-note series-stats)
+                     (when (seq bin_data)
+                       (let [xs (mapv first bin_data)]
+                         (render-axis-range "X-axis" {:min (apply min xs) :max (apply max xs)})))
+                     summary-str p-str iqr-str shape-str struct-str
+                     (render-sample-data bin_data)]]
     (str/join "\n" (remove nil? sections))))
 
 ;;; ----------------------------------------- Main Representation ----------------------------------------------------

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/repr.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/repr.clj
@@ -56,7 +56,7 @@
     "N/A"
     (str (if (pos? n) "+" "") (format "%.1f" (double n)) "%")))
 
-(defn- format-date
+(defn- format-label
   "Format a date value for display."
   [d]
   (cond
@@ -86,6 +86,24 @@
     :high "high"
     :extreme "extreme"
     (name level)))
+
+(defn- render-axis-range
+  "Render '**<label> Range**: min to max' from a summary map with :min/:max."
+  [label summary]
+  (when summary
+    (str "**" label " Range**: "
+         (format-number (:min summary))
+         " to "
+         (format-number (:max summary)))))
+
+(defn- render-sample-data
+  "Render sampled data pairs as 'x: y | x: y | ...'."
+  [data]
+  (when (seq data)
+    (str "**Sample Data** (" (count data) " samples):\n"
+         (str/join " | " (map (fn [[x y]]
+                                (str (format-number x) ": " (format-number y)))
+                              data)))))
 
 ;;; -------------------------------------------- Data Limits Note ---------------------------------------------------
 
@@ -143,7 +161,7 @@
   [{:keys [summary time_range data_points]}]
   (let [{:keys [min max mean median std_dev]} summary
         {:keys [start end]} time_range]
-    (str "**Data Points**: " data_points " (" (format-date start) " to " (format-date end) ")\n"
+    (str "**Data Points**: " data_points " (" (format-label start) " to " (format-label end) ")\n"
          "**Value Range**: " (format-number min) " to " (format-number max)
          " (median: " (format-number median) ")\n"
          "**Mean**: " (format-number mean) " | **Std Dev**: " (format-number std_dev))))
@@ -169,7 +187,7 @@
     (str "**Outliers**: " (count outliers) " detected\n"
          (str/join "\n"
                    (for [{:keys [label value modified_z_score]} outliers]
-                     (str "  - " (format-date label) ": " (format-number value)
+                     (str "  - " (format-label label) ": " (format-number value)
                           " (z-score: " (format "%.2f" (double modified_z_score)) ")"))))
     "**Outliers**: None detected"))
 
@@ -180,7 +198,7 @@
     (str "**Patterns**:\n"
          (str/join "\n"
                    (for [{:keys [description from_date to_date]} patterns]
-                     (str "  - " description " (" (format-date from_date) " to " (format-date to_date) ")"))))))
+                     (str "  - " description " (" (format-label from_date) " to " (format-label to_date) ")"))))))
 
 (defn- render-significant-changes
   "Render significant changes."
@@ -189,7 +207,7 @@
     (str "**Significant Changes**:\n"
          (str/join "\n"
                    (for [{:keys [from_date to_date from_value to_value change_pct]} changes]
-                     (str "  - " (format-date from_date) " → " (format-date to_date)
+                     (str "  - " (format-label from_date) " → " (format-label to_date)
                           ": " (format-number from_value) " → " (format-number to_value)
                           " (" (format-pct change_pct) ")"))))))
 
@@ -197,11 +215,11 @@
   "Render most recent change."
   [{:keys [from_date to_date from_value to_value change_pct] :as change}]
   (when change
-    (str "**Most Recent Change**: " (format-date from_date) " → " (format-date to_date)
+    (str "**Most Recent Change**: " (format-label from_date) " → " (format-label to_date)
          ": " (format-number from_value) " → " (format-number to_value)
          " (" (format-pct change_pct) ")")))
 
-(defn- render-series
+(defn- render-time-series
   "Render complete statistics for a single series."
   [series-name series-stats]
   (let [{:keys [trend is_cumulative volatility outliers patterns
@@ -273,37 +291,10 @@
                   (render-outliers outliers)]]
     (str/join "\n" (remove nil? sections))))
 
-(defn- generate-categorical-representation
-  "Generate markdown representation for categorical (bar, pie, funnel, etc.) stats."
-  [{:keys [title display-type stats timeline-events]}]
-  (let [{:keys [series_count series correlations limits]} stats
-        header              (str "# Chart Analysis\n"
-                                 (when title (str "## Chart: " title "\n"))
-                                 "**Type**: Categorical" (when display-type (str " (" display-type ")")) "\n"
-                                 "**Series Count**: " series_count)
-        limits-note         (when limits (render-limits-note limits))
-        series-sections     (str/join "\n\n"
-                                      (for [[series-name s] series]
-                                        (render-categorical-series series-name s)))
-        correlation-section (render-correlations correlations)
-        events-section      (render-timeline-events timeline-events)]
-    (str/join "\n\n"
-              (remove str/blank?
-                      [header limits-note series-sections correlation-section events-section]))))
-
 ;;; ------------------------------------------ Scatter Representation ------------------------------------------------
 
 (defn- correlation-label [{:keys [strength direction]}]
   (str (name strength) " " (name direction)))
-
-(defn- render-scatter-sample-data
-  "Render sampled points as 'x: y | x: y | ...'."
-  [sampled-points]
-  (when (seq sampled-points)
-    (str "**Sample Data** (" (count sampled-points) " points):\n"
-         (str/join " | " (map (fn [[x y]]
-                                (str (format-number x) ": " (format-number y)))
-                              sampled-points)))))
 
 (defn- render-scatter-outliers
   "Render outliers as 'x=..., y=...'"
@@ -328,12 +319,8 @@
                   (when x_name (str "**X-axis**: " x_name))
                   (when y_name (str "**Y-axis**: " y_name))
                   (render-data-characteristics-note series-stats)
-                  (when x_summary
-                    (str "**X-axis Range**: " (format-number (:min x_summary))
-                         " to " (format-number (:max x_summary))))
-                  (when y_summary
-                    (str "**Y-axis Range**: " (format-number (:min y_summary))
-                         " to " (format-number (:max y_summary))))
+                  (render-axis-range "X-axis" x_summary)
+                  (render-axis-range "Y-axis" y_summary)
                   (when correlation
                     (str "**Relationship**: " (correlation-label correlation)
                          " (r = " (format "%.2f" (double (:coefficient correlation))) ")"))
@@ -341,25 +328,9 @@
                     (str "**Trend Line**: y = "
                          (format "%.3f" (double (:slope regression))) "x + "
                          (format "%.3f" (double (:intercept regression)))))
-                  (render-scatter-sample-data sampled_points)
+                  (render-sample-data sampled_points)
                   (render-scatter-outliers outliers)]]
     (str/join "\n" (remove nil? sections))))
-
-(defn- generate-scatter-representation
-  "Generate markdown representation for scatter plot stats."
-  [{:keys [title display-type stats timeline-events]}]
-  (let [{:keys [series_count series limits]} stats
-        header          (str "# Chart Analysis\n"
-                             (when title (str "## Chart: " title "\n"))
-                             "**Type**: Scatter" (when display-type (str " (" display-type ")")) "\n"
-                             "**Series Count**: " series_count)
-        limits-note     (when limits (render-limits-note limits))
-        series-sections (str/join "\n\n"
-                                  (for [[series-name s] series]
-                                    (render-scatter-series series-name s)))
-        events-section  (render-timeline-events timeline-events)]
-    (str/join "\n\n"
-              (remove str/blank? [header limits-note series-sections events-section]))))
 
 ;;; ----------------------------------------- Histogram Representation -----------------------------------------------
 
@@ -374,15 +345,6 @@
     (> kurtosis 1)  "heavy tails (more extreme values than normal)"
     (< kurtosis -1) "light tails (fewer extreme values than normal)"
     :else           nil))
-
-(defn- render-histogram-bin-data
-  "Render bin data as 'x: y | x: y | ...'."
-  [bin_data]
-  (when (seq bin_data)
-    (str "**Sample Data** (" (count bin_data) " bins):\n"
-         (str/join " | " (map (fn [[x y]]
-                                (str (format-number x) ": " (format-number y)))
-                              bin_data)))))
 
 (defn- render-histogram-series
   "Render stats for a single histogram series."
@@ -409,66 +371,47 @@
                    (render-data-characteristics-note series-stats)
                    (when (seq bin_data)
                      (let [xs (mapv first bin_data)]
-                       (str "**X-axis range**: " (format-number (reduce min xs))
-                            " to " (format-number (reduce max xs)))))
-                   (when summary
-                     (str "**Y-axis range**: " (format-number (:min summary))
-                          " to " (format-number (:max summary))))
+                       (render-axis-range "X-axis" {:min (reduce min xs) :max (reduce max xs)})))
+                   (render-axis-range "Y-axis" summary)
                    p-str iqr-str shape-str
-                   (render-histogram-bin-data bin_data)]]
+                   (render-sample-data bin_data)]]
     (str/join "\n" (remove nil? sections))))
-
-(defn- generate-histogram-representation
-  "Generate markdown representation for histogram stats."
-  [{:keys [title display-type stats timeline-events]}]
-  (let [{:keys [series_count series limits]} stats
-        header          (str "# Chart Analysis\n"
-                             (when title (str "## Chart: " title "\n"))
-                             "**Type**: Histogram" (when display-type (str " (" display-type ")")) "\n"
-                             "**Series Count**: " series_count)
-        limits-note     (when limits (render-limits-note limits))
-        series-sections (str/join "\n\n"
-                                  (for [[series-name s] series]
-                                    (render-histogram-series series-name s)))
-        events-section  (render-timeline-events timeline-events)]
-    (str/join "\n\n"
-              (remove str/blank? [header limits-note series-sections events-section]))))
 
 ;;; ----------------------------------------- Main Representation ----------------------------------------------------
 
-(defn- generate-time-series-representation
-  "Generate comprehensive markdown representation for time series stats."
-  [{:keys [title display-type stats timeline-events]}]
+(defn- generate-chart-representation
+  "Shared generator for all chart types.
+   `type-label`       — e.g. \"Categorical\", \"Scatter\"
+   `render-series-fn` — (fn [series-name series-stats] => string)
+   `extra-sections`   — seq of additional section strings to insert after limits (may contain nils)"
+  [{:keys [title display-type stats timeline-events]} type-label render-series-fn extra-sections]
   (let [{:keys [series_count series correlations limits]} stats
-        header (str "# Chart Analysis\n"
-                    (when title (str "## Chart: " title "\n"))
-                    "**Type**: Time Series" (when display-type (str " (" display-type ")")) "\n"
-                    "**Series Count**: " series_count)
-        limits-note (when limits (render-limits-note limits))
-        temporal-context (generate-temporal-context)
+        header          (str "# Chart Analysis\n"
+                             (when title (str "## Chart: " title "\n"))
+                             "**Type**: " type-label (when display-type (str " (" display-type ")")) "\n"
+                             "**Series Count**: " series_count)
+        limits-note     (when limits (render-limits-note limits))
         series-sections (str/join "\n\n"
-                                  (for [[name s] series]
-                                    (render-series name s)))
-        correlation-section (render-correlations correlations)
-        events-section (render-timeline-events timeline-events)]
+                                  (for [[sname s] series]
+                                    (render-series-fn sname s)))]
     (str/join "\n\n"
               (remove str/blank?
-                      [header
-                       limits-note
-                       temporal-context
-                       series-sections
-                       correlation-section
-                       events-section]))))
+                      (concat [header limits-note]
+                              extra-sections
+                              [series-sections
+                               (render-correlations correlations)
+                               (render-timeline-events timeline-events)])))))
 
 (mu/defn generate-representation :- :string
   "Generate markdown representation for chart statistics.
   Dispatches based on chart type."
   [{:keys [stats] :as context} :- ::stats.types/generate-repr-context]
   (case (:chart_type stats)
-    :time-series  (generate-time-series-representation context)
-    :categorical  (generate-categorical-representation context)
-    :scatter      (generate-scatter-representation context)
-    :histogram    (generate-histogram-representation context)
+    :time-series  (generate-chart-representation context "Time Series" render-time-series
+                                                 [(generate-temporal-context)])
+    :categorical  (generate-chart-representation context "Categorical" render-categorical-series nil)
+    :scatter      (generate-chart-representation context "Scatter" render-scatter-series nil)
+    :histogram    (generate-chart-representation context "Histogram" render-histogram-series nil)
     (str "# Chart Analysis\n"
          "**Type**: " (name (:chart_type stats)) "\n"
          "Statistics computation for this chart type is not yet implemented.")))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/repr.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/repr.clj
@@ -84,6 +84,27 @@
     :extreme "extreme"
     (name level)))
 
+;;; -------------------------------------------- Data Limits Note ---------------------------------------------------
+
+(defn- render-limits-note
+  "Render a note when data limits were applied during stats computation."
+  [{:keys [downsampled_series correlations_capped]}]
+  (let [parts (cond-> []
+                (seq downsampled_series)
+                (conj (let [entries (for [[name {:keys [original_count sampled_count]}] downsampled_series]
+                                      (str name " (" original_count " → " sampled_count " points)"))]
+                        (str "Data was downsampled for statistical analysis: "
+                             (str/join ", " entries)
+                             ". Results are based on a uniform sample of the full dataset.")))
+
+                correlations_capped
+                (conj (str "Cross-series correlations were limited to "
+                           (:max_correlated correlations_capped) " of "
+                           (:total_series correlations_capped)
+                           " series to keep computation tractable.")))]
+    (when (seq parts)
+      (str "**Data Limits Applied**: " (str/join " " parts)))))
+
 ;;; ----------------------------------------- Data Characteristics ---------------------------------------------------
 
 (defn- compute-data-characteristics
@@ -257,11 +278,12 @@
 (defn generate-categorical-representation
   "Generate markdown representation for categorical (bar, pie, funnel, etc.) stats."
   [{:keys [title display-type stats timeline-events]}]
-  (let [{:keys [series_count series correlations]} stats
+  (let [{:keys [series_count series correlations limits]} stats
         header (str "# Chart Analysis\n"
                     (when title (str "## Chart: " title "\n"))
                     "**Type**: Categorical" (when display-type (str " (" display-type ")")) "\n"
                     "**Series Count**: " series_count)
+        limits-note (when limits (render-limits-note limits))
         series-sections (str/join "\n\n"
                                   (for [[series-name s] series]
                                     (render-categorical-series series-name s)))
@@ -269,7 +291,7 @@
         events-section      (render-timeline-events timeline-events)]
     (str/join "\n\n"
               (remove str/blank?
-                      [header series-sections correlation-section events-section]))))
+                      [header limits-note series-sections correlation-section events-section]))))
 
 ;;; ------------------------------------------ Scatter Representation ------------------------------------------------
 
@@ -327,17 +349,18 @@
 (defn generate-scatter-representation
   "Generate markdown representation for scatter plot stats."
   [{:keys [title display-type stats timeline-events]}]
-  (let [{:keys [series_count series]} stats
+  (let [{:keys [series_count series limits]} stats
         header (str "# Chart Analysis\n"
                     (when title (str "## Chart: " title "\n"))
                     "**Type**: Scatter" (when display-type (str " (" display-type ")")) "\n"
                     "**Series Count**: " series_count)
+        limits-note (when limits (render-limits-note limits))
         series-sections (str/join "\n\n"
                                   (for [[series-name s] series]
                                     (render-scatter-series series-name s)))
         events-section (render-timeline-events timeline-events)]
     (str/join "\n\n"
-              (remove str/blank? [header series-sections events-section]))))
+              (remove str/blank? [header limits-note series-sections events-section]))))
 
 ;;; ----------------------------------------- Histogram Representation -----------------------------------------------
 
@@ -396,28 +419,30 @@
 (defn generate-histogram-representation
   "Generate markdown representation for histogram stats."
   [{:keys [title display-type stats timeline-events]}]
-  (let [{:keys [series_count series]} stats
+  (let [{:keys [series_count series limits]} stats
         header (str "# Chart Analysis\n"
                     (when title (str "## Chart: " title "\n"))
                     "**Type**: Histogram" (when display-type (str " (" display-type ")")) "\n"
                     "**Series Count**: " series_count)
+        limits-note (when limits (render-limits-note limits))
         series-sections (str/join "\n\n"
                                   (for [[series-name s] series]
                                     (render-histogram-series series-name s)))
         events-section (render-timeline-events timeline-events)]
     (str/join "\n\n"
-              (remove str/blank? [header series-sections events-section]))))
+              (remove str/blank? [header limits-note series-sections events-section]))))
 
 ;;; ----------------------------------------- Main Representation ----------------------------------------------------
 
 (defn generate-time-series-representation
   "Generate comprehensive markdown representation for time series stats."
   [{:keys [title display-type stats timeline-events]}]
-  (let [{:keys [series_count series correlations]} stats
+  (let [{:keys [series_count series correlations limits]} stats
         header (str "# Chart Analysis\n"
                     (when title (str "## Chart: " title "\n"))
                     "**Type**: Time Series" (when display-type (str " (" display-type ")")) "\n"
                     "**Series Count**: " series_count)
+        limits-note (when limits (render-limits-note limits))
         temporal-context (generate-temporal-context)
         series-sections (str/join "\n\n"
                                   (for [[name s] series]
@@ -427,6 +452,7 @@
     (str/join "\n\n"
               (remove str/blank?
                       [header
+                       limits-note
                        temporal-context
                        series-sections
                        correlation-section

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/repr.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/repr.clj
@@ -189,6 +189,49 @@
                      (str "- **" timestamp "**: " name
                           (when description (str " - " description))))))))
 
+;;; ----------------------------------------- Categorical Representation ---------------------------------------------
+
+(defn- render-category-list
+  "Render a list of categories with values and percentages."
+  [categories]
+  (str/join "\n"
+            (for [{:keys [name value percentage]} categories]
+              (str "  - " name ": " (format-number value)
+                   " (" (format "%.1f" (double percentage)) "%)"))))
+
+(defn- render-categorical-series
+  "Render stats for a single categorical series."
+  [series-name {:keys [summary category_count top_categories bottom_categories outliers]}]
+  (let [sections [(str "## Series: " series-name)
+                  (str "**Categories**: " category_count)
+                  (when summary
+                    (str "**Value Range**: " (format-number (:min summary))
+                         " to " (format-number (:max summary))
+                         " (median: " (format-number (:median summary)) ")"))
+                  (when (seq top_categories)
+                    (str "**Top Categories**:\n" (render-category-list top_categories)))
+                  (when (seq bottom_categories)
+                    (str "**Bottom Categories**:\n" (render-category-list bottom_categories)))
+                  (render-outliers outliers)]]
+    (str/join "\n" (remove nil? sections))))
+
+(defn generate-categorical-representation
+  "Generate markdown representation for categorical (bar, pie, funnel, etc.) stats."
+  [{:keys [title stats timeline-events]}]
+  (let [{:keys [series_count series correlations]} stats
+        header (str "# Chart Analysis\n"
+                    (when title (str "## Chart: " title "\n"))
+                    "**Type**: Categorical\n"
+                    "**Series Count**: " series_count)
+        series-sections (str/join "\n\n"
+                                  (for [[series-name s] series]
+                                    (render-categorical-series series-name s)))
+        correlation-section (render-correlations correlations)
+        events-section      (render-timeline-events timeline-events)]
+    (str/join "\n\n"
+              (remove str/blank?
+                      [header series-sections correlation-section events-section]))))
+
 ;;; ----------------------------------------- Main Representation ----------------------------------------------------
 
 (defn generate-time-series-representation
@@ -218,8 +261,8 @@
   Dispatches based on chart type."
   [{:keys [stats] :as context}]
   (case (:chart_type stats)
-    :time-series (generate-time-series-representation context)
-    ;; Fallback for unimplemented types
+    :time-series  (generate-time-series-representation context)
+    :categorical  (generate-categorical-representation context)
     (str "# Chart Analysis\n"
          "**Type**: " (name (:chart_type stats)) "\n"
          "Statistics computation for this chart type is not yet implemented.")))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/repr.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/repr.clj
@@ -30,7 +30,8 @@
          "- Current month: " month-name " (day " (.getDayOfMonth now) ")\n"
          "- Current quarter: Q" (quarter-of-year now) " " (.getYear now) "\n"
          "Take this into account when analyzing recent data points.\n"
-         "If the latest data point falls within the current week, month, or quarter, it may represent an incomplete period and should be interpreted accordingly.")))
+         "If the latest data point falls within the current week, month, or quarter, it may represent an incomplete"
+         " period and should be interpreted accordingly.")))
 
 ;;; ------------------------------------------------- Formatting -----------------------------------------------------
 
@@ -108,12 +109,7 @@
 ;;; ----------------------------------------- Data Characteristics ---------------------------------------------------
 
 (defn- compute-data-characteristics
-  "Derive data quality flags from pre-computed series stats.
-
-  Uses fields already present in the stats map so no raw values are needed:
-  - :small_counts  max y-value < 20 (percentage changes may be exaggerated)
-  - :high_variance CoV > 0.5        (fluctuations may be normal noise)
-  - :sparse_data   < 10 data points"
+  "Derive data quality flags from pre-computed series stats."
   [{:keys [data_points category_count summary y_summary]}]
   (let [n     (or data_points category_count 0)
         s     (or y_summary summary)
@@ -279,14 +275,14 @@
   "Generate markdown representation for categorical (bar, pie, funnel, etc.) stats."
   [{:keys [title display-type stats timeline-events]}]
   (let [{:keys [series_count series correlations limits]} stats
-        header (str "# Chart Analysis\n"
-                    (when title (str "## Chart: " title "\n"))
-                    "**Type**: Categorical" (when display-type (str " (" display-type ")")) "\n"
-                    "**Series Count**: " series_count)
-        limits-note (when limits (render-limits-note limits))
-        series-sections (str/join "\n\n"
-                                  (for [[series-name s] series]
-                                    (render-categorical-series series-name s)))
+        header              (str "# Chart Analysis\n"
+                                 (when title (str "## Chart: " title "\n"))
+                                 "**Type**: Categorical" (when display-type (str " (" display-type ")")) "\n"
+                                 "**Series Count**: " series_count)
+        limits-note         (when limits (render-limits-note limits))
+        series-sections     (str/join "\n\n"
+                                      (for [[series-name s] series]
+                                        (render-categorical-series series-name s)))
         correlation-section (render-correlations correlations)
         events-section      (render-timeline-events timeline-events)]
     (str/join "\n\n"
@@ -302,13 +298,13 @@
   "Render sampled points as 'x: y | x: y | ...'."
   [sampled-points]
   (when (seq sampled-points)
-    (let [n         (count sampled-points)
-          formatted (str/join " | " (map (fn [[x y]] (str (format-number x) ": " (format-number y)))
-                                         sampled-points))]
-      (str "**Sample Data** (" n " points):\n" formatted))))
+    (str "**Sample Data** (" (count sampled-points) " points):\n"
+         (str/join " | " (map (fn [[x y]]
+                                (str (format-number x) ": " (format-number y)))
+                              sampled-points)))))
 
 (defn- render-scatter-outliers
-  "Render outliers as 'x=..., y=...' (each outlier map has :date=x-value, :value=y-value)."
+  "Render outliers as 'x=..., y=...'"
   [outliers]
   (when (seq outliers)
     (let [total (count outliers)
@@ -316,7 +312,8 @@
           lines (map (fn [{:keys [date value]}]
                        (str "- x=" (format-number date) ", y=" (format-number value)))
                      shown)
-          more  (when (> total 5) (str "... and " (- total 5) " more"))]
+          more  (when (> total 5)
+                  (str "... and " (- total 5) " more"))]
       (str "**Outliers** (" total " total, showing up to 5):\n"
            (str/join "\n" (remove nil? (concat lines [more])))))))
 
@@ -350,15 +347,15 @@
   "Generate markdown representation for scatter plot stats."
   [{:keys [title display-type stats timeline-events]}]
   (let [{:keys [series_count series limits]} stats
-        header (str "# Chart Analysis\n"
-                    (when title (str "## Chart: " title "\n"))
-                    "**Type**: Scatter" (when display-type (str " (" display-type ")")) "\n"
-                    "**Series Count**: " series_count)
-        limits-note (when limits (render-limits-note limits))
+        header          (str "# Chart Analysis\n"
+                             (when title (str "## Chart: " title "\n"))
+                             "**Type**: Scatter" (when display-type (str " (" display-type ")")) "\n"
+                             "**Series Count**: " series_count)
+        limits-note     (when limits (render-limits-note limits))
         series-sections (str/join "\n\n"
                                   (for [[series-name s] series]
                                     (render-scatter-series series-name s)))
-        events-section (render-timeline-events timeline-events)]
+        events-section  (render-timeline-events timeline-events)]
     (str/join "\n\n"
               (remove str/blank? [header limits-note series-sections events-section]))))
 
@@ -380,55 +377,55 @@
   "Render bin data as 'x: y | x: y | ...'."
   [bin_data]
   (when (seq bin_data)
-    (let [n         (count bin_data)
-          formatted (str/join " | " (map (fn [[x y]] (str (format-number x) ": " (format-number y)))
-                                         bin_data))]
-      (str "**Bin Data** (" n " bins):\n" formatted))))
+    (str "**Bin Data** (" (count bin_data) " bins):\n"
+         (str/join " | " (map (fn [[x y]]
+                                (str (format-number x) ": " (format-number y)))
+                              bin_data)))))
 
 (defn- render-histogram-series
   "Render stats for a single histogram series."
   [series-name {:keys [x_name y_name summary data_points bin_data distribution] :as series-stats}]
   (let [{:keys [skewness kurtosis percentiles quartiles]} distribution
-        p-str (when (seq percentiles)
-                (str "**Percentiles**: "
-                     "P25=" (format-number (get percentiles 25))
-                     ", P50=" (format-number (get percentiles 50))
-                     ", P75=" (format-number (get percentiles 75))
-                     ", P90=" (format-number (get percentiles 90))))
-        iqr-str (when quartiles
-                  (str "**IQR**: " (format-number (:iqr quartiles))
-                       " (Q1=" (format-number (:q1 quartiles))
-                       " to Q3=" (format-number (:q3 quartiles)) ")"))
+        p-str     (when (seq percentiles)
+                    (str "**Percentiles**: "
+                         "P25=" (format-number (get percentiles 25))
+                         ", P50=" (format-number (get percentiles 50))
+                         ", P75=" (format-number (get percentiles 75))
+                         ", P90=" (format-number (get percentiles 90))))
+        iqr-str   (when quartiles
+                    (str "**IQR**: " (format-number (:iqr quartiles))
+                         " (Q1=" (format-number (:q1 quartiles))
+                         " to Q3=" (format-number (:q3 quartiles)) ")"))
         shape-str (when skewness
                     (let [k-desc (when kurtosis (kurtosis-description kurtosis))]
                       (str "**Distribution Shape**: " (skewness-description skewness)
                            (when k-desc (str ", " k-desc)))))
-        sections [(str "## Series: " series-name)
-                  (when x_name (str "**X-axis**: " x_name))
-                  (when y_name (str "**Y-axis**: " y_name))
-                  (str "**Data Points**: " data_points)
-                  (render-data-characteristics-note series-stats)
-                  (when summary
-                    (str "**Value Range**: " (format-number (:min summary))
-                         " to " (format-number (:max summary))
-                         " (median: " (format-number (:median summary)) ")"))
-                  p-str iqr-str shape-str
-                  (render-histogram-bin-data bin_data)]]
+        sections  [(str "## Series: " series-name)
+                   (when x_name (str "**X-axis**: " x_name))
+                   (when y_name (str "**Y-axis**: " y_name))
+                   (str "**Data Points**: " data_points)
+                   (render-data-characteristics-note series-stats)
+                   (when summary
+                     (str "**Value Range**: " (format-number (:min summary))
+                          " to " (format-number (:max summary))
+                          " (median: " (format-number (:median summary)) ")"))
+                   p-str iqr-str shape-str
+                   (render-histogram-bin-data bin_data)]]
     (str/join "\n" (remove nil? sections))))
 
 (defn generate-histogram-representation
   "Generate markdown representation for histogram stats."
   [{:keys [title display-type stats timeline-events]}]
   (let [{:keys [series_count series limits]} stats
-        header (str "# Chart Analysis\n"
-                    (when title (str "## Chart: " title "\n"))
-                    "**Type**: Histogram" (when display-type (str " (" display-type ")")) "\n"
-                    "**Series Count**: " series_count)
-        limits-note (when limits (render-limits-note limits))
+        header          (str "# Chart Analysis\n"
+                             (when title (str "## Chart: " title "\n"))
+                             "**Type**: Histogram" (when display-type (str " (" display-type ")")) "\n"
+                             "**Series Count**: " series_count)
+        limits-note     (when limits (render-limits-note limits))
         series-sections (str/join "\n\n"
                                   (for [[series-name s] series]
                                     (render-histogram-series series-name s)))
-        events-section (render-timeline-events timeline-events)]
+        events-section  (render-timeline-events timeline-events)]
     (str/join "\n\n"
               (remove str/blank? [header limits-note series-sections events-section]))))
 

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/repr.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/repr.clj
@@ -29,7 +29,8 @@
          "- Current week: Week " (week-of-year now) " of " (.getYear now) "\n"
          "- Current month: " month-name " (day " (.getDayOfMonth now) ")\n"
          "- Current quarter: Q" (quarter-of-year now) " " (.getYear now) "\n"
-         "Take this into account when analyzing recent data points.")))
+         "Take this into account when analyzing recent data points.\n"
+         "If the latest data point falls within the current week, month, or quarter, it may represent an incomplete period and should be interpreted accordingly.")))
 
 ;;; ------------------------------------------------- Formatting -----------------------------------------------------
 
@@ -82,6 +83,39 @@
     :high "high"
     :extreme "extreme"
     (name level)))
+
+;;; ----------------------------------------- Data Characteristics ---------------------------------------------------
+
+(defn- compute-data-characteristics
+  "Derive data quality flags from pre-computed series stats.
+
+  Uses fields already present in the stats map so no raw values are needed:
+  - :small_counts  max y-value < 20 (percentage changes may be exaggerated)
+  - :high_variance CoV > 0.5        (fluctuations may be normal noise)
+  - :sparse_data   < 10 data points"
+  [{:keys [data_points category_count summary y_summary]}]
+  (let [n     (or data_points category_count 0)
+        s     (or y_summary summary)
+        max-v (some-> s :max)
+        cov   (let [mean-v (some-> s :mean)
+                    std-v  (some-> s :std_dev)]
+                (if (and mean-v std-v (not (zero? mean-v)))
+                  (/ std-v (Math/abs (double mean-v)))
+                  0.0))]
+    {:small_counts  (boolean (and max-v (< max-v 20)))
+     :high_variance (> cov 0.5)
+     :sparse_data   (< n 10)}))
+
+(defn- render-data-characteristics-note
+  "Render a **Note**: line when any data quality warning applies."
+  [series-stats]
+  (let [{:keys [small_counts high_variance sparse_data]} (compute-data-characteristics series-stats)
+        warnings (cond-> []
+                   small_counts  (conj "small values (percentage changes may be exaggerated)")
+                   high_variance (conj "high variance (fluctuations may be normal noise)")
+                   sparse_data   (conj "limited data points"))]
+    (when (seq warnings)
+      (str "**Note**: " (str/join ", " warnings) ". Cross-reference with the chart visual."))))
 
 ;;; ------------------------------------------ Series Representation -------------------------------------------------
 
@@ -201,9 +235,13 @@
 
 (defn- render-categorical-series
   "Render stats for a single categorical series."
-  [series-name {:keys [summary category_count top_categories bottom_categories outliers]}]
+  [series-name {:keys [x_name y_name summary category_count
+                       top_categories bottom_categories outliers] :as series-stats}]
   (let [sections [(str "## Series: " series-name)
+                  (when x_name (str "**X-axis**: " x_name))
+                  (when y_name (str "**Y-axis**: " y_name))
                   (str "**Categories**: " category_count)
+                  (render-data-characteristics-note series-stats)
                   (when summary
                     (str "**Value Range**: " (format-number (:min summary))
                          " to " (format-number (:max summary))
@@ -217,11 +255,11 @@
 
 (defn generate-categorical-representation
   "Generate markdown representation for categorical (bar, pie, funnel, etc.) stats."
-  [{:keys [title stats timeline-events]}]
+  [{:keys [title display-type stats timeline-events]}]
   (let [{:keys [series_count series correlations]} stats
         header (str "# Chart Analysis\n"
                     (when title (str "## Chart: " title "\n"))
-                    "**Type**: Categorical\n"
+                    "**Type**: Categorical" (when display-type (str " (" display-type ")")) "\n"
                     "**Series Count**: " series_count)
         series-sections (str/join "\n\n"
                                   (for [[series-name s] series]
@@ -237,11 +275,37 @@
 (defn- correlation-label [{:keys [strength direction]}]
   (str (name strength) " " (name direction)))
 
+(defn- render-scatter-sample-data
+  "Render sampled points as 'x: y | x: y | ...'."
+  [sampled-points]
+  (when (seq sampled-points)
+    (let [n         (count sampled-points)
+          formatted (str/join " | " (map (fn [[x y]] (str (format-number x) ": " (format-number y)))
+                                         sampled-points))]
+      (str "**Sample Data** (" n " points):\n" formatted))))
+
+(defn- render-scatter-outliers
+  "Render outliers as 'x=..., y=...' (each outlier map has :date=x-value, :value=y-value)."
+  [outliers]
+  (when (seq outliers)
+    (let [total (count outliers)
+          shown (take 5 outliers)
+          lines (map (fn [{:keys [date value]}]
+                       (str "- x=" (format-number date) ", y=" (format-number value)))
+                     shown)
+          more  (when (> total 5) (str "... and " (- total 5) " more"))]
+      (str "**Outliers** (" total " total, showing up to 5):\n"
+           (str/join "\n" (remove nil? (concat lines [more])))))))
+
 (defn- render-scatter-series
   "Render stats for a single scatter series."
-  [series-name {:keys [x_summary y_summary data_points correlation regression]}]
+  [series-name {:keys [x_name y_name x_summary y_summary data_points
+                       correlation regression sampled_points outliers] :as series-stats}]
   (let [sections [(str "## Series: " series-name)
                   (str "**Data Points**: " data_points)
+                  (when x_name (str "**X-axis**: " x_name))
+                  (when y_name (str "**Y-axis**: " y_name))
+                  (render-data-characteristics-note series-stats)
                   (when x_summary
                     (str "**X-axis Range**: " (format-number (:min x_summary))
                          " to " (format-number (:max x_summary))))
@@ -254,16 +318,18 @@
                   (when regression
                     (str "**Trend Line**: y = "
                          (format "%.3f" (double (:slope regression))) "x + "
-                         (format "%.3f" (double (:intercept regression)))))]]
+                         (format "%.3f" (double (:intercept regression)))))
+                  (render-scatter-sample-data sampled_points)
+                  (render-scatter-outliers outliers)]]
     (str/join "\n" (remove nil? sections))))
 
 (defn generate-scatter-representation
   "Generate markdown representation for scatter plot stats."
-  [{:keys [title stats timeline-events]}]
+  [{:keys [title display-type stats timeline-events]}]
   (let [{:keys [series_count series]} stats
         header (str "# Chart Analysis\n"
                     (when title (str "## Chart: " title "\n"))
-                    "**Type**: Scatter\n"
+                    "**Type**: Scatter" (when display-type (str " (" display-type ")")) "\n"
                     "**Series Count**: " series_count)
         series-sections (str/join "\n\n"
                                   (for [[series-name s] series]
@@ -286,9 +352,18 @@
     (< kurtosis -1) "light tails (fewer extreme values than normal)"
     :else           nil))
 
+(defn- render-histogram-bin-data
+  "Render bin data as 'x: y | x: y | ...'."
+  [bin_data]
+  (when (seq bin_data)
+    (let [n         (count bin_data)
+          formatted (str/join " | " (map (fn [[x y]] (str (format-number x) ": " (format-number y)))
+                                         bin_data))]
+      (str "**Bin Data** (" n " bins):\n" formatted))))
+
 (defn- render-histogram-series
   "Render stats for a single histogram series."
-  [series-name {:keys [summary data_points distribution]}]
+  [series-name {:keys [x_name y_name summary data_points bin_data distribution] :as series-stats}]
   (let [{:keys [skewness kurtosis percentiles quartiles]} distribution
         p-str (when (seq percentiles)
                 (str "**Percentiles**: "
@@ -305,21 +380,25 @@
                       (str "**Distribution Shape**: " (skewness-description skewness)
                            (when k-desc (str ", " k-desc)))))
         sections [(str "## Series: " series-name)
+                  (when x_name (str "**X-axis**: " x_name))
+                  (when y_name (str "**Y-axis**: " y_name))
                   (str "**Data Points**: " data_points)
+                  (render-data-characteristics-note series-stats)
                   (when summary
                     (str "**Value Range**: " (format-number (:min summary))
                          " to " (format-number (:max summary))
                          " (median: " (format-number (:median summary)) ")"))
-                  p-str iqr-str shape-str]]
+                  p-str iqr-str shape-str
+                  (render-histogram-bin-data bin_data)]]
     (str/join "\n" (remove nil? sections))))
 
 (defn generate-histogram-representation
   "Generate markdown representation for histogram stats."
-  [{:keys [title stats timeline-events]}]
+  [{:keys [title display-type stats timeline-events]}]
   (let [{:keys [series_count series]} stats
         header (str "# Chart Analysis\n"
                     (when title (str "## Chart: " title "\n"))
-                    "**Type**: Histogram\n"
+                    "**Type**: Histogram" (when display-type (str " (" display-type ")")) "\n"
                     "**Series Count**: " series_count)
         series-sections (str/join "\n\n"
                                   (for [[series-name s] series]
@@ -332,11 +411,11 @@
 
 (defn generate-time-series-representation
   "Generate comprehensive markdown representation for time series stats."
-  [{:keys [title stats timeline-events]}]
+  [{:keys [title display-type stats timeline-events]}]
   (let [{:keys [series_count series correlations]} stats
         header (str "# Chart Analysis\n"
                     (when title (str "## Chart: " title "\n"))
-                    "**Type**: Time Series\n"
+                    "**Type**: Time Series" (when display-type (str " (" display-type ")")) "\n"
                     "**Series Count**: " series_count)
         temporal-context (generate-temporal-context)
         series-sections (str/join "\n\n"

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/repr.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/repr.clj
@@ -240,6 +240,7 @@
   (let [sections [(str "## Series: " series-name)
                   (when x_name (str "**X-axis**: " x_name))
                   (when y_name (str "**Y-axis**: " y_name))
+                  (str "**Data Points**: " category_count)
                   (str "**Categories**: " category_count)
                   (render-data-characteristics-note series-stats)
                   (when summary

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/repr.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/repr.clj
@@ -267,8 +267,8 @@
   [categories]
   (str/join "\n"
             (for [{:keys [name value percentage]} categories]
-              (str "  - " name ": " (format-number value)
-                   " (" (format "%.1f" (double percentage)) "%)"))))
+              (cond-> (str "  - " name ": " (format-number value))
+                percentage (str " (" (format "%.1f" (double percentage)) "%)")))))
 
 (defn- render-categorical-series
   "Render stats for a single categorical series."

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/repr.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/repr.clj
@@ -17,7 +17,7 @@
 (defn- quarter-of-year [^LocalDate date]
   (inc (quot (dec (.getMonthValue date)) 3)))
 
-(defn generate-temporal-context
+(defn- generate-temporal-context
   "Generate temporal context string for the current date.
   Helps the LLM understand recency of data points."
   []
@@ -271,7 +271,7 @@
                   (render-outliers outliers)]]
     (str/join "\n" (remove nil? sections))))
 
-(defn generate-categorical-representation
+(defn- generate-categorical-representation
   "Generate markdown representation for categorical (bar, pie, funnel, etc.) stats."
   [{:keys [title display-type stats timeline-events]}]
   (let [{:keys [series_count series correlations limits]} stats
@@ -343,7 +343,7 @@
                   (render-scatter-outliers outliers)]]
     (str/join "\n" (remove nil? sections))))
 
-(defn generate-scatter-representation
+(defn- generate-scatter-representation
   "Generate markdown representation for scatter plot stats."
   [{:keys [title display-type stats timeline-events]}]
   (let [{:keys [series_count series limits]} stats
@@ -413,7 +413,7 @@
                    (render-histogram-bin-data bin_data)]]
     (str/join "\n" (remove nil? sections))))
 
-(defn generate-histogram-representation
+(defn- generate-histogram-representation
   "Generate markdown representation for histogram stats."
   [{:keys [title display-type stats timeline-events]}]
   (let [{:keys [series_count series limits]} stats
@@ -431,7 +431,7 @@
 
 ;;; ----------------------------------------- Main Representation ----------------------------------------------------
 
-(defn generate-time-series-representation
+(defn- generate-time-series-representation
   "Generate comprehensive markdown representation for time series stats."
   [{:keys [title display-type stats timeline-events]}]
   (let [{:keys [series_count series correlations limits]} stats

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/repr.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/repr.clj
@@ -272,6 +272,62 @@
     (str/join "\n\n"
               (remove str/blank? [header series-sections events-section]))))
 
+;;; ----------------------------------------- Histogram Representation -----------------------------------------------
+
+(defn- skewness-description [skewness]
+  (cond
+    (> skewness 0.5)  "right-skewed (tail extends toward higher values)"
+    (< skewness -0.5) "left-skewed (tail extends toward lower values)"
+    :else             "approximately symmetric"))
+
+(defn- kurtosis-description [kurtosis]
+  (cond
+    (> kurtosis 1)  "heavy tails (more extreme values than normal)"
+    (< kurtosis -1) "light tails (fewer extreme values than normal)"
+    :else           nil))
+
+(defn- render-histogram-series
+  "Render stats for a single histogram series."
+  [series-name {:keys [summary data_points distribution]}]
+  (let [{:keys [skewness kurtosis percentiles quartiles]} distribution
+        p-str (when (seq percentiles)
+                (str "**Percentiles**: "
+                     "P25=" (format-number (get percentiles 25))
+                     ", P50=" (format-number (get percentiles 50))
+                     ", P75=" (format-number (get percentiles 75))
+                     ", P90=" (format-number (get percentiles 90))))
+        iqr-str (when quartiles
+                  (str "**IQR**: " (format-number (:iqr quartiles))
+                       " (Q1=" (format-number (:q1 quartiles))
+                       " to Q3=" (format-number (:q3 quartiles)) ")"))
+        shape-str (when skewness
+                    (let [k-desc (when kurtosis (kurtosis-description kurtosis))]
+                      (str "**Distribution Shape**: " (skewness-description skewness)
+                           (when k-desc (str ", " k-desc)))))
+        sections [(str "## Series: " series-name)
+                  (str "**Data Points**: " data_points)
+                  (when summary
+                    (str "**Value Range**: " (format-number (:min summary))
+                         " to " (format-number (:max summary))
+                         " (median: " (format-number (:median summary)) ")"))
+                  p-str iqr-str shape-str]]
+    (str/join "\n" (remove nil? sections))))
+
+(defn generate-histogram-representation
+  "Generate markdown representation for histogram stats."
+  [{:keys [title stats timeline-events]}]
+  (let [{:keys [series_count series]} stats
+        header (str "# Chart Analysis\n"
+                    (when title (str "## Chart: " title "\n"))
+                    "**Type**: Histogram\n"
+                    "**Series Count**: " series_count)
+        series-sections (str/join "\n\n"
+                                  (for [[series-name s] series]
+                                    (render-histogram-series series-name s)))
+        events-section (render-timeline-events timeline-events)]
+    (str/join "\n\n"
+              (remove str/blank? [header series-sections events-section]))))
+
 ;;; ----------------------------------------- Main Representation ----------------------------------------------------
 
 (defn generate-time-series-representation
@@ -304,6 +360,7 @@
     :time-series  (generate-time-series-representation context)
     :categorical  (generate-categorical-representation context)
     :scatter      (generate-scatter-representation context)
+    :histogram    (generate-histogram-representation context)
     (str "# Chart Analysis\n"
          "**Type**: " (name (:chart_type stats)) "\n"
          "Statistics computation for this chart type is not yet implemented.")))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/repr.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/repr.clj
@@ -237,15 +237,20 @@
 
 ;;; ----------------------------------------- Correlation Representation ---------------------------------------------
 
+(defn- correlation-label [{:keys [strength direction]}]
+  (if (= :none strength)
+    "no correlation"
+    (str (name strength) " " (name direction))))
+
 (defn- render-correlations
   "Render cross-series correlations."
   [correlations]
   (when (seq correlations)
     (str "## Cross-Series Correlations\n"
          (str/join "\n"
-                   (for [{:keys [series_a series_b coefficient strength direction]} correlations]
+                   (for [{:keys [series_a series_b coefficient] :as corr} correlations]
                      (str "- " series_a " vs " series_b ": "
-                          (name strength) " " (name direction)
+                          (correlation-label corr)
                           " (r=" (format "%.3f" (double coefficient)) ")"))))))
 
 ;;; ----------------------------------------- Timeline Events --------------------------------------------------------
@@ -292,9 +297,6 @@
     (str/join "\n" (remove nil? sections))))
 
 ;;; ------------------------------------------ Scatter Representation ------------------------------------------------
-
-(defn- correlation-label [{:keys [strength direction]}]
-  (str (name strength) " " (name direction)))
 
 (defn- render-scatter-outliers
   "Render outliers as 'x=..., y=...'"

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/repr.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/repr.clj
@@ -379,7 +379,7 @@
   "Render bin data as 'x: y | x: y | ...'."
   [bin_data]
   (when (seq bin_data)
-    (str "**Bin Data** (" (count bin_data) " bins):\n"
+    (str "**Sample Data** (" (count bin_data) " bins):\n"
          (str/join " | " (map (fn [[x y]]
                                 (str (format-number x) ": " (format-number y)))
                               bin_data)))))
@@ -407,10 +407,13 @@
                    (when y_name (str "**Y-axis**: " y_name))
                    (str "**Data Points**: " data_points)
                    (render-data-characteristics-note series-stats)
+                   (when (seq bin_data)
+                     (let [xs (mapv first bin_data)]
+                       (str "**X-axis range**: " (format-number (reduce min xs))
+                            " to " (format-number (reduce max xs)))))
                    (when summary
-                     (str "**Value Range**: " (format-number (:min summary))
-                          " to " (format-number (:max summary))
-                          " (median: " (format-number (:median summary)) ")"))
+                     (str "**Y-axis range**: " (format-number (:min summary))
+                          " to " (format-number (:max summary))))
                    p-str iqr-str shape-str
                    (render-histogram-bin-data bin_data)]]
     (str/join "\n" (remove nil? sections))))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/repr.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/repr.clj
@@ -115,7 +115,7 @@
                    high_variance (conj "high variance (fluctuations may be normal noise)")
                    sparse_data   (conj "limited data points"))]
     (when (seq warnings)
-      (str "**Note**: " (str/join ", " warnings) ". Cross-reference with the chart visual."))))
+      (str "**Note**: " (str/join ", " warnings) "."))))
 
 ;;; ------------------------------------------ Series Representation -------------------------------------------------
 

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/repr.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/repr.clj
@@ -371,7 +371,7 @@
                    (render-data-characteristics-note series-stats)
                    (when (seq bin_data)
                      (let [xs (mapv first bin_data)]
-                       (render-axis-range "X-axis" {:min (reduce min xs) :max (reduce max xs)})))
+                       (render-axis-range "X-axis" {:min (apply min xs) :max (apply max xs)})))
                    (render-axis-range "Y-axis" summary)
                    p-str iqr-str shape-str
                    (render-sample-data bin_data)]]

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/repr.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/repr.clj
@@ -232,6 +232,46 @@
               (remove str/blank?
                       [header series-sections correlation-section events-section]))))
 
+;;; ------------------------------------------ Scatter Representation ------------------------------------------------
+
+(defn- correlation-label [{:keys [strength direction]}]
+  (str (name strength) " " (name direction)))
+
+(defn- render-scatter-series
+  "Render stats for a single scatter series."
+  [series-name {:keys [x_summary y_summary data_points correlation regression]}]
+  (let [sections [(str "## Series: " series-name)
+                  (str "**Data Points**: " data_points)
+                  (when x_summary
+                    (str "**X-axis Range**: " (format-number (:min x_summary))
+                         " to " (format-number (:max x_summary))))
+                  (when y_summary
+                    (str "**Y-axis Range**: " (format-number (:min y_summary))
+                         " to " (format-number (:max y_summary))))
+                  (when correlation
+                    (str "**Relationship**: " (correlation-label correlation)
+                         " (r = " (format "%.2f" (double (:coefficient correlation))) ")"))
+                  (when regression
+                    (str "**Trend Line**: y = "
+                         (format "%.3f" (double (:slope regression))) "x + "
+                         (format "%.3f" (double (:intercept regression)))))]]
+    (str/join "\n" (remove nil? sections))))
+
+(defn generate-scatter-representation
+  "Generate markdown representation for scatter plot stats."
+  [{:keys [title stats timeline-events]}]
+  (let [{:keys [series_count series]} stats
+        header (str "# Chart Analysis\n"
+                    (when title (str "## Chart: " title "\n"))
+                    "**Type**: Scatter\n"
+                    "**Series Count**: " series_count)
+        series-sections (str/join "\n\n"
+                                  (for [[series-name s] series]
+                                    (render-scatter-series series-name s)))
+        events-section (render-timeline-events timeline-events)]
+    (str/join "\n\n"
+              (remove str/blank? [header series-sections events-section]))))
+
 ;;; ----------------------------------------- Main Representation ----------------------------------------------------
 
 (defn generate-time-series-representation
@@ -263,6 +303,7 @@
   (case (:chart_type stats)
     :time-series  (generate-time-series-representation context)
     :categorical  (generate-categorical-representation context)
+    :scatter      (generate-scatter-representation context)
     (str "# Chart Analysis\n"
          "**Type**: " (name (:chart_type stats)) "\n"
          "Statistics computation for this chart type is not yet implemented.")))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/repr.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/repr.clj
@@ -168,8 +168,8 @@
   (if (seq outliers)
     (str "**Outliers**: " (count outliers) " detected\n"
          (str/join "\n"
-                   (for [{:keys [date value modified_z_score]} outliers]
-                     (str "  - " (format-date date) ": " (format-number value)
+                   (for [{:keys [label value modified_z_score]} outliers]
+                     (str "  - " (format-date label) ": " (format-number value)
                           " (z-score: " (format "%.2f" (double modified_z_score)) ")"))))
     "**Outliers**: None detected"))
 
@@ -311,8 +311,8 @@
   (when (seq outliers)
     (let [total (count outliers)
           shown (take 5 outliers)
-          lines (map (fn [{:keys [date value]}]
-                       (str "- x=" (format-number date) ", y=" (format-number value)))
+          lines (map (fn [{:keys [label value]}]
+                       (str "- x=" (format-number label) ", y=" (format-number value)))
                      shown)
           more  (when (> total 5)
                   (str "... and " (- total 5) " more"))]

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/repr.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/repr.clj
@@ -1,7 +1,9 @@
 (ns metabase-enterprise.metabot-v3.stats.repr
   "LLM-friendly text representation generator for chart statistics."
   (:require
-   [clojure.string :as str])
+   [clojure.string :as str]
+   [metabase-enterprise.metabot-v3.stats.types :as stats.types]
+   [metabase.util.malli :as mu])
   (:import
    (java.time LocalDate LocalDateTime ZonedDateTime)
    (java.time.format DateTimeFormatter TextStyle)
@@ -455,10 +457,10 @@
                        correlation-section
                        events-section]))))
 
-(defn generate-representation
+(mu/defn generate-representation :- :string
   "Generate markdown representation for chart statistics.
   Dispatches based on chart type."
-  [{:keys [stats] :as context}]
+  [{:keys [stats] :as context} :- ::stats.types/generate-repr-context]
   (case (:chart_type stats)
     :time-series  (generate-time-series-representation context)
     :categorical  (generate-categorical-representation context)

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/repr.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/repr.clj
@@ -277,12 +277,12 @@
 
 (defn- render-categorical-series
   "Render stats for a single categorical series."
-  [series-name {:keys [x_name y_name summary category_count
+  [series-name {:keys [x_name y_name summary data_points category_count
                        top_categories bottom_categories outliers] :as series-stats}]
   (let [sections [(str "## Series: " series-name)
                   (when x_name (str "**X-axis**: " x_name))
                   (when y_name (str "**Y-axis**: " y_name))
-                  (str "**Data Points**: " category_count)
+                  (str "**Data Points**: " data_points)
                   (str "**Categories**: " category_count)
                   (render-data-characteristics-note series-stats)
                   (when summary

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/scatter.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/scatter.clj
@@ -19,7 +19,7 @@
     (vec coll)
     (vec (take max-points (shuffle coll)))))
 
-(defn compute-series-stats
+(defn- compute-series-stats
   "Compute stats for a single scatter series."
   [x-values y-values]
   (let [valid-pairs (filter (fn [[x y]] (and (some? x) (some? y)))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/scatter.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/scatter.clj
@@ -36,7 +36,7 @@
             x-summary        (stats.u/compute-summary xs)
             y-summary        (stats.u/compute-summary ys)
             raw-coef         (dfn/pearsons-correlation xs ys)
-            coef             (when-not (Double/isNaN (double raw-coef)) raw-coef)
+            coef             (stats.u/nan->nil raw-coef)
             correlation      (when coef
                                {:coefficient coef
                                 :strength    (stats.u/correlation-strength coef)

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/scatter.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/scatter.clj
@@ -1,5 +1,5 @@
 (ns metabase-enterprise.metabot-v3.stats.scatter
-  "Scatter plot statistics computation."
+  "Scatter plot statistics."
   (:require
    [metabase-enterprise.metabot-v3.stats.outliers :as outliers]
    [metabase-enterprise.metabot-v3.stats.util :as stats.u]
@@ -20,8 +20,7 @@
     (vec (take max-points (shuffle coll)))))
 
 (defn compute-series-stats
-  "Compute stats for a single scatter series.
-  x-values and y-values are parallel sequences of numbers."
+  "Compute stats for a single scatter series."
   [x-values y-values]
   (let [valid-pairs (filter (fn [[x y]] (and (some? x) (some? y)))
                             (map vector x-values y-values))
@@ -30,26 +29,26 @@
       {:x_summary   nil
        :y_summary   nil
        :data_points n}
-      (let [xs        (mapv (comp double first) valid-pairs)
-            ys        (mapv (comp double second) valid-pairs)
-            x-summary (stats.u/compute-summary xs)
-            y-summary (stats.u/compute-summary ys)
-            raw-coef  (dfn/pearsons-correlation xs ys)
-            coef      (when-not (Double/isNaN (double raw-coef)) raw-coef)
-            correlation (when coef
-                          {:coefficient coef
-                           :strength    (stats.u/correlation-strength coef)
-                           :direction   (if (neg? coef) :negative :positive)})
-            regression  (when (>= n min-regression-points)
-                          (try
-                            (let [regressor (dfn/linear-regressor xs ys)
-                                  slope     (:slope (meta regressor))
-                                  intercept (- (dfn/mean ys) (* slope (dfn/mean xs)))
-                                  r-squared (* (double raw-coef) (double raw-coef))]
-                              {:slope     slope
-                               :intercept intercept
-                               :r_squared r-squared})
-                            (catch Exception _ nil)))
+      (let [xs               (mapv (comp double first) valid-pairs)
+            ys               (mapv (comp double second) valid-pairs)
+            x-summary        (stats.u/compute-summary xs)
+            y-summary        (stats.u/compute-summary ys)
+            raw-coef         (dfn/pearsons-correlation xs ys)
+            coef             (when-not (Double/isNaN (double raw-coef)) raw-coef)
+            correlation      (when coef
+                               {:coefficient coef
+                                :strength    (stats.u/correlation-strength coef)
+                                :direction   (if (neg? coef) :negative :positive)})
+            regression       (when (>= n min-regression-points)
+                               (try
+                                 (let [regressor (dfn/linear-regressor xs ys)
+                                       slope     (:slope (meta regressor))
+                                       intercept (- (dfn/mean ys) (* slope (dfn/mean xs)))
+                                       r-squared (* (double raw-coef) (double raw-coef))]
+                                   {:slope     slope
+                                    :intercept intercept
+                                    :r_squared r-squared})
+                                 (catch Exception _ nil)))
             ;; Pass numeric xs as "dates" so each outlier map carries the x-value in :date
             scatter-outliers (when (>= n min-outlier-points)
                                (outliers/find-outliers ys xs))
@@ -63,8 +62,7 @@
           (seq scatter-outliers) (assoc :outliers scatter-outliers))))))
 
 (defn compute-scatter-stats
-  "Compute scatter stats for all series in a chart.
-  series-data: map of series-name -> {:x_values [...] :y_values [...] :x {:name ...} :y {:name ...}}"
+  "Compute scatter stats for all series in a chart."
   [series-data _opts]
   (let [series-stats (stats.u/compute-series-with-labels series-data compute-series-stats)]
     (stats.u/make-chart-result :scatter series-data series-stats nil)))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/scatter.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/scatter.clj
@@ -1,0 +1,78 @@
+(ns metabase-enterprise.metabot-v3.stats.scatter
+  "Scatter plot statistics computation."
+  (:require
+   [tech.v3.datatype.functional :as dfn]))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private min-regression-points 3)
+(def ^:private min-correlation-points 2)
+
+(defn- correlation-strength [coef]
+  (let [abs-coef (Math/abs (double coef))]
+    (cond
+      (>= abs-coef 0.7) :strong
+      (>= abs-coef 0.3) :moderate
+      :else :weak)))
+
+(defn compute-series-stats
+  "Compute stats for a single scatter series.
+  x-values and y-values are parallel sequences of numbers."
+  [x-values y-values]
+  (let [valid-pairs (filter (fn [[x y]] (and (some? x) (some? y)))
+                            (map vector x-values y-values))
+        n           (count valid-pairs)]
+    (if (< n min-correlation-points)
+      {:x_summary   nil
+       :y_summary   nil
+       :data_points n}
+      (let [xs        (mapv (comp double first) valid-pairs)
+            ys        (mapv (comp double second) valid-pairs)
+            x-min     (dfn/reduce-min xs)
+            x-max     (dfn/reduce-max xs)
+            y-min     (dfn/reduce-min ys)
+            y-max     (dfn/reduce-max ys)
+            x-summary {:min     x-min
+                       :max     x-max
+                       :mean    (dfn/mean xs)
+                       :median  (dfn/median xs)
+                       :std_dev (dfn/standard-deviation xs)
+                       :range   (- x-max x-min)}
+            y-summary {:min     y-min
+                       :max     y-max
+                       :mean    (dfn/mean ys)
+                       :median  (dfn/median ys)
+                       :std_dev (dfn/standard-deviation ys)
+                       :range   (- y-max y-min)}
+            raw-coef  (dfn/pearsons-correlation xs ys)
+            coef      (when-not (Double/isNaN (double raw-coef)) raw-coef)
+            correlation (when coef
+                          {:coefficient coef
+                           :strength    (correlation-strength coef)
+                           :direction   (if (neg? coef) :negative :positive)})
+            regression  (when (>= n min-regression-points)
+                          (try
+                            (let [regressor (dfn/linear-regressor xs ys)
+                                  slope     (:slope (meta regressor))
+                                  intercept (- (dfn/mean ys) (* slope (dfn/mean xs)))
+                                  r-squared (* (double raw-coef) (double raw-coef))]
+                              {:slope     slope
+                               :intercept intercept
+                               :r_squared r-squared})
+                            (catch Exception _ nil)))]
+        (cond-> {:x_summary   x-summary
+                 :y_summary   y-summary
+                 :data_points n}
+          correlation (assoc :correlation correlation)
+          regression  (assoc :regression regression))))))
+
+(defn compute-scatter-stats
+  "Compute scatter stats for all series in a chart.
+  series-data: map of series-name -> {:x_values [...] :y_values [...]}"
+  [series-data _opts]
+  (let [series-stats (into {}
+                           (for [[series-name {:keys [x_values y_values]}] series-data]
+                             [series-name (compute-series-stats x_values y_values)]))]
+    {:chart_type   :scatter
+     :series_count (count series-data)
+     :series       series-stats}))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/scatter.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/scatter.clj
@@ -51,7 +51,6 @@
                                     :intercept intercept
                                     :r_squared r-squared})
                                  (catch Exception _ nil)))
-            ;; Pass numeric xs as "dates" so each outlier map carries the x-value in :date
             scatter-outliers (when (>= n min-outlier-points)
                                (outliers/find-outliers ys xs))
             sampled-points   (sample-points (mapv vector xs ys) max-sample-points)]

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/scatter.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/scatter.clj
@@ -2,6 +2,7 @@
   "Scatter plot statistics computation."
   (:require
    [metabase-enterprise.metabot-v3.stats.outliers :as outliers]
+   [metabase-enterprise.metabot-v3.stats.util :as stats.u]
    [tech.v3.datatype.functional :as dfn]))
 
 (set! *warn-on-reflection* true)
@@ -18,13 +19,6 @@
     (vec coll)
     (vec (take max-points (shuffle coll)))))
 
-(defn- correlation-strength [coef]
-  (let [abs-coef (Math/abs (double coef))]
-    (cond
-      (>= abs-coef 0.7) :strong
-      (>= abs-coef 0.3) :moderate
-      :else :weak)))
-
 (defn compute-series-stats
   "Compute stats for a single scatter series.
   x-values and y-values are parallel sequences of numbers."
@@ -38,27 +32,13 @@
        :data_points n}
       (let [xs        (mapv (comp double first) valid-pairs)
             ys        (mapv (comp double second) valid-pairs)
-            x-min     (dfn/reduce-min xs)
-            x-max     (dfn/reduce-max xs)
-            y-min     (dfn/reduce-min ys)
-            y-max     (dfn/reduce-max ys)
-            x-summary {:min     x-min
-                       :max     x-max
-                       :mean    (dfn/mean xs)
-                       :median  (dfn/median xs)
-                       :std_dev (dfn/standard-deviation xs)
-                       :range   (- x-max x-min)}
-            y-summary {:min     y-min
-                       :max     y-max
-                       :mean    (dfn/mean ys)
-                       :median  (dfn/median ys)
-                       :std_dev (dfn/standard-deviation ys)
-                       :range   (- y-max y-min)}
+            x-summary (stats.u/compute-summary xs)
+            y-summary (stats.u/compute-summary ys)
             raw-coef  (dfn/pearsons-correlation xs ys)
             coef      (when-not (Double/isNaN (double raw-coef)) raw-coef)
             correlation (when coef
                           {:coefficient coef
-                           :strength    (correlation-strength coef)
+                           :strength    (stats.u/correlation-strength coef)
                            :direction   (if (neg? coef) :negative :positive)})
             regression  (when (>= n min-regression-points)
                           (try
@@ -86,11 +66,5 @@
   "Compute scatter stats for all series in a chart.
   series-data: map of series-name -> {:x_values [...] :y_values [...] :x {:name ...} :y {:name ...}}"
   [series-data _opts]
-  (let [series-stats (into {}
-                           (for [[series-name {:keys [x_values y_values x y]}] series-data]
-                             [series-name (-> (compute-series-stats x_values y_values)
-                                              (assoc :x_name (some-> x :name))
-                                              (assoc :y_name (some-> y :name)))]))]
-    {:chart_type   :scatter
-     :series_count (count series-data)
-     :series       series-stats}))
+  (let [series-stats (stats.u/compute-series-with-labels series-data compute-series-stats)]
+    (stats.u/make-chart-result :scatter series-data series-stats nil)))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/scatter.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/scatter.clj
@@ -2,7 +2,9 @@
   "Scatter plot statistics."
   (:require
    [metabase-enterprise.metabot-v3.stats.outliers :as outliers]
+   [metabase-enterprise.metabot-v3.stats.types :as stats.types]
    [metabase-enterprise.metabot-v3.stats.util :as stats.u]
+   [metabase.util.malli :as mu]
    [tech.v3.datatype.functional :as dfn]))
 
 (set! *warn-on-reflection* true)
@@ -61,8 +63,9 @@
           regression             (assoc :regression regression)
           (seq scatter-outliers) (assoc :outliers scatter-outliers))))))
 
-(defn compute-scatter-stats
+(mu/defn compute-scatter-stats :- ::stats.types/scatter-stats
   "Compute scatter stats for all series in a chart."
-  [series-data _opts]
+  [series-data :- [:map-of :string ::stats.types/series-config]
+   _opts       :- ::stats.types/options]
   (let [series-stats (stats.u/compute-series-with-labels series-data compute-series-stats)]
     (stats.u/make-chart-result :scatter series-data series-stats nil)))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/scatter.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/scatter.clj
@@ -1,12 +1,22 @@
 (ns metabase-enterprise.metabot-v3.stats.scatter
   "Scatter plot statistics computation."
   (:require
+   [metabase-enterprise.metabot-v3.stats.outliers :as outliers]
    [tech.v3.datatype.functional :as dfn]))
 
 (set! *warn-on-reflection* true)
 
 (def ^:private min-regression-points 3)
 (def ^:private min-correlation-points 2)
+(def ^:private min-outlier-points 5)
+(def ^:private max-sample-points 30)
+
+(defn- sample-points
+  "Randomly sample up to max-points items from a collection."
+  [coll max-points]
+  (if (<= (count coll) max-points)
+    (vec coll)
+    (vec (take max-points (shuffle coll)))))
 
 (defn- correlation-strength [coef]
   (let [abs-coef (Math/abs (double coef))]
@@ -59,20 +69,28 @@
                               {:slope     slope
                                :intercept intercept
                                :r_squared r-squared})
-                            (catch Exception _ nil)))]
-        (cond-> {:x_summary   x-summary
-                 :y_summary   y-summary
-                 :data_points n}
-          correlation (assoc :correlation correlation)
-          regression  (assoc :regression regression))))))
+                            (catch Exception _ nil)))
+            ;; Pass numeric xs as "dates" so each outlier map carries the x-value in :date
+            scatter-outliers (when (>= n min-outlier-points)
+                               (outliers/find-outliers ys xs))
+            sampled-points   (sample-points (mapv vector xs ys) max-sample-points)]
+        (cond-> {:x_summary      x-summary
+                 :y_summary      y-summary
+                 :data_points    n
+                 :sampled_points sampled-points}
+          correlation            (assoc :correlation correlation)
+          regression             (assoc :regression regression)
+          (seq scatter-outliers) (assoc :outliers scatter-outliers))))))
 
 (defn compute-scatter-stats
   "Compute scatter stats for all series in a chart.
-  series-data: map of series-name -> {:x_values [...] :y_values [...]}"
+  series-data: map of series-name -> {:x_values [...] :y_values [...] :x {:name ...} :y {:name ...}}"
   [series-data _opts]
   (let [series-stats (into {}
-                           (for [[series-name {:keys [x_values y_values]}] series-data]
-                             [series-name (compute-series-stats x_values y_values)]))]
+                           (for [[series-name {:keys [x_values y_values x y]}] series-data]
+                             [series-name (-> (compute-series-stats x_values y_values)
+                                              (assoc :x_name (some-> x :name))
+                                              (assoc :y_name (some-> y :name)))]))]
     {:chart_type   :scatter
      :series_count (count series-data)
      :series       series-stats}))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/scatter.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/scatter.clj
@@ -40,7 +40,7 @@
             correlation      (when coef
                                {:coefficient coef
                                 :strength    (stats.u/correlation-strength coef)
-                                :direction   (if (neg? coef) :negative :positive)})
+                                :direction   (stats.u/correlation-direction coef)})
             regression       (when (>= n min-regression-points)
                                (try
                                  (let [regressor (dfn/linear-regressor xs ys)

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/time_series.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/time_series.clj
@@ -6,24 +6,12 @@
   - Deep: volatility, patterns, significant changes, correlations"
   (:require
    [metabase-enterprise.metabot-v3.stats.outliers :as outliers]
+   [metabase-enterprise.metabot-v3.stats.util :as stats.u]
    [tech.v3.datatype.functional :as dfn]))
 
 (set! *warn-on-reflection* true)
 
 ;;; ------------------------------------------------ Basic Statistics ------------------------------------------------
-
-(defn compute-summary
-  "Compute basic statistical summary for a series of values.
-  Returns map with :min :max :mean :median :std_dev :range"
-  [values]
-  (let [min-val (dfn/reduce-min values)
-        max-val (dfn/reduce-max values)]
-    {:min min-val
-     :max max-val
-     :mean (dfn/mean values)
-     :median (dfn/median values)
-     :std_dev (dfn/standard-deviation values)
-     :range (- max-val min-val)}))
 
 (defn compute-time-range
   "Compute time range information from dates.
@@ -66,9 +54,7 @@
         start-val (first values-vec)
         end-val (last values-vec)
         mean-val (dfn/mean values)
-        change-pct (if (zero? start-val)
-                     0.0
-                     (* 100.0 (/ (- end-val start-val) (Math/abs (double start-val)))))]
+        change-pct (stats.u/percentage-change start-val end-val)]
     {:direction (slope-to-direction slope mean-val n)
      :overall_change_pct change-pct
      :start_value start-val
@@ -164,9 +150,7 @@
                       :let [from-val (nth values-vec (dec i))
                             to-val (nth values-vec i)
                             change-abs (- to-val from-val)
-                            change-pct (if (zero? from-val)
-                                         0.0
-                                         (* 100.0 (/ change-abs (Math/abs (double from-val)))))]]
+                            change-pct (stats.u/percentage-change from-val to-val)]]
                   {:from_date (nth dates-vec (dec i))
                    :to_date (nth dates-vec i)
                    :from_value from-val
@@ -189,70 +173,13 @@
       (let [from-val (nth values-vec (- n 2))
             to-val (nth values-vec (dec n))
             change-abs (- to-val from-val)
-            change-pct (if (zero? from-val)
-                         0.0
-                         (* 100.0 (/ change-abs (Math/abs (double from-val)))))]
+            change-pct (stats.u/percentage-change from-val to-val)]
         {:from_date (nth dates-vec (- n 2))
          :to_date (nth dates-vec (dec n))
          :from_value from-val
          :to_value to-val
          :change_abs change-abs
          :change_pct change-pct}))))
-
-;;; --------------------------------------------- Cross-Series Correlation -------------------------------------------
-
-(defn- correlation-strength
-  "Classify correlation coefficient into strength category."
-  [coef]
-  (let [abs-coef (Math/abs (double coef))]
-    (cond
-      (>= abs-coef 0.7) :strong
-      (>= abs-coef 0.4) :moderate
-      (>= abs-coef 0.2) :weak
-      :else :none)))
-
-(defn- align-series-on-x
-  "Align two series on common x-values using listwise deletion.
-  Returns [aligned-vals-a aligned-vals-b] containing only values at shared x positions."
-  [x-vals-a y-vals-a x-vals-b y-vals-b]
-  (let [b-lookup (zipmap x-vals-b y-vals-b)
-        common-pairs (for [[x y-a] (map vector x-vals-a y-vals-a)
-                           :let [y-b (get b-lookup x)]
-                           :when (some? y-b)]
-                       [y-a y-b])]
-    [(mapv first common-pairs)
-     (mapv second common-pairs)]))
-
-(def ^:private min-correlation-sample-size
-  "Minimum sample size required for meaningful correlation computation."
-  10)
-
-(defn compute-correlations
-  "Compute pairwise correlations between multiple series.
-  series-map is a map of series-name -> {:x_values [...] :y_values [...]}.
-  Aligns series on common x-values (listwise deletion) before computing correlation.
-  Skips pairs with fewer than 10 aligned data points.
-  Returns sequence of correlation maps."
-  [series-map]
-  (let [series-names (keys series-map)
-        pairs (for [a series-names
-                    b series-names
-                    :when (pos? (compare (str b) (str a)))]
-                [a b])]
-    (vec
-     (for [[name-a name-b] pairs
-           :let [{x-a :x_values y-a :y_values} (get series-map name-a)
-                 {x-b :x_values y-b :y_values} (get series-map name-b)
-                 [aligned-a aligned-b] (align-series-on-x x-a y-a x-b y-b)
-                 n (count aligned-a)]
-           :when (>= n min-correlation-sample-size)
-           :let [coef (dfn/pearsons-correlation aligned-a aligned-b)]]
-       {:series_a name-a
-        :series_b name-b
-        :coefficient coef
-        :strength (correlation-strength coef)
-        :direction (if (neg? coef) :negative :positive)
-        :aligned_sample_size n}))))
 
 ;;; ------------------------------------------------ Main Entry Point ------------------------------------------------
 
@@ -269,7 +196,7 @@
         outliers (if is-cumulative
                    (outliers/find-outliers-cumulative values dates)
                    (outliers/find-outliers values dates))
-        basic-stats {:summary (compute-summary values)
+        basic-stats {:summary (stats.u/compute-summary values)
                      :time_range (compute-time-range dates)
                      :data_points (count values)
                      :trend (compute-trend values)
@@ -291,15 +218,9 @@
     opts        - options map:
                   :deep? - if true, compute additional stats"
   [series-data opts]
-  (let [series-stats (into {}
-                           (for [[name {:keys [x_values y_values]}] series-data]
-                             [name (compute-series-stats y_values x_values opts)]))
-        correlation-series (if-let [max-k (:max-correlation-series opts)]
-                             (into {} (take max-k series-data))
-                             series-data)
-        correlations (when (and (:deep? opts) (> (count correlation-series) 1))
-                       (compute-correlations correlation-series))]
-    (cond-> {:chart_type :time-series
-             :series_count (count series-data)
-             :series series-stats}
-      correlations (assoc :correlations correlations))))
+  (let [series-stats (stats.u/compute-series-with-labels
+                      series-data
+                      (fn [x-vals y-vals]
+                        (compute-series-stats y-vals x-vals opts)))
+        correlations (stats.u/maybe-compute-correlations series-data opts)]
+    (stats.u/make-chart-result :time-series series-data series-stats correlations)))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/time_series.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/time_series.clj
@@ -6,7 +6,9 @@
   - Deep: volatility, patterns, significant changes, correlations"
   (:require
    [metabase-enterprise.metabot-v3.stats.outliers :as outliers]
+   [metabase-enterprise.metabot-v3.stats.types :as stats.types]
    [metabase-enterprise.metabot-v3.stats.util :as stats.u]
+   [metabase.util.malli :as mu]
    [tech.v3.datatype.functional :as dfn]))
 
 (set! *warn-on-reflection* true)
@@ -210,14 +212,15 @@
              :most_recent_change (compute-most-recent-change values dates))
       basic-stats)))
 
-(defn compute-time-series-stats
+(mu/defn compute-time-series-stats :- ::stats.types/time-series-stats
   "Compute complete time series statistics for a chart.
 
   Arguments:
     series-data - map of series-name -> {:x_values [...] :y_values [...]}
     opts        - options map:
                   :deep? - if true, compute additional stats"
-  [series-data opts]
+  [series-data :- [:map-of :string ::stats.types/series-config]
+   opts        :- ::stats.types/options]
   (let [series-stats (stats.u/compute-series-with-labels
                       series-data
                       (fn [x-vals y-vals]

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/time_series.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/time_series.clj
@@ -294,8 +294,11 @@
   (let [series-stats (into {}
                            (for [[name {:keys [x_values y_values]}] series-data]
                              [name (compute-series-stats y_values x_values opts)]))
-        correlations (when (and (:deep? opts) (> (count series-data) 1))
-                       (compute-correlations series-data))]
+        correlation-series (if-let [max-k (:max-correlation-series opts)]
+                             (into {} (take max-k series-data))
+                             series-data)
+        correlations (when (and (:deep? opts) (> (count correlation-series) 1))
+                       (compute-correlations correlation-series))]
     (cond-> {:chart_type :time-series
              :series_count (count series-data)
              :series series-stats}

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/time_series.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/time_series.clj
@@ -13,7 +13,7 @@
 
 ;;; ------------------------------------------------ Basic Statistics ------------------------------------------------
 
-(defn compute-time-range
+(defn- compute-time-range
   "Compute time range information from dates.
   Returns map with :start :end :span_description"
   [dates]
@@ -42,7 +42,7 @@
         (< pct-change -10) :decreasing
         :else :flat))))
 
-(defn compute-trend
+(defn- compute-trend
   "Compute trend summary using linear regression.
   Returns map with :direction :overall_change_pct :start_value :end_value"
   [values]
@@ -62,7 +62,7 @@
 
 ;;; --------------------------------------------- Cumulative Detection -----------------------------------------------
 
-(defn detect-cumulative?
+(defn- detect-cumulative?
   "Detect if data appears to be cumulative (monotonically increasing).
   Returns true if at least 95% of consecutive differences are non-negative."
   [values]
@@ -75,7 +75,7 @@
 
 ;;; ------------------------------------------------ Deep Statistics -------------------------------------------------
 
-(defn compute-volatility
+(defn- compute-volatility
   "Compute volatility metrics for time series.
   Returns map with :level :coefficient_of_variation :max_period_change_pct"
   [values]
@@ -127,7 +127,7 @@
                                 streaks)]
               (recur (inc i) direction i new-streaks))))))))
 
-(defn detect-patterns
+(defn- detect-patterns
   "Detect patterns like consecutive increases/decreases (5+ periods).
   Returns sequence of pattern insight maps."
   [values dates]
@@ -140,7 +140,7 @@
              :to_date (nth dates-vec end_idx)})
           streaks)))
 
-(defn find-significant-changes
+(defn- find-significant-changes
   "Find the top N most significant period-to-period changes.
   Returns sequence of significant change maps sorted by magnitude."
   [values dates n]
@@ -162,7 +162,7 @@
          (take n)
          vec)))
 
-(defn compute-most-recent-change
+(defn- compute-most-recent-change
   "Compute the most recent period-to-period change.
   Returns a significant change map or nil if insufficient data."
   [values dates]
@@ -183,7 +183,7 @@
 
 ;;; ------------------------------------------------ Main Entry Point ------------------------------------------------
 
-(defn compute-series-stats
+(defn- compute-series-stats
   "Compute statistics for a single time series.
 
   Arguments:

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/types.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/types.clj
@@ -128,7 +128,7 @@
   "An outlier detected in the data."
   [:map
    [:index :int]
-   [:date :any]
+   [:label :any]
    [:value number?]
    [:modified_z_score number?]])
 
@@ -136,7 +136,7 @@
   "An outlier detected in cumulative data (via period-over-period diffs)."
   [:map
    [:index :int]
-   [:date :any]
+   [:label :any]
    [:value number?]
    [:diff number?]
    [:modified_z_score number?]])

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/types.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/types.clj
@@ -43,11 +43,6 @@
    [:display_type {:optional true} [:maybe :string]]
    [:title {:optional true} [:maybe :string]]])
 
-(mr/def ::analyze-chart-input
-  "Input schema for the analyze-chart tool."
-  [:map
-   [:chart_config ::chart-config]])
-
 ;;; ------------------------------------------------- Output Schemas -------------------------------------------------
 
 (mr/def ::series-summary
@@ -254,10 +249,6 @@
    [:series_count :int]
    [:series [:map-of :string ::histogram-series-stats]]])
 
-(mr/def ::chart-type
-  "Detected chart type."
-  [:enum :time-series :categorical :scatter :histogram :unknown])
-
 (mr/def ::chart-stats
   "Union of all chart statistics types."
   [:or
@@ -277,10 +268,3 @@
    [:display-type {:optional true} [:maybe :string]]
    [:timeline-events {:optional true} [:maybe [:sequential ::timeline-event]]]])
 
-;;; --------------------------------------------- Tool Response Schema -----------------------------------------------
-
-(mr/def ::analyze-chart-output
-  "Output schema for the analyze-chart tool."
-  [:map
-   [:output :string]
-   [:stats {:optional true} [:maybe ::chart-stats]]])

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/types.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/types.clj
@@ -205,28 +205,25 @@
 (mr/def ::distribution-stats
   "Distribution statistics for histogram data."
   [:map
-   [:percentiles [:map
-                  [:p25 number?]
-                  [:p50 number?]
-                  [:p75 number?]
-                  [:p90 number?]
-                  [:p95 number?]
-                  [:p99 number?]]]
+   [:percentiles [:map-of :int number?]]
    [:quartiles [:map
                 [:q1 number?]
                 [:median number?]
                 [:q3 number?]
                 [:iqr number?]]]
-   [:skewness number?]
-   [:kurtosis number?]])
+   [:skewness {:optional true} [:maybe number?]]
+   [:kurtosis {:optional true} [:maybe number?]]])
 
 (mr/def ::histogram-stats
   "Statistics for histogram charts."
   [:map
    [:chart_type [:= :histogram]]
-   [:summary ::series-summary]
-   [:data_points :int]
-   [:distribution ::distribution-stats]])
+   [:series_count :int]
+   [:series [:map-of :string
+             [:map
+              [:summary ::series-summary]
+              [:data_points :int]
+              [:distribution ::distribution-stats]]]]])
 
 (mr/def ::chart-type
   "Detected chart type."

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/types.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/types.clj
@@ -267,4 +267,3 @@
    [:title {:optional true} [:maybe :string]]
    [:display-type {:optional true} [:maybe :string]]
    [:timeline-events {:optional true} [:maybe [:sequential ::timeline-event]]]])
-

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/types.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/types.clj
@@ -137,25 +137,45 @@
    [:value number?]
    [:modified_z_score number?]])
 
+(mr/def ::cumulative-outlier
+  "An outlier detected in cumulative data (via period-over-period diffs)."
+  [:map
+   [:index :int]
+   [:date :any]
+   [:value number?]
+   [:diff number?]
+   [:modified_z_score number?]])
+
+;;; --------------------------------------------------- Options ------------------------------------------------------
+
+(mr/def ::options
+  "Options map for chart statistics computation."
+  [:map
+   [:deep? {:optional true} [:maybe :boolean]]
+   [:max-correlation-series {:optional true} [:maybe :int]]])
+
 ;;; ---------------------------------------------- Chart Type Stats --------------------------------------------------
+
+(mr/def ::time-series-series-stats
+  "Statistics for a single time series."
+  [:map
+   [:summary ::series-summary]
+   [:time_range ::time-range]
+   [:data_points :int]
+   [:trend ::trend-summary]
+   [:is_cumulative :boolean]
+   [:outliers {:optional true} [:maybe [:sequential ::outlier]]]
+   [:volatility {:optional true} [:maybe ::volatility]]
+   [:patterns {:optional true} [:maybe [:sequential ::pattern-insight]]]
+   [:significant_changes {:optional true} [:maybe [:sequential ::significant-change]]]
+   [:most_recent_change {:optional true} [:maybe ::significant-change]]])
 
 (mr/def ::time-series-stats
   "Statistics for time series charts."
   [:map
    [:chart_type [:= :time-series]]
    [:series_count :int]
-   [:series [:map-of :string
-             [:map
-              [:summary ::series-summary]
-              [:time_range ::time-range]
-              [:data_points :int]
-              [:trend ::trend-summary]
-              [:is_cumulative :boolean]
-              [:outliers {:optional true} [:maybe [:sequential ::outlier]]]
-              [:volatility {:optional true} [:maybe ::volatility]]
-              [:patterns {:optional true} [:maybe [:sequential ::pattern-insight]]]
-              [:significant_changes {:optional true} [:maybe [:sequential ::significant-change]]]
-              [:most_recent_change {:optional true} [:maybe ::significant-change]]]]]
+   [:series [:map-of :string ::time-series-series-stats]]
    [:correlations {:optional true} [:maybe [:sequential ::correlation]]]])
 
 (mr/def ::category-stat
@@ -165,18 +185,21 @@
    [:value number?]
    [:percentage number?]])
 
+(mr/def ::categorical-series-stats
+  "Statistics for a single categorical series."
+  [:map
+   [:summary [:maybe ::series-summary]]
+   [:category_count :int]
+   [:top_categories [:sequential ::category-stat]]
+   [:bottom_categories {:optional true} [:maybe [:sequential ::category-stat]]]
+   [:outliers {:optional true} [:maybe [:sequential ::outlier]]]])
+
 (mr/def ::categorical-stats
   "Statistics for categorical charts (bar, pie, etc.)."
   [:map
    [:chart_type [:= :categorical]]
    [:series_count :int]
-   [:series [:map-of :string
-             [:map
-              [:summary [:maybe ::series-summary]]
-              [:category_count :int]
-              [:top_categories [:sequential ::category-stat]]
-              [:bottom_categories {:optional true} [:maybe [:sequential ::category-stat]]]
-              [:outliers {:optional true} [:maybe [:sequential ::outlier]]]]]]
+   [:series [:map-of :string ::categorical-series-stats]]
    [:correlations {:optional true} [:maybe [:sequential ::correlation]]]])
 
 (mr/def ::regression-stats
@@ -186,21 +209,24 @@
    [:intercept number?]
    [:r_squared number?]])
 
+(mr/def ::scatter-series-stats
+  "Statistics for a single scatter series."
+  [:map
+   [:x_summary [:maybe ::series-summary]]
+   [:y_summary [:maybe ::series-summary]]
+   [:data_points :int]
+   [:correlation {:optional true} [:maybe [:map
+                                           [:coefficient number?]
+                                           [:strength ::correlation-strength]
+                                           [:direction ::correlation-direction]]]]
+   [:regression {:optional true} [:maybe ::regression-stats]]])
+
 (mr/def ::scatter-stats
   "Statistics for scatter plots."
   [:map
    [:chart_type [:= :scatter]]
    [:series_count :int]
-   [:series [:map-of :string
-             [:map
-              [:x_summary [:maybe ::series-summary]]
-              [:y_summary [:maybe ::series-summary]]
-              [:data_points :int]
-              [:correlation {:optional true} [:maybe [:map
-                                                      [:coefficient number?]
-                                                      [:strength ::correlation-strength]
-                                                      [:direction ::correlation-direction]]]]
-              [:regression {:optional true} [:maybe ::regression-stats]]]]]])
+   [:series [:map-of :string ::scatter-series-stats]]])
 
 (mr/def ::distribution-stats
   "Distribution statistics for histogram data."
@@ -214,16 +240,19 @@
    [:skewness {:optional true} [:maybe number?]]
    [:kurtosis {:optional true} [:maybe number?]]])
 
+(mr/def ::histogram-series-stats
+  "Statistics for a single histogram series."
+  [:map
+   [:summary ::series-summary]
+   [:data_points :int]
+   [:distribution ::distribution-stats]])
+
 (mr/def ::histogram-stats
   "Statistics for histogram charts."
   [:map
    [:chart_type [:= :histogram]]
    [:series_count :int]
-   [:series [:map-of :string
-             [:map
-              [:summary ::series-summary]
-              [:data_points :int]
-              [:distribution ::distribution-stats]]]]])
+   [:series [:map-of :string ::histogram-series-stats]]])
 
 (mr/def ::chart-type
   "Detected chart type."
@@ -236,6 +265,17 @@
    ::categorical-stats
    ::scatter-stats
    ::histogram-stats])
+
+;;; ------------------------------------------ Representation Schema ------------------------------------------------
+
+(mr/def ::generate-repr-context
+  "Context map for generating chart statistics representation.
+  Accepts either a valid ::chart-stats or a map with :chart_type :unknown for the fallback branch."
+  [:map
+   [:stats [:or ::chart-stats [:map [:chart_type [:= :unknown]]]]]
+   [:title {:optional true} [:maybe :string]]
+   [:display-type {:optional true} [:maybe :string]]
+   [:timeline-events {:optional true} [:maybe [:sequential ::timeline-event]]]])
 
 ;;; --------------------------------------------- Tool Response Schema -----------------------------------------------
 

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/types.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/types.clj
@@ -184,6 +184,7 @@
   "Statistics for a single categorical series."
   [:map
    [:summary [:maybe ::series-summary]]
+   [:data_points :int]
    [:category_count :int]
    [:top_categories [:sequential ::category-stat]]
    [:bottom_categories {:optional true} [:maybe [:sequential ::category-stat]]]

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/types.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/types.clj
@@ -113,7 +113,7 @@
 
 (mr/def ::correlation-direction
   "Direction of correlation."
-  [:enum :positive :negative])
+  [:enum :positive :negative :none])
 
 (mr/def ::correlation
   "Correlation between two series."

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/types.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/types.clj
@@ -190,14 +190,17 @@
   "Statistics for scatter plots."
   [:map
    [:chart_type [:= :scatter]]
-   [:x_summary ::series-summary]
-   [:y_summary ::series-summary]
-   [:data_points :int]
-   [:correlation [:map
-                  [:coefficient number?]
-                  [:strength ::correlation-strength]
-                  [:direction ::correlation-direction]]]
-   [:regression ::regression-stats]])
+   [:series_count :int]
+   [:series [:map-of :string
+             [:map
+              [:x_summary [:maybe ::series-summary]]
+              [:y_summary [:maybe ::series-summary]]
+              [:data_points :int]
+              [:correlation {:optional true} [:maybe [:map
+                                                      [:coefficient number?]
+                                                      [:strength ::correlation-strength]
+                                                      [:direction ::correlation-direction]]]]
+              [:regression {:optional true} [:maybe ::regression-stats]]]]]])
 
 (mr/def ::distribution-stats
   "Distribution statistics for histogram data."

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/types.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/types.clj
@@ -7,7 +7,7 @@
 
 (mr/def ::column-type
   "Type of data in a column."
-  [:enum :string :number :datetime :date :time :boolean])
+  [:enum "string" "number" "datetime" "date" "time" "boolean"])
 
 (mr/def ::column-metadata
   "Metadata about a column in the chart data."

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/types.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/types.clj
@@ -210,11 +210,13 @@
    [:x_summary [:maybe ::series-summary]]
    [:y_summary [:maybe ::series-summary]]
    [:data_points :int]
+   [:sampled_points {:optional true} [:maybe [:sequential [:sequential :any]]]]
    [:correlation {:optional true} [:maybe [:map
                                            [:coefficient number?]
                                            [:strength ::correlation-strength]
                                            [:direction ::correlation-direction]]]]
-   [:regression {:optional true} [:maybe ::regression-stats]]])
+   [:regression {:optional true} [:maybe ::regression-stats]]
+   [:outliers {:optional true} [:maybe [:sequential ::outlier]]]])
 
 (mr/def ::scatter-stats
   "Statistics for scatter plots."
@@ -240,6 +242,7 @@
   [:map
    [:summary ::series-summary]
    [:data_points :int]
+   [:bin_data [:sequential [:sequential :any]]]
    [:distribution ::distribution-stats]])
 
 (mr/def ::histogram-stats

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/types.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/types.clj
@@ -226,25 +226,44 @@
    [:series_count :int]
    [:series [:map-of :string ::scatter-series-stats]]])
 
-(mr/def ::distribution-stats
-  "Distribution statistics for histogram data."
+(mr/def ::histogram-summary
+  "Weighted summary statistics estimated from binned histogram data."
   [:map
-   [:percentiles [:map-of :int number?]]
-   [:quartiles [:map
-                [:q1 number?]
-                [:median number?]
-                [:q3 number?]
-                [:iqr number?]]]
-   [:skewness {:optional true} [:maybe number?]]
-   [:kurtosis {:optional true} [:maybe number?]]])
+   [:weighted_mean number?]
+   [:weighted_std_dev number?]
+   [:data_range number?]])
+
+(mr/def ::estimated-distribution-stats
+  "Distribution statistics estimated from binned histogram data using weighted approximations."
+  [:map
+   [:estimated_percentiles [:map-of :int number?]]
+   [:estimated_quartiles [:map
+                          [:q1 number?]
+                          [:median number?]
+                          [:q3 number?]
+                          [:iqr number?]]]
+   [:weighted_skewness {:optional true} [:maybe number?]]
+   [:weighted_kurtosis {:optional true} [:maybe number?]]])
+
+(mr/def ::histogram-structure
+  "Structural properties of histogram bin distribution."
+  [:map
+   [:mode_bin [:maybe [:sequential :any]]]
+   [:peak_count :int]
+   [:concentration_top3 number?]
+   [:gap_count :int]
+   [:empty_bin_ratio number?]
+   [:bin_count :int]])
 
 (mr/def ::histogram-series-stats
   "Statistics for a single histogram series."
   [:map
-   [:summary ::series-summary]
+   [:estimated_summary ::histogram-summary]
+   [:total_count :int]
    [:data_points :int]
    [:bin_data [:sequential [:sequential :any]]]
-   [:distribution ::distribution-stats]])
+   [:distribution ::estimated-distribution-stats]
+   [:structure ::histogram-structure]])
 
 (mr/def ::histogram-stats
   "Statistics for histogram charts."

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/types.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/types.clj
@@ -166,16 +166,18 @@
    [:percentage number?]])
 
 (mr/def ::categorical-stats
-  "Statistics for categorical charts."
+  "Statistics for categorical charts (bar, pie, etc.)."
   [:map
    [:chart_type [:= :categorical]]
    [:series_count :int]
    [:series [:map-of :string
              [:map
-              [:summary ::series-summary]
+              [:summary [:maybe ::series-summary]]
               [:category_count :int]
               [:top_categories [:sequential ::category-stat]]
-              [:bottom_categories {:optional true} [:maybe [:sequential ::category-stat]]]]]]])
+              [:bottom_categories {:optional true} [:maybe [:sequential ::category-stat]]]
+              [:outliers {:optional true} [:maybe [:sequential ::outlier]]]]]]
+   [:correlations {:optional true} [:maybe [:sequential ::correlation]]]])
 
 (mr/def ::regression-stats
   "Linear regression statistics."

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/types.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/types.clj
@@ -272,21 +272,28 @@
    [:series_count :int]
    [:series [:map-of :string ::histogram-series-stats]]])
 
+(mr/def ::unknown-stats
+  "Fallback stats for chart types that don't have dedicated analysis (e.g. scalar)."
+  [:map
+   [:chart_type [:= :unknown]]
+   [:series_count :int]
+   [:message :string]])
+
 (mr/def ::chart-stats
   "Union of all chart statistics types."
   [:or
    ::time-series-stats
    ::categorical-stats
    ::scatter-stats
-   ::histogram-stats])
+   ::histogram-stats
+   ::unknown-stats])
 
 ;;; ------------------------------------------ Representation Schema ------------------------------------------------
 
 (mr/def ::generate-repr-context
-  "Context map for generating chart statistics representation.
-  Accepts either a valid ::chart-stats or a map with :chart_type :unknown for the fallback branch."
+  "Context map for generating chart statistics representation."
   [:map
-   [:stats [:or ::chart-stats [:map [:chart_type [:= :unknown]]]]]
+   [:stats ::chart-stats]
    [:title {:optional true} [:maybe :string]]
    [:display-type {:optional true} [:maybe :string]]
    [:timeline-events {:optional true} [:maybe [:sequential ::timeline-event]]]])

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/types.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/types.clj
@@ -178,7 +178,7 @@
   [:map
    [:name :string]
    [:value number?]
-   [:percentage number?]])
+   [:percentage {:optional true} number?]])
 
 (mr/def ::categorical-series-stats
   "Statistics for a single categorical series."

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/util.clj
@@ -45,7 +45,7 @@
   "Minimum sample size required for meaningful correlation computation."
   10)
 
-(mu/defn compute-correlations :- [:sequential ::stats.types/correlation]
+(mu/defn ^:private compute-correlations :- [:sequential ::stats.types/correlation]
   "Compute pairwise correlations between multiple series.
   Aligns series on common x-values (listwise deletion) before computing correlation.
   Skips pairs with fewer than 10 aligned data points."

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/util.clj
@@ -74,7 +74,7 @@
   "Compute pairwise correlations if deep mode is enabled and there are multiple series.
   Respects :max-correlation-series opt to cap the number of series considered."
   [series-data :- [:map-of :string ::stats.types/series-config]
-   opts :- :map]
+   opts :- ::stats.types/options]
   (when (and (:deep? opts) (> (count series-data) 1))
     (let [capped (if-let [max-k (:max-correlation-series opts)]
                    (into {} (take max-k series-data))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/util.clj
@@ -7,6 +7,12 @@
 
 (set! *warn-on-reflection* true)
 
+(mu/defn nan->nil :- [:maybe number?]
+  "Convert NaN to nil, pass through other values."
+  [x :- number?]
+  (when-not (Double/isNaN (double x))
+    x))
+
 (mu/defn compute-summary :- ::stats.types/series-summary
   "Compute basic statistical summary for a series of values."
   [values :- [:sequential number?]]

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/util.clj
@@ -25,6 +25,14 @@
      :std_dev (dfn/standard-deviation values)
      :range (- max-val min-val)}))
 
+(mu/defn correlation-direction :- ::stats.types/correlation-direction
+  "Classify correlation coefficient direction as :positive/:negative/:none."
+  [coef :- number?]
+  (cond
+    (neg? coef) :negative
+    (pos? coef) :positive
+    :else       :none))
+
 (mu/defn correlation-strength :- ::stats.types/correlation-strength
   "Classify correlation coefficient into :strong/:moderate/:weak/:none."
   [coef :- number?]
@@ -73,7 +81,7 @@
         :series_b name-b
         :coefficient coef
         :strength (correlation-strength coef)
-        :direction (if (neg? coef) :negative :positive)
+        :direction (correlation-direction coef)
         :aligned_sample_size n}))))
 
 (mu/defn maybe-compute-correlations :- [:maybe [:sequential ::stats.types/correlation]]

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/util.clj
@@ -1,0 +1,111 @@
+(ns metabase-enterprise.metabot-v3.stats.util
+  "Shared utilities used across various stats chart types."
+  (:require
+   [metabase-enterprise.metabot-v3.stats.types :as stats.types]
+   [metabase.util.malli :as mu]
+   [tech.v3.datatype.functional :as dfn]))
+
+(set! *warn-on-reflection* true)
+
+(mu/defn compute-summary :- ::stats.types/series-summary
+  "Compute basic statistical summary for a series of values."
+  [values :- [:sequential number?]]
+  (let [min-val (dfn/reduce-min values)
+        max-val (dfn/reduce-max values)]
+    {:min min-val
+     :max max-val
+     :mean (dfn/mean values)
+     :median (dfn/median values)
+     :std_dev (dfn/standard-deviation values)
+     :range (- max-val min-val)}))
+
+(mu/defn correlation-strength :- ::stats.types/correlation-strength
+  "Classify correlation coefficient into :strong/:moderate/:weak/:none."
+  [coef :- number?]
+  (let [abs-coef (Math/abs (double coef))]
+    (cond
+      (>= abs-coef 0.7) :strong
+      (>= abs-coef 0.4) :moderate
+      (>= abs-coef 0.2) :weak
+      :else :none)))
+
+(defn- align-series-on-x
+  "Align two series on common x-values using listwise deletion.
+  Returns [aligned-vals-a aligned-vals-b] containing only values at shared x positions."
+  [x-vals-a y-vals-a x-vals-b y-vals-b]
+  (let [b-lookup (zipmap x-vals-b y-vals-b)
+        common-pairs (for [[x y-a] (map vector x-vals-a y-vals-a)
+                           :let [y-b (get b-lookup x)]
+                           :when (some? y-b)]
+                       [y-a y-b])]
+    [(mapv first common-pairs)
+     (mapv second common-pairs)]))
+
+(def ^:private min-correlation-sample-size
+  "Minimum sample size required for meaningful correlation computation."
+  10)
+
+(mu/defn compute-correlations :- [:sequential ::stats.types/correlation]
+  "Compute pairwise correlations between multiple series.
+  Aligns series on common x-values (listwise deletion) before computing correlation.
+  Skips pairs with fewer than 10 aligned data points."
+  [series-map :- [:map-of :string ::stats.types/series-config]]
+  (let [series-names (keys series-map)
+        pairs (for [a series-names
+                    b series-names
+                    :when (pos? (compare (str b) (str a)))]
+                [a b])]
+    (vec
+     (for [[name-a name-b] pairs
+           :let [{x-a :x_values y-a :y_values} (get series-map name-a)
+                 {x-b :x_values y-b :y_values} (get series-map name-b)
+                 [aligned-a aligned-b] (align-series-on-x x-a y-a x-b y-b)
+                 n (count aligned-a)]
+           :when (>= n min-correlation-sample-size)
+           :let [coef (dfn/pearsons-correlation aligned-a aligned-b)]]
+       {:series_a name-a
+        :series_b name-b
+        :coefficient coef
+        :strength (correlation-strength coef)
+        :direction (if (neg? coef) :negative :positive)
+        :aligned_sample_size n}))))
+
+(mu/defn maybe-compute-correlations :- [:maybe [:sequential ::stats.types/correlation]]
+  "Compute pairwise correlations if deep mode is enabled and there are multiple series.
+  Respects :max-correlation-series opt to cap the number of series considered."
+  [series-data :- [:map-of :string ::stats.types/series-config]
+   opts :- :map]
+  (when (and (:deep? opts) (> (count series-data) 1))
+    (let [capped (if-let [max-k (:max-correlation-series opts)]
+                   (into {} (take max-k series-data))
+                   series-data)]
+      (when (> (count capped) 1)
+        (compute-correlations capped)))))
+
+(mu/defn percentage-change :- :double
+  "Compute percentage change from `from-val` to `to-val`.
+  Returns 0.0 when from-val is zero to avoid division by zero."
+  [from-val :- number?
+   to-val :- number?]
+  (if (zero? from-val)
+    0.0
+    (* 100.0 (/ (- to-val from-val) (Math/abs (double from-val))))))
+
+(defn compute-series-with-labels
+  "Apply `compute-fn` to each series' x_values and y_values, attaching :x_name and :y_name
+  from column metadata. `compute-fn` is called on x_values and y_values for each series.
+  Returns a map of series-name -> stats-with-labels."
+  [series-data compute-fn]
+  (into {}
+        (for [[series-name {:keys [x_values y_values x y]}] series-data]
+          [series-name (-> (compute-fn x_values y_values)
+                           (assoc :x_name (some-> x :name))
+                           (assoc :y_name (some-> y :name)))])))
+
+(mu/defn make-chart-result :- ::stats.types/chart-stats
+  "Build the standard chart stats result map."
+  [chart-type series-data series-stats correlations]
+  (cond-> {:chart_type   chart-type
+           :series_count (count series-data)
+           :series       series-stats}
+    correlations (assoc :correlations correlations)))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/categorical_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/categorical_test.clj
@@ -191,6 +191,14 @@
              ["North" "South" "East" "West"]
              [100 200 150 80])))))
 
+(deftest ^:parallel compute-series-stats-negative-values-no-percentage-test
+  (testing "percentage is omitted when any value is negative"
+    (let [result (#'categorical/compute-series-stats
+                  ["A" "B" "C"]
+                  [100 -20 50])]
+      (is (= 3 (:category_count result)))
+      (is (every? #(not (contains? % :percentage)) (:top_categories result))))))
+
 (deftest ^:parallel compute-series-stats-exact-percentages-test
   (testing "percentages in top_categories match expected values"
     ;; enabled=112, disabled=103, invited=85 → total=300

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/categorical_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/categorical_test.clj
@@ -166,14 +166,14 @@
               (categorical/compute-categorical-stats series-data {:deep? false}))))))
 
 (deftest ^:parallel compute-series-stats-duplicate-categories-test
-  (testing "duplicate x-values: category_count counts unique dimensions only"
+  (testing "duplicate x-values are merged by summing their values"
     (let [result (#'categorical/compute-series-stats
                   ["A" "A" "B"]
                   [100 150 200])]
-      ;; data_point_count includes all valid pairs including duplicates
-      (is (= 3 (count (:top_categories result))))
-      ;; category_count is unique dimensions
-      (is (=? {:category_count 2} result)))))
+      (is (= 2 (:category_count result)))
+      (is (= 2 (count (:top_categories result))))
+      (let [by-name (into {} (map (juxt :name :value) (:top_categories result)))]
+        (is (= {"A" 250 "B" 200} by-name))))))
 
 (deftest ^:parallel compute-series-stats-nil-dimensions-excluded-test
   (testing "nil x-values are excluded from category_count"

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/categorical_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/categorical_test.clj
@@ -6,7 +6,7 @@
 
 (set! *warn-on-reflection* true)
 
-(deftest compute-series-stats-empty-test
+(deftest ^:parallel compute-series-stats-empty-test
   (testing "empty series returns zero counts without crashing"
     (is (=? {:category_count 0
              :top_categories []
@@ -14,14 +14,14 @@
              :summary        nil?}
             (categorical/compute-series-stats [] [])))))
 
-(deftest compute-series-stats-nil-y-filtered-test
+(deftest ^:parallel compute-series-stats-nil-y-filtered-test
   (testing "nil y-values are filtered out"
     (is (=? {:category_count 2
              :top_categories [{:name "C" :value 200}
                               {:name "A" :value 100}]}
             (categorical/compute-series-stats ["A" "B" "C"] [100 nil 200])))))
 
-(deftest compute-series-stats-single-category-test
+(deftest ^:parallel compute-series-stats-single-category-test
   (testing "single category has 100% share"
     (is (=? {:category_count 1
              :top_categories [{:name "only"
@@ -29,7 +29,7 @@
                                :percentage 100.0}]}
             (categorical/compute-series-stats ["only"] [42])))))
 
-(deftest compute-series-stats-percentages-sum-to-100-test
+(deftest ^:parallel compute-series-stats-percentages-sum-to-100-test
   (testing "percentages sum to approximately 100"
     (let [result (categorical/compute-series-stats
                   ["A" "B" "C" "D"]
@@ -38,14 +38,14 @@
       (let [total-pct (reduce + (map :percentage (:top_categories result)))]
         (is (== total-pct 100.0))))))
 
-(deftest compute-series-stats-sorted-by-value-desc-test
+(deftest ^:parallel compute-series-stats-sorted-by-value-desc-test
   (testing "top categories are sorted by value descending"
     (is (= ["C" "B" "A"]
            (->> (categorical/compute-series-stats ["C" "A" "B"] [30 10 20])
                 :top_categories
                 (map :name))))))
 
-(deftest compute-series-stats-top-10-limit-test
+(deftest ^:parallel compute-series-stats-top-10-limit-test
   (testing "top_categories capped at 10"
     (let [xs (map str (range 20))
           ys (range 1 21)]
@@ -53,21 +53,21 @@
                :top_categories #(= 10 (count %))}
               (categorical/compute-series-stats xs ys))))))
 
-(deftest compute-series-stats-bottom-categories-present-test
+(deftest ^:parallel compute-series-stats-bottom-categories-present-test
   (testing "bottom_categories populated when > 15 categories"
     (let [xs (map str (range 16))
           ys (range 1 17)]
       (is (=? {:bottom_categories #(= 5 (count %))}
               (categorical/compute-series-stats xs ys))))))
 
-(deftest compute-series-stats-bottom-categories-missing-test
+(deftest ^:parallel compute-series-stats-bottom-categories-missing-test
   (testing "bottom_categories absent when <= 15 categories"
     (is (=? {:bottom_categories (symbol "nil #_\"key is not present.\"")}
             (categorical/compute-series-stats
              (map str (range 15))
              (range 1 16))))))
 
-(deftest compute-series-stats-outliers-present-test
+(deftest ^:parallel compute-series-stats-outliers-present-test
   (testing "outlier detection triggered at >= 5 valid points"
     (is (=? {:outliers [{:index 5
                          :date "F"
@@ -77,14 +77,14 @@
              ["A" "B" "C" "D" "E" "F"]
              [10 12 11 9 13 1000])))))
 
-(deftest compute-series-stats-outliers-missing-test
+(deftest ^:parallel compute-series-stats-outliers-missing-test
   (testing "outlier detection not triggered at < 5 valid points"
     (is (=? {:outliers empty?}
             (categorical/compute-series-stats
              ["A" "B" "C"]
              [10 10 1000])))))
 
-(deftest compute-categorical-stats-multi-series-test
+(deftest ^:parallel compute-categorical-stats-multi-series-test
   (testing "multiple series each get their own stats"
     (let [series-data {"Revenue" {:x_values ["A" "B"]
                                   :y_values [100 200]
@@ -134,7 +134,7 @@
                                 :y_name "cost"}}}
               (categorical/compute-categorical-stats series-data {:deep? false}))))))
 
-(deftest compute-categorical-stats-correlations-when-deep?-test
+(deftest ^:parallel compute-categorical-stats-correlations-when-deep?-test
   (testing "correlations computed with deep? and multiple series with >= 10 shared x-values"
     (let [xs  (map str (range 12))
           series-data {"A" {:x_values xs
@@ -150,7 +150,7 @@
       (is (=? {:correlations #(pos? (count %))}
               (categorical/compute-categorical-stats series-data {:deep? true}))))))
 
-(deftest compute-categorical-stats-correlations-when-not-deep?-test
+(deftest ^:parallel compute-categorical-stats-correlations-when-not-deep?-test
   (testing "no correlations without deep?"
     (let [series-data {"A" {:x_values ["x" "y"]
                             :y_values [1 2]
@@ -165,7 +165,7 @@
       (is (=? {:correlations (symbol "nil #_\"key is not present.\"")}
               (categorical/compute-categorical-stats series-data {:deep? false}))))))
 
-(deftest compute-series-stats-duplicate-categories-test
+(deftest ^:parallel compute-series-stats-duplicate-categories-test
   (testing "duplicate x-values: category_count counts unique dimensions only"
     (let [result (categorical/compute-series-stats
                   ["A" "A" "B"]
@@ -175,14 +175,14 @@
       ;; category_count is unique dimensions
       (is (=? {:category_count 2} result)))))
 
-(deftest compute-series-stats-nil-dimensions-excluded-test
+(deftest ^:parallel compute-series-stats-nil-dimensions-excluded-test
   (testing "nil x-values are excluded from category_count"
     (is (=? {:category_count 1}
             (categorical/compute-series-stats
              [nil "A" nil]
              [100 200 150])))))
 
-(deftest compute-series-stats-summary-values-test
+(deftest ^:parallel compute-series-stats-summary-values-test
   (testing "summary min, max, and mean are correct"
     (is (=? {:summary {:min  80
                        :max  200
@@ -191,7 +191,7 @@
              ["North" "South" "East" "West"]
              [100 200 150 80])))))
 
-(deftest compute-series-stats-exact-percentages-test
+(deftest ^:parallel compute-series-stats-exact-percentages-test
   (testing "percentages in top_categories match expected values"
     ;; enabled=112, disabled=103, invited=85 → total=300
     (is (=? {"enabled"  (=?/approx [37.3 0.1])

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/categorical_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/categorical_test.clj
@@ -70,7 +70,7 @@
 (deftest ^:parallel compute-series-stats-outliers-present-test
   (testing "outlier detection triggered at >= 5 valid points"
     (is (=? {:outliers [{:index 5
-                         :date "F"
+                         :label "F"
                          :value 1000
                          :modified_z_score pos?}]}
             (#'categorical/compute-series-stats

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/categorical_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/categorical_test.clj
@@ -12,14 +12,14 @@
              :top_categories []
              :outliers       []
              :summary        nil?}
-            (categorical/compute-series-stats [] [])))))
+            (#'categorical/compute-series-stats [] [])))))
 
 (deftest ^:parallel compute-series-stats-nil-y-filtered-test
   (testing "nil y-values are filtered out"
     (is (=? {:category_count 2
              :top_categories [{:name "C" :value 200}
                               {:name "A" :value 100}]}
-            (categorical/compute-series-stats ["A" "B" "C"] [100 nil 200])))))
+            (#'categorical/compute-series-stats ["A" "B" "C"] [100 nil 200])))))
 
 (deftest ^:parallel compute-series-stats-single-category-test
   (testing "single category has 100% share"
@@ -27,11 +27,11 @@
              :top_categories [{:name "only"
                                :value 42
                                :percentage 100.0}]}
-            (categorical/compute-series-stats ["only"] [42])))))
+            (#'categorical/compute-series-stats ["only"] [42])))))
 
 (deftest ^:parallel compute-series-stats-percentages-sum-to-100-test
   (testing "percentages sum to approximately 100"
-    (let [result (categorical/compute-series-stats
+    (let [result (#'categorical/compute-series-stats
                   ["A" "B" "C" "D"]
                   [10 20 30 40])]
       (is (= 4 (:category_count result)))
@@ -41,7 +41,7 @@
 (deftest ^:parallel compute-series-stats-sorted-by-value-desc-test
   (testing "top categories are sorted by value descending"
     (is (= ["C" "B" "A"]
-           (->> (categorical/compute-series-stats ["C" "A" "B"] [30 10 20])
+           (->> (#'categorical/compute-series-stats ["C" "A" "B"] [30 10 20])
                 :top_categories
                 (map :name))))))
 
@@ -51,19 +51,19 @@
           ys (range 1 21)]
       (is (=? {:category_count 20
                :top_categories #(= 10 (count %))}
-              (categorical/compute-series-stats xs ys))))))
+              (#'categorical/compute-series-stats xs ys))))))
 
 (deftest ^:parallel compute-series-stats-bottom-categories-present-test
   (testing "bottom_categories populated when > 15 categories"
     (let [xs (map str (range 16))
           ys (range 1 17)]
       (is (=? {:bottom_categories #(= 5 (count %))}
-              (categorical/compute-series-stats xs ys))))))
+              (#'categorical/compute-series-stats xs ys))))))
 
 (deftest ^:parallel compute-series-stats-bottom-categories-missing-test
   (testing "bottom_categories absent when <= 15 categories"
     (is (=? {:bottom_categories (symbol "nil #_\"key is not present.\"")}
-            (categorical/compute-series-stats
+            (#'categorical/compute-series-stats
              (map str (range 15))
              (range 1 16))))))
 
@@ -73,14 +73,14 @@
                          :date "F"
                          :value 1000
                          :modified_z_score pos?}]}
-            (categorical/compute-series-stats
+            (#'categorical/compute-series-stats
              ["A" "B" "C" "D" "E" "F"]
              [10 12 11 9 13 1000])))))
 
 (deftest ^:parallel compute-series-stats-outliers-missing-test
   (testing "outlier detection not triggered at < 5 valid points"
     (is (=? {:outliers empty?}
-            (categorical/compute-series-stats
+            (#'categorical/compute-series-stats
              ["A" "B" "C"]
              [10 10 1000])))))
 
@@ -167,7 +167,7 @@
 
 (deftest ^:parallel compute-series-stats-duplicate-categories-test
   (testing "duplicate x-values: category_count counts unique dimensions only"
-    (let [result (categorical/compute-series-stats
+    (let [result (#'categorical/compute-series-stats
                   ["A" "A" "B"]
                   [100 150 200])]
       ;; data_point_count includes all valid pairs including duplicates
@@ -178,7 +178,7 @@
 (deftest ^:parallel compute-series-stats-nil-dimensions-excluded-test
   (testing "nil x-values are excluded from category_count"
     (is (=? {:category_count 1}
-            (categorical/compute-series-stats
+            (#'categorical/compute-series-stats
              [nil "A" nil]
              [100 200 150])))))
 
@@ -187,7 +187,7 @@
     (is (=? {:summary {:min  80
                        :max  200
                        :mean 132.5}}
-            (categorical/compute-series-stats
+            (#'categorical/compute-series-stats
              ["North" "South" "East" "West"]
              [100 200 150 80])))))
 
@@ -197,7 +197,7 @@
     (is (=? {"enabled"  (=?/approx [37.3 0.1])
              "disabled" (=?/approx [34.4 0.1])
              "invited"  (=?/approx [28.3 0.1])}
-            (->> (categorical/compute-series-stats
+            (->> (#'categorical/compute-series-stats
                   ["enabled" "disabled" "invited"]
                   [112 103 85])
                  :top_categories

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/categorical_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/categorical_test.clj
@@ -88,13 +88,13 @@
   (testing "multiple series each get their own stats"
     (let [series-data {"Revenue" {:x_values ["A" "B"]
                                   :y_values [100 200]
-                                  :x {:name "cat" :type :string}
-                                  :y {:name "rev" :type :number}
+                                  :x {:name "cat" :type "string"}
+                                  :y {:name "rev" :type "number"}
                                   :display_name "Revenue"}
                        "Cost"    {:x_values ["A" "B"]
                                   :y_values [50 80]
-                                  :x {:name "cat" :type :string}
-                                  :y {:name "cost" :type :number}
+                                  :x {:name "cat" :type "string"}
+                                  :y {:name "cost" :type "number"}
                                   :display_name "Cost"}}]
       (is (=? {:chart_type :categorical
                :series_count 2
@@ -139,13 +139,13 @@
     (let [xs  (map str (range 12))
           series-data {"A" {:x_values xs
                             :y_values (range 1 13)
-                            :x {:name "cat" :type :string}
-                            :y {:name "a" :type :number}
+                            :x {:name "cat" :type "string"}
+                            :y {:name "a" :type "number"}
                             :display_name "A"}
                        "B" {:x_values xs
                             :y_values (range 2 14)
-                            :x {:name "cat" :type :string}
-                            :y {:name "b" :type :number}
+                            :x {:name "cat" :type "string"}
+                            :y {:name "b" :type "number"}
                             :display_name "B"}}]
       (is (=? {:correlations #(pos? (count %))}
               (categorical/compute-categorical-stats series-data {:deep? true}))))))
@@ -154,13 +154,13 @@
   (testing "no correlations without deep?"
     (let [series-data {"A" {:x_values ["x" "y"]
                             :y_values [1 2]
-                            :x {:name "cat" :type :string}
-                            :y {:name "a" :type :number}
+                            :x {:name "cat" :type "string"}
+                            :y {:name "a" :type "number"}
                             :display_name "A"}
                        "B" {:x_values ["x" "y"]
                             :y_values [2 3]
-                            :x {:name "cat" :type :string}
-                            :y {:name "b" :type :number}
+                            :x {:name "cat" :type "string"}
+                            :y {:name "b" :type "number"}
                             :display_name "B"}}]
       (is (=? {:correlations (symbol "nil #_\"key is not present.\"")}
               (categorical/compute-categorical-stats series-data {:deep? false}))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/categorical_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/categorical_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]
+   [mb.hawk.assert-exprs.approximately-equal :as =?]
    [metabase-enterprise.metabot-v3.stats.categorical :as categorical]
    [metabase-enterprise.metabot-v3.stats.repr :as repr]))
 
@@ -9,27 +10,26 @@
 
 (deftest compute-series-stats-empty-test
   (testing "empty series returns zero counts without crashing"
-    (let [result (categorical/compute-series-stats [] [])]
-      (is (= 0 (:category_count result)))
-      (is (= [] (:top_categories result)))
-      (is (= [] (:outliers result)))
-      (is (nil? (:summary result))))))
+    (is (=? {:category_count 0
+             :top_categories []
+             :outliers       []
+             :summary        nil?}
+            (categorical/compute-series-stats [] [])))))
 
 (deftest compute-series-stats-nil-y-filtered-test
   (testing "nil y-values are filtered out"
-    (let [result (categorical/compute-series-stats ["A" "B" "C"] [100 nil 200])]
-      (is (= 2 (:category_count result)))
-      (is (= 2 (count (:top_categories result)))))))
+    (is (=? {:category_count 2
+             :top_categories [{:name "C" :value 200}
+                              {:name "A" :value 100}]}
+            (categorical/compute-series-stats ["A" "B" "C"] [100 nil 200])))))
 
 (deftest compute-series-stats-single-category-test
   (testing "single category has 100% share"
-    (let [result (categorical/compute-series-stats ["only"] [42])]
-      (is (= 1 (:category_count result)))
-      (is (= 1 (count (:top_categories result))))
-      (let [cat (first (:top_categories result))]
-        (is (= "only" (:name cat)))
-        (is (= 42 (:value cat)))
-        (is (= 100.0 (:percentage cat)))))))
+    (is (=? {:category_count 1
+             :top_categories [{:name "only"
+                               :value 42
+                               :percentage 100.0}]}
+            (categorical/compute-series-stats ["only"] [42])))))
 
 (deftest compute-series-stats-percentages-sum-to-100-test
   (testing "percentages sum to approximately 100"
@@ -42,92 +42,130 @@
 
 (deftest compute-series-stats-sorted-by-value-desc-test
   (testing "top categories are sorted by value descending"
-    (let [result (categorical/compute-series-stats
-                  ["C" "A" "B"]
-                  [30 10 20])]
-      (is (= ["C" "B" "A"] (map :name (:top_categories result)))))))
+    (is (= ["C" "B" "A"]
+           (->> (categorical/compute-series-stats ["C" "A" "B"] [30 10 20])
+                :top_categories
+                (map :name))))))
 
 (deftest compute-series-stats-top-10-limit-test
   (testing "top_categories capped at 10"
     (let [xs (map str (range 20))
-          ys (range 1 21)
-          result (categorical/compute-series-stats xs ys)]
-      (is (= 20 (:category_count result)))
-      (is (= 10 (count (:top_categories result)))))))
+          ys (range 1 21)]
+      (is (=? {:category_count 20
+               :top_categories #(= 10 (count %))}
+              (categorical/compute-series-stats xs ys))))))
 
-(deftest compute-series-stats-bottom-categories-test
+(deftest compute-series-stats-bottom-categories-present-test
   (testing "bottom_categories populated when > 15 categories"
     (let [xs (map str (range 16))
-          ys (range 1 17)
-          result (categorical/compute-series-stats xs ys)]
-      (is (some? (:bottom_categories result)))
-      (is (= 5 (count (:bottom_categories result))))))
+          ys (range 1 17)]
+      (is (=? {:bottom_categories #(= 5 (count %))}
+              (categorical/compute-series-stats xs ys))))))
 
+(deftest compute-series-stats-bottom-categories-missing-test
   (testing "bottom_categories absent when <= 15 categories"
-    (let [result (categorical/compute-series-stats
-                  (map str (range 15))
-                  (range 1 16))]
-      (is (nil? (:bottom_categories result))))))
+    (is (=? {:bottom_categories (symbol "nil #_\"key is not present.\"")}
+            (categorical/compute-series-stats
+             (map str (range 15))
+             (range 1 16))))))
 
-(deftest compute-series-stats-outliers-test
+(deftest compute-series-stats-outliers-present-test
   (testing "outlier detection triggered at >= 5 valid points"
-    (let [;; varied baseline + 1 extreme outlier (non-identical values avoid MAD=0)
-          result (categorical/compute-series-stats
-                  ["A" "B" "C" "D" "E" "F"]
-                  [10 12 11 9 13 1000])]
-      (is (some? (:outliers result)))
-      (is (pos? (count (:outliers result))))))
+    (is (=? {:outliers [{:index 5
+                         :date "F"
+                         :value 1000
+                         :modified_z_score pos?}]}
+            (categorical/compute-series-stats
+             ["A" "B" "C" "D" "E" "F"]
+             [10 12 11 9 13 1000])))))
 
+(deftest compute-series-stats-outliers-missing-test
   (testing "outlier detection not triggered at < 5 valid points"
-    (let [result (categorical/compute-series-stats
-                  ["A" "B" "C"]
-                  [10 10 1000])]
-      ;; outliers may be nil or empty when n < 5
-      (is (or (nil? (:outliers result))
-              (empty? (:outliers result)))))))
+    (is (=? {:outliers empty?}
+            (categorical/compute-series-stats
+             ["A" "B" "C"]
+             [10 10 1000])))))
 
 (deftest compute-categorical-stats-multi-series-test
   (testing "multiple series each get their own stats"
-    (let [series-data {"Revenue" {:x_values ["A" "B"] :y_values [100 200]
+    (let [series-data {"Revenue" {:x_values ["A" "B"]
+                                  :y_values [100 200]
                                   :x {:name "cat" :type :string}
                                   :y {:name "rev" :type :number}
                                   :display_name "Revenue"}
-                       "Cost"    {:x_values ["A" "B"] :y_values [50 80]
+                       "Cost"    {:x_values ["A" "B"]
+                                  :y_values [50 80]
                                   :x {:name "cat" :type :string}
                                   :y {:name "cost" :type :number}
-                                  :display_name "Cost"}}
-          result (categorical/compute-categorical-stats series-data {:deep? false})]
-      (is (= :categorical (:chart_type result)))
-      (is (= 2 (:series_count result)))
-      (is (contains? (:series result) "Revenue"))
-      (is (contains? (:series result) "Cost")))))
+                                  :display_name "Cost"}}]
+      (is (=? {:chart_type :categorical
+               :series_count 2
+               :series {"Revenue" {:summary {:min 100
+                                             :max 200
+                                             :mean 150.0
+                                             :median 200.0
+                                             :std_dev (=?/approx [70.71 0.01])
+                                             :range 100}
+                                   :category_count 2
+                                   :top_categories
+                                   [{:name "B"
+                                     :value 200
+                                     :percentage (=?/approx [66.66 0.01])}
+                                    {:name "A"
+                                     :value 100
+                                     :percentage (=?/approx [33.33 0.01])}]
+                                   :outliers []
+                                   :x_name "cat"
+                                   :y_name "rev"}
+                        "Cost" {:summary {:min 50
+                                          :max 80
+                                          :mean 65.0
+                                          :median 80.0
+                                          :std_dev (=?/approx [21.21 0.01])
+                                          :range 30}
+                                :category_count 2
+                                :top_categories
+                                [{:name "B"
+                                  :value 80
+                                  :percentage (=?/approx [61.5 0.1])}
+                                 {:name "A"
+                                  :value 50
+                                  :percentage (=?/approx [38.4 0.1])}]
+                                :outliers [],
+                                :x_name "cat",
+                                :y_name "cost"}}}
+              (categorical/compute-categorical-stats series-data {:deep? false}))))))
 
-(deftest compute-categorical-stats-correlations-test
+(deftest compute-categorical-stats-correlations-when-deep?-test
   (testing "correlations computed with deep? and multiple series with >= 10 shared x-values"
     (let [xs  (map str (range 12))
-          series-data {"A" {:x_values xs :y_values (range 1 13)
+          series-data {"A" {:x_values xs
+                            :y_values (range 1 13)
                             :x {:name "cat" :type :string}
                             :y {:name "a" :type :number}
                             :display_name "A"}
-                       "B" {:x_values xs :y_values (range 2 14)
+                       "B" {:x_values xs
+                            :y_values (range 2 14)
                             :x {:name "cat" :type :string}
                             :y {:name "b" :type :number}
-                            :display_name "B"}}
-          result (categorical/compute-categorical-stats series-data {:deep? true})]
-      (is (some? (:correlations result)))
-      (is (pos? (count (:correlations result))))))
+                            :display_name "B"}}]
+      (is (=? {:correlations #(pos? (count %))}
+              (categorical/compute-categorical-stats series-data {:deep? true}))))))
 
+(deftest compute-categorical-stats-correlations-when-not-deep?-test
   (testing "no correlations without deep?"
-    (let [series-data {"A" {:x_values ["x" "y"] :y_values [1 2]
+    (let [series-data {"A" {:x_values ["x" "y"]
+                            :y_values [1 2]
                             :x {:name "cat" :type :string}
                             :y {:name "a" :type :number}
                             :display_name "A"}
-                       "B" {:x_values ["x" "y"] :y_values [2 3]
+                       "B" {:x_values ["x" "y"]
+                            :y_values [2 3]
                             :x {:name "cat" :type :string}
                             :y {:name "b" :type :number}
-                            :display_name "B"}}
-          result (categorical/compute-categorical-stats series-data {:deep? false})]
-      (is (nil? (:correlations result))))))
+                            :display_name "B"}}]
+      (is (=? {:correlations (symbol "nil #_\"key is not present.\"")}
+              (categorical/compute-categorical-stats series-data {:deep? false}))))))
 
 (deftest compute-series-stats-duplicate-categories-test
   (testing "duplicate x-values: category_count counts unique dimensions only"
@@ -137,37 +175,36 @@
       ;; data_point_count includes all valid pairs including duplicates
       (is (= 3 (count (:top_categories result))))
       ;; category_count is unique dimensions
-      (is (= 2 (:category_count result))))))
+      (is (=? {:category_count 2} result)))))
 
 (deftest compute-series-stats-nil-dimensions-excluded-test
   (testing "nil x-values are excluded from category_count"
-    (let [result (categorical/compute-series-stats
-                  [nil "A" nil]
-                  [100 200 150])]
-      ;; Only "A" is a non-nil dimension
-      (is (= 1 (:category_count result))))))
+    (is (=? {:category_count 1}
+            (categorical/compute-series-stats
+             [nil "A" nil]
+             [100 200 150])))))
 
 (deftest compute-series-stats-summary-values-test
   (testing "summary min, max, and mean are correct"
-    (let [result (categorical/compute-series-stats
-                  ["North" "South" "East" "West"]
-                  [100 200 150 80])
-          s      (:summary result)]
-      (is (some? s))
-      (is (== 80 (:min s)))
-      (is (== 200 (:max s)))
-      (is (== 132.5 (:mean s))))))
+    (is (=? {:summary {:min  80
+                       :max  200
+                       :mean 132.5}}
+            (categorical/compute-series-stats
+             ["North" "South" "East" "West"]
+             [100 200 150 80])))))
 
 (deftest compute-series-stats-exact-percentages-test
   (testing "percentages in top_categories match expected values"
     ;; enabled=112, disabled=103, invited=85 → total=300
-    (let [result (categorical/compute-series-stats
+    (is (=? {"enabled"  (=?/approx [37.3 0.1])
+             "disabled" (=?/approx [34.4 0.1])
+             "invited"  (=?/approx [28.3 0.1])}
+            (->> (categorical/compute-series-stats
                   ["enabled" "disabled" "invited"]
                   [112 103 85])
-          cats   (into {} (map (juxt :name :percentage) (:top_categories result)))]
-      (is (< (Math/abs (- (get cats "enabled") 37.3)) 0.1))
-      (is (< (Math/abs (- (get cats "disabled") 34.3)) 0.1))
-      (is (< (Math/abs (- (get cats "invited") 28.3)) 0.1)))))
+                 :top_categories
+                 (map (juxt :name :percentage))
+                 (into {}))))))
 
 ;;; Representation tests
 
@@ -184,8 +221,8 @@
 
 (deftest repr-categorical-shows-bottom-categories-for-large-dataset-test
   (testing "Bottom Categories shown when > 15 categories"
-    (let [xs    (map #(str "Cat" (format "%02d" %)) (range 1 21))
-          ys    (map double (range 1 21))
+    (let [xs           (map #(str "Cat" (format "%02d" %)) (range 1 21))
+          ys           (map double (range 1 21))
           series-stats (categorical/compute-series-stats xs ys)
           stats        {:chart_type   :categorical
                         :series_count 1
@@ -195,13 +232,13 @@
       (is (str/includes? rep "Bottom Categories"))
       ;; highest value category (Cat20) appears
       (is (str/includes? rep "Cat20"))
-      ;; lowest value category (Cat01) appears in bottom section
+      ;; lowest value category (Cat01) appears
       (is (str/includes? rep "Cat01")))))
 
 (deftest repr-categorical-no-bottom-categories-for-small-dataset-test
   (testing "Bottom Categories absent when <= 15 categories"
-    (let [xs    (map #(str "Cat" %) (range 1 16))
-          ys    (map double (range 1 16))
+    (let [xs           (map #(str "Cat" %) (range 1 16))
+          ys           (map double (range 1 16))
           series-stats (categorical/compute-series-stats xs ys)
           stats        {:chart_type   :categorical
                         :series_count 1

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/categorical_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/categorical_test.clj
@@ -1,0 +1,211 @@
+(ns metabase-enterprise.metabot-v3.stats.categorical-test
+  (:require
+   [clojure.string :as str]
+   [clojure.test :refer :all]
+   [metabase-enterprise.metabot-v3.stats.categorical :as categorical]
+   [metabase-enterprise.metabot-v3.stats.repr :as repr]))
+
+(set! *warn-on-reflection* true)
+
+(deftest compute-series-stats-empty-test
+  (testing "empty series returns zero counts without crashing"
+    (let [result (categorical/compute-series-stats [] [])]
+      (is (= 0 (:category_count result)))
+      (is (= [] (:top_categories result)))
+      (is (= [] (:outliers result)))
+      (is (nil? (:summary result))))))
+
+(deftest compute-series-stats-nil-y-filtered-test
+  (testing "nil y-values are filtered out"
+    (let [result (categorical/compute-series-stats ["A" "B" "C"] [100 nil 200])]
+      (is (= 2 (:category_count result)))
+      (is (= 2 (count (:top_categories result)))))))
+
+(deftest compute-series-stats-single-category-test
+  (testing "single category has 100% share"
+    (let [result (categorical/compute-series-stats ["only"] [42])]
+      (is (= 1 (:category_count result)))
+      (is (= 1 (count (:top_categories result))))
+      (let [cat (first (:top_categories result))]
+        (is (= "only" (:name cat)))
+        (is (= 42 (:value cat)))
+        (is (= 100.0 (:percentage cat)))))))
+
+(deftest compute-series-stats-percentages-sum-to-100-test
+  (testing "percentages sum to approximately 100"
+    (let [result (categorical/compute-series-stats
+                  ["A" "B" "C" "D"]
+                  [10 20 30 40])]
+      (is (= 4 (:category_count result)))
+      (let [total-pct (reduce + (map :percentage (:top_categories result)))]
+        (is (== total-pct 100.0))))))
+
+(deftest compute-series-stats-sorted-by-value-desc-test
+  (testing "top categories are sorted by value descending"
+    (let [result (categorical/compute-series-stats
+                  ["C" "A" "B"]
+                  [30 10 20])]
+      (is (= ["C" "B" "A"] (map :name (:top_categories result)))))))
+
+(deftest compute-series-stats-top-10-limit-test
+  (testing "top_categories capped at 10"
+    (let [xs (map str (range 20))
+          ys (range 1 21)
+          result (categorical/compute-series-stats xs ys)]
+      (is (= 20 (:category_count result)))
+      (is (= 10 (count (:top_categories result)))))))
+
+(deftest compute-series-stats-bottom-categories-test
+  (testing "bottom_categories populated when > 15 categories"
+    (let [xs (map str (range 16))
+          ys (range 1 17)
+          result (categorical/compute-series-stats xs ys)]
+      (is (some? (:bottom_categories result)))
+      (is (= 5 (count (:bottom_categories result))))))
+
+  (testing "bottom_categories absent when <= 15 categories"
+    (let [result (categorical/compute-series-stats
+                  (map str (range 15))
+                  (range 1 16))]
+      (is (nil? (:bottom_categories result))))))
+
+(deftest compute-series-stats-outliers-test
+  (testing "outlier detection triggered at >= 5 valid points"
+    (let [;; varied baseline + 1 extreme outlier (non-identical values avoid MAD=0)
+          result (categorical/compute-series-stats
+                  ["A" "B" "C" "D" "E" "F"]
+                  [10 12 11 9 13 1000])]
+      (is (some? (:outliers result)))
+      (is (pos? (count (:outliers result))))))
+
+  (testing "outlier detection not triggered at < 5 valid points"
+    (let [result (categorical/compute-series-stats
+                  ["A" "B" "C"]
+                  [10 10 1000])]
+      ;; outliers may be nil or empty when n < 5
+      (is (or (nil? (:outliers result))
+              (empty? (:outliers result)))))))
+
+(deftest compute-categorical-stats-multi-series-test
+  (testing "multiple series each get their own stats"
+    (let [series-data {"Revenue" {:x_values ["A" "B"] :y_values [100 200]
+                                  :x {:name "cat" :type :string}
+                                  :y {:name "rev" :type :number}
+                                  :display_name "Revenue"}
+                       "Cost"    {:x_values ["A" "B"] :y_values [50 80]
+                                  :x {:name "cat" :type :string}
+                                  :y {:name "cost" :type :number}
+                                  :display_name "Cost"}}
+          result (categorical/compute-categorical-stats series-data {:deep? false})]
+      (is (= :categorical (:chart_type result)))
+      (is (= 2 (:series_count result)))
+      (is (contains? (:series result) "Revenue"))
+      (is (contains? (:series result) "Cost")))))
+
+(deftest compute-categorical-stats-correlations-test
+  (testing "correlations computed with deep? and multiple series with >= 10 shared x-values"
+    (let [xs  (map str (range 12))
+          series-data {"A" {:x_values xs :y_values (range 1 13)
+                            :x {:name "cat" :type :string}
+                            :y {:name "a" :type :number}
+                            :display_name "A"}
+                       "B" {:x_values xs :y_values (range 2 14)
+                            :x {:name "cat" :type :string}
+                            :y {:name "b" :type :number}
+                            :display_name "B"}}
+          result (categorical/compute-categorical-stats series-data {:deep? true})]
+      (is (some? (:correlations result)))
+      (is (pos? (count (:correlations result))))))
+
+  (testing "no correlations without deep?"
+    (let [series-data {"A" {:x_values ["x" "y"] :y_values [1 2]
+                            :x {:name "cat" :type :string}
+                            :y {:name "a" :type :number}
+                            :display_name "A"}
+                       "B" {:x_values ["x" "y"] :y_values [2 3]
+                            :x {:name "cat" :type :string}
+                            :y {:name "b" :type :number}
+                            :display_name "B"}}
+          result (categorical/compute-categorical-stats series-data {:deep? false})]
+      (is (nil? (:correlations result))))))
+
+(deftest compute-series-stats-duplicate-categories-test
+  (testing "duplicate x-values: category_count counts unique dimensions only"
+    (let [result (categorical/compute-series-stats
+                  ["A" "A" "B"]
+                  [100 150 200])]
+      ;; data_point_count includes all valid pairs including duplicates
+      (is (= 3 (count (:top_categories result))))
+      ;; category_count is unique dimensions
+      (is (= 2 (:category_count result))))))
+
+(deftest compute-series-stats-nil-dimensions-excluded-test
+  (testing "nil x-values are excluded from category_count"
+    (let [result (categorical/compute-series-stats
+                  [nil "A" nil]
+                  [100 200 150])]
+      ;; Only "A" is a non-nil dimension
+      (is (= 1 (:category_count result))))))
+
+(deftest compute-series-stats-summary-values-test
+  (testing "summary min, max, and mean are correct"
+    (let [result (categorical/compute-series-stats
+                  ["North" "South" "East" "West"]
+                  [100 200 150 80])
+          s      (:summary result)]
+      (is (some? s))
+      (is (== 80 (:min s)))
+      (is (== 200 (:max s)))
+      (is (== 132.5 (:mean s))))))
+
+(deftest compute-series-stats-exact-percentages-test
+  (testing "percentages in top_categories match expected values"
+    ;; enabled=112, disabled=103, invited=85 → total=300
+    (let [result (categorical/compute-series-stats
+                  ["enabled" "disabled" "invited"]
+                  [112 103 85])
+          cats   (into {} (map (juxt :name :percentage) (:top_categories result)))]
+      (is (< (Math/abs (- (get cats "enabled") 37.3)) 0.1))
+      (is (< (Math/abs (- (get cats "disabled") 34.3)) 0.1))
+      (is (< (Math/abs (- (get cats "invited") 28.3)) 0.1)))))
+
+;;; Representation tests
+
+(deftest repr-categorical-includes-key-info-test
+  (testing "representation includes series name, data count, and Categories"
+    (let [series-stats (categorical/compute-series-stats ["A" "B" "C"] [100 200 150])
+          stats        {:chart_type   :categorical
+                        :series_count 1
+                        :series       {"Test Series" series-stats}}
+          rep          (repr/generate-categorical-representation {:stats stats})]
+      (is (str/includes? rep "Test Series"))
+      (is (str/includes? rep "Categories"))
+      (is (str/includes? rep "Top Categories")))))
+
+(deftest repr-categorical-shows-bottom-categories-for-large-dataset-test
+  (testing "Bottom Categories shown when > 15 categories"
+    (let [xs    (map #(str "Cat" (format "%02d" %)) (range 1 21))
+          ys    (map double (range 1 21))
+          series-stats (categorical/compute-series-stats xs ys)
+          stats        {:chart_type   :categorical
+                        :series_count 1
+                        :series       {"Many" series-stats}}
+          rep          (repr/generate-categorical-representation {:stats stats})]
+      (is (str/includes? rep "Top Categories"))
+      (is (str/includes? rep "Bottom Categories"))
+      ;; highest value category (Cat20) appears
+      (is (str/includes? rep "Cat20"))
+      ;; lowest value category (Cat01) appears in bottom section
+      (is (str/includes? rep "Cat01")))))
+
+(deftest repr-categorical-no-bottom-categories-for-small-dataset-test
+  (testing "Bottom Categories absent when <= 15 categories"
+    (let [xs    (map #(str "Cat" %) (range 1 16))
+          ys    (map double (range 1 16))
+          series-stats (categorical/compute-series-stats xs ys)
+          stats        {:chart_type   :categorical
+                        :series_count 1
+                        :series       {"Few" series-stats}}
+          rep          (repr/generate-categorical-representation {:stats stats})]
+      (is (str/includes? rep "Top Categories"))
+      (is (not (str/includes? rep "Bottom Categories"))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/categorical_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/categorical_test.clj
@@ -1,10 +1,8 @@
 (ns metabase-enterprise.metabot-v3.stats.categorical-test
   (:require
-   [clojure.string :as str]
    [clojure.test :refer :all]
    [mb.hawk.assert-exprs.approximately-equal :as =?]
-   [metabase-enterprise.metabot-v3.stats.categorical :as categorical]
-   [metabase-enterprise.metabot-v3.stats.repr :as repr]))
+   [metabase-enterprise.metabot-v3.stats.categorical :as categorical]))
 
 (set! *warn-on-reflection* true)
 
@@ -205,44 +203,3 @@
                  :top_categories
                  (map (juxt :name :percentage))
                  (into {}))))))
-
-;;; Representation tests
-
-(deftest repr-categorical-includes-key-info-test
-  (testing "representation includes series name, data count, and Categories"
-    (let [series-stats (categorical/compute-series-stats ["A" "B" "C"] [100 200 150])
-          stats        {:chart_type   :categorical
-                        :series_count 1
-                        :series       {"Test Series" series-stats}}
-          rep          (repr/generate-categorical-representation {:stats stats})]
-      (is (str/includes? rep "Test Series"))
-      (is (str/includes? rep "Categories"))
-      (is (str/includes? rep "Top Categories")))))
-
-(deftest repr-categorical-shows-bottom-categories-for-large-dataset-test
-  (testing "Bottom Categories shown when > 15 categories"
-    (let [xs           (map #(str "Cat" (format "%02d" %)) (range 1 21))
-          ys           (map double (range 1 21))
-          series-stats (categorical/compute-series-stats xs ys)
-          stats        {:chart_type   :categorical
-                        :series_count 1
-                        :series       {"Many" series-stats}}
-          rep          (repr/generate-categorical-representation {:stats stats})]
-      (is (str/includes? rep "Top Categories"))
-      (is (str/includes? rep "Bottom Categories"))
-      ;; highest value category (Cat20) appears
-      (is (str/includes? rep "Cat20"))
-      ;; lowest value category (Cat01) appears
-      (is (str/includes? rep "Cat01")))))
-
-(deftest repr-categorical-no-bottom-categories-for-small-dataset-test
-  (testing "Bottom Categories absent when <= 15 categories"
-    (let [xs           (map #(str "Cat" %) (range 1 16))
-          ys           (map double (range 1 16))
-          series-stats (categorical/compute-series-stats xs ys)
-          stats        {:chart_type   :categorical
-                        :series_count 1
-                        :series       {"Few" series-stats}}
-          rep          (repr/generate-categorical-representation {:stats stats})]
-      (is (str/includes? rep "Top Categories"))
-      (is (not (str/includes? rep "Bottom Categories"))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/core_test.clj
@@ -28,12 +28,17 @@
 
 ;;; ------------------------------------------- Downsampling Tests -------------------------------------------------
 
+(defn- approx=max-data-points-per-series?
+  "Is `n` approximately [[stats.core/max-data-points-per-series]]?"
+  [n]
+  ;; random-sample is probabilistic, so allow 20% tolerance
+  (< n (* 1.2 stats.core/max-data-points-per-series)))
+
 (deftest data-points-within-limit-are-not-downsampled-test
   (testing "Series within the limit are not modified"
-    (let [config (make-chart-config 1 100)
-          stats  (stats.core/compute-chart-stats config {:deep? false})]
-      (is (nil? (:limits stats)))
-      (is (= 100 (get-in stats [:series "series_0" :data_points]))))))
+    (is (=? {:limits (symbol "nil #_\"key is not present.\"")
+             :series {"series_0" {:data_points 100}}}
+            (stats.core/compute-chart-stats (make-chart-config 1 100) {:deep? false})))))
 
 (deftest data-points-exceeding-limit-are-downsampled-test
   (testing "Series exceeding max-data-points-per-series are downsampled"
@@ -41,25 +46,20 @@
           config (make-chart-config 1 n)
           stats  (stats.core/compute-chart-stats config {:deep? false})
           sampled (get-in stats [:series "series_0" :data_points])]
-      (is (some? (:limits stats)))
-      (is (= n (get-in stats [:limits :downsampled_series "series_0" :original_count])))
-      ;; random-sample is probabilistic, so allow 10% tolerance
-      (is (< sampled (* 1.1 stats.core/max-data-points-per-series))
+      (is (=? {:limits {:downsampled_series {"series_0" {:original_count n}}}}
+              stats))
+
+      (is (approx=max-data-points-per-series? sampled)
           (str "sampled " sampled " should be roughly <= " stats.core/max-data-points-per-series)))))
 
 (deftest downsampling-preserves-first-and-last-points-test
   (testing "Downsampled series preserves the first and last data points"
     (let [n       (+ stats.core/max-data-points-per-series 1000)
           config  (make-chart-config 1 n)
-          orig-xs (get-in config [:series "series_0" :x_values])
           orig-ys (get-in config [:series "series_0" :y_values])]
-      ;; Use the private downsample fn via the stats output: check that trend
-      ;; start_value and end_value match the original first/last y values
-      (let [stats (stats.core/compute-chart-stats config {:deep? false})]
-        (is (= (double (first orig-ys))
-               (get-in stats [:series "series_0" :trend :start_value])))
-        (is (= (double (last orig-ys))
-               (get-in stats [:series "series_0" :trend :end_value])))))))
+      (is (=? {:series {"series_0" {:trend {:start_value (double (first orig-ys))
+                                            :end_value   (double (last orig-ys))}}}}
+              (stats.core/compute-chart-stats config {:deep? false}))))))
 
 (deftest multiple-series-downsampled-independently-test
   (testing "Each series is downsampled independently, limits tracks each"
@@ -70,36 +70,31 @@
                    :series {"small" (make-series small-n)
                             "large" (make-series large-n)}}
           stats   (stats.core/compute-chart-stats config {:deep? false})]
-      (is (some? (:limits stats)))
-      ;; Only the large series should appear in downsampled_series
-      (is (contains? (get-in stats [:limits :downsampled_series]) "large"))
-      (is (not (contains? (get-in stats [:limits :downsampled_series]) "small")))
-      (is (= small-n (get-in stats [:series "small" :data_points])))
-      (is (< (get-in stats [:series "large" :data_points])
-             (* 1.1 stats.core/max-data-points-per-series))))))
+      (is (=? {:limits {:downsampled_series
+                        {"small" (symbol "nil #_\"key is not present.\"")
+                         "large" {:original_count large-n}}}
+               :series {"small" {:data_points small-n}
+                        "large" {:data_points approx=max-data-points-per-series?}}}
+              stats)))))
 
 ;;; ---------------------------------------- Correlation Cap Tests -------------------------------------------------
 
 (deftest correlations-not-capped-when-within-limit-test
   (testing "Correlations are computed for all series when count <= max"
-    (let [config (make-chart-config 3 50)
-          stats  (stats.core/compute-chart-stats config {:deep? true})]
-      (is (nil? (get-in stats [:limits :correlations_capped])))
-      ;; 3 series → C(3,2) = 3 pairs possible (some may be skipped if < 10 aligned points)
-      (is (some? (:correlations stats))))))
+    (is (=? {:correlations some?
+             :limits (symbol "nil #_\"key is not present.\"")}
+            (stats.core/compute-chart-stats (make-chart-config 3 50) {:deep? true})))))
 
 (deftest correlations-capped-when-exceeding-limit-test
   (testing "Correlations are limited to max-series-for-correlations"
     (let [n-series (+ stats.core/max-series-for-correlations 5)
           config   (make-chart-config n-series 50)
           stats    (stats.core/compute-chart-stats config {:deep? true})]
-      (is (some? (get-in stats [:limits :correlations_capped])))
-      (is (= n-series (get-in stats [:limits :correlations_capped :total_series])))
-      (is (= stats.core/max-series-for-correlations
-             (get-in stats [:limits :correlations_capped :max_correlated])))
-      ;; All series should still have stats computed (only correlations are capped)
-      (is (= n-series (:series_count stats)))
-      (is (= n-series (count (:series stats))))
+      (is (=? {:limits       {:correlations_capped {:total_series   n-series
+                                                    :max_correlated stats.core/max-series-for-correlations}}
+               :series       #(= n-series (count %))
+               :series_count n-series}
+              stats))
       ;; Correlations should have at most C(max-k, 2) entries
       (let [max-k stats.core/max-series-for-correlations
             max-pairs (/ (* max-k (dec max-k)) 2)]

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/core_test.clj
@@ -32,13 +32,13 @@
   ;; random-sample is probabilistic, so allow 20% tolerance
   (< n (* 1.2 stats.core/max-data-points-per-series)))
 
-(deftest data-points-within-limit-are-not-downsampled-test
+(deftest ^:parallel data-points-within-limit-are-not-downsampled-test
   (testing "Series within the limit are not modified"
     (is (=? {:limits (symbol "nil #_\"key is not present.\"")
              :series {"series_0" {:data_points 100}}}
             (stats.core/compute-chart-stats (make-chart-config 1 100) {:deep? false})))))
 
-(deftest data-points-exceeding-limit-are-downsampled-test
+(deftest ^:parallel data-points-exceeding-limit-are-downsampled-test
   (testing "Series exceeding max-data-points-per-series are downsampled"
     (let [n      (+ stats.core/max-data-points-per-series 5000)
           config (make-chart-config 1 n)
@@ -50,7 +50,7 @@
       (is (approx=max-data-points-per-series? sampled)
           (str "sampled " sampled " should be roughly <= " stats.core/max-data-points-per-series)))))
 
-(deftest downsampling-preserves-first-and-last-points-test
+(deftest ^:parallel downsampling-preserves-first-and-last-points-test
   (testing "Downsampled series preserves the first and last data points"
     (let [n       (+ stats.core/max-data-points-per-series 1000)
           config  (make-chart-config 1 n)
@@ -59,7 +59,7 @@
                                             :end_value   (double (last orig-ys))}}}}
               (stats.core/compute-chart-stats config {:deep? false}))))))
 
-(deftest multiple-series-downsampled-independently-test
+(deftest ^:parallel multiple-series-downsampled-independently-test
   (testing "Each series is downsampled independently, limits tracks each"
     (let [small-n 100
           large-n (+ stats.core/max-data-points-per-series 2000)
@@ -77,13 +77,13 @@
 
 ;;; ---------------------------------------- Correlation Cap Tests -------------------------------------------------
 
-(deftest correlations-not-capped-when-within-limit-test
+(deftest ^:parallel correlations-not-capped-when-within-limit-test
   (testing "Correlations are computed for all series when count <= max"
     (is (=? {:correlations some?
              :limits (symbol "nil #_\"key is not present.\"")}
             (stats.core/compute-chart-stats (make-chart-config 3 50) {:deep? true})))))
 
-(deftest correlations-capped-when-exceeding-limit-test
+(deftest ^:parallel correlations-capped-when-exceeding-limit-test
   (testing "Correlations are limited to max-series-for-correlations"
     (let [n-series (+ stats.core/max-series-for-correlations 5)
           config   (make-chart-config n-series 50)

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/core_test.clj
@@ -97,4 +97,3 @@
       (let [max-k @#'stats.core/max-series-for-correlations
             max-pairs (/ (* max-k (dec max-k)) 2)]
         (is (<= (count (:correlations stats)) max-pairs))))))
-

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/core_test.clj
@@ -1,9 +1,7 @@
 (ns metabase-enterprise.metabot-v3.stats.core-test
   (:require
-   [clojure.string :as str]
    [clojure.test :refer :all]
-   [metabase-enterprise.metabot-v3.stats.core :as stats.core]
-   [metabase-enterprise.metabot-v3.stats.repr :as repr]))
+   [metabase-enterprise.metabot-v3.stats.core :as stats.core]))
 
 (set! *warn-on-reflection* true)
 
@@ -100,29 +98,3 @@
             max-pairs (/ (* max-k (dec max-k)) 2)]
         (is (<= (count (:correlations stats)) max-pairs))))))
 
-;;; ------------------------------------------ Repr Limits Note Tests ----------------------------------------------
-
-(deftest repr-includes-downsampled-note-test
-  (testing "Representation includes a note about downsampled data"
-    (let [n      (+ stats.core/max-data-points-per-series 1000)
-          config (make-chart-config 1 n)
-          stats  (stats.core/compute-chart-stats config {:deep? false})
-          repr   (repr/generate-representation {:title "Test" :display-type "line" :stats stats})]
-      (is (str/includes? repr "Data Limits Applied"))
-      (is (str/includes? repr "downsampled")))))
-
-(deftest repr-includes-correlations-capped-note-test
-  (testing "Representation includes a note about capped correlations"
-    (let [n-series (+ stats.core/max-series-for-correlations 5)
-          config   (make-chart-config n-series 50)
-          stats    (stats.core/compute-chart-stats config {:deep? true})
-          repr     (repr/generate-representation {:title "Test" :display-type "line" :stats stats})]
-      (is (str/includes? repr "Data Limits Applied"))
-      (is (str/includes? repr "correlations were limited")))))
-
-(deftest repr-no-limits-note-when-within-bounds-test
-  (testing "No limits note when data is within bounds"
-    (let [config (make-chart-config 2 100)
-          stats  (stats.core/compute-chart-stats config {:deep? true})
-          repr   (repr/generate-representation {:title "Test" :display-type "line" :stats stats})]
-      (is (not (str/includes? repr "Data Limits Applied"))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/core_test.clj
@@ -79,7 +79,7 @@
 
 (deftest ^:parallel correlations-not-capped-when-within-limit-test
   (testing "Correlations are computed for all series when count <= max"
-    (is (=? {:correlations some?
+    (is (=? {:correlations #(= 3 (count %))
              :limits (symbol "nil #_\"key is not present.\"")}
             (stats.core/compute-chart-stats (make-chart-config 3 50) {:deep? true})))))
 

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/core_test.clj
@@ -10,8 +10,8 @@
 (defn- make-series
   "Create a series config with n data points."
   [n]
-  {:x {:name "Date" :type :datetime}
-   :y {:name "Value" :type :number}
+  {:x {:name "Date" :type "datetime"}
+   :y {:name "Value" :type "number"}
    :display_name "Test"
    :x_values (mapv #(str "2020-01-" (format "%02d" (inc (mod % 28)))) (range n))
    :y_values (mapv double (range n))})

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/core_test.clj
@@ -27,10 +27,10 @@
 ;;; ------------------------------------------- Downsampling Tests -------------------------------------------------
 
 (defn- approx=max-data-points-per-series?
-  "Is `n` approximately [[stats.core/max-data-points-per-series]]?"
+  "Is `n` approximately [[@#'stats.core/max-data-points-per-series]]?"
   [n]
   ;; random-sample is probabilistic, so allow 20% tolerance
-  (< n (* 1.2 stats.core/max-data-points-per-series)))
+  (< n (* 1.2 @#'stats.core/max-data-points-per-series)))
 
 (deftest ^:parallel data-points-within-limit-are-not-downsampled-test
   (testing "Series within the limit are not modified"
@@ -40,7 +40,7 @@
 
 (deftest ^:parallel data-points-exceeding-limit-are-downsampled-test
   (testing "Series exceeding max-data-points-per-series are downsampled"
-    (let [n      (+ stats.core/max-data-points-per-series 5000)
+    (let [n      (+ @#'stats.core/max-data-points-per-series 5000)
           config (make-chart-config 1 n)
           stats  (stats.core/compute-chart-stats config {:deep? false})
           sampled (get-in stats [:series "series_0" :data_points])]
@@ -48,11 +48,11 @@
               stats))
 
       (is (approx=max-data-points-per-series? sampled)
-          (str "sampled " sampled " should be roughly <= " stats.core/max-data-points-per-series)))))
+          (str "sampled " sampled " should be roughly <= " @#'stats.core/max-data-points-per-series)))))
 
 (deftest ^:parallel downsampling-preserves-first-and-last-points-test
   (testing "Downsampled series preserves the first and last data points"
-    (let [n       (+ stats.core/max-data-points-per-series 1000)
+    (let [n       (+ @#'stats.core/max-data-points-per-series 1000)
           config  (make-chart-config 1 n)
           orig-ys (get-in config [:series "series_0" :y_values])]
       (is (=? {:series {"series_0" {:trend {:start_value (double (first orig-ys))
@@ -62,7 +62,7 @@
 (deftest ^:parallel multiple-series-downsampled-independently-test
   (testing "Each series is downsampled independently, limits tracks each"
     (let [small-n 100
-          large-n (+ stats.core/max-data-points-per-series 2000)
+          large-n (+ @#'stats.core/max-data-points-per-series 2000)
           config  {:display_type "line"
                    :title "Multi"
                    :series {"small" (make-series small-n)
@@ -85,16 +85,16 @@
 
 (deftest ^:parallel correlations-capped-when-exceeding-limit-test
   (testing "Correlations are limited to max-series-for-correlations"
-    (let [n-series (+ stats.core/max-series-for-correlations 5)
+    (let [n-series (+ @#'stats.core/max-series-for-correlations 5)
           config   (make-chart-config n-series 50)
           stats    (stats.core/compute-chart-stats config {:deep? true})]
       (is (=? {:limits       {:correlations_capped {:total_series   n-series
-                                                    :max_correlated stats.core/max-series-for-correlations}}
+                                                    :max_correlated @#'stats.core/max-series-for-correlations}}
                :series       #(= n-series (count %))
                :series_count n-series}
               stats))
       ;; Correlations should have at most C(max-k, 2) entries
-      (let [max-k stats.core/max-series-for-correlations
+      (let [max-k @#'stats.core/max-series-for-correlations
             max-pairs (/ (* max-k (dec max-k)) 2)]
         (is (<= (count (:correlations stats)) max-pairs))))))
 

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/core_test.clj
@@ -1,0 +1,133 @@
+(ns metabase-enterprise.metabot-v3.stats.core-test
+  (:require
+   [clojure.string :as str]
+   [clojure.test :refer :all]
+   [metabase-enterprise.metabot-v3.stats.core :as stats.core]
+   [metabase-enterprise.metabot-v3.stats.repr :as repr]))
+
+(set! *warn-on-reflection* true)
+
+;;; ------------------------------------------------ Helpers -------------------------------------------------------
+
+(defn- make-series
+  "Create a series config with n data points."
+  [n]
+  {:x {:name "Date" :type :datetime}
+   :y {:name "Value" :type :number}
+   :display_name "Test"
+   :x_values (mapv #(str "2020-01-" (format "%02d" (inc (mod % 28)))) (range n))
+   :y_values (mapv double (range n))})
+
+(defn- make-chart-config
+  "Create a chart config with the given number of series, each with n data points."
+  [series-count n]
+  {:display_type "line"
+   :title "Test Chart"
+   :series (into {} (for [i (range series-count)]
+                      [(str "series_" i) (make-series n)]))})
+
+;;; ------------------------------------------- Downsampling Tests -------------------------------------------------
+
+(deftest data-points-within-limit-are-not-downsampled-test
+  (testing "Series within the limit are not modified"
+    (let [config (make-chart-config 1 100)
+          stats  (stats.core/compute-chart-stats config {:deep? false})]
+      (is (nil? (:limits stats)))
+      (is (= 100 (get-in stats [:series "series_0" :data_points]))))))
+
+(deftest data-points-exceeding-limit-are-downsampled-test
+  (testing "Series exceeding max-data-points-per-series are downsampled"
+    (let [n      (+ stats.core/max-data-points-per-series 5000)
+          config (make-chart-config 1 n)
+          stats  (stats.core/compute-chart-stats config {:deep? false})
+          sampled (get-in stats [:series "series_0" :data_points])]
+      (is (some? (:limits stats)))
+      (is (= n (get-in stats [:limits :downsampled_series "series_0" :original_count])))
+      ;; random-sample is probabilistic, so allow 10% tolerance
+      (is (< sampled (* 1.1 stats.core/max-data-points-per-series))
+          (str "sampled " sampled " should be roughly <= " stats.core/max-data-points-per-series)))))
+
+(deftest downsampling-preserves-first-and-last-points-test
+  (testing "Downsampled series preserves the first and last data points"
+    (let [n       (+ stats.core/max-data-points-per-series 1000)
+          config  (make-chart-config 1 n)
+          orig-xs (get-in config [:series "series_0" :x_values])
+          orig-ys (get-in config [:series "series_0" :y_values])]
+      ;; Use the private downsample fn via the stats output: check that trend
+      ;; start_value and end_value match the original first/last y values
+      (let [stats (stats.core/compute-chart-stats config {:deep? false})]
+        (is (= (double (first orig-ys))
+               (get-in stats [:series "series_0" :trend :start_value])))
+        (is (= (double (last orig-ys))
+               (get-in stats [:series "series_0" :trend :end_value])))))))
+
+(deftest multiple-series-downsampled-independently-test
+  (testing "Each series is downsampled independently, limits tracks each"
+    (let [small-n 100
+          large-n (+ stats.core/max-data-points-per-series 2000)
+          config  {:display_type "line"
+                   :title "Multi"
+                   :series {"small" (make-series small-n)
+                            "large" (make-series large-n)}}
+          stats   (stats.core/compute-chart-stats config {:deep? false})]
+      (is (some? (:limits stats)))
+      ;; Only the large series should appear in downsampled_series
+      (is (contains? (get-in stats [:limits :downsampled_series]) "large"))
+      (is (not (contains? (get-in stats [:limits :downsampled_series]) "small")))
+      (is (= small-n (get-in stats [:series "small" :data_points])))
+      (is (< (get-in stats [:series "large" :data_points])
+             (* 1.1 stats.core/max-data-points-per-series))))))
+
+;;; ---------------------------------------- Correlation Cap Tests -------------------------------------------------
+
+(deftest correlations-not-capped-when-within-limit-test
+  (testing "Correlations are computed for all series when count <= max"
+    (let [config (make-chart-config 3 50)
+          stats  (stats.core/compute-chart-stats config {:deep? true})]
+      (is (nil? (get-in stats [:limits :correlations_capped])))
+      ;; 3 series → C(3,2) = 3 pairs possible (some may be skipped if < 10 aligned points)
+      (is (some? (:correlations stats))))))
+
+(deftest correlations-capped-when-exceeding-limit-test
+  (testing "Correlations are limited to max-series-for-correlations"
+    (let [n-series (+ stats.core/max-series-for-correlations 5)
+          config   (make-chart-config n-series 50)
+          stats    (stats.core/compute-chart-stats config {:deep? true})]
+      (is (some? (get-in stats [:limits :correlations_capped])))
+      (is (= n-series (get-in stats [:limits :correlations_capped :total_series])))
+      (is (= stats.core/max-series-for-correlations
+             (get-in stats [:limits :correlations_capped :max_correlated])))
+      ;; All series should still have stats computed (only correlations are capped)
+      (is (= n-series (:series_count stats)))
+      (is (= n-series (count (:series stats))))
+      ;; Correlations should have at most C(max-k, 2) entries
+      (let [max-k stats.core/max-series-for-correlations
+            max-pairs (/ (* max-k (dec max-k)) 2)]
+        (is (<= (count (:correlations stats)) max-pairs))))))
+
+;;; ------------------------------------------ Repr Limits Note Tests ----------------------------------------------
+
+(deftest repr-includes-downsampled-note-test
+  (testing "Representation includes a note about downsampled data"
+    (let [n      (+ stats.core/max-data-points-per-series 1000)
+          config (make-chart-config 1 n)
+          stats  (stats.core/compute-chart-stats config {:deep? false})
+          repr   (repr/generate-representation {:title "Test" :display-type "line" :stats stats})]
+      (is (str/includes? repr "Data Limits Applied"))
+      (is (str/includes? repr "downsampled")))))
+
+(deftest repr-includes-correlations-capped-note-test
+  (testing "Representation includes a note about capped correlations"
+    (let [n-series (+ stats.core/max-series-for-correlations 5)
+          config   (make-chart-config n-series 50)
+          stats    (stats.core/compute-chart-stats config {:deep? true})
+          repr     (repr/generate-representation {:title "Test" :display-type "line" :stats stats})]
+      (is (str/includes? repr "Data Limits Applied"))
+      (is (str/includes? repr "correlations were limited")))))
+
+(deftest repr-no-limits-note-when-within-bounds-test
+  (testing "No limits note when data is within bounds"
+    (let [config (make-chart-config 2 100)
+          stats  (stats.core/compute-chart-stats config {:deep? true})
+          repr   (repr/generate-representation {:title "Test" :display-type "line" :stats stats})]
+      (is (not (str/includes? repr "Data Limits Applied"))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/histogram_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/histogram_test.clj
@@ -1,6 +1,7 @@
 (ns metabase-enterprise.metabot-v3.stats.histogram-test
   (:require
    [clojure.test :refer :all]
+   [mb.hawk.assert-exprs.approximately-equal :as =?]
    [metabase-enterprise.metabot-v3.stats.histogram :as histogram]))
 
 (set! *warn-on-reflection* true)
@@ -8,7 +9,8 @@
 (deftest ^:parallel compute-series-stats-empty-test
   (testing "empty values returns zero counts"
     (is (=? {:data_points  0
-             :distribution some?}
+             :distribution {:percentiles empty?
+                            :quartiles {:q1 0 :median 0 :q3 0 :iqr 0}}}
             (#'histogram/compute-series-stats [])))))
 
 (deftest ^:parallel compute-series-stats-nil-filtered-test
@@ -26,7 +28,8 @@
 (deftest ^:parallel compute-series-stats-enough-points-has-shape-test
   (testing ">= 8 values produces skewness and kurtosis"
     (is (=? {:data_points  8
-             :distribution {:skewness some? :kurtosis some?}}
+             :distribution {:skewness 0.0
+                            :kurtosis (=?/approx [-1.2 0.001])}}
             (#'histogram/compute-series-stats [1 2 3 4 5 6 7 8])))))
 
 (deftest ^:parallel compute-series-stats-symmetric-skewness-test
@@ -54,8 +57,8 @@
           result (#'histogram/compute-series-stats values)
           p50 (get-in result [:distribution :percentiles 50])
           median (:median (:summary result))]
-      (is (some? p50))
-      (is (< (Math/abs (- (double p50) (double median))) 0.01)))))
+      (is (= 6.0 p50))
+      (is (= p50 median)))))
 
 (deftest ^:parallel compute-series-stats-iqr-test
   (testing "IQR = Q3 - Q1"
@@ -66,21 +69,30 @@
 
 (deftest ^:parallel compute-histogram-stats-multi-series-test
   (testing "per-series structure with correct chart_type"
-    (let [series-data {"Bins" {:x_values [0 1 2 3 4] :y_values [5 10 20 10 5]
+    (let [series-data {"Bins" {:x_values [0 1 2 3 4]
+                               :y_values [5 10 20 10 5]
                                :x {:name "bin" :type :number}
                                :y {:name "count" :type :number}
                                :display_name "Bins"}}]
       (is (=? {:chart_type   :histogram
                :series_count 1
                :series       {"Bins" {:data_points  5
-                                      :summary      some?
-                                      :distribution some?}}}
+                                      :summary      {:min 5.0
+                                                     :max 20.0
+                                                     :mean 10.0}
+                                      :distribution {:quartiles {:q1 5.0
+                                                                 :q3 15.0
+                                                                 :iqr 10.0}}}}}
               (histogram/compute-histogram-stats series-data {}))))))
 
 (deftest ^:parallel compute-series-stats-all-nil-test
   (testing "all-nil values returns zero data_points"
     (is (=? {:data_points  0
-             :distribution some?}
+             :distribution {:percentiles empty?
+                            :quartiles {:q1 0
+                                        :median 0
+                                        :q3 0
+                                        :iqr 0}}}
             (#'histogram/compute-series-stats [nil nil nil])))))
 
 (deftest ^:parallel compute-series-stats-all-percentiles-present-test
@@ -102,8 +114,7 @@
   (testing "uniform distribution has negative excess kurtosis"
     (let [result (#'histogram/compute-series-stats (range 1 101))
           kurtosis (get-in result [:distribution :kurtosis])]
-      (is (some? kurtosis))
-      (is (< (double kurtosis) 0)))))
+      (is (== -1.2 kurtosis)))))
 
 (deftest ^:parallel compute-series-stats-single-value-test
   (testing "single value: min = max = mean"

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/histogram_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/histogram_test.clj
@@ -9,49 +9,49 @@
   (testing "empty values returns zero counts"
     (is (=? {:data_points  0
              :distribution some?}
-            (histogram/compute-series-stats [])))))
+            (#'histogram/compute-series-stats [])))))
 
 (deftest ^:parallel compute-series-stats-nil-filtered-test
   (testing "nil values are filtered out"
     (is (=? {:data_points 3}
-            (histogram/compute-series-stats [10 nil 20 nil 30])))))
+            (#'histogram/compute-series-stats [10 nil 20 nil 30])))))
 
 (deftest ^:parallel compute-series-stats-few-points-no-shape-test
   (testing "< 8 values produces no skewness or kurtosis"
     (is (=? {:data_points  7
              :distribution {:skewness (symbol "nil #_\"key is not present.\"")
                             :kurtosis (symbol "nil #_\"key is not present.\"")}}
-            (histogram/compute-series-stats [1 2 3 4 5 6 7])))))
+            (#'histogram/compute-series-stats [1 2 3 4 5 6 7])))))
 
 (deftest ^:parallel compute-series-stats-enough-points-has-shape-test
   (testing ">= 8 values produces skewness and kurtosis"
     (is (=? {:data_points  8
              :distribution {:skewness some? :kurtosis some?}}
-            (histogram/compute-series-stats [1 2 3 4 5 6 7 8])))))
+            (#'histogram/compute-series-stats [1 2 3 4 5 6 7 8])))))
 
 (deftest ^:parallel compute-series-stats-symmetric-skewness-test
   (testing "symmetric data has near-zero skewness"
     (is (=? {:distribution {:skewness #(< (Math/abs (double %)) 0.5)}}
             ;; perfectly symmetric: [1 2 3 4 5 6 7 8 9 10]
-            (histogram/compute-series-stats (range 1 11))))))
+            (#'histogram/compute-series-stats (range 1 11))))))
 
 (deftest ^:parallel compute-series-stats-right-skewed-test
   (testing "right-skewed data has positive skewness > 0.5"
     (is (=? {:distribution {:skewness #(> (double %) 0.5)}}
             ;; right skew: many small values, few large
-            (histogram/compute-series-stats [1 1 1 1 1 2 2 2 3 4 5 100])))))
+            (#'histogram/compute-series-stats [1 1 1 1 1 2 2 2 3 4 5 100])))))
 
 (deftest ^:parallel compute-series-stats-left-skewed-test
   (testing "left-skewed data has negative skewness < -0.5"
     (is (=? {:distribution {:skewness #(< (double %) -0.5)}}
             ;; left skew: many large values, few small
-            (histogram/compute-series-stats [1 99 99 99 100 100 100 100 100 100 100 100])))))
+            (#'histogram/compute-series-stats [1 99 99 99 100 100 100 100 100 100 100 100])))))
 
 (deftest ^:parallel compute-series-stats-percentiles-test
   (testing "P50 matches median from summary"
     ;; Use odd-length data so median is unambiguous (no interpolation difference)
     (let [values (range 1 12)
-          result (histogram/compute-series-stats values)
+          result (#'histogram/compute-series-stats values)
           p50 (get-in result [:distribution :percentiles 50])
           median (:median (:summary result))]
       (is (some? p50))
@@ -59,7 +59,7 @@
 
 (deftest ^:parallel compute-series-stats-iqr-test
   (testing "IQR = Q3 - Q1"
-    (let [result (histogram/compute-series-stats (range 1 11))
+    (let [result (#'histogram/compute-series-stats (range 1 11))
           quartiles (get-in result [:distribution :quartiles])
           {:keys [q1 q3 iqr]} quartiles]
       (is (< (Math/abs (- (double iqr) (- (double q3) (double q1)))) 0.001)))))
@@ -81,11 +81,11 @@
   (testing "all-nil values returns zero data_points"
     (is (=? {:data_points  0
              :distribution some?}
-            (histogram/compute-series-stats [nil nil nil])))))
+            (#'histogram/compute-series-stats [nil nil nil])))))
 
 (deftest ^:parallel compute-series-stats-all-percentiles-present-test
   (testing "all six percentiles (25,50,75,90,95,99) are computed"
-    (let [result (histogram/compute-series-stats (range 1 101))
+    (let [result (#'histogram/compute-series-stats (range 1 101))
           pcts   (get-in result [:distribution :percentiles])]
       (is (contains? pcts 25))
       (is (contains? pcts 50))
@@ -100,7 +100,7 @@
 
 (deftest ^:parallel compute-series-stats-uniform-kurtosis-test
   (testing "uniform distribution has negative excess kurtosis"
-    (let [result (histogram/compute-series-stats (range 1 101))
+    (let [result (#'histogram/compute-series-stats (range 1 101))
           kurtosis (get-in result [:distribution :kurtosis])]
       (is (some? kurtosis))
       (is (< (double kurtosis) 0)))))
@@ -109,21 +109,21 @@
   (testing "single value: min = max = mean"
     (is (=? {:data_points 1
              :summary     {:min 42.0 :max 42.0 :mean 42.0}}
-            (histogram/compute-series-stats [42])))))
+            (#'histogram/compute-series-stats [42])))))
 
 (deftest ^:parallel compute-series-stats-all-same-values-test
   (testing "all identical values: std_dev = 0"
     (is (=? {:data_points 10
              :summary     {:min 50.0 :max 50.0 :std_dev 0.0}}
-            (histogram/compute-series-stats [50 50 50 50 50 50 50 50 50 50])))))
+            (#'histogram/compute-series-stats [50 50 50 50 50 50 50 50 50 50])))))
 
 (deftest ^:parallel compute-series-stats-float-values-test
   (testing "float values handled correctly"
     (is (=? {:data_points 5
              :summary     {:min 1.5 :max 5.5}}
-            (histogram/compute-series-stats [1.5 2.5 3.5 4.5 5.5])))))
+            (#'histogram/compute-series-stats [1.5 2.5 3.5 4.5 5.5])))))
 
 (deftest ^:parallel compute-series-stats-negative-values-test
   (testing "negative values handled correctly"
     (is (=? {:summary {:min -50.0 :max 50.0 :mean 0.0}}
-            (histogram/compute-series-stats [-50 -25 0 25 50])))))
+            (#'histogram/compute-series-stats [-50 -25 0 25 50])))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/histogram_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/histogram_test.clj
@@ -82,7 +82,7 @@
           p50    (get-in result [:distribution :estimated_percentiles 50])
           wmean  (get-in result [:estimated_summary :weighted_mean])]
       ;; For symmetric binned data, P50 should be reasonably close to the mean
-      (is (< (Math/abs (- p50 wmean)) 10.0)))))
+      (is (< (Math/abs (double (- p50 wmean))) 10.0)))))
 
 (deftest ^:parallel estimated-quartiles-iqr-test
   (testing "IQR = Q3 - Q1"

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/histogram_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/histogram_test.clj
@@ -1,9 +1,7 @@
 (ns metabase-enterprise.metabot-v3.stats.histogram-test
   (:require
-   [clojure.string :as str]
    [clojure.test :refer :all]
-   [metabase-enterprise.metabot-v3.stats.histogram :as histogram]
-   [metabase-enterprise.metabot-v3.stats.repr :as repr]))
+   [metabase-enterprise.metabot-v3.stats.histogram :as histogram]))
 
 (set! *warn-on-reflection* true)
 
@@ -129,13 +127,3 @@
   (testing "negative values handled correctly"
     (is (=? {:summary {:min -50.0 :max 50.0 :mean 0.0}}
             (histogram/compute-series-stats [-50 -25 0 25 50])))))
-
-(deftest repr-histogram-shows-shape-test
-  (testing "representation includes Distribution Shape when enough data"
-    (let [series-stats (histogram/compute-series-stats (range 1 101))
-          stats        {:chart_type   :histogram
-                        :series_count 1
-                        :series       {"Test Series" series-stats}}
-          rep          (repr/generate-histogram-representation {:stats stats})]
-      (is (str/includes? rep "Test Series"))
-      (is (str/includes? rep "Distribution Shape")))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/histogram_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/histogram_test.clj
@@ -6,135 +6,194 @@
 
 (set! *warn-on-reflection* true)
 
+;;; ----------------------------------------------- Empty / Edge Cases ------------------------------------------------
+
 (deftest ^:parallel compute-series-stats-empty-test
   (testing "empty values returns zero counts"
-    (is (=? {:data_points  0
-             :distribution {:percentiles empty?
-                            :quartiles {:q1 0 :median 0 :q3 0 :iqr 0}}}
+    (is (=? {:data_points   0
+             :total_count   0
+             :distribution  {:estimated_percentiles empty?
+                             :estimated_quartiles   {:q1 0 :median 0 :q3 0 :iqr 0}}
+             :structure     {:mode_bin nil :peak_count 0 :bin_count 0}}
             (#'histogram/compute-series-stats [])))))
+
+(deftest ^:parallel compute-series-stats-all-nil-test
+  (testing "all-nil values returns zero data_points"
+    (is (=? {:data_points   0
+             :total_count   0
+             :distribution  {:estimated_percentiles empty?
+                             :estimated_quartiles   {:q1 0 :median 0 :q3 0 :iqr 0}}}
+            (#'histogram/compute-series-stats [nil nil nil])))))
 
 (deftest ^:parallel compute-series-stats-nil-filtered-test
   (testing "nil values are filtered out"
     (is (=? {:data_points 3}
-            (#'histogram/compute-series-stats [10 nil 20 nil 30])))))
+            (#'histogram/compute-series-stats [0 1 2 3 4] [10 nil 20 nil 30])))))
 
-(deftest ^:parallel compute-series-stats-few-points-no-shape-test
-  (testing "< 8 values produces no skewness or kurtosis"
-    (is (=? {:data_points  7
-             :distribution {:skewness (symbol "nil #_\"key is not present.\"")
-                            :kurtosis (symbol "nil #_\"key is not present.\"")}}
-            (#'histogram/compute-series-stats [1 2 3 4 5 6 7])))))
+;;; ------------------------------------------- Weighted Summary Stats ------------------------------------------------
 
-(deftest ^:parallel compute-series-stats-enough-points-has-shape-test
-  (testing ">= 8 values produces skewness and kurtosis"
-    (is (=? {:data_points  8
-             :distribution {:skewness 0.0
-                            :kurtosis (=?/approx [-1.2 0.001])}}
-            (#'histogram/compute-series-stats [1 2 3 4 5 6 7 8])))))
+(deftest ^:parallel weighted-mean-test
+  (testing "weighted mean for symmetric histogram centered at 20"
+    ;; bins at 0,10,20,30,40 with counts 5,10,20,10,5 → weighted mean = 20
+    (is (=? {:estimated_summary {:weighted_mean (=?/approx [20.0 0.001])}}
+            (#'histogram/compute-series-stats [0 10 20 30 40] [5 10 20 10 5])))))
 
-(deftest ^:parallel compute-series-stats-symmetric-skewness-test
-  (testing "symmetric data has near-zero skewness"
-    (is (=? {:distribution {:skewness #(< (Math/abs (double %)) 0.5)}}
-            ;; perfectly symmetric: [1 2 3 4 5 6 7 8 9 10]
-            (#'histogram/compute-series-stats (range 1 11))))))
+(deftest ^:parallel weighted-std-dev-test
+  (testing "weighted std dev for known data"
+    ;; variance = Σ(c*(x-20)²)/50 = (5*400+10*100+0+10*100+5*400)/50 = 120
+    ;; std = √120 ≈ 10.954
+    (is (=? {:estimated_summary {:weighted_std_dev (=?/approx [10.954 0.01])}}
+            (#'histogram/compute-series-stats [0 10 20 30 40] [5 10 20 10 5])))))
 
-(deftest ^:parallel compute-series-stats-right-skewed-test
-  (testing "right-skewed data has positive skewness > 0.5"
-    (is (=? {:distribution {:skewness #(> (double %) 0.5)}}
-            ;; right skew: many small values, few large
-            (#'histogram/compute-series-stats [1 1 1 1 1 2 2 2 3 4 5 100])))))
+(deftest ^:parallel data-range-test
+  (testing "data range is max_x - min_x"
+    (is (=? {:estimated_summary {:data_range 40.0}}
+            (#'histogram/compute-series-stats [0 10 20 30 40] [5 10 20 10 5])))))
 
-(deftest ^:parallel compute-series-stats-left-skewed-test
-  (testing "left-skewed data has negative skewness < -0.5"
-    (is (=? {:distribution {:skewness #(< (double %) -0.5)}}
-            ;; left skew: many large values, few small
-            (#'histogram/compute-series-stats [1 99 99 99 100 100 100 100 100 100 100 100])))))
+(deftest ^:parallel total-count-test
+  (testing "total_count is sum of all counts"
+    (is (=? {:total_count 50}
+            (#'histogram/compute-series-stats [0 10 20 30 40] [5 10 20 10 5])))))
 
-(deftest ^:parallel compute-series-stats-percentiles-test
-  (testing "P50 matches median from summary"
-    ;; Use odd-length data so median is unambiguous (no interpolation difference)
-    (let [values (range 1 12)
-          result (#'histogram/compute-series-stats values)
-          p50 (get-in result [:distribution :percentiles 50])
-          median (:median (:summary result))]
-      (is (= 6.0 p50))
-      (is (= p50 median)))))
+;;; ----------------------------------------- Estimated Percentiles ---------------------------------------------------
 
-(deftest ^:parallel compute-series-stats-iqr-test
+(deftest ^:parallel estimated-percentiles-present-test
+  (testing "all six percentiles (25,50,75,90,95,99) are computed"
+    (let [result (#'histogram/compute-series-stats [0 10 20 30 40] [5 10 20 10 5])
+          pcts   (get-in result [:distribution :estimated_percentiles])]
+      (is (contains? pcts 25))
+      (is (contains? pcts 50))
+      (is (contains? pcts 75))
+      (is (contains? pcts 90))
+      (is (contains? pcts 95))
+      (is (contains? pcts 99)))))
+
+(deftest ^:parallel estimated-percentiles-ascending-test
+  (testing "percentile values are in ascending order"
+    (let [pcts (get-in (#'histogram/compute-series-stats [0 10 20 30 40] [5 10 20 10 5])
+                       [:distribution :estimated_percentiles])]
+      (is (<= (get pcts 25) (get pcts 50)))
+      (is (<= (get pcts 50) (get pcts 75)))
+      (is (<= (get pcts 75) (get pcts 90))))))
+
+(deftest ^:parallel estimated-percentiles-symmetric-test
+  (testing "P50 is close to weighted mean for symmetric distribution"
+    (let [result (#'histogram/compute-series-stats [0 10 20 30 40] [5 10 20 10 5])
+          p50    (get-in result [:distribution :estimated_percentiles 50])
+          wmean  (get-in result [:estimated_summary :weighted_mean])]
+      ;; For symmetric binned data, P50 should be reasonably close to the mean
+      (is (< (Math/abs (- p50 wmean)) 10.0)))))
+
+(deftest ^:parallel estimated-quartiles-iqr-test
   (testing "IQR = Q3 - Q1"
-    (let [result (#'histogram/compute-series-stats (range 1 11))
-          quartiles (get-in result [:distribution :quartiles])
+    (let [quartiles (get-in (#'histogram/compute-series-stats [0 10 20 30 40] [5 10 20 10 5])
+                            [:distribution :estimated_quartiles])
           {:keys [q1 q3 iqr]} quartiles]
       (is (< (Math/abs (- (double iqr) (- (double q3) (double q1)))) 0.001)))))
 
+;;; --------------------------------------------- Weighted Skewness/Kurtosis ------------------------------------------
+
+(deftest ^:parallel no-shape-metrics-few-bins-test
+  (testing "< 8 bins produces no weighted_skewness or weighted_kurtosis"
+    (is (=? {:data_points  5
+             :distribution {:weighted_skewness (symbol "nil #_\"key is not present.\"")
+                            :weighted_kurtosis (symbol "nil #_\"key is not present.\"")}}
+            (#'histogram/compute-series-stats [0 10 20 30 40] [5 10 20 10 5])))))
+
+(deftest ^:parallel shape-metrics-enough-bins-test
+  (testing ">= 8 bins produces weighted_skewness and weighted_kurtosis"
+    (let [xs (range 0 80 10)
+          ys [2 5 10 20 20 10 5 2]]
+      (is (=? {:data_points  8
+               :distribution {:weighted_skewness number?
+                              :weighted_kurtosis number?}}
+              (#'histogram/compute-series-stats xs ys))))))
+
+(deftest ^:parallel symmetric-distribution-skewness-test
+  (testing "symmetric distribution has near-zero weighted skewness"
+    (let [xs (range 0 100 10)
+          ys [1 3 8 15 25 25 15 8 3 1]]
+      (is (=? {:distribution {:weighted_skewness #(< (Math/abs (double %)) 0.1)}}
+              (#'histogram/compute-series-stats xs ys))))))
+
+(deftest ^:parallel right-skewed-distribution-test
+  (testing "right-skewed distribution has positive weighted skewness"
+    (let [xs (range 0 100 10)
+          ys [30 20 15 10 8 5 3 2 1 1]]
+      (is (=? {:distribution {:weighted_skewness #(> (double %) 0.3)}}
+              (#'histogram/compute-series-stats xs ys))))))
+
+(deftest ^:parallel left-skewed-distribution-test
+  (testing "left-skewed distribution has negative weighted skewness"
+    (let [xs (range 0 100 10)
+          ys [1 1 2 3 5 8 10 15 20 30]]
+      (is (=? {:distribution {:weighted_skewness #(< (double %) -0.3)}}
+              (#'histogram/compute-series-stats xs ys))))))
+
+;;; ------------------------------------------- Structural Metrics ----------------------------------------------------
+
+(deftest ^:parallel mode-bin-test
+  (testing "mode_bin is the bin with the highest count"
+    (is (=? {:structure {:mode_bin [20.0 20.0]}}
+            (#'histogram/compute-series-stats [0 10 20 30 40] [5 10 20 10 5])))))
+
+(deftest ^:parallel unimodal-peak-count-test
+  (testing "unimodal histogram has peak_count = 1"
+    (is (=? {:structure {:peak_count 1}}
+            (#'histogram/compute-series-stats [0 10 20 30 40] [5 10 20 10 5])))))
+
+(deftest ^:parallel bimodal-peak-count-test
+  (testing "bimodal histogram has peak_count = 2"
+    (is (=? {:structure {:peak_count 2}}
+            (#'histogram/compute-series-stats [0 10 20 30 40] [15 5 2 5 15])))))
+
+(deftest ^:parallel concentration-top3-test
+  (testing "concentration_top3 gives fraction of data in top 3 bins"
+    ;; top 3 counts: 20, 10, 10 = 40 out of 50 = 0.8
+    (is (=? {:structure {:concentration_top3 (=?/approx [0.8 0.001])}}
+            (#'histogram/compute-series-stats [0 10 20 30 40] [5 10 20 10 5])))))
+
+(deftest ^:parallel gap-count-test
+  (testing "gaps are counted between non-zero bins"
+    (is (=? {:structure {:gap_count 3}}
+            (#'histogram/compute-series-stats [0 10 20 30 40] [10 0 0 0 10])))))
+
+(deftest ^:parallel no-gaps-test
+  (testing "no gaps when all bins are non-zero"
+    (is (=? {:structure {:gap_count 0}}
+            (#'histogram/compute-series-stats [0 10 20 30 40] [5 10 20 10 5])))))
+
+(deftest ^:parallel empty-bin-ratio-test
+  (testing "empty_bin_ratio tracks fraction of zero-count bins"
+    (is (=? {:structure {:empty_bin_ratio (=?/approx [0.6 0.001])}}
+            (#'histogram/compute-series-stats [0 10 20 30 40] [10 0 0 0 10])))))
+
+;;; ---------------------------------------- Full Integration Test ----------------------------------------------------
+
 (deftest ^:parallel compute-histogram-stats-multi-series-test
   (testing "per-series structure with correct chart_type"
-    (let [series-data {"Bins" {:x_values [0 1 2 3 4]
+    (let [series-data {"Bins" {:x_values [0 10 20 30 40]
                                :y_values [5 10 20 10 5]
                                :x {:name "bin" :type "number"}
                                :y {:name "count" :type "number"}
                                :display_name "Bins"}}]
       (is (=? {:chart_type   :histogram
                :series_count 1
-               :series       {"Bins" {:data_points  5
-                                      :summary      {:min 5.0
-                                                     :max 20.0
-                                                     :mean 10.0}
-                                      :distribution {:quartiles {:q1 5.0
-                                                                 :q3 15.0
-                                                                 :iqr 10.0}}}}}
+               :series       {"Bins" {:data_points       5
+                                      :total_count       50
+                                      :estimated_summary {:weighted_mean (=?/approx [20.0 0.001])}
+                                      :distribution      {:estimated_quartiles {:q1 number?
+                                                                                :q3 number?
+                                                                                :iqr number?}}
+                                      :structure         {:mode_bin [20.0 20.0]
+                                                          :peak_count 1
+                                                          :bin_count 5}}}}
               (histogram/compute-histogram-stats series-data {}))))))
 
-(deftest ^:parallel compute-series-stats-all-nil-test
-  (testing "all-nil values returns zero data_points"
-    (is (=? {:data_points  0
-             :distribution {:percentiles empty?
-                            :quartiles {:q1 0
-                                        :median 0
-                                        :q3 0
-                                        :iqr 0}}}
-            (#'histogram/compute-series-stats [nil nil nil])))))
-
-(deftest ^:parallel compute-series-stats-all-percentiles-present-test
-  (testing "all six percentiles (25,50,75,90,95,99) are computed"
-    (let [result (#'histogram/compute-series-stats (range 1 101))
-          pcts   (get-in result [:distribution :percentiles])]
-      (is (contains? pcts 25))
-      (is (contains? pcts 50))
-      (is (contains? pcts 75))
-      (is (contains? pcts 90))
-      (is (contains? pcts 95))
-      (is (contains? pcts 99))
-      ;; Values should be in ascending order
-      (is (< (get pcts 25) (get pcts 50)))
-      (is (< (get pcts 50) (get pcts 75)))
-      (is (< (get pcts 75) (get pcts 90))))))
-
-(deftest ^:parallel compute-series-stats-uniform-kurtosis-test
-  (testing "uniform distribution has negative excess kurtosis"
-    (let [result (#'histogram/compute-series-stats (range 1 101))
-          kurtosis (get-in result [:distribution :kurtosis])]
-      (is (== -1.2 kurtosis)))))
-
-(deftest ^:parallel compute-series-stats-single-value-test
-  (testing "single value: min = max = mean"
-    (is (=? {:data_points 1
-             :summary     {:min 42.0 :max 42.0 :mean 42.0}}
-            (#'histogram/compute-series-stats [42])))))
-
-(deftest ^:parallel compute-series-stats-all-same-values-test
-  (testing "all identical values: std_dev = 0"
-    (is (=? {:data_points 10
-             :summary     {:min 50.0 :max 50.0 :std_dev 0.0}}
-            (#'histogram/compute-series-stats [50 50 50 50 50 50 50 50 50 50])))))
-
-(deftest ^:parallel compute-series-stats-float-values-test
-  (testing "float values handled correctly"
-    (is (=? {:data_points 5
-             :summary     {:min 1.5 :max 5.5}}
-            (#'histogram/compute-series-stats [1.5 2.5 3.5 4.5 5.5])))))
-
-(deftest ^:parallel compute-series-stats-negative-values-test
-  (testing "negative values handled correctly"
-    (is (=? {:summary {:min -50.0 :max 50.0 :mean 0.0}}
-            (#'histogram/compute-series-stats [-50 -25 0 25 50])))))
+(deftest ^:parallel single-arity-uses-indices-test
+  (testing "single-arity form uses sequential indices as x_values"
+    (let [result (#'histogram/compute-series-stats [10 20 30])]
+      (is (=? {:data_points       3
+               :total_count       60
+               :estimated_summary {:weighted_mean (=?/approx [1.333 0.01])}}
+              result)))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/histogram_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/histogram_test.clj
@@ -1,0 +1,170 @@
+(ns metabase-enterprise.metabot-v3.stats.histogram-test
+  (:require
+   [clojure.string :as str]
+   [clojure.test :refer :all]
+   [metabase-enterprise.metabot-v3.stats.histogram :as histogram]
+   [metabase-enterprise.metabot-v3.stats.repr :as repr]))
+
+(set! *warn-on-reflection* true)
+
+(deftest compute-series-stats-empty-test
+  (testing "empty values returns zero counts without crashing"
+    (let [result (histogram/compute-series-stats [])]
+      (is (= 0 (:data_points result)))
+      (is (some? (:distribution result))))))
+
+(deftest compute-series-stats-nil-filtered-test
+  (testing "nil values are filtered out"
+    (let [result (histogram/compute-series-stats [10 nil 20 nil 30])]
+      (is (= 3 (:data_points result))))))
+
+(deftest compute-series-stats-few-points-no-shape-test
+  (testing "< 8 values produces no skewness or kurtosis"
+    (let [result (histogram/compute-series-stats [1 2 3 4 5 6 7])]
+      (is (= 7 (:data_points result)))
+      (is (nil? (get-in result [:distribution :skewness])))
+      (is (nil? (get-in result [:distribution :kurtosis]))))))
+
+(deftest compute-series-stats-enough-points-has-shape-test
+  (testing ">= 8 values produces skewness and kurtosis"
+    (let [result (histogram/compute-series-stats [1 2 3 4 5 6 7 8])]
+      (is (= 8 (:data_points result)))
+      (is (some? (get-in result [:distribution :skewness])))
+      (is (some? (get-in result [:distribution :kurtosis]))))))
+
+(deftest compute-series-stats-symmetric-skewness-test
+  (testing "symmetric data has near-zero skewness"
+    (let [;; perfectly symmetric: [1 2 3 4 5 6 7 8 9 10]
+          result (histogram/compute-series-stats (range 1 11))
+          skewness (get-in result [:distribution :skewness])]
+      (is (some? skewness))
+      (is (< (Math/abs (double skewness)) 0.5) "should be approximately symmetric"))))
+
+(deftest compute-series-stats-right-skewed-test
+  (testing "right-skewed data has positive skewness > 0.5"
+    (let [;; right skew: many small values, few large
+          values [1 1 1 1 1 2 2 2 3 4 5 100]
+          result (histogram/compute-series-stats values)
+          skewness (get-in result [:distribution :skewness])]
+      (is (some? skewness))
+      (is (> (double skewness) 0.5)))))
+
+(deftest compute-series-stats-left-skewed-test
+  (testing "left-skewed data has negative skewness < -0.5"
+    (let [;; left skew: many large values, few small
+          values [1 99 99 99 100 100 100 100 100 100 100 100]
+          result (histogram/compute-series-stats values)
+          skewness (get-in result [:distribution :skewness])]
+      (is (some? skewness))
+      (is (< (double skewness) -0.5)))))
+
+(deftest compute-series-stats-percentiles-test
+  (testing "P50 matches median from summary"
+    ;; Use odd-length data so median is unambiguous (no interpolation difference)
+    (let [values (range 1 12)
+          result (histogram/compute-series-stats values)
+          p50 (get-in result [:distribution :percentiles 50])
+          median (:median (:summary result))]
+      (is (some? p50))
+      (is (< (Math/abs (- (double p50) (double median))) 0.01)))))
+
+(deftest compute-series-stats-iqr-test
+  (testing "IQR = Q3 - Q1"
+    (let [result (histogram/compute-series-stats (range 1 11))
+          quartiles (get-in result [:distribution :quartiles])
+          {:keys [q1 q3 iqr]} quartiles]
+      (is (< (Math/abs (- (double iqr) (- (double q3) (double q1)))) 0.001)))))
+
+(deftest compute-histogram-stats-multi-series-test
+  (testing "per-series structure with correct chart_type"
+    (let [series-data {"Bins" {:x_values [0 1 2 3 4] :y_values [5 10 20 10 5]
+                               :x {:name "bin" :type :number}
+                               :y {:name "count" :type :number}
+                               :display_name "Bins"}}
+          result (histogram/compute-histogram-stats series-data {})]
+      (is (= :histogram (:chart_type result)))
+      (is (= 1 (:series_count result)))
+      (is (contains? (:series result) "Bins"))
+      (let [s (get-in result [:series "Bins"])]
+        (is (= 5 (:data_points s)))
+        (is (some? (:summary s)))
+        (is (some? (:distribution s)))))))
+
+(deftest compute-series-stats-all-nil-test
+  (testing "all-nil values returns zero data_points"
+    (let [result (histogram/compute-series-stats [nil nil nil])]
+      (is (= 0 (:data_points result)))
+      (is (some? (:distribution result))))))
+
+(deftest compute-series-stats-all-percentiles-present-test
+  (testing "all six percentiles (25,50,75,90,95,99) are computed"
+    (let [result (histogram/compute-series-stats (range 1 101))
+          pcts   (get-in result [:distribution :percentiles])]
+      (is (contains? pcts 25))
+      (is (contains? pcts 50))
+      (is (contains? pcts 75))
+      (is (contains? pcts 90))
+      (is (contains? pcts 95))
+      (is (contains? pcts 99))
+      ;; Values should be in ascending order
+      (is (< (get pcts 25) (get pcts 50)))
+      (is (< (get pcts 50) (get pcts 75)))
+      (is (< (get pcts 75) (get pcts 90))))))
+
+(deftest compute-series-stats-uniform-kurtosis-test
+  (testing "uniform distribution has negative excess kurtosis"
+    (let [result  (histogram/compute-series-stats (range 1 101))
+          kurtosis (get-in result [:distribution :kurtosis])]
+      (is (some? kurtosis))
+      (is (< (double kurtosis) 0)))))
+
+(deftest compute-series-stats-no-outliers-field-test
+  (testing "histogram stats do not include an outliers field"
+    ;; Histograms show distribution, not individual point anomalies
+    (let [result (histogram/compute-series-stats [10 20 30 40 50 1000])]
+      (is (not (contains? result :outliers))))))
+
+(deftest compute-series-stats-single-value-test
+  (testing "single value: min = max = mean"
+    (let [result (histogram/compute-series-stats [42])
+          s      (:summary result)]
+      (is (= 1 (:data_points result)))
+      (is (some? s))
+      (is (= 42.0 (:min s)))
+      (is (= 42.0 (:max s)))
+      (is (= 42.0 (:mean s))))))
+
+(deftest compute-series-stats-all-same-values-test
+  (testing "all identical values: std_dev = 0"
+    (let [result (histogram/compute-series-stats [50 50 50 50 50 50 50 50 50 50])
+          s      (:summary result)]
+      (is (= 10 (:data_points result)))
+      (is (= 50.0 (:min s)))
+      (is (= 50.0 (:max s)))
+      (is (= 0.0 (:std_dev s))))))
+
+(deftest compute-series-stats-float-values-test
+  (testing "float values handled correctly"
+    (let [result (histogram/compute-series-stats [1.5 2.5 3.5 4.5 5.5])
+          s      (:summary result)]
+      (is (= 5 (:data_points result)))
+      (is (< (Math/abs (- (:min s) 1.5)) 0.001))
+      (is (< (Math/abs (- (:max s) 5.5)) 0.001)))))
+
+(deftest compute-series-stats-negative-values-test
+  (testing "negative values handled correctly"
+    (let [result (histogram/compute-series-stats [-50 -25 0 25 50])
+          s      (:summary result)]
+      (is (= -50.0 (:min s)))
+      (is (= 50.0 (:max s)))
+      (is (= 0.0 (:mean s))))))
+
+(deftest repr-histogram-shows-shape-test
+  (testing "representation includes Distribution Shape when enough data"
+    (let [series-stats (histogram/compute-series-stats (range 1 101))
+          stats        {:chart_type   :histogram
+                        :series_count 1
+                        :series       {"Test Series" series-stats}}
+          rep          (repr/generate-histogram-representation {:stats stats})]
+      (is (str/includes? rep "Test Series"))
+      (is (str/includes? rep "Distribution Shape")))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/histogram_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/histogram_test.clj
@@ -5,49 +5,49 @@
 
 (set! *warn-on-reflection* true)
 
-(deftest compute-series-stats-empty-test
+(deftest ^:parallel compute-series-stats-empty-test
   (testing "empty values returns zero counts"
     (is (=? {:data_points  0
              :distribution some?}
             (histogram/compute-series-stats [])))))
 
-(deftest compute-series-stats-nil-filtered-test
+(deftest ^:parallel compute-series-stats-nil-filtered-test
   (testing "nil values are filtered out"
     (is (=? {:data_points 3}
             (histogram/compute-series-stats [10 nil 20 nil 30])))))
 
-(deftest compute-series-stats-few-points-no-shape-test
+(deftest ^:parallel compute-series-stats-few-points-no-shape-test
   (testing "< 8 values produces no skewness or kurtosis"
     (is (=? {:data_points  7
              :distribution {:skewness (symbol "nil #_\"key is not present.\"")
                             :kurtosis (symbol "nil #_\"key is not present.\"")}}
             (histogram/compute-series-stats [1 2 3 4 5 6 7])))))
 
-(deftest compute-series-stats-enough-points-has-shape-test
+(deftest ^:parallel compute-series-stats-enough-points-has-shape-test
   (testing ">= 8 values produces skewness and kurtosis"
     (is (=? {:data_points  8
              :distribution {:skewness some? :kurtosis some?}}
             (histogram/compute-series-stats [1 2 3 4 5 6 7 8])))))
 
-(deftest compute-series-stats-symmetric-skewness-test
+(deftest ^:parallel compute-series-stats-symmetric-skewness-test
   (testing "symmetric data has near-zero skewness"
     (is (=? {:distribution {:skewness #(< (Math/abs (double %)) 0.5)}}
             ;; perfectly symmetric: [1 2 3 4 5 6 7 8 9 10]
             (histogram/compute-series-stats (range 1 11))))))
 
-(deftest compute-series-stats-right-skewed-test
+(deftest ^:parallel compute-series-stats-right-skewed-test
   (testing "right-skewed data has positive skewness > 0.5"
     (is (=? {:distribution {:skewness #(> (double %) 0.5)}}
             ;; right skew: many small values, few large
             (histogram/compute-series-stats [1 1 1 1 1 2 2 2 3 4 5 100])))))
 
-(deftest compute-series-stats-left-skewed-test
+(deftest ^:parallel compute-series-stats-left-skewed-test
   (testing "left-skewed data has negative skewness < -0.5"
     (is (=? {:distribution {:skewness #(< (double %) -0.5)}}
             ;; left skew: many large values, few small
             (histogram/compute-series-stats [1 99 99 99 100 100 100 100 100 100 100 100])))))
 
-(deftest compute-series-stats-percentiles-test
+(deftest ^:parallel compute-series-stats-percentiles-test
   (testing "P50 matches median from summary"
     ;; Use odd-length data so median is unambiguous (no interpolation difference)
     (let [values (range 1 12)
@@ -57,14 +57,14 @@
       (is (some? p50))
       (is (< (Math/abs (- (double p50) (double median))) 0.01)))))
 
-(deftest compute-series-stats-iqr-test
+(deftest ^:parallel compute-series-stats-iqr-test
   (testing "IQR = Q3 - Q1"
     (let [result (histogram/compute-series-stats (range 1 11))
           quartiles (get-in result [:distribution :quartiles])
           {:keys [q1 q3 iqr]} quartiles]
       (is (< (Math/abs (- (double iqr) (- (double q3) (double q1)))) 0.001)))))
 
-(deftest compute-histogram-stats-multi-series-test
+(deftest ^:parallel compute-histogram-stats-multi-series-test
   (testing "per-series structure with correct chart_type"
     (let [series-data {"Bins" {:x_values [0 1 2 3 4] :y_values [5 10 20 10 5]
                                :x {:name "bin" :type :number}
@@ -77,13 +77,13 @@
                                       :distribution some?}}}
               (histogram/compute-histogram-stats series-data {}))))))
 
-(deftest compute-series-stats-all-nil-test
+(deftest ^:parallel compute-series-stats-all-nil-test
   (testing "all-nil values returns zero data_points"
     (is (=? {:data_points  0
              :distribution some?}
             (histogram/compute-series-stats [nil nil nil])))))
 
-(deftest compute-series-stats-all-percentiles-present-test
+(deftest ^:parallel compute-series-stats-all-percentiles-present-test
   (testing "all six percentiles (25,50,75,90,95,99) are computed"
     (let [result (histogram/compute-series-stats (range 1 101))
           pcts   (get-in result [:distribution :percentiles])]
@@ -98,32 +98,32 @@
       (is (< (get pcts 50) (get pcts 75)))
       (is (< (get pcts 75) (get pcts 90))))))
 
-(deftest compute-series-stats-uniform-kurtosis-test
+(deftest ^:parallel compute-series-stats-uniform-kurtosis-test
   (testing "uniform distribution has negative excess kurtosis"
     (let [result (histogram/compute-series-stats (range 1 101))
           kurtosis (get-in result [:distribution :kurtosis])]
       (is (some? kurtosis))
       (is (< (double kurtosis) 0)))))
 
-(deftest compute-series-stats-single-value-test
+(deftest ^:parallel compute-series-stats-single-value-test
   (testing "single value: min = max = mean"
     (is (=? {:data_points 1
              :summary     {:min 42.0 :max 42.0 :mean 42.0}}
             (histogram/compute-series-stats [42])))))
 
-(deftest compute-series-stats-all-same-values-test
+(deftest ^:parallel compute-series-stats-all-same-values-test
   (testing "all identical values: std_dev = 0"
     (is (=? {:data_points 10
              :summary     {:min 50.0 :max 50.0 :std_dev 0.0}}
             (histogram/compute-series-stats [50 50 50 50 50 50 50 50 50 50])))))
 
-(deftest compute-series-stats-float-values-test
+(deftest ^:parallel compute-series-stats-float-values-test
   (testing "float values handled correctly"
     (is (=? {:data_points 5
              :summary     {:min 1.5 :max 5.5}}
             (histogram/compute-series-stats [1.5 2.5 3.5 4.5 5.5])))))
 
-(deftest compute-series-stats-negative-values-test
+(deftest ^:parallel compute-series-stats-negative-values-test
   (testing "negative values handled correctly"
     (is (=? {:summary {:min -50.0 :max 50.0 :mean 0.0}}
             (histogram/compute-series-stats [-50 -25 0 25 50])))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/histogram_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/histogram_test.clj
@@ -71,8 +71,8 @@
   (testing "per-series structure with correct chart_type"
     (let [series-data {"Bins" {:x_values [0 1 2 3 4]
                                :y_values [5 10 20 10 5]
-                               :x {:name "bin" :type :number}
-                               :y {:name "count" :type :number}
+                               :x {:name "bin" :type "number"}
+                               :y {:name "count" :type "number"}
                                :display_name "Bins"}}]
       (is (=? {:chart_type   :histogram
                :series_count 1

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/histogram_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/histogram_test.clj
@@ -8,55 +8,46 @@
 (set! *warn-on-reflection* true)
 
 (deftest compute-series-stats-empty-test
-  (testing "empty values returns zero counts without crashing"
-    (let [result (histogram/compute-series-stats [])]
-      (is (= 0 (:data_points result)))
-      (is (some? (:distribution result))))))
+  (testing "empty values returns zero counts"
+    (is (=? {:data_points  0
+             :distribution some?}
+            (histogram/compute-series-stats [])))))
 
 (deftest compute-series-stats-nil-filtered-test
   (testing "nil values are filtered out"
-    (let [result (histogram/compute-series-stats [10 nil 20 nil 30])]
-      (is (= 3 (:data_points result))))))
+    (is (=? {:data_points 3}
+            (histogram/compute-series-stats [10 nil 20 nil 30])))))
 
 (deftest compute-series-stats-few-points-no-shape-test
   (testing "< 8 values produces no skewness or kurtosis"
-    (let [result (histogram/compute-series-stats [1 2 3 4 5 6 7])]
-      (is (= 7 (:data_points result)))
-      (is (nil? (get-in result [:distribution :skewness])))
-      (is (nil? (get-in result [:distribution :kurtosis]))))))
+    (is (=? {:data_points  7
+             :distribution {:skewness (symbol "nil #_\"key is not present.\"")
+                            :kurtosis (symbol "nil #_\"key is not present.\"")}}
+            (histogram/compute-series-stats [1 2 3 4 5 6 7])))))
 
 (deftest compute-series-stats-enough-points-has-shape-test
   (testing ">= 8 values produces skewness and kurtosis"
-    (let [result (histogram/compute-series-stats [1 2 3 4 5 6 7 8])]
-      (is (= 8 (:data_points result)))
-      (is (some? (get-in result [:distribution :skewness])))
-      (is (some? (get-in result [:distribution :kurtosis]))))))
+    (is (=? {:data_points  8
+             :distribution {:skewness some? :kurtosis some?}}
+            (histogram/compute-series-stats [1 2 3 4 5 6 7 8])))))
 
 (deftest compute-series-stats-symmetric-skewness-test
   (testing "symmetric data has near-zero skewness"
-    (let [;; perfectly symmetric: [1 2 3 4 5 6 7 8 9 10]
-          result (histogram/compute-series-stats (range 1 11))
-          skewness (get-in result [:distribution :skewness])]
-      (is (some? skewness))
-      (is (< (Math/abs (double skewness)) 0.5) "should be approximately symmetric"))))
+    (is (=? {:distribution {:skewness #(< (Math/abs (double %)) 0.5)}}
+            ;; perfectly symmetric: [1 2 3 4 5 6 7 8 9 10]
+            (histogram/compute-series-stats (range 1 11))))))
 
 (deftest compute-series-stats-right-skewed-test
   (testing "right-skewed data has positive skewness > 0.5"
-    (let [;; right skew: many small values, few large
-          values [1 1 1 1 1 2 2 2 3 4 5 100]
-          result (histogram/compute-series-stats values)
-          skewness (get-in result [:distribution :skewness])]
-      (is (some? skewness))
-      (is (> (double skewness) 0.5)))))
+    (is (=? {:distribution {:skewness #(> (double %) 0.5)}}
+            ;; right skew: many small values, few large
+            (histogram/compute-series-stats [1 1 1 1 1 2 2 2 3 4 5 100])))))
 
 (deftest compute-series-stats-left-skewed-test
   (testing "left-skewed data has negative skewness < -0.5"
-    (let [;; left skew: many large values, few small
-          values [1 99 99 99 100 100 100 100 100 100 100 100]
-          result (histogram/compute-series-stats values)
-          skewness (get-in result [:distribution :skewness])]
-      (is (some? skewness))
-      (is (< (double skewness) -0.5)))))
+    (is (=? {:distribution {:skewness #(< (double %) -0.5)}}
+            ;; left skew: many large values, few small
+            (histogram/compute-series-stats [1 99 99 99 100 100 100 100 100 100 100 100])))))
 
 (deftest compute-series-stats-percentiles-test
   (testing "P50 matches median from summary"
@@ -80,21 +71,19 @@
     (let [series-data {"Bins" {:x_values [0 1 2 3 4] :y_values [5 10 20 10 5]
                                :x {:name "bin" :type :number}
                                :y {:name "count" :type :number}
-                               :display_name "Bins"}}
-          result (histogram/compute-histogram-stats series-data {})]
-      (is (= :histogram (:chart_type result)))
-      (is (= 1 (:series_count result)))
-      (is (contains? (:series result) "Bins"))
-      (let [s (get-in result [:series "Bins"])]
-        (is (= 5 (:data_points s)))
-        (is (some? (:summary s)))
-        (is (some? (:distribution s)))))))
+                               :display_name "Bins"}}]
+      (is (=? {:chart_type   :histogram
+               :series_count 1
+               :series       {"Bins" {:data_points  5
+                                      :summary      some?
+                                      :distribution some?}}}
+              (histogram/compute-histogram-stats series-data {}))))))
 
 (deftest compute-series-stats-all-nil-test
   (testing "all-nil values returns zero data_points"
-    (let [result (histogram/compute-series-stats [nil nil nil])]
-      (is (= 0 (:data_points result)))
-      (is (some? (:distribution result))))))
+    (is (=? {:data_points  0
+             :distribution some?}
+            (histogram/compute-series-stats [nil nil nil])))))
 
 (deftest compute-series-stats-all-percentiles-present-test
   (testing "all six percentiles (25,50,75,90,95,99) are computed"
@@ -113,51 +102,33 @@
 
 (deftest compute-series-stats-uniform-kurtosis-test
   (testing "uniform distribution has negative excess kurtosis"
-    (let [result  (histogram/compute-series-stats (range 1 101))
+    (let [result (histogram/compute-series-stats (range 1 101))
           kurtosis (get-in result [:distribution :kurtosis])]
       (is (some? kurtosis))
       (is (< (double kurtosis) 0)))))
 
-(deftest compute-series-stats-no-outliers-field-test
-  (testing "histogram stats do not include an outliers field"
-    ;; Histograms show distribution, not individual point anomalies
-    (let [result (histogram/compute-series-stats [10 20 30 40 50 1000])]
-      (is (not (contains? result :outliers))))))
-
 (deftest compute-series-stats-single-value-test
   (testing "single value: min = max = mean"
-    (let [result (histogram/compute-series-stats [42])
-          s      (:summary result)]
-      (is (= 1 (:data_points result)))
-      (is (some? s))
-      (is (= 42.0 (:min s)))
-      (is (= 42.0 (:max s)))
-      (is (= 42.0 (:mean s))))))
+    (is (=? {:data_points 1
+             :summary     {:min 42.0 :max 42.0 :mean 42.0}}
+            (histogram/compute-series-stats [42])))))
 
 (deftest compute-series-stats-all-same-values-test
   (testing "all identical values: std_dev = 0"
-    (let [result (histogram/compute-series-stats [50 50 50 50 50 50 50 50 50 50])
-          s      (:summary result)]
-      (is (= 10 (:data_points result)))
-      (is (= 50.0 (:min s)))
-      (is (= 50.0 (:max s)))
-      (is (= 0.0 (:std_dev s))))))
+    (is (=? {:data_points 10
+             :summary     {:min 50.0 :max 50.0 :std_dev 0.0}}
+            (histogram/compute-series-stats [50 50 50 50 50 50 50 50 50 50])))))
 
 (deftest compute-series-stats-float-values-test
   (testing "float values handled correctly"
-    (let [result (histogram/compute-series-stats [1.5 2.5 3.5 4.5 5.5])
-          s      (:summary result)]
-      (is (= 5 (:data_points result)))
-      (is (< (Math/abs (- (:min s) 1.5)) 0.001))
-      (is (< (Math/abs (- (:max s) 5.5)) 0.001)))))
+    (is (=? {:data_points 5
+             :summary     {:min 1.5 :max 5.5}}
+            (histogram/compute-series-stats [1.5 2.5 3.5 4.5 5.5])))))
 
 (deftest compute-series-stats-negative-values-test
   (testing "negative values handled correctly"
-    (let [result (histogram/compute-series-stats [-50 -25 0 25 50])
-          s      (:summary result)]
-      (is (= -50.0 (:min s)))
-      (is (= 50.0 (:max s)))
-      (is (= 0.0 (:mean s))))))
+    (is (=? {:summary {:min -50.0 :max 50.0 :mean 0.0}}
+            (histogram/compute-series-stats [-50 -25 0 25 50])))))
 
 (deftest repr-histogram-shows-shape-test
   (testing "representation includes Distribution Shape when enough data"

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/outliers_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/outliers_test.clj
@@ -22,13 +22,6 @@
           indices (outliers/find-outlier-indices values)]
       (is (empty? indices)))))
 
-(deftest find-outlier-indices-multiple-outliers-test
-  (testing "multiple extreme values are all detected"
-    (let [values  [1.0 2.0 100.0 2.1 2.2 -50.0]
-          indices (outliers/find-outlier-indices values)]
-      (is (some #{2} indices))    ; 100.0 at index 2
-      (is (some #{5} indices))))) ; -50.0 at index 5
-
 ;;; ---------------------------------------------- find-outliers tests -----------------------------------------------
 
 (deftest find-outliers-returns-detail-maps-test
@@ -37,11 +30,10 @@
           dates  ["A" "B" "C" "D" "E" "F" "G"]
           result (outliers/find-outliers values dates)]
       (is (seq result))
-      (let [outlier-E (first (filter #(= "E" (:date %)) result))]
-        (is (some? outlier-E))
-        (is (= 4 (:index outlier-E)))
-        (is (= 10.0 (:value outlier-E)))
-        (is (> (Math/abs (double (:modified_z_score outlier-E))) 3.0))))))
+      (is (=? {:index 4
+               :value 10.0
+               :modified_z_score #(> (Math/abs (double %)) 3.0)}
+              (first (filter #(= "E" (:date %)) result)))))))
 
 (deftest find-outliers-no-outliers-returns-empty-test
   (testing "tightly clustered data produces no outliers"
@@ -61,10 +53,8 @@
       (is (nil? result)))))
 
 (deftest find-outliers-mad-zero-returns-nil-test
-  (testing "when all values are identical MAD is 0 → returns nil, not false outliers"
-    ;; Clojure behavior: MAD=0 means z-scores are undefined → nil returned
-    (let [result (outliers/find-outliers [3.0 3.0 3.0 3.0 3.0] ["A" "B" "C" "D" "E"])]
-      (is (nil? result)))))
+  (testing "when all values are identical MAD is 0 → returns nil"
+    (is (nil? (outliers/find-outliers [3.0 3.0 3.0 3.0 3.0] ["A" "B" "C" "D" "E"])))))
 
 ;;; ---------------------------------------- find-outliers-cumulative tests ------------------------------------------
 
@@ -84,12 +74,12 @@
           dates  ["A" "B" "C" "D" "E"]
           result (outliers/find-outliers-cumulative values dates)]
       (is (seq result))
-      (let [outlier (first result)]
-        (is (contains? outlier :index))
-        (is (contains? outlier :date))
-        (is (contains? outlier :value))
-        (is (contains? outlier :diff))
-        (is (contains? outlier :modified_z_score))))))
+      (is (=? {:index some?
+               :date some?
+               :value some?
+               :diff some?
+               :modified_z_score some?}
+              (first result))))))
 
 (deftest find-outliers-cumulative-uniform-increments-test
   (testing "uniform diffs → MAD of diffs is 0 → returns nil"
@@ -102,9 +92,7 @@
   (testing "outlier point index is diff-index+1 (destination of unusual jump)"
     (let [values [1.0 2.0 3.0 10.0 12.0]
           dates  ["A" "B" "C" "D" "E"]
-          result (outliers/find-outliers-cumulative values dates)
-          outlier (first (filter #(= "D" (:date %)) result))]
-      (is (some? outlier))
+          result (outliers/find-outliers-cumulative values dates)]
       ;; diff-index is 2 (the 3→10 transition), so point index is 3
-      (is (= 3 (:index outlier)))
-      (is (= 10.0 (:value outlier))))))
+      (is (=? {:index 3 :value 10.0}
+              (first (filter #(= "D" (:date %)) result)))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/outliers_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/outliers_test.clj
@@ -6,23 +6,6 @@
 
 (set! *warn-on-reflection* true)
 
-;;; ------------------------------------------ find-outlier-indices tests -------------------------------------------
-
-(deftest ^:parallel find-outlier-indices-normal-distribution-test
-  (testing "extreme values detected as outliers via modified Z-score"
-    ;; In [1 2 2.1 2.2 10 1.9 2.3]: median≈2.1, MAD≈0.2
-    ;; modified-z for 1.0 ≈ 3.71 and for 10.0 ≈ 26.6 → both exceed threshold 3.0
-    (let [values  [1.0 2.0 2.1 2.2 10.0 1.9 2.3]
-          indices (#'outliers/find-outlier-indices values)]
-      (is (some #{0} indices))    ; 1.0 at index 0
-      (is (some #{4} indices))))) ; 10.0 at index 4
-
-(deftest ^:parallel find-outlier-indices-no-outliers-test
-  (testing "tightly clustered values produce no outliers"
-    (let [values  [1.0 1.1 1.2 0.9 1.15]
-          indices (#'outliers/find-outlier-indices values)]
-      (is (empty? indices)))))
-
 ;;; ---------------------------------------------- find-outliers tests -----------------------------------------------
 
 (deftest ^:parallel find-outliers-returns-detail-maps-test

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/outliers_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/outliers_test.clj
@@ -1,0 +1,110 @@
+(ns metabase-enterprise.metabot-v3.stats.outliers-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase-enterprise.metabot-v3.stats.outliers :as outliers]))
+
+(set! *warn-on-reflection* true)
+
+;;; ------------------------------------------ find-outlier-indices tests -------------------------------------------
+
+(deftest find-outlier-indices-normal-distribution-test
+  (testing "extreme values detected as outliers via modified Z-score"
+    ;; In [1 2 2.1 2.2 10 1.9 2.3]: median≈2.1, MAD≈0.2
+    ;; modified-z for 1.0 ≈ 3.71 and for 10.0 ≈ 26.6 → both exceed threshold 3.0
+    (let [values  [1.0 2.0 2.1 2.2 10.0 1.9 2.3]
+          indices (outliers/find-outlier-indices values)]
+      (is (some #{0} indices))    ; 1.0 at index 0
+      (is (some #{4} indices))))) ; 10.0 at index 4
+
+(deftest find-outlier-indices-no-outliers-test
+  (testing "tightly clustered values produce no outliers"
+    (let [values  [1.0 1.1 1.2 0.9 1.15]
+          indices (outliers/find-outlier-indices values)]
+      (is (empty? indices)))))
+
+(deftest find-outlier-indices-multiple-outliers-test
+  (testing "multiple extreme values are all detected"
+    (let [values  [1.0 2.0 100.0 2.1 2.2 -50.0]
+          indices (outliers/find-outlier-indices values)]
+      (is (some #{2} indices))    ; 100.0 at index 2
+      (is (some #{5} indices))))) ; -50.0 at index 5
+
+;;; ---------------------------------------------- find-outliers tests -----------------------------------------------
+
+(deftest find-outliers-returns-detail-maps-test
+  (testing "outlier maps contain index, date, value, and modified z-score"
+    (let [values [1.0 2.0 2.1 2.2 10.0 1.9 2.3]
+          dates  ["A" "B" "C" "D" "E" "F" "G"]
+          result (outliers/find-outliers values dates)]
+      (is (seq result))
+      (let [outlier-E (first (filter #(= "E" (:date %)) result))]
+        (is (some? outlier-E))
+        (is (= 4 (:index outlier-E)))
+        (is (= 10.0 (:value outlier-E)))
+        (is (> (Math/abs (double (:modified_z_score outlier-E))) 3.0))))))
+
+(deftest find-outliers-no-outliers-returns-empty-test
+  (testing "tightly clustered data produces no outliers"
+    (let [values [10.0 11.0 10.5 10.2 10.8]
+          dates  ["A" "B" "C" "D" "E"]
+          result (outliers/find-outliers values dates)]
+      (is (empty? result)))))
+
+(deftest find-outliers-empty-input-test
+  (testing "empty values returns nil (MAD undefined)"
+    (let [result (outliers/find-outliers [] [])]
+      (is (nil? result)))))
+
+(deftest find-outliers-single-value-returns-nil-test
+  (testing "single value has no MAD and returns nil"
+    (let [result (outliers/find-outliers [10.0] ["A"])]
+      (is (nil? result)))))
+
+(deftest find-outliers-mad-zero-returns-nil-test
+  (testing "when all values are identical MAD is 0 → returns nil, not false outliers"
+    ;; Clojure behavior: MAD=0 means z-scores are undefined → nil returned
+    (let [result (outliers/find-outliers [3.0 3.0 3.0 3.0 3.0] ["A" "B" "C" "D" "E"])]
+      (is (nil? result)))))
+
+;;; ---------------------------------------- find-outliers-cumulative tests ------------------------------------------
+
+(deftest find-outliers-cumulative-detects-unusual-jump-test
+  (testing "sudden jump in cumulative diffs detected; outlier reported at destination point"
+    ;; diffs=[1,1,7,2]; 7 is the outlier diff (modified-z ≈ 7.4 > 3.0)
+    ;; destination point D (index 3) is flagged
+    (let [values [1.0 2.0 3.0 10.0 12.0]
+          dates  ["A" "B" "C" "D" "E"]
+          result (outliers/find-outliers-cumulative values dates)]
+      (is (seq result))
+      (is (some #(= "D" (:date %)) result)))))
+
+(deftest find-outliers-cumulative-outlier-map-structure-test
+  (testing "cumulative outlier maps include :index :date :value :diff :modified_z_score"
+    (let [values [1.0 2.0 3.0 10.0 12.0]
+          dates  ["A" "B" "C" "D" "E"]
+          result (outliers/find-outliers-cumulative values dates)]
+      (is (seq result))
+      (let [outlier (first result)]
+        (is (contains? outlier :index))
+        (is (contains? outlier :date))
+        (is (contains? outlier :value))
+        (is (contains? outlier :diff))
+        (is (contains? outlier :modified_z_score))))))
+
+(deftest find-outliers-cumulative-uniform-increments-test
+  (testing "uniform diffs → MAD of diffs is 0 → returns nil"
+    (let [values [10.0 20.0 30.0 40.0 50.0]
+          dates  ["A" "B" "C" "D" "E"]
+          result (outliers/find-outliers-cumulative values dates)]
+      (is (nil? result)))))
+
+(deftest find-outliers-cumulative-destination-index-is-one-past-diff-index-test
+  (testing "outlier point index is diff-index+1 (destination of unusual jump)"
+    (let [values [1.0 2.0 3.0 10.0 12.0]
+          dates  ["A" "B" "C" "D" "E"]
+          result (outliers/find-outliers-cumulative values dates)
+          outlier (first (filter #(= "D" (:date %)) result))]
+      (is (some? outlier))
+      ;; diff-index is 2 (the 3→10 transition), so point index is 3
+      (is (= 3 (:index outlier)))
+      (is (= 10.0 (:value outlier))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/outliers_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/outliers_test.clj
@@ -7,7 +7,7 @@
 
 ;;; ------------------------------------------ find-outlier-indices tests -------------------------------------------
 
-(deftest find-outlier-indices-normal-distribution-test
+(deftest ^:parallel find-outlier-indices-normal-distribution-test
   (testing "extreme values detected as outliers via modified Z-score"
     ;; In [1 2 2.1 2.2 10 1.9 2.3]: median≈2.1, MAD≈0.2
     ;; modified-z for 1.0 ≈ 3.71 and for 10.0 ≈ 26.6 → both exceed threshold 3.0
@@ -16,7 +16,7 @@
       (is (some #{0} indices))    ; 1.0 at index 0
       (is (some #{4} indices))))) ; 10.0 at index 4
 
-(deftest find-outlier-indices-no-outliers-test
+(deftest ^:parallel find-outlier-indices-no-outliers-test
   (testing "tightly clustered values produce no outliers"
     (let [values  [1.0 1.1 1.2 0.9 1.15]
           indices (outliers/find-outlier-indices values)]
@@ -24,7 +24,7 @@
 
 ;;; ---------------------------------------------- find-outliers tests -----------------------------------------------
 
-(deftest find-outliers-returns-detail-maps-test
+(deftest ^:parallel find-outliers-returns-detail-maps-test
   (testing "outlier maps contain index, date, value, and modified z-score"
     (let [values [1.0 2.0 2.1 2.2 10.0 1.9 2.3]
           dates  ["A" "B" "C" "D" "E" "F" "G"]
@@ -35,30 +35,30 @@
                :modified_z_score #(> (Math/abs (double %)) 3.0)}
               (first (filter #(= "E" (:date %)) result)))))))
 
-(deftest find-outliers-no-outliers-returns-empty-test
+(deftest ^:parallel find-outliers-no-outliers-returns-empty-test
   (testing "tightly clustered data produces no outliers"
     (let [values [10.0 11.0 10.5 10.2 10.8]
           dates  ["A" "B" "C" "D" "E"]
           result (outliers/find-outliers values dates)]
       (is (empty? result)))))
 
-(deftest find-outliers-empty-input-test
+(deftest ^:parallel find-outliers-empty-input-test
   (testing "empty values returns nil (MAD undefined)"
     (let [result (outliers/find-outliers [] [])]
       (is (nil? result)))))
 
-(deftest find-outliers-single-value-returns-nil-test
+(deftest ^:parallel find-outliers-single-value-returns-nil-test
   (testing "single value has no MAD and returns nil"
     (let [result (outliers/find-outliers [10.0] ["A"])]
       (is (nil? result)))))
 
-(deftest find-outliers-mad-zero-returns-nil-test
+(deftest ^:parallel find-outliers-mad-zero-returns-nil-test
   (testing "when all values are identical MAD is 0 → returns nil"
     (is (nil? (outliers/find-outliers [3.0 3.0 3.0 3.0 3.0] ["A" "B" "C" "D" "E"])))))
 
 ;;; ---------------------------------------- find-outliers-cumulative tests ------------------------------------------
 
-(deftest find-outliers-cumulative-detects-unusual-jump-test
+(deftest ^:parallel find-outliers-cumulative-detects-unusual-jump-test
   (testing "sudden jump in cumulative diffs detected; outlier reported at destination point"
     ;; diffs=[1,1,7,2]; 7 is the outlier diff (modified-z ≈ 7.4 > 3.0)
     ;; destination point D (index 3) is flagged
@@ -68,7 +68,7 @@
       (is (seq result))
       (is (some #(= "D" (:date %)) result)))))
 
-(deftest find-outliers-cumulative-outlier-map-structure-test
+(deftest ^:parallel find-outliers-cumulative-outlier-map-structure-test
   (testing "cumulative outlier maps include :index :date :value :diff :modified_z_score"
     (let [values [1.0 2.0 3.0 10.0 12.0]
           dates  ["A" "B" "C" "D" "E"]
@@ -81,14 +81,14 @@
                :modified_z_score some?}
               (first result))))))
 
-(deftest find-outliers-cumulative-uniform-increments-test
+(deftest ^:parallel find-outliers-cumulative-uniform-increments-test
   (testing "uniform diffs → MAD of diffs is 0 → returns nil"
     (let [values [10.0 20.0 30.0 40.0 50.0]
           dates  ["A" "B" "C" "D" "E"]
           result (outliers/find-outliers-cumulative values dates)]
       (is (nil? result)))))
 
-(deftest find-outliers-cumulative-destination-index-is-one-past-diff-index-test
+(deftest ^:parallel find-outliers-cumulative-destination-index-is-one-past-diff-index-test
   (testing "outlier point index is diff-index+1 (destination of unusual jump)"
     (let [values [1.0 2.0 3.0 10.0 12.0]
           dates  ["A" "B" "C" "D" "E"]

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/outliers_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/outliers_test.clj
@@ -9,21 +9,21 @@
 ;;; ---------------------------------------------- find-outliers tests -----------------------------------------------
 
 (deftest ^:parallel find-outliers-returns-detail-maps-test
-  (testing "outlier maps contain index, date, value, and modified z-score"
+  (testing "outlier maps contain index, label, value, and modified z-score"
     (let [values [1.0 2.0 2.1 2.2 10.0 1.9 2.3]
-          dates  ["A" "B" "C" "D" "E" "F" "G"]
-          result (outliers/find-outliers values dates)]
+          labels ["A" "B" "C" "D" "E" "F" "G"]
+          result (outliers/find-outliers values labels)]
       (is (seq result))
       (is (=? {:index 4
                :value 10.0
                :modified_z_score #(> (Math/abs (double %)) 3.0)}
-              (first (filter #(= "E" (:date %)) result)))))))
+              (first (filter #(= "E" (:label %)) result)))))))
 
 (deftest ^:parallel find-outliers-no-outliers-returns-empty-test
   (testing "tightly clustered data produces no outliers"
     (let [values [10.0 11.0 10.5 10.2 10.8]
-          dates  ["A" "B" "C" "D" "E"]
-          result (outliers/find-outliers values dates)]
+          labels ["A" "B" "C" "D" "E"]
+          result (outliers/find-outliers values labels)]
       (is (empty? result)))))
 
 (deftest ^:parallel find-outliers-empty-input-test
@@ -47,19 +47,19 @@
     ;; diffs=[1,1,7,2]; 7 is the outlier diff (modified-z ≈ 7.4 > 3.0)
     ;; destination point D (index 3) is flagged
     (let [values [1.0 2.0 3.0 10.0 12.0]
-          dates  ["A" "B" "C" "D" "E"]
-          result (outliers/find-outliers-cumulative values dates)]
+          labels ["A" "B" "C" "D" "E"]
+          result (outliers/find-outliers-cumulative values labels)]
       (is (seq result))
-      (is (some #(= "D" (:date %)) result)))))
+      (is (some #(= "D" (:label %)) result)))))
 
 (deftest ^:parallel find-outliers-cumulative-outlier-map-structure-test
-  (testing "cumulative outlier maps include :index :date :value :diff :modified_z_score"
+  (testing "cumulative outlier maps include :index :label :value :diff :modified_z_score"
     (let [values [1.0 2.0 3.0 10.0 12.0]
-          dates  ["A" "B" "C" "D" "E"]
-          result (outliers/find-outliers-cumulative values dates)]
+          labels ["A" "B" "C" "D" "E"]
+          result (outliers/find-outliers-cumulative values labels)]
       (is (seq result))
       (is (=? {:index 3
-               :date "D"
+               :label "D"
                :value 10.0
                :diff 7.0
                :modified_z_score (=?/approx [3.37 0.01])}
@@ -68,15 +68,15 @@
 (deftest ^:parallel find-outliers-cumulative-uniform-increments-test
   (testing "uniform diffs → MAD of diffs is 0 → returns nil"
     (let [values [10.0 20.0 30.0 40.0 50.0]
-          dates  ["A" "B" "C" "D" "E"]
-          result (outliers/find-outliers-cumulative values dates)]
+          labels ["A" "B" "C" "D" "E"]
+          result (outliers/find-outliers-cumulative values labels)]
       (is (nil? result)))))
 
 (deftest ^:parallel find-outliers-cumulative-destination-index-is-one-past-diff-index-test
   (testing "outlier point index is diff-index+1 (destination of unusual jump)"
     (let [values [1.0 2.0 3.0 10.0 12.0]
-          dates  ["A" "B" "C" "D" "E"]
-          result (outliers/find-outliers-cumulative values dates)]
+          labels ["A" "B" "C" "D" "E"]
+          result (outliers/find-outliers-cumulative values labels)]
       ;; diff-index is 2 (the 3→10 transition), so point index is 3
       (is (=? {:index 3 :value 10.0}
-              (first (filter #(= "D" (:date %)) result)))))))
+              (first (filter #(= "D" (:label %)) result)))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/outliers_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/outliers_test.clj
@@ -1,6 +1,7 @@
 (ns metabase-enterprise.metabot-v3.stats.outliers-test
   (:require
    [clojure.test :refer :all]
+   [mb.hawk.assert-exprs.approximately-equal :as =?]
    [metabase-enterprise.metabot-v3.stats.outliers :as outliers]))
 
 (set! *warn-on-reflection* true)
@@ -74,11 +75,11 @@
           dates  ["A" "B" "C" "D" "E"]
           result (outliers/find-outliers-cumulative values dates)]
       (is (seq result))
-      (is (=? {:index some?
-               :date some?
-               :value some?
-               :diff some?
-               :modified_z_score some?}
+      (is (=? {:index 3
+               :date "D"
+               :value 10.0
+               :diff 7.0
+               :modified_z_score (=?/approx [3.37 0.01])}
               (first result))))))
 
 (deftest ^:parallel find-outliers-cumulative-uniform-increments-test

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/outliers_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/outliers_test.clj
@@ -12,14 +12,14 @@
     ;; In [1 2 2.1 2.2 10 1.9 2.3]: median≈2.1, MAD≈0.2
     ;; modified-z for 1.0 ≈ 3.71 and for 10.0 ≈ 26.6 → both exceed threshold 3.0
     (let [values  [1.0 2.0 2.1 2.2 10.0 1.9 2.3]
-          indices (outliers/find-outlier-indices values)]
+          indices (#'outliers/find-outlier-indices values)]
       (is (some #{0} indices))    ; 1.0 at index 0
       (is (some #{4} indices))))) ; 10.0 at index 4
 
 (deftest ^:parallel find-outlier-indices-no-outliers-test
   (testing "tightly clustered values produce no outliers"
     (let [values  [1.0 1.1 1.2 0.9 1.15]
-          indices (outliers/find-outlier-indices values)]
+          indices (#'outliers/find-outlier-indices values)]
       (is (empty? indices)))))
 
 ;;; ---------------------------------------------- find-outliers tests -----------------------------------------------

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/repr_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/repr_test.clj
@@ -1,0 +1,165 @@
+(ns metabase-enterprise.metabot-v3.stats.repr-test
+  (:require
+   [clojure.string :as str]
+   [clojure.test :refer :all]
+   [metabase-enterprise.metabot-v3.stats.categorical :as categorical]
+   [metabase-enterprise.metabot-v3.stats.core :as stats.core]
+   [metabase-enterprise.metabot-v3.stats.histogram :as histogram]
+   [metabase-enterprise.metabot-v3.stats.repr :as repr]
+   [metabase-enterprise.metabot-v3.stats.scatter :as scatter]
+   [metabase-enterprise.metabot-v3.stats.time-series :as time-series]
+   [metabase.util :as u]))
+
+(set! *warn-on-reflection* true)
+
+;;; -------------------------------------------------- Helpers -------------------------------------------------------
+
+(defn- make-series
+  "Create a series config with n data points."
+  [n]
+  {:x {:name "Date" :type :datetime}
+   :y {:name "Value" :type :number}
+   :display_name "Test"
+   :x_values (mapv #(str "2020-01-" (format "%02d" (inc (mod % 28)))) (range n))
+   :y_values (mapv double (range n))})
+
+(defn- make-chart-config
+  "Create a chart config with the given number of series, each with n data points."
+  [series-count n]
+  {:display_type "line"
+   :title "Test Chart"
+   :series (into {} (for [i (range series-count)]
+                      [(str "series_" i) (make-series n)]))})
+
+;;; ------------------------------------------ Repr Limits Note Tests ------------------------------------------------
+
+(deftest repr-includes-downsampled-note-test
+  (testing "Representation includes a note about downsampled data"
+    (let [n      (+ stats.core/max-data-points-per-series 1000)
+          config (make-chart-config 1 n)
+          stats  (stats.core/compute-chart-stats config {:deep? false})
+          repr   (repr/generate-representation {:title "Test" :display-type "line" :stats stats})]
+      (is (str/includes? repr "Data Limits Applied"))
+      (is (str/includes? repr "downsampled")))))
+
+(deftest repr-includes-correlations-capped-note-test
+  (testing "Representation includes a note about capped correlations"
+    (let [n-series (+ stats.core/max-series-for-correlations 5)
+          config   (make-chart-config n-series 50)
+          stats    (stats.core/compute-chart-stats config {:deep? true})
+          repr     (repr/generate-representation {:title "Test" :display-type "line" :stats stats})]
+      (is (str/includes? repr "Data Limits Applied"))
+      (is (str/includes? repr "correlations were limited")))))
+
+(deftest repr-no-limits-note-when-within-bounds-test
+  (testing "No limits note when data is within bounds"
+    (let [config (make-chart-config 2 100)
+          stats  (stats.core/compute-chart-stats config {:deep? true})
+          repr   (repr/generate-representation {:title "Test" :display-type "line" :stats stats})]
+      (is (not (str/includes? repr "Data Limits Applied"))))))
+
+;;; ------------------------------------------- Histogram Repr Tests -------------------------------------------------
+
+(deftest repr-histogram-shows-shape-test
+  (testing "representation includes Distribution Shape when enough data"
+    (let [series-stats (histogram/compute-series-stats (range 1 101))
+          stats        {:chart_type   :histogram
+                        :series_count 1
+                        :series       {"Test Series" series-stats}}
+          rep          (repr/generate-histogram-representation {:stats stats})]
+      (is (str/includes? rep "Test Series"))
+      (is (str/includes? rep "Distribution Shape")))))
+
+;;; -------------------------------------------- Scatter Repr Tests --------------------------------------------------
+
+(deftest repr-scatter-shows-relationship-test
+  (testing "representation includes Relationship with strength and direction"
+    (let [series-stats (scatter/compute-series-stats [1 2 3 4 5] [10 20 30 40 50])
+          stats        {:chart_type   :scatter
+                        :series_count 1
+                        :series       {"Test Series" series-stats}}
+          rep          (repr/generate-scatter-representation {:stats stats})]
+      (is (str/includes? rep "Test Series"))
+      (is (str/includes? rep "Relationship"))
+      (is (str/includes? rep "strong positive")))))
+
+;;; ------------------------------------------ Categorical Repr Tests ------------------------------------------------
+
+(deftest repr-categorical-includes-key-info-test
+  (testing "representation includes series name, data count, and Categories"
+    (let [series-stats (categorical/compute-series-stats ["A" "B" "C"] [100 200 150])
+          stats        {:chart_type   :categorical
+                        :series_count 1
+                        :series       {"Test Series" series-stats}}
+          rep          (repr/generate-categorical-representation {:stats stats})]
+      (is (str/includes? rep "Test Series"))
+      (is (str/includes? rep "Categories"))
+      (is (str/includes? rep "Top Categories")))))
+
+(deftest repr-categorical-shows-bottom-categories-for-large-dataset-test
+  (testing "Bottom Categories shown when > 15 categories"
+    (let [xs           (map #(str "Cat" (format "%02d" %)) (range 1 21))
+          ys           (map double (range 1 21))
+          series-stats (categorical/compute-series-stats xs ys)
+          stats        {:chart_type   :categorical
+                        :series_count 1
+                        :series       {"Many" series-stats}}
+          rep          (repr/generate-categorical-representation {:stats stats})]
+      (is (str/includes? rep "Top Categories"))
+      (is (str/includes? rep "Bottom Categories"))
+      ;; highest value category (Cat20) appears
+      (is (str/includes? rep "Cat20"))
+      ;; lowest value category (Cat01) appears
+      (is (str/includes? rep "Cat01")))))
+
+(deftest repr-categorical-no-bottom-categories-for-small-dataset-test
+  (testing "Bottom Categories absent when <= 15 categories"
+    (let [xs           (map #(str "Cat" %) (range 1 16))
+          ys           (map double (range 1 16))
+          series-stats (categorical/compute-series-stats xs ys)
+          stats        {:chart_type   :categorical
+                        :series_count 1
+                        :series       {"Few" series-stats}}
+          rep          (repr/generate-categorical-representation {:stats stats})]
+      (is (str/includes? rep "Top Categories"))
+      (is (not (str/includes? rep "Bottom Categories"))))))
+
+;;; ----------------------------------------- Time Series Repr Tests -------------------------------------------------
+
+(deftest generate-temporal-context-test
+  (testing "temporal context includes current date, day of week, week, month, and quarter"
+    (let [result (repr/generate-temporal-context)]
+      (is (str/includes? result "Today is"))
+      (is (some #(str/includes? result %)
+                ["Monday" "Tuesday" "Wednesday" "Thursday" "Friday" "Saturday" "Sunday"]))
+      (is (str/includes? (u/lower-case-en result) "week"))
+      (is (str/includes? (u/lower-case-en result) "month"))
+      (is (str/includes? (u/lower-case-en result) "quarter"))
+      (is (some #(str/includes? result %) ["Q1" "Q2" "Q3" "Q4"])))))
+
+(deftest repr-time-series-includes-series-name-and-trend-test
+  (testing "time series representation includes series name and trend direction"
+    (let [values [10.0 20.0 30.0 40.0 50.0]
+          dates  ["2024-01" "2024-02" "2024-03" "2024-04" "2024-05"]
+          series-stats (time-series/compute-series-stats values dates {})
+          stats {:chart_type   :time-series
+                 :series_count 1
+                 :series       {"Revenue" series-stats}}
+          rep (repr/generate-time-series-representation {:stats stats})]
+      (is (str/includes? rep "Revenue"))
+      (is (str/includes? rep "Trend"))
+      (is (str/includes? rep "Time Series")))))
+
+(deftest repr-time-series-multi-series-test
+  (testing "representation with multiple series includes all series names"
+    (let [make-stats (fn [values dates]
+                       (time-series/compute-series-stats values dates {}))
+          stats {:chart_type   :time-series
+                 :series_count 2
+                 :series       {"Sales"   (make-stats [10.0 20.0 30.0 40.0 50.0]
+                                                      ["d1" "d2" "d3" "d4" "d5"])
+                                "Revenue" (make-stats [20.0 40.0 60.0 80.0 100.0]
+                                                      ["d1" "d2" "d3" "d4" "d5"])}}
+          rep (repr/generate-time-series-representation {:stats stats})]
+      (is (str/includes? rep "Sales"))
+      (is (str/includes? rep "Revenue")))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/repr_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/repr_test.clj
@@ -17,8 +17,8 @@
 (defn- make-series
   "Create a series config with n data points."
   [n]
-  {:x {:name "Date" :type :datetime}
-   :y {:name "Value" :type :number}
+  {:x {:name "Date" :type "datetime"}
+   :y {:name "Value" :type "number"}
    :display_name "Test"
    :x_values (mapv #(str "2020-01-" (format "%02d" (inc (mod % 28)))) (range n))
    :y_values (mapv double (range n))})

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/repr_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/repr_test.clj
@@ -220,5 +220,5 @@
 (deftest ^:parallel generate-representation-unknown-chart-type-fallback-test
   (testing "unknown chart type produces fallback message"
     (is (str/includes?
-         (repr/generate-representation {:stats {:chart_type :waterfall}})
+         (repr/generate-representation {:stats {:chart_type :unknown}})
          "not yet implemented"))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/repr_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/repr_test.clj
@@ -70,6 +70,17 @@
       (is (str/includes? rep "Test Series"))
       (is (str/includes? rep "Distribution Shape")))))
 
+(deftest repr-histogram-shows-percentiles-and-iqr-test
+  (testing "histogram representation includes percentiles and IQR for sufficient data"
+    (let [series-stats (histogram/compute-series-stats (range 1 101))
+          stats        {:chart_type   :histogram
+                        :series_count 1
+                        :series       {"Values" series-stats}}
+          rep          (repr/generate-histogram-representation {:stats stats})]
+      (is (str/includes? rep "Percentiles"))
+      (is (str/includes? rep "P50="))
+      (is (str/includes? rep "IQR")))))
+
 ;;; -------------------------------------------- Scatter Repr Tests --------------------------------------------------
 
 (deftest repr-scatter-shows-relationship-test
@@ -82,6 +93,16 @@
       (is (str/includes? rep "Test Series"))
       (is (str/includes? rep "Relationship"))
       (is (str/includes? rep "strong positive")))))
+
+(deftest repr-scatter-shows-trend-line-test
+  (testing "scatter representation includes trend line equation when regression is present"
+    (let [series-stats (scatter/compute-series-stats [1 2 3 4 5] [12 14 16 18 20])
+          stats        {:chart_type   :scatter
+                        :series_count 1
+                        :series       {"Linear" series-stats}}
+          rep          (repr/generate-scatter-representation {:stats stats})]
+      (is (str/includes? rep "Trend Line"))
+      (is (str/includes? rep "y =")))))
 
 ;;; ------------------------------------------ Categorical Repr Tests ------------------------------------------------
 
@@ -124,6 +145,15 @@
       (is (str/includes? rep "Top Categories"))
       (is (not (str/includes? rep "Bottom Categories"))))))
 
+(deftest repr-categorical-sparse-data-warning-test
+  (testing "sparse data warning shown for series with < 10 data points"
+    (let [series-stats (categorical/compute-series-stats ["A" "B" "C"] [100 200 150])
+          stats        {:chart_type   :categorical
+                        :series_count 1
+                        :series       {"Few" series-stats}}
+          rep          (repr/generate-categorical-representation {:stats stats})]
+      (is (str/includes? rep "limited data points")))))
+
 ;;; ----------------------------------------- Time Series Repr Tests -------------------------------------------------
 
 (deftest generate-temporal-context-test
@@ -163,3 +193,32 @@
           rep (repr/generate-time-series-representation {:stats stats})]
       (is (str/includes? rep "Sales"))
       (is (str/includes? rep "Revenue")))))
+
+(deftest repr-time-series-deep-stats-test
+  (testing "deep stats include volatility, significant changes, and most recent change"
+    (let [values (mapv #(* 10.0 %) (range 1 13))
+          dates  (mapv #(format "2024-%02d" %) (range 1 13))
+          series-stats (time-series/compute-series-stats values dates {:deep? true})
+          stats  {:chart_type   :time-series
+                  :series_count 1
+                  :series       {"Metric" series-stats}}
+          rep    (repr/generate-time-series-representation {:stats stats})]
+      (is (str/includes? rep "Volatility"))
+      (is (str/includes? rep "Significant Changes"))
+      (is (str/includes? rep "Most Recent Change")))))
+
+;;; ---------------------------------------- generate-representation dispatch ------------------------------------------
+
+(deftest generate-representation-dispatches-to-correct-renderer-test
+  (testing "dispatches to the correct renderer for known chart type"
+    (let [ts-stats {:chart_type :time-series :series_count 1
+                    :series {"S" (time-series/compute-series-stats
+                                  [1.0 2.0 3.0 4.0 5.0]
+                                  ["d1" "d2" "d3" "d4" "d5"] {})}}]
+      (is (str/includes? (repr/generate-representation {:stats ts-stats}) "Time Series")))))
+
+(deftest generate-representation-unknown-chart-type-fallback-test
+  (testing "unknown chart type produces fallback message"
+    (is (str/includes?
+         (repr/generate-representation {:stats {:chart_type :waterfall}})
+         "not yet implemented"))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/repr_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/repr_test.clj
@@ -66,7 +66,7 @@
           stats        {:chart_type   :histogram
                         :series_count 1
                         :series       {"Test Series" series-stats}}
-          rep          (#'repr/generate-histogram-representation {:stats stats})]
+          rep          (repr/generate-representation {:stats stats})]
       (is (str/includes? rep "Test Series"))
       (is (str/includes? rep "Distribution Shape")))))
 
@@ -76,7 +76,7 @@
           stats        {:chart_type   :histogram
                         :series_count 1
                         :series       {"Values" series-stats}}
-          rep          (#'repr/generate-histogram-representation {:stats stats})]
+          rep          (repr/generate-representation {:stats stats})]
       (is (str/includes? rep "Percentiles"))
       (is (str/includes? rep "P50="))
       (is (str/includes? rep "IQR")))))
@@ -89,7 +89,7 @@
           stats        {:chart_type   :scatter
                         :series_count 1
                         :series       {"Test Series" series-stats}}
-          rep          (#'repr/generate-scatter-representation {:stats stats})]
+          rep          (repr/generate-representation {:stats stats})]
       (is (str/includes? rep "Test Series"))
       (is (str/includes? rep "Relationship"))
       (is (str/includes? rep "strong positive")))))
@@ -100,7 +100,7 @@
           stats        {:chart_type   :scatter
                         :series_count 1
                         :series       {"Linear" series-stats}}
-          rep          (#'repr/generate-scatter-representation {:stats stats})]
+          rep          (repr/generate-representation {:stats stats})]
       (is (str/includes? rep "Trend Line"))
       (is (str/includes? rep "y =")))))
 
@@ -112,7 +112,7 @@
           stats        {:chart_type   :categorical
                         :series_count 1
                         :series       {"Test Series" series-stats}}
-          rep          (#'repr/generate-categorical-representation {:stats stats})]
+          rep          (repr/generate-representation {:stats stats})]
       (is (str/includes? rep "Test Series"))
       (is (str/includes? rep "Categories"))
       (is (str/includes? rep "Top Categories")))))
@@ -125,7 +125,7 @@
           stats        {:chart_type   :categorical
                         :series_count 1
                         :series       {"Many" series-stats}}
-          rep          (#'repr/generate-categorical-representation {:stats stats})]
+          rep          (repr/generate-representation {:stats stats})]
       (is (str/includes? rep "Top Categories"))
       (is (str/includes? rep "Bottom Categories"))
       ;; highest value category (Cat20) appears
@@ -141,7 +141,7 @@
           stats        {:chart_type   :categorical
                         :series_count 1
                         :series       {"Few" series-stats}}
-          rep          (#'repr/generate-categorical-representation {:stats stats})]
+          rep          (repr/generate-representation {:stats stats})]
       (is (str/includes? rep "Top Categories"))
       (is (not (str/includes? rep "Bottom Categories"))))))
 
@@ -151,7 +151,7 @@
           stats        {:chart_type   :categorical
                         :series_count 1
                         :series       {"Few" series-stats}}
-          rep          (#'repr/generate-categorical-representation {:stats stats})]
+          rep          (repr/generate-representation {:stats stats})]
       (is (str/includes? rep "limited data points")))))
 
 ;;; ----------------------------------------- Time Series Repr Tests -------------------------------------------------
@@ -175,7 +175,7 @@
           stats {:chart_type   :time-series
                  :series_count 1
                  :series       {"Revenue" series-stats}}
-          rep (#'repr/generate-time-series-representation {:stats stats})]
+          rep (repr/generate-representation {:stats stats})]
       (is (str/includes? rep "Revenue"))
       (is (str/includes? rep "Trend"))
       (is (str/includes? rep "Time Series")))))
@@ -190,7 +190,7 @@
                                                       ["d1" "d2" "d3" "d4" "d5"])
                                 "Revenue" (make-stats [20.0 40.0 60.0 80.0 100.0]
                                                       ["d1" "d2" "d3" "d4" "d5"])}}
-          rep (#'repr/generate-time-series-representation {:stats stats})]
+          rep (repr/generate-representation {:stats stats})]
       (is (str/includes? rep "Sales"))
       (is (str/includes? rep "Revenue")))))
 
@@ -202,7 +202,7 @@
           stats  {:chart_type   :time-series
                   :series_count 1
                   :series       {"Metric" series-stats}}
-          rep    (#'repr/generate-time-series-representation {:stats stats})]
+          rep    (repr/generate-representation {:stats stats})]
       (is (str/includes? rep "Volatility"))
       (is (str/includes? rep "Significant Changes"))
       (is (str/includes? rep "Most Recent Change")))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/repr_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/repr_test.clj
@@ -61,8 +61,10 @@
 ;;; ------------------------------------------- Histogram Repr Tests -------------------------------------------------
 
 (deftest ^:parallel repr-histogram-shows-shape-test
-  (testing "representation includes Distribution Shape when enough data"
-    (let [series-stats (#'histogram/compute-series-stats (range 1 101))
+  (testing "representation includes Distribution Shape when enough bins"
+    (let [xs           (range 0 100 10)
+          ys           [1 3 8 15 25 25 15 8 3 1]
+          series-stats (#'histogram/compute-series-stats xs ys)
           stats        {:chart_type   :histogram
                         :series_count 1
                         :series       {"Test Series" series-stats}}
@@ -71,15 +73,28 @@
       (is (str/includes? rep "Distribution Shape")))))
 
 (deftest ^:parallel repr-histogram-shows-percentiles-and-iqr-test
-  (testing "histogram representation includes percentiles and IQR for sufficient data"
-    (let [series-stats (#'histogram/compute-series-stats (range 1 101))
+  (testing "histogram representation includes estimated percentiles and IQR"
+    (let [xs           (range 0 100 10)
+          ys           [1 3 8 15 25 25 15 8 3 1]
+          series-stats (#'histogram/compute-series-stats xs ys)
           stats        {:chart_type   :histogram
                         :series_count 1
                         :series       {"Values" series-stats}}
           rep          (repr/generate-representation {:stats stats})]
-      (is (str/includes? rep "Percentiles"))
-      (is (str/includes? rep "P50="))
-      (is (str/includes? rep "IQR")))))
+      (is (str/includes? rep "Estimated Percentiles"))
+      (is (str/includes? rep "P50≈"))
+      (is (str/includes? rep "Estimated IQR")))))
+
+(deftest ^:parallel repr-histogram-shows-structure-test
+  (testing "histogram representation includes structural metrics"
+    (let [series-stats (#'histogram/compute-series-stats [0 10 20 30 40] [5 10 20 10 5])
+          stats        {:chart_type   :histogram
+                        :series_count 1
+                        :series       {"Bins" series-stats}}
+          rep          (repr/generate-representation {:stats stats})]
+      (is (str/includes? rep "Structure"))
+      (is (str/includes? rep "mode bin"))
+      (is (str/includes? rep "top 3 bins contain")))))
 
 ;;; -------------------------------------------- Scatter Repr Tests --------------------------------------------------
 

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/repr_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/repr_test.clj
@@ -35,7 +35,7 @@
 
 (deftest ^:parallel repr-includes-downsampled-note-test
   (testing "Representation includes a note about downsampled data"
-    (let [n      (+ stats.core/max-data-points-per-series 1000)
+    (let [n      (+ @#'stats.core/max-data-points-per-series 1000)
           config (make-chart-config 1 n)
           stats  (stats.core/compute-chart-stats config {:deep? false})
           repr   (repr/generate-representation {:title "Test" :display-type "line" :stats stats})]
@@ -44,7 +44,7 @@
 
 (deftest ^:parallel repr-includes-correlations-capped-note-test
   (testing "Representation includes a note about capped correlations"
-    (let [n-series (+ stats.core/max-series-for-correlations 5)
+    (let [n-series (+ @#'stats.core/max-series-for-correlations 5)
           config   (make-chart-config n-series 50)
           stats    (stats.core/compute-chart-stats config {:deep? true})
           repr     (repr/generate-representation {:title "Test" :display-type "line" :stats stats})]
@@ -62,21 +62,21 @@
 
 (deftest ^:parallel repr-histogram-shows-shape-test
   (testing "representation includes Distribution Shape when enough data"
-    (let [series-stats (histogram/compute-series-stats (range 1 101))
+    (let [series-stats (#'histogram/compute-series-stats (range 1 101))
           stats        {:chart_type   :histogram
                         :series_count 1
                         :series       {"Test Series" series-stats}}
-          rep          (repr/generate-histogram-representation {:stats stats})]
+          rep          (#'repr/generate-histogram-representation {:stats stats})]
       (is (str/includes? rep "Test Series"))
       (is (str/includes? rep "Distribution Shape")))))
 
 (deftest ^:parallel repr-histogram-shows-percentiles-and-iqr-test
   (testing "histogram representation includes percentiles and IQR for sufficient data"
-    (let [series-stats (histogram/compute-series-stats (range 1 101))
+    (let [series-stats (#'histogram/compute-series-stats (range 1 101))
           stats        {:chart_type   :histogram
                         :series_count 1
                         :series       {"Values" series-stats}}
-          rep          (repr/generate-histogram-representation {:stats stats})]
+          rep          (#'repr/generate-histogram-representation {:stats stats})]
       (is (str/includes? rep "Percentiles"))
       (is (str/includes? rep "P50="))
       (is (str/includes? rep "IQR")))))
@@ -85,22 +85,22 @@
 
 (deftest ^:parallel repr-scatter-shows-relationship-test
   (testing "representation includes Relationship with strength and direction"
-    (let [series-stats (scatter/compute-series-stats [1 2 3 4 5] [10 20 30 40 50])
+    (let [series-stats (#'scatter/compute-series-stats [1 2 3 4 5] [10 20 30 40 50])
           stats        {:chart_type   :scatter
                         :series_count 1
                         :series       {"Test Series" series-stats}}
-          rep          (repr/generate-scatter-representation {:stats stats})]
+          rep          (#'repr/generate-scatter-representation {:stats stats})]
       (is (str/includes? rep "Test Series"))
       (is (str/includes? rep "Relationship"))
       (is (str/includes? rep "strong positive")))))
 
 (deftest ^:parallel repr-scatter-shows-trend-line-test
   (testing "scatter representation includes trend line equation when regression is present"
-    (let [series-stats (scatter/compute-series-stats [1 2 3 4 5] [12 14 16 18 20])
+    (let [series-stats (#'scatter/compute-series-stats [1 2 3 4 5] [12 14 16 18 20])
           stats        {:chart_type   :scatter
                         :series_count 1
                         :series       {"Linear" series-stats}}
-          rep          (repr/generate-scatter-representation {:stats stats})]
+          rep          (#'repr/generate-scatter-representation {:stats stats})]
       (is (str/includes? rep "Trend Line"))
       (is (str/includes? rep "y =")))))
 
@@ -108,11 +108,11 @@
 
 (deftest ^:parallel repr-categorical-includes-key-info-test
   (testing "representation includes series name, data count, and Categories"
-    (let [series-stats (categorical/compute-series-stats ["A" "B" "C"] [100 200 150])
+    (let [series-stats (#'categorical/compute-series-stats ["A" "B" "C"] [100 200 150])
           stats        {:chart_type   :categorical
                         :series_count 1
                         :series       {"Test Series" series-stats}}
-          rep          (repr/generate-categorical-representation {:stats stats})]
+          rep          (#'repr/generate-categorical-representation {:stats stats})]
       (is (str/includes? rep "Test Series"))
       (is (str/includes? rep "Categories"))
       (is (str/includes? rep "Top Categories")))))
@@ -121,11 +121,11 @@
   (testing "Bottom Categories shown when > 15 categories"
     (let [xs           (map #(str "Cat" (format "%02d" %)) (range 1 21))
           ys           (map double (range 1 21))
-          series-stats (categorical/compute-series-stats xs ys)
+          series-stats (#'categorical/compute-series-stats xs ys)
           stats        {:chart_type   :categorical
                         :series_count 1
                         :series       {"Many" series-stats}}
-          rep          (repr/generate-categorical-representation {:stats stats})]
+          rep          (#'repr/generate-categorical-representation {:stats stats})]
       (is (str/includes? rep "Top Categories"))
       (is (str/includes? rep "Bottom Categories"))
       ;; highest value category (Cat20) appears
@@ -137,28 +137,28 @@
   (testing "Bottom Categories absent when <= 15 categories"
     (let [xs           (map #(str "Cat" %) (range 1 16))
           ys           (map double (range 1 16))
-          series-stats (categorical/compute-series-stats xs ys)
+          series-stats (#'categorical/compute-series-stats xs ys)
           stats        {:chart_type   :categorical
                         :series_count 1
                         :series       {"Few" series-stats}}
-          rep          (repr/generate-categorical-representation {:stats stats})]
+          rep          (#'repr/generate-categorical-representation {:stats stats})]
       (is (str/includes? rep "Top Categories"))
       (is (not (str/includes? rep "Bottom Categories"))))))
 
 (deftest ^:parallel repr-categorical-sparse-data-warning-test
   (testing "sparse data warning shown for series with < 10 data points"
-    (let [series-stats (categorical/compute-series-stats ["A" "B" "C"] [100 200 150])
+    (let [series-stats (#'categorical/compute-series-stats ["A" "B" "C"] [100 200 150])
           stats        {:chart_type   :categorical
                         :series_count 1
                         :series       {"Few" series-stats}}
-          rep          (repr/generate-categorical-representation {:stats stats})]
+          rep          (#'repr/generate-categorical-representation {:stats stats})]
       (is (str/includes? rep "limited data points")))))
 
 ;;; ----------------------------------------- Time Series Repr Tests -------------------------------------------------
 
 (deftest ^:parallel generate-temporal-context-test
   (testing "temporal context includes current date, day of week, week, month, and quarter"
-    (let [result (repr/generate-temporal-context)]
+    (let [result (#'repr/generate-temporal-context)]
       (is (str/includes? result "Today is"))
       (is (some #(str/includes? result %)
                 ["Monday" "Tuesday" "Wednesday" "Thursday" "Friday" "Saturday" "Sunday"]))
@@ -171,11 +171,11 @@
   (testing "time series representation includes series name and trend direction"
     (let [values [10.0 20.0 30.0 40.0 50.0]
           dates  ["2024-01" "2024-02" "2024-03" "2024-04" "2024-05"]
-          series-stats (time-series/compute-series-stats values dates {})
+          series-stats (#'time-series/compute-series-stats values dates {})
           stats {:chart_type   :time-series
                  :series_count 1
                  :series       {"Revenue" series-stats}}
-          rep (repr/generate-time-series-representation {:stats stats})]
+          rep (#'repr/generate-time-series-representation {:stats stats})]
       (is (str/includes? rep "Revenue"))
       (is (str/includes? rep "Trend"))
       (is (str/includes? rep "Time Series")))))
@@ -183,14 +183,14 @@
 (deftest ^:parallel repr-time-series-multi-series-test
   (testing "representation with multiple series includes all series names"
     (let [make-stats (fn [values dates]
-                       (time-series/compute-series-stats values dates {}))
+                       (#'time-series/compute-series-stats values dates {}))
           stats {:chart_type   :time-series
                  :series_count 2
                  :series       {"Sales"   (make-stats [10.0 20.0 30.0 40.0 50.0]
                                                       ["d1" "d2" "d3" "d4" "d5"])
                                 "Revenue" (make-stats [20.0 40.0 60.0 80.0 100.0]
                                                       ["d1" "d2" "d3" "d4" "d5"])}}
-          rep (repr/generate-time-series-representation {:stats stats})]
+          rep (#'repr/generate-time-series-representation {:stats stats})]
       (is (str/includes? rep "Sales"))
       (is (str/includes? rep "Revenue")))))
 
@@ -198,11 +198,11 @@
   (testing "deep stats include volatility, significant changes, and most recent change"
     (let [values (mapv #(* 10.0 %) (range 1 13))
           dates  (mapv #(format "2024-%02d" %) (range 1 13))
-          series-stats (time-series/compute-series-stats values dates {:deep? true})
+          series-stats (#'time-series/compute-series-stats values dates {:deep? true})
           stats  {:chart_type   :time-series
                   :series_count 1
                   :series       {"Metric" series-stats}}
-          rep    (repr/generate-time-series-representation {:stats stats})]
+          rep    (#'repr/generate-time-series-representation {:stats stats})]
       (is (str/includes? rep "Volatility"))
       (is (str/includes? rep "Significant Changes"))
       (is (str/includes? rep "Most Recent Change")))))
@@ -212,7 +212,7 @@
 (deftest ^:parallel generate-representation-dispatches-to-correct-renderer-test
   (testing "dispatches to the correct renderer for known chart type"
     (let [ts-stats {:chart_type :time-series :series_count 1
-                    :series {"S" (time-series/compute-series-stats
+                    :series {"S" (#'time-series/compute-series-stats
                                   [1.0 2.0 3.0 4.0 5.0]
                                   ["d1" "d2" "d3" "d4" "d5"] {})}}]
       (is (str/includes? (repr/generate-representation {:stats ts-stats}) "Time Series")))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/repr_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/repr_test.clj
@@ -235,5 +235,7 @@
 (deftest ^:parallel generate-representation-unknown-chart-type-fallback-test
   (testing "unknown chart type produces fallback message"
     (is (str/includes?
-         (repr/generate-representation {:stats {:chart_type :unknown}})
+         (repr/generate-representation {:stats {:chart_type   :unknown
+                                                :series_count 0
+                                                :message      "Stats not yet implemented"}})
          "not yet implemented"))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/repr_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/repr_test.clj
@@ -33,7 +33,7 @@
 
 ;;; ------------------------------------------ Repr Limits Note Tests ------------------------------------------------
 
-(deftest repr-includes-downsampled-note-test
+(deftest ^:parallel repr-includes-downsampled-note-test
   (testing "Representation includes a note about downsampled data"
     (let [n      (+ stats.core/max-data-points-per-series 1000)
           config (make-chart-config 1 n)
@@ -42,7 +42,7 @@
       (is (str/includes? repr "Data Limits Applied"))
       (is (str/includes? repr "downsampled")))))
 
-(deftest repr-includes-correlations-capped-note-test
+(deftest ^:parallel repr-includes-correlations-capped-note-test
   (testing "Representation includes a note about capped correlations"
     (let [n-series (+ stats.core/max-series-for-correlations 5)
           config   (make-chart-config n-series 50)
@@ -51,7 +51,7 @@
       (is (str/includes? repr "Data Limits Applied"))
       (is (str/includes? repr "correlations were limited")))))
 
-(deftest repr-no-limits-note-when-within-bounds-test
+(deftest ^:parallel repr-no-limits-note-when-within-bounds-test
   (testing "No limits note when data is within bounds"
     (let [config (make-chart-config 2 100)
           stats  (stats.core/compute-chart-stats config {:deep? true})
@@ -60,7 +60,7 @@
 
 ;;; ------------------------------------------- Histogram Repr Tests -------------------------------------------------
 
-(deftest repr-histogram-shows-shape-test
+(deftest ^:parallel repr-histogram-shows-shape-test
   (testing "representation includes Distribution Shape when enough data"
     (let [series-stats (histogram/compute-series-stats (range 1 101))
           stats        {:chart_type   :histogram
@@ -70,7 +70,7 @@
       (is (str/includes? rep "Test Series"))
       (is (str/includes? rep "Distribution Shape")))))
 
-(deftest repr-histogram-shows-percentiles-and-iqr-test
+(deftest ^:parallel repr-histogram-shows-percentiles-and-iqr-test
   (testing "histogram representation includes percentiles and IQR for sufficient data"
     (let [series-stats (histogram/compute-series-stats (range 1 101))
           stats        {:chart_type   :histogram
@@ -83,7 +83,7 @@
 
 ;;; -------------------------------------------- Scatter Repr Tests --------------------------------------------------
 
-(deftest repr-scatter-shows-relationship-test
+(deftest ^:parallel repr-scatter-shows-relationship-test
   (testing "representation includes Relationship with strength and direction"
     (let [series-stats (scatter/compute-series-stats [1 2 3 4 5] [10 20 30 40 50])
           stats        {:chart_type   :scatter
@@ -94,7 +94,7 @@
       (is (str/includes? rep "Relationship"))
       (is (str/includes? rep "strong positive")))))
 
-(deftest repr-scatter-shows-trend-line-test
+(deftest ^:parallel repr-scatter-shows-trend-line-test
   (testing "scatter representation includes trend line equation when regression is present"
     (let [series-stats (scatter/compute-series-stats [1 2 3 4 5] [12 14 16 18 20])
           stats        {:chart_type   :scatter
@@ -106,7 +106,7 @@
 
 ;;; ------------------------------------------ Categorical Repr Tests ------------------------------------------------
 
-(deftest repr-categorical-includes-key-info-test
+(deftest ^:parallel repr-categorical-includes-key-info-test
   (testing "representation includes series name, data count, and Categories"
     (let [series-stats (categorical/compute-series-stats ["A" "B" "C"] [100 200 150])
           stats        {:chart_type   :categorical
@@ -117,7 +117,7 @@
       (is (str/includes? rep "Categories"))
       (is (str/includes? rep "Top Categories")))))
 
-(deftest repr-categorical-shows-bottom-categories-for-large-dataset-test
+(deftest ^:parallel repr-categorical-shows-bottom-categories-for-large-dataset-test
   (testing "Bottom Categories shown when > 15 categories"
     (let [xs           (map #(str "Cat" (format "%02d" %)) (range 1 21))
           ys           (map double (range 1 21))
@@ -133,7 +133,7 @@
       ;; lowest value category (Cat01) appears
       (is (str/includes? rep "Cat01")))))
 
-(deftest repr-categorical-no-bottom-categories-for-small-dataset-test
+(deftest ^:parallel repr-categorical-no-bottom-categories-for-small-dataset-test
   (testing "Bottom Categories absent when <= 15 categories"
     (let [xs           (map #(str "Cat" %) (range 1 16))
           ys           (map double (range 1 16))
@@ -145,7 +145,7 @@
       (is (str/includes? rep "Top Categories"))
       (is (not (str/includes? rep "Bottom Categories"))))))
 
-(deftest repr-categorical-sparse-data-warning-test
+(deftest ^:parallel repr-categorical-sparse-data-warning-test
   (testing "sparse data warning shown for series with < 10 data points"
     (let [series-stats (categorical/compute-series-stats ["A" "B" "C"] [100 200 150])
           stats        {:chart_type   :categorical
@@ -156,7 +156,7 @@
 
 ;;; ----------------------------------------- Time Series Repr Tests -------------------------------------------------
 
-(deftest generate-temporal-context-test
+(deftest ^:parallel generate-temporal-context-test
   (testing "temporal context includes current date, day of week, week, month, and quarter"
     (let [result (repr/generate-temporal-context)]
       (is (str/includes? result "Today is"))
@@ -167,7 +167,7 @@
       (is (str/includes? (u/lower-case-en result) "quarter"))
       (is (some #(str/includes? result %) ["Q1" "Q2" "Q3" "Q4"])))))
 
-(deftest repr-time-series-includes-series-name-and-trend-test
+(deftest ^:parallel repr-time-series-includes-series-name-and-trend-test
   (testing "time series representation includes series name and trend direction"
     (let [values [10.0 20.0 30.0 40.0 50.0]
           dates  ["2024-01" "2024-02" "2024-03" "2024-04" "2024-05"]
@@ -180,7 +180,7 @@
       (is (str/includes? rep "Trend"))
       (is (str/includes? rep "Time Series")))))
 
-(deftest repr-time-series-multi-series-test
+(deftest ^:parallel repr-time-series-multi-series-test
   (testing "representation with multiple series includes all series names"
     (let [make-stats (fn [values dates]
                        (time-series/compute-series-stats values dates {}))
@@ -194,7 +194,7 @@
       (is (str/includes? rep "Sales"))
       (is (str/includes? rep "Revenue")))))
 
-(deftest repr-time-series-deep-stats-test
+(deftest ^:parallel repr-time-series-deep-stats-test
   (testing "deep stats include volatility, significant changes, and most recent change"
     (let [values (mapv #(* 10.0 %) (range 1 13))
           dates  (mapv #(format "2024-%02d" %) (range 1 13))
@@ -209,7 +209,7 @@
 
 ;;; ---------------------------------------- generate-representation dispatch ------------------------------------------
 
-(deftest generate-representation-dispatches-to-correct-renderer-test
+(deftest ^:parallel generate-representation-dispatches-to-correct-renderer-test
   (testing "dispatches to the correct renderer for known chart type"
     (let [ts-stats {:chart_type :time-series :series_count 1
                     :series {"S" (time-series/compute-series-stats
@@ -217,7 +217,7 @@
                                   ["d1" "d2" "d3" "d4" "d5"] {})}}]
       (is (str/includes? (repr/generate-representation {:stats ts-stats}) "Time Series")))))
 
-(deftest generate-representation-unknown-chart-type-fallback-test
+(deftest ^:parallel generate-representation-unknown-chart-type-fallback-test
   (testing "unknown chart type produces fallback message"
     (is (str/includes?
          (repr/generate-representation {:stats {:chart_type :waterfall}})

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/scatter_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/scatter_test.clj
@@ -58,11 +58,11 @@
       (is (= :negative (:direction corr))))))
 
 (deftest compute-series-stats-weak-correlation-test
-  (testing "uncorrelated data has weak strength"
-    ;; y = [3 1 2 1 3] produces Pearson r = 0 with x = [1 2 3 4 5]
+  (testing "uncorrelated data has no correlation strength"
+    ;; y = [3 1 2 1 3] produces Pearson r ≈ 0 with x = [1 2 3 4 5]
     (let [result (scatter/compute-series-stats [1 2 3 4 5] [3 1 2 1 3])]
       (when-let [corr (:correlation result)]
-        (is (= :weak (:strength corr)))))))
+        (is (= :none (:strength corr)))))))
 
 (deftest compute-series-stats-moderate-correlation-test
   (testing "moderate correlation (0.3-0.7)"

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/scatter_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/scatter_test.clj
@@ -1,0 +1,151 @@
+(ns metabase-enterprise.metabot-v3.stats.scatter-test
+  (:require
+   [clojure.string :as str]
+   [clojure.test :refer :all]
+   [metabase-enterprise.metabot-v3.stats.repr :as repr]
+   [metabase-enterprise.metabot-v3.stats.scatter :as scatter]))
+
+(set! *warn-on-reflection* true)
+
+(deftest compute-series-stats-empty-test
+  (testing "empty/nil series returns minimal result without crashing"
+    (let [result (scatter/compute-series-stats [] [])]
+      (is (= 0 (:data_points result)))
+      (is (nil? (:x_summary result)))
+      (is (nil? (:y_summary result))))))
+
+(deftest compute-series-stats-nil-filtered-test
+  (testing "nil x or y values are filtered out"
+    (let [result (scatter/compute-series-stats [1 nil 3] [4 5 nil])]
+      ;; only [1,4] is fully valid
+      (is (= 1 (:data_points result))))))
+
+(deftest compute-series-stats-one-valid-pair-test
+  (testing "< 2 valid pairs gives no correlation or regression"
+    (let [result (scatter/compute-series-stats [1] [2])]
+      (is (= 1 (:data_points result)))
+      (is (nil? (:correlation result)))
+      (is (nil? (:regression result))))))
+
+(deftest compute-series-stats-two-valid-pairs-test
+  (testing "2 valid pairs gives correlation but no regression (< 3)"
+    (let [result (scatter/compute-series-stats [1 2] [3 4])]
+      (is (= 2 (:data_points result)))
+      (is (some? (:correlation result)))
+      (is (nil? (:regression result))))))
+
+(deftest compute-series-stats-perfect-positive-correlation-test
+  (testing "perfect positive correlation"
+    (let [result (scatter/compute-series-stats [1 2 3 4 5] [2 4 6 8 10])
+          corr   (:correlation result)
+          reg    (:regression result)]
+      (is (= 5 (:data_points result)))
+      (is (some? corr))
+      (is (== (:coefficient corr) 1.0))
+      (is (= :strong (:strength corr)))
+      (is (= :positive (:direction corr)))
+      (is (some? reg))
+      (is (== (:slope reg) 2.0))
+      (is (== (:r_squared reg) 1.0)))))
+
+(deftest compute-series-stats-perfect-negative-correlation-test
+  (testing "perfect negative correlation"
+    (let [result (scatter/compute-series-stats [1 2 3 4 5] [10 8 6 4 2])
+          corr   (:correlation result)]
+      (is (some? corr))
+      (is (== (:coefficient corr) -1.0))
+      (is (= :strong (:strength corr)))
+      (is (= :negative (:direction corr))))))
+
+(deftest compute-series-stats-weak-correlation-test
+  (testing "uncorrelated data has weak strength"
+    ;; y = [3 1 2 1 3] produces Pearson r = 0 with x = [1 2 3 4 5]
+    (let [result (scatter/compute-series-stats [1 2 3 4 5] [3 1 2 1 3])]
+      (when-let [corr (:correlation result)]
+        (is (= :weak (:strength corr)))))))
+
+(deftest compute-series-stats-moderate-correlation-test
+  (testing "moderate correlation (0.3-0.7)"
+    ;; y = x + noise roughly
+    (let [result (scatter/compute-series-stats
+                  [1 2 3 4 5 6 7 8]
+                  [1.5 2.1 4.0 3.8 5.5 5.1 7.2 6.9])
+          corr   (:correlation result)]
+      (is (some? corr))
+      (is (#{:moderate :strong} (:strength corr))))))
+
+(deftest compute-series-stats-constant-x-test
+  (testing "constant x-values result in regression returning nil gracefully"
+    (let [result (scatter/compute-series-stats [5 5 5 5] [1 2 3 4])]
+      ;; correlation will be NaN (constant x), regression may fail
+      (is (= 4 (:data_points result)))
+      ;; should not throw
+      (is (map? result)))))
+
+(deftest compute-series-stats-summaries-test
+  (testing "x and y summaries computed correctly"
+    (let [result (scatter/compute-series-stats [1 2 3] [10 20 30])
+          xs     (:x_summary result)
+          ys     (:y_summary result)]
+      (is (= 1.0 (:min xs)))
+      (is (= 3.0 (:max xs)))
+      (is (= 10.0 (:min ys)))
+      (is (= 30.0 (:max ys))))))
+
+(deftest compute-scatter-stats-multi-series-test
+  (testing "each series gets independent stats; no cross-series correlations"
+    (let [series-data {"S1" {:x_values [1 2 3] :y_values [4 5 6]
+                             :x {:name "x" :type :number}
+                             :y {:name "y" :type :number}
+                             :display_name "S1"}
+                       "S2" {:x_values [1 2 3] :y_values [6 5 4]
+                             :x {:name "x" :type :number}
+                             :y {:name "y" :type :number}
+                             :display_name "S2"}}
+          result (scatter/compute-scatter-stats series-data {})]
+      (is (= :scatter (:chart_type result)))
+      (is (= 2 (:series_count result)))
+      (is (contains? (:series result) "S1"))
+      (is (contains? (:series result) "S2"))
+      ;; No cross-series correlations key
+      (is (nil? (:correlations result))))))
+
+(deftest compute-series-stats-regression-intercept-test
+  (testing "regression intercept computed correctly for y = 2x + 10"
+    (let [result (scatter/compute-series-stats [1 2 3 4 5] [12 14 16 18 20])
+          reg    (:regression result)]
+      (is (some? reg))
+      (is (< (Math/abs (- (:slope reg) 2.0)) 0.001))
+      (is (< (Math/abs (- (:intercept reg) 10.0)) 0.001))
+      (is (< (Math/abs (- (:r_squared reg) 1.0)) 0.001)))))
+
+(deftest compute-series-stats-constant-y-test
+  (testing "constant y-values: NaN correlation is handled gracefully (nil correlation)"
+    (let [result (scatter/compute-series-stats [1 2 3 4 5] [50 50 50 50 50])]
+      (is (= 5 (:data_points result)))
+      ;; Y has no variance; correlation is NaN, should be nil
+      (is (nil? (:correlation result))))))
+
+(deftest compute-series-stats-float-values-test
+  (testing "float x and y values handled correctly"
+    (let [result (scatter/compute-series-stats
+                  [1.5 2.5 3.5 4.5 5.5]
+                  [10.1 20.2 30.3 40.4 50.5])
+          xs     (:x_summary result)
+          ys     (:y_summary result)]
+      (is (= 5 (:data_points result)))
+      (is (< (Math/abs (- (:min xs) 1.5)) 0.001))
+      (is (< (Math/abs (- (:max xs) 5.5)) 0.001))
+      (is (< (Math/abs (- (:min ys) 10.1)) 0.001))
+      (is (< (Math/abs (- (:max ys) 50.5)) 0.001)))))
+
+(deftest repr-scatter-shows-relationship-test
+  (testing "representation includes Relationship with strength and direction"
+    (let [series-stats (scatter/compute-series-stats [1 2 3 4 5] [10 20 30 40 50])
+          stats        {:chart_type   :scatter
+                        :series_count 1
+                        :series       {"Test Series" series-stats}}
+          rep          (repr/generate-scatter-representation {:stats stats})]
+      (is (str/includes? rep "Test Series"))
+      (is (str/includes? rep "Relationship"))
+      (is (str/includes? rep "strong positive")))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/scatter_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/scatter_test.clj
@@ -29,7 +29,7 @@
 (deftest ^:parallel compute-series-stats-two-valid-pairs-test
   (testing "2 valid pairs gives correlation but no regression (< 3)"
     (is (=? {:data_points 2
-             :correlation some?
+             :correlation {:coefficient 1.0 :strength :strong :direction :positive}
              :regression  (symbol "nil #_\"key is not present.\"")}
             (#'scatter/compute-series-stats [1 2] [3 4])))))
 
@@ -84,7 +84,14 @@
                              :display_name "S2"}}]
       (is (=? {:chart_type    :scatter
                :series_count  2
-               :series        {"S1" some? "S2" some?}
+               :series        {"S1" {:data_points 3
+                                     :correlation {:coefficient 1.0
+                                                   :strength :strong
+                                                   :direction :positive}}
+                               "S2" {:data_points 3
+                                     :correlation {:coefficient -1.0
+                                                   :strength :strong
+                                                   :direction :negative}}}
                :correlations  (symbol "nil #_\"key is not present.\"")}
               (scatter/compute-scatter-stats series-data {}))))))
 

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/scatter_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/scatter_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]
+   [mb.hawk.assert-exprs.approximately-equal :as =?]
    [metabase-enterprise.metabot-v3.stats.repr :as repr]
    [metabase-enterprise.metabot-v3.stats.scatter :as scatter]))
 
@@ -91,9 +92,9 @@
 
 (deftest compute-series-stats-regression-intercept-test
   (testing "regression intercept computed correctly for y = 2x + 10"
-    (is (=? {:regression {:slope     #(< (Math/abs (- % 2.0)) 0.001)
-                          :intercept #(< (Math/abs (- % 10.0)) 0.001)
-                          :r_squared #(< (Math/abs (- % 1.0)) 0.001)}}
+    (is (=? {:regression {:slope     (=?/approx [2.0 0.001])
+                          :intercept (=?/approx [10.0 0.001])
+                          :r_squared (=?/approx [1.0 0.001])}}
             (scatter/compute-series-stats [1 2 3 4 5] [12 14 16 18 20])))))
 
 (deftest compute-series-stats-constant-y-test
@@ -106,10 +107,10 @@
 (deftest compute-series-stats-float-values-test
   (testing "float x and y values handled correctly"
     (is (=? {:data_points 5
-             :x_summary {:min #(< (Math/abs (- % 1.5)) 0.001)
-                         :max #(< (Math/abs (- % 5.5)) 0.001)}
-             :y_summary {:min #(< (Math/abs (- % 10.1)) 0.001)
-                         :max #(< (Math/abs (- % 50.5)) 0.001)}}
+             :x_summary {:min (=?/approx [1.5 0.001])
+                         :max (=?/approx [5.5 0.001])}
+             :y_summary {:min (=?/approx [10.1 0.001])
+                         :max (=?/approx [50.5 0.001])}}
             (scatter/compute-series-stats
              [1.5 2.5 3.5 4.5 5.5]
              [10.1 20.2 30.3 40.4 50.5])))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/scatter_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/scatter_test.clj
@@ -6,73 +6,73 @@
 
 (set! *warn-on-reflection* true)
 
-(deftest compute-series-stats-empty-test
+(deftest ^:parallel compute-series-stats-empty-test
   (testing "empty/nil series returns minimal result"
     (is (=? {:data_points 0
              :x_summary nil?
              :y_summary nil?}
             (scatter/compute-series-stats [] [])))))
 
-(deftest compute-series-stats-nil-filtered-test
+(deftest ^:parallel compute-series-stats-nil-filtered-test
   (testing "nil x or y values are filtered out"
     ;; only [1,4] is fully valid
     (is (=? {:data_points 1}
             (scatter/compute-series-stats [1 nil 3] [4 5 nil])))))
 
-(deftest compute-series-stats-one-valid-pair-test
+(deftest ^:parallel compute-series-stats-one-valid-pair-test
   (testing "< 2 valid pairs gives no correlation or regression"
     (is (=? {:data_points  1
              :correlation  (symbol "nil #_\"key is not present.\"")
              :regression   (symbol "nil #_\"key is not present.\"")}
             (scatter/compute-series-stats [1] [2])))))
 
-(deftest compute-series-stats-two-valid-pairs-test
+(deftest ^:parallel compute-series-stats-two-valid-pairs-test
   (testing "2 valid pairs gives correlation but no regression (< 3)"
     (is (=? {:data_points 2
              :correlation some?
              :regression  (symbol "nil #_\"key is not present.\"")}
             (scatter/compute-series-stats [1 2] [3 4])))))
 
-(deftest compute-series-stats-perfect-positive-correlation-test
+(deftest ^:parallel compute-series-stats-perfect-positive-correlation-test
   (testing "perfect positive correlation"
     (is (=? {:data_points 5
              :correlation {:coefficient 1.0 :strength :strong :direction :positive}
              :regression  {:slope 2.0 :r_squared 1.0}}
             (scatter/compute-series-stats [1 2 3 4 5] [2 4 6 8 10])))))
 
-(deftest compute-series-stats-perfect-negative-correlation-test
+(deftest ^:parallel compute-series-stats-perfect-negative-correlation-test
   (testing "perfect negative correlation"
     (is (=? {:correlation {:coefficient -1.0
                            :strength :strong
                            :direction :negative}}
             (scatter/compute-series-stats [1 2 3 4 5] [10 8 6 4 2])))))
 
-(deftest compute-series-stats-weak-correlation-test
+(deftest ^:parallel compute-series-stats-weak-correlation-test
   (testing "uncorrelated data has no correlation strength"
     ;; y = [3 1 2 1 3] produces Pearson r ≈ 0 with x = [1 2 3 4 5]
     (is (=? {:correlation {:strength :none}}
             (scatter/compute-series-stats [1 2 3 4 5] [3 1 2 1 3])))))
 
-(deftest compute-series-stats-strong-correlation-test
+(deftest ^:parallel compute-series-stats-strong-correlation-test
   (testing "strong correlation (> 0.7)"
     (is (=? {:correlation {:strength :strong}}
             (scatter/compute-series-stats
              [1 2 3 4 5 6 7 8]
              [1.5 2.1 4.0 3.8 5.5 5.1 7.2 6.9])))))
 
-(deftest compute-series-stats-constant-x-test
+(deftest ^:parallel compute-series-stats-constant-x-test
   (testing "constant x-values result in regression returning nil gracefully"
     ;; correlation will be NaN (constant x). regression may fail but should not throw.
     (is (=? {:data_points 4}
             (scatter/compute-series-stats [5 5 5 5] [1 2 3 4])))))
 
-(deftest compute-series-stats-summaries-test
+(deftest ^:parallel compute-series-stats-summaries-test
   (testing "x and y summaries computed correctly"
     (is (=? {:x_summary {:min 1.0 :max 3.0}
              :y_summary {:min 10.0 :max 30.0}}
             (scatter/compute-series-stats [1 2 3] [10 20 30])))))
 
-(deftest compute-scatter-stats-multi-series-test
+(deftest ^:parallel compute-scatter-stats-multi-series-test
   (testing "each series gets independent stats; no cross-series correlations"
     (let [series-data {"S1" {:x_values [1 2 3] :y_values [4 5 6]
                              :x {:name "x" :type :number}
@@ -88,21 +88,21 @@
                :correlations  (symbol "nil #_\"key is not present.\"")}
               (scatter/compute-scatter-stats series-data {}))))))
 
-(deftest compute-series-stats-regression-intercept-test
+(deftest ^:parallel compute-series-stats-regression-intercept-test
   (testing "regression intercept computed correctly for y = 2x + 10"
     (is (=? {:regression {:slope     (=?/approx [2.0 0.001])
                           :intercept (=?/approx [10.0 0.001])
                           :r_squared (=?/approx [1.0 0.001])}}
             (scatter/compute-series-stats [1 2 3 4 5] [12 14 16 18 20])))))
 
-(deftest compute-series-stats-constant-y-test
+(deftest ^:parallel compute-series-stats-constant-y-test
   (testing "constant y-values: NaN correlation is handled gracefully (nil correlation)"
     ;; Y has no variance; correlation is NaN, should be absent
     (is (=? {:data_points  5
              :correlation  (symbol "nil #_\"key is not present.\"")}
             (scatter/compute-series-stats [1 2 3 4 5] [50 50 50 50 50])))))
 
-(deftest compute-series-stats-float-values-test
+(deftest ^:parallel compute-series-stats-float-values-test
   (testing "float x and y values handled correctly"
     (is (=? {:data_points 5
              :x_summary {:min (=?/approx [1.5 0.001])

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/scatter_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/scatter_test.clj
@@ -8,89 +8,70 @@
 (set! *warn-on-reflection* true)
 
 (deftest compute-series-stats-empty-test
-  (testing "empty/nil series returns minimal result without crashing"
-    (let [result (scatter/compute-series-stats [] [])]
-      (is (= 0 (:data_points result)))
-      (is (nil? (:x_summary result)))
-      (is (nil? (:y_summary result))))))
+  (testing "empty/nil series returns minimal result"
+    (is (=? {:data_points 0
+             :x_summary nil?
+             :y_summary nil?}
+            (scatter/compute-series-stats [] [])))))
 
 (deftest compute-series-stats-nil-filtered-test
   (testing "nil x or y values are filtered out"
-    (let [result (scatter/compute-series-stats [1 nil 3] [4 5 nil])]
-      ;; only [1,4] is fully valid
-      (is (= 1 (:data_points result))))))
+    ;; only [1,4] is fully valid
+    (is (=? {:data_points 1}
+            (scatter/compute-series-stats [1 nil 3] [4 5 nil])))))
 
 (deftest compute-series-stats-one-valid-pair-test
   (testing "< 2 valid pairs gives no correlation or regression"
-    (let [result (scatter/compute-series-stats [1] [2])]
-      (is (= 1 (:data_points result)))
-      (is (nil? (:correlation result)))
-      (is (nil? (:regression result))))))
+    (is (=? {:data_points  1
+             :correlation  (symbol "nil #_\"key is not present.\"")
+             :regression   (symbol "nil #_\"key is not present.\"")}
+            (scatter/compute-series-stats [1] [2])))))
 
 (deftest compute-series-stats-two-valid-pairs-test
   (testing "2 valid pairs gives correlation but no regression (< 3)"
-    (let [result (scatter/compute-series-stats [1 2] [3 4])]
-      (is (= 2 (:data_points result)))
-      (is (some? (:correlation result)))
-      (is (nil? (:regression result))))))
+    (is (=? {:data_points 2
+             :correlation some?
+             :regression  (symbol "nil #_\"key is not present.\"")}
+            (scatter/compute-series-stats [1 2] [3 4])))))
 
 (deftest compute-series-stats-perfect-positive-correlation-test
   (testing "perfect positive correlation"
-    (let [result (scatter/compute-series-stats [1 2 3 4 5] [2 4 6 8 10])
-          corr   (:correlation result)
-          reg    (:regression result)]
-      (is (= 5 (:data_points result)))
-      (is (some? corr))
-      (is (== (:coefficient corr) 1.0))
-      (is (= :strong (:strength corr)))
-      (is (= :positive (:direction corr)))
-      (is (some? reg))
-      (is (== (:slope reg) 2.0))
-      (is (== (:r_squared reg) 1.0)))))
+    (is (=? {:data_points 5
+             :correlation {:coefficient 1.0 :strength :strong :direction :positive}
+             :regression  {:slope 2.0 :r_squared 1.0}}
+            (scatter/compute-series-stats [1 2 3 4 5] [2 4 6 8 10])))))
 
 (deftest compute-series-stats-perfect-negative-correlation-test
   (testing "perfect negative correlation"
-    (let [result (scatter/compute-series-stats [1 2 3 4 5] [10 8 6 4 2])
-          corr   (:correlation result)]
-      (is (some? corr))
-      (is (== (:coefficient corr) -1.0))
-      (is (= :strong (:strength corr)))
-      (is (= :negative (:direction corr))))))
+    (is (=? {:correlation {:coefficient -1.0
+                           :strength :strong
+                           :direction :negative}}
+            (scatter/compute-series-stats [1 2 3 4 5] [10 8 6 4 2])))))
 
 (deftest compute-series-stats-weak-correlation-test
   (testing "uncorrelated data has no correlation strength"
     ;; y = [3 1 2 1 3] produces Pearson r ≈ 0 with x = [1 2 3 4 5]
-    (let [result (scatter/compute-series-stats [1 2 3 4 5] [3 1 2 1 3])]
-      (when-let [corr (:correlation result)]
-        (is (= :none (:strength corr)))))))
+    (is (=? {:correlation {:strength :none}}
+            (scatter/compute-series-stats [1 2 3 4 5] [3 1 2 1 3])))))
 
-(deftest compute-series-stats-moderate-correlation-test
-  (testing "moderate correlation (0.3-0.7)"
-    ;; y = x + noise roughly
-    (let [result (scatter/compute-series-stats
-                  [1 2 3 4 5 6 7 8]
-                  [1.5 2.1 4.0 3.8 5.5 5.1 7.2 6.9])
-          corr   (:correlation result)]
-      (is (some? corr))
-      (is (#{:moderate :strong} (:strength corr))))))
+(deftest compute-series-stats-strong-correlation-test
+  (testing "strong correlation (> 0.7)"
+    (is (=? {:correlation {:strength :strong}}
+            (scatter/compute-series-stats
+             [1 2 3 4 5 6 7 8]
+             [1.5 2.1 4.0 3.8 5.5 5.1 7.2 6.9])))))
 
 (deftest compute-series-stats-constant-x-test
   (testing "constant x-values result in regression returning nil gracefully"
-    (let [result (scatter/compute-series-stats [5 5 5 5] [1 2 3 4])]
-      ;; correlation will be NaN (constant x), regression may fail
-      (is (= 4 (:data_points result)))
-      ;; should not throw
-      (is (map? result)))))
+    ;; correlation will be NaN (constant x). regression may fail but should not throw.
+    (is (=? {:data_points 4}
+            (scatter/compute-series-stats [5 5 5 5] [1 2 3 4])))))
 
 (deftest compute-series-stats-summaries-test
   (testing "x and y summaries computed correctly"
-    (let [result (scatter/compute-series-stats [1 2 3] [10 20 30])
-          xs     (:x_summary result)
-          ys     (:y_summary result)]
-      (is (= 1.0 (:min xs)))
-      (is (= 3.0 (:max xs)))
-      (is (= 10.0 (:min ys)))
-      (is (= 30.0 (:max ys))))))
+    (is (=? {:x_summary {:min 1.0 :max 3.0}
+             :y_summary {:min 10.0 :max 30.0}}
+            (scatter/compute-series-stats [1 2 3] [10 20 30])))))
 
 (deftest compute-scatter-stats-multi-series-test
   (testing "each series gets independent stats; no cross-series correlations"
@@ -101,43 +82,37 @@
                        "S2" {:x_values [1 2 3] :y_values [6 5 4]
                              :x {:name "x" :type :number}
                              :y {:name "y" :type :number}
-                             :display_name "S2"}}
-          result (scatter/compute-scatter-stats series-data {})]
-      (is (= :scatter (:chart_type result)))
-      (is (= 2 (:series_count result)))
-      (is (contains? (:series result) "S1"))
-      (is (contains? (:series result) "S2"))
-      ;; No cross-series correlations key
-      (is (nil? (:correlations result))))))
+                             :display_name "S2"}}]
+      (is (=? {:chart_type    :scatter
+               :series_count  2
+               :series        {"S1" some? "S2" some?}
+               :correlations  (symbol "nil #_\"key is not present.\"")}
+              (scatter/compute-scatter-stats series-data {}))))))
 
 (deftest compute-series-stats-regression-intercept-test
   (testing "regression intercept computed correctly for y = 2x + 10"
-    (let [result (scatter/compute-series-stats [1 2 3 4 5] [12 14 16 18 20])
-          reg    (:regression result)]
-      (is (some? reg))
-      (is (< (Math/abs (- (:slope reg) 2.0)) 0.001))
-      (is (< (Math/abs (- (:intercept reg) 10.0)) 0.001))
-      (is (< (Math/abs (- (:r_squared reg) 1.0)) 0.001)))))
+    (is (=? {:regression {:slope     #(< (Math/abs (- % 2.0)) 0.001)
+                          :intercept #(< (Math/abs (- % 10.0)) 0.001)
+                          :r_squared #(< (Math/abs (- % 1.0)) 0.001)}}
+            (scatter/compute-series-stats [1 2 3 4 5] [12 14 16 18 20])))))
 
 (deftest compute-series-stats-constant-y-test
   (testing "constant y-values: NaN correlation is handled gracefully (nil correlation)"
-    (let [result (scatter/compute-series-stats [1 2 3 4 5] [50 50 50 50 50])]
-      (is (= 5 (:data_points result)))
-      ;; Y has no variance; correlation is NaN, should be nil
-      (is (nil? (:correlation result))))))
+    ;; Y has no variance; correlation is NaN, should be absent
+    (is (=? {:data_points  5
+             :correlation  (symbol "nil #_\"key is not present.\"")}
+            (scatter/compute-series-stats [1 2 3 4 5] [50 50 50 50 50])))))
 
 (deftest compute-series-stats-float-values-test
   (testing "float x and y values handled correctly"
-    (let [result (scatter/compute-series-stats
-                  [1.5 2.5 3.5 4.5 5.5]
-                  [10.1 20.2 30.3 40.4 50.5])
-          xs     (:x_summary result)
-          ys     (:y_summary result)]
-      (is (= 5 (:data_points result)))
-      (is (< (Math/abs (- (:min xs) 1.5)) 0.001))
-      (is (< (Math/abs (- (:max xs) 5.5)) 0.001))
-      (is (< (Math/abs (- (:min ys) 10.1)) 0.001))
-      (is (< (Math/abs (- (:max ys) 50.5)) 0.001)))))
+    (is (=? {:data_points 5
+             :x_summary {:min #(< (Math/abs (- % 1.5)) 0.001)
+                         :max #(< (Math/abs (- % 5.5)) 0.001)}
+             :y_summary {:min #(< (Math/abs (- % 10.1)) 0.001)
+                         :max #(< (Math/abs (- % 50.5)) 0.001)}}
+            (scatter/compute-series-stats
+             [1.5 2.5 3.5 4.5 5.5]
+             [10.1 20.2 30.3 40.4 50.5])))))
 
 (deftest repr-scatter-shows-relationship-test
   (testing "representation includes Relationship with strength and direction"

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/scatter_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/scatter_test.clj
@@ -75,12 +75,12 @@
 (deftest ^:parallel compute-scatter-stats-multi-series-test
   (testing "each series gets independent stats; no cross-series correlations"
     (let [series-data {"S1" {:x_values [1 2 3] :y_values [4 5 6]
-                             :x {:name "x" :type :number}
-                             :y {:name "y" :type :number}
+                             :x {:name "x" :type "number"}
+                             :y {:name "y" :type "number"}
                              :display_name "S1"}
                        "S2" {:x_values [1 2 3] :y_values [6 5 4]
-                             :x {:name "x" :type :number}
-                             :y {:name "y" :type :number}
+                             :x {:name "x" :type "number"}
+                             :y {:name "y" :type "number"}
                              :display_name "S2"}}]
       (is (=? {:chart_type    :scatter
                :series_count  2

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/scatter_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/scatter_test.clj
@@ -11,52 +11,52 @@
     (is (=? {:data_points 0
              :x_summary nil?
              :y_summary nil?}
-            (scatter/compute-series-stats [] [])))))
+            (#'scatter/compute-series-stats [] [])))))
 
 (deftest ^:parallel compute-series-stats-nil-filtered-test
   (testing "nil x or y values are filtered out"
     ;; only [1,4] is fully valid
     (is (=? {:data_points 1}
-            (scatter/compute-series-stats [1 nil 3] [4 5 nil])))))
+            (#'scatter/compute-series-stats [1 nil 3] [4 5 nil])))))
 
 (deftest ^:parallel compute-series-stats-one-valid-pair-test
   (testing "< 2 valid pairs gives no correlation or regression"
     (is (=? {:data_points  1
              :correlation  (symbol "nil #_\"key is not present.\"")
              :regression   (symbol "nil #_\"key is not present.\"")}
-            (scatter/compute-series-stats [1] [2])))))
+            (#'scatter/compute-series-stats [1] [2])))))
 
 (deftest ^:parallel compute-series-stats-two-valid-pairs-test
   (testing "2 valid pairs gives correlation but no regression (< 3)"
     (is (=? {:data_points 2
              :correlation some?
              :regression  (symbol "nil #_\"key is not present.\"")}
-            (scatter/compute-series-stats [1 2] [3 4])))))
+            (#'scatter/compute-series-stats [1 2] [3 4])))))
 
 (deftest ^:parallel compute-series-stats-perfect-positive-correlation-test
   (testing "perfect positive correlation"
     (is (=? {:data_points 5
              :correlation {:coefficient 1.0 :strength :strong :direction :positive}
              :regression  {:slope 2.0 :r_squared 1.0}}
-            (scatter/compute-series-stats [1 2 3 4 5] [2 4 6 8 10])))))
+            (#'scatter/compute-series-stats [1 2 3 4 5] [2 4 6 8 10])))))
 
 (deftest ^:parallel compute-series-stats-perfect-negative-correlation-test
   (testing "perfect negative correlation"
     (is (=? {:correlation {:coefficient -1.0
                            :strength :strong
                            :direction :negative}}
-            (scatter/compute-series-stats [1 2 3 4 5] [10 8 6 4 2])))))
+            (#'scatter/compute-series-stats [1 2 3 4 5] [10 8 6 4 2])))))
 
 (deftest ^:parallel compute-series-stats-weak-correlation-test
   (testing "uncorrelated data has no correlation strength"
     ;; y = [3 1 2 1 3] produces Pearson r ≈ 0 with x = [1 2 3 4 5]
     (is (=? {:correlation {:strength :none}}
-            (scatter/compute-series-stats [1 2 3 4 5] [3 1 2 1 3])))))
+            (#'scatter/compute-series-stats [1 2 3 4 5] [3 1 2 1 3])))))
 
 (deftest ^:parallel compute-series-stats-strong-correlation-test
   (testing "strong correlation (> 0.7)"
     (is (=? {:correlation {:strength :strong}}
-            (scatter/compute-series-stats
+            (#'scatter/compute-series-stats
              [1 2 3 4 5 6 7 8]
              [1.5 2.1 4.0 3.8 5.5 5.1 7.2 6.9])))))
 
@@ -64,13 +64,13 @@
   (testing "constant x-values result in regression returning nil gracefully"
     ;; correlation will be NaN (constant x). regression may fail but should not throw.
     (is (=? {:data_points 4}
-            (scatter/compute-series-stats [5 5 5 5] [1 2 3 4])))))
+            (#'scatter/compute-series-stats [5 5 5 5] [1 2 3 4])))))
 
 (deftest ^:parallel compute-series-stats-summaries-test
   (testing "x and y summaries computed correctly"
     (is (=? {:x_summary {:min 1.0 :max 3.0}
              :y_summary {:min 10.0 :max 30.0}}
-            (scatter/compute-series-stats [1 2 3] [10 20 30])))))
+            (#'scatter/compute-series-stats [1 2 3] [10 20 30])))))
 
 (deftest ^:parallel compute-scatter-stats-multi-series-test
   (testing "each series gets independent stats; no cross-series correlations"
@@ -93,14 +93,14 @@
     (is (=? {:regression {:slope     (=?/approx [2.0 0.001])
                           :intercept (=?/approx [10.0 0.001])
                           :r_squared (=?/approx [1.0 0.001])}}
-            (scatter/compute-series-stats [1 2 3 4 5] [12 14 16 18 20])))))
+            (#'scatter/compute-series-stats [1 2 3 4 5] [12 14 16 18 20])))))
 
 (deftest ^:parallel compute-series-stats-constant-y-test
   (testing "constant y-values: NaN correlation is handled gracefully (nil correlation)"
     ;; Y has no variance; correlation is NaN, should be absent
     (is (=? {:data_points  5
              :correlation  (symbol "nil #_\"key is not present.\"")}
-            (scatter/compute-series-stats [1 2 3 4 5] [50 50 50 50 50])))))
+            (#'scatter/compute-series-stats [1 2 3 4 5] [50 50 50 50 50])))))
 
 (deftest ^:parallel compute-series-stats-float-values-test
   (testing "float x and y values handled correctly"
@@ -109,6 +109,6 @@
                          :max (=?/approx [5.5 0.001])}
              :y_summary {:min (=?/approx [10.1 0.001])
                          :max (=?/approx [50.5 0.001])}}
-            (scatter/compute-series-stats
+            (#'scatter/compute-series-stats
              [1.5 2.5 3.5 4.5 5.5]
              [10.1 20.2 30.3 40.4 50.5])))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/scatter_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/scatter_test.clj
@@ -1,9 +1,7 @@
 (ns metabase-enterprise.metabot-v3.stats.scatter-test
   (:require
-   [clojure.string :as str]
    [clojure.test :refer :all]
    [mb.hawk.assert-exprs.approximately-equal :as =?]
-   [metabase-enterprise.metabot-v3.stats.repr :as repr]
    [metabase-enterprise.metabot-v3.stats.scatter :as scatter]))
 
 (set! *warn-on-reflection* true)
@@ -114,14 +112,3 @@
             (scatter/compute-series-stats
              [1.5 2.5 3.5 4.5 5.5]
              [10.1 20.2 30.3 40.4 50.5])))))
-
-(deftest repr-scatter-shows-relationship-test
-  (testing "representation includes Relationship with strength and direction"
-    (let [series-stats (scatter/compute-series-stats [1 2 3 4 5] [10 20 30 40 50])
-          stats        {:chart_type   :scatter
-                        :series_count 1
-                        :series       {"Test Series" series-stats}}
-          rep          (repr/generate-scatter-representation {:stats stats})]
-      (is (str/includes? rep "Test Series"))
-      (is (str/includes? rep "Relationship"))
-      (is (str/includes? rep "strong positive")))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/time_series_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/time_series_test.clj
@@ -161,8 +161,8 @@
   [display-name x-vals y-vals]
   {:x_values     x-vals
    :y_values     y-vals
-   :x            {:name "x" :type :string}
-   :y            {:name "y" :type :number}
+   :x            {:name "x" :type "string"}
+   :y            {:name "y" :type "number"}
    :display_name display-name})
 
 (deftest ^:parallel compute-correlations-strong-positive-test
@@ -363,13 +363,13 @@
   (testing "each series gets independent stats; no cross-series correlations without deep?"
     (let [series-data {"S1" {:x_values ["d1" "d2" "d3" "d4" "d5"]
                              :y_values [1.0 2.0 3.0 4.0 5.0]
-                             :x {:name "x" :type :string}
-                             :y {:name "y" :type :number}
+                             :x {:name "x" :type "string"}
+                             :y {:name "y" :type "number"}
                              :display_name "S1"}
                        "S2" {:x_values ["d1" "d2" "d3" "d4" "d5"]
                              :y_values [5.0 4.0 3.0 2.0 1.0]
-                             :x {:name "x" :type :string}
-                             :y {:name "y" :type :number}
+                             :x {:name "x" :type "string"}
+                             :y {:name "y" :type "number"}
                              :display_name "S2"}}]
       (is (=? {:chart_type    :time-series
                :series_count  2
@@ -386,13 +386,13 @@
           x-vals      (mapv #(format "2024-%02d" %) (range 1 (inc n)))
           series-data {"A" {:x_values x-vals
                             :y_values (mapv #(* 10.0 %) (range 1 (inc n)))
-                            :x {:name "x" :type :string}
-                            :y {:name "y" :type :number}
+                            :x {:name "x" :type "string"}
+                            :y {:name "y" :type "number"}
                             :display_name "A"}
                        "B" {:x_values x-vals
                             :y_values (mapv #(* 20.0 %) (range 1 (inc n)))
-                            :x {:name "x" :type :string}
-                            :y {:name "y" :type :number}
+                            :x {:name "x" :type "string"}
+                            :y {:name "y" :type "number"}
                             :display_name "B"}}
           result (time-series/compute-time-series-stats series-data {:deep? true})]
       (is (=? {:correlations #(= 1 (count %))}

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/time_series_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/time_series_test.clj
@@ -3,10 +3,8 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [mb.hawk.assert-exprs.approximately-equal :as =?]
-   [metabase-enterprise.metabot-v3.stats.repr :as repr]
    [metabase-enterprise.metabot-v3.stats.time-series :as time-series]
-   [metabase-enterprise.metabot-v3.stats.util :as stats.u]
-   [metabase.util :as u]))
+   [metabase-enterprise.metabot-v3.stats.util :as stats.u]))
 
 (set! *warn-on-reflection* true)
 
@@ -377,42 +375,3 @@
       (is (=? {:correlations #(= 1 (count %))}
               result)))))
 
-;;; ---------------------------------------- temporal context / repr tests -------------------------------------------
-
-(deftest generate-temporal-context-test
-  (testing "temporal context includes current date, day of week, week, month, and quarter"
-    (let [result (repr/generate-temporal-context)]
-      (is (str/includes? result "Today is"))
-      (is (some #(str/includes? result %)
-                ["Monday" "Tuesday" "Wednesday" "Thursday" "Friday" "Saturday" "Sunday"]))
-      (is (str/includes? (u/lower-case-en result) "week"))
-      (is (str/includes? (u/lower-case-en result) "month"))
-      (is (str/includes? (u/lower-case-en result) "quarter"))
-      (is (some #(str/includes? result %) ["Q1" "Q2" "Q3" "Q4"])))))
-
-(deftest repr-time-series-includes-series-name-and-trend-test
-  (testing "time series representation includes series name and trend direction"
-    (let [values [10.0 20.0 30.0 40.0 50.0]
-          dates  ["2024-01" "2024-02" "2024-03" "2024-04" "2024-05"]
-          series-stats (time-series/compute-series-stats values dates {})
-          stats {:chart_type   :time-series
-                 :series_count 1
-                 :series       {"Revenue" series-stats}}
-          rep (repr/generate-time-series-representation {:stats stats})]
-      (is (str/includes? rep "Revenue"))
-      (is (str/includes? rep "Trend"))
-      (is (str/includes? rep "Time Series")))))
-
-(deftest repr-time-series-multi-series-test
-  (testing "representation with multiple series includes all series names"
-    (let [make-stats (fn [values dates]
-                       (time-series/compute-series-stats values dates {}))
-          stats {:chart_type   :time-series
-                 :series_count 2
-                 :series       {"Sales"   (make-stats [10.0 20.0 30.0 40.0 50.0]
-                                                      ["d1" "d2" "d3" "d4" "d5"])
-                                "Revenue" (make-stats [20.0 40.0 60.0 80.0 100.0]
-                                                      ["d1" "d2" "d3" "d4" "d5"])}}
-          rep (repr/generate-time-series-representation {:stats stats})]
-      (is (str/includes? rep "Sales"))
-      (is (str/includes? rep "Revenue")))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/time_series_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/time_series_test.clj
@@ -37,7 +37,6 @@
 
 (deftest detect-cumulative-mostly-increasing-with-significant-drop-test
   (testing "data where >5% of consecutive diffs are negative is not cumulative"
-    ;; [1 2 3 2.9 4 5]: one decrease (3→2.9) out of 5 diffs = 20% → not cumulative
     (is (false? (time-series/detect-cumulative? [1.0 2.0 3.0 2.9 4.0 5.0])))))
 
 ;;; ---------------------------------------------- compute-trend tests -----------------------------------------------
@@ -45,78 +44,70 @@
 (deftest compute-trend-strongly-increasing-test
   (testing "strongly increasing series detected as :strongly_increasing"
     ;; slope=5, mean=20, pct=100*20/20=100% > 50 → :strongly_increasing
-    (let [result (time-series/compute-trend [10.0 15.0 20.0 25.0 30.0])]
-      (is (= :strongly_increasing (:direction result)))
-      (is (> (:overall_change_pct result) 0))
-      (is (= 10.0 (:start_value result)))
-      (is (= 30.0 (:end_value result))))))
+    (is (=? {:direction          :strongly_increasing
+             :overall_change_pct pos?
+             :start_value        10.0
+             :end_value          30.0}
+            (time-series/compute-trend [10.0 15.0 20.0 25.0 30.0])))))
 
 (deftest compute-trend-strongly-decreasing-test
   (testing "strongly decreasing series detected as :strongly_decreasing"
-    (let [result (time-series/compute-trend [100.0 80.0 60.0 40.0 20.0])]
-      (is (= :strongly_decreasing (:direction result)))
-      (is (< (:overall_change_pct result) 0)))))
+    (is (=? {:direction          :strongly_decreasing
+             :overall_change_pct neg?}
+            (time-series/compute-trend [100.0 80.0 60.0 40.0 20.0])))))
 
 (deftest compute-trend-flat-test
   (testing "roughly flat series detected as :flat"
-    (let [result (time-series/compute-trend [50.0 51.0 50.0 50.5 50.0])]
-      (is (= :flat (:direction result))))))
+    (is (=? {:direction :flat}
+            (time-series/compute-trend [50.0 51.0 50.0 50.5 50.0])))))
 
 (deftest compute-trend-increasing-moderate-test
   (testing "moderate increase (10-50% range) detected as :increasing"
-    ;; [100 110 120 130 140]: slope=10, mean=120, total_change=40, pct=33.3% → :increasing
-    (let [result (time-series/compute-trend [100.0 110.0 120.0 130.0 140.0])]
-      (is (= :increasing (:direction result))))))
+    ;; slope=10, mean=120, total_change=40, pct=33.3% → :increasing
+    (is (=? {:direction :increasing}
+            (time-series/compute-trend [100.0 110.0 120.0 130.0 140.0])))))
 
 (deftest compute-trend-returns-start-end-values-test
   (testing "trend includes correct start and end values"
-    (let [result (time-series/compute-trend [5.0 10.0 15.0 20.0 25.0])]
-      (is (= 5.0 (:start_value result)))
-      (is (= 25.0 (:end_value result))))))
+    (is (=? {:start_value 5.0
+             :end_value   25.0}
+            (time-series/compute-trend [5.0 10.0 15.0 20.0 25.0])))))
 
 ;;; --------------------------------------------- compute-volatility tests -------------------------------------------
 
 (deftest compute-volatility-low-test
   (testing "tightly clustered values produce :low volatility (cv < 0.1)"
     ;; mean≈101.6, std≈1.1, cv≈0.011
-    (let [result (time-series/compute-volatility [100.0 102.0 101.0 103.0 102.0])]
-      (is (some? result))
-      (is (= :low (:level result)))
-      (is (< (:coefficient_of_variation result) 0.1)))))
+    (is (=? {:level                    :low
+             :coefficient_of_variation #(< % 0.1)}
+            (time-series/compute-volatility [100.0 102.0 101.0 103.0 102.0])))))
 
 (deftest compute-volatility-moderate-test
   (testing "moderately variable data produces :moderate volatility (0.1 ≤ cv < 0.3)"
     ;; mean=100, std≈17.3, cv≈0.173
-    (let [result (time-series/compute-volatility [80.0 100.0 120.0 90.0 110.0])]
-      (is (some? result))
-      (is (= :moderate (:level result)))
-      (is (<= 0.1 (:coefficient_of_variation result)))
-      (is (< (:coefficient_of_variation result) 0.3)))))
+    (is (=? {:level                    :moderate
+             :coefficient_of_variation #(and (<= 0.1 %) (< % 0.3))}
+            (time-series/compute-volatility [80.0 100.0 120.0 90.0 110.0])))))
 
 (deftest compute-volatility-high-test
   (testing "fairly variable data produces :high volatility (0.3 ≤ cv < 0.5)"
     ;; mean=100, std≈34.6, cv≈0.346
-    (let [result (time-series/compute-volatility [60.0 100.0 140.0 70.0 130.0])]
-      (is (some? result))
-      (is (= :high (:level result)))
-      (is (<= 0.3 (:coefficient_of_variation result)))
-      (is (< (:coefficient_of_variation result) 0.5)))))
+    (is (=? {:level                    :high
+             :coefficient_of_variation #(and (<= 0.3 %) (< % 0.5))}
+            (time-series/compute-volatility [60.0 100.0 140.0 70.0 130.0])))))
 
 (deftest compute-volatility-extreme-test
   (testing "very variable data produces :extreme volatility (cv ≥ 0.5)"
     ;; mean≈102, std≈75, cv≈0.73
-    (let [result (time-series/compute-volatility [10.0 100.0 200.0 50.0 150.0])]
-      (is (some? result))
-      (is (= :extreme (:level result)))
-      (is (>= (:coefficient_of_variation result) 0.5)))))
+    (is (=? {:level                    :extreme
+             :coefficient_of_variation #(>= % 0.5)}
+            (time-series/compute-volatility [10.0 100.0 200.0 50.0 150.0])))))
 
 (deftest compute-volatility-max-period-change-test
   (testing "max period change is computed as absolute percentage of previous value"
-    ;; [100, 200, 250, 500]: changes 100%, 25%, 100% → max = 100%
-    (let [result (time-series/compute-volatility [100.0 200.0 250.0 500.0])]
-      (is (some? result))
-      (is (>= (:max_period_change_pct result) 99.0))
-      (is (<= (:max_period_change_pct result) 101.0)))))
+    ;; changes 100%, 25%, 100% → max = 100%
+    (is (=? {:max_period_change_pct #(and (>= % 99.0) (<= % 101.0))}
+            (time-series/compute-volatility [100.0 200.0 250.0 500.0])))))
 
 ;;; ----------------------------------------------- detect-patterns tests --------------------------------------------
 
@@ -126,8 +117,9 @@
           dates  (mapv #(format "2024-%02d" %) (range 1 11))
           result (time-series/detect-patterns values dates)]
       (is (pos? (count result)))
-      (is (= :consecutive_increase (:type (first result))))
-      (is (str/includes? (:description (first result)) "increase")))))
+      (is (=? {:type        :consecutive_increase
+               :description #(str/includes? % "increase")}
+              (first result))))))
 
 (deftest detect-patterns-decreasing-streak-test
   (testing "detects consecutive decreases of 5+ periods"
@@ -135,8 +127,9 @@
           dates  (mapv #(format "2024-%02d" %) (range 1 11))
           result (time-series/detect-patterns values dates)]
       (is (pos? (count result)))
-      (is (= :consecutive_decrease (:type (first result))))
-      (is (str/includes? (:description (first result)) "decrease")))))
+      (is (=? {:type        :consecutive_decrease
+               :description #(str/includes? % "decrease")}
+              (first result))))))
 
 (deftest detect-patterns-short-sequence-no-streak-test
   (testing "fewer than 5 consecutive changes → no streak detected"
@@ -158,51 +151,57 @@
           dates  (mapv #(format "2024-%02d" %) (range 1 11))
           result (time-series/detect-patterns values dates)]
       (when (seq result)
-        (let [pattern (first result)]
-          (is (contains? pattern :from_date))
-          (is (contains? pattern :to_date))
-          (is (contains? pattern :description)))))))
+        (is (=? {:from_date   some?
+                 :to_date     some?
+                 :description some?}
+                (first result)))))))
 
 ;;; ------------------------------------------- compute-correlations tests -------------------------------------------
+
+(defn- make-corr-series
+  "Build a series config with the required schema keys for compute-correlations."
+  [display-name x-vals y-vals]
+  {:x_values     x-vals
+   :y_values     y-vals
+   :x            {:name "x" :type :string}
+   :y            {:name "y" :type :number}
+   :display_name display-name})
 
 (deftest compute-correlations-strong-positive-test
   (testing "perfectly correlated series produces strong positive correlation"
     ;; Requires ≥ 10 aligned data points
     (let [n       10
           x-vals  (mapv str (range 1 (inc n)))
-          series-map {"Revenue" {:x_values x-vals
-                                 :y_values (mapv #(* 10.0 %) (range 1 (inc n)))}
-                      "Sales"   {:x_values x-vals
-                                 :y_values (mapv #(* 20.0 %) (range 1 (inc n)))}}
+          series-map {"Revenue" (make-corr-series "Revenue" x-vals (mapv #(* 10.0 %) (range 1 (inc n))))
+                      "Sales"   (make-corr-series "Sales" x-vals (mapv #(* 20.0 %) (range 1 (inc n))))}
           result  (stats.u/compute-correlations series-map)]
       (is (= 1 (count result)))
       ;; "Revenue" < "Sales" alphabetically → series_a="Revenue", series_b="Sales"
-      (is (= "Revenue" (:series_a (first result))))
-      (is (= "Sales" (:series_b (first result))))
-      (is (> (:coefficient (first result)) 0.9))
-      (is (= :strong (:strength (first result))))
-      (is (= :positive (:direction (first result)))))))
+      (is (=? {:series_a    "Revenue"
+               :series_b    "Sales"
+               :coefficient #(> % 0.9)
+               :strength    :strong
+               :direction   :positive}
+              (first result))))))
 
 (deftest compute-correlations-strong-negative-test
   (testing "inversely correlated series produces strong negative correlation"
     (let [n      10
           x-vals (mapv str (range 1 (inc n)))
-          series-map {"Costs" {:x_values x-vals
-                               :y_values (mapv #(* 10.0 %) (range 1 (inc n)))}
-                      "Sales" {:x_values x-vals
-                               :y_values (mapv #(* 10.0 %) (range (inc n) 0 -1))}}
+          series-map {"Costs" (make-corr-series "Costs" x-vals (mapv #(* 10.0 %) (range 1 (inc n))))
+                      "Sales" (make-corr-series "Sales" x-vals (mapv #(* 10.0 %) (range (inc n) 0 -1)))}
           result (stats.u/compute-correlations series-map)]
       (is (= 1 (count result)))
-      (is (< (:coefficient (first result)) -0.9))
-      (is (= :strong (:strength (first result))))
-      (is (= :negative (:direction (first result)))))))
+      (is (=? {:coefficient #(< % -0.9)
+               :strength    :strong
+               :direction   :negative}
+              (first result))))))
 
 (deftest compute-correlations-single-series-returns-empty-test
   (testing "single series produces no pairs → empty result"
     (let [n      10
           x-vals (mapv str (range 1 (inc n)))
-          series-map {"Sales" {:x_values x-vals
-                               :y_values (mapv #(* 10.0 %) (range 1 (inc n)))}}
+          series-map {"Sales" (make-corr-series "Sales" x-vals (mapv #(* 10.0 %) (range 1 (inc n))))}
           result (stats.u/compute-correlations series-map)]
       (is (empty? result)))))
 
@@ -211,9 +210,9 @@
     (let [n      10
           x-vals (mapv str (range 1 (inc n)))
           vals   (mapv #(* 10.0 %) (range 1 (inc n)))
-          series-map {"A" {:x_values x-vals :y_values vals}
-                      "B" {:x_values x-vals :y_values vals}
-                      "C" {:x_values x-vals :y_values vals}}
+          series-map {"A" (make-corr-series "A" x-vals vals)
+                      "B" (make-corr-series "B" x-vals vals)
+                      "C" (make-corr-series "C" x-vals vals)}
           result (stats.u/compute-correlations series-map)]
       (is (= 3 (count result))))))
 
@@ -221,8 +220,8 @@
   (testing "pairs with fewer than 10 aligned points are skipped"
     ;; Only 5 aligned points → below min-correlation-sample-size (10) → no correlations
     (let [x-vals (mapv str (range 1 6))
-          series-map {"A" {:x_values x-vals :y_values [1.0 2.0 3.0 4.0 5.0]}
-                      "B" {:x_values x-vals :y_values [2.0 4.0 6.0 8.0 10.0]}}
+          series-map {"A" (make-corr-series "A" x-vals [1.0 2.0 3.0 4.0 5.0])
+                      "B" (make-corr-series "B" x-vals [2.0 4.0 6.0 8.0 10.0])}
           result (stats.u/compute-correlations series-map)]
       (is (empty? result)))))
 
@@ -237,105 +236,107 @@
           result (time-series/find-significant-changes values dates 3)]
       (is (<= (count result) 3))
       ;; Largest change is 12→25 (abs=13)
-      (is (= 12.0 (:from_value (first result))))
-      (is (= 25.0 (:to_value (first result)))))))
+      (is (=? {:from_value 12.0
+               :to_value   25.0}
+              (first result))))))
 
 (deftest find-significant-changes-includes-pct-change-test
   (testing "change maps include :change_abs and :change_pct"
     (let [values [10.0 15.0 20.0]
           dates  ["d1" "d2" "d3"]
           result (time-series/find-significant-changes values dates 3)]
-      (is (every? #(contains? % :change_abs) result))
-      (is (every? #(contains? % :change_pct) result))
-      (is (every? #(contains? % :from_date) result))
-      (is (every? #(contains? % :to_date) result)))))
+      (doseq [change result]
+        (is (=? {:change_abs some?
+                 :change_pct some?
+                 :from_date  some?
+                 :to_date    some?}
+                change))))))
 
 ;;; ---------------------------------------- compute-most-recent-change tests ----------------------------------------
 
 (deftest compute-most-recent-change-test
   (testing "returns the last consecutive change"
-    (let [values [10.0 15.0 12.0 25.0 22.0 20.0]
-          dates  ["2024-01" "2024-02" "2024-03" "2024-04" "2024-05" "2024-06"]
-          result (time-series/compute-most-recent-change values dates)]
-      (is (some? result))
-      (is (= "2024-05" (:from_date result)))
-      (is (= "2024-06" (:to_date result)))
-      (is (= 22.0 (:from_value result)))
-      (is (= 20.0 (:to_value result)))
-      (is (= -2.0 (:change_abs result))))))
+    (is (=? {:from_date  "2024-05"
+             :to_date    "2024-06"
+             :from_value 22.0
+             :to_value   20.0
+             :change_abs -2.0}
+            (time-series/compute-most-recent-change
+             [10.0 15.0 12.0 25.0 22.0 20.0]
+             ["2024-01" "2024-02" "2024-03" "2024-04" "2024-05" "2024-06"])))))
 
 (deftest compute-most-recent-change-single-value-test
   (testing "single value returns nil (no previous point)"
-    (let [result (time-series/compute-most-recent-change [10.0] ["d1"])]
-      (is (nil? result)))))
+    (is (nil? (time-series/compute-most-recent-change [10.0] ["d1"])))))
 
 (deftest compute-most-recent-change-two-values-test
   (testing "two values returns the one change"
-    (let [result (time-series/compute-most-recent-change [10.0 15.0] ["d1" "d2"])]
-      (is (some? result))
-      (is (= 10.0 (:from_value result)))
-      (is (= 15.0 (:to_value result)))
-      (is (= 5.0 (:change_abs result)))
-      (is (< (Math/abs (- (:change_pct result) 50.0)) 0.001)))))
+    (is (=? {:from_value 10.0
+             :to_value   15.0
+             :change_abs 5.0
+             :change_pct #(< (Math/abs (- % 50.0)) 0.001)}
+            (time-series/compute-most-recent-change [10.0 15.0] ["d1" "d2"])))))
 
 ;;; --------------------------------------------- compute-series-stats tests ----------------------------------------
 
 (deftest compute-series-stats-basic-fields-test
   (testing "basic stats include summary, time_range, trend, data_points, is_cumulative"
-    (let [values [10.0 20.0 30.0 40.0 50.0]
-          dates  ["2024-01" "2024-02" "2024-03" "2024-04" "2024-05"]
-          result (time-series/compute-series-stats values dates {})]
-      (is (= 5 (:data_points result)))
-      (is (some? (:summary result)))
-      (is (= 10.0 (:min (:summary result))))
-      (is (= 50.0 (:max (:summary result))))
-      (is (some? (:trend result)))
-      (is (some? (:time_range result)))
-      (is (= "2024-01" (:start (:time_range result))))
-      (is (= "2024-05" (:end (:time_range result)))))))
+    (is (=? {:data_points 5
+             :summary     {:min 10.0 :max 50.0}
+             :trend       some?
+             :time_range  {:start "2024-01" :end "2024-05"}}
+            (time-series/compute-series-stats
+             [10.0 20.0 30.0 40.0 50.0]
+             ["2024-01" "2024-02" "2024-03" "2024-04" "2024-05"]
+             {})))))
 
 (deftest compute-series-stats-cumulative-detection-test
   (testing "cumulative data is flagged as :is_cumulative true"
-    (let [values (mapv #(* 10.0 %) (range 1 13))   ; [10 20 ... 120]
-          dates  (mapv #(format "2024-%02d" %) (range 1 13))
-          result (time-series/compute-series-stats values dates {})]
-      (is (true? (:is_cumulative result))))))
+    (is (=? {:is_cumulative true}
+            (time-series/compute-series-stats
+             (mapv #(* 10.0 %) (range 1 13))
+             (mapv #(format "2024-%02d" %) (range 1 13))
+             {})))))
 
 (deftest compute-series-stats-non-cumulative-detection-test
   (testing "non-cumulative data is flagged as :is_cumulative false"
-    (let [values [10.0 5.0 15.0 8.0 20.0]
-          dates  ["d1" "d2" "d3" "d4" "d5"]
-          result (time-series/compute-series-stats values dates {})]
-      (is (false? (:is_cumulative result))))))
+    (is (=? {:is_cumulative false}
+            (time-series/compute-series-stats
+             [10.0 5.0 15.0 8.0 20.0]
+             ["d1" "d2" "d3" "d4" "d5"]
+             {})))))
 
 (deftest compute-series-stats-no-deep-stats-by-default-test
   (testing "without deep? opt, volatility and patterns are not computed"
-    (let [values (mapv #(* 10.0 %) (range 1 13))
-          dates  (mapv #(format "2024-%02d" %) (range 1 13))
-          result (time-series/compute-series-stats values dates {})]
-      (is (nil? (:volatility result)))
-      (is (nil? (:patterns result)))
-      (is (nil? (:significant_changes result))))))
+    (is (=? {:volatility          (symbol "nil #_\"key is not present.\"")
+             :patterns            (symbol "nil #_\"key is not present.\"")
+             :significant_changes (symbol "nil #_\"key is not present.\"")}
+            (time-series/compute-series-stats
+             (mapv #(* 10.0 %) (range 1 13))
+             (mapv #(format "2024-%02d" %) (range 1 13))
+             {})))))
 
 (deftest compute-series-stats-deep-stats-with-opt-test
   (testing "with deep? true, volatility and patterns are computed"
-    (let [values (mapv #(* 10.0 %) (range 1 13))
-          dates  (mapv #(format "2024-%02d" %) (range 1 13))
-          result (time-series/compute-series-stats values dates {:deep? true})]
-      (is (some? (:volatility result)))
-      (is (some? (:patterns result)))
-      (is (some? (:significant_changes result)))
-      (is (some? (:most_recent_change result))))))
+    (is (=? {:volatility          some?
+             :patterns            some?
+             :significant_changes some?
+             :most_recent_change  some?}
+            (time-series/compute-series-stats
+             (mapv #(* 10.0 %) (range 1 13))
+             (mapv #(format "2024-%02d" %) (range 1 13))
+             {:deep? true})))))
 
 (deftest compute-series-stats-deep-significant-changes-capped-at-3-test
   (testing "significant_changes contains at most 3 entries"
-    (let [values [10.0 15.0 12.0 25.0 22.0 20.0]
-          dates  ["2024-01" "2024-02" "2024-03" "2024-04" "2024-05" "2024-06"]
-          result (time-series/compute-series-stats values dates {:deep? true})]
+    (let [result (time-series/compute-series-stats
+                  [10.0 15.0 12.0 25.0 22.0 20.0]
+                  ["2024-01" "2024-02" "2024-03" "2024-04" "2024-05" "2024-06"]
+                  {:deep? true})]
       (is (<= (count (:significant_changes result)) 3))
-      (is (some? (:most_recent_change result)))
-      (is (= "2024-05" (:from_date (:most_recent_change result))))
-      (is (= "2024-06" (:to_date (:most_recent_change result)))))))
+      (is (=? {:most_recent_change {:from_date "2024-05"
+                                    :to_date   "2024-06"}}
+              result)))))
 
 ;;; ----------------------------------------- compute-time-series-stats tests ----------------------------------------
 
@@ -350,13 +351,12 @@
                              :y_values [5.0 4.0 3.0 2.0 1.0]
                              :x {:name "x" :type :string}
                              :y {:name "y" :type :number}
-                             :display_name "S2"}}
-          result (time-series/compute-time-series-stats series-data {})]
-      (is (= :time-series (:chart_type result)))
-      (is (= 2 (:series_count result)))
-      (is (contains? (:series result) "S1"))
-      (is (contains? (:series result) "S2"))
-      (is (nil? (:correlations result))))))
+                             :display_name "S2"}}]
+      (is (=? {:chart_type    :time-series
+               :series_count  2
+               :series        {"S1" some? "S2" some?}
+               :correlations  (symbol "nil #_\"key is not present.\"")}
+              (time-series/compute-time-series-stats series-data {}))))))
 
 (deftest compute-time-series-stats-deep-correlations-test
   (testing "with deep? true and 2+ series of 10+ points, correlations are computed"
@@ -373,8 +373,8 @@
                             :y {:name "y" :type :number}
                             :display_name "B"}}
           result (time-series/compute-time-series-stats series-data {:deep? true})]
-      (is (some? (:correlations result)))
-      (is (= 1 (count (:correlations result)))))))
+      (is (=? {:correlations #(= 1 (count %))}
+              result)))))
 
 ;;; ---------------------------------------- temporal context / repr tests -------------------------------------------
 

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/time_series_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/time_series_test.clj
@@ -1,0 +1,416 @@
+(ns metabase-enterprise.metabot-v3.stats.time-series-test
+  (:require
+   [clojure.string :as str]
+   [clojure.test :refer :all]
+   [metabase-enterprise.metabot-v3.stats.repr :as repr]
+   [metabase-enterprise.metabot-v3.stats.time-series :as time-series]
+   [metabase.util :as u]))
+
+(set! *warn-on-reflection* true)
+
+;;; ------------------------------------------------ detect-cumulative? ----------------------------------------------
+
+(deftest detect-cumulative-strictly-increasing-test
+  (testing "strictly increasing data is cumulative"
+    (is (true? (time-series/detect-cumulative? [10.0 20.0 30.0 40.0 50.0 60.0])))))
+
+(deftest detect-cumulative-monotone-with-plateaus-test
+  (testing "monotone non-decreasing data with flat sections is cumulative"
+    (is (true? (time-series/detect-cumulative? [100.0 100.0 150.0 150.0 200.0 200.0 250.0])))))
+
+(deftest detect-cumulative-not-cumulative-test
+  (testing "data with frequent decreases is not cumulative"
+    (is (false? (time-series/detect-cumulative? [1.0 2.0 1.5 3.0 2.8])))))
+
+(deftest detect-cumulative-multiple-significant-decreases-test
+  (testing "data with many significant drops is not cumulative"
+    (is (false? (time-series/detect-cumulative? [100.0 90.0 120.0 100.0 150.0 130.0 180.0])))))
+
+(deftest detect-cumulative-single-value-test
+  (testing "single value has no diffs → not cumulative"
+    (is (false? (time-series/detect-cumulative? [100.0])))))
+
+(deftest detect-cumulative-empty-test
+  (testing "empty values are not cumulative"
+    (is (false? (time-series/detect-cumulative? [])))))
+
+(deftest detect-cumulative-mostly-increasing-with-significant-drop-test
+  (testing "data where >5% of consecutive diffs are negative is not cumulative"
+    ;; [1 2 3 2.9 4 5]: one decrease (3→2.9) out of 5 diffs = 20% → not cumulative
+    (is (false? (time-series/detect-cumulative? [1.0 2.0 3.0 2.9 4.0 5.0])))))
+
+;;; ---------------------------------------------- compute-trend tests -----------------------------------------------
+
+(deftest compute-trend-strongly-increasing-test
+  (testing "strongly increasing series detected as :strongly_increasing"
+    ;; slope=5, mean=20, pct=100*20/20=100% > 50 → :strongly_increasing
+    (let [result (time-series/compute-trend [10.0 15.0 20.0 25.0 30.0])]
+      (is (= :strongly_increasing (:direction result)))
+      (is (> (:overall_change_pct result) 0))
+      (is (= 10.0 (:start_value result)))
+      (is (= 30.0 (:end_value result))))))
+
+(deftest compute-trend-strongly-decreasing-test
+  (testing "strongly decreasing series detected as :strongly_decreasing"
+    (let [result (time-series/compute-trend [100.0 80.0 60.0 40.0 20.0])]
+      (is (= :strongly_decreasing (:direction result)))
+      (is (< (:overall_change_pct result) 0)))))
+
+(deftest compute-trend-flat-test
+  (testing "roughly flat series detected as :flat"
+    (let [result (time-series/compute-trend [50.0 51.0 50.0 50.5 50.0])]
+      (is (= :flat (:direction result))))))
+
+(deftest compute-trend-increasing-moderate-test
+  (testing "moderate increase (10-50% range) detected as :increasing"
+    ;; [100 110 120 130 140]: slope=10, mean=120, total_change=40, pct=33.3% → :increasing
+    (let [result (time-series/compute-trend [100.0 110.0 120.0 130.0 140.0])]
+      (is (= :increasing (:direction result))))))
+
+(deftest compute-trend-returns-start-end-values-test
+  (testing "trend includes correct start and end values"
+    (let [result (time-series/compute-trend [5.0 10.0 15.0 20.0 25.0])]
+      (is (= 5.0 (:start_value result)))
+      (is (= 25.0 (:end_value result))))))
+
+;;; --------------------------------------------- compute-volatility tests -------------------------------------------
+
+(deftest compute-volatility-low-test
+  (testing "tightly clustered values produce :low volatility (cv < 0.1)"
+    ;; mean≈101.6, std≈1.1, cv≈0.011
+    (let [result (time-series/compute-volatility [100.0 102.0 101.0 103.0 102.0])]
+      (is (some? result))
+      (is (= :low (:level result)))
+      (is (< (:coefficient_of_variation result) 0.1)))))
+
+(deftest compute-volatility-moderate-test
+  (testing "moderately variable data produces :moderate volatility (0.1 ≤ cv < 0.3)"
+    ;; mean=100, std≈17.3, cv≈0.173
+    (let [result (time-series/compute-volatility [80.0 100.0 120.0 90.0 110.0])]
+      (is (some? result))
+      (is (= :moderate (:level result)))
+      (is (<= 0.1 (:coefficient_of_variation result)))
+      (is (< (:coefficient_of_variation result) 0.3)))))
+
+(deftest compute-volatility-high-test
+  (testing "fairly variable data produces :high volatility (0.3 ≤ cv < 0.5)"
+    ;; mean=100, std≈34.6, cv≈0.346
+    (let [result (time-series/compute-volatility [60.0 100.0 140.0 70.0 130.0])]
+      (is (some? result))
+      (is (= :high (:level result)))
+      (is (<= 0.3 (:coefficient_of_variation result)))
+      (is (< (:coefficient_of_variation result) 0.5)))))
+
+(deftest compute-volatility-extreme-test
+  (testing "very variable data produces :extreme volatility (cv ≥ 0.5)"
+    ;; mean≈102, std≈75, cv≈0.73
+    (let [result (time-series/compute-volatility [10.0 100.0 200.0 50.0 150.0])]
+      (is (some? result))
+      (is (= :extreme (:level result)))
+      (is (>= (:coefficient_of_variation result) 0.5)))))
+
+(deftest compute-volatility-max-period-change-test
+  (testing "max period change is computed as absolute percentage of previous value"
+    ;; [100, 200, 250, 500]: changes 100%, 25%, 100% → max = 100%
+    (let [result (time-series/compute-volatility [100.0 200.0 250.0 500.0])]
+      (is (some? result))
+      (is (>= (:max_period_change_pct result) 99.0))
+      (is (<= (:max_period_change_pct result) 101.0)))))
+
+;;; ----------------------------------------------- detect-patterns tests --------------------------------------------
+
+(deftest detect-patterns-increasing-streak-test
+  (testing "detects consecutive increases of 5+ periods"
+    (let [values (mapv #(* 10.0 %) (range 1 11))  ; [10 20 ... 100]
+          dates  (mapv #(format "2024-%02d" %) (range 1 11))
+          result (time-series/detect-patterns values dates)]
+      (is (pos? (count result)))
+      (is (= :consecutive_increase (:type (first result))))
+      (is (str/includes? (:description (first result)) "increase")))))
+
+(deftest detect-patterns-decreasing-streak-test
+  (testing "detects consecutive decreases of 5+ periods"
+    (let [values (mapv #(* 10.0 %) (range 10 0 -1))  ; [100 90 ... 10]
+          dates  (mapv #(format "2024-%02d" %) (range 1 11))
+          result (time-series/detect-patterns values dates)]
+      (is (pos? (count result)))
+      (is (= :consecutive_decrease (:type (first result))))
+      (is (str/includes? (:description (first result)) "decrease")))))
+
+(deftest detect-patterns-short-sequence-no-streak-test
+  (testing "fewer than 5 consecutive changes → no streak detected"
+    (let [values [10.0 20.0 30.0]
+          dates  ["2024-01" "2024-02" "2024-03"]
+          result (time-series/detect-patterns values dates)]
+      (is (empty? result)))))
+
+(deftest detect-patterns-insufficient-data-test
+  (testing "only 2 data points → no streaks possible"
+    (let [values [10.0 20.0]
+          dates  ["2024-01" "2024-02"]
+          result (time-series/detect-patterns values dates)]
+      (is (empty? result)))))
+
+(deftest detect-patterns-includes-date-range-test
+  (testing "pattern maps include :from_date and :to_date"
+    (let [values (mapv #(* 10.0 %) (range 1 11))
+          dates  (mapv #(format "2024-%02d" %) (range 1 11))
+          result (time-series/detect-patterns values dates)]
+      (when (seq result)
+        (let [pattern (first result)]
+          (is (contains? pattern :from_date))
+          (is (contains? pattern :to_date))
+          (is (contains? pattern :description)))))))
+
+;;; ------------------------------------------- compute-correlations tests -------------------------------------------
+
+(deftest compute-correlations-strong-positive-test
+  (testing "perfectly correlated series produces strong positive correlation"
+    ;; Requires ≥ 10 aligned data points
+    (let [n       10
+          x-vals  (mapv str (range 1 (inc n)))
+          series-map {"Revenue" {:x_values x-vals
+                                 :y_values (mapv #(* 10.0 %) (range 1 (inc n)))}
+                      "Sales"   {:x_values x-vals
+                                 :y_values (mapv #(* 20.0 %) (range 1 (inc n)))}}
+          result  (time-series/compute-correlations series-map)]
+      (is (= 1 (count result)))
+      ;; "Revenue" < "Sales" alphabetically → series_a="Revenue", series_b="Sales"
+      (is (= "Revenue" (:series_a (first result))))
+      (is (= "Sales" (:series_b (first result))))
+      (is (> (:coefficient (first result)) 0.9))
+      (is (= :strong (:strength (first result))))
+      (is (= :positive (:direction (first result)))))))
+
+(deftest compute-correlations-strong-negative-test
+  (testing "inversely correlated series produces strong negative correlation"
+    (let [n      10
+          x-vals (mapv str (range 1 (inc n)))
+          series-map {"Costs" {:x_values x-vals
+                               :y_values (mapv #(* 10.0 %) (range 1 (inc n)))}
+                      "Sales" {:x_values x-vals
+                               :y_values (mapv #(* 10.0 %) (range (inc n) 0 -1))}}
+          result (time-series/compute-correlations series-map)]
+      (is (= 1 (count result)))
+      (is (< (:coefficient (first result)) -0.9))
+      (is (= :strong (:strength (first result))))
+      (is (= :negative (:direction (first result)))))))
+
+(deftest compute-correlations-single-series-returns-empty-test
+  (testing "single series produces no pairs → empty result"
+    (let [n      10
+          x-vals (mapv str (range 1 (inc n)))
+          series-map {"Sales" {:x_values x-vals
+                               :y_values (mapv #(* 10.0 %) (range 1 (inc n)))}}
+          result (time-series/compute-correlations series-map)]
+      (is (empty? result)))))
+
+(deftest compute-correlations-three-series-all-pairs-test
+  (testing "three series with 10 points each produces 3 pairs"
+    (let [n      10
+          x-vals (mapv str (range 1 (inc n)))
+          vals   (mapv #(* 10.0 %) (range 1 (inc n)))
+          series-map {"A" {:x_values x-vals :y_values vals}
+                      "B" {:x_values x-vals :y_values vals}
+                      "C" {:x_values x-vals :y_values vals}}
+          result (time-series/compute-correlations series-map)]
+      (is (= 3 (count result))))))
+
+(deftest compute-correlations-insufficient-points-skipped-test
+  (testing "pairs with fewer than 10 aligned points are skipped"
+    ;; Only 5 aligned points → below min-correlation-sample-size (10) → no correlations
+    (let [x-vals (mapv str (range 1 6))
+          series-map {"A" {:x_values x-vals :y_values [1.0 2.0 3.0 4.0 5.0]}
+                      "B" {:x_values x-vals :y_values [2.0 4.0 6.0 8.0 10.0]}}
+          result (time-series/compute-correlations series-map)]
+      (is (empty? result)))))
+
+;;; ----------------------------------------- find-significant-changes tests -----------------------------------------
+
+(deftest find-significant-changes-top-n-by-magnitude-test
+  (testing "returns top N changes sorted by absolute magnitude"
+    ;; Changes: 10→15 (+5), 15→12 (-3), 12→25 (+13), 25→22 (-3), 22→20 (-2)
+    ;; Top 3 by |abs|: 12→25 (13), 10→15 (5), 15→12 or 25→22 (3)
+    (let [values [10.0 15.0 12.0 25.0 22.0 20.0]
+          dates  ["d1" "d2" "d3" "d4" "d5" "d6"]
+          result (time-series/find-significant-changes values dates 3)]
+      (is (<= (count result) 3))
+      ;; Largest change is 12→25 (abs=13)
+      (is (= 12.0 (:from_value (first result))))
+      (is (= 25.0 (:to_value (first result)))))))
+
+(deftest find-significant-changes-includes-pct-change-test
+  (testing "change maps include :change_abs and :change_pct"
+    (let [values [10.0 15.0 20.0]
+          dates  ["d1" "d2" "d3"]
+          result (time-series/find-significant-changes values dates 3)]
+      (is (every? #(contains? % :change_abs) result))
+      (is (every? #(contains? % :change_pct) result))
+      (is (every? #(contains? % :from_date) result))
+      (is (every? #(contains? % :to_date) result)))))
+
+;;; ---------------------------------------- compute-most-recent-change tests ----------------------------------------
+
+(deftest compute-most-recent-change-test
+  (testing "returns the last consecutive change"
+    (let [values [10.0 15.0 12.0 25.0 22.0 20.0]
+          dates  ["2024-01" "2024-02" "2024-03" "2024-04" "2024-05" "2024-06"]
+          result (time-series/compute-most-recent-change values dates)]
+      (is (some? result))
+      (is (= "2024-05" (:from_date result)))
+      (is (= "2024-06" (:to_date result)))
+      (is (= 22.0 (:from_value result)))
+      (is (= 20.0 (:to_value result)))
+      (is (= -2.0 (:change_abs result))))))
+
+(deftest compute-most-recent-change-single-value-test
+  (testing "single value returns nil (no previous point)"
+    (let [result (time-series/compute-most-recent-change [10.0] ["d1"])]
+      (is (nil? result)))))
+
+(deftest compute-most-recent-change-two-values-test
+  (testing "two values returns the one change"
+    (let [result (time-series/compute-most-recent-change [10.0 15.0] ["d1" "d2"])]
+      (is (some? result))
+      (is (= 10.0 (:from_value result)))
+      (is (= 15.0 (:to_value result)))
+      (is (= 5.0 (:change_abs result)))
+      (is (< (Math/abs (- (:change_pct result) 50.0)) 0.001)))))
+
+;;; --------------------------------------------- compute-series-stats tests ----------------------------------------
+
+(deftest compute-series-stats-basic-fields-test
+  (testing "basic stats include summary, time_range, trend, data_points, is_cumulative"
+    (let [values [10.0 20.0 30.0 40.0 50.0]
+          dates  ["2024-01" "2024-02" "2024-03" "2024-04" "2024-05"]
+          result (time-series/compute-series-stats values dates {})]
+      (is (= 5 (:data_points result)))
+      (is (some? (:summary result)))
+      (is (= 10.0 (:min (:summary result))))
+      (is (= 50.0 (:max (:summary result))))
+      (is (some? (:trend result)))
+      (is (some? (:time_range result)))
+      (is (= "2024-01" (:start (:time_range result))))
+      (is (= "2024-05" (:end (:time_range result)))))))
+
+(deftest compute-series-stats-cumulative-detection-test
+  (testing "cumulative data is flagged as :is_cumulative true"
+    (let [values (mapv #(* 10.0 %) (range 1 13))   ; [10 20 ... 120]
+          dates  (mapv #(format "2024-%02d" %) (range 1 13))
+          result (time-series/compute-series-stats values dates {})]
+      (is (true? (:is_cumulative result))))))
+
+(deftest compute-series-stats-non-cumulative-detection-test
+  (testing "non-cumulative data is flagged as :is_cumulative false"
+    (let [values [10.0 5.0 15.0 8.0 20.0]
+          dates  ["d1" "d2" "d3" "d4" "d5"]
+          result (time-series/compute-series-stats values dates {})]
+      (is (false? (:is_cumulative result))))))
+
+(deftest compute-series-stats-no-deep-stats-by-default-test
+  (testing "without deep? opt, volatility and patterns are not computed"
+    (let [values (mapv #(* 10.0 %) (range 1 13))
+          dates  (mapv #(format "2024-%02d" %) (range 1 13))
+          result (time-series/compute-series-stats values dates {})]
+      (is (nil? (:volatility result)))
+      (is (nil? (:patterns result)))
+      (is (nil? (:significant_changes result))))))
+
+(deftest compute-series-stats-deep-stats-with-opt-test
+  (testing "with deep? true, volatility and patterns are computed"
+    (let [values (mapv #(* 10.0 %) (range 1 13))
+          dates  (mapv #(format "2024-%02d" %) (range 1 13))
+          result (time-series/compute-series-stats values dates {:deep? true})]
+      (is (some? (:volatility result)))
+      (is (some? (:patterns result)))
+      (is (some? (:significant_changes result)))
+      (is (some? (:most_recent_change result))))))
+
+(deftest compute-series-stats-deep-significant-changes-capped-at-3-test
+  (testing "significant_changes contains at most 3 entries"
+    (let [values [10.0 15.0 12.0 25.0 22.0 20.0]
+          dates  ["2024-01" "2024-02" "2024-03" "2024-04" "2024-05" "2024-06"]
+          result (time-series/compute-series-stats values dates {:deep? true})]
+      (is (<= (count (:significant_changes result)) 3))
+      (is (some? (:most_recent_change result)))
+      (is (= "2024-05" (:from_date (:most_recent_change result))))
+      (is (= "2024-06" (:to_date (:most_recent_change result)))))))
+
+;;; ----------------------------------------- compute-time-series-stats tests ----------------------------------------
+
+(deftest compute-time-series-stats-multi-series-test
+  (testing "each series gets independent stats; no cross-series correlations without deep?"
+    (let [series-data {"S1" {:x_values ["d1" "d2" "d3" "d4" "d5"]
+                             :y_values [1.0 2.0 3.0 4.0 5.0]
+                             :x {:name "x" :type :string}
+                             :y {:name "y" :type :number}
+                             :display_name "S1"}
+                       "S2" {:x_values ["d1" "d2" "d3" "d4" "d5"]
+                             :y_values [5.0 4.0 3.0 2.0 1.0]
+                             :x {:name "x" :type :string}
+                             :y {:name "y" :type :number}
+                             :display_name "S2"}}
+          result (time-series/compute-time-series-stats series-data {})]
+      (is (= :time-series (:chart_type result)))
+      (is (= 2 (:series_count result)))
+      (is (contains? (:series result) "S1"))
+      (is (contains? (:series result) "S2"))
+      (is (nil? (:correlations result))))))
+
+(deftest compute-time-series-stats-deep-correlations-test
+  (testing "with deep? true and 2+ series of 10+ points, correlations are computed"
+    (let [n           10
+          x-vals      (mapv #(format "2024-%02d" %) (range 1 (inc n)))
+          series-data {"A" {:x_values x-vals
+                            :y_values (mapv #(* 10.0 %) (range 1 (inc n)))
+                            :x {:name "x" :type :string}
+                            :y {:name "y" :type :number}
+                            :display_name "A"}
+                       "B" {:x_values x-vals
+                            :y_values (mapv #(* 20.0 %) (range 1 (inc n)))
+                            :x {:name "x" :type :string}
+                            :y {:name "y" :type :number}
+                            :display_name "B"}}
+          result (time-series/compute-time-series-stats series-data {:deep? true})]
+      (is (some? (:correlations result)))
+      (is (= 1 (count (:correlations result)))))))
+
+;;; ---------------------------------------- temporal context / repr tests -------------------------------------------
+
+(deftest generate-temporal-context-test
+  (testing "temporal context includes current date, day of week, week, month, and quarter"
+    (let [result (repr/generate-temporal-context)]
+      (is (str/includes? result "Today is"))
+      (is (some #(str/includes? result %)
+                ["Monday" "Tuesday" "Wednesday" "Thursday" "Friday" "Saturday" "Sunday"]))
+      (is (str/includes? (u/lower-case-en result) "week"))
+      (is (str/includes? (u/lower-case-en result) "month"))
+      (is (str/includes? (u/lower-case-en result) "quarter"))
+      (is (some #(str/includes? result %) ["Q1" "Q2" "Q3" "Q4"])))))
+
+(deftest repr-time-series-includes-series-name-and-trend-test
+  (testing "time series representation includes series name and trend direction"
+    (let [values [10.0 20.0 30.0 40.0 50.0]
+          dates  ["2024-01" "2024-02" "2024-03" "2024-04" "2024-05"]
+          series-stats (time-series/compute-series-stats values dates {})
+          stats {:chart_type   :time-series
+                 :series_count 1
+                 :series       {"Revenue" series-stats}}
+          rep (repr/generate-time-series-representation {:stats stats})]
+      (is (str/includes? rep "Revenue"))
+      (is (str/includes? rep "Trend"))
+      (is (str/includes? rep "Time Series")))))
+
+(deftest repr-time-series-multi-series-test
+  (testing "representation with multiple series includes all series names"
+    (let [make-stats (fn [values dates]
+                       (time-series/compute-series-stats values dates {}))
+          stats {:chart_type   :time-series
+                 :series_count 2
+                 :series       {"Sales"   (make-stats [10.0 20.0 30.0 40.0 50.0]
+                                                      ["d1" "d2" "d3" "d4" "d5"])
+                                "Revenue" (make-stats [20.0 40.0 60.0 80.0 100.0]
+                                                      ["d1" "d2" "d3" "d4" "d5"])}}
+          rep (repr/generate-time-series-representation {:stats stats})]
+      (is (str/includes? rep "Sales"))
+      (is (str/includes? rep "Revenue")))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/time_series_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/time_series_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]
+   [mb.hawk.assert-exprs.approximately-equal :as =?]
    [metabase-enterprise.metabot-v3.stats.repr :as repr]
    [metabase-enterprise.metabot-v3.stats.time-series :as time-series]
    [metabase-enterprise.metabot-v3.stats.util :as stats.u]
@@ -274,7 +275,7 @@
     (is (=? {:from_value 10.0
              :to_value   15.0
              :change_abs 5.0
-             :change_pct #(< (Math/abs (- % 50.0)) 0.001)}
+             :change_pct (=?/approx [50.0 0.001])}
             (time-series/compute-most-recent-change [10.0 15.0] ["d1" "d2"])))))
 
 ;;; --------------------------------------------- compute-series-stats tests ----------------------------------------

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/time_series_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/time_series_test.clj
@@ -10,37 +10,37 @@
 
 ;;; ------------------------------------------------ detect-cumulative? ----------------------------------------------
 
-(deftest detect-cumulative-strictly-increasing-test
+(deftest ^:parallel detect-cumulative-strictly-increasing-test
   (testing "strictly increasing data is cumulative"
     (is (true? (time-series/detect-cumulative? [10.0 20.0 30.0 40.0 50.0 60.0])))))
 
-(deftest detect-cumulative-monotone-with-plateaus-test
+(deftest ^:parallel detect-cumulative-monotone-with-plateaus-test
   (testing "monotone non-decreasing data with flat sections is cumulative"
     (is (true? (time-series/detect-cumulative? [100.0 100.0 150.0 150.0 200.0 200.0 250.0])))))
 
-(deftest detect-cumulative-not-cumulative-test
+(deftest ^:parallel detect-cumulative-not-cumulative-test
   (testing "data with frequent decreases is not cumulative"
     (is (false? (time-series/detect-cumulative? [1.0 2.0 1.5 3.0 2.8])))))
 
-(deftest detect-cumulative-multiple-significant-decreases-test
+(deftest ^:parallel detect-cumulative-multiple-significant-decreases-test
   (testing "data with many significant drops is not cumulative"
     (is (false? (time-series/detect-cumulative? [100.0 90.0 120.0 100.0 150.0 130.0 180.0])))))
 
-(deftest detect-cumulative-single-value-test
+(deftest ^:parallel detect-cumulative-single-value-test
   (testing "single value has no diffs → not cumulative"
     (is (false? (time-series/detect-cumulative? [100.0])))))
 
-(deftest detect-cumulative-empty-test
+(deftest ^:parallel detect-cumulative-empty-test
   (testing "empty values are not cumulative"
     (is (false? (time-series/detect-cumulative? [])))))
 
-(deftest detect-cumulative-mostly-increasing-with-significant-drop-test
+(deftest ^:parallel detect-cumulative-mostly-increasing-with-significant-drop-test
   (testing "data where >5% of consecutive diffs are negative is not cumulative"
     (is (false? (time-series/detect-cumulative? [1.0 2.0 3.0 2.9 4.0 5.0])))))
 
 ;;; ---------------------------------------------- compute-trend tests -----------------------------------------------
 
-(deftest compute-trend-strongly-increasing-test
+(deftest ^:parallel compute-trend-strongly-increasing-test
   (testing "strongly increasing series detected as :strongly_increasing"
     ;; slope=5, mean=20, pct=100*20/20=100% > 50 → :strongly_increasing
     (is (=? {:direction          :strongly_increasing
@@ -49,24 +49,24 @@
              :end_value          30.0}
             (time-series/compute-trend [10.0 15.0 20.0 25.0 30.0])))))
 
-(deftest compute-trend-strongly-decreasing-test
+(deftest ^:parallel compute-trend-strongly-decreasing-test
   (testing "strongly decreasing series detected as :strongly_decreasing"
     (is (=? {:direction          :strongly_decreasing
              :overall_change_pct neg?}
             (time-series/compute-trend [100.0 80.0 60.0 40.0 20.0])))))
 
-(deftest compute-trend-flat-test
+(deftest ^:parallel compute-trend-flat-test
   (testing "roughly flat series detected as :flat"
     (is (=? {:direction :flat}
             (time-series/compute-trend [50.0 51.0 50.0 50.5 50.0])))))
 
-(deftest compute-trend-increasing-moderate-test
+(deftest ^:parallel compute-trend-increasing-moderate-test
   (testing "moderate increase (10-50% range) detected as :increasing"
     ;; slope=10, mean=120, total_change=40, pct=33.3% → :increasing
     (is (=? {:direction :increasing}
             (time-series/compute-trend [100.0 110.0 120.0 130.0 140.0])))))
 
-(deftest compute-trend-returns-start-end-values-test
+(deftest ^:parallel compute-trend-returns-start-end-values-test
   (testing "trend includes correct start and end values"
     (is (=? {:start_value 5.0
              :end_value   25.0}
@@ -74,35 +74,35 @@
 
 ;;; --------------------------------------------- compute-volatility tests -------------------------------------------
 
-(deftest compute-volatility-low-test
+(deftest ^:parallel compute-volatility-low-test
   (testing "tightly clustered values produce :low volatility (cv < 0.1)"
     ;; mean≈101.6, std≈1.1, cv≈0.011
     (is (=? {:level                    :low
              :coefficient_of_variation #(< % 0.1)}
             (time-series/compute-volatility [100.0 102.0 101.0 103.0 102.0])))))
 
-(deftest compute-volatility-moderate-test
+(deftest ^:parallel compute-volatility-moderate-test
   (testing "moderately variable data produces :moderate volatility (0.1 ≤ cv < 0.3)"
     ;; mean=100, std≈17.3, cv≈0.173
     (is (=? {:level                    :moderate
              :coefficient_of_variation #(and (<= 0.1 %) (< % 0.3))}
             (time-series/compute-volatility [80.0 100.0 120.0 90.0 110.0])))))
 
-(deftest compute-volatility-high-test
+(deftest ^:parallel compute-volatility-high-test
   (testing "fairly variable data produces :high volatility (0.3 ≤ cv < 0.5)"
     ;; mean=100, std≈34.6, cv≈0.346
     (is (=? {:level                    :high
              :coefficient_of_variation #(and (<= 0.3 %) (< % 0.5))}
             (time-series/compute-volatility [60.0 100.0 140.0 70.0 130.0])))))
 
-(deftest compute-volatility-extreme-test
+(deftest ^:parallel compute-volatility-extreme-test
   (testing "very variable data produces :extreme volatility (cv ≥ 0.5)"
     ;; mean≈102, std≈75, cv≈0.73
     (is (=? {:level                    :extreme
              :coefficient_of_variation #(>= % 0.5)}
             (time-series/compute-volatility [10.0 100.0 200.0 50.0 150.0])))))
 
-(deftest compute-volatility-max-period-change-test
+(deftest ^:parallel compute-volatility-max-period-change-test
   (testing "max period change is computed as absolute percentage of previous value"
     ;; changes 100%, 25%, 100% → max = 100%
     (is (=? {:max_period_change_pct #(and (>= % 99.0) (<= % 101.0))}
@@ -110,7 +110,7 @@
 
 ;;; ----------------------------------------------- detect-patterns tests --------------------------------------------
 
-(deftest detect-patterns-increasing-streak-test
+(deftest ^:parallel detect-patterns-increasing-streak-test
   (testing "detects consecutive increases of 5+ periods"
     (let [values (mapv #(* 10.0 %) (range 1 11))  ; [10 20 ... 100]
           dates  (mapv #(format "2024-%02d" %) (range 1 11))
@@ -120,7 +120,7 @@
                :description #(str/includes? % "increase")}
               (first result))))))
 
-(deftest detect-patterns-decreasing-streak-test
+(deftest ^:parallel detect-patterns-decreasing-streak-test
   (testing "detects consecutive decreases of 5+ periods"
     (let [values (mapv #(* 10.0 %) (range 10 0 -1))  ; [100 90 ... 10]
           dates  (mapv #(format "2024-%02d" %) (range 1 11))
@@ -130,21 +130,21 @@
                :description #(str/includes? % "decrease")}
               (first result))))))
 
-(deftest detect-patterns-short-sequence-no-streak-test
+(deftest ^:parallel detect-patterns-short-sequence-no-streak-test
   (testing "fewer than 5 consecutive changes → no streak detected"
     (let [values [10.0 20.0 30.0]
           dates  ["2024-01" "2024-02" "2024-03"]
           result (time-series/detect-patterns values dates)]
       (is (empty? result)))))
 
-(deftest detect-patterns-insufficient-data-test
+(deftest ^:parallel detect-patterns-insufficient-data-test
   (testing "only 2 data points → no streaks possible"
     (let [values [10.0 20.0]
           dates  ["2024-01" "2024-02"]
           result (time-series/detect-patterns values dates)]
       (is (empty? result)))))
 
-(deftest detect-patterns-includes-date-range-test
+(deftest ^:parallel detect-patterns-includes-date-range-test
   (testing "pattern maps include :from_date and :to_date"
     (let [values (mapv #(* 10.0 %) (range 1 11))
           dates  (mapv #(format "2024-%02d" %) (range 1 11))
@@ -166,7 +166,7 @@
    :y            {:name "y" :type :number}
    :display_name display-name})
 
-(deftest compute-correlations-strong-positive-test
+(deftest ^:parallel compute-correlations-strong-positive-test
   (testing "perfectly correlated series produces strong positive correlation"
     ;; Requires ≥ 10 aligned data points
     (let [n       10
@@ -183,7 +183,7 @@
                :direction   :positive}
               (first result))))))
 
-(deftest compute-correlations-strong-negative-test
+(deftest ^:parallel compute-correlations-strong-negative-test
   (testing "inversely correlated series produces strong negative correlation"
     (let [n      10
           x-vals (mapv str (range 1 (inc n)))
@@ -196,7 +196,7 @@
                :direction   :negative}
               (first result))))))
 
-(deftest compute-correlations-single-series-returns-empty-test
+(deftest ^:parallel compute-correlations-single-series-returns-empty-test
   (testing "single series produces no pairs → empty result"
     (let [n      10
           x-vals (mapv str (range 1 (inc n)))
@@ -204,7 +204,7 @@
           result (stats.u/compute-correlations series-map)]
       (is (empty? result)))))
 
-(deftest compute-correlations-three-series-all-pairs-test
+(deftest ^:parallel compute-correlations-three-series-all-pairs-test
   (testing "three series with 10 points each produces 3 pairs"
     (let [n      10
           x-vals (mapv str (range 1 (inc n)))
@@ -215,7 +215,7 @@
           result (stats.u/compute-correlations series-map)]
       (is (= 3 (count result))))))
 
-(deftest compute-correlations-insufficient-points-skipped-test
+(deftest ^:parallel compute-correlations-insufficient-points-skipped-test
   (testing "pairs with fewer than 10 aligned points are skipped"
     ;; Only 5 aligned points → below min-correlation-sample-size (10) → no correlations
     (let [x-vals (mapv str (range 1 6))
@@ -226,7 +226,7 @@
 
 ;;; ----------------------------------------- find-significant-changes tests -----------------------------------------
 
-(deftest find-significant-changes-top-n-by-magnitude-test
+(deftest ^:parallel find-significant-changes-top-n-by-magnitude-test
   (testing "returns top N changes sorted by absolute magnitude"
     ;; Changes: 10→15 (+5), 15→12 (-3), 12→25 (+13), 25→22 (-3), 22→20 (-2)
     ;; Top 3 by |abs|: 12→25 (13), 10→15 (5), 15→12 or 25→22 (3)
@@ -239,7 +239,7 @@
                :to_value   25.0}
               (first result))))))
 
-(deftest find-significant-changes-includes-pct-change-test
+(deftest ^:parallel find-significant-changes-includes-pct-change-test
   (testing "change maps include :change_abs and :change_pct"
     (let [values [10.0 15.0 20.0]
           dates  ["d1" "d2" "d3"]
@@ -253,7 +253,7 @@
 
 ;;; ---------------------------------------- compute-most-recent-change tests ----------------------------------------
 
-(deftest compute-most-recent-change-test
+(deftest ^:parallel compute-most-recent-change-test
   (testing "returns the last consecutive change"
     (is (=? {:from_date  "2024-05"
              :to_date    "2024-06"
@@ -264,11 +264,11 @@
              [10.0 15.0 12.0 25.0 22.0 20.0]
              ["2024-01" "2024-02" "2024-03" "2024-04" "2024-05" "2024-06"])))))
 
-(deftest compute-most-recent-change-single-value-test
+(deftest ^:parallel compute-most-recent-change-single-value-test
   (testing "single value returns nil (no previous point)"
     (is (nil? (time-series/compute-most-recent-change [10.0] ["d1"])))))
 
-(deftest compute-most-recent-change-two-values-test
+(deftest ^:parallel compute-most-recent-change-two-values-test
   (testing "two values returns the one change"
     (is (=? {:from_value 10.0
              :to_value   15.0
@@ -278,7 +278,7 @@
 
 ;;; --------------------------------------------- compute-series-stats tests ----------------------------------------
 
-(deftest compute-series-stats-basic-fields-test
+(deftest ^:parallel compute-series-stats-basic-fields-test
   (testing "basic stats include summary, time_range, trend, data_points, is_cumulative"
     (is (=? {:data_points 5
              :summary     {:min 10.0 :max 50.0}
@@ -289,7 +289,7 @@
              ["2024-01" "2024-02" "2024-03" "2024-04" "2024-05"]
              {})))))
 
-(deftest compute-series-stats-cumulative-detection-test
+(deftest ^:parallel compute-series-stats-cumulative-detection-test
   (testing "cumulative data is flagged as :is_cumulative true"
     (is (=? {:is_cumulative true}
             (time-series/compute-series-stats
@@ -297,7 +297,7 @@
              (mapv #(format "2024-%02d" %) (range 1 13))
              {})))))
 
-(deftest compute-series-stats-non-cumulative-detection-test
+(deftest ^:parallel compute-series-stats-non-cumulative-detection-test
   (testing "non-cumulative data is flagged as :is_cumulative false"
     (is (=? {:is_cumulative false}
             (time-series/compute-series-stats
@@ -305,7 +305,7 @@
              ["d1" "d2" "d3" "d4" "d5"]
              {})))))
 
-(deftest compute-series-stats-no-deep-stats-by-default-test
+(deftest ^:parallel compute-series-stats-no-deep-stats-by-default-test
   (testing "without deep? opt, volatility and patterns are not computed"
     (is (=? {:volatility          (symbol "nil #_\"key is not present.\"")
              :patterns            (symbol "nil #_\"key is not present.\"")
@@ -315,7 +315,7 @@
              (mapv #(format "2024-%02d" %) (range 1 13))
              {})))))
 
-(deftest compute-series-stats-deep-stats-with-opt-test
+(deftest ^:parallel compute-series-stats-deep-stats-with-opt-test
   (testing "with deep? true, volatility and patterns are computed"
     (is (=? {:volatility          some?
              :patterns            some?
@@ -326,7 +326,7 @@
              (mapv #(format "2024-%02d" %) (range 1 13))
              {:deep? true})))))
 
-(deftest compute-series-stats-deep-significant-changes-capped-at-3-test
+(deftest ^:parallel compute-series-stats-deep-significant-changes-capped-at-3-test
   (testing "significant_changes contains at most 3 entries"
     (let [result (time-series/compute-series-stats
                   [10.0 15.0 12.0 25.0 22.0 20.0]
@@ -339,7 +339,7 @@
 
 ;;; ----------------------------------------- compute-time-series-stats tests ----------------------------------------
 
-(deftest compute-time-series-stats-multi-series-test
+(deftest ^:parallel compute-time-series-stats-multi-series-test
   (testing "each series gets independent stats; no cross-series correlations without deep?"
     (let [series-data {"S1" {:x_values ["d1" "d2" "d3" "d4" "d5"]
                              :y_values [1.0 2.0 3.0 4.0 5.0]
@@ -357,7 +357,7 @@
                :correlations  (symbol "nil #_\"key is not present.\"")}
               (time-series/compute-time-series-stats series-data {}))))))
 
-(deftest compute-time-series-stats-deep-correlations-test
+(deftest ^:parallel compute-time-series-stats-deep-correlations-test
   (testing "with deep? true and 2+ series of 10+ points, correlations are computed"
     (let [n           10
           x-vals      (mapv #(format "2024-%02d" %) (range 1 (inc n)))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/time_series_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/time_series_test.clj
@@ -12,31 +12,31 @@
 
 (deftest ^:parallel detect-cumulative-strictly-increasing-test
   (testing "strictly increasing data is cumulative"
-    (is (true? (time-series/detect-cumulative? [10.0 20.0 30.0 40.0 50.0 60.0])))))
+    (is (true? (#'time-series/detect-cumulative? [10.0 20.0 30.0 40.0 50.0 60.0])))))
 
 (deftest ^:parallel detect-cumulative-monotone-with-plateaus-test
   (testing "monotone non-decreasing data with flat sections is cumulative"
-    (is (true? (time-series/detect-cumulative? [100.0 100.0 150.0 150.0 200.0 200.0 250.0])))))
+    (is (true? (#'time-series/detect-cumulative? [100.0 100.0 150.0 150.0 200.0 200.0 250.0])))))
 
 (deftest ^:parallel detect-cumulative-not-cumulative-test
   (testing "data with frequent decreases is not cumulative"
-    (is (false? (time-series/detect-cumulative? [1.0 2.0 1.5 3.0 2.8])))))
+    (is (false? (#'time-series/detect-cumulative? [1.0 2.0 1.5 3.0 2.8])))))
 
 (deftest ^:parallel detect-cumulative-multiple-significant-decreases-test
   (testing "data with many significant drops is not cumulative"
-    (is (false? (time-series/detect-cumulative? [100.0 90.0 120.0 100.0 150.0 130.0 180.0])))))
+    (is (false? (#'time-series/detect-cumulative? [100.0 90.0 120.0 100.0 150.0 130.0 180.0])))))
 
 (deftest ^:parallel detect-cumulative-single-value-test
   (testing "single value has no diffs → not cumulative"
-    (is (false? (time-series/detect-cumulative? [100.0])))))
+    (is (false? (#'time-series/detect-cumulative? [100.0])))))
 
 (deftest ^:parallel detect-cumulative-empty-test
   (testing "empty values are not cumulative"
-    (is (false? (time-series/detect-cumulative? [])))))
+    (is (false? (#'time-series/detect-cumulative? [])))))
 
 (deftest ^:parallel detect-cumulative-mostly-increasing-with-significant-drop-test
   (testing "data where >5% of consecutive diffs are negative is not cumulative"
-    (is (false? (time-series/detect-cumulative? [1.0 2.0 3.0 2.9 4.0 5.0])))))
+    (is (false? (#'time-series/detect-cumulative? [1.0 2.0 3.0 2.9 4.0 5.0])))))
 
 ;;; ---------------------------------------------- compute-trend tests -----------------------------------------------
 
@@ -47,30 +47,30 @@
              :overall_change_pct pos?
              :start_value        10.0
              :end_value          30.0}
-            (time-series/compute-trend [10.0 15.0 20.0 25.0 30.0])))))
+            (#'time-series/compute-trend [10.0 15.0 20.0 25.0 30.0])))))
 
 (deftest ^:parallel compute-trend-strongly-decreasing-test
   (testing "strongly decreasing series detected as :strongly_decreasing"
     (is (=? {:direction          :strongly_decreasing
              :overall_change_pct neg?}
-            (time-series/compute-trend [100.0 80.0 60.0 40.0 20.0])))))
+            (#'time-series/compute-trend [100.0 80.0 60.0 40.0 20.0])))))
 
 (deftest ^:parallel compute-trend-flat-test
   (testing "roughly flat series detected as :flat"
     (is (=? {:direction :flat}
-            (time-series/compute-trend [50.0 51.0 50.0 50.5 50.0])))))
+            (#'time-series/compute-trend [50.0 51.0 50.0 50.5 50.0])))))
 
 (deftest ^:parallel compute-trend-increasing-moderate-test
   (testing "moderate increase (10-50% range) detected as :increasing"
     ;; slope=10, mean=120, total_change=40, pct=33.3% → :increasing
     (is (=? {:direction :increasing}
-            (time-series/compute-trend [100.0 110.0 120.0 130.0 140.0])))))
+            (#'time-series/compute-trend [100.0 110.0 120.0 130.0 140.0])))))
 
 (deftest ^:parallel compute-trend-returns-start-end-values-test
   (testing "trend includes correct start and end values"
     (is (=? {:start_value 5.0
              :end_value   25.0}
-            (time-series/compute-trend [5.0 10.0 15.0 20.0 25.0])))))
+            (#'time-series/compute-trend [5.0 10.0 15.0 20.0 25.0])))))
 
 ;;; --------------------------------------------- compute-volatility tests -------------------------------------------
 
@@ -79,34 +79,34 @@
     ;; mean≈101.6, std≈1.1, cv≈0.011
     (is (=? {:level                    :low
              :coefficient_of_variation #(< % 0.1)}
-            (time-series/compute-volatility [100.0 102.0 101.0 103.0 102.0])))))
+            (#'time-series/compute-volatility [100.0 102.0 101.0 103.0 102.0])))))
 
 (deftest ^:parallel compute-volatility-moderate-test
   (testing "moderately variable data produces :moderate volatility (0.1 ≤ cv < 0.3)"
     ;; mean=100, std≈17.3, cv≈0.173
     (is (=? {:level                    :moderate
              :coefficient_of_variation #(and (<= 0.1 %) (< % 0.3))}
-            (time-series/compute-volatility [80.0 100.0 120.0 90.0 110.0])))))
+            (#'time-series/compute-volatility [80.0 100.0 120.0 90.0 110.0])))))
 
 (deftest ^:parallel compute-volatility-high-test
   (testing "fairly variable data produces :high volatility (0.3 ≤ cv < 0.5)"
     ;; mean=100, std≈34.6, cv≈0.346
     (is (=? {:level                    :high
              :coefficient_of_variation #(and (<= 0.3 %) (< % 0.5))}
-            (time-series/compute-volatility [60.0 100.0 140.0 70.0 130.0])))))
+            (#'time-series/compute-volatility [60.0 100.0 140.0 70.0 130.0])))))
 
 (deftest ^:parallel compute-volatility-extreme-test
   (testing "very variable data produces :extreme volatility (cv ≥ 0.5)"
     ;; mean≈102, std≈75, cv≈0.73
     (is (=? {:level                    :extreme
              :coefficient_of_variation #(>= % 0.5)}
-            (time-series/compute-volatility [10.0 100.0 200.0 50.0 150.0])))))
+            (#'time-series/compute-volatility [10.0 100.0 200.0 50.0 150.0])))))
 
 (deftest ^:parallel compute-volatility-max-period-change-test
   (testing "max period change is computed as absolute percentage of previous value"
     ;; changes 100%, 25%, 100% → max = 100%
     (is (=? {:max_period_change_pct #(and (>= % 99.0) (<= % 101.0))}
-            (time-series/compute-volatility [100.0 200.0 250.0 500.0])))))
+            (#'time-series/compute-volatility [100.0 200.0 250.0 500.0])))))
 
 ;;; ----------------------------------------------- detect-patterns tests --------------------------------------------
 
@@ -114,7 +114,7 @@
   (testing "detects consecutive increases of 5+ periods"
     (let [values (mapv #(* 10.0 %) (range 1 11))  ; [10 20 ... 100]
           dates  (mapv #(format "2024-%02d" %) (range 1 11))
-          result (time-series/detect-patterns values dates)]
+          result (#'time-series/detect-patterns values dates)]
       (is (pos? (count result)))
       (is (=? {:type        :consecutive_increase
                :description #(str/includes? % "increase")}
@@ -124,7 +124,7 @@
   (testing "detects consecutive decreases of 5+ periods"
     (let [values (mapv #(* 10.0 %) (range 10 0 -1))  ; [100 90 ... 10]
           dates  (mapv #(format "2024-%02d" %) (range 1 11))
-          result (time-series/detect-patterns values dates)]
+          result (#'time-series/detect-patterns values dates)]
       (is (pos? (count result)))
       (is (=? {:type        :consecutive_decrease
                :description #(str/includes? % "decrease")}
@@ -134,21 +134,21 @@
   (testing "fewer than 5 consecutive changes → no streak detected"
     (let [values [10.0 20.0 30.0]
           dates  ["2024-01" "2024-02" "2024-03"]
-          result (time-series/detect-patterns values dates)]
+          result (#'time-series/detect-patterns values dates)]
       (is (empty? result)))))
 
 (deftest ^:parallel detect-patterns-insufficient-data-test
   (testing "only 2 data points → no streaks possible"
     (let [values [10.0 20.0]
           dates  ["2024-01" "2024-02"]
-          result (time-series/detect-patterns values dates)]
+          result (#'time-series/detect-patterns values dates)]
       (is (empty? result)))))
 
 (deftest ^:parallel detect-patterns-includes-date-range-test
   (testing "pattern maps include :from_date and :to_date"
     (let [values (mapv #(* 10.0 %) (range 1 11))
           dates  (mapv #(format "2024-%02d" %) (range 1 11))
-          result (time-series/detect-patterns values dates)]
+          result (#'time-series/detect-patterns values dates)]
       (when (seq result)
         (is (=? {:from_date   some?
                  :to_date     some?
@@ -173,7 +173,7 @@
           x-vals  (mapv str (range 1 (inc n)))
           series-map {"Revenue" (make-corr-series "Revenue" x-vals (mapv #(* 10.0 %) (range 1 (inc n))))
                       "Sales"   (make-corr-series "Sales" x-vals (mapv #(* 20.0 %) (range 1 (inc n))))}
-          result  (stats.u/compute-correlations series-map)]
+          result  (#'stats.u/compute-correlations series-map)]
       (is (= 1 (count result)))
       ;; "Revenue" < "Sales" alphabetically → series_a="Revenue", series_b="Sales"
       (is (=? {:series_a    "Revenue"
@@ -189,7 +189,7 @@
           x-vals (mapv str (range 1 (inc n)))
           series-map {"Costs" (make-corr-series "Costs" x-vals (mapv #(* 10.0 %) (range 1 (inc n))))
                       "Sales" (make-corr-series "Sales" x-vals (mapv #(* 10.0 %) (range (inc n) 0 -1)))}
-          result (stats.u/compute-correlations series-map)]
+          result (#'stats.u/compute-correlations series-map)]
       (is (= 1 (count result)))
       (is (=? {:coefficient #(< % -0.9)
                :strength    :strong
@@ -201,7 +201,7 @@
     (let [n      10
           x-vals (mapv str (range 1 (inc n)))
           series-map {"Sales" (make-corr-series "Sales" x-vals (mapv #(* 10.0 %) (range 1 (inc n))))}
-          result (stats.u/compute-correlations series-map)]
+          result (#'stats.u/compute-correlations series-map)]
       (is (empty? result)))))
 
 (deftest ^:parallel compute-correlations-three-series-all-pairs-test
@@ -212,7 +212,7 @@
           series-map {"A" (make-corr-series "A" x-vals vals)
                       "B" (make-corr-series "B" x-vals vals)
                       "C" (make-corr-series "C" x-vals vals)}
-          result (stats.u/compute-correlations series-map)]
+          result (#'stats.u/compute-correlations series-map)]
       (is (= 3 (count result))))))
 
 (deftest ^:parallel compute-correlations-insufficient-points-skipped-test
@@ -221,7 +221,7 @@
     (let [x-vals (mapv str (range 1 6))
           series-map {"A" (make-corr-series "A" x-vals [1.0 2.0 3.0 4.0 5.0])
                       "B" (make-corr-series "B" x-vals [2.0 4.0 6.0 8.0 10.0])}
-          result (stats.u/compute-correlations series-map)]
+          result (#'stats.u/compute-correlations series-map)]
       (is (empty? result)))))
 
 ;;; ----------------------------------------- find-significant-changes tests -----------------------------------------
@@ -232,7 +232,7 @@
     ;; Top 3 by |abs|: 12→25 (13), 10→15 (5), 15→12 or 25→22 (3)
     (let [values [10.0 15.0 12.0 25.0 22.0 20.0]
           dates  ["d1" "d2" "d3" "d4" "d5" "d6"]
-          result (time-series/find-significant-changes values dates 3)]
+          result (#'time-series/find-significant-changes values dates 3)]
       (is (<= (count result) 3))
       ;; Largest change is 12→25 (abs=13)
       (is (=? {:from_value 12.0
@@ -243,7 +243,7 @@
   (testing "change maps include :change_abs and :change_pct"
     (let [values [10.0 15.0 20.0]
           dates  ["d1" "d2" "d3"]
-          result (time-series/find-significant-changes values dates 3)]
+          result (#'time-series/find-significant-changes values dates 3)]
       (doseq [change result]
         (is (=? {:change_abs some?
                  :change_pct some?
@@ -260,13 +260,13 @@
              :from_value 22.0
              :to_value   20.0
              :change_abs -2.0}
-            (time-series/compute-most-recent-change
+            (#'time-series/compute-most-recent-change
              [10.0 15.0 12.0 25.0 22.0 20.0]
              ["2024-01" "2024-02" "2024-03" "2024-04" "2024-05" "2024-06"])))))
 
 (deftest ^:parallel compute-most-recent-change-single-value-test
   (testing "single value returns nil (no previous point)"
-    (is (nil? (time-series/compute-most-recent-change [10.0] ["d1"])))))
+    (is (nil? (#'time-series/compute-most-recent-change [10.0] ["d1"])))))
 
 (deftest ^:parallel compute-most-recent-change-two-values-test
   (testing "two values returns the one change"
@@ -274,7 +274,7 @@
              :to_value   15.0
              :change_abs 5.0
              :change_pct (=?/approx [50.0 0.001])}
-            (time-series/compute-most-recent-change [10.0 15.0] ["d1" "d2"])))))
+            (#'time-series/compute-most-recent-change [10.0 15.0] ["d1" "d2"])))))
 
 ;;; --------------------------------------------- compute-series-stats tests ----------------------------------------
 
@@ -284,7 +284,7 @@
              :summary     {:min 10.0 :max 50.0}
              :trend       some?
              :time_range  {:start "2024-01" :end "2024-05"}}
-            (time-series/compute-series-stats
+            (#'time-series/compute-series-stats
              [10.0 20.0 30.0 40.0 50.0]
              ["2024-01" "2024-02" "2024-03" "2024-04" "2024-05"]
              {})))))
@@ -292,7 +292,7 @@
 (deftest ^:parallel compute-series-stats-cumulative-detection-test
   (testing "cumulative data is flagged as :is_cumulative true"
     (is (=? {:is_cumulative true}
-            (time-series/compute-series-stats
+            (#'time-series/compute-series-stats
              (mapv #(* 10.0 %) (range 1 13))
              (mapv #(format "2024-%02d" %) (range 1 13))
              {})))))
@@ -300,7 +300,7 @@
 (deftest ^:parallel compute-series-stats-non-cumulative-detection-test
   (testing "non-cumulative data is flagged as :is_cumulative false"
     (is (=? {:is_cumulative false}
-            (time-series/compute-series-stats
+            (#'time-series/compute-series-stats
              [10.0 5.0 15.0 8.0 20.0]
              ["d1" "d2" "d3" "d4" "d5"]
              {})))))
@@ -310,7 +310,7 @@
     (is (=? {:volatility          (symbol "nil #_\"key is not present.\"")
              :patterns            (symbol "nil #_\"key is not present.\"")
              :significant_changes (symbol "nil #_\"key is not present.\"")}
-            (time-series/compute-series-stats
+            (#'time-series/compute-series-stats
              (mapv #(* 10.0 %) (range 1 13))
              (mapv #(format "2024-%02d" %) (range 1 13))
              {})))))
@@ -321,14 +321,14 @@
              :patterns            some?
              :significant_changes some?
              :most_recent_change  some?}
-            (time-series/compute-series-stats
+            (#'time-series/compute-series-stats
              (mapv #(* 10.0 %) (range 1 13))
              (mapv #(format "2024-%02d" %) (range 1 13))
              {:deep? true})))))
 
 (deftest ^:parallel compute-series-stats-deep-significant-changes-capped-at-3-test
   (testing "significant_changes contains at most 3 entries"
-    (let [result (time-series/compute-series-stats
+    (let [result (#'time-series/compute-series-stats
                   [10.0 15.0 12.0 25.0 22.0 20.0]
                   ["2024-01" "2024-02" "2024-03" "2024-04" "2024-05" "2024-06"]
                   {:deep? true})]

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/time_series_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/time_series_test.clj
@@ -397,4 +397,3 @@
           result (time-series/compute-time-series-stats series-data {:deep? true})]
       (is (=? {:correlations #(= 1 (count %))}
               result)))))
-

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/time_series_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/time_series_test.clj
@@ -4,6 +4,7 @@
    [clojure.test :refer :all]
    [metabase-enterprise.metabot-v3.stats.repr :as repr]
    [metabase-enterprise.metabot-v3.stats.time-series :as time-series]
+   [metabase-enterprise.metabot-v3.stats.util :as stats.u]
    [metabase.util :as u]))
 
 (set! *warn-on-reflection* true)
@@ -173,7 +174,7 @@
                                  :y_values (mapv #(* 10.0 %) (range 1 (inc n)))}
                       "Sales"   {:x_values x-vals
                                  :y_values (mapv #(* 20.0 %) (range 1 (inc n)))}}
-          result  (time-series/compute-correlations series-map)]
+          result  (stats.u/compute-correlations series-map)]
       (is (= 1 (count result)))
       ;; "Revenue" < "Sales" alphabetically → series_a="Revenue", series_b="Sales"
       (is (= "Revenue" (:series_a (first result))))
@@ -190,7 +191,7 @@
                                :y_values (mapv #(* 10.0 %) (range 1 (inc n)))}
                       "Sales" {:x_values x-vals
                                :y_values (mapv #(* 10.0 %) (range (inc n) 0 -1))}}
-          result (time-series/compute-correlations series-map)]
+          result (stats.u/compute-correlations series-map)]
       (is (= 1 (count result)))
       (is (< (:coefficient (first result)) -0.9))
       (is (= :strong (:strength (first result))))
@@ -202,7 +203,7 @@
           x-vals (mapv str (range 1 (inc n)))
           series-map {"Sales" {:x_values x-vals
                                :y_values (mapv #(* 10.0 %) (range 1 (inc n)))}}
-          result (time-series/compute-correlations series-map)]
+          result (stats.u/compute-correlations series-map)]
       (is (empty? result)))))
 
 (deftest compute-correlations-three-series-all-pairs-test
@@ -213,7 +214,7 @@
           series-map {"A" {:x_values x-vals :y_values vals}
                       "B" {:x_values x-vals :y_values vals}
                       "C" {:x_values x-vals :y_values vals}}
-          result (time-series/compute-correlations series-map)]
+          result (stats.u/compute-correlations series-map)]
       (is (= 3 (count result))))))
 
 (deftest compute-correlations-insufficient-points-skipped-test
@@ -222,7 +223,7 @@
     (let [x-vals (mapv str (range 1 6))
           series-map {"A" {:x_values x-vals :y_values [1.0 2.0 3.0 4.0 5.0]}
                       "B" {:x_values x-vals :y_values [2.0 4.0 6.0 8.0 10.0]}}
-          result (time-series/compute-correlations series-map)]
+          result (stats.u/compute-correlations series-map)]
       (is (empty? result)))))
 
 ;;; ----------------------------------------- find-significant-changes tests -----------------------------------------

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/time_series_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/time_series_test.clj
@@ -149,11 +149,10 @@
     (let [values (mapv #(* 10.0 %) (range 1 11))
           dates  (mapv #(format "2024-%02d" %) (range 1 11))
           result (#'time-series/detect-patterns values dates)]
-      (when (seq result)
-        (is (=? {:from_date   some?
-                 :to_date     some?
-                 :description some?}
-                (first result)))))))
+      (is (=? [{:type      :consecutive_increase
+                :from_date "2024-02"
+                :to_date   "2024-10"}]
+              result)))))
 
 ;;; ------------------------------------------- compute-correlations tests -------------------------------------------
 
@@ -244,12 +243,19 @@
     (let [values [10.0 15.0 20.0]
           dates  ["d1" "d2" "d3"]
           result (#'time-series/find-significant-changes values dates 3)]
-      (doseq [change result]
-        (is (=? {:change_abs some?
-                 :change_pct some?
-                 :from_date  some?
-                 :to_date    some?}
-                change))))))
+      (is (=? [{:from_date  "d1"
+                :to_date    "d2"
+                :from_value 10.0
+                :to_value   15.0
+                :change_abs 5.0
+                :change_pct 50.0}
+               {:from_date  "d2"
+                :to_date    "d3"
+                :from_value 15.0
+                :to_value   20.0
+                :change_abs 5.0
+                :change_pct (=?/approx [33.33 0.01])}]
+              result)))))
 
 ;;; ---------------------------------------- compute-most-recent-change tests ----------------------------------------
 
@@ -280,10 +286,15 @@
 
 (deftest ^:parallel compute-series-stats-basic-fields-test
   (testing "basic stats include summary, time_range, trend, data_points, is_cumulative"
-    (is (=? {:data_points 5
-             :summary     {:min 10.0 :max 50.0}
-             :trend       some?
-             :time_range  {:start "2024-01" :end "2024-05"}}
+    (is (=? {:data_points   5
+             :summary       {:min 10.0 :max 50.0}
+             :trend         {:direction          :strongly_increasing
+                             :overall_change_pct 400.0
+                             :start_value        10.0
+                             :end_value          50.0}
+             :time_range    {:start "2024-01"
+                             :end   "2024-05"}
+             :is_cumulative true}
             (#'time-series/compute-series-stats
              [10.0 20.0 30.0 40.0 50.0]
              ["2024-01" "2024-02" "2024-03" "2024-04" "2024-05"]
@@ -317,10 +328,19 @@
 
 (deftest ^:parallel compute-series-stats-deep-stats-with-opt-test
   (testing "with deep? true, volatility and patterns are computed"
-    (is (=? {:volatility          some?
-             :patterns            some?
-             :significant_changes some?
-             :most_recent_change  some?}
+    (is (=? {:volatility          {:level                    :extreme
+                                   :coefficient_of_variation #(> % 0.5)
+                                   :max_period_change_pct    100.0}
+             :patterns            [{:type      :consecutive_increase
+                                    :from_date "2024-02"
+                                    :to_date   "2024-12"}]
+             :significant_changes #(= 3 (count %))
+             :most_recent_change  {:from_date  "2024-11"
+                                   :to_date    "2024-12"
+                                   :from_value 110.0
+                                   :to_value   120.0
+                                   :change_abs 10.0
+                                   :change_pct (=?/approx [9.09 0.01])}}
             (#'time-series/compute-series-stats
              (mapv #(* 10.0 %) (range 1 13))
              (mapv #(format "2024-%02d" %) (range 1 13))
@@ -353,7 +373,10 @@
                              :display_name "S2"}}]
       (is (=? {:chart_type    :time-series
                :series_count  2
-               :series        {"S1" some? "S2" some?}
+               :series        {"S1" {:data_points 5
+                                     :trend {:direction :strongly_increasing}}
+                               "S2" {:data_points 5
+                                     :trend {:direction :strongly_decreasing}}}
                :correlations  (symbol "nil #_\"key is not present.\"")}
               (time-series/compute-time-series-stats series-data {}))))))
 

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/util_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/util_test.clj
@@ -1,0 +1,232 @@
+(ns metabase-enterprise.metabot-v3.stats.util-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase-enterprise.metabot-v3.stats.util :as stats.u]))
+
+(set! *warn-on-reflection* true)
+
+;;; -------------------------------------------- compute-summary ---------------------------------------------------
+
+(deftest compute-summary-basic-test
+  (testing "computes correct summary statistics"
+    (let [result (stats.u/compute-summary [10.0 20.0 30.0 40.0 50.0])]
+      (is (= 10.0 (:min result)))
+      (is (= 50.0 (:max result)))
+      (is (= 30.0 (:mean result)))
+      (is (= 30.0 (:median result)))
+      (is (= 40.0 (:range result)))
+      (is (pos? (:std_dev result))))))
+
+(deftest compute-summary-single-value-test
+  (testing "single value has zero range"
+    (let [result (stats.u/compute-summary [42.0])]
+      (is (= 42.0 (:min result)))
+      (is (= 42.0 (:max result)))
+      (is (= 42.0 (:mean result)))
+      (is (= 0.0 (:range result))))))
+
+(deftest compute-summary-median-test
+  (testing "median for odd-count data"
+    (let [result (stats.u/compute-summary [1.0 2.0 3.0 4.0 5.0])]
+      (is (= 3.0 (:median result))))))
+
+;;; ------------------------------------------ compute-correlations ------------------------------------------------
+
+(defn- make-series [x-vals y-vals]
+  {:x_values x-vals :y_values y-vals})
+
+(deftest compute-correlations-perfect-positive-test
+  (testing "perfectly correlated series yield coefficient ~1.0"
+    (let [xs     (mapv double (range 20))
+          result (stats.u/compute-correlations
+                  {"a" (make-series xs xs)
+                   "b" (make-series xs (mapv #(+ 10.0 (* 2.0 %)) xs))})]
+      (is (= 1 (count result)))
+      (is (> (:coefficient (first result)) 0.99))
+      (is (= :strong (:strength (first result))))
+      (is (= :positive (:direction (first result)))))))
+
+(deftest compute-correlations-perfect-negative-test
+  (testing "inversely correlated series yield coefficient ~-1.0"
+    (let [xs     (mapv double (range 20))
+          result (stats.u/compute-correlations
+                  {"a" (make-series xs xs)
+                   "b" (make-series xs (mapv #(- 100.0 %) xs))})]
+      (is (= 1 (count result)))
+      (is (< (:coefficient (first result)) -0.99))
+      (is (= :strong (:strength (first result))))
+      (is (= :negative (:direction (first result)))))))
+
+(deftest compute-correlations-skipped-when-too-few-aligned-points-test
+  (testing "pairs with fewer than 10 aligned points are skipped"
+    (let [result (stats.u/compute-correlations
+                  {"a" (make-series (range 5) (range 5))
+                   "b" (make-series (range 5) (range 5 10))})]
+      (is (empty? result)))))
+
+(deftest compute-correlations-no-overlap-test
+  (testing "series with no common x-values produce no correlations"
+    (let [result (stats.u/compute-correlations
+                  {"a" (make-series (range 0 20) (range 0 20))
+                   "b" (make-series (range 100 120) (range 100 120))})]
+      (is (empty? result)))))
+
+(deftest compute-correlations-three-series-test
+  (testing "three series produce up to C(3,2) = 3 correlation pairs"
+    (let [xs     (mapv double (range 20))
+          result (stats.u/compute-correlations
+                  {"a" (make-series xs xs)
+                   "b" (make-series xs (mapv #(* 2.0 %) xs))
+                   "c" (make-series xs (mapv #(* 3.0 %) xs))})]
+      (is (= 3 (count result))))))
+
+;;; --------------------------------------- maybe-compute-correlations ---------------------------------------------
+
+(deftest maybe-compute-correlations-nil-when-not-deep-test
+  (testing "returns nil when deep? is false"
+    (let [xs (mapv double (range 20))]
+      (is (nil? (stats.u/maybe-compute-correlations
+                 {"a" (make-series xs xs)
+                  "b" (make-series xs xs)}
+                 {:deep? false}))))))
+
+(deftest maybe-compute-correlations-nil-for-single-series-test
+  (testing "returns nil when only one series"
+    (let [xs (mapv double (range 20))]
+      (is (nil? (stats.u/maybe-compute-correlations
+                 {"a" (make-series xs xs)}
+                 {:deep? true}))))))
+
+(deftest maybe-compute-correlations-computes-when-deep-test
+  (testing "computes correlations when deep? is true and multiple series"
+    (let [xs     (mapv double (range 20))
+          result (stats.u/maybe-compute-correlations
+                  {"a" (make-series xs xs)
+                   "b" (make-series xs (mapv #(* 2.0 %) xs))}
+                  {:deep? true})]
+      (is (= 1 (count result))))))
+
+(deftest maybe-compute-correlations-respects-max-cap-test
+  (testing "caps number of series used for correlation"
+    (let [xs         (mapv double (range 20))
+          series-map (into {} (for [i (range 5)]
+                                [(str "s" i) (make-series xs (mapv #(* (inc i) %) xs))]))
+          uncapped   (stats.u/maybe-compute-correlations series-map {:deep? true})
+          capped     (stats.u/maybe-compute-correlations series-map {:deep? true :max-correlation-series 3})]
+      ;; C(5,2)=10 vs C(3,2)=3
+      (is (= 10 (count uncapped)))
+      (is (= 3 (count capped))))))
+
+;;; ------------------------------------------ correlation-strength --------------------------------------------------
+
+(deftest correlation-strength-test
+  (testing "classifies correlation coefficients correctly"
+    (is (= :strong (stats.u/correlation-strength 0.9)))
+    (is (= :strong (stats.u/correlation-strength -0.7)))
+    (is (= :moderate (stats.u/correlation-strength 0.5)))
+    (is (= :moderate (stats.u/correlation-strength -0.4)))
+    (is (= :weak (stats.u/correlation-strength 0.3)))
+    (is (= :weak (stats.u/correlation-strength -0.2)))
+    (is (= :none (stats.u/correlation-strength 0.1)))
+    (is (= :none (stats.u/correlation-strength 0.0)))))
+
+;;; ------------------------------------------- percentage-change ----------------------------------------------------
+
+(deftest percentage-change-basic-test
+  (testing "computes correct percentage change"
+    (is (= 100.0 (stats.u/percentage-change 50.0 100.0)))
+    (is (= -50.0 (stats.u/percentage-change 100.0 50.0)))
+    (is (= 0.0 (stats.u/percentage-change 100.0 100.0)))))
+
+(deftest percentage-change-zero-from-test
+  (testing "returns 0.0 when from-val is zero"
+    (is (= 0.0 (stats.u/percentage-change 0.0 100.0)))
+    (is (= 0.0 (stats.u/percentage-change 0 0)))))
+
+(deftest percentage-change-negative-from-test
+  (testing "handles negative from-val correctly"
+    ;; from -50 to 50: change=100, abs(from)=50 → 200%
+    (is (= 200.0 (stats.u/percentage-change -50.0 50.0)))
+    ;; from -50 to -100: change=-50, abs(from)=50 → -100%
+    (is (= -100.0 (stats.u/percentage-change -50.0 -100.0)))))
+
+;;; ---------------------------------------- compute-series-with-labels ----------------------------------------------
+
+(deftest compute-series-with-labels-test
+  (testing "applies compute-fn and attaches column names"
+    (let [series-data {"s1" {:x_values [1 2 3]
+                             :y_values [10 20 30]
+                             :x {:name "Date"}
+                             :y {:name "Revenue"}}}
+          result (stats.u/compute-series-with-labels
+                  series-data
+                  (fn [xs ys] {:sum (reduce + ys) :count (count xs)}))]
+      (is (= 1 (count result)))
+      (is (= 60 (get-in result ["s1" :sum])))
+      (is (= 3 (get-in result ["s1" :count])))
+      (is (= "Date" (get-in result ["s1" :x_name])))
+      (is (= "Revenue" (get-in result ["s1" :y_name]))))))
+
+(deftest compute-series-with-labels-nil-metadata-test
+  (testing "handles nil column metadata gracefully"
+    (let [series-data {"s1" {:x_values [1] :y_values [10]}}
+          result (stats.u/compute-series-with-labels
+                  series-data
+                  (fn [_ _] {:ok true}))]
+      (is (nil? (get-in result ["s1" :x_name])))
+      (is (nil? (get-in result ["s1" :y_name]))))))
+
+(deftest compute-series-with-labels-multiple-series-test
+  (testing "processes multiple series"
+    (let [series-data {"a" {:x_values [1] :y_values [10] :x {:name "X"} :y {:name "Y"}}
+                       "b" {:x_values [2] :y_values [20] :x {:name "X"} :y {:name "Y"}}}
+          result (stats.u/compute-series-with-labels
+                  series-data
+                  (fn [_ ys] {:val (first ys)}))]
+      (is (= 10 (get-in result ["a" :val])))
+      (is (= 20 (get-in result ["b" :val]))))))
+
+;;; ------------------------------------------- make-chart-result ----------------------------------------------------
+
+(def ^:private sample-summary
+  {:min 1.0 :max 10.0 :mean 5.0 :median 5.0 :std_dev 2.0 :range 9.0})
+
+(def ^:private sample-categorical-series
+  {"s1" {:summary        sample-summary
+         :category_count 3
+         :top_categories [{:name "A" :value 10.0 :percentage 50.0}]
+         :outliers       []}})
+
+(def ^:private sample-histogram-series
+  {"s1" {:summary      sample-summary
+         :data_points  10
+         :distribution {:percentiles {25 2.0 50 5.0 75 8.0 90 9.0 95 9.5 99 9.9}
+                        :quartiles   {:q1 2.0 :median 5.0 :q3 8.0 :iqr 6.0}}}})
+
+(deftest make-chart-result-basic-test
+  (testing "builds standard chart result with valid schema"
+    (let [result (stats.u/make-chart-result :categorical {"s1" {}} sample-categorical-series nil)]
+      (is (= :categorical (:chart_type result)))
+      (is (= 1 (:series_count result)))
+      (is (= sample-categorical-series (:series result)))
+      (is (not (contains? result :correlations))))))
+
+(deftest make-chart-result-with-correlations-test
+  (testing "includes correlations when provided"
+    (let [corrs [{:series_a "a" :series_b "b" :coefficient 0.9
+                  :strength :strong :direction :positive}]
+          series {"a" {:summary        sample-summary
+                       :category_count 2
+                       :top_categories []
+                       :outliers       []}
+                  "b" {:summary        sample-summary
+                       :category_count 2
+                       :top_categories []
+                       :outliers       []}}
+          result (stats.u/make-chart-result :categorical {"a" {} "b" {}} series corrs)]
+      (is (= corrs (:correlations result))))))
+
+(deftest make-chart-result-nil-correlations-test
+  (testing "omits correlations when nil"
+    (let [result (stats.u/make-chart-result :histogram {"s1" {}} sample-histogram-series nil)]
+      (is (not (contains? result :correlations))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/util_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/util_test.clj
@@ -232,10 +232,20 @@
          :outliers       []}})
 
 (def ^:private sample-histogram-series
-  {"s1" {:summary      sample-summary
-         :data_points  10
-         :distribution {:percentiles {25 2.0 50 5.0 75 8.0 90 9.0 95 9.5 99 9.9}
-                        :quartiles   {:q1 2.0 :median 5.0 :q3 8.0 :iqr 6.0}}}})
+  {"s1" {:estimated_summary {:weighted_mean    5.0
+                             :weighted_std_dev 2.0
+                             :data_range       9.0}
+         :total_count       50
+         :data_points       10
+         :bin_data          [[1.0 5.0] [2.0 10.0]]
+         :distribution      {:estimated_percentiles {25 2.0 50 5.0 75 8.0 90 9.0 95 9.5 99 9.9}
+                             :estimated_quartiles   {:q1 2.0 :median 5.0 :q3 8.0 :iqr 6.0}}
+         :structure         {:mode_bin           [2.0 10.0]
+                             :peak_count         1
+                             :concentration_top3 1.0
+                             :gap_count          0
+                             :empty_bin_ratio    0.0
+                             :bin_count          2}}})
 
 (deftest ^:parallel make-chart-result-basic-test
   (testing "builds standard chart result with valid schema"

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/util_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/util_test.clj
@@ -226,6 +226,7 @@
 
 (def ^:private sample-categorical-series
   {"s1" {:summary        sample-summary
+         :data_points    5
          :category_count 3
          :top_categories [{:name "A" :value 10.0 :percentage 50.0}]
          :outliers       []}})
@@ -249,10 +250,12 @@
     (let [corrs [{:series_a "a" :series_b "b" :coefficient 0.9
                   :strength :strong :direction :positive}]
           series {"a" {:summary        sample-summary
+                       :data_points    2
                        :category_count 2
                        :top_categories []
                        :outliers       []}
                   "b" {:summary        sample-summary
+                       :data_points    2
                        :category_count 2
                        :top_categories []
                        :outliers       []}}

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/util_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/util_test.clj
@@ -1,6 +1,7 @@
 (ns metabase-enterprise.metabot-v3.stats.util-test
   (:require
    [clojure.test :refer :all]
+   [mb.hawk.assert-exprs.approximately-equal :as =?]
    [metabase-enterprise.metabot-v3.stats.util :as stats.u]))
 
 (set! *warn-on-reflection* true)
@@ -14,7 +15,7 @@
              :mean 30.0
              :median 30.0
              :range 40.0
-             :std_dev pos?}
+             :std_dev (=?/approx [15.81 0.01])}
             (stats.u/compute-summary [10.0 20.0 30.0 40.0 50.0])))))
 
 (deftest ^:parallel compute-summary-single-value-test

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/util_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/util_test.clj
@@ -9,21 +9,21 @@
 
 (deftest compute-summary-basic-test
   (testing "computes correct summary statistics"
-    (let [result (stats.u/compute-summary [10.0 20.0 30.0 40.0 50.0])]
-      (is (= 10.0 (:min result)))
-      (is (= 50.0 (:max result)))
-      (is (= 30.0 (:mean result)))
-      (is (= 30.0 (:median result)))
-      (is (= 40.0 (:range result)))
-      (is (pos? (:std_dev result))))))
+    (is (=? {:min 10.0
+             :max 50.0
+             :mean 30.0
+             :median 30.0
+             :range 40.0
+             :std_dev pos?}
+            (stats.u/compute-summary [10.0 20.0 30.0 40.0 50.0])))))
 
 (deftest compute-summary-single-value-test
   (testing "single value has zero range"
-    (let [result (stats.u/compute-summary [42.0])]
-      (is (= 42.0 (:min result)))
-      (is (= 42.0 (:max result)))
-      (is (= 42.0 (:mean result)))
-      (is (= 0.0 (:range result))))))
+    (is (=? {:min 42.0
+             :max 42.0
+             :mean 42.0
+             :range 0.0}
+            (stats.u/compute-summary [42.0])))))
 
 ;;; ------------------------------------------ compute-correlations ------------------------------------------------
 
@@ -41,9 +41,10 @@
                   {"a" (make-series xs xs)
                    "b" (make-series xs (mapv #(+ 10.0 (* 2.0 %)) xs))})]
       (is (= 1 (count result)))
-      (is (> (:coefficient (first result)) 0.99))
-      (is (= :strong (:strength (first result))))
-      (is (= :positive (:direction (first result)))))))
+      (is (=? [{:coefficient #(> % 0.99)
+                :strength    :strong
+                :direction   :positive}]
+              result)))))
 
 (deftest compute-correlations-perfect-negative-test
   (testing "inversely correlated series yield coefficient ~-1.0"
@@ -52,32 +53,30 @@
                   {"a" (make-series xs xs)
                    "b" (make-series xs (mapv #(- 100.0 %) xs))})]
       (is (= 1 (count result)))
-      (is (< (:coefficient (first result)) -0.99))
-      (is (= :strong (:strength (first result))))
-      (is (= :negative (:direction (first result)))))))
+      (is (=? [{:coefficient #(< % -0.99)
+                :strength    :strong
+                :direction   :negative}]
+              result)))))
 
 (deftest compute-correlations-skipped-when-too-few-aligned-points-test
   (testing "pairs with fewer than 10 aligned points are skipped"
-    (let [result (stats.u/compute-correlations
-                  {"a" (make-series (range 5) (range 5))
-                   "b" (make-series (range 5) (range 5 10))})]
-      (is (empty? result)))))
+    (is (empty? (stats.u/compute-correlations
+                 {"a" (make-series (range 5) (range 5))
+                  "b" (make-series (range 5) (range 5 10))})))))
 
 (deftest compute-correlations-no-overlap-test
   (testing "series with no common x-values produce no correlations"
-    (let [result (stats.u/compute-correlations
-                  {"a" (make-series (range 0 20) (range 0 20))
-                   "b" (make-series (range 100 120) (range 100 120))})]
-      (is (empty? result)))))
+    (is (empty? (stats.u/compute-correlations
+                 {"a" (make-series (range 0 20) (range 0 20))
+                  "b" (make-series (range 100 120) (range 100 120))})))))
 
 (deftest compute-correlations-three-series-test
   (testing "three series produce up to C(3,2) = 3 correlation pairs"
-    (let [xs     (mapv double (range 20))
-          result (stats.u/compute-correlations
-                  {"a" (make-series xs xs)
-                   "b" (make-series xs (mapv #(* 2.0 %) xs))
-                   "c" (make-series xs (mapv #(* 3.0 %) xs))})]
-      (is (= 3 (count result))))))
+    (let [xs (mapv double (range 20))]
+      (is (= 3 (count (stats.u/compute-correlations
+                       {"a" (make-series xs xs)
+                        "b" (make-series xs (mapv #(* 2.0 %) xs))
+                        "c" (make-series xs (mapv #(* 3.0 %) xs))})))))))
 
 ;;; --------------------------------------- maybe-compute-correlations ---------------------------------------------
 
@@ -98,12 +97,11 @@
 
 (deftest maybe-compute-correlations-computes-when-deep-test
   (testing "computes correlations when deep? is true and multiple series"
-    (let [xs     (mapv double (range 20))
-          result (stats.u/maybe-compute-correlations
-                  {"a" (make-series xs xs)
-                   "b" (make-series xs (mapv #(* 2.0 %) xs))}
-                  {:deep? true})]
-      (is (= 1 (count result))))))
+    (let [xs (mapv double (range 20))]
+      (is (= 1 (count (stats.u/maybe-compute-correlations
+                       {"a" (make-series xs xs)
+                        "b" (make-series xs (mapv #(* 2.0 %) xs))}
+                       {:deep? true})))))))
 
 (deftest maybe-compute-correlations-respects-max-cap-test
   (testing "caps number of series used for correlation"
@@ -159,10 +157,11 @@
                   series-data
                   (fn [xs ys] {:sum (reduce + ys) :count (count xs)}))]
       (is (= 1 (count result)))
-      (is (= 60 (get-in result ["s1" :sum])))
-      (is (= 3 (get-in result ["s1" :count])))
-      (is (= "Date" (get-in result ["s1" :x_name])))
-      (is (= "Revenue" (get-in result ["s1" :y_name]))))))
+      (is (=? {"s1" {:sum 60
+                     :count 3
+                     :x_name "Date"
+                     :y_name "Revenue"}}
+              result)))))
 
 (deftest compute-series-with-labels-nil-metadata-test
   (testing "handles nil column metadata gracefully"
@@ -170,23 +169,36 @@
           result (stats.u/compute-series-with-labels
                   series-data
                   (fn [_ _] {:ok true}))]
-      (is (nil? (get-in result ["s1" :x_name])))
-      (is (nil? (get-in result ["s1" :y_name]))))))
+      (is (=? {"s1" {:x_name nil?
+                     :y_name nil?}}
+              result)))))
 
 (deftest compute-series-with-labels-multiple-series-test
   (testing "processes multiple series"
-    (let [series-data {"a" {:x_values [1] :y_values [10] :x {:name "X"} :y {:name "Y"}}
-                       "b" {:x_values [2] :y_values [20] :x {:name "X"} :y {:name "Y"}}}
+    (let [series-data {"a" {:x_values [1]
+                            :y_values [10]
+                            :x {:name "X"}
+                            :y {:name "Y"}}
+                       "b" {:x_values [2]
+                            :y_values [20]
+                            :x {:name "X"}
+                            :y {:name "Y"}}}
           result (stats.u/compute-series-with-labels
                   series-data
                   (fn [_ ys] {:val (first ys)}))]
-      (is (= 10 (get-in result ["a" :val])))
-      (is (= 20 (get-in result ["b" :val]))))))
+      (is (=? {"a" {:val 10}
+               "b" {:val 20}}
+              result)))))
 
 ;;; ------------------------------------------- make-chart-result ----------------------------------------------------
 
 (def ^:private sample-summary
-  {:min 1.0 :max 10.0 :mean 5.0 :median 5.0 :std_dev 2.0 :range 9.0})
+  {:min     1.0
+   :max     10.0
+   :mean    5.0
+   :median  5.0
+   :std_dev 2.0
+   :range   9.0})
 
 (def ^:private sample-categorical-series
   {"s1" {:summary        sample-summary
@@ -202,11 +214,11 @@
 
 (deftest make-chart-result-basic-test
   (testing "builds standard chart result with valid schema"
-    (let [result (stats.u/make-chart-result :categorical {"s1" {}} sample-categorical-series nil)]
-      (is (= :categorical (:chart_type result)))
-      (is (= 1 (:series_count result)))
-      (is (= sample-categorical-series (:series result)))
-      (is (not (contains? result :correlations))))))
+    (is (=? {:chart_type    :categorical
+             :series_count  1
+             :series        sample-categorical-series
+             :correlations  (symbol "nil #_\"key is not present.\"")}
+            (stats.u/make-chart-result :categorical {"s1" {}} sample-categorical-series nil)))))
 
 (deftest make-chart-result-with-correlations-test
   (testing "includes correlations when provided"
@@ -225,5 +237,5 @@
 
 (deftest make-chart-result-nil-correlations-test
   (testing "omits correlations when nil"
-    (let [result (stats.u/make-chart-result :histogram {"s1" {}} sample-histogram-series nil)]
-      (is (not (contains? result :correlations))))))
+    (is (=? {:correlations (symbol "nil #_\"key is not present.\"")}
+            (stats.u/make-chart-result :histogram {"s1" {}} sample-histogram-series nil)))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/util_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/util_test.clj
@@ -25,15 +25,14 @@
       (is (= 42.0 (:mean result)))
       (is (= 0.0 (:range result))))))
 
-(deftest compute-summary-median-test
-  (testing "median for odd-count data"
-    (let [result (stats.u/compute-summary [1.0 2.0 3.0 4.0 5.0])]
-      (is (= 3.0 (:median result))))))
-
 ;;; ------------------------------------------ compute-correlations ------------------------------------------------
 
 (defn- make-series [x-vals y-vals]
-  {:x_values x-vals :y_values y-vals})
+  {:x_values     x-vals
+   :y_values     y-vals
+   :x            {:name "x" :type :number}
+   :y            {:name "y" :type :number}
+   :display_name "test"})
 
 (deftest compute-correlations-perfect-positive-test
   (testing "perfectly correlated series yield coefficient ~1.0"
@@ -145,9 +144,7 @@
 
 (deftest percentage-change-negative-from-test
   (testing "handles negative from-val correctly"
-    ;; from -50 to 50: change=100, abs(from)=50 → 200%
     (is (= 200.0 (stats.u/percentage-change -50.0 50.0)))
-    ;; from -50 to -100: change=-50, abs(from)=50 → -100%
     (is (= -100.0 (stats.u/percentage-change -50.0 -100.0)))))
 
 ;;; ---------------------------------------- compute-series-with-labels ----------------------------------------------

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/util_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/util_test.clj
@@ -43,8 +43,8 @@
 (defn- make-series [x-vals y-vals]
   {:x_values     x-vals
    :y_values     y-vals
-   :x            {:name "x" :type :number}
-   :y            {:name "y" :type :number}
+   :x            {:name "x" :type "number"}
+   :y            {:name "y" :type "number"}
    :display_name "test"})
 
 (deftest ^:parallel compute-correlations-perfect-positive-test

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/util_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/util_test.clj
@@ -127,6 +127,17 @@
       (is (= 10 (count uncapped)))
       (is (= 3 (count capped))))))
 
+;;; ----------------------------------------- correlation-direction --------------------------------------------------
+
+(deftest ^:parallel correlation-direction-test
+  (testing "classifies correlation direction correctly"
+    (is (= :positive (stats.u/correlation-direction 0.5)))
+    (is (= :positive (stats.u/correlation-direction 0.01)))
+    (is (= :negative (stats.u/correlation-direction -0.5)))
+    (is (= :negative (stats.u/correlation-direction -0.01)))
+    (is (= :none (stats.u/correlation-direction 0.0)))
+    (is (= :none (stats.u/correlation-direction 0)))))
+
 ;;; ------------------------------------------ correlation-strength --------------------------------------------------
 
 (deftest ^:parallel correlation-strength-test

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/util_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/util_test.clj
@@ -7,7 +7,7 @@
 
 ;;; -------------------------------------------- compute-summary ---------------------------------------------------
 
-(deftest compute-summary-basic-test
+(deftest ^:parallel compute-summary-basic-test
   (testing "computes correct summary statistics"
     (is (=? {:min 10.0
              :max 50.0
@@ -17,7 +17,7 @@
              :std_dev pos?}
             (stats.u/compute-summary [10.0 20.0 30.0 40.0 50.0])))))
 
-(deftest compute-summary-single-value-test
+(deftest ^:parallel compute-summary-single-value-test
   (testing "single value has zero range"
     (is (=? {:min 42.0
              :max 42.0
@@ -34,7 +34,7 @@
    :y            {:name "y" :type :number}
    :display_name "test"})
 
-(deftest compute-correlations-perfect-positive-test
+(deftest ^:parallel compute-correlations-perfect-positive-test
   (testing "perfectly correlated series yield coefficient ~1.0"
     (let [xs     (mapv double (range 20))
           result (stats.u/compute-correlations
@@ -46,7 +46,7 @@
                 :direction   :positive}]
               result)))))
 
-(deftest compute-correlations-perfect-negative-test
+(deftest ^:parallel compute-correlations-perfect-negative-test
   (testing "inversely correlated series yield coefficient ~-1.0"
     (let [xs     (mapv double (range 20))
           result (stats.u/compute-correlations
@@ -58,19 +58,19 @@
                 :direction   :negative}]
               result)))))
 
-(deftest compute-correlations-skipped-when-too-few-aligned-points-test
+(deftest ^:parallel compute-correlations-skipped-when-too-few-aligned-points-test
   (testing "pairs with fewer than 10 aligned points are skipped"
     (is (empty? (stats.u/compute-correlations
                  {"a" (make-series (range 5) (range 5))
                   "b" (make-series (range 5) (range 5 10))})))))
 
-(deftest compute-correlations-no-overlap-test
+(deftest ^:parallel compute-correlations-no-overlap-test
   (testing "series with no common x-values produce no correlations"
     (is (empty? (stats.u/compute-correlations
                  {"a" (make-series (range 0 20) (range 0 20))
                   "b" (make-series (range 100 120) (range 100 120))})))))
 
-(deftest compute-correlations-three-series-test
+(deftest ^:parallel compute-correlations-three-series-test
   (testing "three series produce up to C(3,2) = 3 correlation pairs"
     (let [xs (mapv double (range 20))]
       (is (= 3 (count (stats.u/compute-correlations
@@ -80,7 +80,7 @@
 
 ;;; --------------------------------------- maybe-compute-correlations ---------------------------------------------
 
-(deftest maybe-compute-correlations-nil-when-not-deep-test
+(deftest ^:parallel maybe-compute-correlations-nil-when-not-deep-test
   (testing "returns nil when deep? is false"
     (let [xs (mapv double (range 20))]
       (is (nil? (stats.u/maybe-compute-correlations
@@ -88,14 +88,14 @@
                   "b" (make-series xs xs)}
                  {:deep? false}))))))
 
-(deftest maybe-compute-correlations-nil-for-single-series-test
+(deftest ^:parallel maybe-compute-correlations-nil-for-single-series-test
   (testing "returns nil when only one series"
     (let [xs (mapv double (range 20))]
       (is (nil? (stats.u/maybe-compute-correlations
                  {"a" (make-series xs xs)}
                  {:deep? true}))))))
 
-(deftest maybe-compute-correlations-computes-when-deep-test
+(deftest ^:parallel maybe-compute-correlations-computes-when-deep-test
   (testing "computes correlations when deep? is true and multiple series"
     (let [xs (mapv double (range 20))]
       (is (= 1 (count (stats.u/maybe-compute-correlations
@@ -103,7 +103,7 @@
                         "b" (make-series xs (mapv #(* 2.0 %) xs))}
                        {:deep? true})))))))
 
-(deftest maybe-compute-correlations-respects-max-cap-test
+(deftest ^:parallel maybe-compute-correlations-respects-max-cap-test
   (testing "caps number of series used for correlation"
     (let [xs         (mapv double (range 20))
           series-map (into {} (for [i (range 5)]
@@ -116,7 +116,7 @@
 
 ;;; ------------------------------------------ correlation-strength --------------------------------------------------
 
-(deftest correlation-strength-test
+(deftest ^:parallel correlation-strength-test
   (testing "classifies correlation coefficients correctly"
     (is (= :strong (stats.u/correlation-strength 0.9)))
     (is (= :strong (stats.u/correlation-strength -0.7)))
@@ -129,25 +129,25 @@
 
 ;;; ------------------------------------------- percentage-change ----------------------------------------------------
 
-(deftest percentage-change-basic-test
+(deftest ^:parallel percentage-change-basic-test
   (testing "computes correct percentage change"
     (is (= 100.0 (stats.u/percentage-change 50.0 100.0)))
     (is (= -50.0 (stats.u/percentage-change 100.0 50.0)))
     (is (= 0.0 (stats.u/percentage-change 100.0 100.0)))))
 
-(deftest percentage-change-zero-from-test
+(deftest ^:parallel percentage-change-zero-from-test
   (testing "returns 0.0 when from-val is zero"
     (is (= 0.0 (stats.u/percentage-change 0.0 100.0)))
     (is (= 0.0 (stats.u/percentage-change 0 0)))))
 
-(deftest percentage-change-negative-from-test
+(deftest ^:parallel percentage-change-negative-from-test
   (testing "handles negative from-val correctly"
     (is (= 200.0 (stats.u/percentage-change -50.0 50.0)))
     (is (= -100.0 (stats.u/percentage-change -50.0 -100.0)))))
 
 ;;; ---------------------------------------- compute-series-with-labels ----------------------------------------------
 
-(deftest compute-series-with-labels-test
+(deftest ^:parallel compute-series-with-labels-test
   (testing "applies compute-fn and attaches column names"
     (let [series-data {"s1" {:x_values [1 2 3]
                              :y_values [10 20 30]
@@ -163,7 +163,7 @@
                      :y_name "Revenue"}}
               result)))))
 
-(deftest compute-series-with-labels-nil-metadata-test
+(deftest ^:parallel compute-series-with-labels-nil-metadata-test
   (testing "handles nil column metadata gracefully"
     (let [series-data {"s1" {:x_values [1] :y_values [10]}}
           result (stats.u/compute-series-with-labels
@@ -173,7 +173,7 @@
                      :y_name nil?}}
               result)))))
 
-(deftest compute-series-with-labels-multiple-series-test
+(deftest ^:parallel compute-series-with-labels-multiple-series-test
   (testing "processes multiple series"
     (let [series-data {"a" {:x_values [1]
                             :y_values [10]
@@ -212,7 +212,7 @@
          :distribution {:percentiles {25 2.0 50 5.0 75 8.0 90 9.0 95 9.5 99 9.9}
                         :quartiles   {:q1 2.0 :median 5.0 :q3 8.0 :iqr 6.0}}}})
 
-(deftest make-chart-result-basic-test
+(deftest ^:parallel make-chart-result-basic-test
   (testing "builds standard chart result with valid schema"
     (is (=? {:chart_type    :categorical
              :series_count  1
@@ -220,7 +220,7 @@
              :correlations  (symbol "nil #_\"key is not present.\"")}
             (stats.u/make-chart-result :categorical {"s1" {}} sample-categorical-series nil)))))
 
-(deftest make-chart-result-with-correlations-test
+(deftest ^:parallel make-chart-result-with-correlations-test
   (testing "includes correlations when provided"
     (let [corrs [{:series_a "a" :series_b "b" :coefficient 0.9
                   :strength :strong :direction :positive}]
@@ -235,7 +235,7 @@
           result (stats.u/make-chart-result :categorical {"a" {} "b" {}} series corrs)]
       (is (= corrs (:correlations result))))))
 
-(deftest make-chart-result-nil-correlations-test
+(deftest ^:parallel make-chart-result-nil-correlations-test
   (testing "omits correlations when nil"
     (is (=? {:correlations (symbol "nil #_\"key is not present.\"")}
             (stats.u/make-chart-result :histogram {"s1" {}} sample-histogram-series nil)))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/util_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/util_test.clj
@@ -6,6 +6,18 @@
 
 (set! *warn-on-reflection* true)
 
+;;; ------------------------------------------------ nan->nil -------------------------------------------------------
+
+(deftest ^:parallel nan->nil-test
+  (testing "NaN becomes nil"
+    (is (nil? (stats.u/nan->nil Double/NaN))))
+  (testing "normal numbers pass through"
+    (is (= 42.0 (stats.u/nan->nil 42.0)))
+    (is (= 0.0 (stats.u/nan->nil 0.0)))
+    (is (= -1.5 (stats.u/nan->nil -1.5))))
+  (testing "infinity passes through (not NaN)"
+    (is (= Double/POSITIVE_INFINITY (stats.u/nan->nil Double/POSITIVE_INFINITY)))))
+
 ;;; -------------------------------------------- compute-summary ---------------------------------------------------
 
 (deftest ^:parallel compute-summary-basic-test

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/util_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/util_test.clj
@@ -37,7 +37,7 @@
 (deftest ^:parallel compute-correlations-perfect-positive-test
   (testing "perfectly correlated series yield coefficient ~1.0"
     (let [xs     (mapv double (range 20))
-          result (stats.u/compute-correlations
+          result (#'stats.u/compute-correlations
                   {"a" (make-series xs xs)
                    "b" (make-series xs (mapv #(+ 10.0 (* 2.0 %)) xs))})]
       (is (= 1 (count result)))
@@ -49,7 +49,7 @@
 (deftest ^:parallel compute-correlations-perfect-negative-test
   (testing "inversely correlated series yield coefficient ~-1.0"
     (let [xs     (mapv double (range 20))
-          result (stats.u/compute-correlations
+          result (#'stats.u/compute-correlations
                   {"a" (make-series xs xs)
                    "b" (make-series xs (mapv #(- 100.0 %) xs))})]
       (is (= 1 (count result)))
@@ -60,20 +60,20 @@
 
 (deftest ^:parallel compute-correlations-skipped-when-too-few-aligned-points-test
   (testing "pairs with fewer than 10 aligned points are skipped"
-    (is (empty? (stats.u/compute-correlations
+    (is (empty? (#'stats.u/compute-correlations
                  {"a" (make-series (range 5) (range 5))
                   "b" (make-series (range 5) (range 5 10))})))))
 
 (deftest ^:parallel compute-correlations-no-overlap-test
   (testing "series with no common x-values produce no correlations"
-    (is (empty? (stats.u/compute-correlations
+    (is (empty? (#'stats.u/compute-correlations
                  {"a" (make-series (range 0 20) (range 0 20))
                   "b" (make-series (range 100 120) (range 100 120))})))))
 
 (deftest ^:parallel compute-correlations-three-series-test
   (testing "three series produce up to C(3,2) = 3 correlation pairs"
     (let [xs (mapv double (range 20))]
-      (is (= 3 (count (stats.u/compute-correlations
+      (is (= 3 (count (#'stats.u/compute-correlations
                        {"a" (make-series xs xs)
                         "b" (make-series xs (mapv #(* 2.0 %) xs))
                         "c" (make-series xs (mapv #(* 3.0 %) xs))})))))))


### PR DESCRIPTION
Closes [BOT-1058: Analyze Chart - Add support for non timeseries charts](https://linear.app/metabase/issue/BOT-1058/analyze-chart-add-support-for-non-timeseries-charts)

Extends [[BOT-1056] Metabot Analyze Chart in CLJ Port by tsplude · Pull Request #70177 · metabase/metabase](https://github.com/metabase/metabase/pull/70177)

### Description

Analyze chart support for non-timeseries chart types: histogram, scatter, and categorical.

Ported from corresponding Python ai-service PR [Bot 836 improve chart analysis by Somtom · Pull Request #600 · metabase/ai-service](https://github.com/metabase/ai-service/pull/600)

### Example output
<details>
<summary>Histogram: stats</summary>

```markdown
# Chart Analysis
## Chart: Age Distribution
**Type**: Histogram (bar)
**Series Count**: 1

## Series: Age Distribution
**X-axis**: age
**Y-axis**: count
**Bins**: 8
**Note**: limited data points.
**X-axis Range**: 15.00 to 67.50
**Estimated Distribution** (from 8 bins, 1000 total observations): mean≈34.61, std_dev≈11.29, range=52.50
**Estimated Percentiles**: P25≈22.86, P50≈30.38, P75≈39.14, P90≈45.30
**Estimated IQR**: 16.28 (Q1≈22.86 to Q3≈39.14)
**Distribution Shape**: approximately symmetric
**Structure**: mode bin at 30.00 (count=251.0), top 3 bins contain 66% of data
**Sample Data** (8 samples):
15.00: 86.00 | 22.50: 152.0 | 30.00: 251.0 | 37.50: 220.0 | 45.00: 188.0 | 52.50: 75.00 | 60.00: 22.00 | 67.50: 6.00
```
</details>

<details>
<summary>Histogram: agent response</summary>
I'd be happy to analyze the chart for you! Let me pull up the details of the Age Distribution report you're currently viewing.Here's what your Age Distribution chart shows:

**Your customer base skews younger, with ages concentrated in the 20s-40s range.** The distribution is fairly symmetric around an average age of **~35 years**, with about half your customers falling between ages **23-39**. The youngest customers are **15** and the oldest around **68**, but the real action is in the middle — the **30-year-old bin alone contains 251 observations**, representing the peak of your distribution.

The good news: this is a well-shaped, predictable distribution with no obvious outliers or gaps. If you're selling products or services, this age range typically indicates strong purchasing power. 

**Next steps:** Would you like to see how this age distribution breaks down by other dimensions — like by region, product category, or customer segment? That could reveal if certain groups skew younger or older.
</details>

<details>
<summary>Scatter: stats</summary>

```markdown
# Chart Analysis
## Chart: Acquisition Cost vs Lifetime Value
**Type**: Scatter (scatter)
**Series Count**: 1

## Series: Acquisition Cost vs Lifetime Value
**Data Points**: 1000
**X-axis**: acquisition_cost
**Y-axis**: lifetime_value
**X-axis Range**: 5.00 to 111.7
**Y-axis Range**: 10.00 to 2148.4
**Relationship**: none negative (r = -0.06)
**Trend Line**: y = -1.055x + 792.277
**Sample Data** (30 points):
40.73: 920.7 | 32.01: 831.7 | 98.57: 997.0 | 64.27: 490.4 | 41.37: 663.9 | 46.15: 739.6 | 13.48: 494.0 | 30.95: 957.5 | 43.62: 277.7 | 37.80: 834.7 | 74.08: 317.4 | 27.08: 1379.9 | 59.03: 869.9 | 64.91: 848.4 | 71.39: 491.8 | 33.07: 578.8 | 21.96: 590.3 | 44.01: 465.5 | 24.53: 673.0 | 13.21: 696.1 | 54.00: 397.6 | 56.61: 895.4 | 63.04: 877.7 | 24.57: 221.4 | 63.84: 486.9 | 5.00: 1269.4 | 56.02: 271.2 | 21.91: 1288.9 | 92.60: 963.9 | 52.95: 495.1
**Outliers** (6 total, showing up to 5):
- x=32.05, y=1864.8
- x=31.49, y=2148.4
- x=13.51, y=1927.5
- x=30.58, y=2101.7
- x=69.72, y=b1774.1
... and 1 more
```
</details>

<details>
<summary>Scatter: agent response</summary>
I'll analyze the chart you're currently viewing.Here's what I'm seeing in your [Acquisition Cost vs Lifetime Value](/question/121) chart:

**The relationship between acquisition cost and lifetime value is essentially random.** With a correlation of **-0.06** and 1,000 data points scattered across the chart, there's virtually no predictable pattern — what you spend to acquire a customer has almost no bearing on how much value they generate long-term.

The slight negative trend (the trend line slopes down very gently) is so weak it's statistically meaningless. What's more interesting: there are **6 notable outliers** — a handful of customers who generated exceptionally high lifetime value ($1,700–$2,100+) regardless of their acquisition cost. These suggest that factors *other than* acquisition spend drive customer value (product quality, retention strategy, upselling, etc.).

**What this means**: You're not overpaying to acquire high-value customers, but you're also not finding a cost-efficiency pattern. The focus should shift to identifying *what actually determines* long-term value — and potentially replicating those factors rather than tweaking acquisition spend.

Want to dig deeper? I can help you break this down by customer segment, acquisition channel, or cohort to see if patterns emerge in subsets of the data.
</details>

<details>
<summary>Categorical: stats</summary>

```markdown
# Chart Analysis
## Chart: Revenue and Order Count by Category
**Type**: Categorical (bar)
**Series Count**: 2

## Series: Revenue and Order Count by Category (sum)
**X-axis**: category
**Y-axis**: sum
**Data Points**: 5
**Categories**: 5
**Note**: high variance (fluctuations may be normal noise), limited data points.
**Value Range**: 79,927 to 798,309 (median: 210,377)
**Top Categories**:
  - Electronics: 798,309 (52.5%)
  - Sports: 317,301 (20.9%)
  - Clothing: 210,377 (13.8%)
  - Food: 115,535 (7.6%)
  - Books: 79,927 (5.3%)
**Outliers**: 1 detected
  - Electronics: 798,309 (z-score: 3.71)

## Series: Revenue and Order Count by Category (count)
**X-axis**: category
**Y-axis**: count
**Data Points**: 5
**Categories**: 5
**Note**: limited data points.
**Value Range**: 1597.0 to 1672.0 (median: 1643.0)
**Top Categories**:
  - Books: 1672.0 (20.4%)
  - Food: 1656.0 (20.2%)
  - Clothing: 1643.0 (20.1%)
  - Electronics: 1614.0 (19.7%)
  - Sports: 1597.0 (19.5%)
**Outliers**: None detected
```
</details>

<details>
<summary>Categorical: agent response</summary>
I'll analyze the chart you're currently viewing.Here's what stands out in your Revenue and Order Count by Category chart:

**Electronics dominates revenue with a significant 10x gap to Books.** Electronics generates **$798K** (52.5% of total) while simultaneously maintaining average order volume — this suggests higher-value transactions in that category. Meanwhile, order counts are nearly balanced across all categories (**1,597–1,672 orders**), indicating that revenue differences stem from product pricing or order value, not volume.

The one notable outlier is Electronics' revenue spike, which is unusually high compared to other categories. If you're trying to understand what drives revenue, focus on why Electronics generates so much more per order than other categories — investigate pricing, customer segment, or product mix differences.

Want to dig into what's driving the Electronics revenue, or compare this against a different time period?
</details>

<details>
<summary>Time series: stats</summary>

```markdown
# Chart Analysis
## Chart: Monthly Revenue and Order Count
**Type**: Time Series (line)
**Series Count**: 2

Today is Sunday, March 15, 2026
- Current week: Week 11 of 2026
- Current month: March (day 15)
- Current quarter: Q1 2026
Take this into account when analyzing recent data points.
If the latest data point falls within the current week, month, or quarter, it may represent an incomplete period and should be interpreted accordingly.

## Series: Monthly Revenue and Order Count (sum)
**Data Points**: 24 (2023-01-01T00:00:00Z to 2024-12-01T00:00:00Z)
**Value Range**: 48,530 to 83,363 (median: 63,364)
**Mean**: 63,394 | **Std Dev**: 10,400
**Trend**: increasing (+14.1% overall, from 73,066 to 83,363)
**Volatility**: moderate (CV: 0.16, max period change: +31.8%)
**Outliers**: None detected
**Patterns**:
  - consecutive_decrease over 5 periods (2023-04-01T00:00:00Z to 2023-08-01T00:00:00Z)
  - consecutive_increase over 5 periods (2023-09-01T00:00:00Z to 2024-01-01T00:00:00Z)
  - consecutive_decrease over 6 periods (2024-02-01T00:00:00Z to 2024-07-01T00:00:00Z)
**Significant Changes**:
  - 2024-09-01T00:00:00Z → 2024-10-01T00:00:00Z: 57,474 → 75,730 (+31.8%)
  - 2023-01-01T00:00:00Z → 2023-02-01T00:00:00Z: 73,066 → 55,634 (-23.9%)
  - 2023-12-01T00:00:00Z → 2024-01-01T00:00:00Z: 65,626 → 83,051 (+26.6%)
**Most Recent Change**: 2024-11-01T00:00:00Z → 2024-12-01T00:00:00Z: 71,499 → 83,363 (+16.6%)

## Series: Monthly Revenue and Order Count (count)
**Data Points**: 24 (2023-01-01T00:00:00Z to 2024-12-01T00:00:00Z)
**Value Range**: 300.0 to 387.0 (median: 342.0)
**Mean**: 340.9 | **Std Dev**: 20.96
**Trend**: flat (+7.2% overall, from 361.0 to 387.0)
**Volatility**: low (CV: 0.06, max period change: +24.3%)
**Outliers**: None detected
**Significant Changes**:
  - 2024-09-01T00:00:00Z → 2024-10-01T00:00:00Z: 300.0 → 373.0 (+24.3%)
  - 2023-02-01T00:00:00Z → 2023-03-01T00:00:00Z: 307.0 → 362.0 (+17.9%)
  - 2023-01-01T00:00:00Z → 2023-02-01T00:00:00Z: 361.0 → 307.0 (-15.0%)
**Most Recent Change**: 2024-11-01T00:00:00Z → 2024-12-01T00:00:00Z: 344.0 → 387.0 (+12.5%)

## Cross-Series Correlations
- Monthly Revenue and Order Count (count) vs Monthly Revenue and Order Count (sum): moderate positive (r=0.433)

```
</details>

<details>
<summary>Time series: agent response</summary>

I'll analyze the chart you're currently viewing.Here's what your data is telling you:

**Revenue is climbing strongly, but order growth has stalled.** Monthly revenue increased **16.6%** from November to December 2024 (reaching $83,363), while order count only grew **12.5%** to 387 orders. This suggests you're making more money per order — likely through higher-value purchases, upsells, or pricing changes — but not necessarily getting significantly more customers or transactions. 

The most dramatic shift happened in September-October 2024, when revenue jumped **31.8%** while order count spiked **24.3%**, indicating a period where you gained both volume and value. However, the divergence between these metrics since then warrants investigation: are your higher-value orders sustainable, or were there one-time factors (seasonal demand, promotions) driving that September spike?
</details>

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
