### PR TITLE
Backport 22 missing v59 changesets from master

### DIFF
--- a/resources/migrations/059_update_migrations.yaml
+++ b/resources/migrations/059_update_migrations.yaml
@@ -3015,6 +3015,458 @@ databaseChangeLog:
                   constraints:
                     nullable: false
 
+  # ---------- Group 15: Normalize workspace_input (BOT-955) ----------
+  # Drop and recreate workspace_input with new schema (without ref_id / transform_version).
+  # Create workspace_input_transform join table for the m2m relationship.
+  # Truncate analysis tables so they repopulate on next workspace load.
+
+  - changeSet:
+      id: v59.2026-02-09T12:00:00
+      author: qnkhuat
+      comment: Drop workspace_input table to recreate with normalized schema
+      preConditions:
+        - onFail: MARK_RAN
+        - tableExists:
+            tableName: workspace_input
+        - columnExists:
+            tableName: workspace_input
+            columnName: ref_id
+      changes:
+        - dropTable:
+            tableName: workspace_input
+      rollback:
+        - createTable:
+            tableName: workspace_input
+            remarks: External tables that workspace transforms consume from source databases
+            columns:
+              - column:
+                  name: id
+                  type: int
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: workspace_id
+                  type: int
+                  constraints:
+                    nullable: false
+              - column:
+                  name: db_id
+                  type: int
+                  constraints:
+                    nullable: false
+              - column:
+                  name: schema
+                  type: varchar(254)
+                  constraints:
+                    nullable: true
+              - column:
+                  name: table
+                  type: varchar(254)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: table_id
+                  type: int
+                  constraints:
+                    nullable: true
+              - column:
+                  name: ref_id
+                  type: char(36)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: access_granted
+                  type: ${boolean.type}
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false
+              - column:
+                  name: transform_version
+                  type: bigint
+                  defaultValueNumeric: 0
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: ${timestamp_type}
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: ${timestamp_type}
+                  constraints:
+                    nullable: false
+        # Recreate FKs that Group 7 changesets added, so their auto-rollback
+        # (dropForeignKeyConstraint) succeeds when rolling back further.
+        - addForeignKeyConstraint:
+            baseTableName: workspace_input
+            baseColumnNames: workspace_id
+            constraintName: fk_workspace_input_workspace_id
+            referencedTableName: workspace
+            referencedColumnNames: id
+            onDelete: CASCADE
+        - addForeignKeyConstraint:
+            baseTableName: workspace_input
+            baseColumnNames: table_id
+            constraintName: fk_workspace_input_table_id
+            referencedTableName: metabase_table
+            referencedColumnNames: id
+            onDelete: SET NULL
+
+  - changeSet:
+      id: v59.2026-02-09T12:00:01
+      author: qnkhuat
+      comment: Create workspace_input with normalized schema (no ref_id or transform_version)
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: workspace_input
+      changes:
+        - createTable:
+            tableName: workspace_input
+            remarks: External tables that workspace transforms consume from source databases
+            columns:
+              - column:
+                  name: id
+                  type: int
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: workspace_id
+                  type: int
+                  remarks: FK to workspace
+                  constraints:
+                    nullable: false
+              - column:
+                  name: db_id
+                  type: int
+                  remarks: Database containing the source table
+                  constraints:
+                    nullable: false
+              - column:
+                  name: schema
+                  type: varchar(254)
+                  remarks: Schema of the source table (nullable for DBs without schemas)
+                  constraints:
+                    nullable: true
+              - column:
+                  name: table
+                  type: varchar(254)
+                  remarks: Name of the source table
+                  constraints:
+                    nullable: false
+              - column:
+                  name: table_id
+                  type: int
+                  remarks: FK to metabase_table if table exists and is synced
+                  constraints:
+                    nullable: true
+              - column:
+                  name: access_granted
+                  type: ${boolean.type}
+                  remarks: Whether read access has been granted to the workspace user
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: ${timestamp_type}
+                  remarks: Timestamp when the input was created
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: ${timestamp_type}
+                  remarks: Timestamp when the input was last updated
+                  constraints:
+                    nullable: false
+
+  - changeSet:
+      id: v59.2026-02-09T12:00:02
+      author: qnkhuat
+      comment: Add index on workspace_input.workspace_id
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - indexExists:
+                tableName: workspace_input
+                indexName: idx_workspace_input_workspace_id
+      changes:
+        - createIndex:
+            tableName: workspace_input
+            indexName: idx_workspace_input_workspace_id
+            columns:
+              - column:
+                  name: workspace_id
+
+  - changeSet:
+      id: v59.2026-02-09T12:00:03
+      author: qnkhuat
+      comment: Add index on workspace_input.table_id
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - indexExists:
+                tableName: workspace_input
+                indexName: idx_workspace_input_table_id
+      changes:
+        - createIndex:
+            tableName: workspace_input
+            indexName: idx_workspace_input_table_id
+            columns:
+              - column:
+                  name: table_id
+
+  - changeSet:
+      id: v59.2026-02-09T12:00:04
+      author: qnkhuat
+      comment: Add FK from workspace_input.workspace_id to workspace with CASCADE
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - foreignKeyConstraintExists:
+                foreignKeyName: fk_workspace_input_workspace_id
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: workspace_input
+            baseColumnNames: workspace_id
+            constraintName: fk_workspace_input_workspace_id
+            referencedTableName: workspace
+            referencedColumnNames: id
+            onDelete: CASCADE
+
+  - changeSet:
+      id: v59.2026-02-09T12:00:05
+      author: qnkhuat
+      comment: Add FK from workspace_input.table_id to metabase_table with SET NULL
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - foreignKeyConstraintExists:
+                foreignKeyName: fk_workspace_input_table_id
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: workspace_input
+            baseColumnNames: table_id
+            constraintName: fk_workspace_input_table_id
+            referencedTableName: metabase_table
+            referencedColumnNames: id
+            onDelete: SET NULL
+
+  - changeSet:
+      id: v59.2026-02-09T12:00:06
+      author: qnkhuat
+      comment: Add unique constraint on workspace_input (workspace_id, db_id, schema, table)
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - indexExists:
+                tableName: workspace_input
+                indexName: uq_workspace_input_table
+      changes:
+        - addUniqueConstraint:
+            tableName: workspace_input
+            columnNames: workspace_id, db_id, schema, table
+            constraintName: uq_workspace_input_table
+
+  - changeSet:
+      id: v59.2026-02-09T12:00:07
+      author: qnkhuat
+      comment: Create workspace_input_transform join table for m2m between workspace_input and workspace_transform
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: workspace_input_transform
+      changes:
+        - createTable:
+            tableName: workspace_input_transform
+            remarks: Join table linking workspace inputs to the transforms that depend on them
+            columns:
+              - column:
+                  name: id
+                  type: int
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: workspace_input_id
+                  type: int
+                  remarks: FK to workspace_input
+                  constraints:
+                    nullable: false
+              - column:
+                  name: workspace_id
+                  type: int
+                  remarks: FK to workspace (denormalized for query convenience)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: ref_id
+                  type: char(36)
+                  remarks: ref_id of the workspace_transform that depends on this input
+                  constraints:
+                    nullable: false
+              - column:
+                  name: transform_version
+                  type: bigint
+                  remarks: The analysis_version of the transform when this row was created
+                  defaultValueNumeric: 0
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: ${timestamp_type}
+                  remarks: Timestamp when the link was created
+                  defaultValueComputed: current_timestamp
+                  constraints:
+                    nullable: false
+
+  - changeSet:
+      id: v59.2026-02-09T12:00:08
+      author: qnkhuat
+      comment: Add index on workspace_input_transform.workspace_input_id
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - indexExists:
+                tableName: workspace_input_transform
+                indexName: idx_workspace_input_transform_input_id
+      changes:
+        - createIndex:
+            tableName: workspace_input_transform
+            indexName: idx_workspace_input_transform_input_id
+            columns:
+              - column:
+                  name: workspace_input_id
+
+  - changeSet:
+      id: v59.2026-02-09T12:00:09
+      author: qnkhuat
+      comment: Add composite index on workspace_input_transform (workspace_id, ref_id)
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - indexExists:
+                tableName: workspace_input_transform
+                indexName: idx_workspace_input_transform_ws_ref
+      changes:
+        - createIndex:
+            tableName: workspace_input_transform
+            indexName: idx_workspace_input_transform_ws_ref
+            columns:
+              - column:
+                  name: workspace_id
+              - column:
+                  name: ref_id
+
+  - changeSet:
+      id: v59.2026-02-09T12:00:10
+      author: qnkhuat
+      comment: Add FK from workspace_input_transform.workspace_input_id to workspace_input with CASCADE
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - foreignKeyConstraintExists:
+                foreignKeyName: fk_wit_workspace_input_id
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: workspace_input_transform
+            baseColumnNames: workspace_input_id
+            constraintName: fk_wit_workspace_input_id
+            referencedTableName: workspace_input
+            referencedColumnNames: id
+            onDelete: CASCADE
+
+  - changeSet:
+      id: v59.2026-02-09T12:00:11
+      author: qnkhuat
+      comment: Add FK from workspace_input_transform.workspace_id to workspace with CASCADE
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - foreignKeyConstraintExists:
+                foreignKeyName: fk_wit_workspace_id
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: workspace_input_transform
+            baseColumnNames: workspace_id
+            constraintName: fk_wit_workspace_id
+            referencedTableName: workspace
+            referencedColumnNames: id
+            onDelete: CASCADE
+
+  - changeSet:
+      id: v59.2026-02-09T12:00:12
+      author: qnkhuat
+      comment: Add unique constraint on workspace_input_transform (workspace_input_id, workspace_id, ref_id, transform_version)
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - indexExists:
+                tableName: workspace_input_transform
+                indexName: uq_workspace_input_transform_versioned
+      changes:
+        - addUniqueConstraint:
+            tableName: workspace_input_transform
+            columnNames: workspace_input_id, workspace_id, ref_id, transform_version
+            constraintName: uq_workspace_input_transform_versioned
+
+  - changeSet:
+      id: v59.2026-02-09T12:00:13
+      author: qnkhuat
+      comment: Truncate workspace_graph so analysis will re-run
+      changes:
+        - delete:
+            tableName: workspace_graph
+      rollback:
+
+  - changeSet:
+      id: v59.2026-02-09T12:00:14
+      author: qnkhuat
+      comment: Truncate workspace_output so analysis will re-run
+      changes:
+        - delete:
+            tableName: workspace_output
+      rollback:
+
+  - changeSet:
+      id: v59.2026-02-16T12:00:00
+      author: bronsa
+      comment: Usage analytics; Remove logs column from v_tasks view
+      changes:
+        - sqlFile:
+            dbms: postgresql
+            path: instance_analytics_views/tasks/v5/postgres-tasks.sql
+            relativeToChangelogFile: true
+        - sqlFile:
+            dbms: mysql,mariadb
+            path: instance_analytics_views/tasks/v5/mysql-tasks.sql
+            relativeToChangelogFile: true
+        - sqlFile:
+            dbms: h2
+            path: instance_analytics_views/tasks/v5/h2-tasks.sql
+            relativeToChangelogFile: true
+      rollback:
+        - sqlFile:
+            dbms: postgresql
+            path: instance_analytics_views/tasks/v4/postgres-tasks.sql
+            relativeToChangelogFile: true
+        - sqlFile:
+            dbms: mysql,mariadb
+            path: instance_analytics_views/tasks/v4/mysql-tasks.sql
+            relativeToChangelogFile: true
+        - sqlFile:
+            dbms: h2
+            path: instance_analytics_views/tasks/v4/h2-tasks.sql
+            relativeToChangelogFile: true
+
   - changeSet:
       id: v59.2026-02-16T18:00:00
       author: galdre
