### PR TITLE
fix: transform context is included twice

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformEditor.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformEditor.tsx
@@ -3,7 +3,6 @@ import { useEffect } from "react";
 import { usePrevious } from "react-use";
 
 import type { PythonTransformEditorProps } from "metabase/plugins";
-import { useRegisterMetabotTransformContext } from "metabase/transforms/hooks/use-register-transform-metabot-context";
 import { Flex, Stack } from "metabase/ui";
 import type {
   DatabaseId,
@@ -18,12 +17,12 @@ import { PythonEditorBody } from "./PythonEditorBody";
 import { PythonEditorResults } from "./PythonEditorResults";
 import S from "./PythonTransformEditor.module.css";
 import { PythonTransformTopBar } from "./PythonTransformTopBar";
-import { useTestPythonTransform } from "./hooks";
 import { updateTransformSignature } from "./utils";
 
 export function PythonTransformEditor({
   source,
   proposedSource,
+  testState,
   uiOptions,
   isEditMode,
   transform,
@@ -33,14 +32,7 @@ export function PythonTransformEditor({
   onRunTransform,
   onRun,
 }: PythonTransformEditorProps) {
-  const { isRunning, cancel, run, executionResult, isDirty } =
-    useTestPythonTransform(source);
-
-  useRegisterMetabotTransformContext(
-    transform,
-    source,
-    executionResult?.error?.message,
-  );
+  const { isRunning, cancel, run, executionResult, isDirty } = testState;
 
   const wasRunning = usePrevious(isRunning);
 

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformEditor.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformEditor.unit.spec.tsx
@@ -4,7 +4,10 @@ import {
   setupTablesEndpoints,
 } from "__support__/server-mocks";
 import { renderWithProviders, screen } from "__support__/ui";
-import type { PythonTransformEditorUiOptions } from "metabase/plugins/oss/transforms";
+import type {
+  PythonTransformEditorUiOptions,
+  TestPythonScriptState,
+} from "metabase/plugins/oss/transforms";
 import { createMockState } from "metabase/redux/store/mocks";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 import type { PythonTransformSourceDraft, Transform } from "metabase-types/api";
@@ -59,13 +62,25 @@ type SetupOpts = {
   isEditMode?: boolean;
   transform?: Transform;
   uiOptions?: PythonTransformEditorUiOptions;
+  testState?: TestPythonScriptState;
 };
+
+function createMockTestState(): TestPythonScriptState {
+  return {
+    isRunning: false,
+    isDirty: false,
+    executionResult: {},
+    run: jest.fn(),
+    cancel: jest.fn(),
+  };
+}
 
 function setup({
   source = mockPythonSource,
   isEditMode = true,
   transform,
   uiOptions,
+  testState = createMockTestState(),
 }: SetupOpts = {}) {
   setupDatabasesEndpoints([mockDatabase]);
   setupTablesEndpoints([mockTable]);
@@ -74,6 +89,7 @@ function setup({
   renderWithProviders(
     <PythonTransformEditor
       source={source}
+      testState={testState}
       isEditMode={isEditMode}
       transform={transform}
       uiOptions={uiOptions}

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/hooks.ts
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/hooks.ts
@@ -2,28 +2,22 @@ import { useRef } from "react";
 import { t } from "ttag";
 
 import { getErrorMessage } from "metabase/api/utils";
+import type { TestPythonScriptState } from "metabase/plugins";
 import { useExecutePythonMutation } from "metabase-enterprise/api/transform-python";
-import type {
-  PythonTransformSourceDraft,
-  TestPythonTransformResponse,
-} from "metabase-types/api";
-
-type TestPythonScriptState = {
-  isRunning: boolean;
-  isDirty: boolean;
-  executionResult: TestPythonTransformResponse;
-  run: () => void;
-  cancel: () => void;
-};
+import type { PythonTransformSourceDraft } from "metabase-types/api";
 
 export function useTestPythonTransform(
-  source: PythonTransformSourceDraft,
-): TestPythonScriptState {
+  source?: PythonTransformSourceDraft,
+): TestPythonScriptState | undefined {
   const [
     executePython,
     { data = null, error, isLoading: isRunning, originalArgs },
   ] = useExecutePythonMutation();
   const abort = useRef<(() => void) | null>(null);
+
+  if (!source) {
+    return undefined;
+  }
 
   const isDirty = originalArgs?.code !== source.body;
 

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/index.tsx
@@ -2,6 +2,7 @@ import { PLUGIN_TRANSFORMS_PYTHON } from "metabase/plugins";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 
 import { PythonTransformEditor } from "./components/PythonTransformEditor";
+import { useTestPythonTransform } from "./components/PythonTransformEditor/hooks";
 import { SHARED_LIB_IMPORT_PATH } from "./constants";
 import { PythonRunnerSettingsPage } from "./pages/PythonRunnerSettingsPage";
 import { getPythonTransformsRoutes, getPythonUpsellRoutes } from "./routes";
@@ -17,6 +18,7 @@ export function initializePlugin() {
       getPythonTransformsRoutes;
     PLUGIN_TRANSFORMS_PYTHON.getPythonSourceValidationResult =
       getPythonSourceValidationResult;
+    PLUGIN_TRANSFORMS_PYTHON.useTestPythonTransform = useTestPythonTransform;
     PLUGIN_TRANSFORMS_PYTHON.TransformEditor = PythonTransformEditor;
     PLUGIN_TRANSFORMS_PYTHON.PythonRunnerSettingsPage =
       PythonRunnerSettingsPage;

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -128,6 +128,7 @@ export {
   PLUGIN_TRANSFORMS_PYTHON,
   type TransformsPlugin,
   type PythonTransformEditorProps,
+  type TestPythonScriptState,
   type PythonTransformSourceSectionProps,
   type PythonTransformSourceValidationResult,
   type PythonTransformsPlugin,

--- a/frontend/src/metabase/plugins/oss/transforms.ts
+++ b/frontend/src/metabase/plugins/oss/transforms.ts
@@ -5,7 +5,11 @@ import {
   NotFoundPlaceholder,
   PluginPlaceholder,
 } from "metabase/plugins/components/PluginPlaceholder";
-import type { PythonTransformSourceDraft, Transform } from "metabase-types/api";
+import type {
+  PythonTransformSourceDraft,
+  TestPythonTransformResponse,
+  Transform,
+} from "metabase-types/api";
 
 // Types
 export type TransformPickerItem = OmniPickerItem & {
@@ -24,9 +28,18 @@ export type PythonTransformEditorUiOptions = {
   hideRunButton?: boolean;
 };
 
+export type TestPythonScriptState = {
+  isRunning: boolean;
+  isDirty: boolean;
+  executionResult: TestPythonTransformResponse;
+  run: () => void;
+  cancel: () => void;
+};
+
 export type PythonTransformEditorProps = {
   source: PythonTransformSourceDraft;
   proposedSource?: PythonTransformSourceDraft;
+  testState: TestPythonScriptState;
   uiOptions?: PythonTransformEditorUiOptions;
   isEditMode?: boolean;
   transform?: Transform;
@@ -54,6 +67,9 @@ export type PythonTransformsPlugin = {
   getPythonSourceValidationResult: (
     source: PythonTransformSourceDraft,
   ) => PythonTransformSourceValidationResult;
+  useTestPythonTransform: (
+    source?: PythonTransformSourceDraft,
+  ) => TestPythonScriptState | undefined;
   TransformEditor: ComponentType<PythonTransformEditorProps>;
   SourceSection: ComponentType<PythonTransformSourceSectionProps>;
   PythonRunnerSettingsPage: ComponentType;
@@ -80,6 +96,7 @@ const getDefaultPluginTransformsPython = (): PythonTransformsPlugin => ({
     return getDefaultInspectorRoutes();
   },
   getPythonSourceValidationResult: () => ({ isValid: true }),
+  useTestPythonTransform: () => undefined,
   TransformEditor: PluginPlaceholder,
   SourceSection: PluginPlaceholder,
   PythonRunnerSettingsPage: NotFoundPlaceholder,

--- a/frontend/src/metabase/transforms/pages/NewTransformPage/NewTransformPage.tsx
+++ b/frontend/src/metabase/transforms/pages/NewTransformPage/NewTransformPage.tsx
@@ -19,6 +19,7 @@ import { PLUGIN_REMOTE_SYNC, PLUGIN_TRANSFORMS_PYTHON } from "metabase/plugins";
 import { getInitialUiState } from "metabase/querying/editor/components/QueryEditor";
 import { useDispatch, useSelector } from "metabase/redux";
 import { getMetadata } from "metabase/selectors/metadata";
+import { useRegisterMetabotTransformContext } from "metabase/transforms/hooks/use-register-transform-metabot-context";
 import { useTransformPermissions } from "metabase/transforms/hooks/use-transform-permissions";
 import { Box, Center } from "metabase/ui";
 import * as Urls from "metabase/urls";
@@ -31,7 +32,6 @@ import type {
 
 import { TransformEditor } from "../../components/TransformEditor";
 import { NAME_MAX_LENGTH } from "../../constants";
-import { useRegisterMetabotTransformContext } from "../../hooks/use-register-transform-metabot-context";
 import { useSourceState } from "../../hooks/use-source-state";
 import { getValidationResult, isCompleteSource } from "../../utils";
 
@@ -119,7 +119,16 @@ function NewTransformPageBody({
   const [isModalOpened, { open: openModal, close: closeModal }] =
     useDisclosure();
   const dispatch = useDispatch();
-  useRegisterMetabotTransformContext(undefined, source);
+  const pythonTestState = PLUGIN_TRANSFORMS_PYTHON.useTestPythonTransform(
+    source.type === "python" ? source : undefined,
+  );
+  useRegisterMetabotTransformContext(
+    undefined,
+    source,
+    source.type === "python"
+      ? pythonTestState?.executionResult.error?.message
+      : undefined,
+  );
 
   const validationResult = useMemo(() => {
     return source.type === "query"
@@ -183,6 +192,7 @@ function NewTransformPageBody({
               proposedSource={
                 proposedSource?.type === "python" ? proposedSource : undefined
               }
+              testState={pythonTestState!}
               isEditMode
               onChangeSource={setSourceAndRejectProposed}
               onAcceptProposed={acceptProposed}

--- a/frontend/src/metabase/transforms/pages/TransformQueryPage/TransformQueryPage.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformQueryPage/TransformQueryPage.tsx
@@ -22,6 +22,7 @@ import {
 } from "metabase/plugins";
 import { getInitialUiState } from "metabase/querying/editor/components/QueryEditor";
 import { useDispatch, useSelector } from "metabase/redux";
+import { useRegisterMetabotTransformContext } from "metabase/transforms/hooks/use-register-transform-metabot-context";
 import { useTransformPermissions } from "metabase/transforms/hooks/use-transform-permissions";
 import { Box, Center, Group, Icon } from "metabase/ui";
 import * as Urls from "metabase/urls";
@@ -37,7 +38,6 @@ import {
   type TransformEditorProps,
 } from "../../components/TransformEditor";
 import { TransformHeader } from "../../components/TransformHeader";
-import { useRegisterMetabotTransformContext } from "../../hooks/use-register-transform-metabot-context";
 import { useSourceState } from "../../hooks/use-source-state";
 import { isCompleteSource } from "../../utils";
 
@@ -127,8 +127,16 @@ function TransformQueryPageBody({
       ? (transform.last_run.message ?? undefined)
       : undefined;
   }, [transform.last_run]);
-
-  useRegisterMetabotTransformContext(transform, source, lastRunError);
+  const pythonTestState = PLUGIN_TRANSFORMS_PYTHON.useTestPythonTransform(
+    source.type === "python" ? source : undefined,
+  );
+  useRegisterMetabotTransformContext(
+    transform,
+    source,
+    source.type === "python"
+      ? (pythonTestState?.executionResult.error?.message ?? lastRunError)
+      : lastRunError,
+  );
 
   const {
     checkData,
@@ -238,6 +246,7 @@ function TransformQueryPageBody({
               proposedSource={
                 proposedSource?.type === "python" ? proposedSource : undefined
               }
+              testState={pythonTestState!}
               uiOptions={{ readOnly }}
               isEditMode={isEditMode}
               transform={transform}
@@ -319,9 +328,14 @@ export function TransformQueryPageEditor({
   onRunTransform,
   onRun,
 }: TransformQueryPageEditorProps) {
+  const pythonTestState = PLUGIN_TRANSFORMS_PYTHON.useTestPythonTransform(
+    source.type === "python" ? source : undefined,
+  );
+
   return source.type === "python" ? (
     <PLUGIN_TRANSFORMS_PYTHON.TransformEditor
       source={source}
+      testState={pythonTestState!}
       uiOptions={uiOptions}
       proposedSource={
         proposedSource?.type === "python" ? proposedSource : undefined


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/BOT-1146/transform-context-is-included-twice

### Description

Transform context was included twice (one in outer component, and one in specific python transforms one).

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Open metabot on some transform
2. Send a message
3. See the request that should include only one context entry

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
