### PR TITLE
Fix search filters for published tables

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/data_studio/search_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_studio/search_test.clj
@@ -139,6 +139,30 @@
                     (is (= []
                            our-result))))))))))))
 
+(deftest published-table-visible-with-data-perms-but-no-collection-access-test
+  (mt/with-premium-features #{:library}
+    (testing "Published table is discoverable when user has data permissions but no collection access"
+      (let [search-term (random-name)
+            table-name  (str search-term " published")]
+        (mt/with-no-data-perms-for-all-users!
+          (mt/with-temp [:model/Collection {coll-id :id} {:name "No Access Collection" :location "/"}
+                         :model/Table      {pub-table :id} {:name table-name :is_published true :collection_id coll-id}]
+            ;; Grant data permissions on the table
+            (data-perms/set-database-permission! (perms/all-users-group) (mt/id) :perms/view-data :unrestricted)
+            (data-perms/set-database-permission! (perms/all-users-group) (mt/id) :perms/create-queries :query-builder)
+            (doseq [engine ["in-place" "appdb"]]
+              (search/reindex! {:async? false :in-place? true})
+              ;; Remove collection permissions so the user has data perms but NO collection access
+              (mt/with-non-admin-groups-no-root-collection-perms
+                (let [result-ids (->> (mt/user-http-request :rasta :get 200 "search"
+                                                            :q search-term :models "table" :search_engine engine)
+                                      :data
+                                      (map :id)
+                                      (into #{}))]
+                  (is (contains? result-ids pub-table)
+                      (format "Published table should be visible with data permissions even without collection access (engine=%s)"
+                              engine)))))))))))
+
 (deftest unpublished-table-visible-with-data-perms-test
   (testing "Unpublished tables are discoverable when the user has data/query permissions"
     (let [search-term (random-name)

--- a/src/metabase/search/appdb/core.clj
+++ b/src/metabase/search/appdb/core.clj
@@ -94,14 +94,6 @@
                     [:= :search_index.model [:inline "table"]]
                     clause]]))))
 
-(def null-collection-id-should-be-ignored-for-unpublished-tables-clause
-  "For every model except tables, a null collection ID means the thing is in Our Analytics.
-
-  For tables, this means there is no associated collection and the collection_id should be completely ignored."
-  [:and
-   [:= :model [:inline "table"]]
-   [:= :is_published false]])
-
 (defn add-collection-join-and-where-clauses
   "Add a `WHERE` clause to the query to only return Collections the Current User has access to; join against Collection,
   so we can return its `:name`."
@@ -109,10 +101,11 @@
   (let [collection-id-col :search_index.collection_id
         permitted-clause  (search.permissions/permitted-collections-clause search-ctx collection-id-col)
         personal-clause   (search.filter/personal-collections-where-clause search-ctx collection-id-col)
-        excluded-models   (search.filter/models-without-collection)
+        ;; Tables have their own dedicated permission filter (add-table-where-clauses) that checks both data
+        ;; permissions and published-via-collection access, so we exclude them from collection filtering here.
+        excluded-models   (conj (vec (search.filter/models-without-collection)) "table")
         or-null           #(vector :or
                                    [:in :search_index.model excluded-models]
-                                   null-collection-id-should-be-ignored-for-unpublished-tables-clause
                                    %)]
     (cond-> qry
       true (sql.helpers/left-join [:collection :collection] [:= collection-id-col :collection.id])

--- a/src/metabase/search/in_place/legacy.clj
+++ b/src/metabase/search/in_place/legacy.clj
@@ -178,11 +178,7 @@
       (seq with) (update :with (fnil into []) with)
       true       (sql.helpers/where
                   (case model
-                    "table" [:and
-                             clause
-                             [:or
-                              [:not :is_published]
-                              (search.permissions/permitted-collections-clause search-ctx :collection_id)]]
+                    "table" clause
                     "search-index" [:or
                                     [:= :search_index.model nil]
                                     [:!= :search_index.model [:inline "table"]]
@@ -200,10 +196,12 @@
                                  "collection"    :collection.id
                                  "search-index"  :search_index.collection_id
                                  :collection_id)
-        permitted-clause       [:or
-                                (when (= model "table")
-                                  [:not :is_published])
-                                (search.permissions/permitted-collections-clause search-ctx collection-id-col)]
+        permitted-clause       (if (= model "table")
+                                ;; Tables have their own permission filter (add-table-where-clauses).
+                                ;; Skip collection filtering to avoid blocking tables where the user
+                                ;; has data permissions but no collection access.
+                                 [:= [:inline 1] [:inline 1]]
+                                 (search.permissions/permitted-collections-clause search-ctx collection-id-col))
         personal-clause        (search.filter/personal-collections-where-clause search-ctx collection-id-col)]
     (-> honeysql-query
         (sql.helpers/where permitted-clause)


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #71251
When:

- a table was published,
- a user had data permissions for that table, and
- the user did NOT have permissions on the collection the table was published to

Then the search endpoint would not return that table, even though it's queryable and viewable via data permissions.

This fixes the filtering, so that the table is discoverable via search.
