### PR TITLE
Ghy-3258/table tag dependencies missing in incremental transforms

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/dependencies/native_validation.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/native_validation.clj
@@ -278,5 +278,6 @@
           (keep #(case (:type %)
                    :snippet {:snippet (:snippet-id %)}
                    :card    {:card (:card-id %)}
+                   :table   {:table (:table-id %)}
                    nil))
           (lib/all-template-tags query))))

--- a/enterprise/backend/test/metabase_enterprise/dependencies/calculation_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/calculation_test.clj
@@ -224,7 +224,6 @@
                                                             :query query}
                                                    :target {:schema "PUBLIC"
                                                             :name   "test_output"}}]
-          (is (= :fail (:table (calculation/upstream-deps:transform transform))))
           (is (=? {:table #(contains? % products-id)} (calculation/upstream-deps:transform transform))))))))
 
 (deftest ^:parallel upstream-deps-card-native-with-parameter-source-test

--- a/enterprise/backend/test/metabase_enterprise/dependencies/calculation_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/calculation_test.clj
@@ -209,7 +209,7 @@
         (is (= {:table #{products-id orders-id}}
                (calculation/upstream-deps:transform transform)))))))
 
-(deftest ^:synchronized upstream-deps-native-transform-with-table-tag-test
+(deftest ^:parallel upstream-deps-native-transform-with-table-tag-test
   (testing "GHY-3258: native transform with a table template tag should include the table in dependencies"
     (mt/with-premium-features #{:transforms-basic}
       (let [mp          (mt/metadata-provider)

--- a/enterprise/backend/test/metabase_enterprise/dependencies/calculation_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/calculation_test.clj
@@ -209,6 +209,24 @@
         (is (= {:table #{products-id orders-id}}
                (calculation/upstream-deps:transform transform)))))))
 
+(deftest ^:synchronized upstream-deps-native-transform-with-table-tag-test
+  (testing "GHY-3258: native transform with a table template tag should include the table in dependencies"
+    (mt/with-premium-features #{:transforms-basic}
+      (let [mp          (mt/metadata-provider)
+            products-id (mt/id :products)
+            query       (-> (lib/native-query mp "invalid query {{products_table}}")
+                            (lib/with-template-tags {"products_table" {:type         :table
+                                                                       :table-id     products-id
+                                                                       :name         "products_table"
+                                                                       :display-name "Products Table"}}))]
+        (mt/with-temp [:model/Transform transform {:name   "Table Tag Transform"
+                                                   :source {:type  :query
+                                                            :query query}
+                                                   :target {:schema "PUBLIC"
+                                                            :name   "test_output"}}]
+          (is (= :fail (:table (calculation/upstream-deps:transform transform))))
+          (is (=? {:table #(contains? % products-id)} (calculation/upstream-deps:transform transform))))))))
+
 (deftest ^:parallel upstream-deps-card-native-with-parameter-source-test
   (let [mp (mt/metadata-provider)
         products-id (mt/id :products)

--- a/test/metabase/driver/native_parsing_test.clj
+++ b/test/metabase/driver/native_parsing_test.clj
@@ -9,7 +9,7 @@
   (mt/test-drivers (mt/normal-drivers-with-feature :parameters/table-reference)
     (testing "native-query-deps looks in table tags for dependencies"
       (let [mp (mt/metadata-provider)
-            sql (mt/native-query-with-card-template-tag driver/*driver* "table")
+            sql #_(mt/native-query-with-card-template-tag driver/*driver* "table") "invalid query {{table}}"
             base-query (lib/native-query mp sql)
             template-tag (get (lib/template-tags base-query) "table")
             query (lib/with-template-tags base-query

--- a/test/metabase/driver/native_parsing_test.clj
+++ b/test/metabase/driver/native_parsing_test.clj
@@ -9,7 +9,7 @@
   (mt/test-drivers (mt/normal-drivers-with-feature :parameters/table-reference)
     (testing "native-query-deps looks in table tags for dependencies"
       (let [mp (mt/metadata-provider)
-            sql #_(mt/native-query-with-card-template-tag driver/*driver* "table") "invalid query {{table}}"
+            sql (mt/native-query-with-card-template-tag driver/*driver* "table")
             base-query (lib/native-query mp sql)
             template-tag (get (lib/template-tags base-query) "table")
             query (lib/with-template-tags base-query


### PR DESCRIPTION
Fixes [GHY-3258/table-tag-dependencies-missing-in-incremental-transforms](https://linear.app/metabase/issue/GHY-3258/table-tag-dependencies-missing-in-incremental-transforms)