### PR TITLE
Patch vulnerable Trivy action

### DIFF
--- a/.github/workflows/containerize-uberjar.yml
+++ b/.github/workflows/containerize-uberjar.yml
@@ -76,7 +76,7 @@ jobs:
         with:
           ref: ${{ github.event.inputs.commit || github.event.pull_request.head.sha || github.sha }}
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@v0.29.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
         env:
           TRIVY_OFFLINE_SCAN: true
           repo: ${{ fromJson(needs.get-container-info.outputs[matrix.edition]).repo }}


### PR DESCRIPTION
Resolves DEV-1712

Patches Trivy GitHub action to a version that is confirmed not to be affected by the supply chain attack. We're using SHA-1 instead of a tag for an improved security.

See: https://app.mendral.com/insights/01KM6NFNZPV1JS72KAPCA2K9XH

## Resources:
- https://github.com/aquasecurity/trivy-action/commit/57a97c7e7821a5776cebc9bb87c984fa69cba8f1
- https://github.com/aquasecurity/trivy-action/releases

<img width="1144" height="1156" alt="image" src="https://github.com/user-attachments/assets/bc73ae96-74da-42c7-8c55-4065f80a7c88" />

