### PR TITLE
display sql transforms errors in editor

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/CreateTenantsOnboardingStep/hooks/use-field-distinct-values.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/CreateTenantsOnboardingStep/hooks/use-field-distinct-values.unit.spec.tsx
@@ -30,7 +30,7 @@ function setup({ fieldId, rows }: SetupOpts) {
     setupFieldEndpoints(field);
 
     if (rows) {
-      setupCardDataset({ data: { rows } });
+      setupCardDataset({ dataset: { data: { rows } } });
     }
   }
 

--- a/frontend/src/metabase/admin/datamodel/containers/SegmentApp.unit.spec.tsx
+++ b/frontend/src/metabase/admin/datamodel/containers/SegmentApp.unit.spec.tsx
@@ -40,8 +40,10 @@ const setup = ({ initialRoute = FORM_URL }: SetupOpts = {}) => {
   setupDatabasesEndpoints([createSampleDatabase()]);
   setupSearchEndpoints([]);
   setupCardDataset({
-    data: {
-      rows: [[1, 2, 3]],
+    dataset: {
+      data: {
+        rows: [[1, 2, 3]],
+      },
     },
   });
   setupRecentViewsAndSelectionsEndpoints([], ["selections"]);

--- a/frontend/src/metabase/detail-view/components/Relationships/Relationship/Relationship.unit.spec.tsx
+++ b/frontend/src/metabase/detail-view/components/Relationships/Relationship/Relationship.unit.spec.tsx
@@ -61,7 +61,7 @@ function setup({ dataset = DATASET }: SetupOpts = {}) {
     <Relationship fk={FK} rowId={ROW_ID} onClick={onClick} />
   );
 
-  setupCardDataset(dataset);
+  setupCardDataset({ dataset });
 
   renderWithProviders(<Route path="/" component={TestComponent} />, {
     withRouter: true,

--- a/frontend/src/metabase/query_builder/containers/test-utils.tsx
+++ b/frontend/src/metabase/query_builder/containers/test-utils.tsx
@@ -246,7 +246,7 @@ export const setup = async ({
   }`,
 }: SetupOpts) => {
   setupDatabasesEndpoints([TEST_DB]);
-  setupCardDataset(dataset);
+  setupCardDataset({ dataset });
   setupSearchEndpoints([]);
   setupPropertiesEndpoints(createMockSettings());
   setupCollectionsEndpoints({ collections: [] });

--- a/frontend/src/metabase/querying/editor/hooks/use-query-results/use-query-results.ts
+++ b/frontend/src/metabase/querying/editor/hooks/use-query-results/use-query-results.ts
@@ -5,6 +5,7 @@ import * as Lib from "metabase-lib";
 import Question from "metabase-lib/v1/Question";
 import { normalizeParameters } from "metabase-lib/v1/parameters/utils/parameter-values";
 import type { Dataset, DatasetQuery } from "metabase-types/api";
+import { isObject } from "metabase-types/guards";
 
 import type { QueryEditorUiState } from "../../types";
 
@@ -88,5 +89,5 @@ export function useQueryResults(
 }
 
 function hasDataset(value: unknown): value is { data: Dataset } {
-  return typeof value === "object" && value !== null && "data" in value;
+  return isObject(value) && "data" in value;
 }

--- a/frontend/src/metabase/querying/editor/hooks/use-query-results/use-query-results.ts
+++ b/frontend/src/metabase/querying/editor/hooks/use-query-results/use-query-results.ts
@@ -4,7 +4,7 @@ import { useLazyGetAdhocQueryQuery } from "metabase/api";
 import * as Lib from "metabase-lib";
 import Question from "metabase-lib/v1/Question";
 import { normalizeParameters } from "metabase-lib/v1/parameters/utils/parameter-values";
-import type { DatasetQuery } from "metabase-types/api";
+import type { Dataset, DatasetQuery } from "metabase-types/api";
 
 import type { QueryEditorUiState } from "../../types";
 
@@ -60,9 +60,10 @@ export function useQueryResults(
       parameters: normalizeParameters(question.parameters()),
     });
     abortRef.current = action.abort;
-    const { data: lastRunResult = null } = await action;
+    const { data, error } = await action;
     abortRef.current = undefined;
 
+    const lastRunResult = data ?? (hasDataset(error) ? error.data : null);
     onChangeUiState({ ...uiState, lastRunResult, lastRunQuery });
   };
 
@@ -84,4 +85,8 @@ export function useQueryResults(
     runQuery,
     cancelQuery,
   };
+}
+
+function hasDataset(value: unknown): value is { data: Dataset } {
+  return typeof value === "object" && value !== null && "data" in value;
 }

--- a/frontend/src/metabase/querying/editor/hooks/use-query-results/use-query-results.unit.spec.ts
+++ b/frontend/src/metabase/querying/editor/hooks/use-query-results/use-query-results.unit.spec.ts
@@ -2,10 +2,7 @@ import { setupCardDataset } from "__support__/server-mocks";
 import { renderHookWithProviders, waitFor } from "__support__/ui";
 import Question from "metabase-lib/v1/Question";
 import type { Dataset } from "metabase-types/api";
-import {
-  createMockDataset,
-  createMockDatasetData,
-} from "metabase-types/api/mocks";
+import { createMockDataset } from "metabase-types/api/mocks";
 import { createMockNativeDatasetQuery } from "metabase-types/api/mocks/query";
 
 import type { QueryEditorUiState } from "../../types";
@@ -16,13 +13,11 @@ const NATIVE_QUERY = createMockNativeDatasetQuery({
   native: { query: "SELECXT 1" },
 });
 
-const ERROR_DATASET: Dataset = {
-  ...createMockDataset(),
-  data: createMockDatasetData({}),
+const ERROR_DATASET = createMockDataset({
   error: 'ERROR: syntax error at or near "SELECXT"',
   error_type: "invalid-query",
   status: "failed",
-};
+});
 
 function setup({
   mockResponse,

--- a/frontend/src/metabase/querying/editor/hooks/use-query-results/use-query-results.unit.spec.ts
+++ b/frontend/src/metabase/querying/editor/hooks/use-query-results/use-query-results.unit.spec.ts
@@ -1,0 +1,101 @@
+import { setupCardDataset } from "__support__/server-mocks";
+import { renderHookWithProviders, waitFor } from "__support__/ui";
+import Question from "metabase-lib/v1/Question";
+import type { Dataset } from "metabase-types/api";
+import {
+  createMockDataset,
+  createMockDatasetData,
+} from "metabase-types/api/mocks";
+import { createMockNativeDatasetQuery } from "metabase-types/api/mocks/query";
+
+import type { QueryEditorUiState } from "../../types";
+
+import { useQueryResults } from "./use-query-results";
+
+const NATIVE_QUERY = createMockNativeDatasetQuery({
+  native: { query: "SELECXT 1" },
+});
+
+const ERROR_DATASET: Dataset = {
+  ...createMockDataset(),
+  data: createMockDatasetData({}),
+  error: 'ERROR: syntax error at or near "SELECXT"',
+  error_type: "invalid-query",
+  status: "failed",
+};
+
+function setup({
+  mockResponse,
+  onChangeUiState,
+}: {
+  mockResponse: { status?: number; dataset?: Dataset };
+  onChangeUiState: (uiState: QueryEditorUiState) => void;
+}) {
+  setupCardDataset({
+    status: mockResponse.status,
+    dataset: mockResponse.dataset,
+  });
+
+  const question = Question.create({
+    dataset_query: NATIVE_QUERY,
+    metadata: undefined,
+  });
+
+  const initialUiState: QueryEditorUiState = {
+    lastRunResult: null,
+    lastRunQuery: null,
+    selectionRange: [],
+    modalSnippet: null,
+    modalType: null,
+    sidebarType: null,
+  };
+
+  const { result } = renderHookWithProviders(
+    () => useQueryResults(question, initialUiState, onChangeUiState),
+    {},
+  );
+
+  return { result, onChangeUiState };
+}
+
+describe("useQueryResults", () => {
+  it("should propagate a successful dataset result", async () => {
+    const successDataset = createMockDataset();
+    const onChangeUiState = jest.fn();
+    const { result } = setup({
+      mockResponse: { dataset: successDataset },
+      onChangeUiState,
+    });
+
+    await result.current.runQuery();
+
+    await waitFor(() => {
+      expect(onChangeUiState).toHaveBeenCalled();
+    });
+
+    const call = onChangeUiState.mock.calls[0][0];
+    expect(call.lastRunResult).toEqual(successDataset);
+    expect(call.lastRunQuery).toEqual(NATIVE_QUERY);
+  });
+
+  it("should propagate error.data as lastRunResult when the API returns a 400", async () => {
+    const onChangeUiState = jest.fn();
+    const { result } = setup({
+      onChangeUiState,
+      mockResponse: { status: 400, dataset: ERROR_DATASET },
+    });
+
+    await result.current.runQuery();
+
+    await waitFor(() => {
+      expect(onChangeUiState).toHaveBeenCalled();
+    });
+
+    const call = onChangeUiState.mock.calls[0][0];
+    expect(call.lastRunResult).toEqual(ERROR_DATASET);
+    expect(call.lastRunResult.error).toBe(
+      'ERROR: syntax error at or near "SELECXT"',
+    );
+    expect(call.lastRunQuery).toEqual(NATIVE_QUERY);
+  });
+});

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailView.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailView.unit.spec.tsx
@@ -293,19 +293,21 @@ describe("ObjectDetailView", () => {
 
   it("fetches a missing row", async () => {
     setupCardDataset({
-      data: {
-        rows: [
-          [
-            "101",
-            "1807963902339",
-            "Extremely Hungry Toucan",
-            "Gizmo",
-            "Larson, Pfeffer and Klocko",
-            31.78621880685793,
-            4.3,
-            "2017-01-09T09:51:20.352-07:00",
+      dataset: {
+        data: {
+          rows: [
+            [
+              "101",
+              "1807963902339",
+              "Extremely Hungry Toucan",
+              "Gizmo",
+              "Larson, Pfeffer and Klocko",
+              31.78621880685793,
+              4.3,
+              "2017-01-09T09:51:20.352-07:00",
+            ],
           ],
-        ],
+        },
       },
     });
 
@@ -335,7 +337,7 @@ describe("ObjectDetailView", () => {
   });
 
   it("shows not found if it can't find a missing row", async () => {
-    setupCardDataset({ data: { rows: [] } });
+    setupCardDataset({ dataset: { data: { rows: [] } } });
 
     // because this row is not in the test dataset, it should trigger a fetch
     setup({ question: mockQuestion, zoomedRowID: "102", zoomedRow: undefined });

--- a/frontend/test/__support__/server-mocks/dataset.ts
+++ b/frontend/test/__support__/server-mocks/dataset.ts
@@ -29,9 +29,19 @@ export function setupParameterSearchValuesEndpoint(
   });
 }
 
-export function setupCardDataset(args: { dataset?: MockDatasetOpts } = {}) {
-  const { dataset } = args;
-  fetchMock.post("path:/api/dataset", createMockDataset(dataset), {
-    name: "dataset-post",
-  });
+export function setupCardDataset(
+  args: {
+    dataset?: MockDatasetOpts;
+    status?: number;
+  } = {},
+) {
+  const { dataset, status = 200 } = args;
+
+  fetchMock.post(
+    "path:/api/dataset",
+    new Response(JSON.stringify(createMockDataset(dataset)), { status }),
+    {
+      name: "dataset-post",
+    },
+  );
 }

--- a/frontend/test/__support__/server-mocks/dataset.ts
+++ b/frontend/test/__support__/server-mocks/dataset.ts
@@ -29,8 +29,9 @@ export function setupParameterSearchValuesEndpoint(
   });
 }
 
-export function setupCardDataset(options: MockDatasetOpts = {}) {
-  fetchMock.post("path:/api/dataset", createMockDataset(options), {
+export function setupCardDataset(args: { dataset?: MockDatasetOpts } = {}) {
+  const { dataset } = args;
+  fetchMock.post("path:/api/dataset", createMockDataset(dataset), {
     name: "dataset-post",
   });
 }


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #71042
Closes https://github.com/metabase/metabase/issues/[issue_number]

### Description

The error from running an adhoc querywas swallowed, instead of being passed to the editor.
I've also updated `setupCardDataset` API call mock, so it accepts also `status` parameter.

### How to verify

Run SQL transform with an error, e.g. `SELECXT 1 as num`

### Demo

https://www.loom.com/share/8c2a88425d99402fb2481619fb3feb45

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
