### PR TITLE
Fix nested button DOM nesting in StepperWithCards

### DIFF
--- a/frontend/src/metabase/embedding/embedding-hub/components/StepperWithCards/StepperWithCards.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/StepperWithCards/StepperWithCards.tsx
@@ -97,7 +97,7 @@ export const StepperWithCards = ({ steps }: { steps: StepperStep[] }) => {
                 <Grid>
                   {step.cards.map((card) => {
                     const onClick =
-                      card.clickAction?.type === "click"
+                      card.clickAction?.type === "click" && !card.locked
                         ? card.clickAction.onClick
                         : undefined;
 
@@ -116,9 +116,8 @@ export const StepperWithCards = ({ steps }: { steps: StepperStep[] }) => {
                               [S.lockedStepCard]: card.locked,
                               [S.nextStepCard]: isNextCard,
                             })}
-                            component={onClick ? "button" : undefined}
                             onClick={onClick}
-                            disabled={card.locked}
+                            aria-disabled={card.locked}
                             data-testid={`step-card-${card.id}`}
                             data-next-step={isNextCard}
                           >

--- a/frontend/src/metabase/embedding/embedding-hub/components/StepperWithCards/StepperWithCards.unit.spec.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/StepperWithCards/StepperWithCards.unit.spec.tsx
@@ -134,7 +134,7 @@ describe("StepperWithCards", () => {
 
     // The locked card should be disabled
     const lockedCard = screen.getByTestId("step-card-2");
-    expect(lockedCard).toBeDisabled();
+    expect(lockedCard).toHaveAttribute("aria-disabled", "true");
 
     // Clicking the disabled card should not trigger the action
     await userEvent.click(lockedCard);
@@ -142,7 +142,7 @@ describe("StepperWithCards", () => {
 
     // The step should not be marked as done
     const allSteps = screen.getAllByRole("button");
-    expect(allSteps).toHaveLength(2);
+    expect(allSteps).toHaveLength(1);
     expect(allSteps[0]).toHaveAttribute("data-done", "false");
 
     // No steps should be marked as done


### PR DESCRIPTION
Closes [EMB-1420: Fix nested button warning in embedding setup guide](https://linear.app/metabase/issue/EMB-1420/fix-nested-button-warning-in-embedding-setup-guide)

Removes this log caused by cards being buttons that contain a buttojn 
<img width="2248" height="1344" alt="image" src="https://github.com/user-attachments/assets/dfef8bc4-0091-4cfe-90b4-4ca4ffae4338" />
