### PR TITLE
Fix trend visualizations that rely on aggregated datetimes

### DIFF
--- a/src/metabase/analyze/fingerprint/insights.clj
+++ b/src/metabase/analyze/fingerprint/insights.clj
@@ -288,6 +288,16 @@
       (format "Error generating timeseries insight keyed by: %s"
               (sync-util/name-for-logging (mi/instance :model/Field datetime))))))
 
+(defn- resolve-agg-datetimes
+  "If no breakout datetime exists, we use aggregated datetimes as :datetimes
+   Otherwise, move them to :others"
+  [{:keys [agg-datetimes datetimes] :as cols-by-type}]
+  (cond-> (dissoc cols-by-type :agg-datetimes)
+    (and (seq agg-datetimes) (empty? datetimes))
+    (assoc :datetimes agg-datetimes)
+    (and (seq agg-datetimes) (seq datetimes))
+    (update :others into agg-datetimes)))
+
 (defn insights
   "Based on the shape of returned data construct a transducer to statistically analyze data."
   [cols]
@@ -302,9 +312,7 @@
                                           lib-source     :lib/source
                                           lib-breakout?  :lib/breakout?}]
                                       (cond
-                                        ;; Only count datetime columns from breakouts/dimensions, not aggregations
-                                        ;; Aggregations of datetime values (like max(created_at)) are computed values,
-                                        ;; not datetime dimensions for the X-axis (#62069)
+                                        ;; Prefer datetime columns from breakouts, not aggregations (#62069)
                                         ;; Datetime columns with FK/PK semantic types should still be recognized as
                                         ;; datetimes for timeseries insights (#35281)
                                         (and
@@ -316,13 +324,24 @@
                                                   (not (= lib-source :source/aggregations)))))
                                         :datetimes
 
+                                        ;; Aggregated datetimes (like max(created_at)) are tracked separately so
+                                        ;; they can be used as a fallback when no breakout datetime exists (#70613)
+                                        (and
+                                         (or (u.date/truncate-units unit)
+                                             (isa? (or effective-type base-type) :type/Temporal))
+                                         (or (= source :aggregation)
+                                             (= lib-source :source/aggregations)))
+                                        :agg-datetimes
+
                                         (u.date/extract-units unit) :numbers
                                         ;; Don't treat numeric FK/PK columns as numbers - they are identifiers, not
                                         ;; values to compute insights over
                                         (and (isa? base-type :type/Number)
                                              (not (isa? semantic-type :Relation/*)))
                                         :numbers
-                                        :else :others))))]
+                                        :else :others)))
+                          (resolve-agg-datetimes))]
+
     (cond
       (timeseries? cols-by-type) (timeseries-insight cols-by-type)
       :else (fingerprinters/constant-fingerprinter nil))))

--- a/test/metabase/analyze/fingerprint/insights_test.clj
+++ b/test/metabase/analyze/fingerprint/insights_test.clj
@@ -251,7 +251,18 @@
                                            :effective_type :type/DateTime
                                            :source :aggregation}])
                       [["2024-08-09" 10.0 "2024-08-01"]
-                       ["2024-08-10" 20.0 "2024-08-02"]]))))))
+                       ["2024-08-10" 20.0 "2024-08-02"]]))))
+    (testing "Aggregated datetime should be used as fallback when no breakout datetime exists"
+      (is (some?
+           (transduce identity
+                      (insights/insights [{:base_type :type/Boolean
+                                           :source :breakout}
+                                          {:base_type :type/DateTime
+                                           :source :aggregation}
+                                          {:base_type :type/Number
+                                           :source :aggregation}])
+                      [[false "2024-08-09" 10.0]
+                       [true "2024-08-10" 20.0]]))))))
 
 (deftest ^:parallel timeseries-with-relation-semantic-type-test
   (testing "A datetime column with Entity Key or Foreign Key semantic type should still work for timeseries (#35281)"


### PR DESCRIPTION
Closes #70613

### Description

#65873 removed datetime aggregations from consideration in insights, fixing #62069. However, this caused #70613, where the trend viz relied on the datetime aggregation to work correctly.

This PR fixes the issue by using datetime aggregations as a fallback only used if no datetime breakouts are available. This fixes #70613 while preventing a regression of #62069.

### How to verify

Follow the steps in #70613. Verify that the trend visualization appears as expected and as it used to in v56.

Follow the steps in #62069. Verify that you can still add a trend line after adding a datetime aggregation.

### Demo

After:
<img width="1507" height="704" alt="image" src="https://github.com/user-attachments/assets/e1f92160-a54e-42d2-8555-75f88a1bfb3e" />

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
