### PR TITLE
Cypress bail

### DIFF
--- a/.github/workflows/e2e-stress-test-flake-fix.yml
+++ b/.github/workflows/e2e-stress-test-flake-fix.yml
@@ -150,7 +150,7 @@ jobs:
         env:
           GREP: ${{ github.event.inputs.grep }}
           CYPRESS_BROWSER: ${{ steps.cypress-prep.outputs.chrome-path }}
-          BAIL: ${{ inputs.bail }}
+          CYPRESS_BAIL: ${{ inputs.bail }}
         run: |
           node e2e/runner/run_cypress_ci.js ${{ needs.determine-test-type.outputs.type }} \
           --spec '${{ github.event.inputs.spec }}' \

--- a/.github/workflows/e2e-stress-test-flake-fix.yml
+++ b/.github/workflows/e2e-stress-test-flake-fix.yml
@@ -31,6 +31,11 @@ on:
         type: boolean
         required: false
         default: true
+      bail:
+        description: "Stop running remaining tests after the first failure"
+        type: boolean
+        required: false
+        default: true
 
 jobs:
   determine-test-type:
@@ -67,6 +72,7 @@ jobs:
           echo '- `grep`: "${{ inputs.grep }}"' >> $GITHUB_STEP_SUMMARY
           echo '- `qa_db`: "${{ inputs.qa_db }}"' >> $GITHUB_STEP_SUMMARY
           echo '- `enable_network_throttling`: "${{ inputs.enable_network_throttling }}"' >> $GITHUB_STEP_SUMMARY
+          echo '- `bail`: "${{ inputs.bail }}"' >> $GITHUB_STEP_SUMMARY
           echo '' >> $GITHUB_STEP_SUMMARY
           echo 'triggered by: @${{ github.event.sender.login }}' >> $GITHUB_STEP_SUMMARY
 
@@ -144,6 +150,7 @@ jobs:
         env:
           GREP: ${{ github.event.inputs.grep }}
           CYPRESS_BROWSER: ${{ steps.cypress-prep.outputs.chrome-path }}
+          BAIL: ${{ inputs.bail }}
         run: |
           node e2e/runner/run_cypress_ci.js ${{ needs.determine-test-type.outputs.type }} \
           --spec '${{ github.event.inputs.spec }}' \

--- a/.github/workflows/e2e-stress-test-flake-fix.yml
+++ b/.github/workflows/e2e-stress-test-flake-fix.yml
@@ -31,11 +31,11 @@ on:
         type: boolean
         required: false
         default: true
-      bail:
+      fail_fast:
         description: "Stop running remaining tests after the first failure"
         type: boolean
         required: false
-        default: true
+        default: false
 
 jobs:
   determine-test-type:
@@ -72,7 +72,7 @@ jobs:
           echo '- `grep`: "${{ inputs.grep }}"' >> $GITHUB_STEP_SUMMARY
           echo '- `qa_db`: "${{ inputs.qa_db }}"' >> $GITHUB_STEP_SUMMARY
           echo '- `enable_network_throttling`: "${{ inputs.enable_network_throttling }}"' >> $GITHUB_STEP_SUMMARY
-          echo '- `bail`: "${{ inputs.bail }}"' >> $GITHUB_STEP_SUMMARY
+          echo '- `fail_fast`: "${{ inputs.fail_fast }}"' >> $GITHUB_STEP_SUMMARY
           echo '' >> $GITHUB_STEP_SUMMARY
           echo 'triggered by: @${{ github.event.sender.login }}' >> $GITHUB_STEP_SUMMARY
 
@@ -150,7 +150,7 @@ jobs:
         env:
           GREP: ${{ github.event.inputs.grep }}
           CYPRESS_BROWSER: ${{ steps.cypress-prep.outputs.chrome-path }}
-          CYPRESS_BAIL: ${{ inputs.bail }}
+          FAIL_FAST: ${{ inputs.fail_fast }}
         run: |
           node e2e/runner/run_cypress_ci.js ${{ needs.determine-test-type.outputs.type }} \
           --spec '${{ github.event.inputs.spec }}' \

--- a/e2e/support/cypress-stress-test.config.js
+++ b/e2e/support/cypress-stress-test.config.js
@@ -5,7 +5,23 @@ const {
   component: embeddingSdkComponentTestConfig,
 } = require("./cypress-embedding-sdk-component-test.config");
 
