### PR TITLE
enable transform inspector only with advanced (python) transforms

### DIFF
--- a/frontend/src/metabase/transforms/components/TransformHeader/TransformTabs.tsx
+++ b/frontend/src/metabase/transforms/components/TransformHeader/TransformTabs.tsx
@@ -5,7 +5,10 @@ import {
   PaneHeaderTabs,
 } from "metabase/data-studio/common/components/PaneHeader";
 import * as Urls from "metabase/lib/urls";
-import { PLUGIN_DEPENDENCIES } from "metabase/plugins";
+import {
+  PLUGIN_DEPENDENCIES,
+  PLUGIN_TRANSFORMS_PYTHON,
+} from "metabase/plugins";
 import type { Transform, TransformId } from "metabase-types/api";
 
 type TransformTabsProps = {
@@ -32,12 +35,15 @@ function getTabs(id: TransformId): PaneHeaderTab[] {
       label: t`Settings`,
       to: Urls.transformSettings(id),
     },
-    {
+  ];
+
+  if (PLUGIN_TRANSFORMS_PYTHON.isEnabled) {
+    tabs.push({
       label: t`Inspect`,
       to: inspectUrl,
       isSelected: (pathname: string) => pathname.startsWith(inspectUrl),
-    },
-  ];
+    });
+  }
 
   if (PLUGIN_DEPENDENCIES.isEnabled) {
     tabs.push({


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-2018/transform-inspector-appears-without-advanced-transforms-add-on

### Description

We don't have a dedicated token feature for transform inspector, but availability should be tied to `"transforms-advanced` product, which is enables `transforms-python`.  a bit more context

### Demo

https://www.loom.com/share/1bc8324f5311491488fae07e15218ada
