### PR TITLE
Fix sunburst chart labels not appearing

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/pie/util/label.ts
+++ b/frontend/src/metabase/visualizations/echarts/pie/util/label.ts
@@ -160,10 +160,13 @@ export const calcAvailableDonutSliceLabelLength = (
   }
 
   const arcAngle = endAngle - startAngle;
-  const innerCordLength = calcChordLength(innerRadius, arcAngle);
+  const innerChordLength = calcChordLength(
+    innerRadius,
+    Math.min(arcAngle, Math.PI),
+  );
 
   if (labelPosition === "radial") {
-    return innerCordLength > fontSize ? donutThickness : 0;
+    return innerChordLength > fontSize ? donutThickness : 0;
   }
 
   const midRadius = (innerRadius + outerRadius) / 2;
@@ -179,12 +182,10 @@ export const calcAvailableDonutSliceLabelLength = (
     outerRadius,
   );
 
-  const cordLengthLimit =
-    arcAngle < Math.PI ? innerCordLength : 2 * innerRadius;
   const sliceConstraint =
-    isNearXAxis(midAngle) && innerCordLength > fontSize
+    isNearXAxis(midAngle) && innerChordLength > fontSize
       ? donutThickness
-      : cordLengthLimit;
+      : innerChordLength;
 
   return Math.min(maxRectLength, sliceConstraint);
 };

--- a/frontend/src/metabase/visualizations/echarts/pie/util/label.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/echarts/pie/util/label.unit.spec.ts
@@ -140,6 +140,18 @@ describe("pie chart label utilities", () => {
       expect(result).toBe(0);
     });
 
+    it("returns donutThickness for large radial slice arc > PI even though chord is small (metabase#68802)", () => {
+      const result = calcAvailableDonutSliceLabelLength(
+        50,
+        100,
+        0,
+        6.2, // ~355 degrees
+        12,
+        "radial",
+      );
+      expect(result).toBe(50); // should return donutThickness
+    });
+
     it("calculates horizontal label length correctly", () => {
       const result = calcAvailableDonutSliceLabelLength(
         50,


### PR DESCRIPTION
Closes #68802

### Description

The chord length calculation, which is used to determine how much room is available for labels, incorrectly handled cases where the slice angle is greater than pi, or 180 degrees. This meant that for large slices, we incorrectly calculated that there wasn't enough room for labels.

### How to verify

Follow the steps in the issue. Verify that the label for "banana" correctly appears after applying the fix.

### Demo

Before:
<img width="593" height="529" alt="image" src="https://github.com/user-attachments/assets/0ae6443a-e032-48b1-8605-0370d2f598e1" />

After:
<img width="601" height="522" alt="image" src="https://github.com/user-attachments/assets/160d89c2-bac9-4f0a-bb4d-e5cfa8a2cf7e" />

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
