### PR TITLE
Manual Backport: Fix SSO docs link in embedding hub

### DIFF
--- a/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHub.unit.spec.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/EmbeddingHub.unit.spec.tsx
@@ -138,7 +138,7 @@ describe("EmbeddingHub", () => {
 
     expect(configureSsoLink).toHaveAttribute(
       "href",
-      "https://www.metabase.com/docs/latest/embedding/embedded-analytics-js.html?utm_source=product&utm_medium=docs&utm_campaign=embedding_hub&utm_content=secure-embeds&source_plan=oss#set-up-sso",
+      "https://www.metabase.com/docs/latest/embedding/authentication.html?utm_source=product&utm_medium=docs&utm_campaign=embedding_hub&utm_content=secure-embeds&source_plan=oss#setting-up-jwt-sso",
     );
   });
 

--- a/frontend/src/metabase/embedding/embedding-hub/hooks/use-get-embedding-hub-steps.ts
+++ b/frontend/src/metabase/embedding/embedding-hub/hooks/use-get-embedding-hub-steps.ts
@@ -112,8 +112,8 @@ export const useGetEmbeddingHubSteps = (): EmbeddingHubStep[] => {
         {
           title: t`Configure SSO`,
           description: t`Configure JWT or SAML authentication to ensure only authorized users can access your embeds.`,
-          docsPath: "embedding/embedded-analytics-js",
-          anchor: "set-up-sso",
+          docsPath: "embedding/authentication",
+          anchor: "setting-up-jwt-sso",
           variant: "outline",
           stepId: "secure-embeds",
         },


### PR DESCRIPTION
Closes EMB-1389

## Summary
- Manual Backport of #70423 to `release-x.59.x`. It no longer applies to master because of the Embedding Hub onboarding improvements, so it can only be manually backported.
- Fixes the "Configure SSO" link in the embedding hub getting started page pointing to the wrong docs page
- Changes `docsPath` from `embedding/embedded-analytics-js` to `embedding/authentication` and `anchor` from `set-up-sso` to `setting-up-jwt-sso`

## Test plan
- [ ] Verify the SSO link in the embedding hub points to the correct authentication docs page

🤖 Generated with [Claude Code](https://claude.com/claude-code)