### PR TITLE
feat(embedding hub): add ability to hide sidebar for some pages

### DIFF
--- a/frontend/src/metabase/admin/embedding/containers/AdminEmbeddingApp.tsx
+++ b/frontend/src/metabase/admin/embedding/containers/AdminEmbeddingApp.tsx
@@ -1,14 +1,27 @@
+import type { Location } from "history";
+
 import { AdminSettingsLayout } from "metabase/common/components/AdminLayout/AdminSettingsLayout";
 
 import { EmbeddingNav } from "../components/EmbeddingNav";
 
+const SIDEBAR_HIDDEN_PATHS = new Set([
+  "/admin/embedding/setup-guide/permissions",
+  "/admin/embedding/setup-guide/sso",
+]);
+
 export const AdminEmbeddingApp = ({
+  location,
   children,
 }: {
+  location: Location;
   children: React.ReactNode;
 }) => {
+  const shouldHideSidebar = SIDEBAR_HIDDEN_PATHS.has(location.pathname);
+
   return (
-    <AdminSettingsLayout sidebar={<EmbeddingNav />}>
+    <AdminSettingsLayout
+      sidebar={shouldHideSidebar ? undefined : <EmbeddingNav />}
+    >
       {children}
     </AdminSettingsLayout>
   );

--- a/frontend/src/metabase/admin/embedding/containers/AdminEmbeddingApp.unit.spec.tsx
+++ b/frontend/src/metabase/admin/embedding/containers/AdminEmbeddingApp.unit.spec.tsx
@@ -1,0 +1,40 @@
+import type { ComponentProps } from "react";
+import { Route } from "react-router";
+
+import { renderWithProviders, screen } from "__support__/ui";
+
+import { AdminEmbeddingApp } from "./AdminEmbeddingApp";
+
+const TestAdminEmbeddingApp = (
+  props: ComponentProps<typeof AdminEmbeddingApp>,
+) => (
+  <AdminEmbeddingApp {...props}>
+    <div>content</div>
+  </AdminEmbeddingApp>
+);
+
+describe("AdminEmbeddingApp", () => {
+  it("shows the sidebar on the setup guide root", () => {
+    renderWithProviders(<Route path="*" component={TestAdminEmbeddingApp} />, {
+      initialRoute: "/admin/embedding/setup-guide",
+      withRouter: true,
+    });
+
+    expect(screen.getByTestId("admin-layout-sidebar")).toBeInTheDocument();
+  });
+
+  it.each([
+    "/admin/embedding/setup-guide/permissions",
+    "/admin/embedding/setup-guide/sso",
+  ])("hides the sidebar for %s", (pathname) => {
+    renderWithProviders(<Route path="*" component={TestAdminEmbeddingApp} />, {
+      initialRoute: pathname,
+      withRouter: true,
+    });
+
+    expect(
+      screen.queryByTestId("admin-layout-sidebar"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId("admin-layout-content")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION

Closes [EMB-1399: Hide the left sidebar while permissions or SSO wizards are active](https://linear.app/metabase/issue/EMB-1399/hide-the-left-sidebar-while-permissions-or-sso-wizards-are-active)

### Description

What the issue says basically

