### PR TITLE
Allow metric math with non-exact temporal field matches

### DIFF
--- a/frontend/src/metabase-lib/metric/core.ts
+++ b/frontend/src/metabase-lib/metric/core.ts
@@ -710,3 +710,10 @@ export function isSameSource(
 ): boolean {
   return LibMetric.isSameSource(dimension1, dimension2) as boolean;
 }
+
+export function isCompatibleType(
+  dimension1: DimensionMetadata,
+  dimension2: DimensionMetadata,
+): boolean {
+  return LibMetric.isCompatibleType(dimension1, dimension2) as boolean;
+}

--- a/frontend/src/metabase/metrics-viewer/utils/tabs.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/tabs.ts
@@ -272,6 +272,7 @@ function findSourceMatch(
   reference: ClassifiedDimension,
 ): ClassifiedDimension | null {
   let nameMatch: ClassifiedDimension | null = null;
+  let typeMatch: ClassifiedDimension | null = null;
   const referenceName = reference.name;
 
   for (const [, info] of dimensions) {
@@ -284,9 +285,15 @@ function findSourceMatch(
     if (!nameMatch && referenceName && info.name === referenceName) {
       nameMatch = info;
     }
+    if (
+      !typeMatch &&
+      LibMetric.isCompatibleType(info.dimension, reference.dimension)
+    ) {
+      typeMatch = info;
+    }
   }
 
-  return nameMatch;
+  return nameMatch ?? typeMatch;
 }
 
 function resolveAggregateDimensionMapping(
@@ -641,6 +648,7 @@ function findDimensionBySourceMatch(
   getSubtype?: (dimension: DimensionMetadata) => string | null,
 ): string | null {
   let nameMatch: ClassifiedDimension | null = null;
+  let typeMatch: ClassifiedDimension | null = null;
 
   for (const [, info] of dimensionsByType) {
     if (info.type !== reference.type) {
@@ -660,9 +668,20 @@ function findDimensionBySourceMatch(
         nameMatch = info;
       }
     }
+    if (
+      !typeMatch &&
+      LibMetric.isCompatibleType(info.dimension, reference.dimension)
+    ) {
+      if (
+        !getSubtype ||
+        getSubtype(info.dimension) === getSubtype(reference.dimension)
+      ) {
+        typeMatch = info;
+      }
+    }
   }
 
-  return nameMatch?.id ?? null;
+  return nameMatch?.id ?? typeMatch?.id ?? null;
 }
 
 function resolveSubtypeFallback(

--- a/src/metabase/lib_metric/ast/plan.cljc
+++ b/src/metabase/lib_metric/ast/plan.cljc
@@ -7,7 +7,11 @@
    [metabase.lib-metric.ast.compile :as ast.compile]
    [metabase.lib-metric.ast.walk :as ast.walk]
    [metabase.lib-metric.operators :as operators]
+   [metabase.types.core]
    [metabase.util.performance :as perf]))
+
+;; Ensure type hierarchy is loaded
+(comment metabase.types.core/keep-me)
 
 ;;; -------------------- Plan Data Structures --------------------
 ;;;
@@ -53,14 +57,29 @@
                     :signatures     (perf/mapv #(dimension-signature % sub-ast) group-by)}))
                leaves)))
 
