### PR TITLE
BOT-1131 Rename :snake_case keys to :kebab-case in metabot stats

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/categorical.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/categorical.clj
@@ -25,9 +25,9 @@
         n       (count agg)]
     (if (zero? n)
       {:summary        nil
-       :data_points    0
-       :category_count 0
-       :top_categories []
+       :data-points    0
+       :category-count 0
+       :top-categories []
        :outliers       []}
       (let [ys       (mapv second agg)
             xs       (mapv first agg)
@@ -44,11 +44,11 @@
             bottom   (when (> n many-categories-threshold)
                        (mapv make-cat (take-last bottom-n-categories sorted)))]
         (cond-> {:summary        summary
-                 :data_points    (count valid)
-                 :category_count n
-                 :top_categories (mapv make-cat (take top-n-categories sorted))
+                 :data-points    (count valid)
+                 :category-count n
+                 :top-categories (mapv make-cat (take top-n-categories sorted))
                  :outliers       (or outliers [])}
-          bottom (assoc :bottom_categories bottom))))))
+          bottom (assoc :bottom-categories bottom))))))
 
 (mu/defn compute-categorical-stats :- ::stats.types/categorical-stats
   "Compute categorical stats for all series in a chart."

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/core.clj
@@ -51,10 +51,10 @@
         downsampled     (into {} (for [[name orig-count] original-counts
                                        :let [new-count (count (get-in limited-series [name :y_values]))]
                                        :when (< new-count orig-count)]
-                                   [name {:original_count orig-count :sampled_count new-count}]))]
+                                   [name {:original-count orig-count :sampled-count new-count}]))]
     [limited-series
      (when (seq downsampled)
-       {:downsampled_series downsampled})]))
+       {:downsampled-series downsampled})]))
 
 ;;; ----------------------------------------------- Chart Type Detection ---------------------------------------------
 
@@ -156,16 +156,16 @@
         opts                         (cond-> opts
                                        too-many-series? (assoc :max-correlation-series max-series-for-correlations))
         limits-info                  (cond-> limits-info
-                                       too-many-series? (assoc :correlations_capped
-                                                               {:total_series   (count limited-series)
-                                                                :max_correlated max-series-for-correlations}))
+                                       too-many-series? (assoc :correlations-capped
+                                                               {:total-series   (count limited-series)
+                                                                :max-correlated max-series-for-correlations}))
         stats                        (case chart-type
                                        :time-series (time-series/compute-time-series-stats limited-series opts)
                                        :categorical (categorical/compute-categorical-stats limited-series opts)
                                        :scatter     (scatter/compute-scatter-stats limited-series opts)
                                        :histogram   (histogram/compute-histogram-stats limited-series opts)
-                                       {:chart_type   chart-type
-                                        :series_count (count limited-series)
+                                       {:chart-type   chart-type
+                                        :series-count (count limited-series)
                                         :message      (str "Statistics for " (name chart-type)
                                                            " charts not yet implemented")})]
     (cond-> stats

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/histogram.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/histogram.clj
@@ -122,18 +122,18 @@
          total       (reduce + 0.0 valid-ys)]
      (if (or (zero? n)
              (zero? total))
-       {:estimated_summary {:weighted_mean 0 :weighted_std_dev 0 :data_range 0}
-        :total_count       0
-        :data_points       n
-        :bin_data          []
-        :distribution      {:estimated_percentiles {}
-                            :estimated_quartiles   {:q1 0 :median 0 :q3 0 :iqr 0}}
-        :structure         {:mode_bin           nil
-                            :peak_count         0
-                            :concentration_top3 0.0
-                            :gap_count          0
-                            :empty_bin_ratio    0.0
-                            :bin_count          n}}
+       {:estimated-summary {:weighted-mean 0 :weighted-std-dev 0 :data-range 0}
+        :total-count       0
+        :data-points       n
+        :bin-data          []
+        :distribution      {:estimated-percentiles {}
+                            :estimated-quartiles   {:q1 0 :median 0 :q3 0 :iqr 0}}
+        :structure         {:mode-bin           nil
+                            :peak-count         0
+                            :concentration-top3 0.0
+                            :gap-count          0
+                            :empty-bin-ratio    0.0
+                            :bin-count          n}}
        (let [;; Sort by x for cumulative operations
              sorted-pairs (sort-by first (map vector valid-xs valid-ys))
              sorted-xs    (mapv first sorted-pairs)
@@ -160,22 +160,22 @@
              mode-idx     (.indexOf ^java.util.List sorted-ys max-count)
              top3         (reduce + (take 3 (sort > sorted-ys)))
              zero-bins    (count (filter zero? sorted-ys))]
-         {:estimated_summary {:weighted_mean    wmean
-                              :weighted_std_dev wstd
-                              :data_range       (- max-x min-x)}
-          :total_count       (long total)
-          :data_points       n
-          :bin_data          (mapv vector sorted-xs sorted-ys)
-          :distribution      (cond-> {:estimated_percentiles percentiles
-                                      :estimated_quartiles   {:q1 q1 :median med :q3 q3 :iqr (- q3 q1)}}
-                               wskew (assoc :weighted_skewness wskew)
-                               wkurt (assoc :weighted_kurtosis wkurt))
-          :structure         {:mode_bin           [(nth sorted-xs mode-idx) max-count]
-                              :peak_count         (count-peaks sorted-ys)
-                              :concentration_top3 (/ top3 total)
-                              :gap_count          (count-gaps sorted-ys)
-                              :empty_bin_ratio    (/ (double zero-bins) n)
-                              :bin_count          n}})))))
+         {:estimated-summary {:weighted-mean    wmean
+                              :weighted-std-dev wstd
+                              :data-range       (- max-x min-x)}
+          :total-count       (long total)
+          :data-points       n
+          :bin-data          (mapv vector sorted-xs sorted-ys)
+          :distribution      (cond-> {:estimated-percentiles percentiles
+                                      :estimated-quartiles   {:q1 q1 :median med :q3 q3 :iqr (- q3 q1)}}
+                               wskew (assoc :weighted-skewness wskew)
+                               wkurt (assoc :weighted-kurtosis wkurt))
+          :structure         {:mode-bin           [(nth sorted-xs mode-idx) max-count]
+                              :peak-count         (count-peaks sorted-ys)
+                              :concentration-top3 (/ top3 total)
+                              :gap-count          (count-gaps sorted-ys)
+                              :empty-bin-ratio    (/ (double zero-bins) n)
+                              :bin-count          n}})))))
 
 (mu/defn compute-histogram-stats :- ::stats.types/histogram-stats
   "Compute statistics for histogram data.

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/outliers.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/outliers.clj
@@ -55,7 +55,7 @@
     :index           - position in the original sequence
     :label           - the label at that position
     :value           - the numeric value
-    :modified_z_score - the modified Z-score"
+    :modified-z-score - the modified Z-score"
   [values :- [:sequential number?]
    labels :- [:sequential :any]]
   (when-let [z-scores (compute-modified-z-scores values)]
@@ -67,7 +67,7 @@
               {:index idx
                :label (nth labels-vec idx)
                :value (nth values-vec idx)
-               :modified_z_score (nth z-scores-vec idx)})
+               :modified-z-score (nth z-scores-vec idx)})
             indices))))
 
 (mu/defn find-outliers-cumulative :- [:maybe [:sequential ::stats.types/cumulative-outlier]]
@@ -86,7 +86,7 @@
     :label           - the label at that position
     :value           - the numeric value at that position
     :diff            - the period-over-period change that was flagged
-    :modified_z_score - the modified Z-score of the diff"
+    :modified-z-score - the modified Z-score of the diff"
   [values :- [:sequential number?]
    labels :- [:sequential :any]]
   (let [values-vec (vec values)
@@ -101,5 +101,5 @@
                    :label (nth labels-vec point-idx)
                    :value (nth values-vec point-idx)
                    :diff (nth diffs diff-idx)
-                   :modified_z_score (nth z-scores-vec diff-idx)}))
+                   :modified-z-score (nth z-scores-vec diff-idx)}))
               outlier-diff-indices)))))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/repr.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/repr.clj
@@ -70,11 +70,11 @@
   "Convert trend direction keyword to readable text."
   [direction]
   (case direction
-    :strongly_increasing "strongly increasing"
+    :strongly-increasing "strongly increasing"
     :increasing "increasing"
     :flat "flat"
     :decreasing "decreasing"
-    :strongly_decreasing "strongly decreasing"
+    :strongly-decreasing "strongly decreasing"
     (name direction)))
 
 (defn- volatility-level-text
@@ -109,19 +109,19 @@
 
 (defn- render-limits-note
   "Render a note when data limits were applied during stats computation."
-  [{:keys [downsampled_series correlations_capped]}]
+  [{:keys [downsampled-series correlations-capped]}]
   (let [parts (cond-> []
-                (seq downsampled_series)
-                (conj (let [entries (for [[name {:keys [original_count sampled_count]}] downsampled_series]
-                                      (str name " (" original_count " → " sampled_count " points)"))]
+                (seq downsampled-series)
+                (conj (let [entries (for [[name {:keys [original-count sampled-count]}] downsampled-series]
+                                      (str name " (" original-count " → " sampled-count " points)"))]
                         (str "Data was downsampled for statistical analysis: "
                              (str/join ", " entries)
                              ". Results are based on a uniform sample of the full dataset.")))
 
-                correlations_capped
+                correlations-capped
                 (conj (str "Cross-series correlations were limited to "
-                           (:max_correlated correlations_capped) " of "
-                           (:total_series correlations_capped)
+                           (:max-correlated correlations-capped) " of "
+                           (:total-series correlations-capped)
                            " series to keep computation tractable.")))]
     (when (seq parts)
       (str "**Data Limits Applied**: " (str/join " " parts)))))
@@ -130,27 +130,27 @@
 
 (defn- compute-data-characteristics
   "Derive data quality flags from pre-computed series stats."
-  [{:keys [data_points category_count summary y_summary]}]
-  (let [n     (or data_points category_count 0)
-        s     (or y_summary summary)
+  [{:keys [data-points category-count summary y-summary]}]
+  (let [n     (or data-points category-count 0)
+        s     (or y-summary summary)
         max-v (some-> s :max)
         cov   (let [mean-v (some-> s :mean)
-                    std-v  (some-> s :std_dev)]
+                    std-v  (some-> s :std-dev)]
                 (if (and mean-v std-v (not (zero? mean-v)))
                   (/ std-v (Math/abs (double mean-v)))
                   0.0))]
-    {:small_counts  (boolean (and max-v (< max-v 20)))
-     :high_variance (> cov 0.5)
-     :sparse_data   (< n 10)}))
+    {:small-counts  (boolean (and max-v (< max-v 20)))
+     :high-variance (> cov 0.5)
+     :sparse-data   (< n 10)}))
 
 (defn- render-data-characteristics-note
   "Render a **Note**: line when any data quality warning applies."
   [series-stats]
-  (let [{:keys [small_counts high_variance sparse_data]} (compute-data-characteristics series-stats)
+  (let [{:keys [small-counts high-variance sparse-data]} (compute-data-characteristics series-stats)
         warnings (cond-> []
-                   small_counts  (conj "small values (percentage changes may be exaggerated)")
-                   high_variance (conj "high variance (fluctuations may be normal noise)")
-                   sparse_data   (conj "limited data points"))]
+                   small-counts  (conj "small values (percentage changes may be exaggerated)")
+                   high-variance (conj "high variance (fluctuations may be normal noise)")
+                   sparse-data   (conj "limited data points"))]
     (when (seq warnings)
       (str "**Note**: " (str/join ", " warnings) "."))))
 
@@ -158,27 +158,27 @@
 
 (defn- render-series-summary
   "Render summary statistics for a series."
-  [{:keys [summary time_range data_points]}]
-  (let [{:keys [min max mean median std_dev]} summary
-        {:keys [start end]} time_range]
-    (str "**Data Points**: " data_points " (" (format-label start) " to " (format-label end) ")\n"
+  [{:keys [summary time-range data-points]}]
+  (let [{:keys [min max mean median std-dev]} summary
+        {:keys [start end]} time-range]
+    (str "**Data Points**: " data-points " (" (format-label start) " to " (format-label end) ")\n"
          "**Value Range**: " (format-number min) " to " (format-number max)
          " (median: " (format-number median) ")\n"
-         "**Mean**: " (format-number mean) " | **Std Dev**: " (format-number std_dev))))
+         "**Mean**: " (format-number mean) " | **Std Dev**: " (format-number std-dev))))
 
 (defn- render-trend
   "Render trend information."
-  [{:keys [direction overall_change_pct start_value end_value]}]
+  [{:keys [direction overall-change-pct start-value end-value]}]
   (str "**Trend**: " (trend-direction-text direction)
-       " (" (format-pct overall_change_pct) " overall, "
-       "from " (format-number start_value) " to " (format-number end_value) ")"))
+       " (" (format-pct overall-change-pct) " overall, "
+       "from " (format-number start-value) " to " (format-number end-value) ")"))
 
 (defn- render-volatility
   "Render volatility information."
-  [{:keys [level coefficient_of_variation max_period_change_pct]}]
+  [{:keys [level coefficient-of-variation max-period-change-pct]}]
   (str "**Volatility**: " (volatility-level-text level)
-       " (CV: " (format "%.2f" (double coefficient_of_variation))
-       ", max period change: " (format-pct max_period_change_pct) ")"))
+       " (CV: " (format "%.2f" (double coefficient-of-variation))
+       ", max period change: " (format-pct max-period-change-pct) ")"))
 
 (defn- render-outliers
   "Render outlier information."
@@ -186,9 +186,9 @@
   (if (seq outliers)
     (str "**Outliers**: " (count outliers) " detected\n"
          (str/join "\n"
-                   (for [{:keys [label value modified_z_score]} outliers]
+                   (for [{:keys [label value modified-z-score]} outliers]
                      (str "  - " (format-label label) ": " (format-number value)
-                          " (z-score: " (format "%.2f" (double modified_z_score)) ")"))))
+                          " (z-score: " (format "%.2f" (double modified-z-score)) ")"))))
     "**Outliers**: None detected"))
 
 (defn- render-patterns
@@ -197,8 +197,8 @@
   (when (seq patterns)
     (str "**Patterns**:\n"
          (str/join "\n"
-                   (for [{:keys [description from_date to_date]} patterns]
-                     (str "  - " description " (" (format-label from_date) " to " (format-label to_date) ")"))))))
+                   (for [{:keys [description from-date to-date]} patterns]
+                     (str "  - " description " (" (format-label from-date) " to " (format-label to-date) ")"))))))
 
 (defn- render-significant-changes
   "Render significant changes."
@@ -206,33 +206,33 @@
   (when (seq changes)
     (str "**Significant Changes**:\n"
          (str/join "\n"
-                   (for [{:keys [from_date to_date from_value to_value change_pct]} changes]
-                     (str "  - " (format-label from_date) " → " (format-label to_date)
-                          ": " (format-number from_value) " → " (format-number to_value)
-                          " (" (format-pct change_pct) ")"))))))
+                   (for [{:keys [from-date to-date from-value to-value change-pct]} changes]
+                     (str "  - " (format-label from-date) " → " (format-label to-date)
+                          ": " (format-number from-value) " → " (format-number to-value)
+                          " (" (format-pct change-pct) ")"))))))
 
 (defn- render-most-recent-change
   "Render most recent change."
-  [{:keys [from_date to_date from_value to_value change_pct] :as change}]
+  [{:keys [from-date to-date from-value to-value change-pct] :as change}]
   (when change
-    (str "**Most Recent Change**: " (format-label from_date) " → " (format-label to_date)
-         ": " (format-number from_value) " → " (format-number to_value)
-         " (" (format-pct change_pct) ")")))
+    (str "**Most Recent Change**: " (format-label from-date) " → " (format-label to-date)
+         ": " (format-number from-value) " → " (format-number to-value)
+         " (" (format-pct change-pct) ")")))
 
 (defn- render-time-series
   "Render complete statistics for a single series."
   [series-name series-stats]
-  (let [{:keys [trend is_cumulative volatility outliers patterns
-                significant_changes most_recent_change]} series-stats
+  (let [{:keys [trend is-cumulative volatility outliers patterns
+                significant-changes most-recent-change]} series-stats
         sections [(str "## Series: " series-name)
                   (render-series-summary series-stats)
                   (render-trend trend)
-                  (when is_cumulative "**Note**: Data appears to be cumulative")
+                  (when is-cumulative "**Note**: Data appears to be cumulative")
                   (when volatility (render-volatility volatility))
                   (render-outliers outliers)
                   (render-patterns patterns)
-                  (render-significant-changes significant_changes)
-                  (render-most-recent-change most_recent_change)]]
+                  (render-significant-changes significant-changes)
+                  (render-most-recent-change most-recent-change)]]
     (str/join "\n" (remove nil? sections))))
 
 ;;; ----------------------------------------- Correlation Representation ---------------------------------------------
@@ -248,8 +248,8 @@
   (when (seq correlations)
     (str "## Cross-Series Correlations\n"
          (str/join "\n"
-                   (for [{:keys [series_a series_b coefficient] :as corr} correlations]
-                     (str "- " series_a " vs " series_b ": "
+                   (for [{:keys [series-a series-b coefficient] :as corr} correlations]
+                     (str "- " series-a " vs " series-b ": "
                           (correlation-label corr)
                           " (r=" (format "%.3f" (double coefficient)) ")"))))))
 
@@ -277,22 +277,22 @@
 
 (defn- render-categorical-series
   "Render stats for a single categorical series."
-  [series-name {:keys [x_name y_name summary data_points category_count
-                       top_categories bottom_categories outliers] :as series-stats}]
+  [series-name {:keys [x-name y-name summary data-points category-count
+                       top-categories bottom-categories outliers] :as series-stats}]
   (let [sections [(str "## Series: " series-name)
-                  (when x_name (str "**X-axis**: " x_name))
-                  (when y_name (str "**Y-axis**: " y_name))
-                  (str "**Data Points**: " data_points)
-                  (str "**Categories**: " category_count)
+                  (when x-name (str "**X-axis**: " x-name))
+                  (when y-name (str "**Y-axis**: " y-name))
+                  (str "**Data Points**: " data-points)
+                  (str "**Categories**: " category-count)
                   (render-data-characteristics-note series-stats)
                   (when summary
                     (str "**Value Range**: " (format-number (:min summary))
                          " to " (format-number (:max summary))
                          " (median: " (format-number (:median summary)) ")"))
-                  (when (seq top_categories)
-                    (str "**Top Categories**:\n" (render-category-list top_categories)))
-                  (when (seq bottom_categories)
-                    (str "**Bottom Categories**:\n" (render-category-list bottom_categories)))
+                  (when (seq top-categories)
+                    (str "**Top Categories**:\n" (render-category-list top-categories)))
+                  (when (seq bottom-categories)
+                    (str "**Bottom Categories**:\n" (render-category-list bottom-categories)))
                   (render-outliers outliers)]]
     (str/join "\n" (remove nil? sections))))
 
@@ -314,15 +314,15 @@
 
 (defn- render-scatter-series
   "Render stats for a single scatter series."
-  [series-name {:keys [x_name y_name x_summary y_summary data_points
-                       correlation regression sampled_points outliers] :as series-stats}]
+  [series-name {:keys [x-name y-name x-summary y-summary data-points
+                       correlation regression sampled-points outliers] :as series-stats}]
   (let [sections [(str "## Series: " series-name)
-                  (str "**Data Points**: " data_points)
-                  (when x_name (str "**X-axis**: " x_name))
-                  (when y_name (str "**Y-axis**: " y_name))
+                  (str "**Data Points**: " data-points)
+                  (when x-name (str "**X-axis**: " x-name))
+                  (when y-name (str "**Y-axis**: " y-name))
                   (render-data-characteristics-note series-stats)
-                  (render-axis-range "X-axis" x_summary)
-                  (render-axis-range "Y-axis" y_summary)
+                  (render-axis-range "X-axis" x-summary)
+                  (render-axis-range "Y-axis" y-summary)
                   (when correlation
                     (str "**Relationship**: " (correlation-label correlation)
                          " (r = " (format "%.2f" (double (:coefficient correlation))) ")"))
@@ -330,7 +330,7 @@
                     (str "**Trend Line**: y = "
                          (format "%.3f" (double (:slope regression))) "x + "
                          (format "%.3f" (double (:intercept regression)))))
-                  (render-sample-data sampled_points)
+                  (render-sample-data sampled-points)
                   (render-scatter-outliers outliers)]]
     (str/join "\n" (remove nil? sections))))
 
@@ -350,46 +350,46 @@
 
 (defn- render-histogram-series
   "Render stats for a single histogram series."
-  [series-name {:keys [x_name y_name estimated_summary total_count data_points
-                       bin_data distribution structure] :as series-stats}]
-  (let [{:keys [weighted_skewness weighted_kurtosis estimated_percentiles estimated_quartiles]} distribution
-        {:keys [weighted_mean weighted_std_dev data_range]} estimated_summary
-        {:keys [mode_bin peak_count concentration_top3 gap_count empty_bin_ratio bin_count]} structure
-        summary-str (str "**Estimated Distribution** (from " bin_count " bins, " total_count " total observations): "
-                         "mean≈" (format-number weighted_mean)
-                         ", std_dev≈" (format-number weighted_std_dev)
-                         ", range=" (format-number data_range))
-        p-str       (when (seq estimated_percentiles)
+  [series-name {:keys [x-name y-name estimated-summary total-count data-points
+                       bin-data distribution structure] :as series-stats}]
+  (let [{:keys [weighted-skewness weighted-kurtosis estimated-percentiles estimated-quartiles]} distribution
+        {:keys [weighted-mean weighted-std-dev data-range]} estimated-summary
+        {:keys [mode-bin peak-count concentration-top3 gap-count empty-bin-ratio bin-count]} structure
+        summary-str (str "**Estimated Distribution** (from " bin-count " bins, " total-count " total observations): "
+                         "mean≈" (format-number weighted-mean)
+                         ", std_dev≈" (format-number weighted-std-dev)
+                         ", range=" (format-number data-range))
+        p-str       (when (seq estimated-percentiles)
                       (str "**Estimated Percentiles**: "
-                           "P25≈" (format-number (get estimated_percentiles 25))
-                           ", P50≈" (format-number (get estimated_percentiles 50))
-                           ", P75≈" (format-number (get estimated_percentiles 75))
-                           ", P90≈" (format-number (get estimated_percentiles 90))))
-        iqr-str     (when estimated_quartiles
-                      (str "**Estimated IQR**: " (format-number (:iqr estimated_quartiles))
-                           " (Q1≈" (format-number (:q1 estimated_quartiles))
-                           " to Q3≈" (format-number (:q3 estimated_quartiles)) ")"))
-        shape-str   (when weighted_skewness
-                      (let [k-desc (when weighted_kurtosis (kurtosis-description weighted_kurtosis))]
-                        (str "**Distribution Shape**: " (skewness-description weighted_skewness)
+                           "P25≈" (format-number (get estimated-percentiles 25))
+                           ", P50≈" (format-number (get estimated-percentiles 50))
+                           ", P75≈" (format-number (get estimated-percentiles 75))
+                           ", P90≈" (format-number (get estimated-percentiles 90))))
+        iqr-str     (when estimated-quartiles
+                      (str "**Estimated IQR**: " (format-number (:iqr estimated-quartiles))
+                           " (Q1≈" (format-number (:q1 estimated-quartiles))
+                           " to Q3≈" (format-number (:q3 estimated-quartiles)) ")"))
+        shape-str   (when weighted-skewness
+                      (let [k-desc (when weighted-kurtosis (kurtosis-description weighted-kurtosis))]
+                        (str "**Distribution Shape**: " (skewness-description weighted-skewness)
                              (when k-desc (str ", " k-desc)))))
         struct-str  (str "**Structure**: "
-                         (when mode_bin (str "mode bin at " (format-number (first mode_bin))
-                                             " (count=" (format-number (second mode_bin)) ")"))
-                         (when (> peak_count 1) (str ", " peak_count " peaks (multimodal)"))
-                         ", top 3 bins contain " (format "%.0f%%" (* 100.0 concentration_top3)) " of data"
-                         (when (pos? gap_count) (str ", " gap_count " gap(s)"))
-                         (when (pos? empty_bin_ratio) (str ", " (format "%.0f%%" (* 100.0 empty_bin_ratio)) " empty bins")))
+                         (when mode-bin (str "mode bin at " (format-number (first mode-bin))
+                                             " (count=" (format-number (second mode-bin)) ")"))
+                         (when (> peak-count 1) (str ", " peak-count " peaks (multimodal)"))
+                         ", top 3 bins contain " (format "%.0f%%" (* 100.0 concentration-top3)) " of data"
+                         (when (pos? gap-count) (str ", " gap-count " gap(s)"))
+                         (when (pos? empty-bin-ratio) (str ", " (format "%.0f%%" (* 100.0 empty-bin-ratio)) " empty bins")))
         sections    [(str "## Series: " series-name)
-                     (when x_name (str "**X-axis**: " x_name))
-                     (when y_name (str "**Y-axis**: " y_name))
-                     (str "**Bins**: " data_points)
+                     (when x-name (str "**X-axis**: " x-name))
+                     (when y-name (str "**Y-axis**: " y-name))
+                     (str "**Bins**: " data-points)
                      (render-data-characteristics-note series-stats)
-                     (when (seq bin_data)
-                       (let [xs (mapv first bin_data)]
+                     (when (seq bin-data)
+                       (let [xs (mapv first bin-data)]
                          (render-axis-range "X-axis" {:min (apply min xs) :max (apply max xs)})))
                      summary-str p-str iqr-str shape-str struct-str
-                     (render-sample-data bin_data)]]
+                     (render-sample-data bin-data)]]
     (str/join "\n" (remove nil? sections))))
 
 ;;; ----------------------------------------- Main Representation ----------------------------------------------------
@@ -400,11 +400,11 @@
    `render-series-fn` — (fn [series-name series-stats] => string)
    `extra-sections`   — seq of additional section strings to insert after limits (may contain nils)"
   [{:keys [title display-type stats timeline-events]} type-label render-series-fn extra-sections]
-  (let [{:keys [series_count series correlations limits]} stats
+  (let [{:keys [series-count series correlations limits]} stats
         header          (str "# Chart Analysis\n"
                              (when title (str "## Chart: " title "\n"))
                              "**Type**: " type-label (when display-type (str " (" display-type ")")) "\n"
-                             "**Series Count**: " series_count)
+                             "**Series Count**: " series-count)
         limits-note     (when limits (render-limits-note limits))
         series-sections (str/join "\n\n"
                                   (for [[sname s] series]
@@ -421,12 +421,12 @@
   "Generate markdown representation for chart statistics.
   Dispatches based on chart type."
   [{:keys [stats] :as context} :- ::stats.types/generate-repr-context]
-  (case (:chart_type stats)
+  (case (:chart-type stats)
     :time-series  (generate-chart-representation context "Time Series" render-time-series
                                                  [(generate-temporal-context)])
     :categorical  (generate-chart-representation context "Categorical" render-categorical-series nil)
     :scatter      (generate-chart-representation context "Scatter" render-scatter-series nil)
     :histogram    (generate-chart-representation context "Histogram" render-histogram-series nil)
     (str "# Chart Analysis\n"
-         "**Type**: " (name (:chart_type stats)) "\n"
+         "**Type**: " (name (:chart-type stats)) "\n"
          "Statistics computation for this chart type is not yet implemented.")))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/scatter.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/scatter.clj
@@ -28,9 +28,9 @@
                             (map vector x-values y-values))
         n           (count valid-pairs)]
     (if (< n min-correlation-points)
-      {:x_summary   nil
-       :y_summary   nil
-       :data_points n}
+      {:x-summary   nil
+       :y-summary   nil
+       :data-points n}
       (let [xs               (mapv (comp double first) valid-pairs)
             ys               (mapv (comp double second) valid-pairs)
             x-summary        (stats.u/compute-summary xs)
@@ -49,15 +49,15 @@
                                        r-squared (* (double raw-coef) (double raw-coef))]
                                    {:slope     slope
                                     :intercept intercept
-                                    :r_squared r-squared})
+                                    :r-squared r-squared})
                                  (catch Exception _ nil)))
             scatter-outliers (when (>= n min-outlier-points)
                                (outliers/find-outliers ys xs))
             sampled-points   (sample-points (mapv vector xs ys) max-sample-points)]
-        (cond-> {:x_summary      x-summary
-                 :y_summary      y-summary
-                 :data_points    n
-                 :sampled_points sampled-points}
+        (cond-> {:x-summary      x-summary
+                 :y-summary      y-summary
+                 :data-points    n
+                 :sampled-points sampled-points}
           correlation            (assoc :correlation correlation)
           regression             (assoc :regression regression)
           (seq scatter-outliers) (assoc :outliers scatter-outliers))))))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/time_series.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/time_series.clj
