### PR TITLE
[Experimental] Charts in embedded metabot

### DIFF
--- a/METABOT_CHAT_COMPONENT_USAGE_INSTRUCTIONS.md
+++ b/METABOT_CHAT_COMPONENT_USAGE_INSTRUCTIONS.md
@@ -1,0 +1,478 @@
+# MetabotChat Component & useMetabot Hook — Usage Instructions
+
+## Overview
+
+The Metabase Embedding SDK provides two complementary ways to integrate AI chat into your application:
+
+| API | Purpose |
+|-----|---------|
+| `MetabotChat` | Ready-made UI component with chat history, input, and suggestions |
+| `useMetabot` | Headless hook for building a fully custom chat UI |
+
+Both require wrapping your app in `<MetabaseProvider>`.
+
+---
+
+## Table of Contents
+
+1. [MetabotChat Component](#metabotchat-component)
+   - [Standalone Panel](#standalone-panel)
+   - [Floating Action Button (Intercom-style)](#floating-action-button)
+   - [Command Bar (AI bar)](#command-bar)
+2. [useMetabot Hook](#usemetabot-hook)
+   - [API Reference](#api-reference)
+   - [Custom Instructions](#custom-instructions)
+   - [Building a Custom Chat UI](#building-a-custom-chat-ui)
+3. [Theming](#theming)
+4. [Constraints](#constraints)
+
+---
+
+## MetabotChat Component
+
+### Import
+
+```tsx
+import { MetabotChat } from "@metabase/embedding-sdk-react";
+```
+
+`MetabotChat` ships with three layout variants:
+
+| Component | Description |
+|-----------|-------------|
+| `<MetabotChat>` | Inline chat panel — embed it anywhere |
+| `<MetabotChat.FloatingActionButton>` | Intercom-style FAB in the bottom-right corner |
+| `<MetabotChat.CommandBar>` | Centered bottom bar that expands into a chat panel |
+
+---
+
+### Standalone Panel
+
+A chat panel you embed directly into your page layout.
+
+#### Basic usage
+
+```tsx
+<MetabotChat height={500} width={400} />
+```
+
+#### Sidebar layout
+
+```tsx
+function App() {
+  return (
+    <div style={{ display: "flex", height: "100vh" }}>
+      <main style={{ flex: 1 }}>
+        {/* Your app content */}
+      </main>
+
+      <aside style={{ width: 380, borderLeft: "1px solid #eee" }}>
+        <MetabotChat height="100%" width="100%" />
+      </aside>
+    </div>
+  );
+}
+```
+
+#### Full-width bottom drawer
+
+```tsx
+function App() {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", height: "100vh" }}>
+      <main style={{ flex: 1 }}>
+        {/* Your app content */}
+      </main>
+
+      <MetabotChat height={300} width="100%" />
+    </div>
+  );
+}
+```
+
+#### Fixed bottom panel
+
+```tsx
+function App() {
+  return (
+    <>
+      {/* Your app content */}
+
+      <div style={{ position: "fixed", bottom: 0, left: 0, right: 0 }}>
+        <MetabotChat height={280} width="100%" />
+      </div>
+    </>
+  );
+}
+```
+
+#### With custom styling
+
+```tsx
+<MetabotChat
+  height={500}
+  width={400}
+  className="my-chat-panel"
+  style={{ borderRadius: 16, overflow: "hidden" }}
+/>
+```
+
+---
+
+### Floating Action Button
+
+An Intercom-style button fixed to the bottom-right corner. Clicking it toggles a floating chat panel.
+
+#### Basic usage
+
+```tsx
+function App() {
+  return (
+    <>
+      {/* Your app content */}
+      <MetabotChat.FloatingActionButton />
+    </>
+  );
+}
+```
+
+#### Custom panel size
+
+```tsx
+<MetabotChat.FloatingActionButton panelHeight={600} panelWidth={420} />
+```
+
+#### Compact panel for mobile
+
+```tsx
+<MetabotChat.FloatingActionButton panelHeight={400} panelWidth={320} />
+```
+
+---
+
+### Command Bar
+
+A floating bar centered at the bottom of the viewport. Clicking it expands into a full chat panel. Includes a collapse button to minimize back to the bar.
+
+#### Basic usage
+
+```tsx
+function App() {
+  return (
+    <>
+      {/* Your app content */}
+      <MetabotChat.CommandBar />
+    </>
+  );
+}
+```
+
+#### Custom width and panel height
+
+```tsx
+<MetabotChat.CommandBar width={700} panelHeight={500} />
+```
+
+#### Narrow command bar
+
+```tsx
+<MetabotChat.CommandBar width={400} panelHeight={350} />
+```
+
+---
+
+### Props Reference
+
+#### `MetabotChat`
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `height` | `CSSProperties["height"]` | — | Height of the panel |
+| `width` | `CSSProperties["width"]` | — | Width of the panel |
+| `className` | `string` | — | Custom class on root element |
+| `style` | `CSSProperties` | — | Custom inline styles on root element |
+| `children` | `ReactNode` | — | Override the default chat layout |
+
+#### `MetabotChat.FloatingActionButton`
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `panelHeight` | `CSSProperties["height"]` | `500` | Height of the floating chat panel |
+| `panelWidth` | `CSSProperties["width"]` | `400` | Width of the floating chat panel |
+| `className` | `string` | — | Custom class on root element |
+| `style` | `CSSProperties` | — | Custom inline styles on root element |
+| `children` | `ReactNode` | — | Override the default chat layout |
+
+#### `MetabotChat.CommandBar`
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `panelHeight` | `CSSProperties["height"]` | `400` | Height of the expanded chat panel |
+| `width` | `CSSProperties["width"]` | `600` | Width of the command bar and panel |
+| `className` | `string` | — | Custom class on root element |
+| `style` | `CSSProperties` | — | Custom inline styles on root element |
+| `children` | `ReactNode` | — | Override the default chat layout |
+
+---
+
+## useMetabot Hook
+
+A headless hook for full control over Metabot. Use this when you want to build a completely custom chat UI.
+
+### Import
+
+```tsx
+import { useMetabot } from "@metabase/embedding-sdk-react";
+```
+
+### API Reference
+
+```tsx
+const {
+  // --- Prompt State ---
+  prompt,              // string — current input value
+  setPrompt,           // (value: string) => void
+
+  // --- Conversation Actions ---
+  submitMessage,       // (message: string) => void — send a message
+  retryMessage,        // retry a failed message by ID
+  cancelRequest,       // cancel the in-flight request
+  resetConversation,   // clear all messages and start over
+
+  // --- Conversation State ---
+  messages,            // array of chat messages
+  errorMessages,       // array of error messages
+  isProcessing,        // boolean — true while Metabot is thinking
+  isLongConversation,  // boolean — true when conversation is long
+  activeToolCalls,     // currently running tool calls
+  reactions,           // navigation suggestions, code edits, etc.
+
+  // --- Visibility ---
+  visible,             // boolean — sidebar visibility
+  setVisible,          // (visible: boolean) => void
+
+  // --- Custom Instructions ---
+  customInstructions,     // string | undefined
+  setCustomInstructions,  // (instructions: string | undefined) => void
+} = useMetabot();
+```
+
+### Custom Instructions
+
+Append instructions to Metabot's system prompt. These appear last in the prompt and take high precedence.
+
+```tsx
+function App() {
+  const { setCustomInstructions } = useMetabot();
+
+  useEffect(() => {
+    setCustomInstructions("Always respond in bullet points. Keep answers under 3 sentences.");
+  }, []);
+
+  // ...
+}
+```
+
+Clear instructions by passing `undefined`:
+
+```tsx
+setCustomInstructions(undefined);
+```
+
+### Building a Custom Chat UI
+
+#### Minimal chat
+
+```tsx
+function MinimalChat() {
+  const { messages, submitMessage, isProcessing } = useMetabot();
+  const [input, setInput] = useState("");
+
+  const handleSend = () => {
+    if (input.trim()) {
+      submitMessage(input.trim());
+      setInput("");
+    }
+  };
+
+  return (
+    <div>
+      <div>
+        {messages.map((msg) => (
+          <div key={msg.id}>{msg.message}</div>
+        ))}
+        {isProcessing && <div>Thinking...</div>}
+      </div>
+
+      <input
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+        onKeyDown={(e) => e.key === "Enter" && handleSend()}
+        placeholder="Ask something..."
+      />
+      <button onClick={handleSend} disabled={isProcessing}>
+        Send
+      </button>
+    </div>
+  );
+}
+```
+
+#### Chat with error handling and cancel
+
+```tsx
+function ChatWithControls() {
+  const {
+    messages,
+    errorMessages,
+    submitMessage,
+    cancelRequest,
+    resetConversation,
+    isProcessing,
+  } = useMetabot();
+  const [input, setInput] = useState("");
+
+  return (
+    <div>
+      {errorMessages.map((err, i) => (
+        <div key={i} style={{ color: "red" }}>{err.message}</div>
+      ))}
+
+      {messages.map((msg) => (
+        <div key={msg.id}>{msg.message}</div>
+      ))}
+
+      <input
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" && input.trim()) {
+            submitMessage(input.trim());
+            setInput("");
+          }
+        }}
+      />
+
+      {isProcessing ? (
+        <button onClick={cancelRequest}>Stop</button>
+      ) : (
+        <button onClick={() => { submitMessage(input.trim()); setInput(""); }}>
+          Send
+        </button>
+      )}
+
+      <button onClick={resetConversation}>New Chat</button>
+    </div>
+  );
+}
+```
+
+#### Custom instructions panel
+
+```tsx
+function InstructionsPanel() {
+  const { customInstructions, setCustomInstructions } = useMetabot();
+  const [draft, setDraft] = useState(customInstructions ?? "");
+
+  return (
+    <div>
+      <h3>Custom Instructions</h3>
+      <textarea
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        placeholder="e.g. Always respond in bullet points."
+      />
+      <button onClick={() => setCustomInstructions(draft.trim() || undefined)}>
+        Apply
+      </button>
+      <button onClick={() => { setCustomInstructions(undefined); setDraft(""); }}>
+        Clear
+      </button>
+    </div>
+  );
+}
+```
+
+#### Toggle chat visibility
+
+```tsx
+function ChatToggle() {
+  const { visible, setVisible } = useMetabot();
+
+  return (
+    <button onClick={() => setVisible(!visible)}>
+      {visible ? "Hide Chat" : "Show Chat"}
+    </button>
+  );
+}
+```
+
+#### Programmatic message submission (e.g. from a button)
+
+```tsx
+function QuickActions() {
+  const { submitMessage, isProcessing } = useMetabot();
+
+  const prompts = [
+    "What were last month's top products?",
+    "Show me revenue by region",
+    "How is churn trending?",
+  ];
+
+  return (
+    <div>
+      {prompts.map((prompt) => (
+        <button
+          key={prompt}
+          disabled={isProcessing}
+          onClick={() => submitMessage(prompt)}
+        >
+          {prompt}
+        </button>
+      ))}
+    </div>
+  );
+}
+```
+
+---
+
+## Theming
+
+MetabotChat respects the SDK theme passed to `<MetabaseProvider>`. To make the chat match a dark application:
+
+```tsx
+import { MetabaseProvider, defineMetabaseTheme } from "@metabase/embedding-sdk-react";
+
+const darkTheme = defineMetabaseTheme({
+  colors: {
+    brand: "#6C5CE7",
+    "text-primary": "#E4E5E9",
+    "text-secondary": "#8B8F9A",
+    "text-tertiary": "#5C6170",
+    border: "#2A2E38",
+    background: "#13161C",
+    "background-secondary": "#1A1D25",
+    "background-hover": "#1A1D25",
+    positive: "#00D68F",
+    negative: "#FF6B6B",
+  },
+});
+
+function App() {
+  return (
+    <MetabaseProvider authConfig={authConfig} theme={darkTheme}>
+      <MetabotChat.FloatingActionButton />
+    </MetabaseProvider>
+  );
+}
+```
+
+---
+
+## Constraints
+
+- Only **one** instance of `MetabotChat` (or its variants) can be rendered at a time. Rendering multiple will trigger a console warning and the duplicate will not render.
+- `MetabotChat` requires an **Enterprise** license. In OSS builds the component renders nothing.
+- Both `MetabotChat` and `useMetabot` must be used inside a `<MetabaseProvider>`.
+- Guest embedding is not supported — the user must be authenticated.

--- a/enterprise/frontend/src/embedding-sdk-ee/metabot/MetabotChat.module.css
+++ b/enterprise/frontend/src/embedding-sdk-ee/metabot/MetabotChat.module.css
@@ -1,0 +1,131 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  color: var(--mb-color-text-primary);
+  background-color: var(--mb-color-background-primary);
+}
+
+/* Prompt suggestions */
+.promptSuggestionsContainer {
+  flex-shrink: 0;
+  max-width: 30rem;
+}
+
+.promptSuggestionButton {
+  display: block;
+  height: auto;
+  text-align: left;
+  line-height: 1.4;
+  padding: 0.5rem 0.75rem;
+  width: fit-content;
+  border-radius: 8px;
+  border: 1px solid var(--mb-color-border);
+  background-color: var(--mb-color-background-primary);
+  color: var(--mb-color-text-secondary);
+  font-size: 0.875rem;
+}
+
+.promptSuggestionButton span {
+  text-wrap-mode: wrap;
+  justify-content: flex-start;
+}
+
+/* Chat input */
+.chatInput {
+  border: none;
+  border-radius: 0;
+  padding-block: 8px;
+  color: var(--mb-color-text-primary);
+  line-height: 24px;
+  background-color: transparent !important;
+
+  &::placeholder {
+    color: var(--mb-color-text-tertiary);
+  }
+
+  &:focus {
+    outline: none;
+    border-color: transparent;
+  }
+}
+
+.chatButton {
+  display: flex;
+  padding: 0.25rem;
+  border-radius: 4px;
+  transition: background-color 0.2s ease;
+
+  &:hover {
+    background-color: var(--mb-color-background-hover);
+  }
+}
+
+.stopGenerationButton {
+  width: 1.3rem;
+  height: 1.3rem;
+}
+
+/* FAB trigger */
+.fabTrigger {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  z-index: 1000;
+  width: 3.5rem;
+  height: 3.5rem;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: var(--mb-color-brand);
+  color: var(--mb-color-text-white);
+  cursor: pointer;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+
+  &:hover {
+    transform: scale(1.05);
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.2);
+  }
+}
+
+.fabPanel {
+  position: fixed;
+  bottom: 6rem;
+  right: 1.5rem;
+  z-index: 1000;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid var(--mb-color-border);
+  background-color: var(--mb-color-background-primary);
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.12);
+}
+
+/* Command bar */
+.commandBarContainer {
+  position: fixed;
+  bottom: 1.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1000;
+}
+
+.commandBarInput {
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid var(--mb-color-border);
+  background-color: var(--mb-color-background-primary);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
+}
+
+.commandBarPanel {
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid var(--mb-color-border);
+  background-color: var(--mb-color-background-primary);
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.12);
+  margin-bottom: 0.5rem;
+}

--- a/enterprise/frontend/src/embedding-sdk-ee/metabot/MetabotChat.schema.ts
+++ b/enterprise/frontend/src/embedding-sdk-ee/metabot/MetabotChat.schema.ts
@@ -1,0 +1,15 @@
+import * as Yup from "yup";
+
+import type { FunctionSchema } from "embedding-sdk-bundle/types/schema";
+
+import type { MetabotChatProps } from "embedding-sdk-bundle/components/public/MetabotChat/types";
+
+const propsSchema: Yup.SchemaOf<MetabotChatProps> = Yup.object({
+  height: Yup.mixed().optional(),
+  width: Yup.mixed().optional(),
+  className: Yup.string().optional(),
+  style: Yup.object().optional(),
+  children: Yup.mixed().optional(),
+});
+
+export const metabotChatSchema: FunctionSchema = { input: [propsSchema] };

--- a/enterprise/frontend/src/embedding-sdk-ee/metabot/MetabotChat.tsx
+++ b/enterprise/frontend/src/embedding-sdk-ee/metabot/MetabotChat.tsx
@@ -1,0 +1,421 @@
+import cx from "classnames";
+import type { LegacyRef } from "react";
+import { useEffect, useId, useRef, useState } from "react";
+import { t } from "ttag";
+
+import { withPublicComponentWrapper } from "embedding-sdk-bundle/components/private/PublicComponentWrapper";
+import { ResizeWrapper } from "embedding-sdk-bundle/components/private/ResizeWrapper";
+import { METABOT_CHAT_SDK_EE_PLUGIN } from "embedding-sdk-bundle/components/public/MetabotChat/MetabotChat";
+import type {
+  MetabotChatProps,
+  MetabotCommandBarProps,
+  MetabotFloatingActionButtonProps,
+} from "embedding-sdk-bundle/components/public/MetabotChat/types";
+import { EnsureSingleInstance } from "embedding-sdk-shared/components/EnsureSingleInstance/EnsureSingleInstance";
+import {
+  Button,
+  Flex,
+  Icon,
+  Loader,
+  Menu,
+  Stack,
+  Text,
+  Textarea,
+  Tooltip,
+  UnstyledButton,
+} from "metabase/ui";
+import { useGetSuggestedMetabotPromptsQuery } from "metabase-enterprise/api";
+import { Messages } from "metabase-enterprise/metabot/components/MetabotChat/MetabotChatMessage";
+import { MetabotResetLongChatButton } from "metabase-enterprise/metabot/components/MetabotChat/MetabotResetLongChatButton";
+import { useMetabotAgent } from "metabase-enterprise/metabot/hooks";
+
+import S from "./MetabotChat.module.css";
+import { metabotChatSchema } from "./MetabotChat.schema";
+
+/**
+ * Empty state shown when there are no messages yet.
+ */
+function ChatEmptyState() {
+  return (
+    <Stack h="100%" w="100%" gap="sm" align="center" justify="center">
+      <Icon name="ai" c="text-tertiary" size="3rem" opacity={0.7} />
+
+      <Stack gap="xs" align="center">
+        <Text lh="sm" c="text-secondary">{t`Ask questions to AI.`}</Text>
+        <Text lh="sm" c="text-secondary">{t`Results will appear here.`}</Text>
+      </Stack>
+
+      <Text lh="sm" fz="sm" c="text-tertiary">
+        {t`AI isn't perfect. Double-check results.`}
+      </Text>
+    </Stack>
+  );
+}
+
+/**
+ * Chat history sub-component — renders messages and auto-scrolls.
+ */
+function ChatHistory() {
+  const metabot = useMetabotAgent();
+  const { messages, errorMessages } = metabot;
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+
+  const hasMessages = messages.length > 0 || errorMessages.length > 0;
+
+  useEffect(() => {
+    if (scrollContainerRef.current) {
+      scrollContainerRef.current.scrollTop =
+        scrollContainerRef.current.scrollHeight;
+    }
+  }, [messages.length, errorMessages.length, metabot.isDoingScience]);
+
+  return (
+    <Stack
+      ref={scrollContainerRef}
+      flex={1}
+      gap={0}
+      style={{ overflowY: "auto" }}
+      p="md"
+    >
+      {hasMessages ? (
+        <Messages
+          messages={messages}
+          errorMessages={errorMessages}
+          onRetryMessage={metabot.retryMessage}
+          isDoingScience={metabot.isDoingScience}
+          showFeedbackButtons={false}
+        />
+      ) : (
+        <ChatEmptyState />
+      )}
+      {metabot.isLongConversation && (
+        <MetabotResetLongChatButton
+          onResetConversation={metabot.resetConversation}
+        />
+      )}
+    </Stack>
+  );
+}
+
+/**
+ * Suggested prompts sub-component.
+ */
+function ChatSuggestions() {
+  const metabot = useMetabotAgent();
+
+  const suggestedPromptsQuery = useGetSuggestedMetabotPromptsQuery({
+    metabot_id: metabot.metabotId,
+    limit: 3,
+    sample: true,
+  });
+
+  const suggestedPrompts = suggestedPromptsQuery.currentData?.prompts ?? [];
+
+  const shouldShowSuggestedPrompts =
+    metabot.messages.length === 0 &&
+    metabot.errorMessages.length === 0 &&
+    !metabot.isDoingScience &&
+    suggestedPrompts.length > 0;
+
+  if (!shouldShowSuggestedPrompts) {
+    return null;
+  }
+
+  return (
+    <Stack gap="sm" p="md" className={S.promptSuggestionsContainer}>
+      {suggestedPrompts.map(({ prompt }, index) => (
+        <Button
+          key={index}
+          size="xs"
+          variant="outline"
+          fw={400}
+          onClick={() => metabot.submitInput(prompt, { focusInput: true })}
+          className={S.promptSuggestionButton}
+          data-testid="metabot-chat-suggestion-button"
+        >
+          {prompt}
+        </Button>
+      ))}
+    </Stack>
+  );
+}
+
+/**
+ * Chat input sub-component.
+ */
+function ChatInput() {
+  const metabot = useMetabotAgent();
+
+  const placeholder = metabot.isDoingScience
+    ? t`Doing science...`
+    : t`Ask AI a question...`;
+
+  return (
+    <Flex
+      gap="xs"
+      px="md"
+      align="center"
+      justify="center"
+      style={{ borderTop: "1px solid var(--mb-color-border)" }}
+    >
+      <Flex justify="center" align="center" style={{ flexShrink: 0 }}>
+        {metabot.isDoingScience ? (
+          <Loader size="sm" />
+        ) : (
+          <Icon name="ai" c="brand" size="1rem" />
+        )}
+      </Flex>
+
+      <Textarea
+        id="metabot-chat-input"
+        data-testid="metabot-chat-input"
+        w="100%"
+        autosize={false}
+        rows={1}
+        ref={metabot.promptInputRef as LegacyRef<HTMLTextAreaElement>}
+        autoFocus
+        value={metabot.prompt}
+        readOnly={metabot.isDoingScience}
+        placeholder={placeholder}
+        onChange={(e) => metabot.setPrompt(e.target.value)}
+        classNames={{ input: S.chatInput }}
+        onKeyDown={(e) => {
+          if (e.nativeEvent.isComposing) {
+            return;
+          }
+
+          const isModifiedKeyPress =
+            e.shiftKey || e.ctrlKey || e.metaKey || e.altKey;
+
+          if (e.key === "Enter" && !isModifiedKeyPress) {
+            e.preventDefault();
+            e.stopPropagation();
+            metabot.submitInput(metabot.prompt, { focusInput: true });
+          }
+        }}
+      />
+
+      <Flex align="center" justify="center" gap="xs">
+        {metabot.isDoingScience && (
+          <UnstyledButton
+            onClick={metabot.cancelRequest}
+            className={cx(S.chatButton, S.stopGenerationButton)}
+          >
+            <Tooltip label={t`Stop generation`}>
+              <Icon name="stop" c="text-secondary" />
+            </Tooltip>
+          </UnstyledButton>
+        )}
+
+        {!metabot.isDoingScience && metabot.prompt.length > 0 && (
+          <UnstyledButton
+            onClick={() => metabot.setPrompt("")}
+            data-testid="metabot-chat-clear-input"
+            className={S.chatButton}
+          >
+            <Icon name="close" c="text-secondary" />
+          </UnstyledButton>
+        )}
+
+        <Menu position="top-end" withinPortal>
+          <Menu.Target>
+            <UnstyledButton
+              data-testid="metabot-chat-overflow-button"
+              className={S.chatButton}
+            >
+              <Icon name="ellipsis" c="text-secondary" />
+            </UnstyledButton>
+          </Menu.Target>
+
+          <Menu.Dropdown>
+            <Menu.Item
+              leftSection={<Icon name="edit_document_outlined" size="1rem" />}
+              onClick={metabot.resetConversation}
+            >
+              {t`Start new chat`}
+            </Menu.Item>
+          </Menu.Dropdown>
+        </Menu>
+      </Flex>
+    </Flex>
+  );
+}
+
+/**
+ * Default chat layout — history + suggestions + input.
+ */
+function DefaultChatLayout() {
+  return (
+    <>
+      <ChatHistory />
+      <Stack gap={0}>
+        <ChatSuggestions />
+        <ChatInput />
+      </Stack>
+    </>
+  );
+}
+
+/**
+ * The core MetabotChat panel.
+ */
+const MetabotChatInner = ({
+  height,
+  width,
+  className,
+  style,
+  children,
+}: MetabotChatProps) => {
+  return (
+    <ResizeWrapper h={height} w={width} className={className} style={style}>
+      <div className={S.container} data-testid="metabot-chat-container">
+        {children ?? <DefaultChatLayout />}
+      </div>
+    </ResizeWrapper>
+  );
+};
+
+const MetabotChatWrapped = (props: MetabotChatProps) => {
+  const ensureSingleInstanceId = useId();
+
+  return (
+    <EnsureSingleInstance
+      groupId="metabot-chat"
+      instanceId={ensureSingleInstanceId}
+      multipleRegisteredInstancesWarningMessage={
+        "Multiple instances of MetabotChat detected. Ensure only one instance of MetabotChat is rendered at a time."
+      }
+    >
+      <MetabotChatInner {...props} />
+    </EnsureSingleInstance>
+  );
+};
+
+// Side effect: activate MetabotChat in the plugin
+METABOT_CHAT_SDK_EE_PLUGIN.MetabotChat = Object.assign(
+  withPublicComponentWrapper(MetabotChatWrapped, {
+    supportsGuestEmbed: false,
+  }),
+  { schema: metabotChatSchema },
+);
+
+/**
+ * FloatingActionButton trigger — Intercom-style FAB that toggles a chat panel.
+ */
+const FloatingActionButtonInner = ({
+  className,
+  style,
+  panelHeight = 500,
+  panelWidth = 400,
+  children,
+}: MetabotFloatingActionButtonProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <div className={className} style={style}>
+      {isOpen && (
+        <div
+          className={S.fabPanel}
+          style={{ height: panelHeight, width: panelWidth }}
+        >
+          <MetabotChatInner height="100%" width="100%">
+            {children}
+          </MetabotChatInner>
+        </div>
+      )}
+
+      <UnstyledButton
+        className={S.fabTrigger}
+        onClick={() => setIsOpen((open) => !open)}
+        data-testid="metabot-chat-fab"
+        aria-label={isOpen ? t`Close chat` : t`Open chat`}
+      >
+        <Icon name={isOpen ? "close" : "ai"} size="1.5rem" />
+      </UnstyledButton>
+    </div>
+  );
+};
+
+METABOT_CHAT_SDK_EE_PLUGIN.FloatingActionButton =
+  withPublicComponentWrapper(FloatingActionButtonInner, {
+    supportsGuestEmbed: false,
+  });
+
+/**
+ * CommandBar trigger — centered bottom bar that expands into a chat panel.
+ */
+const CommandBarInner = ({
+  className,
+  style,
+  panelHeight = 400,
+  width = 600,
+  children,
+}: MetabotCommandBarProps) => {
+  const metabot = useMetabotAgent();
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const hasMessages =
+    metabot.messages.length > 0 || metabot.errorMessages.length > 0;
+  const showPanel = isExpanded || hasMessages || metabot.isDoingScience;
+
+  return (
+    <div className={cx(S.commandBarContainer, className)} style={{ ...style, width }}>
+      {showPanel && (
+        <div className={S.commandBarPanel} style={{ height: panelHeight }}>
+          <Flex
+            px="md"
+            py="xs"
+            align="center"
+            justify="space-between"
+            style={{ borderBottom: "1px solid var(--mb-color-border)", flexShrink: 0 }}
+          >
+            <Flex align="center" gap="xs">
+              <Icon name="ai" c="brand" size="1rem" />
+              <span style={{ fontSize: 13, fontWeight: 600, color: "var(--mb-color-text-primary)" }}>
+                {t`Metabot`}
+              </span>
+            </Flex>
+            <UnstyledButton
+              onClick={() => setIsExpanded(false)}
+              data-testid="metabot-command-bar-collapse"
+              className={S.chatButton}
+              aria-label={t`Collapse`}
+            >
+              <Icon name="chevrondown" c="text-secondary" size="1rem" />
+            </UnstyledButton>
+          </Flex>
+          <MetabotChatInner
+            height={`calc(${typeof panelHeight === "number" ? `${panelHeight}px` : panelHeight} - 40px)`}
+            width="100%"
+          >
+            {children}
+          </MetabotChatInner>
+        </div>
+      )}
+
+      {!showPanel && (
+        <div className={S.commandBarInput} style={{ width }}>
+          <Flex
+            gap="xs"
+            px="md"
+            py="sm"
+            align="center"
+            onClick={() => setIsExpanded(true)}
+            style={{ cursor: "pointer" }}
+            data-testid="metabot-command-bar"
+          >
+            <Icon name="ai" c="brand" size="1rem" />
+            <span style={{ color: "var(--mb-color-text-light)" }}>
+              {t`Ask AI a question...`}
+            </span>
+          </Flex>
+        </div>
+      )}
+    </div>
+  );
+};
+
+METABOT_CHAT_SDK_EE_PLUGIN.CommandBar = withPublicComponentWrapper(
+  CommandBarInner,
+  { supportsGuestEmbed: false },
+);

--- a/enterprise/frontend/src/embedding-sdk-ee/metabot/MetabotChat.tsx
+++ b/enterprise/frontend/src/embedding-sdk-ee/metabot/MetabotChat.tsx
@@ -1,3 +1,4 @@
+import { useClipboard } from "@mantine/hooks";
 import cx from "classnames";
 import type { LegacyRef } from "react";
 import { useEffect, useId, useRef, useState } from "react";
@@ -5,6 +6,9 @@ import { t } from "ttag";
 
 import { withPublicComponentWrapper } from "embedding-sdk-bundle/components/private/PublicComponentWrapper";
 import { ResizeWrapper } from "embedding-sdk-bundle/components/private/ResizeWrapper";
+import { SdkAdHocQuestion } from "embedding-sdk-bundle/components/private/SdkAdHocQuestion";
+import { SdkQuestionDefaultView } from "embedding-sdk-bundle/components/private/SdkQuestionDefaultView";
+import { InteractiveQuestion } from "embedding-sdk-bundle/components/public/InteractiveQuestion";
 import { METABOT_CHAT_SDK_EE_PLUGIN } from "embedding-sdk-bundle/components/public/MetabotChat/MetabotChat";
 import type {
   MetabotChatProps,
@@ -25,7 +29,11 @@ import {
   UnstyledButton,
 } from "metabase/ui";
 import { useGetSuggestedMetabotPromptsQuery } from "metabase-enterprise/api";
-import { Messages } from "metabase-enterprise/metabot/components/MetabotChat/MetabotChatMessage";
+import {
+  AgentErrorMessage,
+  AgentMessage,
+  UserMessage,
+} from "metabase-enterprise/metabot/components/MetabotChat/MetabotChatMessage";
 import { MetabotResetLongChatButton } from "metabase-enterprise/metabot/components/MetabotChat/MetabotResetLongChatButton";
 import { useMetabotAgent } from "metabase-enterprise/metabot/hooks";
 
@@ -53,12 +61,48 @@ function ChatEmptyState() {
 }
 
 /**
+ * Inline chart rendered as part of the chat history.
+ * Each instance is fully independent — no shared question state.
+ */
+function InlineChart({ questionPath }: { questionPath: string }) {
+  return (
+    <div
+      style={{
+        height: "500px",
+        width: "100%",
+        flexShrink: 0,
+        borderRadius: "8px",
+        overflow: "hidden",
+        background: "var(--mb-color-background-secondary)",
+        marginBottom: "1rem",
+      }}
+    >
+      <SdkAdHocQuestion
+        questionPath={questionPath}
+        title={false}
+        height="500px"
+        isSaveEnabled={false}
+      >
+        <SdkQuestionDefaultView
+          height="500px"
+          withChartTypeSelector
+          withEditorButton={false}
+        />
+        {/* <InteractiveQuestion.QuestionVisualization /> */}
+      </SdkAdHocQuestion>
+    </div>
+  );
+}
+
+/**
  * Chat history sub-component — renders messages and auto-scrolls.
+ * Chart messages are rendered as independent inline ad-hoc questions.
  */
 function ChatHistory() {
   const metabot = useMetabotAgent();
   const { messages, errorMessages } = metabot;
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const clipboard = useClipboard();
 
   const hasMessages = messages.length > 0 || errorMessages.length > 0;
 
@@ -78,13 +122,60 @@ function ChatHistory() {
       p="md"
     >
       {hasMessages ? (
-        <Messages
-          messages={messages}
-          errorMessages={errorMessages}
-          onRetryMessage={metabot.retryMessage}
-          isDoingScience={metabot.isDoingScience}
-          showFeedbackButtons={false}
-        />
+        <>
+          {messages.map((message, index) => {
+            if (message.role === "agent" && message.type === "chart") {
+              return (
+                <InlineChart
+                  key={message.id}
+                  questionPath={message.questionPath}
+                />
+              );
+            }
+
+            if (message.role === "agent") {
+              return (
+                <AgentMessage
+                  key={message.id}
+                  data-testid="metabot-chat-message"
+                  message={message}
+                  onRetry={metabot.retryMessage}
+                  onCopy={() =>
+                    clipboard.copy("message" in message ? message.message : "")
+                  }
+                  showFeedbackButtons={false}
+                  submittedFeedback={undefined}
+                  hideActions={
+                    metabot.isDoingScience ||
+                    messages[index + 1]?.role === "agent"
+                  }
+                />
+              );
+            }
+
+            return (
+              <UserMessage
+                key={message.id}
+                data-testid="metabot-chat-message"
+                message={message}
+                hideActions={
+                  metabot.isDoingScience && messages.length === index + 1
+                }
+                onCopy={() =>
+                  clipboard.copy("message" in message ? message.message : "")
+                }
+              />
+            );
+          })}
+
+          {errorMessages.map((message, index) => (
+            <AgentErrorMessage
+              key={"err-" + index}
+              data-testid="metabot-chat-message"
+              message={message}
+            />
+          ))}
+        </>
       ) : (
         <ChatEmptyState />
       )}
@@ -336,10 +427,12 @@ const FloatingActionButtonInner = ({
   );
 };
 
-METABOT_CHAT_SDK_EE_PLUGIN.FloatingActionButton =
-  withPublicComponentWrapper(FloatingActionButtonInner, {
+METABOT_CHAT_SDK_EE_PLUGIN.FloatingActionButton = withPublicComponentWrapper(
+  FloatingActionButtonInner,
+  {
     supportsGuestEmbed: false,
-  });
+  },
+);
 
 /**
  * CommandBar trigger — centered bottom bar that expands into a chat panel.
@@ -359,7 +452,10 @@ const CommandBarInner = ({
   const showPanel = isExpanded || hasMessages || metabot.isDoingScience;
 
   return (
-    <div className={cx(S.commandBarContainer, className)} style={{ ...style, width }}>
+    <div
+      className={cx(S.commandBarContainer, className)}
+      style={{ ...style, width }}
+    >
       {showPanel && (
         <div className={S.commandBarPanel} style={{ height: panelHeight }}>
           <Flex
@@ -367,11 +463,20 @@ const CommandBarInner = ({
             py="xs"
             align="center"
             justify="space-between"
-            style={{ borderBottom: "1px solid var(--mb-color-border)", flexShrink: 0 }}
+            style={{
+              borderBottom: "1px solid var(--mb-color-border)",
+              flexShrink: 0,
+            }}
           >
             <Flex align="center" gap="xs">
               <Icon name="ai" c="brand" size="1rem" />
-              <span style={{ fontSize: 13, fontWeight: 600, color: "var(--mb-color-text-primary)" }}>
+              <span
+                style={{
+                  fontSize: 13,
+                  fontWeight: 600,
+                  color: "var(--mb-color-text-primary)",
+                }}
+              >
                 {t`Metabot`}
               </span>
             </Flex>

--- a/enterprise/frontend/src/embedding-sdk-ee/metabot/MetabotQuestion.stories.tsx
+++ b/enterprise/frontend/src/embedding-sdk-ee/metabot/MetabotQuestion.stories.tsx
@@ -2,8 +2,8 @@ import type { StoryFn } from "@storybook/react";
 import { HttpResponse, http } from "msw";
 import type { ComponentProps } from "react";
 
+import { MetabotQuestion } from "embedding-sdk-bundle/components/public/MetabotQuestion";
 import { CommonSdkStoryWrapper } from "embedding-sdk-bundle/test/CommonSdkStoryWrapper";
-import { MetabotQuestion } from "embedding-sdk-package";
 import {
   MOCK_AD_HOC_QUESTION_ID,
   mockStreamResponse,

--- a/enterprise/frontend/src/embedding-sdk-ee/metabot/index.ts
+++ b/enterprise/frontend/src/embedding-sdk-ee/metabot/index.ts
@@ -1,4 +1,5 @@
-// Contains side effects that puts `MetabotQuestion` in the plugin
+// Contains side effects that puts `MetabotQuestion` and `MetabotChat` in the plugin
+import "./MetabotChat";
 import "./MetabotQuestion";
 
 import { METABOT_SDK_EE_PLUGIN } from "embedding-sdk-bundle/components/public/MetabotQuestion/MetabotQuestion";

--- a/enterprise/frontend/src/embedding-sdk-package/components/public/AdHocQuestion/AdHocQuestion.tsx
+++ b/enterprise/frontend/src/embedding-sdk-package/components/public/AdHocQuestion/AdHocQuestion.tsx
@@ -1,0 +1,13 @@
+import { createComponent } from "embedding-sdk-package/components/private/ComponentWrapper/ComponentWrapper";
+import { getWindow } from "embedding-sdk-shared/lib/get-window";
+
+/**
+ * A component that renders an ad-hoc question from a base64-encoded MBQL query.
+ *
+ * @function
+ * @category AdHocQuestion
+ * @param props
+ */
+export const AdHocQuestion = createComponent(
+  () => getWindow()?.METABASE_EMBEDDING_SDK_BUNDLE?.AdHocQuestion,
+);

--- a/enterprise/frontend/src/embedding-sdk-package/components/public/AdHocQuestion/index.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/components/public/AdHocQuestion/index.ts
@@ -1,0 +1,1 @@
+export * from "./AdHocQuestion";

--- a/enterprise/frontend/src/embedding-sdk-package/components/public/MetabotChat/MetabotChat.tsx
+++ b/enterprise/frontend/src/embedding-sdk-package/components/public/MetabotChat/MetabotChat.tsx
@@ -1,0 +1,12 @@
+import { createComponent } from "embedding-sdk-package/components/private/ComponentWrapper/ComponentWrapper";
+import { getWindow } from "embedding-sdk-shared/lib/get-window";
+
+/**
+ * A standalone chat panel for Metabot.
+ *
+ * @function
+ * @category MetabotChat
+ */
+export const MetabotChat = createComponent(
+  () => getWindow()?.METABASE_EMBEDDING_SDK_BUNDLE?.MetabotChat,
+);

--- a/enterprise/frontend/src/embedding-sdk-package/components/public/MetabotChat/MetabotChat.tsx
+++ b/enterprise/frontend/src/embedding-sdk-package/components/public/MetabotChat/MetabotChat.tsx
@@ -1,5 +1,12 @@
+import type {
+  MetabotChatProps,
+  MetabotCommandBarProps,
+  MetabotFloatingActionButtonProps,
+} from "embedding-sdk-bundle/components/public/MetabotChat/types";
 import { createComponent } from "embedding-sdk-package/components/private/ComponentWrapper/ComponentWrapper";
 import { getWindow } from "embedding-sdk-shared/lib/get-window";
+
+const getBundle = () => getWindow()?.METABASE_EMBEDDING_SDK_BUNDLE;
 
 /**
  * A standalone chat panel for Metabot.
@@ -7,6 +14,35 @@ import { getWindow } from "embedding-sdk-shared/lib/get-window";
  * @function
  * @category MetabotChat
  */
-export const MetabotChat = createComponent(
-  () => getWindow()?.METABASE_EMBEDDING_SDK_BUNDLE?.MetabotChat,
+const MetabotChatBase = createComponent<MetabotChatProps>(
+  () => getBundle()?.MetabotChat,
 );
+
+/**
+ * Intercom-style floating action button that toggles a chat panel.
+ *
+ * @function
+ * @category MetabotChat
+ */
+const FloatingActionButton = createComponent<MetabotFloatingActionButtonProps>(
+  () => {
+    const MetabotChat = getBundle()?.MetabotChat as any;
+    return MetabotChat?.FloatingActionButton;
+  },
+);
+
+/**
+ * Centered bottom command bar that expands into a chat panel.
+ *
+ * @function
+ * @category MetabotChat
+ */
+const CommandBar = createComponent<MetabotCommandBarProps>(() => {
+  const MetabotChat = getBundle()?.MetabotChat as any;
+  return MetabotChat?.CommandBar;
+});
+
+export const MetabotChat = Object.assign(MetabotChatBase, {
+  FloatingActionButton,
+  CommandBar,
+});

--- a/enterprise/frontend/src/embedding-sdk-package/components/public/MetabotChat/index.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/components/public/MetabotChat/index.ts
@@ -1,0 +1,1 @@
+export { MetabotChat } from "./MetabotChat";

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabot.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabot.ts
@@ -1,0 +1,24 @@
+import { getWindow } from "embedding-sdk-shared/lib/get-window";
+
+/**
+ * Hook for interacting with Metabot.
+ *
+ * Provides methods to send messages, manage conversation state,
+ * and read Metabot responses.
+ *
+ * Must be used within a `MetabaseProvider`.
+ *
+ * @function
+ * @category useMetabot
+ */
+export const useMetabot = () => {
+  const useMetabotHook = getWindow()?.METABASE_EMBEDDING_SDK_BUNDLE?.useMetabot;
+
+  if (!useMetabotHook) {
+    throw new Error(
+      "useMetabot: SDK bundle is not loaded yet. Make sure to use this hook within a MetabaseProvider.",
+    );
+  }
+
+  return useMetabotHook();
+};

--- a/enterprise/frontend/src/embedding-sdk-package/index.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/index.ts
@@ -20,6 +20,7 @@ export { StaticDashboard } from "./components/public/dashboard/StaticDashboard";
 export { InteractiveQuestion } from "./components/public/InteractiveQuestion";
 export { StaticQuestion } from "./components/public/StaticQuestion";
 export { MetabaseProvider } from "./components/public/MetabaseProvider";
+export { MetabotChat } from "./components/public/MetabotChat";
 export { MetabotQuestion } from "./components/public/MetabotQuestion";
 export * from "./components/public/debug/SdkDebugInfo";
 
@@ -28,6 +29,7 @@ export { useAvailableFonts } from "./hooks/public/use-available-fonts";
 export { useCurrentUser } from "./hooks/public/use-current-user";
 export { useCreateDashboardApi } from "./hooks/public/use-create-dashboard-api";
 export { useMetabaseAuthStatus } from "./hooks/public/use-metabase-auth-status";
+export { useMetabot } from "./hooks/public/use-metabot";
 
 export { defineMetabaseAuthConfig } from "./lib/public/define-metabase-auth-config";
 export { defineMetabaseTheme } from "./lib/public/define-metabase-theme";
@@ -69,6 +71,11 @@ export {
   type InteractiveQuestionComponents,
   type InteractiveQuestionProps,
 } from "embedding-sdk-bundle/components/public/InteractiveQuestion";
+export {
+  type MetabotChatProps,
+  type MetabotCommandBarProps,
+  type MetabotFloatingActionButtonProps,
+} from "embedding-sdk-bundle/components/public/MetabotChat";
 export { type MetabotQuestionProps } from "embedding-sdk-bundle/components/public/MetabotQuestion";
 export {
   type StaticQuestionProps,

--- a/enterprise/frontend/src/embedding-sdk-package/index.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/index.ts
@@ -11,6 +11,7 @@ EMBEDDING_SDK_CONFIG.isEmbeddingSdk = true;
 defineBuildInfo("METABASE_EMBEDDING_SDK_PACKAGE_BUILD_INFO");
 defineGlobalDependencies();
 
+export { AdHocQuestion } from "./components/public/AdHocQuestion";
 export { CollectionBrowser } from "./components/public/CollectionBrowser";
 export { CreateQuestion } from "./components/public/CreateQuestion";
 export { CreateDashboardModal } from "./components/public/CreateDashboardModal";
@@ -36,6 +37,7 @@ export {
   type CollectionBrowserProps,
   type CollectionBrowserListColumns,
 } from "embedding-sdk-bundle/components/public/CollectionBrowser";
+export { type AdHocQuestionProps } from "embedding-sdk-bundle/components/public/AdHocQuestion";
 export { type CreateDashboardModalProps } from "embedding-sdk-bundle/components/public/CreateDashboardModal";
 export { type CreateQuestionProps } from "embedding-sdk-bundle/components/public/CreateQuestion";
 export type {

--- a/enterprise/frontend/src/embedding/auth-common/jwt.ts
+++ b/enterprise/frontend/src/embedding/auth-common/jwt.ts
@@ -90,8 +90,12 @@ const runFetchRequestToken = async (
 const refreshUserJwt = async (url: string) => {
   let clientBackendResponse;
   try {
-    // Use window.location.origin as base to support relative URLs like "/api/sso"
-    const urlWithSource = new URL(url, window.location.origin);
+    // Use window.location.origin as base to support relative URLs like "/api/sso".
+    // In sandboxed iframes, window.location.origin is the string "null" (not a valid URL),
+    // so we must omit the base in that case (the url must then be absolute).
+    const origin = window.location.origin;
+    const base = origin !== "null" ? origin : undefined;
+    const urlWithSource = new URL(url, base);
     urlWithSource.searchParams.set("response", "json");
     clientBackendResponse = await fetch(urlWithSource.toString(), {
       method: "GET",

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/actions.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/actions.ts
@@ -41,6 +41,7 @@ import {
   getUserPromptForMessageId,
 } from "./selectors";
 import type {
+  MetabotAgentChartMessage,
   MetabotAgentEditSuggestionChatMessage,
   MetabotAgentId,
   MetabotAgentTodoListChatMessage,
@@ -351,9 +352,18 @@ export const sendAgentRequest = createAsyncThunk<
                 dispatch(addSuggestedCodeEdit({ ...part.value, active: true }));
               })
               .with({ type: "navigate_to" }, (part) => {
+                // Keep for MetabotQuestion backward compat (single global chart)
                 dispatch(setNavigateToPath(part.value));
 
-                if (!isEmbeddingSdk() && !isWorkspace) {
+                if (isEmbeddingSdk()) {
+                  // In SDK mode, also push an inline chart message into the
+                  // conversation so MetabotChat can render it independently.
+                  const chartMessage: Omit<MetabotAgentChartMessage, "id" | "role"> = {
+                    type: "chart",
+                    questionPath: part.value,
+                  };
+                  dispatch(addAgentMessage({ ...chartMessage, agentId }));
+                } else if (!isWorkspace) {
                   dispatch(push(part.value) as UnknownAction);
                 }
               })

--- a/enterprise/frontend/src/metabase-enterprise/metabot/state/types.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/state/types.ts
@@ -59,11 +59,19 @@ export type MetabotDebugToolCallMessage = {
   is_error?: boolean;
 };
 
+export type MetabotAgentChartMessage = {
+  id: string;
+  role: "agent";
+  type: "chart";
+  questionPath: string;
+};
+
 export type MetabotAgentChatMessage =
   | MetabotAgentTextChatMessage
   | MetabotAgentTodoListChatMessage
   | MetabotAgentEditSuggestionChatMessage
-  | MetabotDebugToolCallMessage;
+  | MetabotDebugToolCallMessage
+  | MetabotAgentChartMessage;
 
 export type MetabotUserChatMessage =
   | MetabotUserTextChatMessage

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestionDefaultView/SdkQuestionDefaultView.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestionDefaultView/SdkQuestionDefaultView.tsx
@@ -65,6 +65,8 @@ export interface SdkQuestionDefaultViewProps extends FlexibleSizeProps {
    * Determines whether the chart type selector and corresponding settings button are shown. Only relevant when using the default layout.
    */
   withChartTypeSelector?: boolean;
+
+  withEditorButton?: boolean;
 }
 
 export const SdkQuestionDefaultView = ({
@@ -74,6 +76,7 @@ export const SdkQuestionDefaultView = ({
   style,
   title,
   withChartTypeSelector,
+  withEditorButton = false,
 }: SdkQuestionDefaultViewProps): ReactElement => {
   const { isLocaleLoading } = useLocale();
   const {
@@ -261,7 +264,9 @@ export const SdkQuestionDefaultView = ({
                   <QuestionAlertsButton />
                 </>
               )}
-              <EditorButton isOpen={isEditorOpen} onClick={toggleEditor} />
+              {withEditorButton && (
+                <EditorButton isOpen={isEditorOpen} onClick={toggleEditor} />
+              )}
             </RenderIfHasContent>
           </RenderIfHasContent>
         )}

--- a/frontend/src/embedding-sdk-bundle/components/public/AdHocQuestion/AdHocQuestion.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/AdHocQuestion/AdHocQuestion.tsx
@@ -1,0 +1,62 @@
+import { useMemo } from "react";
+
+import { withPublicComponentWrapper } from "embedding-sdk-bundle/components/private/PublicComponentWrapper";
+import {
+  SdkQuestion,
+  type SdkQuestionProps,
+} from "embedding-sdk-bundle/components/public/SdkQuestion/SdkQuestion";
+import { b64_to_utf8 } from "metabase/lib/encoding";
+import type { Card } from "metabase-types/api";
+
+/**
+ * @interface
+ * @expand
+ * @category AdHocQuestion
+ */
+export type AdHocQuestionProps = Omit<
+  SdkQuestionProps,
+  | "questionId"
+  | "token"
+  | "deserializedCard"
+  | "getClickActionMode"
+  | "navigateToNewCard"
+  | "backToDashboard"
+> & {
+  /**
+   * Base64-encoded MBQL query to run as an ad-hoc question.
+   *
+   * The query should be a JSON object encoded in base64. For example:
+   * ```
+   * btoa(JSON.stringify({
+   *   "lib/type": "mbql/query",
+   *   "database": 2,
+   *   "stages": [{ "lib/type": "mbql.stage/mbql", "source-table": 73 }]
+   * }))
+   * ```
+   */
+  query: string;
+};
+
+const AdHocQuestionInner = ({ query, ...props }: AdHocQuestionProps) => {
+  const deserializedCard = useMemo((): Card => {
+    const decodedQuery = JSON.parse(b64_to_utf8(query));
+
+    return {
+      display: "table",
+      dataset_query: decodedQuery,
+      visualization_settings: {},
+    } as Card;
+  }, [query]);
+
+  return (
+    <SdkQuestion
+      questionId={null}
+      deserializedCard={deserializedCard}
+      {...props}
+    />
+  );
+};
+
+export const AdHocQuestion = withPublicComponentWrapper(AdHocQuestionInner, {
+  supportsGuestEmbed: false,
+});

--- a/frontend/src/embedding-sdk-bundle/components/public/AdHocQuestion/index.ts
+++ b/frontend/src/embedding-sdk-bundle/components/public/AdHocQuestion/index.ts
@@ -1,0 +1,1 @@
+export * from "./AdHocQuestion";

--- a/frontend/src/embedding-sdk-bundle/components/public/MetabotChat/MetabotChat.stories.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/MetabotChat/MetabotChat.stories.tsx
@@ -1,0 +1,288 @@
+import type { Meta, StoryFn } from "@storybook/react";
+import type { CSSProperties } from "react";
+import { useMemo } from "react";
+
+// Side effects (Mantine styles, dayjs plugins, etc)
+import "embedding-sdk-bundle";
+
+import { ComponentProvider } from "embedding-sdk-bundle/components/public/ComponentProvider";
+import { getStorybookSdkAuthConfigForUser } from "embedding-sdk-bundle/test/CommonSdkStoryWrapper";
+import { defineMetabaseTheme } from "metabase/embedding-sdk/theme";
+
+import { MetabotChat } from "./MetabotChat";
+
+// ============================================================================
+// Dark SaaS palette
+// ============================================================================
+
+const dk = {
+  bg: "#0B0D11",
+  surface: "#13161C",
+  surfaceRaised: "#1A1D25",
+  border: "#2A2E38",
+  borderSubtle: "#1F222A",
+  text: "#E4E5E9",
+  textSecondary: "#8B8F9A",
+  textMuted: "#5C6170",
+  accent: "#6C5CE7",
+  accentLight: "#A29BFE",
+  green: "#00D68F",
+  red: "#FF6B6B",
+};
+
+// ============================================================================
+// SDK dark theme that matches the SaaS page palette
+// ============================================================================
+
+const saasTheme = defineMetabaseTheme({
+  fontFamily: "Inter",
+  fontSize: "14px",
+  colors: {
+    brand: dk.accent,
+    filter: dk.accentLight,
+    "text-primary": dk.text,
+    "text-secondary": dk.textSecondary,
+    "text-tertiary": dk.textMuted,
+    border: dk.border,
+    background: dk.surface,
+    "background-secondary": dk.surfaceRaised,
+    "background-hover": dk.surfaceRaised,
+    "background-disabled": dk.border,
+    positive: dk.green,
+    negative: dk.red,
+  },
+});
+
+// ============================================================================
+// Custom decorator: forces dark theme on every story
+// ============================================================================
+
+const DarkSdkWrapper = (Story: StoryFn) => {
+  const authConfig = useMemo(
+    () => getStorybookSdkAuthConfigForUser("admin"),
+    [],
+  );
+
+  return (
+    <ComponentProvider authConfig={authConfig} theme={saasTheme}>
+      <Story />
+    </ComponentProvider>
+  );
+};
+
+// ============================================================================
+// Fake SaaS dashboard background
+// ============================================================================
+
+const SaasPageBg = () => (
+  <div
+    style={{
+      position: "absolute",
+      inset: 0,
+      background: dk.bg,
+      overflow: "hidden",
+      zIndex: 0,
+    }}
+  >
+    <div
+      style={{
+        height: 48,
+        borderBottom: `1px solid ${dk.border}`,
+        display: "flex",
+        alignItems: "center",
+        padding: "0 24px",
+        gap: 24,
+      }}
+    >
+      <span style={{ fontWeight: 800, fontSize: 15, color: dk.text }}>
+        <span style={{ color: dk.accent }}>Acme</span> Analytics
+      </span>
+      {["Dashboard", "Reports", "Data", "Settings"].map((label) => (
+        <span
+          key={label}
+          style={{ fontSize: 13, color: dk.textSecondary, cursor: "pointer" }}
+        >
+          {label}
+        </span>
+      ))}
+    </div>
+
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "1fr 1fr 1fr",
+        gap: 16,
+        padding: "24px",
+        maxWidth: 900,
+      }}
+    >
+      {(
+        [
+          ["Revenue", "$1.24M", "+12.3%"],
+          ["Users", "48.2K", "+8.7%"],
+          ["Churn", "2.1%", "-0.4%"],
+        ] as const
+      ).map(([label, val, delta]) => (
+        <div
+          key={label}
+          style={{
+            background: dk.surface,
+            border: `1px solid ${dk.border}`,
+            borderRadius: 12,
+            padding: 20,
+          }}
+        >
+          <div style={{ fontSize: 12, color: dk.textMuted }}>{label}</div>
+          <div style={{ fontSize: 28, fontWeight: 800, color: dk.text }}>
+            {val}
+          </div>
+          <div
+            style={{
+              fontSize: 12,
+              color: delta.startsWith("-") ? dk.red : dk.green,
+              marginTop: 4,
+            }}
+          >
+            {delta}
+          </div>
+        </div>
+      ))}
+    </div>
+
+    <div style={{ padding: "0 24px" }}>
+      <div
+        style={{
+          background: dk.surface,
+          border: `1px solid ${dk.border}`,
+          borderRadius: 12,
+          overflow: "hidden",
+        }}
+      >
+        {["Top Customers", "Recent Orders", "Pipeline", "Activity"].map(
+          (row, i) => (
+            <div
+              key={row}
+              style={{
+                padding: "12px 20px",
+                borderBottom:
+                  i < 3 ? `1px solid ${dk.borderSubtle}` : "none",
+                display: "flex",
+                justifyContent: "space-between",
+                fontSize: 13,
+                color: dk.textSecondary,
+              }}
+            >
+              <span>{row}</span>
+              <span style={{ color: dk.textMuted }}>View &rarr;</span>
+            </div>
+          ),
+        )}
+      </div>
+    </div>
+  </div>
+);
+
+const fullPageStyle: CSSProperties = {
+  position: "relative",
+  width: "100%",
+  height: "100vh",
+  overflow: "hidden",
+  fontFamily: '"Inter", -apple-system, BlinkMacSystemFont, sans-serif',
+};
+
+// ============================================================================
+// Story 1: Standalone chat panel (inline, no trigger)
+// ============================================================================
+
+const StandalonePanelDemo = () => (
+  <div style={fullPageStyle}>
+    <SaasPageBg />
+    <div
+      style={{
+        position: "absolute",
+        top: "50%",
+        left: "50%",
+        transform: "translate(-50%, -50%)",
+        zIndex: 10,
+        borderRadius: 16,
+        overflow: "hidden",
+        border: `1px solid ${dk.border}`,
+        background: dk.surface,
+        boxShadow: `0 24px 80px rgba(0,0,0,0.5)`,
+      }}
+    >
+      <MetabotChat height={500} width={400} />
+    </div>
+  </div>
+);
+
+// ============================================================================
+// Story 2: FloatingActionButton (Intercom-style)
+// ============================================================================
+
+const FloatingActionButtonDemo = () => (
+  <div style={fullPageStyle}>
+    <SaasPageBg />
+    <MetabotChat.FloatingActionButton panelHeight={520} panelWidth={380} />
+  </div>
+);
+
+// ============================================================================
+// Story 3: CommandBar (centered bottom AI bar)
+// ============================================================================
+
+const CommandBarDemo = () => (
+  <div style={fullPageStyle}>
+    <SaasPageBg />
+    <MetabotChat.CommandBar width={560} panelHeight={420} />
+  </div>
+);
+
+// ============================================================================
+// Story 4: Full-width bottom panel
+// ============================================================================
+
+const FullWidthDemo = () => (
+  <div style={fullPageStyle}>
+    <SaasPageBg />
+    <div
+      style={{
+        position: "absolute",
+        bottom: 0,
+        left: 0,
+        right: 0,
+        zIndex: 10,
+        background: dk.surface,
+        borderTop: `1px solid ${dk.border}`,
+      }}
+    >
+      <MetabotChat height={300} width="100%" />
+    </div>
+  </div>
+);
+
+// ============================================================================
+// Storybook meta
+// ============================================================================
+
+export default {
+  title: "EmbeddingSDK/MetabotChat",
+  parameters: {
+    layout: "fullscreen",
+  },
+  decorators: [DarkSdkWrapper],
+} satisfies Meta;
+
+export const StandalonePanel: StoryFn = () => <StandalonePanelDemo />;
+StandalonePanel.storyName = "Standalone Panel";
+
+export const FloatingActionButton: StoryFn = () => (
+  <FloatingActionButtonDemo />
+);
+FloatingActionButton.storyName = "Floating Action Button (Intercom)";
+
+export const CommandBar: StoryFn = () => <CommandBarDemo />;
+CommandBar.storyName = "Command Bar (AI Bar)";
+
+export const FullWidthPanel: StoryFn = () => <FullWidthDemo />;
+FullWidthPanel.storyName = "Full-Width Bottom Panel";

--- a/frontend/src/embedding-sdk-bundle/components/public/MetabotChat/MetabotChat.stories.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/MetabotChat/MetabotChat.stories.tsx
@@ -164,8 +164,7 @@ const SaasPageBg = () => (
               key={row}
               style={{
                 padding: "12px 20px",
-                borderBottom:
-                  i < 3 ? `1px solid ${dk.borderSubtle}` : "none",
+                borderBottom: i < 3 ? `1px solid ${dk.borderSubtle}` : "none",
                 display: "flex",
                 justifyContent: "space-between",
                 fontSize: 13,
@@ -276,9 +275,7 @@ export default {
 export const StandalonePanel: StoryFn = () => <StandalonePanelDemo />;
 StandalonePanel.storyName = "Standalone Panel";
 
-export const FloatingActionButton: StoryFn = () => (
-  <FloatingActionButtonDemo />
-);
+export const FloatingActionButton: StoryFn = () => <FloatingActionButtonDemo />;
 FloatingActionButton.storyName = "Floating Action Button (Intercom)";
 
 export const CommandBar: StoryFn = () => <CommandBarDemo />;

--- a/frontend/src/embedding-sdk-bundle/components/public/MetabotChat/MetabotChat.stories.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/MetabotChat/MetabotChat.stories.tsx
@@ -6,7 +6,10 @@ import { useMemo } from "react";
 import "embedding-sdk-bundle";
 
 import { ComponentProvider } from "embedding-sdk-bundle/components/public/ComponentProvider";
-import { getStorybookSdkAuthConfigForUser } from "embedding-sdk-bundle/test/CommonSdkStoryWrapper";
+import {
+  CommonSdkStoryWrapper,
+  getStorybookSdkAuthConfigForUser,
+} from "embedding-sdk-bundle/test/CommonSdkStoryWrapper";
 import { defineMetabaseTheme } from "metabase/embedding-sdk/theme";
 
 import { MetabotChat } from "./MetabotChat";
@@ -261,6 +264,38 @@ const FullWidthDemo = () => (
 );
 
 // ============================================================================
+// Story 5: Inline Charts Layout
+//
+// Real MetabotChat — ask Metabot a question and it will render independent
+// inline SdkAdHocQuestion instances directly in the chat history.
+// Use a wider panel to give charts enough room to breathe.
+// ============================================================================
+
+const InlineChartsDemo = () => (
+  <div
+    style={{
+      ...fullPageStyle,
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      background: "#f5f5f5",
+    }}
+  >
+    <div
+      style={{
+        borderRadius: 16,
+        overflow: "hidden",
+        border: "1px solid #e0e0e0",
+        background: "#fff",
+        boxShadow: "0 8px 30px rgba(0,0,0,0.1)",
+      }}
+    >
+      <MetabotChat height={700} width={680} />
+    </div>
+  </div>
+);
+
+// ============================================================================
 // Storybook meta
 // ============================================================================
 
@@ -269,17 +304,24 @@ export default {
   parameters: {
     layout: "fullscreen",
   },
-  decorators: [DarkSdkWrapper],
 } satisfies Meta;
+
+export const InlineCharts: StoryFn = () => <InlineChartsDemo />;
+InlineCharts.storyName = "Inline Charts";
+InlineCharts.decorators = [CommonSdkStoryWrapper];
 
 export const StandalonePanel: StoryFn = () => <StandalonePanelDemo />;
 StandalonePanel.storyName = "Standalone Panel";
+StandalonePanel.decorators = [DarkSdkWrapper];
 
 export const FloatingActionButton: StoryFn = () => <FloatingActionButtonDemo />;
 FloatingActionButton.storyName = "Floating Action Button (Intercom)";
+FloatingActionButton.decorators = [DarkSdkWrapper];
 
 export const CommandBar: StoryFn = () => <CommandBarDemo />;
 CommandBar.storyName = "Command Bar (AI Bar)";
+CommandBar.decorators = [DarkSdkWrapper];
 
 export const FullWidthPanel: StoryFn = () => <FullWidthDemo />;
 FullWidthPanel.storyName = "Full-Width Bottom Panel";
+FullWidthPanel.decorators = [DarkSdkWrapper];

--- a/frontend/src/embedding-sdk-bundle/components/public/MetabotChat/MetabotChat.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/MetabotChat/MetabotChat.tsx
@@ -1,0 +1,55 @@
+import type { ReactNode } from "react";
+
+import type { FunctionSchema } from "embedding-sdk-bundle/types/schema";
+
+import type {
+  MetabotChatProps,
+  MetabotCommandBarProps,
+  MetabotFloatingActionButtonProps,
+} from "./types";
+
+type MetabotChatComponent = ((props: MetabotChatProps) => ReactNode) & {
+  schema?: FunctionSchema;
+};
+
+type MetabotFloatingActionButtonComponent = ((
+  props: MetabotFloatingActionButtonProps,
+) => ReactNode) & {
+  schema?: FunctionSchema;
+};
+
+type MetabotCommandBarComponent = ((
+  props: MetabotCommandBarProps,
+) => ReactNode) & {
+  schema?: FunctionSchema;
+};
+
+export const METABOT_CHAT_SDK_EE_PLUGIN: {
+  MetabotChat: MetabotChatComponent;
+  FloatingActionButton: MetabotFloatingActionButtonComponent;
+  CommandBar: MetabotCommandBarComponent;
+} = {
+  // Placeholder implementations – replaced by EE plugin at runtime
+  MetabotChat: ((_props: MetabotChatProps) => null) as MetabotChatComponent,
+  FloatingActionButton: ((_props: MetabotFloatingActionButtonProps) =>
+    null) as MetabotFloatingActionButtonComponent,
+  CommandBar: ((_props: MetabotCommandBarProps) =>
+    null) as MetabotCommandBarComponent,
+};
+
+const MetabotChatBase = (props: MetabotChatProps) => {
+  return <METABOT_CHAT_SDK_EE_PLUGIN.MetabotChat {...props} />;
+};
+
+const FloatingActionButton = (props: MetabotFloatingActionButtonProps) => {
+  return <METABOT_CHAT_SDK_EE_PLUGIN.FloatingActionButton {...props} />;
+};
+
+const CommandBar = (props: MetabotCommandBarProps) => {
+  return <METABOT_CHAT_SDK_EE_PLUGIN.CommandBar {...props} />;
+};
+
+export const MetabotChat = Object.assign(MetabotChatBase, {
+  FloatingActionButton,
+  CommandBar,
+});

--- a/frontend/src/embedding-sdk-bundle/components/public/MetabotChat/index.ts
+++ b/frontend/src/embedding-sdk-bundle/components/public/MetabotChat/index.ts
@@ -1,0 +1,6 @@
+export { MetabotChat } from "./MetabotChat";
+export type {
+  MetabotChatProps,
+  MetabotCommandBarProps,
+  MetabotFloatingActionButtonProps,
+} from "./types";

--- a/frontend/src/embedding-sdk-bundle/components/public/MetabotChat/types.ts
+++ b/frontend/src/embedding-sdk-bundle/components/public/MetabotChat/types.ts
@@ -1,0 +1,82 @@
+import type { CSSProperties, ReactNode } from "react";
+
+import type { CommonStylingProps } from "embedding-sdk-bundle/types/props";
+
+/**
+ * Props for the MetabotChat component.
+ *
+ * @interface
+ * @expand
+ * @category MetabotChat
+ */
+export interface MetabotChatProps extends CommonStylingProps {
+  /**
+   * A number or string specifying a CSS size value that specifies the height of the component.
+   */
+  height?: CSSProperties["height"];
+
+  /**
+   * A number or string specifying a CSS size value that specifies the width of the component.
+   */
+  width?: CSSProperties["width"];
+
+  /**
+   * Custom content to render inside the chat panel.
+   * When provided, overrides the default chat layout.
+   */
+  children?: ReactNode;
+}
+
+/**
+ * Props for the MetabotChat.FloatingActionButton trigger.
+ *
+ * @interface
+ * @expand
+ * @category MetabotChat
+ */
+export interface MetabotFloatingActionButtonProps extends CommonStylingProps {
+  /**
+   * A number or string specifying a CSS size value that specifies the height of the chat panel.
+   * @default 500
+   */
+  panelHeight?: CSSProperties["height"];
+
+  /**
+   * A number or string specifying a CSS size value that specifies the width of the chat panel.
+   * @default 400
+   */
+  panelWidth?: CSSProperties["width"];
+
+  /**
+   * Custom content to render inside the chat panel.
+   * When provided, overrides the default chat layout.
+   */
+  children?: ReactNode;
+}
+
+/**
+ * Props for the MetabotChat.CommandBar trigger.
+ *
+ * @interface
+ * @expand
+ * @category MetabotChat
+ */
+export interface MetabotCommandBarProps extends CommonStylingProps {
+  /**
+   * A number or string specifying a CSS size value that specifies the height of the expanded chat panel.
+   * @default 400
+   */
+  panelHeight?: CSSProperties["height"];
+
+  /**
+   * A number or string specifying a CSS size value that specifies the width of the command bar.
+   * @default 600
+   */
+  width?: CSSProperties["width"];
+
+  /**
+   * Custom content to render inside the chat panel.
+   * When provided, overrides the default chat layout.
+   */
+  children?: ReactNode;
+}

--- a/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot.stories.tsx
+++ b/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot.stories.tsx
@@ -1,0 +1,1262 @@
+import type { Meta, StoryFn } from "@storybook/react";
+import type { CSSProperties, ReactNode } from "react";
+import { useEffect, useRef, useState } from "react";
+
+import { CommonSdkStoryWrapper } from "embedding-sdk-bundle/test/CommonSdkStoryWrapper";
+
+import { useMetabot } from "./use-metabot";
+
+// ============================================================================
+// Shared dark SaaS palette
+// ============================================================================
+
+const dk = {
+  bg: "#0B0D11",
+  surface: "#13161C",
+  surfaceRaised: "#1A1D25",
+  surfaceHover: "#22262F",
+  border: "#2A2E38",
+  borderSubtle: "#1F222A",
+  text: "#E4E5E9",
+  textSecondary: "#8B8F9A",
+  textMuted: "#5C6170",
+  accent: "#6C5CE7",
+  accentLight: "#A29BFE",
+  accentDim: "#6C5CE730",
+  green: "#00D68F",
+  greenDim: "#00D68F25",
+  red: "#FF6B6B",
+  redDim: "#FF6B6B20",
+  yellow: "#FECA57",
+  gradient: "linear-gradient(135deg, #6C5CE7 0%, #A29BFE 50%, #74B9FF 100%)",
+  gradientSubtle:
+    "linear-gradient(135deg, #6C5CE740 0%, #A29BFE40 50%, #74B9FF40 100%)",
+};
+
+// ============================================================================
+// Shared keyframes
+// ============================================================================
+
+const SharedKeyframes = () => (
+  <style>{`
+    @keyframes metabotPulse {
+      0%, 100% { opacity: 0.4; transform: scale(1); }
+      50% { opacity: 1; transform: scale(1.15); }
+    }
+    @keyframes metabotFadeUp {
+      from { opacity: 0; transform: translateY(8px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+    @keyframes metabotShimmer {
+      0% { background-position: -200% center; }
+      100% { background-position: 200% center; }
+    }
+    @keyframes metabotGlow {
+      0%, 100% { opacity: 0.4; }
+      50% { opacity: 0.8; }
+    }
+  `}</style>
+);
+
+// ============================================================================
+// Shared icons
+// ============================================================================
+
+const BotIcon = ({ size = 18 }: { size?: number }) => (
+  <svg width={size} height={size} viewBox="0 0 20 20" fill="none">
+    <circle cx="7" cy="8.5" r="1.4" fill="currentColor" />
+    <circle cx="13" cy="8.5" r="1.4" fill="currentColor" />
+    <path
+      d="M7 13c0 0 1.5 1.8 3 1.8s3-1.8 3-1.8"
+      stroke="currentColor"
+      strokeWidth="1.3"
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
+const SendIcon = () => (
+  <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+    <path
+      d="M14.5 8L2 14V9.5L9 8L2 6.5V2L14.5 8Z"
+      fill="currentColor"
+    />
+  </svg>
+);
+
+const CloseIcon = () => (
+  <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+    <path
+      d="M11 3L3 11M3 3L11 11"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
+const SparkleIcon = ({ size = 14 }: { size?: number }) => (
+  <svg width={size} height={size} viewBox="0 0 16 16" fill="none">
+    <path
+      d="M8 1L9.5 6.5L15 8L9.5 9.5L8 15L6.5 9.5L1 8L6.5 6.5L8 1Z"
+      fill="currentColor"
+    />
+  </svg>
+);
+
+// ============================================================================
+// Shared: message list renderer
+// ============================================================================
+
+type MetabotMessage = {
+  id: string;
+  role: "user" | "agent";
+  type: string;
+  message?: string;
+  name?: string;
+  args?: string;
+  status?: string;
+  payload?: unknown;
+};
+
+const formatTime = () => {
+  const d = new Date();
+  return `${d.getHours() % 12 || 12}:${d.getMinutes().toString().padStart(2, "0")} ${d.getHours() >= 12 ? "PM" : "AM"}`;
+};
+
+const MessageList = ({
+  messages,
+  isProcessing,
+  scrollRef,
+}: {
+  messages: MetabotMessage[];
+  isProcessing: boolean;
+  scrollRef: React.RefObject<HTMLDivElement>;
+}) => (
+  <>
+    {messages.map((msg) => {
+      const isUser = msg.role === "user";
+
+      if (msg.type === "tool_call") {
+        return (
+          <div
+            key={msg.id}
+            style={{
+              padding: "3px 0",
+              animation: "metabotFadeUp 0.2s ease",
+            }}
+          >
+            <span
+              style={{
+                fontSize: 11,
+                fontFamily: "monospace",
+                color: dk.accentLight,
+                background: dk.accentDim,
+                padding: "2px 8px",
+                borderRadius: 4,
+              }}
+            >
+              {(msg as MetabotMessage & { status: string }).status ===
+              "started"
+                ? "Running"
+                : "Ran"}{" "}
+              {msg.name}
+            </span>
+          </div>
+        );
+      }
+
+      const content: ReactNode =
+        "message" in msg && msg.message ? (
+          msg.message
+        ) : "payload" in msg && msg.payload ? (
+          <pre
+            style={{
+              margin: 0,
+              whiteSpace: "pre-wrap",
+              fontSize: 12,
+              fontFamily: "monospace",
+              color: dk.textSecondary,
+            }}
+          >
+            {JSON.stringify(msg.payload, null, 2)}
+          </pre>
+        ) : null;
+
+      if (!content) {
+        return null;
+      }
+
+      return (
+        <div
+          key={msg.id}
+          style={{
+            display: "flex",
+            gap: 8,
+            padding: "6px 0",
+            animation: "metabotFadeUp 0.25s ease",
+          }}
+        >
+          {!isUser && (
+            <div
+              style={{
+                width: 24,
+                height: 24,
+                borderRadius: 6,
+                background: dk.gradient,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                color: "#fff",
+                flexShrink: 0,
+                marginTop: 1,
+              }}
+            >
+              <BotIcon size={13} />
+            </div>
+          )}
+          <div
+            style={{
+              flex: 1,
+              minWidth: 0,
+              ...(isUser ? { textAlign: "right" as const } : {}),
+            }}
+          >
+            <div
+              style={{
+                display: "inline-block",
+                maxWidth: "85%",
+                textAlign: "left",
+                padding: "7px 12px",
+                borderRadius: 12,
+                fontSize: 13,
+                lineHeight: 1.45,
+                ...(isUser
+                  ? {
+                      background: dk.accent,
+                      color: "#fff",
+                      borderBottomRightRadius: 4,
+                    }
+                  : {
+                      background: dk.surfaceRaised,
+                      color: dk.text,
+                      border: `1px solid ${dk.border}`,
+                      borderBottomLeftRadius: 4,
+                    }),
+              }}
+            >
+              {content}
+            </div>
+            <div
+              style={{
+                fontSize: 10,
+                color: dk.textMuted,
+                marginTop: 2,
+                ...(isUser
+                  ? { paddingRight: 2 }
+                  : { paddingLeft: 2 }),
+              }}
+            >
+              {formatTime()}
+            </div>
+          </div>
+        </div>
+      );
+    })}
+
+    {isProcessing && (
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 6,
+          padding: "6px 0",
+          animation: "metabotFadeUp 0.2s ease",
+        }}
+      >
+        <div
+          style={{
+            width: 24,
+            height: 24,
+            borderRadius: 6,
+            background: dk.gradient,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            color: "#fff",
+            flexShrink: 0,
+          }}
+        >
+          <BotIcon size={13} />
+        </div>
+        <div style={{ display: "flex", gap: 4, padding: "4px 0" }}>
+          {[0, 0.15, 0.3].map((delay) => (
+            <div
+              key={delay}
+              style={{
+                width: 6,
+                height: 6,
+                borderRadius: "50%",
+                background: dk.accentLight,
+                animation: `metabotPulse 1.4s ${delay}s infinite`,
+              }}
+            />
+          ))}
+        </div>
+      </div>
+    )}
+
+    <div ref={scrollRef} />
+  </>
+);
+
+// ============================================================================
+// Shared: composer bar
+// ============================================================================
+
+const Composer = ({
+  value,
+  onChange,
+  onSubmit,
+  canSend,
+  placeholder,
+  onCancel,
+  isProcessing,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  onSubmit: () => void;
+  canSend: boolean;
+  placeholder?: string;
+  onCancel?: () => void;
+  isProcessing: boolean;
+}) => (
+  <div
+    style={{
+      display: "flex",
+      alignItems: "center",
+      gap: 6,
+      padding: "8px 12px",
+      borderTop: `1px solid ${dk.border}`,
+      background: dk.surface,
+    }}
+  >
+    <input
+      style={{
+        flex: 1,
+        background: dk.surfaceRaised,
+        border: `1px solid ${dk.border}`,
+        borderRadius: 8,
+        padding: "8px 12px",
+        fontSize: 13,
+        color: dk.text,
+        outline: "none",
+        fontFamily: "inherit",
+      }}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      onKeyDown={(e) => e.key === "Enter" && onSubmit()}
+      placeholder={placeholder ?? "Ask something..."}
+    />
+    {isProcessing && onCancel && (
+      <button
+        onClick={onCancel}
+        style={{
+          background: dk.redDim,
+          border: `1px solid ${dk.red}40`,
+          borderRadius: 6,
+          padding: "6px 8px",
+          color: dk.red,
+          cursor: "pointer",
+          fontSize: 11,
+          fontWeight: 600,
+          fontFamily: "inherit",
+        }}
+      >
+        Stop
+      </button>
+    )}
+    <button
+      onClick={onSubmit}
+      disabled={!canSend}
+      style={{
+        width: 32,
+        height: 32,
+        borderRadius: 8,
+        border: "none",
+        background: canSend ? dk.accent : dk.surfaceHover,
+        color: canSend ? "#fff" : dk.textMuted,
+        cursor: canSend ? "pointer" : "default",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        transition: "all 0.15s",
+      }}
+    >
+      <SendIcon />
+    </button>
+  </div>
+);
+
+// ============================================================================
+// Shared: custom instructions drawer (collapsible)
+// ============================================================================
+
+const InstructionsDrawer = ({
+  customInstructions,
+  setCustomInstructions,
+}: {
+  customInstructions: string | undefined;
+  setCustomInstructions: (v: string | undefined) => void;
+}) => {
+  const [open, setOpen] = useState(false);
+  const [draft, setDraft] = useState(customInstructions ?? "");
+
+  return (
+    <div
+      style={{
+        borderTop: `1px solid ${dk.border}`,
+        background: dk.surface,
+      }}
+    >
+      <button
+        onClick={() => setOpen(!open)}
+        style={{
+          width: "100%",
+          display: "flex",
+          alignItems: "center",
+          gap: 6,
+          padding: "6px 12px",
+          background: "none",
+          border: "none",
+          color: customInstructions ? dk.accentLight : dk.textMuted,
+          fontSize: 11,
+          fontWeight: 600,
+          cursor: "pointer",
+          fontFamily: "inherit",
+        }}
+      >
+        <SparkleIcon size={10} />
+        {customInstructions ? "Custom instructions active" : "Add instructions"}
+        <span style={{ marginLeft: "auto", fontSize: 10 }}>
+          {open ? "Hide" : "Edit"}
+        </span>
+      </button>
+      {open && (
+        <div
+          style={{
+            padding: "0 12px 8px",
+            display: "flex",
+            flexDirection: "column",
+            gap: 6,
+          }}
+        >
+          <textarea
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            placeholder="e.g. Always respond in bullet points."
+            rows={2}
+            style={{
+              background: dk.surfaceRaised,
+              border: `1px solid ${dk.border}`,
+              borderRadius: 6,
+              padding: "6px 10px",
+              fontSize: 12,
+              color: dk.text,
+              outline: "none",
+              resize: "vertical",
+              fontFamily: "inherit",
+              lineHeight: 1.4,
+            }}
+          />
+          <div style={{ display: "flex", gap: 6, justifyContent: "flex-end" }}>
+            {customInstructions && (
+              <button
+                onClick={() => {
+                  setCustomInstructions(undefined);
+                  setDraft("");
+                }}
+                style={{
+                  background: "none",
+                  border: "none",
+                  color: dk.textMuted,
+                  fontSize: 11,
+                  cursor: "pointer",
+                  fontFamily: "inherit",
+                }}
+              >
+                Clear
+              </button>
+            )}
+            <button
+              onClick={() => {
+                setCustomInstructions(draft.trim() || undefined);
+                setOpen(false);
+              }}
+              style={{
+                background: dk.accent,
+                border: "none",
+                borderRadius: 4,
+                padding: "3px 12px",
+                color: "#fff",
+                fontSize: 11,
+                fontWeight: 600,
+                cursor: "pointer",
+                fontFamily: "inherit",
+              }}
+            >
+              Apply
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+// ============================================================================
+// Fake SaaS page background
+// ============================================================================
+
+const SaasPageBg = () => (
+  <div
+    style={{
+      position: "absolute",
+      inset: 0,
+      background: dk.bg,
+      overflow: "hidden",
+      zIndex: 0,
+    }}
+  >
+    {/* Fake nav */}
+    <div
+      style={{
+        height: 48,
+        borderBottom: `1px solid ${dk.border}`,
+        display: "flex",
+        alignItems: "center",
+        padding: "0 24px",
+        gap: 24,
+      }}
+    >
+      <span style={{ fontWeight: 800, fontSize: 15, color: dk.text }}>
+        <span style={{ color: dk.accent }}>Acme</span> Analytics
+      </span>
+      {["Dashboard", "Reports", "Data", "Settings"].map((t) => (
+        <span
+          key={t}
+          style={{ fontSize: 13, color: dk.textSecondary, cursor: "pointer" }}
+        >
+          {t}
+        </span>
+      ))}
+    </div>
+    {/* Fake cards */}
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "1fr 1fr 1fr",
+        gap: 16,
+        padding: "24px",
+        maxWidth: 900,
+      }}
+    >
+      {[
+        ["Revenue", "$1.24M", "+12.3%"],
+        ["Users", "48.2K", "+8.7%"],
+        ["Churn", "2.1%", "-0.4%"],
+      ].map(([label, val, delta]) => (
+        <div
+          key={label}
+          style={{
+            background: dk.surface,
+            border: `1px solid ${dk.border}`,
+            borderRadius: 12,
+            padding: 20,
+          }}
+        >
+          <div style={{ fontSize: 12, color: dk.textMuted }}>{label}</div>
+          <div style={{ fontSize: 28, fontWeight: 800, color: dk.text }}>
+            {val}
+          </div>
+          <div
+            style={{
+              fontSize: 12,
+              color: delta?.startsWith("-") ? dk.red : dk.green,
+              marginTop: 4,
+            }}
+          >
+            {delta}
+          </div>
+        </div>
+      ))}
+    </div>
+    {/* Fake table */}
+    <div style={{ padding: "0 24px" }}>
+      <div
+        style={{
+          background: dk.surface,
+          border: `1px solid ${dk.border}`,
+          borderRadius: 12,
+          overflow: "hidden",
+        }}
+      >
+        {["Top Customers", "Recent Orders", "Pipeline", "Activity"].map(
+          (row, i) => (
+            <div
+              key={row}
+              style={{
+                padding: "12px 20px",
+                borderBottom:
+                  i < 3 ? `1px solid ${dk.borderSubtle}` : "none",
+                display: "flex",
+                justifyContent: "space-between",
+                fontSize: 13,
+                color: dk.textSecondary,
+              }}
+            >
+              <span>{row}</span>
+              <span style={{ color: dk.textMuted }}>View &rarr;</span>
+            </div>
+          ),
+        )}
+      </div>
+    </div>
+  </div>
+);
+
+// ============================================================================
+// STORY 1: Intercom-style floating bubble
+// ============================================================================
+
+const IntercomDemo = () => {
+  const metabot = useMetabot();
+  const [open, setOpen] = useState(false);
+  const [inputValue, setInputValue] = useState("");
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    scrollRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [metabot.messages, metabot.isProcessing]);
+
+  const handleSubmit = () => {
+    if (inputValue.trim() && !metabot.isProcessing) {
+      metabot.submitMessage(inputValue.trim());
+      setInputValue("");
+    }
+  };
+
+  const canSend = inputValue.trim().length > 0 && !metabot.isProcessing;
+
+  return (
+    <div
+      style={{
+        position: "relative",
+        width: "100%",
+        height: "100vh",
+        overflow: "hidden",
+        fontFamily:
+          '"Inter", -apple-system, BlinkMacSystemFont, sans-serif',
+      }}
+    >
+      <SharedKeyframes />
+      <SaasPageBg />
+
+      {/* FAB */}
+      {!open && (
+        <button
+          onClick={() => setOpen(true)}
+          style={{
+            position: "fixed",
+            bottom: 24,
+            right: 24,
+            width: 56,
+            height: 56,
+            borderRadius: 16,
+            border: "none",
+            background: dk.gradient,
+            color: "#fff",
+            cursor: "pointer",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            boxShadow: `0 4px 24px ${dk.accent}50, 0 0 0 1px ${dk.accent}30`,
+            zIndex: 1000,
+            transition: "transform 0.2s, box-shadow 0.2s",
+          }}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.transform = "scale(1.08)";
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.transform = "scale(1)";
+          }}
+        >
+          <BotIcon size={26} />
+        </button>
+      )}
+
+      {/* Panel */}
+      {open && (
+        <div
+          style={{
+            position: "fixed",
+            bottom: 24,
+            right: 24,
+            width: 380,
+            height: 560,
+            borderRadius: 16,
+            background: dk.surface,
+            border: `1px solid ${dk.border}`,
+            boxShadow: `0 24px 80px rgba(0,0,0,0.5), 0 0 0 1px ${dk.border}`,
+            display: "flex",
+            flexDirection: "column",
+            overflow: "hidden",
+            zIndex: 1000,
+            animation: "metabotFadeUp 0.25s ease",
+          }}
+        >
+          {/* Header */}
+          <div
+            style={{
+              padding: "14px 16px",
+              background: dk.surfaceRaised,
+              borderBottom: `1px solid ${dk.border}`,
+              display: "flex",
+              alignItems: "center",
+              gap: 10,
+              flexShrink: 0,
+            }}
+          >
+            <div
+              style={{
+                width: 32,
+                height: 32,
+                borderRadius: 8,
+                background: dk.gradient,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                color: "#fff",
+              }}
+            >
+              <BotIcon size={16} />
+            </div>
+            <div style={{ flex: 1 }}>
+              <div
+                style={{
+                  fontSize: 14,
+                  fontWeight: 700,
+                  color: dk.text,
+                }}
+              >
+                Metabot
+              </div>
+              <div
+                style={{
+                  fontSize: 11,
+                  color: metabot.isProcessing ? dk.green : dk.textMuted,
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 4,
+                }}
+              >
+                <div
+                  style={{
+                    width: 6,
+                    height: 6,
+                    borderRadius: "50%",
+                    background: metabot.isProcessing
+                      ? dk.green
+                      : dk.textMuted,
+                  }}
+                />
+                {metabot.isProcessing ? "Thinking..." : "Online"}
+              </div>
+            </div>
+            <button
+              onClick={() => metabot.resetConversation()}
+              style={{
+                background: "none",
+                border: "none",
+                color: dk.textMuted,
+                fontSize: 11,
+                cursor: "pointer",
+                fontFamily: "inherit",
+              }}
+            >
+              Clear
+            </button>
+            <button
+              onClick={() => setOpen(false)}
+              style={{
+                background: "none",
+                border: "none",
+                color: dk.textSecondary,
+                cursor: "pointer",
+                padding: 4,
+                display: "flex",
+              }}
+            >
+              <CloseIcon />
+            </button>
+          </div>
+
+          {/* Errors */}
+          {metabot.errorMessages.map((err, i) => (
+            <div
+              key={i}
+              style={{
+                padding: "6px 16px",
+                fontSize: 12,
+                color: dk.red,
+                background: dk.redDim,
+                borderBottom: `1px solid ${dk.red}20`,
+              }}
+            >
+              {err.message}
+            </div>
+          ))}
+
+          {/* Messages */}
+          <div
+            style={{
+              flex: 1,
+              overflowY: "auto",
+              padding: "12px 14px",
+            }}
+          >
+            {metabot.messages.length === 0 && !metabot.isProcessing && (
+              <div
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  height: "100%",
+                  gap: 10,
+                  color: dk.textMuted,
+                  textAlign: "center",
+                }}
+              >
+                <div
+                  style={{
+                    width: 48,
+                    height: 48,
+                    borderRadius: 12,
+                    background: dk.gradient,
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    color: "#fff",
+                  }}
+                >
+                  <BotIcon size={24} />
+                </div>
+                <div
+                  style={{
+                    fontSize: 15,
+                    fontWeight: 700,
+                    color: dk.text,
+                  }}
+                >
+                  Ask Metabot anything
+                </div>
+                <div style={{ fontSize: 12, maxWidth: 240 }}>
+                  Get insights from your data, explore dashboards, or ask
+                  questions in plain English.
+                </div>
+              </div>
+            )}
+            <MessageList
+              messages={metabot.messages as MetabotMessage[]}
+              isProcessing={metabot.isProcessing}
+              scrollRef={scrollRef}
+            />
+          </div>
+
+          {/* Instructions */}
+          <InstructionsDrawer
+            customInstructions={metabot.customInstructions}
+            setCustomInstructions={metabot.setCustomInstructions}
+          />
+
+          {/* Composer */}
+          <Composer
+            value={inputValue}
+            onChange={setInputValue}
+            onSubmit={handleSubmit}
+            canSend={canSend}
+            placeholder="Ask a question..."
+            onCancel={metabot.cancelRequest}
+            isProcessing={metabot.isProcessing}
+          />
+        </div>
+      )}
+    </div>
+  );
+};
+
+// ============================================================================
+// STORY 2: Floating AI bar that expands into a chat panel
+// ============================================================================
+
+const AiBarDemo = () => {
+  const metabot = useMetabot();
+  const [expanded, setExpanded] = useState(false);
+  const [inputValue, setInputValue] = useState("");
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    scrollRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [metabot.messages, metabot.isProcessing]);
+
+  const handleSubmit = () => {
+    if (inputValue.trim() && !metabot.isProcessing) {
+      metabot.submitMessage(inputValue.trim());
+      setInputValue("");
+      if (!expanded) {
+        setExpanded(true);
+      }
+    }
+  };
+
+  const canSend = inputValue.trim().length > 0 && !metabot.isProcessing;
+
+  // Collapsed: floating bar
+  // Expanded: full chat panel
+
+  return (
+    <div
+      style={{
+        position: "relative",
+        width: "100%",
+        height: "100vh",
+        overflow: "hidden",
+        fontFamily:
+          '"Inter", -apple-system, BlinkMacSystemFont, sans-serif',
+      }}
+    >
+      <SharedKeyframes />
+      <SaasPageBg />
+
+      {/* Floating container */}
+      <div
+        style={{
+          position: "fixed",
+          bottom: 24,
+          left: "50%",
+          transform: "translateX(-50%)",
+          zIndex: 1000,
+          transition: "all 0.35s cubic-bezier(0.4, 0, 0.2, 1)",
+          ...(expanded
+            ? {
+                width: 520,
+                height: 500,
+              }
+            : {
+                width: 480,
+                height: "auto",
+              }),
+        }}
+      >
+        {/* Glow effect behind the bar (collapsed only) */}
+        {!expanded && (
+          <div
+            style={{
+              position: "absolute",
+              inset: -2,
+              borderRadius: 18,
+              background: dk.gradient,
+              opacity: 0.35,
+              filter: "blur(8px)",
+              animation: "metabotGlow 3s ease infinite",
+              pointerEvents: "none",
+            }}
+          />
+        )}
+
+        <div
+          style={{
+            position: "relative",
+            borderRadius: expanded ? 16 : 16,
+            background: dk.surface,
+            border: `1px solid ${dk.border}`,
+            boxShadow: expanded
+              ? `0 24px 80px rgba(0,0,0,0.5)`
+              : `0 8px 40px rgba(0,0,0,0.4)`,
+            overflow: "hidden",
+            display: "flex",
+            flexDirection: "column",
+            height: expanded ? 500 : "auto",
+            transition: "height 0.35s cubic-bezier(0.4, 0, 0.2, 1)",
+          }}
+        >
+          {/* Gradient border shimmer (collapsed) */}
+          {!expanded && (
+            <div
+              style={{
+                position: "absolute",
+                inset: 0,
+                borderRadius: 16,
+                border: "1px solid transparent",
+                background: `linear-gradient(${dk.surface}, ${dk.surface}) padding-box, ${dk.gradient} border-box`,
+                pointerEvents: "none",
+                zIndex: 1,
+              }}
+            />
+          )}
+
+          {expanded ? (
+            <>
+              {/* ---- Expanded: Header ---- */}
+              <div
+                style={{
+                  padding: "10px 14px",
+                  borderBottom: `1px solid ${dk.border}`,
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 8,
+                  flexShrink: 0,
+                  background: dk.surfaceRaised,
+                }}
+              >
+                <div
+                  style={{
+                    width: 28,
+                    height: 28,
+                    borderRadius: 7,
+                    background: dk.gradient,
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    color: "#fff",
+                  }}
+                >
+                  <BotIcon size={14} />
+                </div>
+                <div style={{ flex: 1 }}>
+                  <div
+                    style={{
+                      fontSize: 13,
+                      fontWeight: 700,
+                      color: dk.text,
+                    }}
+                  >
+                    Metabot
+                  </div>
+                </div>
+                <button
+                  onClick={() => metabot.resetConversation()}
+                  style={{
+                    background: "none",
+                    border: "none",
+                    color: dk.textMuted,
+                    fontSize: 11,
+                    cursor: "pointer",
+                    fontFamily: "inherit",
+                  }}
+                >
+                  Clear
+                </button>
+                <button
+                  onClick={() => setExpanded(false)}
+                  style={{
+                    background: "none",
+                    border: "none",
+                    color: dk.textSecondary,
+                    cursor: "pointer",
+                    padding: 4,
+                    display: "flex",
+                  }}
+                >
+                  <CloseIcon />
+                </button>
+              </div>
+
+              {/* Errors */}
+              {metabot.errorMessages.map((err, i) => (
+                <div
+                  key={i}
+                  style={{
+                    padding: "6px 14px",
+                    fontSize: 12,
+                    color: dk.red,
+                    background: dk.redDim,
+                    borderBottom: `1px solid ${dk.red}20`,
+                  }}
+                >
+                  {err.message}
+                </div>
+              ))}
+
+              {/* Messages */}
+              <div
+                style={{
+                  flex: 1,
+                  overflowY: "auto",
+                  padding: "10px 14px",
+                }}
+              >
+                {metabot.messages.length === 0 && !metabot.isProcessing && (
+                  <div
+                    style={{
+                      display: "flex",
+                      flexDirection: "column",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      height: "100%",
+                      gap: 8,
+                      color: dk.textMuted,
+                      textAlign: "center",
+                      fontSize: 13,
+                    }}
+                  >
+                    <SparkleIcon size={20} />
+                    Ask about your data, metrics, or dashboards.
+                  </div>
+                )}
+                <MessageList
+                  messages={metabot.messages as MetabotMessage[]}
+                  isProcessing={metabot.isProcessing}
+                  scrollRef={scrollRef}
+                />
+              </div>
+
+              {/* Instructions */}
+              <InstructionsDrawer
+                customInstructions={metabot.customInstructions}
+                setCustomInstructions={metabot.setCustomInstructions}
+              />
+
+              {/* Composer */}
+              <Composer
+                value={inputValue}
+                onChange={setInputValue}
+                onSubmit={handleSubmit}
+                canSend={canSend}
+                placeholder="Follow up..."
+                onCancel={metabot.cancelRequest}
+                isProcessing={metabot.isProcessing}
+              />
+            </>
+          ) : (
+            /* ---- Collapsed: AI bar ---- */
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 10,
+                padding: "6px 6px 6px 14px",
+                position: "relative",
+                zIndex: 2,
+                cursor: "text",
+              }}
+              onClick={() => {
+                const input = document.getElementById("aibar-input");
+                input?.focus();
+              }}
+            >
+              <div
+                style={{
+                  color: dk.accentLight,
+                  display: "flex",
+                  alignItems: "center",
+                  flexShrink: 0,
+                }}
+              >
+                <SparkleIcon size={16} />
+              </div>
+              <input
+                id="aibar-input"
+                style={{
+                  flex: 1,
+                  background: "none",
+                  border: "none",
+                  outline: "none",
+                  fontSize: 14,
+                  color: dk.text,
+                  fontFamily: "inherit",
+                  padding: "8px 0",
+                }}
+                value={inputValue}
+                onChange={(e) => setInputValue(e.target.value)}
+                onKeyDown={(e) => e.key === "Enter" && handleSubmit()}
+                onFocus={() => {
+                  // if there are messages, expand to show them
+                  if (metabot.messages.length > 0) {
+                    setExpanded(true);
+                  }
+                }}
+                placeholder="Ask Metabot about your data..."
+              />
+              {metabot.messages.length > 0 && (
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setExpanded(true);
+                  }}
+                  style={{
+                    background: dk.surfaceHover,
+                    border: `1px solid ${dk.border}`,
+                    borderRadius: 6,
+                    padding: "4px 10px",
+                    fontSize: 11,
+                    color: dk.textSecondary,
+                    cursor: "pointer",
+                    fontFamily: "inherit",
+                    fontWeight: 600,
+                    whiteSpace: "nowrap",
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 4,
+                  }}
+                >
+                  {metabot.messages.length} msg
+                  {metabot.messages.length !== 1 ? "s" : ""}
+                </button>
+              )}
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleSubmit();
+                }}
+                disabled={!canSend}
+                style={{
+                  width: 34,
+                  height: 34,
+                  borderRadius: 10,
+                  border: "none",
+                  background: canSend ? dk.accent : dk.surfaceHover,
+                  color: canSend ? "#fff" : dk.textMuted,
+                  cursor: canSend ? "pointer" : "default",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  flexShrink: 0,
+                  transition: "all 0.15s",
+                }}
+              >
+                <SendIcon />
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ============================================================================
+// Storybook exports
+// ============================================================================
+
+export default {
+  title: "EmbeddingSDK/useMetabot",
+  parameters: {
+    layout: "fullscreen",
+  },
+  decorators: [CommonSdkStoryWrapper],
+} satisfies Meta;
+
+export const Intercom: StoryFn = () => <IntercomDemo />;
+export const FloatingAIBar: StoryFn = () => <AiBarDemo />;

--- a/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot.stories.tsx
+++ b/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryFn } from "@storybook/react";
-import type { CSSProperties, ReactNode } from "react";
+import type { ReactNode } from "react";
 import { useEffect, useRef, useState } from "react";
 
 import { CommonSdkStoryWrapper } from "embedding-sdk-bundle/test/CommonSdkStoryWrapper";
@@ -77,10 +77,7 @@ const BotIcon = ({ size = 18 }: { size?: number }) => (
 
 const SendIcon = () => (
   <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-    <path
-      d="M14.5 8L2 14V9.5L9 8L2 6.5V2L14.5 8Z"
-      fill="currentColor"
-    />
+    <path d="M14.5 8L2 14V9.5L9 8L2 6.5V2L14.5 8Z" fill="currentColor" />
   </svg>
 );
 
@@ -156,8 +153,7 @@ const MessageList = ({
                 borderRadius: 4,
               }}
             >
-              {(msg as MetabotMessage & { status: string }).status ===
-              "started"
+              {(msg as MetabotMessage & { status: string }).status === "started"
                 ? "Running"
                 : "Ran"}{" "}
               {msg.name}
@@ -252,9 +248,7 @@ const MessageList = ({
                 fontSize: 10,
                 color: dk.textMuted,
                 marginTop: 2,
-                ...(isUser
-                  ? { paddingRight: 2 }
-                  : { paddingLeft: 2 }),
+                ...(isUser ? { paddingRight: 2 } : { paddingLeft: 2 }),
               }}
             >
               {formatTime()}
@@ -607,8 +601,7 @@ const SaasPageBg = () => (
               key={row}
               style={{
                 padding: "12px 20px",
-                borderBottom:
-                  i < 3 ? `1px solid ${dk.borderSubtle}` : "none",
+                borderBottom: i < 3 ? `1px solid ${dk.borderSubtle}` : "none",
                 display: "flex",
                 justifyContent: "space-between",
                 fontSize: 13,
@@ -655,8 +648,7 @@ const IntercomDemo = () => {
         width: "100%",
         height: "100vh",
         overflow: "hidden",
-        fontFamily:
-          '"Inter", -apple-system, BlinkMacSystemFont, sans-serif',
+        fontFamily: '"Inter", -apple-system, BlinkMacSystemFont, sans-serif',
       }}
     >
       <SharedKeyframes />
@@ -765,9 +757,7 @@ const IntercomDemo = () => {
                     width: 6,
                     height: 6,
                     borderRadius: "50%",
-                    background: metabot.isProcessing
-                      ? dk.green
-                      : dk.textMuted,
+                    background: metabot.isProcessing ? dk.green : dk.textMuted,
                   }}
                 />
                 {metabot.isProcessing ? "Thinking..." : "Online"}
@@ -932,8 +922,7 @@ const AiBarDemo = () => {
         width: "100%",
         height: "100vh",
         overflow: "hidden",
-        fontFamily:
-          '"Inter", -apple-system, BlinkMacSystemFont, sans-serif',
+        fontFamily: '"Inter", -apple-system, BlinkMacSystemFont, sans-serif',
       }}
     >
       <SharedKeyframes />
@@ -1260,3 +1249,1179 @@ export default {
 
 export const Intercom: StoryFn = () => <IntercomDemo />;
 export const FloatingAIBar: StoryFn = () => <AiBarDemo />;
+
+// ============================================================================
+// Slack palette
+// ============================================================================
+
+const sl = {
+  bg: "#1A1D21",
+  sidebar: "#19171D",
+  sidebarHover: "#27242C",
+  sidebarActive: "#1164A3",
+  sidebarText: "#CFD0D2",
+  sidebarTextMuted: "#9B9C9E",
+  channel: "#FFFFFF",
+  surface: "#222529",
+  surfaceRaised: "#2C2D30",
+  border: "#393A3D",
+  text: "#D1D2D3",
+  textSecondary: "#ABABAD",
+  textMuted: "#757577",
+  accent: "#1264A3",
+  accentHover: "#0D5A94",
+  green: "#007A5A",
+  greenLight: "#2BAC76",
+  link: "#1D9BD1",
+  yellow: "#ECB22E",
+  red: "#E01E5A",
+};
+
+// ============================================================================
+// STORY 3: Slack-style layout — sidebar + channel thread
+// ============================================================================
+
+const SlackDemo = () => {
+  const metabot = useMetabot();
+  const [inputValue, setInputValue] = useState("");
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [activeChannel, setActiveChannel] = useState("metabot");
+
+  useEffect(() => {
+    scrollRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [metabot.messages, metabot.isProcessing]);
+
+  const handleSubmit = () => {
+    if (inputValue.trim() && !metabot.isProcessing) {
+      metabot.submitMessage(inputValue.trim());
+      setInputValue("");
+    }
+  };
+
+  const canSend = inputValue.trim().length > 0 && !metabot.isProcessing;
+
+  const channels = [
+    { name: "general", unread: false },
+    { name: "data-requests", unread: true },
+    { name: "metabot", unread: false, isBot: true },
+    { name: "eng-analytics", unread: false },
+    { name: "revenue-alerts", unread: true },
+  ];
+
+  const dms = [
+    { name: "Sarah Chen", status: "active" },
+    { name: "Alex Rivera", status: "away" },
+    { name: "Metabot", status: "active", isBot: true },
+  ];
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        width: "100%",
+        height: "100vh",
+        fontFamily:
+          '"Lato", "Noto Sans", -apple-system, BlinkMacSystemFont, sans-serif',
+        background: sl.bg,
+        color: sl.text,
+      }}
+    >
+      <SharedKeyframes />
+
+      {/* ---- Sidebar ---- */}
+      <div
+        style={{
+          width: 260,
+          background: sl.sidebar,
+          display: "flex",
+          flexDirection: "column",
+          flexShrink: 0,
+          borderRight: `1px solid ${sl.border}`,
+        }}
+      >
+        {/* Workspace header */}
+        <div
+          style={{
+            padding: "12px 16px",
+            borderBottom: `1px solid ${sl.border}`,
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+          }}
+        >
+          <div
+            style={{
+              width: 28,
+              height: 28,
+              borderRadius: 6,
+              background: sl.green,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              color: "#fff",
+              fontWeight: 900,
+              fontSize: 14,
+            }}
+          >
+            A
+          </div>
+          <div>
+            <div style={{ fontSize: 15, fontWeight: 900, color: "#fff" }}>
+              Acme Corp
+            </div>
+          </div>
+        </div>
+
+        {/* Channels */}
+        <div style={{ padding: "12px 0", flex: 1, overflowY: "auto" }}>
+          <div
+            style={{
+              padding: "0 16px 6px",
+              fontSize: 13,
+              fontWeight: 700,
+              color: sl.sidebarTextMuted,
+            }}
+          >
+            Channels
+          </div>
+          {channels.map((ch) => (
+            <div
+              key={ch.name}
+              onClick={() => setActiveChannel(ch.name)}
+              style={{
+                padding: "4px 16px 4px 22px",
+                fontSize: 14,
+                cursor: "pointer",
+                display: "flex",
+                alignItems: "center",
+                gap: 6,
+                background:
+                  activeChannel === ch.name
+                    ? sl.sidebarActive
+                    : "transparent",
+                color:
+                  activeChannel === ch.name
+                    ? "#fff"
+                    : ch.unread
+                      ? "#fff"
+                      : sl.sidebarText,
+                fontWeight: ch.unread || activeChannel === ch.name ? 700 : 400,
+                borderRadius: 6,
+                margin: "0 8px",
+              }}
+            >
+              <span style={{ color: sl.sidebarTextMuted, fontSize: 14 }}>
+                {ch.isBot ? (
+                  <BotIcon size={14} />
+                ) : (
+                  "#"
+                )}
+              </span>
+              {ch.name}
+              {ch.unread && activeChannel !== ch.name && (
+                <div
+                  style={{
+                    marginLeft: "auto",
+                    width: 8,
+                    height: 8,
+                    borderRadius: "50%",
+                    background: sl.red,
+                  }}
+                />
+              )}
+            </div>
+          ))}
+
+          <div
+            style={{
+              padding: "12px 16px 6px",
+              fontSize: 13,
+              fontWeight: 700,
+              color: sl.sidebarTextMuted,
+            }}
+          >
+            Direct Messages
+          </div>
+          {dms.map((dm) => (
+            <div
+              key={dm.name}
+              style={{
+                padding: "4px 16px 4px 22px",
+                fontSize: 14,
+                cursor: "pointer",
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+                color: sl.sidebarText,
+                borderRadius: 6,
+                margin: "0 8px",
+              }}
+            >
+              <div
+                style={{
+                  width: 8,
+                  height: 8,
+                  borderRadius: "50%",
+                  background:
+                    dm.status === "active" ? sl.greenLight : sl.textMuted,
+                  flexShrink: 0,
+                }}
+              />
+              {dm.name}
+              {dm.isBot && (
+                <span
+                  style={{
+                    fontSize: 10,
+                    background: sl.surfaceRaised,
+                    color: sl.textMuted,
+                    padding: "1px 5px",
+                    borderRadius: 3,
+                    fontWeight: 700,
+                  }}
+                >
+                  BOT
+                </span>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* ---- Main channel area ---- */}
+      <div style={{ flex: 1, display: "flex", flexDirection: "column" }}>
+        {/* Channel header */}
+        <div
+          style={{
+            padding: "10px 20px",
+            borderBottom: `1px solid ${sl.border}`,
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            flexShrink: 0,
+          }}
+        >
+          <BotIcon size={18} />
+          <span style={{ fontSize: 16, fontWeight: 900, color: "#fff" }}>
+            metabot
+          </span>
+          <span
+            style={{
+              fontSize: 10,
+              background: sl.green,
+              color: "#fff",
+              padding: "2px 6px",
+              borderRadius: 3,
+              fontWeight: 700,
+            }}
+          >
+            AI
+          </span>
+          <div
+            style={{
+              marginLeft: "auto",
+              display: "flex",
+              gap: 12,
+              color: sl.textMuted,
+              fontSize: 13,
+            }}
+          >
+            <span
+              onClick={() => metabot.resetConversation()}
+              style={{ cursor: "pointer" }}
+            >
+              Clear
+            </span>
+          </div>
+        </div>
+
+        {/* Messages */}
+        <div style={{ flex: 1, overflowY: "auto", padding: "16px 20px" }}>
+          {metabot.messages.length === 0 && !metabot.isProcessing && (
+            <div style={{ textAlign: "center", padding: "60px 0" }}>
+              <div
+                style={{
+                  width: 64,
+                  height: 64,
+                  borderRadius: 12,
+                  background: sl.green,
+                  display: "inline-flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  color: "#fff",
+                  marginBottom: 16,
+                }}
+              >
+                <BotIcon size={32} />
+              </div>
+              <div
+                style={{
+                  fontSize: 20,
+                  fontWeight: 900,
+                  color: "#fff",
+                  marginBottom: 4,
+                }}
+              >
+                This is the beginning of your conversation with Metabot
+              </div>
+              <div style={{ color: sl.textMuted, fontSize: 14 }}>
+                Ask questions about your data in plain English.
+              </div>
+            </div>
+          )}
+
+          {(metabot.messages as MetabotMessage[]).map((msg) => {
+            const isUser = msg.role === "user";
+
+            if (msg.type === "tool_call") {
+              return (
+                <div
+                  key={msg.id}
+                  style={{
+                    padding: "2px 0 2px 52px",
+                    fontSize: 12,
+                    color: sl.textMuted,
+                    fontStyle: "italic",
+                  }}
+                >
+                  {msg.status === "started" ? "Running" : "Ran"} {msg.name}
+                </div>
+              );
+            }
+
+            const content =
+              "message" in msg && msg.message
+                ? msg.message
+                : "payload" in msg && msg.payload
+                  ? JSON.stringify(msg.payload, null, 2)
+                  : null;
+
+            if (!content) {
+              return null;
+            }
+
+            return (
+              <div
+                key={msg.id}
+                style={{
+                  display: "flex",
+                  gap: 12,
+                  padding: "8px 0",
+                  animation: "metabotFadeUp 0.2s ease",
+                }}
+              >
+                <div
+                  style={{
+                    width: 36,
+                    height: 36,
+                    borderRadius: 6,
+                    background: isUser ? sl.accent : sl.green,
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    color: "#fff",
+                    flexShrink: 0,
+                    fontSize: 14,
+                    fontWeight: 900,
+                  }}
+                >
+                  {isUser ? "Y" : <BotIcon size={18} />}
+                </div>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div
+                    style={{
+                      display: "flex",
+                      alignItems: "baseline",
+                      gap: 8,
+                      marginBottom: 2,
+                    }}
+                  >
+                    <span
+                      style={{
+                        fontSize: 14,
+                        fontWeight: 900,
+                        color: "#fff",
+                      }}
+                    >
+                      {isUser ? "You" : "Metabot"}
+                    </span>
+                    <span
+                      style={{ fontSize: 11, color: sl.textMuted }}
+                    >
+                      {formatTime()}
+                    </span>
+                  </div>
+                  <div
+                    style={{
+                      fontSize: 14,
+                      lineHeight: 1.5,
+                      color: sl.text,
+                      whiteSpace: "pre-wrap",
+                    }}
+                  >
+                    {content}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+
+          {metabot.isProcessing && (
+            <div
+              style={{
+                display: "flex",
+                gap: 12,
+                padding: "8px 0",
+                animation: "metabotFadeUp 0.2s ease",
+              }}
+            >
+              <div
+                style={{
+                  width: 36,
+                  height: 36,
+                  borderRadius: 6,
+                  background: sl.green,
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  color: "#fff",
+                  flexShrink: 0,
+                }}
+              >
+                <BotIcon size={18} />
+              </div>
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 4,
+                  padding: "10px 0",
+                }}
+              >
+                {[0, 0.15, 0.3].map((delay) => (
+                  <div
+                    key={delay}
+                    style={{
+                      width: 7,
+                      height: 7,
+                      borderRadius: "50%",
+                      background: sl.textMuted,
+                      animation: `metabotPulse 1.4s ${delay}s infinite`,
+                    }}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+
+          <div ref={scrollRef} />
+        </div>
+
+        {/* Errors */}
+        {metabot.errorMessages.map((err, i) => (
+          <div
+            key={i}
+            style={{
+              padding: "6px 20px",
+              fontSize: 13,
+              color: sl.red,
+              background: `${sl.red}15`,
+              borderTop: `1px solid ${sl.border}`,
+            }}
+          >
+            {err.message}
+          </div>
+        ))}
+
+        {/* Composer */}
+        <div style={{ padding: "0 20px 20px" }}>
+          <div
+            style={{
+              border: `1px solid ${sl.border}`,
+              borderRadius: 8,
+              background: sl.surface,
+              overflow: "hidden",
+            }}
+          >
+            <div style={{ display: "flex", alignItems: "center" }}>
+              <input
+                style={{
+                  flex: 1,
+                  background: "none",
+                  border: "none",
+                  outline: "none",
+                  padding: "10px 14px",
+                  fontSize: 14,
+                  color: sl.text,
+                  fontFamily: "inherit",
+                }}
+                value={inputValue}
+                onChange={(e) => setInputValue(e.target.value)}
+                onKeyDown={(e) => e.key === "Enter" && handleSubmit()}
+                placeholder="Message #metabot"
+              />
+              {metabot.isProcessing && (
+                <button
+                  onClick={metabot.cancelRequest}
+                  style={{
+                    background: "none",
+                    border: "none",
+                    color: sl.red,
+                    cursor: "pointer",
+                    padding: "0 8px",
+                    fontSize: 12,
+                    fontWeight: 700,
+                    fontFamily: "inherit",
+                  }}
+                >
+                  Stop
+                </button>
+              )}
+            </div>
+            {/* Toolbar */}
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                padding: "4px 8px",
+                borderTop: `1px solid ${sl.border}`,
+                gap: 2,
+              }}
+            >
+              <div style={{ flex: 1 }} />
+              <button
+                onClick={handleSubmit}
+                disabled={!canSend}
+                style={{
+                  width: 28,
+                  height: 28,
+                  borderRadius: 4,
+                  border: "none",
+                  background: canSend ? sl.green : "transparent",
+                  color: canSend ? "#fff" : sl.textMuted,
+                  cursor: canSend ? "pointer" : "default",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  transition: "all 0.1s",
+                }}
+              >
+                <SendIcon />
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ============================================================================
+// Teams palette
+// ============================================================================
+
+const tm = {
+  bg: "#292929",
+  sidebar: "#1F1F1F",
+  sidebarHover: "#3D3D3D",
+  sidebarActive: "#4F4F4F",
+  surface: "#292929",
+  surfaceRaised: "#3D3D3D",
+  border: "#404040",
+  text: "#FFFFFF",
+  textSecondary: "#D6D6D6",
+  textMuted: "#ADADAD",
+  accent: "#6264A7",
+  accentLight: "#7B83EB",
+  purple: "#6264A7",
+  purpleLight: "#8B8CC7",
+  compose: "#323232",
+  composeBorder: "#5B5FC7",
+};
+
+// ============================================================================
+// STORY 4: Microsoft Teams-style layout
+// ============================================================================
+
+const TeamsDemo = () => {
+  const metabot = useMetabot();
+  const [inputValue, setInputValue] = useState("");
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [activeTab, setActiveTab] = useState("chat");
+
+  useEffect(() => {
+    scrollRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [metabot.messages, metabot.isProcessing]);
+
+  const handleSubmit = () => {
+    if (inputValue.trim() && !metabot.isProcessing) {
+      metabot.submitMessage(inputValue.trim());
+      setInputValue("");
+    }
+  };
+
+  const canSend = inputValue.trim().length > 0 && !metabot.isProcessing;
+
+  const navItems = [
+    { icon: "💬", label: "Chat", id: "chat" },
+    { icon: "👥", label: "Teams", id: "teams" },
+    { icon: "📅", label: "Calendar", id: "calendar" },
+    { icon: "📞", label: "Calls", id: "calls" },
+    { icon: "📁", label: "Files", id: "files" },
+  ];
+
+  const recentChats = [
+    { name: "Product Team", preview: "Let's review the sprint...", time: "2m", unread: true },
+    { name: "Metabot", preview: "Revenue is up 12.3%", time: "15m", isBot: true },
+    { name: "Design Review", preview: "Looks great!", time: "1h", unread: false },
+    { name: "Sarah Chen", preview: "Can you check the query?", time: "3h", unread: false },
+  ];
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        width: "100%",
+        height: "100vh",
+        fontFamily:
+          '"Segoe UI", -apple-system, BlinkMacSystemFont, sans-serif',
+        background: tm.bg,
+        color: tm.text,
+      }}
+    >
+      <SharedKeyframes />
+
+      {/* ---- Left rail (icon nav) ---- */}
+      <div
+        style={{
+          width: 68,
+          background: tm.sidebar,
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          paddingTop: 8,
+          gap: 4,
+          flexShrink: 0,
+          borderRight: `1px solid ${tm.border}`,
+        }}
+      >
+        {navItems.map((item) => (
+          <div
+            key={item.id}
+            onClick={() => setActiveTab(item.id)}
+            style={{
+              width: 48,
+              height: 48,
+              borderRadius: 8,
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              justifyContent: "center",
+              cursor: "pointer",
+              background:
+                activeTab === item.id ? tm.sidebarActive : "transparent",
+              position: "relative",
+            }}
+          >
+            {activeTab === item.id && (
+              <div
+                style={{
+                  position: "absolute",
+                  left: -10,
+                  top: "50%",
+                  transform: "translateY(-50%)",
+                  width: 3,
+                  height: 20,
+                  borderRadius: 2,
+                  background: tm.accentLight,
+                }}
+              />
+            )}
+            <span style={{ fontSize: 18 }}>{item.icon}</span>
+            <span
+              style={{
+                fontSize: 9,
+                color: tm.textMuted,
+                marginTop: 1,
+              }}
+            >
+              {item.label}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      {/* ---- Chat list panel ---- */}
+      <div
+        style={{
+          width: 300,
+          background: tm.sidebar,
+          display: "flex",
+          flexDirection: "column",
+          flexShrink: 0,
+          borderRight: `1px solid ${tm.border}`,
+        }}
+      >
+        <div
+          style={{
+            padding: "14px 16px 8px",
+            fontSize: 20,
+            fontWeight: 700,
+          }}
+        >
+          Chat
+        </div>
+
+        {/* Search */}
+        <div style={{ padding: "4px 12px 8px" }}>
+          <div
+            style={{
+              background: tm.surfaceRaised,
+              borderRadius: 4,
+              padding: "6px 10px",
+              fontSize: 13,
+              color: tm.textMuted,
+            }}
+          >
+            Search or type a command
+          </div>
+        </div>
+
+        {/* Recent */}
+        <div style={{ flex: 1, overflowY: "auto" }}>
+          <div
+            style={{
+              padding: "8px 16px 4px",
+              fontSize: 12,
+              fontWeight: 700,
+              color: tm.textMuted,
+              textTransform: "uppercase",
+              letterSpacing: 0.5,
+            }}
+          >
+            Recent
+          </div>
+          {recentChats.map((chat) => (
+            <div
+              key={chat.name}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 10,
+                padding: "8px 16px",
+                cursor: "pointer",
+                background:
+                  chat.isBot ? tm.sidebarActive : "transparent",
+                borderRadius: 4,
+                margin: "0 8px",
+              }}
+            >
+              <div
+                style={{
+                  width: 36,
+                  height: 36,
+                  borderRadius: "50%",
+                  background: chat.isBot ? tm.purple : tm.surfaceRaised,
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  color: "#fff",
+                  flexShrink: 0,
+                  fontSize: 14,
+                  fontWeight: 700,
+                }}
+              >
+                {chat.isBot ? (
+                  <BotIcon size={18} />
+                ) : (
+                  chat.name[0]
+                )}
+              </div>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div
+                  style={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "center",
+                  }}
+                >
+                  <span
+                    style={{
+                      fontSize: 13,
+                      fontWeight: chat.unread ? 700 : 400,
+                      color: tm.text,
+                    }}
+                  >
+                    {chat.name}
+                  </span>
+                  <span
+                    style={{ fontSize: 11, color: tm.textMuted }}
+                  >
+                    {chat.time}
+                  </span>
+                </div>
+                <div
+                  style={{
+                    fontSize: 12,
+                    color: tm.textMuted,
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {chat.preview}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* ---- Main conversation ---- */}
+      <div style={{ flex: 1, display: "flex", flexDirection: "column" }}>
+        {/* Header */}
+        <div
+          style={{
+            padding: "12px 20px",
+            borderBottom: `1px solid ${tm.border}`,
+            display: "flex",
+            alignItems: "center",
+            gap: 10,
+            flexShrink: 0,
+          }}
+        >
+          <div
+            style={{
+              width: 32,
+              height: 32,
+              borderRadius: "50%",
+              background: tm.purple,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              color: "#fff",
+            }}
+          >
+            <BotIcon size={16} />
+          </div>
+          <div>
+            <div style={{ fontSize: 14, fontWeight: 700 }}>Metabot</div>
+            <div style={{ fontSize: 11, color: tm.textMuted }}>
+              {metabot.isProcessing ? "Typing..." : "AI Assistant"}
+            </div>
+          </div>
+          <div
+            style={{
+              marginLeft: "auto",
+              display: "flex",
+              gap: 8,
+            }}
+          >
+            <button
+              onClick={() => metabot.resetConversation()}
+              style={{
+                background: tm.surfaceRaised,
+                border: `1px solid ${tm.border}`,
+                borderRadius: 4,
+                padding: "4px 12px",
+                color: tm.textSecondary,
+                cursor: "pointer",
+                fontSize: 12,
+                fontFamily: "inherit",
+              }}
+            >
+              New chat
+            </button>
+          </div>
+        </div>
+
+        {/* Messages */}
+        <div style={{ flex: 1, overflowY: "auto", padding: "12px 20px" }}>
+          {metabot.messages.length === 0 && !metabot.isProcessing && (
+            <div style={{ textAlign: "center", padding: "80px 0" }}>
+              <div
+                style={{
+                  width: 72,
+                  height: 72,
+                  borderRadius: "50%",
+                  background: `linear-gradient(135deg, ${tm.purple}, ${tm.accentLight})`,
+                  display: "inline-flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  color: "#fff",
+                  marginBottom: 16,
+                }}
+              >
+                <BotIcon size={36} />
+              </div>
+              <div
+                style={{
+                  fontSize: 18,
+                  fontWeight: 700,
+                  marginBottom: 6,
+                }}
+              >
+                Metabot
+              </div>
+              <div
+                style={{
+                  color: tm.textMuted,
+                  fontSize: 14,
+                  maxWidth: 340,
+                  margin: "0 auto",
+                  lineHeight: 1.5,
+                }}
+              >
+                Your AI assistant for exploring data. Ask about metrics,
+                dashboards, or write queries in plain English.
+              </div>
+            </div>
+          )}
+
+          {(metabot.messages as MetabotMessage[]).map((msg) => {
+            const isUser = msg.role === "user";
+
+            if (msg.type === "tool_call") {
+              return (
+                <div
+                  key={msg.id}
+                  style={{
+                    padding: "2px 0 2px 48px",
+                    fontSize: 12,
+                    color: tm.textMuted,
+                    fontStyle: "italic",
+                  }}
+                >
+                  {msg.status === "started" ? "Processing" : "Completed"}{" "}
+                  {msg.name}
+                </div>
+              );
+            }
+
+            const content =
+              "message" in msg && msg.message
+                ? msg.message
+                : "payload" in msg && msg.payload
+                  ? JSON.stringify(msg.payload, null, 2)
+                  : null;
+
+            if (!content) {
+              return null;
+            }
+
+            return (
+              <div
+                key={msg.id}
+                style={{
+                  display: "flex",
+                  gap: 12,
+                  padding: "6px 0",
+                  animation: "metabotFadeUp 0.2s ease",
+                }}
+              >
+                <div
+                  style={{
+                    width: 32,
+                    height: 32,
+                    borderRadius: "50%",
+                    background: isUser ? tm.surfaceRaised : tm.purple,
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    color: "#fff",
+                    flexShrink: 0,
+                    fontSize: 13,
+                    fontWeight: 700,
+                  }}
+                >
+                  {isUser ? "Y" : <BotIcon size={16} />}
+                </div>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div
+                    style={{
+                      display: "flex",
+                      alignItems: "baseline",
+                      gap: 8,
+                      marginBottom: 3,
+                    }}
+                  >
+                    <span style={{ fontSize: 13, fontWeight: 700 }}>
+                      {isUser ? "You" : "Metabot"}
+                    </span>
+                    <span
+                      style={{ fontSize: 11, color: tm.textMuted }}
+                    >
+                      {formatTime()}
+                    </span>
+                  </div>
+                  <div
+                    style={{
+                      fontSize: 14,
+                      lineHeight: 1.55,
+                      color: tm.textSecondary,
+                      whiteSpace: "pre-wrap",
+                    }}
+                  >
+                    {content}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+
+          {metabot.isProcessing && (
+            <div
+              style={{
+                display: "flex",
+                gap: 12,
+                padding: "6px 0",
+                animation: "metabotFadeUp 0.2s ease",
+              }}
+            >
+              <div
+                style={{
+                  width: 32,
+                  height: 32,
+                  borderRadius: "50%",
+                  background: tm.purple,
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  color: "#fff",
+                  flexShrink: 0,
+                }}
+              >
+                <BotIcon size={16} />
+              </div>
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 4,
+                  padding: "10px 0",
+                }}
+              >
+                {[0, 0.15, 0.3].map((delay) => (
+                  <div
+                    key={delay}
+                    style={{
+                      width: 6,
+                      height: 6,
+                      borderRadius: "50%",
+                      background: tm.purpleLight,
+                      animation: `metabotPulse 1.4s ${delay}s infinite`,
+                    }}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+
+          <div ref={scrollRef} />
+        </div>
+
+        {/* Errors */}
+        {metabot.errorMessages.map((err, i) => (
+          <div
+            key={i}
+            style={{
+              padding: "6px 20px",
+              fontSize: 13,
+              color: "#F85149",
+              background: "#F8514915",
+            }}
+          >
+            {err.message}
+          </div>
+        ))}
+
+        {/* Compose box */}
+        <div style={{ padding: "0 20px 16px" }}>
+          <div
+            style={{
+              border: `2px solid ${tm.border}`,
+              borderRadius: 4,
+              background: tm.compose,
+              overflow: "hidden",
+              transition: "border-color 0.15s",
+            }}
+            onFocus={(e) => {
+              e.currentTarget.style.borderColor = tm.composeBorder;
+            }}
+            onBlur={(e) => {
+              e.currentTarget.style.borderColor = tm.border;
+            }}
+          >
+            <div style={{ display: "flex", alignItems: "center" }}>
+              <input
+                style={{
+                  flex: 1,
+                  background: "none",
+                  border: "none",
+                  outline: "none",
+                  padding: "12px 14px",
+                  fontSize: 14,
+                  color: tm.text,
+                  fontFamily: "inherit",
+                }}
+                value={inputValue}
+                onChange={(e) => setInputValue(e.target.value)}
+                onKeyDown={(e) => e.key === "Enter" && handleSubmit()}
+                placeholder="Type a new message"
+              />
+            </div>
+            {/* Toolbar row */}
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                padding: "4px 10px 6px",
+                gap: 4,
+              }}
+            >
+              <div style={{ flex: 1 }} />
+              {metabot.isProcessing && (
+                <button
+                  onClick={metabot.cancelRequest}
+                  style={{
+                    background: "none",
+                    border: `1px solid ${tm.border}`,
+                    borderRadius: 4,
+                    padding: "3px 10px",
+                    color: tm.textMuted,
+                    cursor: "pointer",
+                    fontSize: 12,
+                    fontFamily: "inherit",
+                  }}
+                >
+                  Cancel
+                </button>
+              )}
+              <button
+                onClick={handleSubmit}
+                disabled={!canSend}
+                style={{
+                  width: 32,
+                  height: 28,
+                  borderRadius: 4,
+                  border: "none",
+                  background: canSend ? tm.purple : "transparent",
+                  color: canSend ? "#fff" : tm.textMuted,
+                  cursor: canSend ? "pointer" : "default",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  transition: "all 0.1s",
+                }}
+              >
+                <SendIcon />
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const Slack: StoryFn = () => <SlackDemo />;
+export const MicrosoftTeams: StoryFn = () => <TeamsDemo />;

--- a/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot.stories.tsx
+++ b/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot.stories.tsx
@@ -1,10 +1,15 @@
 import type { Meta, StoryFn } from "@storybook/react";
 import type { ReactNode } from "react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import { SdkAdHocQuestion } from "embedding-sdk-bundle/components/private/SdkAdHocQuestion";
 import { SdkQuestionDefaultView } from "embedding-sdk-bundle/components/private/SdkQuestionDefaultView";
-import { CommonSdkStoryWrapper } from "embedding-sdk-bundle/test/CommonSdkStoryWrapper";
+import { ComponentProvider } from "embedding-sdk-bundle/components/public/ComponentProvider";
+import {
+  CommonSdkStoryWrapper,
+  getStorybookSdkAuthConfigForUser,
+} from "embedding-sdk-bundle/test/CommonSdkStoryWrapper";
+import { defineMetabaseTheme } from "metabase/embedding-sdk/theme";
 
 import { useMetabot } from "./use-metabot";
 
@@ -21,6 +26,7 @@ const InlineChart = ({ questionPath }: { questionPath: string }) => (
       borderRadius: 8,
       overflow: "hidden",
       margin: "6px 0",
+      background: "var(--mb-color-background-secondary)",
     }}
   >
     <SdkAdHocQuestion
@@ -1274,6 +1280,59 @@ const AiBarDemo = () => {
 };
 
 // ============================================================================
+// Per-story SDK wrappers (dk only — sl/tm palettes not yet declared)
+// ============================================================================
+
+const makeSdkWrapper = (theme: ReturnType<typeof defineMetabaseTheme>) =>
+  function SdkWrapper(Story: StoryFn) {
+    const authConfig = useMemo(
+      () => getStorybookSdkAuthConfigForUser("admin"),
+      [],
+    );
+    return (
+      <ComponentProvider authConfig={authConfig} theme={theme}>
+        <Story />
+      </ComponentProvider>
+    );
+  };
+
+// Dark SaaS theme (Intercom / FloatingAIBar)
+const DkSdkWrapper = makeSdkWrapper(
+  defineMetabaseTheme({
+    fontFamily: "Inter",
+    fontSize: "14px",
+    colors: {
+      brand: dk.accent,
+      "text-primary": dk.text,
+      "text-secondary": dk.textSecondary,
+      "text-tertiary": dk.textMuted,
+      background: dk.surface,
+      "background-secondary": dk.surfaceRaised,
+      "background-hover": dk.surfaceHover,
+      "background-disabled": dk.border,
+      border: dk.border,
+      positive: dk.green,
+      negative: dk.red,
+    },
+    components: {
+      question: { backgroundColor: dk.surface },
+      table: {
+        cell: { backgroundColor: dk.surfaceRaised, textColor: dk.text },
+        idColumn: {
+          backgroundColor: dk.surfaceRaised,
+          textColor: dk.accentLight,
+        },
+      },
+      tooltip: {
+        backgroundColor: "#0B0D11",
+        textColor: dk.text,
+        secondaryTextColor: dk.textSecondary,
+      },
+    },
+  }),
+);
+
+// ============================================================================
 // Storybook exports
 // ============================================================================
 
@@ -1282,11 +1341,13 @@ export default {
   parameters: {
     layout: "fullscreen",
   },
-  decorators: [CommonSdkStoryWrapper],
 } satisfies Meta;
 
 export const Intercom: StoryFn = () => <IntercomDemo />;
+Intercom.decorators = [DkSdkWrapper];
+
 export const FloatingAIBar: StoryFn = () => <AiBarDemo />;
+FloatingAIBar.decorators = [DkSdkWrapper];
 
 // ============================================================================
 // Slack palette
@@ -1878,6 +1939,77 @@ const tm = {
   compose: "#323232",
   composeBorder: "#5B5FC7",
 };
+
+// ============================================================================
+// Slack + Teams SDK wrappers (sl/tm palettes now available)
+// ============================================================================
+
+// Slack dark theme
+const SlackSdkWrapper = makeSdkWrapper(
+  defineMetabaseTheme({
+    fontFamily: '"Lato", "Noto Sans", sans-serif',
+    fontSize: "14px",
+    colors: {
+      brand: sl.link,
+      "text-primary": sl.text,
+      "text-secondary": sl.textSecondary,
+      "text-tertiary": sl.textMuted,
+      background: sl.surface,
+      "background-secondary": sl.surfaceRaised,
+      "background-hover": sl.surfaceRaised,
+      "background-disabled": sl.border,
+      border: sl.border,
+      positive: sl.greenLight,
+      negative: sl.red,
+    },
+    components: {
+      question: { backgroundColor: sl.surface },
+      table: {
+        cell: { backgroundColor: sl.surfaceRaised, textColor: sl.text },
+        idColumn: { backgroundColor: sl.surfaceRaised, textColor: sl.link },
+      },
+      tooltip: {
+        backgroundColor: sl.bg,
+        textColor: sl.text,
+        secondaryTextColor: sl.textSecondary,
+      },
+    },
+  }),
+);
+
+// Microsoft Teams dark theme
+const TeamsSdkWrapper = makeSdkWrapper(
+  defineMetabaseTheme({
+    fontFamily: '"Segoe UI", sans-serif',
+    fontSize: "14px",
+    colors: {
+      brand: tm.accentLight,
+      "text-primary": tm.text,
+      "text-secondary": tm.textSecondary,
+      "text-tertiary": tm.textMuted,
+      background: tm.surface,
+      "background-secondary": tm.surfaceRaised,
+      "background-hover": tm.sidebarHover,
+      "background-disabled": tm.border,
+      border: tm.border,
+    },
+    components: {
+      question: { backgroundColor: tm.surface },
+      table: {
+        cell: { backgroundColor: tm.surfaceRaised, textColor: tm.text },
+        idColumn: {
+          backgroundColor: tm.surfaceRaised,
+          textColor: tm.accentLight,
+        },
+      },
+      tooltip: {
+        backgroundColor: tm.sidebar,
+        textColor: tm.text,
+        secondaryTextColor: tm.textSecondary,
+      },
+    },
+  }),
+);
 
 // ============================================================================
 // STORY 4: Microsoft Teams-style layout
@@ -2486,4 +2618,6 @@ const TeamsDemo = () => {
 };
 
 export const Slack: StoryFn = () => <SlackDemo />;
+Slack.decorators = [SlackSdkWrapper];
 export const MicrosoftTeams: StoryFn = () => <TeamsDemo />;
+MicrosoftTeams.decorators = [TeamsSdkWrapper];

--- a/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot.stories.tsx
+++ b/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot.stories.tsx
@@ -2,9 +2,37 @@ import type { Meta, StoryFn } from "@storybook/react";
 import type { ReactNode } from "react";
 import { useEffect, useRef, useState } from "react";
 
+import { SdkAdHocQuestion } from "embedding-sdk-bundle/components/private/SdkAdHocQuestion";
+import { SdkQuestionDefaultView } from "embedding-sdk-bundle/components/private/SdkQuestionDefaultView";
 import { CommonSdkStoryWrapper } from "embedding-sdk-bundle/test/CommonSdkStoryWrapper";
 
 import { useMetabot } from "./use-metabot";
+
+// ============================================================================
+// Shared: inline chart component (independent SdkAdHocQuestion per message)
+// ============================================================================
+
+const InlineChart = ({ questionPath }: { questionPath: string }) => (
+  <div
+    style={{
+      height: 500,
+      width: "100%",
+      flexShrink: 0,
+      borderRadius: 8,
+      overflow: "hidden",
+      margin: "6px 0",
+    }}
+  >
+    <SdkAdHocQuestion
+      questionPath={questionPath}
+      title={false}
+      height="500px"
+      isSaveEnabled={false}
+    >
+      <SdkQuestionDefaultView height="500px" withChartTypeSelector />
+    </SdkAdHocQuestion>
+  </div>
+);
 
 // ============================================================================
 // Shared dark SaaS palette
@@ -159,6 +187,12 @@ const MessageList = ({
               {msg.name}
             </span>
           </div>
+        );
+      }
+
+      if (msg.type === "chart" && "questionPath" in msg) {
+        return (
+          <InlineChart key={msg.id} questionPath={msg.questionPath as string} />
         );
       }
 
@@ -1396,9 +1430,7 @@ const SlackDemo = () => {
                 alignItems: "center",
                 gap: 6,
                 background:
-                  activeChannel === ch.name
-                    ? sl.sidebarActive
-                    : "transparent",
+                  activeChannel === ch.name ? sl.sidebarActive : "transparent",
                 color:
                   activeChannel === ch.name
                     ? "#fff"
@@ -1411,11 +1443,7 @@ const SlackDemo = () => {
               }}
             >
               <span style={{ color: sl.sidebarTextMuted, fontSize: 14 }}>
-                {ch.isBot ? (
-                  <BotIcon size={14} />
-                ) : (
-                  "#"
-                )}
+                {ch.isBot ? <BotIcon size={14} /> : "#"}
               </span>
               {ch.name}
               {ch.unread && activeChannel !== ch.name && (
@@ -1588,6 +1616,15 @@ const SlackDemo = () => {
               );
             }
 
+            if (msg.type === "chart" && "questionPath" in msg) {
+              return (
+                <InlineChart
+                  key={msg.id}
+                  questionPath={msg.questionPath as string}
+                />
+              );
+            }
+
             const content =
               "message" in msg && msg.message
                 ? msg.message
@@ -1644,9 +1681,7 @@ const SlackDemo = () => {
                     >
                       {isUser ? "You" : "Metabot"}
                     </span>
-                    <span
-                      style={{ fontSize: 11, color: sl.textMuted }}
-                    >
+                    <span style={{ fontSize: 11, color: sl.textMuted }}>
                       {formatTime()}
                     </span>
                   </div>
@@ -1870,10 +1905,30 @@ const TeamsDemo = () => {
   ];
 
   const recentChats = [
-    { name: "Product Team", preview: "Let's review the sprint...", time: "2m", unread: true },
-    { name: "Metabot", preview: "Revenue is up 12.3%", time: "15m", isBot: true },
-    { name: "Design Review", preview: "Looks great!", time: "1h", unread: false },
-    { name: "Sarah Chen", preview: "Can you check the query?", time: "3h", unread: false },
+    {
+      name: "Product Team",
+      preview: "Let's review the sprint...",
+      time: "2m",
+      unread: true,
+    },
+    {
+      name: "Metabot",
+      preview: "Revenue is up 12.3%",
+      time: "15m",
+      isBot: true,
+    },
+    {
+      name: "Design Review",
+      preview: "Looks great!",
+      time: "1h",
+      unread: false,
+    },
+    {
+      name: "Sarah Chen",
+      preview: "Can you check the query?",
+      time: "3h",
+      unread: false,
+    },
   ];
 
   return (
@@ -1882,8 +1937,7 @@ const TeamsDemo = () => {
         display: "flex",
         width: "100%",
         height: "100vh",
-        fontFamily:
-          '"Segoe UI", -apple-system, BlinkMacSystemFont, sans-serif',
+        fontFamily: '"Segoe UI", -apple-system, BlinkMacSystemFont, sans-serif',
         background: tm.bg,
         color: tm.text,
       }}
@@ -2009,8 +2063,7 @@ const TeamsDemo = () => {
                 gap: 10,
                 padding: "8px 16px",
                 cursor: "pointer",
-                background:
-                  chat.isBot ? tm.sidebarActive : "transparent",
+                background: chat.isBot ? tm.sidebarActive : "transparent",
                 borderRadius: 4,
                 margin: "0 8px",
               }}
@@ -2030,11 +2083,7 @@ const TeamsDemo = () => {
                   fontWeight: 700,
                 }}
               >
-                {chat.isBot ? (
-                  <BotIcon size={18} />
-                ) : (
-                  chat.name[0]
-                )}
+                {chat.isBot ? <BotIcon size={18} /> : chat.name[0]}
               </div>
               <div style={{ flex: 1, minWidth: 0 }}>
                 <div
@@ -2053,9 +2102,7 @@ const TeamsDemo = () => {
                   >
                     {chat.name}
                   </span>
-                  <span
-                    style={{ fontSize: 11, color: tm.textMuted }}
-                  >
+                  <span style={{ fontSize: 11, color: tm.textMuted }}>
                     {chat.time}
                   </span>
                 </div>
@@ -2197,6 +2244,15 @@ const TeamsDemo = () => {
               );
             }
 
+            if (msg.type === "chart" && "questionPath" in msg) {
+              return (
+                <InlineChart
+                  key={msg.id}
+                  questionPath={msg.questionPath as string}
+                />
+              );
+            }
+
             const content =
               "message" in msg && msg.message
                 ? msg.message
@@ -2247,9 +2303,7 @@ const TeamsDemo = () => {
                     <span style={{ fontSize: 13, fontWeight: 700 }}>
                       {isUser ? "You" : "Metabot"}
                     </span>
-                    <span
-                      style={{ fontSize: 11, color: tm.textMuted }}
-                    >
+                    <span style={{ fontSize: 11, color: tm.textMuted }}>
                       {formatTime()}
                     </span>
                   </div>

--- a/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot.stories.tsx
+++ b/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot.stories.tsx
@@ -129,6 +129,10 @@ const SparkleIcon = ({ size = 14 }: { size?: number }) => (
   </svg>
 );
 
+// Strip markdown links `[text](url)` → `text`
+const stripMarkdownLinks = (text: string) =>
+  text.replace(/\[([^\]]+)\]\([^)]+\)/g, "$1");
+
 // ============================================================================
 // Shared: message list renderer
 // ============================================================================
@@ -198,7 +202,7 @@ const MessageList = ({
 
       const content: ReactNode =
         "message" in msg && msg.message ? (
-          msg.message
+          stripMarkdownLinks(msg.message)
         ) : "payload" in msg && msg.payload ? (
           <pre
             style={{
@@ -1627,7 +1631,7 @@ const SlackDemo = () => {
 
             const content =
               "message" in msg && msg.message
-                ? msg.message
+                ? stripMarkdownLinks(msg.message)
                 : "payload" in msg && msg.payload
                   ? JSON.stringify(msg.payload, null, 2)
                   : null;
@@ -1691,6 +1695,8 @@ const SlackDemo = () => {
                       lineHeight: 1.5,
                       color: sl.text,
                       whiteSpace: "pre-wrap",
+                      overflowWrap: "break-word",
+                      wordBreak: "break-word",
                     }}
                   >
                     {content}
@@ -2255,7 +2261,7 @@ const TeamsDemo = () => {
 
             const content =
               "message" in msg && msg.message
-                ? msg.message
+                ? stripMarkdownLinks(msg.message)
                 : "payload" in msg && msg.payload
                   ? JSON.stringify(msg.payload, null, 2)
                   : null;
@@ -2313,6 +2319,8 @@ const TeamsDemo = () => {
                       lineHeight: 1.55,
                       color: tm.textSecondary,
                       whiteSpace: "pre-wrap",
+                      overflowWrap: "break-word",
+                      wordBreak: "break-word",
                     }}
                   >
                     {content}

--- a/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot.ts
+++ b/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot.ts
@@ -1,0 +1,88 @@
+import { useCallback, useState } from "react";
+
+import { useRegisterMetabotContextProvider } from "metabase/metabot";
+import { useMetabotAgent } from "metabase-enterprise/metabot/hooks/use-metabot-agent";
+
+/**
+ * Public-facing hook for interacting with Metabot in the SDK.
+ *
+ * Provides a simplified API for sending messages, managing conversation state,
+ * and reading Metabot responses.
+ */
+export const useMetabot = () => {
+  const agent = useMetabotAgent("omnibot");
+
+  const [customInstructions, setCustomInstructions] = useState<
+    string | undefined
+  >();
+
+  useRegisterMetabotContextProvider(
+    async () =>
+      customInstructions
+        ? { custom_instructions: customInstructions }
+        : undefined,
+    [customInstructions],
+  );
+
+  const submitMessage = useCallback(
+    (message: string) => agent.submitInput(message),
+    [agent.submitInput],
+  );
+
+  return {
+    /** The current user prompt value. */
+    prompt: agent.prompt,
+
+    /** Set the current prompt value without submitting. */
+    setPrompt: agent.setPrompt,
+
+    /** Whether the Metabot sidebar is visible. */
+    visible: agent.visible,
+
+    /** Show or hide the Metabot sidebar. */
+    setVisible: agent.setVisible,
+
+    /** Submit a message to Metabot. */
+    submitMessage,
+
+    /** Retry a previously failed message by its ID. */
+    retryMessage: agent.retryMessage,
+
+    /** Cancel the current in-flight request. */
+    cancelRequest: agent.cancelRequest,
+
+    /** Reset the conversation, clearing all messages. */
+    resetConversation: agent.resetConversation,
+
+    /** The list of chat messages in the current conversation. */
+    messages: agent.messages,
+
+    /** Any error messages from the current conversation. */
+    errorMessages: agent.errorMessages,
+
+    /** Whether Metabot is currently processing a request. */
+    isProcessing: agent.isDoingScience,
+
+    /** Whether this is a long conversation. */
+    isLongConversation: agent.isLongConversation,
+
+    /** Currently active tool calls being processed by Metabot. */
+    activeToolCalls: agent.activeToolCalls,
+
+    /** Metabot's reactions state (navigation suggestions, code edits, etc). */
+    reactions: agent.reactions,
+
+    /**
+     * Custom instructions appended to Metabot's system prompt.
+     * Takes high precedence as it appears last in the prompt.
+     *
+     * @example
+     * const { setCustomInstructions } = useMetabot();
+     * setCustomInstructions("Always respond in bullet points.");
+     */
+    customInstructions,
+
+    /** Set custom instructions for Metabot. Pass `undefined` to clear. */
+    setCustomInstructions,
+  };
+};

--- a/frontend/src/embedding-sdk-bundle/index.ts
+++ b/frontend/src/embedding-sdk-bundle/index.ts
@@ -24,6 +24,7 @@ import { CreateDashboardModal } from "./components/public/CreateDashboardModal";
 import { CreateQuestion } from "./components/public/CreateQuestion";
 import { InteractiveQuestion } from "./components/public/InteractiveQuestion";
 import { ComponentProvider } from "./components/public/ComponentProvider";
+import { MetabotChat } from "./components/public/MetabotChat";
 import { MetabotQuestion } from "./components/public/MetabotQuestion";
 import { StaticQuestion } from "./components/public/StaticQuestion";
 import {
@@ -44,6 +45,7 @@ import { useLogVersionInfo } from "embedding-sdk-bundle/hooks/private/use-log-ve
 import { createDashboard } from "embedding-sdk-bundle/lib/create-dashboard";
 import { defineBuildInfo } from "metabase/embedding-sdk/lib/define-build-info";
 import { validateFunctionSchema } from "embedding-sdk-bundle/lib/validate-function-schema";
+import { useMetabot } from "embedding-sdk-bundle/hooks/public/use-metabot";
 
 defineBuildInfo("METABASE_EMBEDDING_SDK_BUNDLE_BUILD_INFO");
 
@@ -60,6 +62,7 @@ const sdkBundleExports: MetabaseEmbeddingSdkBundleExports = {
   InteractiveDashboard,
   InteractiveQuestion,
   ComponentProvider,
+  MetabotChat,
   MetabotQuestion,
   SdkDebugInfo,
   StaticDashboard,
@@ -72,6 +75,7 @@ const sdkBundleExports: MetabaseEmbeddingSdkBundleExports = {
   getUser,
   useInitData,
   useLogVersionInfo,
+  useMetabot,
   validateFunctionSchema,
 };
 

--- a/frontend/src/embedding-sdk-bundle/index.ts
+++ b/frontend/src/embedding-sdk-bundle/index.ts
@@ -19,6 +19,7 @@ import "sdk-specific-imports";
 
 import type { MetabaseEmbeddingSdkBundleExports } from "./types/sdk-bundle";
 
+import { AdHocQuestion } from "./components/public/AdHocQuestion";
 import { CollectionBrowser } from "./components/public/CollectionBrowser";
 import { CreateDashboardModal } from "./components/public/CreateDashboardModal";
 import { CreateQuestion } from "./components/public/CreateQuestion";
@@ -53,6 +54,7 @@ defineBuildInfo("METABASE_EMBEDDING_SDK_BUNDLE_BUILD_INFO");
  * and should be done via the deprecation of the field first.
  */
 const sdkBundleExports: MetabaseEmbeddingSdkBundleExports = {
+  AdHocQuestion,
   CollectionBrowser,
   CreateDashboardModal,
   CreateQuestion,

--- a/frontend/src/embedding-sdk-bundle/store/index.ts
+++ b/frontend/src/embedding-sdk-bundle/store/index.ts
@@ -17,19 +17,26 @@ import { reducer as visualizer } from "metabase/visualizer/visualizer.slice";
 import { sdk } from "./reducer";
 import type { SdkDispatch, SdkStore } from "./types";
 
-export const sdkReducers = {
-  ...commonReducers,
-  pulse: combineReducers(pulse),
-  qb: combineReducers(qb),
-  visualizer,
-  sdk,
-  plugins: combineReducers({
-    metabotPlugin: PLUGIN_REDUCERS.metabotPlugin,
-  }),
-} as unknown as Record<string, Reducer>;
+export const buildSdkReducers = () =>
+  ({
+    ...commonReducers,
+    pulse: combineReducers(pulse),
+    qb: combineReducers(qb),
+    visualizer,
+    sdk,
+    plugins: combineReducers({
+      metabotPlugin: PLUGIN_REDUCERS.metabotPlugin,
+    }),
+  }) as unknown as Record<string, Reducer>;
+
+/**
+ * @deprecated Use `buildSdkReducers()` instead — it reads PLUGIN_REDUCERS at
+ * call-time so the EE metabot reducer is picked up correctly.
+ */
+export const sdkReducers = buildSdkReducers();
 
 export const getSdkStore = () =>
-  getStore(sdkReducers, null, {
+  getStore(buildSdkReducers(), null, {
     embed: {
       options: {
         entity_types: DEFAULT_EMBEDDING_ENTITY_TYPES,

--- a/frontend/src/embedding-sdk-bundle/types/sdk-bundle.ts
+++ b/frontend/src/embedding-sdk-bundle/types/sdk-bundle.ts
@@ -5,6 +5,7 @@ import type { ComponentProvider } from "embedding-sdk-bundle/components/public/C
 import type { CreateDashboardModal } from "embedding-sdk-bundle/components/public/CreateDashboardModal";
 import type { CreateQuestion } from "embedding-sdk-bundle/components/public/CreateQuestion";
 import type { InteractiveQuestion } from "embedding-sdk-bundle/components/public/InteractiveQuestion/InteractiveQuestion";
+import type { MetabotChat } from "embedding-sdk-bundle/components/public/MetabotChat";
 import type { MetabotQuestion } from "embedding-sdk-bundle/components/public/MetabotQuestion";
 import type { SdkDebugInfo } from "embedding-sdk-bundle/components/public/SdkDebugInfo/SdkDebugInfo";
 import type { StaticQuestion } from "embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion";
@@ -17,6 +18,7 @@ import type {
   MetabaseDashboard,
 } from "embedding-sdk-bundle/types";
 import type { LoginStatus } from "embedding-sdk-bundle/types/user";
+import type { useMetabot } from "embedding-sdk-bundle/hooks/public/use-metabot";
 import type { FunctionSchemaValidationResult } from "embedding-sdk-shared/types/validation";
 import type { User } from "metabase-types/api";
 
@@ -39,6 +41,7 @@ export type MetabaseEmbeddingSdkBundleExports = PublicExports &
   ReduxStoreUtilityFunctionExports &
   ReduxStoreSelectorsExports &
   InternalHooksExports &
+  PublicHooksExports &
   SchemaValidationUtils;
 
 export type PublicExports = {
@@ -49,6 +52,7 @@ export type PublicExports = {
   InteractiveDashboard: InternalComponent<typeof InteractiveDashboard>;
   InteractiveQuestion: InternalComponent<typeof InteractiveQuestion>;
   ComponentProvider: InternalComponent<typeof ComponentProvider>;
+  MetabotChat: InternalComponent<typeof MetabotChat>;
   MetabotQuestion: InternalComponent<typeof MetabotQuestion>;
   SdkDebugInfo: InternalComponent<typeof SdkDebugInfo>;
   StaticDashboard: InternalComponent<typeof StaticDashboard>;
@@ -75,6 +79,10 @@ export type ReduxStoreSelectorsExports = {
 export type InternalHooksExports = {
   useInitData: InternalHook;
   useLogVersionInfo: InternalHook;
+};
+
+export type PublicHooksExports = {
+  useMetabot: typeof useMetabot;
 };
 
 export type SchemaValidationUtils = {

--- a/frontend/src/embedding-sdk-bundle/types/sdk-bundle.ts
+++ b/frontend/src/embedding-sdk-bundle/types/sdk-bundle.ts
@@ -1,5 +1,6 @@
 import type { JSXElementConstructor } from "react";
 
+import type { AdHocQuestion } from "embedding-sdk-bundle/components/public/AdHocQuestion/AdHocQuestion";
 import type { CollectionBrowser } from "embedding-sdk-bundle/components/public/CollectionBrowser";
 import type { ComponentProvider } from "embedding-sdk-bundle/components/public/ComponentProvider";
 import type { CreateDashboardModal } from "embedding-sdk-bundle/components/public/CreateDashboardModal";
@@ -42,6 +43,7 @@ export type MetabaseEmbeddingSdkBundleExports = PublicExports &
   SchemaValidationUtils;
 
 export type PublicExports = {
+  AdHocQuestion: InternalComponent<typeof AdHocQuestion>;
   CollectionBrowser: InternalComponent<typeof CollectionBrowser>;
   CreateDashboardModal: InternalComponent<typeof CreateDashboardModal>;
   CreateQuestion: InternalComponent<typeof CreateQuestion>;

--- a/frontend/src/metabase-types/api/metabot.ts
+++ b/frontend/src/metabase-types/api/metabot.ts
@@ -51,6 +51,7 @@ export type MetabotChatContext = {
   workspace_id?: number;
   capabilities: string[];
   code_editor?: MetabotCodeEditorContext;
+  custom_instructions?: string;
 };
 
 export type MetabotTool = {

--- a/resources/metabase/config/modules.edn
+++ b/resources/metabase/config/modules.edn
@@ -1,0 +1,2534 @@
+;;
+;; !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+;; !!                                                                                       !!
+;; !!  PRO TIP! Run the tests in [[metabase.core.modules-test]] when you change this file!  !!
+;; !!                                                                                       !!
+;; !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+;;
+;; A "module" is any `metabase.<module>.core` namespace in `src`.
+;;
+;; ## `team`:
+;;
+;; The team that owns this module. This has to match one of the team names in `.github/team.json` EXACTLY. You can
+;; run [[metabase.core.modules-test/all-modules-have-teams-test]] to make sure you did this correctly.
+;;
+;; ## `api`:
+;;
+;; Map of module name => the "core" external public-facing API namespace(s). You have three options here:
+;;
+;; 1. Special sentinel value `:any` means means this module does not (yet) have external public-facing API
+;;    namespace(s). This is mostly a temporary placeholder until we go in and create module namespaces, which means
+;;    you should go create one.
+;;
+;; 2. A set of namespace symbols. All namespaces in other modules will only be allowed to use namespaces from
+;;    this set. Ideally this set should only have one namespace, but restricting it to a set of several is still
+;;    better than `:any`.
+;;
+;; 3. `nil` or not listed here -- we default to assuming there is (some subset) of the 'standard' API namespaces
+;;    `<module>.api`, `<module>.core`, and `<module>.init`
+;;
+;; ## `uses`:
+;;
+;; Map of module => other modules you're allowed to use there. You have two options here:
+;;
+;; 1. `:any` means namespaces in this module are allowed to use any other module -- allowed modules are not
+;;    enforced for this module. Module API namespaces for modules that have them defined are still enforced. For
+;;    ones that are `nil`, please go in and add a list of allowed modules. `:any` is mostly meant a temporary
+;;    placeholder until we can fill these all out, so feel free to fix these.
+;;
+;; 2. A set of module symbols. This is the list of modules that are allowed to be referenced. An empty set means no
+;;    other modules are allowed to be referenced; this is the default for any modules that aren't listed here.
+;;
+;; ## `friends`:
+;;
+;; 'Friend' in the C++ sense; set of modules that are allowed free access into the internals of this module including
+;; namespaces that are not `:api` namespaces. This is useful when writing modules that are 'extensions' of other
+;; modules, for example `enterprise/search` might be enterprise extensions of `search`, or `search-rest` might be the
+;; REST API component for `search`.
+;;
+;;    search
+;;    {...
+;;     :friends #{enterprise/search search-rest}}
+;;
+;; ## Tips
+;;
+;; PRO TIP: Check out the [[dev.deps-graph]] namespace for helpful tools to see where a module is used externally, and
+;; for tools for calculating this config -- you can use [[dev.deps-graph/print-kondo-config-diff]] to see what updates
+;; you need to make
+{:metabase/modules
+ {actions
+  {:team "Gadget"
+   :api  #{metabase.actions.args
+           metabase.actions.core
+           metabase.actions.init
+           metabase.actions.schema
+           metabase.actions.types}
+   :uses #{analytics
+           api
+           driver
+           events
+           legacy-mbql
+           lib
+           lib-be
+           model-persistence
+           models
+           parameters
+           queries
+           query-processor
+           search
+           settings
+           util
+           warehouses}}
+
+  actions-rest
+  {:team "Gadget"
+   :api  #{metabase.actions-rest.api}
+   :uses #{actions
+           analytics
+           api
+           collections
+           lib
+           permissions
+           public-sharing
+           queries
+           util}}
+
+  activity-feed
+  {:team "UX West"
+   :api  #{metabase.activity-feed.api
+           metabase.activity-feed.core
+           metabase.activity-feed.init}
+   :uses #{api
+           app-db
+           collections
+           config
+           events
+           models
+           util}}
+
+  analytics
+  {:team "UX West"
+   :api  #{metabase.analytics.api
+           metabase.analytics.core
+           metabase.analytics.init
+           metabase.analytics.prometheus
+           metabase.analytics.snowplow}
+   :uses #{api
+           app-db
+           appearance
+           config
+           driver
+           eid-translation
+           internal-stats
+           lib-be
+           models
+           permissions
+           premium-features
+           session
+           settings
+           sso
+           system
+           task
+           util
+           version}}
+
+  analyze
+  {:team "Querying"
+   :api  #{metabase.analyze.core
+           metabase.analyze.query-results}
+   :uses #{config
+           driver
+           lib
+           models
+           query-processor
+           sync
+           util}}
+
+  ;; TODO -- consolidate these into a `.core` API namespace.
+  api
+  {:team "DevEx"
+   :api  #{metabase.api.common
+           metabase.api.common.internal
+           metabase.api.docs
+           metabase.api.init
+           metabase.api.macros
+           metabase.api.open-api
+           metabase.api.response
+           metabase.api.routes.common
+           metabase.api.settings
+           metabase.api.util
+           metabase.api.util.handlers}
+   :uses #{config
+           events
+           models
+           settings
+           util}}
+
+  api-keys
+  {:team "UX West"
+   :api  #{metabase.api-keys.api
+           metabase.api-keys.core
+           metabase.api-keys.schema}
+   :uses #{api
+           app-db
+           events
+           models
+           permissions
+           users
+           util}}
+
+  api-routes
+  {:team "UX West"
+   :api  #{metabase.api-routes.cmd
+           metabase.api-routes.core}
+   :uses :any}
+
+  app-db
+  {:team "UX West"
+   :api  #{metabase.app-db.cluster-lock ; TODO FIXME
+           metabase.app-db.core
+           metabase.app-db.init
+           metabase.app-db.setup}
+   :uses #{auth-provider
+           classloader
+           config
+           connection-pool
+           task
+           util}}
+
+  appearance
+  {:team "UX West"
+   :api  #{metabase.appearance.core
+           metabase.appearance.init}
+   :uses #{settings util}}
+
+  audit-app
+  {:team "UX West"
+   :api  #{metabase.audit-app.core
+           metabase.audit-app.init}
+   :uses #{api
+           app-db
+           events
+           models
+           premium-features
+           settings
+           task
+           task-history
+           util}}
+
+  auth-identity
+  {:team "UX West"
+   :api  #{metabase.auth-identity.core
+           metabase.auth-identity.init}
+   :uses #{channel
+           events
+           login-history
+           models
+           notification
+           premium-features
+           request
+           util}}
+
+  auth-provider
+  {:team "UX West"
+   :api  #{metabase.auth-provider.core}
+   :uses #{premium-features}}
+
+  batch-processing
+  {:team "UX West"
+   :api  #{metabase.batch-processing.core
+           metabase.batch-processing.init}
+   :uses #{app-db
+           settings
+           util}}
+
+  bookmarks
+  {:team "UX West"
+   :api  #{metabase.bookmarks.api}
+   :uses #{api
+           app-db
+           collections
+           queries
+           util}}
+
+  bug-reporting
+  {:team "UX West"
+   :api  #{metabase.bug-reporting.api
+           metabase.bug-reporting.init}
+   :uses #{analytics
+           api
+           app-db
+           config
+           driver
+           permissions
+           premium-features
+           settings
+           util}}
+
+  cache
+  {:team "UX West"
+   :api  #{metabase.cache.api
+           metabase.cache.core
+           metabase.cache.init}
+   :uses #{api
+           app-db
+           config
+           events
+           models
+           premium-features
+           request
+           settings
+           util}}
+
+  ;; TODO -- way too many API namespaces.
+  channel
+  {:team "Gadget"
+   :api  #{metabase.channel.api
+           metabase.channel.core
+           metabase.channel.email
+           metabase.channel.email.messages
+           metabase.channel.init
+           metabase.channel.models.channel
+           metabase.channel.render.core
+           metabase.channel.settings
+           metabase.channel.slack
+           metabase.channel.template.core
+           metabase.channel.urls}
+   :uses #{analytics
+           api
+           app-db
+           appearance
+           collections
+           config
+           dashboards
+           driver
+           events
+           formatter
+           lib
+           lib-be
+           models
+           notification
+           parameters
+           permissions
+           premium-features
+           query-processor
+           settings
+           system
+           task
+           timeline
+           types
+           util}}
+
+  classloader
+  {:team "DevEx"
+   :api  #{metabase.classloader.core
+           metabase.classloader.init}
+   :uses #{util}}
+
+  cloud-migration
+  {:team "UX West"
+   :api  #{metabase.cloud-migration.api
+           metabase.cloud-migration.core
+           metabase.cloud-migration.init}
+   :uses #{api
+           app-db
+           cmd
+           config
+           models
+           premium-features
+           settings
+           store-api
+           task
+           util}}
+
+  cmd
+  {:team "UX West"
+   :api  #{metabase.cmd.copy
+           metabase.cmd.core
+           metabase.cmd.dump-to-h2}
+   :uses #{api
+           api-routes
+           app-db
+           auth-identity
+           classloader
+           config
+           models
+           query-processor
+           search
+           settings
+           util}}
+
+  collections
+  {:team "UX West"
+   :api  #{metabase.collections.core
+           metabase.collections.models.collection
+           metabase.collections.models.collection.root
+           metabase.collections.schema}
+   :uses #{api
+           api-keys
+           app-db
+           audit-app
+           config
+           events
+           models
+           permissions
+           premium-features
+           remote-sync
+           search
+           util}}
+
+  collections-rest
+  {:team "UX West"
+   :api  #{metabase.collections-rest.api
+           metabase.collections-rest.init}
+   :uses #{api
+           app-db
+           collections
+           eid-translation
+           events
+           lib-be
+           models
+           notification
+           permissions
+           premium-features
+           queries
+           request
+           revisions
+           settings
+           transforms
+           upload
+           util}}
+
+  comments
+  {:team "UX West"
+   :api  #{metabase.comments.api
+           metabase.comments.init}
+   :uses #{analytics
+           api
+           channel
+           events
+           models
+           request
+           users
+           util}}
+
+  ;; technically this 'uses' `enterprise/core` and `test` since it tries to load them to see if they exists so we know
+  ;; if EE/test code is available; however we can ignore them since they're not real usages.
+  config
+  {:team "DevEx"
+   :api  #{metabase.config.core}
+   :uses #{}}
+
+  ;; this is not actually a real module, but comes from one of our libraries.
+  connection-pool
+  {:team "UX West"
+   :api  #{metabase.connection-pool}
+   :uses #{}}
+
+  content-translation
+  {:team "UX West"
+   :api  #{metabase.content-translation.models}
+   :uses #{premium-features
+           util}}
+
+  content-verification
+  {:team "UX West"
+   :api  #{metabase.content-verification.core
+           metabase.content-verification.init}
+   :uses #{app-db
+           models
+           util}}
+
+  core
+  {:team "UX West"
+   :api  #{}
+   :uses :any}
+
+  dashboards
+  {:team "UX West"
+   :api  #{metabase.dashboards.autoplace
+           metabase.dashboards.constants
+           metabase.dashboards.init
+           metabase.dashboards.models.dashboard
+           metabase.dashboards.models.dashboard-card
+           metabase.dashboards.models.dashboard-tab
+           metabase.dashboards.schema
+           metabase.dashboards.settings}
+   :uses #{api
+           app-db
+           audit-app
+           collections
+           config
+           events
+           lib
+           models
+           parameters
+           permissions
+           public-sharing
+           queries
+           query-processor
+           search
+           settings
+           util
+           warehouse-schema}}
+
+  dashboards-rest
+  {:team "UX West"
+   :api  #{metabase.dashboards-rest.api}
+   :uses #{actions
+           analytics
+           api
+           app-db
+           channel
+           collections
+           collections-rest
+           dashboards
+           eid-translation
+           embedding
+           events
+           lib
+           lib-be
+           models
+           parameters
+           permissions
+           public-sharing
+           pulse
+           queries
+           query-permissions
+           query-processor
+           request
+           revisions
+           util
+           xrays}}
+
+  data-studio
+  {:team "Gadget"
+   :api  #{metabase.data-studio.api}
+   :uses #{api
+           database-routing
+           driver
+           events
+           request
+           sync
+           util
+           warehouse-schema}}
+
+  database-routing
+  {:team "UX West"
+   :api  #{metabase.database-routing.core}
+   :uses #{premium-features}}
+
+  documents
+  {:team "UX West"
+   :api  #{metabase.documents.api
+           metabase.documents.core
+           metabase.documents.init
+           metabase.documents.prose-mirror
+           metabase.documents.schema}
+   :uses #{activity-feed
+           api
+           app-db
+           batch-processing
+           collections
+           events
+           models
+           public-sharing
+           queries
+           query-permissions
+           query-processor
+           revisions
+           search
+           util
+           view-log}}
+
+  driver
+  {:team "Querying"
+   :api  #{metabase.driver
+           metabase.driver.common
+           metabase.driver.common.parameters
+           metabase.driver.common.parameters.parse
+           metabase.driver.connection
+          metabase.driver.connection.workspaces
+           metabase.driver.ddl.interface
+           metabase.driver.h2
+           metabase.driver.impl
+           metabase.driver.init
+           metabase.driver.mysql
+           metabase.driver.postgres
+           metabase.driver.settings
+           metabase.driver.sql
+           metabase.driver.sql-jdbc
+           metabase.driver.sql-jdbc.connection
+           metabase.driver.sql-jdbc.execute
+           metabase.driver.sql-jdbc.execute.diagnostic
+           metabase.driver.sql-jdbc.sync
+           ;; TODO (lbrdnk 2025/12/17): We should revisit addition of the following line. I've added it to make
+           ;; tests pass as we are using it directly with ee/workspaces module. I believe later, when workspaces
+           ;; are in better state quality wise, it should become part of the driver api and that should be used
+           ;; instead of calling directly into the normalize module.
+           metabase.driver.sql.normalize
+           metabase.driver.sql.query-processor
+           metabase.driver.sql.util
+           metabase.driver.sync
+           metabase.driver.util}
+   :uses #{analytics
+           app-db
+           appearance
+           auth-provider
+           classloader
+           config
+           driver-api
+           events
+           legacy-mbql
+           lib
+           lib-be
+           premium-features
+           query-processor
+           settings
+           sql-tools
+           system
+           util
+           warehouse-schema
+           warehouses}}
+
+  driver-api
+  {:team "Querying"
+   :api  #{metabase.driver-api.core}
+   :uses #{actions
+           api
+           app-db
+           appearance
+           classloader
+           config
+           connection-pool
+           database-routing
+           events
+           legacy-mbql
+           lib
+           lib-be
+           logger
+           models
+           premium-features
+           query-processor
+           secrets
+           settings
+           sync
+           system
+           upload
+           util
+           warehouse-schema}}
+
+  eid-translation
+  {:team "UX West"
+   :api  #{metabase.eid-translation.api
+           metabase.eid-translation.core
+           metabase.eid-translation.init}
+   :uses #{api
+           settings
+           util}}
+
+  embedding
+  {:team "Embedding"
+   :api  #{metabase.embedding.init
+           metabase.embedding.jwt
+           metabase.embedding.settings
+           metabase.embedding.util
+           metabase.embedding.validation}
+   :uses #{analytics
+           api
+           premium-features
+           server
+           settings
+           util}}
+
+  embedding-rest
+  {:team "Embedding"
+   :api  #{metabase.embedding-rest.api}
+   :uses #{api
+           dashboards
+           database-routing
+           eid-translation
+           embedding
+           events
+           models
+           notification
+           parameters
+           public-sharing-rest
+           queries
+           query-processor
+           request
+           tiles
+           util}}
+
+  events
+  {:team "DevEx"
+   :api  #{metabase.events.core
+           metabase.events.init}
+   :uses #{models
+           util}}
+
+  formatter
+  {:team "UX West"
+   :api  #{metabase.formatter.core}
+   :uses #{appearance
+           models
+           query-processor
+           types
+           util}}
+
+  geojson
+  {:team "UX West"
+   :api  #{metabase.geojson.api
+           metabase.geojson.init}
+   :uses #{api
+           permissions
+           settings
+           util}}
+
+  glossary
+  {:team "Gadget"
+   :api  #{metabase.glossary.api}
+   :uses #{api
+           events
+           models
+           util}}
+
+  graph
+  {:team "Querying"
+   :api  #{metabase.graph.core}
+   :uses #{util}}
+
+  indexed-entities
+  {:team "UX West"
+   :api  #{metabase.indexed-entities.api
+           metabase.indexed-entities.init}
+   :uses #{analytics
+           api
+           driver
+           legacy-mbql
+           lib
+           models
+           query-processor
+           search
+           sync
+           task
+           util}}
+
+  initialization-status
+  {:team "UX West"
+   :api  #{metabase.initialization-status.core}
+   :uses #{}}
+
+  internal-stats
+  {:team "UX West"
+   :api  #{metabase.internal-stats.core}
+   :uses #{app-db
+           models}}
+
+  legacy-mbql
+  {:team "Querying"
+   :api  #{metabase.legacy-mbql.normalize
+           metabase.legacy-mbql.schema
+           metabase.legacy-mbql.util}
+   :uses #{lib
+           types
+           util}}
+
+  lib
+  {:team "Querying"
+   :api  #{metabase.lib.core
+           metabase.lib.equality
+           metabase.lib.init
+           metabase.lib.metadata
+           metabase.lib.metadata.protocols
+           metabase.lib.options
+           metabase.lib.schema
+           metabase.lib.schema.actions
+           metabase.lib.schema.aggregation
+           metabase.lib.schema.common
+           metabase.lib.schema.expression
+           metabase.lib.schema.expression.temporal
+           metabase.lib.schema.id
+           metabase.lib.schema.info
+           metabase.lib.schema.join
+           metabase.lib.schema.literal
+           metabase.lib.schema.mbql-clause
+           metabase.lib.schema.measure
+           metabase.lib.schema.metadata
+           metabase.lib.schema.metadata.fingerprint
+           metabase.lib.schema.parameter
+           metabase.lib.schema.ref
+           metabase.lib.schema.template-tag
+           metabase.lib.schema.temporal-bucketing
+           metabase.lib.schema.test-spec
+           metabase.lib.schema.util
+           metabase.lib.schema.validate
+           metabase.lib.types.isa
+           metabase.lib.util
+           metabase.lib.util.match}
+   :uses #{config
+           graph
+           legacy-mbql
+           types
+           util}
+   :friends #{legacy-mbql         ;; Reuses internal schemas and a few helper functions. Deeply coupled to MBQL.
+              lib-be              ;; BE-specific extension of lib; tight coupling is acceptable.
+              query-processor     ;; Necessarily manipulates MBQL; better to pull most logic into a new module.
+              enterprise/sandbox  ;; Really part of the QP, though its lives in the enterprise/ tree.
+              }}
+
+  lib-be
+  {:team "Querying"
+   :api  #{metabase.lib-be.core
+           metabase.lib-be.init}
+   :uses #{lib
+           models
+           settings
+           util}}
+
+  llm
+  {:team "Metabot"
+   :api  #{metabase.llm.api
+           metabase.llm.init}
+   :uses #{analytics
+           api
+           driver
+           lib
+           lib-be
+           models
+           premium-features
+           request
+           settings
+           sql-tools
+           sync
+           util
+           warehouse-schema}}
+
+  logger
+  {:team "DevEx"
+   :api  #{metabase.logger.api
+           metabase.logger.core
+           metabase.logger.init}
+   :uses #{analytics
+           api
+           classloader
+           config
+           permissions
+           util}}
+
+  login-history
+  {:team "UX West"
+   :api  #{metabase.login-history.api
+           metabase.login-history.core
+           metabase.login-history.init}
+   :uses #{analytics
+           api
+           channel
+           request
+           settings
+           util}}
+
+  measures
+  {:team "Querying"
+   :api  #{metabase.measures.api}
+   :uses #{api
+           events
+           lib
+           lib-be
+           models
+           permissions
+           remote-sync
+           search
+           util}}
+
+  model-persistence
+  {:team "Querying"
+   :api  #{metabase.model-persistence.api
+           metabase.model-persistence.core
+           metabase.model-persistence.init}
+   :uses #{api
+           app-db
+           driver
+           events
+           lib
+           models
+           permissions
+           premium-features
+           queries
+           query-processor
+           request
+           settings
+           system
+           task
+           task-history
+           util}}
+
+  models
+  {:team "DevEx"
+   :api  #{metabase.models.humanization
+           metabase.models.init
+           metabase.models.interface
+           metabase.models.resolution
+           metabase.models.serialization
+           metabase.models.util.spec-update
+           metabase.models.visualization-settings}
+   :uses #{api
+           app-db
+           classloader
+           collections
+           events
+           legacy-mbql
+           lib
+           lib-be
+           permissions
+           query-processor
+           remote-sync
+           search
+           settings
+           transforms
+           util}
+   :friends #{transforms}}
+
+  native-query-snippets
+  {:team "Querying"
+   :api  #{metabase.native-query-snippets.api
+           metabase.native-query-snippets.core}
+   :uses #{api
+           collections
+           events
+           lib
+           models
+           permissions
+           premium-features
+           remote-sync
+           util}}
+
+  notification
+  {:team "Gadget"
+   :api  #{metabase.notification.api
+           metabase.notification.core
+           metabase.notification.init
+           metabase.notification.models
+           metabase.notification.payload.core}
+   :uses #{analytics
+           api
+           appearance
+           auth-identity
+           channel
+           config
+           dashboards
+           driver
+           embedding
+           events
+           models
+           parameters
+           permissions
+           premium-features
+           query-processor
+           request
+           session
+           settings
+           sso
+           system
+           task
+           task-history
+           users
+           util}}
+
+  ;; TODO -- too many API namespaces
+  parameters
+  {:team "Querying"
+   :api  #{metabase.parameters.chain-filter
+           metabase.parameters.core
+           metabase.parameters.custom-values
+           metabase.parameters.dashboard
+           metabase.parameters.field
+           metabase.parameters.field-values
+           metabase.parameters.init
+           metabase.parameters.params
+           metabase.parameters.schema
+           metabase.parameters.shared}
+   :uses #{api
+           app-db
+           classloader
+           lib
+           lib-be
+           models
+           query-processor
+           util
+           warehouse-schema
+           warehouses}}
+
+  permissions
+  {:team "UX West"
+   :api  #{metabase.permissions.core
+           metabase.permissions.init
+           metabase.permissions.schema}
+   :uses #{api
+           app-db
+           audit-app
+           collections
+           config
+           events
+           lib
+           models
+           premium-features
+           remote-sync
+           settings
+           util
+           enterprise/advanced-permissions}}
+
+  permissions-rest
+  {:team "UX West"
+   :api  #{metabase.permissions-rest.api}
+   :uses #{api
+           app-db
+           audit-app
+           events
+           permissions
+           premium-features
+           request
+           settings
+           util}}
+
+  pivot
+  {:team "UX West"
+   :api  #{metabase.pivot.core}
+   :uses #{models
+           util}}
+
+  plugins
+  {:team "DevEx"
+   :api  #{metabase.plugins.core}
+   :uses #{classloader
+           config
+           driver
+           util}}
+
+  premium-features
+  {:team "UX West"
+   :api  #{metabase.premium-features.api
+           metabase.premium-features.core
+           metabase.premium-features.init}
+   :uses #{analytics
+           api
+           app-db
+           classloader
+           config
+           events
+           internal-stats
+           settings
+           startup
+           task
+           util}}
+
+  product-feedback
+  {:team "UX West"
+   :api  #{metabase.product-feedback.api
+           metabase.product-feedback.init}
+   :uses #{analytics
+           api
+           app-db
+           channel
+           config
+           premium-features
+           settings
+           task
+           util}}
+
+  public-sharing
+  {:team "UX West"
+   :api  #{metabase.public-sharing.core
+           metabase.public-sharing.init
+           metabase.public-sharing.validation}
+   :uses #{api
+           settings
+           util}}
+
+  public-sharing-rest
+  {:team "UX West"
+   :api  #{metabase.public-sharing-rest.api}
+   :uses #{actions
+           analytics
+           api
+           dashboards
+           dashboards-rest
+           events
+           lib
+           models
+           parameters
+           public-sharing
+           queries
+           query-processor
+           request
+           tiles
+           util}}
+
+  pulse
+  {:team "Gadget"
+   :api  #{metabase.pulse.api
+           metabase.pulse.core
+           metabase.pulse.init}
+   :uses #{api
+           app-db
+           channel
+           classloader
+           collections
+           config
+           driver
+           embedding
+           events
+           lib
+           models
+           notification
+           permissions
+           premium-features
+           query-processor
+           request
+           task
+           task-history
+           util
+           enterprise/advanced-permissions
+           enterprise/sandbox}}
+
+  queries
+  {:team "Querying"
+   :api  #{metabase.queries.core
+           metabase.queries.init
+           metabase.queries.models.query ; TODO FIXME
+           metabase.queries.schema}
+   :uses #{analytics
+           analyze
+           api
+           app-db
+           audit-app
+           cache
+           channel
+           collections
+           config
+           content-verification
+           dashboards
+           documents
+           events
+           lib
+           lib-be
+           models
+           parameters
+           permissions
+           premium-features
+           public-sharing
+           pulse
+           query-permissions
+           query-processor
+           request
+           search
+           util
+           view-log
+           warehouse-schema}}
+
+  queries-rest
+  {:team "Querying"
+   :api  #{metabase.queries-rest.api}
+   :uses #{analyze
+           api
+           collections
+           eid-translation
+           embedding
+           events
+           lib
+           lib-be
+           models
+           parameters
+           permissions
+           public-sharing
+           queries
+           query-permissions
+           query-processor
+           request
+           revisions
+           search
+           util}}
+
+  query-permissions
+  {:team "UX West"
+   :api  #{metabase.query-permissions.core}
+   :uses #{api
+           legacy-mbql
+           lib
+           lib-be
+           models
+           permissions
+           query-processor
+           request
+           util}}
+
+  query-processor
+  {:team "Querying"
+   :api  #{metabase.query-processor
+           metabase.query-processor.api
+           metabase.query-processor.card
+           metabase.query-processor.compile
+           metabase.query-processor.dashboard
+           metabase.query-processor.debug
+           metabase.query-processor.error-type
+           metabase.query-processor.init
+           metabase.query-processor.interface
+           metabase.query-processor.metadata
+           metabase.query-processor.middleware.add-remaps
+           metabase.query-processor.middleware.annotate
+           metabase.query-processor.middleware.cache-backend.db
+           metabase.query-processor.middleware.catch-exceptions
+           metabase.query-processor.middleware.constraints
+           metabase.query-processor.middleware.limit
+           metabase.query-processor.middleware.permissions
+           metabase.query-processor.middleware.wrap-value-literals
+           metabase.query-processor.parameters.dates
+           metabase.query-processor.parameters.operators
+           metabase.query-processor.pipeline
+           metabase.query-processor.pivot
+           metabase.query-processor.preprocess
+           metabase.query-processor.reducible
+           metabase.query-processor.schema
+           metabase.query-processor.setup
+           metabase.query-processor.store
+           metabase.query-processor.streaming
+           metabase.query-processor.streaming.common
+           metabase.query-processor.streaming.interface
+           metabase.query-processor.timezone
+           metabase.query-processor.util
+           metabase.query-processor.util.add-alias-info
+           metabase.query-processor.util.nest-query
+           metabase.query-processor.util.persisted-cache
+           metabase.query-processor.util.relative-datetime
+           metabase.query-processor.util.transformations.nest-breakouts
+           metabase.query-processor.writeback}
+   :uses #{analytics
+           analyze
+           api
+           app-db
+           appearance
+           audit-app
+           batch-processing
+           cache
+           config
+           dashboards
+           driver
+           events
+           formatter
+           legacy-mbql
+           lib
+           lib-be
+           model-persistence
+           models
+           parameters
+           permissions
+           pivot
+           premium-features
+           queries
+           query-permissions
+           server
+           settings
+           system
+           users
+           util}}
+
+  remote-sync
+  {:team "UX West"
+   :api  #{metabase.remote-sync.core
+           metabase.remote-sync.init}
+   :uses #{api
+           models
+           premium-features}}
+
+  request
+  {:team "UX West"
+   :api  #{metabase.request.core
+           metabase.request.init
+           metabase.request.schema}
+   :uses #{analytics
+           api
+           config
+           embedding
+           permissions ; FIXME
+           session
+           settings
+           users
+           util}}
+
+  revisions
+  {:team "UX West"
+   :api  #{metabase.revisions.api
+           metabase.revisions.core
+           metabase.revisions.init}
+   :uses #{api
+           config
+           dashboards
+           events
+           lib
+           models
+           queries
+           query-permissions
+           util}}
+
+  sample-data
+  {:team "UX West"
+   :api  #{metabase.sample-data.core
+           metabase.sample-data.init}
+   :uses #{plugins
+           settings
+           sync
+           util}}
+
+  search
+  {:team "UX West"
+   :api  #{metabase.search.api
+           metabase.search.appdb.scoring
+           metabase.search.config
+           metabase.search.core
+           metabase.search.engine
+           metabase.search.in-place.scoring
+           metabase.search.ingestion
+           metabase.search.init
+           metabase.search.scoring
+           metabase.search.spec}
+   :uses #{analytics
+           api
+           app-db
+           appearance
+           audit-app
+           collections
+           config
+           events
+           lib
+           lib-be
+           models
+           permissions
+           premium-features
+           queries
+           query-processor
+           request
+           settings
+           startup
+           task
+           transforms
+           util}}
+
+  secrets
+  {:team "Querying"
+   :api  #{metabase.secrets.core}
+   :uses #{api driver models premium-features util}}
+
+  segments
+  {:team "Querying"
+   :api  #{metabase.segments.api
+           metabase.segments.schema}
+   :uses #{api
+           events
+           lib
+           lib-be
+           models
+           permissions
+           remote-sync
+           search
+           util
+           xrays}}
+
+  server
+  {:team "UX West"
+   :api  #{metabase.server.core
+           metabase.server.init
+           metabase.server.middleware.session
+           metabase.server.settings
+           metabase.server.streaming-response} ; TODO -- too many API namespaces
+   :uses #{analytics
+           api
+           api-keys
+           app-db
+           appearance
+           config
+           driver
+           embedding
+           initialization-status
+           lib-be
+           premium-features
+           query-processor
+           request
+           session
+           settings
+           system
+           users
+           util
+           enterprise/sso}}
+
+  session
+  {:team "UX West"
+   :api  #{metabase.session.api
+           metabase.session.core
+           metabase.session.init
+           metabase.session.settings}      ; TODO -- shouldn't be exposed as an API namespace
+   :uses #{api
+           app-db
+           auth-identity
+           channel
+           config
+           events
+           request
+           settings
+           sso
+           system
+           task
+           util}}
+
+  settings
+  {:team "DevEx"
+   :api  #{metabase.settings.core
+           metabase.settings.init}
+   :uses #{api
+           app-db
+           config
+           events
+           models
+           premium-features
+           util
+           enterprise/advanced-permissions}}
+
+  settings-rest
+  {:team "DevEx"
+   :api  #{metabase.settings-rest.api}
+   :uses #{api
+           permissions
+           settings
+           util}}
+
+  setup
+  {:team "UX West"
+   :api  #{metabase.setup.core
+           metabase.setup.init}
+   :uses #{app-db
+           config
+           settings
+           util}}
+
+  setup-rest
+  {:team "UX West"
+   :api  #{metabase.setup-rest.api}
+   :uses #{analytics
+           api
+           appearance
+           auth-identity
+           events
+           request
+           settings
+           setup
+           system
+           util}}
+
+  sql-parsing
+  {:team "DevEx"
+   :api #{metabase.sql-parsing.core}
+   :uses #{analytics
+           util}}
+
+  sql-tools
+  {:team "DevEx"
+   :api #{metabase.sql-tools.core
+          metabase.sql-tools.init}
+   :uses #{analytics
+           driver
+           lib
+           settings
+           sql-parsing
+           util}}
+
+  sso
+  {:team "UX West"
+   :api  #{metabase.sso.api
+           metabase.sso.core
+           metabase.sso.init}
+   :uses #{api
+           auth-identity
+           config
+           permissions
+           premium-features
+           settings
+           system
+           util}}
+
+  startup
+  {:team "DevEx"
+   :api  #{metabase.startup.core}
+   :uses #{util}}
+
+  store-api
+  {:team "Cloud"
+   :api  #{metabase.store-api.core
+           metabase.store-api.init}
+   :uses #{config
+           settings
+           util}}
+
+  sync
+  {:team "Querying"
+   :api  #{metabase.sync.api
+           metabase.sync.core
+           metabase.sync.init
+           metabase.sync.schedules
+           metabase.sync.task.sync-databases
+           metabase.sync.util}
+   :uses #{analyze
+           api
+           app-db
+           audit-app
+           config
+           database-routing
+           driver
+           events
+           lib
+           models
+           premium-features
+           query-processor
+           settings
+           task
+           task-history
+           util
+           warehouse-schema
+           warehouses}}
+
+  system
+  {:team "UX West"
+   :api  #{metabase.system.core
+           metabase.system.init}
+   :uses #{appearance settings util}}
+
+  task
+  {:team "UX West"
+   :api  #{metabase.task.bootstrap
+           metabase.task.core}
+   :uses #{app-db
+           classloader
+           util}}
+
+  task-history
+  {:team "UX West"
+   :api  #{metabase.task-history.api
+           metabase.task-history.core
+           metabase.task-history.init}
+   :uses #{api
+           app-db
+           config
+           models
+           permissions
+           premium-features
+           query-processor
+           request
+           task
+           util}}
+
+  tenants
+  {:team "Admin Webapp"
+   :api  #{metabase.tenants.core}
+   :uses #{premium-features
+           util}}
+
+  testing-api
+  {:team "DevEx"
+   :api  #{metabase.testing-api.api
+           metabase.testing-api.core
+           metabase.testing-api.init}
+   :uses #{analytics
+           api
+           app-db
+           config
+           lib
+           lib-be
+           premium-features
+           search
+           util}}
+
+  tiles
+  {:team "UX West"
+   :api  #{metabase.tiles.api
+           metabase.tiles.init}
+   :uses #{api
+           legacy-mbql
+           lib
+           lib-be
+           parameters
+           query-processor
+           settings
+           util}}
+
+  timeline
+  {:team "UX West"
+   :api  #{metabase.timeline.api
+           metabase.timeline.core}
+   :uses #{analytics
+           api
+           collections
+           events
+           models
+           util}}
+
+  transforms
+  {:team "Querying"
+   :api  #{metabase.transforms.core
+           metabase.transforms.feature-gating
+           metabase.transforms.init
+           metabase.transforms.interface
+           metabase.transforms.schema
+           metabase.transforms.util}
+   :uses #{analytics
+           api
+           channel
+           database-routing
+           driver
+           events
+           lib
+           lib-be
+           models
+           premium-features
+           queries
+           query-processor
+           revisions
+           settings
+           sync
+           task
+           task-history
+           util}
+   :friends #{models
+              enterprise/transforms-python
+              enterprise/workspaces}}
+
+  transforms-inspector
+  {:team "Gadget"
+   :api  #{metabase.transforms-inspector.core
+           metabase.transforms-inspector.schema}
+   :uses #{driver
+           lib
+           lib-be
+           query-processor
+           sql-tools
+           transforms
+           util}}
+
+  transforms-rest
+  {:team "Gadget"
+   :api  #{metabase.transforms-rest.api.transform
+           metabase.transforms-rest.api.transform-job
+           metabase.transforms-rest.api.transform-tag}
+   :uses #{api
+           driver
+           events
+           models
+           query-processor
+           request
+           server
+           sql-tools
+           transforms
+           transforms-inspector
+           util}}
+
+  types
+  {:team "Querying"
+   :api  #{metabase.types.core
+           metabase.types.init}
+   :uses #{util}}
+
+  upload
+  {:team "Querying"
+   :api  #{metabase.upload.api
+           metabase.upload.core
+           metabase.upload.db
+           metabase.upload.init}
+   :uses #{analytics
+           api
+           appearance
+           driver
+           events
+           lib
+           model-persistence
+           models
+           permissions
+           queries
+           settings
+           sync
+           util
+           warehouse-schema}}
+
+  user-key-value
+  {:team "UX West"
+   :api  #{metabase.user-key-value.api
+           metabase.user-key-value.init}
+   :uses #{api
+           config
+           lib
+           util}}
+
+  users
+  {:team "UX West"
+   :api  #{metabase.users.core
+           metabase.users.init
+           metabase.users.models.user
+           metabase.users.models.user-parameter-value
+           metabase.users.schema
+           metabase.users.settings}
+   :uses #{analytics
+           api
+           batch-processing
+           channel
+           config
+           events
+           models
+           notification
+           permissions
+           premium-features
+           settings
+           setup
+           system
+           tenants
+           util
+           enterprise/advanced-permissions}}
+
+  users-rest
+  {:team "UX West"
+   :api  #{metabase.users-rest.api}
+   :uses #{api
+           appearance
+           auth-identity
+           collections
+           config
+           events
+           models
+           permissions
+           premium-features
+           request
+           sso
+           tenants
+           users
+           util
+           enterprise/advanced-permissions}}
+
+  util
+  {:team "DevEx"
+   :api  :any
+   :uses #{classloader
+           config
+           settings
+           system}}
+
+  version
+  {:team "UX West"
+   :api  #{metabase.version.core
+           metabase.version.init}
+   :uses #{config
+           settings
+           system
+           task
+           util}}
+
+  view-log
+  {:team "UX West"
+   :api  #{metabase.view-log.core
+           metabase.view-log.init}
+   :uses #{analytics
+           api
+           app-db
+           audit-app
+           batch-processing
+           events
+           models
+           premium-features
+           query-permissions
+           util}}
+
+  warehouse-schema
+  {:team "UX West"
+   :api  #{metabase.warehouse-schema.field
+           metabase.warehouse-schema.metadata-from-qp
+           metabase.warehouse-schema.metadata-queries
+           metabase.warehouse-schema.models.field
+           metabase.warehouse-schema.models.field-user-settings
+           metabase.warehouse-schema.models.field-values
+           metabase.warehouse-schema.models.table
+           metabase.warehouse-schema.table}
+   :uses #{analyze
+           api
+           app-db
+           audit-app
+           driver
+           lib
+           lib-be
+           models
+           parameters
+           permissions
+           premium-features
+           query-processor
+           remote-sync
+           search
+           util
+           warehouses}}
+
+  warehouse-schema-rest
+  {:team "UX West"
+   :api  #{metabase.warehouse-schema-rest.api}
+   :uses #{analytics
+           api
+           app-db
+           database-routing
+           driver
+           events
+           lib
+           models
+           parameters
+           permissions
+           premium-features
+           query-processor
+           request
+           sync
+           types
+           upload
+           util
+           warehouse-schema
+           xrays}}
+
+  warehouses
+  {:team "UX West"
+   :api  #{metabase.warehouses.core
+           metabase.warehouses.init
+           metabase.warehouses.models.database}
+   :uses #{analytics
+           api
+           app-db
+           audit-app
+           driver
+           lib
+           models
+           permissions
+           premium-features
+           search
+           secrets
+           settings
+           sync
+           util}}
+
+  warehouses-rest
+  {:team "UX West"
+   :api  #{metabase.warehouses-rest.api}
+   :uses #{analytics
+           api
+           app-db
+           classloader
+           collections
+           config
+           database-routing
+           driver
+           events
+           lib
+           lib-be
+           models
+           permissions
+           premium-features
+           queries
+           request
+           sample-data
+           secrets
+           settings
+           sync
+           upload
+           util
+           warehouse-schema
+           warehouses
+           enterprise/advanced-permissions}}
+
+  xrays
+  {:team "Querying"
+   :api  #{metabase.xrays.api
+           metabase.xrays.core
+           metabase.xrays.init}
+   :uses #{analyze
+           api
+           appearance
+           collections
+           dashboards
+           driver
+           legacy-mbql
+           lib
+           lib-be
+           models
+           queries
+           query-permissions
+           query-processor
+           segments
+           settings
+           util
+           warehouse-schema}}
+
+  enterprise/action-v2
+  {:team "Gadget"
+   :api  #{metabase-enterprise.action-v2.api
+           metabase-enterprise.action-v2.init}
+   :uses #{actions
+           api
+           driver
+           events
+           lib
+           models
+           query-processor
+           util
+           warehouse-schema}}
+
+  enterprise/advanced-config
+  {:team "UX West"
+   :api  #{metabase-enterprise.advanced-config.api.logs
+           metabase-enterprise.advanced-config.file
+           metabase-enterprise.advanced-config.init
+           metabase-enterprise.advanced-config.settings}
+   :uses #{api
+           api-keys
+           app-db
+           driver
+           permissions
+           premium-features
+           settings
+           setup
+           sync
+           users
+           util}}
+
+  enterprise/advanced-permissions
+  {:team "UX West"
+   :api  #{metabase-enterprise.advanced-permissions.api.routes
+           metabase-enterprise.advanced-permissions.common
+           metabase-enterprise.advanced-permissions.models.permissions.group-manager}
+   :uses #{api
+           audit-app
+           lib
+           permissions
+           premium-features
+           query-permissions
+           query-processor
+           remote-sync
+           util
+           warehouses
+           enterprise/impersonation}}
+
+  enterprise/agent-api
+  {:team "Metabot"
+   :api  #{metabase-enterprise.agent-api.api}
+   :uses #{api
+           auth-identity
+           query-processor
+           request
+           server
+           util
+           enterprise/metabot-v3}}
+
+  enterprise/ai-entity-analysis
+  {:team "Metabot"
+   :api  #{metabase-enterprise.ai-entity-analysis.api}
+   :uses #{api
+           premium-features
+           enterprise/metabot-v3}}
+
+  enterprise/ai-sql-fixer
+  {:team "Metabot"
+   :api  #{metabase-enterprise.ai-sql-fixer.api}
+   :uses #{api
+           driver
+           lib
+           lib-be
+           query-processor
+           util
+           enterprise/metabot-v3}}
+
+  enterprise/ai-sql-generation
+  {:team "Metabot"
+   :api  #{metabase-enterprise.ai-sql-generation.api}
+   :uses #{api
+           driver
+           util
+           enterprise/metabot-v3}}
+
+  enterprise/analytics
+  {:team "UX West"
+   :api  #{}
+   :uses #{driver
+           premium-features
+           enterprise/advanced-config
+           enterprise/scim
+           enterprise/semantic-search
+           enterprise/sso}}
+
+  enterprise/api
+  {:team "UX West"
+   :api  #{metabase-enterprise.api.core}
+   :uses #{api
+           premium-features
+           util}}
+
+  enterprise/api-routes
+  {:team "UX West"
+   :api  #{metabase-enterprise.api-routes.routes}
+   :uses :any}
+
+  enterprise/audit-app
+  {:team "UX West"
+   :api  #{metabase-enterprise.audit-app.api.routes
+           metabase-enterprise.audit-app.init}
+   :uses #{api
+           app-db
+           audit-app
+           classloader
+           config
+           driver
+           lib
+           models
+           permissions
+           plugins
+           premium-features
+           query-permissions
+           query-processor
+           settings
+           setup
+           startup
+           sync
+           users
+           util
+           enterprise/serialization}}
+
+  enterprise/auth-identity
+  {:team "UX West"
+   :api  #{}
+   :uses #{premium-features}}
+
+  enterprise/auth-provider
+  {:team "UX West"
+   :api  #{}
+   :uses #{premium-features
+           util}}
+
+  enterprise/billing
+  {:team "UX West"
+   :api  #{metabase-enterprise.billing.api.routes}
+   :uses #{api
+           premium-features
+           store-api
+           util}}
+
+  enterprise/cache
+  {:team "UX West"
+   :api  #{metabase-enterprise.cache.init}
+   :uses #{cache
+           premium-features
+           query-processor
+           task
+           util}}
+
+  enterprise/cloud-add-ons
+  {:team "Cloud"
+   :api  #{metabase-enterprise.cloud-add-ons.api}
+   :uses #{api
+           events
+           premium-features
+           store-api
+           util
+           enterprise/harbormaster}}
+
+  enterprise/cloud-proxy
+  {:team "Cloud"
+   :api  #{metabase-enterprise.cloud-proxy.api}
+   :uses #{api
+           premium-features
+           util
+           enterprise/harbormaster}}
+
+  enterprise/content-translation
+  {:team "UX West"
+   :api  #{metabase-enterprise.content-translation.routes}
+   :uses #{api
+           content-translation
+           embedding
+           premium-features
+           util
+           enterprise/api}}
+
+  enterprise/content-verification
+  {:team "UX West"
+   :api  #{metabase-enterprise.content-verification.api.routes}
+   :uses #{api
+           content-verification
+           util
+           enterprise/api}}
+
+  enterprise/core
+  {:team "DevEx"
+   :api  #{metabase-enterprise.core.init}
+   :uses :any}
+
+  enterprise/dashboard-subscription-filters
+  {:team "Querying"
+   :api  #{}
+   :uses #{premium-features}}
+
+  enterprise/data-studio
+  {:team "UX West"
+   :api  #{metabase-enterprise.data-studio.api}
+   :uses #{api
+           collections
+           events
+           models
+           permissions
+           premium-features
+           util}}
+
+  enterprise/database-replication
+  {:team "Cloud"
+   :api  #{metabase-enterprise.database-replication.api
+           metabase-enterprise.database-replication.init}
+   :uses #{api
+           driver
+           premium-features
+           settings
+           util
+           enterprise/harbormaster}}
+
+  enterprise/database-routing
+  {:team "UX West"
+   :api  #{metabase-enterprise.database-routing.api}
+   :uses #{api
+           config
+           database-routing
+           driver
+           events
+           lib
+           models
+           premium-features
+           query-processor
+           settings
+           util
+           warehouse-schema
+           warehouses}}
+
+  enterprise/dependencies
+  {:team "Querying"
+   :api  #{metabase-enterprise.dependencies.api
+           metabase-enterprise.dependencies.core
+           metabase-enterprise.dependencies.init}
+   :uses #{analyze
+           api
+           app-db
+           collections
+           config
+           documents
+           driver
+           events
+           graph
+           lib
+           lib-be
+           models
+           native-query-snippets
+           permissions
+           premium-features
+           queries
+           query-processor
+           request
+           revisions
+           settings
+           task
+           transforms
+           util}}
+
+  enterprise/email
+  {:team "UX West"
+   :api  #{metabase-enterprise.email.api}
+   :uses #{api
+           channel
+           permissions
+           premium-features
+           settings
+           util}}
+
+  enterprise/embedding-hub
+  {:team "Embedding"
+   :api  #{metabase-enterprise.embedding-hub.api}
+   :uses #{api
+           appearance
+           audit-app
+           embedding
+           permissions
+           premium-features
+           enterprise/sso}}
+
+  enterprise/gsheets
+  {:team "Cloud"
+   :api  #{metabase-enterprise.gsheets.api
+           metabase-enterprise.gsheets.init}
+   :uses #{analytics
+           api
+           premium-features
+           settings
+           util
+           enterprise/harbormaster}}
+
+  enterprise/harbormaster
+  {:team "Cloud"
+   :api  #{metabase-enterprise.harbormaster.client}
+   :uses #{api
+           store-api
+           util}}
+
+  enterprise/impersonation
+  {:team "Querying"
+   :api  #{metabase-enterprise.impersonation.api}
+   :uses #{api
+           audit-app
+           driver
+           lib
+           models
+           premium-features
+           query-processor
+           util
+           warehouse-schema
+           enterprise/sandbox}}
+
+  enterprise/internal-stats
+  {:team "UX West"
+   :api  #{}
+   :uses #{premium-features
+           settings}}
+
+  enterprise/library
+  {:team "UX West"
+   :api  #{metabase-enterprise.library.api}
+   :uses #{api
+           collections
+           premium-features}}
+
+  enterprise/llm
+  {:team "Metabot"
+   :api  #{metabase-enterprise.llm.api
+           metabase-enterprise.llm.init
+           metabase-enterprise.llm.settings}
+   :uses #{analytics
+           analyze
+           api
+           parameters
+           query-processor
+           settings
+           util}}
+
+  enterprise/metabot-v3
+  {:team    "Metabot"
+   :api     #{metabase-enterprise.metabot-v3.api
+              metabase-enterprise.metabot-v3.client
+              metabase-enterprise.metabot-v3.core
+              metabase-enterprise.metabot-v3.init
+              metabase-enterprise.metabot-v3.tools.api}
+   :friends #{enterprise/agent-api}
+   :uses    #{activity-feed
+              api
+              app-db
+              audit-app
+              collections
+              config
+              documents
+              driver
+              legacy-mbql
+              lib
+              lib-be
+              models
+              native-query-snippets
+              parameters
+              permissions
+              premium-features
+              pulse
+              query-processor
+              request
+              search
+              server
+              settings
+              sql-tools
+              store-api
+              sync
+              system
+              task
+              transforms
+              users
+              util
+              warehouses
+              enterprise/dependencies
+              enterprise/transforms-python}}
+
+  enterprise/permission-debug
+  {:team "UX West"
+   :api  #{metabase-enterprise.permission-debug.api}
+   :uses #{api
+           lib
+           models
+           permissions
+           query-processor
+           util}}
+
+  enterprise/premium-features
+  {:team "UX West"
+   :api  #{}
+   :uses #{premium-features
+           util}}
+
+  enterprise/remote-sync
+  {:team "UX West"
+   :api  #{metabase-enterprise.remote-sync.api
+           metabase-enterprise.remote-sync.core
+           metabase-enterprise.remote-sync.init}
+   :uses #{analytics
+           api
+           app-db
+           collections
+           events
+           models
+           premium-features
+           settings
+           task
+           task-history
+           util
+           enterprise/serialization
+           enterprise/transforms-python}}
+
+  enterprise/sandbox
+  {:team "UX West"
+   :api  #{metabase-enterprise.sandbox.api.routes
+           metabase-enterprise.sandbox.api.util}
+   :uses #{api
+           app-db
+           audit-app
+           driver
+           events
+           legacy-mbql
+           lib
+           models
+           permissions
+           premium-features
+           query-processor
+           request
+           tenants
+           users
+           util
+           warehouse-schema
+           warehouses
+           enterprise/api}}
+
+  enterprise/scim
+  {:team "UX West"
+   :api  #{metabase-enterprise.scim.core
+           metabase-enterprise.scim.init
+           metabase-enterprise.scim.routes}
+   :uses #{analytics
+           api
+           api-keys
+           models
+           permissions
+           server
+           settings
+           system
+           users
+           util
+           enterprise/serialization}}
+
+  enterprise/search
+  {:team "UX West"
+   :api  #{}
+   :uses #{premium-features
+           search}}
+
+  enterprise/semantic-search
+  {:team "Metabot"
+   :api  #{metabase-enterprise.semantic-search.api
+           metabase-enterprise.semantic-search.core
+           metabase-enterprise.semantic-search.init}
+   :uses #{activity-feed
+           analytics
+           api
+           app-db
+           config
+           connection-pool
+           models
+           permissions
+           premium-features
+           search
+           settings
+           task
+           util
+           enterprise/llm
+           enterprise/metabot-v3}}
+
+  enterprise/serialization
+  {:team "Querying"
+   :api  #{metabase-enterprise.serialization.api
+           metabase-enterprise.serialization.cmd
+           metabase-enterprise.serialization.core
+           metabase-enterprise.serialization.v2.backfill-ids}
+   :uses #{analytics
+           api
+           app-db
+           appearance
+           collections
+           config
+           events
+           logger
+           models
+           plugins
+           premium-features
+           search
+           setup
+           util}}
+
+  enterprise/snippet-collections
+  {:team "Querying"
+   :api  #{}
+   :uses #{models
+           native-query-snippets
+           permissions
+           premium-features
+           remote-sync
+           util}}
+
+  enterprise/sso
+  {:team "UX West"
+   :api  #{metabase-enterprise.sso.api.routes
+           metabase-enterprise.sso.init
+           metabase-enterprise.sso.settings}
+   :uses #{api
+           appearance
+           auth-identity
+           embedding
+           premium-features
+           request
+           session
+           settings
+           sso
+           system
+           util
+           enterprise/scim}}
+
+  enterprise/stale
+  {:team "UX West"
+   :api  #{metabase-enterprise.stale.api
+           metabase-enterprise.stale.init}
+   :uses #{analytics
+           api
+           collections
+           embedding
+           premium-features
+           queries
+           request
+           settings
+           util}}
+
+  enterprise/support-access-grants
+  {:team "UX West"
+   :api  #{metabase-enterprise.support-access-grants.api
+           metabase-enterprise.support-access-grants.init}
+   :uses #{api
+           auth-identity
+           events
+           models
+           request
+           settings
+           system
+           util}}
+
+  enterprise/tenants
+  {:team "Admin Webapp"
+   :api  #{metabase-enterprise.tenants.api}
+   :uses #{api
+           audit-app
+           auth-identity
+           collections
+           events
+           models
+           permissions
+           premium-features
+           request
+           settings
+           util}}
+
+  enterprise/transforms
+  {:team "Querying"
+   :api  #{}
+   :uses #{premium-features}}
+
+  enterprise/transforms-python
+  {:team "Querying"
+   :api  #{metabase-enterprise.transforms-python.api
+           metabase-enterprise.transforms-python.core
+           metabase-enterprise.transforms-python.init
+           metabase-enterprise.transforms-python.python-runner}
+   :uses #{analytics
+           api
+           app-db
+           config
+           driver
+           events
+           lib
+           lib-be
+           models
+           permissions
+           query-processor
+           settings
+           transforms
+           util}}
+
+  enterprise/upload-management
+  {:team "UX West"
+   :api  #{metabase-enterprise.upload-management.api}
+   :uses #{api
+           models
+           premium-features
+           upload
+           util}}
+
+  enterprise/workspaces
+  {:team "Metabot"
+   :api  #{metabase-enterprise.workspaces.api
+           metabase-enterprise.workspaces.init}
+   :uses #{api
+           api-keys
+           app-db
+           config
+           database-routing
+           driver
+           events
+           lib
+           lib-be
+           models
+           queries
+           ;; NOTE: we will remove this once we get "pure transforms" module.
+           query-processor
+           request
+           settings
+           sql-tools
+           system
+           transforms
+           util
+           enterprise/transforms-python}}}
+
+ ;; namespaces matching these patterns (with `re-find`) are excluded from the module linter. Since regex literals
+ ;; aren't allowed in EDN just used the `(str <regex>)` version i.e. two slashes instead of one.
+ ;;
+ ;; this is mostly intended for excluding test namespaces or those rare 'glue' namespaces that glue multiple modules
+ ;; together, e.g. `metabase.lib-be.metadata.jvm`.
+ :linters
+ {:metabase/modules
+  {:ignored-namespace-patterns
+   #{"-test$"                               ; anything ending in `-test`
+     "test[-.]util"                         ; anything that contains `test.util` or `test-util`
+     "test[-.]dataset"                      ; anything that contains `test.dataset` or `test-dataset`
+     "test\\.impl"                          ; anything that contains `test.impl`
+     "test-setup"                           ; anything that contains `test-setup`
+     "^metabase(?:-enterprise)?\\.test"}}}} ; anything starting with `metabase.test` or `metabase-enterprise.test`
+
+;; !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+;; !!                                                                                       !!
+;; !!  PRO TIP! Run the tests in [[metabase.core.modules-test]] when you change this file!  !!
+;; !!                                                                                       !!
+;; !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!


### PR DESCRIPTION
Closes EMB-1412

Prototype for charts in embedded metabot. Slack-bot style embedding of a chart in embedded Metabot in each responses. Similar to charts in Metabot agent responses in Slack.

This is built on top of the hackathon project for custom UI for embedded metabot.