### PR TITLE
Define additional metrics for release monitoring

### DIFF
--- a/frontend/src/metabase/ErrorBoundary.tsx
+++ b/frontend/src/metabase/ErrorBoundary.tsx
@@ -35,6 +35,11 @@ class ErrorBoundaryInner extends Component<
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     console.error(error, errorInfo);
+    fetch("/api/frontend-errors", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ context: "render-page" }),
+    }).catch(() => {});
     // if we don't provide a specific onError action, the component will display a generic error message
     if (this.props.onError) {
       this.props.onError(errorInfo);

--- a/frontend/src/metabase/visualizations/components/ChartRenderingErrorBoundary/ChartRenderingErrorBoundary.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartRenderingErrorBoundary/ChartRenderingErrorBoundary.tsx
@@ -11,6 +11,11 @@ export class ChartRenderingErrorBoundary extends Component<ChartRenderingErrorBo
   }
 
   componentDidCatch(error: any) {
+    fetch("/api/frontend-errors", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ context: "render-chart" }),
+    }).catch(() => {});
     this.props.onRenderError(error.message || error);
   }
 

--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -593,7 +593,20 @@
                          {:description "Full agent loop duration (ms)"
                           :labels [:profile-id]
                           ;; 100ms -> 10 minutes
-                          :buckets [100 500 1000 5000 10000 30000 60000 120000 300000 600000]})])
+                          :buckets [100 500 1000 5000 10000 30000 60000 120000 300000 600000]})
+
+   ;; release dashboard metrics
+   (prometheus/counter :metabase-sync/failures
+                       {:description "Number of sync operation failures."
+                        :labels [:driver]})
+   (prometheus/counter :metabase-api/unhandled-errors
+                       {:description "Number of unhandled API errors (500s without explicit status code)."})
+   (prometheus/counter :metabase-frontend/errors
+                       {:description "Number of frontend errors reported by the browser."
+                        :labels [:context]})
+   (prometheus/counter :metabase-export/errors
+                       {:description "Number of errors during data export."
+                        :labels [:format]})])
 
 (defn- quartz-collectors
   []

--- a/src/metabase/api_routes/routes.clj
+++ b/src/metabase/api_routes/routes.clj
@@ -24,6 +24,7 @@
    [metabase.documents.api]
    [metabase.eid-translation.api]
    [metabase.embedding-rest.api]
+   [metabase.frontend-errors.api]
    [metabase.geojson.api]
    [metabase.glossary.api]
    [metabase.indexed-entities.api]
@@ -81,6 +82,7 @@
          metabase.data-studio.api/keep-me
          metabase.documents.api/keep-me
          metabase.eid-translation.api/keep-me
+         metabase.frontend-errors.api/keep-me
          metabase.geojson.api/keep-me
          metabase.glossary.api/keep-me
          metabase.indexed-entities.api/keep-me
@@ -170,6 +172,7 @@
    "/email"                metabase.channel.api/email-routes
    "/embed"                (+message-only-exceptions metabase.embedding-rest.api/embedding-routes)
    "/field"                (+auth metabase.warehouse-schema-rest.api/field-routes)
+   "/frontend-errors"      'metabase.frontend-errors.api
    "/geojson"              'metabase.geojson.api
    "/glossary"             (+auth 'metabase.glossary.api)
    "/google"               (+auth metabase.sso.api/google-auth-routes)

--- a/src/metabase/frontend_errors/api.clj
+++ b/src/metabase/frontend_errors/api.clj
@@ -1,0 +1,23 @@
+(ns metabase.frontend-errors.api
+  (:require
+   [metabase.analytics.prometheus :as prometheus]
+   [metabase.api.common :as api]
+   [metabase.api.macros :as api.macros]))
+
+(def ^:private Context
+  "Allowed context values for frontend error reporting."
+  [:enum "render-page" "render-chart"])
+
+#_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
+(api.macros/defendpoint :post "/"
+  "Endpoint for the frontend to report errors. Increments a Prometheus counter
+   with the given `context` label."
+  [_route-params
+   _query-params
+   {:keys [context]} :- [:map [:context Context]]]
+  (prometheus/inc! :metabase-frontend/errors {:context context})
+  api/generic-204-no-content)
+
+;;; !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+;;; !! Endpoints in this namespace do not currently require auth! Keep this in mind when adding new ones. !!
+;;; !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/src/metabase/query_processor/streaming.clj
+++ b/src/metabase/query_processor/streaming.clj
@@ -8,6 +8,7 @@
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.query-processor.pipeline :as qp.pipeline]
    [metabase.query-processor.schema :as qp.schema]
+   [metabase.analytics.prometheus :as prometheus]
    [metabase.query-processor.streaming.csv :as qp.csv]
    [metabase.query-processor.streaming.interface :as qp.si]
    [metabase.query-processor.streaming.json :as qp.json]
@@ -257,6 +258,7 @@
              (assert (not (instance? ManyToManyChannel result)) "QP should not return a core.async channel.")
              (when (or (instance? Throwable result)
                        (= (:status result) :failed))
+               (prometheus/inc! :metabase-export/errors {:format (name export-format)})
                (streaming-response/write-error! os result export-format (status-code result))))))))))
 
 (defn transforming-query-response

--- a/src/metabase/server/middleware/exceptions.clj
+++ b/src/metabase/server/middleware/exceptions.clj
@@ -3,6 +3,7 @@
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]
+   [metabase.analytics.prometheus :as prometheus]
    [metabase.server.middleware.security :as mw.security]
    [metabase.server.settings :as server.settings]
    [metabase.util.i18n :refer [tru]]
