### PR TITLE
Support non-datetime migration ids in tests

### DIFF
--- a/test/metabase/app_db/custom_migrations_test.clj
+++ b/test/metabase/app_db/custom_migrations_test.clj
@@ -2625,10 +2625,10 @@
             (is (zero? (t2/count :notification :payload_type "notification/card")))))))))
 
 (deftest migrate-clickhouse-details-to-multi-db-test
-  (testing "v57.2025-08-22T00:16:00: migrate clickhouse db details to use `enable-multiple-db` with db filters"
+  (testing "v57.2025-08-23T16:00:00: migrate clickhouse db details to use `enable-multiple-db` with db filters"
     (encryption-test/with-secret-key "dont-tell-anyone-about-this"
       (impl/test-migrations
-       ["v57.2025-08-22T00:16:00"] [migrate!]
+       ["v57.2025-08-23T16:00:00"] [migrate!]
         (letfn [(insert-clickhouse-db [name details]
                   (let [details (merge {:host "localhost"
                                         :port 8123

--- a/test/metabase/app_db/schema_migrations_test/impl.clj
+++ b/test/metabase/app_db/schema_migrations_test/impl.clj
@@ -89,7 +89,8 @@
   [[conn-binding db-type] & body]
   `(do-with-temp-empty-app-db ~db-type (fn [~(vary-meta conn-binding assoc :tag 'java.sql.Connection)] ~@body)))
 
-(defn- range-description [start-id end-id {:keys [inclusive-start? inclusive-end?]}]
+(defn- range-description [start-id end-id {:keys [inclusive-start? inclusive-end?]
+                                           :or   {inclusive-start? true inclusive-end? true}}]
   (let [inclusive-exclusive #(if % "inclusive" "exclusive")]
     (if end-id
       (format "between %s (%s) and %s (%s)"
@@ -216,11 +217,11 @@
   e.g.
 
     ;; example test for migrations 100-105
-    (test-migrations [100 105] [migrate!]
-      ;; (Migrations 1-99 are ran automatically before body is invoked)
+    (test-migrations [\"v45.00-001\" \"v45.00-005\"] [migrate!]
+      ;; (Migrations before v45.00-001 are ran automatically before body is invoked)
       ;; 1. Load data
       (create-some-users!)
-      ;; 2. Run migrations 100-105
+      ;; 2. Run migrations v45.00-001 through v45.00-005
       (migrate!)
       ;; 3. Do some test assertions
       (is (= ...)))

--- a/test/metabase/app_db/schema_migrations_test/impl.clj
+++ b/test/metabase/app_db/schema_migrations_test/impl.clj
@@ -236,3 +236,59 @@
     ~migration-range
     (fn [~migrate!-binding]
       ~@body)))
+
+;;; ------------------------------------------------ Range filter tests ------------------------------------------------
+
+(defn- migrations-run
+  "Return the set of migration IDs that have been executed against `conn`."
+  [^java.sql.Connection conn]
+  (let [table-name (liquibase/changelog-table-name conn)]
+    (into #{} (map :id) (jdbc/query {:connection conn} [(format "SELECT id FROM %s" table-name)]))))
+
+(deftest run-migrations-in-range!-boundary-test
+  (testing "inclusive start + inclusive end (defaults)"
+    (with-temp-empty-app-db [conn :h2]
+      (run-migrations-in-range! conn ["v00.00-000" "v45.00-002"])
+      (let [ran (migrations-run conn)]
+        (is (contains? ran "v00.00-000") "start should be included (inclusive)")
+        (is (contains? ran "v45.00-002") "end should be included (inclusive)"))))
+
+  (testing "exclusive end excludes the endpoint"
+    (with-temp-empty-app-db [conn :h2]
+      ;; Run v00.00-000 through v45.00-002 with exclusive end — v45.00-002 should NOT be run
+      (run-migrations-in-range! conn ["v00.00-000" "v45.00-002"] {:inclusive-end? false})
+      (let [ran (migrations-run conn)]
+        (is (contains? ran "v00.00-000") "start should be included (inclusive by default)")
+        (is (not (contains? ran "v45.00-002")) "end should be excluded (exclusive)")
+        (is (contains? ran "v45.00-001") "migration before end should be included"))))
+
+  (testing "exclusive start excludes the start point"
+    (with-temp-empty-app-db [conn :h2]
+      ;; First run all migrations up through v45.00-001 so the DB has the required schema
+      (run-migrations-in-range! conn ["v00.00-000" "v45.00-001"])
+      ;; Now run from v45.00-001 exclusive to v45.00-011 inclusive
+      (run-migrations-in-range! conn ["v45.00-001" "v45.00-011"] {:inclusive-start? false})
+      (let [ran (migrations-run conn)]
+        (is (contains? ran "v45.00-001") "v45.00-001 was run in the first batch")
+        (is (contains? ran "v45.00-002") "v45.00-002 should be included (between exclusive start and end)")
+        (is (contains? ran "v45.00-011") "end should be included (inclusive by default)"))))
+
+  (testing "nil end-id runs through the end of the changelog"
+    (with-temp-empty-app-db [conn :h2]
+      ;; Use the very first migration as start with no end — should run everything
+      (run-migrations-in-range! conn ["v00.00-000" nil])
+      (let [ran (migrations-run conn)]
+        (is (contains? ran "v00.00-000") "start should be included")
+        (is (> (count ran) 10) "should have run many migrations with no upper bound"))))
+
+  (testing "unknown start-id throws"
+    (with-temp-empty-app-db [conn :h2]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"Migration ID not found in changelog"
+                            (run-migrations-in-range! conn ["v99.bogus-999" "v45.00-002"])))))
+
+  (testing "unknown end-id throws"
+    (with-temp-empty-app-db [conn :h2]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"Migration ID not found in changelog"
+                            (run-migrations-in-range! conn ["v00.00-000" "v99.bogus-999"]))))))

--- a/test/metabase/app_db/schema_migrations_test/impl.clj
+++ b/test/metabase/app_db/schema_migrations_test/impl.clj
@@ -11,7 +11,6 @@
   (:require
    [clojure.java.jdbc :as jdbc]
    [clojure.test :refer :all]
-   [java-time.api :as t]
    [metabase.app-db.connection :as mdb.connection]
    [metabase.app-db.core :as mdb]
    [metabase.app-db.custom-migrations.util :as custom-migrations.util]
@@ -24,13 +23,11 @@
    [metabase.test.data.interface :as tx]
    [metabase.test.initialize :as initialize]
    [metabase.util :as u]
-   [metabase.util.date-2 :as u.date]
    [metabase.util.log :as log]
    [toucan2.core :as t2])
   (:import
-   (java.time OffsetDateTime)
    (liquibase LabelExpression)
-   (liquibase.changelog  ChangeLogHistoryServiceFactory)
+   (liquibase.changelog ChangeLogHistoryServiceFactory ChangeSet)
    (liquibase.changelog.filter ChangeSetFilter ChangeSetFilterResult)))
 
 (set! *warn-on-reflection* true)
@@ -91,103 +88,6 @@
   [[conn-binding db-type] & body]
   `(do-with-temp-empty-app-db ~db-type (fn [~(vary-meta conn-binding assoc :tag 'java.sql.Connection)] ~@body)))
 
-(def ^:private timestamp-migration-id-re
-  #"^v(\d{2,})\.(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})$")
-
-;; Assigns sequential numbers to hex-style migration IDs (e.g. v60.f8c3be) in the order they're
-;; first seen, which matches file order since Liquibase reads changesets sequentially.
-(def ^:private hex->ordinal (atom {}))
-
-(defn- migration->number [id]
-  (if (integer? id)
-    id
-    (or (when-let [[_ major-version minor-version migration-num] (re-matches #"^v(\d+)\.(\d+)-(\d+)$" id)]
-          (+ (* (Integer/parseUnsignedInt major-version) 100)
-             (Integer/parseUnsignedInt minor-version)
-             (/ (Integer/parseUnsignedInt migration-num)
-                1000.0)))
-        (when (re-matches #"^\d+$" id)
-          (Integer/parseUnsignedInt id))
-        (when-let [[_ major-version timestamp] (re-matches timestamp-migration-id-re id)]
-          (let [unix-timestamp (-> (u.date/parse timestamp)
-                                   ^OffsetDateTime (u.date/with-time-zone-same-instant (t/zone-id "UTC"))
-                                   .toInstant .getEpochSecond)]
-            (parse-double (format "%d.%d" (* (parse-long major-version) 100) unix-timestamp))))
-        ;; v60.f8c3be style hex IDs -- ordered by first-seen position, not by hex value
-        (when-let [[_ major-version] (re-matches #"^v(\d{2,})\.([0-9a-fA-F]{6})$" id)]
-          (let [ordinal (or (get @hex->ordinal id)
-                            (get (swap! hex->ordinal #(assoc % id (or (get % id) (count %))))
-                                 id))]
-            (+ (* (Integer/parseUnsignedInt major-version) 100)
-               (/ (double ordinal) 1000.0))))
-        (throw (ex-info (format "Invalid migration ID: %s" id) {:id id})))))
-
-(deftest migration->number-test
-  (is (= 356
-         (migration->number 356)
-         (migration->number "356")))
-  (is (= 4301.009
-         (migration->number "v43.01-009")))
-  (is (= 4301.01
-         (migration->number "v43.01-010")))
-  (is (= 4900.16725312
-         (migration->number "v49.2023-01-01T00:00:00"))))
-
-(defn- migration-id-in-range?
-  "Whether `id` should be considered to be between `start-id` and `end-id`, inclusive. Handles both legacy plain-integer
-  and new-style `vMM.mm-NNN` style IDs."
-  [start-id id end-id & [{:keys [inclusive-start? inclusive-end?]
-                          :or   {inclusive-start? true
-                                 inclusive-end? true}}]]
-
-  (let [start (migration->number start-id)
-        id    (migration->number id)
-        ;; end-id can be nil (meaning, unbounded)
-        end   (if end-id
-                (migration->number end-id)
-                Integer/MAX_VALUE)]
-    (and
-     (if inclusive-start?
-       (<= start id)
-       (< start id))
-     (if inclusive-end?
-       (<= id end)
-       (< id end)))))
-
-(deftest migration-id-in-range?-test
-  (testing "legacy IDs"
-    (is (migration-id-in-range? 1 2 3))
-    (is (migration-id-in-range? 1 2 3 {:inclusive-end? false}))
-    (is (migration-id-in-range? 1 1 3))
-    (is (migration-id-in-range? 1 3 3))
-    (is (migration-id-in-range? 100 100 nil))
-    (is (not (migration-id-in-range? 1 3 3 {:inclusive-end? false})))
-    (is (not (migration-id-in-range? 2 1 3)))
-    (is (not (migration-id-in-range? 2 4 3)))
-    (testing "strings"
-      (is (migration-id-in-range? 1 "1" 3))
-      (is (not (migration-id-in-range? 1 "13" 3)))))
-  (testing "new-style IDs"
-    (is (migration-id-in-range? "v42.00-001" "v42.00-002" "v42.00-003"))
-    (is (migration-id-in-range? "v42.00-001" "v42.00-002" "v42.00-002"))
-    (is (not (migration-id-in-range? "v42.00-001" "v42.00-002" "v42.00-002" {:inclusive-end? false})))
-    (is (not (migration-id-in-range? "v42.00-001" "v42.00-004" "v42.00-003")))
-    (is (not (migration-id-in-range? "v42.00-002" "v42.00-001" "v42.00-003")))
-    ;; this case is invoked when the test-migrations macro is only given one item in the range list
-    (is (migration-id-in-range? "v42.00-064" "v42.00-064" nil)))
-  (testing "mixed"
-    (is (migration-id-in-range? 1 3 "v42.00-001"))
-    (is (migration-id-in-range? 1 "v42.00-001" "v42.00-002"))
-    (is (not (migration-id-in-range? "v42.00-002" 1000 "v42.00-003")))
-    (is (not (migration-id-in-range? "v42.00-002" 1000 "v42.00-003" {:inclusive-end? false})))
-    (is (not (migration-id-in-range? 1 "v42.00-001" 1000)))
-    (is (not (migration-id-in-range? 1 "v42.00-001" 1000)))
-    (is (migration-id-in-range? 1 "v42.00-000" "v43.00-000"))
-    (is (migration-id-in-range? 1 "v42.00-001" "v43.00-000"))
-    (is (migration-id-in-range? 1 "v42.00-000" "v43.00-014"))
-    (is (migration-id-in-range? 1 "v42.00-015" "v43.00-014"))
-    (is (not (migration-id-in-range? 1 "v43.00-014" "v42.00-015")))))
-
 (defn- range-description [start-id end-id {:keys [inclusive-start? inclusive-end?]}]
   (let [inclusive-exclusive #(if % "inclusive" "exclusive")]
     (if end-id
@@ -198,7 +98,10 @@
 
 (defn run-migrations-in-range!
   "Run Liquibase migrations from our migrations YAML file in the range of `start-id` -> `end-id` (inclusive) against a
-  DB with `jdbc-spec`."
+  DB with `jdbc-spec`.
+
+  Range comparison uses the actual changelog order (index-based), so all ID formats — including hex-style IDs like
+  `v60.f8c3be` — are handled correctly without numeric conversion."
   {:added "0.41.0", :arglists '([conn [start-id end-id]]
                                 [conn [start-id end-id] {:keys [inclusive-start? inclusive-end?]
                                                          :or {inclusive-start? true
@@ -207,14 +110,33 @@
   (log/debugf "Finding and running migrations %s" (range-description start-id end-id range-options))
 
   (liquibase/with-liquibase [liquibase conn]
-    (let [database (.getDatabase liquibase)
+    (let [database   (.getDatabase liquibase)
+          id->index  (into {} (map-indexed (fn [i ^ChangeSet cs] [(.getId cs) i])
+                                           (.getChangeSets (.getDatabaseChangeLog liquibase))))
+          {:keys [inclusive-start? inclusive-end?]
+           :or   {inclusive-start? true inclusive-end? true}} range-options
+          start-idx  (or (id->index start-id)
+                         (throw (ex-info (format "Migration ID not found in changelog: %s" start-id) {:id start-id})))
+          end-idx    (when end-id
+                       (or (id->index end-id)
+                           (throw (ex-info (format "Migration ID not found in changelog: %s" end-id) {:id end-id}))))
           change-set-filters [(reify ChangeSetFilter
                                 (accepts [this change-set]
-                                  (let [id      (.getId change-set)
-                                        accept? (boolean (migration-id-in-range? start-id id end-id range-options))]
+                                  (let [id      (.getId ^ChangeSet change-set)
+                                        idx     (id->index id)
+                                        accept? (boolean
+                                                 (and (some? idx)
+                                                      (if inclusive-start?
+                                                        (<= start-idx idx)
+                                                        (< start-idx idx))
+                                                      (if end-idx
+                                                        (if inclusive-end?
+                                                          (<= idx end-idx)
+                                                          (< idx end-idx))
+                                                        true)))]
                                     (log/tracef "Migration %s in range [%s ↔ %s] %s ? => %s"
                                                 id start-id end-id
-                                                (if (:inclusive-end? range-options) "(inclusive)" "(exclusive)")
+                                                (if inclusive-end? "(inclusive)" "(exclusive)")
                                                 accept?)
                                     (ChangeSetFilterResult. accept? "decision according to range" (class this)))))]
           change-log-service (.getChangeLogService (ChangeLogHistoryServiceFactory/getInstance) database)]

--- a/test/metabase/app_db/schema_migrations_test/impl.clj
+++ b/test/metabase/app_db/schema_migrations_test/impl.clj
@@ -10,6 +10,7 @@
   Actual tests using this code live in [[metabase.app-db.schema-migrations-test]]."
   (:require
    [clojure.java.jdbc :as jdbc]
+   [clojure.set :as set]
    [clojure.test :refer :all]
    [metabase.app-db.connection :as mdb.connection]
    [metabase.app-db.core :as mdb]
@@ -266,14 +267,17 @@
     (with-temp-empty-app-db [conn :h2]
       ;; First run all migrations up through v45.00-001 so the DB has the required schema
       (run-migrations-in-range! conn ["v00.00-000" "v45.00-001"])
-      ;; Now run from v45.00-001 exclusive to v45.00-011 inclusive
-      (run-migrations-in-range! conn ["v45.00-001" "v45.00-011"] {:inclusive-start? false})
-      (let [ran (migrations-run conn)]
-        (is (contains? ran "v45.00-001") "v45.00-001 was run in the first batch")
-        (is (contains? ran "v45.00-002") "v45.00-002 should be included (between exclusive start and end)")
-        (is (contains? ran "v45.00-011") "end should be included (inclusive by default)"))))
+      (let [ran-before (migrations-run conn)]
+        ;; Now run from v45.00-001 exclusive to v45.00-011 inclusive
+        (run-migrations-in-range! conn ["v45.00-001" "v45.00-011"] {:inclusive-start? false})
+        (let [ran-after  (migrations-run conn)
+              newly-ran  (set/difference ran-after ran-before)]
+          (is (not (contains? newly-ran "v45.00-001")) "v45.00-001 should NOT be re-run (exclusive start)")
+          (is (contains? newly-ran "v45.00-002") "v45.00-002 should be included (between exclusive start and end)")
+          (is (contains? newly-ran "v45.00-011") "end should be included (inclusive by default)")))))
 
   (testing "nil end-id runs through the end of the changelog"
+    ;; This runs the entire migration history, so mark it ^:long to exclude from fast feedback loops
     (with-temp-empty-app-db [conn :h2]
       ;; Use the very first migration as start with no end — should run everything
       (run-migrations-in-range! conn ["v00.00-000" nil])

--- a/test/metabase/app_db/schema_migrations_test/impl.clj
+++ b/test/metabase/app_db/schema_migrations_test/impl.clj
@@ -115,13 +115,13 @@
     (let [database   (.getDatabase liquibase)
           id->index  (into {} (map-indexed (fn [i ^ChangeSet cs] [(.getId cs) i])
                                            (.getChangeSets (.getDatabaseChangeLog liquibase))))
+          resolve-id (fn [id]
+                       (or (id->index id)
+                           (throw (ex-info (format "Migration ID not found in changelog: %s" id) {:id id}))))
           {:keys [inclusive-start? inclusive-end?]
            :or   {inclusive-start? true inclusive-end? true}} range-options
-          start-idx  (or (id->index start-id)
-                         (throw (ex-info (format "Migration ID not found in changelog: %s" start-id) {:id start-id})))
-          end-idx    (when end-id
-                       (or (id->index end-id)
-                           (throw (ex-info (format "Migration ID not found in changelog: %s" end-id) {:id end-id}))))
+          start-idx  (resolve-id start-id)
+          end-idx    (when end-id (resolve-id end-id))
           change-set-filters [(reify ChangeSetFilter
                                 (accepts [this change-set]
                                   (let [id      (.getId ^ChangeSet change-set)

--- a/test/metabase/app_db/schema_migrations_test/impl.clj
+++ b/test/metabase/app_db/schema_migrations_test/impl.clj
@@ -94,6 +94,10 @@
 (def ^:private timestamp-migration-id-re
   #"^v(\d{2,})\.(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})$")
 
+;; Assigns sequential numbers to hex-style migration IDs (e.g. v60.f8c3be) in the order they're
+;; first seen, which matches file order since Liquibase reads changesets sequentially.
+(def ^:private hex->ordinal (atom {}))
+
 (defn- migration->number [id]
   (if (integer? id)
     id
@@ -109,6 +113,13 @@
                                    ^OffsetDateTime (u.date/with-time-zone-same-instant (t/zone-id "UTC"))
                                    .toInstant .getEpochSecond)]
             (parse-double (format "%d.%d" (* (parse-long major-version) 100) unix-timestamp))))
+        ;; v60.f8c3be style hex IDs -- ordered by first-seen position, not by hex value
+        (when-let [[_ major-version] (re-matches #"^v(\d{2,})\.([0-9a-fA-F]{6})$" id)]
+          (let [ordinal (or (get @hex->ordinal id)
+                            (get (swap! hex->ordinal #(assoc % id (or (get % id) (count %))))
+                                 id))]
+            (+ (* (Integer/parseUnsignedInt major-version) 100)
+               (/ (double ordinal) 1000.0))))
         (throw (ex-info (format "Invalid migration ID: %s" id) {:id id})))))
 
 (deftest migration->number-test

--- a/test/metabase/app_db/schema_migrations_test/impl.clj
+++ b/test/metabase/app_db/schema_migrations_test/impl.clj
@@ -255,6 +255,13 @@
         (is (contains? ran "v00.00-000") "start should be included (inclusive)")
         (is (contains? ran "v45.00-002") "end should be included (inclusive)"))))
 
+  (testing "single-item range (start == end)"
+    (with-temp-empty-app-db [conn :h2]
+      (run-migrations-in-range! conn ["v45.00-001" "v45.00-001"])
+      (let [ran (migrations-run conn)]
+        (is (contains? ran "v45.00-001") "the single migration should be included")
+        (is (not (contains? ran "v45.00-002")) "the next migration should NOT be included"))))
+
   (testing "exclusive end excludes the endpoint"
     (with-temp-empty-app-db [conn :h2]
       ;; Run v00.00-000 through v45.00-002 with exclusive end — v45.00-002 should NOT be run
@@ -276,15 +283,6 @@
           (is (not (contains? newly-ran "v45.00-001")) "v45.00-001 should NOT be re-run (exclusive start)")
           (is (contains? newly-ran "v45.00-002") "v45.00-002 should be included (between exclusive start and end)")
           (is (contains? newly-ran "v45.00-011") "end should be included (inclusive by default)")))))
-
-  (testing "nil end-id runs through the end of the changelog"
-    ;; This runs the entire migration history, so mark it ^:long to exclude from fast feedback loops
-    (with-temp-empty-app-db [conn :h2]
-      ;; Use the very first migration as start with no end — should run everything
-      (run-migrations-in-range! conn ["v00.00-000" nil])
-      (let [ran (migrations-run conn)]
-        (is (contains? ran "v00.00-000") "start should be included")
-        (is (> (count ran) 10) "should have run many migrations with no upper bound"))))
 
   (testing "unknown start-id throws"
     (with-temp-empty-app-db [conn :h2]


### PR DESCRIPTION
Add support for Nathan's suggested id format.

Without this change:

```
liquibase.exception.LiquibaseException: clojure.lang.ExceptionInfo: 
   Invalid migration ID: v60.f8c3be {:id "v60.f8c3be"}
            clojure.lang.ExceptionInfo: Invalid migration ID: v60.f8c3be
    id: "v60.f8c3be"
                        metabase.app-db.schema-migrations-test.impl/migration->number
                              impl.clj:  112
```
