### PR TITLE
[Params] Always return `[]` for param `/values` requests

### DIFF
--- a/src/metabase/parameters/custom_values.clj
+++ b/src/metabase/parameters/custom_values.clj
@@ -124,7 +124,7 @@
    (let [mbql-query   (values-from-card-query card field-ref opts)
          result       (some-> mbql-query qp/process-query)
          values       (get-in result [:data :rows])]
-     {:values         values
+     {:values         (or values [])
       ;; If the row_count returned = the limit we specified, then it's probably has more than that.
       ;; If the query has its own limit smaller than *max-rows*, then there's no more values.
       :has_more_values (= (:row_count result) *max-rows*)})))

--- a/test/metabase/parameters/custom_values_test.clj
+++ b/test/metabase/parameters/custom_values_test.clj
@@ -195,6 +195,21 @@
                 [:expression {:lib/uuid "00000000-0000-0000-0000-000000000000", :base-type :type/Float} "unit price"]
                 {:stage-number 0})))))))
 
+(deftest ^:parallel with-mbql-card-test-7-dangling-value-field
+  (binding [custom-values/*max-rows* 3]
+    (testing ":value_field references MBQL model which no longer returns that column, but has outdated :field_ref that matches it (#71164)"
+      (mt/with-temp
+        [:model/Card card (-> (mt/card-with-source-metadata-for-query
+                               (mt/mbql-query people))
+                              (assoc :type :question)
+                              (assoc-in [:result_metadata 3 :field_ref] [:field 99999 nil]))]
+        (is (= {:values          []
+                :has_more_values false}
+               (custom-values/values-from-card
+                card
+                [:field {:lib/uuid "00000000-0000-0000-0000-000000000000", :base-type :type/Text} 99999]
+                {:stage-number 0})))))))
+
 (deftest ^:parallel with-native-card-test
   (doseq [model? [true false]]
     (testing (format "source card is a %s with native question" (if model? "model" "question"))


### PR DESCRIPTION
Fixes #71164.

### Description

On the BE, always return an empty list rather than nil. Old models with `:id` different from `:field_ref` in their metadata could result in `{:values nil ...}` being returned, which breaks the schema and FE. See #71164 for full details.


### How to verify

See #71164 for comprehensive repro steps.


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
