### PR TITLE
GDGT-2089: Adjust viz settings sidebar styling

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChartSettings/BaseChartSettings/BaseChartSettings.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings/BaseChartSettings/BaseChartSettings.styled.tsx
@@ -7,14 +7,15 @@ export const SectionContainer = styled.div`
   width: 100%;
 
   ${Radio.RadioGroupVariants.join(", ")} {
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    padding-top: 1rem;
+    padding-inline: 1.5rem;
     border-bottom: 1px solid var(--mb-color-border);
   }
 
   ${Radio.RadioContainerVariants.join(", ")} {
     padding-left: 1rem;
     padding-right: 1rem;
+    padding-block: 0.5rem;
   }
 
   ${Radio.RadioLabelVariants.join(", ")} {

--- a/frontend/src/metabase/visualizations/components/ChartSettings/BaseChartSettings/BaseChartSettings.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings/BaseChartSettings/BaseChartSettings.styled.tsx
@@ -32,7 +32,7 @@ export const SectionContainer = styled.div`
 
 export const ChartSettingsListContainer = styled.div`
   position: relative;
-  padding: 1.5rem 0;
+  padding: 1.5rem 0 0;
   flex: 1;
   overflow: auto;
 `;

--- a/frontend/src/metabase/visualizations/components/ChartSettingsWidget.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettingsWidget.styled.tsx
@@ -6,9 +6,8 @@ import styled from "@emotion/styled";
 export const Root = styled.div<{
   inline?: boolean;
 }>`
-  margin-left: 2rem;
-  margin-right: 2rem;
-  margin-bottom: 1.5em;
+  margin-inline: 1.5rem;
+  margin-bottom: 1.5rem;
 
   ${(props) =>
     props.hidden &&

--- a/frontend/src/metabase/visualizations/components/ChartSettingsWidgetList.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettingsWidgetList.styled.tsx
@@ -1,18 +1,9 @@
 // eslint-disable-next-line no-restricted-imports
 import styled from "@emotion/styled";
 
-export const ChartSettingsWidgetListHeader = styled.h4`
-  margin-left: 2rem;
-  margin-bottom: 1rem;
-  color: var(--mb-color-text-secondary);
-  text-transform: uppercase;
-`;
-
 export const ChartSettingsWidgetListDivider = styled.div`
   background-color: var(--mb-color-border);
   height: 1px;
   display: block;
   margin-bottom: 1.5rem;
-  margin-left: 2rem;
-  margin-right: 2rem;
 `;

--- a/frontend/src/metabase/visualizations/components/ChartSettingsWidgetList.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettingsWidgetList.tsx
@@ -1,10 +1,9 @@
 import _ from "underscore";
 
+import { Badge } from "metabase/ui";
+
 import ChartSettingsWidget from "./ChartSettingsWidget";
-import {
-  ChartSettingsWidgetListDivider,
-  ChartSettingsWidgetListHeader,
-} from "./ChartSettingsWidgetList.styled";
+import { ChartSettingsWidgetListDivider } from "./ChartSettingsWidgetList.styled";
 
 interface ChartSettingsWidgetListProps {
   widgets: { id: string; group?: string }[];
@@ -36,9 +35,15 @@ const ChartSettingsWidgetList = ({
       return (
         <div key={`group-${groupIndex}`}>
           {group && (
-            <ChartSettingsWidgetListHeader>
+            <Badge
+              mb="1.5rem"
+              ml="1.5rem"
+              tt="none"
+              radius="xs"
+              c="text-primary"
+            >
               {group}
-            </ChartSettingsWidgetListHeader>
+            </Badge>
           )}
           <div>
             {_.sortBy(groupedWidgets[group], "index").map((widget) => (

--- a/frontend/src/metabase/visualizations/components/ChartSettingsWidgetList.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettingsWidgetList.tsx
@@ -36,10 +36,13 @@ const ChartSettingsWidgetList = ({
         <div key={`group-${groupIndex}`}>
           {group && (
             <Badge
-              mb="1.5rem"
-              ml="1.5rem"
+              mb="lg"
+              ml="lg"
+              fz="0.75rem"
+              px="0.5rem"
               tt="none"
               radius="xs"
+              size="lg"
               c="text-primary"
             >
               {group}
@@ -53,7 +56,9 @@ const ChartSettingsWidgetList = ({
                 {...extraWidgetProps}
               />
             ))}
-            {!lastGroup && <ChartSettingsWidgetListDivider />}
+            <ChartSettingsWidgetListDivider
+              style={lastGroup ? { marginBottom: 0 } : undefined}
+            />
           </div>
         </div>
       );


### PR DESCRIPTION
Closes [GDGT-2089](https://linear.app/metabase/issue/GDGT-2089/tweak-viz-settings-sidebar)

### Description

Tweaks the visualization settings sidebar styling to improve spacing and consistency:
- Adjust section tab padding to match sidebar width 
- Unify widget margins to `1.5rem` inline
- Replace custom styled header with Mantine `Badge` component for section group labels
- Remove redundant divider margins

### Demo
**Before**
<img width="200" height="436" alt="image" src="https://github.com/user-attachments/assets/3d2389c4-924b-41e7-a8e4-6ebc4e78b05c" />

**After**
<img width="398" height="823" alt="image" src="https://github.com/user-attachments/assets/679a5c9c-7cdc-4b90-adee-b7b3418b9bd6" />

### How to verify

1. Open any question with chart settings (e.g., bar chart, line chart)
2. Open the settings sidebar (gear icon)
3. Verify section tabs, widget spacing, and group headers look consistent
4. Check that dividers span the full sidebar width