### PR TITLE
Aliases for table template tags

### DIFF
--- a/frontend/src/metabase-types/api/dataset.ts
+++ b/frontend/src/metabase-types/api/dataset.ts
@@ -250,6 +250,7 @@ export interface TemplateTag {
 
   // Table specific
   "table-id"?: TableId;
+  "emit-alias"?: boolean;
 }
 
 export type TemplateTags = Record<TemplateTagName, TemplateTag>;

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.tsx
@@ -184,6 +184,7 @@ class TagEditorParamInner extends Component<
         default: undefined,
         dimension: undefined,
         alias: undefined,
+        "emit-alias": type === "table" ? true : undefined,
         "widget-type": type === "dimension" ? "none" : undefined,
         "table-id": undefined,
       });
@@ -299,6 +300,13 @@ class TagEditorParamInner extends Component<
     }
   };
 
+  setEmitAlias = (emitAlias: boolean) => {
+    const { tag, setTemplateTag } = this.props;
+    if (tag["emit-alias"] !== emitAlias) {
+      setTemplateTag({ ...tag, "emit-alias": emitAlias });
+    }
+  };
+
   setAlias = (alias: string | undefined) => {
     const { tag, setTemplateTag } = this.props;
     if (tag.alias !== alias) {
@@ -371,6 +379,7 @@ class TagEditorParamInner extends Component<
             database={database}
             databases={databases}
             onChange={this.setTableId}
+            onChangeEmitAlias={this.setEmitAlias}
           />
         )}
 

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.unit.spec.tsx
@@ -162,6 +162,19 @@ describe("TagEditorParam", () => {
         type: "number",
         "table-id": undefined,
       });
+
+      expect(
+        screen.getByRole("switch", { name: /emit table alias/i }),
+      ).toBeChecked();
+
+      await userEvent.click(
+        screen.getByRole("switch", { name: /emit table alias/i }),
+      );
+      expect(setTemplateTag).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          "emit-alias": false,
+        }),
+      );
     });
   });
 

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParamParts/TableMappingSelect.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParamParts/TableMappingSelect.tsx
@@ -1,7 +1,7 @@
 import { t } from "ttag";
 
 import { SchemaAndTableDataSelector } from "metabase/query_builder/components/DataSelector";
-import { Group } from "metabase/ui";
+import { Box, Group, HoverCard, Icon, Switch, Text } from "metabase/ui";
 import type Database from "metabase-lib/v1/metadata/Database";
 import type { TableId, TemplateTag } from "metabase-types/api";
 
