### PR TITLE
Add GraalVM sqlglot infrastructure for SQL parsing

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1449,6 +1449,11 @@
            system
            util}}
 
+  sql-parsing
+  {:team "DevEx"
+   :api #{metabase.sql-parsing.core}
+   :uses #{util}}
+
   startup
   {:team "DevEx"
    :api  #{metabase.startup.core}

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1435,6 +1435,10 @@
            system
            util}}
 
+  sql-parsing
+  {:team "DevEx"
+   :uses #{util}}
+
   sso
   {:team "UX West"
    :api  #{metabase.sso.api
@@ -1448,11 +1452,6 @@
            settings
            system
            util}}
-
-  sql-parsing
-  {:team "DevEx"
-   :api #{metabase.sql-parsing.core}
-   :uses #{util}}
 
   startup
   {:team "DevEx"

--- a/.github/actions/prepare-backend/action.yml
+++ b/.github/actions/prepare-backend/action.yml
@@ -33,6 +33,9 @@ runs:
           exit 1
         fi
 
+    - name: Install uv (Python package manager)
+      uses: astral-sh/setup-uv@v6
+
     - name: Get M2 cache key
       uses: ./.github/actions/get-cache-keys
       id: get-cache-keys

--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,7 @@ CLAUDE.local.md
 /logs
 /.clojure-mcp
 
+# sqlglot (installed at dev time, bundled at build time)
+resources/python-sources/sqlglot/
+resources/python-sources/sqlglot-*.dist-info/
+

--- a/bin/build/src/build.clj
+++ b/bin/build/src/build.clj
@@ -2,6 +2,7 @@
   (:require
    [build-drivers :as build-drivers]
    [build.licenses :as license]
+   [build.python :as python]
    [build.uberjar :as uberjar]
    [build.version-properties :as version-properties]
    [clojure.edn :as edn]
@@ -88,6 +89,8 @@
                    (build-frontend! edition))
    :licenses     (fn [{:keys [edition]}]
                    (build-licenses! edition))
+   :python       (fn [{:keys [edition]}]
+                   (python/build-python-deps! edition))
    :drivers      (fn [{:keys [edition]}]
                    (build-drivers/build-drivers! edition))
    :uberjar      (fn [{:keys [edition]}]

--- a/bin/build/src/build/python.clj
+++ b/bin/build/src/build/python.clj
@@ -1,0 +1,38 @@
+(ns build.python
+  "Build step to install Python dependencies (sqlglot) for GraalVM Python."
+  (:require
+   [clojure.java.io :as io]
+   [environ.core :as env]
+   [metabuild-common.core :as u]))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private python-sources-dir
+  "Directory where sqlglot and sql_tools.py shim live."
+  (u/filename u/project-root-directory "resources" "python-sources"))
+
+(def ^:private sqlglot-version
+  "Pinned sqlglot version for reproducible builds.
+  Read from pyproject.toml (single source of truth for both dev and build)."
+  (->> (io/file u/project-root-directory "resources/python-sources/pyproject.toml")
+       slurp
+       (re-find #"\"sqlglot==([^\"]+)\"")
+       second))
+
+(defn build-python-deps!
+  "Install sqlglot to resources/python-sources for bundling into uberjar.
+
+  Uses `uv pip install`. The --no-compile flag skips .pyc generation since GraalVM Python
+  uses interpreted mode.
+
+  Can be skipped by setting SKIP_PYTHON_DEPS=true."
+  [_edition]
+  (if (= (env/env :skip-python-deps) "true")
+    (u/announce "Skipping Python dependencies (SKIP_PYTHON_DEPS=true)")
+    (u/step "Install Python dependencies (sqlglot)"
+      (u/create-directory-unless-exists! python-sources-dir)
+      (u/sh {:dir u/project-root-directory}
+            "uv" "pip" "install" "-r" (u/filename python-sources-dir "pyproject.toml")
+            "--target" python-sources-dir
+            "--no-compile")
+      (u/announce "sqlglot %s installed to %s" sqlglot-version python-sources-dir))))

--- a/deps.edn
+++ b/deps.edn
@@ -168,6 +168,7 @@
   org.flatland/ordered                      {:mvn/version "1.15.12"}            ; ordered maps & sets
   org.graalvm.polyglot/js-community         {:mvn/version "25.0.1" :extension "pom"} ; JavaScript engine
   org.graalvm.polyglot/polyglot             {:mvn/version "25.0.1"}             ; GraalVM platform, required by JS engine
+  org.graalvm.polyglot/python               {:mvn/version "25.0.1" :extension "pom"} ; Python engine for sqlglot SQL parsing
   org.jsoup/jsoup                           {:mvn/version "1.21.2"}             ; required by hickory
   org.liquibase/liquibase-core              {:mvn/version "4.33.0"              ; migration management (Java lib)
                                              :exclusions  [ch.qos.logback/logback-classic]}

--- a/resources/python-sources/pyproject.toml
+++ b/resources/python-sources/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name = "metabase-python-deps"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+    # Keep these in the format "library==X.Y.Z", we parse it with a regex.
+    "sqlglot==28.6.0",
+]

--- a/resources/python-sources/sql_tools.py
+++ b/resources/python-sources/sql_tools.py
@@ -1,0 +1,1601 @@
+import json
+import re
+
+import sqlglot
+import sqlglot.lineage as lineage
+import sqlglot.optimizer as optimizer
+import sqlglot.optimizer.qualify as qualify
+from sqlglot import exp
+from sqlglot.errors import ParseError, OptimizeError
+
+def is_quoted_identifier(name: str, dialect: str = None) -> bool:
+    if not isinstance(name, str):
+        return False
+    else:
+        exp.to_identifier
+        # Using dummy_sql instead of exp.to_identifier so dialect can be provided
+        dummy_sql = "SELECT 1 AS " + name
+        ast = sqlglot.parse_one(dummy_sql, dialect=dialect)
+        return ast.expressions[0].args.get("alias").args.get("quoted")
+
+def needs_quoting(name: str, dialect: str = None) -> bool:
+    """Check if an identifier needs to be quoted due to special characters."""
+    if not name:
+        return False
+    # Check for common problematic characters
+    if '-' in name or ' ' in name:
+        return True
+    # Starts with a digit
+    if name[0].isdigit():
+        return True
+    # provided rename has quotes
+    if is_quoted_identifier(name, dialect=dialect):
+        return True
+    return False
+
+def unquote_identifier(name: str, dialect: str = None):
+    """If name is already a quoted identifier (e.g., `foo` in MySQL, "foo" in Postgres),
+    return (unquoted_name, True). Otherwise return (name, False)."""
+    if not name:
+        return (name, False)
+    try:
+        dummy_sql = "SELECT 1 AS " + name
+        ast = sqlglot.parse_one(dummy_sql, dialect=dialect)
+        ident = ast.expressions[0].args.get("alias")
+        if ident and ident.quoted:
+            return (ident.this, True)
+    except:
+        pass
+    return (name, False)
+
+def table_parts(table):
+    """
+    Extract (catalog, schema, table) 3-tuple from a table expression.
+    Returns None if the table doesn't have a valid name (e.g., UDTFs).
+
+    SQLGlot naming:
+    - table.catalog → SQL catalog (e.g., BigQuery project, Snowflake database)
+    - table.db      → SQL schema (e.g., BigQuery dataset, Postgres schema)
+    - table.name    → table name
+    """
+    name = table.name
+    if not isinstance(name, str) or not name:
+        # UDTFs and other function-based sources don't have traditional table names
+        return None
+    return (table.catalog or None, table.db or None, name)
+
+def referenced_tables(sql: str, dialect: str = "postgres") -> str:
+    """
+    Extract table references from a SQL query.
+
+    Returns a JSON array of [catalog, schema, table] 3-tuples:
+    [[null, null, "users"], [null, "public", "orders"], ["myproject", "dataset", "events"]]
+
+    Excludes CTEs, subquery aliases, and UDTFs.
+
+    :param sql: SQL query string
+    :param dialect: SQL dialect (postgres, mysql, snowflake, bigquery, redshift, duckdb)
+
+    Examples:
+        referenced_tables("SELECT * FROM users")
+        => '[[null, null, "users"]]'
+
+        referenced_tables("SELECT * FROM public.users")
+        => '[[null, "public", "users"]]'
+
+        referenced_tables("SELECT * FROM myproject.analytics.events", "bigquery")
+        => '[["myproject", "analytics", "events"]]'
+    """
+    ast = sqlglot.parse_one(sql, read=dialect)
+    root_scope = optimizer.build_scope(ast)
+
+    tables = set()
+    for scope in root_scope.traverse():
+        for source in scope.sources.values():
+            if isinstance(source, exp.Table):
+                parts = table_parts(source)
+                if parts is not None:
+                    tables.add(parts)
+
+    # Sort for deterministic output (nulls sort first via empty string)
+    return json.dumps(sorted(tables, key=lambda x: (x[0] or "", x[1] or "", x[2])))
+
+def referenced_fields(sql: str, dialect: str = "postgres") -> str:
+    """
+    Extract field references from a SQL query, returning only fields from actual database tables.
+
+    Returns a JSON array of [catalog, schema, table, field] 4-tuples:
+    [[null, null, "users", "id"], [null, "public", "orders", "total"]]
+
+    Includes:
+    - Wildcards as [catalog, schema, table, "*"]
+    - All specific column references
+
+    Excludes:
+    - Fields created in CTEs or subqueries
+    - Aliases (returns actual table names, not their aliases)
+    - Computed/derived columns
+
+    :param sql: SQL query string
+    :param dialect: SQL dialect (postgres, mysql, snowflake, bigquery, redshift, duckdb)
+
+    Examples:
+        referenced_fields("SELECT id FROM users", "postgres")
+        => '[[null, null, "users", "id"]]'
+
+        referenced_fields("SELECT * FROM public.users", "postgres")
+        => '[[null, "public", "users", "*"]]'
+
+        referenced_fields("SELECT * FROM myproject.analytics.events", "bigquery")
+        => '[["myproject", "analytics", "events", "*"]]'
+    """
+    ast = sqlglot.parse_one(sql, read=dialect)
+    root_scope = optimizer.build_scope(ast)
+
+    fields = set()
+
+    # Collect all CTE names to exclude them
+    cte_names = set()
+    for cte in ast.find_all(exp.CTE):
+        if cte.alias:
+            cte_names.add(cte.alias)
+
+    # Track scopes with unqualified wildcards
+    unqualified_wildcard_scopes = []
+
+    # Traverse all scopes to find column references
+    for scope in root_scope.traverse():
+        # Build a mapping of table aliases to table_parts tuples (catalog, schema, table)
+        # Only include actual tables, not CTEs or subqueries
+        alias_to_table_parts = {}
+        for alias, source in scope.sources.items():
+            if isinstance(source, exp.Table):
+                table_name = source.name
+                # Skip if this is actually a CTE reference
+                if table_name and table_name not in cte_names and alias not in cte_names:
+                    parts = table_parts(source)
+                    if parts is not None:
+                        alias_to_table_parts[alias] = parts
+
+        # Check for unqualified wildcards (SELECT * without table qualification)
+        if isinstance(scope.expression, exp.Select):
+            for expr in scope.expression.expressions:
+                if isinstance(expr, exp.Star):
+                    unqualified_wildcard_scopes.append((scope, alias_to_table_parts))
+                    break
+
+        # Find all column references in this scope
+        for column in scope.expression.find_all(exp.Column):
+            column_name = column.name
+            table_ref = column.table
+
+            # Handle qualified wildcards (e.g., "users.*")
+            if column_name == "*":
+                if table_ref:
+                    parts = alias_to_table_parts.get(table_ref)
+                    if parts is not None:
+                        # 4-tuple: (catalog, schema, table, field)
+                        fields.add(parts + ("*",))
+                continue
+
+            # Regular column references
+            if table_ref:
+                parts = alias_to_table_parts.get(table_ref)
+                if parts is not None:
+                    fields.add(parts + (column_name,))
+            else:
+                # Column without explicit table qualifier
+                # If there's only one source table, use that
+                if len(alias_to_table_parts) == 1:
+                    parts = list(alias_to_table_parts.values())[0]
+                    fields.add(parts + (column_name,))
+
+    # For scopes with unqualified wildcards, add wildcard entries for all tables
+    for scope, alias_to_table_parts in unqualified_wildcard_scopes:
+        for parts in alias_to_table_parts.values():
+            fields.add(parts + ("*",))
+
+    # Sort for deterministic output: catalog, schema, table, field
+    return json.dumps(sorted(fields, key=lambda x: (x[0] or "", x[1] or "", x[2], x[3])))
+
+def serialize_error(e):
+    """
+    Convert SQLGlot exceptions to structured error dicts.
+
+    Unrecognized error formats fall through to 'unhandled' type - the Clojure
+    layer can add more specific handling if needed.
+    """
+
+    message = e.args[0]
+    assert isinstance(message, str), "Unexpected error format."
+
+    match = re.search(r'^Unknown table:\s*(?P<table>.*)', message)
+    if match:
+        return {"status": "error",
+                "type": "unknown_table",
+                "message": match.group(),
+                "table": match.group('table')}
+
+    match = re.search(r'''(?P<message>^Column '(?P<column>\S+)' could not be resolved.)(?P<details>.*)''', message)
+    if match:
+        return {"status": "error",
+                "type": "column_not_resolved",
+                "message": match.group('message'),
+                "column": match.group('column'),
+                "details": match.group('details')}
+
+    # ('Invalid expression / Unexpected token. Line 1, Col: 23.\n  complete nonsense \x1b[4mquery\x1b[0m',)
+    match = re.search(r'(?P<message>^Invalid expression.*?\.)(?P<details>.*)', message)
+    if match:
+        return {"status": "error",
+                "type": "invalid_expression",
+                "message": match.group('message'),
+                "details": match.group('details')}
+
+    return {"status": "error",
+            "type": "unhandled",
+            "message": message}
+
+def validate_query(dialect, sql, default_table_schema, sqlglot_schema_json):
+    """
+    Validate a SQL query against a schema using sqlglot's qualify optimizer.
+
+    Validation modes:
+    - Strict mode (sqlglot_schema provided): Validates columns and tables exist in schema.
+      Returns errors for unknown tables, unresolved columns, missing table aliases.
+    - Permissive mode (sqlglot_schema is None/empty): Only checks SQL syntax, infers schema
+      from query structure. Useful for UDTFs and queries against unknown tables.
+
+    Returns JSON with:
+    - If valid: {"status": "ok"}
+    - If error: {"status": "error", "type": "...", "message": "...", ...}
+
+    Error types:
+    - unknown_table: Table reference not found in schema (strict mode only)
+    - column_not_resolved: Column not found (includes 'column' and optionally 'details')
+    - invalid_expression: Syntax/parse error
+    - unhandled: Other errors
+
+    :param dialect: SQLGlot dialect string (e.g., "postgres", "mysql")
+    :param sql: SQL query string to validate
+    :param default_table_schema: Default schema for unqualified tables
+    :param sqlglot_schema_json: JSON-encoded schema dict {schema: {table: {column: type}}},
+                                or None/empty for permissive mode
+    """
+    status = {"status": "ok"}
+
+    # Decode JSON schema if provided (GraalVM Polyglot passes complex maps as JSON strings)
+    sqlglot_schema = json.loads(sqlglot_schema_json) if sqlglot_schema_json else None
+
+    # Determine validation mode based on whether schema is provided
+    # - Strict mode: schema provided → validate columns/tables exist
+    # - Permissive mode: no schema → only check syntax, infer schema from query
+    strict_mode = sqlglot_schema is not None and len(sqlglot_schema) > 0
+
+    try:
+        ast = sqlglot.parse_one(sql, read=dialect)
+        ast = qualify.qualify(ast,
+                            db=default_table_schema,
+                            dialect=dialect,
+                            schema=sqlglot_schema if strict_mode else None,
+                            # In strict mode: don't infer, validate against provided schema
+                            # In permissive mode: infer schema from query (handles UDTFs)
+                            infer_schema=not strict_mode,
+                            # In strict mode: validate that columns can be resolved
+                            validate_qualify_columns=strict_mode,
+                            sql=sql)
+    except ParseError as e:
+        status |= serialize_error(e)
+    except OptimizeError as e:
+        status |= serialize_error(e)
+
+    return json.dumps(status)
+
+#############################################################################
+# Experimental (using lineage)
+#############################################################################
+
+def is_pure_column(root):
+    """
+    Check whether the lineage graph is a path of columns terminated by table.
+
+    :param root: The root of the lineage graph
+    """
+    for node in root.walk():
+        expression = node.expression
+        downstream = node.downstream
+
+        # We are looking for "path"...
+        if len(downstream) > 1:
+            return False
+
+        examined = None
+        if (isinstance(expression, exp.Alias)):
+            examined = expression.this
+        else:
+            examined = expression
+
+        # ...of `exp.Column`s...
+        if isinstance(examined, exp.Column):
+            continue
+        # ...terminated by the `exp.Table`
+        elif isinstance(examined, exp.Table):
+            continue
+        else:
+            return False
+    return True
+
+def simple_query(sql: str, dialect: str = None) -> str:
+    """
+    Check if SQL is a simple SELECT (no LIMIT, OFFSET, or CTEs).
+
+    Used by Workspaces to determine if automatic checkpoints can be inserted.
+
+    Returns a JSON object with:
+    - If simple: {"is_simple": true}
+    - If not simple: {"is_simple": false, "reason": "..."}
+
+    :param sql: SQL query string to check
+    :param dialect: SQL dialect (postgres, mysql, snowflake, bigquery, etc.)
+
+    Examples:
+        simple_query("SELECT * FROM users")
+        => '{"is_simple": true}'
+
+        simple_query("SELECT * FROM users LIMIT 10")
+        => '{"is_simple": false, "reason": "Contains a LIMIT"}'
+
+        simple_query("WITH cte AS (SELECT 1) SELECT * FROM cte")
+        => '{"is_simple": false, "reason": "Contains a CTE"}'
+    """
+    try:
+        ast = sqlglot.parse_one(sql, read=dialect)
+
+        # Must be a SELECT or Query type (CTE queries parse as Select with 'with' arg)
+        if not isinstance(ast, (exp.Select, exp.Query)):
+            return json.dumps({"is_simple": False, "reason": "Not a simple SELECT"})
+
+        # No CTEs (WITH clause) - SQLGlot uses "with_" (with underscore) as the arg name
+        if ast.args.get("with_"):
+            return json.dumps({"is_simple": False, "reason": "Contains a CTE"})
+
+        # For non-Select Query types (Union, Intersect, etc.), reject
+        if not isinstance(ast, exp.Select):
+            return json.dumps({"is_simple": False, "reason": "Not a simple SELECT"})
+
+        # No LIMIT
+        if ast.args.get("limit"):
+            return json.dumps({"is_simple": False, "reason": "Contains a LIMIT"})
+
+        # No OFFSET
+        if ast.args.get("offset"):
+            return json.dumps({"is_simple": False, "reason": "Contains an OFFSET"})
+
+        return json.dumps({"is_simple": True})
+    except ParseError as e:
+        return json.dumps({"is_simple": False, "reason": str(e)})
+    except Exception as e:
+        return json.dumps({"is_simple": False, "reason": f"Unexpected error: {str(e)}"})
+
+def add_into_clause(sql: str, table_name: str, dialect: str = None) -> str:
+    """
+    Add an INTO clause to a SELECT statement for SQL Server SELECT INTO syntax.
+
+    Transforms: SELECT * FROM products
+    Into:       SELECT * INTO "new_table" FROM products
+
+    Used by SQL Server transforms which require SELECT INTO syntax
+    instead of CREATE TABLE AS SELECT.
+
+    :param sql: The SELECT SQL query string
+    :param table_name: The target table name (already formatted/quoted)
+    :param dialect: SQL dialect (e.g., "tsql" for SQL Server)
+    :return: Modified SQL string with INTO clause
+
+    Examples:
+        add_into_clause("SELECT * FROM products", '"PRODUCTS_COPY"', "tsql")
+        => 'SELECT * INTO "PRODUCTS_COPY" FROM products'
+    """
+    ast = sqlglot.parse_one(sql, read=dialect)
+
+    if not isinstance(ast, exp.Select):
+        raise ValueError("SQL must be a SELECT statement")
+
+    # Create the Into expression with the table identifier
+    # The table_name is pre-formatted, so parse it to preserve quotes
+    into = exp.Into(this=exp.to_table(table_name))
+
+    # Set the into clause on the select
+    ast.set("into", into)
+
+    # Generate SQL in the target dialect
+    return ast.sql(dialect=dialect)
+
+
+def returned_columns_lineage(dialect, sql, default_table_schema, sqlglot_schema_json):
+    """
+    Extract column lineage from SQL query.
+
+    Args:
+        dialect: SQL dialect string (e.g., "postgres", "mysql")
+        sql: SQL query string
+        default_table_schema: Default schema name (e.g., "public")
+        sqlglot_schema_json: JSON-encoded schema map (to avoid GraalVM polyglot issues)
+
+    Returns:
+        JSON array of [alias, is_pure, dependencies] tuples
+    """
+    # Decode schema from JSON (passed from Clojure to avoid polyglot map issues)
+    sqlglot_schema = json.loads(sqlglot_schema_json) if sqlglot_schema_json else None
+
+    ast = sqlglot.parse_one(sql, read=dialect)
+    ast = qualify.qualify(ast,
+                          db=default_table_schema,
+                          dialect=dialect,
+                          schema=sqlglot_schema,
+                          infer_schema=True,
+                          sql=sql)
+
+    assert isinstance(ast, exp.Query), "Ast does not represent a `Query`."
+
+    dependencies = []
+    for select in ast.named_selects:
+
+        # Note: SQL allows duplicate column aliases (e.g., SELECT 1 AS x, 2 AS x).
+        # We track columns by position, not by name, so duplicates are fine.
+
+        select_elm_lineage = lineage.lineage(select, ast.sql(dialect), dialect=dialect)
+        is_pure_select = is_pure_column(select_elm_lineage)
+
+        leaves = set()
+        for node in select_elm_lineage.walk():
+            if (# Leaf nodes of `.walk` are `exp.Table`s. We are interested
+                # in the columns selected from those tables (i.e. penultimate
+                # level). The condition is intended to examine those columns.
+                len(node.downstream) == 1
+                and isinstance(node.downstream[0].expression, exp.Table)
+                and not node.downstream[0].downstream):
+                # For UDTFs/table functions, the penultimate node may not be a Column
+                # (e.g., FLATTEN results). Skip these gracefully.
+                if not isinstance(node.expression.this, exp.Column):
+                    continue
+                # Extract table parts (catalog, schema, table) from the source.
+                # Note: Schema may be missing when table is aliased to its own name.
+                table = table_parts(node.downstream[0].expression)
+                # Skip UDTFs and other function-based sources that don't have real table names
+                if table is not None:
+                    namespaced_column = table + (node.expression.this.name, )
+                    leaves.add(namespaced_column)
+
+        dependencies.append((select, is_pure_select, tuple(leaves), ))
+
+    return json.dumps(dependencies)
+
+
+def replace_names(sql: str, replacements_json: str, dialect: str = None) -> str:
+    """
+    Replace schema, table, and column names in a SQL query.
+
+    SECURITY NOTE: Replacement values are injected into the SQL AST without sanitization.
+    This is safe because the only caller (workspaces/execute.clj) passes system-generated
+    values: isolation schema names (mb__isolation_<slug>_<id>) and table names from
+    database metadata. User input never flows into replacement values.
+
+    Args:
+        sql: SQL query string
+        replacements_json: JSON-encoded map with keys:
+            - schemas: {old_schema: new_schema}
+            - tables: list of [[{schema?, table}, new_name], ...]
+            - columns: list of [[{schema?, table?, column}, new_name], ...]
+        dialect: SQL dialect string
+
+    Returns:
+        Modified SQL string with replacements applied.
+
+    Examples:
+        replace_names("SELECT * FROM people", '{"tables": [[{"table": "people"}, "users"]]}', "postgres")
+        => 'SELECT * FROM users'
+
+        replace_names("SELECT id FROM orders", '{"columns": [[{"table": "orders", "column": "id"}, "user_id"]]}')
+        => 'SELECT user_id FROM orders'
+    """
+    replacements = json.loads(replacements_json)
+    schemas = replacements.get("schemas") or {}
+    tables = replacements.get("tables") or []  # List of [key, value] pairs
+    columns = replacements.get("columns") or []  # List of [key, value] pairs
+
+    # Convert list-of-pairs to lookup dicts for O(1) matching
+    # Tables: (schema, table) -> new_name
+    table_map = {}
+    for item in tables:
+        key, new_name = item
+        schema = key.get("schema")  # may be None
+        table = key["table"]
+        table_map[(schema, table)] = new_name
+
+    # Columns: (schema, table, column) -> new_name
+    column_map = {}
+    for item in columns:
+        key, new_name = item
+        schema = key.get("schema")
+        table = key.get("table")  # may be None for unqualified
+        column = key["column"]
+        column_map[(schema, table, column)] = new_name
+
+    ast = sqlglot.parse_one(sql, read=dialect)
+
+    def rename_fn(node):
+        # Schema rename (appears in Table.db)
+        if isinstance(node, exp.Table):
+            # Capture original values BEFORE any modifications (important for lookup)
+            original_schema = node.db
+            original_table = node.name
+            # Preserve original quoting status for renamed identifiers
+            original_schema_quoted = node.args.get("db").quoted if node.args.get("db") else False
+            original_table_quoted = node.this.quoted if node.this else False
+
+            # Rename schema if present
+            if original_schema and original_schema in schemas:
+                raw_schema, was_quoted = unquote_identifier(schemas[original_schema], dialect)
+                schema_quoted = original_schema_quoted or was_quoted or needs_quoting(raw_schema, dialect)
+                node.set("db", exp.Identifier(this=raw_schema, quoted=schema_quoted))
+
+            # Rename table - try exact match first (with original schema), then without schema
+            new_table = (table_map.get((original_schema, original_table)) or
+                         table_map.get((None, original_table)))
+            if new_table:
+                if isinstance(new_table, dict):
+                    # New format: {schema: x, table: y}
+                    if new_table.get("schema"):
+                        # When injecting a new schema, quote if it contains special characters
+                        raw_schema, was_quoted = unquote_identifier(new_table["schema"], dialect)
+                        schema_quoted = original_schema_quoted or was_quoted or needs_quoting(raw_schema, dialect)
+                        node.set("db", exp.Identifier(this=raw_schema, quoted=schema_quoted))
+                    elif "schema" in new_table and new_table["schema"] is None:
+                        # Explicitly clear the schema from the AST node. This matches Macaw's
+                        # behavior: {:schema nil :table "x"} means "remove the schema qualifier",
+                        # turning e.g. `FROM public.orders` into `FROM x`.
+                        node.set("db", None)
+                    if new_table.get("table"):
+                        raw_table, was_quoted = unquote_identifier(new_table["table"], dialect)
+                        table_quoted = original_table_quoted or was_quoted or needs_quoting(raw_table, dialect)
+                        node.set("this", exp.Identifier(this=raw_table, quoted=table_quoted))
+                else:
+                    # String: just the table name
+                    raw_name, was_quoted = unquote_identifier(new_table, dialect)
+                    table_quoted = original_table_quoted or was_quoted or needs_quoting(raw_name, dialect)
+                    node.set("this", exp.Identifier(this=raw_name, quoted=table_quoted))
+
+        # Column rename
+        elif isinstance(node, exp.Column):
+            col_name = node.name
+            col_table = node.table  # May be None if column is unqualified (e.g., "SELECT id" not "SELECT t.id")
+            # Preserve original quoting status
+            original_col_quoted = node.this.quoted if isinstance(node.this, exp.Identifier) else False
+
+            # Try to find a matching column rename.
+            # The challenge: replacement key might be {:table "orders" :column "id"}
+            # but the SQL column ref might just be "id" (unqualified).
+            # We need to match flexibly:
+            # - Exact match: (schema, table, column) all match
+            # - Table match: column and table match, schema is None in key
+            # - Column-only match: just column matches (when no table qualifier in SQL)
+            new_col = None
+
+            # Iterate through all column mappings and find best match
+            for (key_schema, key_table, key_col), new_name in column_map.items():
+                if key_col != col_name:
+                    continue
+                # Column name matches, now check table qualifier
+                # Note: SQLGlot uses empty string (not None) for missing table qualifier
+                if col_table:
+                    # SQL has table qualifier - match if tables are equal
+                    if key_table == col_table:
+                        new_col = new_name
+                        break
+                else:
+                    # SQL has no table qualifier - accept any table in key
+                    # (this is the common case: "SELECT id FROM orders" with key {:table "orders" :column "id"})
+                    new_col = new_name
+                    break
+
+            if new_col:
+                node.set("this", exp.Identifier(this=new_col, quoted=original_col_quoted))
+
+        return node
+
+    transformed = ast.transform(rename_fn)
+    return transformed.sql(dialect=dialect)
+
+
+#############################################################################
+# Field References (Macaw-compatible output)
+#############################################################################
+
+def field_references(sql: str, dialect: str = "postgres") -> str:
+    """
+    Extract field references from SQL, returning used and returned fields.
+
+    This is the SQLGlot equivalent of Macaw's field-references function.
+    Returns a JSON object with:
+    - used_fields: list of field specs from WHERE, JOIN ON, GROUP BY, ORDER BY
+    - returned_fields: list of field specs from SELECT clause (ordered)
+    - errors: list of validation errors
+
+    Each field spec has:
+    - type: single_column, all_columns, custom_field, composite_field, or unknown_columns
+    - column: column name (for single_column)
+    - alias: column alias (null if none)
+    - source_columns: nested list of possible source columns
+    - table: table info (for all_columns)
+    - used_fields: list of fields used (for custom_field)
+    - member_fields: list of fields (for composite_field)
+    """
+    try:
+        ast = sqlglot.parse_one(sql, read=dialect)
+    except ParseError:
+        return json.dumps({
+            "used_fields": [],
+            "returned_fields": [],
+            "errors": [{"type": "syntax_error"}]
+        })
+
+    walker = FieldReferenceWalker(ast, dialect)
+    result = walker.walk()
+
+    # Convert sets to lists for JSON serialization
+    result["used_fields"] = list(result["used_fields"])
+    result["errors"] = list(result["errors"])
+
+    return json.dumps(result, default=_json_default)
+
+
+def _json_default(obj):
+    """JSON serializer for objects not serializable by default json code"""
+    if isinstance(obj, set):
+        return list(obj)
+    if isinstance(obj, frozenset):
+        return list(obj)
+    raise TypeError(f"Object of type {type(obj)} is not JSON serializable")
+
+
+class FieldReferenceWalker:
+    """
+    Walks SQLGlot AST to extract field references matching Macaw's output format.
+
+    Key concepts:
+    - sources: Nested list of source tables/subqueries. Outer list = scope levels,
+               inner list = same-scope sources (FROM + JOINs).
+    - withs: Set of CTE definitions, progressively built.
+    """
+
+    def __init__(self, ast, dialect):
+        self.ast = ast
+        self.dialect = dialect
+
+    def walk(self):
+        """Main entry point - returns {used_fields, returned_fields, errors}"""
+        return self._process_query(self.ast, outside_sources=[], withs={})
+
+    def _process_query(self, expr, outside_sources, withs):
+        """Process a query node (SELECT, UNION, etc.)"""
+        if isinstance(expr, exp.Select):
+            return self._process_select(expr, outside_sources, withs)
+        elif isinstance(expr, exp.Union):
+            return self._process_union(expr, outside_sources, withs)
+        else:
+            # Unknown query type
+            return {
+                "used_fields": set(),
+                "returned_fields": [],
+                "errors": {self._syntax_error()}
+            }
+
+    def _process_select(self, select_expr, outside_sources, withs):
+        """Process a SELECT statement."""
+        errors = set()  # Set of frozen errors for deduplication
+
+        # Handle CTEs (WITH clause)
+        local_withs = dict(withs)
+        with_clause = select_expr.args.get("with_")
+        if with_clause:
+            is_recursive = with_clause.args.get("recursive")
+            for cte in with_clause.expressions:
+                cte_name = cte.alias
+                cte_body = cte.this
+
+                if is_recursive and isinstance(cte_body, exp.Union):
+                    # For recursive CTEs with UNION, process the base case first
+                    # to get the returned_fields structure, then process the full body.
+                    # The base case is the left side of the UNION.
+                    base_result = self._process_query(cte_body.left, outside_sources, local_withs)
+
+                    # Now add the CTE to local_withs with the base case's returned_fields
+                    # so the recursive part can reference it.
+                    # Mark it as the "current CTE" so we can detect self-references.
+                    local_withs[cte_name] = {
+                        "names": {"table": cte_name, "table_alias": cte_name},
+                        "returned_fields": base_result["returned_fields"],
+                        "used_fields": base_result["used_fields"],
+                        "errors": base_result["errors"],
+                        "is_recursive_cte": True  # Marker survives JOIN aliasing
+                    }
+
+                    # Process the full CTE body (UNION) with the CTE now available
+                    cte_result = self._process_query(cte_body, outside_sources, local_withs)
+
+                    # Keep is_recursive_cte flag in final entry
+                    local_withs[cte_name] = {
+                        "names": {"table": cte_name},
+                        "returned_fields": cte_result["returned_fields"],
+                        "used_fields": cte_result["used_fields"],
+                        "errors": cte_result["errors"],
+                        "is_recursive_cte": True
+                    }
+                else:
+                    # Non-recursive CTE - just process normally
+                    cte_result = self._process_query(cte_body, outside_sources, local_withs)
+
+                    local_withs[cte_name] = {
+                        "names": {"table": cte_name},
+                        "returned_fields": cte_result["returned_fields"],
+                        "used_fields": cte_result["used_fields"],
+                        "errors": cte_result["errors"]
+                    }
+                # cte_result["errors"] is a list of dicts, freeze them for set membership
+                for e in cte_result["errors"]:
+                    errors.add(self._freeze_field(e) if isinstance(e, dict) else e)
+
+        # Build local sources from FROM + JOINs
+        local_sources = self._build_sources(select_expr, outside_sources, local_withs)
+        combined_sources = [local_sources] + outside_sources
+
+        # Process returned fields (SELECT clause)
+        returned_fields = []
+        for select_item in select_expr.expressions:
+            fields = self._find_returned_fields(select_item, combined_sources, local_withs)
+            for field_result in fields:
+                if "col" in field_result:
+                    returned_fields.append(field_result["col"])
+                if "errors" in field_result:
+                    errors.update(field_result["errors"])
+
+        # Build sources including SELECT aliases for ORDER BY resolution
+        # SELECT aliases should be a separate scope level from table sources,
+        # so that source_columns properly nests [select_aliases] [table_sources]
+        select_source = {
+            "names": None,
+            "returned_fields": [f for f in returned_fields if f.get("alias")],
+            "used_fields": set(),
+            "errors": set()
+        }
+        sources_with_select = [[select_source]] + [local_sources] + outside_sources
+
+        # Process used fields
+        used_fields = set()
+
+        # SELECT clause (references in expressions, not the returned columns themselves)
+        for select_item in select_expr.expressions:
+            for field_result in self._find_used_fields(select_item, combined_sources, local_withs):
+                if "col" in field_result:
+                    used_fields.add(self._freeze_field(field_result["col"]))
+                if "errors" in field_result:
+                    errors.update(field_result["errors"])
+
+        # WHERE clause (include select aliases for lineage tracking, matching Macaw)
+        where = select_expr.args.get("where")
+        if where:
+            for field_result in self._find_used_fields(where, sources_with_select, local_withs):
+                if "col" in field_result:
+                    used_fields.add(self._freeze_field(field_result["col"]))
+                if "errors" in field_result:
+                    errors.update(field_result["errors"])
+
+        # JOIN ON conditions (include select aliases for lineage tracking, matching Macaw)
+        for join in select_expr.args.get("joins", []):
+            on_clause = join.args.get("on")
+            if on_clause:
+                for field_result in self._find_used_fields(on_clause, sources_with_select, local_withs):
+                    if "col" in field_result:
+                        used_fields.add(self._freeze_field(field_result["col"]))
+                    if "errors" in field_result:
+                        errors.update(field_result["errors"])
+
+        # GROUP BY
+        group = select_expr.args.get("group")
+        if group:
+            for field_result in self._find_used_fields(group, sources_with_select, local_withs):
+                if "col" in field_result:
+                    used_fields.add(self._freeze_field(field_result["col"]))
+                if "errors" in field_result:
+                    errors.update(field_result["errors"])
+
+        # ORDER BY (can reference SELECT aliases)
+        order = select_expr.args.get("order")
+        if order:
+            for field_result in self._find_used_fields(order, sources_with_select, local_withs):
+                if "col" in field_result:
+                    used_fields.add(self._freeze_field(field_result["col"]))
+                if "errors" in field_result:
+                    errors.update(field_result["errors"])
+
+        # HAVING clause
+        having = select_expr.args.get("having")
+        if having:
+            for field_result in self._find_used_fields(having, sources_with_select, local_withs):
+                if "col" in field_result:
+                    used_fields.add(self._freeze_field(field_result["col"]))
+                if "errors" in field_result:
+                    errors.update(field_result["errors"])
+
+        # Include used_fields from local sources (CTEs)
+        for source in local_sources:
+            for field in source.get("used_fields", set()):
+                if isinstance(field, dict):
+                    used_fields.add(self._freeze_field(field))
+                else:
+                    used_fields.add(field)
+
+        # Include used_fields from CTEs
+        for cte_source in local_withs.values():
+            for field in cte_source.get("used_fields", set()):
+                if isinstance(field, dict):
+                    used_fields.add(self._freeze_field(field))
+                else:
+                    used_fields.add(field)
+
+        return {
+            "used_fields": [self._unfreeze_field(f) for f in used_fields],
+            "returned_fields": returned_fields,
+            "errors": [self._unfreeze_field(e) for e in errors]
+        }
+
+    def _process_union(self, union_expr, outside_sources, withs):
+        """Process UNION/INTERSECT/EXCEPT - creates composite_field for returned columns."""
+        left_result = self._process_query(union_expr.left, outside_sources, withs)
+        right_result = self._process_query(union_expr.right, outside_sources, withs)
+
+        # Combine used_fields
+        used_fields = set()
+        for f in left_result["used_fields"]:
+            used_fields.add(self._freeze_field(f) if isinstance(f, dict) else f)
+        for f in right_result["used_fields"]:
+            used_fields.add(self._freeze_field(f) if isinstance(f, dict) else f)
+
+        # Create composite returned_fields
+        returned_fields = []
+        left_fields = left_result["returned_fields"]
+        right_fields = right_result["returned_fields"]
+
+        for i in range(max(len(left_fields), len(right_fields))):
+            left_field = left_fields[i] if i < len(left_fields) else None
+            right_field = right_fields[i] if i < len(right_fields) else None
+
+            if left_field:
+                alias = left_field.get("alias") or left_field.get("column")
+            elif right_field:
+                alias = right_field.get("alias") or right_field.get("column")
+            else:
+                alias = None
+
+            member_fields = []
+            if left_field:
+                member_fields.append(left_field)
+            if right_field:
+                member_fields.append(right_field)
+
+            returned_fields.append({
+                "type": "composite_field",
+                "alias": alias,
+                "member_fields": member_fields
+            })
+
+        all_errors = set()
+        for e in left_result["errors"]:
+            if isinstance(e, dict):
+                all_errors.add(self._freeze_field(e))
+            else:
+                all_errors.add(e)
+        for e in right_result["errors"]:
+            if isinstance(e, dict):
+                all_errors.add(self._freeze_field(e))
+            else:
+                all_errors.add(e)
+
+        return {
+            "used_fields": [self._unfreeze_field(f) for f in used_fields],
+            "returned_fields": returned_fields,
+            "errors": [self._unfreeze_field(e) for e in all_errors]
+        }
+
+    def _build_sources(self, select_expr, outside_sources, withs):
+        """Build source list from FROM clause and JOINs.
+
+        Note: Macaw processes JOINs first, then appends FROM at the end.
+        This affects the order when expanding wildcards.
+        """
+        sources = []
+
+        # Process JOINs first (matching Macaw's order)
+        for join in select_expr.args.get("joins", []):
+            source = self._process_source(join.this, outside_sources, withs)
+            if source:
+                sources.append(source)
+
+        # Then append FROM clause at the end
+        from_clause = select_expr.args.get("from_")
+        if from_clause:
+            source = self._process_source(from_clause.this, outside_sources, withs)
+            if source:
+                sources.append(source)
+
+        return sources
+
+    def _process_source(self, source_expr, outside_sources, withs):
+        """Process a source (table, subquery, or CTE reference)."""
+        # Check for table functions first (UDTF or any UDTF subclass like GenerateSeries)
+        # Note: isinstance checks for subclasses too, so exp.UDTF catches GenerateSeries
+        if isinstance(source_expr, exp.UDTF):
+            # Table function (GENERATE_SERIES, etc.)
+            alias = source_expr.alias
+            return {
+                "names": {"table_alias": alias} if alias else None,
+                "returned_fields": [{"type": "unknown_columns"}],
+                "used_fields": set(),
+                "errors": set()
+            }
+
+        if isinstance(source_expr, exp.Table):
+            table_name = source_expr.name
+            table_alias = source_expr.alias
+
+            # Check if it's a CTE reference
+            if table_name in withs:
+                cte_data = withs[table_name]
+                cte_table_info = {"table": table_name}
+                if table_alias:
+                    cte_table_info["table_alias"] = table_alias
+                cte_source = dict(cte_data)
+                cte_source["names"] = cte_table_info
+                return cte_source
+
+            # A table with empty name but an alias might be a table function result
+            # that SQLGlot didn't recognize. Treat as unknown_columns.
+            if not table_name and table_alias:
+                return {
+                    "names": {"table_alias": table_alias},
+                    "returned_fields": [{"type": "unknown_columns"}],
+                    "used_fields": set(),
+                    "errors": set()
+                }
+
+            # A table with empty name whose 'this' is a function is a table function
+            # that SQLGlot parsed as Table instead of UDTF (e.g., my_function(1, 100))
+            if not table_name and isinstance(source_expr.this, exp.Func):
+                alias = source_expr.alias
+                return {
+                    "names": {"table_alias": alias} if alias else None,
+                    "returned_fields": [{"type": "unknown_columns"}],
+                    "used_fields": set(),
+                    "errors": set()
+                }
+
+            # Real table
+            table_info = {"table": table_name}
+            if source_expr.db:
+                table_info["schema"] = source_expr.db
+            if source_expr.catalog:
+                table_info["database"] = source_expr.catalog
+            if table_alias:
+                table_info["table_alias"] = table_alias
+
+            return {
+                "names": table_info,
+                "returned_fields": [{"type": "all_columns", "table": table_info}],
+                "used_fields": set(),
+                "errors": set()
+            }
+
+        elif isinstance(source_expr, exp.Subquery):
+            subquery_result = self._process_query(source_expr.this, outside_sources, withs)
+            alias = source_expr.alias
+            subquery_result["names"] = {"table_alias": alias} if alias else None
+            return subquery_result
+
+        return None
+
+    def _find_returned_fields(self, expr, sources, withs):
+        """Find returned fields from a SELECT expression."""
+        # Handle aliases
+        if isinstance(expr, exp.Alias):
+            inner_results = self._find_returned_fields(expr.this, sources, withs)
+            alias = expr.alias
+            for result in inner_results:
+                if "col" in result:
+                    result["col"]["alias"] = alias
+            return inner_results
+
+        # Unqualified wildcard: SELECT *
+        if isinstance(expr, exp.Star):
+            results = []
+            if sources and sources[0]:
+                for source in sources[0]:
+                    for field in source.get("returned_fields", []):
+                        results.append({"col": field})
+            return results
+
+        # Column reference (including table.*)
+        if isinstance(expr, exp.Column):
+            column_name = expr.name
+            table_ref = expr.table
+
+            # Table wildcard: SELECT t.*
+            if column_name == "*":
+                if table_ref:
+                    source = self._find_source({"table": table_ref}, sources)
+                    if source:
+                        return [{"col": field} for field in source.get("returned_fields", [])]
+                    else:
+                        return [{"errors": {self._missing_table_alias_error(table_ref)}}]
+                return []
+
+            # Regular column
+            return self._get_column(sources, expr, return_table_matches=True)
+
+        # Subquery in SELECT
+        if isinstance(expr, exp.Subquery):
+            subquery_result = self._process_query(expr.this, sources, withs)
+            # Single-column subquery returns that column
+            if subquery_result["returned_fields"]:
+                return [{"col": subquery_result["returned_fields"][0]}]
+            return []
+
+        # Everything else is a custom field (function, case, binary expression, etc.)
+        used_fields = []
+        for result in self._find_used_fields(expr, sources, withs):
+            if "col" in result:
+                used_fields.append(result["col"])
+
+        alias = expr.alias if hasattr(expr, "alias") and expr.alias else None
+        return [{
+            "col": {
+                "type": "custom_field",
+                "alias": alias,
+                # Don't freeze - these go directly to returned_fields which isn't unfrozen
+                "used_fields": used_fields
+            }
+        }]
+
+    def _find_used_fields(self, expr, sources, withs):
+        """Find fields used in an expression (WHERE, JOIN ON, etc.)."""
+        if expr is None:
+            return []
+
+        # Column reference
+        if isinstance(expr, exp.Column):
+            column_name = expr.name
+            table_ref = expr.table
+
+            # Table wildcard: t.* - expand to actual fields from source
+            if column_name == "*" and table_ref:
+                source = self._find_source({"table": table_ref}, sources)
+                if source:
+                    # Expand wildcard to the actual fields from this source
+                    # But skip all_columns and unknown_columns markers -
+                    # they don't represent specific used columns
+                    results = []
+                    for field in source.get("returned_fields", []):
+                        ftype = field.get("type")
+                        if ftype not in ("all_columns", "unknown_columns"):
+                            results.append({"col": field})
+                    return results
+                # Bad table ref - return empty, error is tracked in _find_returned_fields
+                # Don't create a column entry for "*"
+                return []
+
+            return self._get_column(sources, expr, return_table_matches=False)
+
+        # Star/wildcard - no used fields
+        if isinstance(expr, exp.Star):
+            return []
+
+        # Subquery
+        if isinstance(expr, exp.Subquery):
+            subquery_result = self._process_query(expr.this, sources, withs)
+            results = []
+            for field in subquery_result["used_fields"]:
+                results.append({"col": field})
+            return results
+
+        # SELECT in expression context
+        if isinstance(expr, exp.Select):
+            select_result = self._process_query(expr, sources, withs)
+            results = []
+            for field in select_result["used_fields"]:
+                results.append({"col": field})
+            return results
+
+        # Alias - recurse into the aliased expression
+        # Only propagate alias if the Alias directly wraps a Column.
+        # For complex expressions (functions, etc.), the alias belongs to the
+        # expression result, not to the columns used inside.
+        if isinstance(expr, exp.Alias):
+            results = self._find_used_fields(expr.this, sources, withs)
+            # Only add alias if this Alias directly wraps a Column
+            if isinstance(expr.this, exp.Column):
+                alias = expr.alias
+                for result in results:
+                    if "col" in result:
+                        result["col"]["alias"] = alias
+            return results
+
+        # Binary expressions (AND, OR, =, <, >, etc.)
+        if isinstance(expr, exp.Binary):
+            left = self._find_used_fields(expr.left, sources, withs)
+            right = self._find_used_fields(expr.right, sources, withs)
+            return left + right
+
+        # Unary expressions (NOT, -, etc.)
+        if isinstance(expr, exp.Unary):
+            return self._find_used_fields(expr.this, sources, withs)
+
+        # CASE expression
+        if isinstance(expr, exp.Case):
+            results = []
+            # CASE <expr> WHEN...
+            if expr.this:
+                results.extend(self._find_used_fields(expr.this, sources, withs))
+            # WHEN conditions and THEN values
+            for ifs in expr.args.get("ifs", []):
+                results.extend(self._find_used_fields(ifs.this, sources, withs))
+                results.extend(self._find_used_fields(ifs.args.get("true"), sources, withs))
+            # ELSE
+            if expr.args.get("default"):
+                results.extend(self._find_used_fields(expr.args["default"], sources, withs))
+            return results
+
+        # BETWEEN
+        if isinstance(expr, exp.Between):
+            results = []
+            results.extend(self._find_used_fields(expr.this, sources, withs))
+            results.extend(self._find_used_fields(expr.args.get("low"), sources, withs))
+            results.extend(self._find_used_fields(expr.args.get("high"), sources, withs))
+            return results
+
+        # IS NULL / IS NOT NULL
+        if isinstance(expr, (exp.Is,)):
+            return self._find_used_fields(expr.this, sources, withs)
+
+        # IN expression
+        if isinstance(expr, exp.In):
+            results = self._find_used_fields(expr.this, sources, withs)
+            for item in expr.expressions:
+                results.extend(self._find_used_fields(item, sources, withs))
+            return results
+
+        # EXISTS
+        if isinstance(expr, exp.Exists):
+            return self._find_used_fields(expr.this, sources, withs)
+
+        # Functions
+        if isinstance(expr, exp.Func):
+            results = []
+            for arg in expr.args.values():
+                if isinstance(arg, list):
+                    for item in arg:
+                        results.extend(self._find_used_fields(item, sources, withs))
+                elif isinstance(arg, exp.Expression):
+                    results.extend(self._find_used_fields(arg, sources, withs))
+            return results
+
+        # Window functions
+        if isinstance(expr, exp.Window):
+            results = []
+            results.extend(self._find_used_fields(expr.this, sources, withs))
+            # PARTITION BY
+            partition = expr.args.get("partition_by")
+            if partition:
+                for part in partition:
+                    results.extend(self._find_used_fields(part, sources, withs))
+            # ORDER BY within window
+            order = expr.args.get("order")
+            if order:
+                results.extend(self._find_used_fields(order, sources, withs))
+            return results
+
+        # ORDER BY clause
+        if isinstance(expr, exp.Order):
+            results = []
+            for ordered in expr.expressions:
+                results.extend(self._find_used_fields(ordered.this, sources, withs))
+            return results
+
+        # GROUP BY clause
+        if isinstance(expr, exp.Group):
+            results = []
+            for item in expr.expressions:
+                results.extend(self._find_used_fields(item, sources, withs))
+            return results
+
+        # Ordered (for ORDER BY items)
+        if isinstance(expr, exp.Ordered):
+            return self._find_used_fields(expr.this, sources, withs)
+
+        # Cast
+        if isinstance(expr, exp.Cast):
+            return self._find_used_fields(expr.this, sources, withs)
+
+        # Paren (parenthesized expression)
+        if isinstance(expr, exp.Paren):
+            return self._find_used_fields(expr.this, sources, withs)
+
+        # Interval, Literal, etc. - no columns
+        if isinstance(expr, (exp.Literal, exp.Interval, exp.DataType, exp.Boolean)):
+            return []
+
+        # Identifier (column name without table) - treat as column
+        if isinstance(expr, exp.Identifier):
+            # Create a fake column to reuse column resolution
+            fake_col = exp.Column(this=expr)
+            return self._get_column(sources, fake_col, return_table_matches=False)
+
+        # Fallback: try to walk children
+        results = []
+        for child in expr.iter_expressions():
+            results.extend(self._find_used_fields(child, sources, withs))
+        return results
+
+    def _get_column(self, sources, column_expr, return_table_matches):
+        """Get column reference with source resolution."""
+        column_name = column_expr.name
+        table_ref = column_expr.table
+
+        # Find valid sources
+        if table_ref:
+            source = self._find_source({"table": table_ref}, sources)
+            valid_sources = [[source]] if source else [[]]
+        else:
+            valid_sources = sources
+
+        # Build source_columns (nested list of possible sources)
+        # Pass through returned_fields from all sources (matching Macaw behavior).
+        # This preserves lineage back to original tables through CTEs/subqueries.
+        source_columns = []
+        for scope_sources in valid_sources:
+            if isinstance(scope_sources, list):
+                scope_fields = []
+                for source in scope_sources:
+                    if source and self._source_might_have_column(source, column_name, table_ref):
+                        returned_fields = source.get("returned_fields", [])
+                        scope_fields.extend(returned_fields)
+                if scope_fields:
+                    source_columns.append(scope_fields)
+
+        # Check for direct column match in source_columns (matching Macaw)
+        # Search in (first source_columns), not in the raw returned_fields
+        source_column = None
+        if source_columns:
+            for field in source_columns[0]:
+                field_name = field.get("alias") or field.get("column")
+                if field_name and field_name.lower() == column_name.lower():
+                    source_column = field
+                    break
+
+        # Check for table alias match (SELECT o FROM (SELECT * FROM orders) AS o)
+        if not source_column and not table_ref:
+            for scope_sources in valid_sources:
+                if isinstance(scope_sources, list):
+                    for source in scope_sources:
+                        if source:
+                            names = source.get("names", {})
+                            table_alias = names.get("table_alias") if names else None
+                            table_name = names.get("table") if names else None
+                            if table_alias and table_alias.lower() == column_name.lower():
+                                if return_table_matches:
+                                    return [{
+                                        "col": {
+                                            "type": "custom_field",
+                                            "alias": column_name,
+                                            # Don't freeze - goes directly to returned_fields
+                                            "used_fields": list(source.get("returned_fields", []))
+                                        }
+                                    }]
+                                else:
+                                    # Table alias match but not returning table matches - empty result
+                                    return []
+                            if table_name and table_name.lower() == column_name.lower():
+                                if return_table_matches:
+                                    return [{
+                                        "col": {
+                                            "type": "custom_field",
+                                            "alias": column_name,
+                                            # Don't freeze - goes directly to returned_fields
+                                            "used_fields": list(source.get("returned_fields", []))
+                                        }
+                                    }]
+                                else:
+                                    # Table name match but not returning table matches - empty result
+                                    return []
+
+        # Direct column match handling
+        # The source_columns in single_column entries already point to the correct source.
+        # For custom_field (computed columns like "0 AS level"), we need to create a
+        # single_column reference pointing to the source (e.g., the CTE).
+        if source_column:
+            col_type = source_column.get("type")
+            if col_type == "single_column":
+                # For recursive CTE self-references (like h.id in recursive CTE),
+                # create a CTE reference. For non-recursive CTEs, pass through the
+                # matched column (which already has correct source_columns).
+                if table_ref and not return_table_matches:
+                    source = self._find_source({"table": table_ref}, valid_sources)
+                    # Only create CTE reference for RECURSIVE CTEs
+                    if source and source.get("is_recursive_cte"):
+                        names = source.get("names") or {}
+                        table_info = {"table": names.get("table", table_ref)}
+                        if names.get("table_alias"):
+                            table_info["table_alias"] = names["table_alias"]
+                        return [{
+                            "col": {
+                                "type": "single_column",
+                                "column": column_name,
+                                "alias": None,
+                                "source_columns": [[{"type": "all_columns", "table": table_info}]]
+                            }
+                        }]
+                # For non-recursive CTEs and other cases: pass through matched column
+                result_col = dict(source_column)
+                # For unqualified reference with multiple scopes: use multi-level source_columns
+                if not table_ref and len(source_columns) > 1:
+                    result_col["source_columns"] = source_columns
+                return [{"col": result_col}]
+            elif col_type == "custom_field":
+                # Custom field has no source_columns (it's a computed expression).
+                # For recursive CTE self-references (like h.level in recursive CTE):
+                #   Create single_column with CTE reference
+                # For other CTE references (like m.month referencing non-recursive CTE):
+                #   Pass through custom_field to preserve structure
+                #
+                # Detection: is_recursive_cte flag is set during CTE processing
+                if table_ref:
+                    source = self._find_source({"table": table_ref}, valid_sources)
+                    if source and source.get("is_recursive_cte"):
+                        names = source.get("names") or {}
+                        table_info = {"table": names.get("table", table_ref)}
+                        if names.get("table_alias"):
+                            table_info["table_alias"] = names["table_alias"]
+                        source_ref = [[{"type": "all_columns", "table": table_info}]]
+                        return [{
+                            "col": {
+                                "type": "single_column",
+                                "column": column_name,
+                                "alias": None,
+                                "source_columns": source_ref
+                            }
+                        }]
+                # Return custom_field as-is to preserve structure
+                return [{"col": source_column}]
+            # For composite_field, etc.: return as-is to preserve structure
+            else:
+                return [{"col": source_column}]
+
+        # No direct match - return single_column with source_columns
+        errors = set()
+        if not source_columns or not any(source_columns):
+            # No potential sources found
+            if table_ref:
+                # Table qualifier doesn't exist - return error only, no col spec
+                # (Returning a col with empty source_columns would cause Clojure's
+                # resolve-field to generate a redundant missing-column error)
+                return [{"errors": {self._missing_table_alias_error(table_ref)}}]
+            else:
+                errors.add(self._missing_column_error(column_name))
+
+        return [{
+            "col": {
+                "type": "single_column",
+                "column": column_name,
+                "alias": None,
+                "source_columns": source_columns
+            },
+            "errors": errors
+        }]
+
+    def _find_source(self, search, sources):
+        """Find a source matching the search criteria."""
+        for scope_sources in sources:
+            if isinstance(scope_sources, list):
+                for source in scope_sources:
+                    if source and self._table_matches(search, source.get("names", {})):
+                        return source
+        return None
+
+    def _table_matches(self, search, table_names):
+        """Check if search criteria match table names."""
+        if not table_names:
+            return False
+        search_table = search.get("table")
+        search_schema = search.get("schema")
+        search_database = search.get("database")
+
+        # Match by alias first (if no schema/database in search)
+        if search_table and not search_schema and not search_database:
+            if table_names.get("table_alias") == search_table:
+                return True
+
+        # Match by table/schema/database
+        if search_table and search_table != table_names.get("table"):
+            return False
+        if search_schema and search_schema != table_names.get("schema"):
+            return False
+        if search_database and search_database != table_names.get("database"):
+            return False
+
+        return search_table == table_names.get("table")
+
+    def _source_might_have_column(self, source, column_name, table_ref):
+        """Check if a source might contain a column."""
+        if not source:
+            return False
+
+        # If table ref specified, check if it matches (case-insensitive since
+        # SQLGlot may lowercase identifiers)
+        if table_ref:
+            names = source.get("names", {})
+            if names:
+                table_alias = names.get("table_alias")
+                table_name = names.get("table")
+                if table_alias and table_alias.lower() == table_ref.lower():
+                    return True
+                if table_name and table_name.lower() == table_ref.lower():
+                    return True
+            return False
+
+        # No table ref - source might have column
+        return True
+
+    def _freeze_field(self, field):
+        """Convert a field dict to a hashable frozenset for use in sets."""
+        if field is None:
+            return None
+        if isinstance(field, (str, int, float, bool)):
+            return field
+        if isinstance(field, frozenset):
+            return field
+        if isinstance(field, set):
+            return frozenset(self._freeze_field(item) for item in field)
+        if isinstance(field, (list, tuple)):
+            return tuple(self._freeze_field(item) for item in field)
+        if isinstance(field, dict):
+            items = []
+            for k, v in field.items():
+                items.append((k, self._freeze_field(v)))
+            return frozenset(items)
+        return field
+
+    def _unfreeze_field(self, frozen):
+        """Convert a frozen field back to a dict."""
+        if frozen is None:
+            return None
+        if isinstance(frozen, (str, int, float, bool)):
+            return frozen
+
+        # frozenset of tuples -> dict
+        if isinstance(frozen, frozenset):
+            # Check if it looks like a dict (frozenset of 2-tuples)
+            try:
+                items = list(frozen)
+                if items and all(isinstance(item, tuple) and len(item) == 2 for item in items):
+                    # It's a frozen dict
+                    result = {}
+                    for k, v in items:
+                        result[k] = self._unfreeze_field(v)
+                    return result
+                else:
+                    # It's a frozen set of items
+                    return [self._unfreeze_field(item) for item in frozen]
+            except:
+                return [self._unfreeze_field(item) for item in frozen]
+
+        # tuple -> list
+        if isinstance(frozen, tuple):
+            return [self._unfreeze_field(item) for item in frozen]
+
+        # list -> list (recursively unfreeze items)
+        if isinstance(frozen, list):
+            return [self._unfreeze_field(item) for item in frozen]
+
+        # dict -> dict (recursively unfreeze values)
+        if isinstance(frozen, dict):
+            return {k: self._unfreeze_field(v) for k, v in frozen.items()}
+
+        return frozen
+
+    def _syntax_error(self):
+        """Create a syntax error."""
+        return frozenset([("type", "syntax_error")])
+
+    def _missing_table_alias_error(self, table_name):
+        """Create a missing table alias error."""
+        return frozenset([("type", "missing_table_alias"), ("table", table_name)])
+
+    def _missing_column_error(self, column_name):
+        """Create a missing column error."""
+        return frozenset([("type", "missing_column"), ("column", column_name)])
+
+#############################################################################
+# Transpile sql
+#############################################################################
+
+_METABASE_TEMPLATE_RE = re.compile(r"\{\{|\[\[")
+
+def has_metabase_templates(sql: str) -> bool:
+    """Detect if SQL contains any Metabase template syntax.
+
+    Metabase templates include:
+    - {{variable}} - basic variables
+    - {{#model_id}} - model references
+    - {{snippet: name}} - SQL snippets
+    - [[optional clause]] - optional filter clauses
+
+    We skip validation for templated queries because accurately normalizing
+    all template types for parsing is brittle. For example, model references
+    can appear as subqueries in CTEs or EXISTS clauses, not just FROM clauses.
+    """
+    return bool(_METABASE_TEMPLATE_RE.search(sql))
+
+# Dialects that require identifier quoting due to case sensitivity.
+# These dialects fold unquoted identifiers to uppercase or lowercase,
+# which can cause issues when the LLM generates mixed-case identifiers.
+CASE_SENSITIVE_DIALECTS: set[str] = {
+    "snowflake",  # Folds unquoted to UPPERCASE
+    "oracle",  # Folds unquoted to UPPERCASE
+    "redshift",  # PostgreSQL-based, folds to lowercase
+    "postgres",  # Folds unquoted to lowercase
+}
+
+def transpile_sql(sql: str, from_dialect: str = None, to_dialect: str = None):
+    """Transpile sql string from one dialect to another.
+
+    Args:
+        sql: SQL query string
+        from_dialect: source sql dialect
+        to_dialect: target sql dialect
+
+    Returns:
+        JSON string with keys transpiled and use_identify on success.
+        On failure the object contains keys is_valid and error_message.
+    """
+    result = {}
+    if has_metabase_templates(sql):
+        result['transpiled_sql'] = sql
+        result['status'] = 'skipped'
+        result['reason'] = 'contains_templates'
+    elif not from_dialect or not to_dialect:
+        result['transpiled_sql'] = sql
+        result['status'] = 'skipped'
+        result['reason'] = 'missing_dialect'
+    else:
+        try:
+            use_identify = (from_dialect in CASE_SENSITIVE_DIALECTS 
+                            or to_dialect in CASE_SENSITIVE_DIALECTS)
+
+            transpiled = sqlglot.transpile(
+                sql,
+                read=from_dialect,
+                write=to_dialect,
+                pretty=True,
+                identify=use_identify,
+            )
+
+            if len(transpiled) > 1:
+                result['status'] = 'error'
+                result['error_message'] = 'Multiple SQL statements are not supported. Please provide a single query.'
+            else:
+                result['transpiled_sql'] = transpiled[0]
+                result['status'] = 'success'
+        except Exception as e:
+            result['status'] = 'error'
+            result['error_message'] = e.args[0]
+
+    return json.dumps(result)

--- a/resources/python-sources/uv.lock
+++ b/resources/python-sources/uv.lock
@@ -1,0 +1,23 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "metabase-python-deps"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "sqlglot" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "sqlglot", specifier = "==28.6.0" }]
+
+[[package]]
+name = "sqlglot"
+version = "28.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/b6/f188b9616bef49943353f3622d726af30fdb08acbd081deef28ba43ceb48/sqlglot-28.6.0.tar.gz", hash = "sha256:8c0a432a6745c6c7965bbe99a17667c5a3ca1d524a54b31997cf5422b1727f6a", size = 5676522, upload-time = "2026-01-13T17:39:24.389Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/a6/21b1e19994296ba4a34bc7abaf4fcb40d7e7787477bdfde58cd843594459/sqlglot-28.6.0-py3-none-any.whl", hash = "sha256:8af76e825dc8456a49f8ce049d69bbfcd116655dda3e53051754789e2edf8eba", size = 575186, upload-time = "2026-01-13T17:39:22.327Z" },
+]