@@ -50,6 +51,8 @@
                                            (Throwable->map e)
                                            {:message (.getMessage e)}
                                            other-info))]
+    (when (nil? status-code)
+      (prometheus/inc! :metabase-api/unhandled-errors))
     {:status  (or status-code 500)
      :headers (mw.security/security-headers)
      :body    body}))

--- a/src/metabase/sync/util.clj
+++ b/src/metabase/sync/util.clj
@@ -22,6 +22,7 @@
    [metabase.util.malli.registry :as mr]
    [metabase.util.malli.schema :as ms]
    [metabase.util.memory :as u.mem]
+   [metabase.analytics.prometheus :as prometheus]
    [metabase.warehouses.models.database :as database]
    [toucan2.core :as t2]
    [toucan2.realize :as t2.realize])
@@ -270,15 +271,19 @@
                                     {:run_type    run-type
                                      :entity_type :database
                                      :entity_id   (u/the-id database)})
-        ((with-duplicate-ops-prevented
-          operation database
-          (with-sync-events
-           operation database
-           (with-start-and-finish-logging
-            message
-            (with-db-logging-disabled
-             (sync-in-context database
-                              (partial do-with-error-handling (format "Error in sync step %s" message) f)))))))))))
+        (let [sync-fn (with-duplicate-ops-prevented
+                       operation database
+                       (with-sync-events
+                        operation database
+                        (with-start-and-finish-logging
+                         message
+                         (with-db-logging-disabled
+                          (sync-in-context database
+                                           (partial do-with-error-handling (format "Error in sync step %s" message) f))))))
+              result (sync-fn)]
+          (when (instance? Throwable result)
+            (prometheus/inc! :metabase-sync/failures {:driver (name (:engine database))}))
+          result))))))
 
 (defmacro sync-operation
   "Perform the operations in `body` as a sync operation, which wraps the code in several special macros that do things

--- a/test/metabase/frontend_errors/api_test.clj
+++ b/test/metabase/frontend_errors/api_test.clj
@@ -1,0 +1,23 @@
+(ns metabase.frontend-errors.api-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.analytics.prometheus :as prometheus]
+   [metabase.test :as mt]))
+
+(deftest post-frontend-errors-test
+  (testing "POST /api/frontend-errors increments the counter for render-page and returns 204"
+    (mt/with-prometheus-system! [_ system]
+      (let [initial (mt/metric-value system :metabase-frontend/errors {:context "render-page"})]
+        (is (= {:status 204, :body nil}
+               (mt/user-http-request :rasta :post 204 "frontend-errors" {:context "render-page"})))
+        (is (< initial (mt/metric-value system :metabase-frontend/errors {:context "render-page"}))))))
+
+  (testing "POST /api/frontend-errors with context=render-chart tracks separately"
+    (mt/with-prometheus-system! [_ system]
+      (let [initial (mt/metric-value system :metabase-frontend/errors {:context "render-chart"})]
+        (mt/user-http-request :rasta :post 204 "frontend-errors" {:context "render-chart"})
+        (is (< initial (mt/metric-value system :metabase-frontend/errors {:context "render-chart"}))))))
+
+  (testing "POST /api/frontend-errors rejects unknown context values"
+    (is (= "value may be: render-chart, render-page"
+           (mt/user-http-request :rasta :post 400 "frontend-errors" {:context "bogus"})))))

