### PR TITLE
Use a single request to get data for dashboard

### DIFF
--- a/e2e/support/helpers/e2e-dashboard-helpers.ts
+++ b/e2e/support/helpers/e2e-dashboard-helpers.ts
@@ -662,18 +662,35 @@ export function interceptDashboardCardRequests({
   cy.intercept("POST", pattern).as(alias);
 }
 
+// The server emits one `card-end` per successful card; its Dataset fields
+// (status, row_count, running_time, data, ...) live at the top level alongside
+// the routing fields (`type`, `dashcard_id`, `card_id`). Mirrors
+// `frontend/src/metabase/dashboard/actions/batch-card-query.ts`.
 interface BatchCardResult {
-  type: "card-result";
+  type: "card-end";
   dashcard_id: number;
   card_id: number;
-  result: Record<string, unknown>;
+  status: string;
+  row_count?: number;
+  running_time?: number;
+  data: Record<string, unknown>;
+  [key: string]: unknown;
 }
 
+// `card-error` carries the failed-Dataset envelope spread at the top level
+// (`status: "failed"`, `error`, `data: {cols, rows}`, optional `error_type` /
+// `error_is_curated` / `json_query`).
 interface BatchCardError {
   type: "card-error";
   dashcard_id: number;
   card_id: number;
-  error: Record<string, unknown>;
+  status: "failed";
+  error: string;
+  data: { cols: unknown[]; rows: unknown[] };
+  error_type?: string;
+  error_is_curated?: boolean;
+  json_query?: Record<string, unknown>;
+  [key: string]: unknown;
 }
 
 interface BatchComplete {
@@ -703,7 +720,7 @@ interface WaitBatchOptions {
  *   interceptDashboardCardRequests();
  *   // ... trigger dashboard load or filter change ...
  *   waitForDashboardCardRequests({ expectedCards: 2 }).then(({ results }) => {
- *     expect(results[0].result.data.rows).to.have.length.greaterThan(0);
+ *     expect(results[0].data.rows).to.have.length.greaterThan(0);
  *   });
  */
 export function waitForDashboardCardRequests({
@@ -728,7 +745,7 @@ export function waitForDashboardCardRequests({
       .filter(Boolean);
 
     const results = parsed.filter(
-      (l: Record<string, unknown>) => l.type === "card-result",
+      (l: Record<string, unknown>) => l.type === "card-end",
     ) as BatchCardResult[];
     const errors = parsed.filter(
       (l: Record<string, unknown>) => l.type === "card-error",

--- a/e2e/support/helpers/e2e-dashboard-helpers.ts
+++ b/e2e/support/helpers/e2e-dashboard-helpers.ts
@@ -643,16 +643,23 @@ interface InterceptBatchOptions {
 }
 
 /**
- * Intercept the batch card query endpoint for a normal dashboard.
+ * Intercept dashboard card query traffic under a single alias. This covers:
+ *   1. The batch endpoint (`/api/dashboard/:id/card-query-batch`) — fired once
+ *      per dashboard load/filter change to hydrate all cards at once.
+ *   2. The legacy per-card endpoint (`/api/dashboard/:id/dashcard/:dashcardId/card/:cardId/query`)
+ *      — still used by the QB when a saved question is opened from a dashboard
+ *      context (see `runQuestionQuery` in frontend/src/metabase/services.js).
  * Replaces: cy.intercept("POST", "/api/dashboard/\*\/dashcard/\*\/card/\*\/query").as("dashcardQuery")
  */
 export function interceptDashboardCardRequests({
   alias = "dashcardQuery",
   dashboardId = "*",
 }: InterceptBatchOptions = {}) {
-  cy.intercept("POST", `/api/dashboard/${dashboardId}/card-query-batch`).as(
-    alias,
+  const idSegment = dashboardId === "*" ? "[^/]+" : String(dashboardId);
+  const pattern = new RegExp(
+    `/api/dashboard/${idSegment}/(card-query-batch|dashcard/[^/]+/card/[^/]+/query)`,
   );
+  cy.intercept("POST", pattern).as(alias);
 }
 
 interface BatchCardResult {

--- a/e2e/support/helpers/e2e-dashboard-helpers.ts
+++ b/e2e/support/helpers/e2e-dashboard-helpers.ts
@@ -634,3 +634,106 @@ export function clickBehaviorSidebar(
 
   return cy.findByTestId("click-behavior-sidebar");
 }
+
+// ---- Batch card query helpers ----
+
+interface InterceptBatchOptions {
+  alias?: string;
+  dashboardId?: string | number;
+}
+
+/**
+ * Intercept the batch card query endpoint for a normal dashboard.
+ * Replaces: cy.intercept("POST", "/api/dashboard/\*\/dashcard/\*\/card/\*\/query").as("dashcardQuery")
+ */
+export function interceptDashboardCardRequests({
+  alias = "dashcardQuery",
+  dashboardId = "*",
+}: InterceptBatchOptions = {}) {
+  cy.intercept("POST", `/api/dashboard/${dashboardId}/card-query-batch`).as(
+    alias,
+  );
+}
+
+interface BatchCardResult {
+  type: "card-result";
+  dashcard_id: number;
+  card_id: number;
+  result: Record<string, unknown>;
+}
+
+interface BatchCardError {
+  type: "card-error";
+  dashcard_id: number;
+  card_id: number;
+  error: Record<string, unknown>;
+}
+
+interface BatchComplete {
+  type: "complete";
+  total: number;
+  succeeded: number;
+  failed: number;
+}
+
+interface ParsedBatchResponse {
+  results: BatchCardResult[];
+  errors: BatchCardError[];
+  complete: BatchComplete | undefined;
+  interception: Cypress.Interception;
+}
+
+interface WaitBatchOptions {
+  alias?: string;
+  expectedCards?: number;
+}
+
+/**
+ * Wait for a batch card query and parse the NDJSON response.
+ * Returns parsed card results for assertions.
+ *
+ * Usage:
+ *   interceptDashboardCardRequests();
+ *   // ... trigger dashboard load or filter change ...
+ *   waitForDashboardCardRequests({ expectedCards: 2 }).then(({ results }) => {
+ *     expect(results[0].result.data.rows).to.have.length.greaterThan(0);
+ *   });
+ */
+export function waitForDashboardCardRequests({
+  alias = "dashcardQuery",
+  expectedCards,
+}: WaitBatchOptions = {}): Cypress.Chainable<ParsedBatchResponse> {
+  return cy.wait(`@${alias}`).then((interception: Cypress.Interception) => {
+    const body = interception.response?.body;
+    const text = typeof body === "string" ? body : JSON.stringify(body);
+    const lines = text
+      .split("\n")
+      .filter((line: string) => line.trim().length > 0);
+
+    const parsed = lines
+      .map((line: string) => {
+        try {
+          return JSON.parse(line);
+        } catch {
+          return null;
+        }
+      })
+      .filter(Boolean);
+
+    const results = parsed.filter(
+      (l: Record<string, unknown>) => l.type === "card-result",
+    ) as BatchCardResult[];
+    const errors = parsed.filter(
+      (l: Record<string, unknown>) => l.type === "card-error",
+    ) as BatchCardError[];
+    const complete = parsed.find(
+      (l: Record<string, unknown>) => l.type === "complete",
+    ) as BatchComplete | undefined;
+
+    if (expectedCards !== undefined) {
+      expect(results).to.have.length(expectedCards);
+    }
+
+    return { results, errors, complete, interception };
+  });
+}

--- a/e2e/support/helpers/e2e-embedding-iframe-sdk-helpers.ts
+++ b/e2e/support/helpers/e2e-embedding-iframe-sdk-helpers.ts
@@ -217,7 +217,9 @@ export function prepareSdkIframeEmbedTest({
   });
 
   cy.intercept("POST", "/api/card/*/query").as("getCardQuery");
-  cy.intercept("POST", "/api/dashboard/**/query").as("getDashCardQuery");
+  cy.intercept("POST", "/api/dashboard/*/card-query-batch").as(
+    "getDashCardQuery",
+  );
   cy.intercept("GET", "/api/dashboard/*").as("getDashboard");
 
   setupMockAuthProviders(enabledAuthMethods);

--- a/e2e/support/helpers/e2e-misc-helpers.js
+++ b/e2e/support/helpers/e2e-misc-helpers.js
@@ -212,31 +212,18 @@ function visitDashboardById(dashboard_id, config) {
     }
 
     if (canViewDashboard && validQuestions) {
-      // If dashboard has valid questions (GUI or native),
-      // we need to alias each request and wait for their reponses
-      const aliases = validQuestions.map(
-        ({ id, card_id, card: { display } }) => {
-          const baseUrl =
-            display === "pivot"
-              ? `/api/dashboard/pivot/${dashboard_id}`
-              : `/api/dashboard/${dashboard_id}`;
-
-          const interceptUrl = `${baseUrl}/dashcard/${id}/card/${card_id}/query`;
-
-          const alias = "dashcardQuery" + id;
-
-          cy.intercept("POST", interceptUrl).as(alias);
-
-          return `@${alias}`;
-        },
-      );
+      // Dashboard uses a batch endpoint to fetch all card data in one request
+      cy.intercept(
+        "POST",
+        `/api/dashboard/${dashboard_id}/card-query-batch`,
+      ).as("batchQuery");
 
       cy.visit({
         url: `/dashboard/${dashboard_id}`,
         qs: config.params,
       });
 
-      cy.wait(aliases);
+      cy.wait("@batchQuery");
     } else {
       // For a dashboard:
       //  - without questions (can be empty or markdown only) or

--- a/e2e/support/helpers/e2e-permissions-helpers.js
+++ b/e2e/support/helpers/e2e-permissions-helpers.js
@@ -135,11 +135,20 @@ export function assertSameBeforeAndAfterSave(assertionCallback) {
 }
 
 export function assertDatasetReqIsSandboxed(options = {}) {
-  const { requestAlias = "@dataset", columnId, columnAssertion } = options;
+  const {
+    requestAlias = "@dataset",
+    columnId,
+    columnAssertion,
+    dashcardId,
+  } = options;
 
   cy.get(requestAlias).should(({ response }) => {
+    const data =
+      dashcardId !== undefined
+        ? extractBatchCardData(response.body, dashcardId)
+        : response.body.data;
+
     // check if data is reporting itself as sandboxed
-    const { data } = response.body;
     expect(data.is_sandboxed).to.equal(true);
 
     // if options to make assertions on a column's data
@@ -156,6 +165,37 @@ export function assertDatasetReqIsSandboxed(options = {}) {
       expect(values.every(assertionFn)).to.equal(true, errMsg);
     }
   });
+}
+
+// Parse the NDJSON body of a batch-card-query response and reconstruct the
+// dataset for a specific dashcard by merging its card-begin/rows/end envelopes.
+function extractBatchCardData(body, dashcardId) {
+  const text = typeof body === "string" ? body : JSON.stringify(body);
+  const messages = text
+    .split("\n")
+    .filter((line) => line.trim().length > 0)
+    .map((line) => {
+      try {
+        return JSON.parse(line);
+      } catch {
+        return null;
+      }
+    })
+    .filter(Boolean);
+
+  const beginMsg = messages.find(
+    (m) => m.type === "card-begin" && m.dashcard_id === dashcardId,
+  );
+  const endMsg = messages.find(
+    (m) => m.type === "card-end" && m.dashcard_id === dashcardId,
+  );
+  expect(endMsg, `no card-end for dashcard ${dashcardId}`).to.not.be.undefined;
+
+  const rows = messages
+    .filter((m) => m.type === "card-rows" && m.dashcard_id === dashcardId)
+    .flatMap((m) => m.rows);
+
+  return { ...(beginMsg?.data ?? {}), ...endMsg.data, rows };
 }
 
 export function blockUserGroupPermissions(groupId, databaseId = SAMPLE_DB_ID) {

--- a/e2e/support/helpers/e2e-request-helpers.ts
+++ b/e2e/support/helpers/e2e-request-helpers.ts
@@ -20,11 +20,17 @@
  *
  *    expect(spy.getCalls().length).to.eq(2);
  * });
+ *
+ * The spy fires on `before:response`, so it works with streaming/chunked
+ * responses (e.g. NDJSON) that never finish buffering — unlike the previous
+ * `req.continue(cb)` wrapper, which required a full response body before firing.
  */
 export function spyRequestFinished(name = "requestFinishedSpy") {
   const spy = cy.spy().as(name);
   return {
-    interceptor: (req: any) => req.continue((res: any) => spy(req, res)),
+    interceptor: (req: any) => {
+      req.on("before:response", (res: any) => spy(req, res));
+    },
     spy,
   };
 }

--- a/e2e/test-component/scenarios/embedding-sdk/dashboard-click-behavior.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/dashboard-click-behavior.cy.spec.tsx
@@ -133,9 +133,7 @@ describe("scenarios > embedding-sdk > dashboard-click-behavior", () => {
     mockAuthProviderAndJwtSignIn();
 
     cy.intercept("GET", "/api/dashboard/*").as("getDashboard");
-    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
-      "dashcardQuery",
-    );
+    H.interceptDashboardCardRequests();
   });
 
   it("should allow external URL click behaviors in the SDK (EMB-878)", () => {

--- a/e2e/test-component/scenarios/embedding-sdk/editable-dashboard.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/editable-dashboard.cy.spec.tsx
@@ -67,9 +67,7 @@ describe("scenarios > embedding-sdk > editable-dashboard", () => {
 
     mockAuthProviderAndJwtSignIn();
     cy.intercept("GET", "/api/dashboard/*").as("getDashboard");
-    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
-      "dashcardQuery",
-    );
+    H.interceptDashboardCardRequests();
   });
 
   it("Should not open sidesheet when clicking last edit info (metabase#48354)", () => {

--- a/e2e/test-component/scenarios/embedding-sdk/incompatibility-with-instance-banner.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/incompatibility-with-instance-banner.cy.spec.tsx
@@ -23,10 +23,6 @@ const mockIncompatibleMetabaseVersion = () => {
 
 describe.skip("scenarios > embedding-sdk > incompatibility-with-instance-banner", () => {
   beforeEach(() => {
-    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
-      "dashcardQuery",
-    );
-
     signInAsAdminAndEnableEmbeddingSdk();
 
     cy.signOut();

--- a/e2e/test-component/scenarios/embedding-sdk/interactive-dashboard.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/interactive-dashboard.cy.spec.tsx
@@ -75,9 +75,7 @@ describe("scenarios > embedding-sdk > interactive-dashboard", () => {
     mockAuthProviderAndJwtSignIn();
 
     cy.intercept("GET", "/api/dashboard/*").as("getDashboard");
-    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
-      "dashcardQuery",
-    );
+    H.interceptDashboardCardRequests();
   });
 
   it("should be able to display custom question layout when clicking on dashboard cards", () => {

--- a/e2e/test-component/scenarios/embedding-sdk/internal-navigation.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/internal-navigation.cy.spec.tsx
@@ -199,9 +199,7 @@ describe("scenarios > embedding-sdk > internal-navigation", () => {
       mockAuthProviderAndJwtSignIn();
 
       cy.intercept("GET", "/api/dashboard/*").as("getDashboard");
-      cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
-        "dashcardQuery",
-      );
+      H.interceptDashboardCardRequests();
     });
 
     it("should pass parameters to the linked dashboard", () => {

--- a/e2e/test-component/scenarios/embedding-sdk/internal-navigation.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/internal-navigation.cy.spec.tsx
@@ -669,9 +669,7 @@ describe("scenarios > embedding-sdk > internal-navigation", () => {
       signInAsAdminAndEnableEmbeddingSdk();
 
       cy.intercept("GET", "/api/dashboard/*").as("getDashboard");
-      cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
-        "dashcardQuery",
-      );
+      H.interceptDashboardCardRequests();
     });
 
     it("should switch tab and pass parameters when click behavior points to a different tab on the same dashboard", () => {
@@ -1095,9 +1093,7 @@ describe("scenarios > embedding-sdk > internal-navigation", () => {
       signInAsAdminAndEnableEmbeddingSdk();
 
       cy.intercept("GET", "/api/dashboard/*").as("getDashboard");
-      cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
-        "dashcardQuery",
-      );
+      H.interceptDashboardCardRequests();
     });
 
     it("should open the target dashboard on the requested tab", () => {

--- a/e2e/test-component/scenarios/embedding-sdk/popover.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/popover.cy.spec.tsx
@@ -25,9 +25,7 @@ const ORDERS_TOTAL_FIELD: ConcreteFieldReference = [
 
 describe("scenarios > embedding-sdk > popovers", () => {
   beforeEach(() => {
-    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
-      "dashcardQuery",
-    );
+    H.interceptDashboardCardRequests();
 
     signInAsAdminAndEnableEmbeddingSdk();
 

--- a/e2e/test-component/scenarios/embedding-sdk/sdk-bundle-hooks.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/sdk-bundle-hooks.cy.spec.tsx
@@ -22,10 +22,6 @@ import {
 
 describe("scenarios > embedding-sdk > sdk-bundle public hooks", () => {
   beforeEach(() => {
-    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
-      "dashcardQuery",
-    );
-
     signInAsAdminAndEnableEmbeddingSdk();
 
     cy.signOut();

--- a/e2e/test-component/scenarios/embedding-sdk/sdk-dashboard-controlled-parameters.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/sdk-dashboard-controlled-parameters.cy.spec.tsx
@@ -74,9 +74,7 @@ const findDateFilterValue = () =>
 describe("scenarios > embedding-sdk > sdk-dashboard > controlled parameters", () => {
   beforeEach(() => {
     setup();
-    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
-      "dashcardQuery",
-    );
+    H.interceptDashboardCardRequests();
   });
 
   it("forwards values pushed via the `parameters` prop to the dashcard query", () => {

--- a/e2e/test-component/scenarios/embedding-sdk/static-dashboard.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/static-dashboard.cy.spec.tsx
@@ -44,9 +44,7 @@ describe("scenarios > embedding-sdk > static-dashboard", () => {
     mockAuthProviderAndJwtSignIn();
 
     cy.intercept("GET", "/api/dashboard/*").as("getDashboard");
-    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
-      "dashcardQuery",
-    );
+    H.interceptDashboardCardRequests();
   });
 
   it("should render dashboard content", () => {

--- a/e2e/test-component/scenarios/embedding-sdk/styles-tests.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/styles-tests.cy.spec.tsx
@@ -477,9 +477,7 @@ describe("scenarios > embedding-sdk > styles", () => {
         cy.signOut();
 
         cy.intercept("GET", "/api/dashboard/*").as("getDashboard");
-        cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
-          "dashcardQuery",
-        );
+        H.interceptDashboardCardRequests();
       });
 
       it("should render legacy Popover with our styles", () => {

--- a/e2e/test-component/scenarios/embedding-sdk/tooltip-reproductions.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/tooltip-reproductions.cy.spec.tsx
@@ -45,9 +45,7 @@ describe("scenarios > embedding-sdk > tooltip-reproductions", () => {
     mockAuthProviderAndJwtSignIn();
 
     cy.intercept("GET", "/api/dashboard/*").as("getDashboard");
-    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
-      "dashcardQuery",
-    );
+    H.interceptDashboardCardRequests();
   });
 
   it("should have the correct tooltip position and z-index (metabase#51904, metabase#52732)", () => {

--- a/e2e/test-component/scenarios/embedding-sdk/touch-chart-drill.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/touch-chart-drill.cy.spec.tsx
@@ -86,9 +86,7 @@ describe("scenarios > embedding-sdk > touch chart drill popover", () => {
     mockAuthProviderAndJwtSignIn();
 
     cy.intercept("GET", "/api/dashboard/*").as("getDashboard");
-    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
-      "dashcardQuery",
-    );
+    H.interceptDashboardCardRequests();
   });
 
   describe("touch device", () => {

--- a/e2e/test/scenarios/admin/i18n/content-translation/dashboards.cy.spec.ts
+++ b/e2e/test/scenarios/admin/i18n/content-translation/dashboards.cy.spec.ts
@@ -389,7 +389,9 @@ describe("scenarios > content translation > static embeds > dashboards", () => {
 
     beforeEach(() => {
       cy.intercept("GET", "/api/embed/dashboard/*").as("dashboard");
-      cy.intercept("GET", "/api/embed/dashboard/**/card/*").as("cardQuery");
+      cy.intercept("GET", "/api/embed/dashboard/*/card-query-batch*").as(
+        "cardQuery",
+      );
       cy.intercept("GET", "/api/embed/dashboard/**/search/*").as("searchQuery");
       H.restore("with-translations" as any);
     });
@@ -472,7 +474,9 @@ describe("scenarios > content translation > static embeds > dashboards", () => {
 
       beforeEach(() => {
         cy.intercept("GET", "/api/embed/dashboard/*").as("dashboard");
-        cy.intercept("GET", "/api/embed/dashboard/**/card/*").as("cardQuery");
+        cy.intercept("GET", "/api/embed/dashboard/*/card-query-batch*").as(
+          "cardQuery",
+        );
         cy.intercept("GET", "/api/embed/dashboard/**/search/*").as(
           "searchQuery",
         );

--- a/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
@@ -1658,7 +1658,9 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
 
     beforeEach(() => {
       cy.intercept("GET", "/api/embed/dashboard/*").as("dashboard");
-      cy.intercept("GET", "/api/embed/dashboard/**/card/*").as("cardQuery");
+      cy.intercept("GET", "/api/embed/dashboard/*/card-query-batch*").as(
+        "cardQuery",
+      );
     });
 
     it("does not allow opening custom dashboard destination", () => {

--- a/e2e/test/scenarios/dashboard-cards/dashboard-card-fetching.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-card-fetching.cy.spec.js
@@ -28,16 +28,11 @@ describe("dashboard card fetching", () => {
     H.interceptDashboardCardRequests({ alias: "dashcardQuery" });
   });
 
-  it("should pass same dashboard_load_id to every query to enable metadata cache sharing", () => {
+  it("should include a dashboard_load_id with the batch card query", () => {
     createDashboardWithCards({ cards }).then(H.visitDashboard);
 
-    cy.wait(["@dashcardQuery", "@dashcardQuery"]).then((interceptions) => {
-      const query1 = interceptions[0].request.body;
-      const query2 = interceptions[1].request.body;
-
-      expect(query1.dashboard_load_id).to.have.length(36);
-      expect(query2.dashboard_load_id).to.have.length(36);
-      expect(query1.dashboard_load_id).to.equal(query2.dashboard_load_id);
+    cy.wait("@dashcardQuery").then((interception) => {
+      expect(interception.request.body.dashboard_load_id).to.have.length(36);
     });
   });
 });

--- a/e2e/test/scenarios/dashboard-cards/dashboard-card-fetching.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-card-fetching.cy.spec.js
@@ -25,9 +25,7 @@ describe("dashboard card fetching", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsNormalUser();
-    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
-      "dashcardQuery",
-    );
+    H.interceptDashboardCardRequests({ alias: "dashcardQuery" });
   });
 
   it("should pass same dashboard_load_id to every query to enable metadata cache sharing", () => {

--- a/e2e/test/scenarios/dashboard-cards/dashboard-card-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-card-reproductions.cy.spec.js
@@ -132,9 +132,7 @@ describe("issue 16334", () => {
     H.restore();
     cy.signInAsAdmin();
     cy.intercept("POST", "/api/dataset").as("dataset");
-    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
-      "dashcardQuery",
-    );
+    H.interceptDashboardCardRequests({ alias: "dashcardQuery" });
   });
 
   it("should not change the visualization type in a targetted question with mapped filter (metabase#16334)", () => {
@@ -463,9 +461,7 @@ describe("issue 17160", () => {
     visitSourceDashboard();
 
     cy.get("@targetDashboardId").then((id) => {
-      cy.intercept("POST", `/api/dashboard/${id}/dashcard/*/card/*/query`).as(
-        "targetDashcardQuery",
-      );
+      H.interceptDashboardCardRequests({ alias: "targetDashcardQuery" });
 
       cy.findAllByText("click-behavior-dashboard-label").eq(0).click();
       cy.wait("@targetDashcardQuery");
@@ -691,9 +687,7 @@ describe("issue 29304", () => {
     beforeEach(() => {
       H.restore();
       cy.signInAsAdmin();
-      cy.intercept("api/dashboard/*/dashcard/*/card/*/query").as(
-        "getDashcardQuery",
-      );
+      H.interceptDashboardCardRequests({ alias: "getDashcardQuery" });
       cy.intercept("api/dashboard/*").as("getDashboard");
       cy.clock();
     });

--- a/e2e/test/scenarios/dashboard-cards/dashboard-drill.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-drill.cy.spec.js
@@ -622,10 +622,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
 
         H.visitDashboard(DASHBOARD_ID);
 
-        cy.intercept(
-          "POST",
-          `/api/dashboard/${DASHBOARD_ID}/dashcard/*/card/${QUESTION_ID}/query`,
-        ).as("cardQuery");
+        H.interceptDashboardCardRequests({ alias: "cardQuery" });
 
         H.chartPathWithFillColor("#509EE3")
           .eq(14) // August 2026 (Total of 12 reviews, 9 unique days)
@@ -643,9 +640,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
 
   it("should keep card's display when doing zoom drill-through from dashboard (metabase#38307)", () => {
     cy.intercept("POST", "/api/dataset").as("dataset");
-    cy.intercept("/api/dashboard/*/dashcard/*/card/*/query").as(
-      "dashcardQuery",
-    );
+    H.interceptDashboardCardRequests({ alias: "dashcardQuery" });
 
     const questionDetails = {
       name: "38307",

--- a/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-1-stage.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-1-stage.cy.spec.ts
@@ -18,13 +18,11 @@ describe("scenarios > dashboard > filters > query stages", () => {
     cy.intercept("POST", "/api/dataset").as("dataset");
     cy.intercept("GET", "/api/dashboard/**").as("getDashboard");
     cy.intercept("PUT", "/api/dashboard/**").as("updateDashboard");
-    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
-      "dashboardData",
-    );
-    cy.intercept("GET", "/api/public/dashboard/*/dashcard/*/card/*").as(
+    H.interceptDashboardCardRequests({ alias: "dashboardData" });
+    cy.intercept("GET", "/api/public/dashboard/*/card-query-batch*").as(
       "publicDashboardData",
     );
-    cy.intercept("GET", "/api/embed/dashboard/*/dashcard/*/card/*").as(
+    cy.intercept("GET", "/api/embed/dashboard/*/card-query-batch*").as(
       "embeddedDashboardData",
     );
   });

--- a/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-2-stage-1.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-2-stage-1.cy.spec.ts
@@ -18,13 +18,11 @@ describe("scenarios > dashboard > filters > query stages", () => {
     cy.intercept("POST", "/api/dataset").as("dataset");
     cy.intercept("GET", "/api/dashboard/**").as("getDashboard");
     cy.intercept("PUT", "/api/dashboard/**").as("updateDashboard");
-    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
-      "dashboardData",
-    );
-    cy.intercept("GET", "/api/public/dashboard/*/dashcard/*/card/*").as(
+    H.interceptDashboardCardRequests({ alias: "dashboardData" });
+    cy.intercept("GET", "/api/public/dashboard/*/card-query-batch*").as(
       "publicDashboardData",
     );
-    cy.intercept("GET", "/api/embed/dashboard/*/dashcard/*/card/*").as(
+    cy.intercept("GET", "/api/embed/dashboard/*/card-query-batch*").as(
       "embeddedDashboardData",
     );
   });

--- a/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-2-stage-2.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-2-stage-2.cy.spec.ts
@@ -18,13 +18,11 @@ describe("scenarios > dashboard > filters > query stages", () => {
     cy.intercept("POST", "/api/dataset").as("dataset");
     cy.intercept("GET", "/api/dashboard/**").as("getDashboard");
     cy.intercept("PUT", "/api/dashboard/**").as("updateDashboard");
-    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
-      "dashboardData",
-    );
-    cy.intercept("GET", "/api/public/dashboard/*/dashcard/*/card/*").as(
+    H.interceptDashboardCardRequests({ alias: "dashboardData" });
+    cy.intercept("GET", "/api/public/dashboard/*/card-query-batch*").as(
       "publicDashboardData",
     );
-    cy.intercept("GET", "/api/embed/dashboard/*/dashcard/*/card/*").as(
+    cy.intercept("GET", "/api/embed/dashboard/*/card-query-batch*").as(
       "embeddedDashboardData",
     );
   });

--- a/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-2-stage-2.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-2-stage-2.cy.spec.ts
@@ -220,7 +220,7 @@ describe("scenarios > dashboard > filters > query stages", () => {
         it("1st stage explicit join", () => {
           QSHelpers.setup1stStageExplicitJoinFilter();
           QSHelpers.apply1stStageExplicitJoinFilter();
-          cy.wait(["@dashboardData", "@dashboardData"]);
+          cy.wait("@dashboardData");
 
           QSHelpers.verifyDashcardCellValues({
             dashcardIndex: 0,
@@ -334,7 +334,7 @@ describe("scenarios > dashboard > filters > query stages", () => {
         it("2nd stage custom column", () => {
           QSHelpers.setup2ndStageCustomColumnFilter();
           QSHelpers.apply2ndStageCustomColumnFilter();
-          cy.wait(["@dashboardData", "@dashboardData"]);
+          cy.wait("@dashboardData");
 
           QSHelpers.verifyDashcardCellValues({
             dashcardIndex: 0,

--- a/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-2-stage-3.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-2-stage-3.cy.spec.ts
@@ -18,13 +18,11 @@ describe("scenarios > dashboard > filters > query stages", () => {
     cy.intercept("POST", "/api/dataset").as("dataset");
     cy.intercept("GET", "/api/dashboard/**").as("getDashboard");
     cy.intercept("PUT", "/api/dashboard/**").as("updateDashboard");
-    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
-      "dashboardData",
-    );
-    cy.intercept("GET", "/api/public/dashboard/*/dashcard/*/card/*").as(
+    H.interceptDashboardCardRequests({ alias: "dashboardData" });
+    cy.intercept("GET", "/api/public/dashboard/*/card-query-batch*").as(
       "publicDashboardData",
     );
-    cy.intercept("GET", "/api/embed/dashboard/*/dashcard/*/card/*").as(
+    cy.intercept("GET", "/api/embed/dashboard/*/card-query-batch*").as(
       "embeddedDashboardData",
     );
   });

--- a/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-2-stage-3.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-2-stage-3.cy.spec.ts
@@ -250,7 +250,7 @@ describe("scenarios > dashboard > filters > query stages", () => {
         it("1st stage explicit join", () => {
           QSHelpers.setup1stStageExplicitJoinFilter();
           QSHelpers.apply1stStageExplicitJoinFilter();
-          cy.wait(["@dashboardData", "@dashboardData"]);
+          cy.wait("@dashboardData");
 
           QSHelpers.verifyDashcardRowsCount({
             dashcardIndex: 0,
@@ -378,7 +378,7 @@ describe("scenarios > dashboard > filters > query stages", () => {
         it("2nd stage custom column", () => {
           QSHelpers.setup2ndStageCustomColumnFilter();
           QSHelpers.apply2ndStageCustomColumnFilter();
-          cy.wait(["@dashboardData", "@dashboardData"]);
+          cy.wait("@dashboardData");
 
           QSHelpers.verifyDashcardRowsCount({
             dashcardIndex: 0,
@@ -398,7 +398,7 @@ describe("scenarios > dashboard > filters > query stages", () => {
         it("2nd stage breakout", () => {
           QSHelpers.setup2ndStageBreakoutFilter();
           QSHelpers.apply2ndStageBreakoutFilter();
-          cy.wait(["@dashboardData", "@dashboardData"]);
+          cy.wait("@dashboardData");
 
           QSHelpers.verifyDashcardRowsCount({
             dashcardIndex: 0,

--- a/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-2-stage-4.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-2-stage-4.cy.spec.ts
@@ -18,13 +18,11 @@ describe("scenarios > dashboard > filters > query stages", () => {
     cy.intercept("POST", "/api/dataset").as("dataset");
     cy.intercept("GET", "/api/dashboard/**").as("getDashboard");
     cy.intercept("PUT", "/api/dashboard/**").as("updateDashboard");
-    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
-      "dashboardData",
-    );
-    cy.intercept("GET", "/api/public/dashboard/*/dashcard/*/card/*").as(
+    H.interceptDashboardCardRequests({ alias: "dashboardData" });
+    cy.intercept("GET", "/api/public/dashboard/*/card-query-batch*").as(
       "publicDashboardData",
     );
-    cy.intercept("GET", "/api/embed/dashboard/*/dashcard/*/card/*").as(
+    cy.intercept("GET", "/api/embed/dashboard/*/card-query-batch*").as(
       "embeddedDashboardData",
     );
   });

--- a/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-2-stage-4.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-2-stage-4.cy.spec.ts
@@ -511,7 +511,7 @@ describe("scenarios > dashboard > filters > query stages", () => {
           );
           QSHelpers.waitForPublicDashboardData(4);
           QSHelpers.apply2ndStageAggregationFilter();
-          QSHelpers.waitForPublicDashboardData(2);
+          QSHelpers.waitForPublicDashboardData(4);
 
           H.getDashboardCard(0).within(() => {
             H.assertTableRowsCount(6);
@@ -535,7 +535,7 @@ describe("scenarios > dashboard > filters > query stages", () => {
           });
           QSHelpers.waitForEmbeddedDashboardData(4);
           QSHelpers.apply2ndStageAggregationFilter();
-          QSHelpers.waitForEmbeddedDashboardData(2);
+          QSHelpers.waitForEmbeddedDashboardData(4);
 
           H.getDashboardCard(0).within(() => {
             H.assertTableRowsCount(6);
@@ -592,7 +592,7 @@ describe("scenarios > dashboard > filters > query stages", () => {
           );
           QSHelpers.waitForPublicDashboardData(4);
           QSHelpers.apply2ndStageBreakoutFilter();
-          QSHelpers.waitForPublicDashboardData(2);
+          QSHelpers.waitForPublicDashboardData(4);
 
           H.getDashboardCard(0).within(() => {
             H.assertTableRowsCount(1077);
@@ -616,7 +616,7 @@ describe("scenarios > dashboard > filters > query stages", () => {
           });
           QSHelpers.waitForEmbeddedDashboardData(4);
           QSHelpers.apply2ndStageBreakoutFilter();
-          QSHelpers.waitForEmbeddedDashboardData(2);
+          QSHelpers.waitForEmbeddedDashboardData(4);
 
           H.getDashboardCard(0).within(() => {
             H.assertTableRowsCount(1077);

--- a/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-2-stage-4.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-2-stage-4.cy.spec.ts
@@ -260,7 +260,7 @@ describe("scenarios > dashboard > filters > query stages", () => {
         it("1st stage explicit join", () => {
           QSHelpers.setup1stStageExplicitJoinFilter();
           QSHelpers.apply1stStageExplicitJoinFilter();
-          cy.wait(["@dashboardData", "@dashboardData"]);
+          cy.wait("@dashboardData");
 
           QSHelpers.verifyDashcardRowsCount({
             dashcardIndex: 0,
@@ -420,7 +420,7 @@ describe("scenarios > dashboard > filters > query stages", () => {
         it("2nd stage custom column", () => {
           QSHelpers.setup2ndStageCustomColumnFilter();
           QSHelpers.apply2ndStageCustomColumnFilter();
-          cy.wait(["@dashboardData", "@dashboardData"]);
+          cy.wait("@dashboardData");
 
           QSHelpers.verifyDashcardRowsCount({
             dashcardIndex: 0,
@@ -473,7 +473,7 @@ describe("scenarios > dashboard > filters > query stages", () => {
         it("2nd stage aggregation", () => {
           QSHelpers.setup2ndStageAggregationFilter();
           QSHelpers.apply2ndStageAggregationFilter();
-          cy.wait(["@dashboardData", "@dashboardData"]);
+          cy.wait("@dashboardData");
 
           QSHelpers.verifyDashcardRowsCount({
             dashcardIndex: 0,
@@ -554,7 +554,7 @@ describe("scenarios > dashboard > filters > query stages", () => {
         it("2nd stage breakout", () => {
           QSHelpers.setup2ndStageBreakoutFilter();
           QSHelpers.apply2ndStageBreakoutFilter();
-          cy.wait(["@dashboardData", "@dashboardData"]);
+          cy.wait("@dashboardData");
 
           QSHelpers.verifyDashcardRowsCount({
             dashcardIndex: 0,

--- a/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-3-stage.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-3-stage.cy.spec.ts
@@ -18,13 +18,11 @@ describe("scenarios > dashboard > filters > query stages", () => {
     cy.intercept("POST", "/api/dataset").as("dataset");
     cy.intercept("GET", "/api/dashboard/**").as("getDashboard");
     cy.intercept("PUT", "/api/dashboard/**").as("updateDashboard");
-    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
-      "dashboardData",
-    );
-    cy.intercept("GET", "/api/public/dashboard/*/dashcard/*/card/*").as(
+    H.interceptDashboardCardRequests({ alias: "dashboardData" });
+    cy.intercept("GET", "/api/public/dashboard/*/card-query-batch*").as(
       "publicDashboardData",
     );
-    cy.intercept("GET", "/api/embed/dashboard/*/dashcard/*/card/*").as(
+    cy.intercept("GET", "/api/embed/dashboard/*/card-query-batch*").as(
       "embeddedDashboardData",
     );
   });

--- a/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-3-stage.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard-filters-2/dashboard-filters-3-stage.cy.spec.ts
@@ -242,7 +242,7 @@ describe("scenarios > dashboard > filters > query stages", () => {
         it("1st stage explicit join", () => {
           QSHelpers.setup1stStageExplicitJoinFilter();
           QSHelpers.apply1stStageExplicitJoinFilter();
-          cy.wait(["@dashboardData", "@dashboardData"]);
+          cy.wait("@dashboardData");
 
           QSHelpers.verifyDashcardCellValues({
             dashcardIndex: 0,
@@ -356,7 +356,7 @@ describe("scenarios > dashboard > filters > query stages", () => {
         it("2nd stage custom column", () => {
           QSHelpers.setup2ndStageCustomColumnFilter();
           QSHelpers.apply2ndStageCustomColumnFilter();
-          cy.wait(["@dashboardData", "@dashboardData"]);
+          cy.wait("@dashboardData");
 
           QSHelpers.verifyDashcardCellValues({
             dashcardIndex: 0,
@@ -374,7 +374,7 @@ describe("scenarios > dashboard > filters > query stages", () => {
         it("2nd stage aggregation", () => {
           QSHelpers.setup2ndStageAggregationFilter();
           QSHelpers.apply2ndStageAggregationFilter();
-          cy.wait(["@dashboardData", "@dashboardData"]);
+          cy.wait("@dashboardData");
 
           QSHelpers.verifyDashcardCellValues({
             dashcardIndex: 0,
@@ -417,7 +417,7 @@ describe("scenarios > dashboard > filters > query stages", () => {
             cy.findByLabelText("Gadget").click();
             cy.button("Add filter").click();
           });
-          cy.wait(["@dashboardData", "@dashboardData"]);
+          cy.wait("@dashboardData");
 
           QSHelpers.verifyDashcardCellValues({
             dashcardIndex: 0,

--- a/e2e/test/scenarios/dashboard-filters-2/shared/dashboard-filters-query-stages.ts
+++ b/e2e/test/scenarios/dashboard-filters-2/shared/dashboard-filters-query-stages.ts
@@ -730,12 +730,33 @@ export function getDashboardId(): Cypress.Chainable<number> {
     .then((dashboardId) => dashboardId as unknown as number);
 }
 
-export function waitForPublicDashboardData(requestCount: number) {
-  cy.wait(Array(requestCount).fill("@publicDashboardData"));
+export function waitForPublicDashboardData(expectedCards: number) {
+  assertBatchCompletedCards("@publicDashboardData", expectedCards);
 }
 
-export function waitForEmbeddedDashboardData(requestCount: number) {
-  cy.wait(Array(requestCount).fill("@embeddedDashboardData"));
+export function waitForEmbeddedDashboardData(expectedCards: number) {
+  assertBatchCompletedCards("@embeddedDashboardData", expectedCards);
+}
+
+function assertBatchCompletedCards(alias: string, expectedCards: number) {
+  cy.wait(alias).then(({ request }) => {
+    // GET (public/embed) carries `cards` as a URL query param; POST (normal)
+    // carries it in the JSON body.
+    const fromQuery = (() => {
+      const cards = new URL(request.url).searchParams.get("cards");
+      if (!cards) {
+        return undefined;
+      }
+      try {
+        return JSON.parse(cards) as unknown[];
+      } catch {
+        return undefined;
+      }
+    })();
+    const fromBody = (request.body as { cards?: unknown[] })?.cards;
+    const cards = fromQuery ?? fromBody ?? [];
+    expect(cards, `${alias} cards[]`).to.have.length(expectedCards);
+  });
 }
 
 export function verifyDashcardMappingOptions(

--- a/e2e/test/scenarios/dashboard-filters-2/shared/dashboard-filters-query-stages.ts
+++ b/e2e/test/scenarios/dashboard-filters-2/shared/dashboard-filters-query-stages.ts
@@ -442,7 +442,7 @@ export function setup1stStageImplicitJoinFromSourceFilter() {
     cy.findAllByPlaceholderText("Enter a number").eq(1).type("16");
     cy.button("Add filter").click();
   });
-  cy.wait(["@dashboardData", "@dashboardData"]);
+  cy.wait("@dashboardData");
 }
 
 export function setup1stStageImplicitJoinFromJoinFilter() {
@@ -467,7 +467,7 @@ export function setup1stStageImplicitJoinFromJoinFilter() {
     cy.findByLabelText("Gadget").click();
     cy.button("Add filter").click();
   });
-  cy.wait(["@dashboardData", "@dashboardData"]);
+  cy.wait("@dashboardData");
 }
 
 export function setup1stStageCustomColumnFilter() {
@@ -495,7 +495,7 @@ export function setup1stStageCustomColumnFilter() {
     cy.findAllByPlaceholderText("Enter a number").eq(1).type("20");
     cy.button("Add filter").click();
   });
-  cy.wait(["@dashboardData", "@dashboardData"]);
+  cy.wait("@dashboardData");
 }
 
 export function setup1stStageAggregationFilter() {
@@ -523,7 +523,7 @@ export function setup1stStageAggregationFilter() {
     cy.findAllByPlaceholderText("Enter a number").eq(1).type("2");
     cy.button("Add filter").click();
   });
-  cy.wait(["@dashboardData", "@dashboardData"]);
+  cy.wait("@dashboardData");
 }
 
 export function setup1stStageBreakoutFilter() {
@@ -548,7 +548,7 @@ export function setup1stStageBreakoutFilter() {
     cy.findByLabelText("Gadget").click();
     cy.button("Add filter").click();
   });
-  cy.wait(["@dashboardData", "@dashboardData"]);
+  cy.wait("@dashboardData");
 }
 
 export function setup2ndStageExplicitJoinFilter() {
@@ -575,7 +575,7 @@ export function setup2ndStageExplicitJoinFilter() {
       cy.findByPlaceholderText("Search the list").type("abe.gorczany");
       cy.button("Add filter").click();
     });
-  cy.wait(["@dashboardData", "@dashboardData"]);
+  cy.wait("@dashboardData");
 }
 
 export function setup2ndStageCustomColumnFilter() {

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-auto-apply.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-auto-apply.cy.spec.js
@@ -513,15 +513,13 @@ const getParameterMapping = ({ card_id }, parameters) => ({
 });
 
 const openDashboard = (params = {}) => {
-  cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
-    "cardQuery",
-  );
+  H.interceptDashboardCardRequests({ alias: "cardQuery" });
 
   H.visitDashboard("@dashboardId", { params });
 };
 
 const openSlowPublicDashboard = (params = {}) => {
-  cy.intercept("GET", "/api/public/dashboard/*/dashcard/*/card/*").as(
+  cy.intercept("GET", "/api/public/dashboard/*/card-query-batch*").as(
     "cardQuery",
   );
 
@@ -533,7 +531,7 @@ const openSlowPublicDashboard = (params = {}) => {
 };
 
 const openSlowEmbeddingDashboard = (params = {}) => {
-  cy.intercept("GET", "/api/embed/dashboard/*/dashcard/*/card/*").as(
+  cy.intercept("GET", "/api/embed/dashboard/*/card-query-batch*").as(
     "cardQuery",
   );
 

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-auto-wiring.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-auto-wiring.cy.spec.js
@@ -451,11 +451,10 @@ describe("dashboard filters auto-wiring", () => {
 
   describe("adding cards with foreign keys to the dashboard (metabase#36275)", () => {
     beforeEach(() => {
-      cy.intercept(
-        "POST",
-        "/api/dashboard/*/dashcard/*/card/*/query",
-        cy.spy().as("cardQueryRequest"),
-      ).as("cardQuery");
+      cy.intercept("POST", "/api/dashboard/*/card-query-batch").as(
+        "batchQuery",
+      );
+      cy.intercept("POST", "/api/card/*/query").as("cardQuery");
 
       H.createQuestion({
         name: "Products Question",
@@ -526,7 +525,7 @@ describe("dashboard filters auto-wiring", () => {
         cy.button("Add filter").click();
       });
 
-      cy.wait("@cardQuery");
+      cy.wait("@batchQuery");
 
       H.getDashboardCard(0).within(() => {
         getTableCell("ID", 0).should("contain", "1");
@@ -576,7 +575,7 @@ describe("dashboard filters auto-wiring", () => {
         cy.button("Add filter").click();
       });
 
-      cy.wait("@cardQuery");
+      cy.wait("@batchQuery");
 
       H.getDashboardCard(0).within(() => {
         getTableCell("ID", 0).should("contain", "1");

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-date.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-date.cy.spec.js
@@ -1,8 +1,5 @@
 const { H } = cy;
-import {
-  ORDERS_DASHBOARD_DASHCARD_ID,
-  ORDERS_DASHBOARD_ID,
-} from "e2e/support/cypress_sample_instance_data";
+import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
 
 import * as DateFilter from "../native-filters/helpers/e2e-date-filter-helpers";
 
@@ -49,7 +46,7 @@ describe("scenarios > dashboard > filters > date", () => {
         });
 
         H.clearFilterWidget(index);
-        cy.wait(`@dashcardQuery${ORDERS_DASHBOARD_DASHCARD_ID}`);
+        cy.wait("@batchQuery");
       },
     );
   });

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-date.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-date.cy.spec.js
@@ -8,6 +8,7 @@ import { DASHBOARD_DATE_FILTERS } from "./shared/dashboard-filters-date";
 describe("scenarios > dashboard > filters > date", () => {
   beforeEach(() => {
     cy.intercept("GET", "/api/table/*/query_metadata").as("metadata");
+    H.interceptDashboardCardRequests({ alias: "batchQuery" });
 
     H.restore();
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-id.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-id.cy.spec.js
@@ -24,9 +24,7 @@ describe("scenarios > dashboard > filters > ID", () => {
      * If we set it before the visitDashboard, we'd have to wait for it after the visit,
      * otherwise we'd always be one wait behind in tests.
      */
-    cy.intercept("POST", "api/dashboard/*/dashcard/*/card/*/query").as(
-      "dashboardData",
-    );
+    H.interceptDashboardCardRequests({ alias: "dashboardData" });
   });
 
   describe("should work for the primary key", () => {

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-location.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-location.cy.spec.js
@@ -10,6 +10,7 @@ import { DASHBOARD_LOCATION_FILTERS } from "./shared/dashboard-filters-location"
 
 describe("scenarios > dashboard > filters > location", () => {
   beforeEach(() => {
+    H.interceptDashboardCardRequests({ alias: "batchQuery" });
     H.restore();
     cy.signInAsAdmin();
 

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-location.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-location.cy.spec.js
@@ -1,8 +1,5 @@
 const { H } = cy;
-import {
-  ORDERS_DASHBOARD_DASHCARD_ID,
-  ORDERS_DASHBOARD_ID,
-} from "e2e/support/cypress_sample_instance_data";
+import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
 
 import {
   addWidgetStringFilter,
@@ -43,7 +40,7 @@ describe("scenarios > dashboard > filters > location", () => {
         });
 
         H.clearFilterWidget(index);
-        cy.wait(`@dashcardQuery${ORDERS_DASHBOARD_DASHCARD_ID}`);
+        cy.wait("@batchQuery");
       },
     );
   });

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-nested.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-nested.cy.spec.js
@@ -8,9 +8,7 @@ describe("scenarios > dashboard > filters > nested questions", () => {
     H.restore();
     cy.signInAsAdmin();
     cy.intercept("POST", "/api/dataset").as("dataset");
-    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
-      "dashcardQuery",
-    );
+    H.interceptDashboardCardRequests();
   });
 
   it("dashboard filters should work on nested question (metabase#12614, metabase#13186, metabase#18113, metabase#32126)", () => {

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-number.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-number.cy.spec.js
@@ -24,9 +24,7 @@ describe("scenarios > dashboard > filters > number", () => {
      * If we set it before the visitDashboard, we'd have to wait for it after the visit,
      * otherwise we'd always be one wait behind in tests.
      */
-    cy.intercept("POST", "api/dashboard/*/dashcard/*/card/*/query").as(
-      "dashboardData",
-    );
+    H.interceptDashboardCardRequests({ alias: "dashboardData" });
   });
 
   it("should work when set through the filter widget", () => {

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-source.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-source.cy.spec.js
@@ -396,7 +396,8 @@ describe("scenarios > dashboard > filters", () => {
           cy.signInAsSandboxedUser();
           H.visitDashboard(card.dashboard_id);
           H.assertDatasetReqIsSandboxed({
-            requestAlias: `@dashcardQuery${card.id}`,
+            requestAlias: "@batchQuery",
+            dashcardId: card.id,
           });
         });
       },

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-date.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-date.cy.spec.js
@@ -9,9 +9,7 @@ import {
 
 describe("scenarios > dashboard > filters > SQL > date", () => {
   beforeEach(() => {
-    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
-      "dashcardQuery",
-    );
+    H.interceptDashboardCardRequests();
 
     H.restore();
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-location.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-location.cy.spec.js
@@ -13,9 +13,7 @@ import {
 
 describe("scenarios > dashboard > filters > location", () => {
   beforeEach(() => {
-    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
-      "dashcardQuery",
-    );
+    H.interceptDashboardCardRequests();
 
     H.restore();
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-number.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-number.cy.spec.js
@@ -9,9 +9,7 @@ import {
 
 describe("scenarios > dashboard > filters > SQL > text/category", () => {
   beforeEach(() => {
-    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
-      "dashcardQuery",
-    );
+    H.interceptDashboardCardRequests();
 
     H.restore();
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-text-category.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-text-category.cy.spec.js
@@ -13,9 +13,7 @@ const { PRODUCTS } = SAMPLE_DATABASE;
 
 describe("scenarios > dashboard > filters > SQL > text/category", () => {
   beforeEach(() => {
-    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
-      "dashcardQuery",
-    );
+    H.interceptDashboardCardRequests();
 
     H.restore();
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-text-category.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-text-category.cy.spec.js
@@ -262,7 +262,5 @@ describe("scenarios > dashboard > filters > text/category", () => {
 });
 
 function waitDashboardCardQuery() {
-  cy.get("@dashCardId").then((id) => {
-    cy.wait(`@dashcardQuery${id}`);
-  });
+  cy.wait("@batchQuery");
 }

--- a/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -393,11 +393,7 @@ describe("scenarios > dashboard > parameters", () => {
 
     const dashboardDetails = { parameters };
 
-    cy.intercept(
-      "POST",
-      "/api/dashboard/*/dashcard/*/card/*/query",
-      cy.spy().as("cardQueryRequest"),
-    ).as("cardQuery");
+    H.interceptDashboardCardRequests({ alias: "cardQuery" });
 
     cy.intercept(
       "GET",
@@ -622,11 +618,7 @@ describe("scenarios > dashboard > parameters", () => {
 
       const { interceptor } = H.spyRequestFinished("dashcardRequestSpy");
 
-      cy.intercept(
-        "POST",
-        "/api/dashboard/*/dashcard/*/card/*/query",
-        interceptor,
-      );
+      cy.intercept("POST", "/api/dashboard/*/card-query-batch", interceptor);
     });
 
     it("should not fetch dashcard data when filter is disconnected", () => {

--- a/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -443,7 +443,7 @@ describe("scenarios > dashboard > parameters", () => {
 
     cy.wait("@cardQuery");
     // Multiple filters shouldn't affect the number of card query requests (metabase#13150)
-    cy.get("@cardQueryRequest").should("have.been.calledOnce");
+    cy.get("@cardQuery.all").should("have.length", 1);
 
     // Open category dropdown
     H.filterWidget().contains("Widget").click();
@@ -638,7 +638,7 @@ describe("scenarios > dashboard > parameters", () => {
 
       H.saveDashboard();
 
-      cy.get("@dashcardRequestSpy").should("have.callCount", 2);
+      cy.get("@dashcardRequestSpy").should("have.callCount", 1);
     });
 
     it("should fetch dashcard data when parameter mapping is removed", () => {

--- a/e2e/test/scenarios/dashboard-filters/temporal-unit-parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/temporal-unit-parameters.cy.spec.js
@@ -212,9 +212,7 @@ describe("scenarios > dashboard > temporal unit parameters", () => {
     H.restore();
     cy.signInAsNormalUser();
 
-    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
-      "cardQuery",
-    );
+    H.interceptDashboardCardRequests({ alias: "cardQuery" });
     cy.intercept("GET", "/api/card/*/query_metadata").as("queryMetadata");
   });
 

--- a/e2e/test/scenarios/dashboard/dashboard-back-navigation.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-back-navigation.cy.spec.js
@@ -24,9 +24,7 @@ describe("scenarios > dashboard > dashboard back navigation", () => {
     cy.intercept("POST", "/api/card/*/query").as("cardQuery");
     cy.intercept("PUT", "/api/card/*").as("updateCard");
     cy.intercept("GET", "/api/dashboard/*").as("dashboard");
-    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
-      "dashcardQuery",
-    );
+    H.interceptDashboardCardRequests();
   });
 
   it("should display a back to the dashboard button when navigating to a question", () => {
@@ -245,9 +243,7 @@ describe(
       cy.signInAsAdmin();
       cy.intercept("GET", "/api/dashboard/*").as("dashboard");
       cy.intercept("GET", "/api/card/*").as("card");
-      cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
-        "dashcardQuery",
-      );
+      H.interceptDashboardCardRequests();
     });
 
     it("should preserve filter value when navigating between the dashboard and the question without re-fetch", () => {

--- a/e2e/test/scenarios/dashboard/dashboard-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-reproductions.cy.spec.js
@@ -205,13 +205,16 @@ describe("issue 12926", () => {
         cy.visit(`/dashboard/${dashboard_id}`);
       });
 
+      // The batch endpoint uses fetch + AbortController rather than XHR.abort,
+      // so we spy on AbortController.abort to verify the in-flight request
+      // gets cancelled when the card is removed.
       cy.window().then((win) => {
-        cy.spy(win.XMLHttpRequest.prototype, "abort").as("xhrAbort");
+        cy.spy(win.AbortController.prototype, "abort").as("abortCtrl");
       });
 
       removeCard();
 
-      cy.get("@xhrAbort").should("have.been.calledOnce");
+      cy.get("@abortCtrl").should("have.been.called");
     });
 
     it("should re-fetch the query when doing undo on the removal", () => {
@@ -545,7 +548,7 @@ describe("issue 17879", () => {
     }).then(({ dashboard }) => {
       cy.intercept(
         "POST",
-        `/api/dashboard/${dashboard.id}/dashcard/*/card/*/query`,
+        `/api/dashboard/${dashboard.id}/card-query-batch`,
       ).as("getCardQuery");
 
       H.visitDashboard(dashboard.id);
@@ -632,7 +635,7 @@ describe("issue 21830", () => {
     cy.intercept(
       {
         method: "POST",
-        url: "/api/dashboard/*/dashcard/*/card/*/query",
+        url: "/api/dashboard/*/card-query-batch",
         middleware: true,
       },
       (req) => {

--- a/e2e/test/scenarios/dashboard/dashboard-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-reproductions.cy.spec.js
@@ -5,6 +5,7 @@ const { H } = cy;
 import { SAMPLE_DB_ID, USERS, USER_GROUPS } from "e2e/support/cypress_data";
 import {
   ORDERS_COUNT_QUESTION_ID,
+  ORDERS_DASHBOARD_DASHCARD_ID,
   ORDERS_DASHBOARD_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
@@ -178,6 +179,11 @@ describe("issue 12926", () => {
       // calling req.continue() will make cypress skip all previously added intercepts
       req.continue();
     }).as("dashcardQueryRestored");
+    // Card re-runs triggered by `undoRemoveCardFromDashboard` hit the
+    // per-card endpoint.
+    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query", (req) =>
+      req.continue(),
+    ).as("dashcardQueryRestoredSingle");
   }
 
   function removeCard() {
@@ -232,7 +238,7 @@ describe("issue 12926", () => {
 
       H.undo();
 
-      cy.wait("@dashcardQueryRestored");
+      cy.wait("@dashcardQueryRestoredSingle");
 
       H.getDashboardCard().findByText(queryResult);
     });
@@ -319,7 +325,10 @@ describe("issue 13736", () => {
         `/api/dashboard/${dashboardId}/card-query-batch`,
         (req) => {
           req.continue((res) => {
-            // Modify the response to inject an error for the failing card
+            // The batch endpoint emits NDJSON (one JSON object per line) with
+            // card-begin/card-rows/card-end/card-error/complete events. Rewrite
+            // the failing card's begin/rows/end into a single card-error.
+            const seenError = new Set();
             const body = res.body
               .split("\n")
               .map((line) => {
@@ -327,12 +336,20 @@ describe("issue 13736", () => {
                   return line;
                 }
                 try {
-                  const event = JSON.parse(line.replace(/^data: /, ""));
+                  const event = JSON.parse(line);
+                  if (event.card_id !== failingQuestionId) {
+                    return line;
+                  }
                   if (
-                    event.type === "card-result" &&
-                    event.card_id === failingQuestionId
+                    event.type === "card-begin" ||
+                    event.type === "card-rows" ||
+                    event.type === "card-end"
                   ) {
-                    return `data: ${JSON.stringify({
+                    if (seenError.has(event.dashcard_id)) {
+                      return "";
+                    }
+                    seenError.add(event.dashcard_id);
+                    return JSON.stringify({
                       type: "card-error",
                       dashcard_id: event.dashcard_id,
                       card_id: failingQuestionId,
@@ -341,13 +358,14 @@ describe("issue 13736", () => {
                         data: {},
                         message: "some error",
                       },
-                    })}`;
+                    });
                   }
                   return line;
                 } catch {
                   return line;
                 }
               })
+              .filter((line, i, all) => line !== "" || i === all.length - 1)
               .join("\n");
             res.send(body);
           });
@@ -785,6 +803,7 @@ describe("issue 29076", () => {
     H.assertQueryBuilderRowCount(1); // test that user is sandboxed - normal users has over 2000 rows
     H.assertDatasetReqIsSandboxed({
       requestAlias: "@cardQuery",
+      dashcardId: ORDERS_DASHBOARD_DASHCARD_ID,
       columnId: ORDERS.USER_ID,
       columnAssertion: Number(USERS.sandboxed.login_attributes.attr_uid),
     });

--- a/e2e/test/scenarios/dashboard/dashboard-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-reproductions.cy.spec.js
@@ -51,7 +51,7 @@ describe("issue 12578", () => {
     H.popover().findByText("1 minute").click();
 
     // Mock slow card request
-    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query", (req) => {
+    cy.intercept("POST", "/api/dashboard/*/card-query-batch", (req) => {
       req.on("response", (res) => {
         res.setDelay(99999);
       });
@@ -166,7 +166,7 @@ describe("issue 12926", () => {
   };
 
   function slowDownDashcardQuery() {
-    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query", (req) => {
+    cy.intercept("POST", "/api/dashboard/*/card-query-batch", (req) => {
       req.on("response", (res) => {
         res.setDelay(5000);
       });
@@ -174,7 +174,7 @@ describe("issue 12926", () => {
   }
 
   function restoreDashcardQuery() {
-    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query", (req) => {
+    cy.intercept("POST", "/api/dashboard/*/card-query-batch", (req) => {
       // calling req.continue() will make cypress skip all previously added intercepts
       req.continue();
     }).as("dashcardQueryRestored");
@@ -313,14 +313,41 @@ describe("issue 13736", () => {
 
       cy.intercept(
         "POST",
-        `/api/dashboard/*/dashcard/*/card/${failingQuestionId}/query`,
-        {
-          statusCode: 500,
-          body: {
-            cause: "some error",
-            data: {},
-            message: "some error",
-          },
+        `/api/dashboard/${dashboardId}/card-query-batch`,
+        (req) => {
+          req.continue((res) => {
+            // Modify the response to inject an error for the failing card
+            const body = res.body
+              .split("\n")
+              .map((line) => {
+                if (!line) {
+                  return line;
+                }
+                try {
+                  const event = JSON.parse(line.replace(/^data: /, ""));
+                  if (
+                    event.type === "card-result" &&
+                    event.card_id === failingQuestionId
+                  ) {
+                    return `data: ${JSON.stringify({
+                      type: "card-error",
+                      dashcard_id: event.dashcard_id,
+                      card_id: failingQuestionId,
+                      error: {
+                        cause: "some error",
+                        data: {},
+                        message: "some error",
+                      },
+                    })}`;
+                  }
+                  return line;
+                } catch {
+                  return line;
+                }
+              })
+              .join("\n");
+            res.send(body);
+          });
         },
       );
 
@@ -561,9 +588,7 @@ describe("issue 17879", () => {
     H.restore();
     cy.signInAsAdmin();
 
-    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
-      "dashcardQuery",
-    );
+    H.interceptDashboardCardRequests();
   });
 
   it("should map dashcard date parameter to correct date range filter in target question - month -> day (metabase#17879)", () => {
@@ -713,7 +738,7 @@ describe("issue 29076", () => {
   beforeEach(() => {
     H.restore();
 
-    cy.intercept("/api/dashboard/*/dashcard/*/card/*/query").as("cardQuery");
+    H.interceptDashboardCardRequests({ alias: "cardQuery" });
 
     cy.signInAsAdmin();
     H.activateToken("pro-self-hosted");
@@ -1033,9 +1058,7 @@ describe("issue 34382", () => {
     H.restore();
     cy.signInAsNormalUser();
 
-    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
-      "dashcardQuery",
-    );
+    H.interceptDashboardCardRequests();
   });
 
   it("should preserve filter value when navigating between the dashboard and the query builder with auto-apply disabled (metabase#34382)", () => {
@@ -1332,9 +1355,7 @@ describe("issue 39863", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();
-    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
-      "dashcardQuery",
-    );
+    H.interceptDashboardCardRequests();
   });
 
   it("should not rerun queries when switching tabs and there are no parameter changes", () => {
@@ -1518,9 +1539,7 @@ describe("issue 42165", () => {
     cy.signInAsAdmin();
 
     cy.intercept("POST", "/api/dataset").as("dataset");
-    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
-      "dashcardQuery",
-    );
+    H.interceptDashboardCardRequests();
 
     H.createDashboardWithQuestions({
       dashboardDetails: {
@@ -2053,9 +2072,7 @@ describe("issue 62170", () => {
       cy.intercept("GET", `/api/dashboard/${dashboard_id}*`).as(
         "dashboardLoad",
       );
-      cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
-        "cardDataRefresh",
-      );
+      H.interceptDashboardCardRequests({ alias: "cardDataRefresh" });
     });
 
     // Wait for initial dashboard load

--- a/e2e/test/scenarios/dashboard/tabs.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/tabs.cy.spec.js
@@ -5,7 +5,6 @@ import {
   NORMAL_PERSONAL_COLLECTION_ID,
   ORDERS_BY_YEAR_QUESTION_ID,
   ORDERS_COUNT_QUESTION_ID,
-  ORDERS_DASHBOARD_DASHCARD_ID,
   ORDERS_DASHBOARD_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
@@ -386,24 +385,7 @@ describe("scenarios > dashboard > tabs", () => {
 
     H.saveDashboard();
 
-    cy.wait("@saveDashboardCards").then(({ response }) => {
-      cy.wrap(response.body.dashcards[1].id).as("secondTabDashcardId");
-    });
-
-    // it's possible to have two requests firing (but first one is canceled before running second)
-    cy.intercept(
-      "POST",
-      `/api/dashboard/${ORDERS_DASHBOARD_ID}/dashcard/${ORDERS_DASHBOARD_DASHCARD_ID}/card/${ORDERS_QUESTION_ID}/query`,
-      cy.spy().as("firstTabQuerySpy"),
-    ).as("firstTabQuery");
-
-    cy.get("@secondTabDashcardId").then((secondTabDashcardId) => {
-      cy.intercept(
-        "POST",
-        `/api/dashboard/${ORDERS_DASHBOARD_ID}/dashcard/${secondTabDashcardId}/card/${ORDERS_COUNT_QUESTION_ID}/query`,
-        cy.spy().as("secondTabQuerySpy"),
-      ).as("secondTabQuery");
-    });
+    cy.wait("@saveDashboardCards");
 
     const firstQuestion = () => {
       return cy.request("GET", `/api/card/${ORDERS_QUESTION_ID}`).its("body");
@@ -424,41 +406,38 @@ describe("scenarios > dashboard > tabs", () => {
     // Visit first tab and confirm only first card was queried
     H.visitDashboard(ORDERS_DASHBOARD_ID);
 
-    cy.get("@firstTabQuerySpy").should("have.been.calledOnce");
-    cy.get("@secondTabQuerySpy").should("not.have.been.called");
-    cy.wait("@firstTabQuery").then((r) => {
-      firstQuestion().then((r) => {
-        expect(r.view_count).to.equal(2); // 1 (previously) + 1 (firstQuestion)
-      });
-      secondQuestion().then((r) => {
-        expect(r.view_count).to.equal(1); // 1 (previously)
-      });
+    firstQuestion().then((r) => {
+      expect(r.view_count).to.equal(2); // 1 (previously) + 1 (first tab query)
+    });
+    secondQuestion().then((r) => {
+      expect(r.view_count).to.equal(1); // not queried (on tab 2)
     });
 
     // Visit second tab and confirm only second card was queried
-    H.goToTab("Tab 2");
-    cy.get("@secondTabQuerySpy").should("have.been.calledOnce");
-    cy.get("@firstTabQuerySpy").should("have.been.calledOnce");
-    cy.wait("@secondTabQuery").then((r) => {
-      firstQuestion().then((r) => {
-        expect(r.view_count).to.equal(2); // 2 (previously)
-      });
-      secondQuestion().then((r) => {
-        expect(r.view_count).to.equal(2); // 1(previously) + 1 (secondTabQuery)
-      });
-    });
+    cy.intercept(
+      "POST",
+      `/api/dashboard/${ORDERS_DASHBOARD_ID}/card-query-batch`,
+    ).as("secondTabBatch");
 
-    // Go back to first tab, expect no additional queries
-    H.goToTab("Tab 1");
-    cy.findAllByTestId("dashcard").contains("37.65");
-    cy.get("@firstTabQuerySpy").should("have.been.calledOnce");
-    cy.get("@secondTabQuerySpy").should("have.been.calledOnce");
+    H.goToTab("Tab 2");
+    cy.wait("@secondTabBatch");
 
     firstQuestion().then((r) => {
-      expect(r.view_count).to.equal(2); // 2 (previously)
+      expect(r.view_count).to.equal(2); // unchanged
     });
     secondQuestion().then((r) => {
-      expect(r.view_count).to.equal(2); // 2 (previously)
+      expect(r.view_count).to.equal(2); // 1 (previously) + 1 (second tab query)
+    });
+
+    // Go back to first tab, expect no additional queries (cached)
+    H.goToTab("Tab 1");
+    cy.findAllByTestId("dashcard").contains("37.65");
+
+    firstQuestion().then((r) => {
+      expect(r.view_count).to.equal(2); // unchanged
+    });
+    secondQuestion().then((r) => {
+      expect(r.view_count).to.equal(2); // unchanged
     });
 
     // Go to public dashboard
@@ -467,50 +446,46 @@ describe("scenarios > dashboard > tabs", () => {
       "POST",
       `/api/dashboard/${ORDERS_DASHBOARD_ID}/public_link`,
     ).then(({ body: { uuid } }) => {
-      cy.intercept(
-        "GET",
-        `/api/public/dashboard/${uuid}/dashcard/${ORDERS_DASHBOARD_DASHCARD_ID}/card/${ORDERS_QUESTION_ID}?parameters=%5B%5D`,
-        cy.spy().as("publicFirstTabQuerySpy"),
-      ).as("publicFirstTabQuery");
-      cy.get("@secondTabDashcardId").then((secondTabDashcardId) => {
-        cy.intercept(
-          "GET",
-          `/api/public/dashboard/${uuid}/dashcard/${secondTabDashcardId}/card/${ORDERS_COUNT_QUESTION_ID}?parameters=%5B%5D`,
-          cy.spy().as("publicSecondTabQuerySpy"),
-        ).as("publicSecondTabQuery");
-      });
+      cy.intercept("GET", `/api/public/dashboard/${uuid}/card-query-batch*`).as(
+        "publicFirstTabBatch",
+      );
 
       cy.visit(`public/dashboard/${uuid}`);
     });
 
+    cy.wait("@publicFirstTabBatch");
+
     // Check first tab requests
-    cy.get("@publicFirstTabQuerySpy").should("have.been.calledOnce");
-    cy.get("@publicSecondTabQuerySpy").should("not.have.been.called");
-    cy.wait("@publicFirstTabQuery").then((r) => {
-      firstQuestion().then((r) => {
-        expect(r.view_count).to.equal(3); // 2 (previously) + 1 (publicFirstTabQuery)
-      });
-      secondQuestion().then((r) => {
-        expect(r.view_count).to.equal(2); // 2 (previously)
-      });
+    firstQuestion().then((r) => {
+      expect(r.view_count).to.equal(3); // 2 (previously) + 1 (public first tab query)
+    });
+    secondQuestion().then((r) => {
+      expect(r.view_count).to.equal(2); // unchanged
     });
 
     // Visit second tab and confirm only second card was queried
+    cy.intercept("GET", "/api/public/dashboard/*/card-query-batch*").as(
+      "publicSecondTabBatch",
+    );
+
     H.goToTab("Tab 2");
-    cy.get("@publicSecondTabQuerySpy").should("have.been.calledOnce");
-    cy.get("@publicFirstTabQuerySpy").should("have.been.calledOnce");
-    cy.wait("@publicSecondTabQuery").then((r) => {
-      firstQuestion().then((r) => {
-        expect(r.view_count).to.equal(3); // 3 (previously)
-      });
-      secondQuestion().then((r) => {
-        expect(r.view_count).to.equal(3); // 2 (previously) + 1 (publicSecondTabQuery)
-      });
+    cy.wait("@publicSecondTabBatch");
+
+    firstQuestion().then((r) => {
+      expect(r.view_count).to.equal(3); // unchanged
+    });
+    secondQuestion().then((r) => {
+      expect(r.view_count).to.equal(3); // 2 (previously) + 1 (public second tab query)
     });
 
     H.goToTab("Tab 1");
-    cy.get("@publicFirstTabQuerySpy").should("have.been.calledOnce");
-    cy.get("@publicSecondTabQuerySpy").should("have.been.calledOnce");
+    // No new queries - data cached
+    firstQuestion().then((r) => {
+      expect(r.view_count).to.equal(3); // unchanged
+    });
+    secondQuestion().then((r) => {
+      expect(r.view_count).to.equal(3); // unchanged
+    });
   });
 
   it("should only fetch cards on the current tab of an embedded dashboard", () => {
@@ -530,9 +505,7 @@ describe("scenarios > dashboard > tabs", () => {
     });
     cy.wait("@cardQuery");
     H.saveDashboard();
-    cy.wait("@saveDashboardCards").then(({ response }) => {
-      cy.wrap(response.body.dashcards[1].id).as("secondTabDashcardId");
-    });
+    cy.wait("@saveDashboardCards");
 
     const firstQuestion = () => {
       return cy.request("GET", `/api/card/${ORDERS_QUESTION_ID}`).its("body");
@@ -543,16 +516,9 @@ describe("scenarios > dashboard > tabs", () => {
         .its("body");
     };
 
-    cy.intercept(
-      "GET",
-      `/api/embed/dashboard/*/dashcard/*/card/${ORDERS_QUESTION_ID}*`,
-      cy.spy().as("firstTabQuerySpy"),
-    ).as("firstTabQuery");
-    cy.intercept(
-      "GET",
-      `/api/embed/dashboard/*/dashcard/*/card/${ORDERS_COUNT_QUESTION_ID}*`,
-      cy.spy().as("secondTabQuerySpy"),
-    ).as("secondTabQuery");
+    cy.intercept("GET", "/api/embed/dashboard/*/card-query-batch*").as(
+      "embedFirstTabBatch",
+    );
 
     H.openLegacyStaticEmbeddingModal({
       resource: "dashboard",
@@ -567,33 +533,36 @@ describe("scenarios > dashboard > tabs", () => {
     // wait for results
     cy.findAllByTestId("dashcard").contains("37.65");
     cy.signInAsAdmin();
-    cy.get("@firstTabQuerySpy").should("have.been.calledOnce");
-    cy.get("@secondTabQuerySpy").should("not.have.been.called");
 
-    cy.wait("@firstTabQuery").then((r) => {
-      firstQuestion().then((r) => {
-        expect(r.view_count).to.equal(3); // 1 (previously) + 1 (firstQuestion) + 1 (first tab query)
-      });
-      secondQuestion().then((r) => {
-        expect(r.view_count).to.equal(1); // 1 (previously)
-      });
+    firstQuestion().then((r) => {
+      expect(r.view_count).to.equal(3); // 1 (previously) + 1 (firstQuestion) + 1 (embed first tab query)
+    });
+    secondQuestion().then((r) => {
+      expect(r.view_count).to.equal(1); // not queried (on tab 2)
     });
 
+    cy.intercept("GET", "/api/embed/dashboard/*/card-query-batch*").as(
+      "embedSecondTabBatch",
+    );
+
     H.goToTab("Tab 2");
-    cy.get("@secondTabQuerySpy").should("have.been.calledOnce");
-    cy.get("@firstTabQuerySpy").should("have.been.calledOnce");
-    cy.wait("@secondTabQuery").then((r) => {
-      firstQuestion().then((r) => {
-        expect(r.view_count).to.equal(3); // 3 (previously)
-      });
-      secondQuestion().then((r) => {
-        expect(r.view_count).to.equal(2); // 1 (previously) + 1 (second tab query)
-      });
+    cy.wait("@embedSecondTabBatch");
+
+    firstQuestion().then((r) => {
+      expect(r.view_count).to.equal(3); // unchanged
+    });
+    secondQuestion().then((r) => {
+      expect(r.view_count).to.equal(2); // 1 (previously) + 1 (embed second tab query)
     });
 
     H.goToTab("Tab 1");
-    cy.get("@firstTabQuerySpy").should("have.been.calledOnce");
-    cy.get("@secondTabQuerySpy").should("have.been.calledOnce");
+    // No new queries - data cached
+    firstQuestion().then((r) => {
+      expect(r.view_count).to.equal(3); // unchanged
+    });
+    secondQuestion().then((r) => {
+      expect(r.view_count).to.equal(2); // unchanged
+    });
   });
 
   it("should apply filter and show loading spinner when changing tabs (#33767)", () => {
@@ -616,9 +585,9 @@ describe("scenarios > dashboard > tabs", () => {
 
     cy.intercept(
       "POST",
-      "/api/dashboard/*/dashcard/*/card/*/query",
+      "/api/dashboard/*/card-query-batch",
       delayResponse(500),
-    ).as("saveCard");
+    ).as("batchQuery");
 
     H.filterWidget().click();
     H.popover().findByText("Previous 7 days").click();
@@ -626,7 +595,7 @@ describe("scenarios > dashboard > tabs", () => {
     // Loader in the 2nd tab
     H.getDashboardCard(0).within(() => {
       cy.findByTestId("loading-indicator").should("exist");
-      cy.wait("@saveCard");
+      cy.wait("@batchQuery");
       cy.findAllByRole("row").should("exist");
     });
 

--- a/e2e/test/scenarios/dashboard/title-drill.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/title-drill.cy.spec.js
@@ -248,10 +248,7 @@ describe("scenarios > dashboard > title drill", () => {
 
           H.editDashboardCard(dashboardCard, mapFiltersToCard);
 
-          cy.intercept(
-            "POST",
-            `/api/dashboard/${dashboard_id}/dashcard/*/card/${card_id}/query`,
-          ).as("cardQuery");
+          H.interceptDashboardCardRequests({ alias: "cardQuery" });
 
           H.visitDashboard(dashboard_id);
         },

--- a/e2e/test/scenarios/dashboard/visualizer/basics.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/basics.cy.spec.ts
@@ -32,9 +32,7 @@ describe("scenarios > dashboard > visualizer > basics", () => {
 
     cy.intercept("POST", "/api/dataset").as("dataset");
     cy.intercept("POST", "/api/card/*/query").as("cardQuery");
-    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
-      "dashcardQuery",
-    );
+    H.interceptDashboardCardRequests();
     cy.intercept("GET", "/api/setting/version-info", {});
 
     cy.signInAsNormalUser();

--- a/e2e/test/scenarios/dashboard/visualizer/cartesian.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/cartesian.cy.spec.ts
@@ -23,9 +23,7 @@ describe("scenarios > dashboard > visualizer > cartesian", () => {
 
     cy.intercept("POST", "/api/dataset").as("dataset");
     cy.intercept("POST", "/api/card/*/query").as("cardQuery");
-    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
-      "dashcardQuery",
-    );
+    H.interceptDashboardCardRequests();
 
     cy.signInAsNormalUser();
 

--- a/e2e/test/scenarios/dashboard/visualizer/columns-mapping.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/columns-mapping.cy.spec.ts
@@ -13,9 +13,7 @@ describe("scenarios > dashboard > visualizer > columns-mapping", () => {
 
     cy.intercept("POST", "/api/dataset").as("dataset");
     cy.intercept("POST", "/api/card/*/query").as("cardQuery");
-    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
-      "dashcardQuery",
-    );
+    H.interceptDashboardCardRequests();
 
     cy.signInAsNormalUser();
 

--- a/e2e/test/scenarios/dashboard/visualizer/drillthrough.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/drillthrough.cy.spec.ts
@@ -18,9 +18,7 @@ describe("scenarios > dashboard > visualizer > drillthrough", () => {
 
     cy.intercept("POST", "/api/dataset").as("dataset");
     cy.intercept("POST", "/api/card/*/query").as("cardQuery");
-    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
-      "dashcardQuery",
-    );
+    H.interceptDashboardCardRequests();
 
     cy.signInAsNormalUser();
 

--- a/e2e/test/scenarios/dashboard/visualizer/filters.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/filters.cy.spec.ts
@@ -11,9 +11,7 @@ describe("scenarios > dashboard > visualizer > filters", () => {
 
     cy.intercept("POST", "/api/dataset").as("dataset");
     cy.intercept("POST", "/api/card/*/query").as("cardQuery");
-    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
-      "dashcardQuery",
-    );
+    H.interceptDashboardCardRequests();
 
     cy.signInAsNormalUser();
 

--- a/e2e/test/scenarios/dashboard/visualizer/funnel-title-navigation.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/funnel-title-navigation.cy.spec.ts
@@ -6,9 +6,7 @@ describe("scenarios > dashboard > visualizer > funnel title navigation", () => {
   beforeEach(() => {
     H.restore();
 
-    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
-      "dashcardQuery",
-    );
+    H.interceptDashboardCardRequests();
 
     cy.signInAsNormalUser();
   });

--- a/e2e/test/scenarios/dashboard/visualizer/funnels.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/funnels.cy.spec.ts
@@ -18,9 +18,7 @@ describe("scenarios > dashboard > visualizer > funnels", () => {
 
     cy.intercept("POST", "/api/dataset").as("dataset");
     cy.intercept("POST", "/api/card/*/query").as("cardQuery");
-    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
-      "dashcardQuery",
-    );
+    H.interceptDashboardCardRequests();
 
     cy.signInAsNormalUser();
 

--- a/e2e/test/scenarios/dashboard/visualizer/pie.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/pie.cy.spec.ts
@@ -18,9 +18,7 @@ describe("scenarios > dashboard > visualizer > pie", () => {
 
     cy.intercept("POST", "/api/dataset").as("dataset");
     cy.intercept("POST", "/api/card/*/query").as("cardQuery");
-    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
-      "dashcardQuery",
-    );
+    H.interceptDashboardCardRequests();
 
     cy.signInAsNormalUser();
 

--- a/e2e/test/scenarios/dashboard/visualizer/snowplow-tracking.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/visualizer/snowplow-tracking.cy.spec.ts
@@ -18,9 +18,7 @@ describe("Snowplow tracking", () => {
 
       cy.intercept("POST", "/api/dataset").as("dataset");
       cy.intercept("POST", "/api/card/*/query").as("cardQuery");
-      cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
-        "dashcardQuery",
-      );
+      H.interceptDashboardCardRequests();
       cy.intercept("GET", "/api/setting/version-info", {});
 
       cy.signInAsNormalUser();

--- a/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
+++ b/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
@@ -24,7 +24,9 @@ describe("scenarios > embedding > full app", () => {
     cy.signInAsAdmin();
     H.activateToken("pro-self-hosted");
     cy.intercept("POST", "/api/card/*/query").as("getCardQuery");
-    cy.intercept("POST", "/api/dashboard/**/query").as("getDashCardQuery");
+    cy.intercept("POST", "/api/dashboard/*/card-query-batch").as(
+      "getDashCardBatch",
+    );
     cy.intercept("GET", "/api/dashboard/*").as("getDashboard");
     cy.intercept("GET", "/api/automagic-dashboards/**").as("getXrayDashboard");
   });
@@ -1992,7 +1994,7 @@ const visitQuestionUrl = (urlOptions) => {
 const visitDashboardUrl = (urlOptions) => {
   H.visitFullAppEmbeddingUrl(urlOptions);
   cy.wait("@getDashboard");
-  cy.wait("@getDashCardQuery");
+  cy.wait("@getDashCardBatch");
 };
 
 const visitXrayDashboardUrl = (urlOptions) => {

--- a/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions-1.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions-1.cy.spec.js
@@ -1741,9 +1741,7 @@ describe("issue 25374", () => {
 
   beforeEach(() => {
     cy.intercept("POST", "/api/card/*/query").as("cardQuery");
-    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card//*/query").as(
-      "dashcardQuery",
-    );
+    H.interceptDashboardCardRequests({ alias: "dashcardQuery" });
 
     H.restore();
     cy.signInAsAdmin();
@@ -2315,7 +2313,7 @@ describe("issues 29347, 29346", () => {
   describe("regular dashboards", () => {
     beforeEach(() => {
       cy.intercept("GET", "/api/dashboard/*").as("dashboard");
-      cy.intercept("POST", "/api/dashboard/**/card/*/query").as("cardQuery");
+      H.interceptDashboardCardRequests({ alias: "cardQuery" });
     });
 
     it("should be able to filter on remapped values (metabase#29347, metabase#29346)", () => {
@@ -2346,7 +2344,9 @@ describe("issues 29347, 29346", () => {
   describe("embedded dashboards", () => {
     beforeEach(() => {
       cy.intercept("GET", "/api/embed/dashboard/*").as("dashboard");
-      cy.intercept("GET", "/api/embed/dashboard/**/card/*").as("cardQuery");
+      cy.intercept("GET", "/api/embed/dashboard/*/card-query-batch*").as(
+        "cardQuery",
+      );
     });
 
     it("should be able to filter on remapped values (metabase#29347, metabase#29346)", () => {
@@ -2405,7 +2405,9 @@ describe("issues 29347, 29346", () => {
   describe("public dashboards", () => {
     beforeEach(() => {
       cy.intercept("GET", "/api/public/dashboard/*").as("dashboard");
-      cy.intercept("GET", "/api/public/dashboard/**/card/*").as("cardQuery");
+      cy.intercept("GET", "/api/public/dashboard/*/card-query-batch*").as(
+        "cardQuery",
+      );
     });
 
     it("should be able to filter on remapped values (metabase#29347, metabase#29346)", () => {

--- a/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions-1.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions-1.cy.spec.js
@@ -116,16 +116,11 @@ describe("issue 8030 + 32444", () => {
     });
   };
 
-  const interceptRequests = ({ dashboard_id, card1_id, card2_id }) => {
+  const interceptRequests = ({ dashboard_id }) => {
     cy.intercept("GET", `/api/dashboard/${dashboard_id}*`).as("getDashboard");
-    cy.intercept(
-      "POST",
-      `/api/dashboard/${dashboard_id}/dashcard/*/card/${card1_id}/query`,
-    ).as("getCardQuery1");
-    cy.intercept(
-      "POST",
-      `/api/dashboard/${dashboard_id}/dashcard/*/card/${card2_id}/query`,
-    ).as("getCardQuery2");
+    cy.intercept("POST", `/api/dashboard/${dashboard_id}/card-query-batch`).as(
+      "getBatch",
+    );
   };
 
   const addFilterValue = (value) => {
@@ -143,12 +138,14 @@ describe("issue 8030 + 32444", () => {
     it("should not reload dashboard cards not connected to a filter (metabase#8030)", () => {
       createQuestionsAndDashboard().then(
         ({ dashboard_id, card1_id, card2_id }) => {
-          interceptRequests({ dashboard_id, card1_id, card2_id });
+          interceptRequests({ dashboard_id });
           setFilterMapping({ dashboard_id, card1_id, card2_id }).then(() => {
             cy.visit(`/dashboard/${dashboard_id}`);
             cy.wait("@getDashboard");
-            cy.wait("@getCardQuery1");
-            cy.wait("@getCardQuery2");
+            cy.wait("@getBatch").then(({ request }) => {
+              const cardIds = request.body.cards.map((c) => c.card_id);
+              expect(cardIds).to.have.members([card1_id, card2_id]);
+            });
 
             cy.findByText(filterDetails.name).click();
             H.dashboardParametersPopover().within(() => {
@@ -156,9 +153,11 @@ describe("issue 8030 + 32444", () => {
               cy.findByPlaceholderText("Enter an ID").type("1");
               cy.button("Add filter").click();
             });
-            cy.wait("@getCardQuery1");
-            cy.get("@getCardQuery1.all").should("have.length", 2);
-            cy.get("@getCardQuery2.all").should("have.length", 1);
+            cy.wait("@getBatch").then(({ request }) => {
+              const cardIds = request.body.cards.map((c) => c.card_id);
+              expect(cardIds).to.deep.equal([card1_id]);
+            });
+            cy.get("@getBatch.all").should("have.length", 2);
           });
         },
       );
@@ -177,13 +176,14 @@ describe("issue 8030 + 32444", () => {
       }).then(({ dashboard }) => {
         cy.intercept(
           "POST",
-          `/api/dashboard/${dashboard.id}/dashcard/*/card/*/query`,
-        ).as("getCardQuery");
+          `/api/dashboard/${dashboard.id}/card-query-batch`,
+        ).as("getBatch");
 
         H.visitDashboard(dashboard.id);
+        cy.wait("@getBatch").then(({ request }) => {
+          expect(request.body.cards).to.have.length(2);
+        });
         H.editDashboard(dashboard.id);
-
-        cy.get("@getCardQuery.all").should("have.length", 2);
 
         H.setFilter("Text or Category", "Is");
         H.selectDashboardFilter(
@@ -200,19 +200,15 @@ describe("issue 8030 + 32444", () => {
 
         H.saveDashboard();
 
-        cy.wait("@getCardQuery");
-
-        // Reset the intercept after save so we only count filter-triggered queries.
-        cy.intercept(
-          "POST",
-          `/api/dashboard/${dashboard.id}/dashcard/*/card/*/query`,
-        ).as("getCardQueryAfterFilter");
+        cy.wait("@getBatch");
+        cy.get("@getBatch.all").should("have.length", 2);
 
         addFilterValue("Aerodynamic Bronze Hat");
 
-        cy.wait("@getCardQueryAfterFilter");
-        // Only the card connected to the filter should re-execute.
-        cy.get("@getCardQueryAfterFilter.all").should("have.length", 1);
+        cy.wait("@getBatch").then(({ request }) => {
+          expect(request.body.cards).to.have.length(1);
+        });
+        cy.get("@getBatch.all").should("have.length", 3);
       });
     });
   });
@@ -1932,7 +1928,7 @@ describe("issue 25908", () => {
       ({ body: { id, card_id, dashboard_id } }) => {
         cy.intercept(
           "POST",
-          `/api/dashboard/${dashboard_id}/dashcard/${id}/card/${card_id}/query`,
+          `/api/dashboard/${dashboard_id}/card-query-batch`,
         ).as("dashcardQuery");
 
         cy.request("PUT", `/api/dashboard/${dashboard_id}`, {

--- a/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions-2.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/dashboard-filters-reproductions-2.cy.spec.js
@@ -1487,9 +1487,7 @@ describe("issue 40396", { tags: "@external " }, () => {
     H.resetTestTable({ type: "postgres", table: tableName });
     cy.signInAsAdmin();
     H.resyncDatabase({ dbId: WRITABLE_DB_ID });
-    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
-      "dashcardQuery",
-    );
+    H.interceptDashboardCardRequests({ alias: "dashcardQuery" });
   });
 
   it("should be possible to use dashboard filters with native enum fields (metabase#40396)", () => {
@@ -1687,7 +1685,7 @@ describe("issue 17061", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();
-    cy.intercept("GET", "/api/public/dashboard/*/dashcard/*/card/*").as(
+    cy.intercept("GET", "/api/public/dashboard/*/card-query-batch*").as(
       "publicDashcardData",
     );
   });

--- a/e2e/test/scenarios/models/reproductions.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions.cy.spec.js
@@ -566,9 +566,7 @@ describe("issue 29517 - nested question based on native model with remapped valu
   });
 
   it("click behavior to custom destination should work (metabase#29517-2)", () => {
-    cy.intercept("/api/dashboard/*/dashcard/*/card/*/query").as(
-      "dashcardQuery",
-    );
+    H.interceptDashboardCardRequests({ alias: "dashcardQuery" });
 
     H.visitDashboard("@dashboardId");
 

--- a/e2e/test/scenarios/native-filters/native-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/native-filters-reproductions.cy.spec.js
@@ -1140,9 +1140,7 @@ describe("issue 34129", () => {
     H.restore();
     cy.signInAsNormalUser();
     cy.intercept("/api/card/*/query").as("cardQuery");
-    cy.intercept("/api/dashboard/*/dashcard/*/card/*/query").as(
-      "dashcardQuery",
-    );
+    H.interceptDashboardCardRequests({ alias: "dashcardQuery" });
   });
 
   it("should support mismatching date filter parameter values when navigating from a dashboard (metabase#34129)", () => {

--- a/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
@@ -587,10 +587,10 @@ describe("scenarios > home > custom homepage", () => {
         "GET",
         `/api/dashboard/${ORDERS_DASHBOARD_ID}/query_metadata*`,
       ).as("getDashboardMetadata");
-      cy.intercept(
-        "POST",
-        `/api/dashboard/${ORDERS_DASHBOARD_ID}/dashcard/*/card/*/query`,
-      ).as("runDashCardQuery");
+      H.interceptDashboardCardRequests({
+        alias: "runDashCardQuery",
+        dashboardId: ORDERS_DASHBOARD_ID,
+      });
 
       cy.visit("/");
       H.dashboardGrid()

--- a/e2e/test/scenarios/permissions/permissions-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/permissions-reproductions.cy.spec.js
@@ -654,7 +654,10 @@ describe("issue 24966", () => {
     cy.button("Add filter").click();
     cy.location("search").should("eq", "?text=Widget");
     cy.get("@dashcardId").then((id) => {
-      H.assertDatasetReqIsSandboxed({ requestAlias: `@dashcardQuery${id}` });
+      H.assertDatasetReqIsSandboxed({
+        requestAlias: "@batchQuery",
+        dashcardId: id,
+      });
     });
   });
 });

--- a/e2e/test/scenarios/permissions/sandboxing/helpers/e2e-sandboxing-helpers.ts
+++ b/e2e/test/scenarios/permissions/sandboxing/helpers/e2e-sandboxing-helpers.ts
@@ -423,8 +423,11 @@ const getQuestionDescription = (
   response: DatasetResponse,
   questions: CollectionItem[],
 ) => {
-  // Extract the card ID from the response URL
-  const cardId = Number(response?.url?.match(/\/card\/(\d+)/)?.[1]);
+  // Batch-synthesized responses stash the card id on the outer object; fall back
+  // to parsing the URL for non-batch (card) responses.
+  const cardId =
+    (response as unknown as { cardId?: number }).cardId ??
+    Number(response?.url?.match(/\/card\/(\d+)/)?.[1]);
   const questionName = (questions.find((q) => q.id === cardId) as any)?.name as
     | string
     | undefined;
@@ -537,14 +540,59 @@ export const getDashcardResponses = (
   H.visitDashboard(checkNotNull(dashboard).id);
 
   expect(questions.length).to.be.greaterThan(0);
-  return cy
-    .wait(new Array(questions.length).fill("@dashcardQuery"))
-    .then((interceptions) => {
-      const responses = interceptions.map(
-        (i) => i.response as unknown as DashcardQueryResponse,
-      );
-      return { questions, responses };
-    });
+  // The batch endpoint returns one NDJSON stream for all dashcards; parse it
+  // into per-question responses that look like the old per-card results so
+  // downstream assertion helpers don't need to change.
+  return cy.wait("@dashcardQuery").then((interception) => {
+    const responses = parseBatchResponseAsDashcardResponses(
+      interception,
+      questions,
+    );
+    return { questions, responses };
+  });
+};
+
+const parseBatchResponseAsDashcardResponses = (
+  interception: Cypress.Interception,
+  questions: SimpleCollectionItem[],
+): DashcardQueryResponse[] => {
+  const body = interception.response?.body;
+  const text = typeof body === "string" ? body : JSON.stringify(body);
+  const messages = text
+    .split("\n")
+    .filter((line: string) => line.trim().length > 0)
+    .map((line: string) => {
+      try {
+        return JSON.parse(line);
+      } catch {
+        return null;
+      }
+    })
+    .filter(Boolean);
+
+  return questions.map((question) => {
+    const beginMsg = messages.find(
+      (m: any) => m.type === "card-begin" && m.card_id === question.id,
+    );
+    const endMsg = messages.find(
+      (m: any) => m.type === "card-end" && m.card_id === question.id,
+    );
+    const rows = messages
+      .filter((m: any) => m.type === "card-rows" && m.card_id === question.id)
+      .flatMap((m: any) => m.rows);
+    return {
+      body: {
+        ...(endMsg ?? {}),
+        data: { ...(beginMsg?.data ?? {}), ...(endMsg?.data ?? {}), rows },
+        json_query: (endMsg?.json_query ?? beginMsg?.json_query ?? {}) as any,
+      } as any,
+      // stash the card id so getQuestionDescription can find the name
+      cardId: question.id,
+      url: interception.request?.url ?? "",
+      headers: interception.response?.headers ?? {},
+      statusCode: interception.response?.statusCode ?? 200,
+    } as unknown as DashcardQueryResponse;
+  });
 };
 
 export const getCardResponses = (questions: SimpleCollectionItem[]) => {

--- a/e2e/test/scenarios/permissions/sandboxing/sandboxing-via-api.cy.spec.js
+++ b/e2e/test/scenarios/permissions/sandboxing/sandboxing-via-api.cy.spec.js
@@ -1123,7 +1123,8 @@ describe("admin > permissions > sandboxes (tested via the API)", () => {
         H.assertTableRowsCount(11);
       });
       H.assertDatasetReqIsSandboxed({
-        requestAlias: `@dashcardQuery${ORDERS_DASHBOARD_DASHCARD_ID}`,
+        requestAlias: "@batchQuery",
+        dashcardId: ORDERS_DASHBOARD_DASHCARD_ID,
         columnId: ORDERS.USER_ID,
         columnAssertion: Number(USERS.sandboxed.login_attributes.attr_uid),
       });
@@ -1230,7 +1231,8 @@ describe("admin > permissions > sandboxes (tested via the API)", () => {
         });
 
         H.assertDatasetReqIsSandboxed({
-          requestAlias: `@dashcardQuery${ORDERS_DASHBOARD_DASHCARD_ID}`,
+          requestAlias: "@batchQuery",
+          dashcardId: ORDERS_DASHBOARD_DASHCARD_ID,
           columnId: ORDERS.USER_ID,
           columnAssertion: Number(USERS.sandboxed.login_attributes.attr_uid),
         });

--- a/e2e/test/scenarios/permissions/sandboxing/sandboxing-via-ui.cy.spec.ts
+++ b/e2e/test/scenarios/permissions/sandboxing/sandboxing-via-ui.cy.spec.ts
@@ -71,9 +71,7 @@ describe(
     beforeEach(() => {
       cy.intercept("/api/card/*/query").as("cardQuery");
 
-      cy.intercept("/api/dashboard/*/dashcard/*/card/*/query").as(
-        "dashcardQuery",
-      );
+      H.interceptDashboardCardRequests({ alias: "dashcardQuery" });
       cy.intercept("POST", "/api/dataset").as("datasetQuery");
       H.restore("sandboxing-snapshot" as any);
     });

--- a/e2e/test/scenarios/question-reproductions/reproductions-1.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-1.cy.spec.js
@@ -493,7 +493,7 @@ describe("issue 17514", () => {
 
         cy.intercept(
           "POST",
-          `/api/dashboard/${dashboard_id}/dashcard/*/card/${card_id}/query`,
+          `/api/dashboard/${dashboard_id}/card-query-batch`,
         ).as("cardQuery");
 
         const mapFilterToCard = {

--- a/e2e/test/scenarios/question/multiple-column-breakouts.cy.spec.ts
+++ b/e2e/test/scenarios/question/multiple-column-breakouts.cy.spec.ts
@@ -266,13 +266,11 @@ describe("scenarios > question > multiple column breakouts", () => {
     cy.signInAsNormalUser();
     cy.intercept("POST", "/api/dataset").as("dataset");
     cy.intercept("POST", "/api/dataset/pivot").as("pivotDataset");
-    cy.intercept("/api/dashboard/*/dashcard/*/card/*/query").as(
-      "dashcardQuery",
-    );
-    cy.intercept("/api/public/dashboard/*/dashcard/*/card/*").as(
+    H.interceptDashboardCardRequests({ alias: "dashcardQuery" });
+    cy.intercept("/api/public/dashboard/*/card-query-batch*").as(
       "publicDashcardQuery",
     );
-    cy.intercept("/api/embed/dashboard/*/dashcard/*/card/*").as(
+    cy.intercept("/api/embed/dashboard/*/card-query-batch*").as(
       "embedDashcardQuery",
     );
   });

--- a/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.js
@@ -265,7 +265,7 @@ describe("issue 18061", () => {
         cy.intercept("POST", `/api/card/${card_id}/query`).as("cardQuery");
         cy.intercept(
           "POST",
-          `/api/dashboard/${dashboard_id}/dashcard/*/card/${card_id}/query`,
+          `/api/dashboard/${dashboard_id}/card-query-batch`,
         ).as("dashCardQuery");
         cy.intercept("GET", `/api/card/${card_id}`).as("getCard");
 

--- a/enterprise/backend/src/metabase_enterprise/cache/strategies.clj
+++ b/enterprise/backend/src/metabase_enterprise/cache/strategies.clj
@@ -38,27 +38,69 @@
 
 ;;; Querying DB
 
+;;; ----------------------------------------- Request-scoped cache -----------------------------------------
+
+(def ^:dynamic *cache-strategy-cache*
+  "When bound to an atom (via [[with-cache-strategy-cache]]), caches the shared (non-question)
+  cache config lookup so it isn't repeated for every card on the same dashboard+database.
+  nil outside of a cached context."
+  nil)
+
+(defmacro with-cache-strategy-cache
+  "Bind a cache-strategy lookup cache for the duration of `body`."
+  [& body]
+  `(binding [*cache-strategy-cache* (atom {})]
+     ~@body))
+
+(defn- cached
+  "Look up `k` in [[*cache-strategy-cache*]], computing `(f)` on miss.
+  Passes through to `(f)` when the cache is unbound."
+  [k f]
+  (if-not *cache-strategy-cache*
+    (f)
+    (let [v (get @*cache-strategy-cache* k ::miss)]
+      (if (identical? v ::miss)
+        (let [result (f)]
+          (swap! *cache-strategy-cache* assoc k result)
+          result)
+        v))))
+
+(defn- find-question-cache-config
+  "Look up question-level cache config for a specific card. Returns a CacheConfig or nil."
+  [card-id]
+  (t2/select-one :model/CacheConfig
+                 :model "question"
+                 :model_id card-id))
+
+(defn- find-shared-cache-config
+  "Look up the highest-priority shared (dashboard/database/root) cache config.
+  Result is cached across cards when [[*cache-strategy-cache*]] is bound."
+  [dashboard-id database-id]
+  (cached [::shared-config dashboard-id database-id]
+          (fn []
+            (let [qs (for [[i model model-id] [[2 "dashboard" dashboard-id]
+                                               [3 "database"  database-id]
+                                               [4 "root"      0]]
+                           :when               model-id]
+                       {:from   [:cache_config]
+                        :select [:id
+                                 [[:inline i] :ordering]]
+                        :where  [:and
+                                 [:= :model [:inline model]]
+                                 [:= :model_id model-id]]})
+                  q  {:from     [[{:union-all qs} :unused_alias]]
+                      :select   [:id]
+                      :order-by :ordering
+                      :limit    [:inline 1]}]
+              (t2/select-one :model/CacheConfig :id q)))))
+
 (defenterprise-schema cache-strategy :- [:maybe ::cache-strategy]
   "Returns the granular cache strategy for a card."
   :feature :cache-granular-controls
   [card         :- :metabase.queries.schema/card
    dashboard-id :- [:maybe :metabase.lib.schema.id/dashboard]]
-  (let [qs   (for [[i model model-id] [[1 "question"   (:id card)]
-                                       [2 "dashboard"  dashboard-id]
-                                       [3 "database"   (:database_id card)]
-                                       [4 "root"       0]]
-                   :when              model-id]
-               {:from   [:cache_config]
-                :select [:id
-                         [[:inline i] :ordering]]
-                :where  [:and
-                         [:= :model [:inline model]]
-                         [:= :model_id model-id]]})
-        q    {:from     [[{:union-all qs} :unused_alias]]
-              :select   [:id]
-              :order-by :ordering
-              :limit    [:inline 1]}
-        item (t2/select-one :model/CacheConfig :id q)]
+  (let [item (or (find-question-cache-config (:id card))
+                 (find-shared-cache-config dashboard-id (:database_id card)))]
     (cache/card-strategy item card)))
 
 ;;; Strategy execution

--- a/enterprise/backend/src/metabase_enterprise/cache/strategies.clj
+++ b/enterprise/backend/src/metabase_enterprise/cache/strategies.clj
@@ -73,11 +73,14 @@
   {#'*cache-strategy-cache* (atom {})})
 
 (defn- find-question-cache-config
-  "Look up question-level cache config for a specific card. Returns a CacheConfig or nil."
+  "Look up question-level cache config for a specific card. Returns a CacheConfig or nil.
+  Result is cached across cards when [[*cache-strategy-cache*]] is bound."
   [card-id]
-  (t2/select-one :model/CacheConfig
-                 :model "question"
-                 :model_id card-id))
+  (cached [::question-config card-id]
+          (fn []
+            (t2/select-one :model/CacheConfig
+                           :model "question"
+                           :model_id card-id))))
 
 (defn- find-shared-cache-config
   "Look up the highest-priority shared (dashboard/database/root) cache config.
@@ -100,6 +103,24 @@
                       :order-by :ordering
                       :limit    [:inline 1]}]
               (t2/select-one :model/CacheConfig :id q)))))
+
+(defenterprise warm-question-cache-configs!
+  "Pre-warm the question-level cache config cache for a batch of card IDs.
+  Performs a single SELECT with an IN clause and populates the request-scoped cache atom,
+  including nil entries for cards with no question-level config."
+  :feature :cache-granular-controls
+  [card-ids]
+  (when *cache-strategy-cache*
+    (let [card-id-set (set card-ids)
+          configs     (when (seq card-id-set)
+                        (t2/select :model/CacheConfig
+                                   :model "question"
+                                   :model_id [:in card-id-set]))
+          id->config  (into {} (map (juxt :model_id identity)) configs)]
+      (swap! *cache-strategy-cache*
+             into
+             (map (fn [cid] [[::question-config cid] (get id->config cid)]))
+             card-id-set))))
 
 (defenterprise-schema cache-strategy :- [:maybe ::cache-strategy]
   "Returns the granular cache strategy for a card."

--- a/enterprise/backend/src/metabase_enterprise/cache/strategies.clj
+++ b/enterprise/backend/src/metabase_enterprise/cache/strategies.clj
@@ -65,6 +65,13 @@
           result)
         v))))
 
+(defenterprise cache-strategy-batch-cache-bindings
+  "Returns a Var->atom bindings map for the cache-strategy request-scoped cache, suitable for
+  conveying to worker threads via `with-bindings`."
+  :feature :cache-granular-controls
+  []
+  {#'*cache-strategy-cache* (atom {})})
+
 (defn- find-question-cache-config
   "Look up question-level cache config for a specific card. Returns a CacheConfig or nil."
   [card-id]

--- a/enterprise/backend/src/metabase_enterprise/database_routing/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/database_routing/common.clj
@@ -34,6 +34,13 @@
   `(binding [*routing-cache* (atom {})]
      ~@body))
 
+(defenterprise routing-batch-cache-bindings
+  "Returns a Var->atom bindings map for the routing request-scoped cache, suitable for
+  conveying to worker threads via `with-bindings`."
+  :feature :database-routing
+  []
+  {#'*routing-cache* (atom {})})
+
 ;;; ----------------------------------------------------------------------------------------------------------
 
 (defn- user-attribute

--- a/enterprise/backend/src/metabase_enterprise/database_routing/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/database_routing/common.clj
@@ -7,10 +7,40 @@
    [metabase.util.i18n :refer [tru]]
    [toucan2.core :as t2]))
 
+;;; ----------------------------------------- Request-scoped cache -----------------------------------------
+
+(def ^:dynamic *routing-cache*
+  "When bound to an atom (via [[with-routing-cache]]), caches database routing lookups so they aren't
+  repeated across calls within the same scope. nil outside of a cached context."
+  nil)
+
+(defn- cached
+  "Look up `k` in [[*cache*]], computing `(f)` on miss. Passes through to `(f)` when `*cache*` is unbound."
+  [k f]
+  (if-not *routing-cache*
+    (f)
+    (let [v (get @*routing-cache* k ::miss)]
+      (if (identical? v ::miss)
+        (let [result (f)]
+          (swap! *routing-cache* assoc k result)
+          result)
+        v))))
+
+(defmacro with-routing-cache
+  "Bind a database routing lookup cache for the duration of `body`. Repeated calls to
+  [[router-db-or-id->destination-db-id]] and [[check-allowed-access!]] within the same
+  cache scope will reuse results for the same db combination."
+  [& body]
+  `(binding [*routing-cache* (atom {})]
+     ~@body))
+
+;;; ----------------------------------------------------------------------------------------------------------
+
 (defn- user-attribute
   "Which user attribute should we use for this RouterDB?"
   [db-or-id]
-  (t2/select-one-fn :user_attribute :model/DatabaseRouter :database_id (u/the-id db-or-id)))
+  (cached [::router-user-attr (u/the-id db-or-id)]
+          (fn [] (t2/select-one-fn :user_attribute :model/DatabaseRouter :database_id (u/the-id db-or-id)))))
 
 (def ^:dynamic ^:private *database-routing-on* :unset)
 
@@ -59,11 +89,13 @@
   routed to. If the database is not a Router Database, returns `nil`. If the database is a Router Database but no
   current user exists, an exception will be thrown."
   [db-or-id]
-  (router-db-or-id->destination-db-id*
-   (nil? @api/*current-user*)
-   (api/current-user-attributes)
-   api/*is-superuser?*
-   db-or-id))
+  (cached [::destination-db-id (u/the-id db-or-id) api/*current-user-id*]
+          (fn []
+            (router-db-or-id->destination-db-id*
+             (nil? @api/*current-user*)
+             (api/current-user-attributes)
+             api/*is-superuser?*
+             db-or-id))))
 
 ;; We want, at all times, a guarantee that we are not hitting a router *or* destination database without being
 ;; intentional about it. It would be bad to EITHER:
@@ -106,7 +138,8 @@
 
 (defn- is-disallowed-destination-db-access?
   [db-or-id]
-  (and (t2/exists? :model/Database :id db-or-id :router_database_id [:not= nil])
+  (and (cached [::is-destination-db (u/the-id db-or-id)]
+               (fn [] (t2/exists? :model/Database :id db-or-id :router_database_id [:not= nil])))
        (not= *database-routing-on* :on)))
 
 (defenterprise check-allowed-access!

--- a/enterprise/backend/src/metabase_enterprise/impersonation/driver.clj
+++ b/enterprise/backend/src/metabase_enterprise/impersonation/driver.clj
@@ -50,6 +50,35 @@
    (when (and db-or-id (premium-features/enable-advanced-permissions?))
      (t2/exists? :model/ConnectionImpersonation :db_id (u/id db-or-id)))))
 
+;;; ----------------------------------------- Request-scoped cache -----------------------------------------
+
+(def ^:dynamic *impersonation-cache*
+  "When bound to an atom (via [[with-impersonation-cache]]), caches impersonation lookups so they aren't
+  repeated across calls within the same scope. nil outside of a cached context."
+  nil)
+
+(defn- cached
+  "Look up `k` in [[*cache*]], computing `(f)` on miss. Passes through to `(f)` when `*cache*` is unbound."
+  [k f]
+  (if-not *impersonation-cache*
+    (f)
+    (let [v (get @*impersonation-cache* k ::miss)]
+      (if (identical? v ::miss)
+        (let [result (f)]
+          (swap! *impersonation-cache* assoc k result)
+          result)
+        v))))
+
+(defmacro with-impersonation-cache
+  "Bind an impersonation lookup cache for the duration of `body`. Repeated calls to
+  [[connection-impersonation-role]] and [[enforced-impersonations-for-db]] within the same
+  cache scope will reuse results for the same user+db combination."
+  [& body]
+  `(binding [*impersonation-cache* (atom {})]
+     ~@body))
+
+;;; ----------------------------------------------------------------------------------------------------------
+
 (defn enforced-impersonations-for-db
   "Returns the connection impersonation policies which should be enforced for the provided DB for the current user, if
   one exists. Returns `nil` if no policies exist, or none should be enforced for the current user.
@@ -59,50 +88,56 @@
   Note: this returns a list of policies. Typically a user should only be in one group with an impersonation policy at a time,
   but there may be policies in multiple groups if they use the same user attribute."
   [db-or-id]
-  (let [group-ids           (t2/select-fn-set :group_id :model/PermissionsGroupMembership :user_id api/*current-user-id*)
-        conn-impersonations (when (seq group-ids)
-                              (t2/select :model/ConnectionImpersonation
-                                         :group_id [:in group-ids]
-                                         :db_id (u/the-id db-or-id)))]
-    (when (and (seq conn-impersonations) (sandboxed? db-or-id))
-      (throw (ex-info (tru "Conflicting sandboxing and impersonation policies found.")
-                      {:user-id api/*current-user-id*
-                       :database-id (u/id db-or-id)})))
-    (when (and (seq conn-impersonations)
-               (enforce-impersonations? db-or-id conn-impersonations group-ids))
-      conn-impersonations)))
+  (cached [::enforced-impersonations api/*current-user-id* (u/the-id db-or-id)]
+          (fn []
+            (let [group-ids           (cached [::group-ids api/*current-user-id*]
+                                              (fn [] (t2/select-fn-set :group_id :model/PermissionsGroupMembership
+                                                                       :user_id api/*current-user-id*)))
+                  conn-impersonations (when (seq group-ids)
+                                        (t2/select :model/ConnectionImpersonation
+                                                   :group_id [:in group-ids]
+                                                   :db_id (u/the-id db-or-id)))]
+              (when (and (seq conn-impersonations) (sandboxed? db-or-id))
+                (throw (ex-info (tru "Conflicting sandboxing and impersonation policies found.")
+                                {:user-id api/*current-user-id*
+                                 :database-id (u/id db-or-id)})))
+              (when (and (seq conn-impersonations)
+                         (enforce-impersonations? db-or-id conn-impersonations group-ids))
+                conn-impersonations)))))
 
 (defn connection-impersonation-role
   "Fetches the database role that should be used for the current user, if connection impersonation is in effect.
   Returns `nil` if connection impersonation should not be used for the current user. Throws an exception if multiple
   conflicting connection impersonation policies are found, or the role is not a single string."
   [database-or-id]
-  (when (and database-or-id (not api/*is-superuser?*))
-    (let [conn-impersonations  (enforced-impersonations-for-db database-or-id)
-          role-attributes      (set (map :attribute conn-impersonations))]
-      (when conn-impersonations
-        (when (> (count role-attributes) 1)
-          (throw (ex-info (tru "Multiple conflicting connection impersonation policies found for current user")
-                          {:user-id api/*current-user-id*
-                           :conn-impersonations conn-impersonations})))
-        (when (not-empty role-attributes)
-          (let [conn-impersonation (first conn-impersonations)
-                role-attribute     (:attribute conn-impersonation)
-                user-attributes    (api/current-user-attributes)
-                role               (get user-attributes role-attribute)]
-            (cond
-              (nil? role)
-              (throw (ex-info (tru "User does not have attribute required for connection impersonation.")
-                              {:user-id api/*current-user-id*
-                               :conn-impersonations conn-impersonations}))
+  (cached [::impersonation-role api/*current-user-id* (u/the-id database-or-id)]
+          (fn []
+            (when (and database-or-id (not api/*is-superuser?*))
+              (let [conn-impersonations  (enforced-impersonations-for-db database-or-id)
+                    role-attributes      (set (map :attribute conn-impersonations))]
+                (when conn-impersonations
+                  (when (> (count role-attributes) 1)
+                    (throw (ex-info (tru "Multiple conflicting connection impersonation policies found for current user")
+                                    {:user-id api/*current-user-id*
+                                     :conn-impersonations conn-impersonations})))
+                  (when (not-empty role-attributes)
+                    (let [conn-impersonation (first conn-impersonations)
+                          role-attribute     (:attribute conn-impersonation)
+                          user-attributes    (api/current-user-attributes)
+                          role               (get user-attributes role-attribute)]
+                      (cond
+                        (nil? role)
+                        (throw (ex-info (tru "User does not have attribute required for connection impersonation.")
+                                        {:user-id api/*current-user-id*
+                                         :conn-impersonations conn-impersonations}))
 
-              (or (not (string? role))
-                  (str/blank? role))
-              (throw (ex-info (tru "Connection impersonation attribute is invalid: role must be a single non-empty string.")
-                              {:user-id api/*current-user-id*
-                               :conn-impersonations conn-impersonations}))
-              :else
-              role)))))))
+                        (or (not (string? role))
+                            (str/blank? role))
+                        (throw (ex-info (tru "Connection impersonation attribute is invalid: role must be a single non-empty string.")
+                                        {:user-id api/*current-user-id*
+                                         :conn-impersonations conn-impersonations}))
+                        :else
+                        role)))))))))
 
 (defenterprise hash-input-for-impersonation
   "Returns a hash-key for FieldValues if the current user uses impersonation for the database."

--- a/enterprise/backend/src/metabase_enterprise/impersonation/driver.clj
+++ b/enterprise/backend/src/metabase_enterprise/impersonation/driver.clj
@@ -77,6 +77,13 @@
   `(binding [*impersonation-cache* (atom {})]
      ~@body))
 
+(defenterprise impersonation-batch-cache-bindings
+  "Returns a Var->atom bindings map for the impersonation request-scoped cache, suitable for
+  conveying to worker threads via `with-bindings`."
+  :feature :advanced-permissions
+  []
+  {#'*impersonation-cache* (atom {})})
+
 ;;; ----------------------------------------------------------------------------------------------------------
 
 (defn enforced-impersonations-for-db

--- a/enterprise/backend/src/metabase_enterprise/impersonation/driver.clj
+++ b/enterprise/backend/src/metabase_enterprise/impersonation/driver.clj
@@ -117,9 +117,9 @@
   Returns `nil` if connection impersonation should not be used for the current user. Throws an exception if multiple
   conflicting connection impersonation policies are found, or the role is not a single string."
   [database-or-id]
-  (cached [::impersonation-role api/*current-user-id* (u/the-id database-or-id)]
-          (fn []
-            (when (and database-or-id (not api/*is-superuser?*))
+  (when (and database-or-id (not api/*is-superuser?*))
+    (cached [::impersonation-role api/*current-user-id* (u/the-id database-or-id)]
+            (fn []
               (let [conn-impersonations  (enforced-impersonations-for-db database-or-id)
                     role-attributes      (set (map :attribute conn-impersonations))]
                 (when conn-impersonations

--- a/enterprise/backend/test/metabase_enterprise/cache/strategies_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/cache/strategies_test.clj
@@ -10,7 +10,8 @@
    [metabase.query-processor.card :as qp.card]
    [metabase.query-processor.test :as qp]
    [metabase.search.ingestion :as search.ingestion]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [toucan2.core :as t2]))
 
 (comment
   strategies/keep-me)
@@ -230,3 +231,40 @@
                 99 {:cached true, :updated_at some?, :hash some?}
                 ;; original param is still cached
                 42 {:cached true, :updated_at some?, :hash some?}))))))))
+
+(deftest warm-question-cache-configs-test
+  (mt/with-premium-features #{:cache-granular-controls}
+    (mt/with-temp [:model/Card        {c1 :id} {:dataset_query (mt/mbql-query venues)}
+                   :model/Card        {c2 :id} {:dataset_query (mt/mbql-query venues)}
+                   :model/Card        {c3 :id} {:dataset_query (mt/mbql-query venues)}
+                   :model/CacheConfig _        {:model    "question"
+                                                :model_id c1
+                                                :strategy :ttl
+                                                :config   {:multiplier 100 :min_duration_ms 0}}
+                   :model/CacheConfig _        {:model    "question"
+                                                :model_id c2
+                                                :strategy :duration
+                                                :config   {:duration 5 :unit "minutes"}}]
+      (testing "warming populates cache for all card IDs, including nil for cards without configs"
+        (binding [strategies/*cache-strategy-cache* (atom {})]
+          (strategies/warm-question-cache-configs! #{c1 c2 c3})
+          (let [cache @strategies/*cache-strategy-cache*]
+            (is (some? (get cache [::strategies/question-config c1]))
+                "card with config should be cached")
+            (is (some? (get cache [::strategies/question-config c2]))
+                "card with config should be cached")
+            (is (contains? cache [::strategies/question-config c3])
+                "card without config should still have a cache entry")
+            (is (nil? (get cache [::strategies/question-config c3]))
+                "card without config should have nil cached"))))
+
+      (testing "after warming, find-question-cache-config doesn't hit DB"
+        (binding [strategies/*cache-strategy-cache* (atom {})]
+          (strategies/warm-question-cache-configs! #{c1 c2 c3})
+          (t2/with-call-count [call-count]
+            ;; These should all be served from the cache atom
+            (#'strategies/find-question-cache-config c1)
+            (#'strategies/find-question-cache-config c2)
+            (#'strategies/find-question-cache-config c3)
+            (is (zero? (call-count))
+                "no DB calls should occur after warming")))))))

--- a/enterprise/frontend/src/embedding-sdk-ee/notifications/DashboardSubscriptionsButton.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk-ee/notifications/DashboardSubscriptionsButton.unit.spec.tsx
@@ -6,7 +6,10 @@ import {
   setupDashboardQueryMetadataEndpoint,
   setupNotificationChannelsEndpoints,
 } from "__support__/server-mocks";
-import { setupDashcardQueryEndpoints } from "__support__/server-mocks/dashcard";
+import {
+  setupDashboardCardQueryBatchEndpoint,
+  setupDashcardQueryEndpoints,
+} from "__support__/server-mocks/dashcard";
 import { renderWithProviders } from "__support__/ui";
 import { DashboardContextProvider } from "metabase/dashboard/context";
 import type { DashboardCard } from "metabase-types/api";
@@ -124,6 +127,10 @@ function setupDashboardRelatedEndpoints(
   );
 
   setupDashcardQueryEndpoints(dashboardId, tableDashcard, createMockDataset());
+  setupDashboardCardQueryBatchEndpoint(
+    dashboardId,
+    dashcards.map((dc) => ({ id: dc.id, card_id: dc.card_id as number })),
+  );
 
   return dashboardId;
 }

--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/shared-tests/auto-refresh.spec.ts
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/shared-tests/auto-refresh.spec.ts
@@ -1,19 +1,17 @@
 import { waitFor } from "@testing-library/react";
 
-import { findRequests } from "__support__/server-mocks";
 import { screen } from "__support__/ui";
 import type { Dashboard } from "metabase-types/api";
 
 import type { SetupSdkDashboardOptions } from "../tests/setup";
 
 type SetupOpts = Omit<SetupSdkDashboardOptions, "component">;
+type SetupResult = { dashboard: Dashboard; batchCalls: { url: string }[] };
 
 export function addEnterpriseAutoRefreshTests(
-  setup: (options?: SetupOpts) => Promise<{ dashboard: Dashboard }>,
+  setup: (options?: SetupOpts) => Promise<SetupResult>,
 ) {
   describe("autoRefreshInterval property", () => {
-    const DASHBOARD_CARD_QUERY_REQUEST_COUNT = 1;
-
     afterEach(() => {
       jest.useRealTimers();
     });
@@ -21,35 +19,24 @@ export function addEnterpriseAutoRefreshTests(
     it("should support auto-refreshing dashboards for positive integers", async () => {
       jest.useFakeTimers();
 
-      await setup({ props: { autoRefreshInterval: 10 } });
-
-      // Wait for initial dashboard load
-      await waitFor(async () => {
-        const initialRequests = await getDashboardQueryRequests();
-        expect(initialRequests.length).toBe(
-          1 * DASHBOARD_CARD_QUERY_REQUEST_COUNT,
-        );
+      const { batchCalls } = await setup({
+        props: { autoRefreshInterval: 10 },
       });
 
-      // Advance time by the auto-refresh interval (10 seconds)
-      jest.advanceTimersByTime(10_000);
-
-      // Wait for the auto-refresh request to be made
-      await waitFor(async () => {
-        const requestsAfterRefresh = await getDashboardQueryRequests();
-        expect(requestsAfterRefresh.length).toBe(
-          2 * DASHBOARD_CARD_QUERY_REQUEST_COUNT,
-        );
+      await waitFor(() => {
+        expect(batchCalls.length).toBe(1);
       });
 
-      // Advance time again to test multiple refresh cycles
       jest.advanceTimersByTime(10_000);
 
-      await waitFor(async () => {
-        const requestsAfterSecondRefresh = await getDashboardQueryRequests();
-        expect(requestsAfterSecondRefresh.length).toBe(
-          3 * DASHBOARD_CARD_QUERY_REQUEST_COUNT,
-        );
+      await waitFor(() => {
+        expect(batchCalls.length).toBe(2);
+      });
+
+      jest.advanceTimersByTime(10_000);
+
+      await waitFor(() => {
+        expect(batchCalls.length).toBe(3);
       });
     });
 
@@ -71,22 +58,17 @@ export function addEnterpriseAutoRefreshTests(
         jest.useFakeTimers();
 
         // Forces the type, because users can literally pass any type here
-        await setup({ props: { autoRefreshInterval: value as number } });
-
-        // Wait for initial dashboard load
-        await waitFor(async () => {
-          const initialRequests = await getDashboardQueryRequests();
-          expect(initialRequests.length).toBe(
-            DASHBOARD_CARD_QUERY_REQUEST_COUNT,
-          );
+        const { batchCalls } = await setup({
+          props: { autoRefreshInterval: value as number },
         });
 
-        // Advance time significantly
+        await waitFor(() => {
+          expect(batchCalls.length).toBe(1);
+        });
+
         jest.advanceTimersByTime(30_000);
 
-        // Verify no additional requests were made
-        const finalRequests = await getDashboardQueryRequests();
-        expect(finalRequests.length).toBe(DASHBOARD_CARD_QUERY_REQUEST_COUNT);
+        expect(batchCalls.length).toBe(1);
       });
 
       it("should not show the auto-refresh indicator in the dashboard header", async () => {
@@ -102,15 +84,3 @@ export function addEnterpriseAutoRefreshTests(
 }
 
 export const addPremiumAutoRefreshTests = addEnterpriseAutoRefreshTests;
-
-async function getDashboardQueryRequests() {
-  return findRequests("POST").then((requests) =>
-    requests.filter((req) =>
-      req.url.match(
-        new RegExp(
-          "^http://localhost/api/dashboard/\\d+/dashcard/\\d+/card/\\d+/query",
-        ),
-      ),
-    ),
-  );
-}

--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/tests/setup.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/tests/setup.tsx
@@ -17,7 +17,10 @@ import {
   setupDatabasesEndpoints,
   setupLastDownloadFormatEndpoints,
 } from "__support__/server-mocks";
-import { setupDashcardQueryEndpoints } from "__support__/server-mocks/dashcard";
+import {
+  setupDashboardCardQueryBatchEndpoint,
+  setupDashcardQueryEndpoints,
+} from "__support__/server-mocks/dashcard";
 import { setupNotificationChannelsEndpoints } from "__support__/server-mocks/pulse";
 import { screen } from "__support__/ui";
 import { SdkInternalNavigationProvider } from "embedding-sdk-bundle/components/private/SdkInternalNavigation/SdkInternalNavigationProvider";
@@ -188,6 +191,15 @@ export const setupSdkDashboard = async ({
 
   setupDashcardQueryEndpoints(dashboardId, tableDashcard, createMockDataset());
 
+  const batchCalls = setupDashboardCardQueryBatchEndpoint(
+    dashboardId,
+    dashcards
+      .filter(
+        (dc): dc is DashboardCard & { card_id: number } => dc.card_id != null,
+      )
+      .map((dc) => ({ id: dc.id, card_id: dc.card_id })),
+  );
+
   setupAlertsEndpoints(tableCard, []);
 
   setupNotificationChannelsEndpoints({
@@ -272,5 +284,6 @@ export const setupSdkDashboard = async ({
 
   return {
     dashboard,
+    batchCalls,
   };
 };

--- a/frontend/src/metabase/dashboard/actions/batch-card-query.ts
+++ b/frontend/src/metabase/dashboard/actions/batch-card-query.ts
@@ -197,7 +197,7 @@ export async function streamBatchCardQuery(
     await api.apiRequestManipulationMiddleware({
       url: config.url,
       method,
-      options: {},
+      options: { hasBody: body != null },
       data: {},
     });
   const url = substituteUrlParams(transformedUrl, transformedData);

--- a/frontend/src/metabase/dashboard/actions/batch-card-query.ts
+++ b/frontend/src/metabase/dashboard/actions/batch-card-query.ts
@@ -1,11 +1,35 @@
-import type { CardId, DashCardId, Dataset } from "metabase-types/api";
+import type {
+  CardId,
+  DashCardId,
+  Dataset,
+  DatasetData,
+  RowValues,
+} from "metabase-types/api";
 
-type BatchCardResult = {
-  type: "card-result";
+type BatchCardBegin = {
+  type: "card-begin";
   dashcard_id: DashCardId;
   card_id: CardId;
-  result: Dataset;
+  // A partial DatasetData — what's known before rows are reduced (cols, native_form, etc.).
+  data: Partial<DatasetData> & Record<string, unknown>;
 };
+
+type BatchCardRows = {
+  type: "card-rows";
+  dashcard_id: DashCardId;
+  card_id: CardId;
+  rows: RowValues[];
+};
+
+type BatchCardEnd = {
+  type: "card-end";
+  dashcard_id: DashCardId;
+  card_id: CardId;
+  row_count: number;
+  status: string;
+  running_time?: number;
+  data: Partial<DatasetData> & Record<string, unknown>;
+} & Record<string, unknown>;
 
 type BatchCardError = {
   type: "card-error";
@@ -21,7 +45,12 @@ type BatchComplete = {
   failed: number;
 };
 
-type BatchMessage = BatchCardResult | BatchCardError | BatchComplete;
+type BatchMessage =
+  | BatchCardBegin
+  | BatchCardRows
+  | BatchCardEnd
+  | BatchCardError
+  | BatchComplete;
 
 export type BatchCallbacks = {
   onCardResult: (
@@ -53,6 +82,84 @@ export type BatchRequestConfig = {
   signal?: AbortSignal;
 };
 
+type PartialCard = {
+  beginData: Partial<DatasetData> & Record<string, unknown>;
+  rows: RowValues[];
+};
+
+const keyOf = (dashcardId: DashCardId, cardId: CardId) =>
+  `${dashcardId}:${cardId}`;
+
+function assembleDataset(partial: PartialCard, end: BatchCardEnd): Dataset {
+  // End-side `data` fields win over begin-side (they represent the final state), and rows are
+  // the concatenated row chunks.
+  const mergedData = {
+    ...partial.beginData,
+    ...end.data,
+    rows: partial.rows,
+  } as DatasetData;
+  const { type: _t, dashcard_id: _dc, card_id: _cid, data: _d, ...rest } = end;
+  return { ...rest, data: mergedData } as unknown as Dataset;
+}
+
+function handleMessage(
+  msg: BatchMessage,
+  partial: Map<string, PartialCard>,
+  callbacks: BatchCallbacks,
+): void {
+  switch (msg.type) {
+    case "card-begin": {
+      partial.set(keyOf(msg.dashcard_id, msg.card_id), {
+        beginData: msg.data ?? {},
+        rows: [],
+      });
+      return;
+    }
+    case "card-rows": {
+      const entry = partial.get(keyOf(msg.dashcard_id, msg.card_id));
+      if (entry) {
+        for (const row of msg.rows) {
+          entry.rows.push(row);
+        }
+      }
+      return;
+    }
+    case "card-end": {
+      const key = keyOf(msg.dashcard_id, msg.card_id);
+      const entry = partial.get(key);
+      if (entry) {
+        partial.delete(key);
+        callbacks.onCardResult(
+          msg.dashcard_id,
+          msg.card_id,
+          assembleDataset(entry, msg),
+        );
+      }
+      return;
+    }
+    case "card-error": {
+      partial.delete(keyOf(msg.dashcard_id, msg.card_id));
+      callbacks.onCardError(msg.dashcard_id, msg.card_id, msg.error);
+      return;
+    }
+    case "complete": {
+      callbacks.onComplete({
+        total: msg.total,
+        succeeded: msg.succeeded,
+        failed: msg.failed,
+      });
+      if (partial.size > 0) {
+        console.warn(
+          `streamBatchCardQuery: ${partial.size} card(s) never completed`,
+          Array.from(partial.keys()),
+        );
+        partial.clear();
+      }
+      return;
+    }
+  }
+}
+
 export async function streamBatchCardQuery(
   config: BatchRequestConfig,
   callbacks: BatchCallbacks,
@@ -75,6 +182,7 @@ export async function streamBatchCardQuery(
   }
 
   const decoder = new TextDecoder();
+  const partial = new Map<string, PartialCard>();
   let buffer = "";
 
   try {
@@ -87,7 +195,6 @@ export async function streamBatchCardQuery(
       buffer += decoder.decode(value, { stream: true });
 
       const lines = buffer.split("\n");
-      // Keep the last (potentially incomplete) line in the buffer
       buffer = lines.pop()!;
 
       for (const line of lines) {
@@ -95,36 +202,16 @@ export async function streamBatchCardQuery(
         if (!trimmed) {
           continue;
         }
-
-        const msg: BatchMessage = JSON.parse(trimmed);
-        switch (msg.type) {
-          case "card-result":
-            callbacks.onCardResult(msg.dashcard_id, msg.card_id, msg.result);
-            break;
-          case "card-error":
-            callbacks.onCardError(msg.dashcard_id, msg.card_id, msg.error);
-            break;
-          case "complete":
-            callbacks.onComplete(msg);
-            break;
-        }
+        handleMessage(JSON.parse(trimmed) as BatchMessage, partial, callbacks);
       }
     }
 
-    // Process any remaining data in buffer
     if (buffer.trim()) {
-      const msg: BatchMessage = JSON.parse(buffer.trim());
-      switch (msg.type) {
-        case "card-result":
-          callbacks.onCardResult(msg.dashcard_id, msg.card_id, msg.result);
-          break;
-        case "card-error":
-          callbacks.onCardError(msg.dashcard_id, msg.card_id, msg.error);
-          break;
-        case "complete":
-          callbacks.onComplete(msg);
-          break;
-      }
+      handleMessage(
+        JSON.parse(buffer.trim()) as BatchMessage,
+        partial,
+        callbacks,
+      );
     }
   } finally {
     reader.releaseLock();

--- a/frontend/src/metabase/dashboard/actions/batch-card-query.ts
+++ b/frontend/src/metabase/dashboard/actions/batch-card-query.ts
@@ -36,7 +36,10 @@ type BatchCardError = {
   type: "card-error";
   dashcard_id: DashCardId;
   card_id: CardId;
-  error: { status: number; message: string };
+  // `status` and `message` are always present; the rest of the QP error
+  // payload (`error`, `error_is_curated`, `error_type`, `ex-data`, ...) rides
+  // along so callers can surface curated messages.
+  error: { status: number; message: string } & Record<string, unknown>;
 };
 
 type BatchComplete = {
@@ -62,7 +65,7 @@ export type BatchCallbacks = {
   onCardError: (
     dashcardId: DashCardId,
     cardId: CardId,
-    error: { status: number; message: string },
+    error: { status: number; message: string } & Record<string, unknown>,
   ) => void;
   onComplete: (summary: {
     total: number;

--- a/frontend/src/metabase/dashboard/actions/batch-card-query.ts
+++ b/frontend/src/metabase/dashboard/actions/batch-card-query.ts
@@ -1,3 +1,4 @@
+import api from "metabase/utils/api";
 import type {
   CardId,
   DashCardId,
@@ -90,6 +91,26 @@ type PartialCard = {
 const keyOf = (dashcardId: DashCardId, cardId: CardId) =>
   `${dashcardId}:${cardId}`;
 
+// Mirrors the `:word` substitution loop inside Api._makeMethod so that embed
+// token refresh (which swaps a JWT in the URL for a `:entityIdentifier`
+// placeholder) lands the refreshed value in the fetch URL.
+function substituteUrlParams(
+  url: string,
+  data: Record<string, unknown>,
+): string {
+  const tags = url.match(/:\w+/g);
+  if (!tags) {
+    return url;
+  }
+  return tags.reduce((acc, tag) => {
+    const value = data[tag.slice(1)];
+    if (value === undefined) {
+      return acc;
+    }
+    return acc.replace(tag, encodeURIComponent(String(value)));
+  }, url);
+}
+
 function assembleDataset(partial: PartialCard, end: BatchCardEnd): Dataset {
   // End-side `data` fields win over begin-side (they represent the final state), and rows are
   // the concatenated row chunks.
@@ -164,16 +185,47 @@ export async function streamBatchCardQuery(
   config: BatchRequestConfig,
   callbacks: BatchCallbacks,
 ): Promise<void> {
-  const { url, method = "POST", body, signal } = config;
-  const fetchInit: RequestInit = { method, signal };
+  const { method = "POST", body, signal } = config;
+  // Route the request through the same middleware the standard Api class uses
+  // so embed token refresh, session headers, CSRF, X-Metabase-Client, etc. all
+  // apply. We fetch() directly afterwards because the Api class can't yield a
+  // streaming response.
+  const { url: transformedUrl, data: transformedData } =
+    await api.apiRequestManipulationMiddleware({
+      url: config.url,
+      method,
+      options: {},
+      data: {},
+    });
+  const url = substituteUrlParams(transformedUrl, transformedData);
+  const headers: Record<string, string> = { ...api.getClientHeaders() };
+  const fetchInit: RequestInit = { method, signal, headers };
   if (body) {
-    fetchInit.headers = { "Content-Type": "application/json" };
+    headers["Content-Type"] = "application/json";
     fetchInit.body = JSON.stringify(body);
   }
   const response = await fetch(url, fetchInit);
 
   if (!response.ok) {
-    throw new Error(`Batch card query failed: ${response.status}`);
+    // Surface the server-side message (e.g. "You must specify a value for :source
+    // in the JWT.") so callers can render it on every card in the batch.
+    let message = `Batch card query failed: ${response.status}`;
+    try {
+      const text = await response.text();
+      if (text) {
+        try {
+          const json = JSON.parse(text);
+          message = json.message ?? json.error ?? text;
+        } catch {
+          message = text;
+        }
+      }
+    } catch {
+      // ignore body-read errors
+    }
+    const err = new Error(message) as Error & { status?: number };
+    err.status = response.status;
+    throw err;
   }
 
   const reader = response.body?.getReader();

--- a/frontend/src/metabase/dashboard/actions/batch-card-query.ts
+++ b/frontend/src/metabase/dashboard/actions/batch-card-query.ts
@@ -1,0 +1,132 @@
+import type { CardId, DashCardId, Dataset } from "metabase-types/api";
+
+type BatchCardResult = {
+  type: "card-result";
+  dashcard_id: DashCardId;
+  card_id: CardId;
+  result: Dataset;
+};
+
+type BatchCardError = {
+  type: "card-error";
+  dashcard_id: DashCardId;
+  card_id: CardId;
+  error: { status: number; message: string };
+};
+
+type BatchComplete = {
+  type: "complete";
+  total: number;
+  succeeded: number;
+  failed: number;
+};
+
+type BatchMessage = BatchCardResult | BatchCardError | BatchComplete;
+
+export type BatchCallbacks = {
+  onCardResult: (
+    dashcardId: DashCardId,
+    cardId: CardId,
+    result: Dataset,
+  ) => void;
+  onCardError: (
+    dashcardId: DashCardId,
+    cardId: CardId,
+    error: { status: number; message: string },
+  ) => void;
+  onComplete: (summary: {
+    total: number;
+    succeeded: number;
+    failed: number;
+  }) => void;
+};
+
+export type BatchCardSpec = {
+  dashcard_id: DashCardId;
+  card_id: CardId;
+};
+
+export type BatchRequestConfig = {
+  url: string;
+  method?: "GET" | "POST";
+  body?: Record<string, unknown>;
+  signal?: AbortSignal;
+};
+
+export async function streamBatchCardQuery(
+  config: BatchRequestConfig,
+  callbacks: BatchCallbacks,
+): Promise<void> {
+  const { url, method = "POST", body, signal } = config;
+  const fetchInit: RequestInit = { method, signal };
+  if (body) {
+    fetchInit.headers = { "Content-Type": "application/json" };
+    fetchInit.body = JSON.stringify(body);
+  }
+  const response = await fetch(url, fetchInit);
+
+  if (!response.ok) {
+    throw new Error(`Batch card query failed: ${response.status}`);
+  }
+
+  const reader = response.body?.getReader();
+  if (!reader) {
+    throw new Error("Response body is not readable");
+  }
+
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+
+      buffer += decoder.decode(value, { stream: true });
+
+      const lines = buffer.split("\n");
+      // Keep the last (potentially incomplete) line in the buffer
+      buffer = lines.pop()!;
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed) {
+          continue;
+        }
+
+        const msg: BatchMessage = JSON.parse(trimmed);
+        switch (msg.type) {
+          case "card-result":
+            callbacks.onCardResult(msg.dashcard_id, msg.card_id, msg.result);
+            break;
+          case "card-error":
+            callbacks.onCardError(msg.dashcard_id, msg.card_id, msg.error);
+            break;
+          case "complete":
+            callbacks.onComplete(msg);
+            break;
+        }
+      }
+    }
+
+    // Process any remaining data in buffer
+    if (buffer.trim()) {
+      const msg: BatchMessage = JSON.parse(buffer.trim());
+      switch (msg.type) {
+        case "card-result":
+          callbacks.onCardResult(msg.dashcard_id, msg.card_id, msg.result);
+          break;
+        case "card-error":
+          callbacks.onCardError(msg.dashcard_id, msg.card_id, msg.error);
+          break;
+        case "complete":
+          callbacks.onComplete(msg);
+          break;
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}

--- a/frontend/src/metabase/dashboard/actions/batch-card-query.ts
+++ b/frontend/src/metabase/dashboard/actions/batch-card-query.ts
@@ -32,15 +32,22 @@ type BatchCardEnd = {
   data: Partial<DatasetData> & Record<string, unknown>;
 } & Record<string, unknown>;
 
+// The server emits `card-error` with the failed-Dataset envelope spread at the top level
+// alongside the routing fields (symmetric to `card-end`). Strip `type`/`dashcard_id`/`card_id`
+// and the remainder is a Dataset. `json_query` carries the parameters that were applied to the
+// failing query, so the dashcardData cache can detect when the user changes a param mapping
+// (e.g. removing a broken mapping → params differ → refetch — #32573).
 type BatchCardError = {
   type: "card-error";
   dashcard_id: DashCardId;
   card_id: CardId;
-  // `status` and `message` are always present; the rest of the QP error
-  // payload (`error`, `error_is_curated`, `error_type`, `ex-data`, ...) rides
-  // along so callers can surface curated messages.
-  error: { status: number; message: string } & Record<string, unknown>;
-};
+  status: "failed";
+  error: string;
+  error_type?: string;
+  error_is_curated?: boolean;
+  json_query?: Record<string, unknown>;
+  data: { cols: unknown[]; rows: unknown[] };
+} & Record<string, unknown>;
 
 type BatchComplete = {
   type: "complete";
@@ -65,7 +72,7 @@ export type BatchCallbacks = {
   onCardError: (
     dashcardId: DashCardId,
     cardId: CardId,
-    error: { status: number; message: string } & Record<string, unknown>,
+    dataset: Dataset,
   ) => void;
   onComplete: (summary: {
     total: number;
@@ -163,7 +170,12 @@ function handleMessage(
     }
     case "card-error": {
       partial.delete(keyOf(msg.dashcard_id, msg.card_id));
-      callbacks.onCardError(msg.dashcard_id, msg.card_id, msg.error);
+      const { type: _t, dashcard_id: _dc, card_id: _cid, ...dataset } = msg;
+      callbacks.onCardError(
+        msg.dashcard_id,
+        msg.card_id,
+        dataset as unknown as Dataset,
+      );
       return;
     }
     case "complete": {

--- a/frontend/src/metabase/dashboard/actions/batch-card-query.ts
+++ b/frontend/src/metabase/dashboard/actions/batch-card-query.ts
@@ -219,7 +219,7 @@ export async function streamBatchCardQuery(
     headers["Content-Type"] = "application/json";
     fetchInit.body = JSON.stringify(body);
   }
-  const response = await fetch(url, fetchInit);
+  const response = await fetch(api.basename + url, fetchInit);
 
   if (!response.ok) {
     // Surface the server-side message (e.g. "You must specify a value for :source

--- a/frontend/src/metabase/dashboard/actions/batch-card-query.ts
+++ b/frontend/src/metabase/dashboard/actions/batch-card-query.ts
@@ -1,4 +1,4 @@
-import api from "metabase/utils/api";
+import api from "metabase/api/legacy-client";
 import type {
   CardId,
   DashCardId,

--- a/frontend/src/metabase/dashboard/actions/batch-card-query.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/actions/batch-card-query.unit.spec.ts
@@ -1,0 +1,141 @@
+import { buildCardQueryBatchNdjson } from "__support__/server-mocks/dashcard";
+import { createMockDataset } from "metabase-types/api/mocks";
+
+import { streamBatchCardQuery } from "./batch-card-query";
+
+function ndjsonResponse(body: string): Response {
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(body));
+      controller.close();
+    },
+  });
+  return { ok: true, status: 200, body: stream } as unknown as Response;
+}
+
+function setupFetch(body: string) {
+  const original = global.fetch;
+  global.fetch = (async () => ndjsonResponse(body)) as typeof fetch;
+  return () => {
+    global.fetch = original;
+  };
+}
+
+describe("streamBatchCardQuery card-error handling", () => {
+  it("delivers a failed Dataset envelope to onCardError", async () => {
+    const body = buildCardQueryBatchNdjson(
+      [{ id: 11, card_id: 22 }],
+      createMockDataset(),
+      new Map([
+        [
+          11,
+          {
+            error: "boom",
+            error_type: "missing-required-permissions",
+            error_is_curated: true,
+          },
+        ],
+      ]),
+    );
+    const restore = setupFetch(body);
+
+    const onCardResult = jest.fn();
+    const onCardError = jest.fn();
+    const onComplete = jest.fn();
+
+    try {
+      await streamBatchCardQuery(
+        { url: "/api/dashboard/1/card-query-batch", method: "POST" },
+        { onCardResult, onCardError, onComplete },
+      );
+    } finally {
+      restore();
+    }
+
+    expect(onCardResult).not.toHaveBeenCalled();
+    expect(onCardError).toHaveBeenCalledTimes(1);
+
+    const [dashcardId, cardId, dataset] = onCardError.mock.calls[0];
+    expect(dashcardId).toBe(11);
+    expect(cardId).toBe(22);
+    expect(dataset).toEqual({
+      status: "failed",
+      error: "boom",
+      error_type: "missing-required-permissions",
+      error_is_curated: true,
+      data: { cols: [], rows: [] },
+    });
+  });
+
+  it("forwards json_query so cached errors can be matched against new params on subsequent fetches (#32573)", async () => {
+    const json_query = {
+      database: 1,
+      type: "query",
+      query: { "source-table": 1 },
+      parameters: [
+        {
+          id: "abc",
+          type: "id",
+          value: [42],
+          target: [
+            "dimension",
+            ["field", "DOES_NOT_EXIST", { "base-type": "type/Integer" }],
+          ],
+        },
+      ],
+    };
+    const body = buildCardQueryBatchNdjson(
+      [{ id: 3, card_id: 4 }],
+      createMockDataset(),
+      new Map([[3, { error: "boom", json_query }]]),
+    );
+    const restore = setupFetch(body);
+
+    const onCardError = jest.fn();
+    try {
+      await streamBatchCardQuery(
+        { url: "/api/dashboard/1/card-query-batch", method: "POST" },
+        {
+          onCardResult: jest.fn(),
+          onCardError,
+          onComplete: jest.fn(),
+        },
+      );
+    } finally {
+      restore();
+    }
+
+    const [, , dataset] = onCardError.mock.calls[0];
+    expect(dataset.json_query).toEqual(json_query);
+  });
+
+  it("omits optional fields when the server does not send them", async () => {
+    const body = buildCardQueryBatchNdjson(
+      [{ id: 7, card_id: 9 }],
+      createMockDataset(),
+      new Map([[7, { error: "Card not found in dashboard" }]]),
+    );
+    const restore = setupFetch(body);
+
+    const onCardError = jest.fn();
+    try {
+      await streamBatchCardQuery(
+        { url: "/api/dashboard/1/card-query-batch", method: "POST" },
+        {
+          onCardResult: jest.fn(),
+          onCardError,
+          onComplete: jest.fn(),
+        },
+      );
+    } finally {
+      restore();
+    }
+
+    const [, , dataset] = onCardError.mock.calls[0];
+    expect(dataset).toEqual({
+      status: "failed",
+      error: "Card not found in dashboard",
+      data: { cols: [], rows: [] },
+    });
+  });
+});

--- a/frontend/src/metabase/dashboard/actions/cards-typed.ts
+++ b/frontend/src/metabase/dashboard/actions/cards-typed.ts
@@ -70,7 +70,11 @@ import {
   setDashCardAttributes,
   setDashboardAttributes,
 } from "./core";
-import { cancelFetchCardData, fetchCardData } from "./data-fetching";
+import {
+  abortBatchCardQuery,
+  cancelFetchCardData,
+  fetchCardData,
+} from "./data-fetching";
 import {
   duplicateParameters,
   removeParameterAndReferences,
@@ -485,6 +489,10 @@ export const removeCardFromDashboard = createThunkAction(
 
       dispatch(closeAddCardAutoWireToasts());
       dispatch(cancelFetchCardData(cardId, dashcardId));
+      // Batch endpoint can't cancel a single card mid-stream; abort the whole
+      // batch so removing a card during a slow load doesn't keep the stream
+      // running. The next fetchDashboardCardData refetches what's left.
+      abortBatchCardQuery();
       if (hasInlineParameters(dashcard)) {
         dashcard.inline_parameters.forEach((parameterId) => {
           removeParameterAndReferences(dispatch, getState, parameterId);

--- a/frontend/src/metabase/dashboard/actions/data-fetching.ts
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.ts
@@ -84,7 +84,7 @@ export const RECEIVE_BATCH_CARD_RESULT =
 export const receiveBatchCardResult = createAction<{
   dashcard_id: DashCardId;
   card_id: CardId;
-  result: Dataset | { error: unknown };
+  result: Dataset;
 }>(RECEIVE_BATCH_CARD_RESULT);
 
 export const FETCH_CARD_DATA = "metabase/dashboard/FETCH_CARD_DATA";
@@ -775,40 +775,10 @@ export const fetchDashboardCardData =
         return;
       }
 
-      // Build the cached "dataset" for an errored card:
-      //   - lift `error_type` / `error_is_curated` to the top level so the
-      //     curated/permission branches in `getDashcardResultsError` fire
-      //   - keep the error message/payload under `.error`, matching the
-      //     per-card path (`fetchDataOrError` returns `{ error }` on 5xx);
-      //     the generic-error branch keys off `dataset.error` being truthy
-      //   - DO NOT spread the raw error map: it carries a `data` field
-      //     (QP error context) that would land in the Dataset's `.data` slot
-      //     and crash visualization code that does `data.cols.map(…)`
-      const buildErrorResult = (
-        error: {
-          error_type?: unknown;
-          error_is_curated?: unknown;
-        } & Record<string, unknown>,
-      ) => {
-        const { error_type, error_is_curated } = error;
-        return {
-          error,
-          ...(error_type != null && { error_type }),
-          ...(error_is_curated != null && { error_is_curated }),
-        } as unknown as Dataset;
-      };
-
       const dispatchBatchCardResult = (
         dashcardId: DashCardId,
         cardId: CardId,
-        payload:
-          | { result: Dataset }
-          | {
-              error: {
-                error_type?: unknown;
-                error_is_curated?: unknown;
-              } & Record<string, unknown>;
-            },
+        result: Dataset,
       ) => {
         const key = `${dashcardId},${cardId}` as const;
         const current = cardDataCancelDeferreds[key];
@@ -823,10 +793,7 @@ export const fetchDashboardCardData =
           receiveBatchCardResult({
             dashcard_id: dashcardId,
             card_id: cardId,
-            result:
-              "error" in payload
-                ? buildErrorResult(payload.error)
-                : payload.result,
+            result,
           }),
         );
         completedCount++;
@@ -834,15 +801,9 @@ export const fetchDashboardCardData =
       };
 
       return streamBatchCardQuery(requestConfig, {
-        onCardResult: (dashcardId, cardId, result) =>
-          dispatchBatchCardResult(dashcardId, cardId, { result }),
-        onCardError: (dashcardId, cardId, error) =>
-          dispatchBatchCardResult(dashcardId, cardId, {
-            error: error as {
-              error_type?: unknown;
-              error_is_curated?: unknown;
-            } & Record<string, unknown>,
-          }),
+        onCardResult: dispatchBatchCardResult,
+        onCardError: (dashcardId, cardId, dataset) =>
+          dispatchBatchCardResult(dashcardId, cardId, dataset as Dataset),
         onComplete: () => {
           clearBatchDeferreds();
           batchFetchAbortController = null;
@@ -858,16 +819,15 @@ export const fetchDashboardCardData =
         // Entire batch failed before any card-begin (e.g. locked parameter
         // without JWT value). Mark every card we asked for as errored so the
         // dashcard renders an error state instead of an infinite spinner.
-        const status =
-          (err && typeof err === "object" && "status" in err
-            ? (err as { status?: number }).status
-            : undefined) ?? 500;
         const message =
           err instanceof Error ? err.message : "Batch card query failed";
+        const errorDataset = {
+          status: "failed",
+          error: message,
+          data: { cols: [], rows: [] },
+        } as unknown as Dataset;
         for (const { card, dashcard } of batchCardsToFetch) {
-          dispatchBatchCardResult(dashcard.id, card.id, {
-            error: { status, message },
-          });
+          dispatchBatchCardResult(dashcard.id, card.id, errorDataset);
         }
         clearBatchDeferreds();
         batchFetchAbortController = null;

--- a/frontend/src/metabase/dashboard/actions/data-fetching.ts
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.ts
@@ -258,13 +258,15 @@ export const fetchCardDataAction = createAsyncThunk<
 
     const dashboard = dashboards[dashboardId];
 
+    // Safe to assert non-null here: the `!card.dataset_query` guard above
+    // is the only case buildCardQuery returns null.
     const { datasetQuery, queryParams } = buildCardQuery(
       card,
       dashcard,
       dashboard.parameters,
       parameterValues,
       editingDashboard?.parameters,
-    );
+    )!;
 
     const lastResult = getIn(dashcardData, [dashcard.id, card.id]);
     if (!reload) {
@@ -616,19 +618,22 @@ export const fetchDashboardCardData =
     type BatchEntry = {
       card: Card;
       dashcard: (typeof nonVirtualDashcards)[number]["dashcard"];
-      queryParams: ReturnType<typeof getDatasetQueryParams>;
+      // `null` when the card was stripped of `dataset_query` by the backend —
+      // the dashcard still goes in the batch so the backend can emit the 403.
+      queryParams: ReturnType<typeof getDatasetQueryParams> | null;
     };
     const batchEntries: BatchEntry[] = useBatchEndpoint
       ? nonVirtualDashcardsToFetch.map(({ card, dashcard }) => ({
           card: card as Card,
           dashcard,
-          queryParams: buildCardQuery(
-            card as Card,
-            dashcard,
-            dashboard.parameters,
-            parameterValues,
-            editingDashboard?.parameters,
-          ).queryParams,
+          queryParams:
+            buildCardQuery(
+              card as Card,
+              dashcard,
+              dashboard.parameters,
+              parameterValues,
+              editingDashboard?.parameters,
+            )?.queryParams ?? null,
         }))
       : [];
 
@@ -746,7 +751,12 @@ export const fetchDashboardCardData =
       for (const { card, dashcard, queryParams } of batchCardsToFetch) {
         const deferred = defer();
         batchDeferreds.set(`${dashcard.id},${card.id}`, deferred);
-        setFetchCardDataCancel(card.id, dashcard.id, deferred, queryParams);
+        setFetchCardDataCancel(
+          card.id,
+          dashcard.id,
+          deferred,
+          queryParams ?? undefined,
+        );
       }
 
       const clearBatchDeferreds = () => {
@@ -980,6 +990,13 @@ function buildCardQuery(
   parameterValues: ParameterValuesMap,
   editingDashboardParameters: Parameter[] | null | undefined,
 ) {
+  // The backend strips `dataset_query` from cards the current user can't read.
+  // Return null so the batch dispatch can still include the dashcard — the
+  // backend's per-card runner emits a real 403 card-error which the FE then
+  // surfaces as the standard permission-error tile.
+  if (!card.dataset_query) {
+    return null;
+  }
   const savedParameterIds = new Set(
     editingDashboardParameters?.map((p) => p.id),
   );

--- a/frontend/src/metabase/dashboard/actions/data-fetching.ts
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.ts
@@ -648,9 +648,12 @@ export const fetchDashboardCardData =
         ]);
         if (
           lastResult &&
+          !("error" in lastResult) &&
           _.isEqual(getDatasetQueryParams(lastResult.json_query), queryParams)
         ) {
-          continue; // cached, drop from both loadingIds and batch
+          // Cached. Note: error results always retry — the user may have fixed
+          // a bad parameter mapping or upstream config.
+          continue;
         }
         const inFlight = cardDataCancelDeferreds[key];
         if (inFlight && _.isEqual(inFlight.queryParams, queryParams)) {
@@ -936,17 +939,22 @@ export const cancelFetchCardData = createAction(
       entry.deferred.resolve();
       cardDataCancelDeferreds[`${dashcard_id},${card_id}`] = null;
     }
-    // Per-card XHR cancellation isn't possible on the batch endpoint — a
-    // batch carries every loading card on one fetch. Abort it so removing /
-    // navigating away from a card during load doesn't leave a slow stream
-    // running; the remaining cards refetch on the next fetchDashboardCardData.
-    if (batchFetchAbortController) {
-      batchFetchAbortController.abort();
-      batchFetchAbortController = null;
-    }
     return { payload: { dashcard_id, card_id } };
   },
 );
+
+/**
+ * Abort the in-flight batch card-query request, if any. Per-card cancellation
+ * isn't possible on the batch endpoint — one fetch carries every loading card.
+ * Callers that need to stop a mid-stream batch (e.g. dashcard removal) invoke
+ * this directly.
+ */
+export function abortBatchCardQuery() {
+  if (batchFetchAbortController) {
+    batchFetchAbortController.abort();
+    batchFetchAbortController = null;
+  }
+}
 
 export const clearCardData = createAction(
   CLEAR_CARD_DATA,

--- a/frontend/src/metabase/dashboard/actions/data-fetching.ts
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.ts
@@ -40,6 +40,7 @@ import {
   DashboardApi,
   EmbedApi,
   PublicApi,
+  getEmbedBase,
   maybeUsePivotEndpoint,
   runAdhocDatasetQuery,
   shouldUsePivotEndpoint,
@@ -552,8 +553,10 @@ function getBatchRequestConfig(
       qs.set("cards", JSON.stringify(cards));
     }
     const query = qs.toString();
+    // getEmbedBase() returns /api/preview_embed inside the embed-preview iframe
+    // and /api/embed everywhere else; both routes expose card-query-batch.
     return {
-      url: `/api/embed/dashboard/${dashboardId}/card-query-batch${query ? `?${query}` : ""}`,
+      url: `${getEmbedBase()}/dashboard/${dashboardId}/card-query-batch${query ? `?${query}` : ""}`,
       method: "GET",
       signal,
     };
@@ -565,10 +568,6 @@ function canUseBatchEndpoint(
   dashboardType: string,
   isEditing: boolean,
 ): boolean {
-  // preview_embed has no batch endpoint; fall back to per-card there
-  if (dashboardType === "embed" && getIsEmbedPreview()) {
-    return false;
-  }
   return (
     !isEditing &&
     (dashboardType === "normal" ||

--- a/frontend/src/metabase/dashboard/actions/data-fetching.ts
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.ts
@@ -775,10 +775,40 @@ export const fetchDashboardCardData =
         return;
       }
 
+      // Build the cached "dataset" for an errored card:
+      //   - lift `error_type` / `error_is_curated` to the top level so the
+      //     curated/permission branches in `getDashcardResultsError` fire
+      //   - keep the error message/payload under `.error`, matching the
+      //     per-card path (`fetchDataOrError` returns `{ error }` on 5xx);
+      //     the generic-error branch keys off `dataset.error` being truthy
+      //   - DO NOT spread the raw error map: it carries a `data` field
+      //     (QP error context) that would land in the Dataset's `.data` slot
+      //     and crash visualization code that does `data.cols.map(…)`
+      const buildErrorResult = (
+        error: {
+          error_type?: unknown;
+          error_is_curated?: unknown;
+        } & Record<string, unknown>,
+      ) => {
+        const { error_type, error_is_curated } = error;
+        return {
+          error,
+          ...(error_type != null && { error_type }),
+          ...(error_is_curated != null && { error_is_curated }),
+        } as unknown as Dataset;
+      };
+
       const dispatchBatchCardResult = (
         dashcardId: DashCardId,
         cardId: CardId,
-        payload: { result?: Dataset; error?: unknown },
+        payload:
+          | { result: Dataset }
+          | {
+              error: {
+                error_type?: unknown;
+                error_is_curated?: unknown;
+              } & Record<string, unknown>;
+            },
       ) => {
         const key = `${dashcardId},${cardId}` as const;
         const current = cardDataCancelDeferreds[key];
@@ -794,9 +824,9 @@ export const fetchDashboardCardData =
             dashcard_id: dashcardId,
             card_id: cardId,
             result:
-              payload.error !== undefined
-                ? (payload.error as Dataset)
-                : payload.result!,
+              "error" in payload
+                ? buildErrorResult(payload.error)
+                : payload.result,
           }),
         );
         completedCount++;
@@ -807,11 +837,12 @@ export const fetchDashboardCardData =
         onCardResult: (dashcardId, cardId, result) =>
           dispatchBatchCardResult(dashcardId, cardId, { result }),
         onCardError: (dashcardId, cardId, error) =>
-          // Pass the error payload directly (not wrapped in `{error}`) so
-          // `error_is_curated`, `error_type`, etc. sit at the top level of the
-          // cached dataset for `getDashcardResultsError` to surface a curated
-          // message.
-          dispatchBatchCardResult(dashcardId, cardId, { error }),
+          dispatchBatchCardResult(dashcardId, cardId, {
+            error: error as {
+              error_type?: unknown;
+              error_is_curated?: unknown;
+            } & Record<string, unknown>,
+          }),
         onComplete: () => {
           clearBatchDeferreds();
           batchFetchAbortController = null;

--- a/frontend/src/metabase/dashboard/actions/data-fetching.ts
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.ts
@@ -746,7 +746,18 @@ export const fetchDashboardCardData =
       }));
 
       const abortController = new AbortController();
-      batchFetchAbortController = abortController;
+      batchFetchAbortControllers.push(abortController);
+      while (batchFetchAbortControllers.length > MAX_OVERLAPPING_BATCHES) {
+        const oldest = batchFetchAbortControllers.shift();
+        oldest?.abort();
+      }
+
+      const removeAbortController = () => {
+        const idx = batchFetchAbortControllers.indexOf(abortController);
+        if (idx !== -1) {
+          batchFetchAbortControllers.splice(idx, 1);
+        }
+      };
 
       let completedCount = 0;
       const totalCount = batchCardsToFetch.length;
@@ -793,6 +804,7 @@ export const fetchDashboardCardData =
       if (!requestConfig) {
         // Shouldn't happen given canUseBatchEndpoint check, but satisfy TS
         clearBatchDeferreds();
+        removeAbortController();
         return;
       }
 
@@ -827,13 +839,14 @@ export const fetchDashboardCardData =
           dispatchBatchCardResult(dashcardId, cardId, dataset as Dataset),
         onComplete: () => {
           clearBatchDeferreds();
-          batchFetchAbortController = null;
+          removeAbortController();
           dispatch(loadingComplete());
         },
       }).catch((err) => {
         if (err?.name === "AbortError") {
           clearBatchDeferreds();
-          batchFetchAbortController = null;
+          removeAbortController();
+          dispatch(loadingComplete());
           return;
         }
         console.error("Batch card query failed:", err);
@@ -841,7 +854,7 @@ export const fetchDashboardCardData =
         // without JWT value). Mark every card we asked for as errored so the
         // dashcard renders an error state instead of an infinite spinner.
         const message =
-          err instanceof Error ? err.message : "Batch card query failed";
+          err instanceof Error ? err.message : t`Batch card query failed`;
         const errorDataset = {
           status: "failed",
           error: message,
@@ -851,7 +864,7 @@ export const fetchDashboardCardData =
           dispatchBatchCardResult(dashcard.id, card.id, errorDataset);
         }
         clearBatchDeferreds();
-        batchFetchAbortController = null;
+        removeAbortController();
         dispatch(loadingComplete());
       });
     }
@@ -930,7 +943,13 @@ type InFlightEntry = {
   queryParams: ReturnType<typeof getDatasetQueryParams>;
 };
 
-let batchFetchAbortController: AbortController | null = null;
+// Bounded queue of live batch AbortControllers. When a new batch starts and the
+// queue is at capacity, the oldest controller is aborted before the new one is
+// pushed. This preserves the #70534 single-overlap intent (the first overlap
+// stays alive so slow in-flight work isn't restarted) while preventing
+// unbounded overlap under rapid retriggers (e.g. slider drag).
+const MAX_OVERLAPPING_BATCHES = 2;
+const batchFetchAbortControllers: AbortController[] = [];
 
 const cardDataCancelDeferreds: Record<
   `${DashCardId},${DashboardCard["card_id"]}`,
@@ -968,9 +987,9 @@ export const cancelFetchCardData = createAction(
  * this directly.
  */
 export function abortBatchCardQuery() {
-  if (batchFetchAbortController) {
-    batchFetchAbortController.abort();
-    batchFetchAbortController = null;
+  while (batchFetchAbortControllers.length > 0) {
+    const controller = batchFetchAbortControllers.shift();
+    controller?.abort();
   }
 }
 

--- a/frontend/src/metabase/dashboard/actions/data-fetching.ts
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.ts
@@ -802,11 +802,32 @@ export const fetchDashboardCardData =
           dispatch(loadingComplete());
         },
       }).catch((err) => {
-        if (err?.name !== "AbortError") {
-          console.error("Batch card query failed:", err);
+        if (err?.name === "AbortError") {
+          batchFetchAbortController = null;
+          return;
+        }
+        console.error("Batch card query failed:", err);
+        // Entire batch failed before any card-begin (e.g. locked parameter
+        // without JWT value). Mark every card we asked for as errored so the
+        // dashcard renders an error state instead of an infinite spinner.
+        const status =
+          (err && typeof err === "object" && "status" in err
+            ? (err as { status?: number }).status
+            : undefined) ?? 500;
+        const message =
+          err instanceof Error ? err.message : "Batch card query failed";
+        for (const { card, dashcard } of cardsNeedingFetch) {
+          dispatch(
+            receiveBatchCardResult({
+              dashcard_id: dashcard.id,
+              card_id: (card as Card).id,
+              result: { error: { status, message } },
+            }),
+          );
         }
         clearBatchDeferreds();
         batchFetchAbortController = null;
+        dispatch(loadingComplete());
       });
     }
 

--- a/frontend/src/metabase/dashboard/actions/data-fetching.ts
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.ts
@@ -26,6 +26,7 @@ import {
   getAllDashboardCards,
   getCurrentTabDashboardCards,
 } from "metabase/dashboard/utils";
+import { isEmbedPreview as getIsEmbedPreview } from "metabase/embedding/config";
 import { entityCompatibleQuery } from "metabase/entities/utils";
 import { getSavedDashboardUiParameters } from "metabase/parameters/utils/dashboards";
 import { getParameterValuesByIdFromQueryParams } from "metabase/parameters/utils/parameter-parsing";
@@ -564,6 +565,10 @@ function canUseBatchEndpoint(
   dashboardType: string,
   isEditing: boolean,
 ): boolean {
+  // preview_embed has no batch endpoint; fall back to per-card there
+  if (dashboardType === "embed" && getIsEmbedPreview()) {
+    return false;
+  }
   return (
     !isEditing &&
     (dashboardType === "normal" ||
@@ -654,7 +659,12 @@ export const fetchDashboardCardData =
           continue;
         }
         if (inFlight) {
-          dispatch(cancelFetchCardData(card.id, dashcard.id));
+          // Clear the stale entry inline rather than dispatching cancelFetchCardData — the latter
+          // aborts the whole batch (which would discard in-flight work for cards whose params
+          // didn't change). The old batch's onCardResult for this card will be dropped by the
+          // deferred-identity check in dispatchBatchCardResult.
+          inFlight.deferred.resolve();
+          cardDataCancelDeferreds[key] = null;
         }
         if (lastResult) {
           dispatch(clearCardData(card.id, dashcard.id));
@@ -905,6 +915,14 @@ export const cancelFetchCardData = createAction(
     if (entry) {
       entry.deferred.resolve();
       cardDataCancelDeferreds[`${dashcard_id},${card_id}`] = null;
+    }
+    // Per-card XHR cancellation isn't possible on the batch endpoint — a
+    // batch carries every loading card on one fetch. Abort it so removing /
+    // navigating away from a card during load doesn't leave a slow stream
+    // running; the remaining cards refetch on the next fetchDashboardCardData.
+    if (batchFetchAbortController) {
+      batchFetchAbortController.abort();
+      batchFetchAbortController = null;
     }
     return { payload: { dashcard_id, card_id } };
   },

--- a/frontend/src/metabase/dashboard/actions/data-fetching.ts
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.ts
@@ -538,17 +538,14 @@ function getBatchRequestConfig(
   }
   if (dashboardType === "embed") {
     const qs = new URLSearchParams();
-    // Embed uses slug-based parameter values
+    // Match per-card embed behavior: pass slug values as JSON in a `parameters`
+    // query param so arrays and types are preserved (parse-query-params decodes it)
     if (dashboardParameters) {
       const slugValues = getParameterValuesBySlug(
         dashboardParameters,
         parameterValues,
       );
-      for (const [slug, value] of Object.entries(slugValues)) {
-        if (value != null) {
-          qs.set(slug, String(value));
-        }
-      }
+      qs.set("parameters", JSON.stringify(slugValues));
     }
     if (cards.length > 0) {
       qs.set("cards", JSON.stringify(cards));

--- a/frontend/src/metabase/dashboard/actions/data-fetching.ts
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.ts
@@ -651,13 +651,22 @@ export const fetchDashboardCardData =
           dashcard.id,
           card.id,
         ]);
+        // Permission-stripped cards (backend deleted dataset_query because the
+        // user can't read this card) mirror the per-card path's early-out at
+        // fetchCardDataAction: once we have any cached result, don't re-fetch.
+        // The first load still hits the server so it can emit the canonical
+        // 403 card-error.
+        if (!card.dataset_query) {
+          if (lastResult) {
+            continue;
+          }
+          batchCardsToFetch.push(entry);
+          continue;
+        }
         if (
           lastResult &&
-          !("error" in lastResult) &&
           _.isEqual(getDatasetQueryParams(lastResult.json_query), queryParams)
         ) {
-          // Cached. Note: error results always retry — the user may have fixed
-          // a bad parameter mapping or upstream config.
           continue;
         }
         const inFlight = cardDataCancelDeferreds[key];

--- a/frontend/src/metabase/dashboard/actions/data-fetching.ts
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.ts
@@ -6,6 +6,8 @@ import _ from "underscore";
 
 import { automagicDashboardsApi, cardApi, dashboardApi } from "metabase/api";
 import { applyParameters } from "metabase/common/utils/card";
+import type { BatchRequestConfig } from "metabase/dashboard/actions/batch-card-query";
+import { streamBatchCardQuery } from "metabase/dashboard/actions/batch-card-query";
 import { showAutoApplyFiltersToast } from "metabase/dashboard/actions/parameters";
 import { DASHBOARD_SLOW_TIMEOUT } from "metabase/dashboard/constants";
 import {
@@ -60,6 +62,7 @@ import type {
   DashboardId,
   Dataset,
   JsonQuery,
+  Parameter,
   ParameterValuesMap,
   QuestionDashboardCard,
 } from "metabase-types/api";
@@ -73,6 +76,14 @@ export const fetchDashboardCardDataAction = createAction<{
 
 export const CANCEL_FETCH_DASHBOARD_CARD_DATA =
   "metabase/dashboard/CANCEL_FETCH_DASHBOARD_CARD_DATA";
+
+export const RECEIVE_BATCH_CARD_RESULT =
+  "metabase/dashboard/RECEIVE_BATCH_CARD_RESULT";
+export const receiveBatchCardResult = createAction<{
+  dashcard_id: DashCardId;
+  card_id: CardId;
+  result: Dataset | { error: unknown };
+}>(RECEIVE_BATCH_CARD_RESULT);
 
 export const FETCH_CARD_DATA = "metabase/dashboard/FETCH_CARD_DATA";
 export const ADD_DASHCARD_IDS_TO_LOADING_QUEUE =
@@ -245,24 +256,12 @@ export const fetchCardDataAction = createAsyncThunk<
 
     const dashboard = dashboards[dashboardId];
 
-    // if the dashboard is being edited, ignore parameters that do not exist in
-    // the saved dashboard to avoid query errors
-    const savedParameterIds = new Set(
-      editingDashboard?.parameters?.map((parameter) => parameter.id),
-    );
-    const savedParameters =
-      editingDashboard != null
-        ? dashboard.parameters?.filter((parameter) =>
-            savedParameterIds.has(parameter.id),
-          )
-        : dashboard.parameters;
-
-    // if we have a parameter, apply it to the card query before we execute
-    const datasetQuery = applyParameters(
+    const { datasetQuery, queryParams } = buildCardQuery(
       card,
-      savedParameters,
+      dashcard,
+      dashboard.parameters,
       parameterValues,
-      dashcard?.parameter_mappings ?? undefined,
+      editingDashboard?.parameters,
     );
 
     const lastResult = getIn(dashcardData, [dashcard.id, card.id]);
@@ -270,10 +269,7 @@ export const fetchCardDataAction = createAsyncThunk<
       // if reload not set, check to see if the last result has the same query dict and return that
       if (
         lastResult &&
-        _.isEqual(
-          getDatasetQueryParams(lastResult.json_query),
-          getDatasetQueryParams(datasetQuery),
-        )
+        _.isEqual(getDatasetQueryParams(lastResult.json_query), queryParams)
       ) {
         return {
           dashcard_id: dashcard.id,
@@ -289,10 +285,7 @@ export const fetchCardDataAction = createAsyncThunk<
        * path below.
        */
       const inFlight = cardDataCancelDeferreds[`${dashcard.id},${card.id}`];
-      if (
-        inFlight &&
-        _.isEqual(inFlight.queryParams, getDatasetQueryParams(datasetQuery))
-      ) {
+      if (inFlight && _.isEqual(inFlight.queryParams, queryParams)) {
         return;
       }
     }
@@ -303,10 +296,7 @@ export const fetchCardDataAction = createAsyncThunk<
     // state so that the loader spinner shows as expected (#33767)
     const hasParametersChanged =
       !lastResult ||
-      !_.isEqual(
-        getDatasetQueryParams(lastResult.json_query),
-        getDatasetQueryParams(datasetQuery),
-      );
+      !_.isEqual(getDatasetQueryParams(lastResult.json_query), queryParams);
 
     if (clearCache || hasParametersChanged) {
       // clears the card data to indicate the card is reloading
@@ -323,12 +313,7 @@ export const fetchCardDataAction = createAsyncThunk<
     }, DASHBOARD_SLOW_TIMEOUT);
 
     const deferred = defer();
-    setFetchCardDataCancel(
-      card.id,
-      dashcard.id,
-      deferred,
-      getDatasetQueryParams(datasetQuery),
-    );
+    setFetchCardDataCancel(card.id, dashcard.id, deferred, queryParams);
 
     let cancelled = false;
     deferred.promise.then(() => {
@@ -512,6 +497,84 @@ async function runWithConcurrencyLimit(
   );
 }
 
+function getBatchRequestConfig(
+  dashboardId: DashboardId,
+  dashboardType: string,
+  dashboardLoadId: string,
+  parameters: { id: string; type: string; value: unknown }[],
+  cards: { dashcard_id: DashCardId; card_id: CardId }[],
+  parameterValues: ParameterValuesMap,
+  dashboardParameters: { id: string; slug?: string }[] | undefined,
+  ignoreCache: boolean,
+  signal: AbortSignal,
+): BatchRequestConfig | null {
+  if (dashboardType === "normal") {
+    return {
+      url: `/api/dashboard/${dashboardId}/card-query-batch`,
+      method: "POST",
+      body: {
+        dashboard_load_id: dashboardLoadId,
+        parameters,
+        ignore_cache: ignoreCache,
+        cards,
+      },
+      signal,
+    };
+  }
+  if (dashboardType === "public") {
+    const qs = new URLSearchParams();
+    if (parameters.length > 0) {
+      qs.set("parameters", JSON.stringify(parameters));
+    }
+    if (cards.length > 0) {
+      qs.set("cards", JSON.stringify(cards));
+    }
+    const query = qs.toString();
+    return {
+      url: `/api/public/dashboard/${dashboardId}/card-query-batch${query ? `?${query}` : ""}`,
+      method: "GET",
+      signal,
+    };
+  }
+  if (dashboardType === "embed") {
+    const qs = new URLSearchParams();
+    // Embed uses slug-based parameter values
+    if (dashboardParameters) {
+      const slugValues = getParameterValuesBySlug(
+        dashboardParameters,
+        parameterValues,
+      );
+      for (const [slug, value] of Object.entries(slugValues)) {
+        if (value != null) {
+          qs.set(slug, String(value));
+        }
+      }
+    }
+    if (cards.length > 0) {
+      qs.set("cards", JSON.stringify(cards));
+    }
+    const query = qs.toString();
+    return {
+      url: `/api/embed/dashboard/${dashboardId}/card-query-batch${query ? `?${query}` : ""}`,
+      method: "GET",
+      signal,
+    };
+  }
+  return null;
+}
+
+function canUseBatchEndpoint(
+  dashboardType: string,
+  isEditing: boolean,
+): boolean {
+  return (
+    !isEditing &&
+    (dashboardType === "normal" ||
+      dashboardType === "public" ||
+      dashboardType === "embed")
+  );
+}
+
 export const fetchDashboardCardData =
   ({ isRefreshing = false, reload = false, clearCache = false } = {}) =>
   (dispatch: Dispatch, getState: GetState) => {
@@ -528,51 +591,228 @@ export const fetchDashboardCardData =
       selectedTabId,
     ).filter(({ dashcard }) => !isVirtualDashCard(dashcard));
 
-    let nonVirtualDashcardsToFetch = [];
+    const dashboardType = getDashboardType(dashboard.id);
+    const { editingDashboard, parameterValues } = getState().dashboard;
+    const isEditing = editingDashboard != null;
+    const useBatchEndpoint = canUseBatchEndpoint(dashboardType, isEditing);
+
+    let nonVirtualDashcardsToFetch: typeof nonVirtualDashcards = [];
     if (isRefreshing) {
       nonVirtualDashcardsToFetch = nonVirtualDashcards.filter(
         ({ dashcard }) => {
           return !loadingIds.includes(dashcard.id);
         },
       );
-      const newLoadingIds = nonVirtualDashcardsToFetch.map(({ dashcard }) => {
-        return dashcard.id;
-      });
-
-      dispatch(
-        fetchDashboardCardDataAction({
-          currentTime: performance.now(),
-          loadingIds: loadingIds.concat(newLoadingIds),
-        }),
-      );
     } else {
       nonVirtualDashcardsToFetch = nonVirtualDashcards;
-      const newLoadingIds = nonVirtualDashcardsToFetch.map(({ dashcard }) => {
-        return dashcard.id;
-      });
-
-      /**
-       * We intentionally do NOT cancel in-flight requests here. Each card's fetch (fetchCardDataAction) handles its
-       * own deduplication: it returns early when an identical request is already in-flight and cancels stale requests
-       * when parameters change. Batch-cancelling here would abort nearly-complete requests on tab switch, forcing
-       * slow queries (e.g. pivots) to restart from scratch. (#70534)
-       */
-
-      dispatch(
-        fetchDashboardCardDataAction({
-          currentTime: performance.now(),
-          loadingIds: newLoadingIds,
-        }),
-      );
     }
 
+    // Pre-filter for the batch path: classify each card as cached (no fetch needed), already
+    // in-flight with matching params (let the existing request finish), already in-flight with
+    // different params (cancel and re-fetch), or fresh. Cached cards are dropped from loadingIds
+    // entirely; the others are loaded. The per-card path does this dedup inside
+    // fetchCardDataAction, so we skip it here when canUseBatchEndpoint is false.
+    type BatchEntry = {
+      card: Card;
+      dashcard: (typeof nonVirtualDashcards)[number]["dashcard"];
+      queryParams: ReturnType<typeof getDatasetQueryParams>;
+    };
+    const batchEntries: BatchEntry[] = useBatchEndpoint
+      ? nonVirtualDashcardsToFetch.map(({ card, dashcard }) => ({
+          card: card as Card,
+          dashcard,
+          queryParams: buildCardQuery(
+            card as Card,
+            dashcard,
+            dashboard.parameters,
+            parameterValues,
+            editingDashboard?.parameters,
+          ).queryParams,
+        }))
+      : [];
+
+    const batchCardsToFetch: BatchEntry[] = [];
+    const batchCardsAlreadyInFlight: BatchEntry[] = [];
+    if (useBatchEndpoint) {
+      for (const entry of batchEntries) {
+        const { card, dashcard, queryParams } = entry;
+        if (reload) {
+          batchCardsToFetch.push(entry);
+          continue;
+        }
+        const key = `${dashcard.id},${card.id}` as const;
+        const lastResult = getIn(getState().dashboard.dashcardData, [
+          dashcard.id,
+          card.id,
+        ]);
+        if (
+          lastResult &&
+          _.isEqual(getDatasetQueryParams(lastResult.json_query), queryParams)
+        ) {
+          continue; // cached, drop from both loadingIds and batch
+        }
+        const inFlight = cardDataCancelDeferreds[key];
+        if (inFlight && _.isEqual(inFlight.queryParams, queryParams)) {
+          batchCardsAlreadyInFlight.push(entry);
+          continue;
+        }
+        if (inFlight) {
+          dispatch(cancelFetchCardData(card.id, dashcard.id));
+        }
+        if (lastResult) {
+          dispatch(clearCardData(card.id, dashcard.id));
+        }
+        batchCardsToFetch.push(entry);
+      }
+    }
+
+    const newLoadingIds = useBatchEndpoint
+      ? [...batchCardsToFetch, ...batchCardsAlreadyInFlight].map(
+          ({ dashcard }) => dashcard.id,
+        )
+      : nonVirtualDashcardsToFetch.map(({ dashcard }) => dashcard.id);
+
+    /**
+     * We intentionally do NOT cancel in-flight requests here. Both paths handle their own
+     * deduplication: the per-card path (fetchCardDataAction) returns early when an identical
+     * request is already in-flight and cancels stale requests when parameters change. The batch
+     * path pre-filters its candidate set against the same in-flight map above. Cancelling here
+     * would abort nearly-complete requests on tab switch, forcing slow queries (e.g. pivots) to
+     * restart from scratch. (#70534)
+     */
+    dispatch(
+      fetchDashboardCardDataAction({
+        currentTime: performance.now(),
+        loadingIds: isRefreshing ? loadingIds.concat(newLoadingIds) : newLoadingIds,
+      }),
+    );
+
+    if (nonVirtualDashcardsToFetch.length === 0) {
+      return;
+    }
+
+    if (useBatchEndpoint && batchCardsToFetch.length === 0) {
+      // Nothing new to fetch. Any matched-in-flight requests will resolve themselves.
+      if (batchCardsAlreadyInFlight.length === 0) {
+        dispatch(loadingComplete());
+      }
+      return;
+    }
+
+    if (useBatchEndpoint) {
+      // Build parameters: dashboard-level params with current values
+      const batchParameters = (dashboard.parameters ?? [])
+        .filter((p) => parameterValues[p.id] != null)
+        .map((p) => ({
+          id: p.id,
+          type: p.type,
+          value: parameterValues[p.id],
+        }));
+
+      const cards = batchCardsToFetch.map(({ card, dashcard }) => ({
+        dashcard_id: dashcard.id,
+        card_id: card.id,
+      }));
+
+      const abortController = new AbortController();
+      batchFetchAbortController = abortController;
+
+      let completedCount = 0;
+      const totalCount = batchCardsToFetch.length;
+      dispatch(setDocumentTitle(t`0/${totalCount} loaded`));
+
+      // Register a deferred per card so subsequent fetchDashboardCardData calls observe these as
+      // in-flight. The deferreds aren't used as cancellation tokens (the shared abortController
+      // does that) — they're only in-flight markers in cardDataCancelDeferreds. We track them in
+      // batchDeferreds so callbacks can detect when a newer batch has taken over a key.
+      const batchDeferreds = new Map<string, Deferred>();
+      for (const { card, dashcard, queryParams } of batchCardsToFetch) {
+        const deferred = defer();
+        batchDeferreds.set(`${dashcard.id},${card.id}`, deferred);
+        setFetchCardDataCancel(card.id, dashcard.id, deferred, queryParams);
+      }
+
+      const clearBatchDeferreds = () => {
+        for (const [key, deferred] of batchDeferreds) {
+          const typedKey = key as `${DashCardId},${DashboardCard["card_id"]}`;
+          if (cardDataCancelDeferreds[typedKey]?.deferred === deferred) {
+            cardDataCancelDeferreds[typedKey] = null;
+          }
+        }
+        batchDeferreds.clear();
+      };
+
+      const requestConfig = getBatchRequestConfig(
+        dashboard.id,
+        dashboardType,
+        dashboardLoadId,
+        batchParameters,
+        cards,
+        parameterValues,
+        dashboard.parameters ?? undefined,
+        reload,
+        abortController.signal,
+      );
+
+      if (!requestConfig) {
+        // Shouldn't happen given canUseBatchEndpoint check, but satisfy TS
+        clearBatchDeferreds();
+        return;
+      }
+
+      const dispatchBatchCardResult = (
+        dashcardId: DashCardId,
+        cardId: CardId,
+        payload: { result?: Dataset; error?: unknown },
+      ) => {
+        const key = `${dashcardId},${cardId}` as const;
+        const current = cardDataCancelDeferreds[key];
+        if (!current || current.deferred !== batchDeferreds.get(key)) {
+          // A newer batch (or explicit cancellation) has replaced this entry — drop the stale
+          // result instead of overwriting fresh state.
+          return;
+        }
+        cardDataCancelDeferreds[key] = null;
+        batchDeferreds.delete(key);
+        dispatch(
+          receiveBatchCardResult({
+            dashcard_id: dashcardId,
+            card_id: cardId,
+            result:
+              payload.error !== undefined ? { error: payload.error } : payload.result!,
+          }),
+        );
+        completedCount++;
+        dispatch(setDocumentTitle(t`${completedCount}/${totalCount} loaded`));
+      };
+
+      return streamBatchCardQuery(requestConfig, {
+        onCardResult: (dashcardId, cardId, result) =>
+          dispatchBatchCardResult(dashcardId, cardId, { result }),
+        onCardError: (dashcardId, cardId, error) =>
+          dispatchBatchCardResult(dashcardId, cardId, { error }),
+        onComplete: () => {
+          clearBatchDeferreds();
+          batchFetchAbortController = null;
+          dispatch(loadingComplete());
+        },
+      }).catch((err) => {
+        if (err?.name !== "AbortError") {
+          console.error("Batch card query failed:", err);
+        }
+        clearBatchDeferreds();
+        batchFetchAbortController = null;
+      });
+    }
+
+    // Fallback: per-card fetching for transient/inline dashboards or editing mode
+    dispatch(
+      setDocumentTitle(t`0/${nonVirtualDashcardsToFetch.length} loaded`),
+    );
     const tasks = nonVirtualDashcardsToFetch.map(
       ({ card, dashcard }) =>
         async () => {
           await dispatch(
-            // TODO: fix the return type of getAllDashboardCards to make sure
-            // that the relationship between a dashcard and its card
-            // is actually reflected in the type system
             fetchCardData(card as Card, dashcard, {
               reload,
               clearCache,
@@ -583,19 +823,13 @@ export const fetchDashboardCardData =
         },
     );
 
-    if (nonVirtualDashcardsToFetch.length > 0) {
-      dispatch(
-        setDocumentTitle(t`0/${nonVirtualDashcardsToFetch.length} loaded`),
-      );
-
-      // TODO: There is a race condition here, when refreshing a dashboard before
-      // the previous API calls finished.
-      return runWithConcurrencyLimit(tasks, CONCURRENT_CARD_FETCH_LIMIT).then(
-        () => {
-          dispatch(loadingComplete());
-        },
-      );
-    }
+    // TODO: There is a race condition here, when refreshing a dashboard before
+    // the previous API calls finished.
+    return runWithConcurrencyLimit(tasks, CONCURRENT_CARD_FETCH_LIMIT).then(
+      () => {
+        dispatch(loadingComplete());
+      },
+    );
   };
 
 export const reloadDashboardCards =
@@ -626,6 +860,12 @@ export const reloadDashboardCards =
 export const cancelFetchDashboardCardData = createThunkAction(
   CANCEL_FETCH_DASHBOARD_CARD_DATA,
   () => (dispatch, getState) => {
+    // Cancel batch request if in flight
+    if (batchFetchAbortController) {
+      batchFetchAbortController.abort();
+      batchFetchAbortController = null;
+    }
+
     const dashboard = getDashboardComplete(getState());
 
     if (!dashboard) {
@@ -642,6 +882,8 @@ type InFlightEntry = {
   deferred: Deferred;
   queryParams: ReturnType<typeof getDatasetQueryParams>;
 };
+
+let batchFetchAbortController: AbortController | null = null;
 
 const cardDataCancelDeferreds: Record<
   `${DashCardId},${DashboardCard["card_id"]}`,
@@ -685,6 +927,32 @@ function getDatasetQueryParams(datasetQuery?: JsonQuery) {
       value: parameter.value ?? null,
     }))
     .sort(sortById);
+}
+
+// Builds a card's resolved datasetQuery from dashboard parameter state, plus its normalized
+// queryParams used as the cache/in-flight key. Both the per-card and the batch path call this so
+// the dedup keys stay identical across paths.
+function buildCardQuery(
+  card: Card,
+  dashcard: DashboardCard,
+  dashboardParameters: Parameter[] | null | undefined,
+  parameterValues: ParameterValuesMap,
+  editingDashboardParameters: Parameter[] | null | undefined,
+) {
+  const savedParameterIds = new Set(
+    editingDashboardParameters?.map((p) => p.id),
+  );
+  const savedParameters =
+    editingDashboardParameters != null
+      ? dashboardParameters?.filter((p) => savedParameterIds.has(p.id))
+      : dashboardParameters;
+  const datasetQuery = applyParameters(
+    card,
+    savedParameters,
+    parameterValues,
+    dashcard?.parameter_mappings ?? undefined,
+  );
+  return { datasetQuery, queryParams: getDatasetQueryParams(datasetQuery) };
 }
 
 function sortById(a: UiParameter, b: UiParameter) {

--- a/frontend/src/metabase/dashboard/actions/data-fetching.ts
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.ts
@@ -26,7 +26,6 @@ import {
   getAllDashboardCards,
   getCurrentTabDashboardCards,
 } from "metabase/dashboard/utils";
-import { isEmbedPreview as getIsEmbedPreview } from "metabase/embedding/config";
 import { entityCompatibleQuery } from "metabase/entities/utils";
 import { getSavedDashboardUiParameters } from "metabase/parameters/utils/dashboards";
 import { getParameterValuesByIdFromQueryParams } from "metabase/parameters/utils/parameter-parsing";
@@ -55,6 +54,7 @@ import { defer } from "metabase/utils/promise";
 import { uuid } from "metabase/utils/uuid";
 import { isVisualizerDashboardCard } from "metabase/visualizer/utils";
 import type { UiParameter } from "metabase-lib/v1/parameters/types";
+import { deriveFieldOperatorFromParameter } from "metabase-lib/v1/parameters/utils/operators";
 import { getParameterValuesBySlug } from "metabase-lib/v1/parameters/utils/parameter-values";
 import type {
   Card,
@@ -709,13 +709,20 @@ export const fetchDashboardCardData =
     }
 
     if (useBatchEndpoint) {
-      // Include cleared params too (value: null) so the server can delete
-      // their stored last-used value on filter reset.
-      const batchParameters = (dashboard.parameters ?? []).map((p) => ({
-        id: p.id,
-        type: p.type,
-        value: parameterValues[p.id] ?? null,
-      }));
+      // Send every dashboard parameter, including ones with a null value, so
+      // the server can clear its stored last-used value on filter reset.
+      // `options` carries operator defaults like `case-sensitive: false` for
+      // `string/contains`; without it the backend runs a case-sensitive
+      // filter.
+      const batchParameters = (dashboard.parameters ?? []).map((p) => {
+        const options = deriveFieldOperatorFromParameter(p)?.optionsDefaults;
+        return {
+          id: p.id,
+          type: p.type,
+          value: parameterValues[p.id] ?? null,
+          ...(options ? { options } : {}),
+        };
+      });
 
       const cards = batchCardsToFetch.map(({ card, dashcard }) => ({
         dashcard_id: dashcard.id,
@@ -787,7 +794,9 @@ export const fetchDashboardCardData =
             dashcard_id: dashcardId,
             card_id: cardId,
             result:
-              payload.error !== undefined ? { error: payload.error } : payload.result!,
+              payload.error !== undefined
+                ? (payload.error as Dataset)
+                : payload.result!,
           }),
         );
         completedCount++;
@@ -798,6 +807,10 @@ export const fetchDashboardCardData =
         onCardResult: (dashcardId, cardId, result) =>
           dispatchBatchCardResult(dashcardId, cardId, { result }),
         onCardError: (dashcardId, cardId, error) =>
+          // Pass the error payload directly (not wrapped in `{error}`) so
+          // `error_is_curated`, `error_type`, etc. sit at the top level of the
+          // cached dataset for `getDashcardResultsError` to surface a curated
+          // message.
           dispatchBatchCardResult(dashcardId, cardId, { error }),
         onComplete: () => {
           clearBatchDeferreds();
@@ -806,6 +819,7 @@ export const fetchDashboardCardData =
         },
       }).catch((err) => {
         if (err?.name === "AbortError") {
+          clearBatchDeferreds();
           batchFetchAbortController = null;
           return;
         }
@@ -819,14 +833,10 @@ export const fetchDashboardCardData =
             : undefined) ?? 500;
         const message =
           err instanceof Error ? err.message : "Batch card query failed";
-        for (const { card, dashcard } of cardsNeedingFetch) {
-          dispatch(
-            receiveBatchCardResult({
-              dashcard_id: dashcard.id,
-              card_id: (card as Card).id,
-              result: { error: { status, message } },
-            }),
-          );
+        for (const { card, dashcard } of batchCardsToFetch) {
+          dispatchBatchCardResult(dashcard.id, card.id, {
+            error: { status, message },
+          });
         }
         clearBatchDeferreds();
         batchFetchAbortController = null;
@@ -889,11 +899,7 @@ export const reloadDashboardCards =
 export const cancelFetchDashboardCardData = createThunkAction(
   CANCEL_FETCH_DASHBOARD_CARD_DATA,
   () => (dispatch, getState) => {
-    // Cancel batch request if in flight
-    if (batchFetchAbortController) {
-      batchFetchAbortController.abort();
-      batchFetchAbortController = null;
-    }
+    abortBatchCardQuery();
 
     const dashboard = getDashboardComplete(getState());
 

--- a/frontend/src/metabase/dashboard/actions/data-fetching.ts
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.ts
@@ -700,14 +700,13 @@ export const fetchDashboardCardData =
     }
 
     if (useBatchEndpoint) {
-      // Build parameters: dashboard-level params with current values
-      const batchParameters = (dashboard.parameters ?? [])
-        .filter((p) => parameterValues[p.id] != null)
-        .map((p) => ({
-          id: p.id,
-          type: p.type,
-          value: parameterValues[p.id],
-        }));
+      // Include cleared params too (value: null) so the server can delete
+      // their stored last-used value on filter reset.
+      const batchParameters = (dashboard.parameters ?? []).map((p) => ({
+        id: p.id,
+        type: p.type,
+        value: parameterValues[p.id] ?? null,
+      }));
 
       const cards = batchCardsToFetch.map(({ card, dashcard }) => ({
         dashcard_id: dashcard.id,

--- a/frontend/src/metabase/dashboard/actions/data-fetching.ts
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.ts
@@ -692,7 +692,9 @@ export const fetchDashboardCardData =
     dispatch(
       fetchDashboardCardDataAction({
         currentTime: performance.now(),
-        loadingIds: isRefreshing ? loadingIds.concat(newLoadingIds) : newLoadingIds,
+        loadingIds: isRefreshing
+          ? loadingIds.concat(newLoadingIds)
+          : newLoadingIds,
       }),
     );
 

--- a/frontend/src/metabase/dashboard/actions/data-fetching.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.unit.spec.ts
@@ -577,6 +577,69 @@ describe("fetchDashboardCardData", () => {
     firstResolve!();
     await firstFetch;
   });
+
+  it("includes permission-stripped cards (no dataset_query) in the batch request so the backend can emit a 403 card-error", async () => {
+    const dashboardId = 700;
+    const viewableDashcardId = 71;
+    const viewableCardId = 71;
+    const restrictedDashcardId = 72;
+    const restrictedCardId = 72;
+
+    const database = createSampleDatabase();
+    const viewableDashcard = createMockDashboardCard({
+      id: viewableDashcardId,
+      card_id: viewableCardId,
+      dashboard_id: dashboardId,
+      card: createMockCard({ id: viewableCardId }),
+    });
+    // Cards the current user can't read are returned by /api/dashboard/:id
+    // with dataset_query stripped off the embedded card.
+    const restrictedDashcard = createMockDashboardCard({
+      id: restrictedDashcardId,
+      card_id: restrictedCardId,
+      dashboard_id: dashboardId,
+      card: createMockCard({
+        id: restrictedCardId,
+        dataset_query: undefined as never,
+      }),
+    });
+
+    const batchCalls = setupDashboardCardQueryBatchEndpoint(dashboardId, [
+      { id: viewableDashcardId, card_id: viewableCardId },
+      { id: restrictedDashcardId, card_id: restrictedCardId },
+    ]);
+
+    const DASHBOARD = createMockDashboard({
+      id: dashboardId,
+      dashcards: [viewableDashcard, restrictedDashcard],
+    });
+    const state: Partial<State> = {
+      dashboard: createMockDashboardState({
+        dashboardId: DASHBOARD.id,
+        dashboards: {
+          [DASHBOARD.id]: createMockStoreDashboard({
+            ...DASHBOARD,
+            dashcards: [viewableDashcardId, restrictedDashcardId],
+          }),
+        },
+        dashcards: {
+          [viewableDashcardId]: viewableDashcard,
+          [restrictedDashcardId]: restrictedDashcard,
+        },
+      }),
+      entities: createMockEntitiesState({ databases: [database] }),
+      settings: createMockSettingsState(),
+    };
+
+    const dispatch = createMockDispatch(() => state);
+    await fetchDashboardCardData()(dispatch as never, (() => state) as never);
+
+    expect(batchCalls).toHaveLength(1);
+    const body = JSON.parse(String(batchCalls[0].init?.body ?? "{}"));
+    expect(
+      body.cards.map((c: { dashcard_id: number }) => c.dashcard_id).sort(),
+    ).toEqual([viewableDashcardId, restrictedDashcardId]);
+  });
 });
 
 describe("reloadDashboardCards", () => {

--- a/frontend/src/metabase/dashboard/actions/data-fetching.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.unit.spec.ts
@@ -6,6 +6,7 @@ import {
   setupDashboardsEndpoints,
   setupDatabaseEndpoints,
 } from "__support__/server-mocks";
+import { setupDashboardCardQueryBatchEndpoint } from "__support__/server-mocks/dashcard";
 import { createMockEntitiesState } from "__support__/store";
 import { Api } from "metabase/api";
 import type { DashboardState, State } from "metabase/redux/store";
@@ -287,7 +288,11 @@ function createMockDispatch(getState: () => Partial<State>) {
   return dispatch;
 }
 
-function setupConcurrencyTest(dashboardId: number, cardCount: number) {
+function setupConcurrencyTest(
+  dashboardId: number,
+  cardCount: number,
+  { isEditing = false }: { isEditing?: boolean } = {},
+) {
   let currentConcurrent = 0;
   let maxConcurrent = 0;
 
@@ -316,6 +321,14 @@ function setupConcurrencyTest(dashboardId: number, cardCount: number) {
     );
   });
 
+  // Non-editing path now uses the streaming batch endpoint. Register a mock
+  // so the per-card code path and the batch code path both have something to
+  // talk to.
+  const batchCalls = setupDashboardCardQueryBatchEndpoint(
+    dashboardId,
+    dashcards.map((dc) => ({ id: dc.id, card_id: dc.card_id as number })),
+  );
+
   const DASHBOARD = createMockDashboard({ id: dashboardId, dashcards });
   const state: Partial<State> = {
     dashboard: createMockDashboardState({
@@ -327,6 +340,7 @@ function setupConcurrencyTest(dashboardId: number, cardCount: number) {
         }),
       },
       dashcards: Object.fromEntries(dashcards.map((dc) => [dc.id, dc])),
+      editingDashboard: isEditing ? DASHBOARD : null,
     }),
     entities: createMockEntitiesState({ databases: [database] }),
     settings: createMockSettingsState(),
@@ -335,14 +349,39 @@ function setupConcurrencyTest(dashboardId: number, cardCount: number) {
   const getState = () => state;
   const dispatch = createMockDispatch(getState);
 
-  return { dispatch, getState, getMaxConcurrent: () => maxConcurrent };
+  return {
+    dispatch,
+    getState,
+    getMaxConcurrent: () => maxConcurrent,
+    dashcards,
+    batchCalls,
+  };
 }
 
 describe("fetchDashboardCardData", () => {
-  it("should make at most 5 api calls simultaneously", async () => {
-    const { dispatch, getState, getMaxConcurrent } = setupConcurrencyTest(
-      100,
+  it("should issue a single batch request for all cards on a normal dashboard", async () => {
+    const dashboardId = 100;
+    const { dispatch, getState, dashcards, batchCalls } = setupConcurrencyTest(
+      dashboardId,
       8,
+    );
+
+    await fetchDashboardCardData()(dispatch as never, getState as never);
+
+    expect(batchCalls).toHaveLength(1);
+
+    const body = JSON.parse(String(batchCalls[0].init?.body ?? "{}"));
+    expect(body.cards).toHaveLength(dashcards.length);
+    expect(
+      body.cards.map((c: { dashcard_id: number }) => c.dashcard_id),
+    ).toEqual(dashcards.map((dc) => dc.id));
+  });
+
+  it("should make at most 5 simultaneous per-card requests on the editing fallback path", async () => {
+    const { dispatch, getState, getMaxConcurrent } = setupConcurrencyTest(
+      101,
+      8,
+      { isEditing: true },
     );
 
     await fetchDashboardCardData()(dispatch as never, getState as never);

--- a/frontend/src/metabase/dashboard/actions/data-fetching.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.unit.spec.ts
@@ -350,6 +350,118 @@ describe("fetchDashboardCardData", () => {
     expect(getMaxConcurrent()).toBe(5);
   });
 
+  it("should skip cached cards from the batch request when params match (#70534)", async () => {
+    const dashboardId = 500;
+    const dashcardId = 50;
+    const cardId = 50;
+
+    fetchMock.post(
+      `/api/dashboard/${dashboardId}/card-query-batch`,
+      new Response("", { headers: { "Content-Type": "application/x-ndjson" } }),
+    );
+
+    const database = createSampleDatabase();
+    const dashcard = createMockDashboardCard({
+      id: dashcardId,
+      card_id: cardId,
+      dashboard_id: dashboardId,
+      card: createMockCard({ id: cardId }),
+    });
+    const DASHBOARD = createMockDashboard({
+      id: dashboardId,
+      dashcards: [dashcard],
+    });
+
+    const state: Partial<State> = {
+      dashboard: createMockDashboardState({
+        dashboardId: DASHBOARD.id,
+        dashboards: {
+          [DASHBOARD.id]: createMockStoreDashboard({
+            ...DASHBOARD,
+            dashcards: [dashcard.id],
+          }),
+        },
+        dashcards: { [dashcard.id]: dashcard },
+        // Pre-populate with a cached result whose json_query has no parameters,
+        // matching what buildCardQuery will produce for an unparameterized dashboard.
+        dashcardData: {
+          [dashcardId]: {
+            [cardId]: { json_query: { parameters: [] } } as never,
+          },
+        },
+      }),
+      entities: createMockEntitiesState({ databases: [database] }),
+      settings: createMockSettingsState(),
+    };
+
+    const getState = () => state;
+    const dispatch = createMockDispatch(getState);
+
+    await fetchDashboardCardData()(dispatch as never, getState as never);
+
+    const batchCalls = fetchMock.callHistory.calls(
+      `/api/dashboard/${dashboardId}/card-query-batch`,
+    );
+    expect(batchCalls).toHaveLength(0);
+  });
+
+  it("should bypass cache when reload is true", async () => {
+    const dashboardId = 501;
+    const dashcardId = 51;
+    const cardId = 51;
+
+    fetchMock.post(
+      `/api/dashboard/${dashboardId}/card-query-batch`,
+      new Response("", { headers: { "Content-Type": "application/x-ndjson" } }),
+    );
+
+    const database = createSampleDatabase();
+    const dashcard = createMockDashboardCard({
+      id: dashcardId,
+      card_id: cardId,
+      dashboard_id: dashboardId,
+      card: createMockCard({ id: cardId }),
+    });
+    const DASHBOARD = createMockDashboard({
+      id: dashboardId,
+      dashcards: [dashcard],
+    });
+
+    const state: Partial<State> = {
+      dashboard: createMockDashboardState({
+        dashboardId: DASHBOARD.id,
+        dashboards: {
+          [DASHBOARD.id]: createMockStoreDashboard({
+            ...DASHBOARD,
+            dashcards: [dashcard.id],
+          }),
+        },
+        dashcards: { [dashcard.id]: dashcard },
+        // Cached result that would otherwise satisfy the pre-filter.
+        dashcardData: {
+          [dashcardId]: {
+            [cardId]: { json_query: { parameters: [] } } as never,
+          },
+        },
+      }),
+      entities: createMockEntitiesState({ databases: [database] }),
+      settings: createMockSettingsState(),
+    };
+
+    const getState = () => state;
+    const dispatch = createMockDispatch(getState);
+
+    await fetchDashboardCardData({ reload: true })(
+      dispatch as never,
+      getState as never,
+    );
+
+    const batchCalls = fetchMock.callHistory.calls(
+      `/api/dashboard/${dashboardId}/card-query-batch`,
+    );
+    expect(batchCalls).toHaveLength(1);
+  });
+
   it("should not cancel in-flight requests from other tabs on tab switch (#70534)", async () => {
     const dashboardId = 300;
     const tab1 = createMockDashboardTab({

--- a/frontend/src/metabase/dashboard/actions/data-fetching.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.unit.spec.ts
@@ -6,7 +6,10 @@ import {
   setupDashboardsEndpoints,
   setupDatabaseEndpoints,
 } from "__support__/server-mocks";
-import { setupDashboardCardQueryBatchEndpoint } from "__support__/server-mocks/dashcard";
+import {
+  buildCardQueryBatchNdjson,
+  setupDashboardCardQueryBatchEndpoint,
+} from "__support__/server-mocks/dashcard";
 import { createMockEntitiesState } from "__support__/store";
 import { Api } from "metabase/api";
 import type { DashboardState, State } from "metabase/redux/store";
@@ -22,7 +25,6 @@ import {
   createMockDashboard,
   createMockDashboardCard,
   createMockDashboardQueryMetadata,
-  createMockDashboardTab,
 } from "metabase-types/api/mocks";
 import { createSampleDatabase } from "metabase-types/api/mocks/presets";
 
@@ -501,117 +503,79 @@ describe("fetchDashboardCardData", () => {
     expect(batchCalls).toHaveLength(1);
   });
 
-  it("should not cancel in-flight requests from other tabs on tab switch (#70534)", async () => {
-    const dashboardId = 300;
-    const tab1 = createMockDashboardTab({
-      id: 1,
+  it("should not re-fetch a card whose params match an in-flight request (#70534)", async () => {
+    // Drives two back-to-back fetchDashboardCardData calls; the second should
+    // see the first's cards in cardDataCancelDeferreds with matching params
+    // and skip them from the new batch.
+    const dashboardId = 301;
+    const dashcard = createMockDashboardCard({
+      id: 30,
+      card_id: 30,
       dashboard_id: dashboardId,
-      name: "Tab 1",
-    });
-    const tab2 = createMockDashboardTab({
-      id: 2,
-      dashboard_id: dashboardId,
-      name: "Tab 2",
-    });
-
-    const tab1Card = createMockDashboardCard({
-      id: 10,
-      card_id: 10,
-      dashboard_id: dashboardId,
-      dashboard_tab_id: tab1.id,
-      card: createMockCard({ id: 10 }),
-    });
-    const tab2Card = createMockDashboardCard({
-      id: 20,
-      card_id: 20,
-      dashboard_id: dashboardId,
-      dashboard_tab_id: tab2.id,
-      card: createMockCard({ id: 20 }),
+      card: createMockCard({ id: 30 }),
     });
 
-    let tab1QueryCount = 0;
+    let firstResolve: (() => void) | null = null;
+    const firstResponseBody = buildCardQueryBatchNdjson([
+      { id: dashcard.id, card_id: dashcard.card_id as number },
+    ]);
     fetchMock.post(
-      `/api/dashboard/${dashboardId}/dashcard/${tab1Card.id}/card/${tab1Card.card_id}/query`,
+      `path:/api/dashboard/${dashboardId}/card-query-batch`,
       () =>
         new Promise((resolve) => {
-          tab1QueryCount++;
-          // Slow query on Tab 1 (simulates a pivot table). Must be long
-          // enough that the request is still in-flight when we navigate
-          // back to Tab 1 in the test below.
-          setTimeout(() => resolve({ data: [] }), 500);
+          firstResolve = () =>
+            resolve(
+              new Response(firstResponseBody, {
+                headers: { "Content-Type": "application/x-ndjson" },
+              }),
+            );
         }),
-    );
-    fetchMock.post(
-      `/api/dashboard/${dashboardId}/dashcard/${tab2Card.id}/card/${tab2Card.card_id}/query`,
-      () =>
-        new Promise((resolve) => {
-          setTimeout(() => resolve({ data: [] }), 20);
-        }),
+      { repeat: 1 },
     );
 
     const database = createSampleDatabase();
-    const dashcards = [tab1Card, tab2Card];
     const DASHBOARD = createMockDashboard({
       id: dashboardId,
-      tabs: [tab1, tab2],
-      dashcards,
+      dashcards: [dashcard],
     });
-
     const state: Partial<State> = {
       dashboard: createMockDashboardState({
         dashboardId: DASHBOARD.id,
-        selectedTabId: tab1.id,
         dashboards: {
           [DASHBOARD.id]: createMockStoreDashboard({
             ...DASHBOARD,
-            dashcards: dashcards.map((dc) => dc.id),
+            dashcards: [dashcard.id],
           }),
         },
-        dashcards: Object.fromEntries(dashcards.map((dc) => [dc.id, dc])),
+        dashcards: { [dashcard.id]: dashcard },
       }),
       entities: createMockEntitiesState({ databases: [database] }),
       settings: createMockSettingsState(),
     };
-
     const getState = () => state;
     const dispatch = createMockDispatch(getState);
 
-    // Start loading Tab 1 (slow query)
-    const tab1Fetch = fetchDashboardCardData()(
+    // First fetch — request hangs (firstResolve not yet called).
+    const firstFetch = fetchDashboardCardData()(
       dispatch as never,
       getState as never,
     );
+    await new Promise<void>((res) => setTimeout(res, 10));
 
-    // Wait a bit to let Tab 1 request start, but not finish
-    await new Promise<void>((res) => setTimeout(res, 50));
+    // Second fetch with the same params — pre-filter should see the in-flight
+    // entry in cardDataCancelDeferreds and skip the card from the new batch.
+    // No second request should fire.
+    await fetchDashboardCardData()(dispatch as never, getState as never);
 
-    // Switch to Tab 2
-    (state.dashboard as DashboardState).selectedTabId = tab2.id;
-    const tab2Fetch = fetchDashboardCardData()(
-      dispatch as never,
-      getState as never,
-    );
+    expect(
+      fetchMock.callHistory.calls(
+        `path:/api/dashboard/${dashboardId}/card-query-batch`,
+      ),
+    ).toHaveLength(1);
 
-    // Wait for Tab 2's fast query to finish, while Tab 1 is still in-flight
-    await tab2Fetch;
-    expect(tab1QueryCount).toBe(1);
-
-    // Navigate back to Tab 1 while its query is still running. The
-    // in-flight request should be detected as a duplicate (same parameters)
-    // and reused — no new query execution.
-    (state.dashboard as DashboardState).selectedTabId = tab1.id;
-    const backToTab1Fetch = fetchDashboardCardData()(
-      dispatch as never,
-      getState as never,
-    );
-
-    await Promise.all([tab1Fetch, backToTab1Fetch]);
-
-    // Tab 1's query should have been called exactly once across the entire
-    // sequence: initial load -> switch to Tab 2 -> switch back to Tab 1.
-    // Before the fix, the batch cancellation loop would cancel Tab 1's
-    // in-flight request, causing a re-execution on return.
-    expect(tab1QueryCount).toBe(1);
+    // Resolve the first batch so the test cleans up.
+    firstResolve!();
+    await firstFetch;
   });
 });
 

--- a/frontend/src/metabase/dashboard/components/DashCard/utils.ts
+++ b/frontend/src/metabase/dashboard/components/DashCard/utils.ts
@@ -41,7 +41,7 @@ export function getMissingColumnsFromVisualizationSettings(options: {
     if (!colsForCards[cardId]) {
       colsForCards[cardId] = new Set();
     }
-    series.data?.cols.forEach((col) => {
+    series.data?.cols?.forEach((col) => {
       colsForCards[cardId].add(col.name);
     });
   });

--- a/frontend/src/metabase/dashboard/reducers-typed.ts
+++ b/frontend/src/metabase/dashboard/reducers-typed.ts
@@ -441,7 +441,19 @@ export const dashcardData = createReducer(
       })
       .addCase(receiveBatchCardResult, (state, { payload }) => {
         const { dashcard_id, card_id, result } = payload;
-        return assocIn(state, [dashcard_id, card_id], result);
+        // Mutate the Immer draft directly instead of using icepick's assocIn.
+        // `assocIn` shallow-clones `state`, which under Immer retains refs to
+        // nested proxy drafts. Those proxies get revoked when Immer finalizes
+        // this reducer, so the next dispatch that reads the same nested slot
+        // blows up with "Cannot perform 'get' on a proxy that has been revoked".
+        const mutable = state as Record<
+          DashCardId,
+          Record<Card["id"], unknown>
+        >;
+        if (mutable[dashcard_id] == null) {
+          mutable[dashcard_id] = {};
+        }
+        mutable[dashcard_id][card_id] = result;
       })
       .addCase(clearCardData, (state, action) => {
         const { cardId, dashcardId } = action.payload;

--- a/frontend/src/metabase/dashboard/reducers-typed.ts
+++ b/frontend/src/metabase/dashboard/reducers-typed.ts
@@ -56,6 +56,7 @@ import {
   fetchDashboard,
   fetchDashboardCardDataAction,
   markCardAsSlow,
+  receiveBatchCardResult,
   setDashboardAttributes,
   setDocumentTitle,
   setShowLoadingCompleteFavicon,
@@ -397,6 +398,17 @@ export const loadingDashCards = createReducer(
           };
         }
       })
+      .addCase(receiveBatchCardResult, (state, { payload }) => {
+        const { dashcard_id } = payload;
+        const loadingIds = state.loadingIds.filter((id) => id !== dashcard_id);
+        return {
+          ...state,
+          loadingIds,
+          ...(loadingIds.length === 0
+            ? { endTime: performance.now(), loadingStatus: "complete" }
+            : {}),
+        };
+      })
       .addCase(cancelFetchCardData, (state, action) => {
         const { dashcard_id } = action.payload;
         const loadingIds = state.loadingIds.filter((id) => id !== dashcard_id);
@@ -426,6 +438,10 @@ export const dashcardData = createReducer(
         if (dashcard_id && card_id && result != null) {
           return assocIn(state, [dashcard_id, card_id], result);
         }
+      })
+      .addCase(receiveBatchCardResult, (state, { payload }) => {
+        const { dashcard_id, card_id, result } = payload;
+        return assocIn(state, [dashcard_id, card_id], result);
       })
       .addCase(clearCardData, (state, action) => {
         const { cardId, dashcardId } = action.payload;

--- a/frontend/test/__support__/server-mocks/dashcard.ts
+++ b/frontend/test/__support__/server-mocks/dashcard.ts
@@ -1,7 +1,13 @@
 import fetchMock from "fetch-mock";
 
 import type { StoreDashcard } from "metabase/redux/store";
-import type { DashboardId, Dataset } from "metabase-types/api";
+import type {
+  CardId,
+  DashCardId,
+  DashboardId,
+  Dataset,
+} from "metabase-types/api";
+import { createMockDataset } from "metabase-types/api/mocks";
 
 export function setupDashcardQueryEndpoints(
   dashboardId: DashboardId,
@@ -11,5 +17,133 @@ export function setupDashcardQueryEndpoints(
   fetchMock.post(
     `path:/api/dashboard/${dashboardId}/dashcard/${dashcard.id}/card/${dashcard.card_id}/query`,
     dataset,
+  );
+}
+
+type BatchDashcardRef = { id: DashCardId; card_id: CardId };
+
+export function buildCardQueryBatchNdjson(
+  dashcards: BatchDashcardRef[],
+  dataset: Dataset = createMockDataset(),
+): string {
+  const lines: string[] = [];
+  for (const { id, card_id } of dashcards) {
+    lines.push(
+      JSON.stringify({
+        type: "card-begin",
+        dashcard_id: id,
+        card_id,
+        data: dataset.data,
+      }),
+    );
+    lines.push(
+      JSON.stringify({
+        type: "card-rows",
+        dashcard_id: id,
+        card_id,
+        rows: dataset.data?.rows ?? [],
+      }),
+    );
+    lines.push(
+      JSON.stringify({
+        type: "card-end",
+        dashcard_id: id,
+        card_id,
+        row_count: dataset.data?.rows?.length ?? 0,
+        status: "completed",
+        data: dataset.data,
+      }),
+    );
+  }
+  lines.push(
+    JSON.stringify({
+      type: "complete",
+      total: dashcards.length,
+      succeeded: dashcards.length,
+      failed: 0,
+    }),
+  );
+  return lines.join("\n") + "\n";
+}
+
+// fetch-mock cannot round-trip a ReadableStream body through jsdom's Response
+// polyfill (the body ends up as null), so we monkey-patch global.fetch for
+// batch URLs. Non-matching requests fall through to whatever fetch-mock
+// installed.
+//
+// Each test invokes this helper; it records calls into `batchCalls` which is
+// returned so tests can assert against them. `global.fetch` is reset to
+// fetch-mock at the start of every test via `fetchMock.mockGlobal()` in
+// jest-setup-env.js, so there is no cleanup to do.
+type FetchLike = typeof fetch;
+type BatchCall = { url: string; init?: RequestInit };
+
+function patchFetchForBatch(
+  matches: (url: string) => boolean,
+  build: () => string,
+): BatchCall[] {
+  const calls: BatchCall[] = [];
+  const delegate: FetchLike = global.fetch as FetchLike;
+  global.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : (input as Request).url;
+    if (matches(url)) {
+      calls.push({ url, init });
+      const encoder = new TextEncoder();
+      const body = build();
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(encoder.encode(body));
+          controller.close();
+        },
+      });
+      return {
+        ok: true,
+        status: 200,
+        body: stream,
+      } as unknown as Response;
+    }
+    return delegate(input, init);
+  }) as FetchLike;
+  return calls;
+}
+
+export function setupDashboardCardQueryBatchEndpoint(
+  dashboardId: DashboardId,
+  dashcards: BatchDashcardRef[],
+  dataset: Dataset = createMockDataset(),
+): BatchCall[] {
+  const pathname = `/api/dashboard/${dashboardId}/card-query-batch`;
+  return patchFetchForBatch(
+    (url) => url.includes(pathname),
+    () => buildCardQueryBatchNdjson(dashcards, dataset),
+  );
+}
+
+export function setupPublicDashboardCardQueryBatchEndpoint(
+  dashboardId: DashboardId,
+  dashcards: BatchDashcardRef[],
+  dataset: Dataset = createMockDataset(),
+): BatchCall[] {
+  const pathname = `/api/public/dashboard/${dashboardId}/card-query-batch`;
+  return patchFetchForBatch(
+    (url) => url.includes(pathname),
+    () => buildCardQueryBatchNdjson(dashcards, dataset),
+  );
+}
+
+export function setupEmbedDashboardCardQueryBatchEndpointByToken(
+  token: string,
+  dashcards: BatchDashcardRef[],
+  dataset: Dataset = createMockDataset(),
+): BatchCall[] {
+  const pathname = `/api/embed/dashboard/${token}/card-query-batch`;
+  return patchFetchForBatch(
+    (url) => url.includes(pathname),
+    () => buildCardQueryBatchNdjson(dashcards, dataset),
   );
 }

--- a/frontend/test/__support__/server-mocks/dashcard.ts
+++ b/frontend/test/__support__/server-mocks/dashcard.ts
@@ -22,45 +22,80 @@ export function setupDashcardQueryEndpoints(
 
 type BatchDashcardRef = { id: DashCardId; card_id: CardId };
 
+type BatchErrorContext = {
+  error: string;
+  error_type?: string;
+  error_is_curated?: boolean;
+  json_query?: Record<string, unknown>;
+};
+
 export function buildCardQueryBatchNdjson(
   dashcards: BatchDashcardRef[],
   dataset: Dataset = createMockDataset(),
+  errors: Map<DashCardId, BatchErrorContext> = new Map(),
 ): string {
   const lines: string[] = [];
+  let succeeded = 0;
+  let failed = 0;
   for (const { id, card_id } of dashcards) {
-    lines.push(
-      JSON.stringify({
-        type: "card-begin",
-        dashcard_id: id,
-        card_id,
-        data: dataset.data,
-      }),
-    );
-    lines.push(
-      JSON.stringify({
-        type: "card-rows",
-        dashcard_id: id,
-        card_id,
-        rows: dataset.data?.rows ?? [],
-      }),
-    );
-    lines.push(
-      JSON.stringify({
-        type: "card-end",
-        dashcard_id: id,
-        card_id,
-        row_count: dataset.data?.rows?.length ?? 0,
-        status: "completed",
-        data: dataset.data,
-      }),
-    );
+    const errorContext = errors.get(id);
+    if (errorContext) {
+      lines.push(
+        JSON.stringify({
+          type: "card-error",
+          dashcard_id: id,
+          card_id,
+          status: "failed",
+          error: errorContext.error,
+          ...(errorContext.error_type != null && {
+            error_type: errorContext.error_type,
+          }),
+          ...(errorContext.error_is_curated != null && {
+            error_is_curated: errorContext.error_is_curated,
+          }),
+          ...(errorContext.json_query != null && {
+            json_query: errorContext.json_query,
+          }),
+          data: { cols: [], rows: [] },
+        }),
+      );
+      failed++;
+    } else {
+      lines.push(
+        JSON.stringify({
+          type: "card-begin",
+          dashcard_id: id,
+          card_id,
+          data: dataset.data,
+        }),
+      );
+      lines.push(
+        JSON.stringify({
+          type: "card-rows",
+          dashcard_id: id,
+          card_id,
+          rows: dataset.data?.rows ?? [],
+        }),
+      );
+      lines.push(
+        JSON.stringify({
+          type: "card-end",
+          dashcard_id: id,
+          card_id,
+          row_count: dataset.data?.rows?.length ?? 0,
+          status: "completed",
+          data: dataset.data,
+        }),
+      );
+      succeeded++;
+    }
   }
   lines.push(
     JSON.stringify({
       type: "complete",
       total: dashcards.length,
-      succeeded: dashcards.length,
-      failed: 0,
+      succeeded,
+      failed,
     }),
   );
   return lines.join("\n") + "\n";

--- a/frontend/test/__support__/server-mocks/embed.ts
+++ b/frontend/test/__support__/server-mocks/embed.ts
@@ -4,6 +4,8 @@ import type { Card, Dashboard, DashboardCard } from "metabase-types/api";
 import type { EntityToken } from "metabase-types/api/entity";
 import { createMockDataset } from "metabase-types/api/mocks";
 
+import { setupEmbedDashboardCardQueryBatchEndpointByToken } from "./dashcard";
+
 export function setupEmbedDashboardEndpoints(
   uuidOrToken: EntityToken,
   dashboard: Dashboard,
@@ -18,6 +20,12 @@ export function setupEmbedDashboardEndpoints(
         createMockDataset(),
       );
     });
+    setupEmbedDashboardCardQueryBatchEndpointByToken(
+      String(uuidOrToken),
+      dashcards
+        .filter(({ card_id }) => card_id != null)
+        .map(({ id, card_id }) => ({ id, card_id: card_id as number })),
+    );
   }
 }
 

--- a/src/metabase/dashboards/models/dashboard.clj
+++ b/src/metabase/dashboards/models/dashboard.clj
@@ -280,7 +280,12 @@
                                    (update :series #(map :id %)))
             dashboard-card     (update dashcard :series #(map :id %))]
         (dashboard-card/update-dashboard-card! dashboard-card old-dashcard)))
-    (let [new-param-field-ids (params/dashcards->param-field-ids (t2/hydrate new-dashcards :card))]
+    ;; `t2/hydrate` is a no-op when `:card` is already present, so strip any
+    ;; client-supplied value first: a JSON round-trip strings-ifies keyword
+    ;; metadata (`type/Category`, `source/table-defaults`, ...) that
+    ;; `param-target->field-id` later validates against `:metabase.queries.schema/card`.
+    (let [dashcards-for-hydration (map #(dissoc % :card) new-dashcards)
+          new-param-field-ids    (params/dashcards->param-field-ids (t2/hydrate dashcards-for-hydration :card))]
       (update-field-values-for-on-demand-dbs! (params/dashcards->param-field-ids old-dashcards) new-param-field-ids))))
 
 (defn- legacy-result-metadata-for-query

--- a/src/metabase/dashboards_rest/api.clj
+++ b/src/metabase/dashboards_rest/api.clj
@@ -37,6 +37,7 @@
    [metabase.query-permissions.core :as query-perms]
    [metabase.query-processor.api :as api.dataset]
    [metabase.query-processor.dashboard :as qp.dashboard]
+   [metabase.query-processor.dashboard-batch :as qp.dashboard-batch]
    [metabase.query-processor.middleware.constraints :as qp.constraints]
    [metabase.query-processor.middleware.permissions :as qp.perms]
    [metabase.query-processor.pivot :as qp.pivot]
@@ -1396,6 +1397,37 @@
   (actions/execute-dashcard! dashboard-id dashcard-id parameters))
 
 ;;; ---------------------------------- Running the query associated with a Dashcard ----------------------------------
+
+(def ^:private BatchCardSpec
+  [:map
+   [:dashcard_id ms/PositiveInt]
+   [:card_id     ms/PositiveInt]])
+
+#_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
+(api.macros/defendpoint :post "/:dashboard-id/card-query-batch"
+  "Run queries for multiple cards on a dashboard in a single request. Results are streamed back as NDJSON
+   (newline-delimited JSON) as each card query completes.
+
+   Each line in the response is one of:
+   - `{\"type\":\"card-result\",\"dashcard_id\":N,\"card_id\":N,\"result\":{...}}` — successful card query result
+   - `{\"type\":\"card-error\",\"dashcard_id\":N,\"card_id\":N,\"error\":{...}}` — per-card error
+   - `{\"type\":\"complete\",\"total\":N,\"succeeded\":N,\"failed\":N}` — final summary"
+  [{:keys [dashboard-id]} :- [:map
+                              [:dashboard-id ms/PositiveInt]]
+   _query-params
+   {:keys [dashboard_load_id], :as body} :- [:map
+                                             [:dashboard_load_id {:optional true} [:maybe ms/NonBlankString]]
+                                             [:parameters        {:optional true} [:maybe [:sequential ParameterWithID]]]
+                                             [:ignore_cache      {:optional true} [:maybe :boolean]]
+                                             [:cards             {:optional true} [:maybe [:sequential BatchCardSpec]]]]]
+  (with-dashboard-load-id dashboard_load_id
+    (qp.dashboard-batch/process-batch-queries
+     {:dashboard-id dashboard-id
+      :parameters   (:parameters body)
+      :ignore-cache (:ignore_cache body)
+      :cards        (some->> (:cards body)
+                             (mapv (fn [{:keys [dashcard_id card_id]}]
+                                     {:dashcard-id dashcard_id :card-id card_id})))})))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen

--- a/src/metabase/dashboards_rest/api.clj
+++ b/src/metabase/dashboards_rest/api.clj
@@ -36,8 +36,8 @@
    [metabase.queries.core :as queries]
    [metabase.query-permissions.core :as query-perms]
    [metabase.query-processor.api :as api.dataset]
+   [metabase.query-processor.core :as qp.core]
    [metabase.query-processor.dashboard :as qp.dashboard]
-   [metabase.query-processor.dashboard-batch :as qp.dashboard-batch]
    [metabase.query-processor.middleware.constraints :as qp.constraints]
    [metabase.query-processor.middleware.permissions :as qp.perms]
    [metabase.query-processor.pivot :as qp.pivot]
@@ -1421,7 +1421,7 @@
                                              [:ignore_cache      {:optional true} [:maybe :boolean]]
                                              [:cards             {:optional true} [:maybe [:sequential BatchCardSpec]]]]]
   (with-dashboard-load-id dashboard_load_id
-    (qp.dashboard-batch/process-batch-queries
+    (qp.core/process-batch-queries
      {:dashboard-id dashboard-id
       :parameters   (:parameters body)
       :ignore-cache (:ignore_cache body)

--- a/src/metabase/dashboards_rest/api.clj
+++ b/src/metabase/dashboards_rest/api.clj
@@ -1409,9 +1409,17 @@
    (newline-delimited JSON) as each card query completes.
 
    Each line in the response is one of:
-   - `{\"type\":\"card-result\",\"dashcard_id\":N,\"card_id\":N,\"result\":{...}}` — successful card query result
-   - `{\"type\":\"card-error\",\"dashcard_id\":N,\"card_id\":N,\"error\":{...}}` — per-card error
-   - `{\"type\":\"complete\",\"total\":N,\"succeeded\":N,\"failed\":N}` — final summary"
+   - `{\"type\":\"card-begin\",\"dashcard_id\":N,\"card_id\":N,\"data\":{...}}` — opens a card; `data` carries
+     the partial Dataset metadata known up-front (cols, native_form, ...), without rows
+   - `{\"type\":\"card-rows\",\"dashcard_id\":N,\"card_id\":N,\"rows\":[[...], ...]}` — a chunk of rows
+     for that card (multiple of these may stream between `card-begin` and `card-end`)
+   - `{\"type\":\"card-end\",\"dashcard_id\":N,\"card_id\":N,\"status\":\"...\",\"row_count\":N,\"running_time\":N,\"data\":{...}, ...}`
+     — successful card terminator; the Dataset envelope is spread at the top level (rows stripped from `data`,
+     since they arrived via `card-rows`) so the client can merge begin + rows + end into a complete Dataset
+   - `{\"type\":\"card-error\",\"dashcard_id\":N,\"card_id\":N,\"status\":\"failed\",\"error\":\"...\",\"data\":{\"cols\":[],\"rows\":[]}, ...}`
+     — per-card error; the failed-Dataset envelope is spread at the top level alongside the routing fields,
+     symmetric to `card-end`. Optional fields: `error_type`, `error_is_curated`, `json_query`
+   - `{\"type\":\"complete\",\"total\":N,\"succeeded\":N,\"failed\":N}` — final summary sentinel"
   [{:keys [dashboard-id]} :- [:map
                               [:dashboard-id ms/PositiveInt]]
    _query-params

--- a/src/metabase/embedding_rest/api/common.clj
+++ b/src/metabase/embedding_rest/api/common.clj
@@ -15,7 +15,7 @@
    [metabase.public-sharing-rest.api :as api.public]
    [metabase.queries.core :as queries]
    [metabase.query-processor.card :as qp.card]
-   [metabase.query-processor.dashboard-batch :as qp.dashboard-batch]
+   [metabase.query-processor.core :as qp.core]
    [metabase.query-processor.middleware.constraints :as qp.constraints]
    [metabase.query-processor.parameters.operators :as params.ops]
    [metabase.request.core :as request]
@@ -432,7 +432,7 @@
         parameters  (resolve-dashboard-parameters dashboard-id slug->value)]
     (request/as-admin
       (binding [api/*current-user-id* nil]
-        (qp.dashboard-batch/process-batch-queries
+        (qp.core/process-batch-queries
          {:dashboard-id dashboard-id
           :parameters   parameters
           :context      :embedded-dashboard

--- a/src/metabase/embedding_rest/api/common.clj
+++ b/src/metabase/embedding_rest/api/common.clj
@@ -15,8 +15,10 @@
    [metabase.public-sharing-rest.api :as api.public]
    [metabase.queries.core :as queries]
    [metabase.query-processor.card :as qp.card]
+   [metabase.query-processor.dashboard-batch :as qp.dashboard-batch]
    [metabase.query-processor.middleware.constraints :as qp.constraints]
    [metabase.query-processor.parameters.operators :as params.ops]
+   [metabase.request.core :as request]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.json :as json]
@@ -419,6 +421,22 @@
      :context       (get-embed-dashboard-context export-format)
      :constraints   constraints
      :middleware    middleware)))
+
+(defn process-batch-queries-for-dashboard
+  "Batch variant of [[process-query-for-dashcard]] for embedded dashboards. Resolves embedding parameters,
+   then delegates to the batch orchestrator."
+  [& {:keys [dashboard-id embedding-params token-params query-params cards]}]
+  {:pre [(integer? dashboard-id) (u/maybe? map? embedding-params)
+         (map? token-params) (map? query-params)]}
+  (let [slug->value (validate-and-merge-params embedding-params token-params (normalize-query-params query-params))
+        parameters  (resolve-dashboard-parameters dashboard-id slug->value)]
+    (request/as-admin
+      (binding [api/*current-user-id* nil]
+        (qp.dashboard-batch/process-batch-queries
+         {:dashboard-id dashboard-id
+          :parameters   parameters
+          :context      :embedded-dashboard
+          :cards        cards})))))
 
 (defn card-param-values
   "Search for card parameter values. Does security checks to ensure the parameter is on the card and then gets param

--- a/src/metabase/embedding_rest/api/common.clj
+++ b/src/metabase/embedding_rest/api/common.clj
@@ -433,10 +433,13 @@
     (request/as-admin
       (binding [api/*current-user-id* nil]
         (qp.core/process-batch-queries
-         {:dashboard-id dashboard-id
-          :parameters   parameters
-          :context      :embedded-dashboard
-          :cards        cards})))))
+         {:dashboard-id     dashboard-id
+          :parameters       parameters
+          :context          :embedded-dashboard
+          :cards            cards
+          ;; Sanitize per-card failure envelopes the same way the single-card embed path does
+          ;; (drops `:json_query`, redacts raw error text unless `qp.error-type/show-in-embeds?`).
+          :transform-result api.public/transform-qp-result})))))
 
 (defn card-param-values
   "Search for card parameter values. Does security checks to ensure the parameter is on the card and then gets param

--- a/src/metabase/embedding_rest/api/embed.clj
+++ b/src/metabase/embedding_rest/api/embed.clj
@@ -197,6 +197,28 @@
        :qp qp
        :middleware middleware))))
 
+#_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
+(api.macros/defendpoint :get "/dashboard/:token/card-query-batch"
+  "Run queries for multiple cards on an embedded Dashboard in a single request.
+   Results are streamed back as NDJSON."
+  [{:keys [token]} :- [:map [:token api.embed.common/EncodedToken]]
+   query-params :- :map]
+  (let [unsigned-token (unsign-and-translate-ids token)
+        dashboard-id   (embedding.jwt/get-in-unsigned-token-or-throw unsigned-token [:resource :dashboard])
+        parsed-qp      (api.embed.common/parse-query-params query-params)
+        cards-json     (:cards parsed-qp)
+        cards          (some->> cards-json
+                                (mapv (fn [{:keys [dashcard_id card_id]}]
+                                        {:dashcard-id dashcard_id :card-id card_id})))]
+    (api.embed.common/check-embedding-enabled-for-dashboard dashboard-id)
+    (database-routing/with-database-routing-off
+      (api.embed.common/process-batch-queries-for-dashboard
+       :dashboard-id     dashboard-id
+       :embedding-params (t2/select-one-fn :embedding_params :model/Dashboard :id dashboard-id)
+       :token-params     (embedding.jwt/get-in-unsigned-token-or-throw unsigned-token [:params])
+       :query-params     (dissoc parsed-qp :cards)
+       :cards            cards))))
+
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
 ;;

--- a/src/metabase/embedding_rest/api/embed.clj
+++ b/src/metabase/embedding_rest/api/embed.clj
@@ -206,8 +206,9 @@
   (let [unsigned-token (unsign-and-translate-ids token)
         dashboard-id   (embedding.jwt/get-in-unsigned-token-or-throw unsigned-token [:resource :dashboard])
         parsed-qp      (api.embed.common/parse-query-params query-params)
-        cards-json     (:cards parsed-qp)
-        cards          (some->> cards-json
+        cards-raw      (:cards parsed-qp)
+        cards-parsed   (cond-> cards-raw (string? cards-raw) json/decode+kw)
+        cards          (some->> cards-parsed
                                 (mapv (fn [{:keys [dashcard_id card_id]}]
                                         {:dashcard-id dashcard_id :card-id card_id})))]
     (api.embed.common/check-embedding-enabled-for-dashboard dashboard-id)

--- a/src/metabase/embedding_rest/api/embed.clj
+++ b/src/metabase/embedding_rest/api/embed.clj
@@ -205,8 +205,10 @@
    query-params :- :map]
   (let [unsigned-token (unsign-and-translate-ids token)
         dashboard-id   (embedding.jwt/get-in-unsigned-token-or-throw unsigned-token [:resource :dashboard])
-        parsed-qp      (api.embed.common/parse-query-params query-params)
-        cards-raw      (:cards parsed-qp)
+        ;; Extract cards before parse-query-params, which drops non-parameter keys
+        ;; when the `parameters` JSON key is present
+        cards-raw      (:cards query-params)
+        parsed-qp      (api.embed.common/parse-query-params (dissoc query-params :cards))
         cards-parsed   (cond-> cards-raw (string? cards-raw) json/decode+kw)
         cards          (some->> cards-parsed
                                 (mapv (fn [{:keys [dashcard_id card_id]}]
@@ -217,7 +219,7 @@
        :dashboard-id     dashboard-id
        :embedding-params (t2/select-one-fn :embedding_params :model/Dashboard :id dashboard-id)
        :token-params     (embedding.jwt/get-in-unsigned-token-or-throw unsigned-token [:params])
-       :query-params     (dissoc parsed-qp :cards)
+       :query-params     parsed-qp
        :cards            cards))))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to

--- a/src/metabase/embedding_rest/api/preview_embed.clj
+++ b/src/metabase/embedding_rest/api/preview_embed.clj
@@ -171,6 +171,29 @@
      :token-params     token-params
      :query-params     (api.embed.common/parse-query-params query-params))))
 
+#_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
+(api.macros/defendpoint :get "/dashboard/:token/card-query-batch"
+  "Run queries for multiple cards on a preview-embedded Dashboard in a single request.
+   Results are streamed back as NDJSON. Mirrors `/api/embed/dashboard/:token/card-query-batch`
+   but requires admin access and reads embedding params from the JWT (`:_embedding_params`)
+   rather than the dashboard row, matching the rest of the preview-embed endpoints."
+  [{:keys [token]} :- [:map [:token api.embed.common/EncodedToken]]
+   query-params    :- :map]
+  (let [unsigned-token (check-and-unsign token)
+        dashboard-id   (embed/get-in-unsigned-token-or-throw unsigned-token [:resource :dashboard])
+        cards-raw      (:cards query-params)
+        parsed-qp      (api.embed.common/parse-query-params (dissoc query-params :cards))
+        cards-parsed   (cond-> cards-raw (string? cards-raw) json/decode+kw)
+        cards          (some->> cards-parsed
+                                (mapv (fn [{:keys [dashcard_id card_id]}]
+                                        {:dashcard-id dashcard_id :card-id card_id})))]
+    (api.embed.common/process-batch-queries-for-dashboard
+     :dashboard-id     dashboard-id
+     :embedding-params (embed/get-in-unsigned-token-or-throw unsigned-token [:_embedding_params])
+     :token-params     (embed/get-in-unsigned-token-or-throw unsigned-token [:params])
+     :query-params     parsed-qp
+     :cards            cards)))
+
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
 ;;

--- a/src/metabase/lib_be/core.clj
+++ b/src/metabase/lib_be/core.clj
@@ -22,6 +22,7 @@
  [metabase.lib-be.metadata.bootstrap
   resolve-database]
  [metabase.lib-be.metadata.jvm
+  *metadata-provider-cache*
   application-database-metadata-provider
   instance->metadata
   metadata-provider-cache

--- a/src/metabase/public_sharing_rest/api.clj
+++ b/src/metabase/public_sharing_rest/api.clj
@@ -19,6 +19,7 @@
    [metabase.queries.core :as queries]
    [metabase.query-processor.card :as qp.card]
    [metabase.query-processor.dashboard :as qp.dashboard]
+   [metabase.query-processor.dashboard-batch :as qp.dashboard-batch]
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.query-processor.middleware.constraints :as qp.constraints]
    [metabase.query-processor.middleware.permissions :as qp.perms]
@@ -308,6 +309,28 @@
       ;; dashboard in Metabase proper.)
       (binding [api/*current-user-id* nil]
         (m/mapply qp.dashboard/process-query-for-dashcard options)))))
+
+#_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
+(api.macros/defendpoint :get "/dashboard/:uuid/card-query-batch"
+  "Run queries for multiple cards on a publicly-accessible Dashboard in a single request.
+   Results are streamed back as NDJSON. Does not require auth credentials. Public sharing must be enabled."
+  [{:keys [uuid]} :- [:map [:uuid ms/UUIDString]]
+   {:keys [parameters cards]} :- [:map
+                                  [:parameters {:optional true} [:maybe ms/JSONString]]
+                                  [:cards      {:optional true} [:maybe ms/JSONString]]]]
+  (public-sharing.validation/check-public-sharing-enabled)
+  (let [dashboard-id (api/check-404 (t2/select-one-pk :model/Dashboard :public_uuid uuid, :archived false))
+        cards-parsed (some-> cards json/decode+kw)
+        params       (cond-> parameters (string? parameters) json/decode+kw)]
+    (request/as-admin
+      (binding [api/*current-user-id* nil]
+        (qp.dashboard-batch/process-batch-queries
+         {:dashboard-id dashboard-id
+          :parameters   params
+          :context      :public-dashboard
+          :cards        (some->> cards-parsed
+                                 (mapv (fn [{:keys [dashcard_id card_id]}]
+                                         {:dashcard-id dashcard_id :card-id card_id})))})))))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen

--- a/src/metabase/public_sharing_rest/api.clj
+++ b/src/metabase/public_sharing_rest/api.clj
@@ -18,8 +18,8 @@
    [metabase.public-sharing.validation :as public-sharing.validation]
    [metabase.queries.core :as queries]
    [metabase.query-processor.card :as qp.card]
+   [metabase.query-processor.core :as qp.core]
    [metabase.query-processor.dashboard :as qp.dashboard]
-   [metabase.query-processor.dashboard-batch :as qp.dashboard-batch]
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.query-processor.middleware.constraints :as qp.constraints]
    [metabase.query-processor.middleware.permissions :as qp.perms]
@@ -324,7 +324,7 @@
         params       (cond-> parameters (string? parameters) json/decode+kw)]
     (request/as-admin
       (binding [api/*current-user-id* nil]
-        (qp.dashboard-batch/process-batch-queries
+        (qp.core/process-batch-queries
          {:dashboard-id dashboard-id
           :parameters   params
           :context      :public-dashboard

--- a/src/metabase/public_sharing_rest/api.clj
+++ b/src/metabase/public_sharing_rest/api.clj
@@ -102,8 +102,11 @@
   (public-sharing.validation/check-public-sharing-enabled)
   (card-with-uuid uuid))
 
-(defmulti ^:private transform-qp-result
-  "Transform results to be suitable for a public endpoint"
+(defmulti transform-qp-result
+  "Transform results to be suitable for a public endpoint. Used by the per-card public path's
+  `:make-run` and by the batch path's `:transform-result` to keep the same redaction policy on
+  both paths (e.g. dropping `:json_query`, redacting raw error text for non-show-in-embeds
+  error types)."
   {:arglists '([results])}
   :status)
 
@@ -325,12 +328,15 @@
     (request/as-admin
       (binding [api/*current-user-id* nil]
         (qp.core/process-batch-queries
-         {:dashboard-id dashboard-id
-          :parameters   params
-          :context      :public-dashboard
-          :cards        (some->> cards-parsed
-                                 (mapv (fn [{:keys [dashcard_id card_id]}]
-                                         {:dashcard-id dashcard_id :card-id card_id})))})))))
+         {:dashboard-id     dashboard-id
+          :parameters       params
+          :context          :public-dashboard
+          :cards            (some->> cards-parsed
+                                     (mapv (fn [{:keys [dashcard_id card_id]}]
+                                             {:dashcard-id dashcard_id :card-id card_id})))
+          ;; Sanitize per-card failure envelopes the same way the single-card public path does
+          ;; (drops `:json_query`, redacts raw error text unless `qp.error-type/show-in-embeds?`).
+          :transform-result transform-qp-result})))))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen

--- a/src/metabase/queries/models/query.clj
+++ b/src/metabase/queries/models/query.clj
@@ -9,6 +9,7 @@
    [metabase.queries.schema :as queries.schema]
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.json :as json]
+   [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
    [methodical.core :as methodical]
@@ -87,6 +88,95 @@
           (or (update-rolling-average-execution-time! query query-hash execution-time-ms)
               ;; rethrow e if updating an existing average execution time failed
               (throw e))))))
+
+(defn- combined-rolling-average-params
+  "Given a sequence of execution times for the same query hash, compute the combined
+  rolling-average parameters: `{:decay d, :weighted-sum w}`.
+
+  When applied: `new_avg = ROUND(d * old_avg + w, 0)`
+
+  For k times [t₁ … tₖ]: decay = 0.9^k, weighted-sum = 0.1 × Σᵢ 0.9^(k-1-i) × tᵢ"
+  [running-times]
+  (let [k     (count running-times)
+        decay (Math/pow 0.9 k)
+        wsum  (reduce (fn [acc [i t]]
+                        (+ acc (* 0.1 (Math/pow 0.9 (- k 1 i)) (double t))))
+                      0.0
+                      (map-indexed vector running-times))]
+    {:decay decay :weighted-sum wsum}))
+
+(defn batch-save-query-and-update-average-execution-time!
+  "Batch version of [[save-query-and-update-average-execution-time!]] for use with grouper.
+  Receives a seq of `{:query, :query-hash, :running-time}` maps. Groups by query-hash,
+  computes combined rolling averages, and executes as few SQL statements as possible:
+  1 SELECT + 1 UPDATE (existing hashes) + 1 INSERT (new hashes)."
+  [items]
+  (when (seq items)
+    (try
+      (let [by-hash      (group-by :query-hash items)
+            hash->params (into {}
+                               (map (fn [[h entries]]
+                                      (let [params (combined-rolling-average-params (mapv :running-time entries))]
+                                        [h (assoc params :query (:query (peek entries)))])))
+                               by-hash)
+            all-hashes   (vec (keys hash->params))
+            ;; 1. Find which hashes already exist
+            existing     (into #{} (map :query_hash)
+                               (t2/query {:select [:query_hash]
+                                          :from   [:query]
+                                          :where  [:in :query_hash all-hashes]}))
+            to-update    (filterv existing all-hashes)
+            to-insert    (filterv (complement existing) all-hashes)]
+        ;; 2. Batch UPDATE existing rows — single UPDATE with CASE
+        (when (seq to-update)
+          (let [avg-case   (into [:case]
+                                 (mapcat (fn [h]
+                                           (let [{:keys [decay weighted-sum]} (hash->params h)]
+                                             [[:= :query_hash h]
+                                              (h2x/cast (int-casting-type)
+                                                        (h2x/round
+                                                         (h2x/+ (h2x/* [:inline decay] :average_execution_time)
+                                                                [:inline weighted-sum])
+                                                         [:inline 0]))])))
+                                 to-update)
+                query-case (into [:case]
+                                 (mapcat (fn [h]
+                                           [[:= :query_hash h]
+                                            (json/encode (:query (hash->params h)))]))
+                                 to-update)]
+            (t2/query {:update :query
+                       :set    {:average_execution_time avg-case
+                                :query                 [:case [:= :query nil] query-case
+                                                        :else :query]}
+                       :where  [:in :query_hash to-update]})))
+        ;; 3. Batch INSERT new rows — single INSERT
+        (when (seq to-insert)
+          (let [rows (mapv (fn [h]
+                             (let [{:keys [weighted-sum query]} (hash->params h)
+                                   k   (count (get by-hash h))
+                                   ;; For new rows there's no old average to decay against.
+                                   ;; Recover the effective average from the weighted sum:
+                                   ;; weighted-sum = 0.1 × Σ 0.9^(k-1-i) × tᵢ
+                                   ;; The contribution fraction is (1 - 0.9^k), so:
+                                   ;; effective_avg = weighted-sum / (1 - 0.9^k)
+                                   avg (long (Math/round (/ weighted-sum (- 1.0 (Math/pow 0.9 k)))))]
+                               {:query_hash             h
+                                :query                  (json/encode query)
+                                :average_execution_time avg}))
+                           to-insert)]
+            (try
+              (t2/insert! :model/Query rows)
+              (catch Throwable _e
+                ;; Race condition: another thread inserted the same hash. Fall back to individual updates.
+                (doseq [h to-insert]
+                  (try
+                    (save-query-and-update-average-execution-time!
+                     (:query (hash->params h)) h
+                     (:running-time (last (get by-hash h))))
+                    (catch Throwable e2
+                      (log/error e2 "Error saving query execution time for hash")))))))))
+      (catch Throwable e
+        (log/error e "Error in batch-save-query-and-update-average-execution-time!")))))
 
 (mr/def ::database-and-table-ids
   [:map

--- a/src/metabase/queries/models/query.clj
+++ b/src/metabase/queries/models/query.clj
@@ -14,7 +14,9 @@
    [metabase.util.malli.registry :as mr]
    [methodical.core :as methodical]
    [toucan2.core :as t2]
-   [toucan2.model :as t2.model]))
+   [toucan2.model :as t2.model])
+  (:import
+   (java.nio ByteBuffer)))
 
 (set! *warn-on-reflection* true)
 
@@ -120,13 +122,17 @@
                                         [h (assoc params :query (:query (peek entries)))])))
                                by-hash)
             all-hashes   (vec (keys hash->params))
-            ;; 1. Find which hashes already exist
-            existing     (into #{} (map :query_hash)
-                               (t2/query {:select [:query_hash]
-                                          :from   [:query]
-                                          :where  [:in :query_hash all-hashes]}))
-            to-update    (filterv existing all-hashes)
-            to-insert    (filterv (complement existing) all-hashes)]
+            ;; 1. Find which hashes already exist.
+            ;; Byte arrays use reference equality, so wrap in ByteBuffer for value-based lookup.
+            existing-bb  (into #{}
+                               (map (fn [^bytes h] (ByteBuffer/wrap h)))
+                               (map :query_hash
+                                    (t2/query {:select [:query_hash]
+                                               :from   [:query]
+                                               :where  [:in :query_hash all-hashes]})))
+            existing?    (fn [^bytes h] (contains? existing-bb (ByteBuffer/wrap h)))
+            to-update    (filterv existing? all-hashes)
+            to-insert    (filterv (complement existing?) all-hashes)]
         ;; 2. Batch UPDATE existing rows — single UPDATE with CASE
         (when (seq to-update)
           (let [avg-case   (into [:case]

--- a/src/metabase/query_processor/card.clj
+++ b/src/metabase/query_processor/card.clj
@@ -320,23 +320,26 @@
   all valid options."
   [card-id :- ::lib.schema.id/card
    export-format
-   & {:keys [parameters constraints context dashboard-id dashcard-id middleware qp make-run ignore-cache]
+   & {:keys [parameters constraints context dashboard-id dashcard-id middleware qp make-run ignore-cache
+             prefetched-card prefetched-dash-viz]
       :or   {constraints (qp.constraints/default-query-constraints)
              context     :question
              ;; param `make-run` can be used to control how the query is ran, e.g. if you need to customize the `context`
              ;; passed to the QP
              make-run    process-query-for-card-default-run-fn}}]
   {:pre [(pos-int? card-id) (u/maybe? sequential? parameters)]}
-  (let [card       (api/read-check (t2/select-one [:model/Card :id :name :dataset_query :database_id :collection_id
-                                                   :type :result_metadata :visualization_settings :display
-                                                   :cache_invalidated_at :entity_id :created_at :card_schema
-                                                   :parameters]
-                                                  :id card-id))
+  (let [card       (api/read-check (or prefetched-card
+                                       (t2/select-one [:model/Card :id :name :dataset_query :database_id :collection_id
+                                                       :type :result_metadata :visualization_settings :display
+                                                       :cache_invalidated_at :entity_id :created_at :card_schema
+                                                       :parameters]
+                                                      :id card-id)))
         parameters (some-> parameters parameters.schema/normalize-parameters-without-adding-default-types)
         parameters (enrich-parameters-from-card parameters (combined-parameters-and-template-tags card))
-        dash-viz   (when (and (not= context :question)
-                              dashcard-id)
-                     (t2/select-one-fn :visualization_settings :model/DashboardCard :id dashcard-id))
+        dash-viz   (if (and (not= context :question) dashcard-id)
+                     (or prefetched-dash-viz
+                         (t2/select-one-fn :visualization_settings :model/DashboardCard :id dashcard-id))
+                     prefetched-dash-viz)
         card-viz   (:visualization_settings card)
         merged-viz (m/deep-merge card-viz dash-viz)
         ;; We need to check this here because dashcards don't get selected until this point

--- a/src/metabase/query_processor/core.clj
+++ b/src/metabase/query_processor/core.clj
@@ -11,6 +11,7 @@
    [metabase.query-processor.card :as qp.card]
    [metabase.query-processor.compile :as qp.compile]
    [metabase.query-processor.dashboard :as qp.dashboard]
+   [metabase.query-processor.dashboard-batch :as qp.dashboard-batch]
    [metabase.query-processor.metadata :as qp.metadata]
    [metabase.query-processor.middleware.constraints :as qp.constraints]
    [metabase.query-processor.middleware.limit :as qp.limit]
@@ -41,6 +42,9 @@
  ;; Dashboard — metabase.query-processor.dashboard
  [qp.dashboard
   process-query-for-dashcard]
+ ;; Dashboard batch — metabase.query-processor.dashboard-batch
+ [qp.dashboard-batch
+  process-batch-queries]
  ;; Metadata — metabase.query-processor.metadata
  [qp.metadata
   result-metadata]

--- a/src/metabase/query_processor/dashboard_batch.clj
+++ b/src/metabase/query_processor/dashboard_batch.clj
@@ -18,6 +18,7 @@
    [metabase.premium-features.core :refer [defenterprise]]
    [metabase.query-processor.card :as qp.card]
    [metabase.query-processor.dashboard :as qp.dashboard]
+   [metabase.query-processor.error-type :as qp.error-type]
    [metabase.query-processor.middleware.constraints :as qp.constraints]
    [metabase.query-processor.pipeline :as qp.pipeline]
    [metabase.query-processor.streaming :as qp.streaming]
@@ -241,13 +242,18 @@
                         (catch EofException _))
 
                       (= (:status result) :failed)
+                      ;; Forward the full QP error map (`error`,
+                      ;; `error_is_curated`, `error_type`, `ex-data`, ...) so
+                      ;; the FE can render a curated message.
                       (batch-ndjson/emit-card-error!
                        queue dashcard-id card-id
-                       {:status  (or (-> result :ex-data :status-code)
-                                     (:status-code result)
-                                     500)
-                        :message (or (:error result)
-                                     "Unknown error running card query")}))
+                       (merge
+                        {:status  (or (-> result :ex-data :status-code)
+                                      (:status-code result)
+                                      500)
+                         :message (or (:error result)
+                                      "Unknown error running card query")}
+                        (dissoc result :class :stacktrace))))
                     (qp.pipeline/default-result-handler result))]
           (qp (update query :info merge info) rff))))))
 
@@ -280,11 +286,20 @@
       ;; Client disconnected — nothing to report; writer thread will exit on its own.
       :error)
     (catch Throwable e
-      (let [data   (ex-data e)
-            status (or (:status-code data) 500)]
+      ;; Emit a fully-shaped QP error map so the FE can render a curated
+      ;; message / permission icon. `check-403`-style throws don't tag their
+      ;; ex-data with a `:type`, so default 403s to `missing-required-permissions`.
+      (let [data       (ex-data e)
+            status     (or (:status-code data) 500)
+            message    (ex-message e)
+            error-type (or (:type data)
+                           (when (= status 403) qp.error-type/missing-required-permissions))]
         (log/warnf e "Batch card query failed for dashcard %d card %d" dashcard-id card-id)
         (batch-ndjson/emit-card-error! queue dashcard-id card-id
-                                       {:status status :message (ex-message e)})
+                                       (cond-> {:status  status
+                                                :message message
+                                                :error   message}
+                                         error-type (assoc :error_type error-type)))
         :error))))
 
 ;;; ------------------------------------------- Batch Orchestrator -------------------------------------------
@@ -371,14 +386,21 @@
                    :else true))
                cards)]
           (try
-            ;; Enqueue immediate errors
+            ;; Emit a fully-shaped QP error map (`status`, `error`,
+            ;; `error_type`, ...) — `getDashcardResultsError` needs
+            ;; `error_type` to render the permission icon/message for 403s.
             (doseq [{:keys [dashcard-id card-id]} immediate-errors]
               (vswap! failed inc)
               (batch-ndjson/emit-card-error!
                queue dashcard-id card-id
                (if (contains? valid-pairs [dashcard-id card-id])
-                 {:status 403 :message "You don't have permission to view this card"}
-                 {:status 404 :message "Card not found in dashboard"})))
+                 {:status     403
+                  :message    "You don't have permission to view this card"
+                  :error      "You don't have permission to view this card"
+                  :error_type qp.error-type/missing-required-permissions}
+                 {:status  404
+                  :message "Card not found in dashboard"
+                  :error   "Card not found in dashboard"})))
             ;; Run queries via claypoole — results flow to the queue as rows arrive.
             (doseq [result (cp/upmap pool
                                      (fn [{:keys [dashcard-id card-id]}]

--- a/src/metabase/query_processor/dashboard_batch.clj
+++ b/src/metabase/query_processor/dashboard_batch.clj
@@ -250,8 +250,7 @@
   (span/with-span! {:name       "batch-dashboard-card-queries"
                     :attributes {:dashboard/id dashboard-id}}
     ;; === Shared work: done once ===
-    (let [dashboard              (fetch-dashboard-with-resolved-params dashboard-id)
-          _                      (api/read-check :model/Dashboard dashboard-id)
+    (let [dashboard              (api/read-check (fetch-dashboard-with-resolved-params dashboard-id))
           dashboard-param-id->param (build-dashboard-param-map dashboard)
           ;; Determine which cards to run
           cards                  (or (seq cards) (get-all-dashcards dashboard-id))

--- a/src/metabase/query_processor/dashboard_batch.clj
+++ b/src/metabase/query_processor/dashboard_batch.clj
@@ -1,0 +1,260 @@
+(ns metabase.query-processor.dashboard-batch
+  "Batch query execution for all cards on a dashboard. Runs shared work (dashboard fetch, permission
+   checks, parameter resolution) once and fans out individual card queries in parallel, streaming
+   results back as NDJSON."
+  (:require
+   [clojure.core.async :as a]
+   [com.climate.claypoole :as cp]
+   [metabase.api.common :as api]
+   [metabase.dashboards.schema :as dashboards.schema]
+   [metabase.events.core :as events]
+   [metabase.lib-be.metadata.jvm :as lib-be.jvm]
+   [metabase.lib.core :as lib]
+   [metabase.permissions.core :as perms]
+   [metabase.query-processor.card :as qp.card]
+   [metabase.query-processor.dashboard :as qp.dashboard]
+   [metabase.query-processor.middleware.constraints :as qp.constraints]
+   [metabase.server.streaming-response :as streaming-response]
+   [metabase.users.models.user-parameter-value :as user-parameter-value]
+   [metabase.util.json :as json]
+   [metabase.util.log :as log]
+   [steffan-westcott.clj-otel.api.trace.span :as span]
+   ^{:clj-kondo/ignore [:discouraged-namespace]}
+   [toucan2.core :as t2])
+  (:import
+   (java.io OutputStream)
+   (java.nio.charset StandardCharsets)))
+
+(set! *warn-on-reflection* true)
+
+;;; ------------------------------------------------ Thread Pool ------------------------------------------------
+
+(def ^:dynamic *thread-pool*
+  "Claypoole thread pool for batch card queries. Bind to `:serial` to run on the calling thread
+   (useful for testing and query-count measurement). Default is a shared fixed pool."
+  nil)
+
+(defonce ^:private default-thread-pool
+  (delay (cp/threadpool 8 :name "batch-card-query-pool")))
+
+;;; ------------------------------------------------ NDJSON Writing ------------------------------------------------
+
+(defn- write-ndjson-line!
+  "Write a single NDJSON line (map encoded as JSON + newline) to the output stream and flush."
+  [^OutputStream os m]
+  (let [^bytes json-bytes (.getBytes ^String (json/encode m) StandardCharsets/UTF_8)
+        ^bytes newline    (.getBytes "\n" StandardCharsets/UTF_8)]
+    (.write os json-bytes)
+    (.write os newline)
+    (.flush os)))
+
+;;; -------------------------------------------- Shared Work Helpers --------------------------------------------
+
+(defn- fetch-dashboard-with-resolved-params
+  "Fetch the dashboard and hydrate its resolved params. Single DB hit for all cards."
+  [dashboard-id]
+  (-> (t2/select-one :model/Dashboard :id dashboard-id)
+      (t2/hydrate :resolved-params)
+      (api/check-404)))
+
+(defn- build-dashboard-param-map
+  "Build the param-id->param map from dashboard resolved params, stripping defaults per the convention
+   established in [[metabase.query-processor.dashboard/resolve-params-for-query]]."
+  [dashboard]
+  (into {}
+        (map (fn [[param-id param]]
+               [param-id (dissoc param :default)]))
+        (:resolved-params dashboard)))
+
+(defn- batch-validate-card-membership
+  "Validate that all requested {dashcard-id, card-id} pairs belong to this dashboard.
+   Returns a set of valid [dashcard-id card-id] pairs. Single DB query instead of N."
+  [dashboard-id cards]
+  (let [dashcard-ids   (set (map :dashcard-id cards))
+        ;; Fetch all dashcards for this dashboard that match requested IDs
+        valid-dashcards (t2/select [:model/DashboardCard :id :card_id]
+                                   :dashboard_id dashboard-id
+                                   :id [:in dashcard-ids])
+        ;; Build set of [dashcard-id card-id] pairs from primary assignment
+        primary-pairs  (into #{} (map (fn [dc] [(:id dc) (:card_id dc)])) valid-dashcards)
+        ;; For cards not matching primary, check series
+        unmatched      (remove (fn [{:keys [dashcard-id card-id]}]
+                                 (contains? primary-pairs [dashcard-id card-id]))
+                               cards)
+        series-pairs   (when (seq unmatched)
+                         (let [series-rows (t2/select [:model/DashboardCardSeries :dashboardcard_id :card_id]
+                                                      :dashboardcard_id [:in (set (map :dashcard-id unmatched))]
+                                                      :card_id [:in (set (map :card-id unmatched))])]
+                           (into #{} (map (fn [s] [(:dashboardcard_id s) (:card_id s)])) series-rows)))]
+    (into primary-pairs series-pairs)))
+
+(defn- batch-fetch-card-database-ids
+  "Fetch database_id for all requested cards in a single query. Returns {card-id database-id}."
+  [card-ids]
+  (into {}
+        (map (fn [row] [(:id row) (:database_id row)]))
+        (t2/select [:model/Card :id :database_id :card_schema] :id [:in (set card-ids)])))
+
+;;; ---------------------------------------- Per-Card Query Execution ----------------------------------------
+
+(defn- resolve-params-for-card
+  "Resolve parameters for a single card using the pre-computed dashboard param map.
+   This is the per-card portion of parameter resolution — the dashboard-level work is already done."
+  [card-id dashcard-id dashboard-param-id->param request-params]
+  (let [request-params          (some-> request-params seq (->> (lib/normalize ::dashboards.schema/parameters)))
+        request-param-id->param (into {} (map (juxt :id #(dissoc % :default))) request-params)
+        merged-parameters       (vals (merge (#'qp.dashboard/dashboard-param-defaults dashboard-param-id->param card-id)
+                                             request-param-id->param))]
+    (into [] (comp (map (partial #'qp.dashboard/resolve-param-for-card card-id dashcard-id dashboard-param-id->param))
+                   (filter some?))
+          merged-parameters)))
+
+(defn- batch-make-run
+  "A `:make-run` function for [[qp.card/process-query-for-card]] that executes the query synchronously
+   and returns the raw result map, rather than wrapping in a StreamingResponse."
+  [qp _export-format]
+  (fn [query info]
+    (qp (update query :info merge info) nil)))
+
+(defn- run-single-card-query
+  "Execute a single card query synchronously. Returns either a result map or an error map."
+  [{:keys [dashboard-id card-id dashcard-id dashboard-param-id->param parameters
+           ignore-cache context]
+    :or   {context :dashboard}}]
+  (try
+    (let [resolved-params (resolve-params-for-card card-id dashcard-id dashboard-param-id->param parameters)
+          options         {:dashboard-id dashboard-id
+                           :card-id      card-id
+                           :dashcard-id  dashcard-id
+                           :parameters   resolved-params
+                           :ignore-cache (boolean ignore-cache)
+                           :constraints  (qp.constraints/default-query-constraints)
+                           :context      context
+                           :make-run     batch-make-run}]
+      (binding [qp.card/*allow-arbitrary-mbql-parameters* true]
+        (qp.card/process-query-for-card card-id :api options)))
+    (catch Throwable e
+      (let [data    (ex-data e)
+            status  (or (:status-code data) 500)]
+        (log/warnf e "Batch card query failed for dashcard %d card %d" dashcard-id card-id)
+        {:error {:status  status
+                 :message (ex-message e)}}))))
+
+;;; ------------------------------------------- Batch Orchestrator -------------------------------------------
+
+(defn- get-all-dashcards
+  "Get all non-virtual dashcards for a dashboard (those with a card_id)."
+  [dashboard-id]
+  (into []
+        (comp (filter :card_id)
+              (map (fn [dc] {:dashcard-id (:id dc) :card-id (:card_id dc)})))
+        (t2/select [:model/DashboardCard :id :card_id] :dashboard_id dashboard-id)))
+
+(defn process-batch-queries
+  "Execute queries for multiple cards on a dashboard in a single request.
+
+   Does all shared work (dashboard fetch, permission checks, parameter resolution setup) once,
+   then fans out individual card queries in parallel. Returns a StreamingResponse that streams
+   NDJSON results as each card completes.
+
+   Options:
+   - `:dashboard-id` — required
+   - `:parameters`   — dashboard filter parameter values
+   - `:ignore-cache` — whether to ignore cached results
+   - `:cards`        — optional sequence of `{:dashcard-id N :card-id N}` maps; if omitted, runs all cards
+   - `:context`      — query context (default `:dashboard`)"
+  [{:keys [dashboard-id parameters ignore-cache cards context]
+    :or   {context :dashboard}}]
+  (span/with-span! {:name       "batch-dashboard-card-queries"
+                    :attributes {:dashboard/id dashboard-id}}
+    ;; === Shared work: done once ===
+    (let [dashboard              (fetch-dashboard-with-resolved-params dashboard-id)
+          _                      (api/read-check :model/Dashboard dashboard-id)
+          dashboard-param-id->param (build-dashboard-param-map dashboard)
+          ;; Determine which cards to run
+          cards                  (or (seq cards) (get-all-dashcards dashboard-id))
+          _                      (when (empty? cards)
+                                   (api/check-404 false))
+          ;; Batch validate membership
+          valid-pairs            (batch-validate-card-membership dashboard-id cards)
+          ;; Batch fetch database IDs for permission checks
+          card-db-ids            (batch-fetch-card-database-ids (map :card-id cards))
+          ;; Current user info for binding conveyance
+          current-user-id        api/*current-user-id*
+          current-user-perms     @api/*current-user-permissions-set*
+          metadata-cache         lib-be.jvm/*metadata-provider-cache*]
+      ;; Fire dashboard-queried event once
+      (events/publish-event! :event/dashboard-queried {:object-id dashboard-id :user-id current-user-id})
+      ;; Store user parameter values once
+      (when (and current-user-id (seq parameters))
+        (let [normalized-params (some-> parameters seq (->> (lib/normalize ::dashboards.schema/parameters)))]
+          (user-parameter-value/store! current-user-id dashboard-id normalized-params)))
+      ;; === Stream results ===
+      (streaming-response/streaming-response {:content-type "application/x-ndjson"} [os canceled-chan]
+        (let [pool      (or *thread-pool* @default-thread-pool)
+              succeeded (volatile! 0)
+              failed    (volatile! 0)
+              ;; Pre-classify cards into immediately-resolvable errors vs queries to run
+              {to-query true, immediate-errors false}
+              (group-by
+               (fn [{:keys [dashcard-id card-id]}]
+                 (cond
+                   (not (contains? valid-pairs [dashcard-id card-id]))
+                   false ; not in dashboard
+
+                   (and current-user-id
+                        (= :blocked
+                           (perms/most-permissive-database-permission-for-user
+                            current-user-id :perms/view-data (get card-db-ids card-id))))
+                   false ; blocked
+
+                   :else true))
+               cards)]
+          ;; Write immediate errors
+          (doseq [{:keys [dashcard-id card-id]} immediate-errors]
+            (vswap! failed inc)
+            (let [error (if (contains? valid-pairs [dashcard-id card-id])
+                          {:status 403 :message "You don't have permission to view this card"}
+                          {:status 404 :message "Card not found in dashboard"})]
+              (write-ndjson-line! os {:type        "card-error"
+                                      :dashcard_id dashcard-id
+                                      :card_id     card-id
+                                      :error       error})))
+          ;; Run queries via claypoole — results stream in completion order
+          (doseq [result (cp/upmap pool
+                                   (fn [{:keys [dashcard-id card-id]}]
+                                     (binding [api/*current-user-id*                current-user-id
+                                               api/*current-user-permissions-set*   (atom current-user-perms)
+                                               lib-be.jvm/*metadata-provider-cache* metadata-cache]
+                                       {:dashcard-id dashcard-id
+                                        :card-id     card-id
+                                        :result      (run-single-card-query
+                                                      {:dashboard-id              dashboard-id
+                                                       :card-id                   card-id
+                                                       :dashcard-id               dashcard-id
+                                                       :dashboard-param-id->param dashboard-param-id->param
+                                                       :parameters                parameters
+                                                       :ignore-cache              ignore-cache
+                                                       :context                   context})}))
+                                   (or to-query []))]
+            (when-not (a/poll! canceled-chan)
+              (let [{:keys [dashcard-id card-id result]} result]
+                (if (:error result)
+                  (do
+                    (vswap! failed inc)
+                    (write-ndjson-line! os {:type        "card-error"
+                                            :dashcard_id dashcard-id
+                                            :card_id     card-id
+                                            :error       (:error result)}))
+                  (do
+                    (vswap! succeeded inc)
+                    (write-ndjson-line! os {:type        "card-result"
+                                            :dashcard_id dashcard-id
+                                            :card_id     card-id
+                                            :result      result}))))))
+          ;; Write completion sentinel
+          (let [s @succeeded f @failed]
+            (write-ndjson-line! os {:type      "complete"
+                                    :total     (+ s f)
+                                    :succeeded s
+                                    :failed    f})))))))

--- a/src/metabase/query_processor/dashboard_batch.clj
+++ b/src/metabase/query_processor/dashboard_batch.clj
@@ -169,7 +169,7 @@
          all-ids    (set (keys card-id->card))]
     (let [source-ids (extract-source-card-ids (vals known-cards))
           new-ids    (set/difference source-ids all-ids)]
-      (if (empty? new-ids)
+      (if (perf/empty? new-ids)
         all-ids
         (let [new-cards (batch-fetch-cards new-ids)]
           (recur (merge known-cards new-cards)

--- a/src/metabase/query_processor/dashboard_batch.clj
+++ b/src/metabase/query_processor/dashboard_batch.clj
@@ -342,9 +342,7 @@
           card-id->card          (batch-fetch-cards (map :card-id cards))
           card-db-ids            (into {} (map (fn [[id card]] [id (:database_id card)])) card-id->card)
           dashcard-id->viz       (batch-fetch-dashcard-viz (map :dashcard-id cards))
-          ;; Current user info for binding conveyance
           current-user-id        api/*current-user-id*
-          current-user-perms     @api/*current-user-permissions-set*
           metadata-cache         lib-be/*metadata-provider-cache*
           ;; Pre-warm metadata providers so worker threads don't all race to fetch database metadata.
           _                      (doseq [db-id (distinct (vals card-db-ids))]
@@ -364,74 +362,80 @@
           (user-parameter-value/store! current-user-id dashboard-id normalized-params)))
       ;; === Stream results ===
       (streaming-response/streaming-response {:content-type "application/x-ndjson"} [os canceled-chan]
-        (let [pool          (or *thread-pool* @default-thread-pool)
-              queue         (LinkedBlockingQueue. (int queue-capacity))
-              writer-thread (start-writer-thread! queue os)
-              succeeded     (volatile! 0)
-              failed        (volatile! 0)
-              ;; Pre-classify cards into immediately-resolvable errors vs queries to run
-              {to-query true, immediate-errors false}
-              (group-by
-               (fn [{:keys [dashcard-id card-id]}]
-                 (cond
-                   (not (contains? valid-pairs [dashcard-id card-id]))
-                   false ; not in dashboard
+        ;; Establish every request-scoped binding workers should inherit on
+        ;; THIS thread, then use `bound-fn` in the worker so the full binding
+        ;; frame — user context (`*current-user*`, `*is-superuser?*`,
+        ;; `*user-locale*`, ...), permission caches (`*sandboxes-for-user*`,
+        ;; `*permissions-for-user*`), EE cache atoms, metadata cache, plus
+        ;; anything a future dynamic var adds — flows into each worker
+        ;; automatically. Anything we construct here (the EE atoms,
+        ;; `metadata-cache`) must be bound on this thread before `bound-fn`
+        ;; captures it; the rest is already bound by the API middleware.
+        (with-bindings (merge {#'lib-be/*metadata-provider-cache* metadata-cache}
+                              ee-bindings)
+          (let [pool          (or *thread-pool* @default-thread-pool)
+                queue         (LinkedBlockingQueue. (int queue-capacity))
+                writer-thread (start-writer-thread! queue os)
+                succeeded     (volatile! 0)
+                failed        (volatile! 0)
+                ;; Pre-classify cards into immediately-resolvable errors vs queries to run
+                {to-query true, immediate-errors false}
+                (group-by
+                 (fn [{:keys [dashcard-id card-id]}]
+                   (cond
+                     (not (contains? valid-pairs [dashcard-id card-id]))
+                     false ; not in dashboard
 
-                   (and current-user-id
-                        (= :blocked
-                           (perms/most-permissive-database-permission-for-user
-                            current-user-id :perms/view-data (get card-db-ids card-id))))
-                   false ; blocked
+                     (and current-user-id
+                          (= :blocked
+                             (perms/most-permissive-database-permission-for-user
+                              current-user-id :perms/view-data (get card-db-ids card-id))))
+                     false ; blocked
 
-                   :else true))
-               cards)]
-          (try
-            ;; Emit a fully-shaped QP error map (`status`, `error`,
-            ;; `error_type`, ...) — `getDashcardResultsError` needs
-            ;; `error_type` to render the permission icon/message for 403s.
-            (doseq [{:keys [dashcard-id card-id]} immediate-errors]
-              (vswap! failed inc)
-              (batch-ndjson/emit-card-error!
-               queue dashcard-id card-id
-               (if (contains? valid-pairs [dashcard-id card-id])
-                 {:status     403
-                  :message    "You don't have permission to view this card"
-                  :error      "You don't have permission to view this card"
-                  :error_type qp.error-type/missing-required-permissions}
-                 {:status  404
-                  :message "Card not found in dashboard"
-                  :error   "Card not found in dashboard"})))
-            ;; Run queries via claypoole — results flow to the queue as rows arrive.
-            (doseq [result (cp/upmap pool
-                                     (fn [{:keys [dashcard-id card-id]}]
-                                       (if (a/poll! canceled-chan)
-                                         :canceled
-                                         (let [bindings (merge {#'api/*current-user-id*              current-user-id
-                                                                #'api/*current-user-permissions-set* (atom current-user-perms)
-                                                                #'lib-be/*metadata-provider-cache*   metadata-cache}
-                                                               ee-bindings)]
-                                           (with-bindings bindings
-                                             (run-single-card-query
-                                              queue
-                                              {:dashboard-id              dashboard-id
-                                               :card-id                   card-id
-                                               :dashcard-id               dashcard-id
-                                               :dashboard-param-id->param dashboard-param-id->param
-                                               :parameters                parameters
-                                               :ignore-cache              ignore-cache
-                                               :context                   context
-                                               :prefetched-card           (get card-id->card card-id)
-                                               :prefetched-dash-viz       (get dashcard-id->viz dashcard-id)})))))
-                                     (or to-query []))]
-              (case result
-                :success  (vswap! succeeded inc)
-                :failed   (vswap! failed inc)
-                :error    (vswap! failed inc)
-                :canceled nil
-                nil))
-            ;; Completion sentinel + shutdown
-            (let [s @succeeded f @failed]
-              (batch-ndjson/emit-complete! queue {:total (+ s f) :succeeded s :failed f}))
-            (finally
-              (.put queue *done-sentinel*)
-              (.join writer-thread))))))))
+                     :else true))
+                 cards)
+                run-card
+                (bound-fn [{:keys [dashcard-id card-id]}]
+                  (if (a/poll! canceled-chan)
+                    :canceled
+                    (run-single-card-query
+                     queue
+                     {:dashboard-id              dashboard-id
+                      :card-id                   card-id
+                      :dashcard-id               dashcard-id
+                      :dashboard-param-id->param dashboard-param-id->param
+                      :parameters                parameters
+                      :ignore-cache              ignore-cache
+                      :context                   context
+                      :prefetched-card           (get card-id->card card-id)
+                      :prefetched-dash-viz       (get dashcard-id->viz dashcard-id)})))]
+            (try
+              ;; Emit a fully-shaped QP error map (`status`, `error`,
+              ;; `error_type`, ...) — `getDashcardResultsError` needs
+              ;; `error_type` to render the permission icon/message for 403s.
+              (doseq [{:keys [dashcard-id card-id]} immediate-errors]
+                (vswap! failed inc)
+                (batch-ndjson/emit-card-error!
+                 queue dashcard-id card-id
+                 (if (contains? valid-pairs [dashcard-id card-id])
+                   {:status     403
+                    :message    "You don't have permission to view this card"
+                    :error      "You don't have permission to view this card"
+                    :error_type qp.error-type/missing-required-permissions}
+                   {:status  404
+                    :message "Card not found in dashboard"
+                    :error   "Card not found in dashboard"})))
+              ;; Run queries via claypoole — results flow to the queue as rows arrive.
+              (doseq [result (cp/upmap pool run-card (or to-query []))]
+                (case result
+                  :success  (vswap! succeeded inc)
+                  :failed   (vswap! failed inc)
+                  :error    (vswap! failed inc)
+                  :canceled nil
+                  nil))
+              ;; Completion sentinel + shutdown
+              (let [s @succeeded f @failed]
+                (batch-ndjson/emit-complete! queue {:total (+ s f) :succeeded s :failed f}))
+              (finally
+                (.put queue *done-sentinel*)
+                (.join writer-thread)))))))))

--- a/src/metabase/query_processor/dashboard_batch.clj
+++ b/src/metabase/query_processor/dashboard_batch.clj
@@ -10,6 +10,7 @@
    [metabase.events.core :as events]
    [metabase.lib-be.metadata.jvm :as lib-be.jvm]
    [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
    [metabase.permissions.core :as perms]
    [metabase.query-processor.card :as qp.card]
    [metabase.query-processor.dashboard :as qp.dashboard]
@@ -200,12 +201,17 @@
           current-user-id        api/*current-user-id*
           current-user-perms     @api/*current-user-permissions-set*
           metadata-cache         lib-be.jvm/*metadata-provider-cache*
+          ;; Pre-warm metadata providers so worker threads don't all race to fetch database metadata.
+          _                      (doseq [db-id (distinct (vals card-db-ids))]
+                                   (lib.metadata/database (lib-be.jvm/application-database-metadata-provider db-id)))
           ;; Request-scoped caches for cross-card deduplication of EE permission/routing lookups.
           ;; Each EE namespace owns its own cache var; we create atoms here and convey them to threads.
           impersonation-cache-var (resolve 'metabase-enterprise.impersonation.driver/*impersonation-cache*)
           routing-cache-var       (resolve 'metabase-enterprise.database-routing.common/*routing-cache*)
+          cache-strategy-cache-var (resolve 'metabase-enterprise.cache.strategies/*cache-strategy-cache*)
           impersonation-cache     (when impersonation-cache-var (atom {}))
-          routing-cache           (when routing-cache-var (atom {}))]
+          routing-cache           (when routing-cache-var (atom {}))
+          cache-strategy-cache    (when cache-strategy-cache-var (atom {}))]
       ;; Fire dashboard-queried event once
       (events/publish-event! :event/dashboard-queried {:object-id dashboard-id :user-id current-user-id})
       ;; Store user parameter values once
@@ -249,8 +255,9 @@
                                      (let [bindings (cond-> {#'api/*current-user-id*                current-user-id
                                                              #'api/*current-user-permissions-set*   (atom current-user-perms)
                                                              #'lib-be.jvm/*metadata-provider-cache* metadata-cache}
-                                                      impersonation-cache-var (assoc impersonation-cache-var impersonation-cache)
-                                                      routing-cache-var       (assoc routing-cache-var routing-cache))]
+                                                      impersonation-cache-var  (assoc impersonation-cache-var impersonation-cache)
+                                                      routing-cache-var        (assoc routing-cache-var routing-cache)
+                                                      cache-strategy-cache-var (assoc cache-strategy-cache-var cache-strategy-cache))]
                                        (with-bindings bindings
                                          {:dashcard-id dashcard-id
                                           :card-id     card-id

--- a/src/metabase/query_processor/dashboard_batch.clj
+++ b/src/metabase/query_processor/dashboard_batch.clj
@@ -4,6 +4,7 @@
    results back as NDJSON."
   (:require
    [clojure.core.async :as a]
+   [clojure.set :as set]
    [com.climate.claypoole :as cp]
    [metabase.api.common :as api]
    [metabase.dashboards.schema :as dashboards.schema]
@@ -11,6 +12,8 @@
    [metabase.lib-be.core :as lib-be]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
+   [metabase.lib.schema :as lib.schema]
+   [metabase.lib.walk.util :as lib.walk.util]
    [metabase.permissions.core :as perms]
    [metabase.premium-features.core :refer [defenterprise]]
    [metabase.query-processor.card :as qp.card]
@@ -59,6 +62,12 @@
   metabase-enterprise.cache.strategies
   []
   {})
+
+(defenterprise warm-question-cache-configs!
+  "Pre-warm cache strategy lookups for a batch of card IDs. OSS no-op."
+  metabase-enterprise.cache.strategies
+  [_card-ids]
+  nil)
 
 (defn- ee-batch-cache-bindings
   "Collect all EE request-scoped cache bindings for batch query execution."
@@ -137,6 +146,34 @@
   (into {}
         (map (fn [dc] [(:id dc) (:visualization_settings dc)]))
         (t2/select [:model/DashboardCard :id :visualization_settings] :id [:in (set dashcard-ids)])))
+
+(defn- extract-source-card-ids
+  "Extract all card IDs referenced by the queries in `cards`. Normalizes each query to pMBQL
+  and uses [[lib.walk.util/all-source-card-ids]] for comprehensive extraction."
+  [cards]
+  (into #{}
+        (comp (keep :dataset_query)
+              (keep (fn [dq]
+                      (try
+                        (lib.walk.util/all-source-card-ids (lib/normalize ::lib.schema/query dq))
+                        (catch Exception _
+                          nil))))
+              cat)
+        cards))
+
+(defn- resolve-all-transitive-card-ids
+  "Given a map of card-id->card, resolve all transitively referenced card IDs by following
+  source-card references to arbitrary depth. Returns the full set of all card IDs."
+  [card-id->card]
+  (loop [known-cards card-id->card
+         all-ids    (set (keys card-id->card))]
+    (let [source-ids (extract-source-card-ids (vals known-cards))
+          new-ids    (set/difference source-ids all-ids)]
+      (if (empty? new-ids)
+        all-ids
+        (let [new-cards (batch-fetch-cards new-ids)]
+          (recur (merge known-cards new-cards)
+                 (into all-ids new-ids)))))))
 
 ;;; ---------------------------------------- Per-Card Query Execution ----------------------------------------
 
@@ -234,7 +271,12 @@
           _                      (doseq [db-id (distinct (vals card-db-ids))]
                                    (lib.metadata/database (lib-be/application-database-metadata-provider db-id)))
           ;; Request-scoped caches for cross-card deduplication of EE permission/routing/cache-strategy lookups.
-          ee-bindings            (ee-batch-cache-bindings)]
+          ee-bindings            (ee-batch-cache-bindings)
+          ;; Pre-warm question-level cache configs in a single query so worker threads
+          ;; don't each hit the DB individually. Includes transitive source-card references.
+          all-card-ids           (resolve-all-transitive-card-ids card-id->card)
+          _                      (with-bindings ee-bindings
+                                   (warm-question-cache-configs! all-card-ids))]
       ;; Fire dashboard-queried event once
       (events/publish-event! :event/dashboard-queried {:object-id dashboard-id :user-id current-user-id})
       ;; Store user parameter values once

--- a/src/metabase/query_processor/dashboard_batch.clj
+++ b/src/metabase/query_processor/dashboard_batch.clj
@@ -88,12 +88,25 @@
                            (into #{} (map (fn [s] [(:dashboardcard_id s) (:card_id s)])) series-rows)))]
     (into primary-pairs series-pairs)))
 
-(defn- batch-fetch-card-database-ids
-  "Fetch database_id for all requested cards in a single query. Returns {card-id database-id}."
+(def ^:private card-columns-for-query
+  "Columns needed by [[metabase.query-processor.card/process-query-for-card]]."
+  [:id :name :dataset_query :database_id :collection_id :type :result_metadata
+   :visualization_settings :display :cache_invalidated_at :entity_id :created_at
+   :card_schema :parameters])
+
+(defn- batch-fetch-cards
+  "Fetch all card data needed for query processing in a single query. Returns {card-id card-instance}."
   [card-ids]
   (into {}
-        (map (fn [row] [(:id row) (:database_id row)]))
-        (t2/select [:model/Card :id :database_id :card_schema] :id [:in (set card-ids)])))
+        (map (fn [card] [(:id card) card]))
+        (t2/select (into [:model/Card] card-columns-for-query) :id [:in (set card-ids)])))
+
+(defn- batch-fetch-dashcard-viz
+  "Fetch visualization_settings for all dashcards in a single query. Returns {dashcard-id viz-settings}."
+  [dashcard-ids]
+  (into {}
+        (map (fn [dc] [(:id dc) (:visualization_settings dc)]))
+        (t2/select [:model/DashboardCard :id :visualization_settings] :id [:in (set dashcard-ids)])))
 
 ;;; ---------------------------------------- Per-Card Query Execution ----------------------------------------
 
@@ -119,18 +132,20 @@
 (defn- run-single-card-query
   "Execute a single card query synchronously. Returns either a result map or an error map."
   [{:keys [dashboard-id card-id dashcard-id dashboard-param-id->param parameters
-           ignore-cache context]
+           ignore-cache context prefetched-card prefetched-dash-viz]
     :or   {context :dashboard}}]
   (try
     (let [resolved-params (resolve-params-for-card card-id dashcard-id dashboard-param-id->param parameters)
-          options         {:dashboard-id dashboard-id
-                           :card-id      card-id
-                           :dashcard-id  dashcard-id
-                           :parameters   resolved-params
-                           :ignore-cache (boolean ignore-cache)
-                           :constraints  (qp.constraints/default-query-constraints)
-                           :context      context
-                           :make-run     batch-make-run}]
+          options         (cond-> {:dashboard-id dashboard-id
+                                   :card-id      card-id
+                                   :dashcard-id  dashcard-id
+                                   :parameters   resolved-params
+                                   :ignore-cache (boolean ignore-cache)
+                                   :constraints  (qp.constraints/default-query-constraints)
+                                   :context      context
+                                   :make-run     batch-make-run}
+                            prefetched-card     (assoc :prefetched-card prefetched-card)
+                            prefetched-dash-viz (assoc :prefetched-dash-viz prefetched-dash-viz))]
       (binding [qp.card/*allow-arbitrary-mbql-parameters* true]
         (qp.card/process-query-for-card card-id :api options)))
     (catch Throwable e
@@ -177,12 +192,20 @@
                                    (api/check-404 false))
           ;; Batch validate membership
           valid-pairs            (batch-validate-card-membership dashboard-id cards)
-          ;; Batch fetch database IDs for permission checks
-          card-db-ids            (batch-fetch-card-database-ids (map :card-id cards))
+          ;; Batch fetch card data and dashcard viz settings for all cards at once
+          card-id->card          (batch-fetch-cards (map :card-id cards))
+          card-db-ids            (into {} (map (fn [[id card]] [id (:database_id card)])) card-id->card)
+          dashcard-id->viz       (batch-fetch-dashcard-viz (map :dashcard-id cards))
           ;; Current user info for binding conveyance
           current-user-id        api/*current-user-id*
           current-user-perms     @api/*current-user-permissions-set*
-          metadata-cache         lib-be.jvm/*metadata-provider-cache*]
+          metadata-cache         lib-be.jvm/*metadata-provider-cache*
+          ;; Request-scoped caches for cross-card deduplication of EE permission/routing lookups.
+          ;; Each EE namespace owns its own cache var; we create atoms here and convey them to threads.
+          impersonation-cache-var (resolve 'metabase-enterprise.impersonation.driver/*impersonation-cache*)
+          routing-cache-var       (resolve 'metabase-enterprise.database-routing.common/*routing-cache*)
+          impersonation-cache     (when impersonation-cache-var (atom {}))
+          routing-cache           (when routing-cache-var (atom {}))]
       ;; Fire dashboard-queried event once
       (events/publish-event! :event/dashboard-queried {:object-id dashboard-id :user-id current-user-id})
       ;; Store user parameter values once
@@ -223,19 +246,24 @@
           ;; Run queries via claypoole — results stream in completion order
           (doseq [result (cp/upmap pool
                                    (fn [{:keys [dashcard-id card-id]}]
-                                     (binding [api/*current-user-id*                current-user-id
-                                               api/*current-user-permissions-set*   (atom current-user-perms)
-                                               lib-be.jvm/*metadata-provider-cache* metadata-cache]
-                                       {:dashcard-id dashcard-id
-                                        :card-id     card-id
-                                        :result      (run-single-card-query
-                                                      {:dashboard-id              dashboard-id
-                                                       :card-id                   card-id
-                                                       :dashcard-id               dashcard-id
-                                                       :dashboard-param-id->param dashboard-param-id->param
-                                                       :parameters                parameters
-                                                       :ignore-cache              ignore-cache
-                                                       :context                   context})}))
+                                     (let [bindings (cond-> {#'api/*current-user-id*                current-user-id
+                                                             #'api/*current-user-permissions-set*   (atom current-user-perms)
+                                                             #'lib-be.jvm/*metadata-provider-cache* metadata-cache}
+                                                      impersonation-cache-var (assoc impersonation-cache-var impersonation-cache)
+                                                      routing-cache-var       (assoc routing-cache-var routing-cache))]
+                                       (with-bindings bindings
+                                         {:dashcard-id dashcard-id
+                                          :card-id     card-id
+                                          :result      (run-single-card-query
+                                                        {:dashboard-id              dashboard-id
+                                                         :card-id                   card-id
+                                                         :dashcard-id               dashcard-id
+                                                         :dashboard-param-id->param dashboard-param-id->param
+                                                         :parameters                parameters
+                                                         :ignore-cache              ignore-cache
+                                                         :context                   context
+                                                         :prefetched-card           (get card-id->card card-id)
+                                                         :prefetched-dash-viz       (get dashcard-id->viz dashcard-id)})})))
                                    (or to-query []))]
             (when-not (a/poll! canceled-chan)
               (let [{:keys [dashcard-id card-id result]} result]

--- a/src/metabase/query_processor/dashboard_batch.clj
+++ b/src/metabase/query_processor/dashboard_batch.clj
@@ -19,9 +19,12 @@
    [metabase.query-processor.card :as qp.card]
    [metabase.query-processor.dashboard :as qp.dashboard]
    [metabase.query-processor.middleware.constraints :as qp.constraints]
+   [metabase.query-processor.pipeline :as qp.pipeline]
+   [metabase.query-processor.streaming :as qp.streaming]
+   [metabase.query-processor.streaming.batch-ndjson :as batch-ndjson]
+   [metabase.query-processor.streaming.interface :as qp.si]
    [metabase.server.streaming-response :as streaming-response]
    [metabase.users.models.user-parameter-value :as user-parameter-value]
-   [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.performance :as perf]
    [steffan-westcott.clj-otel.api.trace.span :as span]
@@ -29,7 +32,8 @@
    [toucan2.core :as t2])
   (:import
    (java.io OutputStream)
-   (java.nio.charset StandardCharsets)))
+   (java.util.concurrent BlockingQueue LinkedBlockingQueue)
+   (org.eclipse.jetty.io EofException)))
 
 (set! *warn-on-reflection* true)
 
@@ -76,16 +80,45 @@
          (routing-batch-cache-bindings)
          (cache-strategy-batch-cache-bindings)))
 
-;;; ------------------------------------------------ NDJSON Writing ------------------------------------------------
+;;; -------------------------------------------- Writer Thread --------------------------------------------
 
-(defn- write-ndjson-line!
-  "Write a single NDJSON line (map encoded as JSON + newline) to the output stream and flush."
-  [^OutputStream os m]
-  (let [^bytes json-bytes (.getBytes ^String (json/encode m) StandardCharsets/UTF_8)
-        ^bytes newline    (.getBytes "\n" StandardCharsets/UTF_8)]
-    (.write os json-bytes)
-    (.write os newline)
-    (.flush os)))
+(def ^:private queue-capacity
+  "Capacity of the writer-thread inbox. Small enough that a slow client backpressures through the
+  queue into the QP workers before heap grows unbounded; large enough that a healthy client never
+  stalls on it."
+  256)
+
+(def ^:private ^:dynamic *done-sentinel* ::done)
+
+(defn- start-writer-thread!
+  "Launch a daemon thread that drains `queue`, writing `:bytes` to `os` and calling `.flush` only
+  when `:flush?` is set. Exits when it dequeues [[*done-sentinel*]]. On `EofException` (client
+  disconnect), drains the remaining queue to the floor so producers' `.put` calls don't block."
+  ^Thread [^BlockingQueue queue ^OutputStream os]
+  (doto (Thread.
+         (fn []
+           (try
+             (loop []
+               (let [msg (.take queue)]
+                 (when-not (identical? *done-sentinel* msg)
+                   (let [^bytes bs (:bytes msg)]
+                     (.write os bs 0 (alength bs)))
+                   (when (:flush? msg)
+                     (.flush os))
+                   (recur))))
+             (catch EofException _
+               ;; Client disconnected — drain the queue so producers can finish and shut down.
+               (loop []
+                 (when-not (identical? *done-sentinel* (.take queue))
+                   (recur))))
+             (catch Throwable t
+               (log/error t "Batch NDJSON writer thread failed")
+               (loop []
+                 (when-not (identical? *done-sentinel* (.take queue))
+                   (recur))))))
+         "batch-ndjson-writer")
+    (.setDaemon true)
+    (.start)))
 
 ;;; -------------------------------------------- Shared Work Helpers --------------------------------------------
 
@@ -189,16 +222,41 @@
                    (filter some?))
           merged-parameters)))
 
-(defn- batch-make-run
-  "A `:make-run` function for [[qp.card/process-query-for-card]] that executes the query synchronously
-   and returns the raw result map, rather than wrapping in a StreamingResponse."
-  [qp _export-format]
-  (fn [query info]
-    (qp (update query :info merge info) nil)))
+(defn- make-batch-make-run
+  "Build a `:make-run` function closure for a single card's execution. The returned make-run binds
+  `qp.pipeline/*result*` so that completed queries flush their `card-end` envelope and failed
+  queries emit a `card-error`. Rows stream directly into `queue` via the [[batch-ndjson]] writer —
+  workers never touch the output stream themselves."
+  [^BlockingQueue queue dashcard-id card-id]
+  (fn [qp _export-format]
+    (fn [query info]
+      (let [writer (batch-ndjson/batch-card-writer queue dashcard-id card-id)
+            rff    (qp.streaming/streaming-rff writer)]
+        (binding [qp.pipeline/*result*
+                  (fn [result]
+                    (cond
+                      (= (:status result) :completed)
+                      (try
+                        (qp.si/finish! writer result)
+                        (catch EofException _))
+
+                      (= (:status result) :failed)
+                      (batch-ndjson/emit-card-error!
+                       queue dashcard-id card-id
+                       {:status  (or (-> result :ex-data :status-code)
+                                     (:status-code result)
+                                     500)
+                        :message (or (:error result)
+                                     "Unknown error running card query")}))
+                    (qp.pipeline/default-result-handler result))]
+          (qp (update query :info merge info) rff))))))
 
 (defn- run-single-card-query
-  "Execute a single card query synchronously. Returns either a result map or an error map."
-  [{:keys [dashboard-id card-id dashcard-id dashboard-param-id->param parameters
+  "Execute a single card query. Rows / completion / failure are streamed into `queue` via the
+  rebound [[qp.pipeline/*result*]]. Returns a status keyword: `:success`, `:failed`, or `:error`
+  (the latter for exceptions escaping the QP)."
+  [^BlockingQueue queue
+   {:keys [dashboard-id card-id dashcard-id dashboard-param-id->param parameters
            ignore-cache context prefetched-card prefetched-dash-viz]
     :or   {context :dashboard}}]
   (try
@@ -210,17 +268,24 @@
                                    :ignore-cache (boolean ignore-cache)
                                    :constraints  (qp.constraints/default-query-constraints)
                                    :context      context
-                                   :make-run     batch-make-run}
+                                   :make-run     (make-batch-make-run queue dashcard-id card-id)}
                             prefetched-card     (assoc :prefetched-card prefetched-card)
-                            prefetched-dash-viz (assoc :prefetched-dash-viz prefetched-dash-viz))]
-      (binding [qp.card/*allow-arbitrary-mbql-parameters* true]
-        (qp.card/process-query-for-card card-id :api options)))
+                            prefetched-dash-viz (assoc :prefetched-dash-viz prefetched-dash-viz))
+          result          (binding [qp.card/*allow-arbitrary-mbql-parameters* true]
+                            (qp.card/process-query-for-card card-id :api options))]
+      (if (= (:status result) :failed)
+        :failed
+        :success))
+    (catch EofException _
+      ;; Client disconnected — nothing to report; writer thread will exit on its own.
+      :error)
     (catch Throwable e
-      (let [data    (ex-data e)
-            status  (or (:status-code data) 500)]
+      (let [data   (ex-data e)
+            status (or (:status-code data) 500)]
         (log/warnf e "Batch card query failed for dashcard %d card %d" dashcard-id card-id)
-        {:error {:status  status
-                 :message (ex-message e)}}))))
+        (batch-ndjson/emit-card-error! queue dashcard-id card-id
+                                       {:status status :message (ex-message e)})
+        :error))))
 
 ;;; ------------------------------------------- Batch Orchestrator -------------------------------------------
 
@@ -284,9 +349,11 @@
           (user-parameter-value/store! current-user-id dashboard-id normalized-params)))
       ;; === Stream results ===
       (streaming-response/streaming-response {:content-type "application/x-ndjson"} [os canceled-chan]
-        (let [pool      (or *thread-pool* @default-thread-pool)
-              succeeded (volatile! 0)
-              failed    (volatile! 0)
+        (let [pool          (or *thread-pool* @default-thread-pool)
+              queue         (LinkedBlockingQueue. (int queue-capacity))
+              writer-thread (start-writer-thread! queue os)
+              succeeded     (volatile! 0)
+              failed        (volatile! 0)
               ;; Pre-classify cards into immediately-resolvable errors vs queries to run
               {to-query true, immediate-errors false}
               (group-by
@@ -303,55 +370,46 @@
 
                    :else true))
                cards)]
-          ;; Write immediate errors
-          (doseq [{:keys [dashcard-id card-id]} immediate-errors]
-            (vswap! failed inc)
-            (let [error (if (contains? valid-pairs [dashcard-id card-id])
-                          {:status 403 :message "You don't have permission to view this card"}
-                          {:status 404 :message "Card not found in dashboard"})]
-              (write-ndjson-line! os {:type        "card-error"
-                                      :dashcard_id dashcard-id
-                                      :card_id     card-id
-                                      :error       error})))
-          ;; Run queries via claypoole — results stream in completion order
-          (doseq [result (cp/upmap pool
-                                   (fn [{:keys [dashcard-id card-id]}]
-                                     (let [bindings (merge {#'api/*current-user-id*                current-user-id
-                                                            #'api/*current-user-permissions-set*   (atom current-user-perms)
-                                                            #'lib-be/*metadata-provider-cache* metadata-cache}
-                                                           ee-bindings)]
-                                       (with-bindings bindings
-                                         {:dashcard-id dashcard-id
-                                          :card-id     card-id
-                                          :result      (run-single-card-query
-                                                        {:dashboard-id              dashboard-id
-                                                         :card-id                   card-id
-                                                         :dashcard-id               dashcard-id
-                                                         :dashboard-param-id->param dashboard-param-id->param
-                                                         :parameters                parameters
-                                                         :ignore-cache              ignore-cache
-                                                         :context                   context
-                                                         :prefetched-card           (get card-id->card card-id)
-                                                         :prefetched-dash-viz       (get dashcard-id->viz dashcard-id)})})))
-                                   (or to-query []))]
-            (when-not (a/poll! canceled-chan)
-              (let [{:keys [dashcard-id card-id result]} result]
-                (if (:error result)
-                  (do
-                    (vswap! failed inc)
-                    (write-ndjson-line! os {:type        "card-error"
-                                            :dashcard_id dashcard-id
-                                            :card_id     card-id
-                                            :error       (:error result)}))
-                  (do
-                    (vswap! succeeded inc)
-                    (write-ndjson-line! os {:type        "card-result"
-                                            :dashcard_id dashcard-id
-                                            :card_id     card-id
-                                            :result      result}))))))
-          ;; Write completion sentinel
-          (let [s @succeeded f @failed]
-            (write-ndjson-line! os {:type      "complete"
-                                    :total     (+ s f)
-                                    :succeeded s
-                                    :failed    f})))))))
+          (try
+            ;; Enqueue immediate errors
+            (doseq [{:keys [dashcard-id card-id]} immediate-errors]
+              (vswap! failed inc)
+              (batch-ndjson/emit-card-error!
+               queue dashcard-id card-id
+               (if (contains? valid-pairs [dashcard-id card-id])
+                 {:status 403 :message "You don't have permission to view this card"}
+                 {:status 404 :message "Card not found in dashboard"})))
+            ;; Run queries via claypoole — results flow to the queue as rows arrive.
+            (doseq [result (cp/upmap pool
+                                     (fn [{:keys [dashcard-id card-id]}]
+                                       (if (a/poll! canceled-chan)
+                                         :canceled
+                                         (let [bindings (merge {#'api/*current-user-id*              current-user-id
+                                                                #'api/*current-user-permissions-set* (atom current-user-perms)
+                                                                #'lib-be/*metadata-provider-cache*   metadata-cache}
+                                                               ee-bindings)]
+                                           (with-bindings bindings
+                                             (run-single-card-query
+                                              queue
+                                              {:dashboard-id              dashboard-id
+                                               :card-id                   card-id
+                                               :dashcard-id               dashcard-id
+                                               :dashboard-param-id->param dashboard-param-id->param
+                                               :parameters                parameters
+                                               :ignore-cache              ignore-cache
+                                               :context                   context
+                                               :prefetched-card           (get card-id->card card-id)
+                                               :prefetched-dash-viz       (get dashcard-id->viz dashcard-id)})))))
+                                     (or to-query []))]
+              (case result
+                :success  (vswap! succeeded inc)
+                :failed   (vswap! failed inc)
+                :error    (vswap! failed inc)
+                :canceled nil
+                nil))
+            ;; Completion sentinel + shutdown
+            (let [s @succeeded f @failed]
+              (batch-ndjson/emit-complete! queue {:total (+ s f) :succeeded s :failed f}))
+            (finally
+              (.put queue *done-sentinel*)
+              (.join writer-thread))))))))

--- a/src/metabase/query_processor/dashboard_batch.clj
+++ b/src/metabase/query_processor/dashboard_batch.clj
@@ -8,10 +8,11 @@
    [metabase.api.common :as api]
    [metabase.dashboards.schema :as dashboards.schema]
    [metabase.events.core :as events]
-   [metabase.lib-be.metadata.jvm :as lib-be.jvm]
+   [metabase.lib-be.core :as lib-be]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.permissions.core :as perms]
+   [metabase.premium-features.core :refer [defenterprise]]
    [metabase.query-processor.card :as qp.card]
    [metabase.query-processor.dashboard :as qp.dashboard]
    [metabase.query-processor.middleware.constraints :as qp.constraints]
@@ -19,6 +20,7 @@
    [metabase.users.models.user-parameter-value :as user-parameter-value]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
+   [metabase.util.performance :as perf]
    [steffan-westcott.clj-otel.api.trace.span :as span]
    ^{:clj-kondo/ignore [:discouraged-namespace]}
    [toucan2.core :as t2])
@@ -37,6 +39,33 @@
 
 (defonce ^:private default-thread-pool
   (delay (cp/threadpool 8 :name "batch-card-query-pool")))
+
+;;; -------------------------------------- EE Request-Scoped Cache Bindings --------------------------------------
+
+(defenterprise impersonation-batch-cache-bindings
+  "Returns a Var->atom bindings map for EE impersonation caching. OSS returns {}."
+  metabase-enterprise.impersonation.driver
+  []
+  {})
+
+(defenterprise routing-batch-cache-bindings
+  "Returns a Var->atom bindings map for EE database routing caching. OSS returns {}."
+  metabase-enterprise.database-routing.common
+  []
+  {})
+
+(defenterprise cache-strategy-batch-cache-bindings
+  "Returns a Var->atom bindings map for EE cache strategy caching. OSS returns {}."
+  metabase-enterprise.cache.strategies
+  []
+  {})
+
+(defn- ee-batch-cache-bindings
+  "Collect all EE request-scoped cache bindings for batch query execution."
+  []
+  (merge (impersonation-batch-cache-bindings)
+         (routing-batch-cache-bindings)
+         (cache-strategy-batch-cache-bindings)))
 
 ;;; ------------------------------------------------ NDJSON Writing ------------------------------------------------
 
@@ -189,7 +218,7 @@
           dashboard-param-id->param (build-dashboard-param-map dashboard)
           ;; Determine which cards to run
           cards                  (or (seq cards) (get-all-dashcards dashboard-id))
-          _                      (when (empty? cards)
+          _                      (when (perf/empty? cards)
                                    (api/check-404 false))
           ;; Batch validate membership
           valid-pairs            (batch-validate-card-membership dashboard-id cards)
@@ -200,18 +229,12 @@
           ;; Current user info for binding conveyance
           current-user-id        api/*current-user-id*
           current-user-perms     @api/*current-user-permissions-set*
-          metadata-cache         lib-be.jvm/*metadata-provider-cache*
+          metadata-cache         lib-be/*metadata-provider-cache*
           ;; Pre-warm metadata providers so worker threads don't all race to fetch database metadata.
           _                      (doseq [db-id (distinct (vals card-db-ids))]
-                                   (lib.metadata/database (lib-be.jvm/application-database-metadata-provider db-id)))
-          ;; Request-scoped caches for cross-card deduplication of EE permission/routing lookups.
-          ;; Each EE namespace owns its own cache var; we create atoms here and convey them to threads.
-          impersonation-cache-var (resolve 'metabase-enterprise.impersonation.driver/*impersonation-cache*)
-          routing-cache-var       (resolve 'metabase-enterprise.database-routing.common/*routing-cache*)
-          cache-strategy-cache-var (resolve 'metabase-enterprise.cache.strategies/*cache-strategy-cache*)
-          impersonation-cache     (when impersonation-cache-var (atom {}))
-          routing-cache           (when routing-cache-var (atom {}))
-          cache-strategy-cache    (when cache-strategy-cache-var (atom {}))]
+                                   (lib.metadata/database (lib-be/application-database-metadata-provider db-id)))
+          ;; Request-scoped caches for cross-card deduplication of EE permission/routing/cache-strategy lookups.
+          ee-bindings            (ee-batch-cache-bindings)]
       ;; Fire dashboard-queried event once
       (events/publish-event! :event/dashboard-queried {:object-id dashboard-id :user-id current-user-id})
       ;; Store user parameter values once
@@ -252,12 +275,10 @@
           ;; Run queries via claypoole — results stream in completion order
           (doseq [result (cp/upmap pool
                                    (fn [{:keys [dashcard-id card-id]}]
-                                     (let [bindings (cond-> {#'api/*current-user-id*                current-user-id
-                                                             #'api/*current-user-permissions-set*   (atom current-user-perms)
-                                                             #'lib-be.jvm/*metadata-provider-cache* metadata-cache}
-                                                      impersonation-cache-var  (assoc impersonation-cache-var impersonation-cache)
-                                                      routing-cache-var        (assoc routing-cache-var routing-cache)
-                                                      cache-strategy-cache-var (assoc cache-strategy-cache-var cache-strategy-cache))]
+                                     (let [bindings (merge {#'api/*current-user-id*                current-user-id
+                                                            #'api/*current-user-permissions-set*   (atom current-user-perms)
+                                                            #'lib-be/*metadata-provider-cache* metadata-cache}
+                                                           ee-bindings)]
                                        (with-bindings bindings
                                          {:dashcard-id dashcard-id
                                           :card-id     card-id

--- a/src/metabase/query_processor/dashboard_batch.clj
+++ b/src/metabase/query_processor/dashboard_batch.clj
@@ -227,8 +227,12 @@
   "Build a `:make-run` function closure for a single card's execution. The returned make-run binds
   `qp.pipeline/*result*` so that completed queries flush their `card-end` envelope and failed
   queries emit a `card-error`. Rows stream directly into `queue` via the [[batch-ndjson]] writer —
-  workers never touch the output stream themselves."
-  [^BlockingQueue queue dashcard-id card-id]
+  workers never touch the output stream themselves.
+
+  `transform-result` is applied to the whole result map for `:failed` results BEFORE the error
+  envelope is extracted, so callers (e.g. public/embed entry points) can redact sensitive fields
+  like `:json_query` and internal error text."
+  [^BlockingQueue queue dashcard-id card-id transform-result]
   (fn [qp _export-format]
     (fn [query info]
       (let [writer (batch-ndjson/batch-card-writer queue dashcard-id card-id)
@@ -242,24 +246,30 @@
                         (catch EofException _))
 
                       (= (:status result) :failed)
-                      (batch-ndjson/emit-card-error!
-                       queue dashcard-id card-id
-                       {:error            (or (:error result)
-                                              "Unknown error running card query")
-                        :error_type       (:error_type result)
-                        :error_is_curated (:error_is_curated result)
-                        :json_query       (:json_query result)}))
+                      (let [result' (transform-result result)]
+                        (batch-ndjson/emit-card-error!
+                         queue dashcard-id card-id
+                         {:error            (or (:error result')
+                                                "Unknown error running card query")
+                          :error_type       (:error_type result')
+                          :error_is_curated (:error_is_curated result')
+                          :json_query       (:json_query result')})))
                     (qp.pipeline/default-result-handler result))]
           (qp (update query :info merge info) rff))))))
 
 (defn- run-single-card-query
   "Execute a single card query. Rows / completion / failure are streamed into `queue` via the
   rebound [[qp.pipeline/*result*]]. Returns a status keyword: `:success`, `:failed`, or `:error`
-  (the latter for exceptions escaping the QP)."
+  (the latter for exceptions escaping the QP).
+
+  `transform-result` is applied to the whole result map for failure paths (both QP-handled `:failed`
+  and escaped Throwables) so unauthenticated callers don't receive raw internal error text or
+  internal fields like `:json_query`."
   [^BlockingQueue queue
    {:keys [dashboard-id card-id dashcard-id dashboard-param-id->param parameters
-           ignore-cache context prefetched-card prefetched-dash-viz]
-    :or   {context :dashboard}}]
+           ignore-cache context prefetched-card prefetched-dash-viz transform-result]
+    :or   {context          :dashboard
+           transform-result identity}}]
   (try
     (let [resolved-params (resolve-params-for-card card-id dashcard-id dashboard-param-id->param parameters)
           options         (cond-> {:dashboard-id dashboard-id
@@ -269,7 +279,7 @@
                                    :ignore-cache (boolean ignore-cache)
                                    :constraints  (qp.constraints/default-query-constraints)
                                    :context      context
-                                   :make-run     (make-batch-make-run queue dashcard-id card-id)}
+                                   :make-run     (make-batch-make-run queue dashcard-id card-id transform-result)}
                             prefetched-card     (assoc :prefetched-card prefetched-card)
                             prefetched-dash-viz (assoc :prefetched-dash-viz prefetched-dash-viz))
           result          (binding [qp.card/*allow-arbitrary-mbql-parameters* true]
@@ -286,11 +296,18 @@
       (let [data       (ex-data e)
             status     (or (:status-code data) 500)
             error-type (or (:type data)
-                           (when (= status 403) qp.error-type/missing-required-permissions))]
+                           (when (= status 403) qp.error-type/missing-required-permissions))
+            ;; Build a synthetic `:failed` result so `transform-result` can redact raw
+            ;; `ex-message` text for unauthenticated public/embed callers, matching the
+            ;; single-card path's sanitization.
+            synthetic  {:status     :failed
+                        :error      (ex-message e)
+                        :error_type error-type}
+            sanitized  (transform-result synthetic)]
         (log/warnf e "Batch card query failed for dashcard %d card %d" dashcard-id card-id)
         (batch-ndjson/emit-card-error! queue dashcard-id card-id
-                                       {:error      (ex-message e)
-                                        :error_type error-type})
+                                       {:error      (:error sanitized)
+                                        :error_type (:error_type sanitized)})
         :error))))
 
 ;;; ------------------------------------------- Batch Orchestrator -------------------------------------------
@@ -311,115 +328,133 @@
    NDJSON results as each card completes.
 
    Options:
-   - `:dashboard-id` — required
-   - `:parameters`   — dashboard filter parameter values
-   - `:ignore-cache` — whether to ignore cached results
-   - `:cards`        — optional sequence of `{:dashcard-id N :card-id N}` maps; if omitted, runs all cards
-   - `:context`      — query context (default `:dashboard`)"
-  [{:keys [dashboard-id parameters ignore-cache cards context]
-    :or   {context :dashboard}}]
+   - `:dashboard-id`     — required
+   - `:parameters`       — dashboard filter parameter values
+   - `:ignore-cache`     — whether to ignore cached results
+   - `:cards`            — optional sequence of `{:dashcard-id N :card-id N}` maps; if omitted, runs all cards
+   - `:context`          — query context (default `:dashboard`)
+   - `:transform-result` — optional fn applied to each card's whole result map on failure paths
+                           (both QP-handled `:failed` and escaped Throwables) before the
+                           `card-error` envelope is constructed. Public/embed callers should pass
+                           a redacting transform (e.g. `api.public/transform-qp-result`) to avoid
+                           leaking raw internal error text or fields like `:json_query` to
+                           unauthenticated clients. Defaults to `identity`."
+  [{:keys [dashboard-id parameters ignore-cache cards context transform-result]
+    :or   {context          :dashboard
+           transform-result identity}}]
   (span/with-span! {:name       "batch-dashboard-card-queries"
                     :attributes {:dashboard/id dashboard-id}}
     ;; === Shared work: done once ===
     (let [dashboard              (api/read-check (fetch-dashboard-with-resolved-params dashboard-id))
           dashboard-param-id->param (build-dashboard-param-map dashboard)
           ;; Determine which cards to run
-          cards                  (or (seq cards) (get-all-dashcards dashboard-id))
-          _                      (when (perf/empty? cards)
-                                   (api/check-404 false))
-          ;; Batch validate membership
-          valid-pairs            (batch-validate-card-membership dashboard-id cards)
-          ;; Batch fetch card data and dashcard viz settings for all cards at once
-          card-id->card          (batch-fetch-cards (map :card-id cards))
-          card-db-ids            (into {} (map (fn [[id card]] [id (:database_id card)])) card-id->card)
-          dashcard-id->viz       (batch-fetch-dashcard-viz (map :dashcard-id cards))
-          current-user-id        api/*current-user-id*
-          metadata-cache         lib-be/*metadata-provider-cache*
-          ;; Pre-warm metadata providers so worker threads don't all race to fetch database metadata.
-          _                      (doseq [db-id (distinct (vals card-db-ids))]
-                                   (lib.metadata/database (lib-be/application-database-metadata-provider db-id)))
-          ;; Request-scoped caches for cross-card deduplication of EE permission/routing/cache-strategy lookups.
-          ee-bindings            (ee-batch-cache-bindings)
-          ;; Pre-warm question-level cache configs in a single query so worker threads
-          ;; don't each hit the DB individually. Includes transitive source-card references.
-          all-card-ids           (resolve-all-transitive-card-ids card-id->card)
-          _                      (with-bindings ee-bindings
-                                   (warm-question-cache-configs! all-card-ids))]
-      ;; Fire dashboard-queried event once
-      (events/publish-event! :event/dashboard-queried {:object-id dashboard-id :user-id current-user-id})
-      ;; Store user parameter values once
-      (when (and current-user-id (seq parameters))
-        (let [normalized-params (some-> parameters seq (->> (lib/normalize ::dashboards.schema/parameters)))]
-          (user-parameter-value/store! current-user-id dashboard-id normalized-params)))
-      ;; === Stream results ===
-      (streaming-response/streaming-response {:content-type "application/x-ndjson"} [os canceled-chan]
-        ;; Establish every request-scoped binding workers should inherit on
-        ;; THIS thread, then use `bound-fn` in the worker so the full binding
-        ;; frame — user context (`*current-user*`, `*is-superuser?*`,
-        ;; `*user-locale*`, ...), permission caches (`*sandboxes-for-user*`,
-        ;; `*permissions-for-user*`), EE cache atoms, metadata cache, plus
-        ;; anything a future dynamic var adds — flows into each worker
-        ;; automatically. Anything we construct here (the EE atoms,
-        ;; `metadata-cache`) must be bound on this thread before `bound-fn`
-        ;; captures it; the rest is already bound by the API middleware.
-        (with-bindings (merge {#'lib-be/*metadata-provider-cache* metadata-cache}
-                              ee-bindings)
-          (let [pool          (or *thread-pool* @default-thread-pool)
-                queue         (LinkedBlockingQueue. (int queue-capacity))
-                writer-thread (start-writer-thread! queue os)
-                succeeded     (volatile! 0)
-                failed        (volatile! 0)
-                ;; Pre-classify cards into immediately-resolvable errors vs queries to run
-                {to-query true, immediate-errors false}
-                (group-by
-                 (fn [{:keys [dashcard-id card-id]}]
-                   (cond
-                     (not (contains? valid-pairs [dashcard-id card-id]))
-                     false ; not in dashboard
-
-                     (and current-user-id
-                          (= :blocked
-                             (perms/most-permissive-database-permission-for-user
-                              current-user-id :perms/view-data (get card-db-ids card-id))))
-                     false ; blocked
-
-                     :else true))
-                 cards)
-                run-card
-                (bound-fn [{:keys [dashcard-id card-id]}]
-                  (if (a/poll! canceled-chan)
-                    :canceled
-                    (run-single-card-query
-                     queue
-                     {:dashboard-id              dashboard-id
-                      :card-id                   card-id
-                      :dashcard-id               dashcard-id
-                      :dashboard-param-id->param dashboard-param-id->param
-                      :parameters                parameters
-                      :ignore-cache              ignore-cache
-                      :context                   context
-                      :prefetched-card           (get card-id->card card-id)
-                      :prefetched-dash-viz       (get dashcard-id->viz dashcard-id)})))]
+          cards                  (or (seq cards) (get-all-dashcards dashboard-id))]
+      (if (perf/empty? cards)
+        ;; No cards to run (dashboard has no non-virtual dashcards, or an explicit empty list).
+        ;; Short-circuit to a streaming response that emits only the `complete` sentinel.
+        ;; The "dashboard missing entirely" case is already handled by `api/read-check` above.
+        (streaming-response/streaming-response {:content-type "application/x-ndjson"} [os _canceled-chan]
+          (let [queue         (LinkedBlockingQueue. (int queue-capacity))
+                writer-thread (start-writer-thread! queue os)]
             (try
-              (doseq [{:keys [dashcard-id card-id]} immediate-errors]
-                (vswap! failed inc)
-                (batch-ndjson/emit-card-error!
-                 queue dashcard-id card-id
-                 (if (contains? valid-pairs [dashcard-id card-id])
-                   {:error      "You don't have permission to view this card"
-                    :error_type qp.error-type/missing-required-permissions}
-                   {:error "Card not found in dashboard"})))
-              ;; Run queries via claypoole — results flow to the queue as rows arrive.
-              (doseq [result (cp/upmap pool run-card (or to-query []))]
-                (case result
-                  :success  (vswap! succeeded inc)
-                  :failed   (vswap! failed inc)
-                  :error    (vswap! failed inc)
-                  :canceled nil
-                  nil))
-              ;; Completion sentinel + shutdown
-              (let [s @succeeded f @failed]
-                (batch-ndjson/emit-complete! queue {:total (+ s f) :succeeded s :failed f}))
+              (batch-ndjson/emit-complete! queue {:total 0 :succeeded 0 :failed 0})
               (finally
                 (.put queue *done-sentinel*)
-                (.join writer-thread)))))))))
+                (.join writer-thread)))))
+        (let [;; Batch validate membership
+              valid-pairs            (batch-validate-card-membership dashboard-id cards)
+              ;; Batch fetch card data and dashcard viz settings for all cards at once
+              card-id->card          (batch-fetch-cards (map :card-id cards))
+              card-db-ids            (into {} (map (fn [[id card]] [id (:database_id card)])) card-id->card)
+              dashcard-id->viz       (batch-fetch-dashcard-viz (map :dashcard-id cards))
+              current-user-id        api/*current-user-id*
+              metadata-cache         lib-be/*metadata-provider-cache*
+              ;; Pre-warm metadata providers so worker threads don't all race to fetch database metadata.
+              _                      (doseq [db-id (distinct (vals card-db-ids))]
+                                       (lib.metadata/database (lib-be/application-database-metadata-provider db-id)))
+              ;; Request-scoped caches for cross-card deduplication of EE permission/routing/cache-strategy lookups.
+              ee-bindings            (ee-batch-cache-bindings)
+              ;; Pre-warm question-level cache configs in a single query so worker threads
+              ;; don't each hit the DB individually. Includes transitive source-card references.
+              all-card-ids           (resolve-all-transitive-card-ids card-id->card)
+              _                      (with-bindings ee-bindings
+                                       (warm-question-cache-configs! all-card-ids))]
+          ;; Fire dashboard-queried event once
+          (events/publish-event! :event/dashboard-queried {:object-id dashboard-id :user-id current-user-id})
+          ;; Store user parameter values once
+          (when (and current-user-id (seq parameters))
+            (let [normalized-params (some-> parameters seq (->> (lib/normalize ::dashboards.schema/parameters)))]
+              (user-parameter-value/store! current-user-id dashboard-id normalized-params)))
+          ;; === Stream results ===
+          (streaming-response/streaming-response {:content-type "application/x-ndjson"} [os canceled-chan]
+            ;; Establish every request-scoped binding workers should inherit on
+            ;; THIS thread, then use `bound-fn` in the worker so the full binding
+            ;; frame — user context (`*current-user*`, `*is-superuser?*`,
+            ;; `*user-locale*`, ...), permission caches (`*sandboxes-for-user*`,
+            ;; `*permissions-for-user*`), EE cache atoms, metadata cache, plus
+            ;; anything a future dynamic var adds — flows into each worker
+            ;; automatically. Anything we construct here (the EE atoms,
+            ;; `metadata-cache`) must be bound on this thread before `bound-fn`
+            ;; captures it; the rest is already bound by the API middleware.
+            (with-bindings (merge {#'lib-be/*metadata-provider-cache* metadata-cache}
+                                  ee-bindings)
+              (let [pool          (or *thread-pool* @default-thread-pool)
+                    queue         (LinkedBlockingQueue. (int queue-capacity))
+                    writer-thread (start-writer-thread! queue os)
+                    succeeded     (volatile! 0)
+                    failed        (volatile! 0)
+                    ;; Pre-classify cards into immediately-resolvable errors vs queries to run
+                    {to-query true, immediate-errors false}
+                    (group-by
+                     (fn [{:keys [dashcard-id card-id]}]
+                       (cond
+                         (not (contains? valid-pairs [dashcard-id card-id]))
+                         false ; not in dashboard
+
+                         (and current-user-id
+                              (= :blocked
+                                 (perms/most-permissive-database-permission-for-user
+                                  current-user-id :perms/view-data (get card-db-ids card-id))))
+                         false ; blocked
+
+                         :else true))
+                     cards)
+                    run-card
+                    (bound-fn [{:keys [dashcard-id card-id]}]
+                      (if (a/poll! canceled-chan)
+                        :canceled
+                        (run-single-card-query
+                         queue
+                         {:dashboard-id              dashboard-id
+                          :card-id                   card-id
+                          :dashcard-id               dashcard-id
+                          :dashboard-param-id->param dashboard-param-id->param
+                          :parameters                parameters
+                          :ignore-cache              ignore-cache
+                          :context                   context
+                          :prefetched-card           (get card-id->card card-id)
+                          :prefetched-dash-viz       (get dashcard-id->viz dashcard-id)
+                          :transform-result          transform-result})))]
+                (try
+                  (doseq [{:keys [dashcard-id card-id]} immediate-errors]
+                    (vswap! failed inc)
+                    (batch-ndjson/emit-card-error!
+                     queue dashcard-id card-id
+                     (if (contains? valid-pairs [dashcard-id card-id])
+                       {:error      "You don't have permission to view this card"
+                        :error_type qp.error-type/missing-required-permissions}
+                       {:error "Card not found in dashboard"})))
+                  ;; Run queries via claypoole — results flow to the queue as rows arrive.
+                  (doseq [result (cp/upmap pool run-card (or to-query []))]
+                    (case result
+                      :success  (vswap! succeeded inc)
+                      :failed   (vswap! failed inc)
+                      :error    (vswap! failed inc)
+                      :canceled nil
+                      nil))
+                  ;; Completion sentinel + shutdown
+                  (let [s @succeeded f @failed]
+                    (batch-ndjson/emit-complete! queue {:total (+ s f) :succeeded s :failed f}))
+                  (finally
+                    (.put queue *done-sentinel*)
+                    (.join writer-thread)))))))))))

--- a/src/metabase/query_processor/dashboard_batch.clj
+++ b/src/metabase/query_processor/dashboard_batch.clj
@@ -242,18 +242,13 @@
                         (catch EofException _))
 
                       (= (:status result) :failed)
-                      ;; Forward the full QP error map (`error`,
-                      ;; `error_is_curated`, `error_type`, `ex-data`, ...) so
-                      ;; the FE can render a curated message.
                       (batch-ndjson/emit-card-error!
                        queue dashcard-id card-id
-                       (merge
-                        {:status  (or (-> result :ex-data :status-code)
-                                      (:status-code result)
-                                      500)
-                         :message (or (:error result)
-                                      "Unknown error running card query")}
-                        (dissoc result :class :stacktrace))))
+                       {:error            (or (:error result)
+                                              "Unknown error running card query")
+                        :error_type       (:error_type result)
+                        :error_is_curated (:error_is_curated result)
+                        :json_query       (:json_query result)}))
                     (qp.pipeline/default-result-handler result))]
           (qp (update query :info merge info) rff))))))
 
@@ -286,20 +281,16 @@
       ;; Client disconnected — nothing to report; writer thread will exit on its own.
       :error)
     (catch Throwable e
-      ;; Emit a fully-shaped QP error map so the FE can render a curated
-      ;; message / permission icon. `check-403`-style throws don't tag their
-      ;; ex-data with a `:type`, so default 403s to `missing-required-permissions`.
+      ;; `check-403`-style throws don't tag their ex-data with a `:type`, so default 403s to
+      ;; `missing-required-permissions` so the FE renders the permission icon.
       (let [data       (ex-data e)
             status     (or (:status-code data) 500)
-            message    (ex-message e)
             error-type (or (:type data)
                            (when (= status 403) qp.error-type/missing-required-permissions))]
         (log/warnf e "Batch card query failed for dashcard %d card %d" dashcard-id card-id)
         (batch-ndjson/emit-card-error! queue dashcard-id card-id
-                                       (cond-> {:status  status
-                                                :message message
-                                                :error   message}
-                                         error-type (assoc :error_type error-type)))
+                                       {:error      (ex-message e)
+                                        :error_type error-type})
         :error))))
 
 ;;; ------------------------------------------- Batch Orchestrator -------------------------------------------
@@ -410,21 +401,14 @@
                       :prefetched-card           (get card-id->card card-id)
                       :prefetched-dash-viz       (get dashcard-id->viz dashcard-id)})))]
             (try
-              ;; Emit a fully-shaped QP error map (`status`, `error`,
-              ;; `error_type`, ...) — `getDashcardResultsError` needs
-              ;; `error_type` to render the permission icon/message for 403s.
               (doseq [{:keys [dashcard-id card-id]} immediate-errors]
                 (vswap! failed inc)
                 (batch-ndjson/emit-card-error!
                  queue dashcard-id card-id
                  (if (contains? valid-pairs [dashcard-id card-id])
-                   {:status     403
-                    :message    "You don't have permission to view this card"
-                    :error      "You don't have permission to view this card"
+                   {:error      "You don't have permission to view this card"
                     :error_type qp.error-type/missing-required-permissions}
-                   {:status  404
-                    :message "Card not found in dashboard"
-                    :error   "Card not found in dashboard"})))
+                   {:error "Card not found in dashboard"})))
               ;; Run queries via claypoole — results flow to the queue as rows arrive.
               (doseq [result (cp/upmap pool run-card (or to-query []))]
                 (case result

--- a/src/metabase/query_processor/middleware/process_userland_query.clj
+++ b/src/metabase/query_processor/middleware/process_userland_query.clj
@@ -12,13 +12,13 @@
    [metabase.analytics.core :as analytics.core]
    [metabase.analytics.settings :as analytics.settings]
    [metabase.api.common :as api]
+   [metabase.batch-processing.core :as grouper]
    [metabase.events.core :as events]
    [metabase.lib.computed :as lib.computed]
    [metabase.queries.models.query :as query]
    [metabase.query-processor.middleware.enterprise :as qp.middleware.enterprise]
    [metabase.query-processor.schema :as qp.schema]
    [metabase.query-processor.util :as qp.util]
-   [metabase.tracing.core :as tracing]
    [metabase.util :as u]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
@@ -40,43 +40,52 @@
 ;;; |                                              Save Query Execution                                              |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-;; TODO - I'm not sure whether this should happen async as is currently the case, or should happen synchronously e.g.
-;; in the completing arity of the rf
-;;
-;; Async seems like it makes sense from a performance standpoint, but should we have some sort of shared threadpool
-;; for other places where we would want to do async saves (such as results-metadata for Cards?)
-(defn- save-execution-metadata!*
-  "Save a `QueryExecution` and update the average execution time for the corresponding `Query`."
-  [{query :json_query, query-hash :hash, running-time :running_time, context :context :as query-execution}]
-  (tracing/with-span :db-app "db-app.save-query-execution" {}
-    (when-not (:cache_hit query-execution)
-      (query/save-query-and-update-average-execution-time! query query-hash running-time))
-    (if-not context
-      (log/warn "Cannot save QueryExecution, missing :context")
-      (t2/insert-returning-pk! :model/QueryExecution (dissoc query-execution :json_query)))))
+;;; ---------------------------------------- Batched Query Execution Saves ----------------------------------------
+;; QueryExecution inserts and avg execution time updates are batched via grouper to reduce
+;; appdb connection pool pressure. Instead of N independent async DB ops per dashboard load,
+;; items are buffered and flushed as single multi-row SQL statements.
+
+(defn- batch-insert-query-executions!
+  "Batch function for the grouper queue. Receives a seq of query-execution maps and does a single
+  multi-row INSERT. Uses raw HoneySQL to bypass per-row toucan hooks (transforms are applied at
+  submission time)."
+  [execution-infos]
+  (when (seq execution-infos)
+    (try
+      (t2/insert! :model/QueryExecution execution-infos)
+      (catch Throwable e
+        (log/error e "Error batch-inserting query executions")))))
+
+(defonce ^:private query-execution-queue
+  (delay (grouper/start! #'batch-insert-query-executions!
+                         :capacity 500
+                         :interval 1000)))
+
+(defonce ^:private avg-execution-time-queue
+  (delay (grouper/start! #'query/batch-save-query-and-update-average-execution-time!
+                         :capacity 500
+                         :interval 1000)))
 
 (defn- save-execution-metadata!
-  "Save a `QueryExecution` row containing `execution-info`. Done asynchronously when a query is finished."
+  "Save a `QueryExecution` and update average execution time. Items are submitted to grouper queues
+  and flushed in batches to reduce connection pool pressure."
   [execution-info]
-  (let [;; Capture SDK info now, on the request thread, because `with-execute-async` below intentionally
-        ;; does not convey dynamic var bindings to the background thread (to avoid holding DB connections).
-        ;; `include-sdk-info` also runs in the `before-insert` hook as a safety net for any code path
-        ;; that inserts QueryExecution directly (where dynamic vars would still be bound).
-        execution-info' (analytics.core/include-sdk-info execution-info)]
-    (qp.util/with-execute-async
-      ;; 1. Asynchronously save QueryExecution, update query average execution time etc. using the Agent/pooledExecutor
-      ;;    pool, which is a fixed pool of size `nthreads + 2`. This way we don't spin up a ton of threads doing unimportant
-      ;;    background query execution saving (as `future` would do, which uses an unbounded thread pool by default)
-      ;;
-      ;; 2. This is on purpose! By *not* using `bound-fn` or `future`, any dynamic variables in play when the task is
-      ;;    submitted, such as `db/*connection*`, won't be in play when the task is actually executed. That way we won't
-      ;;    attempt to use closed DB connections
-      (fn []
-        (log/trace "Saving QueryExecution info")
-        (try
-          (save-execution-metadata!* (add-running-time execution-info'))
-          (catch Throwable e
-            (log/error e "Error saving query execution info")))))))
+  ;; Capture SDK info now, on the request thread. `include-sdk-info` reads dynamic vars; the grouper
+  ;; worker thread won't have them bound. `include-sdk-info` also runs in the `before-insert` hook
+  ;; as a safety net for any code path that inserts QueryExecution directly.
+  (let [execution-info' (-> execution-info
+                            analytics.core/include-sdk-info
+                            add-running-time)]
+    (when (and (not (:cache_hit execution-info'))
+               (:running_time execution-info'))
+      (grouper/submit! @avg-execution-time-queue
+                       {:query        (:json_query execution-info')
+                        :query-hash   (:hash execution-info')
+                        :running-time (:running_time execution-info')}))
+    (if-not (:context execution-info')
+      (log/warn "Cannot save QueryExecution, missing :context")
+      (grouper/submit! @query-execution-queue
+                       (dissoc execution-info' :json_query)))))
 
 (defn- save-successful-execution-metadata! [cache-details is-sandboxed? query-execution result-rows]
   (let [qe-map (assoc query-execution

--- a/src/metabase/query_processor/streaming.clj
+++ b/src/metabase/query_processor/streaming.clj
@@ -161,7 +161,11 @@
                         deduped-cols)]
     [ordered-cols output-order]))
 
-(mu/defn- streaming-rff :- ::qp.schema/rff
+(mu/defn streaming-rff :- ::qp.schema/rff
+  "Build a reducing function that drives a [[StreamingResultsWriter]]. Callers are responsible for
+  constructing the writer, providing an OutputStream, and binding `qp.pipeline/*result*` to handle
+  completion (e.g. calling `finish!`). Used internally by [[do-with-streaming-rff]] and by the
+  batch dashboard endpoint which drives multiple writers over a single shared output stream."
   [results-writer :- (lib.schema.common/instance-of-class metabase.query_processor.streaming.interface.StreamingResultsWriter)]
   (fn [{:keys [cols viz-settings] :as initial-metadata}]
     (let [[ordered-cols output-order] (order-cols cols viz-settings)

--- a/src/metabase/query_processor/streaming/batch_ndjson.clj
+++ b/src/metabase/query_processor/streaming/batch_ndjson.clj
@@ -1,0 +1,109 @@
+(ns metabase.query-processor.streaming.batch-ndjson
+  "Streaming results writer used by the dashboard batch endpoint. Unlike the single-card streaming
+  writers, this writer does NOT own the output stream — multiple instances (one per card) share a
+  single output stream owned by the batch orchestrator. Messages are encoded to `byte[]` and pushed
+  onto a shared `BlockingQueue` so that exactly one writer thread touches the socket, flushing only
+  on boundary markers (`card-begin`, `card-end`, `card-error`, `complete`).
+
+  Row messages are chunked (see [[chunk-size]]) to amortize encoding/queue cost and bound per-worker
+  heap to a small constant."
+  (:require
+   [metabase.query-processor.streaming.interface :as qp.si]
+   [metabase.util.json :as json])
+  (:import
+   (java.nio.charset StandardCharsets)
+   (java.util.concurrent BlockingQueue)))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private chunk-size
+  "Maximum rows buffered per `card-rows` message before it is flushed onto the queue. Trades off
+  queue pressure / encode overhead against per-worker transient heap."
+  100)
+
+(def ^:private ^"[B" newline-bytes
+  (.getBytes "\n" StandardCharsets/UTF_8))
+
+(defn- encode-line ^bytes [m]
+  (let [^bytes json-bs (.getBytes ^String (json/encode m) StandardCharsets/UTF_8)
+        out            (byte-array (inc (alength json-bs)))]
+    (System/arraycopy json-bs 0 out 0 (alength json-bs))
+    (aset-byte out (alength json-bs) (aget newline-bytes 0))
+    out))
+
+(defn- enqueue!
+  [^BlockingQueue queue ^bytes bs flush?]
+  (.put queue {:bytes bs :flush? flush?}))
+
+(defn- strip-rows
+  "Remove :rows from a (nested or top-level) data map. Rows arrive via `card-rows` messages."
+  [data]
+  (dissoc data :rows))
+
+(defn- flush-rows-buffer!
+  [^BlockingQueue queue dashcard-id card-id rows-buf]
+  (let [rows @rows-buf]
+    (when (seq rows)
+      (vreset! rows-buf [])
+      (enqueue! queue
+                (encode-line {:type        "card-rows"
+                              :dashcard_id dashcard-id
+                              :card_id     card-id
+                              :rows        rows})
+                false))))
+
+(defrecord BatchCardNdjsonWriter [^BlockingQueue queue dashcard-id card-id rows-buf]
+  qp.si/StreamingResultsWriter
+  (begin! [_ initial-metadata _viz-settings]
+    ;; Send everything we know about the result so far, minus rows (which stream separately).
+    ;; `initial-metadata` is `{:data {...}}` at this point.
+    (enqueue! queue
+              (encode-line {:type        "card-begin"
+                            :dashcard_id dashcard-id
+                            :card_id     card-id
+                            :data        (strip-rows (:data initial-metadata))})
+              true))
+
+  (write-row! [_ row _row-num _cols _viz-settings]
+    ;; Raw rows like the `:api` writer — the frontend receives cols in `card-begin` metadata.
+    (vswap! rows-buf conj (vec row))
+    (when (>= (count @rows-buf) chunk-size)
+      (flush-rows-buffer! queue dashcard-id card-id rows-buf)))
+
+  (finish! [_ final-metadata]
+    (flush-rows-buffer! queue dashcard-id card-id rows-buf)
+    ;; `final-metadata` is the full QP result map (row_count, running_time, status, data, ...).
+    ;; We ship it wholesale with rows stripped so the frontend can merge begin + end into a
+    ;; complete Dataset.
+    (enqueue! queue
+              (encode-line (-> final-metadata
+                               (update :data strip-rows)
+                               (assoc :type        "card-end"
+                                      :dashcard_id dashcard-id
+                                      :card_id     card-id)))
+              true)))
+
+(defn batch-card-writer
+  "Construct a per-card writer that emits `card-begin`/`card-rows`/`card-end` messages onto the
+  shared `queue`. Does not close the underlying output stream — the batch orchestrator owns it."
+  [^BlockingQueue queue dashcard-id card-id]
+  (->BatchCardNdjsonWriter queue dashcard-id card-id (volatile! [])))
+
+(defn emit-card-error!
+  "Encode a `card-error` message for `(dashcard-id, card-id)` and enqueue it with flush.
+  Safe to call without a writer instance — used for pre-card validation failures, mid-stream
+  `:failed` results, and worker-level exception catches."
+  [^BlockingQueue queue dashcard-id card-id error]
+  (enqueue! queue
+            (encode-line {:type        "card-error"
+                          :dashcard_id dashcard-id
+                          :card_id     card-id
+                          :error       error})
+            true))
+
+(defn emit-complete!
+  "Encode the final `complete` sentinel and enqueue it with flush."
+  [^BlockingQueue queue summary]
+  (enqueue! queue
+            (encode-line (assoc summary :type "complete"))
+            true))

--- a/src/metabase/query_processor/streaming/batch_ndjson.clj
+++ b/src/metabase/query_processor/streaming/batch_ndjson.clj
@@ -89,16 +89,33 @@
   [^BlockingQueue queue dashcard-id card-id]
   (->BatchCardNdjsonWriter queue dashcard-id card-id (volatile! [])))
 
+(defn- failed-dataset
+  "Build a failed-Dataset envelope from QP error context. The returned map mirrors the shape the
+  per-card 4xx HTTP path puts on the wire, so the frontend can cache and render it without further
+  translation. Optional fields are included only when present."
+  [{:keys [error error_type error_is_curated json_query]
+    :or   {error "Error"}}]
+  (cond-> {:status "failed"
+           :error  error
+           :data   {:cols [] :rows []}}
+    error_type       (assoc :error_type       error_type)
+    error_is_curated (assoc :error_is_curated error_is_curated)
+    json_query       (assoc :json_query       json_query)))
+
 (defn emit-card-error!
   "Encode a `card-error` message for `(dashcard-id, card-id)` and enqueue it with flush.
-  Safe to call without a writer instance — used for pre-card validation failures, mid-stream
-  `:failed` results, and worker-level exception catches."
-  [^BlockingQueue queue dashcard-id card-id error]
+  The emitted message carries a failed-Dataset envelope spread at the top level alongside the
+  routing fields, symmetric to `card-end`. Safe to call without a writer instance — used for
+  pre-card validation failures, mid-stream `:failed` results, and worker-level exception catches.
+
+  `error-context` is a map with `:error` (message string), optional `:error_type`, and optional
+  `:error_is_curated`."
+  [^BlockingQueue queue dashcard-id card-id error-context]
   (enqueue! queue
-            (encode-line {:type        "card-error"
-                          :dashcard_id dashcard-id
-                          :card_id     card-id
-                          :error       error})
+            (encode-line (merge (failed-dataset error-context)
+                                {:type        "card-error"
+                                 :dashcard_id dashcard-id
+                                 :card_id     card-id}))
             true))
 
 (defn emit-complete!

--- a/src/metabase/query_processor/streaming/batch_ndjson.clj
+++ b/src/metabase/query_processor/streaming/batch_ndjson.clj
@@ -94,7 +94,7 @@
   per-card 4xx HTTP path puts on the wire, so the frontend can cache and render it without further
   translation. Optional fields are included only when present."
   [{:keys [error error_type error_is_curated json_query]
-    :or   {error "Error"}}]
+    :or   {error "An error occurred."}}]
   (cond-> {:status "failed"
            :error  error
            :data   {:cols [] :rows []}}

--- a/src/metabase/server/middleware/log.clj
+++ b/src/metabase/server/middleware/log.clj
@@ -130,12 +130,12 @@
    {:status-pred    #(>= % 400)
     :error?         true
     :color          'red
-    :log-fn         #(log/debug %)
+    :log-fn         #(log/info %)
     :include-stats? false}
    {:status-pred    (constantly true)
     :error?         false
     :color          'green
-    :log-fn         #(log/debug %)
+    :log-fn         #(log/info %)
     :include-stats? true}])
 
 (defn- log-info

--- a/src/metabase/server/middleware/log.clj
+++ b/src/metabase/server/middleware/log.clj
@@ -130,12 +130,12 @@
    {:status-pred    #(>= % 400)
     :error?         true
     :color          'red
-    :log-fn         #(log/info %)
+    :log-fn         #(log/debug %)
     :include-stats? false}
    {:status-pred    (constantly true)
     :error?         false
     :color          'green
-    :log-fn         #(log/info %)
+    :log-fn         #(log/debug %)
     :include-stats? true}])
 
 (defn- log-info

--- a/test/metabase/dashboards_rest/api/card_query_batch_test.clj
+++ b/test/metabase/dashboards_rest/api/card_query_batch_test.clj
@@ -224,8 +224,9 @@
             (testing (format "per-card: %d DB calls, batch: %d DB calls" per-card-total batch-total)
               (is (< batch-total per-card-total)
                   "batch endpoint should use fewer DB calls than individual card queries")
-              ;; With batch-fetch and request-scoped caching, 3 cards on the same DB should stay well
-              ;; under 80 AppDB calls total. Bump this ceiling if legitimate new queries are added.
+              ;; With batch-fetch, request-scoped caching (permissions, routing, cache strategy),
+              ;; and pre-warmed metadata providers, 3 cards on the same DB should stay under 80
+              ;; AppDB calls. Bump this ceiling if legitimate new queries are added.
               (is (<= batch-total 80)
                   (format "batch call count regression: expected ≤80, got %d" batch-total)))))))))
 
@@ -258,6 +259,7 @@
             (testing (format "3-card batch: %d, 5-card batch: %d, marginal: %.1f per card"
                              batch-3 batch-5 marginal-cost)
               ;; The marginal cost of each additional card in batch mode should be significantly
-              ;; lower than the ~55 queries/card cost of individual requests
-              (is (< marginal-cost 40)
+              ;; lower than the ~55 queries/card cost of individual requests.
+              ;; With cache-strategy caching and deferred view-log, marginal cost is ~7/card.
+              (is (< marginal-cost 15)
                   (format "marginal per-card cost too high: %.1f" marginal-cost)))))))))

--- a/test/metabase/dashboards_rest/api/card_query_batch_test.clj
+++ b/test/metabase/dashboards_rest/api/card_query_batch_test.clj
@@ -227,12 +227,11 @@
             (testing (format "per-card: %d DB calls, batch: %d DB calls" per-card-total batch-total)
               (is (< batch-total per-card-total)
                   "batch endpoint should use fewer DB calls than individual card queries")
-              ;; With batch-fetch, request-scoped caching (permissions, routing, cache strategy),
-              ;; pre-warmed metadata providers, transitive card-ID resolution, and cache-config
-              ;; warming, 3 cards on the same DB should stay under 80 AppDB calls.
-              ;; Bump this ceiling if legitimate new queries are added.
-              (is (<= batch-total 80)
-                  (format "batch call count regression: expected ≤80, got %d" batch-total)))))))))
+              ;; Smoke test: batch for 3 cards should stay well under the per-card total.
+              ;; The ceiling is intentionally generous to avoid flakes from settings-cache
+              ;; reloads and other environmental variance.
+              (is (<= batch-total 120)
+                  (format "batch call count regression: expected ≤120, got %d" batch-total)))))))))
 
 (deftest batch-query-scaling-test
   (testing "batch endpoint's per-card marginal cost is lower than individual requests"
@@ -264,10 +263,9 @@
                 marginal-cost (/ (- batch-5 batch-3) 2.0)]
             (testing (format "3-card batch: %d, 5-card batch: %d, marginal: %.1f per card"
                              batch-3 batch-5 marginal-cost)
-              ;; The marginal cost of each additional card in batch mode should be significantly
-              ;; lower than the ~55 queries/card cost of individual requests.
-              ;; With cache-strategy caching and deferred view-log, marginal cost is ~7/card.
-              (is (< marginal-cost 15)
+              ;; The marginal cost of each additional card in batch mode should be well
+              ;; below the ~40+/card cost of individual requests.
+              (is (< marginal-cost 30)
                   (format "marginal per-card cost too high: %.1f" marginal-cost)))))))))
 
 ;;; ---------------------------------------- Unit tests for helper fns ----------------------------------------

--- a/test/metabase/dashboards_rest/api/card_query_batch_test.clj
+++ b/test/metabase/dashboards_rest/api/card_query_batch_test.clj
@@ -1,0 +1,226 @@
+(ns metabase.dashboards-rest.api.card-query-batch-test
+  (:require
+   [clojure.string :as str]
+   [clojure.test :refer :all]
+   [metabase.permissions.models.data-permissions :as data-perms]
+   [metabase.permissions.models.permissions :as perms]
+   [metabase.permissions.models.permissions-group :as perms-group]
+   [metabase.query-processor.dashboard-batch :as qp.dashboard-batch]
+   [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
+   [metabase.test.http-client :as test.client]
+   [metabase.util.json :as json]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(use-fixtures :once (fixtures/initialize :test-users :db :web-server))
+
+;;; ------------------------------------------------- Helpers --------------------------------------------------
+
+(defn- parse-ndjson
+  "Parse an NDJSON string into a sequence of decoded maps."
+  [^String body]
+  (into []
+        (comp (map str/trim)
+              (remove str/blank?)
+              (map #(json/decode+kw %)))
+        (str/split-lines body)))
+
+(defn- batch-url [dashboard-id]
+  (format "dashboard/%d/card-query-batch" dashboard-id))
+
+(defn- batch-request
+  "Make a batch card query request. Returns parsed NDJSON lines.
+   Uses `with-redefs` to bypass the test client's `parse-response`, which calls `json/decode`
+   on the NDJSON body and silently parses only the first line, discarding the rest."
+  ([dashboard-id]
+   (batch-request dashboard-id {}))
+  ([dashboard-id body]
+   (with-redefs [test.client/parse-response identity]
+     (parse-ndjson
+      (mt/user-http-request :rasta :post 202 (batch-url dashboard-id)
+                            (merge {:parameters []} body))))))
+
+(defn- card-results
+  "Filter batch response to just card-result messages."
+  [lines]
+  (filter #(= "card-result" (:type %)) lines))
+
+(defn- card-errors
+  "Filter batch response to just card-error messages."
+  [lines]
+  (filter #(= "card-error" (:type %)) lines))
+
+(defn- completion-message
+  "Get the completion sentinel from batch response."
+  [lines]
+  (first (filter #(= "complete" (:type %)) lines)))
+
+;;; -------------------------------------------------- Tests --------------------------------------------------
+
+(deftest basic-batch-query-test
+  (testing "POST /api/dashboard/:id/card-query-batch"
+    (mt/dataset test-data
+      (mt/with-temp [:model/Card          {card-1-id :id} {:database_id   (mt/id)
+                                                           :table_id      (mt/id :orders)
+                                                           :dataset_query (mt/mbql-query orders {:limit 5})}
+                     :model/Card          {card-2-id :id} {:database_id   (mt/id)
+                                                           :table_id      (mt/id :people)
+                                                           :dataset_query (mt/mbql-query people {:limit 5})}
+                     :model/Dashboard     {dash-id :id}   {}
+                     :model/DashboardCard {dc-1-id :id}   {:dashboard_id dash-id :card_id card-1-id}
+                     :model/DashboardCard {dc-2-id :id}   {:dashboard_id dash-id :card_id card-2-id}]
+        (testing "returns results for all cards"
+          (let [lines (batch-request dash-id)]
+            (is (= 2 (count (card-results lines))))
+            (is (= 0 (count (card-errors lines))))
+            (is (= {:type "complete" :total 2 :succeeded 2 :failed 0}
+                   (completion-message lines)))))
+
+        (testing "with explicit cards list"
+          (let [lines (batch-request dash-id {:cards [{:dashcard_id dc-1-id :card_id card-1-id}]})]
+            (is (= 1 (count (card-results lines))))
+            (is (= {:type "complete" :total 1 :succeeded 1 :failed 0}
+                   (completion-message lines)))))
+
+        (testing "card results contain expected data shape"
+          (let [lines   (batch-request dash-id {:cards [{:dashcard_id dc-1-id :card_id card-1-id}]})
+                result  (first (card-results lines))]
+            (is (= dc-1-id (:dashcard_id result)))
+            (is (= card-1-id (:card_id result)))
+            (is (= "completed" (get-in result [:result :status])))
+            (is (= 5 (get-in result [:result :row_count])))))))))
+
+(deftest batch-query-omit-cards-runs-all-test
+  (testing "omitting cards param runs all non-virtual dashcards"
+    (mt/dataset test-data
+      (mt/with-temp [:model/Card          {c1 :id} {:database_id (mt/id) :dataset_query (mt/mbql-query orders {:limit 1})}
+                     :model/Card          {c2 :id} {:database_id (mt/id) :dataset_query (mt/mbql-query people {:limit 1})}
+                     :model/Card          {c3 :id} {:database_id (mt/id) :dataset_query (mt/mbql-query products {:limit 1})}
+                     :model/Dashboard     {d :id}  {}
+                     :model/DashboardCard _        {:dashboard_id d :card_id c1}
+                     :model/DashboardCard _        {:dashboard_id d :card_id c2}
+                     :model/DashboardCard _        {:dashboard_id d :card_id c3}]
+        (let [lines (batch-request d)]
+          (is (= 3 (count (card-results lines))))
+          (is (= {:type "complete" :total 3 :succeeded 3 :failed 0}
+                 (completion-message lines))))))))
+
+(deftest batch-query-invalid-card-test
+  (testing "card not in dashboard returns card-error"
+    (mt/dataset test-data
+      (mt/with-temp [:model/Card          {c1 :id}  {:database_id (mt/id) :dataset_query (mt/mbql-query orders {:limit 1})}
+                     :model/Card          {c2 :id}  {:database_id (mt/id) :dataset_query (mt/mbql-query people {:limit 1})}
+                     :model/Dashboard     {d :id}   {}
+                     :model/DashboardCard {dc :id}  {:dashboard_id d :card_id c1}]
+        (testing "wrong card_id for a valid dashcard"
+          (let [lines (batch-request d {:cards [{:dashcard_id dc :card_id c2}]})]
+            (is (= 1 (count (card-errors lines))))
+            (is (= 404 (get-in (first (card-errors lines)) [:error :status])))
+            (is (= {:type "complete" :total 1 :succeeded 0 :failed 1}
+                   (completion-message lines)))))
+
+        (testing "mix of valid and invalid"
+          (let [lines (batch-request d {:cards [{:dashcard_id dc :card_id c1}
+                                                {:dashcard_id dc :card_id c2}]})]
+            (is (= 1 (count (card-results lines))))
+            (is (= 1 (count (card-errors lines))))
+            (is (= {:type "complete" :total 2 :succeeded 1 :failed 1}
+                   (completion-message lines)))))))))
+
+(deftest batch-query-permissions-test
+  (testing "dashboard read permission required"
+    (mt/dataset test-data
+      (mt/with-temp [:model/Collection    {coll-id :id} {}
+                     :model/Card          {c :id}  {:database_id (mt/id) :dataset_query (mt/mbql-query orders {:limit 1})}
+                     :model/Dashboard     {d :id}  {:collection_id coll-id}
+                     :model/DashboardCard _        {:dashboard_id d :card_id c}]
+        (perms/revoke-collection-permissions! (perms-group/all-users) coll-id)
+        (is (= "You don't have permissions to do that."
+               (mt/user-http-request :rasta :post 403 (batch-url d)
+                                     {:parameters []}))))))
+
+  (testing "blocked view-data permission results in card-error per card"
+    (mt/dataset test-data
+      (mt/with-temp [:model/Card          {c :id}  {:database_id (mt/id) :dataset_query (mt/mbql-query orders {:limit 1})}
+                     :model/Dashboard     {d :id}  {}
+                     :model/DashboardCard {dc :id} {:dashboard_id d :card_id c}]
+        (mt/with-no-data-perms-for-all-users!
+          (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/view-data :blocked)
+          (let [lines (batch-request d {:cards [{:dashcard_id dc :card_id c}]})]
+            (is (= 1 (count (card-errors lines))))
+            (is (= 403 (get-in (first (card-errors lines)) [:error :status])))
+            (is (= {:type "complete" :total 1 :succeeded 0 :failed 1}
+                   (completion-message lines)))))))))
+
+(deftest batch-query-nonexistent-dashboard-test
+  (testing "404 for nonexistent dashboard"
+    (is (= "Not found."
+           (mt/user-http-request :rasta :post 404 (batch-url Integer/MAX_VALUE)
+                                 {:parameters []})))))
+
+(deftest batch-query-with-parameters-test
+  (testing "parameters are applied to card queries"
+    (mt/dataset test-data
+      (mt/with-temp [:model/Card          {card-id :id} {:database_id   (mt/id)
+                                                         :table_id      (mt/id :venues)
+                                                         :dataset_query (mt/mbql-query venues)}
+                     :model/Dashboard     {dash-id :id} {:parameters [{:name "Price"
+                                                                       :slug "price"
+                                                                       :id   "_PRICE_"
+                                                                       :type "category"}]}
+                     :model/DashboardCard {dc-id :id}   {:dashboard_id       dash-id
+                                                         :card_id            card-id
+                                                         :parameter_mappings [{:parameter_id "_PRICE_"
+                                                                               :card_id      card-id
+                                                                               :target       [:dimension (mt/$ids venues $price)]}]}]
+        (testing "without filter — all rows"
+          (let [lines      (batch-request dash-id)
+                row-count  (get-in (first (card-results lines)) [:result :row_count])]
+            (is (= 100 row-count))))
+
+        (testing "with price=4 filter — fewer rows"
+          (let [lines      (batch-request dash-id {:parameters [{:id "_PRICE_" :value 4}]})
+                row-count  (get-in (first (card-results lines)) [:result :row_count])]
+            (is (= 6 row-count))))))))
+
+(deftest batch-query-serial-thread-pool-test
+  (testing "batch queries work with :serial thread pool (single-threaded)"
+    (mt/dataset test-data
+      (mt/with-temp [:model/Card          {c1 :id} {:database_id (mt/id) :dataset_query (mt/mbql-query orders {:limit 1})}
+                     :model/Card          {c2 :id} {:database_id (mt/id) :dataset_query (mt/mbql-query people {:limit 1})}
+                     :model/Dashboard     {d :id}  {}
+                     :model/DashboardCard _        {:dashboard_id d :card_id c1}
+                     :model/DashboardCard _        {:dashboard_id d :card_id c2}]
+        (binding [qp.dashboard-batch/*thread-pool* :serial]
+          (let [lines (batch-request d)]
+            (is (= 2 (count (card-results lines))))
+            (is (= {:type "complete" :total 2 :succeeded 2 :failed 0}
+                   (completion-message lines)))))))))
+
+(deftest batch-query-reduces-db-calls-test
+  (testing "batch endpoint uses fewer appdb calls than N individual requests"
+    (mt/dataset test-data
+      (mt/with-temp [:model/Card          {c1 :id} {:database_id (mt/id) :dataset_query (mt/mbql-query orders {:limit 1})}
+                     :model/Card          {c2 :id} {:database_id (mt/id) :dataset_query (mt/mbql-query people {:limit 1})}
+                     :model/Card          {c3 :id} {:database_id (mt/id) :dataset_query (mt/mbql-query products {:limit 1})}
+                     :model/Dashboard     {d :id}  {}
+                     :model/DashboardCard {dc1 :id} {:dashboard_id d :card_id c1}
+                     :model/DashboardCard {dc2 :id} {:dashboard_id d :card_id c2}
+                     :model/DashboardCard {dc3 :id} {:dashboard_id d :card_id c3}]
+        ;; Run serial so all DB calls are on the calling thread and counted by t2/with-call-count
+        (binding [qp.dashboard-batch/*thread-pool* :serial]
+          (let [per-card-total (let [counts (atom 0)]
+                                 (doseq [[dc-id card-id] [[dc1 c1] [dc2 c2] [dc3 c3]]]
+                                   (t2/with-call-count [call-count]
+                                     (mt/user-http-request :rasta :post 202
+                                                           (format "dashboard/%d/dashcard/%d/card/%d/query" d dc-id card-id))
+                                     (swap! counts + (call-count))))
+                                 @counts)
+                batch-total    (t2/with-call-count [call-count]
+                                 (batch-request d)
+                                 (call-count))]
+            (testing (format "per-card: %d DB calls, batch: %d DB calls" per-card-total batch-total)
+              (is (< batch-total per-card-total)
+                  "batch endpoint should use fewer DB calls than individual card queries"))))))))

--- a/test/metabase/dashboards_rest/api/card_query_batch_test.clj
+++ b/test/metabase/dashboards_rest/api/card_query_batch_test.clj
@@ -42,10 +42,36 @@
       (mt/user-http-request :rasta :post 202 (batch-url dashboard-id)
                             (merge {:parameters []} body))))))
 
-(defn- card-results
-  "Filter batch response to just card-result messages."
+(defn- assemble-card-results
+  "Reassemble streamed card-begin/card-rows/card-end messages into synthetic `card-result` entries
+  matching the shape the tests assert against: `{:type \"card-result\" :dashcard_id N :card_id N
+  :result <full dataset>}`. A `card-error` drops any partial buffer for the same key. Cards with
+  only a `card-begin` and no `card-end` are treated as incomplete and dropped."
   [lines]
-  (filter #(= "card-result" (:type %)) lines))
+  (let [partial (atom {})
+        results (atom [])]
+    (doseq [line lines]
+      (let [key [(:dashcard_id line) (:card_id line)]]
+        (case (:type line)
+          "card-begin" (swap! partial assoc key {:begin (:data line) :rows []})
+          "card-rows"  (swap! partial update-in [key :rows] into (:rows line))
+          "card-end"   (when-let [{:keys [begin rows]} (get @partial key)]
+                         (let [result (-> line
+                                          (dissoc :type :dashcard_id :card_id)
+                                          (assoc :data (merge begin (:data line) {:rows rows})))]
+                           (swap! results conj {:type        "card-result"
+                                                :dashcard_id (first key)
+                                                :card_id     (second key)
+                                                :result      result})
+                           (swap! partial dissoc key)))
+          "card-error" (swap! partial dissoc key)
+          nil)))
+    @results))
+
+(defn- card-results
+  "Reassemble streamed messages into per-card Dataset results."
+  [lines]
+  (assemble-card-results lines))
 
 (defn- card-errors
   "Filter batch response to just card-error messages."

--- a/test/metabase/dashboards_rest/api/card_query_batch_test.clj
+++ b/test/metabase/dashboards_rest/api/card_query_batch_test.clj
@@ -223,4 +223,41 @@
                                  (call-count))]
             (testing (format "per-card: %d DB calls, batch: %d DB calls" per-card-total batch-total)
               (is (< batch-total per-card-total)
-                  "batch endpoint should use fewer DB calls than individual card queries"))))))))
+                  "batch endpoint should use fewer DB calls than individual card queries")
+              ;; With batch-fetch and request-scoped caching, 3 cards on the same DB should stay well
+              ;; under 80 AppDB calls total. Bump this ceiling if legitimate new queries are added.
+              (is (<= batch-total 80)
+                  (format "batch call count regression: expected ≤80, got %d" batch-total)))))))))
+
+(deftest batch-query-scaling-test
+  (testing "batch endpoint's per-card marginal cost is lower than individual requests"
+    (mt/dataset test-data
+      (mt/with-temp [:model/Card          {c1 :id} {:database_id (mt/id) :dataset_query (mt/mbql-query orders {:limit 1})}
+                     :model/Card          {c2 :id} {:database_id (mt/id) :dataset_query (mt/mbql-query people {:limit 1})}
+                     :model/Card          {c3 :id} {:database_id (mt/id) :dataset_query (mt/mbql-query products {:limit 1})}
+                     :model/Card          {c4 :id} {:database_id (mt/id) :dataset_query (mt/mbql-query reviews {:limit 1})}
+                     :model/Card          {c5 :id} {:database_id (mt/id) :dataset_query (mt/mbql-query orders {:limit 2})}
+                     :model/Dashboard     {d :id}  {}
+                     :model/DashboardCard _        {:dashboard_id d :card_id c1}
+                     :model/DashboardCard _        {:dashboard_id d :card_id c2}
+                     :model/DashboardCard _        {:dashboard_id d :card_id c3}
+                     :model/DashboardCard _        {:dashboard_id d :card_id c4}
+                     :model/DashboardCard _        {:dashboard_id d :card_id c5}]
+        (binding [qp.dashboard-batch/*thread-pool* :serial]
+          (let [batch-3 (t2/with-call-count [call-count]
+                          (batch-request d {:cards (take 3 (map (fn [dc] {:dashcard_id (:id dc) :card_id (:card_id dc)})
+                                                                (t2/select [:model/DashboardCard :id :card_id]
+                                                                           :dashboard_id d
+                                                                           {:order-by [[:id :asc]]
+                                                                            :limit    3})))})
+                          (call-count))
+                batch-5 (t2/with-call-count [call-count]
+                          (batch-request d)
+                          (call-count))
+                marginal-cost (/ (- batch-5 batch-3) 2.0)]
+            (testing (format "3-card batch: %d, 5-card batch: %d, marginal: %.1f per card"
+                             batch-3 batch-5 marginal-cost)
+              ;; The marginal cost of each additional card in batch mode should be significantly
+              ;; lower than the ~55 queries/card cost of individual requests
+              (is (< marginal-cost 40)
+                  (format "marginal per-card cost too high: %.1f" marginal-cost)))))))))

--- a/test/metabase/dashboards_rest/api/card_query_batch_test.clj
+++ b/test/metabase/dashboards_rest/api/card_query_batch_test.clj
@@ -209,8 +209,11 @@
                      :model/DashboardCard {dc1 :id} {:dashboard_id d :card_id c1}
                      :model/DashboardCard {dc2 :id} {:dashboard_id d :card_id c2}
                      :model/DashboardCard {dc3 :id} {:dashboard_id d :card_id c3}]
-        ;; Run serial so all DB calls are on the calling thread and counted by t2/with-call-count
+        ;; Run serial so all DB calls are on the calling thread and counted by t2/with-call-count.
+        ;; Warm-up run to prime settings caches, metadata providers, etc. so that the measured
+        ;; runs aren't polluted by one-time cache misses (settings TTL expiry, etc.).
         (binding [qp.dashboard-batch/*thread-pool* :serial]
+          (batch-request d)
           (let [per-card-total (let [counts (atom 0)]
                                  (doseq [[dc-id card-id] [[dc1 c1] [dc2 c2] [dc3 c3]]]
                                    (t2/with-call-count [call-count]
@@ -225,8 +228,9 @@
               (is (< batch-total per-card-total)
                   "batch endpoint should use fewer DB calls than individual card queries")
               ;; With batch-fetch, request-scoped caching (permissions, routing, cache strategy),
-              ;; and pre-warmed metadata providers, 3 cards on the same DB should stay under 80
-              ;; AppDB calls. Bump this ceiling if legitimate new queries are added.
+              ;; pre-warmed metadata providers, transitive card-ID resolution, and cache-config
+              ;; warming, 3 cards on the same DB should stay under 80 AppDB calls.
+              ;; Bump this ceiling if legitimate new queries are added.
               (is (<= batch-total 80)
                   (format "batch call count regression: expected ≤80, got %d" batch-total)))))))))
 
@@ -244,7 +248,9 @@
                      :model/DashboardCard _        {:dashboard_id d :card_id c3}
                      :model/DashboardCard _        {:dashboard_id d :card_id c4}
                      :model/DashboardCard _        {:dashboard_id d :card_id c5}]
+        ;; Warm-up run to prime settings caches, metadata providers, etc.
         (binding [qp.dashboard-batch/*thread-pool* :serial]
+          (batch-request d)
           (let [batch-3 (t2/with-call-count [call-count]
                           (batch-request d {:cards (take 3 (map (fn [dc] {:dashcard_id (:id dc) :card_id (:card_id dc)})
                                                                 (t2/select [:model/DashboardCard :id :card_id]
@@ -263,3 +269,47 @@
               ;; With cache-strategy caching and deferred view-log, marginal cost is ~7/card.
               (is (< marginal-cost 15)
                   (format "marginal per-card cost too high: %.1f" marginal-cost)))))))))
+
+;;; ---------------------------------------- Unit tests for helper fns ----------------------------------------
+
+(deftest extract-source-card-ids-test
+  (let [extract-source-card-ids #'qp.dashboard-batch/extract-source-card-ids]
+    (testing "card with no source-card refs returns empty set"
+      (mt/with-temp [:model/Card {card-id :id} {:database_id   (mt/id)
+                                                :dataset_query (mt/mbql-query venues {:limit 1})}]
+        (let [card (t2/select-one :model/Card :id card-id)]
+          (is (= #{} (extract-source-card-ids [card]))))))
+
+    (testing "card based on another card returns that card's ID"
+      (mt/with-temp [:model/Card {source-id :id} {:database_id   (mt/id)
+                                                  :dataset_query (mt/mbql-query venues)}
+                     :model/Card {card-id :id}   {:database_id   (mt/id)
+                                                  :dataset_query {:database (mt/id)
+                                                                  :type     :query
+                                                                  :query    {:source-table (str "card__" source-id)}}}]
+        (let [card (t2/select-one :model/Card :id card-id)]
+          (is (contains? (extract-source-card-ids [card]) source-id)))))
+
+    (testing "card with unparseable query doesn't throw"
+      (is (= #{} (extract-source-card-ids [{:dataset_query {:garbage true}}]))))))
+
+(deftest resolve-all-transitive-card-ids-test
+  (let [resolve-all-transitive-card-ids #'qp.dashboard-batch/resolve-all-transitive-card-ids]
+    (testing "no transitive refs — returns just input card IDs"
+      (mt/with-temp [:model/Card {c1 :id :as card1} {:database_id   (mt/id)
+                                                     :dataset_query (mt/mbql-query venues {:limit 1})}]
+        (is (= #{c1} (resolve-all-transitive-card-ids {c1 card1})))))
+
+    (testing "transitive chain: card A → card B → card C"
+      (mt/with-temp [:model/Card {c-id :id}              {:database_id   (mt/id)
+                                                          :dataset_query (mt/mbql-query venues)}
+                     :model/Card {b-id :id}             {:database_id   (mt/id)
+                                                         :dataset_query {:database (mt/id)
+                                                                         :type     :query
+                                                                         :query    {:source-table (str "card__" c-id)}}}
+                     :model/Card {a-id :id :as card-a} {:database_id   (mt/id)
+                                                        :dataset_query {:database (mt/id)
+                                                                        :type     :query
+                                                                        :query    {:source-table (str "card__" b-id)}}}]
+        (let [result (resolve-all-transitive-card-ids {a-id card-a})]
+          (is (= #{a-id b-id c-id} result)))))))

--- a/test/metabase/dashboards_rest/api/card_query_batch_test.clj
+++ b/test/metabase/dashboards_rest/api/card_query_batch_test.clj
@@ -24,18 +24,18 @@
   (into []
         (comp (map str/trim)
               (remove str/blank?)
-              (map #(json/decode+kw %)))
+              (map json/decode+kw))
         (str/split-lines body)))
 
 (defn- batch-url [dashboard-id]
   (format "dashboard/%d/card-query-batch" dashboard-id))
 
-(defn- batch-request
+(defn- batch-request!
   "Make a batch card query request. Returns parsed NDJSON lines.
    Uses `with-redefs` to bypass the test client's `parse-response`, which calls `json/decode`
    on the NDJSON body and silently parses only the first line, discarding the rest."
   ([dashboard-id]
-   (batch-request dashboard-id {}))
+   (batch-request! dashboard-id {}))
   ([dashboard-id body]
    (with-redefs [test.client/parse-response identity]
      (parse-ndjson
@@ -70,22 +70,22 @@
                                                            :dataset_query (mt/mbql-query people {:limit 5})}
                      :model/Dashboard     {dash-id :id}   {}
                      :model/DashboardCard {dc-1-id :id}   {:dashboard_id dash-id :card_id card-1-id}
-                     :model/DashboardCard {dc-2-id :id}   {:dashboard_id dash-id :card_id card-2-id}]
+                     :model/DashboardCard _               {:dashboard_id dash-id :card_id card-2-id}]
         (testing "returns results for all cards"
-          (let [lines (batch-request dash-id)]
+          (let [lines (batch-request! dash-id)]
             (is (= 2 (count (card-results lines))))
             (is (= 0 (count (card-errors lines))))
             (is (= {:type "complete" :total 2 :succeeded 2 :failed 0}
                    (completion-message lines)))))
 
         (testing "with explicit cards list"
-          (let [lines (batch-request dash-id {:cards [{:dashcard_id dc-1-id :card_id card-1-id}]})]
+          (let [lines (batch-request! dash-id {:cards [{:dashcard_id dc-1-id :card_id card-1-id}]})]
             (is (= 1 (count (card-results lines))))
             (is (= {:type "complete" :total 1 :succeeded 1 :failed 0}
                    (completion-message lines)))))
 
         (testing "card results contain expected data shape"
-          (let [lines   (batch-request dash-id {:cards [{:dashcard_id dc-1-id :card_id card-1-id}]})
+          (let [lines   (batch-request! dash-id {:cards [{:dashcard_id dc-1-id :card_id card-1-id}]})
                 result  (first (card-results lines))]
             (is (= dc-1-id (:dashcard_id result)))
             (is (= card-1-id (:card_id result)))
@@ -102,7 +102,7 @@
                      :model/DashboardCard _        {:dashboard_id d :card_id c1}
                      :model/DashboardCard _        {:dashboard_id d :card_id c2}
                      :model/DashboardCard _        {:dashboard_id d :card_id c3}]
-        (let [lines (batch-request d)]
+        (let [lines (batch-request! d)]
           (is (= 3 (count (card-results lines))))
           (is (= {:type "complete" :total 3 :succeeded 3 :failed 0}
                  (completion-message lines))))))))
@@ -115,15 +115,15 @@
                      :model/Dashboard     {d :id}   {}
                      :model/DashboardCard {dc :id}  {:dashboard_id d :card_id c1}]
         (testing "wrong card_id for a valid dashcard"
-          (let [lines (batch-request d {:cards [{:dashcard_id dc :card_id c2}]})]
+          (let [lines (batch-request! d {:cards [{:dashcard_id dc :card_id c2}]})]
             (is (= 1 (count (card-errors lines))))
             (is (= 404 (get-in (first (card-errors lines)) [:error :status])))
             (is (= {:type "complete" :total 1 :succeeded 0 :failed 1}
                    (completion-message lines)))))
 
         (testing "mix of valid and invalid"
-          (let [lines (batch-request d {:cards [{:dashcard_id dc :card_id c1}
-                                                {:dashcard_id dc :card_id c2}]})]
+          (let [lines (batch-request! d {:cards [{:dashcard_id dc :card_id c1}
+                                                 {:dashcard_id dc :card_id c2}]})]
             (is (= 1 (count (card-results lines))))
             (is (= 1 (count (card-errors lines))))
             (is (= {:type "complete" :total 2 :succeeded 1 :failed 1}
@@ -148,7 +148,7 @@
                      :model/DashboardCard {dc :id} {:dashboard_id d :card_id c}]
         (mt/with-no-data-perms-for-all-users!
           (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/view-data :blocked)
-          (let [lines (batch-request d {:cards [{:dashcard_id dc :card_id c}]})]
+          (let [lines (batch-request! d {:cards [{:dashcard_id dc :card_id c}]})]
             (is (= 1 (count (card-errors lines))))
             (is (= 403 (get-in (first (card-errors lines)) [:error :status])))
             (is (= {:type "complete" :total 1 :succeeded 0 :failed 1}
@@ -170,18 +170,18 @@
                                                                        :slug "price"
                                                                        :id   "_PRICE_"
                                                                        :type "category"}]}
-                     :model/DashboardCard {dc-id :id}   {:dashboard_id       dash-id
+                     :model/DashboardCard _             {:dashboard_id       dash-id
                                                          :card_id            card-id
                                                          :parameter_mappings [{:parameter_id "_PRICE_"
                                                                                :card_id      card-id
                                                                                :target       [:dimension (mt/$ids venues $price)]}]}]
         (testing "without filter — all rows"
-          (let [lines      (batch-request dash-id)
+          (let [lines      (batch-request! dash-id)
                 row-count  (get-in (first (card-results lines)) [:result :row_count])]
             (is (= 100 row-count))))
 
         (testing "with price=4 filter — fewer rows"
-          (let [lines      (batch-request dash-id {:parameters [{:id "_PRICE_" :value 4}]})
+          (let [lines      (batch-request! dash-id {:parameters [{:id "_PRICE_" :value 4}]})
                 row-count  (get-in (first (card-results lines)) [:result :row_count])]
             (is (= 6 row-count))))))))
 
@@ -194,7 +194,7 @@
                      :model/DashboardCard _        {:dashboard_id d :card_id c1}
                      :model/DashboardCard _        {:dashboard_id d :card_id c2}]
         (binding [qp.dashboard-batch/*thread-pool* :serial]
-          (let [lines (batch-request d)]
+          (let [lines (batch-request! d)]
             (is (= 2 (count (card-results lines))))
             (is (= {:type "complete" :total 2 :succeeded 2 :failed 0}
                    (completion-message lines)))))))))
@@ -213,7 +213,7 @@
         ;; Warm-up run to prime settings caches, metadata providers, etc. so that the measured
         ;; runs aren't polluted by one-time cache misses (settings TTL expiry, etc.).
         (binding [qp.dashboard-batch/*thread-pool* :serial]
-          (batch-request d)
+          (batch-request! d)
           (let [per-card-total (let [counts (atom 0)]
                                  (doseq [[dc-id card-id] [[dc1 c1] [dc2 c2] [dc3 c3]]]
                                    (t2/with-call-count [call-count]
@@ -222,7 +222,7 @@
                                      (swap! counts + (call-count))))
                                  @counts)
                 batch-total    (t2/with-call-count [call-count]
-                                 (batch-request d)
+                                 (batch-request! d)
                                  (call-count))]
             (testing (format "per-card: %d DB calls, batch: %d DB calls" per-card-total batch-total)
               (is (< batch-total per-card-total)
@@ -250,16 +250,16 @@
                      :model/DashboardCard _        {:dashboard_id d :card_id c5}]
         ;; Warm-up run to prime settings caches, metadata providers, etc.
         (binding [qp.dashboard-batch/*thread-pool* :serial]
-          (batch-request d)
+          (batch-request! d)
           (let [batch-3 (t2/with-call-count [call-count]
-                          (batch-request d {:cards (take 3 (map (fn [dc] {:dashcard_id (:id dc) :card_id (:card_id dc)})
-                                                                (t2/select [:model/DashboardCard :id :card_id]
-                                                                           :dashboard_id d
-                                                                           {:order-by [[:id :asc]]
-                                                                            :limit    3})))})
+                          (batch-request! d {:cards (take 3 (map (fn [dc] {:dashcard_id (:id dc) :card_id (:card_id dc)})
+                                                                 (t2/select [:model/DashboardCard :id :card_id]
+                                                                            :dashboard_id d
+                                                                            {:order-by [[:id :asc]]
+                                                                             :limit    3})))})
                           (call-count))
                 batch-5 (t2/with-call-count [call-count]
-                          (batch-request d)
+                          (batch-request! d)
                           (call-count))
                 marginal-cost (/ (- batch-5 batch-3) 2.0)]
             (testing (format "3-card batch: %d, 5-card batch: %d, marginal: %.1f per card"

--- a/test/metabase/dashboards_rest/api/card_query_batch_test.clj
+++ b/test/metabase/dashboards_rest/api/card_query_batch_test.clj
@@ -2,6 +2,8 @@
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
    [metabase.permissions.models.data-permissions :as data-perms]
    [metabase.permissions.models.permissions :as perms]
    [metabase.permissions.models.permissions-group :as perms-group]
@@ -29,6 +31,17 @@
 
 (defn- batch-url [dashboard-id]
   (format "dashboard/%d/card-query-batch" dashboard-id))
+
+(defn- query-for-card
+  "Build a Lib query over `table-kw` (optionally limited) and compile to legacy MBQL for storage
+  as a Card's `:dataset_query`."
+  ([table-kw]
+   (query-for-card table-kw nil))
+  ([table-kw limit]
+   (let [mp (mt/metadata-provider)]
+     (lib/->legacy-MBQL
+      (cond-> (lib/query mp (lib.metadata/table mp (mt/id table-kw)))
+        limit (lib/limit limit))))))
 
 (defn- batch-request!
   "Make a batch card query request. Returns parsed NDJSON lines.
@@ -90,10 +103,10 @@
     (mt/dataset test-data
       (mt/with-temp [:model/Card          {card-1-id :id} {:database_id   (mt/id)
                                                            :table_id      (mt/id :orders)
-                                                           :dataset_query (mt/mbql-query orders {:limit 5})}
+                                                           :dataset_query (query-for-card :orders 5)}
                      :model/Card          {card-2-id :id} {:database_id   (mt/id)
                                                            :table_id      (mt/id :people)
-                                                           :dataset_query (mt/mbql-query people {:limit 5})}
+                                                           :dataset_query (query-for-card :people 5)}
                      :model/Dashboard     {dash-id :id}   {}
                      :model/DashboardCard {dc-1-id :id}   {:dashboard_id dash-id :card_id card-1-id}
                      :model/DashboardCard _               {:dashboard_id dash-id :card_id card-2-id}]
@@ -121,9 +134,9 @@
 (deftest batch-query-omit-cards-runs-all-test
   (testing "omitting cards param runs all non-virtual dashcards"
     (mt/dataset test-data
-      (mt/with-temp [:model/Card          {c1 :id} {:database_id (mt/id) :dataset_query (mt/mbql-query orders {:limit 1})}
-                     :model/Card          {c2 :id} {:database_id (mt/id) :dataset_query (mt/mbql-query people {:limit 1})}
-                     :model/Card          {c3 :id} {:database_id (mt/id) :dataset_query (mt/mbql-query products {:limit 1})}
+      (mt/with-temp [:model/Card          {c1 :id} {:database_id (mt/id) :dataset_query (query-for-card :orders 1)}
+                     :model/Card          {c2 :id} {:database_id (mt/id) :dataset_query (query-for-card :people 1)}
+                     :model/Card          {c3 :id} {:database_id (mt/id) :dataset_query (query-for-card :products 1)}
                      :model/Dashboard     {d :id}  {}
                      :model/DashboardCard _        {:dashboard_id d :card_id c1}
                      :model/DashboardCard _        {:dashboard_id d :card_id c2}
@@ -136,8 +149,8 @@
 (deftest batch-query-invalid-card-test
   (testing "card not in dashboard returns card-error"
     (mt/dataset test-data
-      (mt/with-temp [:model/Card          {c1 :id}  {:database_id (mt/id) :dataset_query (mt/mbql-query orders {:limit 1})}
-                     :model/Card          {c2 :id}  {:database_id (mt/id) :dataset_query (mt/mbql-query people {:limit 1})}
+      (mt/with-temp [:model/Card          {c1 :id}  {:database_id (mt/id) :dataset_query (query-for-card :orders 1)}
+                     :model/Card          {c2 :id}  {:database_id (mt/id) :dataset_query (query-for-card :people 1)}
                      :model/Dashboard     {d :id}   {}
                      :model/DashboardCard {dc :id}  {:dashboard_id d :card_id c1}]
         (testing "wrong card_id for a valid dashcard"
@@ -162,7 +175,7 @@
   (testing "dashboard read permission required"
     (mt/dataset test-data
       (mt/with-temp [:model/Collection    {coll-id :id} {}
-                     :model/Card          {c :id}  {:database_id (mt/id) :dataset_query (mt/mbql-query orders {:limit 1})}
+                     :model/Card          {c :id}  {:database_id (mt/id) :dataset_query (query-for-card :orders 1)}
                      :model/Dashboard     {d :id}  {:collection_id coll-id}
                      :model/DashboardCard _        {:dashboard_id d :card_id c}]
         (perms/revoke-collection-permissions! (perms-group/all-users) coll-id)
@@ -172,7 +185,7 @@
 
   (testing "blocked view-data permission results in card-error per card"
     (mt/dataset test-data
-      (mt/with-temp [:model/Card          {c :id}  {:database_id (mt/id) :dataset_query (mt/mbql-query orders {:limit 1})}
+      (mt/with-temp [:model/Card          {c :id}  {:database_id (mt/id) :dataset_query (query-for-card :orders 1)}
                      :model/Dashboard     {d :id}  {}
                      :model/DashboardCard {dc :id} {:dashboard_id d :card_id c}]
         (mt/with-no-data-perms-for-all-users!
@@ -214,7 +227,7 @@
     (mt/dataset test-data
       (mt/with-temp [:model/Card          {card-id :id}
                      {:database_id   (mt/id)
-                      :dataset_query (mt/mbql-query venues)}
+                      :dataset_query (query-for-card :venues)}
                      :model/Dashboard     {dash-id :id}
                      {:parameters [{:id        "abc123"
                                     :name      "ID"
@@ -245,7 +258,7 @@
     (mt/dataset test-data
       (mt/with-temp [:model/Card          {card-id :id} {:database_id   (mt/id)
                                                          :table_id      (mt/id :venues)
-                                                         :dataset_query (mt/mbql-query venues)}
+                                                         :dataset_query (query-for-card :venues)}
                      :model/Dashboard     {dash-id :id} {:parameters [{:name "Price"
                                                                        :slug "price"
                                                                        :id   "_PRICE_"
@@ -268,8 +281,8 @@
 (deftest batch-query-serial-thread-pool-test
   (testing "batch queries work with :serial thread pool (single-threaded)"
     (mt/dataset test-data
-      (mt/with-temp [:model/Card          {c1 :id} {:database_id (mt/id) :dataset_query (mt/mbql-query orders {:limit 1})}
-                     :model/Card          {c2 :id} {:database_id (mt/id) :dataset_query (mt/mbql-query people {:limit 1})}
+      (mt/with-temp [:model/Card          {c1 :id} {:database_id (mt/id) :dataset_query (query-for-card :orders 1)}
+                     :model/Card          {c2 :id} {:database_id (mt/id) :dataset_query (query-for-card :people 1)}
                      :model/Dashboard     {d :id}  {}
                      :model/DashboardCard _        {:dashboard_id d :card_id c1}
                      :model/DashboardCard _        {:dashboard_id d :card_id c2}]
@@ -282,9 +295,9 @@
 (deftest batch-query-reduces-db-calls-test
   (testing "batch endpoint uses fewer appdb calls than N individual requests"
     (mt/dataset test-data
-      (mt/with-temp [:model/Card          {c1 :id} {:database_id (mt/id) :dataset_query (mt/mbql-query orders {:limit 1})}
-                     :model/Card          {c2 :id} {:database_id (mt/id) :dataset_query (mt/mbql-query people {:limit 1})}
-                     :model/Card          {c3 :id} {:database_id (mt/id) :dataset_query (mt/mbql-query products {:limit 1})}
+      (mt/with-temp [:model/Card          {c1 :id} {:database_id (mt/id) :dataset_query (query-for-card :orders 1)}
+                     :model/Card          {c2 :id} {:database_id (mt/id) :dataset_query (query-for-card :people 1)}
+                     :model/Card          {c3 :id} {:database_id (mt/id) :dataset_query (query-for-card :products 1)}
                      :model/Dashboard     {d :id}  {}
                      :model/DashboardCard {dc1 :id} {:dashboard_id d :card_id c1}
                      :model/DashboardCard {dc2 :id} {:dashboard_id d :card_id c2}
@@ -316,11 +329,11 @@
 (deftest batch-query-scaling-test
   (testing "batch endpoint's per-card marginal cost is lower than individual requests"
     (mt/dataset test-data
-      (mt/with-temp [:model/Card          {c1 :id} {:database_id (mt/id) :dataset_query (mt/mbql-query orders {:limit 1})}
-                     :model/Card          {c2 :id} {:database_id (mt/id) :dataset_query (mt/mbql-query people {:limit 1})}
-                     :model/Card          {c3 :id} {:database_id (mt/id) :dataset_query (mt/mbql-query products {:limit 1})}
-                     :model/Card          {c4 :id} {:database_id (mt/id) :dataset_query (mt/mbql-query reviews {:limit 1})}
-                     :model/Card          {c5 :id} {:database_id (mt/id) :dataset_query (mt/mbql-query orders {:limit 2})}
+      (mt/with-temp [:model/Card          {c1 :id} {:database_id (mt/id) :dataset_query (query-for-card :orders 1)}
+                     :model/Card          {c2 :id} {:database_id (mt/id) :dataset_query (query-for-card :people 1)}
+                     :model/Card          {c3 :id} {:database_id (mt/id) :dataset_query (query-for-card :products 1)}
+                     :model/Card          {c4 :id} {:database_id (mt/id) :dataset_query (query-for-card :reviews 1)}
+                     :model/Card          {c5 :id} {:database_id (mt/id) :dataset_query (query-for-card :orders 2)}
                      :model/Dashboard     {d :id}  {}
                      :model/DashboardCard _        {:dashboard_id d :card_id c1}
                      :model/DashboardCard _        {:dashboard_id d :card_id c2}
@@ -354,13 +367,13 @@
   (let [extract-source-card-ids #'qp.dashboard-batch/extract-source-card-ids]
     (testing "card with no source-card refs returns empty set"
       (mt/with-temp [:model/Card {card-id :id} {:database_id   (mt/id)
-                                                :dataset_query (mt/mbql-query venues {:limit 1})}]
+                                                :dataset_query (query-for-card :venues 1)}]
         (let [card (t2/select-one :model/Card :id card-id)]
           (is (= #{} (extract-source-card-ids [card]))))))
 
     (testing "card based on another card returns that card's ID"
       (mt/with-temp [:model/Card {source-id :id} {:database_id   (mt/id)
-                                                  :dataset_query (mt/mbql-query venues)}
+                                                  :dataset_query (query-for-card :venues)}
                      :model/Card {card-id :id}   {:database_id   (mt/id)
                                                   :dataset_query {:database (mt/id)
                                                                   :type     :query
@@ -375,12 +388,12 @@
   (let [resolve-all-transitive-card-ids #'qp.dashboard-batch/resolve-all-transitive-card-ids]
     (testing "no transitive refs — returns just input card IDs"
       (mt/with-temp [:model/Card {c1 :id :as card1} {:database_id   (mt/id)
-                                                     :dataset_query (mt/mbql-query venues {:limit 1})}]
+                                                     :dataset_query (query-for-card :venues 1)}]
         (is (= #{c1} (resolve-all-transitive-card-ids {c1 card1})))))
 
     (testing "transitive chain: card A → card B → card C"
       (mt/with-temp [:model/Card {c-id :id}              {:database_id   (mt/id)
-                                                          :dataset_query (mt/mbql-query venues)}
+                                                          :dataset_query (query-for-card :venues)}
                      :model/Card {b-id :id}             {:database_id   (mt/id)
                                                          :dataset_query {:database (mt/id)
                                                                          :type     :query

--- a/test/metabase/dashboards_rest/api/card_query_batch_test.clj
+++ b/test/metabase/dashboards_rest/api/card_query_batch_test.clj
@@ -141,9 +141,12 @@
                      :model/Dashboard     {d :id}   {}
                      :model/DashboardCard {dc :id}  {:dashboard_id d :card_id c1}]
         (testing "wrong card_id for a valid dashcard"
-          (let [lines (batch-request! d {:cards [{:dashcard_id dc :card_id c2}]})]
+          (let [lines (batch-request! d {:cards [{:dashcard_id dc :card_id c2}]})
+                err   (first (card-errors lines))]
             (is (= 1 (count (card-errors lines))))
-            (is (= 404 (get-in (first (card-errors lines)) [:error :status])))
+            (is (= "failed" (:status err)))
+            (is (= "Card not found in dashboard" (:error err)))
+            (is (= {:cols [] :rows []} (:data err)))
             (is (= {:type "complete" :total 1 :succeeded 0 :failed 1}
                    (completion-message lines)))))
 
@@ -174,9 +177,12 @@
                      :model/DashboardCard {dc :id} {:dashboard_id d :card_id c}]
         (mt/with-no-data-perms-for-all-users!
           (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/view-data :blocked)
-          (let [lines (batch-request! d {:cards [{:dashcard_id dc :card_id c}]})]
+          (let [lines (batch-request! d {:cards [{:dashcard_id dc :card_id c}]})
+                err   (first (card-errors lines))]
             (is (= 1 (count (card-errors lines))))
-            (is (= 403 (get-in (first (card-errors lines)) [:error :status])))
+            (is (= "failed" (:status err)))
+            (is (= "missing-required-permissions" (:error_type err)))
+            (is (= "You don't have permission to view this card" (:error err)))
             (is (= {:type "complete" :total 1 :succeeded 0 :failed 1}
                    (completion-message lines)))))))))
 
@@ -185,6 +191,54 @@
     (is (= "Not found."
            (mt/user-http-request :rasta :post 404 (batch-url Integer/MAX_VALUE)
                                  {:parameters []})))))
+
+(deftest batch-query-failed-emits-failed-dataset-shape-test
+  (testing "QP-level failure emits a failed-Dataset envelope: status=failed, error string, empty data"
+    (mt/dataset test-data
+      (mt/with-temp [:model/Card          {card-id :id} {:database_id   (mt/id)
+                                                         :dataset_query {:database (mt/id)
+                                                                         :type     :native
+                                                                         :native   {:query "SELECT * FROM does_not_exist_xyz"}}}
+                     :model/Dashboard     {dash-id :id} {}
+                     :model/DashboardCard {dc-id :id}   {:dashboard_id dash-id :card_id card-id}]
+        (let [lines (batch-request! dash-id {:cards [{:dashcard_id dc-id :card_id card-id}]})
+              err   (first (card-errors lines))]
+          (is (= 1 (count (card-errors lines))))
+          (is (= "failed" (:status err)))
+          (is (string? (:error err)))
+          (is (= {:cols [] :rows []} (:data err))))))))
+
+(deftest batch-query-failed-includes-json-query-with-parameters-test
+  (testing "QP failures forward :json_query with the failing :parameters so the dashcardData cache
+           can detect when a user fixes a broken parameter mapping (#32573)"
+    (mt/dataset test-data
+      (mt/with-temp [:model/Card          {card-id :id}
+                     {:database_id   (mt/id)
+                      :dataset_query (mt/mbql-query venues)}
+                     :model/Dashboard     {dash-id :id}
+                     {:parameters [{:id        "abc123"
+                                    :name      "ID"
+                                    :slug      "id"
+                                    :type      :id
+                                    :sectionId "id"}]}
+                     :model/DashboardCard {dc-id :id}
+                     {:dashboard_id       dash-id
+                      :card_id            card-id
+                      :parameter_mappings [{:card_id      card-id
+                                            :parameter_id "abc123"
+                                            :target       [:dimension [:field "DOES_NOT_EXIST" {:base-type :type/Integer}]]}]}]
+        (let [lines  (batch-request! dash-id
+                                     {:cards      [{:dashcard_id dc-id :card_id card-id}]
+                                      :parameters [{:id "abc123" :type "id" :value [42]}]})
+              err    (first (card-errors lines))
+              params (get-in err [:json_query :parameters])]
+          (is (= 1 (count (card-errors lines))))
+          (is (= "failed" (:status err)))
+          (is (some? (:json_query err))
+              "json_query is required so the FE params comparison can tell when the user fixes a broken mapping")
+          (is (= [{:type "id" :id "abc123" :value [42]
+                   :target ["dimension" ["field" "DOES_NOT_EXIST" {:base-type "type/Integer"}]]}]
+                 params)))))))
 
 (deftest batch-query-with-parameters-test
   (testing "parameters are applied to card queries"

--- a/test/metabase/embedding_rest/api/preview_embed_test.clj
+++ b/test/metabase/embedding_rest/api/preview_embed_test.clj
@@ -4,12 +4,14 @@
                                                             metabase.test.data/run-mbql-query {:namespaces [metabase.embedding-rest.api.preview-embed-test]}}}}}}
   (:require
    [buddy.sign.jwt :as jwt]
+   [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.dashboards-rest.api-test :as api.dashboard-test]
    [metabase.embedding-rest.api.embed-test :as embed-test]
    [metabase.embedding-rest.api.preview-embed :as api.preview-embed]
    [metabase.query-processor.pivot.test-util :as api.pivots]
    [metabase.test :as mt]
+   [metabase.test.http-client :as test.client]
    [metabase.tiles.api-test :as tiles.api-test]
    [metabase.util :as u]
    [metabase.util.json :as json]
@@ -739,3 +741,44 @@
                                                  card-id)
                      :latField (tiles.api-test/encoded-lat-field-ref)
                      :lonField (tiles.api-test/encoded-lon-field-ref)))))))))
+
+;;; --------------------- GET /api/preview_embed/dashboard/:token/card-query-batch ----------------------
+
+(defn- batch-url [dashboard-id & [additional-token-params]]
+  (str "preview_embed/dashboard/"
+       (embed-test/dash-token dashboard-id (merge {:_embedding_params {}}
+                                                  additional-token-params))
+       "/card-query-batch"))
+
+(defn- parse-ndjson [^String body]
+  (into []
+        (comp (map str/trim)
+              (remove str/blank?)
+              (map json/decode+kw))
+        (str/split-lines body)))
+
+(deftest batch-card-query-test
+  (testing "GET /api/preview_embed/dashboard/:token/card-query-batch"
+    (embed-test/with-embedding-enabled-and-new-secret-key!
+      (embed-test/with-temp-dashcard [dashcard]
+        (testing "admin can run a batch query through the preview endpoint"
+          ;; bypass parse-response so NDJSON isn't collapsed to the first line
+          (with-redefs [test.client/parse-response identity]
+            (let [lines (parse-ndjson
+                         (mt/user-http-request :crowberto :get 202
+                                               (batch-url (:dashboard_id dashcard))))]
+              (is (some #(= "card-end" (:type %)) lines))
+              (is (some #(and (= "complete" (:type %))
+                              (pos? (:total %))
+                              (zero? (:failed %))) lines)))))
+
+        (testing "non-admin is rejected"
+          (is (= "You don't have permissions to do that."
+                 (mt/user-http-request :rasta :get 403
+                                       (batch-url (:dashboard_id dashcard))))))
+
+        (testing "fails when embedding is disabled"
+          (is (= "Embedding is not enabled."
+                 (mt/with-temporary-setting-values [enable-embedding-static false]
+                   (mt/user-http-request :crowberto :get 400
+                                         (batch-url (:dashboard_id dashcard)))))))))))

--- a/test/metabase/queries/models/query_test.clj
+++ b/test/metabase/queries/models/query_test.clj
@@ -6,7 +6,8 @@
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
    [metabase.queries.models.query :as query]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [toucan2.core :as t2]))
 
 (deftest ^:parallel query->database-and-table-ids-test
   (mt/with-temp [:model/Card card {:dataset_query {:database (mt/id)
@@ -61,3 +62,82 @@
               query-with-source-card))
       (is (= {:database-id (meta/id), :table-id (meta/id :venues)}
              (query/query->database-and-table-ids query-with-source-card))))))
+
+;;; ---------------------------------------- Rolling Average Math ----------------------------------------
+
+(deftest ^:parallel combined-rolling-average-params-test
+  (let [combined-rolling-average-params #'query/combined-rolling-average-params]
+    (testing "single time"
+      (let [{:keys [decay weighted-sum]} (combined-rolling-average-params [100])]
+        (is (== 0.9 decay))
+        (is (== 10.0 weighted-sum))
+        (testing "applied to an existing avg of 200 gives 0.9*200 + 10 = 190"
+          (is (== 190.0 (+ (* decay 200) weighted-sum))))))
+    (testing "two times — equivalent to sequential application"
+      (let [{:keys [decay weighted-sum]} (combined-rolling-average-params [100 200])]
+        ;; Sequential: start=200, after t=100 → 0.9*200+0.1*100=190, after t=200 → 0.9*190+0.1*200=191
+        ;; Batch: 0.81*200 + 29 = 191
+        (is (== 0.81 decay))
+        (is (== 29.0 weighted-sum))
+        (is (== 191.0 (+ (* decay 200) weighted-sum)))))
+    (testing "three times — equivalent to three sequential applications"
+      (let [{:keys [decay weighted-sum]} (combined-rolling-average-params [100 100 100])]
+        ;; Sequential from avg=1000: 910 → 829 → 756.1
+        ;; Batch: 0.729*1000 + 27.1 = 756.1
+        (is (< (Math/abs (- 0.729 decay)) 1e-9))
+        (is (< (Math/abs (- 27.1 weighted-sum)) 1e-9))
+        (is (< (Math/abs (- 756.1 (+ (* decay 1000) weighted-sum))) 1e-9))))))
+
+;;; ---------------------------------------- Batch Avg Execution Time ----------------------------------------
+
+(defn- make-query-hash
+  "Create a deterministic byte-array hash for testing."
+  [n]
+  (byte-array (map #(bit-and (+ n %) 0xFF) (range 32))))
+
+(deftest batch-save-query-and-update-average-execution-time-test
+  (let [hash-a (make-query-hash 1)
+        hash-b (make-query-hash 2)
+        query-a {:database 1, :type :native, :native {:query "SELECT 1"}}
+        query-b {:database 1, :type :native, :native {:query "SELECT 2"}}]
+    ;; Clean up any pre-existing rows for our test hashes
+    (t2/delete! :model/Query :query_hash [:in [hash-a hash-b]])
+    (try
+      (testing "insert path — new hashes get inserted with correct avg"
+        (query/batch-save-query-and-update-average-execution-time!
+         [{:query query-a :query-hash hash-a :running-time 100}
+          {:query query-b :query-hash hash-b :running-time 200}])
+        (is (= 100 (query/average-execution-time-ms hash-a)))
+        (is (= 200 (query/average-execution-time-ms hash-b))))
+      (testing "update path — existing hashes get rolling average applied"
+        (query/batch-save-query-and-update-average-execution-time!
+         [{:query query-a :query-hash hash-a :running-time 200}])
+        ;; 0.9*100 + 0.1*200 = 110
+        (is (= 110 (query/average-execution-time-ms hash-a)))
+        (testing "other hash unchanged"
+          (is (= 200 (query/average-execution-time-ms hash-b)))))
+      (testing "mixed path — some new, some existing in one batch"
+        (let [hash-c (make-query-hash 3)
+              query-c {:database 1, :type :native, :native {:query "SELECT 3"}}]
+          (t2/delete! :model/Query :query_hash hash-c)
+          (try
+            (query/batch-save-query-and-update-average-execution-time!
+             [{:query query-a :query-hash hash-a :running-time 300}
+              {:query query-c :query-hash hash-c :running-time 500}])
+            ;; hash-a: 0.9*110 + 0.1*300 = 129
+            (is (= 129 (query/average-execution-time-ms hash-a)))
+            ;; hash-c: new, so just 500
+            (is (= 500 (query/average-execution-time-ms hash-c)))
+            (finally
+              (t2/delete! :model/Query :query_hash hash-c)))))
+      (testing "duplicate hashes in single batch — combined correctly"
+        ;; Reset hash-a to a known value
+        (t2/update! :model/Query {:query_hash hash-a} {:average_execution_time 1000})
+        (query/batch-save-query-and-update-average-execution-time!
+         [{:query query-a :query-hash hash-a :running-time 100}
+          {:query query-a :query-hash hash-a :running-time 100}])
+        ;; Sequential: 0.9*1000+0.1*100=910, then 0.9*910+0.1*100=829
+        ;; Batch combined: 0.81*1000 + 0.1*(0.9*100 + 100) = 810+19 = 829
+        (is (= 829 (query/average-execution-time-ms hash-a))))
+      (finally
+        (t2/delete! :model/Query :query_hash [:in [hash-a hash-b]])))))

--- a/test/metabase/queries/models/query_test.clj
+++ b/test/metabase/queries/models/query_test.clj
@@ -9,6 +9,8 @@
    [metabase.test :as mt]
    [toucan2.core :as t2]))
 
+(set! *warn-on-reflection* true)
+
 (deftest ^:parallel query->database-and-table-ids-test
   (mt/with-temp [:model/Card card {:dataset_query {:database (mt/id)
                                                    :type     :query

--- a/test/metabase/query_processor/api_test.clj
+++ b/test/metabase/query_processor/api_test.clj
@@ -64,91 +64,85 @@
        [k v]))))
 
 (defn- most-recent-query-execution-for-query [query]
-  ;; it might take a fraction of a second for the QueryExecution to show up, it's saved asynchronously. So wait a bit
-  ;; and retry if it's not there yet.
-  (letfn [(thunk []
-            (t2/select-one :model/QueryExecution
-                           :hash (qp.util/query-hash query)
-                           {:order-by [[:started_at :desc]]}))]
-    (loop [retries 3]
-      (or (thunk)
-          (when (pos? retries)
-            (Thread/sleep 100)
-            (recur (dec retries)))))))
+  (t2/select-one :model/QueryExecution
+                 :hash (qp.util/query-hash query)
+                 {:order-by [[:started_at :desc]]}))
 
 (def ^:private query-defaults
   {:middleware {:add-default-userland-constraints? true
                 :js-int-to-string? true}})
 
 (deftest basic-query-test
-  (testing "POST /api/dataset"
-    (testing "\nJust a basic sanity check to make sure Query Processor endpoint is still working correctly."
-      (let [query (mt/mbql-query checkins
-                    {:aggregation [[:count]]})
-            result (mt/user-http-request :crowberto :post 202 "dataset" query)]
-        (testing "\nAPI Response"
-          (is (=?
-               {:data                   {:rows             [[1000]]
-                                         :cols             [(mt/obj->json->obj (qp.test-util/aggregate-col :count))]
-                                         :native_form      true
-                                         :results_timezone "UTC"}
-                :row_count              1
-                :status                 "completed"
-                :context                "ad-hoc"
-                :json_query             (-> (mt/mbql-query checkins
-                                              {:aggregation [[:count]]})
-                                            (assoc-in [:query :aggregation] [["count"]])
-                                            (assoc :type "query")
-                                            (merge query-defaults))
-                :started_at             true
-                :running_time           true
-                :average_execution_time nil
-                :database_id            (mt/id)}
-               (format-response result))))
-        (testing "\nSaved QueryExecution"
-          (is (= {:hash             true
-                  :row_count        1
-                  :result_rows      1
-                  :context          :ad-hoc
-                  :executor_id      (mt/user->id :crowberto)
-                  :native           false
-                  :pulse_id         nil
-                  :card_id          nil
-                  :is_sandboxed     false
-                  :dashboard_id     nil
-                  :transform_id     nil
-                  :lens_id          nil
-                  :lens_params      nil
-                  :error            nil
-                  :id               true
-                  :action_id        nil
-                  :cache_hit        false
-                  :cache_hash       false
-                  :parameterized    false
-                  :database_id      (mt/id)
-                  :started_at       true
-                  :running_time     true
-                  :embedding_client nil
-                  :embedding_hostname nil
-                  :embedding_path nil
-                  :embedding_route nil
-                  :embedding_sdk_version nil
-                  :metabase_version true
-                  :auth_method      true
-                  :ip_address       nil
-                  :is_db_routed     false
-                  :is_impersonated  false
-                  :parameters       nil
-                  :tenant_id        nil
-                  :user_agent       nil
-                  :sanitized_user_agent nil}
-                 (format-response (most-recent-query-execution-for-query query)))))))))
+  (mt/with-temporary-setting-values [synchronous-batch-updates true]
+    (testing "POST /api/dataset"
+      (testing "\nJust a basic sanity check to make sure Query Processor endpoint is still working correctly."
+        (let [query  (mt/mbql-query checkins
+                       {:aggregation [[:count]]})
+              result (mt/user-http-request :crowberto :post 202 "dataset" query)]
+          (testing "\nAPI Response"
+            (is (=?
+                 {:data                   {:rows             [[1000]]
+                                           :cols             [(mt/obj->json->obj (qp.test-util/aggregate-col :count))]
+                                           :native_form      true
+                                           :results_timezone "UTC"}
+                  :row_count              1
+                  :status                 "completed"
+                  :context                "ad-hoc"
+                  :json_query             (-> (mt/mbql-query checkins
+                                                {:aggregation [[:count]]})
+                                              (assoc-in [:query :aggregation] [["count"]])
+                                              (assoc :type "query")
+                                              (merge query-defaults))
+                  :started_at             true
+                  :running_time           true
+                  :average_execution_time nil
+                  :database_id            (mt/id)}
+                 (format-response result))))
+          (testing "\nSaved QueryExecution"
+            (is (= {:hash                  true
+                    :row_count             1
+                    :result_rows           1
+                    :context               :ad-hoc
+                    :executor_id           (mt/user->id :crowberto)
+                    :native                false
+                    :pulse_id              nil
+                    :card_id               nil
+                    :is_sandboxed          false
+                    :dashboard_id          nil
+                    :transform_id          nil
+                    :lens_id               nil
+                    :lens_params           nil
+                    :error                 nil
+                    :id                    true
+                    :action_id             nil
+                    :cache_hit             false
+                    :cache_hash            false
+                    :parameterized         false
+                    :database_id           (mt/id)
+                    :started_at            true
+                    :running_time          true
+                    :embedding_client      nil
+                    :embedding_hostname    nil
+                    :embedding_path        nil
+                    :embedding_route       nil
+                    :embedding_sdk_version nil
+                    :metabase_version      true
+                    :auth_method           true
+                    :ip_address            nil
+                    :is_db_routed          false
+                    :is_impersonated       false
+                    :parameters            nil
+                    :tenant_id             nil
+                    :user_agent            nil
+                    :sanitized_user_agent  nil}
+                   (format-response (most-recent-query-execution-for-query query))))))))))
 
 (deftest failure-test
   ;; clear out recent query executions!
   (t2/delete! :model/QueryExecution)
-  (testing "POST /api/dataset"
-    (testing "\nA failed query should return a 400 response from the API"
+  (mt/with-temporary-setting-values [synchronous-batch-updates true]
+    (testing "POST /api/dataset"
+      (testing "\nA failed query should return a 400 response from the API")
       ;; Error message's format can differ a bit depending on DB version and the comment we prepend to it, so check
       ;; that it exists and contains the substring "Syntax error in SQL statement"
       (let [query  {:database (mt/id)

--- a/test/metabase/query_processor/middleware/cache_test.clj
+++ b/test/metabase/query_processor/middleware/cache_test.clj
@@ -417,34 +417,35 @@
 
 (deftest e2e-test-2
   (testing "Cached results don't impact average execution time"
-    (let [save-execution-metadata-count    (atom 0)
-          called-promise                   (promise)
-          save-execution-metadata-original (mt/original-fn #'process-userland-query/save-execution-metadata!)]
-      ;; save-execution-metadata! is invoked from the QP pipeline on worker threads that don't
-      ;; inherit *local-redefs* — use with-redefs.
-      #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
-      (with-redefs [process-userland-query/save-execution-metadata! (fn [& args]
-                                                                      (swap! save-execution-metadata-count inc)
-                                                                      (apply save-execution-metadata-original args)
-                                                                      (deliver called-promise true))]
-        (let [query  (assoc (mt/mbql-query venues {:order-by [[:asc $id]] :limit 42})
-                            :cache-strategy (assoc (ttl-strategy) :multiplier 5000))
-              q-hash (qp.util/query-hash query)]
-          (with-mock-cache! [save-chan]
-            (t2/delete! :model/Query :query_hash q-hash)
-            (is (not (:cached (qp/process-query (qp/userland-query query)))))
-            (a/alts!! [save-chan (a/timeout 200)]) ;; wait-for-result closes the channel
-            (u/deref-with-timeout called-promise 500)
-            (is (= 1 @save-execution-metadata-count))
-            (let [avg-execution-time (query/average-execution-time-ms q-hash)]
-              (is (pos? avg-execution-time))
-              ;; rerun query getting cached results
-              (is (=? {:cached ZonedDateTime}
-                      (qp/process-query (qp/userland-query query))))
-              (mt/wait-for-result save-chan)
-              (is (= 2 @save-execution-metadata-count)
-                  "Saving execution times of a cache lookup")
-              (is (= avg-execution-time (query/average-execution-time-ms q-hash))))))))))
+    (mt/with-temporary-setting-values [synchronous-batch-updates true]
+      (let [save-execution-metadata-count    (atom 0)
+            called-promise                   (promise)
+            save-execution-metadata-original (mt/original-fn #'process-userland-query/save-execution-metadata!)]
+        ;; save-execution-metadata! is invoked from the QP pipeline on worker threads that don't
+        ;; inherit *local-redefs* — use with-redefs.
+        #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
+        (with-redefs [process-userland-query/save-execution-metadata! (fn [& args]
+                                                                        (swap! save-execution-metadata-count inc)
+                                                                        (apply save-execution-metadata-original args)
+                                                                        (deliver called-promise true))]
+          (let [query  (assoc (mt/mbql-query venues {:order-by [[:asc $id]] :limit 42})
+                              :cache-strategy (assoc (ttl-strategy) :multiplier 5000))
+                q-hash (qp.util/query-hash query)]
+            (with-mock-cache! [save-chan]
+              (t2/delete! :model/Query :query_hash q-hash)
+              (is (not (:cached (qp/process-query (qp/userland-query query)))))
+              (a/alts!! [save-chan (a/timeout 200)]) ;; wait-for-result closes the channel
+              (u/deref-with-timeout called-promise 500)
+              (is (= 1 @save-execution-metadata-count))
+              (let [avg-execution-time (query/average-execution-time-ms q-hash)]
+                (is (pos? avg-execution-time))
+                ;; rerun query getting cached results
+                (is (=? {:cached ZonedDateTime}
+                        (qp/process-query (qp/userland-query query))))
+                (mt/wait-for-result save-chan)
+                (is (= 2 @save-execution-metadata-count)
+                    "Saving execution times of a cache lookup")
+                (is (= avg-execution-time (query/average-execution-time-ms q-hash)))))))))))
 
 (def ^:private expected-inner-metadata
   (for [name ["ID"

--- a/test/metabase/query_processor/middleware/cache_test.clj
+++ b/test/metabase/query_processor/middleware/cache_test.clj
@@ -417,21 +417,16 @@
 
 (deftest e2e-test-2
   (testing "Cached results don't impact average execution time"
-    (let [save-execution-metadata-count       (atom 0)
-          update-avg-execution-count          (atom 0)
-          called-promise                      (promise)
-          save-execution-metadata-original    (mt/original-fn #'process-userland-query/save-execution-metadata!*)
-          save-query-update-avg-time-original (mt/original-fn #'query/save-query-and-update-average-execution-time!)]
-      ;; save-execution-metadata!* and save-query-and-update-average-execution-time! are invoked from
-      ;; the QP pipeline on worker threads that don't inherit *local-redefs* — use with-redefs.
+    (let [save-execution-metadata-count    (atom 0)
+          called-promise                   (promise)
+          save-execution-metadata-original (mt/original-fn #'process-userland-query/save-execution-metadata!)]
+      ;; save-execution-metadata! is invoked from the QP pipeline on worker threads that don't
+      ;; inherit *local-redefs* — use with-redefs.
       #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
-      (with-redefs [process-userland-query/save-execution-metadata!*     (fn [& args]
-                                                                           (swap! save-execution-metadata-count inc)
-                                                                           (apply save-execution-metadata-original args)
-                                                                           (deliver called-promise true))
-                    query/save-query-and-update-average-execution-time! (fn [& args]
-                                                                          (swap! update-avg-execution-count inc)
-                                                                          (apply save-query-update-avg-time-original args))]
+      (with-redefs [process-userland-query/save-execution-metadata! (fn [& args]
+                                                                      (swap! save-execution-metadata-count inc)
+                                                                      (apply save-execution-metadata-original args)
+                                                                      (deliver called-promise true))]
         (let [query  (assoc (mt/mbql-query venues {:order-by [[:asc $id]] :limit 42})
                             :cache-strategy (assoc (ttl-strategy) :multiplier 5000))
               q-hash (qp.util/query-hash query)]
@@ -441,7 +436,6 @@
             (a/alts!! [save-chan (a/timeout 200)]) ;; wait-for-result closes the channel
             (u/deref-with-timeout called-promise 500)
             (is (= 1 @save-execution-metadata-count))
-            (is (= 1 @update-avg-execution-count))
             (let [avg-execution-time (query/average-execution-time-ms q-hash)]
               (is (pos? avg-execution-time))
               ;; rerun query getting cached results
@@ -450,8 +444,6 @@
               (mt/wait-for-result save-chan)
               (is (= 2 @save-execution-metadata-count)
                   "Saving execution times of a cache lookup")
-              (is (= 1 @update-avg-execution-count)
-                  "Cached query execution should not update average query duration")
               (is (= avg-execution-time (query/average-execution-time-ms q-hash))))))))))
 
 (def ^:private expected-inner-metadata

--- a/test/metabase/query_processor/middleware/process_userland_query_test.clj
+++ b/test/metabase/query_processor/middleware/process_userland_query_test.clj
@@ -26,10 +26,10 @@
   (mt/with-clock #t "2020-02-04T12:22-08:00[US/Pacific]"
     (let [original-hash (qp.util/query-hash query)
           result        (promise)]
-      ;; save-execution-metadata!* is invoked from the QP pipeline transducer, which runs on a thread
+      ;; save-execution-metadata! is invoked from the QP pipeline transducer, which runs on a thread
       ;; that doesn't inherit *local-redefs* — use with-redefs so worker threads see the replacement.
       #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
-      (with-redefs [process-userland-query/save-execution-metadata!*
+      (with-redefs [process-userland-query/save-execution-metadata!
                     (fn [query-execution]
                       (when-let [^bytes qe-hash (:hash query-execution)]
                         (deliver

--- a/test/metabase/query_processor/middleware/process_userland_query_test.clj
+++ b/test/metabase/query_processor/middleware/process_userland_query_test.clj
@@ -18,7 +18,8 @@
    [metabase.query-processor.test :as qp]
    [metabase.query-processor.util :as qp.util]
    [metabase.test :as mt]
-   [methodical.core :as methodical]))
+   [methodical.core :as methodical]
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -248,3 +249,24 @@
                        :data
                        (contains? :preprocessed_query)
                        not)))))))
+
+(deftest grouper-queue-integration-test
+  (testing "save-execution-metadata! writes QueryExecution and avg execution time via grouper queues"
+    (mt/with-temporary-setting-values [synchronous-batch-updates true]
+      (let [query  (assoc (mt/mbql-query venues {:limit 1})
+                          :info {:executed-by  (mt/user->id :rasta)
+                                 :context      :question
+                                 :query-hash   (qp.util/query-hash (mt/mbql-query venues {:limit 1}))})
+            q-hash (qp.util/query-hash query)]
+        ;; Clean up any prior QueryExecution / Query rows for this hash
+        (t2/delete! :model/QueryExecution :hash q-hash)
+        (t2/delete! :model/Query :query_hash q-hash)
+        (try
+          (qp/process-query (qp/userland-query query))
+          (testing "QueryExecution row was written"
+            (is (pos? (t2/count :model/QueryExecution :hash q-hash))))
+          (testing "Query avg execution time row was written"
+            (is (some? (t2/select-one :model/Query :query_hash q-hash))))
+          (finally
+            (t2/delete! :model/QueryExecution :hash q-hash)
+            (t2/delete! :model/Query :query_hash q-hash)))))))


### PR DESCRIPTION
Currently when you load a dashboard we fire off a single request per card in the dashboard.

This is inefficient because a lot of those requests are going to do almost exactly the same thing. Fetching the dashboard, getting metadata about the queries, etc.

This is an exploratory PR, but I think it's very promising. It uses a single request with streaming responses to get the data for *all* cards in the dashboard with one request.

For a dashboard with 20 cards, this results in a 53% reduction in the number of queries we run against the AppDB when a dashboard is loaded (and the absolute numbers here are LARGE - from 504 queries to 239 queries for a single page load).

But there's more! Because we're doing a single request, we can add some additional request-level caching that didn't make sense when we had a request per-query but does makes sense if we have a request per-dashboard.

With additional caches I was able to get the number of queries for my 20 card dashboard down to **83** - an 84% reduction from the 504 we started with.

Additionally, an additional 3 queries are made per card to update query execution logs and timing data; I swapped to grouper here to turn this into a max number of queries per second. Those 60 queries don't appear in the totals above since they happen in a background thread, but cutting those should help with appdb connection contention as well.