### PR TITLE
Fix silent data loss when importing unparseable YAML files

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/remote_sync/source.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/source.clj
@@ -43,7 +43,7 @@
   [snapshot {:keys [path-filters root-dependencies]}]
   (cond->> (ingestable/->IngestableSnapshot (cond-> snapshot
                                               (seq path-filters) (->WrappingSnapshot path-filters))
-                                            (atom nil))
+                                            (atom nil) (atom []))
     (seq root-dependencies) (ingestable/wrap-root-dep-ingestable root-dependencies)))
 
 (defn- remote-sync-path

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/source/ingestable.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/source/ingestable.clj
@@ -28,14 +28,14 @@
                               :let [content (try
                                               (source.p/read-file snapshot path)
                                               (catch Exception e
-                                                (log/warnf (u/strip-error e "Error reading file during ingestion"))
+                                                (log/warn (u/strip-error e "Error reading file during ingestion"))
                                                 (swap! errors conj e)
                                                 nil))
                                     loaded (try
                                              (when content
                                                (serdes/path (ingest-content content)))
                                              (catch Exception e
-                                               (log/warnf (u/strip-error e "Error parsing file during ingestion"))
+                                               (log/warn (u/strip-error e "Error parsing file during ingestion"))
                                                (swap! errors conj e)
                                                nil))]
                               :when loaded]

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/source/ingestable.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/source/ingestable.clj
@@ -17,21 +17,30 @@
   (serialization/read-timestamps (yaml/parse-string file-content {:key-fn serialization/parse-key})))
 
 (defn- ingest-all
+  "Returns {:entities {stripped-hierarchy [hierarchy content]}, :errors [Exception...]}.
+  Dotfiles are silently skipped (editor temp files, see #41567).
+  Non-dotfile YAML parse/read failures are collected in :errors."
   [snapshot]
-  (into {} (for [path (source.p/list-files snapshot)
-                 :when (and (not (str/starts-with? path "."))
-                            (str/ends-with? path ".yaml"))
-                 :let [content (try
-                                 (source.p/read-file snapshot path)
-                                 (catch Exception e
-                                   (log/error e "Error reading file" path)))
-                       loaded (try
-                                (when content
-                                  (serdes/path (ingest-content content)))
-                                (catch Exception e
-                                  (log/error e "Error reading file" path)))]
-                 :when loaded]
-             [(serialization/strip-labels loaded) [loaded content]])))
+  (let [errors (atom [])]
+    {:entities (into {} (for [path (source.p/list-files snapshot)
+                              :when (and (not (str/starts-with? path "."))
+                                         (str/ends-with? path ".yaml"))
+                              :let [content (try
+                                              (source.p/read-file snapshot path)
+                                              (catch Exception e
+                                                (log/warnf (u/strip-error e "Error reading file during ingestion"))
+                                                (swap! errors conj e)
+                                                nil))
+                                    loaded (try
+                                             (when content
+                                               (serdes/path (ingest-content content)))
+                                             (catch Exception e
+                                               (log/warnf (u/strip-error e "Error parsing file during ingestion"))
+                                               (swap! errors conj e)
+                                               nil))]
+                              :when loaded]
+                          [(serialization/strip-labels loaded) [loaded content]]))
+     :errors @errors}))
 
 ;; Wraps another Ingestable calling a callback when a file is ingested
 (defrecord CallbackIngestable [ingestable callback]
@@ -41,7 +50,10 @@
 
   (ingest-one [_ serdes-path]
     (u/prog1 (serialization/ingest-one ingestable serdes-path)
-      (callback <> serdes-path))))
+      (callback <> serdes-path)))
+
+  (ingestion-errors [_]
+    (serialization/ingestion-errors ingestable)))
 
 (defn wrap-progress-ingestable
   "Wraps an Ingestable to track and update progress during ingestion.
@@ -83,7 +95,10 @@
                root-dependencies))
             (serialization/ingest-list ingestable)))
   (ingest-one [_ serdes-path]
-    (serialization/ingest-one ingestable serdes-path)))
+    (serialization/ingest-one ingestable serdes-path))
+
+  (ingestion-errors [_]
+    (serialization/ingestion-errors ingestable)))
 
 (defn wrap-root-dep-ingestable
   "Wraps an Ingestable to filter items by root dependencies.
@@ -97,16 +112,25 @@
   (->RootDependencyIngestable ingestable root-dependencies (atom {})))
 
 ;; Wraps a snapshot object providing the ingestable interface for serdes
