### PR TITLE
Remove dangling reference to use-native-agent setting in e2e tests

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
@@ -455,8 +455,6 @@ describe("scenarios > embedding > sdk iframe embedding > custom elements api", (
     });
 
     it("should load the embedded Metabot component", () => {
-      cy.request("PUT", "/api/setting/use-native-agent", { value: true });
-
       H.visitCustomHtmlPage(`
       ${H.getNewEmbedScriptTag()}
       ${H.getNewEmbedConfigurationScript()}


### PR DESCRIPTION
### Description

This defsettings was removed in 311b735ae5d

https://metaboat.slack.com/archives/C07SJT1P0ET/p1774455259389979
https://metaboat.slack.com/archives/C5XHN8GLW/p1774450228014619

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
