### PR TITLE
remove claude from mise as it's not a required tool

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -111,7 +111,3 @@ op = "latest"
 # jq - Command-line JSON processor
 # https://github.com/jqlang/jq
 jq = "latest"
-
-# claude code - Terminal AI coding agent
-# https://github.com/anthropics/claude-code
-claude = "latest"


### PR DESCRIPTION
### Description

Claude code installed via mise doesn't auto upgrade and overrides the one installed globally, this means people might be using a older version of claude code when inside the metabase repo, causing issue with installing plugins etc
See https://metaboat.slack.com/archives/C08FUFKCFCN/p1773906431653829?thread_ts=1772017625.624209&cid=C08FUFKCFCN

The comments above the section also mention
```
# Project-required tools belong here.
# Anything custom should go to your personal mise.local.toml file (gitignored 👻)
```
and claude code is not a project-required tool