+(defn- effective-types-compatible?
+  "Check if two effective types are compatible for dimension joining.
+   Types are compatible if they are equal, or if both are date/datetime types
+   (Date, DateTime, DateTimeWithLocalTZ, etc.), or if both are time types."
+  [type-a type-b]
+  (or (= type-a type-b)
+      ;; Both have a date component — Date, DateTime, DateTimeWithLocalTZ, etc.
+      (and (isa? type-a :type/HasDate)
+           (isa? type-b :type/HasDate))
+      ;; Both are pure time types — Time, TimeWithLocalTZ
+      (and (isa? type-a :type/Time)
+           (isa? type-b :type/Time))))
+
 (defn- signatures-compatible?
   "Check if two dimension signatures are compatible for joining.
    nil values are treated as unknown and compatible with any known value.
-   Only rejects when both sides have known but different values."
+   Only rejects when both sides have known but different values.
+   Effective types are matched using [[effective-types-compatible?]] which allows
+   compatible-but-not-identical temporal types (e.g. Date vs DateTimeWithLocalTZ)."
   [sig-a sig-b]
   (and (or (nil? (:effective-type sig-a))
            (nil? (:effective-type sig-b))
-           (= (:effective-type sig-a) (:effective-type sig-b)))
+           (effective-types-compatible? (:effective-type sig-a) (:effective-type sig-b)))
        (or (nil? (:temporal-unit sig-a))
            (nil? (:temporal-unit sig-b))
            (= (:temporal-unit sig-a) (:temporal-unit sig-b)))

--- a/src/metabase/lib_metric/ast/plan.cljc
+++ b/src/metabase/lib_metric/ast/plan.cljc
@@ -109,7 +109,10 @@
       (when-not (apply = breakout-counts)
         (throw (ex-info "All leaves in arithmetic expression must have the same number of breakout dimensions"
                         {:status-code 400
-                         :breakout-counts (zipmap (map :uuid leaf-infos) breakout-counts)}))))
+                         :breakout-counts (zipmap (map :uuid leaf-infos) breakout-counts)})))
+      (when (zero? (first breakout-counts))
+        (throw (ex-info "Arithmetic expressions require projections (group-by dimensions) on all metrics"
+                        {:status-code 400}))))
     (let [sig-vecs (map :signatures leaf-infos)]
       (when-not (all-signatures-compatible? sig-vecs)
         (throw (ex-info "All leaves in arithmetic expression must have the same breakout dimension types and bucketing"

--- a/src/metabase/lib_metric/js.cljs
+++ b/src/metabase/lib_metric/js.cljs
@@ -843,3 +843,18 @@
     (boolean
      (when (and (seq sources1) (seq sources2))
        (some (set sources1) sources2)))))
+
+(defn ^:export isCompatibleType
+  "Check if two dimensions have compatible effective types for cross-database matching.
+   Two date/datetime dimensions are compatible, two time dimensions are compatible,
+   otherwise requires exact type match. Returns false if either type is nil."
+  [dimension1 dimension2]
+  (let [type1 (types.isa/column-type dimension1)
+        type2 (types.isa/column-type dimension2)]
+    (boolean
+     (when (and type1 type2)
+       (or (= type1 type2)
+           (and (isa? type1 :type/HasDate)
+                (isa? type2 :type/HasDate))
+           (and (isa? type1 :type/Time)
+                (isa? type2 :type/Time)))))))

--- a/test/metabase/lib_metric/ast/plan_test.cljc
+++ b/test/metabase/lib_metric/ast/plan_test.cljc
@@ -195,6 +195,21 @@
            #"same breakout dimension types"
            (ast.plan/validate-arithmetic-ast! expr))))))
 
+(deftest ^:parallel validate-arithmetic-ast-compatible-datetime-types-test
+  (testing "accepts compatible date/datetime types across different databases"
+    (let [expr (make-expression-arithmetic
+                :+ [(make-expression-leaf uuid-a [dim-1] {dim-1 {:effective-type :type/Date}})
+                    (make-expression-leaf uuid-b [dim-1] {dim-1 {:effective-type :type/DateTimeWithLocalTZ}})])]
+      (is (nil? (ast.plan/validate-arithmetic-ast! expr)))))
+  (testing "rejects incompatible temporal types (date vs time)"
+    (let [expr (make-expression-arithmetic
+                :+ [(make-expression-leaf uuid-a [dim-1] {dim-1 {:effective-type :type/Date}})
+                    (make-expression-leaf uuid-b [dim-1] {dim-1 {:effective-type :type/Time}})])]
+      (is (thrown-with-msg?
+           #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
+           #"same breakout dimension types"
+           (ast.plan/validate-arithmetic-ast! expr))))))
+
 (deftest ^:parallel validate-arithmetic-ast-valid-test
   (testing "valid arithmetic AST passes validation"
     (let [expr (make-expression-arithmetic :+ [(make-expression-leaf uuid-a [dim-1])

--- a/test/metabase/lib_metric/definition_test.cljc
+++ b/test/metabase/lib_metric/definition_test.cljc
@@ -367,7 +367,6 @@
           result     (lib-metric.definition/unprojected-sources definition)]
       (is (empty? result)))))
 
-
 ;;; -------------------------------------------------- Schema Validation --------------------------------------------------
 
 (deftest ^:parallel metric-definition-schema-test

--- a/test/metabase/lib_metric/filter_test.cljc
+++ b/test/metabase/lib_metric/filter_test.cljc
@@ -451,7 +451,6 @@
       (is (thrown? #?(:clj Exception :cljs js/Error)
                    (lib-metric.filter/exclude-date-filter-clause parts))))))
 
-
 (deftest ^:parallel exclude-date-filter-clause-null-test
   (testing "exclude-date-filter-clause creates null check clause"
     (let [dimension {:id "dim-date" :effective-type :type/DateTime}


### PR DESCRIPTION
We can now do metric math between two metrics that both have temporal dimensions, even if those temporal dimensions aren't identical! :tada:
