### PR TITLE
Fix slackbot feedback acknowledgement

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot.clj
@@ -94,7 +94,7 @@
     (slackbot.client/post-message
      client
      (merge (slackbot.events/event->reply-context event)
-            { ;; DMs: always thread. Channels: only thread if already in a thread.
+            {;; DMs: always thread. Channels: only thread if already in a thread.
              :thread_ts (or (:thread_ts event) (:ts event))
              :text msg
              :blocks [{:type "section"
@@ -501,15 +501,20 @@
         freeform-block]))})
 
 (defn- replace-feedback-buttons-with-thanks
-  "Update the Slack message to replace the feedback buttons with a confirmation."
-  [client channel message-ts message-blocks]
-  (let [updated-blocks (-> (into [] (remove #(= (:block_id %) "metabot_feedback")) message-blocks)
-                           (conj {:type     "context"
-                                  :elements [{:type "mrkdwn"
-                                              :text "Thanks for your feedback!"}]}))]
-    (slackbot.client/update-message client {:channel channel
-                                            :ts      message-ts
-                                            :blocks  updated-blocks})))
+  "Update the Slack message to replace the feedback buttons with a confirmation.
+   Uses the message from the `block_actions` payload (which contains the full content as rendered by
+   Slack) rather than re-fetching via `conversations.history`, which may not return the full content
+   for streamed messages."
+  [client channel message]
+  (let [{:keys [ts text blocks]} message
+        updated-blocks           (-> (into [] (remove #(= (:block_id %) "metabot_feedback")) blocks)
+                                     (conj {:type     "context"
+                                            :elements [{:type "mrkdwn"
+                                                        :text "Thanks for your feedback!"}]}))]
+    (slackbot.client/update-message client (cond-> {:channel channel
+                                                    :ts      ts
+                                                    :blocks  updated-blocks}
+                                             text (assoc :text text)))))
 
 (defn- build-base-feedback
   "Build the common feedback payload fields."
@@ -526,9 +531,9 @@
 
 (defn- handle-feedback-action
   "Handle a metabot feedback button click from Slack.
-   Opens the detail modal immediately (trigger_id expires in 3s). Feedback is
-   submitted to Harbormaster only when the user submits the modal."
-  [{:keys [action trigger-id slack-user-id channel-id message-ts]}]
+   Opens the detail modal immediately (trigger_id expires in 3s), then asynchronously replaces the
+   feedback buttons with a confirmation message using the message from the interaction payload."
+  [{:keys [action trigger-id slack-user-id channel-id message]}]
   (let [{:keys [conversation_id positive]} (json/decode (:value action) true)
         client  {:token (channel.settings/unobfuscated-slack-app-token)}
         user-id (slack-id->user-id slack-user-id)]
@@ -541,9 +546,14 @@
                                                      :positive        positive
                                                      :user_id         user-id
                                                      :channel_id      channel-id
-                                                     :message_ts      message-ts})})
+                                                     :message_ts      (:ts message)})})
         (catch Exception e
-          (log/errorf e "[slackbot] Error opening feedback modal: %s" (ex-data e)))))))
+          (log/errorf e "[slackbot] Error opening feedback modal: %s" (ex-data e))))
+      (future
+        (try
+          (replace-feedback-buttons-with-thanks client channel-id message)
+          (catch Exception e
+            (log/errorf e "[slackbot] Error replacing feedback buttons: %s" (ex-data e))))))))
 
 (defn- handle-delete-action
   "Handle replacing a metabot response message with a removed notice.
@@ -563,11 +573,11 @@
 
 (defn- handle-feedback-modal-submission
   "Handle submission of the feedback details modal.
-   Always submits to Harbormaster (the modal opening already captured positive/negative),
-   then replaces the feedback buttons with a thanks message."
+   Submits detailed feedback to Harbormaster. The feedback buttons are already replaced with a
+   confirmation message at button-click time (see `handle-feedback-action`)."
   [payload]
   (let [private-metadata (json/decode (get-in payload [:view :private_metadata]) true)
-        {:keys [conversation_id positive user_id channel_id message_ts]} private-metadata
+        {:keys [conversation_id positive user_id]} private-metadata
         values           (get-in payload [:view :state :values])
         issue-type       (get-in values [:issue_type :issue_type_select :selected_option :value])
         freeform         (get-in values [:freeform_feedback :freeform_input :value])]
@@ -578,15 +588,7 @@
            true       (assoc-in [:feedback :freeform_feedback] (or freeform ""))
            issue-type (assoc-in [:feedback :issue_type] issue-type)))
         (catch Exception e
-          (log/error e "[slackbot] Error submitting feedback to Harbormaster")))
-      (try
-        (when (and channel_id message_ts)
-          (let [client  {:token (channel.settings/unobfuscated-slack-app-token)}
-                message (slackbot.client/fetch-message client channel_id message_ts)]
-            (when message
-              (replace-feedback-buttons-with-thanks client channel_id message_ts (:blocks message)))))
-        (catch Exception e
-          (log/error e "[slackbot] Error replacing feedback buttons"))))))
+          (log/error e "[slackbot] Error submitting feedback to Harbormaster"))))))
 
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :post "/interactive"
@@ -602,7 +604,7 @@
               slack-user (get-in payload [:user :id])
               trigger-id (:trigger_id payload)
               channel-id (get-in payload [:channel :id])
