### PR TITLE
Fixed extraneous item in filter popover in embeds

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-dashboard.cy.spec.js
@@ -12,7 +12,7 @@ import {
   questionDetailsWithDefaults,
 } from "./shared/embedding-dashboard";
 
-const { ORDERS, PEOPLE, PRODUCTS, ORDERS_ID } = SAMPLE_DATABASE;
+const { ORDERS, PEOPLE, PEOPLE_ID, PRODUCTS, ORDERS_ID } = SAMPLE_DATABASE;
 
 describe("scenarios > embedding > static embedding dashboard", () => {
   beforeEach(() => {
@@ -1380,6 +1380,84 @@ describe("scenarios > embedding > dashboard appearance", () => {
             .should("be.visible")
             .should("have.css", "color", "rgba(255, 255, 255, 0.95)");
         });
+      });
+    });
+  });
+
+  it("should not show raw parameter value in static-list filter dropdown when using initial-parameters", () => {
+    const staticListFilter = {
+      name: "Number",
+      slug: "number",
+      id: "static-list-id",
+      type: "number/=",
+      sectionId: "number",
+      values_source_type: "static-list",
+      values_source_config: {
+        values: [
+          ["1", "Option A"],
+          ["2", "Option B"],
+        ],
+      },
+    };
+
+    H.createQuestionAndDashboard({
+      questionDetails: {
+        name: "Static list filter question",
+        query: {
+          "source-table": PEOPLE_ID,
+          expressions: { Thing: ["*", 1, 1] },
+        },
+      },
+      dashboardDetails: {
+        parameters: [staticListFilter],
+        enable_embedding: true,
+        embedding_params: {
+          [staticListFilter.slug]: "enabled",
+        },
+      },
+    }).then(({ body: { id, card_id, dashboard_id } }) => {
+      cy.request("PUT", `/api/dashboard/${dashboard_id}`, {
+        dashcards: [
+          {
+            id,
+            card_id,
+            row: 0,
+            col: 0,
+            size_x: 24,
+            size_y: 9,
+            parameter_mappings: [
+              {
+                parameter_id: staticListFilter.id,
+                card_id,
+                target: [
+                  "dimension",
+                  ["expression", "Thing", { "base-type": "type/Integer" }],
+                  { "stage-number": 0 },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+
+      H.visitEmbeddedPage(
+        {
+          resource: { dashboard: dashboard_id },
+          params: {},
+        },
+        {
+          setFilters: { [staticListFilter.slug]: "1" },
+        },
+      );
+
+      H.filterWidget().findByText("Option A").should("be.visible");
+
+      H.filterWidget().findByText("Option A").click();
+      H.popover().within(() => {
+        cy.findByText("Option A").should("exist");
+        cy.findByText("Option B").should("exist");
+        // The raw numeric value "1" should NOT appear as a separate option
+        cy.findByText("1").should("not.exist");
       });
     });
   });

--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/ListField/ListField.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/ListField/ListField.tsx
@@ -21,7 +21,11 @@ import {
   OptionsList,
 } from "./ListField.styled";
 import type { ListFieldProps, Option } from "./types";
-import { getOptionDisplayName, optionMatchesFilter } from "./utils";
+import {
+  getOptionDisplayName,
+  normalizeValuesToOptionKeys,
+  optionMatchesFilter,
+} from "./utils";
 
 const DEBOUNCE_FILTER_TIME = delay(100);
 
@@ -44,9 +48,15 @@ export const ListField = ({
   isDashboardFilter,
   isLoading,
 }: ListFieldProps) => {
-  const [selectedValues, setSelectedValues] = useState(new Set(value));
+  const normalizedValue = useMemo(
+    () => normalizeValuesToOptionKeys(value, options),
+    [value, options],
+  );
+  const [selectedValues, setSelectedValues] = useState(
+    new Set(normalizedValue),
+  );
   const [addedOptions, setAddedOptions] = useState<Option[]>(() =>
-    createOptionsFromValuesWithoutOptions(value, options),
+    createOptionsFromValuesWithoutOptions(normalizedValue, options),
   );
 
   const augmentedOptions = useMemo(() => {

--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/ListField/utils.ts
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/ListField/utils.ts
@@ -34,3 +34,22 @@ export const removeDiacritics = (value: string) =>
 
 export const getOptionDisplayName = (option: Option | RowValue[]) =>
   String(option.at(-1));
+
+/**
+ * Coerces selected values to match option key types via string comparison.
+ * This fixes a type mismatch where URL query params are normalized to numbers
+ * (e.g. `1`) but static-list option keys remain strings (e.g. `"1"`), causing
+ * `Map.has()` / `Set.has()` to miss the match and create synthetic options.
+ */
+export function normalizeValuesToOptionKeys(
+  values: RowValue[],
+  options: Option[],
+): RowValue[] {
+  const optionKeysByString = new Map(
+    options.map((option) => [String(option[0]), option[0]]),
+  );
+  return values.map((value) => {
+    const matchingKey = optionKeysByString.get(String(value));
+    return matchingKey !== undefined ? matchingKey : value;
+  });
+}

--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/SingleSelectListField/SingleSelectListField.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/SingleSelectListField/SingleSelectListField.tsx
@@ -13,7 +13,11 @@ import { PLUGIN_CONTENT_TRANSLATION } from "metabase/plugins";
 import { Flex } from "metabase/ui";
 import type { RowValue } from "metabase-types/api";
 
-import { getOptionDisplayName, optionMatchesFilter } from "../ListField/utils";
+import {
+  getOptionDisplayName,
+  normalizeValuesToOptionKeys,
+  optionMatchesFilter,
+} from "../ListField/utils";
 
 import {
   EmptyStateContainer,
@@ -48,9 +52,13 @@ const SingleSelectListField = ({
   isLoading,
   checkedColor,
 }: SingleSelectListFieldProps) => {
-  const [selectedValue, setSelectedValue] = useState(value?.[0]);
+  const normalizedValue = useMemo(
+    () => normalizeValuesToOptionKeys(value, options),
+    [value, options],
+  );
+  const [selectedValue, setSelectedValue] = useState(normalizedValue?.[0]);
   const [addedOptions, setAddedOptions] = useState<Option[]>(() =>
-    createOptionsFromValuesWithoutOptions(value, options),
+    createOptionsFromValuesWithoutOptions(normalizedValue, options),
   );
   const tc = useTranslateContent();
   const sortByTranslation =


### PR DESCRIPTION
Closes [EMB-1418: Using `initial-parameters` adds an extra item in filter dropdown](https://linear.app/metabase/issue/EMB-1418/using-initial-parameters-adds-an-extra-item-in-filter-dropdown)

### Description

URL query params are normalized to numbers (`1`) by normalizeNumberParameterValue, but static-list option keys remain strings (`"1"`). `Map.has()` / `Set.has()` use strict equality (`1 !== "1"`), so the selected value isn't found among the options and a synthetic option is created from the raw value.


Before:
<img width="1637" height="549" alt="image" src="https://github.com/user-attachments/assets/e932b2e6-d38d-4915-a90d-ce09179c78a7" />


After:
<img width="1638" height="548" alt="image" src="https://github.com/user-attachments/assets/70ec6c85-6c4b-429c-a744-7afb7381e14b" />


### How to verify

  1. Create a dashboard with a number-type filter using a static list as the value source (e.g., "1" → "Yes", "2" → "No")
  2. Map the filter to a card column
  3. Enable the dashboard for static/guest embedding, setting the filter to "Editable"
  4. Visit the embedded dashboard with an initial parameter value set via the URL (e.g., ?number=1)
  5. The filter widget correctly shows the label "Yes"
  6. Click the filter widget to open the dropdown
  7. Bug: The dropdown shows three items instead of two: "1", "Yes", "No" — the raw value "1" appears as an extra checked option

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
