### PR TITLE
feat(PivotTable) : Add URL and Click Behavior support to Pivot Tables…

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.tsx
@@ -480,6 +480,8 @@ const PivotTableInner = forwardRef<HTMLDivElement, VisualizationProps>(
                             newWidth,
                           )
                         }
+                        settings={settings}
+                        columns={columnsWithoutPivotGroup}
                       />
                     )}
                     cellSizeAndPositionGetter={({ index }) =>
@@ -515,6 +517,7 @@ const PivotTableInner = forwardRef<HTMLDivElement, VisualizationProps>(
                               }
                               settings={settings}
                               getCellClickHandler={getCellClickHandler}
+                              columns={columnsWithoutPivotGroup}
                             />
                           )}
                           cellSizeAndPositionGetter={({ index }) =>
@@ -576,6 +579,8 @@ const PivotTableInner = forwardRef<HTMLDivElement, VisualizationProps>(
                                   valueIndexes,
                                   columnIndex,
                                 )}
+                                settings={settings}
+                                columns={columnsWithoutPivotGroup}
                               />
                             );
                           }}

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTableCell.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTableCell.tsx
@@ -5,6 +5,7 @@ import { useEffect, useId, useRef } from "react";
 import { Ellipsified } from "metabase/common/components/Ellipsified";
 import CS from "metabase/css/core/index.css";
 import { useTranslateContent } from "metabase/i18n/hooks";
+import { formatUrl } from "metabase/lib/formatting/url";
 import type { VisualizationSettings } from "metabase-types/api";
 
 import { PivotTableCell, ResizeHandle } from "./PivotTable.styled";
