### PR TITLE
Fix flaky schema-change integration test (follow-up to #70863)

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/transforms_python/transforms_api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms_python/transforms_api_test.clj
@@ -559,8 +559,12 @@
                 (transforms.tu/wait-for-transform-completion transform-id 10000)
 
                 ;; Sync runs asynchronously after succeed-started-run!, so wait for
-                ;; the new "friend" field to appear in metadata before querying.
+                ;; the new "friend" field to appear AND the old "age" field to be
+                ;; deactivated before querying. Sync activates new fields and retires
+                ;; old fields in separate non-transactional steps, so there's a window
+                ;; where both are active simultaneously.
                 (transforms.tu/wait-for-field table-name "friend" 10000)
+                (transforms.tu/wait-for-field-deactivation table-name "age" 10000)
                 (let [updated-rows (transforms.tu/table-rows table-name)]
                   (is (= [["Alice" "Bob"] ["Bob" "Alice"]] updated-rows)
                       "Updated data should show Alice/Bob with friends instead of ages"))))))))))

--- a/enterprise/backend/test/metabase_enterprise/transforms_python/transforms_api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms_python/transforms_api_test.clj
@@ -558,13 +558,10 @@
                 (transforms.tu/test-run transform-id)
                 (transforms.tu/wait-for-transform-completion transform-id 10000)
 
-                ;; Sync runs asynchronously after succeed-started-run!, so wait for
-                ;; the new "friend" field to appear AND the old "age" field to be
-                ;; deactivated before querying. Sync activates new fields and retires
-                ;; old fields in separate non-transactional steps, so there's a window
-                ;; where both are active simultaneously.
-                (transforms.tu/wait-for-field table-name "friend" 10000)
-                (transforms.tu/wait-for-field-deactivation table-name "age" 10000)
+                ;; Sync runs after succeed-started-run! and activates new fields
+                ;; before retiring old ones (non-transactional). Waiting for "age"
+                ;; to be deactivated guarantees "friend" is already active too.
+                (transforms.tu/wait-for-field table-name "age" 10000 {:active false})
                 (let [updated-rows (transforms.tu/table-rows table-name)]
                   (is (= [["Alice" "Bob"] ["Bob" "Alice"]] updated-rows)
                       "Updated data should show Alice/Bob with friends instead of ages"))))))))))

--- a/enterprise/backend/test/metabase_enterprise/transforms_python/transforms_api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms_python/transforms_api_test.clj
@@ -561,7 +561,7 @@
                 ;; Sync runs after succeed-started-run! and activates new fields
                 ;; before retiring old ones (non-transactional). Waiting for "age"
                 ;; to be deactivated guarantees "friend" is already active too.
-                (transforms.tu/wait-for-field table-name "age" 10000 {:active false})
+                (transforms.tu/wait-for-field-inactive table-name "age" 10000)
                 (let [updated-rows (transforms.tu/table-rows table-name)]
                   (is (= [["Alice" "Bob"] ["Bob" "Alice"]] updated-rows)
                       "Updated data should show Alice/Bob with friends instead of ages"))))))))))

--- a/test/metabase/transforms/test_util.clj
+++ b/test/metabase/transforms/test_util.clj
@@ -161,38 +161,29 @@
                           {:resp resp :status status})))))))
 
 (defn wait-for-field
-  "Wait for a field with `field-name` to appear as active on the table named `table-name`.
-   Useful after schema changes where sync runs asynchronously."
-  [table-name field-name timeout-ms]
-  (let [timer (u/start-timer)]
-    (loop []
-      (let [table  (t2/select-one :model/Table :name table-name :db_id (mt/id))
-            field  (when table
-                     (t2/select-one :model/Field :table_id (:id table) :name field-name :active true))]
-        (cond
-          field    field
-          (> (u/since-ms timer) timeout-ms)
-          (throw (ex-info (format "Field %s on table %s did not appear after %dms" field-name table-name timeout-ms)
-                          {:table-name table-name :field-name field-name :timeout-ms timeout-ms}))
-          :else    (do (Thread/sleep 200)
-                       (recur)))))))
+  "Wait for a field with `field-name` on `table-name` to reach the desired `:active` state (default true).
+   Polls every 200ms until the condition is met or `timeout-ms` is exceeded."
+  ([table-name field-name timeout-ms]
+   (wait-for-field table-name field-name timeout-ms {:active true}))
+  ([table-name field-name timeout-ms {:keys [active]}]
+   (let [timer (u/start-timer)]
+     (loop []
+       (let [table       (t2/select-one :model/Table :name table-name :db_id (mt/id))
+             field-found (when table
+                           (t2/select-one :model/Field :table_id (:id table) :name field-name :active true))
+             satisfied?  (if active (some? field-found) (nil? field-found))]
+         (cond
+           satisfied?
+           field-found
 
-(defn wait-for-field-deactivation
-  "Wait for a field with `field-name` to no longer be active on the table named `table-name`.
-   Useful after schema changes where a column was dropped but sync hasn't caught up yet."
-  [table-name field-name timeout-ms]
-  (let [timer (u/start-timer)]
-    (loop []
-      (let [table  (t2/select-one :model/Table :name table-name :db_id (mt/id))
-            field  (when table
-                     (t2/select-one :model/Field :table_id (:id table) :name field-name :active true))]
-        (cond
-          (nil? field) nil
-          (> (u/since-ms timer) timeout-ms)
-          (throw (ex-info (format "Field %s on table %s still active after %dms" field-name table-name timeout-ms)
-                          {:table-name table-name :field-name field-name :timeout-ms timeout-ms}))
-          :else        (do (Thread/sleep 200)
-                           (recur)))))))
+           (> (u/since-ms timer) timeout-ms)
+           (throw (ex-info (format "Field %s on table %s did not become %s after %dms"
+                                   field-name table-name (if active "active" "inactive") timeout-ms)
+                           {:table-name table-name :field-name field-name :timeout-ms timeout-ms}))
+
+           :else
+           (do (Thread/sleep 200)
+               (recur))))))))
 
 (defn get-test-schema
   "Get the schema from the products table in the test dataset.

--- a/test/metabase/transforms/test_util.clj
+++ b/test/metabase/transforms/test_util.clj
@@ -177,6 +177,23 @@
           :else    (do (Thread/sleep 200)
                        (recur)))))))
 
