### PR TITLE
ad-hoc aggregations BE

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -183,6 +183,7 @@
      ;; Workspace isolation functions are safe in parallel tests because they operate on
      ;; isolated, test-specific workspaces and databases that don't affect other tests
      metabase-enterprise.workspaces.isolation/destroy-workspace-isolation!
+     metabase.lib-metric.ast.plan/validate-arithmetic-ast!
      metabase-enterprise.workspaces.isolation/ensure-database-isolation!
      metabase-enterprise.workspaces.test-util/create-ready-ws!
      ;; Safe in tests, where we typically use a private, temporary index per thread.

--- a/frontend/src/metabase-types/api/metric.ts
+++ b/frontend/src/metabase-types/api/metric.ts
@@ -23,20 +23,43 @@ export type Metric = {
   result_column_name?: string;
 };
 
+export type AdhocDimension = {
+  id: string;
+  "field-ref": unknown;
+  "display-name": string;
+  "effective-type": string;
+  "semantic-type"?: string;
+};
+
+export type AdhocLeafDefinition = {
+  "database-id": number;
+  "table-id": number;
+  aggregation: unknown;
+  dimensions: AdhocDimension[];
+  filter?: unknown;
+};
+
 export type ExpressionRef =
   | ["metric", { "lib/uuid": string }, number]
-  | ["measure", { "lib/uuid": string }, number];
+  | ["measure", { "lib/uuid": string }, number]
+  | ["adhoc", { "lib/uuid": string }, AdhocLeafDefinition];
 
 export type InstanceFilter = {
   "lib/uuid": string;
   filter: unknown;
 };
 
-export type TypedProjection = {
-  type: "metric" | "measure";
-  id: number;
-  projection: unknown[];
-};
+export type TypedProjection =
+  | {
+      type: "metric" | "measure";
+      id: number;
+      projection: unknown[];
+    }
+  | {
+      type: "adhoc";
+      "lib/uuid": string;
+      projection: unknown[];
+    };
 
 export type JsMetricDefinition = {
   expression: ExpressionRef | unknown[];

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricExpressionPill/MetricExpressionPill.module.css
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricExpressionPill/MetricExpressionPill.module.css
@@ -1,0 +1,12 @@
+.metricExpressionPill {
+  background-color: var(--mb-color-background-primary);
+  border-radius: var(--mantine-radius-md);
+  cursor: pointer;
+  transition: background-color 150ms ease;
+  box-shadow: var(--mantine-shadow-xs);
+  max-width: 100%;
+}
+
+.metricExpressionPill:hover {
+  background-color: var(--mb-color-background-brand);
+}

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricExpressionPill/MetricExpressionPill.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricExpressionPill/MetricExpressionPill.tsx
@@ -1,0 +1,46 @@
+import { t } from "ttag";
+
+import { SourceColorIndicator } from "metabase/common/components/SourceColorIndicator";
+import { Flex, Pill } from "metabase/ui";
+
+import S from "./MetricExpressionPill.module.css";
+
+type MetricExpressionPillProps = {
+  expressionText: string;
+  color?: string;
+  onClick: (e: React.MouseEvent) => void;
+  onRemove: () => void;
+};
+
+export function MetricExpressionPill({
+  expressionText,
+  color,
+  onClick,
+  onRemove,
+}: MetricExpressionPillProps) {
+  return (
+    <Pill
+      className={S.metricExpressionPill}
+      c="text-primary"
+      h="2rem"
+      px="sm"
+      py="xs"
+      fw={600}
+      withRemoveButton
+      onRemove={onRemove}
+      removeButtonProps={{
+        mr: 0,
+        "aria-label": t`Remove expression`,
+      }}
+      onClick={onClick}
+    >
+      <Flex align="center" gap="xs">
+        <SourceColorIndicator
+          colors={color !== undefined ? [color] : undefined}
+          fallbackIcon="metric"
+        />
+        <span>{expressionText}</span>
+      </Flex>
+    </Pill>
+  );
+}

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricExpressionPill/index.ts
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricExpressionPill/index.ts
@@ -1,0 +1,1 @@
+export { MetricExpressionPill } from "./MetricExpressionPill";

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricPill/MetricPill.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricPill/MetricPill.tsx
@@ -34,7 +34,7 @@ type MetricPillProps = {
   selectedMetricIds: Set<number>;
   selectedMeasureIds: Set<number>;
   onSwap: (oldMetric: SelectedMetric, newMetric: SelectedMetric) => void;
-  onRemove: (metricId: number, sourceType: "metric" | "measure") => void;
+  onRemove: (metric: SelectedMetric) => void;
   onSetBreakout: (dimension: ProjectionClause | undefined) => void;
   onOpen?: () => void;
 };
@@ -147,7 +147,7 @@ export function MetricPill({
             fw={600}
             withRemoveButton
             onRemove={() => {
-              onRemove(metric.id, metric.sourceType);
+              onRemove(metric);
             }}
             onClick={(e) => {
               e.stopPropagation();
@@ -170,7 +170,11 @@ export function MetricPill({
                   <SourceColorIndicator
                     colors={colors}
                     fallbackIcon={
-                      metric.sourceType === "measure" ? "ruler" : "metric"
+                      metric.sourceType === "adhoc"
+                        ? "sum"
+                        : metric.sourceType === "measure"
+                          ? "ruler"
+                          : "metric"
                     }
                   />
                   <span>{metric.name}</span>
@@ -185,10 +189,11 @@ export function MetricPill({
             selectedMeasureIds={selectedMeasureIds}
             onSelect={handleSelect}
             onClose={handleClose}
-            excludeMetric={{
-              id: metric.id,
-              sourceType: metric.sourceType,
-            }}
+            excludeMetric={
+              metric.sourceType !== "adhoc"
+                ? { id: metric.id, sourceType: metric.sourceType }
+                : undefined
+            }
             showSearchInput
           />
         </Popover.Dropdown>
@@ -233,7 +238,7 @@ export function MetricPill({
               <Menu.Divider />
             </>
           )}
-          {hasDataStudioAccess && (
+          {hasDataStudioAccess && metric.sourceType !== "adhoc" && (
             <Menu.Item
               leftSection={<Icon name="pencil" />}
               rightSection={<Icon name="external" />}

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchDropdown/MetricSearchDropdown.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchDropdown/MetricSearchDropdown.tsx
@@ -27,6 +27,7 @@ type MetricSearchDropdownProps = {
   excludeMetric?: ExcludeMetric;
   showSearchInput?: boolean;
   externalSearchText?: string;
+  onSummarizeTable?: () => void;
 };
 
 export function MetricSearchDropdown({
@@ -37,6 +38,7 @@ export function MetricSearchDropdown({
   excludeMetric,
   showSearchInput = false,
   externalSearchText,
+  onSummarizeTable,
 }: MetricSearchDropdownProps) {
   const [internalSearchText, setInternalSearchText] = useState("");
   const searchText = showSearchInput
@@ -122,6 +124,7 @@ export function MetricSearchDropdown({
             cursorIndex={cursorIndex}
             getRef={getRef}
             onSelectResult={handleSelectResult}
+            onSummarizeTable={onSummarizeTable}
           />
         </Box>
       </Flex>
@@ -135,6 +138,7 @@ export function MetricSearchDropdown({
       cursorIndex={cursorIndex}
       getRef={getRef}
       onSelectResult={handleSelectResult}
+      onSummarizeTable={onSummarizeTable}
     />
   );
 }

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/MetricSearchInput.module.css
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/MetricSearchInput.module.css
@@ -65,6 +65,22 @@
   border-color: var(--mb-color-brand);
 }
 
+.constantPill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 1.75rem;
+  padding: 0 0.5rem;
+  border-radius: var(--mantine-radius-sm);
+  background: var(--mb-color-background-hover);
+  color: var(--mb-color-text-primary);
+  font-weight: 700;
+  font-size: 0.875rem;
+  border: 1px solid var(--mb-color-border);
+  flex-shrink: 0;
+  user-select: none;
+}
+
 .parenToken {
   font-size: 1.25rem;
   font-weight: 700;

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/MetricSearchInput.module.css
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/MetricSearchInput.module.css
@@ -14,77 +14,36 @@
   color: var(--mb-color-text-tertiary);
 }
 
-.operatorPill {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 1.75rem;
-  height: 1.75rem;
-  border-radius: var(--mantine-radius-sm);
-  background: var(--mb-color-background-inverse);
-  color: var(--mb-color-text-white);
-  font-weight: 700;
-  font-size: 1rem;
-  border: none;
-  cursor: pointer;
-  flex-shrink: 0;
-  transition: opacity 0.1s ease;
-}
-
-.operatorPill:hover {
-  opacity: 0.8;
-}
-
-.operatorPillPending {
-  opacity: 0.5;
-  cursor: default;
-}
-
-.operatorChoice {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 2rem;
-  height: 2rem;
-  border-radius: var(--mantine-radius-sm);
-  background: var(--mb-color-background-secondary);
-  color: var(--mb-color-text-primary);
-  font-weight: 700;
-  font-size: 0.875rem;
-  border: 1px solid var(--mb-color-border);
-  cursor: pointer;
-  transition: background 0.1s ease;
-}
-
-.operatorChoice:hover {
-  background: var(--mb-color-background-hover);
-}
-
-.operatorChoiceActive {
-  background: var(--mb-color-background-hover);
-  border-color: var(--mb-color-brand);
-}
-
-.constantPill {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  height: 1.75rem;
-  padding: 0 0.5rem;
-  border-radius: var(--mantine-radius-sm);
-  background: var(--mb-color-background-hover);
-  color: var(--mb-color-text-primary);
-  font-weight: 700;
-  font-size: 0.875rem;
-  border: 1px solid var(--mb-color-border);
-  flex-shrink: 0;
-  user-select: none;
-}
-
 .parenToken {
   font-size: 1.25rem;
   font-weight: 700;
   color: var(--mb-color-text-medium);
   line-height: 1;
+  user-select: none;
+}
+
+.operatorText {
+  font-weight: 700;
+  font-size: 1rem;
+  color: var(--mb-color-text-medium);
+  user-select: none;
+  white-space: nowrap;
+}
+
+.operatorTextPending {
+  opacity: 0.5;
+}
+
+.metricTokenText {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--mb-color-text-primary);
+  white-space: nowrap;
+}
+
+.separatorText {
+  font-weight: 700;
+  font-size: 1rem;
+  color: var(--mb-color-text-medium);
   user-select: none;
 }

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/MetricSearchInput.module.css
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/MetricSearchInput.module.css
@@ -13,3 +13,63 @@
 .inputField::placeholder {
   color: var(--mb-color-text-tertiary);
 }
+
+.operatorPill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: var(--mantine-radius-sm);
+  background: var(--mb-color-background-inverse);
+  color: var(--mb-color-text-white);
+  font-weight: 700;
+  font-size: 1rem;
+  border: none;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: opacity 0.1s ease;
+}
+
+.operatorPill:hover {
+  opacity: 0.8;
+}
+
+.operatorPillPending {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.operatorChoice {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: var(--mantine-radius-sm);
+  background: var(--mb-color-background-secondary);
+  color: var(--mb-color-text-primary);
+  font-weight: 700;
+  font-size: 0.875rem;
+  border: 1px solid var(--mb-color-border);
+  cursor: pointer;
+  transition: background 0.1s ease;
+}
+
+.operatorChoice:hover {
+  background: var(--mb-color-background-hover);
+}
+
+.operatorChoiceActive {
+  background: var(--mb-color-background-inverse);
+  color: var(--mb-color-text-white);
+  border-color: var(--mb-color-background-inverse);
+}
+
+.parenToken {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--mb-color-text-medium);
+  line-height: 1;
+  user-select: none;
+}

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/MetricSearchInput.module.css
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/MetricSearchInput.module.css
@@ -61,9 +61,8 @@
 }
 
 .operatorChoiceActive {
-  background: var(--mb-color-background-inverse);
-  color: var(--mb-color-text-white);
-  border-color: var(--mb-color-background-inverse);
+  background: var(--mb-color-background-hover);
+  border-color: var(--mb-color-brand);
 }
 
 .parenToken {

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/MetricSearchInput.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/MetricSearchInput.tsx
@@ -3,7 +3,6 @@ import { t } from "ttag";
 
 import { Flex, Popover, TextInput } from "metabase/ui";
 import type { ProjectionClause } from "metabase-lib/metric";
-import type { DatabaseId } from "metabase-types/api";
 
 import type { ExpressionToken } from "../../../types/operators";
 import type {
@@ -54,7 +53,6 @@ type MetricSearchInputProps = {
     dimension: ProjectionClause | undefined,
   ) => void;
   onAddAdhoc?: (result: AdhocResult) => void;
-  databaseId?: DatabaseId | null;
 };
 
 export function MetricSearchInput({
@@ -68,7 +66,6 @@ export function MetricSearchInput({
   onSwapMetric,
   onSetBreakout,
   onAddAdhoc,
-  databaseId,
 }: MetricSearchInputProps) {
   // editText is the full expression as plain text — only meaningful while focused
   const [editText, setEditText] = useState("");
@@ -383,152 +380,153 @@ export function MetricSearchInput({
   const isCollapsed = !isFocused && tokens.length > 0;
 
   return (
-    <Flex
-      className={S.inputWrapper}
-      bg="background-secondary"
-      align="center"
-      gap="sm"
-      px="sm"
-      py="xs"
-      onClick={handleContainerClick}
-    >
-      <Flex align="center" gap="sm" flex={1} wrap="wrap" mih="2.375rem">
-        {isCollapsed ? (
-          // Unfocused: each item rendered as MetricPill or MetricExpressionPill
-          <>
-            {items.map((itemTokens, itemIndex) => {
-              const isSingleMetric =
-                itemTokens.length === 1 && itemTokens[0].type === "metric";
+    <>
+      <Flex
+        className={S.inputWrapper}
+        bg="background-secondary"
+        align="center"
+        gap="sm"
+        px="sm"
+        py="xs"
+        onClick={handleContainerClick}
+      >
+        <Flex align="center" gap="sm" flex={1} wrap="wrap" mih="2.375rem">
+          {isCollapsed ? (
+            // Unfocused: each item rendered as MetricPill or MetricExpressionPill
+            <>
+              {items.map((itemTokens, itemIndex) => {
+                const isSingleMetric =
+                  itemTokens.length === 1 && itemTokens[0].type === "metric";
 
-              const pill = isSingleMetric
-                ? (() => {
-                    const token = itemTokens[0];
-                    if (token.type !== "metric") {
-                      return null;
-                    }
-                    const metric = selectedMetrics[token.metricIndex];
-                    if (!metric) {
-                      return null;
-                    }
-                    const sid =
-                      metric.sourceType === "adhoc" && metric.adhocUuid
-                        ? createAdhocSourceId(metric.adhocUuid)
-                        : metric.sourceType === "metric"
-                          ? createMetricSourceId(metric.id)
-                          : createMeasureSourceId(metric.id);
-                    const entry = definitionsBySourceId.get(sid);
-                    if (!entry) {
-                      return null;
-                    }
-                    return (
-                      <MetricPill
-                        metric={metric}
-                        colors={metricColors[sid]}
-                        definitionEntry={entry}
-                        selectedMetricIds={selectedMetricIds}
-                        selectedMeasureIds={selectedMeasureIds}
-                        onSwap={onSwapMetric}
-                        onRemove={() => handleRemoveItem(itemIndex)}
-                        onSetBreakout={(dimension) =>
-                          onSetBreakout(sid, dimension)
-                        }
-                      />
-                    );
-                  })()
-                : (() => {
-                    // Use the first color of the first metric as the single
-                    // series color (the expression result is one chart series)
-                    const firstMetricToken = itemTokens.find(
-                      (t): t is { type: "metric"; metricIndex: number } =>
-                        t.type === "metric",
-                    );
-                    const firstMetric =
-                      firstMetricToken !== undefined
-                        ? selectedMetrics[firstMetricToken.metricIndex]
-                        : undefined;
-                    const expressionColor =
-                      firstMetric !== undefined
-                        ? metricColors[
-                            firstMetric.sourceType === "adhoc" &&
-                            firstMetric.adhocUuid
-                              ? createAdhocSourceId(firstMetric.adhocUuid)
-                              : firstMetric.sourceType === "metric"
-                                ? createMetricSourceId(firstMetric.id)
-                                : createMeasureSourceId(firstMetric.id)
-                          ]?.[0]
-                        : undefined;
+                const pill = isSingleMetric
+                  ? (() => {
+                      const token = itemTokens[0];
+                      if (token.type !== "metric") {
+                        return null;
+                      }
+                      const metric = selectedMetrics[token.metricIndex];
+                      if (!metric) {
+                        return null;
+                      }
+                      const sid =
+                        metric.sourceType === "adhoc" && metric.adhocUuid
+                          ? createAdhocSourceId(metric.adhocUuid)
+                          : metric.sourceType === "metric"
+                            ? createMetricSourceId(metric.id)
+                            : createMeasureSourceId(metric.id);
+                      const entry = definitionsBySourceId.get(sid);
+                      if (!entry) {
+                        return null;
+                      }
+                      return (
+                        <MetricPill
+                          metric={metric}
+                          colors={metricColors[sid]}
+                          definitionEntry={entry}
+                          selectedMetricIds={selectedMetricIds}
+                          selectedMeasureIds={selectedMeasureIds}
+                          onSwap={onSwapMetric}
+                          onRemove={() => handleRemoveItem(itemIndex)}
+                          onSetBreakout={(dimension) =>
+                            onSetBreakout(sid, dimension)
+                          }
+                        />
+                      );
+                    })()
+                  : (() => {
+                      // Use the first color of the first metric as the single
+                      // series color (the expression result is one chart series)
+                      const firstMetricToken = itemTokens.find(
+                        (t): t is { type: "metric"; metricIndex: number } =>
+                          t.type === "metric",
+                      );
+                      const firstMetric =
+                        firstMetricToken !== undefined
+                          ? selectedMetrics[firstMetricToken.metricIndex]
+                          : undefined;
+                      const expressionColor =
+                        firstMetric !== undefined
+                          ? metricColors[
+                              firstMetric.sourceType === "adhoc" &&
+                              firstMetric.adhocUuid
+                                ? createAdhocSourceId(firstMetric.adhocUuid)
+                                : firstMetric.sourceType === "metric"
+                                  ? createMetricSourceId(firstMetric.id)
+                                  : createMeasureSourceId(firstMetric.id)
+                            ]?.[0]
+                          : undefined;
 
-                    return (
-                      <MetricExpressionPill
-                        expressionText={buildExpressionText(
-                          itemTokens,
-                          selectedMetrics,
-                        )}
-                        color={expressionColor}
-                        onClick={(e: React.MouseEvent) => {
-                          e.stopPropagation();
-                          pendingFocusRef.current = true;
-                          setIsFocused(true);
-                        }}
-                        onRemove={() => handleRemoveItem(itemIndex)}
-                      />
-                    );
-                  })();
+                      return (
+                        <MetricExpressionPill
+                          expressionText={buildExpressionText(
+                            itemTokens,
+                            selectedMetrics,
+                          )}
+                          color={expressionColor}
+                          onClick={(e: React.MouseEvent) => {
+                            e.stopPropagation();
+                            pendingFocusRef.current = true;
+                            setIsFocused(true);
+                          }}
+                          onRemove={() => handleRemoveItem(itemIndex)}
+                        />
+                      );
+                    })();
 
-              return <span key={itemIndex}>{pill}</span>;
-            })}
-          </>
-        ) : (
-          // Focused: single text input showing the full expression
-          <Popover
-            opened={isOpen}
-            onChange={setIsOpen}
-            position="bottom-start"
-            shadow="md"
-            withinPortal
-          >
-            <Popover.Target>
-              <TextInput
-                ref={inputRef}
-                classNames={{ input: S.inputField }}
-                flex={1}
-                miw="7.5rem"
-                variant="unstyled"
-                placeholder={
-                  tokens.length === 0 ? t`Search for metrics...` : ""
-                }
-                value={editText}
-                onChange={handleChange}
-                onClick={handleInputClick}
-                onFocus={handleInputFocus}
-                onBlur={handleInputBlur}
-                data-testid="metrics-viewer-search-input"
-              />
-            </Popover.Target>
-            <Popover.Dropdown p={0} miw="19rem" maw="25rem">
-              {isOpen && (
-                <MetricSearchDropdown
-                  selectedMetricIds={EMPTY_SET}
-                  selectedMeasureIds={EMPTY_SET}
-                  onSelect={handleSelect}
-                  externalSearchText={currentWord}
-                  onSummarizeTable={
-                    onAddAdhoc ? handleSummarizeTable : undefined
+                return <span key={itemIndex}>{pill}</span>;
+              })}
+            </>
+          ) : (
+            // Focused: single text input showing the full expression
+            <Popover
+              opened={isOpen}
+              onChange={setIsOpen}
+              position="bottom-start"
+              shadow="md"
+              withinPortal
+            >
+              <Popover.Target>
+                <TextInput
+                  ref={inputRef}
+                  classNames={{ input: S.inputField }}
+                  flex={1}
+                  miw="7.5rem"
+                  variant="unstyled"
+                  placeholder={
+                    tokens.length === 0 ? t`Search for metrics...` : ""
                   }
+                  value={editText}
+                  onChange={handleChange}
+                  onClick={handleInputClick}
+                  onFocus={handleInputFocus}
+                  onBlur={handleInputBlur}
+                  data-testid="metrics-viewer-search-input"
                 />
-              )}
-            </Popover.Dropdown>
-          </Popover>
-        )}
+              </Popover.Target>
+              <Popover.Dropdown p={0} miw="19rem" maw="25rem">
+                {isOpen && (
+                  <MetricSearchDropdown
+                    selectedMetricIds={EMPTY_SET}
+                    selectedMeasureIds={EMPTY_SET}
+                    onSelect={handleSelect}
+                    externalSearchText={currentWord}
+                    onSummarizeTable={
+                      onAddAdhoc ? handleSummarizeTable : undefined
+                    }
+                  />
+                )}
+              </Popover.Dropdown>
+            </Popover>
+          )}
+        </Flex>
       </Flex>
       {onAddAdhoc && (
         <SummarizeTableDialog
           opened={showSummarizeDialog}
           onClose={() => setShowSummarizeDialog(false)}
           onAdd={handleAddAdhoc}
-          databaseId={databaseId ?? null}
         />
       )}
-    </Flex>
+    </>
   );
 }

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/MetricSearchInput.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/MetricSearchInput.tsx
@@ -3,6 +3,7 @@ import { t } from "ttag";
 
 import { Flex, Popover, TextInput } from "metabase/ui";
 import type { ProjectionClause } from "metabase-lib/metric";
+import type { DatabaseId } from "metabase-types/api";
 
 import type { ExpressionToken } from "../../../types/operators";
 import type {
@@ -12,9 +13,12 @@ import type {
   SourceColorMap,
 } from "../../../types/viewer-state";
 import {
+  createAdhocSourceId,
   createMeasureSourceId,
   createMetricSourceId,
 } from "../../../utils/source-ids";
+import type { AdhocResult } from "../../SummarizeTable";
+import { SummarizeTableDialog } from "../../SummarizeTable";
 import { MetricExpressionPill } from "../MetricExpressionPill";
 import { MetricPill } from "../MetricPill";
 import { MetricSearchDropdown } from "../MetricSearchDropdown";
@@ -43,12 +47,14 @@ type MetricSearchInputProps = {
   metricColors: SourceColorMap;
   definitions: MetricsViewerDefinitionEntry[];
   onAddMetric: (metric: SelectedMetric) => void;
-  onRemoveMetric: (metricId: number, sourceType: "metric" | "measure") => void;
+  onRemoveMetric: (metric: SelectedMetric) => void;
   onSwapMetric: (oldMetric: SelectedMetric, newMetric: SelectedMetric) => void;
   onSetBreakout: (
     id: MetricSourceId,
     dimension: ProjectionClause | undefined,
   ) => void;
+  onAddAdhoc?: (result: AdhocResult) => void;
+  databaseId?: DatabaseId | null;
 };
 
 export function MetricSearchInput({
@@ -61,6 +67,8 @@ export function MetricSearchInput({
   onRemoveMetric,
   onSwapMetric,
   onSetBreakout,
+  onAddAdhoc,
+  databaseId,
 }: MetricSearchInputProps) {
   // editText is the full expression as plain text — only meaningful while focused
   const [editText, setEditText] = useState("");
@@ -68,6 +76,7 @@ export function MetricSearchInput({
   const [currentWord, setCurrentWord] = useState("");
   const [isOpen, setIsOpen] = useState(false);
   const [isFocused, setIsFocused] = useState(false);
+  const [showSummarizeDialog, setShowSummarizeDialog] = useState(false);
 
   const inputRef = useRef<HTMLInputElement>(null);
   const pendingFocusRef = useRef(false);
@@ -193,7 +202,7 @@ export function MetricSearchInput({
         );
         const metric = selectedMetricsRef.current[removeIdx];
         if (metric) {
-          onRemoveMetric(metric.id, metric.sourceType);
+          onRemoveMetric(metric);
         }
       }
 
@@ -328,13 +337,26 @@ export function MetricSearchInput({
         );
         const metric = selectedMetrics[removeIdx];
         if (metric) {
-          onRemoveMetric(metric.id, metric.sourceType);
+          onRemoveMetric(metric);
         }
       }
 
       onTokensChange(newTokens);
     },
     [tokens, selectedMetrics, onRemoveMetric, onTokensChange],
+  );
+
+  const handleSummarizeTable = useCallback(() => {
+    setIsOpen(false);
+    setShowSummarizeDialog(true);
+  }, []);
+
+  const handleAddAdhoc = useCallback(
+    (result: AdhocResult) => {
+      onAddAdhoc?.(result);
+      setShowSummarizeDialog(false);
+    },
+    [onAddAdhoc],
   );
 
   const handleContainerClick = useCallback(() => {
@@ -389,9 +411,11 @@ export function MetricSearchInput({
                       return null;
                     }
                     const sid =
-                      metric.sourceType === "metric"
-                        ? createMetricSourceId(metric.id)
-                        : createMeasureSourceId(metric.id);
+                      metric.sourceType === "adhoc" && metric.adhocUuid
+                        ? createAdhocSourceId(metric.adhocUuid)
+                        : metric.sourceType === "metric"
+                          ? createMetricSourceId(metric.id)
+                          : createMeasureSourceId(metric.id);
                     const entry = definitionsBySourceId.get(sid);
                     if (!entry) {
                       return null;
@@ -404,9 +428,7 @@ export function MetricSearchInput({
                         selectedMetricIds={selectedMetricIds}
                         selectedMeasureIds={selectedMeasureIds}
                         onSwap={onSwapMetric}
-                        onRemove={(_id, _sourceType) =>
-                          handleRemoveItem(itemIndex)
-                        }
+                        onRemove={() => handleRemoveItem(itemIndex)}
                         onSetBreakout={(dimension) =>
                           onSetBreakout(sid, dimension)
                         }
@@ -427,9 +449,12 @@ export function MetricSearchInput({
                     const expressionColor =
                       firstMetric !== undefined
                         ? metricColors[
-                            firstMetric.sourceType === "metric"
-                              ? createMetricSourceId(firstMetric.id)
-                              : createMeasureSourceId(firstMetric.id)
+                            firstMetric.sourceType === "adhoc" &&
+                            firstMetric.adhocUuid
+                              ? createAdhocSourceId(firstMetric.adhocUuid)
+                              : firstMetric.sourceType === "metric"
+                                ? createMetricSourceId(firstMetric.id)
+                                : createMeasureSourceId(firstMetric.id)
                           ]?.[0]
                         : undefined;
 
@@ -487,12 +512,23 @@ export function MetricSearchInput({
                   selectedMeasureIds={EMPTY_SET}
                   onSelect={handleSelect}
                   externalSearchText={currentWord}
+                  onSummarizeTable={
+                    onAddAdhoc ? handleSummarizeTable : undefined
+                  }
                 />
               )}
             </Popover.Dropdown>
           </Popover>
         )}
       </Flex>
+      {onAddAdhoc && (
+        <SummarizeTableDialog
+          opened={showSummarizeDialog}
+          onClose={() => setShowSummarizeDialog(false)}
+          onAdd={handleAddAdhoc}
+          databaseId={databaseId ?? null}
+        />
+      )}
     </Flex>
   );
 }

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/MetricSearchInput.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/MetricSearchInput.tsx
@@ -22,9 +22,16 @@ import {
 } from "../../../utils/source-ids";
 import { MetricPill } from "../MetricPill";
 import { MetricSearchDropdown } from "../MetricSearchDropdown";
-import { getSelectedMeasureIds, getSelectedMetricIds } from "../utils";
+import {
+  cleanupParens,
+  getSelectedMeasureIds,
+  getSelectedMetricIds,
+} from "../utils";
 
 import S from "./MetricSearchInput.module.css";
+
+// Metrics in the expression input can be used multiple times, so nothing is filtered out
+const EMPTY_SET = new Set<number>();
 
 type OperatorPillProps = {
   operator: MathOperator;
@@ -78,6 +85,8 @@ function OperatorPill({ operator, onChange }: OperatorPillProps) {
 }
 
 type MetricSearchInputProps = {
+  tokens: ExpressionToken[];
+  onTokensChange: (tokens: ExpressionToken[]) => void;
   selectedMetrics: SelectedMetric[];
   metricColors: SourceColorMap;
   definitions: MetricsViewerDefinitionEntry[];
@@ -88,10 +97,11 @@ type MetricSearchInputProps = {
     id: MetricSourceId,
     dimension: ProjectionClause | undefined,
   ) => void;
-  onExpressionChange?: (tokens: ExpressionToken[]) => void;
 };
 
 export function MetricSearchInput({
+  tokens,
+  onTokensChange,
   selectedMetrics,
   metricColors,
   definitions,
@@ -99,31 +109,32 @@ export function MetricSearchInput({
   onRemoveMetric,
   onSwapMetric,
   onSetBreakout,
-  onExpressionChange,
 }: MetricSearchInputProps) {
   const [searchText, setSearchText] = useState("");
   const [isOpen, setIsOpen] = useState(false);
-  // Full expression token stream (committed tokens only)
-  const [tokens, setTokens] = useState<ExpressionToken[]>([]);
   const [pendingOperator, setPendingOperator] = useState<MathOperator | null>(
     null,
   );
   const inputRef = useRef<HTMLInputElement>(null);
 
+  // Remove unnecessary parentheses: empty parens or parens around a single metric
   useEffect(() => {
-    onExpressionChange?.(tokens);
-  }, [tokens, onExpressionChange]);
+    const cleaned = cleanupParens(tokens);
+    if (cleaned !== tokens) {
+      onTokensChange(cleaned);
+    }
+  }, [tokens, onTokensChange]);
 
   // Safety net: drop any metric tokens whose index is out of range
   useEffect(() => {
     const maxIdx = selectedMetrics.length - 1;
-    setTokens((prev) => {
-      const filtered = prev.filter(
-        (t) => t.type !== "metric" || t.metricIndex <= maxIdx,
-      );
-      return filtered.length === prev.length ? prev : filtered;
-    });
-  }, [selectedMetrics.length]);
+    const filtered = tokens.filter(
+      (t) => t.type !== "metric" || t.metricIndex <= maxIdx,
+    );
+    if (filtered.length !== tokens.length) {
+      onTokensChange(filtered);
+    }
+  }, [selectedMetrics.length, tokens, onTokensChange]);
 
   const selectedMetricIds = useMemo(
     () => getSelectedMetricIds(selectedMetrics),
@@ -171,14 +182,16 @@ export function MetricSearchInput({
         (m) => m.id === id && m.sourceType === sourceType,
       );
       if (index !== -1) {
-        setTokens((prev) => {
-          const tokenIdx = prev.findIndex(
-            (t) => t.type === "metric" && t.metricIndex === index,
-          );
-          if (tokenIdx === -1) {
-            return prev;
-          }
-          const next = [...prev];
+        // Only remove from selectedMetrics when this is the last token referencing it
+        const isLastReference =
+          tokens.filter((t) => t.type === "metric" && t.metricIndex === index)
+            .length <= 1;
+
+        const tokenIdx = tokens.findIndex(
+          (t) => t.type === "metric" && t.metricIndex === index,
+        );
+        if (tokenIdx !== -1) {
+          const next = [...tokens];
           next.splice(tokenIdx, 1); // remove metric token
 
           // Remove adjacent operator (prefer before, then after)
@@ -190,35 +203,47 @@ export function MetricSearchInput({
             next.splice(tokenIdx, 1);
           }
 
-          // Decrement metricIndex for all subsequent metric tokens
-          return next.map((t) =>
-            t.type === "metric" && t.metricIndex > index
-              ? { ...t, metricIndex: t.metricIndex - 1 }
-              : t,
+          onTokensChange(
+            isLastReference
+              ? next.map((t) =>
+                  t.type === "metric" && t.metricIndex > index
+                    ? { ...t, metricIndex: t.metricIndex - 1 }
+                    : t,
+                )
+              : next,
           );
-        });
+        }
+
+        if (isLastReference) {
+          onRemoveMetric(id, sourceType);
+        }
       }
-      onRemoveMetric(id, sourceType);
     },
-    [selectedMetrics, onRemoveMetric],
+    [selectedMetrics, tokens, onRemoveMetric, onTokensChange],
   );
 
   const handleSelect = useCallback(
     (metric: SelectedMetric) => {
-      const newMetricIndex = selectedMetrics.length; // will be appended at this index
+      // Reuse the existing index if this metric is already in selectedMetrics
+      // (addMetric is a no-op for duplicates, so length won't grow)
+      const existingIndex = selectedMetrics.findIndex(
+        (m) => m.id === metric.id && m.sourceType === metric.sourceType,
+      );
+      const metricIndex =
+        existingIndex !== -1 ? existingIndex : selectedMetrics.length;
       onAddMetric(metric);
-      setTokens((prev) => [
-        ...prev,
+      onTokensChange([
+        ...tokens,
         ...(pendingOperator !== null
           ? [{ type: "operator" as const, op: pendingOperator }]
           : []),
-        { type: "metric" as const, metricIndex: newMetricIndex },
+        { type: "metric" as const, metricIndex },
       ]);
       setPendingOperator(null);
       setSearchText("");
       setIsOpen(false);
     },
-    [onAddMetric, pendingOperator, selectedMetrics.length],
+    [onAddMetric, onTokensChange, pendingOperator, selectedMetrics, tokens],
   );
 
   const handleKeyDown = useCallback(
@@ -238,8 +263,8 @@ export function MetricSearchInput({
         // Open paren
         if (event.key === "(" && canOpenParen) {
           event.preventDefault();
-          setTokens((prev) => [
-            ...prev,
+          onTokensChange([
+            ...tokens,
             ...(pendingOperator !== null
               ? [{ type: "operator" as const, op: pendingOperator }]
               : []),
@@ -253,7 +278,7 @@ export function MetricSearchInput({
         // Close paren
         if (event.key === ")" && canCloseParen) {
           event.preventDefault();
-          setTokens((prev) => [...prev, { type: "close-paren" as const }]);
+          onTokensChange([...tokens, { type: "close-paren" as const }]);
           return;
         }
 
@@ -271,25 +296,31 @@ export function MetricSearchInput({
             lastToken.type === "open-paren" ||
             lastToken.type === "operator"
           ) {
-            setTokens((prev) => prev.slice(0, -1));
+            onTokensChange(tokens.slice(0, -1));
             return;
           }
           if (lastToken.type === "metric") {
             const metricIdx = lastToken.metricIndex;
             const metric = selectedMetrics[metricIdx];
-            setTokens((prev) => {
-              let next = prev.slice(0, -1);
-              const prevToken = next[next.length - 1];
-              if (prevToken?.type === "operator") {
-                next = next.slice(0, -1);
-              }
-              return next.map((t) =>
-                t.type === "metric" && t.metricIndex > metricIdx
-                  ? { ...t, metricIndex: t.metricIndex - 1 }
-                  : t,
-              );
-            });
-            if (metric) {
+            const isLastReference =
+              tokens.filter(
+                (t) => t.type === "metric" && t.metricIndex === metricIdx,
+              ).length <= 1;
+            let next = tokens.slice(0, -1);
+            const prevToken = next[next.length - 1];
+            if (prevToken?.type === "operator") {
+              next = next.slice(0, -1);
+            }
+            onTokensChange(
+              isLastReference
+                ? next.map((t) =>
+                    t.type === "metric" && t.metricIndex > metricIdx
+                      ? { ...t, metricIndex: t.metricIndex - 1 }
+                      : t,
+                  )
+                : next,
+            );
+            if (metric && isLastReference) {
               onRemoveMetric(metric.id, metric.sourceType);
             }
             return;
@@ -299,12 +330,14 @@ export function MetricSearchInput({
     },
     [
       searchText,
+      tokens,
       selectedMetrics,
       pendingOperator,
       lastToken,
       canOpenParen,
       canCloseParen,
       onRemoveMetric,
+      onTokensChange,
     ],
   );
 
@@ -318,13 +351,13 @@ export function MetricSearchInput({
 
   const handleChangeOperator = useCallback(
     (tokenIndex: number, newOp: MathOperator) => {
-      setTokens((prev) =>
-        prev.map((t, i) =>
+      onTokensChange(
+        tokens.map((t, i) =>
           i === tokenIndex && t.type === "operator" ? { ...t, op: newOp } : t,
         ),
       );
     },
-    [],
+    [tokens, onTokensChange],
   );
 
   return (
@@ -377,7 +410,7 @@ export function MetricSearchInput({
             }
             return (
               <MetricPill
-                key={`${metric.sourceType}-${metric.id}`}
+                key={i}
                 metric={metric}
                 colors={metricColors[sid]}
                 definitionEntry={entry}
@@ -431,8 +464,8 @@ export function MetricSearchInput({
           <Popover.Dropdown p={0} miw="19rem" maw="25rem">
             {isOpen && (
               <MetricSearchDropdown
-                selectedMetricIds={selectedMetricIds}
-                selectedMeasureIds={selectedMeasureIds}
+                selectedMetricIds={EMPTY_SET}
+                selectedMeasureIds={EMPTY_SET}
                 onSelect={handleSelect}
                 externalSearchText={searchText}
               />

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/MetricSearchInput.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/MetricSearchInput.tsx
@@ -1,15 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { t } from "ttag";
 
-import { Box, Flex, Group, Popover, TextInput } from "metabase/ui";
+import { Flex, Popover, TextInput } from "metabase/ui";
 import type { ProjectionClause } from "metabase-lib/metric";
 
-import {
-  type ExpressionToken,
-  MATH_OPERATORS,
-  type MathOperator,
-  isMathOperator,
-} from "../../../types/operators";
+import type { ExpressionToken } from "../../../types/operators";
 import type {
   MetricSourceId,
   MetricsViewerDefinitionEntry,
@@ -20,69 +15,26 @@ import {
   createMeasureSourceId,
   createMetricSourceId,
 } from "../../../utils/source-ids";
+import { MetricExpressionPill } from "../MetricExpressionPill";
 import { MetricPill } from "../MetricPill";
 import { MetricSearchDropdown } from "../MetricSearchDropdown";
 import {
+  buildExpressionText,
+  buildFullText,
   cleanupParens,
+  cleanupSeparators,
   getSelectedMeasureIds,
   getSelectedMetricIds,
+  getWordAtCursor,
+  parseFullText,
+  removeUnmatchedParens,
+  splitByItems,
 } from "../utils";
 
 import S from "./MetricSearchInput.module.css";
 
 // Metrics in the expression input can be used multiple times, so nothing is filtered out
 const EMPTY_SET = new Set<number>();
-
-type OperatorPillProps = {
-  operator: MathOperator;
-  onChange: (op: MathOperator) => void;
-};
-
-function OperatorPill({ operator, onChange }: OperatorPillProps) {
-  const [isOpen, setIsOpen] = useState(false);
-
-  return (
-    <Popover
-      opened={isOpen}
-      onChange={setIsOpen}
-      position="bottom"
-      shadow="md"
-      withinPortal
-    >
-      <Popover.Target>
-        <Box
-          component="button"
-          className={S.operatorPill}
-          onClick={(e: React.MouseEvent) => {
-            e.stopPropagation();
-            setIsOpen((o) => !o);
-          }}
-          aria-label={t`Change operator`}
-        >
-          {operator}
-        </Box>
-      </Popover.Target>
-      <Popover.Dropdown p="xs">
-        <Group gap="xs">
-          {MATH_OPERATORS.map((op) => (
-            <Box
-              key={op}
-              component="button"
-              className={`${S.operatorChoice} ${op === operator ? S.operatorChoiceActive : ""}`}
-              onClick={() => {
-                onChange(op);
-                setIsOpen(false);
-              }}
-              aria-label={op}
-            >
-              {op}
-            </Box>
-          ))}
-        </Group>
-      </Popover.Dropdown>
-    </Popover>
-  );
-}
 
 type MetricSearchInputProps = {
   tokens: ExpressionToken[];
@@ -110,23 +62,56 @@ export function MetricSearchInput({
   onSwapMetric,
   onSetBreakout,
 }: MetricSearchInputProps) {
-  const [searchText, setSearchText] = useState("");
+  // editText is the full expression as plain text — only meaningful while focused
+  const [editText, setEditText] = useState("");
+  // currentWord is the word under the cursor, used as the dropdown search query
+  const [currentWord, setCurrentWord] = useState("");
   const [isOpen, setIsOpen] = useState(false);
-  const [pendingOperator, setPendingOperator] = useState<MathOperator | null>(
-    null,
-  );
+  const [isFocused, setIsFocused] = useState(false);
+
   const inputRef = useRef<HTMLInputElement>(null);
+  const pendingFocusRef = useRef(false);
+  const blurTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Refs so blur timeout can read latest values without stale closures
+  const editTextRef = useRef(editText);
+  editTextRef.current = editText;
+  const selectedMetricsRef = useRef(selectedMetrics);
+  selectedMetricsRef.current = selectedMetrics;
 
-  // Remove unnecessary parentheses: empty parens or parens around a single metric
+  // Remove unnecessary parentheses per item (only when not actively editing)
   useEffect(() => {
-    const cleaned = cleanupParens(tokens);
-    if (cleaned !== tokens) {
-      onTokensChange(cleaned);
+    if (isFocused) {
+      return;
     }
-  }, [tokens, onTokensChange]);
+    const allItems = splitByItems(tokens);
+    const cleanedItems = allItems.map((item) =>
+      cleanupParens(removeUnmatchedParens(item)),
+    );
+    if (cleanedItems.some((item, i) => item !== allItems[i])) {
+      const newTokens = cleanedItems.flatMap((item, i) =>
+        i < cleanedItems.length - 1
+          ? [...item, { type: "separator" as const }]
+          : item,
+      );
+      onTokensChange(newTokens);
+    }
+  }, [isFocused, tokens, onTokensChange]);
 
-  // Safety net: drop any metric tokens whose index is out of range
+  // Remove empty items (trailing / consecutive separators) when not focused
   useEffect(() => {
+    if (!isFocused) {
+      const cleaned = cleanupSeparators(tokens);
+      if (cleaned.length !== tokens.length) {
+        onTokensChange(cleaned);
+      }
+    }
+  }, [isFocused, tokens, onTokensChange]);
+
+  // Safety net: drop out-of-range metric tokens (only when not editing)
+  useEffect(() => {
+    if (isFocused) {
+      return;
+    }
     const maxIdx = selectedMetrics.length - 1;
     const filtered = tokens.filter(
       (t) => t.type !== "metric" || t.metricIndex <= maxIdx,
@@ -134,7 +119,10 @@ export function MetricSearchInput({
     if (filtered.length !== tokens.length) {
       onTokensChange(filtered);
     }
-  }, [selectedMetrics.length, tokens, onTokensChange]);
+  }, [isFocused, selectedMetrics.length, tokens, onTokensChange]);
+
+  // Split tokens into items for the collapsed (pill) view
+  const items = useMemo(() => splitByItems(tokens), [tokens]);
 
   const selectedMetricIds = useMemo(
     () => getSelectedMetricIds(selectedMetrics),
@@ -151,260 +139,226 @@ export function MetricSearchInput({
     [definitions],
   );
 
-  // Derived state from tokens
-  const openParenCount = useMemo(
-    () => tokens.filter((t) => t.type === "open-paren").length,
-    [tokens],
-  );
-  const closeParenCount = useMemo(
-    () => tokens.filter((t) => t.type === "close-paren").length,
-    [tokens],
-  );
-  const hasUnclosedParen = openParenCount > closeParenCount;
-  const lastToken = tokens[tokens.length - 1] ?? null;
+  // Focus the input after transitioning from collapsed → expanded mode
+  useEffect(() => {
+    if (isFocused && pendingFocusRef.current) {
+      pendingFocusRef.current = false;
+      inputRef.current?.focus();
+    }
+  }, [isFocused]);
 
-  // Whether we can insert a close-paren
-  const canCloseParen =
-    hasUnclosedParen &&
-    pendingOperator === null &&
-    (lastToken?.type === "metric" ||
-      lastToken?.type === "constant" ||
-      lastToken?.type === "close-paren");
+  const handleInputFocus = useCallback(() => {
+    if (blurTimeoutRef.current !== null) {
+      // Re-focused before the blur timeout fired — cancel and keep current text
+      clearTimeout(blurTimeoutRef.current);
+      blurTimeoutRef.current = null;
+      setIsFocused(true);
+      return;
+    }
+    setIsFocused(true);
+    setEditText(buildFullText(tokens, selectedMetrics));
+  }, [tokens, selectedMetrics]);
 
-  // Whether we can insert an open-paren
-  const canOpenParen =
-    pendingOperator !== null ||
-    tokens.length === 0 ||
-    lastToken?.type === "open-paren" ||
-    lastToken?.type === "operator";
+  const handleInputBlur = useCallback(() => {
+    blurTimeoutRef.current = setTimeout(() => {
+      blurTimeoutRef.current = null;
 
-  const handleRemoveMetric = useCallback(
-    (id: number, sourceType: "metric" | "measure") => {
-      const index = selectedMetrics.findIndex(
-        (m) => m.id === id && m.sourceType === sourceType,
+      // Parse the final text and sync tokens, removing unreferenced metrics
+      const finalTokens = parseFullText(
+        editTextRef.current,
+        selectedMetricsRef.current,
       );
-      if (index !== -1) {
-        // Only remove from selectedMetrics when this is the last token referencing it
-        const isLastReference =
-          tokens.filter((t) => t.type === "metric" && t.metricIndex === index)
-            .length <= 1;
 
-        const tokenIdx = tokens.findIndex(
-          (t) => t.type === "metric" && t.metricIndex === index,
+      const referencedIndices = new Set(
+        finalTokens
+          .filter(
+            (t): t is { type: "metric"; metricIndex: number } =>
+              t.type === "metric",
+          )
+          .map((t) => t.metricIndex),
+      );
+
+      // Remove unreferenced metrics, highest index first to keep indices valid
+      let remappedTokens = [...finalTokens];
+      const toRemove = selectedMetricsRef.current
+        .map((_, idx) => idx)
+        .filter((idx) => !referencedIndices.has(idx))
+        .sort((a, b) => b - a);
+
+      for (const removeIdx of toRemove) {
+        remappedTokens = remappedTokens.map((t) =>
+          t.type === "metric" && t.metricIndex > removeIdx
+            ? { ...t, metricIndex: t.metricIndex - 1 }
+            : t,
         );
-        if (tokenIdx !== -1) {
-          const next = [...tokens];
-          next.splice(tokenIdx, 1); // remove metric token
-
-          // Remove adjacent operator (prefer before, then after)
-          const before = next[tokenIdx - 1];
-          const after = next[tokenIdx];
-          if (before?.type === "operator") {
-            next.splice(tokenIdx - 1, 1);
-          } else if (after?.type === "operator") {
-            next.splice(tokenIdx, 1);
-          }
-
-          onTokensChange(
-            isLastReference
-              ? next.map((t) =>
-                  t.type === "metric" && t.metricIndex > index
-                    ? { ...t, metricIndex: t.metricIndex - 1 }
-                    : t,
-                )
-              : next,
-          );
-        }
-
-        if (isLastReference) {
-          onRemoveMetric(id, sourceType);
+        const metric = selectedMetricsRef.current[removeIdx];
+        if (metric) {
+          onRemoveMetric(metric.id, metric.sourceType);
         }
       }
+
+      onTokensChange(remappedTokens);
+      setIsFocused(false);
+      setIsOpen(false);
+      setCurrentWord("");
+      setEditText("");
+    }, 150);
+  }, [onRemoveMetric, onTokensChange]);
+
+  const handleChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const newText = event.target.value;
+      setEditText(newText);
+
+      // Re-parse tokens from the updated text
+      const newTokens = parseFullText(newText, selectedMetrics);
+      onTokensChange(newTokens);
+
+      // Extract the word at the cursor for the dropdown search
+      const cursorPos = event.target.selectionStart ?? newText.length;
+      const { word } = getWordAtCursor(newText, cursorPos);
+      setCurrentWord(word);
+      setIsOpen(true);
     },
-    [selectedMetrics, tokens, onRemoveMetric, onTokensChange],
+    [selectedMetrics, onTokensChange],
   );
 
   const handleSelect = useCallback(
     (metric: SelectedMetric) => {
-      // Reuse the existing index if this metric is already in selectedMetrics
-      // (addMetric is a no-op for duplicates, so length won't grow)
+      const cursorPos = inputRef.current?.selectionStart ?? editText.length;
+      const { start, end } = getWordAtCursor(editText, cursorPos);
+
+      const metricName = metric.name ?? "";
+
+      // Check if we need to auto-insert a separator before this metric.
+      // A comma is needed when the preceding content ends with something that
+      // is not an operator, open-paren, comma, or nothing — i.e. another metric
+      // name or a close-paren would make the new metric ambiguously part of the
+      // same expression without an operator.
+      const textBeforeWord = editText.slice(0, start).trimEnd();
+      const lastChar = textBeforeWord[textBeforeWord.length - 1];
+      const NO_COMMA_CHARS = new Set(["+", "-", "*", "/", "(", ","]);
+      const needsComma =
+        textBeforeWord.length > 0 && !NO_COMMA_CHARS.has(lastChar);
+
+      // Build the new text.
+      // • comma case: trim trailing whitespace from the text before the word,
+      //   then insert ", " so we don't get "Metric  , NewMetric".
+      // • no-comma case: use the original (untrimmed) slice so any deliberate
+      //   spacing between an operator and the metric is preserved (e.g. the " "
+      //   in "Revenue + " stays, giving "Revenue + Costs" not "Revenue +Costs").
+      let newText: string;
+      let newCursorPos: number;
+      if (needsComma) {
+        newText = textBeforeWord + ", " + metricName + editText.slice(end);
+        newCursorPos = textBeforeWord.length + 2 + metricName.length;
+      } else {
+        newText = editText.slice(0, start) + metricName + editText.slice(end);
+        newCursorPos = start + metricName.length;
+      }
+
+      setEditText(newText);
+
+      onAddMetric(metric);
+
+      // Compute the optimistic updated metrics list so we can parse immediately
       const existingIndex = selectedMetrics.findIndex(
         (m) => m.id === metric.id && m.sourceType === metric.sourceType,
       );
-      const metricIndex =
-        existingIndex !== -1 ? existingIndex : selectedMetrics.length;
-      onAddMetric(metric);
-      onTokensChange([
-        ...tokens,
-        ...(pendingOperator !== null
-          ? [{ type: "operator" as const, op: pendingOperator }]
-          : []),
-        { type: "metric" as const, metricIndex },
-      ]);
-      setPendingOperator(null);
-      setSearchText("");
-      setIsOpen(false);
-    },
-    [onAddMetric, onTokensChange, pendingOperator, selectedMetrics, tokens],
-  );
+      const updatedMetrics =
+        existingIndex !== -1 ? selectedMetrics : [...selectedMetrics, metric];
 
-  const commitConstant = useCallback(
-    (value: number) => {
-      onTokensChange([
-        ...tokens,
-        ...(pendingOperator !== null
-          ? [{ type: "operator" as const, op: pendingOperator }]
-          : []),
-        { type: "constant" as const, value },
-      ]);
-      setPendingOperator(null);
-      setSearchText("");
-      setIsOpen(false);
-    },
-    [onTokensChange, pendingOperator, tokens],
-  );
+      const newTokens = parseFullText(newText, updatedMetrics);
+      onTokensChange(newTokens);
 
-  const handleKeyDown = useCallback(
-    (event: React.KeyboardEvent) => {
-      // Commit numeric constant when pressing Enter or an operator key
-      const numValue = searchText !== "" ? Number(searchText) : NaN;
-      if (searchText !== "" && !isNaN(numValue) && isFinite(numValue)) {
-        if (event.key === "Enter") {
-          event.preventDefault();
-          commitConstant(numValue);
-          return;
+      setCurrentWord("");
+      setIsOpen(false);
+
+      // Reposition cursor right after the inserted metric name
+      setTimeout(() => {
+        if (inputRef.current) {
+          inputRef.current.setSelectionRange(newCursorPos, newCursorPos);
+          inputRef.current.focus();
         }
-        if (isMathOperator(event.key)) {
-          event.preventDefault();
-          commitConstant(numValue);
-          setPendingOperator(event.key);
-          setIsOpen(true);
-          return;
+      }, 0);
+    },
+    [editText, selectedMetrics, onAddMetric, onTokensChange],
+  );
+
+  // Remove one item (pill) by index
+  const handleRemoveItem = useCallback(
+    (itemIndex: number) => {
+      const allItems = splitByItems(tokens);
+      const removedItemTokens = allItems[itemIndex];
+
+      const removedIndices = new Set(
+        removedItemTokens
+          .filter(
+            (t): t is { type: "metric"; metricIndex: number } =>
+              t.type === "metric",
+          )
+          .map((t) => t.metricIndex),
+      );
+
+      const remainingItems = allItems.filter((_, i) => i !== itemIndex);
+      let newTokens: ExpressionToken[] = remainingItems.flatMap((item, i) =>
+        i < remainingItems.length - 1
+          ? [...item, { type: "separator" as const }]
+          : item,
+      );
+
+      const stillReferenced = new Set(
+        newTokens
+          .filter(
+            (t): t is { type: "metric"; metricIndex: number } =>
+              t.type === "metric",
+          )
+          .map((t) => t.metricIndex),
+      );
+
+      const toRemove = [...removedIndices]
+        .filter((idx) => !stillReferenced.has(idx))
+        .sort((a, b) => b - a);
+
+      for (const removeIdx of toRemove) {
+        newTokens = newTokens.map((t) =>
+          t.type === "metric" && t.metricIndex > removeIdx
+            ? { ...t, metricIndex: t.metricIndex - 1 }
+            : t,
+        );
+        const metric = selectedMetrics[removeIdx];
+        if (metric) {
+          onRemoveMetric(metric.id, metric.sourceType);
         }
       }
 
-      if (searchText === "") {
-        // Operator keys
-        if (
-          isMathOperator(event.key) &&
-          (lastToken?.type === "metric" ||
-            lastToken?.type === "constant" ||
-            lastToken?.type === "close-paren")
-        ) {
-          event.preventDefault();
-          setPendingOperator(event.key);
-          setIsOpen(true);
-          return;
-        }
-
-        // Open paren
-        if (event.key === "(" && canOpenParen) {
-          event.preventDefault();
-          onTokensChange([
-            ...tokens,
-            ...(pendingOperator !== null
-              ? [{ type: "operator" as const, op: pendingOperator }]
-              : []),
-            { type: "open-paren" as const },
-          ]);
-          setPendingOperator(null);
-          setIsOpen(true);
-          return;
-        }
-
-        // Close paren
-        if (event.key === ")" && canCloseParen) {
-          event.preventDefault();
-          onTokensChange([...tokens, { type: "close-paren" as const }]);
-          return;
-        }
-
-        // Backspace
-        if (event.key === "Backspace") {
-          if (pendingOperator !== null) {
-            setPendingOperator(null);
-            return;
-          }
-          if (!lastToken) {
-            return;
-          }
-          if (
-            lastToken.type === "close-paren" ||
-            lastToken.type === "open-paren" ||
-            lastToken.type === "operator" ||
-            lastToken.type === "constant"
-          ) {
-            let next = tokens.slice(0, -1);
-            if (
-              lastToken.type === "constant" &&
-              next[next.length - 1]?.type === "operator"
-            ) {
-              next = next.slice(0, -1);
-            }
-            onTokensChange(next);
-            return;
-          }
-          if (lastToken.type === "metric") {
-            const metricIdx = lastToken.metricIndex;
-            const metric = selectedMetrics[metricIdx];
-            const isLastReference =
-              tokens.filter(
-                (t) => t.type === "metric" && t.metricIndex === metricIdx,
-              ).length <= 1;
-            let next = tokens.slice(0, -1);
-            const prevToken = next[next.length - 1];
-            if (prevToken?.type === "operator") {
-              next = next.slice(0, -1);
-            }
-            onTokensChange(
-              isLastReference
-                ? next.map((t) =>
-                    t.type === "metric" && t.metricIndex > metricIdx
-                      ? { ...t, metricIndex: t.metricIndex - 1 }
-                      : t,
-                  )
-                : next,
-            );
-            if (metric && isLastReference) {
-              onRemoveMetric(metric.id, metric.sourceType);
-            }
-            return;
-          }
-        }
-      }
+      onTokensChange(newTokens);
     },
-    [
-      searchText,
-      tokens,
-      selectedMetrics,
-      pendingOperator,
-      lastToken,
-      canOpenParen,
-      canCloseParen,
-      commitConstant,
-      onRemoveMetric,
-      onTokensChange,
-    ],
+    [tokens, selectedMetrics, onRemoveMetric, onTokensChange],
   );
 
   const handleContainerClick = useCallback(() => {
-    inputRef.current?.focus();
+    if (inputRef.current) {
+      inputRef.current.focus();
+    } else {
+      // TextInput not rendered yet (collapsed mode) — transition to expanded
+      pendingFocusRef.current = true;
+      setIsFocused(true);
+    }
   }, []);
 
   const handleInputClick = useCallback(() => {
+    if (!inputRef.current) {
+      return;
+    }
+    // Re-extract word at the new cursor position after a click
+    const cursorPos = inputRef.current.selectionStart ?? editText.length;
+    const { word } = getWordAtCursor(editText, cursorPos);
+    setCurrentWord(word);
     setIsOpen(true);
-  }, []);
+  }, [editText]);
 
-  const handleChangeOperator = useCallback(
-    (tokenIndex: number, newOp: MathOperator) => {
-      onTokensChange(
-        tokens.map((t, i) =>
-          i === tokenIndex && t.type === "operator" ? { ...t, op: newOp } : t,
-        ),
-      );
-    },
-    [tokens, onTokensChange],
-  );
+  const isCollapsed = !isFocused && tokens.length > 0;
 
   return (
     <Flex
@@ -416,115 +370,128 @@ export function MetricSearchInput({
       py="xs"
       onClick={handleContainerClick}
     >
-      <Flex align="center" gap="sm" flex={1} wrap="wrap" mih="2.25rem">
-        {tokens.map((token, i) => {
-          if (token.type === "open-paren") {
-            return (
-              <span key={i} className={S.parenToken}>
-                (
-              </span>
-            );
-          }
-          if (token.type === "close-paren") {
-            return (
-              <span key={i} className={S.parenToken}>
-                )
-              </span>
-            );
-          }
-          if (token.type === "operator") {
-            return (
-              <OperatorPill
-                key={i}
-                operator={token.op}
-                onChange={(op) => handleChangeOperator(i, op)}
-              />
-            );
-          }
-          if (token.type === "constant") {
-            return (
-              <Box key={i} component="span" className={S.constantPill}>
-                {token.value}
-              </Box>
-            );
-          }
-          if (token.type === "metric") {
-            const metric = selectedMetrics[token.metricIndex];
-            if (!metric) {
-              return null;
-            }
-            const sid =
-              metric.sourceType === "metric"
-                ? createMetricSourceId(metric.id)
-                : createMeasureSourceId(metric.id);
-            const entry = definitionsBySourceId.get(sid);
-            if (!entry) {
-              return null;
-            }
-            return (
-              <MetricPill
-                key={i}
-                metric={metric}
-                colors={metricColors[sid]}
-                definitionEntry={entry}
-                selectedMetricIds={selectedMetricIds}
-                selectedMeasureIds={selectedMeasureIds}
-                onSwap={onSwapMetric}
-                onRemove={handleRemoveMetric}
-                onSetBreakout={(dimension) => onSetBreakout(sid, dimension)}
-                onOpen={() => setIsOpen(false)}
-              />
-            );
-          }
-          return null;
-        })}
-        {pendingOperator !== null && (
-          <Box
-            component="span"
-            className={`${S.operatorPill} ${S.operatorPillPending}`}
+      <Flex align="center" gap="sm" flex={1} wrap="wrap" mih="2.375rem">
+        {isCollapsed ? (
+          // Unfocused: each item rendered as MetricPill or MetricExpressionPill
+          <>
+            {items.map((itemTokens, itemIndex) => {
+              const isSingleMetric =
+                itemTokens.length === 1 && itemTokens[0].type === "metric";
+
+              const pill = isSingleMetric
+                ? (() => {
+                    const token = itemTokens[0];
+                    if (token.type !== "metric") {
+                      return null;
+                    }
+                    const metric = selectedMetrics[token.metricIndex];
+                    if (!metric) {
+                      return null;
+                    }
+                    const sid =
+                      metric.sourceType === "metric"
+                        ? createMetricSourceId(metric.id)
+                        : createMeasureSourceId(metric.id);
+                    const entry = definitionsBySourceId.get(sid);
+                    if (!entry) {
+                      return null;
+                    }
+                    return (
+                      <MetricPill
+                        metric={metric}
+                        colors={metricColors[sid]}
+                        definitionEntry={entry}
+                        selectedMetricIds={selectedMetricIds}
+                        selectedMeasureIds={selectedMeasureIds}
+                        onSwap={onSwapMetric}
+                        onRemove={(_id, _sourceType) =>
+                          handleRemoveItem(itemIndex)
+                        }
+                        onSetBreakout={(dimension) =>
+                          onSetBreakout(sid, dimension)
+                        }
+                      />
+                    );
+                  })()
+                : (() => {
+                    // Use the first color of the first metric as the single
+                    // series color (the expression result is one chart series)
+                    const firstMetricToken = itemTokens.find(
+                      (t): t is { type: "metric"; metricIndex: number } =>
+                        t.type === "metric",
+                    );
+                    const firstMetric =
+                      firstMetricToken !== undefined
+                        ? selectedMetrics[firstMetricToken.metricIndex]
+                        : undefined;
+                    const expressionColor =
+                      firstMetric !== undefined
+                        ? metricColors[
+                            firstMetric.sourceType === "metric"
+                              ? createMetricSourceId(firstMetric.id)
+                              : createMeasureSourceId(firstMetric.id)
+                          ]?.[0]
+                        : undefined;
+
+                    return (
+                      <MetricExpressionPill
+                        expressionText={buildExpressionText(
+                          itemTokens,
+                          selectedMetrics,
+                        )}
+                        color={expressionColor}
+                        onClick={(e: React.MouseEvent) => {
+                          e.stopPropagation();
+                          pendingFocusRef.current = true;
+                          setIsFocused(true);
+                        }}
+                        onRemove={() => handleRemoveItem(itemIndex)}
+                      />
+                    );
+                  })();
+
+              return <span key={itemIndex}>{pill}</span>;
+            })}
+          </>
+        ) : (
+          // Focused: single text input showing the full expression
+          <Popover
+            opened={isOpen}
+            onChange={setIsOpen}
+            position="bottom-start"
+            shadow="md"
+            withinPortal
           >
-            {pendingOperator}
-          </Box>
-        )}
-        <Popover
-          opened={isOpen}
-          onChange={setIsOpen}
-          position="bottom-start"
-          shadow="md"
-          withinPortal
-        >
-          <Popover.Target>
-            <TextInput
-              ref={inputRef}
-              classNames={{ input: S.inputField }}
-              flex={1}
-              miw="7.5rem"
-              ml="xs"
-              variant="unstyled"
-              placeholder={
-                selectedMetrics.length === 0 ? t`Search for metrics...` : ""
-              }
-              value={searchText}
-              onChange={(event) => {
-                setSearchText(event.target.value);
-                setIsOpen(true);
-              }}
-              onClick={handleInputClick}
-              onKeyDown={handleKeyDown}
-              data-testid="metrics-viewer-search-input"
-            />
-          </Popover.Target>
-          <Popover.Dropdown p={0} miw="19rem" maw="25rem">
-            {isOpen && (
-              <MetricSearchDropdown
-                selectedMetricIds={EMPTY_SET}
-                selectedMeasureIds={EMPTY_SET}
-                onSelect={handleSelect}
-                externalSearchText={searchText}
+            <Popover.Target>
+              <TextInput
+                ref={inputRef}
+                classNames={{ input: S.inputField }}
+                flex={1}
+                miw="7.5rem"
+                variant="unstyled"
+                placeholder={
+                  tokens.length === 0 ? t`Search for metrics...` : ""
+                }
+                value={editText}
+                onChange={handleChange}
+                onClick={handleInputClick}
+                onFocus={handleInputFocus}
+                onBlur={handleInputBlur}
+                data-testid="metrics-viewer-search-input"
               />
-            )}
-          </Popover.Dropdown>
-        </Popover>
+            </Popover.Target>
+            <Popover.Dropdown p={0} miw="19rem" maw="25rem">
+              {isOpen && (
+                <MetricSearchDropdown
+                  selectedMetricIds={EMPTY_SET}
+                  selectedMeasureIds={EMPTY_SET}
+                  onSelect={handleSelect}
+                  externalSearchText={currentWord}
+                />
+              )}
+            </Popover.Dropdown>
+          </Popover>
+        )}
       </Flex>
     </Flex>
   );

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/MetricSearchInput.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/MetricSearchInput.tsx
@@ -167,7 +167,9 @@ export function MetricSearchInput({
   const canCloseParen =
     hasUnclosedParen &&
     pendingOperator === null &&
-    (lastToken?.type === "metric" || lastToken?.type === "close-paren");
+    (lastToken?.type === "metric" ||
+      lastToken?.type === "constant" ||
+      lastToken?.type === "close-paren");
 
   // Whether we can insert an open-paren
   const canOpenParen =
@@ -246,13 +248,48 @@ export function MetricSearchInput({
     [onAddMetric, onTokensChange, pendingOperator, selectedMetrics, tokens],
   );
 
+  const commitConstant = useCallback(
+    (value: number) => {
+      onTokensChange([
+        ...tokens,
+        ...(pendingOperator !== null
+          ? [{ type: "operator" as const, op: pendingOperator }]
+          : []),
+        { type: "constant" as const, value },
+      ]);
+      setPendingOperator(null);
+      setSearchText("");
+      setIsOpen(false);
+    },
+    [onTokensChange, pendingOperator, tokens],
+  );
+
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent) => {
+      // Commit numeric constant when pressing Enter or an operator key
+      const numValue = searchText !== "" ? Number(searchText) : NaN;
+      if (searchText !== "" && !isNaN(numValue) && isFinite(numValue)) {
+        if (event.key === "Enter") {
+          event.preventDefault();
+          commitConstant(numValue);
+          return;
+        }
+        if (isMathOperator(event.key)) {
+          event.preventDefault();
+          commitConstant(numValue);
+          setPendingOperator(event.key);
+          setIsOpen(true);
+          return;
+        }
+      }
+
       if (searchText === "") {
         // Operator keys
         if (
           isMathOperator(event.key) &&
-          (lastToken?.type === "metric" || lastToken?.type === "close-paren")
+          (lastToken?.type === "metric" ||
+            lastToken?.type === "constant" ||
+            lastToken?.type === "close-paren")
         ) {
           event.preventDefault();
           setPendingOperator(event.key);
@@ -294,9 +331,17 @@ export function MetricSearchInput({
           if (
             lastToken.type === "close-paren" ||
             lastToken.type === "open-paren" ||
-            lastToken.type === "operator"
+            lastToken.type === "operator" ||
+            lastToken.type === "constant"
           ) {
-            onTokensChange(tokens.slice(0, -1));
+            let next = tokens.slice(0, -1);
+            if (
+              lastToken.type === "constant" &&
+              next[next.length - 1]?.type === "operator"
+            ) {
+              next = next.slice(0, -1);
+            }
+            onTokensChange(next);
             return;
           }
           if (lastToken.type === "metric") {
@@ -336,6 +381,7 @@ export function MetricSearchInput({
       lastToken,
       canOpenParen,
       canCloseParen,
+      commitConstant,
       onRemoveMetric,
       onTokensChange,
     ],
@@ -393,6 +439,13 @@ export function MetricSearchInput({
                 operator={token.op}
                 onChange={(op) => handleChangeOperator(i, op)}
               />
+            );
+          }
+          if (token.type === "constant") {
+            return (
+              <Box key={i} component="span" className={S.constantPill}>
+                {token.value}
+              </Box>
             );
           }
           if (token.type === "metric") {

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/MetricSearchInput.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/MetricSearchInput.tsx
@@ -1,9 +1,15 @@
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { t } from "ttag";
 
-import { Flex, Popover, TextInput } from "metabase/ui";
+import { Box, Flex, Group, Popover, TextInput } from "metabase/ui";
 import type { ProjectionClause } from "metabase-lib/metric";
 
+import {
+  type ExpressionToken,
+  MATH_OPERATORS,
+  type MathOperator,
+  isMathOperator,
+} from "../../../types/operators";
 import type {
   MetricSourceId,
   MetricsViewerDefinitionEntry,
@@ -20,6 +26,57 @@ import { getSelectedMeasureIds, getSelectedMetricIds } from "../utils";
 
 import S from "./MetricSearchInput.module.css";
 
+type OperatorPillProps = {
+  operator: MathOperator;
+  onChange: (op: MathOperator) => void;
+};
+
+function OperatorPill({ operator, onChange }: OperatorPillProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <Popover
+      opened={isOpen}
+      onChange={setIsOpen}
+      position="bottom"
+      shadow="md"
+      withinPortal
+    >
+      <Popover.Target>
+        <Box
+          component="button"
+          className={S.operatorPill}
+          onClick={(e: React.MouseEvent) => {
+            e.stopPropagation();
+            setIsOpen((o) => !o);
+          }}
+          aria-label={t`Change operator`}
+        >
+          {operator}
+        </Box>
+      </Popover.Target>
+      <Popover.Dropdown p="xs">
+        <Group gap="xs">
+          {MATH_OPERATORS.map((op) => (
+            <Box
+              key={op}
+              component="button"
+              className={`${S.operatorChoice} ${op === operator ? S.operatorChoiceActive : ""}`}
+              onClick={() => {
+                onChange(op);
+                setIsOpen(false);
+              }}
+              aria-label={op}
+            >
+              {op}
+            </Box>
+          ))}
+        </Group>
+      </Popover.Dropdown>
+    </Popover>
+  );
+}
+
 type MetricSearchInputProps = {
   selectedMetrics: SelectedMetric[];
   metricColors: SourceColorMap;
@@ -31,6 +88,7 @@ type MetricSearchInputProps = {
     id: MetricSourceId,
     dimension: ProjectionClause | undefined,
   ) => void;
+  onExpressionChange?: (tokens: ExpressionToken[]) => void;
 };
 
 export function MetricSearchInput({
@@ -41,10 +99,31 @@ export function MetricSearchInput({
   onRemoveMetric,
   onSwapMetric,
   onSetBreakout,
+  onExpressionChange,
 }: MetricSearchInputProps) {
   const [searchText, setSearchText] = useState("");
   const [isOpen, setIsOpen] = useState(false);
+  // Full expression token stream (committed tokens only)
+  const [tokens, setTokens] = useState<ExpressionToken[]>([]);
+  const [pendingOperator, setPendingOperator] = useState<MathOperator | null>(
+    null,
+  );
   const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    onExpressionChange?.(tokens);
+  }, [tokens, onExpressionChange]);
+
+  // Safety net: drop any metric tokens whose index is out of range
+  useEffect(() => {
+    const maxIdx = selectedMetrics.length - 1;
+    setTokens((prev) => {
+      const filtered = prev.filter(
+        (t) => t.type !== "metric" || t.metricIndex <= maxIdx,
+      );
+      return filtered.length === prev.length ? prev : filtered;
+    });
+  }, [selectedMetrics.length]);
 
   const selectedMetricIds = useMemo(
     () => getSelectedMetricIds(selectedMetrics),
@@ -61,27 +140,172 @@ export function MetricSearchInput({
     [definitions],
   );
 
+  // Derived state from tokens
+  const openParenCount = useMemo(
+    () => tokens.filter((t) => t.type === "open-paren").length,
+    [tokens],
+  );
+  const closeParenCount = useMemo(
+    () => tokens.filter((t) => t.type === "close-paren").length,
+    [tokens],
+  );
+  const hasUnclosedParen = openParenCount > closeParenCount;
+  const lastToken = tokens[tokens.length - 1] ?? null;
+
+  // Whether we can insert a close-paren
+  const canCloseParen =
+    hasUnclosedParen &&
+    pendingOperator === null &&
+    (lastToken?.type === "metric" || lastToken?.type === "close-paren");
+
+  // Whether we can insert an open-paren
+  const canOpenParen =
+    pendingOperator !== null ||
+    tokens.length === 0 ||
+    lastToken?.type === "open-paren" ||
+    lastToken?.type === "operator";
+
+  const handleRemoveMetric = useCallback(
+    (id: number, sourceType: "metric" | "measure") => {
+      const index = selectedMetrics.findIndex(
+        (m) => m.id === id && m.sourceType === sourceType,
+      );
+      if (index !== -1) {
+        setTokens((prev) => {
+          const tokenIdx = prev.findIndex(
+            (t) => t.type === "metric" && t.metricIndex === index,
+          );
+          if (tokenIdx === -1) {
+            return prev;
+          }
+          const next = [...prev];
+          next.splice(tokenIdx, 1); // remove metric token
+
+          // Remove adjacent operator (prefer before, then after)
+          const before = next[tokenIdx - 1];
+          const after = next[tokenIdx];
+          if (before?.type === "operator") {
+            next.splice(tokenIdx - 1, 1);
+          } else if (after?.type === "operator") {
+            next.splice(tokenIdx, 1);
+          }
+
+          // Decrement metricIndex for all subsequent metric tokens
+          return next.map((t) =>
+            t.type === "metric" && t.metricIndex > index
+              ? { ...t, metricIndex: t.metricIndex - 1 }
+              : t,
+          );
+        });
+      }
+      onRemoveMetric(id, sourceType);
+    },
+    [selectedMetrics, onRemoveMetric],
+  );
+
   const handleSelect = useCallback(
     (metric: SelectedMetric) => {
+      const newMetricIndex = selectedMetrics.length; // will be appended at this index
       onAddMetric(metric);
+      setTokens((prev) => [
+        ...prev,
+        ...(pendingOperator !== null
+          ? [{ type: "operator" as const, op: pendingOperator }]
+          : []),
+        { type: "metric" as const, metricIndex: newMetricIndex },
+      ]);
+      setPendingOperator(null);
       setSearchText("");
       setIsOpen(false);
     },
-    [onAddMetric],
+    [onAddMetric, pendingOperator, selectedMetrics.length],
   );
 
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent) => {
-      if (
-        event.key === "Backspace" &&
-        searchText === "" &&
-        selectedMetrics.length > 0
-      ) {
-        const last = selectedMetrics[selectedMetrics.length - 1];
-        onRemoveMetric(last.id, last.sourceType);
+      if (searchText === "") {
+        // Operator keys
+        if (
+          isMathOperator(event.key) &&
+          (lastToken?.type === "metric" || lastToken?.type === "close-paren")
+        ) {
+          event.preventDefault();
+          setPendingOperator(event.key);
+          setIsOpen(true);
+          return;
+        }
+
+        // Open paren
+        if (event.key === "(" && canOpenParen) {
+          event.preventDefault();
+          setTokens((prev) => [
+            ...prev,
+            ...(pendingOperator !== null
+              ? [{ type: "operator" as const, op: pendingOperator }]
+              : []),
+            { type: "open-paren" as const },
+          ]);
+          setPendingOperator(null);
+          setIsOpen(true);
+          return;
+        }
+
+        // Close paren
+        if (event.key === ")" && canCloseParen) {
+          event.preventDefault();
+          setTokens((prev) => [...prev, { type: "close-paren" as const }]);
+          return;
+        }
+
+        // Backspace
+        if (event.key === "Backspace") {
+          if (pendingOperator !== null) {
+            setPendingOperator(null);
+            return;
+          }
+          if (!lastToken) {
+            return;
+          }
+          if (
+            lastToken.type === "close-paren" ||
+            lastToken.type === "open-paren" ||
+            lastToken.type === "operator"
+          ) {
+            setTokens((prev) => prev.slice(0, -1));
+            return;
+          }
+          if (lastToken.type === "metric") {
+            const metricIdx = lastToken.metricIndex;
+            const metric = selectedMetrics[metricIdx];
+            setTokens((prev) => {
+              let next = prev.slice(0, -1);
+              const prevToken = next[next.length - 1];
+              if (prevToken?.type === "operator") {
+                next = next.slice(0, -1);
+              }
+              return next.map((t) =>
+                t.type === "metric" && t.metricIndex > metricIdx
+                  ? { ...t, metricIndex: t.metricIndex - 1 }
+                  : t,
+              );
+            });
+            if (metric) {
+              onRemoveMetric(metric.id, metric.sourceType);
+            }
+            return;
+          }
+        }
       }
     },
-    [searchText, selectedMetrics, onRemoveMetric],
+    [
+      searchText,
+      selectedMetrics,
+      pendingOperator,
+      lastToken,
+      canOpenParen,
+      canCloseParen,
+      onRemoveMetric,
+    ],
   );
 
   const handleContainerClick = useCallback(() => {
@@ -91,6 +315,17 @@ export function MetricSearchInput({
   const handleInputClick = useCallback(() => {
     setIsOpen(true);
   }, []);
+
+  const handleChangeOperator = useCallback(
+    (tokenIndex: number, newOp: MathOperator) => {
+      setTokens((prev) =>
+        prev.map((t, i) =>
+          i === tokenIndex && t.type === "operator" ? { ...t, op: newOp } : t,
+        ),
+      );
+    },
+    [],
+  );
 
   return (
     <Flex
@@ -103,30 +338,68 @@ export function MetricSearchInput({
       onClick={handleContainerClick}
     >
       <Flex align="center" gap="sm" flex={1} wrap="wrap" mih="2.25rem">
-        {selectedMetrics.map((metric) => {
-          const sid =
-            metric.sourceType === "metric"
-              ? createMetricSourceId(metric.id)
-              : createMeasureSourceId(metric.id);
-          const entry = definitionsBySourceId.get(sid);
-          if (!entry) {
-            return null;
+        {tokens.map((token, i) => {
+          if (token.type === "open-paren") {
+            return (
+              <span key={i} className={S.parenToken}>
+                (
+              </span>
+            );
           }
-          return (
-            <MetricPill
-              key={`${metric.sourceType}-${metric.id}`}
-              metric={metric}
-              colors={metricColors[sid]}
-              definitionEntry={entry}
-              selectedMetricIds={selectedMetricIds}
-              selectedMeasureIds={selectedMeasureIds}
-              onSwap={onSwapMetric}
-              onRemove={onRemoveMetric}
-              onSetBreakout={(dimension) => onSetBreakout(sid, dimension)}
-              onOpen={() => setIsOpen(false)}
-            />
-          );
+          if (token.type === "close-paren") {
+            return (
+              <span key={i} className={S.parenToken}>
+                )
+              </span>
+            );
+          }
+          if (token.type === "operator") {
+            return (
+              <OperatorPill
+                key={i}
+                operator={token.op}
+                onChange={(op) => handleChangeOperator(i, op)}
+              />
+            );
+          }
+          if (token.type === "metric") {
+            const metric = selectedMetrics[token.metricIndex];
+            if (!metric) {
+              return null;
+            }
+            const sid =
+              metric.sourceType === "metric"
+                ? createMetricSourceId(metric.id)
+                : createMeasureSourceId(metric.id);
+            const entry = definitionsBySourceId.get(sid);
+            if (!entry) {
+              return null;
+            }
+            return (
+              <MetricPill
+                key={`${metric.sourceType}-${metric.id}`}
+                metric={metric}
+                colors={metricColors[sid]}
+                definitionEntry={entry}
+                selectedMetricIds={selectedMetricIds}
+                selectedMeasureIds={selectedMeasureIds}
+                onSwap={onSwapMetric}
+                onRemove={handleRemoveMetric}
+                onSetBreakout={(dimension) => onSetBreakout(sid, dimension)}
+                onOpen={() => setIsOpen(false)}
+              />
+            );
+          }
+          return null;
         })}
+        {pendingOperator !== null && (
+          <Box
+            component="span"
+            className={`${S.operatorPill} ${S.operatorPillPending}`}
+          >
+            {pendingOperator}
+          </Box>
+        )}
         <Popover
           opened={isOpen}
           onChange={setIsOpen}

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchResults/MetricSearchResults.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchResults/MetricSearchResults.tsx
@@ -1,7 +1,7 @@
 import type React from "react";
 import { t } from "ttag";
 
-import { Box, Repeat, Skeleton, Stack, Text } from "metabase/ui";
+import { Box, Divider, Repeat, Skeleton, Stack, Text } from "metabase/ui";
 
 import type { MetricOrMeasureResult } from "../../../hooks/use-metric-measure-search";
 import { MetricResultItem } from "../MetricResultItem";
@@ -16,6 +16,7 @@ type MetricSearchResultsProps = {
     item: MetricOrMeasureResult,
   ) => React.RefObject<HTMLDivElement> | undefined;
   onSelectResult: (id: number, model: "metric" | "measure") => void;
+  onSummarizeTable?: () => void;
 };
 
 export function MetricSearchResults({
@@ -24,6 +25,7 @@ export function MetricSearchResults({
   cursorIndex,
   getRef,
   onSelectResult,
+  onSummarizeTable,
 }: MetricSearchResultsProps) {
   if (isLoading) {
     return (
@@ -37,32 +39,55 @@ export function MetricSearchResults({
 
   if (results.length === 0) {
     return (
-      <Box p="xl" data-testid="metrics-search-results">
-        <Text c="text-secondary" ta="center">
-          {t`No results found`}
-        </Text>
+      <Box data-testid="metrics-search-results">
+        <Box p="xl">
+          <Text c="text-secondary" ta="center">
+            {t`No results found`}
+          </Text>
+        </Box>
+        {onSummarizeTable && (
+          <>
+            <Divider />
+            <Box p="sm">
+              <MetricResultItem
+                name={t`Summarize a table`}
+                icon="table"
+                onClick={onSummarizeTable}
+              />
+            </Box>
+          </>
+        )}
       </Box>
     );
   }
 
   return (
-    <Box
-      mah="25rem"
-      p="sm"
-      className={S.listbox}
-      data-testid="metrics-search-results"
-    >
-      {results.map((item, index) => (
-        <MetricResultItem
-          key={`${item.model}-${item.id}`}
-          ref={getRef(item)}
-          name={item.name}
-          slug={item.table_name ?? undefined}
-          icon={item.model === "metric" ? "metric" : "sum"}
-          active={cursorIndex === index}
-          onClick={() => onSelectResult(item.id, item.model)}
-        />
-      ))}
+    <Box data-testid="metrics-search-results">
+      <Box mah="25rem" p="sm" className={S.listbox}>
+        {results.map((item, index) => (
+          <MetricResultItem
+            key={`${item.model}-${item.id}`}
+            ref={getRef(item)}
+            name={item.name}
+            slug={item.table_name ?? undefined}
+            icon={item.model === "metric" ? "metric" : "sum"}
+            active={cursorIndex === index}
+            onClick={() => onSelectResult(item.id, item.model)}
+          />
+        ))}
+      </Box>
+      {onSummarizeTable && (
+        <>
+          <Divider />
+          <Box p="sm">
+            <MetricResultItem
+              name={t`Summarize a table`}
+              icon="table"
+              onClick={onSummarizeTable}
+            />
+          </Box>
+        </>
+      )}
     </Box>
   );
 }

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.ts
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.ts
@@ -1,5 +1,222 @@
-import type { ExpressionToken } from "../../types/operators";
+import type { ExpressionToken, MathOperator } from "../../types/operators";
 import type { SelectedMetric } from "../../types/viewer-state";
+
+/**
+ * Splits a flat token array into items at each separator token.
+ * Always returns at least one item (possibly empty).
+ */
+export function splitByItems(tokens: ExpressionToken[]): ExpressionToken[][] {
+  const items: ExpressionToken[][] = [[]];
+  for (const token of tokens) {
+    if (token.type === "separator") {
+      items.push([]);
+    } else {
+      items[items.length - 1].push(token);
+    }
+  }
+  return items;
+}
+
+/**
+ * Builds a human-readable expression string from a single item's tokens.
+ * Spaces are omitted after "(" and before ")".
+ */
+export function buildExpressionText(
+  itemTokens: ExpressionToken[],
+  selectedMetrics: SelectedMetric[],
+): string {
+  let result = "";
+  for (let i = 0; i < itemTokens.length; i++) {
+    const token = itemTokens[i];
+    const prev = itemTokens[i - 1];
+    if (i > 0 && prev?.type !== "open-paren" && token.type !== "close-paren") {
+      result += " ";
+    }
+    if (token.type === "open-paren") {
+      result += "(";
+    } else if (token.type === "close-paren") {
+      result += ")";
+    } else if (token.type === "operator") {
+      result += token.op;
+    } else if (token.type === "metric") {
+      result += selectedMetrics[token.metricIndex]?.name ?? "";
+    }
+  }
+  return result;
+}
+
+/**
+ * Removes leading, trailing, and consecutive separator tokens,
+ * which result in empty items. Safe to call at any time.
+ */
+export function cleanupSeparators(
+  tokens: ExpressionToken[],
+): ExpressionToken[] {
+  const result: ExpressionToken[] = [];
+  let prevWasSeparator = true; // treat start as separator to drop leading ones
+
+  for (const token of tokens) {
+    if (token.type === "separator") {
+      if (!prevWasSeparator) {
+        result.push(token);
+        prevWasSeparator = true;
+      }
+    } else {
+      result.push(token);
+      prevWasSeparator = false;
+    }
+  }
+
+  // Drop trailing separator
+  if (result[result.length - 1]?.type === "separator") {
+    result.pop();
+  }
+
+  return result;
+}
+
+/**
+ * Builds the full editable text for all items joined by ", ".
+ */
+export function buildFullText(
+  tokens: ExpressionToken[],
+  selectedMetrics: SelectedMetric[],
+): string {
+  return splitByItems(tokens)
+    .map((item) => buildExpressionText(item, selectedMetrics))
+    .join(", ");
+}
+
+const EXPRESSION_DELIMITERS = new Set(["+", "-", "*", "/", "(", ")", ","]);
+
+/**
+ * Extracts the "word" (potential metric name) at the given cursor position,
+ * using expression delimiters (+, -, *, /, (, ), ,) as boundaries.
+ * Spaces are NOT delimiters so that multi-word metric names like "Page Views"
+ * are returned as a single word. Surrounding whitespace is trimmed.
+ */
+export function getWordAtCursor(
+  text: string,
+  cursorPos: number,
+): { word: string; start: number; end: number } {
+  let start = cursorPos;
+  while (start > 0 && !EXPRESSION_DELIMITERS.has(text[start - 1])) {
+    start--;
+  }
+
+  let end = cursorPos;
+  while (end < text.length && !EXPRESSION_DELIMITERS.has(text[end])) {
+    end++;
+  }
+
+  const rawWord = text.slice(start, end);
+  const trimmedWord = rawWord.trim();
+  const leadingSpaces = rawWord.length - rawWord.trimStart().length;
+
+  return {
+    word: trimmedWord,
+    start: start + leadingSpaces,
+    end: start + leadingSpaces + trimmedWord.length,
+  };
+}
+
+/**
+ * Parses a full expression text (potentially with ", " separators) back into
+ * a flat ExpressionToken array. Only metrics present in `selectedMetrics` are
+ * recognized; unresolved words are silently dropped.
+ * Metric names are matched greedily, longest first, so names containing
+ * operators (e.g. "Year-to-Date") are handled correctly.
+ */
+export function parseFullText(
+  text: string,
+  selectedMetrics: SelectedMetric[],
+): ExpressionToken[] {
+  const rawItems = text.split(",");
+  const allTokens: ExpressionToken[] = [];
+
+  rawItems.forEach((rawItem, idx) => {
+    const itemTokens = parseItemText(rawItem, selectedMetrics);
+    allTokens.push(...itemTokens);
+    if (idx < rawItems.length - 1) {
+      allTokens.push({ type: "separator" });
+    }
+  });
+
+  return cleanupSeparators(allTokens);
+}
+
+function parseItemText(
+  text: string,
+  selectedMetrics: SelectedMetric[],
+): ExpressionToken[] {
+  const tokens: ExpressionToken[] = [];
+
+  // Sort metrics by name length descending for greedy longest-first matching
+  const sortedMetrics = selectedMetrics
+    .map((m, idx) => ({ name: (m.name ?? "").toLowerCase(), idx }))
+    .filter((m) => m.name.length > 0)
+    .sort((a, b) => b.name.length - a.name.length);
+
+  const lower = text.toLowerCase();
+  let i = 0;
+
+  while (i < text.length) {
+    const ch = text[i];
+
+    // Skip whitespace
+    if (ch === " " || ch === "\t") {
+      i++;
+      continue;
+    }
+
+    // Parens
+    if (ch === "(") {
+      tokens.push({ type: "open-paren" });
+      i++;
+      continue;
+    }
+    if (ch === ")") {
+      tokens.push({ type: "close-paren" });
+      i++;
+      continue;
+    }
+
+    // Math operators
+    if (ch === "+" || ch === "-" || ch === "*" || ch === "/") {
+      tokens.push({ type: "operator", op: ch as MathOperator });
+      i++;
+      continue;
+    }
+
+    // Try to match a metric name (greedy, longest first)
+    let matched = false;
+    for (const { name, idx } of sortedMetrics) {
+      if (lower.startsWith(name, i)) {
+        const nextI = i + name.length;
+        const nextCh = text[nextI];
+        // Ensure we're at a word boundary (next char is a delimiter, space, or end)
+        if (
+          !nextCh ||
+          nextCh === " " ||
+          nextCh === "\t" ||
+          EXPRESSION_DELIMITERS.has(nextCh)
+        ) {
+          tokens.push({ type: "metric", metricIndex: idx });
+          i = nextI;
+          matched = true;
+          break;
+        }
+      }
+    }
+
+    if (!matched) {
+      // Unrecognized character (partial name being typed) – skip
+      i++;
+    }
+  }
+
+  return tokens;
+}
 
 export function getSelectedMetricIds(
   selectedMetrics: SelectedMetric[],
@@ -18,6 +235,46 @@ export function getSelectedMeasureIds(
     selectedMetrics
       .filter((metric) => metric.sourceType === "measure")
       .map((metric) => metric.id),
+  );
+}
+
+/**
+ * Removes unmatched parentheses from a token stream.
+ * An open-paren with no matching close-paren, or a close-paren with no matching
+ * open-paren, are both stripped. Returns the original reference if no change.
+ */
+export function removeUnmatchedParens(
+  tokens: ExpressionToken[],
+): ExpressionToken[] {
+  const openStack: number[] = [];
+  const matchedIndices = new Set<number>();
+
+  tokens.forEach((token, i) => {
+    if (token.type === "open-paren") {
+      openStack.push(i);
+    } else if (token.type === "close-paren") {
+      if (openStack.length > 0) {
+        matchedIndices.add(openStack.pop()!);
+        matchedIndices.add(i);
+      }
+      // unmatched close-paren: intentionally not added to matchedIndices
+    }
+  });
+
+  const hasDangling = tokens.some(
+    (token, i) =>
+      (token.type === "open-paren" || token.type === "close-paren") &&
+      !matchedIndices.has(i),
+  );
+
+  if (!hasDangling) {
+    return tokens; // same reference — no change
+  }
+
+  return tokens.filter((token, i) =>
+    token.type !== "open-paren" && token.type !== "close-paren"
+      ? true
+      : matchedIndices.has(i),
   );
 }
 

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.ts
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.ts
@@ -1,3 +1,4 @@
+import type { ExpressionToken } from "../../types/operators";
 import type { SelectedMetric } from "../../types/viewer-state";
 
 export function getSelectedMetricIds(
@@ -18,6 +19,59 @@ export function getSelectedMeasureIds(
       .filter((metric) => metric.sourceType === "measure")
       .map((metric) => metric.id),
   );
+}
+
+/**
+ * Removes unnecessary parentheses from a token stream.
+ * Parens are unnecessary when they contain 0 or 1 metric tokens (at any depth).
+ * Runs repeatedly until no more cleanup is possible.
+ */
+export function cleanupParens(tokens: ExpressionToken[]): ExpressionToken[] {
+  let current = tokens;
+  let changed = true;
+
+  while (changed) {
+    changed = false;
+
+    for (let i = 0; i < current.length; i++) {
+      if (current[i].type !== "open-paren") {
+        continue;
+      }
+
+      // Find the matching close-paren
+      let depth = 1;
+      let j = i + 1;
+      while (j < current.length && depth > 0) {
+        if (current[j].type === "open-paren") {
+          depth++;
+        } else if (current[j].type === "close-paren") {
+          depth--;
+        }
+        j++;
+      }
+
+      if (depth !== 0) {
+        // Unmatched open-paren — skip
+        continue;
+      }
+
+      const closeIdx = j - 1;
+      const content = current.slice(i + 1, closeIdx);
+      const metricCount = content.filter((t) => t.type === "metric").length;
+
+      if (metricCount <= 1) {
+        current = [
+          ...current.slice(0, i),
+          ...content,
+          ...current.slice(closeIdx + 1),
+        ];
+        changed = true;
+        break;
+      }
+    }
+  }
+
+  return current;
 }
 
 type ExcludeMetric = {

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.ts
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.ts
@@ -40,6 +40,8 @@ export function buildExpressionText(
       result += token.op;
     } else if (token.type === "metric") {
       result += selectedMetrics[token.metricIndex]?.name ?? "";
+    } else if (token.type === "constant") {
+      result += String(token.value);
     }
   }
   return result;
@@ -185,6 +187,30 @@ function parseItemText(
     if (ch === "+" || ch === "-" || ch === "*" || ch === "/") {
       tokens.push({ type: "operator", op: ch as MathOperator });
       i++;
+      continue;
+    }
+
+    // Numeric literal: one or more digits, optionally followed by "." and more digits
+    // e.g. "0.85", "100", "1.5" — but NOT a leading-dot form like ".85"
+    if (ch >= "0" && ch <= "9") {
+      let numStr = "";
+      while (i < text.length && text[i] >= "0" && text[i] <= "9") {
+        numStr += text[i++];
+      }
+      // Consume decimal part only when followed by at least one digit
+      if (
+        i < text.length &&
+        text[i] === "." &&
+        i + 1 < text.length &&
+        text[i + 1] >= "0" &&
+        text[i + 1] <= "9"
+      ) {
+        numStr += text[i++]; // consume "."
+        while (i < text.length && text[i] >= "0" && text[i] <= "9") {
+          numStr += text[i++];
+        }
+      }
+      tokens.push({ type: "constant", value: parseFloat(numStr) });
       continue;
     }
 

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.ts
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.ts
@@ -57,9 +57,11 @@ export function cleanupParens(tokens: ExpressionToken[]): ExpressionToken[] {
 
       const closeIdx = j - 1;
       const content = current.slice(i + 1, closeIdx);
-      const metricCount = content.filter((t) => t.type === "metric").length;
+      const operandCount = content.filter(
+        (t) => t.type === "metric" || t.type === "constant",
+      ).length;
 
-      if (metricCount <= 1) {
+      if (operandCount <= 1) {
         current = [
           ...current.slice(0, i),
           ...content,

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.unit.spec.ts
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.unit.spec.ts
@@ -1,6 +1,8 @@
+import type { ExpressionToken } from "../../types/operators";
 import type { SelectedMetric } from "../../types/viewer-state";
 
 import {
+  cleanupParens,
   filterSearchResults,
   getSelectedMeasureIds,
   getSelectedMetricIds,
@@ -121,5 +123,68 @@ describe("filterSearchResults", () => {
     expect(filtered.map((r) => ({ id: r.id, model: r.model }))).toEqual([
       { id: 20, model: "measure" },
     ]);
+  });
+});
+
+describe("cleanupParens", () => {
+  const m = (metricIndex: number): ExpressionToken => ({
+    type: "metric",
+    metricIndex,
+  });
+  const op = (o: "+" | "-" | "*" | "/"): ExpressionToken => ({
+    type: "operator",
+    op: o,
+  });
+  const open: ExpressionToken = { type: "open-paren" };
+  const close: ExpressionToken = { type: "close-paren" };
+
+  it("returns empty array unchanged", () => {
+    expect(cleanupParens([])).toEqual([]);
+  });
+
+  it("returns same reference when no cleanup needed", () => {
+    const tokens: ExpressionToken[] = [m(0), op("+"), m(1)];
+    expect(cleanupParens(tokens)).toBe(tokens);
+  });
+
+  it("removes empty parentheses", () => {
+    expect(cleanupParens([open, close])).toEqual([]);
+  });
+
+  it("removes parentheses around a single metric", () => {
+    expect(cleanupParens([open, m(0), close])).toEqual([m(0)]);
+  });
+
+  it("keeps parentheses around multiple metrics", () => {
+    const tokens = [open, m(0), op("+"), m(1), close];
+    expect(cleanupParens(tokens)).toEqual(tokens);
+  });
+
+  it("removes nested single-metric parens", () => {
+    // ((A)) → A
+    expect(cleanupParens([open, open, m(0), close, close])).toEqual([m(0)]);
+  });
+
+  it("removes inner single-metric parens but keeps outer multi-metric parens", () => {
+    // (A + (B)) → (A + B)
+    expect(
+      cleanupParens([open, m(0), op("+"), open, m(1), close, close]),
+    ).toEqual([open, m(0), op("+"), m(1), close]);
+  });
+
+  it("removes single-metric parens in a larger expression", () => {
+    // (A) + B → A + B
+    expect(cleanupParens([open, m(0), close, op("+"), m(1)])).toEqual([
+      m(0),
+      op("+"),
+      m(1),
+    ]);
+  });
+
+  it("removes multiple independent single-metric paren groups", () => {
+    // (A) + (B) → A + B
+    expect(
+      cleanupParens([open, m(0), close, op("+"), open, m(1), close]),
+    ).toEqual([m(0), op("+"), m(1)]);
   });
 });

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.unit.spec.ts
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.unit.spec.ts
@@ -2,10 +2,12 @@ import type { ExpressionToken } from "../../types/operators";
 import type { SelectedMetric } from "../../types/viewer-state";
 
 import {
+  buildExpressionText,
   cleanupParens,
   filterSearchResults,
   getSelectedMeasureIds,
   getSelectedMetricIds,
+  parseFullText,
 } from "./utils";
 
 function makeSelectedMetric(
@@ -186,5 +188,182 @@ describe("cleanupParens", () => {
     expect(
       cleanupParens([open, m(0), close, op("+"), open, m(1), close]),
     ).toEqual([m(0), op("+"), m(1)]);
+  });
+
+  it("keeps parentheses around a metric and a constant (two operands)", () => {
+    // (A * 0.85) stays — two operands inside
+    const k = (v: number): ExpressionToken => ({ type: "constant", value: v });
+    expect(cleanupParens([open, m(0), op("*"), k(0.85), close])).toEqual([
+      open,
+      m(0),
+      op("*"),
+      k(0.85),
+      close,
+    ]);
+  });
+
+  it("removes parentheses around a lone constant (one operand)", () => {
+    const k = (v: number): ExpressionToken => ({ type: "constant", value: v });
+    expect(cleanupParens([open, k(1), close])).toEqual([k(1)]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildExpressionText — constants
+// ---------------------------------------------------------------------------
+
+describe("buildExpressionText", () => {
+  const revenue: SelectedMetric = {
+    id: 1,
+    name: "Revenue",
+    sourceType: "metric",
+  };
+  const costs: SelectedMetric = { id: 2, name: "Costs", sourceType: "metric" };
+  const metrics = [revenue, costs];
+
+  const m = (idx: number): ExpressionToken => ({
+    type: "metric",
+    metricIndex: idx,
+  });
+  const op = (o: "+" | "-" | "*" | "/"): ExpressionToken => ({
+    type: "operator",
+    op: o,
+  });
+  const k = (v: number): ExpressionToken => ({ type: "constant", value: v });
+  const open: ExpressionToken = { type: "open-paren" };
+  const close: ExpressionToken = { type: "close-paren" };
+
+  it("renders a metric scaled by a decimal constant", () => {
+    expect(buildExpressionText([m(0), op("*"), k(0.85)], metrics)).toBe(
+      "Revenue * 0.85",
+    );
+  });
+
+  it("renders an integer constant", () => {
+    expect(buildExpressionText([m(0), op("*"), k(100)], metrics)).toBe(
+      "Revenue * 100",
+    );
+  });
+
+  it("renders constants inside parentheses", () => {
+    // (Revenue + Costs) * 0.85
+    expect(
+      buildExpressionText(
+        [open, m(0), op("+"), m(1), close, op("*"), k(0.85)],
+        metrics,
+      ),
+    ).toBe("(Revenue + Costs) * 0.85");
+  });
+
+  it("renders a constant divided by a metric", () => {
+    expect(buildExpressionText([k(1), op("/"), m(0)], metrics)).toBe(
+      "1 / Revenue",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseFullText — numeric literals
+// ---------------------------------------------------------------------------
+
+describe("parseFullText — numeric literal parsing", () => {
+  const revenue: SelectedMetric = {
+    id: 1,
+    name: "Revenue",
+    sourceType: "metric",
+  };
+  const costs: SelectedMetric = { id: 2, name: "Costs", sourceType: "metric" };
+  const metrics = [revenue, costs];
+
+  const m = (idx: number): ExpressionToken => ({
+    type: "metric",
+    metricIndex: idx,
+  });
+  const op = (o: "+" | "-" | "*" | "/"): ExpressionToken => ({
+    type: "operator",
+    op: o,
+  });
+  const k = (v: number): ExpressionToken => ({ type: "constant", value: v });
+
+  it("parses a metric multiplied by a decimal constant", () => {
+    expect(parseFullText("Revenue * 0.85", metrics)).toEqual([
+      m(0),
+      op("*"),
+      k(0.85),
+    ]);
+  });
+
+  it("parses a metric multiplied by an integer constant", () => {
+    expect(parseFullText("Revenue * 100", metrics)).toEqual([
+      m(0),
+      op("*"),
+      k(100),
+    ]);
+  });
+
+  it("parses a constant on the left side", () => {
+    expect(parseFullText("0.5 * Revenue", metrics)).toEqual([
+      k(0.5),
+      op("*"),
+      m(0),
+    ]);
+  });
+
+  it("parses a constant inside parentheses — (Revenue + Costs) * 0.85", () => {
+    expect(parseFullText("(Revenue + Costs) * 0.85", metrics)).toEqual([
+      { type: "open-paren" },
+      m(0),
+      op("+"),
+      m(1),
+      { type: "close-paren" },
+      op("*"),
+      k(0.85),
+    ]);
+  });
+
+  it("parses multiple constants in one expression", () => {
+    // 0.5 * Revenue + 0.5 * Costs
+    expect(parseFullText("0.5 * Revenue + 0.5 * Costs", metrics)).toEqual([
+      k(0.5),
+      op("*"),
+      m(0),
+      op("+"),
+      k(0.5),
+      op("*"),
+      m(1),
+    ]);
+  });
+
+  it("handles an integer that looks like it could start a decimal (no dot follows)", () => {
+    // "1 + Revenue" — "1" is an integer with no fractional part
+    expect(parseFullText("1 + Revenue", metrics)).toEqual([
+      k(1),
+      op("+"),
+      m(0),
+    ]);
+  });
+
+  it("does not parse a trailing dot as part of the number", () => {
+    // "1." — trailing dot with no digit after it; "1" is the constant, "." is skipped
+    expect(parseFullText("1.", metrics)).toEqual([k(1)]);
+  });
+
+  it("parses constants and metrics as separate items separated by a comma", () => {
+    // "Revenue * 0.85, Costs"
+    expect(parseFullText("Revenue * 0.85, Costs", metrics)).toEqual([
+      m(0),
+      op("*"),
+      k(0.85),
+      { type: "separator" },
+      m(1),
+    ]);
+  });
+
+  it("round-trips through buildExpressionText", () => {
+    const text = "(Revenue + Costs) * 0.85";
+    const tokens = parseFullText(text, metrics);
+    // Remove the separator-less single item and rebuild
+    const [item] = [tokens]; // only one item (no separators)
+    expect(buildExpressionText(item as ExpressionToken[], metrics)).toBe(text);
   });
 });

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearchPanel/MetricSearchPanel.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearchPanel/MetricSearchPanel.tsx
@@ -20,6 +20,8 @@ import { MetricsFilterPills } from "../MetricsFilterPills";
 import S from "./MetricSearchPanel.module.css";
 
 type MetricSearchPanelProps = {
+  tokens: ExpressionToken[];
+  onTokensChange: (tokens: ExpressionToken[]) => void;
   selectedMetrics: SelectedMetric[];
   metricColors: SourceColorMap;
   definitions: MetricsViewerDefinitionEntry[];
@@ -34,10 +36,11 @@ type MetricSearchPanelProps = {
     id: MetricSourceId,
     definition: MetricDefinition,
   ) => void;
-  onExpressionChange?: (tokens: ExpressionToken[]) => void;
 };
 
 export function MetricSearchPanel({
+  tokens,
+  onTokensChange,
   selectedMetrics,
   metricColors,
   definitions,
@@ -46,7 +49,6 @@ export function MetricSearchPanel({
   onSwapMetric,
   onSetBreakout,
   onUpdateDefinition,
-  onExpressionChange,
 }: MetricSearchPanelProps) {
   const [isFilterPillsExpanded, setIsFilterPillsExpanded] = useState(true);
 
@@ -125,6 +127,8 @@ export function MetricSearchPanel({
       <Box className={S.container}>
         <Box>
           <MetricSearch
+            tokens={tokens}
+            onTokensChange={onTokensChange}
             selectedMetrics={selectedMetrics}
             metricColors={metricColors}
             definitions={definitions}
@@ -132,7 +136,6 @@ export function MetricSearchPanel({
             onRemoveMetric={onRemoveMetric}
             onSwapMetric={onSwapMetric}
             onSetBreakout={onSetBreakout}
-            onExpressionChange={onExpressionChange}
           />
         </Box>
         {hasFilters && isFilterPillsExpanded && (

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearchPanel/MetricSearchPanel.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearchPanel/MetricSearchPanel.tsx
@@ -4,6 +4,7 @@ import { t } from "ttag";
 import { Box, Button, Flex, Icon, Stack, Text, Tooltip } from "metabase/ui";
 import type { MetricDefinition, ProjectionClause } from "metabase-lib/metric";
 import * as LibMetric from "metabase-lib/metric";
+import type { DatabaseId } from "metabase-types/api";
 
 import type { ExpressionToken } from "../../types/operators";
 import type {
@@ -16,6 +17,7 @@ import { FilterPopover } from "../FilterPopover";
 import type { DefinitionSource } from "../FilterPopover/FilterPopoverContent";
 import { MetricSearch } from "../MetricSearch";
 import { MetricsFilterPills } from "../MetricsFilterPills";
+import type { AdhocResult } from "../SummarizeTable";
 
 import S from "./MetricSearchPanel.module.css";
 
@@ -26,7 +28,7 @@ type MetricSearchPanelProps = {
   metricColors: SourceColorMap;
   definitions: MetricsViewerDefinitionEntry[];
   onAddMetric: (metric: SelectedMetric) => void;
-  onRemoveMetric: (metricId: number, sourceType: "metric" | "measure") => void;
+  onRemoveMetric: (metric: SelectedMetric) => void;
   onSwapMetric: (oldMetric: SelectedMetric, newMetric: SelectedMetric) => void;
   onSetBreakout: (
     id: MetricSourceId,
@@ -36,6 +38,8 @@ type MetricSearchPanelProps = {
     id: MetricSourceId,
     definition: MetricDefinition,
   ) => void;
+  onAddAdhoc?: (result: AdhocResult) => void;
+  databaseId?: DatabaseId | null;
 };
 
 export function MetricSearchPanel({
@@ -49,6 +53,8 @@ export function MetricSearchPanel({
   onSwapMetric,
   onSetBreakout,
   onUpdateDefinition,
+  onAddAdhoc,
+  databaseId,
 }: MetricSearchPanelProps) {
   const [isFilterPillsExpanded, setIsFilterPillsExpanded] = useState(true);
 
@@ -136,6 +142,8 @@ export function MetricSearchPanel({
             onRemoveMetric={onRemoveMetric}
             onSwapMetric={onSwapMetric}
             onSetBreakout={onSetBreakout}
+            onAddAdhoc={onAddAdhoc}
+            databaseId={databaseId}
           />
         </Box>
         {hasFilters && isFilterPillsExpanded && (

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearchPanel/MetricSearchPanel.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearchPanel/MetricSearchPanel.tsx
@@ -4,7 +4,6 @@ import { t } from "ttag";
 import { Box, Button, Flex, Icon, Stack, Text, Tooltip } from "metabase/ui";
 import type { MetricDefinition, ProjectionClause } from "metabase-lib/metric";
 import * as LibMetric from "metabase-lib/metric";
-import type { DatabaseId } from "metabase-types/api";
 
 import type { ExpressionToken } from "../../types/operators";
 import type {
@@ -39,7 +38,6 @@ type MetricSearchPanelProps = {
     definition: MetricDefinition,
   ) => void;
   onAddAdhoc?: (result: AdhocResult) => void;
-  databaseId?: DatabaseId | null;
 };
 
 export function MetricSearchPanel({
@@ -54,7 +52,6 @@ export function MetricSearchPanel({
   onSetBreakout,
   onUpdateDefinition,
   onAddAdhoc,
-  databaseId,
 }: MetricSearchPanelProps) {
   const [isFilterPillsExpanded, setIsFilterPillsExpanded] = useState(true);
 
@@ -143,7 +140,6 @@ export function MetricSearchPanel({
             onSwapMetric={onSwapMetric}
             onSetBreakout={onSetBreakout}
             onAddAdhoc={onAddAdhoc}
-            databaseId={databaseId}
           />
         </Box>
         {hasFilters && isFilterPillsExpanded && (

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearchPanel/MetricSearchPanel.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearchPanel/MetricSearchPanel.tsx
@@ -5,6 +5,7 @@ import { Box, Button, Flex, Icon, Stack, Text, Tooltip } from "metabase/ui";
 import type { MetricDefinition, ProjectionClause } from "metabase-lib/metric";
 import * as LibMetric from "metabase-lib/metric";
 
+import type { ExpressionToken } from "../../types/operators";
 import type {
   MetricSourceId,
   MetricsViewerDefinitionEntry,
@@ -33,6 +34,7 @@ type MetricSearchPanelProps = {
     id: MetricSourceId,
     definition: MetricDefinition,
   ) => void;
+  onExpressionChange?: (tokens: ExpressionToken[]) => void;
 };
 
 export function MetricSearchPanel({
@@ -44,6 +46,7 @@ export function MetricSearchPanel({
   onSwapMetric,
   onSetBreakout,
   onUpdateDefinition,
+  onExpressionChange,
 }: MetricSearchPanelProps) {
   const [isFilterPillsExpanded, setIsFilterPillsExpanded] = useState(true);
 
@@ -72,7 +75,7 @@ export function MetricSearchPanel({
 
   return (
     <Stack gap="sm">
-      <Flex align="center" justify="space-between">
+      <Flex align="center" justify="space-between" mih="1.875rem">
         <Text fw={700} size="lg">{t`Explore`}</Text>
         {hasDefinitions && (
           <FilterPopover
@@ -129,6 +132,7 @@ export function MetricSearchPanel({
             onRemoveMetric={onRemoveMetric}
             onSwapMetric={onSwapMetric}
             onSetBreakout={onSetBreakout}
+            onExpressionChange={onExpressionChange}
           />
         </Box>
         {hasFilters && isFilterPillsExpanded && (

--- a/frontend/src/metabase/metrics-viewer/components/MetricsViewerTabs/MetricsViewerTabContent/MetricsViewerTabContent.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricsViewerTabs/MetricsViewerTabContent/MetricsViewerTabContent.tsx
@@ -27,6 +27,13 @@ import { getTabConfig } from "../../../utils/tab-config";
 import { MetricControls } from "../../MetricControls";
 import { MetricsViewerVisualization } from "../../MetricsViewerVisualization";
 
+type ExpressionItemResult = {
+  name: string;
+  result: Dataset | null;
+  isExecuting: boolean;
+  error: string | null;
+};
+
 type MetricsViewerTabContentProps = {
   definitions: MetricsViewerDefinitionEntry[];
   tab: MetricsViewerTabState;
@@ -35,10 +42,16 @@ type MetricsViewerTabContentProps = {
   modifiedDefinitions: Map<MetricSourceId, MetricDefinition>;
   sourceColors: SourceColorMap;
   isExecuting: (id: MetricSourceId) => boolean;
-  arithmeticResult?: Dataset | null;
-  arithmeticIsExecuting?: boolean;
-  arithmeticError?: string | null;
-  expressionName?: string | null;
+  /**
+   * One entry per expression item (items with operators). Empty in pure
+   * individual-metric mode.
+   */
+  expressionItems?: ExpressionItemResult[];
+  /**
+   * Source IDs that are plain single-metric items. `null` = pure individual
+   * mode (all definitions are standalone).
+   */
+  standaloneSourceIds?: Set<MetricSourceId> | null;
   onTabUpdate: (updates: Partial<MetricsViewerTabState>) => void;
   onDimensionChange: (
     definitionId: MetricSourceId,
@@ -55,75 +68,78 @@ export function MetricsViewerTabContent({
   modifiedDefinitions,
   sourceColors,
   isExecuting,
-  arithmeticResult,
-  arithmeticIsExecuting,
-  arithmeticError,
-  expressionName,
+  expressionItems = [],
+  standaloneSourceIds = null,
   onTabUpdate,
   onDimensionChange,
   onDimensionRemove,
 }: MetricsViewerTabContentProps) {
-  const isArithmeticMode =
-    arithmeticResult != null ||
-    arithmeticIsExecuting === true ||
-    arithmeticError != null;
+  // Definitions that are plain single-metric items (or all, in pure individual mode).
+  const standaloneDefs = useMemo(
+    () =>
+      standaloneSourceIds === null
+        ? definitions
+        : definitions.filter((d) => standaloneSourceIds.has(d.id)),
+    [definitions, standaloneSourceIds],
+  );
 
   const isLoading = useMemo(() => {
-    if (isArithmeticMode) {
-      return arithmeticIsExecuting === true;
-    }
-    return getObjectKeys(tab.dimensionMapping).some(isExecuting);
-  }, [
-    isArithmeticMode,
-    arithmeticIsExecuting,
-    tab.dimensionMapping,
-    isExecuting,
-  ]);
+    const expressionLoading = expressionItems.some((item) => item.isExecuting);
+    const individualLoading = standaloneDefs.map((d) => d.id).some(isExecuting);
+    return expressionLoading || individualLoading;
+  }, [expressionItems, standaloneDefs, isExecuting]);
 
   const firstError = useMemo(() => {
-    if (isArithmeticMode) {
-      return arithmeticError ?? null;
+    const expressionError =
+      expressionItems.find((item) => item.error)?.error ?? null;
+    if (expressionError) {
+      return expressionError;
     }
-    for (const sourceId of getObjectKeys(tab.dimensionMapping)) {
-      const err = errorsByDefinitionId.get(sourceId);
+    for (const { id } of standaloneDefs) {
+      const err = errorsByDefinitionId.get(id);
       if (err) {
         return err;
       }
     }
     return null;
-  }, [
-    isArithmeticMode,
-    arithmeticError,
-    tab.dimensionMapping,
-    errorsByDefinitionId,
-  ]);
+  }, [expressionItems, standaloneDefs, errorsByDefinitionId]);
 
   const dimensionFilter = getTabConfig(tab.type).dimensionPredicate;
 
   const { series: rawSeries, cardIdToDimensionId } = useMemo(() => {
-    if (isArithmeticMode && arithmeticResult && expressionName) {
-      const series = buildArithmeticSeriesFromResult(
-        definitions,
+    // Build one arithmetic series per expression item that has a result.
+    const expressionSeries = expressionItems.flatMap((item) =>
+      item.result && item.name
+        ? buildArithmeticSeriesFromResult(
+            definitions,
+            tab.dimensionMapping,
+            tab.display,
+            item.result,
+            modifiedDefinitions,
+            item.name,
+          )
+        : [],
+    );
+
+    // Build individual series for standalone metric items (or all in pure
+    // individual mode when there are no expression items).
+    const { series: individualSeries, cardIdToDimensionId } =
+      buildRawSeriesFromDefinitions(
+        standaloneDefs,
         tab.dimensionMapping,
         tab.display,
-        arithmeticResult,
+        resultsByDefinitionId,
         modifiedDefinitions,
-        expressionName,
+        sourceColors,
       );
-      return { series, cardIdToDimensionId: {} };
-    }
-    return buildRawSeriesFromDefinitions(
-      definitions,
-      tab.dimensionMapping,
-      tab.display,
-      resultsByDefinitionId,
-      modifiedDefinitions,
-      sourceColors,
-    );
+
+    return {
+      series: [...expressionSeries, ...individualSeries],
+      cardIdToDimensionId,
+    };
   }, [
-    isArithmeticMode,
-    arithmeticResult,
-    expressionName,
+    expressionItems,
+    standaloneDefs,
     definitions,
     tab.dimensionMapping,
     tab.display,

--- a/frontend/src/metabase/metrics-viewer/components/MetricsViewerTabs/MetricsViewerTabContent/MetricsViewerTabContent.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricsViewerTabs/MetricsViewerTabContent/MetricsViewerTabContent.tsx
@@ -19,6 +19,7 @@ import type {
 import { getProjectionInfo } from "../../../utils/definition-builder";
 import type { DimensionFilterValue } from "../../../utils/dimension-filters";
 import {
+  buildArithmeticSeriesFromResult,
   buildDimensionItemsFromDefinitions,
   buildRawSeriesFromDefinitions,
 } from "../../../utils/series";
@@ -34,6 +35,10 @@ type MetricsViewerTabContentProps = {
   modifiedDefinitions: Map<MetricSourceId, MetricDefinition>;
   sourceColors: SourceColorMap;
   isExecuting: (id: MetricSourceId) => boolean;
+  arithmeticResult?: Dataset | null;
+  arithmeticIsExecuting?: boolean;
+  arithmeticError?: string | null;
+  expressionName?: string | null;
   onTabUpdate: (updates: Partial<MetricsViewerTabState>) => void;
   onDimensionChange: (
     definitionId: MetricSourceId,
@@ -50,15 +55,35 @@ export function MetricsViewerTabContent({
   modifiedDefinitions,
   sourceColors,
   isExecuting,
+  arithmeticResult,
+  arithmeticIsExecuting,
+  arithmeticError,
+  expressionName,
   onTabUpdate,
   onDimensionChange,
   onDimensionRemove,
 }: MetricsViewerTabContentProps) {
+  const isArithmeticMode =
+    arithmeticResult != null ||
+    arithmeticIsExecuting === true ||
+    arithmeticError != null;
+
   const isLoading = useMemo(() => {
+    if (isArithmeticMode) {
+      return arithmeticIsExecuting === true;
+    }
     return getObjectKeys(tab.dimensionMapping).some(isExecuting);
-  }, [tab.dimensionMapping, isExecuting]);
+  }, [
+    isArithmeticMode,
+    arithmeticIsExecuting,
+    tab.dimensionMapping,
+    isExecuting,
+  ]);
 
   const firstError = useMemo(() => {
+    if (isArithmeticMode) {
+      return arithmeticError ?? null;
+    }
     for (const sourceId of getObjectKeys(tab.dimensionMapping)) {
       const err = errorsByDefinitionId.get(sourceId);
       if (err) {
@@ -66,29 +91,46 @@ export function MetricsViewerTabContent({
       }
     }
     return null;
-  }, [tab.dimensionMapping, errorsByDefinitionId]);
+  }, [
+    isArithmeticMode,
+    arithmeticError,
+    tab.dimensionMapping,
+    errorsByDefinitionId,
+  ]);
 
   const dimensionFilter = getTabConfig(tab.type).dimensionPredicate;
 
-  const { series: rawSeries, cardIdToDimensionId } = useMemo(
-    () =>
-      buildRawSeriesFromDefinitions(
+  const { series: rawSeries, cardIdToDimensionId } = useMemo(() => {
+    if (isArithmeticMode && arithmeticResult && expressionName) {
+      const series = buildArithmeticSeriesFromResult(
         definitions,
         tab.dimensionMapping,
         tab.display,
-        resultsByDefinitionId,
+        arithmeticResult,
         modifiedDefinitions,
-        sourceColors,
-      ),
-    [
+        expressionName,
+      );
+      return { series, cardIdToDimensionId: {} };
+    }
+    return buildRawSeriesFromDefinitions(
       definitions,
       tab.dimensionMapping,
       tab.display,
       resultsByDefinitionId,
       modifiedDefinitions,
       sourceColors,
-    ],
-  );
+    );
+  }, [
+    isArithmeticMode,
+    arithmeticResult,
+    expressionName,
+    definitions,
+    tab.dimensionMapping,
+    tab.display,
+    resultsByDefinitionId,
+    modifiedDefinitions,
+    sourceColors,
+  ]);
 
   const dimensionItems = useMemo(
     () =>

--- a/frontend/src/metabase/metrics-viewer/components/MetricsViewerTabs/MetricsViewerTabs.module.css
+++ b/frontend/src/metabase/metrics-viewer/components/MetricsViewerTabs/MetricsViewerTabs.module.css
@@ -9,6 +9,10 @@
 }
 
 .closeButton {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 0.25rem;
+  cursor: pointer;
   visibility: hidden;
 }
 

--- a/frontend/src/metabase/metrics-viewer/components/MetricsViewerTabs/MetricsViewerTabs.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricsViewerTabs/MetricsViewerTabs.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from "react";
 import { t } from "ttag";
 
-import { ActionIcon, Icon, Skeleton, Tabs } from "metabase/ui";
+import { Icon, Skeleton, Tabs } from "metabase/ui";
 
 import type {
   MetricSourceId,
@@ -77,16 +77,20 @@ export function MetricsViewerTabs({
             ) : (
               tab.label
             )}
-            <ActionIcon
+            <span
+              role="button"
+              tabIndex={0}
               className={S.closeButton}
-              size="xs"
-              variant="subtle"
-              ml="xs"
               aria-label={t`Remove ${tab.label} tab`}
               onClick={(e) => handleRemoveTab(e, tab.id)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  handleRemoveTab(e as unknown as React.MouseEvent, tab.id);
+                }
+              }}
             >
               <Icon name="close" size={10} />
-            </ActionIcon>
+            </span>
           </Tabs.Tab>
         ))}
         {hasAvailableDimensions && (

--- a/frontend/src/metabase/metrics-viewer/components/SummarizeTable/SummarizeTableDialog.module.css
+++ b/frontend/src/metabase/metrics-viewer/components/SummarizeTable/SummarizeTableDialog.module.css
@@ -1,0 +1,133 @@
+.dialog {
+  width: 28rem;
+  max-height: 32rem;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: var(--mantine-spacing-sm);
+  padding: var(--mantine-spacing-md);
+  border-bottom: 1px solid var(--mb-color-border);
+}
+
+.headerTitle {
+  flex: 1;
+  font-weight: 700;
+  font-size: var(--mantine-font-size-lg);
+}
+
+.headerButton {
+  all: unset;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: var(--mantine-radius-sm);
+  color: var(--mb-color-text-secondary);
+}
+
+.headerButton:hover {
+  color: var(--mb-color-text-primary);
+  background-color: var(--mb-color-background-hover);
+}
+
+.searchWrapper {
+  padding: var(--mantine-spacing-sm) var(--mantine-spacing-md);
+}
+
+.tableList {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0 var(--mantine-spacing-sm);
+}
+
+.tableItem {
+  all: unset;
+  display: flex;
+  align-items: center;
+  gap: var(--mantine-spacing-xs);
+  width: 100%;
+  padding: var(--mantine-spacing-xs) var(--mantine-spacing-sm);
+  border-radius: var(--mantine-radius-sm);
+  cursor: pointer;
+  color: var(--mb-color-text-primary);
+  box-sizing: border-box;
+}
+
+.tableItem:hover {
+  background-color: var(--mb-color-background-hover);
+}
+
+.tableItem[data-active] {
+  color: var(--mb-color-brand);
+  background-color: var(--mb-color-background-selected);
+}
+
+.body {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--mantine-spacing-md);
+}
+
+.section {
+  margin-bottom: var(--mantine-spacing-lg);
+}
+
+.sectionTitle {
+  font-weight: 600;
+  font-size: var(--mantine-font-size-sm);
+  color: var(--mb-color-text-secondary);
+  margin-bottom: var(--mantine-spacing-sm);
+}
+
+.pickerRow {
+  display: flex;
+  align-items: center;
+  gap: var(--mantine-spacing-xs);
+  padding: var(--mantine-spacing-xs) var(--mantine-spacing-sm);
+  border: 1px solid var(--mb-color-border);
+  border-radius: var(--mantine-radius-md);
+  cursor: pointer;
+  min-height: 2.5rem;
+}
+
+.pickerRow:hover {
+  border-color: var(--mb-color-text-tertiary);
+}
+
+.pickerRow[data-disabled] {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.pickerRow[data-disabled]:hover {
+  border-color: var(--mb-color-border);
+}
+
+.pickerRowText {
+  flex: 1;
+}
+
+.connectedTop {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.connectedBottom {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  border-top: 0;
+}
+
+.footer {
+  display: flex;
+  justify-content: center;
+  padding: var(--mantine-spacing-md);
+  border-top: 1px solid var(--mb-color-border);
+}

--- a/frontend/src/metabase/metrics-viewer/components/SummarizeTable/SummarizeTableDialog.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/SummarizeTable/SummarizeTableDialog.tsx
@@ -1,0 +1,531 @@
+import { useCallback, useMemo, useState } from "react";
+import { t } from "ttag";
+
+import {
+  useGetTableQueryMetadataQuery,
+  useListTablesQuery,
+} from "metabase/api";
+import {
+  Box,
+  Button,
+  Flex,
+  Icon,
+  Modal,
+  Popover,
+  Text,
+  TextInput,
+} from "metabase/ui";
+import type { DatabaseId, Field, Table } from "metabase-types/api";
+
+import type { AdhocAggregationOperator } from "../../utils/adhoc-definition";
+import { buildAdhocDisplayName } from "../../utils/adhoc-definition";
+
+import S from "./SummarizeTableDialog.module.css";
+
+type AdhocResult = {
+  uuid: string;
+  databaseId: number;
+  tableId: number;
+  tableName: string;
+  aggregationOperator: AdhocAggregationOperator;
+  column?: Field;
+  displayName: string;
+};
+
+type SummarizeTableDialogProps = {
+  opened: boolean;
+  onClose: () => void;
+  onAdd: (result: AdhocResult) => void;
+  databaseId: DatabaseId | null;
+};
+
+const AGGREGATION_OPTIONS: {
+  operator: AdhocAggregationOperator;
+  label: string;
+  requiresColumn: boolean;
+}[] = [
+  { operator: "count", label: "Count of rows", requiresColumn: false },
+  { operator: "sum", label: "Sum", requiresColumn: true },
+  { operator: "avg", label: "Average", requiresColumn: true },
+  { operator: "min", label: "Min", requiresColumn: true },
+  { operator: "max", label: "Max", requiresColumn: true },
+  { operator: "distinct", label: "Distinct values", requiresColumn: true },
+];
+
+function isNumericField(field: Field): boolean {
+  const effectiveType = field.effective_type ?? field.base_type;
+  return (
+    effectiveType.startsWith("type/Integer") ||
+    effectiveType.startsWith("type/Float") ||
+    effectiveType.startsWith("type/Decimal") ||
+    effectiveType.startsWith("type/Number") ||
+    effectiveType === "type/BigInteger"
+  );
+}
+
+function isAggregatable(
+  field: Field,
+  operator: AdhocAggregationOperator,
+): boolean {
+  if (
+    !field.active ||
+    field.visibility_type !== "normal" ||
+    typeof field.id !== "number"
+  ) {
+    return false;
+  }
+  if (operator === "sum" || operator === "avg") {
+    return isNumericField(field);
+  }
+  return true;
+}
+
+function isBreakoutEligible(field: Field): boolean {
+  return (
+    field.active &&
+    field.visibility_type === "normal" &&
+    typeof field.id === "number"
+  );
+}
+
+function isTemporalField(field: Field): boolean {
+  const effectiveType = field.effective_type ?? field.base_type;
+  return (
+    effectiveType.startsWith("type/Date") ||
+    effectiveType.startsWith("type/DateTime") ||
+    effectiveType.startsWith("type/Temporal")
+  );
+}
+
+// ── Table Picker Step ──
+
+function TablePickerStep({
+  databaseId,
+  onSelectTable,
+  onClose,
+}: {
+  databaseId: DatabaseId | null;
+  onSelectTable: (table: Table) => void;
+  onClose: () => void;
+}) {
+  const [searchText, setSearchText] = useState("");
+  const { data: allTables, isLoading } = useListTablesQuery();
+
+  const tables = useMemo(() => {
+    if (!allTables) {
+      return [];
+    }
+    return allTables.filter((table) => {
+      if (databaseId != null && table.db_id !== databaseId) {
+        return false;
+      }
+      if (table.visibility_type !== null) {
+        return false;
+      }
+      if (searchText) {
+        return table.display_name
+          .toLowerCase()
+          .includes(searchText.toLowerCase());
+      }
+      return true;
+    });
+  }, [allTables, databaseId, searchText]);
+
+  return (
+    <Box className={S.dialog}>
+      <Box className={S.header}>
+        <Text className={S.headerTitle}>{t`Summarize a table`}</Text>
+        <button
+          type="button"
+          className={S.headerButton}
+          onClick={onClose}
+          aria-label={t`Close`}
+        >
+          <Icon name="close" size={16} />
+        </button>
+      </Box>
+      <Box className={S.searchWrapper}>
+        <TextInput
+          placeholder={t`Search tables`}
+          leftSection={<Icon name="search" size={14} />}
+          value={searchText}
+          onChange={(e) => setSearchText(e.target.value)}
+          autoFocus
+        />
+      </Box>
+      <Box className={S.tableList}>
+        {isLoading && (
+          <Text c="text-secondary" p="md" ta="center">
+            {t`Loading...`}
+          </Text>
+        )}
+        {!isLoading && tables.length === 0 && (
+          <Text c="text-secondary" p="md" ta="center">
+            {t`No tables found`}
+          </Text>
+        )}
+        {tables.map((table) => (
+          <button
+            key={table.id}
+            type="button"
+            className={S.tableItem}
+            onClick={() => onSelectTable(table)}
+          >
+            <Icon name="table" size={16} c="text-tertiary" />
+            <Text lineClamp={1}>{table.display_name}</Text>
+          </button>
+        ))}
+      </Box>
+    </Box>
+  );
+}
+
+// ── Configuration Step ──
+
+function ConfigurationStep({
+  table,
+  onBack,
+  onClose,
+  onAdd,
+}: {
+  table: Table;
+  onBack: () => void;
+  onClose: () => void;
+  onAdd: (result: AdhocResult) => void;
+}) {
+  const [selectedOperator, setSelectedOperator] =
+    useState<AdhocAggregationOperator | null>(null);
+  const [selectedColumn, setSelectedColumn] = useState<Field | null>(null);
+  const [selectedGroupBy, setSelectedGroupBy] = useState<Field | null>(null);
+  const [aggPickerOpen, setAggPickerOpen] = useState(false);
+  const [colPickerOpen, setColPickerOpen] = useState(false);
+  const [groupByPickerOpen, setGroupByPickerOpen] = useState(false);
+
+  const { data: tableWithFields } = useGetTableQueryMetadataQuery({
+    id: table.id as number,
+  });
+
+  const fields = useMemo(
+    () => tableWithFields?.fields ?? table.fields ?? [],
+    [tableWithFields?.fields, table.fields],
+  );
+
+  const currentAggOption = selectedOperator
+    ? AGGREGATION_OPTIONS.find((o) => o.operator === selectedOperator)
+    : null;
+
+  const aggregatableFields = useMemo(
+    () =>
+      selectedOperator
+        ? fields.filter((f) => isAggregatable(f, selectedOperator))
+        : [],
+    [fields, selectedOperator],
+  );
+
+  const breakoutFields = useMemo(
+    () => fields.filter(isBreakoutEligible),
+    [fields],
+  );
+
+  // Auto-select first temporal field as group-by when fields load
+  useMemo(() => {
+    if (breakoutFields.length > 0 && selectedGroupBy === null) {
+      const temporalField = breakoutFields.find(isTemporalField);
+      if (temporalField) {
+        setSelectedGroupBy(temporalField);
+      }
+    }
+  }, [breakoutFields, selectedGroupBy]);
+
+  const canAdd =
+    selectedOperator != null &&
+    (!currentAggOption?.requiresColumn || selectedColumn != null);
+
+  const handleAdd = useCallback(() => {
+    if (!selectedOperator || !canAdd) {
+      return;
+    }
+
+    const displayName = buildAdhocDisplayName(
+      selectedOperator,
+      table.display_name,
+      selectedColumn?.display_name,
+    );
+
+    onAdd({
+      uuid: crypto.randomUUID(),
+      databaseId: table.db_id,
+      tableId: table.id as number,
+      tableName: table.display_name,
+      aggregationOperator: selectedOperator,
+      column: selectedColumn ?? undefined,
+      displayName,
+    });
+  }, [selectedOperator, selectedColumn, canAdd, table, onAdd]);
+
+  return (
+    <Box className={S.dialog}>
+      <Box className={S.header}>
+        <button
+          type="button"
+          className={S.headerButton}
+          onClick={onBack}
+          aria-label={t`Back`}
+        >
+          <Icon name="chevronleft" size={16} />
+        </button>
+        <Text className={S.headerTitle}>{table.display_name}</Text>
+        <button
+          type="button"
+          className={S.headerButton}
+          onClick={onClose}
+          aria-label={t`Close`}
+        >
+          <Icon name="close" size={16} />
+        </button>
+      </Box>
+
+      <Box className={S.body}>
+        {/* Summarize section */}
+        <Box className={S.section}>
+          <Text className={S.sectionTitle}>{t`Summarize`}</Text>
+
+          {/* Aggregation picker */}
+          <Popover
+            opened={aggPickerOpen}
+            onChange={setAggPickerOpen}
+            position="bottom-start"
+            shadow="md"
+            withinPortal
+          >
+            <Popover.Target>
+              <Flex
+                className={`${S.pickerRow} ${currentAggOption?.requiresColumn ? S.connectedTop : ""}`}
+                onClick={() => setAggPickerOpen((o) => !o)}
+              >
+                <Icon name="formula" size={16} c="text-tertiary" />
+                <Text
+                  className={S.pickerRowText}
+                  c={selectedOperator ? "text-primary" : "text-secondary"}
+                >
+                  {currentAggOption?.label ?? t`Pick how to summarize`}
+                </Text>
+                <Icon name="chevrondown" size={14} c="text-tertiary" />
+              </Flex>
+            </Popover.Target>
+            <Popover.Dropdown p="xs">
+              {AGGREGATION_OPTIONS.map((opt) => (
+                <Box
+                  key={opt.operator}
+                  component="button"
+                  className={S.tableItem}
+                  data-active={opt.operator === selectedOperator || undefined}
+                  onClick={() => {
+                    setSelectedOperator(opt.operator);
+                    setSelectedColumn(null);
+                    setAggPickerOpen(false);
+                  }}
+                >
+                  <Text>{opt.label}</Text>
+                </Box>
+              ))}
+            </Popover.Dropdown>
+          </Popover>
+
+          {/* Column picker (connected below aggregation) */}
+          <Popover
+            opened={colPickerOpen}
+            onChange={setColPickerOpen}
+            position="bottom-start"
+            shadow="md"
+            withinPortal
+          >
+            <Popover.Target>
+              <Flex
+                className={`${S.pickerRow} ${currentAggOption?.requiresColumn ? S.connectedBottom : ""}`}
+                data-disabled={!currentAggOption?.requiresColumn || undefined}
+                onClick={() => {
+                  if (currentAggOption?.requiresColumn) {
+                    setColPickerOpen((o) => !o);
+                  }
+                }}
+              >
+                <Icon name="table2" size={16} c="text-tertiary" />
+                <Text
+                  className={S.pickerRowText}
+                  c={
+                    !currentAggOption?.requiresColumn
+                      ? "text-tertiary"
+                      : selectedColumn
+                        ? "text-primary"
+                        : "text-secondary"
+                  }
+                >
+                  {!currentAggOption?.requiresColumn
+                    ? t`in this table`
+                    : selectedColumn
+                      ? selectedColumn.display_name
+                      : t`Pick a column`}
+                </Text>
+                {currentAggOption?.requiresColumn && (
+                  <Icon name="chevrondown" size={14} c="text-tertiary" />
+                )}
+              </Flex>
+            </Popover.Target>
+            <Popover.Dropdown p="xs" mah="15rem" style={{ overflowY: "auto" }}>
+              {aggregatableFields.map((field) => (
+                <Box
+                  key={field.id as number}
+                  component="button"
+                  className={S.tableItem}
+                  data-active={field.id === selectedColumn?.id || undefined}
+                  onClick={() => {
+                    setSelectedColumn(field);
+                    setColPickerOpen(false);
+                  }}
+                >
+                  <Text>{field.display_name}</Text>
+                </Box>
+              ))}
+            </Popover.Dropdown>
+          </Popover>
+        </Box>
+
+        {/* Group by section */}
+        <Box className={S.section}>
+          <Text className={S.sectionTitle}>{t`Group by`}</Text>
+          <Popover
+            opened={groupByPickerOpen}
+            onChange={setGroupByPickerOpen}
+            position="bottom-start"
+            shadow="md"
+            withinPortal
+          >
+            <Popover.Target>
+              <Flex
+                className={S.pickerRow}
+                onClick={() => setGroupByPickerOpen((o) => !o)}
+              >
+                <Icon
+                  name={
+                    selectedGroupBy && isTemporalField(selectedGroupBy)
+                      ? "calendar"
+                      : "table2"
+                  }
+                  size={16}
+                  c="text-tertiary"
+                />
+                <Text
+                  className={S.pickerRowText}
+                  c={selectedGroupBy ? "text-primary" : "text-secondary"}
+                >
+                  {selectedGroupBy?.display_name ?? t`Pick a column`}
+                </Text>
+                <Icon name="chevrondown" size={14} c="text-tertiary" />
+              </Flex>
+            </Popover.Target>
+            <Popover.Dropdown p="xs" mah="15rem" style={{ overflowY: "auto" }}>
+              {breakoutFields.map((field) => (
+                <Box
+                  key={field.id as number}
+                  component="button"
+                  className={S.tableItem}
+                  data-active={field.id === selectedGroupBy?.id || undefined}
+                  onClick={() => {
+                    setSelectedGroupBy(field);
+                    setGroupByPickerOpen(false);
+                  }}
+                >
+                  <Icon
+                    name={isTemporalField(field) ? "calendar" : "table2"}
+                    size={14}
+                    c="text-tertiary"
+                  />
+                  <Text>{field.display_name}</Text>
+                </Box>
+              ))}
+            </Popover.Dropdown>
+          </Popover>
+        </Box>
+      </Box>
+
+      <Box className={S.footer}>
+        <Button
+          variant="filled"
+          disabled={!canAdd}
+          onClick={handleAdd}
+          leftSection={<Icon name="add" size={14} />}
+        >
+          {t`Add to chart`}
+        </Button>
+      </Box>
+    </Box>
+  );
+}
+
+// ── Main Dialog ──
+
+export function SummarizeTableDialog({
+  opened,
+  onClose,
+  onAdd,
+  databaseId,
+}: SummarizeTableDialogProps) {
+  const [step, setStep] = useState<"table-picker" | "configuration">(
+    "table-picker",
+  );
+  const [selectedTable, setSelectedTable] = useState<Table | null>(null);
+
+  const handleClose = useCallback(() => {
+    setStep("table-picker");
+    setSelectedTable(null);
+    onClose();
+  }, [onClose]);
+
+  const handleSelectTable = useCallback((table: Table) => {
+    setSelectedTable(table);
+    setStep("configuration");
+  }, []);
+
+  const handleBack = useCallback(() => {
+    setStep("table-picker");
+    setSelectedTable(null);
+  }, []);
+
+  const handleAdd = useCallback(
+    (result: AdhocResult) => {
+      onAdd(result);
+      handleClose();
+    },
+    [onAdd, handleClose],
+  );
+
+  return (
+    <Modal
+      opened={opened}
+      onClose={handleClose}
+      withCloseButton={false}
+      padding={0}
+      size="auto"
+      centered
+    >
+      {step === "table-picker" && (
+        <TablePickerStep
+          databaseId={databaseId}
+          onSelectTable={handleSelectTable}
+          onClose={handleClose}
+        />
+      )}
+      {step === "configuration" && selectedTable && (
+        <ConfigurationStep
+          table={selectedTable}
+          onBack={handleBack}
+          onClose={handleClose}
+          onAdd={handleAdd}
+        />
+      )}
+    </Modal>
+  );
+}
+
+export type { AdhocResult };

--- a/frontend/src/metabase/metrics-viewer/components/SummarizeTable/SummarizeTableDialog.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/SummarizeTable/SummarizeTableDialog.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { t } from "ttag";
 
 import {
   useGetTableQueryMetadataQuery,
+  useListDatabasesQuery,
   useListTablesQuery,
 } from "metabase/api";
 import {
@@ -12,10 +13,11 @@ import {
   Icon,
   Modal,
   Popover,
+  Select,
   Text,
   TextInput,
 } from "metabase/ui";
-import type { DatabaseId, Field, Table } from "metabase-types/api";
+import type { Field, Table } from "metabase-types/api";
 
 import type { AdhocAggregationOperator } from "../../utils/adhoc-definition";
 import { buildAdhocDisplayName } from "../../utils/adhoc-definition";
@@ -36,7 +38,6 @@ type SummarizeTableDialogProps = {
   opened: boolean;
   onClose: () => void;
   onAdd: (result: AdhocResult) => void;
-  databaseId: DatabaseId | null;
 };
 
 const AGGREGATION_OPTIONS: {
@@ -100,23 +101,40 @@ function isTemporalField(field: Field): boolean {
 // ── Table Picker Step ──
 
 function TablePickerStep({
-  databaseId,
   onSelectTable,
   onClose,
 }: {
-  databaseId: DatabaseId | null;
   onSelectTable: (table: Table) => void;
   onClose: () => void;
 }) {
   const [searchText, setSearchText] = useState("");
-  const { data: allTables, isLoading } = useListTablesQuery();
+  const [selectedDbId, setSelectedDbId] = useState<string | null>(null);
+
+  const { data: dbResponse } = useListDatabasesQuery();
+  const { data: allTables, isLoading: isLoadingTables } = useListTablesQuery();
+
+  const dbData = dbResponse?.data;
+  const databases = useMemo(() => dbData ?? [], [dbData]);
+
+  // Auto-select first database when loaded
+  useEffect(() => {
+    if (selectedDbId === null && databases.length > 0) {
+      setSelectedDbId(String(databases[0].id));
+    }
+  }, [databases, selectedDbId]);
+
+  const databaseOptions = useMemo(
+    () => databases.map((db) => ({ value: String(db.id), label: db.name })),
+    [databases],
+  );
 
   const tables = useMemo(() => {
     if (!allTables) {
       return [];
     }
+    const dbId = selectedDbId != null ? Number(selectedDbId) : null;
     return allTables.filter((table) => {
-      if (databaseId != null && table.db_id !== databaseId) {
+      if (dbId != null && table.db_id !== dbId) {
         return false;
       }
       if (table.visibility_type !== null) {
@@ -129,7 +147,9 @@ function TablePickerStep({
       }
       return true;
     });
-  }, [allTables, databaseId, searchText]);
+  }, [allTables, selectedDbId, searchText]);
+
+  const isLoading = isLoadingTables || databases.length === 0;
 
   return (
     <Box className={S.dialog}>
@@ -145,6 +165,12 @@ function TablePickerStep({
         </button>
       </Box>
       <Box className={S.searchWrapper}>
+        <Select
+          data={databaseOptions}
+          value={selectedDbId}
+          onChange={setSelectedDbId}
+          mb="xs"
+        />
         <TextInput
           placeholder={t`Search tables`}
           leftSection={<Icon name="search" size={14} />}
@@ -228,7 +254,7 @@ function ConfigurationStep({
   );
 
   // Auto-select first temporal field as group-by when fields load
-  useMemo(() => {
+  useEffect(() => {
     if (breakoutFields.length > 0 && selectedGroupBy === null) {
       const temporalField = breakoutFields.find(isTemporalField);
       if (temporalField) {
@@ -469,7 +495,6 @@ export function SummarizeTableDialog({
   opened,
   onClose,
   onAdd,
-  databaseId,
 }: SummarizeTableDialogProps) {
   const [step, setStep] = useState<"table-picker" | "configuration">(
     "table-picker",
@@ -511,7 +536,6 @@ export function SummarizeTableDialog({
     >
       {step === "table-picker" && (
         <TablePickerStep
-          databaseId={databaseId}
           onSelectTable={handleSelectTable}
           onClose={handleClose}
         />

--- a/frontend/src/metabase/metrics-viewer/components/SummarizeTable/index.ts
+++ b/frontend/src/metabase/metrics-viewer/components/SummarizeTable/index.ts
@@ -1,0 +1,2 @@
+export { SummarizeTableDialog } from "./SummarizeTableDialog";
+export type { AdhocResult } from "./SummarizeTableDialog";

--- a/frontend/src/metabase/metrics-viewer/hooks/use-definition-queries.ts
+++ b/frontend/src/metabase/metrics-viewer/hooks/use-definition-queries.ts
@@ -194,7 +194,13 @@ function buildArithmeticRequest(
         measureId,
       ]);
     } else {
-      return null;
+      // Adhoc leaf: the expression from toJsDefinition is the full
+      // ["adhoc", {"lib/uuid": ...}, definition] ref
+      const jsdef = toJsDefinition(req.modifiedDefinition);
+      if (!jsdef.expression) {
+        return null;
+      }
+      leafRefs.set(token.metricIndex, jsdef.expression);
     }
 
     const jsdef = toJsDefinition(req.modifiedDefinition);

--- a/frontend/src/metabase/metrics-viewer/hooks/use-definition-queries.ts
+++ b/frontend/src/metabase/metrics-viewer/hooks/use-definition-queries.ts
@@ -4,9 +4,16 @@ import { metricApi } from "metabase/api";
 import { getErrorMessage } from "metabase/api/utils/errors";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import type { MetricDefinition } from "metabase-lib/metric";
-import type { Dataset, MetricBreakoutValuesResponse } from "metabase-types/api";
+import * as LibMetric from "metabase-lib/metric";
+import type {
+  Dataset,
+  JsMetricDefinition,
+  MetricBreakoutValuesResponse,
+  TypedProjection,
+} from "metabase-types/api";
 import type { State } from "metabase-types/store";
 
+import type { ExpressionToken, MathOperator } from "../types/operators";
 import type {
   MetricSourceId,
   MetricsViewerDefinitionEntry,
@@ -24,11 +31,150 @@ export interface UseDefinitionQueriesResult {
   modifiedDefinitions: Map<MetricSourceId, MetricDefinition>;
   breakoutValuesBySourceId: Map<MetricSourceId, MetricBreakoutValuesResponse>;
   isExecuting: (id: MetricSourceId) => boolean;
+  arithmeticResult: Dataset | null;
+  arithmeticIsExecuting: boolean;
+  arithmeticError: string | null;
+}
+
+// --- Expression parsing ---
+
+type ParseCtx = {
+  tokens: ExpressionToken[];
+  pos: number;
+  leafRefs: Map<number, unknown>;
+};
+
+function parseTerm(ctx: ParseCtx): unknown | null {
+  if (ctx.pos >= ctx.tokens.length) {
+    return null;
+  }
+  const token = ctx.tokens[ctx.pos];
+
+  if (token.type === "metric") {
+    ctx.pos++;
+    return ctx.leafRefs.get(token.metricIndex) ?? null;
+  }
+
+  if (token.type === "open-paren") {
+    ctx.pos++;
+    const expr = parseExpression(ctx);
+    if (
+      ctx.pos < ctx.tokens.length &&
+      ctx.tokens[ctx.pos].type === "close-paren"
+    ) {
+      ctx.pos++;
+    }
+    return expr;
+  }
+
+  return null;
+}
+
+function parseExpression(ctx: ParseCtx): unknown | null {
+  let left = parseTerm(ctx);
+  if (!left) {
+    return null;
+  }
+
+  while (
+    ctx.pos < ctx.tokens.length &&
+    ctx.tokens[ctx.pos].type === "operator"
+  ) {
+    const op = (ctx.tokens[ctx.pos] as { type: "operator"; op: MathOperator })
+      .op;
+    ctx.pos++;
+    const right = parseTerm(ctx);
+    if (!right) {
+      return null;
+    }
+    left = [op, {}, left, right];
+  }
+
+  return left;
+}
+
+// ---
+
+function buildArithmeticRequest(
+  datasetRequests: Array<{
+    sourceId: MetricSourceId;
+    modifiedDefinition: MetricDefinition;
+  }>,
+  definitions: MetricsViewerDefinitionEntry[],
+  tokens: ExpressionToken[],
+): { definition: JsMetricDefinition } | null {
+  // Map metricIndex → datasetRequest (metricIndex = position in definitions)
+  const indexToRequest = new Map<number, (typeof datasetRequests)[0]>();
+  let idx = 0;
+  for (const entry of definitions) {
+    const req = datasetRequests.find((r) => r.sourceId === entry.id);
+    if (req) {
+      indexToRequest.set(idx, req);
+    }
+    idx++;
+  }
+
+  // Build leaf refs and projections for each unique metric index in the expression
+  const leafRefs = new Map<number, unknown>();
+  const projections: TypedProjection[] = [];
+
+  for (const token of tokens) {
+    if (token.type !== "metric") {
+      continue;
+    }
+    if (leafRefs.has(token.metricIndex)) {
+      continue;
+    }
+    const req = indexToRequest.get(token.metricIndex);
+    if (!req) {
+      return null; // metric not in a tab yet
+    }
+
+    const uuid = `leaf-${token.metricIndex}`;
+    const metricId = LibMetric.sourceMetricId(req.modifiedDefinition);
+    const measureId = LibMetric.sourceMeasureId(req.modifiedDefinition);
+
+    if (metricId != null) {
+      leafRefs.set(token.metricIndex, [
+        "metric",
+        { "lib/uuid": uuid },
+        metricId,
+      ]);
+    } else if (measureId != null) {
+      leafRefs.set(token.metricIndex, [
+        "measure",
+        { "lib/uuid": uuid },
+        measureId,
+      ]);
+    } else {
+      return null;
+    }
+
+    const jsdef = toJsDefinition(req.modifiedDefinition);
+    if (jsdef.projections) {
+      projections.push(...jsdef.projections);
+    }
+  }
+
+  // Parse token stream into nested expression tree
+  const ctx: ParseCtx = { tokens, pos: 0, leafRefs };
+  const expr = parseExpression(ctx);
+  if (!expr) {
+    return null;
+  }
+
+  return {
+    definition: {
+      expression: expr as JsMetricDefinition["expression"],
+      projections,
+    },
+  };
 }
 
 export function useDefinitionQueries(
   definitions: MetricsViewerDefinitionEntry[],
   tab: MetricsViewerTabState | null,
+  tokens: ExpressionToken[] = [],
 ): UseDefinitionQueriesResult {
   const dispatch = useDispatch();
 
@@ -90,8 +236,30 @@ export function useDefinitionQueries(
     return map;
   }, [datasetRequests]);
 
+  // Arithmetic mode: valid expression with ≥2 metrics, balanced parens
+  const arithmeticRequest = useMemo(() => {
+    const metricCount = tokens.filter((t) => t.type === "metric").length;
+    const opCount = tokens.filter((t) => t.type === "operator").length;
+    const openParens = tokens.filter((t) => t.type === "open-paren").length;
+    const closeParens = tokens.filter((t) => t.type === "close-paren").length;
+
+    if (
+      metricCount < 2 ||
+      opCount !== metricCount - 1 ||
+      openParens !== closeParens ||
+      datasetRequests.length < 2
+    ) {
+      return null;
+    }
+
+    return buildArithmeticRequest(datasetRequests, definitions, tokens);
+  }, [datasetRequests, definitions, tokens]);
+
+  const isArithmeticMode = arithmeticRequest !== null;
+
+  // Individual dataset queries — skipped in arithmetic mode
   useEffect(() => {
-    if (datasetRequests.length === 0) {
+    if (datasetRequests.length === 0 || isArithmeticMode) {
       return;
     }
 
@@ -102,7 +270,20 @@ export function useDefinitionQueries(
     return () => {
       subscriptions.forEach((subscription) => subscription.unsubscribe());
     };
-  }, [datasetRequests, dispatch]);
+  }, [datasetRequests, dispatch, isArithmeticMode]);
+
+  // Arithmetic combined query
+  useEffect(() => {
+    if (!arithmeticRequest) {
+      return;
+    }
+
+    const subscription = dispatch(
+      metricApi.endpoints.getMetricDataset.initiate(arithmeticRequest),
+    );
+
+    return () => subscription.unsubscribe();
+  }, [arithmeticRequest, dispatch]);
 
   useEffect(() => {
     if (breakoutRequests.length === 0) {
@@ -127,6 +308,15 @@ export function useDefinitionQueries(
     })),
   );
 
+  const arithmeticQueryResult = useSelector((state: State) => {
+    if (!arithmeticRequest) {
+      return null;
+    }
+    return metricApi.endpoints.getMetricDataset.select(arithmeticRequest)(
+      state,
+    );
+  });
+
   const breakoutResults = useSelector((state: State) =>
     breakoutRequests.map((query) => ({
       sourceId: query.sourceId,
@@ -138,6 +328,14 @@ export function useDefinitionQueries(
 
   const { resultsByDefinitionId, errorsByDefinitionId, isExecuting } =
     useMemo(() => {
+      if (isArithmeticMode) {
+        return {
+          resultsByDefinitionId: new Map<MetricSourceId, Dataset>(),
+          errorsByDefinitionId: new Map<MetricSourceId, string>(),
+          isExecuting: (_id: MetricSourceId) => false,
+        };
+      }
+
       const results = new Map<MetricSourceId, Dataset>();
       const errors = new Map<MetricSourceId, string>();
       const executing = new Set<MetricSourceId>();
@@ -159,7 +357,7 @@ export function useDefinitionQueries(
         errorsByDefinitionId: errors,
         isExecuting: (id: MetricSourceId) => executing.has(id),
       };
-    }, [datasetResults]);
+    }, [isArithmeticMode, datasetResults]);
 
   const breakoutValuesBySourceId = useMemo(() => {
     const map = new Map<MetricSourceId, MetricBreakoutValuesResponse>();
@@ -177,5 +375,10 @@ export function useDefinitionQueries(
     modifiedDefinitions,
     breakoutValuesBySourceId,
     isExecuting,
+    arithmeticResult: arithmeticQueryResult?.data ?? null,
+    arithmeticIsExecuting: arithmeticQueryResult?.isLoading ?? false,
+    arithmeticError: arithmeticQueryResult?.error
+      ? getErrorMessage(arithmeticQueryResult.error)
+      : null,
   };
 }

--- a/frontend/src/metabase/metrics-viewer/hooks/use-definition-queries.ts
+++ b/frontend/src/metabase/metrics-viewer/hooks/use-definition-queries.ts
@@ -55,6 +55,11 @@ function parseTerm(ctx: ParseCtx): unknown | null {
     return ctx.leafRefs.get(token.metricIndex) ?? null;
   }
 
+  if (token.type === "constant") {
+    ctx.pos++;
+    return token.value;
+  }
+
   if (token.type === "open-paren") {
     ctx.pos++;
     const expr = parseExpression(ctx);
@@ -236,18 +241,20 @@ export function useDefinitionQueries(
     return map;
   }, [datasetRequests]);
 
-  // Arithmetic mode: valid expression with ≥2 metrics, balanced parens
+  // Arithmetic mode: valid expression with ≥1 metric, ≥1 operator, balanced parens
   const arithmeticRequest = useMemo(() => {
     const metricCount = tokens.filter((t) => t.type === "metric").length;
+    const constantCount = tokens.filter((t) => t.type === "constant").length;
+    const operandCount = metricCount + constantCount;
     const opCount = tokens.filter((t) => t.type === "operator").length;
     const openParens = tokens.filter((t) => t.type === "open-paren").length;
     const closeParens = tokens.filter((t) => t.type === "close-paren").length;
 
     if (
-      metricCount < 2 ||
-      opCount !== metricCount - 1 ||
-      openParens !== closeParens ||
-      datasetRequests.length < 2
+      metricCount < 1 ||
+      opCount < 1 ||
+      opCount !== operandCount - 1 ||
+      openParens !== closeParens
     ) {
       return null;
     }

--- a/frontend/src/metabase/metrics-viewer/hooks/use-definition-queries.ts
+++ b/frontend/src/metabase/metrics-viewer/hooks/use-definition-queries.ts
@@ -13,6 +13,7 @@ import type {
 } from "metabase-types/api";
 import type { State } from "metabase-types/store";
 
+import { splitByItems } from "../components/MetricSearch/utils";
 import type { ExpressionToken, MathOperator } from "../types/operators";
 import type {
   MetricSourceId,
@@ -25,15 +26,37 @@ import {
 } from "../utils/definition-cache";
 import { entryHasBreakout } from "../utils/definition-entries";
 
+/**
+ * One entry per expression item in the token list (items separated by
+ * separator tokens that contain at least one operator — i.e. not a plain
+ * single-metric item).
+ */
+export type ExpressionItemResult = {
+  /** The tokens that form this expression item (no separator tokens). */
+  itemTokens: ExpressionToken[];
+  result: Dataset | null;
+  isExecuting: boolean;
+  error: string | null;
+};
+
 export interface UseDefinitionQueriesResult {
   resultsByDefinitionId: Map<MetricSourceId, Dataset>;
   errorsByDefinitionId: Map<MetricSourceId, string>;
   modifiedDefinitions: Map<MetricSourceId, MetricDefinition>;
   breakoutValuesBySourceId: Map<MetricSourceId, MetricBreakoutValuesResponse>;
   isExecuting: (id: MetricSourceId) => boolean;
-  arithmeticResult: Dataset | null;
-  arithmeticIsExecuting: boolean;
-  arithmeticError: string | null;
+  /**
+   * Per-expression-item results. Empty when there are no expression items
+   * (pure individual-metric mode). When non-empty the tab should render one
+   * chart series per entry alongside any standalone individual-metric series.
+   */
+  expressionItems: ExpressionItemResult[];
+  /**
+   * Source IDs of definitions that are plain single-metric items in the token
+   * list. `null` means "pure individual mode" — all loaded definitions are
+   * standalone and individual queries fire for all of them.
+   */
+  standaloneSourceIds: Set<MetricSourceId> | null;
 }
 
 // --- Expression parsing ---
@@ -99,6 +122,25 @@ function parseExpression(ctx: ParseCtx): unknown | null {
 }
 
 // ---
+
+/**
+ * Returns true when a single separator-delimited item's tokens form a valid
+ * arithmetic expression: at least one metric, at least one operator, and
+ * balanced parentheses.
+ */
+function isExpressionItem(itemTokens: ExpressionToken[]): boolean {
+  const metricCount = itemTokens.filter((t) => t.type === "metric").length;
+  const constantCount = itemTokens.filter((t) => t.type === "constant").length;
+  const opCount = itemTokens.filter((t) => t.type === "operator").length;
+  const openParens = itemTokens.filter((t) => t.type === "open-paren").length;
+  const closeParens = itemTokens.filter((t) => t.type === "close-paren").length;
+  return (
+    metricCount >= 1 &&
+    opCount >= 1 &&
+    opCount === metricCount + constantCount - 1 &&
+    openParens === closeParens
+  );
+}
 
 function buildArithmeticRequest(
   datasetRequests: Array<{
@@ -241,56 +283,108 @@ export function useDefinitionQueries(
     return map;
   }, [datasetRequests]);
 
-  // Arithmetic mode: valid expression with ≥1 metric, ≥1 operator, balanced parens
-  const arithmeticRequest = useMemo(() => {
-    const metricCount = tokens.filter((t) => t.type === "metric").length;
-    const constantCount = tokens.filter((t) => t.type === "constant").length;
-    const operandCount = metricCount + constantCount;
-    const opCount = tokens.filter((t) => t.type === "operator").length;
-    const openParens = tokens.filter((t) => t.type === "open-paren").length;
-    const closeParens = tokens.filter((t) => t.type === "close-paren").length;
+  /**
+   * Arithmetic requests, one per expression item.  Each entry carries the
+   * original itemTokens (used downstream to build the series name) plus the
+   * RTK-Query request payload (null when the expression cannot yet be built,
+   * e.g. a required definition is not loaded yet).
+   */
+  const expressionItemsConfig = useMemo(() => {
+    const items = splitByItems(tokens);
+    return items
+      .filter(
+        (itemTokens) => itemTokens.length > 0 && isExpressionItem(itemTokens),
+      )
+      .map((itemTokens) => ({
+        itemTokens,
+        request: buildArithmeticRequest(
+          datasetRequests,
+          definitions,
+          itemTokens,
+        ),
+      }));
+  }, [datasetRequests, definitions, tokens]);
 
-    if (
-      metricCount < 1 ||
-      opCount < 1 ||
-      opCount !== operandCount - 1 ||
-      openParens !== closeParens
-    ) {
+  /**
+   * Source IDs of definitions that are referenced by plain single-metric
+   * items (not part of any expression item).  `null` means pure-individual
+   * mode: no expression items exist, so all loaded definitions are standalone.
+   */
+  const standaloneSourceIds = useMemo((): Set<MetricSourceId> | null => {
+    const items = splitByItems(tokens);
+    const hasExpressionItem = items.some(
+      (itemTokens) => itemTokens.length > 0 && isExpressionItem(itemTokens),
+    );
+
+    if (!hasExpressionItem) {
+      // Pure individual mode — caller uses all definitions.
       return null;
     }
 
-    return buildArithmeticRequest(datasetRequests, definitions, tokens);
-  }, [datasetRequests, definitions, tokens]);
+    const ids = new Set<MetricSourceId>();
+    for (const itemTokens of items) {
+      if (itemTokens.length === 0 || isExpressionItem(itemTokens)) {
+        continue;
+      }
+      for (const token of itemTokens) {
+        if (token.type === "metric") {
+          const entry = definitions[token.metricIndex];
+          if (entry) {
+            ids.add(entry.id);
+          }
+        }
+      }
+    }
+    return ids;
+  }, [tokens, definitions]);
 
-  const isArithmeticMode = arithmeticRequest !== null;
+  const isIndividualMode = expressionItemsConfig.length === 0;
 
-  // Individual dataset queries — skipped in arithmetic mode
+  // Individual dataset queries:
+  //   • pure individual mode → fire for every definition in the tab
+  //   • mixed mode           → fire only for standalone metric items
   useEffect(() => {
-    if (datasetRequests.length === 0 || isArithmeticMode) {
+    if (datasetRequests.length === 0) {
       return;
     }
 
-    const subscriptions = datasetRequests.map((query) =>
+    const requestsToFire = isIndividualMode
+      ? datasetRequests
+      : datasetRequests.filter(
+          (r) => standaloneSourceIds?.has(r.sourceId) ?? false,
+        );
+
+    if (requestsToFire.length === 0) {
+      return;
+    }
+
+    const subscriptions = requestsToFire.map((query) =>
       dispatch(metricApi.endpoints.getMetricDataset.initiate(query.request)),
     );
 
     return () => {
       subscriptions.forEach((subscription) => subscription.unsubscribe());
     };
-  }, [datasetRequests, dispatch, isArithmeticMode]);
+  }, [datasetRequests, dispatch, isIndividualMode, standaloneSourceIds]);
 
-  // Arithmetic combined query
+  // Per-expression-item arithmetic queries
   useEffect(() => {
-    if (!arithmeticRequest) {
+    const validRequests = expressionItemsConfig
+      .map((item) => item.request)
+      .filter((r): r is NonNullable<typeof r> => r !== null);
+
+    if (validRequests.length === 0) {
       return;
     }
 
-    const subscription = dispatch(
-      metricApi.endpoints.getMetricDataset.initiate(arithmeticRequest),
+    const subscriptions = validRequests.map((req) =>
+      dispatch(metricApi.endpoints.getMetricDataset.initiate(req)),
     );
 
-    return () => subscription.unsubscribe();
-  }, [arithmeticRequest, dispatch]);
+    return () => {
+      subscriptions.forEach((subscription) => subscription.unsubscribe());
+    };
+  }, [expressionItemsConfig, dispatch]);
 
   useEffect(() => {
     if (breakoutRequests.length === 0) {
@@ -315,14 +409,14 @@ export function useDefinitionQueries(
     })),
   );
 
-  const arithmeticQueryResult = useSelector((state: State) => {
-    if (!arithmeticRequest) {
-      return null;
-    }
-    return metricApi.endpoints.getMetricDataset.select(arithmeticRequest)(
-      state,
-    );
-  });
+  const expressionItemQueryResults = useSelector((state: State) =>
+    expressionItemsConfig.map(({ request }) => {
+      if (!request) {
+        return null;
+      }
+      return metricApi.endpoints.getMetricDataset.select(request)(state);
+    }),
+  );
 
   const breakoutResults = useSelector((state: State) =>
     breakoutRequests.map((query) => ({
@@ -335,19 +429,16 @@ export function useDefinitionQueries(
 
   const { resultsByDefinitionId, errorsByDefinitionId, isExecuting } =
     useMemo(() => {
-      if (isArithmeticMode) {
-        return {
-          resultsByDefinitionId: new Map<MetricSourceId, Dataset>(),
-          errorsByDefinitionId: new Map<MetricSourceId, string>(),
-          isExecuting: (_id: MetricSourceId) => false,
-        };
-      }
-
       const results = new Map<MetricSourceId, Dataset>();
       const errors = new Map<MetricSourceId, string>();
       const executing = new Set<MetricSourceId>();
 
+      // In mixed/expression mode only populate results for standalone sources
+      // so they don't bleed into the expression-series chart path.
       for (const { sourceId, result } of datasetResults) {
+        if (!isIndividualMode && !standaloneSourceIds?.has(sourceId)) {
+          continue;
+        }
         if (result.data) {
           results.set(sourceId, result.data);
         }
@@ -364,7 +455,7 @@ export function useDefinitionQueries(
         errorsByDefinitionId: errors,
         isExecuting: (id: MetricSourceId) => executing.has(id),
       };
-    }, [isArithmeticMode, datasetResults]);
+    }, [isIndividualMode, standaloneSourceIds, datasetResults]);
 
   const breakoutValuesBySourceId = useMemo(() => {
     const map = new Map<MetricSourceId, MetricBreakoutValuesResponse>();
@@ -376,16 +467,27 @@ export function useDefinitionQueries(
     return map;
   }, [breakoutResults]);
 
+  const expressionItems: ExpressionItemResult[] = useMemo(
+    () =>
+      expressionItemsConfig.map(({ itemTokens }, idx) => {
+        const queryResult = expressionItemQueryResults[idx];
+        return {
+          itemTokens,
+          result: queryResult?.data ?? null,
+          isExecuting: queryResult?.isLoading ?? false,
+          error: queryResult?.error ? getErrorMessage(queryResult.error) : null,
+        };
+      }),
+    [expressionItemsConfig, expressionItemQueryResults],
+  );
+
   return {
     resultsByDefinitionId,
     errorsByDefinitionId,
     modifiedDefinitions,
     breakoutValuesBySourceId,
     isExecuting,
-    arithmeticResult: arithmeticQueryResult?.data ?? null,
-    arithmeticIsExecuting: arithmeticQueryResult?.isLoading ?? false,
-    arithmeticError: arithmeticQueryResult?.error
-      ? getErrorMessage(arithmeticQueryResult.error)
-      : null,
+    expressionItems,
+    standaloneSourceIds,
   };
 }

--- a/frontend/src/metabase/metrics-viewer/hooks/use-metrics-viewer.ts
+++ b/frontend/src/metabase/metrics-viewer/hooks/use-metrics-viewer.ts
@@ -157,6 +157,7 @@ function buildUrlRestoreTransform(
 export function useMetricsViewer(
   { location }: MetricsViewerPageProps,
   tokens: ExpressionToken[] = [],
+  onTokensRestored: (tokens: ExpressionToken[]) => void = () => {},
 ): UseMetricsViewerResult {
   const {
     state,
@@ -194,7 +195,14 @@ export function useMetricsViewer(
     [loadAndAddMetric, loadAndAddMeasure],
   );
 
-  useViewerUrl(state, initialize, handleLoadSources, location);
+  useViewerUrl(
+    state,
+    initialize,
+    handleLoadSources,
+    location,
+    tokens,
+    onTokensRestored,
+  );
 
   const activeTab = useMemo((): MetricsViewerTabState | null => {
     if (state.tabs.length === 0) {

--- a/frontend/src/metabase/metrics-viewer/hooks/use-metrics-viewer.ts
+++ b/frontend/src/metabase/metrics-viewer/hooks/use-metrics-viewer.ts
@@ -19,6 +19,7 @@ import type {
   SelectedMetric,
   SourceColorMap,
 } from "../types/viewer-state";
+import type { AdhocConfig } from "../utils/adhoc-definition";
 import {
   applyProjection,
   buildBinnedBreakoutDefinition,
@@ -38,6 +39,7 @@ import type {
 import { getAvailableDimensionsForPicker } from "../utils/dimension-picker";
 import { computeSourceColors, getSelectedMetricsInfo } from "../utils/series";
 import {
+  createAdhocSourceId,
   createMeasureSourceId,
   createMetricSourceId,
   createSourceId,
@@ -89,8 +91,9 @@ export interface UseMetricsViewerResult {
   availableDimensions: AvailableDimensionsResult;
 
   addMetric: (metric: SelectedMetric) => void;
+  addAdhocMetric: (config: AdhocConfig) => void;
   swapMetric: (oldMetric: SelectedMetric, newMetric: SelectedMetric) => void;
-  removeMetric: (id: number, sourceType: "metric" | "measure") => void;
+  removeMetric: (metric: SelectedMetric) => void;
   changeTab: (tabId: string) => void;
   addAndSelectTab: (dimensionId: string) => void;
   removeTab: (tabId: string) => void;
@@ -190,6 +193,7 @@ export function useMetricsViewer(
     loadAndAddMeasure,
     loadAndReplaceMetric,
     loadAndReplaceMeasure,
+    addAdhocDefinition,
   } = useViewerState();
 
   const handleLoadSources = useCallback(
@@ -285,13 +289,15 @@ export function useMetricsViewer(
       if (!definition) {
         continue;
       }
-      const name = getDefinitionName(definition);
+      const name = entry.displayName ?? getDefinitionName(definition);
       if (!name) {
         continue;
       }
       if (LibMetric.sourceMetricId(definition) != null) {
         result[entry.id] = { type: "metric", name };
       } else if (LibMetric.sourceMeasureId(definition) != null) {
+        result[entry.id] = { type: "measure", name };
+      } else if (entry.id.startsWith("adhoc:")) {
         result[entry.id] = { type: "measure", name };
       }
     }
@@ -344,6 +350,10 @@ export function useMetricsViewer(
 
   const addMetric = useCallback(
     (metric: SelectedMetric) => {
+      if (metric.sourceType === "adhoc") {
+        return; // adhoc metrics are added via addAdhocMetric
+      }
+
       const sourceId = createSourceId(metric.id, metric.sourceType);
 
       if (state.definitions.some((entry) => entry.id === sourceId)) {
@@ -359,13 +369,34 @@ export function useMetricsViewer(
     [state.definitions, loadAndAddMetric, loadAndAddMeasure],
   );
 
+  const addAdhocMetric = useCallback(
+    (config: AdhocConfig) => {
+      const sourceId = createAdhocSourceId(config.uuid);
+      if (state.definitions.some((entry) => entry.id === sourceId)) {
+        return;
+      }
+      addAdhocDefinition(config);
+    },
+    [state.definitions, addAdhocDefinition],
+  );
+
   const swapMetric = useCallback(
     (oldMetric: SelectedMetric, newMetric: SelectedMetric) => {
-      const oldSourceId = createSourceId(oldMetric.id, oldMetric.sourceType);
+      let oldSourceId: MetricSourceId;
+      if (oldMetric.sourceType === "adhoc" && oldMetric.adhocUuid) {
+        oldSourceId = createAdhocSourceId(oldMetric.adhocUuid);
+      } else if (
+        oldMetric.sourceType === "metric" ||
+        oldMetric.sourceType === "measure"
+      ) {
+        oldSourceId = createSourceId(oldMetric.id, oldMetric.sourceType);
+      } else {
+        return;
+      }
 
       if (newMetric.sourceType === "metric") {
         loadAndReplaceMetric(oldSourceId, newMetric.id);
-      } else {
+      } else if (newMetric.sourceType === "measure") {
         loadAndReplaceMeasure(oldSourceId, newMetric.id);
       }
     },
@@ -373,8 +404,15 @@ export function useMetricsViewer(
   );
 
   const removeMetric = useCallback(
-    (id: number, sourceType: "metric" | "measure") => {
-      removeDefinition(createSourceId(id, sourceType));
+    (metric: SelectedMetric) => {
+      if (metric.sourceType === "adhoc" && metric.adhocUuid) {
+        removeDefinition(createAdhocSourceId(metric.adhocUuid));
+      } else if (
+        metric.sourceType === "metric" ||
+        metric.sourceType === "measure"
+      ) {
+        removeDefinition(createSourceId(metric.id, metric.sourceType));
+      }
     },
     [removeDefinition],
   );
@@ -429,6 +467,7 @@ export function useMetricsViewer(
     availableDimensions,
 
     addMetric,
+    addAdhocMetric,
     swapMetric,
     removeMetric,
     changeTab,

--- a/frontend/src/metabase/metrics-viewer/hooks/use-metrics-viewer.ts
+++ b/frontend/src/metabase/metrics-viewer/hooks/use-metrics-viewer.ts
@@ -10,6 +10,7 @@ import * as LibMetric from "metabase-lib/metric";
 import type { Dataset, MetricBreakoutValuesResponse } from "metabase-types/api";
 
 import type { MetricsViewerPageProps } from "../pages/MetricsViewerPage/MetricsViewerPage";
+import type { ExpressionToken } from "../types/operators";
 import type {
   MetricSourceId,
   MetricsViewerDefinitionEntry,
@@ -61,6 +62,10 @@ export interface UseMetricsViewerResult {
   errorsByDefinitionId: Map<MetricSourceId, string>;
   modifiedDefinitions: Map<MetricSourceId, MetricDefinition>;
   isExecuting: (id: MetricSourceId) => boolean;
+
+  arithmeticResult: Dataset | null;
+  arithmeticIsExecuting: boolean;
+  arithmeticError: string | null;
 
   sourceColors: SourceColorMap;
   breakoutValuesBySourceId: Map<MetricSourceId, MetricBreakoutValuesResponse>;
@@ -149,9 +154,10 @@ function buildUrlRestoreTransform(
   };
 }
 
-export function useMetricsViewer({
-  location,
-}: MetricsViewerPageProps): UseMetricsViewerResult {
+export function useMetricsViewer(
+  { location }: MetricsViewerPageProps,
+  tokens: ExpressionToken[] = [],
+): UseMetricsViewerResult {
   const {
     state,
     loadingIds,
@@ -205,7 +211,10 @@ export function useMetricsViewer({
     modifiedDefinitions,
     breakoutValuesBySourceId,
     isExecuting,
-  } = useDefinitionQueries(state.definitions, activeTab);
+    arithmeticResult,
+    arithmeticIsExecuting,
+    arithmeticError,
+  } = useDefinitionQueries(state.definitions, activeTab, tokens);
 
   const selectedMetrics = useMemo(
     () => getSelectedMetricsInfo(state.definitions, loadingIds),
@@ -372,6 +381,10 @@ export function useMetricsViewer({
     errorsByDefinitionId,
     modifiedDefinitions,
     isExecuting,
+
+    arithmeticResult,
+    arithmeticIsExecuting,
+    arithmeticError,
 
     sourceColors,
     breakoutValuesBySourceId,

--- a/frontend/src/metabase/metrics-viewer/hooks/use-metrics-viewer.ts
+++ b/frontend/src/metabase/metrics-viewer/hooks/use-metrics-viewer.ts
@@ -9,6 +9,7 @@ import type {
 import * as LibMetric from "metabase-lib/metric";
 import type { Dataset, MetricBreakoutValuesResponse } from "metabase-types/api";
 
+import { buildExpressionText } from "../components/MetricSearch/utils";
 import type { MetricsViewerPageProps } from "../pages/MetricsViewerPage/MetricsViewerPage";
 import type { ExpressionToken } from "../types/operators";
 import type {
@@ -63,9 +64,22 @@ export interface UseMetricsViewerResult {
   modifiedDefinitions: Map<MetricSourceId, MetricDefinition>;
   isExecuting: (id: MetricSourceId) => boolean;
 
-  arithmeticResult: Dataset | null;
-  arithmeticIsExecuting: boolean;
-  arithmeticError: string | null;
+  /**
+   * One entry per expression item in the token list (items with operators).
+   * Each entry's `name` is the human-readable expression text built from the
+   * current selectedMetrics list.
+   */
+  expressionItems: Array<{
+    name: string;
+    result: Dataset | null;
+    isExecuting: boolean;
+    error: string | null;
+  }>;
+  /**
+   * Source IDs of definitions that are plain single-metric items.
+   * `null` means pure individual mode — all definitions are standalone.
+   */
+  standaloneSourceIds: Set<MetricSourceId> | null;
 
   sourceColors: SourceColorMap;
   breakoutValuesBySourceId: Map<MetricSourceId, MetricBreakoutValuesResponse>;
@@ -219,14 +233,28 @@ export function useMetricsViewer(
     modifiedDefinitions,
     breakoutValuesBySourceId,
     isExecuting,
-    arithmeticResult,
-    arithmeticIsExecuting,
-    arithmeticError,
+    expressionItems: rawExpressionItems,
+    standaloneSourceIds,
   } = useDefinitionQueries(state.definitions, activeTab, tokens);
 
   const selectedMetrics = useMemo(
     () => getSelectedMetricsInfo(state.definitions, loadingIds),
     [state.definitions, loadingIds],
+  );
+
+  // Enrich each expression item with its human-readable name derived from the
+  // current selectedMetrics list (which maps metricIndex → metric name).
+  const expressionItems = useMemo(
+    () =>
+      rawExpressionItems.map(
+        ({ itemTokens, result, isExecuting: itemExec, error }) => ({
+          name: buildExpressionText(itemTokens, selectedMetrics),
+          result,
+          isExecuting: itemExec,
+          error,
+        }),
+      ),
+    [rawExpressionItems, selectedMetrics],
   );
 
   const sourceColors = useMemo(
@@ -390,9 +418,8 @@ export function useMetricsViewer(
     modifiedDefinitions,
     isExecuting,
 
-    arithmeticResult,
-    arithmeticIsExecuting,
-    arithmeticError,
+    expressionItems,
+    standaloneSourceIds,
 
     sourceColors,
     breakoutValuesBySourceId,

--- a/frontend/src/metabase/metrics-viewer/hooks/use-viewer-state.ts
+++ b/frontend/src/metabase/metrics-viewer/hooks/use-viewer-state.ts
@@ -1,6 +1,6 @@
 import { useCallback, useRef, useState } from "react";
 
-import { measureApi, metricApi } from "metabase/api";
+import { measureApi, metricApi, tableApi } from "metabase/api";
 import { getObjectEntries, objectFromEntries } from "metabase/lib/objects";
 import { useDispatch, useStore } from "metabase/lib/redux";
 import { isNotNull } from "metabase/lib/types";
@@ -22,8 +22,11 @@ import type {
   StoredMetricsViewerTab,
 } from "../types/viewer-state";
 import { getInitialMetricsViewerPageState } from "../types/viewer-state";
+import type { AdhocConfig } from "../utils/adhoc-definition";
+import { buildAdhocMetricDefinition } from "../utils/adhoc-definition";
 import { buildBinnedBreakoutDefinition } from "../utils/definition-builder";
 import {
+  createAdhocSourceId,
   createMeasureSourceId,
   createMetricSourceId,
 } from "../utils/source-ids";
@@ -167,6 +170,7 @@ export interface UseViewerStateResult {
     oldSourceId: MetricSourceId,
     measureId: MeasureId,
   ) => void;
+  addAdhocDefinition: (config: AdhocConfig) => void;
 }
 
 export function useViewerState(): UseViewerStateResult {
@@ -451,6 +455,7 @@ export function useViewerState(): UseViewerStateResult {
       id: MetricSourceId,
       loader: () => Promise<MetricDefinition>,
       transform?: (def: MetricDefinition) => MetricDefinition,
+      displayName?: string,
     ) => {
       if (loadingRef.current.has(id)) {
         return;
@@ -458,7 +463,7 @@ export function useViewerState(): UseViewerStateResult {
 
       loadingRef.current.add(id);
       setLoadingIds((prev) => new Set(prev).add(id));
-      addDefinition({ id, definition: null });
+      addDefinition({ id, definition: null, displayName });
 
       try {
         const rawDefinition = await loader();
@@ -563,6 +568,26 @@ export function useViewerState(): UseViewerStateResult {
     [loadAndReplace, dispatch, store],
   );
 
+  const addAdhocDefinition = useCallback(
+    (config: AdhocConfig) => {
+      const sourceId = createAdhocSourceId(config.uuid);
+      const loader = async () => {
+        const result = await dispatch(
+          tableApi.endpoints.getTableQueryMetadata.initiate({
+            id: config.tableId,
+          }),
+        );
+        const fields = result.data?.fields ?? [];
+        const provider = LibMetric.metadataProvider(
+          getMetadata(store.getState()),
+        );
+        return buildAdhocMetricDefinition(config, fields, provider);
+      };
+      loadDefinition(sourceId, loader, undefined, config.displayName);
+    },
+    [dispatch, store, loadDefinition],
+  );
+
   return {
     state,
     loadingIds,
@@ -583,5 +608,6 @@ export function useViewerState(): UseViewerStateResult {
     loadAndAddMeasure,
     loadAndReplaceMetric,
     loadAndReplaceMeasure,
+    addAdhocDefinition,
   };
 }

--- a/frontend/src/metabase/metrics-viewer/hooks/use-viewer-url.ts
+++ b/frontend/src/metabase/metrics-viewer/hooks/use-viewer-url.ts
@@ -7,6 +7,7 @@ import * as Urls from "metabase/lib/urls";
 import type { MeasureId, TemporalUnit } from "metabase-types/api";
 import type { MetricId } from "metabase-types/api/metric";
 
+import type { ExpressionToken } from "../types/operators";
 import type {
   MetricSourceId,
   MetricsViewerPageState,
@@ -17,6 +18,7 @@ import { createSourceId } from "../utils/source-ids";
 import {
   type SerializedMetricsViewerPageState,
   decodeState,
+  deserializeExpression,
   deserializeTab,
   encodeState,
   stateToSerializedState,
@@ -40,6 +42,8 @@ export function useViewerUrl(
   initialize: (state: MetricsViewerPageState) => void,
   onLoadSources: (request: LoadSourcesRequest) => void,
   location: Location,
+  tokens: ExpressionToken[],
+  onTokensRestored: (tokens: ExpressionToken[]) => void,
 ): void {
   const dispatch = useDispatch();
   const lastHashRef = useRef<string | null>(null);
@@ -57,6 +61,7 @@ export function useViewerUrl(
           sources: [{ type: "metric", id: parseInt(metricId, 10) }],
           tabs: [],
           selectedTabId: null,
+          expression: [],
         };
         const encodedHash = encodeState(serializedState);
         if (encodedHash === undefined) {
@@ -123,7 +128,26 @@ export function useViewerUrl(
         filtersBySourceId: hasFilters ? filtersBySourceId : undefined,
       });
     }
-  }, [location, dispatch, initialize, onLoadSources]);
+
+    const restoredExpression = deserializeExpression(
+      serializedState.expression ?? [],
+    );
+
+    // When there is no saved expression (e.g. legacy URLs, ?metricId= entry point),
+    // generate default tokens so every source appears as a pill in the formula input.
+    if (restoredExpression.length === 0 && serializedState.sources.length > 0) {
+      const defaultTokens: ExpressionToken[] = [];
+      for (let i = 0; i < serializedState.sources.length; i++) {
+        if (i > 0) {
+          defaultTokens.push({ type: "operator", op: "+" });
+        }
+        defaultTokens.push({ type: "metric", metricIndex: i });
+      }
+      onTokensRestored(defaultTokens);
+    } else {
+      onTokensRestored(restoredExpression);
+    }
+  }, [location, dispatch, initialize, onLoadSources, onTokensRestored]);
 
   // sync state to URL
   useEffect(() => {
@@ -134,7 +158,7 @@ export function useViewerUrl(
       return;
     }
 
-    const serializedState = stateToSerializedState(state);
+    const serializedState = stateToSerializedState(state, tokens);
     const hash = encodeState(serializedState);
     if (hash !== undefined && hash !== lastHashRef.current) {
       lastHashRef.current = hash;
@@ -145,5 +169,5 @@ export function useViewerUrl(
         dispatch(push(url));
       }
     }
-  }, [state, dispatch]);
+  }, [state, tokens, dispatch]);
 }

--- a/frontend/src/metabase/metrics-viewer/pages/MetricsViewerPage/MetricsViewerPage.tsx
+++ b/frontend/src/metabase/metrics-viewer/pages/MetricsViewerPage/MetricsViewerPage.tsx
@@ -1,4 +1,5 @@
 import type { Location } from "history";
+import { useMemo, useState } from "react";
 
 import { Box, Flex, Stack } from "metabase/ui";
 
@@ -13,6 +14,7 @@ import {
   MetricsViewerTabs,
 } from "../../components/MetricsViewerTabs";
 import { useMetricsViewer } from "../../hooks/use-metrics-viewer";
+import type { ExpressionToken } from "../../types/operators";
 
 import S from "./MetricsViewerPage.module.css";
 
@@ -21,6 +23,8 @@ export type MetricsViewerPageProps = {
 };
 
 export function MetricsViewerPage(props: MetricsViewerPageProps) {
+  const [tokens, setTokens] = useState<ExpressionToken[]>([]);
+
   const {
     definitions,
     tabs,
@@ -36,6 +40,9 @@ export function MetricsViewerPage(props: MetricsViewerPageProps) {
     sourceDataById,
     availableDimensions,
     isExecuting,
+    arithmeticResult,
+    arithmeticIsExecuting,
+    arithmeticError,
     addMetric,
     swapMetric,
     removeMetric,
@@ -47,7 +54,29 @@ export function MetricsViewerPage(props: MetricsViewerPageProps) {
     removeTabDimension,
     updateDefinition,
     setBreakoutDimension,
-  } = useMetricsViewer(props);
+  } = useMetricsViewer(props, tokens);
+
+  const expressionName = useMemo(() => {
+    const metricCount = tokens.filter((t) => t.type === "metric").length;
+    const opCount = tokens.filter((t) => t.type === "operator").length;
+    if (metricCount < 2 || opCount === 0) {
+      return null;
+    }
+    return tokens
+      .map((token) => {
+        if (token.type === "open-paren") {
+          return "(";
+        }
+        if (token.type === "close-paren") {
+          return ")";
+        }
+        if (token.type === "operator") {
+          return token.op;
+        }
+        return selectedMetrics[token.metricIndex]?.name ?? "...";
+      })
+      .join(" ");
+  }, [tokens, selectedMetrics]);
 
   const hasDefinitions = definitions.length > 0;
   const hasLoadedDefinitions = definitions.some(
@@ -66,6 +95,7 @@ export function MetricsViewerPage(props: MetricsViewerPageProps) {
           onSwapMetric={swapMetric}
           onSetBreakout={setBreakoutDimension}
           onUpdateDefinition={updateDefinition}
+          onExpressionChange={setTokens}
         />
       </Box>
       <Flex flex="1 1 auto" mih={0}>
@@ -106,6 +136,10 @@ export function MetricsViewerPage(props: MetricsViewerPageProps) {
                   modifiedDefinitions={modifiedDefinitions}
                   sourceColors={sourceColors}
                   isExecuting={isExecuting}
+                  arithmeticResult={arithmeticResult}
+                  arithmeticIsExecuting={arithmeticIsExecuting}
+                  arithmeticError={arithmeticError}
+                  expressionName={expressionName}
                   onTabUpdate={updateActiveTab}
                   onDimensionChange={(defId, dim) =>
                     changeTabDimension(activeTab.id, defId, dim)

--- a/frontend/src/metabase/metrics-viewer/pages/MetricsViewerPage/MetricsViewerPage.tsx
+++ b/frontend/src/metabase/metrics-viewer/pages/MetricsViewerPage/MetricsViewerPage.tsx
@@ -1,5 +1,5 @@
 import type { Location } from "history";
-import { useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 
 import { Box, Flex, Stack } from "metabase/ui";
 
@@ -13,6 +13,7 @@ import {
   MetricsViewerTabContent,
   MetricsViewerTabs,
 } from "../../components/MetricsViewerTabs";
+import type { AdhocResult } from "../../components/SummarizeTable";
 import { useMetricsViewer } from "../../hooks/use-metrics-viewer";
 import type { ExpressionToken } from "../../types/operators";
 
@@ -43,6 +44,7 @@ export function MetricsViewerPage(props: MetricsViewerPageProps) {
     expressionItems,
     standaloneSourceIds,
     addMetric,
+    addAdhocMetric,
     swapMetric,
     removeMetric,
     changeTab,
@@ -54,6 +56,62 @@ export function MetricsViewerPage(props: MetricsViewerPageProps) {
     updateDefinition,
     setBreakoutDimension,
   } = useMetricsViewer(props, tokens, setTokens);
+
+  const expressionName = useMemo(() => {
+    const metricCount = tokens.filter((t) => t.type === "metric").length;
+    const opCount = tokens.filter((t) => t.type === "operator").length;
+    if (metricCount < 1 || opCount === 0) {
+      return null;
+    }
+    return tokens
+      .map((token) => {
+        if (token.type === "open-paren") {
+          return "(";
+        }
+        if (token.type === "close-paren") {
+          return ")";
+        }
+        if (token.type === "operator") {
+          return token.op;
+        }
+        if (token.type === "constant") {
+          return String(token.value);
+        }
+        if (token.type === "separator") {
+          return ",";
+        }
+        return selectedMetrics[token.metricIndex]?.name ?? "...";
+      })
+      .join(" ");
+  }, [tokens, selectedMetrics]);
+
+  const handleAddAdhoc = useCallback(
+    (result: AdhocResult) => {
+      addAdhocMetric({
+        uuid: result.uuid,
+        databaseId: result.databaseId,
+        tableId: result.tableId,
+        tableName: result.tableName,
+        aggregationOperator: result.aggregationOperator,
+        column: result.column,
+        displayName: result.displayName,
+      });
+    },
+    [addAdhocMetric],
+  );
+
+  // Derive database ID from first definition for scoping the table picker
+  const databaseId = useMemo(() => {
+    for (const metric of selectedMetrics) {
+      if (metric.sourceType === "adhoc") {
+        continue;
+      }
+      if (metric.tableId != null) {
+        return undefined; // measures have tableId but not databaseId directly
+      }
+    }
+    return undefined;
+  }, [selectedMetrics]);
 
   const hasDefinitions = definitions.length > 0;
   const hasLoadedDefinitions = definitions.some(
@@ -74,6 +132,8 @@ export function MetricsViewerPage(props: MetricsViewerPageProps) {
           onSwapMetric={swapMetric}
           onSetBreakout={setBreakoutDimension}
           onUpdateDefinition={updateDefinition}
+          onAddAdhoc={handleAddAdhoc}
+          databaseId={databaseId}
         />
       </Box>
       <Flex flex="1 1 auto" mih={0}>

--- a/frontend/src/metabase/metrics-viewer/pages/MetricsViewerPage/MetricsViewerPage.tsx
+++ b/frontend/src/metabase/metrics-viewer/pages/MetricsViewerPage/MetricsViewerPage.tsx
@@ -54,7 +54,7 @@ export function MetricsViewerPage(props: MetricsViewerPageProps) {
     removeTabDimension,
     updateDefinition,
     setBreakoutDimension,
-  } = useMetricsViewer(props, tokens);
+  } = useMetricsViewer(props, tokens, setTokens);
 
   const expressionName = useMemo(() => {
     const metricCount = tokens.filter((t) => t.type === "metric").length;
@@ -87,6 +87,8 @@ export function MetricsViewerPage(props: MetricsViewerPageProps) {
     <Stack h="100%" gap={0} className={S.root}>
       <Box px="lg" pt="md" flex="0 0 auto">
         <MetricSearchPanel
+          tokens={tokens}
+          onTokensChange={setTokens}
           selectedMetrics={selectedMetrics}
           metricColors={sourceColors}
           definitions={definitions}
@@ -95,7 +97,6 @@ export function MetricsViewerPage(props: MetricsViewerPageProps) {
           onSwapMetric={swapMetric}
           onSetBreakout={setBreakoutDimension}
           onUpdateDefinition={updateDefinition}
-          onExpressionChange={setTokens}
         />
       </Box>
       <Flex flex="1 1 auto" mih={0}>

--- a/frontend/src/metabase/metrics-viewer/pages/MetricsViewerPage/MetricsViewerPage.tsx
+++ b/frontend/src/metabase/metrics-viewer/pages/MetricsViewerPage/MetricsViewerPage.tsx
@@ -1,5 +1,5 @@
 import type { Location } from "history";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 
 import { Box, Flex, Stack } from "metabase/ui";
 
@@ -40,9 +40,8 @@ export function MetricsViewerPage(props: MetricsViewerPageProps) {
     sourceDataById,
     availableDimensions,
     isExecuting,
-    arithmeticResult,
-    arithmeticIsExecuting,
-    arithmeticError,
+    expressionItems,
+    standaloneSourceIds,
     addMetric,
     swapMetric,
     removeMetric,
@@ -55,34 +54,6 @@ export function MetricsViewerPage(props: MetricsViewerPageProps) {
     updateDefinition,
     setBreakoutDimension,
   } = useMetricsViewer(props, tokens, setTokens);
-
-  const expressionName = useMemo(() => {
-    const metricCount = tokens.filter((t) => t.type === "metric").length;
-    const opCount = tokens.filter((t) => t.type === "operator").length;
-    if (metricCount < 1 || opCount === 0) {
-      return null;
-    }
-    return tokens
-      .map((token) => {
-        if (token.type === "open-paren") {
-          return "(";
-        }
-        if (token.type === "close-paren") {
-          return ")";
-        }
-        if (token.type === "operator") {
-          return token.op;
-        }
-        if (token.type === "separator") {
-          return ",";
-        }
-        if (token.type === "constant") {
-          return String(token.value);
-        }
-        return selectedMetrics[token.metricIndex]?.name ?? "...";
-      })
-      .join(" ");
-  }, [tokens, selectedMetrics]);
 
   const hasDefinitions = definitions.length > 0;
   const hasLoadedDefinitions = definitions.some(
@@ -143,10 +114,8 @@ export function MetricsViewerPage(props: MetricsViewerPageProps) {
                   modifiedDefinitions={modifiedDefinitions}
                   sourceColors={sourceColors}
                   isExecuting={isExecuting}
-                  arithmeticResult={arithmeticResult}
-                  arithmeticIsExecuting={arithmeticIsExecuting}
-                  arithmeticError={arithmeticError}
-                  expressionName={expressionName}
+                  expressionItems={expressionItems}
+                  standaloneSourceIds={standaloneSourceIds}
                   onTabUpdate={updateActiveTab}
                   onDimensionChange={(defId, dim) =>
                     changeTabDimension(activeTab.id, defId, dim)

--- a/frontend/src/metabase/metrics-viewer/pages/MetricsViewerPage/MetricsViewerPage.tsx
+++ b/frontend/src/metabase/metrics-viewer/pages/MetricsViewerPage/MetricsViewerPage.tsx
@@ -73,6 +73,9 @@ export function MetricsViewerPage(props: MetricsViewerPageProps) {
         if (token.type === "operator") {
           return token.op;
         }
+        if (token.type === "separator") {
+          return ",";
+        }
         if (token.type === "constant") {
           return String(token.value);
         }

--- a/frontend/src/metabase/metrics-viewer/pages/MetricsViewerPage/MetricsViewerPage.tsx
+++ b/frontend/src/metabase/metrics-viewer/pages/MetricsViewerPage/MetricsViewerPage.tsx
@@ -1,5 +1,5 @@
 import type { Location } from "history";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useState } from "react";
 
 import { Box, Flex, Stack } from "metabase/ui";
 
@@ -57,34 +57,6 @@ export function MetricsViewerPage(props: MetricsViewerPageProps) {
     setBreakoutDimension,
   } = useMetricsViewer(props, tokens, setTokens);
 
-  const expressionName = useMemo(() => {
-    const metricCount = tokens.filter((t) => t.type === "metric").length;
-    const opCount = tokens.filter((t) => t.type === "operator").length;
-    if (metricCount < 1 || opCount === 0) {
-      return null;
-    }
-    return tokens
-      .map((token) => {
-        if (token.type === "open-paren") {
-          return "(";
-        }
-        if (token.type === "close-paren") {
-          return ")";
-        }
-        if (token.type === "operator") {
-          return token.op;
-        }
-        if (token.type === "constant") {
-          return String(token.value);
-        }
-        if (token.type === "separator") {
-          return ",";
-        }
-        return selectedMetrics[token.metricIndex]?.name ?? "...";
-      })
-      .join(" ");
-  }, [tokens, selectedMetrics]);
-
   const handleAddAdhoc = useCallback(
     (result: AdhocResult) => {
       addAdhocMetric({
@@ -96,22 +68,22 @@ export function MetricsViewerPage(props: MetricsViewerPageProps) {
         column: result.column,
         displayName: result.displayName,
       });
-    },
-    [addAdhocMetric],
-  );
 
-  // Derive database ID from first definition for scoping the table picker
-  const databaseId = useMemo(() => {
-    for (const metric of selectedMetrics) {
-      if (metric.sourceType === "adhoc") {
-        continue;
-      }
-      if (metric.tableId != null) {
-        return undefined; // measures have tableId but not databaseId directly
-      }
-    }
-    return undefined;
-  }, [selectedMetrics]);
+      // Append a token so the adhoc metric appears in the text box / as a pill.
+      // The new metric will be appended to selectedMetrics at this index.
+      const newIndex = selectedMetrics.length;
+      const metricToken: ExpressionToken = {
+        type: "metric",
+        metricIndex: newIndex,
+      };
+      setTokens((prev) =>
+        prev.length > 0
+          ? [...prev, { type: "separator" as const }, metricToken]
+          : [metricToken],
+      );
+    },
+    [addAdhocMetric, selectedMetrics.length, setTokens],
+  );
 
   const hasDefinitions = definitions.length > 0;
   const hasLoadedDefinitions = definitions.some(
@@ -133,7 +105,6 @@ export function MetricsViewerPage(props: MetricsViewerPageProps) {
           onSetBreakout={setBreakoutDimension}
           onUpdateDefinition={updateDefinition}
           onAddAdhoc={handleAddAdhoc}
-          databaseId={databaseId}
         />
       </Box>
       <Flex flex="1 1 auto" mih={0}>

--- a/frontend/src/metabase/metrics-viewer/pages/MetricsViewerPage/MetricsViewerPage.tsx
+++ b/frontend/src/metabase/metrics-viewer/pages/MetricsViewerPage/MetricsViewerPage.tsx
@@ -59,7 +59,7 @@ export function MetricsViewerPage(props: MetricsViewerPageProps) {
   const expressionName = useMemo(() => {
     const metricCount = tokens.filter((t) => t.type === "metric").length;
     const opCount = tokens.filter((t) => t.type === "operator").length;
-    if (metricCount < 2 || opCount === 0) {
+    if (metricCount < 1 || opCount === 0) {
       return null;
     }
     return tokens
@@ -72,6 +72,9 @@ export function MetricsViewerPage(props: MetricsViewerPageProps) {
         }
         if (token.type === "operator") {
           return token.op;
+        }
+        if (token.type === "constant") {
+          return String(token.value);
         }
         return selectedMetrics[token.metricIndex]?.name ?? "...";
       })

--- a/frontend/src/metabase/metrics-viewer/types/operators.ts
+++ b/frontend/src/metabase/metrics-viewer/types/operators.ts
@@ -10,4 +10,5 @@ export type ExpressionToken =
   | { type: "constant"; value: number }
   | { type: "operator"; op: MathOperator }
   | { type: "open-paren" }
-  | { type: "close-paren" };
+  | { type: "close-paren" }
+  | { type: "separator" };

--- a/frontend/src/metabase/metrics-viewer/types/operators.ts
+++ b/frontend/src/metabase/metrics-viewer/types/operators.ts
@@ -1,0 +1,12 @@
+export type MathOperator = "+" | "-" | "*" | "/";
+export const MATH_OPERATORS: MathOperator[] = ["+", "-", "*", "/"];
+
+export function isMathOperator(key: string): key is MathOperator {
+  return key === "+" || key === "-" || key === "*" || key === "/";
+}
+
+export type ExpressionToken =
+  | { type: "metric"; metricIndex: number }
+  | { type: "operator"; op: MathOperator }
+  | { type: "open-paren" }
+  | { type: "close-paren" };

--- a/frontend/src/metabase/metrics-viewer/types/operators.ts
+++ b/frontend/src/metabase/metrics-viewer/types/operators.ts
@@ -7,6 +7,7 @@ export function isMathOperator(key: string): key is MathOperator {
 
 export type ExpressionToken =
   | { type: "metric"; metricIndex: number }
+  | { type: "constant"; value: number }
   | { type: "operator"; op: MathOperator }
   | { type: "open-paren" }
   | { type: "close-paren" };

--- a/frontend/src/metabase/metrics-viewer/types/viewer-state.ts
+++ b/frontend/src/metabase/metrics-viewer/types/viewer-state.ts
@@ -5,6 +5,7 @@ import type {
   DimensionId,
   TemporalUnit,
 } from "metabase-types/api";
+import type { AdhocLeafDefinition } from "metabase-types/api/metric";
 
 import type { DimensionFilterValue } from "../utils/dimension-filters";
 
@@ -15,7 +16,10 @@ export type MetricsViewerDisplayType = Extract<
   "line" | "area" | "bar" | "map" | "row" | "pie" | "scatter"
 >;
 
-export type MetricSourceId = `metric:${number}` | `measure:${number}`;
+export type MetricSourceId =
+  | `metric:${number}`
+  | `measure:${number}`
+  | `adhoc:${string}`;
 
 export type MetricsViewerTabType =
   | "time"
@@ -46,6 +50,8 @@ export interface StoredMetricsViewerTab {
 export interface MetricsViewerDefinitionEntry {
   id: MetricSourceId;
   definition: MetricDefinition | null;
+  /** Override display name (used for adhoc aggregations). */
+  displayName?: string;
 }
 
 // ── Tab state ──
@@ -90,7 +96,13 @@ export type SourceColorMap = Partial<Record<MetricSourceId, string[]>>;
 export type SelectedMetric = {
   id: number;
   name: string | null;
-  sourceType: "metric" | "measure";
+  sourceType: "metric" | "measure" | "adhoc";
   tableId?: ConcreteTableId;
   isLoading?: boolean;
+  /** For adhoc: the stable UUID used as the leaf's lib/uuid */
+  adhocUuid?: string;
+  /** For adhoc: the table name for display in pills */
+  tableName?: string;
+  /** For adhoc: the inline definition sent to the API */
+  adhocDefinition?: AdhocLeafDefinition;
 };

--- a/frontend/src/metabase/metrics-viewer/utils/adhoc-definition.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/adhoc-definition.ts
@@ -1,0 +1,158 @@
+import type { MetadataProvider, MetricDefinition } from "metabase-lib/metric";
+import * as LibMetric from "metabase-lib/metric";
+import type { Field } from "metabase-types/api/field";
+import type {
+  AdhocDimension,
+  AdhocLeafDefinition,
+  JsMetricDefinition,
+} from "metabase-types/api/metric";
+
+export type AdhocAggregationOperator =
+  | "count"
+  | "sum"
+  | "avg"
+  | "min"
+  | "max"
+  | "distinct";
+
+export type AdhocConfig = {
+  uuid: string;
+  databaseId: number;
+  tableId: number;
+  tableName: string;
+  aggregationOperator: AdhocAggregationOperator;
+  /** The field to aggregate (null for count) */
+  column?: Field;
+  displayName: string;
+};
+
+/**
+ * Build the dimensions array from all breakout-eligible fields on the table.
+ * Each dimension gets a stable UUID as its ID (required by the CLJS schema).
+ * Field-refs include lib/uuid as required by the MBQL field clause schema.
+ */
+export function buildAdhocDimensions(
+  tableId: number,
+  fields: Field[],
+): AdhocDimension[] {
+  return fields
+    .filter(
+      (field) =>
+        field.active &&
+        field.visibility_type === "normal" &&
+        field.id != null &&
+        typeof field.id === "number",
+    )
+    .map((field) => {
+      const fieldId = field.id as number;
+      const dimension: AdhocDimension = {
+        id: crypto.randomUUID(),
+        "field-ref": [
+          "field",
+          { "lib/uuid": crypto.randomUUID(), "table-id": tableId },
+          fieldId,
+        ],
+        "display-name": field.display_name,
+        "effective-type": field.effective_type ?? field.base_type,
+      };
+      if (field.semantic_type) {
+        dimension["semantic-type"] = field.semantic_type;
+      }
+      return dimension;
+    });
+}
+
+/**
+ * Build the MBQL aggregation clause for the given operator and optional column.
+ */
+export function buildAdhocAggregation(
+  operator: AdhocAggregationOperator,
+  tableId: number,
+  column?: Field,
+): unknown {
+  if (operator === "count") {
+    return ["count", {}];
+  }
+
+  if (!column || typeof column.id !== "number") {
+    throw new Error(`Aggregation "${operator}" requires a column`);
+  }
+
+  return [
+    operator,
+    {},
+    [
+      "field",
+      { "lib/uuid": crypto.randomUUID(), "table-id": tableId },
+      column.id,
+    ],
+  ];
+}
+
+/**
+ * Build the full inline definition for an adhoc expression leaf.
+ */
+export function buildAdhocLeafDefinition(
+  config: AdhocConfig,
+  fields: Field[],
+): AdhocLeafDefinition {
+  return {
+    "database-id": config.databaseId,
+    "table-id": config.tableId,
+    aggregation: buildAdhocAggregation(
+      config.aggregationOperator,
+      config.tableId,
+      config.column,
+    ),
+    dimensions: buildAdhocDimensions(config.tableId, fields),
+  };
+}
+
+/**
+ * Build a full MetricDefinition for an adhoc leaf, using the CLJS lib.
+ * This produces an opaque MetricDefinition that works with all the existing
+ * dimension, projection, and filter infrastructure.
+ */
+export function buildAdhocMetricDefinition(
+  config: AdhocConfig,
+  fields: Field[],
+  metadataProvider: MetadataProvider,
+): MetricDefinition {
+  const leafDefinition = buildAdhocLeafDefinition(config, fields);
+
+  const jsDef: JsMetricDefinition = {
+    expression: ["adhoc", { "lib/uuid": config.uuid }, leafDefinition],
+  };
+
+  return LibMetric.fromJsMetricDefinition(metadataProvider, jsDef);
+}
+
+/**
+ * Build a display name for an adhoc aggregation.
+ * e.g. "Count of rows (Sales Transactions)" or "Sum of Tax (Sales Transactions)"
+ */
+export function buildAdhocDisplayName(
+  operator: AdhocAggregationOperator,
+  tableName: string,
+  columnName?: string,
+): string {
+  const OPERATOR_LABELS: Record<AdhocAggregationOperator, string> = {
+    count: "Count of rows",
+    sum: "Sum",
+    avg: "Average",
+    min: "Min",
+    max: "Max",
+    distinct: "Distinct values",
+  };
+
+  const opLabel = OPERATOR_LABELS[operator];
+  if (operator === "count") {
+    return `${opLabel} (${tableName})`;
+  }
+
+  if (columnName) {
+    return `${opLabel} of ${columnName} (${tableName})`;
+  }
+
+  return `${opLabel} (${tableName})`;
+}

--- a/frontend/src/metabase/metrics-viewer/utils/series.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/series.ts
@@ -536,7 +536,7 @@ export function getSelectedMetricsInfo(
             id: 0,
             sourceType: "adhoc",
             adhocUuid: parsed.uuid,
-            name: null,
+            name: entry.displayName ?? null,
             isLoading,
           },
         ];
@@ -545,7 +545,7 @@ export function getSelectedMetricsInfo(
         {
           id: parsed.id,
           sourceType: parsed.type,
-          name: null,
+          name: entry.displayName ?? null,
           isLoading,
         },
       ];

--- a/frontend/src/metabase/metrics-viewer/utils/series.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/series.ts
@@ -110,16 +110,13 @@ export function buildArithmeticSeriesFromResult(
   ];
 }
 
-function getDefinitionCardId(def: MetricDefinition): number | null {
+function getDefinitionCardId(def: MetricDefinition): number {
   const metricId = LibMetric.sourceMetricId(def);
   if (metricId != null) {
     return metricId;
   }
-  const measureId = LibMetric.sourceMeasureId(def);
-  if (measureId != null) {
-    return nextSyntheticCardId();
-  }
-  return null;
+  // Measures and adhoc definitions use synthetic card IDs.
+  return nextSyntheticCardId();
 }
 
 /**
@@ -140,7 +137,8 @@ export function computeSourceColors(
     if (!entry.definition) {
       continue;
     }
-    const displayName = getDefinitionName(entry.definition);
+    const displayName =
+      entry.displayName ?? getDefinitionName(entry.definition);
     if (!displayName) {
       continue;
     }
@@ -342,11 +340,8 @@ export function buildRawSeriesFromDefinitions(
     }
 
     const cardId = getDefinitionCardId(entry.definition);
-    if (cardId == null) {
-      return [];
-    }
 
-    const name = getDefinitionName(entry.definition);
+    const name = entry.displayName ?? getDefinitionName(entry.definition);
 
     const seriesKey = getSeriesVizSettingsKey(
       result.data.cols[1], // metric API returns [projection_cols..., aggregation_col]
@@ -532,9 +527,20 @@ export function getSelectedMetricsInfo(
   return definitions.flatMap((entry): SelectedMetric[] => {
     const { definition } = entry;
     const isLoading = loadingIds.has(entry.id);
+    const parsed = parseSourceId(entry.id);
 
     if (!definition) {
-      const parsed = parseSourceId(entry.id);
+      if (parsed.type === "adhoc") {
+        return [
+          {
+            id: 0,
+            sourceType: "adhoc",
+            adhocUuid: parsed.uuid,
+            name: null,
+            isLoading,
+          },
+        ];
+      }
       return [
         {
           id: parsed.id,
@@ -545,7 +551,20 @@ export function getSelectedMetricsInfo(
       ];
     }
 
-    const name = getDefinitionName(definition) ?? entry.id;
+    const name = entry.displayName ?? getDefinitionName(definition) ?? entry.id;
+
+    if (parsed.type === "adhoc") {
+      return [
+        {
+          id: 0,
+          sourceType: "adhoc",
+          adhocUuid: parsed.uuid,
+          name,
+          isLoading,
+        },
+      ];
+    }
+
     const metricId = LibMetric.sourceMetricId(definition);
     if (metricId != null) {
       return [

--- a/frontend/src/metabase/metrics-viewer/utils/series.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/series.ts
@@ -40,6 +40,76 @@ import { nextSyntheticCardId, parseSourceId } from "./source-ids";
 import { DISPLAY_TYPE_REGISTRY } from "./tab-config";
 import { getDimensionIcon } from "./tabs";
 
+export function buildArithmeticSeriesFromResult(
+  definitions: MetricsViewerDefinitionEntry[],
+  dimensionMapping: Record<MetricSourceId, DimensionId | null>,
+  display: MetricsViewerDisplayType,
+  arithmeticResult: Dataset,
+  modifiedDefinitions: Map<MetricSourceId, MetricDefinition>,
+  expressionName: string,
+): SingleSeries[] {
+  if (!arithmeticResult.data?.cols?.length) {
+    return [];
+  }
+
+  const firstSettingsEntry = definitions.reduce<{
+    def: MetricDefinition;
+    dimension: DimensionMetadata;
+  } | null>((found, entry) => {
+    if (found) {
+      return found;
+    }
+    const dimensionId = dimensionMapping[entry.id];
+    if (!dimensionId || !entry.definition) {
+      return null;
+    }
+    const dimension = findDimensionById(entry.definition, dimensionId);
+    if (!dimension) {
+      return null;
+    }
+    const def = modifiedDefinitions.get(entry.id);
+    if (!def) {
+      return null;
+    }
+    return { def, dimension };
+  }, null);
+
+  if (!firstSettingsEntry) {
+    return [];
+  }
+
+  const vizSettings = DISPLAY_TYPE_REGISTRY[display].getSettings(
+    firstSettingsEntry.def,
+    firstSettingsEntry.dimension,
+  );
+
+  const cardId = nextSyntheticCardId();
+  const cols = arithmeticResult.data.cols;
+  const metricCol = cols[cols.length - 1];
+  const seriesKey = getSeriesVizSettingsKey(
+    metricCol,
+    false,
+    true,
+    1,
+    null,
+    expressionName,
+  );
+
+  return [
+    {
+      card: createSeriesCard(cardId, expressionName, display, {
+        ...vizSettings,
+        ...computeColorVizSettings({
+          displayType: display,
+          seriesKey,
+          color: undefined,
+        }),
+      }),
+      data: arithmeticResult.data,
+    },
+  ];
+}
+
 function getDefinitionCardId(def: MetricDefinition): number | null {
   const metricId = LibMetric.sourceMetricId(def);
   if (metricId != null) {

--- a/frontend/src/metabase/metrics-viewer/utils/source-ids.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/source-ids.ts
@@ -10,6 +10,10 @@ export function createMeasureSourceId(measureId: MeasureId): MetricSourceId {
   return `measure:${measureId}`;
 }
 
+export function createAdhocSourceId(uuid: string): MetricSourceId {
+  return `adhoc:${uuid}`;
+}
+
 export function createSourceId(
   id: number,
   sourceType: "metric" | "measure",
@@ -19,23 +23,45 @@ export function createSourceId(
     : createMeasureSourceId(id);
 }
 
-export function parseSourceId(sourceId: MetricSourceId): {
-  type: "metric" | "measure";
-  id: number;
-} {
-  const [type, idStr] = sourceId.split(":");
+export type ParsedSourceId =
+  | { type: "metric"; id: number }
+  | { type: "measure"; id: number }
+  | { type: "adhoc"; uuid: string };
+
+export function parseSourceId(sourceId: MetricSourceId): ParsedSourceId {
+  const colonIdx = sourceId.indexOf(":");
+  const type = sourceId.slice(0, colonIdx);
+  const rest = sourceId.slice(colonIdx + 1);
+
+  if (type === "adhoc") {
+    return { type: "adhoc", uuid: rest };
+  }
+
   if (type !== "metric" && type !== "measure") {
     throw new Error(`Invalid source ID format: ${sourceId}`);
   }
-  const id = Number(idStr);
+  const id = Number(rest);
   if (Number.isNaN(id)) {
     throw new Error(`Invalid source ID format: ${sourceId}`);
   }
   return { type, id };
 }
 
-export function getSourceIcon(sourceId: MetricSourceId): "metric" | "ruler" {
-  return parseSourceId(sourceId).type === "metric" ? "metric" : "ruler";
+export function isAdhocSourceId(sourceId: MetricSourceId): boolean {
+  return sourceId.startsWith("adhoc:");
+}
+
+export function getSourceIcon(
+  sourceId: MetricSourceId,
+): "metric" | "ruler" | "sum" {
+  const parsed = parseSourceId(sourceId);
+  if (parsed.type === "metric") {
+    return "metric";
+  }
+  if (parsed.type === "adhoc") {
+    return "sum";
+  }
+  return "ruler";
 }
 
 let syntheticCardIdCounter = -1;

--- a/frontend/src/metabase/metrics-viewer/utils/source-ids.unit.spec.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/source-ids.unit.spec.ts
@@ -1,8 +1,10 @@
 import {
+  createAdhocSourceId,
   createMeasureSourceId,
   createMetricSourceId,
   createSourceId,
   getSourceIcon,
+  isAdhocSourceId,
   nextSyntheticCardId,
   parseSourceId,
 } from "./source-ids";
@@ -31,6 +33,12 @@ describe("createSourceId", () => {
   });
 });
 
+describe("createAdhocSourceId", () => {
+  it("creates an adhoc source ID", () => {
+    expect(createAdhocSourceId("abc-123")).toBe("adhoc:abc-123");
+  });
+});
+
 describe("parseSourceId", () => {
   it("parses a metric source ID", () => {
     expect(parseSourceId("metric:1")).toEqual({ type: "metric", id: 1 });
@@ -38,6 +46,13 @@ describe("parseSourceId", () => {
 
   it("parses a measure source ID", () => {
     expect(parseSourceId("measure:5")).toEqual({ type: "measure", id: 5 });
+  });
+
+  it("parses an adhoc source ID", () => {
+    expect(parseSourceId("adhoc:abc-123" as any)).toEqual({
+      type: "adhoc",
+      uuid: "abc-123",
+    });
   });
 });
 
@@ -50,6 +65,21 @@ describe("getSourceIcon", () => {
   it('returns "ruler" icon for measure source IDs', () => {
     expect(getSourceIcon("measure:5")).toBe("ruler");
     expect(getSourceIcon("measure:42")).toBe("ruler");
+  });
+
+  it('returns "sum" icon for adhoc source IDs', () => {
+    expect(getSourceIcon("adhoc:abc-123" as any)).toBe("sum");
+  });
+});
+
+describe("isAdhocSourceId", () => {
+  it("returns true for adhoc source IDs", () => {
+    expect(isAdhocSourceId("adhoc:abc-123" as any)).toBe(true);
+  });
+
+  it("returns false for metric/measure source IDs", () => {
+    expect(isAdhocSourceId("metric:1")).toBe(false);
+    expect(isAdhocSourceId("measure:5")).toBe(false);
   });
 });
 

--- a/frontend/src/metabase/metrics-viewer/utils/url-serialization.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/url-serialization.ts
@@ -4,6 +4,7 @@ import type { MetricDefinition } from "metabase-lib/metric";
 import * as LibMetric from "metabase-lib/metric";
 import type { TemporalUnit } from "metabase-types/api";
 
+import type { ExpressionToken, MathOperator } from "../types/operators";
 import type {
   MetricSourceId,
   MetricsViewerDisplayType,
@@ -37,6 +38,12 @@ function reviveFilter(filter: DimensionFilterValue): DimensionFilterValue {
 }
 
 // ── Serialized types (internal, URL-facing) ──
+
+interface SerializedExpressionToken {
+  type: "metric" | "operator" | "open-paren" | "close-paren";
+  metricIndex?: number;
+  op?: MathOperator;
+}
 
 interface SerializedUrlFilter {
   dimensionId: string;
@@ -76,6 +83,37 @@ export interface SerializedMetricsViewerPageState {
   sources: SerializedSource[];
   tabs: SerializedTab[];
   selectedTabId: string | null;
+  expression: SerializedExpressionToken[];
+}
+
+// ── Expression token helpers ──
+
+function serializeToken(token: ExpressionToken): SerializedExpressionToken {
+  if (token.type === "metric") {
+    return { type: "metric", metricIndex: token.metricIndex };
+  }
+  if (token.type === "operator") {
+    return { type: "operator", op: token.op };
+  }
+  return { type: token.type };
+}
+
+export function deserializeExpression(
+  tokens: SerializedExpressionToken[],
+): ExpressionToken[] {
+  const result: ExpressionToken[] = [];
+  for (const token of tokens) {
+    if (token.type === "metric" && token.metricIndex !== undefined) {
+      result.push({ type: "metric", metricIndex: token.metricIndex });
+    } else if (token.type === "operator" && token.op) {
+      result.push({ type: "operator", op: token.op });
+    } else if (token.type === "open-paren") {
+      result.push({ type: "open-paren" });
+    } else if (token.type === "close-paren") {
+      result.push({ type: "close-paren" });
+    }
+  }
+  return result;
 }
 
 // ── Conversion functions ──
@@ -145,8 +183,10 @@ export function deserializeTab(
 
 export function stateToSerializedState(
   state: MetricsViewerPageState,
+  tokens: ExpressionToken[] = [],
 ): SerializedMetricsViewerPageState {
   return {
+    expression: tokens.map(serializeToken),
     sources: state.definitions.flatMap((entry) => {
       if (!entry.definition) {
         return [];
@@ -215,6 +255,12 @@ export function stateToSerializedState(
 
 // ── Compact schemas ──
 
+const expressionTokenSchema = defineCompactSchema<SerializedExpressionToken>({
+  type: "t",
+  metricIndex: { key: "i", optional: true },
+  op: { key: "o", optional: true },
+});
+
 const sourceFilterSchema = defineCompactSchema<SerializedUrlFilter>({
   dimensionId: "d",
   value: { key: "v" },
@@ -257,12 +303,13 @@ const rootSchema = defineCompactSchema<SerializedMetricsViewerPageState>({
   sources: { key: "s", schema: sourceSchema, default: [] },
   tabs: { key: "t", schema: tabSchema, default: [] },
   selectedTabId: { key: "a", default: null },
+  expression: { key: "e", schema: expressionTokenSchema, default: [] },
 });
 
 // ── Encode / decode ──
 
 function emptyState(): SerializedMetricsViewerPageState {
-  return { sources: [], tabs: [], selectedTabId: null };
+  return { sources: [], tabs: [], selectedTabId: null, expression: [] };
 }
 
 // After JSON.parse, Date values are ISO strings. Walk the decoded state and revive them.

--- a/frontend/src/metabase/metrics-viewer/utils/url-serialization.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/url-serialization.ts
@@ -40,7 +40,13 @@ function reviveFilter(filter: DimensionFilterValue): DimensionFilterValue {
 // ── Serialized types (internal, URL-facing) ──
 
 interface SerializedExpressionToken {
-  type: "metric" | "constant" | "operator" | "open-paren" | "close-paren";
+  type:
+    | "metric"
+    | "constant"
+    | "operator"
+    | "open-paren"
+    | "close-paren"
+    | "separator";
   metricIndex?: number;
   op?: MathOperator;
   value?: number;
@@ -117,6 +123,8 @@ export function deserializeExpression(
       result.push({ type: "open-paren" });
     } else if (token.type === "close-paren") {
       result.push({ type: "close-paren" });
+    } else if (token.type === "separator") {
+      result.push({ type: "separator" });
     }
   }
   return result;

--- a/frontend/src/metabase/metrics-viewer/utils/url-serialization.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/url-serialization.ts
@@ -40,9 +40,10 @@ function reviveFilter(filter: DimensionFilterValue): DimensionFilterValue {
 // ── Serialized types (internal, URL-facing) ──
 
 interface SerializedExpressionToken {
-  type: "metric" | "operator" | "open-paren" | "close-paren";
+  type: "metric" | "constant" | "operator" | "open-paren" | "close-paren";
   metricIndex?: number;
   op?: MathOperator;
+  value?: number;
 }
 
 interface SerializedUrlFilter {
@@ -92,6 +93,9 @@ function serializeToken(token: ExpressionToken): SerializedExpressionToken {
   if (token.type === "metric") {
     return { type: "metric", metricIndex: token.metricIndex };
   }
+  if (token.type === "constant") {
+    return { type: "constant", value: token.value };
+  }
   if (token.type === "operator") {
     return { type: "operator", op: token.op };
   }
@@ -105,6 +109,8 @@ export function deserializeExpression(
   for (const token of tokens) {
     if (token.type === "metric" && token.metricIndex !== undefined) {
       result.push({ type: "metric", metricIndex: token.metricIndex });
+    } else if (token.type === "constant" && token.value !== undefined) {
+      result.push({ type: "constant", value: token.value });
     } else if (token.type === "operator" && token.op) {
       result.push({ type: "operator", op: token.op });
     } else if (token.type === "open-paren") {
@@ -259,6 +265,7 @@ const expressionTokenSchema = defineCompactSchema<SerializedExpressionToken>({
   type: "t",
   metricIndex: { key: "i", optional: true },
   op: { key: "o", optional: true },
+  value: { key: "v", optional: true },
 });
 
 const sourceFilterSchema = defineCompactSchema<SerializedUrlFilter>({

--- a/frontend/src/metabase/metrics-viewer/utils/url-serialization.unit.spec.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/url-serialization.unit.spec.ts
@@ -2,6 +2,7 @@ import type { DimensionFilterValue } from "./dimension-filters";
 import {
   type SerializedMetricsViewerPageState,
   decodeState,
+  deserializeExpression,
   encodeState,
 } from "./url-serialization";
 
@@ -36,6 +37,7 @@ describe("url-serialization", () => {
           },
         ],
         selectedTabId: "tab-1",
+        expression: [],
       };
 
       const hash = encodeStateOrThrow(state);
@@ -55,6 +57,7 @@ describe("url-serialization", () => {
         ],
         tabs: [],
         selectedTabId: null,
+        expression: [],
       };
 
       const hash = encodeStateOrThrow(state);
@@ -74,6 +77,7 @@ describe("url-serialization", () => {
         ],
         tabs: [],
         selectedTabId: null,
+        expression: [],
       };
 
       const hash = encodeStateOrThrow(state);
@@ -94,6 +98,7 @@ describe("url-serialization", () => {
         ],
         tabs: [],
         selectedTabId: null,
+        expression: [],
       };
 
       const hash = encodeStateOrThrow(state);
@@ -106,6 +111,7 @@ describe("url-serialization", () => {
         sources: [],
         tabs: [],
         selectedTabId: null,
+        expression: [],
       };
 
       const hash = encodeStateOrThrow(state);
@@ -134,6 +140,78 @@ describe("url-serialization", () => {
         ],
         tabs: [],
         selectedTabId: null,
+        expression: [],
+      };
+
+      const hash = encodeStateOrThrow(state);
+      const decoded = decodeState(hash);
+      expect(decoded).toEqual(state);
+    });
+
+    it("round-trips a non-empty expression", () => {
+      const state: SerializedMetricsViewerPageState = {
+        sources: [
+          { type: "metric", id: 1 },
+          { type: "metric", id: 2 },
+        ],
+        tabs: [],
+        selectedTabId: null,
+        expression: [
+          { type: "metric", metricIndex: 0 },
+          { type: "operator", op: "+" },
+          { type: "metric", metricIndex: 1 },
+        ],
+      };
+
+      const hash = encodeStateOrThrow(state);
+      const decoded = decodeState(hash);
+      expect(decoded).toEqual(state);
+    });
+
+    it("round-trips an expression with parentheses", () => {
+      const state: SerializedMetricsViewerPageState = {
+        sources: [
+          { type: "metric", id: 1 },
+          { type: "metric", id: 2 },
+          { type: "metric", id: 3 },
+        ],
+        tabs: [],
+        selectedTabId: null,
+        expression: [
+          { type: "open-paren" },
+          { type: "metric", metricIndex: 0 },
+          { type: "operator", op: "+" },
+          { type: "metric", metricIndex: 1 },
+          { type: "close-paren" },
+          { type: "operator", op: "*" },
+          { type: "metric", metricIndex: 2 },
+        ],
+      };
+
+      const hash = encodeStateOrThrow(state);
+      const decoded = decodeState(hash);
+      expect(decoded).toEqual(state);
+    });
+
+    it("round-trips an expression with all operator types", () => {
+      const state: SerializedMetricsViewerPageState = {
+        sources: [
+          { type: "metric", id: 1 },
+          { type: "metric", id: 2 },
+          { type: "metric", id: 3 },
+          { type: "metric", id: 4 },
+        ],
+        tabs: [],
+        selectedTabId: null,
+        expression: [
+          { type: "metric", metricIndex: 0 },
+          { type: "operator", op: "+" },
+          { type: "metric", metricIndex: 1 },
+          { type: "operator", op: "-" },
+          { type: "metric", metricIndex: 2 },
+          { type: "operator", op: "*" },
+          { type: "metric", metricIndex: 3 },
+        ],
       };
 
       const hash = encodeStateOrThrow(state);
@@ -148,6 +226,7 @@ describe("url-serialization", () => {
         sources: [],
         tabs: [],
         selectedTabId: null,
+        expression: [],
       });
     });
 
@@ -156,6 +235,7 @@ describe("url-serialization", () => {
         sources: [],
         tabs: [],
         selectedTabId: null,
+        expression: [],
       });
     });
 
@@ -165,6 +245,7 @@ describe("url-serialization", () => {
         sources: [],
         tabs: [],
         selectedTabId: null,
+        expression: [],
       });
     });
 
@@ -189,6 +270,7 @@ describe("url-serialization", () => {
           },
         ],
         selectedTabId: "tab-1",
+        expression: [],
       };
 
       const hash = encodeStateOrThrow(state);
@@ -209,6 +291,7 @@ describe("url-serialization", () => {
           },
         ],
         selectedTabId: null,
+        expression: [],
       };
 
       const hash = encodeStateOrThrow(state);
@@ -229,6 +312,7 @@ describe("url-serialization", () => {
           },
         ],
         selectedTabId: null,
+        expression: [],
       };
 
       const hash = encodeStateOrThrow(state);
@@ -249,6 +333,7 @@ describe("url-serialization", () => {
         ],
         tabs: [],
         selectedTabId: null,
+        expression: [],
       };
       return decodeState(encodeStateOrThrow(state)).sources[0].filters![0]
         .value;
@@ -320,6 +405,7 @@ describe("url-serialization", () => {
         ],
         tabs: [],
         selectedTabId: null,
+        expression: [],
       };
 
       const decoded = decodeState(encodeStateOrThrow(state));
@@ -334,6 +420,55 @@ describe("url-serialization", () => {
       expect(first).not.toBe(second);
       expect(first.sources).not.toBe(second.sources);
       expect(first.tabs).not.toBe(second.tabs);
+    });
+  });
+
+  describe("deserializeExpression", () => {
+    it("returns empty array for empty input", () => {
+      expect(deserializeExpression([])).toEqual([]);
+    });
+
+    it("deserializes metric tokens", () => {
+      expect(
+        deserializeExpression([{ type: "metric", metricIndex: 0 }]),
+      ).toEqual([{ type: "metric", metricIndex: 0 }]);
+    });
+
+    it("deserializes operator tokens", () => {
+      expect(deserializeExpression([{ type: "operator", op: "+" }])).toEqual([
+        { type: "operator", op: "+" },
+      ]);
+    });
+
+    it("deserializes open-paren and close-paren tokens", () => {
+      expect(
+        deserializeExpression([
+          { type: "open-paren" },
+          { type: "close-paren" },
+        ]),
+      ).toEqual([{ type: "open-paren" }, { type: "close-paren" }]);
+    });
+
+    it("skips metric tokens with missing metricIndex", () => {
+      expect(deserializeExpression([{ type: "metric" }])).toEqual([]);
+    });
+
+    it("skips operator tokens with missing op", () => {
+      expect(deserializeExpression([{ type: "operator" }])).toEqual([]);
+    });
+
+    it("deserializes a full expression", () => {
+      expect(
+        deserializeExpression([
+          { type: "metric", metricIndex: 0 },
+          { type: "operator", op: "+" },
+          { type: "metric", metricIndex: 1 },
+        ]),
+      ).toEqual([
+        { type: "metric", metricIndex: 0 },
+        { type: "operator", op: "+" },
+        { type: "metric", metricIndex: 1 },
+      ]);
     });
   });
 });

--- a/frontend/src/metabase/visualizations/shared/settings/pie.ts
+++ b/frontend/src/metabase/visualizations/shared/settings/pie.ts
@@ -209,7 +209,7 @@ export function getColors(
   return Object.fromEntries(
     Object.entries(colors).map(([key, value]) => [
       key === "null" ? NULL_DISPLAY_VALUE : key,
-      getHexColor(value),
+      value,
     ]),
   );
 }

--- a/frontend/src/metabase/visualizations/shared/settings/pie.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/shared/settings/pie.unit.spec.ts
@@ -143,34 +143,4 @@ describe("getColors", () => {
       Widget: "#000000",
     });
   });
-  it("should return hex values for colors", () => {
-    // getPreferredColor returns hsla values for strings like "active"
-    // make sure getColors is correctly converting them to hex values
-    // because hsla is not supported in static-viz
-    const columns = [
-      createMockColumn({ name: "Category" }),
-      createMockColumn({ name: "Count" }),
-    ];
-    const rawSeries = [
-      {
-        data: createMockDatasetData({
-          rows: [
-            ["active", 1],
-            ["other", 2],
-          ],
-          cols: columns,
-        }),
-      },
-    ] as RawSeries;
-    const settings = {
-      "pie.metric": "Count",
-      "pie.dimension": "Category",
-    };
-    const result = getColors(rawSeries, settings);
-    expect(
-      Object.values(result).every(
-        (color) => color.startsWith("#") && color.length === 7,
-      ),
-    ).toBe(true);
-  });
 });

--- a/src/metabase/lib_metric/ast/build.cljc
+++ b/src/metabase/lib_metric/ast/build.cljc
@@ -333,6 +333,13 @@
        (= 3 (count expression))
        (#{:metric :measure} (first expression))))
 
+(defn arithmetic-expression?
+  "Returns true if the expression is an arithmetic node [op opts expr expr ...]."
+  [expression]
+  (and (sequential? expression)
+       (>= (count expression) 4)
+       (operators/arithmetic? (first expression))))
+
 (defn expression-leaf-type
   "Returns :metric or :measure from an expression leaf."
   [expression]
@@ -351,27 +358,15 @@
   (when (expression-leaf? expression)
     (get (second expression) :lib/uuid)))
 
-(defn from-definition
-  "Create complete AST from MetricDefinition.
-   Converts legacy MBQL to pMBQL before processing.
-
-   Metadata is loaded from the provider using the expression leaf's type and ID.
-   Dimensions and dimension-mappings are loaded from the fetched metadata."
-  [definition]
-  (let [{:keys [expression metadata-provider filters projections]} definition
-        leaf-type  (expression-leaf-type expression)
-        leaf-id    (expression-leaf-id expression)
-        leaf-uuid  (expression-leaf-uuid expression)
-        _          (when-not leaf-type
-                     (throw (ex-info "Arithmetic metric math expressions are not yet supported in AST builder"
-                                     {:expression expression})))
-        ;; Load metadata from provider
-        source-type (case leaf-type :metric :source/metric :measure :source/measure)
-        metadata-type (case leaf-type :metric :metadata/metric :measure :metadata/measure)
-        metadata   (first (lib.metadata.protocols/metadatas
-                           metadata-provider
-                           {:lib/type metadata-type :id #{leaf-id}}))
-        ;; Load dimensions/mappings from source metadata
+(defn- build-leaf-ast
+  "Build a complete single-source AST for one expression leaf.
+   Extracted from from-definition for reuse in arithmetic expressions."
+  [leaf-type leaf-id leaf-uuid metadata-provider filters projections]
+  (let [source-type    (case leaf-type :metric :source/metric :measure :source/measure)
+        metadata-type  (case leaf-type :metric :metadata/metric :measure :metadata/measure)
+        metadata       (first (lib.metadata.protocols/metadatas
+                               metadata-provider
+                               {:lib/type metadata-type :id #{leaf-id}}))
         dimensions         (lib-metric.dimension/get-persisted-dimensions metadata)
         dimension-mappings (lib-metric.dimension/get-persisted-dimension-mappings metadata)
         raw-query          (case leaf-type
@@ -390,10 +385,49 @@
         ;; Convert filters and projections to AST nodes
         ast-filter         (when (seq leaf-filters) (mbql-filters->ast-filter leaf-filters))
         ast-group-by       (when (seq leaf-projections) (perf/mapv dimension-ref->ast-dimension-ref leaf-projections))]
-    {:node/type         :ast/root
+    {:node/type         :ast/source-query
      :source            (pmbql-query->source-node source-type leaf-id metadata pmbql-query)
      :dimensions        (perf/mapv dimension-node (or dimensions []))
      :mappings          (perf/mapv dimension-mapping-node (or dimension-mappings []))
      :filter            ast-filter
-     :group-by          (or ast-group-by [])
+     :group-by          (or ast-group-by [])}))
+
+(defn- arithmetic-operator
+  "Returns the arithmetic operator keyword if expression is an arithmetic node, nil otherwise."
+  [expression]
+  (when (arithmetic-expression? expression)
+    (first expression)))
+
+(defn- build-expression-ast
+  "Recursively build expression AST from a metric-math expression tree.
+   For leaves, calls build-leaf-ast and wraps in :expression/leaf.
+   For arithmetic, recursively builds children and wraps in :expression/arithmetic."
+  [expression metadata-provider filters projections]
+  (if-let [leaf-type (expression-leaf-type expression)]
+    (let [leaf-id   (expression-leaf-id expression)
+          leaf-uuid (expression-leaf-uuid expression)
+          sub-ast   (build-leaf-ast leaf-type leaf-id leaf-uuid metadata-provider filters projections)]
+      {:node/type :expression/leaf
+       :uuid      leaf-uuid
+       :ast       sub-ast})
+    (let [op       (arithmetic-operator expression)
+          children (drop 2 expression)]
+      {:node/type :expression/arithmetic
+       :operator  op
+       :children  (perf/mapv #(build-expression-ast % metadata-provider filters projections) children)})))
+
+(defn from-definition
+  "Create complete AST from MetricDefinition.
+   Converts legacy MBQL to pMBQL before processing.
+
+   Metadata is loaded from the provider using the expression leaf's type and ID.
+   Dimensions and dimension-mappings are loaded from the fetched metadata.
+
+   Always produces a unified root shape {:node/type :ast/root, :expression ...}.
+   Single-leaf definitions become a single :expression/leaf node."
+  [definition]
+  (let [{:keys [expression metadata-provider filters projections]} definition
+        expr-ast (build-expression-ast expression metadata-provider filters projections)]
+    {:node/type         :ast/root
+     :expression        expr-ast
      :metadata-provider metadata-provider}))

--- a/src/metabase/lib_metric/ast/build.cljc
+++ b/src/metabase/lib_metric/ast/build.cljc
@@ -327,11 +327,11 @@
 ;;; -------------------- Main Construction --------------------
 
 (defn expression-leaf?
-  "Returns true if the expression is a single leaf node ([:metric opts id] or [:measure opts id])."
+  "Returns true if the expression is a single leaf node ([:metric opts id], [:measure opts id], or [:adhoc opts def])."
   [expression]
   (and (sequential? expression)
        (= 3 (count expression))
-       (#{:metric :measure} (first expression))))
+       (#{:metric :measure :adhoc} (first expression))))
 
 (defn arithmetic-expression?
   "Returns true if the expression is an arithmetic node [op opts expr expr ...]."
@@ -341,22 +341,96 @@
        (operators/arithmetic? (first expression))))
 
 (defn expression-leaf-type
-  "Returns :metric or :measure from an expression leaf."
+  "Returns :metric, :measure, or :adhoc from an expression leaf."
   [expression]
   (when (expression-leaf? expression)
     (first expression)))
 
 (defn expression-leaf-id
-  "Returns the source ID from an expression leaf."
+  "Returns the source ID from an expression leaf.
+   Throws if called on an :adhoc leaf — use [[expression-leaf-definition]] instead."
   [expression]
   (when (expression-leaf? expression)
-    (nth expression 2)))
+    (let [leaf-type (first expression)]
+      (when (= :adhoc leaf-type)
+        (throw (ex-info "expression-leaf-id called on :adhoc leaf; adhoc leaves have no persisted ID"
+                        {:expression expression})))
+      (nth expression 2))))
 
 (defn expression-leaf-uuid
   "Returns the :lib/uuid from an expression leaf."
   [expression]
   (when (expression-leaf? expression)
     (get (second expression) :lib/uuid)))
+
+(defn expression-leaf-definition
+  "Returns the inline definition map from an :adhoc expression leaf, or nil for other leaf types."
+  [expression]
+  (when (and (expression-leaf? expression)
+             (= :adhoc (first expression)))
+    (nth expression 2)))
+
+(defn- adhoc-dimension->dimension-node
+  "Convert an adhoc dimension declaration to a dimension AST node."
+  [{:keys [id display-name effective-type semantic-type]}]
+  (cond-> {:node/type :ast/dimension
+           :id        id}
+    display-name   (assoc :display-name display-name)
+    effective-type (assoc :effective-type effective-type)
+    semantic-type  (assoc :semantic-type semantic-type)
+    true           (assoc :status :status/active)))
+
+(defn- adhoc-dimension->mapping-node
+  "Convert an adhoc dimension declaration to a dimension mapping AST node."
+  [{:keys [id field-ref]}]
+  (let [[_field opts field-id] field-ref
+        source-field (:source-field opts)
+        table-id     (:table-id opts)]
+    {:node/type    :ast/dimension-mapping
+     :dimension-id id
+     :table-id     table-id
+     :column       (cond-> (column-node field-id nil table-id)
+                     source-field (assoc :source-field source-field))}))
+
+(defn- build-adhoc-leaf-ast
+  "Build a complete single-source AST for an ad-hoc aggregation leaf.
+   Unlike metric/measure leaves, the definition is inline — no metadata fetch needed."
+  [adhoc-def leaf-uuid _metadata-provider filters projections]
+  (let [{:keys [database-id table-id aggregation dimensions]} adhoc-def
+        baked-filter   (:filter adhoc-def)
+        ;; Parse aggregation clause
+        agg-node       (mbql-aggregation->node aggregation)
+        ;; Build source node directly (no pMBQL parsing needed)
+        source-node    (cond-> {:node/type   :source/adhoc
+                                :id          leaf-uuid
+                                :name        nil
+                                :aggregation (or agg-node {:node/type :aggregation/count})
+                                :base-table  (table-node table-id)
+                                :metadata    {:database-id database-id
+                                              :table-id    table-id
+                                              :definition  {:database database-id}}}
+                         baked-filter (assoc :filters (mbql-clause->filter-mbql-node baked-filter)))
+        ;; Convert inline dimensions to AST nodes
+        dim-nodes      (perf/mapv adhoc-dimension->dimension-node (or dimensions []))
+        mapping-nodes  (perf/mapv adhoc-dimension->mapping-node (or dimensions []))
+        ;; Extract instance-filters for this leaf's UUID
+        leaf-filters   (into []
+                             (comp (filter #(= leaf-uuid (:lib/uuid %)))
+                                   (map :filter))
+                             (or filters []))
+        ;; Extract projections for this adhoc leaf (keyed by :type :adhoc, :lib/uuid)
+        leaf-projections (perf/some #(when (and (= :adhoc (:type %)) (= leaf-uuid (:lib/uuid %)))
+                                       (:projection %))
+                                    (or projections []))
+        ;; Convert to AST nodes
+        ast-filter     (when (seq leaf-filters) (mbql-filters->ast-filter leaf-filters))
+        ast-group-by   (when (seq leaf-projections) (perf/mapv dimension-ref->ast-dimension-ref leaf-projections))]
+    {:node/type         :ast/source-query
+     :source            source-node
+     :dimensions        dim-nodes
+     :mappings          mapping-nodes
+     :filter            ast-filter
+     :group-by          (or ast-group-by [])}))
 
 (defn- build-leaf-ast
   "Build a complete single-source AST for one expression leaf.
@@ -401,7 +475,7 @@
 (defn- build-expression-ast
   "Recursively build expression AST from a metric-math expression tree.
    For numeric constants, produces :expression/constant.
-   For leaves, calls build-leaf-ast and wraps in :expression/leaf.
+   For leaves, calls build-leaf-ast (or build-adhoc-leaf-ast) and wraps in :expression/leaf.
    For arithmetic, recursively builds children and wraps in :expression/arithmetic."
   [expression metadata-provider filters projections]
   (cond
@@ -410,9 +484,12 @@
 
     (expression-leaf-type expression)
     (let [leaf-type (expression-leaf-type expression)
-          leaf-id   (expression-leaf-id expression)
           leaf-uuid (expression-leaf-uuid expression)
-          sub-ast   (build-leaf-ast leaf-type leaf-id leaf-uuid metadata-provider filters projections)]
+          sub-ast   (if (= :adhoc leaf-type)
+                      (build-adhoc-leaf-ast (expression-leaf-definition expression)
+                                            leaf-uuid metadata-provider filters projections)
+                      (let [leaf-id (expression-leaf-id expression)]
+                        (build-leaf-ast leaf-type leaf-id leaf-uuid metadata-provider filters projections)))]
       {:node/type :expression/leaf
        :uuid      leaf-uuid
        :ast       sub-ast})

--- a/src/metabase/lib_metric/ast/build.cljc
+++ b/src/metabase/lib_metric/ast/build.cljc
@@ -400,16 +400,24 @@
 
 (defn- build-expression-ast
   "Recursively build expression AST from a metric-math expression tree.
+   For numeric constants, produces :expression/constant.
    For leaves, calls build-leaf-ast and wraps in :expression/leaf.
    For arithmetic, recursively builds children and wraps in :expression/arithmetic."
   [expression metadata-provider filters projections]
-  (if-let [leaf-type (expression-leaf-type expression)]
-    (let [leaf-id   (expression-leaf-id expression)
+  (cond
+    (number? expression)
+    {:node/type :expression/constant :value expression}
+
+    (expression-leaf-type expression)
+    (let [leaf-type (expression-leaf-type expression)
+          leaf-id   (expression-leaf-id expression)
           leaf-uuid (expression-leaf-uuid expression)
           sub-ast   (build-leaf-ast leaf-type leaf-id leaf-uuid metadata-provider filters projections)]
       {:node/type :expression/leaf
        :uuid      leaf-uuid
        :ast       sub-ast})
+
+    :else
     (let [op       (arithmetic-operator expression)
           children (drop 2 expression)]
       {:node/type :expression/arithmetic

--- a/src/metabase/lib_metric/ast/compile.cljc
+++ b/src/metabase/lib_metric/ast/compile.cljc
@@ -234,7 +234,7 @@
      :stages   [stage-0 stage-1]}))
 
 (mu/defn compile-to-mbql
-  "Compile AST to MBQL query.
+  "Compile a source-query to MBQL query.
 
    Generates a two-stage query when the source has joins:
    - Stage 0: Data model (base table + joins + source filters)
@@ -242,11 +242,11 @@
 
    Options:
    - :limit - add limit to query"
-  [{:keys [source] :as ast} :- ::ast.schema/ast
+  [{:keys [source] :as source-query} :- ::ast.schema/source-query
    & {:as opts}]
   (if (has-joins? source)
-    (compile-two-stage-query ast opts)
-    (compile-single-stage-query ast opts)))
+    (compile-two-stage-query source-query opts)
+    (compile-single-stage-query source-query opts)))
 
 ;;; -------------------- Values Query Compilation (no aggregation) --------------------
 
@@ -297,15 +297,15 @@
      :stages   [stage-0 stage-1]}))
 
 (mu/defn compile-to-values-query
-  "Compile AST to MBQL query for fetching distinct values (no aggregation).
+  "Compile a source-query to MBQL query for fetching distinct values (no aggregation).
 
    Like [[compile-to-mbql]] but omits the aggregation clause, producing a query
    that returns distinct breakout values instead of aggregated results.
 
    Options:
    - :limit - add limit to query"
-  [{:keys [source] :as ast} :- ::ast.schema/ast
+  [{:keys [source] :as source-query} :- ::ast.schema/source-query
    & {:as opts}]
   (if (has-joins? source)
-    (compile-two-stage-values-query ast opts)
-    (compile-single-stage-values-query ast opts)))
+    (compile-two-stage-values-query source-query opts)
+    (compile-single-stage-values-query source-query opts)))

--- a/src/metabase/lib_metric/ast/compile.cljc
+++ b/src/metabase/lib_metric/ast/compile.cljc
@@ -157,6 +157,8 @@
      (perf/get-in metadata [:dataset-query :database])
      ;; From measure definition
      (perf/get-in metadata [:definition :database])
+     ;; From adhoc definition (stored directly)
+     (:database-id metadata)
      (throw (ex-info "Cannot determine database ID for metric source"
                      {:source-metadata metadata})))))
 

--- a/src/metabase/lib_metric/ast/plan.cljc
+++ b/src/metabase/lib_metric/ast/plan.cljc
@@ -6,7 +6,8 @@
    [clojure.set :as set]
    [metabase.lib-metric.ast.compile :as ast.compile]
    [metabase.lib-metric.ast.walk :as ast.walk]
-   [metabase.lib-metric.operators :as operators]))
+   [metabase.lib-metric.operators :as operators]
+   [metabase.util.performance :as perf]))
 
 ;;; -------------------- Plan Data Structures --------------------
 ;;;
@@ -30,7 +31,7 @@
   [dim-ref sub-ast]
   (let [dim-id      (:dimension-id dim-ref)
         ;; Look up the dimension node to get effective-type
-        dim-node    (some #(when (= dim-id (:id %)) %) (:dimensions sub-ast))
+        dim-node    (perf/some #(when (= dim-id (:id %)) %) (:dimensions sub-ast))
         ;; Get bucketing/binning from the ref options
         ref-options (:options dim-ref)]
     {:effective-type (:effective-type dim-node)
@@ -43,14 +44,14 @@
    and :signatures (a vector of dimension signatures in group-by order)."
   [expression-node]
   (let [leaves (ast.walk/collect #(= :expression/leaf (:node/type %)) expression-node)]
-    (mapv (fn [leaf]
-            (let [sub-ast  (:ast leaf)
-                  group-by (:group-by sub-ast)]
-              {:uuid           (:uuid leaf)
-               :has-group-by   (boolean (seq group-by))
-               :breakout-count (count group-by)
-               :signatures     (mapv #(dimension-signature % sub-ast) group-by)}))
-          leaves)))
+    (perf/mapv (fn [leaf]
+                 (let [sub-ast  (:ast leaf)
+                       group-by (:group-by sub-ast)]
+                   {:uuid           (:uuid leaf)
+                    :has-group-by   (boolean (seq group-by))
+                    :breakout-count (count group-by)
+                    :signatures     (perf/mapv #(dimension-signature % sub-ast) group-by)}))
+               leaves)))
 
 (defn- signatures-compatible?
   "Check if two dimension signatures are compatible for joining.
@@ -71,11 +72,11 @@
   "Check that all leaves' signature vectors are pairwise compatible at each position."
   [sig-vecs]
   (let [positions (count (first sig-vecs))]
-    (every? (fn [pos]
-              (let [sigs-at-pos (map #(nth % pos) sig-vecs)]
-                (every? #(signatures-compatible? (first sigs-at-pos) %)
-                        (rest sigs-at-pos))))
-            (range positions))))
+    (perf/every? (fn [pos]
+                   (let [sigs-at-pos (map #(nth % pos) sig-vecs)]
+                     (perf/every? #(signatures-compatible? (first sigs-at-pos) %)
+                                  (rest sigs-at-pos))))
+                 (range positions))))
 
 (defn validate-arithmetic-ast!
   "Validate that an arithmetic expression AST has consistent group-by dimensions.
@@ -85,7 +86,7 @@
    Throws ex-info with :status-code 400 on validation failure."
   [expression-node]
   (let [leaf-infos (collect-leaf-group-bys expression-node)]
-    (when (some #(not (:has-group-by %)) leaf-infos)
+    (when (perf/some #(not (:has-group-by %)) leaf-infos)
       (throw (ex-info "Arithmetic expressions require projections (group-by) on all leaves"
                       {:status-code 400
                        :leaves-missing-projections
@@ -167,12 +168,12 @@
 
     :expression/arithmetic
     (let [{:keys [operator children]} expression-node
-          child-vals (mapv #(evaluate-expression % uuid->value) children)]
-      (when (every? some? child-vals)
+          child-vals (perf/mapv #(evaluate-expression % uuid->value) children)]
+      (when (perf/every? some? child-vals)
         (let [f              (operators/eval-fn operator)
               [init & rest-vals] child-vals]
           (when-not (and (operators/zero-guard? operator)
-                         (some zero? rest-vals))
+                         (perf/some zero? rest-vals))
             (reduce f init rest-vals)))))))
 
 ;;; -------------------- Result Joining --------------------
@@ -181,7 +182,7 @@
   "Index QP result rows as {dim-value-tuple -> agg-value}.
    The first `breakout-count` columns are dimension values, the rest is the aggregate."
   [result breakout-count]
-  (let [rows (get-in result [:data :rows])]
+  (let [rows (perf/get-in result [:data :rows])]
     (into {}
           (map (fn [row]
                  [(vec (take breakout-count row))
@@ -217,7 +218,7 @@
                    (sort all-dim-tuples))
         ;; Build column metadata from the first leaf's result
         first-result     (val (first leaf-results))
-        source-cols      (get-in first-result [:data :cols])
+        source-cols      (perf/get-in first-result [:data :cols])
         breakout-cols    (vec (take breakout-count source-cols))
         ;; Use the last col (aggregate) with a generic name for the computed result
         agg-col          (-> (last source-cols)

--- a/src/metabase/lib_metric/ast/plan.cljc
+++ b/src/metabase/lib_metric/ast/plan.cljc
@@ -1,0 +1,224 @@
+(ns metabase.lib-metric.ast.plan
+  "Query planning and execution for metric ASTs.
+   Takes an AST (from ast.build/from-definition) and produces a query plan
+   that can be compiled and executed."
+  (:require
+   [clojure.set :as set]
+   [metabase.lib-metric.ast.compile :as ast.compile]
+   [metabase.lib-metric.ast.walk :as ast.walk]
+   [metabase.lib-metric.operators :as operators]))
+
+;;; -------------------- Plan Data Structures --------------------
+;;;
+;;; Leaf plan (single-source, pass-through):
+;;;   {:plan/type  :leaf
+;;;    :plan/mbql  <compiled-mbql-query>}
+;;;
+;;; Arithmetic plan (multi-query):
+;;;   {:plan/type           :arithmetic
+;;;    :plan/expression     <expression-node from AST>
+;;;    :plan/leaves         {"uuid-a" {:leaf/uuid "a" :leaf/mbql <mbql>} ...}
+;;;    :plan/breakout-count 2
+;;;    :plan/limit          10000}
+
+;;; -------------------- Validation --------------------
+
+(defn- dimension-signature
+  "Build a signature for a group-by dimension ref that captures its type compatibility.
+   Two dimensions are compatible for joining if they have the same effective type
+   and the same bucketing/binning options."
+  [dim-ref sub-ast]
+  (let [dim-id      (:dimension-id dim-ref)
+        ;; Look up the dimension node to get effective-type
+        dim-node    (some #(when (= dim-id (:id %)) %) (:dimensions sub-ast))
+        ;; Get bucketing/binning from the ref options
+        ref-options (:options dim-ref)]
+    {:effective-type (:effective-type dim-node)
+     :temporal-unit  (:temporal-unit ref-options)
+     :binning        (:binning ref-options)}))
+
+(defn- collect-leaf-group-bys
+  "Collect group-by info from all expression leaves in an expression AST.
+   Returns a vector of maps with :uuid, :has-group-by, :breakout-count,
+   and :signatures (a vector of dimension signatures in group-by order)."
+  [expression-node]
+  (let [leaves (ast.walk/collect #(= :expression/leaf (:node/type %)) expression-node)]
+    (mapv (fn [leaf]
+            (let [sub-ast  (:ast leaf)
+                  group-by (:group-by sub-ast)]
+              {:uuid           (:uuid leaf)
+               :has-group-by   (boolean (seq group-by))
+               :breakout-count (count group-by)
+               :signatures     (mapv #(dimension-signature % sub-ast) group-by)}))
+          leaves)))
+
+(defn- signatures-compatible?
+  "Check if two dimension signatures are compatible for joining.
+   nil values are treated as unknown and compatible with any known value.
+   Only rejects when both sides have known but different values."
+  [sig-a sig-b]
+  (and (or (nil? (:effective-type sig-a))
+           (nil? (:effective-type sig-b))
+           (= (:effective-type sig-a) (:effective-type sig-b)))
+       (or (nil? (:temporal-unit sig-a))
+           (nil? (:temporal-unit sig-b))
+           (= (:temporal-unit sig-a) (:temporal-unit sig-b)))
+       (or (nil? (:binning sig-a))
+           (nil? (:binning sig-b))
+           (= (:binning sig-a) (:binning sig-b)))))
+
+(defn- all-signatures-compatible?
+  "Check that all leaves' signature vectors are pairwise compatible at each position."
+  [sig-vecs]
+  (let [positions (count (first sig-vecs))]
+    (every? (fn [pos]
+              (let [sigs-at-pos (map #(nth % pos) sig-vecs)]
+                (every? #(signatures-compatible? (first sigs-at-pos) %)
+                        (rest sigs-at-pos))))
+            (range positions))))
+
+(defn validate-arithmetic-ast!
+  "Validate that an arithmetic expression AST has consistent group-by dimensions.
+   All leaves must have group-by projections, and the breakout dimensions must be
+   type-compatible (same effective type, temporal unit, and binning) across all leaves.
+   nil values are treated as unknown and compatible with any known value.
+   Throws ex-info with :status-code 400 on validation failure."
+  [expression-node]
+  (let [leaf-infos (collect-leaf-group-bys expression-node)]
+    (when (some #(not (:has-group-by %)) leaf-infos)
+      (throw (ex-info "Arithmetic expressions require projections (group-by) on all leaves"
+                      {:status-code 400
+                       :leaves-missing-projections
+                       (into [] (comp (remove :has-group-by) (map :uuid)) leaf-infos)})))
+    (let [breakout-counts (map :breakout-count leaf-infos)]
+      (when-not (apply = breakout-counts)
+        (throw (ex-info "All leaves in arithmetic expression must have the same number of breakout dimensions"
+                        {:status-code 400
+                         :breakout-counts (zipmap (map :uuid leaf-infos) breakout-counts)}))))
+    (let [sig-vecs (map :signatures leaf-infos)]
+      (when-not (all-signatures-compatible? sig-vecs)
+        (throw (ex-info "All leaves in arithmetic expression must have the same breakout dimension types and bucketing"
+                        {:status-code 400
+                         :signatures (zipmap (map :uuid leaf-infos) sig-vecs)}))))))
+
+;;; -------------------- Plan Construction --------------------
+
+(defn- compile-leaf-queries
+  "Walk the expression AST, compile each leaf's sub-AST to MBQL.
+   Returns a map of {uuid -> {:leaf/uuid uuid :leaf/mbql mbql}}."
+  [expression-node opts]
+  (let [leaves (ast.walk/collect #(= :expression/leaf (:node/type %)) expression-node)]
+    (into {}
+          (map (fn [leaf]
+                 (let [uuid (:uuid leaf)
+                       mbql (if-let [limit (:limit opts)]
+                              (ast.compile/compile-to-mbql (:ast leaf) :limit limit)
+                              (ast.compile/compile-to-mbql (:ast leaf)))]
+                   [uuid {:leaf/uuid uuid :leaf/mbql mbql}])))
+          leaves)))
+
+(defn- single-leaf?
+  "Returns true if the expression is a single leaf (no arithmetic operator)."
+  [expression-node]
+  (= :expression/leaf (:node/type expression-node)))
+
+(defn plan-from-ast
+  "Take a complete AST (from from-definition) and produce a query plan.
+   Single-leaf expressions produce a :leaf plan.
+   Arithmetic expressions validate and produce an :arithmetic plan.
+
+   Options:
+   - :limit - add limit to compiled queries
+   - :values-only - if true, compile as values query (no aggregation, for breakout values)"
+  [ast & {:as opts}]
+  (let [expression (:expression ast)
+        compile-fn (if (:values-only opts) ast.compile/compile-to-values-query ast.compile/compile-to-mbql)]
+    (if (single-leaf? expression)
+      ;; Single leaf — compile the sub-AST directly
+      {:plan/type :leaf
+       :plan/mbql (if-let [limit (:limit opts)]
+                    (compile-fn (:ast expression) :limit limit)
+                    (compile-fn (:ast expression)))}
+      ;; Arithmetic — validate and compile each leaf
+      (do
+        (validate-arithmetic-ast! expression)
+        (let [leaf-infos  (collect-leaf-group-bys expression)
+              breakout-ct (:breakout-count (first leaf-infos))
+              leaves      (compile-leaf-queries expression opts)]
+          {:plan/type           :arithmetic
+           :plan/expression     expression
+           :plan/leaves         leaves
+           :plan/breakout-count breakout-ct
+           :plan/limit          (:limit opts)})))))
+
+;;; -------------------- Expression Evaluation --------------------
+
+(defn evaluate-expression
+  "Recursively evaluate an expression AST node given {uuid -> numeric-value}.
+   Returns nil on nil inputs or division by zero.
+   Operator behavior is driven by metadata in [[operators/operator-metadata]]."
+  [expression-node uuid->value]
+  (case (:node/type expression-node)
+    :expression/leaf
+    (get uuid->value (:uuid expression-node))
+
+    :expression/arithmetic
+    (let [{:keys [operator children]} expression-node
+          child-vals (mapv #(evaluate-expression % uuid->value) children)]
+      (when (every? some? child-vals)
+        (let [f              (operators/eval-fn operator)
+              [init & rest-vals] child-vals]
+          (when-not (and (operators/zero-guard? operator)
+                         (some zero? rest-vals))
+            (reduce f init rest-vals)))))))
+
+;;; -------------------- Result Joining --------------------
+
+(defn index-result-by-dimensions
+  "Index QP result rows as {dim-value-tuple -> agg-value}.
+   The first `breakout-count` columns are dimension values, the rest is the aggregate."
+  [result breakout-count]
+  (let [rows (get-in result [:data :rows])]
+    (into {}
+          (map (fn [row]
+                 [(vec (take breakout-count row))
+                  (nth row breakout-count)]))
+          rows)))
+
+(defn join-and-compute
+  "Inner-join all leaf results on dimension tuples, evaluate expression per row.
+   Returns {:cols [...] :rows [...]}."
+  [expression-node leaf-results breakout-count]
+  (let [;; Index each leaf's results by dimension tuple
+        uuid->indexed (into {}
+                            (map (fn [[uuid result]]
+                                   [uuid (index-result-by-dimensions result breakout-count)]))
+                            leaf-results)
+        ;; Find dimension tuples present in ALL leaves (inner join)
+        all-dim-tuples (reduce (fn [acc [_uuid indexed]]
+                                 (if (nil? acc)
+                                   (set (keys indexed))
+                                   (set/intersection acc (set (keys indexed)))))
+                               nil
+                               uuid->indexed)
+        ;; Compute expression for each joined row
+        rows (into []
+                   (keep (fn [dim-tuple]
+                           (let [uuid->val (into {}
+                                                 (map (fn [[uuid indexed]]
+                                                        [uuid (get indexed dim-tuple)]))
+                                                 uuid->indexed)
+                                 result    (evaluate-expression expression-node uuid->val)]
+                             (when (some? result)
+                               (conj dim-tuple result)))))
+                   (sort all-dim-tuples))
+        ;; Build column metadata from the first leaf's result
+        first-result     (val (first leaf-results))
+        source-cols      (get-in first-result [:data :cols])
+        breakout-cols    (vec (take breakout-count source-cols))
+        ;; Use the last col (aggregate) with a generic name for the computed result
+        agg-col          (-> (last source-cols)
+                             (assoc :name "expression" :display_name "Expression"))]
+    {:cols (conj breakout-cols agg-col)
+     :rows rows}))
+

--- a/src/metabase/lib_metric/ast/plan.cljc
+++ b/src/metabase/lib_metric/ast/plan.cljc
@@ -162,6 +162,9 @@
     :expression/leaf
     (get uuid->value (:uuid expression-node))
 
+    :expression/constant
+    (:value expression-node)
+
     :expression/arithmetic
     (let [{:keys [operator children]} expression-node
           child-vals (mapv #(evaluate-expression % uuid->value) children)]

--- a/src/metabase/lib_metric/ast/plan.cljc
+++ b/src/metabase/lib_metric/ast/plan.cljc
@@ -225,4 +225,3 @@
                              (assoc :name "expression" :display_name "Expression"))]
     {:cols (conj breakout-cols agg-col)
      :rows rows}))
-

--- a/src/metabase/lib_metric/ast/schema.cljc
+++ b/src/metabase/lib_metric/ast/schema.cljc
@@ -242,9 +242,22 @@
   "Measure source - contains the measure's definition as AST."
   (source-node-schema :source/measure))
 
+(mr/def ::source-adhoc
+  "Ad-hoc aggregation source - inline definition, no persisted entity.
+   Uses the leaf UUID as :id to ensure uniqueness across multiple adhoc leaves."
+  [:map
+   [:node/type [:= :source/adhoc]]
+   [:id string?]
+   [:name {:optional true} [:maybe string?]]
+   [:aggregation ::aggregation-node]
+   [:base-table ::table-node]
+   [:metadata {:optional true} [:maybe :map]]
+   [:joins {:optional true} [:maybe [:sequential ::join-node]]]
+   [:filters {:optional true} [:maybe [:ref ::filter-node]]]])
+
 (mr/def ::source-node
   "Union of source node types."
-  [:or ::source-metric ::source-measure])
+  [:or ::source-metric ::source-measure ::source-adhoc])
 
 ;;; -------------------- Expression Nodes --------------------
 

--- a/src/metabase/lib_metric/ast/schema.cljc
+++ b/src/metabase/lib_metric/ast/schema.cljc
@@ -266,16 +266,22 @@
    [:uuid string?]
    [:ast ::source-query]])
 
+(mr/def ::expression-constant
+  "A numeric constant in an expression tree."
+  [:map
+   [:node/type [:= :expression/constant]]
+   [:value number?]])
+
 (mr/def ::expression-arithmetic
   "An arithmetic operation over expression children."
   [:map
    [:node/type [:= :expression/arithmetic]]
    [:operator (into [:enum] (operators/arithmetic-operator-keywords))]
-   [:children [:sequential [:or [:ref ::expression-leaf] [:ref ::expression-arithmetic]]]]])
+   [:children [:sequential [:or [:ref ::expression-leaf] [:ref ::expression-arithmetic] [:ref ::expression-constant]]]]])
 
 (mr/def ::expression-node
   "Union of expression node types."
-  [:or ::expression-leaf ::expression-arithmetic])
+  [:or ::expression-leaf ::expression-arithmetic ::expression-constant])
 
 ;;; -------------------- Root Node --------------------
 

--- a/src/metabase/lib_metric/ast/schema.cljc
+++ b/src/metabase/lib_metric/ast/schema.cljc
@@ -3,6 +3,7 @@
    The AST provides an intermediate representation for metric definitions
    that can be walked, transformed, and compiled to MBQL queries."
   (:require
+   [metabase.lib-metric.operators :as operators]
    [metabase.lib-metric.schema :as lib-metric.schema]
    [metabase.util.malli.registry :as mr]))
 
@@ -245,15 +246,43 @@
   "Union of source node types."
   [:or ::source-metric ::source-measure])
 
-;;; -------------------- Root Node --------------------
+;;; -------------------- Expression Nodes --------------------
 
-(mr/def ::ast
-  "Root AST node - the complete metric exploration."
+(mr/def ::source-query
+  "A single-source query node with source, dimensions, mappings, filters, and group-by.
+   Used inside expression leaves as the compilable sub-query."
   [:map
-   [:node/type [:= :ast/root]]
+   [:node/type [:= :ast/source-query]]
    [:source ::source-node]
    [:dimensions [:sequential ::dimension-node]]
    [:mappings [:sequential ::dimension-mapping-node]]
    [:filter {:optional true} [:maybe ::filter-node]]
-   [:group-by {:optional true} [:maybe [:sequential ::dimension-ref-node]]]
+   [:group-by {:optional true} [:maybe [:sequential ::dimension-ref-node]]]])
+
+(mr/def ::expression-leaf
+  "A leaf in an expression tree — wraps a source-query."
+  [:map
+   [:node/type [:= :expression/leaf]]
+   [:uuid string?]
+   [:ast ::source-query]])
+
+(mr/def ::expression-arithmetic
+  "An arithmetic operation over expression children."
+  [:map
+   [:node/type [:= :expression/arithmetic]]
+   [:operator (into [:enum] (operators/arithmetic-operator-keywords))]
+   [:children [:sequential [:or [:ref ::expression-leaf] [:ref ::expression-arithmetic]]]]])
+
+(mr/def ::expression-node
+  "Union of expression node types."
+  [:or ::expression-leaf ::expression-arithmetic])
+
+;;; -------------------- Root Node --------------------
+
+(mr/def ::ast
+  "Root AST node - the complete metric exploration.
+   Always has an :expression tree (single leaf or arithmetic)."
+  [:map
+   [:node/type [:= :ast/root]]
+   [:expression ::expression-node]
    [:metadata-provider {:optional true} [:maybe :some]]])

--- a/src/metabase/lib_metric/ast/type.cljc
+++ b/src/metabase/lib_metric/ast/type.cljc
@@ -15,4 +15,5 @@
       (derive :filter/or  :filter/compound)
       ;; Source nodes
       (derive :source/metric  :source/any)
-      (derive :source/measure :source/any)))
+      (derive :source/measure :source/any)
+      (derive :source/adhoc   :source/any)))

--- a/src/metabase/lib_metric/ast/walk.cljc
+++ b/src/metabase/lib_metric/ast/walk.cljc
@@ -60,7 +60,17 @@
     (:lat-dimension ast) (update :lat-dimension inner)
     (:lon-dimension ast) (update :lon-dimension inner)))
 
-(defmethod walk-node :ast/root
+;; Expression leaf — walk into the nested AST
+(defmethod walk-node :expression/leaf
+  [inner ast]
+  (update ast :ast inner))
+
+;; Expression arithmetic — walk into children
+(defmethod walk-node :expression/arithmetic
+  [inner ast]
+  (update ast :children #(perf/mapv inner %)))
+
+(defmethod walk-node :ast/source-query
   [inner ast]
   (cond-> ast
     (:filter ast)     (update :filter inner)
@@ -68,6 +78,10 @@
     (:group-by ast)   (update :group-by #(perf/mapv inner %))
     (:dimensions ast) (update :dimensions #(perf/mapv inner %))
     (:mappings ast)   (update :mappings #(perf/mapv inner %))))
+
+(defmethod walk-node :ast/root
+  [inner ast]
+  (update ast :expression inner))
 
 (defmethod walk-node :source/any
   [inner ast]

--- a/src/metabase/lib_metric/ast/walk.cljc
+++ b/src/metabase/lib_metric/ast/walk.cljc
@@ -65,6 +65,11 @@
   [inner ast]
   (update ast :ast inner))
 
+;; Expression constant — no children to walk
+(defmethod walk-node :expression/constant
+  [_inner ast]
+  ast)
+
 ;; Expression arithmetic — walk into children
 (defmethod walk-node :expression/arithmetic
   [inner ast]

--- a/src/metabase/lib_metric/core.cljc
+++ b/src/metabase/lib_metric/core.cljc
@@ -46,11 +46,12 @@
      filters
      from-measure-metadata
      from-metric-metadata
+     projection-valid?
      projections
      source-measure-id
      source-metric-id
-     ->mbql-query
-     ->values-query]
+     unprojected-sources
+     ->query-plan]
     [lib-metric.dimension
      dimension
      dimensionable-query

--- a/src/metabase/lib_metric/core.cljc
+++ b/src/metabase/lib_metric/core.cljc
@@ -11,11 +11,11 @@
    or column aliases. Dimension refs `[:dimension {} \"uuid\"]` are resolved to
    concrete field refs when the definition is converted to an executable MBQL query."
   (:require
-   #?@(:clj [[metabase.lib-metric.dimension.jvm :as lib-metric.dimension.jvm]
+   #?@(:clj [[metabase.lib-metric.ast.plan :as ast.plan]
+             [metabase.lib-metric.dimension.jvm :as lib-metric.dimension.jvm]
              [metabase.lib-metric.metadata.jvm :as lib-metric.metadata.jvm]
              [potemkin :as p]]
        :cljs [[metabase.lib-metric.metadata.js :as lib-metric.metadata.js]])
-   [metabase.lib-metric.ast.plan :as ast.plan]
    [metabase.lib-metric.clause :as lib-metric.clause]
    [metabase.lib-metric.definition :as lib-metric.definition]
    [metabase.lib-metric.dimension :as lib-metric.dimension]

--- a/src/metabase/lib_metric/core.cljc
+++ b/src/metabase/lib_metric/core.cljc
@@ -15,6 +15,7 @@
              [metabase.lib-metric.metadata.jvm :as lib-metric.metadata.jvm]
              [potemkin :as p]]
        :cljs [[metabase.lib-metric.metadata.js :as lib-metric.metadata.js]])
+   [metabase.lib-metric.ast.plan :as ast.plan]
    [metabase.lib-metric.clause :as lib-metric.clause]
    [metabase.lib-metric.definition :as lib-metric.definition]
    [metabase.lib-metric.dimension :as lib-metric.dimension]
@@ -38,6 +39,8 @@
      remove-clause
      replace-clause
      swap-clauses]
+    [ast.plan
+     join-and-compute]
     [lib-metric.definition
      expression-leaf-id
      expression-leaf-type

--- a/src/metabase/lib_metric/definition.cljc
+++ b/src/metabase/lib_metric/definition.cljc
@@ -34,11 +34,12 @@
 
 (defn source-type-for-leaf
   "Returns the source type keyword for an expression leaf.
-   :metric -> :source/metric, :measure -> :source/measure."
+   :metric -> :source/metric, :measure -> :source/measure, :adhoc -> :source/adhoc."
   [expression]
   (case (expression-leaf-type expression)
     :metric  :source/metric
     :measure :source/measure
+    :adhoc   :source/adhoc
     nil))
 
 (defn expression-leaves
@@ -101,19 +102,27 @@
     (when (= :measure (expression-leaf-type expr))
       (expression-leaf-id expr))))
 
+(defn- leaf-matches-projection?
+  "Check if a typed-projection matches an expression leaf.
+   For :metric/:measure, matches by type + id.
+   For :adhoc, matches by type + lib/uuid."
+  [leaf tp]
+  (let [leaf-type (expression-leaf-type leaf)]
+    (if (= :adhoc leaf-type)
+      (and (= :adhoc (:type tp))
+           (= (expression-leaf-uuid leaf) (:lib/uuid tp))
+           (seq (:projection tp)))
+      (and (= leaf-type (:type tp))
+           (= (expression-leaf-id leaf) (:id tp))
+           (seq (:projection tp))))))
+
 (defn projection-valid?
   "Returns true when every distinct source leaf in the expression has a non-empty projection defined."
   [definition]
   (let [leaves      (expression-leaves (:expression definition))
         projections (or (:projections definition) [])]
     (perf/every? (fn [leaf]
-                   (let [leaf-type (expression-leaf-type leaf)
-                         leaf-id   (expression-leaf-id leaf)]
-                     (perf/some (fn [tp]
-                                  (and (= leaf-type (:type tp))
-                                       (= leaf-id (:id tp))
-                                       (seq (:projection tp))))
-                                projections)))
+                   (perf/some #(leaf-matches-projection? leaf %) projections))
                  leaves)))
 
 (defn unprojected-sources
@@ -122,13 +131,7 @@
   (let [leaves      (expression-leaves (:expression definition))
         projections (or (:projections definition) [])
         projected?  (fn [leaf]
-                      (let [leaf-type (expression-leaf-type leaf)
-                            leaf-id   (expression-leaf-id leaf)]
-                        (perf/some (fn [tp]
-                                     (and (= leaf-type (:type tp))
-                                          (= leaf-id (:id tp))
-                                          (seq (:projection tp))))
-                                   projections)))]
+                      (perf/some #(leaf-matches-projection? leaf %) projections))]
     (into [] (remove projected?) leaves)))
 
 (defn filters

--- a/src/metabase/lib_metric/definition.cljc
+++ b/src/metabase/lib_metric/definition.cljc
@@ -5,7 +5,8 @@
    [metabase.lib-metric.ast.plan :as ast.plan]
    [metabase.lib-metric.ast.schema :as ast.schema]
    [metabase.lib-metric.schema :as lib-metric.schema]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :as perf]))
 
 (comment ast.schema/keep-me)
 
@@ -105,15 +106,15 @@
   [definition]
   (let [leaves      (expression-leaves (:expression definition))
         projections (or (:projections definition) [])]
-    (every? (fn [leaf]
-              (let [leaf-type (expression-leaf-type leaf)
-                    leaf-id   (expression-leaf-id leaf)]
-                (some (fn [tp]
-                        (and (= leaf-type (:type tp))
-                             (= leaf-id (:id tp))
-                             (seq (:projection tp))))
-                      projections)))
-            leaves)))
+    (perf/every? (fn [leaf]
+                   (let [leaf-type (expression-leaf-type leaf)
+                         leaf-id   (expression-leaf-id leaf)]
+                     (perf/some (fn [tp]
+                                  (and (= leaf-type (:type tp))
+                                       (= leaf-id (:id tp))
+                                       (seq (:projection tp))))
+                                projections)))
+                 leaves)))
 
 (defn unprojected-sources
   "Returns a vector of expression leaves that are missing projections."
@@ -123,11 +124,11 @@
         projected?  (fn [leaf]
                       (let [leaf-type (expression-leaf-type leaf)
                             leaf-id   (expression-leaf-id leaf)]
-                        (some (fn [tp]
-                                (and (= leaf-type (:type tp))
-                                     (= leaf-id (:id tp))
-                                     (seq (:projection tp))))
-                              projections)))]
+                        (perf/some (fn [tp]
+                                     (and (= leaf-type (:type tp))
+                                          (= leaf-id (:id tp))
+                                          (seq (:projection tp))))
+                                   projections)))]
     (into [] (remove projected?) leaves)))
 
 (defn filters

--- a/src/metabase/lib_metric/definition.cljc
+++ b/src/metabase/lib_metric/definition.cljc
@@ -46,6 +46,7 @@
   [expression]
   (cond
     (nil? expression) []
+    (number? expression) []
     (expression-leaf? expression) [expression]
     (arithmetic-expression? expression)
     (into [] (mapcat expression-leaves) (drop 2 expression))

--- a/src/metabase/lib_metric/definition.cljc
+++ b/src/metabase/lib_metric/definition.cljc
@@ -2,7 +2,7 @@
   "Functions for creating and manipulating MetricDefinitions."
   (:require
    [metabase.lib-metric.ast.build :as ast.build]
-   [metabase.lib-metric.ast.compile :as ast.compile]
+   [metabase.lib-metric.ast.plan :as ast.plan]
    [metabase.lib-metric.ast.schema :as ast.schema]
    [metabase.lib-metric.schema :as lib-metric.schema]
    [metabase.util.malli :as mu]))
@@ -14,6 +14,10 @@
 (def expression-leaf?
   "Returns true if the expression is a single leaf node ([:metric opts id] or [:measure opts id])."
   ast.build/expression-leaf?)
+
+(def arithmetic-expression?
+  "Returns true if the expression is an arithmetic node [op opts expr expr ...]."
+  ast.build/arithmetic-expression?)
 
 (def expression-leaf-type
   "Returns the type keyword (:metric or :measure) from an expression leaf."
@@ -43,9 +47,7 @@
   (cond
     (nil? expression) []
     (expression-leaf? expression) [expression]
-    (and (sequential? expression)
-         (#{:+ :- :* :/} (first expression))
-         (>= (count expression) 4))
+    (arithmetic-expression? expression)
     (into [] (mapcat expression-leaves) (drop 2 expression))
     :else (throw (ex-info "Invalid expression: not a leaf or arithmetic node"
                           {:expression expression}))))
@@ -97,6 +99,36 @@
     (when (= :measure (expression-leaf-type expr))
       (expression-leaf-id expr))))
 
+(defn projection-valid?
+  "Returns true when every distinct source leaf in the expression has a non-empty projection defined."
+  [definition]
+  (let [leaves      (expression-leaves (:expression definition))
+        projections (or (:projections definition) [])]
+    (every? (fn [leaf]
+              (let [leaf-type (expression-leaf-type leaf)
+                    leaf-id   (expression-leaf-id leaf)]
+                (some (fn [tp]
+                        (and (= leaf-type (:type tp))
+                             (= leaf-id (:id tp))
+                             (seq (:projection tp))))
+                      projections)))
+            leaves)))
+
+(defn unprojected-sources
+  "Returns a vector of expression leaves that are missing projections."
+  [definition]
+  (let [leaves      (expression-leaves (:expression definition))
+        projections (or (:projections definition) [])
+        projected?  (fn [leaf]
+                      (let [leaf-type (expression-leaf-type leaf)
+                            leaf-id   (expression-leaf-id leaf)]
+                        (some (fn [tp]
+                                (and (= leaf-type (:type tp))
+                                     (= leaf-id (:id tp))
+                                     (seq (:projection tp))))
+                              projections)))]
+    (into [] (remove projected?) leaves)))
+
 (defn filters
   "Get the filter clauses from a metric definition.
    Returns the instance-filters vector."
@@ -116,27 +148,13 @@
   [definition :- ::lib-metric.schema/metric-definition]
   (ast.build/from-definition definition))
 
-(mu/defn ->mbql-query
-  "Convert MetricDefinition to MBQL query via AST."
+(mu/defn ->query-plan
+  "Convert MetricDefinition to a QueryPlan via AST.
+   For single-leaf definitions, returns a :leaf plan with compiled MBQL.
+   For arithmetic expressions, returns an :arithmetic plan with multiple compiled queries."
   ([definition :- ::lib-metric.schema/metric-definition]
-   (->mbql-query definition {}))
+   (->query-plan definition {}))
   ([definition :- ::lib-metric.schema/metric-definition
-    opts :- [:map
-             [:limit {:optional true} [:maybe pos-int?]]]]
+    opts]
    (let [ast (->ast definition)]
-     (if (some? (:limit opts))
-       (ast.compile/compile-to-mbql ast :limit (:limit opts))
-       (ast.compile/compile-to-mbql ast)))))
-
-(mu/defn ->values-query
-  "Convert MetricDefinition to a values-only MBQL query via AST.
-   Like [[->mbql-query]] but omits aggregation, returning distinct breakout values."
-  ([definition :- ::lib-metric.schema/metric-definition]
-   (->values-query definition {}))
-  ([definition :- ::lib-metric.schema/metric-definition
-    opts :- [:map
-             [:limit {:optional true} [:maybe pos-int?]]]]
-   (let [ast (->ast definition)]
-     (if (some? (:limit opts))
-       (ast.compile/compile-to-values-query ast :limit (:limit opts))
-       (ast.compile/compile-to-values-query ast)))))
+     (ast.plan/plan-from-ast ast opts))))

--- a/src/metabase/lib_metric/filter.cljc
+++ b/src/metabase/lib_metric/filter.cljc
@@ -82,10 +82,10 @@
   (let [provider    (:metadata-provider definition)
         expression  (:expression definition)
         leaf-type   (definition/expression-leaf-type expression)
-        leaf-id     (definition/expression-leaf-id expression)
         dimensions  (case leaf-type
-                      :metric  (dimension/dimensions-for-metric provider leaf-id)
-                      :measure (dimension/dimensions-for-measure provider leaf-id)
+                      :adhoc   []  ;; adhoc leaves don't support filtering yet
+                      :metric  (dimension/dimensions-for-metric provider (definition/expression-leaf-id expression))
+                      :measure (dimension/dimensions-for-measure provider (definition/expression-leaf-id expression))
                       [])
         inst-filters (definition/filters definition)
         flat-filters (perf/mapv :filter inst-filters)
@@ -103,11 +103,11 @@
   [definition source-instance]
   (let [provider      (:metadata-provider definition)
         leaf-type     (definition/expression-leaf-type source-instance)
-        leaf-id       (definition/expression-leaf-id source-instance)
         leaf-uuid     (definition/expression-leaf-uuid source-instance)
         dimensions    (case leaf-type
-                        :metric  (dimension/dimensions-for-metric provider leaf-id)
-                        :measure (dimension/dimensions-for-measure provider leaf-id)
+                        :adhoc   []  ;; adhoc leaves don't support filtering yet
+                        :metric  (dimension/dimensions-for-metric provider (definition/expression-leaf-id source-instance))
+                        :measure (dimension/dimensions-for-measure provider (definition/expression-leaf-id source-instance))
                         [])
         inst-filters  (filterv #(= (:lib/uuid %) leaf-uuid)
                                (definition/filters definition))
@@ -147,12 +147,14 @@
   (let [provider   (:metadata-provider definition)
         leaves     (definition/expression-leaves (:expression definition))]
     (perf/some (fn [leaf]
-                 (let [dims (case (definition/expression-leaf-type leaf)
-                              :metric  (dimension/dimensions-for-metric
-                                        provider (definition/expression-leaf-id leaf))
-                              :measure (dimension/dimensions-for-measure
-                                        provider (definition/expression-leaf-id leaf))
-                              [])]
+                 (let [leaf-type (definition/expression-leaf-type leaf)
+                       dims     (case leaf-type
+                                  :adhoc   []  ;; adhoc leaves don't support filtering yet
+                                  :metric  (dimension/dimensions-for-metric
+                                            provider (definition/expression-leaf-id leaf))
+                                  :measure (dimension/dimensions-for-measure
+                                            provider (definition/expression-leaf-id leaf))
+                                  [])]
                    (perf/some #(when (= (:id %) dimension-id) %) dims)))
                leaves)))
 

--- a/src/metabase/lib_metric/hierarchy.cljc
+++ b/src/metabase/lib_metric/hierarchy.cljc
@@ -17,3 +17,8 @@
   "Like [[clojure.core/isa?]], but uses the lib-metric [[hierarchy]]."
   [tag parent]
   (clojure.core/isa? @hierarchy tag parent))
+
+(defn descendants
+  "Like [[clojure.core/descendants]], but uses the lib-metric [[hierarchy]]."
+  [tag]
+  (clojure.core/descendants @hierarchy tag))

--- a/src/metabase/lib_metric/hierarchy.cljc
+++ b/src/metabase/lib_metric/hierarchy.cljc
@@ -2,7 +2,7 @@
   "Shared keyword hierarchy for lib-metric dispatch.
    Provides a hierarchy that can be used for multimethod dispatch and
    operator categorization throughout the lib-metric system."
-  (:refer-clojure :exclude [derive isa?]))
+  (:refer-clojure :exclude [derive isa? descendants]))
 
 (defonce ^{:doc "Hierarchy for lib-metric dispatch."} hierarchy
   (atom (make-hierarchy)))

--- a/src/metabase/lib_metric/js.cljs
+++ b/src/metabase/lib_metric/js.cljs
@@ -276,9 +276,11 @@
             ;; Normalize typed projections
             raw-projections (or (:projections definition) [])
             norm-projections (mapv (fn [tp]
-                                     {:type       (keyword (:type tp))
-                                      :id         (:id tp)
-                                      :projection (into [] (keep lib-metric.schema/normalize-dimension-ref) (:projection tp))})
+                                     (let [tp-type (keyword (:type tp))]
+                                       (cond-> {:type       tp-type
+                                                :projection (into [] (keep lib-metric.schema/normalize-dimension-ref) (:projection tp))}
+                                         (= :adhoc tp-type) (assoc :lib/uuid (:lib/uuid tp))
+                                         (not= :adhoc tp-type) (assoc :id (:id tp)))))
                                    raw-projections)]
         {:lib/type          :metric/definition
          :expression        norm-expression
@@ -329,10 +331,12 @@
 
 (defn- typed-projection->js
   "Convert a typed-projection map to JS."
-  [{:keys [type id projection]}]
+  [{:keys [type id projection] :as tp}]
   (let [obj #js {}]
     (gobject/set obj "type" (name type))
-    (gobject/set obj "id" id)
+    (if (= :adhoc type)
+      (gobject/set obj "lib/uuid" (:lib/uuid tp))
+      (gobject/set obj "id" id))
     (gobject/set obj "projection" (to-array (map expression->js projection)))
     obj))
 

--- a/src/metabase/lib_metric/operators.cljc
+++ b/src/metabase/lib_metric/operators.cljc
@@ -1,8 +1,8 @@
 (ns metabase.lib-metric.operators
-  "Unified operator definitions for lib-metric filters.
+  "Unified operator definitions for lib-metric filters and arithmetic.
    Uses lib-metric.hierarchy for category dispatch.
 
-   Operator categories:
+   Filter categories:
    - ::nullary    - no value argument (:is-null, :not-null, :is-empty, :not-empty)
    - ::comparison - single or variadic values (:=, :!=, :<, :<=, :>, :>=)
    - ::string-op  - string-specific operators (:contains, :does-not-contain, :starts-with, :ends-with)
@@ -11,7 +11,10 @@
    - ::compound   - logical operators (:and, :or, :not)
    - ::multi-value - multi-value operators (:in, :not-in)
 
-   All categories derive from ::filter-operator for display-info compatibility."
+   Arithmetic category:
+   - ::arithmetic - numeric operations (:+, :-, :*, :/)
+
+   All filter categories derive from ::filter-operator for display-info compatibility."
   (:require
    [metabase.lib-metric.hierarchy :as hierarchy]
    [metabase.util.performance :as perf]))
@@ -50,15 +53,25 @@
 (doseq [op [:get-day-of-week :get-month :get-hour :get-quarter]]
   (hierarchy/derive op ::temporal-extraction))
 
-;; All operator categories are filter operators (for display-info compatibility)
+;; Arithmetic operators
+(doseq [op [:+ :- :* :/]]
+  (hierarchy/derive op ::arithmetic))
+
+;; All filter categories are filter operators (for display-info compatibility)
 (doseq [cat [::nullary ::comparison ::string-op ::range ::temporal ::compound ::multi-value]]
   (hierarchy/derive cat ::filter-operator))
 
 ;;; -------------------------------------------------- Operator Metadata --------------------------------------------------
 
 (def ^:private operator-metadata
-  "Metadata for each filter operator."
-  {:is-null          {:display-name "is empty"           :arity 0         :ast-node-type :filter/null}
+  "Metadata for all operators (filter and arithmetic)."
+  {;; --- Arithmetic operators ---
+   :+                {:display-name "plus"               :arity :variadic :eval-fn +}
+   :-                {:display-name "minus"              :arity :variadic :eval-fn -}
+   :*                {:display-name "times"              :arity :variadic :eval-fn *}
+   :/                {:display-name "divided by"         :arity :variadic :eval-fn (fn [a b] (/ (double a) (double b)))  :zero-guard? true}
+   ;; --- Filter operators ---
+   :is-null          {:display-name "is empty"           :arity 0         :ast-node-type :filter/null}
    :not-null         {:display-name "is not empty"       :arity 0         :ast-node-type :filter/null}
    :is-empty         {:display-name "is empty"           :arity 0         :ast-node-type :filter/null}
    :not-empty        {:display-name "is not empty"       :arity 0         :ast-node-type :filter/null}
@@ -129,6 +142,11 @@
   [op]
   (hierarchy/isa? op ::filter-operator))
 
+(defn arithmetic?
+  "Returns true if `op` is an arithmetic operator."
+  [op]
+  (hierarchy/isa? op ::arithmetic))
+
 ;;; -------------------------------------------------- Query Functions --------------------------------------------------
 
 (defn display-name
@@ -145,6 +163,21 @@
   "Get the AST node type for an operator."
   [op]
   (perf/get-in operator-metadata [op :ast-node-type]))
+
+(defn eval-fn
+  "Get the evaluation function for an arithmetic operator."
+  [op]
+  (perf/get-in operator-metadata [op :eval-fn]))
+
+(defn zero-guard?
+  "Returns true if the arithmetic operator needs division-by-zero protection."
+  [op]
+  (perf/get-in operator-metadata [op :zero-guard?]))
+
+(defn arithmetic-operator-keywords
+  "Returns the set of registered arithmetic operator keywords."
+  []
+  (hierarchy/descendants ::arithmetic))
 
 ;;; -------------------------------------------------- Operators by Dimension Type --------------------------------------------------
 

--- a/src/metabase/lib_metric/projection.cljc
+++ b/src/metabase/lib_metric/projection.cljc
@@ -116,12 +116,16 @@
    dimension-ref :- ::lib-metric.schema/dimension-reference]
   (let [expression    (:expression definition)
         leaf-type     (lib-metric.definition/expression-leaf-type expression)
-        leaf-id       (lib-metric.definition/expression-leaf-id expression)
+        adhoc?        (= :adhoc leaf-type)
+        leaf-uuid     (lib-metric.definition/expression-leaf-uuid expression)
+        leaf-id       (when-not adhoc? (lib-metric.definition/expression-leaf-id expression))
         dimension-ref (lib/ensure-uuid dimension-ref)
         projections   (or (:projections definition) [])
         ;; Find existing typed-projection entry for this source
         existing-idx  (perf/some (fn [[idx tp]]
-                                   (when (and (= leaf-type (:type tp)) (= leaf-id (:id tp)))
+                                   (when (if adhoc?
+                                           (and (= :adhoc (:type tp)) (= leaf-uuid (:lib/uuid tp)))
+                                           (and (= leaf-type (:type tp)) (= leaf-id (:id tp))))
                                      idx))
                                  (map-indexed vector projections))]
     (if existing-idx
@@ -129,7 +133,9 @@
       (update-in definition [:projections existing-idx :projection] conj dimension-ref)
       ;; Create new typed-projection entry
       (update definition :projections (fnil conj [])
-              {:type leaf-type :id leaf-id :projection [dimension-ref]}))))
+              (if adhoc?
+                {:type :adhoc :lib/uuid leaf-uuid :projection [dimension-ref]}
+                {:type leaf-type :id leaf-id :projection [dimension-ref]})))))
 
 (defn- all-projectable-dimensions
   "Get all projectable dimensions, handling both single-source and multi-source definitions."

--- a/src/metabase/lib_metric/projection.cljc
+++ b/src/metabase/lib_metric/projection.cljc
@@ -112,13 +112,32 @@
       (update definition :projections (fnil conj [])
               {:type leaf-type :id leaf-id :projection [dimension-ref]}))))
 
+(defn- all-projectable-dimensions
+  "Get all projectable dimensions, handling both single-source and multi-source definitions."
+  [definition]
+  (let [expression (:expression definition)]
+    (if (lib-metric.definition/expression-leaf? expression)
+      (projectable-dimensions definition)
+      ;; Multi-source: collect dimensions from each leaf source
+      (let [leaves (lib-metric.definition/expression-leaves expression)]
+        (into []
+              (mapcat (fn [leaf]
+                        (let [leaf-type (lib-metric.definition/expression-leaf-type leaf)
+                              leaf-id   (lib-metric.definition/expression-leaf-id leaf)
+                              source-metadata {:lib/type (case leaf-type
+                                                           :metric  :metadata/metric
+                                                           :measure :metadata/measure)
+                                               :id       leaf-id}]
+                          (projectable-dimensions-for-source definition source-metadata))))
+              leaves)))))
+
 (mu/defn projection-dimension :- [:maybe ::lib-metric.schema/metadata-dimension]
   "Get the dimension metadata for a projection clause.
    The projection is a dimension-reference [:dimension opts uuid].
    Returns the dimension metadata or nil if not found."
   [definition :- ::lib-metric.schema/metric-definition
    projection-or-reference :- ::lib-metric.schema/dimension-or-reference]
-  (let [dimensions (projectable-dimensions definition)
+  (let [dimensions (all-projectable-dimensions definition)
         dimension-id (if (map? projection-or-reference)
                        (:id projection-or-reference)
                        (projection-dimension-id projection-or-reference))]

--- a/src/metabase/lib_metric/projection.cljc
+++ b/src/metabase/lib_metric/projection.cljc
@@ -39,16 +39,35 @@
                      positions (assoc :projection-positions (vec positions)))))
                dimensions)))
 
+(defn- adhoc-dimensions-from-expression
+  "Extract dimensions from an adhoc expression leaf's inline definition.
+   Converts adhoc dimension declarations to metadata-dimension format."
+  [expression]
+  (let [leaf-uuid (lib-metric.definition/expression-leaf-uuid expression)
+        adhoc-def (nth expression 2)
+        dims      (:dimensions adhoc-def)]
+    (perf/mapv (fn [{:keys [id display-name effective-type semantic-type]}]
+                 (cond-> {:lib/type    :metadata/dimension
+                          :id          id
+                          :source-type :adhoc
+                          :source-id   leaf-uuid}
+                   display-name   (assoc :display-name display-name)
+                   effective-type (assoc :effective-type effective-type)
+                   semantic-type  (assoc :semantic-type semantic-type)))
+               (or dims []))))
+
 (mu/defn projectable-dimensions :- [:sequential ::lib-metric.schema/metadata-dimension]
   "Get dimensions that can be used for projections.
    Returns dimensions with :projection-positions indicating which are already used."
   [definition :- ::lib-metric.schema/metric-definition]
   (let [{:keys [expression projections metadata-provider]} definition
         leaf-type (lib-metric.definition/expression-leaf-type expression)
-        leaf-id   (lib-metric.definition/expression-leaf-id expression)
-        dimensions (case leaf-type
-                     :metric  (lib-metric.dimension/dimensions-for-metric metadata-provider leaf-id)
-                     :measure (lib-metric.dimension/dimensions-for-measure metadata-provider leaf-id))
+        dimensions (if (= :adhoc leaf-type)
+                     (adhoc-dimensions-from-expression expression)
+                     (let [leaf-id (lib-metric.definition/expression-leaf-id expression)]
+                       (case leaf-type
+                         :metric  (lib-metric.dimension/dimensions-for-metric metadata-provider leaf-id)
+                         :measure (lib-metric.dimension/dimensions-for-measure metadata-provider leaf-id))))
         flat-projs (lib-metric.definition/flat-projections (or projections []))]
     (add-projection-positions dimensions flat-projs)))
 
@@ -122,13 +141,15 @@
       (let [leaves (lib-metric.definition/expression-leaves expression)]
         (into []
               (mapcat (fn [leaf]
-                        (let [leaf-type (lib-metric.definition/expression-leaf-type leaf)
-                              leaf-id   (lib-metric.definition/expression-leaf-id leaf)
-                              source-metadata {:lib/type (case leaf-type
-                                                           :metric  :metadata/metric
-                                                           :measure :metadata/measure)
-                                               :id       leaf-id}]
-                          (projectable-dimensions-for-source definition source-metadata))))
+                        (let [leaf-type (lib-metric.definition/expression-leaf-type leaf)]
+                          (if (= :adhoc leaf-type)
+                            (adhoc-dimensions-from-expression leaf)
+                            (let [leaf-id (lib-metric.definition/expression-leaf-id leaf)
+                                  source-metadata {:lib/type (case leaf-type
+                                                               :metric  :metadata/metric
+                                                               :measure :metadata/measure)
+                                                   :id       leaf-id}]
+                              (projectable-dimensions-for-source definition source-metadata))))))
               leaves)))))
 
 (mu/defn projection-dimension :- [:maybe ::lib-metric.schema/metadata-dimension]
@@ -336,14 +357,22 @@
 
 (mu/defn default-breakout-dimensions :- [:sequential ::lib-metric.schema/metadata-dimension]
   "Get dimensions corresponding to the source metric's default breakout columns.
-   Returns DimensionMetadata objects matching the breakout field-ids in the dataset_query."
+   Returns DimensionMetadata objects matching the breakout field-ids in the dataset_query.
+   For adhoc leaves, returns all declared dimensions (the user chose them explicitly)."
   [definition :- ::lib-metric.schema/metric-definition]
   (let [{:keys [expression metadata-provider]} definition
-        leaf-type (lib-metric.definition/expression-leaf-type expression)
-        leaf-id   (lib-metric.definition/expression-leaf-id expression)]
-    (if-not leaf-type
+        leaf-type (lib-metric.definition/expression-leaf-type expression)]
+    (cond
+      (not leaf-type)
       []
-      (let [metadata-type (case leaf-type :metric :metadata/metric :measure :metadata/measure)
+
+      ;; For adhoc, all declared dimensions are "default" breakouts
+      (= :adhoc leaf-type)
+      (adhoc-dimensions-from-expression expression)
+
+      :else
+      (let [leaf-id       (lib-metric.definition/expression-leaf-id expression)
+            metadata-type (case leaf-type :metric :metadata/metric :measure :metadata/measure)
             metadata      (first (lib.metadata.protocols/metadatas
                                   metadata-provider
                                   {:lib/type metadata-type :id #{leaf-id}}))

--- a/src/metabase/lib_metric/schema.cljc
+++ b/src/metabase/lib_metric/schema.cljc
@@ -8,7 +8,7 @@
    [metabase.lib.schema.ref :as lib.schema.ref]
    [metabase.lib.schema.temporal-bucketing :as lib.schema.temporal-bucketing]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :refer [some]]))
+   [metabase.util.performance :as perf :refer [some]]))
 
 (comment lib.schema.ref/keep-me)
 
@@ -247,6 +247,30 @@
    [:filter       {:optional true} [:maybe :any]]
    [:dimensions   [:sequential ::adhoc-dimension]]])
 
+(defn- normalize-field-ref
+  "Normalize a field-ref clause: ensure opts map has normalized keys."
+  [field-ref]
+  (if (and (sequential? field-ref) (>= (count field-ref) 3))
+    (let [[tag opts & args] field-ref]
+      (into [(lib.schema.common/normalize-keyword tag)
+             (lib.schema.common/normalize-options-map (or opts {}))]
+            args))
+    field-ref))
+
+(defn- normalize-adhoc-dimension
+  "Normalize an adhoc dimension map, keywordizing type values."
+  [dim]
+  (cond-> dim
+    (string? (:effective-type dim))  (update :effective-type lib.schema.common/normalize-keyword)
+    (string? (:semantic-type dim))   (update :semantic-type lib.schema.common/normalize-keyword)
+    (:field-ref dim)                 (update :field-ref normalize-field-ref)))
+
+(defn- normalize-adhoc-definition
+  "Normalize the inline definition map inside an adhoc expression ref."
+  [definition]
+  (cond-> definition
+    (:dimensions definition) (update :dimensions #(perf/mapv normalize-adhoc-dimension %))))
+
 (defn- normalize-adhoc-ref
   "Normalize an adhoc expression ref from API format."
   [x]
@@ -256,7 +280,7 @@
       (when (or (= t "adhoc") (= t :adhoc))
         [:adhoc
          (lib.schema.common/normalize-options-map (or opts {}))
-         definition]))))
+         (normalize-adhoc-definition definition)]))))
 
 (mr/def ::adhoc-expression-ref
   "An ad-hoc aggregation reference in an expression: [:adhoc {:lib/uuid uuid} definition-map]."
@@ -404,8 +428,8 @@
 ;;; fetchable through the MetricContextMetadataProvider.
 
 (mr/def ::dimension-source-type
-  "Source type indicating whether a dimension comes from a metric or measure."
-  [:enum :metric :measure])
+  "Source type indicating whether a dimension comes from a metric, measure, or adhoc aggregation."
+  [:enum :metric :measure :adhoc])
 
 (mr/def ::metadata-dimension
   "Schema for dimension metadata fetchable via metadata provider.
@@ -425,7 +449,7 @@
    [:group            {:optional true} [:maybe ::dimension-group]]
    ;; Source tracking
    [:source-type      ::dimension-source-type]
-   [:source-id        pos-int?]
+   [:source-id        [:or pos-int? ::lib.schema.common/non-blank-string]]
    ;; Optional mapping for field resolution
    [:dimension-mapping {:optional true} [:maybe ::dimension-mapping]]])
 

--- a/src/metabase/lib_metric/schema.cljc
+++ b/src/metabase/lib_metric/schema.cljc
@@ -222,9 +222,54 @@
     [:lib/uuid ::lib.schema.common/non-blank-string]]
    pos-int?])
 
+;;; ------------------------------------------------- Ad-hoc Aggregation -------------------------------------------------
+;;; Schemas for ad-hoc (inline) aggregation definitions that carry their own dimensions.
+
+(mr/def ::adhoc-dimension
+  "A dimension declared inline in an ad-hoc aggregation definition.
+   The frontend generates the UUID and field-ref from table metadata."
+  [:map
+   {:decode/normalize lib.schema.common/normalize-map}
+   [:id            ::dimension-id]
+   [:field-ref     [:ref :mbql.clause/field]]
+   [:effective-type {:optional true} [:maybe ::lib.schema.common/base-type]]
+   [:display-name   {:optional true} [:maybe :string]]
+   [:semantic-type  {:optional true} [:maybe ::lib.schema.common/semantic-or-relation-type]]])
+
+(mr/def ::adhoc-definition
+  "Inline definition for an ad-hoc aggregation.
+   Carries everything needed to build a query without referencing a persisted entity."
+  [:map
+   {:decode/normalize lib.schema.common/normalize-map}
+   [:database-id  pos-int?]
+   [:table-id     pos-int?]
+   [:aggregation  :any]
+   [:filter       {:optional true} [:maybe :any]]
+   [:dimensions   [:sequential ::adhoc-dimension]]])
+
+(defn- normalize-adhoc-ref
+  "Normalize an adhoc expression ref from API format."
+  [x]
+  (when (and (sequential? x)
+             (= 3 (count x)))
+    (let [[t opts definition] x]
+      (when (or (= t "adhoc") (= t :adhoc))
+        [:adhoc
+         (lib.schema.common/normalize-options-map (or opts {}))
+         definition]))))
+
+(mr/def ::adhoc-expression-ref
+  "An ad-hoc aggregation reference in an expression: [:adhoc {:lib/uuid uuid} definition-map]."
+  [:tuple
+   {:decode/normalize normalize-adhoc-ref}
+   [:= {:decode/normalize lib.schema.common/normalize-keyword} :adhoc]
+   [:map {:decode/normalize lib.schema.common/normalize-options-map}
+    [:lib/uuid ::lib.schema.common/non-blank-string]]
+   ::adhoc-definition])
+
 (mr/def ::expression-leaf
-  "A leaf node in a metric math expression: either a metric or measure reference."
-  [:or ::metric-expression-ref ::measure-expression-ref])
+  "A leaf node in a metric math expression: a metric, measure, or ad-hoc aggregation reference."
+  [:or ::metric-expression-ref ::measure-expression-ref ::adhoc-expression-ref])
 
 (mr/def ::arithmetic-operator
   "Arithmetic operators for metric math."
@@ -238,18 +283,24 @@
   (cond
     (number? x) x
     (sequential? x)
-    (let [[first-el] x]
-      (if (and (>= (count x) 3)
-               (let [tag (lib.schema.common/normalize-keyword first-el)]
-                 (or (= tag :metric) (= tag :measure))))
-        ;; It's a leaf ref - normalize it
-        ((normalize-expression-ref (lib.schema.common/normalize-keyword first-el)) x)
-        ;; It's an arithmetic expression: [op opts & exprs]
-        (when (>= (count x) 4)
-          (let [[op opts & exprs] x]
-            (into [(lib.schema.common/normalize-keyword op)
-                   (lib.schema.common/normalize-options-map (or opts {}))]
-                  (map normalize-math-expression exprs))))))
+    (let [[first-el] x
+          tag (lib.schema.common/normalize-keyword first-el)]
+      (cond
+        ;; Metric or measure leaf ref
+        (and (>= (count x) 3)
+             (or (= tag :metric) (= tag :measure)))
+        ((normalize-expression-ref tag) x)
+
+        ;; Ad-hoc leaf ref
+        (and (= (count x) 3) (= tag :adhoc))
+        (normalize-adhoc-ref x)
+
+        ;; Arithmetic expression: [op opts & exprs]
+        (>= (count x) 4)
+        (let [[op opts & exprs] x]
+          (into [(lib.schema.common/normalize-keyword op)
+                 (lib.schema.common/normalize-options-map (or opts {}))]
+                (map normalize-math-expression exprs)))))
     :else nil))
 
 (mr/def ::metric-math-expression
@@ -288,11 +339,12 @@
 ;;; Projections keyed by source type and ID.
 
 (mr/def ::typed-projection
-  "A projection associated with a specific source type and ID."
+  "A projection associated with a specific source type and ID (or lib/uuid for adhoc)."
   [:map
    {:decode/normalize lib.schema.common/normalize-map}
-   [:type       [:enum {:decode/normalize lib.schema.common/normalize-keyword} :metric :measure]]
-   [:id         pos-int?]
+   [:type       [:enum {:decode/normalize lib.schema.common/normalize-keyword} :metric :measure :adhoc]]
+   [:id         {:optional true} [:maybe pos-int?]]
+   [:lib/uuid   {:optional true} [:maybe ::lib.schema.common/non-blank-string]]
    [:projection [:sequential ::dimension-reference]]])
 
 (mr/def ::typed-projections

--- a/src/metabase/lib_metric/schema.cljc
+++ b/src/metabase/lib_metric/schema.cljc
@@ -2,6 +2,7 @@
   "Malli schemas for metric dimensions, dimension-mappings, and dimension-references."
   (:refer-clojure :exclude [some])
   (:require
+   [metabase.lib-metric.operators :as operators]
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.schema.ref :as lib.schema.ref]
@@ -227,7 +228,8 @@
 
 (mr/def ::arithmetic-operator
   "Arithmetic operators for metric math."
-  [:enum {:decode/normalize lib.schema.common/normalize-keyword} :+ :- :* :/])
+  (into [:enum {:decode/normalize lib.schema.common/normalize-keyword}]
+        (operators/arithmetic-operator-keywords)))
 
 (defn normalize-math-expression
   "Recursively normalize a metric math expression from API format.
@@ -261,7 +263,7 @@
      [:fn {:error/message "must be arithmetic expression [op opts expr expr ...] with at least 2 operands"}
       (fn [x]
         (and (>= (count x) 4)
-             (#{:+ :- :* :/} (first x))
+             (operators/arithmetic? (first x))
              (map? (second x))))]]]])
 
 ;;; ------------------------------------------------- Per-Instance Filters -------------------------------------------------

--- a/src/metabase/lib_metric/schema.cljc
+++ b/src/metabase/lib_metric/schema.cljc
@@ -233,9 +233,11 @@
 
 (defn normalize-math-expression
   "Recursively normalize a metric math expression from API format.
-   Handles string keys, string operators, and nested expressions."
+   Handles string keys, string operators, nested expressions, and bare numeric constants."
   [x]
-  (when (sequential? x)
+  (cond
+    (number? x) x
+    (sequential? x)
     (let [[first-el] x]
       (if (and (>= (count x) 3)
                (let [tag (lib.schema.common/normalize-keyword first-el)]
@@ -247,7 +249,8 @@
           (let [[op opts & exprs] x]
             (into [(lib.schema.common/normalize-keyword op)
                    (lib.schema.common/normalize-options-map (or opts {}))]
-                  (map normalize-math-expression exprs))))))))
+                  (map normalize-math-expression exprs))))))
+    :else nil))
 
 (mr/def ::metric-math-expression
   "A recursive metric math expression tree.
@@ -258,6 +261,7 @@
    {:decode/normalize normalize-math-expression}
    [:or
     ::expression-leaf
+    number?
     [:and
      vector?
      [:fn {:error/message "must be arithmetic expression [op opts expr expr ...] with at least 2 operands"}

--- a/src/metabase/metrics/api.clj
+++ b/src/metabase/metrics/api.clj
@@ -121,6 +121,9 @@
     [:expression  ::lib-metric.schema/metric-math-expression]
     [:filters     {:optional true} [:maybe ::lib-metric.schema/instance-filters]]
     [:projections {:optional true} [:maybe ::lib-metric.schema/typed-projections]]]
+   [:fn {:error/message "Expression must contain at least one metric or measure"}
+    (fn [{:keys [expression]}]
+      (seq (collect-expression-leaves expression)))]
    [:fn {:error/message "All :lib/uuid values in expression must be unique"}
     (fn [{:keys [expression]}]
       (let [uuids (collect-expression-uuids expression)]

--- a/src/metabase/metrics/api.clj
+++ b/src/metabase/metrics/api.clj
@@ -4,7 +4,6 @@
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.collections.models.collection :as collection]
-   [metabase.lib-metric.ast.plan :as ast.plan]
    [metabase.lib-metric.core :as lib-metric]
    [metabase.lib-metric.schema :as lib-metric.schema]
    [metabase.metrics.core :as metrics]
@@ -201,7 +200,7 @@
   "Join leaf results and stream the computed output through the QP reduce pipeline.
    Called INSIDE streaming context with the rff."
   [{:keys [plan/expression plan/breakout-count]} uuid->result rff]
-  (let [{:keys [cols rows]} (ast.plan/join-and-compute expression uuid->result breakout-count)
+  (let [{:keys [cols rows]} (lib-metric/join-and-compute expression uuid->result breakout-count)
         reducible (reify clojure.lang.IReduceInit
                     (reduce [_ rf init]
                       (reduce rf init rows)))]

--- a/src/metabase/metrics/api.clj
+++ b/src/metabase/metrics/api.clj
@@ -4,10 +4,12 @@
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.collections.models.collection :as collection]
+   [metabase.lib-metric.ast.plan :as ast.plan]
    [metabase.lib-metric.core :as lib-metric]
    [metabase.lib-metric.schema :as lib-metric.schema]
    [metabase.metrics.core :as metrics]
    [metabase.query-processor :as qp]
+   [metabase.query-processor.pipeline :as qp.pipeline]
    [metabase.query-processor.streaming :as qp.streaming]
    [metabase.request.core :as request]
    [metabase.server.core :as server]
@@ -179,6 +181,29 @@
      :projections       (or projections [])
      :metadata-provider provider}))
 
+(defn- execute-leaf-queries
+  "Execute all leaf queries in parallel, collecting results eagerly.
+   Must be called OUTSIDE streaming context to avoid JSON writer conflicts.
+   Returns {uuid -> qp-result}."
+  [leaves]
+  (let [uuid->future (into {}
+                           (map (fn [[uuid leaf-plan]]
+                                  [uuid (future (qp/process-query (qp/userland-query (:leaf/mbql leaf-plan))))]))
+                           leaves)]
+    (into {}
+          (map (fn [[uuid f]] [uuid @f]))
+          uuid->future)))
+
+(defn- stream-arithmetic-results
+  "Join leaf results and stream the computed output through the QP reduce pipeline.
+   Called INSIDE streaming context with the rff."
+  [{:keys [plan/expression plan/breakout-count]} uuid->result rff]
+  (let [{:keys [cols rows]} (ast.plan/join-and-compute expression uuid->result breakout-count)
+        reducible (reify clojure.lang.IReduceInit
+                    (reduce [_ rf init]
+                      (reduce rf init rows)))]
+    (qp.pipeline/*reduce* rff {:cols cols} reducible)))
+
 (api.macros/defendpoint :post "/dataset"
   :- (server/streaming-response-schema ::DatasetResponse)
   "Execute a metric or measure-based query and stream the results.
@@ -191,11 +216,15 @@
   [_route-params
    _query-params
    {:keys [definition]} :- ::DatasetRequest]
-  (let [query (-> (lib-metric/metadata-provider)
-                  (from-api-definition definition)
-                  (lib-metric/->mbql-query {:limit 10000}))]
-    (qp.streaming/streaming-response [rff :api]
-      (qp/process-query (qp/userland-query query) rff))))
+  (let [definition (from-api-definition (lib-metric/metadata-provider) definition)
+        plan       (lib-metric/->query-plan definition {:limit 10000})]
+    (if (= :leaf (:plan/type plan))
+      (qp.streaming/streaming-response [rff :api]
+        (qp/process-query (qp/userland-query (:plan/mbql plan)) rff))
+      ;; Arithmetic: execute leaf queries BEFORE streaming to avoid JSON writer conflicts
+      (let [uuid->result (execute-leaf-queries (:plan/leaves plan))]
+        (qp.streaming/streaming-response [rff :api]
+          (stream-arithmetic-results plan uuid->result rff))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                       Dimension Value Endpoints                                                |
@@ -213,12 +242,11 @@
   [_route-params
    _query-params
    {:keys [definition]} :- ::DatasetRequest]
-  (let [query   (-> (lib-metric/metadata-provider)
-                    (from-api-definition definition)
-                    (lib-metric/->values-query {:limit 100}))
-        result  (qp/process-query (qp/userland-query query))
-        col     (first (get-in result [:data :cols]))
-        values  (mapv first (get-in result [:data :rows]))]
+  (let [definition (from-api-definition (lib-metric/metadata-provider) definition)
+        plan       (lib-metric/->query-plan definition {:limit 100 :values-only true})
+        result     (qp/process-query (qp/userland-query (:plan/mbql plan)))
+        col        (first (get-in result [:data :cols]))
+        values     (mapv first (get-in result [:data :rows]))]
     {:values values
      :col    (or col {})}))
 

--- a/src/metabase/metrics/api.clj
+++ b/src/metabase/metrics/api.clj
@@ -108,10 +108,15 @@
   [expr]
   (mapv lib-metric/expression-leaf-uuid (lib-metric/expression-leaves expr)))
 
-(defn- collect-expression-leaves
-  "Collect [type id] pairs from leaf nodes in an expression tree."
+(defn- collect-expression-leaf-identities
+  "Collect identity tuples for projection matching.
+   For :metric/:measure, returns [type id]. For :adhoc, returns [type lib/uuid]."
   [expr]
-  (mapv (juxt lib-metric/expression-leaf-type lib-metric/expression-leaf-id)
+  (mapv (fn [leaf]
+          (let [leaf-type (lib-metric/expression-leaf-type leaf)]
+            (if (= :adhoc leaf-type)
+              [:adhoc (lib-metric/expression-leaf-uuid leaf)]
+              [leaf-type (lib-metric/expression-leaf-id leaf)])))
         (lib-metric/expression-leaves expr)))
 
 (mr/def ::Definition
@@ -122,9 +127,9 @@
     [:expression  ::lib-metric.schema/metric-math-expression]
     [:filters     {:optional true} [:maybe ::lib-metric.schema/instance-filters]]
     [:projections {:optional true} [:maybe ::lib-metric.schema/typed-projections]]]
-   [:fn {:error/message "Expression must contain at least one metric or measure"}
+   [:fn {:error/message "Expression must contain at least one metric, measure, or adhoc aggregation"}
     (fn [{:keys [expression]}]
-      (seq (collect-expression-leaves expression)))]
+      (seq (collect-expression-uuids expression)))]
    [:fn {:error/message "All :lib/uuid values in expression must be unique"}
     (fn [{:keys [expression]}]
       (let [uuids (collect-expression-uuids expression)]
@@ -135,8 +140,12 @@
         (every? #(contains? expr-uuids (:lib/uuid %)) (or filters []))))]
    [:fn {:error/message "Projection type/id pairs must correspond to expression leaves"}
     (fn [{:keys [expression projections]}]
-      (let [leaves (set (collect-expression-leaves expression))]
-        (every? #(contains? leaves [(:type %) (:id %)]) (or projections []))))]])
+      (let [identities (set (collect-expression-leaf-identities expression))]
+        (every? (fn [proj]
+                  (if (= :adhoc (:type proj))
+                    (contains? identities [:adhoc (:lib/uuid proj)])
+                    (contains? identities [(:type proj) (:id proj)])))
+                (or projections []))))]])
 
 (mr/def ::DatasetRequest
   "Schema for POST /dataset request body."
@@ -159,13 +168,20 @@
                 [:rows [:sequential :any]]]]
    [:row_count ms/IntGreaterThanOrEqualToZero]])
 
+(defn- check-adhoc-table-permissions
+  "Check that the current user has query permissions for the given table."
+  [table-id]
+  (api/query-check (t2/select-one :model/Table :id table-id)))
+
 (defn- check-expression-permissions
-  "Collect all metric/measure leaves from the expression and verify query permissions for each."
+  "Collect all metric/measure/adhoc leaves from the expression and verify query permissions for each."
   [expression]
-  (doseq [[source-type source-id] (collect-expression-leaves expression)]
-    (case source-type
-      :metric  (api/query-check (t2/select-one :model/Card :id source-id :type "metric"))
-      :measure (api/query-check (t2/select-one :model/Measure :id source-id)))))
+  (doseq [leaf (lib-metric/expression-leaves expression)]
+    (let [leaf-type (lib-metric/expression-leaf-type leaf)]
+      (case leaf-type
+        :metric  (api/query-check (t2/select-one :model/Card :id (lib-metric/expression-leaf-id leaf) :type "metric"))
+        :measure (api/query-check (t2/select-one :model/Measure :id (lib-metric/expression-leaf-id leaf)))
+        :adhoc   (check-adhoc-table-permissions (get-in leaf [2 :table-id]))))))
 
 (defn- from-api-definition
   "Create a MetricDefinition from API definition parameters.

--- a/src/metabase/metrics/api.clj
+++ b/src/metabase/metrics/api.clj
@@ -17,6 +17,8 @@
    [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2]))
 
+(set! *warn-on-reflection* true)
+
 (mr/def ::Metric
   "Schema for a Metric in list responses (without hydrated dimensions)."
   [:map

--- a/test/metabase/lib_metric/ast/build_test.cljc
+++ b/test/metabase/lib_metric/ast/build_test.cljc
@@ -513,6 +513,28 @@
         (is (some? (get-in child-a [:ast :filter])))
         (is (nil? (get-in child-b [:ast :filter])))))))
 
+(deftest ^:parallel from-definition-arithmetic-with-constant-test
+  (let [definition {:lib/type          :metric/definition
+                    :expression        [:* {} [:metric {:lib/uuid arith-uuid-a} 42] 100]
+                    :filters           []
+                    :projections       []
+                    :metadata-provider (make-test-provider (sample-metric-metadata) (sample-measure-metadata))}
+        ast (ast.build/from-definition definition)]
+
+    (testing "creates valid AST with constant child"
+      (is (nil? (me/humanize (mr/explain ::ast.schema/ast ast)))))
+
+    (testing "expression root is arithmetic"
+      (is (= :expression/arithmetic (get-in ast [:expression :node/type])))
+      (is (= :* (get-in ast [:expression :operator]))))
+
+    (testing "has one leaf and one constant child"
+      (let [children (get-in ast [:expression :children])]
+        (is (= 2 (count children)))
+        (is (= :expression/leaf (get-in children [0 :node/type])))
+        (is (= :expression/constant (get-in children [1 :node/type])))
+        (is (= 100 (get-in children [1 :value])))))))
+
 (deftest ^:parallel from-definition-arithmetic-with-projections-test
   (let [definition (assoc (arithmetic-definition)
                           :projections [{:type :metric

--- a/test/metabase/lib_metric/ast/build_test.cljc
+++ b/test/metabase/lib_metric/ast/build_test.cljc
@@ -137,24 +137,33 @@
 
     (testing "has correct root structure"
       (is (= :ast/root (:node/type ast)))
-      (is (nil? (:filter ast)))
-      (is (= [] (:group-by ast)))
+      (is (some? (:expression ast)))
       (is (some? (:metadata-provider ast))))
 
-    (testing "has correct source"
-      (let [source (:source ast)]
-        (is (= :source/metric (:node/type source)))
-        (is (= 42 (:id source)))
-        (is (= "Total Revenue" (:name source)))))
+    (testing "expression is a single leaf"
+      (is (= :expression/leaf (get-in ast [:expression :node/type])))
+      (is (string? (get-in ast [:expression :uuid]))))
 
-    (testing "has dimensions as nodes"
-      (is (= 2 (count (:dimensions ast))))
-      (is (every? #(= :ast/dimension (:node/type %)) (:dimensions ast)))
-      (is (= uuid-1 (get-in ast [:dimensions 0 :id]))))
+    (let [source-query (get-in ast [:expression :ast])]
+      (testing "leaf wraps a source-query"
+        (is (= :ast/source-query (:node/type source-query)))
+        (is (nil? (:filter source-query)))
+        (is (= [] (:group-by source-query))))
 
-    (testing "has mappings as nodes"
-      (is (= 2 (count (:mappings ast))))
-      (is (every? #(= :ast/dimension-mapping (:node/type %)) (:mappings ast))))))
+      (testing "has correct source"
+        (let [source (:source source-query)]
+          (is (= :source/metric (:node/type source)))
+          (is (= 42 (:id source)))
+          (is (= "Total Revenue" (:name source)))))
+
+      (testing "has dimensions as nodes"
+        (is (= 2 (count (:dimensions source-query))))
+        (is (every? #(= :ast/dimension (:node/type %)) (:dimensions source-query)))
+        (is (= uuid-1 (get-in source-query [:dimensions 0 :id]))))
+
+      (testing "has mappings as nodes"
+        (is (= 2 (count (:mappings source-query))))
+        (is (every? #(= :ast/dimension-mapping (:node/type %)) (:mappings source-query)))))))
 
 (deftest ^:parallel from-definition-measure-test
   (let [measure-def {:lib/type          :metric/definition
@@ -168,10 +177,10 @@
       (is (nil? (me/humanize (mr/explain ::ast.schema/ast ast)))))
 
     (testing "has measure source type"
-      (is (= :source/measure (get-in ast [:source :node/type]))))
+      (is (= :source/measure (get-in ast [:expression :ast :source :node/type]))))
 
     (testing "extracts sum aggregation"
-      (is (= :aggregation/sum (get-in ast [:source :aggregation :node/type]))))))
+      (is (= :aggregation/sum (get-in ast [:expression :ast :source :aggregation :node/type]))))))
 
 ;;; -------------------------------------------------- Dimension Reference Conversion --------------------------------------------------
 
@@ -377,15 +386,16 @@
   (let [definition-with-filters (assoc (sample-definition)
                                        :filters [{:lib/uuid expr-uuid
                                                   :filter [:= {} [:dimension {} uuid-1] 42]}])
-        ast (ast.build/from-definition definition-with-filters)]
+        ast (ast.build/from-definition definition-with-filters)
+        source-query (get-in ast [:expression :ast])]
 
     (testing "creates valid AST structure with filter"
       (is (nil? (me/humanize (mr/explain ::ast.schema/ast ast)))))
 
     (testing "has filter node"
-      (is (some? (:filter ast)))
-      (is (= :filter/comparison (get-in ast [:filter :node/type])))
-      (is (= := (get-in ast [:filter :operator]))))))
+      (is (some? (:filter source-query)))
+      (is (= :filter/comparison (get-in source-query [:filter :node/type])))
+      (is (= := (get-in source-query [:filter :operator]))))))
 
 (deftest ^:parallel from-definition-with-projections-test
   (let [definition-with-projections (assoc (sample-definition)
@@ -393,24 +403,26 @@
                                                           :id 42
                                                           :projection [[:dimension {} uuid-1]
                                                                        [:dimension {"temporal-unit" "year"} uuid-2]]}])
-        ast (ast.build/from-definition definition-with-projections)]
+        ast (ast.build/from-definition definition-with-projections)
+        source-query (get-in ast [:expression :ast])]
 
     (testing "creates valid AST structure with group-by"
       (is (nil? (me/humanize (mr/explain ::ast.schema/ast ast)))))
 
     (testing "has group-by dimension refs"
-      (is (= 2 (count (:group-by ast))))
-      (is (every? #(= :ast/dimension-ref (:node/type %)) (:group-by ast)))
-      (is (= uuid-1 (get-in ast [:group-by 0 :dimension-id])))
-      (is (= {:temporal-unit :year} (get-in ast [:group-by 1 :options]))))))
+      (is (= 2 (count (:group-by source-query))))
+      (is (every? #(= :ast/dimension-ref (:node/type %)) (:group-by source-query)))
+      (is (= uuid-1 (get-in source-query [:group-by 0 :dimension-id])))
+      (is (= {:temporal-unit :year} (get-in source-query [:group-by 1 :options]))))))
 
 (deftest ^:parallel from-definition-loads-dimensions-from-provider-test
   (testing "dimensions are loaded from metadata fetched via provider"
     (let [definition (sample-definition)
-          ast (ast.build/from-definition definition)]
+          ast (ast.build/from-definition definition)
+          source-query (get-in ast [:expression :ast])]
       ;; Dimensions are loaded from provider -> sample-metric-metadata
-      (is (= 2 (count (:dimensions ast))))
-      (is (= 2 (count (:mappings ast)))))))
+      (is (= 2 (count (:dimensions source-query))))
+      (is (= 2 (count (:mappings source-query)))))))
 
 ;;; -------------------------------------------------- Multi-Stage Source Queries --------------------------------------------------
 
@@ -440,6 +452,75 @@
                       :metadata-provider provider}
           ast        (ast.build/from-definition definition)]
       (testing "has joins extracted from stage 0"
-        (is (seq (get-in ast [:source :joins]))))
+        (is (seq (get-in ast [:expression :ast :source :joins]))))
       (testing "has aggregation extracted from stage 0"
-        (is (some? (get-in ast [:source :aggregation])))))))
+        (is (some? (get-in ast [:expression :ast :source :aggregation])))))))
+
+;;; -------------------------------------------------- Arithmetic Expression Building --------------------------------------------------
+
+(def ^:private arith-uuid-a "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+(def ^:private arith-uuid-b "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+
+(defn- arithmetic-definition []
+  {:lib/type          :metric/definition
+   :expression        [:+ {}
+                       [:metric {:lib/uuid arith-uuid-a} 42]
+                       [:metric {:lib/uuid arith-uuid-b} 42]]
+   :filters           []
+   :projections       []
+   :metadata-provider (make-test-provider (sample-metric-metadata) (sample-measure-metadata))})
+
+(deftest ^:parallel from-definition-arithmetic-test
+  (let [ast (ast.build/from-definition (arithmetic-definition))]
+
+    (testing "arithmetic expression builds AST with :expression key"
+      (is (= :ast/root (:node/type ast)))
+      (is (some? (:expression ast)))
+      (is (nil? (:source ast))))
+
+    (testing "expression root is arithmetic node"
+      (is (= :expression/arithmetic (get-in ast [:expression :node/type])))
+      (is (= :+ (get-in ast [:expression :operator]))))
+
+    (testing "arithmetic has two children"
+      (is (= 2 (count (get-in ast [:expression :children])))))
+
+    (testing "each child is an expression leaf with complete sub-AST"
+      (doseq [child (get-in ast [:expression :children])]
+        (is (= :expression/leaf (:node/type child)))
+        (is (string? (:uuid child)))
+        (let [sub-ast (:ast child)]
+          (is (= :ast/source-query (:node/type sub-ast)))
+          (is (some? (:source sub-ast)))
+          (is (seq (:dimensions sub-ast)))
+          (is (seq (:mappings sub-ast))))))
+
+    (testing "leaf UUIDs match expression"
+      (let [uuids (set (map :uuid (get-in ast [:expression :children])))]
+        (is (contains? uuids arith-uuid-a))
+        (is (contains? uuids arith-uuid-b))))))
+
+(deftest ^:parallel from-definition-arithmetic-with-filters-test
+  (let [definition (assoc (arithmetic-definition)
+                          :filters [{:lib/uuid arith-uuid-a
+                                     :filter [:= {} [:dimension {} uuid-1] 42]}])
+        ast (ast.build/from-definition definition)]
+
+    (testing "instance filters are partitioned to matching leaf sub-ASTs"
+      (let [children (get-in ast [:expression :children])
+            child-a  (first (filter #(= arith-uuid-a (:uuid %)) children))
+            child-b  (first (filter #(= arith-uuid-b (:uuid %)) children))]
+        (is (some? (get-in child-a [:ast :filter])))
+        (is (nil? (get-in child-b [:ast :filter])))))))
+
+(deftest ^:parallel from-definition-arithmetic-with-projections-test
+  (let [definition (assoc (arithmetic-definition)
+                          :projections [{:type :metric
+                                         :id 42
+                                         :projection [[:dimension {} uuid-1]]}])
+        ast (ast.build/from-definition definition)]
+
+    (testing "projections are assigned to matching leaf sub-ASTs"
+      (doseq [child (get-in ast [:expression :children])]
+        ;; Both children reference :metric 42, so both get the projection
+        (is (= 1 (count (get-in child [:ast :group-by]))))))))

--- a/test/metabase/lib_metric/ast/compile_test.cljc
+++ b/test/metabase/lib_metric/ast/compile_test.cljc
@@ -12,7 +12,7 @@
 (def ^:private dim-ref-2 {:node/type :ast/dimension-ref :dimension-id uuid-2 :options {:temporal-unit :month}})
 
 (def ^:private sample-ast
-  {:node/type  :ast/root
+  {:node/type  :ast/source-query
    :source     {:node/type   :source/metric
                 :id          42
                 :name        "Test Metric"
@@ -36,8 +36,7 @@
                  :table-id     100
                  :column       {:node/type :ast/column :id 2}}]
    :filter     nil
-   :group-by   []
-   :metadata-provider :test-provider})
+   :group-by   []})
 
 ;;; -------------------------------------------------- Basic Compilation --------------------------------------------------
 

--- a/test/metabase/lib_metric/ast/plan_test.cljc
+++ b/test/metabase/lib_metric/ast/plan_test.cljc
@@ -101,6 +101,22 @@
       (is (nil? (ast.plan/evaluate-expression expr {uuid-a nil uuid-b 20})))
       (is (nil? (ast.plan/evaluate-expression expr {uuid-a 10}))))))
 
+(deftest ^:parallel evaluate-expression-constant-test
+  (testing "constant node returns its value"
+    (is (= 42 (ast.plan/evaluate-expression {:node/type :expression/constant :value 42} {})))))
+
+(deftest ^:parallel evaluate-expression-leaf-times-constant-test
+  (testing "leaf * constant evaluates correctly"
+    (let [expr (make-expression-arithmetic :* [(make-expression-leaf uuid-a [])
+                                               {:node/type :expression/constant :value 100}])]
+      (is (= 500 (ast.plan/evaluate-expression expr {uuid-a 5}))))))
+
+(deftest ^:parallel validate-arithmetic-ast-with-constants-test
+  (testing "arithmetic with constants + leaves with projections passes validation"
+    (let [expr (make-expression-arithmetic :* [(make-expression-leaf uuid-a [dim-1])
+                                               {:node/type :expression/constant :value 100}])]
+      (is (nil? (ast.plan/validate-arithmetic-ast! expr))))))
+
 (deftest ^:parallel evaluate-expression-division-by-zero-test
   (testing "division by zero returns nil"
     (let [expr (make-expression-arithmetic :/ [(make-expression-leaf uuid-a [])

--- a/test/metabase/lib_metric/ast/plan_test.cljc
+++ b/test/metabase/lib_metric/ast/plan_test.cljc
@@ -83,7 +83,7 @@
   (testing "division of two leaves"
     (let [expr (make-expression-arithmetic :/ [(make-expression-leaf uuid-a [])
                                                (make-expression-leaf uuid-b [])])]
-      (is (= #?(:clj 1/2 :cljs 0.5) (ast.plan/evaluate-expression expr {uuid-a 10 uuid-b 20}))))))
+      (is (= 0.5 (ast.plan/evaluate-expression expr {uuid-a 10 uuid-b 20}))))))
 
 (deftest ^:parallel evaluate-expression-nested-test
   (testing "nested expression (a + b) * c"

--- a/test/metabase/lib_metric/ast/plan_test.cljc
+++ b/test/metabase/lib_metric/ast/plan_test.cljc
@@ -1,0 +1,211 @@
+(ns metabase.lib-metric.ast.plan-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [metabase.lib-metric.ast.plan :as ast.plan]))
+
+;;; -------------------------------------------------- Test Data --------------------------------------------------
+
+(def ^:private uuid-a "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+(def ^:private uuid-b "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+(def ^:private uuid-c "cccccccc-cccc-cccc-cccc-cccccccccccc")
+(def ^:private dim-1  "dddddddd-dddd-dddd-dddd-dddddddddd01")
+(def ^:private dim-2  "dddddddd-dddd-dddd-dddd-dddddddddd02")
+
+(defn- make-leaf-ast
+  "Build a minimal single-source AST for testing.
+   Includes dimension mappings so compile-to-mbql can resolve dimension refs."
+  [group-by-dim-ids]
+  {:node/type  :ast/source-query
+   :source     {:node/type   :source/metric
+                :id          1
+                :name        "test"
+                :aggregation {:node/type :aggregation/count}
+                :base-table  {:node/type :ast/table :id 1}
+                :metadata    {:dataset-query {:database 1}}}
+   :dimensions (mapv (fn [dim-id] {:node/type :ast/dimension :id dim-id}) group-by-dim-ids)
+   :mappings   (mapv (fn [dim-id]
+                       {:node/type    :ast/dimension-mapping
+                        :dimension-id dim-id
+                        :column       {:node/type :ast/column :id 100}})
+                     group-by-dim-ids)
+   :group-by   (mapv (fn [dim-id] {:node/type :ast/dimension-ref :dimension-id dim-id})
+                     group-by-dim-ids)})
+
+(defn- make-expression-leaf
+  ([uuid group-by-dim-ids]
+   {:node/type :expression/leaf
+    :uuid      uuid
+    :ast       (make-leaf-ast group-by-dim-ids)})
+  ([uuid group-by-dim-ids dim-opts]
+   {:node/type :expression/leaf
+    :uuid      uuid
+    :ast       (-> (make-leaf-ast group-by-dim-ids)
+                   (update :dimensions
+                           (fn [dims]
+                             (mapv (fn [dim]
+                                     (merge dim (get dim-opts (:id dim))))
+                                   dims)))
+                   (update :group-by
+                           (fn [refs]
+                             (mapv (fn [ref]
+                                     (if-let [opts (get dim-opts (:dimension-id ref))]
+                                       (cond-> ref
+                                         (:temporal-unit opts) (assoc-in [:options :temporal-unit] (:temporal-unit opts)))
+                                       ref))
+                                   refs))))}))
+
+(defn- make-expression-arithmetic [op children]
+  {:node/type :expression/arithmetic
+   :operator  op
+   :children  children})
+
+;;; -------------------------------------------------- evaluate-expression --------------------------------------------------
+
+(deftest ^:parallel evaluate-expression-addition-test
+  (testing "addition of two leaves"
+    (let [expr (make-expression-arithmetic :+ [(make-expression-leaf uuid-a [])
+                                               (make-expression-leaf uuid-b [])])]
+      (is (= 30 (ast.plan/evaluate-expression expr {uuid-a 10 uuid-b 20}))))))
+
+(deftest ^:parallel evaluate-expression-subtraction-test
+  (testing "subtraction of two leaves"
+    (let [expr (make-expression-arithmetic :- [(make-expression-leaf uuid-a [])
+                                               (make-expression-leaf uuid-b [])])]
+      (is (= -10 (ast.plan/evaluate-expression expr {uuid-a 10 uuid-b 20}))))))
+
+(deftest ^:parallel evaluate-expression-multiplication-test
+  (testing "multiplication of two leaves"
+    (let [expr (make-expression-arithmetic :* [(make-expression-leaf uuid-a [])
+                                               (make-expression-leaf uuid-b [])])]
+      (is (= 200 (ast.plan/evaluate-expression expr {uuid-a 10 uuid-b 20}))))))
+
+(deftest ^:parallel evaluate-expression-division-test
+  (testing "division of two leaves"
+    (let [expr (make-expression-arithmetic :/ [(make-expression-leaf uuid-a [])
+                                               (make-expression-leaf uuid-b [])])]
+      (is (= #?(:clj 1/2 :cljs 0.5) (ast.plan/evaluate-expression expr {uuid-a 10 uuid-b 20}))))))
+
+(deftest ^:parallel evaluate-expression-nested-test
+  (testing "nested expression (a + b) * c"
+    (let [inner (make-expression-arithmetic :+ [(make-expression-leaf uuid-a [])
+                                                (make-expression-leaf uuid-b [])])
+          expr  (make-expression-arithmetic :* [inner
+                                                (make-expression-leaf uuid-c [])])]
+      (is (= 150 (ast.plan/evaluate-expression expr {uuid-a 10 uuid-b 20 uuid-c 5}))))))
+
+(deftest ^:parallel evaluate-expression-nil-propagation-test
+  (testing "nil input propagates as nil"
+    (let [expr (make-expression-arithmetic :+ [(make-expression-leaf uuid-a [])
+                                               (make-expression-leaf uuid-b [])])]
+      (is (nil? (ast.plan/evaluate-expression expr {uuid-a 10 uuid-b nil})))
+      (is (nil? (ast.plan/evaluate-expression expr {uuid-a nil uuid-b 20})))
+      (is (nil? (ast.plan/evaluate-expression expr {uuid-a 10}))))))
+
+(deftest ^:parallel evaluate-expression-division-by-zero-test
+  (testing "division by zero returns nil"
+    (let [expr (make-expression-arithmetic :/ [(make-expression-leaf uuid-a [])
+                                               (make-expression-leaf uuid-b [])])]
+      (is (nil? (ast.plan/evaluate-expression expr {uuid-a 10 uuid-b 0}))))))
+
+;;; -------------------------------------------------- index-result-by-dimensions --------------------------------------------------
+
+(deftest ^:parallel index-result-by-dimensions-no-breakouts-test
+  (testing "no breakout columns — single row, empty key"
+    (let [result {:data {:rows [[42]]}}]
+      (is (= {[] 42} (ast.plan/index-result-by-dimensions result 0))))))
+
+(deftest ^:parallel index-result-by-dimensions-with-breakouts-test
+  (testing "two breakout columns"
+    (let [result {:data {:rows [["US" "NY" 100]
+                                ["US" "CA" 200]
+                                ["UK" "London" 50]]}}]
+      (is (= {["US" "NY"] 100
+              ["US" "CA"] 200
+              ["UK" "London"] 50}
+             (ast.plan/index-result-by-dimensions result 2))))))
+
+;;; -------------------------------------------------- join-and-compute --------------------------------------------------
+
+(deftest ^:parallel join-and-compute-inner-join-test
+  (testing "inner join semantics — only matching dimension tuples"
+    (let [expr (make-expression-arithmetic :+ [(make-expression-leaf uuid-a [dim-1])
+                                               (make-expression-leaf uuid-b [dim-1])])
+          leaf-results {uuid-a {:data {:cols [{:name "dim1"} {:name "count"}]
+                                       :rows [["X" 10] ["Y" 20] ["Z" 30]]}}
+                        uuid-b {:data {:cols [{:name "dim1"} {:name "count"}]
+                                       :rows [["X" 100] ["Y" 200] ["W" 400]]}}}
+          result (ast.plan/join-and-compute expr leaf-results 1)]
+      (is (= [["X" 110] ["Y" 220]]
+             (:rows result))))))
+
+(deftest ^:parallel join-and-compute-empty-results-test
+  (testing "no matching tuples returns empty rows"
+    (let [expr (make-expression-arithmetic :+ [(make-expression-leaf uuid-a [dim-1])
+                                               (make-expression-leaf uuid-b [dim-1])])
+          leaf-results {uuid-a {:data {:cols [{:name "dim1"} {:name "count"}]
+                                       :rows [["X" 10]]}}
+                        uuid-b {:data {:cols [{:name "dim1"} {:name "count"}]
+                                       :rows [["Y" 20]]}}}
+          result (ast.plan/join-and-compute expr leaf-results 1)]
+      (is (= [] (:rows result))))))
+
+;;; -------------------------------------------------- validate-arithmetic-ast! --------------------------------------------------
+
+(deftest ^:parallel validate-arithmetic-ast-missing-projections-test
+  (testing "throws 400 when leaves are missing projections"
+    (let [expr (make-expression-arithmetic :+ [(make-expression-leaf uuid-a [])
+                                               (make-expression-leaf uuid-b [])])]
+      (is (thrown-with-msg?
+           #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
+           #"require projections"
+           (ast.plan/validate-arithmetic-ast! expr))))))
+
+(deftest ^:parallel validate-arithmetic-ast-mismatched-dims-test
+  (testing "throws 400 when leaves have different number of breakout dimensions"
+    (let [expr (make-expression-arithmetic :+ [(make-expression-leaf uuid-a [dim-1])
+                                               (make-expression-leaf uuid-b [dim-1 dim-2])])]
+      (is (thrown-with-msg?
+           #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
+           #"same number of breakout"
+           (ast.plan/validate-arithmetic-ast! expr))))))
+
+(deftest ^:parallel validate-arithmetic-ast-mismatched-types-test
+  (testing "throws 400 when leaves have same count but different dimension types"
+    (let [expr (make-expression-arithmetic
+                :+ [(make-expression-leaf uuid-a [dim-1] {dim-1 {:effective-type :type/Integer}})
+                    (make-expression-leaf uuid-b [dim-1] {dim-1 {:effective-type :type/Text}})])]
+      (is (thrown-with-msg?
+           #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
+           #"same breakout dimension types"
+           (ast.plan/validate-arithmetic-ast! expr))))))
+
+(deftest ^:parallel validate-arithmetic-ast-valid-test
+  (testing "valid arithmetic AST passes validation"
+    (let [expr (make-expression-arithmetic :+ [(make-expression-leaf uuid-a [dim-1])
+                                               (make-expression-leaf uuid-b [dim-1])])]
+      (is (nil? (ast.plan/validate-arithmetic-ast! expr))))))
+
+;;; -------------------------------------------------- plan-from-ast --------------------------------------------------
+
+(deftest ^:parallel plan-from-ast-leaf-test
+  (testing "single-source AST produces :leaf plan"
+    (let [ast  {:node/type  :ast/root
+                :expression {:node/type :expression/leaf
+                             :uuid      uuid-a
+                             :ast       (make-leaf-ast [dim-1])}}
+          plan (ast.plan/plan-from-ast ast)]
+      (is (= :leaf (:plan/type plan)))
+      (is (some? (:plan/mbql plan))))))
+
+(deftest ^:parallel plan-from-ast-arithmetic-test
+  (testing "arithmetic AST produces :arithmetic plan"
+    (let [expr (make-expression-arithmetic :+ [(make-expression-leaf uuid-a [dim-1])
+                                               (make-expression-leaf uuid-b [dim-1])])
+          ast  {:node/type  :ast/root
+                :expression expr}
+          plan (ast.plan/plan-from-ast ast)]
+      (is (= :arithmetic (:plan/type plan)))
+      (is (= 2 (count (:plan/leaves plan))))
+      (is (= 1 (:plan/breakout-count plan)))
+      (is (contains? (:plan/leaves plan) uuid-a))
+      (is (contains? (:plan/leaves plan) uuid-b)))))

--- a/test/metabase/lib_metric/ast/schema_test.cljc
+++ b/test/metabase/lib_metric/ast/schema_test.cljc
@@ -277,6 +277,48 @@
        :aggregation {:node/type :aggregation/count}
        :base-table  {:node/type :ast/table :id 1}})))
 
+;;; -------------------------------------------------- Expression Constant Nodes --------------------------------------------------
+
+(deftest ^:parallel expression-constant-test
+  (testing "valid expression constant nodes"
+    (are [node] (nil? (me/humanize (mr/explain ::ast.schema/expression-constant node)))
+      {:node/type :expression/constant :value 42}
+      {:node/type :expression/constant :value 3.14}
+      {:node/type :expression/constant :value -7}
+      {:node/type :expression/constant :value 0}))
+  (testing "invalid expression constant nodes"
+    (testing "missing value"
+      (is (some? (me/humanize (mr/explain ::ast.schema/expression-constant
+                                          {:node/type :expression/constant})))))
+    (testing "non-numeric value"
+      (is (some? (me/humanize (mr/explain ::ast.schema/expression-constant
+                                          {:node/type :expression/constant :value "nope"})))))))
+
+(deftest ^:parallel expression-arithmetic-with-constant-children-test
+  (let [source {:node/type   :source/metric
+                :id          1
+                :aggregation {:node/type :aggregation/count}
+                :base-table  {:node/type :ast/table :id 1}}
+        source-query {:node/type  :ast/source-query
+                      :source     source
+                      :dimensions []
+                      :mappings   []}]
+    (testing "arithmetic with constant children validates"
+      (is (nil? (me/humanize (mr/explain ::ast.schema/expression-arithmetic
+                                         {:node/type :expression/arithmetic
+                                          :operator  :*
+                                          :children  [{:node/type :expression/leaf
+                                                       :uuid      "test-uuid"
+                                                       :ast       source-query}
+                                                      {:node/type :expression/constant
+                                                       :value     100}]})))))))
+
+(deftest ^:parallel expression-node-includes-constant-test
+  (testing "expression-node union includes constants"
+    (is (nil? (me/humanize (mr/explain ::ast.schema/expression-node
+                                       {:node/type :expression/constant
+                                        :value     42}))))))
+
 ;;; -------------------------------------------------- Root Node --------------------------------------------------
 
 (deftest ^:parallel ast-root-test

--- a/test/metabase/lib_metric/ast/schema_test.cljc
+++ b/test/metabase/lib_metric/ast/schema_test.cljc
@@ -287,31 +287,42 @@
         dim    {:node/type :ast/dimension :id uuid-1}
         mapping {:node/type    :ast/dimension-mapping
                  :dimension-id uuid-1
-                 :column       {:node/type :ast/column :id 1}}]
-    (testing "valid root AST"
+                 :column       {:node/type :ast/column :id 1}}
+        source-query-simple {:node/type  :ast/source-query
+                             :source     source
+                             :dimensions []
+                             :mappings   []}
+        source-query-full {:node/type  :ast/source-query
+                           :source     source
+                           :dimensions [dim]
+                           :mappings   [mapping]
+                           :filter     {:node/type :filter/comparison
+                                        :operator  :=
+                                        :dimension {:node/type :ast/dimension-ref :dimension-id uuid-1}
+                                        :values    ["test"]}
+                           :group-by   [{:node/type :ast/dimension-ref :dimension-id uuid-1}]}]
+    (testing "valid root AST with expression leaf"
       (are [node] (nil? (me/humanize (mr/explain ::ast.schema/ast node)))
         {:node/type  :ast/root
-         :source     source
-         :dimensions []
-         :mappings   []}
+         :expression {:node/type :expression/leaf
+                      :uuid      "test-uuid"
+                      :ast       source-query-simple}}
         {:node/type  :ast/root
-         :source     source
-         :dimensions [dim]
-         :mappings   [mapping]
-         :filter     nil
-         :group-by   []}
-        {:node/type  :ast/root
-         :source     source
-         :dimensions [dim]
-         :mappings   [mapping]
-         :filter     {:node/type :filter/comparison
-                      :operator  :=
-                      :dimension {:node/type :ast/dimension-ref :dimension-id uuid-1}
-                      :values    ["test"]}
-         :group-by   [{:node/type :ast/dimension-ref :dimension-id uuid-1}]}))
+         :expression {:node/type :expression/leaf
+                      :uuid      "test-uuid"
+                      :ast       source-query-full}}))
+    (testing "valid root AST with arithmetic expression"
+      (is (nil? (me/humanize (mr/explain ::ast.schema/ast
+                                         {:node/type  :ast/root
+                                          :expression {:node/type :expression/arithmetic
+                                                       :operator  :+
+                                                       :children  [{:node/type :expression/leaf
+                                                                    :uuid      "uuid-a"
+                                                                    :ast       source-query-simple}
+                                                                   {:node/type :expression/leaf
+                                                                    :uuid      "uuid-b"
+                                                                    :ast       source-query-simple}]}})))))
     (testing "invalid root AST"
-      (testing "missing source"
+      (testing "missing expression"
         (is (some? (me/humanize (mr/explain ::ast.schema/ast
-                                            {:node/type  :ast/root
-                                             :dimensions []
-                                             :mappings   []}))))))))
+                                            {:node/type :ast/root}))))))))

--- a/test/metabase/lib_metric/ast/walk_test.cljc
+++ b/test/metabase/lib_metric/ast/walk_test.cljc
@@ -60,8 +60,8 @@
 (def ^:private filter-b (comparison-filter :> dim-ref-2 10))
 (def ^:private filter-c (string-filter :contains dim-ref-1 "foo"))
 
-(def ^:private sample-ast
-  {:node/type  :ast/root
+(def ^:private sample-source-query
+  {:node/type  :ast/source-query
    :source     {:node/type   :source/metric
                 :id          1
                 :aggregation {:node/type :aggregation/count}
@@ -73,6 +73,12 @@
                  :column       {:node/type :ast/column :id 1}}]
    :filter     (and-filter filter-a filter-b)
    :group-by   [dim-ref-1]})
+
+(def ^:private sample-ast
+  {:node/type  :ast/root
+   :expression {:node/type :expression/leaf
+                :uuid      "test-uuid"
+                :ast       sample-source-query}})
 
 ;;; -------------------------------------------------- Predicates --------------------------------------------------
 
@@ -179,7 +185,7 @@
                   #(assoc % :transformed true)
                   sample-ast)]
       ;; Original filters in :filter/and children should be transformed
-      (is (every? :transformed (get-in result [:filter :children]))))))
+      (is (every? :transformed (get-in result [:expression :ast :filter :children]))))))
 
 (deftest ^:parallel transform-by-type-test
   (testing "transforms nodes by type"
@@ -228,7 +234,7 @@
                        placeholder
                        sample-ast)]
       ;; filter-a had := operator, should be replaced
-      (is (= ["REPLACED"] (get-in result [:filter :children 0 :values]))))))
+      (is (= ["REPLACED"] (get-in result [:expression :ast :filter :children 0 :values]))))))
 
 (deftest ^:parallel remove-filters-test
   (testing "removes matching filters from and"
@@ -237,40 +243,42 @@
                   sample-ast)]
       ;; filter-b had :> operator, should be removed
       ;; Since only one child remains, :filter/and should be unwrapped
-      (is (= :filter/comparison (get-in result [:filter :node/type])))
-      (is (= := (get-in result [:filter :operator])))))
+      (is (= :filter/comparison (get-in result [:expression :ast :filter :node/type])))
+      (is (= := (get-in result [:expression :ast :filter :operator])))))
 
   (testing "removes all filters leaving nil"
     (let [all-comparison (ast.walk/remove-filters
                           #(= :filter/comparison (:node/type %))
                           sample-ast)]
-      (is (nil? (:filter all-comparison)))))
+      (is (nil? (get-in all-comparison [:expression :ast :filter])))))
 
   (testing "handles nested compound filters"
-    (let [nested-ast (assoc sample-ast
-                            :filter (and-filter
-                                     (or-filter filter-a filter-b)
-                                     filter-c))
+    (let [nested-source-query (assoc sample-source-query
+                                     :filter (and-filter
+                                              (or-filter filter-a filter-b)
+                                              filter-c))
+          nested-ast (assoc-in sample-ast [:expression :ast] nested-source-query)
           result     (ast.walk/remove-filters
                       #(= :> (:operator %))
                       nested-ast)]
       ;; filter-b removed from inner :or, leaving just filter-a
       ;; Inner :or should unwrap to just filter-a
-      (is (= :filter/and (get-in result [:filter :node/type])))
-      (is (= 2 (count (get-in result [:filter :children]))))))
+      (is (= :filter/and (get-in result [:expression :ast :filter :node/type])))
+      (is (= 2 (count (get-in result [:expression :ast :filter :children]))))))
 
   (testing "handles nested compound where all inner children are removed"
-    (let [nested-ast (assoc sample-ast
-                            :filter (and-filter
-                                     (or-filter filter-a filter-b)
-                                     filter-c))
+    (let [nested-source-query (assoc sample-source-query
+                                     :filter (and-filter
+                                              (or-filter filter-a filter-b)
+                                              filter-c))
+          nested-ast (assoc-in sample-ast [:expression :ast] nested-source-query)
           ;; Remove all comparison filters — inner :or loses both children → nil
           result     (ast.walk/remove-filters
                       #(= :filter/comparison (:node/type %))
                       nested-ast)]
       ;; Only filter-c (string filter) should remain, :and unwrapped
-      (is (= :filter/string (get-in result [:filter :node/type])))
-      (is (= :contains (get-in result [:filter :operator]))))))
+      (is (= :filter/string (get-in result [:expression :ast :filter :node/type])))
+      (is (= :contains (get-in result [:expression :ast :filter :operator]))))))
 
 ;;; -------------------------------------------------- Complex Transformations --------------------------------------------------
 
@@ -288,21 +296,25 @@
                                       (and-filter existing audit-filter)
                                       audit-filter))))
                         sample-ast)]
-      (is (= audit-filter (get-in result [:source :filters]))))))
+      (is (= audit-filter (get-in result [:expression :ast :source :filters]))))))
 
 (deftest ^:parallel dimension-ref-collection-from-filters-test
   (testing "can collect dimension refs from filters only"
-    (let [filter-only-ast {:node/type :ast/root
-                           :source    (:source sample-ast)
-                           :dimensions []
-                           :mappings  []
-                           :filter    (and-filter
-                                       (comparison-filter := dim-ref-1 1)
-                                       (comparison-filter := dim-ref-2 2)
-                                       (or-filter
-                                        (comparison-filter := dim-ref-1 3)
-                                        (comparison-filter := dim-ref-2 4)))
-                           :group-by  []}
+    (let [filter-only-source-query {:node/type  :ast/source-query
+                                    :source     (:source sample-source-query)
+                                    :dimensions []
+                                    :mappings   []
+                                    :filter     (and-filter
+                                                 (comparison-filter := dim-ref-1 1)
+                                                 (comparison-filter := dim-ref-2 2)
+                                                 (or-filter
+                                                  (comparison-filter := dim-ref-1 3)
+                                                  (comparison-filter := dim-ref-2 4)))
+                                    :group-by   []}
+          filter-only-ast {:node/type  :ast/root
+                           :expression {:node/type :expression/leaf
+                                        :uuid      "filter-test-uuid"
+                                        :ast       filter-only-source-query}}
           refs            (ast.walk/collect-dimension-refs filter-only-ast)]
       (is (= 4 (count refs)))
       (is (= #{uuid-1 uuid-2} (set (map :dimension-id refs)))))))

--- a/test/metabase/lib_metric/ast/walk_test.cljc
+++ b/test/metabase/lib_metric/ast/walk_test.cljc
@@ -298,6 +298,32 @@
                         sample-ast)]
       (is (= audit-filter (get-in result [:expression :ast :source :filters]))))))
 
+(deftest ^:parallel collect-constants-test
+  (testing "collect with :expression/constant pred finds constants"
+    (let [constant-node {:node/type :expression/constant :value 100}
+          arith-ast {:node/type  :ast/root
+                     :expression {:node/type :expression/arithmetic
+                                  :operator  :*
+                                  :children  [{:node/type :expression/leaf
+                                               :uuid      "test-uuid"
+                                               :ast       sample-source-query}
+                                              constant-node]}}
+          constants (ast.walk/collect #(= :expression/constant (:node/type %)) arith-ast)]
+      (is (= 1 (count constants)))
+      (is (= 100 (:value (first constants))))))
+  (testing "collect with :expression/leaf pred excludes constants"
+    (let [constant-node {:node/type :expression/constant :value 100}
+          arith-ast {:node/type  :ast/root
+                     :expression {:node/type :expression/arithmetic
+                                  :operator  :*
+                                  :children  [{:node/type :expression/leaf
+                                               :uuid      "test-uuid"
+                                               :ast       sample-source-query}
+                                              constant-node]}}
+          leaves (ast.walk/collect #(= :expression/leaf (:node/type %)) arith-ast)]
+      (is (= 1 (count leaves)))
+      (is (= "test-uuid" (:uuid (first leaves)))))))
+
 (deftest ^:parallel dimension-ref-collection-from-filters-test
   (testing "can collect dimension refs from filters only"
     (let [filter-only-source-query {:node/type  :ast/source-query

--- a/test/metabase/lib_metric/definition_test.cljc
+++ b/test/metabase/lib_metric/definition_test.cljc
@@ -240,6 +240,13 @@
           expr  [:* {} inner leaf3]]
       (is (= [leaf1 leaf2 leaf3] (lib-metric.definition/expression-leaves expr))))))
 
+(deftest ^:parallel expression-leaves-with-constant-test
+  (testing "arithmetic with constant returns only the metric leaf"
+    (let [leaf [:metric {:lib/uuid "a"} 1]]
+      (is (= [leaf] (lib-metric.definition/expression-leaves [:* {} leaf 100])))))
+  (testing "bare number returns empty vector"
+    (is (= [] (lib-metric.definition/expression-leaves 42)))))
+
 (deftest ^:parallel expression-leaves-invalid-input-test
   (testing "nil returns empty vector"
     (is (= [] (lib-metric.definition/expression-leaves nil))))
@@ -299,6 +306,15 @@
                       :projections       [{:type :metric :id 1 :projection [[:dimension {} uuid-1]]}]
                       :metadata-provider mock-provider}]
       (is (not (lib-metric.definition/projection-valid? definition))))))
+
+(deftest ^:parallel projection-valid?-constant-in-arithmetic-test
+  (testing "only real leaves need projections when constants present"
+    (let [definition {:lib/type          :metric/definition
+                      :expression        [:* {} [:metric {:lib/uuid "a"} 1] 100]
+                      :filters           []
+                      :projections       [{:type :metric :id 1 :projection [[:dimension {} uuid-1]]}]
+                      :metadata-provider mock-provider}]
+      (is (lib-metric.definition/projection-valid? definition)))))
 
 (deftest ^:parallel projection-valid?-wrong-type-match-test
   (testing "projection with wrong type does not match"

--- a/test/metabase/lib_metric/definition_test.cljc
+++ b/test/metabase/lib_metric/definition_test.cljc
@@ -191,7 +191,11 @@
 (deftest ^:parallel expression-leaf-id-test
   (is (= 42 (lib-metric.definition/expression-leaf-id [:metric {:lib/uuid "a"} 42])))
   (is (= 99 (lib-metric.definition/expression-leaf-id [:measure {:lib/uuid "a"} 99])))
-  (is (nil? (lib-metric.definition/expression-leaf-id nil))))
+  (is (nil? (lib-metric.definition/expression-leaf-id nil)))
+  (is (thrown-with-msg? #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
+                        #"adhoc leaves have no persisted ID"
+                        (lib-metric.definition/expression-leaf-id
+                         [:adhoc {:lib/uuid "x"} {:database-id 1 :table-id 2 :aggregation [:count {}]}]))))
 
 (deftest ^:parallel expression-leaf-uuid-test
   (is (= "a" (lib-metric.definition/expression-leaf-uuid [:metric {:lib/uuid "a"} 42])))
@@ -366,7 +370,6 @@
                       :metadata-provider mock-provider}
           result     (lib-metric.definition/unprojected-sources definition)]
       (is (empty? result)))))
-
 
 ;;; -------------------------------------------------- Schema Validation --------------------------------------------------
 

--- a/test/metabase/lib_metric/definition_test.cljc
+++ b/test/metabase/lib_metric/definition_test.cljc
@@ -260,6 +260,98 @@
                (lib-metric.definition/expression-leaves [op {} leaf1 leaf2]))
             (str "operator " op " should be supported"))))))
 
+;;; -------------------------------------------------- projection-valid? --------------------------------------------------
+
+(deftest ^:parallel projection-valid?-single-leaf-no-projections-test
+  (testing "single leaf with no projections is not valid"
+    (let [definition (lib-metric.definition/from-metric-metadata mock-provider sample-metric-metadata)]
+      (is (not (lib-metric.definition/projection-valid? definition))))))
+
+(deftest ^:parallel projection-valid?-single-leaf-with-projection-test
+  (testing "single leaf with a projection is valid"
+    (let [definition (-> (lib-metric.definition/from-metric-metadata mock-provider sample-metric-metadata)
+                         (assoc :projections [{:type :metric :id 42
+                                               :projection [[:dimension {} uuid-1]]}]))]
+      (is (lib-metric.definition/projection-valid? definition)))))
+
+(deftest ^:parallel projection-valid?-single-leaf-empty-projection-vector-test
+  (testing "single leaf with empty projection vector is not valid"
+    (let [definition (-> (lib-metric.definition/from-metric-metadata mock-provider sample-metric-metadata)
+                         (assoc :projections [{:type :metric :id 42
+                                               :projection []}]))]
+      (is (not (lib-metric.definition/projection-valid? definition))))))
+
+(deftest ^:parallel projection-valid?-arithmetic-all-projected-test
+  (testing "arithmetic expression with all leaves projected is valid"
+    (let [definition {:lib/type          :metric/definition
+                      :expression        [:+ {} [:metric {:lib/uuid "a"} 1] [:measure {:lib/uuid "b"} 2]]
+                      :filters           []
+                      :projections       [{:type :metric  :id 1 :projection [[:dimension {} uuid-1]]}
+                                          {:type :measure :id 2 :projection [[:dimension {} uuid-2]]}]
+                      :metadata-provider mock-provider}]
+      (is (lib-metric.definition/projection-valid? definition)))))
+
+(deftest ^:parallel projection-valid?-arithmetic-one-missing-test
+  (testing "arithmetic expression with one leaf missing projection is not valid"
+    (let [definition {:lib/type          :metric/definition
+                      :expression        [:+ {} [:metric {:lib/uuid "a"} 1] [:measure {:lib/uuid "b"} 2]]
+                      :filters           []
+                      :projections       [{:type :metric :id 1 :projection [[:dimension {} uuid-1]]}]
+                      :metadata-provider mock-provider}]
+      (is (not (lib-metric.definition/projection-valid? definition))))))
+
+(deftest ^:parallel projection-valid?-wrong-type-match-test
+  (testing "projection with wrong type does not match"
+    (let [definition {:lib/type          :metric/definition
+                      :expression        [:metric {:lib/uuid "a"} 1]
+                      :filters           []
+                      :projections       [{:type :measure :id 1 :projection [[:dimension {} uuid-1]]}]
+                      :metadata-provider mock-provider}]
+      (is (not (lib-metric.definition/projection-valid? definition))))))
+
+;;; -------------------------------------------------- unprojected-sources --------------------------------------------------
+
+(deftest ^:parallel unprojected-sources-single-leaf-no-projections-test
+  (testing "single leaf with no projections returns the leaf"
+    (let [definition (lib-metric.definition/from-metric-metadata mock-provider sample-metric-metadata)
+          result     (lib-metric.definition/unprojected-sources definition)]
+      (is (= 1 (count result)))
+      (is (= :metric (first (first result))))
+      (is (= 42 (nth (first result) 2))))))
+
+(deftest ^:parallel unprojected-sources-single-leaf-with-projection-test
+  (testing "single leaf with projection returns empty"
+    (let [definition (-> (lib-metric.definition/from-metric-metadata mock-provider sample-metric-metadata)
+                         (assoc :projections [{:type :metric :id 42
+                                               :projection [[:dimension {} uuid-1]]}]))
+          result     (lib-metric.definition/unprojected-sources definition)]
+      (is (empty? result)))))
+
+(deftest ^:parallel unprojected-sources-arithmetic-one-missing-test
+  (testing "arithmetic with one missing returns that leaf"
+    (let [leaf-b     [:measure {:lib/uuid "b"} 2]
+          definition {:lib/type          :metric/definition
+                      :expression        [:+ {} [:metric {:lib/uuid "a"} 1] leaf-b]
+                      :filters           []
+                      :projections       [{:type :metric :id 1 :projection [[:dimension {} uuid-1]]}]
+                      :metadata-provider mock-provider}
+          result     (lib-metric.definition/unprojected-sources definition)]
+      (is (= 1 (count result)))
+      (is (= :measure (first (first result))))
+      (is (= 2 (nth (first result) 2))))))
+
+(deftest ^:parallel unprojected-sources-all-projected-test
+  (testing "all sources projected returns empty"
+    (let [definition {:lib/type          :metric/definition
+                      :expression        [:+ {} [:metric {:lib/uuid "a"} 1] [:measure {:lib/uuid "b"} 2]]
+                      :filters           []
+                      :projections       [{:type :metric  :id 1 :projection [[:dimension {} uuid-1]]}
+                                          {:type :measure :id 2 :projection [[:dimension {} uuid-2]]}]
+                      :metadata-provider mock-provider}
+          result     (lib-metric.definition/unprojected-sources definition)]
+      (is (empty? result)))))
+
+
 ;;; -------------------------------------------------- Schema Validation --------------------------------------------------
 
 (deftest ^:parallel metric-definition-schema-test

--- a/test/metabase/lib_metric/filter_test.cljc
+++ b/test/metabase/lib_metric/filter_test.cljc
@@ -451,6 +451,7 @@
       (is (thrown? #?(:clj Exception :cljs js/Error)
                    (lib-metric.filter/exclude-date-filter-clause parts))))))
 
+
 (deftest ^:parallel exclude-date-filter-clause-null-test
   (testing "exclude-date-filter-clause creates null check clause"
     (let [dimension {:id "dim-date" :effective-type :type/DateTime}

--- a/test/metabase/lib_metric/schema_test.cljc
+++ b/test/metabase/lib_metric/schema_test.cljc
@@ -5,6 +5,10 @@
    [metabase.lib-metric.schema :as lib-metric.schema]
    [metabase.util.malli.registry :as mr]))
 
+(def ^:private uuid-a "550e8400-e29b-41d4-a716-446655440000")
+(def ^:private uuid-b "550e8400-e29b-41d4-a716-446655440001")
+(def ^:private uuid-c "550e8400-e29b-41d4-a716-446655440002")
+
 (deftest ^:parallel dimension-id-test
   (testing "dimension-id must be a valid UUID string"
     (are [id valid?] (= valid? (mr/validate ::lib-metric.schema/dimension-id id))
@@ -140,3 +144,135 @@
     (testing "wrong arity"
       (is (some? (me/humanize (mr/explain ::lib-metric.schema/dimension-reference
                                           [:dimension {} "550e8400-e29b-41d4-a716-446655440000" "extra"])))))))
+
+;;; -------------------------------------------------- Ad-hoc Schemas --------------------------------------------------
+
+(def ^:private sample-field-ref
+  [:field {:lib/uuid uuid-a :table-id 1} 42])
+
+(def ^:private sample-adhoc-dimension
+  {:id             uuid-a
+   :field-ref      sample-field-ref
+   :display-name   "Tax"
+   :effective-type :type/Float
+   :semantic-type  :type/Currency})
+
+(def ^:private sample-adhoc-definition
+  {:database-id 1
+   :table-id    10
+   :aggregation [:count {}]
+   :dimensions  [sample-adhoc-dimension]})
+
+(deftest ^:parallel adhoc-dimension-test
+  (testing "valid adhoc dimensions"
+    (are [dim] (nil? (me/humanize (mr/explain ::lib-metric.schema/adhoc-dimension dim)))
+      sample-adhoc-dimension
+      ;; minimal — only required fields
+      {:id        uuid-a
+       :field-ref sample-field-ref}
+      ;; optional fields explicitly nil
+      {:id             uuid-a
+       :field-ref      sample-field-ref
+       :display-name   nil
+       :effective-type nil
+       :semantic-type  nil}))
+  (testing "invalid adhoc dimensions"
+    (testing "missing id"
+      (is (some? (me/humanize (mr/explain ::lib-metric.schema/adhoc-dimension
+                                          {:field-ref sample-field-ref})))))
+    (testing "missing field-ref"
+      (is (some? (me/humanize (mr/explain ::lib-metric.schema/adhoc-dimension
+                                          {:id uuid-a})))))
+    (testing "invalid id (not UUID)"
+      (is (some? (me/humanize (mr/explain ::lib-metric.schema/adhoc-dimension
+                                          {:id "not-uuid" :field-ref sample-field-ref})))))))
+
+(deftest ^:parallel adhoc-definition-test
+  (testing "valid definitions"
+    (are [def-map] (nil? (me/humanize (mr/explain ::lib-metric.schema/adhoc-definition def-map)))
+      sample-adhoc-definition
+      ;; with filter
+      (assoc sample-adhoc-definition :filter [:= {} [:field {} 1] "foo"])
+      ;; empty dimensions
+      (assoc sample-adhoc-definition :dimensions [])
+      ;; aggregation with column
+      (assoc sample-adhoc-definition :aggregation [:sum {} [:field {:lib/uuid uuid-b :table-id 10} 5]])))
+  (testing "invalid definitions"
+    (testing "missing database-id"
+      (is (some? (me/humanize (mr/explain ::lib-metric.schema/adhoc-definition
+                                          (dissoc sample-adhoc-definition :database-id))))))
+    (testing "missing table-id"
+      (is (some? (me/humanize (mr/explain ::lib-metric.schema/adhoc-definition
+                                          (dissoc sample-adhoc-definition :table-id))))))
+    (testing "missing aggregation"
+      (is (some? (me/humanize (mr/explain ::lib-metric.schema/adhoc-definition
+                                          (dissoc sample-adhoc-definition :aggregation))))))
+    (testing "missing dimensions"
+      (is (some? (me/humanize (mr/explain ::lib-metric.schema/adhoc-definition
+                                          (dissoc sample-adhoc-definition :dimensions))))))))
+
+(deftest ^:parallel adhoc-expression-ref-test
+  (testing "valid adhoc expression refs"
+    (is (nil? (me/humanize (mr/explain ::lib-metric.schema/adhoc-expression-ref
+                                       [:adhoc {:lib/uuid uuid-a} sample-adhoc-definition])))))
+  (testing "invalid adhoc expression refs"
+    (testing "missing lib/uuid"
+      (is (some? (me/humanize (mr/explain ::lib-metric.schema/adhoc-expression-ref
+                                          [:adhoc {} sample-adhoc-definition])))))
+    (testing "wrong tag"
+      (is (some? (me/humanize (mr/explain ::lib-metric.schema/adhoc-expression-ref
+                                          [:metric {:lib/uuid uuid-a} sample-adhoc-definition])))))))
+
+(deftest ^:parallel expression-leaf-adhoc-test
+  (testing "adhoc refs are accepted by the expression-leaf union"
+    (is (nil? (me/humanize (mr/explain ::lib-metric.schema/expression-leaf
+                                       [:adhoc {:lib/uuid uuid-a} sample-adhoc-definition])))))
+  (testing "metric refs still validate"
+    (is (nil? (me/humanize (mr/explain ::lib-metric.schema/expression-leaf
+                                       [:metric {:lib/uuid uuid-a} 42])))))
+  (testing "measure refs still validate"
+    (is (nil? (me/humanize (mr/explain ::lib-metric.schema/expression-leaf
+                                       [:measure {:lib/uuid uuid-a} 99]))))))
+
+(deftest ^:parallel normalize-math-expression-adhoc-test
+  (testing "normalizes an adhoc leaf expression"
+    (let [raw     ["adhoc" {"lib/uuid" uuid-a}
+                   {:database-id 1 :table-id 10
+                    :aggregation [:count {}]
+                    :dimensions  [{:id        uuid-b
+                                   :field-ref [:field {"lib/uuid" uuid-c "table-id" 10} 42]
+                                   :effective-type "type/Integer"}]}]
+          result  (lib-metric.schema/normalize-math-expression raw)]
+      (is (= :adhoc (first result)))
+      (is (= uuid-a (get-in result [1 :lib/uuid])))
+      (is (= :type/Integer (get-in result [2 :dimensions 0 :effective-type])))))
+  (testing "adhoc leaf validates as metric-math-expression after normalization"
+    (is (mr/validate ::lib-metric.schema/metric-math-expression
+                     [:adhoc {:lib/uuid uuid-a} sample-adhoc-definition])))
+  (testing "arithmetic with adhoc + metric validates"
+    (is (mr/validate ::lib-metric.schema/metric-math-expression
+                     [:+ {}
+                      [:metric {:lib/uuid uuid-a} 1]
+                      [:adhoc {:lib/uuid uuid-b} sample-adhoc-definition]])))
+  (testing "arithmetic with adhoc + measure validates"
+    (is (mr/validate ::lib-metric.schema/metric-math-expression
+                     [:- {}
+                      [:measure {:lib/uuid uuid-a} 5]
+                      [:adhoc {:lib/uuid uuid-b} sample-adhoc-definition]]))))
+
+(deftest ^:parallel typed-projection-adhoc-test
+  (testing "adhoc typed projection with lib/uuid validates"
+    (is (nil? (me/humanize (mr/explain ::lib-metric.schema/typed-projection
+                                       {:type       :adhoc
+                                        :lib/uuid   uuid-a
+                                        :projection [[:dimension {} uuid-b]]})))))
+  (testing "metric typed projection still validates"
+    (is (nil? (me/humanize (mr/explain ::lib-metric.schema/typed-projection
+                                       {:type       :metric
+                                        :id         42
+                                        :projection [[:dimension {} uuid-a]]})))))
+  (testing "measure typed projection still validates"
+    (is (nil? (me/humanize (mr/explain ::lib-metric.schema/typed-projection
+                                       {:type       :measure
+                                        :id         99
+                                        :projection [[:dimension {} uuid-a]]}))))))

--- a/test/metabase/measures/models/measure_test.clj
+++ b/test/metabase/measures/models/measure_test.clj
@@ -339,4 +339,3 @@
       (is (false? (mi/can-create? :model/Measure {:name "Test Measure"
                                                   :table_id (mt/id :venues)
                                                   :definition (measure-definition (lib/count))}))))))
-

--- a/test/metabase/measures/models/measure_test.clj
+++ b/test/metabase/measures/models/measure_test.clj
@@ -339,3 +339,4 @@
       (is (false? (mi/can-create? :model/Measure {:name "Test Measure"
                                                   :table_id (mt/id :venues)
                                                   :definition (measure-definition (lib/count))}))))))
+

--- a/test/metabase/metrics/api_arithmetic_test.clj
+++ b/test/metabase/metrics/api_arithmetic_test.clj
@@ -150,6 +150,124 @@
             (is (= (* 2 single-val) (get double-rows dim-val))
                 (str "Value for " dim-val " should be doubled"))))))))
 
+(deftest arithmetic-nested-values-test
+  (testing "POST /api/metric/dataset nested (A + A) * 2 returns 4N per row"
+    (mt/with-temp [:model/Card metric {:name          "Test Metric"
+                                       :type          :metric
+                                       :dataset_query (mt/mbql-query venues {:aggregation [[:count]]})}]
+      (mt/user-http-request :rasta :get 200 (str "metric/" (:id metric)))
+      (let [metric-response (mt/user-http-request :rasta :get 200 (str "metric/" (:id metric)))
+            dim-uuid        (:id (first (:dimensions metric-response)))
+            projections     [{:type :metric :id (:id metric)
+                              :projection [[:dimension {} dim-uuid]]}]
+            baseline        (mt/user-http-request :rasta :post 202 "metric/dataset"
+                                                  {:definition
+                                                   {:expression   [:metric {:lib/uuid "x"} (:id metric)]
+                                                    :projections  projections}})
+            response        (mt/user-http-request :rasta :post 202 "metric/dataset"
+                                                  {:definition
+                                                   {:expression   [:* {}
+                                                                   [:+ {}
+                                                                    [:metric {:lib/uuid "a"} (:id metric)]
+                                                                    [:metric {:lib/uuid "b"} (:id metric)]]
+                                                                   2]
+                                                    :projections  projections}})]
+        (is (= "completed" (:status response)))
+        (is (pos? (:row_count response)))
+        (let [base-rows   (into {} (map (fn [[k v]] [k v]) (get-in baseline [:data :rows])))
+              nested-rows (into {} (map (fn [[k v]] [k v]) (get-in response [:data :rows])))]
+          (doseq [[dim-val base-val] base-rows]
+            (is (= (* 4 base-val) (get nested-rows dim-val))
+                (str "Value for " dim-val " should be 4N"))))))))
+
+(deftest arithmetic-associativity-test
+  (testing "POST /api/metric/dataset nesting position affects result"
+    (mt/with-temp [:model/Card metric {:name          "Test Metric"
+                                       :type          :metric
+                                       :dataset_query (mt/mbql-query venues {:aggregation [[:count]]})}]
+      (mt/user-http-request :rasta :get 200 (str "metric/" (:id metric)))
+      (let [metric-response (mt/user-http-request :rasta :get 200 (str "metric/" (:id metric)))
+            dim-uuid        (:id (first (:dimensions metric-response)))
+            projections     [{:type :metric :id (:id metric)
+                              :projection [[:dimension {} dim-uuid]]}]
+            ;; A / (A / 2) = N / (N/2) = 2.0
+            response-a      (mt/user-http-request :rasta :post 202 "metric/dataset"
+                                                  {:definition
+                                                   {:expression   [:/ {}
+                                                                   [:metric {:lib/uuid "a"} (:id metric)]
+                                                                   [:/ {}
+                                                                    [:metric {:lib/uuid "b"} (:id metric)]
+                                                                    2]]
+                                                    :projections  projections}})
+            ;; (A / A) / 2 = (N/N) / 2 = 0.5
+            response-b      (mt/user-http-request :rasta :post 202 "metric/dataset"
+                                                  {:definition
+                                                   {:expression   [:/ {}
+                                                                   [:/ {}
+                                                                    [:metric {:lib/uuid "a"} (:id metric)]
+                                                                    [:metric {:lib/uuid "b"} (:id metric)]]
+                                                                   2]
+                                                    :projections  projections}})]
+        (is (= "completed" (:status response-a)))
+        (is (= "completed" (:status response-b)))
+        (let [rows-a (into {} (map (fn [[k v]] [k (double v)]) (get-in response-a [:data :rows])))
+              rows-b (into {} (map (fn [[k v]] [k (double v)]) (get-in response-b [:data :rows])))]
+          (doseq [[dim-val val-a] rows-a]
+            (is (= 2.0 val-a) (str "A/(A/2) should be 2.0 for " dim-val))
+            (is (= 0.5 (get rows-b dim-val)) (str "(A/A)/2 should be 0.5 for " dim-val))))))))
+
+(deftest arithmetic-deeply-nested-test
+  (testing "POST /api/metric/dataset with 3-level nesting ((A + A) * A) / 2 = N²"
+    (mt/with-temp [:model/Card metric {:name          "Test Metric"
+                                       :type          :metric
+                                       :dataset_query (mt/mbql-query venues {:aggregation [[:count]]})}]
+      (mt/user-http-request :rasta :get 200 (str "metric/" (:id metric)))
+      (let [metric-response (mt/user-http-request :rasta :get 200 (str "metric/" (:id metric)))
+            dim-uuid        (:id (first (:dimensions metric-response)))
+            projections     [{:type :metric :id (:id metric)
+                              :projection [[:dimension {} dim-uuid]]}]
+            baseline        (mt/user-http-request :rasta :post 202 "metric/dataset"
+                                                  {:definition
+                                                   {:expression   [:metric {:lib/uuid "x"} (:id metric)]
+                                                    :projections  projections}})
+            response        (mt/user-http-request :rasta :post 202 "metric/dataset"
+                                                  {:definition
+                                                   {:expression   [:/ {}
+                                                                   [:* {}
+                                                                    [:+ {}
+                                                                     [:metric {:lib/uuid "a"} (:id metric)]
+                                                                     [:metric {:lib/uuid "b"} (:id metric)]]
+                                                                    [:metric {:lib/uuid "c"} (:id metric)]]
+                                                                   2]
+                                                    :projections  projections}})]
+        (is (= "completed" (:status response)))
+        (is (pos? (:row_count response)))
+        (let [base-rows (into {} (map (fn [[k v]] [k v]) (get-in baseline [:data :rows])))
+              deep-rows (into {} (map (fn [[k v]] [k v]) (get-in response [:data :rows])))]
+          (doseq [[dim-val base-val] base-rows]
+            (is (= (* base-val base-val) (get deep-rows dim-val))
+                (str "((A+A)*A)/2 should be N² for " dim-val))))))))
+
+(deftest arithmetic-nested-division-by-zero-test
+  (testing "POST /api/metric/dataset A / (A - A) returns 0 rows (zero guard)"
+    (mt/with-temp [:model/Card metric {:name          "Test Metric"
+                                       :type          :metric
+                                       :dataset_query (mt/mbql-query venues {:aggregation [[:count]]})}]
+      (mt/user-http-request :rasta :get 200 (str "metric/" (:id metric)))
+      (let [metric-response (mt/user-http-request :rasta :get 200 (str "metric/" (:id metric)))
+            dim-uuid        (:id (first (:dimensions metric-response)))
+            response        (mt/user-http-request :rasta :post 202 "metric/dataset"
+                                                  {:definition
+                                                   {:expression   [:/ {}
+                                                                   [:metric {:lib/uuid "a"} (:id metric)]
+                                                                   [:- {}
+                                                                    [:metric {:lib/uuid "b"} (:id metric)]
+                                                                    [:metric {:lib/uuid "c"} (:id metric)]]]
+                                                    :projections  [{:type :metric :id (:id metric)
+                                                                    :projection [[:dimension {} dim-uuid]]}]}})]
+        (is (= "completed" (:status response)))
+        (is (zero? (:row_count response)))))))
+
 (deftest arithmetic-mixed-metric-measure-test
   (testing "POST /api/metric/dataset with metric + measure arithmetic"
     (let [mp             (mt/metadata-provider)

--- a/test/metabase/metrics/api_arithmetic_test.clj
+++ b/test/metabase/metrics/api_arithmetic_test.clj
@@ -121,6 +121,35 @@
         (is (= "completed" (:status response)))
         (is (pos? (:row_count response)))))))
 
+(deftest arithmetic-metric-times-constant-test
+  (testing "POST /api/metric/dataset with [:* {} [:metric ...] 2] returns correct results"
+    (mt/with-temp [:model/Card metric {:name          "Test Metric"
+                                       :type          :metric
+                                       :dataset_query (mt/mbql-query venues {:aggregation [[:count]]})}]
+      (mt/user-http-request :rasta :get 200 (str "metric/" (:id metric)))
+      (let [metric-response (mt/user-http-request :rasta :get 200 (str "metric/" (:id metric)))
+            dim-uuid        (:id (first (:dimensions metric-response)))
+            response        (mt/user-http-request :rasta :post 202 "metric/dataset"
+                                                  {:definition
+                                                   {:expression   [:* {}
+                                                                   [:metric {:lib/uuid "a"} (:id metric)]
+                                                                   2]
+                                                    :projections  [{:type :metric :id (:id metric)
+                                                                    :projection [[:dimension {} dim-uuid]]}]}})]
+        (is (= "completed" (:status response)))
+        (is (pos? (:row_count response)))
+        ;; Each result should be exactly double the count
+        (let [single-response (mt/user-http-request :rasta :post 202 "metric/dataset"
+                                                    {:definition
+                                                     {:expression   [:metric {:lib/uuid "x"} (:id metric)]
+                                                      :projections  [{:type :metric :id (:id metric)
+                                                                      :projection [[:dimension {} dim-uuid]]}]}})
+              single-rows     (into {} (map (fn [[k v]] [k v]) (get-in single-response [:data :rows])))
+              double-rows     (into {} (map (fn [[k v]] [k v]) (get-in response [:data :rows])))]
+          (doseq [[dim-val single-val] single-rows]
+            (is (= (* 2 single-val) (get double-rows dim-val))
+                (str "Value for " dim-val " should be doubled"))))))))
+
 (deftest arithmetic-mixed-metric-measure-test
   (testing "POST /api/metric/dataset with metric + measure arithmetic"
     (let [mp             (mt/metadata-provider)

--- a/test/metabase/metrics/api_arithmetic_test.clj
+++ b/test/metabase/metrics/api_arithmetic_test.clj
@@ -1,0 +1,155 @@
+(ns metabase.metrics.api-arithmetic-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
+   [metabase.metrics.core :as metrics]
+   [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
+   [toucan2.core :as t2]))
+
+(use-fixtures :once (fixtures/initialize :db :web-server :test-users))
+
+(deftest arithmetic-metric-plus-metric-test
+  (testing "POST /api/metric/dataset with metric_A + metric_B returns correct sum"
+    (mt/with-temp [:model/Card metric-a {:name          "Metric A"
+                                         :type          :metric
+                                         :dataset_query (mt/mbql-query venues {:aggregation [[:count]]})}
+                   :model/Card metric-b {:name          "Metric B"
+                                         :type          :metric
+                                         :dataset_query (mt/mbql-query venues {:aggregation [[:count]]})}]
+      ;; Trigger dimension sync for both metrics
+      (mt/user-http-request :rasta :get 200 (str "metric/" (:id metric-a)))
+      (mt/user-http-request :rasta :get 200 (str "metric/" (:id metric-b)))
+      ;; Get dimension UUIDs from each metric separately
+      (let [metric-a-response (mt/user-http-request :rasta :get 200 (str "metric/" (:id metric-a)))
+            metric-b-response (mt/user-http-request :rasta :get 200 (str "metric/" (:id metric-b)))
+            dim-a-uuid        (:id (first (:dimensions metric-a-response)))
+            dim-b-uuid        (:id (first (:dimensions metric-b-response)))
+            response          (mt/user-http-request :rasta :post 202 "metric/dataset"
+                                                    {:definition
+                                                     {:expression   [:+ {}
+                                                                     [:metric {:lib/uuid "a"} (:id metric-a)]
+                                                                     [:metric {:lib/uuid "b"} (:id metric-b)]]
+                                                      :projections  [{:type :metric :id (:id metric-a)
+                                                                      :projection [[:dimension {} dim-a-uuid]]}
+                                                                     {:type :metric :id (:id metric-b)
+                                                                      :projection [[:dimension {} dim-b-uuid]]}]}})]
+        (is (= "completed" (:status response)))
+        (is (pos? (:row_count response)))
+        ;; Each row should have [dim-value, sum] where sum is a+b for that dimension value
+        (is (every? #(= 2 (count %)) (get-in response [:data :rows])))))))
+
+(deftest arithmetic-subtraction-test
+  (testing "POST /api/metric/dataset with metric_A - metric_B"
+    (mt/with-temp [:model/Card metric-a {:name          "Metric A"
+                                         :type          :metric
+                                         :dataset_query (mt/mbql-query venues {:aggregation [[:count]]})}
+                   :model/Card metric-b {:name          "Metric B"
+                                         :type          :metric
+                                         :dataset_query (mt/mbql-query venues {:aggregation [[:count]]})}]
+      (mt/user-http-request :rasta :get 200 (str "metric/" (:id metric-a)))
+      (mt/user-http-request :rasta :get 200 (str "metric/" (:id metric-b)))
+      (let [metric-a-response (mt/user-http-request :rasta :get 200 (str "metric/" (:id metric-a)))
+            metric-b-response (mt/user-http-request :rasta :get 200 (str "metric/" (:id metric-b)))
+            dim-a-uuid        (:id (first (:dimensions metric-a-response)))
+            dim-b-uuid        (:id (first (:dimensions metric-b-response)))
+            response          (mt/user-http-request :rasta :post 202 "metric/dataset"
+                                                    {:definition
+                                                     {:expression   [:- {}
+                                                                     [:metric {:lib/uuid "a"} (:id metric-a)]
+                                                                     [:metric {:lib/uuid "b"} (:id metric-b)]]
+                                                      :projections  [{:type :metric :id (:id metric-a)
+                                                                      :projection [[:dimension {} dim-a-uuid]]}
+                                                                     {:type :metric :id (:id metric-b)
+                                                                      :projection [[:dimension {} dim-b-uuid]]}]}})]
+        (is (= "completed" (:status response)))
+        ;; Same query minus itself: all values should be 0
+        (is (every? #(zero? (last %)) (get-in response [:data :rows])))))))
+
+(deftest arithmetic-with-instance-filters-test
+  (testing "POST /api/metric/dataset with instance filters on arithmetic"
+    (mt/with-temp [:model/Card metric {:name          "Test Metric"
+                                       :type          :metric
+                                       :dataset_query (mt/mbql-query venues {:aggregation [[:count]]})}]
+      (mt/user-http-request :rasta :get 200 (str "metric/" (:id metric)))
+      (let [metric-response (mt/user-http-request :rasta :get 200 (str "metric/" (:id metric)))
+            dim             (first (:dimensions metric-response))
+            dim-uuid        (:id dim)
+            response        (mt/user-http-request :rasta :post 202 "metric/dataset"
+                                                  {:definition
+                                                   {:expression   [:- {}
+                                                                   [:metric {:lib/uuid "a"} (:id metric)]
+                                                                   [:metric {:lib/uuid "b"} (:id metric)]]
+                                                    :filters      [{:lib/uuid "a"
+                                                                    :filter [:= {} [:dimension {} dim-uuid] 1]}]
+                                                    :projections  [{:type :metric :id (:id metric)
+                                                                    :projection [[:dimension {} dim-uuid]]}]}})]
+        (is (= "completed" (:status response)))))))
+
+(deftest arithmetic-missing-projections-test
+  (testing "POST /api/metric/dataset arithmetic without projections returns 400"
+    (mt/with-temp [:model/Card metric {:name          "Test Metric"
+                                       :type          :metric
+                                       :dataset_query (mt/mbql-query venues {:aggregation [[:count]]})}]
+      ;; Arithmetic without projections should fail validation
+      (is (some? (mt/user-http-request :rasta :post 400 "metric/dataset"
+                                       {:definition
+                                        {:expression [:+ {}
+                                                      [:metric {:lib/uuid "a"} (:id metric)]
+                                                      [:metric {:lib/uuid "b"} (:id metric)]]}}))))))
+
+(deftest arithmetic-nested-expression-test
+  (testing "POST /api/metric/dataset with nested (A + B) * C"
+    (mt/with-temp [:model/Card metric {:name          "Test Metric"
+                                       :type          :metric
+                                       :dataset_query (mt/mbql-query venues {:aggregation [[:count]]})}]
+      (mt/user-http-request :rasta :get 200 (str "metric/" (:id metric)))
+      (let [metric-response (mt/user-http-request :rasta :get 200 (str "metric/" (:id metric)))
+            dim             (first (:dimensions metric-response))
+            dim-uuid        (:id dim)
+            _               (assert dim-uuid (str "No dimension found in metric response: " (pr-str (:dimensions metric-response))))
+            response        (mt/user-http-request :rasta :post 202 "metric/dataset"
+                                                  {:definition
+                                                   {:expression   [:* {}
+                                                                   [:+ {}
+                                                                    [:metric {:lib/uuid "a"} (:id metric)]
+                                                                    [:metric {:lib/uuid "b"} (:id metric)]]
+                                                                   [:metric {:lib/uuid "c"} (:id metric)]]
+                                                    :projections  [{:type :metric :id (:id metric)
+                                                                    :projection [[:dimension {} dim-uuid]]}]}})]
+        (is (= "completed" (:status response)))
+        (is (pos? (:row_count response)))))))
+
+(deftest arithmetic-mixed-metric-measure-test
+  (testing "POST /api/metric/dataset with metric + measure arithmetic"
+    (let [mp             (mt/metadata-provider)
+          table-metadata (lib.metadata/table mp (mt/id :venues))
+          pmbql-def      (-> (lib/query mp table-metadata)
+                             (lib/aggregate (lib/count)))]
+      (mt/with-temp [:model/Card    metric  {:name          "Test Metric"
+                                             :type          :metric
+                                             :dataset_query (mt/mbql-query venues {:aggregation [[:count]]})}
+                     :model/Measure measure {:name       "Test Measure"
+                                             :table_id   (mt/id :venues)
+                                             :definition pmbql-def}]
+        (mt/with-full-data-perms-for-all-users!
+          ;; Sync dimensions for both metric and measure
+          (mt/user-http-request :rasta :get 200 (str "metric/" (:id metric)))
+          (metrics/sync-dimensions! :metadata/measure (:id measure))
+          ;; Get dimension UUIDs from each entity
+          (let [metric-response  (mt/user-http-request :rasta :get 200 (str "metric/" (:id metric)))
+                dim-metric-uuid  (:id (first (:dimensions metric-response)))
+                measure-entity   (t2/select-one :model/Measure :id (:id measure))
+                dim-measure-uuid (:id (first (:dimensions measure-entity)))
+                response         (mt/user-http-request :rasta :post 202 "metric/dataset"
+                                                       {:definition
+                                                        {:expression   [:+ {}
+                                                                        [:metric {:lib/uuid "a"} (:id metric)]
+                                                                        [:measure {:lib/uuid "b"} (:id measure)]]
+                                                         :projections  [{:type :metric :id (:id metric)
+                                                                         :projection [[:dimension {} dim-metric-uuid]]}
+                                                                        {:type :measure :id (:id measure)
+                                                                         :projection [[:dimension {} dim-measure-uuid]]}]}})]
+            (is (= "completed" (:status response)))
+            (is (pos? (:row_count response)))))))))

--- a/test/metabase/metrics/api_arithmetic_test.clj
+++ b/test/metabase/metrics/api_arithmetic_test.clj
@@ -242,8 +242,8 @@
                                                     :projections  projections}})]
         (is (= "completed" (:status response)))
         (is (pos? (:row_count response)))
-        (let [base-rows (into {} (map (fn [[k v]] [k v]) (get-in baseline [:data :rows])))
-              deep-rows (into {} (map (fn [[k v]] [k v]) (get-in response [:data :rows])))]
+        (let [base-rows (into {} (map (fn [[k v]] [k (double v)]) (get-in baseline [:data :rows])))
+              deep-rows (into {} (map (fn [[k v]] [k (double v)]) (get-in response [:data :rows])))]
           (doseq [[dim-val base-val] base-rows]
             (is (= (* base-val base-val) (get deep-rows dim-val))
                 (str "((A+A)*A)/2 should be N² for " dim-val))))))))

--- a/test/metabase/metrics/api_math_test.clj
+++ b/test/metabase/metrics/api_math_test.clj
@@ -178,3 +178,38 @@
       (is (= :metric (:type decoded)))
       (is (= 42 (:id decoded)))
       (is (= 1 (count (:projection decoded)))))))
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                      Numeric Constant Tests                                                     |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+(deftest bare-integer-constant-test
+  (testing "A bare integer is a valid expression"
+    (is (valid? ::lib-metric.schema/metric-math-expression 42))))
+
+(deftest bare-float-constant-test
+  (testing "A bare float is a valid expression"
+    (is (valid? ::lib-metric.schema/metric-math-expression 3.14))))
+
+(deftest constant-in-arithmetic-test
+  (testing "Constant as operand in arithmetic is valid"
+    (is (valid? ::lib-metric.schema/metric-math-expression
+                [:* {} [:metric {:lib/uuid "a"} 1] 100]))))
+
+(deftest nested-constant-in-arithmetic-test
+  (testing "Constant in nested arithmetic is valid"
+    (is (valid? ::lib-metric.schema/metric-math-expression
+                [:/ {} [:metric {:lib/uuid "a"} 1] [:- {} [:metric {:lib/uuid "b"} 2] 10]]))))
+
+(deftest valid-definition-with-constant-test
+  (testing "Valid definition with constant in arithmetic (no projection needed for constant)"
+    (is (valid-definition?
+         {:expression  [:* {} [:metric {:lib/uuid "a"} 42] 100]
+          :projections [{:type       :metric
+                         :id         42
+                         :projection [[:dimension {} "550e8400-e29b-41d4-a716-446655440001"]]}]}))))
+
+(deftest normalize-json-number-passthrough-test
+  (testing "JSON number passes through normalization unchanged"
+    (let [decoded (decode ::lib-metric.schema/metric-math-expression 42)]
+      (is (= 42 decoded)))))


### PR DESCRIPTION
BE for ad-hoc aggregations.

Ad-hoc aggregations look like so:

```
["adhoc", { "lib/uuid": uuid }, {
  "database-id": number,
  "table-id": number,
  "aggregation": <mbql-aggregation-clause>,
  "dimensions": [
    {
      "id": "<uuid-you-generate>",
      "field-ref": ["field", { <opts> }, fieldId],
      "display-name": "Created At",
      "effective-type": "type/Date",
      "semantic-type": "type/CreationTimestamp" // optional
    }
  ],
  "filter": <mbql-filter-clause> // optional baked-in filter
}]
```

Projections use UUID, not ID. For metrics/measures, projections match by
{type, id}. For ad-hoc there's no persisted ID - they match by

```
{type: "adhoc", "lib/uuid": <same-uuid-as-the-leaf>}
```

Each dimension needs to be constructed:
- `id`: a UUID the FE generates
- `field-ref`: a concrete `[:field opts field-id]` clause.
- `effective-type` and `display-name`: from the field/column metadata