### PR TITLE
Avoid sending only whitespace in a slack API request

### DIFF
--- a/src/metabase/slackbot/streaming.clj
+++ b/src/metabase/slackbot/streaming.clj
@@ -432,7 +432,7 @@
                                                                            :title  (tool-friendly-names tool-name "Thinking")
                                                                            :status status}])
                                           (when (= status "complete")
-                                            (slackbot.client/append-markdown-text client channel stream_ts "\n"))
+                                            (swap! pending-text #(str "\n\n" %)))
                                           nil))))
 
         on-tool-start (fn [{:keys [id tool-name]}]


### PR DESCRIPTION
- When we add newlines, we should add it to the pending-text atom instead of sending it alone
- Testing out paragraph breaks instead of single newlines

I hope this fixes [BOT-1166: Slackbot sentences sometimes join without spaces](https://linear.app/metabase/issue/BOT-1166/slackbot-sentences-sometimes-join-without-spaces); if not it's easy to back out