### PR TITLE
BOT-1044 Convert links back to metabase:// format before sending to llm

### DIFF
--- a/src/metabase/metabot/agent/core.clj
+++ b/src/metabase/metabot/agent/core.clj
@@ -197,6 +197,14 @@
     :else                         :stop))
 
 ;;; Call LLM
+(defn- part->invert-links-key
+  "Return the key that might contain links that need to be inverted or nil if no such key exists."
+  [part]
+  (cond
+    (and (= (:type part) :text) (string? (:text part)))
+    :text
+    (and (= (:role part) :user) (string? (:content part)))
+    :content))
 
 (defn- invert-links
   "Apply link inversion to all :text parts in a sequence of AISDK parts.
@@ -205,18 +213,10 @@
   (if (empty? registry-map)
     parts
     (mapv (fn [part]
-            (cond
-              (and (= (:type part) :text) (string? (:text part)))
-              (-> part
-                  (update :text links/invert-links registry-map)
-                  (update :text links/invert-slack-links registry-map))
-
-              (and (= (:role part) :user) (string? (:content part)))
-              (-> part
-                  (update :content links/invert-links registry-map)
-                  (update :content links/invert-slack-links registry-map))
-
-              :else part))
+            (let [links-key (part->invert-links-key part)]
+              (cond-> part
+                links-key (-> (update links-key links/invert-links registry-map)
+                              (update links-key links/invert-slack-links registry-map)))))
           parts)))
 
 (defn- call-llm

--- a/src/metabase/metabot/agent/core.clj
+++ b/src/metabase/metabot/agent/core.clj
@@ -357,37 +357,35 @@
 (defn- init-agent
   "Initialize agent state."
   [{:keys [messages state metabot-id profile-id context tracking-opts]}]
-  (let [context            (assign-context-ids context)
-        profile            (or (profiles/get-profile profile-id)
-                               (throw (ex-info "Unknown profile" {:profile-id profile-id})))
-        capabilities       (get context :capabilities #{})
-        base-tools         (profiles/get-tools-for-profile profile-id capabilities)
-        seeded             (-> (or state {})
-                               (seed-state context)
-                               (seed-chart-configs context))
-        memory             (-> (memory/initialize messages seeded context)
-                               (memory/load-queries-from-state seeded)
-                               (memory/load-charts-from-state seeded)
-                               (memory/load-transforms-from-state seeded)
-                               (memory/load-todos-from-state seeded)
-                               (memory/load-link-registry-from-state seeded))
-        link-registry-atom (atom (get-in memory [:state :link-registry] {}))
-        memory-atom        (atom memory)
-        tools              (agent-tools/wrap-tools-with-state base-tools memory-atom metabot-id)]
+  (let [context      (assign-context-ids context)
+        profile      (or (profiles/get-profile profile-id)
+                         (throw (ex-info "Unknown profile" {:profile-id profile-id})))
+        capabilities (get context :capabilities #{})
+        base-tools   (profiles/get-tools-for-profile profile-id capabilities)
+        seeded       (-> (or state {})
+                         (seed-state context)
+                         (seed-chart-configs context))
+        memory       (-> (memory/initialize messages seeded context)
+                         (memory/load-queries-from-state seeded)
+                         (memory/load-charts-from-state seeded)
+                         (memory/load-transforms-from-state seeded)
+                         (memory/load-todos-from-state seeded)
+                         (memory/load-link-registry-from-state seeded))
+        memory-atom  (atom memory)
+        tools        (agent-tools/wrap-tools-with-state base-tools memory-atom metabot-id)]
     (log/info "Starting agent" {:profile  profile-id
                                 :tools    (count tools)
                                 :max-iter (:max-iterations profile)
                                 :msgs     (count messages)})
-    {:profile            profile
-     :tools              tools
-     :context            context
-     :memory-atom        memory-atom
-     :link-registry-atom link-registry-atom
-     :tracking-opts      (merge {:profile-id profile-id
-                                 :request-id (str (random-uuid))
-                                 :source     "metabot_agent"
-                                 :tag        "agent"}
-                                tracking-opts)}))
+    {:profile       profile
+     :tools         tools
+     :context       context
+     :memory-atom   memory-atom
+     :tracking-opts (merge {:profile-id profile-id
+                            :request-id (str (random-uuid))
+                            :source     "metabot_agent"
+                            :tag        "agent"}
+                           tracking-opts)}))
 
 (defn- initial-loop-state
   "Create initial loop state from agent config and reduction context."
@@ -399,11 +397,8 @@
    :status     :continue
    :usage-atom usage-atom})
 
-(defn- final-state-part [memory link-registry-atom]
-  {:type :data
-   :data-type "state"
-   :version 1
-   :data (assoc (memory/get-state memory) :link-registry @link-registry-atom)})
+(defn- final-state-part [memory]
+  {:type :data, :data-type "state", :version 1, :data (memory/get-state memory)})
 
 (defn- error-part [^Exception e]
   {:type :error, :error {:message (.getMessage e), :type (str (type e)), :data (ex-data e)}})
@@ -429,11 +424,13 @@
   [{:keys [agent rf result iteration usage-atom] :as loop-state}]
   (with-span :debug {:name      :metabot.agent/loop-step
                      :iteration iteration}
-    (let [{:keys [profile tools context memory-atom tracking-opts link-registry-atom]} agent
-          max-iter      (:max-iterations profile 10)
-          tracking-opts (assoc tracking-opts :iteration iteration)
-          parts-atom    (atom [])
-          llm-call      (call-llm @memory-atom context profile tools iteration tracking-opts link-registry-atom)
+    (let [{:keys [profile tools context memory-atom tracking-opts]} agent
+          max-iter           (:max-iterations profile 10)
+          tracking-opts      (assoc tracking-opts :iteration iteration)
+          memory             @memory-atom
+          parts-atom         (atom [])
+          link-registry-atom (atom (get-in memory [:state :link-registry] {}))
+          llm-call           (call-llm memory context profile tools iteration tracking-opts link-registry-atom)
           xf         (comp (accumulate-usage-xf usage-atom)
                            (u/tee-xf parts-atom))
           ;; We use `reduce` instead of `transduce` because rf is the outer reducing
@@ -442,6 +439,8 @@
           ;; entire agent loop, not after every iteration.
           result'    (reduce (xf rf) result llm-call)
           parts      @parts-atom]
+      ;; Sync link registry back to memory after streaming completes
+      (swap! memory-atom assoc-in [:state :link-registry] @link-registry-atom)
       ;; Capture response for debug log
       (when *debug-log*
         (debug-log! {:iteration iteration
@@ -451,7 +450,7 @@
                      :all-parts parts}))
       (log/debug "Iteration" {:n iteration :parts-count (count parts)})
       (if (empty? parts)
-        (assoc loop-state :status :done :result (rf result (final-state-part @memory-atom link-registry-atom)))
+        (assoc loop-state :status :done :result (rf result (final-state-part @memory-atom)))
         (do
           (log/debug "Got parts" {:count (count parts) :types (mapv :type parts)})
           (swap! memory-atom update-memory parts)
@@ -469,7 +468,7 @@
                            :reason     (finish-reason iteration max-iter parts)})
                 (assoc loop-state
                        :status :done
-                       :result (rf result' (final-state-part @memory-atom link-registry-atom))))))))))
+                       :result (rf result' (final-state-part @memory-atom))))))))))
 
 ;;; Public API
 

--- a/src/metabase/metabot/agent/core.clj
+++ b/src/metabase/metabot/agent/core.clj
@@ -6,6 +6,7 @@
    [metabase.analytics.prometheus :as prometheus]
    [metabase.config.core :as config]
    [metabase.metabot.agent.analytics :as agent-analytics]
+   [metabase.metabot.agent.links :as links]
    [metabase.metabot.agent.memory :as memory]
    [metabase.metabot.agent.messages :as messages]
    [metabase.metabot.agent.profiles :as profiles]
@@ -141,13 +142,14 @@
   [:sequential ::message])
 
 (mr/def ::state
-  "Agent state containing queries, charts, chart-configs, todos, and transforms."
+  "Agent state containing queries, charts, chart-configs, todos, transforms, and link-registry."
   [:map
    [:queries {:optional true} [:map-of [:or :string :keyword] :map]]
    [:charts {:optional true} [:map-of [:or :string :keyword] :map]]
    [:chart-configs {:optional true} [:map-of [:or :string :keyword] :map]]
    [:todos {:optional true} [:sequential :map]]
-   [:transforms {:optional true} [:map-of [:or :string :keyword] :map]]])
+   [:transforms {:optional true} [:map-of [:or :string :keyword] :map]]
+   [:link-registry {:optional true} [:map-of [:or :string :keyword] :string]]])
 
 (mr/def ::context
   "Context information for the agent."
@@ -196,15 +198,33 @@
 
 ;;; Call LLM
 
+(defn- invert-links
+  "Apply link inversion to all :text parts in a sequence of AISDK parts.
+  Also inverts :content in user-role parts (which contain resolved URLs from prior requests)."
+  [parts registry-map]
+  (if (empty? registry-map)
+    parts
+    (mapv (fn [part]
+            (cond
+              (and (= (:type part) :text) (string? (:text part)))
+              (update part :text links/invert-links registry-map)
+
+              (and (= (:role part) :user) (string? (:content part)))
+              (update part :content links/invert-links registry-map)
+
+              :else part))
+          parts)))
+
 (defn- call-llm
   "Call the LLM and stream processed parts.
 
   Builds AISDK parts from memory and passes them to the adapter which converts
   them to its native wire format."
-  [memory context profile tools iteration tracking-opts]
+  [memory context profile tools iteration tracking-opts link-registry-atom]
   (let [model        (:model profile)
         system-msg   (messages/build-system-message context profile tools)
-        input-parts  (messages/build-message-history memory)
+        input-parts  (-> (messages/build-message-history memory)
+                         (invert-links @link-registry-atom))
         llm-opts     (cond-> {}
                        (:required-tool-call? profile) (assoc :tool-choice "required"))]
     (when *debug-log*
@@ -215,7 +235,8 @@
                    :parts     input-parts
                    :tools     (vec tools)}))
     (eduction (streaming/post-process-xf (get-in memory [:state :queries] {})
-                                         (get-in memory [:state :charts] {}))
+                                         (get-in memory [:state :charts] {})
+                                         link-registry-atom)
               (self/call-llm model (:content system-msg) input-parts tools tracking-opts llm-opts))))
 
 ;;; Memory management
@@ -336,34 +357,37 @@
 (defn- init-agent
   "Initialize agent state."
   [{:keys [messages state metabot-id profile-id context tracking-opts]}]
-  (let [context      (assign-context-ids context)
-        profile      (or (profiles/get-profile profile-id)
-                         (throw (ex-info "Unknown profile" {:profile-id profile-id})))
-        capabilities (get context :capabilities #{})
-        base-tools   (profiles/get-tools-for-profile profile-id capabilities)
-        seeded       (-> (or state {})
-                         (seed-state context)
-                         (seed-chart-configs context))
-        memory       (-> (memory/initialize messages seeded context)
-                         (memory/load-queries-from-state seeded)
-                         (memory/load-charts-from-state seeded)
-                         (memory/load-transforms-from-state seeded)
-                         (memory/load-todos-from-state seeded))
-        memory-atom  (atom memory)
-        tools        (agent-tools/wrap-tools-with-state base-tools memory-atom metabot-id)]
+  (let [context            (assign-context-ids context)
+        profile            (or (profiles/get-profile profile-id)
+                               (throw (ex-info "Unknown profile" {:profile-id profile-id})))
+        capabilities       (get context :capabilities #{})
+        base-tools         (profiles/get-tools-for-profile profile-id capabilities)
+        seeded             (-> (or state {})
+                               (seed-state context)
+                               (seed-chart-configs context))
+        memory             (-> (memory/initialize messages seeded context)
+                               (memory/load-queries-from-state seeded)
+                               (memory/load-charts-from-state seeded)
+                               (memory/load-transforms-from-state seeded)
+                               (memory/load-todos-from-state seeded)
+                               (memory/load-link-registry-from-state seeded))
+        link-registry-atom (atom (get-in memory [:state :link-registry] {}))
+        memory-atom        (atom memory)
+        tools              (agent-tools/wrap-tools-with-state base-tools memory-atom metabot-id)]
     (log/info "Starting agent" {:profile  profile-id
                                 :tools    (count tools)
                                 :max-iter (:max-iterations profile)
                                 :msgs     (count messages)})
-    {:profile       profile
-     :tools         tools
-     :context       context
-     :memory-atom   memory-atom
-     :tracking-opts (merge {:profile-id profile-id
-                            :request-id (str (random-uuid))
-                            :source     "metabot_agent"
-                            :tag        "agent"}
-                           tracking-opts)}))
+    {:profile            profile
+     :tools              tools
+     :context            context
+     :memory-atom        memory-atom
+     :link-registry-atom link-registry-atom
+     :tracking-opts      (merge {:profile-id profile-id
+                                 :request-id (str (random-uuid))
+                                 :source     "metabot_agent"
+                                 :tag        "agent"}
+                                tracking-opts)}))
 
 (defn- initial-loop-state
   "Create initial loop state from agent config and reduction context."
@@ -375,8 +399,11 @@
    :status     :continue
    :usage-atom usage-atom})
 
-(defn- final-state-part [memory]
-  {:type :data, :data-type "state", :version 1, :data (memory/get-state memory)})
+(defn- final-state-part [memory link-registry-atom]
+  {:type :data
+   :data-type "state"
+   :version 1
+   :data (assoc (memory/get-state memory) :link-registry @link-registry-atom)})
 
 (defn- error-part [^Exception e]
   {:type :error, :error {:message (.getMessage e), :type (str (type e)), :data (ex-data e)}})
@@ -402,11 +429,11 @@
   [{:keys [agent rf result iteration usage-atom] :as loop-state}]
   (with-span :debug {:name      :metabot.agent/loop-step
                      :iteration iteration}
-    (let [{:keys [profile tools context memory-atom tracking-opts]} agent
+    (let [{:keys [profile tools context memory-atom tracking-opts link-registry-atom]} agent
           max-iter      (:max-iterations profile 10)
           tracking-opts (assoc tracking-opts :iteration iteration)
           parts-atom    (atom [])
-          llm-call      (call-llm @memory-atom context profile tools iteration tracking-opts)
+          llm-call      (call-llm @memory-atom context profile tools iteration tracking-opts link-registry-atom)
           xf         (comp (accumulate-usage-xf usage-atom)
                            (u/tee-xf parts-atom))
           ;; We use `reduce` instead of `transduce` because rf is the outer reducing
@@ -424,7 +451,7 @@
                      :all-parts parts}))
       (log/debug "Iteration" {:n iteration :parts-count (count parts)})
       (if (empty? parts)
-        (assoc loop-state :status :done :result (rf result (final-state-part @memory-atom)))
+        (assoc loop-state :status :done :result (rf result (final-state-part @memory-atom link-registry-atom)))
         (do
           (log/debug "Got parts" {:count (count parts) :types (mapv :type parts)})
           (swap! memory-atom update-memory parts)
@@ -442,7 +469,7 @@
                            :reason     (finish-reason iteration max-iter parts)})
                 (assoc loop-state
                        :status :done
-                       :result (rf result' (final-state-part @memory-atom))))))))))
+                       :result (rf result' (final-state-part @memory-atom link-registry-atom))))))))))
 
 ;;; Public API
 

--- a/src/metabase/metabot/agent/core.clj
+++ b/src/metabase/metabot/agent/core.clj
@@ -207,10 +207,14 @@
     (mapv (fn [part]
             (cond
               (and (= (:type part) :text) (string? (:text part)))
-              (update part :text links/invert-links registry-map)
+              (-> part
+                  (update :text links/invert-links registry-map)
+                  (update :text links/invert-slack-links registry-map))
 
               (and (= (:role part) :user) (string? (:content part)))
-              (update part :content links/invert-links registry-map)
+              (-> part
+                  (update :content links/invert-links registry-map)
+                  (update :content links/invert-slack-links registry-map))
 
               :else part))
           parts)))

--- a/src/metabase/metabot/agent/links.clj
+++ b/src/metabase/metabot/agent/links.clj
@@ -5,6 +5,7 @@
    [buddy.core.codecs :as codecs]
    [clojure.string :as str]
    [metabase.lib.core :as lib]
+   [metabase.system.core :as system]
    [metabase.util.json :as json]
    [metabase.util.log :as log]))
 
@@ -175,6 +176,29 @@
                    (if-let [original (get registry-map url)]
                      (str "[" link-text "](" original ")")
                      whole)))))
