### PR TITLE
Fix flaky schema-change integration test on Redshift

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/transforms_python/transforms_api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms_python/transforms_api_test.clj
@@ -558,8 +558,9 @@
                 (transforms.tu/test-run transform-id)
                 (transforms.tu/wait-for-transform-completion transform-id 10000)
 
-                ;; hmmm, looks like QP needs a bit more time to update metadata
-                (Thread/sleep 2000)
+                ;; Sync runs asynchronously after succeed-started-run!, so wait for
+                ;; the new "friend" field to appear in metadata before querying.
+                (transforms.tu/wait-for-field table-name "friend" 10000)
                 (let [updated-rows (transforms.tu/table-rows table-name)]
                   (is (= [["Alice" "Bob"] ["Bob" "Alice"]] updated-rows)
                       "Updated data should show Alice/Bob with friends instead of ages"))))))))))

--- a/test/metabase/transforms/test_util.clj
+++ b/test/metabase/transforms/test_util.clj
@@ -147,6 +147,23 @@
           (throw (ex-info (format "Transform run failed with status %s" status)
                           {:resp resp :status status})))))))
 
+(defn wait-for-field
+  "Wait for a field with `field-name` to appear as active on the table named `table-name`.
+   Useful after schema changes where sync runs asynchronously."
+  [table-name field-name timeout-ms]
+  (let [timer (u/start-timer)]
+    (loop []
+      (let [table  (t2/select-one :model/Table :name table-name :db_id (mt/id))
+            field  (when table
+                     (t2/select-one :model/Field :table_id (:id table) :name field-name :active true))]
+        (cond
+          field    field
+          (> (u/since-ms timer) timeout-ms)
+          (throw (ex-info (format "Field %s on table %s did not appear after %dms" field-name table-name timeout-ms)
+                          {:table-name table-name :field-name field-name :timeout-ms timeout-ms}))
+          :else    (do (Thread/sleep 200)
+                       (recur)))))))
+
 (defn get-test-schema
   "Get the schema from the products table in the test dataset.
    This is needed for databases like BigQuery that require a schema/dataset."


### PR DESCRIPTION
- Fixes flaky `python-transform-schema-change-integration-test` on Redshift
- **Hypothesis:** The transform run status is marked succeeded before the metadata sync finishes. On Redshift the sync is slower due to network latency, so the test queries before field metadata is updated.
- **Fix:** Poll for the expected field to appear instead of a fixed 2s sleep.