### PR TITLE
Fix SQL injection in workspace grant via unescaped identifiers

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/workspaces/isolation_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/isolation_test.clj
@@ -7,6 +7,7 @@
    [metabase-enterprise.workspaces.util :as ws.u]
    [metabase.driver :as driver]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
+   [metabase.driver.sql.util :as sql.u]
    [metabase.driver.util :as driver.u]
    [metabase.lib.core :as lib]
    [metabase.test :as mt]
@@ -203,3 +204,85 @@
                    database
                    nil))
             "Should succeed when test-table is nil")))))
+
+;;; SQL injection via identifier interpolation tests
+;;
+;; grant-workspace-read-access! builds GRANT SQL by interpolating schema/table names
+;; from synced metadata. If those names contain the identifier delimiter character
+;; (" for Postgres), the SQL breaks or becomes injectable.
+;;
+;; Two entry points feed external table names into this code:
+;; 1. Synced metadata: metabase_table rows (schema/name persisted as-is from source DB)
+;;    → WorkspaceInput → sync-grant-accesses! → grant-workspace-read-access!
+;; 2. Native query refs: driver/native-query-table-refs parses SQL to extract table names
+;;    → WorkspaceInput → sync-grant-accesses! → grant-workspace-read-access!
+;;
+;; Both converge at grant-workspace-read-access!, so we test the SQL construction there.
+
+(defn- with-pg-isolation
+  "Set up Postgres workspace isolation manually and call f with [workspace conn-spec].
+   Tears down isolation resources afterward."
+  [f]
+  (let [database    (mt/db)
+        test-ws     {:id   (str (random-uuid))
+                     :name "_test_injection_"}
+        init-result (driver/init-workspace-isolation! :postgres database test-ws)
+        workspace   (merge test-ws init-result)
+        conn-spec   (sql-jdbc.conn/db->pooled-connection-spec (:id database))]
+    (try
+      (f workspace conn-spec)
+      (finally
+        (driver/destroy-workspace-isolation! :postgres database workspace)))))
+
+(defn- pg-create-table!
+  "Create a table in Postgres using properly-escaped DDL."
+  [conn-spec schema table-name]
+  (let [qs (sql.u/quote-name :postgres :schema schema)
+        qt (sql.u/quote-name :postgres :table table-name)]
+    (jdbc/execute! conn-spec [(format "CREATE TABLE %s.%s (id INT)" qs qt)])))
+
+(defn- pg-drop-schema!
+  [conn-spec schema]
+  (jdbc/execute! conn-spec [(format "DROP SCHEMA IF EXISTS %s CASCADE"
+                                    (sql.u/quote-name :postgres :schema schema))]))
+
+(deftest grant-workspace-read-access-escapes-table-names-test
+  (mt/test-driver :postgres
+    (testing "Table names with embedded double-quote should not cause SQL injection (entry point: synced metadata)"
+      ;; Synced metadata persists table names as-is from the source database.
+      ;; A table named: evil"table produces broken SQL without escaping:
+      ;;   GRANT SELECT ON TABLE "schema"."evil"table" TO "user"  -- syntax error / injection
+      ;; With proper escaping it becomes:
+      ;;   GRANT SELECT ON TABLE "schema"."evil""table" TO "user"  -- valid identifier
+      (with-pg-isolation
+        (fn [workspace conn-spec]
+          (let [ws-schema (:schema workspace)
+                evil-name "evil\"table"]
+            (pg-create-table! conn-spec ws-schema evil-name)
+            (is (driver/grant-workspace-read-access!
+                 :postgres (mt/db) workspace
+                 [{:schema ws-schema :name evil-name}])
+                "GRANT should succeed without SQL syntax error for table names with embedded quotes")))))))
+
+(deftest grant-workspace-read-access-escapes-schema-names-test
+  (mt/test-driver :postgres
+    (testing "Schema names with embedded double-quote should not cause SQL injection (entry point: native query refs)"
+      ;; Native query parsing extracts schema.table references from SQL.
+      ;; A schema named: evil"schema produces broken SQL without escaping:
+      ;;   GRANT USAGE ON SCHEMA "evil"schema" TO "user"  -- syntax error / injection
+      ;; With proper escaping:
+      ;;   GRANT USAGE ON SCHEMA "evil""schema" TO "user"  -- valid identifier
+      (with-pg-isolation
+        (fn [workspace conn-spec]
+          (let [evil-schema "evil\"schema"
+                table-name  "normal_table"]
+            (jdbc/execute! conn-spec [(format "CREATE SCHEMA %s"
+                                              (sql.u/quote-name :postgres :schema evil-schema))])
+            (try
+              (pg-create-table! conn-spec evil-schema table-name)
+              (is (driver/grant-workspace-read-access!
+                   :postgres (mt/db) workspace
+                   [{:schema evil-schema :name table-name}])
+                  "GRANT should succeed without SQL syntax error for schema names with embedded quotes")
+              (finally
+                (pg-drop-schema! conn-spec evil-schema)))))))))

--- a/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
+++ b/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
@@ -382,11 +382,12 @@
 (defmethod driver/grant-workspace-read-access! :clickhouse
   [_driver database workspace tables]
   (let [read-user-name (-> workspace :database_details :user)
+        qu             (sql.u/quote-name :clickhouse :field read-user-name)
         sqls           (for [table tables]
-                         (format "GRANT SELECT ON `%s`.`%s` TO `%s`"
-                                 (:schema table)
-                                 (:name table)
-                                 read-user-name))]
+                         (format "GRANT SELECT ON %s.%s TO %s"
+                                 (sql.u/quote-name :clickhouse :schema (:schema table))
+                                 (sql.u/quote-name :clickhouse :table (:name table))
+                                 qu))]
     (when-not read-user-name
       (throw (ex-info "Workspace isolation is not properly initialized - missing read user name"
                       {:workspace-id (:id workspace) :step :grant})))

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -1083,14 +1083,19 @@
     (when-not role-name
       (throw (ex-info "Workspace isolation is not properly initialized - missing role name"
                       {:workspace-id (:id workspace) :step :grant})))
-    ;; Grant USAGE on each unique schema first (required to access tables within)
-    (doseq [schema (distinct (map :schema tables))]
-      (jdbc/execute! conn-spec [(format "GRANT USAGE ON SCHEMA \"%s\".\"%s\" TO ROLE \"%s\""
-                                        db-name schema role-name)]))
-    ;; Grant SELECT on each specific table
-    (doseq [table tables]
-      (jdbc/execute! conn-spec [(format "GRANT SELECT ON TABLE \"%s\".\"%s\".\"%s\" TO ROLE \"%s\""
-                                        db-name (:schema table) (:name table) role-name)]))))
+    (let [qdb (sql.u/quote-name :snowflake :schema db-name)
+          qr  (sql.u/quote-name :snowflake :field role-name)]
+      ;; Grant USAGE on each unique schema first (required to access tables within)
+      (doseq [schema (distinct (map :schema tables))]
+        (jdbc/execute! conn-spec [(format "GRANT USAGE ON SCHEMA %s.%s TO ROLE %s"
+                                          qdb (sql.u/quote-name :snowflake :schema schema) qr)]))
+      ;; Grant SELECT on each specific table
+      (doseq [table tables]
+        (jdbc/execute! conn-spec [(format "GRANT SELECT ON TABLE %s.%s.%s TO ROLE %s"
+                                          qdb
+                                          (sql.u/quote-name :snowflake :schema (:schema table))
+                                          (sql.u/quote-name :snowflake :table (:name table))
+                                          qr)])))))
 
 (defmethod driver/llm-sql-dialect-resource :snowflake [_]
   "llm/prompts/dialects/snowflake.md")

