### PR TITLE
Fix search related testing race conditions 

### DIFF
--- a/src/metabase/search/appdb/index.clj
+++ b/src/metabase/search/appdb/index.clj
@@ -105,8 +105,8 @@
 
 (defn- drop-table! [table]
   (boolean
-   (when (and table (exists? table))
-     (t2/query (sql.helpers/drop-table (keyword (table-name table)))))))
+   (when table
+     (t2/query (sql.helpers/drop-table :if-exists (keyword (table-name table)))))))
 
 (defn- orphan-indexes []
   (map (comp keyword u/lower-case-en :table_name)
@@ -274,8 +274,9 @@
             (sync-tracking-atoms!)
             (specialization/batch-upsert! table-name entries)
             (catch Exception e2
-              (log/error e2 "Error syncing index tracking atoms after table not found exception")
-              (throw e)))
+              (if (table-not-found-exception? e2)
+                (log/warnf "Search index table %s no longer exists, skipping upsert" table-name)
+                (throw e))))
           (throw e))))))
 
 (defn- batch-update!

--- a/src/metabase/search/appdb/index.clj
+++ b/src/metabase/search/appdb/index.clj
@@ -263,14 +263,14 @@
   (or (instance? PSQLException (ex-cause e))
       (instance? JdbcSQLSyntaxErrorException (ex-cause e))))
 
