### PR TITLE
Fix token check errors on startup

### DIFF
--- a/src/metabase/premium_features/token_check.clj
+++ b/src/metabase/premium_features/token_check.clj
@@ -422,47 +422,47 @@
                 result))]
       (reify TokenChecker
         (-check-token [_ token]
-          (let [token-hash  (hash-token token)
-                local-entry (get @local-cache token-hash)
-                db-row      (read-cache-from-db token-hash)
-                now         (t/instant)]
-            (if (and local-entry
-                     db-row
-                     (= (:result-hash local-entry) (:token_status_hash db-row)))
-              ;; Local cache matches DB hash — check TTLs
-              (let [age-start (:updated-at local-entry)]
-                (cond
-                  ;; Fresh (< soft-ttl): return local value
-                  (t/before? now (t/plus age-start soft-ttl))
-                  (:result local-entry)
+          (if-not (app-db/db-is-set-up?)
+            (-check-token token-checker token)
+            (let [token-hash  (hash-token token)
+                  local-entry (get @local-cache token-hash)
+                  db-row      (read-cache-from-db token-hash)
+                  now         (t/instant)]
+              (if (and local-entry
+                       db-row
+                       (= (:result-hash local-entry) (:token_status_hash db-row)))
+                ;; Local cache matches DB hash — check TTLs
+                (let [age-start (:updated-at local-entry)]
+                  (cond
+                    ;; Fresh (< soft-ttl): return local value
+                    (t/before? now (t/plus age-start soft-ttl))
+                    (:result local-entry)
 
-                  ;; Stale (soft..hard): return local + async refresh
-                  (t/before? now (t/plus age-start hard-ttl))
-                  (do
-                    (when (compare-and-set! refresh-in-progress? false true)
-                      (future
-                        (try
-                          (do-refresh! token token-hash)
-                          (catch Exception e
-                            (log/error e "Background premium features refresh failed"))
-                          (finally
-                            (reset! refresh-in-progress? false)
-                            (when-let [after *testing-only-call-after-refresh*]
-                              (after))))))
-                    (:result local-entry))
+                    ;; Stale (soft..hard): return local + async refresh
+                    (t/before? now (t/plus age-start hard-ttl))
+                    (do
+                      (when (compare-and-set! refresh-in-progress? false true)
+                        (future
+                          (try
+                            (do-refresh! token token-hash)
+                            (catch Exception e
+                              (log/error e "Background premium features refresh failed"))
+                            (finally
+                              (reset! refresh-in-progress? false)
+                              (when-let [after *testing-only-call-after-refresh*]
+                                (after))))))
+                      (:result local-entry))
 
-                  ;; Expired (> hard-ttl): synchronous refresh
-                  :else
-                  (do-refresh! token token-hash)))
+                    ;; Expired (> hard-ttl): synchronous refresh
+                    :else
+                    (do-refresh! token token-hash)))
 
-              ;; No local cache, no DB row, or hash mismatch: synchronous fetch
-              (do-refresh! token token-hash))))
+                ;; No local cache, no DB row, or hash mismatch: synchronous fetch
+                (do-refresh! token token-hash)))))
         (-clear-cache! [_]
           (reset! local-cache {})
-          (try
-            (clear-db-cache!)
-            (catch Exception e
-              (log/warn e "Failed to clear premium features cache table")))
+          (when (app-db/db-is-set-up?)
+            (clear-db-cache!))
           (-clear-cache! token-checker))))))
 
 (defn local-cached-token-checker

--- a/test/metabase/premium_features/token_check_test.clj
+++ b/test/metabase/premium_features/token_check_test.clj
@@ -609,3 +609,23 @@
           (is (nil? (t2/select-one :model/PremiumFeaturesCache :token_hash token-hash))))
         (finally
           (token-check/-clear-cache! checker))))))
+
+(deftest db-hash-aware-token-checker-db-not-set-up-test
+  (testing "When DB is not set up, delegates directly to inner checker without touching the DB"
+    (let [call-count    (atom 0)
+          good-response {:valid true :status "OK" :features ["sandboxes"]}
+          checker       (make-db-hash-aware-checker
+                         (fn [_token]
+                           (swap! call-count inc)
+                           good-response)
+                         {:soft-ttl (t/minutes 1) :hard-ttl (t/minutes 2)})
+          token         (tu/random-token)
+          bomb          (fn [& _] (throw (ex-info "DB should not be touched" {})))]
+      (with-redefs [mdb/db-is-set-up? (constantly false)
+                    token-check/read-cache-from-db bomb
+                    token-check/write-cache-to-db! bomb
+                    token-check/clear-db-cache! bomb]
+        (is (= good-response (token-check/-check-token checker token)))
+        (is (= 1 @call-count) "inner checker was called exactly once")
+        ;; clear-cache! should also skip DB without error
+        (token-check/-clear-cache! checker)))))


### PR DESCRIPTION
During startup, the database isn't migrated yet, so we can't check the
token hash.

If the database hasn't been started yet, skip checking the token hash in
the DB and just delegate to the lower-level checker that actually hits
the store.

Should fix the token check errors in  #70761  but note that I'm not entirely confident that this was what caused the failure to upgrade.