### PR TITLE
BOT-1172 Fix markdown link buffering for slack links

### DIFF
--- a/src/metabase/metabot/agent/markdown_link_buffer.clj
+++ b/src/metabase/metabot/agent/markdown_link_buffer.clj
@@ -45,17 +45,29 @@
                     (re-find #"\[[^\]]*\]\([^)]*$" suffix)) ; unclosed (
             last-open))))))
 
+(def ^:private slack-link-prefix
+  "The prefix that starts a Slack-format metabase:// link."
+  "<metabase://")
+
 (defn- find-potential-slack-link-start
   "Find the index of a potential incomplete Slack-format metabase:// link.
-   Only buffers on `<metabase://` prefix — regular `<` characters must NOT trigger buffering.
+   Detects both complete `<metabase://` prefixes and partial prefixes at the end
+   of text (e.g., `<meta`, `<metabase:/`) to handle streaming chunk boundaries.
    Returns nil if no potential incomplete link exists."
   [text]
-  (let [idx (str/last-index-of text "<metabase://")]
-    (when idx
+  (let [idx (str/last-index-of text slack-link-prefix)]
+    (if idx
+      ;; Found full prefix — buffer if the link is incomplete (no closing >)
       (let [suffix (subs text idx)]
-        ;; Only buffer if there's no closing > (i.e., the link is incomplete)
         (when-not (re-find links/slack-link-pattern suffix)
-          idx)))))
+          idx))
+      ;; Check if text ends with any partial prefix of "<metabase://"
+      (loop [prefix-len (min (dec (count slack-link-prefix))
+                             (count text))]
+        (when (pos? prefix-len)
+          (if (str/ends-with? text (subs slack-link-prefix 0 prefix-len))
+            (- (count text) prefix-len)
+            (recur (dec prefix-len))))))))
 
 (defn- find-potential-link-start
   "Find the index of the earliest potential incomplete link start.

--- a/test/metabase/metabot/agent/markdown_link_buffer_test.clj
+++ b/test/metabase/metabot/agent/markdown_link_buffer_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.test :refer :all]
    [metabase.lib.test-util :as lib.tu]
+   [metabase.metabot.agent.links :as links]
    [metabase.metabot.agent.markdown-link-buffer :as mlb]
    [metabase.test :as mt]))
 
@@ -35,6 +36,20 @@
        (let [[new-state output] (mlb/step state chunk)]
          (recur new-state more (conj outputs output)))
        [outputs (mlb/flush-state state)]))))
+
+(defn- process-chunks-with-registry
+  "Like `process-chunks` but returns [outputs flushed registry-map]."
+  ([chunks] (process-chunks-with-registry chunks {} {}))
+  ([chunks queries] (process-chunks-with-registry chunks queries {}))
+  ([chunks queries charts]
+   (let [registry (atom {})]
+     (loop [state (mlb/with-context mlb/initial-state queries charts registry)
+            [chunk & more] chunks
+            outputs []]
+       (if chunk
+         (let [[new-state output] (mlb/step state chunk)]
+           (recur new-state more (conj outputs output)))
+         [outputs (mlb/flush-state state) @registry])))))
 
 ;;; State machine / buffering tests
 
@@ -180,10 +195,47 @@
         (is (= "" flushed))))))
 
 (deftest ^:parallel slack-link-no-buffering-regular-angle-brackets-test
-  (testing "does NOT buffer regular < characters"
+  (testing "does NOT buffer regular < characters in the middle of text"
     (let [[output flushed] (process "x < y and z > w")]
       (is (= "x < y and z > w" output))
       (is (= "" flushed)))))
+
+(deftest ^:parallel slack-link-split-prefix-lone-angle-bracket-test
+  (testing "lone < at end followed by non-link text disambiguates on next chunk"
+    (let [[outputs flushed] (process-chunks ["x <" " y"])]
+      (is (= "x " (first outputs)))
+      (is (= "< y" (second outputs)))
+      (is (= "" flushed)))))
+
+(deftest slack-link-split-prefix-test
+  (mt/with-temporary-setting-values [site-url "https://metabase.example.com"]
+    (testing "resolves link when prefix is split at various points"
+      (doseq [[desc chunks] [["split after <"             ["Check <" "metabase://metric/123|My Metric>"]]
+                             ["split after <m"            ["Check <m" "etabase://metric/123|My Metric>"]]
+                             ["split after <meta"         ["Check <meta" "base://metric/123|My Metric>"]]
+                             ["split after <metabase"     ["Check <metabase" "://metric/123|My Metric>"]]
+                             ["split after <metabase:"    ["Check <metabase:" "//metric/123|My Metric>"]]
+                             ["split after <metabase:/"   ["Check <metabase:/" "/metric/123|My Metric>"]]
+                             ["split after <metabase://"  ["Check <metabase://" "metric/123|My Metric>"]]
+                             ["split after <metabase://m" ["Check <metabase://m" "etric/123|My Metric>"]]]]
+        (testing desc
+          (let [[outputs flushed] (process-chunks chunks)]
+            (is (= "Check " (first outputs))
+                (str "should buffer partial prefix — " desc))
+            (is (re-find #"metabase\.example\.com/metric/123" (apply str (rest outputs)))
+                (str "should resolve link — " desc))
+            (is (= "" flushed))))))))
+
+(deftest slack-link-split-prefix-registry-and-inversion-test
+  (mt/with-temporary-setting-values [site-url "https://metabase.example.com"]
+    (testing "split-prefix Slack links are recorded in link registry and invertible"
+      (let [[outputs flushed registry] (process-chunks-with-registry
+                                        ["Check <metabase" "://metric/123|My Metric>"])
+            resolved-output (apply str (conj outputs flushed))]
+        (is (= {"https://metabase.example.com/metric/123" "metabase://metric/123"}
+               registry))
+        (is (= "Check <metabase://metric/123|My Metric>"
+               (links/invert-slack-links resolved-output registry)))))))
 
 (deftest mixed-link-formats-test
   (mt/with-temporary-setting-values [site-url "https://metabase.example.com"]


### PR DESCRIPTION
Closes [BOT-1172: Metric links don’t open from Slack](https://linear.app/metabase/issue/BOT-1172/metric-links-dont-open-from-slack)

### Description

`find-potential-slack-link-start` was looking for a full `<metabase://` prefix which doesn't work if the link prefix is split across streamed text chunks. Updated it to deal with this case.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