@@ -3039,6 +3491,96 @@ databaseChangeLog:
         - dropColumn:
             tableName: metabase_database
             columnName: write_data_details
+
+  - changeSet:
+      id: v59.2026-02-17T12:00:00
+      author: bronsa
+      comment: Add query_execution.transform_id for inspector query attribution
+      changes:
+        - addColumn:
+            tableName: query_execution
+            columns:
+              - column:
+                  name: transform_id
+                  type: int
+                  remarks: The ID of the Transform associated with this query execution, if any.
+
+  - changeSet:
+      id: v59.2026-02-17T12:00:01
+      author: bronsa
+      comment: Index query_execution.transform_id
+      changes:
+        - createIndex:
+            tableName: query_execution
+            indexName: idx_query_execution_transform_id
+            columns:
+              - column:
+                  name: transform_id
+
+  - changeSet:
+      id: v59.2026-02-17T12:01:02
+      author: bronsa
+      comment: Add query_execution.lens_id for inspector query attribution
+      changes:
+        - addColumn:
+            tableName: query_execution
+            columns:
+              - column:
+                  name: lens_id
+                  type: varchar(254)
+                  remarks: The ID of the inspector lens associated with this query execution, if any.
+
+  - changeSet:
+      id: v59.2026-02-17T12:01:03
+      author: bronsa
+      comment: Add query_execution.lens_params for inspector query attribution
+      changes:
+        - addColumn:
+            tableName: query_execution
+            columns:
+              - column:
+                  name: lens_params
+                  type: ${text.type}
+                  remarks: JSON-encoded parameters of the inspector lens associated with this query execution, if any.
+
+  - changeSet:
+      id: v59.2026-02-17T12:01:04
+      author: bronsa
+      comment: Updated view v_query_log v4 - add transform_id, lens_id, lens_params
+      changes:
+        - sqlFile:
+            dbms: postgresql
+            path: instance_analytics_views/query_log/v4/postgres-query_log.sql
+            relativeToChangelogFile: true
+        - sqlFile:
+            dbms: mysql,mariadb
+            path: instance_analytics_views/query_log/v4/mysql-query_log.sql
+            relativeToChangelogFile: true
+        - sqlFile:
+            dbms: h2
+            path: instance_analytics_views/query_log/v4/h2-query_log.sql
+            relativeToChangelogFile: true
+      rollback:
+        - sqlFile:
+            dbms: postgresql
+            path: instance_analytics_views/query_log/v2/postgres-query_log.sql
+            relativeToChangelogFile: true
+        - sqlFile:
+            dbms: mysql,mariadb
+            path: instance_analytics_views/query_log/v3/mysql-query_log.sql
+            relativeToChangelogFile: true
+        - sqlFile:
+            dbms: h2
+            path: instance_analytics_views/query_log/v2/h2-query_log.sql
+            relativeToChangelogFile: true
+
+  - changeSet:
+      id: v59.2026-03-03T12:00:00
+      author: qnkhuat
+      comment: Unify source-tables format from map to ordered array
+      changes:
+        - customChange:
+            class: "metabase.app_db.custom_migrations.UnifySourceTablesFormat"
 
   - changeSet:
       id: v59.2026-03-04T00:00:00

