### PR TITLE
hide sample db from embedding onboarding picker

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
@@ -3,7 +3,35 @@ import { ALL_EXTERNAL_USERS_GROUP_ID } from "e2e/support/cypress_sample_instance
 
 const { H } = cy;
 
-const { STATIC_ORDERS_ID, STATIC_PEOPLE_ID } = SAMPLE_DB_TABLES;
+const { STATIC_ORDERS_ID } = SAMPLE_DB_TABLES;
+const NON_SAMPLE_DB_NAME = "QA Postgres12";
+
+const getDatabaseTable = (databaseId: number, displayName: string) =>
+  cy.request("GET", `/api/database/${databaseId}/metadata`).then(({ body }) => {
+    const table = body?.tables?.find(
+      (table: { display_name?: string; name?: string }) =>
+        table.display_name === displayName ||
+        table.name?.toLowerCase() === displayName.toLowerCase(),
+    );
+
+    expect(table, `table ${displayName} in database ${databaseId}`).to.exist;
+
+    return table;
+  });
+
+const getTableFieldId = (tableId: number, displayName: string) =>
+  cy.request("GET", `/api/table/${tableId}/query_metadata`).then(({ body }) => {
+    const field = body?.fields?.find(
+      (field: { display_name?: string; name?: string; id?: number }) =>
+        field.display_name === displayName ||
+        field.name?.toLowerCase() === displayName.toLowerCase(),
+    );
+
+    expect(field, `field ${displayName} in table ${tableId}`).to.exist;
+    expect(field?.id, `field id for ${displayName}`).to.be.a("number");
+
+    return field.id as number;
+  });
 
 describe("scenarios - embedding hub", () => {
   describe("checklist", () => {
@@ -712,6 +740,7 @@ describe("scenarios - embedding hub", () => {
         H.restore("setup");
         cy.signInAsAdmin();
         H.activateToken("bleeding-edge");
+        H.addPostgresDatabase(NON_SAMPLE_DB_NAME);
 
         cy.visit("/admin/embedding/setup-guide/permissions");
 
@@ -744,7 +773,8 @@ describe("scenarios - embedding hub", () => {
 
         cy.log("pick orders table");
         H.main().findByText("Pick a table").click();
-        H.miniPicker().findByText("Sample Database").click();
+        H.miniPicker().findByText("Sample Database").should("not.exist");
+        H.miniPicker().findByText(NON_SAMPLE_DB_NAME).click();
         H.miniPicker().findByText("Orders").click();
 
         H.main().findByPlaceholderText("Pick a column").click();
@@ -770,6 +800,7 @@ describe("scenarios - embedding hub", () => {
       H.restore("setup");
       cy.signInAsAdmin();
       H.activateToken("bleeding-edge");
+      H.addPostgresDatabase(NON_SAMPLE_DB_NAME);
 
       cy.visit("/admin/embedding/setup-guide/permissions");
 
@@ -802,7 +833,8 @@ describe("scenarios - embedding hub", () => {
 
       cy.log("pick Orders table and User ID column");
       H.main().findByText("Pick a table").click();
-      H.miniPicker().findByText("Sample Database").click();
+      H.miniPicker().findByText("Sample Database").should("not.exist");
+      H.miniPicker().findByText(NON_SAMPLE_DB_NAME).click();
       H.miniPicker().findByText("Orders").click();
 
       H.main().findByPlaceholderText("Pick a column").click();
@@ -848,6 +880,7 @@ describe("scenarios - embedding hub", () => {
       H.restore("setup");
       cy.signInAsAdmin();
       H.activateToken("bleeding-edge");
+      H.addPostgresDatabase(NON_SAMPLE_DB_NAME);
 
       cy.intercept("PUT", "/api/permissions/graph").as(
         "updatePermissionsGraph",
@@ -900,8 +933,10 @@ describe("scenarios - embedding hub", () => {
 
       cy.log("Our analytics should be hidden in the table picker");
       H.miniPicker().findByText("Our analytics").should("not.exist");
+      cy.log("Sample Database should be hidden in the table picker");
+      H.miniPicker().findByText("Sample Database").should("not.exist");
 
-      H.miniPicker().findByText("Sample Database").click();
+      H.miniPicker().findByText(NON_SAMPLE_DB_NAME).click();
       H.miniPicker().findByText("Orders").click();
 
       H.main().findByPlaceholderText("Pick a column").click();
@@ -911,7 +946,7 @@ describe("scenarios - embedding hub", () => {
       H.main().findByText("Add table").click();
       H.main().findAllByText("Pick a table").first().click();
 
-      H.miniPicker().findByText("Sample Database").click();
+      H.miniPicker().findByText(NON_SAMPLE_DB_NAME).click();
 
       cy.log("orders should be hidden as it's already selected");
       H.miniPicker().findByText("Orders").should("not.exist");
@@ -939,55 +974,77 @@ describe("scenarios - embedding hub", () => {
       // 1. The admin permissions UI is complex and would add significant test time
       // 2. This test focuses on the onboarding flow, not the permissions UI
       cy.log("access policies should be created");
-      cy.request("GET", "/api/mt/gtap").should((response) => {
-        const policies = response.body;
-        expect(policies.length).to.be.at.least(2);
+      cy.get<number>("@postgresID").then((postgresId) => {
+        getDatabaseTable(postgresId, "Orders").then((ordersTable) => {
+          getDatabaseTable(postgresId, "People").then((peopleTable) => {
+            cy.request("GET", "/api/mt/gtap").should((response) => {
+              const policies = response.body;
+              expect(policies.length).to.be.at.least(2);
 
-        const orderPolicy = policies.find(
-          (policy: { table_id: number }) =>
-            policy.table_id === STATIC_ORDERS_ID,
-        );
+              const orderPolicy = policies.find(
+                (policy: { table_id: number }) =>
+                  policy.table_id === ordersTable.id,
+              );
 
-        const peoplePolicy = policies.find(
-          (policy: { table_id: number }) =>
-            policy.table_id === STATIC_PEOPLE_ID,
-        );
+              const peoplePolicy = policies.find(
+                (policy: { table_id: number }) =>
+                  policy.table_id === peopleTable.id,
+              );
 
-        expect(orderPolicy).to.exist;
-        expect(peoplePolicy).to.exist;
+              expect(orderPolicy).to.exist;
+              expect(peoplePolicy).to.exist;
 
-        expect(orderPolicy.attribute_remappings).to.have.property(
-          "organization_id",
-        );
+              expect(orderPolicy.attribute_remappings).to.have.property(
+                "organization_id",
+              );
 
-        expect(peoplePolicy.attribute_remappings).to.have.property(
-          "organization_id",
-        );
-      });
+              expect(peoplePolicy.attribute_remappings).to.have.property(
+                "organization_id",
+              );
+            });
 
-      cy.request(
-        "GET",
-        `/api/permissions/graph/group/${ALL_EXTERNAL_USERS_GROUP_ID}`,
-      ).should((response) => {
-        const graph = response.body;
+            cy.request(
+              "GET",
+              `/api/permissions/graph/group/${ALL_EXTERNAL_USERS_GROUP_ID}`,
+            ).should((response) => {
+              const graph = response.body;
 
-        const permissions = graph.groups[ALL_EXTERNAL_USERS_GROUP_ID!][1];
-        expect(permissions).to.exist;
+              const permissions =
+                graph.groups[ALL_EXTERNAL_USERS_GROUP_ID!][postgresId];
+              expect(permissions).to.exist;
+              const viewData = permissions["view-data"];
+              const createQueries = permissions["create-queries"];
+              const schemaPermissions =
+                Object.values(viewData).find(
+                  (value) =>
+                    value != null &&
+                    typeof value === "object" &&
+                    !Array.isArray(value) &&
+                    ordersTable.id in value &&
+                    peopleTable.id in value,
+                ) ?? {};
 
-        // deep.equal ensures only the selected tables have permissions —
-        // non-selected tables should be blocked (omitted from the response)
-        expect(permissions["view-data"]).to.deep.equal({
-          PUBLIC: {
-            [STATIC_ORDERS_ID]: "sandboxed",
-            [STATIC_PEOPLE_ID]: "sandboxed",
-          },
-        });
+              expect(schemaPermissions).to.deep.equal({
+                [ordersTable.id]: "sandboxed",
+                [peopleTable.id]: "sandboxed",
+              });
 
-        expect(permissions["create-queries"]).to.deep.equal({
-          PUBLIC: {
-            [STATIC_ORDERS_ID]: "query-builder",
-            [STATIC_PEOPLE_ID]: "query-builder",
-          },
+              const createQuerySchemaPermissions =
+                Object.values(createQueries).find(
+                  (value) =>
+                    value != null &&
+                    typeof value === "object" &&
+                    !Array.isArray(value) &&
+                    ordersTable.id in value &&
+                    peopleTable.id in value,
+                ) ?? {};
+
+              expect(createQuerySchemaPermissions).to.deep.equal({
+                [ordersTable.id]: "query-builder",
+                [peopleTable.id]: "query-builder",
+              });
+            });
+          });
         });
       });
 
@@ -1004,6 +1061,7 @@ describe("scenarios - embedding hub", () => {
       H.restore("setup");
       cy.signInAsAdmin();
       H.activateToken("bleeding-edge");
+      H.addPostgresDatabase(NON_SAMPLE_DB_NAME);
 
       cy.intercept("PUT", "/api/permissions/graph").as(
         "updatePermissionsGraph",
@@ -1024,19 +1082,28 @@ describe("scenarios - embedding hub", () => {
       });
 
       cy.log("create an existing sandbox for Orders table via API");
-      cy.request("GET", "/api/permissions/group").then((response) => {
-        const allExternalUsersGroup = response.body.find(
-          (g: { magic_group_type: string }) =>
-            g.magic_group_type === "all-external-users",
-        );
+      cy.get<number>("@postgresID").then((postgresId) => {
+        getDatabaseTable(postgresId, "Orders").then((ordersTable) => {
+          getTableFieldId(ordersTable.id, "User ID").then((userIdFieldId) => {
+            cy.request("GET", "/api/permissions/group").then((response) => {
+              const allExternalUsersGroup = response.body.find(
+                (g: { magic_group_type: string }) =>
+                  g.magic_group_type === "all-external-users",
+              );
 
-        cy.request("POST", "/api/mt/gtap", {
-          table_id: STATIC_ORDERS_ID,
-          group_id: allExternalUsersGroup.id,
-          card_id: null,
-          attribute_remappings: {
-            organization_id: ["dimension", ["field", 2, null]], // USER_ID field
-          },
+              cy.request("POST", "/api/mt/gtap", {
+                table_id: ordersTable.id,
+                group_id: allExternalUsersGroup.id,
+                card_id: null,
+                attribute_remappings: {
+                  organization_id: [
+                    "dimension",
+                    ["field", userIdFieldId, null],
+                  ],
+                },
+              });
+            });
+          });
         });
       });
 
@@ -1066,7 +1133,8 @@ describe("scenarios - embedding hub", () => {
 
       cy.log("Select the same Orders table");
       H.main().findByText("Pick a table").click();
-      H.miniPicker().findByText("Sample Database").click();
+      H.miniPicker().findByText("Sample Database").should("not.exist");
+      H.miniPicker().findByText(NON_SAMPLE_DB_NAME).click();
       H.miniPicker().findByText("Orders").click();
 
       cy.log("select Product ID column instead of User ID");
@@ -1081,23 +1149,30 @@ describe("scenarios - embedding hub", () => {
       H.undoToast().should("not.exist");
 
       cy.log("sandbox should be updated and not created");
-      cy.request("GET", "/api/mt/gtap").should((response) => {
-        const policies = response.body;
+      cy.get<number>("@postgresID").then((postgresId) => {
+        getDatabaseTable(postgresId, "Orders").then((ordersTable) => {
+          getTableFieldId(ordersTable.id, "Product ID").then(
+            (productIdFieldId) => {
+              cy.request("GET", "/api/mt/gtap").should((response) => {
+                const policies = response.body;
 
-        const orderPolicies = policies.filter(
-          (policy: { table_id: number }) =>
-            policy.table_id === STATIC_ORDERS_ID,
-        );
+                const orderPolicies = policies.filter(
+                  (policy: { table_id: number }) =>
+                    policy.table_id === ordersTable.id,
+                );
 
-        // should only have one sandbox for Orders table
-        expect(orderPolicies.length).to.equal(1);
+                // should only have one sandbox for Orders table
+                expect(orderPolicies.length).to.equal(1);
 
-        const [orderPolicy] = orderPolicies;
-        const tenantFieldRef = orderPolicy.attribute_remappings.organization_id;
+                const [orderPolicy] = orderPolicies;
+                const tenantFieldRef =
+                  orderPolicy.attribute_remappings.organization_id;
 
-        // attribute_remappings should reference field 3 (PRODUCT_ID),
-        // not field 2 (USER_ID)
-        expect(tenantFieldRef[1][1]).to.equal(3);
+                expect(tenantFieldRef[1][1]).to.equal(productIdFieldId);
+              });
+            },
+          );
+        });
       });
 
       H.main()

--- a/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
@@ -974,75 +974,69 @@ describe("scenarios - embedding hub", () => {
       // 1. The admin permissions UI is complex and would add significant test time
       // 2. This test focuses on the onboarding flow, not the permissions UI
       cy.log("access policies should be created");
-      cy.get<number>("@postgresID").then((postgresId) => {
-        getDatabaseTable(postgresId, "Orders").then((ordersTable) => {
-          getDatabaseTable(postgresId, "People").then((peopleTable) => {
-            cy.request("GET", "/api/mt/gtap").should((response) => {
-              const policies = response.body;
-              expect(policies.length).to.be.at.least(2);
+      cy.request("GET", "/api/mt/gtap").then((response) => {
+        const policies = response.body;
+        expect(policies.length).to.be.at.least(2);
 
-              const orderPolicy = policies.find(
-                (policy: { table_id: number }) =>
-                  policy.table_id === ordersTable.id,
-              );
+        const orderPolicy = policies.find(
+          (p: { attribute_remappings: Record<string, unknown> }) =>
+            p.attribute_remappings?.organization_id,
+        );
+        const peoplePolicy = policies.find(
+          (p: {
+            table_id: number;
+            attribute_remappings: Record<string, unknown>;
+          }) =>
+            p.attribute_remappings?.organization_id &&
+            p.table_id !== orderPolicy.table_id,
+        );
 
-              const peoplePolicy = policies.find(
-                (policy: { table_id: number }) =>
-                  policy.table_id === peopleTable.id,
-              );
+        expect(orderPolicy).to.exist;
+        expect(peoplePolicy).to.exist;
 
-              expect(orderPolicy).to.exist;
-              expect(peoplePolicy).to.exist;
+        const ordersTableId = orderPolicy.table_id as number;
+        const peopleTableId = peoplePolicy.table_id as number;
 
-              expect(orderPolicy.attribute_remappings).to.have.property(
-                "organization_id",
-              );
+        cy.get<number>("@postgresID").then((postgresId) => {
+          cy.request(
+            "GET",
+            `/api/permissions/graph/group/${ALL_EXTERNAL_USERS_GROUP_ID}`,
+          ).should((response) => {
+            const graph = response.body;
 
-              expect(peoplePolicy.attribute_remappings).to.have.property(
-                "organization_id",
-              );
+            const permissions =
+              graph.groups[ALL_EXTERNAL_USERS_GROUP_ID!][postgresId];
+            expect(permissions).to.exist;
+            const viewData = permissions["view-data"];
+            const createQueries = permissions["create-queries"];
+            const schemaPermissions =
+              Object.values(viewData).find(
+                (value) =>
+                  value != null &&
+                  typeof value === "object" &&
+                  !Array.isArray(value) &&
+                  ordersTableId in value &&
+                  peopleTableId in value,
+              ) ?? {};
+
+            expect(schemaPermissions).to.deep.equal({
+              [ordersTableId]: "sandboxed",
+              [peopleTableId]: "sandboxed",
             });
 
-            cy.request(
-              "GET",
-              `/api/permissions/graph/group/${ALL_EXTERNAL_USERS_GROUP_ID}`,
-            ).should((response) => {
-              const graph = response.body;
+            const createQuerySchemaPermissions =
+              Object.values(createQueries).find(
+                (value) =>
+                  value != null &&
+                  typeof value === "object" &&
+                  !Array.isArray(value) &&
+                  ordersTableId in value &&
+                  peopleTableId in value,
+              ) ?? {};
 
-              const permissions =
-                graph.groups[ALL_EXTERNAL_USERS_GROUP_ID!][postgresId];
-              expect(permissions).to.exist;
-              const viewData = permissions["view-data"];
-              const createQueries = permissions["create-queries"];
-              const schemaPermissions =
-                Object.values(viewData).find(
-                  (value) =>
-                    value != null &&
-                    typeof value === "object" &&
-                    !Array.isArray(value) &&
-                    ordersTable.id in value &&
-                    peopleTable.id in value,
-                ) ?? {};
-
-              expect(schemaPermissions).to.deep.equal({
-                [ordersTable.id]: "sandboxed",
-                [peopleTable.id]: "sandboxed",
-              });
-
-              const createQuerySchemaPermissions =
-                Object.values(createQueries).find(
-                  (value) =>
-                    value != null &&
-                    typeof value === "object" &&
-                    !Array.isArray(value) &&
-                    ordersTable.id in value &&
-                    peopleTable.id in value,
-                ) ?? {};
-
-              expect(createQuerySchemaPermissions).to.deep.equal({
-                [ordersTable.id]: "query-builder",
-                [peopleTable.id]: "query-builder",
-              });
+            expect(createQuerySchemaPermissions).to.deep.equal({
+              [ordersTableId]: "query-builder",
+              [peopleTableId]: "query-builder",
             });
           });
         });
@@ -1085,6 +1079,7 @@ describe("scenarios - embedding hub", () => {
       cy.get<number>("@postgresID").then((postgresId) => {
         getDatabaseTable(postgresId, "Orders").then((ordersTable) => {
           getTableFieldId(ordersTable.id, "User ID").then((userIdFieldId) => {
+            cy.wrap(userIdFieldId).as("setupUserIdFieldId");
             cy.request("GET", "/api/permissions/group").then((response) => {
               const allExternalUsersGroup = response.body.find(
                 (g: { magic_group_type: string }) =>
@@ -1149,29 +1144,24 @@ describe("scenarios - embedding hub", () => {
       H.undoToast().should("not.exist");
 
       cy.log("sandbox should be updated and not created");
-      cy.get<number>("@postgresID").then((postgresId) => {
-        getDatabaseTable(postgresId, "Orders").then((ordersTable) => {
-          getTableFieldId(ordersTable.id, "Product ID").then(
-            (productIdFieldId) => {
-              cy.request("GET", "/api/mt/gtap").should((response) => {
-                const policies = response.body;
+      cy.get<number>("@setupUserIdFieldId").then((userIdFieldId) => {
+        cy.request("GET", "/api/mt/gtap").should((response) => {
+          const policies = response.body;
 
-                const orderPolicies = policies.filter(
-                  (policy: { table_id: number }) =>
-                    policy.table_id === ordersTable.id,
-                );
-
-                // should only have one sandbox for Orders table
-                expect(orderPolicies.length).to.equal(1);
-
-                const [orderPolicy] = orderPolicies;
-                const tenantFieldRef =
-                  orderPolicy.attribute_remappings.organization_id;
-
-                expect(tenantFieldRef[1][1]).to.equal(productIdFieldId);
-              });
-            },
+          const orderPolicies = policies.filter(
+            (policy: { attribute_remappings?: Record<string, unknown> }) =>
+              policy.attribute_remappings?.organization_id,
           );
+
+          // should only have one sandbox for Orders table
+          expect(orderPolicies.length).to.equal(1);
+
+          const [orderPolicy] = orderPolicies;
+          const tenantFieldRef =
+            orderPolicy.attribute_remappings.organization_id;
+
+          // field ref should have changed from the original User ID field
+          expect(tenantFieldRef[1][1]).to.not.equal(userIdFieldId);
         });
       });
 

--- a/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
@@ -982,20 +982,15 @@ describe("scenarios - embedding hub", () => {
                   graph.groups[ALL_EXTERNAL_USERS_GROUP_ID!][WRITABLE_DB_ID];
                 expect(permissions).to.exist;
 
-                const schemaName =
-                  permissions["view-data"].public != null ? "public" : "PUBLIC";
-
-                expect(permissions["view-data"][schemaName]).to.deep.equal({
+                expect(permissions["view-data"].public).to.deep.equal({
                   [ordersTableId]: "sandboxed",
                   [peopleTableId]: "sandboxed",
                 });
 
-                expect(permissions["create-queries"][schemaName]).to.deep.equal(
-                  {
-                    [ordersTableId]: "query-builder",
-                    [peopleTableId]: "query-builder",
-                  },
-                );
+                expect(permissions["create-queries"].public).to.deep.equal({
+                  [ordersTableId]: "query-builder",
+                  [peopleTableId]: "query-builder",
+                });
               });
             },
           );

--- a/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
@@ -6,33 +6,6 @@ const { H } = cy;
 const { STATIC_ORDERS_ID } = SAMPLE_DB_TABLES;
 const NON_SAMPLE_DB_NAME = "QA Postgres12";
 
-const getDatabaseTable = (databaseId: number, displayName: string) =>
-  cy.request("GET", `/api/database/${databaseId}/metadata`).then(({ body }) => {
-    const table = body?.tables?.find(
-      (table: { display_name?: string; name?: string }) =>
-        table.display_name === displayName ||
-        table.name?.toLowerCase() === displayName.toLowerCase(),
-    );
-
-    expect(table, `table ${displayName} in database ${databaseId}`).to.exist;
-
-    return table;
-  });
-
-const getTableFieldId = (tableId: number, displayName: string) =>
-  cy.request("GET", `/api/table/${tableId}/query_metadata`).then(({ body }) => {
-    const field = body?.fields?.find(
-      (field: { display_name?: string; name?: string; id?: number }) =>
-        field.display_name === displayName ||
-        field.name?.toLowerCase() === displayName.toLowerCase(),
-    );
-
-    expect(field, `field ${displayName} in table ${tableId}`).to.exist;
-    expect(field?.id, `field id for ${displayName}`).to.be.a("number");
-
-    return field.id as number;
-  });
-
 describe("scenarios - embedding hub", () => {
   describe("checklist", () => {
     beforeEach(() => {
@@ -737,10 +710,9 @@ describe("scenarios - embedding hub", () => {
       });
 
       it("shows autocomplete suggestions for organization_id based on selected field values", () => {
-        H.restore("setup");
+        H.restore("postgres-12");
         cy.signInAsAdmin();
         H.activateToken("bleeding-edge");
-        H.addPostgresDatabase(NON_SAMPLE_DB_NAME);
 
         cy.visit("/admin/embedding/setup-guide/permissions");
 
@@ -773,7 +745,6 @@ describe("scenarios - embedding hub", () => {
 
         cy.log("pick orders table");
         H.main().findByText("Pick a table").click();
-        H.miniPicker().findByText("Sample Database").should("not.exist");
         H.miniPicker().findByText(NON_SAMPLE_DB_NAME).click();
         H.miniPicker().findByText("Orders").click();
 
@@ -797,10 +768,9 @@ describe("scenarios - embedding hub", () => {
     // are only populated when the user goes through the "Select data" step
     // in the UI. Without it, the data permissions description won't show.
     it("shows RLS data permissions description in summary", () => {
-      H.restore("setup");
+      H.restore("postgres-12");
       cy.signInAsAdmin();
       H.activateToken("bleeding-edge");
-      H.addPostgresDatabase(NON_SAMPLE_DB_NAME);
 
       cy.visit("/admin/embedding/setup-guide/permissions");
 
@@ -833,7 +803,6 @@ describe("scenarios - embedding hub", () => {
 
       cy.log("pick Orders table and User ID column");
       H.main().findByText("Pick a table").click();
-      H.miniPicker().findByText("Sample Database").should("not.exist");
       H.miniPicker().findByText(NON_SAMPLE_DB_NAME).click();
       H.miniPicker().findByText("Orders").click();
 
@@ -877,10 +846,9 @@ describe("scenarios - embedding hub", () => {
     });
 
     it("should create sandboxes for multiple tables via row-level security setup", () => {
-      H.restore("setup");
+      H.restore("postgres-12");
       cy.signInAsAdmin();
       H.activateToken("bleeding-edge");
-      H.addPostgresDatabase(NON_SAMPLE_DB_NAME);
 
       cy.intercept("PUT", "/api/permissions/graph").as(
         "updatePermissionsGraph",
@@ -974,73 +942,65 @@ describe("scenarios - embedding hub", () => {
       // 1. The admin permissions UI is complex and would add significant test time
       // 2. This test focuses on the onboarding flow, not the permissions UI
       cy.log("access policies should be created");
-      cy.request("GET", "/api/mt/gtap").then((response) => {
-        const policies = response.body;
-        expect(policies.length).to.be.at.least(2);
+      H.getTableId({ databaseId: WRITABLE_DB_ID, name: "orders" }).then(
+        (ordersTableId) => {
+          H.getTableId({ databaseId: WRITABLE_DB_ID, name: "people" }).then(
+            (peopleTableId) => {
+              cy.request("GET", "/api/mt/gtap").should((response) => {
+                const policies = response.body;
+                expect(policies.length).to.be.at.least(2);
 
-        const orderPolicy = policies.find(
-          (p: { attribute_remappings: Record<string, unknown> }) =>
-            p.attribute_remappings?.organization_id,
-        );
-        const peoplePolicy = policies.find(
-          (p: {
-            table_id: number;
-            attribute_remappings: Record<string, unknown>;
-          }) =>
-            p.attribute_remappings?.organization_id &&
-            p.table_id !== orderPolicy.table_id,
-        );
+                const orderPolicy = policies.find(
+                  (policy: { table_id: number }) =>
+                    policy.table_id === ordersTableId,
+                );
 
-        expect(orderPolicy).to.exist;
-        expect(peoplePolicy).to.exist;
+                const peoplePolicy = policies.find(
+                  (policy: { table_id: number }) =>
+                    policy.table_id === peopleTableId,
+                );
 
-        const ordersTableId = orderPolicy.table_id as number;
-        const peopleTableId = peoplePolicy.table_id as number;
+                expect(orderPolicy).to.exist;
+                expect(peoplePolicy).to.exist;
 
-        cy.get<number>("@postgresID").then((postgresId) => {
-          cy.request(
-            "GET",
-            `/api/permissions/graph/group/${ALL_EXTERNAL_USERS_GROUP_ID}`,
-          ).should((response) => {
-            const graph = response.body;
+                expect(orderPolicy.attribute_remappings).to.have.property(
+                  "organization_id",
+                );
 
-            const permissions =
-              graph.groups[ALL_EXTERNAL_USERS_GROUP_ID!][postgresId];
-            expect(permissions).to.exist;
-            const viewData = permissions["view-data"];
-            const createQueries = permissions["create-queries"];
-            const schemaPermissions =
-              Object.values(viewData).find(
-                (value) =>
-                  value != null &&
-                  typeof value === "object" &&
-                  !Array.isArray(value) &&
-                  ordersTableId in value &&
-                  peopleTableId in value,
-              ) ?? {};
+                expect(peoplePolicy.attribute_remappings).to.have.property(
+                  "organization_id",
+                );
+              });
 
-            expect(schemaPermissions).to.deep.equal({
-              [ordersTableId]: "sandboxed",
-              [peopleTableId]: "sandboxed",
-            });
+              cy.request(
+                "GET",
+                `/api/permissions/graph/group/${ALL_EXTERNAL_USERS_GROUP_ID}`,
+              ).should((response) => {
+                const graph = response.body;
 
-            const createQuerySchemaPermissions =
-              Object.values(createQueries).find(
-                (value) =>
-                  value != null &&
-                  typeof value === "object" &&
-                  !Array.isArray(value) &&
-                  ordersTableId in value &&
-                  peopleTableId in value,
-              ) ?? {};
+                const permissions =
+                  graph.groups[ALL_EXTERNAL_USERS_GROUP_ID!][WRITABLE_DB_ID];
+                expect(permissions).to.exist;
 
-            expect(createQuerySchemaPermissions).to.deep.equal({
-              [ordersTableId]: "query-builder",
-              [peopleTableId]: "query-builder",
-            });
-          });
-        });
-      });
+                const schemaName =
+                  permissions["view-data"].public != null ? "public" : "PUBLIC";
+
+                expect(permissions["view-data"][schemaName]).to.deep.equal({
+                  [ordersTableId]: "sandboxed",
+                  [peopleTableId]: "sandboxed",
+                });
+
+                expect(permissions["create-queries"][schemaName]).to.deep.equal(
+                  {
+                    [ordersTableId]: "query-builder",
+                    [peopleTableId]: "query-builder",
+                  },
+                );
+              });
+            },
+          );
+        },
+      );
 
       H.main()
         .findByRole("listitem", {
@@ -1052,10 +1012,9 @@ describe("scenarios - embedding hub", () => {
     });
 
     it("should update existing sandboxes when changing column selection", () => {
-      H.restore("setup");
+      H.restore("postgres-12");
       cy.signInAsAdmin();
       H.activateToken("bleeding-edge");
-      H.addPostgresDatabase(NON_SAMPLE_DB_NAME);
 
       cy.intercept("PUT", "/api/permissions/graph").as(
         "updatePermissionsGraph",
@@ -1076,31 +1035,42 @@ describe("scenarios - embedding hub", () => {
       });
 
       cy.log("create an existing sandbox for Orders table via API");
-      cy.get<number>("@postgresID").then((postgresId) => {
-        getDatabaseTable(postgresId, "Orders").then((ordersTable) => {
-          getTableFieldId(ordersTable.id, "User ID").then((userIdFieldId) => {
-            cy.wrap(userIdFieldId).as("setupUserIdFieldId");
-            cy.request("GET", "/api/permissions/group").then((response) => {
-              const allExternalUsersGroup = response.body.find(
-                (g: { magic_group_type: string }) =>
-                  g.magic_group_type === "all-external-users",
-              );
+      H.getTableId({ databaseId: WRITABLE_DB_ID, name: "orders" }).then(
+        (ordersTableId) => {
+          cy.wrap(ordersTableId).as("ordersTableId");
 
-              cy.request("POST", "/api/mt/gtap", {
-                table_id: ordersTable.id,
-                group_id: allExternalUsersGroup.id,
-                card_id: null,
-                attribute_remappings: {
-                  organization_id: [
-                    "dimension",
-                    ["field", userIdFieldId, null],
-                  ],
+          H.getFieldId({ tableId: ordersTableId, name: "user_id" }).then(
+            (userIdFieldId) => {
+              H.getFieldId({ tableId: ordersTableId, name: "product_id" }).then(
+                (productIdFieldId) => {
+                  cy.wrap(productIdFieldId).as("productIdFieldId");
+
+                  cy.request("GET", "/api/permissions/group").then(
+                    (response) => {
+                      const allExternalUsersGroup = response.body.find(
+                        (g: { magic_group_type: string }) =>
+                          g.magic_group_type === "all-external-users",
+                      );
+
+                      cy.request("POST", "/api/mt/gtap", {
+                        table_id: ordersTableId,
+                        group_id: allExternalUsersGroup.id,
+                        card_id: null,
+                        attribute_remappings: {
+                          organization_id: [
+                            "dimension",
+                            ["field", userIdFieldId, null],
+                          ],
+                        },
+                      });
+                    },
+                  );
                 },
-              });
-            });
-          });
-        });
-      });
+              );
+            },
+          );
+        },
+      );
 
       cy.visit("/admin/embedding/setup-guide/permissions");
 
@@ -1128,7 +1098,6 @@ describe("scenarios - embedding hub", () => {
 
       cy.log("Select the same Orders table");
       H.main().findByText("Pick a table").click();
-      H.miniPicker().findByText("Sample Database").should("not.exist");
       H.miniPicker().findByText(NON_SAMPLE_DB_NAME).click();
       H.miniPicker().findByText("Orders").click();
 
@@ -1144,24 +1113,25 @@ describe("scenarios - embedding hub", () => {
       H.undoToast().should("not.exist");
 
       cy.log("sandbox should be updated and not created");
-      cy.get<number>("@setupUserIdFieldId").then((userIdFieldId) => {
-        cy.request("GET", "/api/mt/gtap").should((response) => {
-          const policies = response.body;
+      cy.get<number>("@ordersTableId").then((ordersTableId) => {
+        cy.get<number>("@productIdFieldId").then((productIdFieldId) => {
+          cy.request("GET", "/api/mt/gtap").should((response) => {
+            const policies = response.body;
 
-          const orderPolicies = policies.filter(
-            (policy: { attribute_remappings?: Record<string, unknown> }) =>
-              policy.attribute_remappings?.organization_id,
-          );
+            const orderPolicies = policies.filter(
+              (policy: { table_id: number }) =>
+                policy.table_id === ordersTableId,
+            );
 
-          // should only have one sandbox for Orders table
-          expect(orderPolicies.length).to.equal(1);
+            // should only have one sandbox for Orders table
+            expect(orderPolicies.length).to.equal(1);
 
-          const [orderPolicy] = orderPolicies;
-          const tenantFieldRef =
-            orderPolicy.attribute_remappings.organization_id;
+            const [orderPolicy] = orderPolicies;
+            const tenantFieldRef =
+              orderPolicy.attribute_remappings.organization_id;
 
-          // field ref should have changed from the original User ID field
-          expect(tenantFieldRef[1][1]).to.not.equal(userIdFieldId);
+            expect(tenantFieldRef[1][1]).to.equal(productIdFieldId);
+          });
         });
       });
 

--- a/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/RlsDataSelector/TableColumnCard.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/RlsDataSelector/TableColumnCard.tsx
@@ -113,8 +113,12 @@ export const TableColumnCard = ({
         selectedTableIds.includes(pickerItem.id);
       const isOurAnalytics =
         pickerItem.model === "collection" && pickerItem.id === "root";
+      const isSampleDatabase =
+        pickerItem.model === "database" &&
+        "is_sample" in pickerItem &&
+        pickerItem.is_sample === true;
 
-      return isAlreadySelected || isOurAnalytics;
+      return isAlreadySelected || isOurAnalytics || isSampleDatabase;
     },
     [selectedTableIds],
   );


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/EMB-1395/hide-sample-database-in-minipicker-in-embedding-onboarding-step

### Description

This adds the sample db from the picker, the change itself is very small, but since we were using it in the e2e tests, the final diff of the PR is bigger as it needs to change a couple of sandbox tests to use db/tables from the pg db, for which we need to query for the ids