### PR TITLE
Fix Snowflake Netty code scanning alert

### DIFF
--- a/modules/drivers/snowflake/deps.edn
+++ b/modules/drivers/snowflake/deps.edn
@@ -7,7 +7,7 @@
                                                    ;; This will already get excluded automatically by the build tools
                                                    ;; since it's a top-level dep in `/deps.edn` but adding the
                                                    ;; exclusion here will (hopefully?) prevent code scanning alerts
-                                                   ;; from complaining about it as well
+                                                   ;; from complaining about it as well.
                                                    io.netty/netty-codec-http]}
   ;; drop when snowflake update driver to the one without the vulnerabilities
   io.grpc/grpc-netty-shaded         {:mvn/version "1.77.0"}}}

--- a/modules/drivers/snowflake/deps.edn
+++ b/modules/drivers/snowflake/deps.edn
@@ -3,6 +3,11 @@
 
  :deps
  {net.snowflake/snowflake-jdbc-thin {:mvn/version "4.0.1"
-                                     :exclusions  [io.grpc/grpc-netty-shaded]}
+                                     :exclusions  [io.grpc/grpc-netty-shaded
+                                                   ;; This will already get excluded automatically by the build tools
+                                                   ;; since it's a top-level dep in `/deps.edn` but adding the
+                                                   ;; exclusion here will (hopefully?) prevent code scanning alerts
+                                                   ;; from complaining about it as well
+                                                   io.netty/netty-codec-http]}
   ;; drop when snowflake update driver to the one without the vulnerabilities
   io.grpc/grpc-netty-shaded         {:mvn/version "1.77.0"}}}


### PR DESCRIPTION
Fixes QUE2-454

Not a real issue since we pin the Netty dep in `/deps.edn` but adding this exclusion should quiet the code scanner alert