+
+;;; Slack Link Processing
+
+(def slack-link-pattern
+  "Regex matching a complete Slack-format link <metabase://type/id|text>."
+  #"<(metabase://[^>|]+)(?:\|([^>]*))?>")
+
+(defn- resolve-slack-link
+  "Resolve a single Slack-format metabase:// link match. Returns the replacement string."
+  [queries charts [_ url link-text]]
+  (if-let [resolved (resolve-metabase-uri url queries charts)]
+    (let [absolute-url (str (system/site-url) resolved)]
+      (if link-text
+        (str "<" absolute-url "|" link-text ">")
+        (str "<" absolute-url ">")))
+    (do
+      (log/warn "Failed to resolve Slack link URL" {:url url})
+      (or link-text url))))
+
+(defn resolve-slack-links
+  "Resolve all Slack-format metabase:// links in text."
+  [text queries charts]
+  (str/replace text slack-link-pattern (partial resolve-slack-link queries charts)))
 
 (defn resolve-links-xf
   "Transducer that resolves metabase:// links in text parts.

--- a/src/metabase/metabot/agent/links.clj
+++ b/src/metabase/metabot/agent/links.clj
@@ -161,6 +161,7 @@
 (defn invert-links
   "Replace resolved URLs with their original metabase:// URIs.
 
+  Only replaces URLs that appear inside `[text](url)` markdown syntax.
   `registry-map` is a map of {resolved-url original-metabase-uri}.
 
   Returns `text` unchanged if `registry-map` is empty or nil."
@@ -169,10 +170,11 @@
           (empty? text)
           (empty? registry-map))
     text
-    (reduce-kv (fn [txt resolved original]
-                 (str/replace txt resolved original))
-               text
-               registry-map)))
+    (str/replace text link-pattern
+                 (fn [[whole link-text url]]
+                   (if-let [original (get registry-map url)]
+                     (str "[" link-text "](" original ")")
+                     whole)))))
 
 (defn resolve-links-xf
   "Transducer that resolves metabase:// links in text parts.

--- a/src/metabase/metabot/agent/links.clj
+++ b/src/metabase/metabot/agent/links.clj
@@ -139,18 +139,40 @@
   and replaces metabase:// URLs with proper Metabase URLs.
   Non-metabase:// links are preserved unchanged.
 
+  `link-registry-atom` is an atom of {resolved-url original-metabase-uri}.
+  Every successful resolution is recorded so that resolved URLs can later be
+  inverted back to metabase:// URIs (see [[invert-links]]).
+
   Returns the text with all resolvable links replaced."
-  [text queries-state charts-state]
+  [text queries-state charts-state link-registry-atom]
   (when (string? text)
     (str/replace text link-pattern
                  (fn [[_ link-text url]]
                    (if (str/starts-with? url "metabase://")
                      (if-let [resolved (resolve-metabase-uri url queries-state charts-state)]
-                       (str "[" link-text "](" resolved ")")
+                       (do
+                         (swap! link-registry-atom assoc resolved url)
+                         (str "[" link-text "](" resolved ")"))
                        (do
                          (log/warn "Failed to resolve link URL" {:url url})
                          link-text))
                      (str "[" link-text "](" url ")"))))))
+
+(defn invert-links
+  "Replace resolved URLs with their original metabase:// URIs.
+
+  `registry-map` is a map of {resolved-url original-metabase-uri}.
+
+  Returns `text` unchanged if `registry-map` is empty or nil."
+  [text registry-map]
+  (if (or (not (string? text))
+          (empty? text)
+          (empty? registry-map))
+    text
+    (reduce-kv (fn [txt resolved original]
+                 (str/replace txt resolved original))
+               text
+               registry-map)))
 
 (defn resolve-links-xf
   "Transducer that resolves metabase:// links in text parts.
@@ -158,10 +180,10 @@
   Takes queries-state and charts-state for link resolution.
   For :text parts, resolves metabase:// links to proper URLs.
   For other part types, passes through unchanged."
-  [queries-state charts-state]
+  [queries-state charts-state link-registry-atom]
   (map (fn [part]
          (if (and (= (:type part) :text) (:text part))
-           (update part :text resolve-links queries-state charts-state)
+           (update part :text resolve-links queries-state charts-state link-registry-atom)
            part))))
 
 ;;; Part Processing (deprecated, use resolve-links-xf)
@@ -173,9 +195,9 @@
   For other part types, returns unchanged.
 
   Deprecated: Use resolve-links-xf transducer instead."
-  [part queries-state charts-state]
+  [part queries-state charts-state link-registry-atom]
   (if (and (= (:type part) :text) (:text part))
-    (update part :text resolve-links queries-state charts-state)
+    (update part :text resolve-links queries-state charts-state link-registry-atom)
     part))
 
 (defn process-parts-links
@@ -183,5 +205,5 @@
   Returns parts with all text links resolved.
 
   Deprecated: Use resolve-links-xf transducer instead."
-  [parts queries-state charts-state]
-  (into [] (resolve-links-xf queries-state charts-state) parts))
+  [parts queries-state charts-state link-registry-atom]
+  (into [] (resolve-links-xf queries-state charts-state link-registry-atom) parts))

--- a/src/metabase/metabot/agent/links.clj
+++ b/src/metabase/metabot/agent/links.clj
@@ -159,6 +159,23 @@
                          link-text))
                      (str "[" link-text "](" url ")"))))))
 
+;;; Link Inversion
+
+(defn- invert-matched-links
+  "Replace resolved URLs with original metabase:// URIs using pattern matching.
+  `match->url` extracts the URL from a regex match.
+  `rebuild` reconstructs the link syntax given [match-groups original-uri]."
+  [text pattern match->url rebuild registry-map]
+  (if (or (not (string? text))
+          (empty? text)
+          (empty? registry-map))
+    text
+    (str/replace text pattern
+                 (fn [match]
+                   (if-let [original (get registry-map (match->url match))]
+                     (rebuild match original)
+                     (first match))))))
+
 (defn invert-links
   "Replace resolved URLs with their original metabase:// URIs.
 
@@ -167,15 +184,12 @@
 
   Returns `text` unchanged if `registry-map` is empty or nil."
   [text registry-map]
-  (if (or (not (string? text))
-          (empty? text)
-          (empty? registry-map))
-    text
-    (str/replace text link-pattern
-                 (fn [[whole link-text url]]
-                   (if-let [original (get registry-map url)]
-                     (str "[" link-text "](" original ")")
-                     whole)))))
+  (invert-matched-links text
+                        link-pattern
+                        (fn [[_ _ url]] url)
+                        (fn [[_ link-text _] original]
+                          (str "[" link-text "](" original ")"))
+                        registry-map))
 
 ;;; Slack Link Processing
 
@@ -185,9 +199,10 @@
 
 (defn- resolve-slack-link
   "Resolve a single Slack-format metabase:// link match. Returns the replacement string."
-  [queries charts [_ url link-text]]
+  [queries charts link-registry-atom [_ url link-text]]
   (if-let [resolved (resolve-metabase-uri url queries charts)]
     (let [absolute-url (str (system/site-url) resolved)]
+      (swap! link-registry-atom assoc absolute-url url)
       (if link-text
         (str "<" absolute-url "|" link-text ">")
         (str "<" absolute-url ">")))
@@ -196,9 +211,34 @@
       (or link-text url))))
 
 (defn resolve-slack-links
-  "Resolve all Slack-format metabase:// links in text."
-  [text queries charts]
-  (str/replace text slack-link-pattern (partial resolve-slack-link queries charts)))
+  "Resolve all Slack-format metabase:// links in text.
+
+  `link-registry-atom` is an atom of {absolute-url original-metabase-uri}.
+  Every successful resolution is recorded so that resolved URLs can later
+  be inverted back to metabase:// URIs (see [[invert-slack-links]])."
+  [text queries charts link-registry-atom]
+  (str/replace text slack-link-pattern (partial resolve-slack-link queries charts link-registry-atom)))
+
+(def ^:private slack-url-link-pattern
+  "Regex matching a Slack-format link <url|text> with any HTTP(S) URL."
+  #"<(https?://[^>|]+)(?:\|([^>]*))?>")
+
+(defn invert-slack-links
+  "Replace resolved absolute URLs with their original metabase:// URIs in Slack-format links.
+
+  Only replaces URLs that appear inside `<url|text>` Slack link syntax.
+  `registry-map` is a map of {resolved-absolute-url original-metabase-uri}.
+
+  Returns `text` unchanged if `registry-map` is empty or nil."
+  [text registry-map]
+  (invert-matched-links text
+                        slack-url-link-pattern
+                        (fn [[_ url _]] url)
+                        (fn [[_ _ link-text] original]
+                          (if link-text
+                            (str "<" original "|" link-text ">")
+                            (str "<" original ">")))
+                        registry-map))
 
 (defn resolve-links-xf
   "Transducer that resolves metabase:// links in text parts.

--- a/src/metabase/metabot/agent/markdown_link_buffer.clj
+++ b/src/metabase/metabot/agent/markdown_link_buffer.clj
@@ -17,14 +17,17 @@
 
 (def initial-state
   "Initial parser state."
-  {:buffer  ""
-   :queries {}
-   :charts  {}})
+  {:buffer             ""
+   :queries            {}
+   :charts             {}
+   :link-registry-atom (atom {})})
 
 (defn with-context
-  "Update the queries and charts context in the state."
-  [state queries charts]
-  (assoc state :queries queries :charts charts))
+  "Update the queries, charts, and link-registry-atom context in the state."
+  ([state queries charts]
+   (assoc state :queries queries :charts charts))
+  ([state queries charts link-registry-atom]
+   (assoc state :queries queries :charts charts :link-registry-atom link-registry-atom)))
 
 ;;; Slack Link Resolution
 