--- a/resources/migrations/instance_analytics_views/query_log/v4/h2-query_log.sql
+++ b/resources/migrations/instance_analytics_views/query_log/v4/h2-query_log.sql
@@ -1,0 +1,29 @@
+DROP VIEW IF EXISTS v_query_log;
+
+
+CREATE OR REPLACE VIEW v_query_log AS
+SELECT id AS entity_id,
+       started_at,
+       cast(running_time AS DOUBLE) / 1000 AS running_time_seconds,
+       result_rows,
+       native AS is_native,
+       context AS query_source,
+       error,
+       coalesce(executor_id, 0) AS user_id,
+       card_id,
+       'card_' || card_id AS card_qualified_id,
+       dashboard_id,
+       'dashboard_' || dashboard_id AS dashboard_qualified_id,
+       pulse_id,
+       database_id,
+       'database_' || database_id AS database_qualified_id,
+       cache_hit,
+       action_id,
+       'action_' || action_id AS action_qualified_id,
+       transform_id,
+       'transform_' || transform_id AS transform_qualified_id,
+       lens_id,
+       lens_params,
+       query
+FROM query_execution
+    LEFT JOIN query ON query_execution.hash = query.query_hash;

--- a/resources/migrations/instance_analytics_views/query_log/v4/mysql-query_log.sql
+++ b/resources/migrations/instance_analytics_views/query_log/v4/mysql-query_log.sql
@@ -1,0 +1,31 @@
+DROP VIEW IF EXISTS v_query_log;
+
+
+CREATE OR REPLACE
+SQL SECURITY INVOKER
+VIEW v_query_log AS
+SELECT id AS entity_id,
+       started_at,
+       cast(running_time AS DOUBLE) / 1000 AS running_time_seconds,
+       result_rows,
+       native AS is_native,
+       context AS query_source,
+       error,
+       coalesce(executor_id, 0) AS user_id,
+       card_id,
+       concat('card_', card_id) AS card_qualified_id,
+       dashboard_id,
+       concat('dashboard_', dashboard_id) AS dashboard_qualified_id,
+       pulse_id,
+       database_id,
+       concat('database_', database_id) AS database_qualified_id,
+       cache_hit,
+       action_id,
+       concat('action_', action_id) AS action_qualified_id,
+       transform_id,
+       concat('transform_', transform_id) AS transform_qualified_id,
+       lens_id,
+       lens_params,
+       query
+FROM query_execution
+    LEFT JOIN query ON query_execution.hash = query.query_hash;

