### PR TITLE
Feature hide columns in table vis

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardColumnsMenuItem.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardColumnsMenuItem.tsx
@@ -1,0 +1,57 @@
+import { t } from "ttag";
+
+import { useTransientColumnVisibility } from "metabase/dashboard/components/DashCard/TransientColumnVisibilityContext";
+import { Checkbox, Icon, Menu } from "metabase/ui";
+
+export const DashCardColumnsMenuItem = () => {
+  const columnVisibility = useTransientColumnVisibility();
+
+  if (!columnVisibility || columnVisibility.allColumns.length === 0) {
+    return null;
+  }
+
+  const { allColumns, hiddenColumnIds, toggleColumnVisibility } =
+    columnVisibility;
+
+  return (
+    <Menu trigger="click-hover" shadow="md" position="right" width={220}>
+      <Menu.Target>
+        <Menu.Item
+          fw="bold"
+          styles={{
+            item: {
+              backgroundColor: "transparent",
+              color: "var(--mb-color-text-primary)",
+            },
+            itemSection: {
+              color: "var(--mb-color-text-primary)",
+            },
+          }}
+          leftSection={<Icon name="eye" aria-hidden />}
+          rightSection={<Icon name="chevronright" aria-hidden />}
+        >
+          {t`Columns`}
+        </Menu.Item>
+      </Menu.Target>
+      <Menu.Dropdown data-testid="dashcard-menu-columns">
+        {allColumns.map(({ id, name }) => (
+          <Menu.Item
+            key={id}
+            closeMenuOnClick={false}
+            onClick={() => toggleColumnVisibility(id)}
+            leftSection={
+              <Checkbox
+                size="xs"
+                checked={!hiddenColumnIds.has(id)}
+                onChange={() => toggleColumnVisibility(id)}
+                readOnly
+              />
+            }
+          >
+            {name}
+          </Menu.Item>
+        ))}
+      </Menu.Dropdown>
+    </Menu>
+  );
+};

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardColumnsMenuItem.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardColumnsMenuItem.unit.spec.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from "@testing-library/react";
+import { useEffect } from "react";
+
+import { renderWithProviders } from "__support__/ui";
+import {
+  TransientColumnVisibilityProvider,
+  useTransientColumnVisibility,
+} from "metabase/dashboard/components/DashCard/TransientColumnVisibilityContext";
+
+import { DashCardColumnsMenuItem } from "./DashCardColumnsMenuItem";
+
+const TEST_COLUMNS = [
+  { id: "col_a", name: "Column A" },
+  { id: "col_b", name: "Column B" },
+  { id: "col_c", name: "Column C" },
+];
+
+/**
+ * Helper component that seeds the context with columns before rendering the
+ * menu item, mimicking what TableInteractive does at runtime.
+ */
+const ColumnsMenuWithSetup = ({
+  columns = TEST_COLUMNS,
+  hiddenIds = [] as string[],
+}: {
+  columns?: Array<{ id: string; name: string }>;
+  hiddenIds?: string[];
+}) => {
+  const ctx = useTransientColumnVisibility();
+
+  useEffect(() => {
+    if (ctx) {
+      ctx.setAllColumns(columns);
+      hiddenIds.forEach(id => ctx.hideColumn(id));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return <DashCardColumnsMenuItem />;
+};
+
+const setup = ({
+  columns,
+  hiddenIds,
+}: {
+  columns?: Array<{ id: string; name: string }>;
+  hiddenIds?: string[];
+} = {}) => {
+  return renderWithProviders(
+    <TransientColumnVisibilityProvider>
+      <ColumnsMenuWithSetup columns={columns} hiddenIds={hiddenIds} />
+    </TransientColumnVisibilityProvider>,
+  );
+};
+
+describe("DashCardColumnsMenuItem", () => {
+  it("should render nothing when outside the context provider", () => {
+    const { container } = render(<DashCardColumnsMenuItem />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("should render nothing when no columns are registered", () => {
+    const { container } = render(
+      <TransientColumnVisibilityProvider>
+        <DashCardColumnsMenuItem />
+      </TransientColumnVisibilityProvider>,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("should render 'Columns' menu item when columns are registered", () => {
+    setup();
+    expect(screen.getByText("Columns")).toBeInTheDocument();
+  });
+
+  it("should render 'Columns' menu item even when no columns are hidden", () => {
+    setup({ hiddenIds: [] });
+    expect(screen.getByText("Columns")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu.tsx
@@ -7,6 +7,7 @@ import {
   canDownloadResults,
   canEditQuestion,
 } from "metabase/dashboard/components/DashCard/DashCardMenu/utils";
+import { useTransientColumnVisibility } from "metabase/dashboard/components/DashCard/TransientColumnVisibilityContext";
 import {
   type DashboardContextReturned,
   useDashboardContext,
@@ -70,6 +71,35 @@ export const DashCardMenu = ({
   const dashcardId = dashcard.id;
   const { dashboard, dashboardId, dashcardMenu, downloadsEnabled } =
     useDashboardContext();
+
+  const columnVisibility = useTransientColumnVisibility();
+  const downloadVizSettings = useMemo(() => {
+    if (!columnVisibility?.hasHiddenColumns) {
+      return undefined;
+    }
+
+    // Build table.columns from the full query result columns (result.data.cols)
+    // so that remapped/extra columns are explicitly accounted for.
+    // Columns tracked by the transient context use its visibility state;
+    // columns NOT tracked (e.g. FK-remapped display columns) are marked disabled
+    // so the backend's not-explicitly-excluded-columns logic doesn't add them back.
+    const contextColumnIds = new Set(
+      columnVisibility.allColumns.map(c => c.id),
+    );
+    const resultCols = result?.data?.cols ?? [];
+
+    const tableColumns = resultCols.map(col => ({
+      name: col.name,
+      enabled: contextColumnIds.has(col.name)
+        ? !columnVisibility.hiddenColumnIds.has(col.name)
+        : false,
+    }));
+
+    return {
+      "table.columns": tableColumns,
+    };
+  }, [columnVisibility, result]);
+
   const [{ loading: isDownloadingData }, handleDownload] = useDownloadData({
     question,
     result,
@@ -79,6 +109,7 @@ export const DashCardMenu = ({
     uuid,
     token,
     params: getParameterValuesBySlugMap(store.getState()),
+    visualizationSettings: downloadVizSettings,
   });
 
   const [menuView, setMenuView] = useState<string | null>(null);

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu.tsx
@@ -25,6 +25,7 @@ import type { DashboardCard, Dataset } from "metabase-types/api";
 
 import { getDashcardTokenId, getDashcardUuid } from "../dashcard-ids";
 
+import { DashCardColumnsMenuItem } from "./DashCardColumnsMenuItem";
 import { DashCardMenuItems } from "./DashCardMenuItems";
 
 interface DashCardMenuProps {
@@ -117,6 +118,7 @@ export const DashCardMenu = ({
 
     return (
       <>
+        <DashCardColumnsMenuItem />
         <DashCardMenuItems
           dashcardId={dashcardId}
           question={question}

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -6,6 +6,7 @@ import _ from "underscore";
 import { ExternalLink } from "metabase/common/components/ExternalLink/ExternalLink";
 import { useLearnUrl } from "metabase/common/hooks";
 import CS from "metabase/css/core/index.css";
+import { TransientColumnVisibilityProvider } from "metabase/dashboard/components/DashCard/TransientColumnVisibilityContext";
 import { useDashboardContext } from "metabase/dashboard/context";
 import { useClickBehaviorData } from "metabase/dashboard/hooks";
 import { useResponsiveParameterList } from "metabase/dashboard/hooks/use-responsive-parameter-list";
@@ -590,51 +591,53 @@ export function DashCardVisualization({
       })}
       ref={containerRef}
     >
-      <EmbeddingEntityContextProvider uuid={uuid ?? null} token={token ?? null}>
-        <Visualization
-          className={cx(CS.flexFull, {
-            [CS.overflowAuto]: visualizationOverlay,
-            [CS.overflowHidden]: !visualizationOverlay,
-          })}
-          dashboard={dashboard ?? undefined}
-          dashcard={dashcard}
-          rawSeries={series}
-          visualizerRawSeries={
-            isVisualizerDashboardCard(dashcard) ? rawSeries : undefined
-          }
-          metadata={metadata}
-          mode={getClickActionMode}
-          getHref={getHref}
-          gridSize={gridSize}
-          totalNumGridCols={totalNumGridCols}
-          headerIcon={headerIcon}
-          expectedDuration={expectedDuration}
-          error={error?.message}
-          errorIcon={error?.icon}
-          showTitle={cardTitled}
-          canToggleSeriesVisibility={!isEditing}
-          isAction={isAction}
-          isDashboard
-          isSlow={isSlow}
-          isFullscreen={isFullscreen}
-          isEditing={isEditing}
-          isPreviewing={isPreviewing}
-          isEditingParameter={isEditingParameter}
-          isMobile={isMobile}
-          actionButtons={actionButtons}
-          replacementContent={visualizationOverlay}
-          getExtraDataForClick={getExtraDataForClick}
-          onUpdateVisualizationSettings={handleOnUpdateVisualizationSettings}
-          onTogglePreviewing={onTogglePreviewing}
-          onChangeCardAndRun={onChangeCardAndRun}
-          onChangeLocation={onChangeLocation}
-          renderLoadingView={renderLoadingView}
-          titleMenuItems={titleMenuItems}
-          errorMessageOverride={visualizerErrMsg}
-          enableEntityNavigation={enableEntityNavigation}
-          autoAdjustSettings
-        />
-      </EmbeddingEntityContextProvider>
+      <TransientColumnVisibilityProvider>
+        <EmbeddingEntityContextProvider uuid={uuid ?? null} token={token ?? null}>
+          <Visualization
+            className={cx(CS.flexFull, {
+              [CS.overflowAuto]: visualizationOverlay,
+              [CS.overflowHidden]: !visualizationOverlay,
+            })}
+            dashboard={dashboard ?? undefined}
+            dashcard={dashcard}
+            rawSeries={series}
+            visualizerRawSeries={
+              isVisualizerDashboardCard(dashcard) ? rawSeries : undefined
+            }
+            metadata={metadata}
+            mode={getClickActionMode}
+            getHref={getHref}
+            gridSize={gridSize}
+            totalNumGridCols={totalNumGridCols}
+            headerIcon={headerIcon}
+            expectedDuration={expectedDuration}
+            error={error?.message}
+            errorIcon={error?.icon}
+            showTitle={cardTitled}
+            canToggleSeriesVisibility={!isEditing}
+            isAction={isAction}
+            isDashboard
+            isSlow={isSlow}
+            isFullscreen={isFullscreen}
+            isEditing={isEditing}
+            isPreviewing={isPreviewing}
+            isEditingParameter={isEditingParameter}
+            isMobile={isMobile}
+            actionButtons={actionButtons}
+            replacementContent={visualizationOverlay}
+            getExtraDataForClick={getExtraDataForClick}
+            onUpdateVisualizationSettings={handleOnUpdateVisualizationSettings}
+            onTogglePreviewing={onTogglePreviewing}
+            onChangeCardAndRun={onChangeCardAndRun}
+            onChangeLocation={onChangeLocation}
+            renderLoadingView={renderLoadingView}
+            titleMenuItems={titleMenuItems}
+            errorMessageOverride={visualizerErrMsg}
+            enableEntityNavigation={enableEntityNavigation}
+            autoAdjustSettings
+          />
+        </EmbeddingEntityContextProvider>
+      </TransientColumnVisibilityProvider>
     </div>
   );
 }

--- a/frontend/src/metabase/dashboard/components/DashCard/TransientColumnVisibilityContext.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/TransientColumnVisibilityContext.tsx
@@ -1,0 +1,96 @@
+import {
+  type ReactNode,
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from "react";
+
+import type { TableColumnOrderSetting } from "metabase-types/api";
+
+type ColumnInfo = { id: string; name: string };
+
+type TransientColumnVisibilityContextValue = {
+  allColumns: ColumnInfo[];
+  hiddenColumnIds: Set<string>;
+  setAllColumns: (columns: ColumnInfo[]) => void;
+  hideColumn: (columnId: string) => void;
+  toggleColumnVisibility: (columnId: string) => void;
+  showAllColumns: () => void;
+  hasHiddenColumns: boolean;
+  getVisibleColumnSettings: () => TableColumnOrderSetting[];
+};
+
+const TransientColumnVisibilityContext =
+  createContext<TransientColumnVisibilityContextValue | null>(null);
+
+export const useTransientColumnVisibility = () =>
+  useContext(TransientColumnVisibilityContext);
+
+export const TransientColumnVisibilityProvider = ({
+  children,
+}: {
+  children: ReactNode;
+}) => {
+  const [allColumns, setAllColumns] = useState<ColumnInfo[]>([]);
+  const [hiddenColumnIds, setHiddenColumnIds] = useState<Set<string>>(
+    new Set(),
+  );
+
+  const hideColumn = useCallback((id: string) => {
+    setHiddenColumnIds(prev => {
+      const next = new Set(prev);
+      next.add(id);
+      return next;
+    });
+  }, []);
+
+  const toggleColumnVisibility = useCallback((id: string) => {
+    setHiddenColumnIds(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
+  const showAllColumns = useCallback(() => setHiddenColumnIds(new Set()), []);
+
+  const getVisibleColumnSettings = useCallback((): TableColumnOrderSetting[] => {
+    return allColumns.map(col => ({
+      name: col.id,
+      enabled: !hiddenColumnIds.has(col.id),
+    }));
+  }, [allColumns, hiddenColumnIds]);
+
+  const value = useMemo(
+    () => ({
+      allColumns,
+      hiddenColumnIds,
+      setAllColumns,
+      hideColumn,
+      toggleColumnVisibility,
+      showAllColumns,
+      hasHiddenColumns: hiddenColumnIds.size > 0,
+      getVisibleColumnSettings,
+    }),
+    [
+      allColumns,
+      hiddenColumnIds,
+      hideColumn,
+      toggleColumnVisibility,
+      showAllColumns,
+      getVisibleColumnSettings,
+    ],
+  );
+
+  return (
+    <TransientColumnVisibilityContext.Provider value={value}>
+      {children}
+    </TransientColumnVisibilityContext.Provider>
+  );
+};

--- a/frontend/src/metabase/dashboard/components/DashCard/TransientColumnVisibilityContext.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/TransientColumnVisibilityContext.unit.spec.tsx
@@ -1,0 +1,123 @@
+import { act, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+import {
+  TransientColumnVisibilityProvider,
+  useTransientColumnVisibility,
+} from "./TransientColumnVisibilityContext";
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <TransientColumnVisibilityProvider>{children}</TransientColumnVisibilityProvider>
+);
+
+const TEST_COLUMNS = [
+  { id: "col_a", name: "Column A" },
+  { id: "col_b", name: "Column B" },
+  { id: "col_c", name: "Column C" },
+];
+
+describe("TransientColumnVisibilityContext", () => {
+  it("should start with no columns and no hidden columns", () => {
+    const { result } = renderHook(() => useTransientColumnVisibility(), {
+      wrapper,
+    });
+
+    expect(result.current?.allColumns).toEqual([]);
+    expect(result.current?.hiddenColumnIds.size).toBe(0);
+    expect(result.current?.hasHiddenColumns).toBe(false);
+  });
+
+  it("should register columns with setAllColumns", () => {
+    const { result } = renderHook(() => useTransientColumnVisibility(), {
+      wrapper,
+    });
+
+    act(() => {
+      result.current?.setAllColumns(TEST_COLUMNS);
+    });
+
+    expect(result.current?.allColumns).toEqual(TEST_COLUMNS);
+  });
+
+  it("should hide a column with hideColumn", () => {
+    const { result } = renderHook(() => useTransientColumnVisibility(), {
+      wrapper,
+    });
+
+    act(() => {
+      result.current?.setAllColumns(TEST_COLUMNS);
+      result.current?.hideColumn("col_b");
+    });
+
+    expect(result.current?.hiddenColumnIds.has("col_b")).toBe(true);
+    expect(result.current?.hiddenColumnIds.size).toBe(1);
+    expect(result.current?.hasHiddenColumns).toBe(true);
+  });
+
+  it("should toggle column visibility with toggleColumnVisibility", () => {
+    const { result } = renderHook(() => useTransientColumnVisibility(), {
+      wrapper,
+    });
+
+    act(() => {
+      result.current?.setAllColumns(TEST_COLUMNS);
+    });
+
+    // Hide
+    act(() => {
+      result.current?.toggleColumnVisibility("col_a");
+    });
+    expect(result.current?.hiddenColumnIds.has("col_a")).toBe(true);
+
+    // Show again
+    act(() => {
+      result.current?.toggleColumnVisibility("col_a");
+    });
+    expect(result.current?.hiddenColumnIds.has("col_a")).toBe(false);
+  });
+
+  it("should clear all hidden columns with showAllColumns", () => {
+    const { result } = renderHook(() => useTransientColumnVisibility(), {
+      wrapper,
+    });
+
+    act(() => {
+      result.current?.setAllColumns(TEST_COLUMNS);
+      result.current?.hideColumn("col_a");
+      result.current?.hideColumn("col_b");
+    });
+
+    expect(result.current?.hiddenColumnIds.size).toBe(2);
+
+    act(() => {
+      result.current?.showAllColumns();
+    });
+
+    expect(result.current?.hiddenColumnIds.size).toBe(0);
+    expect(result.current?.hasHiddenColumns).toBe(false);
+  });
+
+  it("should return TableColumnOrderSetting[] from getVisibleColumnSettings", () => {
+    const { result } = renderHook(() => useTransientColumnVisibility(), {
+      wrapper,
+    });
+
+    act(() => {
+      result.current?.setAllColumns(TEST_COLUMNS);
+      result.current?.hideColumn("col_b");
+    });
+
+    const settings = result.current?.getVisibleColumnSettings();
+    expect(settings).toEqual([
+      { name: "col_a", enabled: true },
+      { name: "col_b", enabled: false },
+      { name: "col_c", enabled: true },
+    ]);
+  });
+
+  it("should return null when used outside the provider", () => {
+    const { result } = renderHook(() => useTransientColumnVisibility());
+
+    expect(result.current).toBeNull();
+  });
+});

--- a/frontend/src/metabase/redux/downloads.ts
+++ b/frontend/src/metabase/redux/downloads.ts
@@ -364,12 +364,16 @@ const getInternalDashcardParams = (
   type: string,
   result: Dataset,
   exportParams: ExportParams,
+  visualizationSettings?: VisualizationSettings,
 ): DownloadQueryResultsParams => ({
   method: "POST",
   url: `/api/dashboard/${dashboardId}/dashcard/${dashcardId}/card/${cardId}/query/${type}`,
   body: {
     parameters: result?.json_query?.parameters ?? [],
     ...exportParams,
+    ...(visualizationSettings
+      ? { visualization_settings: visualizationSettings }
+      : {}),
   },
 });
 
@@ -501,6 +505,7 @@ const getDatasetParams = ({
       type,
       result,
       exportParams,
+      visualizationSettings,
     );
   }
 

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.tsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.tsx
@@ -26,6 +26,7 @@ import {
   useMemoizedCallback,
 } from "metabase/common/hooks/use-memoized-callback";
 import DashboardS from "metabase/css/dashboard.module.css";
+import { useTransientColumnVisibility } from "metabase/dashboard/components/DashCard/TransientColumnVisibilityContext";
 import { DataGrid, type DataGridStylesProps } from "metabase/data-grid";
 import {
   FOOTER_HEIGHT,
@@ -188,9 +189,46 @@ export const TableInteractiveInner = forwardRef(function TableInteractiveInner(
   const isDashcardViewTable = isDashboard && !isSettings;
   const [sorting, setSorting] = useState<SortingState>([]);
 
+  const columnVisibility = useTransientColumnVisibility();
+  const isClientSideColumnHidingEnabled =
+    isDashcardViewTable &&
+    !isPivoted &&
+    settings["table.allow_column_hiding"] !== false;
+  const hiddenColumnIds = useMemo(
+    () => columnVisibility?.hiddenColumnIds ?? new Set<string>(),
+    [columnVisibility?.hiddenColumnIds],
+  );
+
   const tc = useTranslateContent();
 
   const { rows, cols } = data;
+
+  useEffect(() => {
+    if (isClientSideColumnHidingEnabled && columnVisibility) {
+      columnVisibility.setAllColumns(
+        cols.map((col, i) => ({
+          id: col.name,
+          name: getColumnTitle(i),
+        })),
+      );
+      columnVisibility.showAllColumns();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cols, isClientSideColumnHidingEnabled]);
+
+  const handleHideColumn = useCallback(
+    (columnId: string) => {
+      if (!columnVisibility || !isClientSideColumnHidingEnabled) {
+        return;
+      }
+      const visibleCount = cols.length - columnVisibility.hiddenColumnIds.size;
+      if (visibleCount <= 1) {
+        return;
+      }
+      columnVisibility.hideColumn(columnId);
+    },
+    [cols.length, columnVisibility, isClientSideColumnHidingEnabled],
+  );
 
   const getColumnSortDirection = useMemo(() => {
     if (!isClientSideSortingEnabled) {
@@ -545,6 +583,10 @@ export const TableInteractiveInner = forwardRef(function TableInteractiveInner(
               columnIndex={columnIndex}
               theme={theme}
               renderTableHeader={renderTableHeader}
+              onHideColumn={
+                isClientSideColumnHidingEnabled ? handleHideColumn : undefined
+              }
+              columnId={id}
             />
           );
         },
@@ -601,7 +643,23 @@ export const TableInteractiveInner = forwardRef(function TableInteractiveInner(
     isDashboard,
     tc,
     getInfoPopoversDisabledRef,
+    isClientSideColumnHidingEnabled,
+    handleHideColumn,
   ]);
+
+  const visibleColumnsOptions = useMemo(() => {
+    if (!isClientSideColumnHidingEnabled || hiddenColumnIds.size === 0) {
+      return columnsOptions;
+    }
+    return columnsOptions.filter(col => !hiddenColumnIds.has(col.id));
+  }, [columnsOptions, hiddenColumnIds, isClientSideColumnHidingEnabled]);
+
+  const visibleColumnOrder = useMemo(() => {
+    if (!isClientSideColumnHidingEnabled || hiddenColumnIds.size === 0) {
+      return columnOrder;
+    }
+    return columnOrder.filter(id => !hiddenColumnIds.has(id));
+  }, [columnOrder, hiddenColumnIds, isClientSideColumnHidingEnabled]);
 
   const handleColumnResize = useCallback(
     (columnName: string, width: number) => {
@@ -714,9 +772,9 @@ export const TableInteractiveInner = forwardRef(function TableInteractiveInner(
     data: rows,
     rowId,
     sorting,
-    columnOrder,
+    columnOrder: visibleColumnOrder,
     columnSizingMap,
-    columnsOptions,
+    columnsOptions: visibleColumnsOptions,
     theme: dataGridTheme,
     onColumnResize: handleColumnResize,
     onColumnReorder: handleColumnReordering,

--- a/frontend/src/metabase/visualizations/components/TableInteractive/cells/HeaderCellWithColumnInfo.module.css
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/cells/HeaderCellWithColumnInfo.module.css
@@ -2,3 +2,14 @@
   width: auto;
   overflow: hidden;
 }
+
+.hideButton {
+  opacity: 0;
+  transition: opacity 150ms ease;
+  flex-shrink: 0;
+  margin-left: 4px;
+}
+
+[role="columnheader"]:hover .hideButton {
+  opacity: 1;
+}

--- a/frontend/src/metabase/visualizations/components/TableInteractive/cells/HeaderCellWithColumnInfo.tsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/cells/HeaderCellWithColumnInfo.tsx
@@ -1,5 +1,6 @@
 import type React from "react";
 import { memo, useMemo } from "react";
+import { t } from "ttag";
 
 import { QueryColumnInfoPopover } from "metabase/common/components/MetadataInfo/ColumnInfoPopover";
 import {
@@ -7,7 +8,7 @@ import {
   type HeaderCellProps,
   HeaderCellWrapper,
 } from "metabase/data-grid";
-import type { MantineTheme } from "metabase/ui";
+import { ActionIcon, Icon, type MantineTheme } from "metabase/ui";
 import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
 import type { DatasetColumn } from "metabase-types/api";
@@ -27,6 +28,8 @@ export interface HeaderCellWithColumnInfoProps extends HeaderCellProps {
     index: number,
     theme: MantineTheme,
   ) => React.ReactNode;
+  onHideColumn?: (columnId: string) => void;
+  columnId?: string;
 }
 
 export const HeaderCellWithColumnInfo = memo(
@@ -43,6 +46,8 @@ export const HeaderCellWithColumnInfo = memo(
     theme,
     className,
     renderTableHeader,
+    onHideColumn,
+    columnId,
   }: HeaderCellWithColumnInfoProps) {
     const headerCellOverride = useMemo(() => {
       return renderTableHeader != null
@@ -87,6 +92,19 @@ export const HeaderCellWithColumnInfo = memo(
     return (
       <HeaderCellWrapper className={className} variant={variant} align={align}>
         {headerContent}
+        {onHideColumn && columnId && (
+          <ActionIcon
+            size="xs"
+            className={S.hideButton}
+            onClick={(e: React.MouseEvent) => {
+              e.stopPropagation();
+              onHideColumn(columnId);
+            }}
+            aria-label={t`Hide column`}
+          >
+            <Icon name="eye_crossed_out" size={12} />
+          </ActionIcon>
+        )}
       </HeaderCellWrapper>
     );
   },

--- a/frontend/src/metabase/visualizations/components/TableInteractive/cells/HeaderCellWithColumnInfo.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/cells/HeaderCellWithColumnInfo.unit.spec.tsx
@@ -1,0 +1,101 @@
+import userEvent from "@testing-library/user-event";
+
+import { renderWithProviders, screen } from "__support__/ui";
+import type { DatasetColumn } from "metabase-types/api";
+
+import { HeaderCellWithColumnInfo } from "./HeaderCellWithColumnInfo";
+
+// Minimal mock that avoids needing a real metabase-lib Question.
+// When getInfoPopoversDisabled returns true (dashboard mode), the component
+// doesn't call question.query(), so we only need a stub.
+const mockQuestion = {} as any;
+
+const mockColumn: DatasetColumn = {
+  name: "TOTAL",
+  display_name: "Total",
+  base_type: "type/Float",
+  semantic_type: null,
+  source: "fields",
+  effective_type: "type/Float",
+  field_ref: ["field", 1, null],
+} as DatasetColumn;
+
+const mockTheme = {} as any;
+
+const defaultProps = {
+  name: "Total",
+  align: "right" as const,
+  sort: undefined,
+  variant: "light" as const,
+  getInfoPopoversDisabled: () => true,
+  question: mockQuestion,
+  column: mockColumn,
+  columnIndex: 0,
+  theme: mockTheme,
+};
+
+describe("HeaderCellWithColumnInfo", () => {
+  it("should not render a hide button when onHideColumn is not provided", () => {
+    renderWithProviders(<HeaderCellWithColumnInfo {...defaultProps} />);
+
+    expect(
+      screen.queryByRole("button", { name: "Hide column" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should render a hide button when onHideColumn is provided", () => {
+    const onHideColumn = jest.fn();
+    renderWithProviders(
+      <HeaderCellWithColumnInfo
+        {...defaultProps}
+        onHideColumn={onHideColumn}
+        columnId="TOTAL"
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Hide column" }),
+    ).toBeInTheDocument();
+  });
+
+  it("should call onHideColumn with the columnId when the hide button is clicked", async () => {
+    const onHideColumn = jest.fn();
+    renderWithProviders(
+      <HeaderCellWithColumnInfo
+        {...defaultProps}
+        onHideColumn={onHideColumn}
+        columnId="TOTAL"
+      />,
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Hide column" }),
+    );
+
+    expect(onHideColumn).toHaveBeenCalledWith("TOTAL");
+    expect(onHideColumn).toHaveBeenCalledTimes(1);
+  });
+
+  it("should stop event propagation when the hide button is clicked", async () => {
+    const onHideColumn = jest.fn();
+    const onParentClick = jest.fn();
+
+    const onParentClickHandler = onParentClick;
+    renderWithProviders(
+      <div role="button" tabIndex={0} onKeyDown={onParentClickHandler} onClick={onParentClickHandler}>
+        <HeaderCellWithColumnInfo
+          {...defaultProps}
+          onHideColumn={onHideColumn}
+          columnId="TOTAL"
+        />
+      </div>,
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Hide column" }),
+    );
+
+    expect(onHideColumn).toHaveBeenCalledTimes(1);
+    expect(onParentClick).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/metabase/visualizations/visualizations/Table/Table.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Table/Table.tsx
@@ -115,6 +115,17 @@ export class Table extends Component<TableProps, TableState> {
       widget: "toggle",
       default: false,
     },
+    "table.allow_column_hiding": {
+      get section() {
+        return t`Columns`;
+      },
+      get title() {
+        return t`Allow column selection`;
+      },
+      inline: true,
+      widget: "toggle",
+      default: false,
+    },
     "table.pivot": {
       get section() {
         return t`Columns`;

--- a/src/metabase/dashboards_rest/api.clj
+++ b/src/metabase/dashboards_rest/api.clj
@@ -1426,35 +1426,39 @@
                                                                 [:card-id       ms/PositiveInt]
                                                                 [:export-format ::qp.schema/export-format]]
    _query-params
-   {:keys          [parameters]
+   {:keys          [parameters visualization_settings]
     format-rows?   :format_rows
     pivot-results? :pivot_results}
    :- [:map
-       [:parameters    {:optional true} [:maybe [:or
-                                                 [:sequential ParameterWithID]
-                                                 ;; support <form> encoded params for backwards compatibility... see
-                                                 ;; https://metaboat.slack.com/archives/C010L1Z4F9S/p1738003606875659
-                                                 ms/JSONString]]]
-       [:format_rows   {:default false} ms/BooleanValue]
-       [:pivot_results {:default false} ms/BooleanValue]]]
+       [:parameters             {:optional true} [:maybe [:or
+                                                          [:sequential ParameterWithID]
+                                                          ;; support <form> encoded params for backwards compatibility... see
+                                                          ;; https://metaboat.slack.com/archives/C010L1Z4F9S/p1738003606875659
+                                                          ms/JSONString]]]
+       [:visualization_settings {:optional true} [:maybe [:or :map ms/JSONString]]]
+       [:format_rows            {:default false} ms/BooleanValue]
+       [:pivot_results          {:default false} ms/BooleanValue]]]
   (m/mapply qp.dashboard/process-query-for-dashcard
-            {:dashboard-id  dashboard-id
-             :card-id       card-id
-             :dashcard-id   dashcard-id
-             :export-format export-format
-             :parameters    (cond-> parameters
-                              (string? parameters) json/decode+kw)
-             :context       (api.dataset/export-format->context export-format)
-             :constraints   nil
-             ;; TODO -- passing this `:middleware` map is a little repetitive, need to think of a way to not have to
-             ;; specify this all over the codebase any time we want to do a query with an export format. Maybe this
-             ;; should be the default if `export-format` isn't `:api`?
-             :middleware    {:process-viz-settings?  true
-                             :skip-results-metadata? true
-                             :ignore-cached-results? true
-                             :format-rows?           format-rows?
-                             :pivot?                 pivot-results?
-                             :js-int-to-string?      false}}))
+            (cond-> {:dashboard-id  dashboard-id
+                     :card-id       card-id
+                     :dashcard-id   dashcard-id
+                     :export-format export-format
+                     :parameters    (cond-> parameters
+                                     (string? parameters) json/decode+kw)
+                     :context       (api.dataset/export-format->context export-format)
+                     :constraints   nil
+                     ;; TODO -- passing this `:middleware` map is a little repetitive, need to think of a way to not have to
+                     ;; specify this all over the codebase any time we want to do a query with an export format. Maybe this
+                     ;; should be the default if `export-format` isn't `:api`?
+                     :middleware    {:process-viz-settings?  true
+                                    :skip-results-metadata? true
+                                    :ignore-cached-results? true
+                                    :format-rows?           format-rows?
+                                    :pivot?                 pivot-results?
+                                    :js-int-to-string?      false}}
+              visualization_settings (assoc :visualization-settings
+                                            (cond-> visualization_settings
+                                              (string? visualization_settings) json/decode+kw)))))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen

--- a/src/metabase/query_processor/card.clj
+++ b/src/metabase/query_processor/card.clj
@@ -314,7 +314,8 @@
   all valid options."
   [card-id :- ::lib.schema.id/card
    export-format
-   & {:keys [parameters constraints context dashboard-id dashcard-id middleware qp make-run ignore-cache]
+   & {:keys [parameters constraints context dashboard-id dashcard-id middleware qp make-run ignore-cache
+             visualization-settings]
       :or   {constraints (qp.constraints/default-query-constraints)
              context     :question
              ;; param `make-run` can be used to control how the query is ran, e.g. if you need to customize the `context`
@@ -332,7 +333,9 @@
                               dashcard-id)
                      (t2/select-one-fn :visualization_settings :model/DashboardCard :id dashcard-id))
         card-viz   (:visualization_settings card)
-        merged-viz (m/deep-merge card-viz dash-viz)
+        merged-viz (cond-> (m/deep-merge card-viz dash-viz)
+                     ;; Allow request-body overrides (e.g. transient column hiding) to take precedence
+                     visualization-settings (m/deep-merge visualization-settings))
         ;; We need to check this here because dashcards don't get selected until this point
         qp         (if (= :pivot (:display card))
                      qp.pivot/run-pivot-query

--- a/src/metabase/query_processor/dashboard.clj
+++ b/src/metabase/query_processor/dashboard.clj
@@ -166,7 +166,7 @@
   Exception if preconditions such as proper permissions are not met *before* returning the `StreamingResponse`.
 
   See [[metabase.query-processor.card/process-query-for-card]] for more information about the various parameters."
-  {:arglists '([& {:keys [dashboard-id card-id dashcard-id export-format parameters ignore-cache constraints parameters middleware]}])}
+  {:arglists '([& {:keys [dashboard-id card-id dashcard-id export-format parameters ignore-cache constraints parameters middleware visualization-settings]}])}
   [& {:keys [dashboard-id card-id dashcard-id parameters export-format]
       :or   {export-format :api}
       :as   options}]

--- a/test/metabase/api/downloads_exports_test.clj
+++ b/test/metabase/api/downloads_exports_test.clj
@@ -949,6 +949,37 @@
                    {:card-download     (first card-result)
                     :dashcard-download (first dashcard-result)}))))))))
 
+(deftest ^:parallel dashcard-viz-settings-override-downloads-test
+  (testing "visualization_settings sent in the request body override DB-persisted settings in dashcard downloads"
+    (mt/dataset test-data
+      (mt/with-temp [:model/Card {card-id :id} {:display       :table
+                                                 :dataset_query {:database (mt/id)
+                                                                 :type     :query
+                                                                 :query    {:source-table (mt/id :orders)}}}
+                     :model/Dashboard {dashboard-id :id} {}
+                     :model/DashboardCard {dashcard-id :id} {:dashboard_id dashboard-id
+                                                              :card_id      card-id}]
+        (let [;; Build table.columns that enables only ID, Tax, and Quantity, disabling the rest
+              override-viz {"table.columns"
+                            [{"name" "ID"         "fieldRef" ["field" (mt/id :orders :id) nil]         "enabled" true}
+                             {"name" "USER_ID"    "fieldRef" ["field" (mt/id :orders :user-id) nil]    "enabled" false}
+                             {"name" "PRODUCT_ID" "fieldRef" ["field" (mt/id :orders :product-id) nil] "enabled" false}
+                             {"name" "SUBTOTAL"   "fieldRef" ["field" (mt/id :orders :subtotal) nil]   "enabled" false}
+                             {"name" "TAX"        "fieldRef" ["field" (mt/id :orders :tax) nil]        "enabled" true}
+                             {"name" "TOTAL"      "fieldRef" ["field" (mt/id :orders :total) nil]      "enabled" false}
+                             {"name" "DISCOUNT"   "fieldRef" ["field" (mt/id :orders :discount) nil]   "enabled" false}
+                             {"name" "CREATED_AT" "fieldRef" ["field" (mt/id :orders :created-at) nil] "enabled" false}
+                             {"name" "QUANTITY"   "fieldRef" ["field" (mt/id :orders :quantity) nil]   "enabled" true}]}
+              result      (->> (mt/user-http-request :crowberto :post 200
+                                                     (format "dashboard/%d/dashcard/%d/card/%d/query/csv"
+                                                             dashboard-id dashcard-id card-id)
+                                                     {:format_rows             false
+                                                      :visualization_settings  override-viz})
+                               (process-results :csv))]
+          (is (= ["ID" "Tax" "Quantity"]
+                 (first result))
+              "Only columns marked as enabled in the request-body override should appear in the CSV"))))))
+
 (deftest dashcard-viz-settings-attachments-test
   (testing "Dashcard visualization settings are respected in subscription attachments."
     (testing "for csv"


### PR DESCRIPTION
> [!IMPORTANT]
> For those employed by Metabase: if you are merging into master, please add either a `backport` or a `no-backport` label to this PR. You will not be able to merge until you do this step. Refer to the section [Do I need to backport this PR?](https://www.notion.so/metabase/Metabase-Branching-Strategy-6eb577d5f61142aa960a626d6bbdfeb3?pvs=4#89f80d6f17714a0198aeb66c0efd1b71) in the Metabase Branching Strategy document for more details. If you're not employed by Metabase, this section does not apply to you, and the label will be taken care of by your reviewer.

> **Warning**
>
> If that is your first contribution to Metabase, please sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform). Also, if you're attempting to fix a translation issue, please submit your changes to our [Crowdin project](https://crowdin.com/project/metabase-i18n) instead of opening a PR.

Closes https://github.com/metabase/metabase/issues/70849

### Description

**Column hiding UI:**
- Hide button (×) on each column header in dashboard table cards
- "Columns" submenu in the dashcard menu (⋯) with a checklist to toggle visibility and restore hidden columns
- Controlled by a new `table.allow_column_hiding` visualization setting (default: off)
- State is session-only — refreshing or navigating away resets to saved configuration

**Downloads respect hidden columns:**
- When columns are hidden, the frontend sends a `visualization_settings` override in the download request body
- The override is built from `result.data.cols` (all query columns including FK-remapped and value-remapped columns) to ensure extra columns don't leak into exports
- Backend accepts the optional `visualization_settings` on the dashcard download endpoint and deep-merges it on top of DB-persisted card/dashcard settings

### How to verify

**Column hiding:**
1. Create a new question → Sample Database → Orders → Save to a dashboard
2. Open the dashcard settings → enable "Allow column hiding" under the Table section
3. On the dashboard, hover over a column header → click the × button → column disappears
4. Open the dashcard menu (⋯) → "Columns" → toggle columns on/off
5. Refresh the page → verify all columns are back (state is transient)

**Downloads with hidden columns:**
1. With column hiding enabled, hide a few columns
2. Click the dashcard menu (⋯) → Download results → CSV
3. Verify the downloaded file only contains the visible columns
4. If the underlying question has FK remapping or value remapping, verify no extra remapped columns appear in the download

### Demo

<img width="947" height="409" alt="image" src="https://github.com/user-attachments/assets/f76e3cd0-9f34-4667-85a6-9f932cdcf72d" />
<img width="1014" height="492" alt="image" src="https://github.com/user-attachments/assets/fbd7e251-71c6-4ba2-a3fb-880a87666cf3" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
