### PR TITLE
Hide destination DBs from permissions

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/database_routing/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/database_routing/api_test.clj
@@ -3,6 +3,7 @@
    [clojure.test :refer [deftest is testing use-fixtures]]
    [metabase.driver :as driver]
    [metabase.driver.settings :as driver.settings]
+   [metabase.permissions-rest.data-permissions.graph :as data-perms.graph]
    [metabase.permissions.core :as perms]
    [metabase.test :as mt]
    [toucan2.core :as t2]))
@@ -197,3 +198,28 @@
       (mt/user-http-request :crowberto :get 404 (str "database/" destination-db-id "/syncable_schemas")))
     (testing "GET /database/:id/schemas"
       (mt/user-http-request :crowberto :get 404 (str "database/" destination-db-id "/schemas")))))
+
+(deftest destination-databases-excluded-from-permissions-graph
+  (mt/with-temp [:model/Database {db-id :id} {}
+                 :model/DatabaseRouter _ {:database_id db-id :user_attribute "foo"}
+                 :model/Database {destination-db-id :id} {:router_database_id db-id}]
+    (testing "Permissions graph does not include destination databases"
+      (let [graph (data-perms.graph/data-permissions-graph)]
+        (is (not (some (fn [[_group-id db-perms]]
+                         (contains? db-perms destination-db-id))
+                       graph)))))
+    (testing "API permissions graph does not include destination databases"
+      (let [api-graph (:groups (data-perms.graph/api-graph))]
+        (is (not (some (fn [[_group-id db-perms]]
+                         (contains? db-perms destination-db-id))
+                       api-graph)))))))
+
+(deftest new-group-does-not-get-destination-database-permissions
+  (mt/with-temp [:model/Database {db-id :id} {}
+                 :model/DatabaseRouter _ {:database_id db-id :user_attribute "foo"}
+                 :model/Database {destination-db-id :id} {:router_database_id db-id}]
+    (mt/with-temp [:model/PermissionsGroup {group-id :id} {:name "Test Group for Routing"}]
+      (testing "New group should have permissions for the router database"
+        (is (t2/exists? :model/DataPermissions :group_id group-id :db_id db-id)))
+      (testing "New group should NOT have permissions for the destination database"
+        (is (not (t2/exists? :model/DataPermissions :group_id group-id :db_id destination-db-id)))))))

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/data-permissions.unit.spec.fixtures.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/data-permissions.unit.spec.fixtures.ts
@@ -24,6 +24,12 @@ export const normalizedMetadata = {
       tables: [10, 11, 12, 13],
       id: 3,
     },
+    "4": {
+      name: "Destination Database",
+      tables: [],
+      id: 4,
+      router_database_id: 2,
+    },
   },
   schemas: {
     "2:schema_1": {
@@ -121,7 +127,7 @@ export const normalizedMetadata = {
   },
   snippets: {},
   revisions: {},
-  databasesList: [2, 3],
+  databasesList: [2, 3, 4],
 
   groups: {
     "1": createMockGroup({

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/data-sidebar.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/data-sidebar.ts
@@ -54,6 +54,7 @@ const getDatabasesSidebar = (metadata: Metadata): DataSidebarProps => {
   const entities = metadata
     .databasesList({ savedQuestions: false })
     .filter((db) => !PLUGIN_AUDIT.isAuditDb(db as DatabaseType))
+    .filter((db) => !(db as DatabaseType).router_database_id)
     .map((database) => ({
       id: database.id,
       name: database.name,

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/data-sidebar.unit.spec.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/data-sidebar.unit.spec.ts
@@ -55,6 +55,15 @@ describe("getDataFocusSidebar", () => {
         ],
       ]);
     });
+
+    it("excludes destination databases from the list", () => {
+      const sidebarData = getDataFocusSidebar(state, getRouteProps({}));
+      const allDbNames = sidebarData?.entityGroups
+        ?.flat()
+        .map((entity: any) => entity.name);
+
+      expect(allDbNames).not.toContain("Destination Database");
+    });
   });
 
   describe("when a database is selected", () => {

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/permission-editor.tsx
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/permission-editor.tsx
@@ -309,6 +309,7 @@ export const getDatabasesPermissionEditor = createSelector(
       entities = metadata
         .databasesList({ savedQuestions: false })
         .filter((db) => !PLUGIN_AUDIT.isAuditDb(db as Database))
+        .filter((db) => !(db as Database).router_database_id)
         .map((database) => {
           const entityId = getDatabaseEntityId(database);
           return {

--- a/src/metabase/permissions/models/permissions_group.clj
+++ b/src/metabase/permissions/models/permissions_group.clj
@@ -121,7 +121,7 @@
 (defn- set-default-permission-values!
   [group]
   (t2/with-transaction [_conn]
-    (doseq [db-id (t2/select-pks-vec :model/Database)]
+    (doseq [db-id (t2/select-pks-vec :model/Database :router_database_id nil)]
       (if (:is_tenant_group group)
         (data-perms/set-external-group-permissions! group db-id)
         (data-perms/set-new-group-permissions! group db-id (u/the-id (all-users)))))))

--- a/src/metabase/permissions_rest/data_permissions/graph.clj
+++ b/src/metabase/permissions_rest/data_permissions/graph.clj
@@ -135,7 +135,8 @@
   (let [admin-group-id (u/the-id (perms/admin-group))
         db-ids         (if db-id [db-id] (t2/select-pks-vec :model/Database
                                                             {:where [:and
-                                                                     (when-not audit? [:not= :id audit/audit-db-id])]}))]
+                                                                     (when-not audit? [:not= :id audit/audit-db-id])
+                                                                     [:= :router_database_id nil]]}))]
     ;; Don't add admin perms when we're fetching the perms for a specific non-admin group or set of groups
     (if (or (= group-id admin-group-id)
             (contains? (set group-ids) admin-group-id)
@@ -155,7 +156,8 @@
   (let [data-analyst-group-id (u/the-id (perms/data-analyst-group))
         db-ids                (if db-id [db-id] (t2/select-pks-vec :model/Database
                                                                    {:where [:and
-                                                                            (when-not audit? [:not= :id audit/audit-db-id])]}))]
+                                                                            (when-not audit? [:not= :id audit/audit-db-id])
+                                                                            [:= :router_database_id nil]]}))]
     ;; Don't add data analyst perms when we're fetching perms for a specific non-data-analyst group
     (if (or (= group-id data-analyst-group-id)
             (contains? (set group-ids) data-analyst-group-id)
@@ -207,7 +209,10 @@
                                        (when db-id [:= :db_id db-id])
                                        (when group-id [:= :group_id group-id])
                                        (when group-ids [:in :group_id group-ids])
-                                       (when-not audit? [:not= :db_id audit/audit-db-id])]})]
+                                       (when-not audit? [:not= :db_id audit/audit-db-id])
+                                       [:not-in :db_id {:select [:id]
+                                                        :from   [:metabase_database]
+                                                        :where  [:not= :router_database_id nil]}]]})]
     (reduce
      (fn [graph {group-id  :group-id
                  perm-type :type


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #71303
Two commits:

## FE: do not show destination DBs in permissions editor

If you add a destination database, don't show it in the perms editor.

This was a temporary bug (disappears on refresh) BUT if you edit permissions
for the destination database then that is persisted, which is not great. I
will fix that in a separate PR.

## Don't add data permissions rows for destination DBs

- Exclude destination databases from the permissions graph

- Don't add permissions for destination DBs when creating a new group