### PR TITLE
Fix broken pie chart colors for some strings in static-viz

### DIFF
--- a/frontend/src/metabase/visualizations/shared/settings/pie.ts
+++ b/frontend/src/metabase/visualizations/shared/settings/pie.ts
@@ -209,7 +209,7 @@ export function getColors(
   return Object.fromEntries(
     Object.entries(colors).map(([key, value]) => [
       key === "null" ? NULL_DISPLAY_VALUE : key,
-      value,
+      getHexColor(value),
     ]),
   );
 }

--- a/frontend/src/metabase/visualizations/shared/settings/pie.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/shared/settings/pie.unit.spec.ts
@@ -143,4 +143,34 @@ describe("getColors", () => {
       Widget: "#000000",
     });
   });
+  it("should return hex values for colors", () => {
+    // getPreferredColor returns hsla values for strings like "active"
+    // make sure getColors is correctly converting them to hex values
+    // because hsla is not supported in static-viz
+    const columns = [
+      createMockColumn({ name: "Category" }),
+      createMockColumn({ name: "Count" }),
+    ];
+    const rawSeries = [
+      {
+        data: createMockDatasetData({
+          rows: [
+            ["active", 1],
+            ["other", 2],
+          ],
+          cols: columns,
+        }),
+      },
+    ] as RawSeries;
+    const settings = {
+      "pie.metric": "Count",
+      "pie.dimension": "Category",
+    };
+    const result = getColors(rawSeries, settings);
+    expect(
+      Object.values(result).every(
+        (color) => color.startsWith("#") && color.length === 7,
+      ),
+    ).toBe(true);
+  });
 });


### PR DESCRIPTION
Fixes https://metaboat.slack.com/archives/C05MPF0TM3L/p1773148201037769

### Description

#68095 introduced a bug where some pie chart colors were hsla rather than hex, and hsla isn't supported in static-viz.

Specifically, `getPreferredColor` in `getColorsForValues` returns hsla for certain strings like "active" or "success", and pie's `getColors` was not converting these to hex.

### How to verify

Create a native SQL question with the below query, visualize it as pie, and send it via email or slack.

```
select 2 as x, 'success' as status union all
select 1 as x, 'other' as status
```

### Demo

Before:
<img width="680" height="588" alt="image" src="https://github.com/user-attachments/assets/c5eae33f-21cc-4ecb-86fb-cc5f20536ca1" />

After:
<img width="660" height="586" alt="image" src="https://github.com/user-attachments/assets/0d70398e-db6a-46a1-a238-e16bcff0061a" />

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