--- a/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
+++ b/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
@@ -1172,9 +1172,12 @@
       (throw (ex-info "Workspace isolation is not properly initialized - missing read user name"
                       {:workspace-id (:id workspace) :step :grant})))
     ;; Grant SELECT on each specific table only - no schema-level grants
-    (doseq [table tables]
-      (jdbc/execute! conn-spec [(format "GRANT SELECT ON [%s].[%s] TO [%s]"
-                                        (:schema table) (:name table) username)]))))
+    (let [qu (sql.u/quote-name :sqlserver :field username)]
+      (doseq [table tables]
+        (jdbc/execute! conn-spec [(format "GRANT SELECT ON %s.%s TO %s"
+                                          (sql.u/quote-name :sqlserver :schema (:schema table))
+                                          (sql.u/quote-name :sqlserver :table (:name table))
+                                          qu)])))))
 
 (defmethod driver/llm-sql-dialect-resource :sqlserver [_]
   "llm/prompts/dialects/sqlserver.md")

--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -21,6 +21,7 @@
    [metabase.driver.sql.normalize :as sql.normalize]
    [metabase.driver.sql.query-processor :as sql.qp]
    [metabase.driver.sql.query-processor.like-escape-char-built-in :as like-escape-char-built-in]
+   [metabase.driver.sql.util :as sql.u]
    [metabase.driver.util :as driver.u]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.schema.metadata :as lib.schema.metadata]