-              message-ts (get-in payload [:message :ts])]
+              message    (:message payload)]
           (doseq [action actions]
             (case (:action_id action)
               "metabot_feedback"
@@ -610,12 +612,12 @@
                                        :trigger-id    trigger-id
                                        :slack-user-id slack-user
                                        :channel-id    channel-id
-                                       :message-ts    message-ts})
+                                       :message       message})
 
               "metabot_delete_response"
               (handle-delete-action {:slack-user-id slack-user
                                      :channel-id    channel-id
-                                     :message-ts    message-ts})
+                                     :message-ts    (:ts message)})
               nil)))
 
         "view_submission"

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot.clj
@@ -487,7 +487,7 @@
                                                   :text (if positive
                                                           "Tell us what you liked!"
                                                           "What could be improved about this response?")}}
-                         :label    {:type "plain_text" :text "Any details you'd like to share? (optional)"}}]
+                         :label    {:type "plain_text" :text "Any details you'd like to share?"}}]
      (if positive
        [freeform-block]
        [{:type     "input"
@@ -497,22 +497,8 @@
                     :action_id   "issue_type_select"
                     :placeholder {:type "plain_text" :text "Select issue type"}
                     :options     issue-type-options}
-         :label    {:type "plain_text" :text "What kind of issue are you reporting? (optional)"}}
+         :label    {:type "plain_text" :text "What kind of issue are you reporting?"}}
         freeform-block]))})
