### PR TITLE
Script to pull PR comments for agents

### DIFF
--- a/bin/pr-comments
+++ b/bin/pr-comments
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Fetch all unresolved review comment threads from a GitHub PR.
+# Usage: bin/pr-comments [PR_NUMBER]
+#   If PR_NUMBER is omitted, uses the PR associated with the current branch.
+
+set -euo pipefail
+
+REPO="metabase/metabase"
+
+if [[ $# -ge 1 ]]; then
+  PR_NUMBER="$1"
+else
+  PR_NUMBER=$(gh pr view --json number --jq '.number' 2>/dev/null) || true
+  if [[ -z "$PR_NUMBER" ]]; then
+    echo "Error: No PR found for current branch and no PR number provided." >&2
+    exit 1
+  fi
+fi
+
+if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+  echo "Error: Invalid PR number: $PR_NUMBER" >&2
+  exit 1
+fi
+
+# Use the GraphQL API to get review threads with resolved status
+gh api graphql -f query='
+query($owner: String!, $repo: String!, $pr: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $pr) {
+      title
+      url
+      number
+      reviewThreads(first: 100) {
+        pageInfo { hasNextPage }
+        nodes {
+          isResolved
+          isOutdated
+          path
+          line
+          comments(first: 50) {
+            pageInfo { hasNextPage }
+            nodes {
+              author { login }
+              body
+              createdAt
+              url
+            }
+          }
+        }
+      }
+    }
+  }
+}' -f owner="${REPO%/*}" -f repo="${REPO#*/}" -F pr="$PR_NUMBER" \
+  --jq '
+    .data.repository.pullRequest as $pr |
+    "PR #\($pr.number): \($pr.title)\n\($pr.url)\n" +
+    (if $pr.reviewThreads.pageInfo.hasNextPage then
+      "WARNING: More than 100 review threads exist; some may be missing.\n"
+    else "" end) +
+    (
+      [ $pr.reviewThreads.nodes[] | select(.isResolved == false) ] as $threads |
+      if ($threads | length) == 0 then
+        "No unresolved comment threads."
+      else
+        "\(($threads | length)) unresolved thread(s):\n" +
+        (
+          [ $threads | to_entries[] |
+            (.key + 1) as $num | .value |
+            .path as $path | .line as $line |
+            .comments.nodes as $comments |
+            "\n--- [\($num)] \($path):\($line // "file-level") ---" +
+            (if .comments.pageInfo.hasNextPage then
+              "\n  (WARNING: Thread has more than 50 comments; some may be missing.)"
+            else "" end) +
+            ([ $comments[] |
+              "\n  @\(.author.login) (\(.createdAt | split("T")[0])):\n\(.body | split("\n") | map("    " + .) | join("\n"))"
+            ] | join("\n"))
+          ] | join("\n")
+        )
+      end
+    )
+  '

--- a/bin/pr-resolve-outdated
+++ b/bin/pr-resolve-outdated
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Resolve specific review comment threads on a GitHub PR by thread number.
+# Thread numbers correspond to the order shown by bin/pr-comments.
+#
+# Usage: bin/pr-resolve-outdated THREAD_NUM [THREAD_NUM ...] [--pr PR_NUMBER]
+#   If --pr is omitted, uses the PR associated with the current branch.
+#
+# Examples:
+#   bin/pr-resolve-outdated 1 3        # resolve threads 1 and 3
+#   bin/pr-resolve-outdated 1 2 3      # resolve threads 1, 2, and 3
+#   bin/pr-resolve-outdated 2 --pr 71471
+
+set -euo pipefail
+
+REPO="metabase/metabase"
+PR_NUMBER=""
+THREAD_NUMS=()
+
+# Parse args
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --pr)
+      PR_NUMBER="$2"
+      shift 2
+      ;;
+    *)
+      if ! [[ "$1" =~ ^[0-9]+$ ]]; then
+        echo "Error: Invalid thread number: $1 (must be a positive integer)" >&2
+        exit 1
+      fi
+      THREAD_NUMS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [[ ${#THREAD_NUMS[@]} -eq 0 ]]; then
+  echo "Usage: bin/pr-resolve-outdated THREAD_NUM [THREAD_NUM ...] [--pr PR_NUMBER]" >&2
+  echo "Thread numbers match the order shown by bin/pr-comments." >&2
+  exit 1
+fi
+
+if [[ -z "$PR_NUMBER" ]]; then
+  PR_NUMBER=$(gh pr view --json number --jq '.number' 2>/dev/null) || true
+  if [[ -z "$PR_NUMBER" ]]; then
+    echo "Error: No PR found for current branch and no PR number provided." >&2
+    exit 1
+  fi
+fi
+
+# Fetch all unresolved threads (same order as bin/pr-comments)
+THREADS=$(gh api graphql -f query='
+query($owner: String!, $repo: String!, $pr: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $pr) {
+      reviewThreads(first: 100) {
+        nodes {
+          id
+          isResolved
+          path
+          line
+          comments(first: 1) {
+            nodes {
+              body
+            }
+          }
+        }
+      }
+    }
+  }
+}' -f owner="${REPO%/*}" -f repo="${REPO#*/}" -F pr="$PR_NUMBER" \
+  --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | to_entries[] | "\(.key + 1)\t\(.value.id)\t\(.value.path):\(.value.line // "file" | tostring)\t\(.value.comments.nodes[0].body | split("\n")[0][:80])"')
+
+if [[ -z "$THREADS" ]]; then
+  echo "No unresolved threads on PR #${PR_NUMBER}."
+  exit 0
+fi
+
+TOTAL=$(echo "$THREADS" | wc -l | tr -d ' ')
+RESOLVED=0
+
+for num in "${THREAD_NUMS[@]}"; do
+  LINE=$(echo "$THREADS" | awk -F'\t' -v n="$num" '$1 == n')
+  if [[ -z "$LINE" ]]; then
+    echo "Warning: thread #${num} not found (PR has ${TOTAL} unresolved threads)" >&2
+    continue
+  fi
+
+  THREAD_ID=$(echo "$LINE" | cut -f2)
+  LOCATION=$(echo "$LINE" | cut -f3)
+  PREVIEW=$(echo "$LINE" | cut -f4)
+
+  echo "Resolving #${num} ${LOCATION}: ${PREVIEW}"
+  RESPONSE=$(gh api graphql -f query='mutation($threadId: ID!) { resolveReviewThread(input: {threadId: $threadId}) { thread { isResolved } } }' -f threadId="$THREAD_ID" 2>&1) || true
+  if ! echo "$RESPONSE" | jq -e . >/dev/null 2>&1; then
+    echo "Error: gh api call failed for thread #${num}" >&2
+    continue
+  fi
+  if echo "$RESPONSE" | jq -e '.errors' >/dev/null 2>&1; then
+    ERROR_MSG=$(echo "$RESPONSE" | jq -r '.errors[0].message // "unknown error"')
+    echo "Error resolving thread #${num}: ${ERROR_MSG}" >&2
+    continue
+  fi
+  RESOLVED=$((RESOLVED + 1))
+done
+
+echo "Done. Resolved ${RESOLVED} thread(s)."


### PR DESCRIPTION
Putting this in a script allows me to auto-approve it.

Putting it in the repo makes it easier to use across worktrees, and perhaps improves the lives of others as well.

Example output:

```
PR #71467: Move `metabase/lib` to `metabase/utils` and move domain-related utils to other modules
https://github.com/metabase/metabase/pull/71467
1 unresolved thread(s):

--- enterprise/frontend/src/metabase-enterprise/whitelabel/components/LogoIcon.jsx:61 ---
  @fraserdrops (2026-03-26):
    Where does this function even come from?
```
