### PR TITLE
Correctly hide/show card filters based on permissions

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -525,7 +525,16 @@ export function DashCardVisualization({
         result,
       });
 
-    const showInlineParams = inlineParameters.length > 0;
+    const cardResult = dashcard.card_id
+      ? datasets?.[dashcard.card_id]
+      : undefined;
+    const errorStatus =
+      cardResult?.error && typeof cardResult.error === "object"
+        ? cardResult.error.status
+        : undefined;
+    const hasViewAccess = !cardResult || errorStatus !== 403;
+
+    const showInlineParams = inlineParameters.length > 0 && hasViewAccess;
 
     if (!showMenu && !showInlineParams) {
       return null;
@@ -567,6 +576,7 @@ export function DashCardVisualization({
     dashboard,
     dashcard,
     dashcardMenu,
+    datasets,
     isEditing,
     inlineParameters,
     onChangeCardAndRun,

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -516,21 +516,24 @@ export function DashCardVisualization({
   const actionButtons = useMemo(() => {
     const result = series[0] as unknown as Dataset;
 
-    if (
-      !question ||
-      !DashCardMenu.shouldRender({
+    const showMenu =
+      question &&
+      DashCardMenu.shouldRender({
         question,
         dashboard,
         dashcardMenu,
         result,
-      })
-    ) {
+      });
+
+    const showInlineParams = inlineParameters.length > 0;
+
+    if (!showMenu && !showInlineParams) {
       return null;
     }
 
     return (
       <Group>
-        {inlineParameters.length > 0 && (
+        {showInlineParams && (
           <CollapsibleDashboardParameterList
             className={S.InlineParametersList}
             triggerClassName={S.InlineParametersMenuTrigger}
@@ -541,7 +544,7 @@ export function DashCardVisualization({
             ref={parameterListRef}
           />
         )}
-        {!isEditing && (
+        {showMenu && !isEditing && (
           <DashCardMenu
             question={question}
             result={result}

--- a/frontend/src/metabase/dashboard/components/DashCard/Dashcard.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/Dashcard.unit.spec.tsx
@@ -11,6 +11,7 @@ import {
   screen,
   within,
 } from "__support__/ui";
+import * as dashboardSelectors from "metabase/dashboard/selectors";
 import {
   MockDashboardContext,
   type MockDashboardContextProps,
@@ -28,6 +29,8 @@ import {
   createMockHeadingDashboardCard,
   createMockIFrameDashboardCard,
   createMockLinkDashboardCard,
+  createMockNativeCard,
+  createMockParameter,
   createMockPlaceholderDashboardCard,
   createMockTable,
   createMockTextDashboardCard,
@@ -105,7 +108,17 @@ function setup({
   } = {}) {
   const onReplaceCard = jest.fn();
 
+  const dashcardIds = (dashboard.dashcards ?? []).map(
+    (dc: { id: number } | number) => (typeof dc === "number" ? dc : dc.id),
+  );
   const baseDashboardState = createMockDashboardState({
+    dashboardId: dashboard.id,
+    dashboards: {
+      [dashboard.id]: {
+        ...dashboard,
+        dashcards: dashcardIds.length > 0 ? dashcardIds : [dashcard.id],
+      },
+    },
     dashcardData,
     dashcards: {
       [dashcard.id]: dashcard,
@@ -528,6 +541,67 @@ describe("DashCard", () => {
         });
         expect(screen.queryByLabelText("Add a filter")).not.toBeInTheDocument();
       });
+    });
+  });
+
+  describe("inline parameters", () => {
+    it("should show inline parameters even when the card has an error and user cannot edit (GHY-3228)", () => {
+      const parameter = createMockParameter({
+        id: "param-1",
+        name: "State",
+        type: "string/=",
+        slug: "state",
+      });
+
+      const nativeCard = createMockNativeCard({
+        name: "SQL Card",
+        can_write: false,
+      });
+
+      const dashcard = createMockDashboardCard({
+        card: nativeCard,
+        inline_parameters: [parameter.id],
+        parameter_mappings: [
+          {
+            card_id: nativeCard.id,
+            parameter_id: parameter.id,
+            target: ["variable", ["template-tag", "state"]],
+          },
+        ],
+      });
+
+      const dashboard = createMockDashboard({
+        parameters: [parameter],
+        dashcards: [dashcard],
+      });
+
+      const dashcardData: DashCardDataMap = {
+        [dashcard.id]: {
+          [nativeCard.id]: createMockDataset({
+            data: createMockDatasetData({ rows: [], cols: [] }),
+            database_id: 1,
+            context: "dashboard",
+            status: "error",
+            error: { status: 400 },
+          }),
+        },
+      };
+
+      jest
+        .spyOn(dashboardSelectors, "getDashCardInlineValuePopulatedParameters")
+        .mockReturnValue([parameter]);
+
+      setup({
+        dashboard,
+        dashcard,
+        dashcardData,
+      });
+
+      // The inline parameter filter should be visible even when the card
+      // errors and the user cannot edit the question. Before the fix,
+      // both inline parameters and the download button were gated behind
+      // DashCardMenu.shouldRender(), which returned false in this case.
+      expect(screen.getByText("State")).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/metabase/dashboard/components/DashCard/Dashcard.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/Dashcard.unit.spec.tsx
@@ -603,5 +603,63 @@ describe("DashCard", () => {
       // DashCardMenu.shouldRender(), which returned false in this case.
       expect(screen.getByText("State")).toBeInTheDocument();
     });
+
+    it("should hide inline parameters when the card returns a 403 error (no view-data permission) (GHY-3228)", () => {
+      const parameter = createMockParameter({
+        id: "param-1",
+        name: "State",
+        type: "string/=",
+        slug: "state",
+      });
+
+      const nativeCard = createMockNativeCard({
+        name: "SQL Card",
+        can_write: false,
+      });
+
+      const dashcard = createMockDashboardCard({
+        card: nativeCard,
+        inline_parameters: [parameter.id],
+        parameter_mappings: [
+          {
+            card_id: nativeCard.id,
+            parameter_id: parameter.id,
+            target: ["variable", ["template-tag", "state"]],
+          },
+        ],
+      });
+
+      const dashboard = createMockDashboard({
+        parameters: [parameter],
+        dashcards: [dashcard],
+      });
+
+      const dashcardData: DashCardDataMap = {
+        [dashcard.id]: {
+          [nativeCard.id]: createMockDataset({
+            data: createMockDatasetData({ rows: [], cols: [] }),
+            database_id: 1,
+            context: "dashboard",
+            status: "error",
+            error: { status: 403 },
+          }),
+        },
+      };
+
+      jest
+        .spyOn(dashboardSelectors, "getDashCardInlineValuePopulatedParameters")
+        .mockReturnValue([parameter]);
+
+      setup({
+        dashboard,
+        dashcard,
+        dashcardData,
+      });
+
+      // When the user has no view-data permission (403), the inline
+      // parameter filter should be hidden — there's no point showing
+      // a filter for data the user can't access.
+      expect(screen.queryByText("State")).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/metabase/query_processor/dashboard.clj
+++ b/src/metabase/query_processor/dashboard.clj
@@ -181,10 +181,10 @@
     (api/read-check :model/Dashboard dashboard-id)
     (check-card-and-dashcard-are-in-dashboard dashboard-id card-id dashcard-id)
     (api/check-403
-     (= :unrestricted
-        (perms/most-permissive-database-permission-for-user
-         api/*current-user-id* :perms/view-data
-         (t2/select-one-fn :database_id :model/Card card-id))))
+     (not= :blocked
+           (perms/most-permissive-database-permission-for-user
+            api/*current-user-id* :perms/view-data
+            (t2/select-one-fn :database_id :model/Card card-id))))
     (let [resolved-params (resolve-params-for-query dashboard-id card-id dashcard-id parameters)
           options         (merge
                            {:ignore-cache false

--- a/src/metabase/query_processor/dashboard.clj
+++ b/src/metabase/query_processor/dashboard.clj
@@ -9,6 +9,7 @@
    [metabase.events.core :as events]
    [metabase.lib.core :as lib]
    [metabase.lib.schema.id :as lib.schema.id]
+   [metabase.permissions.core :as perms]
    [metabase.query-processor.card :as qp.card]
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.query-processor.middleware.constraints :as qp.constraints]
@@ -179,6 +180,11 @@
     ;; [[qp.card/process-query-for-card]]
     (api/read-check :model/Dashboard dashboard-id)
     (check-card-and-dashcard-are-in-dashboard dashboard-id card-id dashcard-id)
+    (api/check-403
+     (= :unrestricted
+        (perms/most-permissive-database-permission-for-user
+         api/*current-user-id* :perms/view-data
+         (t2/select-one-fn :database_id :model/Card card-id))))
     (let [resolved-params (resolve-params-for-query dashboard-id card-id dashcard-id parameters)
           options         (merge
                            {:ignore-cache false

--- a/src/metabase/query_processor/dashboard.clj
+++ b/src/metabase/query_processor/dashboard.clj
@@ -180,6 +180,12 @@
     ;; [[qp.card/process-query-for-card]]
     (api/read-check :model/Dashboard dashboard-id)
     (check-card-and-dashcard-are-in-dashboard dashboard-id card-id dashcard-id)
+    ;; Early view-data permission check so that blocked users get a 403 *before* parameter
+    ;; resolution. Without this, a missing required parameter would produce a 400, and the
+    ;; frontend couldn't distinguish "no permission" (hide inline filters) from "missing
+    ;; params" (show inline filters). The QP middleware's check-block-permissions does a
+    ;; thorough check later on the resolved query; this is intentionally just the card's
+    ;; database_id since we don't have the resolved query yet.
     (api/check-403
      (not= :blocked
            (perms/most-permissive-database-permission-for-user

--- a/test/metabase/dashboards_rest/api_test.clj
+++ b/test/metabase/dashboards_rest/api_test.clj
@@ -3659,7 +3659,19 @@
                 (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/view-data :unrestricted)
                 (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/create-queries :no)
                 (is (malli= (dashboard-card-query-expected-results-schema)
-                            (mt/user-http-request :rasta :post 202 (url)))))))
+                            (mt/user-http-request :rasta :post 202 (url))))))
+            (testing "Should return 403 if user does not have view-data permission (GHY-3228)"
+              (mt/with-no-data-perms-for-all-users!
+                (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/view-data :blocked)
+                (is (= "You don't have permissions to do that."
+                       (mt/user-http-request :rasta :post 403 (url))))))
+            (testing "Should return 403 for blocked view-data even with invalid parameters (GHY-3228)"
+              (mt/with-no-data-perms-for-all-users!
+                (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/view-data :blocked)
+                (is (= "You don't have permissions to do that."
+                       (mt/user-http-request :rasta :post 403 (url)
+                                             {:parameters [{:id    "FAKE_PARAM"
+                                                            :value "fake"}]}))))))
           (testing "Validation"
             (testing "404s"
               (testing "Should return 404 if Dashboard doesn't exist"


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #70881
Closes GHY-3228

  - Fix a bug where card-specific (inline) parameter filters were hidden for users without native query permissions on SQL dashboard cards, making it  impossible to provide the filter value needed to load the card
  - Add a backend view-data permission check so users without data access get a proper 403 instead of a 400 and the frontend can distinguish "no permission" from "missing parameter"
  - On the frontend, decouple inline parameter visibility from the DashCardMenu.shouldRender() guard so filters render independently of the download menu

  Problem

  When a SQL card with a {{template_tag}} parameter was added to a dashboard with a card-specific inline filter, non-admin users saw neither the filter widget nor the card
  data:

  1. DashCardMenu.shouldRender() returned false because canEditQuestion = false (no native query permission) and canDownloadResults = false (card errored due to missing
  parameter value)
  2. Both the CollapsibleDashboardParameterList and DashCardMenu were gated behind this single check
  3. The filter needed to load the card was hidden because the card couldn't load without the filter — a deadlock

  Fix

  Backend (query_processor/dashboard.clj): Added an explicit view-data permission check using most-permissive-database-permission-for-user. This returns 403 when a user has
  no view-data access, taking precedence over parameter validation errors (400).

  Frontend (DashCardVisualization.tsx): Decoupled the three concerns:
  - Inline parameters render when inlineParameters.length > 0 AND the user has view access (no 403 on the card result)
  - DashCardMenu (download button) renders when DashCardMenu.shouldRender() is true (requires canEditQuestion or canDownloadResults)
  - 403 from backend hides both inline params and menu — no point showing UI for data the user can't access

  Test plan

  - Backend: user with blocked view-data permission gets 403 on dashboard card query
  - Backend: 403 is returned even when parameters are invalid (permission check takes precedence)
  - Backend: user with view-data but no create-queries permission can still query (existing test, unchanged)
  - Frontend: inline params visible when card errors with 400 and user can't edit
  - Frontend: inline params hidden when card errors with 403 (no view-data permission)

Demo

https://www.loom.com/share/6c8ad7db7b874600b850950205d0014a
