### PR TITLE
Fix deactivated published tables remaining in Library

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/library/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/library/api.clj
@@ -28,7 +28,7 @@
 (defn- add-here-and-below [collection]
   (let [descendent-ids (map :id (collection/descendants-flat collection))
         below-card-types (t2/select-fn-set :type [:model/Card :type] :collection_id [:in descendent-ids])
-        below-tables? (t2/exists? :model/Table :is_published true :collection_id [:in descendent-ids])]
+        below-tables? (t2/exists? :model/Table :is_published true :active true :collection_id [:in descendent-ids])]
     ;; This function is only used on the root Library which cannot have items directly in it
     ;; So can assume :here is only collection, and all descendants are :below
     (assoc collection :here #{"collection"}

--- a/enterprise/backend/test/metabase_enterprise/library/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/library/api_test.clj
@@ -4,7 +4,10 @@
    [metabase.collections.models.collection :as collection]
    [metabase.collections.test-utils :refer [without-library]]
    [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
    [toucan2.core :as t2]))
+
+(use-fixtures :once (fixtures/initialize :db :test-users))
 
 (deftest get-library-test
   (mt/with-premium-features #{:library}
@@ -34,4 +37,37 @@
              (let [response (mt/user-http-request :crowberto :get 200 "ee/library")]
                (is (= "Library" (:name response)))
                (is (= ["metric" "table"] (:below response)))
-               (is (= ["collection"] (:here response)))))))))))
+               (is (= ["collection"] (:here response))))))
+         (testing "Inactive (deactivated) tables should NOT appear in library :below"
+           (mt/with-temp [:model/Table _ {:display_name  "Inactive Table in Data"
+                                          :collection_id data-id
+                                          :is_published  true
+                                          :active        false}]
+             (let [response (mt/user-http-request :crowberto :get 200 "ee/library")]
+               (is (= [] (:below response))
+                   "Deactivated published table should not show up in library :below")))))))))
+
+(deftest deactivated-published-tables-not-shown-in-library-test
+  (testing "Deactivated published tables should not appear in collection items (GET /api/collection/:id/items)"
+    (mt/with-premium-features #{:library}
+      (mt/with-discard-model-updates! [:model/Collection]
+        (without-library
+         (collection/create-library-collection!)
+         (let [data-id (t2/select-one-pk :model/Collection :type collection/library-data-collection-type)]
+           (mt/with-temp [:model/Table {table-id :id} {:display_name  "Published Active Table"
+                                                       :collection_id data-id
+                                                       :is_published  true
+                                                       :active        true}]
+             (testing "Active published table appears in collection items"
+               (let [items (:data (mt/user-http-request :crowberto :get 200
+                                                        (str "collection/" data-id "/items")
+                                                        :models "table"))]
+                 (is (= 1 (count items)))
+                 (is (= table-id (:id (first items))))))
+             (testing "After deactivation, table no longer appears in collection items"
+               (t2/update! :model/Table table-id {:active false})
+               (let [items (:data (mt/user-http-request :crowberto :get 200
+                                                        (str "collection/" data-id "/items")
+                                                        :models "table"))]
+                 (is (= 0 (count items))
+                     "Deactivated published table should not be in collection items"))))))))))

--- a/src/metabase/collections_rest/api.clj
+++ b/src/metabase/collections_rest/api.clj
@@ -279,6 +279,7 @@
                                                                  :from :metabase_table
                                                                  :where [:and
                                                                          [:= :is_published true]
+                                                                         [:= :active true]
                                                                          [:= :archived_at nil]]})
                                                       (map :collection_id)
                                                       (into #{}))}))
@@ -780,6 +781,7 @@
      :from   [[:metabase_table :t]]
      :where  [:and
               [:= :t.is_published true]
+              [:= :t.active true]
               (poison-when-pinned-clause pinned-state)
               (collection/visible-collection-filter-clause :t.collection_id {:cte-name :visible_collection_ids})
               queryable-clause
@@ -822,6 +824,7 @@
                             :from :metabase_table
                             :where [:and
                                     [:= :is_published true]
+                                    [:= :active true]
                                     [:= :archived_at nil]
                                     [:in :collection_id descendant-collection-ids]]}))
                (map :collection_id)

--- a/src/metabase/transforms_base/util.clj
+++ b/src/metabase/transforms_base/util.clj
@@ -380,11 +380,15 @@
   (activate-table-and-mark-computed! database target))
 
 (defn deactivate-table!
-  "Deactivate table for `target` in `database` in the app db."
+  "Deactivate table for `target` in `database` in the app db.
+  Also clears `is_published` and `collection_id` so the table is removed from the Library.
+  Uses [[target-table]] rather than [[sync-table!]] since the physical table has already been dropped."
   [database target]
-  (when-let [table (sync-table! database target)]
+  (when-let [table (target-table (:id database) target)]
     ;; TODO this should probably be a function in the sync module
-    (t2/update! :model/Table (:id table) {:active false})))
+    (t2/update! :model/Table (:id table) {:active        false
+                                          :is_published  false
+                                          :collection_id nil})))
 
 (defn delete-target-table!
   "Delete the target table of a transform and sync it from the app db."


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #71195
### Description

When a transform's output table is deleted, the physical table is dropped first and then `deactivate-table\!` is called to update the app DB. However, `deactivate-table\!` was calling `sync-table\!`, which tries to describe the now-dropped physical table from the database. This threw an exception, causing `deactivate-table\!` to silently skip the app DB update — leaving the table record with `active=true`, `is_published=true`, and a `collection_id`, so it continued to appear in the Library.

**Root cause fix** (`transforms_base/util.clj`): `deactivate-table\!` now uses `target-table` (app DB lookup only) instead of `sync-table\!` (which requires the physical table to exist). It also clears `is_published` and `collection_id` so the table is fully removed from the Library.

**Defensive fix** (`collections_rest/api.clj`, `library/api.clj`): Added `active=true` filters to the collection items query, collection tree query, `annotate-collections`, and `add-here-and-below` so inactive tables are excluded even if `is_published` is not cleared by some other code path.

### How to verify

1. Create and run a transform
2. Publish the resulting table to the Library
3. Confirm the table appears in the Library
4. Delete the transform, choosing "Delete the transform and the table"
5. Go to the Library — the table should no longer appear

### Checklist

- [x] Tests have been added/updated to cover changes in this PR