### PR TITLE
Run Mage Tests on all PRs and fix module count

### DIFF
--- a/.github/workflows/mage.yml
+++ b/.github/workflows/mage.yml
@@ -2,9 +2,6 @@ name: Mage Tests
 
 on:
   pull_request:
-    paths:
-      - "mage/**"
-      - "bb.edn"
 
 jobs:
   # run mage tests even if the rest of be isnt needed

--- a/mage/src/mage/modules.clj
+++ b/mage/src/mage/modules.clj
@@ -115,6 +115,7 @@
      login-history
      notification
      permissions
+     premium-features
      public-sharing
      pulse
      remote-sync

--- a/mage/test/mage/modules_test.clj
+++ b/mage/test/mage/modules_test.clj
@@ -269,10 +269,20 @@
             If this test fails, you've likely connected a module to driver that shouldn't trigger driver tests.
             Add it to driver-affecting-overrides if it shouldn't trigger driver tests."
     (let [modules-triggering-drivers (modules-affecting-drivers)
-          ;; This count was 37 as of 2026-02-06. Update this number ONLY if you
-          ;; intentionally want more modules to trigger driver tests.
-          ;; 2-10-26 Bumping to 38 for sql-tools + sql-parsing
-          max-allowed-count 38]
+          ;; This is a ratchet: it prevents accidental expansion of which modules
+          ;; trigger driver tests. When a module transitively depends on driver code,
+          ;; changes to that module cause ALL driver tests to run in CI, which is
+          ;; expensive. If this test fails, either:
+          ;;   1. Your module legitimately affects drivers -- bump max-allowed-count
+          ;;   2. Your module is infrastructure/gating, not driver logic
+          ;;      -- add it to driver-affecting-overrides in mage.modules
+          ;;
+          ;; History:
+          ;; 2026-02-06 Initial count: 37
+          ;; 2026-02-10 Bumped to 38 for sql-tools + sql-parsing
+          ;; 2026-03-10 Bumped to 40 for lib-metric + metrics (Metrics Explorer #68961)
+          ;;            Added premium-features to driver-affecting-overrides (#69561)
+          max-allowed-count 40]
       (is (<= (count modules-triggering-drivers) max-allowed-count)
           (format "Too many modules trigger driver tests! Expected <= %d, got %d.
                    Modules triggering driver tests: %s


### PR DESCRIPTION
## Summary

The `module-graph-may-not-become-more-connected` ratchet test has been silently failing on master because the Mage Tests workflow only ran when `mage/**` or `bb.edn` files changed. PRs that alter module dependencies (in `.clj-kondo/config/modules/config.edn`) slipped through undetected.

Three new modules now trigger driver tests (count went from 38 to 41):
- **`lib-metric`** and **`metrics`** -- added by Metrics Explorer (#68961), I think they're legitimately query-related. 
    - Path to drivers in the module graph: `lib-metric -> metrics -> queries -> query-processor -> driver`
    
- **`premium-features`** -- pulled in because `enterprise/workspaces` added it as a dependency (#69561). This is infrastructure/gating, not driver logic, so it belongs in `driver-affecting-overrides`.

Changes:
- Remove `paths:` filter from `mage.yml` so the workflow runs on **all PRs**
- Add `premium-features` to `driver-affecting-overrides`
- Bump `max-allowed-count` from 38 to 40 (41 minus 1 for the override)

## Test plan
- [x] `./bin/mage -test` passes locally (51 tests, 493 assertions, 0 failures)
