### PR TITLE
[QP] Change the nested query alias from `source` to `__mb_source`

### DIFF
--- a/modules/drivers/athena/test/metabase/driver/athena_test.clj
+++ b/modules/drivers/athena/test/metabase/driver/athena_test.clj
@@ -341,6 +341,26 @@
                      :native
                      (update :query #(str/split-lines (driver/prettify-native-form :athena %)))))))))))
 
+(deftest ^:parallel source-column-name-conflict-test
+  (testing "A column named `source` should not conflict with the subquery alias (#70224)"
+    ;; When a nested query has a column named "source", it conflicts with the subquery alias "source",
+    ;; generating SQL like `"source"."source"` which Athena/Trino/Presto interpret as accessing a field
+    ;; within a ROW type rather than table.column, causing TYPE_MISMATCH errors.
+    (mt/test-driver :athena
+      (let [query (mt/mbql-query checkins
+                    {:aggregation  [[:count]]
+                     :breakout     [[:field "source" {:base-type :type/Text}]]
+                     :source-query {:native "select 1 as \"val\", '2' as \"source\""}})
+            compiled (-> (qp/compile query)
+                         (update :query #(str/split-lines (driver/prettify-native-form :athena %))))]
+        ;; The generated SQL must NOT contain `"source"."source"` — this is ambiguous and fails on Athena.
+        ;; The column reference should be unambiguous, e.g. by qualifying with a different subquery alias
+        ;; or by avoiding the table qualifier when it would collide with the column name.
+        (is (not (some #(re-find #"\"source\"\.\"source\"" %) (:query compiled)))
+            (str "Generated SQL should not contain ambiguous \"source\".\"source\" reference.\n"
+                 "Got:\n"
+                 (str/join "\n" (:query compiled))))))))
+
 ;;; Athena version of [[metabase.query-processor.date-time-zone-functions-test/datetime-diff-mixed-types-test]]
 (deftest datetime-diff-mixed-types-test
   (mt/test-driver :athena

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
@@ -493,7 +493,7 @@
     (mt/with-driver :bigquery-cloud-sdk
       (qp.store/with-metadata-provider (mt/id)
         (mt/with-temporary-setting-values [start-of-week :sunday]
-          (is (= ["DATE_TRUNC(`source`.`date`, week(sunday))"]
+          (is (= ["DATE_TRUNC(`__mb_source`.`date`, week(sunday))"]
                  (sql.qp/format-honeysql
                   :bigquery-cloud-sdk
                   (sql.qp/->honeysql
@@ -1179,20 +1179,20 @@
                      :breakout     [[:field "source" {:base-type :type/Text}]]
                      :source-query {:native "select 1 as `val`, '2' as `source`"}})]
         (is (= {:query      ["SELECT"
-                             "  `source`.`source` AS `source`,"
+                             "  `__mb_source`.`source` AS `source`,"
                              "  COUNT(*) AS `count`"
                              "FROM"
                              "  ("
                              "    select"
                              "      1 as `val`,"
                              "      '2' as `source`"
-                             "  ) AS `source`"
+                             "  ) AS `__mb_source`"
                              "GROUP BY"
                              "  `source`"
                              "ORDER BY"
                              "  `source` ASC"]
                 :params     nil
-                :table-name "source"
+                :table-name "__mb_source"
                 :mbql?      true}
                (-> (qp.compile/compile query)
                    (update :query #(str/split-lines (driver/prettify-native-form :bigquery-cloud-sdk %))))))
@@ -1263,16 +1263,16 @@
                                 (lib/aggregate (lib/sum orders-total))
                                 (lib/limit 3))]
       (is (= ["SELECT"
-              "  `source`.`created_at` AS `created_at`,"
+              "  `__mb_source`.`created_at` AS `created_at`,"
               "  SUM(COUNT(*)) OVER ("
               "    ORDER BY"
-              "      `source`.`created_at` ASC ROWS UNBOUNDED PRECEDING"
+              "      `__mb_source`.`created_at` ASC ROWS UNBOUNDED PRECEDING"
               "  ) AS `count`,"
-              "  SUM(SUM(`source`.`total`)) OVER ("
+              "  SUM(SUM(`__mb_source`.`total`)) OVER ("
               "    ORDER BY"
-              "      `source`.`created_at` ASC ROWS UNBOUNDED PRECEDING"
+              "      `__mb_source`.`created_at` ASC ROWS UNBOUNDED PRECEDING"
               "  ) AS `sum`,"
-              "  SUM(`source`.`total`) AS `sum_2`"
+              "  SUM(`__mb_source`.`total`) AS `sum_2`"
               "FROM"
               "  ("
               "    SELECT"
@@ -1283,7 +1283,7 @@
               "      `test_data.orders`.`total` AS `total`"
               "    FROM"
               "      `test_data.orders`"
-              "  ) AS `source`"
+              "  ) AS `__mb_source`"
               "GROUP BY"
               "  `created_at`"
               "ORDER BY"

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
@@ -1113,7 +1113,7 @@
         (mt/with-native-query-testing-context query
           (is (= (with-test-db-name
                    {:query      ["SELECT"
-                                 "  `source`.`count` AS `count`,"
+                                 "  `__mb_source`.`count` AS `count`,"
                                  "  COUNT(*) AS `count_2`"
                                  "FROM"
                                  "  ("
@@ -1130,7 +1130,7 @@
                                  "      `date`"
                                  "    ORDER BY"
                                  "      `date` ASC"
-                                 "  ) AS `source`"
+                                 "  ) AS `__mb_source`"
                                  "GROUP BY"
                                  "  `count`"
                                  "ORDER BY"
@@ -1138,7 +1138,7 @@
                                  "LIMIT"
                                  "  2"]
                     :params     nil
-                    :table-name "source"
+                    :table-name "__mb_source"
                     :mbql?      true})
                  (-> (qp.compile/compile query)
                      (update :query #(str/split-lines (driver/prettify-native-form :bigquery-cloud-sdk %))))))

--- a/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
+++ b/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
@@ -262,7 +262,7 @@
                    "FROM"
                    "  ("
                    "    SELECT"
-                   "      \"source\".\"s\" \"s\""
+                   "      \"__mb_source\".\"s\" \"s\""
                    "    FROM"
                    "      ("
                    "        SELECT"
@@ -270,7 +270,7 @@
                    "          SUBSTR(\"public\".\"table\".\"field\", 2) \"s\""
                    "        FROM"
                    "          \"public\".\"table\""
-                   "      ) \"source\""
+                   "      ) \"__mb_source\""
                    "  )"
                    "WHERE"
                    "  rownum <= 3"]]

--- a/modules/drivers/sqlite/test/metabase/driver/sqlite_test.clj
+++ b/modules/drivers/sqlite/test/metabase/driver/sqlite_test.clj
@@ -215,13 +215,13 @@
 (deftest ^:parallel duplicate-identifiers-test
   (testing "Make sure duplicate identifiers (even with different cases) get unique aliases"
     (mt/test-driver :sqlite
-      (is (= '{:select   [source.CATEGORY AS CATEGORY
+      (is (= '{:select   [__mb_source.CATEGORY AS CATEGORY
                           COUNT (*)         AS count]
                :from     [{:select [products.category || ? AS CATEGORY]
                            :from   [products]}
-                          AS source]
-               :group-by [source.CATEGORY]
-               :order-by [source.CATEGORY ASC]
+                          AS __mb_source]
+               :group-by [__mb_source.CATEGORY]
+               :order-by [__mb_source.CATEGORY ASC]
                :limit    [1]}
              (sql.qp-test-util/query->sql-map
               (mt/mbql-query products

--- a/modules/drivers/sqlserver/test/metabase/driver/sqlserver_test.clj
+++ b/modules/drivers/sqlserver/test/metabase/driver/sqlserver_test.clj
@@ -124,7 +124,7 @@
     (testing (str "SQL Server doesn't let you use ORDER BY in nested SELECTs unless you also specify a TOP (their "
                   "equivalent of LIMIT). Make sure we add a max-results LIMIT to the nested query")
       (is (= {:query ["SELECT"
-                      "  TOP(1048575) \"source\".\"name\" AS \"name\""
+                      "  TOP(1048575) \"__mb_source\".\"name\" AS \"name\""
                       "FROM"
                       "  ("
                       "    SELECT"
@@ -133,7 +133,7 @@
                       "      \"dbo\".\"venues\""
                       "    ORDER BY"
                       "      \"dbo\".\"venues\".\"id\" ASC"
-                      "  ) AS \"source\""]
+                      "  ) AS \"__mb_source\""]
               :params nil}
              (-> (mt/mbql-query venues
                    {:source-query {:source-table $$venues
@@ -147,7 +147,7 @@
     (testing (str "make sure when adding TOP clauses to make ORDER BY work we don't stomp over any explicit TOP "
                   "clauses that may have been set in the query")
       (is (= {:query  ["SELECT"
-                       "  TOP(10) \"source\".\"name\" AS \"name\""
+                       "  TOP(10) \"__mb_source\".\"name\" AS \"name\""
                        "FROM"
                        "  ("
                        "    SELECT"
@@ -156,7 +156,7 @@
                        "      \"dbo\".\"venues\""
                        "    ORDER BY"
                        "      \"dbo\".\"venues\".\"id\" ASC"
-                       "  ) AS \"source\""]
+                       "  ) AS \"__mb_source\""]
               :params nil}
              (-> (qp.compile/compile
                   (mt/mbql-query venues
@@ -182,7 +182,7 @@
                            (lib/limit nil))]
       (mt/with-metadata-provider (mt/id)
         (is (= {:query  ["SELECT"
-                         "  \"source\".\"name\" AS \"name\""
+                         "  \"__mb_source\".\"name\" AS \"name\""
                          "FROM"
                          "  ("
                          "    SELECT"
@@ -191,9 +191,9 @@
                          "      \"dbo\".\"venues\""
                          "    ORDER BY"
                          "      \"dbo\".\"venues\".\"id\" ASC"
-                         "  ) AS \"source\""
+                         "  ) AS \"__mb_source\""
                          "ORDER BY"
-                         "  \"source\".\"id\" ASC"]
+                         "  \"__mb_source\".\"id\" ASC"]
                 :params nil}
                (-> (driver/mbql->native :sqlserver preprocessed)
                    (update :query (fn [sql]

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -30,9 +30,9 @@
 (def source-query-alias
   "Alias to use for source queries, e.g.:
 
-    SELECT source.*
-    FROM ( SELECT * FROM some_table ) source"
-  "source")
+    SELECT __mb_source.*
+    FROM ( SELECT * FROM some_table ) __mb_source"
+  "__mb_source")
 
 (def ^:dynamic *inner-query*
   "The INNER query currently being processed, for situations where we need to refer back to it."
@@ -2057,7 +2057,7 @@
     (merge
      honeysql-form
      (if needs-columns?
-        ;; HoneySQL cannot expand [::h2x/identifier :table "source"] in the with alias.
+        ;; HoneySQL cannot expand [::h2x/identifier :table "__mb_source"] in the with alias.
         ;; This is ok since we control the alias.
        {:with [[[source-query-alias {:columns (mapv #(h2x/identifier :field %) desired-aliases)}]
                 source-clause]]

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -2032,7 +2032,7 @@
 (defn- apply-source-query
   "Handle a `:source-query` clause by adding a recursive `SELECT` or native query. If the source query has ambiguous
   column names, use a `WITH` statement to rename the source columns. At the time of this writing, all source queries
-  are aliased as `source`."
+  are aliased as `__mb_source`."
   [driver honeysql-form {{:keys [native params] persisted :persisted-info/native :as source-query} :source-query
                          source-metadata :source-metadata}]
   (let [table-alias (->honeysql driver (h2x/identifier :table-alias source-query-alias))

--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -562,7 +562,7 @@
                              (str joined-name " - " home-name))
                         joined-name
                         home-name
-                        "source")]
+                        "__mb_source")]
     join-alias))
 
 (defn- add-alias-to-join-refs [query stage-number form join-alias join-cols]

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -528,8 +528,8 @@
                        :type     :query
                        :query    {:source-table "card__123"}})]
           (is (= ["SELECT"
-                  "  \"source\".\"json_alias_test\" AS \"json_alias_test\","
-                  "  \"source\".\"count\" AS \"count\""
+                  "  \"__mb_source\".\"json_alias_test\" AS \"json_alias_test\","
+                  "  \"__mb_source\".\"count\" AS \"count\""
                   "FROM"
                   "  ("
                   "    SELECT"
@@ -541,7 +541,7 @@
                   "      \"json_alias_test\""
                   "    ORDER BY"
                   "      \"json_alias_test\" ASC"
-                  "  ) AS \"source\""
+                  "  ) AS \"__mb_source\""
                   "LIMIT"
                   "  1048575"]
                  (str/split-lines (driver/prettify-native-form :postgres (:query nested))))))))))

--- a/test/metabase/driver/sql/query_processor_test.clj
+++ b/test/metabase/driver/sql/query_processor_test.clj
@@ -39,9 +39,9 @@
          (sql.qp/->honeysql :sql (sql.qp/compiled [:raw "x"])))))
 
 (deftest ^:parallel default-select-test
-  (is (= ["SELECT \"source\".* FROM (SELECT *) AS \"source\""]
+  (is (= ["SELECT \"__mb_source\".* FROM (SELECT *) AS \"__mb_source\""]
          (->> {:from [[(sql.qp/sql-source-query "SELECT *" nil)
-                       [(h2x/identifier :table-alias "source")]]]}
+                       [(h2x/identifier :table-alias "__mb_source")]]]}
               (#'sql.qp/add-default-select :sql)
               (sql.qp/format-honeysql :sql)))))
 
@@ -160,7 +160,7 @@
                                    CHECKINS.VENUE_ID AS VENUE_ID]
                           :from   [CHECKINS]
                           :where  [CHECKINS.DATE > ?]}
-                         AS source]
+                         AS __mb_source]
              :left-join [{:select
                           [VENUES.ID          AS ID
                            VENUES.NAME        AS NAME
@@ -169,8 +169,8 @@
                            VENUES.LONGITUDE   AS LONGITUDE
                            VENUES.PRICE       AS PRICE]
                           :from [VENUES]} AS v
-                         ON source.VENUE_ID = v.ID]
-             :where     [(v.NAME LIKE ?) AND (source.USER_ID > 0)]
+                         ON __mb_source.VENUE_ID = v.ID]
+             :where     [(v.NAME LIKE ?) AND (__mb_source.USER_ID > 0)]
              :group-by  [v.NAME]
              :order-by  [v.NAME ASC]}
            (-> (lib.tu.macros/mbql-query checkins
@@ -219,7 +219,7 @@
   (driver/with-driver :h2
     (mt/with-metadata-provider (mt/id)
       (testing "params from source queries should get passed in to the top-level. Semicolons should be removed"
-        (is (= {:query  "SELECT \"source\".* FROM (SELECT * FROM some_table WHERE name = ?) AS \"source\" WHERE (\"source\".\"name\" <> ?) OR (\"source\".\"name\" IS NULL)"
+        (is (= {:query  "SELECT \"__mb_source\".* FROM (SELECT * FROM some_table WHERE name = ?) AS \"__mb_source\" WHERE (\"__mb_source\".\"name\" <> ?) OR (\"__mb_source\".\"name\" IS NULL)"
                 :params ["Cam" "Lucky Pigeon"]}
                (sql.qp/mbql->native
                 :h2
@@ -357,13 +357,13 @@
 (deftest ^:parallel joined-field-clauses-test-2
   (testing "Should correctly compile `:field` clauses with `:join-alias`"
     (testing "when the join is NOT at the same level"
-      (is (= {:select '[source.c__NAME AS c__NAME]
+      (is (= {:select '[__mb_source.c__NAME AS c__NAME]
               :from   '[{:select    [c.NAME AS c__NAME]
                          :from      [VENUES]
                          :left-join [{:select [CATEGORIES.ID AS ID
                                                CATEGORIES.NAME AS NAME]
                                       :from   [CATEGORIES]} AS c
-                                     ON VENUES.CATEGORY_ID = c.ID]} AS source]
+                                     ON VENUES.CATEGORY_ID = c.ID]} AS __mb_source]
               :limit  [limit/absolute-max-results]}
              (-> (lib.tu.macros/mbql-query venues
                    {:fields       [&c.categories.name]
@@ -428,13 +428,13 @@
                sql.qp-test-util/sql->sql-map)))))
 
 (deftest ^:parallel simple-expressions-test
-  (is (= '{:select [source.ID          AS ID
-                    source.NAME        AS NAME
-                    source.CATEGORY_ID AS CATEGORY_ID
-                    source.LATITUDE    AS LATITUDE
-                    source.LONGITUDE   AS LONGITUDE
-                    source.PRICE       AS PRICE
-                    source.double_id   AS double_id]
+  (is (= '{:select [__mb_source.ID          AS ID
+                    __mb_source.NAME        AS NAME
+                    __mb_source.CATEGORY_ID AS CATEGORY_ID
+                    __mb_source.LATITUDE    AS LATITUDE
+                    __mb_source.LONGITUDE   AS LONGITUDE
+                    __mb_source.PRICE       AS PRICE
+                    __mb_source.double_id   AS double_id]
            :from   [{:select [VENUES.ID          AS ID
                               VENUES.NAME        AS NAME
                               VENUES.CATEGORY_ID AS CATEGORY_ID
@@ -443,7 +443,7 @@
                               VENUES.PRICE       AS PRICE
                               VENUES.ID * 2      AS double_id]
                      :from   [VENUES]}
-                    AS source]
+                    AS __mb_source]
            :limit  [1]}
          (-> (lib.tu.macros/mbql-query venues
                {:source-query {:source-table $$venues
@@ -456,11 +456,11 @@
 
 (deftest ^:parallel multiple-joins-with-expressions-test
   (testing "We should be able to compile a complicated query with multiple joins and expressions correctly"
-    (is (= '{:select   [source.PRODUCTS__via__PRODUCT_ID__CATEGORY AS PRODUCTS__via__PRODUCT_ID__CATEGORY
-                        source.PEOPLE__via__USER_ID__SOURCE        AS PEOPLE__via__USER_ID__SOURCE
-                        DATE_TRUNC ("year" source.CREATED_AT)      AS CREATED_AT
-                        source.pivot-grouping                      AS pivot-grouping
-                        COUNT (*)                                  AS count]
+    (is (= '{:select   [__mb_source.PRODUCTS__via__PRODUCT_ID__CATEGORY AS PRODUCTS__via__PRODUCT_ID__CATEGORY
+                        __mb_source.PEOPLE__via__USER_ID__SOURCE        AS PEOPLE__via__USER_ID__SOURCE
+                        DATE_TRUNC ("year" __mb_source.CREATED_AT)      AS CREATED_AT
+                        __mb_source.pivot-grouping                      AS pivot-grouping
+                        COUNT (*)                                       AS count]
              ;; TODO: The order here is not deterministic! It's coming
              ;; from [[metabase.query-processor.util.transformations.nest-breakouts]]
              ;; or [[metabase.query-processor.util.nest-query]], which walks the query looking for refs in an
@@ -504,15 +504,15 @@
                                      (ORDERS.CREATED_AT >= DATE_TRUNC ("year" DATEADD ("year" -2 NOW ())))
                                      AND
                                      (ORDERS.CREATED_AT < DATE_TRUNC ("year" NOW ()))]}
-                        AS source]
-             :group-by [source.PRODUCTS__via__PRODUCT_ID__CATEGORY
-                        source.PEOPLE__via__USER_ID__SOURCE
-                        DATE_TRUNC ("year" source.CREATED_AT)
-                        source.pivot-grouping]
-             :order-by [source.PRODUCTS__via__PRODUCT_ID__CATEGORY ASC
-                        source.PEOPLE__via__USER_ID__SOURCE        ASC
-                        DATE_TRUNC ("year" source.CREATED_AT)      ASC
-                        source.pivot-grouping                      ASC]}
+                        AS __mb_source]
+             :group-by [__mb_source.PRODUCTS__via__PRODUCT_ID__CATEGORY
+                        __mb_source.PEOPLE__via__USER_ID__SOURCE
+                        DATE_TRUNC ("year" __mb_source.CREATED_AT)
+                        __mb_source.pivot-grouping]
+             :order-by [__mb_source.PRODUCTS__via__PRODUCT_ID__CATEGORY ASC
+                        __mb_source.PEOPLE__via__USER_ID__SOURCE        ASC
+                        DATE_TRUNC ("year" __mb_source.CREATED_AT)      ASC
+                        __mb_source.pivot-grouping                      ASC]}
            (-> (lib.tu.macros/mbql-query orders
                  {:aggregation [[:aggregation-options [:count] {:name "count"}]]
                   :breakout    [&PRODUCTS__via__PRODUCT_ID.products.category
@@ -688,7 +688,7 @@
 
 (deftest ^:parallel join-inside-source-query-test
   (testing "Make sure a JOIN inside a source query gets compiled as expected"
-    (is (= '{:select [source.P1__CATEGORY AS P1__CATEGORY]
+    (is (= '{:select [__mb_source.P1__CATEGORY AS P1__CATEGORY]
              :from   [{:select    [P1.CATEGORY AS P1__CATEGORY]
                        :from      [ORDERS]
                        :left-join [{:select [PRODUCTS.ID         AS ID
@@ -701,7 +701,7 @@
                                              PRODUCTS.CREATED_AT AS CREATED_AT]
                                     :from [PRODUCTS]} AS P1
                                    ON ORDERS.PRODUCT_ID = P1.ID]}
-                      AS source]
+                      AS __mb_source]
              :limit  [1]}
            (-> (lib.tu.macros/mbql-query orders
                  {:fields       [&P1.products.category]
@@ -718,7 +718,7 @@
 (deftest ^:parallel join-against-source-query-test
   (testing "Make sure a JOIN referencing fields from the source query use correct aliases/etc"
     (qp.store/with-metadata-provider meta/metadata-provider
-      (is (= '{:select    [source.P1__CATEGORY AS P1__CATEGORY]
+      (is (= '{:select    [__mb_source.P1__CATEGORY AS P1__CATEGORY]
                :from      [{:select    [P1.CATEGORY AS P1__CATEGORY]
                             :from      [ORDERS]
                             :left-join [{:select [PRODUCTS.ID         AS ID
@@ -731,7 +731,7 @@
                                                   PRODUCTS.CREATED_AT AS CREATED_AT]
                                          :from [PRODUCTS]} AS P1
                                         ON ORDERS.PRODUCT_ID = P1.ID]}
-                           AS source]
+                           AS __mb_source]
                :left-join [{:select    [P2.CATEGORY AS P2__CATEGORY]
                             :from      [REVIEWS]
                             :left-join [{:select [PRODUCTS.ID         AS ID
@@ -745,7 +745,7 @@
                                          :from [PRODUCTS]} AS P2
                                         ON REVIEWS.PRODUCT_ID = P2.ID]}
                            AS Q2
-                           ON source.P1__CATEGORY = Q2.P2__CATEGORY]
+                           ON __mb_source.P1__CATEGORY = Q2.P2__CATEGORY]
                :limit     [1]}
              (-> (lib.tu.macros/mbql-query orders
                    {:fields       [&P1.products.category]
@@ -792,17 +792,17 @@
              sql.qp-test-util/sql->sql-map))))
 
 (deftest ^:parallel another-source-query-test
-  (is (= '{:select [source.DATE  AS DATE
-                    source.sum   AS sum
-                    source.sum_2 AS sum_2]
+  (is (= '{:select [__mb_source.DATE  AS DATE
+                    __mb_source.sum   AS sum
+                    __mb_source.sum_2 AS sum_2]
            :from   [{:select   [DATE_TRUNC ("month" CHECKINS.DATE) AS DATE
                                 SUM (CHECKINS.USER_ID)                                           AS sum
                                 SUM (CHECKINS.VENUE_ID)                                          AS sum_2]
                      :from     [CHECKINS]
                      :group-by [DATE_TRUNC ("month" CHECKINS.DATE)]
                      :order-by [DATE_TRUNC ("month" CHECKINS.DATE) ASC]}
-                    AS source]
-           :where  [source.sum > 300]
+                    AS __mb_source]
+           :where  [__mb_source.sum > 300]
            :limit  [2]}
          (-> (lib.tu.macros/mbql-query checkins
                {:source-query {:source-table $$checkins
@@ -816,13 +816,13 @@
 
 (deftest ^:parallel expression-with-duplicate-column-name-test
   (testing "Can we use expression with same column name as table (#14267)"
-    (is (= '{:select   [source.CATEGORY AS CATEGORY
-                        COUNT (*)         AS count]
+    (is (= '{:select   [__mb_source.CATEGORY AS CATEGORY
+                        COUNT (*)            AS count]
              :from     [{:select [CONCAT (PRODUCTS.CATEGORY ?) AS CATEGORY]
                          :from   [PRODUCTS]}
-                        AS source]
-             :group-by [source.CATEGORY]
-             :order-by [source.CATEGORY ASC]
+                        AS __mb_source]
+             :group-by [__mb_source.CATEGORY]
+             :order-by [__mb_source.CATEGORY ASC]
              :limit    [1]}
            (-> (lib.tu.macros/mbql-query products
                  {:expressions {:CATEGORY [:concat $category "2"]}
@@ -835,9 +835,9 @@
 
 (deftest ^:parallel join-source-queries-with-joins-test
   (testing "Should be able to join against source queries that themselves contain joins (#12928)"
-    (is (= '{:select    [source.P1__CATEGORY   AS P1__CATEGORY
-                         source.People__SOURCE AS People__SOURCE
-                         source.count          AS count
+    (is (= '{:select    [__mb_source.P1__CATEGORY   AS P1__CATEGORY
+                         __mb_source.People__SOURCE AS People__SOURCE
+                         __mb_source.count          AS count
                          Q2.P2__CATEGORY       AS Q2__P2__CATEGORY
                          Q2.avg                AS Q2__avg]
              :from      [{:select    [P1.CATEGORY   AS P1__CATEGORY
@@ -872,7 +872,7 @@
                           :group-by  [P1.CATEGORY
                                       People.SOURCE]
                           :order-by  [P1.CATEGORY ASC People.SOURCE ASC]}
-                         AS source]
+                         AS __mb_source]
              :left-join [{:select    [P2.CATEGORY          AS P2__CATEGORY
                                       AVG (REVIEWS.RATING) AS avg]
                           :from      [REVIEWS]
@@ -889,9 +889,9 @@
                           :group-by  [P2.CATEGORY]
                           :order-by  [P2.CATEGORY ASC]}
                          AS Q2
-                         ON source.P1__CATEGORY = Q2.P2__CATEGORY]
-             :order-by  [source.P1__CATEGORY   ASC
-                         source.People__SOURCE ASC]
+                         ON __mb_source.P1__CATEGORY = Q2.P2__CATEGORY]
+             :order-by  [__mb_source.P1__CATEGORY   ASC
+                         __mb_source.People__SOURCE ASC]
              :limit     [2]}
            (-> (lib.tu.macros/mbql-query orders
                  {:source-query {:source-table $$orders
@@ -971,14 +971,14 @@
 (deftest ^:parallel join-against-query-with-implicit-joins-test
   (testing "Should be able to do subsequent joins against a query with implicit joins (#17767)"
     (qp.store/with-metadata-provider meta/metadata-provider
-      (is (= '{:select    [source.PRODUCTS__via__PRODUCT_ID__ID AS PRODUCTS__via__PRODUCT_ID__ID
-                           source.count                         AS count
-                           Reviews.ID                           AS Reviews__ID
-                           Reviews.PRODUCT_ID                   AS Reviews__PRODUCT_ID
-                           Reviews.REVIEWER                     AS Reviews__REVIEWER
-                           Reviews.RATING                       AS Reviews__RATING
-                           Reviews.BODY                         AS Reviews__BODY
-                           Reviews.CREATED_AT                   AS Reviews__CREATED_AT]
+      (is (= '{:select    [__mb_source.PRODUCTS__via__PRODUCT_ID__ID AS PRODUCTS__via__PRODUCT_ID__ID
+                           __mb_source.count                         AS count
+                           Reviews.ID                                AS Reviews__ID
+                           Reviews.PRODUCT_ID                        AS Reviews__PRODUCT_ID
+                           Reviews.REVIEWER                          AS Reviews__REVIEWER
+                           Reviews.RATING                            AS Reviews__RATING
+                           Reviews.BODY                              AS Reviews__BODY
+                           Reviews.CREATED_AT                        AS Reviews__CREATED_AT]
                :from      [{:select    [PRODUCTS__via__PRODUCT_ID.ID AS PRODUCTS__via__PRODUCT_ID__ID
                                         COUNT (*)                    AS count]
                             :from      [ORDERS]
@@ -1011,7 +1011,7 @@
                                         ON ORDERS.PRODUCT_ID = PRODUCTS__via__PRODUCT_ID.ID]
                             :group-by  [PRODUCTS__via__PRODUCT_ID.ID]
                             :order-by  [PRODUCTS__via__PRODUCT_ID.ID ASC]}
-                           AS source]
+                           AS __mb_source]
                :left-join [{:select [REVIEWS.ID         AS ID
                                      REVIEWS.PRODUCT_ID AS PRODUCT_ID
                                      REVIEWS.REVIEWER   AS REVIEWER
@@ -1019,7 +1019,7 @@
                                      REVIEWS.BODY       AS BODY
                                      REVIEWS.CREATED_AT AS CREATED_AT]
                             :from   [REVIEWS]} AS Reviews
-                           ON source.PRODUCTS__via__PRODUCT_ID__ID = Reviews.PRODUCT_ID]
+                           ON __mb_source.PRODUCTS__via__PRODUCT_ID__ID = Reviews.PRODUCT_ID]
                :limit     [1]}
              (sql.qp-test-util/query->sql-map
               (lib.tu.macros/mbql-query orders
@@ -1035,32 +1035,32 @@
 (deftest ^:parallel join-table-on-itself-with-custom-column-test
   (testing "Should be able to join a source query against itself using an expression (#17770)"
     (qp.store/with-metadata-provider meta/metadata-provider
-      (is (= '{:select    [source.CATEGORY AS CATEGORY
-                           source.count    AS count
-                           source.CC       AS CC
-                           Q1.CATEGORY     AS Q1__CATEGORY
-                           Q1.count        AS Q1__count
-                           Q1.CC           AS Q1__CC]
-               :from      [{:select [source.CATEGORY AS CATEGORY
-                                     source.count    AS count
+      (is (= '{:select    [__mb_source.CATEGORY AS CATEGORY
+                           __mb_source.count    AS count
+                           __mb_source.CC       AS CC
+                           Q1.CATEGORY          AS Q1__CATEGORY
+                           Q1.count             AS Q1__count
+                           Q1.CC                AS Q1__CC]
+               :from      [{:select [__mb_source.CATEGORY AS CATEGORY
+                                     __mb_source.count    AS count
                                      1 + 1           AS CC]
                             :from   [{:select   [PRODUCTS.CATEGORY AS CATEGORY
                                                  COUNT (*)         AS count]
                                       :from     [PRODUCTS]
                                       :group-by [PRODUCTS.CATEGORY]
                                       :order-by [PRODUCTS.CATEGORY ASC]}
-                                     AS source]}
-                           AS source]
-               :left-join [{:select [source.CATEGORY AS CATEGORY
-                                     source.count    AS count
-                                     1 + 1           AS CC]
+                                     AS __mb_source]}
+                           AS __mb_source]
+               :left-join [{:select [__mb_source.CATEGORY AS CATEGORY
+                                     __mb_source.count    AS count
+                                     1 + 1                AS CC]
                             :from   [{:select   [PRODUCTS.CATEGORY AS CATEGORY
                                                  COUNT (*)         AS count]
                                       :from     [PRODUCTS]
                                       :group-by [PRODUCTS.CATEGORY]
                                       :order-by [PRODUCTS.CATEGORY ASC]}
-                                     AS source]}
-                           AS Q1 ON source.CC = Q1.CC]
+                                     AS __mb_source]}
+                           AS Q1 ON __mb_source.CC = Q1.CC]
                :limit     [1]}
              (sql.qp-test-util/query->sql-map
               (lib.tu.macros/mbql-query nil
@@ -1081,9 +1081,9 @@
 
 (deftest ^:parallel mega-query-test
   (testing "Should generate correct SQL for joins against source queries that contain joins (#12928)"
-    (is (= '{:select    [source.P1__CATEGORY   AS P1__CATEGORY
-                         source.People__SOURCE AS People__SOURCE
-                         source.count          AS count
+    (is (= '{:select    [__mb_source.P1__CATEGORY   AS P1__CATEGORY
+                         __mb_source.People__SOURCE AS People__SOURCE
+                         __mb_source.count          AS count
                          Q2.P2__CATEGORY       AS Q2__P2__CATEGORY
                          Q2.avg                AS Q2__avg]
              :from      [{:select    [P1.CATEGORY   AS P1__CATEGORY
@@ -1119,7 +1119,7 @@
                                       People.SOURCE]
                           :order-by  [P1.CATEGORY   ASC
                                       People.SOURCE ASC]}
-                         AS source]
+                         AS __mb_source]
              :left-join [{:select    [P2.CATEGORY          AS P2__CATEGORY
                                       AVG (REVIEWS.RATING) AS avg]
                           :from      [REVIEWS]
@@ -1136,7 +1136,7 @@
                           :group-by  [P2.CATEGORY]
                           :order-by  [P2.CATEGORY ASC]}
                          AS Q2
-                         ON source.P1__CATEGORY = Q2.P2__CATEGORY]
+                         ON __mb_source.P1__CATEGORY = Q2.P2__CATEGORY]
              :limit     [2]}
            (-> (lib.tu.macros/mbql-query nil
                  {:fields       [&P1.products.category
@@ -1397,7 +1397,7 @@
       (qp.store/with-metadata-provider
         meta/metadata-provider
         (is (=? {:query  ["SELECT"
-                          "  \"source\".\"count\" AS \"count\","
+                          "  \"__mb_source\".\"count\" AS \"count\","
                           "  COUNT(*) AS \"count_2\""
                           "FROM"
                           "  ("
@@ -1410,11 +1410,11 @@
                           "      DATE_TRUNC('month', \"PUBLIC\".\"CHECKINS\".\"DATE\")"
                           "    ORDER BY"
                           "      DATE_TRUNC('month', \"PUBLIC\".\"CHECKINS\".\"DATE\") ASC"
-                          "  ) AS \"source\""
+                          "  ) AS \"__mb_source\""
                           "GROUP BY"
-                          "  \"source\".\"count\""
+                          "  \"__mb_source\".\"count\""
                           "ORDER BY"
-                          "  \"source\".\"count\" ASC"
+                          "  \"__mb_source\".\"count\" ASC"
                           "LIMIT"
                           "  2"]
                  :params nil}
@@ -1444,7 +1444,7 @@
       (qp.store/with-metadata-provider meta/metadata-provider
         (is (= {:params nil
                 :query  ["SELECT"
-                         "  \"source\".\"ID\" AS \"ID\""
+                         "  \"__mb_source\".\"ID\" AS \"ID\""
                          "FROM"
                          "  ("
                          "    SELECT"
@@ -1456,7 +1456,7 @@
                          "      2 = 1"
                          "    LIMIT"
                          "      20"
-                         "  ) AS \"source\""
+                         "  ) AS \"__mb_source\""
                          "LIMIT"
                          "  20"]}
                (-> (qp.compile/compile query)
@@ -1607,25 +1607,25 @@
       (is (= ["SELECT"
               "  SUM("
               "    CASE"
-              "      WHEN \"source\".\"T\" THEN 1"
+              "      WHEN \"__mb_source\".\"T\" THEN 1"
               "      ELSE 0.0"
               "    END"
               "  ) AS \"count_where\","
               "  SUM("
               "    CASE"
-              "      WHEN \"source\".\"F\" THEN 1"
+              "      WHEN \"__mb_source\".\"F\" THEN 1"
               "      ELSE 0.0"
               "    END"
               "  ) AS \"count_where_2\","
               "  SUM("
               "    CASE"
-              "      WHEN \"source\".\"LIKED\" THEN 1"
+              "      WHEN \"__mb_source\".\"LIKED\" THEN 1"
               "      ELSE 0.0"
               "    END"
               "  ) AS \"count_where_3\","
               "  SUM("
               "    CASE"
-              "      WHEN \"source\".\"LIKED\" THEN 1"
+              "      WHEN \"__mb_source\".\"LIKED\" THEN 1"
               "      ELSE 0.0"
               "    END"
               "  ) AS \"count_where_4\""
@@ -1634,19 +1634,19 @@
               "    SELECT"
               "      TRUE AS \"T\","
               "      FALSE AS \"F\","
-              "      \"source\".\"LIKED\" AS \"LIKED\""
+              "      \"__mb_source\".\"LIKED\" AS \"LIKED\""
               "    FROM"
               "      ("
               "        SELECT"
               "          \"PUBLIC\".\"PLACES\".\"LIKED\" AS \"LIKED\""
               "        FROM"
               "          \"PUBLIC\".\"PLACES\""
-              "      ) AS \"source\""
+              "      ) AS \"__mb_source\""
               "    WHERE"
-              "      \"source\".\"LIKED\""
-              "      OR \"source\".\"LIKED\""
+              "      \"__mb_source\".\"LIKED\""
+              "      OR \"__mb_source\".\"LIKED\""
               "      OR TRUE"
-              "  ) AS \"source\""]
+              "  ) AS \"__mb_source\""]
              (-> query
                  qp.compile/compile
                  :query

--- a/test/metabase/query_processor/date_time_zone_functions_test.clj
+++ b/test/metabase/query_processor/date_time_zone_functions_test.clj
@@ -829,7 +829,7 @@
 
 (defmethod nested-convert-timezone-test-6-native-query :default
   [_driver card-tag]
-  (format "select * from {{%s}} as source" card-tag))
+  (format "select * from {{%s}} as __mb_source" card-tag))
 
 (defmethod nested-convert-timezone-test-6-native-query :oracle
   [_driver card-tag]

--- a/test/metabase/query_processor/nested_queries_test.clj
+++ b/test/metabase/query_processor/nested_queries_test.clj
@@ -437,14 +437,14 @@
 
 (deftest ^:parallel field-literals-test
   (is (= (honeysql->sql
-          {:select [[:source.ID :ID]
-                    [:source.NAME :NAME]
-                    [:source.CATEGORY_ID :CATEGORY_ID]
-                    [:source.LATITUDE :LATITUDE]
-                    [:source.LONGITUDE :LONGITUDE]
-                    [:source.PRICE :PRICE]]
-           :from   [[venues-source-honeysql :source]]
-           :where  [:= [:raw "\"source\".\"BIRD.ID\""] [:inline 1]]
+          {:select [[:__mb_source.ID :ID]
+                    [:__mb_source.NAME :NAME]
+                    [:__mb_source.CATEGORY_ID :CATEGORY_ID]
+                    [:__mb_source.LATITUDE :LATITUDE]
+                    [:__mb_source.LONGITUDE :LONGITUDE]
+                    [:__mb_source.PRICE :PRICE]]
+           :from   [[venues-source-honeysql :__mb_source]]
+           :where  [:= [:raw "\"__mb_source\".\"BIRD.ID\""] [:inline 1]]
            :limit  [:inline 10]})
          (qp.compile/compile
           {:database (mt/id)
@@ -458,16 +458,16 @@
 (deftest field-literals-date-time-fields-test
   (mt/with-temporary-setting-values [start-of-week :sunday]
     (is (= (honeysql->sql
-            {:select [[:source.ID :ID]
-                      [:source.NAME :NAME]
-                      [:source.CATEGORY_ID :CATEGORY_ID]
-                      [:source.LATITUDE :LATITUDE]
-                      [:source.LONGITUDE :LONGITUDE]
-                      [:source.PRICE :PRICE]]
-             :from   [[venues-source-honeysql :source]]
+            {:select [[:__mb_source.ID :ID]
+                      [:__mb_source.NAME :NAME]
+                      [:__mb_source.CATEGORY_ID :CATEGORY_ID]
+                      [:__mb_source.LATITUDE :LATITUDE]
+                      [:__mb_source.LONGITUDE :LONGITUDE]
+                      [:__mb_source.PRICE :PRICE]]
+             :from   [[venues-source-honeysql :__mb_source]]
              :where  [:and
-                      [:>= [:raw "\"source\".\"BIRD.ID\""] (t/local-date-time "2017-01-01T00:00")]
-                      [:< [:raw "\"source\".\"BIRD.ID\""]  (t/local-date-time "2017-01-08T00:00")]]
+                      [:>= [:raw "\"__mb_source\".\"BIRD.ID\""] (t/local-date-time "2017-01-01T00:00")]
+                      [:< [:raw "\"__mb_source\".\"BIRD.ID\""]  (t/local-date-time "2017-01-08T00:00")]]
              :limit  [:inline 10]})
            (qp.compile/compile
             (mt/mbql-query venues
@@ -480,7 +480,7 @@
   (testing "make sure that aggregation references match up to aggregations from the same level they're from"
     ;; e.g. the ORDER BY in the source-query should refer the 'stddev' aggregation, NOT the 'avg' aggregation
     (is (= {:query ["SELECT"
-                    "  AVG(\"source\".\"stddev\") AS \"avg\""
+                    "  AVG(\"__mb_source\".\"stddev\") AS \"avg\""
                     "FROM"
                     "  ("
                     "    SELECT"
@@ -493,7 +493,7 @@
                     "    ORDER BY"
                     "      \"stddev\" DESC,"
                     "      \"PUBLIC\".\"VENUES\".\"PRICE\" ASC"
-                    "  ) AS \"source\""]
+                    "  ) AS \"__mb_source\""]
             :params nil}
            (-> (mt/mbql-query venues
                  {:source-query {:source-table $$venues
@@ -507,7 +507,7 @@
 (deftest ^:parallel handle-incorrect-field-forms-gracefully-test
   (testing "make sure that we handle [:field [:field <name> ...]] forms gracefully, despite that not making any sense"
     (is (= {:query  ["SELECT"
-                     "  \"source\".\"CATEGORY_ID\" AS \"CATEGORY_ID\""
+                     "  \"__mb_source\".\"CATEGORY_ID\" AS \"CATEGORY_ID\""
                      "FROM"
                      "  ("
                      "    SELECT"
@@ -519,11 +519,11 @@
                      "      \"PUBLIC\".\"VENUES\".\"PRICE\" AS \"PRICE\""
                      "    FROM"
                      "      \"PUBLIC\".\"VENUES\""
-                     "  ) AS \"source\""
+                     "  ) AS \"__mb_source\""
                      "GROUP BY"
-                     "  \"source\".\"CATEGORY_ID\""
+                     "  \"__mb_source\".\"CATEGORY_ID\""
                      "ORDER BY"
-                     "  \"source\".\"CATEGORY_ID\" ASC"
+                     "  \"__mb_source\".\"CATEGORY_ID\" ASC"
                      "LIMIT"
                      "  10"]
             :params nil}
@@ -537,15 +537,15 @@
 (deftest ^:parallel filter-by-string-fields-test
   (testing "Make sure we can filter by string fields from a source query"
     (is (= (honeysql->sql
-            {:select [[:source.ID :ID]
-                      [:source.NAME :NAME]
-                      [:source.CATEGORY_ID :CATEGORY_ID]
-                      [:source.LATITUDE :LATITUDE]
-                      [:source.LONGITUDE :LONGITUDE]
-                      [:source.PRICE :PRICE]]
-             :from   [[venues-source-honeysql :source]]
-             :where  [:or [:not= :source.text "Coo"]
-                      [:= :source.text nil]]
+            {:select [[:__mb_source.ID :ID]
+                      [:__mb_source.NAME :NAME]
+                      [:__mb_source.CATEGORY_ID :CATEGORY_ID]
+                      [:__mb_source.LATITUDE :LATITUDE]
+                      [:__mb_source.LONGITUDE :LONGITUDE]
+                      [:__mb_source.PRICE :PRICE]]
+             :from   [[venues-source-honeysql :__mb_source]]
+             :where  [:or [:not= :__mb_source.text "Coo"]
+                      [:= :__mb_source.text nil]]
              :limit  [:inline 10]})
            (qp.compile/compile
             (mt/mbql-query nil
@@ -556,14 +556,14 @@
 (deftest ^:parallel filter-by-number-fields-test
   (testing "Make sure we can filter by number fields form a source query"
     (is (= (honeysql->sql
-            {:select [[:source.ID :ID]
-                      [:source.NAME :NAME]
-                      [:source.CATEGORY_ID :CATEGORY_ID]
-                      [:source.LATITUDE :LATITUDE]
-                      [:source.LONGITUDE :LONGITUDE]
-                      [:source.PRICE :PRICE]]
-             :from   [[venues-source-honeysql :source]]
-             :where  [:> :source.sender_id [:inline 3]]
+            {:select [[:__mb_source.ID :ID]
+                      [:__mb_source.NAME :NAME]
+                      [:__mb_source.CATEGORY_ID :CATEGORY_ID]
+                      [:__mb_source.LATITUDE :LATITUDE]
+                      [:__mb_source.LONGITUDE :LONGITUDE]
+                      [:__mb_source.PRICE :PRICE]]
+             :from   [[venues-source-honeysql :__mb_source]]
+             :where  [:> :__mb_source.sender_id [:inline 3]]
              :limit  [:inline 10]})
            (qp.compile/compile
             (mt/mbql-query nil
@@ -583,7 +583,7 @@
                                                                                :type         :text
                                                                                :required     true
                                                                                :default      "Widget"}}}}])
-      (is (= {:query  "SELECT \"source\".* FROM (SELECT * FROM PRODUCTS WHERE CATEGORY = ? LIMIT 10) AS \"source\" LIMIT 1048575"
+      (is (= {:query  "SELECT \"__mb_source\".* FROM (SELECT * FROM PRODUCTS WHERE CATEGORY = ? LIMIT 10) AS \"__mb_source\" LIMIT 1048575"
               :params ["Widget"]}
              (qp.compile/compile
               {:database (meta/id)
@@ -1513,8 +1513,8 @@
                        {:source-query (:query q1)})]
               (when (= driver/*driver* :h2)
                 (is (= (update q1-native :query (fn [s]
-                                                  (format (str "SELECT \"source\".\"count\" AS \"count\" "
-                                                               "FROM (%s) AS \"source\" "
+                                                  (format (str "SELECT \"__mb_source\".\"count\" AS \"count\" "
+                                                               "FROM (%s) AS \"__mb_source\" "
                                                                "LIMIT 1048575")
                                                           s)))
                        (qp.compile/compile q2))))


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #70224
Fixes QUE2-396.

### Description

This is necessary because `source` is a reasonably common name for a
column, and databases diverge on how they treat a reference like
`"source"."source"`:

- Postgres et al see the relation `source` in scope, and access its
  column called `source`, and all is well.
- Athena et al:
  - See that there is a **column** `source` in scope that doesn't require a prefix.
  - Assume it's a nested column with `ROW` type, and try to access the
    nested `source` field.
  - Type mismatch! It's a string or whatever, not `ROW`.

This PR doesn't *eliminate* the problem, but there's not really anything
we can do to fix Athena's honestly pretty odd choice of how to resolve this
ambiguous parse tree. But by changing our hard-coded alias for all
nested queries from `source` to `__mb_source`, we can make it extremely
unlikely that it will collide with a column that's in scope.

### How to verify

Run an ambiguous query on Athena, like in the bug. It errors with

```
TYPE_MISMATCH: line 2:332: Expression "source" is not of type ROW
```

before this PR and works correctly with it. That generates a reference like
`__mb_source.source` now, which can only be interpreted as accessing the `source`
column of the `__mb_source` relation.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
