### PR TITLE
Use official images

### DIFF
--- a/.github/workflows/app-db.yml
+++ b/.github/workflows/app-db.yml
@@ -60,7 +60,7 @@ jobs:
           # MYSQL_* isn't supported on :latest aka 12.2.2
           # MARIADB_* isn't supported on 10.2.23
           # Send both until we upgrade to 10.6+ then remove MYSQL_*
-          MYSQL_ALLOW_EMPTY_ROOT_PASSWORD: true
+          MYSQL_ALLOW_EMPTY_PASSWORD: true
           MYSQL_DATABASE: mb_test
           MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: true
           MARIADB_DATABASE: mb_test

--- a/.github/workflows/app-db.yml
+++ b/.github/workflows/app-db.yml
@@ -57,7 +57,7 @@ jobs:
         ports:
           - "3306:3306"
         env:
-          MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: true
+          MYSQL_ALLOW_EMPTY_ROOT_PASSWORD: true
           MARIADB_DATABASE: mb_test
     env:
       # Only run old migrations tests on pushes to master or release branches. All other branches should skip tests

--- a/.github/workflows/app-db.yml
+++ b/.github/workflows/app-db.yml
@@ -22,7 +22,7 @@ jobs:
         version:
           - name: MariaDB 10.2
             junit-name: be-tests-mariadb-10-2-ee
-            image: mariadb:10.2.23
+            image: metabase/mariadb:10.2.23
             env:
               enable-ssl-tests: 'false'
           - name: MariaDB Latest

--- a/.github/workflows/app-db.yml
+++ b/.github/workflows/app-db.yml
@@ -57,7 +57,7 @@ jobs:
         ports:
           - "3306:3306"
         env:
-          MYSQL_ALLOW_EMPTY_ROOT_PASSWORD: true
+          MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: true
           MARIADB_DATABASE: mb_test
     env:
       # Only run old migrations tests on pushes to master or release branches. All other branches should skip tests

--- a/.github/workflows/app-db.yml
+++ b/.github/workflows/app-db.yml
@@ -57,6 +57,11 @@ jobs:
         ports:
           - "3306:3306"
         env:
+          # MYSQL_* isn't supported on :latest aka 12.2.2
+          # MARIADB_* isn't supported on 10.2.23
+          # Send both until we upgrade to 10.6+ then remove MYSQL_*
+          MYSQL_ALLOW_EMPTY_ROOT_PASSWORD: true
+          MYSQL_DATABASE: mb_test
           MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: true
           MARIADB_DATABASE: mb_test
     env:

--- a/.github/workflows/app-db.yml
+++ b/.github/workflows/app-db.yml
@@ -22,12 +22,12 @@ jobs:
         version:
           - name: MariaDB 10.2
             junit-name: be-tests-mariadb-10-2-ee
-            image: circleci/mariadb:10.2.23
+            image: mariadb:10.2.23
             env:
               enable-ssl-tests: 'false'
           - name: MariaDB Latest
             junit-name: be-tests-mariadb-latest-ee
-            image: circleci/mariadb:latest
+            image: mariadb:latest
             env:
               enable-ssl-tests: 'false'
         job:
@@ -136,7 +136,7 @@ jobs:
         version:
           - name: MySQL 8.0
             junit-name: be-tests-mysql-8-0-ee
-            image: cimg/mysql:8.0
+            image: mysql:8.0
             env:
               enable-ssl-tests: 'false'
               enable-aws-iam-tests: 'false'

--- a/.github/workflows/app-db.yml
+++ b/.github/workflows/app-db.yml
@@ -57,8 +57,8 @@ jobs:
         ports:
           - "3306:3306"
         env:
-          MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: true
-          MARIADB_DATABASE: mb_test
+          MYSQL_ALLOW_EMPTY_PASSWORD: true
+          MYSQL_DATABASE: circle_test
     env:
       # Only run old migrations tests on pushes to master or release branches. All other branches should skip tests
       # with the tag `mb/old-migrations-test`. `__ADDITIONAL_EXCLUDED_TAG__` is not used anywhere outside of splicing
@@ -81,7 +81,7 @@ jobs:
       MB_DB_TYPE: mysql
       MB_DB_HOST: localhost
       MB_DB_PORT: 3306
-      MB_DB_DBNAME: mb_test
+      MB_DB_DBNAME: circle_test
       MB_DB_USER: root
       MB_MYSQL_TEST_USER: root
       #
@@ -174,7 +174,7 @@ jobs:
           - "3306:3306"
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: true
-          MYSQL_DATABASE: mb_test
+          MYSQL_DATABASE: circle_test
     env:
       # Only run old migrations tests on pushes to master or release branches. All other branches should skip tests
       # with the tag `mb/old-migrations-test`. `__ADDITIONAL_EXCLUDED_TAG__` is not used anywhere outside of splicing
@@ -197,7 +197,7 @@ jobs:
       MB_DB_TYPE: mysql
       MB_DB_HOST: localhost
       MB_DB_PORT: 3306
-      MB_DB_DBNAME: mb_test
+      MB_DB_DBNAME: circle_test
       MB_DB_USER: root
       MB_MYSQL_TEST_USER: root
       #