--- a/test/metabase/server/middleware/exceptions_test.clj
+++ b/test/metabase/server/middleware/exceptions_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]
+   [metabase.analytics.prometheus :as prometheus]
    [metabase.server.middleware.exceptions :as mw.exceptions]
    [metabase.server.settings :as server.settings]
    [metabase.test :as mt]))
@@ -193,3 +194,16 @@
        (fn [e] (reset! captured-exception e)))
       (is (= test-exception @captured-exception)
           "Exception should be routed to raise handler"))))
+
+(deftest unhandled-error-increments-prometheus-counter-test
+  (testing "An unhandled exception (no status-code in ex-data) increments :metabase-api/unhandled-errors"
+    (mt/with-prometheus-system! [_ system]
+      (let [initial (mt/metric-value system :metabase-api/unhandled-errors)]
+        (mw.exceptions/api-exception-response (Exception. "boom"))
+        (is (< initial (mt/metric-value system :metabase-api/unhandled-errors))))))
+
+  (testing "An exception with an explicit status-code does NOT increment the counter"
+    (mt/with-prometheus-system! [_ system]
+      (let [initial (mt/metric-value system :metabase-api/unhandled-errors)]
+        (mw.exceptions/api-exception-response (ex-info "not found" {:status-code 404}))
+        (is (= initial (mt/metric-value system :metabase-api/unhandled-errors)))))))

--- a/test/metabase/sync/util_test.clj
+++ b/test/metabase/sync/util_test.clj
@@ -5,6 +5,7 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [java-time.api :as t]
+   [metabase.analytics.prometheus :as prometheus]
    [metabase.driver :as driver]
    [metabase.models.interface :as mi]
    [metabase.sync.core :as sync]
@@ -363,3 +364,13 @@
                 (is (= "complete"   (:initial_sync_status (get-inactive-table)))))))
           (a/close! syncing-chan)
           (a/close! completed-chan))))))
+
+(deftest sync-failure-increments-prometheus-counter-test
+  (testing "When a sync operation fails, the :metabase-sync/failures counter is incremented"
+    (mt/with-prometheus-system! [_ system]
+      (mt/with-temp [:model/Database db {:engine :h2}]
+        (let [initial (mt/metric-value system :metabase-sync/failures {:driver "h2"})]
+          (sync-util/do-sync-operation
+           :sync db "test sync failure"
+           (fn [] (throw (Exception. "sync boom"))))
+          (is (< initial (mt/metric-value system :metabase-sync/failures {:driver "h2"}))))))))


### PR DESCRIPTION
Replaced by: https://github.com/metabase/metabase/pull/71237

Closes [BOT-1158: Additional metrics for Release Dashboard](https://linear.app/metabase/issue/BOT-1158/additional-metrics-for-release-dashboard)

  - Adds four new Prometheus counters for release health monitoring:
    - metabase_sync_failures_total
    - metabase_api_unhandled_errors_total
    - metabase_frontend_errors_total — reported by the browser via a new POST /api/frontend-errors endpoint
    - metabase_export_errors_total 
  - New POST /api/frontend-errors endpoint (no auth)
  - ErrorBoundary and ChartRenderingErrorBoundary fire-and-forget POST to the new endpoint on catch