### PR TITLE
Validate FK target and dimension remap fields belong to the same database

### DIFF
--- a/src/metabase/warehouse_schema_rest/api/field.clj
+++ b/src/metabase/warehouse_schema_rest/api/field.clj
@@ -51,22 +51,19 @@
                                                                    [:include_editable_data_model {:default false} ms/BooleanValue]]]
   (schema.field/get-field id {:include-editable-data-model? include-editable-data-model?}))
 
-(defn- field-db-id
-  "Given a field ID, return the `db_id` of the database it belongs to."
-  [field-id]
-  (-> (t2/query {:select [[:t.db_id :db_id]]
-                 :from   [[(t2/table-name :model/Field) :f]]
-                 :join   [[(t2/table-name :model/Table) :t] [:= :f.table_id :t.id]]
-                 :where  [:= :f.id field-id]})
-      first
-      :db_id))
-
 (defn- check-field-in-same-database!
-  "Check that `target-field-id` belongs to the same database as `source-field-id`. Throws a 400 if not."
+  "Check that `target-field-id` is a valid field in the same database as `source-field-id`. Throws a 400 if
+   the target field does not exist or belongs to a different database. Uses a single query."
   [source-field-id target-field-id param-name]
-  (let [source-db-id (field-db-id source-field-id)
-        target-db-id (field-db-id target-field-id)]
-    (api/checkp (= source-db-id target-db-id)
+  (let [result (first (t2/query {:select [[:source_t.db_id :source_db_id]
+                                          [:target_t.db_id :target_db_id]]
+                                 :from   [[(t2/table-name :model/Field) :sf]]
+                                 :join   [[(t2/table-name :model/Table) :source_t] [:= :sf.table_id :source_t.id]
+                                          [(t2/table-name :model/Field) :tf] [:= :tf.id target-field-id]
+                                          [(t2/table-name :model/Table) :target_t] [:= :tf.table_id :target_t.id]]
+                                 :where  [:= :sf.id source-field-id]}))]
+    (api/checkp result param-name "Invalid target field")
+    (api/checkp (= (:source_db_id result) (:target_db_id result))
                 param-name "Target field must belong to the same database")))
 
 (defn- clear-dimension-on-fk-change! [{:keys [dimensions], :as _field}]
@@ -169,8 +166,6 @@
 
     ;; validate that fk_target_field_id is a valid Field in the same database
     (when fk-target-field-id
-      (api/checkp (t2/exists? :model/Field :id fk-target-field-id)
-                  :fk_target_field_id "Invalid target field")
       (check-field-in-same-database! id fk-target-field-id :fk_target_field_id))
     (when (and display-name
                (not removed-fk?)
@@ -242,8 +237,6 @@
                       human-readable-field-id))
              [400 "Foreign key based remappings require a human readable field id"])
   (when human-readable-field-id
-    (api/checkp (t2/exists? :model/Field :id human-readable-field-id)
-                :human_readable_field_id "Invalid target field")
     (check-field-in-same-database! id human-readable-field-id :human_readable_field_id))
   (if-let [dimension (t2/select-one :model/Dimension :field_id id)]
     (t2/update! :model/Dimension (u/the-id dimension)

--- a/src/metabase/warehouse_schema_rest/api/field.clj
+++ b/src/metabase/warehouse_schema_rest/api/field.clj
@@ -51,6 +51,24 @@
                                                                    [:include_editable_data_model {:default false} ms/BooleanValue]]]
   (schema.field/get-field id {:include-editable-data-model? include-editable-data-model?}))
 
+(defn- field-db-id
+  "Given a field ID, return the `db_id` of the database it belongs to."
+  [field-id]
+  (-> (t2/query {:select [[:t.db_id :db_id]]
+                 :from   [[(t2/table-name :model/Field) :f]]
+                 :join   [[(t2/table-name :model/Table) :t] [:= :f.table_id :t.id]]
+                 :where  [:= :f.id field-id]})
+      first
+      :db_id))
+
+(defn- check-field-in-same-database!
+  "Check that `target-field-id` belongs to the same database as `source-field-id`. Throws a 400 if not."
+  [source-field-id target-field-id param-name]
+  (let [source-db-id (field-db-id source-field-id)
+        target-db-id (field-db-id target-field-id)]
+    (api/checkp (= source-db-id target-db-id)
+                param-name "Target field must belong to the same database")))
+
 (defn- clear-dimension-on-fk-change! [{:keys [dimensions], :as _field}]
   (doseq [{dimension-id :id, dimension-type :type} dimensions]
     (when (and dimension-id (= :external dimension-type))
@@ -149,11 +167,11 @@
         removed-fk?        (removed-fk-semantic-type? (:semantic_type field) new-semantic-type)
         fk-target-field-id (get body :fk_target_field_id (:fk_target_field_id field))]
 
-    ;; validate that fk_target_field_id is a valid Field
-    ;; TODO - we should also check that the Field is within the same database as our field
+    ;; validate that fk_target_field_id is a valid Field in the same database
     (when fk-target-field-id
       (api/checkp (t2/exists? :model/Field :id fk-target-field-id)
-                  :fk_target_field_id "Invalid target field"))
+                  :fk_target_field_id "Invalid target field")
+      (check-field-in-same-database! id fk-target-field-id :fk_target_field_id))
     (when (and display-name
                (not removed-fk?)
                (not= (:display_name field) display-name))
@@ -223,6 +241,10 @@
                  (and (= dimension-type "external")
                       human-readable-field-id))
              [400 "Foreign key based remappings require a human readable field id"])