--- a/resources/migrations/instance_analytics_views/query_log/v4/postgres-query_log.sql
+++ b/resources/migrations/instance_analytics_views/query_log/v4/postgres-query_log.sql
@@ -1,0 +1,29 @@
+DROP VIEW IF EXISTS v_query_log;
+
+
+CREATE OR REPLACE VIEW v_query_log AS
+SELECT id AS entity_id,
+       started_at,
+       cast(running_time AS double precision) / 1000 AS running_time_seconds,
+       result_rows,
+       native AS is_native,
+       context AS query_source,
+       error,
+       coalesce(executor_id, 0) AS user_id,
+       card_id,
+       'card_' || card_id AS card_qualified_id,
+       dashboard_id,
+       'dashboard_' || dashboard_id AS dashboard_qualified_id,
+       pulse_id,
+       database_id,
+       'database_' || database_id AS database_qualified_id,
+       cache_hit,
+       action_id,
+       'action_' || action_id AS action_qualified_id,
+       transform_id,
+       'transform_' || transform_id AS transform_qualified_id,
+       lens_id,
+       lens_params,
+       query
+FROM query_execution
+    LEFT JOIN query ON query_execution.hash = query.query_hash;

--- a/resources/migrations/instance_analytics_views/tasks/v5/h2-tasks.sql
+++ b/resources/migrations/instance_analytics_views/tasks/v5/h2-tasks.sql
@@ -1,0 +1,14 @@
+drop view if exists v_tasks;
+
+create or replace view v_tasks as
+select
+    id,
+    task,
+    status,
+    'database_' || db_id as database_qualified_id,
+    started_at,
+    ended_at,
+    cast(duration as double) / 1000 as duration_seconds,
+    task_details as details,
+    run_id
+from task_history;