@@ -17,7 +17,7 @@
 
 (defn- compute-time-range
   "Compute time range information from dates.
-  Returns map with :start :end :span_description"
+  Returns map with :start :end :span-description"
   [dates]
   (let [sorted-dates (sort dates)
         start (first sorted-dates)
@@ -25,7 +25,7 @@
         n (count dates)]
     {:start start
      :end end
-     :span_description (str n " data points from " start " to " end)}))
+     :span-description (str n " data points from " start " to " end)}))
 
 ;;; ------------------------------------------------ Trend Detection ------------------------------------------------
 
@@ -38,15 +38,15 @@
     (let [total-change (* slope (dec n))
           pct-change (* 100.0 (/ total-change (Math/abs (double mean))))]
       (cond
-        (> pct-change 50) :strongly_increasing
+        (> pct-change 50) :strongly-increasing
         (> pct-change 10) :increasing
-        (< pct-change -50) :strongly_decreasing
+        (< pct-change -50) :strongly-decreasing
         (< pct-change -10) :decreasing
         :else :flat))))
 
 (defn- compute-trend
   "Compute trend summary using linear regression.
-  Returns map with :direction :overall_change_pct :start_value :end_value"
+  Returns map with :direction :overall-change-pct :start-value :end-value"
   [values]
   (let [n (count values)
         values-vec (vec values)
@@ -58,9 +58,9 @@
         mean-val (dfn/mean values)
         change-pct (stats.u/percentage-change start-val end-val)]
     {:direction (slope-to-direction slope mean-val n)
-     :overall_change_pct change-pct
-     :start_value start-val
-     :end_value end-val}))
+     :overall-change-pct change-pct
+     :start-value start-val
+     :end-value end-val}))
 
 ;;; --------------------------------------------- Cumulative Detection -----------------------------------------------
 
@@ -79,7 +79,7 @@
 
 (defn- compute-volatility
   "Compute volatility metrics for time series.
-  Returns map with :level :coefficient_of_variation :max_period_change_pct"
+  Returns map with :level :coefficient-of-variation :max-period-change-pct"
   [values]
   (let [mean-val (dfn/mean values)
         std-dev (dfn/standard-deviation values)
@@ -97,12 +97,12 @@
                 (< cv 0.5) :high
                 :else :extreme)]
     {:level level
-     :coefficient_of_variation cv
-     :max_period_change_pct max-change}))
+     :coefficient-of-variation cv
+     :max-period-change-pct max-change}))
 
 (defn- find-consecutive-streaks
   "Find consecutive increasing or decreasing streaks of length >= min-length.
-  Returns sequence of maps with :type :start_idx :end_idx :length"
+  Returns sequence of maps with :type :start-idx :end-idx :length"
   [values min-length]
   (let [values-vec (vec values)
         n (count values-vec)]
@@ -113,19 +113,19 @@
       (if (>= i n)
         (let [final-length (- i streak-start)]
           (if (and current-type (>= final-length min-length))
-            (conj streaks {:type current-type :start_idx streak-start :end_idx (dec i) :length final-length})
+            (conj streaks {:type current-type :start-idx streak-start :end-idx (dec i) :length final-length})
             streaks))
         (let [prev (nth values-vec (dec i))
               curr (nth values-vec i)
               direction (cond
-                          (> curr prev) :consecutive_increase
-                          (< curr prev) :consecutive_decrease
+                          (> curr prev) :consecutive-increase
+                          (< curr prev) :consecutive-decrease
                           :else nil)]
           (if (= direction current-type)
             (recur (inc i) current-type streak-start streaks)
             (let [streak-length (- i streak-start)
                   new-streaks (if (and current-type (>= streak-length min-length))
-                                (conj streaks {:type current-type :start_idx streak-start :end_idx (dec i) :length streak-length})
+                                (conj streaks {:type current-type :start-idx streak-start :end-idx (dec i) :length streak-length})
                                 streaks)]
               (recur (inc i) direction i new-streaks))))))))
 
@@ -135,11 +135,11 @@
   [values dates]
   (let [dates-vec (vec dates)
         streaks (find-consecutive-streaks values 5)]
-    (mapv (fn [{:keys [type start_idx end_idx length]}]
+    (mapv (fn [{:keys [type start-idx end-idx length]}]
             {:type type
              :description (str (name type) " over " length " periods")
-             :from_date (nth dates-vec start_idx)
-             :to_date (nth dates-vec end_idx)})
+             :from-date (nth dates-vec start-idx)
+             :to-date (nth dates-vec end-idx)})
           streaks)))
 
 (defn- find-significant-changes
@@ -153,14 +153,14 @@
                             to-val (nth values-vec i)
                             change-abs (- to-val from-val)
                             change-pct (stats.u/percentage-change from-val to-val)]]
-                  {:from_date (nth dates-vec (dec i))
-                   :to_date (nth dates-vec i)
-                   :from_value from-val
-                   :to_value to-val
-                   :change_abs change-abs
-                   :change_pct change-pct})]
+                  {:from-date (nth dates-vec (dec i))
+                   :to-date (nth dates-vec i)
+                   :from-value from-val
+                   :to-value to-val
+                   :change-abs change-abs
+                   :change-pct change-pct})]
     (->> changes
-         (sort-by #(Math/abs (double (:change_abs %))) >)
+         (sort-by #(Math/abs (double (:change-abs %))) >)
          (take n)
          vec)))
 
@@ -176,12 +176,12 @@
             to-val (nth values-vec (dec n))
             change-abs (- to-val from-val)
             change-pct (stats.u/percentage-change from-val to-val)]
-        {:from_date (nth dates-vec (- n 2))
-         :to_date (nth dates-vec (dec n))
-         :from_value from-val
-         :to_value to-val
-         :change_abs change-abs
-         :change_pct change-pct}))))
+        {:from-date (nth dates-vec (- n 2))
+         :to-date (nth dates-vec (dec n))
+         :from-value from-val
+         :to-value to-val
+         :change-abs change-abs
+         :change-pct change-pct}))))
 
 ;;; ------------------------------------------------ Main Entry Point ------------------------------------------------
 
@@ -199,17 +199,17 @@
                    (outliers/find-outliers-cumulative values dates)
                    (outliers/find-outliers values dates))
         basic-stats {:summary (stats.u/compute-summary values)
-                     :time_range (compute-time-range dates)
-                     :data_points (count values)
+                     :time-range (compute-time-range dates)
+                     :data-points (count values)
                      :trend (compute-trend values)
-                     :is_cumulative is-cumulative
+                     :is-cumulative is-cumulative
                      :outliers outliers}]
     (if deep?
       (assoc basic-stats
              :volatility (compute-volatility values)
              :patterns (detect-patterns values dates)
-             :significant_changes (find-significant-changes values dates 3)
-             :most_recent_change (compute-most-recent-change values dates))
+             :significant-changes (find-significant-changes values dates 3)
+             :most-recent-change (compute-most-recent-change values dates))
       basic-stats)))
 
 (mu/defn compute-time-series-stats :- ::stats.types/time-series-stats

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/types.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/types.clj
@@ -52,7 +52,7 @@
    [:max number?]
    [:mean number?]
    [:median number?]
-   [:std_dev number?]
+   [:std-dev number?]
    [:range number?]])
 
 (mr/def ::time-range
@@ -60,19 +60,19 @@
   [:map
    [:start :any]
    [:end :any]
-   [:span_description :string]])
+   [:span-description :string]])
 
 (mr/def ::trend-direction
   "Direction of a trend."
-  [:enum :strongly_increasing :increasing :flat :decreasing :strongly_decreasing])
+  [:enum :strongly-increasing :increasing :flat :decreasing :strongly-decreasing])
 
 (mr/def ::trend-summary
   "Summary of trend in time series data."
   [:map
    [:direction ::trend-direction]
-   [:overall_change_pct number?]
-   [:start_value number?]
-   [:end_value number?]])
+   [:overall-change-pct number?]
+   [:start-value number?]
+   [:end-value number?]])
 
 (mr/def ::volatility-level
   "Level of volatility in the data."
@@ -82,30 +82,30 @@
   "Volatility metrics for time series data."
   [:map
    [:level ::volatility-level]
-   [:coefficient_of_variation number?]
-   [:max_period_change_pct number?]])
+   [:coefficient-of-variation number?]
+   [:max-period-change-pct number?]])
 
 (mr/def ::significant-change
   "A significant change detected in the data."
   [:map
-   [:from_date :any]
-   [:to_date :any]
-   [:from_value number?]
-   [:to_value number?]
-   [:change_abs number?]
-   [:change_pct number?]])
+   [:from-date :any]
+   [:to-date :any]
+   [:from-value number?]
+   [:to-value number?]
+   [:change-abs number?]
+   [:change-pct number?]])
 
 (mr/def ::pattern-type
   "Type of pattern detected in the data."
-  [:enum :consecutive_increase :consecutive_decrease :spike :dip :plateau])
+  [:enum :consecutive-increase :consecutive-decrease :spike :dip :plateau])
 
 (mr/def ::pattern-insight
   "A pattern detected in the data."
   [:map
    [:type ::pattern-type]
    [:description :string]
-   [:from_date {:optional true} [:maybe :any]]
-   [:to_date {:optional true} [:maybe :any]]])
+   [:from-date {:optional true} [:maybe :any]]
+   [:to-date {:optional true} [:maybe :any]]])
 
 (mr/def ::correlation-strength
   "Strength of correlation between series."
@@ -118,8 +118,8 @@
 (mr/def ::correlation
   "Correlation between two series."
   [:map
-   [:series_a :string]
-   [:series_b :string]
+   [:series-a :string]
+   [:series-b :string]
    [:coefficient number?]
    [:strength ::correlation-strength]
    [:direction ::correlation-direction]])
@@ -130,7 +130,7 @@
    [:index :int]
    [:label :any]
    [:value number?]
-   [:modified_z_score number?]])
+   [:modified-z-score number?]])
 
 (mr/def ::cumulative-outlier
   "An outlier detected in cumulative data (via period-over-period diffs)."
@@ -139,7 +139,7 @@
    [:label :any]
    [:value number?]
    [:diff number?]
-   [:modified_z_score number?]])
+   [:modified-z-score number?]])
 
 ;;; --------------------------------------------------- Options ------------------------------------------------------
 
@@ -155,21 +155,21 @@
   "Statistics for a single time series."
   [:map
    [:summary ::series-summary]
-   [:time_range ::time-range]
-   [:data_points :int]
+   [:time-range ::time-range]
+   [:data-points :int]
    [:trend ::trend-summary]
-   [:is_cumulative :boolean]
+   [:is-cumulative :boolean]
    [:outliers {:optional true} [:maybe [:sequential ::outlier]]]
    [:volatility {:optional true} [:maybe ::volatility]]
    [:patterns {:optional true} [:maybe [:sequential ::pattern-insight]]]
-   [:significant_changes {:optional true} [:maybe [:sequential ::significant-change]]]
-   [:most_recent_change {:optional true} [:maybe ::significant-change]]])
+   [:significant-changes {:optional true} [:maybe [:sequential ::significant-change]]]
+   [:most-recent-change {:optional true} [:maybe ::significant-change]]])
 
 (mr/def ::time-series-stats
   "Statistics for time series charts."
   [:map
-   [:chart_type [:= :time-series]]
-   [:series_count :int]
+   [:chart-type [:= :time-series]]
+   [:series-count :int]
    [:series [:map-of :string ::time-series-series-stats]]
    [:correlations {:optional true} [:maybe [:sequential ::correlation]]]])
 
