### PR TITLE
Fix drill popover flashing at top-left corner when scrolling table

### DIFF
--- a/frontend/src/metabase/ui/components/overlays/Popover/PopoverWithRef.tsx
+++ b/frontend/src/metabase/ui/components/overlays/Popover/PopoverWithRef.tsx
@@ -9,6 +9,31 @@ import {
 
 import { Popover, type PopoverProps } from "./index";
 
+// Elements that have been patched with a stable getBoundingClientRect.
+const patchedElements = new WeakSet<Element>();
+
+// When a DOM element is removed (e.g. by virtual scroll),
+// getBoundingClientRect() returns {top:0, left:0, width:0, height:0}.
+// This causes Floating UI to flash the popover at the viewport origin.
+// Patching the method to cache the last known rect prevents this.
+function ensureStableRect(element: Element): void {
+  if (patchedElements.has(element)) {
+    return;
+  }
+
+  const original = element.getBoundingClientRect.bind(element);
+  let lastRect = original();
+
+  element.getBoundingClientRect = () => {
+    if (element.isConnected) {
+      lastRect = original();
+    }
+    return lastRect;
+  };
+
+  patchedElements.add(element);
+}
+
 // Not something we want to use a ton. This is only meant to help migrate
 // to Mantine popovers in situations where we pass an anchor as a reference for
 // positioning purposes.
@@ -22,6 +47,10 @@ export const PopoverWithRef = ({
     anchorEl: Element | null;
     popoverContentTestId?: string;
   }) => {
+  if (anchorEl) {
+    ensureStableRect(anchorEl);
+  }
+
   const anchorRef = useRef(anchorEl);
   anchorRef.current = anchorEl;
 

--- a/frontend/src/metabase/ui/components/overlays/Popover/PopoverWithRef.unit.spec.tsx
+++ b/frontend/src/metabase/ui/components/overlays/Popover/PopoverWithRef.unit.spec.tsx
@@ -1,0 +1,45 @@
+import { renderWithProviders } from "__support__/ui";
+
+import { PopoverWithRef } from "./PopoverWithRef";
+
+describe("PopoverWithRef", () => {
+  it("should return cached rect when anchor element is removed from DOM", () => {
+    const anchor = document.createElement("div");
+    document.body.appendChild(anchor);
+
+    // Mock getBoundingClientRect to return a known position
+    anchor.getBoundingClientRect = jest.fn(() => ({
+      top: 100,
+      left: 200,
+      bottom: 120,
+      right: 300,
+      width: 100,
+      height: 20,
+      x: 200,
+      y: 100,
+      toJSON: () => ({}),
+    }));
+
+    renderWithProviders(
+      <PopoverWithRef anchorEl={anchor} opened>
+        <div data-testid="content">Popover content</div>
+      </PopoverWithRef>,
+    );
+
+    // After passing through PopoverWithRef, getBoundingClientRect should
+    // still work normally while connected
+    const rectWhileConnected = anchor.getBoundingClientRect();
+    expect(rectWhileConnected.top).toBe(100);
+    expect(rectWhileConnected.left).toBe(200);
+
+    // Remove the element from DOM (simulates virtual scroll unmounting a row)
+    document.body.removeChild(anchor);
+
+    // getBoundingClientRect should return cached values, not zeros
+    const rectWhileDetached = anchor.getBoundingClientRect();
+    expect(rectWhileDetached.top).toBe(100);
+    expect(rectWhileDetached.left).toBe(200);
+    expect(rectWhileDetached.width).toBe(100);
+    expect(rectWhileDetached.height).toBe(20);
+  });
+});

--- a/frontend/src/metabase/visualizations/components/ClickActions/ClickActionsPopover.tsx
+++ b/frontend/src/metabase/visualizations/components/ClickActions/ClickActionsPopover.tsx
@@ -140,7 +140,6 @@ export class ClickActionsPopover extends Component<
           }
         }}
         trapFocus
-        hideDetached
         position="bottom-start"
         offset={8}
         popoverContentTestId="click-actions-popover"

--- a/frontend/src/metabase/visualizations/components/ClickActions/ClickActionsPopover.tsx
+++ b/frontend/src/metabase/visualizations/components/ClickActions/ClickActionsPopover.tsx
@@ -140,6 +140,7 @@ export class ClickActionsPopover extends Component<
           }
         }}
         trapFocus
+        hideDetached
         position="bottom-start"
         offset={8}
         popoverContentTestId="click-actions-popover"