--- a/src/metabase/sql_parsing/common.clj
+++ b/src/metabase/sql_parsing/common.clj
@@ -1,0 +1,8 @@
+(ns metabase.sql-parsing.common
+  (:require
+   [potemkin :as p]))
+
+(p/defprotocol+ PythonEval
+  "Protocol for evaluating Python code. Abstracts over raw Context and pooled contexts."
+  (eval-python [this code]
+    "Evaluate Python code."))

--- a/src/metabase/sql_parsing/core.clj
+++ b/src/metabase/sql_parsing/core.clj
@@ -1,0 +1,415 @@
+(ns metabase.sql-parsing.core
+  "Stateless SQL parsing via sqlglot (Python) and GraalVM Polyglot.
+
+  This module provides dialect-aware SQL parsing with no Metabase dependencies.
+  All functions take strings and return strings/simple data structures.
+
+  API:
+    (referenced-tables sql dialect) → [[catalog schema table] ...]
+    (referenced-fields dialect sql) → [[catalog schema table field] ...]
+    (returned-columns-lineage dialect sql schema schema-map) → [[col pure? deps] ...]
+    (validate-query dialect sql schema schema-map) → {:status :ok} | {:status :error ...}"
+  (:require
+   [clojure.string :as str]
+   [medley.core :as m]
+   [metabase.sql-parsing.common :as common]
+   [metabase.sql-parsing.pool :as python.pool]
+   [metabase.util :as u]
+   [metabase.util.json :as json]
+   [metabase.util.log :as log])
+  (:import
+   (java.io Closeable)
+   (java.util.concurrent ExecutionException TimeoutException)
+   (org.graalvm.polyglot Value)))
+
+(set! *warn-on-reflection* true)
+
+;;; -------------------------------------------------- Timeout handling --------------------------------------------------
+
+(def ^:private ^:const default-timeout-ms
+  "Default timeout for Python operations in milliseconds.
+   GraalVM Python can occasionally hang (DEV-1393), so we wrap calls with a timeout."
+  30000) ; 30 seconds
+
+(defn- with-timeout*
+  "Execute f in a future with timeout. On timeout, throws TimeoutException.
+   The caller is responsible for cleaning up resources (e.g., disposing context)."
+  [timeout-ms f]
+  (let [fut (future (f))]
+    (try
+      (deref fut timeout-ms ::timeout)
+      (catch ExecutionException e
+        ;; Unwrap execution exception to get the real cause
+        (throw (or (.getCause e) e)))
+      (finally
+        ;; If we timed out or got an exception, try to cancel the future
+        ;; Note: This won't actually interrupt GraalVM, but prevents resource leaks
+        (future-cancel fut)))))
+
+(defmacro ^:private with-python-timeout
+  "Execute body with a timeout. If timeout is reached:
+   1. Interrupts the GraalVM context (actually stops execution)
+   2. Poisons context so it gets disposed rather than returned to pool
+   3. Logs warning and throws TimeoutException"
+  [ctx timeout-ms & body]
+  `(let [result# (with-timeout* ~timeout-ms (^:once fn* [] ~@body))]
+     (if (= result# ::timeout)
+       (do
+         ;; Actually interrupt the GraalVM context (1s grace period for soft interrupt)
+         ;; This is necessary because future-cancel doesn't stop GraalVM execution
+         (python.pool/interrupt! ~ctx 1000)
+         (python.pool/poison! ~ctx)
+         (log/warn "Python execution timed out after" ~timeout-ms "ms - GraalVM interrupted")
+         (throw (TimeoutException. (str "Python execution timed out after " ~timeout-ms "ms"))))
+       result#)))
+
+;;; -------------------------------------------------- Public API --------------------------------------------------
+
+(defn referenced-tables
+  "Extract table references from SQL.
+
+   Returns a vector of [catalog schema table] 3-tuples:
+   [[nil nil \"users\"] [nil \"public\" \"orders\"] [\"myproject\" \"analytics\" \"events\"]]
+
+   This is the pure parsing layer - it returns what's literally in the SQL.
+   Default schema resolution happens in the matching layer (core.clj)."
+  [dialect sql]
+  (-> (with-open [^Closeable ctx (python.pool/python-context)]
+        (with-python-timeout ctx default-timeout-ms
+          (-> ^Value (common/eval-python ctx "sql_tools.referenced_tables")
+              (.execute ^Value (object-array [sql dialect]))
+              .asString)))
+      json/decode
+      vec))
+
+(defn referenced-fields
+  "Extract field references from SQL, returning only fields from actual database tables.
+
+   Returns a vector of [catalog schema table field] 4-tuples:
+   [[nil nil \"users\" \"id\"] [nil \"public\" \"orders\" \"total\"]]
+
+   Includes:
+   - Wildcards as [catalog schema table \"*\"]
+   - All specific column references
+
+   Excludes:
+   - Fields from CTEs or subqueries
+   - Table aliases (returns actual table names)
+
+   Examples:
+   (referenced-fields \"postgres\" \"SELECT id FROM users\")
+   => [[nil nil \"users\" \"id\"]]
+
+   (referenced-fields \"postgres\" \"SELECT * FROM public.users\")
+   => [[nil \"public\" \"users\" \"*\"]]
+
+   (referenced-fields \"bigquery\" \"SELECT * FROM myproject.analytics.events\")
+   => [[\"myproject\" \"analytics\" \"events\" \"*\"]]"
+  [dialect sql]
+  (-> (with-open [^Closeable ctx (python.pool/python-context)]
+        (with-python-timeout ctx default-timeout-ms
+          (-> ^Value (common/eval-python ctx "sql_tools.referenced_fields")
+              (.execute ^Value (object-array [sql dialect]))
+              .asString)))
+      json/decode
+      vec))
+
+(defn returned-columns-lineage
+  "Extract column lineage from SQL query, showing which output columns depend on which source columns.
+
+   Returns a vector of [alias pure? [[schema table col]...]] tuples:
+   - alias: The output column name/alias
+   - pure?: Boolean - true if the column is a direct pass-through from a source column
+   - deps: Vector of [schema table column] dependencies
+
+   Requires a schema map of the form:
+   {\"schema_name\" {\"table_name\" {\"column_name\" \"TYPE\"}}}
+
+   Examples:
+   (returned-columns-lineage \"postgres\" \"SELECT id FROM users\" nil {nil {\"users\" {\"id\" \"INT\"}}})
+   => [[\"id\" true [[[nil \"users\" \"id\"]]]]]
+
+   (returned-columns-lineage \"postgres\" \"SELECT id + 1 as computed FROM users\" nil schema)
+   => [[\"computed\" false [[[nil \"users\" \"id\"]]]]]"
+  [dialect sql default-table-schema sqlglot-schema]
+  (-> (with-open [^Closeable ctx (python.pool/python-context)]
+        (with-python-timeout ctx default-timeout-ms
+          ;; JSON-encode schema to avoid GraalVM polyglot map conversion issues
+          (-> ^Value (common/eval-python ctx "sql_tools.returned_columns_lineage")
+              (.execute ^Value (object-array [dialect
+                                              sql
+                                              default-table-schema
+                                              (json/encode sqlglot-schema)]))
+              .asString)))
+      json/decode
+      vec))
+
+(defn validate-query
+  "Validate a SQL query against a schema using sqlglot's qualify optimizer.
+
+   Operates in two modes based on whether a schema is provided:
+
+   **Strict mode** (sqlglot-schema provided):
+   Validates that column and table references exist in the provided schema.
+   Returns errors for unknown tables, unresolved columns, missing table aliases.
+
+   **Permissive mode** (sqlglot-schema is nil or empty):
+   Only checks SQL syntax. Infers schema from query structure.
+   Useful for UDTFs and queries where the schema is unknown.
+
+   Parameters:
+   - dialect: SQLGlot dialect string (e.g., \"postgres\", \"mysql\"), or nil
+   - sql: The SQL query string to validate
+   - default-table-schema: Default schema name for unqualified table references
+   - sqlglot-schema: Schema map of {schema-name {table-name {column-name type}}},
+                     or nil/empty for permissive mode
+
+   Returns a map with:
+   - If valid: {:status \"ok\"}
+   - If error: {:status \"error\", :type \"...\", :message \"...\", ...}
+
+   Error types (strict mode):
+   - \"unknown_table\": Table not found in schema
+   - \"column_not_resolved\": Column not found (includes :column key)
+   - \"invalid_expression\": Syntax/parse error
+   - \"unhandled\": Other errors"
+  [dialect sql default-table-schema & [sqlglot-schema]]
+  (-> (with-open [^Closeable ctx (python.pool/python-context)]
+        (with-python-timeout ctx default-timeout-ms
+          ;; JSON-encode schema to avoid GraalVM polyglot map conversion issues
+          (-> ^Value (common/eval-python ctx "sql_tools.validate_query")
+              (.execute ^Value (object-array [dialect sql default-table-schema (json/encode (or sqlglot-schema "{}"))]))
+              .asString)))
+      json/decode+kw))
+
+(defn simple-query?
+  "Check if SQL is a simple SELECT without LIMIT, OFFSET, or CTEs.
+
+   Used by Workspaces to determine if automatic checkpoints can be inserted.
+
+   Parameters:
+   - dialect: SQLGlot dialect string (e.g., \"postgres\", \"mysql\"), or nil for default
+   - sql: The SQL query string to check
+
+   Returns a map with:
+   - :is_simple - boolean indicating if query is simple
+   - :reason - string explaining why query is not simple (when false)
+
+   Examples:
+   (simple-query? \"postgres\" \"SELECT * FROM users\")
+   => {:is_simple true}
+
+   (simple-query? nil \"SELECT * FROM users LIMIT 10\")
+   => {:is_simple false :reason \"Contains a LIMIT\"}"
+  [dialect sql]
+  (-> (with-open [^Closeable ctx (python.pool/python-context)]
+        (with-python-timeout ctx default-timeout-ms
+          (-> ^Value (common/eval-python ctx "sql_tools.simple_query")
+              (.execute ^Value (object-array [sql dialect]))
+              .asString)))
+      json/decode+kw))
+
+(defn add-into-clause
+  "Add an INTO clause to a SELECT statement for SQL Server SELECT INTO syntax.
+
+   Transforms: 'SELECT * FROM products'
+   Into:       'SELECT * INTO \"TABLE\" FROM products'
+
+   Used by SQL Server compile-transform which requires SELECT INTO syntax
+   instead of CREATE TABLE AS SELECT.
+
+   Parameters:
+   - dialect: SQLGlot dialect string (e.g., \"tsql\" for SQL Server)
+   - sql: The SELECT SQL query string
+   - table-name: The target table name (already formatted/quoted)
+
+   Returns: Modified SQL string with INTO clause"
+  [dialect sql table-name]
+  (with-open [^Closeable ctx (python.pool/python-context)]
+    (with-python-timeout ctx default-timeout-ms
+      (-> ^Value (common/eval-python ctx "sql_tools.add_into_clause")
+          (.execute ^Value (object-array [sql table-name dialect]))
+          .asString))))
+
+(defn- convert-field-type
+  "Convert field type string (snake_case) to keyword (kebab-case)."
+  [type-str]
+  (-> type-str
+      (str/replace "_" "-")
+      keyword))
+
+(defn- convert-error
+  "Convert Python error format to Metabase lib error format."
+  [error]
+  (let [;; Get type from various possible key formats
+        err-type (or (:type error) (get error "type"))
+        ;; Get name/table/column from various possible formats
+        table-name (or (:table error) (get error "table"))
+        column-name (or (:column error) (get error "column") (:name error) (get error "name"))]
+    (cond
+      ;; Python frozenset came through as vector of pairs: [["type" "syntax_error"]]
+      (and (sequential? error) (sequential? (first error)))
+      (let [m (into {} error)
+            err-type (get m "type")]
+        (case err-type
+          "syntax_error" {:type :syntax-error}
+          "missing_column" {:type :missing-column :name (get m "column")}
+          "missing_table_alias" {:type :missing-table-alias :name (get m "table")}
+          {:type (keyword err-type)}))
+
+      ;; Handle string or keyword types
+      (or (string? err-type) (keyword? err-type))
+      (case (if (keyword? err-type) (name err-type) err-type)
+        ("syntax-error" "syntax_error") {:type :syntax-error}
+        ("missing-column" "missing_column") {:type :missing-column :name column-name}
+        ("missing-table-alias" "missing_table_alias") {:type :missing-table-alias :name table-name}
+        {:type (keyword err-type)})
+
+      :else error)))
+
+(defn- convert-field
+  "Convert a field spec from Python format to Clojure format."
+  [field]
+  (when field
+    (let [field-type (some-> (or (:type field) (get field "type")) convert-field-type)]
+      (case field-type
+        :single-column
+        {:type :single-column
+         :column (or (:column field) (get field "column"))
+         :alias (or (:alias field) (get field "alias"))
+         :source-columns (mapv (fn [scope]
+                                 (mapv convert-field scope))
+                               (or (:source-columns field)
+                                   (:source_columns field)
+                                   (get field "source_columns")
+                                   []))}
+
+        :all-columns
+        {:type :all-columns
+         :table (let [t (or (:table field) (get field "table"))]
+                  (cond-> {}
+                    (or (:table t) (get t "table"))
+                    (assoc :table (or (:table t) (get t "table")))
+                    (or (:schema t) (get t "schema"))
+                    (assoc :schema (or (:schema t) (get t "schema")))
+                    (or (:database t) (get t "database"))
+                    (assoc :database (or (:database t) (get t "database")))
+                    (or (:table-alias t) (:table_alias t) (get t "table_alias"))
+                    (assoc :table-alias (or (:table-alias t) (:table_alias t) (get t "table_alias")))))}
+
+        :custom-field
+        {:type :custom-field
+         :alias (or (:alias field) (get field "alias"))
+         :used-fields (set (map convert-field
+                                (or (:used-fields field)
+                                    (:used_fields field)
+                                    (get field "used_fields")
+                                    [])))}
+
+        :composite-field
+        {:type :composite-field
+         :alias (or (:alias field) (get field "alias"))
+         :member-fields (mapv convert-field
+                              (or (:member-fields field)
+                                  (:member_fields field)
+                                  (get field "member_fields")
+                                  []))}
+
+        :unknown-columns
+        {:type :unknown-columns}
+
+        ;; Fallback - return as-is with type conversion
+        (assoc field :type field-type)))))
+
+(defn field-references
+  "Extract field references from SQL, returning used and returned fields.
+
+   This is the SQLGlot equivalent of Macaw's field-references function.
+   Returns a map with:
+   - :used-fields - set of field specs from WHERE, JOIN ON, GROUP BY, ORDER BY
+   - :returned-fields - vector of field specs from SELECT clause (ordered)
+   - :errors - set of validation errors
+
+   Each field spec has:
+   - :type - :single-column, :all-columns, :custom-field, :composite-field, or :unknown-columns
+   - :column - column name (for single-column)
+   - :alias - column alias (nil if none)
+   - :source-columns - nested list of possible source columns
+   - :table - table info (for all-columns)
+   - :used-fields - set of fields used (for custom-field)
+   - :member-fields - list of fields (for composite-field)
+
+   On timeout, returns an error map instead of throwing, consistent with the
+   'fail soft' pattern used for parsing failures."
+  [dialect sql]
+  (try
+    (let [raw (-> (with-open [^Closeable ctx (python.pool/python-context)]
+                    (with-python-timeout ctx default-timeout-ms
+                      (-> ^Value (common/eval-python ctx "sql_tools.field_references")
+                          (.execute ^Value (object-array [sql dialect]))
+                          .asString)))
+                  json/decode+kw)
+          used-fields (or (:used-fields raw) (:used_fields raw) (get raw "used_fields") [])
+          returned-fields (or (:returned-fields raw) (:returned_fields raw) (get raw "returned_fields") [])
+          errors (or (:errors raw) (get raw "errors") [])]
+      {:used-fields (set (map convert-field used-fields))
+       :returned-fields (vec (map convert-field returned-fields))
+       :errors (set (map convert-error errors))})
+    (catch TimeoutException e
+      {:used-fields #{}
+       :returned-fields []
+       :errors #{{:type :timeout :message (.getMessage e)}}})))
+
+(defn replace-names
+  "Replace schema, table, and column names in SQL.
+
+   Parameters:
+   - dialect: SQLGlot dialect string (e.g., \"postgres\", \"mysql\"), or nil
+   - sql: The SQL query string
+   - replacements: A map with optional keys:
+     - :schemas - map of old-schema-name -> new-schema-name
+     - :tables - seq of [[{:schema s :table t} new-name] ...]
+     - :columns - seq of [[{:schema s :table t :column c} new-name] ...]
+
+   Returns modified SQL string.
+
+   SECURITY: Replacement values are injected into the SQL AST as identifier names
+   without sanitization. Callers MUST ensure replacement values are system-generated.
+   See sql_tools.py replace_names for details.
+
+   Examples:
+   (replace-names \"postgres\" \"SELECT * FROM people\" {:tables [[{:table \"people\"} \"users\"]]})
+   => \"SELECT * FROM users\""
+  [dialect sql replacements]
+  (with-open [^Closeable ctx (python.pool/python-context)]
+    (with-python-timeout ctx default-timeout-ms
+      (-> ^Value (common/eval-python ctx "sql_tools.replace_names")
+          (.execute ^Value (object-array [sql (json/encode replacements) dialect]))
+          .asString))))
+
+(comment
+  (referenced-tables "postgres" "select * from transactions")
+
+  (validate-sql-query "postgres" "SELECT * FROM users")
+
+  (referenced-fields "postgres" "SELECT id, name FROM users WHERE active = true"))
+
+;;;; Transpile sql
+
+(defn- normalize-transpilation-result
+  [json-str]
+  (-> json-str
+      json/decode+kw
+      (update-keys (comp keyword u/->kebab-case-en))
+      (m/update-existing :status (comp keyword u/->kebab-case-en))
+      (m/update-existing :reason (comp keyword u/->kebab-case-en))))
+
+(defn transpile-sql
+  "Transpiles sql string from one dialect to another."
+  [sql from-dialect to-dialect]
+  (-> (with-open [^Closeable ctx (python.pool/python-context)]
+        (with-python-timeout ctx default-timeout-ms
+          (-> ^Value (common/eval-python ctx "sql_tools.transpile_sql")
+              (.execute ^Value (object-array [sql from-dialect to-dialect]))
+              .asString)))
+      normalize-transpilation-result))

--- a/src/metabase/sql_parsing/pool.clj
+++ b/src/metabase/sql_parsing/pool.clj
@@ -1,0 +1,310 @@
+(ns metabase.sql-parsing.pool
+  "Namespace to handle python environment. Has only a single public function, [[python-context]] which will return a
+  python context. This is an internal detail to the sql-parsing module. If you want something from this, add a
+  function to the core namespace that uses this. No one should know about this implmentation detail."
+  (:require
+   [clojure.java.io :as io]
+   [clojure.java.shell :as shell]
+   [clojure.string :as str]
+   [metabase.sql-parsing.common :as common]
+   [metabase.util.files :as u.files]
+   [metabase.util.log :as log]
+   [potemkin :as p])
+  (:import
+   (io.aleph.dirigiste
+    IPool$Controller
+    IPool$Generator
+    Pool
+    Pools)
+   (java.io Closeable File)
+   (java.nio.file Files Path)
+   (java.time Duration)
+   (java.util.concurrent TimeUnit TimeoutException)
+   (org.graalvm.polyglot Context HostAccess)))
+
+(set! *warn-on-reflection* true)
+
+;;; -------------------------------------------------- Python path resolution --------------------------------------------------
+
+(def ^:private python-sources-resource
+  "Resource path for Python sources (sql_tools.py and sqlglot)."
+  "python-sources")
+
+(defn- plugins-dir-path
+  "Get path to plugins directory. Lightweight alternative to metabase.plugins.core/plugins-dir
+   that avoids loading the entire plugin system (~8 seconds of namespace loading)."
+  ^Path []
+  (let [dir-name (or (System/getenv "MB_PLUGINS_DIR")
+                     "plugins")
+        path     (u.files/get-path dir-name)]
+    (u.files/create-dir-if-not-exists! path)
+    path))
+
+(defn- jar-resource?
+  "True if the given resource is inside a JAR (production), false if from filesystem (dev)."
+  [resource]
+  (boolean
+   (when-let [url (io/resource resource)]
+     (.contains (.getFile ^java.net.URL url) ".jar!/"))))
+
+(defn- copy-dir-recursive!
+  "Recursively copy all files from source Path to dest Path.
+  Works across filesystems (e.g., from JAR filesystem to default filesystem)."
+  [^Path source ^Path dest]
+  (doseq [^Path child (u.files/files-seq source)]
+    (let [relative-name (str (.getFileName child))
+          target        (.resolve dest relative-name)]
+      (if (Files/isDirectory child (into-array java.nio.file.LinkOption []))
+        (do
+          (u.files/create-dir-if-not-exists! target)
+          (copy-dir-recursive! child target))
+        (log/with-no-logs ;; <-- Suppress per-file logs from copy-file! (hundreds of files in sqlglot)
+          (u.files/copy-file! child target))))))
+
+(defn- extract-python-sources!
+  "Extract python-sources from JAR to plugins directory. Returns the path as a string.
+  Uses the same plugins directory as driver modules for consistency.
+  Skips extraction if version file matches."
+  ^String []
+  (let [^Path plugins-path (plugins-dir-path)
+        dest-path          (.resolve plugins-path "python-sources")
+        version-file       (.resolve dest-path "pyproject.toml")
+        jar-version        (some-> (io/resource "python-sources/pyproject.toml") slurp str/trim)
+        dest-version       (when (u.files/exists? version-file)
+                             (str/trim (slurp (.toFile version-file))))]
+    (if (and jar-version (= jar-version dest-version))
+      (log/info "Python sources already extracted (version" jar-version ")")
+      (do
+        (u.files/create-dir-if-not-exists! dest-path)
+        (log/info "Extracting Python sources to" (str dest-path))
+        (u.files/with-open-path-to-resource [source-path python-sources-resource]
+          (copy-dir-recursive! source-path dest-path))
+        (log/info "Python sources extracted")))
+    (str dest-path)))
+
+;;; -------------------------------------------------- Dev lazy installation --------------------------------------------------
+
+(def ^:private dev-python-sources-dir
+  "Directory where sqlglot is installed in dev mode."
+  "resources/python-sources")
+
+(defn- delete-recursive!
+  "Recursively delete a directory and all its contents."
+  [^File f]
+  (when (.isDirectory f)
+    (doseq [child (.listFiles f)]
+      (delete-recursive! child)))
+  (.delete f))
+
+(defn- expected-sqlglot-version
+  "Read the expected sqlglot version from pyproject.toml resource file."
+  []
+  (some->> (io/resource "python-sources/pyproject.toml")
+           slurp
+           (re-find #"\"sqlglot==([^\"]+)\"")
+           second))
+
+(defn- package-installer-available?
+  "Check if uv or pip is available for installing Python packages."
+  []
+  (or (zero? (:exit (shell/sh "which" "uv")))
+      (zero? (:exit (shell/sh "which" "pip")))))
+
+(defn- version-installed?
+  "Check if sqlglot is installed with the expected version by looking for the dist-info directory."
+  [target-dir expected-version]
+  (let [dist-info (io/file target-dir (str "sqlglot-" expected-version ".dist-info"))]
+    (.exists dist-info)))
+
+(defn- install-sqlglot!
+  "Install sqlglot via uv (preferred) or pip (fallback).
+  Deletes any existing sqlglot directories first to handle version upgrades."
+  [target-dir version]
+  ;; Delete old versions first (sqlglot/ and any sqlglot-*.dist-info/)
+  (doseq [^File f (.listFiles (io/file target-dir))]
+    (when (or (= "sqlglot" (.getName f))
+              (.startsWith (.getName f) "sqlglot-"))
+      (log/info "Removing old sqlglot:" (.getName f))
+      (delete-recursive! f)))
+  ;; Try uv first (fast), fall back to pip
+  (let [pyproject-file (str target-dir "/pyproject.toml")
+        uv-result      (shell/sh "uv" "pip" "install" "-r" pyproject-file "--target" target-dir "--no-compile")]
+    (if (zero? (:exit uv-result))
+      (log/info "sqlglot" version "installed via uv")
+      (do
+        (log/info "uv not available, trying pip...")
+        (let [pkg        (str "sqlglot==" version)
+              pip-result (shell/sh "pip" "install" pkg "--target" target-dir "--no-compile")]
+          (when-not (zero? (:exit pip-result))
+            (throw (ex-info (str "Failed to install sqlglot. Please install uv (recommended) or pip.\n"
+                                 "Manual install: uv pip install -r " pyproject-file " --target " target-dir "\n"
+                                 "Install uv: https://docs.astral.sh/uv/getting-started/installation/")
+                            {:uv-error   (:err uv-result)
+                             :pip-error  (:err pip-result)
+                             :version    version
+                             :target-dir target-dir})))
+          (log/info "sqlglot" version "installed via pip"))))))
+
+(defn- ensure-sqlglot-installed!
+  "Ensure sqlglot is installed with correct version. Called lazily on first use in dev.
+  If version mismatch or missing, automatically installs the correct version."
+  []
+  (let [expected-ver (expected-sqlglot-version)]
+    (when-not expected-ver
+      (throw (ex-info "Missing pyproject.toml or unable to parse sqlglot entry in resources/python-sources/"
+                      {:resource "python-sources/pyproject.toml"})))
+    (when-not (version-installed? dev-python-sources-dir expected-ver)
+      (if (package-installer-available?)
+        (do
+          (log/info "Installing sqlglot" expected-ver "(first use in dev)...")
+          (install-sqlglot! dev-python-sources-dir expected-ver))
+        (log/warn "sqlglot not installed and no package installer (uv or pip) found."
+                  "SQL parsing features will fail until sqlglot is installed."
+                  "Install uv: https://docs.astral.sh/uv/getting-started/installation/")))))
+
+;;; -------------------------------------------------- Python path delay --------------------------------------------------
+
+(defonce ^:private
+  ^{:doc "Path to Python sources directory. In dev, this is resources/python-sources.
+          When running from a JAR, we extract to the plugins directory.
+          In dev, lazily installs sqlglot if not present or version mismatched."}
+  python-path
+  (delay
+    (if (jar-resource? python-sources-resource)
+      (extract-python-sources!)
+      (do
+        (ensure-sqlglot-installed!)
+        dev-python-sources-dir))))
+
+;;; -------------------------------------------- Context Wrappers ----------------------------------------------------
+
+(p/defrecord+ PooledContext [^Context context ^Pool pool tuple poisoned?]
+  common/PythonEval
+  (eval-python [_this code]
+    (.eval context "python" ^String code))
+
+  Closeable
+  (close [_this]
+    (if @poisoned?
+      (do
+        (log/warn "Disposing poisoned Python context (likely hung GraalVM)")
+        (.dispose pool :python tuple))
+      (.release pool :python tuple))))
+
+(defn poison!
+  "Mark a PooledContext as poisoned. When closed, it will be disposed from the pool
+   rather than released back. Use this when GraalVM hangs to prevent returning a
+   broken context to the pool."
+  [ctx]
+  (when (instance? PooledContext ctx)
+    (reset! (:poisoned? ctx) true)))
+
+(defn interrupt!
+  "Interrupt Python execution in this context. Returns true if interrupted successfully.
+   If interrupt times out (guest in uninterruptible code), forces context closure with close(true).
+   This is necessary because future-cancel doesn't actually stop GraalVM execution."
+  [ctx ^long timeout-ms]
+  (when-let [^Context raw-ctx (when (instance? PooledContext ctx)
+                                (:context ctx))]
+    (try
+      (.interrupt raw-ctx (Duration/ofMillis timeout-ms))
+      true
+      (catch TimeoutException _
+        ;; Interrupt timed out - guest app may be in uninterruptible native code
+        ;; Force close cannot be denied by guest application
+        (log/warn "GraalVM interrupt timed out, forcing context closure")
+        (.close raw-ctx true)
+        false))))
+
+(defn- create-graalvm-context
+  "Create a new GraalVM Python context configured for sqlglot.
+
+  The context is configured with:
+  - PythonPath pointing to python-sources (contains sql_tools.py and sqlglot)
+  - Full host access (needed for JSON serialization)
+  - IO access enabled (for Python imports)"
+  ^Context []
+  (let [ctx (.. (Context/newBuilder (into-array String ["python"]))
+                (option "engine.WarnInterpreterOnly" "false")
+                ;; python-sources contains both sql_tools.py shim and installed sqlglot
+                (option "python.PythonPath" @python-path)
+                (allowHostAccess HostAccess/ALL)
+                (allowIO true)
+                (build))]
+    (.eval ctx "python" "import sql_tools")
+    ctx))
+
+(defn- make-python-context-pool
+  "Create a pool of Python contexts. Accepts a generator function and optional config map.
+
+  Config options:
+  - :max-size          - Maximum pool size (default: 3)
+  - :min-size          - Minimum pool size (default: 1)
+  - :ttl-minutes       - How long contexts live before expiry (default: 10)
+  - :utilization       - Target utilization (default: 1.0 = 100%)
+
+  This allows for easy testing by injecting mock context generators and custom pool configs."
+  ([context-generator]
+   (make-python-context-pool context-generator {}))
+  ([context-generator {:keys [max-size min-size ttl-minutes utilization]
+                       :or {max-size 3
+                            min-size 1
+                            ttl-minutes 10
+                            utilization 1.0}}]
+   (let [base-controller (Pools/utilizationController utilization max-size max-size)]
+     (Pool. (reify IPool$Generator
+              (generate [_ _]
+                ;; Generate a tuple of the context and the expiry timestamp.
+                [(context-generator)
+                 (+ (System/nanoTime) (.toNanos TimeUnit/MINUTES ttl-minutes))])
+              (destroy [_ _ [^Context ctx _expiry]]
+                ;; Close context when disposed from pool (expiry, poison, or shutdown)
+                (try
+                  (.close ctx true) ;; Force close - can't wait for running code
+                  (catch Exception _))))
+            ;; Wrap the utilization controller with a modification that doesn't allow the pool to go below min-size.
+            (reify IPool$Controller
+              (shouldIncrement [_ k a b] (.shouldIncrement base-controller k a b))
+              (adjustment [_ stats]
+                (let [adj (.adjustment base-controller stats)
+                      ;; :python is arbitrary key, it just has to be consistent everywhere when working with the pool.
+                      n (some-> ^io.aleph.dirigiste.Stats (:python stats) .getNumWorkers)
+                      python-adj (:python adj)]
+                  (if (and n python-adj (<= (+ n python-adj) min-size))
+                    ;; If the adjustment is going to bring the pool below min-size, return empty adjustment instead.
+                    {}
+                    adj))))
+            65000 ;; Queue size - doesn't matter much.
+            25 ;; Sampling interval - doesn't matter much.
+            10000 ;; Recheck every 10 seconds
+            TimeUnit/MILLISECONDS))))
+
+(def ^:private python-context-pool
+  "Pool of Python context objects. They are not thread-safe, so access to them has to be carefully managed between
+  threads. Each context with loaded Python interpreter takes significant memory, so we don't want too many of them.
+  However, one takes significant time to initialize, so we don't want to load them anew each time in prod. Under some
+  circumstances, the GraalVM Python context tends to leak memory, so we don't want to keep the reference to the
+  context forever. Considering all that, this pool targets 100% utilization (so, if the utilization is lower, the pool
+  will start dropping objects) and the maximum of 3 objects (to prevent OOMs), but at least 1 object will always be in
+  the pool to pick up. However, together with each context keep its creation timestamp so that we can throwaway
+  instances that are too old to avoid leaks.
+
+  Wrapped in delay to avoid initialization during AOT compilation."
+  (delay (make-python-context-pool create-graalvm-context {:max-size 3
+                                                           :min-size 1
+                                                           :ttl-minutes 10})))
+
+(defn- acquire-context
+  "Acquire a context from the pool, handling expiry. Returns a PooledContext."
+  [^Pool pool]
+  (loop []
+    (let [[context expiry-ts :as tuple] (.acquire pool :python)]
+      (if (>= (System/nanoTime) expiry-ts)
+        (do (.dispose pool :python tuple)
+            (recur))
+        (->PooledContext context pool tuple (atom false))))))
+
+(defn python-context
+  "Acquire a python context from the pool. Must be closed. Use in a `with-open` context."
+  []
+  (acquire-context @python-context-pool))

--- a/test/metabase/sql_parsing/core_test.clj
+++ b/test/metabase/sql_parsing/core_test.clj
@@ -1,0 +1,484 @@
+(ns metabase.sql-parsing.core-test
+  (:require
+   [clojure.java.io :as io]
+   [clojure.test :refer :all]
+   [metabase.sql-parsing.core :as sql-parsing]
+   [metabase.util :as u]))
+
+(set! *warn-on-reflection* true)
+
+;;; ------------------------------------------ referenced-tables API Tests -----------------------------------------
+
+(deftest ^:parallel referenced-tables-basic-test
+  (testing "Simple table extraction"
+    (is (= [[nil nil "users"]]
+           (sql-parsing/referenced-tables "postgres" "SELECT * FROM users"))))
+
+  (testing "Multiple tables from JOIN"
+    (is (= [[nil nil "orders"] [nil nil "users"]]
+           (sql-parsing/referenced-tables
+            "postgres"
+            "SELECT * FROM users u LEFT JOIN orders o ON u.id = o.user_id"))))
+
+  (testing "Schema-qualified tables are preserved"
+    (is (= [[nil "other" "users"] [nil "public" "users"]]
+           (sql-parsing/referenced-tables
+            "postgres"
+            "SELECT public.users.id, other.users.id
+             FROM public.users u1
+             LEFT JOIN other.users u2 ON u1.id = u2.id"))))
+
+  (testing "CTE names are excluded"
+    (is (= [[nil nil "users"]]
+           (sql-parsing/referenced-tables
+            "postgres"
+            "WITH active AS (SELECT * FROM users WHERE active) SELECT * FROM active")))))
+
+(deftest ^:parallel cte-test
+  (testing "CTE (WITH clause) parsing"
+    (is (= [[nil nil "users"]]
+           (sql-parsing/referenced-tables
+            "postgres"
+            "WITH active_users AS (SELECT * FROM users WHERE active)
+                             SELECT * FROM active_users")))))
+
+(deftest ^:parallel join-test
+  (testing "JOIN parsing extracts all tables"
+    (is (=? [[nil nil "orders"] [nil nil "users"]]
+            (sql-parsing/referenced-tables
+             "postgres"
+             "SELECT u.name, o.total
+                             FROM users u
+                             JOIN orders o ON u.id = o.user_id")))))
+
+(deftest ^:parallel subquery-test
+  (testing "Subquery table extraction"
+    (is (=? [[nil nil "users"]]
+            (sql-parsing/referenced-tables
+             "postgres"
+             "SELECT * FROM (SELECT id FROM users) AS sub")))))
+
+;;; ---------------------------------------- Catalog/Schema Extraction Tests ----------------------------------------
+;;; These tests verify the 3-tuple (tables) and 4-tuple (fields) API per the design doc:
+;;; - BigQuery: project.dataset.table → [project, dataset, table]
+;;; - Snowflake: database.schema.table → [database, schema, table]
+;;; - PostgreSQL: schema.table → [nil, schema, table]
+;;; - MySQL: database.table → [nil, database, table] (MySQL's "database" = schema level)
+
+(deftest ^:parallel catalog-schema-tables-bigquery-test
+  (testing "BigQuery: project.dataset.table extracts all three levels"
+    (is (= [["myproject" "analytics" "events"]]
+           (sql-parsing/referenced-tables "bigquery" "SELECT * FROM myproject.analytics.events")))
+    (is (= [["myproject" "analytics" "events"] ["myproject" "analytics" "users"]]
+           (sql-parsing/referenced-tables "bigquery"
+                                          "SELECT * FROM myproject.analytics.events e
+                                           JOIN myproject.analytics.users u ON e.user_id = u.id")))))
+
+(deftest ^:parallel catalog-schema-tables-snowflake-test
+  (testing "Snowflake: database.schema.table extracts all three levels"
+    ;; Snowflake uppercases identifiers by default
+    (let [result (sql-parsing/referenced-tables "snowflake" "SELECT * FROM mydb.public.orders")
+          normalized (mapv (fn [[c s t]] [(some-> c u/lower-case-en)
+                                          (some-> s u/lower-case-en)
+                                          (u/lower-case-en t)])
+                           result)]
+      (is (= [["mydb" "public" "orders"]] normalized)))))
+
+(deftest ^:parallel catalog-schema-tables-postgres-test
+  (testing "PostgreSQL: schema.table (no cross-database queries)"
+    (is (= [[nil "public" "users"]]
+           (sql-parsing/referenced-tables "postgres" "SELECT * FROM public.users")))
+    (is (= [[nil "other_schema" "accounts"] [nil "public" "users"]]
+           (sql-parsing/referenced-tables "postgres"
+                                          "SELECT * FROM public.users u
+                                           JOIN other_schema.accounts a ON u.id = a.user_id")))))
+
+(deftest ^:parallel catalog-schema-tables-mysql-test
+  (testing "MySQL: database.table (MySQL 'database' maps to schema slot)"
+    ;; In MySQL, CREATE SCHEMA = CREATE DATABASE, so there's no separate schema level
+    ;; SQLGlot maps MySQL's database to the schema slot (slot 2)
+    (is (= [[nil "mydb" "users"]]
+           (sql-parsing/referenced-tables "mysql" "SELECT * FROM mydb.users")))
+    (is (= [[nil nil "users"]]
+           (sql-parsing/referenced-tables "mysql" "SELECT * FROM users")))))
+
+(deftest ^:parallel catalog-schema-fields-bigquery-test
+  (testing "BigQuery: fully-qualified field references"
+    (is (= [["myproject" "analytics" "users" "email"]]
+           (sql-parsing/referenced-fields "bigquery"
+                                          "SELECT myproject.analytics.users.email
+                                           FROM myproject.analytics.users")))))
+
+(deftest ^:parallel catalog-schema-fields-postgres-test
+  (testing "PostgreSQL: schema-qualified field references"
+    (is (= [[nil "public" "orders" "total"]]
+           (sql-parsing/referenced-fields "postgres" "SELECT public.orders.total FROM public.orders")))))
+
+(deftest ^:parallel catalog-schema-fields-mysql-test
+  (testing "MySQL: database-qualified field references"
+    (is (= [[nil "mydb" "users" "id"]]
+           (sql-parsing/referenced-fields "mysql" "SELECT mydb.users.id FROM mydb.users")))
+    (is (= [[nil nil "users" "id"]]
+           (sql-parsing/referenced-fields "mysql" "SELECT id FROM users")))))
+
+;;; -------------------------------------------- UDTF (Table Function) Tests -----------------------------------------
+
+;; Dialect-specific UDTF queries - each dialect may have slightly different syntax
+;; for table-valued functions. The queries should be semantically equivalent.
+;; We use a generic function name for dialects without well-known UDTFs to test
+;; that unknown functions are handled gracefully.
+(def udtf-queries
+  {:postgres  "SELECT * FROM generate_series(1, 10)"
+   :mysql     "SELECT * FROM my_table_func(1, 10)"  ; MySQL's JSON_TABLE has complex syntax
+   :snowflake "SELECT * FROM TABLE(FLATTEN(input => ARRAY_CONSTRUCT(1, 2, 3)))"
+   :bigquery  "SELECT * FROM UNNEST([1, 2, 3]) AS val"
+   :redshift  "SELECT * FROM generate_series(1, 10)"
+   :duckdb    "SELECT * FROM generate_series(1, 10)"})
+
+;; UDTF queries mixed with real tables - tests that we correctly identify real tables
+;; while gracefully handling table functions
+(def udtf-with-table-queries
+  {:postgres  "SELECT o.* FROM orders o, generate_series(1, 10) g"
+   :mysql     "SELECT o.* FROM orders o, my_table_func(1, 10) t"
+   :snowflake "SELECT o.* FROM orders o, TABLE(FLATTEN(input => ARRAY_CONSTRUCT(1))) f"
+   :bigquery  "SELECT o.* FROM orders o, UNNEST([1]) AS val"
+   :redshift  "SELECT o.* FROM orders o, generate_series(1, 10) g"
+   :duckdb    "SELECT o.* FROM orders o, generate_series(1, 10) g"})
+
+(deftest ^:parallel udtf-referenced-tables-test
+  (testing "UDTFs are handled by referenced-tables across dialects"
+    (doseq [[dialect sql] udtf-queries]
+      (testing (str "dialect: " dialect " - pure UDTF query")
+        ;; Table functions shouldn't appear as referenced tables - they're not real tables
+        (let [result (sql-parsing/referenced-tables (name dialect) sql)]
+          (is (vector? result)
+              (format "dialect %s: should return vector, got %s" dialect (type result)))
+          (is (every? vector? result)
+              (format "dialect %s: each element should be [catalog schema table] tuple" dialect)))))
+
+    (doseq [[dialect sql] udtf-with-table-queries]
+      (testing (str "dialect: " dialect " - UDTF mixed with real table")
+        (let [result (sql-parsing/referenced-tables (name dialect) sql)]
+          ;; Case-insensitive comparison since dialects like Snowflake uppercase identifiers
+          ;; 3-tuple: [catalog schema table] - table is third element
+          (is (some #(= "orders" (u/lower-case-en (nth % 2))) result)
+              (format "dialect %s: should find 'orders' table in %s" dialect (pr-str result))))))))
+
+;;; ------------------------------------------ Set Operation Tests (UNION, INTERSECT, EXCEPT) ------------------------------------------
+
+;; Set operation queries by dialect - tests UNION, UNION ALL, INTERSECT, EXCEPT
+;; All queries use tables "a" and "b" for consistent expected results
+(def dialect->set-operation->query
+  {:postgres
+   {:union          "SELECT id, name FROM a UNION SELECT id, name FROM b"
+    :union-all      "SELECT id, name FROM a UNION ALL SELECT id, name FROM b"
+    :intersect      "SELECT id FROM a INTERSECT SELECT id FROM b"
+    :except         "SELECT id FROM a EXCEPT SELECT id FROM b"
+    :nested-union   "SELECT * FROM (SELECT id FROM a UNION SELECT id FROM b) AS combined"
+    :cte-with-union "WITH c AS (SELECT id FROM a UNION SELECT id FROM b) SELECT * FROM c"}
+
+   :mysql
+   {:union          "SELECT id, name FROM a UNION SELECT id, name FROM b"
+    :union-all      "SELECT id, name FROM a UNION ALL SELECT id, name FROM b"
+    :intersect      "SELECT id FROM a INTERSECT SELECT id FROM b"
+    :except         "SELECT id FROM a EXCEPT SELECT id FROM b"
+    :nested-union   "SELECT * FROM (SELECT id FROM a UNION SELECT id FROM b) AS combined"
+    :cte-with-union "WITH c AS (SELECT id FROM a UNION SELECT id FROM b) SELECT * FROM c"}
+
+   :snowflake
+   {:union          "SELECT id, name FROM a UNION SELECT id, name FROM b"
+    :union-all      "SELECT id, name FROM a UNION ALL SELECT id, name FROM b"
+    :intersect      "SELECT id FROM a INTERSECT SELECT id FROM b"
+    :except         "SELECT id FROM a EXCEPT SELECT id FROM b"
+    :nested-union   "SELECT * FROM (SELECT id FROM a UNION SELECT id FROM b) AS combined"
+    :cte-with-union "WITH c AS (SELECT id FROM a UNION SELECT id FROM b) SELECT * FROM c"}
+
+   :bigquery
+   {:union          "SELECT id, name FROM a UNION DISTINCT SELECT id, name FROM b"
+    :union-all      "SELECT id, name FROM a UNION ALL SELECT id, name FROM b"
+    :intersect      "SELECT id FROM a INTERSECT DISTINCT SELECT id FROM b"
+    :except         "SELECT id FROM a EXCEPT DISTINCT SELECT id FROM b"
+    :nested-union   "SELECT * FROM (SELECT id FROM a UNION DISTINCT SELECT id FROM b) AS combined"
+    :cte-with-union "WITH c AS (SELECT id FROM a UNION DISTINCT SELECT id FROM b) SELECT * FROM c"}
+
+   :redshift
+   {:union          "SELECT id, name FROM a UNION SELECT id, name FROM b"
+    :union-all      "SELECT id, name FROM a UNION ALL SELECT id, name FROM b"
+    :intersect      "SELECT id FROM a INTERSECT SELECT id FROM b"
+    :except         "SELECT id FROM a EXCEPT SELECT id FROM b"
+    :nested-union   "SELECT * FROM (SELECT id FROM a UNION SELECT id FROM b) AS combined"
+    :cte-with-union "WITH c AS (SELECT id FROM a UNION SELECT id FROM b) SELECT * FROM c"}
+
+   :duckdb
+   {:union          "SELECT id, name FROM a UNION SELECT id, name FROM b"
+    :union-all      "SELECT id, name FROM a UNION ALL SELECT id, name FROM b"
+    :intersect      "SELECT id FROM a INTERSECT SELECT id FROM b"
+    :except         "SELECT id FROM a EXCEPT SELECT id FROM b"
+    :nested-union   "SELECT * FROM (SELECT id FROM a UNION SELECT id FROM b) AS combined"
+    :cte-with-union "WITH c AS (SELECT id FROM a UNION SELECT id FROM b) SELECT * FROM c"}})
+
+(deftest ^:parallel set-operation-referenced-tables-test
+  (testing "Set operations correctly identify all referenced tables across dialects"
+    (doseq [[dialect ops] dialect->set-operation->query
+            [op-type sql] ops]
+      (testing (str "dialect: " (name dialect) " - " (name op-type))
+        (let [result (sql-parsing/referenced-tables (name dialect) sql)
+              ;; Normalize to lowercase for case-insensitive comparison (Snowflake uppercases)
+              ;; 3-tuple: [catalog schema table]
+              normalized (into #{} (map (fn [[catalog schema table]]
+                                          [(some-> catalog u/lower-case-en)
+                                           (some-> schema u/lower-case-en)
+                                           (u/lower-case-en table)])
+                                        result))]
+          (is (= #{[nil nil "a"] [nil nil "b"]} normalized)
+              (format "%s/%s should return [[nil nil a] [nil nil b]], got %s"
+                      (name dialect) (name op-type) normalized)))))))
+
+(def ^:private set-operation->returned-columns
+  {:union          ["id" "name"]
+   :union-all      ["id" "name"]
+   :intersect      ["id"]
+   :except         ["id"]
+   :nested-union   ["id"]
+   :cte-with-union ["id"]})
+
+(deftest ^:parallel set-operation-validate-query-test
+  (testing "Set operations validate correctly across dialects"
+    (doseq [[dialect ops] dialect->set-operation->query
+            [op-type sql] ops]
+      (testing (str "dialect: " (name dialect) " - " (name op-type))
+        (let [result (sql-parsing/validate-query (name dialect) sql "public" {})]
+          (is (= "ok" (:status result))
+              (format "%s/%s should validate OK, got %s"
+                      (name dialect) (name op-type) result)))))))
+
+(deftest ^:parallel set-operation-returned-columns-lineage-test
+  (testing "Set operations return correct column lineage across dialects"
+    (doseq [[dialect ops] dialect->set-operation->query
+            [op-type sql] ops
+            :let [expected (get set-operation->returned-columns op-type)]]
+      (testing (str "dialect: " (name dialect) ", operation: " (name op-type))
+        (let [result (sql-parsing/returned-columns-lineage (name dialect) sql "public" {})
+              columns (sort (map (comp u/lower-case-en first) result))]
+          (is (= expected columns)
+              (format "%s %s should return %s, got %s"
+                      (name dialect) (name op-type) (pr-str expected) columns)))))))
+
+;;; -------------------------------------------- Schema Validation Tests (validate-query) ------------------------------------------------
+
+;; validate-query validates SQL against a provided schema, detecting:
+;; - Missing columns (column doesn't exist in any table)
+;; - Missing table aliases (table wildcard references non-existent source)
+;; - Unknown tables (table not in schema)
+
+(def ^:private test-schema
+  "Test schema for validation tests.
+   Structure: {schema-name {table-name {column-name type}}}"
+  {"PUBLIC" {"PRODUCTS" {"ID" "INT"
+                         "TITLE" "VARCHAR"
+                         "CATEGORY" "VARCHAR"
+                         "PRICE" "DECIMAL"}
+             "ORDERS" {"ID" "INT"
+                       "USER_ID" "INT"
+                       "PRODUCT_ID" "INT"
+                       "TOTAL" "DECIMAL"}
+             "USERS" {"ID" "INT"
+                      "NAME" "VARCHAR"
+                      "EMAIL" "VARCHAR"}}})
+
+(deftest ^:parallel validate-query-valid-queries-test
+  (testing "Valid queries against schema"
+    (testing "simple select with existing columns"
+      (is (= "ok" (:status (sql-parsing/validate-query nil "SELECT id, title FROM products" "PUBLIC" test-schema)))))
+
+    (testing "wildcard select"
+      (is (= "ok" (:status (sql-parsing/validate-query nil "SELECT * FROM products" "PUBLIC" test-schema)))))
+
+    (testing "table-qualified columns"
+      (is (= "ok" (:status (sql-parsing/validate-query nil "SELECT products.id, products.title FROM products" "PUBLIC" test-schema)))))
+
+    (testing "join with valid columns"
+      (is (= "ok" (:status (sql-parsing/validate-query nil
+                                                       "SELECT o.id, p.title FROM orders o JOIN products p ON o.product_id = p.id"
+                                                       "PUBLIC" test-schema)))))
+
+    (testing "subquery"
+      (is (= "ok" (:status (sql-parsing/validate-query nil
+                                                       "SELECT * FROM (SELECT id, title FROM products) AS sub"
+                                                       "PUBLIC" test-schema)))))))
+
+(deftest ^:parallel validate-query-missing-column-test
+  (testing "Missing column errors"
+    (testing "non-existent column"
+      (let [result (sql-parsing/validate-query nil "SELECT bad_column FROM products" "PUBLIC" test-schema)]
+        (is (= "error" (:status result)))
+        (is (= "column_not_resolved" (:type result)))
+        (is (re-find #"(?i)bad_column" (:column result)))))
+
+    (testing "column from wrong table"
+      (let [result (sql-parsing/validate-query nil "SELECT email FROM products" "PUBLIC" test-schema)]
+        (is (= "error" (:status result)))
+        (is (= "column_not_resolved" (:type result)))))))
+
+(deftest ^:parallel validate-query-missing-table-alias-test
+  (testing "Missing table alias errors"
+    (testing "table wildcard with non-existent table"
+      (let [result (sql-parsing/validate-query nil "SELECT products.* FROM orders" "PUBLIC" test-schema)]
+        (is (= "error" (:status result)))
+        ;; SQLGlot reports this as unknown_table
+        (is (contains? #{"unknown_table" "column_not_resolved"} (:type result)))))
+
+    (testing "qualified column with non-existent alias"
+      (let [result (sql-parsing/validate-query nil "SELECT p.id FROM products" "PUBLIC" test-schema)]
+        (is (= "error" (:status result)))))))
+
+(deftest ^:parallel validate-query-unknown-table-test
+  ;; SQLGlot's qualify.qualify() does NOT detect unknown tables - it just doesn't qualify them.
+  ;; Unknown table detection happens at the sql-tools layer by matching referenced tables
+  ;; against Metabase's database metadata.
+  (testing "Unknown tables are not detected by SQLGlot (known limitation)"
+    (let [result (sql-parsing/validate-query nil "SELECT * FROM nonexistent" "PUBLIC" test-schema)]
+      (is (= "ok" (:status result))
+          "SQLGlot passes unknown tables through without error"))))
+
+(deftest ^:parallel validate-query-syntax-error-test
+  (testing "Syntax errors are caught"
+    (let [result (sql-parsing/validate-query nil "SELECT * FORM products" "PUBLIC" test-schema)]
+      (is (= "error" (:status result)))
+      (is (= "invalid_expression" (:type result))))))
+
+(deftest ^:parallel lenient-parsing-incomplete-limit-test
+  (testing "SQLGlot's lenient parsing treats 'SELECT 1 LIMIT' as 'SELECT 1 AS LIMIT'"
+    ;; This documents a known SQLGlot behavior where incomplete LIMIT clauses
+    ;; are parsed as column aliases.
+    (let [result (sql-parsing/referenced-tables "postgres" "SELECT 1 LIMIT")]
+      (is (= [] result)
+          "No tables are referenced in 'SELECT 1 LIMIT'")))
+
+  (testing "To reliably trigger SQL errors, use nonexistent tables instead"
+    ;; This is the recommended pattern for tests that need to trigger SQL failures
+    (let [result (sql-parsing/referenced-tables "postgres" "SELECT * FROM nonexistent_table_xyz")]
+      (is (= [[nil nil "nonexistent_table_xyz"]] result)
+          "Nonexistent table reference is parsed and will fail at execution time"))))
+
+(comment
+  (require '[clojure.string :as str])
+  (def query-corpus-path "/Users/bcm/dv/mb/query_corpus/")
+
+  (def sentinel (re-pattern "\n-----end-query-----\n"))
+
+  (def drivers ["mysql"])
+
+  (let [driver (first drivers)
+        corpus (slurp (str query-corpus-path driver ".log"))
+        queries (sort (distinct (str/split corpus sentinel)))]
+
+    (frequencies
+     (doall
+      (for [q queries]
+        (try
+          (sql-parsing/referenced-tables q driver)
+          true
+          (catch Exception _ false))))))
+
+  ;; Load and run validation tests interactively
+  (load-validation-test-cases)
+
+  ;; Test a single case
+  (validate-test-case {:name "test"
+                       :sql "SELECT * FROM users"
+                       :dialect "postgres"
+                       :expected :valid})
+
+  ;; Run all valid query tests
+  (doseq [tc (:valid-queries (load-validation-test-cases))]
+    (let [result (validate-test-case tc)]
+      (when-not (:passed result)
+        result)))
+
+  ;; Run all invalid query tests
+  (doseq [tc (:invalid-queries (load-validation-test-cases))]
+    (let [result (validate-test-case tc)]
+      (when-not (:passed result)
+        result))))
+
+;;; -------------------------------------------- Referenced Fields Tests --------------------------------------------
+
+(defn- load-referenced-fields-test-cases
+  "Load referenced fields test cases from EDN file."
+  []
+  (let [resource (io/resource "metabase/sql_parsing/referenced_fields_test_cases.edn")]
+    (when-not resource
+      (throw (ex-info "Could not find referenced_fields_test_cases.edn" {})))
+    (read-string (slurp resource))))
+
+(defn- normalize-fields
+  "Normalize field references for comparison (sort and ensure consistent format).
+   Handles both 2-tuples (expected format in test cases) and 4-tuples (actual API format)."
+  [fields]
+  (vec (sort-by (fn [f]
+                  (if (= 4 (count f))
+                    ;; 4-tuple: [catalog schema table field]
+                    [(u/lower-case-en (nth f 2)) (u/lower-case-en (nth f 3))]
+                    ;; 2-tuple: [table field] (test case format)
+                    [(u/lower-case-en (first f)) (u/lower-case-en (second f))]))
+                (map (fn [f]
+                       (if (= 4 (count f))
+                         ;; Convert 4-tuple to 2-tuple for comparison
+                         [(u/lower-case-en (nth f 2)) (u/lower-case-en (nth f 3))]
+                         ;; Already 2-tuple
+                         [(u/lower-case-en (first f)) (u/lower-case-en (second f))]))
+                     fields))))
+
+(defn- fields-match?
+  "Check if actual fields match expected fields (case-insensitive, order-independent)."
+  [expected actual]
+  (= (normalize-fields expected)
+     (normalize-fields actual)))
+
+(deftest ^:parallel referenced-fields-test
+  (testing "Referenced fields extraction from SQL queries"
+    (let [test-cases (:test-cases (load-referenced-fields-test-cases))]
+      (doseq [test-case test-cases]
+        (testing (:name test-case)
+          (let [{:keys [sql dialect expected]} test-case
+                actual (sql-parsing/referenced-fields dialect sql)]
+            (is (fields-match? expected actual)
+                (str "Test '" (:name test-case) "' failed"
+                     "\n  SQL: " sql
+                     "\n  Expected: " (pr-str (normalize-fields expected))
+                     "\n  Actual:   " (pr-str (normalize-fields actual))))))))))
+
+(deftest ^:parallel referenced-fields-dialect-support-test
+  (testing "Referenced fields works across different SQL dialects"
+    (doseq [dialect ["postgres" "mysql" "snowflake" "bigquery" "redshift" "duckdb"]]
+      (testing (str "dialect: " dialect)
+        (let [result (sql-parsing/referenced-fields dialect "SELECT id, name FROM users WHERE active = true")]
+          (is (seq result)
+              (str "Should return fields for " dialect))
+          (is (every? #(and (vector? %) (= 4 (count %))) result)
+              (str "Each field should be [catalog schema table field] tuple for " dialect)))))))
+
+(deftest ^:parallel referenced-fields-wildcard-test
+  (testing "Wildcard handling in referenced fields"
+    (testing "Unqualified wildcard - single table"
+      (let [result (sql-parsing/referenced-fields "postgres" "SELECT * FROM users")]
+        (is (fields-match? [["users" "*"]] result))))
+
+    (testing "Unqualified wildcard - multiple tables"
+      (let [result (sql-parsing/referenced-fields "postgres" "SELECT * FROM users u LEFT JOIN orders o ON u.id = o.user_id")]
+        (is (some #(= ["orders" "*"] %) (normalize-fields result))
+            "Should include orders wildcard")
+        (is (some #(= ["users" "*"] %) (normalize-fields result))
+            "Should include users wildcard")))
+
+    (testing "Qualified wildcard"
+      (let [result (sql-parsing/referenced-fields "postgres" "SELECT u.* FROM users u")]
+        (is (fields-match? [["users" "*"]] result))))
+
+    (testing "Mixed wildcards and specific columns"
+      (let [result (sql-parsing/referenced-fields "postgres" "SELECT u.*, t.total FROM users u, transactions t WHERE u.id = t.user_id")]
+        (is (some #(= ["users" "*"] %) (normalize-fields result))
+            "Should include users wildcard")
+        (is (some #(= ["transactions" "total"] %) (normalize-fields result))
+            "Should include transactions.total")))))

--- a/test/metabase/sql_parsing/pool_test.clj
+++ b/test/metabase/sql_parsing/pool_test.clj
@@ -1,0 +1,171 @@
+(ns metabase.sql-parsing.pool-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.sql-parsing.pool :as pool])
+  (:import
+   (io.aleph.dirigiste Pool)
+   (java.util.concurrent CountDownLatch)))
+
+(set! *warn-on-reflection* true)
+
+(defn- mock-context
+  "Create a mock 'context' object. Since Context is final, we just return a map with metadata.
+  The pool doesn't care what type the objects are - it just stores and returns them."
+  [id]
+  {:context-id id
+   :created-at (System/currentTimeMillis)})
+
+(defn- counting-generator
+  "Returns a generator function that counts how many contexts it has created."
+  [counter-atom]
+  (fn []
+    (let [id (swap! counter-atom inc)]
+      (mock-context id))))
+
+(defn- failing-generator
+  "Returns a generator that fails after creating n contexts."
+  [counter-atom fail-after]
+  (fn []
+    (let [id (swap! counter-atom inc)]
+      (when (> id fail-after)
+        (throw (ex-info "Generator limit reached" {:count id :limit fail-after})))
+      (mock-context id))))
+
+;;; ------------------------------------------------- Test Helpers ---------------------------------------------------
+
+(defn- test-pool
+  "Create a pool for testing with sensible defaults.
+  Returns [pool created-count-atom]."
+  ([]
+   (test-pool {}))
+  ([config]
+   (let [counter (atom 0)
+         generator (counting-generator counter)
+         pool (#'pool/make-python-context-pool generator config)]
+     [pool counter])))
+
+(defn- with-pool
+  "Execute f with a context from pool. Uses with-open for proper resource management."
+  [pool f]
+  (with-open [^java.io.Closeable ctx (#'pool/acquire-context pool)]
+    (f ctx)))
+
+(defn- run-concurrent
+  "Run n threads concurrently, each executing f with a context from pool.
+  Returns vector of results."
+  [pool n f]
+  (let [latch   (CountDownLatch. n)
+        results (atom [])
+        futures (doall
+                 (for [i (range n)]
+                   (future
+                     (.countDown latch)
+                     (.await latch)
+                     (let [result (with-pool pool (fn [ctx] (f i ctx)))]
+                       (swap! results conj result)))))]
+    (doseq [fut futures] @fut)
+    @results))
+
+;;; ------------------------------------------------ Pool Size Tests -------------------------------------------------
+
+(deftest pool-respects-maximum-size-test
+  (testing "Pool never creates more than max contexts even under concurrent load"
+    (let [[pool created-count] (test-pool {:max-size 3})
+          num-threads 20
+          results (run-concurrent pool num-threads
+                                  (fn [_i ctx]
+                                    (Thread/sleep (long (+ 10 (rand-int 50))))
+                                    ctx))]
+
+      (is (<= @created-count 3)
+          (str "Pool created " @created-count " contexts but max is 3"))
+      (is (= num-threads (count results))
+          "All threads should have received a context"))))
+
+(deftest pool-maintains-minimum-size-test
+  (testing "Pool keeps at least 1 context available"
+    (let [[pool created-count] (test-pool)]
+      (with-pool pool (fn [_ctx] (is (= 1 @created-count) "First use creates one context")))
+      (Thread/sleep (long 100))
+      (with-pool pool (fn [_ctx] (is (= 1 @created-count) "Second use reuses the same context"))))))
+
+;;; ----------------------------------------------- Context Expiry Tests ---------------------------------------------
+
+(deftest pool-expires-old-contexts-test
+  (testing "Pool disposes of contexts that have exceeded their TTL"
+    (let [[pool _created-count] (test-pool {:ttl-minutes 10})
+          [context expiry-ts :as tuple] (.acquire ^Pool pool :python)]
+      (try
+        (is (some? context) "Context should be created")
+        (is (number? expiry-ts) "Expiry timestamp should be set")
+        (is (< (System/nanoTime) expiry-ts) "Expiry should be in the future")
+
+        (let [expiry-in-minutes (/ (- expiry-ts (System/nanoTime)) (* 1000000000 60))]
+          (is (< 9 expiry-in-minutes 11) "Expiry should be approximately 10 minutes"))
+        (finally
+          (.release ^Pool pool :python tuple))))))
+
+(deftest with-pooled-context-handles-expired-contexts-test
+  (testing "with-pooled-context properly handles and replaces expired contexts"
+    (let [[pool created-count] (test-pool)]
+      (with-pool pool (fn [_ctx] (is (= 1 @created-count))))
+
+      ;; Manually expire by disposing
+      (let [tuple (.acquire ^Pool pool :python)]
+        (.dispose ^Pool pool :python tuple))
+
+      (with-pool pool (fn [_ctx] (is (= 2 @created-count) "Expired context should be replaced"))))))
+
+;;; --------------------------------------------- Generator Failure Tests --------------------------------------------
+
+(deftest pool-handles-generator-failures-test
+  (testing "Pool gracefully handles when generator fails"
+    (let [counter (atom 0)
+          generator (failing-generator counter 1)
+          pool (#'pool/make-python-context-pool generator)]
+
+      (is (some? (with-pool pool identity)) "First context creation succeeds")
+
+      ;; Dispose to force new creation
+      (let [tuple (.acquire ^Pool pool :python)]
+        (.dispose ^Pool pool :python tuple))
+
+      (is (thrown? Exception (with-pool pool identity)) "Generator failure should propagate"))))
+
+;;; ------------------------------------------- Concurrent Access Tests ----------------------------------------------
+
+(deftest pool-handles-concurrent-access-safely-test
+  (testing "Pool handles concurrent access without race conditions"
+    (let [[pool created-count] (test-pool {:max-size 3})
+          num-threads 50
+          results (run-concurrent pool num-threads
+                                  (fn [i _ctx]
+                                    (Thread/sleep (long (rand-int 20)))
+                                    i))]
+
+      (is (= num-threads (count results)) "All threads should complete successfully")
+      (is (<= @created-count 3) (str "Created " @created-count " contexts, expected <= 3")))))
+
+;;; -------------------------------------------- Pool Behavior Tests -------------------------------------------------
+
+(deftest pool-stores-and-returns-objects-test
+  (testing "Pool correctly stores and returns arbitrary objects"
+    (let [[pool created-count] (test-pool)
+          result1 (with-pool pool :context)
+          result2 (with-pool pool :context)]
+
+      (is (map? result1))
+      (is (= 1 (:context-id result1)))
+      (is (= 1 @created-count))
+
+      (is (map? result2))
+      (is (= 1 (:context-id result2)))  ;; Same context ID
+      (is (= 1 @created-count)))))
+
+;;; ----------------------------------------- Version Parsing --------------------------------------------------------
+
+(deftest expected-sqlglot-version-test
+  (testing "Sqlglot version is properly parsed from pyproject.toml"
+    (let [version (#'pool/expected-sqlglot-version)]
+      (is (string? version))
+      (is (re-matches #"\d+\.\d+\.\d+" version)))))

--- a/test/metabase/sql_parsing/referenced_fields_test_cases.edn
+++ b/test/metabase/sql_parsing/referenced_fields_test_cases.edn
@@ -1,0 +1,244 @@
+;; Referenced Fields Test Cases
+;; Each test case has:
+;; - :name - descriptive name for the test
+;; - :sql - the SQL query to analyze
+;; - :dialect - SQL dialect (postgres, mysql, snowflake, bigquery, redshift, duckdb)
+;; - :expected - vector of [table field] pairs (sorted)
+
+{:test-cases
+ [;; Basic SELECT queries
+  {:name "simple-select-with-columns"
+   :sql "SELECT id, name FROM users"
+   :dialect "postgres"
+   :expected [["users" "id"] ["users" "name"]]}
+
+  {:name "select-with-where-clause"
+   :sql "SELECT id, name FROM users WHERE active = true"
+   :dialect "postgres"
+   :expected [["users" "active"] ["users" "id"] ["users" "name"]]}
+
+  {:name "select-with-multiple-where-conditions"
+   :sql "SELECT id, name FROM users WHERE active = true AND age > 18"
+   :dialect "postgres"
+   :expected [["users" "active"] ["users" "age"] ["users" "id"] ["users" "name"]]}
+
+  {:name "select-with-order-by"
+   :sql "SELECT id, name FROM users ORDER BY created_at DESC"
+   :dialect "postgres"
+   :expected [["users" "created_at"] ["users" "id"] ["users" "name"]]}
+
+  {:name "select-with-limit"
+   :sql "SELECT id, name FROM users LIMIT 10"
+   :dialect "postgres"
+   :expected [["users" "id"] ["users" "name"]]}
+
+  ;; Wildcards
+  {:name "unqualified-wildcard-single-table"
+   :sql "SELECT * FROM users"
+   :dialect "postgres"
+   :expected [["users" "*"]]}
+
+  {:name "unqualified-wildcard-with-where"
+   :sql "SELECT * FROM users WHERE active = true"
+   :dialect "postgres"
+   :expected [["users" "*"] ["users" "active"]]}
+
+  {:name "qualified-wildcard"
+   :sql "SELECT u.* FROM users u"
+   :dialect "postgres"
+   :expected [["users" "*"]]}
+
+  {:name "qualified-wildcard-with-specific-column"
+   :sql "SELECT u.*, t.total FROM users u, transactions t WHERE u.id = t.user_id"
+   :dialect "postgres"
+   :expected [["transactions" "total"] ["transactions" "user_id"] ["users" "*"] ["users" "id"]]}
+
+  ;; JOINs
+  {:name "inner-join-simple"
+   :sql "SELECT u.id, o.total FROM users u INNER JOIN orders o ON u.id = o.user_id"
+   :dialect "postgres"
+   :expected [["orders" "total"] ["orders" "user_id"] ["users" "id"]]}
+
+  {:name "left-join-with-aliases"
+   :sql "SELECT t.id, u.email FROM transactions t LEFT JOIN users u ON t.user_id = u.id"
+   :dialect "postgres"
+   :expected [["transactions" "id"] ["transactions" "user_id"] ["users" "email"] ["users" "id"]]}
+
+  {:name "multiple-joins"
+   :sql "SELECT u.name, o.total, p.name FROM users u LEFT JOIN orders o ON u.id = o.user_id LEFT JOIN products p ON o.product_id = p.id"
+   :dialect "postgres"
+   :expected [["orders" "product_id"] ["orders" "total"] ["orders" "user_id"] ["products" "id"] ["products" "name"] ["users" "id"] ["users" "name"]]}
+
+  {:name "join-with-wildcard"
+   :sql "SELECT * FROM users u LEFT JOIN transactions t ON u.id = t.user_id"
+   :dialect "postgres"
+   :expected [["transactions" "*"] ["transactions" "user_id"] ["users" "*"] ["users" "id"]]}
+
+  {:name "cross-join"
+   :sql "SELECT u.id, t.total FROM users u, transactions t WHERE u.id = t.user_id"
+   :dialect "postgres"
+   :expected [["transactions" "total"] ["transactions" "user_id"] ["users" "id"]]}
+
+  ;; CTEs
+  ;; Note: CTEs create scopes, and sqlglot attributes columns to the CTE scope in some cases
+  {:name "simple-cte"
+   :sql "WITH active_users AS (SELECT id FROM users WHERE active) SELECT * FROM active_users"
+   :dialect "postgres"
+   :expected [["users" "active"] ["users" "id"]]}
+
+  {:name "cte-with-join"
+   :sql "WITH active AS (SELECT id FROM users WHERE active = true) SELECT a.id, t.total FROM active a JOIN transactions t ON a.id = t.user_id"
+   :dialect "postgres"
+   ;; Note: sqlglot sees columns from CTE join and attributes some to transactions scope
+   :expected [["transactions" "active"] ["transactions" "id"] ["transactions" "total"] ["transactions" "user_id"] ["users" "active"] ["users" "id"]]}
+
+  {:name "multiple-ctes"
+   :sql "WITH active AS (SELECT id FROM users WHERE active), recent AS (SELECT user_id, total FROM transactions WHERE created_at > '2024-01-01') SELECT * FROM active a JOIN recent r ON a.id = r.user_id"
+   :dialect "postgres"
+   :expected [["transactions" "created_at"] ["transactions" "total"] ["transactions" "user_id"] ["users" "active"] ["users" "id"]]}
+
+  ;; Subqueries
+  {:name "subquery-in-from"
+   :sql "SELECT * FROM (SELECT id, name FROM users WHERE active = true) AS active_users"
+   :dialect "postgres"
+   :expected [["users" "active"] ["users" "id"] ["users" "name"]]}
+
+  {:name "subquery-in-where"
+   :sql "SELECT id, name FROM users WHERE id IN (SELECT user_id FROM transactions WHERE total > 100)"
+   :dialect "postgres"
+   ;; Note: sqlglot attributes some subquery columns to outer scope
+   :expected [["transactions" "total"] ["transactions" "user_id"] ["users" "id"] ["users" "name"] ["users" "total"] ["users" "user_id"]]}
+
+  {:name "correlated-subquery"
+   :sql "SELECT u.id, u.name FROM users u WHERE EXISTS (SELECT 1 FROM transactions t WHERE t.user_id = u.id)"
+   :dialect "postgres"
+   :expected [["transactions" "user_id"] ["users" "id"] ["users" "name"]]}
+
+  ;; Aggregations
+  ;; Note: The * in COUNT(*) is not a column reference, it's part of the aggregate function syntax
+  {:name "count-aggregate"
+   :sql "SELECT COUNT(*) FROM users"
+   :dialect "postgres"
+   :expected []}
+
+  {:name "group-by-simple"
+   :sql "SELECT country, COUNT(*) FROM users GROUP BY country"
+   :dialect "postgres"
+   :expected [["users" "country"]]}
+
+  {:name "group-by-with-having"
+   :sql "SELECT country, COUNT(*) as cnt FROM users GROUP BY country HAVING COUNT(*) > 10"
+   :dialect "postgres"
+   :expected [["users" "country"]]}
+
+  {:name "multiple-aggregates"
+   :sql "SELECT department, COUNT(*), AVG(salary), MAX(salary) FROM employees GROUP BY department"
+   :dialect "postgres"
+   :expected [["employees" "department"] ["employees" "salary"]]}
+
+  ;; Window functions
+  {:name "window-function-simple"
+   :sql "SELECT name, salary, RANK() OVER (ORDER BY salary DESC) FROM employees"
+   :dialect "postgres"
+   :expected [["employees" "name"] ["employees" "salary"]]}
+
+  {:name "window-with-partition"
+   :sql "SELECT name, department, salary, AVG(salary) OVER (PARTITION BY department) FROM employees"
+   :dialect "postgres"
+   :expected [["employees" "department"] ["employees" "name"] ["employees" "salary"]]}
+
+  ;; CASE expressions
+  {:name "case-expression"
+   :sql "SELECT name, CASE WHEN age < 18 THEN 'minor' ELSE 'adult' END AS age_group FROM users"
+   :dialect "postgres"
+   :expected [["users" "age"] ["users" "name"]]}
+
+  {:name "case-with-multiple-conditions"
+   :sql "SELECT name, CASE WHEN active = true AND age > 18 THEN 'active_adult' WHEN active = true THEN 'active_minor' ELSE 'inactive' END FROM users"
+   :dialect "postgres"
+   :expected [["users" "active"] ["users" "age"] ["users" "name"]]}
+
+  ;; Set operations
+  {:name "union-simple"
+   :sql "SELECT id, name FROM users UNION SELECT id, name FROM archived_users"
+   :dialect "postgres"
+   :expected [["archived_users" "id"] ["archived_users" "name"] ["users" "id"] ["users" "name"]]}
+
+  {:name "union-all"
+   :sql "SELECT id FROM active_users UNION ALL SELECT id FROM inactive_users"
+   :dialect "postgres"
+   :expected [["active_users" "id"] ["inactive_users" "id"]]}
+
+  ;; Schema-qualified tables
+  {:name "schema-qualified-single"
+   :sql "SELECT id, name FROM public.users"
+   :dialect "postgres"
+   :expected [["users" "id"] ["users" "name"]]}
+
+  {:name "schema-qualified-multiple"
+   :sql "SELECT u.id, o.total FROM public.users u JOIN sales.orders o ON u.id = o.user_id"
+   :dialect "postgres"
+   :expected [["orders" "total"] ["orders" "user_id"] ["users" "id"]]}
+
+  ;; Complex queries
+  {:name "complex-with-cte-join-subquery"
+   :sql "WITH ranked AS (SELECT id, name, RANK() OVER (ORDER BY created_at DESC) as rank FROM users WHERE active = true) SELECT r.id, r.name, t.total FROM ranked r JOIN (SELECT user_id, SUM(amount) as total FROM transactions GROUP BY user_id) t ON r.id = t.user_id WHERE r.rank <= 10"
+   :dialect "postgres"
+   :expected [["transactions" "amount"] ["transactions" "user_id"] ["users" "active"] ["users" "created_at"] ["users" "id"] ["users" "name"]]}
+
+  {:name "nested-subqueries"
+   :sql "SELECT id, name FROM users WHERE id IN (SELECT user_id FROM transactions WHERE total > (SELECT AVG(total) FROM transactions))"
+   :dialect "postgres"
+   ;; Note: sqlglot attributes some subquery columns to outer scope
+   :expected [["transactions" "total"] ["transactions" "user_id"] ["users" "id"] ["users" "name"] ["users" "total"] ["users" "user_id"]]}
+
+  ;; Edge cases
+  {:name "table-alias-same-as-table-name"
+   :sql "SELECT users.id, users.name FROM users users"
+   :dialect "postgres"
+   :expected [["users" "id"] ["users" "name"]]}
+
+  {:name "no-from-clause"
+   :sql "SELECT 1 as one, 2 as two"
+   :dialect "postgres"
+   :expected []}
+
+  {:name "select-from-values"
+   :sql "SELECT * FROM (VALUES (1, 'a'), (2, 'b')) AS t(id, name)"
+   :dialect "postgres"
+   :expected []}
+
+  ;; Different dialects
+  {:name "mysql-backticks"
+   :sql "SELECT `id`, `name` FROM `users` WHERE `active` = 1"
+   :dialect "mysql"
+   :expected [["users" "active"] ["users" "id"] ["users" "name"]]}
+
+  {:name "bigquery-struct"
+   :sql "SELECT id, name, address.city FROM users"
+   :dialect "bigquery"
+   ;; Note: Struct field access (address.city) is not parsed as a column reference
+   :expected [["users" "id"] ["users" "name"]]}
+
+  {:name "snowflake-uppercase"
+   :sql "SELECT ID, NAME FROM USERS"
+   :dialect "snowflake"
+   :expected [["USERS" "ID"] ["USERS" "NAME"]]}
+
+  ;; INSERT/UPDATE/DELETE (less common but valid)
+  {:name "insert-with-select"
+   :sql "INSERT INTO archive_users SELECT id, name, email FROM users WHERE active = false"
+   :dialect "postgres"
+   :expected [["users" "active"] ["users" "email"] ["users" "id"] ["users" "name"]]}
+
+  {:name "update-with-join"
+   :sql "UPDATE users SET last_purchase = t.max_date FROM (SELECT user_id, MAX(created_at) as max_date FROM transactions GROUP BY user_id) t WHERE users.id = t.user_id"
+   :dialect "postgres"
+   ;; Note: UPDATE statements may not be fully parsed by sqlglot for field extraction
+   :expected []}
+
+  {:name "delete-with-subquery"
+   :sql "DELETE FROM users WHERE id IN (SELECT user_id FROM transactions WHERE total < 10)"
+   :dialect "postgres"
+   ;; Note: DELETE statements don't include the target table's columns in references
+   :expected [["transactions" "total"] ["transactions" "user_id"]]}]}


### PR DESCRIPTION
## Summary

Backports the GraalVM Python pool + sqlglot infrastructure from master to enable reliable, dialect-aware SQL parsing on the release branch.

- Adds GraalVM Python context pool (`sql_parsing/pool.clj`) using dirigiste for thread-safe, utilization-based pooling with TTL expiry
- Adds sqlglot Python wrapper (`sql_tools.py`) providing `referenced-tables`, `referenced-fields`, `validate-query`, `transpile-sql`, `simple-query?`, `add-into-clause`, etc.
- Adds Clojure API layer (`sql_parsing/core.clj`) with timeout handling and GraalVM interrupt support
- Adds `org.graalvm.polyglot/python` dep (same 25.0.1 version as existing JS engine)
- Adds uv setup to CI and Python build step for uberjar packaging

**Adapted from master:**
- Removed prometheus `analytics/inc!` calls (counters not registered on release branch)
- Replaced `metabase.util.performance/update-keys` with Clojure 1.11+ built-in `update-keys`

All new files, no existing callers modified.

## Test plan

- [x] Pool tests pass: `./bin/test-agent :only '[metabase.sql-parsing.pool-test]'`
- [x] Core tests pass: `./bin/test-agent :only '[metabase.sql-parsing.core-test]'`
- [x] CI passes (uv installed, deps resolve, no compile errors)