-(defrecord IngestableSnapshot [^SourceSnapshot snapshot cache]
+(defrecord IngestableSnapshot [^SourceSnapshot snapshot cache errors-atom]
   serialization/Ingestable
   (ingest-list [_]
-    (keys (or @cache (reset! cache (ingest-all snapshot)))))
+    (when-not @cache
+      (let [result (ingest-all snapshot)]
+        (reset! cache (:entities result))
+        (reset! errors-atom (:errors result))))
+    (keys @cache))
 
   (ingest-one [_ serdes-path]
     (when-not @cache
-      (reset! cache (ingest-all snapshot)))
+      (let [result (ingest-all snapshot)]
+        (reset! cache (:entities result))
+        (reset! errors-atom (:errors result))))
     (when-let [target (get @cache (serialization/strip-labels serdes-path))]
       (try
         (ingest-content (second target))
         (catch Exception e
-          (throw (ex-info "Unable to ingest file" {:abs-path serdes-path} e)))))))
+          (throw (ex-info "Unable to ingest file" {:abs-path serdes-path} e))))))
+
+  (ingestion-errors [_]
+    (or @errors-atom [])))

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/source/ingestable.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/source/ingestable.clj
@@ -29,14 +29,14 @@
                                               (source.p/read-file snapshot path)
                                               (catch Exception e
                                                 (log/warn (u/strip-error e "Error reading file during ingestion"))
-                                                (swap! errors conj e)
+                                                (swap! errors conj (ex-info (format "Failed to read file: %s" path) {:file path} e))
                                                 nil))
                                     loaded (try
                                              (when content
                                                (serdes/path (ingest-content content)))
                                              (catch Exception e
                                                (log/warn (u/strip-error e "Error parsing file during ingestion"))
-                                               (swap! errors conj e)
+                                               (swap! errors conj (ex-info (format "Failed to parse file: %s" path) {:file path} e))
                                                nil))]
                               :when loaded]
                           [(serialization/strip-labels loaded) [loaded content]]))

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/source/ingestable.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/source/ingestable.clj
@@ -52,8 +52,8 @@
     (u/prog1 (serialization/ingest-one ingestable serdes-path)
       (callback <> serdes-path)))
 
-  (ingestion-errors [_]
-    (serialization/ingestion-errors ingestable)))
+  (ingest-errors [_]
+    (serialization/ingest-errors ingestable)))
 
 (defn wrap-progress-ingestable
   "Wraps an Ingestable to track and update progress during ingestion.
@@ -97,8 +97,8 @@
   (ingest-one [_ serdes-path]
     (serialization/ingest-one ingestable serdes-path))
 
-  (ingestion-errors [_]
-    (serialization/ingestion-errors ingestable)))
+  (ingest-errors [_]
+    (serialization/ingest-errors ingestable)))
 
 (defn wrap-root-dep-ingestable
   "Wraps an Ingestable to filter items by root dependencies.
@@ -111,26 +111,26 @@
   [root-dependencies ingestable]
   (->RootDependencyIngestable ingestable root-dependencies (atom {})))
 
+(defn- populate-cache! [cache errors-atom ingest-fn]
+  (when-not @cache
+    (let [result (ingest-fn)]
+      (reset! cache (:entities result))
+      (reset! errors-atom (:errors result)))))
+
 ;; Wraps a snapshot object providing the ingestable interface for serdes
 (defrecord IngestableSnapshot [^SourceSnapshot snapshot cache errors-atom]
   serialization/Ingestable
   (ingest-list [_]
-    (when-not @cache
-      (let [result (ingest-all snapshot)]
-        (reset! cache (:entities result))
-        (reset! errors-atom (:errors result))))
+    (populate-cache! cache errors-atom #(ingest-all snapshot))
     (keys @cache))
 
   (ingest-one [_ serdes-path]
-    (when-not @cache
-      (let [result (ingest-all snapshot)]
-        (reset! cache (:entities result))
-        (reset! errors-atom (:errors result))))
+    (populate-cache! cache errors-atom #(ingest-all snapshot))
     (when-let [target (get @cache (serialization/strip-labels serdes-path))]
       (try
         (ingest-content (second target))
         (catch Exception e
           (throw (ex-info "Unable to ingest file" {:abs-path serdes-path} e))))))
 
-  (ingestion-errors [_]
+  (ingest-errors [_]
     (or @errors-atom [])))

--- a/enterprise/backend/src/metabase_enterprise/serialization/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/core.clj
@@ -26,7 +26,7 @@
   ingest-yaml
   ingest-list
   ingest-one
-  ingestion-errors
+  ingest-errors
   read-timestamps
   parse-key]
  [metabase-enterprise.serialization.v2.load

--- a/enterprise/backend/src/metabase_enterprise/serialization/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/core.clj
@@ -26,6 +26,7 @@
   ingest-yaml
   ingest-list
   ingest-one
+  ingestion-errors
   read-timestamps
   parse-key]
  [metabase-enterprise.serialization.v2.load

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/ingest.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/ingest.clj
@@ -32,7 +32,7 @@
     "Given one of the `:serdes/meta` abstract paths returned by [[ingest-list]], read in and return the entire
     corresponding entity.")
 
-  (ingestion-errors
+  (ingest-errors
     [this]
     "Return a vector of exceptions that occurred during ingestion (e.g. YAML parse failures).
     Returns [] if no errors occurred."))
@@ -104,23 +104,23 @@
                           [(strip-labels hierarchy) [hierarchy file]]))
      :errors  @errors}))
 