@@ -184,17 +184,17 @@
   "Statistics for a single categorical series."
   [:map
    [:summary [:maybe ::series-summary]]
-   [:data_points :int]
-   [:category_count :int]
-   [:top_categories [:sequential ::category-stat]]
-   [:bottom_categories {:optional true} [:maybe [:sequential ::category-stat]]]
+   [:data-points :int]
+   [:category-count :int]
+   [:top-categories [:sequential ::category-stat]]
+   [:bottom-categories {:optional true} [:maybe [:sequential ::category-stat]]]
    [:outliers {:optional true} [:maybe [:sequential ::outlier]]]])
 
 (mr/def ::categorical-stats
   "Statistics for categorical charts (bar, pie, etc.)."
   [:map
-   [:chart_type [:= :categorical]]
-   [:series_count :int]
+   [:chart-type [:= :categorical]]
+   [:series-count :int]
    [:series [:map-of :string ::categorical-series-stats]]
    [:correlations {:optional true} [:maybe [:sequential ::correlation]]]])
 
@@ -203,15 +203,15 @@
   [:map
    [:slope number?]
    [:intercept number?]
-   [:r_squared number?]])
+   [:r-squared number?]])
 
 (mr/def ::scatter-series-stats
   "Statistics for a single scatter series."
   [:map
-   [:x_summary [:maybe ::series-summary]]
-   [:y_summary [:maybe ::series-summary]]
-   [:data_points :int]
-   [:sampled_points {:optional true} [:maybe [:sequential [:sequential :any]]]]
+   [:x-summary [:maybe ::series-summary]]
+   [:y-summary [:maybe ::series-summary]]
+   [:data-points :int]
+   [:sampled-points {:optional true} [:maybe [:sequential [:sequential :any]]]]
    [:correlation {:optional true} [:maybe [:map
                                            [:coefficient number?]
                                            [:strength ::correlation-strength]
@@ -222,61 +222,61 @@
 (mr/def ::scatter-stats
   "Statistics for scatter plots."
   [:map
-   [:chart_type [:= :scatter]]
-   [:series_count :int]
+   [:chart-type [:= :scatter]]
+   [:series-count :int]
    [:series [:map-of :string ::scatter-series-stats]]])
 
 (mr/def ::histogram-summary
   "Weighted summary statistics estimated from binned histogram data."
   [:map
-   [:weighted_mean number?]
-   [:weighted_std_dev number?]
-   [:data_range number?]])
+   [:weighted-mean number?]
+   [:weighted-std-dev number?]
+   [:data-range number?]])
 
 (mr/def ::estimated-distribution-stats
   "Distribution statistics estimated from binned histogram data using weighted approximations."
   [:map
-   [:estimated_percentiles [:map-of :int number?]]
-   [:estimated_quartiles [:map
+   [:estimated-percentiles [:map-of :int number?]]
+   [:estimated-quartiles [:map
                           [:q1 number?]
                           [:median number?]
                           [:q3 number?]
                           [:iqr number?]]]
-   [:weighted_skewness {:optional true} [:maybe number?]]
-   [:weighted_kurtosis {:optional true} [:maybe number?]]])
+   [:weighted-skewness {:optional true} [:maybe number?]]
+   [:weighted-kurtosis {:optional true} [:maybe number?]]])
 
 (mr/def ::histogram-structure
   "Structural properties of histogram bin distribution."
   [:map
-   [:mode_bin [:maybe [:sequential :any]]]
-   [:peak_count :int]
-   [:concentration_top3 number?]
-   [:gap_count :int]
-   [:empty_bin_ratio number?]
-   [:bin_count :int]])
+   [:mode-bin [:maybe [:sequential :any]]]
+   [:peak-count :int]
+   [:concentration-top3 number?]
+   [:gap-count :int]
+   [:empty-bin-ratio number?]
+   [:bin-count :int]])
 
 (mr/def ::histogram-series-stats
   "Statistics for a single histogram series."
   [:map
-   [:estimated_summary ::histogram-summary]
-   [:total_count :int]
-   [:data_points :int]
-   [:bin_data [:sequential [:sequential :any]]]
+   [:estimated-summary ::histogram-summary]
+   [:total-count :int]
+   [:data-points :int]
+   [:bin-data [:sequential [:sequential :any]]]
    [:distribution ::estimated-distribution-stats]
    [:structure ::histogram-structure]])
 
 (mr/def ::histogram-stats
   "Statistics for histogram charts."
   [:map
-   [:chart_type [:= :histogram]]
-   [:series_count :int]
+   [:chart-type [:= :histogram]]
+   [:series-count :int]
    [:series [:map-of :string ::histogram-series-stats]]])
 
 (mr/def ::unknown-stats
   "Fallback stats for chart types that don't have dedicated analysis (e.g. scalar)."
   [:map
-   [:chart_type [:= :unknown]]
-   [:series_count :int]
+   [:chart-type [:= :unknown]]
+   [:series-count :int]
    [:message :string]])
 
 (mr/def ::chart-stats

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/stats/util.clj
@@ -22,7 +22,7 @@
      :max max-val
      :mean (dfn/mean values)
      :median (dfn/median values)
-     :std_dev (dfn/standard-deviation values)
+     :std-dev (dfn/standard-deviation values)
      :range (- max-val min-val)}))
 
 (mu/defn correlation-direction :- ::stats.types/correlation-direction
@@ -77,12 +77,12 @@
                  n (count aligned-a)]
            :when (>= n min-correlation-sample-size)
            :let [coef (dfn/pearsons-correlation aligned-a aligned-b)]]
