### PR TITLE
Update account settings docs

### DIFF
--- a/docs/people-and-groups/account-settings.md
+++ b/docs/people-and-groups/account-settings.md
@@ -11,7 +11,7 @@ To access your account settings, click the **profile or grid icon** in the top r
 
 ## Account profile
 
-You can set your first and last names, change your email address, and set your language. See our list of [supported languages](../configuring-metabase/localization.md). If you use SSO to log into your Metabase (e.g., your Google account), you won't be able to edit these settings in Metabase.
+You can set your first and last names, change your email address, and set your language. See our list of [supported languages](../configuring-metabase/localization.md).
 
 ## Theme
 


### PR DESCRIPTION
This is currently doable in version 59.3. It's weird as I reproduced in 56 but not in 59.3.

<img width="541" height="475" alt="Screenshot 2026-03-20 at 1 50 09 PM" src="https://github.com/user-attachments/assets/28598c39-2d2b-4627-b2c6-4f9c98e672c9" />

See this issue: https://github.com/metabase/metabase/issues/63581