### PR TITLE
Update TablePicker when users publish/unpublish tables, change name

### DIFF
--- a/e2e/test/scenarios/data-studio/data-model/data-studio-single-table.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-model/data-studio-single-table.cy.spec.ts
@@ -75,10 +75,16 @@ describe("Table editing", () => {
       TablePicker.getTable("Orders").click();
 
       cy.log("publish the table and verify it's published");
+      TablePicker.getTable("Orders")
+        .findByTestId("table-published")
+        .should("not.exist");
       cy.findByRole("button", { name: /Publish/ }).click();
       H.modal().findByText("Create my Library").click();
       H.modal().findByText("Publish this table").click();
       cy.wait("@publishTables");
+      TablePicker.getTable("Orders")
+        .findByTestId("table-published")
+        .should("be.visible");
       H.undoToastListContainer().within(() => {
         cy.findByText("Published").should("be.visible");
         cy.findByRole("button", { name: /Go to Data/ }).click();
@@ -93,6 +99,9 @@ describe("Table editing", () => {
       cy.findByRole("button", { name: /Unpublish/ }).click();
       H.modal().findByText("Unpublish this table").click();
       cy.wait("@unpublishTables");
+      TablePicker.getTable("Orders")
+        .findByTestId("table-published")
+        .should("not.exist");
       H.DataStudio.nav().findByLabelText("Library").click();
       H.DataStudio.Library.allTableItems().should("have.length", 0);
     },
@@ -104,6 +113,14 @@ describe("Table editing", () => {
     H.DataModel.visitDataStudio();
     TablePicker.getDatabase("QA Postgres12").click();
     TablePicker.getTable("Orders").click();
+
+    cy.log("rename the table and verify the name is updated in the picker");
+    H.DataModel.TableSection.getNameInput()
+      .clear()
+      .type("Renamed Orders")
+      .blur();
+    cy.wait("@updateTable");
+    TablePicker.getTable("Renamed Orders").should("be.visible");
 
     H.selectHasValue("Owner", "No owner").click();
     H.selectDropdown().contains("Bobby Tables").click();
@@ -131,7 +148,7 @@ describe("Table editing", () => {
 
     // navigate away and back
     TablePicker.getTable("Products").click();
-    TablePicker.getTable("Orders").click();
+    TablePicker.getTable("Renamed Orders").click();
 
     H.selectHasValue("Owner", "Bobby Tables");
     H.selectHasValue("Visibility layer", "Final");

--- a/e2e/test/scenarios/data-studio/data-model/data-studio-single-table.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-model/data-studio-single-table.cy.spec.ts
@@ -192,4 +192,46 @@ describe("Table editing", () => {
       });
     },
   );
+
+  describe("with remote sync enabled", () => {
+    it(
+      "should update the tree after publishing, unpublishing, and renaming a table (metabase#69554)",
+      { tags: ["@external"] },
+      () => {
+        H.restore("mysql-8");
+        H.activateToken("bleeding-edge");
+        H.setupGitSync();
+        H.configureGit("read-write");
+
+        H.DataModel.visitDataStudio();
+        TablePicker.getDatabase("QA MySQL8").click();
+        TablePicker.getTable("Orders").click();
+
+        cy.log("publish the table and verify the tree updates");
+        cy.findByRole("button", { name: /Publish/ }).click();
+        H.modal().findByText("Create my Library").click();
+        H.modal().findByText("Publish this table").click();
+        cy.wait("@publishTables");
+        TablePicker.getTable("Orders")
+          .findByTestId("table-published")
+          .should("be.visible");
+
+        cy.log("unpublish the table and verify the tree updates");
+        cy.findByRole("button", { name: /Unpublish/ }).click();
+        H.modal().findByText("Unpublish this table").click();
+        cy.wait("@unpublishTables");
+        TablePicker.getTable("Orders")
+          .findByTestId("table-published")
+          .should("not.exist");
+
+        cy.log("rename the table and verify the tree updates");
+        H.DataModel.TableSection.getNameInput()
+          .clear()
+          .type("Renamed Orders")
+          .blur();
+        cy.wait("@updateTable");
+        TablePicker.getTable("Renamed Orders").should("be.visible");
+      },
+    );
+  });
 });

--- a/e2e/test/scenarios/data-studio/data-model/data-studio-single-table.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-model/data-studio-single-table.cy.spec.ts
@@ -231,6 +231,23 @@ describe("Table editing", () => {
           .blur();
         cy.wait("@updateTable");
         TablePicker.getTable("Renamed Orders").should("be.visible");
+
+        cy.log("update the owner and verify it is reflected");
+        TablePicker.getTable("Renamed Orders").should(
+          "not.contain.text",
+          "Bobby Tables",
+        );
+        H.selectHasValue("Owner", "No owner").click();
+        H.selectDropdown().contains("Bobby Tables").click();
+        cy.wait("@updateTable");
+        H.undoToastListContainer()
+          .findByText("Table owner updated")
+          .should("be.visible");
+        H.selectHasValue("Owner", "Bobby Tables");
+        TablePicker.getTable("Renamed Orders").should(
+          "contain.text",
+          "Bobby Tables",
+        );
       },
     );
   });

--- a/frontend/src/metabase/data-studio/data-model/components/TablePicker/components/TablePicker.tsx
+++ b/frontend/src/metabase/data-studio/data-model/components/TablePicker/components/TablePicker.tsx
@@ -35,7 +35,7 @@ interface TablePickerProps {
   path: TreePath;
   className?: string;
   onChange: (path: TreePath, options?: ChangeOptions) => void;
-  setOnUpdateCallback: (callback: (() => void) | null) => void;
+  setOnUpdateCallback: (callback: ((path?: TreePath) => void) | null) => void;
 }
 
 export function TablePicker({

--- a/frontend/src/metabase/data-studio/data-model/components/TablePicker/components/TablePickerTreeTable.tsx
+++ b/frontend/src/metabase/data-studio/data-model/components/TablePicker/components/TablePickerTreeTable.tsx
@@ -14,6 +14,7 @@ import { useNumberFormatter } from "metabase/common/hooks/use-number-formatter";
 import type { SelectionState, TreeTableColumnDef } from "metabase/ui";
 import {
   Box,
+  Center,
   EntityNameCell,
   Icon,
   TreeTable,
@@ -265,13 +266,13 @@ export function TablePickerTreeTable({
             return null;
           }
           return row.original.table.is_published ? (
-            <Box w="100%" ta="center" data-testid="table-published">
+            <Center w="100%" data-testid="table-published">
               <Icon
                 name="verified_round"
                 c="success"
                 aria-label={t`Published`}
               />
-            </Box>
+            </Center>
           ) : null;
         },
       });

--- a/frontend/src/metabase/data-studio/data-model/components/TablePicker/components/Tree.tsx
+++ b/frontend/src/metabase/data-studio/data-model/components/TablePicker/components/Tree.tsx
@@ -25,7 +25,7 @@ interface Props {
   path: TreePath;
   isLibraryEnabled: boolean;
   onChange: (path: TreePath, options?: ChangeOptions) => void;
-  setOnUpdateCallback: (callback: (() => void) | null) => void;
+  setOnUpdateCallback: (callback: ((path?: TreePath) => void) | null) => void;
 }
 
 export function Tree({
@@ -50,17 +50,24 @@ export function Tree({
     reload(path);
   }, [reload, path]);
 
-  const refetchSelectedTables = useCallback(() => {
-    const selectedTableNodes = findSelectedTableNodes(tree, selectedTables);
-    selectedTableNodes.forEach((tableNode) => {
-      reload(tableNode.value);
-    });
-  }, [tree, reload, selectedTables]);
+  const refetchTables = useCallback(
+    (path?: TreePath) => {
+      if (path) {
+        reload(path);
+      } else {
+        const selectedTableNodes = findSelectedTableNodes(tree, selectedTables);
+        selectedTableNodes.forEach((tableNode) => {
+          reload(tableNode.value);
+        });
+      }
+    },
+    [tree, reload, selectedTables],
+  );
 
   useEffect(() => {
-    setOnUpdateCallback(() => refetchSelectedTables);
+    setOnUpdateCallback(() => refetchTables);
     return () => setOnUpdateCallback(null);
-  }, [refetchSelectedTables, setOnUpdateCallback]);
+  }, [refetchTables, setOnUpdateCallback]);
 
   useEffect(() => {
     if (tree.children.length !== 1) {

--- a/frontend/src/metabase/data-studio/data-model/components/TablePicker/hooks/useTableLoader.ts
+++ b/frontend/src/metabase/data-studio/data-model/components/TablePicker/hooks/useTableLoader.ts
@@ -85,7 +85,10 @@ export function useTableLoader() {
         return [];
       }
 
-      const response = await fetchTables(newArgs, true);
+      // Ensuring that we always fetch fresh table data. It's possible that this is triggered by publish/unpublish
+      // for a single table, but if remote sync is enabled we tend to call this before cache invalidation has completed.
+      // https://github.com/metabase/metabase/pull/70954#pullrequestreview-3960445972
+      const response = await fetchTables(newArgs);
 
       return (
         response?.data?.map((table) =>

--- a/frontend/src/metabase/data-studio/data-model/components/TablePicker/wrappers.tsx
+++ b/frontend/src/metabase/data-studio/data-model/components/TablePicker/wrappers.tsx
@@ -11,7 +11,7 @@ import type { TreePath } from "./types";
 
 type Props = TreePath & {
   params: RouteParams;
-  setOnUpdateCallback: (callback: (() => void) | null) => void;
+  setOnUpdateCallback: (callback: ((path?: TreePath) => void) | null) => void;
 };
 
 export function RouterTablePicker({
@@ -72,7 +72,7 @@ export function UncontrolledTablePicker({
   initialValue: TreePath;
   onChange?: (path: TreePath) => void;
   params: RouteParams;
-  setOnUpdateCallback: (callback: (() => void) | null) => void;
+  setOnUpdateCallback: (callback: ((path?: TreePath) => void) | null) => void;
 }) {
   const [value, setValue] = useState(initialValue);
   const handleChange = useCallback(

--- a/frontend/src/metabase/data-studio/data-model/components/TableSection/TableSection.tsx
+++ b/frontend/src/metabase/data-studio/data-model/components/TableSection/TableSection.tsx
@@ -60,6 +60,7 @@ interface Props {
   canPublish: boolean;
   hasLibrary: boolean;
   onSyncOptionsClick: () => void;
+  onUpdate: () => void;
 }
 
 type TableModalType = "library" | "publish" | "unpublish" | "replace";
@@ -71,6 +72,7 @@ const TableSectionBase = ({
   canPublish,
   hasLibrary,
   onSyncOptionsClick,
+  onUpdate,
 }: Props) => {
   const [updateTable] = useUpdateTableMutation();
   const [updateTableSorting, { isLoading: isUpdatingSorting }] =
@@ -131,6 +133,7 @@ const TableSectionBase = ({
     if (error) {
       sendErrorToast(t`Failed to update table name`);
     } else {
+      onUpdate();
       sendSuccessToast(t`Table name updated`, async () => {
         const { error } = await updateTable({
           id: table.id,
@@ -214,6 +217,11 @@ const TableSectionBase = ({
 
   const handleCloseModal = () => {
     setModalType(undefined);
+  };
+
+  const handleSuccessCloseModal = () => {
+    onUpdate();
+    handleCloseModal();
   };
 
   const registerDependencyGraphTrackingEvent = () => {
@@ -412,13 +420,13 @@ const TableSectionBase = ({
       <PLUGIN_LIBRARY.PublishTablesModal
         isOpened={modalType === "publish"}
         tableIds={[table.id]}
-        onPublish={handleCloseModal}
+        onPublish={handleSuccessCloseModal}
         onClose={handleCloseModal}
       />
       <PLUGIN_LIBRARY.UnpublishTablesModal
         isOpened={modalType === "unpublish"}
         tableIds={[table.id]}
-        onUnpublish={handleCloseModal}
+        onUnpublish={handleSuccessCloseModal}
         onClose={handleCloseModal}
       />
       <PLUGIN_REPLACEMENT.ReplaceDataSourceModal

--- a/frontend/src/metabase/data-studio/data-model/components/TableSection/TableSection.tsx
+++ b/frontend/src/metabase/data-studio/data-model/components/TableSection/TableSection.tsx
@@ -304,7 +304,7 @@ const TableSectionBase = ({
         </Box>
       </Group>
 
-      <TableAttributesEditSingle table={table} />
+      <TableAttributesEditSingle table={table} onUpdate={onUpdate} />
 
       <TableSectionGroup title={t`Metadata`}>
         <TableMetadata table={table} />

--- a/frontend/src/metabase/data-studio/data-model/components/TableSection/components/TableAttributesEditSingle.tsx
+++ b/frontend/src/metabase/data-studio/data-model/components/TableSection/components/TableAttributesEditSingle.tsx
@@ -24,9 +24,10 @@ import { TableSectionGroup } from "./TableSectionGroup";
 
 interface Props {
   table: Table;
+  onUpdate: () => void;
 }
 
-export function TableAttributesEditSingle({ table }: Props) {
+export function TableAttributesEditSingle({ table, onUpdate }: Props) {
   const [updateTable] = useUpdateTableMutation();
   const { sendErrorToast, sendSuccessToast, sendUndoToast } =
     useMetadataToasts();
@@ -40,6 +41,7 @@ export function TableAttributesEditSingle({ table }: Props) {
     if (error) {
       sendErrorToast(t`Failed to update table owner`);
     } else {
+      onUpdate();
       sendSuccessToast(t`Table owner updated`, async () => {
         const { error } = await updateTable({
           id: table.id,
@@ -65,6 +67,7 @@ export function TableAttributesEditSingle({ table }: Props) {
     if (error) {
       sendErrorToast(t`Failed to update table owner`);
     } else {
+      onUpdate();
       sendSuccessToast(t`Table owner updated`, async () => {
         const { error } = await updateTable({
           id: table.id,

--- a/frontend/src/metabase/data-studio/data-model/components/TableSection/tests/setup.tsx
+++ b/frontend/src/metabase/data-studio/data-model/components/TableSection/tests/setup.tsx
@@ -83,6 +83,7 @@ export function setup({
           hasLibrary
           canPublish
           onSyncOptionsClick={onSyncOptionsClick}
+          onUpdate={jest.fn()}
         />
       )}
     />,

--- a/frontend/src/metabase/data-studio/data-model/pages/DataModel/DataModel.tsx
+++ b/frontend/src/metabase/data-studio/data-model/pages/DataModel/DataModel.tsx
@@ -43,6 +43,7 @@ import {
   SyncOptionsModal,
   TableSection,
 } from "../../components";
+import type { TreePath } from "../../components/TablePicker/types";
 import { TableAttributesEditBulk } from "../../components/TableSection/components/TableAttributesEditBulk";
 
 import S from "./DataModel.module.css";
@@ -126,9 +127,9 @@ function DataModelContent({ params }: Props) {
   const hasLibrary = hasLibraryCollection(libraryCollection);
   const canPublish = hasLibraryFeature;
 
-  const [onUpdateCallback, setOnUpdateCallback] = useState<(() => void) | null>(
-    null,
-  );
+  const [onUpdateCallback, setOnUpdateCallback] = useState<
+    ((path?: TreePath) => void) | null
+  >(null);
 
   useWindowEvent(
     "keydown",
@@ -287,6 +288,13 @@ function DataModelContent({ params }: Props) {
                     canPublish={canPublish}
                     hasLibrary={hasLibrary}
                     onSyncOptionsClick={openSyncModal}
+                    onUpdate={() =>
+                      onUpdateCallback?.({
+                        databaseId: table.db_id,
+                        schemaName: table.schema,
+                        tableId: table.id,
+                      })
+                    }
                   />
                 )}
               </LoadingAndErrorWrapper>


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #69554
### Description

Update the `TableSection` component to call to refetch data when a user publishes / unpublishes tables, as well as updating the name.

### How to verify

1. Go to the Data studio
2. In the table picker, click a table and change it's published status
3. The table picker should update to reflect the published status *without* a refresh
4. Same for update the tables name.

### Demo
https://github.com/user-attachments/assets/330350f8-6970-4475-87d2-09a91f62731e

### Checklist
- [x] Tests have been added/updated to cover changes in this PR
