### PR TITLE
scroll to top on page change in admin settings

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
@@ -611,6 +611,7 @@ describe("scenarios - embedding hub", () => {
         cy.findByTestId("admin-layout-content")
           .findByText("Configure data permissions and enable tenants")
           .closest("button")
+          .scrollIntoView()
           .findByText("Done")
           .should("be.visible");
 

--- a/frontend/src/metabase/common/components/AdminLayout/AdminSettingsLayout.tsx
+++ b/frontend/src/metabase/common/components/AdminLayout/AdminSettingsLayout.tsx
@@ -1,4 +1,7 @@
+import type { Location } from "history";
 import type React from "react";
+import { useEffect, useRef } from "react";
+import { withRouter } from "react-router";
 
 import ErrorBoundary from "metabase/ErrorBoundary";
 import { Box } from "metabase/ui";
@@ -18,6 +21,8 @@ export const AdminSettingsLayout = ({
   fullWidth?: boolean;
   maw?: string;
 }) => {
+  const contentRef = useRef<HTMLDivElement>(null);
+
   return (
     <Box className={S.Wrapper}>
       <Box className={S.Main}>
@@ -27,10 +32,12 @@ export const AdminSettingsLayout = ({
           </Box>
         )}
         <Box
+          ref={contentRef}
           className={S.Content}
           data-testid="admin-layout-content"
           p={fullWidth ? 0 : "2rem"}
         >
+          <ScrollToTopAdmin contentRef={contentRef} />
           <Box maw={fullWidth ? undefined : maw} w="100%">
             <Box {...(fullWidth ? { h: "100%" } : { pb: "2rem" })}>
               <ErrorBoundary>{children ?? <NotFound />}</ErrorBoundary>
@@ -41,3 +48,17 @@ export const AdminSettingsLayout = ({
     </Box>
   );
 };
+
+const ScrollToTopAdminInner = ({
+  location,
+  contentRef,
+}: {
+  location: Location;
+  contentRef: React.RefObject<HTMLDivElement | null>;
+}) => {
+  useEffect(() => {
+    contentRef.current?.scrollTo(0, 0);
+  }, [location.pathname, contentRef]);
+  return null;
+};
+const ScrollToTopAdmin = withRouter(ScrollToTopAdminInner);

--- a/frontend/src/metabase/common/components/AdminLayout/AdminSettingsLayout.tsx
+++ b/frontend/src/metabase/common/components/AdminLayout/AdminSettingsLayout.tsx
@@ -58,7 +58,7 @@ const ScrollToTopAdminInner = ({
 }) => {
   useEffect(() => {
     contentRef.current?.scrollTo(0, 0);
-  }, [location.pathname, contentRef]);
+  }, [location?.pathname, contentRef]);
   return null;
 };
 const ScrollToTopAdmin = withRouter(ScrollToTopAdminInner);

--- a/frontend/src/metabase/common/components/AdminLayout/AdminSettingsLayout.tsx
+++ b/frontend/src/metabase/common/components/AdminLayout/AdminSettingsLayout.tsx
@@ -1,9 +1,8 @@
-import type { Location } from "history";
 import type React from "react";
 import { useEffect, useRef } from "react";
-import { withRouter } from "react-router";
 
 import ErrorBoundary from "metabase/ErrorBoundary";
+import { useRouter } from "metabase/router/useRouter";
 import { Box } from "metabase/ui";
 
 import { NotFound } from "../ErrorPages";
@@ -22,6 +21,7 @@ export const AdminSettingsLayout = ({
   maw?: string;
 }) => {
   const contentRef = useRef<HTMLDivElement>(null);
+  useScrollToTop(contentRef);
 
   return (
     <Box className={S.Wrapper}>
@@ -37,7 +37,6 @@ export const AdminSettingsLayout = ({
           data-testid="admin-layout-content"
           p={fullWidth ? 0 : "2rem"}
         >
-          <ScrollToTopAdmin contentRef={contentRef} />
           <Box maw={fullWidth ? undefined : maw} w="100%">
             <Box {...(fullWidth ? { h: "100%" } : { pb: "2rem" })}>
               <ErrorBoundary>{children ?? <NotFound />}</ErrorBoundary>
@@ -49,16 +48,10 @@ export const AdminSettingsLayout = ({
   );
 };
 
-const ScrollToTopAdminInner = ({
-  location,
-  contentRef,
-}: {
-  location: Location;
-  contentRef: React.RefObject<HTMLDivElement | null>;
-}) => {
+const useScrollToTop = (contentRef: React.RefObject<HTMLDivElement | null>) => {
+  const { location } = useRouter();
+
   useEffect(() => {
     contentRef.current?.scrollTo(0, 0);
   }, [location?.pathname, contentRef]);
-  return null;
 };
-const ScrollToTopAdmin = withRouter(ScrollToTopAdminInner);


### PR DESCRIPTION

Closes [EMB-1397: Reset the scroll position when opening the permissions sub-checklist](https://linear.app/metabase/issue/EMB-1397/reset-the-scroll-position-when-opening-the-permissions-sub-checklist)

### Description

The global `ScrollToTop` component that we have doesn't work in the admin settings, as is does `window.scrollTo`, in the admin pages we don't have scrollbars on the entire page but only on a container, see here that the scrollbar is not on the full page:
<img width="886" height="498" alt="image" src="https://github.com/user-attachments/assets/27fc406f-1ab3-4d04-a36d-5d60a185252c" />

This PR adds an ad-hoc scroll to top behavior for the admin settings that scrolls on the correct element

### How to verify

Resize the window and navigate between two pages that are big enough that you have scrollbars, "General" (`/admin/settings/general`) and "Localization" (`admin/settings/localization`) work well for this.
You should be brought back to the top of the page on each navigation

