### PR TITLE
Support entityId for guest embedded questions

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/guest-embed-reproductions.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/guest-embed-reproductions.cy.spec.tsx
@@ -30,6 +30,7 @@ describe("scenarios > embedding-sdk > guest-embed reproductions", () => {
       display,
     }).then(({ body: question }) => {
       cy.wrap(question.id).as("questionId");
+      cy.wrap(question.entity_id).as("questionEntityId");
     });
 
     cy.signOut();
@@ -64,6 +65,24 @@ describe("scenarios > embedding-sdk > guest-embed reproductions", () => {
           downloadUrl: "/api/embed/card/*/query/csv*",
           downloadMethod: "GET",
         });
+      });
+    });
+  });
+
+  it("should show question with a token containing entity id (EMB-1473)", () => {
+    setup();
+
+    cy.get("@questionEntityId").then(async (questionEntityId) => {
+      const token = await getSignedJwtForResource({
+        resourceId: questionEntityId as unknown as number,
+        resourceType: "question",
+      });
+
+      mountGuestEmbedQuestion({ token, title: true, withDownloads: true });
+
+      getSdkRoot().within(() => {
+        cy.findByText("Product ID").should("be.visible");
+        cy.findByText("Max of Quantity").should("be.visible");
       });
     });
   });

--- a/frontend/src/embedding-sdk-bundle/lib/sdk-question/load-question.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/sdk-question/load-question.ts
@@ -63,8 +63,9 @@ export const loadQuestionSdk =
 
     const metadata = getMetadata(getState());
 
