### PR TITLE
Fix cloud driver tests skipped when deps.edn changes [DEV-1672]

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -351,12 +351,13 @@
                          "RUN"
                          (str "any of " (pr-str driver-triggers) " affected by cloud-driver module changes")]
                         ["7"    "Cloud driver + query-processor updated"  "RUN"  "query-processor module updated"]
-                        ["8"    "Cloud driver, no relevant changes"       "SKIP" "no relevant changes for cloud driver"]
-                        ["9"
+                        ["8"    "Cloud driver + driver deps affected"     "RUN"  "driver module affected by shared code changes"]
+                        ["9"    "Cloud driver, no relevant changes"       "SKIP" "no relevant changes for cloud driver"]
+                        ["10"
                          (str (pr-str driver-triggers) " module deps affected")
                          "RUN"
                          (str "any of " (pr-str driver-triggers) " affected by module changes")]
-                        ["10"   "Self-hosted driver, not affected"        "SKIP" "driver module not affected"]])))))
+                        ["11"   "Self-hosted driver, not affected"        "SKIP" "driver module not affected"]])))))
    :options [[nil "--git-ref REF" "The git ref to compute changed modules against"]
              [nil "--is-master-or-release MASTER_OR_RELEASE"]
              [nil "--pr-labels PR_LABELS" "Comma delimited labels on the pr"]

--- a/mage/src/mage/modules.clj
+++ b/mage/src/mage/modules.clj
@@ -388,17 +388,23 @@
     {:should-run true
      :reason "Module updated which explicitly triggers cloud drivers"}
 
-    ;; Priority 8: Cloud driver, no relevant changes → skip
+    ;; Priority 8: Cloud driver + driver deps affected (e.g., deps.edn changed)
+    (and (contains? cloud-drivers driver)
+         driver-deps-affected?)
+    {:should-run true
+     :reason "driver module affected by shared code changes"}
+
+    ;; Priority 9: Cloud driver, no relevant changes → skip
     (contains? cloud-drivers driver)
     {:should-run false
      :reason "no relevant changes for cloud driver"}
 
-    ;; Priority 9: Driver deps affected by shared code changes
+    ;; Priority 10: Driver deps affected by shared code changes
     driver-deps-affected?
     {:should-run true
      :reason "driver module affected by shared code changes"}
 
-    ;; Priority 10: Self-hosted driver, not affected
+    ;; Priority 11: Self-hosted driver, not affected
     :else
     {:should-run false
      :reason "driver module not affected"}))

--- a/mage/test/mage/modules_test.clj
+++ b/mage/test/mage/modules_test.clj
@@ -142,12 +142,12 @@
         (is (= "master/release branch" (:reason result)))))))
 
 ;;; =============================================================================
-;;; Priority 9: Driver deps affected (self-hosted only)
+;;; Priority 10: Driver deps affected (self-hosted only)
 ;;; =============================================================================
 
 (deftest driver-deps-affected-runs-self-hosted-drivers
   (testing "Self-hosted drivers run when driver module is affected"
-    ;; H2/Postgres hit priority 2 first, others hit priority 8
+    ;; H2/Postgres hit priority 2 first, others hit priority 10
     (doseq [driver [:mysql :mongo :oracle :sqlserver]]
       (let [result (mage.modules/driver-decision driver
                                                  (make-ctx {})
@@ -159,7 +159,7 @@
         (is (= "driver module affected by shared code changes" (:reason result)))))))
 
 ;;; =============================================================================
-;;; Priority 5-8: Cloud driver special rules
+;;; Priority 5-9: Cloud driver special rules
 ;;; =============================================================================
 
 (deftest cloud-driver-with-label-runs
@@ -199,6 +199,18 @@
         (is (= "Module updated which explicitly triggers cloud drivers"
                (:reason result)))))))
 
+(deftest cloud-driver-runs-when-driver-deps-affected
+  (testing "Cloud driver runs when driver deps are affected (e.g., deps.edn changed)"
+    (doseq [driver [:athena :bigquery :databricks :redshift :snowflake]]
+      (let [result (mage.modules/driver-decision driver
+                                                 (make-ctx {})
+                                                 true  ; driver-deps-affected
+                                                 #{}   ; quarantined
+                                                 #{})] ; updated
+        (is (true? (:should-run result))
+            (str driver " should run when driver deps affected"))
+        (is (= "driver module affected by shared code changes" (:reason result)))))))
+
 (deftest cloud-driver-without-changes-skips
   (testing "Cloud driver skips when no relevant changes"
     (doseq [driver [:athena :bigquery :databricks :redshift :snowflake]]
@@ -212,7 +224,7 @@
         (is (= "no relevant changes for cloud driver" (:reason result)))))))
 
 ;;; =============================================================================
-;;; Priority 10: Self-hosted drivers
+;;; Priority 11: Self-hosted drivers
 ;;; =============================================================================
 
 (deftest self-hosted-driver-not-affected-skips


### PR DESCRIPTION
## Summary

`driver-decision` uses a `cond` (first-match-wins) with a priority cascade. Cloud drivers were hitting the "no relevant changes → SKIP" catch-all before reaching the `driver-deps-affected?` check. This meant bumping dependency versions in `deps.edn` correctly triggered self-hosted driver tests but silently skipped cloud drivers (athena, bigquery, databricks, redshift, snowflake).

Adds a new priority 8 clause that checks `driver-deps-affected?` for cloud drivers before the catch-all skip, and renumbers subsequent priorities.

## How the priority cascade bug worked

```
Priority 7:  Cloud + module triggers cloud drivers → RUN  ✓
Priority 8:  Cloud driver (catch-all)              → SKIP ← cloud drivers stopped here
Priority 9:  driver-deps-affected?                 → RUN  ← only self-hosted drivers reached this
Priority 10: else                                  → SKIP
```

After fix (renumbered 8-11):
```
Priority 7:  Cloud + module triggers cloud drivers → RUN
Priority 8:  Cloud + driver-deps-affected          → RUN  ← NEW
Priority 9:  Cloud driver (catch-all)              → SKIP
Priority 10: driver-deps-affected?                 → RUN  (self-hosted)
Priority 11: else                                  → SKIP
```

## Test plan

- [x] `bin/mage -test modules` — 22 tests, 316 assertions, 0 failures
- [x] `bin/mage -driver-decisions -h` — help table shows new priority 8 row
- [x] Existing `cloud-driver-without-changes-skips` still passes (uses `driver-deps-affected?=false`)
- [x] New `cloud-driver-runs-when-driver-deps-affected` test validates the fix