### PR TITLE
Track OSS transform usage in Snowplow

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/analytics/stats.clj
+++ b/enterprise/backend/src/metabase_enterprise/analytics/stats.clj
@@ -1,6 +1,5 @@
 (ns metabase-enterprise.analytics.stats
   (:require
-   [java-time.api :as t]
    [metabase-enterprise.advanced-config.settings :as advanced-config.settings]
    [metabase-enterprise.scim.core :as scim]
    [metabase-enterprise.semantic-search.core :as semantic-search]
@@ -36,12 +35,3 @@
    {:name      :semantic-search
     :available (premium-features/enable-semantic-search?)
     :enabled   (semantic-search/supported?)}])
-
-(defenterprise ee-transform-metrics
-  "Returns transform usage metrics for the Snowplow stats ping."
-  :feature :none
-  []
-  (let [one-day-ago (t/minus (t/offset-date-time) (t/days 1))]
-    {:transforms               (t2/count :model/Transform)
-     :transform_runs_last_24h  (t2/count :model/TransformRun
-                                         :start_time [:>= one-day-ago])}))

--- a/enterprise/backend/test/metabase_enterprise/analytics/stats_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/analytics/stats_test.clj
@@ -1,12 +1,10 @@
 (ns metabase-enterprise.analytics.stats-test
   (:require
    [clojure.test :refer :all]
-   [java-time.api :as t]
    [metabase-enterprise.analytics.stats :as ee-stats]
    [metabase-enterprise.audit-app.audit :as ee-audit]
    [metabase.analytics.stats :as stats]
    [metabase.app-db.core :as mdb]
-   [metabase.lib.core :as lib]
    [metabase.test :as mt]
    [toucan2.core :as t2]))
 
@@ -38,29 +36,3 @@
                 :public             {}
                 :embedded           {}}
                (#'stats/dashboard-metrics)))))))
-
-(deftest ee-transform-metrics-test
-  (mt/with-temp-empty-app-db [_conn :h2]
-    (mdb/setup-db! :create-sample-content? false)
-    (testing "with no transforms"
-      (is (=? {:transforms 0 :transform_runs_last_24h 0}
-              (ee-stats/ee-transform-metrics))))
-    (testing "with transforms"
-      (mt/with-temp [:model/Transform transform {:target {:database (mt/id)
-                                                          :table "test_table"}
-                                                 :name "Test SQL transform"
-                                                 :source {:type "query"
-                                                          :query (lib/native-query (mt/metadata-provider) "SELECT 1")}}
-                     :model/TransformRun _ {:start_time (t/minus (t/offset-date-time) (t/hours 1))
-                                            :transform_id (:id transform)}]
-        (is (=? {:transforms 1 :transform_runs_last_24h 1}
-                (ee-stats/ee-transform-metrics))))
-      (testing "with old transform runs"
-        (mt/with-temp [:model/Transform transform {:target {:database (mt/id)
-                                                            :table "test_table"}
-                                                   :name "Test SQL transform"
-                                                   :source {:type "query"
-                                                            :query (lib/native-query (mt/metadata-provider) "SELECT 1")}}
-                       :model/TransformRun _ {:start_time (t/minus (t/offset-date-time) (t/hours 25))
-                                              :transform_id (:id transform)}]
-          (is (zero? (:transform_runs_last_24h (ee-stats/ee-transform-metrics)))))))))

--- a/src/metabase/analytics/stats.clj
+++ b/src/metabase/analytics/stats.clj
@@ -673,17 +673,13 @@
      :values (mapv (fn [[k v]] {:group k :value v}) eid-translations-24h)
      :tags ["embedding"]}]))
 
-(defn- ee-transform-metrics'
-  "OSS fallback for transform metrics. Returns zeros since transforms are an enterprise feature."
-  []
-  {:transforms               0
-   :transform_runs_last_24h  0})
-
-(defenterprise ee-transform-metrics
+(defn- transform-metrics
   "Returns transform usage metrics for the Snowplow stats ping."
-  metabase-enterprise.analytics.stats
   []
-  (ee-transform-metrics'))
+  (let [one-day-ago (->one-day-ago)]
+    {:transforms               (t2/count :model/Transform)
+     :transform_runs_last_24h  (t2/count :model/TransformRun
+                                         :start_time [:>= one-day-ago])}))
 
 (defn- ->snowplow-metric-info
   "Collects Snowplow metrics data that is not in the legacy stats format. Also clears entity id translation count."
@@ -705,7 +701,7 @@
       :scim_users_last_24h             (t2/count :model/User :sso_source :scim
                                                  :is_active true
                                                  :date_joined [:>= one-day-ago])}
-     (ee-transform-metrics))))
+     (transform-metrics))))
 
 (mu/defn- snowplow-metrics
   [stats metric-info :- [:map

--- a/test/metabase/analytics/stats_test.clj
+++ b/test/metabase/analytics/stats_test.clj
@@ -10,6 +10,7 @@
    [metabase.channel.settings :as channel.settings]
    [metabase.config.core :as config]
    [metabase.core.core :as mbc]
+   [metabase.lib.core :as lib]
    [metabase.premium-features.settings :as premium-features.settings]
    [metabase.query-processor.util :as qp.util]
    [metabase.test :as mt]
@@ -706,7 +707,26 @@
                (#'stats/library-stats)))))))
 
 (deftest transform-metrics-test
-  (testing "ee-transform-metrics should return zeros for OSS"
-    (mt/with-empty-h2-app-db!
-      (is (= {:transforms 0, :transform_runs_last_24h 0}
-             (stats/ee-transform-metrics))))))
+  (mt/with-empty-h2-app-db!
+    (testing "with no transforms"
+      (is (=? {:transforms 0 :transform_runs_last_24h 0}
+              (#'stats/transform-metrics))))
+    (testing "with transforms and recent runs"
+      (mt/with-temp [:model/Transform transform {:target {:database (mt/id)
+                                                          :table "test_table"}
+                                                 :name "Test SQL transform"
+                                                 :source {:type "query"
+                                                          :query (lib/native-query (mt/metadata-provider) "SELECT 1")}}
+                     :model/TransformRun _ {:start_time (t/minus (t/offset-date-time) (t/hours 1))
+                                            :transform_id (:id transform)}]
+        (is (=? {:transforms 1 :transform_runs_last_24h 1}
+                (#'stats/transform-metrics)))))
+    (testing "with old transform runs"
+      (mt/with-temp [:model/Transform transform {:target {:database (mt/id)
+                                                          :table "test_table"}
+                                                 :name "Test SQL transform"
+                                                 :source {:type "query"
+                                                          :query (lib/native-query (mt/metadata-provider) "SELECT 1")}}
+                     :model/TransformRun _ {:start_time (t/minus (t/offset-date-time) (t/hours 25))
+                                            :transform_id (:id transform)}]
+        (is (zero? (:transform_runs_last_24h (#'stats/transform-metrics))))))))


### PR DESCRIPTION
Since transforms were moved from EE to OSS, snowplow metrics were not ported. This includes them in OSS 

Closes https://linear.app/metabase/issue/GDGT-2004/track-oss-transform-usage-in-snowplow