### PR TITLE
Add clickhouse setting to fix grouping by date32

### DIFF
--- a/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
+++ b/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
@@ -125,7 +125,10 @@
          :jdbc_schema_term               "schema"
          :max_open_connections           (or max-open-connections 100)
          ;; see also: https://clickhouse.com/docs/en/integrations/java#configuration
-         :custom_http_params             (cond-> "select_sequential_consistency=1"
+         ;; enable_extended_results_for_datetime_functions=1 to make toStartOfMonth, toStartOfYear, etc.
+         ;; work with Date32 values before 1970. See #68249 for mroe details.
+         :custom_http_params             (cond-> "select_sequential_consistency=1,
+                                                  enable_extended_results_for_datetime_functions=1"
                                            (not (str/blank? clickhouse-settings))
                                            (str "," clickhouse-settings))}
         (sql-jdbc.common/handle-additional-options details :separator-style :url))))

--- a/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
+++ b/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
@@ -126,7 +126,7 @@
          :max_open_connections           (or max-open-connections 100)
          ;; see also: https://clickhouse.com/docs/en/integrations/java#configuration
          ;; enable_extended_results_for_datetime_functions=1 to make toStartOfMonth, toStartOfYear, etc.
-         ;; work with Date32 values before 1970. See #68249 for mroe details.
+         ;; work with Date32 values before 1970. See #68249 for more details.
          :custom_http_params             (cond-> "select_sequential_consistency=1,
                                                   enable_extended_results_for_datetime_functions=1"
                                            (not (str/blank? clickhouse-settings))

--- a/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
+++ b/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
@@ -127,8 +127,7 @@
          ;; see also: https://clickhouse.com/docs/en/integrations/java#configuration
          ;; enable_extended_results_for_datetime_functions=1 to make toStartOfMonth, toStartOfYear, etc.
          ;; work with Date32 values before 1970. See #68249 for more details.
-         :custom_http_params             (cond-> "select_sequential_consistency=1,
-                                                  enable_extended_results_for_datetime_functions=1"
+         :custom_http_params             (cond-> "select_sequential_consistency=1,enable_extended_results_for_datetime_functions=1"
                                            (not (str/blank? clickhouse-settings))
                                            (str "," clickhouse-settings))}
         (sql-jdbc.common/handle-additional-options details :separator-style :url))))

--- a/modules/drivers/clickhouse/test/metabase/driver/clickhouse_test.clj
+++ b/modules/drivers/clickhouse/test/metabase/driver/clickhouse_test.clj
@@ -464,6 +464,30 @@
                        (qp/process-query)
                        (mt/rows))))))))))
 
+(mt/defdataset date32-dataset
+  [["date32_table"
+    [{:field-name "date", :base-type {:native "Date32"}}]
+    [["1969-12-29"]
+     ["1969-12-30"]
+     ["1969-12-31"]
+     ["1970-01-01"]
+     ["1970-01-02"]
+     ["2024-06-15"]]]])
+
+(deftest ^:parallel group-date32-values-before-1970-test
+  (mt/test-driver :clickhouse
+    (testing "grouping a Date32 column with values before 1970 by day should work (#68249)"
+      (mt/dataset date32-dataset
+        (let [mp (mt/metadata-provider)
+              query (-> (lib/query mp (lib.metadata/table mp (mt/id :date32_table)))
+                        (lib/breakout (lib/with-temporal-bucket (lib.metadata/field mp (mt/id :date32_table :date)) :month))
+                        (lib/aggregate (lib/count))
+                        (lib/order-by (lib.metadata/field mp (mt/id :date32_table :date)) :asc))]
+          (is (= [["1969-12-01T00:00:00Z" 3]
+                  ["1970-01-01T00:00:00Z" 2]
+                  ["2024-06-01T00:00:00Z" 1]]
+                 (mt/rows (qp/process-query query)))))))))
+
 ;; TODO (lbrdnk 2026-01-23): Excplicit exceptions from [[metabase.driver.util/parsed-query]] are shutdown
 ;;                           at the moment to avoid potential log flooding. We should revisit this during further
 ;;                           parsing work.

--- a/modules/drivers/clickhouse/test/metabase/driver/clickhouse_test.clj
+++ b/modules/drivers/clickhouse/test/metabase/driver/clickhouse_test.clj
@@ -61,7 +61,7 @@
              :user "bob"
              :password "qaz"
              :ssl true
-             :custom_http_params "select_sequential_consistency=1,max_threads=42,allow_experimental_analyzer=0"})
+             :custom_http_params "select_sequential_consistency=1,enable_extended_results_for_datetime_functions=1,max_threads=42,allow_experimental_analyzer=0"})
            (sql-jdbc.conn/connection-details->spec
             :clickhouse
             {:host "myclickhouse"

--- a/modules/drivers/clickhouse/test/metabase/test/data/clickhouse.clj
+++ b/modules/drivers/clickhouse/test/metabase/test/data/clickhouse.clj
@@ -56,7 +56,7 @@
    :max_open_connections           100
    :remember_last_set_roles        true
    :http_connection_provider       "HTTP_URL_CONNECTION"
-   :custom_http_params             "select_sequential_consistency=1"})
+   :custom_http_params             "select_sequential_consistency=1,enable_extended_results_for_datetime_functions=1"})
 
 (defmethod sql.tx/field-base-type->sql-type [:clickhouse :type/Boolean]         [_ _] "Boolean")
 (defmethod sql.tx/field-base-type->sql-type [:clickhouse :type/BigInteger]      [_ _] "Int64")


### PR DESCRIPTION
Close https://github.com/metabase/metabase/issues/68249

### Description

Adds `enable_extended_results_for_datetime_functions=1` to http params to make functions like `toStartOfDay` work with `Date32` values before 1970.

### How to verify

See original issue. It should work as expected now. 

### Demo

<img width="854" height="564" alt="Screenshot 2026-03-10 at 8 39 28 PM" src="https://github.com/user-attachments/assets/e32fffca-3da7-42fc-80d7-0dd4836abef0" />

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
