### PR TITLE
Fix pivot text overlapping when next header column is collapsed

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/utils.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/utils.ts
@@ -246,14 +246,14 @@ export const leftHeaderCellSizeAndPositionGetter = (
   leftHeaderWidths: number[],
   rowIndexes: number[],
 ) => {
-  const { offset, span, depth, maxDepthBelow } = item;
+  const { offset, span, depth, maxDepthBelow, isSubtotal } = item;
 
   const columnsToSpan = rowIndexes.length - depth - maxDepthBelow;
 
-  // add up all the widths of the columns, other than itself, that this cell spans
-  const spanWidth = sumArray(
-    leftHeaderWidths.slice(depth + 1, depth + columnsToSpan),
-  );
+  // for subtotals, add up all the widths of the columns, other than itself, that this cell spans
+  const spanWidth = isSubtotal
+    ? sumArray(leftHeaderWidths.slice(depth + 1, depth + columnsToSpan))
+    : 0;
   const columnPadding = depth === 0 ? LEFT_HEADER_LEFT_SPACING : 0;
   const columnWidth = leftHeaderWidths[depth];
 

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/utils.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/utils.unit.spec.ts
@@ -14,6 +14,7 @@ import {
   getLeftHeaderWidths,
   isColumnValid,
   isFormattablePivotColumn,
+  leftHeaderCellSizeAndPositionGetter,
   updateValueWithCurrentColumns,
 } from "./utils";
 
@@ -353,6 +354,35 @@ describe("Visualizations > Visualizations > PivotTable > utils", () => {
         { values: ["bar1", "bar2"], hasSubtotal: false },
         { values: ["baz1"], hasSubtotal: true },
       ]);
+    });
+  });
+
+  describe("leftHeaderCellSizeAndPositionGetter", () => {
+    it("should return the correct width for a subtotal", () => {
+      const result = leftHeaderCellSizeAndPositionGetter(
+        { depth: 1, maxDepthBelow: 0, isSubtotal: true } as HeaderItem,
+        [100, 100, 100],
+        [0, 1, 2],
+      );
+      expect(result.width).toBe(200);
+    });
+
+    it("should return the correct width for a non-subtotal", () => {
+      const result = leftHeaderCellSizeAndPositionGetter(
+        { depth: 1, maxDepthBelow: 1, isSubtotal: false } as HeaderItem,
+        [100, 100, 100],
+        [0, 1, 2],
+      );
+      expect(result.width).toBe(100);
+    });
+
+    it("non-subtotal widths should not increase when columns are collapsed", () => {
+      const result = leftHeaderCellSizeAndPositionGetter(
+        { depth: 1, maxDepthBelow: 0, isSubtotal: false } as HeaderItem,
+        [100, 100, 100],
+        [0, 1, 2],
+      );
+      expect(result.width).toBe(100);
     });
   });
 });


### PR DESCRIPTION
Closes #71013

### Description

Collapsing a pivot header column causes `maxDepthBelow` to decrease by 1 for its parent header columns. This is used to calculate the column width for subtotals but was being incorrectly applied to non-subtotal headers as well.

The fix here is to only allow subtotals to span multiple columns, preventing long text fields from overlapping as seen in #71013.

### How to verify

Follow #71013 and verify the text no longer overlaps.

### Demo

[Loom](https://www.loom.com/share/9b7cd68d47fb43d88dae9b912ce493e0)

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
