### PR TITLE
Log the migrations blocking the downgrade

### DIFF
--- a/src/metabase/app_db/liquibase.clj
+++ b/src/metabase/app_db/liquibase.clj
@@ -521,6 +521,15 @@
           changeset-id (last (map :id (jdbc/query {:connection conn} [changeset-query])))]
       (some-> changeset-id extract-numbers first))))
 
+(defn changesets-from-later-version
+  "Returns changeset IDs applied from versions later than `latest-available` up to `latest-applied`, ordered by execution date."
+  [conn ^Database database latest-available latest-applied]
+  (let [table    (.getDatabaseChangeLogTableName database)
+        versions (range (inc latest-available) (inc latest-applied))
+        clauses  (str/join " OR " (map #(format "id LIKE 'v%d.%%'" %) versions))
+        query    (format "SELECT id FROM %s WHERE %s ORDER BY dateexecuted ASC" table clauses)]
+    (mapv :id (jdbc/query {:connection conn} [query]))))
+
 (defn rollback-major-version!
   "Roll back migrations later than given Metabase major version. If force is true, it will ignore any checks and always
   roll back"

--- a/src/metabase/app_db/setup.clj
+++ b/src/metabase/app_db/setup.clj
@@ -226,7 +226,8 @@
         ;; `latest-applied` will be `nil` for fresh installs
         (when (and latest-applied (< latest-available latest-applied))
           (let [later-changesets (liquibase/changesets-from-later-version conn (.getDatabase liquibase) latest-available latest-applied)]
-            (log/warn (u/format-color 'red "The following changesets from a later version were found (in execution order):"))
+            (log/warn (u/format-color 'red "Database has migrations from v%d but this binary only knows up to v%d:"
+                                      latest-applied latest-available))
             (doseq [cs later-changesets]
               (log/warn (u/format-color 'red "  - %s" cs))))
           (throw (ex-info

--- a/src/metabase/app_db/setup.clj
+++ b/src/metabase/app_db/setup.clj
@@ -225,6 +225,10 @@
             latest-applied   (liquibase/latest-applied-major-version conn (.getDatabase liquibase))]
         ;; `latest-applied` will be `nil` for fresh installs
         (when (and latest-applied (< latest-available latest-applied))
+          (let [later-changesets (liquibase/changesets-from-later-version conn (.getDatabase liquibase) latest-available latest-applied)]
+            (log/warn (u/format-color 'red "The following changesets from a later version were found (in execution order):"))
+            (doseq [cs later-changesets]
+              (log/warn (u/format-color 'red "  - %s" cs))))
           (throw (ex-info
                   (str (u/format-color 'red (trs "ERROR: Downgrade detected."))
                        "\n\n"

--- a/test/metabase/app_db/setup_test.clj
+++ b/test/metabase/app_db/setup_test.clj
@@ -188,6 +188,32 @@
              Exception #"You must run `java --add-opens java.base/java.nio=ALL-UNNAMED -jar metabase.jar migrate down` from version 46."
              (#'mdb.setup/error-if-downgrade-required! (mdb.connection/data-source))))))))
 
+(deftest changesets-from-later-version-test
+  (mt/test-drivers #{:h2 :mysql :postgres}
+    (mt/with-temp-empty-app-db [conn driver/*driver*]
+      ;; Run all real migrations first so the changelog table exists
+      (mdb.setup/setup-db! driver/*driver* (mdb.connection/data-source) true false)
+      (liquibase/with-liquibase [liquibase conn]
+        (let [table    (liquibase/changelog-table-name liquibase)
+              db-conn  {:connection conn}
+              fake-ids ["v998.00-001" "v998.00-002" "v999.00-001"]]
+          ;; Insert fake changelog entries for versions 998 and 999
+          (doseq [[i id] (map-indexed vector fake-ids)]
+            (jdbc/execute! db-conn
+                           [(format "INSERT INTO %s (id, author, filename, dateexecuted, orderexecuted, exectype, md5sum)
+                                     VALUES (?, 'test', 'test.yaml', CURRENT_TIMESTAMP, ?, 'EXECUTED', 'fake')"
+                                    table)
+                            id (+ 99990 i)]))
+          (try
+            (let [later (liquibase/changesets-from-later-version conn (.getDatabase liquibase) 997 999)]
+              (testing "returns exactly the fake changeset IDs in execution order"
+                (is (= fake-ids later))))
+            (finally
+              ;; Clean up fake rows
+              (doseq [id fake-ids]
+                (jdbc/execute! db-conn
+                               [(format "DELETE FROM %s WHERE id = ?" table) id])))))))))
+
 ;; `delete!` below is ok in a parallel test since it's not actually executing anything
 #_{:clj-kondo/ignore [:metabase/validate-deftest]}
 (deftest ^:parallel build-query-dont-add-delete-from-when-query-contains-delete-test


### PR DESCRIPTION
Will help diagnose issues and support users easier when we run into problems like [this](https://github.com/metabase/metabase/actions/runs/22948056234/job/66605401330?pr=70063)
