### PR TITLE
Temporarily disable app db version checks

### DIFF
--- a/src/metabase/app_db/setup.clj
+++ b/src/metabase/app_db/setup.clj
@@ -174,23 +174,23 @@
           db-version (db-version metadata)
           db-type (or (when (= "MariaDB" (.getDatabaseProductName metadata)) :mariadb)
                       db-type)]
-      (if (supported-app-db-version? db-type db-version)
-        (log/infof "Successfully verified %s %s application database connection. %s"
-                   (.getDatabaseProductName metadata) (.getDatabaseProductVersion metadata) (u/emoji "✅"))
-        (throw (ex-info (str/join \newline [(trs "Metabase {0} DB version not supported (found {1}, required {2}). Please upgrade your database to a supported version and try again."
-                                                 (name db-type)
-                                                 (format "%s.%s.%s (%s)"
-                                                         (:major db-version)
-                                                         (:minor db-version)
-                                                         (:patch db-version)
-                                                         (.getDatabaseProductVersion metadata))
-                                                 (let [required-version (get supported-db-versions db-type)]
-                                                   (format "%s.%s.%s"
-                                                           (:major required-version)
-                                                           (:minor required-version)
-                                                           (:patch required-version))))
-                                            "https://www.metabase.com/docs/latest/installation-and-operation/migrating-from-h2#supported-databases-for-storing-your-metabase-application-data"])
-                        {}))))))
+      (if true #_(supported-app-db-version? db-type db-version)
+          (log/infof "Successfully verified %s %s application database connection. %s"
+                     (.getDatabaseProductName metadata) (.getDatabaseProductVersion metadata) (u/emoji "✅"))
+          (throw (ex-info (str/join \newline [(trs "Metabase {0} DB version not supported (found {1}, required {2}). Please upgrade your database to a supported version and try again."
+                                                   (name db-type)
+                                                   (format "%s.%s.%s (%s)"
+                                                           (:major db-version)
+                                                           (:minor db-version)
+                                                           (:patch db-version)
+                                                           (.getDatabaseProductVersion metadata))
+                                                   (let [required-version (get supported-db-versions db-type)]
+                                                     (format "%s.%s.%s"
+                                                             (:major required-version)
+                                                             (:minor required-version)
+                                                             (:patch required-version))))
+                                              "https://www.metabase.com/docs/latest/installation-and-operation/migrating-from-h2#supported-databases-for-storing-your-metabase-application-data"])
+                          {}))))))
 
 (mu/defn- check-encryption
   "Ensure encryption env variable is correctly set if needed, and encrypt the database if it needs to be

--- a/src/metabase/app_db/setup.clj
+++ b/src/metabase/app_db/setup.clj
@@ -152,12 +152,12 @@
    {:major (.getDatabaseMajorVersion metadata)
     :minor (.getDatabaseMinorVersion metadata)}))
 
-(defn- supported-app-db-version?
-  [db-type {:keys [major minor patch]}]
-  (let [required-version (get supported-db-versions db-type)]
-    (and required-version
-         (not (pos? (compare ((juxt :major :minor :patch) required-version)
-                             [major minor patch]))))))
+#_(defn- supported-app-db-version?
+    [db-type {:keys [major minor patch]}]
+    (let [required-version (get supported-db-versions db-type)]
+      (and required-version
+           (not (pos? (compare ((juxt :major :minor :patch) required-version)
+                               [major minor patch]))))))
 
 (mu/defn- verify-db-connection
   "Test connection to application database with `data-source` and throw an exception if we have any troubles

--- a/src/metabase/app_db/setup.clj
+++ b/src/metabase/app_db/setup.clj
@@ -7,10 +7,7 @@
   Because functions here don't know where the JDBC spec came from, you can use them to perform the usual application
   DB setup steps on arbitrary databases -- useful for functionality like the `load-from-h2` or `dump-to-h2` commands."
   (:require
-   [clojure.edn :as edn]
-   [clojure.java.io :as io]
    [clojure.java.jdbc :as jdbc]
-   [clojure.string :as str]
    [honey.sql :as sql]
    [metabase.app-db.connection :as mdb.connection]
    [metabase.app-db.custom-migrations :as custom-migrations]
@@ -123,42 +120,6 @@
         [result]    (vals first-row)]
     (= result 1)))
 
