### PR TITLE
Inline parameter in clickhouse honeysql method

### DIFF
--- a/modules/drivers/clickhouse/src/metabase/driver/clickhouse_qp.clj
+++ b/modules/drivers/clickhouse/src/metabase/driver/clickhouse_qp.clj
@@ -183,8 +183,8 @@
   (let [report-timezone (get-report-timezone-id-safely)
         inner-expr      (h2x// expr 1000)]
     (if report-timezone
-      [:'toDateTime64 inner-expr 3 report-timezone]
-      [:'toDateTime64 inner-expr 3])))
+      [:'toDateTime64 inner-expr [:inline 3] (h2x/literal report-timezone)]
+      [:'toDateTime64 inner-expr [:inline 3]])))
 
 (defmethod sql.qp/unix-timestamp->honeysql [:clickhouse :microseconds]
   [_ _ expr]

--- a/modules/drivers/clickhouse/test/metabase/driver/clickhouse_substitution_test.clj
+++ b/modules/drivers/clickhouse/test/metabase/driver/clickhouse_substitution_test.clj
@@ -340,13 +340,12 @@
   (mt/test-driver :clickhouse
     (mt/with-clock clock
       (testing "Field filter on a UInt64 column coerced to UNIX milliseconds->DateTime generates valid SQL (#70901)"
-        (let [;; Use timestamps around the mock clock time (2019-11-30T23:00:00Z)
-              now   (local-date-time-now)
+        (let [now   (local-date-time-now)
               ->epoch-millis (fn [^LocalDateTime ldt]
                                (.toEpochMilli (.toInstant (.atZone ldt (java.time.ZoneId/of "UTC")))))]
           (mt/dataset
-            (mt/dataset-definition "mb_vars_unix_millis"
-                                   [["test_table"
+            (mt/dataset-definition "milliseconds_db"
+                                   [["milliseconds_table"
                                      [{:field-name        "time"
                                        :base-type         {:native "UInt64"}
                                        :effective-type    :type/Instant
@@ -357,20 +356,20 @@
                                       [(->epoch-millis (.minusHours now 24)) "Event B"]
                                       [(->epoch-millis (.plusHours now 1)) "Event C"]
                                       [(->epoch-millis (.plusDays now 2)) "Event D"]]]])
-            (let [uuid  (str (java.util.UUID/randomUUID))
+            (let [uuid  (str (random-uuid))
                   query {:database   (mt/id)
                          :type       "native"
-                         :native     {:collection    "test-table"
-                                      :template-tags {:x {:id           uuid
-                                                          :name         "time"
-                                                          :display-name "Time"
-                                                          :type         "dimension"
-                                                          :dimension    ["field" (mt/id :test-table :time) nil]
-                                                          :required     true}}
-                                      :query         "SELECT * FROM `mb_vars_unix_millis`.`test_table` WHERE {{x}}"}
+                         :native     {:collection    "milliseconds-table"
+                                      :template-tags {:date_filter {:id           uuid
+                                                                    :name         "time"
+                                                                    :display-name "Time"
+                                                                    :type         "dimension"
+                                                                    :dimension    ["field" (mt/id :milliseconds-table :time) nil]
+                                                                    :required     true}}
+                                      :query "SELECT * FROM `milliseconds_db`.`milliseconds_table` WHERE {{date_filter}}"}
                          :parameters [{:type   "date/all-options"
                                        :value  "past7days"
-                                       :target ["dimension" ["template-tag" "x"]]
+                                       :target ["dimension" ["template-tag" "date_filter"]]
                                        :id     uuid}]}]
               (is (= [[1 1574982000000 "Event A"]
                       [2 1575068400000 "Event B"]]

--- a/modules/drivers/clickhouse/test/metabase/driver/clickhouse_substitution_test.clj
+++ b/modules/drivers/clickhouse/test/metabase/driver/clickhouse_substitution_test.clj
@@ -336,6 +336,47 @@
                                         :target ["variable" ["template-tag" "x"]]
                                         :id uuid}]}))))))))
 
+(deftest ^:parallel clickhouse-field-filter-unix-millis-coercion-test
+  (mt/test-driver :clickhouse
+    (mt/with-clock clock
+      (testing "Field filter on a UInt64 column coerced to UNIX milliseconds->DateTime generates valid SQL (#70901)"
+        (let [db    "mb_vars_unix_millis5"
+              ;; Use timestamps around the mock clock time (2019-11-30T23:00:00Z)
+              now   (local-date-time-now)
+              ->epoch-millis (fn [^LocalDateTime ldt]
+                               (.toEpochMilli (.toInstant (.atZone ldt (java.time.ZoneId/of "UTC")))))
+              table [["test_table"
+                      [{:field-name        "time"
+                        :base-type         {:native "UInt64"}
+                        :effective-type    :type/Instant
+                        :coercion-strategy :Coercion/UNIXMilliSeconds->DateTime}
+                       {:field-name "name"
+                        :base-type  :type/Text}]
+                      [[(->epoch-millis (.minusDays now 2)) "Event A"]
+                       [(->epoch-millis (.minusHours now 24)) "Event B"]
+                       [(->epoch-millis (.plusHours now 1)) "Event C"]
+                       [(->epoch-millis (.plusDays now 2)) "Event D"]]]]]
+          (mt/dataset
+            (mt/dataset-definition db table)
+            (let [uuid  (str (java.util.UUID/randomUUID))
+                  query {:database   (mt/id)
+                         :type       "native"
+                         :native     {:collection    "test-table"
+                                      :template-tags {:x {:id           uuid
+                                                          :name         "time"
+                                                          :display-name "Time"
+                                                          :type         "dimension"
+                                                          :dimension    ["field" (mt/id :test-table :time) nil]
+                                                          :required     true}}
+                                      :query         (format "SELECT * FROM `%s`.`test_table` WHERE {{x}}" db)}
+                         :parameters [{:type   "date/all-options"
+                                       :value  "past7days"
+                                       :target ["dimension" ["template-tag" "x"]]
+                                       :id     uuid}]}]
+              (is (= [[1 1574982000000 "Event A"]
+                      [2 1575068400000 "Event B"]]
+                     (mt/rows (qp/process-query query)))))))))))
+
 (deftest clickhouse-native-query-with-uuid-filter-test
   (mt/test-driver :clickhouse
     (let [uuid-1 #uuid "3127abff-e634-4114-a015-59893b49ae74"

--- a/modules/drivers/clickhouse/test/metabase/driver/clickhouse_substitution_test.clj
+++ b/modules/drivers/clickhouse/test/metabase/driver/clickhouse_substitution_test.clj
@@ -340,24 +340,23 @@
   (mt/test-driver :clickhouse
     (mt/with-clock clock
       (testing "Field filter on a UInt64 column coerced to UNIX milliseconds->DateTime generates valid SQL (#70901)"
-        (let [db    "mb_vars_unix_millis5"
-              ;; Use timestamps around the mock clock time (2019-11-30T23:00:00Z)
+        (let [;; Use timestamps around the mock clock time (2019-11-30T23:00:00Z)
               now   (local-date-time-now)
               ->epoch-millis (fn [^LocalDateTime ldt]
-                               (.toEpochMilli (.toInstant (.atZone ldt (java.time.ZoneId/of "UTC")))))
-              table [["test_table"
-                      [{:field-name        "time"
-                        :base-type         {:native "UInt64"}
-                        :effective-type    :type/Instant
-                        :coercion-strategy :Coercion/UNIXMilliSeconds->DateTime}
-                       {:field-name "name"
-                        :base-type  :type/Text}]
-                      [[(->epoch-millis (.minusDays now 2)) "Event A"]
-                       [(->epoch-millis (.minusHours now 24)) "Event B"]
-                       [(->epoch-millis (.plusHours now 1)) "Event C"]
-                       [(->epoch-millis (.plusDays now 2)) "Event D"]]]]]
+                               (.toEpochMilli (.toInstant (.atZone ldt (java.time.ZoneId/of "UTC")))))]
           (mt/dataset
-            (mt/dataset-definition db table)
+            (mt/dataset-definition "mb_vars_unix_millis"
+                                   [["test_table"
+                                     [{:field-name        "time"
+                                       :base-type         {:native "UInt64"}
+                                       :effective-type    :type/Instant
+                                       :coercion-strategy :Coercion/UNIXMilliSeconds->DateTime}
+                                      {:field-name "name"
+                                       :base-type  :type/Text}]
+                                     [[(->epoch-millis (.minusDays now 2)) "Event A"]
+                                      [(->epoch-millis (.minusHours now 24)) "Event B"]
+                                      [(->epoch-millis (.plusHours now 1)) "Event C"]
+                                      [(->epoch-millis (.plusDays now 2)) "Event D"]]]])
             (let [uuid  (str (java.util.UUID/randomUUID))
                   query {:database   (mt/id)
                          :type       "native"
@@ -368,7 +367,7 @@
                                                           :type         "dimension"
                                                           :dimension    ["field" (mt/id :test-table :time) nil]
                                                           :required     true}}
-                                      :query         (format "SELECT * FROM `%s`.`test_table` WHERE {{x}}" db)}
+                                      :query         "SELECT * FROM `mb_vars_unix_millis`.`test_table` WHERE {{x}}"}
                          :parameters [{:type   "date/all-options"
                                        :value  "past7days"
                                        :target ["dimension" ["template-tag" "x"]]


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/70901

### Description

Uses fix suggested by @ghostframe to inline the precision value in the millseconds -> datetime casting

### How to verify

See original issue. The query should work now. 

### Demo

https://github.com/user-attachments/assets/9b45ed08-003e-4a89-8a39-1e45dcfea241

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
