### PR TITLE
Fix scatter plot flicker on hover

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/scatter/option/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/scatter/option/series.ts
@@ -80,5 +80,6 @@ export function buildEChartsScatterSeries(
         opacity: CHART_STYLE.opacity.blur,
       },
     },
+    progressive: 0,
   };
 }


### PR DESCRIPTION
Closes #60654

### Description

Hovering on a point in a scatter plot causes a flicker due to Echarts' "progressive rendering". This PR simply disables progressive rendering for scatter plots. Bar charts also use progressive rendering, but I couldn't recreate the same flicker effect, so left them as is.

Progressive rendering might make sense on the initial render to show data sooner, but performance is quite bad - about 10x slower in my testing. And progressive rendering certainly doesn't make sense for a rerender.

Initially I experimented with changes in use-chart-events to try to prevent the rerender from triggering, but there were some unwanted side effects. Simply disabling progressive rendering is a simple fix and performance seems good enough (tested on a scatter with 10K points and CPU throttled to "mid-tier mobile").

### How to verify

Follow the steps in #60654 and verify the flicker effect is gone.

### Demo

[Loom](https://www.loom.com/share/9bece49278b84c5e9a450701032ea785)

### Checklist

I could try to write an E2E test to cover this, but it seems tricky/potentially flaky and there seems like a low risk of regression for this change.
