### PR TITLE
Fix remote sync flaky test

### DIFF
--- a/e2e/test/scenarios/admin/remote-sync.cy.spec.ts
+++ b/e2e/test/scenarios/admin/remote-sync.cy.spec.ts
@@ -438,14 +438,54 @@ describe("Remote Sync", () => {
     });
   });
 
-  describe("remote sync admin settings page", () => {
-    beforeEach(() => {
-      H.restore();
-      H.activateToken("bleeding-edge");
-      H.setupGitSync();
-      cy.signInAsAdmin();
-    });
+  describe("read-only mode", () => {
+    it("can change branches", () => {
+      const UPDATED_REMOTE_QUESTION_NAME = "New Name";
 
+      H.copySyncedCollectionFixture();
+      H.commitToRepo();
+      H.configureGit("read-only");
+
+      cy.visit("/");
+
+      H.navigationSidebar()
+        .findByRole("treeitem", { name: /Synced Collection/ })
+        .click();
+      H.collectionTable().findByText(REMOTE_QUESTION_NAME);
+
+      // Make a change, and commit it to the branch
+      H.checkoutSyncedCollectionBranch("test");
+      H.updateRemoteQuestion((doc) => {
+        doc.name = UPDATED_REMOTE_QUESTION_NAME;
+        return doc;
+      });
+
+      cy.visit("/admin/settings/remote-sync");
+      cy.findByLabelText("Sync branch").scrollIntoView().clear().type("test");
+      cy.findByTestId("remote-sync-submit-button").click();
+
+      cy.findByTestId("admin-layout-content")
+        .findByText("Success")
+        .should("exist");
+
+      cy.findByRole("dialog", { name: "Switch branches?" })
+        .button("Continue")
+        .click();
+
+      H.waitForTask({ taskName: "import" });
+
+      cy.findByTestId("remote-sync-submit-button").should("be.disabled");
+
+      cy.visit("/");
+
+      H.navigationSidebar()
+        .findByRole("treeitem", { name: /Synced Collection/ })
+        .click();
+      H.collectionTable().findByText(UPDATED_REMOTE_QUESTION_NAME);
+    });
+  });
+
+  describe("remote sync admin settings page", () => {
     it("can set up read-write mode", () => {
       cy.visit("/admin/settings/remote-sync");
       cy.findByLabelText(/repository url/i)
@@ -587,74 +627,10 @@ describe("Remote Sync", () => {
     });
   });
 
-  describe("read-only mode", () => {
-    beforeEach(() => {
-      H.restore();
-      cy.signInAsAdmin();
-      H.activateToken("bleeding-edge");
-      H.setupGitSync();
-    });
-
-    it("can change branches", () => {
-      const UPDATED_REMOTE_QUESTION_NAME = "New Name";
-
-      H.copySyncedCollectionFixture();
-      H.commitToRepo();
-      H.configureGit("read-only");
-
-      cy.visit("/");
-
-      H.navigationSidebar()
-        .findByRole("treeitem", { name: /Synced Collection/ })
-        .click();
-      H.collectionTable().findByText(REMOTE_QUESTION_NAME);
-
-      // Make a change, and commit it to the branch
-      H.checkoutSyncedCollectionBranch("test");
-      H.updateRemoteQuestion((doc) => {
-        doc.name = UPDATED_REMOTE_QUESTION_NAME;
-        return doc;
-      });
-
-      cy.visit("/admin/settings/remote-sync");
-      cy.findByLabelText("Sync branch").scrollIntoView().clear().type("test");
-      cy.findByTestId("remote-sync-submit-button").click();
-
-      cy.findByTestId("admin-layout-content")
-        .findByText("Success")
-        .should("exist");
-
-      cy.findByRole("dialog", { name: "Switch branches?" })
-        .button("Continue")
-        .click();
-
-      H.waitForTask({ taskName: "import" });
-
-      cy.findByTestId("remote-sync-submit-button").should("be.disabled");
-
-      cy.visit("/");
-
-      H.navigationSidebar()
-        .findByRole("treeitem", { name: /Synced Collection/ })
-        .click();
-      H.collectionTable().findByText(UPDATED_REMOTE_QUESTION_NAME);
-    });
-  });
-
   describe("shared tenant collections", () => {
     beforeEach(() => {
-      H.restore();
-      cy.signInAsAdmin();
-      H.activateToken("bleeding-edge");
-      H.setupGitSync();
-      H.interceptTask();
-
       // Enable tenants feature
       H.enableTenants();
-    });
-
-    afterEach(() => {
-      H.expectNoBadSnowplowEvents();
     });
 
     describe("admin settings", () => {


### PR DESCRIPTION
### Stats (for the last 7 days on `master`)
| type | %|
|-|-|
|Failure Rate|100.00%|

(I think it is reporting a 100% failure rate because it's a `beforeEach` block)

Examples of failed runs:
- https://github.com/metabase/metabase/actions/runs/23202066585
- https://github.com/metabase/metabase/actions/runs/23196480299/attempts/1
- https://github.com/metabase/metabase/actions/runs/23070409399

### The cause

The cause seems to be the db restore endpoint taking too long to return. Taking a look at the test file, it seems we were calling the same functions in the parent and child describe beforeEacg blocks, which is redundant and might be causing the application to get clogged and time out. Also, it seems we were calling `H.restore` with "postgres-writable" and other times without any argument.
Relevant log chunk:
```
Because this error occurred during a `before each` hook we are skipping the remaining tests in the current suite: `Remote Sync`

CypressError: `cy.request()` timed out waiting `30000ms` for a response from your server.

The request we sent was:

Method: POST
URL: http://localhost:4000/api/testing/restore/postgres-writable

No response was received within the timeout.
```

### The solution

We're simplifying the `beforeEach` blocks, avoiding to repeat set up calls already made in the main `beforeEach`.

### Stress-tests
From master
- https://github.com/metabase/metabase/actions/runs/23258725045 1x20 (isolated test) ✅
- https://github.com/metabase/metabase/actions/runs/23259146814 1x10 (full file test) ✅

EDIT: So it seems the test is simply not failing anymore in master, it's not flaky too. I'll close this PR as there's nothing else to fix (I'll reopen if it gets flaky again.

From this branch: 1x30, 2x20
- TODO