### PR TITLE
Small positioning adjustments to the data studio nav bar

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data-studio/workspaces/components/WorkspaceSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/workspaces/components/WorkspaceSection.tsx
@@ -114,11 +114,15 @@ export function WorkspacesSection({ showLabel }: WorkspacesSectionProps) {
           className={cx(S.tab, { [S.selected]: isWorkspaceListPage })}
           component={ForwardRefLink}
           to={Urls.dataStudioWorkspaceList()}
-          p="0.75rem"
+          p="0.5rem"
           bdrs="md"
         >
-          <Flex align="center" justify="center">
-            <FixedSizeIcon name="git_branch" display="block" />
+          <Flex align="center" justify="center" w="100%">
+            <FixedSizeIcon
+              name="git_branch"
+              display="block"
+              c="text-secondary"
+            />
           </Flex>
         </UnstyledButton>
       </Tooltip>

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/workspaces/components/WorkspaceSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/workspaces/components/WorkspaceSection.tsx
@@ -114,7 +114,7 @@ export function WorkspacesSection({ showLabel }: WorkspacesSectionProps) {
           className={cx(S.tab, { [S.selected]: isWorkspaceListPage })}
           component={ForwardRefLink}
           to={Urls.dataStudioWorkspaceList()}
-          p="0.5rem"
+          p="sm"
           bdrs="md"
         >
           <Flex align="center" justify="center" w="100%">

--- a/frontend/src/metabase/data-studio/app/pages/DataStudioLayout/DataStudioLayout.module.css
+++ b/frontend/src/metabase/data-studio/app/pages/DataStudioLayout/DataStudioLayout.module.css
@@ -22,7 +22,6 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 0.5rem;
   width: 100%;
 
   &:hover {

--- a/frontend/src/metabase/data-studio/app/pages/DataStudioLayout/DataStudioLayout.module.css
+++ b/frontend/src/metabase/data-studio/app/pages/DataStudioLayout/DataStudioLayout.module.css
@@ -21,7 +21,9 @@
 .tab {
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: 0.5rem;
+  width: 100%;
 
   &:hover {
     background-color: var(--mb-color-background-hover);

--- a/frontend/src/metabase/data-studio/app/pages/DataStudioLayout/DataStudioLayout.tsx
+++ b/frontend/src/metabase/data-studio/app/pages/DataStudioLayout/DataStudioLayout.tsx
@@ -265,7 +265,8 @@ function DataStudioTab({
         className={cx(S.tab, { [S.selected]: isSelected })}
         component={ForwardRefLink}
         to={to}
-        p="0.5rem"
+        p="sm"
+        gap="sm"
         bdrs="md"
         aria-label={label}
         justify={showLabel ? "start" : "center"}

--- a/frontend/src/metabase/data-studio/app/pages/DataStudioLayout/DataStudioLayout.tsx
+++ b/frontend/src/metabase/data-studio/app/pages/DataStudioLayout/DataStudioLayout.tsx
@@ -261,13 +261,14 @@ function DataStudioTab({
       openDelay={TOOLTIP_OPEN_DELAY}
       disabled={showLabel}
     >
-      <Box
+      <Flex
         className={cx(S.tab, { [S.selected]: isSelected })}
         component={ForwardRefLink}
         to={to}
         p="0.5rem"
         bdrs="md"
         aria-label={label}
+        justify={showLabel ? "start" : "center"}
       >
         <FixedSizeIcon name={icon} display="block" className={S.icon} />
         {showLabel && <Text lh="sm">{label}</Text>}
@@ -279,7 +280,7 @@ function DataStudioTab({
             {effectiveRightSection}
           </Box>
         )}
-      </Box>
+      </Flex>
     </Tooltip>
   );
 }
@@ -302,10 +303,9 @@ function DataStudioNavbarToggle({
   return (
     <Flex
       align="center"
-      justify="space-between"
+      justify={isNavbarOpened ? "space-between" : "center"}
       mb="0.75rem"
       mt="sm"
-      mr="0.125rem"
     >
       <Group gap="sm">
         <Box


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #71216
### Description
Fixes some sizing inconsistencies with the data studio navbar, as well as changes the color of the workbench icon to `text-secondary`

### How to verify
1. Go to the data studio
2. Notice that in the navbar, all the nav icons are now the same size, and should be centered within their containers
3. This is also true for the logo at the top of the nav bar
4. Open the navbar and ensure that styling there is correct as well.

### Demo

https://github.com/user-attachments/assets/7f75ac7f-9164-47b0-ac48-4cbe91a575f9

### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~