@@ -96,7 +99,7 @@
   [{:keys [buffer] :as state} chunk]
   (let [text        (str buffer chunk)
         ;; Resolve complete markdown links, then Slack-format links
-        resolved    (-> (links/resolve-links text (:queries state) (:charts state))
+        resolved    (-> (links/resolve-links text (:queries state) (:charts state) (:link-registry-atom state))
                         (resolve-slack-links (:queries state) (:charts state)))
         ;; Then check for incomplete link at the end
         split-point (find-potential-link-start resolved)]
@@ -131,12 +134,14 @@
 
    Parameters:
    - initial-queries: Initial map of query-id to query data
-   - initial-charts: Initial map of chart-id to chart data"
-  [initial-queries initial-charts]
+   - initial-charts: Initial map of chart-id to chart data
+   - link-registry-atom: Atom of {resolved-url original-metabase-uri}"
+  [initial-queries initial-charts link-registry-atom]
   (fn [rf]
     (let [state   (volatile! (with-context initial-state
                                (or initial-queries {})
-                               (or initial-charts {})))
+                               (or initial-charts {})
+                               link-registry-atom))
           queries (volatile! (or initial-queries {}))
           charts  (volatile! (or initial-charts {}))]
       (fn

--- a/src/metabase/metabot/agent/markdown_link_buffer.clj
+++ b/src/metabase/metabot/agent/markdown_link_buffer.clj
@@ -76,7 +76,7 @@
   (let [text        (str buffer chunk)
         ;; Resolve complete markdown links, then Slack-format links
         resolved    (-> (links/resolve-links text (:queries state) (:charts state) (:link-registry-atom state))
-                        (links/resolve-slack-links (:queries state) (:charts state)))
+                        (links/resolve-slack-links (:queries state) (:charts state) (:link-registry-atom state)))
         ;; Then check for incomplete link at the end
         split-point (find-potential-link-start resolved)]
     (if split-point

--- a/src/metabase/metabot/agent/markdown_link_buffer.clj
+++ b/src/metabase/metabot/agent/markdown_link_buffer.clj
@@ -8,7 +8,6 @@
   (:require
    [clojure.string :as str]
    [metabase.metabot.agent.links :as links]
-   [metabase.system.core :as system]
    [metabase.util.log :as log]))
 
 (set! *warn-on-reflection* true)
@@ -28,29 +27,6 @@
    (assoc state :queries queries :charts charts))
   ([state queries charts link-registry-atom]
    (assoc state :queries queries :charts charts :link-registry-atom link-registry-atom)))
-
-;;; Slack Link Resolution
-
-(def ^:private slack-link-pattern
-  "Regex matching a complete Slack-format link <metabase://type/id|text>."
-  #"<(metabase://[^>|]+)(?:\|([^>]*))?>")
-
-(defn- resolve-slack-link
-  "Resolve a single Slack-format metabase:// link match. Returns the replacement string."
-  [queries charts [_ url link-text]]
-  (if-let [resolved (links/resolve-metabase-uri url queries charts)]
-    (let [absolute-url (str (system/site-url) resolved)]
-      (if link-text
-        (str "<" absolute-url "|" link-text ">")
-        (str "<" absolute-url ">")))
-    (do
-      (log/warn "Failed to resolve Slack link URL" {:url url})
-      (or link-text url))))
-
-(defn- resolve-slack-links
-  "Resolve all Slack-format metabase:// links in text."
-  [text queries charts]
-  (str/replace text slack-link-pattern (partial resolve-slack-link queries charts)))
 
 ;;; Buffering Logic
 
@@ -78,7 +54,7 @@
     (when idx
       (let [suffix (subs text idx)]
         ;; Only buffer if there's no closing > (i.e., the link is incomplete)
-        (when-not (re-find slack-link-pattern suffix)
+        (when-not (re-find links/slack-link-pattern suffix)
           idx)))))
 
 (defn- find-potential-link-start
@@ -100,7 +76,7 @@
   (let [text        (str buffer chunk)
         ;; Resolve complete markdown links, then Slack-format links
         resolved    (-> (links/resolve-links text (:queries state) (:charts state) (:link-registry-atom state))
-                        (resolve-slack-links (:queries state) (:charts state)))
+                        (links/resolve-slack-links (:queries state) (:charts state)))
         ;; Then check for incomplete link at the end
         split-point (find-potential-link-start resolved)]
     (if split-point

--- a/src/metabase/metabot/agent/memory.clj
+++ b/src/metabase/metabot/agent/memory.clj
@@ -17,7 +17,7 @@
    {:input-messages messages
     :steps-taken []
     :context context
-    :state (or state {:queries {} :charts {} :todos [] :transforms {}})}))
+    :state (or state {:queries {} :charts {} :todos [] :transforms {} :link-registry {}})}))
 
 (defn add-step
   "Add a completed agent step to memory.
@@ -169,4 +169,16 @@
   [memory state]
   (if-let [todos (:todos state)]
     (set-todos memory todos)
+    memory))
+
+(defn load-link-registry-from-state
+  "Load link registry from incoming state into memory.
+  Ensures keys are strings since JSON round-tripping may keywordize them."
+  [memory state]
+  (if-let [link-registry (not-empty (:link-registry state))]
+    (assoc-in memory [:state :link-registry]
+              ;; We don't use `name` in case the key is a relative url fragment like `:question/123`.
+              (update-keys link-registry #(if (keyword? %)
+                                            (subs (str %) 1)
+                                            %)))
     memory))

--- a/src/metabase/metabot/agent/streaming.clj
+++ b/src/metabase/metabot/agent/streaming.clj
@@ -166,9 +166,10 @@
 
   Parameters:
   - initial-queries: Initial map of query-id to query data
-  - initial-charts: Initial map of chart-id to chart data"
-  [initial-queries initial-charts]
+  - initial-charts: Initial map of chart-id to chart data
+  - link-registry-atom: Atom of {resolved-url original-metabase-uri}"
+  [initial-queries initial-charts link-registry-atom]
   (comp
    expand-data-parts-xf
    expand-reactions-xf
-   (markdown-link-buffer/resolve-xf initial-queries initial-charts)))
+   (markdown-link-buffer/resolve-xf initial-queries initial-charts link-registry-atom)))

--- a/test/metabase/metabot/agent/links_test.clj
+++ b/test/metabase/metabot/agent/links_test.clj
@@ -382,6 +382,13 @@
       (is (= "[Results](metabase://query/q1)"
              (links/invert-links text registry))))))
 
+(deftest ^:parallel invert-links-only-replaces-inside-markdown-links-test
+  (testing "does not replace URLs that appear outside of markdown link syntax"
+    (let [registry {"/model/123" "metabase://model/123"}
+          text     "Visit /model/123 or see [Model](/model/123) for details"]
+      (is (= "Visit /model/123 or see [Model](metabase://model/123) for details"
+             (links/invert-links text registry))))))
+
 ;;; Round-trip tests
 
 (deftest ^:parallel round-trip-entity-links-test

--- a/test/metabase/metabot/agent/links_test.clj
+++ b/test/metabase/metabot/agent/links_test.clj
@@ -5,7 +5,8 @@
    [metabase.lib.core :as lib]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
-   [metabase.metabot.agent.links :as links]))
+   [metabase.metabot.agent.links :as links]
+   [metabase.test :as mt]))
 
 ;;; resolve-metabase-uri tests
 
@@ -468,3 +469,40 @@
           resolved      (links/resolve-links original queries-state {} registry)
           inverted      (links/invert-links resolved @registry)]
       (is (= original inverted)))))
+
+;;; Slack link resolution tests
+
+(deftest resolve-slack-links-entity-links-test
+  (testing "resolves Slack-format metabase:// entity links"
+    (mt/with-temporary-setting-values [site-url "https://metabase.example.com"]
+      (is (= "<https://metabase.example.com/model/123|My Model>"
+             (links/resolve-slack-links "<metabase://model/123|My Model>" {} {})))
+      (is (= "<https://metabase.example.com/dashboard/456>"
+             (links/resolve-slack-links "<metabase://dashboard/456>" {} {}))))))
+
+(deftest resolve-slack-links-query-links-test
+  (testing "resolves Slack-format metabase://query links"
+    (mt/with-temporary-setting-values [site-url "https://metabase.example.com"]
+      (let [query   (lib.tu/venues-query)
+            result  (links/resolve-slack-links "<metabase://query/q1|Results>" {"q1" query} {})]
+        (is (str/starts-with? result "<https://metabase.example.com/question#"))
+        (is (str/ends-with? result "|Results>"))))))
+
+(deftest resolve-slack-links-multiple-test
+  (testing "resolves multiple Slack-format links"
+    (mt/with-temporary-setting-values [site-url "https://mb.test"]
+      (is (= "<https://mb.test/model/1|Model A> and <https://mb.test/metric/2|Metric B>"
+             (links/resolve-slack-links "<metabase://model/1|Model A> and <metabase://metric/2|Metric B>" {} {}))))))
+
+(deftest ^:parallel resolve-slack-links-unresolvable-test
+  (testing "falls back to link text for unresolvable Slack link"
+    (is (= "My Query"
+           (links/resolve-slack-links "<metabase://query/unknown|My Query>" {} {}))))
+  (testing "falls back to URL for unresolvable Slack link without text"
+    (is (= "metabase://query/unknown"
+           (links/resolve-slack-links "<metabase://query/unknown>" {} {})))))
+
+(deftest ^:parallel resolve-slack-links-no-links-test
+  (testing "passes through text without Slack links"
+    (is (= "plain text" (links/resolve-slack-links "plain text" {} {})))
+    (is (= "x < y" (links/resolve-slack-links "x < y" {} {})))))

--- a/test/metabase/metabot/agent/links_test.clj
+++ b/test/metabase/metabot/agent/links_test.clj
@@ -2,6 +2,8 @@
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]
+   [metabase.lib.core :as lib]
+   [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
    [metabase.metabot.agent.links :as links]))
 