+(defn- populate-cache! [cache errors-atom ingest-fn]
+  (when-not @cache
+    (let [result (ingest-fn)]
+      (reset! cache (:entities result))
+      (reset! errors-atom (:errors result)))))
+
 (deftype YamlIngestion [^File root-dir settings cache errors-atom]
   Ingestable
   (ingest-list [_]
-    (when-not @cache
-      (let [result (ingest-all root-dir)]
-        (reset! cache (:entities result))
-        (reset! errors-atom (:errors result))))
+    (populate-cache! cache errors-atom #(ingest-all root-dir))
     (-> @cache
         keys
         (concat (for [k (keys settings)]
                   [{:model "Setting" :id (name k)}]))))
 
   (ingest-one [_ serdes-meta]
-    (when-not @cache
-      (let [result (ingest-all root-dir)]
-        (reset! cache (:entities result))
-        (reset! errors-atom (:errors result))))
+    (populate-cache! cache errors-atom #(ingest-all root-dir))
     (let [{:keys [id]} (first serdes-meta)
           kw-id        (keyword id)]
       (if (= ["Setting"] (mapv :model serdes-meta))
@@ -133,7 +133,7 @@
               (throw (ex-info "Unable to ingest file" {:file     (.getName ^File (second target))
                                                        :abs-path serdes-meta} e))))))))
 
-  (ingestion-errors [_]
+  (ingest-errors [_]
     (or @errors-atom [])))
 
 (defn ingest-yaml

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/ingest.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/ingest.clj
@@ -94,11 +94,12 @@
                                          (str/ends-with? (.getName file) ".yaml")
                                          (let [rel (.relativize (.toPath root-dir) (.toPath file))]
                                            (-> rel (.subpath 0 1) (.toString) legal-top-level-paths)))
-                              :let [hierarchy (try
+                              :let [file-name (.getName file)
+                                    hierarchy (try
                                                 (serdes/path (ingest-file file))
                                                 (catch Exception e
                                                   (log/warn (u/strip-error e "Error reading file during ingestion"))
-                                                  (swap! errors conj e)
+                                                  (swap! errors conj (ex-info (format "Failed to parse file: %s" file-name) {:file file-name} e))
                                                   nil))]
                               :when hierarchy]
                           [(strip-labels hierarchy) [hierarchy file]]))

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/ingest.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/ingest.clj
@@ -97,7 +97,7 @@
                               :let [hierarchy (try
                                                 (serdes/path (ingest-file file))
                                                 (catch Exception e
-                                                  (log/warnf (u/strip-error e "Error reading file during ingestion"))
+                                                  (log/warn (u/strip-error e "Error reading file during ingestion"))
                                                   (swap! errors conj e)
                                                   nil))]
                               :when hierarchy]

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/ingest.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/ingest.clj
@@ -7,6 +7,7 @@
    [clojure.java.io :as io]
    [clojure.string :as str]
    [metabase.models.serialization :as serdes]
+   [metabase.util :as u]
    [metabase.util.date-2 :as u.date]
    [metabase.util.log :as log]
    [metabase.util.yaml :as yaml]
