### PR TITLE
Replace circleci Docker images with the official DB images

### DIFF
--- a/.github/workflows/app-db.yml
+++ b/.github/workflows/app-db.yml
@@ -22,12 +22,12 @@ jobs:
         version:
           - name: MariaDB 10.6
             junit-name: be-tests-mariadb-10-6-ee
-            image: cimg/mariadb:10.6
+            image: mariadb:10.6
             env:
               enable-ssl-tests: 'false'
           - name: MariaDB Latest
             junit-name: be-tests-mariadb-latest-ee
-            image: cimg/mariadb:latest
+            image: mariadb:latest
             env:
               enable-ssl-tests: 'false'
         job:
@@ -58,7 +58,7 @@ jobs:
           - "3306:3306"
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: true
-          MYSQL_DATABASE: circle_test
+          MYSQL_DATABASE: mb_test
     env:
       # Only run old migrations tests on pushes to master or release branches. All other branches should skip tests
       # with the tag `mb/old-migrations-test`. `__ADDITIONAL_EXCLUDED_TAG__` is not used anywhere outside of splicing
@@ -81,7 +81,7 @@ jobs:
       MB_DB_TYPE: mysql
       MB_DB_HOST: localhost
       MB_DB_PORT: 3306
-      MB_DB_DBNAME: circle_test
+      MB_DB_DBNAME: mb_test
       MB_DB_USER: root
       MB_MYSQL_TEST_USER: root
       #
@@ -136,7 +136,7 @@ jobs:
         version:
           - name: MySQL 8.4
             junit-name: be-tests-mysql-8-4-ee
-            image: cimg/mysql:8.4
+            image: mysql:8.4
             env:
               enable-ssl-tests: 'false'
               enable-aws-iam-tests: 'false'
@@ -174,7 +174,7 @@ jobs:
           - "3306:3306"
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: true
-          MYSQL_DATABASE: circle_test
+          MYSQL_DATABASE: mb_test
     env:
       # Only run old migrations tests on pushes to master or release branches. All other branches should skip tests
       # with the tag `mb/old-migrations-test`. `__ADDITIONAL_EXCLUDED_TAG__` is not used anywhere outside of splicing
@@ -197,7 +197,7 @@ jobs:
       MB_DB_TYPE: mysql
       MB_DB_HOST: localhost
       MB_DB_PORT: 3306
-      MB_DB_DBNAME: circle_test
+      MB_DB_DBNAME: mb_test
       MB_DB_USER: root
       MB_MYSQL_TEST_USER: root
       #

--- a/.github/workflows/app-db.yml
+++ b/.github/workflows/app-db.yml
@@ -22,12 +22,12 @@ jobs:
         version:
           - name: MariaDB 10.6
             junit-name: be-tests-mariadb-10-6-ee
-            image: circleci/mariadb:10.6
+            image: cimg/mariadb:10.6
             env:
               enable-ssl-tests: 'false'
           - name: MariaDB Latest
             junit-name: be-tests-mariadb-latest-ee
-            image: circleci/mariadb:latest
+            image: cimg/mariadb:latest
             env:
               enable-ssl-tests: 'false'
         job:

--- a/.github/workflows/app-db.yml
+++ b/.github/workflows/app-db.yml
@@ -22,7 +22,8 @@ jobs:
         version:
           - name: MariaDB 10.6
             junit-name: be-tests-mariadb-10-6-ee
-            image: mariadb:10.6
+            # FIXME: Use the official image when DEV-1668 gets resolved
+            image: circleci/mariadb:10.6
             env:
               enable-ssl-tests: 'false'
           - name: MariaDB Latest

--- a/.github/workflows/cross-branch-migrations.yml
+++ b/.github/workflows/cross-branch-migrations.yml
@@ -46,16 +46,16 @@ jobs:
       MB_DB_TYPE: postgres
       MB_DB_PORT: 5432
       MB_DB_HOST: localhost
-      MB_DB_DBNAME: circle_test
-      MB_DB_USER: circle_test
+      MB_DB_DBNAME: mb_test
+      MB_DB_USER: mb_test
     services:
       postgres:
         image: postgres:14-alpine
         ports:
           - "5432:5432"
         env:
