### PR TITLE
untgz: use resolveIn to prevent zip slip

### DIFF
--- a/src/metabase/util/compress.clj
+++ b/src/metabase/util/compress.clj
@@ -47,13 +47,14 @@
   (with-open [tar (-> (io/input-stream archive)
                       (GzipCompressorInputStream.)
                       (TarArchiveInputStream.))]
-    (let [tar-entries (entries tar)]
+    (let [tar-entries (entries tar)
+          dst-path    (.toPath dst)]
       (count
        (for [^TarArchiveEntry e tar-entries
              :let [actual-name (last (.split (.getName e) "/"))]
              ;; skip hidden files
              :when (not (str/starts-with? actual-name "."))]
-         (let [f (io/file dst (.getName e))]
+         (let [f (.toFile (.resolveIn e dst-path))]
            (if (.isFile e)
              (io/copy tar f)
              (.mkdirs f))

--- a/test/metabase/util/compress_test.clj
+++ b/test/metabase/util/compress_test.clj
@@ -6,7 +6,9 @@
    [metabase.util.compress :as u.compress])
   (:import
    (java.io File)
-   (java.nio.file Files)))
+   (java.nio.file Files)
+   (org.apache.commons.compress.archivers.tar TarArchiveEntry TarArchiveOutputStream)
+   (org.apache.commons.compress.compressors.gzip GzipCompressorOutputStream)))
 
 (set! *warn-on-reflection* true)
 
@@ -38,3 +40,31 @@
           (when (.exists archive)
             (io/delete-file archive))
           (run! io/delete-file (reverse (file-seq out))))))))
+
+(defn- create-tgz
+  "Create a tar.gz archive."
+  ^File [entry-name ^bytes content]
+  (let [archive (File/createTempFile "archive" ".tar.gz")]
+    (with-open [tar (-> (io/output-stream archive)
+                        (GzipCompressorOutputStream.)
+                        (TarArchiveOutputStream. 512 "UTF-8"))]
+      (let [entry (doto (TarArchiveEntry. ^String entry-name)
+                    (.setSize (alength content)))]
+        (.putArchiveEntry tar entry)
+        (.write tar content)
+        (.closeArchiveEntry tar)))
+    archive))
+
+(deftest untgz-path-traversal-test
+  (testing "untgz rejects tar entries with path traversal"
+    (let [content (.getBytes "content" "UTF-8")
+          out     (doto (io/file (System/getProperty "java.io.tmpdir") (mt/random-name))
+                    .mkdirs)]
+      (doseq [file-name ["../../etc/foo" "../escape" "foo/../../escape"]]
+        (let [archive (create-tgz file-name content)]
+          (try
+            (is (thrown? java.io.IOException
+                         (u.compress/untgz archive out)))
+            (finally
+              (io/delete-file archive true)
+              (run! #(io/delete-file % true) (reverse (file-seq out))))))))))


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-1935/serialization-import-untgz-path-traversal-writes-files-outside-temp