### PR TITLE
Include conversation history in slackbot feedback

### DIFF
--- a/src/metabase/slackbot/api.clj
+++ b/src/metabase/slackbot/api.clj
@@ -501,6 +501,15 @@
          :label    {:type "plain_text" :text "What kind of issue are you reporting?"}}
         freeform-block]))})
 
+(defn- get-conversation-messages
+  "Retrieve all messages for a conversation from the database."
+  [conversation-id]
+  (when conversation-id
+    (t2/select :model/MetabotMessage
+               :conversation_id conversation-id
+               :deleted_at nil
+               {:order-by [[:created_at :asc]]})))
+
 (defn- build-base-feedback
   "Build the common feedback payload fields."
   [user-id conversation-id positive]
@@ -508,7 +517,7 @@
    :feedback          {:positive          positive
                        :message_id        conversation-id
                        :freeform_feedback ""}
-   :conversation_data {}
+   :conversation_data {:messages (get-conversation-messages conversation-id)}
    :version           config/mb-version-info
    :submission_time   (str (java.time.OffsetDateTime/now))
    :is_admin          (boolean (t2/select-one-fn :is_superuser :model/User :id user-id))

--- a/test/metabase/slackbot/api_test.clj
+++ b/test/metabase/slackbot/api_test.clj
@@ -785,11 +785,13 @@
               result (#'slackbot/handle-feedback-modal-submission payload)]
           @result
           (is (= 1 (count @harbormaster-calls)))
-          (let [feedback (first @harbormaster-calls)]
-            (is (false? (get-in feedback [:feedback :positive])))
-            (is (= "conv-123" (get-in feedback [:feedback :message_id])))
-            (is (= "not-factual" (get-in feedback [:feedback :issue_type])))
-            (is (= "The answer was wrong" (get-in feedback [:feedback :freeform_feedback]))))))))
+          (is (=? {:feedback          {:positive          false
+                                       :message_id        "conv-123"
+                                       :issue_type        "not-factual"
+                                       :freeform_feedback "The answer was wrong"}
+                   :source            "slack"
+                   :conversation_data {:messages []}}
+                  (first @harbormaster-calls)))))))
 
   (testing "modal submission with only freeform text submits"
     (let [harbormaster-calls (atom [])]
@@ -807,7 +809,10 @@
               result (#'slackbot/handle-feedback-modal-submission payload)]
           @result
           (is (= 1 (count @harbormaster-calls)))
-          (is (= "Great response!" (get-in (first @harbormaster-calls) [:feedback :freeform_feedback])))))))
+          (is (=? {:feedback {:positive          true
+                              :freeform_feedback "Great response!"}
+                   :source   "slack"}
+                  (first @harbormaster-calls)))))))
 
   (testing "modal submission with no details still submits basic feedback"
     (let [harbormaster-calls (atom [])]
@@ -825,7 +830,10 @@
               result (#'slackbot/handle-feedback-modal-submission payload)]
           @result
           (is (= 1 (count @harbormaster-calls)))
-          (is (true? (get-in (first @harbormaster-calls) [:feedback :positive])))))))
+          (is (=? {:feedback {:positive          true
+                              :freeform_feedback ""}
+                   :source   "slack"}
+                  (first @harbormaster-calls)))))))
 
   (testing "modal submission with only issue type submits"
     (let [harbormaster-calls (atom [])]
@@ -844,7 +852,53 @@
               result (#'slackbot/handle-feedback-modal-submission payload)]
           @result
           (is (= 1 (count @harbormaster-calls)))
-          (is (= "ui-bug" (get-in (first @harbormaster-calls) [:feedback :issue_type]))))))))
+          (is (=? {:feedback {:positive   false
+                              :issue_type "ui-bug"}
+                   :source   "slack"}
+                  (first @harbormaster-calls)))))))
+
+  (testing "feedback includes conversation messages from the database"
+    (let [conv-id            (str (random-uuid))
+          harbormaster-calls (atom [])]
+      (mt/with-model-cleanup [:model/MetabotMessage [:model/MetabotConversation :created_at]]
+        (t2/insert! :model/MetabotConversation {:id conv-id :user_id (mt/user->id :rasta)})
+        (t2/insert! :model/MetabotMessage
+                    {:conversation_id conv-id
+                     :role            "user"
+                     :profile_id      "slackbot"
+                     :total_tokens    0
+                     :data            [{:_type "TEXT" :role "user" :content "What is revenue?"}]})
+        (t2/insert! :model/MetabotMessage
+                    {:conversation_id conv-id
+                     :role            "assistant"
+                     :profile_id      "slackbot"
+                     :total_tokens    10
+                     :data            [{:_type "TEXT" :role "assistant" :content "Here are the results."}]})
+        (with-redefs [metabot.feedback/submit-to-harbormaster! (fn [feedback]
+                                                                 (swap! harbormaster-calls conj feedback)
+                                                                 true)]
+          (let [payload {:type "view_submission"
+                         :view {:callback_id      "metabot_feedback_modal"
+                                :private_metadata (json/encode {:conversation_id conv-id
+                                                                :positive        true
+                                                                :user_id         (mt/user->id :rasta)
+                                                                :channel_id      "C123"
+                                                                :message_ts      "123.456"})
+                                :state {:values {:freeform_feedback {:freeform_input {:value "Great!"}}}}}}
+                result (#'slackbot/handle-feedback-modal-submission payload)]
+            @result
+            (is (= 1 (count @harbormaster-calls)))
+            (is (=? {:feedback          {:positive          true
+                                         :message_id        conv-id
+                                         :freeform_feedback "Great!"}
+                     :source            "slack"
+                     :conversation_data {:messages [{:role        :user
+                                                     :data        [{:_type "TEXT" :role "user" :content "What is revenue?"}]
+                                                     :profile_id  "slackbot"}
+                                                    {:role        :assistant
+                                                     :data        [{:_type "TEXT" :role "assistant" :content "Here are the results."}]
+                                                     :profile_id  "slackbot"}]}}
+                    (first @harbormaster-calls)))))))))
 
 ;; -------------------------------- Visualization Integration Tests --------------------------------
 


### PR DESCRIPTION
Fixes [BOT-1163: Conversation data is dropped from Slack metabot feedback](https://linear.app/metabase/issue/BOT-1163/conversation-data-is-dropped-from-slack-metabot-feedback)

I think this was in an earlier version of the branch and got dropped during rebase conflict resolution. Regardless, it's easy to add back.