--- a/.github/workflows/app-db.yml
+++ b/.github/workflows/app-db.yml
@@ -57,8 +57,8 @@ jobs:
         ports:
           - "3306:3306"
         env:
-          MYSQL_ALLOW_EMPTY_PASSWORD: true
-          MYSQL_DATABASE: circle_test
+          MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: true
+          MARIADB_DATABASE: mb_test
     env:
       # Only run old migrations tests on pushes to master or release branches. All other branches should skip tests
       # with the tag `mb/old-migrations-test`. `__ADDITIONAL_EXCLUDED_TAG__` is not used anywhere outside of splicing
@@ -81,7 +81,7 @@ jobs:
       MB_DB_TYPE: mysql
       MB_DB_HOST: localhost
       MB_DB_PORT: 3306
-      MB_DB_DBNAME: circle_test
+      MB_DB_DBNAME: mb_test
       MB_DB_USER: root
       MB_MYSQL_TEST_USER: root
       #
@@ -174,7 +174,7 @@ jobs:
           - "3306:3306"
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: true
-          MYSQL_DATABASE: circle_test
+          MYSQL_DATABASE: mb_test
     env:
       # Only run old migrations tests on pushes to master or release branches. All other branches should skip tests
       # with the tag `mb/old-migrations-test`. `__ADDITIONAL_EXCLUDED_TAG__` is not used anywhere outside of splicing
@@ -197,7 +197,7 @@ jobs:
       MB_DB_TYPE: mysql
       MB_DB_HOST: localhost
       MB_DB_PORT: 3306
-      MB_DB_DBNAME: circle_test
+      MB_DB_DBNAME: mb_test
       MB_DB_USER: root
       MB_MYSQL_TEST_USER: root
       #

--- a/.github/workflows/cross-branch-migrations.yml
+++ b/.github/workflows/cross-branch-migrations.yml
@@ -46,16 +46,16 @@ jobs:
       MB_DB_TYPE: postgres
       MB_DB_PORT: 5432
       MB_DB_HOST: localhost
-      MB_DB_DBNAME: mb_test
-      MB_DB_USER: mb_test
+      MB_DB_DBNAME: circle_test
+      MB_DB_USER: circle_test
     services:
       postgres:
         image: postgres:12-alpine
         ports:
           - "5432:5432"
         env:
-          POSTGRES_USER: mb_test
-          POSTGRES_DB: mb_test
+          POSTGRES_USER: circle_test
+          POSTGRES_DB: circle_test
           POSTGRES_HOST_AUTH_METHOD: trust
     steps:
       - uses: actions/checkout@v4
@@ -72,16 +72,16 @@ jobs:
       MB_DB_TYPE: postgres
       MB_DB_PORT: 5432
       MB_DB_HOST: localhost
-      MB_DB_DBNAME: mb_test
-      MB_DB_USER: mb_test
+      MB_DB_DBNAME: circle_test
+      MB_DB_USER: circle_test
     services:
       postgres:
         image: postgres:latest
         ports:
           - "5432:5432"
         env:
-          POSTGRES_USER: mb_test
-          POSTGRES_DB: mb_test
+          POSTGRES_USER: circle_test
+          POSTGRES_DB: circle_test
           POSTGRES_HOST_AUTH_METHOD: trust
     steps:
       - uses: actions/checkout@v4
@@ -98,16 +98,13 @@ jobs:
       MB_DB_TYPE: mysql
       MB_DB_HOST: localhost
       MB_DB_PORT: 3306
-      MB_DB_DBNAME: mb_test
+      MB_DB_DBNAME: circle_test
       MB_DB_USER: root
     services:
       mysql:
         image: mysql:8.0
         ports:
           - "3306:3306"
-        env:
-          MYSQL_ALLOW_EMPTY_PASSWORD: true
-          MYSQL_DATABASE: mb_test
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/cross-branch-migration-test
@@ -123,7 +120,7 @@ jobs:
       MB_DB_TYPE: mysql
       MB_DB_HOST: localhost
       MB_DB_PORT: 3306
-      MB_DB_DBNAME: mb_test
+      MB_DB_DBNAME: circle_test
       MB_DB_USER: root
       MB_MYSQL_TEST_USER: root
     services:
@@ -131,7 +128,7 @@ jobs:
         image: mysql:latest
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: true
-          MYSQL_DATABASE: mb_test
+          MYSQL_DATABASE: circle_test
         ports:
           - "3306:3306"
     steps:
@@ -149,16 +146,13 @@ jobs:
       MB_DB_TYPE: mysql
       MB_DB_HOST: localhost
       MB_DB_PORT: 3306
-      MB_DB_DBNAME: mb_test
+      MB_DB_DBNAME: circle_test
       MB_DB_USER: root
     services:
       mariadb:
         image: mariadb:10.2.23
         ports:
           - "3306:3306"
-        env:
-          MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: true
-          MARIADB_DATABASE: mb_test
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/cross-branch-migration-test
@@ -174,16 +168,13 @@ jobs:
       MB_DB_TYPE: mysql
       MB_DB_HOST: localhost
       MB_DB_PORT: 3306