@@ -733,18 +734,21 @@
 (defmethod driver/grant-workspace-read-access! :h2
   [_driver database workspace tables]
   (let [username (-> workspace :database_details :db get-user-from-connection-string)
+        qu       (sql.u/quote-name :h2 :field username)
         schemas  (distinct (map :schema tables))]
     ;; H2 uses GRANT SELECT ON SCHEMA schemaName TO userName
     (jdbc/with-db-transaction [t-conn (sql-jdbc.conn/db->pooled-connection-spec (:id database))]
       (with-open [^Statement stmt (.createStatement ^Connection (:connection t-conn))]
         (doseq [schema schemas]
           (.addBatch ^Statement stmt
-                     ^String (format "GRANT SELECT ON SCHEMA \"%s\" TO \"%s\"" schema username)))
+                     ^String (format "GRANT SELECT ON SCHEMA %s TO %s"
+                                     (sql.u/quote-name :h2 :schema schema) qu)))
         ;; Also grant on individual tables for more fine-grained access
         (doseq [table tables]
           (.addBatch ^Statement stmt
-                     ^String (format "GRANT SELECT ON \"%s\".\"%s\" TO \"%s\""
-                                     (:schema table) (:name table) username)))
+                     ^String (format "GRANT SELECT ON %s.%s TO %s"
+                                     (sql.u/quote-name :h2 :schema (:schema table))
+                                     (sql.u/quote-name :h2 :table (:name table)) qu)))
         (.executeBatch ^Statement stmt)))))
 
 (defmethod driver/llm-sql-dialect-resource :h2 [_]

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -1277,12 +1277,16 @@
 (defmethod driver/grant-workspace-read-access! :mysql
   [_driver database workspace tables]
   (let [username (-> workspace :database_details :user)
+        qu       (sql.u/quote-name :mysql :field username)
         ;; In MySQL, tables don't have separate schemas within a database,
         ;; but the :schema field contains the source database name
         sqls     (for [{db :schema, t :name} tables]
                    (if (str/blank? db)
-                     (format "GRANT SELECT ON `%s` TO `%s`@'%%'" t username)
-                     (format "GRANT SELECT ON `%s`.`%s` TO `%s`@'%%'" db t username)))]
+                     (format "GRANT SELECT ON %s TO %s@'%%'"
+                             (sql.u/quote-name :mysql :table t) qu)
+                     (format "GRANT SELECT ON %s.%s TO %s@'%%'"
+                             (sql.u/quote-name :mysql :schema db)
+                             (sql.u/quote-name :mysql :table t) qu)))]
     (jdbc/with-db-transaction [t-conn (sql-jdbc.conn/db->pooled-connection-spec (:id database))]
       (with-open [^Statement stmt (.createStatement ^Connection (:connection t-conn))]
         (doseq [sql sqls]

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -1368,6 +1368,7 @@
 (defmethod driver/grant-workspace-read-access! :postgres
   [_driver database workspace tables]
   (let [username       (-> workspace :database_details :user)
+        qu             (sql.u/quote-name :postgres :field username)
         ;; Collect all unique source schemas that contain the tables we need to grant access to
         source-schemas (into #{} (keep :schema) tables)
         ;; Grant USAGE on source schemas, then SELECT on each table
@@ -1375,12 +1376,16 @@
         sqls           (concat
                         ;; USAGE on each source schema containing tables we're granting access to
                         (for [s source-schemas]
-                          (format "GRANT USAGE ON SCHEMA \"%s\" TO \"%s\"" s username))
+                          (format "GRANT USAGE ON SCHEMA %s TO %s"
+                                  (sql.u/quote-name :postgres :schema s) qu))
                         ;; SELECT on each table
                         (for [{s :schema, t :name} tables]
                           (if (str/blank? s)
-                            (format "GRANT SELECT ON TABLE \"%s\" TO \"%s\"" t username)
-                            (format "GRANT SELECT ON TABLE \"%s\".\"%s\" TO \"%s\"" s t username))))]
+                            (format "GRANT SELECT ON TABLE %s TO %s"
+                                    (sql.u/quote-name :postgres :table t) qu)
+                            (format "GRANT SELECT ON TABLE %s.%s TO %s"
+                                    (sql.u/quote-name :postgres :schema s)
+                                    (sql.u/quote-name :postgres :table t) qu))))]
     (jdbc/with-db-transaction [t-conn (sql-jdbc.conn/db->pooled-connection-spec (:id database))]
       (with-open [^Statement stmt (.createStatement ^Connection (:connection t-conn))]
         (doseq [sql sqls]


### PR DESCRIPTION
## Summary
- Workspace GRANT SQL statements interpolated schema/table identifiers with raw `format`/`%s`, allowing embedded delimiter characters (`"` for Postgres/H2/Snowflake, `` ` `` for MySQL/ClickHouse, `[]` for SQL Server) to break identifier boundaries
- Replaced all raw interpolation with `sql.u/quote-name` across 6 drivers: postgres, mysql, h2, snowflake, sqlserver, clickhouse
- Added regression tests against Postgres that create tables/schemas with embedded double-quotes and verify GRANT succeeds

Fixes GDGT-1934

## Test plan
- [x] Verified vulnerability exists: `PSQLException: Unterminated identifier` with embedded `"` in table/schema names before fix
- [x] Both new Postgres tests pass after fix (`grant-workspace-read-access-escapes-table-names-test`, `grant-workspace-read-access-escapes-schema-names-test`)
- [x] All 9 existing workspace isolation tests pass (`DRIVERS=postgres clojure -X:dev:ee:ee-dev:test :only metabase-enterprise.workspaces.isolation-test`)
- [ ] CI passes for all affected drivers (postgres, mysql, h2, snowflake, sqlserver, clickhouse)