-
-(defn- replace-feedback-buttons-with-thanks
-  "Replace the feedback buttons on a Slack message with a confirmation.
-   `message` should come directly from the `block_actions` payload to preserve message content."
-  [client channel message]
-  (let [{:keys [ts text blocks]} message
-        updated-blocks           (-> (into [] (remove #(= (:block_id %) "metabot_feedback")) blocks)
-                                     (conj {:type     "context"
-                                            :elements [{:type "mrkdwn"
-                                                        :text "Thanks for your feedback!"}]}))]
-    (slackbot.client/update-message client (cond-> {:channel channel
-                                                    :ts      ts
-                                                    :blocks  updated-blocks}
-                                             text (assoc :text text)))))
 
 (defn- build-base-feedback
   "Build the common feedback payload fields."
@@ -529,9 +515,9 @@
 
 (defn- handle-feedback-action
   "Handle a metabot feedback button click from Slack.
-   Opens the detail modal immediately (trigger_id expires in 3s), then asynchronously replaces the
-   feedback buttons with a confirmation message using the message from the interaction payload."
-  [{:keys [action trigger-id slack-user-id channel-id message]}]
+   Opens the detail modal immediately (trigger_id expires in 3s). Feedback is
+   submitted to Harbormaster only when the user submits the modal."
+  [{:keys [action trigger-id slack-user-id channel-id message-ts]}]
   (let [{:keys [conversation_id positive]} (json/decode (:value action) true)
         client  {:token (channel.settings/unobfuscated-slack-app-token)}
         user-id (slack-id->user-id slack-user-id)]
@@ -544,14 +530,9 @@
                                                      :positive        positive
                                                      :user_id         user-id
                                                      :channel_id      channel-id
-                                                     :message_ts      (:ts message)})})
+                                                     :message_ts      message-ts})})
         (catch Exception e
-          (log/errorf e "[slackbot] Error opening feedback modal: %s" (ex-data e))))
-      (future
-        (try
-          (replace-feedback-buttons-with-thanks client channel-id message)
-          (catch Exception e
-            (log/errorf e "[slackbot] Error replacing feedback buttons: %s" (ex-data e))))))))
+          (log/errorf e "[slackbot] Error opening feedback modal: %s" (ex-data e)))))))
 
 (defn- handle-delete-action
   "Handle replacing a metabot response message with a removed notice.
@@ -570,9 +551,7 @@
       (log-ignored-delete-request (assoc authorization :source "action")))))
 
 (defn- handle-feedback-modal-submission
-  "Handle submission of the feedback details modal.
-   Submits detailed feedback to Harbormaster. The feedback buttons are already replaced with a
-   confirmation message at button-click time (see `handle-feedback-action`)."
+  "Handle submission of the feedback details modal. Submits detailed feedback to Harbormaster."
   [payload]
   (let [private-metadata (json/decode (get-in payload [:view :private_metadata]) true)
         {:keys [conversation_id positive user_id]} private-metadata
@@ -602,7 +581,7 @@
               slack-user (get-in payload [:user :id])
               trigger-id (:trigger_id payload)
               channel-id (get-in payload [:channel :id])
-              message    (:message payload)]
+              message-ts (get-in payload [:message :ts])]
           (doseq [action actions]
             (case (:action_id action)
               "metabot_feedback"
@@ -610,12 +589,12 @@
                                        :trigger-id    trigger-id
                                        :slack-user-id slack-user
                                        :channel-id    channel-id
-                                       :message       message})
+                                       :message-ts    message-ts})
 
               "metabot_delete_response"
               (handle-delete-action {:slack-user-id slack-user
                                      :channel-id    channel-id
-                                     :message-ts    (:ts message)})
+                                     :message-ts    message-ts})
               nil)))
 
         "view_submission"

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/api/slackbot.clj
@@ -501,10 +501,8 @@
         freeform-block]))})
 
 (defn- replace-feedback-buttons-with-thanks
-  "Update the Slack message to replace the feedback buttons with a confirmation.
-   Uses the message from the `block_actions` payload (which contains the full content as rendered by
-   Slack) rather than re-fetching via `conversations.history`, which may not return the full content
-   for streamed messages."
+  "Replace the feedback buttons on a Slack message with a confirmation.
+   `message` should come directly from the `block_actions` payload to preserve message content."
   [client channel message]
   (let [{:keys [ts text blocks]} message
         updated-blocks           (-> (into [] (remove #(= (:block_id %) "metabot_feedback")) blocks)

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
@@ -1820,23 +1820,16 @@
       (is (= "freeform_feedback" (:block_id (second (:blocks view))))))))
 
 (deftest handle-feedback-action-authenticated-test
-  (testing "feedback action opens modal and replaces feedback buttons with thanks"
+  (testing "feedback action opens modal with correct private_metadata but does not submit to harbormaster"
     (let [conversation-id    "conv-123"
           harbormaster-calls (atom [])
-          open-view-calls    (atom [])
-          update-calls       (atom [])
-          message-blocks     [{:type "section" :text {:type "mrkdwn" :text "The answer"}}
-                              {:type "context_actions" :block_id "metabot_feedback"
-                               :elements [{:type "feedback_buttons"}]}]]
+          open-view-calls    (atom [])]
       (with-redefs [slackbot/slack-id->user-id                  (constantly (mt/user->id :rasta))
                     metabot-v3.feedback/submit-to-harbormaster!  (fn [feedback]
                                                                    (swap! harbormaster-calls conj feedback)
                                                                    true)
                     slackbot.client/open-view                    (fn [_ params]
                                                                    (swap! open-view-calls conj params)
-                                                                   {:ok true})
-                    slackbot.client/update-message               (fn [_ msg]
-                                                                   (swap! update-calls conj msg)
                                                                    {:ok true})]
         (let [action {:action_id "metabot_feedback"
                       :value     (json/encode {:conversation_id conversation-id :positive true})}]
@@ -1845,7 +1838,7 @@
             :trigger-id    "trigger-abc"
             :slack-user-id "U123"
             :channel-id    "C123"
-            :message       {:ts "123.456" :text "The answer" :blocks message-blocks}})
+            :message-ts    "123.456"})
           (testing "modal was opened"
             (is (= 1 (count @open-view-calls)))
             (is (= "trigger-abc" (:trigger_id (first @open-view-calls))))
@@ -1856,24 +1849,16 @@
               (is (true? (:positive pm)))
               (is (= "C123" (:channel_id pm)))
               (is (= "123.456" (:message_ts pm)))))
-          (testing "feedback buttons were replaced with thanks"
-            (Thread/sleep 100)
-            (is (= 1 (count @update-calls)))
-            (let [{:keys [blocks text]} (first @update-calls)]
-              (is (= "The answer" text))
-              (is (not-any? #(= (:block_id %) "metabot_feedback") blocks))
-              (is (some #(= "Thanks for your feedback!" (get-in % [:elements 0 :text])) blocks))))
           (testing "harbormaster was NOT called on button click"
             (is (= 0 (count @harbormaster-calls)))))))))
 
 (deftest handle-feedback-action-negative-test
   (testing "negative feedback action opens modal with issue type dropdown"
     (let [open-view-calls (atom [])]
-      (with-redefs [slackbot/slack-id->user-id    (constantly (mt/user->id :rasta))
-                    slackbot.client/open-view      (fn [_ params]
-                                                     (swap! open-view-calls conj params)
-                                                     {:ok true})
-                    slackbot.client/update-message (constantly {:ok true})]
+      (with-redefs [slackbot/slack-id->user-id (constantly (mt/user->id :rasta))
+                    slackbot.client/open-view  (fn [_ params]
+                                                 (swap! open-view-calls conj params)
+                                                 {:ok true})]
         (let [action {:action_id "metabot_feedback"
                       :value     (json/encode {:conversation_id "conv-123" :positive false})}]
           (#'slackbot/handle-feedback-action
@@ -1881,7 +1866,7 @@
             :trigger-id    "trigger-abc"
             :slack-user-id "U123"
             :channel-id    "C123"
-            :message       {:ts "123.456" :blocks []}})
+            :message-ts    "123.456"})
           (let [view (:view (first @open-view-calls))]
             (is (= 2 (count (:blocks view))) "negative modal should have issue_type and freeform blocks")
             (is (= "issue_type" (:block_id (first (:blocks view)))))))))))
@@ -1889,17 +1874,13 @@
 (deftest handle-feedback-action-unauthenticated-test
   (testing "feedback action is silently skipped for unauthenticated user"
     (let [harbormaster-calls (atom [])
-          open-view-calls    (atom [])
-          update-calls       (atom [])]
+          open-view-calls    (atom [])]
       (with-redefs [slackbot/slack-id->user-id                  (constantly nil)
                     metabot-v3.feedback/submit-to-harbormaster!  (fn [feedback]
                                                                    (swap! harbormaster-calls conj feedback)
                                                                    true)
                     slackbot.client/open-view                    (fn [_ params]
                                                                    (swap! open-view-calls conj params)
-                                                                   {:ok true})
-                    slackbot.client/update-message               (fn [_ msg]
-                                                                   (swap! update-calls conj msg)
                                                                    {:ok true})]
         (let [action {:action_id "metabot_feedback"
                       :value     (json/encode {:conversation_id "conv-456" :positive false})}
@@ -1908,12 +1889,11 @@
                        :trigger-id    "trigger-abc"
                        :slack-user-id "U-UNKNOWN"
                        :channel-id    "C123"
-                       :message       {:ts "123.456" :blocks []}})]
+                       :message-ts    "123.456"})]
           (is (nil? result) "should return nil when user is not found")
           (testing "nothing was called"
             (is (= 0 (count @harbormaster-calls)))
-            (is (= 0 (count @open-view-calls)))
-            (is (= 0 (count @update-calls)))))))))
+            (is (= 0 (count @open-view-calls)))))))))
 
 (deftest handle-feedback-modal-submission-test
   (testing "modal submission sends feedback to harbormaster"

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/api/slackbot_test.clj
@@ -1820,16 +1820,23 @@
       (is (= "freeform_feedback" (:block_id (second (:blocks view))))))))
 
 (deftest handle-feedback-action-authenticated-test
-  (testing "feedback action opens modal with correct private_metadata but does not submit to harbormaster"
+  (testing "feedback action opens modal and replaces feedback buttons with thanks"
     (let [conversation-id    "conv-123"
           harbormaster-calls (atom [])
-          open-view-calls    (atom [])]
+          open-view-calls    (atom [])
+          update-calls       (atom [])
+          message-blocks     [{:type "section" :text {:type "mrkdwn" :text "The answer"}}
+                              {:type "context_actions" :block_id "metabot_feedback"
+                               :elements [{:type "feedback_buttons"}]}]]
       (with-redefs [slackbot/slack-id->user-id                  (constantly (mt/user->id :rasta))
                     metabot-v3.feedback/submit-to-harbormaster!  (fn [feedback]
                                                                    (swap! harbormaster-calls conj feedback)
                                                                    true)
                     slackbot.client/open-view                    (fn [_ params]
                                                                    (swap! open-view-calls conj params)
+                                                                   {:ok true})
+                    slackbot.client/update-message               (fn [_ msg]
+                                                                   (swap! update-calls conj msg)
                                                                    {:ok true})]
         (let [action {:action_id "metabot_feedback"
                       :value     (json/encode {:conversation_id conversation-id :positive true})}]
@@ -1838,7 +1845,7 @@
             :trigger-id    "trigger-abc"
             :slack-user-id "U123"
             :channel-id    "C123"
-            :message-ts    "123.456"})
+            :message       {:ts "123.456" :text "The answer" :blocks message-blocks}})
           (testing "modal was opened"
             (is (= 1 (count @open-view-calls)))
             (is (= "trigger-abc" (:trigger_id (first @open-view-calls))))
@@ -1849,16 +1856,24 @@
               (is (true? (:positive pm)))
               (is (= "C123" (:channel_id pm)))
               (is (= "123.456" (:message_ts pm)))))
