### PR TITLE
Fix dataset-already-loaded?-test flake on Redshift

### DIFF
--- a/modules/drivers/redshift/test/metabase/test/data/redshift.clj
+++ b/modules/drivers/redshift/test/metabase/test/data/redshift.clj
@@ -346,14 +346,15 @@
          tabledef       (first (:table-definitions dbdef))
          ;; table-name should be something like test_data_venues
          table-name     (tx/db-qualified-table-name (:database-name dbdef) (:table-name tabledef))
-         ;; Use direct SQL query instead of JDBC metadata API (.getTables) because the metadata API
-         ;; can return stale/cached results on Redshift, causing flaky test failures.
-         jdbc-spec      (sql-jdbc.conn/connection-details->spec driver (tx/dbdef->connection-details driver))
-         results        (jdbc/query jdbc-spec
-                                    ["SELECT 1 FROM information_schema.tables WHERE table_schema = ? AND table_name = ? LIMIT 1"
-                                     session-schema
-                                     table-name])]
-     (seq results))))
+         ;; Probe the table directly instead of querying information_schema.tables, which can return
+         ;; stale results on Redshift due to metadata catalog propagation delays between connections.
+         jdbc-spec      (sql-jdbc.conn/connection-details->spec driver (tx/dbdef->connection-details driver))]
+     (try
+       (jdbc/query jdbc-spec
+                   [(format "SELECT 1 FROM \"%s\".\"%s\" LIMIT 0" session-schema table-name)])
+       true
+       (catch Exception _
+         false)))))
 
 (defmethod driver/database-supports? [:redshift :test/use-fake-sync]
   [_driver _feature _database]


### PR DESCRIPTION
## Summary

- Fixes quarantined `dataset-already-loaded?-test` flake on Redshift by replacing the `information_schema.tables` metadata query with a direct table probe: `SELECT 1 FROM "schema"."table" LIMIT 0`
- The metadata catalog on Redshift is eventually consistent and can have delays between connections, causing the check to return `false` when the table actually exists
- The direct probe should be right: if the table exists and is accessible, the query succeeds if not, it throws and we return `false`

## Test plan

- [x] Verify the `dataset-already-loaded?-test` passes on Redshift CI (no longer flaky)
- [x] Verify the "should return false for dataset that definitely does not exist" case still works (exception path)