### PR TITLE
Fix metabot snowplow test flakes

### DIFF
--- a/test/metabase/metabot/self_test.clj
+++ b/test/metabase/metabot/self_test.clj
@@ -733,24 +733,28 @@
         (mt/with-current-user rasta-id
           (snowplow-test/with-fake-snowplow-collector
             (run! identity (self/call-llm "openrouter/test-model" nil [] test-util/TOOLS snowplow-tracking-opts))
-            (is (=? [{:user-id (str rasta-id)
-                      :data    {"model_id"            "openrouter/test-model"
-                                "total_tokens"         120
-                                "prompt_tokens"        100
-                                "completion_tokens"    20
-                                "estimated_costs_usd"  0.0
-                                "duration_ms"          nat-int?
-                                "source"               "test-source"
-                                "tag"                  "test-tag"
-                                "session_id"           "00000000-0000-0000-0000-000000000002"}}
-                     {:user-id (str rasta-id)
-                      :data    {"event"         "agent_used_tool"
-                                "source"        "test-source"
-                                "result"        "success"
-                                "duration_ms"   nat-int?
-                                "session_id"    "00000000-0000-0000-0000-000000000002"
-                                "event_details" {"tool_name" "get-time"}}}]
-                    (snowplow-test/pop-event-data-and-user-id!)))))))))
+            (let [events       (snowplow-test/pop-event-data-and-user-id!)
+                  token-events (filter #(contains? (:data %) "total_tokens") events)
+                  tool-events  (filter #(= "agent_used_tool" (get-in % [:data "event"])) events)]
+              (is (=? [{:user-id (str rasta-id)
+                        :data    {"model_id"            "openrouter/test-model"
+                                  "total_tokens"         120
+                                  "prompt_tokens"        100
+                                  "completion_tokens"    20
+                                  "estimated_costs_usd"  0.0
+                                  "duration_ms"          nat-int?
+                                  "source"               "test-source"
+                                  "tag"                  "test-tag"
+                                  "session_id"           "00000000-0000-0000-0000-000000000002"}}]
+                      token-events))
+              (is (=? [{:user-id (str rasta-id)
+                        :data    {"event"         "agent_used_tool"
+                                  "source"        "test-source"
+                                  "result"        "success"
+                                  "duration_ms"   nat-int?
+                                  "session_id"    "00000000-0000-0000-0000-000000000002"
+                                  "event_details" {"tool_name" "get-time"}}}]
+                      tool-events)))))))))
 
 (deftest call-llm-structured-snowplow-test
   (testing "fires :snowplow/token_usage event for call-llm-structured"
@@ -770,14 +774,16 @@
                                       0.3
                                       1024
                                       snowplow-tracking-opts)
-            (is (=? [{:user-id (str rasta-id)
-                      :data    {"model_id"            "openrouter/test-model"
-                                "total_tokens"         60
-                                "prompt_tokens"        50
-                                "completion_tokens"    10
-                                "estimated_costs_usd"  0.0
-                                "duration_ms"          nat-int?
-                                "source"               "test-source"
-                                "tag"                  "test-tag"
-                                "session_id"           "00000000-0000-0000-0000-000000000002"}}]
-                    (snowplow-test/pop-event-data-and-user-id!)))))))))
+            (let [events       (snowplow-test/pop-event-data-and-user-id!)
+                  token-events (filter #(contains? (:data %) "total_tokens") events)]
+              (is (=? [{:user-id (str rasta-id)
+                        :data    {"model_id"            "openrouter/test-model"
+                                  "total_tokens"         60
+                                  "prompt_tokens"        50
+                                  "completion_tokens"    10
+                                  "estimated_costs_usd"  0.0
+                                  "duration_ms"          nat-int?
+                                  "source"               "test-source"
+                                  "tag"                  "test-tag"
+                                  "session_id"           "00000000-0000-0000-0000-000000000002"}}]
+                      token-events)))))))))


### PR DESCRIPTION
### Description

In `call-llm-snowplow-test` and `call-llm-structured-snowplow-test` filter the snowplow events to remove potential
`new_instance_created` events.

Should fix failures like https://github.com/metabase/metabase/actions/runs/23466422627/job/68280303958?pr=71125

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
