### PR TITLE
embedding-hub: preserve "Select data" state + reset next steps after changing data segregation strategy

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
@@ -1614,7 +1614,6 @@ describe("scenarios - embedding hub", () => {
       H.main().findByRole("button", { name: "Next" }).click();
 
       cy.wait("@updatePermissionsGraph");
-      cy.wait("@getChecklist");
 
       cy.log("create tenants should reopen instead of skipping to summary");
       H.main()

--- a/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
@@ -1567,6 +1567,90 @@ describe("scenarios - embedding hub", () => {
         )
         .should("be.visible");
     });
+
+    it("reopens the create tenants step after changing the segregation strategy", () => {
+      H.addPostgresDatabase("QA Postgres12");
+
+      cy.log("pre-complete RLS and create a tenant");
+      cy.sandboxTable({
+        table_id: STATIC_ORDERS_ID,
+        group_id: ALL_EXTERNAL_USERS_GROUP_ID,
+      });
+      cy.request("POST", "/api/ee/tenant", {
+        name: "Legacy Tenant",
+        slug: "legacy-tenant",
+        attributes: {
+          organization_id: "legacy-org",
+        },
+      });
+
+      cy.intercept("PUT", "/api/permissions/graph").as(
+        "updatePermissionsGraph",
+      );
+      cy.intercept("GET", "/api/ee/embedding-hub/checklist").as("getChecklist");
+
+      cy.visit("/admin/embedding/setup-guide/permissions");
+
+      cy.log("reopen the strategy step and switch to connection impersonation");
+      H.main()
+        .findByRole("listitem", {
+          name: "Which data segregation strategy does your database use?",
+        })
+        .click();
+
+      H.main()
+        .findByRole("radio", { name: /Connection impersonation/ })
+        .scrollIntoView()
+        .click();
+
+      H.main()
+        .findByRole("button", { name: "Use connection impersonation" })
+        .scrollIntoView()
+        .click();
+
+      cy.log("complete the new select-data step");
+      H.main().findByPlaceholderText("Pick a database").click();
+      H.popover().findByText("QA Postgres12").click();
+      H.main().findByRole("button", { name: "Next" }).click();
+
+      cy.wait("@updatePermissionsGraph");
+      cy.wait("@getChecklist");
+
+      cy.log("create tenants should reopen instead of skipping to summary");
+      H.main()
+        .findByRole("listitem", {
+          name: "Create tenants",
+          timeout: 10_000,
+        })
+        .should("have.attr", "aria-current", "step");
+
+      H.main()
+        .findByRole("listitem", { name: "Summary" })
+        .should("not.have.attr", "aria-current", "step");
+
+      cy.log("creating a new tenant should go to summary");
+      H.main().within(() => {
+        cy.findByPlaceholderText("Tenant name").clear().type("Acme Corp");
+        cy.findByPlaceholderText("tenant_role").type("acme_role");
+        cy.findByPlaceholderText("tenant-slug").clear().type("acme-corp");
+      });
+
+      H.main().findByRole("button", { name: "Create tenants" }).click();
+
+      H.undoToast()
+        .findByText("Tenants created successfully")
+        .should("be.visible");
+
+      H.main()
+        .findByRole("listitem", { name: "Summary", timeout: 10_000 })
+        .should("have.attr", "aria-current", "step");
+
+      H.main()
+        .contains(
+          "All users in Acme Corp will connect using the acme_role database role.",
+        )
+        .should("be.visible");
+    });
   });
 
   describe("database routing create tenants step", () => {

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/CreateTenantsOnboardingStep/CreateTenantsOnboardingStep.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/CreateTenantsOnboardingStep/CreateTenantsOnboardingStep.tsx
@@ -1,9 +1,11 @@
-import { useCallback, useState } from "react";
+import type { SetStateAction } from "react";
+import { useCallback } from "react";
 import { t } from "ttag";
 
 import { getErrorMessage } from "metabase/api/utils";
 import { useToast } from "metabase/common/hooks";
 import type { DataSegregationStrategy } from "metabase/embedding/embedding-hub";
+import { createEmptyTenantDraft } from "metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/utils";
 import { slugify } from "metabase/lib/formatting";
 import type { CreatedTenantData } from "metabase/plugins/oss/tenants";
 import {
@@ -26,11 +28,15 @@ import { getIsolationFieldConfig } from "./isolation-field-config";
 
 export const CreateTenantsOnboardingStep = ({
   onTenantsCreated,
+  tenants,
+  onTenantsChange,
   selectedFieldIds,
   strategy,
   rlsColumnName,
 }: {
   onTenantsCreated?: (tenants: CreatedTenantData[]) => void;
+  tenants: CreatedTenantData[];
+  onTenantsChange: (value: SetStateAction<CreatedTenantData[]>) => void;
   selectedFieldIds?: FieldId[];
   strategy?: DataSegregationStrategy | null;
   rlsColumnName?: string | null;
@@ -39,17 +45,16 @@ export const CreateTenantsOnboardingStep = ({
 
   const [createTenant, { isLoading }] = useCreateTenantMutation();
 
-  const [tenants, setTenants] = useState<CreatedTenantData[]>([
-    createEmptyTenant(1),
-  ]);
-
   const addTenantCard = useCallback(() => {
-    setTenants((prev) => [...prev, createEmptyTenant(prev.length + 1)]);
-  }, []);
+    onTenantsChange((prev) => [
+      ...prev,
+      createEmptyTenantDraft(prev.length + 1),
+    ]);
+  }, [onTenantsChange]);
 
   const updateTenantCard = useCallback(
     (index: number, field: keyof CreatedTenantData, value: string) => {
-      setTenants((prev) =>
+      onTenantsChange((prev) =>
         prev.map((tenant, i) => {
           if (i !== index) {
             return tenant;
@@ -66,12 +71,15 @@ export const CreateTenantsOnboardingStep = ({
         }),
       );
     },
-    [],
+    [onTenantsChange],
   );
 
-  const removeTenantCard = useCallback((index: number) => {
-    setTenants((prev) => prev.filter((_, i) => i !== index));
-  }, []);
+  const removeTenantCard = useCallback(
+    (index: number) => {
+      onTenantsChange((prev) => prev.filter((_, i) => i !== index));
+    },
+    [onTenantsChange],
+  );
 
   const fieldConfig = getIsolationFieldConfig(strategy);
 
@@ -235,9 +243,3 @@ const TenantFormField = ({
     />
   </Stack>
 );
-
-const createEmptyTenant = (index: number): CreatedTenantData => ({
-  name: `Tenant ${index}`,
-  dataIsolationFieldValue: "",
-  slug: `tenant-${index}`,
-});

--- a/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/RlsDataSelector/RlsDataSelector.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/RlsDataSelector/RlsDataSelector.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useState } from "react";
+import type { SetStateAction } from "react";
+import { useCallback } from "react";
 import { t } from "ttag";
 
 import { getErrorMessage } from "metabase/api/utils";
@@ -26,15 +27,17 @@ export interface RlsSelectionResult {
 }
 
 interface RlsDataSelectorProps {
+  selections: TableColumnSelection[];
+  onSelectionsChange: (value: SetStateAction<TableColumnSelection[]>) => void;
   onSuccess: (result: RlsSelectionResult) => void;
 }
 
-export const RlsDataSelector = ({ onSuccess }: RlsDataSelectorProps) => {
+export const RlsDataSelector = ({
+  selections,
+  onSelectionsChange,
+  onSuccess,
+}: RlsDataSelectorProps) => {
   const [sendToast] = useToast();
-
-  const [selections, setSelections] = useState<TableColumnSelection[]>([
-    { tableId: null, columnId: null },
-  ]);
 
   const { handleUpsertPolicies, isCreatingPolicy, isLoadingPolicies } =
     useUpsertGroupTableAccessPolicies({ tableColumnSelections: selections });
@@ -69,25 +72,27 @@ export const RlsDataSelector = ({ onSuccess }: RlsDataSelectorProps) => {
   }, [handleUpsertPolicies, selections, onSuccess, sendToast]);
 
   const addTable = useCallback(() => {
-    setSelections((prev) => [...prev, { tableId: null, columnId: null }]);
-  }, []);
+    onSelectionsChange((prev) => [...prev, createEmptyTableColumnSelection()]);
+  }, [onSelectionsChange]);
 
-  const removeTable = useCallback((nextIndex: number) => {
-    setSelections((prev) =>
-      prev.filter((_, prevIndex) => prevIndex !== nextIndex),
-    );
-  }, []);
+  const removeTable = useCallback(
+    (nextIndex: number) => {
+      onSelectionsChange((prev) =>
+        prev.filter((_, prevIndex) => prevIndex !== nextIndex),
+      );
+    },
+    [onSelectionsChange],
+  );
 
   const updateTable = useCallback(
     (index: number, selection: TableColumnSelection) => {
-      setSelections((prev) => {
-        const newSelections = [...prev];
-        newSelections[index] = selection;
-
-        return newSelections;
-      });
+      onSelectionsChange((prev) =>
+        prev.map((prevSelection, prevIndex) =>
+          prevIndex === index ? selection : prevSelection,
+        ),
+      );
     },
-    [],
+    [onSelectionsChange],
   );
 
   const canRemove = selections.length > 1;
@@ -144,3 +149,8 @@ export const RlsDataSelector = ({ onSuccess }: RlsDataSelectorProps) => {
     </Stack>
   );
 };
+
+export const createEmptyTableColumnSelection = (): TableColumnSelection => ({
+  tableId: null,
+  columnId: null,
+});

--- a/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/RlsDataSelector/index.ts
+++ b/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/RlsDataSelector/index.ts
@@ -1,5 +1,6 @@
 export {
   RlsDataSelector,
+  createEmptyTableColumnSelection,
   type TableColumnSelection,
   type RlsSelectionResult,
 } from "./RlsDataSelector";

--- a/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/SetupPermissionsAndTenantsPage.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/SetupPermissionsAndTenantsPage.tsx
@@ -20,11 +20,17 @@ import {
 import { DatabaseRoutingStepContent } from "./DatabaseRoutingStepContent";
 import { EnableTenantsStepContent } from "./EnableTenantsStepContent";
 import { MoveDashboardStepContent } from "./MoveDashboardStepContent";
-import type { RlsSelectionResult } from "./RlsDataSelector";
-import { RlsDataSelector } from "./RlsDataSelector";
+import type {
+  RlsSelectionResult,
+  TableColumnSelection,
+} from "./RlsDataSelector";
+import {
+  RlsDataSelector,
+  createEmptyTableColumnSelection,
+} from "./RlsDataSelector";
 import S from "./SetupPermissionsAndTenantsPage.module.css";
 import { useLastXrayDashboard } from "./hooks/use-xray-dashboards";
-
+import { createEmptyTenantDraft } from "./utils";
 const SETUP_GUIDE_PATH = "/admin/embedding/setup-guide";
 
 export const SetupPermissionsAndTenantsPage = () => {
@@ -43,12 +49,18 @@ export const SetupPermissionsAndTenantsPage = () => {
   // Track the tenants created in this onboarding flow
   const [createdTenants, setCreatedTenants] = useState<CreatedTenantData[]>([]);
 
+  const [tenantDrafts, setTenantDrafts] = useState<CreatedTenantData[]>(() => [
+    createEmptyTenantDraft(1),
+  ]);
+
   // Track RLS selection from the "Select data" step (in-session only)
-  const [rlsSelection, setRlsSelection] = useState<RlsSelectionResult>({
-    fieldIds: [],
-    tableNames: [],
-    columnName: null,
-  });
+  const [rlsSelection, setRlsSelection] = useState<RlsSelectionResult>(
+    createEmptyRlsSelection,
+  );
+
+  const [rlsSelectionsDraft, setRlsSelectionsDraft] = useState<
+    TableColumnSelection[]
+  >(() => [createEmptyTableColumnSelection()]);
 
   const isMoveDashboardDone = checklist?.["move-dashboard-to-shared"] ?? false;
 
@@ -184,6 +196,8 @@ export const SetupPermissionsAndTenantsPage = () => {
           {match(activeStrategy)
             .with("row-column-level-security", () => (
               <RlsDataSelector
+                selections={rlsSelectionsDraft}
+                onSelectionsChange={setRlsSelectionsDraft}
                 onSuccess={(result) => {
                   setRlsSelection(result);
 
@@ -207,7 +221,12 @@ export const SetupPermissionsAndTenantsPage = () => {
           title={t`Create tenants`}
         >
           <PLUGIN_TENANTS.CreateTenantsOnboardingStep
-            onTenantsCreated={setCreatedTenants}
+            onTenantsCreated={(tenants) => {
+              setCreatedTenants(tenants);
+              setTenantDrafts([createEmptyTenantDraft(1)]);
+            }}
+            tenants={tenantDrafts}
+            onTenantsChange={setTenantDrafts}
             selectedFieldIds={rlsSelection.fieldIds}
             strategy={activeStrategy}
             rlsColumnName={rlsSelection.columnName}
@@ -230,3 +249,9 @@ export const SetupPermissionsAndTenantsPage = () => {
     </Stack>
   );
 };
+
+const createEmptyRlsSelection = (): RlsSelectionResult => ({
+  fieldIds: [],
+  tableNames: [],
+  columnName: null,
+});

--- a/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/SetupPermissionsAndTenantsPage.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/SetupPermissionsAndTenantsPage.tsx
@@ -48,6 +48,7 @@ export const SetupPermissionsAndTenantsPage = () => {
 
   // Track the tenants created in this onboarding flow
   const [createdTenants, setCreatedTenants] = useState<CreatedTenantData[]>([]);
+  const [needsTenantRecreation, setNeedsTenantRecreation] = useState(false);
 
   const [tenantDrafts, setTenantDrafts] = useState<CreatedTenantData[]>(() => [
     createEmptyTenantDraft(1),
@@ -76,7 +77,13 @@ export const SetupPermissionsAndTenantsPage = () => {
   const isDataSegregationSetupDone =
     checklist?.["setup-data-segregation-strategy"] ?? false;
 
-  const isTenantsCreated = checklist?.["create-tenants"] ?? false;
+  const backendStrategy =
+    checklistResponse?.["data-isolation-strategy"] ?? null;
+  const isTenantsCreatedFromBackend = checklist?.["create-tenants"] ?? false;
+  const isTenantsCreated =
+    !needsTenantRecreation &&
+    (createdTenants.length > 0 ||
+      (isTenantsCreatedFromBackend && activeStrategy === backendStrategy));
 
   // When data segregation is finally configured, we permanently
   // mark this step as done. Otherwise rely on UI state.
@@ -174,11 +181,29 @@ export const SetupPermissionsAndTenantsPage = () => {
           <DataSegregationStrategyPicker
             value={activeStrategy}
             onChange={(value) => {
+              const hasStrategyChanged = value !== activeStrategy;
+
               setSelectedStrategy(value);
               setIsStrategyConfirmed(false);
+
+              if (hasStrategyChanged) {
+                setCreatedTenants([]);
+                setTenantDrafts([createEmptyTenantDraft(1)]);
+                setRlsSelection(createEmptyRlsSelection());
+                setRlsSelectionsDraft([createEmptyTableColumnSelection()]);
+              }
             }}
             onConfirm={() => {
+              const confirmedStrategy = activeStrategy;
+              const shouldRecreateTenants =
+                confirmedStrategy !== backendStrategy;
+
               setIsStrategyConfirmed(true);
+              setNeedsTenantRecreation(shouldRecreateTenants);
+
+              if (shouldRecreateTenants) {
+                setCreatedTenants([]);
+              }
 
               // User is re-configuring the data segregation,
               // so we need to _always_ go to the next step.
@@ -223,6 +248,7 @@ export const SetupPermissionsAndTenantsPage = () => {
           <PLUGIN_TENANTS.CreateTenantsOnboardingStep
             onTenantsCreated={(tenants) => {
               setCreatedTenants(tenants);
+              setNeedsTenantRecreation(false);
               setTenantDrafts([createEmptyTenantDraft(1)]);
             }}
             tenants={tenantDrafts}

--- a/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/utils.ts
+++ b/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/utils.ts
@@ -1,0 +1,7 @@
+import type { CreatedTenantData } from "metabase/plugins/oss/tenants";
+
+export const createEmptyTenantDraft = (index: number): CreatedTenantData => ({
+  name: `Tenant ${index}`,
+  dataIsolationFieldValue: "",
+  slug: `tenant-${index}`,
+});

--- a/frontend/src/metabase/plugins/oss/tenants.ts
+++ b/frontend/src/metabase/plugins/oss/tenants.ts
@@ -1,4 +1,5 @@
 import type React from "react";
+import type { SetStateAction } from "react";
 
 import type {
   OmniPickerCollectionItem,
@@ -39,6 +40,8 @@ const getDefaultPluginTenants = () => ({
   tenantsRoutes: null as React.ReactElement | null,
   CreateTenantsOnboardingStep: PluginPlaceholder as React.ComponentType<{
     onTenantsCreated?: (tenants: CreatedTenantData[]) => void;
+    tenants: CreatedTenantData[];
+    onTenantsChange: (value: SetStateAction<CreatedTenantData[]>) => void;
     selectedFieldIds?: number[];
     strategy?: DataSegregationStrategy | null;
     rlsColumnName?: string | null;
@@ -113,6 +116,8 @@ export const PLUGIN_TENANTS: {
   tenantsRoutes: React.ReactElement | null;
   CreateTenantsOnboardingStep: React.ComponentType<{
     onTenantsCreated?: (tenants: CreatedTenantData[]) => void;
+    tenants: CreatedTenantData[];
+    onTenantsChange: (value: SetStateAction<CreatedTenantData[]>) => void;
     selectedFieldIds?: number[];
     strategy?: DataSegregationStrategy | null;
     rlsColumnName?: string | null;


### PR DESCRIPTION
Closes [EMB-1398: Preserve state when navigating away in embedding permissions onboarding steps](https://linear.app/metabase/issue/EMB-1398/preserve-state-when-navigating-away-in-embedding-permissions)
Closes [EMB-1403: Changing data segregation strategy doesn't reopen create tenants step if it was previously completed](https://linear.app/metabase/issue/EMB-1403/changing-data-segregation-strategy-doesnt-reopen-create-tenants-step)

Addressing two tasks here as they were about similar things and didn't want to risk having conflicts or one pr breaking the other.
The tasks are split across two commits for easier review

[EMB-1398: Preserve state when navigating away in embedding permissions onboarding steps](https://linear.app/metabase/issue/EMB-1398/preserve-state-when-navigating-away-in-embedding-permissions)

This lifts up the state so that the state of "Select data to make available" is not lost when changing step

[EMB-1403: Changing data segregation strategy doesn't reopen create tenants step if it was previously completed](https://linear.app/metabase/issue/EMB-1403/changing-data-segregation-strategy-doesnt-reopen-create-tenants-step)

This allows the customer to change data segregation strategy and be able to do the steps after that again


# Demo + How to verify
https://www.loom.com/share/b3143dd4534141879f28da5486c85aa3