### PR TITLE
fix expected status of bigquery tests after #62351

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -1290,7 +1290,8 @@
             (let [query  {:database (mt/id)
                           :type "native"
                           :native {:query (format "select * from `%s.orders` limit 100" (get-test-data-name))}}
-                  result (mt/user-http-request :crowberto :post 202 "dataset" query)]
+                  expected-status (if (and (= :exception stop-tag) (= :initial-query tag)) 400 500)
+                  result (mt/user-http-request :crowberto :post expected-status "dataset" query)]
               (is (= "failed" (:status result)))
               (is (= (if (= :cancelled stop-tag) "Query cancelled" "My Exception")
                      (:error result)))))))


### PR DESCRIPTION
Blocking https://github.com/metabase/metabase/pull/69752, https://github.com/metabase/metabase/pull/70197 and https://github.com/metabase/metabase/pull/70198