### PR TITLE
Clear ChartSettingSelect display value on remove

### DIFF
--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingSelect.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingSelect.jsx
@@ -58,7 +58,7 @@ export const ChartSettingSelect = ({
       data={data}
       dropdownComponent={dropdownComponent}
       disabled={disabled}
-      value={encodeWidgetValue(value)}
+      value={value === null ? value : encodeWidgetValue(value)}
       //Mantine V7 select onChange has 2 arguments passed. This breaks the assumption in visualizations/lib/settings.js where the onChange function is defined
       onChange={(v) => onChange(decodeWidgetValue(v))}
       placeholder={options.length === 0 ? placeholderNoOptions : placeholder}

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingSelect.unit.spec.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingSelect.unit.spec.jsx
@@ -128,4 +128,31 @@ describe("ChartSettingSelect", () => {
     );
     expect(screen.getByTestId("chart-setting-select")).toBeDisabled();
   });
+
+  it("should show placeholder text when value is cleared", () => {
+    const simpleOptions = [
+      { name: "Option 1", value: "value1" },
+      { name: "Option 2", value: "value2" },
+    ];
+    const { rerender } = render(
+      <ChartSettingSelect
+        options={simpleOptions}
+        value="value1"
+        onChange={jest.fn()}
+        placeholder="Pick a value"
+      />,
+    );
+    expect(screen.getByDisplayValue("Option 1")).toBeInTheDocument();
+
+    rerender(
+      <ChartSettingSelect
+        options={simpleOptions}
+        value={null}
+        onChange={jest.fn()}
+        placeholder="Pick a value"
+      />,
+    );
+
+    expect(screen.getByPlaceholderText("Pick a value")).toHaveValue("");
+  });
 });


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #70709
### Description

Updates the ChartSettingSelect to not encode null values. This allows the Select component to show a placeholder if the value has been cleared.

### How to verify

1. Set up a question for a scatter plot viz type (Orders, Count, group by year)
2. Set the bubble size to the count field
3. Clear the value, you should see the placeholder again.

### Demo

https://github.com/user-attachments/assets/33d4fb41-628c-4553-8014-bd35b288e762

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
