### PR TITLE
Fix pivot table drill through when binning a datetime by day

### DIFF
--- a/frontend/src/metabase/lib/data_grid.js
+++ b/frontend/src/metabase/lib/data_grid.js
@@ -26,7 +26,7 @@ export function multiLevelPivot(data, settings) {
     data.cols,
   );
 
-  const columns = Pivot.columns_without_pivot_group(data.cols);
+  const columns = data.cols.filter((col) => col.name !== "pivot-grouping");
 
   const {
     columns: columnIndexes,

--- a/frontend/src/metabase/lib/data_grid.js
+++ b/frontend/src/metabase/lib/data_grid.js
@@ -26,7 +26,7 @@ export function multiLevelPivot(data, settings) {
     data.cols,
   );
 
-  const columns = data.cols.filter((col) => col.name !== "pivot-grouping");
+  const columns = Pivot.columns_without_pivot_group(data.cols);
 
   const {
     columns: columnIndexes,

--- a/src/metabase/pivot/js.cljs
+++ b/src/metabase/pivot/js.cljs
@@ -2,6 +2,7 @@
   "Javascript-facing interface for pivot table postprocessing. Wraps functions in metabase.pivot.core."
   (:require
    [metabase.pivot.core :as pivot]
+   [metabase.util :as u]
    [metabase.util.performance :as perf]))
 
 (defn ^:export columns-without-pivot-group
@@ -9,7 +10,8 @@
   [cols]
   (let [cols (js->clj cols :keywordize-keys true)]
     (clj->js
-     (pivot/columns-without-pivot-group cols))))
+     (pivot/columns-without-pivot-group cols)
+     :keyword-fn u/qualified-name)))
 
 (defn ^:export split-pivot-data
   "Pulls apart different aggregations that were packed into one result set returned from the QP.

--- a/test/metabase/pivot/js_test.cljs
+++ b/test/metabase/pivot/js_test.cljs
@@ -1,0 +1,16 @@
+(ns metabase.pivot.js-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [metabase.pivot.js :as pivot.js]))
+
+(deftest ^:parallel columns-without-pivot-group-preserves-namespaced-keys-test
+  (testing "Namespaced keys like lib/breakout? survive the JS->CLJS->JS round-trip (#70358)"
+    (let [input    #js [#js {"name"          "CREATED_AT"
+                             "lib/breakout?" true}
+                        #js {"name" "pivot-grouping"}]
+          result   (pivot.js/columns-without-pivot-group input)
+          col      (first result)]
+      (is (= 1 (.-length result)))
+      (is (= "CREATED_AT" (unchecked-get col "name")))
+      (is (true? (unchecked-get col "lib/breakout?"))
+          "namespaced key lib/breakout? should be preserved through CLJS conversion"))))


### PR DESCRIPTION
Closes #70358

### Description

This fixes a bug where `Pivot.columns_without_pivot_group` was changing the "lib/breakout?" key to "breakout?" during clj->js conversion.

The changed key name introduced a bug where `breakout->filterable-column` was not correctly returning a column with effective-type "type/Datetime" (this was working fine for tables, but not for pivot tables) because `day-bucketed-breakout-column?` is looking for the keyword `:lib/breakout?`, not `breakout?`.

### How to verify

Follow #70358

### Demo

[Loom](https://www.loom.com/share/dccbec156e384ffd884bca86c66395e5)

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