-(defn- load-supported-db-versions
-  []
-  (if-let [resource (io/resource "metabase/app_db/supported-db-versions.edn")]
-    (edn/read-string (slurp resource))
-    (throw (ex-info "Resource not found: metabase/app_db/supported-db-versions.edn"
-                    {:path "metabase/app_db/supported-db-versions.edn"}))))
-
-(def ^:private supported-db-versions
-  "https://www.metabase.com/docs/latest/installation-and-operation/migrating-from-h2#supported-databases-for-storing-your-metabase-application-data"
-  (load-supported-db-versions))
-
-(defn- parse-db-version
-  [product-version]
-  (let [[_ major minor patch] (re-find #"^(\d+)(?:\.(\d+))?(?:\.(\d+))?" product-version)]
-    {:major (or (some-> major parse-long) 0)
-     :minor (or (some-> minor parse-long) 0)
-     :patch (or (some-> patch parse-long) 0)}))
-
-(mu/defn- db-version
-  :- [:map
-      [:major [:int {:min 0}]]
-      [:minor [:int {:min 0}]]
-      [:patch [:int {:min 0}]]]
-  [^java.sql.DatabaseMetaData metadata :- (ms/InstanceOfClass java.sql.DatabaseMetaData)]
-  (merge
-   (parse-db-version (.getDatabaseProductVersion metadata))
-   {:major (.getDatabaseMajorVersion metadata)
-    :minor (.getDatabaseMinorVersion metadata)}))
-
-#_(defn- supported-app-db-version?
-    [db-type {:keys [major minor patch]}]
-    (let [required-version (get supported-db-versions db-type)]
-      (and required-version
-           (not (pos? (compare ((juxt :major :minor :patch) required-version)
-                               [major minor patch]))))))
-
 (mu/defn- verify-db-connection
   "Test connection to application database with `data-source` and throw an exception if we have any troubles
   connecting."
@@ -170,27 +131,9 @@
          (catch Throwable e
            (throw (ex-info error-msg {} e)))))
   (with-open [conn (.getConnection ^javax.sql.DataSource data-source)]
-    (let [metadata (.getMetaData conn)
-          db-version (db-version metadata)
-          db-type (or (when (= "MariaDB" (.getDatabaseProductName metadata)) :mariadb)
-                      db-type)]
-      (if true #_(supported-app-db-version? db-type db-version)
-          (log/infof "Successfully verified %s %s application database connection. %s"
-                     (.getDatabaseProductName metadata) (.getDatabaseProductVersion metadata) (u/emoji "✅"))
-          (throw (ex-info (str/join \newline [(trs "Metabase {0} DB version not supported (found {1}, required {2}). Please upgrade your database to a supported version and try again."
-                                                   (name db-type)
-                                                   (format "%s.%s.%s (%s)"
-                                                           (:major db-version)
-                                                           (:minor db-version)
-                                                           (:patch db-version)
-                                                           (.getDatabaseProductVersion metadata))
-                                                   (let [required-version (get supported-db-versions db-type)]
-                                                     (format "%s.%s.%s"
-                                                             (:major required-version)
-                                                             (:minor required-version)
-                                                             (:patch required-version))))
-                                              "https://www.metabase.com/docs/latest/installation-and-operation/migrating-from-h2#supported-databases-for-storing-your-metabase-application-data"])
-                          {}))))))
+    (let [metadata (.getMetaData conn)]
+      (log/infof "Successfully verified %s %s application database connection. %s"
+                 (.getDatabaseProductName metadata) (.getDatabaseProductVersion metadata) (u/emoji "✅")))))
 
 (mu/defn- check-encryption
   "Ensure encryption env variable is correctly set if needed, and encrypt the database if it needs to be

--- a/test/metabase/app_db/setup_test.clj
+++ b/test/metabase/app_db/setup_test.clj
@@ -27,18 +27,18 @@
       (#'mdb.setup/verify-db-connection :h2 (mdb.data-source/raw-connection-string->DataSource
                                              (format "jdbc:h2:mem:%s" (mt/random-name)))))))
 
