### PR TITLE
Add role="gridcell" to DataGrid body cell wrappers for valid aria-selected usage (#70549)

### DIFF
--- a/frontend/src/metabase/data-grid/components/BodyCell/BodyCell.tsx
+++ b/frontend/src/metabase/data-grid/components/BodyCell/BodyCell.tsx
@@ -64,7 +64,6 @@ export const BodyCell = memo(function BodyCell<TValue>({
 
   return (
     <BaseCell
-      role="gridcell"
       align={align}
       isSelected={isSelected}
       className={cx(S.root, className, {

--- a/frontend/src/metabase/data-grid/components/DataGrid/DataGrid.tsx
+++ b/frontend/src/metabase/data-grid/components/DataGrid/DataGrid.tsx
@@ -348,6 +348,7 @@ export const DataGrid = function DataGrid<TData>({
                       return (
                         <div
                           key={cell.id}
+                          role="gridcell"
                           aria-selected={selection.isCellSelected(cell)}
                           data-column-id={cell.column.id}
                           data-selectable-cell={isSelectable ? "" : undefined}

--- a/frontend/src/metabase/data-grid/components/DataGrid/DataGrid.unit.spec.tsx
+++ b/frontend/src/metabase/data-grid/components/DataGrid/DataGrid.unit.spec.tsx
@@ -174,6 +174,23 @@ describe("DataGrid", () => {
     expect(screen.getByTestId("table-body")).toBeInTheDocument();
   });
 
+  it("renders body cells with role='gridcell' and aria-selected attributes", () => {
+    renderWithProviders(<TestDataGrid enableSelection />);
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    const bodyCells = screen
+      .getByTestId("table-body")
+      .querySelectorAll('[role="gridcell"]');
+
+    expect(bodyCells.length).toBeGreaterThan(0);
+
+    bodyCells.forEach((cell) => {
+      expect(cell).toHaveAttribute("aria-selected");
+    });
+  });
+
   it("calls onBodyCellClick when clicking a cell", () => {
     const onBodyCellClick = jest.fn();
     renderWithProviders(<TestDataGrid onBodyCellClick={onBodyCellClick} />);
@@ -237,7 +254,7 @@ describe("DataGrid", () => {
 
     const firstRow = rows[0];
     const cellsInRow = within(firstRow).getAllByRole("gridcell");
-    expect(cellsInRow.length).toBe(4); // 3 data columns + 1 row ID column
+    expect(cellsInRow.length).toBe(5); // 4 data columns + 1 row ID column
   });
 
   it("displays proper sort indicators for sortable columns", () => {

--- a/frontend/src/metabase/data-grid/components/DataGrid/DataGrid.unit.spec.tsx
+++ b/frontend/src/metabase/data-grid/components/DataGrid/DataGrid.unit.spec.tsx
@@ -174,7 +174,7 @@ describe("DataGrid", () => {
     expect(screen.getByTestId("table-body")).toBeInTheDocument();
   });
 
-  it("renders body cells with role='gridcell' and aria-selected attributes", () => {
+  it("renders body cells with role='gridcell' and aria-selected attributes (#70549)", () => {
     renderWithProviders(<TestDataGrid enableSelection />);
     act(() => {
       jest.runAllTimers();

--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.tsx
@@ -9,7 +9,7 @@ import FormattedParameterValue from "metabase/parameters/components/FormattedPar
 import S from "metabase/parameters/components/ParameterValueWidget.module.css";
 import { ParameterValueWidgetTrigger } from "metabase/parameters/components/ParameterValueWidgetTrigger";
 import { getParameterIconName } from "metabase/parameters/utils/ui";
-import { Box, Icon, Popover, type PopoverProps } from "metabase/ui";
+import { Icon, Popover, type PopoverProps } from "metabase/ui";
 import type { UiParameter } from "metabase-lib/v1/parameters/types";
 import {
   isBooleanParameter,
@@ -240,88 +240,83 @@ export const ParameterValueWidget = ({
   }
 
   return (
-    <Popover
-      opened={isOpen}
-      onChange={toggle}
-      position="bottom-start"
-      trapFocus
-      middlewares={{ flip: true, shift: true }}
-      clickOutsideEvents={["mousedown", "touchstart", "pointerdown"]}
-      {...popoverProps}
+    <Sortable
+      id={parameter.id}
+      draggingStyle={{ opacity: 0.5 }}
+      disabled={!isSortable}
+      role="listitem"
     >
-      <Popover.Target>
-        <Box
-          data-testid="parameter-value-widget-target"
-          onClick={toggle}
-          className={CS.cursorPointer}
-          maw="100%"
-        >
-          <Sortable
-            id={parameter.id}
-            draggingStyle={{ opacity: 0.5 }}
-            disabled={!isSortable}
-            role="listitem"
-          >
-            <ParameterValueWidgetTrigger
-              hasValue={hasValue}
-              className={className}
-              ariaLabel={placeholder}
-              mimicMantine={mimicMantine}
-              hasPopover
-            >
-              {typeIcon}
-              {prefix && <div className={S.Prefix}>{prefix}</div>}
-              <div
-                className={CS.mr1}
-                style={
-                  isStringParameter(parameter)
-                    ? { maxWidth: "190px" }
-                    : {
-                        overflow: "hidden",
-                        textOverflow: "ellipsis",
-                      }
-                }
-              >
-                <FormattedParameterValue
-                  parameter={parameter}
-                  value={value}
-                  cardId={cardId}
-                  dashboardId={dashboardId}
-                  placeholder={translatedPlaceholder}
-                  isPopoverOpen={isOpen}
-                />
-              </div>
-              {getActionIcon()}
-            </ParameterValueWidgetTrigger>
-          </Sortable>
-        </Box>
-      </Popover.Target>
-      <Popover.Dropdown
-        // Removes `maxWidth` so that `floating-ui` can detect the new element size. See metabase#52918 for details.
-        // Use `size` middleware options when we upgrade to mantine v7.
-        maw={isDateParameter(parameter) ? "100vw !important" : undefined}
-        data-testid="parameter-value-dropdown"
+      <Popover
+        opened={isOpen}
+        onChange={toggle}
+        position="bottom-start"
+        trapFocus
+        middlewares={{ flip: true, shift: true }}
+        clickOutsideEvents={["mousedown", "touchstart", "pointerdown"]}
+        {...popoverProps}
       >
-        <ParameterDropdownWidget
-          parameter={parameter}
-          parameters={parameters}
-          cardId={cardId}
-          dashboardId={dashboardId}
-          value={value}
-          setValue={setValue}
-          isEditing={isEditing}
-          placeholder={placeholder}
-          focusChanged={setIsFocused}
-          isFullscreen={isFullscreen}
-          commitImmediately={commitImmediately}
-          setParameterValueToDefault={setParameterValueToDefault}
-          enableRequiredBehavior={enableRequiredBehavior}
-          isSortable={isSortable}
-          onFocusChanged={onFocusChanged}
-          onPopoverClose={close}
-        />
-      </Popover.Dropdown>
-    </Popover>
+        <Popover.Target>
+          <ParameterValueWidgetTrigger
+            data-testid="parameter-value-widget-target"
+            onClick={toggle}
+            hasValue={hasValue}
+            className={cx(CS.cursorPointer, className)}
+            ariaLabel={placeholder}
+            mimicMantine={mimicMantine}
+            hasPopover
+          >
+            {typeIcon}
+            {prefix && <div className={S.Prefix}>{prefix}</div>}
+            <div
+              className={CS.mr1}
+              style={
+                isStringParameter(parameter)
+                  ? { maxWidth: "190px" }
+                  : {
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                    }
+              }
+            >
+              <FormattedParameterValue
+                parameter={parameter}
+                value={value}
+                cardId={cardId}
+                dashboardId={dashboardId}
+                placeholder={translatedPlaceholder}
+                isPopoverOpen={isOpen}
+              />
+            </div>
+            {getActionIcon()}
+          </ParameterValueWidgetTrigger>
+        </Popover.Target>
+        <Popover.Dropdown
+          // Removes `maxWidth` so that `floating-ui` can detect the new element size. See metabase#52918 for details.
+          // Use `size` middleware options when we upgrade to mantine v7.
+          maw={isDateParameter(parameter) ? "100vw !important" : undefined}
+          data-testid="parameter-value-dropdown"
+        >
+          <ParameterDropdownWidget
+            parameter={parameter}
+            parameters={parameters}
+            cardId={cardId}
+            dashboardId={dashboardId}
+            value={value}
+            setValue={setValue}
+            isEditing={isEditing}
+            placeholder={placeholder}
+            focusChanged={setIsFocused}
+            isFullscreen={isFullscreen}
+            commitImmediately={commitImmediately}
+            setParameterValueToDefault={setParameterValueToDefault}
+            enableRequiredBehavior={enableRequiredBehavior}
+            isSortable={isSortable}
+            onFocusChanged={onFocusChanged}
+            onPopoverClose={close}
+          />
+        </Popover.Dropdown>
+      </Popover>
+    </Sortable>
   );
 };
 

--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.unit.spec.tsx
@@ -1,0 +1,53 @@
+import userEvent from "@testing-library/user-event";
+
+import { renderWithProviders, screen } from "__support__/ui";
+import type { UiParameter } from "metabase-lib/v1/parameters/types";
+import { createMockParameter } from "metabase-types/api/mocks";
+
+import { ParameterValueWidget } from "./ParameterValueWidget";
+
+function setup({ parameter }: { parameter?: Partial<UiParameter> } = {}) {
+  const defaultParameter: UiParameter = {
+    ...createMockParameter({
+      id: "test-param",
+      type: "string/=",
+      slug: "text",
+      name: "Text",
+    }),
+    fields: [],
+    ...parameter,
+  } as UiParameter;
+
+  const setValue = jest.fn();
+
+  renderWithProviders(
+    <ParameterValueWidget
+      parameter={defaultParameter}
+      setValue={setValue}
+      value={null}
+      placeholder="Enter a value"
+    />,
+  );
+
+  return { setValue };
+}
+
+describe("ParameterValueWidget", () => {
+  it("should apply aria-expanded on the trigger button element, not a wrapper div", async () => {
+    setup();
+
+    const triggerButton = screen.getByTestId("parameter-value-widget-target");
+
+    // The trigger should be a button element (rendered via UnstyledButton when hasPopover is true)
+    expect(triggerButton.tagName).toBe("BUTTON");
+
+    // Before opening, aria-expanded should be false
+    expect(triggerButton).toHaveAttribute("aria-expanded", "false");
+
+    // Open the popover
+    await userEvent.click(triggerButton);
+
+    // After opening, aria-expanded should be true on the same button
+    expect(triggerButton).toHaveAttribute("aria-expanded", "true");
+  });
+});

--- a/frontend/src/metabase/parameters/components/ParameterValueWidgetTrigger.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidgetTrigger.tsx
@@ -1,5 +1,10 @@
 import cx from "classnames";
-import { type ReactNode, type Ref, forwardRef } from "react";
+import {
+  type HTMLAttributes,
+  type ReactNode,
+  type Ref,
+  forwardRef,
+} from "react";
 
 import { Box, Flex, UnstyledButton } from "metabase/ui";
 
@@ -9,6 +14,15 @@ export const ParameterValueWidgetTrigger = forwardRef(
   ParameterValueWidgetTriggerInner,
 );
 
+type ParameterValueWidgetTriggerProps = {
+  children: ReactNode;
+  hasValue: boolean;
+  ariaLabel?: string;
+  className?: string;
+  mimicMantine?: boolean;
+  hasPopover?: boolean;
+} & Omit<HTMLAttributes<HTMLElement>, "children">;
+
 function ParameterValueWidgetTriggerInner(
   {
     children,
@@ -17,14 +31,8 @@ function ParameterValueWidgetTriggerInner(
     className,
     mimicMantine = false,
     hasPopover = false,
-  }: {
-    children: ReactNode;
-    hasValue: boolean;
-    ariaLabel?: string;
-    className?: string;
-    mimicMantine?: boolean;
-    hasPopover?: boolean;
-  },
+    ...htmlProps
+  }: ParameterValueWidgetTriggerProps,
   ref: Ref<HTMLButtonElement | HTMLButtonElement>,
 ) {
   const attributes = hasPopover
@@ -52,6 +60,7 @@ function ParameterValueWidgetTriggerInner(
           [S.hasValue]: hasValue,
         })}
         aria-label={ariaLabel}
+        {...htmlProps}
         {...attributes}
       >
         {children}
@@ -66,6 +75,7 @@ function ParameterValueWidgetTriggerInner(
       })}
       aria-label={ariaLabel}
       maw="100%"
+      {...htmlProps}
       {...attributes}
     >
       {children}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/70549

### Description

The DataGrid body cell wrapper divs had `aria-selected` attributes but no valid
ARIA role, which violates WAI-ARIA spec (`aria-selected` is only valid on elements
with roles like `gridcell`, `option`, `row`, `tab`, `columnheader`, `rowheader`, `treeitem`).

Moved `role="gridcell"` from the inner `BodyCell` component to the outer wrapper
div in `DataGrid.tsx` — the same element that carries `aria-selected`. This ensures
all body cells (including `RowIdCell` and custom cell renderers) have the correct
role without creating nested gridcell roles.

### How to verify

1. Open any question with a table visualization
2. Inspect the table body cells in browser DevTools
3. Confirm each cell wrapper div has both `role="gridcell"` and `aria-selected`
4. Run an accessibility audit (e.g. axe DevTools) and verify no violations for
   `aria-selected` on elements without a valid role

### Checklist

- [x] Tests have been added/updated to cover changes in this PR