--- a/resources/migrations/instance_analytics_views/tasks/v5/mysql-tasks.sql
+++ b/resources/migrations/instance_analytics_views/tasks/v5/mysql-tasks.sql
@@ -1,0 +1,16 @@
+drop view if exists v_tasks;
+
+CREATE OR REPLACE
+SQL SECURITY INVOKER
+VIEW v_tasks AS
+select
+    id,
+    task,
+    status,
+    concat('database_', db_id) as database_qualified_id,
+    started_at,
+    ended_at,
+    cast(duration as double) / 1000 as duration_seconds,
+    task_details as details,
+    run_id
+from task_history;

--- a/resources/migrations/instance_analytics_views/tasks/v5/postgres-tasks.sql
+++ b/resources/migrations/instance_analytics_views/tasks/v5/postgres-tasks.sql
@@ -1,0 +1,14 @@
+drop view if exists v_tasks;
+
+create or replace view v_tasks as
+select
+    id,
+    task,
+    status,
+    'database_' || db_id as database_qualified_id,
+    started_at,
+    ended_at,
+    cast(duration as double precision) / 1000 as duration_seconds,
+    task_details as details,
+    run_id
+from task_history;

--- a/src/metabase/app_db/custom_migrations.clj
+++ b/src/metabase/app_db/custom_migrations.clj
@@ -1855,6 +1855,73 @@
 (define-migration MoveExistingAtSymbolUserAttributes
   (reserve-at-symbol-user-attributes/migrate!))
 