@@ -29,7 +30,12 @@
   (ingest-one
     [this path]
     "Given one of the `:serdes/meta` abstract paths returned by [[ingest-list]], read in and return the entire
-    corresponding entity."))
+    corresponding entity.")
+
+  (ingestion-errors
+    [this]
+    "Return a vector of exceptions that occurred during ingestion (e.g. YAML parse failures).
+    Returns [] if no errors occurred."))
 
 (defn read-timestamps
   "Parses timestamp fields in an entity.
@@ -76,34 +82,45 @@
 (def legal-top-level-paths "Known top-level paths for directory with serialization output"
   #{"actions" "collections" "databases" "glossary" "python-libraries" "snippets" "transforms"})
 
-(defn- ingest-all [^File root-dir]
-  ;; This returns a map {unlabeled-hierarchy [original-hierarchy File]}.
-  (into {} (for [^File file (file-seq root-dir)
-                 :when (and (.isFile file)
-                            (not (str/starts-with? (.getName file) "."))
-                            (str/ends-with? (.getName file) ".yaml")
-                            (let [rel (.relativize (.toPath root-dir) (.toPath file))]
-                              (-> rel (.subpath 0 1) (.toString) legal-top-level-paths)))
-                 ;; TODO: only load YAML once.
-                 :let  [hierarchy (try
-                                    (serdes/path (ingest-file file))
-                                    (catch Exception e
-                                      (log/error e "Error reading file" (.getName file))))]
-                 :when hierarchy]
-             [(strip-labels hierarchy) [hierarchy file]])))
+(defn- ingest-all
+  "Returns {:entities {unlabeled-hierarchy [hierarchy File]}, :errors [Exception...]}.
+  Dotfiles are silently skipped (editor temp files, see #41567).
+  Non-dotfile YAML parse failures are collected in :errors."
+  [^File root-dir]
+  (let [errors (atom [])]
+    {:entities (into {} (for [^File file (file-seq root-dir)
+                              :when (and (.isFile file)
+                                         (not (str/starts-with? (.getName file) "."))
+                                         (str/ends-with? (.getName file) ".yaml")
+                                         (let [rel (.relativize (.toPath root-dir) (.toPath file))]
+                                           (-> rel (.subpath 0 1) (.toString) legal-top-level-paths)))
+                              :let [hierarchy (try
+                                                (serdes/path (ingest-file file))
+                                                (catch Exception e
+                                                  (log/warnf (u/strip-error e "Error reading file during ingestion"))
+                                                  (swap! errors conj e)
+                                                  nil))]
+                              :when hierarchy]
+                          [(strip-labels hierarchy) [hierarchy file]]))
+     :errors  @errors}))
 
-(deftype YamlIngestion [^File root-dir settings cache]
+(deftype YamlIngestion [^File root-dir settings cache errors-atom]
   Ingestable
   (ingest-list [_]
-    (-> (or @cache (reset! cache (ingest-all root-dir)))
+    (when-not @cache
+      (let [result (ingest-all root-dir)]
+        (reset! cache (:entities result))
+        (reset! errors-atom (:errors result))))
+    (-> @cache
         keys
-        ;; add settings ingestion paths
         (concat (for [k (keys settings)]
                   [{:model "Setting" :id (name k)}]))))
 
   (ingest-one [_ serdes-meta]
     (when-not @cache
-      (reset! cache (ingest-all root-dir)))
+      (let [result (ingest-all root-dir)]
+        (reset! cache (:entities result))
+        (reset! errors-atom (:errors result))))
     (let [{:keys [id]} (first serdes-meta)
           kw-id        (keyword id)]
       (if (= ["Setting"] (mapv :model serdes-meta))
@@ -114,10 +131,13 @@
             (ingest-file (second target))
             (catch Exception e
               (throw (ex-info "Unable to ingest file" {:file     (.getName ^File (second target))
-                                                       :abs-path serdes-meta} e)))))))))
+                                                       :abs-path serdes-meta} e))))))))
+
+  (ingestion-errors [_]
+    (or @errors-atom [])))
 
 (defn ingest-yaml
   "Creates a new Ingestable on a directory of YAML files, as created by
   [[metabase-enterprise.serialization.v2.storage.yaml]]."
   [root-dir]
-  (->YamlIngestion (io/file root-dir) (yaml/from-file (io/file root-dir "settings.yaml")) (atom nil)))
+  (->YamlIngestion (io/file root-dir) (yaml/from-file (io/file root-dir "settings.yaml")) (atom nil) (atom [])))

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
@@ -216,8 +216,14 @@
         ;; guide the import, and make sure all containers are imported before contents, etc.
         (when backfill?
           (serdes.backfill/backfill-ids!))