+(defn wait-for-field-deactivation
+  "Wait for a field with `field-name` to no longer be active on the table named `table-name`.
+   Useful after schema changes where a column was dropped but sync hasn't caught up yet."
+  [table-name field-name timeout-ms]
+  (let [timer (u/start-timer)]
+    (loop []
+      (let [table  (t2/select-one :model/Table :name table-name :db_id (mt/id))
+            field  (when table
+                     (t2/select-one :model/Field :table_id (:id table) :name field-name :active true))]
+        (cond
+          (nil? field) nil
+          (> (u/since-ms timer) timeout-ms)
+          (throw (ex-info (format "Field %s on table %s still active after %dms" field-name table-name timeout-ms)
+                          {:table-name table-name :field-name field-name :timeout-ms timeout-ms}))
+          :else        (do (Thread/sleep 200)
+                           (recur)))))))
+
 (defn get-test-schema
   "Get the schema from the products table in the test dataset.
    This is needed for databases like BigQuery that require a schema/dataset."

--- a/test/metabase/transforms/test_util.clj
+++ b/test/metabase/transforms/test_util.clj
@@ -160,30 +160,35 @@
           (throw (ex-info (format "Transform run failed with status %s" status)
                           {:resp resp :status status})))))))
 
+(defn- poll-field
+  "Poll until `pred` is satisfied for the active-field lookup of `field-name` on `table-name`.
+   Returns the first truthy result of `pred`, or throws after `timeout-ms`."
+  [table-name field-name timeout-ms pred timeout-msg]
+  (let [timer (u/start-timer)]
+    (loop []
+      (let [table (t2/select-one :model/Table :name table-name :db_id (mt/id))
+            field (when table
+                    (t2/select-one :model/Field :table_id (:id table) :name field-name :active true))]
+        (or (pred field)
+            (if (> (u/since-ms timer) timeout-ms)
+              (throw (ex-info (format timeout-msg field-name table-name timeout-ms)
+                              {:table-name table-name :field-name field-name :timeout-ms timeout-ms}))
+              (do (Thread/sleep 200)
+                  (recur))))))))
+
 (defn wait-for-field
-  "Wait for a field with `field-name` on `table-name` to reach the desired `:active` state (default true).
-   Polls every 200ms until the condition is met or `timeout-ms` is exceeded."
-  ([table-name field-name timeout-ms]
-   (wait-for-field table-name field-name timeout-ms {:active true}))
-  ([table-name field-name timeout-ms {:keys [active]}]
-   (let [timer (u/start-timer)]
-     (loop []
-       (let [table       (t2/select-one :model/Table :name table-name :db_id (mt/id))
-             field-found (when table
-                           (t2/select-one :model/Field :table_id (:id table) :name field-name :active true))
-             satisfied?  (if active (some? field-found) (nil? field-found))]
-         (cond
-           satisfied?
-           field-found
+  "Wait for a field with `field-name` to appear as active on `table-name`."
+  [table-name field-name timeout-ms]
+  (poll-field table-name field-name timeout-ms
+              some?
+              "Field %s on table %s did not appear after %dms"))
 
-           (> (u/since-ms timer) timeout-ms)
-           (throw (ex-info (format "Field %s on table %s did not become %s after %dms"
-                                   field-name table-name (if active "active" "inactive") timeout-ms)
-                           {:table-name table-name :field-name field-name :timeout-ms timeout-ms}))
-
-           :else
-           (do (Thread/sleep 200)
-               (recur))))))))
+(defn wait-for-field-inactive
+  "Wait for a field with `field-name` to no longer be active on `table-name`."
+  [table-name field-name timeout-ms]
+  (poll-field table-name field-name timeout-ms
+              nil?
+              "Field %s on table %s still active after %dms"))
 
 (defn get-test-schema
   "Get the schema from the products table in the test dataset.


### PR DESCRIPTION


Follow-up to #70863 to fix `python-transform-schema-change-integration-test` on redshift that is still flaking with:
```
ERROR: column schema_change_test_....age does not exist
```

The previous fix waited for the new "friend" field to appear as active before querying. But sync activates new fields (`sync-active-instances!`) and retires old fields (`retire-fields!`) in separate non-transactional steps. So there's a window where "friend" is active but "age" is also still active — the QP generates SQL selecting the dropped column and Redshift errors.

Fix: wait for the old "age" field to be deactivated instead. Since retirement runs after activation, this guarantees "friend" is already active too.

Close https://linear.app/metabase/issue/GDGT-1616/flaky-test-be-tests-redshift-ee-metabase-enterprisetransforms