@@ -10,7 +12,7 @@
 (deftest ^:parallel resolve-metabase-uri-query-links-test
   (testing "resolves query links"
     (let [query-id      "abc-123"
-          query         {:database 1 :type :query :query {:source-table 1}}
+          query         (lib.tu/venues-query)
           queries-state {query-id query}
           charts-state  {}
           result        (links/resolve-metabase-uri "metabase://query/abc-123" queries-state charts-state)]
@@ -50,7 +52,7 @@
   (testing "resolves chart links using chart state"
     (let [query-id      "query-abc"
           chart-id      "chart-123"
-          query         {:database 1 :type :query :query {:source-table 1}}
+          query         (lib.tu/venues-query)
           queries-state {query-id query}
           charts-state  {chart-id {:query-id query-id :chart-type :bar}}
           result (links/resolve-metabase-uri "metabase://chart/chart-123" queries-state charts-state)]
@@ -61,7 +63,7 @@
   (testing "falls back to query when chart link uses query ID"
     ;; LLM sometimes uses metabase://chart/ when it should use metabase://query/
     (let [query-id      "qp_6a8c1d99-6f46-4ebb-9b7e-2fcad97a7f1c"
-          query         {:database 1 :type :query :query {:source-table 1}}
+          query         (lib.tu/venues-query)
           queries-state {query-id query}
           charts-state  {}
           result (links/resolve-metabase-uri (str "metabase://chart/" query-id) queries-state charts-state)]
@@ -73,7 +75,7 @@
 (deftest ^:parallel resolve-links-markdown-test
   (testing "resolves metabase:// links in markdown"
     (let [query-id "test-query"
-          query {:database 1 :type :query :query {:source-table 1}}
+          query (lib.tu/venues-query)
           queries-state {query-id query}
           charts-state {}
           text "Check out [My Results](metabase://query/test-query) for details."
@@ -144,7 +146,7 @@
 (deftest ^:parallel resolve-links-xf-with-transduce-test
   (testing "transducer works with transduce"
     (let [query-id "q1"
-          query {:database 1 :type :query :query {:source-table 1}}
+          query (lib.tu/venues-query)
           queries-state {query-id query}
           parts [{:type :text :text "[Query](metabase://query/q1)"}]
           result (transduce (links/resolve-links-xf queries-state {} (atom {}))
@@ -245,7 +247,7 @@
   (testing "resolves chart links correctly with state"
     (let [query-id      "q-abc-123"
           chart-id      "chart-xyz-789"
-          query         {:database 1 :type :query :query {:source-table 1}}
+          query         (lib.tu/venues-query)
           queries-state {query-id query}
           charts-state  {chart-id {:query-id query-id :chart-type :bar}}
           result        (links/resolve-metabase-uri (str "metabase://chart/" chart-id) queries-state charts-state)]
@@ -260,7 +262,7 @@
 (deftest ^:parallel chart-link-falls-back-to-query-test
   (testing "chart link falls back to query when chart-id matches query-id"
     (let [query-id      "shared-id-123"
-          query         {:database 1 :type :query :query {:source-table 1}}
+          query         (lib.tu/venues-query)
           queries-state {query-id query}
           charts-state  {}
           result        (links/resolve-metabase-uri (str "metabase://chart/" query-id) queries-state charts-state)]
@@ -280,7 +282,7 @@
 (deftest ^:parallel query-link-valid-query-test
   (testing "resolves query links with valid query in state"
     (let [query-id      "test-query-id"
-          query         {:database 1 :type :query :query {:source-table 1}}
+          query         (lib.tu/venues-query)
           queries-state {query-id query}
           result        (links/resolve-metabase-uri (str "metabase://query/" query-id) queries-state {})]
       (is (string? result))
@@ -293,11 +295,10 @@
 (deftest ^:parallel query-link-complex-nested-structure-test
   (testing "handles query with complex nested structure"
     (let [query-id      "complex-query"
-          query         {:database 1
-                         :type     :query
-                         :query    {:source-table 1
-                                    :joins        [{:fields :all :source-table 2}]
-                                    :filter       [:= [:field 1 nil] "test"]}}
+          query         (-> (lib.tu/venues-query)
+                            (lib/join (-> (lib/join-clause (meta/table-metadata :categories))
+                                          (lib/with-join-fields :all)))
+                            (lib/filter (lib/= (meta/field-metadata :venues :name) "test")))
           queries-state {query-id query}
           result        (links/resolve-metabase-uri (str "metabase://query/" query-id) queries-state {})]
       (is (string? result))
@@ -308,7 +309,7 @@
 (deftest ^:parallel multiple-different-link-types-test
   (testing "processes multiple different link types in same text"
     (let [query-id "q1"
-          query {:database 1 :type :query :query {:source-table 1}}
+          query (lib.tu/venues-query)
           queries-state {query-id query}
           text "See [Model](metabase://model/1), [Metric](metabase://metric/2), and [Query](metabase://query/q1)"
           result (links/resolve-links text queries-state {} (atom {}))]
@@ -336,7 +337,7 @@
 (deftest ^:parallel uuid-entity-ids-test
   (testing "handles entity IDs that look like UUIDs"
     (let [query-id      "550e8400-e29b-41d4-a716-446655440000"
-          query         {:database 1 :type :query :query {:source-table 1}}
+          query         (lib.tu/venues-query)
           queries-state {query-id query}
           result        (links/resolve-metabase-uri (str "metabase://query/" query-id) queries-state {})]
       (is (string? result)))))
@@ -344,7 +345,7 @@
 (deftest ^:parallel nano-id-entity-ids-test
   (testing "handles nano-id style identifiers"
     (let [query-id      "puL95JSvym3k23W1UUuog"
-          query         {:database 1 :type :query :query {:source-table 1}}
+          query         (lib.tu/venues-query)
           queries-state {query-id query}
           result        (links/resolve-metabase-uri (str "metabase://query/" query-id) queries-state {})]
       (is (string? result)))))

--- a/test/metabase/metabot/agent/links_test.clj
+++ b/test/metabase/metabot/agent/links_test.clj
@@ -5,7 +5,9 @@
    [metabase.lib.test-util :as lib.tu]
    [metabase.metabot.agent.links :as links]))
 
-(deftest resolve-metabase-uri-test
+;;; resolve-metabase-uri tests
+
+(deftest ^:parallel resolve-metabase-uri-query-links-test
   (testing "resolves query links"
     (let [query-id      "abc-123"
           query         {:database 1 :type :query :query {:source-table 1}}
@@ -13,32 +15,38 @@
           charts-state  {}
           result        (links/resolve-metabase-uri "metabase://query/abc-123" queries-state charts-state)]
       (is (string? result))
-      (is (str/starts-with? result "/question#"))))
+      (is (str/starts-with? result "/question#")))))
 
+(deftest ^:parallel resolve-metabase-uri-missing-query-test
   (testing "returns nil for missing query"
     (let [result (links/resolve-metabase-uri "metabase://query/missing" {} {})]
-      (is (nil? result))))
+      (is (nil? result)))))
 
+(deftest ^:parallel resolve-metabase-uri-entity-links-test
   (testing "resolves entity links"
     (is (= "/model/123" (links/resolve-metabase-uri "metabase://model/123" {} {})))
     (is (= "/metric/456" (links/resolve-metabase-uri "metabase://metric/456" {} {})))
     (is (= "/dashboard/789" (links/resolve-metabase-uri "metabase://dashboard/789" {} {})))
     (is (= "/question/101" (links/resolve-metabase-uri "metabase://question/101" {} {})))
     (is (= "/admin/transforms/202" (links/resolve-metabase-uri "metabase://transform/202" {} {})))
-    (is (= "/table/123" (links/resolve-metabase-uri "metabase://table/123" {} {}))))
+    (is (= "/table/123" (links/resolve-metabase-uri "metabase://table/123" {} {})))))
 
+(deftest ^:parallel resolve-metabase-uri-unknown-entity-type-test
   (testing "returns nil for unknown entity types"
-    (is (nil? (links/resolve-metabase-uri "metabase://unknown/123" {} {}))))
+    (is (nil? (links/resolve-metabase-uri "metabase://unknown/123" {} {})))))
 
+(deftest ^:parallel resolve-metabase-uri-non-metabase-uris-test
   (testing "returns nil for non-metabase URIs"
     (is (nil? (links/resolve-metabase-uri "https://example.com" {} {})))
-    (is (nil? (links/resolve-metabase-uri "/question/123" {} {}))))
+    (is (nil? (links/resolve-metabase-uri "/question/123" {} {})))))
 
+(deftest ^:parallel resolve-metabase-uri-missing-entity-ids-test
   (testing "returns nil for missing entity IDs"
     (is (nil? (links/resolve-metabase-uri "metabase://model/" {} {})))
     (is (nil? (links/resolve-metabase-uri "metabase://metric/" {} {})))
-    (is (nil? (links/resolve-metabase-uri "metabase://query/" {} {}))))
+    (is (nil? (links/resolve-metabase-uri "metabase://query/" {} {})))))
 
+(deftest ^:parallel resolve-metabase-uri-chart-links-test
   (testing "resolves chart links using chart state"
     (let [query-id      "query-abc"
           chart-id      "chart-123"
@@ -47,8 +55,9 @@
           charts-state  {chart-id {:query-id query-id :chart-type :bar}}
           result (links/resolve-metabase-uri "metabase://chart/chart-123" queries-state charts-state)]
       (is (string? result))
-      (is (str/starts-with? result "/question#"))))
+      (is (str/starts-with? result "/question#")))))
 
+(deftest ^:parallel resolve-metabase-uri-chart-fallback-to-query-test
   (testing "falls back to query when chart link uses query ID"
     ;; LLM sometimes uses metabase://chart/ when it should use metabase://query/
     (let [query-id      "qp_6a8c1d99-6f46-4ebb-9b7e-2fcad97a7f1c"
@@ -59,7 +68,9 @@
       (is (string? result))
       (is (str/starts-with? result "/question#")))))
 
-(deftest resolve-links-test
+;;; resolve-links tests
+
+(deftest ^:parallel resolve-links-markdown-test
   (testing "resolves metabase:// links in markdown"
     (let [query-id "test-query"
           query {:database 1 :type :query :query {:source-table 1}}
@@ -68,37 +79,45 @@
           text "Check out [My Results](metabase://query/test-query) for details."
           result (links/resolve-links text queries-state charts-state (atom {}))]
       (is (str/includes? result "[My Results](/question#"))
-      (is (not (str/includes? result "metabase://")))))
+      (is (not (str/includes? result "metabase://"))))))
 
+(deftest ^:parallel resolve-links-preserves-non-metabase-test
   (testing "preserves non-metabase links"
     (let [text "Visit [Google](https://google.com) for more."
           result (links/resolve-links text {} {} (atom {}))]
-      (is (= text result))))
+      (is (= text result)))))
 
+(deftest ^:parallel resolve-links-multiple-test
   (testing "handles multiple links"
     (let [text "[Model](metabase://model/1) and [Metric](metabase://metric/2)"
           result (links/resolve-links text {} {} (atom {}))]
       (is (str/includes? result "[Model](/model/1)"))
-      (is (str/includes? result "[Metric](/metric/2)"))))
+      (is (str/includes? result "[Metric](/metric/2)")))))
 
+(deftest ^:parallel resolve-links-no-links-test
   (testing "handles text without links"
     (let [text "Just some plain text"
           result (links/resolve-links text {} {} (atom {}))]
       (is (= text result)))))
 
-(deftest process-part-links-test
+;;; process-part-links tests
+
+(deftest ^:parallel process-part-links-text-parts-test
   (testing "processes text parts"
     (let [part {:type :text :text "[Link](metabase://model/123)"}
           result (links/process-part-links part {} {} (atom {}))]
       (is (= :text (:type result)))
-      (is (= "[Link](/model/123)" (:text result)))))
+      (is (= "[Link](/model/123)" (:text result))))))
 
+(deftest ^:parallel process-part-links-non-text-parts-test
   (testing "leaves non-text parts unchanged"
     (let [part {:type :tool-input :function "search" :arguments {:query "test"}}
           result (links/process-part-links part {} {} (atom {}))]
       (is (= part result)))))
 
-(deftest process-parts-links-test
+;;; process-parts-links tests
+
+(deftest ^:parallel process-parts-links-test
   (testing "processes all parts"
     (let [parts [{:type :text :text "[A](metabase://model/1)"}
                  {:type :tool-input :function "search"}
@@ -109,7 +128,9 @@
       (is (= {:type :tool-input :function "search"} (second result)))
       (is (= "[B](/metric/2)" (-> result (nth 2) :text))))))
 
-(deftest resolve-links-xf-test
+;;; resolve-links-xf tests
+
+(deftest ^:parallel resolve-links-xf-processes-text-parts-test
   (testing "transducer processes text parts"
     (let [parts [{:type :text :text "[A](metabase://model/1)"}
                  {:type :tool-input :function "search"}
@@ -118,8 +139,9 @@
       (is (= 3 (count result)))
       (is (= "[A](/model/1)" (-> result first :text)))
       (is (= {:type :tool-input :function "search"} (second result)))
-      (is (= "[B](/metric/2)" (-> result (nth 2) :text)))))
+      (is (= "[B](/metric/2)" (-> result (nth 2) :text))))))
 
+(deftest ^:parallel resolve-links-xf-with-transduce-test
   (testing "transducer works with transduce"
     (let [query-id "q1"
           query {:database 1 :type :query :query {:source-table 1}}
@@ -130,8 +152,9 @@
                             []
                             parts)]
       (is (= 1 (count result)))
-      (is (str/starts-with? (-> result first :text) "[Query](/question#"))))
+      (is (str/starts-with? (-> result first :text) "[Query](/question#")))))
 
+(deftest ^:parallel resolve-links-xf-composes-test
   (testing "transducer composes with other transducers"
     (let [parts [{:type :text :text "[A](metabase://model/1)"}
                  {:type :text :text "[B](metabase://model/2)"}
@@ -142,8 +165,9 @@
                        parts)]
       (is (= 2 (count result)))
       (is (= "[A](/model/1)" (-> result first :text)))
-      (is (= "[B](/model/2)" (-> result second :text)))))
+      (is (= "[B](/model/2)" (-> result second :text))))))
 
+(deftest ^:parallel resolve-links-xf-nil-state-test
   (testing "transducer handles nil state maps"
     (let [parts [{:type :text :text "[Link](metabase://model/123)"}]
           result (into [] (links/resolve-links-xf nil nil (atom {})) parts)]
@@ -151,64 +175,73 @@
 
 ;;; Nil handling tests - important for robustness against LLM edge cases
 
-(deftest resolve-metabase-uri-nil-handling-test
+(deftest ^:parallel resolve-metabase-uri-nil-uri-test
   (testing "handles nil URI gracefully"
-    (is (nil? (links/resolve-metabase-uri nil {} {}))))
+    (is (nil? (links/resolve-metabase-uri nil {} {})))))
 
+(deftest ^:parallel resolve-metabase-uri-empty-string-test
   (testing "handles empty string URI"
-    (is (nil? (links/resolve-metabase-uri "" {} {}))))
+    (is (nil? (links/resolve-metabase-uri "" {} {})))))
 
+(deftest ^:parallel resolve-metabase-uri-nil-state-maps-test
   (testing "handles nil queries-state and charts-state"
     (is (= "/model/123" (links/resolve-metabase-uri "metabase://model/123" nil nil)))
     (is (= "/metric/456" (links/resolve-metabase-uri "metabase://metric/456" nil nil)))))
 
-(deftest resolve-links-nil-handling-test
+(deftest ^:parallel resolve-links-nil-text-test
   (testing "handles nil text gracefully"
-    ;; Note: This test verifies the function doesn't throw on edge cases
-    ;; The actual behavior may need adjustment based on requirements
     (let [result (links/resolve-links nil {} {} (atom {}))]
-      (is (nil? result))))
+      (is (nil? result)))))
 
+(deftest ^:parallel resolve-links-text-without-links-test
   (testing "handles text with nil URL in regex capture groups"
-    ;; This tests the case where markdown regex captures nil
     (let [text "Some text without links"
           result (links/resolve-links text {} {} (atom {}))]
-      (is (= text result))))
+      (is (= text result)))))
 
+(deftest ^:parallel resolve-links-empty-text-test
   (testing "handles empty text"
     (let [result (links/resolve-links "" {} {} (atom {}))]
-      (is (= "" result))))
+      (is (= "" result)))))
 
+(deftest ^:parallel resolve-links-nil-state-maps-test
   (testing "handles nil state maps"
     (let [text "[Link](metabase://model/123)"
           result (links/resolve-links text nil nil (atom {}))]
       (is (str/includes? result "[Link](/model/123)")))))
 
-(deftest process-part-links-edge-cases-test
+;;; process-part-links edge cases
+
+(deftest ^:parallel process-part-links-nil-text-test
   (testing "handles part with nil text"
     (let [part {:type :text :text nil}
           result (links/process-part-links part {} {} (atom {}))]
       (is (= :text (:type result)))
-      (is (nil? (:text result)))))
+      (is (nil? (:text result))))))
 
+(deftest ^:parallel process-part-links-empty-text-test
   (testing "handles part with empty text"
     (let [part {:type :text :text ""}
           result (links/process-part-links part {} {} (atom {}))]
       (is (= :text (:type result)))
-      (is (= "" (:text result)))))
+      (is (= "" (:text result))))))
 
+(deftest ^:parallel process-part-links-missing-type-test
   (testing "handles part without :type key"
     (let [part {:text "[Link](metabase://model/1)"}
           result (links/process-part-links part {} {} (atom {}))]
       ;; Should return unchanged since :type is not :text
-      (is (= part result))))
+      (is (= part result)))))
 
+(deftest ^:parallel process-part-links-tool-output-test
   (testing "handles tool-output parts (should not process links)"
     (let [part {:type :tool-output :id "test-123" :result {:data "test"}}
           result (links/process-part-links part {} {} (atom {}))]
       (is (= part result)))))
 
-(deftest chart-link-resolution-test
+;;; chart-link-resolution tests
+
+(deftest ^:parallel chart-link-resolves-with-state-test
   (testing "resolves chart links correctly with state"
     (let [query-id      "q-abc-123"
           chart-id      "chart-xyz-789"
@@ -217,12 +250,14 @@
           charts-state  {chart-id {:query-id query-id :chart-type :bar}}
           result        (links/resolve-metabase-uri (str "metabase://chart/" chart-id) queries-state charts-state)]
       (is (string? result))
-      (is (str/starts-with? result "/question#"))))
+      (is (str/starts-with? result "/question#")))))
 
+(deftest ^:parallel chart-link-nil-when-not-found-test
   (testing "chart link returns nil when chart not found and no query fallback"
     (let [result (links/resolve-metabase-uri "metabase://chart/nonexistent" {} {})]
-      (is (nil? result))))
+      (is (nil? result)))))
 
+(deftest ^:parallel chart-link-falls-back-to-query-test
   (testing "chart link falls back to query when chart-id matches query-id"
     (let [query-id      "shared-id-123"
           query         {:database 1 :type :query :query {:source-table 1}}
@@ -230,8 +265,9 @@
           charts-state  {}
           result        (links/resolve-metabase-uri (str "metabase://chart/" query-id) queries-state charts-state)]
       (is (string? result))
-      (is (str/starts-with? result "/question#"))))
+      (is (str/starts-with? result "/question#")))))
 