-          POSTGRES_USER: circle_test
-          POSTGRES_DB: circle_test
+          POSTGRES_USER: mb_test
+          POSTGRES_DB: mb_test
           POSTGRES_HOST_AUTH_METHOD: trust
     steps:
       - uses: actions/checkout@v4
@@ -72,16 +72,16 @@ jobs:
       MB_DB_TYPE: postgres
       MB_DB_PORT: 5432
       MB_DB_HOST: localhost
-      MB_DB_DBNAME: circle_test
-      MB_DB_USER: circle_test
+      MB_DB_DBNAME: mb_test
+      MB_DB_USER: mb_test
     services:
       postgres:
-        image: cimg/postgres:latest
+        image: postgres:latest
         ports:
           - "5432:5432"
         env:
-          POSTGRES_USER: circle_test
-          POSTGRES_DB: circle_test
+          POSTGRES_USER: mb_test
+          POSTGRES_DB: mb_test
           POSTGRES_HOST_AUTH_METHOD: trust
     steps:
       - uses: actions/checkout@v4
@@ -98,13 +98,16 @@ jobs:
       MB_DB_TYPE: mysql
       MB_DB_HOST: localhost
       MB_DB_PORT: 3306
-      MB_DB_DBNAME: circle_test
+      MB_DB_DBNAME: mb_test
       MB_DB_USER: root
     services:
       mysql:
-        image: cimg/mysql:8.4
+        image: mysql:8.4
         ports:
           - "3306:3306"
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: true
+          MYSQL_DATABASE: mb_test
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/cross-branch-migration-test
@@ -120,7 +123,7 @@ jobs:
       MB_DB_TYPE: mysql
       MB_DB_HOST: localhost
       MB_DB_PORT: 3306
-      MB_DB_DBNAME: circle_test
+      MB_DB_DBNAME: mb_test
       MB_DB_USER: root
       MB_MYSQL_TEST_USER: root
     services:
@@ -128,7 +131,7 @@ jobs:
         image: mysql:latest
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: true
-          MYSQL_DATABASE: circle_test
+          MYSQL_DATABASE: mb_test
         ports:
           - "3306:3306"
     steps:
@@ -146,13 +149,16 @@ jobs:
       MB_DB_TYPE: mysql
       MB_DB_HOST: localhost
       MB_DB_PORT: 3306
-      MB_DB_DBNAME: circle_test
+      MB_DB_DBNAME: mb_test
       MB_DB_USER: root
     services:
       mariadb:
-        image: cimg/mariadb:10.6
+        image: mariadb:10.6
         ports:
           - "3306:3306"
+        env:
+          MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: true
+          MARIADB_DATABASE: mb_test
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/cross-branch-migration-test
@@ -168,13 +174,16 @@ jobs:
       MB_DB_TYPE: mysql
       MB_DB_HOST: localhost
       MB_DB_PORT: 3306
-      MB_DB_DBNAME: circle_test
+      MB_DB_DBNAME: mb_test
       MB_DB_USER: root
     services:
       mariadb:
-        image: cimg/mariadb:latest
+        image: mariadb:latest
         ports:
           - "3306:3306"
+        env:
+          MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: true
+          MARIADB_DATABASE: mb_test
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/cross-branch-migration-test

--- a/.github/workflows/cross-branch-migrations.yml
+++ b/.github/workflows/cross-branch-migrations.yml
@@ -76,7 +76,7 @@ jobs:
       MB_DB_USER: circle_test
     services:
       postgres:
-        image: circleci/postgres:latest
+        image: cimg/postgres:latest
         ports:
           - "5432:5432"
         env:
@@ -150,7 +150,7 @@ jobs:
       MB_DB_USER: root
     services:
       mariadb:
-        image: circleci/mariadb:10.6
+        image: cimg/mariadb:10.6
         ports:
           - "3306:3306"
     steps:
@@ -172,7 +172,7 @@ jobs:
       MB_DB_USER: root
     services:
       mariadb:
-        image: circleci/mariadb:latest
+        image: cimg/mariadb:latest
         ports:
           - "3306:3306"
     steps:

--- a/.github/workflows/drivers-stress-test.yml
+++ b/.github/workflows/drivers-stress-test.yml
@@ -119,14 +119,17 @@ jobs:
       MB_DB_TYPE: mysql
       MB_DB_HOST: localhost
       MB_DB_PORT: 3306
