### PR TITLE
Add saved question display type to metabot context

### DIFF
--- a/resources/metabot/prompts/llm_representations.selmer
+++ b/resources/metabot/prompts/llm_representations.selmer
@@ -125,7 +125,7 @@ Chart link: metabase://chart/{{chart_id}}
 </chart>
 {% endif %}
 {% if is_question %}
-<metabase_question id="{{question_id}}" is_verified="{{question_verified}}">
+<metabase_question id="{{question_id}}" is_verified="{{question_verified}}"{% if question_display_type %} display_type="{{question_display_type}}"{% endif %}>
 <name>{{question_name}}</name>
 {% if question_description %}
 <description>{{question_description}}</description>

--- a/src/metabase/metabot/tools/entity_details.clj
+++ b/src/metabase/metabot/tools/entity_details.clj
@@ -414,7 +414,8 @@
                         (-> details
                             (select-keys [:id :type :description :name :verified])
                             (assoc :result-columns (:fields details))
-                            (m/assoc-some :average_query_time (:average_query_time card))))
+                            (m/assoc-some :average_query_time (:average_query_time card)
+                                          :display (:display card))))
                       (throw (ex-info "Invalid report_id format"
                                       {:agent-error? true :status-code 400})))]
         {:structured-output (assoc details :result-type :entity)}))

--- a/src/metabase/metabot/tools/llm_representations.clj
+++ b/src/metabase/metabot/tools/llm_representations.clj
@@ -278,15 +278,15 @@
     :chart_type (if chart-type (clojure.core/name chart-type) "table")}))
 
 (defn question->xml
-  "Format question for LLM consumption.
-   Matches Python Question.llm_representation exactly."
-  [{:keys [id name description verified collection visualization]}]
+  "Format question for LLM consumption."
+  [{:keys [id name description verified collection visualization display]}]
   (render-llm-template
    :question
    {:question_id (str id)
     :question_verified (boolean verified)
     :question_name name
     :question_description description
+    :question_display_type (some-> display clojure.core/name)
     :question_collection_xml (when collection (collection->xml collection))
     :question_visualization_xml (when visualization (visualization->xml visualization))}))
 

--- a/test/metabase/metabot/agent/user_context_test.clj
+++ b/test/metabase/metabot/agent/user_context_test.clj
@@ -364,6 +364,19 @@
           (is (re-find #"Retention Cohorts" result))
           (is (re-find #"Shows retention by cohort" result))))))
 
+  (testing "question includes display_type in formatted output"
+    (mt/with-test-user :rasta
+      (mt/with-temp [:model/Card {card-id :id} {:name          "Revenue Pie Chart"
+                                                :type          "question"
+                                                :display       :pie
+                                                :database_id   (mt/id)
+                                                :dataset_query {:database (mt/id)
+                                                                :type     :query
+                                                                :query    {:source-table (mt/id :orders)}}}]
+        (let [result (user-context/format-viewing-context
+                      {:user_is_viewing [{:type "question" :id card-id}]})]
+          (is (re-find #"display_type=\"pie\"" result))))))
+
   (testing "dashboard with only type+id fetches name and description from DB"
     (mt/with-test-user :rasta
       (mt/with-temp [:model/Dashboard {dash-id :id} {:name        "Executive Dashboard"

--- a/test/metabase/metabot/tools/api_test.clj
+++ b/test/metabase/metabot/tools/api_test.clj
@@ -633,6 +633,7 @@
                                            (lib.metadata/field mp (mt/id :products :created_at)) :week)))
           question-data {:name "Question?"
                          :description "Descriptive?"
+                         :display :bar
                          :dataset_query (lib/->legacy-MBQL source-query)
                          :type :question}]
       (mt/with-temp [:model/Card {question-id :id} question-data]
@@ -664,6 +665,7 @@
                                               (select-keys [:name :description :database_id])
                                               (assoc :id question-id
                                                      :type "question"
+                                                     :display "bar"
                                                      :verified true
                                                      :result_columns
                                                      (map-indexed #(assoc %2 :field_id (format "c%d-%d" question-id %1))

--- a/test/metabase/metabot/tools/llm_representations_test.clj
+++ b/test/metabase/metabot/tools/llm_representations_test.clj
@@ -207,7 +207,18 @@
       (is (str/includes? xml "<name>Revenue Report</name>"))
       (is (str/includes? xml "<description>Monthly revenue breakdown</description>"))
       (is (str/includes? xml "The question is stored in the following collection"))
-      (is (str/ends-with? (str/trim xml) "</metabase_question>")))))
+      (is (str/ends-with? (str/trim xml) "</metabase_question>"))))
+  (testing "includes display_type when present"
+    (let [question {:id 101
+                    :name "Pie Chart"
+                    :display :pie}
+          xml (llm-rep/question->xml question)]
+      (is (str/includes? xml "display_type=\"pie\""))))
+  (testing "omits display_type when not present"
+    (let [question {:id 102
+                    :name "No Display"}
+          xml (llm-rep/question->xml question)]
+      (is (not (str/includes? xml "display_type"))))))
 
 (deftest dashboard->xml-test
   (testing "formats dashboard matching Python"


### PR DESCRIPTION
[BOT-1169: Give Metabot viz type metadata for saved questions](https://linear.app/metabase/issue/BOT-1169/give-metabot-viz-type-metadata-for-saved-questions)

Allows Metabot to understand the viz type of a saved question (without giving it more info about viz settings, at least for now). In particular this should hopefully help to prevent the situation where Slackbot renders a chart static viz image for a saved question when the user asked for a list of rows, or similar.