### PR TITLE
Allow changing conditional formatting to color range when rule condition is set

### DIFF
--- a/frontend/src/metabase/ui/components/inputs/TextInputBlurChange/TextInputBlurChange.tsx
+++ b/frontend/src/metabase/ui/components/inputs/TextInputBlurChange/TextInputBlurChange.tsx
@@ -54,7 +54,7 @@ export function TextInputBlurChange<T extends TextInputProps = TextInputProps>({
     (event: FocusEvent<HTMLInputElement>) => {
       onBlur?.(event);
 
-      if (onBlurChange && (value || "") !== event.target.value) {
+      if (onBlurChange && String(value ?? "") !== event.target.value) {
         onBlurChange(event);
         setInternalValue(normalize(event.target.value) ?? undefined);
       }
@@ -73,7 +73,7 @@ export function TextInputBlurChange<T extends TextInputProps = TextInputProps>({
   );
 
   useUnmountLayout(() => {
-    const lastPropsValue = value || "";
+    const lastPropsValue = String(value ?? "");
     const currentValue = ref.current?.value || "";
 
     if (onBlurChange && ref.current && lastPropsValue !== currentValue) {

--- a/frontend/src/metabase/ui/components/inputs/TextInputBlurChange/TextInputBlurChange.unit.spec.tsx
+++ b/frontend/src/metabase/ui/components/inputs/TextInputBlurChange/TextInputBlurChange.unit.spec.tsx
@@ -55,6 +55,14 @@ describe("TextInputBlurChange", () => {
     expect(onBlurChange.mock.results[0].value).toBe("test");
   });
 
+  it("should not trigger onBlurChange if the value hasn't changed", async () => {
+    const { onBlurChange } = setup({ value: 5 }); // should handle numeric values as well
+
+    cleanup();
+
+    expect(onBlurChange).toHaveBeenCalledTimes(0);
+  });
+
   it("should set `internalValue` to the normalized value even if the normalized value is the same as the previous one", async () => {
     const value = "/";
     setup({ value, normalize: (value) => (value as string).trim() });

--- a/frontend/src/metabase/ui/components/inputs/TextareaBlurChange/TextareaBlurChange.tsx
+++ b/frontend/src/metabase/ui/components/inputs/TextareaBlurChange/TextareaBlurChange.tsx
@@ -55,7 +55,7 @@ export function TextareaBlurChange<T extends TextareaProps = TextareaProps>({
     (event: FocusEvent<HTMLTextAreaElement>) => {
       onBlur?.(event);
 
-      if (onBlurChange && (value || "") !== event.target.value) {
+      if (onBlurChange && String(value ?? "") !== event.target.value) {
         onBlurChange(event);
         setInternalValue(normalize(event.target.value) ?? undefined);
       }
@@ -74,7 +74,7 @@ export function TextareaBlurChange<T extends TextareaProps = TextareaProps>({
   );
 
   useUnmountLayout(() => {
-    const lastPropsValue = value || "";
+    const lastPropsValue = String(value ?? "");
     const currentValue = ref.current?.value || "";
 
     if (ref.current && lastPropsValue !== currentValue) {

--- a/frontend/src/metabase/ui/components/inputs/TextareaBlurChange/TextareaBlurChange.unit.spec.tsx
+++ b/frontend/src/metabase/ui/components/inputs/TextareaBlurChange/TextareaBlurChange.unit.spec.tsx
@@ -55,6 +55,14 @@ describe("TextareaBlurChange", () => {
     expect(onBlurChange.mock.results[0].value).toBe("test");
   });
 
+  it("should not trigger onBlurChange if the value hasn't changed", async () => {
+    const { onBlurChange } = setup({ value: 5 }); // should handle numeric values as well
+
+    cleanup();
+
+    expect(onBlurChange).toHaveBeenCalledTimes(0);
+  });
+
   it("should set `internalValue` to the normalized value even if the normalized value is the same as the previous one", async () => {
     const value = "/";
     setup({ value, normalize: (value) => (value as string).trim() });


### PR DESCRIPTION
Closes #70478

### Description

When a rule condition is set, you couldn't change the formatting style to "Color range". The flow is:

1. Change to "Color range" in `ChartSettingRadio`, which calls `onChange`
2. `RuleEditorValueInput` unmounts, since it's only used for the "Single input" rule type
3. `onBlurChange` is called inside `useUnmountLayout` in `TextInputBlurChange`, which calls `onChange` with a stale `rule` from React state, overwriting the `onChange` call in step 1

The bug is in step 3 - `onBlurChange` shouldn't be called because the value hasn't been changed. The bug is we were comparing the prop `value`, which in this case is a number, to the ref's `value`, which is a string, with strict equality. The fix is to cast the prop `value` to a string so that the strict equality check works as intended.

This PR also fixes the same bug in `TextareaBlurChange` to keep the components in sync, though we don't currently pass a numeric `value` to `TextareaBlurChange` anywhere in the codebase.

### How to verify

Follow #70478 and verify you can change the formatting style to "Color range".

### Demo

[Loom](https://www.loom.com/share/a0c68351d0a14883bcb06f0670005a17)

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
