### PR TITLE
Fix model settings sidebar blocked by query errors

### DIFF
--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.unit.spec.tsx
@@ -17,6 +17,7 @@ import {
   createMockUnsavedCard,
 } from "metabase-types/api/mocks";
 import { createSampleDatabase } from "metabase-types/api/mocks/presets";
+import { createMockQueryBuilderUIControlsState } from "metabase-types/store/mocks";
 
 const TEST_DB = createSampleDatabase();
 const ROOT_COLLECTION = createMockCollection({ id: "root" });
@@ -63,7 +64,16 @@ const defaultDatasetEditorProps = {
   runDirtyQuestionQuery: noop,
 };
 
-const renderDatasetEditor = async (card: Card | UnsavedCard) => {
+const renderDatasetEditor = async (
+  card: Card | UnsavedCard,
+  {
+    propOverrides = {},
+    storeInitialState = {},
+  }: {
+    propOverrides?: Record<string, unknown>;
+    storeInitialState?: object;
+  } = {},
+) => {
   setupDatabasesEndpoints([TEST_DB]);
   setupCollectionsEndpoints({ collections: [ROOT_COLLECTION] });
   setupNativeQuerySnippetEndpoints();
@@ -74,7 +84,12 @@ const renderDatasetEditor = async (card: Card | UnsavedCard) => {
   fetchMock.get("path:/api/model-index", { body: [] });
 
   renderWithProviders(
-    <DatasetEditor {...defaultDatasetEditorProps} question={question} />,
+    <DatasetEditor
+      {...defaultDatasetEditorProps}
+      question={question}
+      {...propOverrides}
+    />,
+    { storeInitialState },
   );
 
   await screen.findByText("Query");
@@ -106,5 +121,22 @@ describe("DatasetEditor", () => {
     await renderDatasetEditor(mockUnsavedCard);
     const calls = fetchMock.callHistory.calls("path:/api/model-index");
     expect(calls).toHaveLength(0);
+  });
+
+  it("shows the settings sidebar on the metadata tab even when the query has an error", async () => {
+    await renderDatasetEditor(mockSavedModel, {
+      propOverrides: {
+        result: { error: "Column not found" },
+      },
+      storeInitialState: {
+        qb: {
+          uiControls: createMockQueryBuilderUIControlsState({
+            datasetEditorTab: "metadata",
+          }),
+        },
+      },
+    });
+
+    expect(screen.getByText("Model Settings")).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditorInner.tsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditorInner.tsx
@@ -153,7 +153,6 @@ function getSidebar(
   props: DatasetEditorInnerProps & { modelIndexes?: unknown },
   {
     datasetEditorTab,
-    isQueryError,
     focusedField,
     focusedFieldIndex,
     focusFirstField,
@@ -162,7 +161,6 @@ function getSidebar(
     onUpdateModelSettings,
   }: {
     datasetEditorTab: DatasetEditorTab;
-    isQueryError?: unknown;
     focusedField?: DatasetColumn;
     focusedFieldIndex: number;
     focusFirstField: () => void;
@@ -185,9 +183,6 @@ function getSidebar(
   } = props;
 
   if (datasetEditorTab === "columns") {
-    if (isQueryError) {
-      return null;
-    }
     if (!focusedField) {
       // Returning a div, so the sidebar is visible while the data is loading.
       // The field metadata sidebar will appear with an animation once a query completes
@@ -209,15 +204,6 @@ function getSidebar(
   }
 
   if (datasetEditorTab === "metadata") {
-    if (isQueryError || !props.rawSeries) {
-      return null;
-    }
-
-    if (!focusedField) {
-      // Returning a div, so the sidebar is visible while the data is loading.
-      return <div />;
-    }
-
     return (
       <DatasetEditorSettingsSidebar
         display={question.display()}
@@ -323,13 +309,20 @@ const DatasetEditorInnerView = (props: DatasetEditorInnerProps) => {
   const { isNative, isEditable } = Lib.queryDisplayInfo(question.query());
   const [modalOpened, { open: openModal, close: closeModal }] = useDisclosure();
 
+  const savedResultMetadata = question.getResultMetadata();
+  const effectiveMetadataColumns =
+    (resultsMetadata?.columns as unknown as Field[]) ??
+    (savedResultMetadata as unknown as Field[]) ??
+    [];
+
   const fields = useMemo(
     () =>
       getSortedModelFields(
-        (resultsMetadata?.columns as unknown as Field[]) ?? [],
+        effectiveMetadataColumns,
         visualizationSettings ?? {},
       ),
-    [resultsMetadata, visualizationSettings],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [resultsMetadata, savedResultMetadata, visualizationSettings],
   );
 
   /**
@@ -409,11 +402,20 @@ const DatasetEditorInnerView = (props: DatasetEditorInnerProps) => {
   useEffect(() => {
     // Focused field has to be set once the query is completed and the result is rendered
     // Visualization render can remove the focus
-    const hasQueryResults = !!result;
-    if (!focusedField && hasQueryResults && !result.error) {
+    // When the query has an error, fall back to saved result metadata
+    const hasQueryResults = !!result && !result.error;
+    const hasFallbackMetadata = savedResultMetadata.length > 0;
+    if (!focusedField && (hasQueryResults || hasFallbackMetadata)) {
       focusFirstField();
     }
-  }, [result, focusedFieldName, fields, focusFirstField, focusedField]);
+  }, [
+    result,
+    focusedFieldName,
+    fields,
+    focusFirstField,
+    focusedField,
+    savedResultMetadata,
+  ]);
 
   const inheritMappedFieldProperties = useCallback(
     (changes: { id: number } & Partial<DatasetColumn>) => {
@@ -648,7 +650,6 @@ const DatasetEditorInnerView = (props: DatasetEditorInnerProps) => {
     { ...props, modelIndexes },
     {
       datasetEditorTab,
-      isQueryError: result?.error,
       focusedField,
       focusedFieldIndex,
       focusFirstField,
@@ -679,7 +680,9 @@ const DatasetEditorInnerView = (props: DatasetEditorInnerProps) => {
           <EditorTabs
             currentTab={datasetEditorTab}
             disabledQuery={!isEditable}
-            disabledColumns={!resultsMetadata}
+            disabledColumns={
+              !resultsMetadata && savedResultMetadata.length === 0
+            }
             onChange={onChangeEditorTab}
           />
         }

--- a/frontend/src/metabase/query_builder/components/QueryVisualization.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryVisualization.jsx
@@ -79,7 +79,7 @@ export function QueryVisualization(props) {
         )}
         data-testid="query-visualization-root"
       >
-        {result?.error ? (
+        {result?.error && props.queryBuilderMode !== "dataset" ? (
           <VisualizationError
             className={CS.spread}
             error={result.error}
@@ -88,7 +88,7 @@ export function QueryVisualization(props) {
             question={question}
             duration={result.duration}
           />
-        ) : result?.data ? (
+        ) : result?.data && !result?.error ? (
           <VisualizationResult
             {...props}
             maxTableRows={maxTableRows}


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #69928
## Summary
- Remove the `isQueryError` guard from the Settings tab in the model metadata editor
- The Settings sidebar only needs `question.display()` and `question.settings()` (from the saved card), so it should remain accessible even when the model query has errors (e.g. a deleted column)

Fixes GDGT-1840