### PR TITLE
Fixed empty csv for adhoc pivot tables in SDK

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/sdk-csv-downloads.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/sdk-csv-downloads.cy.spec.ts
@@ -1,0 +1,115 @@
+import { parse } from "csv-parse/browser/esm/sync";
+
+const { H } = cy;
+
+describe("scenarios > embedding > sdk iframe embedding > csv downloads", () => {
+  beforeEach(() => {
+    cy.deleteDownloadsFolder();
+    H.prepareSdkIframeEmbedTest({ signOut: true });
+  });
+
+  const addGroupBy = (column: string) => {
+    cy.findByTestId("step-summarize-0-0")
+      .findByTestId("breakout-step")
+      .findAllByTestId("notebook-cell-item")
+      .should("have.length.at.least", 1)
+      .last()
+      .click();
+    H.popover().within(() => {
+      cy.findByText(column).click();
+    });
+  };
+
+  const addSummarize = (metric: string) => {
+    cy.findByText("Pick a function or metric").click();
+    H.popover().within(() => {
+      cy.findByText(metric).click();
+    });
+  };
+
+  const setup = () => {
+    cy.intercept("POST", "/api/dataset").as("dataset");
+    cy.intercept("POST", "/api/dataset/pivot").as("pivotDataset");
+
+    H.loadSdkIframeEmbedTestPage({
+      elements: [
+        {
+          component: "metabase-question",
+          attributes: {
+            questionId: "new",
+            withDownloads: true,
+          },
+        },
+      ],
+    });
+
+    // Pick Orders table from the data picker
+    H.getSimpleEmbedIframeContent().contains("Pick your starting data");
+    H.getSimpleEmbedIframeContent().within(() => {
+      H.popover().within(() => {
+        cy.findByText("Orders").click();
+      });
+
+      addSummarize("Count of rows");
+      addGroupBy("Subtotal");
+      addGroupBy("Created At");
+      cy.button("Visualize").click();
+    });
+
+    cy.wait("@dataset");
+
+    // Switch to Pivot Table visualization
+    H.getSimpleEmbedIframeContent().within(() => {
+      cy.findByTestId("chart-type-selector-button").click();
+
+      cy.findByText("Pivot Table").click();
+    });
+
+    cy.wait("@pivotDataset");
+  };
+
+  it("should download a non-empty pivoted CSV for an ad-hoc pivot table (metabase#70757)", () => {
+    setup();
+
+    // Intercept the CSV download request and assert the response is non-empty.
+    // Before the fix, pivoted downloads returned blank CSVs because
+    // visualization_settings (including pivot_table.column_split) were not passed.
+    cy.intercept("POST", "/api/dataset/csv", (req) => {
+      req.continue((res) => {
+        expect(res.statusCode).to.eq(200);
+        expect(res.headers["content-type"]).to.include("text/csv");
+
+        const csvContent = res.body;
+        const lines = csvContent.split("\n").filter(Boolean);
+        expect(lines.length).to.be.greaterThan(1);
+
+        // this will error out if the CSV is invalid
+        parse(csvContent);
+
+        res.send({ statusCode: 200 });
+      });
+    }).as("csvDownload");
+
+    H.getSimpleEmbedIframeContent().within(() => {
+      // Click the download button on the toolbar
+      cy.get("[aria-label='download icon']").should("be.visible").click();
+
+      // Select CSV format
+      cy.findByText(".csv").click();
+
+      // Ensure "Keep the data pivoted" is checked
+      cy.findByTestId("keep-data-pivoted").then(($checkbox) => {
+        if (!$checkbox.prop("checked")) {
+          cy.findByTestId("keep-data-pivoted").click();
+        }
+      });
+
+      // Click the download button
+      cy.findByTestId("download-results-button").click();
+    });
+
+    cy.wait("@csvDownload");
+
+    cy.verifyDownload("query_result_", { contains: true });
+  });
+});

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/sdk-csv-downloads.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/sdk-csv-downloads.cy.spec.ts
@@ -92,7 +92,7 @@ describe("scenarios > embedding > sdk iframe embedding > csv downloads", () => {
 
     H.getSimpleEmbedIframeContent().within(() => {
       // Click the download button on the toolbar
-      cy.get("[aria-label='download icon']").should("be.visible").click();
+      cy.findByLabelText("download icon").should("be.visible").click();
 
       // Select CSV format
       cy.findByText(".csv").click();

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/DownloadWidget/DownloadWidget.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/DownloadWidget/DownloadWidget.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from "react";
+
 import { useEmbeddingEntityContext } from "metabase/embedding/context";
 import { QuestionDownloadWidget } from "metabase/query_builder/components/QuestionDownloadWidget";
 import {
@@ -5,6 +7,7 @@ import {
   useDownloadData,
 } from "metabase/query_builder/components/QuestionDownloadWidget/use-download-data";
 import type { StackProps } from "metabase/ui";
+import { getComputedSettingsForSeries } from "metabase/visualizations/lib/settings/visualization";
 
 import { useSdkQuestionContext } from "../../context";
 
@@ -24,10 +27,19 @@ const DownloadWidgetInner = ({
   const { withDownloads } = useSdkQuestionContext();
   const { token } = useEmbeddingEntityContext();
 
+  const visualizationSettings = useMemo(
+    () =>
+      getComputedSettingsForSeries([
+        { card: question.card(), data: result.data },
+      ]),
+    [question, result],
+  );
+
   const [, handleDownload] = useDownloadData({
     question,
     result,
     token,
+    visualizationSettings,
   });
 
   return (


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #70757
Closes [EMB-1428: Downloading pivot tables created in the SDK results in blank CSVs when you keep the data pivoted](https://linear.app/metabase/issue/EMB-1428/downloading-pivot-tables-created-in-the-sdk-results-in-blank-csvs-when)

### Description

The SDK download widget did not include computed visualization settings, which prevented proper download of data for ad-hoc questions (for saved questions, the settings are taken directly from the saved question, which means it wasn't an issue).

### How to verify

Make an ad-hoc pivot table in an SDK app (by using `<InteractiveQuestion questionId="new"/>` for example), and try to download data as CSV. The result should be a proper CSV, not a empty file.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
