### PR TITLE
Fix mage mise-diagnosis

### DIFF
--- a/mage/src/mage/doctor.clj
+++ b/mage/src/mage/doctor.clj
@@ -125,7 +125,7 @@
     {:installed? false}
     (let [doctor-json (try
                         ;; `mise doctor` has a non-zero exit code when there are pending installs,
-                        ;;  but still produces valid JSON on stdout — but `sh` requires exit 0.
+                        ;; but still produces valid JSON on stdout — but `sh` requires exit 0.
                         (some-> @(p/process {:out :string, :err :string, :dir u/project-root-directory}
                                             "mise" "doctor" "--json")
                                 :out str/trim not-empty

--- a/mage/src/mage/doctor.clj
+++ b/mage/src/mage/doctor.clj
@@ -124,7 +124,11 @@
   (if-not (can-run? "mise")
     {:installed? false}
     (let [doctor-json (try
-                        (some-> (sh "mise" "doctor" "--json")
+                        ;; `mise doctor` has a non-zero exit code when there are pending installs,
+                        ;;  but still produces valid JSON on stdout — but `sh` requires exit 0.
+                        (some-> @(p/process {:out :string, :err :string, :dir u/project-root-directory}
+                                            "mise" "doctor" "--json")
+                                :out str/trim not-empty
                                 json/read-str)
                         (catch Exception _ nil))
           config-json (try


### PR DESCRIPTION
If there are any warnings from mise, e.g. some new packages haven't been installed, mage currently misreports this as mise not being activated.

I got kinda confused by this while looking into an issue with an unrelated tool.
