### PR TITLE
update copy and styling of table variable select

### DIFF
--- a/frontend/src/metabase/common/components/LabelWithInfo/LabelWithInfo.module.css
+++ b/frontend/src/metabase/common/components/LabelWithInfo/LabelWithInfo.module.css
@@ -1,4 +1,4 @@
-.SettingRequiredLabel {
+.LabelWithInfo {
   display: flex;
   align-items: center;
   gap: 0.5rem;

--- a/frontend/src/metabase/common/components/LabelWithInfo/LabelWithInfo.tsx
+++ b/frontend/src/metabase/common/components/LabelWithInfo/LabelWithInfo.tsx
@@ -1,0 +1,31 @@
+import type { ReactNode } from "react";
+
+import { HoverCard, Icon, Stack } from "metabase/ui";
+
+import S from "./LabelWithInfo.module.css";
+
+type LabelWithInfoProps = {
+  label: ReactNode;
+  info?: ReactNode;
+  htmlFor?: string;
+};
+
+export function LabelWithInfo({ label, info, htmlFor }: LabelWithInfoProps) {
+  return (
+    <label className={S.LabelWithInfo} htmlFor={htmlFor}>
+      {label}
+      {info && (
+        <HoverCard shadow="xs">
+          <HoverCard.Target>
+            <Icon name="info" />
+          </HoverCard.Target>
+          <HoverCard.Dropdown maw="24rem">
+            <Stack p="md" gap="sm">
+              {info}
+            </Stack>
+          </HoverCard.Dropdown>
+        </HoverCard>
+      )}
+    </label>
+  );
+}

--- a/frontend/src/metabase/common/components/LabelWithInfo/index.ts
+++ b/frontend/src/metabase/common/components/LabelWithInfo/index.ts
@@ -1,0 +1,1 @@
+export { LabelWithInfo } from "./LabelWithInfo";

--- a/frontend/src/metabase/parameters/components/RequiredParamToggle/RequiredParamToggle.tsx
+++ b/frontend/src/metabase/parameters/components/RequiredParamToggle/RequiredParamToggle.tsx
@@ -1,8 +1,7 @@
 import { t } from "ttag";
 
-import { Flex, HoverCard, Icon, Stack, Switch, Text } from "metabase/ui";
-
-import S from "./RequiredParamToggle.module.css";
+import { LabelWithInfo } from "metabase/common/components/LabelWithInfo";
+import { Flex, Switch, Text } from "metabase/ui";
 
 interface RequiredParamToggleProps {
   disabled?: boolean;
@@ -33,21 +32,11 @@ export function RequiredParamToggle(props: RequiredParamToggleProps) {
         onChange={(event) => onChange(event.currentTarget.checked)}
       />
       <div>
-        <label className={S.SettingRequiredLabel} htmlFor={id}>
-          {t`Always require a value`}
-          {disabled && (
-            <HoverCard position="top-end" shadow="xs">
-              <HoverCard.Target>
-                <Icon name="info" />
-              </HoverCard.Target>
-              <HoverCard.Dropdown w={320}>
-                <Stack p="md" gap="sm">
-                  {disabledTooltip}
-                </Stack>
-              </HoverCard.Dropdown>
-            </HoverCard>
-          )}
-        </label>
+        <LabelWithInfo
+          label={t`Always require a value`}
+          info={disabled ? disabledTooltip : undefined}
+          htmlFor={id}
+        />
 
         {parametersAreUserVisible && (
           <Text

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.unit.spec.tsx
@@ -164,11 +164,11 @@ describe("TagEditorParam", () => {
       });
 
       expect(
-        screen.getByRole("switch", { name: /emit table alias/i }),
+        screen.getByRole("switch", { name: /use variable name as alias/i }),
       ).toBeChecked();
 
       await userEvent.click(
-        screen.getByRole("switch", { name: /emit table alias/i }),
+        screen.getByRole("switch", { name: /use variable name as alias/i }),
       );
       expect(setTemplateTag).toHaveBeenLastCalledWith(
         expect.objectContaining({

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParamParts/TableMappingSelect.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParamParts/TableMappingSelect.tsx
@@ -1,7 +1,9 @@
+import { useId } from "react";
 import { t } from "ttag";
 
+import S from "metabase/parameters/components/RequiredParamToggle/RequiredParamToggle.module.css";
 import { SchemaAndTableDataSelector } from "metabase/query_builder/components/DataSelector";
-import { Group, HoverCard, Icon, Switch, Text } from "metabase/ui";
+import { Box, Group, HoverCard, Icon, Switch, Text } from "metabase/ui";
 import type Database from "metabase-lib/v1/metadata/Database";
 import type { TableId, TemplateTag } from "metabase-types/api";
 
@@ -24,6 +26,7 @@ export function TableMappingSelect({
 }: TableMappingSelectProps) {
   const tableId = tag["table-id"];
   const isEmpty = tableId == null;
+  const id = useId();
 
   return (
     <>
@@ -46,27 +49,31 @@ export function TableMappingSelect({
         />
       </InputContainer>
       <InputContainer>
-        <Group gap="xs">
+        <Group gap="sm">
           <Switch
-            id={`emit-alias-toggle-${tag.id}`}
-            label={t`Emit table alias`}
+            id={id}
             checked={tag["emit-alias"] ?? true}
             onChange={(e) => onChangeEmitAlias(e.currentTarget.checked)}
           />
-          <HoverCard>
-            <HoverCard.Target>
-              <Icon
-                c="text-secondary"
-                name="info"
-                data-testid="emit-alias-info-icon"
-              />
-            </HoverCard.Target>
-            <HoverCard.Dropdown>
-              <Text p="md" maw="24rem">
-                {t`When enabled, the table reference will include an alias matching the variable name.`}
-              </Text>
-            </HoverCard.Dropdown>
-          </HoverCard>
+          <Box>
+            <label className={S.SettingRequiredLabel} htmlFor={id}>
+              {t`Use variable name as alias`}
+              <HoverCard>
+                <HoverCard.Target>
+                  <Icon
+                    c="text-secondary"
+                    name="info"
+                    data-testid="emit-alias-info-icon"
+                  />
+                </HoverCard.Target>
+                <HoverCard.Dropdown>
+                  <Text p="md" maw="24rem">
+                    {t`You can refer to this table by the variable name in other parts of the query.`}
+                  </Text>
+                </HoverCard.Dropdown>
+              </HoverCard>
+            </label>
+          </Box>
         </Group>
       </InputContainer>
     </>

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParamParts/TableMappingSelect.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParamParts/TableMappingSelect.tsx
@@ -1,9 +1,9 @@
 import { useId } from "react";
 import { t } from "ttag";
 
-import S from "metabase/parameters/components/RequiredParamToggle/RequiredParamToggle.module.css";
+import { LabelWithInfo } from "metabase/common/components/LabelWithInfo";
 import { SchemaAndTableDataSelector } from "metabase/query_builder/components/DataSelector";
-import { Box, Group, HoverCard, Icon, Switch, Text } from "metabase/ui";
+import { Group, Switch } from "metabase/ui";
 import type Database from "metabase-lib/v1/metadata/Database";
 import type { TableId, TemplateTag } from "metabase-types/api";
 
@@ -55,25 +55,11 @@ export function TableMappingSelect({
             checked={tag["emit-alias"] ?? true}
             onChange={(e) => onChangeEmitAlias(e.currentTarget.checked)}
           />
-          <Box>
-            <label className={S.SettingRequiredLabel} htmlFor={id}>
-              {t`Use variable name as alias`}
-              <HoverCard>
-                <HoverCard.Target>
-                  <Icon
-                    c="text-secondary"
-                    name="info"
-                    data-testid="emit-alias-info-icon"
-                  />
-                </HoverCard.Target>
-                <HoverCard.Dropdown>
-                  <Text p="md" maw="24rem">
-                    {t`You can refer to this table by the variable name in other parts of the query.`}
-                  </Text>
-                </HoverCard.Dropdown>
-              </HoverCard>
-            </label>
-          </Box>
+          <LabelWithInfo
+            label={t`Use variable name as alias`}
+            info={t`You can refer to this table by the variable name in other parts of the query.`}
+            htmlFor={id}
+          />
         </Group>
       </InputContainer>
     </>


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-2030/rename-and-clarify-emit-table-alias-toggle

### Description

Copy updates are self explanatory
For the styling I've re-used pre-existing a bit non standard `<label>` native HTML tag and styles, so it matches other form components in the query variables form.

### How to verify

Go to native transform, create a query `select * from {{t}} limit {{n}}`. Verify if copy and styling matches requirements.

### Demo

![image](https://github.com/user-attachments/assets/4ee56ed8-ea76-4a07-8cc0-d048126273ee)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR