### PR TITLE
feat: add TOTP-based 2FA for password login and admin option to require it

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -128,6 +128,7 @@
         "prosemirror-dropcursor": "1.8.2",
         "prosemirror-state": "^1.4.4",
         "prosemirror-view": "^1.40.1",
+        "qrcode.react": "^4.2.0",
         "querystring-es3": "^0.2.1",
         "re-reselect": "^4.0.1",
         "react": "^18.2.0",
@@ -4447,6 +4448,8 @@
     "pure-rand": ["pure-rand@7.0.1", "", {}, "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ=="],
 
     "qified": ["qified@0.5.0", "", { "dependencies": { "hookified": "^1.12.1" } }, "sha512-Zj6Q/Vc/SQ+Fzc87N90jJUzBzxD7MVQ2ZvGyMmYtnl2u1a07CejAhvtk4ZwASos+SiHKCAIylyGHJKIek75QBw=="],
+
+    "qrcode.react": ["qrcode.react@4.2.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA=="],
 
     "qs": ["qs@6.12.3", "", { "dependencies": { "side-channel": "^1.0.6" } }, "sha512-AWJm14H1vVaO/iNZ4/hO+HyaTehuy9nRqVdkTqlJt0HWvBiBIEXFmb4C0DGeYo3Xes9rrEW+TxHsaigCbN5ICQ=="],
 