-      MB_DB_DBNAME: mb_test
+      MB_DB_DBNAME: circle_test
       MB_DB_USER: root
     services:
       mariadb:
         image: mariadb:latest
         ports:
           - "3306:3306"
-        env:
-          MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: true
-          MARIADB_DATABASE: mb_test
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/cross-branch-migration-test

--- a/.github/workflows/cross-branch-migrations.yml
+++ b/.github/workflows/cross-branch-migrations.yml
@@ -157,7 +157,7 @@ jobs:
         ports:
           - "3306:3306"
         env:
-          MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: true
+          MYSQL_ALLOW_EMPTY_ROOT_PASSWORD: true
           MARIADB_DATABASE: mb_test
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/cross-branch-migrations.yml
+++ b/.github/workflows/cross-branch-migrations.yml
@@ -150,7 +150,7 @@ jobs:
       MB_DB_USER: root
     services:
       mariadb:
-        image: mariadb:10.2.23
+        image: metabase/mariadb:10.2.23
         ports:
           - "3306:3306"
     steps:

--- a/.github/workflows/cross-branch-migrations.yml
+++ b/.github/workflows/cross-branch-migrations.yml
@@ -76,7 +76,7 @@ jobs:
       MB_DB_USER: circle_test
     services:
       postgres:
-        image: circleci/postgres:latest
+        image: postgres:latest
         ports:
           - "5432:5432"
         env:
@@ -102,7 +102,7 @@ jobs:
       MB_DB_USER: root
     services:
       mysql:
-        image: cimg/mysql:8.0
+        image: mysql:8.0
         ports:
           - "3306:3306"
     steps:
@@ -150,7 +150,7 @@ jobs:
       MB_DB_USER: root
     services:
       mariadb:
-        image: circleci/mariadb:10.2.23
+        image: mariadb:10.2.23
         ports:
           - "3306:3306"
     steps:
@@ -172,7 +172,7 @@ jobs:
       MB_DB_USER: root
     services:
       mariadb:
-        image: circleci/mariadb:latest
+        image: mariadb:latest
         ports:
           - "3306:3306"
     steps:

--- a/.github/workflows/cross-branch-migrations.yml
+++ b/.github/workflows/cross-branch-migrations.yml
@@ -157,7 +157,7 @@ jobs:
         ports:
           - "3306:3306"
         env:
-          MYSQL_ALLOW_EMPTY_ROOT_PASSWORD: true
+          MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: true
           MARIADB_DATABASE: mb_test
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/cross-branch-migrations.yml
+++ b/.github/workflows/cross-branch-migrations.yml
@@ -46,16 +46,16 @@ jobs:
       MB_DB_TYPE: postgres
       MB_DB_PORT: 5432
       MB_DB_HOST: localhost
-      MB_DB_DBNAME: circle_test
-      MB_DB_USER: circle_test
+      MB_DB_DBNAME: mb_test
+      MB_DB_USER: mb_test
     services:
       postgres:
         image: postgres:12-alpine
         ports:
           - "5432:5432"
         env:
-          POSTGRES_USER: circle_test
-          POSTGRES_DB: circle_test
+          POSTGRES_USER: mb_test
+          POSTGRES_DB: mb_test
           POSTGRES_HOST_AUTH_METHOD: trust
     steps:
       - uses: actions/checkout@v4
@@ -72,16 +72,16 @@ jobs:
       MB_DB_TYPE: postgres
       MB_DB_PORT: 5432
       MB_DB_HOST: localhost
-      MB_DB_DBNAME: circle_test
-      MB_DB_USER: circle_test
+      MB_DB_DBNAME: mb_test
+      MB_DB_USER: mb_test
     services:
       postgres:
         image: postgres:latest
         ports:
           - "5432:5432"
         env:
-          POSTGRES_USER: circle_test
-          POSTGRES_DB: circle_test
+          POSTGRES_USER: mb_test
+          POSTGRES_DB: mb_test
           POSTGRES_HOST_AUTH_METHOD: trust
     steps:
       - uses: actions/checkout@v4
@@ -98,13 +98,16 @@ jobs:
       MB_DB_TYPE: mysql
       MB_DB_HOST: localhost
       MB_DB_PORT: 3306
-      MB_DB_DBNAME: circle_test
+      MB_DB_DBNAME: mb_test
       MB_DB_USER: root
     services:
       mysql:
         image: mysql:8.0
         ports:
           - "3306:3306"
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: true
+          MYSQL_DATABASE: mb_test
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/cross-branch-migration-test
@@ -120,7 +123,7 @@ jobs:
       MB_DB_TYPE: mysql
       MB_DB_HOST: localhost
       MB_DB_PORT: 3306
-      MB_DB_DBNAME: circle_test
+      MB_DB_DBNAME: mb_test
       MB_DB_USER: root
       MB_MYSQL_TEST_USER: root
     services:
@@ -128,7 +131,7 @@ jobs:
         image: mysql:latest
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: true
-          MYSQL_DATABASE: circle_test
+          MYSQL_DATABASE: mb_test
         ports:
           - "3306:3306"
     steps:
