### PR TITLE
BOT-1127 Metabot Conditional Tool Schema Params

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/agent/tools/search.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/agent/tools/search.clj
@@ -31,7 +31,7 @@
 (mu/defn ^{:tool-name "search"} search-tool
   "Search for tables, models, metrics, dashboards, and saved questions."
   [{:keys [semantic_queries keyword_queries entity_types]} :- [:map {:closed true}
-                                                               [:semantic_queries [:sequential :string]]
+                                                               [:semantic_queries {:feature :semantic-search} [:sequential :string]]
                                                                [:keyword_queries [:sequential :string]]
                                                                [:entity_types {:optional true}
                                                                 [:maybe [:sequential [:enum "table" "model" "metric" "dashboard" "question"]]]]]]

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/agent/tools/search.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/agent/tools/search.clj
@@ -54,7 +54,7 @@
 (mu/defn ^{:tool-name "search" :prompt "sql_search.md"} sql-search-tool
   "Search for SQL-queryable data sources (tables and models) within a database."
   [{:keys [semantic_queries keyword_queries entity_types database_id]} :- [:map {:closed true}
-                                                                           [:semantic_queries [:sequential :string]]
+                                                                           [:semantic_queries {:feature :semantic-search} [:sequential :string]]
                                                                            [:keyword_queries [:sequential :string]]
                                                                            [:database_id :int]
                                                                            [:entity_types {:optional true}
@@ -79,7 +79,7 @@
 (mu/defn ^{:tool-name "search" :prompt "nql_search.md"} nlq-search-tool
   "Search for NLQ-queryable data sources (models, metrics, tables)."
   [{:keys [semantic_queries keyword_queries entity_types]} :- [:map {:closed true}
-                                                               [:semantic_queries [:sequential :string]]
+                                                               [:semantic_queries {:feature :semantic-search} [:sequential :string]]
                                                                [:keyword_queries [:sequential :string]]
                                                                [:entity_types {:optional true}
                                                                 [:maybe [:sequential [:enum "model" "metric" "table"]]]]]]
@@ -103,7 +103,7 @@
 (mu/defn ^{:tool-name "search" :prompt "transform_search"} transform-search-tool
   "Search for transforms, tables, and models."
   [{:keys [semantic_queries keyword_queries entity_types search_native_query]} :- [:map {:closed true}
-                                                                                   [:semantic_queries [:sequential :string]]
+                                                                                   [:semantic_queries {:feature :semantic-search} [:sequential :string]]
                                                                                    [:keyword_queries [:sequential :string]]
                                                                                    [:search_native_query {:optional true} [:maybe :boolean]]
                                                                                    [:entity_types {:optional true}

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/self/claude.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/self/claude.clj
@@ -5,6 +5,7 @@
    [malli.json-schema :as mjs]
    [metabase-enterprise.llm.settings :as llm]
    [metabase-enterprise.metabot-v3.self.core :as core]
+   [metabase-enterprise.metabot-v3.self.schema :as schema]
    [metabase.util :as u]
    [metabase.util.json :as json]
    [metabase.util.malli :as mu]
@@ -174,6 +175,7 @@
   [[tool-name tool]]
   (let [{:keys [doc schema] :as tool} (if (map? tool) tool (meta tool))
         [_:=> [_:cat params] _out]    schema
+        params                        (schema/filter-schema-by-features params)
         doc                           (if (str/starts-with? (or doc "") "Inputs: ")
                                         ;; strip that stuff we're appending in mu/defn
                                         (second (str/split doc #"\n\n  " 2))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/self/features.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/self/features.clj
@@ -1,0 +1,44 @@
+(ns metabase-enterprise.metabot-v3.self.features
+  "Feature registry for conditional schema properties.
+
+  Maps feature keywords to predicate functions that determine availability
+  at runtime. Used by schema filtering to include/exclude tool parameters."
+  (:require
+   [metabase.search.engine :as search.engine]
+   [metabase.util.log :as log]))
+
+(def feature-predicates
+  "Registry of feature keywords to predicate functions."
+  {:semantic-search #(search.engine/supported-engine? :search.engine/semantic)})
+
+(defn feature-available?
+  "Check if a feature spec is satisfied.
+
+   Supports:
+   - Simple keyword:  :semantic-search
+   - All required:    [:all :feature-a :feature-b]
+   - Any sufficient:  [:any :feature-a :feature-b]
+   - Negation:        [:not :legacy-mode]
+
+   Unknown features return true (fail-open)."
+  [feature-spec]
+  (cond
+    (nil? feature-spec)
+    true
+
+    (keyword? feature-spec)
+    (if-let [pred (get feature-predicates feature-spec)]
+      (pred)
+      (do (log/warn "Unknown feature key in schema, assuming available:" feature-spec)
+          true))
+
+    (vector? feature-spec)
+    (let [[op & features] feature-spec]
+      (case op
+        :all (every? feature-available? features)
+        :any (boolean (some feature-available? features))
+        :not (not (feature-available? (first features)))
+        ;; Default: treat as :all
+        (every? feature-available? feature-spec)))
+
+    :else true))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/self/features.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/self/features.clj
@@ -12,33 +12,9 @@
   {:semantic-search #(search.engine/supported-engine? :search.engine/semantic)})
 
 (defn feature-available?
-  "Check if a feature spec is satisfied.
-
-   Supports:
-   - Simple keyword:  :semantic-search
-   - All required:    [:all :feature-a :feature-b]
-   - Any sufficient:  [:any :feature-a :feature-b]
-   - Negation:        [:not :legacy-mode]
-
-   Unknown features return true (fail-open)."
-  [feature-spec]
-  (cond
-    (nil? feature-spec)
-    true
-
-    (keyword? feature-spec)
-    (if-let [pred (get feature-predicates feature-spec)]
-      (pred)
-      (do (log/warn "Unknown feature key in schema, assuming available:" feature-spec)
-          true))
-
-    (vector? feature-spec)
-    (let [[op & features] feature-spec]
-      (case op
-        :all (every? feature-available? features)
-        :any (boolean (some feature-available? features))
-        :not (not (feature-available? (first features)))
-        ;; Default: treat as :all
-        (every? feature-available? feature-spec)))
-
-    :else true))
+  "Check if a feature is available. Unknown features return true (fail-open)."
+  [feature-key]
+  (if-let [pred (get feature-predicates feature-key)]
+    (pred)
+    (do (log/warn "Unknown feature key in schema, assuming available:" feature-key)
+        true)))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/self/openai.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/self/openai.clj
@@ -5,6 +5,7 @@
    [malli.json-schema :as mjs]
    [metabase-enterprise.llm.settings :as llm]
    [metabase-enterprise.metabot-v3.self.core :as core]
+   [metabase-enterprise.metabot-v3.self.schema :as schema]
    [metabase.util :as u]
    [metabase.util.json :as json]
    [metabase.util.malli :as mu]))
@@ -141,9 +142,12 @@
 
 ;;; Tool definition format
 
-(defn- tool->openai [[tool-name tool]]
+(defn- tool->openai
+  "Convert a tool to OpenAI Responses API format."
+  [[tool-name tool]]
   (let [{:keys [doc schema] :as tool} (if (map? tool) tool (meta tool))
         [_:=> [_:cat params] _out]    schema
+        params                        (schema/filter-schema-by-features params)
         doc                           (if (str/starts-with? doc "Inputs: ")
                                         ;; strip that stuff we're appending in mu/defn
                                         (second (str/split doc #"\n\n  " 2))

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/self/openrouter.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/self/openrouter.clj
@@ -13,6 +13,7 @@
    [malli.json-schema :as mjs]
    [metabase-enterprise.llm.settings :as llm]
    [metabase-enterprise.metabot-v3.self.core :as core]
+   [metabase-enterprise.metabot-v3.self.schema :as schema]
    [metabase.util :as u]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
@@ -84,6 +85,7 @@
   [[tool-name tool]]
   (let [{:keys [doc schema]} (if (map? tool) tool (meta tool))
         [_:=> [_:cat params] _out] schema
+        params     (schema/filter-schema-by-features params)
         doc        (if (str/starts-with? (or doc "") "Inputs: ")
                      (second (str/split doc #"\n\n  " 2))
                      doc)

--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/self/schema.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/self/schema.clj
@@ -1,0 +1,38 @@
+(ns metabase-enterprise.metabot-v3.self.schema
+  "Schema filtering for feature-gated properties.
+
+  Walks Malli schemas and removes map entries whose `:feature` property
+  indicates a feature that is not available in the current context."
+  (:require
+   [malli.core :as mc]
+   [metabase-enterprise.metabot-v3.self.features :as features]))
+
+(defn- filter-map-entries
+  "Filter map schema entries, keeping only those whose :feature is available.
+
+   Each map entry is [key props child-schema]. If props contains :feature,
+   check availability. Strip :feature from output props (internal metadata)."
+  [schema]
+  (let [props    (mc/properties schema)
+        children (mc/children schema)]
+    (into [:map props]
+          (for [[k entry-props child-schema :as entry] children
+                :let [feature (:feature entry-props)]
+                :when (or (nil? feature)
+                          (features/feature-available? feature))]
+            (if feature
+              [k (dissoc entry-props :feature) child-schema]
+              entry)))))
+
+(defn filter-schema-by-features
+  "Walk a schema and remove any map properties that require unavailable features.
+
+   Uses Malli's schema-walker to recursively process nested schemas.
+   Only :map schemas are filtered; other schema types pass through unchanged."
+  [schema]
+  (mc/walk schema
+           (mc/schema-walker
+            (fn [s]
+              (if (= :map (mc/type s))
+                (filter-map-entries s)
+                s)))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/self/features_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/self/features_test.clj
@@ -1,0 +1,32 @@
+(ns metabase-enterprise.metabot-v3.self.features-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase-enterprise.metabot-v3.self.features :as features]))
+
+(set! *warn-on-reflection* true)
+
+;;; ──────────────────────────────────────────────────────────────────
+;;; feature-available? tests
+;;; ──────────────────────────────────────────────────────────────────
+
+(deftest ^:synchronized feature-available?-known-feature-available-test
+  (testing "returns true when predicate returns true"
+    (with-redefs [features/feature-predicates {:test-feature (constantly true)}]
+      (is (true? (features/feature-available? :test-feature))))))
+
+(deftest ^:synchronized feature-available?-known-feature-unavailable-test
+  (testing "returns false when predicate returns false"
+    (with-redefs [features/feature-predicates {:test-feature (constantly false)}]
+      (is (false? (features/feature-available? :test-feature))))))
+
+(deftest ^:synchronized feature-available?-unknown-feature-test
+  (testing "unknown feature returns true (fail-open behavior)"
+    (with-redefs [features/feature-predicates {}]
+      (is (true? (features/feature-available? :unknown-feature))))))
+
+(deftest ^:synchronized feature-available?-predicate-called-test
+  (testing "predicate is actually invoked"
+    (let [call-count (atom 0)]
+      (with-redefs [features/feature-predicates {:counting-feature #(do (swap! call-count inc) true)}]
+        (features/feature-available? :counting-feature)
+        (is (= 1 @call-count))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot_v3/self/schema_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot_v3/self/schema_test.clj
@@ -1,0 +1,134 @@
+(ns metabase-enterprise.metabot-v3.self.schema-test
+  (:require
+   [clojure.test :refer :all]
+   [malli.core :as mc]
+   [metabase-enterprise.metabot-v3.self.features :as features]
+   [metabase-enterprise.metabot-v3.self.schema :as schema]))
+
+(set! *warn-on-reflection* true)
+
+;;; ──────────────────────────────────────────────────────────────────
+;;; filter-schema-by-features tests
+;;; ──────────────────────────────────────────────────────────────────
+
+(deftest ^:synchronized filter-schema-by-features-available-feature-test
+  (testing "entry with available feature is kept, :feature prop stripped"
+    (with-redefs [features/feature-available? (constantly true)]
+      (let [input    [:map [:field {:feature :some-feature} :string]]
+            result   (schema/filter-schema-by-features input)
+            children (mc/children result)]
+        (is (= 1 (count children)))
+        (is (= :field (first (first children))))
+        (is (not (contains? (second (first children)) :feature)))))))
+
+(deftest ^:synchronized filter-schema-by-features-unavailable-feature-test
+  (testing "entry with unavailable feature is removed"
+    (with-redefs [features/feature-available? (constantly false)]
+      (let [input    [:map [:field {:feature :some-feature} :string]]
+            result   (schema/filter-schema-by-features input)
+            children (mc/children result)]
+        (is (= 0 (count children)))))))
+
+(deftest ^:synchronized filter-schema-by-features-no-feature-annotation-test
+  (testing "entry without :feature annotation passes through unchanged"
+    (with-redefs [features/feature-available? (fn [_] (throw (ex-info "should not be called" {})))]
+      (let [input    [:map [:field :string]]
+            result   (schema/filter-schema-by-features input)
+            children (mc/children result)]
+        (is (= 1 (count children)))
+        (is (= :field (first (first children))))
+        (is (= :string (mc/type (last (first children)))))))))
+
+(deftest ^:synchronized filter-schema-by-features-mixed-entries-test
+  (testing "map with mixed entries: only unavailable feature-gated entries removed"
+    (with-redefs [features/feature-available? #(= :available-feature %)]
+      (let [input    [:map
+                      [:always-present :string]
+                      [:gated-available {:feature :available-feature} :int]
+                      [:gated-unavailable {:feature :unavailable-feature} :boolean]]
+            result   (schema/filter-schema-by-features input)
+            children (mc/children result)
+            keys     (set (map first children))]
+        (is (= 2 (count children)))
+        (is (contains? keys :always-present))
+        (is (contains? keys :gated-available))
+        (is (not (contains? keys :gated-unavailable)))))))
+
+(deftest ^:synchronized filter-schema-by-features-nested-maps-test
+  (testing "nested map schemas are also filtered"
+    (with-redefs [features/feature-available? (constantly false)]
+      (let [input    [:map
+                      [:outer :string]
+                      [:nested [:map
+                                [:inner-ungated :string]
+                                [:inner-gated {:feature :some-feature} :int]]]]
+            result   (schema/filter-schema-by-features input)
+            outer-children (mc/children result)
+            nested-entry   (second outer-children)
+            nested-schema  (nth nested-entry 2)
+            inner-children (mc/children nested-schema)]
+        (is (= 2 (count outer-children)))
+        (is (= 1 (count inner-children)))
+        (is (= :inner-ungated (first (first inner-children))))))))
+
+(deftest ^:synchronized filter-schema-by-features-non-map-schema-test
+  (testing "non-map schemas pass through unchanged"
+    (with-redefs [features/feature-available? (constantly false)]
+      (let [sequential-schema [:sequential :string]
+            string-schema     :string
+            enum-schema       [:enum "a" "b"]]
+        (is (= :sequential (mc/type (schema/filter-schema-by-features sequential-schema))))
+        (is (= :string (mc/type (schema/filter-schema-by-features string-schema))))
+        (is (= :enum (mc/type (schema/filter-schema-by-features enum-schema))))))))
+
+(deftest ^:synchronized filter-schema-by-features-optional-and-feature-test
+  (testing "entry with both :optional and :feature handles both properties"
+    (with-redefs [features/feature-available? (constantly true)]
+      (let [input    [:map [:field {:optional true :feature :some-feature} :string]]
+            result   (schema/filter-schema-by-features input)
+            children (mc/children result)
+            entry    (first children)
+            props    (second entry)]
+        (is (= 1 (count children)))
+        (is (true? (:optional props)))
+        (is (not (contains? props :feature)))))))
+
+(deftest ^:synchronized filter-schema-by-features-all-entries-filtered-test
+  (testing "all feature-gated entries unavailable results in empty map"
+    (with-redefs [features/feature-available? (constantly false)]
+      (let [input    [:map {:closed true}
+                      [:field1 {:feature :f1} :string]
+                      [:field2 {:feature :f2} :int]]
+            result   (schema/filter-schema-by-features input)
+            children (mc/children result)
+            props    (mc/properties result)]
+        (is (= 0 (count children)))
+        (is (= {:closed true} props))))))
+
+(deftest ^:synchronized filter-schema-by-features-preserves-map-properties-test
+  (testing "map-level properties like :closed are preserved"
+    (with-redefs [features/feature-available? (constantly true)]
+      (let [input  [:map {:closed true} [:field :string]]
+            result (schema/filter-schema-by-features input)
+            props  (mc/properties result)]
+        (is (= {:closed true} props))))))
+
+(deftest ^:synchronized filter-schema-by-features-complex-nested-structure-test
+  (testing "complex nesting with sequential containing map"
+    (with-redefs [features/feature-available? #(= :enabled %)]
+      (let [input    [:map
+                      [:items [:sequential
+                               [:map
+                                [:name :string]
+                                [:secret {:feature :disabled} :string]
+                                [:visible {:feature :enabled} :int]]]]]
+            result   (schema/filter-schema-by-features input)
+            items-entry    (first (mc/children result))
+            sequential-schema (nth items-entry 2)
+            inner-map      (first (mc/children sequential-schema))
+            inner-children (mc/children inner-map)
+            inner-keys     (set (map first inner-children))]
+        (is (= 2 (count inner-children)))
+        (is (contains? inner-keys :name))
+        (is (contains? inner-keys :visible))
+        (is (not (contains? inner-keys :secret)))))))


### PR DESCRIPTION
Closes BOT-1127

### Description

Support for conditional input params in metabot tool malli schemas. Uses a feature -> predicate registry to allow for filtering input params from tool schemas before rendering to provider format. For example, to make `:semantic_queries` input param on our search tools be conditional on whether semantic search engine is available and active in the instance we now do:

```clj
[:semantic_queries {:feature :semantic-search} [:sequential :string]]
```

```clj
;; features.clj

(def feature-predicates
  "Registry of feature keywords to predicate functions."
  {:semantic-search #(search.engine/supported-engine? :search.engine/semantic)})
```

<details>
<summary>Openrouter tool schema before / after</summary>

Before
```clojure
{:type "function",
  :function
  {:name "search",
   :description
   "Search for tables, models, metrics, dashboards, and saved questions.",
   :parameters
   {:type "object",
    :properties
    {:semantic_queries {:type "array", :items {:type "string"}},
     :keyword_queries {:type "array", :items {:type "string"}},
     :entity_types
     {:oneOf
      [{:type "array",
        :items
        {:type "string",
         :enum ["table" "model" "metric" "dashboard" "question"]}}
       {:type "null"}]}},
    :required [:semantic_queries :keyword_queries],
    :additionalProperties false}}}
```

After (semantic disabled)
```clojure
{:type "function",
  :function
  {:name "search",
   :description
   "Search for tables, models, metrics, dashboards, and saved questions.",
   :parameters
   {:type "object",
    :properties
    {:keyword_queries {:type "array", :items {:type "string"}},
     :entity_types
     {:oneOf
      [{:type "array",
        :items
        {:type "string",
         :enum ["table" "model" "metric" "dashboard" "question"]}}
       {:type "null"}]}},
    :required [:keyword_queries],
    :additionalProperties false}}}
```

</details>

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