--- a/frontend/src/metabase-types/api/mocks/settings.ts
+++ b/frontend/src/metabase-types/api/mocks/settings.ts
@@ -331,6 +331,7 @@ export const createMockSettings = (
   "report-timezone": "Europe/London",
   "report-timezone-short": "UTC",
   "report-timezone-long": "Europe/London",
+  "require-mfa": false,
   "oidc-configured": false,
   "oidc-enabled": false,
   "oidc-login-providers": [],

--- a/frontend/src/metabase-types/api/mocks/user.ts
+++ b/frontend/src/metabase-types/api/mocks/user.ts
@@ -22,6 +22,7 @@ export const createMockUser = (opts?: Partial<User>): User => {
     is_qbnewb: false,
     is_superuser: false,
     is_data_analyst: false,
+    totp_enabled: false,
     is_installer: false,
     has_invited_second_user: false,
     has_question_and_dashboard: false,

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -586,6 +586,7 @@ interface PublicSettings {
   "report-timezone": string | null;
   "report-timezone-long": string;
   "report-timezone-short": string;
+  "require-mfa": boolean;
   "session-cookies": boolean | null;
   "setup-token": string | null;
   "metabot-enabled?": boolean;

--- a/frontend/src/metabase-types/api/user.ts
+++ b/frontend/src/metabase-types/api/user.ts
@@ -36,6 +36,7 @@ export interface BaseUser {
   is_qbnewb: boolean;
   is_superuser: boolean;
   is_data_analyst: boolean;
+  totp_enabled: boolean;
 
   date_joined: string;
   last_login: string;

--- a/frontend/src/metabase/account/app/components/AccountHeader/AccountHeader.tsx
+++ b/frontend/src/metabase/account/app/components/AccountHeader/AccountHeader.tsx
@@ -37,6 +37,7 @@ export const AccountHeader = ({
       ...(hasPasswordChange
         ? [{ name: t`Password`, value: "/account/password" }]
         : []),
+      { name: t`Security`, value: "/account/security" },
       { name: t`Login History`, value: "/account/login-history" },
       { name: t`Notifications`, value: "/account/notifications" },
     ],

--- a/frontend/src/metabase/account/mfa/components/MfaSetup.tsx
+++ b/frontend/src/metabase/account/mfa/components/MfaSetup.tsx
@@ -1,0 +1,290 @@
+import { QRCodeSVG } from "qrcode.react";
+import { type ChangeEvent, useCallback, useState } from "react";
+import { t } from "ttag";
+
+import { MfaApi } from "metabase/services";
+import {
+  Alert,
+  Box,
+  Button,
+  Code,
+  Group,
+  Stack,
+  Text,
+  TextInput,
+  Title,
+} from "metabase/ui";
+
+interface MfaSetupProps {
+  totpEnabled: boolean;
+  onStatusChange: () => void;
+}
+
+type SetupStep = "idle" | "qr" | "verify" | "complete";
+
+interface SetupData {
+  secret: string;
+  otpauth_uri: string;
+  recovery_codes: string[];
+}
+
+export const MfaSetup = ({
+  totpEnabled,
+  onStatusChange,
+}: MfaSetupProps): JSX.Element => {
+  const [step, setStep] = useState<SetupStep>("idle");
+  const [setupData, setSetupData] = useState<SetupData | null>(null);
+  const [verifyCode, setVerifyCode] = useState("");
+  const [disablePassword, setDisablePassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [showRecoveryCodes, setShowRecoveryCodes] = useState(false);
+  const [recoveryCodes, setRecoveryCodes] = useState<string[] | null>(null);
+  const [regenPassword, setRegenPassword] = useState("");
+
+  const handleStartSetup = useCallback(async () => {
+    setError(null);
+    setIsLoading(true);
+    try {
+      const data = await MfaApi.setup();
+      setSetupData(data);
+      setStep("qr");
+    } catch (e: unknown) {
+      setError(
+        (e as { data?: { message?: string } })?.data?.message ??
+          t`Failed to start setup`,
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const handleConfirm = useCallback(async () => {
+    setError(null);
+    setIsLoading(true);
+    try {
+      await MfaApi.confirm({ "totp-code": verifyCode });
+      setStep("complete");
+      onStatusChange();
+    } catch (e: unknown) {
+      setError(
+        (e as { data?: { errors?: { "totp-code"?: string } } })?.data?.errors?.[
+          "totp-code"
+        ] ?? t`Invalid verification code`,
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }, [verifyCode, onStatusChange]);
+
+  const handleDisable = useCallback(async () => {
+    setError(null);
+    setIsLoading(true);
+    try {
+      await MfaApi.disable({ password: disablePassword });
+      onStatusChange();
+    } catch (e: unknown) {
+      setError(
+        (e as { data?: { errors?: { password?: string } } })?.data?.errors
+          ?.password ?? t`Failed to disable two-factor authentication`,
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }, [disablePassword, onStatusChange]);
+
+  const handleRegenerateRecoveryCodes = useCallback(async () => {
+    setError(null);
+    setIsLoading(true);
+    try {
+      const data = await MfaApi.regenerateRecoveryCodes({
+        password: regenPassword,
+      });
+      setRecoveryCodes(data.recovery_codes);
+      setShowRecoveryCodes(true);
+      setRegenPassword("");
+    } catch (e: unknown) {
+      setError(
+        (e as { data?: { errors?: { password?: string } } })?.data?.errors
+          ?.password ?? t`Failed to regenerate recovery codes`,
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }, [regenPassword]);
+
+  // Enrolled state
+  if (totpEnabled && step !== "complete") {
+    return (
+      <Stack gap="lg">
+        <Title order={2}>{t`Two-factor authentication`}</Title>
+        <Alert color="success" title={t`Enabled`}>
+          {t`Two-factor authentication is enabled for your account.`}
+        </Alert>
+
+        {showRecoveryCodes && recoveryCodes && (
+          <Box>
+            <Text fw="bold" mb="sm">
+              {t`New recovery codes`}
+            </Text>
+            <Text c="text-secondary" mb="sm">
+              {t`Save these codes in a safe place. Each code can only be used once.`}
+            </Text>
+            <Code block>{recoveryCodes.join("\n")}</Code>
+          </Box>
+        )}
+
+        {!showRecoveryCodes && (
+          <Box>
+            <Text fw="bold" mb="sm">
+              {t`Regenerate recovery codes`}
+            </Text>
+            <Group>
+              <TextInput
+                type="password"
+                placeholder={t`Current password`}
+                value={regenPassword}
+                onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                  setRegenPassword(e.currentTarget.value)
+                }
+              />
+              <Button
+                variant="outline"
+                onClick={handleRegenerateRecoveryCodes}
+                loading={isLoading}
+                disabled={!regenPassword}
+              >
+                {t`Regenerate`}
+              </Button>
+            </Group>
+          </Box>
+        )}
+
+        <Box>
+          <Text fw="bold" mb="sm">
+            {t`Disable two-factor authentication`}
+          </Text>
+          <Group>
+            <TextInput
+              type="password"
+              placeholder={t`Current password`}
+              value={disablePassword}
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                setDisablePassword(e.currentTarget.value)
+              }
+            />
+            <Button
+              variant="outline"
+              color="danger"
+              onClick={handleDisable}
+              loading={isLoading}
+              disabled={!disablePassword}
+            >
+              {t`Disable`}
+            </Button>
+          </Group>
+        </Box>
+
+        {error && <Alert color="error">{error}</Alert>}
+      </Stack>
+    );
+  }
+
+  // Setup complete state (just enabled)
+  if (step === "complete" && setupData) {
+    return (
+      <Stack gap="lg">
+        <Title order={2}>{t`Two-factor authentication`}</Title>
+        <Alert color="success" title={t`Setup complete`}>
+          {t`Two-factor authentication has been enabled for your account.`}
+        </Alert>
+        <Box>
+          <Text fw="bold" mb="sm">
+            {t`Recovery codes`}
+          </Text>
+          <Text c="text-secondary" mb="sm">
+            {t`Save these codes in a safe place. Each code can only be used once. If you lose access to your authenticator app, you can use these codes to sign in.`}
+          </Text>
+          <Code block>{setupData.recovery_codes.join("\n")}</Code>
+        </Box>
+      </Stack>
+    );
+  }
+
+  // QR code display + verification step
+  if (step === "qr" && setupData) {
+    return (
+      <Stack gap="lg">
+        <Title order={2}>{t`Set up two-factor authentication`}</Title>
+        <Text>
+          {t`Scan this QR code with your authenticator app (such as Google Authenticator or Authy).`}
+        </Text>
+        <Box style={{ display: "flex", justifyContent: "center" }}>
+          <QRCodeSVG value={setupData.otpauth_uri} size={200} />
+        </Box>
+        <Box>
+          <Text fz="sm" c="text-secondary" mb="xs">
+            {t`Or enter this secret manually:`}
+          </Text>
+          <Code>{setupData.secret}</Code>
+        </Box>
+        <Box>
+          <Text fw="bold" mb="sm">
+            {t`Verify setup`}
+          </Text>
+          <Text c="text-secondary" mb="sm">
+            {t`Enter the 6-digit code from your authenticator app to confirm setup.`}
+          </Text>
+          <Group>
+            <TextInput
+              placeholder="000000"
+              inputMode="numeric"
+              maxLength={6}
+              value={verifyCode}
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                setVerifyCode(e.currentTarget.value)
+              }
+              autoFocus
+            />
+            <Button
+              variant="filled"
+              onClick={handleConfirm}
+              loading={isLoading}
+              disabled={verifyCode.length !== 6}
+            >
+              {t`Verify and enable`}
+            </Button>
+          </Group>
+        </Box>
+
+        <Box>
+          <Text fw="bold" mb="sm">
+            {t`Recovery codes`}
+          </Text>
+          <Text c="text-secondary" mb="sm">
+            {t`Save these codes now. They will be shown again after setup is complete, but this is your first chance to copy them.`}
+          </Text>
+          <Code block>{setupData.recovery_codes.join("\n")}</Code>
+        </Box>
+
+        {error && <Alert color="error">{error}</Alert>}
+      </Stack>
+    );
+  }
+
+  // Idle state — not enrolled
+  return (
+    <Stack gap="lg">
+      <Title order={2}>{t`Two-factor authentication`}</Title>
+      <Text>
+        {t`Add an extra layer of security to your account by requiring a verification code from an authenticator app when you sign in.`}
+      </Text>
+      <Box>
+        <Button variant="filled" onClick={handleStartSetup} loading={isLoading}>
+          {t`Enable two-factor authentication`}
+        </Button>
+      </Box>
+      {error && <Alert color="error">{error}</Alert>}
+    </Stack>
+  );
+};

--- a/frontend/src/metabase/account/mfa/components/MfaSetup.tsx
+++ b/frontend/src/metabase/account/mfa/components/MfaSetup.tsx
@@ -2,6 +2,7 @@ import { QRCodeSVG } from "qrcode.react";
 import { type ChangeEvent, useCallback, useState } from "react";
 import { t } from "ttag";
 
+import { color } from "metabase/lib/colors";
 import { MfaApi } from "metabase/services";
 import {
   Alert,
@@ -219,8 +220,22 @@ export const MfaSetup = ({
         <Text>
           {t`Scan this QR code with your authenticator app (such as Google Authenticator or Authy).`}
         </Text>
-        <Box style={{ display: "flex", justifyContent: "center" }}>
-          <QRCodeSVG value={setupData.otpauth_uri} size={200} />
+        <Box
+          style={{
+            display: "flex",
+            justifyContent: "center",
+          }}
+        >
+          <Box
+            p="md"
+            style={{
+              backgroundColor: color("white"),
+              borderRadius: "var(--mantine-radius-sm)",
+              lineHeight: 0,
+            }}
+          >
+            <QRCodeSVG value={setupData.otpauth_uri} size={200} />
+          </Box>
         </Box>
         <Box>
           <Text fz="sm" c="text-secondary" mb="xs">

--- a/frontend/src/metabase/account/mfa/components/MfaSetup.tsx
+++ b/frontend/src/metabase/account/mfa/components/MfaSetup.tsx
@@ -16,6 +16,19 @@ import {
   Title,
 } from "metabase/ui";
 
+function getApiError(e: unknown): string | undefined {
+  const err = e as {
+    data?: { message?: string; errors?: Record<string, string> };
+  };
+  if (err?.data?.errors) {
+    const firstError = Object.values(err.data.errors)[0];
+    if (firstError) {
+      return firstError;
+    }
+  }
+  return err?.data?.message;
+}
+
 interface MfaSetupProps {
   totpEnabled: boolean;
   onStatusChange: () => void;
@@ -53,12 +66,7 @@ export const MfaSetup = ({
       setSetupPassword("");
       setStep("qr");
     } catch (e: unknown) {
-      setError(
-        (e as { data?: { message?: string } })?.data?.message ??
-          (e as { data?: { errors?: { password?: string } } })?.data?.errors
-            ?.password ??
-          t`Failed to start setup`,
-      );
+      setError(getApiError(e) ?? t`Failed to start setup`);
     } finally {
       setIsLoading(false);
     }
@@ -72,11 +80,7 @@ export const MfaSetup = ({
       setStep("complete");
       onStatusChange();
     } catch (e: unknown) {
-      setError(
-        (e as { data?: { errors?: { "totp-code"?: string } } })?.data?.errors?.[
-          "totp-code"
-        ] ?? t`Invalid verification code`,
-      );
+      setError(getApiError(e) ?? t`Invalid verification code`);
     } finally {
       setIsLoading(false);
     }
@@ -90,8 +94,7 @@ export const MfaSetup = ({
       onStatusChange();
     } catch (e: unknown) {
       setError(
-        (e as { data?: { errors?: { password?: string } } })?.data?.errors
-          ?.password ?? t`Failed to disable two-factor authentication`,
+        getApiError(e) ?? t`Failed to disable two-factor authentication`,
       );
     } finally {
       setIsLoading(false);
@@ -109,10 +112,7 @@ export const MfaSetup = ({
       setShowRecoveryCodes(true);
       setRegenPassword("");
     } catch (e: unknown) {
-      setError(
-        (e as { data?: { errors?: { password?: string } } })?.data?.errors
-          ?.password ?? t`Failed to regenerate recovery codes`,
-      );
+      setError(getApiError(e) ?? t`Failed to regenerate recovery codes`);
     } finally {
       setIsLoading(false);
     }

--- a/frontend/src/metabase/account/mfa/components/MfaSetup.tsx
+++ b/frontend/src/metabase/account/mfa/components/MfaSetup.tsx
@@ -36,6 +36,7 @@ export const MfaSetup = ({
   const [step, setStep] = useState<SetupStep>("idle");
   const [setupData, setSetupData] = useState<SetupData | null>(null);
   const [verifyCode, setVerifyCode] = useState("");
+  const [setupPassword, setSetupPassword] = useState("");
   const [disablePassword, setDisablePassword] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
@@ -47,18 +48,21 @@ export const MfaSetup = ({
     setError(null);
     setIsLoading(true);
     try {
-      const data = await MfaApi.setup();
+      const data = await MfaApi.setup({ password: setupPassword });
       setSetupData(data);
+      setSetupPassword("");
       setStep("qr");
     } catch (e: unknown) {
       setError(
         (e as { data?: { message?: string } })?.data?.message ??
+          (e as { data?: { errors?: { password?: string } } })?.data?.errors
+            ?.password ??
           t`Failed to start setup`,
       );
     } finally {
       setIsLoading(false);
     }
-  }, []);
+  }, [setupPassword]);
 
   const handleConfirm = useCallback(async () => {
     setError(null);
@@ -295,9 +299,24 @@ export const MfaSetup = ({
         {t`Add an extra layer of security to your account by requiring a verification code from an authenticator app when you sign in.`}
       </Text>
       <Box>
-        <Button variant="filled" onClick={handleStartSetup} loading={isLoading}>
-          {t`Enable two-factor authentication`}
-        </Button>
+        <Group>
+          <TextInput
+            type="password"
+            placeholder={t`Current password`}
+            value={setupPassword}
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+              setSetupPassword(e.currentTarget.value)
+            }
+          />
+          <Button
+            variant="filled"
+            onClick={handleStartSetup}
+            loading={isLoading}
+            disabled={!setupPassword}
+          >
+            {t`Enable two-factor authentication`}
+          </Button>
+        </Group>
       </Box>
       {error && <Alert color="error">{error}</Alert>}
     </Stack>

--- a/frontend/src/metabase/account/mfa/components/MfaSetup.tsx
+++ b/frontend/src/metabase/account/mfa/components/MfaSetup.tsx
@@ -32,6 +32,8 @@ function getApiError(e: unknown): string | undefined {
 interface MfaSetupProps {
   totpEnabled: boolean;
   onStatusChange: () => void;
+  /** When true, hides the disable option (used when MFA is required by admin). */
+  required?: boolean;
 }
 
 type SetupStep = "idle" | "qr" | "verify" | "complete";
@@ -45,6 +47,7 @@ interface SetupData {
 export const MfaSetup = ({
   totpEnabled,
   onStatusChange,
+  required = false,
 }: MfaSetupProps): JSX.Element => {
   const [step, setStep] = useState<SetupStep>("idle");
   const [setupData, setSetupData] = useState<SetupData | null>(null);
@@ -165,30 +168,32 @@ export const MfaSetup = ({
           </Box>
         )}
 
-        <Box>
-          <Text fw="bold" mb="sm">
-            {t`Disable two-factor authentication`}
-          </Text>
-          <Group>
-            <TextInput
-              type="password"
-              placeholder={t`Current password`}
-              value={disablePassword}
-              onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                setDisablePassword(e.currentTarget.value)
-              }
-            />
-            <Button
-              variant="outline"
-              color="danger"
-              onClick={handleDisable}
-              loading={isLoading}
-              disabled={!disablePassword}
-            >
-              {t`Disable`}
-            </Button>
-          </Group>
-        </Box>
+        {!required && (
+          <Box>
+            <Text fw="bold" mb="sm">
+              {t`Disable two-factor authentication`}
+            </Text>
+            <Group>
+              <TextInput
+                type="password"
+                placeholder={t`Current password`}
+                value={disablePassword}
+                onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                  setDisablePassword(e.currentTarget.value)
+                }
+              />
+              <Button
+                variant="outline"
+                color="danger"
+                onClick={handleDisable}
+                loading={isLoading}
+                disabled={!disablePassword}
+              >
+                {t`Disable`}
+              </Button>
+            </Group>
+          </Box>
+        )}
 
         {error && <Alert color="error">{error}</Alert>}
       </Stack>

--- a/frontend/src/metabase/account/mfa/containers/MfaApp.tsx
+++ b/frontend/src/metabase/account/mfa/containers/MfaApp.tsx
@@ -1,0 +1,30 @@
+import { useCallback } from "react";
+
+import { useDispatch, useSelector } from "metabase/lib/redux";
+import { refreshCurrentUser } from "metabase/redux/user";
+import { getUser } from "metabase/selectors/user";
+
+import { MfaSetup } from "../components/MfaSetup";
+
+const MfaApp = (): JSX.Element | null => {
+  const user = useSelector(getUser);
+  const dispatch = useDispatch();
+
+  const handleStatusChange = useCallback(() => {
+    dispatch(refreshCurrentUser());
+  }, [dispatch]);
+
+  if (!user) {
+    return null;
+  }
+
+  return (
+    <MfaSetup
+      totpEnabled={user.totp_enabled}
+      onStatusChange={handleStatusChange}
+    />
+  );
+};
+
+// eslint-disable-next-line import/no-default-export -- routes require default export
+export default MfaApp;

--- a/frontend/src/metabase/account/mfa/containers/MfaRequiredApp.tsx
+++ b/frontend/src/metabase/account/mfa/containers/MfaRequiredApp.tsx
@@ -16,7 +16,8 @@ const MfaRequiredApp = (): JSX.Element | null => {
 
   const handleStatusChange = useCallback(async () => {
     await dispatch(refreshCurrentUser());
-    await dispatch(refreshSiteSettings());
+    // Best-effort — don't block navigation if settings refresh fails
+    dispatch(refreshSiteSettings());
     dispatch(push("/"));
   }, [dispatch]);
 

--- a/frontend/src/metabase/account/mfa/containers/MfaRequiredApp.tsx
+++ b/frontend/src/metabase/account/mfa/containers/MfaRequiredApp.tsx
@@ -1,5 +1,5 @@
-import { useCallback } from "react";
-import { push } from "react-router-redux";
+import { useCallback, useEffect } from "react";
+import { push, replace } from "react-router-redux";
 import { t } from "ttag";
 
 import { useDispatch, useSelector } from "metabase/lib/redux";
@@ -20,13 +20,21 @@ const MfaRequiredApp = (): JSX.Element | null => {
     dispatch(push("/"));
   }, [dispatch]);
 
-  if (!user) {
-    return null;
-  }
+  // Redirect unauthenticated users to login
+  useEffect(() => {
+    if (!user) {
+      dispatch(replace("/auth/login"));
+    }
+  }, [user, dispatch]);
 
-  // If the user already has MFA enabled, redirect home
-  if (user.totp_enabled) {
-    dispatch(push("/"));
+  // Redirect home if MFA is already enabled
+  useEffect(() => {
+    if (user?.totp_enabled) {
+      dispatch(replace("/"));
+    }
+  }, [user?.totp_enabled, dispatch]);
+
+  if (!user || user.totp_enabled) {
     return null;
   }
 

--- a/frontend/src/metabase/account/mfa/containers/MfaRequiredApp.tsx
+++ b/frontend/src/metabase/account/mfa/containers/MfaRequiredApp.tsx
@@ -1,0 +1,49 @@
+import { useCallback } from "react";
+import { push } from "react-router-redux";
+import { t } from "ttag";
+
+import { useDispatch, useSelector } from "metabase/lib/redux";
+import { refreshCurrentUser } from "metabase/redux/user";
+import { getUser } from "metabase/selectors/user";
+import { Alert, Box, Stack } from "metabase/ui";
+
+import { MfaSetup } from "../components/MfaSetup";
+
+const MfaRequiredApp = (): JSX.Element | null => {
+  const user = useSelector(getUser);
+  const dispatch = useDispatch();
+
+  const handleStatusChange = useCallback(async () => {
+    await dispatch(refreshCurrentUser());
+    dispatch(push("/"));
+  }, [dispatch]);
+
+  if (!user) {
+    return null;
+  }
+
+  // If the user already has MFA enabled, redirect home
+  if (user.totp_enabled) {
+    dispatch(push("/"));
+    return null;
+  }
+
+  return (
+    <Box maw={600} mx="auto" mt="xl" p="xl">
+      <Stack gap="lg">
+        <Alert
+          color="warning"
+          title={t`Two-factor authentication required`}
+        >{t`Your administrator requires two-factor authentication for your account. Please set it up to continue.`}</Alert>
+        <MfaSetup
+          totpEnabled={user.totp_enabled}
+          onStatusChange={handleStatusChange}
+          required
+        />
+      </Stack>
+    </Box>
+  );
+};
+
+// eslint-disable-next-line import/no-default-export -- routes require default export
+export default MfaRequiredApp;

--- a/frontend/src/metabase/account/mfa/containers/MfaRequiredApp.tsx
+++ b/frontend/src/metabase/account/mfa/containers/MfaRequiredApp.tsx
@@ -3,6 +3,7 @@ import { push } from "react-router-redux";
 import { t } from "ttag";
 
 import { useDispatch, useSelector } from "metabase/lib/redux";
+import { refreshSiteSettings } from "metabase/redux/settings";
 import { refreshCurrentUser } from "metabase/redux/user";
 import { getUser } from "metabase/selectors/user";
 import { Alert, Box, Stack } from "metabase/ui";
@@ -15,6 +16,7 @@ const MfaRequiredApp = (): JSX.Element | null => {
 
   const handleStatusChange = useCallback(async () => {
     await dispatch(refreshCurrentUser());
+    await dispatch(refreshSiteSettings());
     dispatch(push("/"));
   }, [dispatch]);
 

--- a/frontend/src/metabase/account/routes.tsx
+++ b/frontend/src/metabase/account/routes.tsx
@@ -6,6 +6,7 @@ import type { State } from "metabase-types/store";
 
 import AccountApp from "./app/containers/AccountApp";
 import LoginHistoryApp from "./login-history/containers/LoginHistoryApp";
+import MfaApp from "./mfa/containers/MfaApp";
 import { getNotificationRoutes } from "./notifications/routes";
 import UserPasswordApp from "./password/containers/UserPasswordApp";
 import UserProfileApp from "./profile/containers/UserProfileApp";
@@ -20,6 +21,7 @@ export const getAccountRoutes = (
         <IndexRedirect to="profile" />
         <Route path="profile" component={UserProfileApp} />
         <Route path="password" component={UserPasswordApp} />
+        <Route path="security" component={MfaApp} />
         <Route path="login-history" component={LoginHistoryApp} />
         {getNotificationRoutes()}
       </Route>

--- a/frontend/src/metabase/admin/people/components/PeopleList.tsx
+++ b/frontend/src/metabase/admin/people/components/PeopleList.tsx
@@ -14,8 +14,9 @@ import { PaginationControls } from "metabase/common/components/PaginationControl
 import { useConfirmation } from "metabase/common/hooks/use-confirmation";
 import AdminS from "metabase/css/admin.module.css";
 import CS from "metabase/css/core/index.css";
-import { useDispatch } from "metabase/lib/redux";
+import { useDispatch, useSelector } from "metabase/lib/redux";
 import { PLUGIN_GROUP_MANAGERS } from "metabase/plugins";
+import { getSetting } from "metabase/selectors/settings";
 import { Box, Flex, Icon, Text } from "metabase/ui";
 import type {
   GroupId,
@@ -84,6 +85,8 @@ export const PeopleList = ({
   const { data: membershipsByUser = {} } = useListUserMembershipsQuery();
 
   const { page, pageSize, status } = query;
+
+  const requireMfa = useSelector((state) => getSetting(state, "require-mfa"));
 
   const isCurrentUser = (u: User) => currentUser.id === u.id;
   const showDeactivated = status === ACTIVE_STATUS.deactivated;
@@ -181,6 +184,7 @@ export const PeopleList = ({
               <th>{t`Name`}</th>
               <th />
               <th>{t`Email`}</th>
+              {requireMfa && <th>{t`MFA`}</th>}
               {showDeactivated ? (
                 <Fragment>
                   {external && <th>{t`Tenant`}</th>}

--- a/frontend/src/metabase/admin/people/components/PeopleListRow.tsx
+++ b/frontend/src/metabase/admin/people/components/PeopleListRow.tsx
@@ -71,6 +71,7 @@ export const PeopleListRow = ({
   const isPasswordLoginEnabled = useSelector((state) =>
     getSetting(state, enablePasswordLoginKey),
   );
+  const requireMfa = useSelector((state) => getSetting(state, "require-mfa"));
 
   return (
     <tr key={user.id}>
@@ -91,6 +92,23 @@ export const PeopleListRow = ({
         ) : null}
       </td>
       <td>{user.email}</td>
+      {requireMfa && (
+        <td>
+          {user.sso_source ? (
+            <Tooltip label={t`SSO user — exempt`}>
+              <Text c="text-tertiary" fz="sm">{t`N/A`}</Text>
+            </Tooltip>
+          ) : user.totp_enabled ? (
+            <Tooltip label={t`MFA enabled`}>
+              <Icon name="lock" c="success" />
+            </Tooltip>
+          ) : (
+            <Tooltip label={t`MFA not set up`}>
+              <Icon name="warning" c="warning" />
+            </Tooltip>
+          )}
+        </td>
+      )}
       {showDeactivated ? (
         <Fragment>
           {isExternal && (

--- a/frontend/src/metabase/admin/people/components/PeopleListRow.tsx
+++ b/frontend/src/metabase/admin/people/components/PeopleListRow.tsx
@@ -172,6 +172,15 @@ export const PeopleListRow = ({
                     </Menu.Item>
                   )}
 
+                  {user.totp_enabled && (
+                    <Menu.Item
+                      component={ForwardRefLink}
+                      to={Urls.resetMfa(user)}
+                    >
+                      {t`Reset MFA`}
+                    </Menu.Item>
+                  )}
+
                   {PLUGIN_ADMIN_USER_MENU_ITEMS.flatMap((getItems) =>
                     getItems(user),
                   )}

--- a/frontend/src/metabase/admin/people/containers/UserMfaResetModal.tsx
+++ b/frontend/src/metabase/admin/people/containers/UserMfaResetModal.tsx
@@ -1,0 +1,66 @@
+import { useState } from "react";
+import { t } from "ttag";
+
+import { useGetUserQuery } from "metabase/api";
+import { ConfirmModal } from "metabase/common/components/ConfirmModal";
+import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
+import { useToast } from "metabase/common/hooks/use-toast";
+import { MfaApi } from "metabase/services";
+
+interface UserMfaResetModalProps {
+  params: { userId?: string };
+  onClose: () => void;
+}
+
+export const UserMfaResetModal = ({
+  params,
+  onClose,
+}: UserMfaResetModalProps) => {
+  const userId = parseInt(params.userId ?? "", 10);
+  const {
+    data: user,
+    isLoading,
+    error,
+  } = useGetUserQuery(userId, { skip: isNaN(userId) });
+  const [sendToast] = useToast();
+  const [confirmError, setConfirmError] = useState<string | null>(null);
+
+  if (isNaN(userId)) {
+    onClose();
+    return null;
+  }
+
+  const handleConfirm = async () => {
+    try {
+      await MfaApi.adminReset({ id: userId });
+      sendToast({
+        message: t`Two-factor authentication has been reset for ${user?.common_name}.`,
+      });
+      onClose();
+    } catch (e: unknown) {
+      const err = e as { data?: { message?: string } };
+      setConfirmError(
+        err?.data?.message ?? t`Failed to reset two-factor authentication.`,
+      );
+    }
+  };
+
+  return (
+    <LoadingAndErrorWrapper loading={isLoading} error={error}>
+      {user && (
+        <ConfirmModal
+          opened
+          title={t`Reset two-factor authentication for ${user.common_name}?`}
+          onClose={onClose}
+          confirmButtonText={t`Reset MFA`}
+          confirmButtonProps={{ color: "danger", variant: "filled" }}
+          onConfirm={handleConfirm}
+          message={
+            confirmError ??
+            t`This will remove their authenticator app enrollment and recovery codes. They will need to set up two-factor authentication again on their next login.`
+          }
+        />
+      )}
+    </LoadingAndErrorWrapper>
+  );
+};

--- a/frontend/src/metabase/admin/routes.tsx
+++ b/frontend/src/metabase/admin/routes.tsx
@@ -22,6 +22,7 @@ import { GroupsListingApp } from "metabase/admin/people/containers/GroupsListing
 import { NewUserModal } from "metabase/admin/people/containers/NewUserModal";
 import { PeopleListingApp } from "metabase/admin/people/containers/PeopleListingApp";
 import { UserActivationModal } from "metabase/admin/people/containers/UserActivationModal";
+import { UserMfaResetModal } from "metabase/admin/people/containers/UserMfaResetModal";
 import { UserPasswordResetModal } from "metabase/admin/people/containers/UserPasswordResetModal";
 import { UserSuccessModal } from "metabase/admin/people/containers/UserSuccessModal";
 import { PerformanceApp } from "metabase/admin/performance/components/PerformanceApp";
@@ -165,6 +166,11 @@ export const getRoutes = (
               <ModalRoute path="edit" modal={EditUserModal} noWrap />
               <ModalRoute path="success" modal={UserSuccessModal} noWrap />
               <ModalRoute path="reset" modal={UserPasswordResetModal} noWrap />
+              <ModalRoute
+                path="reset-mfa"
+                modal={UserMfaResetModal}
+                noWrap
+              />
               <ModalRoute
                 path="deactivate"
                 modal={UserActivationModal}

--- a/frontend/src/metabase/admin/settings/auth/components/MfaCard/MfaCard.tsx
+++ b/frontend/src/metabase/admin/settings/auth/components/MfaCard/MfaCard.tsx
@@ -1,4 +1,4 @@
-import { t } from "ttag";
+import { jt, t } from "ttag";
 
 import { useAdminSetting } from "metabase/api/utils";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
@@ -24,10 +24,7 @@ export function MfaCard() {
     <Card withBorder p="lg">
       <Group justify="space-between" align="flex-start">
         <div>
-          <Title
-            order={4}
-            mb="xs"
-          >{t`Two-factor authentication`}</Title>
+          <Title order={4} mb="xs">{t`Two-factor authentication`}</Title>
           <Text
             c="text-secondary"
             fz="sm"
@@ -35,11 +32,7 @@ export function MfaCard() {
           >{t`When enabled, all password-authenticated users must set up two-factor authentication. SSO users and API keys are exempt.`}</Text>
           {!adminHasMfa && !isRequired && (
             <Text c="error" fz="sm" mt="sm">
-              {t`You must`}{" "}
-              <Anchor
-                href="/account/security"
-              >{t`enable two-factor authentication on your own account`}</Anchor>{" "}
-              {t`before requiring it for others.`}
+              {jt`You must ${(<Anchor key="link" href="/account/security">{t`enable two-factor authentication on your own account`}</Anchor>)} before requiring it for others.`}
             </Text>
           )}
         </div>

--- a/frontend/src/metabase/admin/settings/auth/components/MfaCard/MfaCard.tsx
+++ b/frontend/src/metabase/admin/settings/auth/components/MfaCard/MfaCard.tsx
@@ -1,0 +1,60 @@
+import { t } from "ttag";
+
+import { useAdminSetting } from "metabase/api/utils";
+import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
+import { useSelector } from "metabase/lib/redux";
+import { getUser } from "metabase/selectors/user";
+import { Anchor, Card, Group, Switch, Text, Title } from "metabase/ui";
+
+export function MfaCard() {
+  const {
+    value: isRequired,
+    updateSetting,
+    isLoading,
+  } = useAdminSetting("require-mfa");
+
+  const currentUser = useSelector(getUser);
+  const adminHasMfa = currentUser?.totp_enabled ?? false;
+
+  if (isLoading) {
+    return <LoadingAndErrorWrapper loading />;
+  }
+
+  return (
+    <Card withBorder p="lg">
+      <Group justify="space-between" align="flex-start">
+        <div>
+          <Title
+            order={4}
+            mb="xs"
+          >{t`Two-factor authentication`}</Title>
+          <Text
+            c="text-secondary"
+            fz="sm"
+            maw={400}
+          >{t`When enabled, all password-authenticated users must set up two-factor authentication. SSO users and API keys are exempt.`}</Text>
+          {!adminHasMfa && !isRequired && (
+            <Text c="error" fz="sm" mt="sm">
+              {t`You must`}{" "}
+              <Anchor
+                href="/account/security"
+              >{t`enable two-factor authentication on your own account`}</Anchor>{" "}
+              {t`before requiring it for others.`}
+            </Text>
+          )}
+        </div>
+        <Switch
+          checked={!!isRequired}
+          disabled={!adminHasMfa && !isRequired}
+          onChange={(e) =>
+            updateSetting({
+              key: "require-mfa",
+              value: e.currentTarget.checked,
+            })
+          }
+          aria-label={t`Require two-factor authentication`}
+        />
+      </Group>
+    </Card>
+  );
+}

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/AuthenticationSettingsPage.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/AuthenticationSettingsPage.tsx
@@ -11,6 +11,7 @@ import {
 import { Box, Flex, Stack } from "metabase/ui";
 
 import { ApiKeysAuthCard } from "../../auth/components/ApiKeysAuthCard";
+import { MfaCard } from "../../auth/components/MfaCard/MfaCard";
 import { GoogleAuthCard } from "../../auth/containers/GoogleAuthCard/GoogleAuthCard";
 import { LdapAuthCard } from "../../auth/containers/LdapAuthCard";
 import { ManageApiKeys } from "../ApiKeys/ManageApiKeys";
@@ -34,6 +35,7 @@ export function AuthenticationSettingsPage({
     <SettingsPageWrapper title={t`Authentication`}>
       <Flex justify={"space-between"} gap="lg">
         <Stack gap="lg">
+          <MfaCard />
           <GoogleAuthCard />
           <LdapAuthCard />
           <ApiKeysAuthCard />

--- a/frontend/src/metabase/auth/actions.ts
+++ b/frontend/src/metabase/auth/actions.ts
@@ -15,7 +15,7 @@ import { getSetting } from "metabase/selectors/settings";
 import { getUser } from "metabase/selectors/user";
 import { SessionApi, UtilApi } from "metabase/services";
 
-import type { LoginData } from "./types";
+import type { LoginData, MfaVerifyData } from "./types";
 
 export const REFRESH_LOCALE = "metabase/user/REFRESH_LOCALE";
 export const refreshLocale = createAsyncThunk(
@@ -58,7 +58,27 @@ export const login = createAsyncThunk(
   LOGIN,
   async ({ data }: LoginPayload, { dispatch, rejectWithValue }) => {
     try {
-      await SessionApi.create(data);
+      const response = await SessionApi.create(data);
+      if (response?.mfa_required) {
+        return { mfaRequired: true, mfaToken: response.mfa_token };
+      }
+      await dispatch(refreshSession()).unwrap();
+      if (!isSmallScreen()) {
+        dispatch(openNavbar());
+      }
+      return { mfaRequired: false };
+    } catch (error) {
+      return rejectWithValue(error);
+    }
+  },
+);
+
+export const MFA_VERIFY = "metabase/auth/MFA_VERIFY";
+export const mfaVerify = createAsyncThunk(
+  MFA_VERIFY,
+  async (data: MfaVerifyData, { dispatch, rejectWithValue }) => {
+    try {
+      await SessionApi.mfaVerify(data);
       await dispatch(refreshSession()).unwrap();
       if (!isSmallScreen()) {
         dispatch(openNavbar());

--- a/frontend/src/metabase/auth/components/MfaForm/MfaForm.tsx
+++ b/frontend/src/metabase/auth/components/MfaForm/MfaForm.tsx
@@ -27,9 +27,14 @@ const RECOVERY_SCHEMA = Yup.object().shape({
 interface MfaFormProps {
   mfaToken: string;
   onSubmit: (data: MfaVerifyData) => void;
+  onCancel?: () => void;
 }
 
-export const MfaForm = ({ mfaToken, onSubmit }: MfaFormProps): JSX.Element => {
+export const MfaForm = ({
+  mfaToken,
+  onSubmit,
+  onCancel,
+}: MfaFormProps): JSX.Element => {
   const [useRecoveryCode, setUseRecoveryCode] = useState(false);
 
   const initialValues = useMemo(
@@ -99,6 +104,13 @@ export const MfaForm = ({ mfaToken, onSubmit }: MfaFormProps): JSX.Element => {
             : t`Use a recovery code`}
         </Anchor>
       </Text>
+      {onCancel && (
+        <Text ta="center" mt="0.5rem">
+          <Anchor component="button" type="button" onClick={onCancel}>
+            {t`Back to login`}
+          </Anchor>
+        </Text>
+      )}
     </div>
   );
 };

--- a/frontend/src/metabase/auth/components/MfaForm/MfaForm.tsx
+++ b/frontend/src/metabase/auth/components/MfaForm/MfaForm.tsx
@@ -1,0 +1,104 @@
+import { useCallback, useMemo, useState } from "react";
+import { t } from "ttag";
+import * as Yup from "yup";
+
+import {
+  Form,
+  FormErrorMessage,
+  FormProvider,
+  FormSubmitButton,
+  FormTextInput,
+} from "metabase/forms";
+import * as Errors from "metabase/lib/errors";
+import { Anchor, Text } from "metabase/ui";
+
+import type { MfaVerifyData } from "../../types";
+
+const TOTP_SCHEMA = Yup.object().shape({
+  "totp-code": Yup.string()
+    .required(Errors.required)
+    .matches(/^\d{6}$/, Errors.required),
+});
+
+const RECOVERY_SCHEMA = Yup.object().shape({
+  "recovery-code": Yup.string().required(Errors.required),
+});
+
+interface MfaFormProps {
+  mfaToken: string;
+  onSubmit: (data: MfaVerifyData) => void;
+}
+
+export const MfaForm = ({ mfaToken, onSubmit }: MfaFormProps): JSX.Element => {
+  const [useRecoveryCode, setUseRecoveryCode] = useState(false);
+
+  const initialValues = useMemo(
+    (): Record<string, string> =>
+      useRecoveryCode ? { "recovery-code": "" } : { "totp-code": "" },
+    [useRecoveryCode],
+  );
+
+  const handleSubmit = useCallback(
+    (values: Record<string, string>) => {
+      onSubmit({
+        "mfa-token": mfaToken,
+        ...values,
+      } as MfaVerifyData);
+    },
+    [mfaToken, onSubmit],
+  );
+
+  return (
+    <div>
+      <Text fw="bold" fz="xl" mb="1rem">
+        {t`Two-factor authentication`}
+      </Text>
+      <Text c="text-secondary" mb="1.5rem">
+        {useRecoveryCode
+          ? t`Enter one of your recovery codes to sign in.`
+          : t`Enter the 6-digit code from your authenticator app.`}
+      </Text>
+      <FormProvider
+        key={useRecoveryCode ? "recovery" : "totp"}
+        initialValues={initialValues}
+        validationSchema={useRecoveryCode ? RECOVERY_SCHEMA : TOTP_SCHEMA}
+        onSubmit={handleSubmit}
+      >
+        <Form>
+          {useRecoveryCode ? (
+            <FormTextInput
+              name="recovery-code"
+              label={t`Recovery code`}
+              placeholder="abcd1234"
+              autoFocus
+              mb="1.25rem"
+            />
+          ) : (
+            <FormTextInput
+              name="totp-code"
+              label={t`Verification code`}
+              placeholder="000000"
+              inputMode="numeric"
+              maxLength={6}
+              autoFocus
+              mb="1.25rem"
+            />
+          )}
+          <FormSubmitButton label={t`Verify`} variant="filled" w="100%" />
+          <FormErrorMessage mt="1rem" />
+        </Form>
+      </FormProvider>
+      <Text ta="center" mt="1rem">
+        <Anchor
+          component="button"
+          type="button"
+          onClick={() => setUseRecoveryCode(!useRecoveryCode)}
+        >
+          {useRecoveryCode
+            ? t`Use authenticator app instead`
+            : t`Use a recovery code`}
+        </Anchor>
+      </Text>
+    </div>
+  );
+};

--- a/frontend/src/metabase/auth/components/MfaForm/index.ts
+++ b/frontend/src/metabase/auth/components/MfaForm/index.ts
@@ -1,0 +1,1 @@
+export { MfaForm } from "./MfaForm";

--- a/frontend/src/metabase/auth/components/PasswordPanel/PasswordPanel.tsx
+++ b/frontend/src/metabase/auth/components/PasswordPanel/PasswordPanel.tsx
@@ -44,8 +44,18 @@ export const PasswordPanel = ({ redirectUrl }: PasswordPanelProps) => {
     [dispatch],
   );
 
+  const handleMfaCancel = useCallback(() => {
+    setMfaToken(null);
+  }, []);
+
   if (mfaToken) {
-    return <MfaForm mfaToken={mfaToken} onSubmit={handleMfaSubmit} />;
+    return (
+      <MfaForm
+        mfaToken={mfaToken}
+        onSubmit={handleMfaSubmit}
+        onCancel={handleMfaCancel}
+      />
+    );
   }
 
   return (

--- a/frontend/src/metabase/auth/components/PasswordPanel/PasswordPanel.tsx
+++ b/frontend/src/metabase/auth/components/PasswordPanel/PasswordPanel.tsx
@@ -1,17 +1,18 @@
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import { t } from "ttag";
 
 import { useDispatch, useSelector } from "metabase/lib/redux";
 
-import { login } from "../../actions";
+import { login, mfaVerify } from "../../actions";
 import {
   getExternalAuthProviders,
   getHasSessionCookies,
   getIsLdapEnabled,
 } from "../../selectors";
-import type { LoginData } from "../../types";
+import type { LoginData, MfaVerifyData } from "../../types";
 import { AuthButton } from "../AuthButton";
 import { LoginForm } from "../LoginForm";
+import { MfaForm } from "../MfaForm";
 
 import { ActionList, ActionListItem } from "./PasswordPanel.styled";
 
@@ -24,20 +25,35 @@ export const PasswordPanel = ({ redirectUrl }: PasswordPanelProps) => {
   const isLdapEnabled = useSelector(getIsLdapEnabled);
   const hasSessionCookies = useSelector(getHasSessionCookies);
   const dispatch = useDispatch();
+  const [mfaToken, setMfaToken] = useState<string | null>(null);
 
-  const handleSubmit = useCallback(
+  const handleLoginSubmit = useCallback(
     async (data: LoginData) => {
-      await dispatch(login({ data, redirectUrl })).unwrap();
+      const result = await dispatch(login({ data, redirectUrl })).unwrap();
+      if (result?.mfaRequired && result.mfaToken) {
+        setMfaToken(result.mfaToken);
+      }
     },
     [dispatch, redirectUrl],
   );
+
+  const handleMfaSubmit = useCallback(
+    async (data: MfaVerifyData) => {
+      await dispatch(mfaVerify(data)).unwrap();
+    },
+    [dispatch],
+  );
+
+  if (mfaToken) {
+    return <MfaForm mfaToken={mfaToken} onSubmit={handleMfaSubmit} />;
+  }
 
   return (
     <div>
       <LoginForm
         isLdapEnabled={isLdapEnabled}
         hasSessionCookies={hasSessionCookies}
-        onSubmit={handleSubmit}
+        onSubmit={handleLoginSubmit}
       />
       <ActionList>
         <ActionListItem>

--- a/frontend/src/metabase/auth/types.ts
+++ b/frontend/src/metabase/auth/types.ts
@@ -12,3 +12,19 @@ export interface ResetPasswordData {
   password: string;
   password_confirm: string;
 }
+
+export interface MfaLoginResponse {
+  mfa_required: true;
+  mfa_token: string;
+}
+
+export interface MfaVerifyData {
+  "mfa-token": string;
+  "totp-code"?: string;
+  "recovery-code"?: string;
+}
+
+export interface LoginResult {
+  mfaRequired: boolean;
+  mfaToken?: string;
+}

--- a/frontend/src/metabase/lib/urls/admin.ts
+++ b/frontend/src/metabase/lib/urls/admin.ts
@@ -34,6 +34,12 @@ export function newUserSuccess(user: BaseUser) {
     : `/admin/people/tenants/people/${user.id}/success`;
 }
 
+export function resetMfa(user: BaseUser) {
+  return isInternalUser(user)
+    ? `/admin/people/${user.id}/reset-mfa`
+    : `/admin/people/tenants/people/${user.id}/reset-mfa`;
+}
+
 export function deactivateUser(user: BaseUser) {
   return isInternalUser(user)
     ? `/admin/people/${user.id}/deactivate`

--- a/frontend/src/metabase/route-guards.tsx
+++ b/frontend/src/metabase/route-guards.tsx
@@ -118,8 +118,30 @@ const UserCanAccessTransforms = connectedReduxRedirect<Props, State>({
   context: MetabaseReduxContext,
 });
 
+const UserHasMfaIfRequired = connectedReduxRedirect<Props, State>({
+  wrapperDisplayName: "UserHasMfaIfRequired",
+  redirectPath: "/mfa/setup-required",
+  allowRedirectBack: false,
+  authenticatedSelector: (state) => {
+    const user = state.currentUser;
+    if (!user) {
+      return true;
+    }
+    const requireMfa = getSetting(state, "require-mfa");
+    if (!requireMfa) {
+      return true;
+    }
+    if (user.sso_source) {
+      return true;
+    }
+    return user.totp_enabled;
+  },
+  redirectAction: routerActions.replace,
+  context: MetabaseReduxContext,
+});
+
 export const IsAuthenticated = MetabaseIsSetup(
-  UserIsAuthenticated(({ children }) => children),
+  UserIsAuthenticated(UserHasMfaIfRequired(({ children }) => children)),
 );
 export const IsAdmin = MetabaseIsSetup(
   UserIsAuthenticated(UserIsAdmin(({ children }) => children)),

--- a/frontend/src/metabase/route-guards.tsx
+++ b/frontend/src/metabase/route-guards.tsx
@@ -144,7 +144,9 @@ export const IsAuthenticated = MetabaseIsSetup(
   UserIsAuthenticated(UserHasMfaIfRequired(({ children }) => children)),
 );
 export const IsAdmin = MetabaseIsSetup(
-  UserIsAuthenticated(UserIsAdmin(({ children }) => children)),
+  UserIsAuthenticated(
+    UserHasMfaIfRequired(UserIsAdmin(({ children }) => children)),
+  ),
 );
 
 export const IsNotAuthenticated = MetabaseIsSetup(
@@ -152,7 +154,9 @@ export const IsNotAuthenticated = MetabaseIsSetup(
 );
 
 export const CanAccessSettings = MetabaseIsSetup(
-  UserIsAuthenticated(UserCanAccessSettings(({ children }) => children)),
+  UserIsAuthenticated(
+    UserHasMfaIfRequired(UserCanAccessSettings(({ children }) => children)),
+  ),
 );
 
 export const CanAccessOnboarding = UserCanAccessOnboarding(
@@ -162,7 +166,9 @@ export const CanAccessOnboarding = UserCanAccessOnboarding(
 // Must be in sync with canAccessDataStudio in frontend/src/metabase/data-studio/selectors.ts
 export const CanAccessDataStudio = MetabaseIsSetup(
   UserIsAuthenticated(
-    UserCanAccessDataStudio(AvailableInEmbedding(({ children }) => children)),
+    UserHasMfaIfRequired(
+      UserCanAccessDataStudio(AvailableInEmbedding(({ children }) => children)),
+    ),
   ),
 );
 

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -1,6 +1,7 @@
 import { IndexRedirect, IndexRoute, Redirect, Route } from "react-router";
 
 import App from "metabase/App.tsx";
+import MfaRequiredApp from "metabase/account/mfa/containers/MfaRequiredApp";
 import { getAccountRoutes } from "metabase/account/routes";
 import CollectionPermissionsModal from "metabase/admin/permissions/components/CollectionPermissionsModal/CollectionPermissionsModal";
 import { getRoutes as getAdminRoutes } from "metabase/admin/routes";
@@ -128,6 +129,9 @@ export const getRoutes = (store) => {
           <Route path="forgot_password" component={ForgotPassword} />
           <Route path="reset_password/:token" component={ResetPassword} />
         </Route>
+
+        {/* MFA SETUP REQUIRED — must be outside IsAuthenticated to avoid circular redirect */}
+        <Route path="/mfa/setup-required" component={MfaRequiredApp} />
 
         {/* MAIN */}
         <Route component={IsAuthenticated}>

--- a/frontend/src/metabase/selectors/app.ts
+++ b/frontend/src/metabase/selectors/app.ts
@@ -28,6 +28,7 @@ export interface RouterProps {
 const PATHS_WITHOUT_NAVBAR = [
   /^\/setup/,
   /^\/auth/,
+  /^\/mfa\/setup-required/,
   /^\/data-studio/,
   /\/model\/.*\/query/,
   /\/model\/.*\/columns/,

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -329,6 +329,7 @@ export const MfaApi = {
   confirm: POST("/api/mfa/confirm"),
   disable: POST("/api/mfa/disable"),
   regenerateRecoveryCodes: POST("/api/mfa/recovery-codes"),
+  adminReset: POST("/api/user/:id/reset-mfa"),
 };
 
 export const SettingsApi = {

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -325,10 +325,10 @@ export const SessionApi = {
 };
 
 export const MfaApi = {
-  setup: POST("/api/account/mfa/setup"),
-  confirm: POST("/api/account/mfa/confirm"),
-  disable: POST("/api/account/mfa/disable"),
-  regenerateRecoveryCodes: POST("/api/account/mfa/recovery-codes"),
+  setup: POST("/api/mfa/setup"),
+  confirm: POST("/api/mfa/confirm"),
+  disable: POST("/api/mfa/disable"),
+  regenerateRecoveryCodes: POST("/api/mfa/recovery-codes"),
 };
 
 export const SettingsApi = {

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -327,7 +327,7 @@ export const SessionApi = {
 export const MfaApi = {
   setup: POST("/api/account/mfa/setup"),
   confirm: POST("/api/account/mfa/confirm"),
-  disable: DELETE("/api/account/mfa"),
+  disable: POST("/api/account/mfa/disable"),
   regenerateRecoveryCodes: POST("/api/account/mfa/recovery-codes"),
 };
 

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -318,9 +318,17 @@ export const SessionApi = {
   create: POST("/api/session"),
   createWithGoogleAuth: POST("/api/session/google_auth"),
   delete: DELETE("/api/session"),
+  mfaVerify: POST("/api/session/mfa-verify"),
   slo: POST("/auth/sso/logout"),
   forgot_password: POST("/api/session/forgot_password"),
   reset_password: POST("/api/session/reset_password"),
+};
+
+export const MfaApi = {
+  setup: POST("/api/account/mfa/setup"),
+  confirm: POST("/api/account/mfa/confirm"),
+  disable: DELETE("/api/account/mfa"),
+  regenerateRecoveryCodes: POST("/api/account/mfa/recovery-codes"),
 };
 
 export const SettingsApi = {

--- a/package.json
+++ b/package.json
@@ -140,6 +140,7 @@
     "react-color": "^2.14.1",
     "react-dnd": "4",
     "react-dnd-html5-backend": "4",
+    "qrcode.react": "^4.2.0",
     "react-dom": "^18.2.0",
     "react-dropzone": "^14.2.3",
     "react-grid-layout": "^1.4.4",

--- a/resources/migrations/060/20260312_totp_mfa.yaml
+++ b/resources/migrations/060/20260312_totp_mfa.yaml
@@ -1,0 +1,41 @@
+## Add TOTP-based multi-factor authentication columns to core_user
+
+databaseChangeLog:
+  - logicalFilePath: migrations/060_update_migrations.yaml
+  - changeSet:
+      id: v60.2026-03-12T00:00:00
+      author: chris
+      comment: Add TOTP MFA columns to core_user
+      changes:
+        - addColumn:
+            tableName: core_user
+            columns:
+              - column:
+                  name: totp_secret
+                  type: ${text.type}
+                  remarks: Encrypted Base32-encoded TOTP shared secret
+                  constraints:
+                    nullable: true
+              - column:
+                  name: totp_enabled
+                  type: ${boolean.type}
+                  defaultValueBoolean: false
+                  remarks: Whether TOTP MFA is active for this user
+                  constraints:
+                    nullable: false
+              - column:
+                  name: totp_recovery_codes
+                  type: ${text.type}
+                  remarks: Encrypted JSON array of bcrypt-hashed recovery codes
+                  constraints:
+                    nullable: true
+      rollback:
+        - dropColumn:
+            tableName: core_user
+            columnName: totp_secret
+        - dropColumn:
+            tableName: core_user
+            columnName: totp_enabled
+        - dropColumn:
+            tableName: core_user
+            columnName: totp_recovery_codes

--- a/src/metabase/account/mfa_api.clj
+++ b/src/metabase/account/mfa_api.clj
@@ -5,6 +5,7 @@
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.auth-identity.totp :as totp]
+   [metabase.session.settings :as session.settings]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.malli.schema :as ms]
    [metabase.util.password :as u.password]
@@ -74,6 +75,10 @@
    {:keys [password]} :- [:map
                           [:password ms/NonBlankString]]]
   (verify-user-password! password)
+  (when (and (session.settings/require-mfa)
+             (nil? (t2/select-one-fn :sso_source :model/User :id api/*current-user-id*)))
+    (throw (ex-info (tru "Cannot disable two-factor authentication while it is required by your administrator.")
+                    {:status-code 400})))
   (t2/update! :model/User api/*current-user-id*
               {:totp_enabled        false
                :totp_secret         nil

--- a/src/metabase/account/mfa_api.clj
+++ b/src/metabase/account/mfa_api.clj
@@ -1,0 +1,89 @@
+(ns metabase.account.mfa-api
+  "API endpoints for managing TOTP-based multi-factor authentication.
+   All endpoints require authentication (the user must already be logged in)."
+  (:require
+   [metabase.api.common :as api]
+   [metabase.api.macros :as api.macros]
+   [metabase.auth-identity.totp :as totp]
+   [metabase.util.i18n :refer [tru]]
+   [metabase.util.malli.schema :as ms]
+   [metabase.util.password :as u.password]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(defn- verify-user-password!
+  "Verify the current user's password. Throws 403 if invalid."
+  [password]
+  (let [{:keys [password_salt]
+         hashed-password :password} (t2/select-one [:model/User :password :password_salt]
+                                                   :id api/*current-user-id*)]
+    (when-not (u.password/verify-password password password_salt hashed-password)
+      (throw (ex-info (tru "Invalid password")
+                      {:status-code 403
+                       :errors      {:password (tru "Invalid password")}})))))
+
+#_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
+(api.macros/defendpoint :post "/setup"
+  "Begin TOTP enrollment. Generates a new secret and recovery codes.
+   The secret is stored on the user but TOTP is not yet enabled — call `POST /confirm` to activate."
+  []
+  (when (t2/select-one-fn :totp_enabled :model/User :id api/*current-user-id*)
+    (throw (ex-info (tru "TOTP is already enabled") {:status-code 400})))
+  (let [secret         (totp/generate-secret)
+        {:keys [plaintext hashed]} (totp/generate-recovery-codes)
+        user           (t2/select-one [:model/User :email] :id api/*current-user-id*)]
+    ;; Store the secret and hashed recovery codes, but don't enable TOTP yet
+    (t2/update! :model/User api/*current-user-id*
+                {:totp_secret         secret
+                 :totp_recovery_codes hashed})
+    {:secret         secret
+     :otpauth_uri    (totp/otpauth-uri secret (:email user) "Metabase")
+     :recovery_codes plaintext}))
+
+#_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
+(api.macros/defendpoint :post "/confirm"
+  "Confirm TOTP enrollment by verifying a code from the authenticator app.
+   This activates TOTP for the user's account."
+  [_route-params
+   _query-params
+   {:keys [totp-code]} :- [:map
+                           [:totp-code ms/NonBlankString]]]
+  (let [secret (t2/select-one-fn :totp_secret :model/User :id api/*current-user-id*)]
+    (when-not secret
+      (throw (ex-info (tru "Call POST /setup first") {:status-code 400})))
+    (when-not (totp/valid-code? secret totp-code)
+      (throw (ex-info (tru "Invalid verification code")
+                      {:status-code 400
+                       :errors {:totp-code (tru "Invalid verification code")}})))
+    (t2/update! :model/User api/*current-user-id* {:totp_enabled true})
+    {:success true}))
+
+#_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
+(api.macros/defendpoint :delete "/"
+  "Disable TOTP for the current user. Requires password confirmation."
+  [_route-params
+   _query-params
+   {:keys [password]} :- [:map
+                          [:password ms/NonBlankString]]]
+  (verify-user-password! password)
+  (t2/update! :model/User api/*current-user-id*
+              {:totp_enabled        false
+               :totp_secret         nil
+               :totp_recovery_codes nil})
+  api/generic-204-no-content)
+
+#_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
+(api.macros/defendpoint :post "/recovery-codes"
+  "Regenerate recovery codes. Requires password confirmation.
+   Returns new plaintext codes (shown once) and replaces the stored hashed codes."
+  [_route-params
+   _query-params
+   {:keys [password]} :- [:map
+                          [:password ms/NonBlankString]]]
+  (verify-user-password! password)
+  (when-not (t2/select-one-fn :totp_enabled :model/User :id api/*current-user-id*)
+    (throw (ex-info (tru "TOTP is not enabled") {:status-code 400})))
+  (let [{:keys [plaintext hashed]} (totp/generate-recovery-codes)]
+    (t2/update! :model/User api/*current-user-id* {:totp_recovery_codes hashed})
+    {:recovery_codes plaintext}))

--- a/src/metabase/account/mfa_api.clj
+++ b/src/metabase/account/mfa_api.clj
@@ -26,8 +26,13 @@
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :post "/setup"
   "Begin TOTP enrollment. Generates a new secret and recovery codes.
+   Requires password confirmation to prevent session-hijacking from escalating to MFA enrollment.
    The secret is stored on the user but TOTP is not yet enabled — call `POST /confirm` to activate."
-  []
+  [_route-params
+   _query-params
+   {:keys [password]} :- [:map
+                          [:password ms/NonBlankString]]]
+  (verify-user-password! password)
   (when (t2/select-one-fn :totp_enabled :model/User :id api/*current-user-id*)
     (throw (ex-info (tru "TOTP is already enabled") {:status-code 400})))
   (let [secret         (totp/generate-secret)

--- a/src/metabase/account/mfa_api.clj
+++ b/src/metabase/account/mfa_api.clj
@@ -60,8 +60,10 @@
     {:success true}))
 
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
-(api.macros/defendpoint :delete "/"
-  "Disable TOTP for the current user. Requires password confirmation."
+(api.macros/defendpoint :post "/disable"
+  "Disable TOTP for the current user. Requires password confirmation.
+   Uses POST instead of DELETE to ensure request body is reliably transmitted
+   through proxies and CDNs."
   [_route-params
    _query-params
    {:keys [password]} :- [:map

--- a/src/metabase/api_routes/routes.clj
+++ b/src/metabase/api_routes/routes.clj
@@ -1,6 +1,7 @@
 (ns metabase.api-routes.routes
   (:require
    [compojure.route :as route]
+   [metabase.account.mfa-api]
    [metabase.actions-rest.api]
    [metabase.activity-feed.api]
    [metabase.analytics.api]
@@ -66,7 +67,8 @@
    [metabase.warehouses-rest.api]
    [metabase.xrays.api]))
 
-(comment metabase.actions-rest.api/keep-me
+(comment metabase.account.mfa-api/keep-me
+         metabase.actions-rest.api/keep-me
          metabase.activity-feed.api/keep-me
          metabase.analytics.api/keep-me
          metabase.api-keys.api/keep-me
@@ -145,7 +147,8 @@
 
 ;;; ↓↓↓ KEEP THIS SORTED OR ELSE! ↓↓↓
 (def ^:private route-map
-  {"/action"               (+auth 'metabase.actions-rest.api)
+  {"/account/mfa"          (+auth 'metabase.account.mfa-api)
+   "/action"               (+auth 'metabase.actions-rest.api)
    "/activity"             (+auth 'metabase.activity-feed.api)
    "/alert"                (+auth metabase.pulse.api/alert-routes)
    "/analytics"            (+auth 'metabase.analytics.api)

--- a/src/metabase/api_routes/routes.clj
+++ b/src/metabase/api_routes/routes.clj
@@ -147,8 +147,7 @@
 
 ;;; ↓↓↓ KEEP THIS SORTED OR ELSE! ↓↓↓
 (def ^:private route-map
-  {"/account/mfa"          (+auth 'metabase.account.mfa-api)
-   "/action"               (+auth 'metabase.actions-rest.api)
+  {"/action"               (+auth 'metabase.actions-rest.api)
    "/activity"             (+auth 'metabase.activity-feed.api)
    "/alert"                (+auth metabase.pulse.api/alert-routes)
    "/analytics"            (+auth 'metabase.analytics.api)
@@ -182,6 +181,7 @@
    "/login-history"        (+auth 'metabase.login-history.api)
    "/measure"              (+auth 'metabase.measures.api)
    "/metric"               (+auth 'metabase.metrics.api)
+   "/mfa"                  (+auth 'metabase.account.mfa-api)
    "/model-index"          (+auth 'metabase.indexed-entities.api)
    "/native-query-snippet" (+auth 'metabase.native-query-snippets.api)
    "/notification"         metabase.notification.api/notification-routes

--- a/src/metabase/auth_identity/mfa_token.clj
+++ b/src/metabase/auth_identity/mfa_token.clj
@@ -9,9 +9,7 @@
    [metabase.util.log :as log])
   (:import
    (java.security SecureRandom)
-   (java.util.concurrent ConcurrentHashMap)
-   (javax.crypto Mac)
-   (javax.crypto.spec SecretKeySpec)))
+   (java.util.concurrent ConcurrentHashMap)))
 
 (set! *warn-on-reflection* true)
 
@@ -24,21 +22,17 @@
   "mfa-pending")
 
 (defn- derive-signing-key
-  "Derive a 32-byte signing key from the encryption secret via HMAC-SHA256.
-   Falls back to a random key if no encryption secret is configured."
+  "Derive a 32-byte signing key for MFA tokens. Uses `encryption/derive-key` to produce a
+   purpose-scoped sub-key from `MB_ENCRYPTION_SECRET_KEY` (deterministic across instances).
+   Falls back to a random per-instance key if no encryption secret is configured."
   ^bytes []
-  (if (encryption/default-encryption-enabled?)
-    (let [mac (Mac/getInstance "HmacSHA256")
-          ;; Use a fixed context string to derive the MFA-specific key
-          context (.getBytes "metabase-mfa-signing-key" "UTF-8")]
-      (.init mac (SecretKeySpec. (encryption/default-secret-key-hashed) "HmacSHA256"))
-      (.doFinal mac context))
-    (do
-      (log/warn "MB_ENCRYPTION_SECRET_KEY is not set; MFA signing key is instance-local."
-                "MFA tokens will not be portable across instances.")
-      (let [buf (byte-array 32)]
-        (.nextBytes (SecureRandom.) buf)
-        buf))))
+  (or (encryption/derive-key "metabase-mfa-signing-key")
+      (do
+        (log/warn "MB_ENCRYPTION_SECRET_KEY is not set; MFA signing key is instance-local."
+                  "MFA tokens will not be portable across instances.")
+        (let [buf (byte-array 32)]
+          (.nextBytes (SecureRandom.) buf)
+          buf))))
 
 (defonce ^:private ^bytes signing-key
   (derive-signing-key))

--- a/src/metabase/auth_identity/mfa_token.clj
+++ b/src/metabase/auth_identity/mfa_token.clj
@@ -1,0 +1,48 @@
+(ns metabase.auth-identity.mfa-token
+  "Short-lived JWT tokens for the MFA verification step during login.
+   After a user with TOTP enabled provides valid credentials, they receive an MFA pending token
+   instead of a session. This token is then exchanged for a real session after TOTP verification."
+  (:require
+   [buddy.sign.jwt :as jwt]
+   [java-time.api :as t])
+  (:import
+   (java.security SecureRandom)))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private ^:const mfa-token-expiry-minutes
+  "How long an MFA pending token is valid."
+  5)
+
+(def ^:private ^:const token-type
+  "Token type claim to prevent reuse of other JWTs as MFA tokens."
+  "mfa-pending")
+
+(defonce ^:private ^bytes signing-key
+  (let [buf (byte-array 32)]
+    (.nextBytes (SecureRandom.) buf)
+    buf))
+
+(defn create-mfa-token
+  "Create a short-lived JWT for MFA verification. Contains the user-id and expires in 5 minutes."
+  ^String [user-id]
+  (jwt/sign {:user-id user-id
+             :type    token-type
+             :exp     (t/plus (t/instant) (t/minutes mfa-token-expiry-minutes))}
+            signing-key))
+
+(defn verify-mfa-token
+  "Verify and decode an MFA pending token. Returns `{:user-id <id>}` on success.
+   Throws an exception if the token is invalid, expired, or not an MFA pending token."
+  [^String token]
+  (let [claims (try
+                 (jwt/unsign token signing-key {:leeway 0})
+                 (catch Exception e
+                   (throw (ex-info "Invalid or expired MFA token"
+                                   {:status-code 401}
+                                   e))))]
+    (when-not (= token-type (:type claims))
+      (throw (ex-info "Invalid token type"
+                      {:status-code 401
+                       :type        (:type claims)})))
+    {:user-id (:user-id claims)}))

--- a/src/metabase/auth_identity/mfa_token.clj
+++ b/src/metabase/auth_identity/mfa_token.clj
@@ -6,7 +6,8 @@
    [buddy.sign.jwt :as jwt]
    [java-time.api :as t])
   (:import
-   (java.security SecureRandom)))
+   (java.security SecureRandom)
+   (java.util.concurrent ConcurrentHashMap)))
 
 (set! *warn-on-reflection* true)
 
@@ -23,17 +24,32 @@
     (.nextBytes (SecureRandom.) buf)
     buf))
 
+;; Track consumed token JTIs to enforce single-use. Values are expiry instants for cleanup.
+(defonce ^:private ^ConcurrentHashMap consumed-tokens
+  (ConcurrentHashMap.))
+
+(defn- cleanup-expired-tokens!
+  "Remove expired entries from the consumed-tokens map."
+  []
+  (let [now (t/instant)]
+    (doseq [^java.util.Map$Entry entry (.entrySet consumed-tokens)]
+      (when (t/before? (.getValue entry) now)
+        (.remove consumed-tokens (.getKey entry))))))
+
 (defn create-mfa-token
-  "Create a short-lived JWT for MFA verification. Contains the user-id and expires in 5 minutes."
+  "Create a short-lived JWT for MFA verification. Contains the user-id and expires in 5 minutes.
+   Each token has a unique `jti` claim to enforce single-use."
   ^String [user-id]
   (jwt/sign {:user-id user-id
              :type    token-type
+             :jti     (str (random-uuid))
              :exp     (t/plus (t/instant) (t/minutes mfa-token-expiry-minutes))}
             signing-key))
 
 (defn verify-mfa-token
   "Verify and decode an MFA pending token. Returns `{:user-id <id>}` on success.
-   Throws an exception if the token is invalid, expired, or not an MFA pending token."
+   Throws an exception if the token is invalid, expired, already used, or not an MFA pending token.
+   Each token can only be verified once (single-use enforcement via `jti` claim)."
   [^String token]
   (let [claims (try
                  (jwt/unsign token signing-key {:leeway 0})
@@ -45,4 +61,15 @@
       (throw (ex-info "Invalid token type"
                       {:status-code 401
                        :type        (:type claims)})))
+    ;; Enforce single-use via jti
+    (let [jti (:jti claims)]
+      (when-not jti
+        (throw (ex-info "MFA token missing jti claim"
+                        {:status-code 401})))
+      (when (.putIfAbsent consumed-tokens jti
+                          (t/plus (t/instant) (t/minutes (inc mfa-token-expiry-minutes))))
+        (throw (ex-info "MFA token has already been used"
+                        {:status-code 401})))
+      ;; Periodically clean up expired entries
+      (cleanup-expired-tokens!))
     {:user-id (:user-id claims)}))

--- a/src/metabase/auth_identity/mfa_token.clj
+++ b/src/metabase/auth_identity/mfa_token.clj
@@ -4,10 +4,14 @@
    instead of a session. This token is then exchanged for a real session after TOTP verification."
   (:require
    [buddy.sign.jwt :as jwt]
-   [java-time.api :as t])
+   [java-time.api :as t]
+   [metabase.util.encryption :as encryption]
+   [metabase.util.log :as log])
   (:import
    (java.security SecureRandom)
-   (java.util.concurrent ConcurrentHashMap)))
+   (java.util.concurrent ConcurrentHashMap)
+   (javax.crypto Mac)
+   (javax.crypto.spec SecretKeySpec)))
 
 (set! *warn-on-reflection* true)
 
@@ -19,12 +23,29 @@
   "Token type claim to prevent reuse of other JWTs as MFA tokens."
   "mfa-pending")
 
+(defn- derive-signing-key
+  "Derive a 32-byte signing key from the encryption secret via HMAC-SHA256.
+   Falls back to a random key if no encryption secret is configured."
+  ^bytes []
+  (if (encryption/default-encryption-enabled?)
+    (let [mac (Mac/getInstance "HmacSHA256")
+          ;; Use a fixed context string to derive the MFA-specific key
+          context (.getBytes "metabase-mfa-signing-key" "UTF-8")]
+      (.init mac (SecretKeySpec. (encryption/default-secret-key-hashed) "HmacSHA256"))
+      (.doFinal mac context))
+    (do
+      (log/warn "MB_ENCRYPTION_SECRET_KEY is not set; MFA signing key is instance-local."
+                "MFA tokens will not be portable across instances.")
+      (let [buf (byte-array 32)]
+        (.nextBytes (SecureRandom.) buf)
+        buf))))
+
 (defonce ^:private ^bytes signing-key
-  (let [buf (byte-array 32)]
-    (.nextBytes (SecureRandom.) buf)
-    buf))
+  (derive-signing-key))
 
 ;; Track consumed token JTIs to enforce single-use. Values are expiry instants for cleanup.
+;; NOTE: This is an in-memory store, so single-use enforcement is per-instance. Given the
+;; 5-minute token expiry, the replay window in multi-instance deployments is small.
 (defonce ^:private ^ConcurrentHashMap consumed-tokens
   (ConcurrentHashMap.))
 

--- a/src/metabase/auth_identity/totp.clj
+++ b/src/metabase/auth_identity/totp.clj
@@ -136,16 +136,16 @@
 (defn verify-recovery-code
   "Check if `code` matches any of the `hashed-codes`. Returns a map with:
    - `:valid?`    — whether the code matched
-   - `:remaining` — the hashed codes with the matched code removed (or unchanged if no match)"
+   - `:remaining` — the hashed codes with the matched code removed (or unchanged if no match)
+   Checks all codes to avoid timing side-channel that could reveal position."
   [^String code hashed-codes]
-  (loop [idx 0
-         remaining (transient [])]
-    (if (>= idx (count hashed-codes))
-      {:valid? false :remaining hashed-codes}
-      (if (u.password/bcrypt-verify code (nth hashed-codes idx))
-        {:valid?    true
-         :remaining (persistent! (reduce conj! remaining (subvec (vec hashed-codes) (inc idx))))}
-        (recur (inc idx) (conj! remaining (nth hashed-codes idx)))))))
+  (let [results (mapv (fn [hashed] (u.password/bcrypt-verify code hashed)) hashed-codes)
+        match-idx (first (keep-indexed (fn [i matched?] (when matched? i)) results))]
+    (if match-idx
+      {:valid?    true
+       :remaining (into (subvec (vec hashed-codes) 0 match-idx)
+                        (subvec (vec hashed-codes) (inc match-idx)))}
+      {:valid? false :remaining hashed-codes})))
 
 ;;; -------------------------------------------------- OTPAuth URI --------------------------------------------------
 

--- a/src/metabase/auth_identity/totp.clj
+++ b/src/metabase/auth_identity/totp.clj
@@ -156,7 +156,7 @@
   (format "otpauth://totp/%s:%s?secret=%s&issuer=%s&digits=%d&period=%d"
           (java.net.URLEncoder/encode issuer "UTF-8")
           (java.net.URLEncoder/encode email "UTF-8")
-          secret
+          (java.net.URLEncoder/encode secret "UTF-8")
           (java.net.URLEncoder/encode issuer "UTF-8")
           totp-digits
           totp-period))

--- a/src/metabase/auth_identity/totp.clj
+++ b/src/metabase/auth_identity/totp.clj
@@ -1,0 +1,162 @@
+(ns metabase.auth-identity.totp
+  "TOTP (Time-based One-Time Password) implementation per RFC 6238/4226.
+   Provides functions for generating secrets, computing and validating TOTP codes,
+   and managing recovery codes."
+  (:require
+   [metabase.util.password :as u.password])
+  (:import
+   (java.security MessageDigest SecureRandom)
+   (javax.crypto Mac)
+   (javax.crypto.spec SecretKeySpec)
+   (org.apache.commons.codec.binary Base32)))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private ^:const totp-digits
+  "Number of digits in a TOTP code."
+  6)
+
+(def ^:private ^:const totp-period
+  "Time step in seconds for TOTP."
+  30)
+
+(def ^:private ^:const totp-window
+  "Number of time steps to check in each direction for clock skew tolerance."
+  1)
+
+(def ^:private ^:const secret-bytes
+  "Number of random bytes for TOTP secret (20 bytes = 160 bits, standard for HMAC-SHA1)."
+  20)
+
+(def ^:private ^:const recovery-code-count
+  "Number of recovery codes to generate."
+  10)
+
+(def ^:private ^:const recovery-code-length
+  "Length of each recovery code."
+  8)
+
+(def ^:private ^:const recovery-code-chars
+  "Characters used in recovery codes."
+  "abcdefghijklmnopqrstuvwxyz0123456789")
+
+;;; -------------------------------------------------- Secret Generation --------------------------------------------------
+
+(defn generate-secret
+  "Generate a random TOTP secret as a Base32-encoded string."
+  ^String []
+  (let [random (SecureRandom.)
+        buf    (byte-array secret-bytes)]
+    (.nextBytes random buf)
+    (.encodeToString (Base32.) buf)))
+
+;;; -------------------------------------------------- TOTP Code Computation --------------------------------------------------
+
+(defn- decode-base32
+  "Decode a Base32-encoded string to bytes."
+  ^bytes [^String s]
+  (.decode (Base32.) s))
+
+(defn- time-step
+  "Return the current TOTP time step (Unix time / period)."
+  (^long []
+   (time-step (quot (System/currentTimeMillis) 1000)))
+  (^long [^long unix-seconds]
+   (quot unix-seconds totp-period)))
+
+(defn- long->bytes
+  "Convert a long to an 8-byte big-endian byte array."
+  ^bytes [^long n]
+  (let [buf (byte-array 8)]
+    (doseq [i (range 7 -1 -1)]
+      (aset-byte buf (- 7 i) (unchecked-byte (bit-shift-right n (* i 8)))))
+    buf))
+
+(defn- hmac-sha1
+  "Compute HMAC-SHA1 of `data` using `key-bytes`."
+  ^bytes [^bytes key-bytes ^bytes data]
+  (let [mac (Mac/getInstance "HmacSHA1")]
+    (.init mac (SecretKeySpec. key-bytes "HmacSHA1"))
+    (.doFinal mac data)))
+
+(defn- dynamic-truncate
+  "RFC 4226 dynamic truncation: extract a 4-byte dynamic binary code from the HMAC result."
+  ^long [^bytes hmac-result]
+  (let [offset (bit-and (aget hmac-result 19) 0x0f)]
+    (bit-and (bit-or (bit-shift-left (bit-and (aget hmac-result offset) 0x7f) 24)
+                     (bit-shift-left (bit-and (aget hmac-result (+ offset 1)) 0xff) 16)
+                     (bit-shift-left (bit-and (aget hmac-result (+ offset 2)) 0xff) 8)
+                     (bit-and (aget hmac-result (+ offset 3)) 0xff))
+             0x7fffffff)))
+
+(defn totp-code
+  "Generate a TOTP code for the given Base32-encoded `secret` at the given `step`.
+   Returns a zero-padded string of `totp-digits` digits."
+  ^String [^String secret-b32 ^long step]
+  (let [key-bytes   (decode-base32 secret-b32)
+        time-bytes  (long->bytes step)
+        hmac-result (hmac-sha1 key-bytes time-bytes)
+        code        (mod (dynamic-truncate hmac-result)
+                         (long (Math/pow 10 totp-digits)))]
+    (format (str "%0" totp-digits "d") code)))
+
+;;; -------------------------------------------------- TOTP Validation --------------------------------------------------
+
+(defn- constant-time-equals?
+  "Constant-time string comparison to prevent timing attacks."
+  [^String a ^String b]
+  (MessageDigest/isEqual (.getBytes a "UTF-8") (.getBytes b "UTF-8")))
+
+(defn valid-code?
+  "Check if `code` is a valid TOTP code for the given Base32-encoded `secret`.
+   Checks the current time step and ±`totp-window` steps for clock skew tolerance."
+  [^String secret-b32 ^String code]
+  (let [current-step (time-step)]
+    (boolean
+     (some (fn [offset]
+             (constant-time-equals? code (totp-code secret-b32 (+ current-step offset))))
+           (range (- totp-window) (inc totp-window))))))
+
+;;; -------------------------------------------------- Recovery Codes --------------------------------------------------
+
+(defn generate-recovery-codes
+  "Generate a set of recovery codes. Returns a map with:
+   - `:plaintext` — vector of plaintext codes (shown to user once)
+   - `:hashed`    — vector of bcrypt-hashed codes (stored in DB)"
+  []
+  (let [random    (SecureRandom.)
+        chars-len (count recovery-code-chars)
+        codes     (vec (repeatedly recovery-code-count
+                                   (fn []
+                                     (apply str (repeatedly recovery-code-length
+                                                            #(nth recovery-code-chars (.nextInt random chars-len)))))))]
+    {:plaintext codes
+     :hashed    (mapv u.password/hash-bcrypt codes)}))
+
+(defn verify-recovery-code
+  "Check if `code` matches any of the `hashed-codes`. Returns a map with:
+   - `:valid?`    — whether the code matched
+   - `:remaining` — the hashed codes with the matched code removed (or unchanged if no match)"
+  [^String code hashed-codes]
+  (loop [idx 0
+         remaining (transient [])]
+    (if (>= idx (count hashed-codes))
+      {:valid? false :remaining hashed-codes}
+      (if (u.password/bcrypt-verify code (nth hashed-codes idx))
+        {:valid?    true
+         :remaining (persistent! (reduce conj! remaining (subvec (vec hashed-codes) (inc idx))))}
+        (recur (inc idx) (conj! remaining (nth hashed-codes idx)))))))
+
+;;; -------------------------------------------------- OTPAuth URI --------------------------------------------------
+
+(defn otpauth-uri
+  "Build an otpauth:// URI for QR code generation.
+   See: https://github.com/google/google-authenticator/wiki/Key-Uri-Format"
+  ^String [^String secret ^String email ^String issuer]
+  (format "otpauth://totp/%s:%s?secret=%s&issuer=%s&digits=%d&period=%d"
+          (java.net.URLEncoder/encode issuer "UTF-8")
+          (java.net.URLEncoder/encode email "UTF-8")
+          secret
+          (java.net.URLEncoder/encode issuer "UTF-8")
+          totp-digits
+          totp-period))

--- a/src/metabase/channel/email/messages.clj
+++ b/src/metabase/channel/email/messages.clj
@@ -161,6 +161,20 @@
       :message-type :html
       :message      message-body})))
 
+(defn send-mfa-required-email!
+  "Send an email notifying a user that MFA is now required by their administrator."
+  [email]
+  {:pre [(u/email? email)]}
+  (let [message-body (channel.template/render
+                      "metabase/channel/email/mfa_required.hbs"
+                      (merge (common-context)
+                             {:logoHeader true}))]
+    (send-email-with-logo!
+     {:subject      (trs "[{0}] Two-factor authentication is now required" (app-name-trs))
+      :recipients   [email]
+      :message-type :html
+      :message      message-body})))
+
 (mu/defn send-login-from-new-device-email!
   "Format and send an email informing the user that this is the first time we've seen a login from this device. Expects
   login history information as returned by [[metabase.login-history.models.login-history/human-friendly-infos]]."

--- a/src/metabase/channel/email/mfa_required.hbs
+++ b/src/metabase/channel/email/mfa_required.hbs
@@ -1,0 +1,9 @@
+{{> metabase/channel/email/_header.hbs }}
+  <div style="text-align: center">
+    <p>Your administrator has enabled a requirement for two-factor authentication on {{applicationName}}.</p>
+    <p>You will need to set up two-factor authentication the next time you sign in.</p>
+    <p style="padding-top: 1em">
+      <a style="{{buttonStyle}}" href="{{siteUrl}}/account/security">Set up two-factor authentication</a>
+    </p>
+  </div>
+{{> metabase/channel/email/_footer.hbs }}

--- a/src/metabase/request/schema.clj
+++ b/src/metabase/request/schema.clj
@@ -11,4 +11,6 @@
    [:is-data-analyst?   {:optional true} :boolean]
    [:user-locale        {:optional true} [:maybe string?]]
    [:is-group-manager?  {:optional true} :boolean]
-   [:permissions-set    {:optional true} [:set :string]]])
+   [:permissions-set    {:optional true} [:set :string]]
+   [:totp-enabled?      {:optional true} :boolean]
+   [:sso-source         {:optional true} [:maybe :string]]])

--- a/src/metabase/server/handler.clj
+++ b/src/metabase/server/handler.clj
@@ -10,6 +10,7 @@
    [metabase.server.middleware.json :as mw.json]
    [metabase.server.middleware.log :as mw.log]
    [metabase.server.middleware.metadata-provider-cache :as mw.mp-cache]
+   [metabase.server.middleware.mfa-enforcement :as mw.mfa-enforcement]
    [metabase.server.middleware.misc :as mw.misc]
    [metabase.server.middleware.offset-paging :as mw.offset-paging]
    [metabase.server.middleware.premium-features-cache :as mw.pf-cache]
@@ -82,6 +83,7 @@
         #'wrap-params                                ; parses GET and POST params as :query-params/:form-params and both as :params
         #'mw.misc/maybe-set-site-url                 ; set the value of `site-url` if it hasn't been set yet
         #'mw.session/reset-session-timeout           ; Resets the timeout cookie for user activity to [[metabase.request.cookies/session-timeout]]
+        #'mw.mfa-enforcement/wrap-enforce-mfa        ; Block non-MFA users when require-mfa is enabled
         #'mw.session/bind-current-user               ; Binds *current-user* and *current-user-id* if :metabase-user-id is non-nil
         #'mw.session/wrap-current-user-info          ; looks for :metabase-session-key and sets :metabase-user-id and other info if Session ID is valid
         #'mw.pf-cache/wrap-premium-features-cache-check ; check cookie to refresh premium features cache if needed

--- a/src/metabase/server/middleware/mfa_enforcement.clj
+++ b/src/metabase/server/middleware/mfa_enforcement.clj
@@ -1,0 +1,59 @@
+(ns metabase.server.middleware.mfa-enforcement
+  "Ring middleware that enforces MFA setup for password-authenticated users when the `require-mfa`
+   setting is enabled. Returns 403 for non-allowlisted API requests from users who haven't set up TOTP."
+  (:require
+   [clojure.string :as str]
+   [metabase.session.settings :as session.settings]))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private allowlisted-paths
+  "Paths that are always accessible, even when MFA enforcement is active.
+   Users need these to complete MFA setup, view their account, and log out."
+  #{"/api/user/current"
+    "/api/mfa/setup"
+    "/api/mfa/confirm"
+    "/api/session"
+    "/api/session/properties"
+    "/api/setting/require-mfa"})
+
+(defn- allowlisted-request?
+  "Check whether this request path is allowlisted for MFA-pending users."
+  [{:keys [uri request-method]}]
+  (or (contains? allowlisted-paths uri)
+      ;; Allow all sub-paths of /api/session (e.g., /api/session/properties)
+      ;; but the main set already covers the critical ones.
+      ;; Allow non-API paths (static assets, health check, etc.)
+      (not (str/starts-with? uri "/api/"))))
+
+(defn- mfa-enforcement-applies?
+  "Should MFA enforcement block this request?
+   Returns true when:
+   1. require-mfa setting is enabled
+   2. User is authenticated via session (not API key)
+   3. User is a password-auth user (no SSO source)
+   4. User has not set up TOTP
+   5. Request is not on the allowlist"
+  [request]
+  (and (session.settings/require-mfa)
+       ;; Only enforce for session-based auth (not API keys)
+       (:metabase-session-key request)
+       ;; Only enforce for password-auth users (SSO users are exempt)
+       (not (:sso-source request))
+       ;; Only enforce for users who haven't set up TOTP
+       (not (:totp-enabled? request))
+       ;; Only block non-allowlisted paths
+       (not (allowlisted-request? request))))
+
+(defn wrap-enforce-mfa
+  "Middleware that blocks API requests from password-authenticated users who haven't set up TOTP
+   when the `require-mfa` setting is enabled. Returns a 403 response with `{:mfa-setup-required true}`
+   so the frontend can redirect to the MFA setup page."
+  [handler]
+  (fn [request respond raise]
+    (if (mfa-enforcement-applies? request)
+      (respond {:status  403
+                :headers {"Content-Type" "application/json; charset=utf-8"}
+                :body    {:mfa-setup-required true
+                          :message            "Two-factor authentication setup is required for your account."}})
+      (handler request respond raise))))

--- a/src/metabase/server/middleware/mfa_enforcement.clj
+++ b/src/metabase/server/middleware/mfa_enforcement.clj
@@ -19,10 +19,8 @@
 
 (defn- allowlisted-request?
   "Check whether this request path is allowlisted for MFA-pending users."
-  [{:keys [uri request-method]}]
+  [{:keys [uri]}]
   (or (contains? allowlisted-paths uri)
-      ;; Allow all sub-paths of /api/session (e.g., /api/session/properties)
-      ;; but the main set already covers the critical ones.
       ;; Allow non-API paths (static assets, health check, etc.)
       (not (str/starts-with? uri "/api/"))))
 
@@ -37,7 +35,7 @@
   [request]
   (and (session.settings/require-mfa)
        ;; Only enforce for session-based auth (not API keys)
-       (:metabase-session-key request)
+       (not (get-in request [:headers "x-api-key"]))
        ;; Only enforce for password-auth users (SSO users are exempt)
        (not (:sso-source request))
        ;; Only enforce for users who haven't set up TOTP

--- a/src/metabase/server/middleware/mfa_enforcement.clj
+++ b/src/metabase/server/middleware/mfa_enforcement.clj
@@ -34,8 +34,8 @@
    5. Request is not on the allowlist"
   [request]
   (and (session.settings/require-mfa)
-       ;; Only enforce for session-based auth (not API keys)
-       (not (get-in request [:headers "x-api-key"]))
+       ;; Only enforce for session-based auth — API key auth doesn't set :metabase-session-key
+       (:metabase-session-key request)
        ;; Only enforce for password-auth users (SSO users are exempt)
        (not (:sso-source request))
        ;; Only enforce for users who haven't set up TOTP

--- a/src/metabase/server/middleware/session.clj
+++ b/src/metabase/server/middleware/session.clj
@@ -103,7 +103,9 @@
        (cond-> {:select    [[:session.user_id :metabase-user-id]
                             [:user.is_superuser :is-superuser?]
                             [:user.is_data_analyst :is-data-analyst?]
-                            [:user.locale :user-locale]]
+                            [:user.locale :user-locale]
+                            [:user.totp_enabled :totp-enabled?]
+                            [:user.sso_source :sso-source]]
                 :from      [[:core_session :session]]
                 :left-join [[:core_user :user] [:= :session.user_id :user.id]
                             [:tenant] [:= :tenant.id :user.tenant_id]]
@@ -189,7 +191,8 @@
                            [anti-csrf-token]))]
       (some-> (t2/query-one (cons sql params))
               ;; is-group-manager? could return `nil, convert it to boolean so it's guaranteed to be only true/false
-              (update :is-group-manager? boolean)))))
+              (update :is-group-manager? boolean)
+              (update :totp-enabled? boolean)))))
 
 (def ^:private api-key-that-should-never-match (str (random-uuid)))
 (def ^:private hash-that-should-never-match (u.password/hash-bcrypt "password"))

--- a/src/metabase/session/api.clj
+++ b/src/metabase/session/api.clj
@@ -1,11 +1,15 @@
 (ns metabase.session.api
   "/api/session endpoints"
   (:require
+   [clojure.string :as str]
    [java-time.api :as t]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.api.open-api :as open-api]
    [metabase.auth-identity.core :as auth-identity]
+   [metabase.auth-identity.mfa-token :as mfa-token]
+   [metabase.auth-identity.session :as auth-session]
+   [metabase.auth-identity.totp :as totp]
    [metabase.channel.email.messages :as messages]
    [metabase.config.core :as config]
    [metabase.events.core :as events]
@@ -130,8 +134,16 @@
         request-time (t/zoned-date-time (t/zone-id "GMT"))
         do-login     (fn []
                        (let [{session-key :key, :as session} (login username password (request/device-info request))
-                             response                        {:id (str session-key)}]
-                         (request/set-session-cookies request response session request-time)))]
+                             user-id (:user_id session)]
+                         (if (t2/select-one-fn :totp_enabled :model/User :id user-id)
+                           ;; MFA required: delete the premature session and return an MFA token
+                           (do
+                             (t2/delete! :model/Session :key_hashed (session/hash-session-key session-key))
+                             {:mfa_required true
+                              :mfa_token    (mfa-token/create-mfa-token user-id)})
+                           ;; No MFA: return session as usual
+                           (let [response {:id (str session-key)}]
+                             (request/set-session-cookies request response session request-time)))))]
     (if throttling-disabled?
       (do-login)
       (http-401-on-error
@@ -152,6 +164,61 @@
         rows-deleted (t2/delete! :model/Session {:where [:or [:= :key_hashed session-key-hashed] [:= :id metabase-session-key]]})]
     (api/check-404 (> rows-deleted 0))
     (request/clear-session-cookie api/generic-204-no-content)))
+
+(def ^:private mfa-throttlers
+  {:ip-address (throttle/make-throttler :username :attempts-threshold 10)})
+
+#_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
+(api.macros/defendpoint :post "/mfa-verify"
+  "Verify a TOTP code or recovery code to complete MFA login. Called after `POST /` returns `{:mfa_required true}`."
+  [_route-params
+   _query-params
+   {:keys [mfa-token totp-code recovery-code]} :- [:map
+                                                   [:mfa-token     ms/NonBlankString]
+                                                   [:totp-code     {:optional true} [:maybe ms/NonBlankString]]
+                                                   [:recovery-code {:optional true} [:maybe ms/NonBlankString]]]
+   request]
+  (let [ip-address   (request/ip-address request)
+        request-time (t/zoned-date-time (t/zone-id "GMT"))
+        do-verify    (fn []
+                       (let [{:keys [user-id]} (mfa-token/verify-mfa-token mfa-token)
+                             user              (t2/select-one [:model/User :id :totp_secret :totp_recovery_codes :totp_enabled]
+                                                              :id user-id)]
+                         (api/check-404 user)
+                         (when-not (:totp_enabled user)
+                           (throw (ex-info "MFA is not enabled for this user"
+                                           {:status-code 400})))
+                         (cond
+                           ;; Verify TOTP code
+                           (not (str/blank? totp-code))
+                           (when-not (totp/valid-code? (:totp_secret user) totp-code)
+                             (throw (ex-info "Invalid TOTP code"
+                                             {:status-code 401
+                                              :errors {:totp-code (deferred-tru "Invalid verification code")}})))
+
+                           ;; Verify recovery code
+                           (not (str/blank? recovery-code))
+                           (let [{:keys [valid? remaining]} (totp/verify-recovery-code recovery-code (:totp_recovery_codes user))]
+                             (when-not valid?
+                               (throw (ex-info "Invalid recovery code"
+                                               {:status-code 401
+                                                :errors {:recovery-code (deferred-tru "Invalid recovery code")}})))
+                             ;; Consume the used recovery code
+                             (t2/update! :model/User user-id {:totp_recovery_codes remaining}))
+
+                           :else
+                           (throw (ex-info "Either totp-code or recovery-code is required"
+                                           {:status-code 400})))
+                         ;; MFA verified — create a real session
+                         (let [session  (auth-session/create-session-with-auth-tracking!
+                                         user (request/device-info request) :provider/password)
+                               response {:id (str (:key session))}]
+                           (request/set-session-cookies request response session request-time))))]
+    (if throttling-disabled?
+      (do-verify)
+      (http-401-on-error
+        (throttle/with-throttling [(mfa-throttlers :ip-address) ip-address]
+          (do-verify))))))
 
 ;; Reset tokens: We need some way to match a plaintext token with the a user since the token stored in the DB is
 ;; hashed. So we'll make the plaintext token in the format USER-ID_RANDOM-UUID, e.g.
@@ -299,12 +366,20 @@
               (cond
                 ;; Login succeeded
                 (:success? login-result)
-                (let [session (:session login-result)
-                      response {:id (str (:key session))}]
-                  (request/set-session-cookies request
-                                               response
-                                               session
-                                               (t/zoned-date-time (t/zone-id "GMT"))))
+                (let [session  (:session login-result)
+                      user-id  (:user_id session)]
+                  (if (t2/select-one-fn :totp_enabled :model/User :id user-id)
+                    ;; MFA required: delete the premature session and return an MFA token
+                    (do
+                      (t2/delete! :model/Session :key_hashed (session/hash-session-key (:key session)))
+                      {:mfa_required true
+                       :mfa_token    (mfa-token/create-mfa-token user-id)})
+                    ;; No MFA: return session as usual
+                    (let [response {:id (str (:key session))}]
+                      (request/set-session-cookies request
+                                                   response
+                                                   session
+                                                   (t/zoned-date-time (t/zone-id "GMT"))))))
 
                 ;; Login failed
                 :else

--- a/src/metabase/session/api.clj
+++ b/src/metabase/session/api.clj
@@ -196,15 +196,19 @@
                                              {:status-code 401
                                               :errors {:totp-code (deferred-tru "Invalid verification code")}})))
 
-                           ;; Verify recovery code
+                           ;; Verify recovery code — use transaction + row lock to prevent concurrent consumption
                            (not (str/blank? recovery-code))
-                           (let [{:keys [valid? remaining]} (totp/verify-recovery-code recovery-code (:totp_recovery_codes user))]
-                             (when-not valid?
-                               (throw (ex-info "Invalid recovery code"
-                                               {:status-code 401
-                                                :errors {:recovery-code (deferred-tru "Invalid recovery code")}})))
-                             ;; Consume the used recovery code
-                             (t2/update! :model/User user-id {:totp_recovery_codes remaining}))
+                           (t2/with-transaction [_tx]
+                             (let [locked-user (t2/select-one [:model/User :id :totp_recovery_codes]
+                                                              :id user-id
+                                                              {:for :update})
+                                   {:keys [valid? remaining]} (totp/verify-recovery-code recovery-code (:totp_recovery_codes locked-user))]
+                               (when-not valid?
+                                 (throw (ex-info "Invalid recovery code"
+                                                 {:status-code 401
+                                                  :errors {:recovery-code (deferred-tru "Invalid recovery code")}})))
+                               ;; Consume the used recovery code
+                               (t2/update! :model/User user-id {:totp_recovery_codes remaining})))
 
                            :else
                            (throw (ex-info "Either totp-code or recovery-code is required"

--- a/src/metabase/session/api.clj
+++ b/src/metabase/session/api.clj
@@ -104,6 +104,19 @@
                 {:status-code 401
                  :errors      {:password password-fail-snippet}}))))
 
+(defn- mfa-gate-session
+  "Check if the user who just authenticated has TOTP enabled. If so, delete the premature session and
+   return an MFA token response. Otherwise, build the normal session response with cookies."
+  [session-key session request request-time]
+  (let [user-id (:user_id session)]
+    (if (t2/select-one-fn :totp_enabled :model/User :id user-id)
+      (do
+        (t2/delete! :model/Session :key_hashed (session/hash-session-key session-key))
+        {:mfa_required true
+         :mfa_token    (mfa-token/create-mfa-token user-id)})
+      (let [response {:id (str session-key)}]
+        (request/set-session-cookies request response session request-time)))))
+
 (defn- do-http-401-on-error [f]
   (try
     (f)
@@ -133,17 +146,8 @@
   (let [ip-address   (request/ip-address request)
         request-time (t/zoned-date-time (t/zone-id "GMT"))
         do-login     (fn []
-                       (let [{session-key :key, :as session} (login username password (request/device-info request))
-                             user-id (:user_id session)]
-                         (if (t2/select-one-fn :totp_enabled :model/User :id user-id)
-                           ;; MFA required: delete the premature session and return an MFA token
-                           (do
-                             (t2/delete! :model/Session :key_hashed (session/hash-session-key session-key))
-                             {:mfa_required true
-                              :mfa_token    (mfa-token/create-mfa-token user-id)})
-                           ;; No MFA: return session as usual
-                           (let [response {:id (str session-key)}]
-                             (request/set-session-cookies request response session request-time)))))]
+                       (let [{session-key :key, :as session} (login username password (request/device-info request))]
+                         (mfa-gate-session session-key session request request-time)))]
     (if throttling-disabled?
       (do-login)
       (http-401-on-error
@@ -370,20 +374,9 @@
               (cond
                 ;; Login succeeded
                 (:success? login-result)
-                (let [session  (:session login-result)
-                      user-id  (:user_id session)]
-                  (if (t2/select-one-fn :totp_enabled :model/User :id user-id)
-                    ;; MFA required: delete the premature session and return an MFA token
-                    (do
-                      (t2/delete! :model/Session :key_hashed (session/hash-session-key (:key session)))
-                      {:mfa_required true
-                       :mfa_token    (mfa-token/create-mfa-token user-id)})
-                    ;; No MFA: return session as usual
-                    (let [response {:id (str (:key session))}]
-                      (request/set-session-cookies request
-                                                   response
-                                                   session
-                                                   (t/zoned-date-time (t/zone-id "GMT"))))))
+                (let [session (:session login-result)]
+                  (mfa-gate-session (:key session) session request
+                                    (t/zoned-date-time (t/zone-id "GMT"))))
 
                 ;; Login failed
                 :else

--- a/src/metabase/session/settings.clj
+++ b/src/metabase/session/settings.clj
@@ -54,6 +54,8 @@
   :default    false
   :audit      :raw-value
   :setter     (fn [new-value]
+                ;; NOTE: the setter assumes HTTP request context (api/*current-user-id* must be bound).
+                ;; Programmatic callers (REPL, migrations) should use setting/set-value-of-type! directly.
                 (when new-value
                   (api/check-superuser)
                   (when-not (t2/select-one-fn :totp_enabled :model/User :id api/*current-user-id*)

--- a/src/metabase/session/settings.clj
+++ b/src/metabase/session/settings.clj
@@ -1,9 +1,11 @@
 (ns metabase.session.settings
   (:require
+   [metabase.api.common :as api]
    [metabase.settings.core :as setting :refer [defsetting]]
    [metabase.sso.core :as sso]
-   [metabase.util.i18n :refer [deferred-tru]]
-   [metabase.util.password :as u.password]))
+   [metabase.util.i18n :refer [deferred-tru tru]]
+   [metabase.util.password :as u.password]
+   [toucan2.core :as t2]))
 
 (defsetting enable-password-login
   (deferred-tru "Allow logging in by email and password.")
@@ -43,3 +45,17 @@
   :type       :integer
   :default    48
   :audit      :getter)
+
+(defsetting require-mfa
+  (deferred-tru "Require all password-authenticated users to set up two-factor authentication.")
+  :visibility :public
+  :type       :boolean
+  :default    false
+  :audit      :raw-value
+  :setter     (fn [new-value]
+                (when new-value
+                  (api/check-superuser)
+                  (when-not (t2/select-one-fn :totp_enabled :model/User :id api/*current-user-id*)
+                    (throw (ex-info (str (tru "You must enable two-factor authentication on your own account before requiring it for others."))
+                                    {:status-code 400}))))
+                (setting/set-value-of-type! :boolean :require-mfa new-value)))

--- a/src/metabase/session/settings.clj
+++ b/src/metabase/session/settings.clj
@@ -1,9 +1,11 @@
 (ns metabase.session.settings
   (:require
    [metabase.api.common :as api]
+   [metabase.channel.email.messages :as messages]
    [metabase.settings.core :as setting :refer [defsetting]]
    [metabase.sso.core :as sso]
    [metabase.util.i18n :refer [deferred-tru tru]]
+   [metabase.util.log :as log]
    [metabase.util.password :as u.password]
    [toucan2.core :as t2]))
 
@@ -58,4 +60,20 @@
                   (when-not (t2/select-one-fn :totp_enabled :model/User :id api/*current-user-id*)
                     (throw (ex-info (str (tru "You must enable two-factor authentication on your own account before requiring it for others."))
                                     {:status-code 400}))))
-                (setting/set-value-of-type! :boolean :require-mfa new-value)))
+                (let [was-enabled (require-mfa)]
+                  (setting/set-value-of-type! :boolean :require-mfa new-value)
+                  ;; Send notification emails when transitioning from disabled to enabled
+                  (when (and new-value (not was-enabled))
+                    (future
+                      (try
+                        (let [affected-users (t2/select [:model/User :email]
+                                                        :is_active true
+                                                        :totp_enabled false
+                                                        :sso_source nil)]
+                          (doseq [{:keys [email]} affected-users]
+                            (try
+                              (messages/send-mfa-required-email! email)
+                              (catch Exception e
+                                (log/warnf e "Failed to send MFA required email to %s" email)))))
+                        (catch Exception e
+                          (log/error e "Failed to send MFA required notification emails"))))))))

--- a/src/metabase/session/settings.clj
+++ b/src/metabase/session/settings.clj
@@ -59,14 +59,14 @@
                   (when-not (t2/select-one-fn :totp_enabled :model/User :id api/*current-user-id*)
                     (throw (ex-info (str (tru "You must enable two-factor authentication on your own account before requiring it for others."))
                                     {:status-code 400}))))
-                (let [was-enabled (require-mfa)]
+                (let [was-enabled (setting/get-value-of-type :boolean :require-mfa)]
                   (setting/set-value-of-type! :boolean :require-mfa new-value)
                   ;; Send notification emails when transitioning from disabled to enabled
                   (when (and new-value (not was-enabled))
                     (future
                       (try
                         ;; Re-check the setting inside the future to guard against rapid toggle-off-on
-                        (when (require-mfa)
+                        (when (setting/get-value-of-type :boolean :require-mfa)
                           (let [affected-users (t2/select [:model/User :email]
                                                           :is_active true
                                                           :totp_enabled false

--- a/src/metabase/session/settings.clj
+++ b/src/metabase/session/settings.clj
@@ -1,7 +1,6 @@
 (ns metabase.session.settings
   (:require
    [metabase.api.common :as api]
-   [metabase.channel.email.messages :as messages]
    [metabase.settings.core :as setting :refer [defsetting]]
    [metabase.sso.core :as sso]
    [metabase.util.i18n :refer [deferred-tru tru]]
@@ -74,7 +73,7 @@
                                                           :sso_source nil)]
                             (doseq [{:keys [email]} affected-users]
                               (try
-                                (messages/send-mfa-required-email! email)
+                                ((requiring-resolve 'metabase.channel.email.messages/send-mfa-required-email!) email)
                                 (catch Exception e
                                   (log/warnf e "Failed to send MFA required email to %s" email))))))
                         (catch Exception e

--- a/src/metabase/session/settings.clj
+++ b/src/metabase/session/settings.clj
@@ -66,14 +66,16 @@
                   (when (and new-value (not was-enabled))
                     (future
                       (try
-                        (let [affected-users (t2/select [:model/User :email]
-                                                        :is_active true
-                                                        :totp_enabled false
-                                                        :sso_source nil)]
-                          (doseq [{:keys [email]} affected-users]
-                            (try
-                              (messages/send-mfa-required-email! email)
-                              (catch Exception e
-                                (log/warnf e "Failed to send MFA required email to %s" email)))))
+                        ;; Re-check the setting inside the future to guard against rapid toggle-off-on
+                        (when (require-mfa)
+                          (let [affected-users (t2/select [:model/User :email]
+                                                          :is_active true
+                                                          :totp_enabled false
+                                                          :sso_source nil)]
+                            (doseq [{:keys [email]} affected-users]
+                              (try
+                                (messages/send-mfa-required-email! email)
+                                (catch Exception e
+                                  (log/warnf e "Failed to send MFA required email to %s" email))))))
                         (catch Exception e
                           (log/error e "Failed to send MFA required notification emails"))))))))

--- a/src/metabase/users/models/user.clj
+++ b/src/metabase/users/models/user.clj
@@ -62,11 +62,13 @@
    :out (comp stringify-keys-and-values mi/json-out-without-keywordization)})
 
 (t2/deftransforms :model/User
-  {:login_attributes transform-attributes
-   :jwt_attributes   transform-attributes
-   :settings         mi/transform-encrypted-json
-   :sso_source       mi/transform-keyword
-   :type             mi/transform-keyword})
+  {:login_attributes    transform-attributes
+   :jwt_attributes      transform-attributes
+   :settings            mi/transform-encrypted-json
+   :totp_secret         mi/transform-encrypted-json
+   :totp_recovery_codes mi/transform-encrypted-json
+   :sso_source          mi/transform-keyword
+   :type                mi/transform-keyword})
 
 (def ^:private allowed-user-types
   #{:internal :personal :api-key})
@@ -347,7 +349,7 @@
 
 (def ^:private default-user-columns
   "Sequence of columns that are normally returned when fetching a User from the DB."
-  [:id :email :date_joined :first_name :last_name :last_login :is_superuser :is_data_analyst :is_qbnewb :tenant_id])
+  [:id :email :date_joined :first_name :last_name :last_login :is_superuser :is_data_analyst :is_qbnewb :tenant_id :totp_enabled])
 
 (def admin-or-self-visible-columns
   "Sequence of columns that we can/should return for admins fetching a list of all Users, or for the current user

--- a/src/metabase/users_rest/api.clj
+++ b/src/metabase/users_rest/api.clj
@@ -639,6 +639,23 @@
   (events/publish-event! :event/user-deactivated {:object (t2/select-one :model/User :id id) :user-id api/*current-user-id*})
   {:success true})
 
+#_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
+(api.macros/defendpoint :post "/:id/reset-mfa"
+  "Reset a user's TOTP multi-factor authentication enrollment. Superuser only.
+   Clears totp_secret, totp_enabled, and totp_recovery_codes so the user can re-enroll."
+  [{:keys [id]} :- [:map
+                    [:id ms/PositiveInt]]]
+  (api/check-superuser)
+  (let [totp-enabled? (t2/select-one-fn :totp_enabled :model/User :id id :is_active true)]
+    (api/check-404 (some? totp-enabled?))
+    (when-not totp-enabled?
+      (throw (ex-info (tru "This user does not have two-factor authentication enabled.")
+                      {:status-code 400}))))
+  (t2/update! :model/User id {:totp_enabled        false
+                               :totp_secret         nil
+                               :totp_recovery_codes nil})
+  api/generic-204-no-content)
+
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                             Other Endpoints                                                    |
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/src/metabase/util/encryption.clj
+++ b/src/metabase/util/encryption.clj
@@ -61,11 +61,15 @@
   []
   (boolean default-secret-key))
 
-(defn default-secret-key-hashed
-  "Return the hashed encryption secret key bytes, or nil if encryption is not enabled.
-   Used to derive secondary keys (e.g. MFA token signing) from the same root secret."
-  ^bytes []
-  default-secret-key)
+(defn derive-key
+  "Derive a 32-byte sub-key from `MB_ENCRYPTION_SECRET_KEY` for a specific purpose.
+   `context` is a string identifying the purpose (e.g. \"mfa-signing-key\").
+   Returns nil if encryption is not enabled. The master key never leaves this namespace."
+  ^bytes [^String context]
+  (when default-secret-key
+    (let [mac (javax.crypto.Mac/getInstance "HmacSHA256")]
+      (.init mac (SecretKeySpec. default-secret-key "HmacSHA256"))
+      (.doFinal mac (.getBytes context "UTF-8")))))
 
 ;; log a nice message letting people know whether DB details encryption is enabled
 (when-not *compile-files*

--- a/src/metabase/util/encryption.clj
+++ b/src/metabase/util/encryption.clj
@@ -61,6 +61,12 @@
   []
   (boolean default-secret-key))
 
+(defn default-secret-key-hashed
+  "Return the hashed encryption secret key bytes, or nil if encryption is not enabled.
+   Used to derive secondary keys (e.g. MFA token signing) from the same root secret."
+  ^bytes []
+  default-secret-key)
+
 ;; log a nice message letting people know whether DB details encryption is enabled
 (when-not *compile-files*
   (log/info

--- a/test/metabase/account/mfa_api_test.clj
+++ b/test/metabase/account/mfa_api_test.clj
@@ -139,3 +139,24 @@
     (mt/client :post 401 "session/mfa-verify"
                {:mfa-token     "invalid-token"
                 :totp-code     "123456"})))
+
+;;; ------------------------------------------- MFA Disable When Required -------------------------------------------
+
+(deftest mfa-disable-blocked-when-required-test
+  (testing "POST /api/mfa/disable is blocked when require-mfa is enabled for password-auth users"
+    (mt/with-temp-vals-in-db :model/User (mt/user->id :rasta) {:totp_enabled true}
+      (mt/with-temp-vals-in-db :model/User (mt/user->id :crowberto) {:totp_enabled true}
+        (mt/user-http-request :crowberto :put 204 "setting/require-mfa" {:value true})
+        (try
+          (is (re-find #"required by your administrator"
+                       (mt/user-http-request :rasta :post 400 "mfa/disable"
+                                             {:password (:password (mt/user->credentials :rasta))})))
+          (finally
+            (mt/user-http-request :crowberto :put 204 "setting/require-mfa" {:value false}))))))
+
+  (testing "POST /api/mfa/disable works when require-mfa is disabled"
+    (mt/with-temp-vals-in-db :model/User (mt/user->id :rasta) {:totp_enabled true
+                                                               :totp_secret  "JBSWY3DPEHPK3PXP"}
+      (mt/user-http-request :rasta :post 204 "mfa/disable"
+                            {:password (:password (mt/user->credentials :rasta))})
+      (is (false? (t2/select-one-fn :totp_enabled :model/User :id (mt/user->id :rasta)))))))

--- a/test/metabase/account/mfa_api_test.clj
+++ b/test/metabase/account/mfa_api_test.clj
@@ -1,0 +1,141 @@
+(ns metabase.account.mfa-api-test
+  "Tests for /api/account/mfa and /api/session MFA flow"
+  (:require
+   [clojure.test :refer :all]
+   [metabase.auth-identity.totp :as totp]
+   [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(use-fixtures :once (fixtures/initialize :db :web-server :test-users))
+
+;;; -------------------------------------------------- MFA Setup Flow --------------------------------------------------
+
+(deftest mfa-setup-test
+  (testing "POST /api/account/mfa/setup returns secret, URI, and recovery codes"
+    (let [response (mt/user-http-request :rasta :post 200 "account/mfa/setup")]
+      (is (string? (:secret response)))
+      (is (string? (:otpauth_uri response)))
+      (is (= 10 (count (:recovery_codes response)))))))
+
+(deftest mfa-confirm-test
+  (testing "POST /api/account/mfa/confirm activates TOTP with a valid code"
+    (mt/with-temp-vals-in-db :model/User (mt/user->id :rasta) {:totp_enabled false
+                                                               :totp_secret  nil
+                                                               :totp_recovery_codes nil}
+      ;; Step 1: Setup
+      (let [setup-response (mt/user-http-request :rasta :post 200 "account/mfa/setup")
+            secret         (:secret setup-response)
+            ;; Generate a valid TOTP code from the secret
+            time-step      (quot (quot (System/currentTimeMillis) 1000) 30)
+            valid-code     (totp/totp-code secret time-step)]
+        ;; Step 2: Confirm
+        (let [confirm-response (mt/user-http-request :rasta :post 200 "account/mfa/confirm"
+                                                     {:totp-code valid-code})]
+          (is (= {:success true} confirm-response))
+          ;; Verify it's actually enabled in the DB
+          (is (true? (t2/select-one-fn :totp_enabled :model/User :id (mt/user->id :rasta)))))))))
+
+(deftest mfa-confirm-invalid-code-test
+  (testing "POST /api/account/mfa/confirm rejects an invalid code"
+    (mt/with-temp-vals-in-db :model/User (mt/user->id :rasta) {:totp_enabled false
+                                                               :totp_secret  nil
+                                                               :totp_recovery_codes nil}
+      (mt/user-http-request :rasta :post 200 "account/mfa/setup")
+      (is (= 400
+             (:status-code
+              (mt/user-http-request :rasta :post "account/mfa/confirm"
+                                    {:totp-code "000000"})))))))
+
+(deftest mfa-disable-test
+  (testing "DELETE /api/account/mfa disables TOTP when given correct password"
+    (mt/with-temp-vals-in-db :model/User (mt/user->id :rasta) {:totp_enabled false
+                                                               :totp_secret  nil
+                                                               :totp_recovery_codes nil}
+      ;; Enable TOTP first
+      (let [setup-response (mt/user-http-request :rasta :post 200 "account/mfa/setup")
+            secret         (:secret setup-response)
+            time-step      (quot (quot (System/currentTimeMillis) 1000) 30)
+            valid-code     (totp/totp-code secret time-step)]
+        (mt/user-http-request :rasta :post 200 "account/mfa/confirm" {:totp-code valid-code})
+        ;; Now disable
+        (mt/user-http-request :rasta :delete 204 "account/mfa"
+                              {:password "password"})
+        (is (false? (t2/select-one-fn :totp_enabled :model/User :id (mt/user->id :rasta))))))))
+
+;;; -------------------------------------------------- MFA Login Flow --------------------------------------------------
+
+(deftest mfa-login-flow-test
+  (testing "Login with MFA-enabled user returns mfa_required, then verify completes login"
+    (mt/with-temp-vals-in-db :model/User (mt/user->id :rasta) {:totp_enabled false
+                                                               :totp_secret  nil
+                                                               :totp_recovery_codes nil}
+      ;; Enable TOTP
+      (let [setup-response (mt/user-http-request :rasta :post 200 "account/mfa/setup")
+            secret         (:secret setup-response)
+            time-step      (quot (quot (System/currentTimeMillis) 1000) 30)
+            valid-code     (totp/totp-code secret time-step)]
+        (mt/user-http-request :rasta :post 200 "account/mfa/confirm" {:totp-code valid-code})
+
+        ;; Login should now return mfa_required
+        (let [login-response (mt/client :post 200 "session" (mt/user->credentials :rasta))]
+          (is (true? (:mfa_required login-response)))
+          (is (string? (:mfa_token login-response)))
+
+          ;; Verify with TOTP code
+          (let [mfa-code     (totp/totp-code secret (quot (quot (System/currentTimeMillis) 1000) 30))
+                verify-response (mt/client :post 200 "session/mfa-verify"
+                                           {:mfa-token     (:mfa_token login-response)
+                                            :totp-code     mfa-code})]
+            (is (string? (:id verify-response)))))))))
+
+(deftest mfa-login-without-mfa-test
+  (testing "Login with MFA-disabled user returns normal session (backward compat)"
+    (mt/with-temp-vals-in-db :model/User (mt/user->id :rasta) {:totp_enabled false}
+      (let [response (mt/client :post 200 "session" (mt/user->credentials :rasta))]
+        (is (string? (:id response)))
+        (is (nil? (:mfa_required response)))))))
+
+(deftest mfa-login-recovery-code-test
+  (testing "Login with MFA using a recovery code"
+    (mt/with-temp-vals-in-db :model/User (mt/user->id :rasta) {:totp_enabled false
+                                                               :totp_secret  nil
+                                                               :totp_recovery_codes nil}
+      ;; Enable TOTP
+      (let [setup-response (mt/user-http-request :rasta :post 200 "account/mfa/setup")
+            secret         (:secret setup-response)
+            recovery-codes (:recovery_codes setup-response)
+            time-step      (quot (quot (System/currentTimeMillis) 1000) 30)
+            valid-code     (totp/totp-code secret time-step)]
+        (mt/user-http-request :rasta :post 200 "account/mfa/confirm" {:totp-code valid-code})
+
+        ;; Login
+        (let [login-response (mt/client :post 200 "session" (mt/user->credentials :rasta))]
+          ;; Verify with recovery code
+          (let [verify-response (mt/client :post 200 "session/mfa-verify"
+                                           {:mfa-token     (:mfa_token login-response)
+                                            :recovery-code (first recovery-codes)})]
+            (is (string? (:id verify-response)))))))))
+
+(deftest mfa-verify-invalid-totp-test
+  (testing "MFA verify rejects an invalid TOTP code"
+    (mt/with-temp-vals-in-db :model/User (mt/user->id :rasta) {:totp_enabled false
+                                                               :totp_secret  nil
+                                                               :totp_recovery_codes nil}
+      (let [setup-response (mt/user-http-request :rasta :post 200 "account/mfa/setup")
+            secret         (:secret setup-response)
+            time-step      (quot (quot (System/currentTimeMillis) 1000) 30)
+            valid-code     (totp/totp-code secret time-step)]
+        (mt/user-http-request :rasta :post 200 "account/mfa/confirm" {:totp-code valid-code})
+        (let [login-response (mt/client :post 200 "session" (mt/user->credentials :rasta))]
+          (mt/client :post 401 "session/mfa-verify"
+                     {:mfa-token (:mfa_token login-response)
+                      :totp-code "000000"}))))))
+
+(deftest mfa-verify-expired-token-test
+  (testing "MFA verify rejects an expired or invalid token"
+    (mt/client :post 401 "session/mfa-verify"
+               {:mfa-token     "invalid-token"
+                :totp-code     "123456"})))

--- a/test/metabase/account/mfa_api_test.clj
+++ b/test/metabase/account/mfa_api_test.clj
@@ -154,6 +154,19 @@
           (finally
             (mt/user-http-request :crowberto :put 204 "setting/require-mfa" {:value false}))))))
 
+  (testing "SSO users can disable TOTP even when require-mfa is enabled"
+    (mt/with-temp-vals-in-db :model/User (mt/user->id :rasta) {:totp_enabled true
+                                                               :totp_secret  "JBSWY3DPEHPK3PXP"
+                                                               :sso_source   "google"}
+      (mt/with-temp-vals-in-db :model/User (mt/user->id :crowberto) {:totp_enabled true}
+        (mt/user-http-request :crowberto :put 204 "setting/require-mfa" {:value true})
+        (try
+          (mt/user-http-request :rasta :post 204 "mfa/disable"
+                                {:password (:password (mt/user->credentials :rasta))})
+          (is (false? (t2/select-one-fn :totp_enabled :model/User :id (mt/user->id :rasta))))
+          (finally
+            (mt/user-http-request :crowberto :put 204 "setting/require-mfa" {:value false}))))))
+
   (testing "POST /api/mfa/disable works when require-mfa is disabled"
     (mt/with-temp-vals-in-db :model/User (mt/user->id :rasta) {:totp_enabled true
                                                                :totp_secret  "JBSWY3DPEHPK3PXP"}

--- a/test/metabase/account/mfa_api_test.clj
+++ b/test/metabase/account/mfa_api_test.clj
@@ -1,5 +1,5 @@
 (ns metabase.account.mfa-api-test
-  "Tests for /api/account/mfa and /api/session MFA flow"
+  "Tests for /api/mfa and /api/session MFA flow"
   (:require
    [clojure.test :refer :all]
    [metabase.auth-identity.totp :as totp]
@@ -14,54 +14,54 @@
 ;;; -------------------------------------------------- MFA Setup Flow --------------------------------------------------
 
 (deftest mfa-setup-test
-  (testing "POST /api/account/mfa/setup returns secret, URI, and recovery codes"
-    (let [response (mt/user-http-request :rasta :post 200 "account/mfa/setup")]
+  (testing "POST /api/mfa/setup returns secret, URI, and recovery codes"
+    (let [response (mt/user-http-request :rasta :post 200 "mfa/setup")]
       (is (string? (:secret response)))
       (is (string? (:otpauth_uri response)))
       (is (= 10 (count (:recovery_codes response)))))))
 
 (deftest mfa-confirm-test
-  (testing "POST /api/account/mfa/confirm activates TOTP with a valid code"
+  (testing "POST /api/mfa/confirm activates TOTP with a valid code"
     (mt/with-temp-vals-in-db :model/User (mt/user->id :rasta) {:totp_enabled false
                                                                :totp_secret  nil
                                                                :totp_recovery_codes nil}
       ;; Step 1: Setup
-      (let [setup-response (mt/user-http-request :rasta :post 200 "account/mfa/setup")
+      (let [setup-response (mt/user-http-request :rasta :post 200 "mfa/setup")
             secret         (:secret setup-response)
             ;; Generate a valid TOTP code from the secret
             time-step      (quot (quot (System/currentTimeMillis) 1000) 30)
             valid-code     (totp/totp-code secret time-step)]
         ;; Step 2: Confirm
-        (let [confirm-response (mt/user-http-request :rasta :post 200 "account/mfa/confirm"
+        (let [confirm-response (mt/user-http-request :rasta :post 200 "mfa/confirm"
                                                      {:totp-code valid-code})]
           (is (= {:success true} confirm-response))
           ;; Verify it's actually enabled in the DB
           (is (true? (t2/select-one-fn :totp_enabled :model/User :id (mt/user->id :rasta)))))))))
 
 (deftest mfa-confirm-invalid-code-test
-  (testing "POST /api/account/mfa/confirm rejects an invalid code"
+  (testing "POST /api/mfa/confirm rejects an invalid code"
     (mt/with-temp-vals-in-db :model/User (mt/user->id :rasta) {:totp_enabled false
                                                                :totp_secret  nil
                                                                :totp_recovery_codes nil}
-      (mt/user-http-request :rasta :post 200 "account/mfa/setup")
+      (mt/user-http-request :rasta :post 200 "mfa/setup")
       (is (= 400
              (:status-code
-              (mt/user-http-request :rasta :post "account/mfa/confirm"
+              (mt/user-http-request :rasta :post "mfa/confirm"
                                     {:totp-code "000000"})))))))
 
 (deftest mfa-disable-test
-  (testing "POST /api/account/mfa/disable disables TOTP when given correct password"
+  (testing "POST /api/mfa/disable disables TOTP when given correct password"
     (mt/with-temp-vals-in-db :model/User (mt/user->id :rasta) {:totp_enabled false
                                                                :totp_secret  nil
                                                                :totp_recovery_codes nil}
       ;; Enable TOTP first
-      (let [setup-response (mt/user-http-request :rasta :post 200 "account/mfa/setup")
+      (let [setup-response (mt/user-http-request :rasta :post 200 "mfa/setup")
             secret         (:secret setup-response)
             time-step      (quot (quot (System/currentTimeMillis) 1000) 30)
             valid-code     (totp/totp-code secret time-step)]
-        (mt/user-http-request :rasta :post 200 "account/mfa/confirm" {:totp-code valid-code})
+        (mt/user-http-request :rasta :post 200 "mfa/confirm" {:totp-code valid-code})
         ;; Now disable
-        (mt/user-http-request :rasta :post 204 "account/mfa/disable"
+        (mt/user-http-request :rasta :post 204 "mfa/disable"
                               {:password "password"})
         (is (false? (t2/select-one-fn :totp_enabled :model/User :id (mt/user->id :rasta))))))))
 
@@ -73,11 +73,11 @@
                                                                :totp_secret  nil
                                                                :totp_recovery_codes nil}
       ;; Enable TOTP
-      (let [setup-response (mt/user-http-request :rasta :post 200 "account/mfa/setup")
+      (let [setup-response (mt/user-http-request :rasta :post 200 "mfa/setup")
             secret         (:secret setup-response)
             time-step      (quot (quot (System/currentTimeMillis) 1000) 30)
             valid-code     (totp/totp-code secret time-step)]
-        (mt/user-http-request :rasta :post 200 "account/mfa/confirm" {:totp-code valid-code})
+        (mt/user-http-request :rasta :post 200 "mfa/confirm" {:totp-code valid-code})
 
         ;; Login should now return mfa_required
         (let [login-response (mt/client :post 200 "session" (mt/user->credentials :rasta))]
@@ -104,12 +104,12 @@
                                                                :totp_secret  nil
                                                                :totp_recovery_codes nil}
       ;; Enable TOTP
-      (let [setup-response (mt/user-http-request :rasta :post 200 "account/mfa/setup")
+      (let [setup-response (mt/user-http-request :rasta :post 200 "mfa/setup")
             secret         (:secret setup-response)
             recovery-codes (:recovery_codes setup-response)
             time-step      (quot (quot (System/currentTimeMillis) 1000) 30)
             valid-code     (totp/totp-code secret time-step)]
-        (mt/user-http-request :rasta :post 200 "account/mfa/confirm" {:totp-code valid-code})
+        (mt/user-http-request :rasta :post 200 "mfa/confirm" {:totp-code valid-code})
 
         ;; Login
         (let [login-response (mt/client :post 200 "session" (mt/user->credentials :rasta))]
@@ -124,11 +124,11 @@
     (mt/with-temp-vals-in-db :model/User (mt/user->id :rasta) {:totp_enabled false
                                                                :totp_secret  nil
                                                                :totp_recovery_codes nil}
-      (let [setup-response (mt/user-http-request :rasta :post 200 "account/mfa/setup")
+      (let [setup-response (mt/user-http-request :rasta :post 200 "mfa/setup")
             secret         (:secret setup-response)
             time-step      (quot (quot (System/currentTimeMillis) 1000) 30)
             valid-code     (totp/totp-code secret time-step)]
-        (mt/user-http-request :rasta :post 200 "account/mfa/confirm" {:totp-code valid-code})
+        (mt/user-http-request :rasta :post 200 "mfa/confirm" {:totp-code valid-code})
         (let [login-response (mt/client :post 200 "session" (mt/user->credentials :rasta))]
           (mt/client :post 401 "session/mfa-verify"
                      {:mfa-token (:mfa_token login-response)

--- a/test/metabase/account/mfa_api_test.clj
+++ b/test/metabase/account/mfa_api_test.clj
@@ -62,7 +62,7 @@
         (mt/user-http-request :rasta :post 200 "mfa/confirm" {:totp-code valid-code})
         ;; Now disable
         (mt/user-http-request :rasta :post 204 "mfa/disable"
-                              {:password "password"})
+                              {:password (:password (mt/user->credentials :rasta))})
         (is (false? (t2/select-one-fn :totp_enabled :model/User :id (mt/user->id :rasta))))))))
 
 ;;; -------------------------------------------------- MFA Login Flow --------------------------------------------------

--- a/test/metabase/account/mfa_api_test.clj
+++ b/test/metabase/account/mfa_api_test.clj
@@ -50,7 +50,7 @@
                                     {:totp-code "000000"})))))))
 
 (deftest mfa-disable-test
-  (testing "DELETE /api/account/mfa disables TOTP when given correct password"
+  (testing "POST /api/account/mfa/disable disables TOTP when given correct password"
     (mt/with-temp-vals-in-db :model/User (mt/user->id :rasta) {:totp_enabled false
                                                                :totp_secret  nil
                                                                :totp_recovery_codes nil}
@@ -61,7 +61,7 @@
             valid-code     (totp/totp-code secret time-step)]
         (mt/user-http-request :rasta :post 200 "account/mfa/confirm" {:totp-code valid-code})
         ;; Now disable
-        (mt/user-http-request :rasta :delete 204 "account/mfa"
+        (mt/user-http-request :rasta :post 204 "account/mfa/disable"
                               {:password "password"})
         (is (false? (t2/select-one-fn :totp_enabled :model/User :id (mt/user->id :rasta))))))))
 

--- a/test/metabase/auth_identity/mfa_token_test.clj
+++ b/test/metabase/auth_identity/mfa_token_test.clj
@@ -1,0 +1,38 @@
+(ns metabase.auth-identity.mfa-token-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.auth-identity.mfa-token :as mfa-token]))
+
+(set! *warn-on-reflection* true)
+
+(deftest create-and-verify-test
+  (testing "round-trip: create then verify returns the same user-id"
+    (let [user-id 42
+          token   (mfa-token/create-mfa-token user-id)
+          result  (mfa-token/verify-mfa-token token)]
+      (is (= {:user-id user-id} result))))
+
+  (testing "token is a non-empty string"
+    (let [token (mfa-token/create-mfa-token 1)]
+      (is (string? token))
+      (is (pos? (count token))))))
+
+(deftest verify-invalid-token-test
+  (testing "rejects a garbage token"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"Invalid or expired MFA token"
+                          (mfa-token/verify-mfa-token "not-a-valid-jwt"))))
+
+  (testing "rejects a tampered token"
+    (let [token (mfa-token/create-mfa-token 1)]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"Invalid or expired MFA token"
+                            (mfa-token/verify-mfa-token (str token "x")))))))
+
+(deftest verify-different-users-test
+  (testing "different user IDs produce different tokens"
+    (let [token1 (mfa-token/create-mfa-token 1)
+          token2 (mfa-token/create-mfa-token 2)]
+      (is (not= token1 token2))
+      (is (= {:user-id 1} (mfa-token/verify-mfa-token token1)))
+      (is (= {:user-id 2} (mfa-token/verify-mfa-token token2))))))

--- a/test/metabase/auth_identity/mfa_token_test.clj
+++ b/test/metabase/auth_identity/mfa_token_test.clj
@@ -36,3 +36,11 @@
       (is (not= token1 token2))
       (is (= {:user-id 1} (mfa-token/verify-mfa-token token1)))
       (is (= {:user-id 2} (mfa-token/verify-mfa-token token2))))))
+
+(deftest single-use-enforcement-test
+  (testing "a token cannot be used twice (replay prevention)"
+    (let [token (mfa-token/create-mfa-token 99)]
+      (is (= {:user-id 99} (mfa-token/verify-mfa-token token)))
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"MFA token has already been used"
+                            (mfa-token/verify-mfa-token token))))))

--- a/test/metabase/auth_identity/totp_test.clj
+++ b/test/metabase/auth_identity/totp_test.clj
@@ -2,7 +2,9 @@
   (:require
    [clojure.test :refer :all]
    [metabase.auth-identity.totp :as totp]
-   [metabase.util.password :as u.password]))
+   [metabase.util.password :as u.password])
+  (:import
+   (org.apache.commons.codec.binary Base32)))
 
 (set! *warn-on-reflection* true)
 
@@ -16,6 +18,35 @@
   (testing "generates unique secrets"
     (let [secrets (repeatedly 10 totp/generate-secret)]
       (is (= 10 (count (set secrets)))))))
+
+;;; -------------------------------------------------- RFC Test Vectors --------------------------------------------------
+
+(def ^:private rfc4226-secret-b32
+  "Base32 encoding of the ASCII string \"12345678901234567890\" used in RFC 4226 Appendix D."
+  (.encodeToString (Base32.) (.getBytes "12345678901234567890" "ASCII")))
+
+(deftest rfc4226-appendix-d-test
+  (testing "HOTP codes match RFC 4226 Appendix D test vectors (secret = \"12345678901234567890\")"
+    (let [expected ["755224" "287082" "359152" "969429" "338314"
+                    "254676" "287922" "162583" "399871" "520489"]]
+      (doseq [[count expected-code] (map-indexed vector expected)]
+        (testing (str "count=" count)
+          (is (= expected-code (totp/totp-code rfc4226-secret-b32 count))))))))
+
+(deftest rfc6238-appendix-b-test
+  (testing "TOTP codes match RFC 6238 Appendix B test vectors for SHA1"
+    ;; RFC 6238 Appendix B test values (SHA1, 8-digit codes with T0=0 X=30)
+    ;; We use the 6-digit implementation so we verify the last 6 digits match
+    (let [test-cases [[59          "287082"]
+                      [1111111109  "081804"]
+                      [1111111111  "050471"]
+                      [1234567890  "005924"]
+                      [2000000000  "279037"]
+                      [20000000000 "353130"]]]
+      (doseq [[unix-time expected-6digit] test-cases]
+        (testing (str "time=" unix-time)
+          (let [step (quot unix-time 30)]
+            (is (= expected-6digit (totp/totp-code rfc4226-secret-b32 step)))))))))
 
 (deftest totp-code-test
   (testing "generates 6-digit codes"

--- a/test/metabase/auth_identity/totp_test.clj
+++ b/test/metabase/auth_identity/totp_test.clj
@@ -1,0 +1,89 @@
+(ns metabase.auth-identity.totp-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.auth-identity.totp :as totp]
+   [metabase.util.password :as u.password]))
+
+(set! *warn-on-reflection* true)
+
+(deftest generate-secret-test
+  (testing "generates a non-empty Base32 string"
+    (let [secret (totp/generate-secret)]
+      (is (string? secret))
+      (is (pos? (count secret)))
+      (is (re-matches #"[A-Z2-7=]+" secret))))
+
+  (testing "generates unique secrets"
+    (let [secrets (repeatedly 10 totp/generate-secret)]
+      (is (= 10 (count (set secrets)))))))
+
+(deftest totp-code-test
+  (testing "generates 6-digit codes"
+    (let [secret (totp/generate-secret)
+          code   (totp/totp-code secret 1000000)]
+      (is (string? code))
+      (is (= 6 (count code)))
+      (is (re-matches #"\d{6}" code))))
+
+  (testing "same secret + step produces same code"
+    (let [secret (totp/generate-secret)]
+      (is (= (totp/totp-code secret 12345)
+             (totp/totp-code secret 12345)))))
+
+  (testing "different steps produce different codes (most of the time)"
+    (let [secret (totp/generate-secret)
+          codes  (set (map #(totp/totp-code secret %) (range 100 110)))]
+      ;; At least 5 out of 10 should be different (collisions possible but rare)
+      (is (>= (count codes) 5)))))
+
+(deftest valid-code-test
+  (testing "accepts the current code"
+    (let [secret     (totp/generate-secret)
+          time-step  (quot (quot (System/currentTimeMillis) 1000) 30)
+          valid-code (totp/totp-code secret time-step)]
+      (is (true? (totp/valid-code? secret valid-code)))))
+
+  (testing "rejects an incorrect code"
+    (let [secret (totp/generate-secret)]
+      (is (false? (totp/valid-code? secret "000000")))
+      (is (false? (totp/valid-code? secret "123456"))))))
+
+(deftest generate-recovery-codes-test
+  (testing "generates the right number of codes"
+    (let [{:keys [plaintext hashed]} (totp/generate-recovery-codes)]
+      (is (= 10 (count plaintext)))
+      (is (= 10 (count hashed)))))
+
+  (testing "plaintext codes are 8-char alphanumeric"
+    (let [{:keys [plaintext]} (totp/generate-recovery-codes)]
+      (doseq [code plaintext]
+        (is (= 8 (count code)))
+        (is (re-matches #"[a-z0-9]+" code)))))
+
+  (testing "hashed codes are valid bcrypt hashes"
+    (let [{:keys [plaintext hashed]} (totp/generate-recovery-codes)]
+      (doseq [[plain hash] (map vector plaintext hashed)]
+        (is (u.password/bcrypt-verify plain hash))))))
+
+(deftest verify-recovery-code-test
+  (testing "verifies a valid recovery code and removes it"
+    (let [{:keys [plaintext hashed]} (totp/generate-recovery-codes)
+          code-to-use                (first plaintext)
+          {:keys [valid? remaining]} (totp/verify-recovery-code code-to-use hashed)]
+      (is (true? valid?))
+      (is (= 9 (count remaining)))))
+
+  (testing "rejects an invalid recovery code"
+    (let [{:keys [hashed]}           (totp/generate-recovery-codes)
+          {:keys [valid? remaining]} (totp/verify-recovery-code "invalidx" hashed)]
+      (is (false? valid?))
+      (is (= 10 (count remaining))))))
+
+(deftest otpauth-uri-test
+  (testing "builds a valid otpauth URI"
+    (let [uri (totp/otpauth-uri "JBSWY3DPEHPK3PXP" "user@example.com" "Metabase")]
+      (is (clojure.string/starts-with? uri "otpauth://totp/"))
+      (is (clojure.string/includes? uri "secret=JBSWY3DPEHPK3PXP"))
+      (is (clojure.string/includes? uri "issuer=Metabase"))
+      (is (clojure.string/includes? uri "digits=6"))
+      (is (clojure.string/includes? uri "period=30")))))

--- a/test/metabase/server/middleware/mfa_enforcement_test.clj
+++ b/test/metabase/server/middleware/mfa_enforcement_test.clj
@@ -2,8 +2,7 @@
   (:require
    [clojure.test :refer :all]
    [metabase.test :as mt]
-   [metabase.test.fixtures :as fixtures]
-   [toucan2.core :as t2]))
+   [metabase.test.fixtures :as fixtures]))
 
 (use-fixtures :once (fixtures/initialize :db :web-server :test-users))
 
@@ -39,8 +38,7 @@
       (mt/with-temp-vals-in-db :model/User (mt/user->id :rasta) {:sso_source "google"}
         (is (some? (mt/user-http-request :rasta :get 200 "card")))))
     (finally
-      (disable-require-mfa!)
-      (t2/update! :model/User (mt/user->id :rasta) {:sso_source nil}))))
+      (disable-require-mfa!))))
 
 (deftest enforcement-exempts-superusers-with-mfa-test
   (enable-require-mfa!)

--- a/test/metabase/server/middleware/mfa_enforcement_test.clj
+++ b/test/metabase/server/middleware/mfa_enforcement_test.clj
@@ -1,0 +1,52 @@
+(ns metabase.server.middleware.mfa-enforcement-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
+   [toucan2.core :as t2]))
+
+(use-fixtures :once (fixtures/initialize :db :web-server :test-users))
+
+(defn- enable-require-mfa!
+  "Enable the require-mfa setting for tests. Temporarily gives crowberto MFA so the setter validation passes."
+  []
+  (mt/with-temp-vals-in-db :model/User (mt/user->id :crowberto) {:totp_enabled true}
+    (mt/user-http-request :crowberto :put 204 "setting/require-mfa" {:value true})))
+
+(defn- disable-require-mfa! []
+  (mt/user-http-request :crowberto :put 204 "setting/require-mfa" {:value false}))
+
+(deftest enforcement-off-by-default-test
+  (testing "With require-mfa disabled, non-MFA users can access any endpoint"
+    (is (some? (mt/user-http-request :rasta :get 200 "user/current")))))
+
+(deftest enforcement-blocks-non-mfa-users-test
+  (enable-require-mfa!)
+  (try
+    (testing "Non-MFA password user gets 403 on non-allowlisted endpoint"
+      (let [response (mt/user-http-request :rasta :get 403 "card")]
+        (is (true? (:mfa-setup-required response)))))
+
+    (testing "Non-MFA password user can still access allowlisted endpoints"
+      (is (some? (mt/user-http-request :rasta :get 200 "user/current")))
+      (is (some? (mt/user-http-request :rasta :get 200 "session/properties"))))
+
+    (testing "User with MFA enabled is unaffected"
+      (mt/with-temp-vals-in-db :model/User (mt/user->id :rasta) {:totp_enabled true}
+        (is (some? (mt/user-http-request :rasta :get 200 "card")))))
+
+    (testing "SSO user (with sso_source) is exempt"
+      (mt/with-temp-vals-in-db :model/User (mt/user->id :rasta) {:sso_source "google"}
+        (is (some? (mt/user-http-request :rasta :get 200 "card")))))
+    (finally
+      (disable-require-mfa!)
+      (t2/update! :model/User (mt/user->id :rasta) {:sso_source nil}))))
+
+(deftest enforcement-exempts-superusers-with-mfa-test
+  (enable-require-mfa!)
+  (try
+    (testing "Superuser with MFA can access everything (crowberto still has MFA from enable)"
+      (mt/with-temp-vals-in-db :model/User (mt/user->id :crowberto) {:totp_enabled true}
+        (is (some? (mt/user-http-request :crowberto :get 200 "card")))))
+    (finally
+      (disable-require-mfa!))))

--- a/test/metabase/session/settings_test.clj
+++ b/test/metabase/session/settings_test.clj
@@ -3,8 +3,7 @@
    [clojure.test :refer :all]
    [metabase.session.settings :as session.settings]
    [metabase.test :as mt]
-   [metabase.test.fixtures :as fixtures]
-   [toucan2.core :as t2]))
+   [metabase.test.fixtures :as fixtures]))
 
 (use-fixtures :once (fixtures/initialize :db :web-server :test-users))
 
@@ -46,9 +45,8 @@
     (mt/with-fake-inbox
       (mt/with-temp-vals-in-db :model/User (mt/user->id :crowberto) {:totp_enabled true}
         (mt/with-temp-vals-in-db :model/User (mt/user->id :rasta) {:totp_enabled false, :sso_source nil}
-          (mt/user-http-request :crowberto :put 204 "setting/require-mfa" {:value true})
-          ;; Wait for the async future to complete
-          (Thread/sleep 2000)
+          (mt/with-expected-messages 1
+            (mt/user-http-request :crowberto :put 204 "setting/require-mfa" {:value true}))
           (let [inbox @mt/inbox]
             (testing "rasta (password user without MFA) receives email"
               (is (seq (get inbox (:email (mt/fetch-user :rasta))))))
@@ -61,19 +59,20 @@
       (mt/with-temp-vals-in-db :model/User (mt/user->id :crowberto) {:totp_enabled true}
         (mt/with-temp-vals-in-db :model/User (mt/user->id :rasta) {:totp_enabled false, :sso_source "google"}
           (mt/user-http-request :crowberto :put 204 "setting/require-mfa" {:value true})
-          (Thread/sleep 2000)
+          ;; Short sleep since we can't prove a negative with with-expected-messages
+          (Thread/sleep 1000)
           (let [inbox @mt/inbox]
             (testing "rasta (SSO user) does not receive email"
               (is (empty? (get inbox (:email (mt/fetch-user :rasta)))))))
-          (mt/user-http-request :crowberto :put 204 "setting/require-mfa" {:value false})))
-      (t2/update! :model/User (mt/user->id :rasta) {:sso_source nil})))
+          (mt/user-http-request :crowberto :put 204 "setting/require-mfa" {:value false})))))
 
   (testing "users with MFA already enabled do not receive email"
     (mt/with-fake-inbox
       (mt/with-temp-vals-in-db :model/User (mt/user->id :crowberto) {:totp_enabled true}
         (mt/with-temp-vals-in-db :model/User (mt/user->id :rasta) {:totp_enabled true}
           (mt/user-http-request :crowberto :put 204 "setting/require-mfa" {:value true})
-          (Thread/sleep 2000)
+          ;; Short sleep since we can't prove a negative with with-expected-messages
+          (Thread/sleep 1000)
           (let [inbox @mt/inbox]
             (testing "rasta (already has MFA) does not receive email"
               (is (empty? (get inbox (:email (mt/fetch-user :rasta)))))))

--- a/test/metabase/session/settings_test.clj
+++ b/test/metabase/session/settings_test.clj
@@ -3,7 +3,8 @@
    [clojure.test :refer :all]
    [metabase.session.settings :as session.settings]
    [metabase.test :as mt]
-   [metabase.test.fixtures :as fixtures]))
+   [metabase.test.fixtures :as fixtures]
+   [toucan2.core :as t2]))
 
 (use-fixtures :once (fixtures/initialize :db :web-server :test-users))
 
@@ -39,3 +40,41 @@
     ;; now disable it without MFA (should work — only enabling requires MFA)
     (mt/user-http-request :crowberto :put 204 "setting/require-mfa" {:value false})
     (is (false? (session.settings/require-mfa)))))
+
+(deftest require-mfa-email-notification-test
+  (testing "enabling require-mfa sends emails to affected password-auth users"
+    (mt/with-fake-inbox
+      (mt/with-temp-vals-in-db :model/User (mt/user->id :crowberto) {:totp_enabled true}
+        (mt/with-temp-vals-in-db :model/User (mt/user->id :rasta) {:totp_enabled false, :sso_source nil}
+          (mt/user-http-request :crowberto :put 204 "setting/require-mfa" {:value true})
+          ;; Wait for the async future to complete
+          (Thread/sleep 2000)
+          (let [inbox @mt/inbox]
+            (testing "rasta (password user without MFA) receives email"
+              (is (seq (get inbox (:email (mt/fetch-user :rasta))))))
+            (testing "email subject mentions two-factor authentication"
+              (is (mt/received-email-subject? :rasta #"Two-factor authentication"))))
+          (mt/user-http-request :crowberto :put 204 "setting/require-mfa" {:value false})))))
+
+  (testing "SSO users do not receive MFA required email"
+    (mt/with-fake-inbox
+      (mt/with-temp-vals-in-db :model/User (mt/user->id :crowberto) {:totp_enabled true}
+        (mt/with-temp-vals-in-db :model/User (mt/user->id :rasta) {:totp_enabled false, :sso_source "google"}
+          (mt/user-http-request :crowberto :put 204 "setting/require-mfa" {:value true})
+          (Thread/sleep 2000)
+          (let [inbox @mt/inbox]
+            (testing "rasta (SSO user) does not receive email"
+              (is (empty? (get inbox (:email (mt/fetch-user :rasta)))))))
+          (mt/user-http-request :crowberto :put 204 "setting/require-mfa" {:value false})))
+      (t2/update! :model/User (mt/user->id :rasta) {:sso_source nil})))
+
+  (testing "users with MFA already enabled do not receive email"
+    (mt/with-fake-inbox
+      (mt/with-temp-vals-in-db :model/User (mt/user->id :crowberto) {:totp_enabled true}
+        (mt/with-temp-vals-in-db :model/User (mt/user->id :rasta) {:totp_enabled true}
+          (mt/user-http-request :crowberto :put 204 "setting/require-mfa" {:value true})
+          (Thread/sleep 2000)
+          (let [inbox @mt/inbox]
+            (testing "rasta (already has MFA) does not receive email"
+              (is (empty? (get inbox (:email (mt/fetch-user :rasta)))))))
+          (mt/user-http-request :crowberto :put 204 "setting/require-mfa" {:value false}))))))

--- a/test/metabase/session/settings_test.clj
+++ b/test/metabase/session/settings_test.clj
@@ -1,0 +1,41 @@
+(ns metabase.session.settings-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.session.settings :as session.settings]
+   [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]))
+
+(use-fixtures :once (fixtures/initialize :db :web-server :test-users))
+
+(deftest require-mfa-setting-test
+  (testing "require-mfa defaults to false"
+    (is (false? (session.settings/require-mfa))))
+
+  (testing "require-mfa is readable via session properties (public visibility)"
+    (let [props (mt/client :get 200 "session/properties")]
+      (is (contains? props :require-mfa))
+      (is (false? (:require-mfa props))))))
+
+(deftest require-mfa-admin-only-write-test
+  (testing "non-admin cannot update require-mfa"
+    (mt/user-http-request :rasta :put 403 "setting/require-mfa" {:value true})))
+
+(deftest require-mfa-admin-must-have-mfa-test
+  (testing "admin without MFA cannot enable require-mfa"
+    (mt/user-http-request :crowberto :put 400 "setting/require-mfa" {:value true}))
+
+  (testing "admin with MFA can enable require-mfa"
+    (mt/with-temp-vals-in-db :model/User (mt/user->id :crowberto) {:totp_enabled true}
+      (mt/user-http-request :crowberto :put 204 "setting/require-mfa" {:value true})
+      (is (true? (session.settings/require-mfa)))
+      ;; cleanup: disable the setting while admin still has MFA
+      (mt/user-http-request :crowberto :put 204 "setting/require-mfa" {:value false}))))
+
+(deftest require-mfa-disable-test
+  (testing "admin can disable require-mfa without needing MFA themselves"
+    ;; first enable it while admin has MFA
+    (mt/with-temp-vals-in-db :model/User (mt/user->id :crowberto) {:totp_enabled true}
+      (mt/user-http-request :crowberto :put 204 "setting/require-mfa" {:value true}))
+    ;; now disable it without MFA (should work — only enabling requires MFA)
+    (mt/user-http-request :crowberto :put 204 "setting/require-mfa" {:value false})
+    (is (false? (session.settings/require-mfa)))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/3729

### Description

Adds TOTP-based multi-factor authentication to Metabase with both opt-in per-user enrollment and an admin-enforced "require MFA for all users" mode.

I've used Claude Code heavily in implementing this after thorough planning, and have tested and oppositionally reviewed it extensively. In the before times I've implemented this by hand in other applications but under different stacks. I understand though that this is a big PR and being related to security will require a high bar be passed, and very much appreciate any time folks are willing to contribute towards reviewing.

This will be an extremely high-value feature for the community though, as password authentication with no 2FA presents a massive risk being the only thing between attackers and access to a user's data warehouse. I believe it is in Metabase's best interest to merge this or some derivative of it to quell any market perceptions that Metabase in insecure. Further, I don't see this as impacting Metabase' business model as comprehensive IdP integration is still a must-have for enterprise users that merely adding TOTP for password users does not address.

**Core MFA (opt-in):**
- TOTP secret generation, QR code enrollment, and 6-digit code verification (RFC 6238, HMAC-SHA1, 30s windows with ±1 clock skew tolerance)
- 10 single-use bcrypt-hashed recovery codes with `SELECT FOR UPDATE` to prevent race conditions
- Short-lived single-use JWT MFA tokens (5-min TTL, jti-based replay prevention) for the two-step login flow
- Login flow: `POST /session` returns `{mfa_required, mfa_token}` → `POST /session/mfa-verify` with TOTP or recovery code → real session
- Account security page at `/account/security` for self-service setup, disable, and recovery code regeneration (all password-confirmed)
- MFA signing key derived from `MB_ENCRYPTION_SECRET_KEY` for multi-instance portability

**Admin-enforced MFA:**
- New `require-mfa` boolean setting (public visibility, superadmin-only write) — admin must have MFA on their own account before enabling
- Backend Ring middleware hard-locks non-MFA password-auth users out of all API endpoints except an allowlist (MFA setup, confirm, logout, current user, session properties)
- `totp_enabled` and `sso_source` added to the per-request session query (no extra DB hit)
- Frontend `UserHasMfaIfRequired` route guard redirects to `/mfa/setup-required` — a standalone page (no navbar) with the MFA setup flow
- SSO users and API key requests are exempt
- Users cannot disable MFA while it's admin-required
- MFA status column in the admin people list (conditionally visible when require-mfa is on)
- MFA toggle card in admin authentication settings with pre-validation UX
- Email notification sent asynchronously to affected users when the requirement is first enabled (uses `requiring-resolve` to avoid cyclic dependency with `channel.email.messages`)

### How to verify

**Opt-in MFA:**
1. Go to Account → Security (`/account/security`)
2. Enter password, click "Enable two-factor authentication"
3. Scan QR code with authenticator app, enter 6-digit code to confirm
4. Log out and log back in — should be prompted for MFA code
5. Try a recovery code — should work and be consumed

**Admin-enforced MFA:**
1. As an admin with MFA enabled, go to Admin → Authentication
2. Toggle "Two-factor authentication" on
3. Log in as a regular password user — should be redirected to `/mfa/setup-required` (no sidebar)
4. Complete MFA setup — should redirect to home cleanly
5. Verify SSO users are not affected
6. Verify the admin people list shows an MFA status column

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
