### PR TITLE
Allow linear to trigger repro-bot

### DIFF
--- a/.github/workflows/repro-bot.yml
+++ b/.github/workflows/repro-bot.yml
@@ -135,6 +135,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY_REPRO_BOT }}
           github_token: ${{ steps.claude-app-token.outputs.token }}
+          allowed_bots: linear
           prompt: |
             Read and follow the instructions in .claude/commands/repro.md to investigate this GitHub issue:
             https://github.com/${{ github.repository }}/issues/${{ steps.issue.outputs.number }}


### PR DESCRIPTION
### Description

Adds `allowed_bots: linear` that when a label is added by the linear integration, the repro-bot action can still run.

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