+  (when human-readable-field-id
+    (api/checkp (t2/exists? :model/Field :id human-readable-field-id)
+                :human_readable_field_id "Invalid target field")
+    (check-field-in-same-database! id human-readable-field-id :human_readable_field_id))
   (if-let [dimension (t2/select-one :model/Dimension :field_id id)]
     (t2/update! :model/Dimension (u/the-id dimension)
                 {:type                    dimension-type

--- a/test/metabase/warehouse_schema_rest/api/field_test.clj
+++ b/test/metabase/warehouse_schema_rest/api/field_test.clj
@@ -492,6 +492,45 @@
                (mt/user-http-request :rasta :post 403 (format "field/%d/dimension" field-id)
                                      {:name "some dimension name", :type "external"})))))))
 
+(deftest fk-target-field-cross-database-test
+  (testing "PUT /api/field/:id rejects fk_target_field_id from a different database"
+    (mt/with-temp [:model/Database db1    {:name "db1" :engine :h2}
+                   :model/Database db2    {:name "db2" :engine :h2}
+                   :model/Table    table1 {:schema "PUBLIC" :name "t1" :db_id (:id db1)}
+                   :model/Table    table2 {:schema "PUBLIC" :name "t2" :db_id (:id db2)}
+                   :model/Field    field1 {:name "Field 1" :table_id (:id table1) :base_type :type/Integer}
+                   :model/Field    field2 {:name "Field 2" :table_id (:id table2) :base_type :type/Integer}]
+      (is (= "Target field must belong to the same database"
+             (-> (mt/user-http-request :crowberto :put 400 (format "field/%d" (:id field1))
+                                       {:semantic_type :type/FK :fk_target_field_id (:id field2)})
+                 :errors vals first))))))
+
+(deftest dimension-human-readable-field-cross-database-test
+  (testing "POST /api/field/:id/dimension rejects human_readable_field_id from a different database"
+    (mt/with-temp [:model/Database db1    {:name "db1" :engine :h2}
+                   :model/Database db2    {:name "db2" :engine :h2}
+                   :model/Table    table1 {:schema "PUBLIC" :name "t1" :db_id (:id db1)}
+                   :model/Table    table2 {:schema "PUBLIC" :name "t2" :db_id (:id db2)}
+                   :model/Field    field1 {:name "Field 1" :table_id (:id table1) :base_type :type/Integer}
+                   :model/Field    field2 {:name "Field 2" :table_id (:id table2) :base_type :type/Integer}]
+      (is (= "Target field must belong to the same database"
+             (-> (create-dimension-via-API! (:id field1)
+                                            {:name "test dim" :type "external" :human_readable_field_id (:id field2)}
+                                            :expected-status-code 400)
+                 :errors vals first))))))
+
+(deftest dimension-human-readable-field-same-database-test
+  (testing "POST /api/field/:id/dimension accepts human_readable_field_id from the same database"
+    (mt/with-temp [:model/Database db1    {:name "db1" :engine :h2}
+                   :model/Table    table1 {:schema "PUBLIC" :name "t1" :db_id (:id db1)}
+                   :model/Table    table2 {:schema "PUBLIC" :name "t2" :db_id (:id db1)}
+                   :model/Field    field1 {:name "Field 1" :table_id (:id table1) :base_type :type/Integer}
+                   :model/Field    field2 {:name "Field 2" :table_id (:id table2) :base_type :type/Integer}]
+      (is (=? {:field_id (:id field1)
+               :human_readable_field_id (:id field2)}
+              (create-dimension-via-API! (:id field1)
+                                         {:name "test dim" :type "external" :human_readable_field_id (:id field2)}))))))
+
 (deftest delete-dimension-test
   (testing "DELETE /api/field/:id/dimension"
     (testing "Ensure we can delete a dimension"


### PR DESCRIPTION
## Summary

- Adds same-database validation for `fk_target_field_id` in `PUT /api/field/:id` (resolves existing TODO)
- Adds existence and same-database validation for `human_readable_field_id` in `POST /api/field/:id/dimension`
- Returns 400 if the target field belongs to a different database than the source field

Fixes GHY-3222

## Test plan

- [x] Cross-database FK target is rejected with 400
- [x] Cross-database dimension human_readable_field_id is rejected with 400
- [x] Same-database dimension target is accepted (positive test)
- [x] All pre-existing field API tests still pass