### PR TITLE
Remove hard-coded Trivy version

### DIFF
--- a/.github/workflows/containerize-uberjar.yml
+++ b/.github/workflows/containerize-uberjar.yml
@@ -85,7 +85,6 @@ jobs:
           image-ref: docker.io/${{ env.repo }}:${{ env.tag }}
           format: sarif
           output: trivy-results.sarif
-          version: "v0.57.1"
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3
         with:


### PR DESCRIPTION
Resolves DEV-1713

The hard-coded pinned version has been severely outdated. If we delete it, Trivy _should_ pick the appropriate version itself. 