-(deftest supported-app-db-version?-test
-  (testing "Should be able to check if an app DB is a supported version"
-    (letfn [(test-supported-versions [db expected-min-version]
-              (doseq [diff [nil {:major 1} {:minor 1} {:patch 1}]]
-                (is (true? (#'mdb.setup/supported-app-db-version? db (merge-with + expected-min-version diff)))))
-              (doseq [diff [{:major -1} {:minor -1} {:patch -1}]]
-                (is (false? (#'mdb.setup/supported-app-db-version? db (merge-with + expected-min-version diff))))))]
+#_(deftest supported-app-db-version?-test
+    (testing "Should be able to check if an app DB is a supported version"
+      (letfn [(test-supported-versions [db expected-min-version]
+                (doseq [diff [nil {:major 1} {:minor 1} {:patch 1}]]
+                  (is (true? (#'mdb.setup/supported-app-db-version? db (merge-with + expected-min-version diff)))))
+                (doseq [diff [{:major -1} {:minor -1} {:patch -1}]]
+                  (is (false? (#'mdb.setup/supported-app-db-version? db (merge-with + expected-min-version diff))))))]
 
-      (test-supported-versions :h2 {:major 2 :minor 1 :patch 214})
-      (test-supported-versions :postgres {:major 14 :minor 0 :patch 0})
-      (test-supported-versions :mysql {:major 8 :minor 4 :patch 0})
-      (test-supported-versions :mariadb {:major 10 :minor 6 :patch 0}))))
+        (test-supported-versions :h2 {:major 2 :minor 1 :patch 214})
+        (test-supported-versions :postgres {:major 14 :minor 0 :patch 0})
+        (test-supported-versions :mysql {:major 8 :minor 4 :patch 0})
+        (test-supported-versions :mariadb {:major 10 :minor 6 :patch 0}))))
 
 (deftest parse-db-version-test
   (testing "Can parse H2 version strings"

--- a/test/metabase/app_db/setup_test.clj
+++ b/test/metabase/app_db/setup_test.clj
@@ -27,34 +27,6 @@
       (#'mdb.setup/verify-db-connection :h2 (mdb.data-source/raw-connection-string->DataSource
                                              (format "jdbc:h2:mem:%s" (mt/random-name)))))))
 
-#_(deftest supported-app-db-version?-test
-    (testing "Should be able to check if an app DB is a supported version"
-      (letfn [(test-supported-versions [db expected-min-version]
-                (doseq [diff [nil {:major 1} {:minor 1} {:patch 1}]]
-                  (is (true? (#'mdb.setup/supported-app-db-version? db (merge-with + expected-min-version diff)))))
-                (doseq [diff [{:major -1} {:minor -1} {:patch -1}]]
-                  (is (false? (#'mdb.setup/supported-app-db-version? db (merge-with + expected-min-version diff))))))]
-
-        (test-supported-versions :h2 {:major 2 :minor 1 :patch 214})
-        (test-supported-versions :postgres {:major 14 :minor 0 :patch 0})
-        (test-supported-versions :mysql {:major 8 :minor 4 :patch 0})
-        (test-supported-versions :mariadb {:major 10 :minor 6 :patch 0}))))
-
-(deftest parse-db-version-test
-  (testing "Can parse H2 version strings"
-    (is (= {:major 2 :minor 1 :patch 214} (#'mdb.setup/parse-db-version "2.1.214 (2022-06-13)"))))
-  (testing "Can parse postgres version strings"
-    (is (= {:major 18 :minor 3 :patch 0} (#'mdb.setup/parse-db-version "18.3 (Debian 18.3-1.pgdg13+1)")))
-    (is (= {:major 14 :minor 22 :patch 0} (#'mdb.setup/parse-db-version "14.22 (Debian 14.22-1.pgdg13+1)")))
-    (is (= {:major 11 :minor 16 :patch 0} (#'mdb.setup/parse-db-version "11.16 (Debian 11.16-1.pgdg90+1)"))))
-
-  (testing "Can parse mysql version strings"
-    (is (= {:major 9 :minor 6 :patch 0} (#'mdb.setup/parse-db-version "9.6.0")))
-    (is (= {:major 8 :minor 0 :patch 45} (#'mdb.setup/parse-db-version "8.0.45"))))
-
-  (testing "Can parse mariadb version strings"
-    (is (= {:major 12 :minor 2 :patch 2} (#'mdb.setup/parse-db-version "12.2.2-MariaDB-ubu2404")))))
-
 (deftest setup-db-test
   (testing "Should be able to set up an arbitrary application DB"
     (letfn [(test* [data-source]


### PR DESCRIPTION
closes [GIT-9485](https://linear.app/metabase/issue/GIT-9485/disable-app-db-version-check-to-unblock-ci)

### Description



### How to verify

Temporarily disable the app db startup version check to unblock CI.