-       {:series_a name-a
-        :series_b name-b
+       {:series-a name-a
+        :series-b name-b
         :coefficient coef
         :strength (correlation-strength coef)
         :direction (correlation-direction coef)
-        :aligned_sample_size n}))))
+        :aligned-sample-size n}))))
 
 (mu/defn maybe-compute-correlations :- [:maybe [:sequential ::stats.types/correlation]]
   "Compute pairwise correlations if deep mode is enabled and there are multiple series.
@@ -106,20 +106,20 @@
     (* 100.0 (/ (- to-val from-val) (Math/abs (double from-val))))))
 
 (defn compute-series-with-labels
-  "Apply `compute-fn` to each series' x_values and y_values, attaching :x_name and :y_name
+  "Apply `compute-fn` to each series' x_values and y_values, attaching :x-name and :y-name
   from column metadata. `compute-fn` is called on x_values and y_values for each series.
   Returns a map of series-name -> stats-with-labels."
   [series-data compute-fn]
   (into {}
         (for [[series-name {:keys [x_values y_values x y]}] series-data]
           [series-name (-> (compute-fn x_values y_values)
-                           (assoc :x_name (some-> x :name))
-                           (assoc :y_name (some-> y :name)))])))
+                           (assoc :x-name (some-> x :name))
+                           (assoc :y-name (some-> y :name)))])))
 
 (mu/defn make-chart-result :- ::stats.types/chart-stats
   "Build the standard chart stats result map."
   [chart-type series-data series-stats correlations]
-  (cond-> {:chart_type   chart-type
-           :series_count (count series-data)
+  (cond-> {:chart-type   chart-type
+           :series-count (count series-data)
            :series       series-stats}
     correlations (assoc :correlations correlations)))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/categorical_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/categorical_test.clj
@@ -8,23 +8,23 @@
 
 (deftest ^:parallel compute-series-stats-empty-test
   (testing "empty series returns zero counts without crashing"
-    (is (=? {:category_count 0
-             :top_categories []
+    (is (=? {:category-count 0
+             :top-categories []
              :outliers       []
              :summary        nil?}
             (#'categorical/compute-series-stats [] [])))))
 
 (deftest ^:parallel compute-series-stats-nil-y-filtered-test
   (testing "nil y-values are filtered out"
-    (is (=? {:category_count 2
-             :top_categories [{:name "C" :value 200}
+    (is (=? {:category-count 2
+             :top-categories [{:name "C" :value 200}
                               {:name "A" :value 100}]}
             (#'categorical/compute-series-stats ["A" "B" "C"] [100 nil 200])))))
 
 (deftest ^:parallel compute-series-stats-single-category-test
   (testing "single category has 100% share"
-    (is (=? {:category_count 1
-             :top_categories [{:name "only"
+    (is (=? {:category-count 1
+             :top-categories [{:name "only"
                                :value 42
                                :percentage 100.0}]}
             (#'categorical/compute-series-stats ["only"] [42])))))
@@ -34,35 +34,35 @@
     (let [result (#'categorical/compute-series-stats
                   ["A" "B" "C" "D"]
                   [10 20 30 40])]
-      (is (= 4 (:category_count result)))
-      (let [total-pct (reduce + (map :percentage (:top_categories result)))]
+      (is (= 4 (:category-count result)))
+      (let [total-pct (reduce + (map :percentage (:top-categories result)))]
         (is (== total-pct 100.0))))))
 
 (deftest ^:parallel compute-series-stats-sorted-by-value-desc-test
   (testing "top categories are sorted by value descending"
     (is (= ["C" "B" "A"]
            (->> (#'categorical/compute-series-stats ["C" "A" "B"] [30 10 20])
-                :top_categories
+                :top-categories
                 (map :name))))))
 
 (deftest ^:parallel compute-series-stats-top-10-limit-test
   (testing "top_categories capped at 10"
     (let [xs (map str (range 20))
           ys (range 1 21)]
-      (is (=? {:category_count 20
-               :top_categories #(= 10 (count %))}
+      (is (=? {:category-count 20
+               :top-categories #(= 10 (count %))}
               (#'categorical/compute-series-stats xs ys))))))
 
 (deftest ^:parallel compute-series-stats-bottom-categories-present-test
   (testing "bottom_categories populated when > 15 categories"
     (let [xs (map str (range 16))
           ys (range 1 17)]
-      (is (=? {:bottom_categories #(= 5 (count %))}
+      (is (=? {:bottom-categories #(= 5 (count %))}
               (#'categorical/compute-series-stats xs ys))))))
 
 (deftest ^:parallel compute-series-stats-bottom-categories-missing-test
   (testing "bottom_categories absent when <= 15 categories"
-    (is (=? {:bottom_categories (symbol "nil #_\"key is not present.\"")}
+    (is (=? {:bottom-categories (symbol "nil #_\"key is not present.\"")}
             (#'categorical/compute-series-stats
              (map str (range 15))
              (range 1 16))))))
@@ -72,7 +72,7 @@
     (is (=? {:outliers [{:index 5
                          :label "F"
                          :value 1000
-                         :modified_z_score pos?}]}
+                         :modified-z-score pos?}]}
             (#'categorical/compute-series-stats
              ["A" "B" "C" "D" "E" "F"]
              [10 12 11 9 13 1000])))))
@@ -96,16 +96,16 @@
                                   :x {:name "cat" :type "string"}
                                   :y {:name "cost" :type "number"}
                                   :display_name "Cost"}}]
-      (is (=? {:chart_type :categorical
-               :series_count 2
+      (is (=? {:chart-type :categorical
+               :series-count 2
                :series {"Revenue" {:summary {:min 100
                                              :max 200
                                              :mean 150.0
                                              :median 200.0
-                                             :std_dev (=?/approx [70.71 0.01])
+                                             :std-dev (=?/approx [70.71 0.01])
                                              :range 100}
-                                   :category_count 2
-                                   :top_categories
+                                   :category-count 2
+                                   :top-categories
                                    [{:name "B"
                                      :value 200
                                      :percentage (=?/approx [66.66 0.01])}
@@ -113,16 +113,16 @@
                                      :value 100
                                      :percentage (=?/approx [33.33 0.01])}]
                                    :outliers []
-                                   :x_name "cat"
-                                   :y_name "rev"}
+                                   :x-name "cat"
+                                   :y-name "rev"}
                         "Cost" {:summary {:min 50
                                           :max 80
                                           :mean 65.0
                                           :median 80.0
-                                          :std_dev (=?/approx [21.21 0.01])
+                                          :std-dev (=?/approx [21.21 0.01])
                                           :range 30}
-                                :category_count 2
-                                :top_categories
+                                :category-count 2
+                                :top-categories
                                 [{:name "B"
                                   :value 80
                                   :percentage (=?/approx [61.5 0.1])}
@@ -130,8 +130,8 @@
                                   :value 50
                                   :percentage (=?/approx [38.4 0.1])}]
                                 :outliers [],
-                                :x_name "cat",
-                                :y_name "cost"}}}
+                                :x-name "cat",
+                                :y-name "cost"}}}
               (categorical/compute-categorical-stats series-data {:deep? false}))))))
 
 (deftest ^:parallel compute-categorical-stats-correlations-when-deep?-test
@@ -170,14 +170,14 @@
     (let [result (#'categorical/compute-series-stats
                   ["A" "A" "B"]
                   [100 150 200])]
-      (is (= 2 (:category_count result)))
-      (is (= 2 (count (:top_categories result))))
-      (let [by-name (into {} (map (juxt :name :value) (:top_categories result)))]
+      (is (= 2 (:category-count result)))
+      (is (= 2 (count (:top-categories result))))
+      (let [by-name (into {} (map (juxt :name :value) (:top-categories result)))]
         (is (= {"A" 250 "B" 200} by-name))))))
 
 (deftest ^:parallel compute-series-stats-nil-dimensions-excluded-test
   (testing "nil x-values are excluded from category_count"
-    (is (=? {:category_count 1}
+    (is (=? {:category-count 1}
             (#'categorical/compute-series-stats
              [nil "A" nil]
              [100 200 150])))))
@@ -196,8 +196,8 @@
     (let [result (#'categorical/compute-series-stats
                   ["A" "B" "C"]
                   [100 -20 50])]
-      (is (= 3 (:category_count result)))
-      (is (every? #(not (contains? % :percentage)) (:top_categories result))))))
+      (is (= 3 (:category-count result)))
+      (is (every? #(not (contains? % :percentage)) (:top-categories result))))))
 
 (deftest ^:parallel compute-series-stats-exact-percentages-test
   (testing "percentages in top_categories match expected values"
@@ -208,6 +208,6 @@
             (->> (#'categorical/compute-series-stats
                   ["enabled" "disabled" "invited"]
                   [112 103 85])
-                 :top_categories
+                 :top-categories
                  (map (juxt :name :percentage))
                  (into {}))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/core_test.clj
@@ -35,7 +35,7 @@
 (deftest ^:parallel data-points-within-limit-are-not-downsampled-test
   (testing "Series within the limit are not modified"
     (is (=? {:limits (symbol "nil #_\"key is not present.\"")
-             :series {"series_0" {:data_points 100}}}
+             :series {"series_0" {:data-points 100}}}
             (stats.core/compute-chart-stats (make-chart-config 1 100) {:deep? false})))))
 
 (deftest ^:parallel data-points-exceeding-limit-are-downsampled-test
@@ -43,8 +43,8 @@
     (let [n      (+ @#'stats.core/max-data-points-per-series 5000)
           config (make-chart-config 1 n)
           stats  (stats.core/compute-chart-stats config {:deep? false})
-          sampled (get-in stats [:series "series_0" :data_points])]
-      (is (=? {:limits {:downsampled_series {"series_0" {:original_count n}}}}
+          sampled (get-in stats [:series "series_0" :data-points])]
+      (is (=? {:limits {:downsampled-series {"series_0" {:original-count n}}}}
               stats))
 
       (is (approx=max-data-points-per-series? sampled)
@@ -55,8 +55,8 @@
     (let [n       (+ @#'stats.core/max-data-points-per-series 1000)
           config  (make-chart-config 1 n)
           orig-ys (get-in config [:series "series_0" :y_values])]
-      (is (=? {:series {"series_0" {:trend {:start_value (double (first orig-ys))
-                                            :end_value   (double (last orig-ys))}}}}
+      (is (=? {:series {"series_0" {:trend {:start-value (double (first orig-ys))
+                                            :end-value   (double (last orig-ys))}}}}
               (stats.core/compute-chart-stats config {:deep? false}))))))
 
 (deftest ^:parallel multiple-series-downsampled-independently-test
@@ -68,11 +68,11 @@
                    :series {"small" (make-series small-n)
                             "large" (make-series large-n)}}
           stats   (stats.core/compute-chart-stats config {:deep? false})]
-      (is (=? {:limits {:downsampled_series
+      (is (=? {:limits {:downsampled-series
                         {"small" (symbol "nil #_\"key is not present.\"")
-                         "large" {:original_count large-n}}}
-               :series {"small" {:data_points small-n}
-                        "large" {:data_points approx=max-data-points-per-series?}}}
+                         "large" {:original-count large-n}}}
+               :series {"small" {:data-points small-n}
+                        "large" {:data-points approx=max-data-points-per-series?}}}
               stats)))))
 
 ;;; ---------------------------------------- Correlation Cap Tests -------------------------------------------------
@@ -88,10 +88,10 @@
     (let [n-series (+ @#'stats.core/max-series-for-correlations 5)
           config   (make-chart-config n-series 50)
           stats    (stats.core/compute-chart-stats config {:deep? true})]
-      (is (=? {:limits       {:correlations_capped {:total_series   n-series
-                                                    :max_correlated @#'stats.core/max-series-for-correlations}}
+      (is (=? {:limits       {:correlations-capped {:total-series   n-series
+                                                    :max-correlated @#'stats.core/max-series-for-correlations}}
                :series       #(= n-series (count %))
-               :series_count n-series}
+               :series-count n-series}
               stats))
       ;; Correlations should have at most C(max-k, 2) entries
       (let [max-k @#'stats.core/max-series-for-correlations

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/histogram_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/histogram_test.clj
@@ -10,24 +10,24 @@
 
 (deftest ^:parallel compute-series-stats-empty-test
   (testing "empty values returns zero counts"
-    (is (=? {:data_points   0
-             :total_count   0
-             :distribution  {:estimated_percentiles empty?
-                             :estimated_quartiles   {:q1 0 :median 0 :q3 0 :iqr 0}}
-             :structure     {:mode_bin nil :peak_count 0 :bin_count 0}}
+    (is (=? {:data-points   0
+             :total-count   0
+             :distribution  {:estimated-percentiles empty?
+                             :estimated-quartiles   {:q1 0 :median 0 :q3 0 :iqr 0}}
+             :structure     {:mode-bin nil :peak-count 0 :bin-count 0}}
             (#'histogram/compute-series-stats [])))))
 
 (deftest ^:parallel compute-series-stats-all-nil-test
   (testing "all-nil values returns zero data_points"
-    (is (=? {:data_points   0
-             :total_count   0
-             :distribution  {:estimated_percentiles empty?
-                             :estimated_quartiles   {:q1 0 :median 0 :q3 0 :iqr 0}}}
+    (is (=? {:data-points   0
+             :total-count   0
+             :distribution  {:estimated-percentiles empty?
+                             :estimated-quartiles   {:q1 0 :median 0 :q3 0 :iqr 0}}}
             (#'histogram/compute-series-stats [nil nil nil])))))
 
 (deftest ^:parallel compute-series-stats-nil-filtered-test
   (testing "nil values are filtered out"
-    (is (=? {:data_points 3}
+    (is (=? {:data-points 3}
             (#'histogram/compute-series-stats [0 1 2 3 4] [10 nil 20 nil 30])))))
 
 ;;; ------------------------------------------- Weighted Summary Stats ------------------------------------------------
@@ -35,24 +35,24 @@
 (deftest ^:parallel weighted-mean-test
   (testing "weighted mean for symmetric histogram centered at 20"
     ;; bins at 0,10,20,30,40 with counts 5,10,20,10,5 → weighted mean = 20
-    (is (=? {:estimated_summary {:weighted_mean (=?/approx [20.0 0.001])}}
+    (is (=? {:estimated-summary {:weighted-mean (=?/approx [20.0 0.001])}}
             (#'histogram/compute-series-stats [0 10 20 30 40] [5 10 20 10 5])))))
 
 (deftest ^:parallel weighted-std-dev-test
   (testing "weighted std dev for known data"
     ;; variance = Σ(c*(x-20)²)/50 = (5*400+10*100+0+10*100+5*400)/50 = 120
     ;; std = √120 ≈ 10.954
-    (is (=? {:estimated_summary {:weighted_std_dev (=?/approx [10.954 0.01])}}
+    (is (=? {:estimated-summary {:weighted-std-dev (=?/approx [10.954 0.01])}}
             (#'histogram/compute-series-stats [0 10 20 30 40] [5 10 20 10 5])))))
 
 (deftest ^:parallel data-range-test
   (testing "data range is max_x - min_x"
-    (is (=? {:estimated_summary {:data_range 40.0}}
+    (is (=? {:estimated-summary {:data-range 40.0}}
             (#'histogram/compute-series-stats [0 10 20 30 40] [5 10 20 10 5])))))
 
 (deftest ^:parallel total-count-test
   (testing "total_count is sum of all counts"
-    (is (=? {:total_count 50}
+    (is (=? {:total-count 50}
             (#'histogram/compute-series-stats [0 10 20 30 40] [5 10 20 10 5])))))
 
 ;;; ----------------------------------------- Estimated Percentiles ---------------------------------------------------
@@ -60,7 +60,7 @@
 (deftest ^:parallel estimated-percentiles-present-test
   (testing "all six percentiles (25,50,75,90,95,99) are computed"
     (let [result (#'histogram/compute-series-stats [0 10 20 30 40] [5 10 20 10 5])
-          pcts   (get-in result [:distribution :estimated_percentiles])]
+          pcts   (get-in result [:distribution :estimated-percentiles])]
       (is (contains? pcts 25))
       (is (contains? pcts 50))
       (is (contains? pcts 75))
@@ -71,7 +71,7 @@
 (deftest ^:parallel estimated-percentiles-ascending-test
   (testing "percentile values are in ascending order"
     (let [pcts (get-in (#'histogram/compute-series-stats [0 10 20 30 40] [5 10 20 10 5])
-                       [:distribution :estimated_percentiles])]
+                       [:distribution :estimated-percentiles])]
       (is (<= (get pcts 25) (get pcts 50)))
       (is (<= (get pcts 50) (get pcts 75)))
       (is (<= (get pcts 75) (get pcts 90))))))
@@ -79,15 +79,15 @@
 (deftest ^:parallel estimated-percentiles-symmetric-test
   (testing "P50 is close to weighted mean for symmetric distribution"
     (let [result (#'histogram/compute-series-stats [0 10 20 30 40] [5 10 20 10 5])
-          p50    (get-in result [:distribution :estimated_percentiles 50])
-          wmean  (get-in result [:estimated_summary :weighted_mean])]
+          p50    (get-in result [:distribution :estimated-percentiles 50])
+          wmean  (get-in result [:estimated-summary :weighted-mean])]
       ;; For symmetric binned data, P50 should be reasonably close to the mean
       (is (< (Math/abs (double (- p50 wmean))) 10.0)))))
 
 (deftest ^:parallel estimated-quartiles-iqr-test
   (testing "IQR = Q3 - Q1"
     (let [quartiles (get-in (#'histogram/compute-series-stats [0 10 20 30 40] [5 10 20 10 5])
-                            [:distribution :estimated_quartiles])
+                            [:distribution :estimated-quartiles])
           {:keys [q1 q3 iqr]} quartiles]
       (is (< (Math/abs (- (double iqr) (- (double q3) (double q1)))) 0.001)))))
 
@@ -95,77 +95,77 @@
 
 (deftest ^:parallel no-shape-metrics-few-bins-test
   (testing "< 8 bins produces no weighted_skewness or weighted_kurtosis"
-    (is (=? {:data_points  5
-             :distribution {:weighted_skewness (symbol "nil #_\"key is not present.\"")
-                            :weighted_kurtosis (symbol "nil #_\"key is not present.\"")}}
+    (is (=? {:data-points  5
+             :distribution {:weighted-skewness (symbol "nil #_\"key is not present.\"")
+                            :weighted-kurtosis (symbol "nil #_\"key is not present.\"")}}
             (#'histogram/compute-series-stats [0 10 20 30 40] [5 10 20 10 5])))))
 
 (deftest ^:parallel shape-metrics-enough-bins-test
   (testing ">= 8 bins produces weighted_skewness and weighted_kurtosis"
     (let [xs (range 0 80 10)
           ys [2 5 10 20 20 10 5 2]]
-      (is (=? {:data_points  8
-               :distribution {:weighted_skewness number?
-                              :weighted_kurtosis number?}}
+      (is (=? {:data-points  8
+               :distribution {:weighted-skewness number?
+                              :weighted-kurtosis number?}}
               (#'histogram/compute-series-stats xs ys))))))
 
 (deftest ^:parallel symmetric-distribution-skewness-test
   (testing "symmetric distribution has near-zero weighted skewness"
     (let [xs (range 0 100 10)
           ys [1 3 8 15 25 25 15 8 3 1]]
-      (is (=? {:distribution {:weighted_skewness #(< (Math/abs (double %)) 0.1)}}
+      (is (=? {:distribution {:weighted-skewness #(< (Math/abs (double %)) 0.1)}}
               (#'histogram/compute-series-stats xs ys))))))
 
 (deftest ^:parallel right-skewed-distribution-test
   (testing "right-skewed distribution has positive weighted skewness"
     (let [xs (range 0 100 10)
           ys [30 20 15 10 8 5 3 2 1 1]]
-      (is (=? {:distribution {:weighted_skewness #(> (double %) 0.3)}}
+      (is (=? {:distribution {:weighted-skewness #(> (double %) 0.3)}}
               (#'histogram/compute-series-stats xs ys))))))
 
 (deftest ^:parallel left-skewed-distribution-test
   (testing "left-skewed distribution has negative weighted skewness"
     (let [xs (range 0 100 10)
           ys [1 1 2 3 5 8 10 15 20 30]]
-      (is (=? {:distribution {:weighted_skewness #(< (double %) -0.3)}}
+      (is (=? {:distribution {:weighted-skewness #(< (double %) -0.3)}}
               (#'histogram/compute-series-stats xs ys))))))
 
 ;;; ------------------------------------------- Structural Metrics ----------------------------------------------------
 
 (deftest ^:parallel mode-bin-test
   (testing "mode_bin is the bin with the highest count"
-    (is (=? {:structure {:mode_bin [20.0 20.0]}}
+    (is (=? {:structure {:mode-bin [20.0 20.0]}}
             (#'histogram/compute-series-stats [0 10 20 30 40] [5 10 20 10 5])))))
 
 (deftest ^:parallel unimodal-peak-count-test
   (testing "unimodal histogram has peak_count = 1"
-    (is (=? {:structure {:peak_count 1}}
+    (is (=? {:structure {:peak-count 1}}
             (#'histogram/compute-series-stats [0 10 20 30 40] [5 10 20 10 5])))))
 
 (deftest ^:parallel bimodal-peak-count-test
   (testing "bimodal histogram has peak_count = 2"
-    (is (=? {:structure {:peak_count 2}}
+    (is (=? {:structure {:peak-count 2}}
             (#'histogram/compute-series-stats [0 10 20 30 40] [15 5 2 5 15])))))
 
 (deftest ^:parallel concentration-top3-test
   (testing "concentration_top3 gives fraction of data in top 3 bins"
     ;; top 3 counts: 20, 10, 10 = 40 out of 50 = 0.8
-    (is (=? {:structure {:concentration_top3 (=?/approx [0.8 0.001])}}
+    (is (=? {:structure {:concentration-top3 (=?/approx [0.8 0.001])}}
             (#'histogram/compute-series-stats [0 10 20 30 40] [5 10 20 10 5])))))
 
 (deftest ^:parallel gap-count-test
   (testing "gaps are counted between non-zero bins"
-    (is (=? {:structure {:gap_count 3}}
+    (is (=? {:structure {:gap-count 3}}
             (#'histogram/compute-series-stats [0 10 20 30 40] [10 0 0 0 10])))))
 
 (deftest ^:parallel no-gaps-test
   (testing "no gaps when all bins are non-zero"
-    (is (=? {:structure {:gap_count 0}}
+    (is (=? {:structure {:gap-count 0}}
             (#'histogram/compute-series-stats [0 10 20 30 40] [5 10 20 10 5])))))
 
 (deftest ^:parallel empty-bin-ratio-test
   (testing "empty_bin_ratio tracks fraction of zero-count bins"
-    (is (=? {:structure {:empty_bin_ratio (=?/approx [0.6 0.001])}}
+    (is (=? {:structure {:empty-bin-ratio (=?/approx [0.6 0.001])}}
             (#'histogram/compute-series-stats [0 10 20 30 40] [10 0 0 0 10])))))
 
 ;;; ---------------------------------------- Full Integration Test ----------------------------------------------------
@@ -177,23 +177,23 @@
                                :x {:name "bin" :type "number"}
                                :y {:name "count" :type "number"}
                                :display_name "Bins"}}]
-      (is (=? {:chart_type   :histogram
-               :series_count 1
-               :series       {"Bins" {:data_points       5
-                                      :total_count       50
-                                      :estimated_summary {:weighted_mean (=?/approx [20.0 0.001])}
-                                      :distribution      {:estimated_quartiles {:q1 number?
+      (is (=? {:chart-type   :histogram
+               :series-count 1
+               :series       {"Bins" {:data-points       5
+                                      :total-count       50
+                                      :estimated-summary {:weighted-mean (=?/approx [20.0 0.001])}
+                                      :distribution      {:estimated-quartiles {:q1 number?
                                                                                 :q3 number?
                                                                                 :iqr number?}}
-                                      :structure         {:mode_bin [20.0 20.0]
-                                                          :peak_count 1
-                                                          :bin_count 5}}}}
+                                      :structure         {:mode-bin [20.0 20.0]
+                                                          :peak-count 1
+                                                          :bin-count 5}}}}
               (histogram/compute-histogram-stats series-data {}))))))
 
 (deftest ^:parallel single-arity-uses-indices-test
   (testing "single-arity form uses sequential indices as x_values"
     (let [result (#'histogram/compute-series-stats [10 20 30])]
-      (is (=? {:data_points       3
-               :total_count       60
-               :estimated_summary {:weighted_mean (=?/approx [1.333 0.01])}}
+      (is (=? {:data-points       3
+               :total-count       60
+               :estimated-summary {:weighted-mean (=?/approx [1.333 0.01])}}
               result)))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/outliers_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/outliers_test.clj
@@ -16,7 +16,7 @@
       (is (seq result))
       (is (=? {:index 4
                :value 10.0
-               :modified_z_score #(> (Math/abs (double %)) 3.0)}
+               :modified-z-score #(> (Math/abs (double %)) 3.0)}
               (first (filter #(= "E" (:label %)) result)))))))
 
 (deftest ^:parallel find-outliers-no-outliers-returns-empty-test
@@ -53,7 +53,7 @@
       (is (some #(= "D" (:label %)) result)))))
 
 (deftest ^:parallel find-outliers-cumulative-outlier-map-structure-test
-  (testing "cumulative outlier maps include :index :label :value :diff :modified_z_score"
+  (testing "cumulative outlier maps include :index :label :value :diff :modified-z-score"
     (let [values [1.0 2.0 3.0 10.0 12.0]
           labels ["A" "B" "C" "D" "E"]
           result (outliers/find-outliers-cumulative values labels)]
@@ -62,7 +62,7 @@
                :label "D"
                :value 10.0
                :diff 7.0
-               :modified_z_score (=?/approx [3.37 0.01])}
+               :modified-z-score (=?/approx [3.37 0.01])}
               (first result))))))
 
 (deftest ^:parallel find-outliers-cumulative-uniform-increments-test

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/repr_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/repr_test.clj
@@ -65,8 +65,8 @@
     (let [xs           (range 0 100 10)
           ys           [1 3 8 15 25 25 15 8 3 1]
           series-stats (#'histogram/compute-series-stats xs ys)
-          stats        {:chart_type   :histogram
-                        :series_count 1
+          stats        {:chart-type   :histogram
+                        :series-count 1
                         :series       {"Test Series" series-stats}}
           rep          (repr/generate-representation {:stats stats})]
       (is (str/includes? rep "Test Series"))
@@ -77,8 +77,8 @@
     (let [xs           (range 0 100 10)
           ys           [1 3 8 15 25 25 15 8 3 1]
           series-stats (#'histogram/compute-series-stats xs ys)
-          stats        {:chart_type   :histogram
-                        :series_count 1
+          stats        {:chart-type   :histogram
+                        :series-count 1
                         :series       {"Values" series-stats}}
           rep          (repr/generate-representation {:stats stats})]
       (is (str/includes? rep "Estimated Percentiles"))
@@ -88,8 +88,8 @@
 (deftest ^:parallel repr-histogram-shows-structure-test
   (testing "histogram representation includes structural metrics"
     (let [series-stats (#'histogram/compute-series-stats [0 10 20 30 40] [5 10 20 10 5])
-          stats        {:chart_type   :histogram
-                        :series_count 1
+          stats        {:chart-type   :histogram
+                        :series-count 1
                         :series       {"Bins" series-stats}}
           rep          (repr/generate-representation {:stats stats})]
       (is (str/includes? rep "Structure"))
@@ -101,8 +101,8 @@
 (deftest ^:parallel repr-scatter-shows-relationship-test
   (testing "representation includes Relationship with strength and direction"
     (let [series-stats (#'scatter/compute-series-stats [1 2 3 4 5] [10 20 30 40 50])
-          stats        {:chart_type   :scatter
-                        :series_count 1
+          stats        {:chart-type   :scatter
+                        :series-count 1
                         :series       {"Test Series" series-stats}}
           rep          (repr/generate-representation {:stats stats})]
       (is (str/includes? rep "Test Series"))
@@ -112,8 +112,8 @@
 (deftest ^:parallel repr-scatter-shows-trend-line-test
   (testing "scatter representation includes trend line equation when regression is present"
     (let [series-stats (#'scatter/compute-series-stats [1 2 3 4 5] [12 14 16 18 20])
-          stats        {:chart_type   :scatter
-                        :series_count 1
+          stats        {:chart-type   :scatter
+                        :series-count 1
                         :series       {"Linear" series-stats}}
           rep          (repr/generate-representation {:stats stats})]
       (is (str/includes? rep "Trend Line"))
@@ -124,8 +124,8 @@
 (deftest ^:parallel repr-categorical-includes-key-info-test
   (testing "representation includes series name, data count, and Categories"
     (let [series-stats (#'categorical/compute-series-stats ["A" "B" "C"] [100 200 150])
-          stats        {:chart_type   :categorical
-                        :series_count 1
+          stats        {:chart-type   :categorical
+                        :series-count 1
                         :series       {"Test Series" series-stats}}
           rep          (repr/generate-representation {:stats stats})]
       (is (str/includes? rep "Test Series"))
@@ -137,8 +137,8 @@
     (let [xs           (map #(str "Cat" (format "%02d" %)) (range 1 21))
           ys           (map double (range 1 21))
           series-stats (#'categorical/compute-series-stats xs ys)
-          stats        {:chart_type   :categorical
-                        :series_count 1
+          stats        {:chart-type   :categorical
+                        :series-count 1
                         :series       {"Many" series-stats}}
           rep          (repr/generate-representation {:stats stats})]
       (is (str/includes? rep "Top Categories"))
@@ -153,8 +153,8 @@
     (let [xs           (map #(str "Cat" %) (range 1 16))
           ys           (map double (range 1 16))
           series-stats (#'categorical/compute-series-stats xs ys)
-          stats        {:chart_type   :categorical
-                        :series_count 1
+          stats        {:chart-type   :categorical
+                        :series-count 1
                         :series       {"Few" series-stats}}
           rep          (repr/generate-representation {:stats stats})]
       (is (str/includes? rep "Top Categories"))
@@ -163,8 +163,8 @@
 (deftest ^:parallel repr-categorical-sparse-data-warning-test
   (testing "sparse data warning shown for series with < 10 data points"
     (let [series-stats (#'categorical/compute-series-stats ["A" "B" "C"] [100 200 150])
-          stats        {:chart_type   :categorical
-                        :series_count 1
+          stats        {:chart-type   :categorical
+                        :series-count 1
                         :series       {"Few" series-stats}}
           rep          (repr/generate-representation {:stats stats})]
       (is (str/includes? rep "limited data points")))))
@@ -187,8 +187,8 @@
     (let [values [10.0 20.0 30.0 40.0 50.0]
           dates  ["2024-01" "2024-02" "2024-03" "2024-04" "2024-05"]
           series-stats (#'time-series/compute-series-stats values dates {})
-          stats {:chart_type   :time-series
-                 :series_count 1
+          stats {:chart-type   :time-series
+                 :series-count 1
                  :series       {"Revenue" series-stats}}
           rep (repr/generate-representation {:stats stats})]
       (is (str/includes? rep "Revenue"))
@@ -199,8 +199,8 @@
   (testing "representation with multiple series includes all series names"
     (let [make-stats (fn [values dates]
                        (#'time-series/compute-series-stats values dates {}))
-          stats {:chart_type   :time-series
-                 :series_count 2
+          stats {:chart-type   :time-series
+                 :series-count 2
                  :series       {"Sales"   (make-stats [10.0 20.0 30.0 40.0 50.0]
                                                       ["d1" "d2" "d3" "d4" "d5"])
                                 "Revenue" (make-stats [20.0 40.0 60.0 80.0 100.0]
@@ -214,8 +214,8 @@
     (let [values (mapv #(* 10.0 %) (range 1 13))
           dates  (mapv #(format "2024-%02d" %) (range 1 13))
           series-stats (#'time-series/compute-series-stats values dates {:deep? true})
-          stats  {:chart_type   :time-series
-                  :series_count 1
+          stats  {:chart-type   :time-series
+                  :series-count 1
                   :series       {"Metric" series-stats}}
           rep    (repr/generate-representation {:stats stats})]
       (is (str/includes? rep "Volatility"))
@@ -226,7 +226,7 @@
 
 (deftest ^:parallel generate-representation-dispatches-to-correct-renderer-test
   (testing "dispatches to the correct renderer for known chart type"
-    (let [ts-stats {:chart_type :time-series :series_count 1
+    (let [ts-stats {:chart-type :time-series :series-count 1
                     :series {"S" (#'time-series/compute-series-stats
                                   [1.0 2.0 3.0 4.0 5.0]
                                   ["d1" "d2" "d3" "d4" "d5"] {})}}]
@@ -235,7 +235,7 @@
 (deftest ^:parallel generate-representation-unknown-chart-type-fallback-test
   (testing "unknown chart type produces fallback message"
     (is (str/includes?
-         (repr/generate-representation {:stats {:chart_type   :unknown
-                                                :series_count 0
+         (repr/generate-representation {:stats {:chart-type   :unknown
+                                                :series-count 0
                                                 :message      "Stats not yet implemented"}})
          "not yet implemented"))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/scatter_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/scatter_test.clj
@@ -8,36 +8,36 @@
 
 (deftest ^:parallel compute-series-stats-empty-test
   (testing "empty/nil series returns minimal result"
-    (is (=? {:data_points 0
-             :x_summary nil?
-             :y_summary nil?}
+    (is (=? {:data-points 0
+             :x-summary nil?
+             :y-summary nil?}
             (#'scatter/compute-series-stats [] [])))))
 
 (deftest ^:parallel compute-series-stats-nil-filtered-test
   (testing "nil x or y values are filtered out"
     ;; only [1,4] is fully valid
-    (is (=? {:data_points 1}
+    (is (=? {:data-points 1}
             (#'scatter/compute-series-stats [1 nil 3] [4 5 nil])))))
 
 (deftest ^:parallel compute-series-stats-one-valid-pair-test
   (testing "< 2 valid pairs gives no correlation or regression"
-    (is (=? {:data_points  1
+    (is (=? {:data-points  1
              :correlation  (symbol "nil #_\"key is not present.\"")
              :regression   (symbol "nil #_\"key is not present.\"")}
             (#'scatter/compute-series-stats [1] [2])))))
 
 (deftest ^:parallel compute-series-stats-two-valid-pairs-test
   (testing "2 valid pairs gives correlation but no regression (< 3)"
-    (is (=? {:data_points 2
+    (is (=? {:data-points 2
              :correlation {:coefficient 1.0 :strength :strong :direction :positive}
              :regression  (symbol "nil #_\"key is not present.\"")}
             (#'scatter/compute-series-stats [1 2] [3 4])))))
 
 (deftest ^:parallel compute-series-stats-perfect-positive-correlation-test
   (testing "perfect positive correlation"
-    (is (=? {:data_points 5
+    (is (=? {:data-points 5
              :correlation {:coefficient 1.0 :strength :strong :direction :positive}
-             :regression  {:slope 2.0 :r_squared 1.0}}
+             :regression  {:slope 2.0 :r-squared 1.0}}
             (#'scatter/compute-series-stats [1 2 3 4 5] [2 4 6 8 10])))))
 
 (deftest ^:parallel compute-series-stats-perfect-negative-correlation-test
@@ -63,13 +63,13 @@
 (deftest ^:parallel compute-series-stats-constant-x-test
   (testing "constant x-values result in regression returning nil gracefully"
     ;; correlation will be NaN (constant x). regression may fail but should not throw.
-    (is (=? {:data_points 4}
+    (is (=? {:data-points 4}
             (#'scatter/compute-series-stats [5 5 5 5] [1 2 3 4])))))
 
 (deftest ^:parallel compute-series-stats-summaries-test
   (testing "x and y summaries computed correctly"
-    (is (=? {:x_summary {:min 1.0 :max 3.0}
-             :y_summary {:min 10.0 :max 30.0}}
+    (is (=? {:x-summary {:min 1.0 :max 3.0}
+             :y-summary {:min 10.0 :max 30.0}}
             (#'scatter/compute-series-stats [1 2 3] [10 20 30])))))
 
 (deftest ^:parallel compute-scatter-stats-multi-series-test
@@ -82,13 +82,13 @@
                              :x {:name "x" :type "number"}
                              :y {:name "y" :type "number"}
                              :display_name "S2"}}]
-      (is (=? {:chart_type    :scatter
-               :series_count  2
-               :series        {"S1" {:data_points 3
+      (is (=? {:chart-type    :scatter
+               :series-count  2
+               :series        {"S1" {:data-points 3
                                      :correlation {:coefficient 1.0
                                                    :strength :strong
                                                    :direction :positive}}
-                               "S2" {:data_points 3
+                               "S2" {:data-points 3
                                      :correlation {:coefficient -1.0
                                                    :strength :strong
                                                    :direction :negative}}}
@@ -99,22 +99,22 @@
   (testing "regression intercept computed correctly for y = 2x + 10"
     (is (=? {:regression {:slope     (=?/approx [2.0 0.001])
                           :intercept (=?/approx [10.0 0.001])
-                          :r_squared (=?/approx [1.0 0.001])}}
+                          :r-squared (=?/approx [1.0 0.001])}}
             (#'scatter/compute-series-stats [1 2 3 4 5] [12 14 16 18 20])))))
 
 (deftest ^:parallel compute-series-stats-constant-y-test
   (testing "constant y-values: NaN correlation is handled gracefully (nil correlation)"
     ;; Y has no variance; correlation is NaN, should be absent
-    (is (=? {:data_points  5
+    (is (=? {:data-points  5
              :correlation  (symbol "nil #_\"key is not present.\"")}
             (#'scatter/compute-series-stats [1 2 3 4 5] [50 50 50 50 50])))))
 
 (deftest ^:parallel compute-series-stats-float-values-test
   (testing "float x and y values handled correctly"
-    (is (=? {:data_points 5
-             :x_summary {:min (=?/approx [1.5 0.001])
+    (is (=? {:data-points 5
+             :x-summary {:min (=?/approx [1.5 0.001])
                          :max (=?/approx [5.5 0.001])}
-             :y_summary {:min (=?/approx [10.1 0.001])
+             :y-summary {:min (=?/approx [10.1 0.001])
                          :max (=?/approx [50.5 0.001])}}
             (#'scatter/compute-series-stats
              [1.5 2.5 3.5 4.5 5.5]

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/time_series_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/time_series_test.clj
@@ -41,18 +41,18 @@
 ;;; ---------------------------------------------- compute-trend tests -----------------------------------------------
 
 (deftest ^:parallel compute-trend-strongly-increasing-test
-  (testing "strongly increasing series detected as :strongly_increasing"
-    ;; slope=5, mean=20, pct=100*20/20=100% > 50 → :strongly_increasing
-    (is (=? {:direction          :strongly_increasing
-             :overall_change_pct pos?
-             :start_value        10.0
-             :end_value          30.0}
+  (testing "strongly increasing series detected as :strongly-increasing"
+    ;; slope=5, mean=20, pct=100*20/20=100% > 50 → :strongly-increasing
+    (is (=? {:direction          :strongly-increasing
+             :overall-change-pct pos?
+             :start-value        10.0
+             :end-value          30.0}
             (#'time-series/compute-trend [10.0 15.0 20.0 25.0 30.0])))))
 
 (deftest ^:parallel compute-trend-strongly-decreasing-test
-  (testing "strongly decreasing series detected as :strongly_decreasing"
-    (is (=? {:direction          :strongly_decreasing
-             :overall_change_pct neg?}
+  (testing "strongly decreasing series detected as :strongly-decreasing"
+    (is (=? {:direction          :strongly-decreasing
+             :overall-change-pct neg?}
             (#'time-series/compute-trend [100.0 80.0 60.0 40.0 20.0])))))
 
 (deftest ^:parallel compute-trend-flat-test
@@ -68,8 +68,8 @@
 
 (deftest ^:parallel compute-trend-returns-start-end-values-test
   (testing "trend includes correct start and end values"
-    (is (=? {:start_value 5.0
-             :end_value   25.0}
+    (is (=? {:start-value 5.0
+             :end-value   25.0}
             (#'time-series/compute-trend [5.0 10.0 15.0 20.0 25.0])))))
 
 ;;; --------------------------------------------- compute-volatility tests -------------------------------------------
@@ -78,34 +78,34 @@
   (testing "tightly clustered values produce :low volatility (cv < 0.1)"
     ;; mean≈101.6, std≈1.1, cv≈0.011
     (is (=? {:level                    :low
-             :coefficient_of_variation #(< % 0.1)}
+             :coefficient-of-variation #(< % 0.1)}
             (#'time-series/compute-volatility [100.0 102.0 101.0 103.0 102.0])))))
 
 (deftest ^:parallel compute-volatility-moderate-test
   (testing "moderately variable data produces :moderate volatility (0.1 ≤ cv < 0.3)"
     ;; mean=100, std≈17.3, cv≈0.173
     (is (=? {:level                    :moderate
-             :coefficient_of_variation #(and (<= 0.1 %) (< % 0.3))}
+             :coefficient-of-variation #(and (<= 0.1 %) (< % 0.3))}
             (#'time-series/compute-volatility [80.0 100.0 120.0 90.0 110.0])))))
 
 (deftest ^:parallel compute-volatility-high-test
   (testing "fairly variable data produces :high volatility (0.3 ≤ cv < 0.5)"
     ;; mean=100, std≈34.6, cv≈0.346
     (is (=? {:level                    :high
-             :coefficient_of_variation #(and (<= 0.3 %) (< % 0.5))}
+             :coefficient-of-variation #(and (<= 0.3 %) (< % 0.5))}
             (#'time-series/compute-volatility [60.0 100.0 140.0 70.0 130.0])))))
 
 (deftest ^:parallel compute-volatility-extreme-test
   (testing "very variable data produces :extreme volatility (cv ≥ 0.5)"
     ;; mean≈102, std≈75, cv≈0.73
     (is (=? {:level                    :extreme
-             :coefficient_of_variation #(>= % 0.5)}
+             :coefficient-of-variation #(>= % 0.5)}
             (#'time-series/compute-volatility [10.0 100.0 200.0 50.0 150.0])))))
 
 (deftest ^:parallel compute-volatility-max-period-change-test
   (testing "max period change is computed as absolute percentage of previous value"
     ;; changes 100%, 25%, 100% → max = 100%
-    (is (=? {:max_period_change_pct #(and (>= % 99.0) (<= % 101.0))}
+    (is (=? {:max-period-change-pct #(and (>= % 99.0) (<= % 101.0))}
             (#'time-series/compute-volatility [100.0 200.0 250.0 500.0])))))
 
 ;;; ----------------------------------------------- detect-patterns tests --------------------------------------------
@@ -116,7 +116,7 @@
           dates  (mapv #(format "2024-%02d" %) (range 1 11))
           result (#'time-series/detect-patterns values dates)]
       (is (pos? (count result)))
-      (is (=? {:type        :consecutive_increase
+      (is (=? {:type        :consecutive-increase
                :description #(str/includes? % "increase")}
               (first result))))))
 
@@ -126,7 +126,7 @@
           dates  (mapv #(format "2024-%02d" %) (range 1 11))
           result (#'time-series/detect-patterns values dates)]
       (is (pos? (count result)))
-      (is (=? {:type        :consecutive_decrease
+      (is (=? {:type        :consecutive-decrease
                :description #(str/includes? % "decrease")}
               (first result))))))
 
@@ -145,13 +145,13 @@
       (is (empty? result)))))
 
 (deftest ^:parallel detect-patterns-includes-date-range-test
-  (testing "pattern maps include :from_date and :to_date"
+  (testing "pattern maps include :from-date and :to-date"
     (let [values (mapv #(* 10.0 %) (range 1 11))
           dates  (mapv #(format "2024-%02d" %) (range 1 11))
           result (#'time-series/detect-patterns values dates)]
-      (is (=? [{:type      :consecutive_increase
-                :from_date "2024-02"
-                :to_date   "2024-10"}]
+      (is (=? [{:type      :consecutive-increase
+                :from-date "2024-02"
+                :to-date   "2024-10"}]
               result)))))
 
 ;;; ------------------------------------------- compute-correlations tests -------------------------------------------
@@ -174,9 +174,9 @@
                       "Sales"   (make-corr-series "Sales" x-vals (mapv #(* 20.0 %) (range 1 (inc n))))}
           result  (#'stats.u/compute-correlations series-map)]
       (is (= 1 (count result)))
-      ;; "Revenue" < "Sales" alphabetically → series_a="Revenue", series_b="Sales"
-      (is (=? {:series_a    "Revenue"
-               :series_b    "Sales"
+      ;; "Revenue" < "Sales" alphabetically → series-a="Revenue", series-b="Sales"
+      (is (=? {:series-a    "Revenue"
+               :series-b    "Sales"
                :coefficient #(> % 0.9)
                :strength    :strong
                :direction   :positive}
@@ -234,8 +234,8 @@
           result (#'time-series/find-significant-changes values dates 3)]
       (is (<= (count result) 3))
       ;; Largest change is 12→25 (abs=13)
-      (is (=? {:from_value 12.0
-               :to_value   25.0}
+      (is (=? {:from-value 12.0
+               :to-value   25.0}
               (first result))))))
 
 (deftest ^:parallel find-significant-changes-includes-pct-change-test
@@ -243,29 +243,29 @@
     (let [values [10.0 15.0 20.0]
           dates  ["d1" "d2" "d3"]
           result (#'time-series/find-significant-changes values dates 3)]
-      (is (=? [{:from_date  "d1"
-                :to_date    "d2"
-                :from_value 10.0
-                :to_value   15.0
-                :change_abs 5.0
-                :change_pct 50.0}
-               {:from_date  "d2"
-                :to_date    "d3"
-                :from_value 15.0
-                :to_value   20.0
-                :change_abs 5.0
-                :change_pct (=?/approx [33.33 0.01])}]
+      (is (=? [{:from-date  "d1"
+                :to-date    "d2"
+                :from-value 10.0
+                :to-value   15.0
+                :change-abs 5.0
+                :change-pct 50.0}
+               {:from-date  "d2"
+                :to-date    "d3"
+                :from-value 15.0
+                :to-value   20.0
+                :change-abs 5.0
+                :change-pct (=?/approx [33.33 0.01])}]
               result)))))
 
 ;;; ---------------------------------------- compute-most-recent-change tests ----------------------------------------
 
 (deftest ^:parallel compute-most-recent-change-test
   (testing "returns the last consecutive change"
-    (is (=? {:from_date  "2024-05"
-             :to_date    "2024-06"
-             :from_value 22.0
-             :to_value   20.0
-             :change_abs -2.0}
+    (is (=? {:from-date  "2024-05"
+             :to-date    "2024-06"
+             :from-value 22.0
+             :to-value   20.0
+             :change-abs -2.0}
             (#'time-series/compute-most-recent-change
              [10.0 15.0 12.0 25.0 22.0 20.0]
              ["2024-01" "2024-02" "2024-03" "2024-04" "2024-05" "2024-06"])))))
@@ -276,41 +276,41 @@
 
 (deftest ^:parallel compute-most-recent-change-two-values-test
   (testing "two values returns the one change"
-    (is (=? {:from_value 10.0
-             :to_value   15.0
-             :change_abs 5.0
-             :change_pct (=?/approx [50.0 0.001])}
+    (is (=? {:from-value 10.0
+             :to-value   15.0
+             :change-abs 5.0
+             :change-pct (=?/approx [50.0 0.001])}
             (#'time-series/compute-most-recent-change [10.0 15.0] ["d1" "d2"])))))
 
 ;;; --------------------------------------------- compute-series-stats tests ----------------------------------------
 
 (deftest ^:parallel compute-series-stats-basic-fields-test
-  (testing "basic stats include summary, time_range, trend, data_points, is_cumulative"
-    (is (=? {:data_points   5
+  (testing "basic stats include summary, time-range, trend, data-points, is-cumulative"
+    (is (=? {:data-points   5
              :summary       {:min 10.0 :max 50.0}
-             :trend         {:direction          :strongly_increasing
-                             :overall_change_pct 400.0
-                             :start_value        10.0
-                             :end_value          50.0}
-             :time_range    {:start "2024-01"
+             :trend         {:direction          :strongly-increasing
+                             :overall-change-pct 400.0
+                             :start-value        10.0
+                             :end-value          50.0}
+             :time-range    {:start "2024-01"
                              :end   "2024-05"}
-             :is_cumulative true}
+             :is-cumulative true}
             (#'time-series/compute-series-stats
              [10.0 20.0 30.0 40.0 50.0]
              ["2024-01" "2024-02" "2024-03" "2024-04" "2024-05"]
              {})))))
 
 (deftest ^:parallel compute-series-stats-cumulative-detection-test
-  (testing "cumulative data is flagged as :is_cumulative true"
-    (is (=? {:is_cumulative true}
+  (testing "cumulative data is flagged as :is-cumulative true"
+    (is (=? {:is-cumulative true}
             (#'time-series/compute-series-stats
              (mapv #(* 10.0 %) (range 1 13))
              (mapv #(format "2024-%02d" %) (range 1 13))
              {})))))
 
 (deftest ^:parallel compute-series-stats-non-cumulative-detection-test
-  (testing "non-cumulative data is flagged as :is_cumulative false"
-    (is (=? {:is_cumulative false}
+  (testing "non-cumulative data is flagged as :is-cumulative false"
+    (is (=? {:is-cumulative false}
             (#'time-series/compute-series-stats
              [10.0 5.0 15.0 8.0 20.0]
              ["d1" "d2" "d3" "d4" "d5"]
@@ -320,7 +320,7 @@
   (testing "without deep? opt, volatility and patterns are not computed"
     (is (=? {:volatility          (symbol "nil #_\"key is not present.\"")
              :patterns            (symbol "nil #_\"key is not present.\"")
-             :significant_changes (symbol "nil #_\"key is not present.\"")}
+             :significant-changes (symbol "nil #_\"key is not present.\"")}
             (#'time-series/compute-series-stats
              (mapv #(* 10.0 %) (range 1 13))
              (mapv #(format "2024-%02d" %) (range 1 13))
@@ -329,18 +329,18 @@
 (deftest ^:parallel compute-series-stats-deep-stats-with-opt-test
   (testing "with deep? true, volatility and patterns are computed"
     (is (=? {:volatility          {:level                    :extreme
-                                   :coefficient_of_variation #(> % 0.5)
-                                   :max_period_change_pct    100.0}
-             :patterns            [{:type      :consecutive_increase
-                                    :from_date "2024-02"
-                                    :to_date   "2024-12"}]
-             :significant_changes #(= 3 (count %))
-             :most_recent_change  {:from_date  "2024-11"
-                                   :to_date    "2024-12"
-                                   :from_value 110.0
-                                   :to_value   120.0
-                                   :change_abs 10.0
-                                   :change_pct (=?/approx [9.09 0.01])}}
+                                   :coefficient-of-variation #(> % 0.5)
+                                   :max-period-change-pct    100.0}
+             :patterns            [{:type      :consecutive-increase
+                                    :from-date "2024-02"
+                                    :to-date   "2024-12"}]
+             :significant-changes #(= 3 (count %))
+             :most-recent-change  {:from-date  "2024-11"
+                                   :to-date    "2024-12"
+                                   :from-value 110.0
+                                   :to-value   120.0
+                                   :change-abs 10.0
+                                   :change-pct (=?/approx [9.09 0.01])}}
             (#'time-series/compute-series-stats
              (mapv #(* 10.0 %) (range 1 13))
              (mapv #(format "2024-%02d" %) (range 1 13))
@@ -352,9 +352,9 @@
                   [10.0 15.0 12.0 25.0 22.0 20.0]
                   ["2024-01" "2024-02" "2024-03" "2024-04" "2024-05" "2024-06"]
                   {:deep? true})]
-      (is (<= (count (:significant_changes result)) 3))
-      (is (=? {:most_recent_change {:from_date "2024-05"
-                                    :to_date   "2024-06"}}
+      (is (<= (count (:significant-changes result)) 3))
+      (is (=? {:most-recent-change {:from-date "2024-05"
+                                    :to-date   "2024-06"}}
               result)))))
 
 ;;; ----------------------------------------- compute-time-series-stats tests ----------------------------------------
@@ -371,12 +371,12 @@
                              :x {:name "x" :type "string"}
                              :y {:name "y" :type "number"}
                              :display_name "S2"}}]
-      (is (=? {:chart_type    :time-series
-               :series_count  2
-               :series        {"S1" {:data_points 5
-                                     :trend {:direction :strongly_increasing}}
-                               "S2" {:data_points 5
-                                     :trend {:direction :strongly_decreasing}}}
+      (is (=? {:chart-type    :time-series
+               :series-count  2
+               :series        {"S1" {:data-points 5
+                                     :trend {:direction :strongly-increasing}}
+                               "S2" {:data-points 5
+                                     :trend {:direction :strongly-decreasing}}}
                :correlations  (symbol "nil #_\"key is not present.\"")}
               (time-series/compute-time-series-stats series-data {}))))))
 

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/util_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/stats/util_test.clj
@@ -27,7 +27,7 @@
              :mean 30.0
              :median 30.0
              :range 40.0
-             :std_dev (=?/approx [15.81 0.01])}
+             :std-dev (=?/approx [15.81 0.01])}
             (stats.u/compute-summary [10.0 20.0 30.0 40.0 50.0])))))
 
 (deftest ^:parallel compute-summary-single-value-test
@@ -183,8 +183,8 @@
       (is (= 1 (count result)))
       (is (=? {"s1" {:sum 60
                      :count 3
-                     :x_name "Date"
-                     :y_name "Revenue"}}
+                     :x-name "Date"
+                     :y-name "Revenue"}}
               result)))))
 
 (deftest ^:parallel compute-series-with-labels-nil-metadata-test
@@ -193,8 +193,8 @@
           result (stats.u/compute-series-with-labels
                   series-data
                   (fn [_ _] {:ok true}))]
-      (is (=? {"s1" {:x_name nil?
-                     :y_name nil?}}
+      (is (=? {"s1" {:x-name nil?
+                     :y-name nil?}}
               result)))))
 
 (deftest ^:parallel compute-series-with-labels-multiple-series-test
@@ -221,53 +221,53 @@
    :max     10.0
    :mean    5.0
    :median  5.0
-   :std_dev 2.0
+   :std-dev 2.0
    :range   9.0})
 
 (def ^:private sample-categorical-series
   {"s1" {:summary        sample-summary
-         :data_points    5
-         :category_count 3
-         :top_categories [{:name "A" :value 10.0 :percentage 50.0}]
+         :data-points    5
+         :category-count 3
+         :top-categories [{:name "A" :value 10.0 :percentage 50.0}]
          :outliers       []}})
 
 (def ^:private sample-histogram-series
-  {"s1" {:estimated_summary {:weighted_mean    5.0
-                             :weighted_std_dev 2.0
-                             :data_range       9.0}
-         :total_count       50
-         :data_points       10
-         :bin_data          [[1.0 5.0] [2.0 10.0]]
-         :distribution      {:estimated_percentiles {25 2.0 50 5.0 75 8.0 90 9.0 95 9.5 99 9.9}
-                             :estimated_quartiles   {:q1 2.0 :median 5.0 :q3 8.0 :iqr 6.0}}
-         :structure         {:mode_bin           [2.0 10.0]
-                             :peak_count         1
-                             :concentration_top3 1.0
-                             :gap_count          0
-                             :empty_bin_ratio    0.0
-                             :bin_count          2}}})
+  {"s1" {:estimated-summary {:weighted-mean    5.0
+                             :weighted-std-dev 2.0
+                             :data-range       9.0}
+         :total-count       50
+         :data-points       10
+         :bin-data          [[1.0 5.0] [2.0 10.0]]
+         :distribution      {:estimated-percentiles {25 2.0 50 5.0 75 8.0 90 9.0 95 9.5 99 9.9}
+                             :estimated-quartiles   {:q1 2.0 :median 5.0 :q3 8.0 :iqr 6.0}}
+         :structure         {:mode-bin           [2.0 10.0]
+                             :peak-count         1
+                             :concentration-top3 1.0
+                             :gap-count          0
+                             :empty-bin-ratio    0.0
+                             :bin-count          2}}})
 
 (deftest ^:parallel make-chart-result-basic-test
   (testing "builds standard chart result with valid schema"
-    (is (=? {:chart_type    :categorical
-             :series_count  1
+    (is (=? {:chart-type    :categorical
+             :series-count  1
              :series        sample-categorical-series
              :correlations  (symbol "nil #_\"key is not present.\"")}
             (stats.u/make-chart-result :categorical {"s1" {}} sample-categorical-series nil)))))
 
 (deftest ^:parallel make-chart-result-with-correlations-test
   (testing "includes correlations when provided"
-    (let [corrs [{:series_a "a" :series_b "b" :coefficient 0.9
+    (let [corrs [{:series-a "a" :series-b "b" :coefficient 0.9
                   :strength :strong :direction :positive}]
           series {"a" {:summary        sample-summary
-                       :data_points    2
-                       :category_count 2
-                       :top_categories []
+                       :data-points    2
+                       :category-count 2
+                       :top-categories []
                        :outliers       []}
                   "b" {:summary        sample-summary
-                       :data_points    2
-                       :category_count 2
-                       :top_categories []
+                       :data-points    2
+                       :category-count 2
+                       :top-categories []
                        :outliers       []}}
           result (stats.u/make-chart-result :categorical {"a" {} "b" {}} series corrs)]
       (is (= corrs (:correlations result))))))


### PR DESCRIPTION
Closes [BOT-1131: Analyze chart - convert map keys from snake_case to kebab-case](https://linear.app/metabase/issue/BOT-1131/analyze-chart-convert-map-keys-from-snake-case-to-kebab-case)

### Description

Follow up to https://github.com/metabase/metabase/pull/70616

Rename `:snake_case` map keys to `:kebab-case` to conform to Clojure conventions.

### Demo

<details>
<summary>Categorical chart: tool output</summary>

```markdown
# Chart Analysis
## Chart: Revenue and Order Count by Category
**Type**: Categorical (bar)
**Series Count**: 2

## Series: Revenue and Order Count by Category (sum)
**X-axis**: category
**Y-axis**: sum
**Data Points**: 5
**Categories**: 5
**Note**: high variance (fluctuations may be normal noise), limited data points.
**Value Range**: 79,927 to 798,309 (median: 210,377)
**Top Categories**:
  - Electronics: 798,309 (52.5%)
  - Sports: 317,301 (20.9%)
  - Clothing: 210,377 (13.8%)
  - Food: 115,535 (7.6%)
  - Books: 79,927 (5.3%)
**Outliers**: 1 detected
  - Electronics: 798,309 (z-score: 3.71)

## Series: Revenue and Order Count by Category (count)
**X-axis**: category
**Y-axis**: count
**Data Points**: 5
**Categories**: 5
**Note**: limited data points.
**Value Range**: 1597.0 to 1672.0 (median: 1643.0)
**Top Categories**:
  - Books: 1672.0 (20.4%)
  - Food: 1656.0 (20.2%)
  - Clothing: 1643.0 (20.1%)
  - Electronics: 1614.0 (19.7%)
  - Sports: 1597.0 (19.5%)
**Outliers**: None detected
```
</details>

<details>
<summary>Categorical chart: agent response</summary>
I'd be happy to analyze the chart for you! Let me get the details of the "Revenue and Order Count by Category" report you're currently viewing.**Electronics dominates revenue at $798k (52.5% of total), but order volume is evenly distributed across categories.** This means Electronics generates nearly 3x the revenue per order compared to other categories — likely due to higher product prices. 

**Key insight:** While Books and Food drive the most orders (1,672 and 1,656 respectively), Electronics' pricing power delivers outsized revenue despite having **fewer** orders (1,614). This suggests your high-value product strategy is working, but you're missing upside in lower-priced categories that could move higher volume.

Would you like me to drill deeper into any specific category, or compare this to other time periods to see if this pattern is consistent?
</details>
### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