@@ -26,6 +27,7 @@ interface CellProps {
   onClick?: ((e: React.MouseEvent) => void) | undefined;
   onResize?: (newWidth: number) => void;
   showTooltip?: boolean;
+  isDashboardLink?: boolean;
 }
 
 interface ResizableHandleProps {
@@ -88,8 +90,22 @@ export function Cell({
   onClick,
   onResize,
   showTooltip = true,
+  isDashboardLink = false,
 }: CellProps) {
   const cellId = useId();
+
+  const displayValue = isDashboardLink ? (
+    <span
+      className={cx(CS.textBrand)}
+      style={{ cursor: "pointer", textDecoration: "none" }}
+      onMouseEnter={(e) => (e.currentTarget.style.textDecoration = "underline")}
+      onMouseLeave={(e) => (e.currentTarget.style.textDecoration = "none")}
+    >
+      {value}
+    </span>
+  ) : (
+    value
+  );
 
   return (
     <PivotTableCell
@@ -116,7 +132,7 @@ export function Cell({
             [CS.justifyEnd]: isBody,
           })}
         >
-          <Ellipsified showTooltip={showTooltip}>{value}</Ellipsified>
+          <Ellipsified showTooltip={showTooltip}>{displayValue}</Ellipsified>
           {icon && <div className={CS.pl1}>{icon}</div>}
         </div>
         {!!onResize && (
@@ -135,11 +151,89 @@ type CellClickHandler = (
   clicked: PivotTableClicked,
 ) => ((e: React.MouseEvent) => void) | undefined;
 
+function hydrateClicked(clicked: any, columns: any[]) {
+  if (!clicked || !columns) {
+    return clicked;
+  }
+  const hydrated = { ...clicked };
+
+  if (typeof hydrated.colIdx === "number") {
+    hydrated.column = columns[hydrated.colIdx];
+    if (!hydrated.data) {
+      hydrated.data = [
+        { value: hydrated.value, col: columns[hydrated.colIdx] },
+      ];
+    }
+  }
+
+  if (hydrated.data) {
+    hydrated.data = hydrated.data.map((item: any) => ({
+      ...item,
+      col: item.colIdx !== undefined ? columns[item.colIdx] : item.col,
+    }));
+  }
+
+  if (hydrated.dimensions) {
+    hydrated.dimensions = hydrated.dimensions.map((item: any) => ({
+      ...item,
+      col: item.colIdx !== undefined ? columns[item.colIdx] : item.col,
+    }));
+  }
+
+  return hydrated;
+}
+
+function getCellLinkData(hydratedClicked: any, settings: any) {
+  try {
+    if (!hydratedClicked || !settings) {
+      return {
+        colSettings: null,
+        isExplicitLink: false,
+        hasClickBehavior: false,
+        col: null,
+      };
+    }
+
+    const col = hydratedClicked.column;
+
+    if (!col) {
+      return {
+        colSettings: null,
+        isExplicitLink: false,
+        hasClickBehavior: false,
+        col: null,
+      };
+    }
+
+    const colSettings = settings.column(col) || {};
+
+    const hasClickBehavior =
+      colSettings.click_behavior &&
+      colSettings.click_behavior.type &&
+      colSettings.click_behavior.type !== "none";
+    const isExplicitLink =
+      (colSettings.view_as === "link" ||
+        colSettings.view_as === "email_link") &&
+      (colSettings.link_url || colSettings.link_text);
+
+    return { colSettings, isExplicitLink, hasClickBehavior, col };
+  } catch (e) {
+    return {
+      colSettings: null,
+      isExplicitLink: false,
+      hasClickBehavior: false,
+      col: null,
+    };
+  }
+}
+
 interface TopHeaderCellProps {
   item: HeaderItem;
   style: React.CSSProperties;
   getCellClickHandler: CellClickHandler;
   onResize?: (newWidth: number) => void;
+  settings?: VisualizationSettings;
+  columns?: any[];
 }
 
 export const TopHeaderCell = ({
@@ -147,22 +241,45 @@ export const TopHeaderCell = ({
   style,
   getCellClickHandler,
   onResize,
+  settings,
+  columns = [],
 }: TopHeaderCellProps) => {
   const { value, hasChildren, clicked, isSubtotal, maxDepthBelow, span } = item;
 
   const tc = useTranslateContent();
+
+  const hydratedClicked = hydrateClicked(clicked, columns);
+  const { colSettings, isExplicitLink, hasClickBehavior, col } =
+    getCellLinkData(hydratedClicked, settings);
+
+  let finalValue: React.ReactNode = tc(value);
+  let finalOnClick = getCellClickHandler(clicked);
+
+  if (isExplicitLink && value !== null && value !== undefined) {
+    finalValue = formatUrl(String(value), {
+      jsx: true,
+      rich: true,
+      view_as: colSettings.view_as,
+      link_url: colSettings.link_url,
+      link_text: colSettings.link_text,
+      column: col,
+      clicked: hydratedClicked,
+    });
+    finalOnClick = undefined;
+  }
 
   return (
     <Cell
       style={{
         ...style,
       }}
-      value={tc(value)}
+      value={finalValue}
       isBorderedHeader={maxDepthBelow === 0}
       isEmphasized={hasChildren}
       isBold={isSubtotal}
-      onClick={getCellClickHandler(clicked)}
+      onClick={finalOnClick}
       onResize={span < 2 ? onResize : undefined}
+      isDashboardLink={hasClickBehavior && !isExplicitLink}
     />
   );
 };
@@ -181,8 +298,29 @@ export const LeftHeaderCell = ({
   settings,
   onUpdateVisualizationSettings,
   onResize,
+  columns = [],
 }: LeftHeaderCellProps) => {
   const { value, isSubtotal, hasSubtotal, depth, path, clicked } = item;
+
+  const hydratedClicked = hydrateClicked(clicked, columns);
+  const { colSettings, isExplicitLink, hasClickBehavior, col } =
+    getCellLinkData(hydratedClicked, settings);
+
+  let finalValue: React.ReactNode = value;
+  let finalOnClick = getCellClickHandler(clicked);
+
+  if (isExplicitLink && value !== null && value !== undefined) {
+    finalValue = formatUrl(String(value), {
+      jsx: true,
+      rich: true,
+      view_as: colSettings.view_as,
+      link_url: colSettings.link_url,
+      link_text: colSettings.link_text,
+      column: col,
+      clicked: hydratedClicked,
+    });
+    finalOnClick = undefined;
+  }
 
   return (
     <Cell
@@ -190,11 +328,12 @@ export const LeftHeaderCell = ({
         ...style,
         ...(depth === 0 ? { paddingLeft: LEFT_HEADER_LEFT_SPACING } : {}),
       }}
-      value={value}
+      value={finalValue}
       isEmphasized={isSubtotal}
       isBold={isSubtotal}
-      onClick={getCellClickHandler(clicked)}
+      onClick={finalOnClick}
       onResize={onResize}
+      isDashboardLink={hasClickBehavior && !isExplicitLink}
       icon={
         (isSubtotal || hasSubtotal) && (
           <RowToggleIcon
@@ -217,6 +356,8 @@ interface BodyCellProps {
   getCellClickHandler: CellClickHandler;
   cellWidths: number[];
   showTooltip?: boolean;
+  settings?: VisualizationSettings;
+  columns?: any[];
 }
 
 export const BodyCell = ({
@@ -225,24 +366,47 @@ export const BodyCell = ({
   getCellClickHandler,
   cellWidths,
   showTooltip = true,
+  settings,
+  columns = [],
 }: BodyCellProps) => {
   return (
     <div style={style} className={CS.flex}>
       {rowSection.map(
         ({ value, isSubtotal, clicked, backgroundColor }, index) => {
+          const hydratedClicked = hydrateClicked(clicked, columns);
+          const { colSettings, isExplicitLink, hasClickBehavior, col } =
+            getCellLinkData(hydratedClicked, settings);
+
+          let finalValue: React.ReactNode = value;
+          let finalOnClick = getCellClickHandler(clicked);
+
+          if (isExplicitLink && value !== null && value !== undefined) {
+            finalValue = formatUrl(String(value), {
+              jsx: true,
+              rich: true,
+              view_as: colSettings.view_as,
+              link_url: colSettings.link_url,
+              link_text: colSettings.link_text,
+              column: col,
+              clicked: hydratedClicked,
+            });
+            finalOnClick = undefined;
+          }
+
           return (
             <Cell
               key={index}
               style={{
                 flexBasis: cellWidths[index],
               }}
-              value={value}
+              value={finalValue}
               isEmphasized={isSubtotal}
               isBold={isSubtotal}
               showTooltip={showTooltip}
               isBody
-              onClick={getCellClickHandler(clicked)}
+              onClick={finalOnClick}
               backgroundColor={backgroundColor}
+              isDashboardLink={hasClickBehavior && !isExplicitLink}
             />
           );
         },

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/settings.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/settings.ts
@@ -14,6 +14,7 @@ import {
 } from "metabase/lib/data_grid";
 import { displayNameForColumn } from "metabase/lib/formatting";
 import { ChartSettingIconRadio } from "metabase/visualizations/components/settings/ChartSettingIconRadio";
+import ChartSettingLinkUrlInput from "metabase/visualizations/components/settings/ChartSettingLinkUrlInput";
 import { ChartSettingsTableFormatting } from "metabase/visualizations/components/settings/ChartSettingsTableFormatting";
 import { columnSettings } from "metabase/visualizations/lib/settings/column";
 import type { ComputedVisualizationSettings } from "metabase/visualizations/types";
@@ -22,7 +23,13 @@ import {
   getDimensionReferenceWithoutBaseType,
   isDimensionReferenceWithOptions,
 } from "metabase-lib/v1/references";
-import { isDimension } from "metabase-lib/v1/types/utils/isa";
+import {
+  isAvatarURL,
+  isDimension,
+  isEmail,
+  isImageURL,
+  isURL,
+} from "metabase-lib/v1/types/utils/isa";
 import type {
   Card,
   DatasetColumn,
@@ -263,79 +270,178 @@ export const settings = {
   },
 };
 
-export const _columnSettings = {
-  [COLUMN_SORT_ORDER]: {
-    get title() {
-      return t`Sort order`;
-    },
-    widget: ChartSettingIconRadio,
-    inline: true,
-    borderBottom: true,
-    props: {
-      options: [
-        {
-          iconName: "arrow_up",
-          value: COLUMN_SORT_ORDER_ASC,
-        },
-        {
-          iconName: "arrow_down",
-          value: COLUMN_SORT_ORDER_DESC,
-        },
-      ],
-    },
-    getHidden: ({ source }: { source: DatasetColumn["source"] }) =>
-      source === "aggregation",
-  },
-  [COLUMN_SHOW_TOTALS]: {
-    get title() {
-      return t`Show totals`;
-    },
-    widget: "toggle",
-    inline: true,
-    getDefault: (
-      column: DatasetColumn,
-      columnSettings: DatasetColumn,
-      { settings }: { settings: VisualizationSettings },
-    ) => {
-      // Default to showing totals if appropriate
-      const rows = settings[COLUMN_SPLIT_SETTING]?.rows || [];
+export const _columnSettings = (column: DatasetColumn) => {
+  let defaultValue = !column.semantic_type || isURL(column) ? "link" : null;
 
-      // `rows` can be either in a legacy format where it's a field ref, or in a new format where it's a column name.
-      // All new questions visualized as pivot tables will have column name settings only. We migrate
-      // `COLUMN_SPLIT_SETTING` for existing questions only on an explicit change from the user; therefore we need to
-      // support both column names and field refs for now.
-      return rows
-        .slice(0, -1)
-        .some(
-          (row) =>
-            _.isEqual(row, column.name) ||
-            (Array.isArray(row) &&
-              column.field_ref != null &&
-              _.isEqual(
-                getFieldRefForComparison(row),
-                getFieldRefForComparison(column.field_ref),
-              )),
-        );
+  const options = [
+    { name: t`Text`, value: null },
+    { name: t`Link`, value: "link" },
+  ];
+
+  if (!column.semantic_type || isEmail(column)) {
+    defaultValue = "email_link";
+    options.push({ name: t`Email link`, value: "email_link" });
+  }
+  if (!column.semantic_type || isImageURL(column) || isAvatarURL(column)) {
+    defaultValue = isAvatarURL(column) ? "image" : "link";
+    options.push({ name: t`Image`, value: "image" });
+  }
+  if (!column.semantic_type) {
+    defaultValue = "auto";
+    options.push({ name: t`Automatic`, value: "auto" });
+  }
+
+  const viewAsSetting: Record<string, any> = {};
+  if (options.length > 1) {
+    viewAsSetting["view_as"] = {
+      get title() {
+        return t`Display as`;
+      },
+      widget: options.length === 2 ? "radio" : "select",
+      default: defaultValue,
+      props: {
+        options,
+      },
+    };
+  }
+
+  const linkFieldsHint = t`You can use the value of any column here like this: {{COLUMN}}`;
+
+  return {
+    [COLUMN_SORT_ORDER]: {
+      get title() {
+        return t`Sort order`;
+      },
+      widget: ChartSettingIconRadio,
+      inline: true,
+      borderBottom: true,
+      props: {
+        options: [
+          {
+            iconName: "arrow_up",
+            value: COLUMN_SORT_ORDER_ASC,
+          },
+          {
+            iconName: "arrow_down",
+            value: COLUMN_SORT_ORDER_DESC,
+          },
+        ],
+      },
+      getHidden: ({ source }: { source: DatasetColumn["source"] }) =>
+        source === "aggregation",
     },
-    getHidden: (
-      column: DatasetColumn,
-      columnSettings: DatasetColumn,
-      { settings }: { settings: VisualizationSettings },
-    ) => {
-      const rows = settings[COLUMN_SPLIT_SETTING]?.rows || [];
-      // to show totals a column needs to be:
-      //  - in the left header ("rows" in COLUMN_SPLIT_SETTING)
-      //  - not the last column
-      return !rows.slice(0, -1).some((row) => _.isEqual(row, column.name));
+    [COLUMN_SHOW_TOTALS]: {
+      get title() {
+        return t`Show totals`;
+      },
+      widget: "toggle",
+      inline: true,
+      getDefault: (
+        column: DatasetColumn,
+        columnSettings: DatasetColumn,
+        { settings }: { settings: VisualizationSettings },
+      ) => {
+        // Default to showing totals if appropriate
+        const rows = settings[COLUMN_SPLIT_SETTING]?.rows || [];
+
+        // `rows` can be either in a legacy format where it's a field ref, or in a new format where it's a column name.
+        // All new questions visualized as pivot tables will have column name settings only. We migrate
+        // `COLUMN_SPLIT_SETTING` for existing questions only on an explicit change from the user; therefore we need to
+        // support both column names and field refs for now.
+        return rows
+          .slice(0, -1)
+          .some(
+            (row) =>
+              _.isEqual(row, column.name) ||
+              (Array.isArray(row) &&
+                column.field_ref != null &&
+                _.isEqual(
+                  getFieldRefForComparison(row),
+                  getFieldRefForComparison(column.field_ref),
+                )),
+          );
+      },
+      getHidden: (
+        column: DatasetColumn,
+        columnSettings: DatasetColumn,
+        { settings }: { settings: VisualizationSettings },
+      ) => {
+        const rows = settings[COLUMN_SPLIT_SETTING]?.rows || [];
+        // to show totals a column needs to be:
+        //  - in the left header ("rows" in COLUMN_SPLIT_SETTING)
+        //  - not the last column
+        return !rows.slice(0, -1).some((row) => _.isEqual(row, column.name));
+      },
     },
-  },
-  column_title: {
-    get title() {
-      return t`Column title`;
+    column_title: {
+      get title() {
+        return t`Column title`;
+      },
+      widget: "input",
+      getDefault: displayNameForColumn,
     },
-    widget: "input",
-    getDefault: displayNameForColumn,
-  },
+    click_behavior: {},
+    ...viewAsSetting,
+    link_text: {
+      get title() {
+        return t`Link text`;
+      },
+      widget: ChartSettingLinkUrlInput,
+      get hint() {
+        return linkFieldsHint;
+      },
+      default: null,
+      getHidden: (_: any, settings: any) =>
+        settings["view_as"] !== "link" && settings["view_as"] !== "email_link",
+      readDependencies: ["view_as"],
+      getProps: (
+        column: any,
+        settings: any,
+        onChange: any,
+        {
+          series: [
+            {
+              data: { cols },
+            },
+          ],
+        }: any,
+      ) => {
+        return {
+          options: cols.map((column: any) => column.name),
+          placeholder: t`Link to {{bird_id}}`,
+        };
+      },
+    },
+    link_url: {
+      get title() {
+        return t`Link URL`;
+      },
+      widget: ChartSettingLinkUrlInput,
+      get hint() {
+        return linkFieldsHint;
+      },
+      default: null,
+      getHidden: (_: any, settings: any) => settings["view_as"] !== "link",
+      readDependencies: ["view_as"],
+      getProps: (
+        column: any,
+        settings: any,
+        onChange: any,
+        {
+          series: [
+            {
+              data: { cols },
+            },
+          ],
+        }: any,
+      ) => {
+        return {
+          options: cols.map((column: any) => column.name),
+          placeholder: t`http://toucan.example/{{bird_id}}`,
+        };
+      },
+    },
+  };
 };
 
 /*


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/70788

### Description

**The Problem:**
Currently, Pivot Tables do not support URLs ("Display as Link"), which limits their use case compared to standard flat tables. 

**The Solution:**
This PR brings the standard table link functionality over to Pivot Tables by:
1. Adding "click_behavior" and "view_as" (Link, Email, Image) formatting options to the Pivot Table "_columnSettings" in "settings.ts".
2. Hydrating the stripped "clicked" object in "PivotTableCell.tsx" with the correct column metadata so "formatUrl" can properly resolve column variables (e.g., `{{Category}}`).
3. Using Metabase's native "formatUrl" helper to render the links as "<ExternalLink>", ensuring that external routing, embedded SDK behaviors, and variable interpolations work identically to standard tables.
4. Adding strict column matching to ensure that metric/aggregation cells (like "SUM of Price") do not accidentally inherit link settings from dimension columns.

### How to verify

1. Ask a New question -> Sample Database -> Products.
2. Summarize: Add a metric (SUM(Profit)) and group by two dimensions (Category, Created_at:Month).
3. Change the Visualization to **Pivot Table**.
4. Open the Visualization Settings (Gear Icon) -> **Columns** tab -> Click the gear icon next to "Category".
5. Under "Display as", select **Link**.
6. In the Link URL input, enter a URL with a variable: "https://google.com/search?q={{CATEGORY}}".
7. Verify that the "Category" cells (e.g., "Widget") render in blue and are clickable.
8. Click a "Category" cell and verify it routes to the correct URL (https://google.com/search?q=Widget)
9. Verify that the metric cells remain standard text and do not render as links.
10. Verify that we can modify the alias of the Link (Link Text)

### Demo

https://github.com/user-attachments/assets/f0ee8d09-e100-4793-b65b-c73d452336ad


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)