### PR TITLE
docs - agent resources for embedding

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -213,6 +213,7 @@ Metabase's reference documentation.
   - [SDK](./embedding/sdk/introduction.md)
 - [Full app embedding](./embedding/full-app-embedding.md)
 - [Securing embeds](./embedding/securing-embeds.md)
+- [AI agent resources](./embedding/ai-agent-resources.md)
 
 ### Configuration
 

--- a/docs/embedding/ai-agent-resources.md
+++ b/docs/embedding/ai-agent-resources.md
@@ -1,6 +1,6 @@
 ---
 title: AI agent resources for embedding
-summary: LLM.txt and agent skills to help AI coding agents with Metabase embedding.
+summary: Agent skills and llms.txt to help AI coding agents embed Metabase in your app.
 ---
 
 # AI agent resources for embedding

--- a/docs/embedding/ai-agent-resources.md
+++ b/docs/embedding/ai-agent-resources.md
@@ -9,7 +9,7 @@ If you use an AI coding agent, you can give the agent Metabase-specific context 
 
 ## llms.txt
 
-Agents can read the docs you're reading now (and many agents have already read our docs), but we also publish llms.txts to that you can give your AI agent:
+Agents can read the docs you're reading now (and many agents have already read our docs), but we also publish llms.txts so that you can give your AI agent:
 
 - [Summary of docs, with links](https://www.metabase.com/docs/llms.txt).
 - [The full docs](https://www.metabase.com/docs/llms-embedding-full.txt).
@@ -28,7 +28,7 @@ The [Metabase agent skills pack](https://github.com/metabase/agent-skills) gives
 | [Static → guest embeds](https://skillsmp.com/skills/metabase-agent-skills-skills-metabase-static-embedding-to-guest-embedding-upgrade-skill-md) | Migrate from static (signed) embeds to guest embeds. |
 | [SSO for embeds](https://skillsmp.com/skills/metabase-agent-skills-skills-metabase-embedding-sso-implementation-skill-md) | Set up SSO authentication for embedded Metabase. _(In development.)_ |
 
-Browse all skills on the [Skills Marketplace](https://skillsmp.com/skills/metabase-agent-skills-skills-metabase-modular-embedding-version-upgrade-skill-md).
+Browse all skills on the [agent skills repo](https://github.com/metabase/agent-skills).
 
 ## Agents are not magic
 

--- a/docs/embedding/ai-agent-resources.md
+++ b/docs/embedding/ai-agent-resources.md
@@ -22,11 +22,11 @@ The [Metabase agent skills pack](https://github.com/metabase/agent-skills) gives
 
 | Skill                           | Description                                                                                  |
 | ------------------------------- | -------------------------------------------------------------------------------------------- |
-| SDK version upgrade             | Upgrade your modular embedding SDK, including changelog checks and breaking change handling. |
-| Full app → modular embedding    | Migrate from full app embedding to modular embedding.                                        |
-| Modular embedding → SDK (React) | Migrate from script-based modular embedding to the React SDK.                                |
-| Static → guest embeds           | Migrate from static (signed) embeds to guest embeds.                                         |
-| SSO for embeds                  | Set up SSO authentication for embedded Metabase. _(In development.)_                         |
+| [SDK version upgrade](https://skillsmp.com/skills/metabase-agent-skills-skills-metabase-modular-embedding-version-upgrade-skill-md) | Upgrade your modular embedding SDK, including changelog checks and breaking change handling. |
+| [Full app → modular embedding](https://skillsmp.com/skills/metabase-agent-skills-skills-metabase-full-app-to-modular-embedding-upgrade-skill-md) | Migrate from full app embedding to modular embedding. |
+| [Modular embedding → SDK (React)](https://skillsmp.com/skills/metabase-agent-skills-skills-metabase-modular-embedding-to-modular-embedding-sdk-upgrade-skill-md) | Migrate from script-based modular embedding to the React SDK. |
+| [Static → guest embeds](https://skillsmp.com/skills/metabase-agent-skills-skills-metabase-static-embedding-to-guest-embedding-upgrade-skill-md) | Migrate from static (signed) embeds to guest embeds. |
+| [SSO for embeds](https://skillsmp.com/skills/metabase-agent-skills-skills-metabase-embedding-sso-implementation-skill-md) | Set up SSO authentication for embedded Metabase. _(In development.)_ |
 
 Browse all skills on the [Skills Marketplace](https://skillsmp.com/skills/metabase-agent-skills-skills-metabase-modular-embedding-version-upgrade-skill-md).
 

--- a/docs/embedding/ai-agent-resources.md
+++ b/docs/embedding/ai-agent-resources.md
@@ -1,0 +1,41 @@
+---
+title: AI agent resources for embedding
+summary: LLM.txt and agent skills to help AI coding agents with Metabase embedding.
+---
+
+# AI agent resources for embedding
+
+If you use an AI coding agent, you can give the agent Metabase-specific context to help with embedding setup, upgrades, and migrations.
+
+## llms.txt
+
+Agents can read the docs you're reading now (and many agents have already read our docs), but we also publish llms.txts to that you can give your AI agent:
+
+- [Summary of docs, with links](https://www.metabase.com/docs/llms.txt).
+- [The full docs](https://www.metabase.com/docs/llms-embedding-full.txt).
+
+## Agent skills
+
+The [Metabase agent skills pack](https://github.com/metabase/agent-skills) gives your AI agent step-by-step playbooks for specific embedding tasks.
+
+### Available skills
+
+| Skill                           | Description                                                                                  |
+| ------------------------------- | -------------------------------------------------------------------------------------------- |
+| SDK version upgrade             | Upgrade your modular embedding SDK, including changelog checks and breaking change handling. |
+| Full app → modular embedding    | Migrate from full app embedding to modular embedding.                                        |
+| Modular embedding → SDK (React) | Migrate from script-based modular embedding to the React SDK.                                |
+| Static → guest embeds           | Migrate from static (signed) embeds to guest embeds.                                         |
+| SSO for embeds                  | Set up SSO authentication for embedded Metabase. _(In development.)_                         |
+
+Browse all skills on the [Skills Marketplace](https://skillsmp.com/skills/metabase-agent-skills-skills-metabase-modular-embedding-version-upgrade-skill-md).
+
+## Agents are not magic
+
+Always review and validate the changes made by a skill. Check that your application builds, tests pass, and the embedding works as expected before committing.
+
+## Further reading
+
+- [Embedding introduction](./introduction.md)
+- [Modular embedding SDK](./sdk/introduction.md)
+- [Upgrading the modular embedding SDK](./sdk/upgrade.md)

--- a/docs/embedding/ai-agent-resources.md
+++ b/docs/embedding/ai-agent-resources.md
@@ -7,18 +7,6 @@ summary: Agent skills and llms.txt to help AI coding agents embed Metabase in yo
 
 If you use an AI coding agent, you can give the agent Metabase-specific context to help with embedding setup, upgrades, and migrations.
 
-## llms.txt
-
-Agents can read the docs you're reading now (and many agents have already read our docs), but we also publish llms.txts so that you can give your AI agent:
-
-- [Summary of embedding docs, with links](https://www.metabase.com/docs/llms.txt).
-- [The full embedding docs](https://www.metabase.com/docs/llms-embedding-full.txt).
-
-If you're on a specific version (e.g., v0.58), you can use versioned llms.txt files scoped to that version's docs:
-
-- `https://www.metabase.com/docs/v0.58/llms.txt`
-- `https://www.metabase.com/docs/v0.58/llms-embedding-full.txt`
-
 ## Agent skills
 
 We've developed some [agent skills](https://github.com/metabase/agent-skills) to give your AI agents step-by-step playbooks for specific embedding tasks.
@@ -35,9 +23,21 @@ We've developed some [agent skills](https://github.com/metabase/agent-skills) to
 
 Browse all skills on the [agent skills repo](https://github.com/metabase/agent-skills).
 
+## llms.txt
+
+Agents can read the docs you're reading now (and many agents have already read our docs), but we also publish llms.txts so that you can give your AI agent:
+
+- [Summary of embedding docs, with links](https://www.metabase.com/docs/llms.txt).
+- [The full embedding docs](https://www.metabase.com/docs/llms-embedding-full.txt).
+
+If you're on a specific version (e.g., v0.58), you can use versioned llms.txt files scoped to that version's docs:
+
+- `https://www.metabase.com/docs/v0.58/llms.txt`
+- `https://www.metabase.com/docs/v0.58/llms-embedding-full.txt`
+
 ## Agents are not magic
 
-Always review and validate the changes made by agents. Check that your application builds, tests pass, and the embedding works as expected before committing.
+Always review and validate the changes made by agents. Check that your application builds, tests pass, and the embedding works as expected before committing anything.
 
 ## Further reading
 

--- a/docs/embedding/ai-agent-resources.md
+++ b/docs/embedding/ai-agent-resources.md
@@ -11,12 +11,12 @@ If you use an AI coding agent, you can give the agent Metabase-specific context 
 
 Agents can read the docs you're reading now (and many agents have already read our docs), but we also publish llms.txts so that you can give your AI agent:
 
-- [Summary of docs, with links](https://www.metabase.com/docs/llms.txt).
-- [The full docs](https://www.metabase.com/docs/llms-embedding-full.txt).
+- [Summary of embedding docs, with links](https://www.metabase.com/docs/llms.txt).
+- [The full embedding docs](https://www.metabase.com/docs/llms-embedding-full.txt).
 
 ## Agent skills
 
-The [Metabase agent skills pack](https://github.com/metabase/agent-skills) gives your AI agent step-by-step playbooks for specific embedding tasks.
+We've developed some [agent skills](https://github.com/metabase/agent-skills) to give your AI agents step-by-step playbooks for specific embedding tasks.
 
 ### Available skills
 
@@ -32,10 +32,11 @@ Browse all skills on the [agent skills repo](https://github.com/metabase/agent-s
 
 ## Agents are not magic
 
-Always review and validate the changes made by a skill. Check that your application builds, tests pass, and the embedding works as expected before committing.
+Always review and validate the changes made by agents. Check that your application builds, tests pass, and the embedding works as expected before committing.
 
 ## Further reading
 
 - [Embedding introduction](./introduction.md)
 - [Modular embedding SDK](./sdk/introduction.md)
 - [Upgrading the modular embedding SDK](./sdk/upgrade.md)
+- [Agent skills repo](https://github.com/metabase/agent-skills)

--- a/docs/embedding/ai-agent-resources.md
+++ b/docs/embedding/ai-agent-resources.md
@@ -14,6 +14,11 @@ Agents can read the docs you're reading now (and many agents have already read o
 - [Summary of embedding docs, with links](https://www.metabase.com/docs/llms.txt).
 - [The full embedding docs](https://www.metabase.com/docs/llms-embedding-full.txt).
 
+If you're on a specific version (e.g., v0.58), you can use versioned llms.txt files scoped to that version's docs:
+
+- `https://www.metabase.com/docs/v0.58/llms.txt`
+- `https://www.metabase.com/docs/v0.58/llms-embedding-full.txt`
+
 ## Agent skills
 
 We've developed some [agent skills](https://github.com/metabase/agent-skills) to give your AI agents step-by-step playbooks for specific embedding tasks.

--- a/docs/embedding/introduction.md
+++ b/docs/embedding/introduction.md
@@ -2,7 +2,7 @@
 title: Embedding introduction
 summary: Different ways you can embed charts and dashboards, or all of Metabase, in your app.
 redirect_from:
-  - /docs/latest/administration-guide/13-embedding
+- /docs/latest/administration-guide/13-embedding
 ---
 
 # Embedding introduction
@@ -67,11 +67,11 @@ If you'd like to share your data with the good people of the internet, admins ca
 | Charts and dashboards                                                                                                | ✅                                   | ✅                                    | ✅                                    | ✅                                  | ✅                                     |
 | [Filter widgets](https://www.metabase.com/glossary/filter-widget)                                                    | ✅                                   | ✅                                    | ✅                                    | ✅                                  | ✅                                     |
 | Export results\*                                                                                                     | ✅                                   | ✅                                    | ✅                                    | ✅                                  | ✅                                     |
-| [Locked filters](./static-embedding-parameters.md#restricting-data-in-a-static-embed-with-locked-parameters)          | ❌                                   | ❌                                    | ✅                                    | ❌                                  | ❌                                     |
+| [Locked filters](./static-embedding-parameters.md#restricting-data-in-a-static-embed-with-locked-parameters)         | ❌                                   | ❌                                    | ✅                                    | ❌                                  | ❌                                     |
 | [Data segregation](../permissions/embedding.md)                                                                      | ✅                                   | ✅                                    | ❌                                    | ✅                                  | ❌                                     |
 | [Drill-through menu](https://www.metabase.com/learn/metabase-basics/querying-and-dashboards/questions/drill-through) | ✅                                   | ✅                                    | ❌                                    | ✅                                  | ❌                                     |
 | [Query builder](../questions/query-builder/editor.md)                                                                | ✅                                   | ✅                                    | ❌                                    | ✅                                  | ❌                                     |
-| [Basic appearance customization](../configuring-metabase/appearance.md)\*\*                                          | ✅                                   | ✅                                    | ✅                                    | ✅                                  | ✅                                     |
+| [Basic appearance customization](../configuring-metabase/appearance.md)\_\_                                          | ✅                                   | ✅                                    | ✅                                    | ✅                                  | ✅                                     |
 | [Advanced theming](./appearance.md)                                                                                  | ✅                                   | ✅                                    | ❌                                    | ❌                                  | ❌                                     |
 | [Usage analytics](../usage-and-performance-tools/usage-analytics.md)                                                 | ✅                                   | ✅                                    | ❌                                    | ✅                                  | ❌                                     |
 | Embed individual Metabase components                                                                                 | ✅                                   | ✅                                    | ❌                                    | ❌                                  | ❌                                     |
@@ -82,7 +82,11 @@ If you'd like to share your data with the good people of the internet, admins ca
 
 \* Each embedding type allows data downloads by default, but only [Pro and Enterprise](https://www.metabase.com/pricing/) plans can disable data downloads.
 
-\*\* Requires a [Pro and Enterprise](https://www.metabase.com/pricing/) plan for any embedding type.
+\_\_ Requires a [Pro and Enterprise](https://www.metabase.com/pricing/) plan for any embedding type.
+
+## Resources for AI agents
+
+If you're using an AI agent to help you embed Metabase in your app, check out [AI agent resources](./ai-agent-resources.md).
 
 ## Further reading
 

--- a/docs/embedding/introduction.md
+++ b/docs/embedding/introduction.md
@@ -2,7 +2,7 @@
 title: Embedding introduction
 summary: Different ways you can embed charts and dashboards, or all of Metabase, in your app.
 redirect_from:
-- /docs/latest/administration-guide/13-embedding
+  - /docs/latest/administration-guide/13-embedding
 ---
 
 # Embedding introduction
@@ -71,7 +71,7 @@ If you'd like to share your data with the good people of the internet, admins ca
 | [Data segregation](../permissions/embedding.md)                                                                      | ✅                                   | ✅                                    | ❌                                    | ✅                                  | ❌                                     |
 | [Drill-through menu](https://www.metabase.com/learn/metabase-basics/querying-and-dashboards/questions/drill-through) | ✅                                   | ✅                                    | ❌                                    | ✅                                  | ❌                                     |
 | [Query builder](../questions/query-builder/editor.md)                                                                | ✅                                   | ✅                                    | ❌                                    | ✅                                  | ❌                                     |
-| [Basic appearance customization](../configuring-metabase/appearance.md)\_\_                                          | ✅                                   | ✅                                    | ✅                                    | ✅                                  | ✅                                     |
+| [Basic appearance customization](../configuring-metabase/appearance.md)\*\*                                          | ✅                                   | ✅                                    | ✅                                    | ✅                                  | ✅                                     |
 | [Advanced theming](./appearance.md)                                                                                  | ✅                                   | ✅                                    | ❌                                    | ❌                                  | ❌                                     |
 | [Usage analytics](../usage-and-performance-tools/usage-analytics.md)                                                 | ✅                                   | ✅                                    | ❌                                    | ✅                                  | ❌                                     |
 | Embed individual Metabase components                                                                                 | ✅                                   | ✅                                    | ❌                                    | ❌                                  | ❌                                     |
@@ -82,7 +82,7 @@ If you'd like to share your data with the good people of the internet, admins ca
 
 \* Each embedding type allows data downloads by default, but only [Pro and Enterprise](https://www.metabase.com/pricing/) plans can disable data downloads.
 
-\_\_ Requires a [Pro and Enterprise](https://www.metabase.com/pricing/) plan for any embedding type.
+\*\* Requires a [Pro and Enterprise](https://www.metabase.com/pricing/) plan for any embedding type.
 
 ## Resources for AI agents
 

--- a/docs/embedding/sdk/upgrade.md
+++ b/docs/embedding/sdk/upgrade.md
@@ -7,6 +7,8 @@ summary: How to upgrade your Metabase and modular embedding SDK versions, test t
 
 Here's a basic overview of the steps you'll want to take when upgrading your SDK.
 
+> **Using an AI coding agent?** The [agent skills pack](../ai-agent-resources.md) includes a skill that walks your agent through SDK upgrades step by step.
+
 ## 1. Read the release post and changelog for Metabase and the modular embedding SDK
 
 - [Release posts](https://www.metabase.com/releases) give a good overview of what's in each release, and call out breaking changes (which are rare).

--- a/docs/embedding/start.md
+++ b/docs/embedding/start.md
@@ -51,3 +51,7 @@ Admins can also create unsecured public links or embeds of questions and dashboa
 ## [Securing embeds](./securing-embeds.md)
 
 How to make sure the right people can see the right data in your embedded Metabase.
+
+## [AI agent resources](./ai-agent-resources.md)
+
+Machine-readable docs and agent skills to help AI coding agents with embedding setup, upgrades, and migrations.


### PR DESCRIPTION
Adds page about agent resources for embedding.

See https://linear.app/metabase/issue/DOC-78/add-llmagent-resources-to-embedding-documentation