### PR TITLE
Allow Enterprise module to import from feature modules

### DIFF
--- a/frontend/lint/module-boundaries.mjs
+++ b/frontend/lint/module-boundaries.mjs
@@ -18,6 +18,11 @@ const elements = [
   ...basicModules.map((name) => createElement({ type: "basic", name })),
   ...sharedModules.map((name) => createElement({ type: "shared", name })),
   ...featureModules.map((name) => createElement({ type: "feature", name })),
+  {
+    type: "feature/enterprise",
+    pattern: "enterprise/frontend/src/metabase-enterprise/**",
+    mode: "full", // matches the entire path, because enterprise is in a different directory
+  },
   { type: "app/misc", pattern: "frontend/src/metabase/*.*" },
   { type: "shared/other", pattern: "frontend/src/*/**" },
 ];
@@ -50,6 +55,11 @@ const rules = [
     from: ["feature/*"],
     allow: ["lib/*", "basic/*", "shared/*"],
     message: "Feature modules cannot import from other feature modules",
+  },
+  {
+    from: ["feature/enterprise"],
+    allow: ["feature/*"],
+    message: "Enterprise module can import from all feature modules",
   },
   {
     from: ["app/*"],


### PR DESCRIPTION
Enterprise is classed as a special feature which can import from features, which is how the plugin system currently works.