### PR TITLE
Fix incorrect docstrings and copy-paste errors in settings and tools

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/llm/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/llm/settings.clj
@@ -28,7 +28,7 @@
   :doc false)
 
 (defsetting ee-anthropic-api-base-url
-  (deferred-tru "The OpenAI embeddings base URL used in Metabase Enterprise.")
+  (deferred-tru "The Anthropic API base URL used in Metabase Enterprise.")
   :encryption :no
   :visibility :settings-manager
   :default "https://api.anthropic.com"

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/config.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/config.clj
@@ -30,7 +30,7 @@
 (defn normalize-metabot-id
   "Return the primary key for the metabot instance identified by `metabot-id`.
 
-  Returns nil, no entry can be found.
+  Returns nil if no entry can be found.
   The provided ID can be a UUID from [[metabot-config]] or an entity_id of a Metabot instance."
   [metabot-id]
   (t2/select-one-pk :model/Metabot :entity_id (get-in metabot-config [metabot-id :entity-id] metabot-id)))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/settings.clj
@@ -4,7 +4,7 @@
    [metabase.util.i18n :refer [deferred-tru]]))
 
 (defsetting ai-service-base-url
-  (deferred-tru "URL for the a AI Service")
+  (deferred-tru "URL for the AI Service")
   :type       :string
   :encryption :no
   :default    "http://localhost:8000"

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/api.clj
@@ -887,7 +887,7 @@
    [:map {:encode/tool-api-request #(update-keys % metabot-v3.u/safe->kebab-case-en)}]])
 
 (deftool "/filter-records"
-  "Construct a query from a metric."
+  "Apply filters to records from a data source (query, report, or table)."
   {:args-schema   ::filter-records-arguments
    :result-schema ::filtering-result
    :handler       metabot-v3.tools.filters/filter-records})

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/tools/util.clj
@@ -175,7 +175,7 @@
       api/read-check))
 
 (defn card-query
-  "Return a query based on the model with ID `model-id`."
+  "Return a query based on the card with ID `card-id`."
   [card-id]
   (when-let [card (get-card card-id)]
     (let [mp (lib-be/application-database-metadata-provider (:database_id card))]
@@ -184,7 +184,7 @@
                       (#{:question} (:type card)) (get :dataset-query))))))
 
 (defn metric-query
-  "Return a query based on the model with ID `model-id`."
+  "Return a query based on the metric with ID `metric-id`."
   [metric-id]
   (when-let [card (get-card metric-id)]
     (let [mp (lib-be/application-database-metadata-provider (:database_id card))]


### PR DESCRIPTION
- settings.clj: Remove duplicate article ("the a AI Service" → "the AI Service")
- llm/settings.clj: Fix ee-anthropic-api-base-url description (said "OpenAI" instead of "Anthropic")
- config.clj: Fix grammar ("Returns nil, no entry" → "Returns nil if no entry")
- tools/util.clj: Fix card-query and metric-query docstrings (both said "model with ID `model-id`")
- tools/api.clj: Fix /filter-records docstring (copy-pasted from /query-metric)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
