### PR TITLE
Update Value normalization / collapsing in ChartSettingInputNumeric.tsx

### DIFF
--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingInputNumeric.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingInputNumeric.tsx
@@ -1,5 +1,12 @@
 import debounce from "lodash.debounce";
-import { type ChangeEvent, useEffect, useMemo, useState } from "react";
+import {
+  type ChangeEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useLatest } from "react-use";
 
 import { TextInput } from "metabase/ui";
@@ -46,10 +53,12 @@ export const ChartSettingInputNumeric = ({
   className,
 }: ChartSettingInputProps) => {
   const [inputValue, setInputValue] = useState<string>(value?.toString() ?? "");
+  const isFocusedRef = useRef(false);
   const defaultValueProps = getDefault ? { defaultValue: getDefault() } : {};
 
-  const handleChangeRef = useLatest((e: ChangeEvent<HTMLInputElement>) => {
-    let num = e.target.value !== "" ? Number(e.target.value) : Number.NaN;
+  const processValueRef = useLatest((rawValue: string) => {
+    const rawNum = rawValue !== "" ? Number(rawValue) : Number.NaN;
+    let num = rawNum;
     if (options?.isInteger) {
       num = Math.round(num);
     }
@@ -61,17 +70,40 @@ export const ChartSettingInputNumeric = ({
       onChange(undefined);
     } else {
       onChange(num);
-      setInputValue(String(num));
+      // When the user is mid-edit with a decimal value (e.g. "0.", "0.00",
+      // ".5"), String(num) would collapse their input. Only skip the display
+      // update for these cosmetic differences — still normalize when options
+      // corrected the value or for scientific notation expansion.
+      const isMidEditDecimal =
+        isFocusedRef.current &&
+        num === rawNum &&
+        String(num) !== rawValue &&
+        !rawValue.includes("e");
+      if (!isMidEditDecimal) {
+        setInputValue(String(num));
+      }
     }
   });
-  const handleChangeDebounced = useMemo(() => {
-    return debounce((e: ChangeEvent<HTMLInputElement>) => {
-      handleChangeRef.current(e);
-    }, 400);
-  }, [handleChangeRef]);
+  const processValueDebounced = useMemo(() => {
+    return debounce((rawValue: string) => {
+      processValueRef.current(rawValue);
+    }, 200);
+  }, [processValueRef]);
+
+  const handleFocus = useCallback(() => {
+    isFocusedRef.current = true;
+  }, []);
+
+  const handleBlur = useCallback(() => {
+    isFocusedRef.current = false;
+    processValueDebounced.cancel();
+    processValueRef.current(inputValue);
+  }, [processValueDebounced, processValueRef, inputValue]);
 
   useEffect(() => {
-    setInputValue(value?.toString() ?? "");
+    if (!isFocusedRef.current) {
+      setInputValue(value?.toString() ?? "");
+    }
   }, [value]);
 
   return (
@@ -85,9 +117,11 @@ export const ChartSettingInputNumeric = ({
       onChange={(e: ChangeEvent<HTMLInputElement>) => {
         if (e.target.value.split("").every((ch) => ALLOWED_CHARS.has(ch))) {
           setInputValue(e.target.value);
-          handleChangeDebounced(e);
+          processValueDebounced(e.target.value);
         }
       }}
+      onFocus={handleFocus}
+      onBlur={handleBlur}
       className={className}
     />
   );

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingInputNumeric.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingInputNumeric.unit.spec.tsx
@@ -121,6 +121,93 @@ describe("ChartSettingInputNumber", () => {
     expect(onChange).toHaveBeenCalledWith(9412);
   });
 
+  it("does not truncate mid-edit decimal values", async () => {
+    const { input, onChange } = setup();
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+    await user.clear(input);
+    await user.type(input, "0.");
+    act(() => jest.runAllTimers());
+    expect(input).toHaveDisplayValue("0.");
+    expect(onChange).toHaveBeenLastCalledWith(0);
+
+    await user.clear(input);
+    await user.type(input, "0.00");
+    act(() => jest.runAllTimers());
+    expect(input).toHaveDisplayValue("0.00");
+    expect(onChange).toHaveBeenLastCalledWith(0);
+
+    await user.clear(input);
+    await user.type(input, ".5");
+    act(() => jest.runAllTimers());
+    expect(input).toHaveDisplayValue(".5");
+    expect(onChange).toHaveBeenLastCalledWith(0.5);
+
+    await user.clear(input);
+    await user.type(input, "1.50");
+    act(() => jest.runAllTimers());
+    expect(input).toHaveDisplayValue("1.50");
+    expect(onChange).toHaveBeenLastCalledWith(1.5);
+  });
+
+  it("normalizes the displayed value on blur", async () => {
+    const { input } = setup();
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+    await user.clear(input);
+    await user.type(input, "0.");
+    act(() => jest.runAllTimers());
+    expect(input).toHaveDisplayValue("0.");
+
+    await user.click(document.body);
+    expect(input).toHaveDisplayValue("0");
+
+    await user.clear(input);
+    await user.type(input, ".5");
+    act(() => jest.runAllTimers());
+    expect(input).toHaveDisplayValue(".5");
+
+    await user.click(document.body);
+    expect(input).toHaveDisplayValue("0.5");
+
+    await user.clear(input);
+    await user.type(input, "1.50");
+    act(() => jest.runAllTimers());
+    expect(input).toHaveDisplayValue("1.50");
+
+    await user.click(document.body);
+    expect(input).toHaveDisplayValue("1.5");
+  });
+
+  it("does not truncate when deleting characters from a decimal value", async () => {
+    const { input, onChange } = setup();
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+    // Type "1.5" then delete the "5" — should stay "1.", not collapse to "1"
+    await user.clear(input);
+    await user.type(input, "1.5");
+    act(() => jest.runAllTimers());
+    expect(input).toHaveDisplayValue("1.5");
+    expect(onChange).toHaveBeenLastCalledWith(1.5);
+
+    await user.type(input, "{Backspace}");
+    act(() => jest.runAllTimers());
+    expect(input).toHaveDisplayValue("1.");
+    expect(onChange).toHaveBeenLastCalledWith(1);
+
+    // Type "0.009" then delete the "9" — should stay "0.00", not collapse to "0"
+    await user.clear(input);
+    await user.type(input, "0.009");
+    act(() => jest.runAllTimers());
+    expect(input).toHaveDisplayValue("0.009");
+    expect(onChange).toHaveBeenLastCalledWith(0.009);
+
+    await user.type(input, "{Backspace}");
+    act(() => jest.runAllTimers());
+    expect(input).toHaveDisplayValue("0.00");
+    expect(onChange).toHaveBeenLastCalledWith(0);
+  });
+
   it("does not allow non-numeric values", async () => {
     const { input, onChange } = setup();
 


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #64608
### Description
Updates ChartSettingInputNumeric to with some additional rules to prevent collapsing while in mid edit, while keeping the chart updating without the need to blur. Also decreases the debounce timer for quicker feedback.

### How to verify
1. Go to any line / area / bar chart
2. add a goal line, and slowly type a decimal value like 0.005
3. Note that the value is never overwritten while you type
4. Delete the 5, so you're left with 0.00, and blur the element
5. Now the value has been collapsed to it's smaller value `0`

### Demo

https://github.com/user-attachments/assets/9b78b302-cf19-489b-8482-691d08ee17e7


### Checklist

- [x] Tests have been added/updated to cover changes in this PR