### PR TITLE
Hide 'New metric' and 'Publish a table' actions on Data Studio Library empty state when in read-only mode

### DIFF
--- a/e2e/test/scenarios/data-studio/data-studio-library.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-studio-library.cy.spec.ts
@@ -149,6 +149,54 @@ describe("scenarios > data studio > library", () => {
     });
   });
 
+  describe("read-only mode", () => {
+    it("should hide +New button and empty state actions in read-only mode (UXW-3341)", () => {
+      H.restore();
+      cy.signInAsAdmin();
+      H.activateToken("bleeding-edge");
+      H.setupGitSync();
+
+      // Create library first
+      H.createLibrary();
+
+      // Set up git remote sync in read-only mode
+      cy.request("PUT", "/api/setting/remote-sync-enabled", { value: true });
+      cy.request("PUT", "/api/setting/remote-sync-type", {
+        value: "read-only",
+      });
+
+      // Visit library page
+      H.DataStudio.Library.visit();
+
+      cy.log("Verify +New button is not visible");
+      H.DataStudio.Library.newButton().should("not.exist");
+
+      cy.log("Verify Data section empty state action is not visible");
+      H.DataStudio.Library.libraryPage()
+        .findByText("Cleaned, pre-transformed data sources ready for exploring")
+        .should("be.visible");
+      H.DataStudio.Library.libraryPage()
+        .findByRole("button", { name: "Publish a table" })
+        .should("not.exist");
+
+      cy.log("Verify Metrics section empty state action is not visible");
+      H.DataStudio.Library.libraryPage()
+        .findByText("Standardized calculations with known dimensions")
+        .should("be.visible");
+      H.DataStudio.Library.libraryPage()
+        .findByRole("link", { name: "New metric" })
+        .should("not.exist");
+
+      cy.log("Verify SQL snippets section empty state action is not visible");
+      H.DataStudio.Library.libraryPage()
+        .findByText("Reusable bits of code that save your time")
+        .should("be.visible");
+      H.DataStudio.Library.libraryPage()
+        .findByRole("link", { name: "New snippet" })
+        .should("not.exist");
+    });
+  });
+
   describe("empty state", () => {
     it("should show empty states with interactions when sections are empty", () => {
       H.createLibrary();

--- a/e2e/test/scenarios/data-studio/data-studio-library.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-studio-library.cy.spec.ts
@@ -149,54 +149,6 @@ describe("scenarios > data studio > library", () => {
     });
   });
 
-  describe("read-only mode", () => {
-    it("should hide +New button and empty state actions in read-only mode (UXW-3341)", () => {
-      H.restore();
-      cy.signInAsAdmin();
-      H.activateToken("bleeding-edge");
-      H.setupGitSync();
-
-      // Create library first
-      H.createLibrary();
-
-      // Set up git remote sync in read-only mode
-      cy.request("PUT", "/api/setting/remote-sync-enabled", { value: true });
-      cy.request("PUT", "/api/setting/remote-sync-type", {
-        value: "read-only",
-      });
-
-      // Visit library page
-      H.DataStudio.Library.visit();
-
-      cy.log("Verify +New button is not visible");
-      H.DataStudio.Library.newButton().should("not.exist");
-
-      cy.log("Verify Data section empty state action is not visible");
-      H.DataStudio.Library.libraryPage()
-        .findByText("Cleaned, pre-transformed data sources ready for exploring")
-        .should("be.visible");
-      H.DataStudio.Library.libraryPage()
-        .findByRole("button", { name: "Publish a table" })
-        .should("not.exist");
-
-      cy.log("Verify Metrics section empty state action is not visible");
-      H.DataStudio.Library.libraryPage()
-        .findByText("Standardized calculations with known dimensions")
-        .should("be.visible");
-      H.DataStudio.Library.libraryPage()
-        .findByRole("link", { name: "New metric" })
-        .should("not.exist");
-
-      cy.log("Verify SQL snippets section empty state action is not visible");
-      H.DataStudio.Library.libraryPage()
-        .findByText("Reusable bits of code that save your time")
-        .should("be.visible");
-      H.DataStudio.Library.libraryPage()
-        .findByRole("link", { name: "New snippet" })
-        .should("not.exist");
-    });
-  });
-
   describe("empty state", () => {
     it("should show empty states with interactions when sections are empty", () => {
       H.createLibrary();
@@ -285,6 +237,47 @@ describe("scenarios > data studio > library", () => {
       H.DataStudio.Library.libraryPage()
         .findByText("Reusable bits of code that save your time")
         .should("be.visible");
+    });
+
+    describe("read-only mode", () => {
+      beforeEach(() => {
+        H.setupGitSync();
+        H.configureGit("read-only");
+        H.createLibrary();
+      });
+
+      it("should hide +New button and empty state actions in read-only mode (UXW-3341)", () => {
+        H.DataStudio.Library.visit();
+
+        cy.log("Verify +New button is not visible");
+        H.DataStudio.Library.newButton().should("not.exist");
+
+        cy.log("Verify Data section empty state action is not visible");
+        H.DataStudio.Library.libraryPage()
+          .findByText(
+            "Cleaned, pre-transformed data sources ready for exploring",
+          )
+          .should("be.visible");
+        H.DataStudio.Library.libraryPage()
+          .findByRole("button", { name: "Publish a table" })
+          .should("not.exist");
+
+        cy.log("Verify Metrics section empty state action is not visible");
+        H.DataStudio.Library.libraryPage()
+          .findByText("Standardized calculations with known dimensions")
+          .should("be.visible");
+        H.DataStudio.Library.libraryPage()
+          .findByRole("link", { name: "New metric" })
+          .should("not.exist");
+
+        cy.log("Verify SQL snippets section empty state action is not visible");
+        H.DataStudio.Library.libraryPage()
+          .findByText("Reusable bits of code that save your time")
+          .should("be.visible");
+        H.DataStudio.Library.libraryPage()
+          .findByRole("link", { name: "New snippet" })
+          .should("not.exist");
+      });
     });
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/LibrarySectionLayout/LibrarySectionLayout.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/LibrarySectionLayout/LibrarySectionLayout.tsx
@@ -22,10 +22,10 @@ import {
 import type { ExpandedState } from "metabase/data-studio/data-model/components/TablePicker/types";
 import { LibraryUpsellPage } from "metabase/data-studio/upsells/pages";
 import { usePageTitle } from "metabase/hooks/use-page-title";
+import { useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
 import { PLUGIN_SNIPPET_FOLDERS } from "metabase/plugins";
 import { useRouter } from "metabase/router";
-import { useSelector } from "metabase/lib/redux";
 import { ListEmptyState } from "metabase/transforms/components/ListEmptyState";
 import {
   Anchor,
@@ -41,8 +41,8 @@ import {
   TreeTableSkeleton,
   useTreeTableInstance,
 } from "metabase/ui";
-import type { Collection, CollectionId } from "metabase-types/api";
 import { getIsRemoteSyncReadOnly } from "metabase-enterprise/remote_sync/selectors";
+import type { Collection, CollectionId } from "metabase-types/api";
 
 import { LibraryEmptyState } from "../components/LibraryEmptyState";
 
@@ -58,13 +58,6 @@ interface EmptyStateActionProps {
 }
 
 function EmptyStateAction({ data, onPublishTable }: EmptyStateActionProps) {
-  const remoteSyncReadOnly = useSelector(getIsRemoteSyncReadOnly);
-
-  // Don't show any actions in read-only mode
-  if (remoteSyncReadOnly) {
-    return null;
-  }
-
   if (data.sectionType === "data") {
     return (
       <Anchor
@@ -117,6 +110,7 @@ function LibrarySectionContent() {
     useState<CollectionId | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
   const [isPublishTableModalOpen, setIsPublishTableModalOpen] = useState(false);
+  const isRemoteSyncReadOnly = useSelector(getIsRemoteSyncReadOnly);
 
   const expandedIdsFromUrl = useMemo(() => {
     const rawIds = location.query?.expandedId;
@@ -263,10 +257,12 @@ function LibrarySectionContent() {
                 <Text c="text-tertiary" fz="inherit">
                   {data.description}
                 </Text>
-                <EmptyStateAction
-                  data={data}
-                  onPublishTable={() => setIsPublishTableModalOpen(true)}
-                />
+                {!isRemoteSyncReadOnly && (
+                  <EmptyStateAction
+                    data={data}
+                    onPublishTable={() => setIsPublishTableModalOpen(true)}
+                  />
+                )}
               </Flex>
             );
           }
@@ -330,7 +326,7 @@ function LibrarySectionContent() {
         },
       },
     ],
-    [setIsPublishTableModalOpen],
+    [setIsPublishTableModalOpen, isRemoteSyncReadOnly],
   );
 
   const getRowHref = useCallback(

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/LibrarySectionLayout/LibrarySectionLayout.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/LibrarySectionLayout/LibrarySectionLayout.tsx
@@ -25,6 +25,7 @@ import { usePageTitle } from "metabase/hooks/use-page-title";
 import * as Urls from "metabase/lib/urls";
 import { PLUGIN_SNIPPET_FOLDERS } from "metabase/plugins";
 import { useRouter } from "metabase/router";
+import { useSelector } from "metabase/lib/redux";
 import { ListEmptyState } from "metabase/transforms/components/ListEmptyState";
 import {
   Anchor,
@@ -41,6 +42,7 @@ import {
   useTreeTableInstance,
 } from "metabase/ui";
 import type { Collection, CollectionId } from "metabase-types/api";
+import { getIsRemoteSyncReadOnly } from "metabase-enterprise/remote_sync/selectors";
 
 import { LibraryEmptyState } from "../components/LibraryEmptyState";
 
@@ -56,6 +58,13 @@ interface EmptyStateActionProps {
 }
 
 function EmptyStateAction({ data, onPublishTable }: EmptyStateActionProps) {
+  const remoteSyncReadOnly = useSelector(getIsRemoteSyncReadOnly);
+
+  // Don't show any actions in read-only mode
+  if (remoteSyncReadOnly) {
+    return null;
+  }
+
   if (data.sectionType === "data") {
     return (
       <Anchor

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/LibrarySectionLayout/hooks.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/LibrarySectionLayout/hooks.ts
@@ -10,7 +10,9 @@ import type {
 } from "metabase/data-studio/common/types";
 import { createEmptyStateItem } from "metabase/data-studio/common/utils";
 import { getIcon } from "metabase/lib/icon";
+import { useSelector } from "metabase/lib/redux";
 import { useMetadataToasts } from "metabase/metadata/hooks";
+import { getIsRemoteSyncReadOnly } from "metabase-enterprise/remote_sync/selectors";
 import type { Collection, CollectionId } from "metabase-types/api";
 
 export const useBuildTreeForCollection = (
@@ -29,6 +31,7 @@ export const useBuildTreeForCollection = (
   } = useListCollectionItemsQuery(
     collection ? { id: collection.id, models: ["metric", "table"] } : skipToken,
   );
+  const isRemoteSyncReadOnly = useSelector(getIsRemoteSyncReadOnly);
 
   return useMemo(() => {
     if (isLoading || !items || !collection) {
@@ -49,7 +52,13 @@ export const useBuildTreeForCollection = (
           id: `${item.model}:${item.id}`,
           model: item.model,
         }))
-      : [createEmptyStateItem(sectionType, metricCollectionId)];
+      : [
+          createEmptyStateItem(
+            sectionType,
+            metricCollectionId,
+            isRemoteSyncReadOnly,
+          ),
+        ];
 
     return {
       isLoading,
@@ -65,7 +74,15 @@ export const useBuildTreeForCollection = (
         },
       ],
     };
-  }, [isLoading, items, collection, error, sectionType, metricCollectionId]);
+  }, [
+    isLoading,
+    items,
+    collection,
+    error,
+    sectionType,
+    metricCollectionId,
+    isRemoteSyncReadOnly,
+  ]);
 };
 
 export const useErrorHandling = (_error: unknown) => {


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/UXW-3341/read-only-instances-still-allow-metric-creation-and-table-publishing

### Description

on Data Studio > Library, when we show the empty state, we should hide the "New" buttons when remote sync is set to read-only mode. Today we are still showing the 'Publish a table' and 'New metric' buttons when we shouldn't.

### How to verify

1. Enable remote sync in read-only mode (Admin > Settings > Remote Sync)
2. Go to Data Studio > Library
3. All three empty state sections should show their descriptions but no action links

### Demo

| Before | After |
|--------|--------|
| <img width="1006" height="519" alt="image" src="https://github.com/user-attachments/assets/e57aa01e-742a-4de3-a6cd-93364907c8bc" /> | <img width="1006" height="519" alt="image" src="https://github.com/user-attachments/assets/ff20e19e-083e-48ab-89ea-a135d59efe32" /> | 

### Checklist

- [x] Tests have been added/updated to cover changes in this PR