### PR TITLE
Fix StackOverflowError in deduplicated column name resolution

### DIFF
--- a/src/metabase/lib/field/resolution.cljc
+++ b/src/metabase/lib/field/resolution.cljc
@@ -661,22 +661,25 @@
    stage-number :- :int
    id-or-name   :- ::id-or-name]
   (log/debugf "Resolving %s from previous stage, source table, or source card" (pr-str id-or-name))
-  (let [col (or (resolve-from-previous-stage-or-source* query stage-number id-or-name)
-                (do
-                  (log/debugf "Failed to resolve Field %s in stage %s. Trying other methods..." (pr-str id-or-name) (pr-str stage-number))
-                  (resolve-ref-missing-join-alias query stage-number id-or-name))
-                ;; if we haven't found a match yet try getting metadata from the metadata provider if this is a
-                ;; Field ID ref. It's likely a ref that makes little or no sense (e.g. wrong table) but we can
-                ;; let QP code worry about that.
-                (fallback-metadata-for-field query stage-number id-or-name)
-                ;; try looking in the expressions in this stage to see if someone incorrectly used a field ref for an
-                ;; expression.
-                (maybe-resolve-expression-in-current-stage query stage-number id-or-name)
+  (let [col (or ;; Allow nested dedup resolution for other columns encountered through card resolution,
+                ;; join resolution, etc. Only the direct dedup call below should be blocked by the guard.
+             (binding [*in-deduplicated-column-resolution?* false]
+               (or (resolve-from-previous-stage-or-source* query stage-number id-or-name)
+                   (do
+                     (log/debugf "Failed to resolve Field %s in stage %s. Trying other methods..." (pr-str id-or-name) (pr-str stage-number))
+                     (resolve-ref-missing-join-alias query stage-number id-or-name))
+                      ;; if we haven't found a match yet try getting metadata from the metadata provider if this is a
+                      ;; Field ID ref. It's likely a ref that makes little or no sense (e.g. wrong table) but we can
+                      ;; let QP code worry about that.
+                   (fallback-metadata-for-field query stage-number id-or-name)
+                      ;; try looking in the expressions in this stage to see if someone incorrectly used a field ref for an
+                      ;; expression.
+                   (maybe-resolve-expression-in-current-stage query stage-number id-or-name)))
                 ;; if that fails and this is a deduplicated name like `CATEGORY_2` then try looking for `CATEGORY` and
-                ;; so forth
-                (resolve-nonexistent-deduplicated-column-name query stage-number id-or-name)
+                ;; so forth. The *in-deduplicated-column-resolution?* guard prevents re-entry here.
+             (resolve-nonexistent-deduplicated-column-name query stage-number id-or-name)
                 ;; if we STILL can't find a match, return made-up fallback metadata.
-                (fallback-metadata id-or-name))]
+             (fallback-metadata id-or-name))]
     (when col
       (merge-metadata [col (additional-metadata-from-source-card query stage-number col)]))))
 

--- a/src/metabase/lib/field/resolution.cljc
+++ b/src/metabase/lib/field/resolution.cljc
@@ -630,26 +630,31 @@
 
 (declare resolve-from-previous-stage-or-source)
 
