### PR TITLE
feat(sdk,embed-js): Improve mobile range selection experience for visualizations

### DIFF
--- a/e2e/support/helpers/e2e-mobile-device-helpers.ts
+++ b/e2e/support/helpers/e2e-mobile-device-helpers.ts
@@ -30,25 +30,14 @@ export function longPressAndDrag(
   cy.findByTestId(selector).trigger("pointerdown", startX, startY, {
     force: true,
     isPrimary: true,
-    pointerType: "touch",
     button: 0,
   });
 
   cy.wait(holdMs);
 
   cy.findByTestId(selector)
-    .trigger("pointermove", endX, startY, {
-      force: true,
-      isPrimary: true,
-      pointerType: "touch",
-      button: 0,
-    })
-    .trigger("pointerup", endX, startY, {
-      force: true,
-      isPrimary: true,
-      pointerType: "touch",
-      button: 0,
-    });
+    .trigger("mousemove", endX, startY)
+    .trigger("mouseup", endX, startY);
 }
 
 export function quickSwipe(
@@ -61,19 +50,16 @@ export function quickSwipe(
     .trigger("pointerdown", startX, startY, {
       force: true,
       isPrimary: true,
-      pointerType: "touch",
       button: 0,
     })
     .trigger("pointermove", endX, startY, {
       force: true,
       isPrimary: true,
-      pointerType: "touch",
       button: 0,
     })
     .trigger("pointerup", endX, startY, {
       force: true,
       isPrimary: true,
-      pointerType: "touch",
       button: 0,
     });
 }

--- a/e2e/support/helpers/e2e-mobile-device-helpers.ts
+++ b/e2e/support/helpers/e2e-mobile-device-helpers.ts
@@ -1,3 +1,5 @@
+const LONG_PRESS_MS = 600;
+
 export function enableTouchEmulation() {
   cy.then(() =>
     Cypress.automation("remote:debugger:protocol", {
@@ -16,4 +18,48 @@ export function disableTouchEmulation() {
       params: { enabled: false },
     }),
   );
+}
+
+export function longPressAndDrag(
+  selector: string,
+  startX: number,
+  startY: number,
+  endX: number,
+  holdMs = LONG_PRESS_MS,
+) {
+  cy.findByTestId(selector).trigger("pointerdown", startX, startY, {
+    force: true,
+    isPrimary: true,
+    button: 0,
+  });
+
+  cy.wait(holdMs);
+
+  cy.findByTestId(selector)
+    .trigger("mousemove", endX, startY)
+    .trigger("mouseup", endX, startY);
+}
+
+export function quickSwipe(
+  selector: string,
+  startX: number,
+  startY: number,
+  endX: number,
+) {
+  cy.findByTestId(selector)
+    .trigger("pointerdown", startX, startY, {
+      force: true,
+      isPrimary: true,
+      button: 0,
+    })
+    .trigger("pointermove", endX, startY, {
+      force: true,
+      isPrimary: true,
+      button: 0,
+    })
+    .trigger("pointerup", endX, startY, {
+      force: true,
+      isPrimary: true,
+      button: 0,
+    });
 }

--- a/e2e/support/helpers/e2e-mobile-device-helpers.ts
+++ b/e2e/support/helpers/e2e-mobile-device-helpers.ts
@@ -30,14 +30,25 @@ export function longPressAndDrag(
   cy.findByTestId(selector).trigger("pointerdown", startX, startY, {
     force: true,
     isPrimary: true,
+    pointerType: "touch",
     button: 0,
   });
 
   cy.wait(holdMs);
 
   cy.findByTestId(selector)
-    .trigger("mousemove", endX, startY)
-    .trigger("mouseup", endX, startY);
+    .trigger("pointermove", endX, startY, {
+      force: true,
+      isPrimary: true,
+      pointerType: "touch",
+      button: 0,
+    })
+    .trigger("pointerup", endX, startY, {
+      force: true,
+      isPrimary: true,
+      pointerType: "touch",
+      button: 0,
+    });
 }
 
 export function quickSwipe(
@@ -50,16 +61,19 @@ export function quickSwipe(
     .trigger("pointerdown", startX, startY, {
       force: true,
       isPrimary: true,
+      pointerType: "touch",
       button: 0,
     })
     .trigger("pointermove", endX, startY, {
       force: true,
       isPrimary: true,
+      pointerType: "touch",
       button: 0,
     })
     .trigger("pointerup", endX, startY, {
       force: true,
       isPrimary: true,
+      pointerType: "touch",
       button: 0,
     });
 }

--- a/e2e/test-component/scenarios/embedding-sdk/touch-brush.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/touch-brush.cy.spec.tsx
@@ -1,3 +1,5 @@
+const { H } = cy;
+
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { createQuestion } from "e2e/support/helpers";
 import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
@@ -102,6 +104,39 @@ describe("scenarios > embedding-sdk > touch-brush", () => {
 
       getSdkRoot().within(() => {
         cy.findByText("Count by Product ID").should("be.visible");
+      });
+    });
+  });
+
+  describe("tap on data point", () => {
+    describe("touch device", () => {
+      beforeEach(() => {
+        cy.viewport("iphone-x");
+        enableTouchEmulation();
+      });
+
+      afterEach(() => {
+        disableTouchEmulation();
+      });
+
+      it("should open drill popover on regular tap (not long press)", () => {
+        mountInteractiveQuestion();
+        waitForChart();
+
+        H.cartesianChartCircle().first().click({ force: true });
+
+        H.popover().should("be.visible");
+      });
+    });
+
+    describe("desktop (non-touch)", () => {
+      it("should open drill popover on click", () => {
+        mountInteractiveQuestion();
+        waitForChart();
+
+        H.cartesianChartCircle().first().click({ force: true });
+
+        H.popover().should("be.visible");
       });
     });
   });

--- a/e2e/test-component/scenarios/embedding-sdk/touch-brush.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/touch-brush.cy.spec.tsx
@@ -19,8 +19,9 @@ const { ORDERS_ID, ORDERS } = SAMPLE_DATABASE;
 function waitForChart() {
   getSdkRoot().within(() => {
     echartsContainer().should("be.visible");
+    // Wait for ECharts to finish rendering data points.
+    echartsContainer().find("path").should("have.length.greaterThan", 0);
   });
-  cy.wait(200);
 }
 
 describe("scenarios > embedding-sdk > touch-brush", () => {
@@ -60,6 +61,7 @@ describe("scenarios > embedding-sdk > touch-brush", () => {
       longPressAndDrag("chart-container", 100, 150, 250);
 
       getSdkRoot().within(() => {
+        // We check a title of a new question that appears after a range selection
         cy.findByText("Count by Product ID").should("be.visible");
       });
     });

--- a/e2e/test-component/scenarios/embedding-sdk/touch-brush.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/touch-brush.cy.spec.tsx
@@ -77,21 +77,6 @@ describe("scenarios > embedding-sdk > touch-brush", () => {
         cy.findByText("Count by Product ID").should("not.exist");
       });
     });
-
-    it("should suppress context menu on the chart", () => {
-      mountInteractiveQuestion();
-      waitForChart();
-
-      cy.findByTestId("chart-container").then(($el) => {
-        const event = new Event("contextmenu", {
-          bubbles: true,
-          cancelable: true,
-        });
-        const prevented = !$el[0].dispatchEvent(event);
-
-        expect(prevented).to.be.true;
-      });
-    });
   });
 
   describe("desktop (non-touch)", () => {

--- a/e2e/test-component/scenarios/embedding-sdk/touch-brush.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/touch-brush.cy.spec.tsx
@@ -1,6 +1,12 @@
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { createQuestion } from "e2e/support/helpers";
 import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
+import {
+  disableTouchEmulation,
+  enableTouchEmulation,
+  longPressAndDrag,
+  quickSwipe,
+} from "e2e/support/helpers/e2e-mobile-device-helpers";
 import { echartsContainer } from "e2e/support/helpers/e2e-visual-tests-helpers";
 import { mountInteractiveQuestion } from "e2e/support/helpers/embedding-sdk-component-testing";
 import { signInAsAdminAndEnableEmbeddingSdk } from "e2e/support/helpers/embedding-sdk-testing";
@@ -8,109 +14,12 @@ import { mockAuthProviderAndJwtSignIn } from "e2e/support/helpers/embedding-sdk-
 
 const { ORDERS_ID, ORDERS } = SAMPLE_DATABASE;
 
-const LONG_PRESS_MS = 600;
-
-// ---------------------------------------------------------------------------
-// CDP touch helpers — dispatches real (trusted) touch events via the browser
-// ---------------------------------------------------------------------------
-
-function cdpTouch(
-  type: "touchStart" | "touchMove" | "touchEnd",
-  x?: number,
-  y?: number,
-) {
-  const touchPoints =
-    type === "touchEnd"
-      ? []
-      : [{ x: x!, y: y!, id: 0, radiusX: 1, radiusY: 1, force: 1 }];
-
-  return Cypress.automation("remote:debugger:protocol", {
-    command: "Input.dispatchTouchEvent",
-    params: { type, touchPoints },
-  });
-}
-
-/**
- * Real CDP touch long-press + horizontal drag.
- * Coordinates are absolute viewport pixels (use getBoundingClientRect).
- */
-function longPressAndDrag(
-  startX: number,
-  startY: number,
-  endX: number,
-  holdMs = LONG_PRESS_MS,
-) {
-  // Finger down
-  cy.then(() => cdpTouch("touchStart", startX, startY));
-
-  // Hold still
-  cy.wait(holdMs);
-
-  // Drag in steps for realistic gesture
-  const steps = 5;
-  for (let i = 1; i <= steps; i++) {
-    const x = Math.round(startX + ((endX - startX) * i) / steps);
-    cy.then(() => cdpTouch("touchMove", x, startY));
-    cy.wait(16);
-  }
-
-  // Lift finger
-  cy.then(() => cdpTouch("touchEnd"));
-}
-
-/**
- * Real CDP touch quick swipe (no hold).
- */
-function quickSwipe(startX: number, startY: number, endX: number) {
-  cy.then(() => cdpTouch("touchStart", startX, startY));
-
-  const steps = 5;
-  for (let i = 1; i <= steps; i++) {
-    const x = Math.round(startX + ((endX - startX) * i) / steps);
-    cy.then(() => cdpTouch("touchMove", x, startY));
-    cy.wait(16);
-  }
-
-  cy.then(() => cdpTouch("touchEnd"));
-}
-
-function enableTouchEmulation() {
-  Cypress.automation("remote:debugger:protocol", {
-    command: "Emulation.setTouchEmulationEnabled",
-    params: { enabled: true, maxTouchPoints: 5 },
-  });
-}
-
-function disableTouchEmulation() {
-  Cypress.automation("remote:debugger:protocol", {
-    command: "Emulation.setTouchEmulationEnabled",
-    params: { enabled: false, maxTouchPoints: 0 },
-  });
-}
-
 function waitForChart() {
   getSdkRoot().within(() => {
     echartsContainer().should("be.visible");
   });
   cy.wait(200);
 }
-
-/**
- * Get center coordinates of the chart container in viewport pixels.
- */
-function getChartCenter(): Cypress.Chainable<{ x: number; y: number }> {
-  return cy.findByTestId("chart-container").then(($el) => {
-    const rect = $el[0].getBoundingClientRect();
-    return {
-      x: Math.round(rect.left + rect.width / 2),
-      y: Math.round(rect.top + rect.height / 2),
-    };
-  });
-}
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
 
 describe("scenarios > embedding-sdk > touch-brush", () => {
   beforeEach(() => {
@@ -143,35 +52,26 @@ describe("scenarios > embedding-sdk > touch-brush", () => {
     });
 
     it("should activate brush on long press + horizontal drag", () => {
-      cy.intercept("POST", "/api/card/*/query").as("brushQuery");
-
       mountInteractiveQuestion();
-      // Initial query
-      cy.wait("@brushQuery");
       waitForChart();
 
-      getChartCenter().then(({ x, y }) => {
-        longPressAndDrag(x - 50, y, x + 50);
-      });
+      longPressAndDrag("chart-container", 100, 150, 250);
 
-      // Brush should trigger a second query with filter
-      cy.wait("@brushQuery").its("request.body.parameters").should("exist");
+      getSdkRoot().within(() => {
+        cy.findByText("Count by Product ID").should("be.visible");
+      });
     });
 
     it("should NOT trigger brush on quick horizontal swipe", () => {
-      cy.intercept("POST", "/api/card/*/query").as("brushQuery");
-
       mountInteractiveQuestion();
-      cy.wait("@brushQuery");
       waitForChart();
 
-      getChartCenter().then(({ x, y }) => {
-        quickSwipe(x - 50, y, x + 50);
-      });
+      quickSwipe("chart-container", 100, 150, 250);
 
-      // No second query — brush did not activate
       cy.wait(1000);
-      cy.get("@brushQuery.all").should("have.length", 1);
+      getSdkRoot().within(() => {
+        cy.findByText("Count by Product ID").should("not.exist");
+      });
     });
 
     it("should suppress context menu on the chart", () => {
@@ -197,10 +97,12 @@ describe("scenarios > embedding-sdk > touch-brush", () => {
 
       cy.findByTestId("query-visualization-root")
         .trigger("mousedown", 150, 150)
-        .trigger("mousemove", 150, 150)
+        .trigger("mousemove", 300, 150)
         .trigger("mouseup", 300, 150);
 
-      cy.findByTestId("filter-pill").should("exist");
+      getSdkRoot().within(() => {
+        cy.findByText("Count by Product ID").should("be.visible");
+      });
     });
   });
 });

--- a/e2e/test-component/scenarios/embedding-sdk/touch-brush.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/touch-brush.cy.spec.tsx
@@ -1,0 +1,206 @@
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import { createQuestion } from "e2e/support/helpers";
+import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
+import { echartsContainer } from "e2e/support/helpers/e2e-visual-tests-helpers";
+import { mountInteractiveQuestion } from "e2e/support/helpers/embedding-sdk-component-testing";
+import { signInAsAdminAndEnableEmbeddingSdk } from "e2e/support/helpers/embedding-sdk-testing";
+import { mockAuthProviderAndJwtSignIn } from "e2e/support/helpers/embedding-sdk-testing/embedding-sdk-helpers";
+
+const { ORDERS_ID, ORDERS } = SAMPLE_DATABASE;
+
+const LONG_PRESS_MS = 600;
+
+// ---------------------------------------------------------------------------
+// CDP touch helpers — dispatches real (trusted) touch events via the browser
+// ---------------------------------------------------------------------------
+
+function cdpTouch(
+  type: "touchStart" | "touchMove" | "touchEnd",
+  x?: number,
+  y?: number,
+) {
+  const touchPoints =
+    type === "touchEnd"
+      ? []
+      : [{ x: x!, y: y!, id: 0, radiusX: 1, radiusY: 1, force: 1 }];
+
+  return Cypress.automation("remote:debugger:protocol", {
+    command: "Input.dispatchTouchEvent",
+    params: { type, touchPoints },
+  });
+}
+
+/**
+ * Real CDP touch long-press + horizontal drag.
+ * Coordinates are absolute viewport pixels (use getBoundingClientRect).
+ */
+function longPressAndDrag(
+  startX: number,
+  startY: number,
+  endX: number,
+  holdMs = LONG_PRESS_MS,
+) {
+  // Finger down
+  cy.then(() => cdpTouch("touchStart", startX, startY));
+
+  // Hold still
+  cy.wait(holdMs);
+
+  // Drag in steps for realistic gesture
+  const steps = 5;
+  for (let i = 1; i <= steps; i++) {
+    const x = Math.round(startX + ((endX - startX) * i) / steps);
+    cy.then(() => cdpTouch("touchMove", x, startY));
+    cy.wait(16);
+  }
+
+  // Lift finger
+  cy.then(() => cdpTouch("touchEnd"));
+}
+
+/**
+ * Real CDP touch quick swipe (no hold).
+ */
+function quickSwipe(startX: number, startY: number, endX: number) {
+  cy.then(() => cdpTouch("touchStart", startX, startY));
+
+  const steps = 5;
+  for (let i = 1; i <= steps; i++) {
+    const x = Math.round(startX + ((endX - startX) * i) / steps);
+    cy.then(() => cdpTouch("touchMove", x, startY));
+    cy.wait(16);
+  }
+
+  cy.then(() => cdpTouch("touchEnd"));
+}
+
+function enableTouchEmulation() {
+  Cypress.automation("remote:debugger:protocol", {
+    command: "Emulation.setTouchEmulationEnabled",
+    params: { enabled: true, maxTouchPoints: 5 },
+  });
+}
+
+function disableTouchEmulation() {
+  Cypress.automation("remote:debugger:protocol", {
+    command: "Emulation.setTouchEmulationEnabled",
+    params: { enabled: false, maxTouchPoints: 0 },
+  });
+}
+
+function waitForChart() {
+  getSdkRoot().within(() => {
+    echartsContainer().should("be.visible");
+  });
+  cy.wait(200);
+}
+
+/**
+ * Get center coordinates of the chart container in viewport pixels.
+ */
+function getChartCenter(): Cypress.Chainable<{ x: number; y: number }> {
+  return cy.findByTestId("chart-container").then(($el) => {
+    const rect = $el[0].getBoundingClientRect();
+    return {
+      x: Math.round(rect.left + rect.width / 2),
+      y: Math.round(rect.top + rect.height / 2),
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("scenarios > embedding-sdk > touch-brush", () => {
+  beforeEach(() => {
+    signInAsAdminAndEnableEmbeddingSdk();
+
+    createQuestion({
+      name: "Line chart for brush test",
+      query: {
+        "source-table": ORDERS_ID,
+        aggregation: [["count"]],
+        breakout: [["field", ORDERS.PRODUCT_ID, null]],
+      },
+      display: "line",
+    }).then(({ body: question }) => {
+      cy.wrap(question.id).as("questionId");
+    });
+
+    cy.signOut();
+    mockAuthProviderAndJwtSignIn();
+  });
+
+  describe("touch device", () => {
+    beforeEach(() => {
+      cy.viewport("iphone-x");
+      enableTouchEmulation();
+    });
+
+    afterEach(() => {
+      disableTouchEmulation();
+    });
+
+    it("should activate brush on long press + horizontal drag", () => {
+      cy.intercept("POST", "/api/card/*/query").as("brushQuery");
+
+      mountInteractiveQuestion();
+      // Initial query
+      cy.wait("@brushQuery");
+      waitForChart();
+
+      getChartCenter().then(({ x, y }) => {
+        longPressAndDrag(x - 50, y, x + 50);
+      });
+
+      // Brush should trigger a second query with filter
+      cy.wait("@brushQuery").its("request.body.parameters").should("exist");
+    });
+
+    it("should NOT trigger brush on quick horizontal swipe", () => {
+      cy.intercept("POST", "/api/card/*/query").as("brushQuery");
+
+      mountInteractiveQuestion();
+      cy.wait("@brushQuery");
+      waitForChart();
+
+      getChartCenter().then(({ x, y }) => {
+        quickSwipe(x - 50, y, x + 50);
+      });
+
+      // No second query — brush did not activate
+      cy.wait(1000);
+      cy.get("@brushQuery.all").should("have.length", 1);
+    });
+
+    it("should suppress context menu on the chart", () => {
+      mountInteractiveQuestion();
+      waitForChart();
+
+      cy.findByTestId("chart-container").then(($el) => {
+        const event = new Event("contextmenu", {
+          bubbles: true,
+          cancelable: true,
+        });
+        const prevented = !$el[0].dispatchEvent(event);
+
+        expect(prevented).to.be.true;
+      });
+    });
+  });
+
+  describe("desktop (non-touch)", () => {
+    it("should trigger brush on regular mouse drag", () => {
+      mountInteractiveQuestion();
+      waitForChart();
+
+      cy.findByTestId("query-visualization-root")
+        .trigger("mousedown", 150, 150)
+        .trigger("mousemove", 150, 150)
+        .trigger("mouseup", 300, 150);
+
+      cy.findByTestId("filter-pill").should("exist");
+    });
+  });
+});

--- a/frontend/src/metabase/lib/browser.ts
+++ b/frontend/src/metabase/lib/browser.ts
@@ -48,5 +48,22 @@ export function isMac() {
   return Boolean(platform.match(/^Mac/));
 }
 
+export const isTouchDevice = () => {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  if (typeof window.matchMedia === "function") {
+    const hasCoarsePointer = window.matchMedia("(pointer: coarse)").matches;
+    const cannotHover = window.matchMedia("(hover: none)").matches;
+
+    if (hasCoarsePointer && cannotHover) {
+      return true;
+    }
+  }
+
+  return typeof navigator !== "undefined" && navigator.maxTouchPoints > 0;
+};
+
 export const METAKEY = isMac() ? "⌘" : "Ctrl";
 export const ALTKEY = isMac() ? "⌥" : "Alt";

--- a/frontend/src/metabase/lib/browser.ts
+++ b/frontend/src/metabase/lib/browser.ts
@@ -48,22 +48,5 @@ export function isMac() {
   return Boolean(platform.match(/^Mac/));
 }
 
-export const isTouchDevice = () => {
-  if (typeof window === "undefined") {
-    return false;
-  }
-
-  if (typeof window.matchMedia === "function") {
-    const hasCoarsePointer = window.matchMedia("(pointer: coarse)").matches;
-    const cannotHover = window.matchMedia("(hover: none)").matches;
-
-    if (hasCoarsePointer && cannotHover) {
-      return true;
-    }
-  }
-
-  return typeof navigator !== "undefined" && navigator.maxTouchPoints > 0;
-};
-
 export const METAKEY = isMac() ? "⌘" : "Ctrl";
 export const ALTKEY = isMac() ? "⌥" : "Alt";

--- a/frontend/src/metabase/visualizations/components/EChartsRenderer/EChartsRenderer.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/EChartsRenderer/EChartsRenderer.styled.tsx
@@ -5,8 +5,20 @@ export const EChartsRendererRoot = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  /* HACK: zrender adds user-select: none to the root svg element which prevents users from selecting text on charts */
+  /* Prevent the browser from selecting / highlighting the chart container
+     on long-press. Without this the browser claims the gesture for element
+     selection and swallows subsequent pointer events, blocking brush. */
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-touch-callout: none;
+  -webkit-tap-highlight-color: transparent;
+  /* zrender sets touch-action: none on the SVG which blocks all native
+     scrolling. We override with pan-y so vertical page scroll works on
+     touch devices while horizontal drags stay available for brush selection
+     (gated behind a long-press, see useTouchBrush). */
   & svg {
-    user-select: auto !important;
+    user-select: none !important;
+    -webkit-touch-callout: none !important;
+    touch-action: pan-y !important;
   }
 `;

--- a/frontend/src/metabase/visualizations/components/EChartsRenderer/EChartsRenderer.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/EChartsRenderer/EChartsRenderer.styled.tsx
@@ -5,9 +5,7 @@ export const EChartsRendererRoot = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  /* zrender adds user-select: none to the root svg element which prevents
-     users from selecting text on charts. Only restore on desktop — on touch
-     devices it causes unwanted text selection during gestures. */
+  /* HACK: zrender adds user-select: none to the root svg element which prevents users from selecting text on charts */
   @media (hover: hover) {
     & svg {
       user-select: auto !important;

--- a/frontend/src/metabase/visualizations/components/EChartsRenderer/EChartsRenderer.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/EChartsRenderer/EChartsRenderer.styled.tsx
@@ -5,20 +5,13 @@ export const EChartsRendererRoot = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  /* Prevent the browser from selecting / highlighting the chart container
-     on long-press. Without this the browser claims the gesture for element
-     selection and swallows subsequent pointer events, blocking brush. */
-  user-select: none;
-  -webkit-user-select: none;
-  -webkit-touch-callout: none;
-  -webkit-tap-highlight-color: transparent;
-  /* zrender sets touch-action: none on the SVG which blocks all native
-     scrolling. We override with pan-y so vertical page scroll works on
-     touch devices while horizontal drags stay available for brush selection
-     (gated behind a long-press, see useTouchBrush). */
+  /* HACK: zrender adds user-select: none to the root svg element which prevents users from selecting text on charts */
+  /* zrender also sets touch-action: none which blocks all native scrolling.
+     We override with auto so the browser handles scroll in all directions.
+     Brush selection is gated behind a long-press that calls preventDefault
+     on touchmove to reclaim the gesture from the browser (see useBrush). */
   & svg {
-    user-select: none !important;
-    -webkit-touch-callout: none !important;
-    touch-action: pan-y !important;
+    user-select: auto !important;
+    touch-action: auto !important;
   }
 `;

--- a/frontend/src/metabase/visualizations/components/EChartsRenderer/EChartsRenderer.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/EChartsRenderer/EChartsRenderer.styled.tsx
@@ -5,13 +5,11 @@ export const EChartsRendererRoot = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  /* HACK: zrender adds user-select: none to the root svg element which prevents users from selecting text on charts */
-  /* zrender also sets touch-action: none which blocks all native scrolling.
-     We override with auto so the browser handles scroll in all directions.
-     Brush selection is gated behind a long-press that calls preventDefault
-     on touchmove to reclaim the gesture from the browser (see useBrush). */
+  /* zrender sets touch-action: none on the SVG which blocks all native
+     scrolling. We override with auto so the browser handles scroll in all
+     directions. Brush selection is gated behind a long-press that calls
+     preventDefault on touchmove to reclaim the gesture (see useBrush). */
   & svg {
-    user-select: auto !important;
     touch-action: auto !important;
   }
 `;

--- a/frontend/src/metabase/visualizations/components/EChartsRenderer/EChartsRenderer.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/EChartsRenderer/EChartsRenderer.styled.tsx
@@ -5,11 +5,22 @@ export const EChartsRendererRoot = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
+  /* zrender adds user-select: none to the root svg element which prevents
+     users from selecting text on charts. Only restore on desktop — on touch
+     devices it causes unwanted text selection during gestures. */
+  @media (hover: hover) {
+    & svg {
+      user-select: auto !important;
+    }
+  }
+
   /* zrender sets touch-action: none on the SVG which blocks all native
-     scrolling. We override with auto so the browser handles scroll in all
-     directions. Brush selection is gated behind a long-press that calls
-     preventDefault on touchmove to reclaim the gesture (see useBrush). */
-  & svg {
-    touch-action: auto !important;
+     scrolling on touch devices. We override with auto so the browser handles
+     scroll in all directions. Brush selection is gated behind a long-press
+     that calls preventDefault on touchmove to reclaim the gesture (see useBrush). */
+  @media (hover: none) {
+    & svg {
+      touch-action: auto !important;
+    }
   }
 `;

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-brush.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-brush.ts
@@ -171,6 +171,11 @@ function useTouchBrush({
     // Save originals to restore on cleanup.
     const svg = containerEl.querySelector("svg");
 
+    // Removes highlight on tap on android
+    containerEl.style.setProperty("-webkit-tap-highlight-color", "transparent");
+
+    // Removes text selection on long tap
+    svg?.style.setProperty("user-select", "none");
     svg?.style.setProperty("-webkit-user-select", "none");
     svg?.style.setProperty("-webkit-touch-callout", "none");
 
@@ -255,6 +260,8 @@ function useTouchBrush({
       cancel();
       removeListeners();
 
+      containerEl.style.setProperty("-webkit-tap-highlight-color", "none");
+      svg?.style.setProperty("user-select", "none");
       svg?.style.setProperty("-webkit-user-select", "none");
       svg?.style.setProperty("-webkit-touch-callout", "none");
     };

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-brush.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-brush.ts
@@ -168,6 +168,22 @@ function useTouchBrush({
 
     disableBrush();
 
+    // Prevent selection highlight and callout on long-press (touch only).
+    // Applied as inline styles so desktop text selection is unaffected.
+    // Save originals to restore on cleanup.
+    const savedStyles = {
+      userSelect: containerEl.style.userSelect,
+      webkitTouchCallout: containerEl.style.getPropertyValue(
+        "-webkit-touch-callout",
+      ),
+      webkitTapHighlightColor: containerEl.style.getPropertyValue(
+        "-webkit-tap-highlight-color",
+      ),
+    };
+    containerEl.style.userSelect = "none";
+    containerEl.style.setProperty("-webkit-touch-callout", "none");
+    containerEl.style.setProperty("-webkit-tap-highlight-color", "transparent");
+
     const cancel = () => {
       clearTimeout(timerRef.current);
 
@@ -228,6 +244,16 @@ function useTouchBrush({
     const onContextMenu = (e: Event) => e.preventDefault();
     containerEl.addEventListener("contextmenu", onContextMenu);
 
+    // Prevent browser scroll ONLY when brush is active (after long-press).
+    // Must be non-passive to allow preventDefault(). Before the long-press
+    // fires, touchmove is not prevented and the browser scrolls normally.
+    const onTouchMove = (e: TouchEvent) => {
+      if (activeRef.current) {
+        e.preventDefault();
+      }
+    };
+    containerEl.addEventListener("touchmove", onTouchMove, { passive: false });
+
     const removeListeners = addPointerListeners(containerEl, {
       pointerdown: onPointerDown,
       pointermove: onPointerMove,
@@ -239,6 +265,16 @@ function useTouchBrush({
       cancel();
       removeListeners();
       containerEl.removeEventListener("contextmenu", onContextMenu);
+      containerEl.removeEventListener("touchmove", onTouchMove);
+      containerEl.style.userSelect = savedStyles.userSelect;
+      containerEl.style.setProperty(
+        "-webkit-touch-callout",
+        savedStyles.webkitTouchCallout,
+      );
+      containerEl.style.setProperty(
+        "-webkit-tap-highlight-color",
+        savedStyles.webkitTapHighlightColor,
+      );
     };
   }, [
     containerEl,

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-brush.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-brush.ts
@@ -260,10 +260,6 @@ function useTouchBrush({
       }
     };
 
-    // Prevent native long-press context menu on touch devices.
-    const onContextMenu = (e: Event) => e.preventDefault();
-    containerEl.addEventListener("contextmenu", onContextMenu);
-
     // Prevent browser scroll ONLY when brush is active (after long-press).
     // Must be non-passive to allow preventDefault(). Before the long-press
     // fires, touchmove is not prevented and the browser scrolls normally.
@@ -284,7 +280,6 @@ function useTouchBrush({
     return () => {
       cancel();
       removeListeners();
-      containerEl.removeEventListener("contextmenu", onContextMenu);
       containerEl.removeEventListener("touchmove", onTouchMove);
       containerEl.style.setProperty(
         "-webkit-user-select",

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-brush.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-brush.ts
@@ -8,14 +8,12 @@ import {
   useState,
 } from "react";
 
+import { isTouchDevice } from "metabase/lib/browser";
+
 const LONG_PRESS_DURATION_MS = 500;
 const TOUCH_MOVE_THRESHOLD_PX = 10;
 
 type Point = { x: number; y: number };
-
-export const isTouchDevice = () =>
-  typeof window !== "undefined" &&
-  ("ontouchstart" in window || navigator.maxTouchPoints > 0);
 
 export const hasMovedBeyondThreshold = (
   start: Point,
@@ -202,21 +200,35 @@ function useTouchBrush({
       svg.style.setProperty("-webkit-touch-callout", "none");
     }
 
+    let activePointerId: number | null = null;
+
     const cancel = () => {
       clearTimeout(timerRef.current);
 
       timerRef.current = undefined;
       startRef.current = null;
+      activePointerId = null;
     };
 
     const onPointerDown = (event: PointerEvent) => {
+      if (!event.isPrimary || event.pointerType !== "touch") {
+        return;
+      }
+
+      cancel();
+
       if (activeRef.current) {
         return;
       }
 
+      activePointerId = event.pointerId;
       startRef.current = { x: event.clientX, y: event.clientY };
 
+      const pointerId = event.pointerId;
       timerRef.current = setTimeout(() => {
+        if (pointerId !== activePointerId) {
+          return;
+        }
         activeRef.current = true;
         enableBrush();
 

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-brush.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-brush.ts
@@ -1,0 +1,251 @@
+import type { EChartsType } from "echarts/core";
+import {
+  type MutableRefObject,
+  type RefObject,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+
+const LONG_PRESS_DURATION_MS = 500;
+const TOUCH_MOVE_THRESHOLD_PX = 10;
+
+type Point = { x: number; y: number };
+
+export const isTouchDevice = () =>
+  typeof window !== "undefined" &&
+  ("ontouchstart" in window || navigator.maxTouchPoints > 0);
+
+export const hasMovedBeyondThreshold = (
+  start: Point,
+  current: Point,
+  threshold = TOUCH_MOVE_THRESHOLD_PX,
+) => {
+  const dx = current.x - start.x;
+  const dy = current.y - start.y;
+
+  return dx * dx + dy * dy > threshold * threshold;
+};
+
+export const createZrenderMousedownEvent = (
+  point: Point,
+  containerRect: DOMRect,
+) => ({
+  offsetX: point.x - containerRect.left,
+  offsetY: point.y - containerRect.top,
+  target: null,
+  event: {
+    preventDefault: () => {},
+  },
+});
+
+const addPointerListeners = (
+  el: HTMLElement,
+  listeners: Record<string, (e: PointerEvent) => void>,
+) => {
+  for (const [event, handler] of Object.entries(listeners)) {
+    el.addEventListener(event, handler as EventListener);
+  }
+
+  return () => {
+    for (const [event, handler] of Object.entries(listeners)) {
+      el.removeEventListener(event, handler as EventListener);
+    }
+  };
+};
+
+/**
+ * Manages brush (range selection) for cartesian charts.
+ *
+ * Delegates to `useDesktopBrush` or `useTouchBrush` depending on device.
+ */
+export const useBrush = (
+  chartRef: MutableRefObject<EChartsType | undefined>,
+  containerRef: RefObject<HTMLDivElement>,
+  canBrushChart: boolean,
+  isBrushable: boolean,
+  // ECharts option object — used as a signal dep to re-enable brush after
+  // chart model changes (ECharts resets the cursor state on re-render).
+  option?: unknown,
+) => {
+  const isTouch = useRef(isTouchDevice()).current;
+
+  const enableBrush = useCallback(() => {
+    chartRef.current?.dispatchAction({
+      type: "takeGlobalCursor",
+      key: "brush",
+      brushOption: { brushType: "lineX", brushMode: "single" },
+    });
+  }, [chartRef]);
+
+  const disableBrush = useCallback(() => {
+    chartRef.current?.dispatchAction({ type: "takeGlobalCursor" });
+  }, [chartRef]);
+
+  useDesktopBrush({ isTouch, isBrushable, enableBrush, disableBrush, option });
+  useTouchBrush({
+    chartRef,
+    containerRef,
+    isTouch,
+    canBrushChart,
+    enableBrush,
+    disableBrush,
+  });
+};
+
+/** Desktop: brush is always on while `isBrushable` is true. */
+function useDesktopBrush({
+  isTouch,
+  isBrushable,
+  enableBrush,
+  disableBrush,
+  option,
+}: {
+  isTouch: boolean;
+  isBrushable: boolean;
+  enableBrush: () => void;
+  disableBrush: () => void;
+  option?: unknown;
+}) {
+  useEffect(() => {
+    if (isTouch) {
+      return;
+    }
+
+    const timeout = setTimeout(() => {
+      if (isBrushable) {
+        enableBrush();
+      } else {
+        disableBrush();
+      }
+    }, 0);
+
+    return () => clearTimeout(timeout);
+  }, [isBrushable, isTouch, enableBrush, disableBrush, option]);
+}
+
+/**
+ * Touch: long press activates brush for a single gesture.
+ * The user continues dragging horizontally to select a range, and brush
+ * is deactivated on pointer up.
+ */
+function useTouchBrush({
+  chartRef,
+  containerRef,
+  isTouch,
+  canBrushChart,
+  enableBrush,
+  disableBrush,
+}: {
+  chartRef: MutableRefObject<EChartsType | undefined>;
+  containerRef: RefObject<HTMLDivElement>;
+  isTouch: boolean;
+  canBrushChart: boolean;
+  enableBrush: () => void;
+  disableBrush: () => void;
+}) {
+  const timerRef = useRef<ReturnType<typeof setTimeout>>();
+  const startRef = useRef<Point | null>(null);
+  const activeRef = useRef(false);
+
+  // Track container element via state so the effect re-runs once when the
+  // ref becomes available (ExplicitSize hasn't measured on first render).
+  const [containerEl, setContainerEl] = useState<HTMLDivElement | null>(null);
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally no deps: syncs ref → state on every render
+  useEffect(() => {
+    const container = containerRef.current;
+
+    if (container && container !== containerEl) {
+      setContainerEl(container);
+    }
+  });
+
+  useEffect(() => {
+    if (!containerEl || !canBrushChart || !isTouch) {
+      return;
+    }
+
+    disableBrush();
+
+    const cancel = () => {
+      clearTimeout(timerRef.current);
+
+      timerRef.current = undefined;
+      startRef.current = null;
+    };
+
+    const onPointerDown = (event: PointerEvent) => {
+      if (activeRef.current) {
+        return;
+      }
+
+      startRef.current = { x: event.clientX, y: event.clientY };
+
+      timerRef.current = setTimeout(() => {
+        activeRef.current = true;
+        enableBrush();
+
+        // Trigger mousedown directly on zrender's internal event bus.
+        // BrushController missed the real pointerdown (brush wasn't enabled
+        // yet), so we feed it the start position to anchor the selection.
+        const zrender = chartRef.current?.getZr();
+
+        if (zrender && startRef.current) {
+          zrender.trigger(
+            "mousedown",
+            createZrenderMousedownEvent(
+              startRef.current,
+              containerEl.getBoundingClientRect(),
+            ),
+          );
+        }
+      }, LONG_PRESS_DURATION_MS);
+    };
+
+    const onPointerMove = (event: PointerEvent) => {
+      if (!startRef.current || activeRef.current) {
+        return;
+      }
+
+      if (hasMovedBeyondThreshold(startRef.current, event)) {
+        cancel();
+      }
+    };
+
+    const onPointerEnd = () => {
+      cancel();
+
+      if (activeRef.current) {
+        activeRef.current = false;
+
+        // Defer so pointerup → brushEnd chain completes first.
+        setTimeout(disableBrush, 0);
+      }
+    };
+
+    // Prevent native long-press context menu on touch devices.
+    const onContextMenu = (e: Event) => e.preventDefault();
+    containerEl.addEventListener("contextmenu", onContextMenu);
+
+    const removeListeners = addPointerListeners(containerEl, {
+      pointerdown: onPointerDown,
+      pointermove: onPointerMove,
+      pointerup: onPointerEnd,
+      pointercancel: onPointerEnd,
+    });
+
+    return () => {
+      cancel();
+      removeListeners();
+      containerEl.removeEventListener("contextmenu", onContextMenu);
+    };
+  }, [
+    containerEl,
+    chartRef,
+    canBrushChart,
+    isTouch,
+    enableBrush,
+    disableBrush,
+  ]);
+}

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-brush.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-brush.ts
@@ -171,34 +171,8 @@ function useTouchBrush({
     // Save originals to restore on cleanup.
     const svg = containerEl.querySelector("svg");
 
-    const savedContainerStyles = {
-      webkitUserSelect: containerEl.style.getPropertyValue(
-        "-webkit-user-select",
-      ),
-      webkitTouchCallout: containerEl.style.getPropertyValue(
-        "-webkit-touch-callout",
-      ),
-      webkitTapHighlightColor: containerEl.style.getPropertyValue(
-        "-webkit-tap-highlight-color",
-      ),
-    };
-    const savedSvgStyles = svg
-      ? {
-          webkitUserSelect: svg.style.getPropertyValue("-webkit-user-select"),
-          webkitTouchCallout: svg.style.getPropertyValue(
-            "-webkit-touch-callout",
-          ),
-        }
-      : null;
-
-    containerEl.style.setProperty("-webkit-user-select", "none");
-    containerEl.style.setProperty("-webkit-touch-callout", "none");
-    containerEl.style.setProperty("-webkit-tap-highlight-color", "transparent");
-
-    if (svg) {
-      svg.style.setProperty("-webkit-user-select", "none");
-      svg.style.setProperty("-webkit-touch-callout", "none");
-    }
+    svg?.style.setProperty("-webkit-user-select", "none");
+    svg?.style.setProperty("-webkit-touch-callout", "none");
 
     const cancel = () => {
       clearTimeout(timerRef.current);
@@ -280,30 +254,9 @@ function useTouchBrush({
     return () => {
       cancel();
       removeListeners();
-      containerEl.removeEventListener("touchmove", onTouchMove);
-      containerEl.style.setProperty(
-        "-webkit-user-select",
-        savedContainerStyles.webkitUserSelect,
-      );
-      containerEl.style.setProperty(
-        "-webkit-touch-callout",
-        savedContainerStyles.webkitTouchCallout,
-      );
-      containerEl.style.setProperty(
-        "-webkit-tap-highlight-color",
-        savedContainerStyles.webkitTapHighlightColor,
-      );
 
-      if (svg && savedSvgStyles) {
-        svg.style.setProperty(
-          "-webkit-user-select",
-          savedSvgStyles.webkitUserSelect,
-        );
-        svg.style.setProperty(
-          "-webkit-touch-callout",
-          savedSvgStyles.webkitTouchCallout,
-        );
-      }
+      svg?.style.setProperty("-webkit-user-select", "none");
+      svg?.style.setProperty("-webkit-touch-callout", "none");
     };
   }, [
     containerEl,

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-brush.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-brush.ts
@@ -168,11 +168,15 @@ function useTouchBrush({
 
     disableBrush();
 
-    // Prevent selection highlight and callout on long-press (touch only).
-    // Applied as inline styles so desktop text selection is unaffected.
+    // Prevent selection highlight, callout, and tap highlight on long-press.
+    // Applied as inline styles so only brushable charts on touch are affected.
     // Save originals to restore on cleanup.
-    const savedStyles = {
-      userSelect: containerEl.style.userSelect,
+    const svg = containerEl.querySelector("svg");
+
+    const savedContainerStyles = {
+      webkitUserSelect: containerEl.style.getPropertyValue(
+        "-webkit-user-select",
+      ),
       webkitTouchCallout: containerEl.style.getPropertyValue(
         "-webkit-touch-callout",
       ),
@@ -180,9 +184,23 @@ function useTouchBrush({
         "-webkit-tap-highlight-color",
       ),
     };
-    containerEl.style.userSelect = "none";
+    const savedSvgStyles = svg
+      ? {
+          webkitUserSelect: svg.style.getPropertyValue("-webkit-user-select"),
+          webkitTouchCallout: svg.style.getPropertyValue(
+            "-webkit-touch-callout",
+          ),
+        }
+      : null;
+
+    containerEl.style.setProperty("-webkit-user-select", "none");
     containerEl.style.setProperty("-webkit-touch-callout", "none");
     containerEl.style.setProperty("-webkit-tap-highlight-color", "transparent");
+
+    if (svg) {
+      svg.style.setProperty("-webkit-user-select", "none");
+      svg.style.setProperty("-webkit-touch-callout", "none");
+    }
 
     const cancel = () => {
       clearTimeout(timerRef.current);
@@ -266,15 +284,29 @@ function useTouchBrush({
       removeListeners();
       containerEl.removeEventListener("contextmenu", onContextMenu);
       containerEl.removeEventListener("touchmove", onTouchMove);
-      containerEl.style.userSelect = savedStyles.userSelect;
+      containerEl.style.setProperty(
+        "-webkit-user-select",
+        savedContainerStyles.webkitUserSelect,
+      );
       containerEl.style.setProperty(
         "-webkit-touch-callout",
-        savedStyles.webkitTouchCallout,
+        savedContainerStyles.webkitTouchCallout,
       );
       containerEl.style.setProperty(
         "-webkit-tap-highlight-color",
-        savedStyles.webkitTapHighlightColor,
+        savedContainerStyles.webkitTapHighlightColor,
       );
+
+      if (svg && savedSvgStyles) {
+        svg.style.setProperty(
+          "-webkit-user-select",
+          savedSvgStyles.webkitUserSelect,
+        );
+        svg.style.setProperty(
+          "-webkit-touch-callout",
+          savedSvgStyles.webkitTouchCallout,
+        );
+      }
     };
   }, [
     containerEl,

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-brush.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-brush.ts
@@ -265,7 +265,11 @@ function useTouchBrush({
       if (activeRef.current) {
         activeRef.current = false;
 
-        // Defer so pointerup → brushEnd chain completes first.
+        // ECharts processes pointerup synchronously through its DOM handler
+        // chain (zrender pointerup → mouseup → brush end). All of this runs
+        // in the current microtask before any setTimeout(0) callback fires,
+        // so deferring by one macrotask is enough to guarantee brushEnd has
+        // already completed.
         setTimeout(disableBrush, 0);
       }
     };

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-brush.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-brush.ts
@@ -8,12 +8,14 @@ import {
   useState,
 } from "react";
 
-import { isTouchDevice } from "metabase/lib/browser";
-
 const LONG_PRESS_DURATION_MS = 500;
 const TOUCH_MOVE_THRESHOLD_PX = 10;
 
 type Point = { x: number; y: number };
+
+export const isTouchDevice = () =>
+  typeof window !== "undefined" &&
+  ("ontouchstart" in window || navigator.maxTouchPoints > 0);
 
 export const hasMovedBeyondThreshold = (
   start: Point,
@@ -200,35 +202,21 @@ function useTouchBrush({
       svg.style.setProperty("-webkit-touch-callout", "none");
     }
 
-    let activePointerId: number | null = null;
-
     const cancel = () => {
       clearTimeout(timerRef.current);
 
       timerRef.current = undefined;
       startRef.current = null;
-      activePointerId = null;
     };
 
     const onPointerDown = (event: PointerEvent) => {
-      if (!event.isPrimary || event.pointerType !== "touch") {
-        return;
-      }
-
-      cancel();
-
       if (activeRef.current) {
         return;
       }
 
-      activePointerId = event.pointerId;
       startRef.current = { x: event.clientX, y: event.clientY };
 
-      const pointerId = event.pointerId;
       timerRef.current = setTimeout(() => {
-        if (pointerId !== activePointerId) {
-          return;
-        }
         activeRef.current = true;
         enableBrush();
 

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-brush.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-brush.ts
@@ -8,14 +8,12 @@ import {
   useState,
 } from "react";
 
+import { isTouchDevice } from "metabase/lib/browser";
+
 const LONG_PRESS_DURATION_MS = 500;
 const TOUCH_MOVE_THRESHOLD_PX = 10;
 
 type Point = { x: number; y: number };
-
-export const isTouchDevice = () =>
-  typeof window !== "undefined" &&
-  ("ontouchstart" in window || navigator.maxTouchPoints > 0);
 
 export const hasMovedBeyondThreshold = (
   start: Point,

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-brush.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-brush.unit.spec.ts
@@ -333,15 +333,6 @@ describe("use-brush", () => {
 
         expect(touchmove.defaultPrevented).toBe(true);
       });
-
-      it("prevents context menu on the container", () => {
-        const { el } = setupTouchBrush();
-
-        const event = new Event("contextmenu", { cancelable: true });
-        el.dispatchEvent(event);
-
-        expect(event.defaultPrevented).toBe(true);
-      });
     });
   });
 });

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-brush.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-brush.unit.spec.ts
@@ -283,6 +283,30 @@ describe("use-brush", () => {
         expect(dispatchAction).not.toHaveBeenCalled();
       });
 
+      it("allows scroll (touchmove) before long press", () => {
+        const { el } = setupTouchBrush();
+
+        firePointer(el, "pointerdown", { clientX: 100, clientY: 100 });
+        act(() => jest.advanceTimersByTime(200));
+
+        const touchmove = new Event("touchmove", { cancelable: true });
+        el.dispatchEvent(touchmove);
+
+        expect(touchmove.defaultPrevented).toBe(false);
+      });
+
+      it("prevents scroll (touchmove) after long press", () => {
+        const { el } = setupTouchBrush();
+
+        firePointer(el, "pointerdown", { clientX: 100, clientY: 100 });
+        act(() => jest.advanceTimersByTime(500));
+
+        const touchmove = new Event("touchmove", { cancelable: true });
+        el.dispatchEvent(touchmove);
+
+        expect(touchmove.defaultPrevented).toBe(true);
+      });
+
       it("prevents context menu on the container", () => {
         const { el } = setupTouchBrush();
 

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-brush.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-brush.unit.spec.ts
@@ -1,0 +1,296 @@
+import { act, renderHook } from "@testing-library/react";
+import type { EChartsType } from "echarts/core";
+import type { MutableRefObject, RefObject } from "react";
+
+import {
+  createZrenderMousedownEvent,
+  hasMovedBeyondThreshold,
+  isTouchDevice,
+  useBrush,
+} from "./use-brush";
+
+class PointerEventPolyfill extends MouseEvent {
+  readonly pointerType: string;
+
+  constructor(type: string, init: PointerEventInit = {}) {
+    super(type, init);
+
+    this.pointerType = init.pointerType ?? "";
+  }
+}
+
+if (typeof globalThis.PointerEvent === "undefined") {
+  (globalThis as any).PointerEvent = PointerEventPolyfill;
+}
+
+const createMockChartRef = () => {
+  const dispatchAction = jest.fn();
+  const trigger = jest.fn();
+  const getZrender = jest.fn(() => ({ trigger }));
+  const chartRef = {
+    current: { dispatchAction, getZr: getZrender } as unknown as EChartsType,
+  } as MutableRefObject<EChartsType | undefined>;
+
+  return { chartRef, dispatchAction, trigger };
+};
+
+const createMockContainerRef = () => {
+  const element = document.createElement("div");
+
+  element.getBoundingClientRect = jest.fn(
+    () => ({ left: 10, top: 20, width: 400, height: 300 }) as DOMRect,
+  );
+
+  const containerRef = { current: element } as RefObject<HTMLDivElement>;
+
+  return { containerRef, el: element };
+};
+
+const firePointer = (
+  element: HTMLElement,
+  type: string,
+  { clientX = 0, clientY = 0 }: { clientX?: number; clientY?: number } = {},
+) => {
+  element.dispatchEvent(
+    new PointerEvent(type, {
+      clientX,
+      clientY,
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+};
+
+const simulateTouch = () => {
+  (window as any).ontouchstart = null;
+};
+
+const simulateDesktop = () => {
+  delete (window as any).ontouchstart;
+  Object.defineProperty(navigator, "maxTouchPoints", {
+    value: 0,
+    configurable: true,
+  });
+};
+
+// Behavioral assertions — hide ECharts action payload details
+const expectBrushEnabled = (dispatchAction: jest.Mock) => {
+  expect(dispatchAction).toHaveBeenCalledWith(
+    expect.objectContaining({ type: "takeGlobalCursor", key: "brush" }),
+  );
+};
+
+const expectBrushDisabled = (dispatchAction: jest.Mock) => {
+  expect(dispatchAction).toHaveBeenCalledWith({ type: "takeGlobalCursor" });
+};
+
+const expectBrushNotEnabled = (dispatchAction: jest.Mock) => {
+  expect(dispatchAction).not.toHaveBeenCalledWith(
+    expect.objectContaining({ key: "brush" }),
+  );
+};
+
+/**
+ * Renders useBrush in touch mode, flushes the initial setup,
+ * and clears dispatchAction so tests only see subsequent calls.
+ */
+const setupTouchBrush = (canBrushChart = true, isBrushable = true) => {
+  const { chartRef, dispatchAction, trigger } = createMockChartRef();
+  const { containerRef, el } = createMockContainerRef();
+
+  renderHook(() =>
+    useBrush(chartRef, containerRef, canBrushChart, isBrushable),
+  );
+  act(() => jest.runAllTimers());
+  dispatchAction.mockClear();
+
+  return { el, dispatchAction, trigger };
+};
+
+describe("use-brush", () => {
+  describe("hasMovedBeyondThreshold", () => {
+    it.each([
+      { start: { x: 0, y: 0 }, current: { x: 5, y: 5 }, expected: false },
+      { start: { x: 0, y: 0 }, current: { x: 10, y: 10 }, expected: true },
+      { start: { x: 100, y: 100 }, current: { x: 85, y: 85 }, expected: true },
+      { start: { x: 0, y: 0 }, current: { x: 0, y: 0 }, expected: false },
+    ])(
+      "($start → $current) = $expected (default threshold)",
+      ({ start, current, expected }) => {
+        expect(hasMovedBeyondThreshold(start, current)).toBe(expected);
+      },
+    );
+
+    it.each([
+      {
+        start: { x: 0, y: 0 },
+        current: { x: 3, y: 3 },
+        threshold: 100,
+        expected: false,
+      },
+      {
+        start: { x: 0, y: 0 },
+        current: { x: 80, y: 80 },
+        threshold: 100,
+        expected: true,
+      },
+    ])(
+      "($start → $current, threshold=$threshold) = $expected",
+      ({ start, current, threshold, expected }) => {
+        expect(hasMovedBeyondThreshold(start, current, threshold)).toBe(
+          expected,
+        );
+      },
+    );
+  });
+
+  describe("createZrenderMousedownEvent", () => {
+    it("calculates correct offsets from client coords and rect", () => {
+      const rect = { left: 50, top: 100 } as DOMRect;
+      const { offsetX, offsetY, target, event } = createZrenderMousedownEvent(
+        { x: 150, y: 250 },
+        rect,
+      );
+
+      expect(offsetX).toBe(100);
+      expect(offsetY).toBe(150);
+      expect(target).toBeNull();
+      expect(event.preventDefault).toBeInstanceOf(Function);
+    });
+  });
+
+  describe("isTouchDevice", () => {
+    afterEach(() => {
+      delete (window as any).ontouchstart;
+    });
+
+    it("returns false when no touch support", () => {
+      simulateDesktop();
+      expect(isTouchDevice()).toBe(false);
+    });
+
+    it("returns true when ontouchstart exists", () => {
+      simulateTouch();
+      expect(isTouchDevice()).toBe(true);
+    });
+
+    it("returns true when maxTouchPoints > 0", () => {
+      delete (window as any).ontouchstart;
+      Object.defineProperty(navigator, "maxTouchPoints", {
+        value: 1,
+        configurable: true,
+      });
+      expect(isTouchDevice()).toBe(true);
+    });
+  });
+
+  describe("useBrush", () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+      delete (window as any).ontouchstart;
+    });
+
+    describe("desktop (non-touch)", () => {
+      beforeEach(simulateDesktop);
+
+      it("enables brush when isBrushable is true", () => {
+        const { chartRef, dispatchAction } = createMockChartRef();
+        const { containerRef } = createMockContainerRef();
+
+        renderHook(() => useBrush(chartRef, containerRef, true, true));
+        act(() => jest.runAllTimers());
+
+        expectBrushEnabled(dispatchAction);
+      });
+
+      it("disables brush when isBrushable is false", () => {
+        const { chartRef, dispatchAction } = createMockChartRef();
+        const { containerRef } = createMockContainerRef();
+
+        renderHook(() => useBrush(chartRef, containerRef, true, false));
+        act(() => jest.runAllTimers());
+
+        expectBrushDisabled(dispatchAction);
+      });
+    });
+
+    describe("touch", () => {
+      beforeEach(simulateTouch);
+
+      it("disables brush by default", () => {
+        const { chartRef, dispatchAction } = createMockChartRef();
+        const { containerRef } = createMockContainerRef();
+
+        renderHook(() => useBrush(chartRef, containerRef, true, true));
+        act(() => jest.runAllTimers());
+
+        expectBrushDisabled(dispatchAction);
+      });
+
+      it("enables brush after long press", () => {
+        const { el, dispatchAction } = setupTouchBrush();
+
+        firePointer(el, "pointerdown", { clientX: 100, clientY: 100 });
+        act(() => jest.advanceTimersByTime(500));
+
+        expectBrushEnabled(dispatchAction);
+      });
+
+      it("cancels long press on movement", () => {
+        const { el, dispatchAction } = setupTouchBrush();
+
+        firePointer(el, "pointerdown", { clientX: 100, clientY: 100 });
+        firePointer(el, "pointermove", { clientX: 150, clientY: 100 });
+        act(() => jest.advanceTimersByTime(500));
+
+        expectBrushNotEnabled(dispatchAction);
+      });
+
+      it("cancels long press on pointer up before timeout", () => {
+        const { el, dispatchAction } = setupTouchBrush();
+
+        firePointer(el, "pointerdown", { clientX: 100, clientY: 100 });
+        act(() => jest.advanceTimersByTime(200));
+        firePointer(el, "pointerup");
+        act(() => jest.advanceTimersByTime(300));
+
+        expectBrushNotEnabled(dispatchAction);
+      });
+
+      it("disables brush when finger is lifted after long press", () => {
+        const { el, dispatchAction } = setupTouchBrush();
+
+        firePointer(el, "pointerdown", { clientX: 100, clientY: 100 });
+        act(() => jest.advanceTimersByTime(500));
+        dispatchAction.mockClear();
+
+        firePointer(el, "pointerup");
+        act(() => jest.runAllTimers());
+
+        expectBrushDisabled(dispatchAction);
+      });
+
+      it("does not activate when chart does not support brush", () => {
+        const { el, dispatchAction } = setupTouchBrush(false, false);
+
+        firePointer(el, "pointerdown", { clientX: 100, clientY: 100 });
+        act(() => jest.advanceTimersByTime(500));
+
+        expect(dispatchAction).not.toHaveBeenCalled();
+      });
+
+      it("prevents context menu on the container", () => {
+        const { el } = setupTouchBrush();
+
+        const event = new Event("contextmenu", { cancelable: true });
+        el.dispatchEvent(event);
+
+        expect(event.defaultPrevented).toBe(true);
+      });
+    });
+  });
+});

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-brush.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-brush.unit.spec.ts
@@ -73,7 +73,6 @@ const simulateDesktop = () => {
   });
 };
 
-// Behavioral assertions — hide ECharts action payload details
 const expectBrushEnabled = (dispatchAction: jest.Mock) => {
   expect(dispatchAction).toHaveBeenCalledWith(
     expect.objectContaining({ type: "takeGlobalCursor", key: "brush" }),

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-brush.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-brush.unit.spec.ts
@@ -2,20 +2,25 @@ import { act, renderHook } from "@testing-library/react";
 import type { EChartsType } from "echarts/core";
 import type { MutableRefObject, RefObject } from "react";
 
+import { isTouchDevice } from "metabase/lib/browser";
+
 import {
   createZrenderMousedownEvent,
   hasMovedBeyondThreshold,
-  isTouchDevice,
   useBrush,
 } from "./use-brush";
 
 class PointerEventPolyfill extends MouseEvent {
   readonly pointerType: string;
+  readonly pointerId: number;
+  readonly isPrimary: boolean;
 
   constructor(type: string, init: PointerEventInit = {}) {
     super(type, init);
 
     this.pointerType = init.pointerType ?? "";
+    this.pointerId = init.pointerId ?? 0;
+    this.isPrimary = init.isPrimary ?? false;
   }
 }
 
@@ -57,12 +62,17 @@ const firePointer = (
       clientY,
       bubbles: true,
       cancelable: true,
+      pointerType: "touch",
+      isPrimary: true,
     }),
   );
 };
 
 const simulateTouch = () => {
-  (window as any).ontouchstart = null;
+  Object.defineProperty(navigator, "maxTouchPoints", {
+    value: 5,
+    configurable: true,
+  });
 };
 
 const simulateDesktop = () => {
@@ -159,8 +169,11 @@ describe("use-brush", () => {
   });
 
   describe("isTouchDevice", () => {
+    const originalMatchMedia = window.matchMedia;
+
     afterEach(() => {
       delete (window as any).ontouchstart;
+      window.matchMedia = originalMatchMedia;
     });
 
     it("returns false when no touch support", () => {
@@ -168,9 +181,34 @@ describe("use-brush", () => {
       expect(isTouchDevice()).toBe(false);
     });
 
-    it("returns true when ontouchstart exists", () => {
-      simulateTouch();
+    it("returns true when coarse pointer and no hover", () => {
+      simulateDesktop();
+      window.matchMedia = jest.fn((query: string) => ({
+        matches: query === "(pointer: coarse)" || query === "(hover: none)",
+        media: query,
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      }));
       expect(isTouchDevice()).toBe(true);
+    });
+
+    it("returns false when fine pointer even with hover none", () => {
+      simulateDesktop();
+      window.matchMedia = jest.fn((query: string) => ({
+        matches: query === "(hover: none)",
+        media: query,
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      }));
+      expect(isTouchDevice()).toBe(false);
     });
 
     it("returns true when maxTouchPoints > 0", () => {

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-brush.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-brush.unit.spec.ts
@@ -76,7 +76,6 @@ const simulateTouch = () => {
 };
 
 const simulateDesktop = () => {
-  delete (window as any).ontouchstart;
   Object.defineProperty(navigator, "maxTouchPoints", {
     value: 0,
     configurable: true,
@@ -172,7 +171,6 @@ describe("use-brush", () => {
     const originalMatchMedia = window.matchMedia;
 
     afterEach(() => {
-      delete (window as any).ontouchstart;
       window.matchMedia = originalMatchMedia;
     });
 
@@ -212,7 +210,6 @@ describe("use-brush", () => {
     });
 
     it("returns true when maxTouchPoints > 0", () => {
-      delete (window as any).ontouchstart;
       Object.defineProperty(navigator, "maxTouchPoints", {
         value: 1,
         configurable: true,
@@ -228,7 +225,6 @@ describe("use-brush", () => {
 
     afterEach(() => {
       jest.useRealTimers();
-      delete (window as any).ontouchstart;
     });
 
     describe("desktop (non-touch)", () => {

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-brush.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-brush.unit.spec.ts
@@ -2,25 +2,20 @@ import { act, renderHook } from "@testing-library/react";
 import type { EChartsType } from "echarts/core";
 import type { MutableRefObject, RefObject } from "react";
 
-import { isTouchDevice } from "metabase/lib/browser";
-
 import {
   createZrenderMousedownEvent,
   hasMovedBeyondThreshold,
+  isTouchDevice,
   useBrush,
 } from "./use-brush";
 
 class PointerEventPolyfill extends MouseEvent {
   readonly pointerType: string;
-  readonly pointerId: number;
-  readonly isPrimary: boolean;
 
   constructor(type: string, init: PointerEventInit = {}) {
     super(type, init);
 
     this.pointerType = init.pointerType ?? "";
-    this.pointerId = init.pointerId ?? 0;
-    this.isPrimary = init.isPrimary ?? false;
   }
 }
 
@@ -62,17 +57,12 @@ const firePointer = (
       clientY,
       bubbles: true,
       cancelable: true,
-      pointerType: "touch",
-      isPrimary: true,
     }),
   );
 };
 
 const simulateTouch = () => {
-  Object.defineProperty(navigator, "maxTouchPoints", {
-    value: 5,
-    configurable: true,
-  });
+  (window as any).ontouchstart = null;
 };
 
 const simulateDesktop = () => {
@@ -168,8 +158,6 @@ describe("use-brush", () => {
   });
 
   describe("isTouchDevice", () => {
-    const originalMatchMedia = window.matchMedia;
-
     afterEach(() => {
       window.matchMedia = originalMatchMedia;
     });
@@ -179,34 +167,9 @@ describe("use-brush", () => {
       expect(isTouchDevice()).toBe(false);
     });
 
-    it("returns true when coarse pointer and no hover", () => {
-      simulateDesktop();
-      window.matchMedia = jest.fn((query: string) => ({
-        matches: query === "(pointer: coarse)" || query === "(hover: none)",
-        media: query,
-        onchange: null,
-        addListener: jest.fn(),
-        removeListener: jest.fn(),
-        addEventListener: jest.fn(),
-        removeEventListener: jest.fn(),
-        dispatchEvent: jest.fn(),
-      }));
+    it("returns true when ontouchstart exists", () => {
+      simulateTouch();
       expect(isTouchDevice()).toBe(true);
-    });
-
-    it("returns false when fine pointer even with hover none", () => {
-      simulateDesktop();
-      window.matchMedia = jest.fn((query: string) => ({
-        matches: query === "(hover: none)",
-        media: query,
-        onchange: null,
-        addListener: jest.fn(),
-        removeListener: jest.fn(),
-        addEventListener: jest.fn(),
-        removeEventListener: jest.fn(),
-        dispatchEvent: jest.fn(),
-      }));
-      expect(isTouchDevice()).toBe(false);
     });
 
     it("returns true when maxTouchPoints > 0", () => {

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-brush.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-brush.unit.spec.ts
@@ -2,10 +2,11 @@ import { act, renderHook } from "@testing-library/react";
 import type { EChartsType } from "echarts/core";
 import type { MutableRefObject, RefObject } from "react";
 
+import { isTouchDevice } from "metabase/lib/browser";
+
 import {
   createZrenderMousedownEvent,
   hasMovedBeyondThreshold,
-  isTouchDevice,
   useBrush,
 } from "./use-brush";
 
@@ -62,7 +63,10 @@ const firePointer = (
 };
 
 const simulateTouch = () => {
-  (window as any).ontouchstart = null;
+  Object.defineProperty(navigator, "maxTouchPoints", {
+    value: 5,
+    configurable: true,
+  });
 };
 
 const simulateDesktop = () => {
@@ -158,6 +162,8 @@ describe("use-brush", () => {
   });
 
   describe("isTouchDevice", () => {
+    const originalMatchMedia = window.matchMedia;
+
     afterEach(() => {
       window.matchMedia = originalMatchMedia;
     });
@@ -167,9 +173,34 @@ describe("use-brush", () => {
       expect(isTouchDevice()).toBe(false);
     });
 
-    it("returns true when ontouchstart exists", () => {
-      simulateTouch();
+    it("returns true when coarse pointer and no hover", () => {
+      simulateDesktop();
+      window.matchMedia = jest.fn((query: string) => ({
+        matches: query === "(pointer: coarse)" || query === "(hover: none)",
+        media: query,
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      }));
       expect(isTouchDevice()).toBe(true);
+    });
+
+    it("returns false when fine pointer even with hover none", () => {
+      simulateDesktop();
+      window.matchMedia = jest.fn((query: string) => ({
+        matches: query === "(hover: none)",
+        media: query,
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      }));
+      expect(isTouchDevice()).toBe(false);
     });
 
     it("returns true when maxTouchPoints > 0", () => {

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
@@ -43,6 +43,7 @@ import {
 import { getVisualizerSeriesCardIndex } from "metabase/visualizer/utils";
 import type { CardId } from "metabase-types/api";
 
+import { useBrush } from "./use-brush";
 import { useTooltipMouseLeave } from "./use-tooltip-mouse-leave";
 import { getHoveredEChartsSeriesDataKeyAndIndex } from "./utils";
 
@@ -356,42 +357,15 @@ export const useChartEvents = (
 
   useClickedStateTooltipSync(chartRef.current, clicked);
 
-  // In order to keep brushing always enabled we have to re-enable it on every model change
-  useEffect(
-    function toggleBrushing() {
-      const shouldEnableBrushing =
-        canBrush(rawSeries, settings, onChangeCardAndRun, onBrush) &&
-        !hovered &&
-        !clicked;
-
-      setTimeout(() => {
-        if (shouldEnableBrushing) {
-          chartRef.current?.dispatchAction({
-            type: "takeGlobalCursor",
-            key: "brush",
-            brushOption: {
-              brushType: "lineX",
-              brushMode: "single",
-            },
-          });
-        } else {
-          chartRef.current?.dispatchAction({
-            type: "takeGlobalCursor",
-          });
-        }
-      }, 0);
-    },
-    [
-      chartRef,
-      hovered,
-      onChangeCardAndRun,
-      onBrush,
-      option,
-      rawSeries,
-      settings,
-      clicked,
-    ],
+  const canBrushChart = canBrush(
+    rawSeries,
+    settings,
+    onChangeCardAndRun,
+    onBrush,
   );
+  const isBrushable = canBrushChart && !hovered && !clicked;
+
+  useBrush(chartRef, containerRef, canBrushChart, isBrushable, option);
 
   const onSelectSeries = useCallback(
     (event: React.MouseEvent, seriesIndex: number) => {


### PR DESCRIPTION
Improve mobile range selection experience for visualizations

On mobile devices we have a UX issue, when a user tries to scroll a page horizontally via a swipe - it selects a range on a chart instead.

This PR changes the behavior on mobile devices both for main app and embedding:
- short swipe - scroll
- long touch (500ms) + swipe - range selection.


The 500ms threshold is under the question, i can set 350ms or so.

Also i initially wanted to add a haptic feedback after a long touch, but it is not supported for such interactions.

This PR MUST NOT affect regular desktop behavior in any case, if it does - it's a bug.

Video before:

https://github.com/user-attachments/assets/e372bdba-35e7-4bc1-a940-19b74e376328

Video after:

https://github.com/user-attachments/assets/7bf5b816-a635-46c5-b9dd-44e345ceef9e



How to test:
- as it affects main app, the simpliest way is to test locally on the main app level
- just open any viz with range selection
- open devtools + mobile view
- ensure there  is a horizontal scrollbar for a viz (if it's not there - adjust CSS to have it)
- try to fast swipe - chart should be scrolled
- try to touch for 500ms+ and swipe - range selection should be applied
- test desktop behavior - NOTHING should be changed compared to master
- test click on a data point on mobile device - drill popup should be shown (its position may be wrong, it's a different issue)