### PR TITLE
fix(sdk-bundle): only render SDK components when EE plugins are loaded

### DIFF
--- a/frontend/src/embedding-sdk-bundle/components/private/PublicComponentWrapper/PublicComponentWrapper.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/PublicComponentWrapper/PublicComponentWrapper.tsx
@@ -3,6 +3,7 @@ import { type ReactNode, forwardRef } from "react";
 import { PublicComponentStylesWrapper } from "embedding-sdk-bundle/components/private/PublicComponentStylesWrapper";
 import { SdkError } from "embedding-sdk-bundle/components/private/PublicComponentWrapper/SdkError";
 import { SdkLoader } from "embedding-sdk-bundle/components/private/PublicComponentWrapper/SdkLoader";
+import { useArePluginsReady } from "embedding-sdk-bundle/hooks/private/use-are-plugins-ready";
 import { useSdkSelector } from "embedding-sdk-bundle/store";
 import {
   getInitStatus,
@@ -20,6 +21,7 @@ export const PublicComponentWrapper = forwardRef<
 >(function PublicComponentWrapper({ children, className, style }, ref) {
   const initStatus = useSdkSelector(getInitStatus);
   const usageProblem = useSdkSelector(getUsageProblem);
+  const pluginsReady = useArePluginsReady();
 
   let content = children;
 
@@ -39,6 +41,11 @@ export const PublicComponentWrapper = forwardRef<
   // The SDK components should not load if there is a license error.
   if (usageProblem?.severity === "error") {
     content = null;
+  }
+
+  // Wait for EE plugins to be initialized before rendering children.
+  if (!pluginsReady && content === children) {
+    content = <SdkLoader />;
   }
 
   return (

--- a/frontend/src/embedding-sdk-bundle/components/private/PublicComponentWrapper/PublicComponentWrapper.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/PublicComponentWrapper/PublicComponentWrapper.unit.spec.tsx
@@ -1,5 +1,8 @@
+import { act } from "@testing-library/react";
+
 import { renderWithProviders, screen } from "__support__/ui";
 import { sdkReducers } from "embedding-sdk-bundle/store";
+import { setPluginsReady } from "embedding-sdk-bundle/store/reducer";
 import {
   createMockLoginStatusState,
   createMockSdkState,
@@ -9,10 +12,14 @@ import { createMockState } from "metabase-types/store/mocks";
 
 import { PublicComponentWrapper } from "./PublicComponentWrapper";
 
-const setup = (status: LoginStatus = { status: "uninitialized" }) => {
+const setup = (
+  status: LoginStatus = { status: "uninitialized" },
+  pluginsReady = true,
+) => {
   const state = createMockState({
     sdk: createMockSdkState({
       initStatus: createMockLoginStatusState(status),
+      pluginsReady,
     }),
   });
 
@@ -54,5 +61,33 @@ describe("PublicComponentWrapper", () => {
     setup({ status: "success" });
     const component = screen.getByText("My component");
     expect(component).toBeInTheDocument();
+  });
+
+  describe("plugin initialization race condition (EMB-1426)", () => {
+    it("shows loader when auth is done but plugins are not yet initialized", () => {
+      // Simulate the race: initStatus is "success" (auth completed) but
+      // pluginsReady is false (EE plugins haven't been initialized yet).
+      // This happens when ComponentProvider mounts after the SDK has already
+      // loaded, e.g. when a collapsible containing an iframe is first opened.
+      setup({ status: "success" }, false);
+
+      expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
+      expect(screen.queryByText("My component")).not.toBeInTheDocument();
+    });
+
+    it("renders children once plugins are initialized", async () => {
+      const { store } = setup({ status: "success" }, false);
+
+      expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
+
+      // Simulate useInitPlugins completing — dispatch is what
+      // ComponentProvider does after initializePlugins() returns.
+      act(() => {
+        store.dispatch(setPluginsReady(true));
+      });
+
+      expect(await screen.findByText("My component")).toBeInTheDocument();
+      expect(screen.queryByTestId("loading-indicator")).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/embedding-sdk-bundle/components/public/ComponentProvider/ComponentProvider.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/ComponentProvider/ComponentProvider.tsx
@@ -21,11 +21,7 @@ import { EnsureSingleInstance } from "embedding-sdk-shared/components/EnsureSing
 import { useInstanceLocale } from "metabase/common/hooks/use-instance-locale";
 import { isEmbeddingEajs } from "metabase/embedding-sdk/config";
 import { isEmbeddingThemeV1 } from "metabase/embedding-sdk/theme";
-import {
-  MetabaseReduxProvider,
-  useDispatch,
-  useSelector,
-} from "metabase/lib/redux";
+import { MetabaseReduxProvider, useSelector } from "metabase/lib/redux";
 import { LocaleProvider } from "metabase/public/LocaleProvider";
 import { setOptions } from "metabase/redux/embed";
 import { EmotionCacheProvider } from "metabase/styled-components/components/EmotionCacheProvider";
@@ -44,34 +40,36 @@ export type ComponentProviderInternalProps = ComponentProviderProps & {
 
 let hasInitializedPlugins = false;
 
-function useInitPlugins() {
-  const dispatch = useDispatch();
-
+/**
+ * Initializes EE plugins synchronously during render
+ * to avoid an extra frame where children render without plugins.
+ *
+ * Uses reduxStore.dispatch directly instead of the useDispatch hook,
+ * since the hook-based dispatch may not be available during render.
+ * This follows the same pattern as use-init-data-internal.ts.
+ */
+function useInitPlugins(reduxStore: SdkStore) {
   const tokenFeatures = useSelector(
     (state) => state.settings.values["token-features"],
   );
 
-  useEffect(() => {
-    // Modular Embedding already initializes the plugins in its entrypoint.
-    // We have to avoid re-initializing SDK plugins as they could override
-    // some of plugins needed by EAJS
-    if (isEmbeddingEajs() || !tokenFeatures) {
-      return;
-    }
+  // Modular Embedding already initializes the plugins in its entrypoint.
+  // We have to avoid re-initializing SDK plugins as they could override
+  // some of plugins needed by EAJS
+  if (isEmbeddingEajs() || !tokenFeatures) {
+    return;
+  }
 
-    if (hasInitializedPlugins) {
-      // Plugins already initialized (e.g. a second ComponentProvider mounting,
-      // or a fresh store in tests). Don't re-run initializePlugins, but do
-      // mark this store instance as ready.
-      dispatch(setPluginsReady(true));
-      return;
-    }
-
+  if (!hasInitializedPlugins) {
     hasInitializedPlugins = true;
 
     initializePlugins();
-    dispatch(setPluginsReady(true));
-  }, [tokenFeatures, dispatch]);
+  }
+
+  // Mark ready for this store instance on first render.
+  if (!reduxStore.getState().sdk?.pluginsReady) {
+    reduxStore.dispatch(setPluginsReady(true));
+  }
 }
 
 export const ComponentProviderInternal = (
@@ -104,7 +102,7 @@ export const ComponentProviderInternal = (
     isLocalHost,
   });
 
-  useInitPlugins();
+  useInitPlugins(reduxStore);
 
   useSdkCustomLoader();
 

--- a/frontend/src/embedding-sdk-bundle/components/public/ComponentProvider/ComponentProvider.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/ComponentProvider/ComponentProvider.tsx
@@ -1,6 +1,6 @@
 // eslint-disable-next-line no-restricted-imports -- We sometimes need css-in-js in the SDK
 import { Global } from "@emotion/react";
-import { type JSX, memo, useEffect, useId, useRef, useState } from "react";
+import { type JSX, memo, useEffect, useId, useRef } from "react";
 
 import { ContentTranslationsProvider } from "embedding-sdk-bundle/components/private/ContentTranslationsProvider";
 import { SdkThemeProvider } from "embedding-sdk-bundle/components/private/SdkThemeProvider";
@@ -13,6 +13,7 @@ import {
   setEventHandlers,
   setIsGuestEmbed,
   setPlugins,
+  setPluginsReady,
 } from "embedding-sdk-bundle/store/reducer";
 import type { SdkStore } from "embedding-sdk-bundle/store/types";
 import type { MetabaseProviderProps } from "embedding-sdk-bundle/types/metabase-provider";
@@ -20,7 +21,11 @@ import { EnsureSingleInstance } from "embedding-sdk-shared/components/EnsureSing
 import { useInstanceLocale } from "metabase/common/hooks/use-instance-locale";
 import { isEmbeddingEajs } from "metabase/embedding-sdk/config";
 import { isEmbeddingThemeV1 } from "metabase/embedding-sdk/theme";
-import { MetabaseReduxProvider, useSelector } from "metabase/lib/redux";
+import {
+  MetabaseReduxProvider,
+  useDispatch,
+  useSelector,
+} from "metabase/lib/redux";
 import { LocaleProvider } from "metabase/public/LocaleProvider";
 import { setOptions } from "metabase/redux/embed";
 import { EmotionCacheProvider } from "metabase/styled-components/components/EmotionCacheProvider";
@@ -40,11 +45,7 @@ export type ComponentProviderInternalProps = ComponentProviderProps & {
 let hasInitializedPlugins = false;
 
 function useInitPlugins() {
-  // If plugins are already initialized (e.g. EAJS, or a second SDK component
-  // mounting after the first), we are ready immediately.
-  const [pluginsReady, setPluginsReady] = useState(
-    () => isEmbeddingEajs() || hasInitializedPlugins,
-  );
+  const dispatch = useDispatch();
 
   const tokenFeatures = useSelector(
     (state) => state.settings.values["token-features"],
@@ -61,10 +62,8 @@ function useInitPlugins() {
     hasInitializedPlugins = true;
 
     initializePlugins();
-    setPluginsReady(true);
-  }, [tokenFeatures]);
-
-  return pluginsReady;
+    dispatch(setPluginsReady(true));
+  }, [tokenFeatures, dispatch]);
 }
 
 export const ComponentProviderInternal = (
@@ -97,7 +96,7 @@ export const ComponentProviderInternal = (
     isLocalHost,
   });
 
-  const pluginsReady = useInitPlugins();
+  useInitPlugins();
 
   useSdkCustomLoader();
 
@@ -137,7 +136,7 @@ export const ComponentProviderInternal = (
           {({ isInstanceToRender }) => (
             <>
               <LocaleProvider locale={locale || instanceLocale}>
-                {pluginsReady && children}
+                {children}
 
                 {isInstanceToRender && <ContentTranslationsProvider />}
               </LocaleProvider>

--- a/frontend/src/embedding-sdk-bundle/components/public/ComponentProvider/ComponentProvider.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/ComponentProvider/ComponentProvider.tsx
@@ -1,6 +1,6 @@
 // eslint-disable-next-line no-restricted-imports -- We sometimes need css-in-js in the SDK
 import { Global } from "@emotion/react";
-import { type JSX, memo, useEffect, useId, useRef } from "react";
+import { type JSX, memo, useEffect, useId, useRef, useState } from "react";
 
 import { ContentTranslationsProvider } from "embedding-sdk-bundle/components/private/ContentTranslationsProvider";
 import { SdkThemeProvider } from "embedding-sdk-bundle/components/private/SdkThemeProvider";
@@ -40,6 +40,12 @@ export type ComponentProviderInternalProps = ComponentProviderProps & {
 let hasInitializedPlugins = false;
 
 function useInitPlugins() {
+  // If plugins are already initialized (e.g. EAJS, or a second SDK component
+  // mounting after the first), we are ready immediately.
+  const [pluginsReady, setPluginsReady] = useState(
+    () => isEmbeddingEajs() || hasInitializedPlugins,
+  );
+
   const tokenFeatures = useSelector(
     (state) => state.settings.values["token-features"],
   );
@@ -55,7 +61,10 @@ function useInitPlugins() {
     hasInitializedPlugins = true;
 
     initializePlugins();
+    setPluginsReady(true);
   }, [tokenFeatures]);
+
+  return pluginsReady;
 }
 
 export const ComponentProviderInternal = (
@@ -88,7 +97,7 @@ export const ComponentProviderInternal = (
     isLocalHost,
   });
 
-  useInitPlugins();
+  const pluginsReady = useInitPlugins();
 
   useSdkCustomLoader();
 
@@ -128,7 +137,7 @@ export const ComponentProviderInternal = (
           {({ isInstanceToRender }) => (
             <>
               <LocaleProvider locale={locale || instanceLocale}>
-                {children}
+                {pluginsReady && children}
 
                 {isInstanceToRender && <ContentTranslationsProvider />}
               </LocaleProvider>

--- a/frontend/src/embedding-sdk-bundle/components/public/ComponentProvider/ComponentProvider.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/ComponentProvider/ComponentProvider.tsx
@@ -52,10 +52,18 @@ function useInitPlugins() {
   );
 
   useEffect(() => {
-    // EAJS already initializes the plugins in its entrypoint, and this
-    // component is used by EAJS we have to make sure we don't re-initialize the
-    // sdk plugins as they could override some of plugins needed by EAJS
-    if (isEmbeddingEajs() || hasInitializedPlugins || !tokenFeatures) {
+    // Modular Embedding already initializes the plugins in its entrypoint.
+    // We have to avoid re-initializing SDK plugins as they could override
+    // some of plugins needed by EAJS
+    if (isEmbeddingEajs() || !tokenFeatures) {
+      return;
+    }
+
+    if (hasInitializedPlugins) {
+      // Plugins already initialized (e.g. a second ComponentProvider mounting,
+      // or a fresh store in tests). Don't re-run initializePlugins, but do
+      // mark this store instance as ready.
+      dispatch(setPluginsReady(true));
       return;
     }
 

--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-are-plugins-ready.ts
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-are-plugins-ready.ts
@@ -1,0 +1,24 @@
+import { useSdkSelector } from "embedding-sdk-bundle/store";
+import { getPluginsReady } from "embedding-sdk-bundle/store/selectors";
+import { isEmbeddingEajs } from "metabase/embedding-sdk/config";
+
+/**
+ * Returns whether the EE plugins have been initialized.
+ *
+ * For EAJS, plugins are always initialized in the entrypoint,
+ * so this always returns true.
+ *
+ * Can be used inside PublicComponentWrapper or public hooks
+ * to gate rendering until plugins are ready.
+ */
+export function useArePluginsReady(): boolean {
+  const pluginsReady = useSdkSelector(getPluginsReady);
+
+  // EAJS initializes plugins in its own entrypoint,
+  // so they are always ready.
+  if (isEmbeddingEajs()) {
+    return true;
+  }
+
+  return pluginsReady;
+}

--- a/frontend/src/embedding-sdk-bundle/store/reducer.ts
+++ b/frontend/src/embedding-sdk-bundle/store/reducer.ts
@@ -53,6 +53,9 @@ export const setUsageProblem = createAction<SdkUsageProblem | null>(
   SET_USAGE_PROBLEM,
 );
 
+const SET_PLUGINS_READY = "sdk/SET_PLUGINS_READY";
+export const setPluginsReady = createAction<boolean>(SET_PLUGINS_READY);
+
 const initialState: SdkState = {
   isGuestEmbed: null,
   metabaseInstanceUrl: "",
@@ -70,6 +73,7 @@ const initialState: SdkState = {
   usageProblem: null,
   errorComponent: null,
   fetchRefreshTokenFn: null,
+  pluginsReady: false,
 };
 
 export const sdk = createReducer(initialState, (builder) => {
@@ -193,5 +197,9 @@ export const sdk = createReducer(initialState, (builder) => {
       loading: false,
       error,
     };
+  });
+
+  builder.addCase(setPluginsReady, (state, action) => {
+    state.pluginsReady = action.payload;
   });
 });

--- a/frontend/src/embedding-sdk-bundle/store/selectors.ts
+++ b/frontend/src/embedding-sdk-bundle/store/selectors.ts
@@ -40,6 +40,8 @@ export const getMetabaseInstanceVersion = (state: SdkStoreState) =>
 export const getFetchRefreshTokenFn = (state: SdkStoreState) =>
   state.sdk.fetchRefreshTokenFn;
 
+export const getPluginsReady = (state: SdkStoreState) => state.sdk.pluginsReady;
+
 export const getAvailableFonts = (state: SdkStoreState) =>
   getSetting(state, "available-fonts");
 

--- a/frontend/src/embedding-sdk-bundle/store/types.ts
+++ b/frontend/src/embedding-sdk-bundle/store/types.ts
@@ -43,6 +43,7 @@ export type SdkState = {
   usageProblem: null | SdkUsageProblem;
   errorComponent: null | SdkErrorComponent;
   fetchRefreshTokenFn: null | MetabaseAuthConfig["fetchRequestToken"];
+  pluginsReady: boolean;
 };
 
 export interface SdkStoreState extends State {

--- a/frontend/src/embedding-sdk-bundle/test/mocks/state.ts
+++ b/frontend/src/embedding-sdk-bundle/test/mocks/state.ts
@@ -38,6 +38,7 @@ export const createMockSdkState = ({
     errorComponent: null,
     error: null,
     fetchRefreshTokenFn: null,
+    pluginsReady: true,
     ...opts,
   };
 };


### PR DESCRIPTION
Closes #70763
Closes EMB-1424

### Description

When the `ComponentProvider` mounts late (e.g. when an SDK embed is inside a collapsible element that isn't visible on page load), the first render of child components like `QuestionVisualization` would use OSS no-op plugin hooks. Then, when `useInitPlugins` fired and called `initializePlugins()`, the same components would re-render with EE hooks — changing the hook count and violating React's Rules of Hooks, causing a crash.

**Root cause:** `initializePlugins()` is called in a `useEffect`, so it always runs after the first paint. Any SDK component that had already rendered with the OSS (no-op) version of a plugin hook (e.g. `PLUGIN_CONTENT_TRANSLATION.useTranslateSeries`) would then see that hook replaced with an EE implementation on the next render, changing the number of hooks called.

**Fix:** Track plugin initialization as `pluginsReady` in the Redux store and check it in `PublicComponentWrapper` alongside the existing `initStatus` and `usageProblem` checks. SDK components show a loader until plugins are ready, so they never render with the OSS hooks and then switch to EE hooks mid-lifecycle.

A secondary bug was also fixed: the module-level `hasInitializedPlugins` flag was preventing `setPluginsReady(true)` from being dispatched when a fresh Redux store was created (e.g. in tests or when `ComponentProvider` re-mounts). Now, when plugins are already initialized, we dispatch to the new store without re-running `initializePlugins()`.

Key changes:
- `pluginsReady: boolean` added to `SdkState` (Redux store), dispatched by `useInitPlugins` in `ComponentProvider`
- `useArePluginsReady()` internal hook reads from the store (always returns `true` for EAJS, which initializes plugins in its own entrypoint)
- `PublicComponentWrapper` checks `useArePluginsReady()` and shows loader until ready
- `useInitPlugins` now dispatches `setPluginsReady(true)` even when plugins were already initialized (to sync new store instances)

### How to verify

The reliable way to reproduce this is quite convoluted. I've already done it for you though:

1. Revert the latest hotfix commit in Shoppy (https://github.com/metabase/shoppy/pull/187) so the bug happens
2. Do `MB_EDITION=ee ./bin/build.sh` and `bun run build-embedding-sdk-package` to build uberjar and SDK package
3. Copy it into Shoppy's `local-dist`.
4. Try rendering Shoppy in an iframe in a collapsible. See below code snippet
5. Wait for 5 - 6 seconds.
6. Open the collapsible.
7. It should NOT crash.

```html
<details>
  <summary>Embedded Analytics</summary>
  <iframe src="http://localhost:4400/admin/products" width="400px" height="1000px" style="border: none"></iframe>
</details>
```

<img width="200" alt="CleanShot 2569-03-13 at 20 41 36@2x" src="https://github.com/user-attachments/assets/48243989-aabf-46a6-8969-452197ac7967" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR - unit test