### PR TITLE
Fixes a loki flaky

### DIFF
--- a/frontend/src/metabase/lib/loki-utils.ts
+++ b/frontend/src/metabase/lib/loki-utils.ts
@@ -16,10 +16,12 @@ export const openImageBlobOnStorybook = ({
   imageDownloaded.setAttribute("data-testid", "image-downloaded");
   root.replaceChildren(imgElement);
 
-  // the presence of this element is used to detect when the image is ready
-  // in the storybook you'll need to `await canvas.findByTestId("image-downloaded");`
-  // and then call `asyncCallback()` to continue the story
-  root.appendChild(imageDownloaded);
-
-  window.document.body.style.height = "initial";
+  // Wait for the image to fully load before signaling readiness,
+  // otherwise Loki may capture the screenshot before the image renders.
+  // In the storybook you'll need to `await canvas.findByTestId("image-downloaded");`
+  // and then call `asyncCallback()` to continue the story.
+  imgElement.addEventListener("load", () => {
+    root.appendChild(imageDownloaded);
+    window.document.body.style.height = "initial";
+  });
 };

--- a/frontend/src/metabase/lib/loki-utils.ts
+++ b/frontend/src/metabase/lib/loki-utils.ts
@@ -20,8 +20,16 @@ export const openImageBlobOnStorybook = ({
   // otherwise Loki may capture the screenshot before the image renders.
   // In the storybook you'll need to `await canvas.findByTestId("image-downloaded");`
   // and then call `asyncCallback()` to continue the story.
-  imgElement.addEventListener("load", () => {
+  const onImageReady = () => {
     root.appendChild(imageDownloaded);
     window.document.body.style.height = "initial";
-  });
+  };
+
+  // The image may already be loaded if the blob URL resolved synchronously,
+  // so check `complete` to avoid a missed `load` event.
+  if (imgElement.complete) {
+    onImageReady();
+  } else {
+    imgElement.addEventListener("load", onImageReady);
+  }
 };

--- a/frontend/src/metabase/visualizations/lib/save-chart-image.ts
+++ b/frontend/src/metabase/visualizations/lib/save-chart-image.ts
@@ -39,6 +39,10 @@ export const saveChartImage = async ({
   // Appending any element to the node does not automatically increase the canvas height.
   const canvasHeight = contentHeight + verticalOffset;
 
+  // Ensure fonts are fully loaded before capturing, otherwise
+  // html2canvas may render text with fallback fonts.
+  await document.fonts.ready;
+
   const { default: html2canvas } = await import("html2canvas-pro");
   const canvas = await html2canvas(node, {
     scale: 2,

--- a/frontend/src/metabase/visualizations/lib/save-chart-image.ts
+++ b/frontend/src/metabase/visualizations/lib/save-chart-image.ts
@@ -69,13 +69,19 @@ export const saveChartImage = async ({
     },
   });
 
-  canvas.toBlob((blob) => {
+  if (isStorybookActive) {
+    // In storybook/loki we must wait for the blob and image to be ready
+    // before the play function returns, otherwise the async callback may
+    // be garbage-collected ("Promise was collected").
+    const blob = await new Promise<Blob | null>((resolve) =>
+      canvas.toBlob(resolve),
+    );
     if (blob) {
-      if (isStorybookActive) {
-        // if we're running storybook we open the image in place
-        // so we can test the export result with loki
-        openImageBlobOnStorybook({ canvas, blob });
-      } else {
+      openImageBlobOnStorybook({ canvas, blob });
+    }
+  } else {
+    canvas.toBlob((blob) => {
+      if (blob) {
         const link = document.createElement("a");
         const url = URL.createObjectURL(blob);
         link.rel = "noopener";
@@ -85,6 +91,6 @@ export const saveChartImage = async ({
         link.remove();
         setTimeout(() => URL.revokeObjectURL(url), 60_000);
       }
-    }
-  });
+    });
+  }
 };


### PR DESCRIPTION
Closes [EMB-1466: Investigate flaky Loki test for embedded question view](https://linear.app/metabase/issue/EMB-1466/investigate-flaky-loki-test-for-embedded-question-view)

### Description

Tweaked the loki setup and image-saving files to wait for images and fonts readiness before taking screenshots.

Strees test here: https://github.com/metabase/metabase/actions/runs/23342859100