### PR TITLE
Wrap dashboard filter items in a list container for accessibility

### DIFF
--- a/frontend/src/metabase/parameters/components/ParametersList/ParametersList.tsx
+++ b/frontend/src/metabase/parameters/components/ParametersList/ParametersList.tsx
@@ -112,6 +112,7 @@ export const ParametersList = forwardRef<HTMLDivElement, ParametersListProps>(
 
     return visibleValuePopulatedParameters.length > 0 ? (
       <Flex
+        role="list"
         display="flex"
         direction={vertical ? "column" : "row"}
         align="end"


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/70545

### Description

Dashboard filter parameters are rendered with `role="listitem"` on each individual filter widget (via the `Sortable` component in `ParameterWidget.tsx` and `ParameterValueWidget.tsx`), but the parent container (`Flex` in `ParametersList.tsx`) did not have `role="list"`. This is an ARIA violation: `listitem` elements must be contained within a `list` role container.

Added `role="list"` to the `Flex` wrapper in `ParametersList.tsx` so that the child filter items with `role="listitem"` have a valid accessible parent.

### How to verify

1. Open any dashboard with filters/parameters
2. Inspect the filter bar container in the DOM
3. Verify the container element now has `role="list"`
4. Run an accessibility audit (e.g., axe DevTools) and confirm no listitem-without-list violations

### Checklist

- [x] Tests have been added/updated to cover changes in this PR