### PR TITLE
Page Visualization

### DIFF
--- a/frontend/src/metabase-types/api/visualization.ts
+++ b/frontend/src/metabase-types/api/visualization.ts
@@ -30,6 +30,7 @@ export const cardDisplayTypes = [
   "progress",
   "funnel",
   "object",
+  "page",
   "map",
   "scatter",
   "boxplot",

--- a/frontend/src/metabase/query_builder/components/chart-type-selector/viz-order.ts
+++ b/frontend/src/metabase/query_builder/components/chart-type-selector/viz-order.ts
@@ -15,6 +15,7 @@ export const DEFAULT_VIZ_ORDER: CardDisplayType[] = [
   "progress",
   "funnel",
   "object",
+  "page",
   "map",
   "scatter",
   "waterfall",

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingTextarea.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingTextarea.tsx
@@ -1,0 +1,48 @@
+import debounce from "lodash.debounce";
+import { useEffect, useMemo, useState } from "react";
+import { useLatest } from "react-use";
+
+import { Textarea } from "metabase/ui";
+
+interface ChartSettingTextareaProps {
+  value: string | undefined;
+  placeholder?: string;
+  onChange: (value: string) => void;
+  id?: string;
+  rows?: number;
+}
+
+export const ChartSettingTextarea = ({
+  value,
+  onChange,
+  placeholder,
+  id,
+  rows = 8,
+}: ChartSettingTextareaProps) => {
+  const [localValue, setLocalValue] = useState(value ?? "");
+
+  useEffect(() => {
+    setLocalValue(value ?? "");
+  }, [value]);
+
+  const onChangeRef = useLatest(onChange);
+  const onChangeDebounced = useMemo(
+    () => debounce((val: string) => onChangeRef.current(val), 400),
+    [onChangeRef],
+  );
+
+  return (
+    <Textarea
+      id={id}
+      data-testid={id}
+      placeholder={placeholder}
+      value={localValue}
+      rows={rows}
+  styles={{ input: { fontFamily: "monospace", fontSize: "0.8rem", resize: "vertical" } }}
+      onChange={e => {
+        setLocalValue(e.target.value);
+        onChangeDebounced(e.target.value);
+      }}
+    />
+  );
+};

--- a/frontend/src/metabase/visualizations/register.js
+++ b/frontend/src/metabase/visualizations/register.js
@@ -18,6 +18,7 @@ import { LineChart } from "./visualizations/LineChart";
 import { LinkViz } from "./visualizations/LinkViz";
 import { Map } from "./visualizations/Map";
 import { ObjectDetail } from "./visualizations/ObjectDetail";
+import { Page } from "./visualizations/Page";
 import { PieChart } from "./visualizations/PieChart";
 import { PivotTable } from "./visualizations/PivotTable";
 import { Progress } from "./visualizations/Progress";
@@ -49,6 +50,7 @@ export default function () {
   registerVisualization(Map);
   registerVisualization(Funnel);
   registerVisualization(ObjectDetail);
+  registerVisualization(Page);
   registerVisualization(PivotTable);
   registerVisualization(SankeyChart);
 

--- a/frontend/src/metabase/visualizations/visualizations/Page/Page.module.css
+++ b/frontend/src/metabase/visualizations/visualizations/Page/Page.module.css
@@ -1,0 +1,54 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+  padding: 1rem;
+}
+
+.markdownWrapper {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.placeholder {
+  font-style: italic;
+}
+
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--mb-color-border);
+  margin-top: 0.75rem;
+  flex-shrink: 0;
+}
+
+.paginationButton {
+  background: none;
+  border: 1px solid var(--mb-color-border);
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 1.25rem;
+  line-height: 1;
+  padding: 0.1rem 0.5rem;
+  color: var(--mb-color-text-medium);
+
+  &:disabled {
+    opacity: 0.35;
+    cursor: default;
+  }
+
+  &:not(:disabled):hover {
+    background-color: var(--mb-color-bg-light);
+  }
+}
+
+.paginationLabel {
+  color: var(--mb-color-text-medium);
+  font-size: 0.875rem;
+  min-width: 4rem;
+  text-align: center;
+}

--- a/frontend/src/metabase/visualizations/visualizations/Page/Page.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Page/Page.tsx
@@ -1,0 +1,86 @@
+import cx from "classnames";
+import { useState } from "react";
+import ReactMarkdown, { type Options } from "react-markdown";
+import rehypeExternalLinks from "rehype-external-links";
+import remarkGfm from "remark-gfm";
+import { t } from "ttag";
+
+import CS from "metabase/css/core/index.css";
+import { isEmpty } from "metabase/lib/validate";
+import type { VisualizationProps } from "metabase/visualizations/types";
+
+import S from "./Page.module.css";
+import { substituteColumnsInTemplate } from "./utils";
+
+const REMARK_PLUGINS = [remarkGfm];
+const REHYPE_PLUGINS: Options["rehypePlugins"] = [
+  [rehypeExternalLinks, { rel: ["noreferrer"], target: "_blank" }],
+];
+
+export function Page({
+  data,
+  settings,
+  className,
+}: Pick<VisualizationProps, "data" | "settings" | "className">) {
+  const template: string = settings["page.template"] ?? "";
+  const { cols, rows } = data;
+
+  const [currentRowIndex, setCurrentRowIndex] = useState(0);
+
+  const safeRowIndex = Math.min(currentRowIndex, rows.length - 1);
+  const currentRow = rows[safeRowIndex] ?? [];
+
+  const hasTemplate = !isEmpty(template);
+
+  const content = hasTemplate
+    ? substituteColumnsInTemplate(template, cols, currentRow, settings)
+    : "";
+
+  const hasPagination = rows.length > 1;
+
+  return (
+    <div className={cx(S.container, className)}>
+      <div className={S.markdownWrapper}>
+        {hasTemplate ? (
+          <ReactMarkdown
+            className={cx(CS.full, "text-card-markdown")}
+            remarkPlugins={REMARK_PLUGINS}
+            rehypePlugins={REHYPE_PLUGINS}
+          >
+            {content}
+          </ReactMarkdown>
+        ) : (
+          <span className={cx(CS.textMedium, S.placeholder)}>
+            {t`Add a template in the visualization settings using {{Column Name}}`}
+          </span>
+        )}
+      </div>
+
+      {hasPagination && (
+        <div className={S.pagination}>
+          <button
+            className={S.paginationButton}
+            disabled={safeRowIndex === 0}
+            onClick={() => setCurrentRowIndex(i => Math.max(0, i - 1))}
+            aria-label={t`Previous row`}
+          >
+            ‹
+          </button>
+          <span className={S.paginationLabel}>
+            {safeRowIndex + 1} / {rows.length}
+          </span>
+          <button
+            className={S.paginationButton}
+            disabled={safeRowIndex >= rows.length - 1}
+            onClick={() =>
+              setCurrentRowIndex(i => Math.min(rows.length - 1, i + 1))
+            }
+            aria-label={t`Next row`}
+          >
+            ›
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/metabase/visualizations/visualizations/Page/Page.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Page/Page.unit.spec.tsx
@@ -1,0 +1,198 @@
+import userEvent from "@testing-library/user-event";
+
+import { renderWithProviders, screen } from "__support__/ui";
+import {
+  createMockColumn,
+  createMockVisualizationSettings,
+} from "metabase-types/api/mocks";
+
+import { Page } from "./Page";
+
+// Minimal data helpers
+const cols = [
+  createMockColumn({ name: "name", display_name: "Name" }),
+  createMockColumn({ name: "total", display_name: "Total" }),
+];
+
+const makeSettings = (template: string) =>
+  createMockVisualizationSettings({
+    "page.template": template,
+    column: () => ({}),
+  });
+
+const makeData = (rows: (string | number | null)[][]) => ({ cols, rows });
+
+interface SetupOpts {
+  template?: string;
+  rows?: (string | number | null)[][];
+}
+
+function setup({ template = "", rows = [["Alice", 42]] }: SetupOpts = {}) {
+  renderWithProviders(
+    <Page
+      data={makeData(rows) as any}
+      settings={makeSettings(template) as any}
+    />,
+  );
+}
+
+describe("Page visualization", () => {
+  describe("empty template", () => {
+    it("shows a placeholder message when no template is set", () => {
+      setup({ template: "" });
+      expect(
+        screen.getByText(
+          /Add a template in the visualization settings using \{\{Column Name\}\}/i,
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it("does not render the markdown wrapper when no template is set", () => {
+      setup({ template: "" });
+      // The markdown prose container is only rendered when a template exists
+      expect(
+        screen.getByText(/Add a template/i),
+      ).toBeInTheDocument(); // placeholder is present instead
+    });
+  });
+
+  describe("template rendering", () => {
+    it("renders plain text from the template", () => {
+      setup({ template: "Hello world" });
+      expect(screen.getByText("Hello world")).toBeInTheDocument();
+    });
+
+    it("renders markdown bold text", () => {
+      setup({ template: "**Bold text**" });
+      expect(screen.getByText("Bold text")).toHaveStyle("font-weight: bold");
+    });
+
+    it("renders a markdown heading", () => {
+      setup({ template: "# My Heading" });
+      const heading = screen.getByRole("heading", { level: 1 });
+      expect(heading).toHaveTextContent("My Heading");
+    });
+
+    it("renders external links with target=_blank and rel=noreferrer", () => {
+      setup({ template: "[Visit](https://example.com)" });
+      const link = screen.getByRole("link", { name: "Visit" });
+      expect(link).toHaveAttribute("href", "https://example.com");
+      expect(link).toHaveAttribute("target", "_blank");
+      expect(link).toHaveAttribute("rel", "noreferrer");
+    });
+  });
+
+  describe("token substitution", () => {
+    it("replaces {{display_name}} tokens with row values", () => {
+      setup({ template: "Name: {{Name}}, Total: {{Total}}" });
+      expect(screen.getByText("Name: Alice, Total: 42")).toBeInTheDocument();
+    });
+
+    it("leaves unresolved tokens intact", () => {
+      setup({ template: "Unknown: {{Missing}}" });
+      expect(screen.getByText(/Unknown: \{\{Missing\}\}/)).toBeInTheDocument();
+    });
+
+    it("substitutes tokens inline in markdown", () => {
+      setup({ template: "**{{Name}}** spent {{Total}}" });
+      expect(screen.getByText("Alice")).toBeInTheDocument();
+      expect(screen.getByText(/spent 42/)).toBeInTheDocument();
+    });
+  });
+
+  describe("pagination", () => {
+    it("does not show pagination controls when there is only one row", () => {
+      setup({ template: "{{Name}}", rows: [["Alice", 42]] });
+      expect(
+        screen.queryByRole("button", { name: /previous row/i }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: /next row/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("shows pagination controls when there are multiple rows", () => {
+      setup({
+        template: "{{Name}}",
+        rows: [
+          ["Alice", 42],
+          ["Bob", 99],
+        ],
+      });
+      expect(
+        screen.getByRole("button", { name: /previous row/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /next row/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("shows the first row initially and displays 1 / N", () => {
+      setup({
+        template: "{{Name}}",
+        rows: [
+          ["Alice", 42],
+          ["Bob", 99],
+        ],
+      });
+      expect(screen.getByText("Alice")).toBeInTheDocument();
+      expect(screen.getByText("1 / 2")).toBeInTheDocument();
+    });
+
+    it("navigates to the next row when the next button is clicked", async () => {
+      setup({
+        template: "{{Name}}",
+        rows: [
+          ["Alice", 42],
+          ["Bob", 99],
+        ],
+      });
+      await userEvent.click(screen.getByRole("button", { name: /next row/i }));
+      expect(screen.getByText("Bob")).toBeInTheDocument();
+      expect(screen.getByText("2 / 2")).toBeInTheDocument();
+    });
+
+    it("navigates back to the previous row", async () => {
+      setup({
+        template: "{{Name}}",
+        rows: [
+          ["Alice", 42],
+          ["Bob", 99],
+        ],
+      });
+      await userEvent.click(screen.getByRole("button", { name: /next row/i }));
+      await userEvent.click(
+        screen.getByRole("button", { name: /previous row/i }),
+      );
+      expect(screen.getByText("Alice")).toBeInTheDocument();
+      expect(screen.getByText("1 / 2")).toBeInTheDocument();
+    });
+
+    it("disables the previous button on the first row", () => {
+      setup({
+        template: "{{Name}}",
+        rows: [
+          ["Alice", 42],
+          ["Bob", 99],
+        ],
+      });
+      expect(
+        screen.getByRole("button", { name: /previous row/i }),
+      ).toBeDisabled();
+    });
+
+    it("disables the next button on the last row", async () => {
+      setup({
+        template: "{{Name}}",
+        rows: [
+          ["Alice", 42],
+          ["Bob", 99],
+        ],
+      });
+      await userEvent.click(screen.getByRole("button", { name: /next row/i }));
+      expect(
+        screen.getByRole("button", { name: /next row/i }),
+      ).toBeDisabled();
+    });
+  });
+});

--- a/frontend/src/metabase/visualizations/visualizations/Page/PageColumnPanel.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Page/PageColumnPanel.tsx
@@ -1,0 +1,137 @@
+import { useCallback, useMemo, useState } from "react";
+import { t } from "ttag";
+
+import { getColumnIcon } from "metabase/common/utils/columns";
+import { useTranslateContent } from "metabase/i18n/hooks";
+import { FieldPanel } from "metabase/querying/fields/components/FieldPanel";
+import { Box, Button } from "metabase/ui";
+import type { EditWidgetData } from "metabase/visualizations/components/settings/ChartSettingTableColumns/types";
+import { canEditQuery } from "metabase/visualizations/components/settings/ChartSettingTableColumns/utils";
+import { ColumnItem } from "metabase/visualizations/components/settings/ColumnItem";
+import * as Lib from "metabase-lib";
+import type Question from "metabase-lib/v1/Question";
+import { getColumnKey } from "metabase-lib/v1/queries/utils/column-key";
+import { findColumnIndexesForColumnSettings } from "metabase-lib/v1/queries/utils/dataset";
+import type {
+  DatasetColumn,
+  TableColumnOrderSetting,
+} from "metabase-types/api";
+
+/**
+ * Props injected by the settings framework via the `getProps` defined in
+ * the "table.columns" setting, plus `onShowWidget` injected by the sidebar.
+ */
+export type PageColumnPanelProps = {
+  value: TableColumnOrderSetting[];
+  columns: DatasetColumn[];
+  question?: Question;
+  isShowingDetailsOnlyColumns: boolean;
+  getColumnName: (column: DatasetColumn) => string;
+  onChange: (value: TableColumnOrderSetting[], question?: Question) => void;
+  onShowWidget: (config: EditWidgetData, targetElement: HTMLElement) => void;
+};
+
+/**
+ * Column list for the Page visualization settings panel.
+ *
+ * Shows the "Add or remove columns" button (when the query is editable) and
+ * renders each column as a `ColumnItem` row with a type icon and a "⋯" popover
+ * for per-column formatting — but without drag handles or show/hide toggles,
+ * since the markdown template controls what appears and in what order.
+ */
+export function PageColumnPanel({
+  value,
+  columns,
+  question,
+  isShowingDetailsOnlyColumns,
+  getColumnName,
+  onChange,
+  onShowWidget,
+}: PageColumnPanelProps) {
+  const tc = useTranslateContent();
+  const query = question?.query();
+  const hasEditButton = canEditQuery(query);
+  const [isEditingQuery, setIsEditingQuery] = useState(false);
+
+  const handleQueryChange = (newQuery: Lib.Query) => {
+    onChange(value, question?.setQuery(newQuery));
+  };
+
+  const columnItems = useMemo(() => {
+    const columnIndexes = findColumnIndexesForColumnSettings(columns, value);
+
+    return value.reduce(
+      (
+        acc: Array<{
+          column: DatasetColumn;
+          icon: ReturnType<typeof getColumnIcon>;
+        }>,
+        _setting,
+        settingIndex,
+      ) => {
+        const colIndex = columnIndexes[settingIndex];
+        const column = columns[colIndex];
+        if (!column) {
+          return acc;
+        }
+        if (
+          !isShowingDetailsOnlyColumns &&
+          column.visibility_type === "details-only"
+        ) {
+          return acc;
+        }
+        acc.push({
+          column: { ...column, display_name: tc(column.display_name) },
+          icon: getColumnIcon(Lib.legacyColumnTypeInfo(column)),
+        });
+        return acc;
+      },
+      [],
+    );
+  }, [value, columns, isShowingDetailsOnlyColumns, tc]);
+
+  const handleEdit = useCallback(
+    (column: DatasetColumn, targetElement: HTMLElement) => {
+      onShowWidget(
+        { id: "column_settings", props: { initialKey: getColumnKey(column) } },
+        targetElement,
+      );
+    },
+    [onShowWidget],
+  );
+
+  return (
+    <div>
+      {hasEditButton && (
+        <Button
+          pl="0"
+          variant="subtle"
+          onClick={() => setIsEditingQuery((e) => !e)}
+        >
+          {isEditingQuery ? t`Done picking columns` : t`Add or remove columns`}
+        </Button>
+      )}
+      {query != null && isEditingQuery ? (
+        <FieldPanel
+          query={query}
+          stageIndex={-1}
+          onChange={handleQueryChange}
+        />
+      ) : (
+        <Box role="list" data-testid="page-column-panel">
+          {columnItems.map(({ column, icon }) => (
+            <ColumnItem
+              key={column.name}
+              title={getColumnName(column)}
+              icon={icon}
+              role="listitem"
+              onEdit={(targetElement: HTMLElement) =>
+                handleEdit(column, targetElement)
+              }
+            />
+          ))}
+        </Box>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/metabase/visualizations/visualizations/Page/index.ts
+++ b/frontend/src/metabase/visualizations/visualizations/Page/index.ts
@@ -1,0 +1,149 @@
+import { t } from "ttag";
+
+import { displayNameForColumn } from "metabase/lib/formatting";
+import { ChartSettingTextarea } from "metabase/visualizations/components/settings/ChartSettingTextarea";
+import { columnSettings } from "metabase/visualizations/lib/settings/column";
+import { getDeduplicatedTableColumnSettings } from "metabase/visualizations/lib/settings/utils";
+import {
+  getDefaultSize,
+  getMinSize,
+} from "metabase/visualizations/shared/utils/sizes";
+import {
+  findColumnIndexesForColumnSettings,
+  findColumnSettingIndexesForColumns,
+} from "metabase-lib/v1/queries/utils/dataset";
+import type { DatasetColumn } from "metabase-types/api";
+
+import type {
+  VisualizationDefinition,
+  VisualizationSettingsDefinitions,
+} from "../../types";
+
+import { Page } from "./Page";
+import { PageColumnPanel } from "./PageColumnPanel";
+
+/**
+ * Static visualization definition that is merged onto the Page component.
+ * Follows the same pattern as ObjectDetail.tsx.
+ */
+const PageProperties: VisualizationDefinition = {
+  getUiName() {
+    return t`Page`;
+  },
+  identifier: "page",
+  iconName: "document",
+  get noun() {
+    return t`page`;
+  },
+  minSize: getMinSize("page"),
+  defaultSize: getDefaultSize("page"),
+  hidden: false,
+  canSavePng: false,
+  disableClickBehavior: true,
+
+  settings: {
+    // Markdown template containing {{Column Display Name}} tokens.
+    "page.template": {
+      get section() {
+        return t`Display`;
+      },
+      get title() {
+        return t`Markdown template`;
+      },
+      widget: ChartSettingTextarea,
+      getDefault: () => "",
+      getProps: () => ({
+        placeholder:
+          "# {{Name}}\n\n**Total:** {{Total}}\n**Created At:** {{Created At}}",
+        rows: 10,
+      }),
+    },
+    // columnSettings provides the per-column formatting popover data.
+    ...columnSettings({ hidden: true }),
+    // "table.columns" drives the column list in the sidebar. We use our own
+    // PageColumnPanel widget instead of ChartSettingTableColumns so that the
+    // list is purely for formatting access — no drag handles, no show/hide.
+    "table.columns": {
+      get section() {
+        return t`Columns`;
+      },
+      widget: PageColumnPanel,
+      getHidden: () => false,
+      getValue: ([{ data }], vizSettings) => {
+        const { cols } = data;
+        const settings = vizSettings["table.columns"] ?? [];
+        const uniqColumnSettings = getDeduplicatedTableColumnSettings(settings);
+
+        const columnIndexes = findColumnIndexesForColumnSettings(
+          cols,
+          uniqColumnSettings,
+        );
+        const settingIndexes = findColumnSettingIndexesForColumns(
+          cols,
+          uniqColumnSettings,
+        );
+
+        return [
+          ...uniqColumnSettings.filter(
+            (_, settingIndex) => columnIndexes[settingIndex] >= 0,
+          ),
+          ...cols
+            .filter((_, columnIndex) => settingIndexes[columnIndex] < 0)
+            .map((column) => ({
+              name: column.name,
+              enabled: true,
+            })),
+        ];
+      },
+      getProps: (series, settings) => {
+        const [
+          {
+            data: { cols },
+          },
+        ] = series;
+        return {
+          columns: cols,
+          isShowingDetailsOnlyColumns: true,
+          getColumnName: (column: DatasetColumn) =>
+            settings.column?.(column)?.column_title ??
+            column.display_name ??
+            column.name,
+        };
+      },
+    },
+  },
+
+  /**
+   * Per-column formatting settings, matching ObjectDetail so that number
+   * formats, date formats, prefixes, suffixes, etc. are all available and
+   * applied when substituting {{Column Name}} tokens.
+   *
+   * Tokens are matched by `display_name` (case-insensitive) — the same label
+   * the user sees in table headers and in the conditional-formatting / link
+   * widgets.
+   */
+  columnSettings: () => {
+    const settings: VisualizationSettingsDefinitions = {
+      column_title: {
+        get title() {
+          return t`Column title`;
+        },
+        widget: "input",
+        getDefault: (column) => displayNameForColumn(column),
+      },
+      click_behavior: {},
+      // Keep these so that formatValue can use them when rendering tokens
+      view_as: { hidden: true },
+      link_text: { hidden: true },
+      link_url: { hidden: true },
+    };
+    return settings;
+  },
+
+  isSensible: () => true,
+  checkRenderable: () => true,
+};
+
+const PageWithProperties = Object.assign(Page, PageProperties);
+
+export { PageWithProperties as Page };

--- a/frontend/src/metabase/visualizations/visualizations/Page/utils.ts
+++ b/frontend/src/metabase/visualizations/visualizations/Page/utils.ts
@@ -1,0 +1,51 @@
+import { formatValue } from "metabase/lib/formatting";
+import type { OptionsType } from "metabase/lib/formatting/types";
+import type { ComputedVisualizationSettings } from "metabase/visualizations/types";
+import type { DatasetColumn, RowValue } from "metabase-types/api";
+
+/**
+ * Replaces {{display_name}} tokens in a markdown template with formatted column
+ * values from the current row.  Tokens are matched against each column's
+ * `display_name` (case-insensitive) first, then against the raw `name` as a
+ * fallback — mirroring how the Table chart's conditional-formatting and link
+ * widgets refer to columns by their display name.
+ */
+export function substituteColumnsInTemplate(
+  template: string,
+  cols: DatasetColumn[],
+  row: RowValue[],
+  settings: ComputedVisualizationSettings,
+): string {
+  return template.replace(/\{\{([^}]+?)\}\}/g, (_match, token: string) => {
+    const trimmed = token.trim();
+
+    // Match by display_name first (case-insensitive), fall back to name
+    const colIndex = (() => {
+      const byDisplay = cols.findIndex(
+        col => col.display_name.toLowerCase() === trimmed.toLowerCase(),
+      );
+      if (byDisplay !== -1) return byDisplay;
+
+      return cols.findIndex(
+        col => col.name.toLowerCase() === trimmed.toLowerCase(),
+      );
+    })();
+
+    if (colIndex === -1) {
+      // Leave unresolved tokens intact so the user can see what's wrong
+      return `{{${trimmed}}}`;
+    }
+
+    const col = cols[colIndex];
+    const value = row[colIndex];
+    const colSettings: OptionsType = settings.column?.(col) ?? {};
+
+    const formatted = formatValue(value, {
+      ...colSettings,
+      column: col,
+      jsx: false,
+    });
+
+    return formatted == null ? "" : String(formatted);
+  });
+}

--- a/frontend/src/metabase/visualizations/visualizations/Page/utils.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/Page/utils.unit.spec.ts
@@ -1,0 +1,164 @@
+import { createMockColumn } from "metabase-types/api/mocks";
+
+import { substituteColumnsInTemplate } from "./utils";
+
+// Minimal settings mock: column() returns an empty object (no special formatting)
+const plainSettings = {
+  column: () => ({}),
+} as any;
+
+describe("substituteColumnsInTemplate", () => {
+  const cols = [
+    createMockColumn({ name: "user_name", display_name: "User Name" }),
+    createMockColumn({ name: "total", display_name: "Total" }),
+    createMockColumn({ name: "created_at", display_name: "Created At" }),
+  ];
+
+  describe("token matching", () => {
+    it("should replace a token that matches a column display_name", () => {
+      const result = substituteColumnsInTemplate(
+        "Hello, {{User Name}}!",
+        cols,
+        ["Alice", 42, "2024-01-01"],
+        plainSettings,
+      );
+      expect(result).toBe("Hello, Alice!");
+    });
+
+    it("should fall back to raw column name when display_name does not match", () => {
+      const result = substituteColumnsInTemplate(
+        "Total: {{total}}",
+        cols,
+        ["Alice", 42, "2024-01-01"],
+        plainSettings,
+      );
+      expect(result).toBe("Total: 42");
+    });
+
+    it("should leave unresolved tokens intact when no column matches", () => {
+      const result = substituteColumnsInTemplate(
+        "Unknown: {{nonexistent}}",
+        cols,
+        ["Alice", 42, "2024-01-01"],
+        plainSettings,
+      );
+      expect(result).toBe("Unknown: {{nonexistent}}");
+    });
+
+    it("should match tokens case-insensitively against display_name", () => {
+      const result = substituteColumnsInTemplate(
+        "{{user name}} and {{TOTAL}}",
+        cols,
+        ["Bob", 99, "2024-06-01"],
+        plainSettings,
+      );
+      expect(result).toBe("Bob and 99");
+    });
+
+    it("should match tokens case-insensitively against raw name", () => {
+      const result = substituteColumnsInTemplate(
+        "{{CREATED_AT}}",
+        cols,
+        ["Alice", 42, "2024-03-15"],
+        plainSettings,
+      );
+      expect(result).toBe("2024-03-15");
+    });
+
+    it("should trim whitespace inside token braces", () => {
+      const result = substituteColumnsInTemplate(
+        "{{ Total }}",
+        cols,
+        ["Alice", 7, "2024-01-01"],
+        plainSettings,
+      );
+      expect(result).toBe("7");
+    });
+  });
+
+  describe("multiple tokens", () => {
+    it("should replace multiple tokens in a single template", () => {
+      const result = substituteColumnsInTemplate(
+        "**{{User Name}}** spent {{Total}} on {{Created At}}",
+        cols,
+        ["Charlie", 150, "2024-07-04"],
+        plainSettings,
+      );
+      expect(result).toBe("**Charlie** spent 150 on 2024-07-04");
+    });
+
+    it("should handle repeated use of the same token", () => {
+      const result = substituteColumnsInTemplate(
+        "{{Total}} total ({{Total}} again)",
+        cols,
+        ["Alice", 5, "2024-01-01"],
+        plainSettings,
+      );
+      expect(result).toBe("5 total (5 again)");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should return the template unchanged when there are no tokens", () => {
+      const template = "No tokens here.";
+      const result = substituteColumnsInTemplate(
+        template,
+        cols,
+        ["Alice", 42, "2024-01-01"],
+        plainSettings,
+      );
+      expect(result).toBe(template);
+    });
+
+    it("should return an empty string for an empty template", () => {
+      const result = substituteColumnsInTemplate(
+        "",
+        cols,
+        ["Alice", 42, "2024-01-01"],
+        plainSettings,
+      );
+      expect(result).toBe("");
+    });
+
+    it("should handle null/undefined row values gracefully", () => {
+      const result = substituteColumnsInTemplate(
+        "Value: {{Total}}",
+        cols,
+        ["Alice", null, "2024-01-01"],
+        plainSettings,
+      );
+      // null formatted → empty string
+      expect(result).toBe("Value: ");
+    });
+
+    it("should work with an empty column list (all tokens unresolved)", () => {
+      const result = substituteColumnsInTemplate(
+        "{{foo}} {{bar}}",
+        [],
+        [],
+        plainSettings,
+      );
+      expect(result).toBe("{{foo}} {{bar}}");
+    });
+  });
+
+  describe("display_name takes priority over raw name", () => {
+    it("should prefer display_name match when both display_name and name could match different columns", () => {
+      // col A: name="total", display_name="Grand Total"
+      // col B: name="grand_total", display_name="Total"
+      // Token "Total" should match col B (display_name match) not col A (name match)
+      const mixedCols = [
+        createMockColumn({ name: "total", display_name: "Grand Total" }),
+        createMockColumn({ name: "grand_total", display_name: "Total" }),
+      ];
+      const result = substituteColumnsInTemplate(
+        "{{Total}}",
+        mixedCols,
+        [100, 200],
+        plainSettings,
+      );
+      // Should use col B's value (index 1 = 200) because display_name="Total" matches first
+      expect(result).toBe("200");
+    });
+  });
+});

--- a/src/metabase/dashboards/constants.cljc
+++ b/src/metabase/dashboards/constants.cljc
@@ -28,6 +28,7 @@
    :smartscalar {:min {:width 2 :height 2} :default {:width 6 :height 3}}
    :map         {:min {:width 4 :height 3} :default {:width 12 :height 6}}
    :object      {:min {:width 4 :height 3} :default {:width 12 :height 9}}
+   :page        {:min {:width 4 :height 3} :default {:width 12 :height 9}}
    :row         {:min {:width 4 :height 3} :default {:width 12 :height 6}}
    :heading     {:min {:width 1 :height 1} :default {:width grid-width :height 1}}
    :text        {:min {:width 1 :height 1} :default {:width 12 :height 3}}})


### PR DESCRIPTION

### Description

Adds a new chart type, Page, that will display the columns of a question in a metabase content, similar to what is used in Dashboard virtual questions but using columns instead of filters

This attempts to implement what is commented on https://discourse.metabase.com/t/how-can-i-visualise-a-single-paragraph-coming-from-database/24591

I have created a new component to list columns without the order and show/hide. I think it is better to modify the current components, but first I want to make sure that would be the desired approach

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Database -> Table -> Visualize
2. Visualization -> More Charts -> Page
3. Visualization Settings -> Write the markdown selecting some fields as usual

### Demo

<img width="563" height="261" alt="image" src="https://github.com/user-attachments/assets/dd8d32dc-327d-464b-bad8-ca5fb31e035e" />

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