-      MB_DB_DBNAME: circle_test
+      MB_DB_DBNAME: mb_test
       MB_DB_USER: root
       MB_MYSQL_TEST_USER: root
     services:
       mariadb:
-        image: cimg/mariadb:10.6
+        image: mariadb:10.6
         ports:
           - "3306:3306"
+        env:
+          MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: true
+          MARIADB_DATABASE: mb_test
     steps:
     - uses: actions/checkout@v4
     - name: Test MariaDB driver (10.6)
@@ -145,14 +148,17 @@ jobs:
       MB_DB_TYPE: mysql
       MB_DB_HOST: localhost
       MB_DB_PORT: 3306
-      MB_DB_DBNAME: circle_test
+      MB_DB_DBNAME: mb_test
       MB_DB_USER: root
       MB_MYSQL_TEST_USER: root
     services:
       mariadb:
-        image: cimg/mariadb:latest
+        image: mariadb:latest
         ports:
           - "3306:3306"
+        env:
+          MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: true
+          MARIADB_DATABASE: mb_test
     steps:
     - uses: actions/checkout@v4
     - name: Test MariaDB driver (latest)
@@ -284,7 +290,7 @@ jobs:
       MB_MONGO_TEST_PASSWORD: metasample123
     services:
       mongodb:
-        image: cimg/mongo:latest
+        image: mongo:latest
         ports:
           - "27017:27017"
         env:
@@ -308,14 +314,17 @@ jobs:
       MB_DB_TYPE: mysql
       MB_DB_HOST: localhost
       MB_DB_PORT: 3306
-      MB_DB_DBNAME: circle_test
+      MB_DB_DBNAME: mb_test
       MB_DB_USER: root
       MB_MYSQL_TEST_USER: root
     services:
       mysql:
-        image: cimg/mysql:8.4
+        image: mysql:8.4
         ports:
           - "3306:3306"
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: true
+          MYSQL_DATABASE: mb_test
     steps:
     - uses: actions/checkout@v4
     - name: Test MySQL driver (8.4)
@@ -334,7 +343,7 @@ jobs:
       MB_DB_TYPE: mysql
       MB_DB_HOST: localhost
       MB_DB_PORT: 3306
-      MB_DB_DBNAME: circle_test
+      MB_DB_DBNAME: mb_test
       MB_DB_USER: root
       MB_MYSQL_TEST_USER: root
       # set up env vars for something named "MYSQL_SSL" to run MySQL SSL tests verifying connectivity with PEM cert
@@ -463,20 +472,20 @@ jobs:
       MB_DB_TYPE: postgres
       MB_DB_PORT: 5432
       MB_DB_HOST: localhost
-      MB_DB_DBNAME: circle_test
-      MB_DB_USER: circle_test
-      MB_POSTGRESQL_TEST_USER: circle_test
+      MB_DB_DBNAME: mb_test
+      MB_DB_USER: mb_test
+      MB_POSTGRESQL_TEST_USER: mb_test
       MB_POSTGRES_SSL_TEST_SSL: true
       MB_POSTGRES_SSL_TEST_SSL_MODE: verify-full
       MB_POSTGRES_SSL_TEST_SSL_ROOT_CERT_PATH: 'test-resources/certificates/us-east-2-bundle.pem'
     services:
       postgres:
-        image: cimg/postgres:latest
+        image: postgres:latest
         ports:
           - "5432:5432"
         env:
-          POSTGRES_USER: circle_test
-          POSTGRES_DB: circle_test
+          POSTGRES_USER: mb_test
+          POSTGRES_DB: mb_test
           POSTGRES_HOST_AUTH_METHOD: trust
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/drivers-stress-test.yml
+++ b/.github/workflows/drivers-stress-test.yml
@@ -124,7 +124,7 @@ jobs:
       MB_MYSQL_TEST_USER: root
     services:
       mariadb:
-        image: circleci/mariadb:10.6
+        image: cimg/mariadb:10.6
         ports:
           - "3306:3306"
     steps:
@@ -150,7 +150,7 @@ jobs:
       MB_MYSQL_TEST_USER: root
     services:
       mariadb:
-        image: circleci/mariadb:latest
+        image: cimg/mariadb:latest
         ports:
           - "3306:3306"
     steps:
@@ -284,7 +284,7 @@ jobs:
       MB_MONGO_TEST_PASSWORD: metasample123
     services:
       mongodb:
-        image: circleci/mongo:latest
+        image: cimg/mongo:latest
         ports:
           - "27017:27017"
         env:
@@ -471,7 +471,7 @@ jobs:
       MB_POSTGRES_SSL_TEST_SSL_ROOT_CERT_PATH: 'test-resources/certificates/us-east-2-bundle.pem'
     services:
       postgres:
-        image: circleci/postgres:latest
+        image: cimg/postgres:latest
         ports:
           - "5432:5432"
         env:

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -563,13 +563,13 @@ jobs:
         version:
           - name: MariaDB 10.6
             junit-name: be-tests-mariadb-10-6-ee
-            image: cimg/mariadb:10.6
+            image: mariadb:10.6
             env:
               enable-ssl-tests: 'false'
               enable-aws-iam-tests: 'false'
           - name: MariaDB Latest
             junit-name: be-tests-mariadb-latest-ee
-            image: cimg/mariadb:latest
+            image: mariadb:latest
             env:
               enable-ssl-tests: 'false'
               enable-aws-iam-tests: 'false'
@@ -602,7 +602,7 @@ jobs:
           - "3306:3306"
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: true
-          MYSQL_DATABASE: circle_test
+          MYSQL_DATABASE: mb_test
     env:
       # Only run old migrations tests on pushes to master or release branches. All other branches should skip tests
       # with the tag `mb/old-migrations-test`. `__ADDITIONAL_EXCLUDED_TAG__` is not used anywhere outside of splicing
@@ -625,7 +625,7 @@ jobs:
       MB_DB_TYPE: mysql
       MB_DB_HOST: localhost
       MB_DB_PORT: 3306
-      MB_DB_DBNAME: circle_test
+      MB_DB_DBNAME: mb_test
       MB_DB_USER: root
       MB_MYSQL_TEST_USER: root
       #

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -563,13 +563,13 @@ jobs:
         version:
           - name: MariaDB 10.6
             junit-name: be-tests-mariadb-10-6-ee
-            image: circleci/mariadb:10.6
+            image: cimg/mariadb:10.6
             env:
               enable-ssl-tests: 'false'
               enable-aws-iam-tests: 'false'
           - name: MariaDB Latest
             junit-name: be-tests-mariadb-latest-ee
-            image: circleci/mariadb:latest
+            image: cimg/mariadb:latest
             env:
               enable-ssl-tests: 'false'
               enable-aws-iam-tests: 'false'

--- a/.github/workflows/semantic-search.yml
+++ b/.github/workflows/semantic-search.yml
@@ -77,11 +77,11 @@ jobs:
         version:
           - name: MariaDB 10.6 with pgvector pg17
             junit-name: semantic-search-tests-mariadb-10-6
-            mariadb-image: cimg/mariadb:10.6
+            mariadb-image: mariadb:10.6
             pgvector-image: pgvector/pgvector:pg17
           - name: MariaDB Latest with pgvector pg17
             junit-name: semantic-search-tests-mariadb-latest
-            mariadb-image: cimg/mariadb:latest
+            mariadb-image: mariadb:latest
             pgvector-image: pgvector/pgvector:pg17
         job:
           - name: Semantic Search Tests
@@ -105,14 +105,14 @@ jobs:
           - "3306:3306"
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: true
-          MYSQL_DATABASE: circle_test
+          MYSQL_DATABASE: mb_test
     env:
       CI: 'true'
       DRIVERS: mysql
       MB_DB_TYPE: mysql
       MB_DB_HOST: localhost
       MB_DB_PORT: 3306
-      MB_DB_DBNAME: circle_test
+      MB_DB_DBNAME: mb_test
       MB_DB_USER: root
       MB_MYSQL_TEST_USER: root
       MB_PGVECTOR_DB_URL: 'jdbc:postgres://localhost:5432/mb_semantic_search?user=postgres&password=postgres'
@@ -151,7 +151,7 @@ jobs:
         version:
           - name: MySQL 8.4 with pgvector pg17
             junit-name: semantic-search-tests-mysql-8-4
-            mysql-image: cimg/mysql:8.4
+            mysql-image: mysql:8.4
             pgvector-image: pgvector/pgvector:pg17
           - name: MySQL Latest with pgvector pg17
             junit-name: semantic-search-tests-mysql-latest