--- a/frontend/src/metabase/visualizations/components/ClickActions/ClickActionsPopover.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/ClickActions/ClickActionsPopover.unit.spec.tsx
@@ -1,4 +1,8 @@
 import { renderWithProviders, screen } from "__support__/ui";
+import type {
+  ClickObject,
+  RegularClickAction,
+} from "metabase/visualizations/types";
 
 import { ClickActionsPopover } from "./ClickActionsPopover";
 
@@ -10,27 +14,27 @@ function setup() {
     element: anchor,
     column: { display_name: "Total" },
     value: 42,
-  };
+  } as unknown as ClickObject;
 
   const clickActions = [
     {
       name: "test-action",
       title: "Test Action",
-      icon: "filter" as const,
-      section: "filter" as const,
-      buttonType: "horizontal" as const,
+      icon: "filter",
+      section: "filter",
+      buttonType: "horizontal",
       question: () => undefined,
       default: true,
     },
-  ];
+  ] as unknown as RegularClickAction[];
 
   return renderWithProviders(
     <ClickActionsPopover
       clicked={clicked}
       clickActions={clickActions}
       series={null}
-      dispatch={jest.fn()}
-      onChangeCardAndRun={jest.fn()}
+      dispatch={jest.fn() as any}
+      onChangeCardAndRun={jest.fn() as any}
       onUpdateVisualizationSettings={jest.fn()}
     />,
   );

--- a/frontend/src/metabase/visualizations/components/ClickActions/ClickActionsPopover.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/ClickActions/ClickActionsPopover.unit.spec.tsx
@@ -1,0 +1,67 @@
+import { renderWithProviders, screen } from "__support__/ui";
+
+import { ClickActionsPopover } from "./ClickActionsPopover";
+
+function setup() {
+  const anchor = document.createElement("div");
+  document.body.appendChild(anchor);
+
+  const clicked = {
+    element: anchor,
+    column: { display_name: "Total" },
+    value: 42,
+  };
+
+  const clickActions = [
+    {
+      name: "test-action",
+      title: "Test Action",
+      icon: "filter" as const,
+      section: "filter" as const,
+      buttonType: "horizontal" as const,
+      question: () => undefined,
+      default: true,
+    },
+  ];
+
+  return renderWithProviders(
+    <ClickActionsPopover
+      clicked={clicked}
+      clickActions={clickActions}
+      series={null}
+      dispatch={jest.fn()}
+      onChangeCardAndRun={jest.fn()}
+      onUpdateVisualizationSettings={jest.fn()}
+    />,
+  );
+}
+
+describe("ClickActionsPopover", () => {
+  it("renders the popover when clicked with a connected anchor element", () => {
+    setup();
+    expect(screen.getByTestId("click-actions-popover")).toBeInTheDocument();
+  });
+
+  it("renders click action items in the popover", () => {
+    setup();
+    expect(
+      screen.getByTestId("click-actions-popover-content-for-Total"),
+    ).toBeInTheDocument();
+  });
+
+  it("does not render when there is no clicked object", () => {
+    renderWithProviders(
+      <ClickActionsPopover
+        clicked={null}
+        clickActions={[]}
+        series={null}
+        dispatch={jest.fn()}
+        onChangeCardAndRun={jest.fn()}
+        onUpdateVisualizationSettings={jest.fn()}
+      />,
+    );
+    expect(
+      screen.queryByTestId("click-actions-popover"),
+    ).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #71277
### Description

When scrolling a table after clicking a cell to show the drill popover, the popover briefly flashes at the top-left corner of the viewport before disappearing. This happens because virtual scroll removes the clicked row's DOM element, causing `getBoundingClientRect()` to return `{top: 0, left: 0}` on the detached element. Floating UI then repositions the popover to (0,0) for one frame before React's state update closes it.

The fix patches `getBoundingClientRect` on anchor elements passed to `PopoverWithRef`, caching the last known rect. When the element becomes disconnected from the DOM, the cached rect is returned instead of zeros, keeping the popover at its last correct position until React closes it. This is implemented in `PopoverWithRef` so it benefits all popovers that use element references, not just the drill popover.

### How to verify

1. Go to Databases > Sample Database > Orders
2. Click any cell to show the drill popover
3. Scroll the table down
4. The popover should disappear cleanly without flashing at the top-left corner of the viewport

### Checklist

- [x] Tests have been added/updated to cover changes in this PR