@@ -146,13 +149,16 @@ jobs:
       MB_DB_TYPE: mysql
       MB_DB_HOST: localhost
       MB_DB_PORT: 3306
-      MB_DB_DBNAME: circle_test
+      MB_DB_DBNAME: mb_test
       MB_DB_USER: root
     services:
       mariadb:
         image: mariadb:10.2.23
         ports:
           - "3306:3306"
+        env:
+          MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: true
+          MARIADB_DATABASE: mb_test
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/cross-branch-migration-test
@@ -168,13 +174,16 @@ jobs:
       MB_DB_TYPE: mysql
       MB_DB_HOST: localhost
       MB_DB_PORT: 3306
-      MB_DB_DBNAME: circle_test
+      MB_DB_DBNAME: mb_test
       MB_DB_USER: root
     services:
       mariadb:
         image: mariadb:latest
         ports:
           - "3306:3306"
+        env:
+          MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: true
+          MARIADB_DATABASE: mb_test
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/cross-branch-migration-test

--- a/.github/workflows/drivers-stress-test.yml
+++ b/.github/workflows/drivers-stress-test.yml
@@ -124,7 +124,7 @@ jobs:
       MB_MYSQL_TEST_USER: root
     services:
       mariadb:
-        image: circleci/mariadb:10.2.23
+        image: mariadb:10.2.23
         ports:
           - "3306:3306"
     steps:
@@ -150,7 +150,7 @@ jobs:
       MB_MYSQL_TEST_USER: root
     services:
       mariadb:
-        image: circleci/mariadb:latest
+        image: mariadb:latest
         ports:
           - "3306:3306"
     steps:
@@ -284,7 +284,7 @@ jobs:
       MB_MONGO_TEST_PASSWORD: metasample123
     services:
       mongodb:
-        image: circleci/mongo:latest
+        image: mongo:latest
         ports:
           - "27017:27017"
         env:
@@ -313,7 +313,7 @@ jobs:
       MB_MYSQL_TEST_USER: root
     services:
       mysql:
-        image: cimg/mysql:8.0
+        image: mysql:8.0
         ports:
           - "3306:3306"
     steps:
@@ -471,7 +471,7 @@ jobs:
       MB_POSTGRES_SSL_TEST_SSL_ROOT_CERT_PATH: 'test-resources/certificates/us-east-2-bundle.pem'
     services:
       postgres:
-        image: circleci/postgres:latest
+        image: postgres:latest
         ports:
           - "5432:5432"
         env:

--- a/.github/workflows/drivers-stress-test.yml
+++ b/.github/workflows/drivers-stress-test.yml
@@ -128,7 +128,7 @@ jobs:
         ports:
           - "3306:3306"
         env:
-          MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: true
+          MYSQL_ALLOW_EMPTY_ROOT_PASSWORD: true
           MARIADB_DATABASE: mb_test
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/drivers-stress-test.yml
+++ b/.github/workflows/drivers-stress-test.yml
@@ -119,7 +119,7 @@ jobs:
       MB_DB_TYPE: mysql
       MB_DB_HOST: localhost
       MB_DB_PORT: 3306
-      MB_DB_DBNAME: mb_test
+      MB_DB_DBNAME: circle_test
       MB_DB_USER: root
       MB_MYSQL_TEST_USER: root
     services:
@@ -127,9 +127,6 @@ jobs:
         image: mariadb:10.2.23
         ports:
           - "3306:3306"
-        env:
-          MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: true
-          MARIADB_DATABASE: mb_test
     steps:
     - uses: actions/checkout@v4
     - name: Test MariaDB driver (10.2)
@@ -148,7 +145,7 @@ jobs:
       MB_DB_TYPE: mysql
       MB_DB_HOST: localhost
       MB_DB_PORT: 3306
-      MB_DB_DBNAME: mb_test
+      MB_DB_DBNAME: circle_test
       MB_DB_USER: root
       MB_MYSQL_TEST_USER: root
     services:
@@ -156,9 +153,6 @@ jobs:
         image: mariadb:latest
         ports:
           - "3306:3306"
-        env:
-          MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: true
-          MARIADB_DATABASE: mb_test
     steps:
     - uses: actions/checkout@v4
     - name: Test MariaDB driver (latest)
@@ -314,7 +308,7 @@ jobs:
       MB_DB_TYPE: mysql
       MB_DB_HOST: localhost
       MB_DB_PORT: 3306
-      MB_DB_DBNAME: mb_test
+      MB_DB_DBNAME: circle_test
       MB_DB_USER: root
       MB_MYSQL_TEST_USER: root
     services:
@@ -322,9 +316,6 @@ jobs:
         image: mysql:8.0
         ports:
           - "3306:3306"
-        env:
-          MYSQL_ALLOW_EMPTY_PASSWORD: true
-          MYSQL_DATABASE: mb_test
     steps:
     - uses: actions/checkout@v4
     - name: Test MySQL driver (8.0)
@@ -343,7 +334,7 @@ jobs:
       MB_DB_TYPE: mysql
       MB_DB_HOST: localhost
       MB_DB_PORT: 3306
