### PR TITLE
Fix boolean cartesian charts defaulting to timeseries axis

### DIFF
--- a/frontend/src/metabase/visualizations/lib/timeseries.ts
+++ b/frontend/src/metabase/visualizations/lib/timeseries.ts
@@ -30,7 +30,7 @@ export function dimensionIsTimeseries({ cols, rows = [] }: DatasetData, i = 0) {
     }
 
     if (
-      (typeof value === "number" || typeof value === "string") &&
+      !(typeof value === "number" || typeof value === "string") ||
       !isValidIso8601(value)
     ) {
       return false;

--- a/frontend/src/metabase/visualizations/lib/timeseries.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/lib/timeseries.unit.spec.ts
@@ -23,7 +23,16 @@ describe("visualization.lib.timeseries", () => {
       19210413,
     ];
 
-    const NOT_DATES = ["100", "100 %", "scanner 005", 99999999];
+    const NOT_DATES = [
+      "100",
+      "100 %",
+      "scanner 005",
+      99999999,
+      true,
+      false,
+      { foo: "bar" },
+      null,
+    ];
 
     it("should detect Date column as timeseries", () => {
       expect(


### PR DESCRIPTION
Closes #71377
Closes #70835

### Description

Fixes a bug introduced by #70249 where the additional check added for type safety before calling `isValidIso8601` was applied incorrectly, allowing boolean or object values to be detected as timeseries values.

This bug is worse than the issues suggest and affects all boolean cartesian charts. It's not specific to metrics viewer as described in #71377 and it doesn't require first adding then removing a time breakout as described in #70835.

### How to verify

Create a question -> Sample Database -> Invoices -> Count grouped by Expected Invoice. Verify that the bar chart appears with boolean values on the x-axis as expected.

### Demo

[Loom](https://www.loom.com/share/09376b7bf4a54fa0a377413cb2268245)

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
