### PR TITLE
Catch drag events on Dashcard placeholders

### DIFF
--- a/e2e/test/scenarios/dashboard-cards/dashboard-sections.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-sections.cy.spec.js
@@ -55,6 +55,9 @@ describe("scenarios > dashboard cards > sections", () => {
       section_layout: "kpi_grid",
     });
 
+    // Verify placeholder cards can be dragged (metabase#UXW-3387)
+    assertPlaceholderCardCanBeDragged();
+
     selectQuestion("Orders, Count, Grouped by Created At (year)");
 
     overwriteDashCardTitle(
@@ -162,4 +165,43 @@ function mapDashCardToFilter(dashcardElement, filterName) {
   filterPanel().findByText(filterName).click();
   H.selectDashboardFilter(dashcardElement, filterName);
   H.sidebar().button("Done").click();
+}
+
+function assertPlaceholderCardCanBeDragged() {
+  H.getDashboardCards().then(($cards) => {
+    const initialLeftValues = [...$cards].map(
+      (card) => card.getBoundingClientRect().left,
+    );
+
+    const $target = $cards
+      .filter((_i, card) =>
+        card
+          .querySelector("[data-testid='dashcard']")
+          ?.textContent?.includes("Select question"),
+      )
+      .first();
+
+    const rect = $target[0].getBoundingClientRect();
+
+    cy.wrap($target)
+      .trigger("mousedown", { button: 0, x: 10, y: 50 })
+      .trigger("mousemove", {
+        button: 0,
+        clientX: rect.left + 900,
+        clientY: rect.top + 200,
+      })
+      .wait(100)
+      .trigger("mouseup");
+
+    H.getDashboardCards().then(($afterCards) => {
+      const afterLeftValues = [...$afterCards].map(
+        (card) => card.getBoundingClientRect().left,
+      );
+
+      const someCardMoved = afterLeftValues.some(
+        (left, i) => left !== initialLeftValues[i],
+      );
+      expect(someCardMoved).to.eq(true);
+    });
+  });
 }

--- a/e2e/test/scenarios/dashboard-cards/dashboard-sections.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-sections.cy.spec.js
@@ -58,12 +58,12 @@ describe("scenarios > dashboard cards > sections", () => {
     selectQuestion("Orders, Count, Grouped by Created At (year)");
 
     overwriteDashCardTitle(
-      2,
+      1,
       "Orders, Count, Grouped by Created At (year)",
       "Line chart",
     );
     // TODO: if the mapping is done before the title is changed, the mapping is lost
-    mapDashCardToFilter(H.getDashboardCard(2), "Category");
+    mapDashCardToFilter(H.getDashboardCard(1), "Category");
 
     H.goToTab("Tab 1");
     H.saveDashboard();
@@ -101,7 +101,7 @@ describe("scenarios > dashboard cards > sections", () => {
     // Ensure parameter mapping is persisted
     H.editDashboard();
     filterPanel().findByText("Category").click();
-    H.getDashboardCard(2).findByText("Product.Category").should("exist");
+    H.getDashboardCard(1).findByText("Product.Category").should("exist");
   });
 });
 

--- a/frontend/src/metabase/visualizations/visualizations/DashCardPlaceholder.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/DashCardPlaceholder.tsx
@@ -59,11 +59,7 @@ function DashCardPlaceholderInner({
   };
 
   return (
-    <div
-      onMouseDown={preventDragging}
-      onPointerDown={preventDragging}
-      style={{ display: "contents" }}
-    >
+    <>
       <Flex
         p={2}
         style={{ flex: 1, pointerEvents }}
@@ -80,31 +76,39 @@ function DashCardPlaceholderInner({
             <Button
               onClick={() => setQuestionPickerOpen(true)}
               style={{ pointerEvents }}
+              onMouseDown={preventDragging}
+              onPointerDown={preventDragging}
             >{t`Select question`}</Button>
           </Flex>
         )}
       </Flex>
       {isQuestionPickerOpen && (
-        <QuestionPickerModal
-          title={t`Pick what you want to replace this with`}
-          value={
-            dashboard.collection_id
-              ? {
-                  id: dashboard.collection_id,
-                  model: "collection",
-                }
-              : undefined
-          }
-          options={{ hasConfirmButtons: false }}
-          // TODO: account for restrictions on adding personal
-          // questions to public dashboards
-          models={["card", "dataset", "metric", "dashboard"]}
-          onChange={handleSelectQuestion}
-          onClose={() => setQuestionPickerOpen(false)}
-          isDisabledItem={shouldDisableItem}
-        />
+        <div
+          style={{ display: "contents" }}
+          onMouseDown={preventDragging}
+          onPointerDown={preventDragging}
+        >
+          <QuestionPickerModal
+            title={t`Pick what you want to replace this with`}
+            value={
+              dashboard.collection_id
+                ? {
+                    id: dashboard.collection_id,
+                    model: "collection",
+                  }
+                : undefined
+            }
+            options={{ hasConfirmButtons: false }}
+            // TODO: account for restrictions on adding personal
+            // questions to public dashboards
+            models={["card", "dataset", "metric", "dashboard"]}
+            onChange={handleSelectQuestion}
+            onClose={() => setQuestionPickerOpen(false)}
+            isDisabledItem={shouldDisableItem}
+          />
+        </div>
       )}
-    </div>
+    </>
   );
 }
 

--- a/frontend/src/metabase/visualizations/visualizations/DashCardPlaceholder.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/DashCardPlaceholder.tsx
@@ -59,7 +59,11 @@ function DashCardPlaceholderInner({
   };
 
   return (
-    <>
+    <div
+      onMouseDown={preventDragging}
+      onPointerDown={preventDragging}
+      style={{ display: "contents" }}
+    >
       <Flex
         p={2}
         style={{ flex: 1, pointerEvents }}
@@ -75,7 +79,6 @@ function DashCardPlaceholderInner({
           >
             <Button
               onClick={() => setQuestionPickerOpen(true)}
-              onMouseDown={preventDragging}
               style={{ pointerEvents }}
             >{t`Select question`}</Button>
           </Flex>
@@ -101,13 +104,23 @@ function DashCardPlaceholderInner({
           isDisabledItem={shouldDisableItem}
         />
       )}
-    </>
+    </div>
   );
 }
 
 DashCardPlaceholderInner.displayName = "DashCardPlaceholder";
 
-function preventDragging(e: React.MouseEvent<HTMLButtonElement>) {
+/**
+ * Prevents React portal event bubbling from triggering grid item drags.
+ *
+ * React portals (used by modals) bubble synthetic events through the React
+ * component tree, not the DOM tree. This means clicks inside a modal rendered
+ * by this component would bubble up to DraggableCore on the grid item and
+ * initiate a drag. We stop both mousedown and pointerdown because Cypress
+ * (and browsers) dispatch both events, and React processes them as separate
+ * synthetic event dispatches — stopPropagation on one doesn't affect the other.
+ */
+function preventDragging(e: React.SyntheticEvent) {
   e.stopPropagation();
 }
 


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #71273
### Description
Captures the drag events of the entity picker modal from the Dashcard Placeholder components. This was introduced with https://github.com/metabase/metabase/pull/70760, and the symptom was shown in the tests that were updated (I should have looked more into this 🤦). This PR captures the events, and resets the dashboard section tests to the way they were before.

Note: I've set this to no-backport because these changes are included on the backports of 70760 in v57, v58, and v59

### How to verify
1. Go to a dashboard and enter edit mode.
2. Add a new section, and click Select Question in one of the dashcard placeholders
3. Try dragging any element in the entity picker modal, Nothing should happen "behind" the modal (or in the modal... The entity picker doesn't support dragging entities).

### Checklist
- [x] Tests have been added/updated to cover changes in this PR
