### PR TITLE
UXW-3382 Fix metric names with commas and other symbols

### DIFF
--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/MetricSearchInput.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/MetricSearchInput.tsx
@@ -307,7 +307,11 @@ export function MetricSearchInput({
     // Extract the word at the cursor for the dropdown search
     const view = editorRef.current?.view;
     const cursorPos = view?.state.selection.main.head ?? newText.length;
-    const { word, start: wordStart } = getWordAtCursor(newText, cursorPos);
+    const { word, start: wordStart } = getWordAtCursor(
+      newText,
+      cursorPos,
+      metricEntriesRef.current,
+    );
     // Anchor the dropdown at the word's left edge / line bottom in the viewport
     if (view) {
       const coords = view.coordsAtPos(wordStart);
@@ -323,7 +327,11 @@ export function MetricSearchInput({
     (metric: SelectedMetric) => {
       const cursorPos =
         editorRef.current?.view?.state.selection.main.head ?? editText.length;
-      const { start, end } = getWordAtCursor(editText, cursorPos);
+      const { start, end } = getWordAtCursor(
+        editText,
+        cursorPos,
+        metricEntriesRef.current,
+      );
 
       const metricName = metric.name ?? "";
 
@@ -451,7 +459,11 @@ export function MetricSearchInput({
     // Re-extract word at the new cursor position after a click
     const cursorPos = view.state.selection.main.head;
     const text = view.state.doc.toString();
-    const { word, start: wordStart } = getWordAtCursor(text, cursorPos);
+    const { word, start: wordStart } = getWordAtCursor(
+      text,
+      cursorPos,
+      metricEntriesRef.current,
+    );
     // Update the anchor position so the dropdown is correctly placed
     const coords = view.coordsAtPos(wordStart);
     if (coords) {

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/MetricSearchInput.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/MetricSearchInput.tsx
@@ -271,6 +271,15 @@ export function MetricSearchInput({
 
     // Text was modified — validate on blur but do NOT commit.
     // The expression is only executed when the user explicitly clicks "Run".
+    const invalidRanges = findInvalidRanges(
+      editTextRef.current,
+      metricEntriesRef.current,
+    );
+    if (invalidRanges.length > 0) {
+      setValidationError(invalidRanges[0].message);
+      return;
+    }
+
     const newEntities = parseFullText(
       editTextRef.current,
       metricEntriesRef.current,
@@ -461,6 +470,18 @@ export function MetricSearchInput({
 
   /** Validate the expression and either show an error or commit + run the query. */
   const handleRun = useCallback(() => {
+    // Check for unknown / invalid tokens in the raw text first, before
+    // parseFullText strips them.  This catches trailing junk like "!!!"
+    // that would otherwise be silently dropped.
+    const invalidRanges = findInvalidRanges(
+      editTextRef.current,
+      metricEntriesRef.current,
+    );
+    if (invalidRanges.length > 0) {
+      setValidationError(invalidRanges[0].message);
+      return;
+    }
+
     const newEntities = parseFullText(
       editTextRef.current,
       metricEntriesRef.current,

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.ts
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.ts
@@ -78,6 +78,11 @@ export function buildFullText(
 
 const EXPRESSION_DELIMITERS = new Set(["+", "-", "*", "/", "(", ")", ","]);
 
+/** Returns true for characters that form word continuations (letters, digits, underscore). */
+function isWordChar(ch: string): boolean {
+  return /\w/.test(ch);
+}
+
 /**
  * Extracts the "word" (potential metric name) at the given cursor position,
  * using expression delimiters (+, -, *, /, (, ), ,) as boundaries.
@@ -110,30 +115,99 @@ export function getWordAtCursor(
 }
 
 /**
+ * Returns positions of commas in the text that are NOT inside a metric token.
+ * These are the real item separators. Metric names may contain commas (e.g.
+ * "Revenue, Total") — those commas are consumed by the greedy metric matcher
+ * in `parseFullTextWithPositions` and must not be treated as separators.
+ */
+function findSeparatorCommaPositions(
+  text: string,
+  allTokens: PositionedToken[],
+): number[] {
+  const metricRanges = allTokens.filter((t) => t.type === "metric");
+  const commas: number[] = [];
+  for (let i = 0; i < text.length; i++) {
+    if (text[i] === "," && !metricRanges.some((r) => i >= r.from && i < r.to)) {
+      commas.push(i);
+    }
+  }
+  return commas;
+}
+
+/**
+ * Groups an array of positioned tokens into segments split by separator commas.
+ */
+function groupTokensBySegment(
+  allTokens: PositionedToken[],
+  separatorPositions: number[],
+): PositionedToken[][] {
+  const segments: PositionedToken[][] = [];
+  let current: PositionedToken[] = [];
+  let commaIdx = 0;
+
+  for (const token of allTokens) {
+    while (
+      commaIdx < separatorPositions.length &&
+      token.from > separatorPositions[commaIdx]
+    ) {
+      segments.push(current);
+      current = [];
+      commaIdx++;
+    }
+    current.push(token);
+  }
+  segments.push(current);
+  return segments;
+}
+
+/** Strip position info from a positioned token, dropping unknown tokens. */
+function stripPositions(token: PositionedToken): ExpressionSubToken | null {
+  if (token.type === "metric") {
+    return { type: "metric", sourceId: token.sourceId };
+  }
+  if (token.type === "operator") {
+    return { type: "operator", op: token.op };
+  }
+  if (token.type === "constant") {
+    return { type: "constant", value: token.value };
+  }
+  if (token.type === "open-paren") {
+    return { type: "open-paren" };
+  }
+  if (token.type === "unknown") {
+    return null;
+  }
+  return { type: "close-paren" };
+}
+
+/**
  * Parses a full expression text (with ", " separating items) into a
  * `MetricsViewerFormulaEntity[]`. Each comma-separated segment becomes
  * either a standalone metric entry (if it matches a single metric name) or
  * an expression entry (if it contains operators / multiple operands).
  *
  * Metric names are matched greedily, longest first, so names containing
- * operators (e.g. "Year-to-Date") are handled correctly.
+ * operators (e.g. "Year-to-Date") or commas (e.g. "Revenue, Total") are
+ * handled correctly — metrics are identified before commas are used as
+ * separators.
  */
 export function parseFullText(
   text: string,
   metricEntries: MetricDefinitionEntry[],
 ): MetricsViewerFormulaEntity[] {
-  const rawItems = text.split(",");
+  const allTokens = parseFullTextWithPositions(text, metricEntries);
+  const separators = findSeparatorCommaPositions(text, allTokens);
+  const segments = groupTokensBySegment(allTokens, separators);
   const result: MetricsViewerFormulaEntity[] = [];
 
-  for (const rawItem of rawItems) {
-    const trimmed = rawItem.trim();
-    if (trimmed.length === 0) {
+  for (const segmentTokens of segments) {
+    if (segmentTokens.length === 0) {
       continue;
     }
-    const subTokens = parseItemText(rawItem, metricEntries);
-    if (subTokens.length === 0) {
-      continue;
-    }
+
+    const subTokens = segmentTokens
+      .map(stripPositions)
+      .filter((t): t is ExpressionSubToken => t !== null);
 
     // Single metric reference without operators → standalone metric entry
     const firstToken = subTokens[0];
@@ -146,8 +220,7 @@ export function parseFullText(
     }
 
     // Multiple tokens or operators → expression entry
-    const metricEntriesForName = metricEntries;
-    const name = buildExpressionText(subTokens, metricEntriesForName);
+    const name = buildExpressionText(subTokens, metricEntries);
     result.push({
       id: `expression:${name}`,
       type: "expression",
@@ -157,104 +230,6 @@ export function parseFullText(
   }
 
   return result;
-}
-
-function parseItemText(
-  text: string,
-  metricEntries: MetricDefinitionEntry[],
-): ExpressionSubToken[] {
-  const tokens: ExpressionSubToken[] = [];
-
-  // Sort metrics by name length descending for greedy longest-first matching
-  const sortedMetrics = metricEntries
-    .map((entry) => ({
-      name: (
-        (entry.definition ? getDefinitionName(entry.definition) : null) ?? ""
-      ).toLowerCase(),
-      sourceId: entry.id,
-    }))
-    .filter((m) => m.name.length > 0)
-    .sort((a, b) => b.name.length - a.name.length);
-
-  const lower = text.toLowerCase();
-  let i = 0;
-
-  while (i < text.length) {
-    const ch = text[i];
-
-    // Skip whitespace
-    if (ch === " " || ch === "\t") {
-      i++;
-      continue;
-    }
-
-    // Parens
-    if (ch === "(") {
-      tokens.push({ type: "open-paren" });
-      i++;
-      continue;
-    }
-    if (ch === ")") {
-      tokens.push({ type: "close-paren" });
-      i++;
-      continue;
-    }
-
-    // Math operators
-    if (ch === "+" || ch === "-" || ch === "*" || ch === "/") {
-      tokens.push({ type: "operator", op: ch as MathOperator });
-      i++;
-      continue;
-    }
-
-    // Numeric literal
-    if (ch >= "0" && ch <= "9") {
-      let numStr = "";
-      while (i < text.length && text[i] >= "0" && text[i] <= "9") {
-        numStr += text[i++];
-      }
-      if (
-        i < text.length &&
-        text[i] === "." &&
-        i + 1 < text.length &&
-        text[i + 1] >= "0" &&
-        text[i + 1] <= "9"
-      ) {
-        numStr += text[i++];
-        while (i < text.length && text[i] >= "0" && text[i] <= "9") {
-          numStr += text[i++];
-        }
-      }
-      tokens.push({ type: "constant", value: parseFloat(numStr) });
-      continue;
-    }
-
-    // Try to match a metric name (greedy, longest first)
-    let matched = false;
-    for (const { name, sourceId } of sortedMetrics) {
-      if (lower.startsWith(name, i)) {
-        const nextI = i + name.length;
-        const nextCh = text[nextI];
-        if (
-          !nextCh ||
-          nextCh === " " ||
-          nextCh === "\t" ||
-          EXPRESSION_DELIMITERS.has(nextCh)
-        ) {
-          tokens.push({ type: "metric", sourceId });
-          i = nextI;
-          matched = true;
-          break;
-        }
-      }
-    }
-
-    if (!matched) {
-      i++;
-    }
-  }
-
-  return tokens;
 }
 
 export function getSelectedMetricIds(
@@ -444,7 +419,10 @@ export function validateExpression(
 
 // ── Positioned token type (internal) ────────────────────────────────────────
 
-export type PositionedToken = ExpressionSubToken & { from: number; to: number };
+export type PositionedToken = (
+  | ExpressionSubToken
+  | { type: "unknown"; text: string }
+) & { from: number; to: number };
 
 /** Same as the main parser but records character positions for each token. */
 export function parseFullTextWithPositions(
@@ -535,11 +513,12 @@ export function parseFullTextWithPositions(
       if (lower.startsWith(name, i)) {
         const nextI = i + name.length;
         const nextCh = text[nextI];
+        // Accept the match unless the next character continues an
+        // alphanumeric word (e.g. "Revenue" inside "Revenues").
         if (
           !nextCh ||
-          nextCh === " " ||
-          nextCh === "\t" ||
-          EXPRESSION_DELIMITERS.has(nextCh)
+          !isWordChar(nextCh) ||
+          !isWordChar(name[name.length - 1])
         ) {
           tokens.push({ type: "metric", sourceId, from: i, to: nextI });
           i = nextI;
@@ -550,7 +529,53 @@ export function parseFullTextWithPositions(
     }
 
     if (!matched) {
+      // Collect consecutive unrecognized characters into a single unknown token
+      const start = i;
       i++;
+      while (i < text.length) {
+        const c = text[i];
+        if (
+          c === " " ||
+          c === "\t" ||
+          c === "," ||
+          c === "(" ||
+          c === ")" ||
+          c === "+" ||
+          c === "-" ||
+          c === "*" ||
+          c === "/" ||
+          (c >= "0" && c <= "9")
+        ) {
+          break;
+        }
+        // Check if a metric name starts here — if so, stop the unknown span
+        let metricStartsHere = false;
+        for (const { name } of sortedMetrics) {
+          if (lower.startsWith(name, i)) {
+            const nI = i + name.length;
+            const nC = text[nI];
+            if (
+              !nC ||
+              nC === " " ||
+              nC === "\t" ||
+              EXPRESSION_DELIMITERS.has(nC)
+            ) {
+              metricStartsHere = true;
+              break;
+            }
+          }
+        }
+        if (metricStartsHere) {
+          break;
+        }
+        i++;
+      }
+      tokens.push({
+        type: "unknown",
+        text: text.slice(start, i),
+        from: start,
+        to: i,
+      });
     }
   }
 
@@ -570,33 +595,9 @@ export function findInvalidRanges(
   text: string,
   metricEntries: MetricDefinitionEntry[],
 ): ErrorRange[] {
-  // Split text by commas to get item boundaries, then parse + validate each
   const allTokens = parseFullTextWithPositions(text, metricEntries);
-
-  // Group tokens by their comma-separated segment (by character position)
-  const commaPositions: number[] = [];
-  for (let i = 0; i < text.length; i++) {
-    if (text[i] === ",") {
-      commaPositions.push(i);
-    }
-  }
-
-  // Build segments: tokens between consecutive commas
-  const segments: PositionedToken[][] = [];
-  let segmentTokens: PositionedToken[] = [];
-  let commaIdx = 0;
-  for (const token of allTokens) {
-    while (
-      commaIdx < commaPositions.length &&
-      token.from > commaPositions[commaIdx]
-    ) {
-      segments.push(segmentTokens);
-      segmentTokens = [];
-      commaIdx++;
-    }
-    segmentTokens.push(token);
-  }
-  segments.push(segmentTokens);
+  const separators = findSeparatorCommaPositions(text, allTokens);
+  const segments = groupTokensBySegment(allTokens, separators);
 
   const invalid: ErrorRange[] = [];
 
@@ -674,6 +675,17 @@ export function findInvalidRanges(
         to: prevSignificant.to,
         message: t`Expression cannot end with an operator`,
       });
+    }
+
+    // Unknown tokens
+    for (const token of itemTokens) {
+      if (token.type === "unknown") {
+        itemInvalid.push({
+          from: token.from,
+          to: token.to,
+          message: t`Unknown token: "${token.text}"`,
+        });
+      }
     }
 
     // No operands at all

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.ts
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.ts
@@ -76,7 +76,9 @@ export function buildFullText(
     .join(", ");
 }
 
-const EXPRESSION_DELIMITERS = new Set(["+", "-", "*", "/", "(", ")", ","]);
+const COMMA = ",";
+
+const EXPRESSION_DELIMITERS = new Set(["+", "-", "*", "/", "(", ")", COMMA]);
 
 /** Delimiters that are always boundaries (everything except comma). */
 const NON_COMMA_DELIMITERS = new Set(["+", "-", "*", "/", "(", ")"]);
@@ -156,7 +158,7 @@ export function getWordAtCursor(
         beforeLower.endsWith(name) &&
         (before.length === name.length ||
           NON_COMMA_DELIMITERS.has(before[before.length - name.length - 1]) ||
-          before[before.length - name.length - 1] === "," ||
+          before[before.length - name.length - 1] === COMMA ||
           before[before.length - name.length - 1] === " ")
       ) {
         return true;
@@ -170,7 +172,7 @@ export function getWordAtCursor(
     if (NON_COMMA_DELIMITERS.has(ch)) {
       return true;
     }
-    if (ch === ",") {
+    if (ch === COMMA) {
       return isCommaASeparator(pos);
     }
     return false;
@@ -210,7 +212,10 @@ function findSeparatorCommaPositions(
   const metricRanges = allTokens.filter((t) => t.type === "metric");
   const commas: number[] = [];
   for (let i = 0; i < text.length; i++) {
-    if (text[i] === "," && !metricRanges.some((r) => i >= r.from && i < r.to)) {
+    if (
+      text[i] === COMMA &&
+      !metricRanges.some((r) => i >= r.from && i < r.to)
+    ) {
       commas.push(i);
     }
   }
@@ -536,7 +541,7 @@ export function parseFullTextWithPositions(
 
     // Commas are item separators — tracked for position-based splitting
     // but NOT emitted as a token type (no more "separator" tokens).
-    if (ch === ",") {
+    if (ch === COMMA) {
       i++;
       continue;
     }
@@ -616,18 +621,11 @@ export function parseFullTextWithPositions(
       const start = i;
       i++;
       while (i < text.length) {
-        const c = text[i];
+        const char = text[i];
         if (
-          c === " " ||
-          c === "\t" ||
-          c === "," ||
-          c === "(" ||
-          c === ")" ||
-          c === "+" ||
-          c === "-" ||
-          c === "*" ||
-          c === "/" ||
-          (c >= "0" && c <= "9")
+          EXPRESSION_DELIMITERS.has(char) ||
+          char === " " ||
+          (char >= "0" && char <= "9")
         ) {
           break;
         }
@@ -635,13 +633,12 @@ export function parseFullTextWithPositions(
         let metricStartsHere = false;
         for (const { name } of sortedMetrics) {
           if (lower.startsWith(name, i)) {
-            const nI = i + name.length;
-            const nC = text[nI];
+            const nameEndIndex = i + name.length;
+            const afterNameChar = text[nameEndIndex];
             if (
-              !nC ||
-              nC === " " ||
-              nC === "\t" ||
-              EXPRESSION_DELIMITERS.has(nC)
+              !afterNameChar ||
+              afterNameChar === " " ||
+              EXPRESSION_DELIMITERS.has(afterNameChar)
             ) {
               metricStartsHere = true;
               break;

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.ts
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.ts
@@ -78,6 +78,9 @@ export function buildFullText(
 
 const EXPRESSION_DELIMITERS = new Set(["+", "-", "*", "/", "(", ")", ","]);
 
+/** Delimiters that are always boundaries (everything except comma). */
+const NON_COMMA_DELIMITERS = new Set(["+", "-", "*", "/", "(", ")"]);
+
 /** Returns true for characters that form word continuations (letters, digits, underscore). */
 function isWordChar(ch: string): boolean {
   return /\w/.test(ch);
@@ -85,21 +88,101 @@ function isWordChar(ch: string): boolean {
 
 /**
  * Extracts the "word" (potential metric name) at the given cursor position,
- * using expression delimiters (+, -, *, /, (, ), ,) as boundaries.
+ * using expression delimiters as boundaries.
+ *
  * Spaces are NOT delimiters so that multi-word metric names like "Page Views"
  * are returned as a single word. Surrounding whitespace is trimmed.
+ *
+ * When `metricEntries` is provided, commas are only treated as delimiters
+ * when they are real item separators — i.e. the text before the comma forms
+ * a complete token (known metric, number, or closing paren). This allows
+ * metric names containing commas (e.g. "Revenue, Total") to be typed and
+ * searched as a single word.
  */
 export function getWordAtCursor(
   text: string,
   cursorPos: number,
+  metricEntries?: MetricDefinitionEntry[],
 ): { word: string; start: number; end: number } {
+  // Build a set of metric names (lowercased) for quick lookup.
+  let metricNamesLower: Set<string> | null = null;
+  if (metricEntries && metricEntries.length > 0) {
+    metricNamesLower = new Set(
+      metricEntries
+        .map((e) =>
+          (
+            (e.definition ? getDefinitionName(e.definition) : null) ?? ""
+          ).toLowerCase(),
+        )
+        .filter((n) => n.length > 0),
+    );
+  }
+
+  /**
+   * Decides whether the comma at `pos` is a separator (delimiter) rather
+   * than part of a metric name being typed.
+   *
+   * A comma is a separator when the trimmed text before it ends with:
+   *  - a known metric name,
+   *  - a numeric constant, or
+   *  - a closing parenthesis.
+   *
+   * Otherwise the comma is likely inside a metric name the user is still
+   * typing (e.g. "Revenue," as part of "Revenue, Total").
+   */
+  const isCommaASeparator = (commaPos: number): boolean => {
+    if (!metricNamesLower) {
+      return true; // no entries → fall back to always splitting on commas
+    }
+
+    const before = text.slice(0, commaPos).trimEnd();
+    if (before.length === 0) {
+      return true;
+    }
+
+    const lastCh = before[before.length - 1];
+    // After a closing paren → separator
+    if (lastCh === ")") {
+      return true;
+    }
+    // After a digit → separator (number constant)
+    if (/\d/.test(lastCh)) {
+      return true;
+    }
+    // Check if `before` ends with a known metric name
+    const beforeLower = before.toLowerCase();
+    for (const name of metricNamesLower) {
+      if (
+        beforeLower.endsWith(name) &&
+        (before.length === name.length ||
+          NON_COMMA_DELIMITERS.has(before[before.length - name.length - 1]) ||
+          before[before.length - name.length - 1] === "," ||
+          before[before.length - name.length - 1] === " ")
+      ) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  const isDelimiter = (pos: number): boolean => {
+    const ch = text[pos];
+    if (NON_COMMA_DELIMITERS.has(ch)) {
+      return true;
+    }
+    if (ch === ",") {
+      return isCommaASeparator(pos);
+    }
+    return false;
+  };
+
   let start = cursorPos;
-  while (start > 0 && !EXPRESSION_DELIMITERS.has(text[start - 1])) {
+  while (start > 0 && !isDelimiter(start - 1)) {
     start--;
   }
 
   let end = cursorPos;
-  while (end < text.length && !EXPRESSION_DELIMITERS.has(text[end])) {
+  while (end < text.length && !isDelimiter(end)) {
     end++;
   }
 

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.unit.spec.ts
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.unit.spec.ts
@@ -9,6 +9,7 @@ import {
   buildExpressionText,
   cleanupParens,
   filterSearchResults,
+  findInvalidRanges,
   getSelectedMeasureIds,
   getSelectedMetricIds,
   parseFullText,
@@ -409,10 +410,10 @@ describe("parseFullText — numeric literal parsing", () => {
   });
 
   it("does not parse a trailing dot as part of the number", () => {
-    // "1." — trailing dot with no digit after it; "1" is the constant, "." is skipped
+    // "1." — trailing dot with no digit after it; "1" is the constant, "." is
+    // dropped (unknown tokens are filtered out of committed data)
     const result = parseFullText("1.", metricEntries);
     expect(result).toHaveLength(1);
-    // Single constant → still becomes an expression entry since it's not a metric name
     expect(result[0]).toMatchObject({
       type: "expression",
       tokens: [k(1)],
@@ -445,5 +446,186 @@ describe("parseFullText — numeric literal parsing", () => {
     } else {
       throw new Error("Expected expression entry");
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseFullText — metric names containing commas
+// ---------------------------------------------------------------------------
+
+describe("parseFullText — metric names with commas", () => {
+  const revTotalEntry = makeMetricEntry("metric:10", "Revenue, Total");
+  const costsEntry = makeMetricEntry("metric:2", "Costs");
+  const costsAnnualEntry = makeMetricEntry("metric:11", "Costs, Annual");
+  const revenueEntry = makeMetricEntry("metric:1", "Revenue");
+
+  const m = (sourceId: MetricSourceId): ExpressionSubToken => ({
+    type: "metric",
+    sourceId,
+  });
+  const op = (o: "+" | "-" | "*" | "/"): ExpressionSubToken => ({
+    type: "operator",
+    op: o,
+  });
+  const k = (v: number): ExpressionSubToken => ({
+    type: "constant",
+    value: v,
+  });
+
+  it("parses a single metric whose name contains a comma", () => {
+    const entries = [revTotalEntry, costsEntry];
+    const result = parseFullText("Revenue, Total", entries);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ type: "metric", id: "metric:10" });
+  });
+
+  it("parses metric-with-comma followed by another metric", () => {
+    const entries = [revTotalEntry, costsEntry];
+    const result = parseFullText("Revenue, Total, Costs", entries);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({ type: "metric", id: "metric:10" });
+    expect(result[1]).toMatchObject({ type: "metric", id: "metric:2" });
+  });
+
+  it("parses metric-with-comma in an expression", () => {
+    const entries = [revTotalEntry, costsEntry];
+    const result = parseFullText("Revenue, Total + Costs", entries);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      type: "expression",
+      tokens: [m("metric:10"), op("+"), m("metric:2")],
+    });
+  });
+
+  it("parses two metrics whose names each contain commas", () => {
+    const entries = [revTotalEntry, costsAnnualEntry];
+    const result = parseFullText("Revenue, Total, Costs, Annual", entries);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({ type: "metric", id: "metric:10" });
+    expect(result[1]).toMatchObject({ type: "metric", id: "metric:11" });
+  });
+
+  it("prefers longer metric name over shorter one when both match", () => {
+    // "Revenue, Total" should match as one metric, not "Revenue" + separator
+    const entries = [revTotalEntry, revenueEntry, costsEntry];
+    const result = parseFullText("Revenue, Total, Costs", entries);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({ type: "metric", id: "metric:10" });
+    expect(result[1]).toMatchObject({ type: "metric", id: "metric:2" });
+  });
+
+  it("falls back to shorter metric when longer does not match", () => {
+    // Only "Revenue" is known, not "Revenue, Total"
+    const entries = [revenueEntry, costsEntry];
+    const result = parseFullText("Revenue, Costs", entries);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({ type: "metric", id: "metric:1" });
+    expect(result[1]).toMatchObject({ type: "metric", id: "metric:2" });
+  });
+
+  it("handles metric-with-comma multiplied by a constant", () => {
+    const entries = [revTotalEntry];
+    const result = parseFullText("Revenue, Total * 0.85", entries);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      type: "expression",
+      tokens: [m("metric:10"), op("*"), k(0.85)],
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findInvalidRanges — unknown token detection
+// ---------------------------------------------------------------------------
+
+describe("findInvalidRanges — unknown token detection", () => {
+  const revenueEntry = makeMetricEntry("metric:1", "Revenue");
+  const costsEntry = makeMetricEntry("metric:2", "Costs");
+  const metricEntries = [revenueEntry, costsEntry];
+
+  it("returns no errors for valid expression", () => {
+    expect(findInvalidRanges("Revenue + Costs", metricEntries)).toEqual([]);
+  });
+
+  it("returns no errors for valid expression with constant", () => {
+    expect(findInvalidRanges("Revenue * 0.85", metricEntries)).toEqual([]);
+  });
+
+  it("flags a single unknown word", () => {
+    const errors = findInvalidRanges("Revenue + xyz", metricEntries);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({
+      from: 10,
+      to: 13,
+      message: expect.stringContaining("xyz"),
+    });
+  });
+
+  it("flags unknown text that is not a known metric", () => {
+    const errors = findInvalidRanges("Foo", metricEntries);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({
+      message: expect.stringContaining("Foo"),
+    });
+  });
+
+  it("flags multiple unknown tokens in different segments", () => {
+    const errors = findInvalidRanges("abc, def", metricEntries);
+    expect(errors.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("flags unknown token mixed with valid tokens", () => {
+    const errors = findInvalidRanges(
+      "Revenue + unknown + Costs",
+      metricEntries,
+    );
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({
+      message: expect.stringContaining("unknown"),
+    });
+  });
+
+  it("does not flag numbers as unknown", () => {
+    expect(findInvalidRanges("Revenue * 100", metricEntries)).toEqual([]);
+  });
+
+  it("does not flag parentheses as unknown", () => {
+    expect(findInvalidRanges("(Revenue + Costs)", metricEntries)).toEqual([]);
+  });
+
+  it("does not flag operators as unknown", () => {
+    expect(
+      findInvalidRanges("Revenue + Costs - Revenue", metricEntries),
+    ).toEqual([]);
+  });
+
+  it("flags unknown token at the start of expression", () => {
+    const errors = findInvalidRanges("xyz + Revenue", metricEntries);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({
+      from: 0,
+      to: 3,
+      message: expect.stringContaining("xyz"),
+    });
+  });
+
+  it("returns both structural and unknown errors", () => {
+    // "xyz +" has an unknown token AND a trailing operator
+    const errors = findInvalidRanges("xyz +", metricEntries);
+    expect(errors.length).toBeGreaterThanOrEqual(2);
+    const messages = errors.map((e) => e.message);
+    expect(messages.some((m) => m.includes("xyz"))).toBe(true);
+    expect(messages.some((m) => m.includes("end with an operator"))).toBe(true);
+  });
+
+  it("flags trailing characters after a metric name with special chars", () => {
+    const entry = makeMetricEntry("metric:99", "People Q H2 Orders, Count!");
+    const errors = findInvalidRanges("People Q H2 Orders, Count!!!!", [entry]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({
+      from: 26,
+      to: 29,
+      message: expect.stringContaining("!!!"),
+    });
   });
 });

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.unit.spec.ts
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.unit.spec.ts
@@ -12,6 +12,7 @@ import {
   findInvalidRanges,
   getSelectedMeasureIds,
   getSelectedMetricIds,
+  getWordAtCursor,
   parseFullText,
 } from "./utils";
 
@@ -627,5 +628,56 @@ describe("findInvalidRanges — unknown token detection", () => {
       to: 29,
       message: expect.stringContaining("!!!"),
     });
+  });
+});
+
+describe("getWordAtCursor — comma handling with metric entries", () => {
+  const commaMetric = makeMetricEntry("metric:99", "Revenue, Total");
+
+  it("without entries, comma is always a delimiter", () => {
+    const text = "Revenue, Total";
+    // cursor at end
+    const result = getWordAtCursor(text, text.length);
+    expect(result.word).toBe("Total");
+  });
+
+  it("with entries, comma inside a known metric name is not a delimiter", () => {
+    const text = "Revenue, Total";
+    const result = getWordAtCursor(text, text.length, [commaMetric]);
+    expect(result.word).toBe("Revenue, Total");
+  });
+
+  it("with entries, separator comma between two metrics is still a delimiter", () => {
+    const revenueEntry = makeMetricEntry("metric:1", "Revenue");
+    const ordersEntry = makeMetricEntry("metric:2", "Orders");
+    const text = "Revenue, Orders";
+    // cursor at end (inside "Orders")
+    const result = getWordAtCursor(text, text.length, [
+      revenueEntry,
+      ordersEntry,
+    ]);
+    expect(result.word).toBe("Orders");
+  });
+
+  it("treats comma as part of metric name when typing a partial match", () => {
+    // User is typing "Revenue, T" which is a prefix of "Revenue, Total"
+    // The comma is NOT a separator because "Revenue" alone is not a known
+    // metric in this set — the only known metric is "Revenue, Total".
+    const text = "Revenue, T";
+    const result = getWordAtCursor(text, text.length, [commaMetric]);
+    expect(result.word).toBe("Revenue, T");
+  });
+
+  it("math-operator delimiters still work with metric entries", () => {
+    const text = "Revenue, Total + 1";
+    const result = getWordAtCursor(text, text.length, [commaMetric]);
+    expect(result.word).toBe("1");
+  });
+
+  it("returns full metric name when cursor is in the middle", () => {
+    const text = "Revenue, Total";
+    // cursor after the comma+space (position 9, inside "Total")
+    const result = getWordAtCursor(text, 9, [commaMetric]);
+    expect(result.word).toBe("Revenue, Total");
   });
 });


### PR DESCRIPTION
Closes UXW-3382

### Description

Fixes issues with metrics with special symbols.
Unknown symbols and expressions are treated as incorrect syntax rather being just stripped.

### Demo

https://github.com/user-attachments/assets/54a019ae-d02a-46ec-b162-27e52a053888

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
