### PR TITLE
fix frontmatter in add-tracing skill

### DIFF
--- a/.claude/skills/add-tracing/SKILL.md
+++ b/.claude/skills/add-tracing/SKILL.md
@@ -1,4 +1,4 @@
---b-
+---
 name: add-tracing
 description: Add OpenTelemetry tracing spans to Clojure code following Metabase tracing conventions. Use when instrumenting backend code with trace coverage.
 ---


### PR DESCRIPTION
Fixes a typo in the frontmatter of `.claude/skills/add-tracing/SKILL.md`