### PR TITLE
Fix broken deps not surfaced for missing fields in :fields (GHY-3157)

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/dependencies/models/analysis_finding.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/models/analysis_finding.clj
@@ -25,8 +25,9 @@
   - 3: Initial version
   - 4: Disable naive sql validation
   - 5: Added source entity tracking in analysis_finding_error table
-  - 6: Removed validate prefix from error_type in analysis_finding_error"
-  6)
+  - 6: Removed validate prefix from error_type in analysis_finding_error
+  - 7: Only mark inactive (not missing) field refs in :fields as soft (GHY-3157)"
+  7)
 
 (defn- error->finding-error-row
   "Convert an error from lib/find-bad-refs-with-source to a row for analysis_finding_error table.

--- a/enterprise/backend/test/metabase_enterprise/dependencies/findings_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/findings_test.clj
@@ -1,12 +1,15 @@
 (ns metabase-enterprise.dependencies.findings-test
   (:require
    [clojure.test :refer :all]
+   [medley.core :as m]
    [metabase-enterprise.dependencies.analysis :as deps.analysis]
    [metabase-enterprise.dependencies.findings :as deps.findings]
    [metabase-enterprise.dependencies.models.analysis-finding :as models.analysis-finding]
    [metabase.lib-be.core :as lib-be]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
+   [metabase.lib.test-metadata :as meta]
+   [metabase.lib.test-util :as lib.tu]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [toucan2.core :as t2]))
@@ -96,31 +99,27 @@
 ;; TODO: (bshepherdson, 2026-02-05) Add a test like does-not-report-errors-in-removable-refs-test-1-stage-fields for
 ;; join clause :fields as well. See QUE-3081 and QUE-3044.
 
-(deftest ^:sequential reports-missing-field-in-downstream-card-fields-test
+(deftest ^:parallel reports-missing-field-in-downstream-card-fields-test
   (testing "Q2 based on Q1 with :fields referencing a column Q1 no longer returns should be reported (GHY-3157)"
-    (let [mp      (mt/metadata-provider)
-          orders  (lib.metadata/table mp (mt/id :orders))
-          q1      (lib/query mp orders)
-          q1-cols (lib/returned-columns q1)]
-      (mt/with-premium-features #{:dependencies}
-        (mt/with-temp [:model/Card {q1-id :id} {:dataset_query q1}]
-          ;; Q2: based on Q1, with :fields selecting some columns including ID
-          (let [mp2       (lib-be/application-database-metadata-provider (mt/id))
-                q1-card   (lib.metadata/card mp2 q1-id)
-                q2-base   (lib/query mp2 q1-card)
-                q2-cols   (lib/returned-columns q2-base)
-                id-col    (some #(when (= (:name %) "ID") %) q2-cols)
-                total-col (some #(when (= (:name %) "TOTAL") %) q2-cols)
-                q2        (lib/with-fields q2-base [id-col total-col])]
-            (mt/with-temp [:model/Card {q2-id :id} {:dataset_query q2}]
-              ;; Now update Q1 to remove ID from its result_metadata, simulating Q1 dropping that field
-              (let [new-result-metadata (vec (remove #(= (:name %) "ID") q1-cols))]
-                (t2/update! :model/Card q1-id {:result_metadata new-result-metadata})
-                ;; check-entity on Q2 should find the missing field
-                (let [mp3     (lib-be/application-database-metadata-provider (mt/id))
-                      results (deps.analysis/check-entity mp3 :card q2-id)]
-                  (is (seq results)
-                      "Q2 should have findings for the missing ID column from Q1"))))))))))
+    (let [mp          meta/metadata-provider
+          q1          (lib/query mp (meta/table-metadata :orders))
+          q1-cols     (lib/returned-columns q1)
+          removed-col (m/find-first #(= (:name %) "ID") q1-cols)
+          ;; Card 101 = Q1 with ID removed from result-metadata (simulates Q1 dropping that field)
+          mp          (lib.tu/metadata-provider-with-card-from-query
+                       mp 101 q1
+                       {:result-metadata (vec (remove #(= (:name %) "ID") q1-cols))})
+          ;; Q2: query based on card 101, with :fields including the now-missing ID
+          q2-base     (lib/query mp {:lib/type :metadata/card :id 101})
+          q2-cols     (lib/returned-columns q2-base)
+          q2          (lib/with-fields q2-base (conj (vec q2-cols) (lib/ref removed-col)))
+          ;; Card 102 = Q2 (provide result-metadata explicitly since q2 has a bad ref)
+          mp          (lib.tu/metadata-provider-with-card-from-query
+                       mp 102 q2
+                       {:result-metadata (vec q2-cols)})
+          results     (deps.analysis/check-entity mp :card 102)]
+      (is (seq results)
+          "Q2 should have findings for the missing ID column from Q1"))))
 
 (defn- stale-map
   "Returns a map of {entity-id stale?} for the given card IDs."

--- a/enterprise/backend/test/metabase_enterprise/dependencies/findings_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/findings_test.clj
@@ -1,6 +1,7 @@
 (ns metabase-enterprise.dependencies.findings-test
   (:require
    [clojure.test :refer :all]
+   [metabase-enterprise.dependencies.analysis :as deps.analysis]
    [metabase-enterprise.dependencies.findings :as deps.findings]
    [metabase-enterprise.dependencies.models.analysis-finding :as models.analysis-finding]
    [metabase.lib-be.core :as lib-be]
@@ -72,8 +73,8 @@
                                    :analyzed_entity_id card-id
                                    :analyzed_entity_type :card))))))))
 
-(deftest ^:sequential does-not-report-errors-in-removable-refs-test-1-stage-fields
-  (testing ":fields lists have soft refs that the QP will remove, so they're not considered analysis findings"
+(deftest ^:sequential does-report-errors-for-missing-refs-in-fields-test
+  (testing "missing (not inactive) field refs in :fields are reported as findings (GHY-3157)"
     (backfill-all-entity-analyses!)
     (let [mp      (mt/metadata-provider)
           orders  (lib.metadata/table mp (mt/id :orders))
@@ -86,7 +87,7 @@
       (mt/with-premium-features #{:dependencies}
         (mt/with-temp [:model/Card {card-id :id} {:dataset_query query}]
           (is (= 1 (deps.findings/analyze-batch! :card 1)))
-          (is (= [models.analysis-finding/*current-analysis-finding-version* true]
+          (is (= [models.analysis-finding/*current-analysis-finding-version* false]
                  (t2/select-one-fn (juxt :analysis_version :result)
                                    :model/AnalysisFinding
                                    :analyzed_entity_id card-id
@@ -94,6 +95,32 @@
 
 ;; TODO: (bshepherdson, 2026-02-05) Add a test like does-not-report-errors-in-removable-refs-test-1-stage-fields for
 ;; join clause :fields as well. See QUE-3081 and QUE-3044.
+
+(deftest ^:sequential reports-missing-field-in-downstream-card-fields-test
+  (testing "Q2 based on Q1 with :fields referencing a column Q1 no longer returns should be reported (GHY-3157)"
+    (let [mp      (mt/metadata-provider)
+          orders  (lib.metadata/table mp (mt/id :orders))
+          q1      (lib/query mp orders)
+          q1-cols (lib/returned-columns q1)]
+      (mt/with-premium-features #{:dependencies}
+        (mt/with-temp [:model/Card {q1-id :id} {:dataset_query q1}]
+          ;; Q2: based on Q1, with :fields selecting some columns including ID
+          (let [mp2       (lib-be/application-database-metadata-provider (mt/id))
+                q1-card   (lib.metadata/card mp2 q1-id)
+                q2-base   (lib/query mp2 q1-card)
+                q2-cols   (lib/returned-columns q2-base)
+                id-col    (some #(when (= (:name %) "ID") %) q2-cols)
+                total-col (some #(when (= (:name %) "TOTAL") %) q2-cols)
+                q2        (lib/with-fields q2-base [id-col total-col])]
+            (mt/with-temp [:model/Card {q2-id :id} {:dataset_query q2}]
+              ;; Now update Q1 to remove ID from its result_metadata, simulating Q1 dropping that field
+              (let [new-result-metadata (vec (remove #(= (:name %) "ID") q1-cols))]
+                (t2/update! :model/Card q1-id {:result_metadata new-result-metadata})
+                ;; check-entity on Q2 should find the missing field
+                (let [mp3     (lib-be/application-database-metadata-provider (mt/id))
+                      results (deps.analysis/check-entity mp3 :card q2-id)]
+                  (is (seq results)
+                      "Q2 should have findings for the missing ID column from Q1"))))))))))
 
 (defn- stale-map
   "Returns a map of {entity-id stale?} for the given card IDs."

--- a/src/metabase/lib/validate.cljc
+++ b/src/metabase/lib/validate.cljc
@@ -138,7 +138,8 @@
                    source   (extract-source-from-field-ref query stage-number clause)
                    error    (cond-> (missing-column-error col-name)
                               source                                          (merge source)
-                              (and (seq fields)
+                              (and (not (:active column true))
+                                   (seq fields)
                                    (perf/some #(identical? clause %) fields)) (assoc :soft? true))]
                (vswap! bad-fields conj error)))))
        nil))

--- a/test/metabase/lib/validate_test.cljc
+++ b/test/metabase/lib/validate_test.cljc
@@ -268,6 +268,29 @@
               :name               "missingcol"}
              (first errors))))))
 
+(deftest ^:parallel find-bad-refs-with-source-inactive-field-in-fields-is-soft-test
+  (testing "inactive field refs in top-level `:fields` clauses are marked :soft?"
+    (let [mp           meta/metadata-provider
+          base         (lib/query mp (meta/table-metadata :orders))
+          fieldable    (->> (lib/fieldable-columns base)
+                            (filter :selected?))
+          last-col     (last fieldable)
+          ;; Create a provider where this field is inactive
+          mp           (lib.tu/mock-metadata-provider
+                        mp
+                        {:fields [(assoc last-col :active false)]})
+          query        (lib/query mp (meta/table-metadata :orders))
+          fields       (mapv lib/ref fieldable)
+          bad-query    (lib/with-fields query fields)
+          errors       (lib/find-bad-refs-with-source bad-query)]
+      (is (= 1 (count errors)))
+      (is (= {:type               :missing-column
+              :source-entity-type :table
+              :source-entity-id   (meta/id :orders)
+              :name               (:name last-col)
+              :soft?              true}
+             (first errors))))))
+
 (deftest ^:parallel find-bad-refs-with-source-missing-field-in-fields-not-soft-test
   (testing "missing field refs in `:fields` (not just inactive) should NOT be marked :soft? (GHY-3157)"
     (let [mp           meta/metadata-provider

--- a/test/metabase/lib/validate_test.cljc
+++ b/test/metabase/lib/validate_test.cljc
@@ -248,8 +248,8 @@
               :name "missingcol"}
              (first errors))))))
 
-(deftest ^:parallel find-bad-refs-with-source-soft-refs-test-1-main-fields
-  (testing "invalid field refs in top-level `:fields` clauses are marked :soft?"
+(deftest ^:parallel find-bad-refs-with-source-missing-field-in-fields-not-soft-test-1-main-fields
+  (testing "missing (not inactive) field refs in top-level `:fields` clauses are NOT marked :soft?"
     (let [mp           meta/metadata-provider
           base         (lib/query mp (meta/table-metadata :orders))
           removing     (->> (lib/fieldable-columns base)
@@ -265,9 +265,34 @@
       (is (= {:type               :missing-column
               :source-entity-type :table
               :source-entity-id   (meta/id :orders)
-              :name               "missingcol"
-              :soft?              true}
+              :name               "missingcol"}
              (first errors))))))
+
+(deftest ^:parallel find-bad-refs-with-source-missing-field-in-fields-not-soft-test
+  (testing "missing field refs in `:fields` (not just inactive) should NOT be marked :soft? (GHY-3157)"
+    (let [mp           meta/metadata-provider
+          ;; Q1: query on orders with explicit fields
+          q1           (lib/query mp (meta/table-metadata :orders))
+          q1-cols      (lib/returned-columns q1)
+          ;; Create card 101 from Q1, but with one column removed from result-metadata
+          ;; This simulates Q1 dropping a field (e.g., removing ID from :fields)
+          removed-col  (m/find-first #(= (:name %) "ID") q1-cols)
+          mp           (lib.tu/metadata-provider-with-card-from-query
+                        mp 101 q1
+                        {:result-metadata (vec (remove #(= (:name %) "ID") q1-cols))})
+          ;; Q2: query based on card 101, with :fields that include the now-missing ID
+          q2           (lib/query mp {:lib/type :metadata/card :id 101})
+          q2-cols      (lib/returned-columns q2)
+          ;; Add a :fields clause that includes a ref to the removed column
+          q2-with-fields (lib/with-fields q2 (concat q2-cols [(lib/ref removed-col)]))
+          errors       (lib/find-bad-refs-with-source q2-with-fields)]
+      (is (= 1 (count errors)))
+      ;; The key assertion: this should NOT be soft, because the field is missing, not just inactive
+      (is (not (:soft? (first errors))))
+      (is (= {:type               :missing-column
+              :source-entity-type :card
+              :source-entity-id   101}
+             (select-keys (first errors) [:type :source-entity-type :source-entity-id]))))))
 
 ;; TODO: (bshepherdson, 2026-02-05) This doesn't pass right now, because refs in join clauses are ignored by
 ;; find-bad-refs-with-source. Restore this test as part of QUE-3081.


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #69927
## Summary
- The `:soft?` marking in `find-bad-refs-with-source` was too broad — it marked **all** bad refs in `:fields` clauses as soft, even when the field was completely missing from the source (not just inactive).
- Added `(not (:active column true))` guard so only **inactive** fields in `:fields` are marked `:soft?`. Missing/unresolvable fields remain hard errors and are properly surfaced by dependency analysis.
- This preserves the GHY-3044 fix (inactive fields the QP can drop are still soft) while fixing GHY-3157 (genuinely missing fields are reported).

## Test plan
- [x] New unit test: missing card field in `:fields` is NOT marked `:soft?`
- [x] New integration test: `check-entity` on Q2 reports findings when Q1 drops a referenced field
- [x] Updated existing tests to expect missing (not inactive) fields in `:fields` to be reported as findings
- [x] Existing `find-bad-refs-with-source` tests continue to pass

Closes: GHY-3157