### PR TITLE
Fix flaky sync-materialized-views-test with auto-retry

### DIFF
--- a/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
+++ b/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
@@ -354,9 +354,13 @@
              qual-tbl-nm
              qual-mview-nm)
             (binding [redshift.tx/*override-describe-database-to-filter-by-db-name?* false]
-              (is (contains?
-                   (set (map :name (:tables (driver/describe-database :redshift database))))
-                   mview-nm)))))))))
+              (u/auto-retry 3
+                (let [table-names (set (map :name (:tables (driver/describe-database :redshift database))))]
+                  (when-not (contains? table-names mview-nm)
+                    (Thread/sleep 1000)
+                    (throw (ex-info "Materialized view not yet visible in describe-database results"
+                                    {:expected mview-nm :actual table-names})))
+                  (is (contains? table-names mview-nm)))))))))))
 
 (mt/defdataset unix-timestamps
   [["timestamps"


### PR DESCRIPTION
## Summary

- Fixes the quarantined flaky test `metabase.driver.redshift-test/sync-materialized-views-test` (0.22% failure rate)
- Root cause: Redshift's distributed catalog has eventual consistency for `pg_catalog.pg_class` — the materialized view created via one JDBC connection may not be immediately visible when queried via a different pooled connection
- Wraps the assertion in `u/auto-retry 3` with a 1-second sleep between attempts, matching the retry pattern already used in the production `describe-database*` method (redshift.clj:151-170)

## Test plan
- [x] `be-tests-redshift-ee` CI passes
- [ ] Test can be unquarantined after several clean CI runs