### PR TITLE
Create a virtual anchor for PopoverWithRef

### DIFF
--- a/frontend/src/metabase/ui/components/overlays/Popover/PopoverWithRef.tsx
+++ b/frontend/src/metabase/ui/components/overlays/Popover/PopoverWithRef.tsx
@@ -1,3 +1,4 @@
+import type { ReferenceElement, VirtualElement } from "@floating-ui/dom";
 import {
   type PropsWithChildren,
   type Ref,
@@ -8,6 +9,28 @@ import {
 } from "react";
 
 import { Popover, type PopoverProps } from "./index";
+
+export interface VirtualAnchor extends VirtualElement {
+  contains: (node: Node | null) => boolean;
+}
+
+// Creates a Floating UI virtual element that tracks the real element's live
+// position. When the element is disconnected from the DOM (e.g. removed by
+// virtual scrolling), it returns the last known rect to prevent Floating UI
+// from repositioning the popover to (0,0).
+export function createVirtualAnchor(element: Element): VirtualAnchor {
+  let lastRect = element.getBoundingClientRect();
+  return {
+    getBoundingClientRect: () => {
+      if (element.isConnected) {
+        lastRect = element.getBoundingClientRect();
+      }
+      return lastRect;
+    },
+    // Delegates to the real element for Mantine's click-outside detection
+    contains: (node: Node | null) => element.contains(node),
+  };
+}
 
 // Not something we want to use a ton. This is only meant to help migrate
 // to Mantine popovers in situations where we pass an anchor as a reference for
@@ -22,8 +45,15 @@ export const PopoverWithRef = ({
     anchorEl: Element | null;
     popoverContentTestId?: string;
   }) => {
-  const anchorRef = useRef(anchorEl);
-  anchorRef.current = anchorEl;
+  // Wrap the anchor in a virtual element that tracks its live position but
+  // falls back to the last known rect when removed from the DOM.
+  const virtualAnchor = useMemo(
+    () => (anchorEl ? createVirtualAnchor(anchorEl) : null),
+    [anchorEl],
+  );
+
+  const anchorRef = useRef(virtualAnchor);
+  anchorRef.current = virtualAnchor;
 
   const Target = useMemo(() => {
     return forwardRef(function Target(
@@ -31,8 +61,14 @@ export const PopoverWithRef = ({
       ref: Ref<Element> | null,
     ) {
       useLayoutEffect(() => {
-        if (typeof ref === "function") {
-          ref(anchorRef.current);
+        // Mantine types the ref as Ref<Element>, but internally it forwards
+        // to Floating UI's setReference which accepts ReferenceElement
+        // (Element | VirtualElement).
+        const setRef = ref as
+          | ((instance: ReferenceElement | null) => void)
+          | null;
+        if (typeof setRef === "function") {
+          setRef(anchorRef.current);
         }
       }, [ref]);
 

--- a/frontend/src/metabase/ui/components/overlays/Popover/PopoverWithRef.unit.spec.tsx
+++ b/frontend/src/metabase/ui/components/overlays/Popover/PopoverWithRef.unit.spec.tsx
@@ -1,0 +1,89 @@
+import { createVirtualAnchor } from "./PopoverWithRef";
+
+function createAnchorEl(rect: Partial<DOMRect> = {}) {
+  const element = document.createElement("div");
+  document.body.appendChild(element);
+
+  const fullRect = {
+    top: 100,
+    left: 200,
+    bottom: 140,
+    right: 360,
+    width: 160,
+    height: 40,
+    x: 200,
+    y: 100,
+    toJSON: () => ({}),
+    ...rect,
+  };
+
+  // jsdom elements return all zeros from getBoundingClientRect by default
+  element.getBoundingClientRect = () => fullRect as DOMRect;
+  return element;
+}
+
+describe("createVirtualAnchor", () => {
+  it("returns the live rect while the element is connected", () => {
+    const element = createAnchorEl({ top: 100, left: 200 });
+    const anchor = createVirtualAnchor(element);
+
+    expect(anchor.getBoundingClientRect().top).toBe(100);
+    expect(anchor.getBoundingClientRect().left).toBe(200);
+
+    // Simulate the element moving during normal scroll
+    element.getBoundingClientRect = () =>
+      ({
+        top: 60,
+        left: 200,
+        bottom: 100,
+        right: 360,
+        width: 160,
+        height: 40,
+        x: 200,
+        y: 60,
+        toJSON: () => ({}),
+      }) as DOMRect;
+
+    expect(anchor.getBoundingClientRect().top).toBe(60);
+    expect(anchor.getBoundingClientRect().left).toBe(200);
+  });
+
+  it("returns the last known rect after the element is removed from DOM", () => {
+    const element = createAnchorEl({ top: 100, left: 200 });
+    const anchor = createVirtualAnchor(element);
+
+    // Read once so lastRect is up to date
+    anchor.getBoundingClientRect();
+
+    element.remove();
+
+    // Returns the cached rect to prevent the (0,0) flash
+    const rect = anchor.getBoundingClientRect();
+    expect(rect.top).toBe(100);
+    expect(rect.left).toBe(200);
+  });
+
+  it("delegates contains() to the real element", () => {
+    const element = createAnchorEl();
+    const child = document.createElement("span");
+    element.appendChild(child);
+    const outside = document.createElement("span");
+
+    const anchor = createVirtualAnchor(element);
+
+    expect(anchor.contains(child)).toBe(true);
+    expect(anchor.contains(outside)).toBe(false);
+  });
+
+  it("contains() still works after element is removed from DOM", () => {
+    const element = createAnchorEl();
+    const child = document.createElement("span");
+    element.appendChild(child);
+
+    const anchor = createVirtualAnchor(element);
+    element.remove();
+
+    // Detached elements still maintain parent-child relationships
+    expect(anchor.contains(child)).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/71277

### Description
Sets up our `popoverWithRef` component with a virtual anchor to use for positioning. This virtual anchor will have a consistent boundingRect, and appears to be a valid way of positioning popovers in [floating-ui](https://floating-ui.com/docs/virtual-elements). As far as I can tell, this component is only used by TableInteractive (it used to be used in more places), so the scope of the change is relatively small

### How to verify
1. open up a table viz
2. click on a cell to open the click actions menu
3. Scroll the table. The popover should close without flickering in the top left corner of the screen.

### Demo

https://github.com/user-attachments/assets/d420a589-2863-4fdd-a24e-ddd40135b7ab

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
