### PR TITLE
Increase transform test timeout

### DIFF
--- a/test/metabase/transforms/test_util.clj
+++ b/test/metabase/transforms/test_util.clj
@@ -15,6 +15,13 @@
 
 (set! *warn-on-reflection* true)
 
+(defn seconds-from-now-ns
+  "Returns a deadline `seconds` from now in nanoseconds, for use with `System/nanoTime`.
+  We use nanoTime rather than currentTimeMillis because it is monotonic and not affected by
+  clock adjustments."
+  [seconds]
+  (+ (System/nanoTime) (* seconds 1000000000)))
+
 (defn source-table-entry
   "Build a full source-table-entry from alias + table_id by looking up database_id and schema."
   [alias table-id]
@@ -128,12 +135,12 @@
 (defn test-run
   [transform-id]
   (let [resp      (mt/user-http-request :crowberto :post 202 (format "transform/%s/run" transform-id))
-        timeout-s 10 ; 10 seconds is our timeout to finish execution and sync
-        limit     (+ (System/currentTimeMillis) (* timeout-s 1000))]
+        timeout-s 20 ; 20 seconds is our timeout to finish execution and sync
+        deadline  (seconds-from-now-ns timeout-s)]
     (is (=? {:message "Transform run started"}
             resp))
     (loop [last-resp nil]
-      (when (> (System/currentTimeMillis) limit)
+      (when (> (System/nanoTime) deadline)
         (throw (ex-info (str "Transform run timed out after " timeout-s " seconds") {:resp last-resp})))
       (let [resp   (mt/user-http-request :crowberto :get 200 (format "transform/%s" transform-id))
             status (some-> resp :last_run :status keyword)]

--- a/test/metabase/transforms_rest/api/transform_test.clj
+++ b/test/metabase/transforms_rest/api/transform_test.clj
@@ -17,6 +17,7 @@
    [metabase.transforms.test-dataset :as transforms-dataset]
    [metabase.transforms.test-util :refer [get-test-schema
                                           parse-instant
+                                          seconds-from-now-ns
                                           utc-timestamp
                                           with-transform-cleanup!]]
    [metabase.util :as u]
@@ -685,12 +686,12 @@
   (mt/with-db-perm-for-group! (perms-group/all-users) (mt/id) :perms/transforms :yes
     (mt/with-data-analyst-role! (mt/user->id :lucky)
       (let [resp      (mt/user-http-request :lucky :post 202 (format "transform/%s/run" transform-id))
-            timeout-s 10 ; 10 seconds is our timeout to finish execution and sync
-            limit     (+ (System/currentTimeMillis) (* timeout-s 1000))]
+            timeout-s 20 ; 20 seconds is our timeout to finish execution and sync
+            deadline  (seconds-from-now-ns timeout-s)]
         (is (=? {:message "Transform run started"}
                 resp))
         (loop []
-          (when (> (System/currentTimeMillis) limit)
+          (when (> (System/nanoTime) deadline)
             (throw (ex-info (str "Transform run timed out after " timeout-s " seconds") {})))
           (let [resp   (mt/user-http-request :lucky :get 200 (format "transform/%s" transform-id))
                 status (some-> resp :last_run :status keyword)]


### PR DESCRIPTION
We often [see this test timeout](https://app.trunk.io/metabase/flaky-tests/test/3aec7ed8-8439-5372-b6ec-f5031f9b0444?repo=metabase%2Fmetabase) on Redshift[^1], so it's worth a longer timeout to save additional runs.

[^1]: 41 times in the last 2 weeks, and 20 times on Monday 23rd March.