-        (let [contents (serdes.ingest/ingest-list ingestion)
-              ctx (new-context ingestion)]
+        (let [contents      (serdes.ingest/ingest-list ingestion)
+              ingest-errors (serdes.ingest/ingestion-errors ingestion)
+              ctx           (cond-> (new-context ingestion)
+                              (seq ingest-errors) (update :errors into ingest-errors))]
+          (when (and (seq ingest-errors) (not continue-on-error))
+            (throw (ex-info (format "Failed to read %d file(s) during ingestion" (count ingest-errors))
+                            {:ingestion-errors ingest-errors}
+                            (first ingest-errors))))
           (log/infof "Starting deserialization, total %s documents" (count contents))
           (reduce (fn [ctx item]
                     (try

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
@@ -221,9 +221,13 @@
               ctx           (cond-> (new-context ingestion)
                               (seq ingest-errors) (update :errors into ingest-errors))]
           (when (and (seq ingest-errors) (not continue-on-error))
-            (throw (ex-info (format "Failed to read %d file(s) during ingestion" (count ingest-errors))
-                            {:ingest-errors ingest-errors}
-                            (first ingest-errors))))
+            (let [file-names (mapv #(or (:file (ex-data %)) (ex-message %)) ingest-errors)]
+              (throw (ex-info (format "Failed to read %d file(s) during ingestion: %s"
+                                      (count ingest-errors)
+                                      (str/join ", " file-names))
+                              {:ingest-errors ingest-errors
+                               :files         file-names}
+                              (first ingest-errors)))))
           (log/infof "Starting deserialization, total %s documents" (count contents))
           (reduce (fn [ctx item]
                     (try

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
@@ -217,12 +217,12 @@
         (when backfill?
           (serdes.backfill/backfill-ids!))
         (let [contents      (serdes.ingest/ingest-list ingestion)
-              ingest-errors (serdes.ingest/ingestion-errors ingestion)
+              ingest-errors (serdes.ingest/ingest-errors ingestion)
               ctx           (cond-> (new-context ingestion)
                               (seq ingest-errors) (update :errors into ingest-errors))]
           (when (and (seq ingest-errors) (not continue-on-error))
             (throw (ex-info (format "Failed to read %d file(s) during ingestion" (count ingest-errors))
-                            {:ingestion-errors ingest-errors}
+                            {:ingest-errors ingest-errors}
                             (first ingest-errors))))
           (log/infof "Starting deserialization, total %s documents" (count contents))
           (reduce (fn [ctx item]

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/impl_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/impl_test.clj
@@ -78,6 +78,21 @@
       (is (= :error (:status result)))
       (is (re-find #"Branch error:" (:message result))))))
 
+(deftest import!-unparseable-yaml-should-not-silently-succeed-test
+  (testing "import! should fail when a YAML file in the snapshot is unparseable, not silently skip it"
+    (let [task-id   (t2/insert-returning-pk! :model/RemoteSyncTask {:sync_task_type "import" :initiated_by (mt/user->id :rasta)})
+          ;; A valid collection + a card with unparseable YAML (malformed syntax)
+          bad-yaml  "name: Bad Card\nentity_id: bad-card-entity0001\ndataset_query: [invalid\n"
+          files     {"main" {"collections/coll01xxxxxxxxxxxxx_test/coll01xxxxxxxxxxxxx_test.yaml"
+                             (test-helpers/generate-collection-yaml "coll01xxxxxxxxxxxxx" "Test")
+                             "collections/coll01xxxxxxxxxxxxx_test/cards/bad-card-entity0001.yaml"
+                             bad-yaml}}
+          result    (impl/import! (source.p/snapshot (test-helpers/create-mock-source :initial-files files)) task-id)]
+      ;; Currently this returns :success because the unparseable card is silently dropped.
+      ;; It should return :error — silently losing data is worse than failing.
+      (is (= :error (:status result))
+          "Import should fail when a YAML file cannot be parsed, not silently skip it"))))
+
 (deftest import!-handles-generic-errors-test
   (testing "import! handles generic errors"
     (let [task-id (t2/insert-returning-pk! :model/RemoteSyncTask {:sync_task_type "import" :initiated_by (mt/user->id :rasta)})

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/impl_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/impl_test.clj
@@ -88,8 +88,6 @@
                              "collections/coll01xxxxxxxxxxxxx_test/cards/bad-card-entity0001.yaml"
                              bad-yaml}}
           result    (impl/import! (source.p/snapshot (test-helpers/create-mock-source :initial-files files)) task-id)]
-      ;; Currently this returns :success because the unparseable card is silently dropped.
-      ;; It should return :error — silently losing data is worse than failing.
       (is (= :error (:status result))
           "Import should fail when a YAML file cannot be parsed, not silently skip it"))))
 

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/source/ingestable_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/source/ingestable_test.clj
@@ -143,3 +143,47 @@
         (let [root-deps [{:model "Collection" :id "M-Q4pcV0qkiyJ0kiSWECl"}]
               wrapped (ingestable/wrap-root-dep-ingestable root-deps base-ingestable)]
           (is (map? @(:dep-cache wrapped)) "Should have dep-cache atom initialized as empty map"))))))
+
+(deftest ingest-errors-test
+  (testing "IngestableSnapshot collects parse errors and returns them via ingest-errors"
+    (let [bad-yaml  "name: Bad Card\ndataset_query: [invalid\n"
+          files     {"main" {"collections/coll01xxxxxxxxxxxxx_test/coll01xxxxxxxxxxxxx_test.yaml"
+                             (test-helpers/generate-collection-yaml "coll01xxxxxxxxxxxxx" "Test")
+                             "collections/coll01xxxxxxxxxxxxx_test/cards/bad-card.yaml"
+                             bad-yaml}}
+          snapshot  (source.p/snapshot (test-helpers/create-mock-source :initial-files files))
+          ingestable (ingestable/->IngestableSnapshot snapshot (atom nil) (atom []))]
+
+      (testing "ingest-list succeeds, skipping the bad file"
+        (let [paths (serialization/ingest-list ingestable)]
+          (is (seq paths) "Should return paths for valid files")))
+
+      (testing "ingest-errors returns the parse failure"
+        (let [errors (serialization/ingest-errors ingestable)]
+          (is (= 1 (count errors)))
+          (is (instance? Exception (first errors)))))))
+
+  (testing "ingest-errors returns [] when all files parse successfully"
+    (let [snapshot   (source.p/snapshot (test-helpers/create-mock-source))
+          ingestable (ingestable/->IngestableSnapshot snapshot (atom nil) (atom []))]
+      (serialization/ingest-list ingestable)
+      (is (= [] (serialization/ingest-errors ingestable)))))
+
+  (testing "wrapper ingestables delegate ingest-errors"
+    (let [bad-yaml  "name: Bad\ndataset_query: [invalid\n"
+          files     {"main" {"collections/coll01xxxxxxxxxxxxx_test/coll01xxxxxxxxxxxxx_test.yaml"
+                             (test-helpers/generate-collection-yaml "coll01xxxxxxxxxxxxx" "Test")
+                             "collections/coll01xxxxxxxxxxxxx_test/cards/bad.yaml"
+                             bad-yaml}}
+          snapshot  (source.p/snapshot (test-helpers/create-mock-source :initial-files files))
+          base      (ingestable/->IngestableSnapshot snapshot (atom nil) (atom []))
+          callback  (ingestable/->CallbackIngestable base (fn [_ _]))
+          root-dep  (ingestable/wrap-root-dep-ingestable [{:model "Collection" :id "coll01xxxxxxxxxxxxx"}] base)]
+      ;; Trigger cache population
+      (serialization/ingest-list base)
+
+      (testing "CallbackIngestable delegates"
+        (is (= 1 (count (serialization/ingest-errors callback)))))
+
+      (testing "RootDependencyIngestable delegates"
+        (is (= 1 (count (serialization/ingest-errors root-dep))))))))

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/source/ingestable_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/source/ingestable_test.clj
@@ -16,7 +16,7 @@
 (deftest ingestable-snapshot-test
   (testing "IngestableSnapshot wraps a snapshot and provides Ingestable interface"
     (let [mock-source (test-helpers/create-mock-source)
-          ingestable (ingestable/->IngestableSnapshot (source.p/snapshot mock-source) (atom nil))]
+          ingestable (ingestable/->IngestableSnapshot (source.p/snapshot mock-source) (atom nil) (atom []))]
 
       (testing "ingest-list returns list of serdes paths"
         (let [paths (serialization/ingest-list ingestable)]
@@ -32,7 +32,7 @@
           (is (contains? entity :serdes/meta) "Should have serdes/meta key")))
 
       (testing "cache is populated after first ingest-list call"
-        (let [ingestable (ingestable/->IngestableSnapshot (source.p/snapshot mock-source) (atom nil))]
+        (let [ingestable (ingestable/->IngestableSnapshot (source.p/snapshot mock-source) (atom nil) (atom []))]
           (is (nil? @(:cache ingestable)) "Cache should be empty initially")
           (serialization/ingest-list ingestable)
           (is (map? @(:cache ingestable)) "Cache should be populated after ingest-list")
@@ -41,7 +41,7 @@
 (deftest callback-ingestable-test
   (testing "CallbackIngestable wraps an ingestable and calls callback on ingest-one"
     (let [mock-source (test-helpers/create-mock-source)
-          base-ingestable (ingestable/->IngestableSnapshot (source.p/snapshot mock-source) (atom nil))
+          base-ingestable (ingestable/->IngestableSnapshot (source.p/snapshot mock-source) (atom nil) (atom []))
           calls (atom [])
           callback (fn [_ path] (swap! calls conj path))
           wrapped (ingestable/->CallbackIngestable base-ingestable callback)]
@@ -79,7 +79,7 @@
                                                                                :initiated_by (:id user)}))
             task-id (:id task)
             mock-source (test-helpers/create-mock-source)
-            base-ingestable (ingestable/->IngestableSnapshot (source.p/snapshot mock-source) (atom nil))
+            base-ingestable (ingestable/->IngestableSnapshot (source.p/snapshot mock-source) (atom nil) (atom []))
             normalize 100]
 
         (testing "creates a CallbackIngestable"
@@ -124,7 +124,7 @@
 (deftest root-dependency-ingestable-test
   (testing "RootDependencyIngestable filters items based on root dependencies"
     (let [mock-source (test-helpers/create-mock-source)
-          base-ingestable (ingestable/->IngestableSnapshot (source.p/snapshot mock-source) (atom nil))]
+          base-ingestable (ingestable/->IngestableSnapshot (source.p/snapshot mock-source) (atom nil) (atom []))]
 
       (testing "with no root dependencies, returns empty list"
         (let [wrapped (ingestable/wrap-root-dep-ingestable [] base-ingestable)

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/source/ingestable_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/source/ingestable_test.clj
@@ -169,6 +169,32 @@
       (serialization/ingest-list ingestable)
       (is (= [] (serialization/ingest-errors ingestable)))))
 
+  (testing "ingest-errors returns [] before cache is populated"
+    (let [bad-yaml  "name: Bad Card\ndataset_query: [invalid\n"
+          files     {"main" {"collections/coll01xxxxxxxxxxxxx_test/coll01xxxxxxxxxxxxx_test.yaml"
+                             (test-helpers/generate-collection-yaml "coll01xxxxxxxxxxxxx" "Test")
+                             "collections/coll01xxxxxxxxxxxxx_test/cards/bad-card.yaml"
+                             bad-yaml}}
+          snapshot  (source.p/snapshot (test-helpers/create-mock-source :initial-files files))
+          ingestable (ingestable/->IngestableSnapshot snapshot (atom nil) (atom []))]
+      (is (= [] (serialization/ingest-errors ingestable))
+          "Before ingest-list is called, ingest-errors should return [] not the real errors")))
+
+  (testing "multiple bad files produce multiple errors"
+    (let [bad-yaml-1 "name: Bad1\ndataset_query: [invalid\n"
+          bad-yaml-2 "name: Bad2\ndataset_query: {broken\n"
+          files      {"main" {"collections/coll01xxxxxxxxxxxxx_test/coll01xxxxxxxxxxxxx_test.yaml"
+                              (test-helpers/generate-collection-yaml "coll01xxxxxxxxxxxxx" "Test")
+                              "collections/coll01xxxxxxxxxxxxx_test/cards/bad1.yaml"
+                              bad-yaml-1
+                              "collections/coll01xxxxxxxxxxxxx_test/cards/bad2.yaml"
+                              bad-yaml-2}}
+          snapshot   (source.p/snapshot (test-helpers/create-mock-source :initial-files files))
+          ingestable (ingestable/->IngestableSnapshot snapshot (atom nil) (atom []))]
+      (serialization/ingest-list ingestable)
+      (is (= 2 (count (serialization/ingest-errors ingestable)))
+          "Each unparseable file should produce a separate error")))
+
   (testing "wrapper ingestables delegate ingest-errors"
     (let [bad-yaml  "name: Bad\ndataset_query: [invalid\n"
           files     {"main" {"collections/coll01xxxxxxxxxxxxx_test/coll01xxxxxxxxxxxxx_test.yaml"

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
@@ -910,7 +910,7 @@
           (spit (io/file dump-dir "collections" "corrupt.yaml") "\0")
 
           (testing "continue-on-error false (default) — throws on ingestion errors"
-            (is (thrown-with-msg? Exception #"Failed to read 1 file\(s\) during ingestion"
+            (is (thrown-with-msg? Exception #"Failed to read 1 file\(s\) during ingestion: corrupt\.yaml"
                                   (serdes/with-cache
                                     (serdes.load/load-metabase! (ingest/ingest-yaml dump-dir))))))
 

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
@@ -899,6 +899,30 @@
             (let [{:keys [errors]} (#'ingest/ingest-all (io/file dump-dir))]
               (is (= 1 (count errors))))))))))
 
+(deftest ingestion-errors-fail-import-test
+  (testing "Unparseable YAML files cause load-metabase! to fail by default"
+    (ts/with-random-dump-dir [dump-dir "serdesv2-"]
+      (mt/with-empty-h2-app-db!
+        (let [coll (ts/create! :model/Collection :name "coll")
+              _    (ts/create! :model/Card :name "card" :collection_id (:id coll))]
+          (storage/store! (extract/extract {:no-settings   true
+                                            :no-data-model true}) dump-dir)
+          (spit (io/file dump-dir "collections" "corrupt.yaml") "\0")
+
+          (testing "continue-on-error false (default) — throws on ingestion errors"
+            (is (thrown-with-msg? Exception #"Failed to read 1 file\(s\) during ingestion"
+                                  (serdes/with-cache
+                                    (serdes.load/load-metabase! (ingest/ingest-yaml dump-dir))))))
+
+          (testing "continue-on-error true — collects ingestion errors without throwing"
+            (let [result (serdes/with-cache
+                           (serdes.load/load-metabase! (ingest/ingest-yaml dump-dir)
+                                                       {:continue-on-error true}))]
+              (is (seq (:errors result))
+                  "Should have collected ingestion errors")
+              (is (seq (:seen result))
+                  "Should have still loaded the valid entities"))))))))
+
 (deftest channel-test
   (mt/test-helpers-set-global-values!
     (ts/with-random-dump-dir [dump-dir "serdesv2-"]

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
@@ -885,19 +885,19 @@
                                             :no-data-model true}) dump-dir)
 
           (spit (io/file dump-dir "collections" ".hidden.yaml") "serdes/meta: [{do-not: read}]")
-          (spit (io/file dump-dir "collections" "unreadable.yaml") "\0")
 
-          (testing "No exceptions when loading despite unreadable files"
-            (mt/with-log-messages-for-level [logs [metabase-enterprise :error]]
-              (let [files (->> (#'ingest/ingest-all (io/file dump-dir))
-                               (map (comp second second))
-                               (map #(.getName ^File %))
-                               set)]
-                (testing "Hidden YAML wasn't read even though it's not throwing errors"
-                  (is (not (contains? files ".hidden.yaml")))))
-              (testing ".yaml files not containing valid yaml are just logged and do not break ingestion process"
-                (is (=? [{:level :error, :e Throwable, :message "Error reading file unreadable.yaml"}]
-                        (logs)))))))))))
+          (testing "Hidden YAML files are still silently skipped"
+            (let [{:keys [entities]} (#'ingest/ingest-all (io/file dump-dir))
+                  files (->> entities
+                             (map (comp second second))
+                             (map #(.getName ^File %))
+                             set)]
+              (is (not (contains? files ".hidden.yaml")))))
+
+          (testing "Unparseable non-hidden YAML files are collected as ingestion errors"
+            (spit (io/file dump-dir "collections" "unreadable.yaml") "\0")
+            (let [{:keys [errors]} (#'ingest/ingest-all (io/file dump-dir))]
+              (is (= 1 (count errors))))))))))
 
 (deftest channel-test
   (mt/test-helpers-set-global-values!

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
@@ -918,8 +918,8 @@
             (let [result (serdes/with-cache
                            (serdes.load/load-metabase! (ingest/ingest-yaml dump-dir)
                                                        {:continue-on-error true}))]
-              (is (seq (:errors result))
-                  "Should have collected ingestion errors")
+              (is (= 1 (count (:errors result)))
+                  "Should have collected exactly 1 ingestion error")
               (is (seq (:seen result))
                   "Should have still loaded the valid entities"))))))))
 

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -49,7 +49,7 @@
         (keys mapped))
       (ingest-one [_ path]
         (get mapped (no-labels path)))
-      (ingestion-errors [_]
+      (ingest-errors [_]
         []))))
 
 ;;; WARNING for test authors: [[extract/extract]] returns a lazy reducible value. To make sure you don't

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -48,7 +48,9 @@
       (ingest-list [_]
         (keys mapped))
       (ingest-one [_ path]
-        (get mapped (no-labels path))))))
+        (get mapped (no-labels path)))
+      (ingestion-errors [_]
+        []))))
 
 ;;; WARNING for test authors: [[extract/extract]] returns a lazy reducible value. To make sure you don't
 ;;; confound your tests with data from your dev appdb, remember to eagerly