+          (testing "feedback buttons were replaced with thanks"
+            (Thread/sleep 100)
+            (is (= 1 (count @update-calls)))
+            (let [{:keys [blocks text]} (first @update-calls)]
+              (is (= "The answer" text))
+              (is (not-any? #(= (:block_id %) "metabot_feedback") blocks))
+              (is (some #(= "Thanks for your feedback!" (get-in % [:elements 0 :text])) blocks))))
           (testing "harbormaster was NOT called on button click"
             (is (= 0 (count @harbormaster-calls)))))))))
 
 (deftest handle-feedback-action-negative-test
   (testing "negative feedback action opens modal with issue type dropdown"
     (let [open-view-calls (atom [])]
-      (with-redefs [slackbot/slack-id->user-id (constantly (mt/user->id :rasta))
-                    slackbot.client/open-view  (fn [_ params]
-                                                 (swap! open-view-calls conj params)
-                                                 {:ok true})]
+      (with-redefs [slackbot/slack-id->user-id    (constantly (mt/user->id :rasta))
+                    slackbot.client/open-view      (fn [_ params]
+                                                     (swap! open-view-calls conj params)
+                                                     {:ok true})
+                    slackbot.client/update-message (constantly {:ok true})]
         (let [action {:action_id "metabot_feedback"
                       :value     (json/encode {:conversation_id "conv-123" :positive false})}]
           (#'slackbot/handle-feedback-action
@@ -1866,7 +1881,7 @@
             :trigger-id    "trigger-abc"
             :slack-user-id "U123"
             :channel-id    "C123"
-            :message-ts    "123.456"})
+            :message       {:ts "123.456" :blocks []}})
           (let [view (:view (first @open-view-calls))]
             (is (= 2 (count (:blocks view))) "negative modal should have issue_type and freeform blocks")
             (is (= "issue_type" (:block_id (first (:blocks view)))))))))))
