### PR TITLE
fix flaky test in embedding hub

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
@@ -1134,11 +1134,18 @@ describe("scenarios - embedding hub", () => {
 
       cy.visit("/admin/embedding/setup-guide/permissions");
 
+      cy.log("wait for checklist data to load before interacting with steps");
+      H.main()
+        .findByRole("listitem", {
+          name: /Enable multi-tenant user strategy/,
+          timeout: 10_000,
+        })
+        .should("have.attr", "data-completed", "true");
+
       cy.log("open the data segregation strategy step");
       H.main()
         .findByText("Which data segregation strategy does your database use?")
         .scrollIntoView()
-        .should("be.visible")
         .click();
 
       cy.log("select row and column level security strategy");


### PR DESCRIPTION
Closes [EMB-1485: [Flaky Test] [e2e-tests] checklist scenarios - embedding hub checklist should update existing sandboxes when changing column selection](https://linear.app/metabase/issue/EMB-1485/flaky-test-e2e-tests-checklist-scenarios-embedding-hub-checklist)


Stress test: https://github.com/metabase/metabase/actions/runs/23549306215/job/68558503784

