### PR TITLE
Enable old clickhouse tests

### DIFF
--- a/modules/drivers/clickhouse/src/metabase/driver/clickhouse_qp.clj
+++ b/modules/drivers/clickhouse/src/metabase/driver/clickhouse_qp.clj
@@ -623,8 +623,11 @@
   (format "'%s'" (t/format "HH:mm:ss.SSSZZZZZ" t)))
 
 (defmethod sql.qp/inline-value [:clickhouse LocalDateTime]
-  [_ t]
-  (format "'%s'" (t/format "yyyy-MM-dd HH:mm:ss.SSS" t)))
+  [_ ^LocalDateTime t]
+  (let [fmt (if (zero? (.getNano t))
+              "yyyy-MM-dd HH:mm:ss"
+              "yyyy-MM-dd HH:mm:ss.SSS")]
+    (format "'%s'" (t/format fmt t))))
 
 (defmethod sql.qp/inline-value [:clickhouse OffsetDateTime]
   [_ ^OffsetDateTime t]
@@ -649,7 +652,7 @@
   (format "[%s]" (str/join ", " (map #(sql.qp/inline-value driver %) arr))))
 
 (defmethod sql.qp/inline-value [:clickhouse java.util.HashMap]
-  [driver m]
+  [driver ^java.util.HashMap m]
   (format "{%s}"
           (str/join ", "
                     (map (fn [^java.util.Map$Entry e]

--- a/modules/drivers/clickhouse/src/metabase/driver/clickhouse_qp.clj
+++ b/modules/drivers/clickhouse/src/metabase/driver/clickhouse_qp.clj
@@ -623,8 +623,10 @@
   (format "'%s'" (t/format "HH:mm:ss.SSSZZZZZ" t)))
 
 (defmethod sql.qp/inline-value [:clickhouse LocalDateTime]
-  [_ t]
-  (format "'%s'" (t/format "yyyy-MM-dd HH:mm:ss.SSS" t)))
+  [_ ^LocalDateTime t]
+  (if (zero? (.getNano t))
+    (format "'%s'" (t/format "yyyy-MM-dd HH:mm:ss" t))
+    (format "'%s'" (t/format "yyyy-MM-dd HH:mm:ss.SSS" t))))
 
 (defmethod sql.qp/inline-value [:clickhouse OffsetDateTime]
   [_ ^OffsetDateTime t]
@@ -635,6 +637,18 @@
 (defmethod sql.qp/inline-value [:clickhouse ZonedDateTime]
   [_ t]
   (format "'%s'" (t/format "yyyy-MM-dd HH:mm:ss.SSSZZZZZ" t)))
+
+(defmethod sql.qp/inline-value [:clickhouse (Class/forName "[Ljava.lang.String;")]
+  [driver arr]
+  (format "[%s]" (str/join ", " (map #(sql.qp/inline-value driver %) arr))))
+
+(defmethod sql.qp/inline-value [:clickhouse (Class/forName "[Ljava.lang.Long;")]
+  [driver arr]
+  (format "[%s]" (str/join ", " (map #(sql.qp/inline-value driver %) arr))))
+
+(defmethod sql.qp/inline-value [:clickhouse (Class/forName "[Ljava.lang.Object;")]
+  [driver arr]
+  (format "[%s]" (str/join ", " (map #(sql.qp/inline-value driver %) arr))))
 
 (defmethod sql.params.substitution/->replacement-snippet-info [:clickhouse UUID]
   [_driver this]

--- a/modules/drivers/clickhouse/src/metabase/driver/clickhouse_qp.clj
+++ b/modules/drivers/clickhouse/src/metabase/driver/clickhouse_qp.clj
@@ -623,10 +623,8 @@
   (format "'%s'" (t/format "HH:mm:ss.SSSZZZZZ" t)))
 
 (defmethod sql.qp/inline-value [:clickhouse LocalDateTime]
-  [_ ^LocalDateTime t]
-  (if (zero? (.getNano t))
-    (format "'%s'" (t/format "yyyy-MM-dd HH:mm:ss" t))
-    (format "'%s'" (t/format "yyyy-MM-dd HH:mm:ss.SSS" t))))
+  [_ t]
+  (format "'%s'" (t/format "yyyy-MM-dd HH:mm:ss.SSS" t)))
 
 (defmethod sql.qp/inline-value [:clickhouse OffsetDateTime]
   [_ ^OffsetDateTime t]
@@ -649,6 +647,16 @@
 (defmethod sql.qp/inline-value [:clickhouse (Class/forName "[Ljava.lang.Object;")]
   [driver arr]
   (format "[%s]" (str/join ", " (map #(sql.qp/inline-value driver %) arr))))
+
+(defmethod sql.qp/inline-value [:clickhouse java.util.HashMap]
+  [driver m]
+  (format "{%s}"
+          (str/join ", "
+                    (map (fn [^java.util.Map$Entry e]
+                           (format "%s:%s"
+                                   (sql.qp/inline-value driver (str (.getKey e)))
+                                   (sql.qp/inline-value driver (.getValue e))))
+                         (.entrySet m)))))
 
 (defmethod sql.params.substitution/->replacement-snippet-info [:clickhouse UUID]
   [_driver this]

--- a/modules/drivers/clickhouse/test/metabase/driver/clickhouse_data_types_test.clj
+++ b/modules/drivers/clickhouse/test/metabase/driver/clickhouse_data_types_test.clj
@@ -35,216 +35,216 @@
                    :limit 1})
                 mt/first-row last double)))))))
 
-#_(deftest ^:parallel clickhouse-array-string
-    (mt/test-driver :clickhouse
-      (is
-       (= "[foo, bar]"
-          (-> (mt/dataset
-                (mt/dataset-definition "metabase_tests_array_string"
-                                       [["test-data-array-string"
-                                         [{:field-name "my_array"
-                                           :base-type {:native "Array(String)"}}]
-                                         [[(into-array (list "foo" "bar"))]]]])
-                (mt/run-mbql-query test-data-array-string {:limit 1}))
-              mt/first-row
-              last)))))
+(deftest ^:parallel clickhouse-array-string
+  (mt/test-driver :clickhouse
+    (is
+     (= "[foo, bar]"
+        (-> (mt/dataset
+              (mt/dataset-definition "metabase_tests_array_string"
+                                     [["test-data-array-string"
+                                       [{:field-name "my_array"
+                                         :base-type {:native "Array(String)"}}]
+                                       [[(into-array (list "foo" "bar"))]]]])
+              (mt/run-mbql-query test-data-array-string {:limit 1}))
+            mt/first-row
+            last)))))
 
-#_(deftest ^:parallel clickhouse-array-uint64
-    (mt/test-driver :clickhouse
-      (is
-       (= "[23, 42]"
-          (-> (mt/dataset
-                (mt/dataset-definition "metabase_tests_array_uint"
-                                       [["test-data-array-uint64"
-                                         [{:field-name "my_array"
-                                           :base-type {:native "Array(UInt64)"}}]
-                                         [[(into-array (list 23 42))]]]])
-                (mt/run-mbql-query test-data-array-uint64 {:limit 1}))
-              mt/first-row
-              last)))))
+(deftest ^:parallel clickhouse-array-uint64
+  (mt/test-driver :clickhouse
+    (is
+     (= "[23, 42]"
+        (-> (mt/dataset
+              (mt/dataset-definition "metabase_tests_array_uint"
+                                     [["test-data-array-uint64"
+                                       [{:field-name "my_array"
+                                         :base-type {:native "Array(UInt64)"}}]
+                                       [[(into-array (list 23 42))]]]])
+              (mt/run-mbql-query test-data-array-uint64 {:limit 1}))
+            mt/first-row
+            last)))))
 
-#_(deftest ^:parallel clickhouse-array-of-arrays
-    (mt/test-driver :clickhouse
-      (let [row1 (into-array (list
-                              (into-array (list "foo" "bar"))
-                              (into-array (list "qaz" "qux"))))
-            row2 (into-array nil)
-            query-result (mt/dataset
-                           (mt/dataset-definition "metabase_tests_array_of_arrays"
-                                                  [["test-data-array-of-arrays"
-                                                    [{:field-name "my_array_of_arrays"
-                                                      :base-type {:native "Array(Array(String))"}}]
-                                                    [[row1] [row2]]]])
-                           (mt/run-mbql-query test-data-array-of-arrays {}))
-            result (ctd/rows-without-index query-result)]
-        (is (= [["[[foo, bar], [qaz, qux]]"], ["[]"]] result)))))
+(deftest ^:parallel clickhouse-array-of-arrays
+  (mt/test-driver :clickhouse
+    (let [row1 (into-array (list
+                            (into-array (list "foo" "bar"))
+                            (into-array (list "qaz" "qux"))))
+          row2 (into-array nil)
+          query-result (mt/dataset
+                         (mt/dataset-definition "metabase_tests_array_of_arrays"
+                                                [["test-data-array-of-arrays"
+                                                  [{:field-name "my_array_of_arrays"
+                                                    :base-type {:native "Array(Array(String))"}}]
+                                                  [[row1] [row2]]]])
+                         (mt/run-mbql-query test-data-array-of-arrays {}))
+          result (ctd/rows-without-index query-result)]
+      (is (= [["[[foo, bar], [qaz, qux]]"], ["[]"]] result)))))
 
-#_(deftest ^:parallel clickhouse-low-cardinality-array
-    (mt/test-driver :clickhouse
-      (let [row1 (into-array (list "foo" "bar"))
-            row2 (into-array nil)
-            query-result (mt/dataset
-                           (mt/dataset-definition "metabase_tests_low_cardinality_array"
-                                                  [["test-data-low-cardinality-array"
-                                                    [{:field-name "my_low_card_array"
-                                                      :base-type {:native "Array(LowCardinality(String))"}}]
-                                                    [[row1] [row2]]]])
-                           (mt/run-mbql-query test-data-low-cardinality-array {}))
-            result (ctd/rows-without-index query-result)]
-        (is (= [["[foo, bar]"], ["[]"]] result)))))
+(deftest ^:parallel clickhouse-low-cardinality-array
+  (mt/test-driver :clickhouse
+    (let [row1 (into-array (list "foo" "bar"))
+          row2 (into-array nil)
+          query-result (mt/dataset
+                         (mt/dataset-definition "metabase_tests_low_cardinality_array"
+                                                [["test-data-low-cardinality-array"
+                                                  [{:field-name "my_low_card_array"
+                                                    :base-type {:native "Array(LowCardinality(String))"}}]
+                                                  [[row1] [row2]]]])
+                         (mt/run-mbql-query test-data-low-cardinality-array {}))
+          result (ctd/rows-without-index query-result)]
+      (is (= [["[foo, bar]"], ["[]"]] result)))))
 
-#_(deftest ^:parallel clickhouse-array-of-nullables
-    (mt/test-driver :clickhouse
-      (let [row1 (into-array (list "foo" nil "bar"))
-            row2 (into-array nil)
-            query-result (mt/dataset
-                           (mt/dataset-definition "metabase_tests_array_of_nullables"
-                                                  [["test-data-array-of-nullables"
-                                                    [{:field-name "my_array_of_nullables"
-                                                      :base-type {:native "Array(Nullable(String))"}}]
-                                                    [[row1] [row2]]]])
-                           (mt/run-mbql-query test-data-array-of-nullables {}))
-            result (ctd/rows-without-index query-result)]
-        (is (= [["[foo, null, bar]"], ["[]"]] result)))))
+(deftest ^:parallel clickhouse-array-of-nullables
+  (mt/test-driver :clickhouse
+    (let [row1 (into-array (list "foo" nil "bar"))
+          row2 (into-array nil)
+          query-result (mt/dataset
+                         (mt/dataset-definition "metabase_tests_array_of_nullables"
+                                                [["test-data-array-of-nullables"
+                                                  [{:field-name "my_array_of_nullables"
+                                                    :base-type {:native "Array(Nullable(String))"}}]
+                                                  [[row1] [row2]]]])
+                         (mt/run-mbql-query test-data-array-of-nullables {}))
+          result (ctd/rows-without-index query-result)]
+      (is (= [["[foo, null, bar]"], ["[]"]] result)))))
 
-#_(deftest ^:parallel clickhouse-array-of-booleans
-    (mt/test-driver :clickhouse
-      (let [row1 (into-array (list true false true))
-            row2 (into-array nil)
-            query-result (mt/dataset
-                           (mt/dataset-definition "metabase_tests_array_of_booleans"
-                                                  [["test-data-array-of-booleans"
-                                                    [{:field-name "my_array_of_booleans"
-                                                      :base-type {:native "Array(Boolean)"}}]
-                                                    [[row1] [row2]]]])
-                           (mt/run-mbql-query test-data-array-of-booleans {}))
-            result (ctd/rows-without-index query-result)]
-        (is (= [["[true, false, true]"], ["[]"]] result)))))
+(deftest ^:parallel clickhouse-array-of-booleans
+  (mt/test-driver :clickhouse
+    (let [row1 (into-array (list true false true))
+          row2 (into-array nil)
+          query-result (mt/dataset
+                         (mt/dataset-definition "metabase_tests_array_of_booleans"
+                                                [["test-data-array-of-booleans"
+                                                  [{:field-name "my_array_of_booleans"
+                                                    :base-type {:native "Array(Boolean)"}}]
+                                                  [[row1] [row2]]]])
+                         (mt/run-mbql-query test-data-array-of-booleans {}))
+          result (ctd/rows-without-index query-result)]
+      (is (= [["[true, false, true]"], ["[]"]] result)))))
 
-#_(deftest ^:parallel clickhouse-array-of-nullable-booleans
-    (mt/test-driver :clickhouse
-      (let [row1 (into-array (list true false nil))
-            row2 (into-array nil)
-            query-result (mt/dataset
-                           (mt/dataset-definition "metabase_tests_array_of_nullable_booleans"
-                                                  [["test-data-array-of-booleans"
-                                                    [{:field-name "my_array_of_nullable_booleans"
-                                                      :base-type {:native "Array(Nullable(Boolean))"}}]
-                                                    [[row1] [row2]]]])
-                           (mt/run-mbql-query test-data-array-of-booleans {}))
-            result (ctd/rows-without-index query-result)]
-        (is (= [["[true, false, null]"], ["[]"]] result)))))
+(deftest ^:parallel clickhouse-array-of-nullable-booleans
+  (mt/test-driver :clickhouse
+    (let [row1 (into-array (list true false nil))
+          row2 (into-array nil)
+          query-result (mt/dataset
+                         (mt/dataset-definition "metabase_tests_array_of_nullable_booleans"
+                                                [["test-data-array-of-booleans"
+                                                  [{:field-name "my_array_of_nullable_booleans"
+                                                    :base-type {:native "Array(Nullable(Boolean))"}}]
+                                                  [[row1] [row2]]]])
+                         (mt/run-mbql-query test-data-array-of-booleans {}))
+          result (ctd/rows-without-index query-result)]
+      (is (= [["[true, false, null]"], ["[]"]] result)))))
 
-#_(deftest ^:parallel clickhouse-array-of-uint8
-    (mt/test-driver :clickhouse
-      (let [row1 (into-array (list 42 100 2))
-            row2 (into-array nil)
-            query-result (mt/dataset
-                           (mt/dataset-definition "metabase_tests_array_of_uint8"
-                                                  [["test-data-array-of-uint8"
-                                                    [{:field-name "my_array_of_uint8"
-                                                      :base-type {:native "Array(UInt8)"}}]
-                                                    [[row1] [row2]]]])
-                           (mt/run-mbql-query test-data-array-of-uint8 {}))
-            result (ctd/rows-without-index query-result)]
-        (is (= [["[42, 100, 2]"], ["[]"]] result)))))
+(deftest ^:parallel clickhouse-array-of-uint8
+  (mt/test-driver :clickhouse
+    (let [row1 (into-array (list 42 100 2))
+          row2 (into-array nil)
+          query-result (mt/dataset
+                         (mt/dataset-definition "metabase_tests_array_of_uint8"
+                                                [["test-data-array-of-uint8"
+                                                  [{:field-name "my_array_of_uint8"
+                                                    :base-type {:native "Array(UInt8)"}}]
+                                                  [[row1] [row2]]]])
+                         (mt/run-mbql-query test-data-array-of-uint8 {}))
+          result (ctd/rows-without-index query-result)]
+      (is (= [["[42, 100, 2]"], ["[]"]] result)))))
 
-#_(deftest ^:parallel clickhouse-array-of-floats
-    (mt/test-driver :clickhouse
-      (let [row1 (into-array (list 1.2 3.4))
-            row2 (into-array nil)
-            query-result (mt/dataset
-                           (mt/dataset-definition "metabase_tests_array_of_floats"
-                                                  [["test-data-array-of-floats"
-                                                    [{:field-name "my_array_of_floats"
-                                                      :base-type {:native "Array(Float64)"}}]
-                                                    [[row1] [row2]]]])
-                           (mt/run-mbql-query test-data-array-of-floats {}))
-            result (ctd/rows-without-index query-result)]
-        (is (= [["[1.2, 3.4]"], ["[]"]] result)))))
+(deftest ^:parallel clickhouse-array-of-floats
+  (mt/test-driver :clickhouse
+    (let [row1 (into-array (list 1.2 3.4))
+          row2 (into-array nil)
+          query-result (mt/dataset
+                         (mt/dataset-definition "metabase_tests_array_of_floats"
+                                                [["test-data-array-of-floats"
+                                                  [{:field-name "my_array_of_floats"
+                                                    :base-type {:native "Array(Float64)"}}]
+                                                  [[row1] [row2]]]])
+                         (mt/run-mbql-query test-data-array-of-floats {}))
+          result (ctd/rows-without-index query-result)]
+      (is (= [["[1.2, 3.4]"], ["[]"]] result)))))
 
 ;; NB: timezones in the formatted string are purely cosmetic; it will be fine on the UI
-#_(deftest ^:parallel clickhouse-array-of-dates
-    (mt/test-driver :clickhouse
-      (let [row1 (into-array
-                  (list
-                   #t "2022-12-06"
-                   #t "2021-10-19"))
-            row2 (into-array nil)
-            query-result (mt/dataset
-                           (mt/dataset-definition "metabase_tests_array_of_dates"
-                                                  [["test-data-array-of-dates"
-                                                    [{:field-name "my_array_of_dates"
-                                                      :base-type {:native "Array(Date)"}}]
-                                                    [[row1] [row2]]]])
-                           (mt/run-mbql-query test-data-array-of-dates {}))
-            result (ctd/rows-without-index query-result)]
-        (is (= [["[2022-12-06T00:00Z[UTC], 2021-10-19T00:00Z[UTC]]"], ["[]"]] result)))))
+(deftest ^:parallel clickhouse-array-of-dates
+  (mt/test-driver :clickhouse
+    (let [row1 (into-array
+                (list
+                 #t "2022-12-06"
+                 #t "2021-10-19"))
+          row2 (into-array nil)
+          query-result (mt/dataset
+                         (mt/dataset-definition "metabase_tests_array_of_dates"
+                                                [["test-data-array-of-dates"
+                                                  [{:field-name "my_array_of_dates"
+                                                    :base-type {:native "Array(Date)"}}]
+                                                  [[row1] [row2]]]])
+                         (mt/run-mbql-query test-data-array-of-dates {}))
+          result (ctd/rows-without-index query-result)]
+      (is (= [["[2022-12-06, 2021-10-19]"], ["[]"]] result)))))
 
-#_(deftest ^:parallel clickhouse-array-of-date32
-    (mt/test-driver :clickhouse
-      (let [row1 (into-array
-                  (list
-                   #t "2122-12-06"
-                   #t "2099-10-19"))
-            row2 (into-array nil)
-            query-result (mt/dataset
-                           (mt/dataset-definition "metabase_tests_array_of_date32"
-                                                  [["test-data-array-of-date32"
-                                                    [{:field-name "my_array_of_date32"
-                                                      :base-type {:native "Array(Date32)"}}]
-                                                    [[row1] [row2]]]])
-                           (mt/run-mbql-query test-data-array-of-date32 {}))
-            result (ctd/rows-without-index query-result)]
-        (is (= [["[2122-12-06T00:00Z[UTC], 2099-10-19T00:00Z[UTC]]"], ["[]"]] result)))))
+(deftest ^:parallel clickhouse-array-of-date32
+  (mt/test-driver :clickhouse
+    (let [row1 (into-array
+                (list
+                 #t "2122-12-06"
+                 #t "2099-10-19"))
+          row2 (into-array nil)
+          query-result (mt/dataset
+                         (mt/dataset-definition "metabase_tests_array_of_date32"
+                                                [["test-data-array-of-date32"
+                                                  [{:field-name "my_array_of_date32"
+                                                    :base-type {:native "Array(Date32)"}}]
+                                                  [[row1] [row2]]]])
+                         (mt/run-mbql-query test-data-array-of-date32 {}))
+          result (ctd/rows-without-index query-result)]
+      (is (= [["[2122-12-06, 2099-10-19]"], ["[]"]] result)))))
 
-#_(deftest ^:parallel clickhouse-array-of-datetime
-    (mt/test-driver :clickhouse
-      (let [row1 (into-array
-                  (list
-                   #t "2022-12-06T18:28:31"
-                   #t "2021-10-19T13:12:44"))
-            row2 (into-array nil)
-            query-result (mt/dataset
-                           (mt/dataset-definition "metabase_tests_array_of_datetime"
-                                                  [["test-data-array-of-datetime"
-                                                    [{:field-name "my_array_of_datetime"
-                                                      :base-type {:native "Array(DateTime)"}}]
-                                                    [[row1] [row2]]]])
-                           (mt/run-mbql-query test-data-array-of-datetime {}))
-            result (ctd/rows-without-index query-result)]
-        (is (= [["[2022-12-06T18:28:31Z[UTC], 2021-10-19T13:12:44Z[UTC]]"], ["[]"]] result)))))
+(deftest ^:parallel clickhouse-array-of-datetime
+  (mt/test-driver :clickhouse
+    (let [row1 (into-array
+                (list
+                 #t "2022-12-06T18:28:31"
+                 #t "2021-10-19T13:12:44"))
+          row2 (into-array nil)
+          query-result (mt/dataset
+                         (mt/dataset-definition "metabase_tests_array_of_datetime"
+                                                [["test-data-array-of-datetime"
+                                                  [{:field-name "my_array_of_datetime"
+                                                    :base-type {:native "Array(DateTime)"}}]
+                                                  [[row1] [row2]]]])
+                         (mt/run-mbql-query test-data-array-of-datetime {}))
+          result (ctd/rows-without-index query-result)]
+      (is (= [["[2022-12-06 18:28:31.0, 2021-10-19 13:12:44.0]"], ["[]"]] result)))))
 
-#_(deftest ^:parallel clickhouse-array-of-datetime64
-    (mt/test-driver :clickhouse
-      (let [row1 (into-array
-                  (list
-                   #t "2022-12-06T18:28:31.123"
-                   #t "2021-10-19T13:12:44.456"))
-            row2 (into-array nil)
-            query-result (mt/dataset
-                           (mt/dataset-definition "metabase_tests_array_of_datetime64"
-                                                  [["test-data-array-of-datetime64"
-                                                    [{:field-name "my_array_of_datetime64"
-                                                      :base-type {:native "Array(DateTime64(3))"}}]
-                                                    [[row1] [row2]]]])
-                           (mt/run-mbql-query test-data-array-of-datetime64 {}))
-            result (ctd/rows-without-index query-result)]
-        (is (= [["[2022-12-06T18:28:31.123Z[UTC], 2021-10-19T13:12:44.456Z[UTC]]"], ["[]"]] result)))))
+(deftest ^:parallel clickhouse-array-of-datetime64
+  (mt/test-driver :clickhouse
+    (let [row1 (into-array
+                (list
+                 #t "2022-12-06T18:28:31.123"
+                 #t "2021-10-19T13:12:44.456"))
+          row2 (into-array nil)
+          query-result (mt/dataset
+                         (mt/dataset-definition "metabase_tests_array_of_datetime64"
+                                                [["test-data-array-of-datetime64"
+                                                  [{:field-name "my_array_of_datetime64"
+                                                    :base-type {:native "Array(DateTime64(3))"}}]
+                                                  [[row1] [row2]]]])
+                         (mt/run-mbql-query test-data-array-of-datetime64 {}))
+          result (ctd/rows-without-index query-result)]
+      (is (= [["[2022-12-06 18:28:31.123, 2021-10-19 13:12:44.456]"], ["[]"]] result)))))
 
-#_(deftest ^:parallel clickhouse-array-of-decimals
-    (mt/test-driver :clickhouse
-      (let [row1 (into-array (list "12345123.123456789" "78.245"))
-            row2 nil
-            query-result (mt/dataset
-                           (mt/dataset-definition "metabase_tests_array_of_decimals"
-                                                  [["test-data-array-of-decimals"
-                                                    [{:field-name "my_array_of_decimals"
-                                                      :base-type {:native "Array(Decimal(18, 9))"}}]
-                                                    [[row1] [row2]]]])
-                           (mt/run-mbql-query test-data-array-of-decimals {}))
-            result (ctd/rows-without-index query-result)]
-        (is (= [["[12345123.123456789, 78.245000000]"], ["[]"]] result)))))
+(deftest ^:parallel clickhouse-array-of-decimals
+  (mt/test-driver :clickhouse
+    (let [row1 (into-array (list "12345123.123456789" "78.245"))
+          row2 nil
+          query-result (mt/dataset
+                         (mt/dataset-definition "metabase_tests_array_of_decimals"
+                                                [["test-data-array-of-decimals"
+                                                  [{:field-name "my_array_of_decimals"
+                                                    :base-type {:native "Array(Decimal(18, 9))"}}]
+                                                  [[row1] [row2]]]])
+                         (mt/run-mbql-query test-data-array-of-decimals {}))
+          result (ctd/rows-without-index query-result)]
+      (is (= [["[12345123.123456789, 78.245000000]"], ["[]"]] result)))))
 
 ;; TODO: Re-enable these tests once the JDBC driver issue mentioned in
 ;; https://github.com/ClickHouse/metabase-clickhouse-driver/pull/305 has been fixed

--- a/modules/drivers/clickhouse/test/metabase/driver/clickhouse_data_types_test.clj
+++ b/modules/drivers/clickhouse/test/metabase/driver/clickhouse_data_types_test.clj
@@ -246,18 +246,16 @@
           result (ctd/rows-without-index query-result)]
       (is (= [["[12345123.123456789, 78.245000000]"], ["[]"]] result)))))
 
-;; TODO: Re-enable these tests once the JDBC driver issue mentioned in
-;; https://github.com/ClickHouse/metabase-clickhouse-driver/pull/305 has been fixed
 (mt/defdataset metabase_test
-  [#_["arrays_inner_types"
-      [{:field-name "arr_str",  :base-type {:native "Array(String)"}}
-       {:field-name "arr_nstr", :base-type {:native "Array(Nullable(String))"}}
-       {:field-name "arr_dec",  :base-type {:native "Array(Decimal(18, 4))"}}
-       {:field-name "arr_ndec", :base-type {:native "Array(Nullable(Decimal(18, 4)))"}}]
-      [[(into-array ["a" "b" "c"])
-        (into-array [nil "d" "e"])
-        (into-array [1 2 3])
-        (into-array [4 nil 5])]]]
+  [["arrays_inner_types"
+    [{:field-name "arr_str",  :base-type {:native "Array(String)"}}
+     {:field-name "arr_nstr", :base-type {:native "Array(Nullable(String))"}}
+     {:field-name "arr_dec",  :base-type {:native "Array(Decimal(18, 4))"}}
+     {:field-name "arr_ndec", :base-type {:native "Array(Nullable(Decimal(18, 4)))"}}]
+    [[(into-array ["a" "b" "c"])
+      (into-array [nil "d" "e"])
+      (into-array [1 2 3])
+      (into-array [4 nil 5])]]]
    ["metabase_test_lowercases"
     [{:field-name "mystring", :base-type {:native "Nullable(String)"}}]
     [["Я_1"] ["R"] ["Я_2"] ["Я"] ["я"] [nil]]]
@@ -274,11 +272,11 @@
     [["127.0.0.1" "0:0:0:0:0:0:0:1"]
      ["0.0.0.0" "2001:438:ffff:0:0:0:407d:1bc1"]
      [nil nil]]]
-   #_["maps_test"
-      [{:field-name "m", :base-type {:native "Map(String, UInt64)"}}]
-      [[(java.util.HashMap. {"key1" 1, "key2" 10})]
-       [(java.util.HashMap. {"key1" 2, "key2" 20})]
-       [(java.util.HashMap. {"key1" 3, "key2" 30})]]]
+   ["maps_test"
+    [{:field-name "m", :base-type {:native "Map(String, UInt64)"}}]
+    [[(java.util.HashMap. {"key1" 1, "key2" 10})]
+     [(java.util.HashMap. {"key1" 2, "key2" 20})]
+     [(java.util.HashMap. {"key1" 3, "key2" 30})]]]
    ["datetime_diff_nullable"
     [{:field-name "idx",  :base-type {:native "Int32"}}
      {:field-name "dt64", :base-type {:native "Nullable(DateTime64(3, 'UTC'))"}}
@@ -404,32 +402,32 @@
             "AAA" true  []
             "AAA" false [[1 #uuid "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"]]))))))
 
-#_(deftest ^:parallel clickhouse-array-of-uuids
-    (mt/test-driver :clickhouse
-      (let [row1 (into-array (list "2eac427e-7596-11ed-a1eb-0242ac120002"
-                                   "2eac44f4-7596-11ed-a1eb-0242ac120002"))
-            row2 nil
-            query-result (mt/dataset
-                           (mt/dataset-definition "metabase_tests_array_of_uuids"
-                                                  [["test-data-array-of-uuids"
-                                                    [{:field-name "my_array_of_uuids"
-                                                      :base-type {:native "Array(UUID)"}}]
-                                                    [[row1] [row2]]]])
-                           (mt/run-mbql-query test-data-array-of-uuids {}))
-            result (ctd/rows-without-index query-result)]
-        (is (= [["[2eac427e-7596-11ed-a1eb-0242ac120002, 2eac44f4-7596-11ed-a1eb-0242ac120002]"], ["[]"]] result)))))
+(deftest ^:parallel clickhouse-array-of-uuids
+  (mt/test-driver :clickhouse
+    (let [row1 (into-array (list "2eac427e-7596-11ed-a1eb-0242ac120002"
+                                 "2eac44f4-7596-11ed-a1eb-0242ac120002"))
+          row2 nil
+          query-result (mt/dataset
+                         (mt/dataset-definition "metabase_tests_array_of_uuids"
+                                                [["test-data-array-of-uuids"
+                                                  [{:field-name "my_array_of_uuids"
+                                                    :base-type {:native "Array(UUID)"}}]
+                                                  [[row1] [row2]]]])
+                         (mt/run-mbql-query test-data-array-of-uuids {}))
+          result (ctd/rows-without-index query-result)]
+      (is (= [["[2eac427e-7596-11ed-a1eb-0242ac120002, 2eac44f4-7596-11ed-a1eb-0242ac120002]"], ["[]"]] result)))))
 
-#_(deftest clickhouse-array-inner-types
-    (mt/test-driver :clickhouse
-      (mt/dataset metabase_test
-        (is (= [[1
-                 "[a, b, c]"
-                 "[null, d, e]"
-                 "[1.0000, 2.0000, 3.0000]"
-                 "[4.0000, null, 5.0000]"]]
-               (mt/with-db (mt/db)
-                 (->> (mt/run-mbql-query arrays_inner_types {})
-                      (mt/formatted-rows [int str str str str]))))))))
+(deftest clickhouse-array-inner-types
+  (mt/test-driver :clickhouse
+    (mt/dataset metabase_test
+      (is (= [[1
+               "[a, b, c]"
+               "[null, d, e]"
+               "[1.0000, 2.0000, 3.0000]"
+               "[4.0000, null, 5.0000]"]]
+             (mt/with-db (mt/db)
+               (->> (mt/run-mbql-query arrays_inner_types {})
+                    (mt/formatted-rows [int str str str str]))))))))
 
 (deftest ^:parallel clickhouse-nullable-strings
   (mt/test-driver :clickhouse
@@ -578,19 +576,19 @@
               [int str str]
               (mt/with-db (mt/db) (mt/run-mbql-query ipaddress_test {}))))))))
 
-#_(defn- map-as-string [^java.util.LinkedHashMap m] (.toString m))
+(defn- map-as-string [^java.util.LinkedHashMap m] (.toString m))
 
-#_(deftest clickhouse-simple-map-test
-    (mt/test-driver :clickhouse
-      (mt/dataset metabase_test
-        (is (= [[1 "{key1=1, key2=10}"] [2 "{key1=2, key2=20}"] [3 "{key1=3, key2=30}"]]
-               (mt/formatted-rows
-                [int map-as-string]
-                :format-nil-values
-                (mt/with-db (mt/db)
-                  (mt/run-mbql-query
-                    maps_test
-                    {}))))))))
+(deftest clickhouse-simple-map-test
+  (mt/test-driver :clickhouse
+    (mt/dataset metabase_test
+      (is (= [[1 "{key1=1, key2=10}"] [2 "{key1=2, key2=20}"] [3 "{key1=3, key2=30}"]]
+             (mt/formatted-rows
+              [int map-as-string]
+              :format-nil-values
+              (mt/with-db (mt/db)
+                (mt/run-mbql-query
+                  maps_test
+                  {}))))))))
 
 (deftest clickhouse-datetime-diff-nullable
   (mt/test-driver :clickhouse


### PR DESCRIPTION
Closes [QUE2-415: Re-enable ClickHouse array and map tests when JDBC driver supports it](https://linear.app/metabase/issue/QUE2-415/re-enable-clickhouse-array-and-map-tests-when-jdbc-driver-supports-it)

### Description

Enables tests that were previously disabled. Needed to add some inline-value `defmethod`s for array classes, and change some of the expected values. 

### How to verify

All tests should pass 

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
