### PR TITLE
add ability to hide Our analytics in MiniPicker and hide it in the table picker in the embedding setup

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
@@ -898,6 +898,9 @@ describe("scenarios - embedding hub", () => {
       cy.log("pick first table and column");
       H.main().findByText("Pick a table").click();
 
+      cy.log("Our analytics should be hidden in the table picker");
+      H.miniPicker().findByText("Our analytics").should("not.exist");
+
       H.miniPicker().findByText("Sample Database").click();
       H.miniPicker().findByText("Orders").click();
 

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx
@@ -36,6 +36,7 @@ import type {
   MiniPickerSchemaItem,
   MiniPickerTableItem,
 } from "../types";
+import { getOurAnalytics } from "../utils";
 
 import { MiniPickerItem } from "./MiniPickerItem";
 import styles from "./MiniPickerItem.module.css";
@@ -132,20 +133,22 @@ function RootItemList() {
           }}
         />
       )) ?? <MiniPickerListLoader />}
-      <MiniPickerItem
-        name={rootCollectionError ? t`Collections` : t`Our analytics`}
-        model="collection"
-        isFolder
-        onClick={() => {
-          setPath([
-            {
-              model: "collection",
-              id: "root" as any, // cmon typescript, trust me
-              name: rootCollectionError ? t`Collections` : t`Our analytics`,
-            },
-          ]);
-        }}
-      />
+      {!isHidden(getOurAnalytics()) && (
+        <MiniPickerItem
+          name={rootCollectionError ? t`Collections` : t`Our analytics`}
+          model="collection"
+          isFolder
+          onClick={() => {
+            setPath([
+              {
+                model: "collection",
+                id: "root" as any, // cmon typescript, trust me
+                name: rootCollectionError ? t`Collections` : t`Our analytics`,
+              },
+            ]);
+          }}
+        />
+      )}
     </ItemList>
   );
 }

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/utils.ts
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/utils.ts
@@ -22,8 +22,18 @@ export const getOurAnalytics = (): MiniPickerFolderItem => ({
   model: "collection",
   id: "root" as any, // cmon typescript
   name: t`Our analytics`,
-  here: ["card", "dataset", "metric"],
-  below: ["card", "dataset", "metric"],
+  here: ["collection"],
+  below: [
+    "collection",
+    "dashboard",
+    "document",
+    "card",
+    "dataset",
+    "metric",
+    "table",
+    "snippet",
+    "transform",
+  ],
 });
 
 export function useGetPathFromValue({

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/utils.ts
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/utils.ts
@@ -22,8 +22,8 @@ export const getOurAnalytics = (): MiniPickerFolderItem => ({
   model: "collection",
   id: "root" as any, // cmon typescript
   name: t`Our analytics`,
-  here: ["card"],
-  below: ["card"],
+  here: ["card", "dataset", "metric"],
+  below: ["card", "dataset", "metric"],
 });
 
 export function useGetPathFromValue({

--- a/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/RlsDataSelector/TableColumnCard.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/RlsDataSelector/TableColumnCard.tsx
@@ -106,10 +106,16 @@ export const TableColumnCard = ({
     ? { model: "table" as const, id: selection.tableId }
     : undefined;
 
-  // Hide tables that are already selected in other cards
   const shouldHidePickerItem = useCallback(
-    (pickerItem: MiniPickerItem | OmniPickerItem) =>
-      pickerItem.model === "table" && selectedTableIds.includes(pickerItem.id),
+    (pickerItem: MiniPickerItem | OmniPickerItem) => {
+      const isAlreadySelected =
+        pickerItem.model === "table" &&
+        selectedTableIds.includes(pickerItem.id);
+      const isOurAnalytics =
+        pickerItem.model === "collection" && pickerItem.id === "root";
+
+      return isAlreadySelected || isOurAnalytics;
+    },
     [selectedTableIds],
   );
 

--- a/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/RlsDataSelector/TableColumnCard.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/RlsDataSelector/TableColumnCard.tsx
@@ -106,16 +106,10 @@ export const TableColumnCard = ({
     ? { model: "table" as const, id: selection.tableId }
     : undefined;
 
+  // Hide tables that are already selected in other cards
   const shouldHidePickerItem = useCallback(
-    (pickerItem: MiniPickerItem | OmniPickerItem) => {
-      const isOurAnalytics =
-        pickerItem.model === "collection" && pickerItem.id === "root";
-      const isAlreadySelectedTable =
-        pickerItem.model === "table" &&
-        selectedTableIds.includes(pickerItem.id);
-
-      return isOurAnalytics || isAlreadySelectedTable;
-    },
+    (pickerItem: MiniPickerItem | OmniPickerItem) =>
+      pickerItem.model === "table" && selectedTableIds.includes(pickerItem.id),
     [selectedTableIds],
   );
 

--- a/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/RlsDataSelector/TableColumnCard.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/RlsDataSelector/TableColumnCard.tsx
@@ -106,10 +106,16 @@ export const TableColumnCard = ({
     ? { model: "table" as const, id: selection.tableId }
     : undefined;
 
-  // Hide tables that are already selected in other cards
   const shouldHidePickerItem = useCallback(
-    (pickerItem: MiniPickerItem | OmniPickerItem) =>
-      pickerItem.model === "table" && selectedTableIds.includes(pickerItem.id),
+    (pickerItem: MiniPickerItem | OmniPickerItem) => {
+      const isOurAnalytics =
+        pickerItem.model === "collection" && pickerItem.id === "root";
+      const isAlreadySelectedTable =
+        pickerItem.model === "table" &&
+        selectedTableIds.includes(pickerItem.id);
+
+      return isOurAnalytics || isAlreadySelectedTable;
+    },
     [selectedTableIds],
   );
 


### PR DESCRIPTION

Closes [EMB-1415: Investigate if it is possible to hide collections in the MiniPicker in embedding onboarding step](https://linear.app/metabase/issue/EMB-1415/investigate-if-it-is-possible-to-hide-collections-in-the-minipicker-in)

### Description

Adds the possibility to hide `Our Analytics` in `MiniPicker`.
I also changed the definition of `getOurAnalytics` to be the same as the one used in `EntityPicker`, which [is more accurate according to Ryan](https://metaboat.slack.com/archives/C0AESD9100H/p1773955266946939?thread_ts=1773929460.394509&cid=C0AESD9100H)

### How to verify

- Go to the embedding setup
- reach the step 4
- enable tenants
- configure RLS
- verify that in the mini picker as part of "Select data to make available" "Our analytics" doesn't show up


### Demo

<img width="794" height="1175" alt="image" src="https://github.com/user-attachments/assets/1816e2cc-8d8c-459b-8752-8076e130f3d9" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
