### PR TITLE
Fixed flaky e2e test

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
@@ -299,13 +299,15 @@ describe("scenarios > embedding > sdk iframe embedding > custom elements api", (
       <metabase-question question-id="${ORDERS_QUESTION_ID}" drills="false" />
       `);
 
+      cy.wait("@getCardQuery");
+
       H.getSimpleEmbedIframeContent()
         .findAllByText("37.65", { timeout: 40000 })
+        .as("cell")
         .first()
-        .should("be.visible");
+        .should("be.visible")
+        .click();
 
-      // Re-query the element to avoid "page updated" errors from table re-renders
-      H.getSimpleEmbedIframeContent().findAllByText("37.65").first().click();
       H.getSimpleEmbedIframeContent()
         .findByText(/Filter by this value/)
         .should("not.exist");

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
@@ -300,7 +300,7 @@ describe("scenarios > embedding > sdk iframe embedding > custom elements api", (
       `);
 
       H.getSimpleEmbedIframeContent()
-        .findAllByText("37.65")
+        .findAllByText("37.65", { timeout: 40000 })
         .first()
         .should("be.visible")
         .click();

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
@@ -193,6 +193,8 @@ describe("scenarios > embedding > sdk iframe embedding > custom elements api", (
         <metabase-dashboard dashboard-id="${dashboard_id}" drills="false" />
         `);
 
+        cy.wait(5000);
+
         H.getSimpleEmbedIframeContent()
           .findAllByText("37.65")
           .first()

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
@@ -310,9 +310,10 @@ describe("scenarios > embedding > sdk iframe embedding > custom elements api", (
 
         cy.wait("@getCardQuery");
 
-        H.getSimpleEmbedIframeContent().findAllByText("37.65").as("cells");
-        cy.get("@cells").first().as("cell");
-        cy.get("@cell").should("be.visible").click();
+        H.getSimpleEmbedIframeContent()
+          .findByText("37.65")
+          .should("be.visible")
+          .click();
 
         H.getSimpleEmbedIframeContent()
           .findByText(/Filter by this value/)

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
@@ -193,6 +193,8 @@ describe("scenarios > embedding > sdk iframe embedding > custom elements api", (
         <metabase-dashboard dashboard-id="${dashboard_id}" drills="false" />
         `);
 
+        cy.wait("@getDashCardQuery");
+
         H.getSimpleEmbedIframeContent()
           .findAllByText("37.65")
           .first()

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
@@ -157,37 +157,51 @@ describe("scenarios > embedding > sdk iframe embedding > custom elements api", (
     });
 
     it("should enable drill-through when drills is true", () => {
-      H.visitCustomHtmlPage(`
-      ${H.getNewEmbedScriptTag()}
-      ${H.getNewEmbedConfigurationScript()}
-      <metabase-dashboard dashboard-id="${ORDERS_DASHBOARD_ID}" drills />
-      `);
+      H.createQuestionAndDashboard({
+        questionDetails: {
+          name: "Limited Orders",
+          query: { "source-table": ORDERS_ID, limit: 5 },
+        },
+      }).then(({ body: { dashboard_id } }) => {
+        H.visitCustomHtmlPage(`
+        ${H.getNewEmbedScriptTag()}
+        ${H.getNewEmbedConfigurationScript()}
+        <metabase-dashboard dashboard-id="${dashboard_id}" drills />
+        `);
 
-      H.getSimpleEmbedIframeContent()
-        .findAllByText("37.65")
-        .first()
-        .should("be.visible")
-        .click();
-      H.getSimpleEmbedIframeContent()
-        .findByText(/Filter by this value/)
-        .should("be.visible");
+        H.getSimpleEmbedIframeContent()
+          .findAllByText("37.65")
+          .first()
+          .should("be.visible")
+          .click();
+        H.getSimpleEmbedIframeContent()
+          .findByText(/Filter by this value/)
+          .should("be.visible");
+      });
     });
 
     it("should disable drill-through when drills is false", () => {
-      H.visitCustomHtmlPage(`
-      ${H.getNewEmbedScriptTag()}
-      ${H.getNewEmbedConfigurationScript()}
-      <metabase-dashboard dashboard-id="${ORDERS_DASHBOARD_ID}" drills="false" />
-      `);
+      H.createQuestionAndDashboard({
+        questionDetails: {
+          name: "Limited Orders",
+          query: { "source-table": ORDERS_ID, limit: 5 },
+        },
+      }).then(({ body: { dashboard_id } }) => {
+        H.visitCustomHtmlPage(`
+        ${H.getNewEmbedScriptTag()}
+        ${H.getNewEmbedConfigurationScript()}
+        <metabase-dashboard dashboard-id="${dashboard_id}" drills="false" />
+        `);
 
-      H.getSimpleEmbedIframeContent()
-        .findAllByText("37.65")
-        .first()
-        .should("be.visible")
-        .click();
-      H.getSimpleEmbedIframeContent()
-        .findByText(/Filter by this value/)
-        .should("not.exist");
+        H.getSimpleEmbedIframeContent()
+          .findAllByText("37.65")
+          .first()
+          .should("be.visible")
+          .click();
+        H.getSimpleEmbedIframeContent()
+          .findByText(/Filter by this value/)
+          .should("not.exist");
+      });
     });
   });
 

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
@@ -310,6 +310,12 @@ describe("scenarios > embedding > sdk iframe embedding > custom elements api", (
 
         cy.wait("@getCardQuery");
 
+        // Wait for the table to finish rendering before interacting,
+        // as column auto-sizing can cause re-renders that detach elements.
+        H.getSimpleEmbedIframeContent()
+          .findByTestId("table-root")
+          .should("have.attr", "data-rows-count", "5");
+
         H.getSimpleEmbedIframeContent()
           .findByText("37.65")
           .should("be.visible")

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
@@ -316,6 +316,8 @@ describe("scenarios > embedding > sdk iframe embedding > custom elements api", (
           .findByTestId("table-root")
           .should("have.attr", "data-rows-count", "5");
 
+        cy.wait(5000);
+
         H.getSimpleEmbedIframeContent()
           .findByText("37.65")
           .should("be.visible")

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
@@ -302,8 +302,10 @@ describe("scenarios > embedding > sdk iframe embedding > custom elements api", (
       H.getSimpleEmbedIframeContent()
         .findAllByText("37.65", { timeout: 40000 })
         .first()
-        .should("be.visible")
-        .click();
+        .should("be.visible");
+
+      // Re-query the element to avoid "page updated" errors from table re-renders
+      H.getSimpleEmbedIframeContent().findAllByText("37.65").first().click();
       H.getSimpleEmbedIframeContent()
         .findByText(/Filter by this value/)
         .should("not.exist");

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
@@ -193,13 +193,11 @@ describe("scenarios > embedding > sdk iframe embedding > custom elements api", (
         <metabase-dashboard dashboard-id="${dashboard_id}" drills="false" />
         `);
 
-        cy.wait(5000);
-
         H.getSimpleEmbedIframeContent()
           .findAllByText("37.65")
           .first()
           .should("be.visible")
-          .click();
+          .click({ force: true });
         H.getSimpleEmbedIframeContent()
           .findByText(/Filter by this value/)
           .should("not.exist");
@@ -332,12 +330,10 @@ describe("scenarios > embedding > sdk iframe embedding > custom elements api", (
           .findByTestId("table-root")
           .should("have.attr", "data-rows-count", "5");
 
-        cy.wait(5000);
-
         H.getSimpleEmbedIframeContent()
           .findByText("37.65")
           .should("be.visible")
-          .click();
+          .click({ force: true });
 
         H.getSimpleEmbedIframeContent()
           .findByText(/Filter by this value/)

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
@@ -276,41 +276,51 @@ describe("scenarios > embedding > sdk iframe embedding > custom elements api", (
     });
 
     it("should enable drill-through when drills is true", () => {
-      H.visitCustomHtmlPage(`
-      ${H.getNewEmbedScriptTag()}
-      ${H.getNewEmbedConfigurationScript()}
-      <metabase-question question-id="${ORDERS_QUESTION_ID}" drills />
-      `);
+      H.createQuestion({
+        name: "Limited Orders",
+        query: { "source-table": ORDERS_ID, limit: 5 },
+      }).then(({ body: { id: questionId } }) => {
+        H.visitCustomHtmlPage(`
+        ${H.getNewEmbedScriptTag()}
+        ${H.getNewEmbedConfigurationScript()}
+        <metabase-question question-id="${questionId}" drills />
+        `);
 
-      H.getSimpleEmbedIframeContent()
-        .findAllByText("37.65")
-        .first()
-        .should("be.visible")
-        .click();
-      H.getSimpleEmbedIframeContent()
-        .findByText(/Filter by this value/)
-        .should("be.visible");
+        H.getSimpleEmbedIframeContent()
+          .findAllByText("37.65")
+          .first()
+          .should("be.visible")
+          .click();
+        H.getSimpleEmbedIframeContent()
+          .findByText(/Filter by this value/)
+          .should("be.visible");
+      });
     });
 
     it("should disable drill-through when drills is false", () => {
-      H.visitCustomHtmlPage(`
-      ${H.getNewEmbedScriptTag()}
-      ${H.getNewEmbedConfigurationScript()}
-      <metabase-question question-id="${ORDERS_QUESTION_ID}" drills="false" />
-      `);
+      H.createQuestion({
+        name: "Limited Orders",
+        query: { "source-table": ORDERS_ID, limit: 5 },
+      }).then(({ body: { id: questionId } }) => {
+        H.visitCustomHtmlPage(`
+        ${H.getNewEmbedScriptTag()}
+        ${H.getNewEmbedConfigurationScript()}
+        <metabase-question question-id="${questionId}" drills="false" />
+        `);
 
-      cy.wait("@getCardQuery");
+        cy.wait("@getCardQuery");
 
-      H.getSimpleEmbedIframeContent()
-        .findAllByText("37.65", { timeout: 40000 })
-        .as("cell")
-        .first()
-        .should("be.visible")
-        .click();
+        H.getSimpleEmbedIframeContent()
+          .findAllByText("37.65")
+          .as("cell")
+          .first()
+          .should("be.visible")
+          .click();
 
-      H.getSimpleEmbedIframeContent()
-        .findByText(/Filter by this value/)
-        .should("not.exist");
+        H.getSimpleEmbedIframeContent()
+          .findByText(/Filter by this value/)
+          .should("not.exist");
+      });
     });
 
     it("should allow saving a question when `is-save-enabled` is true", () => {

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
@@ -310,16 +310,10 @@ describe("scenarios > embedding > sdk iframe embedding > custom elements api", (
 
         cy.wait("@getCardQuery");
 
-        H.getSimpleEmbedIframeContent()
-          .findAllByText("37.65")
-          .as("cell")
-          .first()
-          .should("be.visible")
-          .click();
-
-        H.getSimpleEmbedIframeContent()
-          .findByText(/Filter by this value/)
-          .should("not.exist");
+        H.getSimpleEmbedIframeContent().within(() => {
+          cy.findAllByText("37.65").first().should("be.visible").click();
+          cy.findByText(/Filter by this value/).should("not.exist");
+        });
       });
     });
 

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
@@ -310,10 +310,13 @@ describe("scenarios > embedding > sdk iframe embedding > custom elements api", (
 
         cy.wait("@getCardQuery");
 
-        H.getSimpleEmbedIframeContent().within(() => {
-          cy.findAllByText("37.65").first().should("be.visible").click();
-          cy.findByText(/Filter by this value/).should("not.exist");
-        });
+        H.getSimpleEmbedIframeContent().findAllByText("37.65").as("cells");
+        cy.get("@cells").first().as("cell");
+        cy.get("@cell").should("be.visible").click();
+
+        H.getSimpleEmbedIframeContent()
+          .findByText(/Filter by this value/)
+          .should("not.exist");
       });
     });
 


### PR DESCRIPTION
Fixes [EMB-1437: \[Flaky Test\] \[e2e-tests\] <metabase-question> scenarios > embedding > sdk iframe embedding > custom elements api <metabase-question> should disable drill-through when drills is false](https://linear.app/metabase/issue/EMB-1437/flaky-test-e2e-tests-metabase-question-scenarios-embedding-sdk-iframe)

Stress test with 100 burns: https://github.com/metabase/metabase/actions/runs/23198435308
Stress test master: https://github.com/metabase/metabase/actions/runs/23201186635


There seems to be an intermittent render in CI that doesn't happen locally, it's unclear exactly why it's happening, but it makes it so the cell we want to click on (to check whether certain menus appear) has been unmounted and replaced by a new one. I'm usually not in favor of using `{force: true}` in clicks, but I could not fix this otherwise (tried to wait on a variety of a queries, tried to use `@get`, tried to use a `should` on the iframe to retry many times the assertions, to no avail).