### PR TITLE
measure table names in tree in v1 data model page

### DIFF
--- a/frontend/src/metabase/metadata/pages/DataModelV1/components/TablePicker/components/Results.tsx
+++ b/frontend/src/metabase/metadata/pages/DataModelV1/components/TablePicker/components/Results.tsx
@@ -7,8 +7,8 @@ import {
   useRef,
   useState,
 } from "react";
-import { Link } from "react-router";
 
+import { ForwardRefLink } from "metabase/common/components/Link";
 import * as Urls from "metabase/lib/urls";
 import { Box, Flex, Icon, Skeleton, rem } from "metabase/ui";
 
@@ -194,7 +194,7 @@ export function Results({
 
           return (
             <Flex
-              component={Link}
+              component={ForwardRefLink}
               key={key}
               aria-selected={isActive}
               align="center"
@@ -229,6 +229,7 @@ export function Results({
                 handleItemSelect();
               }}
               onFocus={() => onSelectedIndexChange?.(index)}
+              ref={virtual.measureElement}
             >
               <Flex align="center" mih={ITEM_MIN_HEIGHT} py="xs" w="100%">
                 <Flex align="flex-start" gap="xs" w="100%">


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #70093
### Description
Uses the measureElement function from `useVirtualizer` to handle dynamically sized items in the table. Previously, items that were not rendered at the beginning were not measures, and if the list was long enough, you could have overlap. Rerendering would fix the issue, but this change allows the virtualizer to handle differently sized items.

### How to verify

1. Set up some databases with really long names so that they will wrap in the tree
2. Go to the "Table Metadata" page in admin, and open a table so that the list needs to scroll
3. refresh the page and scroll down to the bottom.
4. before this change, there would be a high likely hook of elements overlapping. Now, everything should render as expected

### Demo

https://github.com/user-attachments/assets/f24b831b-3def-4585-a900-07620e16cb81

### Checklist
- [ ] ~Tests have been added/updated to cover changes in this PR~ I may be able to set up an e2e test for this if we think it's needed, but it's a very visual thing
