### PR TITLE
GDGT-1919: Custom visualization plugin manager

### DIFF
--- a/frontend/src/metabase-types/api/custom-viz-plugin.ts
+++ b/frontend/src/metabase-types/api/custom-viz-plugin.ts
@@ -24,8 +24,9 @@ export interface CustomVizPluginRuntime {
 export interface CreateCustomVizPluginRequest {
   repo_url: string;
   display_name: string;
+  icon?: string | null;
   access_token?: string;
-  pinned_version?: string;
+  pinned_version?: string | null;
 }
 
 export interface UpdateCustomVizPluginRequest {

--- a/frontend/src/metabase-types/api/custom-viz-plugin.ts
+++ b/frontend/src/metabase-types/api/custom-viz-plugin.ts
@@ -17,6 +17,7 @@ export interface CustomVizPluginRuntime {
   id: number;
   identifier: string;
   display_name: string;
+  icon: string | null;
   bundle_url: string;
 }
 

--- a/frontend/src/metabase-types/api/custom-viz-plugin.ts
+++ b/frontend/src/metabase-types/api/custom-viz-plugin.ts
@@ -1,0 +1,19 @@
+export interface CustomVizPlugin {
+  id: number;
+  repo_url: string;
+  display_name: string;
+  identifier: string;
+  status: "pending" | "active" | "error";
+  error_message: string | null;
+  pinned_version: string | null;
+  resolved_commit: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CreateCustomVizPluginRequest {
+  repo_url: string;
+  display_name: string;
+  access_token?: string;
+  pinned_version?: string;
+}

--- a/frontend/src/metabase-types/api/custom-viz-plugin.ts
+++ b/frontend/src/metabase-types/api/custom-viz-plugin.ts
@@ -4,6 +4,8 @@ export interface CustomVizPlugin {
   display_name: string;
   identifier: string;
   status: "pending" | "active" | "error";
+  enabled: boolean;
+  icon: string | null;
   error_message: string | null;
   pinned_version: string | null;
   resolved_commit: string | null;
@@ -11,9 +13,25 @@ export interface CustomVizPlugin {
   updated_at: string;
 }
 
+export interface CustomVizPluginRuntime {
+  id: number;
+  identifier: string;
+  display_name: string;
+  bundle_url: string;
+}
+
 export interface CreateCustomVizPluginRequest {
   repo_url: string;
   display_name: string;
+  access_token?: string;
+  pinned_version?: string;
+}
+
+export interface UpdateCustomVizPluginRequest {
+  id: number;
+  enabled?: boolean;
+  display_name?: string;
+  icon?: string | null;
   access_token?: string;
   pinned_version?: string;
 }

--- a/frontend/src/metabase-types/api/index.ts
+++ b/frontend/src/metabase-types/api/index.ts
@@ -14,6 +14,7 @@ export * from "./cloud-add-ons";
 export * from "./collection";
 export * from "./comments";
 export * from "./content-translation";
+export * from "./custom-viz-plugin";
 export * from "./dashboard";
 export * from "./database";
 export * from "./dataset";

--- a/frontend/src/metabase/admin/settings/components/SettingsNav/SettingsNav.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsNav/SettingsNav.tsx
@@ -65,6 +65,11 @@ export function SettingsNav() {
         label={t`Localization`}
         icon="globe"
       />
+      <SettingsNavItem
+        path="custom-viz-plugins"
+        label={t`Custom viz plugins`}
+        icon="embed"
+      />
       <SettingsNavItem path="maps" label={t`Maps`} icon="pinmap" />
       <SettingsNavItem
         path={!hasWhitelabel ? "whitelabel" : undefined}

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/CustomVizPluginsSettingsPage.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/CustomVizPluginsSettingsPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { t } from "ttag";
 
 import {
@@ -9,6 +9,8 @@ import {
   useCreateCustomVizPluginMutation,
   useDeleteCustomVizPluginMutation,
   useListAllCustomVizPluginsQuery,
+  useRefreshCustomVizPluginMutation,
+  useUpdateCustomVizPluginMutation,
 } from "metabase/api";
 import {
   Form,
@@ -18,102 +20,129 @@ import {
   FormTextInput,
 } from "metabase/forms";
 import {
-  Badge,
+  ActionIcon,
   Box,
   Button,
   Flex,
   Group,
   Icon,
+  type IconName,
   Loader,
+  Menu,
+  Select,
+  type SelectOption,
   Stack,
+  Switch,
   Text,
 } from "metabase/ui";
+import { iconNames } from "metabase/ui/components/icons/Icon/icons";
 import type { CustomVizPlugin } from "metabase-types/api";
 
-function PluginStatusBadge({ status }: { status: CustomVizPlugin["status"] }) {
-  const color =
-    status === "active" ? "success" : status === "error" ? "error" : "warning";
-  return <Badge color={color}>{status}</Badge>;
-}
+const DEFAULT_ICON: IconName = "area";
 
-function PluginListItem({
-  plugin,
-  onDelete,
-}: {
-  plugin: CustomVizPlugin;
-  onDelete: (id: number) => void;
-}) {
-  const [isDeleting, setIsDeleting] = useState(false);
+const ICON_OPTIONS: SelectOption[] = iconNames.map((name) => ({
+  value: name,
+  label: name,
+  icon: name as IconName,
+}));
 
-  const handleDelete = useCallback(async () => {
-    setIsDeleting(true);
-    try {
-      await onDelete(plugin.id);
-    } finally {
-      setIsDeleting(false);
-    }
-  }, [plugin.id, onDelete]);
-
+function IconPreview({ iconName }: { iconName: IconName }) {
   return (
-    <Flex
-      justify="space-between"
-      align="center"
-      p="md"
-      style={{
-        border: "1px solid var(--mb-color-border)",
-        borderRadius: "var(--mb-radius-md)",
-      }}
+    <ActionIcon
+      w="3.125rem"
+      h="3.125rem"
+      radius="xl"
+      color="brand"
+      variant="outline"
+      style={{ border: "1px solid var(--mb-color-border)" }}
     >
-      <Stack gap="xs">
-        <Group gap="sm">
-          <Text fw={700}>{plugin.display_name}</Text>
-          <PluginStatusBadge status={plugin.status} />
-        </Group>
-        <Text size="sm" c="text-tertiary">
-          {plugin.repo_url}
-        </Text>
-        {plugin.error_message && (
-          <Text size="sm" c="error">
-            {plugin.error_message}
-          </Text>
-        )}
-        {plugin.resolved_commit && (
-          <Text size="sm" c="text-tertiary">
-            {t`Commit`}: {plugin.resolved_commit.slice(0, 8)}
-            {plugin.pinned_version && ` (${plugin.pinned_version})`}
-          </Text>
-        )}
-      </Stack>
-      <Button
-        variant="subtle"
-        color="error"
-        loading={isDeleting}
-        onClick={handleDelete}
-        leftSection={<Icon name="trash" />}
-      >
-        {t`Remove`}
-      </Button>
-    </Flex>
+      <Icon name={iconName} c="brand" size={20} />
+    </ActionIcon>
   );
 }
 
-function AddPluginForm({ onClose }: { onClose: () => void }) {
+function IconPickerField({
+  value,
+  onChange,
+}: {
+  value: IconName;
+  onChange: (icon: IconName) => void;
+}) {
+  return (
+    <Box>
+      <Text fw={700} size="sm" mb={4}>
+        {t`Icon (optional)`}
+      </Text>
+      <Group gap="md" align="center">
+        <Box style={{ flex: 1 }}>
+          <Select
+            data={ICON_OPTIONS}
+            value={value}
+            onChange={(val) => onChange((val as IconName) ?? DEFAULT_ICON)}
+            searchable
+            clearable
+            placeholder={t`Search icons...`}
+          />
+        </Box>
+        <IconPreview iconName={value} />
+      </Group>
+    </Box>
+  );
+}
+
+function PluginForm({
+  plugin,
+  onClose,
+}: {
+  plugin?: CustomVizPlugin;
+  onClose: () => void;
+}) {
   const [createPlugin] = useCreateCustomVizPluginMutation();
+  const [updatePlugin] = useUpdateCustomVizPluginMutation();
+  const isEdit = Boolean(plugin);
+
+  const [selectedIcon, setSelectedIcon] = useState<IconName>(
+    (plugin?.icon as IconName) ?? DEFAULT_ICON,
+  );
+
+  const initialValues = useMemo(
+    () => ({
+      repo_url: plugin?.repo_url ?? "",
+      display_name: plugin?.display_name ?? "",
+      access_token: "",
+      pinned_version: plugin?.pinned_version ?? "",
+    }),
+    [plugin],
+  );
 
   const handleSubmit = useCallback(
     async (values: {
       repo_url: string;
       display_name: string;
       access_token: string;
+      pinned_version: string;
     }) => {
-      await createPlugin({
-        repo_url: values.repo_url,
-        display_name: values.display_name,
-        access_token: values.access_token || undefined,
-      }).unwrap();
+      const icon = selectedIcon === DEFAULT_ICON ? null : selectedIcon;
+
+      if (isEdit && plugin) {
+        await updatePlugin({
+          id: plugin.id,
+          display_name: values.display_name,
+          icon,
+          access_token: values.access_token || undefined,
+          pinned_version: values.pinned_version || undefined,
+        }).unwrap();
+      } else {
+        await createPlugin({
+          repo_url: values.repo_url,
+          display_name: values.display_name,
+          access_token: values.access_token || undefined,
+          pinned_version: values.pinned_version || undefined,
+        }).unwrap();
+      }
       onClose();
     },
-    [createPlugin, onClose],
+    [createPlugin, updatePlugin, plugin, isEdit, selectedIcon, onClose],
   );
 
   return (
@@ -124,39 +153,62 @@ function AddPluginForm({ onClose }: { onClose: () => void }) {
         borderRadius: "var(--mb-radius-md)",
       }}
     >
-      <FormProvider
-        initialValues={{ repo_url: "", display_name: "", access_token: "" }}
-        onSubmit={handleSubmit}
-      >
+      <FormProvider initialValues={initialValues} onSubmit={handleSubmit}>
         {({ dirty }) => (
           <Form>
-            <Stack gap="md">
-              <FormTextInput
-                name="repo_url"
-                label={t`Repository URL`}
-                placeholder="https://github.com/user/custom-viz-plugin"
-                autoFocus
-              />
-              <FormTextInput
-                name="display_name"
-                label={t`Display name`}
-                placeholder={t`My Custom Visualization`}
-              />
-              <FormTextInput
-                name="access_token"
-                label={t`Access token (optional)`}
-                description={
-                  <Text c="text-tertiary" size="sm" component="span">
-                    {t`Personal access token for private repositories`}
-                  </Text>
-                }
-                type="password"
-              />
+            <Stack gap="lg">
+              <Stack gap="md">
+                <Text fw={700}>{t`Git settings`}</Text>
+                <FormTextInput
+                  name="repo_url"
+                  label={t`Repository URL`}
+                  placeholder="https://github.com/user/custom-viz-plugin"
+                  disabled={isEdit}
+                  autoFocus={!isEdit}
+                />
+                <FormTextInput
+                  name="access_token"
+                  label={t`Access token (optional)`}
+                  description={
+                    <Text c="text-tertiary" size="sm" component="span">
+                      {t`Personal access token for private repositories`}
+                    </Text>
+                  }
+                  type="password"
+                />
+                <FormTextInput
+                  name="pinned_version"
+                  label={t`Pinned version (optional)`}
+                  description={
+                    <Text c="text-tertiary" size="sm" component="span">
+                      {t`Branch, tag, or commit SHA to pin to`}
+                    </Text>
+                  }
+                  placeholder="main"
+                />
+              </Stack>
+              <Stack gap="md">
+                <Text fw={700}>{t`Customization`}</Text>
+                <FormTextInput
+                  name="display_name"
+                  label={t`Display name`}
+                  placeholder={t`My Custom Visualization`}
+                  autoFocus={isEdit}
+                />
+                <IconPickerField
+                  value={selectedIcon}
+                  onChange={setSelectedIcon}
+                />
+              </Stack>
               <FormErrorMessage />
               <Group gap="sm">
                 <FormSubmitButton
-                  label={t`Add plugin`}
-                  disabled={!dirty}
+                  label={isEdit ? t`Update plugin` : t`Add plugin`}
+                  disabled={
+                    !dirty &&
+                    selectedIcon ===
+                      ((plugin?.icon as IconName) ?? DEFAULT_ICON)
+                  }
                   variant="filled"
                 />
                 <Button variant="subtle" onClick={onClose}>
@@ -171,10 +223,126 @@ function AddPluginForm({ onClose }: { onClose: () => void }) {
   );
 }
 
+function PluginListItem({
+  plugin,
+  onDelete,
+  onEdit,
+}: {
+  plugin: CustomVizPlugin;
+  onDelete: (id: number) => void;
+  onEdit: (plugin: CustomVizPlugin) => void;
+}) {
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [updatePlugin] = useUpdateCustomVizPluginMutation();
+  const [refreshPlugin, { isLoading: isRefreshing }] =
+    useRefreshCustomVizPluginMutation();
+
+  const handleDelete = useCallback(async () => {
+    setIsDeleting(true);
+    try {
+      await onDelete(plugin.id);
+    } finally {
+      setIsDeleting(false);
+    }
+  }, [plugin.id, onDelete]);
+
+  const handleToggleEnabled = useCallback(async () => {
+    await updatePlugin({ id: plugin.id, enabled: !plugin.enabled });
+  }, [plugin.id, plugin.enabled, updatePlugin]);
+
+  const handleRefresh = useCallback(async () => {
+    await refreshPlugin(plugin.id);
+  }, [plugin.id, refreshPlugin]);
+
+  return (
+    <Flex
+      justify="space-between"
+      align="flex-start"
+      p="md"
+      style={{
+        border: "1px solid var(--mb-color-border)",
+        borderRadius: "var(--mb-radius-md)",
+      }}
+    >
+      <Group gap="md" align="flex-start">
+        <IconPreview iconName={(plugin.icon as IconName) ?? DEFAULT_ICON} />
+        <Stack gap="xs">
+          <Text fw={700}>{plugin.display_name}</Text>
+          <Text
+            component="a"
+            href={plugin.repo_url}
+            target="_blank"
+            rel="noopener noreferrer"
+            size="sm"
+            c="text-tertiary"
+            td="underline"
+          >
+            {plugin.repo_url}
+          </Text>
+          {plugin.error_message && (
+            <Text size="sm" c="error">
+              {plugin.error_message}
+            </Text>
+          )}
+          {plugin.resolved_commit && (
+            <Text size="sm" c="text-tertiary">
+              {t`Commit`}: {plugin.resolved_commit.slice(0, 8)}
+              {plugin.pinned_version && ` (${plugin.pinned_version})`}
+            </Text>
+          )}
+        </Stack>
+      </Group>
+      <Group gap="sm">
+        <Switch
+          checked={plugin.enabled}
+          onChange={handleToggleEnabled}
+          label={plugin.enabled ? t`Enabled` : t`Disabled`}
+          size="sm"
+        />
+        <Menu>
+          <Menu.Target>
+            <Button
+              variant="subtle"
+              p="xs"
+              loading={isRefreshing || isDeleting}
+            >
+              <Icon name="ellipsis" />
+            </Button>
+          </Menu.Target>
+          <Menu.Dropdown>
+            <Menu.Item
+              leftSection={<Icon name="pencil" />}
+              onClick={() => onEdit(plugin)}
+            >
+              {t`Edit`}
+            </Menu.Item>
+            <Menu.Item
+              leftSection={<Icon name="refresh" />}
+              onClick={handleRefresh}
+            >
+              {t`Refetch`}
+            </Menu.Item>
+            <Menu.Item
+              leftSection={<Icon name="trash" />}
+              color="error"
+              onClick={handleDelete}
+            >
+              {t`Remove`}
+            </Menu.Item>
+          </Menu.Dropdown>
+        </Menu>
+      </Group>
+    </Flex>
+  );
+}
+
 export function CustomVizPluginsSettingsPage() {
   const { data: plugins, isLoading } = useListAllCustomVizPluginsQuery();
   const [deletePlugin] = useDeleteCustomVizPluginMutation();
   const [showAddForm, setShowAddForm] = useState(false);
+  const [editingPlugin, setEditingPlugin] = useState<CustomVizPlugin | null>(
+    null,
+  );
 
   const handleDelete = useCallback(
     async (id: number) => {
@@ -183,6 +351,16 @@ export function CustomVizPluginsSettingsPage() {
     [deletePlugin],
   );
 
+  const handleEdit = useCallback((plugin: CustomVizPlugin) => {
+    setShowAddForm(false);
+    setEditingPlugin(plugin);
+  }, []);
+
+  const handleCloseForm = useCallback(() => {
+    setShowAddForm(false);
+    setEditingPlugin(null);
+  }, []);
+
   return (
     <SettingsPageWrapper
       title={t`Custom visualization plugins`}
@@ -190,7 +368,7 @@ export function CustomVizPluginsSettingsPage() {
     >
       <SettingsSection>
         <Stack gap="md">
-          {!showAddForm && (
+          {!showAddForm && !editingPlugin && (
             <Box>
               <Button
                 variant="filled"
@@ -202,8 +380,10 @@ export function CustomVizPluginsSettingsPage() {
             </Box>
           )}
 
-          {showAddForm && (
-            <AddPluginForm onClose={() => setShowAddForm(false)} />
+          {showAddForm && <PluginForm onClose={handleCloseForm} />}
+
+          {editingPlugin && (
+            <PluginForm plugin={editingPlugin} onClose={handleCloseForm} />
           )}
 
           {isLoading && (
@@ -216,13 +396,16 @@ export function CustomVizPluginsSettingsPage() {
             <Text c="text-tertiary">{t`No plugins registered yet.`}</Text>
           )}
 
-          {plugins?.map(plugin => (
-            <PluginListItem
-              key={plugin.id}
-              plugin={plugin}
-              onDelete={handleDelete}
-            />
-          ))}
+          {plugins
+            ?.filter((plugin) => plugin.id !== editingPlugin?.id)
+            .map((plugin) => (
+              <PluginListItem
+                key={plugin.id}
+                plugin={plugin}
+                onDelete={handleDelete}
+                onEdit={handleEdit}
+              />
+            ))}
         </Stack>
       </SettingsSection>
     </SettingsPageWrapper>

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/CustomVizPluginsSettingsPage.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/CustomVizPluginsSettingsPage.tsx
@@ -130,14 +130,14 @@ function PluginForm({
           display_name: values.display_name,
           icon,
           access_token: values.access_token || undefined,
-          pinned_version: values.pinned_version || undefined,
+          pinned_version: values.pinned_version || null,
         }).unwrap();
       } else {
         await createPlugin({
           repo_url: values.repo_url,
           display_name: values.display_name,
           access_token: values.access_token || undefined,
-          pinned_version: values.pinned_version || undefined,
+          pinned_version: values.pinned_version || null,
         }).unwrap();
       }
       onClose();

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/CustomVizPluginsSettingsPage.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/CustomVizPluginsSettingsPage.tsx
@@ -1,0 +1,230 @@
+import { useCallback, useState } from "react";
+import { t } from "ttag";
+
+import {
+  SettingsPageWrapper,
+  SettingsSection,
+} from "metabase/admin/components/SettingsSection";
+import {
+  useCreateCustomVizPluginMutation,
+  useDeleteCustomVizPluginMutation,
+  useListAllCustomVizPluginsQuery,
+} from "metabase/api";
+import {
+  Form,
+  FormErrorMessage,
+  FormProvider,
+  FormSubmitButton,
+  FormTextInput,
+} from "metabase/forms";
+import {
+  Badge,
+  Box,
+  Button,
+  Flex,
+  Group,
+  Icon,
+  Loader,
+  Stack,
+  Text,
+} from "metabase/ui";
+import type { CustomVizPlugin } from "metabase-types/api";
+
+function PluginStatusBadge({ status }: { status: CustomVizPlugin["status"] }) {
+  const color =
+    status === "active" ? "success" : status === "error" ? "error" : "warning";
+  return <Badge color={color}>{status}</Badge>;
+}
+
+function PluginListItem({
+  plugin,
+  onDelete,
+}: {
+  plugin: CustomVizPlugin;
+  onDelete: (id: number) => void;
+}) {
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const handleDelete = useCallback(async () => {
+    setIsDeleting(true);
+    try {
+      await onDelete(plugin.id);
+    } finally {
+      setIsDeleting(false);
+    }
+  }, [plugin.id, onDelete]);
+
+  return (
+    <Flex
+      justify="space-between"
+      align="center"
+      p="md"
+      style={{
+        border: "1px solid var(--mb-color-border)",
+        borderRadius: "var(--mb-radius-md)",
+      }}
+    >
+      <Stack gap="xs">
+        <Group gap="sm">
+          <Text fw={700}>{plugin.display_name}</Text>
+          <PluginStatusBadge status={plugin.status} />
+        </Group>
+        <Text size="sm" c="text-tertiary">
+          {plugin.repo_url}
+        </Text>
+        {plugin.error_message && (
+          <Text size="sm" c="error">
+            {plugin.error_message}
+          </Text>
+        )}
+        {plugin.resolved_commit && (
+          <Text size="sm" c="text-tertiary">
+            {t`Commit`}: {plugin.resolved_commit.slice(0, 8)}
+            {plugin.pinned_version && ` (${plugin.pinned_version})`}
+          </Text>
+        )}
+      </Stack>
+      <Button
+        variant="subtle"
+        color="error"
+        loading={isDeleting}
+        onClick={handleDelete}
+        leftSection={<Icon name="trash" />}
+      >
+        {t`Remove`}
+      </Button>
+    </Flex>
+  );
+}
+
+function AddPluginForm({ onClose }: { onClose: () => void }) {
+  const [createPlugin] = useCreateCustomVizPluginMutation();
+
+  const handleSubmit = useCallback(
+    async (values: {
+      repo_url: string;
+      display_name: string;
+      access_token: string;
+    }) => {
+      await createPlugin({
+        repo_url: values.repo_url,
+        display_name: values.display_name,
+        access_token: values.access_token || undefined,
+      }).unwrap();
+      onClose();
+    },
+    [createPlugin, onClose],
+  );
+
+  return (
+    <Box
+      p="lg"
+      style={{
+        border: "1px solid var(--mb-color-border)",
+        borderRadius: "var(--mb-radius-md)",
+      }}
+    >
+      <FormProvider
+        initialValues={{ repo_url: "", display_name: "", access_token: "" }}
+        onSubmit={handleSubmit}
+      >
+        {({ dirty }) => (
+          <Form>
+            <Stack gap="md">
+              <FormTextInput
+                name="repo_url"
+                label={t`Repository URL`}
+                placeholder="https://github.com/user/custom-viz-plugin"
+                autoFocus
+              />
+              <FormTextInput
+                name="display_name"
+                label={t`Display name`}
+                placeholder={t`My Custom Visualization`}
+              />
+              <FormTextInput
+                name="access_token"
+                label={t`Access token (optional)`}
+                description={
+                  <Text c="text-tertiary" size="sm" component="span">
+                    {t`Personal access token for private repositories`}
+                  </Text>
+                }
+                type="password"
+              />
+              <FormErrorMessage />
+              <Group gap="sm">
+                <FormSubmitButton
+                  label={t`Add plugin`}
+                  disabled={!dirty}
+                  variant="filled"
+                />
+                <Button variant="subtle" onClick={onClose}>
+                  {t`Cancel`}
+                </Button>
+              </Group>
+            </Stack>
+          </Form>
+        )}
+      </FormProvider>
+    </Box>
+  );
+}
+
+export function CustomVizPluginsSettingsPage() {
+  const { data: plugins, isLoading } = useListAllCustomVizPluginsQuery();
+  const [deletePlugin] = useDeleteCustomVizPluginMutation();
+  const [showAddForm, setShowAddForm] = useState(false);
+
+  const handleDelete = useCallback(
+    async (id: number) => {
+      await deletePlugin(id).unwrap();
+    },
+    [deletePlugin],
+  );
+
+  return (
+    <SettingsPageWrapper
+      title={t`Custom visualization plugins`}
+      description={t`Register Git repositories containing custom visualization bundles. Plugins provide additional chart types for your questions and dashboards.`}
+    >
+      <SettingsSection>
+        <Stack gap="md">
+          {!showAddForm && (
+            <Box>
+              <Button
+                variant="filled"
+                leftSection={<Icon name="add" />}
+                onClick={() => setShowAddForm(true)}
+              >
+                {t`Add plugin`}
+              </Button>
+            </Box>
+          )}
+
+          {showAddForm && (
+            <AddPluginForm onClose={() => setShowAddForm(false)} />
+          )}
+
+          {isLoading && (
+            <Flex justify="center" p="xl">
+              <Loader />
+            </Flex>
+          )}
+
+          {plugins && plugins.length === 0 && !isLoading && (
+            <Text c="text-tertiary">{t`No plugins registered yet.`}</Text>
+          )}
+
+          {plugins?.map(plugin => (
+            <PluginListItem
+              key={plugin.id}
+              plugin={plugin}
+              onDelete={handleDelete}
+            />
+          ))}
+        </Stack>
+      </SettingsSection>
+    </SettingsPageWrapper>
+  );
+}

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/CustomVizPluginsSettingsPage.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/CustomVizPluginsSettingsPage.tsx
@@ -136,6 +136,7 @@ function PluginForm({
         await createPlugin({
           repo_url: values.repo_url,
           display_name: values.display_name,
+          icon,
           access_token: values.access_token || undefined,
           pinned_version: values.pinned_version || null,
         }).unwrap();

--- a/frontend/src/metabase/admin/settingsRoutes.tsx
+++ b/frontend/src/metabase/admin/settingsRoutes.tsx
@@ -14,6 +14,7 @@ import { SettingsNav } from "./settings/components/SettingsNav";
 import { AppearanceSettingsPage } from "./settings/components/SettingsPages/AppearanceSettingsPage";
 import { AuthenticationSettingsPage } from "./settings/components/SettingsPages/AuthenticationSettingsPage";
 import { CloudSettingsPage } from "./settings/components/SettingsPages/CloudSettingsPage";
+import { CustomVizPluginsSettingsPage } from "./settings/components/SettingsPages/CustomVizPluginsSettingsPage";
 import { EmailSettingsPage } from "./settings/components/SettingsPages/EmailSettingsPage";
 import { GeneralSettingsPage } from "./settings/components/SettingsPages/GeneralSettingsPage";
 import { LicenseSettingsPage } from "./settings/components/SettingsPages/LicenseSettingsPage";
@@ -69,6 +70,10 @@ export const getSettingsRoutes = () => (
     />
     <Route path="maps" component={MapsSettingsPage} />
     <Route path="localization" component={LocalizationSettingsPage} />
+    <Route
+      path="custom-viz-plugins"
+      component={CustomVizPluginsSettingsPage}
+    />
     <Route path="uploads" component={UploadSettingsPage} />
     <Route
       path="python-runner"

--- a/frontend/src/metabase/api/custom-viz-plugin.ts
+++ b/frontend/src/metabase/api/custom-viz-plugin.ts
@@ -1,21 +1,23 @@
 import type {
   CreateCustomVizPluginRequest,
   CustomVizPlugin,
+  CustomVizPluginRuntime,
+  UpdateCustomVizPluginRequest,
 } from "metabase-types/api";
 
 import { Api } from "./api";
 import { idTag, invalidateTags, listTag } from "./tags";
 
 export const customVizPluginApi = Api.injectEndpoints({
-  endpoints: builder => ({
-    listCustomVizPlugins: builder.query<CustomVizPlugin[], void>({
+  endpoints: (builder) => ({
+    listCustomVizPlugins: builder.query<CustomVizPluginRuntime[], void>({
       query: () => ({
         method: "GET",
         url: "/api/custom-viz-plugin/list",
       }),
       providesTags: (plugins = []) => [
         listTag("custom-viz-plugin"),
-        ...plugins.map(plugin => idTag("custom-viz-plugin", plugin.id)),
+        ...plugins.map((plugin) => idTag("custom-viz-plugin", plugin.id)),
       ],
     }),
     listAllCustomVizPlugins: builder.query<CustomVizPlugin[], void>({
@@ -25,14 +27,14 @@ export const customVizPluginApi = Api.injectEndpoints({
       }),
       providesTags: (plugins = []) => [
         listTag("custom-viz-plugin"),
-        ...plugins.map(plugin => idTag("custom-viz-plugin", plugin.id)),
+        ...plugins.map((plugin) => idTag("custom-viz-plugin", plugin.id)),
       ],
     }),
     createCustomVizPlugin: builder.mutation<
       CustomVizPlugin,
       CreateCustomVizPluginRequest
     >({
-      query: body => ({
+      query: (body) => ({
         method: "POST",
         url: "/api/custom-viz-plugin",
         body,
@@ -41,15 +43,30 @@ export const customVizPluginApi = Api.injectEndpoints({
         invalidateTags(error, [listTag("custom-viz-plugin")]),
     }),
     deleteCustomVizPlugin: builder.mutation<void, number>({
-      query: id => ({
+      query: (id) => ({
         method: "DELETE",
         url: `/api/custom-viz-plugin/${id}`,
       }),
       invalidatesTags: (_, error) =>
         invalidateTags(error, [listTag("custom-viz-plugin")]),
     }),
+    updateCustomVizPlugin: builder.mutation<
+      CustomVizPlugin,
+      UpdateCustomVizPluginRequest
+    >({
+      query: ({ id, ...body }) => ({
+        method: "PUT",
+        url: `/api/custom-viz-plugin/${id}`,
+        body,
+      }),
+      invalidatesTags: (_, error, { id }) =>
+        invalidateTags(error, [
+          listTag("custom-viz-plugin"),
+          idTag("custom-viz-plugin", id),
+        ]),
+    }),
     refreshCustomVizPlugin: builder.mutation<CustomVizPlugin, number>({
-      query: id => ({
+      query: (id) => ({
         method: "POST",
         url: `/api/custom-viz-plugin/${id}/refresh`,
       }),
@@ -67,5 +84,6 @@ export const {
   useListAllCustomVizPluginsQuery,
   useCreateCustomVizPluginMutation,
   useDeleteCustomVizPluginMutation,
+  useUpdateCustomVizPluginMutation,
   useRefreshCustomVizPluginMutation,
 } = customVizPluginApi;

--- a/frontend/src/metabase/api/custom-viz-plugin.ts
+++ b/frontend/src/metabase/api/custom-viz-plugin.ts
@@ -1,0 +1,71 @@
+import type {
+  CreateCustomVizPluginRequest,
+  CustomVizPlugin,
+} from "metabase-types/api";
+
+import { Api } from "./api";
+import { idTag, invalidateTags, listTag } from "./tags";
+
+export const customVizPluginApi = Api.injectEndpoints({
+  endpoints: builder => ({
+    listCustomVizPlugins: builder.query<CustomVizPlugin[], void>({
+      query: () => ({
+        method: "GET",
+        url: "/api/custom-viz-plugin/list",
+      }),
+      providesTags: (plugins = []) => [
+        listTag("custom-viz-plugin"),
+        ...plugins.map(plugin => idTag("custom-viz-plugin", plugin.id)),
+      ],
+    }),
+    listAllCustomVizPlugins: builder.query<CustomVizPlugin[], void>({
+      query: () => ({
+        method: "GET",
+        url: "/api/custom-viz-plugin",
+      }),
+      providesTags: (plugins = []) => [
+        listTag("custom-viz-plugin"),
+        ...plugins.map(plugin => idTag("custom-viz-plugin", plugin.id)),
+      ],
+    }),
+    createCustomVizPlugin: builder.mutation<
+      CustomVizPlugin,
+      CreateCustomVizPluginRequest
+    >({
+      query: body => ({
+        method: "POST",
+        url: "/api/custom-viz-plugin",
+        body,
+      }),
+      invalidatesTags: (_, error) =>
+        invalidateTags(error, [listTag("custom-viz-plugin")]),
+    }),
+    deleteCustomVizPlugin: builder.mutation<void, number>({
+      query: id => ({
+        method: "DELETE",
+        url: `/api/custom-viz-plugin/${id}`,
+      }),
+      invalidatesTags: (_, error) =>
+        invalidateTags(error, [listTag("custom-viz-plugin")]),
+    }),
+    refreshCustomVizPlugin: builder.mutation<CustomVizPlugin, number>({
+      query: id => ({
+        method: "POST",
+        url: `/api/custom-viz-plugin/${id}/refresh`,
+      }),
+      invalidatesTags: (_, error, id) =>
+        invalidateTags(error, [
+          listTag("custom-viz-plugin"),
+          idTag("custom-viz-plugin", id),
+        ]),
+    }),
+  }),
+});
+
+export const {
+  useListCustomVizPluginsQuery,
+  useListAllCustomVizPluginsQuery,
+  useCreateCustomVizPluginMutation,
+  useDeleteCustomVizPluginMutation,
+  useRefreshCustomVizPluginMutation,
+} = customVizPluginApi;

--- a/frontend/src/metabase/api/index.ts
+++ b/frontend/src/metabase/api/index.ts
@@ -11,6 +11,7 @@ export * from "./channel";
 export * from "./cloud-migration";
 export * from "./collection";
 export * from "./comment";
+export * from "./custom-viz-plugin";
 export * from "./dashboard";
 export * from "./database";
 export * from "./dataset";

--- a/frontend/src/metabase/api/tags/constants.ts
+++ b/frontend/src/metabase/api/tags/constants.ts
@@ -20,6 +20,7 @@ export const TAG_TYPES = [
   "external-transform",
   "public-document",
   "comment",
+  "custom-viz-plugin",
   "embedding-hub-checklist",
   "field",
   "field-values",

--- a/frontend/src/metabase/query_builder/components/chart-type-selector/ChartTypeSettings/ChartTypeSettings.tsx
+++ b/frontend/src/metabase/query_builder/components/chart-type-selector/ChartTypeSettings/ChartTypeSettings.tsx
@@ -1,26 +1,77 @@
+import cx from "classnames";
 import { t } from "ttag";
 
 import { CollapseSection } from "metabase/common/components/CollapseSection";
-import { Space, Stack, type StackProps, Text } from "metabase/ui";
+import {
+  ActionIcon,
+  Center,
+  Grid,
+  Icon,
+  type IconName,
+  Space,
+  Stack,
+  type StackProps,
+  Text,
+} from "metabase/ui";
+import type { CustomVizPluginRuntime } from "metabase-types/api";
 
 import { ChartTypeList, type ChartTypeListProps } from "../ChartTypeList";
+import ChartTypeOptionS from "../ChartTypeOption/ChartTypeOption.module.css";
 
 import S from "./ChartTypeSettings.module.css";
 
 export type ChartTypeSettingsProps = {
   sensibleVisualizations: ChartTypeListProps["visualizationList"];
   nonSensibleVisualizations: ChartTypeListProps["visualizationList"];
+  customVizPlugins?: CustomVizPluginRuntime[];
+  onSelectCustomVizPlugin?: (plugin: CustomVizPluginRuntime) => void;
 } & Pick<
   ChartTypeListProps,
   "selectedVisualization" | "onSelectVisualization" | "onOpenSettings"
 > &
   StackProps;
 
+function CustomVizOption({
+  plugin,
+  onSelect,
+}: {
+  plugin: CustomVizPluginRuntime;
+  onSelect: (plugin: CustomVizPluginRuntime) => void;
+}) {
+  const iconName: IconName = (plugin.icon as IconName) ?? "area";
+
+  return (
+    <Center data-testid="chart-type-option">
+      <Stack align="center" gap="xs" role="option" aria-selected={false}>
+        <ActionIcon
+          w="3.125rem"
+          h="3.125rem"
+          radius="xl"
+          onClick={() => onSelect(plugin)}
+          color="brand"
+          variant="outline"
+          className={cx(
+            ChartTypeOptionS.BorderedButton,
+            ChartTypeOptionS.VisualizationButton,
+          )}
+        >
+          <Icon name={iconName} c="brand" size={20} />
+        </ActionIcon>
+        <Text lh="unset" ta="center" fw="bold" fz="sm" c="text-secondary">
+          {plugin.display_name}
+        </Text>
+      </Stack>
+    </Center>
+  );
+}
+
 export const ChartTypeSettings = ({
   selectedVisualization,
   onSelectVisualization,
   sensibleVisualizations,
   nonSensibleVisualizations,
+  customVizPlugins,
+  onSelectCustomVizPlugin,
   onOpenSettings,
   ...stackProps
 }: ChartTypeSettingsProps) => {
@@ -66,6 +117,52 @@ export const ChartTypeSettings = ({
           />
         </>
       </CollapseSection>
+
+      {customVizPlugins &&
+        customVizPlugins.length > 0 &&
+        onSelectCustomVizPlugin && (
+          <>
+            <Space h="xl" />
+            <CollapseSection
+              header={
+                <Text
+                  fw="bold"
+                  c="inherit"
+                  tt="uppercase"
+                  fz="sm"
+                  data-testid="custom-viz-plugins-toggle"
+                >{t`Custom visualizations`}</Text>
+              }
+              headerClass={S.moreChartsHeader}
+              initialState="collapsed"
+              iconPosition="right"
+              iconSize={10}
+            >
+              <>
+                <Space h="md" />
+                <Grid
+                  data-testid="display-options-custom-viz"
+                  align="flex-start"
+                  justify="flex-start"
+                  grow={false}
+                >
+                  {customVizPlugins.map((plugin) => (
+                    <Grid.Col
+                      span={3}
+                      key={plugin.id}
+                      data-testid="chart-type-list-col"
+                    >
+                      <CustomVizOption
+                        plugin={plugin}
+                        onSelect={onSelectCustomVizPlugin}
+                      />
+                    </Grid.Col>
+                  ))}
+                </Grid>
+              </>
+            </CollapseSection>
+          </>
+        )}
     </Stack>
   );
 };

--- a/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar/ChartTypeSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar/ChartTypeSidebar.tsx
@@ -1,5 +1,5 @@
 import cx from "classnames";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { t } from "ttag";
 
 import CS from "metabase/css/core/index.css";
@@ -18,9 +18,10 @@ import {
   getSensibleVisualizations,
   useQuestionVisualizationState,
 } from "metabase/query_builder/components/chart-type-selector";
+import { useCustomVizPlugins } from "metabase/visualizations/custom-viz-plugins";
 import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
-import type { CardDisplayType } from "metabase-types/api";
+import type { CardDisplayType, CustomVizPluginRuntime } from "metabase-types/api";
 
 export type ChartTypeSidebarProps = Pick<
   UseQuestionVisualizationStateProps,
@@ -33,6 +34,7 @@ export const ChartTypeSidebar = ({
   result,
 }: ChartTypeSidebarProps) => {
   const dispatch = useDispatch();
+  const customVizPlugins = useCustomVizPlugins();
 
   const onUpdateQuestion = (newQuestion: Question) => {
     if (question) {
@@ -60,6 +62,13 @@ export const ChartTypeSidebar = ({
     updateQuestionVisualization(display);
   };
 
+  const handleSelectCustomVizPlugin = useCallback(
+    (_plugin: CustomVizPluginRuntime) => {
+      // TODO: implement custom viz rendering — for now this is a no-op placeholder
+    },
+    [],
+  );
+
   const onOpenVizSettings = () => {
     dispatch(
       onOpenChartSettings({
@@ -80,6 +89,8 @@ export const ChartTypeSidebar = ({
         onSelectVisualization={handleSelectVisualization}
         sensibleVisualizations={sensibleVisualizations}
         nonSensibleVisualizations={nonSensibleVisualizations}
+        customVizPlugins={customVizPlugins}
+        onSelectCustomVizPlugin={handleSelectCustomVizPlugin}
         onOpenSettings={onOpenVizSettings}
         gap={0}
         w="100%"

--- a/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar/ChartTypeSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar/ChartTypeSidebar.tsx
@@ -18,10 +18,16 @@ import {
   getSensibleVisualizations,
   useQuestionVisualizationState,
 } from "metabase/query_builder/components/chart-type-selector";
-import { useCustomVizPlugins } from "metabase/visualizations/custom-viz-plugins";
+import {
+  loadCustomVizPlugin,
+  useCustomVizPlugins,
+} from "metabase/visualizations/custom-viz-plugins";
 import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
-import type { CardDisplayType, CustomVizPluginRuntime } from "metabase-types/api";
+import type {
+  CardDisplayType,
+  CustomVizPluginRuntime,
+} from "metabase-types/api";
 
 export type ChartTypeSidebarProps = Pick<
   UseQuestionVisualizationStateProps,
@@ -63,8 +69,8 @@ export const ChartTypeSidebar = ({
   };
 
   const handleSelectCustomVizPlugin = useCallback(
-    (_plugin: CustomVizPluginRuntime) => {
-      // TODO: implement custom viz rendering — for now this is a no-op placeholder
+    (plugin: CustomVizPluginRuntime) => {
+      void loadCustomVizPlugin(plugin);
     },
     [],
   );

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
@@ -40,6 +40,7 @@ import { getMode } from "metabase/visualizations/click-actions/lib/modes";
 import ChartCaption from "metabase/visualizations/components/ChartCaption";
 import ChartTooltip from "metabase/visualizations/components/ChartTooltip";
 import { ConnectedClickActionsPopover } from "metabase/visualizations/components/ClickActions";
+import { useCustomVizPlugins } from "metabase/visualizations/custom-viz-plugins";
 import { performDefaultAction } from "metabase/visualizations/lib/action";
 import {
   ChartSettingsError,
@@ -1032,6 +1033,7 @@ export default _.compose(
 )(
   forwardRef<HTMLDivElement, VisualizationProps>(
     function VisualizationForwardRef(props, ref) {
+      useCustomVizPlugins();
       return <VisualizationMemoized {...props} forwardedRef={ref} />;
     },
   ),

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
@@ -1033,7 +1033,11 @@ export default _.compose(
 )(
   forwardRef<HTMLDivElement, VisualizationProps>(
     function VisualizationForwardRef(props, ref) {
-      useCustomVizPlugins();
+      const shouldLoadCustomVizPlugins =
+        Boolean(props.isQueryBuilder) &&
+        props.queryBuilderMode === "view" &&
+        !props.isEmbeddingSdk;
+      useCustomVizPlugins({ enabled: shouldLoadCustomVizPlugins });
       return <VisualizationMemoized {...props} forwardedRef={ref} />;
     },
   ),

--- a/frontend/src/metabase/visualizations/custom-viz-plugins.ts
+++ b/frontend/src/metabase/visualizations/custom-viz-plugins.ts
@@ -1,14 +1,22 @@
 import { useEffect } from "react";
 
 import { useListCustomVizPluginsQuery } from "metabase/api";
+import { useEmbeddingEntityContext } from "metabase/embedding/context";
 
 /**
  * Hook that fetches the list of active custom visualization plugins.
  * For PoC: logs available plugins to console.
  * This will later be used to register custom visualizations with the rendering pipeline.
  */
-export function useCustomVizPlugins() {
-  const { data: plugins } = useListCustomVizPluginsQuery();
+export function useCustomVizPlugins({
+  enabled = true,
+}: { enabled?: boolean } = {}) {
+  const { token, uuid } = useEmbeddingEntityContext();
+  const isPublicOrStaticEmbed = Boolean(token || uuid);
+  const shouldLoad = enabled && !isPublicOrStaticEmbed;
+  const { data: plugins } = useListCustomVizPluginsQuery(undefined, {
+    skip: !shouldLoad,
+  });
 
   useEffect(() => {
     if (plugins && plugins.length > 0) {

--- a/frontend/src/metabase/visualizations/custom-viz-plugins.ts
+++ b/frontend/src/metabase/visualizations/custom-viz-plugins.ts
@@ -2,6 +2,10 @@ import { useEffect } from "react";
 
 import { useListCustomVizPluginsQuery } from "metabase/api";
 import { useEmbeddingEntityContext } from "metabase/embedding/context";
+import type { CustomVizPluginRuntime } from "metabase-types/api";
+
+// Track which plugins have already been loaded to avoid re-execution
+const loadedPlugins = new Set<number>();
 
 /**
  * Hook that fetches the list of active custom visualization plugins.
@@ -26,4 +30,39 @@ export function useCustomVizPlugins({
   }, [plugins]);
 
   return plugins;
+}
+
+/**
+ * Dynamically load and execute a custom viz plugin's JS bundle.
+ * Uses dynamic import() against the same-origin bundle endpoint,
+ * which is allowed by the CSP `'self'` directive.
+ */
+export async function loadCustomVizPlugin(
+  plugin: CustomVizPluginRuntime,
+): Promise<void> {
+  if (loadedPlugins.has(plugin.id)) {
+    // eslint-disable-next-line no-console
+    console.log(
+      `[custom-viz-plugins] Plugin "${plugin.display_name}" already loaded, skipping`,
+    );
+    return;
+  }
+
+  // eslint-disable-next-line no-console
+  console.log(`[custom-viz-plugins] Loading plugin "${plugin.display_name}"…`);
+
+  try {
+    const absoluteUrl = new URL(plugin.bundle_url, window.location.origin).href;
+    await import(/* webpackIgnore: true */ absoluteUrl);
+    loadedPlugins.add(plugin.id);
+    // eslint-disable-next-line no-console
+    console.log(
+      `[custom-viz-plugins] Plugin "${plugin.display_name}" loaded successfully`,
+    );
+  } catch (error) {
+    console.error(
+      `[custom-viz-plugins] Failed to load plugin "${plugin.display_name}":`,
+      error,
+    );
+  }
 }

--- a/frontend/src/metabase/visualizations/custom-viz-plugins.ts
+++ b/frontend/src/metabase/visualizations/custom-viz-plugins.ts
@@ -1,0 +1,21 @@
+import { useEffect } from "react";
+
+import { useListCustomVizPluginsQuery } from "metabase/api";
+
+/**
+ * Hook that fetches the list of active custom visualization plugins.
+ * For PoC: logs available plugins to console.
+ * This will later be used to register custom visualizations with the rendering pipeline.
+ */
+export function useCustomVizPlugins() {
+  const { data: plugins } = useListCustomVizPluginsQuery();
+
+  useEffect(() => {
+    if (plugins && plugins.length > 0) {
+      // eslint-disable-next-line no-console
+      console.log("[custom-viz-plugins] Available plugins:", plugins);
+    }
+  }, [plugins]);
+
+  return plugins;
+}

--- a/resources/migrations/059_update_migrations.yaml
+++ b/resources/migrations/059_update_migrations.yaml
@@ -3043,6 +3043,120 @@ databaseChangeLog:
         - customChange:
             class: "metabase.app_db.custom_migrations.FixClickHouseUploadDBSchemaNames"
 
+  - changeSet:
+      id: v59.2026-03-11T10:00:00
+      author: sgavrylov
+      comment: Create custom_viz_plugin table for custom visualization plugins
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - tableExists:
+                tableName: custom_viz_plugin
+      changes:
+        - createTable:
+            tableName: custom_viz_plugin
+            remarks: Stores registered custom visualization plugin repositories
+            columns:
+              - column:
+                  name: id
+                  type: int
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: repo_url
+                  type: varchar(1024)
+                  remarks: Git repository URL
+                  constraints:
+                    nullable: false
+              - column:
+                  name: access_token
+                  type: ${text.type}
+                  remarks: Encrypted access token for private repositories
+                  constraints:
+                    nullable: true
+              - column:
+                  name: display_name
+                  type: varchar(254)
+                  remarks: Human-readable name for the plugin
+                  constraints:
+                    nullable: false
+              - column:
+                  name: identifier
+                  type: varchar(254)
+                  remarks: Unique identifier used as visualization display type
+                  constraints:
+                    nullable: false
+              - column:
+                  name: status
+                  type: varchar(32)
+                  remarks: Plugin status - pending, active, or error
+                  constraints:
+                    nullable: false
+              - column:
+                  name: error_message
+                  type: ${text.type}
+                  remarks: Last error message if status is error
+                  constraints:
+                    nullable: true
+              - column:
+                  name: pinned_version
+                  type: varchar(254)
+                  remarks: Git ref (branch, tag, or commit SHA) to pin the plugin to
+                  constraints:
+                    nullable: true
+              - column:
+                  name: resolved_commit
+                  type: varchar(64)
+                  remarks: Resolved commit SHA of the currently cached version
+                  constraints:
+                    nullable: true
+              - column:
+                  name: created_at
+                  type: ${timestamp_type}
+                  remarks: Timestamp when the plugin was registered
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: ${timestamp_type}
+                  remarks: Timestamp when the plugin was last updated
+                  constraints:
+                    nullable: false
+
+  - changeSet:
+      id: v59.2026-03-11T10:00:01
+      author: sgavrylov
+      comment: Add unique constraint on custom_viz_plugin.repo_url
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - indexExists:
+                tableName: custom_viz_plugin
+                indexName: uq_custom_viz_plugin_repo_url
+      changes:
+        - addUniqueConstraint:
+            tableName: custom_viz_plugin
+            columnNames: repo_url
+            constraintName: uq_custom_viz_plugin_repo_url
+
+  - changeSet:
+      id: v59.2026-03-11T10:00:02
+      author: sgavrylov
+      comment: Add unique constraint on custom_viz_plugin.identifier
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - indexExists:
+                tableName: custom_viz_plugin
+                indexName: uq_custom_viz_plugin_identifier
+      changes:
+        - addUniqueConstraint:
+            tableName: custom_viz_plugin
+            columnNames: identifier
+            constraintName: uq_custom_viz_plugin_identifier
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/resources/migrations/059_update_migrations.yaml
+++ b/resources/migrations/059_update_migrations.yaml
@@ -3157,6 +3157,47 @@ databaseChangeLog:
             columnNames: identifier
             constraintName: uq_custom_viz_plugin_identifier
 
+  - changeSet:
+      id: v59.2026-03-11T12:00:00
+      author: sgavrylov
+      comment: Add enabled column to custom_viz_plugin table
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - columnExists:
+                tableName: custom_viz_plugin
+                columnName: enabled
+      changes:
+        - addColumn:
+            tableName: custom_viz_plugin
+            columns:
+              - column:
+                  name: enabled
+                  type: ${boolean.type}
+                  defaultValueBoolean: true
+                  remarks: Whether the plugin is enabled for use in dashboards and questions
+                  constraints:
+                    nullable: false
+
+  - changeSet:
+      id: v59.2026-03-11T12:30:00
+      author: sgavrylov
+      comment: Add icon column to custom_viz_plugin table
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - columnExists:
+                tableName: custom_viz_plugin
+                columnName: icon
+      changes:
+        - addColumn:
+            tableName: custom_viz_plugin
+            columns:
+              - column:
+                  name: icon
+                  type: varchar(254)
+                  remarks: Icon name for the visualization type selector
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/api_routes/routes.clj
+++ b/src/metabase/api_routes/routes.clj
@@ -17,6 +17,7 @@
    [metabase.channel.api]
    [metabase.cloud-migration.api]
    [metabase.collections-rest.api]
+   [metabase.custom-viz-plugin.api]
    [metabase.comments.api]
    [metabase.config.core :as config]
    [metabase.dashboards-rest.api]
@@ -77,6 +78,7 @@
          metabase.cloud-migration.api/keep-me
          metabase.comments.api/keep-me
          metabase.collections-rest.api/keep-me
+         metabase.custom-viz-plugin.api/keep-me
          metabase.dashboards-rest.api/keep-me
          metabase.data-studio.api/keep-me
          metabase.documents.api/keep-me
@@ -160,6 +162,7 @@
    "/cloud-migration"      (+auth 'metabase.cloud-migration.api)
    "/collection"           (+auth 'metabase.collections-rest.api)
    "/comment"              (+auth metabase.comments.api/routes)
+   "/custom-viz-plugin"    (+auth 'metabase.custom-viz-plugin.api)
    "/dashboard"            (+auth 'metabase.dashboards-rest.api)
    "/data-studio"          (+auth metabase.data-studio.api/routes)
    "/database"             (+auth 'metabase.warehouses-rest.api)

--- a/src/metabase/custom_viz_plugin/api.clj
+++ b/src/metabase/custom_viz_plugin/api.clj
@@ -20,11 +20,20 @@
    [:display_name  ms/NonBlankString]
    [:identifier    ms/NonBlankString]
    [:status        [:enum "pending" "active" "error"]]
+   [:enabled       :boolean]
+   [:icon          {:optional true} [:maybe :string]]
    [:error_message {:optional true} [:maybe :string]]
    [:pinned_version  {:optional true} [:maybe :string]]
    [:resolved_commit {:optional true} [:maybe :string]]
    [:created_at    :any]
    [:updated_at    :any]])
+
+(def ^:private CustomVizPluginRuntimeResponse
+  [:map
+   [:id           ms/PositiveInt]
+   [:identifier   ms/NonBlankString]
+   [:display_name ms/NonBlankString]
+   [:bundle_url   ms/NonBlankString]])
 
 ;;; ------------------------------------------------ Helpers ------------------------------------------------
 
@@ -40,6 +49,14 @@
       strip-token
       (update :status name)))
 
+(defn- plugin->runtime-response
+  "Convert a plugin record to the safe runtime response shape."
+  [{:keys [id identifier display_name]}]
+  {:id           id
+   :identifier   identifier
+   :display_name display_name
+   :bundle_url   (format "/api/custom-viz-plugin/%d/bundle" id)})
+
 ;;; ------------------------------------------------ Endpoints ------------------------------------------------
 
 (api.macros/defendpoint :post "/" :- CustomVizPluginResponse
@@ -48,10 +65,10 @@
   [_route-params
    _query-params
    {:keys [repo_url display_name access_token pinned_version]} :- [:map
-                                                                    [:repo_url      ms/NonBlankString]
-                                                                    [:display_name  ms/NonBlankString]
-                                                                    [:access_token  {:optional true} [:maybe :string]]
-                                                                    [:pinned_version {:optional true} [:maybe :string]]]]
+                                                                   [:repo_url      ms/NonBlankString]
+                                                                   [:display_name  ms/NonBlankString]
+                                                                   [:access_token  {:optional true} [:maybe :string]]
+                                                                   [:pinned_version {:optional true} [:maybe :string]]]]
   (api/check-superuser)
   (let [identifier (git/parse-repo-name repo_url)
         plugin     (first (t2/insert-returning-instances! :model/CustomVizPlugin
@@ -72,10 +89,14 @@
   (api/check-superuser)
   (map plugin->response (t2/select :model/CustomVizPlugin {:order-by [[:display_name :asc]]})))
 
-(api.macros/defendpoint :get "/list" :- [:sequential CustomVizPluginResponse]
-  "List active custom visualization plugins. Available to any authenticated user."
+(api.macros/defendpoint :get "/list" :- [:sequential CustomVizPluginRuntimeResponse]
+  "List active and enabled custom visualization plugins. Available to any authenticated user."
   []
-  (map plugin->response (t2/select :model/CustomVizPlugin :status "active" {:order-by [[:display_name :asc]]})))
+  (map plugin->runtime-response
+       (t2/select [:model/CustomVizPlugin :id :identifier :display_name]
+                  :status :active
+                  :enabled true
+                  {:order-by [[:display_name :asc]]})))
 
 (api.macros/defendpoint :delete "/:id"
   "Remove a custom visualization plugin and evict its cached bundle."
@@ -85,6 +106,23 @@
   (cache/evict! id)
   (t2/delete! :model/CustomVizPlugin :id id)
   nil)
+
+(api.macros/defendpoint :put "/:id" :- CustomVizPluginResponse
+  "Update a custom visualization plugin."
+  [{:keys [id]} :- [:map [:id ms/PositiveInt]]
+   _query-params
+   body :- [:map
+            [:enabled       {:optional true} [:maybe :boolean]]
+            [:display_name  {:optional true} [:maybe ms/NonBlankString]]
+            [:icon          {:optional true} [:maybe :string]]
+            [:access_token  {:optional true} [:maybe :string]]
+            [:pinned_version {:optional true} [:maybe :string]]]]
+  (api/check-superuser)
+  (api/check-404 (t2/select-one :model/CustomVizPlugin :id id))
+  (let [updates (into {} (filter (fn [[_ v]] (some? v))) body)]
+    (when (seq updates)
+      (t2/update! :model/CustomVizPlugin id updates)))
+  (plugin->response (t2/select-one :model/CustomVizPlugin :id id)))
 
 (api.macros/defendpoint :get "/:id/bundle"
   "Serve the cached JS bundle for a plugin.
@@ -117,5 +155,5 @@
   (api/check-superuser)
   (let [plugin (api/check-404 (t2/select-one :model/CustomVizPlugin :id id))]
     (cache/evict! id)
-    (cache/fetch-and-cache! plugin)
+    (cache/fetch-and-cache! plugin {:force? true})
     (plugin->response (t2/select-one :model/CustomVizPlugin :id id))))

--- a/src/metabase/custom_viz_plugin/api.clj
+++ b/src/metabase/custom_viz_plugin/api.clj
@@ -33,6 +33,7 @@
    [:id           ms/PositiveInt]
    [:identifier   ms/NonBlankString]
    [:display_name ms/NonBlankString]
+   [:icon         {:optional true} [:maybe :string]]
    [:bundle_url   ms/NonBlankString]])
 
 ;;; ------------------------------------------------ Helpers ------------------------------------------------
@@ -51,10 +52,11 @@
 
 (defn- plugin->runtime-response
   "Convert a plugin record to the safe runtime response shape."
-  [{:keys [id identifier display_name]}]
+  [{:keys [id identifier display_name icon]}]
   {:id           id
    :identifier   identifier
    :display_name display_name
+   :icon         icon
    :bundle_url   (format "/api/custom-viz-plugin/%d/bundle" id)})
 
 ;;; ------------------------------------------------ Endpoints ------------------------------------------------
@@ -93,7 +95,7 @@
   "List active and enabled custom visualization plugins. Available to any authenticated user."
   []
   (map plugin->runtime-response
-       (t2/select [:model/CustomVizPlugin :id :identifier :display_name]
+       (t2/select [:model/CustomVizPlugin :id :identifier :display_name :icon]
                   :status :active
                   :enabled true
                   {:order-by [[:display_name :asc]]})))

--- a/src/metabase/custom_viz_plugin/api.clj
+++ b/src/metabase/custom_viz_plugin/api.clj
@@ -120,10 +120,17 @@
             [:access_token  {:optional true} [:maybe :string]]
             [:pinned_version {:optional true} [:maybe :string]]]]
   (api/check-superuser)
-  (api/check-404 (t2/select-one :model/CustomVizPlugin :id id))
-  (let [updates (into {} (filter (fn [[_ v]] (some? v))) body)]
+  (let [existing    (api/check-404 (t2/select-one :model/CustomVizPlugin :id id))
+        ;; select-keys preserves nil values (meaning "clear this field"),
+        ;; while absent keys are simply not included.
+        updates    (select-keys body [:enabled :display_name :icon :access_token :pinned_version])]
     (when (seq updates)
-      (t2/update! :model/CustomVizPlugin id updates)))
+      (t2/update! :model/CustomVizPlugin id updates))
+    (when (and (contains? updates :pinned_version)
+               (not= (:pinned_version updates) (:pinned_version existing)))
+      (let [updated-plugin (t2/select-one :model/CustomVizPlugin :id id)]
+        (cache/evict! id)
+        (cache/fetch-and-cache! updated-plugin {:force? true}))))
   (plugin->response (t2/select-one :model/CustomVizPlugin :id id)))
 
 (api.macros/defendpoint :get "/:id/bundle"

--- a/src/metabase/custom_viz_plugin/api.clj
+++ b/src/metabase/custom_viz_plugin/api.clj
@@ -1,0 +1,121 @@
+(ns metabase.custom-viz-plugin.api
+  "/api/custom-viz-plugin endpoints."
+  (:require
+   [metabase.api.common :as api]
+   [metabase.api.macros :as api.macros]
+   [metabase.custom-viz-plugin.cache :as cache]
+   [metabase.custom-viz-plugin.git :as git]
+   [metabase.custom-viz-plugin.models.custom-viz-plugin]
+   [metabase.util.malli.schema :as ms]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+;;; ------------------------------------------------ Schemas ------------------------------------------------
+
+(def ^:private CustomVizPluginResponse
+  [:map
+   [:id            ms/PositiveInt]
+   [:repo_url      ms/NonBlankString]
+   [:display_name  ms/NonBlankString]
+   [:identifier    ms/NonBlankString]
+   [:status        [:enum "pending" "active" "error"]]
+   [:error_message {:optional true} [:maybe :string]]
+   [:pinned_version  {:optional true} [:maybe :string]]
+   [:resolved_commit {:optional true} [:maybe :string]]
+   [:created_at    :any]
+   [:updated_at    :any]])
+
+;;; ------------------------------------------------ Helpers ------------------------------------------------
+
+(defn- strip-token
+  "Remove access_token from plugin map before returning to client."
+  [plugin]
+  (dissoc plugin :access_token))
+
+(defn- plugin->response
+  "Convert a plugin record to API response format (keyword status -> string)."
+  [plugin]
+  (-> plugin
+      strip-token
+      (update :status name)))
+
+;;; ------------------------------------------------ Endpoints ------------------------------------------------
+
+(api.macros/defendpoint :post "/" :- CustomVizPluginResponse
+  "Register a new custom visualization plugin from a git repository.
+   Validates by fetching index.js from the repo."
+  [_route-params
+   _query-params
+   {:keys [repo_url display_name access_token pinned_version]} :- [:map
+                                                                    [:repo_url      ms/NonBlankString]
+                                                                    [:display_name  ms/NonBlankString]
+                                                                    [:access_token  {:optional true} [:maybe :string]]
+                                                                    [:pinned_version {:optional true} [:maybe :string]]]]
+  (api/check-superuser)
+  (let [identifier (git/parse-repo-name repo_url)
+        plugin     (first (t2/insert-returning-instances! :model/CustomVizPlugin
+                                                          :repo_url        repo_url
+                                                          :access_token    access_token
+                                                          :display_name    display_name
+                                                          :identifier      identifier
+                                                          :status          :pending
+                                                          :pinned_version  pinned_version))]
+    ;; fetch bundle synchronously — validates the repo is accessible
+    (cache/fetch-and-cache! plugin)
+    ;; re-read to get updated status
+    (plugin->response (t2/select-one :model/CustomVizPlugin :id (:id plugin)))))
+
+(api.macros/defendpoint :get "/" :- [:sequential CustomVizPluginResponse]
+  "List all registered custom visualization plugins."
+  []
+  (api/check-superuser)
+  (map plugin->response (t2/select :model/CustomVizPlugin {:order-by [[:display_name :asc]]})))
+
+(api.macros/defendpoint :get "/list" :- [:sequential CustomVizPluginResponse]
+  "List active custom visualization plugins. Available to any authenticated user."
+  []
+  (map plugin->response (t2/select :model/CustomVizPlugin :status "active" {:order-by [[:display_name :asc]]})))
+
+(api.macros/defendpoint :delete "/:id"
+  "Remove a custom visualization plugin and evict its cached bundle."
+  [{:keys [id]} :- [:map [:id ms/PositiveInt]]]
+  (api/check-superuser)
+  (api/check-404 (t2/select-one :model/CustomVizPlugin :id id))
+  (cache/evict! id)
+  (t2/delete! :model/CustomVizPlugin :id id)
+  nil)
+
+(api.macros/defendpoint :get "/:id/bundle"
+  "Serve the cached JS bundle for a plugin.
+   Returns application/javascript with ETag and Cache-Control headers."
+  [{:keys [id], :as _route-params} :- [:map [:id ms/PositiveInt]]
+   _query-params
+   _body
+   _request
+   respond
+   raise]
+  (try
+    (let [plugin (api/check-404 (t2/select-one :model/CustomVizPlugin :id id))
+          entry  (or (cache/get-bundle id)
+                     (cache/fetch-and-cache! plugin))]
+      (if entry
+        (respond {:status  200
+                  :headers {"Content-Type"  "application/javascript"
+                            "ETag"          (:hash entry)
+                            "Cache-Control" "public, max-age=3600"}
+                  :body    (:content entry)})
+        (respond {:status 503
+                  :headers {"Content-Type" "application/json"}
+                  :body   "{\"error\": \"Bundle not available\"}"})))
+    (catch Throwable e
+      (raise e))))
+
+(api.macros/defendpoint :post "/:id/refresh" :- CustomVizPluginResponse
+  "Re-fetch the bundle from the git repository."
+  [{:keys [id]} :- [:map [:id ms/PositiveInt]]]
+  (api/check-superuser)
+  (let [plugin (api/check-404 (t2/select-one :model/CustomVizPlugin :id id))]
+    (cache/evict! id)
+    (cache/fetch-and-cache! plugin)
+    (plugin->response (t2/select-one :model/CustomVizPlugin :id id))))

--- a/src/metabase/custom_viz_plugin/api.clj
+++ b/src/metabase/custom_viz_plugin/api.clj
@@ -66,11 +66,12 @@
    Validates by fetching index.js from the repo."
   [_route-params
    _query-params
-   {:keys [repo_url display_name access_token pinned_version]} :- [:map
-                                                                   [:repo_url      ms/NonBlankString]
-                                                                   [:display_name  ms/NonBlankString]
-                                                                   [:access_token  {:optional true} [:maybe :string]]
-                                                                   [:pinned_version {:optional true} [:maybe :string]]]]
+   {:keys [repo_url display_name icon access_token pinned_version]} :- [:map
+                                                                        [:repo_url       ms/NonBlankString]
+                                                                        [:display_name   ms/NonBlankString]
+                                                                        [:icon           {:optional true} [:maybe :string]]
+                                                                        [:access_token   {:optional true} [:maybe :string]]
+                                                                        [:pinned_version {:optional true} [:maybe :string]]]]
   (api/check-superuser)
   (let [identifier (git/parse-repo-name repo_url)
         plugin     (first (t2/insert-returning-instances! :model/CustomVizPlugin
@@ -78,6 +79,7 @@
                                                           :access_token    access_token
                                                           :display_name    display_name
                                                           :identifier      identifier
+                                                          :icon            icon
                                                           :status          :pending
                                                           :pinned_version  pinned_version))]
     ;; fetch bundle synchronously — validates the repo is accessible

--- a/src/metabase/custom_viz_plugin/cache.clj
+++ b/src/metabase/custom_viz_plugin/cache.clj
@@ -1,0 +1,99 @@
+(ns metabase.custom-viz-plugin.cache
+  "Cache layer for custom visualization plugin bundles.
+   Fetches files from git repos, caches in memory and on disk."
+  (:require
+   [buddy.core.codecs :as codecs]
+   [buddy.core.hash :as buddy-hash]
+   [clojure.java.io :as io]
+   [metabase.custom-viz-plugin.git :as git]
+   [metabase.util.log :as log]
+   [toucan2.core :as t2])
+  (:import
+   (java.io File)))
+
+(set! *warn-on-reflection* true)
+
+;;; ------------------------------------------------ In-Memory Cache ------------------------------------------------
+
+;; plugin-id -> {:content str, :hash str, :commit str}
+(defonce ^:private bundle-cache (atom {}))
+
+;;; ------------------------------------------------ Disk Cache ------------------------------------------------
+
+(defn- disk-cache-dir ^File []
+  (io/file (System/getProperty "java.io.tmpdir") "metabase-custom-viz-plugins" "bundles"))
+
+(defn- disk-cache-file ^File [plugin-id]
+  (io/file (disk-cache-dir) (str plugin-id ".js")))
+
+(defn- write-to-disk! [plugin-id ^String content]
+  (let [f (disk-cache-file plugin-id)]
+    (io/make-parents f)
+    (spit f content)))
+
+(defn- read-from-disk [plugin-id]
+  (let [f (disk-cache-file plugin-id)]
+    (when (.exists f)
+      (slurp f))))
+
+(defn- delete-from-disk! [plugin-id]
+  (let [f (disk-cache-file plugin-id)]
+    (when (.exists f)
+      (.delete f))))
+
+;;; ------------------------------------------------ Hash ------------------------------------------------
+
+(defn- content-hash [^String content]
+  (-> content .getBytes buddy-hash/sha256 codecs/bytes->hex))
+
+;;; ------------------------------------------------ Fetch & Cache ------------------------------------------------
+
+(defn fetch-and-cache!
+  "Fetch index.js from the plugin's git repo, update both caches and DB record.
+   Returns the cached entry or nil on failure."
+  [{:keys [id repo_url access_token pinned_version]}]
+  (try
+    (let [conn          (git/create-repo-connection repo_url access_token)
+          _             (git/fetch! conn)
+          ref-to-use    (or pinned_version "HEAD")
+          commit-sha    (git/resolve-ref conn ref-to-use)
+          _             (when-not commit-sha
+                          (throw (ex-info (str "Cannot resolve ref: " ref-to-use) {:ref ref-to-use})))
+          content       (git/read-file conn commit-sha "index.js")
+          _             (when-not content
+                          (throw (ex-info "index.js not found in repository" {:commit commit-sha})))
+          hash          (content-hash content)
+          cache-entry   {:content content :hash hash :commit commit-sha}]
+      ;; update caches
+      (swap! bundle-cache assoc id cache-entry)
+      (write-to-disk! id content)
+      ;; update DB
+      (t2/update! :model/CustomVizPlugin id
+                  {:status           :active
+                   :error_message    nil
+                   :resolved_commit  commit-sha})
+      (log/infof "Cached custom viz plugin %d (commit %s)" id commit-sha)
+      cache-entry)
+    (catch Exception e
+      (log/errorf e "Failed to fetch custom viz plugin %d from %s" id repo_url)
+      (t2/update! :model/CustomVizPlugin id
+                  {:status        :error
+                   :error_message (ex-message e)})
+      nil)))
+
+;;; ------------------------------------------------ Get / Evict ------------------------------------------------
+
+(defn get-bundle
+  "Get the JS bundle for a plugin. Checks in-memory first, then disk."
+  [plugin-id]
+  (or (get @bundle-cache plugin-id)
+      (when-let [content (read-from-disk plugin-id)]
+        (let [entry {:content content :hash (content-hash content)}]
+          (swap! bundle-cache assoc plugin-id entry)
+          entry))))
+
+(defn evict!
+  "Remove a plugin from both caches."
+  [plugin-id]
+  (swap! bundle-cache dissoc plugin-id)
+  (delete-from-disk! plugin-id))

--- a/src/metabase/custom_viz_plugin/cache.clj
+++ b/src/metabase/custom_viz_plugin/cache.clj
@@ -6,7 +6,6 @@
    [buddy.core.hash :as buddy-hash]
    [clojure.java.io :as io]
    [metabase.custom-viz-plugin.git :as git]
-   [metabase.util.log :as log]
    [toucan2.core :as t2])
   (:import
    (java.io File)))
@@ -17,6 +16,10 @@
 
 ;; plugin-id -> {:content str, :hash str, :commit str}
 (defonce ^:private bundle-cache (atom {}))
+;; plugin-id -> monotonic nano-time timestamp of last failed fetch
+(defonce ^:private last-fetch-failure-ns (atom {}))
+
+(def ^:private ^:const fetch-failure-cooldown-ms (* 5 60 1000))
 
 ;;; ------------------------------------------------ Disk Cache ------------------------------------------------
 
@@ -48,38 +51,50 @@
 
 ;;; ------------------------------------------------ Fetch & Cache ------------------------------------------------
 
+(defn- in-failure-cooldown?
+  [plugin-id]
+  (when-let [last-failure-ns (get @last-fetch-failure-ns plugin-id)]
+    (< (/ (- (System/nanoTime) last-failure-ns) 1e6)
+       fetch-failure-cooldown-ms)))
+
 (defn fetch-and-cache!
   "Fetch index.js from the plugin's git repo, update both caches and DB record.
    Returns the cached entry or nil on failure."
-  [{:keys [id repo_url access_token pinned_version]}]
-  (try
-    (let [conn          (git/create-repo-connection repo_url access_token)
-          _             (git/fetch! conn)
-          ref-to-use    (or pinned_version "HEAD")
-          commit-sha    (git/resolve-ref conn ref-to-use)
-          _             (when-not commit-sha
-                          (throw (ex-info (str "Cannot resolve ref: " ref-to-use) {:ref ref-to-use})))
-          content       (git/read-file conn commit-sha "index.js")
-          _             (when-not content
-                          (throw (ex-info "index.js not found in repository" {:commit commit-sha})))
-          hash          (content-hash content)
-          cache-entry   {:content content :hash hash :commit commit-sha}]
-      ;; update caches
-      (swap! bundle-cache assoc id cache-entry)
-      (write-to-disk! id content)
-      ;; update DB
-      (t2/update! :model/CustomVizPlugin id
-                  {:status           :active
-                   :error_message    nil
-                   :resolved_commit  commit-sha})
-      (log/infof "Cached custom viz plugin %d (commit %s)" id commit-sha)
-      cache-entry)
-    (catch Exception e
-      (log/errorf e "Failed to fetch custom viz plugin %d from %s" id repo_url)
-      (t2/update! :model/CustomVizPlugin id
-                  {:status        :error
-                   :error_message (ex-message e)})
-      nil)))
+  ([plugin]
+   (fetch-and-cache! plugin nil))
+  ([{:keys [id repo_url access_token pinned_version]}
+    {:keys [force?]
+     :or   {force? false}}]
+   (if (and (not force?) (in-failure-cooldown? id))
+     nil
+     (try
+       (let [conn          (git/create-repo-connection repo_url access_token)
+             _             (git/fetch! conn)
+             ref-to-use    (or pinned_version "HEAD")
+             commit-sha    (git/resolve-ref conn ref-to-use)
+             _             (when-not commit-sha
+                             (throw (ex-info (str "Cannot resolve ref: " ref-to-use) {:ref ref-to-use})))
+             content       (git/read-file conn commit-sha "index.js")
+             _             (when-not content
+                             (throw (ex-info "index.js not found in repository" {:commit commit-sha})))
+             hash          (content-hash content)
+             cache-entry   {:content content :hash hash :commit commit-sha}]
+         ;; update caches
+         (swap! bundle-cache assoc id cache-entry)
+         (swap! last-fetch-failure-ns dissoc id)
+         (write-to-disk! id content)
+         ;; update DB
+         (t2/update! :model/CustomVizPlugin id
+                     {:status           :active
+                      :error_message    nil
+                      :resolved_commit  commit-sha})
+         cache-entry)
+       (catch Exception e
+         (swap! last-fetch-failure-ns assoc id (System/nanoTime))
+         (t2/update! :model/CustomVizPlugin id
+                     {:status        :error
+                      :error_message (ex-message e)})
+         nil)))))
 
 ;;; ------------------------------------------------ Get / Evict ------------------------------------------------
 
@@ -96,4 +111,5 @@
   "Remove a plugin from both caches."
   [plugin-id]
   (swap! bundle-cache dissoc plugin-id)
+  (swap! last-fetch-failure-ns dissoc plugin-id)
   (delete-from-disk! plugin-id))

--- a/src/metabase/custom_viz_plugin/git.clj
+++ b/src/metabase/custom_viz_plugin/git.clj
@@ -1,0 +1,167 @@
+(ns metabase.custom-viz-plugin.git
+  "Read-only JGit wrapper for fetching files from custom visualization plugin repositories.
+   Clones bare repos, fetches updates, and reads files at specific commits."
+  (:require
+   [buddy.core.codecs :as codecs]
+   [buddy.core.hash :as buddy-hash]
+   [clojure.java.io :as io]
+   [clojure.string :as str]
+   [metabase.util :as u]
+   [metabase.util.log :as log])
+  (:import
+   (java.io File)
+   (org.apache.commons.io FileUtils)
+   (org.eclipse.jgit.api Git TransportCommand)
+   (org.eclipse.jgit.revwalk RevWalk)
+   (org.eclipse.jgit.transport UsernamePasswordCredentialsProvider)
+   (org.eclipse.jgit.treewalk TreeWalk)))
+
+(set! *warn-on-reflection* true)
+
+;;; ------------------------------------------------ Auth & Helpers ------------------------------------------------
+
+(defn- root-cause [^Throwable e]
+  (if-let [cause (ex-cause e)]
+    (recur cause)
+    e))
+
+(defn- credentials-provider ^UsernamePasswordCredentialsProvider [^String token]
+  (UsernamePasswordCredentialsProvider. "x-access-token" token))
+
+(defn- call-remote-command [^TransportCommand command token]
+  (when token
+    (.setCredentialsProvider command (credentials-provider token)))
+  (try
+    (.call command)
+    (catch Exception e
+      (throw (ex-info (format "Git operation failed: %s" (ex-message (root-cause e)))
+                      {:error (ex-message e)} e)))))
+
+;;; ------------------------------------------------ Repo Path ------------------------------------------------
+
+(defn- repo-cache-path
+  "Returns the local cache directory for a given repo URL + token combination."
+  ^File [{:keys [^String remote-url ^String token]}]
+  (io/file (System/getProperty "java.io.tmpdir")
+           "metabase-custom-viz-plugins"
+           (-> (str/join ":" [remote-url (or token "")])
+               buddy-hash/sha1
+               codecs/bytes->hex)))
+
+;;; ------------------------------------------------ Clone / Open ------------------------------------------------
+
+(defn- clone-repository!
+  "Bare-clone a repository to the given path."
+  ^Git [^File path {:keys [^String remote-url token]}]
+  (log/infof "Cloning custom viz plugin repo %s" remote-url)
+  (io/make-parents path)
+  (try
+    (u/prog1 (call-remote-command
+              (-> (Git/cloneRepository)
+                  (.setDirectory path)
+                  (.setURI remote-url)
+                  (.setBare true))
+              token)
+      (log/infof "Successfully cloned to %s" path))
+    (catch Exception e
+      (throw (ex-info (format "Failed to clone repository: %s" (ex-message e))
+                      {:url remote-url :repo-path (str path)} e)))))
+
+(defn- open-or-clone!
+  "Open an existing bare repo or clone it fresh."
+  ^Git [^File path {:keys [remote-url] :as opts}]
+  (if (.exists path)
+    (let [git (Git/open path)]
+      ;; ensure origin URL matches
+      (let [config (.getConfig (.getRepository git))
+            current-url (.getString config "remote" "origin" "url")]
+        (when (not= remote-url current-url)
+          (.setString config "remote" "origin" "url" ^String remote-url)
+          (.save config)))
+      git)
+    (clone-repository! path opts)))
+
+;;; ------------------------------------------------ Fetch ------------------------------------------------
+
+(defn fetch!
+  "Fetch latest refs from the remote."
+  [{:keys [^Git git token]}]
+  (when git
+    (log/debug "Fetching custom viz plugin repo")
+    (call-remote-command (.fetch git) token)))
+
+;;; ------------------------------------------------ Read Operations ------------------------------------------------
+
+(defn resolve-ref
+  "Resolve a branch name, tag, or commit SHA to a full commit SHA string.
+   Returns nil if the ref cannot be resolved."
+  [{:keys [^Git git]} ^String ref-str]
+  (when-let [object-id (.resolve (.getRepository git) ref-str)]
+    (.name object-id)))
+
+(defn list-files
+  "List all file paths in the repo at a given commit SHA."
+  [{:keys [^Git git]} ^String commit-sha]
+  (let [repo (.getRepository git)
+        rev-walk (RevWalk. repo)
+        commit-id (.resolve repo commit-sha)
+        commit (.parseCommit rev-walk commit-id)
+        tree-walk (TreeWalk. repo)]
+    (.addTree tree-walk (.getTree commit))
+    (.setRecursive tree-walk true)
+    (sort (loop [files []]
+            (if (.next tree-walk)
+              (recur (conj files (.getPathString tree-walk)))
+              files)))))
+
+(defn read-file
+  "Read a single file at a given commit SHA. Returns the content as a UTF-8 string, or nil if not found."
+  [{:keys [^Git git]} ^String commit-sha ^String path]
+  (let [repo (.getRepository git)]
+    (when-let [object-id (.resolve repo (str commit-sha ":" path))]
+      (let [loader (.open repo object-id)]
+        (String. (.getBytes loader) "UTF-8")))))
+
+;;; ------------------------------------------------ Lifecycle ------------------------------------------------
+
+;; open JGit instances keyed by repo cache path
+(defonce ^:private git-instances (atom {}))
+
+(defn- get-or-create-git!
+  "Get or create a Git instance for the given repo config."
+  ^Git [{:keys [remote-url token] :as opts}]
+  (let [path (repo-cache-path opts)
+        path-key (.getPath path)]
+    (or (get @git-instances path-key)
+        (let [git (open-or-clone! path opts)]
+          (swap! git-instances assoc path-key git)
+          git))))
+
+(defn create-repo-connection
+  "Create a repo connection map for the given URL and optional token.
+   Returns a map with :git, :remote-url, and :token."
+  [remote-url token]
+  (let [opts {:remote-url remote-url :token token}
+        git  (get-or-create-git! opts)]
+    (assoc opts :git git)))
+
+(defn clear-repo-cache!
+  "Remove a cached repo from memory and disk."
+  [remote-url token]
+  (let [opts {:remote-url remote-url :token token}
+        path (repo-cache-path opts)
+        path-key (.getPath path)]
+    (log/infof "Clearing cached repo for %s" remote-url)
+    (swap! git-instances dissoc path-key)
+    (when (.exists path)
+      (FileUtils/deleteDirectory path))))
+
+(defn parse-repo-name
+  "Extract the repository name from a git URL.
+   E.g., 'https://github.com/user/custom-heatmap' -> 'custom-heatmap'
+         'https://github.com/user/custom-heatmap.git' -> 'custom-heatmap'"
+  [^String url]
+  (-> url
+      (str/replace #"\.git$" "")
+      (str/split #"/")
+      last))

--- a/src/metabase/custom_viz_plugin/models/custom_viz_plugin.clj
+++ b/src/metabase/custom_viz_plugin/models/custom_viz_plugin.clj
@@ -1,0 +1,28 @@
+(ns metabase.custom-viz-plugin.models.custom-viz-plugin
+  (:require
+   [metabase.api.common :as api]
+   [metabase.models.interface :as mi]
+   [methodical.core :as methodical]
+   [toucan2.core :as t2]))
+
+(methodical/defmethod t2/table-name :model/CustomVizPlugin [_model] :custom_viz_plugin)
+
+(t2/deftransforms :model/CustomVizPlugin
+  {:access_token mi/transform-encrypted-json
+   :status       mi/transform-keyword})
+
+(doto :model/CustomVizPlugin
+  (derive :metabase/model)
+  (derive :hook/timestamped?))
+
+(defmethod mi/can-read? :model/CustomVizPlugin
+  ([_instance]   api/*is-superuser?*)
+  ([_model _pk]  api/*is-superuser?*))
+
+(defmethod mi/can-write? :model/CustomVizPlugin
+  ([_instance]   api/*is-superuser?*)
+  ([_model _pk]  api/*is-superuser?*))
+
+(defmethod mi/can-create? :model/CustomVizPlugin
+  [_model _instance]
+  api/*is-superuser?*)


### PR DESCRIPTION
### Description

Adds a custom visualization plugin manager that lets admins register Git repositories containing custom visualization JS bundles. The server fetches, caches, and serves these bundles. Users can select custom visualizations from the chart type sidebar.

**Backend:**
- DB migration for `custom_viz_plugin` table with columns for repo URL, encrypted access token, display name, identifier, status, icon, pinned version, enabled flag
- JGit-based read-only wrapper for cloning/fetching from Git repos (supports GitHub, GitLab, any Git host)
- In-memory + disk cache layer with failure cooldown (5 min) to avoid hammering broken repos
- REST API: CRUD + bundle serving + refresh endpoint
- Auto-refetch when pinned version changes via PUT

**Frontend:**
- Admin settings page at `/admin/settings/custom-viz-plugins` with add/edit forms, icon picker, enable/disable toggle, ellipsis menu (edit/refetch/remove)
- RTK Query API slice with full cache invalidation
- "Custom visualizations" collapsible section in chart type sidebar (only visible when plugins exist)
- Dynamic bundle loading via `import()` against same-origin bundle endpoint (CSP-safe)
- Plugin deduplication — bundles are only loaded once per session

**API Endpoints:**
- `POST /api/custom-viz-plugin` — register plugin (superuser)
- `GET /api/custom-viz-plugin` — list all plugins (superuser)
- `GET /api/custom-viz-plugin/list` — list active+enabled plugins (any auth, minimal response)
- `PUT /api/custom-viz-plugin/:id` — update plugin (superuser)
- `DELETE /api/custom-viz-plugin/:id` — remove plugin (superuser)
- `GET /api/custom-viz-plugin/:id/bundle` — serve JS bundle (any auth, cached)
- `POST /api/custom-viz-plugin/:id/refresh` — re-fetch from git (superuser)

### How to verify

1. Go to Admin > Settings > Custom visualization plugins
2. Click "Add plugin", enter a Git repo URL containing an `index.js` file, set display name and icon
3. Plugin should appear in the list with status info and commit hash
4. Toggle enabled/disabled, edit settings, refetch from remote
5. Open any question, click the chart type selector — "Custom visualizations" section should appear
6. Click a custom viz icon — check browser console for bundle execution logs

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)

🤖 Generated with [Claude Code](https://claude.com/claude-code)