+(def ^:private ^:dynamic *in-deduplicated-column-resolution?* false)
+
 (defn- resolve-nonexistent-deduplicated-column-name
-  "Resolve a ref like `CATEGORY_2` to `CATEGORY` if the query only has the latter."
+  "Resolve a ref like `CATEGORY_2` to `CATEGORY` if the query only has the latter.
+  Uses a dynamic guard to prevent mutual recursion with [[resolve-from-previous-stage-or-source]]
+  which could cause a StackOverflowError for large suffixes (e.g. `name_5000`)."
   [query stage-number id-or-name]
-  (when (string? id-or-name)
+  (when (and (string? id-or-name)
+             (not *in-deduplicated-column-resolution?*))
     (when-let [[_match original-name suffix] (re-matches #"^(\w+)_([1-9]\d*)$" id-or-name)]
-      (let [suffix     (parse-long suffix)
-            new-suffix (dec suffix)
-            ;; e.g. `CATEGORY_3` becomes `CATEGORY_2`; `CATEGORY_2` becomes `CATEGORY`
-            new-name   (if (<= new-suffix 1)
-                         original-name
-                         (str original-name \_ new-suffix))]
-        (log/debugf "Failed to resolve %s, trying to resolve Field %s instead..." (pr-str id-or-name) (pr-str new-name))
-        (let [resolved (resolve-from-previous-stage-or-source query stage-number new-name)]
-          (if (::fallback-metadata? resolved)
-            (do
-              (log/debugf "Failed to resolve %s as %s" (pr-str id-or-name) (pr-str new-name))
-              nil)
-            (do
-              (log/debugf "Successfully resolved %s as %s" (pr-str id-or-name) (pr-str new-name))
-              resolved)))))))
+      (binding [*in-deduplicated-column-resolution?* true]
+        (loop [current-suffix (dec (parse-long suffix))]
+          (let [new-name (if (<= current-suffix 1)
+                           original-name
+                           (str original-name \_ current-suffix))]
+            (log/debugf "Failed to resolve %s, trying to resolve Field %s instead..." (pr-str id-or-name) (pr-str new-name))
+            (let [resolved (resolve-from-previous-stage-or-source query stage-number new-name)]
+              (if (::fallback-metadata? resolved)
+                (do
+                  (log/debugf "Failed to resolve %s as %s" (pr-str id-or-name) (pr-str new-name))
+                  (when (> current-suffix 1)
+                    (recur (dec current-suffix))))
+                (do
+                  (log/debugf "Successfully resolved %s as %s" (pr-str id-or-name) (pr-str new-name))
+                  resolved)))))))))
 
 (mu/defn- resolve-from-previous-stage-or-source :- ::lib.metadata.calculation/visible-column
   [query        :- ::lib.schema/query

--- a/test/metabase/lib/field/resolution_test.cljc
+++ b/test/metabase/lib/field/resolution_test.cljc
@@ -1675,6 +1675,18 @@
                query -1
                [:field {:lib/uuid "00000000-0000-0000-0000-000000000000", :base-type :type/Number} "CATEGORY_3"]))))))
 
+(deftest ^:parallel resolve-deduplicated-column-name-large-suffix-no-stackoverflow-test
+  (testing "Resolving a field with a large numeric suffix should not cause a StackOverflowError (#70952 / GHY-3238)"
+    (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :products))
+                    (lib/append-stage))
+          expected (lib.field.resolution/resolve-field-ref
+                    query -1
+                    [:field {:lib/uuid "00000000-0000-0000-0000-000000000000" :base-type :type/Text} "CATEGORY"])]
+      (is (= expected
+             (lib.field.resolution/resolve-field-ref
+              query -1
+              [:field {:lib/uuid "00000000-0000-0000-0000-000000000000" :base-type :type/Text} "CATEGORY_5000"]))))))
+
 (deftest ^:parallel resolve-in-implicit-join-should-use-source-field-join-alias-test
   (testing "resolve-field-ref should use :source-field-join-alias to disambiguate implicit joins through different explicit joins"
     ;; Two-stage query. Stage 0 has orders with an explicit join to orders ("Orders"),


### PR DESCRIPTION
## Summary
- Fixes startup failure caused by `StackOverflowError` when resolving field refs with large numeric suffixes (e.g. `name_5000`) during analytics content loading
- Adds a `*in-deduplicated-column-resolution?*` dynamic guard and converts the mutual recursion between `resolve-nonexistent-deduplicated-column-name` and `resolve-from-previous-stage-or-source` into a loop
- Previously, resolving `name_5000` created O(N) deep mutual recursion, overflowing the JVM stack at ~3000-4000 frames

Closes #70952
Closes GHY-3238

## Test plan
- [x] Existing `resolution-test` suite passes (54 tests)
- [x] New test verifies `CATEGORY_5000` resolves without StackOverflowError