+(deftest ^:parallel chart-link-missing-query-in-chart-state-test
   (testing "chart link resolution with missing query-id in chart state"
     ;; Chart exists but references a query that doesn't exist
     (let [charts-state {"chart-1" {:query-id "missing-query" :chart-type :line}}
@@ -239,18 +275,22 @@
       ;; Should return nil since the underlying query can't be resolved
       (is (nil? result)))))
 
-(deftest query-link-resolution-test
+;;; query-link-resolution tests
+
+(deftest ^:parallel query-link-valid-query-test
   (testing "resolves query links with valid query in state"
     (let [query-id      "test-query-id"
           query         {:database 1 :type :query :query {:source-table 1}}
           queries-state {query-id query}
           result        (links/resolve-metabase-uri (str "metabase://query/" query-id) queries-state {})]
       (is (string? result))
-      (is (str/starts-with? result "/question#"))))
+      (is (str/starts-with? result "/question#")))))
 
+(deftest ^:parallel query-link-missing-query-test
   (testing "returns nil for missing query"
-    (is (nil? (links/resolve-metabase-uri "metabase://query/nonexistent" {} {}))))
+    (is (nil? (links/resolve-metabase-uri "metabase://query/nonexistent" {} {})))))
 
+(deftest ^:parallel query-link-complex-nested-structure-test
   (testing "handles query with complex nested structure"
     (let [query-id      "complex-query"
           query         {:database 1
@@ -263,7 +303,9 @@
       (is (string? result))
       (is (str/starts-with? result "/question#")))))
 
-(deftest multiple-links-in-text-test
+;;; multiple-links tests
+
+(deftest ^:parallel multiple-different-link-types-test
   (testing "processes multiple different link types in same text"
     (let [query-id "q1"
           query {:database 1 :type :query :query {:source-table 1}}
@@ -272,8 +314,9 @@
           result (links/resolve-links text queries-state {} (atom {}))]
       (is (str/includes? result "[Model](/model/1)"))
       (is (str/includes? result "[Metric](/metric/2)"))
-      (is (str/includes? result "/question#"))))
+      (is (str/includes? result "/question#")))))
 
+(deftest ^:parallel preserves-text-between-links-test
   (testing "preserves text between links"
     (let [text "Start [A](metabase://model/1) middle [B](metabase://model/2) end"
           result (links/resolve-links text {} {} (atom {}))]
@@ -281,20 +324,24 @@
       (is (str/includes? result " middle "))
       (is (str/includes? result " end")))))
 
-(deftest special-characters-in-links-test
+;;; special-characters tests
+
+(deftest ^:parallel link-text-with-special-characters-test
   (testing "handles link text with special characters"
     (let [text   "[Link with (parens)](metabase://model/1)"
           result (links/resolve-links text {} {} (atom {}))]
       ;; Markdown parser should handle this - may or may not match depending on regex
-      (is (string? result))))
+      (is (string? result)))))
 
+(deftest ^:parallel uuid-entity-ids-test
   (testing "handles entity IDs that look like UUIDs"
     (let [query-id      "550e8400-e29b-41d4-a716-446655440000"
           query         {:database 1 :type :query :query {:source-table 1}}
           queries-state {query-id query}
           result        (links/resolve-metabase-uri (str "metabase://query/" query-id) queries-state {})]
-      (is (string? result))))
+      (is (string? result)))))
 
+(deftest ^:parallel nano-id-entity-ids-test
   (testing "handles nano-id style identifiers"
     (let [query-id      "puL95JSvym3k23W1UUuog"
           query         {:database 1 :type :query :query {:source-table 1}}

--- a/test/metabase/metabot/agent/links_test.clj
+++ b/test/metabase/metabot/agent/links_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]
+   [metabase.lib.test-util :as lib.tu]
    [metabase.metabot.agent.links :as links]))
 
 (deftest resolve-metabase-uri-test
@@ -65,36 +66,36 @@
           queries-state {query-id query}
           charts-state {}
           text "Check out [My Results](metabase://query/test-query) for details."
-          result (links/resolve-links text queries-state charts-state)]
+          result (links/resolve-links text queries-state charts-state (atom {}))]
       (is (str/includes? result "[My Results](/question#"))
       (is (not (str/includes? result "metabase://")))))
 
   (testing "preserves non-metabase links"
     (let [text "Visit [Google](https://google.com) for more."
-          result (links/resolve-links text {} {})]
+          result (links/resolve-links text {} {} (atom {}))]
       (is (= text result))))
 
   (testing "handles multiple links"
     (let [text "[Model](metabase://model/1) and [Metric](metabase://metric/2)"
-          result (links/resolve-links text {} {})]
+          result (links/resolve-links text {} {} (atom {}))]
       (is (str/includes? result "[Model](/model/1)"))
       (is (str/includes? result "[Metric](/metric/2)"))))
 
   (testing "handles text without links"
     (let [text "Just some plain text"
-          result (links/resolve-links text {} {})]
+          result (links/resolve-links text {} {} (atom {}))]
       (is (= text result)))))
 
 (deftest process-part-links-test
   (testing "processes text parts"
     (let [part {:type :text :text "[Link](metabase://model/123)"}
-          result (links/process-part-links part {} {})]
+          result (links/process-part-links part {} {} (atom {}))]
       (is (= :text (:type result)))
       (is (= "[Link](/model/123)" (:text result)))))
 
   (testing "leaves non-text parts unchanged"
     (let [part {:type :tool-input :function "search" :arguments {:query "test"}}
-          result (links/process-part-links part {} {})]
+          result (links/process-part-links part {} {} (atom {}))]
       (is (= part result)))))
 
 (deftest process-parts-links-test
@@ -102,7 +103,7 @@
     (let [parts [{:type :text :text "[A](metabase://model/1)"}
                  {:type :tool-input :function "search"}
                  {:type :text :text "[B](metabase://metric/2)"}]
-          result (links/process-parts-links parts {} {})]
+          result (links/process-parts-links parts {} {} (atom {}))]
       (is (= 3 (count result)))
       (is (= "[A](/model/1)" (-> result first :text)))
       (is (= {:type :tool-input :function "search"} (second result)))
@@ -113,7 +114,7 @@
     (let [parts [{:type :text :text "[A](metabase://model/1)"}
                  {:type :tool-input :function "search"}
                  {:type :text :text "[B](metabase://metric/2)"}]
-          result (into [] (links/resolve-links-xf {} {}) parts)]
+          result (into [] (links/resolve-links-xf {} {} (atom {})) parts)]
       (is (= 3 (count result)))
       (is (= "[A](/model/1)" (-> result first :text)))
       (is (= {:type :tool-input :function "search"} (second result)))
@@ -124,7 +125,7 @@
           query {:database 1 :type :query :query {:source-table 1}}
           queries-state {query-id query}
           parts [{:type :text :text "[Query](metabase://query/q1)"}]
-          result (transduce (links/resolve-links-xf queries-state {})
+          result (transduce (links/resolve-links-xf queries-state {} (atom {}))
                             conj
                             []
                             parts)]
@@ -136,7 +137,7 @@
                  {:type :text :text "[B](metabase://model/2)"}
                  {:type :tool-input :function "search"}]
           result (into []
-                       (comp (links/resolve-links-xf {} {})
+                       (comp (links/resolve-links-xf {} {} (atom {}))
                              (filter #(= :text (:type %))))
                        parts)]
       (is (= 2 (count result)))
@@ -145,7 +146,7 @@
 
   (testing "transducer handles nil state maps"
     (let [parts [{:type :text :text "[Link](metabase://model/123)"}]
-          result (into [] (links/resolve-links-xf nil nil) parts)]
+          result (into [] (links/resolve-links-xf nil nil (atom {})) parts)]
       (is (= "[Link](/model/123)" (-> result first :text))))))
 
 ;;; Nil handling tests - important for robustness against LLM edge cases
