### PR TITLE
GDGT-2037: Fix CssVarsDeclarationPlugin crashing dev server on missing files

### DIFF
--- a/frontend/build/shared/rspack/plugins/CssVarsDeclarationPlugin/css-vars-declaration-plugin.js
+++ b/frontend/build/shared/rspack/plugins/CssVarsDeclarationPlugin/css-vars-declaration-plugin.js
@@ -48,7 +48,7 @@ const CSS_VAR_CONFIGS = [
     ],
   },
   {
-    path: "metabase/lib/colors/types/color-keys.ts",
+    path: "metabase/ui/colors/types/color-keys.ts",
     sources: [
       {
         type: "unionType",

--- a/frontend/build/shared/rspack/plugins/CssVarsDeclarationPlugin/css-vars-declaration-plugin.js
+++ b/frontend/build/shared/rspack/plugins/CssVarsDeclarationPlugin/css-vars-declaration-plugin.js
@@ -146,11 +146,21 @@ class CssVarsDeclarationPlugin {
       }
     }
 
+    if (cssVars.size === 0) {
+      this.#warn(`No CSS variables found for ${config.path}, skipping .d.css`);
+      return;
+    }
+
     const outputPath = config.path.replace(/\.ts$/, ".d.css");
-    this.#writeCssDeclarationFile(
-      path.join(this.#frontendSrcPath, outputPath),
-      cssVars,
-    );
+    const fullOutputPath = path.join(this.#frontendSrcPath, outputPath);
+    const outputDir = path.dirname(fullOutputPath);
+
+    if (!fs.existsSync(outputDir)) {
+      this.#warn(`Output directory not found: ${outputDir}, skipping .d.css`);
+      return;
+    }
+
+    this.#writeCssDeclarationFile(fullOutputPath, cssVars);
   }
 
   /**

--- a/frontend/src/metabase/embedding-sdk/theme/css-vars-to-sdk-theme.ts
+++ b/frontend/src/metabase/embedding-sdk/theme/css-vars-to-sdk-theme.ts
@@ -1,3 +1,6 @@
+// WARNING: This file is referenced by CssVarsDeclarationPlugin.
+// If you move or rename it, update the path in css-vars-declaration-plugin.js.
+
 import type { FlattenObjectKeys } from "../types/utils";
 
 import type { MetabaseComponentTheme } from "./MetabaseTheme";

--- a/frontend/src/metabase/embedding-sdk/theme/dynamic-css-vars-config.ts
+++ b/frontend/src/metabase/embedding-sdk/theme/dynamic-css-vars-config.ts
@@ -1,3 +1,6 @@
+// WARNING: This file is referenced by CssVarsDeclarationPlugin.
+// If you move or rename it, update the path in css-vars-declaration-plugin.js.
+
 import type { DynamicCssVarConfig } from "../types/private/css-variables";
 
 /**

--- a/frontend/src/metabase/styled-components/theme/css-variables.ts
+++ b/frontend/src/metabase/styled-components/theme/css-variables.ts
@@ -1,3 +1,6 @@
+// WARNING: This file is referenced by CssVarsDeclarationPlugin.
+// If you move or rename it, update the path in css-vars-declaration-plugin.js.
+
 // eslint-disable-next-line no-restricted-imports
 import { css } from "@emotion/react";
 import { getIn } from "icepick";

--- a/frontend/src/metabase/ui/colors/types/color-keys.ts
+++ b/frontend/src/metabase/ui/colors/types/color-keys.ts
@@ -1,3 +1,6 @@
+// WARNING: This file is referenced by CssVarsDeclarationPlugin.
+// If you move or rename it, update the path in css-vars-declaration-plugin.js.
+
 import type { ALL_ACCENT_COLOR_NAMES } from "../constants/accents";
 
 /**


### PR DESCRIPTION
### Description

`CssVarsDeclarationPlugin` crashes the dev server with `ENOENT` when a referenced source file or its parent directory doesn't exist. This happens because the plugin always attempts to write the `.d.css` output file, even when the source file is missing and no CSS variables were extracted.

Changes:
- Skip writing `.d.css` when no CSS variables were collected (warns instead)
- Skip writing `.d.css` when the output directory doesn't exist (warns instead)
- Fix path to `color-keys.ts` (`metabase/lib/colors/types/` → `metabase/ui/colors/types/`)

### How to verify

1. Run the dev server — it should start without crashing
2. The plugin should log warnings for any missing files instead of throwing