### PR TITLE
Don't try to compute diffs in bb cljfmt

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -756,7 +756,7 @@
   ;;
   ;; ./bin/mage cljfmt-all -h for more info
   :cljfmt
-  {:deps       {io.github.weavejester/cljfmt {:mvn/version "0.15.3"}}
+  {:deps       {dev.weavejester/cljfmt {:mvn/version "0.15.3"}}
    :ns-default cljfmt.tool
    :exec-fn    cljfmt.tool/fix}
 

--- a/mage/src/mage/format.clj
+++ b/mage/src/mage/format.clj
@@ -1,5 +1,6 @@
 (ns mage.format
   (:require
+   [cljfmt.report :as report]
    [cljfmt.tool]
    [clojure.string :as str]
    [mage.color :as c]
@@ -7,20 +8,66 @@
 
 (set! *warn-on-reflection* true)
 
-(defn- select-cljfmt-function [force-check?]
-  (if force-check? #'cljfmt.tool/check #'cljfmt.tool/fix))
+(defn- bb-not-implemented?
+  "Returns true if the exception is the babashka cljfmt 'not implemented' error."
+  [e]
+  (some-> (ex-message e)
+          (str/includes? "Not implemented in the babashka version of cljfmt yet")))
+
+(defn- check-results
+  "Extract incorrectly formatted file paths from cljfmt check results.
+  In babashka, incorrectly formatted files end up in :errored-files because
+  diff computation is not implemented. We treat those as 'incorrect' rather
+  than 'errored'."
+  [result]
+  (let [incorrect   (keys (get-in result [:results :incorrect-files]))
+        errored     (get-in result [:results :errored-files])
+        bb-failures (keep (fn [[path {:keys [exception]}]]
+                            (when (bb-not-implemented? exception) path))
+                          errored)
+        real-errors (keep (fn [[path {:keys [exception]}]]
+                            (when (and exception (not (bb-not-implemented? exception)))
+                              [path exception]))
+                          errored)]
+    {:incorrect (concat incorrect bb-failures)
+     :errors    real-errors}))
+
+(defn- report-check!
+  "Run cljfmt check using the clojure reporter (no System/exit), then print
+  which files are incorrectly formatted."
+  [opts]
+  (let [result                    (cljfmt.tool/check (assoc opts :report report/clojure))
+        {:keys [incorrect errors]} (check-results result)]
+    (doseq [[path exception] errors]
+      (binding [*out* *err*]
+        (println "Failed to format file:" path)
+        (println (ex-message exception))))
+    (if (seq incorrect)
+      (do (binding [*out* *err*]
+            (println (c/yellow (str (count incorrect) " file(s) formatted incorrectly:")))
+            (doseq [path (sort incorrect)]
+              (println (str "  " path)))
+            (println (str "\nRun " (c/green "./bin/mage cljfmt-files <files>") " to fix.")))
+          (throw (ex-info "" {:mage/quiet true :babashka/exit 1})))
+      (when-not (seq errors)
+        (binding [*out* *err*]
+          (println "All source files formatted correctly"))))))
 
 (defn files
   "Formats or checks a list of files."
   [{{force-check? :force-check} :options
     file-paths :arguments}]
-  (let [f (select-cljfmt-function force-check?)]
-    (when-not (seq file-paths)
-      (throw (ex-info (str "No files to " f "."
-                           "\nPlease specify file paths as arguments.")
-                      {:babashka/exit 0})))
-    (printf (c/green "%sing %s...\n") f (str/join ", " file-paths)) (flush)
-    (try (f {:paths file-paths}) (catch Exception _e nil))))
+  (when-not (seq file-paths)
+    (throw (ex-info (str "No files to format."
+                         "\nPlease specify file paths as arguments.")
+                    {:babashka/exit 0})))
+  (if force-check?
+    (do (printf (c/green "Checking %s...\n") (str/join ", " file-paths))
+        (flush)
+        (report-check! {:paths file-paths}))
+    (do (printf (c/green "Fixing %s...\n") (str/join ", " file-paths))
+        (flush)
+        (cljfmt.tool/fix {:paths file-paths}))))
 
 (defn updated
   "Formats or checks all updated clojure files with cljfmt."
@@ -40,7 +87,8 @@
          (u/debug "fp " file-paths)
          (if (seq file-paths)
            (files {:options {:force-check force-check?} :arguments file-paths})
-           (println (str "No staged clj, cljc, or cljs files to " (select-cljfmt-function force-check?) "."))))
+           (println (str "No staged clj, cljc, or cljs files to "
+                         (if force-check? "check" "fix") "."))))
        (catch Exception e
          (throw (ex-info (str (c/red "Problem formatting staged files. Are they readable?") "\ncause:\n" (ex-message e))
                          {:babashka/exit 1})))))
@@ -48,6 +96,8 @@
 (defn all
   "Formats or checks of the usual clojure files with cljfmt."
   [{{force-check? :force-check} :options}]
-  (let [f (select-cljfmt-function force-check?)]
-    (println (format "Running %s on all clojure files, sit tight: this could take a minute..." f))
-    (f {})))
+  (if force-check?
+    (do (println "Running check on all clojure files, sit tight: this could take a minute...")
+        (report-check! {}))
+    (do (println "Running fix on all clojure files, sit tight: this could take a minute...")
+        (cljfmt.tool/fix {}))))


### PR DESCRIPTION
the mage task for *checking* (not fixing) files in babashka was a bit broken, because cljfmt tries to compute diffs for the files and this isn't implemented in the babashka version of cljfmt.

So when we're checking for correctness, if we hit these errors, just correctly report that the files are incorrect - not errors. We don't need to produce a diff at all - this is just a check.

also fix the cljfmt version in `deps.edn`