### PR TITLE
Better error logging for slackbot

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot_v3/agent/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot_v3/agent/core.clj
@@ -521,7 +521,8 @@
                     result))
                 (catch Exception e
                   (prometheus/inc! :metabase-metabot/agent-errors labels)
-                  (when-not (:api-error (ex-data e))
+                  (if (:api-error (ex-data e))
+                    (log/errorf "Agent loop API error: %s" (ex-message e))
                     (log/error e "Agent loop error"))
                   (rf init (error-part e)))
                 (finally

--- a/enterprise/backend/src/metabase_enterprise/slackbot/streaming.clj
+++ b/enterprise/backend/src/metabase_enterprise/slackbot/streaming.clj
@@ -207,6 +207,10 @@
                                               {:type  (:data-type part)
                                                :value (:data part)}))
 
+                                   :error
+                                   (when on-text
+                                     (on-text "Something went wrong. Please try again."))
+
                                    nil)
                                  nil)))]
     (transduce dispatch-xf (constantly nil) nil

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/slack_connect.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/slack_connect.clj
@@ -89,7 +89,8 @@
         (let [final-redirect (or (:redirect-url login-result) "/")
               base-response (-> (response/redirect final-redirect)
                                 (sso/clear-oidc-state-cookie))]
-          (log/infof "Slack authentication successful for user %s" (get-in login-result [:user :email]))
+          (log/infof "Slack authentication successful for user %s"
+                     (get-in login-result [:user-data :email]))
           (if-let [session (:session login-result)]
             (request/set-session-cookies request
                                          base-response


### PR DESCRIPTION
- Logs API errors from within the agent loop
- Handles `:error` data parts during slackbot streaming
- Switches auth logging to use `:user-data` which may fix the `nil`s in the logs