### PR TITLE
feat(sdk): adds an undocumented metabase-adhoc component for MCP-UI usage

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
@@ -629,6 +629,30 @@ describe("scenarios > embedding > sdk iframe embedding > custom elements api", (
         .should("not.exist");
     });
 
+    it("should show download button when with-downloads is true", () => {
+      H.visitCustomHtmlPage(`
+      ${H.getNewEmbedScriptTag()}
+      ${H.getNewEmbedConfigurationScript()}
+      <metabase-adhoc query="${ordersQuery}" with-downloads />
+      `);
+
+      H.getSimpleEmbedIframeContent()
+        .findByLabelText("download icon")
+        .should("be.visible");
+    });
+
+    it("should hide download button when with-downloads is false", () => {
+      H.visitCustomHtmlPage(`
+      ${H.getNewEmbedScriptTag()}
+      ${H.getNewEmbedConfigurationScript()}
+      <metabase-adhoc query="${ordersQuery}" with-downloads="false" />
+      `);
+
+      H.getSimpleEmbedIframeContent()
+        .findByLabelText("download icon")
+        .should("not.exist");
+    });
+
     it("should show the save button when is-save-enabled is true", () => {
       H.visitCustomHtmlPage(`
       ${H.getNewEmbedScriptTag()}

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
@@ -569,6 +569,91 @@ describe("scenarios > embedding > sdk iframe embedding > custom elements api", (
     });
   });
 
+  describe("<metabase-adhoc>", () => {
+    // Simple Orders query: SELECT * FROM orders — used for basic rendering tests.
+    // Produces column headers like "ID", "Total", etc. but no title (no aggregation).
+    const ordersQuery = btoa(
+      JSON.stringify({
+        database: 1,
+        type: "query",
+        query: { "source-table": ORDERS_ID },
+      }),
+    );
+
+    // Orders query with aggregation: Max of Quantity, grouped by Product ID.
+    // Produces the title "Max of Quantity by Product ID" for with-title tests.
+    const ordersAggQuery = btoa(
+      JSON.stringify({
+        database: 1,
+        type: "query",
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: [["max", ["field", ORDERS.QUANTITY, null]]],
+          breakout: [["field", ORDERS.PRODUCT_ID, null]],
+          limit: 2,
+        },
+      }),
+    );
+
+    it("should render an ad-hoc question from a base64-encoded MBQL query", () => {
+      H.visitCustomHtmlPage(`
+      ${H.getNewEmbedScriptTag()}
+      ${H.getNewEmbedConfigurationScript()}
+      <metabase-adhoc query="${ordersQuery}" />
+      `);
+
+      H.getSimpleEmbedIframeContent().findByText("Total").should("be.visible");
+    });
+
+    it("should show title when with-title is true", () => {
+      H.visitCustomHtmlPage(`
+      ${H.getNewEmbedScriptTag()}
+      ${H.getNewEmbedConfigurationScript()}
+      <metabase-adhoc query="${ordersAggQuery}" with-title />
+      `);
+
+      H.getSimpleEmbedIframeContent()
+        .findByText("Max of Quantity by Product ID")
+        .should("be.visible");
+    });
+
+    it("should hide title when with-title is false", () => {
+      H.visitCustomHtmlPage(`
+      ${H.getNewEmbedScriptTag()}
+      ${H.getNewEmbedConfigurationScript()}
+      <metabase-adhoc query="${ordersAggQuery}" with-title="false" />
+      `);
+
+      H.getSimpleEmbedIframeContent()
+        .findByText("Max of Quantity by Product ID")
+        .should("not.exist");
+    });
+
+    it("should show the save button when is-save-enabled is true", () => {
+      H.visitCustomHtmlPage(`
+      ${H.getNewEmbedScriptTag()}
+      ${H.getNewEmbedConfigurationScript()}
+      <metabase-adhoc query="${ordersQuery}" is-save-enabled />
+      `);
+
+      H.getSimpleEmbedIframeContent()
+        .findByRole("button", { name: "Save" })
+        .should("be.visible");
+    });
+
+    it("should not show the save button when is-save-enabled is false", () => {
+      H.visitCustomHtmlPage(`
+      ${H.getNewEmbedScriptTag()}
+      ${H.getNewEmbedConfigurationScript()}
+      <metabase-adhoc query="${ordersQuery}" is-save-enabled="false" />
+      `);
+
+      H.getSimpleEmbedIframeContent()
+        .findByRole("button", { name: "Save" })
+        .should("not.exist");
+    });
+  });
+
   describe("common checks", () => {
     describe("should be permissive with json attributes", () => {
       // NOTE: pay attention if you use initialFilters for these tests, as when the filters are not parsed correctly

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
@@ -570,8 +570,7 @@ describe("scenarios > embedding > sdk iframe embedding > custom elements api", (
   });
 
   describe("<metabase-adhoc>", () => {
-    // Simple Orders query: SELECT * FROM orders — used for basic rendering tests.
-    // Produces column headers like "ID", "Total", etc. but no title (no aggregation).
+    // Has column headers like "ID", "Total", etc. but no aggregation.
     const ordersQuery = btoa(
       JSON.stringify({
         database: 1,
@@ -580,9 +579,8 @@ describe("scenarios > embedding > sdk iframe embedding > custom elements api", (
       }),
     );
 
-    // Orders query with aggregation: Max of Quantity, grouped by Product ID.
-    // Produces the title "Max of Quantity by Product ID" for with-title tests.
-    const ordersAggQuery = btoa(
+    // Produces the title "Max of Quantity by Product ID"
+    const maxQuantityQuery = btoa(
       JSON.stringify({
         database: 1,
         type: "query",
@@ -609,7 +607,7 @@ describe("scenarios > embedding > sdk iframe embedding > custom elements api", (
       H.visitCustomHtmlPage(`
       ${H.getNewEmbedScriptTag()}
       ${H.getNewEmbedConfigurationScript()}
-      <metabase-adhoc query="${ordersAggQuery}" with-title />
+      <metabase-adhoc query="${maxQuantityQuery}" with-title />
       `);
 
       H.getSimpleEmbedIframeContent()
@@ -621,7 +619,7 @@ describe("scenarios > embedding > sdk iframe embedding > custom elements api", (
       H.visitCustomHtmlPage(`
       ${H.getNewEmbedScriptTag()}
       ${H.getNewEmbedConfigurationScript()}
-      <metabase-adhoc query="${ordersAggQuery}" with-title="false" />
+      <metabase-adhoc query="${maxQuantityQuery}" with-title="false" />
       `);
 
       H.getSimpleEmbedIframeContent()

--- a/enterprise/frontend/src/embedding-sdk-package/components/public/AdHocQuestion/AdHocQuestion.tsx
+++ b/enterprise/frontend/src/embedding-sdk-package/components/public/AdHocQuestion/AdHocQuestion.tsx
@@ -4,6 +4,7 @@ import { getWindow } from "embedding-sdk-shared/lib/get-window";
 /**
  * A component that renders an ad-hoc question from a base64-encoded MBQL query.
  *
+ * @internal Not part of the public API yet. Do not use in external integrations.
  * @function
  * @category AdHocQuestion
  * @param props

--- a/enterprise/frontend/src/embedding-sdk-package/components/public/AdHocQuestion/AdHocQuestion.tsx
+++ b/enterprise/frontend/src/embedding-sdk-package/components/public/AdHocQuestion/AdHocQuestion.tsx
@@ -1,0 +1,13 @@
+import { createComponent } from "embedding-sdk-package/components/private/ComponentWrapper/ComponentWrapper";
+import { getWindow } from "embedding-sdk-shared/lib/get-window";
+
+/**
+ * A component that renders an ad-hoc question from a base64-encoded MBQL query.
+ *
+ * @function
+ * @category AdHocQuestion
+ * @param props
+ */
+export const AdHocQuestion = createComponent(
+  () => getWindow()?.METABASE_EMBEDDING_SDK_BUNDLE?.AdHocQuestion,
+);

--- a/enterprise/frontend/src/embedding-sdk-package/components/public/AdHocQuestion/index.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/components/public/AdHocQuestion/index.ts
@@ -1,0 +1,1 @@
+export * from "./AdHocQuestion";

--- a/enterprise/frontend/src/embedding-sdk-package/index.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/index.ts
@@ -11,6 +11,7 @@ EMBEDDING_SDK_CONFIG.isEmbeddingSdk = true;
 defineBuildInfo("METABASE_EMBEDDING_SDK_PACKAGE_BUILD_INFO");
 defineGlobalDependencies();
 
+export { AdHocQuestion } from "./components/public/AdHocQuestion";
 export { CollectionBrowser } from "./components/public/CollectionBrowser";
 export { CreateQuestion } from "./components/public/CreateQuestion";
 export { CreateDashboardModal } from "./components/public/CreateDashboardModal";
@@ -69,6 +70,7 @@ export {
   type InteractiveQuestionComponents,
   type InteractiveQuestionProps,
 } from "embedding-sdk-bundle/components/public/InteractiveQuestion";
+export { type AdHocQuestionProps } from "embedding-sdk-bundle/components/public/AdHocQuestion";
 export { type MetabotQuestionProps } from "embedding-sdk-bundle/components/public/MetabotQuestion";
 export {
   type StaticQuestionProps,

--- a/frontend/src/embedding-sdk-bundle/components/public/AdHocQuestion/AdHocQuestion.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/AdHocQuestion/AdHocQuestion.tsx
@@ -1,6 +1,10 @@
 import { useMemo } from "react";
+import { t } from "ttag";
 
-import { withPublicComponentWrapper } from "embedding-sdk-bundle/components/private/PublicComponentWrapper";
+import {
+  SdkError,
+  withPublicComponentWrapper,
+} from "embedding-sdk-bundle/components/private/PublicComponentWrapper";
 import {
   SdkQuestion,
   type SdkQuestionProps,
@@ -39,15 +43,23 @@ export type AdHocQuestionProps = Omit<
 };
 
 const AdHocQuestionInner = ({ query, ...props }: AdHocQuestionProps) => {
-  const deserializedCard = useMemo((): Card => {
-    const decodedQuery = JSON.parse(b64_to_utf8(query));
+  const deserializedCard = useMemo((): Card | null => {
+    try {
+      const decodedQuery = JSON.parse(b64_to_utf8(query));
 
-    return {
-      display: "table",
-      dataset_query: decodedQuery,
-      visualization_settings: {},
-    } as Card;
+      return {
+        display: "table",
+        dataset_query: decodedQuery,
+        visualization_settings: {},
+      } as Card;
+    } catch {
+      return null;
+    }
   }, [query]);
+
+  if (!deserializedCard) {
+    return <SdkError message={t`Question not found`} />;
+  }
 
   return (
     <SdkQuestion

--- a/frontend/src/embedding-sdk-bundle/components/public/AdHocQuestion/AdHocQuestion.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/AdHocQuestion/AdHocQuestion.tsx
@@ -9,6 +9,7 @@ import { b64_to_utf8 } from "metabase/lib/encoding";
 import type { Card } from "metabase-types/api";
 
 /**
+ * @internal Not part of the public API yet. Do not use in external integrations.
  * @interface
  * @expand
  * @category AdHocQuestion

--- a/frontend/src/embedding-sdk-bundle/components/public/AdHocQuestion/AdHocQuestion.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/AdHocQuestion/AdHocQuestion.tsx
@@ -1,0 +1,62 @@
+import { useMemo } from "react";
+
+import { withPublicComponentWrapper } from "embedding-sdk-bundle/components/private/PublicComponentWrapper";
+import {
+  SdkQuestion,
+  type SdkQuestionProps,
+} from "embedding-sdk-bundle/components/public/SdkQuestion/SdkQuestion";
+import { b64_to_utf8 } from "metabase/lib/encoding";
+import type { Card } from "metabase-types/api";
+
+/**
+ * @interface
+ * @expand
+ * @category AdHocQuestion
+ */
+export type AdHocQuestionProps = Omit<
+  SdkQuestionProps,
+  | "questionId"
+  | "token"
+  | "deserializedCard"
+  | "getClickActionMode"
+  | "navigateToNewCard"
+  | "backToDashboard"
+> & {
+  /**
+   * Base64-encoded MBQL query to run as an ad-hoc question.
+   *
+   * The query should be a JSON object encoded in base64. For example:
+   * ```
+   * btoa(JSON.stringify({
+   *   "lib/type": "mbql/query",
+   *   "database": 2,
+   *   "stages": [{ "lib/type": "mbql.stage/mbql", "source-table": 73 }]
+   * }))
+   * ```
+   */
+  query: string;
+};
+
+const AdHocQuestionInner = ({ query, ...props }: AdHocQuestionProps) => {
+  const deserializedCard = useMemo((): Card => {
+    const decodedQuery = JSON.parse(b64_to_utf8(query));
+
+    return {
+      display: "table",
+      dataset_query: decodedQuery,
+      visualization_settings: {},
+    } as Card;
+  }, [query]);
+
+  return (
+    <SdkQuestion
+      questionId={null}
+      deserializedCard={deserializedCard}
+      {...props}
+    />
+  );
+};
+
+export const AdHocQuestion = withPublicComponentWrapper(AdHocQuestionInner, {
+  supportsGuestEmbed: false,
+});

--- a/frontend/src/embedding-sdk-bundle/components/public/AdHocQuestion/index.ts
+++ b/frontend/src/embedding-sdk-bundle/components/public/AdHocQuestion/index.ts
@@ -1,0 +1,1 @@
+export * from "./AdHocQuestion";

--- a/frontend/src/embedding-sdk-bundle/index.ts
+++ b/frontend/src/embedding-sdk-bundle/index.ts
@@ -19,6 +19,7 @@ import "sdk-specific-imports";
 
 import type { MetabaseEmbeddingSdkBundleExports } from "./types/sdk-bundle";
 
+import { AdHocQuestion } from "./components/public/AdHocQuestion";
 import { CollectionBrowser } from "./components/public/CollectionBrowser";
 import { CreateDashboardModal } from "./components/public/CreateDashboardModal";
 import { CreateQuestion } from "./components/public/CreateQuestion";
@@ -53,6 +54,7 @@ defineBuildInfo("METABASE_EMBEDDING_SDK_BUNDLE_BUILD_INFO");
  * and should be done via the deprecation of the field first.
  */
 const sdkBundleExports: MetabaseEmbeddingSdkBundleExports = {
+  AdHocQuestion,
   CollectionBrowser,
   CreateDashboardModal,
   CreateQuestion,

--- a/frontend/src/embedding-sdk-bundle/types/sdk-bundle.ts
+++ b/frontend/src/embedding-sdk-bundle/types/sdk-bundle.ts
@@ -1,5 +1,6 @@
 import type { JSXElementConstructor } from "react";
 
+import type { AdHocQuestion } from "embedding-sdk-bundle/components/public/AdHocQuestion/AdHocQuestion";
 import type { CollectionBrowser } from "embedding-sdk-bundle/components/public/CollectionBrowser";
 import type { ComponentProvider } from "embedding-sdk-bundle/components/public/ComponentProvider";
 import type { CreateDashboardModal } from "embedding-sdk-bundle/components/public/CreateDashboardModal";
@@ -42,6 +43,7 @@ export type MetabaseEmbeddingSdkBundleExports = PublicExports &
   SchemaValidationUtils;
 
 export type PublicExports = {
+  AdHocQuestion: InternalComponent<typeof AdHocQuestion>;
   CollectionBrowser: InternalComponent<typeof CollectionBrowser>;
   CreateDashboardModal: InternalComponent<typeof CreateDashboardModal>;
   CreateQuestion: InternalComponent<typeof CreateQuestion>;

--- a/frontend/src/metabase-types/analytics/embedded-analytics-js.ts
+++ b/frontend/src/metabase-types/analytics/embedded-analytics-js.ts
@@ -9,7 +9,13 @@ export type EmbeddedAnalyticsJsEventSchema = {
 };
 
 type ComponentData = {
-  name: "dashboard" | "question" | "exploration" | "browser" | "metabot";
+  name:
+    | "dashboard"
+    | "question"
+    | "exploration"
+    | "browser"
+    | "metabot"
+    | "adhoc";
   properties: ComponentProperty[];
 };
 
@@ -59,6 +65,11 @@ export type DefaultValues = {
   };
   metabot: {
     layout: "auto" | "sidebar" | "stacked";
+  };
+  adhoc: {
+    withDownloads: boolean;
+    withTitle: boolean;
+    isSaveEnabled: boolean;
   };
 };
 

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/analytics.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/analytics.ts
@@ -68,6 +68,15 @@ const DEFAULT_VALUES: DefaultValues = {
     /** @see {@link https://github.com/metabase/metabase/blob/c8b1767e66352738553211dea3d7b1addc81da27/frontend/src/embedding-sdk-bundle/components/public/MetabotQuestion/types.ts#L17} */
     layout: "auto",
   },
+  // EMB-1452 - new component
+  adhoc: {
+    /** @see {@link https://github.com/metabase/metabase/blob/master/frontend/src/embedding-sdk-bundle/components/public/AdHocQuestion/AdHocQuestion.tsx} */
+    withDownloads: false,
+    /** @see {@link https://github.com/metabase/metabase/blob/master/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx} */
+    withTitle: true,
+    /** @see {@link https://github.com/metabase/metabase/blob/master/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx} */
+    isSaveEnabled: false,
+  },
 };
 
 const DEFAULT_GUEST_EMBED_VALUES: DefaultValues = merge(DEFAULT_VALUES, {
@@ -142,6 +151,9 @@ export function createEmbeddedAnalyticsJsUsage(
   );
   const metabotEmbeds = Array.from(activeEmbeds).filter(
     (element) => element.properties.componentName === "metabase-metabot",
+  );
+  const adhocEmbeds = Array.from(activeEmbeds).filter(
+    (element) => element.properties.componentName === "metabase-adhoc",
   );
 
   // Build dashboard component
@@ -385,6 +397,48 @@ export function createEmbeddedAnalyticsJsUsage(
             propertyName: "layout",
             getValue: (layout) =>
               String(layout ?? DEFAULT_VALUES.metabot.layout),
+          }),
+        },
+      ],
+    });
+  }
+
+  // Build adhoc component
+  if (adhocEmbeds.length > 0) {
+    event.components.push({
+      name: "adhoc",
+      properties: [
+        {
+          name: "with_downloads",
+          values: countPropertyValues({
+            embeds: adhocEmbeds,
+            component: "adhoc",
+            propertyName: "withDownloads",
+            getValue: (withDownloads) =>
+              String(withDownloads ?? DEFAULT_VALUES.adhoc.withDownloads),
+            allPossibleValues: ["false", "true"],
+          }),
+        },
+        {
+          name: "with_title",
+          values: countPropertyValues({
+            embeds: adhocEmbeds,
+            component: "adhoc",
+            propertyName: "withTitle",
+            getValue: (withTitle) =>
+              String(withTitle ?? DEFAULT_VALUES.adhoc.withTitle),
+            allPossibleValues: ["false", "true"],
+          }),
+        },
+        {
+          name: "is_save_enabled",
+          values: countPropertyValues({
+            embeds: adhocEmbeds,
+            component: "adhoc",
+            propertyName: "isSaveEnabled",
+            getValue: (isSaveEnabled) =>
+              String(isSaveEnabled ?? DEFAULT_VALUES.adhoc.isSaveEnabled),
+            allPossibleValues: ["false", "true"],
           }),
         },
       ],

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/analytics.unit.spec.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/analytics.unit.spec.tsx
@@ -1016,6 +1016,51 @@ describe("createEmbeddedAnalyticsJsUsage", () => {
       });
     });
 
+    describe("adhoc", () => {
+      it("should track adhoc component with with_downloads, with_title, and is_save_enabled properties", () => {
+        const usage = createEmbeddedAnalyticsJsUsage(
+          new Set([
+            createEmbeddedAnalyticsJsElement("metabase-adhoc", {
+              query: "abc",
+            }),
+            createEmbeddedAnalyticsJsElement("metabase-adhoc", {
+              query: "abc",
+              "with-downloads": true,
+              "with-title": false,
+              "is-save-enabled": true,
+            }),
+          ]),
+        );
+
+        expect(usage.components).toContainEqual({
+          name: "adhoc",
+          properties: [
+            {
+              name: "with_downloads",
+              values: [
+                { group: "false", value: 1 }, // default
+                { group: "true", value: 1 },
+              ],
+            },
+            {
+              name: "with_title",
+              values: [
+                { group: "false", value: 1 },
+                { group: "true", value: 1 }, // default
+              ],
+            },
+            {
+              name: "is_save_enabled",
+              values: [
+                { group: "false", value: 1 }, // default
+                { group: "true", value: 1 },
+              ],
+            },
+          ],
+        });
+      });
+    });
+
     describe("metabot", () => {
       it("should track metabot component with layout property", () => {
         const usage = createEmbeddedAnalyticsJsUsage(
@@ -1116,7 +1161,9 @@ type Component =
   | "metabase-dashboard"
   | "metabase-question"
   | "metabase-browser"
-  | "metabase-metabot";
+  | "metabase-metabot"
+  | "metabase-adhoc";
+
 function createEmbeddedAnalyticsJsElement(
   componentName: Component,
   properties: Record<string, any> = {},

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx
@@ -5,6 +5,7 @@ import { PublicComponentStylesWrapper } from "embedding-sdk-bundle/components/pr
 import { SdkError } from "embedding-sdk-bundle/components/private/PublicComponentWrapper";
 import { SdkBreadcrumbsProvider } from "embedding-sdk-bundle/components/private/SdkBreadcrumbs";
 import { SdkInternalNavigationProvider } from "embedding-sdk-bundle/components/private/SdkInternalNavigation/SdkInternalNavigationProvider";
+import { AdHocQuestion } from "embedding-sdk-bundle/components/public/AdHocQuestion";
 import { ComponentProvider } from "embedding-sdk-bundle/components/public/ComponentProvider";
 import { MetabotQuestion } from "embedding-sdk-bundle/components/public/MetabotQuestion";
 import { SdkQuestion } from "embedding-sdk-bundle/components/public/SdkQuestion";
@@ -286,6 +287,22 @@ const SdkIframeEmbedView = ({
             layout={settings.layout}
             isSaveEnabled={settings.isSaveEnabled}
             targetCollection={settings.targetCollection}
+            height="100%"
+          />
+        ),
+      )
+      .with(
+        {
+          componentName: "metabase-adhoc",
+          query: P.nonNullable,
+        },
+        (settings) => (
+          <AdHocQuestion
+            key={rerenderKey}
+            query={settings.query}
+            title={settings.withTitle ?? true}
+            withDownloads={settings.withDownloads}
+            isSaveEnabled={settings.isSaveEnabled ?? false}
             height="100%"
           />
         ),

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.ts
@@ -566,6 +566,14 @@ const MetabaseMetabotElement = createCustomElement("metabase-metabot", [
   "target-collection",
 ]);
 
+const MetabaseAdHocElement = createCustomElement("metabase-adhoc", [
+  "query",
+  "with-title",
+  "with-downloads",
+  "drills",
+  "is-save-enabled",
+]);
+
 // Expose the old API that's still used in the tests, we'll probably remove this api unless customers prefer it
 if (typeof window !== "undefined") {
   (window as any)["metabase.embed"] = {
@@ -578,4 +586,5 @@ export {
   MetabaseQuestionElement,
   MetabaseManageContentElement,
   MetabaseMetabotElement,
+  MetabaseAdHocElement,
 };

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.ts
@@ -570,7 +570,6 @@ const MetabaseAdHocElement = createCustomElement("metabase-adhoc", [
   "query",
   "with-title",
   "with-downloads",
-  "drills",
   "is-save-enabled",
 ]);
 

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/types/embed.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/types/embed.ts
@@ -194,6 +194,24 @@ export interface MetabotEmbedOptions {
   token?: never;
 }
 
+export interface AdHocEmbedOptions {
+  componentName: "metabase-adhoc";
+
+  /** Base64-encoded MBQL query */
+  query: string;
+
+  withTitle?: boolean;
+  withDownloads?: boolean;
+  drills?: boolean;
+  isSaveEnabled?: boolean;
+
+  // incompatible options
+  template?: never;
+  questionId?: never;
+  dashboardId?: never;
+  token?: never;
+}
+
 type CollectionBrowserEntityTypes =
   | "collection"
   | "dashboard"
@@ -232,7 +250,8 @@ export type SdkIframeEmbedTemplateSettings =
   | QuestionEmbedOptions
   | ExplorationEmbedOptions
   | BrowserEmbedOptions
-  | MetabotEmbedOptions;
+  | MetabotEmbedOptions
+  | AdHocEmbedOptions;
 
 /** Settings used by the sdk embed route */
 export type SdkIframeEmbedSettings = Omit<
@@ -250,6 +269,7 @@ export type SdkIframeEmbedElementSettings = SdkIframeEmbedBaseSettings &
       })
     | BrowserEmbedOptions
     | MetabotEmbedOptions
+    | AdHocEmbedOptions
   );
 
 export type SdkIframeEmbedEvent = { type: "ready" };
@@ -263,4 +283,5 @@ export type SdkIframeEmbedSettingKey =
   | keyof SdkIframeQuestionEmbedSettings
   | keyof ExplorationEmbedOptions
   | keyof BrowserEmbedOptions
-  | keyof MetabotEmbedOptions;
+  | keyof MetabotEmbedOptions
+  | keyof AdHocEmbedOptions;

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/types/embed.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/types/embed.ts
@@ -202,7 +202,6 @@ export interface AdHocEmbedOptions {
 
   withTitle?: boolean;
   withDownloads?: boolean;
-  drills?: boolean;
   isSaveEnabled?: boolean;
 
   // incompatible options

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/types/modular-embedding.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/types/modular-embedding.ts
@@ -299,6 +299,50 @@ export interface MetabaseMetabotAttributes {
 }
 
 /**
+ * Attributes for the `<metabase-adhoc>` web component.
+ *
+ * Embeds an ad-hoc query result without requiring a saved question.
+ * Provide a base64-encoded MBQL query via the `query` attribute.
+ * Only available for authenticated (SSO) modular embeds.
+ */
+export interface MetabaseAdHocAttributes {
+  /**
+   * Base64-encoded MBQL query to run as an ad-hoc question.
+   *
+   * The query should be a JSON object encoded in base64. For example:
+   * ```
+   * btoa(JSON.stringify({
+   *   "lib/type": "mbql/query",
+   *   "database": 2,
+   *   "stages": [{ "lib/type": "mbql.stage/mbql", "source-table": 73 }]
+   * }))
+   * ```
+   */
+  query: string;
+
+  /**
+   * Whether to show the question title in the embed.
+   *
+   * @defaultValue true
+   */
+  "with-title"?: boolean;
+
+  /**
+   * Whether to show download buttons for question results.
+   *
+   * @defaultValue `true` on OSS/Starter, `false` on Pro/Enterprise
+   */
+  "with-downloads"?: boolean;
+
+  /**
+   * Whether to enable drill-through on the question.
+   *
+   * @defaultValue true
+   */
+  drills?: boolean;
+}
+
+/**
  * Used to enforce types in frontend/src/metabase/embedding/embedding-iframe-sdk/embed.ts
  *
  * @internal
@@ -308,4 +352,5 @@ export interface ComponentToAttributes {
   "metabase-dashboard": MetabaseDashboardAttributes;
   "metabase-browser": MetabaseBrowserAttributes;
   "metabase-metabot": MetabaseMetabotAttributes;
+  "metabase-adhoc": MetabaseAdHocAttributes;
 }

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/types/modular-embedding.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/types/modular-embedding.ts
@@ -340,6 +340,13 @@ export interface MetabaseAdHocAttributes {
    * @defaultValue true
    */
   drills?: boolean;
+
+  /**
+   * Whether the save button is enabled.
+   *
+   * @defaultValue false
+   */
+  "is-save-enabled"?: boolean;
 }
 
 /**

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/types/modular-embedding.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/types/modular-embedding.ts
@@ -335,13 +335,6 @@ export interface MetabaseAdHocAttributes {
   "with-downloads"?: boolean;
 
   /**
-   * Whether to enable drill-through on the question.
-   *
-   * @defaultValue true
-   */
-  drills?: boolean;
-
-  /**
    * Whether the save button is enabled.
    *
    * @defaultValue false


### PR DESCRIPTION
Closes [EMB-1452: Add an ad-hoc question custom element in modular embedding for MCP-UI](https://linear.app/metabase/issue/EMB-1452)

## Summary

Adds an internal `<metabase-adhoc>` web component to modular embedding that renders an ad-hoc question from a base64-encoded MBQL query, without requiring a saved question.

This is intended only for internal use in MCP-UI and will not be publicly documented for now. In the future, this may be exposed e.g. if we decided to go with custom Metabot layouts or letting people use Agent API tool call results with modular embedding.

- Add `AdHocQuestion` React component to `embedding-sdk-bundle` — wraps `SdkQuestion` with a `query` prop that accepts a base64-encoded MBQL query
- Add `AdHocQuestion` package wrapper to `embedding-sdk-package`
- Add `MetabaseAdHocElement` custom element (`<metabase-adhoc>`) with attributes: `query`, `with-title`, `with-downloads`, `drills`, `is-save-enabled`
- Add `AdHocEmbedOptions` to iframe embed settings types
- Add `MetabaseAdHocAttributes` interface to modular embedding types
- Route `metabase-adhoc` in `SdkIframeEmbedRoute`

### Usage

```html
<metabase-adhoc
  instance-url="https://your-metabase.com"
  query="eyJsaWIvdHlwZSI6Im1icWwvcXVlcnkiLCAiZGF0YWJhc2UiOiAyLCAic3RhZ2VzIjogW3sibGliL3R5cGUiOiAibWJxbC5zdGFnZS9tYnFsIiwgInNvdXJjZS10YWJsZSI6IDczfV19"
></metabase-adhoc>
```

Where `query` is a base64-encoded MBQL query:
```js
btoa(JSON.stringify({
  "lib/type": "mbql/query",
  "database": 2,
  "stages": [{ "lib/type": "mbql.stage/mbql", "source-table": 73 }]
}))
```

## Test plan

- Check that `<metabase-adhoc query="...">` renders a question from a base64-encoded MBQL query
- Check that `with-title`, `with-downloads`, and `is-save-enabled` attributes work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)