### PR TITLE
Add keyboard shortcut (g s) to navigate to Data Studio

### DIFF
--- a/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
@@ -575,6 +575,14 @@ describe("shortcuts", { tags: ["@actions"] }, () => {
       event_detail: "navigate-trash",
     });
 
+    cy.realPress("g").realPress("s");
+    cy.location("pathname").should("equal", "/data-studio");
+
+    H.expectUnstructuredSnowplowEvent({
+      event: "keyboard_shortcut_performed",
+      event_detail: "navigate-data-studio",
+    });
+
     cy.log("shortcuts should not be enabled when working in a modal (ADM 658)");
 
     H.navigationSidebar().should("be.visible");
@@ -616,6 +624,17 @@ describe("shortcuts", { tags: ["@actions"] }, () => {
     cy.location("pathname").should("contain", "/admin/datamodel");
     cy.realPress("9");
     cy.location("pathname").should("contain", "/admin/tools");
+  });
+
+  it("should not navigate to data studio via shortcut for non-admin users", () => {
+    cy.signInAsNormalUser();
+    cy.visit("/");
+    cy.findByTestId("home-page")
+      .findByText(/see what metabase can do/i)
+      .should("exist");
+
+    cy.realPress("g").realPress("s");
+    cy.location("pathname").should("equal", "/");
   });
 
   it("should support dashboard shortcuts", () => {

--- a/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
@@ -576,12 +576,14 @@ describe("shortcuts", { tags: ["@actions"] }, () => {
     });
 
     cy.realPress("g").realPress("s");
-    cy.location("pathname").should("equal", "/data-studio");
+    cy.location("pathname").should("match", /^\/data-studio/);
 
     H.expectUnstructuredSnowplowEvent({
       event: "keyboard_shortcut_performed",
       event_detail: "navigate-data-studio",
     });
+
+    cy.realPress("g").realPress("m");
 
     cy.log("shortcuts should not be enabled when working in a modal (ADM 658)");
 

--- a/frontend/src/metabase/palette/hooks/useCommandPaletteBasicActions.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPaletteBasicActions.tsx
@@ -49,6 +49,7 @@ export const BASIC_ACTION_ORDER = [
   "navigate-user-settings",
   "navigate-trash",
   "navigate-home",
+  "navigate-data-studio",
   "navigate-browse-model",
   "navigate-browse-database",
   "navigate-browse-metric",
@@ -258,6 +259,11 @@ export const useCommandPaletteBasicActions = ({
         perform: () => dispatch(push("/")),
       },
     );
+
+    actions.push({
+      id: "navigate-data-studio",
+      perform: () => dispatch(push("/data-studio")),
+    });
 
     const browseActions: RegisterShortcutProps[] = [
       {

--- a/frontend/src/metabase/palette/hooks/useCommandPaletteBasicActions.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPaletteBasicActions.tsx
@@ -10,6 +10,7 @@ import {
   useSearchListQuery,
 } from "metabase/common/hooks";
 import { trackMetricCreateStarted } from "metabase/data-studio/analytics";
+import { canAccessDataStudio } from "metabase/data-studio/selectors";
 import { Collections } from "metabase/entities/collections/collections";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
@@ -74,6 +75,7 @@ export const useCommandPaletteBasicActions = ({
 
   const personalCollectionId = useSelector(getUserPersonalCollectionId);
   const isAdmin = useSelector(getUserIsAdmin);
+  const hasDataStudioAccess = useSelector(canAccessDataStudio);
 
   const hasDataAccess = useSelector(canUserCreateQueries);
   const hasNativeWrite = useSelector(canUserCreateNativeQueries);
@@ -260,10 +262,12 @@ export const useCommandPaletteBasicActions = ({
       },
     );
 
-    actions.push({
-      id: "navigate-data-studio",
-      perform: () => dispatch(push("/data-studio")),
-    });
+    if (hasDataStudioAccess) {
+      actions.push({
+        id: "navigate-data-studio",
+        perform: () => dispatch(push("/data-studio")),
+      });
+    }
 
     const browseActions: RegisterShortcutProps[] = [
       {
@@ -299,6 +303,7 @@ export const useCommandPaletteBasicActions = ({
   }, [
     dispatch,
     hasDataAccess,
+    hasDataStudioAccess,
     hasNativeWrite,
     collectionId,
     openNewModal,

--- a/frontend/src/metabase/palette/shortcuts/global.ts
+++ b/frontend/src/metabase/palette/shortcuts/global.ts
@@ -71,6 +71,13 @@ export const globalShortcuts = {
     shortcut: ["g k"],
     shortcutGroup: "global" as const,
   },
+  "navigate-data-studio": {
+    get name() {
+      return t`Go to Data Studio`;
+    },
+    shortcut: ["g s"],
+    shortcutGroup: "global" as const,
+  },
 
   "download-diagnostics": {
     get name() {


### PR DESCRIPTION
## Summary
- Adds `g s` keyboard shortcut to navigate to Data Studio (`/data-studio`)
- The shortcut appears in the keyboard shortcuts help modal (press `?`)

## How to verify
1. Log in to Metabase
2. From any page, press `g` then `s` — you should be navigated to `/data-studio`
3. Press `?` to open the shortcuts modal — "Go to Data Studio" should appear in the Global tab