### PR TITLE
Fix string field IDs leaking into bulk-metadata queries

### DIFF
--- a/src/metabase/lib/walk/util.cljc
+++ b/src/metabase/lib/walk/util.cljc
@@ -185,7 +185,7 @@
         implicit-join-field-opt? #(and (:source-field %) (not (:join-alias %)))
         walk-clause (fn [clause]
                       (lib.util.match/match-lite clause
-                        [:field (opts :guard implicit-join-field-opt?) id]
+                        [:field (opts :guard implicit-join-field-opt?) (id :guard pos-int?)]
                         (vswap! joined-field-ids conj! id)
 
                         _ nil)

--- a/test/metabase/lib/walk/util_test.cljc
+++ b/test/metabase/lib/walk/util_test.cljc
@@ -165,7 +165,12 @@
                {:source-table $$venues
                 :joins [{:source-table $$users
                          :alias "U"
-                         :condition [:= [:field $categories.name {:source-field %venues.category-id}] &U.users.name]}]})))))))
+                         :condition [:= [:field $categories.name {:source-field %venues.category-id}] &U.users.name]}]}))))))
+  (testing "Ignores string field names (should only collect integer field IDs) - GHY-3085"
+    (mu/disable-enforcement
+      (is (= #{}
+             (lib.walk.util/all-implicitly-joined-field-ids
+              [:field {:source-field 1} "CITY"]))))))
 
 (deftest ^:parallel all-implicitly-joined-table-ids-test
   (testing "Returns table IDs from implicit joins by resolving FK relationships"


### PR DESCRIPTION
## Summary
- `all-implicitly-joined-field-ids` was missing a `pos-int?` guard on the `id` binding in its pattern match, so string field names (e.g. `"CITY"` from native/model sources) with `:source-field` opts were collected as field IDs
- These strings were then passed to `bulk-metadata`, which built a SQL query like `field.id IN ("CITY")` — causing a Postgres type error: `operator does not exist: integer = character varying`
- Added the same `(id :guard pos-int?)` guard that `all-field-ids` already uses

Fixes #69193

## Test plan
- [x] Added test case that passes `[:field {:source-field 1} "CITY"]` and asserts `#{}` is returned
- [x] Confirmed test fails before fix, passes after
- [x] All existing `all-implicitly-joined-field-ids-test` assertions still pass