### PR TITLE
Update response on set token with network error

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/license/components/LicenseAndBillingSettings/LicenseAndBillingSettings.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/license/components/LicenseAndBillingSettings/LicenseAndBillingSettings.unit.spec.tsx
@@ -336,4 +336,25 @@ describe("LicenseAndBilling", () => {
       ),
     ).toBeInTheDocument();
   });
+
+  it("shows an message on a 503 (error accessing metabase store)", async () => {
+    await setup({ token: null });
+
+    expect(
+      await screen.findByText(
+        "Bought a license to unlock advanced functionality? Please enter it below.",
+      ),
+    ).toBeInTheDocument();
+
+    setupUpdateSettingEndpoint({ status: 503 });
+
+    await userEvent.type(screen.getByTestId("license-input"), "invalid");
+    await userEvent.click(await screen.findByTestId("activate-button"));
+
+    expect(
+      await screen.findByText(
+        "We're having trouble validating your token. Please double-check that your instance can connect to Metabase's servers.",
+      ),
+    ).toBeInTheDocument();
+  });
 });

--- a/enterprise/frontend/src/metabase-enterprise/settings/hooks/use-license.ts
+++ b/enterprise/frontend/src/metabase-enterprise/settings/hooks/use-license.ts
@@ -40,8 +40,12 @@ export const useLicense = (onActivated?: () => void) => {
         window.location.href += LICENSE_ACCEPTED_URL_HASH;
       }
       reload();
-    } catch {
-      setError(INVALID_TOKEN_ERROR);
+    } catch (e) {
+      if ((e as any).status === 503) {
+        setError(UNABLE_TO_VALIDATE_TOKEN);
+      } else {
+        setError(INVALID_TOKEN_ERROR);
+      }
     } finally {
       setIsUpdating(false);
     }

--- a/src/metabase/premium_features/token_check.clj
+++ b/src/metabase/premium_features/token_check.clj
@@ -491,7 +491,8 @@
                (analytics/inc-if-initialized! :metabase-token-check/attempt {:status :failure}))
              {:valid         false
               :status        (tru "Unable to validate token")
-              :error-details (.getMessage e)})))
+              :error-details (.getMessage e)
+              :error-type    :network})))
     (-clear-cache! [_] (-clear-cache! token-checker))))
 
 (def ^:dynamic *customize-checker*
@@ -566,7 +567,11 @@
                         {:status-code 400, :error-details "Token should be 64 hexadecimal characters."})))
       (let [decoded (check-token new-value)]
         (when-not (:valid decoded)
-          (throw (ex-info "Invalid token" {:token (u.str/mask new-value)}))))
+          (if (= :network (:error-type decoded))
+            (throw (ex-info (tru "Token validation failed due to a network error. Please check your internet connection and try again.")
+                            {:status-code   503
+                             :error-details (:error-details decoded)}))
+            (throw (ex-info "Invalid token" {:token (u.str/mask new-value)})))))
       (log/info "Token is valid."))
     (setting/set-value-of-type! :string :premium-embedding-token new-value)
     (events/publish-event! :event/set-premium-embedding-token {})

--- a/src/metabase/premium_features/token_check.clj
+++ b/src/metabase/premium_features/token_check.clj
@@ -172,6 +172,7 @@
    [:valid                          :boolean]
    [:status                         [:string {:min 1}]]
    [:error-details {:optional true} [:maybe [:string {:min 1}]]]
+   [:canonical?    {:optional true} [:maybe :boolean]]
    [:features      {:optional true} [:sequential [:string {:min 1}]]]
    [:plan-alias    {:optional true} :string]
    [:trial         {:optional true} :boolean]
@@ -198,12 +199,11 @@
   (let [{:keys [body status] :as resp} (http-fetch base-url token site-uuid)]
     (cond
       (http/success? resp) (do (analytics/inc-if-initialized! :metabase-token-check/attempt {:status :success})
-                               (some-> body json/decode+kw))
-      (<= 400 status 499) (or (some-> body json/decode+kw)
+                               (some-> body json/decode+kw (assoc :canonical? true)))
+      (<= 400 status 499) (or (some-> body json/decode+kw (assoc :canonical? true))
                               {:valid false
                                :status "Unable to validate token"
                                :error-details "Token validation provided no response"})
-
       ;; exceptions are not cached.
       :else (do (analytics/inc-if-initialized! :metabase-token-check/attempt {:status :failure})
                 (throw (ex-info "An unknown error occurred when validating token." {:status status
@@ -491,8 +491,7 @@
                (analytics/inc-if-initialized! :metabase-token-check/attempt {:status :failure}))
              {:valid         false
               :status        (tru "Unable to validate token")
-              :error-details (.getMessage e)
-              :error-type    :network})))
+              :error-details (.getMessage e)})))
     (-clear-cache! [_] (-clear-cache! token-checker))))
 
 (def ^:dynamic *customize-checker*
@@ -567,11 +566,13 @@
                         {:status-code 400, :error-details "Token should be 64 hexadecimal characters."})))
       (let [decoded (check-token new-value)]
         (when-not (:valid decoded)
-          (if (= :network (:error-type decoded))
-            (throw (ex-info (tru "Token validation failed due to a network error. Please check your internet connection and try again.")
-                            {:status-code   503
-                             :error-details (:error-details decoded)}))
-            (throw (ex-info "Invalid token" {:token (u.str/mask new-value)})))))
+          (throw (ex-info (:status decoded)
+                          {:error-details (:error-details decoded)
+                           ;; If MetaStore told us the token is invalid, use 400. If some other error occurred, a 503 is
+                           ;; probably more appropriate.
+                           :status-code (if (:canonical? decoded)
+                                          400
+                                          503)}))))
       (log/info "Token is valid."))
     (setting/set-value-of-type! :string :premium-embedding-token new-value)
     (events/publish-event! :event/set-premium-embedding-token {})

