### PR TITLE
homepage redirect in useLayoutEffect

### DIFF
--- a/frontend/src/metabase/home/components/HomePage/HomePage.tsx
+++ b/frontend/src/metabase/home/components/HomePage/HomePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useLayoutEffect } from "react";
 import { replace } from "react-router-redux";
 import { t } from "ttag";
 
@@ -30,7 +30,9 @@ const useDashboardRedirect = () => {
   const hasDismissedToast = useSelector(getHasDismissedCustomHomePageToast);
   const dispatch = useDispatch();
 
-  useEffect(() => {
+  // This redirect must live inside a useLayoutEffect to prevent the browser from painting a frame of <HomeContent>
+  // before firing the redirect (metabase#69917)
+  useLayoutEffect(() => {
     if (dashboardId && !isLoading && !dashboard?.archived) {
       dispatch(
         replace({


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #69917
### Description
Puts the check of whether to redirect to a custom dashboard rather than a homepage in a `useLayoutEffect` so that the decision is make before the browser paints the screen. 

### How to verify
1. Set up the instance to display a custom dashboard and navigate to a random page
2. refresh the screen to clear any data cache in RTK
3. Click the logo in the app bar to navigate to the home page. You should not see the home page flash before being redirected (You may need to open up dev tools and slow down the CPU performance to ensure that there is no homepage rendered. This can be seen on stats


### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~ I'm not sure how we could effectively write a test for this. I did try to write a unit test to cover this, but jsdom batches events in a way that make distinguishing between useEffect and useLayoutEffect very difficult.