### PR DESCRIPTION
When a YAML file fails to parse during serdes ingestion (e.g. corrupted file, invalid syntax), the error is silently caught and logged — the file is simply skipped. This means remote sync imports can silently lose entities with no indication that anything went wrong. The import reports success even though data was dropped.

This PR extends the `Ingestable` protocol with an `ingest-errors` method that collects parse failures during cache population instead of discarding them. `load-metabase!` checks these errors after ingestion:

- **Default behavior** (`continue-on-error` false, used by remote sync): throws immediately, so the import fails visibly rather than silently losing data
- **Manual imports** (`continue-on-error` true): errors are collected alongside load-phase errors so callers get a unified error report

Dotfiles (editor temp files like `.hidden.yaml`) are still silently skipped per #41567 — only non-hidden YAML files that fail to parse are treated as errors.

Note that this fixes the silent skipping of unparseable YAML files. It does not fix the issue with nested entities (50+ levels) as the limited was added to protect from a DoS security issue. We could increase that limit, but imo50 levels of nesting is unlikely to be hit in the wild.

<img width="516" height="352" alt="Screenshot 2026-03-26 at 21 31 56" src="https://github.com/user-attachments/assets/1bda58f3-68ed-420e-9e3d-d3951dcc62f7" />

cc @metabase/tech-writers this _might_ come up as unexpected for some customers when serdes/remote sync started to fail if they have bad yaml files, so we could you please put a disclaimer in the release note so people know about this and find ways to fix their stuff?

Fixes #71257