### PR TITLE
Skip running transform jobs if there are no transforms to run

### DIFF
--- a/src/metabase/transforms/jobs.clj
+++ b/src/metabase/transforms/jobs.clj
@@ -238,35 +238,36 @@
   (if (transforms.job-run/running-run-for-job-id job-id)
     (log/info "Not executing transform job" (pr-str job-id) "because it is already running")
     (let [transforms (job-transform-ids job-id)]
-      (log/info "Executing transform job" (pr-str job-id) "with transforms" (pr-str transforms))
-      (let [{run-id :id} (transforms.job-run/start-run! job-id run-method)]
-        (tracing/with-span :tasks "task.transform.run-job" {:transform.job/id         job-id
-                                                            :transform.job/run-method (name run-method)
-                                                            :transform.job/count      (count transforms)}
-          (transforms.instrumentation/with-job-timing [job-id run-method]
-            (try ;; catch any catastrophic problems
-              (let [result (run-transforms! run-id transforms opts)]
-                (case (::status result)
-                  :succeeded (transforms.job-run/succeed-started-run! run-id)
-                  :failed (try
-                            (transforms.job-run/fail-started-run! run-id {:message (compile-transform-failure-messages (::failures result))})
-                            (when (= :cron run-method)
-                              (notify-transform-failures job-id (::failures result)))
-                            (catch Exception e
-                              (log/error e "Error when failing a transform run.")))))
-              (catch Throwable t
-                ;; We don't expect a catastrophic failure, but neither did the Titanic.
-                ;; We should clean up in this case and notify the admin users.
-                (try
-                  (transforms.job-run/fail-started-run! run-id {:message (.getMessage t)})
-                  (when (= :cron run-method)
-                    (if (::transform-failure (ex-data t))
-                      (notify-transform-failures job-id (::failures (ex-data t)))
-                      (notify-job-failure job-id (.getMessage t))))
-                  (catch Exception e
-                    (log/error e "Error when failing a transform job run.")))
-                (throw t)))))
-        run-id))))
+      (if (empty? transforms)
+        (log/info "Skipping transform job" (pr-str job-id) "because it has no transforms to run")
+        (let [{run-id :id} (transforms.job-run/start-run! job-id run-method)]
+          (tracing/with-span :tasks "task.transform.run-job" {:transform.job/id         job-id
+                                                              :transform.job/run-method (name run-method)
+                                                              :transform.job/count      (count transforms)}
+            (transforms.instrumentation/with-job-timing [job-id run-method]
+              (try ;; catch any catastrophic problems
+                (let [result (run-transforms! run-id transforms opts)]
+                  (case (::status result)
+                    :succeeded (transforms.job-run/succeed-started-run! run-id)
+                    :failed (try
+                              (transforms.job-run/fail-started-run! run-id {:message (compile-transform-failure-messages (::failures result))})
+                              (when (= :cron run-method)
+                                (notify-transform-failures job-id (::failures result)))
+                              (catch Exception e
+                                (log/error e "Error when failing a transform run.")))))
+                (catch Throwable t
+                  ;; We don't expect a catastrophic failure, but neither did the Titanic.
+                  ;; We should clean up in this case and notify the admin users.
+                  (try
+                    (transforms.job-run/fail-started-run! run-id {:message (.getMessage t)})
+                    (when (= :cron run-method)
+                      (if (::transform-failure (ex-data t))
+                        (notify-transform-failures job-id (::failures (ex-data t)))
+                        (notify-job-failure job-id (.getMessage t))))
+                    (catch Exception e
+                      (log/error e "Error when failing a transform job run.")))
+                  (throw t)))))
+          run-id)))))
 
 (def ^:private job-key "metabase.transforms.jobs.timeout-job")
 

--- a/test/metabase/transforms/jobs_test.clj
+++ b/test/metabase/transforms/jobs_test.clj
@@ -93,6 +93,15 @@
     (mt/with-temp [:model/TransformJob job {:name "job-5" :schedule "0 0 * * * ? *"}]
       (is (= #{} (#'jobs/job-transform-ids (:id job)))))))
 
+(deftest run-job-skips-empty-transforms-test
+  (testing "run-job! returns nil and creates no job run when there are no transforms to execute"
+    (mt/with-temp [:model/TransformTag tag {:name "empty-tag"}
+                   :model/TransformJob job {:name "empty-job" :schedule "0 0 * * * ? *"}
+                   :model/TransformJobTransformTag _ {:job_id (:id job) :tag_id (:id tag) :position 0}]
+      (let [result (jobs/run-job! (:id job) {:run-method :cron})]
+        (is (nil? result))
+        (is (= 0 (t2/count :model/TransformJobRun :job_id (:id job))))))))
+
 (deftest next-transform-test
   (let [ordering {1 #{2 3}
                   2 #{3 4}


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-2005/only-run-transform-jobs-when-transforms-are-associated