### PR TITLE
Clear transform permissions

### DIFF
--- a/resources/migrations/058_update_migrations.yaml
+++ b/resources/migrations/058_update_migrations.yaml
@@ -1228,6 +1228,18 @@ databaseChangeLog:
         - customChange:
             class: "metabase.app_db.custom_migrations.FixClickHouseUploadDBSchemaNames"
 
+
+  - changeSet:
+      id: v58.2026-03-17T00:00:11
+      author: nvoxland
+      comment: Clear out transform permissions from downgrade
+      changes:
+        - sql:
+            sql: delete from data_permissions where perm_type='perms/transforms';
+      rollback:
+        # unneeded
+
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################


### PR DESCRIPTION
Closes #70966

### Description

On downgrade from 59, transform permissions are not deleted. This adds a change which will delete them out on 58 only. This will not be carried forward to 59+ because it's only on 58 that the permissions no longer apply and should be deleted.

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