@@ -165,46 +166,46 @@
   (testing "handles nil text gracefully"
     ;; Note: This test verifies the function doesn't throw on edge cases
     ;; The actual behavior may need adjustment based on requirements
-    (let [result (links/resolve-links nil {} {})]
+    (let [result (links/resolve-links nil {} {} (atom {}))]
       (is (nil? result))))
 
   (testing "handles text with nil URL in regex capture groups"
     ;; This tests the case where markdown regex captures nil
     (let [text "Some text without links"
-          result (links/resolve-links text {} {})]
+          result (links/resolve-links text {} {} (atom {}))]
       (is (= text result))))
 
   (testing "handles empty text"
-    (let [result (links/resolve-links "" {} {})]
+    (let [result (links/resolve-links "" {} {} (atom {}))]
       (is (= "" result))))
 
   (testing "handles nil state maps"
     (let [text "[Link](metabase://model/123)"
-          result (links/resolve-links text nil nil)]
+          result (links/resolve-links text nil nil (atom {}))]
       (is (str/includes? result "[Link](/model/123)")))))
 
 (deftest process-part-links-edge-cases-test
   (testing "handles part with nil text"
     (let [part {:type :text :text nil}
-          result (links/process-part-links part {} {})]
+          result (links/process-part-links part {} {} (atom {}))]
       (is (= :text (:type result)))
       (is (nil? (:text result)))))
 
   (testing "handles part with empty text"
     (let [part {:type :text :text ""}
-          result (links/process-part-links part {} {})]
+          result (links/process-part-links part {} {} (atom {}))]
       (is (= :text (:type result)))
       (is (= "" (:text result)))))
 
   (testing "handles part without :type key"
     (let [part {:text "[Link](metabase://model/1)"}
-          result (links/process-part-links part {} {})]
+          result (links/process-part-links part {} {} (atom {}))]
       ;; Should return unchanged since :type is not :text
       (is (= part result))))
 
   (testing "handles tool-output parts (should not process links)"
     (let [part {:type :tool-output :id "test-123" :result {:data "test"}}
-          result (links/process-part-links part {} {})]
+          result (links/process-part-links part {} {} (atom {}))]
       (is (= part result)))))
 
 (deftest chart-link-resolution-test
@@ -268,14 +269,14 @@
           query {:database 1 :type :query :query {:source-table 1}}
           queries-state {query-id query}
           text "See [Model](metabase://model/1), [Metric](metabase://metric/2), and [Query](metabase://query/q1)"
-          result (links/resolve-links text queries-state {})]
+          result (links/resolve-links text queries-state {} (atom {}))]
       (is (str/includes? result "[Model](/model/1)"))
       (is (str/includes? result "[Metric](/metric/2)"))
       (is (str/includes? result "/question#"))))
 
   (testing "preserves text between links"
     (let [text "Start [A](metabase://model/1) middle [B](metabase://model/2) end"
-          result (links/resolve-links text {} {})]
+          result (links/resolve-links text {} {} (atom {}))]
       (is (str/includes? result "Start "))
       (is (str/includes? result " middle "))
       (is (str/includes? result " end")))))
@@ -283,7 +284,7 @@
 (deftest special-characters-in-links-test
   (testing "handles link text with special characters"
     (let [text   "[Link with (parens)](metabase://model/1)"
-          result (links/resolve-links text {} {})]
+          result (links/resolve-links text {} {} (atom {}))]
       ;; Markdown parser should handle this - may or may not match depending on regex
       (is (string? result))))
 
@@ -300,3 +301,115 @@
           queries-state {query-id query}
           result        (links/resolve-metabase-uri (str "metabase://query/" query-id) queries-state {})]
       (is (string? result)))))
+
+;;; Link registry recording tests
+
+(deftest ^:parallel resolve-links-records-entity-links-in-registry-test
+  (testing "records resolved entity links in registry atom"
+    (let [registry (atom {})
+          text     "[Model](metabase://model/123) and [Metric](metabase://metric/456)"
+          _result  (links/resolve-links text {} {} registry)]
+      (is (= {"/model/123"  "metabase://model/123"
+              "/metric/456" "metabase://metric/456"}
+             @registry)))))
+
+(deftest ^:parallel resolve-links-records-query-links-in-registry-test
+  (testing "records resolved query links in registry atom"
+    (let [registry      (atom {})
+          query-id      "q1"
+          queries-state {query-id (lib.tu/venues-query)}
+          result        (links/resolve-links "[Results](metabase://query/q1)" queries-state {} registry)
+          resolved-url  (second (re-find #"\[Results\]\((/question#[^)]+)\)" result))]
+      (is (= 1 (count @registry)))
+      (is (= "metabase://query/q1" (get @registry resolved-url))))))
+
+(deftest ^:parallel resolve-links-records-dashboard-table-transform-links-test
+  (testing "records dashboard, table, and transform links"
+    (let [registry (atom {})
+          text     "[Dash](metabase://dashboard/10) [Tbl](metabase://table/20) [Tx](metabase://transform/30)"
+          _result  (links/resolve-links text {} {} registry)]
+      (is (= {"/dashboard/10"        "metabase://dashboard/10"
+              "/table/20"            "metabase://table/20"
+              "/admin/transforms/30" "metabase://transform/30"}
+             @registry)))))
+
+(deftest ^:parallel resolve-links-does-not-record-failed-resolutions-test
+  (testing "does not record failed resolutions"
+    (let [registry (atom {})
+          text     "[Missing](metabase://query/nonexistent)"
+          _result  (links/resolve-links text {} {} registry)]
+      (is (empty? @registry)))))
+
+(deftest ^:parallel resolve-links-does-not-record-non-metabase-links-test
+  (testing "does not record non-metabase links"
+    (let [registry (atom {})
+          text     "[Google](https://google.com)"
+          _result  (links/resolve-links text {} {} registry)]
+      (is (empty? @registry)))))
+
+;;; invert-links tests
+
+(deftest ^:parallel invert-links-replaces-resolved-urls-test
+  (testing "replaces resolved URLs with original metabase URIs"
+    (let [registry {"/model/123"  "metabase://model/123"
+                    "/metric/456" "metabase://metric/456"}
+          text     "[Model](/model/123) and [Metric](/metric/456)"]
+      (is (= "[Model](metabase://model/123) and [Metric](metabase://metric/456)"
+             (links/invert-links text registry))))))
+
+(deftest ^:parallel invert-links-unchanged-for-empty-registry-test
+  (testing "returns text unchanged for empty registry"
+    (let [text "some text with [Link](/model/123)"]
+      (is (= text (links/invert-links text {})))
+      (is (= text (links/invert-links text nil))))))
+
+(deftest ^:parallel invert-links-nil-input-test
+  (testing "returns non-string input unchanged"
+    (is (nil? (links/invert-links nil {"/a" "b"})))))
+
+(deftest ^:parallel invert-links-no-matching-entries-test
+  (testing "handles registry entries that don't match text"
+    (let [text "no links here"]
+      (is (= text
+             (links/invert-links text {"/model/999" "metabase://model/999"}))))))
+
+(deftest ^:parallel invert-links-base64-with-regex-special-chars-test
+  (testing "handles base64 URLs with regex-special characters"
+    (let [resolved "/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7fX0="
+          original "metabase://query/q1"
+          registry {resolved original}
+          text     (str "[Results](" resolved ")")]
+      (is (= "[Results](metabase://query/q1)"
+             (links/invert-links text registry))))))
+
+;;; Round-trip tests
+
+(deftest ^:parallel round-trip-entity-links-test
+  (testing "round-trip: resolve then invert returns original text for entity links"
+    (let [original "[Model](metabase://model/123) and [Dashboard](metabase://dashboard/456)"
+          registry (atom {})
+          resolved (links/resolve-links original {} {} registry)
+          inverted (links/invert-links resolved @registry)]
+      (is (= original inverted)))))
+
+(deftest ^:parallel round-trip-query-links-test
+  (testing "round-trip: resolve then invert for query links"
+    (let [query-id      "q1"
+          queries-state {query-id (lib.tu/venues-query)}
+          original      "[Results](metabase://query/q1)"
+          registry      (atom {})
+          resolved      (links/resolve-links original queries-state {} registry)
+          inverted      (links/invert-links resolved @registry)]
+      (is (= original inverted)))))
+
+(deftest ^:parallel round-trip-mixed-link-types-test
+  (testing "round-trip: mixed link types"
+    (let [query-id      "q1"
+          queries-state {query-id (lib.tu/venues-query)}
+          original      (str "See [Model](metabase://model/1), "
+                             "[Query](metabase://query/q1), and "
+                             "[Table](metabase://table/42)")
+          registry      (atom {})
+          resolved      (links/resolve-links original queries-state {} registry)
+          inverted      (links/invert-links resolved @registry)]
+      (is (= original inverted)))))

--- a/test/metabase/metabot/agent/links_test.clj
+++ b/test/metabase/metabot/agent/links_test.clj
@@ -476,15 +476,15 @@
   (testing "resolves Slack-format metabase:// entity links"
     (mt/with-temporary-setting-values [site-url "https://metabase.example.com"]
       (is (= "<https://metabase.example.com/model/123|My Model>"
-             (links/resolve-slack-links "<metabase://model/123|My Model>" {} {})))
+             (links/resolve-slack-links "<metabase://model/123|My Model>" {} {} (atom {}))))
       (is (= "<https://metabase.example.com/dashboard/456>"
-             (links/resolve-slack-links "<metabase://dashboard/456>" {} {}))))))
+             (links/resolve-slack-links "<metabase://dashboard/456>" {} {} (atom {})))))))
 
 (deftest resolve-slack-links-query-links-test
   (testing "resolves Slack-format metabase://query links"
     (mt/with-temporary-setting-values [site-url "https://metabase.example.com"]
       (let [query   (lib.tu/venues-query)
-            result  (links/resolve-slack-links "<metabase://query/q1|Results>" {"q1" query} {})]
+            result  (links/resolve-slack-links "<metabase://query/q1|Results>" {"q1" query} {} (atom {}))]
         (is (str/starts-with? result "<https://metabase.example.com/question#"))
         (is (str/ends-with? result "|Results>"))))))
 
