### PR TITLE
Fix flaky scoring-test/mine-test on H2

### DIFF
--- a/test/metabase/search/appdb/scoring_test.clj
+++ b/test/metabase/search/appdb/scoring_test.clj
@@ -305,7 +305,7 @@
                   ["dataset" c3 "card unseen"]]
                  (search-results :user-recency "card" {:current-user-id user-id}))))))))
 
-(deftest ^:parallel mine-test
+(deftest mine-test
   (let [crowberto (mt/user->id :crowberto)
         rasta     (mt/user->id :rasta)]
     (with-index-contents [{:model "card" :id 1 :name "crow's fly card" :creator_id crowberto}


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-1468/flaky-test-be-tests-java-21-ee-metabasesearchappdbscoring-test-mine

Remove `^:parallel` from `mine-test` in `metabase.search.appdb.scoring-test` to fix H2 flakiness

The root cause might be that:
1. `with-index-contents` does DDL (CREATE/DROP temp table) per test
2. The scoring query generates a permissions CTE joining `DATA_PERMISSIONS`, `PERMISSIONS_GROUP_MEMBERSHIP`, `METABASE_TABLE`
3. When multiple `^:parallel` tests run concurrently, H2's internal SYS catalog lock gets contended