### PR TITLE
[Slackbot] Fancy

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/persistence.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/persistence.clj
@@ -21,18 +21,24 @@
                               (constantly (cond-> {:user_id    api/*current-user-id*}
                                             state (assoc :state state))))
     ;; NOTE: this will need to be constrained at some point, see BOT-386
-    (t2/insert! :model/MetabotMessage
-                (cond-> {:conversation_id conversation-id
-                         :data            messages
-                         :usage           (:usage finish)
-                         :role            (:role (first messages))
-                         :profile_id      profile-id
-                         :total_tokens    (->> (vals (:usage finish))
-                                               ;; NOTE: this filter is supporting backward-compatible usage format, can be
-                                               ;; removed when ai-service does not give us `completionTokens` in `usage`
-                                               (filter map?)
-                                               (map #(+ (:prompt %) (:completion %)))
-                                               (apply +))}
-                  channel-id   (assoc :channel_id channel-id)
-                  slack-msg-id (assoc :slack_msg_id slack-msg-id)
-                  user-id      (assoc :user_id user-id)))))
+    (t2/insert-returning-pk! :model/MetabotMessage
+                             (cond-> {:conversation_id conversation-id
+                                      :data            messages
+                                      :usage           (:usage finish)
+                                      :role            (:role (first messages))
+                                      :profile_id      profile-id
+                                      :total_tokens    (->> (vals (:usage finish))
+                                                            ;; NOTE: this filter is supporting backward-compatible usage format, can be
+                                                            ;; removed when ai-service does not give us `completionTokens` in `usage`
+                                                            (filter map?)
+                                                            (map #(+ (:prompt %) (:completion %)))
+                                                            (apply +))}
+                               channel-id   (assoc :channel_id channel-id)
+                               slack-msg-id (assoc :slack_msg_id slack-msg-id)
+                               user-id      (assoc :user_id user-id)))))
+
+(defn set-response-slack-msg-id!
+  "Backfill slack_msg_id on a MetabotMessage by primary key."
+  [msg-id slack-msg-id]
+  (when (and msg-id slack-msg-id)
+    (t2/update! :model/MetabotMessage msg-id {:slack_msg_id slack-msg-id})))

--- a/enterprise/backend/src/metabase_enterprise/slackbot/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/slackbot/api.clj
@@ -171,27 +171,6 @@
                                                             (str/join ", " skipped-files))})))
       (slackbot.streaming/send-response client event extra-history))))
 
-(defn- with-processing-reaction
-  "Wrap work with a temporary :eyes: reaction on the triggering message for non-DMs."
-  [client event f]
-  (let [reaction-target (when-not (slackbot.events/dm? event)
-                          {:channel (:channel event)
-                           :ts      (:ts event)
-                           :name    "eyes"})]
-    (when reaction-target
-      (let [res (slackbot.client/add-reaction client reaction-target)]
-        (when-not (:ok res)
-          (log/warnf "[slackbot] Failed to add processing reaction: %s (channel=%s ts=%s name=%s)"
-                     (:error res) (:channel reaction-target) (:ts reaction-target) (:name reaction-target)))))
-    (try
-      (f)
-      (finally
-        (when reaction-target
-          (let [res (slackbot.client/remove-reaction client reaction-target)]
-            (when-not (:ok res)
-              (log/warnf "[slackbot] Failed to remove processing reaction: %s (channel=%s ts=%s name=%s)"
-                         (:error res) (:channel reaction-target) (:ts reaction-target) (:name reaction-target)))))))))
-
 (defmethod analytics/known-labels :metabase-slackbot/responses-generated [_]
   [{:source "dm"      :result "success"}
    {:source "dm"      :result "error"}
@@ -213,23 +192,21 @@
   (let [event-type (or (:subtype event) (:channel_type event) (:type event))]
     (log/debugf "[slackbot] Processing %s event" event-type)
     (future
-      (with-processing-reaction client event
-        (fn []
-          (try
-            (when-let [user-id (require-authenticated-slack-user! client event)]
-              (request/with-current-user user-id
-                (let [source (event-source event)
-                      timer  (u/start-timer)]
-                  (try
-                    (handler client event)
-                    (analytics/inc! :metabase-slackbot/responses-generated {:source source :result "success"})
-                    (catch Exception e
-                      (analytics/inc! :metabase-slackbot/responses-generated {:source source :result "error"})
-                      (throw e))
-                    (finally
-                      (analytics/observe! :metabase-slackbot/response-duration-ms {:source source} (u/since-ms timer)))))))
-            (catch Exception e
-              (log/errorf e "[slackbot] Error processing %s: %s" event-type (ex-message e)))))))))
+      (try
+        (when-let [user-id (require-authenticated-slack-user! client event)]
+          (request/with-current-user user-id
+            (let [source (event-source event)
+                  timer  (u/start-timer)]
+              (try
+                (handler client event)
+                (analytics/inc! :metabase-slackbot/responses-generated {:source source :result "success"})
+                (catch Exception e
+                  (analytics/inc! :metabase-slackbot/responses-generated {:source source :result "error"})
+                  (throw e))
+                (finally
+                  (analytics/observe! :metabase-slackbot/response-duration-ms {:source source} (u/since-ms timer)))))))
+        (catch Exception e
+          (log/errorf e "[slackbot] Error processing %s: %s" event-type (ex-message e)))))))
 
 (defn- ignore-event
   "Handle any event we don't care to process"

--- a/enterprise/backend/src/metabase_enterprise/slackbot/channel.clj
+++ b/enterprise/backend/src/metabase_enterprise/slackbot/channel.clj
@@ -2,6 +2,7 @@
   "Visible Slack channel reply/update flow for metabot."
   (:require
    [clojure.string :as str]
+   [metabase-enterprise.metabot-v3.persistence :as metabot-v3.persistence]
    [metabase-enterprise.slackbot.client :as slackbot.client]
    [metabase.util.log :as log]))
 
@@ -62,7 +63,8 @@
                                         :thread-ts            thread-ts
                                         :tool-name->friendly  tool-name->friendly})
         prefetched-viz (atom {})
-        on-data        (make-viz-prefetch-callback prefetched-viz)]
+        on-data        (make-viz-prefetch-callback prefetched-viz)
+        stored-msg-id  (atom nil)]
     (set-status! "Thinking...")
     (try
       (make-streaming-ai-request
@@ -78,7 +80,8 @@
         :on-data              on-data
         :req-slack-msg-id     (:ts event)
         :get-res-slack-msg-id nil
-        :request-prompt       (channel-request-prompt prompt)})
+        :request-prompt       (channel-request-prompt prompt)
+        :stored-msg-id        stored-msg-id})
       (when (seq @prefetched-viz)
         (set-status! "Rendering results..."))
       (let [{:keys [blocks errors]} (collect-viz-blocks @prefetched-viz)
@@ -90,6 +93,8 @@
                                           (feedback-blocks conversation-id))
             res                     (slackbot.client/post-thread-reply client {:channel channel :thread_ts thread-ts}
                                                                        final-text :blocks final-blocks)]
+        (when-let [res-ts (:ts res)]
+          (metabot-v3.persistence/set-response-slack-msg-id! @stored-msg-id res-ts))
         (when-not (:ok res)
           (log/errorf "[slackbot] channel post-message failed: %s (block_count=%d block_types=%s response_messages=%s)"
                       (:error res)

--- a/enterprise/backend/src/metabase_enterprise/slackbot/channel.clj
+++ b/enterprise/backend/src/metabase_enterprise/slackbot/channel.clj
@@ -3,14 +3,9 @@
   (:require
    [clojure.string :as str]
    [metabase-enterprise.slackbot.client :as slackbot.client]
-   [metabase.util :as u]
    [metabase.util.log :as log]))
 
 (set! *warn-on-reflection* true)
-
-(def ^:private min-flush-interval-ms
-  "Minimum milliseconds between consecutive channel progress updates."
-  600)
 
 (def ^:private channel-response-style-suffix
   (str "\n\n"
@@ -33,154 +28,81 @@
       :text {:type "mrkdwn"
              :text text}}]))
 
-(defn- progress-text
-  "Build the in-progress text shown in a visible channel reply."
-  [thinking-placeholder status]
-  (if (seq status)
-    (str "_" status "_")
-    thinking-placeholder))
-
-(defn- progress-blocks
-  "Build blocks for an in-progress visible channel reply."
-  [thinking-placeholder status]
-  [{:type "section"
-    :text {:type "mrkdwn"
-           :text (progress-text thinking-placeholder status)}}])
-
-(defn- update-channel-message!
-  "Update an existing Slack message with the full intended payload."
-  [client channel message-ts op-label text blocks]
-  (let [res (slackbot.client/update-message client
-                                            (cond-> {:channel channel
-                                                     :ts      message-ts
-                                                     :text    text}
-                                              blocks (assoc :blocks blocks)))]
-    (when-not (:ok res)
-      (log/warnf "[slackbot] %s failed: %s (block_count=%d block_types=%s response_messages=%s)"
-                 op-label
-                 (:error res)
-                 (count (or blocks []))
-                 (pr-str (when blocks (mapv :type blocks)))
-                 (pr-str (get-in res [:response_metadata :messages]))))
-    res))
-
 (defn- make-channel-callbacks
-  "Create callback functions that update a single visible threaded reply in channels.
-   Channel replies only surface tool-status updates progressively; text is accumulated
-   and sent once in the final message update."
-  [client {:keys [channel message-ts thinking-placeholder tool-name->friendly]}]
-  (let [rendered-text     (atom thinking-placeholder)
-        current-text      (atom "")
-        current-status    (atom nil)
-        update-failed?    (atom false)
-        slack-writer      (agent nil
-                                 :error-mode    :continue
-                                 :error-handler (fn [_ e] (log/warn e "[slackbot] Async Slack update failed")))
-        last-flush-timer  (volatile! nil)
-        flush-progress!   (fn []
-                            (when (and message-ts (not @update-failed?))
-                              (let [rendered (progress-text thinking-placeholder @current-status)]
-                                (when (not= rendered @rendered-text)
-                                  (let [res (slackbot.client/update-message client {:channel channel
-                                                                                    :ts      message-ts
-                                                                                    :text    rendered
-                                                                                    :blocks  (progress-blocks thinking-placeholder
-                                                                                                              @current-status)})]
-                                    (if (:ok res)
-                                      (reset! rendered-text rendered)
-                                      (do
-                                        (reset! update-failed? true)
-                                        (log/warnf "[slackbot] channel update failed: %s (channel=%s ts=%s)"
-                                                   (:error res) channel message-ts))))))))]
-    (letfn [(request-flush! ([] (request-flush! false))
-              ([force?]
-               (when (and message-ts (not @update-failed?))
-                 (when (or force?
-                           (nil? @last-flush-timer)
-                           (>= (u/since-ms @last-flush-timer) min-flush-interval-ms))
-                   (vreset! last-flush-timer (u/start-timer))
-                   (send-off slack-writer (bound-fn* (fn [_] (flush-progress!) nil)))))))
-            (set-status! [status]
-              (reset! current-status status)
-              (request-flush! true))]
-      {:on-text        (bound-fn* (fn [text]
-                                    (when (seq text)
-                                      (swap! current-text str text))))
-       :on-tool-start  (fn [{:keys [tool-name]}]
-                         (set-status! (str (tool-name->friendly tool-name "Thinking") "...")))
-       :request-flush! request-flush!
-       :set-status!    set-status!
-       :slack-writer   slack-writer
-       :current-text   current-text
-       :update-failed? update-failed?})))
+  "Create callback functions for channel replies.
+   Uses the Slack assistant setStatus API for progress indication.
+   Text is accumulated and sent once in the final message post."
+  [client {:keys [channel thread-ts tool-name->friendly]}]
+  (let [current-text (atom "")]
+    (letfn [(set-status! [status]
+              (try
+                (slackbot.client/set-status client {:status "is doing science..."
+                                                    :channel-id channel
+                                                    :thread-ts  thread-ts
+                                                    :loading-messages [(or status "")]})
+                (catch Exception e
+                  (log/warnf e "[slackbot] set-status failed (channel=%s thread-ts=%s)" channel thread-ts))))]
+      {:on-text       (bound-fn* (fn [text]
+                                   (when (seq text)
+                                     (swap! current-text str text))))
+       :on-tool-start (fn [{:keys [tool-name]}]
+                        (set-status! (str (tool-name->friendly tool-name "Thinking") "...")))
+       :set-status!   set-status!
+       :current-text  current-text})))
 
 (defn send-channel-response
-  "Send a visible threaded reply/update flow for non-DM Slack conversations."
+  "Send a visible threaded reply for non-DM Slack conversations.
+   Accumulates AI text during streaming and posts the final response as a single message."
   [client event extra-history {:keys [channel-id message-ctx channel thread-ts thread bot-user-id prompt conversation-id]}
-   {:keys [thinking-placeholder tool-name->friendly
+   {:keys [tool-name->friendly
            make-streaming-ai-request collect-viz-blocks feedback-blocks post-viz-error!
            make-viz-prefetch-callback cancel-prefetched-viz!]}]
-  (let [initial-response (slackbot.client/post-thread-reply client
-                                                            {:channel channel :thread_ts thread-ts}
-                                                            thinking-placeholder)
-        message-ts       (:ts initial-response)
-        {:keys [on-text on-tool-start
-                request-flush! set-status! slack-writer current-text update-failed?]}
+  (let [{:keys [on-text on-tool-start set-status! current-text]}
         (make-channel-callbacks client {:channel              channel
-                                        :message-ts           message-ts
-                                        :thinking-placeholder thinking-placeholder
+                                        :thread-ts            thread-ts
                                         :tool-name->friendly  tool-name->friendly})
-        prefetched-viz   (atom {})
-        on-data          (make-viz-prefetch-callback prefetched-viz)]
-    (when-not (:ok initial-response)
-      (log/warnf "[slackbot] initial channel reply failed: %s (channel=%s thread_ts=%s)"
-                 (:error initial-response) channel thread-ts))
+        prefetched-viz (atom {})
+        on-data        (make-viz-prefetch-callback prefetched-viz)]
+    (set-status! "Thinking...")
     (try
-      (let [_data-parts (make-streaming-ai-request
-                         conversation-id
-                         prompt
-                         thread
-                         bot-user-id
-                         channel-id
-                         extra-history
-                         {:on-text              on-text
-                          :on-tool-start        on-tool-start
-                          :on-tool-end          nil
-                          :on-data              on-data
-                          :req-slack-msg-id     (:ts event)
-                          :get-res-slack-msg-id (when message-ts (fn [] message-ts))
-                          :request-prompt       (channel-request-prompt prompt)})]
-        (request-flush! true)
-        (when (seq @prefetched-viz)
-          (set-status! "Rendering results..."))
-        (await slack-writer)
-        (let [{:keys [blocks errors]} (collect-viz-blocks @prefetched-viz)
-              answer-text             (str/trim @current-text)
-              final-text              (if (or (seq answer-text) (seq blocks))
-                                        answer-text
-                                        "I wasn't able to generate a response. Please try again.")
-              final-blocks            (into (into (final-text-blocks final-text) blocks)
-                                            (feedback-blocks conversation-id))]
-          (when (or (nil? message-ts)
-                    @update-failed?
-                    (not (:ok (update-channel-message! client channel message-ts "channel update-message" final-text final-blocks))))
-            (let [res (slackbot.client/post-thread-reply client message-ctx
-                                                         "I generated a response, but Slack could not render it. Please try again.")]
-              (when-not (:ok res)
-                (log/errorf "[slackbot] channel fallback post-message failed: %s" (:error res)))))
-          (doseq [e errors]
-            (post-viz-error! client channel thread-ts e))))
+      (make-streaming-ai-request
+       conversation-id
+       prompt
+       thread
+       bot-user-id
+       channel-id
+       extra-history
+       {:on-text              on-text
+        :on-tool-start        on-tool-start
+        :on-tool-end          nil
+        :on-data              on-data
+        :req-slack-msg-id     (:ts event)
+        :get-res-slack-msg-id nil
+        :request-prompt       (channel-request-prompt prompt)})
+      (when (seq @prefetched-viz)
+        (set-status! "Rendering results..."))
+      (let [{:keys [blocks errors]} (collect-viz-blocks @prefetched-viz)
+            answer-text             (str/trim @current-text)
+            final-text              (if (or (seq answer-text) (seq blocks))
+                                      answer-text
+                                      "I wasn't able to generate a response. Please try again.")
+            final-blocks            (into (into (final-text-blocks final-text) blocks)
+                                          (feedback-blocks conversation-id))
+            res                     (slackbot.client/post-thread-reply client {:channel channel :thread_ts thread-ts}
+                                                                       final-text :blocks final-blocks)]
+        (when-not (:ok res)
+          (log/errorf "[slackbot] channel post-message failed: %s (block_count=%d block_types=%s response_messages=%s)"
+                      (:error res)
+                      (count (or final-blocks []))
+                      (pr-str (when final-blocks (mapv :type final-blocks)))
+                      (pr-str (get-in res [:response_metadata :messages]))))
+        (doseq [e errors]
+          (post-viz-error! client channel thread-ts e)))
       (catch Exception e
         (cancel-prefetched-viz! prefetched-viz)
         (log/error e "[slackbot] Error in channel response")
         (set-status! nil)
-        (await slack-writer)
-        (let [error-text "Something went wrong. Please try again."]
-          (when (or (nil? message-ts)
-                    @update-failed?
-                    (not (:ok (slackbot.client/update-message client {:channel channel
-                                                                      :ts      message-ts
-                                                                      :text    error-text}))))
-            (let [res (slackbot.client/post-thread-reply client message-ctx error-text)]
-              (when-not (:ok res)
-                (log/errorf "[slackbot] channel cleanup fallback post-message failed: %s" (:error res))))))))))
+        (let [res (slackbot.client/post-thread-reply client message-ctx
+                                                     "Something went wrong. Please try again.")]
+          (when-not (:ok res)
+            (log/errorf "[slackbot] channel error post-message failed: %s" (:error res))))))))

--- a/enterprise/backend/src/metabase_enterprise/slackbot/client.clj
+++ b/enterprise/backend/src/metabase_enterprise/slackbot/client.clj
@@ -101,6 +101,14 @@
   [client args]
   (slack-post-form client "/files.getUploadURLExternal" args))
 
+(defn set-status
+  "Set the status for a Slack assistant thread."
+  [client {:keys [status channel-id thread-ts loading-messages]}]
+  (:body (slack-post-json client "/assistant.threads.setStatus" (cond-> {:status status
+                                                                         :channel_id channel-id
+                                                                         :thread_ts thread-ts}
+                                                                  loading-messages (assoc :loading_messages loading-messages)))))
+
 (defn post-message
   "Send a Slack message"
   [client message]

--- a/enterprise/backend/src/metabase_enterprise/slackbot/streaming.clj
+++ b/enterprise/backend/src/metabase_enterprise/slackbot/streaming.clj
@@ -573,8 +573,7 @@
                                                event
                                                extra-history
                                                ctx
-                                               {:thinking-placeholder       thinking-placeholder
-                                                :tool-name->friendly        tool-friendly-names
+                                               {:tool-name->friendly        tool-friendly-names
                                                 :make-streaming-ai-request  make-streaming-ai-request
                                                 :collect-viz-blocks         collect-viz-blocks
                                                 :feedback-blocks            feedback-blocks

--- a/enterprise/backend/src/metabase_enterprise/slackbot/streaming.clj
+++ b/enterprise/backend/src/metabase_enterprise/slackbot/streaming.clj
@@ -164,7 +164,7 @@
    - req-slack-msg-id: The Slack message ts for the user's incoming message
    - get-response-ts: Function that returns the Slack message ts for the bot's response"
   [conversation-id prompt thread bot-user-id channel-id extra-history
-   {:keys [on-text on-tool-start on-tool-end on-data req-slack-msg-id get-res-slack-msg-id request-prompt]}]
+   {:keys [on-text on-tool-start on-tool-end on-data req-slack-msg-id get-res-slack-msg-id request-prompt stored-msg-id]}]
   (let [data-idx        (volatile! -1)
         message         (metabot-v3.envelope/user-message prompt)
         request-message (metabot-v3.envelope/user-message (or request-prompt prompt))
@@ -215,13 +215,15 @@
                           :state           {}
                           :on-line         handle-line
                           :on-complete     (fn [lines]
-                                             (metabot-v3.persistence/store-message!
-                                              conversation-id profile-id
-                                              (metabot-v3.u/aisdk->messages :assistant lines)
-                                              :channel-id   channel-id
-                                              :slack-msg-id (when get-res-slack-msg-id (get-res-slack-msg-id))
-                                              :user-id      api/*current-user-id*)
-                                             :store-in-db)})]
+                                             (let [pk (metabot-v3.persistence/store-message!
+                                                       conversation-id profile-id
+                                                       (metabot-v3.u/aisdk->messages :assistant lines)
+                                                       :channel-id   channel-id
+                                                       :slack-msg-id (when get-res-slack-msg-id (get-res-slack-msg-id))
+                                                       :user-id      api/*current-user-id*)]
+                                               (when stored-msg-id
+                                                 (reset! stored-msg-id pk))
+                                               :store-in-db))})]
     (->> (metabot-v3.u/aisdk->messages :assistant lines)
          (filter #(= (:_type %) :DATA)))))
 

--- a/enterprise/backend/test/metabase_enterprise/slackbot/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/slackbot/api_test.clj
@@ -186,31 +186,24 @@
             event-body   tu/base-mention-event]
         (tu/with-slackbot-mocks
           {:ai-text mock-ai-text}
-          (fn [{:keys [post-calls stream-calls stop-stream-calls update-calls
-                       add-reaction-calls remove-reaction-calls]}]
+          (fn [{:keys [post-calls stream-calls stop-stream-calls]}]
             (let [response (mt/client :post 200 "ee/metabot-v3/slack/events"
                                       (tu/slack-request-options event-body)
                                       event-body)]
               (is (= "ok" response))
-              (u/poll {:thunk      #(and (>= (count @update-calls) 1)
-                                         (>= (count @remove-reaction-calls) 1))
+              (u/poll {:thunk      #(>= (count @post-calls) 1)
                        :done?      true?
                        :timeout-ms 5000})
-              (testing "a visible threaded reply is posted immediately with thinking placeholder"
+              (testing "a single threaded reply is posted with the answer"
                 (is (= 1 (count @post-calls)))
-                (is (= "_Thinking..._" (:text (first @post-calls))))
+                (is (str/includes? (:text (first @post-calls)) mock-ai-text))
                 (is (= "1234567890.000001" (:thread_ts (first @post-calls)))))
-              (testing "the triggering message gets a temporary eyes reaction"
-                (is (= [{:channel "C123" :ts "1234567890.000001" :name "eyes"}]
-                       @add-reaction-calls))
-                (is (= [{:channel "C123" :ts "1234567890.000001" :name "eyes"}]
-                       @remove-reaction-calls)))
-              (testing "the visible reply is updated with the answer"
-                (is (= 1 (count @update-calls)))
-                (is (some #(str/includes? (:text %) mock-ai-text) @update-calls)))
               (testing "streaming APIs are not used for app mentions"
                 (is (empty? @stream-calls))
-                (is (empty? @stop-stream-calls))))))))))
+                (is (empty? @stop-stream-calls)))
+              (testing "assistant message in DB has slack_msg_id backfilled"
+                (let [msg (t2/select-one :model/MetabotMessage :channel_id "C123" :role "assistant")]
+                  (is (some? (:slack_msg_id msg))))))))))))
 
 (deftest stream-start-failure-test
   (testing "When start-stream fails, falls back to a regular message"

--- a/enterprise/backend/test/metabase_enterprise/slackbot/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/slackbot/test_util.clj
@@ -101,7 +101,7 @@
    {:post-calls, :delete-calls, :update-calls, :image-calls, :generate-card-output-calls,
     :generate-adhoc-output-calls, :ephemeral-calls, :ai-request-calls, :fake-png-bytes,
     :stream-calls, :append-text-calls, :stop-stream-calls,
-    :add-reaction-calls, :remove-reaction-calls}"
+    :add-reaction-calls, :remove-reaction-calls, :set-status-calls}"
   [{:keys [ai-text data-parts user-id]
     :or   {data-parts []
            user-id    ::default}}
@@ -119,6 +119,7 @@
         stop-stream-calls           (atom [])
         add-reaction-calls          (atom [])
         remove-reaction-calls       (atom [])
+        set-status-calls            (atom [])
         fake-png-bytes              (byte-array [0x89 0x50 0x4E 0x47])
         file-counter                (atom 0)
         placeholder-counter         (atom 0)
@@ -163,6 +164,9 @@
        slackbot.client/remove-reaction (fn [_ msg]
                                          (swap! remove-reaction-calls conj msg)
                                          {:ok true})
+       slackbot.client/set-status (fn [_ opts]
+                                    (swap! set-status-calls conj opts)
+                                    {:ok true})
        channel.slack/upload-file! (fn [image-bytes filename]
                                     (let [file-id (format "FIMG-%d" (swap! file-counter inc))]
                                       (swap! image-calls conj {:image-bytes image-bytes
@@ -210,4 +214,5 @@
                 :stop-stream-calls           stop-stream-calls
                 :add-reaction-calls          add-reaction-calls
                 :remove-reaction-calls       remove-reaction-calls
+                :set-status-calls            set-status-calls
                 :fake-png-bytes              fake-png-bytes}))))


### PR DESCRIPTION
Closes [BOT-1110: Leverage setStatus api](https://linear.app/metabase/issue/BOT-1110/leverage-setstatus-api)

### Description

Makes the response format even fancier in channels. See: https://metaboat.slack.com/archives/C0ACBV3THC3/p1773246200783289