@@ -492,17 +492,108 @@
   (testing "resolves multiple Slack-format links"
     (mt/with-temporary-setting-values [site-url "https://mb.test"]
       (is (= "<https://mb.test/model/1|Model A> and <https://mb.test/metric/2|Metric B>"
-             (links/resolve-slack-links "<metabase://model/1|Model A> and <metabase://metric/2|Metric B>" {} {}))))))
+             (links/resolve-slack-links "<metabase://model/1|Model A> and <metabase://metric/2|Metric B>" {} {} (atom {})))))))
 
 (deftest ^:parallel resolve-slack-links-unresolvable-test
   (testing "falls back to link text for unresolvable Slack link"
     (is (= "My Query"
-           (links/resolve-slack-links "<metabase://query/unknown|My Query>" {} {}))))
+           (links/resolve-slack-links "<metabase://query/unknown|My Query>" {} {} (atom {})))))
   (testing "falls back to URL for unresolvable Slack link without text"
     (is (= "metabase://query/unknown"
-           (links/resolve-slack-links "<metabase://query/unknown>" {} {})))))
+           (links/resolve-slack-links "<metabase://query/unknown>" {} {} (atom {}))))))
 
 (deftest ^:parallel resolve-slack-links-no-links-test
   (testing "passes through text without Slack links"
-    (is (= "plain text" (links/resolve-slack-links "plain text" {} {})))
-    (is (= "x < y" (links/resolve-slack-links "x < y" {} {})))))
+    (is (= "plain text" (links/resolve-slack-links "plain text" {} {} (atom {}))))
+    (is (= "x < y" (links/resolve-slack-links "x < y" {} {} (atom {}))))))
+
+;;; Slack link registry recording tests
+
+(deftest resolve-slack-links-records-entity-links-in-registry-test
+  (testing "records resolved Slack entity links in registry atom"
+    (mt/with-temporary-setting-values [site-url "https://metabase.example.com"]
+      (let [registry (atom {})
+            _result  (links/resolve-slack-links "<metabase://model/123|My Model> and <metabase://metric/456>"
+                                                {} {} registry)]
+        (is (= {"https://metabase.example.com/model/123"  "metabase://model/123"
+                "https://metabase.example.com/metric/456" "metabase://metric/456"}
+               @registry))))))
+
+(deftest resolve-slack-links-records-query-links-in-registry-test
+  (testing "records resolved Slack query links in registry atom"
+    (mt/with-temporary-setting-values [site-url "https://metabase.example.com"]
+      (let [registry (atom {})
+            query    (lib.tu/venues-query)
+            result   (links/resolve-slack-links "<metabase://query/q1|Results>" {"q1" query} {} registry)
+            url      (second (re-find #"<([^|>]+)" result))]
+        (is (= 1 (count @registry)))
+        (is (= "metabase://query/q1" (get @registry url)))))))
+
+(deftest ^:parallel resolve-slack-links-does-not-record-failed-resolutions-test
+  (testing "does not record failed Slack resolutions"
+    (let [registry (atom {})
+          _result  (links/resolve-slack-links "<metabase://query/nonexistent|Missing>" {} {} registry)]
+      (is (empty? @registry)))))
+
+;;; invert-slack-links tests
+
+(deftest ^:parallel invert-slack-links-replaces-resolved-urls-test
+  (testing "replaces resolved absolute URLs with original metabase URIs"
+    (let [registry {"https://metabase.example.com/model/123"  "metabase://model/123"
+                    "https://metabase.example.com/metric/456" "metabase://metric/456"}
+          text     "<https://metabase.example.com/model/123|Model> and <https://metabase.example.com/metric/456|Metric>"]
+      (is (= "<metabase://model/123|Model> and <metabase://metric/456|Metric>"
+             (links/invert-slack-links text registry))))))
+
+(deftest ^:parallel invert-slack-links-without-link-text-test
+  (testing "inverts Slack links that have no display text"
+    (let [registry {"https://metabase.example.com/dashboard/1" "metabase://dashboard/1"}
+          text     "<https://metabase.example.com/dashboard/1>"]
+      (is (= "<metabase://dashboard/1>"
+             (links/invert-slack-links text registry))))))
+
+(deftest ^:parallel invert-slack-links-unchanged-for-empty-registry-test
+  (testing "returns text unchanged for empty registry"
+    (let [text "<https://metabase.example.com/model/123|Model>"]
+      (is (= text (links/invert-slack-links text {})))
+      (is (= text (links/invert-slack-links text nil))))))
+
+(deftest ^:parallel invert-slack-links-nil-input-test
+  (testing "returns non-string input unchanged"
+    (is (nil? (links/invert-slack-links nil {"https://a.com/b" "metabase://b"})))))
+
+(deftest ^:parallel invert-slack-links-no-matching-entries-test
+  (testing "handles registry entries that don't match text"
+    (let [text "no links here"]
+      (is (= text
+             (links/invert-slack-links text {"https://a.com/model/1" "metabase://model/1"}))))))
+
+;;; Slack round-trip tests
+
+(deftest round-trip-slack-entity-links-test
+  (testing "round-trip: resolve then invert returns original text for Slack entity links"
+    (mt/with-temporary-setting-values [site-url "https://metabase.example.com"]
+      (let [original "<metabase://model/123|My Model> and <metabase://dashboard/456|Dash>"
+            registry (atom {})
+            resolved (links/resolve-slack-links original {} {} registry)
+            inverted (links/invert-slack-links resolved @registry)]
+        (is (= original inverted))))))
+
+(deftest round-trip-slack-query-links-test
+  (testing "round-trip: resolve then invert for Slack query links"
+    (mt/with-temporary-setting-values [site-url "https://metabase.example.com"]
+      (let [query    (lib.tu/venues-query)
+            original "<metabase://query/q1|Results>"
+            registry (atom {})
+            resolved (links/resolve-slack-links original {"q1" query} {} registry)
+            inverted (links/invert-slack-links resolved @registry)]
+        (is (= original inverted))))))
+
+(deftest round-trip-slack-no-text-links-test
+  (testing "round-trip: resolve then invert for Slack links without display text"
+    (mt/with-temporary-setting-values [site-url "https://metabase.example.com"]
+      (let [original "<metabase://dashboard/789>"
+            registry (atom {})
+            resolved (links/resolve-slack-links original {} {} registry)
+            inverted (links/invert-slack-links resolved @registry)]
+        (is (= original inverted))))))

--- a/test/metabase/metabot/agent/markdown_link_buffer_test.clj
+++ b/test/metabase/metabot/agent/markdown_link_buffer_test.clj
@@ -3,7 +3,7 @@
    [clojure.test :refer :all]
    [metabase.lib.test-util :as lib.tu]
    [metabase.metabot.agent.markdown-link-buffer :as mlb]
-   [metabase.system.core :as system]))
+   [metabase.test :as mt]))
 
 (defn- process
   "Process text through a fresh state with given queries/charts context.
@@ -146,13 +146,13 @@
 
 (deftest resolve-slack-link-test
   (testing "resolves Slack-format metabase:// links"
-    (with-redefs [system/site-url (constantly "https://metabase.example.com")]
+    (mt/with-temporary-setting-values [site-url "https://metabase.example.com"]
       (let [[output flushed] (process "<metabase://model/123|My Model>")]
         (is (= "<https://metabase.example.com/model/123|My Model>" output))
         (is (= "" flushed)))))
 
   (testing "resolves Slack link without link text"
-    (with-redefs [system/site-url (constantly "https://metabase.example.com")]
+    (mt/with-temporary-setting-values [site-url "https://metabase.example.com"]
       (let [[output flushed] (process "<metabase://dashboard/456>")]
         (is (= "<https://metabase.example.com/dashboard/456>" output))
         (is (= "" flushed)))))
@@ -164,7 +164,7 @@
 
 (deftest slack-link-buffering-test
   (testing "buffers incomplete Slack-format links"
-    (with-redefs [system/site-url (constantly "https://metabase.example.com")]
+    (mt/with-temporary-setting-values [site-url "https://metabase.example.com"]
       (let [[outputs flushed] (process-chunks ["Check <metabase://mod" "el/123|My Model>"])]
         (is (= "Check " (first outputs)))
         (is (re-find #"metabase\.example\.com/model/123" (second outputs)))
@@ -177,7 +177,7 @@
 
 (deftest mixed-link-formats-test
   (testing "resolves both markdown and Slack-format links in same text"
-    (with-redefs [system/site-url (constantly "https://metabase.example.com")]
+    (mt/with-temporary-setting-values [site-url "https://metabase.example.com"]
       (let [[output flushed] (process "[Model](/model/1) and <metabase://dashboard/2|Dashboard>")]
         (is (= "[Model](/model/1) and <https://metabase.example.com/dashboard/2|Dashboard>" output))
         (is (= "" flushed))))))

--- a/test/metabase/metabot/agent/markdown_link_buffer_test.clj
+++ b/test/metabase/metabot/agent/markdown_link_buffer_test.clj
@@ -69,7 +69,7 @@
 
 (deftest resolve-query-link-test
   (testing "resolves metabase://query links using queries-state"
-    (let [query {:database 1 :type :query :query {:source-table 1}}
+    (let [query (lib.tu/venues-query)
           [output flushed] (process "[Results](metabase://query/q-123)" {"q-123" query})]
       (is (=? resolved-link-re output))
       (is (not (re-find #"metabase://" output)))
@@ -81,14 +81,14 @@
       (is (= "" flushed))))
 
   (testing "incomplete chunks are also replaced well"
-    (let [query {:database 1 :type :query :query {:source-table 1}}
+    (let [query (lib.tu/venues-query)
           [output flushed] (process-chunks ["Your [Res" "ults](metabase://qu" "ery/q-123)"] {"q-123" query})]
       (is (=? ["Your " "" resolved-link-re] output))
       (is (= "" flushed)))))
 
 (deftest resolve-chart-link-test
   (testing "resolves metabase://chart links using charts-state"
-    (let [query {:database 1 :type :query :query {:source-table 1}}
+    (let [query (lib.tu/venues-query)
           queries {"q-456" query}
           charts {"c-789" {:query-id "q-456" :chart-type :bar}}
           [output flushed] (process "[My Chart](metabase://chart/c-789)" queries charts)]
@@ -124,7 +124,7 @@
 
 (deftest resolve-link-split-across-chunks-test
   (testing "resolves metabase:// link split across multiple chunks"
-    (let [query {:database 1 :type :query :query {:source-table 1}}
+    (let [query (lib.tu/venues-query)
           [outputs flushed] (process-chunks ["Check [Results](metabase://" "query/split-query)"]
                                             {"split-query" query})]
       (is (= "Check " (first outputs)))

--- a/test/metabase/metabot/agent/markdown_link_buffer_test.clj
+++ b/test/metabase/metabot/agent/markdown_link_buffer_test.clj
@@ -145,18 +145,18 @@
 ;;; Slack link resolution tests
 
 (deftest resolve-slack-link-test
-  (testing "resolves Slack-format metabase:// links"
-    (mt/with-temporary-setting-values [site-url "https://metabase.example.com"]
+  (mt/with-temporary-setting-values [site-url "https://metabase.example.com"]
+    (testing "resolves Slack-format metabase:// links"
       (let [[output flushed] (process "<metabase://model/123|My Model>")]
         (is (= "<https://metabase.example.com/model/123|My Model>" output))
-        (is (= "" flushed)))))
+        (is (= "" flushed))))
 
-  (testing "resolves Slack link without link text"
-    (mt/with-temporary-setting-values [site-url "https://metabase.example.com"]
+    (testing "resolves Slack link without link text"
       (let [[output flushed] (process "<metabase://dashboard/456>")]
         (is (= "<https://metabase.example.com/dashboard/456>" output))
-        (is (= "" flushed)))))
+        (is (= "" flushed))))))
 
+(deftest ^:parallel resolve-slack-link-unresolvable-test
   (testing "falls back to link text for unresolvable Slack link"
     (let [[output flushed] (process "<metabase://query/unknown|My Query>")]
       (is (= "My Query" output))
@@ -168,16 +168,17 @@
       (let [[outputs flushed] (process-chunks ["Check <metabase://mod" "el/123|My Model>"])]
         (is (= "Check " (first outputs)))
         (is (re-find #"metabase\.example\.com/model/123" (second outputs)))
-        (is (= "" flushed)))))
+        (is (= "" flushed))))))
 
+(deftest ^:parallel slack-link-no-buffering-regular-angle-brackets-test
   (testing "does NOT buffer regular < characters"
     (let [[output flushed] (process "x < y and z > w")]
       (is (= "x < y and z > w" output))
       (is (= "" flushed)))))
 
 (deftest mixed-link-formats-test
-  (testing "resolves both markdown and Slack-format links in same text"
-    (mt/with-temporary-setting-values [site-url "https://metabase.example.com"]
+  (mt/with-temporary-setting-values [site-url "https://metabase.example.com"]
+    (testing "resolves both markdown and Slack-format links in same text"
       (let [[output flushed] (process "[Model](/model/1) and <metabase://dashboard/2|Dashboard>")]
         (is (= "[Model](/model/1) and <https://metabase.example.com/dashboard/2|Dashboard>" output))
         (is (= "" flushed))))))

--- a/test/metabase/metabot/agent/markdown_link_buffer_test.clj
+++ b/test/metabase/metabot/agent/markdown_link_buffer_test.clj
@@ -14,6 +14,15 @@
    (let [[state output] (mlb/step (mlb/with-context mlb/initial-state queries charts (atom {})) text)]
      [output (mlb/flush-state state)])))
 
+(defn- process-with-registry
+  "Like `process` but returns [output flushed registry-map]."
+  ([text] (process-with-registry text {} {}))
+  ([text queries] (process-with-registry text queries {}))
+  ([text queries charts]
+   (let [registry (atom {})
+         [state output] (mlb/step (mlb/with-context mlb/initial-state queries charts registry) text)]
+     [output (mlb/flush-state state) @registry])))
+
 (defn- process-chunks
   "Process multiple chunks through state, returns [outputs flushed]."
   ([chunks] (process-chunks chunks {} {}))
@@ -182,6 +191,27 @@
       (let [[output flushed] (process "[Model](/model/1) and <metabase://dashboard/2|Dashboard>")]
         (is (= "[Model](/model/1) and <https://metabase.example.com/dashboard/2|Dashboard>" output))
         (is (= "" flushed))))))
+
+;;; Slack link registry recording tests
+
+(deftest resolve-slack-link-records-in-registry-test
+  (mt/with-temporary-setting-values [site-url "https://metabase.example.com"]
+    (testing "records resolved Slack links in registry"
+      (let [[_output _flushed registry] (process-with-registry "<metabase://model/123|My Model>")]
+        (is (= {"https://metabase.example.com/model/123" "metabase://model/123"}
+               registry))))
+
+    (testing "records multiple Slack links in registry"
+      (let [[_output _flushed registry] (process-with-registry
+                                         "<metabase://model/1|A> and <metabase://dashboard/2|B>")]
+        (is (= {"https://metabase.example.com/model/1"     "metabase://model/1"
+                "https://metabase.example.com/dashboard/2" "metabase://dashboard/2"}
+               registry))))))
+
+(deftest ^:parallel resolve-slack-link-does-not-record-failed-in-registry-test
+  (testing "does not record failed Slack resolutions in registry"
+    (let [[_output _flushed registry] (process-with-registry "<metabase://query/unknown|Missing>")]
+      (is (empty? registry)))))
 
 ;;; with-context tests
 

--- a/test/metabase/metabot/agent/markdown_link_buffer_test.clj
+++ b/test/metabase/metabot/agent/markdown_link_buffer_test.clj
@@ -29,19 +29,19 @@
 
 ;;; State machine / buffering tests
 
-(deftest nested-bracket-handling-test
+(deftest ^:parallel nested-bracket-handling-test
   (testing "does not drop characters when nested brackets appear"
     (let [[output flushed] (process "[foo[")]
       (is (= "[foo" output))
       (is (= "[" flushed)))))
 
-(deftest basic-text-passthrough-test
+(deftest ^:parallel basic-text-passthrough-test
   (testing "passes through plain text unchanged"
     (let [[output flushed] (process "Hello world")]
       (is (= "Hello world" output))
       (is (= "" flushed)))))
 
-(deftest buffering-incomplete-link-test
+(deftest ^:parallel buffering-incomplete-link-test
   (testing "buffers incomplete markdown link"
     (let [[outputs flushed] (process-chunks ["Check [link" "](http://example.com)"])]
       (is (= ["Check " "[link](http://example.com)"] outputs))
@@ -57,7 +57,7 @@
       (is (= "Incomplete " output))
       (is (= "[link" flushed)))))
 
-(deftest regular-url-passthrough-test
+(deftest ^:parallel regular-url-passthrough-test
   (testing "passes through regular URLs unchanged"
     (let [[output flushed] (process "[Google](https://google.com)")]
       (is (= "[Google](https://google.com)" output))
@@ -67,7 +67,7 @@
 
 (def resolved-link-re #"\[Results\]\(/question#[a-zA-ZZ0-9=]+\)")
 
-(deftest resolve-query-link-test
+(deftest ^:parallel resolve-query-link-test
   (testing "resolves metabase://query links using queries-state"
     (let [query (lib.tu/venues-query)
           [output flushed] (process "[Results](metabase://query/q-123)" {"q-123" query})]
@@ -86,7 +86,7 @@
       (is (=? ["Your " "" resolved-link-re] output))
       (is (= "" flushed)))))
 
-(deftest resolve-chart-link-test
+(deftest ^:parallel resolve-chart-link-test
   (testing "resolves metabase://chart links using charts-state"
     (let [query (lib.tu/venues-query)
           queries {"q-456" query}
@@ -101,7 +101,7 @@
       (is (= "Chart" output))
       (is (= "" flushed)))))
 
-(deftest resolve-entity-link-test
+(deftest ^:parallel resolve-entity-link-test
   (testing "resolves metabase://model links"
     (let [[output flushed] (process "[My Model](metabase://model/123)")]
       (is (= "[My Model](/model/123)" output))
@@ -122,7 +122,7 @@
       (is (= "[Users Table](/table/42)" output))
       (is (= "" flushed)))))
 
-(deftest resolve-link-split-across-chunks-test
+(deftest ^:parallel resolve-link-split-across-chunks-test
   (testing "resolves metabase:// link split across multiple chunks"
     (let [query (lib.tu/venues-query)
           [outputs flushed] (process-chunks ["Check [Results](metabase://" "query/split-query)"]
@@ -131,7 +131,7 @@
       (is (re-find #"\[Results\]\(/question#" (second outputs)))
       (is (= "" flushed)))))
 
-(deftest multiple-links-in-text-test
+(deftest ^:parallel multiple-links-in-text-test
   (testing "resolves multiple links in same chunk"
     (let [[output flushed] (process "[Model A](metabase://model/1) and [Model B](metabase://model/2)")]
       (is (= "[Model A](/model/1) and [Model B](/model/2)" output))

--- a/test/metabase/metabot/agent/markdown_link_buffer_test.clj
+++ b/test/metabase/metabot/agent/markdown_link_buffer_test.clj
@@ -1,6 +1,7 @@
 (ns metabase.metabot.agent.markdown-link-buffer-test
   (:require
    [clojure.test :refer :all]
+   [metabase.lib.test-util :as lib.tu]
    [metabase.metabot.agent.markdown-link-buffer :as mlb]
    [metabase.system.core :as system]))
 
@@ -10,7 +11,7 @@
   ([text] (process text {} {}))
   ([text queries] (process text queries {}))
   ([text queries charts]
-   (let [[state output] (mlb/step (mlb/with-context mlb/initial-state queries charts) text)]
+   (let [[state output] (mlb/step (mlb/with-context mlb/initial-state queries charts (atom {})) text)]
      [output (mlb/flush-state state)])))
 
 (defn- process-chunks
@@ -18,7 +19,7 @@
   ([chunks] (process-chunks chunks {} {}))
   ([chunks queries] (process-chunks chunks queries {}))
   ([chunks queries charts]
-   (loop [state (mlb/with-context mlb/initial-state queries charts)
+   (loop [state (mlb/with-context mlb/initial-state queries charts (atom {}))
           [chunk & more] chunks
           outputs []]
      (if chunk
@@ -183,15 +184,41 @@
 
 ;;; with-context tests
 
-(deftest with-context-test
+(deftest ^:parallel resolve-xf-records-link-registry-test
+  (testing "resolve-xf records resolved links in link-registry-atom"
+    (let [registry (atom {})
+          parts    [{:type :text :text "[Model](metabase://model/1)"}
+                    {:type :text :text " and [Dash](metabase://dashboard/2)"}]
+          result   (into [] (mlb/resolve-xf {} {} registry) parts)]
+      (is (= "[Model](/model/1)" (-> result first :text)))
+      (is (= " and [Dash](/dashboard/2)" (-> result second :text)))
+      (is (= {"/model/1"     "metabase://model/1"
+              "/dashboard/2" "metabase://dashboard/2"}
+             @registry)))))
+
+(deftest ^:parallel resolve-xf-accumulates-queries-and-records-link-registry-test
+  (testing "resolve-xf accumulates queries and records query link in registry"
+    (let [registry (atom {})
+          query    (lib.tu/venues-query)
+          parts    [{:type :tool-output
+                     :id "t1"
+                     :result {:structured-output {:query-id "q1" :query query}}}
+                    {:type :text :text "[Results](metabase://query/q1)"}]
+          result   (into [] (mlb/resolve-xf {} {} registry) parts)]
+      (is (re-find #"\[Results\]\(/question#" (-> result second :text)))
+      (is (= 1 (count @registry)))
+      (is (= "metabase://query/q1" (first (vals @registry)))))))
+
+(deftest ^:parallel with-context-test
   (testing "updates state for subsequent link resolution"
-    (let [;; First, link cannot be resolved
-          state1 (mlb/with-context mlb/initial-state {} {})
+    (let [registry (atom {})
+          ;; First, link cannot be resolved
+          state1 (mlb/with-context mlb/initial-state {} {} registry)
           [state2 output1] (mlb/step state1 "[Results](metabase://query/new-query)")
           _ (is (= "Results" output1))
           ;; Update state with the query
-          query {:database 1 :type :query :query {:source-table 1}}
-          state3 (mlb/with-context state2 {"new-query" query} {})
+          query (lib.tu/venues-query)
+          state3 (mlb/with-context state2 {"new-query" query} {} registry)
           ;; Now link can be resolved
           [state4 output2] (mlb/step state3 " See [More](metabase://query/new-query)")]
       (is (re-find #"\[More\]\(/question#" output2))

--- a/test/metabase/metabot/agent/memory_test.clj
+++ b/test/metabase/metabot/agent/memory_test.clj
@@ -15,7 +15,8 @@
   (testing "initializes with default state when nil"
     (let [messages [{:role :user :content "Hello"}]
           mem (memory/initialize messages nil)]
-      (is (= {:queries {} :charts {} :todos [] :transforms {}} (:state mem))))))
+      (is (= {:queries {} :charts {} :todos [] :transforms {} :link-registry {}}
+             (:state mem))))))
 
 (deftest add-step-test
   (testing "adds step to memory"

--- a/test/metabase/metabot/agent/streaming_test.clj
+++ b/test/metabase/metabot/agent/streaming_test.clj
@@ -240,13 +240,13 @@
   (testing "resolves metabase:// links in text parts"
     (let [query {:database 1 :type :query :query {:source-table 1}}
           parts [{:type :text :text "[Results](metabase://query/q1)"}]
-          result (into [] (streaming/post-process-xf {"q1" query} {}) parts)]
+          result (into [] (streaming/post-process-xf {"q1" query} {} (atom {})) parts)]
       (is (= 1 (count result)))
       (is (re-find #"\[Results\]\(/question#" (:text (first result))))))
 
   (testing "passes through non-text parts unchanged"
     (let [parts [{:type :tool-input :id "t1" :function "search"}]
-          result (into [] (streaming/post-process-xf {} {}) parts)]
+          result (into [] (streaming/post-process-xf {} {} (atom {})) parts)]
       (is (= parts result))))
 
   (testing "accumulates queries from tool-output structured-output"
@@ -255,13 +255,13 @@
                   :id "t1"
                   :result {:structured-output {:query-id "q1" :query query}}}
                  {:type :text :text "[Results](metabase://query/q1)"}]
-          result (into [] (streaming/post-process-xf {} {}) parts)]
+          result (into [] (streaming/post-process-xf {} {} (atom {})) parts)]
       (is (= 2 (count result)))
       (is (re-find #"\[Results\]\(/question#" (:text (second result))))))
 
   (testing "flushes incomplete links at end"
     (let [parts [{:type :text :text "Check [incomplete"}]
-          result (into [] (streaming/post-process-xf {} {}) parts)]
+          result (into [] (streaming/post-process-xf {} {} (atom {})) parts)]
       ;; Should have original part (with empty/partial text) + flushed part
       (is (<= 1 (count result)))
       (let [all-text (->> result (filter #(= :text (:type %))) (map :text) (apply str))]
@@ -269,7 +269,7 @@
 
   (testing "resolves model/metric/dashboard links without state"
     (let [parts [{:type :text :text "[Model](metabase://model/123)"}]
-          result (into [] (streaming/post-process-xf {} {}) parts)]
+          result (into [] (streaming/post-process-xf {} {} (atom {})) parts)]
       (is (= "[Model](/model/123)" (:text (first result)))))))
 
 (deftest post-process-xf-test
@@ -281,7 +281,7 @@
                            :reactions [{:type :metabot.reaction/redirect :url "/nav"}]
                            :data-parts [{:type :data :data-type "todo_list" :data []}]}}
                  {:type :text :text "[Link](metabase://query/q1)"}]
-          result (into [] (streaming/post-process-xf {} {}) parts)]
+          result (into [] (streaming/post-process-xf {} {} (atom {})) parts)]
       ;; Should have: tool-output, navigate_to data part, todo_list data part, resolved text
       (is (= 4 (count result)))
       (is (= :tool-output (:type (nth result 0))))
@@ -290,7 +290,7 @@
       (is (re-find #"\[Link\]\(/question#" (:text (nth result 3))))))
 
   (testing "works with empty parts"
-    (let [result (into [] (streaming/post-process-xf {} {}) [])]
+    (let [result (into [] (streaming/post-process-xf {} {} (atom {})) [])]
       (is (= [] result))))
 
   (testing "preserves order: tool-output, reactions, data-parts, text"
@@ -299,7 +299,7 @@
                   :result {:reactions [{:type :metabot.reaction/redirect :url "/r"}]
                            :data-parts [{:type :data :data-type "dp"}]}}
                  {:type :text :text "text"}]
-          result (into [] (streaming/post-process-xf {} {}) parts)]
+          result (into [] (streaming/post-process-xf {} {} (atom {})) parts)]
       (is (= :tool-output (:type (nth result 0))))
       (is (= "navigate_to" (:data-type (nth result 1))))
       (is (= "dp" (:data-type (nth result 2))))


### PR DESCRIPTION
Closes [BOT-1044: Links should be processed into metabase:// protocol when they come from frontend](https://linear.app/metabase/issue/BOT-1044/links-should-be-processed-into-metabase-protocol-when-they-come-from)

~~DRAFT until https://github.com/metabase/metabase/pull/71068 lands to avoid conflicts~~

### Description

BOT-1044 Convert links back to metabase:// format before sending to llm

This is a re-implementation of https://github.com/metabase/ai-service/pull/597 and https://github.com/metabase/ai-service/pull/616/changes/f90619f5e2bd2d4322c17c7efe5862151cdfda97 for the Clojure agent.

resolve-links converts metabase:// links into real URLs before sending them back to the client. When the LLM sees
these resolved URLs in the conversation history, it can get confused and start generating resolved links
itself (e.g. /question#<base64>), rather than following instructions to always use metabase:// links. This sometimes
results in wrong/hallucinated base64 repr, especially in longer conversations where many resolved links accumulate in the history.

With this commit, we add a link-registry to the agent memory to record every link rewritten by resolve-links, and use
invert-links to restore them to metabase:// URIs in the message history before sending it to the LLM for completion.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