+(define-reversible-migration UnifySourceTablesFormat
+  (let [tables [{:table :transform           :pks [:id]                  :where [:= :source_type "python"]}
+                {:table :workspace_transform :pks [:workspace_id :ref_id]}]
+        python? (fn [source]
+                  (= "python" (get (json-out source false) "type")))
+        all-rows (into []
+                       (mapcat (fn [{:keys [table pks] w :where}]
+                                 (->> (t2/query (cond-> {:select (into [:source] pks)
+                                                         :from   [table]}
+                                                  w (assoc :where w)))
+                                      (filter #(or w (python? (:source %))))
+                                      (map #(assoc % ::table table ::pks pks)))))
+                       tables)
+        all-ids  (into #{}
+                       (mapcat (fn [{:keys [source]}]
+                                 (let [st (get (json-out source false) "source-tables")]
+                                   (when (map? st)
+                                     (filter int? (vals st))))))
+                       all-rows)
+        metadata (when (seq all-ids)
+                   (into {}
+                         (map (fn [{:keys [id db_id schema name]}]
+                                [id {"database_id" db_id "schema" schema "table" name}]))
+                         (t2/query {:select [:id :db_id :schema :name]
+                                    :from   [:metabase_table]
+                                    :where  [:in :id all-ids]})))]
+    (doseq [{:keys [source] :as row} all-rows]
+      (let [parsed (json-out source false)
+            st     (get parsed "source-tables")]
+        (when (map? st)
+          (let [entries (mapv (fn [[alias v]]
+                                (if (int? v)
+                                  ;; Integer value: backfill all metadata (database_id, schema, table) from DB.
+                                  (merge {"alias" alias "table_id" v}
+                                         (get metadata v))
+                                  ;; Ref-map value: already has database_id/schema/table; table_id is
+                                  ;; resolved lazily by normalize-source-tables when the transform is saved via the API.
+                                  (assoc v "alias" alias)))
+                              st)
+                pks     (::pks row)]
+            (t2/query {:update (::table row)
+                       :set    {:source (json-in (assoc parsed "source-tables" entries))}
+                       :where  (into [:and] (map #(vector := % (get row %)) pks))}))))))
+  (let [convert-back
+        (fn [source-json]
+          (let [parsed (json-out source-json false)]
+            (when-let [st (get parsed "source-tables")]
+              (when (sequential? st)
+                (let [m (into {} (map (fn [entry]
+                                        [(get entry "alias")
+                                         (or (get entry "table_id") entry)]))
+                              st)]
+                  (json-in (assoc parsed "source-tables" m)))))))
+        tables  [{:table :transform           :pks [:id]                  :where [:= :source_type "python"]}
+                 {:table :workspace_transform :pks [:workspace_id :ref_id]}]
+        python? (fn [source]
+                  (= "python" (get (json-out source false) "type")))]
+    (doseq [{:keys [table pks] w :where} tables]
+      (doseq [row (cond->> (t2/query (cond-> {:select (into [:source] pks)
+                                              :from   [table]}
+                                       w (assoc :where w)))
+                    (not w) (filter #(python? (:source %))))]
+        (when-let [new-source (convert-back (:source row))]
+          (t2/query {:update table
+                     :set    {:source new-source}
+                     :where  (into [:and] (map #(vector := % (get row %)) pks))}))))))
+
 (define-migration FixClickHouseUploadDBSchemaNames
   "This data migration is meant to fix the issues seen in #69667, #68298 and #65945.
    We made the driver feature `schemas` conditional on the `enable-multiple-db` DB connection setting.


### PR DESCRIPTION
## Summary

- Backports 22 changesets that were added to master after the v59 release branch was cut but were versioned as v59 (not v60)
- The cross-version rollback CI test uses the released v59 image to roll back from v59→v58, so it fails when it encounters `databasechangelog` entries for changesets that aren't in the v59 image's changelog YAML
- All workspace table changesets use `preconditions` with `onFail: MARK_RAN`, making them safe to backport (idempotent on existing tables)

### Changesets included

| Category | Count | IDs |
|----------|-------|-----|
| Workspace tables | 15 | `v59.2026-02-09T12:00:00` through `:10`, plus 5 more |
| Analytics views (query_log v4, tasks v5) | 1 | `v59.2026-02-16T18:00:01` |
| Inspector columns | 5 | `v59.2026-02-17T00:00:00` through `:04` |
| Data migration (UnifySourceTablesFormat) | 1 | `v59.2026-03-03T12:00:00` |

### Files changed

- `resources/migrations/059_update_migrations.yaml` — added 22 changeset definitions
- `src/metabase/app_db/custom_migrations.clj` — added `UnifySourceTablesFormat` custom migration
- 6 new SQL files for analytics view updates (query_log v4, tasks v5)

## Test plan

- [ ] Run cross-version rollback CI test (v60→v59→v58)