### PR TITLE
Fixed issue when hiding SDK banner

### DIFF
--- a/frontend/src/embedding-sdk-bundle/components/private/SdkUsageProblem/SdkUsageProblemDisplay-simple-embedding.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkUsageProblem/SdkUsageProblemDisplay-simple-embedding.unit.spec.tsx
@@ -23,12 +23,6 @@ const TEST_USER = createMockUser();
 
 jest.mock("metabase/visualizations/register", () => jest.fn(() => {}));
 
-const mockSdkDispatchFn = jest.fn();
-jest.mock("embedding-sdk-bundle/store", () => ({
-  ...jest.requireActual("embedding-sdk-bundle/store"),
-  useSdkDispatch: () => mockSdkDispatchFn,
-}));
-
 jest.mock("metabase/embedding-sdk/config", () => ({
   ...jest.requireActual("metabase/embedding-sdk/config"),
   EMBEDDING_SDK_CONFIG: {

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkUsageProblem/SdkUsageProblemDisplay.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkUsageProblem/SdkUsageProblemDisplay.unit.spec.tsx
@@ -5,9 +5,8 @@ import {
   setupSettingsEndpoints,
 } from "__support__/server-mocks";
 import { mockSettings } from "__support__/settings";
-import { screen, within } from "__support__/ui";
+import { screen, waitFor, within } from "__support__/ui";
 import * as IsLocalhostModule from "embedding-sdk-bundle/lib/get-is-localhost";
-import { setUsageProblem } from "embedding-sdk-bundle/store/reducer";
 import { renderWithSDKProviders } from "embedding-sdk-bundle/test/__support__/ui";
 import {
   createMockApiKeyConfig,
@@ -28,12 +27,6 @@ import { createMockState } from "metabase-types/store/mocks";
 const TEST_USER = createMockUser();
 
 jest.mock("metabase/visualizations/register", () => jest.fn(() => {}));
-
-const mockSdkDispatchFn = jest.fn();
-jest.mock("embedding-sdk-bundle/store", () => ({
-  ...jest.requireActual("embedding-sdk-bundle/store"),
-  useSdkDispatch: () => mockSdkDispatchFn,
-}));
 
 interface Options {
   authConfig: MetabaseAuthConfig;
@@ -279,6 +272,10 @@ describe("SdkUsageProblemDisplay", () => {
 
     await userEvent.click(within(card).getByText("Hide warning"));
 
-    expect(mockSdkDispatchFn).toHaveBeenCalledWith(setUsageProblem(null));
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId(PROBLEM_INDICATOR_TEST_ID),
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-sdk-usage-problem.ts
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-sdk-usage-problem.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useRef } from "react";
 
 import { printUsageProblemToConsole } from "embedding-sdk-bundle/lib/print-usage-problem";
 import { getSdkUsageProblem } from "embedding-sdk-bundle/lib/usage-problem";
@@ -7,6 +7,7 @@ import { setUsageProblem } from "embedding-sdk-bundle/store/reducer";
 import {
   getHasTokenFeature,
   getIsGuestEmbedRaw,
+  getUsageProblem,
 } from "embedding-sdk-bundle/store/selectors";
 import type { MetabaseAuthConfig } from "embedding-sdk-bundle/types/auth-config";
 import { useSetting } from "metabase/common/hooks";
@@ -48,16 +49,23 @@ export function useSdkUsageProblem({
     return getTokenFeature(state, "development_mode");
   });
 
-  const usageProblem = useMemo(() => {
-    return getSdkUsageProblem({
-      isGuestEmbed,
-      authConfig,
-      hasTokenFeature,
-      isEnabled,
-      isDevelopmentMode,
-      session,
-      isLocalHost,
-    });
+  // Sync the computed usage problem to the store whenever inputs change.
+  // This lets other consumers (e.g. SDK components that stop rendering on
+  // license errors) read the problem from the store.
+  useEffect(() => {
+    dispatch(
+      setUsageProblem(
+        getSdkUsageProblem({
+          isGuestEmbed,
+          authConfig,
+          hasTokenFeature,
+          isEnabled,
+          isDevelopmentMode,
+          session,
+          isLocalHost,
+        }),
+      ),
+    );
   }, [
     isGuestEmbed,
     authConfig,
@@ -66,12 +74,15 @@ export function useSdkUsageProblem({
     isDevelopmentMode,
     session,
     isLocalHost,
+    dispatch,
   ]);
 
-  useEffect(() => {
-    // SDK components will stop rendering if a license error is detected.
-    dispatch(setUsageProblem(usageProblem));
+  // Read the problem from the store rather than from a local useMemo so that
+  // external dispatches (e.g. the "Hide" button calling setUsageProblem(null))
+  // are reflected here.
+  const usageProblem = useSdkSelector(getUsageProblem);
 
+  useEffect(() => {
     // Log the problem to the console once.
     if (!hasLoggedRef.current && allowConsoleLog) {
       printUsageProblemToConsole(usageProblem);


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #70639
Closes [EMB-1419: Modular SDK on a Dev instance - Metabase SDK banner display issues](https://linear.app/metabase/issue/EMB-1419/modular-sdk-on-a-dev-instance-metabase-sdk-banner-display-issues)

### Description

Fixes an issue with how we used to read the sdkUsage value from _not_ the store, preventing users from setting it to `null`
 to hide it.

Double backport so the customer who reported this gets the fix (they're running 58).

### How to verify

Run an SDK app with an API key to get this banner:
<img width="1639" height="750" alt="SCR-20260311-noaj-2" src="https://github.com/user-attachments/assets/b1e9acb4-d08a-43e2-9195-06590a45e31c" />

Clicking on "Hide warning" should hide both the popover and the pill.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
