### PR TITLE
Fixed color flickering for sdk question titles

### DIFF
--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestionDefaultView/DefaultViewTitle.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestionDefaultView/DefaultViewTitle.tsx
@@ -35,7 +35,11 @@ export const DefaultViewTitle = ({ title }: SdkQuestionDefaultViewProps) => {
       <DefaultViewTitleText
         title={
           titleText && (
-            <Text fw={700} c="text-primary" fz="xl">
+            <Text
+              fw={700}
+              fz="xl"
+              style={{ color: "var(--mb-color-text-primary)" }}
+            >
               {titleText}
             </Text>
           )
@@ -50,7 +54,11 @@ export const DefaultViewTitle = ({ title }: SdkQuestionDefaultViewProps) => {
     return (
       <DefaultViewTitleText
         title={
-          <Text fw={700} c="text-primary" fz="xl">
+          <Text
+            fw={700}
+            fz="xl"
+            style={{ color: "var(--mb-color-text-primary)" }}
+          >
             {titleText}
           </Text>
         }


### PR DESCRIPTION
Closes [EMB-1374: InteractiveQuestion/StaticQuestion title color flickers in SDK](https://linear.app/metabase/issue/EMB-1374/interactivequestionstaticquestion-title-color-flickers-in-sdk)

### Description

When mounting a StaticQuestion or an InteractiveQuestion with a theme that changes the text color, the title would briefly blink (see demo).

That's because Mantine's `c="text-primary"` resolves to an inline style `color: var(--mantine-color-text-primary-text)`, which depends on Mantine's `<style>` tag (rendered by `MantineCssVariables`). That `<style>` tag may not be in the DOM on first paint, so the variable is undefined initially → falls back to inherited color → then resolves once the style tag mounts → flicker.

Meanwhile, `--mb-color-text-primary` is injected via Emotion's `<Global>` (which uses `useInsertionEffect`, synchronous before paint), so it's always available.

### How to verify

Mount a StaticQuestion with a theme that sets the font color to somethig light, so the flickering is noticeable.

### Demo

Before:

https://github.com/user-attachments/assets/dc57fc65-62dd-4ec2-828e-51c2695f3853


After:

https://github.com/user-attachments/assets/592323fa-223d-4bd6-9c29-10ab851438e2


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