-(defn- retry-upsert-ex [table-id table-name refreshed-table-name e e2]
+(defn- retry-upsert-ex [table-type table-name-before table-name-after e-before e-after]
   (ex-info "Failed retrying search index batch upsert"
-           {:table-id                  table-id
-            :table-name-before-retry  table-name
-            :table-name-after-retry   refreshed-table-name
-            :initial-exception-class  (class e)
-            :initial-exception-message (ex-message e)}
-           e2))
+           {:table-type                table-type
+            :table-name-before-refresh table-name-before
+            :table-name-after-refresh  table-name-after
+            :initial-exception-class   (class e-before)
+            :initial-exception-message (ex-message e-before)}
+           e-after))
 
 (defn- safe-batch-upsert!
   "Best-effort upsert into the search index table returned by `table-name-fn`.
@@ -279,40 +279,23 @@
   tracked table disappeared during a concurrent index rotation. Missing-table races are
   intentionally suppressed because search indexing is best-effort and must not fail the caller's
   primary write path."
-  [table-id table-name-fn entries]
+  [table-type table-name-fn entries]
   ;; For convenience, no-op if we are not tracking any table.
   (when-let [table-name (table-name-fn)]
-    (letfn [(upsert! [table-name]
-              (specialization/batch-upsert! table-name entries)
-              table-name)]
+    (let [upsert! #(specialization/batch-upsert! % entries)]
       (try
         (upsert! table-name)
         (catch Exception e
-          (cond
-            (not (table-not-found-exception? e))
+          ;; Only suppress failures related to a legitimately non-existent table
+          (if (or (not (table-not-found-exception? e)) (exists? table-name))
             (throw e)
-
-            (exists? table-name)
-            (throw e)
-
-            :else
-            (let [refreshed-table-name (do (sync-tracking-atoms!)
-                                           (table-name-fn))]
-              (if-not refreshed-table-name
-                (do
-                  (log/warnf "Search index %s table %s no longer exists, skipping upsert" table-id table-name)
-                  nil)
+            (when-let [refreshed-table-name (do (sync-tracking-atoms!) (table-name-fn))]
+              (if (= table-name refreshed-table-name)
+                (throw (ex-info "Currently tracked index does not exist" e {:table-name table-name}))
                 (try
                   (upsert! refreshed-table-name)
                   (catch Exception e2
-                    (if (table-not-found-exception? e2)
-                      ;; This method is allowed to skip writes when a concurrent rotation removes the
-                      ;; target index, because dropping a batch is preferable to failing the main write.
-                      (do
-                        (log/warnf "Search index %s table moved from %s to %s during upsert, skipping batch"
-                                   table-id table-name refreshed-table-name)
-                        nil)
-                      (throw (retry-upsert-ex table-id table-name refreshed-table-name e e2)))))))))))))
+                    (retry-upsert-ex table-type table-name refreshed-table-name e e2)))))))))))
 
 (defn- batch-update!
   "Create the given search index entries in bulk. Commits after each batch"
@@ -330,11 +313,11 @@
 
   (let [reindexing? (and (= :search/reindexing context) (not search.ingestion/*force-sync*))
         do-writes   (fn []
-                      (let [active-table-name   (active-table)
-                            entries             (map document->entry documents)
-                            ;; No need to update the active index if we are doing a full index and it will be swapped out soon. Most updates are no-ops anyway.
-                            active-updated-table (when-not (and active-table-name (pending-table) reindexing?)
-                                                   (safe-batch-upsert! :active (constantly active-table-name) entries))
+                      (let [entries             (map document->entry documents)
+                            ;; No need to update the active index if we are doing a full index, as this table will be
+                            ;; swapped out soon. Most updates would be no-ops anyway.
+                            active-updated-table (when-not (and reindexing? (pending-table))
+                                                   (safe-batch-upsert! :active active-table entries))
                             pending-updated-table (safe-batch-upsert! :pending pending-table entries)]
                         (when (or active-updated-table pending-updated-table)
                           (u/prog1 (->> entries (map :model) frequencies)

--- a/src/metabase/search/appdb/index.clj
+++ b/src/metabase/search/appdb/index.clj
@@ -275,25 +275,26 @@
 (defn- safe-batch-upsert!
   "A version of batch-upsert! that no-ops for missing indexes, and handles stale index tracking metadata.
 
-  Returns the name of the table that was written to, or nil if there is none being tracked.
-  We recover gracefully the first time if the tracking atom was stale, but do not check again on retry."
+  We recover gracefully the first time if the tracking atom was stale, but do not check again on retry.
+  Returns whether an upsert happened."
   [table-type table-name-fn entries]
-  ;; For convenience, no-op if we are not tracking any table.
-  (when-let [table-name (table-name-fn)]
-    (let [upsert! (fn [t] (specialization/batch-upsert! t entries) t)]
-      (try
-        (upsert! table-name)
-        (catch Exception e
-          ;; Only suppress failures related to a legitimately non-existent table
-          (if (or (not (table-not-found-exception? e)) (exists? table-name))
-            (throw e)
-            (when-let [refreshed-table-name (do (sync-tracking-atoms!) (table-name-fn))]
-              (if (= table-name refreshed-table-name)
-                (throw (ex-info "Currently tracked index does not exist" e {:table-name table-name}))
-                (try
-                  (upsert! refreshed-table-name)
-                  (catch Exception e2
-                    (retry-upsert-ex table-type table-name refreshed-table-name e e2)))))))))))
+  (boolean
+   ;; For convenience, no-op if we are not tracking any table.
+   (when-let [table-name (table-name-fn)]
+     (let [upsert! (fn [t] (specialization/batch-upsert! t entries) true)]
+       (try
+         (upsert! table-name)
+         (catch Exception e
+           ;; Only suppress failures related to a legitimately non-existent table
+           (if (or (not (table-not-found-exception? e)) (exists? table-name))
+             (throw e)
+             (when-let [refreshed-table-name (do (sync-tracking-atoms!) (table-name-fn))]
+               (if (= table-name refreshed-table-name)
+                 (throw (ex-info "Currently tracked index does not exist" e {:table-name table-name}))
+                 (try
+                   (upsert! refreshed-table-name)
+                   (catch Exception e2
+                     (retry-upsert-ex table-type table-name refreshed-table-name e e2))))))))))))
 
 (defn- batch-update!
   "Create the given search index entries in bulk. Commits after each batch"
@@ -311,19 +312,19 @@
 
   (let [reindexing? (and (= :search/reindexing context) (not search.ingestion/*force-sync*))
         do-writes   (fn []
-                      (let [entries             (map document->entry documents)
+                      (let [entries         (map document->entry documents)
                             ;; No need to update the active index if we are doing a full index, as this table will be
                             ;; swapped out soon. Most updates would be no-ops anyway.
-                            active-updated-table (when-not (and reindexing? (pending-table))
-                                                   (safe-batch-upsert! :active active-table entries))
-                            pending-updated-table (safe-batch-upsert! :pending pending-table entries)]
-                        (when (or active-updated-table pending-updated-table)
+                            active-updated? (when-not (and reindexing? (pending-table))
+                                              (safe-batch-upsert! :active active-table entries))
+                            pending-update? (safe-batch-upsert! :pending pending-table entries)]
+                        (when (or active-updated? pending-update?)
                           (u/prog1 (->> entries (map :model) frequencies)
                             (when reindexing?
                               (t2/query ["commit"]))
                             (log/trace "indexed documents for " <>)
-                            (when active-updated-table
-                              (analytics/set! :metabase-search/appdb-index-size (t2/count (name active-updated-table))))))))]
+                            (when active-updated?
+                              (analytics/set! :metabase-search/appdb-index-size (t2/count (name active-updated?))))))))]
     (if reindexing?
       ;; New connection used for performing the updates which commit periodically without impacting any outer transactions.
       (t2/with-connection [_conn (mdb/data-source)]

--- a/src/metabase/search/appdb/index.clj
+++ b/src/metabase/search/appdb/index.clj
@@ -263,23 +263,56 @@
   (or (instance? PSQLException (ex-cause e))
       (instance? JdbcSQLSyntaxErrorException (ex-cause e))))
 
-(defn- safe-batch-upsert! [table-name entries]
+(defn- retry-upsert-ex [table-id table-name refreshed-table-name e e2]
+  (ex-info "Failed retrying search index batch upsert"
+           {:table-id                  table-id
+            :table-name-before-retry  table-name
+            :table-name-after-retry   refreshed-table-name
+            :initial-exception-class  (class e)
+            :initial-exception-message (ex-message e)}
+           e2))
+
+(defn- safe-batch-upsert!
+  "Best-effort upsert into the search index table returned by `table-name-fn`.
+
+  Returns the table name that was written to, or nil if there is no tracked table or if the
+  tracked table disappeared during a concurrent index rotation. Missing-table races are
+  intentionally suppressed because search indexing is best-effort and must not fail the caller's
+  primary write path."
+  [table-id table-name-fn entries]
   ;; For convenience, no-op if we are not tracking any table.
-  (when table-name
-    (try
-      (specialization/batch-upsert! table-name entries)
-      (catch Exception e
-        (if (table-not-found-exception? e)
-          ;; If resetting tracking atoms resolves the issue (which is likely happened because of stale tracking data),
-          ;; suppress the issue - but throw it all the way to the caller if the issue persists
-          (try
-            (sync-tracking-atoms!)
-            (specialization/batch-upsert! table-name entries)
-            (catch Exception e2
-              (if (table-not-found-exception? e2)
-                (log/warnf "Search index table %s no longer exists, skipping upsert" table-name)
-                (throw e))))
-          (throw e))))))
+  (when-let [table-name (table-name-fn)]
+    (letfn [(upsert! [table-name]
+              (specialization/batch-upsert! table-name entries)
+              table-name)]
+      (try
+        (upsert! table-name)
+        (catch Exception e
+          (cond
+            (not (table-not-found-exception? e))
+            (throw e)
+
+            (exists? table-name)
+            (throw e)
+
+            :else
+            (let [refreshed-table-name (do (sync-tracking-atoms!)
+                                           (table-name-fn))]
+              (if-not refreshed-table-name
+                (do
+                  (log/warnf "Search index %s table %s no longer exists, skipping upsert" table-id table-name)
+                  nil)
+                (try
+                  (upsert! refreshed-table-name)
+                  (catch Exception e2
+                    (if (table-not-found-exception? e2)
+                      ;; This method is allowed to skip writes when a concurrent rotation removes the
+                      ;; target index, because dropping a batch is preferable to failing the main write.
+                      (do
+                        (log/warnf "Search index %s table moved from %s to %s during upsert, skipping batch"
+                                   table-id table-name refreshed-table-name)
+                        nil)
+                      (throw (retry-upsert-ex table-id table-name refreshed-table-name e e2)))))))))))))
 
 (defn- batch-update!
   "Create the given search index entries in bulk. Commits after each batch"
@@ -297,19 +330,19 @@
 
   (let [reindexing? (and (= :search/reindexing context) (not search.ingestion/*force-sync*))
         do-writes   (fn []
-                      (let [active-table    (active-table)
-                            entries          (map document->entry documents)
+                      (let [active-table-name   (active-table)
+                            entries             (map document->entry documents)
                             ;; No need to update the active index if we are doing a full index and it will be swapped out soon. Most updates are no-ops anyway.
-                            active-updated?  (when-not (and active-table (pending-table) reindexing?)
-                                               (safe-batch-upsert! active-table entries))
-                            pending-updated? (safe-batch-upsert! (pending-table) entries)]
-                        (when (or active-updated? pending-updated?)
+                            active-updated-table (when-not (and active-table-name (pending-table) reindexing?)
+                                                   (safe-batch-upsert! :active (constantly active-table-name) entries))
+                            pending-updated-table (safe-batch-upsert! :pending pending-table entries)]
+                        (when (or active-updated-table pending-updated-table)
                           (u/prog1 (->> entries (map :model) frequencies)
                             (when reindexing?
                               (t2/query ["commit"]))
                             (log/trace "indexed documents for " <>)
-                            (when active-updated?
-                              (analytics/set! :metabase-search/appdb-index-size (t2/count (name active-table))))))))]
+                            (when active-updated-table
+                              (analytics/set! :metabase-search/appdb-index-size (t2/count (name active-updated-table))))))))]
     (if reindexing?
       ;; New connection used for performing the updates which commit periodically without impacting any outer transactions.
       (t2/with-connection [_conn (mdb/data-source)]

--- a/src/metabase/search/appdb/index.clj
+++ b/src/metabase/search/appdb/index.clj
@@ -275,26 +275,25 @@
 (defn- safe-batch-upsert!
   "A version of batch-upsert! that no-ops for missing indexes, and handles stale index tracking metadata.
 
-  We recover gracefully the first time if the tracking atom was stale, but do not check again on retry.
-  Returns whether an upsert happened."
+  Returns the name of the table that was written to, or nil if there is none being tracked.
+  We recover gracefully the first time if the tracking atom was stale, but do not check again on retry."
   [table-type table-name-fn entries]
-  (boolean
-   ;; For convenience, no-op if we are not tracking any table.
-   (when-let [table-name (table-name-fn)]
-     (let [upsert! (fn [t] (specialization/batch-upsert! t entries) true)]
-       (try
-         (upsert! table-name)
-         (catch Exception e
-           ;; Only suppress failures related to a legitimately non-existent table
-           (if (or (not (table-not-found-exception? e)) (exists? table-name))
-             (throw e)
-             (when-let [refreshed-table-name (do (sync-tracking-atoms!) (table-name-fn))]
-               (if (= table-name refreshed-table-name)
-                 (throw (ex-info "Currently tracked index does not exist" e {:table-name table-name}))
-                 (try
-                   (upsert! refreshed-table-name)
-                   (catch Exception e2
-                     (retry-upsert-ex table-type table-name refreshed-table-name e e2))))))))))))
+  ;; For convenience, no-op if we are not tracking any table.
+  (when-let [table-name (table-name-fn)]
+    (let [upsert! (fn [t] (specialization/batch-upsert! t entries) t)]
+      (try
+        (upsert! table-name)
+        (catch Exception e
+          ;; Only suppress failures related to a legitimately non-existent table
+          (if (or (not (table-not-found-exception? e)) (exists? table-name))
+            (throw e)
+            (when-let [refreshed-table-name (do (sync-tracking-atoms!) (table-name-fn))]
+              (if (= table-name refreshed-table-name)
+                (throw (ex-info "Currently tracked index does not exist" e {:table-name table-name}))
+                (try
+                  (upsert! refreshed-table-name)
+                  (catch Exception e2
+                    (retry-upsert-ex table-type table-name refreshed-table-name e e2)))))))))))
 
 (defn- batch-update!
   "Create the given search index entries in bulk. Commits after each batch"
@@ -315,16 +314,19 @@
                       (let [entries         (map document->entry documents)
                             ;; No need to update the active index if we are doing a full index, as this table will be
                             ;; swapped out soon. Most updates would be no-ops anyway.
-                            active-updated? (when-not (and reindexing? (pending-table))
+                            active-updated  (when-not (and reindexing? (pending-table))
                                               (safe-batch-upsert! :active active-table entries))
-                            pending-update? (safe-batch-upsert! :pending pending-table entries)]
-                        (when (or active-updated? pending-update?)
+                            pending-updated (safe-batch-upsert! :pending pending-table entries)]
+                        (when (or active-updated pending-updated)
                           (u/prog1 (->> entries (map :model) frequencies)
                             (when reindexing?
                               (t2/query ["commit"]))
                             (log/trace "indexed documents for " <>)
-                            (when active-updated?
-                              (analytics/set! :metabase-search/appdb-index-size (t2/count (name active-updated?))))))))]
+                            (when active-updated
+                              (try
+                                (analytics/set! :metabase-search/appdb-index-size (t2/count (name active-updated)))
+                                (catch Exception e
+                                  (log/warnf e "Unable to measure active search index size (%s)" active-updated))))))))]
     (if reindexing?
       ;; New connection used for performing the updates which commit periodically without impacting any outer transactions.
       (t2/with-connection [_conn (mdb/data-source)]

--- a/src/metabase/search/appdb/index.clj
+++ b/src/metabase/search/appdb/index.clj
@@ -119,6 +119,8 @@
                             ;; legacy table names
                             [:in [:lower :table_name]
                              (mapv #(vector :inline %) ["search_index" "search_index_next" "search_index_retired"])]]
+                           ;; Exclude temp tables — they are managed by with-temp-index-table
+                           [:not-like [:lower :table_name] [:inline "%\\_temp"]]
                            [:not-in [:lower :table_name]
                             [:raw
                              (str "("

--- a/src/metabase/search/appdb/index.clj
+++ b/src/metabase/search/appdb/index.clj
@@ -273,16 +273,14 @@
            e-after))
 
 (defn- safe-batch-upsert!
-  "Best-effort upsert into the search index table returned by `table-name-fn`.
+  "A version of batch-upsert! that no-ops for missing indexes, and handles stale index tracking metadata.
 
-  Returns the table name that was written to, or nil if there is no tracked table or if the
-  tracked table disappeared during a concurrent index rotation. Missing-table races are
-  intentionally suppressed because search indexing is best-effort and must not fail the caller's
-  primary write path."
+  Returns the name of the table that was written to, or nil if there is none being tracked.
+  We recover gracefully the first time if the tracking atom was stale, but do not check again on retry."
   [table-type table-name-fn entries]
   ;; For convenience, no-op if we are not tracking any table.
   (when-let [table-name (table-name-fn)]
-    (let [upsert! #(specialization/batch-upsert! % entries)]
+    (let [upsert! (fn [t] (specialization/batch-upsert! t entries) t)]
       (try
         (upsert! table-name)
         (catch Exception e

--- a/test/metabase/search/appdb/index_test.clj
+++ b/test/metabase/search/appdb/index_test.clj
@@ -7,6 +7,7 @@
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.search.appdb.index :as search.index]
+   [metabase.search.appdb.specialization.api :as specialization]
    [metabase.search.core :as search]
    [metabase.search.engine :as search.engine]
    [metabase.search.ingestion :as search.ingestion]
@@ -567,6 +568,9 @@
   (mt/with-dynamic-fn-redefs [search.index/now (constantly (+ simulated-delay-ns (System/nanoTime)))]
     (search.index/active-table)))
 
+(defn- missing-table-cause []
+  (org.h2.jdbc.JdbcSQLSyntaxErrorException. "missing" nil nil 0 nil nil))
+
 (deftest auto-refresh-test
   (when (search/supports-index?)
     (binding [search.spec/*testing-only-index-version-hash* "auto-refresh-test"]
@@ -628,6 +632,85 @@
         (finally
           (t2/delete! :model/SearchIndexMetadata :version "pending-timeout-test")
           (#'search.index/delete-obsolete-tables!))))))
+
+(deftest safe-batch-upsert-refreshes-table-name-on-retry-test
+  (let [current-table (atom :stale_index)
+        upserts       (atom [])]
+    (with-redefs-fn
+      {#'search.index/exists?             (fn [table-name]
+                                            (not= table-name :stale_index))
+       #'search.index/sync-tracking-atoms! (fn []
+                                             (reset! current-table :fresh_index)
+                                             {:active :fresh_index})
+       #'specialization/batch-upsert!     (fn [table-name _entries]
+                                            (swap! upserts conj table-name)
+                                            (when (= table-name :stale_index)
+                                              (throw (Exception. "missing stale index"
+                                                                 (missing-table-cause)))))}
+      (fn []
+        (is (= :fresh_index
+               (#'search.index/safe-batch-upsert! :active (fn [] @current-table) [{}])))))
+    (is (= [:stale_index :fresh_index] @upserts))))
+
+(deftest safe-batch-upsert-skips-retry-when-original-table-still-exists-test
+  (let [sync-called? (atom false)
+        original-ex  (Exception. "still there"
+                                 (missing-table-cause))]
+    (with-redefs-fn
+      {#'search.index/exists?             (constantly true)
+       #'search.index/sync-tracking-atoms! (fn []
+                                             (reset! sync-called? true))
+       #'specialization/batch-upsert!     (fn [_table-name _entries]
+                                            (throw original-ex))}
+      (fn []
+        (is (thrown-with-msg? Exception #"still there"
+                              (#'search.index/safe-batch-upsert! :active (constantly :current_index) [{}])))))
+    (is (false? @sync-called?))))
+
+(deftest safe-batch-upsert-suppresses-missing-table-after-refresh-test
+  (let [current-table (atom :stale_index)
+        upserts       (atom [])]
+    (with-redefs-fn
+      {#'search.index/exists?             (constantly false)
+       #'search.index/sync-tracking-atoms! (fn []
+                                             (reset! current-table nil)
+                                             {})
+       #'specialization/batch-upsert!     (fn [table-name _entries]
+                                            (swap! upserts conj table-name)
+                                            (throw (Exception. "missing index"
+                                                               (missing-table-cause))))}
+      (fn []
+        (is (nil? (#'search.index/safe-batch-upsert! :pending (fn [] @current-table) [{}])))))
+    (is (= [:stale_index] @upserts))))
+
+(deftest safe-batch-upsert-wraps-retry-failure-test
+  (let [current-table (atom :stale_index)
+        initial-ex    (Exception. "missing stale index"
+                                  (missing-table-cause))
+        retry-ex      (ex-info "retry failed" {:phase :retry})]
+    (with-redefs-fn
+      {#'search.index/exists?             (fn [table-name]
+                                            (not= table-name :stale_index))
+       #'search.index/sync-tracking-atoms! (fn []
+                                             (reset! current-table :fresh_index)
+                                             {:active :fresh_index})
+       #'specialization/batch-upsert!     (fn [table-name _entries]
+                                            (if (= table-name :stale_index)
+                                              (throw initial-ex)
+                                              (throw retry-ex)))}
+      (fn []
+        (try
+          (#'search.index/safe-batch-upsert! :active (fn [] @current-table) [{}])
+          (is false "Expected retry failure to be wrapped")
+          (catch clojure.lang.ExceptionInfo e
+            (is (= "Failed retrying search index batch upsert" (ex-message e)))
+            (is (= retry-ex (ex-cause e)))
+            (is (= {:table-id                  :active
+                    :table-name-before-retry  :stale_index
+                    :table-name-after-retry   :fresh_index
+                    :initial-exception-class  (class initial-ex)
+                    :initial-exception-message "missing stale index"}
+                   (ex-data e)))))))))
 
 (deftest when-index-created
   (when (search/supports-index?)

--- a/test/metabase/search/appdb/index_test.clj
+++ b/test/metabase/search/appdb/index_test.clj
@@ -7,7 +7,6 @@
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.search.appdb.index :as search.index]
-   [metabase.search.appdb.specialization.api :as specialization]
    [metabase.search.core :as search]
    [metabase.search.engine :as search.engine]
    [metabase.search.ingestion :as search.ingestion]
@@ -632,85 +631,6 @@
         (finally
           (t2/delete! :model/SearchIndexMetadata :version "pending-timeout-test")
           (#'search.index/delete-obsolete-tables!))))))
-
-(deftest safe-batch-upsert-refreshes-table-name-on-retry-test
-  (let [current-table (atom :stale_index)
-        upserts       (atom [])]
-    (with-redefs-fn
-      {#'search.index/exists?             (fn [table-name]
-                                            (not= table-name :stale_index))
-       #'search.index/sync-tracking-atoms! (fn []
-                                             (reset! current-table :fresh_index)
-                                             {:active :fresh_index})
-       #'specialization/batch-upsert!     (fn [table-name _entries]
-                                            (swap! upserts conj table-name)
-                                            (when (= table-name :stale_index)
-                                              (throw (Exception. "missing stale index"
-                                                                 (missing-table-cause)))))}
-      (fn []
-        (is (= :fresh_index
-               (#'search.index/safe-batch-upsert! :active (fn [] @current-table) [{}])))))
-    (is (= [:stale_index :fresh_index] @upserts))))
-
-(deftest safe-batch-upsert-skips-retry-when-original-table-still-exists-test
-  (let [sync-called? (atom false)
-        original-ex  (Exception. "still there"
-                                 (missing-table-cause))]
-    (with-redefs-fn
-      {#'search.index/exists?             (constantly true)
-       #'search.index/sync-tracking-atoms! (fn []
-                                             (reset! sync-called? true))
-       #'specialization/batch-upsert!     (fn [_table-name _entries]
-                                            (throw original-ex))}
-      (fn []
-        (is (thrown-with-msg? Exception #"still there"
-                              (#'search.index/safe-batch-upsert! :active (constantly :current_index) [{}])))))
-    (is (false? @sync-called?))))
-
-(deftest safe-batch-upsert-suppresses-missing-table-after-refresh-test
-  (let [current-table (atom :stale_index)
-        upserts       (atom [])]
-    (with-redefs-fn
-      {#'search.index/exists?             (constantly false)
-       #'search.index/sync-tracking-atoms! (fn []
-                                             (reset! current-table nil)
-                                             {})
-       #'specialization/batch-upsert!     (fn [table-name _entries]
-                                            (swap! upserts conj table-name)
-                                            (throw (Exception. "missing index"
-                                                               (missing-table-cause))))}
-      (fn []
-        (is (nil? (#'search.index/safe-batch-upsert! :pending (fn [] @current-table) [{}])))))
-    (is (= [:stale_index] @upserts))))
-
-(deftest safe-batch-upsert-wraps-retry-failure-test
-  (let [current-table (atom :stale_index)
-        initial-ex    (Exception. "missing stale index"
-                                  (missing-table-cause))
-        retry-ex      (ex-info "retry failed" {:phase :retry})]
-    (with-redefs-fn
-      {#'search.index/exists?             (fn [table-name]
-                                            (not= table-name :stale_index))
-       #'search.index/sync-tracking-atoms! (fn []
-                                             (reset! current-table :fresh_index)
-                                             {:active :fresh_index})
-       #'specialization/batch-upsert!     (fn [table-name _entries]
-                                            (if (= table-name :stale_index)
-                                              (throw initial-ex)
-                                              (throw retry-ex)))}
-      (fn []
-        (try
-          (#'search.index/safe-batch-upsert! :active (fn [] @current-table) [{}])
-          (is false "Expected retry failure to be wrapped")
-          (catch clojure.lang.ExceptionInfo e
-            (is (= "Failed retrying search index batch upsert" (ex-message e)))
-            (is (= retry-ex (ex-cause e)))
-            (is (= {:table-id                  :active
-                    :table-name-before-retry  :stale_index
-                    :table-name-after-retry   :fresh_index
-                    :initial-exception-class  (class initial-ex)
-                    :initial-exception-message "missing stale index"}
-                   (ex-data e)))))))))
 
 (deftest when-index-created
   (when (search/supports-index?)

--- a/test/metabase/search/appdb/index_test.clj
+++ b/test/metabase/search/appdb/index_test.clj
@@ -567,9 +567,6 @@
   (mt/with-dynamic-fn-redefs [search.index/now (constantly (+ simulated-delay-ns (System/nanoTime)))]
     (search.index/active-table)))
 
-(defn- missing-table-cause []
-  (org.h2.jdbc.JdbcSQLSyntaxErrorException. "missing" nil nil 0 nil nil))
-
 (deftest auto-refresh-test
   (when (search/supports-index?)
     (binding [search.spec/*testing-only-index-version-hash* "auto-refresh-test"]


### PR DESCRIPTION
Closes [BOT-1105: Search API tests fail with missing temp table](https://linear.app/metabase/issue/BOT-1105/search-api-tests-fail-with-missing-temp-table)
