### PR TITLE
Fix MySQL 8.4 app-db test failures in dependencies tests

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/dependencies/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/api_test.clj
@@ -1616,11 +1616,12 @@
 (deftest ^:sequential unreferenced-sample-db-test
   (testing "GET /api/ee/dependencies/unreferenced - should not return tables from the sample database"
     (mt/with-premium-features #{:dependencies}
-      (mt/with-temp [:model/Database {db-id :id} {:is_sample true}
-                     :model/Table    _           {:db_id db-id :name "Sample DB table - unreftest"}]
-        (is (=? {:data   []
-                 :total  0}
-                (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph/unreferenced?types=table&query=unreftest")))))))
+      (mt/with-empty-h2-app-db!
+        (mt/with-temp [:model/Database {db-id :id} {:is_sample true}
+                       :model/Table    _           {:db_id db-id :name "Sample DB table - unreftest"}]
+          (is (=? {:data   []
+                   :total  0}
+                  (mt/user-http-request :crowberto :get 200 "ee/dependencies/graph/unreferenced?types=table&query=unreftest"))))))))
 
 (deftest ^:sequential unreferenced-audit-db-test
   (testing "GET /api/ee/dependencies/unreferenced - should not return tables from the audit database"

--- a/enterprise/backend/test/metabase_enterprise/dependencies/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/api_test.clj
@@ -819,50 +819,51 @@
   (testing "GET /api/ee/dependencies/graph includes upstream nodes if ANY path to them is readable"
     (mt/dataset test-data
       (mt/with-premium-features #{:dependencies}
-        (mt/with-non-admin-groups-no-root-collection-perms
-          (mt/with-temp [:model/Collection readable-collection {}
-                         :model/Collection unreadable-collection {}
-                         :model/User user {:email "test@test.com"}]
-            (mt/with-model-cleanup [:model/Card :model/Dependency]
-              (let [base-card (card/create-card! (assoc (basic-card) :collection_id (:id readable-collection)) user)
-                    unreadable-middle (card/create-card! (assoc (wrap-card base-card)
-                                                                :collection_id (:id unreadable-collection))
-                                                         user)
-                    readable-alternate (card/create-card! (assoc (wrap-card base-card)
-                                                                 :collection_id (:id readable-collection))
-                                                          user)
-                    end-card (card/create-card! (assoc (wrap-two-cards unreadable-middle readable-alternate)
-                                                       :collection_id (:id readable-collection))
-                                                user)]
-                (perms/grant-collection-read-permissions! (perms/all-users-group) readable-collection)
-                (testing "Diamond pattern: complete upstream graph via readable path"
-                  (let [response (mt/user-http-request :rasta :get 200 "ee/dependencies/graph"
-                                                       :id (:id end-card)
-                                                       :type "card")
-                        nodes (set (map (juxt :type :id) (:nodes response)))
-                        expected-nodes #{["card" (:id end-card)] ["card" (:id readable-alternate)]
-                                         ["card" (:id base-card)] ["table" (mt/id :orders)]}]
-                    (is (= expected-nodes nodes)
-                        "Should see end-card, readable-alternate, base-card, and :orders table")))
-                (testing "Edges show complete readable dependency chain"
-                  (let [response (mt/user-http-request :rasta :get 200 "ee/dependencies/graph"
-                                                       :id (:id end-card)
-                                                       :type "card")
-                        edges (set (:edges response))
-                        expected-edges #{{:from_entity_id (:id end-card)
-                                          :from_entity_type "card"
-                                          :to_entity_id (:id readable-alternate)
-                                          :to_entity_type "card"}
-                                         {:from_entity_id (:id readable-alternate)
-                                          :from_entity_type "card"
-                                          :to_entity_id (:id base-card)
-                                          :to_entity_type "card"}
-                                         {:from_entity_id (:id base-card)
-                                          :from_entity_type "card"
-                                          :to_entity_id (mt/id :orders)
-                                          :to_entity_type "table"}}]
-                    (is (= expected-edges edges)
-                        "Should have edges through readable path only")))))))))))
+        (mt/with-empty-h2-app-db!
+          (mt/with-non-admin-groups-no-root-collection-perms
+            (mt/with-temp [:model/Collection readable-collection {}
+                           :model/Collection unreadable-collection {}
+                           :model/User user {:email "test@test.com"}]
+              (mt/with-model-cleanup [:model/Card :model/Dependency]
+                (let [base-card (card/create-card! (assoc (basic-card) :collection_id (:id readable-collection)) user)
+                      unreadable-middle (card/create-card! (assoc (wrap-card base-card)
+                                                                  :collection_id (:id unreadable-collection))
+                                                           user)
+                      readable-alternate (card/create-card! (assoc (wrap-card base-card)
+                                                                   :collection_id (:id readable-collection))
+                                                            user)
+                      end-card (card/create-card! (assoc (wrap-two-cards unreadable-middle readable-alternate)
+                                                         :collection_id (:id readable-collection))
+                                                  user)]
+                  (perms/grant-collection-read-permissions! (perms/all-users-group) readable-collection)
+                  (testing "Diamond pattern: complete upstream graph via readable path"
+                    (let [response (mt/user-http-request :rasta :get 200 "ee/dependencies/graph"
+                                                         :id (:id end-card)
+                                                         :type "card")
+                          nodes (set (map (juxt :type :id) (:nodes response)))
+                          expected-nodes #{["card" (:id end-card)] ["card" (:id readable-alternate)]
+                                           ["card" (:id base-card)] ["table" (mt/id :orders)]}]
+                      (is (= expected-nodes nodes)
+                          "Should see end-card, readable-alternate, base-card, and :orders table")))
+                  (testing "Edges show complete readable dependency chain"
+                    (let [response (mt/user-http-request :rasta :get 200 "ee/dependencies/graph"
+                                                         :id (:id end-card)
+                                                         :type "card")
+                          edges (set (:edges response))
+                          expected-edges #{{:from_entity_id (:id end-card)
+                                            :from_entity_type "card"
+                                            :to_entity_id (:id readable-alternate)
+                                            :to_entity_type "card"}
+                                           {:from_entity_id (:id readable-alternate)
+                                            :from_entity_type "card"
+                                            :to_entity_id (:id base-card)
+                                            :to_entity_type "card"}
+                                           {:from_entity_id (:id base-card)
+                                            :from_entity_type "card"
+                                            :to_entity_id (mt/id :orders)
+                                            :to_entity_type "table"}}]
+                      (is (= expected-edges edges)
+                          "Should have edges through readable path only"))))))))))))
 
 (deftest graph-filtering-all-unreadable-test
   (testing "GET /api/ee/dependencies/graph returns only root node when all upstream dependencies are unreadable"

--- a/enterprise/backend/test/metabase_enterprise/dependencies/models/dependency_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/models/dependency_test.clj
@@ -227,37 +227,38 @@
 
 (deftest filtered-graph-dependencies-test
   (testing "filtered-graph-dependencies respects filter clause"
-    (mt/with-temp [:model/User user {:email "me@wherever.com"}]
-      (mt/with-premium-features #{:dependencies}
-        (mt/with-model-cleanup [:model/Card :model/Dependency]
-          (let [{id1 :id :as card1} (card/create-card! (basic-orders) user)
-                {id2 :id :as card2} (card/create-card! (wrap-card card1) user)
-                {id3 :id :as _card3} (card/create-card! (wrap-card card2) user)]
-            (testing "without filter, returns all dependencies"
-              (let [graph (deps.graph/graph-dependencies)
-                    deps (graph/transitive graph [[:card id3]])]
-                (is (= #{[:card id2] [:card id1] [:table (mt/id :orders)]}
-                       (set deps)))))
-            (testing "with filter excluding card1, omits card1 and its dependencies"
-              (let [filter-fn (fn [entity-type-field entity-id-field]
-                                [:and
-                                 [:= entity-type-field "card"]
-                                 [:in entity-id-field [id2 id3]]])
-                    graph (deps.graph/filtered-graph-dependencies filter-fn)
-                    deps (graph/transitive graph [[:card id3]])]
-                (is (= #{[:card id2]}
-                       (set deps))
-                    "Should only include card2, not card1 or table")))
-            (testing "with filter excluding card2, breaks the chain"
-              (let [filter-fn (fn [entity-type-field entity-id-field]
-                                [:and
-                                 [:= entity-type-field "card"]
-                                 [:in entity-id-field [id1 id3]]])
-                    graph (deps.graph/filtered-graph-dependencies filter-fn)
-                    deps (graph/transitive graph [[:card id3]])]
-                (is (= #{}
-                       (set deps))
-                    "Should be empty, chain is broken at card2")))))))))
+    (mt/with-empty-h2-app-db!
+      (mt/with-temp [:model/User user {:email "me@wherever.com"}]
+        (mt/with-premium-features #{:dependencies}
+          (mt/with-model-cleanup [:model/Card :model/Dependency]
+            (let [{id1 :id :as card1} (card/create-card! (basic-orders) user)
+                  {id2 :id :as card2} (card/create-card! (wrap-card card1) user)
+                  {id3 :id :as _card3} (card/create-card! (wrap-card card2) user)]
+              (testing "without filter, returns all dependencies"
+                (let [graph (deps.graph/graph-dependencies)
+                      deps (graph/transitive graph [[:card id3]])]
+                  (is (= #{[:card id2] [:card id1] [:table (mt/id :orders)]}
+                         (set deps)))))
+              (testing "with filter excluding card1, omits card1 and its dependencies"
+                (let [filter-fn (fn [entity-type-field entity-id-field]
+                                  [:and
+                                   [:= entity-type-field "card"]
+                                   [:in entity-id-field [id2 id3]]])
+                      graph (deps.graph/filtered-graph-dependencies filter-fn)
+                      deps (graph/transitive graph [[:card id3]])]
+                  (is (= #{[:card id2]}
+                         (set deps))
+                      "Should only include card2, not card1 or table")))
+              (testing "with filter excluding card2, breaks the chain"
+                (let [filter-fn (fn [entity-type-field entity-id-field]
+                                  [:and
+                                   [:= entity-type-field "card"]
+                                   [:in entity-id-field [id1 id3]]])
+                      graph (deps.graph/filtered-graph-dependencies filter-fn)
+                      deps (graph/transitive graph [[:card id3]])]
+                  (is (= #{}
+                         (set deps))
+                      "Should be empty, chain is broken at card2"))))))))))
 
 (deftest filtered-graph-dependents-test
   (testing "filtered-graph-dependents respects filter clause"

--- a/enterprise/backend/test/metabase_enterprise/dependencies/models/dependency_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/models/dependency_test.clj
@@ -180,41 +180,42 @@
 
 (deftest dependency-analysis-version-test
   (testing "dependency_analysis_version is updated when entities are created or updated"
-    (testing "cards"
-      (mt/with-model-cleanup [:model/Dependency]
-        (mt/with-temp [:model/Card card {:dependency_analysis_version 0}]
-          (is (zero? (t2/select-one-fn :dependency_analysis_version :model/Card (:id card))))
-          (mt/with-premium-features #{:dependencies}
-            (card/update-card! {:card-before-update card
-                                :card-updates {:dataset_query (mt/mbql-query orders)}}))
-          (is (= deps.graph/current-dependency-analysis-version
-                 (t2/select-one-fn :dependency_analysis_version :model/Card (:id card)))))))
-    (testing "transforms create"
-      (mt/with-premium-features #{:dependencies}
-        (mt/with-temp [:model/Transform transform]
-          (is (= deps.graph/current-dependency-analysis-version
-                 (t2/select-one-fn :dependency_analysis_version :model/Transform (:id transform)))))))
-    (testing "transforms update"
-      (mt/with-premium-features #{}
-        (mt/with-temp [:model/Transform transform]
-          (is (zero? (t2/select-one-fn :dependency_analysis_version :model/Transform (:id transform))))
-          (mt/with-premium-features #{:dependencies}
-            (t2/update! :model/Transform (:id transform) {:source {:type "query" :query (mt/mbql-query products)}}))
-          (is (= deps.graph/current-dependency-analysis-version
-                 (t2/select-one-fn :dependency_analysis_version :model/Transform (:id transform)))))))
-    (testing "snippets create"
-      (mt/with-premium-features #{:dependencies}
-        (mt/with-temp [:model/NativeQuerySnippet snippet]
-          (is (= deps.graph/current-dependency-analysis-version
-                 (t2/select-one-fn :dependency_analysis_version :model/NativeQuerySnippet (:id snippet)))))))
-    (testing "snippets update"
-      (mt/with-premium-features #{}
-        (mt/with-temp [:model/NativeQuerySnippet snippet]
-          (is (zero? (t2/select-one-fn :dependency_analysis_version :model/NativeQuerySnippet (:id snippet))))
-          (mt/with-premium-features #{:dependencies}
-            (t2/update! :model/NativeQuerySnippet (:id snippet) {:content "new content"}))
-          (is (= deps.graph/current-dependency-analysis-version
-                 (t2/select-one-fn :dependency_analysis_version :model/NativeQuerySnippet (:id snippet)))))))))
+    (mt/with-empty-h2-app-db!
+      (testing "cards"
+        (mt/with-model-cleanup [:model/Dependency]
+          (mt/with-temp [:model/Card card {:dependency_analysis_version 0}]
+            (is (zero? (t2/select-one-fn :dependency_analysis_version :model/Card (:id card))))
+            (mt/with-premium-features #{:dependencies}
+              (card/update-card! {:card-before-update card
+                                  :card-updates {:dataset_query (mt/mbql-query orders)}}))
+            (is (= deps.graph/current-dependency-analysis-version
+                   (t2/select-one-fn :dependency_analysis_version :model/Card (:id card)))))))
+      (testing "transforms create"
+        (mt/with-premium-features #{:dependencies}
+          (mt/with-temp [:model/Transform transform]
+            (is (= deps.graph/current-dependency-analysis-version
+                   (t2/select-one-fn :dependency_analysis_version :model/Transform (:id transform)))))))
+      (testing "transforms update"
+        (mt/with-premium-features #{}
+          (mt/with-temp [:model/Transform transform]
+            (is (zero? (t2/select-one-fn :dependency_analysis_version :model/Transform (:id transform))))
+            (mt/with-premium-features #{:dependencies}
+              (t2/update! :model/Transform (:id transform) {:source {:type "query" :query (mt/mbql-query products)}}))
+            (is (= deps.graph/current-dependency-analysis-version
+                   (t2/select-one-fn :dependency_analysis_version :model/Transform (:id transform)))))))
+      (testing "snippets create"
+        (mt/with-premium-features #{:dependencies}
+          (mt/with-temp [:model/NativeQuerySnippet snippet]
+            (is (= deps.graph/current-dependency-analysis-version
+                   (t2/select-one-fn :dependency_analysis_version :model/NativeQuerySnippet (:id snippet)))))))
+      (testing "snippets update"
+        (mt/with-premium-features #{}
+          (mt/with-temp [:model/NativeQuerySnippet snippet]
+            (is (zero? (t2/select-one-fn :dependency_analysis_version :model/NativeQuerySnippet (:id snippet))))
+            (mt/with-premium-features #{:dependencies}
+              (t2/update! :model/NativeQuerySnippet (:id snippet) {:content "new content"}))
+            (is (= deps.graph/current-dependency-analysis-version
+                   (t2/select-one-fn :dependency_analysis_version :model/NativeQuerySnippet (:id snippet))))))))))
 
 (deftest dependency-analysis-version-create-card-test
   (testing "dependency_analysis_version is updated when a card is created"


### PR DESCRIPTION
## Summary

Two enterprise dependencies tests fail with MySQL 8.4 as the application db. They've been failing since introduced (Jan 2026) but only surfaced in the MySQL 8.4 Enterprise Tests CI job.

**Root cause:** MySQL 8.4's stricter savepoint handling breaks when `mt/with-temp`'s rollback-only transaction interacts with after-insert hooks that create nested transactions. The Database after-insert hook fires `set-new-database-permissions!` which opens a nested savepoint, and FK constraints fail because the outer transaction is rollback-only. Similarly, User creation inside a savepoint context returns nil IDs on MySQL 8.4.

**Fix:** Wrap both tests in `mt/with-empty-h2-app-db!` — the same pattern used by the adjacent `unreferenced-audit-db-test`. These tests verify application logic (dependency tracking, graph filtering), not MySQL-specific behavior.

### Changes
- `unreferenced-sample-db-test` — wrapped in `mt/with-empty-h2-app-db!`
- `filtered-graph-dependencies-test` — wrapped in `mt/with-empty-h2-app-db!`

## Test plan
- [x] Both tests pass locally on H2
- [x] Verify on MySQL 8.4 via CI (the `MySQL 8.4 Enterprise Tests` job)