@@ -12,6 +12,7 @@ type TableMappingSelectProps = {
   database?: Database | null;
   databases: Database[];
   onChange: (tableId: TableId) => void;
+  onChangeEmitAlias: (emitAlias: boolean) => void;
 };
 
 export function TableMappingSelect({
@@ -19,28 +20,57 @@ export function TableMappingSelect({
   database,
   databases,
   onChange,
+  onChangeEmitAlias,
 }: TableMappingSelectProps) {
   const tableId = tag["table-id"];
   const isEmpty = tableId == null;
 
   return (
-    <InputContainer>
-      <ContainerLabel>
+    <>
+      <InputContainer>
+        <ContainerLabel>
+          <Group gap="xs">
+            {t`Table to map to`}
+            {isEmpty && <ErrorSpan>{t`(required)`}</ErrorSpan>}
+          </Group>
+        </ContainerLabel>
+        <SchemaAndTableDataSelector
+          databases={databases}
+          selectedDatabase={database || null}
+          selectedDatabaseId={database?.id || null}
+          selectedTable={tableId}
+          selectedTableId={tableId}
+          setSourceTableFn={onChange}
+          isInitiallyOpen={tableId == null}
+          isMantine
+        />
+      </InputContainer>
+      <InputContainer>
         <Group gap="xs">
-          {t`Table to map to`}
-          {isEmpty && <ErrorSpan>{t`(required)`}</ErrorSpan>}
+          <Switch
+            id={`emit-alias-toggle-${tag.id}`}
+            label={t`Emit table alias`}
+            checked={tag["emit-alias"] ?? true}
+            onChange={(e) => onChangeEmitAlias(e.currentTarget.checked)}
+          />
+          <HoverCard>
+            <HoverCard.Target>
+              <Icon
+                c="text-secondary"
+                name="info"
+                data-testid="emit-alias-info-icon"
+              />
+            </HoverCard.Target>
+            <HoverCard.Dropdown>
+              <Box p="md" maw="24rem">
+                <Text>
+                  {t`When enabled, the table reference will include an alias matching the variable name.`}
+                </Text>
+              </Box>
+            </HoverCard.Dropdown>
+          </HoverCard>
         </Group>
-      </ContainerLabel>
-      <SchemaAndTableDataSelector
-        databases={databases}
-        selectedDatabase={database || null}
-        selectedDatabaseId={database?.id || null}
-        selectedTable={tableId}
-        selectedTableId={tableId}
-        setSourceTableFn={onChange}
-        isInitiallyOpen={tableId == null}
-        isMantine
-      />
-    </InputContainer>
+      </InputContainer>
+    </>
   );
 }

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParamParts/TableMappingSelect.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParamParts/TableMappingSelect.tsx
@@ -1,7 +1,7 @@
 import { t } from "ttag";
 
 import { SchemaAndTableDataSelector } from "metabase/query_builder/components/DataSelector";
-import { Box, Group, HoverCard, Icon, Switch, Text } from "metabase/ui";
+import { Group, HoverCard, Icon, Switch, Text } from "metabase/ui";
 import type Database from "metabase-lib/v1/metadata/Database";
 import type { TableId, TemplateTag } from "metabase-types/api";
 
@@ -62,11 +62,9 @@ export function TableMappingSelect({
               />
             </HoverCard.Target>
             <HoverCard.Dropdown>
-              <Box p="md" maw="24rem">
-                <Text>
-                  {t`When enabled, the table reference will include an alias matching the variable name.`}
-                </Text>
-              </Box>
+              <Text p="md" maw="24rem">
+                {t`When enabled, the table reference will include an alias matching the variable name.`}
+              </Text>
             </HoverCard.Dropdown>
           </HoverCard>
         </Group>

--- a/src/metabase/driver/common/parameters.clj
+++ b/src/metabase/driver/common/parameters.clj
@@ -69,8 +69,12 @@
 ;;   :value     - the value to compare against
 ;; When present, the table reference is rendered as a filtered subquery:
 ;;   (SELECT * FROM "table" WHERE "col" > ? AND "col" <= ?)
-;; This was introduced to support incremental transforms, unused by the frontend.
-(p.types/defrecord+ ReferencedTableQuery [table-id source-filters]
+;; source-filters was introduced to support incremental transforms, unused by the frontend.
+;;
+;; `alias` is an optional string alias for the table reference. When present, the expansion includes
+;; an AS clause: "table" AS "alias" or (SELECT ...) AS "alias".
+;; Resolved from the template tag's `:emit-alias` boolean and `:name` during parsing.
+(p.types/defrecord+ ReferencedTableQuery [table-id source-filters alias]
   pretty/PrettyPrintable
   (pretty [this]
     (list (pretty/qualify-symbol-for-*ns* `map->ReferencedTableQuery) (into {} this))))

--- a/src/metabase/driver/common/parameters/values.clj
+++ b/src/metabase/driver/common/parameters/values.clj
@@ -258,13 +258,13 @@
                 e))))))
 
 (mu/defmethod parse-tag :table :- ReferencedTableQuery
-  [{:keys [table-id source-filters]} :- ::mbql.s/TemplateTag _params]
+  [{:keys [table-id source-filters emit-alias name]} :- ::mbql.s/TemplateTag _params]
   (when (seq source-filters)
     (when-let [op (some #(when-not (lib.schema.template-tag/allowed-source-filter-ops (:op %)) %) source-filters)]
       (throw (ex-info (tru "Invalid source-filter operator: {0}. Allowed operators: {1}"
                            (pr-str op) (pr-str lib.schema.template-tag/allowed-source-filter-ops))
                       {:op op :allowed-ops lib.schema.template-tag/allowed-source-filter-ops}))))
-  (params/->ReferencedTableQuery table-id (not-empty source-filters)))
+  (params/->ReferencedTableQuery table-id (not-empty source-filters) (when emit-alias name)))
 
 (mu/defmethod parse-tag :snippet :- ReferencedQuerySnippet
   [{:keys [snippet-name snippet-id], :as tag} :- ::mbql.s/TemplateTag

--- a/src/metabase/driver/sql/parameters/substitution.clj
+++ b/src/metabase/driver/sql/parameters/substitution.clj
@@ -412,9 +412,14 @@
     (replace-alias driver field alias replacement-snippet-info)))
 
 (defmethod ->replacement-snippet-info [:sql ReferencedTableQuery]
-  [driver {:keys [table-id source-filters]}]
-  (let [mp       (driver-api/metadata-provider)
-        table-hsql (sql.qp/->honeysql driver (driver-api/table mp table-id))]
+  [driver {:keys [table-id source-filters alias]}]
+  (let [mp         (driver-api/metadata-provider)
+        table-hsql (sql.qp/->honeysql driver (driver-api/table mp table-id))
+        add-alias  (fn [result]
+                     (if alias
+                       (let [alias-sql (first (sql.qp/format-honeysql driver (h2x/identifier :table-alias alias)))]
+                         (update result :replacement-snippet str " AS " alias-sql))
+                       result))]
     (if (seq source-filters)
       (let [prepared     (mapv (fn [{:keys [field-id op value]}]
                                  (let [field (driver-api/field mp field-id)]
@@ -429,8 +434,8 @@
             hsql         {:select [:*] :from [[table-hsql]] :where where-clause}
             [sql]        (sql.qp/format-honeysql driver hsql)
             args         (into [] (mapcat (comp :param-values :sub)) prepared)]
-        {:replacement-snippet     (str "(" sql ")")
-         :prepared-statement-args args})
+        (add-alias {:replacement-snippet     (str "(" sql ")")
+                    :prepared-statement-args args}))
       (let [[sql] (sql.qp/format-honeysql driver table-hsql)]
-        {:prepared-statement-args []
-         :replacement-snippet     sql}))))
+        (add-alias {:prepared-statement-args []
+                    :replacement-snippet     sql})))))

--- a/src/metabase/legacy_mbql/schema.cljc
+++ b/src/metabase/legacy_mbql/schema.cljc
@@ -1558,6 +1558,7 @@
    [:map
     [:type                  [:= {:decode/normalize helpers/normalize-keyword} :table]]
     [:table-id              ::lib.schema.id/table]
+    [:emit-alias            {:optional true} :boolean]
     [:source-filters        {:optional true} [:sequential [:ref ::TemplateTag.SourceFilter]]]]])
 
 (mr/def ::TemplateTag.Value.Common

--- a/src/metabase/lib/schema/template_tag.cljc
+++ b/src/metabase/lib/schema/template_tag.cljc
@@ -154,6 +154,7 @@
     [:map
      [:type                  [:= :table]]
      [:table-id              ::id/table]
+     [:emit-alias            {:optional true} :boolean]
      [:source-filters        {:optional true} [:sequential [:ref ::source-filter]]]]]
    [:ref ::disallow-dimension]])
 

--- a/test/metabase/driver/common/parameters/values_test.clj
+++ b/test/metabase/driver/common/parameters/values_test.clj
@@ -624,20 +624,37 @@
                             :display-name "Table tag test"
                             :type         :table
                             :table-id     1}
+                           []))))
+  (testing "Table template tag with emit-alias resolves alias from name"
+    (is (=? {:table-id 1
+             :alias    "my_table"}
+            (value-for-tag {:name         "my_table"
+                            :display-name "My Table"
+                            :type         :table
+                            :table-id     1
+                            :emit-alias   true}
+                           []))))
+  (testing "Table template tag without emit-alias has nil alias"
+    (is (=? {:table-id 1
+             :alias    nil}
+            (value-for-tag {:name         "my_table"
+                            :display-name "My Table"
+                            :type         :table
+                            :table-id     1}
                            [])))))
 
 (deftest ^:parallel table-tag-with-source-filters-test
   (testing "Table template tag with source-filters passes them through"
     (let [filters [{:field-id 100 :op :> :value 10}
                    {:field-id 100 :op :<= :value 50}]]
-      (is (= {:table-id       1
-              :source-filters filters}
-             (value-for-tag {:name           "table-tag-test"
-                             :display-name   "Table tag test"
-                             :type           :table
-                             :table-id       1
-                             :source-filters filters}
-                            [])))))
+      (is (=? {:table-id       1
+               :source-filters filters}
+              (value-for-tag {:name           "table-tag-test"
+                              :display-name   "Table tag test"
+                              :type           :table
+                              :table-id       1
+                              :source-filters filters}
+                             [])))))
   (testing "Table template tag with invalid source-filter op throws"
     (is (thrown-with-msg?
          ExceptionInfo

--- a/test/metabase/driver/sql/parameters/substitution_test.clj
+++ b/test/metabase/driver/sql/parameters/substitution_test.clj
@@ -138,7 +138,16 @@
              (sql.params.substitution/->replacement-snippet-info
               :h2
               (params/map->ReferencedTableQuery
-               {:table-id (meta/id :orders)})))))))
+               {:table-id (meta/id :orders)}))))))
+  (testing "Basic table reference with alias"
+    (mt/with-metadata-provider meta/metadata-provider
+      (is (= {:replacement-snippet     "\"PUBLIC\".\"ORDERS\" AS \"my_orders\""
+              :prepared-statement-args []}
+             (sql.params.substitution/->replacement-snippet-info
+              :h2
+              (params/map->ReferencedTableQuery
+               {:table-id (meta/id :orders)
+                :alias    "my_orders"})))))))
 
 (deftest ^:parallel table-query-with-source-filters->replacement-snippet-test
   (testing "Table reference with a single source-filter produces a filtered subquery"
@@ -178,4 +187,16 @@
                    {:table-id       (meta/id :orders)
                     :source-filters [{:field-id (meta/id :orders :created-at)
                                       :op       :>
-                                      :value    ts}]})))))))))
+                                      :value    ts}]}))))))))
+  (testing "Table reference with source-filters and alias"
+    (mt/with-metadata-provider meta/metadata-provider
+      (is (= {:replacement-snippet     "(SELECT * FROM \"PUBLIC\".\"ORDERS\" WHERE (\"TOTAL\" > 100)) AS \"src\""
+              :prepared-statement-args []}
+             (sql.params.substitution/->replacement-snippet-info
+              :h2
+              (params/map->ReferencedTableQuery
+               {:table-id       (meta/id :orders)
+                :alias          "src"
+                :source-filters [{:field-id (meta/id :orders :total)
+                                  :op       :>
+                                  :value    100}]})))))))


### PR DESCRIPTION
Allow emitting `<table replacement> AS <table-alias>` using the variable name as alias

Adds a toggle in the frontend with tooltip for explanation
<img width="666" height="407" alt="image" src="https://github.com/user-attachments/assets/b6299978-0003-409d-9eb3-1ee20afbee63" />