-    const originalQuestion =
-      originalCard && new Question(originalCard, metadata);
+    const originalQuestion = originalCard
+      ? new Question(originalCard, metadata)
+      : undefined;
 
     let question = new Question(card, metadata);
     if (targetDashboardId) {

--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -406,7 +406,7 @@ export interface ListCardsRequest {
 }
 
 export interface GetCardRequest {
-  id: CardId;
+  id: CardId | EntityToken;
   context?: "collection";
   ignore_view?: boolean;
   ignore_error?: boolean;

--- a/frontend/src/metabase/query_builder/actions/core/card.ts
+++ b/frontend/src/metabase/query_builder/actions/core/card.ts
@@ -13,17 +13,13 @@ export async function loadCard(
     token?: EntityToken | null;
   },
   { dispatch }: { dispatch: Dispatch; getState: GetState },
-): Promise<Card> {
+) {
   try {
-    const result = await dispatch(
+    const { data } = (await dispatch(
       cardApi.endpoints.getCard.initiate({ id: token ?? cardId }),
-    );
+    )) as { data: Card };
 
-    if (result.data != null) {
-      return result.data;
-    }
-
-    throw new Error("Failed to fetch card");
+    return data;
   } catch (error) {
     console.error("error loading card", error);
     throw error;

--- a/frontend/src/metabase/query_builder/actions/core/card.ts
+++ b/frontend/src/metabase/query_builder/actions/core/card.ts
@@ -1,4 +1,5 @@
-import { Questions } from "metabase/entities/questions";
+import { cardApi } from "metabase/api";
+import type { Card } from "metabase-types/api";
 import type { EntityToken } from "metabase-types/api/entity";
 import type { Dispatch, GetState } from "metabase-types/store";
 
@@ -11,29 +12,18 @@ export async function loadCard(
     cardId: string | number;
     token?: EntityToken | null;
   },
-  { dispatch, getState }: { dispatch: Dispatch; getState: GetState },
-) {
+  { dispatch }: { dispatch: Dispatch; getState: GetState },
+): Promise<Card> {
   try {
-    const actionResult = await dispatch(
-      Questions.actions.fetch(
-        { id: token ?? cardId },
-        {
-          properties: [
-            "id",
-            "dataset_query",
-            "display",
-            "visualization_settings",
-          ], // complies with Card interface
-        },
-      ),
+    const result = await dispatch(
+      cardApi.endpoints.getCard.initiate({ id: token ?? cardId }),
     );
 
-    const card = Questions.HACK_getObjectFromAction(actionResult);
-    const question = Questions.selectors.getObject(getState(), {
-      entityId: card.id ?? cardId,
-    });
+    if (result.data != null) {
+      return result.data;
+    }
 
-    return question?.card();
+    throw new Error("Failed to fetch card");
   } catch (error) {
     console.error("error loading card", error);
     throw error;

--- a/frontend/src/metabase/query_builder/actions/core/card.ts
+++ b/frontend/src/metabase/query_builder/actions/core/card.ts
@@ -14,7 +14,7 @@ export async function loadCard(
   { dispatch, getState }: { dispatch: Dispatch; getState: GetState },
 ) {
   try {
-    await dispatch(
+    const actionResult = await dispatch(
       Questions.actions.fetch(
         { id: token ?? cardId },
         {
@@ -28,8 +28,9 @@ export async function loadCard(
       ),
     );
 
+    const card = Questions.HACK_getObjectFromAction(actionResult);
     const question = Questions.selectors.getObject(getState(), {
-      entityId: cardId,
+      entityId: card.id ?? cardId,
     });
 
     return question?.card();

--- a/frontend/src/metabase/query_builder/actions/core/card.ts
+++ b/frontend/src/metabase/query_builder/actions/core/card.ts
@@ -15,11 +15,15 @@ export async function loadCard(
   { dispatch }: { dispatch: Dispatch; getState: GetState },
 ) {
   try {
-    const { data } = (await dispatch(
+    const result = (await dispatch(
       cardApi.endpoints.getCard.initiate({ id: token ?? cardId }),
-    )) as { data: Card };
+    )) as { data?: Card; error?: unknown };
 
-    return data;
+    if (result.error) {
+      throw result.error;
+    }
+
+    return result.data as Card;
   } catch (error) {
     console.error("error loading card", error);
     throw error;

--- a/frontend/src/metabase/query_builder/actions/core/card.ts
+++ b/frontend/src/metabase/query_builder/actions/core/card.ts
@@ -23,7 +23,11 @@ export async function loadCard(
       throw result.error;
     }
 
-    return result.data as Card;
+    if (!result.data) {
+      throw new Error("Card not found");
+    }
+
+    return result.data;
   } catch (error) {
     console.error("error loading card", error);
     throw error;

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
@@ -150,7 +150,7 @@ async function fetchAndPrepareSavedQuestionCards(
 
   // for showing the "started from" lineage correctly when adding filters/breakouts and when going back and forth
   // in browser history, the original_card_id has to be set for the current card (simply the id of card itself for now)
-  return { card: { ...card, original_card_id: card.id }, originalCard };
+  return { card: { ...card, original_card_id: card.id } as Card, originalCard };
 }
 
 async function fetchAndPrepareAdHocQuestionCards(
@@ -175,7 +175,7 @@ async function fetchAndPrepareAdHocQuestionCards(
 
   if (cardIsEquivalent(deserializedCard, originalCard)) {
     return {
-      card: { ...originalCard },
+      card: { ...originalCard } as Card,
       originalCard: originalCard,
     };
   }
@@ -188,7 +188,7 @@ async function fetchAndPrepareAdHocQuestionCards(
 
 type ResolveCardsResult = {
   card: Card;
-  originalCard?: Card;
+  originalCard?: Card | null;
 };
 
 export async function resolveCards({

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
@@ -150,7 +150,7 @@ async function fetchAndPrepareSavedQuestionCards(
 
   // for showing the "started from" lineage correctly when adding filters/breakouts and when going back and forth
   // in browser history, the original_card_id has to be set for the current card (simply the id of card itself for now)
-  return { card: { ...card, original_card_id: card.id } as Card, originalCard };
+  return { card: { ...card, original_card_id: card.id }, originalCard };
 }
 
 async function fetchAndPrepareAdHocQuestionCards(
@@ -175,7 +175,7 @@ async function fetchAndPrepareAdHocQuestionCards(
 
   if (cardIsEquivalent(deserializedCard, originalCard)) {
     return {
-      card: { ...originalCard } as Card,
+      card: { ...originalCard },
       originalCard: originalCard,
     };
   }

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.unit.spec.ts
@@ -142,7 +142,7 @@ async function setup({
 
   jest
     .spyOn(cardActions, "loadCard")
-    .mockReturnValue(Promise.resolve({ ...card }));
+    .mockReturnValue(Promise.resolve({ ...card } as Card));
 
   return baseSetup({ location, params, ...opts });
 }
@@ -441,7 +441,7 @@ describe("QB Actions > initializeQB", () => {
 
         jest
           .spyOn(cardActions, "loadCard")
-          .mockReturnValueOnce(Promise.resolve({ ...originalCard }));
+          .mockReturnValueOnce(Promise.resolve({ ...originalCard } as Card));
 
         return setup({ card: q, ...opts });
       }

--- a/frontend/src/metabase/query_builder/actions/core/parameterUtils.ts
+++ b/frontend/src/metabase/query_builder/actions/core/parameterUtils.ts
@@ -30,7 +30,7 @@ function shouldPropagateDashboardParameters({
 }: {
   cardId?: number;
   deserializedCard: Card;
-  originalCard?: Card;
+  originalCard?: Card | null;
 }): boolean {
   if (cardId && deserializedCard.parameters) {
     return true;
@@ -105,7 +105,7 @@ export async function propagateDashboardParameters({
 }: {
   card: Card;
   deserializedCard: Card; // DashCard (has dashboardId and dashcardId)
-  originalCard?: Card;
+  originalCard?: Card | null;
   dispatch: Dispatch;
 }) {
   const cardId = card.id;


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #71239
Support entityId for guest embedded questions.

This PR fixes the case when an entityId is encoded in JWT token.
As the `cardId` is entityId in this case, the following line:
```
const question = Questions.selectors.getObject(getState(), {
      entityId: cardId,
    });
```

returns question as `null`, because the search should be done by a numeric id.

As the fix we get the numeric id from the response result directly via 
```
    const result = (await dispatch(
      cardApi.endpoints.getCard.initiate({ id: token ?? cardId }),
    )) as { data?: Card; error?: unknown };

    if (result.error) {
      throw result.error;
    }

    return result.data as Card;
```

Context: https://metaboat.slack.com/archives/C063Q3F1HPF/p1773769608393099