-      MB_DB_DBNAME: mb_test
+      MB_DB_DBNAME: circle_test
       MB_DB_USER: root
       MB_MYSQL_TEST_USER: root
       # set up env vars for something named "MYSQL_SSL" to run MySQL SSL tests verifying connectivity with PEM cert
@@ -472,9 +463,9 @@ jobs:
       MB_DB_TYPE: postgres
       MB_DB_PORT: 5432
       MB_DB_HOST: localhost
-      MB_DB_DBNAME: mb_test
-      MB_DB_USER: mb_test
-      MB_POSTGRESQL_TEST_USER: mb_test
+      MB_DB_DBNAME: circle_test
+      MB_DB_USER: circle_test
+      MB_POSTGRESQL_TEST_USER: circle_test
       MB_POSTGRES_SSL_TEST_SSL: true
       MB_POSTGRES_SSL_TEST_SSL_MODE: verify-full
       MB_POSTGRES_SSL_TEST_SSL_ROOT_CERT_PATH: 'test-resources/certificates/us-east-2-bundle.pem'
@@ -484,8 +475,8 @@ jobs:
         ports:
           - "5432:5432"
         env:
-          POSTGRES_USER: mb_test
-          POSTGRES_DB: mb_test
+          POSTGRES_USER: circle_test
+          POSTGRES_DB: circle_test
           POSTGRES_HOST_AUTH_METHOD: trust
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/drivers-stress-test.yml
+++ b/.github/workflows/drivers-stress-test.yml
@@ -124,7 +124,7 @@ jobs:
       MB_MYSQL_TEST_USER: root
     services:
       mariadb:
-        image: mariadb:10.2.23
+        image: metabase/mariadb:10.2.23
         ports:
           - "3306:3306"
     steps:

--- a/.github/workflows/drivers-stress-test.yml
+++ b/.github/workflows/drivers-stress-test.yml
@@ -119,7 +119,7 @@ jobs:
       MB_DB_TYPE: mysql
       MB_DB_HOST: localhost
       MB_DB_PORT: 3306
-      MB_DB_DBNAME: circle_test
+      MB_DB_DBNAME: mb_test
       MB_DB_USER: root
       MB_MYSQL_TEST_USER: root
     services:
@@ -127,6 +127,9 @@ jobs:
         image: mariadb:10.2.23
         ports:
           - "3306:3306"
+        env:
+          MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: true
+          MARIADB_DATABASE: mb_test
     steps:
     - uses: actions/checkout@v4
     - name: Test MariaDB driver (10.2)
@@ -145,7 +148,7 @@ jobs:
       MB_DB_TYPE: mysql
       MB_DB_HOST: localhost
       MB_DB_PORT: 3306
-      MB_DB_DBNAME: circle_test
+      MB_DB_DBNAME: mb_test
       MB_DB_USER: root
       MB_MYSQL_TEST_USER: root
     services:
@@ -153,6 +156,9 @@ jobs:
         image: mariadb:latest
         ports:
           - "3306:3306"
+        env:
+          MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: true
+          MARIADB_DATABASE: mb_test
     steps:
     - uses: actions/checkout@v4
     - name: Test MariaDB driver (latest)
@@ -308,7 +314,7 @@ jobs:
       MB_DB_TYPE: mysql
       MB_DB_HOST: localhost
       MB_DB_PORT: 3306
-      MB_DB_DBNAME: circle_test
+      MB_DB_DBNAME: mb_test
       MB_DB_USER: root
       MB_MYSQL_TEST_USER: root
     services:
@@ -316,6 +322,9 @@ jobs:
         image: mysql:8.0
         ports:
           - "3306:3306"
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: true
+          MYSQL_DATABASE: mb_test
     steps:
     - uses: actions/checkout@v4
     - name: Test MySQL driver (8.0)
@@ -334,7 +343,7 @@ jobs:
       MB_DB_TYPE: mysql
       MB_DB_HOST: localhost
       MB_DB_PORT: 3306
-      MB_DB_DBNAME: circle_test
+      MB_DB_DBNAME: mb_test
       MB_DB_USER: root
       MB_MYSQL_TEST_USER: root
       # set up env vars for something named "MYSQL_SSL" to run MySQL SSL tests verifying connectivity with PEM cert
@@ -463,9 +472,9 @@ jobs:
       MB_DB_TYPE: postgres
       MB_DB_PORT: 5432
       MB_DB_HOST: localhost
-      MB_DB_DBNAME: circle_test
-      MB_DB_USER: circle_test
-      MB_POSTGRESQL_TEST_USER: circle_test
+      MB_DB_DBNAME: mb_test
+      MB_DB_USER: mb_test
+      MB_POSTGRESQL_TEST_USER: mb_test
       MB_POSTGRES_SSL_TEST_SSL: true
       MB_POSTGRES_SSL_TEST_SSL_MODE: verify-full
       MB_POSTGRES_SSL_TEST_SSL_ROOT_CERT_PATH: 'test-resources/certificates/us-east-2-bundle.pem'
@@ -475,8 +484,8 @@ jobs:
         ports:
           - "5432:5432"
         env:
