### PR TITLE
Safer conversion of the Data Analysts group

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/data_studio/api/permissions_groups_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_studio/api/permissions_groups_test.clj
@@ -5,6 +5,7 @@
    [metabase.permissions.core :as perms]
    [metabase.permissions.models.permissions-group :as perms-group]
    [metabase.permissions.models.permissions-group-membership :as perms-group-membership]
+   [metabase.premium-features.token-check :as token-check]
    [metabase.test :as mt]
    [toucan2.core :as t2]))
 
@@ -20,9 +21,20 @@
 
 ;;; ---------------------------------------- sync-data-analyst-group-for-oss! tests ----------------------------------------
 
+(defmacro with-reset-data-analyst-group! [& body]
+  `(let [original-group# (t2/select-one :model/PermissionsGroup :magic_group_type perms-group/data-analyst-magic-group-type)]
+     (try
+       (mt/with-model-cleanup [:model/PermissionsGroup]
+         (do ~@body))
+       (finally
+         (with-bindings {(var perms-group/*allow-modifying-magic-groups*) true}
+           (t2/update! :model/PermissionsGroup :id (:id original-group#)
+                       {:magic_group_type perms-group/data-analyst-magic-group-type
+                        :name             (:name original-group#)}))))))
+
 (deftest sync-data-analyst-group-for-oss!-ee-noop-test
-  (testing "When we have the feature, sync-data-analyst-group-for-oss! does nothing"
-    (mt/with-premium-features #{:advanced-permissions}
+  (testing "When we canonically have the feature, sync-data-analyst-group-for-oss! does nothing"
+    (with-redefs [token-check/canonically-has-feature? (constantly true)]
       (let [data-analyst-group-id (:id (perms-group/data-analyst))]
         (mt/with-temp [:model/User {user-id :id} {}]
           (perms/add-user-to-group! user-id data-analyst-group-id)
@@ -35,20 +47,9 @@
             (is (= perms-group/data-analyst-magic-group-type
                    (t2/select-one-fn :magic_group_type :model/PermissionsGroup :id data-analyst-group-id)))))))))
 
-(defmacro with-reset-data-analyst-group! [& body]
-  `(let [original-group# (t2/select-one :model/PermissionsGroup :magic_group_type perms-group/data-analyst-magic-group-type)]
-     (try
-       (mt/with-model-cleanup [:model/PermissionsGroup]
-         (do ~@body))
-       (finally
-         (with-bindings {(var perms-group/*allow-modifying-magic-groups*) true}
-           (t2/update! :model/PermissionsGroup :id (:id original-group#)
-                       {:magic_group_type perms-group/data-analyst-magic-group-type
-                        :name             (:name original-group#)}))))))
-
 (deftest sync-data-analyst-group-for-oss!-converts-with-members-test
-  (testing "Without the premium feature, sync-data-analyst-group-for-oss! converts the Data Analysts group when it has members"
-    (mt/with-premium-features #{}
+  (testing "When canonically lacking the feature, sync-data-analyst-group-for-oss! converts the Data Analysts group when it has members"
+    (with-redefs [token-check/canonically-has-feature? (constantly false)]
       (with-reset-data-analyst-group!
         (let [original-group-id (t2/select-one-pk :model/PermissionsGroup :magic_group_type perms-group/data-analyst-magic-group-type)]
           (mt/with-temp [:model/User {user-id :id} {}]
@@ -71,7 +72,7 @@
 
 (deftest sync-data-analyst-group-for-oss!-preserves-name-test
   (testing "When the magic group has a non-default name (e.g. from a migration conflict), the new magic group keeps that name"
-    (mt/with-premium-features #{}
+    (with-redefs [token-check/canonically-has-feature? (constantly false)]
       (with-reset-data-analyst-group!
         (let [original-group-id (t2/select-one-pk :model/PermissionsGroup :magic_group_type perms-group/data-analyst-magic-group-type)]
           ;; Simulate the migration conflict scenario: rename the magic group to the fallback name
@@ -90,8 +91,8 @@
                 (is (= "Metabase Data Analysts" (:name new-magic-group)))))))))))
 
 (deftest sync-data-analyst-group-for-oss!-idempotent-empty-test
-  (testing "In OSS, sync-data-analyst-group-for-oss! is idempotent when magic group is empty"
-    (mt/with-premium-features #{}
+  (testing "Sync is idempotent when magic group is empty (no members to convert)"
+    (with-redefs [token-check/canonically-has-feature? (constantly false)]
       (with-reset-data-analyst-group!
         (let [group-count-before (t2/count :model/PermissionsGroup)
               data-analyst-group-id (t2/select-one-pk :model/PermissionsGroup :magic_group_type perms-group/data-analyst-magic-group-type)]
@@ -104,3 +105,27 @@
           (testing "Magic group should still exist unchanged"
             (is (= perms-group/data-analyst-magic-group-type
                    (t2/select-one-fn :magic_group_type :model/PermissionsGroup :id data-analyst-group-id)))))))))
+
+(deftest sync-data-analyst-group-for-oss!-indeterminate-retries-test
+  (testing "When token check is indeterminate, sync retries in background until canonical response"
+    (let [call-count (atom 0)
+          check-results (atom [nil nil false])] ;; indeterminate, indeterminate, then definitively no feature
+      (with-redefs [token-check/canonically-has-feature? (fn [_feature]
+                                                           (let [idx (swap! call-count inc)]
+                                                             (nth @check-results (min (dec idx) (dec (count @check-results))))))
+                    perms-group/seconds-to-sleep-per-attempt 0]
+        (with-reset-data-analyst-group!
+          (let [original-group-id (t2/select-one-pk :model/PermissionsGroup :magic_group_type perms-group/data-analyst-magic-group-type)]
+            (mt/with-temp [:model/User {user-id :id} {}]
+              (perms/add-user-to-group! user-id original-group-id)
+              ;; sync-data-analyst-group-for-oss! will spawn a future since first call returns nil
+              (let [result (perms-group/sync-data-analyst-group-for-oss!)]
+                ;; Wait for the future to complete
+                (when (future? result)
+                  (deref result 500 :timeout))
+                (testing "Should have retried until canonical response"
+                  (is (>= @call-count 3)))
+                (testing "Original group should be converted after retries"
+                  (let [original-group (t2/select-one :model/PermissionsGroup :id original-group-id)]
+                    (is (str/starts-with? (:name original-group) "Data Analysts (converted)"))
+                    (is (nil? (:magic_group_type original-group)))))))))))))

--- a/src/metabase/permissions/models/permissions_group.clj
+++ b/src/metabase/permissions/models/permissions_group.clj
@@ -21,6 +21,8 @@
    [toucan2.core :as t2]
    [toucan2.tools.hydrate :as t2.hydrate]))
 
+(set! *warn-on-reflection* true)
+
 (methodical/defmethod t2/table-name :model/PermissionsGroup [_model] :permissions_group)
 (methodical/defmethod t2/model-for-automagic-hydration [:default :permissions_group] [_original-model _k] :model/PermissionsGroup)
 (methodical/defmethod t2.hydrate/fk-keys-for-automagic-hydration [:default :permissions_group :default]
@@ -241,29 +243,52 @@
                   {:group_id group-id
                    :object   (str "/collection/" coll-id "/")}))))
 
-(defn sync-data-analyst-group-for-oss!
-  "On OSS startup, convert the Data Analysts group to a normal visible group and create a new empty magic group.
+(defn- do-sync-conversion!
+  "Convert the Data Analysts magic group (if it has members) to a normal visible group, and create a fresh empty
+  magic group in its place. This ensures that we don't have an invisible group that affects permissions on OSS."
+  []
+  (when-let [existing-group (t2/select-one :model/PermissionsGroup :magic_group_type data-analyst-magic-group-type)]
+    (when (pos? (t2/count :model/PermissionsGroupMembership :group_id (:id existing-group)))
+      (log/info "Converting Data Analysts group to normal group for OSS")
+      (binding [*allow-modifying-magic-groups* true]
+        (t2/with-transaction [_conn]
+          ;; Rename and demote the existing group to a normal visible group
+          (t2/update! :model/PermissionsGroup (:id existing-group)
+                      {:name             (unique-converted-group-name (:name existing-group))
+                       :magic_group_type nil})
+          ;; Create new empty magic group with default library permissions, reusing the old name
+          (let [{new-group-id :id} (t2/insert-returning-instance! :model/PermissionsGroup
+                                                                  {:name             (:name existing-group)
+                                                                   :magic_group_type data-analyst-magic-group-type})]
+            (grant-library-permissions! new-group-id))
+          (t2/update! :model/User {:is_data_analyst true} {:is_data_analyst false}))))))
 
-  In OSS, we don't want the Data Analysts group to be invisible while still granting permissions - that's a hidden
+(def ^:private seconds-to-sleep-per-attempt 1)
+
+(defn sync-data-analyst-group-for-oss!
+  "On startup, convert the Data Analysts group to a normal visible group if this instance definitively lacks
+  the `:advanced-permissions` premium feature.
+
+  In OSS, we don't want the Data Analysts group to be invisible while still granting permissions — that's a hidden
   backdoor. Instead, we convert any existing Data Analysts group (with members) to a normal group with a unique name
   like 'Data Analysts (converted)' that admins can see and manage. We then create a fresh empty Data Analysts magic
   group.
 
+  Uses [[premium-features/canonically-has-feature?]] to distinguish between 'definitively no feature' and 'token
+  check failed (indeterminate)'. If the token check is indeterminate, retries in a background thread until a
+  canonical response is received.
+
   This is idempotent: if the magic group has no members, nothing happens."
   []
-  (when-not (premium-features/enable-advanced-permissions?)
-    (when-let [existing-group (t2/select-one :model/PermissionsGroup :magic_group_type data-analyst-magic-group-type)]
-      (when (pos? (t2/count :model/PermissionsGroupMembership :group_id (:id existing-group)))
-        (log/info "Converting Data Analysts group to normal group for OSS")
-        (binding [*allow-modifying-magic-groups* true]
-          (t2/with-transaction [_conn]
-            ;; Rename and demote the existing group to a normal visible group
-            (t2/update! :model/PermissionsGroup (:id existing-group)
-                        {:name             (unique-converted-group-name (:name existing-group))
-                         :magic_group_type nil})
-            ;; Create new empty magic group with default library permissions, reusing the old name
-            (let [{new-group-id :id} (t2/insert-returning-instance! :model/PermissionsGroup
-                                                                    {:name             (:name existing-group)
-                                                                     :magic_group_type data-analyst-magic-group-type})]
-              (grant-library-permissions! new-group-id))
-            (t2/update! :model/User {:is_data_analyst true} {:is_data_analyst false})))))))
+  (let [result (premium-features/canonically-has-feature? :advanced-permissions)]
+    (case result
+      true  nil
+      false (do-sync-conversion!)
+      nil   (future
+              (loop [attempt 1]
+                (Thread/sleep (long (* 1000 (min (* attempt seconds-to-sleep-per-attempt) 60))))
+                (let [result (premium-features/canonically-has-feature? :advanced-permissions)]
+                  (case result
+                    true  nil
+                    false (do-sync-conversion!)
+                    nil   (recur (inc attempt)))))))))

--- a/src/metabase/premium_features/core.clj
+++ b/src/metabase/premium_features/core.clj
@@ -23,6 +23,7 @@
   assert-airgap-allows-user-creation!
   assert-has-feature
   assert-has-any-features
+  canonically-has-feature?
   ee-feature-error
   has-any-features?
   has-feature?

--- a/src/metabase/premium_features/token_check.clj
+++ b/src/metabase/premium_features/token_check.clj
@@ -193,8 +193,9 @@
       (http/success? resp) (do (analytics/inc-if-initialized! :metabase-token-check/attempt {:status :success})
                                (some-> body json/decode+kw (assoc :canonical? true)))
       (<= 400 status 499) (or (some-> body json/decode+kw (assoc :canonical? true))
-                              {:valid false
-                               :status "Unable to validate token"
+                              {:valid         false
+                               :canonical?    false
+                               :status        "Unable to validate token"
                                :error-details "Token validation provided no response"})
       ;; exceptions are not cached.
       :else (do (analytics/inc-if-initialized! :metabase-token-check/attempt {:status :failure})
@@ -277,12 +278,13 @@
         (mr/validate [:re AirgapToken] token)
         (do
           (log/infof "Checking airgapped token '%s'..." (u.str/mask token))
-          (decode-airgap-token token))
+          (assoc (decode-airgap-token token) :canonical? true))
 
         :else
         (do
           (log/error (u/format-color 'red "Invalid token format!"))
           {:valid         false
+           :canonical?    true
            :status        "invalid"
            :error-details (trs "Token should be a valid 64 hexadecimal character token or an airgap token.")})))
 
@@ -482,6 +484,7 @@
                (log/infof "Error checking token: %s" (ex-message e))
                (analytics/inc-if-initialized! :metabase-token-check/attempt {:status :failure}))
              {:valid         false
+              :canonical?    false
               :status        (tru "Unable to validate token")
               :error-details (.getMessage e)})))
     (-clear-cache! [_] (-clear-cache! token-checker))))
@@ -642,6 +645,16 @@
     (has-feature? :toucan-management)  ; -> false"
   [feature]
   (contains? (*token-features*) (name feature)))
+
+(defn canonically-has-feature?
+  "Returns `true` if the token definitively has `feature`, `false` if it definitively does not, or `nil` if the token
+  status is indeterminate (e.g., network failure, timeout). Returns `false` (not `nil`) when no token is configured."
+  [feature]
+  (if-let [token (premium-features.settings/premium-embedding-token)]
+    (let [result (check-token token)]
+      (when (:canonical? result)
+        (boolean (contains? (set (:features result)) (name feature)))))
+    false))
 
 (defn ee-feature-error
   "Returns an error that can be used to throw when an enterprise feature check fails."

--- a/test/metabase/premium_features/token_check_test.clj
+++ b/test/metabase/premium_features/token_check_test.clj
@@ -146,11 +146,13 @@
                            :hard-ttl        (t/seconds 1)})]
       (with-redefs [mdb/db-is-set-up? (constantly false)]
         (is (= {:valid false
+                :canonical? false
                 :status "Unable to validate token"
                 :error-details "Metabase DB is not yet set up"}
                (token-check/-check-token checker token)))
         (dotimes [_ 50] (token-check/-check-token checker token))
         (is (= {:valid false
+                :canonical? false
                 :status "Unable to validate token"
                 :error-details "Metabase DB is not yet set up"}
                (token-check/-check-token checker token))))
@@ -210,6 +212,7 @@
             (age-cache-entry! token (+ (u/hours->ms 36) 1000) local-cache)
             (Thread/sleep 60) ;; expire local-cached-token-checker
             (is (= {:valid         false
+                    :canonical?    false
                     :status        "Unable to validate token"
                     :error-details "network failure!"}
                    (token-check/check-token checker token)))))
@@ -557,6 +560,7 @@
           token   (tu/random-token)]
       ;; error-catching wraps it, so we get the error-details response
       (is (= {:valid false
+              :canonical? false
               :status "Unable to validate token"
               :error-details "MetaStore unreachable"}
              (token-check/-check-token checker token))))))


### PR DESCRIPTION
Currently, stats has 5 "Data Analysts (converted)" groups. As far as I can tell, this shouldn't happen in the happy path: after the database is set up, we check for the necessary premium features before converting the "special" Data Analysts group into a renamed "normal" group and creating a new Data Analysts group.

But this is happening - intermittently - so I think we just need to be more defensive here. If some transient network issue or something causes us to temporarily be unsure what features are enabled, then normally we just say "nope, no features here" and that's fine. In this case we need to be sure, and should only do the Data Analysts swap if Metastore has *told us* that the feature is not present.

So, this adds:

- a `:canonical? false` flag, when the result is not canonical

- and a function, `canonically-has-feature?` that returns `true` if the feature is canonically present, `false` if the feature is canonically absent, or `nil` if the feature's presence cannot be canonically determined

Then, when we start up, we check the feature using this function.

If the feature is canonically present, we do nothing.

If the feature is canonically absent, we do the swap.

If neither is true (network blip or some other issue caused us to not receive a valid response from the metastore), we fire off a future that will wait for a canonical response and then do the swap if necessary.
