### PR TITLE
GDGT-2090: Update custom viz manager page

### DIFF
--- a/frontend/src/metabase/admin/settings/components/SettingsNav/SettingsNav.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsNav/SettingsNav.tsx
@@ -63,10 +63,19 @@ export function SettingsNav() {
         icon="globe"
       />
       <SettingsNavItem
-        path="custom-viz-plugins"
-        label={t`Custom viz plugins`}
-        icon="embed"
-      />
+        label={t`Custom visualizations`}
+        icon="bar"
+        folderPattern="custom-visualizations"
+      >
+        <SettingsNavItem
+          path="custom-visualizations"
+          label={t`Manage visualizations`}
+        />
+        <SettingsNavItem
+          path="custom-visualizations/development"
+          label={t`Development`}
+        />
+      </SettingsNavItem>
       <SettingsNavItem path="maps" label={t`Maps`} icon="pinmap" />
       <SettingsNavItem
         path={!hasWhitelabel ? "whitelabel" : undefined}

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/CustomVizPluginsSettingsPage.module.css
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/CustomVizPluginsSettingsPage.module.css
@@ -1,0 +1,16 @@
+.pluginListItem {
+  cursor: pointer;
+  border-radius: var(--mantine-radius-md);
+}
+
+.pluginListItem:hover {
+  background-color: var(--mb-color-background-hover);
+}
+
+.pluginList > *:not(:last-child) {
+  border-bottom: 1px solid var(--mb-color-border);
+}
+
+.devUrlList > *:not(:last-child) {
+  border-bottom: 1px solid var(--mb-color-border);
+}

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/CustomVizPluginsSettingsPage.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/CustomVizPluginsSettingsPage.tsx
@@ -1,5 +1,5 @@
-import { useDisclosure } from "@mantine/hooks";
 import { useCallback, useMemo, useState } from "react";
+import { push } from "react-router-redux";
 import { t } from "ttag";
 
 import {
@@ -14,6 +14,7 @@ import {
   useSetCustomVizPluginDevUrlMutation,
   useUpdateCustomVizPluginMutation,
 } from "metabase/api";
+import { Link } from "metabase/common/components/Link";
 import {
   Form,
   FormErrorMessage,
@@ -21,33 +22,42 @@ import {
   FormSubmitButton,
   FormTextInput,
 } from "metabase/forms";
+import { useDispatch } from "metabase/lib/redux";
 import {
   ActionIcon,
   Box,
   Button,
-  Collapse,
   Flex,
   Group,
   Icon,
   Loader,
   Menu,
   Stack,
-  Switch,
   Text,
   TextInput,
+  Title,
 } from "metabase/ui";
 import { getPluginAssetUrl } from "metabase/visualizations/custom-viz-plugins";
 import type { CustomVizPlugin } from "metabase-types/api";
 
+import S from "./CustomVizPluginsSettingsPage.module.css";
+
+const BASE_PATH = "/admin/settings/custom-visualizations";
+
 function PluginIconPreview({ plugin }: { plugin: CustomVizPlugin }) {
   const iconUrl = getPluginAssetUrl(plugin.id, plugin.icon);
+  const dimmed = !plugin.enabled;
   return (
     <ActionIcon
       w="3.125rem"
       h="3.125rem"
       radius="xl"
       variant="outline"
-      style={{ border: "1px solid var(--mb-color-border)" }}
+      c={dimmed ? "text-secondary" : undefined}
+      style={{
+        border: "1px solid var(--mb-color-border)",
+        opacity: dimmed ? 0.6 : undefined,
+      }}
     >
       {iconUrl ? (
         <img
@@ -55,6 +65,7 @@ function PluginIconPreview({ plugin }: { plugin: CustomVizPlugin }) {
           alt={plugin.display_name}
           width={20}
           height={20}
+          style={dimmed ? { filter: "grayscale(1)", opacity: 0.6 } : undefined}
         />
       ) : (
         <Icon name="unknown" size={20} />
@@ -63,16 +74,204 @@ function PluginIconPreview({ plugin }: { plugin: CustomVizPlugin }) {
   );
 }
 
-function PluginForm({
+function PluginListItem({
   plugin,
-  onClose,
+  onDelete,
 }: {
-  plugin?: CustomVizPlugin;
-  onClose: () => void;
+  plugin: CustomVizPlugin;
+  onDelete: (id: number) => void;
 }) {
+  const dispatch = useDispatch();
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [updatePlugin] = useUpdateCustomVizPluginMutation();
+  const [refreshPlugin, { isLoading: isRefreshing }] =
+    useRefreshCustomVizPluginMutation();
+
+  const handleDelete = useCallback(async () => {
+    setIsDeleting(true);
+    try {
+      await onDelete(plugin.id);
+    } finally {
+      setIsDeleting(false);
+    }
+  }, [plugin.id, onDelete]);
+
+  const handleToggleEnabled = useCallback(async () => {
+    await updatePlugin({ id: plugin.id, enabled: !plugin.enabled });
+  }, [plugin.id, plugin.enabled, updatePlugin]);
+
+  const handleRefresh = useCallback(async () => {
+    await refreshPlugin(plugin.id);
+  }, [plugin.id, refreshPlugin]);
+
+  const handleClick = useCallback(() => {
+    dispatch(push(`${BASE_PATH}/edit/${plugin.id}`));
+  }, [dispatch, plugin.id]);
+
+  return (
+    <Flex
+      justify="space-between"
+      align="center"
+      p="md"
+      className={S.pluginListItem}
+      onClick={handleClick}
+    >
+      <Group gap="md" align="center">
+        <PluginIconPreview plugin={plugin} />
+        <Stack gap={4}>
+          <Text fw={700}>{plugin.display_name}</Text>
+          <Group gap="xs">
+            <Text
+              component="a"
+              href={plugin.repo_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              size="sm"
+              c="text-tertiary"
+              td="underline"
+              onClick={(e) => e.stopPropagation()}
+            >
+              {plugin.repo_url}
+            </Text>
+            {plugin.resolved_commit && (
+              <>
+                <Text size="sm" c="text-tertiary">
+                  &bull;
+                </Text>
+                <Text size="sm" c="text-tertiary">
+                  {t`Commit`}: {plugin.resolved_commit.slice(0, 8)}
+                </Text>
+              </>
+            )}
+          </Group>
+          {plugin.error_message && (
+            <Text size="sm" c="error">
+              {plugin.error_message}
+            </Text>
+          )}
+        </Stack>
+      </Group>
+      <Box onClick={(e) => e.stopPropagation()}>
+        <Menu>
+          <Menu.Target>
+            <ActionIcon variant="subtle" loading={isRefreshing || isDeleting}>
+              <Icon name="ellipsis" />
+            </ActionIcon>
+          </Menu.Target>
+          <Menu.Dropdown>
+            <Menu.Item
+              leftSection={<Icon name="refresh" />}
+              onClick={handleRefresh}
+            >
+              {t`Re-fetch`}
+            </Menu.Item>
+            <Menu.Item
+              leftSection={<Icon name={plugin.enabled ? "stop" : "play"} />}
+              onClick={handleToggleEnabled}
+            >
+              {plugin.enabled ? t`Disable` : t`Enable`}
+            </Menu.Item>
+            <Menu.Item
+              leftSection={<Icon name="trash" />}
+              color="error"
+              onClick={handleDelete}
+            >
+              {t`Remove`}
+            </Menu.Item>
+          </Menu.Dropdown>
+        </Menu>
+      </Box>
+    </Flex>
+  );
+}
+
+export function ManageCustomVisualizationsPage() {
+  const { data: plugins, isLoading } = useListAllCustomVizPluginsQuery();
+  const [deletePlugin] = useDeleteCustomVizPluginMutation();
+
+  const handleDelete = useCallback(
+    async (id: number) => {
+      await deletePlugin(id).unwrap();
+    },
+    [deletePlugin],
+  );
+
+  return (
+    <SettingsPageWrapper
+      description={t`Add custom visualizations to your instance here by adding links to git repositories containing custom visualization bundles.`}
+    >
+      <Flex justify="space-between" align="center" mih="2.75rem">
+        <Title
+          order={1}
+          h="2.75rem"
+          display="flex"
+          style={{ alignItems: "center" }}
+        >{t`Manage custom visualizations`}</Title>
+        <Button
+          component={Link}
+          to={`${BASE_PATH}/new`}
+          variant="filled"
+          leftSection={<Icon name="add" />}
+        >
+          {t`Add visualization`}
+        </Button>
+      </Flex>
+
+      <SettingsSection>
+        {isLoading && (
+          <Flex justify="center" p="xl">
+            <Loader />
+          </Flex>
+        )}
+
+        {plugins && plugins.length === 0 && !isLoading && (
+          <Box
+            p="xl"
+            style={{
+              borderRadius: "var(--mb-radius-md)",
+              backgroundColor: "var(--mb-color-bg-white)",
+              minHeight: "20rem",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+          >
+            <Text c="text-tertiary">{t`You don't have any custom visualizations.`}</Text>
+          </Box>
+        )}
+
+        {plugins && plugins.length > 0 && (
+          <Box
+            className={S.pluginList}
+            style={{
+              borderRadius: "var(--mb-radius-md)",
+              backgroundColor: "var(--mb-color-bg-white)",
+              overflow: "hidden",
+            }}
+          >
+            {plugins.map((plugin) => (
+              <PluginListItem
+                key={plugin.id}
+                plugin={plugin}
+                onDelete={handleDelete}
+              />
+            ))}
+          </Box>
+        )}
+      </SettingsSection>
+    </SettingsPageWrapper>
+  );
+}
+
+export function CustomVizFormPage({ params }: { params?: { id?: string } }) {
+  const dispatch = useDispatch();
+  const pluginId = params?.id ? parseInt(params.id, 10) : undefined;
+  const { data: plugins } = useListAllCustomVizPluginsQuery();
+  const plugin = pluginId ? plugins?.find((p) => p.id === pluginId) : undefined;
+  const isEdit = pluginId != null;
+
   const [createPlugin] = useCreateCustomVizPluginMutation();
   const [updatePlugin] = useUpdateCustomVizPluginMutation();
-  const isEdit = Boolean(plugin);
 
   const initialValues = useMemo(
     () => ({
@@ -102,187 +301,81 @@ function PluginForm({
           pinned_version: values.pinned_version || null,
         }).unwrap();
       }
-      onClose();
+      dispatch(push(BASE_PATH));
     },
-    [createPlugin, updatePlugin, plugin, isEdit, onClose],
+    [createPlugin, updatePlugin, plugin, isEdit, dispatch],
   );
 
-  return (
-    <Box
-      p="lg"
-      style={{
-        border: "1px solid var(--mb-color-border)",
-        borderRadius: "var(--mb-radius-md)",
-      }}
-    >
-      <FormProvider initialValues={initialValues} onSubmit={handleSubmit}>
-        {({ dirty }) => (
-          <Form>
-            <Stack gap="lg">
-              <Stack gap="md">
-                <Text fw={700}>{t`Git settings`}</Text>
-                <FormTextInput
-                  name="repo_url"
-                  label={t`Repository URL`}
-                  placeholder="https://github.com/user/custom-viz-plugin"
-                  disabled={isEdit}
-                  autoFocus={!isEdit}
-                />
-                <FormTextInput
-                  name="access_token"
-                  label={t`Access token (optional)`}
-                  description={
-                    <Text c="text-tertiary" size="sm" component="span">
-                      {t`Personal access token for private repositories`}
-                    </Text>
-                  }
-                  type="password"
-                />
-                <FormTextInput
-                  name="pinned_version"
-                  label={t`Pinned version (optional)`}
-                  description={
-                    <Text c="text-tertiary" size="sm" component="span">
-                      {t`Branch, tag, or commit SHA to pin to`}
-                    </Text>
-                  }
-                  placeholder="main"
-                />
-              </Stack>
-              <FormErrorMessage />
-              <Group gap="sm">
-                <FormSubmitButton
-                  label={isEdit ? t`Update plugin` : t`Add plugin`}
-                  disabled={!dirty}
-                  variant="filled"
-                />
-                <Button variant="subtle" onClick={onClose}>
-                  {t`Cancel`}
-                </Button>
-              </Group>
-            </Stack>
-          </Form>
-        )}
-      </FormProvider>
-    </Box>
-  );
-}
+  const handleCancel = useCallback(() => {
+    dispatch(push(BASE_PATH));
+  }, [dispatch]);
 
-function PluginListItem({
-  plugin,
-  onDelete,
-  onEdit,
-}: {
-  plugin: CustomVizPlugin;
-  onDelete: (id: number) => void;
-  onEdit: (plugin: CustomVizPlugin) => void;
-}) {
-  const [isDeleting, setIsDeleting] = useState(false);
-  const [updatePlugin] = useUpdateCustomVizPluginMutation();
-  const [refreshPlugin, { isLoading: isRefreshing }] =
-    useRefreshCustomVizPluginMutation();
-
-  const handleDelete = useCallback(async () => {
-    setIsDeleting(true);
-    try {
-      await onDelete(plugin.id);
-    } finally {
-      setIsDeleting(false);
-    }
-  }, [plugin.id, onDelete]);
-
-  const handleToggleEnabled = useCallback(async () => {
-    await updatePlugin({ id: plugin.id, enabled: !plugin.enabled });
-  }, [plugin.id, plugin.enabled, updatePlugin]);
-
-  const handleRefresh = useCallback(async () => {
-    await refreshPlugin(plugin.id);
-  }, [plugin.id, refreshPlugin]);
+  if (isEdit && !plugin && plugins) {
+    dispatch(push(BASE_PATH));
+    return null;
+  }
 
   return (
-    <Flex
-      justify="space-between"
-      align="center"
-      p="md"
-      style={{
-        border: "1px solid var(--mb-color-border)",
-        borderRadius: "var(--mb-radius-md)",
-      }}
+    <SettingsPageWrapper
+      description={t`Add custom visualizations to your instance here by adding links to git repositories containing custom visualization bundles.`}
     >
-      <Group gap="md" align="flex-start">
-        <PluginIconPreview plugin={plugin} />
-        <Stack gap="xs">
-          <Text fw={700}>{plugin.display_name}</Text>
-          <Text
-            component="a"
-            href={plugin.repo_url}
-            target="_blank"
-            rel="noopener noreferrer"
-            size="sm"
-            c="text-tertiary"
-            td="underline"
-          >
-            {plugin.repo_url}
-          </Text>
-          {plugin.error_message && (
-            <Text size="sm" c="error">
-              {plugin.error_message}
-            </Text>
-          )}
-          {plugin.resolved_commit && (
-            <Text size="sm" c="text-tertiary">
-              {t`Commit`}: {plugin.resolved_commit.slice(0, 8)}
-              {plugin.pinned_version && ` (${plugin.pinned_version})`}
-            </Text>
-          )}
-          {plugin.metabase_version != null && (
-            <Text size="sm" c="text-tertiary">
-              {t`Metabase version`}: {plugin.metabase_version}
-            </Text>
-          )}
-        </Stack>
-      </Group>
-      <Group gap="sm">
-        <Switch
-          checked={plugin.enabled}
-          onChange={handleToggleEnabled}
-          label={plugin.enabled ? t`Enabled` : t`Disabled`}
-          size="sm"
-        />
-        <Menu>
-          <Menu.Target>
-            <Button
-              variant="subtle"
-              p="xs"
-              loading={isRefreshing || isDeleting}
-            >
-              <Icon name="ellipsis" />
-            </Button>
-          </Menu.Target>
-          <Menu.Dropdown>
-            <Menu.Item
-              leftSection={<Icon name="pencil" />}
-              onClick={() => onEdit(plugin)}
-            >
-              {t`Edit`}
-            </Menu.Item>
-            <Menu.Item
-              leftSection={<Icon name="refresh" />}
-              onClick={handleRefresh}
-            >
-              {t`Refetch`}
-            </Menu.Item>
-            <Menu.Item
-              leftSection={<Icon name="trash" />}
-              color="error"
-              onClick={handleDelete}
-            >
-              {t`Remove`}
-            </Menu.Item>
-          </Menu.Dropdown>
-        </Menu>
-      </Group>
-    </Flex>
+      <Title
+        order={1}
+        h="2.75rem"
+        display="flex"
+        style={{ alignItems: "center" }}
+      >{t`Manage custom visualizations`}</Title>
+
+      <SettingsSection>
+        <Box
+          style={{
+            borderRadius: "var(--mb-radius-md)",
+            backgroundColor: "var(--mb-color-bg-white)",
+          }}
+        >
+          <FormProvider initialValues={initialValues} onSubmit={handleSubmit}>
+            {({ dirty }) => (
+              <Form>
+                <Stack gap="lg">
+                  <Text fw={700} fz="xl">{t`Add a new chart`}</Text>
+                  <FormTextInput
+                    name="repo_url"
+                    label={t`Repository URL`}
+                    description={t`The location of the git repository where your visualization bundle is.`}
+                    placeholder="https://github.com/user/custom-viz-plugin"
+                    disabled={isEdit}
+                    autoFocus={!isEdit}
+                  />
+                  <FormTextInput
+                    name="access_token"
+                    label={t`Repository access token (optional)`}
+                    description={t`Personal access token for private repositories.`}
+                    type="password"
+                  />
+                  <FormTextInput
+                    name="pinned_version"
+                    label={t`Pinned version (optional)`}
+                    description={t`Branch, tag, or commit SHA to pin to.`}
+                    placeholder="main"
+                  />
+                  <FormErrorMessage />
+                  <Group gap="sm" justify="flex-end">
+                    <Button variant="default" onClick={handleCancel}>
+                      {t`Cancel`}
+                    </Button>
+                    <FormSubmitButton
+                      label={t`Save`}
+                      disabled={!dirty}
+                      variant="filled"
+                    />
+                  </Group>
+                </Stack>
+              </Form>
+            )}
+          </FormProvider>
+        </Box>
+      </SettingsSection>
+    </SettingsPageWrapper>
   );
 }
 
@@ -319,150 +412,77 @@ function DevUrlItem({ plugin }: { plugin: CustomVizPlugin }) {
   }, [plugin.id, setDevUrl]);
 
   return (
-    <Flex gap="sm" align="flex-end">
-      <Box style={{ flex: 1 }}>
-        <TextInput
-          label={plugin.display_name}
-          placeholder="http://localhost:5174"
-          value={url}
-          onChange={(e) => {
-            setUrl(e.currentTarget.value);
-            setSaved(false);
-          }}
-        />
-      </Box>
-      <Button
-        variant="filled"
-        size="sm"
-        onClick={handleSave}
-        loading={isLoading}
-      >
-        {saved ? t`Saved` : t`Save`}
-      </Button>
-      {plugin.dev_bundle_url && (
-        <Button variant="subtle" size="sm" onClick={handleClear}>
-          {t`Clear`}
-        </Button>
-      )}
-    </Flex>
-  );
-}
-
-function DevelopmentSection({ plugins }: { plugins: CustomVizPlugin[] }) {
-  const [opened, { toggle }] = useDisclosure(false);
-
-  return (
-    <Box
-      mt="xl"
-      p="md"
-      style={{
-        border: "1px solid var(--mb-color-border)",
-        borderRadius: "var(--mb-radius-md)",
-      }}
-    >
-      <Group
-        gap="xs"
-        onClick={toggle}
-        style={{ cursor: "pointer", userSelect: "none" }}
-      >
-        <Icon
-          name="chevronright"
-          size={12}
-          style={{
-            transform: opened ? "rotate(90deg)" : undefined,
-            transition: "transform 150ms ease",
-          }}
-        />
-        <Text fw={700}>{t`Development`}</Text>
-      </Group>
-      <Collapse in={opened}>
-        <Stack gap="md" mt="md">
-          <Text size="sm" c="text-tertiary">
-            {t`Set dev bundle URLs to load plugin code from a local dev server instead of the stored bundle. Changes take effect on the next page reload.`}
-          </Text>
-          {plugins.map((plugin) => (
-            <DevUrlItem key={plugin.id} plugin={plugin} />
-          ))}
-        </Stack>
-      </Collapse>
+    <Box>
+      <Flex gap="sm" align="flex-end">
+        <Box style={{ flex: 1 }}>
+          <TextInput
+            label={plugin.display_name}
+            placeholder="http://localhost:5174"
+            value={url}
+            onChange={(e) => {
+              setUrl(e.currentTarget.value);
+              setSaved(false);
+            }}
+          />
+        </Box>
+        {url && url !== (plugin.dev_bundle_url ?? "") && (
+          <Button
+            variant="filled"
+            size="sm"
+            onClick={handleSave}
+            loading={isLoading}
+          >
+            {saved ? t`Saved` : t`Save`}
+          </Button>
+        )}
+        {plugin.dev_bundle_url && (
+          <ActionIcon variant="subtle" size="lg" onClick={handleClear}>
+            <Icon name="trash" />
+          </ActionIcon>
+        )}
+      </Flex>
     </Box>
   );
 }
 
-export function CustomVizPluginsSettingsPage() {
+export function CustomVizDevelopmentPage() {
   const { data: plugins, isLoading } = useListAllCustomVizPluginsQuery();
-  const [deletePlugin] = useDeleteCustomVizPluginMutation();
-  const [showAddForm, setShowAddForm] = useState(false);
-  const [editingPlugin, setEditingPlugin] = useState<CustomVizPlugin | null>(
-    null,
-  );
-
-  const handleDelete = useCallback(
-    async (id: number) => {
-      await deletePlugin(id).unwrap();
-    },
-    [deletePlugin],
-  );
-
-  const handleEdit = useCallback((plugin: CustomVizPlugin) => {
-    setShowAddForm(false);
-    setEditingPlugin(plugin);
-  }, []);
-
-  const handleCloseForm = useCallback(() => {
-    setShowAddForm(false);
-    setEditingPlugin(null);
-  }, []);
 
   return (
     <SettingsPageWrapper
-      title={t`Custom visualization plugins`}
-      description={t`Register Git repositories containing custom visualization bundles. Plugins provide additional chart types for your questions and dashboards.`}
+      description={t`Set dev bundle URLs to load plugin code from a local dev server instead of the stored bundle. Changes take effect on the next page reload.`}
     >
+      <Title
+        order={1}
+        h="2.75rem"
+        display="flex"
+        style={{ alignItems: "center" }}
+      >{t`Development`}</Title>
+
       <SettingsSection>
-        <Stack gap="md">
-          {!showAddForm && !editingPlugin && (
-            <Box>
-              <Button
-                variant="filled"
-                leftSection={<Icon name="add" />}
-                onClick={() => setShowAddForm(true)}
-              >
-                {t`Add plugin`}
-              </Button>
-            </Box>
-          )}
+        {isLoading && (
+          <Flex justify="center" p="xl">
+            <Loader />
+          </Flex>
+        )}
 
-          {showAddForm && <PluginForm onClose={handleCloseForm} />}
-
-          {editingPlugin && (
-            <PluginForm plugin={editingPlugin} onClose={handleCloseForm} />
-          )}
-
-          {isLoading && (
-            <Flex justify="center" p="xl">
-              <Loader />
-            </Flex>
-          )}
-
-          {plugins && plugins.length === 0 && !isLoading && (
-            <Text c="text-tertiary">{t`No plugins registered yet.`}</Text>
-          )}
-
-          {plugins
-            ?.filter((plugin) => plugin.id !== editingPlugin?.id)
-            .map((plugin) => (
-              <PluginListItem
-                key={plugin.id}
-                plugin={plugin}
-                onDelete={handleDelete}
-                onEdit={handleEdit}
-              />
-            ))}
-        </Stack>
+        {plugins && plugins.length === 0 && !isLoading && (
+          <Text c="text-tertiary">{t`Register custom visualizations first to configure dev URLs.`}</Text>
+        )}
 
         {plugins && plugins.length > 0 && (
-          <DevelopmentSection plugins={plugins} />
+          <Box
+            className={S.devUrlList}
+            p="md"
+            style={{
+              borderRadius: "var(--mb-radius-md)",
+              backgroundColor: "var(--mb-color-bg-white)",
+            }}
+          >
+            {plugins.map((plugin) => (
+              <DevUrlItem key={plugin.id} plugin={plugin} />
+            ))}
+          </Box>
         )}
       </SettingsSection>
     </SettingsPageWrapper>

--- a/frontend/src/metabase/admin/settingsRoutes.tsx
+++ b/frontend/src/metabase/admin/settingsRoutes.tsx
@@ -14,7 +14,11 @@ import { SettingsNav } from "./settings/components/SettingsNav";
 import { AppearanceSettingsPage } from "./settings/components/SettingsPages/AppearanceSettingsPage";
 import { AuthenticationSettingsPage } from "./settings/components/SettingsPages/AuthenticationSettingsPage";
 import { CloudSettingsPage } from "./settings/components/SettingsPages/CloudSettingsPage";
-import { CustomVizPluginsSettingsPage } from "./settings/components/SettingsPages/CustomVizPluginsSettingsPage";
+import {
+  CustomVizDevelopmentPage,
+  CustomVizFormPage,
+  ManageCustomVisualizationsPage,
+} from "./settings/components/SettingsPages/CustomVizPluginsSettingsPage";
 import { EmailSettingsPage } from "./settings/components/SettingsPages/EmailSettingsPage";
 import { GeneralSettingsPage } from "./settings/components/SettingsPages/GeneralSettingsPage";
 import { LicenseSettingsPage } from "./settings/components/SettingsPages/LicenseSettingsPage";
@@ -73,8 +77,17 @@ export const getSettingsRoutes = () => (
     <Route path="maps" component={MapsSettingsPage} />
     <Route path="localization" component={LocalizationSettingsPage} />
     <Route
-      path="custom-viz-plugins"
-      component={CustomVizPluginsSettingsPage}
+      path="custom-visualizations"
+      component={ManageCustomVisualizationsPage}
+    />
+    <Route path="custom-visualizations/new" component={CustomVizFormPage} />
+    <Route
+      path="custom-visualizations/edit/:id"
+      component={CustomVizFormPage}
+    />
+    <Route
+      path="custom-visualizations/development"
+      component={CustomVizDevelopmentPage}
     />
     <Route path="uploads" component={UploadSettingsPage} />
     <Route


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-2090/update-custom-viz-manager-page

### Description

Redesigns the custom visualization admin settings page per new Figma designs:

- **URL update**: `/admin/settings/custom-viz-plugins` → `/admin/settings/custom-visualizations` with sub-routes (`/new`, `/edit/:id`, `/development`)
- **Sidebar**: "Custom viz plugins" flat item → toggleable "Custom visualizations" section with "Manage visualizations" and "Development" sub-items
- **Manage page**: Title + "Add visualization" button in header, white card empty state, simplified plugin list items with hover state and click-to-edit
- **Add/Edit form**: Separate page (no longer inline), with "Add a new chart" heading, right-aligned Cancel/Save buttons
- **Development page**: Standalone page instead of collapsible section, per-plugin dev URL inputs with Save/trash buttons
- **Context menu**: Re-fetch, Disable/Enable (with stop/play icons), Remove — enable/disable toggle moved from list item surface to menu
- **Copy updates**: All labels and messages updated per designs