-          POSTGRES_USER: circle_test
-          POSTGRES_DB: circle_test
+          POSTGRES_USER: mb_test
+          POSTGRES_DB: mb_test
           POSTGRES_HOST_AUTH_METHOD: trust
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/drivers-stress-test.yml
+++ b/.github/workflows/drivers-stress-test.yml
@@ -128,7 +128,7 @@ jobs:
         ports:
           - "3306:3306"
         env:
-          MYSQL_ALLOW_EMPTY_ROOT_PASSWORD: true
+          MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: true
           MARIADB_DATABASE: mb_test
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -564,13 +564,13 @@ jobs:
         version:
           - name: MariaDB 10.2
             junit-name: be-tests-mariadb-10-2-ee
-            image: circleci/mariadb:10.2.23
+            image: mariadb:10.2.23
             env:
               enable-ssl-tests: 'false'
               enable-aws-iam-tests: 'false'
           - name: MariaDB Latest
             junit-name: be-tests-mariadb-latest-ee
-            image: circleci/mariadb:latest
+            image: mariadb:latest
             env:
               enable-ssl-tests: 'false'
               enable-aws-iam-tests: 'false'

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -564,7 +564,7 @@ jobs:
         version:
           - name: MariaDB 10.2
             junit-name: be-tests-mariadb-10-2-ee
-            image: mariadb:10.2.23
+            image: metabase/mariadb:10.2.23
             env:
               enable-ssl-tests: 'false'
               enable-aws-iam-tests: 'false'

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -603,7 +603,7 @@ jobs:
           - "3306:3306"
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: true
-          MYSQL_DATABASE: circle_test
+          MYSQL_DATABASE: mb_test
     env:
       # Only run old migrations tests on pushes to master or release branches. All other branches should skip tests
       # with the tag `mb/old-migrations-test`. `__ADDITIONAL_EXCLUDED_TAG__` is not used anywhere outside of splicing
@@ -626,7 +626,7 @@ jobs:
       MB_DB_TYPE: mysql
       MB_DB_HOST: localhost
       MB_DB_PORT: 3306
-      MB_DB_DBNAME: circle_test
+      MB_DB_DBNAME: mb_test
       MB_DB_USER: root
       MB_MYSQL_TEST_USER: root
       #

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -603,7 +603,7 @@ jobs:
           - "3306:3306"
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: true
-          MYSQL_DATABASE: mb_test
+          MYSQL_DATABASE: circle_test
     env:
       # Only run old migrations tests on pushes to master or release branches. All other branches should skip tests
       # with the tag `mb/old-migrations-test`. `__ADDITIONAL_EXCLUDED_TAG__` is not used anywhere outside of splicing
@@ -626,7 +626,7 @@ jobs:
       MB_DB_TYPE: mysql
       MB_DB_HOST: localhost
       MB_DB_PORT: 3306
-      MB_DB_DBNAME: mb_test
+      MB_DB_DBNAME: circle_test
       MB_DB_USER: root
       MB_MYSQL_TEST_USER: root
       #

--- a/.github/workflows/semantic-search.yml
+++ b/.github/workflows/semantic-search.yml
@@ -104,7 +104,7 @@ jobs:
         ports:
           - "3306:3306"
         env:
-          MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: true
+          MYSQL_ALLOW_EMPTY_ROOT_PASSWORD: true
           MARIADB_DATABASE: mb_test
     env:
       CI: 'true'

--- a/.github/workflows/semantic-search.yml
+++ b/.github/workflows/semantic-search.yml
@@ -104,7 +104,7 @@ jobs:
         ports:
           - "3306:3306"
         env:
-          MYSQL_ALLOW_EMPTY_ROOT_PASSWORD: true
+          MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: true
           MARIADB_DATABASE: mb_test
     env:
       CI: 'true'

--- a/.github/workflows/semantic-search.yml
+++ b/.github/workflows/semantic-search.yml
@@ -77,11 +77,11 @@ jobs:
         version:
           - name: MariaDB 10.2 with pgvector pg17
             junit-name: semantic-search-tests-mariadb-10-2
-            mariadb-image: circleci/mariadb:10.2.23
+            mariadb-image: mariadb:10.2.23
             pgvector-image: pgvector/pgvector:pg17
           - name: MariaDB Latest with pgvector pg17
             junit-name: semantic-search-tests-mariadb-latest
-            mariadb-image: circleci/mariadb:latest
+            mariadb-image: mariadb:latest
             pgvector-image: pgvector/pgvector:pg17
         job:
           - name: Semantic Search Tests
@@ -151,7 +151,7 @@ jobs:
         version:
           - name: MySQL 8.0 with pgvector pg17
             junit-name: semantic-search-tests-mysql-8-0
-            mysql-image: cimg/mysql:8.0
+            mysql-image: mysql:8.0
             pgvector-image: pgvector/pgvector:pg17
           - name: MySQL Latest with pgvector pg17
             junit-name: semantic-search-tests-mysql-latest

--- a/.github/workflows/semantic-search.yml
+++ b/.github/workflows/semantic-search.yml
@@ -104,15 +104,15 @@ jobs:
         ports:
           - "3306:3306"
         env:
-          MYSQL_ALLOW_EMPTY_PASSWORD: true
-          MYSQL_DATABASE: circle_test
+          MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: true
+          MARIADB_DATABASE: mb_test
     env:
       CI: 'true'
       DRIVERS: mysql
       MB_DB_TYPE: mysql
       MB_DB_HOST: localhost
       MB_DB_PORT: 3306
-      MB_DB_DBNAME: circle_test
+      MB_DB_DBNAME: mb_test
       MB_DB_USER: root
       MB_MYSQL_TEST_USER: root
       MB_PGVECTOR_DB_URL: 'jdbc:postgres://localhost:5432/mb_semantic_search?user=postgres&password=postgres'
@@ -179,14 +179,14 @@ jobs:
           - "3306:3306"
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: true
-          MYSQL_DATABASE: circle_test
+          MYSQL_DATABASE: mb_test
     env:
       CI: 'true'
       DRIVERS: mysql
       MB_DB_TYPE: mysql
       MB_DB_HOST: localhost
       MB_DB_PORT: 3306
-      MB_DB_DBNAME: circle_test
+      MB_DB_DBNAME: mb_test
       MB_DB_USER: root
       MB_MYSQL_TEST_USER: root
       MB_PGVECTOR_DB_URL: 'jdbc:postgres://localhost:5432/mb_semantic_search?user=postgres&password=postgres'

--- a/.github/workflows/semantic-search.yml
+++ b/.github/workflows/semantic-search.yml
@@ -104,15 +104,15 @@ jobs:
         ports:
           - "3306:3306"
         env:
-          MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: true
-          MARIADB_DATABASE: mb_test
+          MYSQL_ALLOW_EMPTY_PASSWORD: true
+          MYSQL_DATABASE: circle_test
     env:
       CI: 'true'
       DRIVERS: mysql
       MB_DB_TYPE: mysql
       MB_DB_HOST: localhost
       MB_DB_PORT: 3306
-      MB_DB_DBNAME: mb_test
+      MB_DB_DBNAME: circle_test
       MB_DB_USER: root
       MB_MYSQL_TEST_USER: root
       MB_PGVECTOR_DB_URL: 'jdbc:postgres://localhost:5432/mb_semantic_search?user=postgres&password=postgres'
@@ -179,14 +179,14 @@ jobs:
           - "3306:3306"
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: true
-          MYSQL_DATABASE: mb_test
+          MYSQL_DATABASE: circle_test
     env:
       CI: 'true'
       DRIVERS: mysql
       MB_DB_TYPE: mysql
       MB_DB_HOST: localhost
       MB_DB_PORT: 3306
-      MB_DB_DBNAME: mb_test
+      MB_DB_DBNAME: circle_test
       MB_DB_USER: root
       MB_MYSQL_TEST_USER: root
       MB_PGVECTOR_DB_URL: 'jdbc:postgres://localhost:5432/mb_semantic_search?user=postgres&password=postgres'

--- a/.github/workflows/semantic-search.yml
+++ b/.github/workflows/semantic-search.yml
@@ -77,7 +77,7 @@ jobs:
         version:
           - name: MariaDB 10.2 with pgvector pg17
             junit-name: semantic-search-tests-mariadb-10-2
-            mariadb-image: mariadb:10.2.23
+            mariadb-image: metabase/mariadb:10.2.23
             pgvector-image: pgvector/pgvector:pg17
           - name: MariaDB Latest with pgvector pg17
             junit-name: semantic-search-tests-mariadb-latest

--- a/docs/developers-guide/drivers/driver-tests.md
+++ b/docs/developers-guide/drivers/driver-tests.md
@@ -220,7 +220,7 @@ be-tests-postgres-latest-ee:
     MB_POSTGRES_SSL_TEST_SSL_ROOT_CERT_PATH: "test-resources/certificates/us-east-2-bundle.pem"
   services:
     postgres:
-      image: circleci/postgres:latest
+      image: postgres:latest
       ports:
         - "5432:5432"
       env:

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -51,8 +51,6 @@
     ZonedDateTime)
    (java.time.format DateTimeFormatter)))
 
-; dirt
-
 (set! *warn-on-reflection* true)
 
 (comment

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -51,6 +51,8 @@
     ZonedDateTime)
    (java.time.format DateTimeFormatter)))
 