@@ -179,14 +179,14 @@ jobs:
           - "3306:3306"
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: true
-          MYSQL_DATABASE: circle_test
+          MYSQL_DATABASE: mb_test
     env:
       CI: 'true'
       DRIVERS: mysql
       MB_DB_TYPE: mysql
       MB_DB_HOST: localhost
       MB_DB_PORT: 3306
-      MB_DB_DBNAME: circle_test
+      MB_DB_DBNAME: mb_test
       MB_DB_USER: root
       MB_MYSQL_TEST_USER: root
       MB_PGVECTOR_DB_URL: 'jdbc:postgres://localhost:5432/mb_semantic_search?user=postgres&password=postgres'

--- a/.github/workflows/semantic-search.yml
+++ b/.github/workflows/semantic-search.yml
@@ -77,11 +77,11 @@ jobs:
         version:
           - name: MariaDB 10.6 with pgvector pg17
             junit-name: semantic-search-tests-mariadb-10-6
-            mariadb-image: circleci/mariadb:10.6
+            mariadb-image: cimg/mariadb:10.6
             pgvector-image: pgvector/pgvector:pg17
           - name: MariaDB Latest with pgvector pg17
             junit-name: semantic-search-tests-mariadb-latest
-            mariadb-image: circleci/mariadb:latest
+            mariadb-image: cimg/mariadb:latest
             pgvector-image: pgvector/pgvector:pg17
         job:
           - name: Semantic Search Tests

--- a/.github/workflows/transforms-python-stress-test.yml
+++ b/.github/workflows/transforms-python-stress-test.yml
@@ -197,14 +197,14 @@ jobs:
           - "3306:3306"
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: true
-          MYSQL_DATABASE: circle_test
+          MYSQL_DATABASE: mb_test
     env:
       CI: 'true'
       DRIVERS: mysql
       MB_DB_TYPE: mysql
       MB_DB_HOST: localhost
       MB_DB_PORT: 3306
-      MB_DB_DBNAME: circle_test
+      MB_DB_DBNAME: mb_test
       MB_DB_USER: root
       MB_MYSQL_TEST_USER: root
     name: MySQL Transforms

--- a/docs/developers-guide/drivers/driver-tests.md
+++ b/docs/developers-guide/drivers/driver-tests.md
@@ -220,7 +220,7 @@ be-tests-postgres-latest-ee:
     MB_POSTGRES_SSL_TEST_SSL_ROOT_CERT_PATH: "test-resources/certificates/us-east-2-bundle.pem"
   services:
     postgres:
-      image: circleci/postgres:latest
+      image: cimg/postgres:latest
       ports:
         - "5432:5432"
       env:

--- a/docs/developers-guide/drivers/driver-tests.md
+++ b/docs/developers-guide/drivers/driver-tests.md
@@ -212,20 +212,20 @@ be-tests-postgres-latest-ee:
     MB_DB_TYPE: postgres
     MB_DB_PORT: 5432
     MB_DB_HOST: localhost
-    MB_DB_DBNAME: circle_test
-    MB_DB_USER: circle_test
-    MB_POSTGRESQL_TEST_USER: circle_test
+    MB_DB_DBNAME: mb_test
+    MB_DB_USER: mb_test
+    MB_POSTGRESQL_TEST_USER: mb_test
     MB_POSTGRES_SSL_TEST_SSL: true
     MB_POSTGRES_SSL_TEST_SSL_MODE: verify-full
     MB_POSTGRES_SSL_TEST_SSL_ROOT_CERT_PATH: "test-resources/certificates/us-east-2-bundle.pem"
   services:
     postgres:
-      image: cimg/postgres:latest
+      image: postgres:latest
       ports:
         - "5432:5432"
       env:
-        POSTGRES_USER: circle_test
-        POSTGRES_DB: circle_test
+        POSTGRES_USER: mb_test
+        POSTGRES_DB: mb_test
         POSTGRES_HOST_AUTH_METHOD: trust
   steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Resolves DEV-1667

- https://circleci.com/developer/images
- https://circleci.com/developer/images/image/cimg/postgres

> [!NOTE]
> This also removes all `circle_` references and replaces them with `mb_`. That prefix was from the days when we used circleci.