### PR TITLE
Increase the polling timeout

### DIFF
--- a/test/metabase/queries_rest/api/card_test.clj
+++ b/test/metabase/queries_rest/api/card_test.clj
@@ -326,7 +326,7 @@
                                                          "x-metabase-client-version" "2"}}})
       (is (=? {:embedding_client "client-B", :embedding_version "2"}
               ;; The query metadata is handled asynchronously, so we need to poll until it's available:
-              (tu/poll-until 500
+              (tu/poll-until 2000
                              (t2/select-one [:model/QueryExecution :embedding_client :embedding_version]
                                             :card_id (u/the-id card-1))))))))
 


### PR DESCRIPTION
This is a band-aid fix for DEV-1693

It would be wise to examine what changed so that 500 ms is not enough anymore. This might point to a performance regression. Also, this needs a more robust long-term solution. Arbitrary waiting should be avoided whenever possible.