### PR TITLE
docs - Fix typo in JWT group mapping documentation

### DIFF
--- a/docs/people-and-groups/authenticating-with-jwt.md
+++ b/docs/people-and-groups/authenticating-with-jwt.md
@@ -65,7 +65,7 @@ You can configure JWT group assignments through Metabase's Admin interface, or b
 
 ### Configure group mapping through environment variables
 
-You can use the following environment variables to configure JTW group mappings instead of configuring them in Metabase's Admin settings:
+You can use the following environment variables to configure JWT group mappings instead of configuring them in Metabase's Admin settings:
 
 - [`MB_JWT_ATTRIBUTE_GROUPS`](../configuring-metabase/environment-variables.md#mb_jwt_attribute_groups) to specify the key to retrieve the JWT user's groups;
 


### PR DESCRIPTION
Like it says on the tin.