### PR TITLE
Add mechanism for more reliably renaming settings

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -793,7 +793,7 @@
     :private-call                                        {:level :off}
     :metabase/defsetting-must-specify-export             {:level :off}
     :metabase/defsetting-namespace                       {:level :off}
-    :metabase/test-helpers-use-non-thread-safe-functions {:level :warning} ; more config in `.clj-kondo/config/test-helpers/config.edn
+    :metabase/test-helpers-use-non-thread-safe-functions {:level :warning} ; more config in `.clj-kondo/config/test-helpers/config.edn`
 
     :discouraged-var
     {metabase.driver/database-supports? {:level :off}

--- a/.clj-kondo/config/test-helpers/config.edn
+++ b/.clj-kondo/config/test-helpers/config.edn
@@ -110,6 +110,7 @@
      metabase.settings.models.setting-test/test-user-local-allowed-setting!
      metabase.settings.models.setting-test/test-user-local-only-setting!
      metabase.settings.models.setting.cache/restore-cache!
+     metabase.settings.models.setting/log-deprecated-env-var-usage!
      metabase.settings.models.setting/set!
      metabase.settings.models.setting/validate-settings-formatting!
      metabase.setup.core/create-token!

--- a/src/metabase/cmd/env_var_dox.clj
+++ b/src/metabase/cmd/env_var_dox.clj
@@ -95,6 +95,12 @@
       (str "> DEPRECATED: " deprecated)
       "> DEPRECATED")))
 
+(defn- format-deprecated-name
+  "Shows the deprecated env var name that still works as a fallback."
+  [env-var]
+  (when-let [deprecated-name (:deprecated-name env-var)]
+    (str "Deprecated env var: `MB_" (u/->SCREAMING_SNAKE_CASE_EN (name deprecated-name)) "`")))
+
 (def paid-message
   "Used to mark an env var that requires a paid plan."
   "> Only available on Metabase [Pro](https://www.metabase.com/product/pro) and [Enterprise](https://www.metabase.com/product/enterprise) plans.")
@@ -154,6 +160,7 @@
                             ;; Like `- Default: 100`
                             (format-list [(format-type env-var)
                                           (format-default env-var)
+                                          (format-deprecated-name env-var)
                                           (format-export env-var)
                                           (format-config-name env-var)])
                             (format-description env-var)

--- a/src/metabase/cmd/env_var_dox.clj
+++ b/src/metabase/cmd/env_var_dox.clj
@@ -95,12 +95,6 @@
       (str "> DEPRECATED: " deprecated)
       "> DEPRECATED")))
 
-(defn- format-deprecated-name
-  "Shows the deprecated env var name that still works as a fallback."
-  [env-var]
-  (when-let [deprecated-name (:deprecated-name env-var)]
-    (str "Deprecated env var: `" (setting/env-var-name deprecated-name) "`")))
-
 (def paid-message
   "Used to mark an env var that requires a paid plan."
   "> Only available on Metabase [Pro](https://www.metabase.com/product/pro) and [Enterprise](https://www.metabase.com/product/enterprise) plans.")
@@ -160,7 +154,6 @@
                             ;; Like `- Default: 100`
                             (format-list [(format-type env-var)
                                           (format-default env-var)
-                                          (format-deprecated-name env-var)
                                           (format-export env-var)
                                           (format-config-name env-var)])
                             (format-description env-var)

--- a/src/metabase/cmd/env_var_dox.clj
+++ b/src/metabase/cmd/env_var_dox.clj
@@ -69,7 +69,7 @@
   "Formats an environment variable name with the 'MB_' prefix
    Example: MB_ENV_VAR_NAME or MB_OLD_SETTING [DEPRECATED]"
   [env-var]
-  (let [base-name (str "MB_" (u/->SCREAMING_SNAKE_CASE_EN (:munged-name env-var)))]
+  (let [base-name (setting/env-var-name (:name env-var))]
     (if (:deprecated env-var)
       (str base-name " [DEPRECATED]")
       base-name)))
@@ -99,7 +99,7 @@
   "Shows the deprecated env var name that still works as a fallback."
   [env-var]
   (when-let [deprecated-name (:deprecated-name env-var)]
-    (str "Deprecated env var: `MB_" (u/->SCREAMING_SNAKE_CASE_EN (name deprecated-name)) "`")))
+    (str "Deprecated env var: `" (setting/env-var-name deprecated-name) "`")))
 
 (def paid-message
   "Used to mark an env var that requires a paid plan."

--- a/src/metabase/core/core.clj
+++ b/src/metabase/core/core.clj
@@ -226,6 +226,7 @@
   (setting/migrate-encrypted-settings!)
   (database/check-health!)
   (startup/run-startup-logic!)
+  (setting/log-deprecated-env-var-usage!)
   (init-status/set-progress! 0.95)
   (task/start-scheduler!)
   (queue/start-listeners!)

--- a/src/metabase/settings/core.clj
+++ b/src/metabase/settings/core.clj
@@ -94,6 +94,7 @@
   default-value
   defsetting
   disabled-for-db-reasons
+  env-var-name
   env-var-value
   export?
   get

--- a/src/metabase/settings/core.clj
+++ b/src/metabase/settings/core.clj
@@ -98,6 +98,7 @@
   export?
   get
   get-raw-value
+  log-deprecated-env-var-usage!
   get-value-of-type
   has-advanced-setting-access?
   migrate-encrypted-settings!

--- a/src/metabase/settings/models/setting.clj
+++ b/src/metabase/settings/models/setting.clj
@@ -490,15 +490,14 @@
   Should be called during startup after all settings are registered."
   []
   (doseq [[_ setting] @registered-settings
-          :let [deprecated-name (:deprecated-name setting)]
-          :when deprecated-name
+          :when (:deprecated-name setting)
           :when (and (allows-site-wide-values? setting)
                      (allows-setting-via-env? setting))
-          :let [primary-v (env/env (setting-env-map-name setting))
-                legacy-v  (env/env (setting-env-map-name deprecated-name))]
+          :let [legacy-v (env/env (setting-env-map-name (:deprecated-name setting)))]
           :when (seq legacy-v)]
     (let [primary-env (env-var-name setting)
-          legacy-env  (env-var-name deprecated-name)]
+          legacy-env  (env-var-name (:deprecated-name setting))
+          primary-v   (env/env (setting-env-map-name setting))]
       (cond
         (and (seq primary-v) (not= primary-v legacy-v))
         (log/warnf "%s and deprecated %s have conflicting values; using %s. Remove %s."

--- a/src/metabase/settings/models/setting.clj
+++ b/src/metabase/settings/models/setting.clj
@@ -443,7 +443,7 @@
   [setting-nm]
   (str/replace (name setting-nm) #"[^a-zA-Z0-9_-]*" ""))
 
-(defn- env-var-name
+(defn env-var-name
   "Get the env var corresponding to `setting-definition-or-name`. (This is used primarily for documentation purposes)."
   ^String [setting-definition-or-name]
   (str "MB_" (-> (setting-name setting-definition-or-name)

--- a/src/metabase/settings/models/setting.clj
+++ b/src/metabase/settings/models/setting.clj
@@ -478,12 +478,10 @@
                (allows-setting-via-env? setting))
       (if-let [v (env/env (setting-env-map-name setting))]
         ;; primary env var is set — return it only if non-empty
-        (when (seq v) v)
+        (not-empty v)
         ;; primary env var is absent — try deprecated name
         (when-let [deprecated-name (:deprecated-name setting)]
-          (let [legacy-v (env/env (setting-env-map-name deprecated-name))]
-            (when (seq legacy-v)
-              legacy-v)))))))
+          (not-empty (env/env (setting-env-map-name deprecated-name))))))))
 
 (defn log-deprecated-env-var-usage!
   "Log warnings for any settings currently using a deprecated env var name.
@@ -493,17 +491,17 @@
           :when (:deprecated-name setting)
           :when (and (allows-site-wide-values? setting)
                      (allows-setting-via-env? setting))
-          :let [legacy-v (env/env (setting-env-map-name (:deprecated-name setting)))]
-          :when (seq legacy-v)]
+          :let [legacy-v (not-empty (env/env (setting-env-map-name (:deprecated-name setting))))]
+          :when legacy-v]
     (let [primary-env (env-var-name setting)
           legacy-env  (env-var-name (:deprecated-name setting))
-          primary-v   (env/env (setting-env-map-name setting))]
+          primary-v   (not-empty (env/env (setting-env-map-name setting)))]
       (cond
-        (and (seq primary-v) (not= primary-v legacy-v))
+        (and primary-v (not= primary-v legacy-v))
         (log/warnf "%s and deprecated %s have conflicting values; using %s. Remove %s."
                    primary-env legacy-env primary-env legacy-env)
 
-        (seq primary-v)
+        primary-v
         (log/warnf "%s and deprecated %s are both set. Remove %s."
                    primary-env legacy-env legacy-env)
 

--- a/src/metabase/settings/models/setting.clj
+++ b/src/metabase/settings/models/setting.clj
@@ -276,7 +276,11 @@
    ;; display rules - for example, giving certain reasons higher precedence.
    ;;
    ;; This is only valid for database-local settings.
-   [:enabled-for-db? [:maybe ifn?]]])
+   [:enabled-for-db? [:maybe ifn?]]
+
+   ;; A previous name for this setting whose env var (e.g. MB_OLD_NAME) is checked
+   ;; as a fallback when the primary env var is not set. Logs a warning when used.
+   [:deprecated-name [:maybe :keyword]]])
 
 (defonce ^{:doc "Map of loaded defsettings"}
   registered-settings
@@ -463,14 +467,50 @@
    The name of the Setting is converted to uppercase and dashes to underscores; for example, a setting named
   `default-domain` can be set with the env var `MB_DEFAULT_DOMAIN`. Note that this strips out characters that are not
   legal for shells. Setting `foo-bar?` will expect to find the key `:mb-foo-bar` which will be sourced from the
-  environment variable `MB_FOO_BAR`."
+  environment variable `MB_FOO_BAR`.
+
+  When the primary env var is truly absent (nil from environ) and the setting has a `:deprecated-name`, the env var
+  derived from that name is checked as a fallback. An empty string for the primary env var means \"explicitly unset\"
+  and blocks the fallback."
   ^String [setting-definition-or-name]
   (let [setting (resolve-setting setting-definition-or-name)]
     (when (and (allows-site-wide-values? setting)
                (allows-setting-via-env? setting))
-      (let [v (env/env (setting-env-map-name setting))]
-        (when (seq v)
-          v)))))
+      (if-let [v (env/env (setting-env-map-name setting))]
+        ;; primary env var is set — return it only if non-empty
+        (when (seq v) v)
+        ;; primary env var is absent — try deprecated name
+        (when-let [deprecated-name (:deprecated-name setting)]
+          (let [legacy-v (env/env (setting-env-map-name deprecated-name))]
+            (when (seq legacy-v)
+              legacy-v)))))))
+
+(defn log-deprecated-env-var-usage!
+  "Log warnings for any settings currently using a deprecated env var name.
+  Should be called during startup after all settings are registered."
+  []
+  (doseq [[_ setting] @registered-settings
+          :let [deprecated-name (:deprecated-name setting)]
+          :when deprecated-name
+          :when (and (allows-site-wide-values? setting)
+                     (allows-setting-via-env? setting))
+          :let [primary-v (env/env (setting-env-map-name setting))
+                legacy-v  (env/env (setting-env-map-name deprecated-name))]
+          :when (seq legacy-v)]
+    (let [primary-env (env-var-name setting)
+          legacy-env  (env-var-name deprecated-name)]
+      (cond
+        (and (seq primary-v) (not= primary-v legacy-v))
+        (log/warnf "%s and deprecated %s have conflicting values; using %s. Remove %s."
+                   primary-env legacy-env primary-env legacy-env)
+
+        (seq primary-v)
+        (log/warnf "%s and deprecated %s are both set. Remove %s."
+                   primary-env legacy-env legacy-env)
+
+        :else
+        (log/warnf "Deprecated %s is set; rename it to %s."
+                   legacy-env primary-env)))))
 
 (def ^:private ^:dynamic *disable-init* false)
 
@@ -1052,6 +1092,7 @@
                  :user-local         :never
                  :driver-feature     nil
                  :enabled-for-db?    nil
+                 :deprecated-name    nil
                  :deprecated         nil
                  :enabled?           nil
                  :can-read-from-env? true
@@ -1102,6 +1143,10 @@
         (throw (ex-info (tru "Setting {0} uses :enabled-for-db?, but is not limited to only database-local values"
                              setting-name)
                         {:setting setting})))
+      (when (and (:deprecated-name <>) (not (:can-read-from-env? <>)))
+        (throw (ex-info (tru "Setting {0} uses :deprecated-name but has :can-read-from-env? set to false"
+                             setting-name)
+                        {:setting <>})))
       (swap! registered-settings assoc setting-name <>))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -1306,6 +1351,13 @@
 
   Whether this Setting is /User-local/. Valid values are `:only`, `:allowed`, and `:never`. Default: `:never`. See
   docstring for [[metabase.settings.models.setting]] for more info.
+
+  ###### `:deprecated-name`
+
+  A keyword naming a previous version of this setting whose env var should be checked as a fallback when the primary
+  env var is not set. For example, `:deprecated-name :my-old-setting` means `MB_MY_OLD_SETTING` will be tried when
+  `MB_MY_NEW_SETTING` is absent. A deprecation warning is logged at startup when the fallback is in use. The setting
+  must allow env var reading (`:can-read-from-env? true`, the default). (Default: `nil`).
 
   ###### `:deprecated`
 

--- a/test/metabase/cmd/env_var_dox_test.clj
+++ b/test/metabase/cmd/env_var_dox_test.clj
@@ -8,9 +8,9 @@
 
 (deftest ^:parallel test-format-prefix
   (testing "format-prefix handles deprecated variables."
-    (let [normal-var {:munged-name "test-setting"}
-          deprecated-var {:munged-name "old-setting" :deprecated true}
-          deprecated-with-msg-var {:munged-name "very-old-setting" :deprecated "Since v0.53"}]
+    (let [normal-var {:name :test-setting}
+          deprecated-var {:name :old-setting :deprecated true}
+          deprecated-with-msg-var {:name :very-old-setting :deprecated "Since v0.53"}]
       (is (= "MB_TEST_SETTING" (#'sut/format-prefix normal-var)))
       (is (= "MB_OLD_SETTING [DEPRECATED]" (#'sut/format-prefix deprecated-var)))
       (is (= "MB_VERY_OLD_SETTING [DEPRECATED]" (#'sut/format-prefix deprecated-with-msg-var))))))

--- a/test/metabase/settings/models/setting_test.clj
+++ b/test/metabase/settings/models/setting_test.clj
@@ -1809,95 +1809,47 @@
 
 ;;; ----------------------------------------- deprecated-name env var fallback -----------------------------------------
 
-(deftest deprecated-name-primary-takes-precedence-test
-  (testing "when both primary and deprecated env vars are set, primary wins"
-    (with-redefs [env/env (assoc env/env
-                                 :mb-test-setting-with-deprecated-name "PRIMARY"
-                                 :mb-old-test-setting-name "LEGACY")]
-      (setting.cache/restore-cache!)
-      (try
-        (is (= "PRIMARY" (setting/env-var-value :test-setting-with-deprecated-name)))
-        (finally
-          (setting.cache/restore-cache!))))))
+(deftest deprecated-name-env-var-value-test
+  (testing "primary takes precedence when both are set"
+    (mt/with-temp-env-var-value! [mb-test-setting-with-deprecated-name "PRIMARY"
+                                  mb-old-test-setting-name             "LEGACY"]
+      (is (= "PRIMARY" (setting/env-var-value :test-setting-with-deprecated-name)))))
+  (testing "falls back to legacy when primary is absent"
+    (mt/with-temp-env-var-value! [mb-old-test-setting-name "LEGACY"]
+      (is (= "LEGACY" (setting/env-var-value :test-setting-with-deprecated-name)))))
+  (testing "empty primary blocks fallback"
+    (mt/with-temp-env-var-value! [mb-test-setting-with-deprecated-name ""
+                                  mb-old-test-setting-name             "LEGACY"]
+      (is (nil? (setting/env-var-value :test-setting-with-deprecated-name)))))
+  (testing "returns nil when neither is set"
+    (is (nil? (setting/env-var-value :test-setting-with-deprecated-name)))))
 
-(deftest deprecated-name-fallback-works-test
-  (testing "when only the deprecated env var is set, its value is returned"
-    (with-redefs [env/env (-> env/env
-                              (dissoc :mb-test-setting-with-deprecated-name)
-                              (assoc :mb-old-test-setting-name "LEGACY"))]
-      (setting.cache/restore-cache!)
-      (try
-        (is (= "LEGACY" (setting/env-var-value :test-setting-with-deprecated-name)))
-        (finally
-          (setting.cache/restore-cache!))))))
-
-(deftest deprecated-name-empty-primary-blocks-fallback-test
-  (testing "when primary is set to empty string, deprecated env var is NOT used"
-    (with-redefs [env/env (assoc env/env
-                                 :mb-test-setting-with-deprecated-name ""
-                                 :mb-old-test-setting-name "LEGACY")]
-      (setting.cache/restore-cache!)
-      (try
-        (is (nil? (setting/env-var-value :test-setting-with-deprecated-name)))
-        (finally
-          (setting.cache/restore-cache!))))))
-
-(deftest deprecated-name-neither-set-test
-  (testing "when neither primary nor deprecated env var is set, returns nil"
-    (with-redefs [env/env (-> env/env
-                              (dissoc :mb-test-setting-with-deprecated-name)
-                              (dissoc :mb-old-test-setting-name))]
-      (setting.cache/restore-cache!)
-      (try
-        (is (nil? (setting/env-var-value :test-setting-with-deprecated-name)))
-        (finally
-          (setting.cache/restore-cache!))))))
-
-(deftest deprecated-name-fallback-warning-test
-  (testing "warns when only the deprecated env var is set (fallback in use)"
-    (with-redefs [env/env (-> env/env
-                              (dissoc :mb-test-setting-with-deprecated-name)
-                              (assoc :mb-old-test-setting-name "LEGACY"))]
+(deftest deprecated-name-warnings-test
+  (testing "only legacy set: rename warning"
+    (mt/with-temp-env-var-value! [mb-old-test-setting-name "LEGACY"]
       (mt/with-log-messages-for-level [messages :warn]
         (setting/log-deprecated-env-var-usage!)
-        (is (some (fn [{:keys [message]}]
-                    (= message
-                       "Deprecated MB_OLD_TEST_SETTING_NAME is set; rename it to MB_TEST_SETTING_WITH_DEPRECATED_NAME."))
-                  (messages)))))))
-
-(deftest deprecated-name-both-set-inconsistent-warning-test
-  (testing "warns about conflicting values when both env vars are set differently"
-    (with-redefs [env/env (assoc env/env
-                                 :mb-test-setting-with-deprecated-name "PRIMARY"
-                                 :mb-old-test-setting-name "LEGACY")]
+        (is (= ["Deprecated MB_OLD_TEST_SETTING_NAME is set; rename it to MB_TEST_SETTING_WITH_DEPRECATED_NAME."]
+               (->> (messages) (mapv :message) (filterv #(str/includes? % "OLD_TEST_SETTING"))))))))
+  (testing "both set with different values: conflict warning"
+    (mt/with-temp-env-var-value! [mb-test-setting-with-deprecated-name "PRIMARY"
+                                  mb-old-test-setting-name             "LEGACY"]
       (mt/with-log-messages-for-level [messages :warn]
         (setting/log-deprecated-env-var-usage!)
-        (is (some (fn [{:keys [message]}]
-                    (= message
-                       (str "MB_TEST_SETTING_WITH_DEPRECATED_NAME and deprecated MB_OLD_TEST_SETTING_NAME"
-                            " have conflicting values; using MB_TEST_SETTING_WITH_DEPRECATED_NAME."
-                            " Remove MB_OLD_TEST_SETTING_NAME.")))
-                  (messages)))))))
-
-(deftest deprecated-name-both-set-consistent-warning-test
-  (testing "warns about redundancy when both env vars are set to the same value"
-    (with-redefs [env/env (assoc env/env
-                                 :mb-test-setting-with-deprecated-name "SAME"
-                                 :mb-old-test-setting-name "SAME")]
+        (is (= [(str "MB_TEST_SETTING_WITH_DEPRECATED_NAME and deprecated MB_OLD_TEST_SETTING_NAME"
+                     " have conflicting values; using MB_TEST_SETTING_WITH_DEPRECATED_NAME."
+                     " Remove MB_OLD_TEST_SETTING_NAME.")]
+               (->> (messages) (mapv :message) (filterv #(str/includes? % "OLD_TEST_SETTING"))))))))
+  (testing "both set with same value: redundancy warning"
+    (mt/with-temp-env-var-value! [mb-test-setting-with-deprecated-name "SAME"
+                                  mb-old-test-setting-name             "SAME"]
       (mt/with-log-messages-for-level [messages :warn]
         (setting/log-deprecated-env-var-usage!)
-        (is (some (fn [{:keys [message]}]
-                    (= message
-                       "MB_TEST_SETTING_WITH_DEPRECATED_NAME and deprecated MB_OLD_TEST_SETTING_NAME are both set. Remove MB_OLD_TEST_SETTING_NAME."))
-                  (messages)))))))
-
-(deftest deprecated-name-no-warning-when-no-legacy-test
-  (testing "no warning is logged when only the primary env var is set (no legacy)"
-    (with-redefs [env/env (-> env/env
-                              (assoc :mb-test-setting-with-deprecated-name "PRIMARY")
-                              (dissoc :mb-old-test-setting-name))]
+        (is (= ["MB_TEST_SETTING_WITH_DEPRECATED_NAME and deprecated MB_OLD_TEST_SETTING_NAME are both set. Remove MB_OLD_TEST_SETTING_NAME."]
+               (->> (messages) (mapv :message) (filterv #(str/includes? % "OLD_TEST_SETTING"))))))))
+  (testing "only primary set: no warning"
+    (mt/with-temp-env-var-value! [mb-test-setting-with-deprecated-name "PRIMARY"]
       (mt/with-log-messages-for-level [messages :warn]
         (setting/log-deprecated-env-var-usage!)
-        (is (not (some (fn [{:keys [message]}]
-                         (str/includes? message "MB_OLD_TEST_SETTING_NAME"))
-                       (messages))))))))
+        (is (= []
+               (->> (messages) (mapv :message) (filterv #(str/includes? % "OLD_TEST_SETTING")))))))))

--- a/test/metabase/settings/models/setting_test.clj
+++ b/test/metabase/settings/models/setting_test.clj
@@ -1809,47 +1809,45 @@
 
 ;;; ----------------------------------------- deprecated-name env var fallback -----------------------------------------
 
-(deftest deprecated-name-env-var-value-test
-  (testing "primary takes precedence when both are set"
-    (mt/with-temp-env-var-value! [mb-test-setting-with-deprecated-name "PRIMARY"
-                                  mb-old-test-setting-name             "LEGACY"]
-      (is (= "PRIMARY" (setting/env-var-value :test-setting-with-deprecated-name)))))
-  (testing "falls back to legacy when primary is absent"
-    (mt/with-temp-env-var-value! [mb-old-test-setting-name "LEGACY"]
-      (is (= "LEGACY" (setting/env-var-value :test-setting-with-deprecated-name)))))
-  (testing "empty primary blocks fallback"
-    (mt/with-temp-env-var-value! [mb-test-setting-with-deprecated-name ""
-                                  mb-old-test-setting-name             "LEGACY"]
-      (is (nil? (setting/env-var-value :test-setting-with-deprecated-name)))))
-  (testing "returns nil when neither is set"
-    (is (nil? (setting/env-var-value :test-setting-with-deprecated-name)))))
+(defn- deprecated-env-var-warnings
+  "Return warning log messages mentioning the deprecated env var after running [[setting/log-deprecated-env-var-usage!]]."
+  []
+  (mt/with-log-messages-for-level [messages :warn]
+    (setting/log-deprecated-env-var-usage!)
+    (->> (messages) (mapv :message) (filterv #(str/includes? % "OLD_TEST_SETTING")))))
 
-(deftest deprecated-name-warnings-test
-  (testing "only legacy set: rename warning"
-    (mt/with-temp-env-var-value! [mb-old-test-setting-name "LEGACY"]
-      (mt/with-log-messages-for-level [messages :warn]
-        (setting/log-deprecated-env-var-usage!)
-        (is (= ["Deprecated MB_OLD_TEST_SETTING_NAME is set; rename it to MB_TEST_SETTING_WITH_DEPRECATED_NAME."]
-               (->> (messages) (mapv :message) (filterv #(str/includes? % "OLD_TEST_SETTING"))))))))
-  (testing "both set with different values: conflict warning"
-    (mt/with-temp-env-var-value! [mb-test-setting-with-deprecated-name "PRIMARY"
-                                  mb-old-test-setting-name             "LEGACY"]
-      (mt/with-log-messages-for-level [messages :warn]
-        (setting/log-deprecated-env-var-usage!)
-        (is (= [(str "MB_TEST_SETTING_WITH_DEPRECATED_NAME and deprecated MB_OLD_TEST_SETTING_NAME"
-                     " have conflicting values; using MB_TEST_SETTING_WITH_DEPRECATED_NAME."
-                     " Remove MB_OLD_TEST_SETTING_NAME.")]
-               (->> (messages) (mapv :message) (filterv #(str/includes? % "OLD_TEST_SETTING"))))))))
-  (testing "both set with same value: redundancy warning"
-    (mt/with-temp-env-var-value! [mb-test-setting-with-deprecated-name "SAME"
-                                  mb-old-test-setting-name             "SAME"]
-      (mt/with-log-messages-for-level [messages :warn]
-        (setting/log-deprecated-env-var-usage!)
-        (is (= ["MB_TEST_SETTING_WITH_DEPRECATED_NAME and deprecated MB_OLD_TEST_SETTING_NAME are both set. Remove MB_OLD_TEST_SETTING_NAME."]
-               (->> (messages) (mapv :message) (filterv #(str/includes? % "OLD_TEST_SETTING"))))))))
-  (testing "only primary set: no warning"
-    (mt/with-temp-env-var-value! [mb-test-setting-with-deprecated-name "PRIMARY"]
-      (mt/with-log-messages-for-level [messages :warn]
-        (setting/log-deprecated-env-var-usage!)
-        (is (= []
-               (->> (messages) (mapv :message) (filterv #(str/includes? % "OLD_TEST_SETTING")))))))))
+(deftest deprecated-name-only-legacy-set-test
+  (mt/with-temp-env-var-value! [mb-old-test-setting-name "LEGACY"]
+    (is (= "LEGACY" (setting/env-var-value :test-setting-with-deprecated-name)))
+    (is (= ["Deprecated MB_OLD_TEST_SETTING_NAME is set; rename it to MB_TEST_SETTING_WITH_DEPRECATED_NAME."]
+           (deprecated-env-var-warnings)))))
+
+(deftest deprecated-name-both-set-different-values-test
+  (mt/with-temp-env-var-value! [mb-test-setting-with-deprecated-name "PRIMARY"
+                                mb-old-test-setting-name             "LEGACY"]
+    (is (= "PRIMARY" (setting/env-var-value :test-setting-with-deprecated-name)))
+    (is (= [(str "MB_TEST_SETTING_WITH_DEPRECATED_NAME and deprecated MB_OLD_TEST_SETTING_NAME"
+                 " have conflicting values; using MB_TEST_SETTING_WITH_DEPRECATED_NAME."
+                 " Remove MB_OLD_TEST_SETTING_NAME.")]
+           (deprecated-env-var-warnings)))))
+
+(deftest deprecated-name-both-set-same-value-test
+  (mt/with-temp-env-var-value! [mb-test-setting-with-deprecated-name "SAME"
+                                mb-old-test-setting-name             "SAME"]
+    (is (= "SAME" (setting/env-var-value :test-setting-with-deprecated-name)))
+    (is (= ["MB_TEST_SETTING_WITH_DEPRECATED_NAME and deprecated MB_OLD_TEST_SETTING_NAME are both set. Remove MB_OLD_TEST_SETTING_NAME."]
+           (deprecated-env-var-warnings)))))
+
+(deftest deprecated-name-only-primary-set-test
+  (mt/with-temp-env-var-value! [mb-test-setting-with-deprecated-name "PRIMARY"]
+    (is (= "PRIMARY" (setting/env-var-value :test-setting-with-deprecated-name)))
+    (is (= [] (deprecated-env-var-warnings)))))
+
+(deftest deprecated-name-neither-set-test
+  (is (nil? (setting/env-var-value :test-setting-with-deprecated-name)))
+  (is (= [] (deprecated-env-var-warnings))))
+
+(deftest deprecated-name-empty-primary-blocks-fallback-test
+  (mt/with-temp-env-var-value! [mb-test-setting-with-deprecated-name ""
+                                mb-old-test-setting-name             "LEGACY"]
+    (is (nil? (setting/env-var-value :test-setting-with-deprecated-name)))))

--- a/test/metabase/settings/models/setting_test.clj
+++ b/test/metabase/settings/models/setting_test.clj
@@ -69,6 +69,12 @@
   :visibility :internal
   :encryption :when-encryption-key-set)
 
+(defsetting test-setting-with-deprecated-name
+  "Test setting with a deprecated env var name"
+  :visibility :internal
+  :encryption :when-encryption-key-set
+  :deprecated-name :old-test-setting-name)
+
 (defsetting toucan-name
   "Name for the Metabase Toucan mascot."
   :visibility :internal
@@ -1800,3 +1806,98 @@
           (mt/with-temporary-setting-values [test-setting-that-is-not-included-when-listing-in-api "fun-times"]
             (is (= ::not-present
                    (f :test-setting-that-is-not-included-when-listing-in-api)))))))))
+
+;;; ----------------------------------------- deprecated-name env var fallback -----------------------------------------
+
+(deftest deprecated-name-primary-takes-precedence-test
+  (testing "when both primary and deprecated env vars are set, primary wins"
+    (with-redefs [env/env (assoc env/env
+                                 :mb-test-setting-with-deprecated-name "PRIMARY"
+                                 :mb-old-test-setting-name "LEGACY")]
+      (setting.cache/restore-cache!)
+      (try
+        (is (= "PRIMARY" (setting/env-var-value :test-setting-with-deprecated-name)))
+        (finally
+          (setting.cache/restore-cache!))))))
+
+(deftest deprecated-name-fallback-works-test
+  (testing "when only the deprecated env var is set, its value is returned"
+    (with-redefs [env/env (-> env/env
+                              (dissoc :mb-test-setting-with-deprecated-name)
+                              (assoc :mb-old-test-setting-name "LEGACY"))]
+      (setting.cache/restore-cache!)
+      (try
+        (is (= "LEGACY" (setting/env-var-value :test-setting-with-deprecated-name)))
+        (finally
+          (setting.cache/restore-cache!))))))
+
+(deftest deprecated-name-empty-primary-blocks-fallback-test
+  (testing "when primary is set to empty string, deprecated env var is NOT used"
+    (with-redefs [env/env (assoc env/env
+                                 :mb-test-setting-with-deprecated-name ""
+                                 :mb-old-test-setting-name "LEGACY")]
+      (setting.cache/restore-cache!)
+      (try
+        (is (nil? (setting/env-var-value :test-setting-with-deprecated-name)))
+        (finally
+          (setting.cache/restore-cache!))))))
+
+(deftest deprecated-name-neither-set-test
+  (testing "when neither primary nor deprecated env var is set, returns nil"
+    (with-redefs [env/env (-> env/env
+                              (dissoc :mb-test-setting-with-deprecated-name)
+                              (dissoc :mb-old-test-setting-name))]
+      (setting.cache/restore-cache!)
+      (try
+        (is (nil? (setting/env-var-value :test-setting-with-deprecated-name)))
+        (finally
+          (setting.cache/restore-cache!))))))
+
+(deftest deprecated-name-fallback-warning-test
+  (testing "warns when only the deprecated env var is set (fallback in use)"
+    (with-redefs [env/env (-> env/env
+                              (dissoc :mb-test-setting-with-deprecated-name)
+                              (assoc :mb-old-test-setting-name "LEGACY"))]
+      (mt/with-log-messages-for-level [messages :warn]
+        (setting/log-deprecated-env-var-usage!)
+        (is (some (fn [{:keys [message]}]
+                    (= message
+                       "Deprecated MB_OLD_TEST_SETTING_NAME is set; rename it to MB_TEST_SETTING_WITH_DEPRECATED_NAME."))
+                  (messages)))))))
+
+(deftest deprecated-name-both-set-inconsistent-warning-test
+  (testing "warns about conflicting values when both env vars are set differently"
+    (with-redefs [env/env (assoc env/env
+                                 :mb-test-setting-with-deprecated-name "PRIMARY"
+                                 :mb-old-test-setting-name "LEGACY")]
+      (mt/with-log-messages-for-level [messages :warn]
+        (setting/log-deprecated-env-var-usage!)
+        (is (some (fn [{:keys [message]}]
+                    (= message
+                       (str "MB_TEST_SETTING_WITH_DEPRECATED_NAME and deprecated MB_OLD_TEST_SETTING_NAME"
+                            " have conflicting values; using MB_TEST_SETTING_WITH_DEPRECATED_NAME."
+                            " Remove MB_OLD_TEST_SETTING_NAME.")))
+                  (messages)))))))
+
+(deftest deprecated-name-both-set-consistent-warning-test
+  (testing "warns about redundancy when both env vars are set to the same value"
+    (with-redefs [env/env (assoc env/env
+                                 :mb-test-setting-with-deprecated-name "SAME"
+                                 :mb-old-test-setting-name "SAME")]
+      (mt/with-log-messages-for-level [messages :warn]
+        (setting/log-deprecated-env-var-usage!)
+        (is (some (fn [{:keys [message]}]
+                    (= message
+                       "MB_TEST_SETTING_WITH_DEPRECATED_NAME and deprecated MB_OLD_TEST_SETTING_NAME are both set. Remove MB_OLD_TEST_SETTING_NAME."))
+                  (messages)))))))
+
+(deftest deprecated-name-no-warning-when-no-legacy-test
+  (testing "no warning is logged when only the primary env var is set (no legacy)"
+    (with-redefs [env/env (-> env/env
+                              (assoc :mb-test-setting-with-deprecated-name "PRIMARY")
+                              (dissoc :mb-old-test-setting-name))]
+      (mt/with-log-messages-for-level [messages :warn]
+        (setting/log-deprecated-env-var-usage!)
+        (is (not (some (fn [{:keys [message]}]
+                         (str/includes? message "MB_OLD_TEST_SETTING_NAME"))
+                       (messages))))))))


### PR DESCRIPTION
We're planning to open source a number of EE features. 

This mechanism will help us migrate settings like `ee-ai-features-enabled`.
