### PR TITLE
fix: use the correct setting for enabling metabot in the embed wizard

### DIFF
--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SelectEmbedExperienceStep.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/SelectEmbedExperienceStep.tsx
@@ -16,7 +16,9 @@ export const SelectEmbedExperienceStep = () => {
     useSdkIframeEmbedSetupContext();
 
   const isGuestEmbed = !!settings.isGuest;
-  const isMetabotAvailable = useMetabotEnabledEmbeddingAware();
+  const isMetabotAvailable = useMetabotEnabledEmbeddingAware({
+    forceEmbedding: true,
+  });
 
   const handleEmbedExperienceChange = useHandleExperienceChange();
 

--- a/frontend/src/metabase/metabot/hooks/use-metabot-embedding-aware-enabled.ts
+++ b/frontend/src/metabase/metabot/hooks/use-metabot-embedding-aware-enabled.ts
@@ -3,12 +3,15 @@ import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import { isWithinIframe } from "metabase/lib/dom";
 
 /** Returns the value for `metabot-enabled?` or `embedded-metabot-enabled?` depending on the context
- * only if the metabot token feature is enabled. */
-export const useMetabotEnabledEmbeddingAware = (): boolean => {
+ * only if the metabot token feature is enabled.
+ * Use `forceEmbedding` to always check the embedding setting (e.g. in the embed wizard). */
+export const useMetabotEnabledEmbeddingAware = ({
+  forceEmbedding = false,
+}: { forceEmbedding?: boolean } = {}): boolean => {
   const hasMetabotV3 = useHasTokenFeature("metabot_v3");
-  const isEmbeddingIframe = isWithinIframe() || isEmbeddingSdk();
+  const isEmbedding = forceEmbedding || isWithinIframe() || isEmbeddingSdk();
   const isEnabled = useSetting(
-    isEmbeddingIframe ? "embedded-metabot-enabled?" : "metabot-enabled?",
+    isEmbedding ? "embedded-metabot-enabled?" : "metabot-enabled?",
   );
   return hasMetabotV3 && isEnabled;
 };


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #70818

Closes https://linear.app/metabase/issue/EMB-1430/disabling-internal-metabot-makes-the-metabot-component-disappear-from

### Description

We were using the "automatic" setting name, that in the core app is for the core app metabot

### How to verify

- Disable internal metabot
- Go to embed wizard
- select SSO
- metabot should be there