@@ -1874,13 +1889,17 @@
 (deftest handle-feedback-action-unauthenticated-test
   (testing "feedback action is silently skipped for unauthenticated user"
     (let [harbormaster-calls (atom [])
-          open-view-calls    (atom [])]
+          open-view-calls    (atom [])
+          update-calls       (atom [])]
       (with-redefs [slackbot/slack-id->user-id                  (constantly nil)
                     metabot-v3.feedback/submit-to-harbormaster!  (fn [feedback]
                                                                    (swap! harbormaster-calls conj feedback)
                                                                    true)
                     slackbot.client/open-view                    (fn [_ params]
                                                                    (swap! open-view-calls conj params)
+                                                                   {:ok true})
+                    slackbot.client/update-message               (fn [_ msg]
+                                                                   (swap! update-calls conj msg)
                                                                    {:ok true})]
         (let [action {:action_id "metabot_feedback"
                       :value     (json/encode {:conversation_id "conv-456" :positive false})}
@@ -1889,25 +1908,19 @@
                        :trigger-id    "trigger-abc"
                        :slack-user-id "U-UNKNOWN"
                        :channel-id    "C123"
-                       :message-ts    "123.456"})]
+                       :message       {:ts "123.456" :blocks []}})]
           (is (nil? result) "should return nil when user is not found")
           (testing "nothing was called"
             (is (= 0 (count @harbormaster-calls)))
-            (is (= 0 (count @open-view-calls)))))))))
+            (is (= 0 (count @open-view-calls)))
+            (is (= 0 (count @update-calls)))))))))
 
 (deftest handle-feedback-modal-submission-test
-  (testing "modal submission sends feedback to harbormaster and replaces buttons"
-    (let [harbormaster-calls (atom [])
-          update-calls       (atom [])
-          message-blocks     [{:type "section" :text "Hi"}
-                              {:type "actions" :block_id "metabot_feedback"}]]
+  (testing "modal submission sends feedback to harbormaster"
+    (let [harbormaster-calls (atom [])]
       (with-redefs [metabot-v3.feedback/submit-to-harbormaster! (fn [feedback]
                                                                   (swap! harbormaster-calls conj feedback)
-                                                                  true)
-                    slackbot.client/fetch-message               (constantly {:blocks message-blocks})
-                    slackbot.client/update-message               (fn [_ msg]
-                                                                   (swap! update-calls conj msg)
-                                                                   {:ok true})]
+                                                                  true)]
         (let [payload {:type "view_submission"
                        :view {:callback_id      "metabot_feedback_modal"
                               :private_metadata (json/encode {:conversation_id "conv-123"
@@ -1924,20 +1937,13 @@
             (is (false? (get-in feedback [:feedback :positive])))
             (is (= "conv-123" (get-in feedback [:feedback :message_id])))
             (is (= "not-factual" (get-in feedback [:feedback :issue_type])))
-            (is (= "The answer was wrong" (get-in feedback [:feedback :freeform_feedback]))))
-          (testing "feedback buttons were replaced with thanks"
-            (is (= 1 (count @update-calls)))
-            (let [blocks (:blocks (first @update-calls))]
-              (is (not-any? #(= (:block_id %) "metabot_feedback") blocks))
-              (is (some #(= "Thanks for your feedback!" (get-in % [:elements 0 :text])) blocks))))))))
+            (is (= "The answer was wrong" (get-in feedback [:feedback :freeform_feedback]))))))))
 
   (testing "modal submission with only freeform text submits"
     (let [harbormaster-calls (atom [])]
       (with-redefs [metabot-v3.feedback/submit-to-harbormaster! (fn [feedback]
                                                                   (swap! harbormaster-calls conj feedback)
-                                                                  true)
-                    slackbot.client/fetch-message               (constantly {:blocks []})
-                    slackbot.client/update-message               (constantly {:ok true})]
+                                                                  true)]
         (let [payload {:type "view_submission"
                        :view {:callback_id      "metabot_feedback_modal"
                               :private_metadata (json/encode {:conversation_id "conv-123"
@@ -1955,9 +1961,7 @@
     (let [harbormaster-calls (atom [])]
       (with-redefs [metabot-v3.feedback/submit-to-harbormaster! (fn [feedback]
                                                                   (swap! harbormaster-calls conj feedback)
-                                                                  true)
-                    slackbot.client/fetch-message               (constantly {:blocks []})
-                    slackbot.client/update-message               (constantly {:ok true})]
+                                                                  true)]
         (let [payload {:type "view_submission"
                        :view {:callback_id      "metabot_feedback_modal"
                               :private_metadata (json/encode {:conversation_id "conv-123"
@@ -1975,9 +1979,7 @@
     (let [harbormaster-calls (atom [])]
       (with-redefs [metabot-v3.feedback/submit-to-harbormaster! (fn [feedback]
                                                                   (swap! harbormaster-calls conj feedback)
-                                                                  true)
-                    slackbot.client/fetch-message               (constantly {:blocks []})
-                    slackbot.client/update-message               (constantly {:ok true})]
+                                                                  true)]
         (let [payload {:type "view_submission"
                        :view {:callback_id      "metabot_feedback_modal"
                               :private_metadata (json/encode {:conversation_id "conv-123"


### PR DESCRIPTION
The feedback acknowledgement flow was overwriting Slackbot messages in channels. I've stripped it out to simplify things — we can keep the feedback buttons in place and not try to overwrite them with a "Thanks..." message