### PR TITLE
Metric viewer can use metrics based on cards

### DIFF
--- a/src/metabase/lib_metric/ast/build.cljc
+++ b/src/metabase/lib_metric/ast/build.cljc
@@ -308,9 +308,12 @@
                joins)))
 
 (defn- pmbql-query->source-node
-  "Parse pMBQL query into source node structure using lib functions."
+  "Parse pMBQL query into source node structure using lib functions.
+   For source-card queries (metrics based on models or saved questions),
+   falls back to the table-id from the entity metadata."
   [source-type id metadata pmbql-query]
-  (let [table-id      (lib.util/source-table-id pmbql-query)
+  (let [table-id      (or (lib.util/source-table-id pmbql-query)
+                          (:table-id metadata))
         aggregation   (first (lib/aggregations pmbql-query 0))
         source-filter (extract-source-filters pmbql-query)
         source-joins  (extract-source-joins pmbql-query)]

--- a/src/metabase/lib_metric/dimension/jvm.clj
+++ b/src/metabase/lib_metric/dimension/jvm.clj
@@ -31,6 +31,23 @@
                      col))
                  cols))))
 
+(defn- field-id-ref
+  "Build a field ref using the column's integer ID rather than its name.
+   Source-card columns have integer :id but `lib/ref` produces name-based refs;
+   dimension mappings need integer field IDs for the AST.
+
+   For source-card columns that are FK-remapped (e.g. PRODUCTS.TITLE appearing as
+   display value for ORDERS.PRODUCT_ID), `:lib/original-fk-field-id` captures the FK
+   column. We include it as `:source-field` so the compiled query gets the implicit join."
+  [column]
+  (let [ref (lib/ref column)]
+    (if (and (pos-int? (:id column))
+             (not (pos-int? (nth ref 2 nil))))
+      (cond-> (assoc ref 2 (:id column))
+        (:lib/original-fk-field-id column)
+        (assoc-in [1 :source-field] (:lib/original-fk-field-id column)))
+      ref)))
+
 (defn- column->computed-pair
   "Convert a column to a dimension/mapping pair. IDs are nil until reconciliation.
    The table-id is extracted from the column's metadata.
@@ -38,7 +55,7 @@
   ([column]
    (column->computed-pair column nil))
   ([column group]
-   (let [target (lib/ref column)
+   (let [target (field-id-ref column)
          has-field-values (lib/infer-has-field-values column)]
      {:dimension (cond-> {:id             nil
                           :name           (:name column)
@@ -62,11 +79,17 @@
   "When the metadata provider is a MetricContextMetadataProvider, return the
    database-specific provider for the query's source table. The DB provider can
    resolve column-by-ID lookups that the metric context provider cannot, which
-   is required for FK / implicitly-joinable column resolution."
+   is required for FK / implicitly-joinable column resolution.
+
+   For source-card queries (metrics based on models or saved questions), resolves
+   the card's table_id and uses that to find the database provider."
   [mp query-with-mp]
   (when (satisfies? lib-metric.provider/MetricMetadataProvider mp)
-    (when-let [table-id (lib.util/source-table-id query-with-mp)]
-      (lib-metric.provider/database-provider-for-table mp table-id))))
+    (or (when-let [table-id (lib.util/source-table-id query-with-mp)]
+          (lib-metric.provider/database-provider-for-table mp table-id))
+        (when-let [card-id (lib.util/source-card-id query-with-mp)]
+          (when-let [table-id (t2/select-one-fn :table_id :model/Card card-id)]
+            (lib-metric.provider/database-provider-for-table mp table-id))))))
 
 (defn- group-type->type
   "Convert a column group's group-type to a dimension group type string."

--- a/src/metabase/lib_metric/metadata/jvm.clj
+++ b/src/metabase/lib_metric/metadata/jvm.clj
@@ -8,6 +8,7 @@
    [honey.sql.helpers :as sql.helpers]
    [medley.core :as m]
    [metabase.lib-be.core :as lib-be]
+   [metabase.lib-metric.dimension :as lib-metric.dimension]
    [metabase.lib-metric.dimension.jvm :as lib-metric.dimension.jvm]
    [metabase.lib-metric.metadata.provider :as provider]
    [metabase.lib.metadata.protocols :as lib.metadata.protocols]
@@ -56,13 +57,16 @@
 
 (defn- extract-dimensions-from-entity
   "Extract dimensions from a metric or measure, annotating with source info.
-   Each dimension is enriched with its corresponding dimension-mapping if available."
+   Each dimension is enriched with its corresponding dimension-mapping if available.
+   Dimensions are normalized after DB read to fix JSON round-trip artifacts
+   (e.g. string enum values for :has-field-values, :status, :sources)."
   [entity source-type]
   (let [dims         (:dimensions entity)
         mappings     (:dimension-mappings entity)
         mappings-by-dim-id (m/index-by :dimension-id mappings)]
     (for [dim dims]
       (-> dim
+          lib-metric.dimension/normalize-persisted-dimension
           (assoc :lib/type :metadata/dimension
                  :source-type source-type
                  :source-id (:id entity))

--- a/test/metabase/lib_metric/dimension_test.cljc
+++ b/test/metabase/lib_metric/dimension_test.cljc
@@ -429,3 +429,27 @@
       (is (some? orphaned) "dimension without :status should appear in results")
       (is (= :status/orphaned (:status orphaned)))
       (is (string? (:status-message orphaned))))))
+
+;;; -------------------------------------------------- Normalization --------------------------------------------------
+
+(deftest ^:parallel normalize-persisted-dimension-test
+  (testing "normalizes string enum values from JSON round-trip"
+    (let [raw        {:id               "dim-1"
+                      :name             "category"
+                      :status           "status/active"
+                      :has-field-values "search"
+                      :sources          [{:type "field" :field-id 42}]}
+          normalized (lib-metric.dimension/normalize-persisted-dimension raw)]
+      (is (= :status/active (:status normalized)))
+      (is (= :search (:has-field-values normalized)))
+      (is (= :field (get-in normalized [:sources 0 :type])))))
+
+  (testing "leaves already-keywordized values unchanged"
+    (let [dim        {:id "dim-2" :name "col" :status :status/active :has-field-values :list}
+          normalized (lib-metric.dimension/normalize-persisted-dimension dim)]
+      (is (= :status/active (:status normalized)))
+      (is (= :list (:has-field-values normalized)))))
+
+  (testing "no-op when optional fields are absent"
+    (let [dim {:id "dim-3" :name "col"}]
+      (is (= dim (lib-metric.dimension/normalize-persisted-dimension dim))))))

--- a/test/metabase/metrics/api_dataset_test.clj
+++ b/test/metabase/metrics/api_dataset_test.clj
@@ -1132,3 +1132,65 @@
             (is (= "completed" (:status response)))
             (is (= 49 (:row_count response))
                 "should have 49 months of order data")))))))
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                               Category 11: Source-Card (Model) Metrics                                          |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+(deftest dataset-source-card-count-test
+  (testing "POST /api/metric/dataset with metric based on a model (source-card)"
+    (mt/with-temp [:model/Card model  {:name          "Orders Model"
+                                       :type          :model
+                                       :dataset_query (mt/mbql-query orders)}
+                   :model/Card metric {:name          "Model Count Metric"
+                                       :type          :metric
+                                       :dataset_query {:database (mt/id)
+                                                       :type     :query
+                                                       :query    {:source-table (str "card__" (:id model))
+                                                                  :aggregation  [[:count]]}}}]
+      (let [response (dataset-request {:expression [:metric {:lib/uuid "a"} (:id metric)]})]
+        (is (= "completed" (:status response)))
+        (is (= 1 (:row_count response)))
+        (is (= 18760 (first-result response))
+            "should count all 18760 orders via model")))))
+
+(deftest dataset-source-card-with-filter-test
+  (testing "POST /api/metric/dataset with source-card metric and dimension filter"
+    (mt/with-temp [:model/Card model  {:name          "Orders Model"
+                                       :type          :model
+                                       :dataset_query (mt/mbql-query orders)}
+                   :model/Card metric {:name          "Model Count Metric"
+                                       :type          :metric
+                                       :dataset_query {:database (mt/id)
+                                                       :type     :query
+                                                       :query    {:source-table (str "card__" (:id model))
+                                                                  :aggregation  [[:count]]}}}]
+      (let [hydrated  (hydrate-metric (:id metric))
+            total-dim (find-dimension-by-name hydrated "TOTAL")]
+        (is (some? total-dim) "TOTAL dimension should exist for model-based metric")
+        (let [response (dataset-request {:expression [:metric {:lib/uuid "a"} (:id metric)]
+                                         :filters    [{:lib/uuid "a" :filter [:> {} [:dimension {} (:id total-dim)] 100]}]})]
+          (is (= "completed" (:status response)))
+          (is (< (first-result response) 18760)
+              "filtered count should be less than total orders"))))))
+
+(deftest dataset-source-card-with-projection-test
+  (testing "POST /api/metric/dataset with source-card metric and dimension breakout"
+    (mt/with-temp [:model/Card model  {:name          "Orders Model"
+                                       :type          :model
+                                       :dataset_query (mt/mbql-query orders)}
+                   :model/Card metric {:name          "Model Count Metric"
+                                       :type          :metric
+                                       :dataset_query {:database (mt/id)
+                                                       :type     :query
+                                                       :query    {:source-table (str "card__" (:id model))
+                                                                  :aggregation  [[:count]]}}}]
+      (let [hydrated    (hydrate-metric (:id metric))
+            created-dim (find-dimension-by-name hydrated "CREATED_AT")]
+        (is (some? created-dim) "CREATED_AT dimension should exist for model-based metric")
+        (let [response (dataset-request {:expression  [:metric {:lib/uuid "a"} (:id metric)]
+                                         :projections [{:type :metric :id (:id metric)
+                                                        :projection [[:dimension {:temporal-unit :month} (:id created-dim)]]}]})]
+          (is (= "completed" (:status response)))
+          (is (= 49 (:row_count response))
+              "should have 49 months of order data, same as table-based metric"))))))


### PR DESCRIPTION
Fixes [UXW-3260: Metrics from models/table questions are not viewable in the Metrics viewer](https://linear.app/metabase/issue/UXW-3260/metrics-from-modelstable-questions-are-not-viewable-in-the-metrics)
