### PR TITLE
Further pdf export improvements

### DIFF
--- a/patches/html2canvas-pro+2.0.2.patch
+++ b/patches/html2canvas-pro+2.0.2.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/html2canvas-pro/dist/html2canvas-pro.esm.js b/node_modules/html2canvas-pro/dist/html2canvas-pro.esm.js
-index d49f1bd..6428dc1 100644
+index d49f1bd..77be9b6 100644
 --- a/node_modules/html2canvas-pro/dist/html2canvas-pro.esm.js
 +++ b/node_modules/html2canvas-pro/dist/html2canvas-pro.esm.js
 @@ -5875,6 +5875,8 @@ class SVGElementContainer extends ElementContainer {
@@ -11,9 +11,26 @@ index d49f1bd..6428dc1 100644
          const bounds = parseBounds(context, img);
          img.setAttribute('width', `${bounds.width}px`);
          img.setAttribute('height', `${bounds.height}px`);
-@@ -7145,13 +7147,13 @@ const ignoredStyleProperties = [
+@@ -7144,13 +7146,39 @@ const ignoredStyleProperties = [
+     'd', // #2483
      'content' // Safari shows pseudoelements if content is set
  ];
++const svgTextFontProperties = [
++    'font-family',
++    'font-size',
++    'font-weight',
++    'font-style',
++    'font-variant',
++    'font-stretch',
++    'font-size-adjust',
++    'letter-spacing',
++    'word-spacing',
++    'line-height',
++];
++const isSVGTextNode = (node) => {
++    const tagName = node.tagName;
++    return tagName === 'text' || tagName === 'tspan' || tagName === 'textPath';
++};
  const copyCSSStyles = (style, target) => {
 -    // Edge does not provide value for cssText
 -    for (let i = style.length - 1; i >= 0; i--) {
@@ -21,7 +38,6 @@ index d49f1bd..6428dc1 100644
 -        // fix: Chrome_138 ignore custom properties
 -        if (ignoredStyleProperties.indexOf(property) === -1 && !property.startsWith('--')) {
 -            target.style.setProperty(property, style.getPropertyValue(property));
--        }
 +    // Use cssText for a single native call instead of iterating 300+ properties
 +    // individually via style.item(i), which is extremely slow in Firefox due to
 +    // Stylo's per-call indexmap lookups in the custom properties map.
@@ -29,10 +45,19 @@ index d49f1bd..6428dc1 100644
 +    // Remove properties that should be ignored
 +    for (let i = ignoredStyleProperties.length - 1; i >= 0; i--) {
 +        target.style.removeProperty(ignoredStyleProperties[i]);
++    }
++    // For SVG text elements, explicitly re-apply font properties from the
++    // computed style since cssText may not reliably serialize them.
++    if (isSVGTextNode(target)) {
++        for (let i = 0; i < svgTextFontProperties.length; i++) {
++            const value = style.getPropertyValue(svgTextFontProperties[i]);
++            if (value) {
++                target.style.setProperty(svgTextFontProperties[i], value);
++            }
+         }
      }
      return target;
- };
-@@ -7534,7 +7536,8 @@ class ElementPaint {
+@@ -7534,7 +7562,8 @@ class ElementPaint {
              const rotateMatrix = [cos, sin, -sin, cos, 0, 0];
              this.effects.push(new TransformEffect(offsetX, offsetY, rotateMatrix));
          }
@@ -42,7 +67,7 @@ index d49f1bd..6428dc1 100644
              const origin = this.container.styles.transformOrigin;
              const offsetX = this.container.bounds.left + getAbsoluteValue(origin[0], this.container.bounds.width);
              const offsetY = this.container.bounds.top + getAbsoluteValue(origin[1], this.container.bounds.height);
-@@ -10373,12 +10376,12 @@ class Validator {
+@@ -10373,12 +10402,12 @@ class Validator {
          }
          // Basic format validation - nonce should be base64-like
          // Typical format: base64 string, often 32+ characters

--- a/patches/html2canvas-pro+2.0.2.patch
+++ b/patches/html2canvas-pro+2.0.2.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/html2canvas-pro/dist/html2canvas-pro.esm.js b/node_modules/html2canvas-pro/dist/html2canvas-pro.esm.js
-index d49f1bd..1387285 100644
+index d49f1bd..6428dc1 100644
 --- a/node_modules/html2canvas-pro/dist/html2canvas-pro.esm.js
 +++ b/node_modules/html2canvas-pro/dist/html2canvas-pro.esm.js
 @@ -5875,6 +5875,8 @@ class SVGElementContainer extends ElementContainer {
@@ -11,6 +11,27 @@ index d49f1bd..1387285 100644
          const bounds = parseBounds(context, img);
          img.setAttribute('width', `${bounds.width}px`);
          img.setAttribute('height', `${bounds.height}px`);
+@@ -7145,13 +7147,13 @@ const ignoredStyleProperties = [
+     'content' // Safari shows pseudoelements if content is set
+ ];
+ const copyCSSStyles = (style, target) => {
+-    // Edge does not provide value for cssText
+-    for (let i = style.length - 1; i >= 0; i--) {
+-        const property = style.item(i);
+-        // fix: Chrome_138 ignore custom properties
+-        if (ignoredStyleProperties.indexOf(property) === -1 && !property.startsWith('--')) {
+-            target.style.setProperty(property, style.getPropertyValue(property));
+-        }
++    // Use cssText for a single native call instead of iterating 300+ properties
++    // individually via style.item(i), which is extremely slow in Firefox due to
++    // Stylo's per-call indexmap lookups in the custom properties map.
++    target.style.cssText = style.cssText;
++    // Remove properties that should be ignored
++    for (let i = ignoredStyleProperties.length - 1; i >= 0; i--) {
++        target.style.removeProperty(ignoredStyleProperties[i]);
+     }
+     return target;
+ };
 @@ -7534,7 +7536,8 @@ class ElementPaint {
              const rotateMatrix = [cos, sin, -sin, cos, 0, 0];
              this.effects.push(new TransformEffect(offsetX, offsetY, rotateMatrix));


### PR DESCRIPTION
### Description
Patches `html2canvas-pro` to use use `cssText`, rather than individually copy 300+ styles per element when cloning. The one thing we do still do is copy font related properties on SVG text based elements, as without these being explicitly added we lose font based styling. This produces a noticable improvement in Firefox, with the e-commerce dashboard going from ~6s to 250ms to generate the dashboard. 

After taking the example ecommerce dashboard and merging all the tabs together, I tested the export before and after the changes, and these were the results:

Before:
Chrome: ~1.500s
Firefox ~18s

After:
Chrome: ~500ms
Firefox: ~700ms

### How to verify
1. Checkout master and go to your favorite dashboard
2. export that dashboard to a PDF and notice the time takes (you can view this in the debug logs). Try in both Chrome and Firefox, note that firefox will take much, much longer
3. Checkout the branch, and try the same thing
4. There should be a noticable improvement