+; dirt
+
 (set! *warn-on-reflection* true)
 
 (comment

--- a/src/metabase/driver/mysql/actions.clj
+++ b/src/metabase/driver/mysql/actions.clj
@@ -118,7 +118,7 @@
 (defmethod sql-jdbc.actions/maybe-parse-sql-error [:mysql driver-api/violate-permission-constraint]
   [_driver error-type _database action-type error-message]
   (or (when-let [[_match _command _table-name]
-                 (re-find #"(INSERT|UPDATE|DELETE) command denied to user .* for table '(.+)'" error-message)]
+                 (re-find #"(INSERT|UPDATE|DELETE) command denied to user .* for table (.+)" error-message)]
         (merge {:type error-type}
                (case action-type
                  (:table.row/create :model.row/create)

--- a/test/metabase/query_processor/filter_test.clj
+++ b/test/metabase/query_processor/filter_test.clj
@@ -1040,10 +1040,10 @@
   (testing (str "Filtering on a specific date (DATE column) should work correctly regardless of report timezone/DB"
                 " timezone support (#39769)")
     (mt/test-drivers (mt/normal-drivers)
-      (mt/with-temporary-setting-values [report-timezone "US/Pacific"]
+      (mt/with-temporary-setting-values [report-timezone "America/Los_Angeles"]
         (let [metadata-provider (lib.tu/merged-mock-metadata-provider
                                  (mt/metadata-provider)
-                                 {:database {:timezone "US/Pacific"}})
+                                 {:database {:timezone "America/Los_Angeles"}})
               checkins          (lib.metadata/table metadata-provider (mt/id :checkins))
               checkins-id       (lib.metadata/field metadata-provider (mt/id :checkins :id))
               checkins-date     (lib.metadata/field metadata-provider (mt/id :checkins :date))
@@ -1079,10 +1079,10 @@
   (testing (str "Filtering on a specific date (TIMESTAMP WITH TIME ZONE column) should work correctly regardless of"
                 " report timezone/DB timezone support (#39769)")
     (mt/test-drivers (mt/normal-drivers)
-      (mt/with-temporary-setting-values [report-timezone "US/Pacific"]
+      (mt/with-temporary-setting-values [report-timezone "America/Los_Angeles"]
         (let [metadata-provider (lib.tu/merged-mock-metadata-provider
                                  (mt/metadata-provider)
-                                 {:database {:timezone "US/Pacific"}})
+                                 {:database {:timezone "America/Los_Angeles"}})
               orders            (lib.metadata/table metadata-provider (mt/id :orders))
               orders-id         (lib.metadata/field metadata-provider (mt/id :orders :id))
               orders-created-at (lib.metadata/field metadata-provider (mt/id :orders :created_at))

--- a/test/metabase/query_processor/timezones_test.clj
+++ b/test/metabase/query_processor/timezones_test.clj
@@ -56,7 +56,7 @@
     (mt/test-drivers (set-timezone-drivers)
       (doseq [[timezone expected-rows] {"UTC"        [[12 "2014-07-03T01:30:00Z"]
                                                       [10 "2014-07-03T19:30:00Z"]]
-                                        "US/Pacific" [[10 "2014-07-03T12:30:00-07:00"]]}]
+                                        "America/Los_Angeles" [[10 "2014-07-03T12:30:00-07:00"]]}]
         (mt/with-temporary-setting-values [report-timezone timezone]
           (is (= expected-rows
                  (mt/formatted-rows
@@ -252,7 +252,7 @@
   ;; Oracle doesn't have a time type
   (mt/test-drivers (filter #(isa? driver/hierarchy % :sql) (set-timezone-drivers))
     (mt/dataset attempted-murders
-      (doseq [timezone [nil "US/Pacific" "US/Eastern" "Asia/Hong_Kong"]]
+      (doseq [timezone [nil "America/Los_Angeles" "America/New_York" "Asia/Hong_Kong"]]
         (mt/with-temporary-setting-values [report-timezone timezone]
           (let [expected (expected-attempts)
                 actual   (select-keys (attempts) (keys expected))]
@@ -366,7 +366,7 @@
         (mt/with-temp-test-data [["relative_filter"
                                   [{:field-name "created", :base-type :type/DateTimeWithTZ}]
                                   [[expected-datetime]]]]
-          (doseq [timezone ["UTC" "Asia/Hong_Kong" "US/Hawaii" "America/Puerto_Rico"]]
+          (doseq [timezone ["UTC" "Asia/Hong_Kong" "Pacific/Honolulu" "America/Puerto_Rico"]]
             (mt/with-temporary-setting-values [report-timezone timezone]
               (let [query (mt/mbql-query relative_filter {:fields [$created]
                                                           :filter [:time-interval $created -1 :day]})]
@@ -388,8 +388,8 @@
     (testing "Fixed date"
       (mt/dataset tz-test-data
         (let [expected-datetime #t "2014-07-03T01:30:00Z"]
-          (doseq [[timezone date-filter] [["US/Pacific" "2014-07-02"]
-                                          ["US/Eastern" "2014-07-02"]
+          (doseq [[timezone date-filter] [["America/Los_Angeles" "2014-07-02"]
+                                          ["America/New_York" "2014-07-02"]
                                           ["UTC" "2014-07-03"]
                                           ["Asia/Hong_Kong" "2014-07-03"]]
                   :let [expected (-> (u.date/with-time-zone-same-instant expected-datetime timezone)


### PR DESCRIPTION
Closes [DEV-1703](https://linear.app/metabase/issue/DEV-1703/use-official-db-images-in-tests)

### Description

We use circleci/* and cimg/* images in tests. Some of these images are outdated (e.g. circleci/mariadb:latest is 10.6 when the official latest is 12.2) or are unnecessarily large (e.g. mysql:8.0 is 782 MB while cimg/mysql:8.0 is 2.73 GB).

Let's upgrade the images we use in tests to the official images. We've already [done this](https://github.com/metabase/metabase/pull/70824) for master but now we should do it for release-x.59.x also.