### PR TITLE
Fix clickhouse test flake

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/workspaces/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/api_test.clj
@@ -1577,7 +1577,7 @@
                   result))))
 
       (testing "returns results for multi-row queries"
-        (let [sql    "SELECT 1 as num UNION ALL SELECT 2 UNION ALL SELECT 3 ORDER BY 1"
+        (let [sql    "SELECT * FROM (SELECT 1 as num UNION ALL SELECT 2 UNION ALL SELECT 3) t ORDER BY 1"
               result (mt/user-http-request :crowberto :post 200
                                            (ws-url (:id ws) "/query")
                                            {:sql sql})]


### PR DESCRIPTION
In Clickhouse ORDER BY binds tighter than UNION ALL

See https://app.trunk.io/metabase/flaky-tests/test/b08ee8a6-f04b-5c6c-ae31-665a4b6c290d?repo=metabase%2Fmetabase

See also https://github.com/metabase/metabase/commit/ccd3e61ff0132a24fee0c50e650394969a811c9f