### PR TITLE
Lint id order for directory-based migrations

### DIFF
--- a/bin/lint-migrations-file/src/lint_migrations_file.cljc
+++ b/bin/lint-migrations-file/src/lint_migrations_file.cljc
@@ -84,16 +84,39 @@
         (and (= v threshold-version)
              (not (neg? (compare local-id threshold-id)))))))
 
-(defn- require-change-set-ids-in-order [change-log file]
-  (when-not (directory-based-migration-file? file)
-    (let [ids              (change-set-ids change-log)
-          out-of-order-ids (->> ids
-                                (partition 2 1)
-                                (filter (fn [[id1 id2]]
-                                          (pos? (compare id1 id2)))))]
-      (when (seq out-of-order-ids)
-        (throw (validation-error "Change set IDs are not in order"
-                                 {:out-of-order-ids out-of-order-ids}))))))
+(defn- numeric-id? [s]
+  (boolean (re-matches #"\d+" s)))
+
+(defn- compare-local-ids
+  "Compare two local changeset IDs (the part after the `v{version}.` prefix).
+  - Both numeric: compare as numbers (so `2` < `10`)
+  - One numeric, one string: string (legacy date format) sorts before number (new format)
+  - Both strings: lexicographic comparison (works for date-based timestamps)"
+  [a b]
+  (let [na (numeric-id? a)
+        nb (numeric-id? b)]
+    (cond
+      (and na nb)       (compare (parse-long a) (parse-long b))
+      (and na (not nb)) 1
+      (and nb (not na)) -1
+      :else             (compare a b))))
+
+(defn- id-local-part
+  "Returns the local part of a changeset ID (after the `v{version}.` prefix), or the full ID if unprefixed."
+  [id]
+  (if-let [[_ local] (re-matches #"^v\d+\.(.+)$" (str id))]
+    local
+    (str id)))
+
+(defn- require-change-set-ids-in-order [change-log _file]
+  (let [ids          (change-set-ids change-log)
+        out-of-order (->> ids
+                          (partition 2 1)
+                          (filter (fn [[a b]] (pos? (compare-local-ids (id-local-part a)
+                                                                       (id-local-part b))))))]
+    (when (seq out-of-order)
+      (throw (validation-error "Change set IDs are not in order"
+                               {:out-of-order-ids out-of-order})))))
 
 (defn- require-change-set-ids-in-correct-file [change-log file]
   (let [fv  (file-version file)

--- a/bin/lint-migrations-file/src/lint_migrations_file.cljc
+++ b/bin/lint-migrations-file/src/lint_migrations_file.cljc
@@ -85,26 +85,27 @@
              (not (neg? (compare local-id threshold-id)))))))
 
 (defn- parse-change-set-id
-  "Parses a changeset ID like `v49.2024-01-01T10:30:00` into [version local-part],
-  or [nil full-id] if unprefixed."
+  "Parses a changeset ID like `v49.2024-01-01T10:30:00` into [version local-part].
+  version is a long, local-part is a long when purely numeric or a string otherwise."
   [id]
-  (if-let [[_ v local] (re-matches #"^v(\d+)\.(.+)$" (str id))]
-    [(parse-long v) local]
-    [nil (str id)]))
+  (let [s (str id)
+        [_ v local] (re-matches #"^v(\d+)\.(.+)$" s)]
+    (if v
+      [(parse-long v) (or (parse-long local) local)]
+      [nil (or (parse-long s) s)])))
 
 (defn- compare-change-set-ids
   "Compare two changeset IDs. Version number takes priority; within the same version,
   numeric local parts are compared as numbers, timestamps lexicographically, and
-  timestamps sort before numeric IDs (legacy before new format)."
+  timestamps sort after string IDs (legacy date format before new numeric format)."
   [a b]
   (let [[va la] (parse-change-set-id a)
         [vb lb] (parse-change-set-id b)]
     (cond
       (and va vb (not= va vb)) (compare va vb)
-      (every? #(re-matches #"\d+" %) [la lb]) (compare (parse-long la) (parse-long lb))
-      (re-matches #"\d+" la) 1
-      (re-matches #"\d+" lb) -1
-      :else (compare la lb))))
+      (= (type la) (type lb))  (compare la lb)
+      (int? la)                 1
+      :else                    -1)))
 
 (defn- require-change-set-ids-in-order [change-log _file]
   (let [ids          (change-set-ids change-log)

--- a/bin/lint-migrations-file/src/lint_migrations_file.cljc
+++ b/bin/lint-migrations-file/src/lint_migrations_file.cljc
@@ -84,36 +84,33 @@
         (and (= v threshold-version)
              (not (neg? (compare local-id threshold-id)))))))
 
-(defn- numeric-id? [s]
-  (boolean (re-matches #"\d+" s)))
-
-(defn- compare-local-ids
-  "Compare two local changeset IDs (the part after the `v{version}.` prefix).
-  - Both numeric: compare as numbers (so `2` < `10`)
-  - One numeric, one string: string (legacy date format) sorts before number (new format)
-  - Both strings: lexicographic comparison (works for date-based timestamps)"
-  [a b]
-  (let [na (numeric-id? a)
-        nb (numeric-id? b)]
-    (cond
-      (and na nb)       (compare (parse-long a) (parse-long b))
-      (and na (not nb)) 1
-      (and nb (not na)) -1
-      :else             (compare a b))))
-
-(defn- id-local-part
-  "Returns the local part of a changeset ID (after the `v{version}.` prefix), or the full ID if unprefixed."
+(defn- parse-change-set-id
+  "Parses a changeset ID like `v49.2024-01-01T10:30:00` into [version local-part],
+  or [nil full-id] if unprefixed."
   [id]
-  (if-let [[_ local] (re-matches #"^v\d+\.(.+)$" (str id))]
-    local
-    (str id)))
+  (if-let [[_ v local] (re-matches #"^v(\d+)\.(.+)$" (str id))]
+    [(parse-long v) local]
+    [nil (str id)]))
+
+(defn- compare-change-set-ids
+  "Compare two changeset IDs. Version number takes priority; within the same version,
+  numeric local parts are compared as numbers, timestamps lexicographically, and
+  timestamps sort before numeric IDs (legacy before new format)."
+  [a b]
+  (let [[va la] (parse-change-set-id a)
+        [vb lb] (parse-change-set-id b)]
+    (cond
+      (and va vb (not= va vb)) (compare va vb)
+      (every? #(re-matches #"\d+" %) [la lb]) (compare (parse-long la) (parse-long lb))
+      (re-matches #"\d+" la) 1
+      (re-matches #"\d+" lb) -1
+      :else (compare la lb))))
 
 (defn- require-change-set-ids-in-order [change-log _file]
   (let [ids          (change-set-ids change-log)
         out-of-order (->> ids
                           (partition 2 1)
-                          (filter (fn [[a b]] (pos? (compare-local-ids (id-local-part a)
-                                                                       (id-local-part b))))))]
+                          (filter (fn [[a b]] (pos? (compare-change-set-ids a b)))))]
     (when (seq out-of-order)
       (throw (validation-error "Change set IDs are not in order"
                                {:out-of-order-ids out-of-order})))))

--- a/bin/lint-migrations-file/test/lint_migrations_file_test.clj
+++ b/bin/lint-migrations-file/test/lint_migrations_file_test.clj
@@ -282,7 +282,23 @@
        (thrown-with-msg?
         clojure.lang.ExceptionInfo
         #"Change set IDs are in the wrong file"
-        (validate-id "v57.2024-01-01T10:30:00" "056_update_migrations.yaml"))))))
+        (validate-id "v57.2024-01-01T10:30:00" "056_update_migrations.yaml"))))
+    (testing "directory-based feature files"
+      (let [file "060/20260310_test.yaml"]
+        (is (= :ok
+               (validate-id "v60.1" file)))
+        (is (= :ok
+               (validate-id "v60.2026-03-10T00:00:00" file)))
+        (is
+         (thrown-with-msg?
+          clojure.lang.ExceptionInfo
+          #"Change set IDs are in the wrong file"
+          (validate-id "v49.2024-01-01T10:30:00" file)))
+        (is
+         (thrown-with-msg?
+          clojure.lang.ExceptionInfo
+          #"Change set IDs are in the wrong file"
+          (validate-id "v61.1" file)))))))
 
 (deftest prevent-text-types-test
   (testing "should allow \"${text.type}\" columns from being added"

--- a/bin/lint-migrations-file/test/lint_migrations_file_test.clj
+++ b/bin/lint-migrations-file/test/lint_migrations_file_test.clj
@@ -132,7 +132,27 @@
              (validate-file dir-file
                             (mock-change-set :id "v60.2026-03-10T00:00:00")
                             (mock-change-set :id "v60.1")
-                            (mock-change-set :id "v60.2")))))))
+                            (mock-change-set :id "v60.2"))))))
+
+  (testing "Cross-version boundaries: later version with earlier local part is allowed"
+    (is (= :ok
+           (validate
+            (mock-change-set :id "v52.2025-05-28T00:00:01")
+            (mock-change-set :id "v53.2024-12-02T16:21:15"))))
+    (is (= :ok
+           (validate
+            (mock-change-set :id "v45.00-057")
+            (mock-change-set :id "v46.00-000")
+            (mock-change-set :id "v46.00-090")
+            (mock-change-set :id "v47.00-001")))))
+
+  (testing "Cross-version boundaries: earlier version after later version is not allowed"
+    (is-thrown-with-error-info?
+     "Change set IDs are not in order"
+     {:out-of-order-ids [["v53.2024-12-02T16:21:15" "v52.2025-05-28T00:00:01"]]}
+     (validate
+      (mock-change-set :id "v53.2024-12-02T16:21:15")
+      (mock-change-set :id "v52.2025-05-28T00:00:01")))))
 
 (deftest only-one-column-per-add-column-test
   (testing "we should only allow one column per addColumn change"

--- a/bin/lint-migrations-file/test/lint_migrations_file_test.clj
+++ b/bin/lint-migrations-file/test/lint_migrations_file_test.clj
@@ -96,7 +96,43 @@
                           "v49.2023-12-14T08:54:53"]]}
      (validate
       (mock-change-set :id "v49.2023-12-14T08:54:54")
-      (mock-change-set :id "v49.2023-12-14T08:54:53")))))
+      (mock-change-set :id "v49.2023-12-14T08:54:53"))))
+
+  (testing "Directory-based: numeric IDs are compared numerically (10 > 2)"
+    (let [dir-file (io/file "060/20260310_test.yaml")]
+      (is (= :ok
+             (validate-file dir-file
+                            (mock-change-set :id "v60.1")
+                            (mock-change-set :id "v60.2")
+                            (mock-change-set :id "v60.10"))))
+      (is-thrown-with-error-info?
+       "Change set IDs are not in order"
+       {:out-of-order-ids [["v60.10" "v60.2"]]}
+       (validate-file dir-file
+                      (mock-change-set :id "v60.10")
+                      (mock-change-set :id "v60.2")))))
+
+  (testing "Directory-based: date-based IDs use string comparison"
+    (let [dir-file (io/file "060/20260310_test.yaml")]
+      (is (= :ok
+             (validate-file dir-file
+                            (mock-change-set :id "v60.2026-03-10T00:00:00")
+                            (mock-change-set :id "v60.2026-03-10T00:00:01")
+                            (mock-change-set :id "v60.2026-03-10T00:00:10"))))
+      (is-thrown-with-error-info?
+       "Change set IDs are not in order"
+       {:out-of-order-ids [["v60.2026-03-10T00:00:10" "v60.2026-03-10T00:00:02"]]}
+       (validate-file dir-file
+                      (mock-change-set :id "v60.2026-03-10T00:00:10")
+                      (mock-change-set :id "v60.2026-03-10T00:00:02")))))
+
+  (testing "Directory-based: numeric IDs sort after date-based IDs (legacy first)"
+    (let [dir-file (io/file "060/20260310_test.yaml")]
+      (is (= :ok
+             (validate-file dir-file
+                            (mock-change-set :id "v60.2026-03-10T00:00:00")
+                            (mock-change-set :id "v60.1")
+                            (mock-change-set :id "v60.2")))))))
 
 (deftest only-one-column-per-add-column-test
   (testing "we should only allow one column per addColumn change"


### PR DESCRIPTION
This remains a best practice IMHO