--- a/test/metabase/premium_features/token_check_test.clj
+++ b/test/metabase/premium_features/token_check_test.clj
@@ -211,7 +211,8 @@
             (Thread/sleep 60) ;; expire local-cached-token-checker
             (is (= {:valid         false
                     :status        "Unable to validate token"
-                    :error-details "network failure!"}
+                    :error-details "network failure!"
+                    :error-type    :network}
                    (token-check/check-token checker token)))))
         (finally
           (token-check/-clear-cache! checker))))))
@@ -558,7 +559,8 @@
       ;; error-catching wraps it, so we get the error-details response
       (is (= {:valid false
               :status "Unable to validate token"
-              :error-details "MetaStore unreachable"}
+              :error-details "MetaStore unreachable"
+              :error-type :network}
              (token-check/-check-token checker token))))))
 
 (deftest db-hash-aware-token-checker-tamper-resistance-test

--- a/test/metabase/premium_features/token_check_test.clj
+++ b/test/metabase/premium_features/token_check_test.clj
@@ -175,7 +175,7 @@
     (let [token       (tu/random-token)
           call-count  (atom 0)
           good-body   "{\"valid\":true,\"status\":\"fake\",\"features\":[\"fake\",\"features\"]}"
-          good-resp   {:valid true, :status "fake", :features ["fake" "features"]}
+          good-resp   {:valid true, :status "fake", :features ["fake" "features"], :canonical? true}
           local-cache (atom {})
           ;; no circuit breaker — it carries state between runs and causes flakes
           checker     (binding [token-check/*customize-checker* true]
@@ -211,8 +211,7 @@
             (Thread/sleep 60) ;; expire local-cached-token-checker
             (is (= {:valid         false
                     :status        "Unable to validate token"
-                    :error-details "network failure!"
-                    :error-type    :network}
+                    :error-details "network failure!"}
                    (token-check/check-token checker token)))))
         (finally
           (token-check/-clear-cache! checker))))))
@@ -220,7 +219,7 @@
 (deftest token-status-setting-test
   (testing "If a `premium-embedding-token` has been set, the `token-status` setting should return the response
             from the store.metabase.com endpoint for that token."
-    (is (= {:valid false, :status "Token does not exist."}
+    (is (= {:valid false, :status "Token does not exist.", :canonical? true}
            (token-check/check-token (tu/random-token)))))
   (testing "If premium-embedding-token is nil, the token-status setting should also be nil."
     (mt/with-temporary-setting-values [premium-embedding-token nil]
@@ -559,8 +558,7 @@
       ;; error-catching wraps it, so we get the error-details response
       (is (= {:valid false
               :status "Unable to validate token"
-              :error-details "MetaStore unreachable"
-              :error-type :network}
+              :error-details "MetaStore unreachable"}
              (token-check/-check-token checker token))))))
 
 (deftest db-hash-aware-token-checker-tamper-resistance-test
@@ -631,3 +629,44 @@
         (is (= 1 @call-count) "inner checker was called exactly once")
         ;; clear-cache! should also skip DB without error
         (token-check/-clear-cache! checker)))))
+
+;;; ------------------------------------------------ -set-premium-embedding-token! ------------------------------------------------
+
+(deftest set-premium-embedding-token-canonical-invalid-test
+  (testing "When MetaStore says the token is invalid (canonical), throws 400 with MetaStore's message"
+    (let [token (tu/random-token)]
+      (with-redefs [token-check/check-token (constantly {:valid        false
+                                                         :status       "Token expired"
+                                                         :error-details "Expired 2024-01-01"
+                                                         :canonical?   true})]
+        (let [e (try (token-check/-set-premium-embedding-token! token)
+                     nil
+                     (catch Exception e e))]
+          (is (some? e))
+          (is (= "Token expired" (ex-message e)))
+          (is (= 400 (:status-code (ex-data e))))
+          (is (= "Expired 2024-01-01" (:error-details (ex-data e)))))))))
+
+(deftest set-premium-embedding-token-non-canonical-failure-test
+  (testing "When token validation fails for non-canonical reasons (network etc), throws 503"
+    (let [token (tu/random-token)]
+      (with-redefs [token-check/check-token (constantly {:valid         false
+                                                         :status        "Unable to validate token"
+                                                         :error-details "Connection refused"})]
+        (let [e (try (token-check/-set-premium-embedding-token! token)
+                     nil
+                     (catch Exception e e))]
+          (is (some? e))
+          (is (= "Unable to validate token" (ex-message e)))
+          (is (= 503 (:status-code (ex-data e))))
+          (is (= "Connection refused" (:error-details (ex-data e)))))))))
+
+(deftest set-premium-embedding-token-valid-test
+  (testing "When token is valid, no exception is thrown and setting is persisted"
+    (let [token (tu/random-token)]
+      (with-redefs [token-check/check-token (constantly {:valid    true
+                                                         :status   "OK"
+                                                         :features ["test"]})]
+        (mt/with-temporary-setting-values [premium-embedding-token nil]
+          (token-check/-set-premium-embedding-token! token)
+          (is (= token (premium-features/premium-embedding-token))))))))


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #70367
### Description
Update the API to return a more specific response if token setting fails for network connectivity reasons

### How to verify
1. Set up an instance somewhere that there is no connectivity to the token server
2. Attempt to activate a license
3. You should see a more descriptive error message, rather than an error message sayin that the token is invalid

### Checklist

- [x] Tests have been added/updated to cover changes in this PR