+const isFailFastEnabled = process.env.FAIL_FAST === "true";
+
 module.exports = defineConfig({
-  e2e: { ...defaultConfig, retries: 0 },
-  component: { ...embeddingSdkComponentTestConfig, retries: 0 },
+  e2e: {
+    ...defaultConfig,
+    expose: {
+      ...defaultConfig.expose,
+      FAIL_FAST: isFailFastEnabled,
+    },
+    retries: 0,
+  },
+  component: {
+    ...embeddingSdkComponentTestConfig,
+    expose: {
+      ...embeddingSdkComponentTestConfig.expose,
+      FAIL_FAST: isFailFastEnabled,
+    },
+    retries: 0,
+  },
 });

--- a/e2e/support/cypress-stress-test.config.js
+++ b/e2e/support/cypress-stress-test.config.js
@@ -5,7 +5,9 @@ const {
   component: embeddingSdkComponentTestConfig,
 } = require("./cypress-embedding-sdk-component-test.config");
 
+const bail = process.env.BAIL === "true" ? 1 : 0;
+
 module.exports = defineConfig({
-  e2e: { ...defaultConfig, retries: 0 },
-  component: { ...embeddingSdkComponentTestConfig, retries: 0 },
+  e2e: { ...defaultConfig, retries: 0, bail },
+  component: { ...embeddingSdkComponentTestConfig, retries: 0, bail },
 });

--- a/e2e/support/cypress-stress-test.config.js
+++ b/e2e/support/cypress-stress-test.config.js
@@ -5,9 +5,7 @@ const {
   component: embeddingSdkComponentTestConfig,
 } = require("./cypress-embedding-sdk-component-test.config");
 
-const bail = process.env.BAIL === "true" ? 1 : 0;
-
 module.exports = defineConfig({
-  e2e: { ...defaultConfig, retries: 0, bail },
-  component: { ...embeddingSdkComponentTestConfig, retries: 0, bail },
+  e2e: { ...defaultConfig, retries: 0 },
+  component: { ...embeddingSdkComponentTestConfig, retries: 0 },
 });

--- a/e2e/support/cypress.js
+++ b/e2e/support/cypress.js
@@ -10,6 +10,7 @@ import "./commands";
 
 const isCI = Cypress.expose("CI");
 const isNetworkThrottlingEnabled = Cypress.expose("ENABLE_NETWORK_THROTTLING");
+const isBailEnabled = Cypress.env("BAIL");
 
 // remove default html output on test failure
 configure({
@@ -156,6 +157,12 @@ if (isCI) {
   // Ensure that after plugin installation is after the afterEach handling the integration.
   require("cypress-terminal-report/src/installLogsCollector")(options);
 }
+
+afterEach(function () {
+  if (isBailEnabled && this.currentTest.state === "failed") {
+    Cypress.runner.stop();
+  }
+});
 
 beforeEach(function () {
   const isCurrentTesOss =

--- a/e2e/support/cypress.js
+++ b/e2e/support/cypress.js
@@ -10,7 +10,7 @@ import "./commands";
 
 const isCI = Cypress.expose("CI");
 const isNetworkThrottlingEnabled = Cypress.expose("ENABLE_NETWORK_THROTTLING");
-const isBailEnabled = Cypress.expose("BAIL");
+const isFailFastEnabled = Cypress.expose("FAIL_FAST");
 
 // remove default html output on test failure
 configure({
@@ -159,7 +159,7 @@ if (isCI) {
 }
 
 afterEach(function () {
-  if (isBailEnabled && this.currentTest.state === "failed") {
+  if (isFailFastEnabled && this.currentTest.state === "failed") {
     Cypress.runner.stop();
   }
 });

--- a/e2e/support/cypress.js
+++ b/e2e/support/cypress.js
@@ -10,7 +10,7 @@ import "./commands";
 
 const isCI = Cypress.expose("CI");
 const isNetworkThrottlingEnabled = Cypress.expose("ENABLE_NETWORK_THROTTLING");
-const isBailEnabled = Cypress.env("BAIL");
+const isBailEnabled = Cypress.expose("BAIL");
 
 // remove default html output on test failure
 configure({


### PR DESCRIPTION
### Description
I've spent so much time to wait until e2 stress test run is completed to look at the recording a workflow creates. If a try fails we still need to wait until the run is finished. It's a waste of time and annoys a bit. So I've decided to add a flag to this pipeline that will force the run to stop on the first failure.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Run https://github.com/metabase/metabase/actions/workflows/e2e-stress-test-flake-fix.yml on some known flakey e2e test with "fast_fail" toggle enabled 
<img width="340" height="669" alt="image" src="https://github.com/user-attachments/assets/70e6f1a5-8d1f-4a71-aa03-2dfa32e4ba29" />

2. See that the run stops right after a burn is failed.

### Demo
https://github.com/metabase/metabase/actions/runs/23559268903/job/68594474002
<img width="1167" height="818" alt="image" src="https://github.com/user-attachments/assets/00dfc25f-6fb7-4b9d-9afa-502f4b9d0339" />

