### PR TITLE
Notify Slack on cross-version test failures

### DIFF
--- a/.github/workflows/cross-version.yml
+++ b/.github/workflows/cross-version.yml
@@ -18,6 +18,11 @@ on:
       - ".github/workflows/cross-version.yml"
       - ".github/scripts/build-cross-version-matrix.js"
 
+  # TEMP: test Slack notification on this branch
+  push:
+    branches:
+      - DEV-1671-cross-version-slack
+
   schedule:
     # Run nightly at 3 AM UTC
     - cron: "0 3 * * *"
@@ -102,7 +107,8 @@ jobs:
 
   # Notify Slack on nightly failures
   notify-on-failure:
-    if: always() && github.event_name == 'schedule' && needs.test-matrix.result == 'failure'
+    # TEMP: changed from 'schedule' to test on push
+    if: always() && needs.test-matrix.result == 'failure'
     needs: [test-matrix]
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 5
@@ -170,7 +176,8 @@ jobs:
 
             const failures = buildFailureResults(failedJobs, artifactData);
             const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${context.runId}`;
-            await sendCrossVersionSlackNotification(failures, runUrl, process.env.SLACK_BOT_TOKEN);
+            // TEMP: using bot-testing channel instead of engineering-ci
+            await sendCrossVersionSlackNotification(failures, runUrl, process.env.SLACK_BOT_TOKEN, 'bot-testing');
             console.log('Slack notification sent');
 
   # Manual test for workflow_dispatch

--- a/.github/workflows/cross-version.yml
+++ b/.github/workflows/cross-version.yml
@@ -18,11 +18,6 @@ on:
       - ".github/workflows/cross-version.yml"
       - ".github/scripts/build-cross-version-matrix.js"
 
-  # TEMP: test Slack notification on this branch
-  push:
-    branches:
-      - DEV-1671-cross-version-slack
-
   schedule:
     # Run nightly at 3 AM UTC
     - cron: "0 3 * * *"
@@ -107,8 +102,7 @@ jobs:
 
   # Notify Slack on nightly failures
   notify-on-failure:
-    # TEMP: changed from 'schedule' to test on push
-    if: always() && needs.test-matrix.result == 'failure'
+    if: always() && github.event_name == 'schedule' && needs.test-matrix.result == 'failure'
     needs: [test-matrix]
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 5
@@ -176,8 +170,7 @@ jobs:
 
             const failures = buildFailureResults(failedJobs, artifactData);
             const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${context.runId}`;
-            // TEMP: using bot-testing channel instead of engineering-ci
-            await sendCrossVersionSlackNotification(failures, runUrl, process.env.SLACK_BOT_TOKEN, 'bot-testing');
+            await sendCrossVersionSlackNotification(failures, runUrl, process.env.SLACK_BOT_TOKEN);
             console.log('Slack notification sent');
 
   # Manual test for workflow_dispatch

--- a/.github/workflows/cross-version.yml
+++ b/.github/workflows/cross-version.yml
@@ -70,9 +70,18 @@ jobs:
       - name: Run cross-version test
         env:
           CURRENT_VERSION: ${{ vars.CURRENT_VERSION }}
+          RESULT_FILE: ${{ runner.temp }}/cross-version-result.json
         run: |
           cd cross-version
           ./test.sh --source "${{ matrix.source }}" --target "${{ matrix.target }}"
+
+      - name: Upload failure result
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: failure-result-${{ matrix.source }}-${{ matrix.target }}
+          path: ${{ runner.temp }}/cross-version-result.json
+          if-no-files-found: ignore
 
       - name: Upload Cypress Artifacts upon failure
         uses: actions/upload-artifact@v4
@@ -90,6 +99,102 @@ jobs:
           cd cross-version
           docker compose logs metabase || true
           docker compose logs postgres || true
+
+  # Notify Slack on nightly failures
+  notify-on-failure:
+    if: always() && github.event_name == 'schedule' && needs.test-matrix.result == 'failure'
+    needs: [test-matrix]
+    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    timeout-minutes: 5
+    steps:
+      - name: Download failure results
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          pattern: failure-result-*
+          path: failure-results
+          merge-multiple: true
+
+      - name: Build Slack payload
+        id: payload
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const resultsDir = 'failure-results';
+
+            const failures = { migration: [], e2e: [] };
+            if (fs.existsSync(resultsDir)) {
+              for (const file of fs.readdirSync(resultsDir)) {
+                if (!file.endsWith('.json')) continue;
+                try {
+                  const result = JSON.parse(fs.readFileSync(path.join(resultsDir, file), 'utf8'));
+                  const category = result.phase === 'migration' ? 'migration' : 'e2e';
+                  failures[category].push(result);
+                } catch (e) {
+                  console.log(`Skipping malformed result: ${file}`);
+                }
+              }
+            }
+
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+            const sections = [];
+
+            if (failures.migration.length > 0) {
+              const items = failures.migration
+                .map(f => `• ${f.source} → ${f.target} — ${f.detail}`)
+                .join('\n');
+              sections.push({
+                type: 'section',
+                text: { type: 'mrkdwn', text: `:rotating_light: *Migration failures*\n${items}` },
+              });
+            }
+
+            if (failures.e2e.length > 0) {
+              const items = failures.e2e
+                .map(f => `• ${f.source} → ${f.target} — ${f.detail}`)
+                .join('\n');
+              sections.push({
+                type: 'section',
+                text: { type: 'mrkdwn', text: `:test_tube: *E2E failures*\n${items}` },
+              });
+            }
+
+            if (sections.length === 0) {
+              sections.push({
+                type: 'section',
+                text: { type: 'mrkdwn', text: 'One or more matrix jobs failed. Check the workflow run for details.' },
+              });
+            }
+
+            sections.push({
+              type: 'context',
+              elements: [{ type: 'mrkdwn', text: `<${runUrl}|View full run>` }],
+            });
+
+            const payload = {
+              blocks: [
+                {
+                  type: 'header',
+                  text: { type: 'plain_text', text: ':warning: Cross-version tests failing', emoji: true },
+                },
+                ...sections,
+              ],
+            };
+
+            core.setOutput('json', JSON.stringify(payload));
+
+      - name: Notify Slack
+        if: steps.payload.outcome == 'success'
+        continue-on-error: true
+        uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
+        with:
+          payload: ${{ steps.payload.outputs.json }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.CROSS_VERSION_SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
   # Manual test for workflow_dispatch
   test-manual:

--- a/.github/workflows/cross-version.yml
+++ b/.github/workflows/cross-version.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Run cross-version test
         env:
           CURRENT_VERSION: ${{ vars.CURRENT_VERSION }}
-          RESULT_FILE: ${{ runner.temp }}/cross-version-result.json
+          RESULT_FILE: ${{ runner.temp }}/cross-version-result-${{ matrix.source }}-${{ matrix.target }}.json
         run: |
           cd cross-version
           ./test.sh --source "${{ matrix.source }}" --target "${{ matrix.target }}"
@@ -85,7 +85,7 @@ jobs:
         if: failure()
         with:
           name: failure-result-${{ matrix.source }}-${{ matrix.target }}
-          path: ${{ runner.temp }}/cross-version-result.json
+          path: ${{ runner.temp }}/cross-version-result-${{ matrix.source }}-${{ matrix.target }}.json
           if-no-files-found: ignore
 
       - name: Upload Cypress Artifacts upon failure

--- a/.github/workflows/cross-version.yml
+++ b/.github/workflows/cross-version.yml
@@ -139,22 +139,43 @@ jobs:
           script: |
             const fs = require('fs');
             const path = require('path');
-            const { sendCrossVersionSlackNotification } = require('${{ github.workspace }}/release/dist/index.cjs');
+            const { buildFailureResults, sendCrossVersionSlackNotification } = require('${{ github.workspace }}/release/dist/index.cjs');
 
+            // Get all failed jobs from the GitHub API
+            const { owner, repo } = context.repo;
+            const jobInfo = await github.rest.actions.listJobsForWorkflowRun({
+              owner,
+              repo,
+              run_id: context.runId,
+              per_page: 100,
+            });
+
+            const failedJobs = jobInfo.data.jobs
+              .filter(job => job.status === 'completed' && job.conclusion === 'failure' && job.name.startsWith('test-matrix'))
+              .map(job => ({ name: job.name, url: job.html_url }));
+
+            if (failedJobs.length === 0) {
+              console.log('No failed test-matrix jobs found');
+              return;
+            }
+
+            // Load artifact data for enrichment (phase/detail)
             const resultsDir = 'failure-results';
-            const failures = [];
+            const artifactData = new Map();
             if (fs.existsSync(resultsDir)) {
               for (const file of fs.readdirSync(resultsDir)) {
                 if (!file.endsWith('.json')) continue;
                 try {
-                  failures.push(JSON.parse(fs.readFileSync(path.join(resultsDir, file), 'utf8')));
+                  const result = JSON.parse(fs.readFileSync(path.join(resultsDir, file), 'utf8'));
+                  artifactData.set(`${result.source}-${result.target}`, result);
                 } catch (e) {
                   console.log(`Skipping malformed result: ${file}`);
                 }
               }
             }
 
-            const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+            const failures = buildFailureResults(failedJobs, artifactData);
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${context.runId}`;
             // TEMP: using bot-testing channel instead of engineering-ci
             await sendCrossVersionSlackNotification(failures, runUrl, process.env.SLACK_BOT_TOKEN, 'bot-testing');
             console.log('Slack notification sent');

--- a/.github/workflows/cross-version.yml
+++ b/.github/workflows/cross-version.yml
@@ -124,15 +124,16 @@ jobs:
           path: failure-results
           merge-multiple: true
 
-      - name: Build Slack payload
-        id: payload
+      - name: Notify Slack
         continue-on-error: true
         uses: actions/github-script@v7
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         with:
           script: |
             const fs = require('fs');
             const path = require('path');
-            const { buildSlackPayload } = require('${{ github.workspace }}/release/dist/index.cjs');
+            const { sendCrossVersionSlackNotification } = require('${{ github.workspace }}/release/dist/index.cjs');
 
             const resultsDir = 'failure-results';
             const failures = [];
@@ -148,18 +149,8 @@ jobs:
             }
 
             const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
-            const payload = buildSlackPayload(failures, runUrl);
-            core.setOutput('json', JSON.stringify(payload));
-
-      - name: Notify Slack
-        if: steps.payload.outcome == 'success'
-        continue-on-error: true
-        uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
-        with:
-          payload: ${{ steps.payload.outputs.json }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.CROSS_VERSION_SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+            await sendCrossVersionSlackNotification(failures, runUrl, process.env.SLACK_BOT_TOKEN);
+            console.log('Slack notification sent');
 
   # Manual test for workflow_dispatch
   test-manual:

--- a/.github/workflows/cross-version.yml
+++ b/.github/workflows/cross-version.yml
@@ -18,6 +18,11 @@ on:
       - ".github/workflows/cross-version.yml"
       - ".github/scripts/build-cross-version-matrix.js"
 
+  # TEMP: test Slack notification on this branch
+  push:
+    branches:
+      - DEV-1671-cross-version-slack
+
   schedule:
     # Run nightly at 3 AM UTC
     - cron: "0 3 * * *"
@@ -102,7 +107,8 @@ jobs:
 
   # Notify Slack on nightly failures
   notify-on-failure:
-    if: always() && github.event_name == 'schedule' && needs.test-matrix.result == 'failure'
+    # TEMP: changed from 'schedule' to test on push
+    if: always() && needs.test-matrix.result == 'failure'
     needs: [test-matrix]
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 5
@@ -149,7 +155,8 @@ jobs:
             }
 
             const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
-            await sendCrossVersionSlackNotification(failures, runUrl, process.env.SLACK_BOT_TOKEN);
+            // TEMP: using bot-testing channel instead of engineering-ci
+            await sendCrossVersionSlackNotification(failures, runUrl, process.env.SLACK_BOT_TOKEN, 'bot-testing');
             console.log('Slack notification sent');
 
   # Manual test for workflow_dispatch

--- a/.github/workflows/cross-version.yml
+++ b/.github/workflows/cross-version.yml
@@ -153,7 +153,7 @@ jobs:
               return;
             }
 
-            // Load artifact data for enrichment (phase/detail)
+            // Load artifact data for enrichment (phase)
             const resultsDir = 'failure-results';
             const artifactData = new Map();
             if (fs.existsSync(resultsDir)) {
@@ -170,7 +170,12 @@ jobs:
 
             const failures = buildFailureResults(failedJobs, artifactData);
             const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${context.runId}`;
-            await sendCrossVersionSlackNotification(failures, runUrl, process.env.SLACK_BOT_TOKEN);
+            const slackBotToken = process.env.SLACK_BOT_TOKEN;
+            if (!slackBotToken) {
+              console.log('SLACK_BOT_TOKEN is not set; skipping Slack notification.');
+              return;
+            }
+            await sendCrossVersionSlackNotification(failures, runUrl, slackBotToken);
             console.log('Slack notification sent');
 
   # Manual test for workflow_dispatch

--- a/.github/workflows/cross-version.yml
+++ b/.github/workflows/cross-version.yml
@@ -107,6 +107,15 @@ jobs:
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 5
     steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            release
+            .github
+
+      - name: Prepare release scripts
+        uses: ./.github/actions/prepare-release-scripts
+
       - name: Download failure results
         uses: actions/download-artifact@v4
         continue-on-error: true
@@ -123,16 +132,15 @@ jobs:
           script: |
             const fs = require('fs');
             const path = require('path');
-            const resultsDir = 'failure-results';
+            const { buildSlackPayload } = require('${{ github.workspace }}/release/dist/index.cjs');
 
-            const failures = { migration: [], e2e: [] };
+            const resultsDir = 'failure-results';
+            const failures = [];
             if (fs.existsSync(resultsDir)) {
               for (const file of fs.readdirSync(resultsDir)) {
                 if (!file.endsWith('.json')) continue;
                 try {
-                  const result = JSON.parse(fs.readFileSync(path.join(resultsDir, file), 'utf8'));
-                  const category = result.phase === 'migration' ? 'migration' : 'e2e';
-                  failures[category].push(result);
+                  failures.push(JSON.parse(fs.readFileSync(path.join(resultsDir, file), 'utf8')));
                 } catch (e) {
                   console.log(`Skipping malformed result: ${file}`);
                 }
@@ -140,50 +148,7 @@ jobs:
             }
 
             const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
-            const sections = [];
-
-            if (failures.migration.length > 0) {
-              const items = failures.migration
-                .map(f => `• ${f.source} → ${f.target} — ${f.detail}`)
-                .join('\n');
-              sections.push({
-                type: 'section',
-                text: { type: 'mrkdwn', text: `:rotating_light: *Migration failures*\n${items}` },
-              });
-            }
-
-            if (failures.e2e.length > 0) {
-              const items = failures.e2e
-                .map(f => `• ${f.source} → ${f.target} — ${f.detail}`)
-                .join('\n');
-              sections.push({
-                type: 'section',
-                text: { type: 'mrkdwn', text: `:test_tube: *E2E failures*\n${items}` },
-              });
-            }
-
-            if (sections.length === 0) {
-              sections.push({
-                type: 'section',
-                text: { type: 'mrkdwn', text: 'One or more matrix jobs failed. Check the workflow run for details.' },
-              });
-            }
-
-            sections.push({
-              type: 'context',
-              elements: [{ type: 'mrkdwn', text: `<${runUrl}|View full run>` }],
-            });
-
-            const payload = {
-              blocks: [
-                {
-                  type: 'header',
-                  text: { type: 'plain_text', text: ':warning: Cross-version tests failing', emoji: true },
-                },
-                ...sections,
-              ],
-            };
-
+            const payload = buildSlackPayload(failures, runUrl);
             core.setOutput('json', JSON.stringify(payload));
 
       - name: Notify Slack

--- a/cross-version/test.sh
+++ b/cross-version/test.sh
@@ -35,9 +35,12 @@ error() { echo -e "${RED}[cross-version]${NC} $*" >&2; }
 write_failure() {
   local phase="$1"  # "migration" or "e2e"
   local detail="$2" # human-readable detail
-  cat > "$RESULT_FILE" <<EOJSON
-{"phase":"${phase}","source":"${SOURCE_VERSION}","target":"${TARGET_VERSION}","detail":"${detail}"}
-EOJSON
+  jq -n \
+    --arg phase "$phase" \
+    --arg source "$SOURCE_VERSION" \
+    --arg target "$TARGET_VERSION" \
+    --arg detail "$detail" \
+    '{phase:$phase, source:$source, target:$target, detail:$detail}' > "$RESULT_FILE"
   log "Wrote failure result to $RESULT_FILE"
 }
 
@@ -234,19 +237,19 @@ migrate_down_step() {
   # Check for errors - Metabase returns 0 even on partial rollback failures
   if [[ $exit_code -ne 0 ]]; then
     error "migrate down failed with exit code $exit_code"
-    MIGRATE_DOWN_FAILURE_DETAIL=$(echo "$output" | grep -o "not rolled back.*" | head -1)
+    MIGRATE_DOWN_FAILURE_DETAIL=$(echo "$output" | grep -o "not rolled back.*" | head -1 || true)
     return 1
   fi
 
   if echo "$output" | grep -q "ERROR.*liquibase\|RollbackFailedException\|Command failed with exception"; then
     error "migrate down encountered errors (check logs above)"
-    MIGRATE_DOWN_FAILURE_DETAIL=$(echo "$output" | grep -o "not rolled back.*" | head -1)
+    MIGRATE_DOWN_FAILURE_DETAIL=$(echo "$output" | grep -o "not rolled back.*" | head -1 || true)
     return 1
   fi
 
   if echo "$output" | grep -q "not rolled back"; then
     error "migrate down had changesets that were not rolled back (check logs above)"
-    MIGRATE_DOWN_FAILURE_DETAIL=$(echo "$output" | grep -o "not rolled back.*" | head -1)
+    MIGRATE_DOWN_FAILURE_DETAIL=$(echo "$output" | grep -o "not rolled back.*" | head -1 || true)
     return 1
   fi
 }

--- a/cross-version/test.sh
+++ b/cross-version/test.sh
@@ -34,13 +34,11 @@ error() { echo -e "${RED}[cross-version]${NC} $*" >&2; }
 # Write a structured result file on failure so CI can categorize the failure
 write_failure() {
   local phase="$1"  # "migration" or "e2e"
-  local detail="$2" # human-readable detail
   jq -n \
     --arg phase "$phase" \
     --arg source "$SOURCE_VERSION" \
     --arg target "$TARGET_VERSION" \
-    --arg detail "$detail" \
-    '{phase:$phase, source:$source, target:$target, detail:$detail}' > "$RESULT_FILE"
+    '{phase:$phase, source:$source, target:$target}' > "$RESULT_FILE"
   log "Wrote failure result to $RESULT_FILE"
 }
 
@@ -237,19 +235,16 @@ migrate_down_step() {
   # Check for errors - Metabase returns 0 even on partial rollback failures
   if [[ $exit_code -ne 0 ]]; then
     error "migrate down failed with exit code $exit_code"
-    MIGRATE_DOWN_FAILURE_DETAIL=$(echo "$output" | grep -o "not rolled back.*" | head -1 || true)
     return 1
   fi
 
   if echo "$output" | grep -q "ERROR.*liquibase\|RollbackFailedException\|Command failed with exception"; then
     error "migrate down encountered errors (check logs above)"
-    MIGRATE_DOWN_FAILURE_DETAIL=$(echo "$output" | grep -o "not rolled back.*" | head -1 || true)
     return 1
   fi
 
   if echo "$output" | grep -q "not rolled back"; then
     error "migrate down had changesets that were not rolled back (check logs above)"
-    MIGRATE_DOWN_FAILURE_DETAIL=$(echo "$output" | grep -o "not rolled back.*" | head -1 || true)
     return 1
   fi
 }
@@ -377,7 +372,7 @@ main() {
   if ! wait_for_health "$HEALTH_TIMEOUT"; then
     error "❌ SOURCE version ($SOURCE_VERSION) failed health check"
     docker compose logs metabase
-    write_failure "migration" "source version failed health check"
+    write_failure "migration"
     exit 1
   fi
 
@@ -386,7 +381,7 @@ main() {
   log ""
   log "Step 2: Running e2e tests (@source)..."
   if ! run_e2e source "$SOURCE_VERSION"; then
-    write_failure "e2e" "e2e tests failed on source version"
+    write_failure "e2e"
     exit 1
   fi
 
@@ -403,7 +398,7 @@ main() {
     if ! wait_for_health "$HEALTH_TIMEOUT"; then
       error "❌ TARGET version ($TARGET_VERSION) failed health check after upgrade"
       docker compose logs metabase
-      write_failure "migration" "upgrade migration failed"
+      write_failure "migration"
       exit 1
     fi
     log "✅ UPGRADE successful - TARGET version ($TARGET_VERSION) is healthy"
@@ -411,7 +406,7 @@ main() {
     log ""
     log "Step 5: Running e2e tests (@target)..."
     if ! run_e2e target "$TARGET_VERSION"; then
-      write_failure "e2e" "e2e tests failed after upgrade"
+      write_failure "e2e"
       exit 1
     fi
 
@@ -420,7 +415,7 @@ main() {
     if ! check_downgrade_refused; then
       error "❌ TARGET version ($TARGET_VERSION) did not properly detect downgrade"
       docker compose logs metabase
-      write_failure "migration" "downgrade not detected"
+      write_failure "migration"
       exit 1
     fi
 
@@ -429,14 +424,9 @@ main() {
 
     log ""
     log "Step 5: Rolling back database ($SOURCE_VERSION → $TARGET_VERSION)..."
-    MIGRATE_DOWN_FAILURE_DETAIL=""
     if ! cascading_migrate_down "$SOURCE_VERSION" "$TARGET_VERSION"; then
       error "❌ migrate down failed"
-      local detail="migrate down failed"
-      if [[ -n "$MIGRATE_DOWN_FAILURE_DETAIL" ]]; then
-        detail="migrate down failed: ${MIGRATE_DOWN_FAILURE_DETAIL}"
-      fi
-      write_failure "migration" "$detail"
+      write_failure "migration"
       exit 1
     fi
 
@@ -448,7 +438,7 @@ main() {
     if ! wait_for_health "$HEALTH_TIMEOUT"; then
       error "❌ TARGET version ($TARGET_VERSION) failed health check after migrate down"
       docker compose logs metabase
-      write_failure "migration" "health check failed after migrate down"
+      write_failure "migration"
       exit 1
     fi
     log "✅ DOWNGRADE successful - TARGET version ($TARGET_VERSION) is healthy after migrate down"
@@ -456,7 +446,7 @@ main() {
     log ""
     log "Step 7: Running e2e tests (@target)..."
     if ! run_e2e target "$TARGET_VERSION"; then
-      write_failure "e2e" "e2e tests failed after downgrade"
+      write_failure "e2e"
       exit 1
     fi
   fi

--- a/cross-version/test.sh
+++ b/cross-version/test.sh
@@ -243,6 +243,12 @@ migrate_down_step() {
     MIGRATE_DOWN_FAILURE_DETAIL=$(echo "$output" | grep -o "not rolled back.*" | head -1)
     return 1
   fi
+
+  if echo "$output" | grep -q "not rolled back"; then
+    error "migrate down had changesets that were not rolled back (check logs above)"
+    MIGRATE_DOWN_FAILURE_DETAIL=$(echo "$output" | grep -o "not rolled back.*" | head -1)
+    return 1
+  fi
 }
 
 # Cascading migrate down: rolls back multiple major versions one at a time

--- a/cross-version/test.sh
+++ b/cross-version/test.sh
@@ -19,6 +19,7 @@ SOURCE_VERSION=""
 TARGET_VERSION=""
 METABASE_PORT="${METABASE_PORT:-3000}"
 HEALTH_TIMEOUT="${HEALTH_TIMEOUT:-120}"
+RESULT_FILE="${RESULT_FILE:-/tmp/cross-version-result.json}"
 
 # Colors for output
 RED='\033[0;31m'
@@ -29,6 +30,16 @@ NC='\033[0m' # No Color
 log() { echo -e "${GREEN}[cross-version]${NC} $*"; }
 warn() { echo -e "${YELLOW}[cross-version]${NC} $*"; }
 error() { echo -e "${RED}[cross-version]${NC} $*" >&2; }
+
+# Write a structured result file on failure so CI can categorize the failure
+write_failure() {
+  local phase="$1"  # "migration" or "e2e"
+  local detail="$2" # human-readable detail
+  cat > "$RESULT_FILE" <<EOJSON
+{"phase":"${phase}","source":"${SOURCE_VERSION}","target":"${TARGET_VERSION}","detail":"${detail}"}
+EOJSON
+  log "Wrote failure result to $RESULT_FILE"
+}
 
 usage() {
   cat <<EOF
@@ -223,11 +234,13 @@ migrate_down_step() {
   # Check for errors - Metabase returns 0 even on partial rollback failures
   if [[ $exit_code -ne 0 ]]; then
     error "migrate down failed with exit code $exit_code"
+    MIGRATE_DOWN_FAILURE_DETAIL=$(echo "$output" | grep -o "not rolled back.*" | head -1)
     return 1
   fi
 
   if echo "$output" | grep -q "ERROR.*liquibase\|RollbackFailedException\|Command failed with exception"; then
     error "migrate down encountered errors (check logs above)"
+    MIGRATE_DOWN_FAILURE_DETAIL=$(echo "$output" | grep -o "not rolled back.*" | head -1)
     return 1
   fi
 }
@@ -355,6 +368,7 @@ main() {
   if ! wait_for_health "$HEALTH_TIMEOUT"; then
     error "❌ SOURCE version ($SOURCE_VERSION) failed health check"
     docker compose logs metabase
+    write_failure "migration" "source version failed health check"
     exit 1
   fi
 
@@ -362,7 +376,10 @@ main() {
 
   log ""
   log "Step 2: Running e2e tests (@source)..."
-  run_e2e source "$SOURCE_VERSION"
+  if ! run_e2e source "$SOURCE_VERSION"; then
+    write_failure "e2e" "e2e tests failed on source version"
+    exit 1
+  fi
 
   log ""
   log "Step 3: Stopping SOURCE version ($SOURCE_VERSION)..."
@@ -377,19 +394,24 @@ main() {
     if ! wait_for_health "$HEALTH_TIMEOUT"; then
       error "❌ TARGET version ($TARGET_VERSION) failed health check after upgrade"
       docker compose logs metabase
+      write_failure "migration" "upgrade migration failed"
       exit 1
     fi
     log "✅ UPGRADE successful - TARGET version ($TARGET_VERSION) is healthy"
 
     log ""
     log "Step 5: Running e2e tests (@target)..."
-    run_e2e target "$TARGET_VERSION"
+    if ! run_e2e target "$TARGET_VERSION"; then
+      write_failure "e2e" "e2e tests failed after upgrade"
+      exit 1
+    fi
 
   else
     # Downgrade: should refuse to start, then we run migrate down
     if ! check_downgrade_refused; then
       error "❌ TARGET version ($TARGET_VERSION) did not properly detect downgrade"
       docker compose logs metabase
+      write_failure "migration" "downgrade not detected"
       exit 1
     fi
 
@@ -398,8 +420,14 @@ main() {
 
     log ""
     log "Step 5: Rolling back database ($SOURCE_VERSION → $TARGET_VERSION)..."
+    MIGRATE_DOWN_FAILURE_DETAIL=""
     if ! cascading_migrate_down "$SOURCE_VERSION" "$TARGET_VERSION"; then
       error "❌ migrate down failed"
+      local detail="migrate down failed"
+      if [[ -n "$MIGRATE_DOWN_FAILURE_DETAIL" ]]; then
+        detail="migrate down failed: ${MIGRATE_DOWN_FAILURE_DETAIL}"
+      fi
+      write_failure "migration" "$detail"
       exit 1
     fi
 
@@ -411,13 +439,17 @@ main() {
     if ! wait_for_health "$HEALTH_TIMEOUT"; then
       error "❌ TARGET version ($TARGET_VERSION) failed health check after migrate down"
       docker compose logs metabase
+      write_failure "migration" "health check failed after migrate down"
       exit 1
     fi
     log "✅ DOWNGRADE successful - TARGET version ($TARGET_VERSION) is healthy after migrate down"
 
     log ""
     log "Step 7: Running e2e tests (@target)..."
-    run_e2e target "$TARGET_VERSION"
+    if ! run_e2e target "$TARGET_VERSION"; then
+      write_failure "e2e" "e2e tests failed after downgrade"
+      exit 1
+    fi
   fi
 
   log ""

--- a/release/src/cross-version-slack.ts
+++ b/release/src/cross-version-slack.ts
@@ -7,7 +7,7 @@
 import { WebClient } from "@slack/web-api";
 
 export interface FailureResult {
-  phase: "migration" | "e2e" | "unknown";
+  phase: "migration" | "e2e";
   source: string;
   target: string;
   detail: string;
@@ -35,7 +35,7 @@ export interface FailedJob {
   url: string;
 }
 
-// Red for migration failures, yellow for e2e-only/unknown
+// Red for migration failures, yellow for e2e
 const COLOR_MIGRATION = "#f85149";
 const COLOR_E2E = "#ffce33";
 
@@ -54,7 +54,7 @@ export const parseJobName = (
 };
 
 /**
- * Build a list of FailureResults from failed jobs and optional artifact data.
+ * Build a list of FailureResults from failed jobs and artifact data.
  * Each failed job becomes a result. Artifact data enriches with phase/detail.
  */
 export const buildFailureResults = (
@@ -65,7 +65,7 @@ export const buildFailureResults = (
     const parsed = parseJobName(job.name);
     if (!parsed) {
       return {
-        phase: "unknown" as const,
+        phase: "e2e" as const,
         source: "?",
         target: "?",
         detail: job.name,
@@ -81,7 +81,7 @@ export const buildFailureResults = (
     }
 
     return {
-      phase: "unknown" as const,
+      phase: "e2e" as const,
       source: parsed.source,
       target: parsed.target,
       detail: "check job logs for details",
@@ -97,65 +97,51 @@ const formatFailureItem = (f: FailureResult): string => {
   return `• ${versions} — ${f.detail}`;
 };
 
+const labelForPhase = (phase: "migration" | "e2e"): string =>
+  phase === "migration"
+    ? ":rotating_light: *Migration failures*"
+    : ":test_tube: *E2E failures*";
+
+const colorForPhase = (phase: "migration" | "e2e"): string =>
+  phase === "migration" ? COLOR_MIGRATION : COLOR_E2E;
+
 export const buildSlackPayload = (
   failures: FailureResult[],
   runUrl: string,
 ): SlackPayload => {
-  const migration = failures.filter(f => f.phase === "migration");
-  const e2e = failures.filter(f => f.phase === "e2e");
-  const unknown = failures.filter(f => f.phase === "unknown");
-
-  const attachmentBlocks: SlackBlock[] = [];
-
-  if (migration.length > 0) {
-    const items = migration.map(formatFailureItem).join("\n");
-    attachmentBlocks.push({
-      type: "section",
-      text: {
-        type: "mrkdwn",
-        text: `:rotating_light: *Migration failures*\n${items}`,
+  const attachments: SlackAttachment[] = failures.map(f => ({
+    color: colorForPhase(f.phase),
+    blocks: [
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: `${labelForPhase(f.phase)}\n${formatFailureItem(f)}`,
+        },
       },
+    ],
+  }));
+
+  if (attachments.length === 0) {
+    attachments.push({
+      color: COLOR_E2E,
+      blocks: [
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: "One or more matrix jobs failed. Check the workflow run for details.",
+          },
+        },
+      ],
     });
   }
 
-  if (e2e.length > 0) {
-    const items = e2e.map(formatFailureItem).join("\n");
-    attachmentBlocks.push({
-      type: "section",
-      text: {
-        type: "mrkdwn",
-        text: `:test_tube: *E2E failures*\n${items}`,
-      },
-    });
-  }
-
-  if (unknown.length > 0) {
-    const items = unknown.map(formatFailureItem).join("\n");
-    attachmentBlocks.push({
-      type: "section",
-      text: {
-        type: "mrkdwn",
-        text: `:warning: *Other failures*\n${items}`,
-      },
-    });
-  }
-
-  if (attachmentBlocks.length === 0) {
-    attachmentBlocks.push({
-      type: "section",
-      text: {
-        type: "mrkdwn",
-        text: "One or more matrix jobs failed. Check the workflow run for details.",
-      },
-    });
-  }
-
-  attachmentBlocks.push({
+  // Add "View full run" to the last attachment
+  attachments[attachments.length - 1].blocks.push({
     type: "context",
     elements: [{ type: "mrkdwn", text: `<${runUrl}|View full run>` }],
   });
-
-  const color = migration.length > 0 ? COLOR_MIGRATION : COLOR_E2E;
 
   return {
     blocks: [
@@ -168,7 +154,7 @@ export const buildSlackPayload = (
         },
       },
     ],
-    attachments: [{ color, blocks: attachmentBlocks }],
+    attachments,
   };
 };
 

--- a/release/src/cross-version-slack.ts
+++ b/release/src/cross-version-slack.ts
@@ -7,10 +7,11 @@
 import { WebClient } from "@slack/web-api";
 
 export interface FailureResult {
-  phase: "migration" | "e2e";
+  phase: "migration" | "e2e" | "unknown";
   source: string;
   target: string;
   detail: string;
+  jobUrl?: string;
 }
 
 interface SlackBlock {
@@ -29,9 +30,72 @@ export interface SlackPayload {
   attachments: SlackAttachment[];
 }
 
-// Red for migration failures, yellow for e2e-only
+export interface FailedJob {
+  name: string;
+  url: string;
+}
+
+// Red for migration failures, yellow for e2e-only/unknown
 const COLOR_MIGRATION = "#f85149";
 const COLOR_E2E = "#ffce33";
+
+/**
+ * Parse source and target versions from a matrix job name.
+ * e.g. "test-matrix (HEAD, v1.59.x)" -> { source: "HEAD", target: "v1.59.x" }
+ */
+export const parseJobName = (
+  name: string,
+): { source: string; target: string } | null => {
+  const match = name.match(/\(([^,]+),\s*([^)]+)\)/);
+  if (!match) {
+    return null;
+  }
+  return { source: match[1], target: match[2] };
+};
+
+/**
+ * Build a list of FailureResults from failed jobs and optional artifact data.
+ * Each failed job becomes a result. Artifact data enriches with phase/detail.
+ */
+export const buildFailureResults = (
+  failedJobs: FailedJob[],
+  artifactData: Map<string, FailureResult>,
+): FailureResult[] => {
+  return failedJobs.map(job => {
+    const parsed = parseJobName(job.name);
+    if (!parsed) {
+      return {
+        phase: "unknown" as const,
+        source: "?",
+        target: "?",
+        detail: job.name,
+        jobUrl: job.url,
+      };
+    }
+
+    const key = `${parsed.source}-${parsed.target}`;
+    const artifact = artifactData.get(key);
+
+    if (artifact) {
+      return { ...artifact, jobUrl: job.url };
+    }
+
+    return {
+      phase: "unknown" as const,
+      source: parsed.source,
+      target: parsed.target,
+      detail: "check job logs for details",
+      jobUrl: job.url,
+    };
+  });
+};
+
+const formatFailureItem = (f: FailureResult): string => {
+  const versions = f.jobUrl
+    ? `<${f.jobUrl}|${f.source} → ${f.target}>`
+    : `${f.source} → ${f.target}`;
+  return `• ${versions} — ${f.detail}`;
+};
 
 export const buildSlackPayload = (
   failures: FailureResult[],
@@ -39,13 +103,12 @@ export const buildSlackPayload = (
 ): SlackPayload => {
   const migration = failures.filter(f => f.phase === "migration");
   const e2e = failures.filter(f => f.phase === "e2e");
+  const unknown = failures.filter(f => f.phase === "unknown");
 
   const attachmentBlocks: SlackBlock[] = [];
 
   if (migration.length > 0) {
-    const items = migration
-      .map(f => `• ${f.source} → ${f.target} — ${f.detail}`)
-      .join("\n");
+    const items = migration.map(formatFailureItem).join("\n");
     attachmentBlocks.push({
       type: "section",
       text: {
@@ -56,14 +119,23 @@ export const buildSlackPayload = (
   }
 
   if (e2e.length > 0) {
-    const items = e2e
-      .map(f => `• ${f.source} → ${f.target} — ${f.detail}`)
-      .join("\n");
+    const items = e2e.map(formatFailureItem).join("\n");
     attachmentBlocks.push({
       type: "section",
       text: {
         type: "mrkdwn",
         text: `:test_tube: *E2E failures*\n${items}`,
+      },
+    });
+  }
+
+  if (unknown.length > 0) {
+    const items = unknown.map(formatFailureItem).join("\n");
+    attachmentBlocks.push({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `:warning: *Other failures*\n${items}`,
       },
     });
   }

--- a/release/src/cross-version-slack.ts
+++ b/release/src/cross-version-slack.ts
@@ -19,9 +19,19 @@ interface SlackBlock {
   elements?: Array<{ type: string; text: string }>;
 }
 
-export interface SlackPayload {
+interface SlackAttachment {
+  color: string;
   blocks: SlackBlock[];
 }
+
+export interface SlackPayload {
+  blocks: SlackBlock[];
+  attachments: SlackAttachment[];
+}
+
+// Red for migration failures, yellow for e2e-only
+const COLOR_MIGRATION = "#f85149";
+const COLOR_E2E = "#ffce33";
 
 export const buildSlackPayload = (
   failures: FailureResult[],
@@ -30,13 +40,13 @@ export const buildSlackPayload = (
   const migration = failures.filter(f => f.phase === "migration");
   const e2e = failures.filter(f => f.phase === "e2e");
 
-  const sections: SlackBlock[] = [];
+  const attachmentBlocks: SlackBlock[] = [];
 
   if (migration.length > 0) {
     const items = migration
       .map(f => `• ${f.source} → ${f.target} — ${f.detail}`)
       .join("\n");
-    sections.push({
+    attachmentBlocks.push({
       type: "section",
       text: {
         type: "mrkdwn",
@@ -49,7 +59,7 @@ export const buildSlackPayload = (
     const items = e2e
       .map(f => `• ${f.source} → ${f.target} — ${f.detail}`)
       .join("\n");
-    sections.push({
+    attachmentBlocks.push({
       type: "section",
       text: {
         type: "mrkdwn",
@@ -58,8 +68,8 @@ export const buildSlackPayload = (
     });
   }
 
-  if (sections.length === 0) {
-    sections.push({
+  if (attachmentBlocks.length === 0) {
+    attachmentBlocks.push({
       type: "section",
       text: {
         type: "mrkdwn",
@@ -68,10 +78,12 @@ export const buildSlackPayload = (
     });
   }
 
-  sections.push({
+  attachmentBlocks.push({
     type: "context",
     elements: [{ type: "mrkdwn", text: `<${runUrl}|View full run>` }],
   });
+
+  const color = migration.length > 0 ? COLOR_MIGRATION : COLOR_E2E;
 
   return {
     blocks: [
@@ -83,8 +95,8 @@ export const buildSlackPayload = (
           emoji: true,
         },
       },
-      ...sections,
     ],
+    attachments: [{ color, blocks: attachmentBlocks }],
   };
 };
 
@@ -95,11 +107,12 @@ export const sendCrossVersionSlackNotification = async (
   channel = "engineering-ci",
 ): Promise<void> => {
   const slack = new WebClient(slackBotToken);
-  const { blocks } = buildSlackPayload(failures, runUrl);
+  const { blocks, attachments } = buildSlackPayload(failures, runUrl);
 
   await slack.chat.postMessage({
     channel,
     text: "Cross-version tests failing",
     blocks,
+    attachments,
   });
 };

--- a/release/src/cross-version-slack.ts
+++ b/release/src/cross-version-slack.ts
@@ -10,7 +10,6 @@ export interface FailureResult {
   phase: "migration" | "e2e";
   source: string;
   target: string;
-  detail: string;
   jobUrl?: string;
 }
 
@@ -45,7 +44,7 @@ export const parseJobName = (
 
 /**
  * Build a list of FailureResults from failed jobs and artifact data.
- * Each failed job becomes a result. Artifact data enriches with phase/detail.
+ * Each failed job becomes a result. Artifact data enriches with phase.
  */
 export const buildFailureResults = (
   failedJobs: FailedJob[],
@@ -58,7 +57,6 @@ export const buildFailureResults = (
         phase: "e2e" as const,
         source: "?",
         target: "?",
-        detail: job.name,
         jobUrl: job.url,
       };
     }
@@ -67,14 +65,13 @@ export const buildFailureResults = (
     const artifact = artifactData.get(key);
 
     if (artifact) {
-      return { ...artifact, jobUrl: job.url };
+      return { phase: artifact.phase, source: artifact.source, target: artifact.target, jobUrl: job.url };
     }
 
     return {
       phase: "e2e" as const,
       source: parsed.source,
       target: parsed.target,
-      detail: "check job logs for details",
       jobUrl: job.url,
     };
   });

--- a/release/src/cross-version-slack.ts
+++ b/release/src/cross-version-slack.ts
@@ -1,9 +1,10 @@
 /**
  * Slack notification helpers for cross-version migration test failures.
  *
- * Pure functions that build Slack Block Kit payloads from structured
- * failure results. Used by the cross-version workflow's notify job.
+ * buildSlackPayload is a pure function (for testability).
+ * sendCrossVersionSlackNotification handles the posting via @slack/web-api.
  */
+import { WebClient } from "@slack/web-api";
 
 export interface FailureResult {
   phase: "migration" | "e2e";
@@ -85,4 +86,20 @@ export const buildSlackPayload = (
       ...sections,
     ],
   };
+};
+
+export const sendCrossVersionSlackNotification = async (
+  failures: FailureResult[],
+  runUrl: string,
+  slackBotToken: string,
+  channel = "engineering-ci",
+): Promise<void> => {
+  const slack = new WebClient(slackBotToken);
+  const { blocks } = buildSlackPayload(failures, runUrl);
+
+  await slack.chat.postMessage({
+    channel,
+    text: "Cross-version tests failing",
+    blocks,
+  });
 };

--- a/release/src/cross-version-slack.ts
+++ b/release/src/cross-version-slack.ts
@@ -20,24 +20,14 @@ interface SlackBlock {
   elements?: Array<{ type: string; text: string }>;
 }
 
-interface SlackAttachment {
-  color: string;
-  blocks: SlackBlock[];
-}
-
 export interface SlackPayload {
   blocks: SlackBlock[];
-  attachments: SlackAttachment[];
 }
 
 export interface FailedJob {
   name: string;
   url: string;
 }
-
-// Red for migration failures, yellow for e2e
-const COLOR_MIGRATION = "#f85149";
-const COLOR_E2E = "#ffce33";
 
 /**
  * Parse source and target versions from a matrix job name.
@@ -94,67 +84,32 @@ const formatFailureItem = (f: FailureResult): string => {
   const versions = f.jobUrl
     ? `<${f.jobUrl}|${f.source} → ${f.target}>`
     : `${f.source} → ${f.target}`;
-  return `• ${versions} — ${f.detail}`;
+  const label = f.phase === "migration" ? "migration failure" : "e2e failure";
+  return `• ${versions} (${label})`;
 };
-
-const labelForPhase = (phase: "migration" | "e2e"): string =>
-  phase === "migration"
-    ? ":rotating_light: *Migration failures*"
-    : ":test_tube: *E2E failures*";
-
-const colorForPhase = (phase: "migration" | "e2e"): string =>
-  phase === "migration" ? COLOR_MIGRATION : COLOR_E2E;
 
 export const buildSlackPayload = (
   failures: FailureResult[],
   runUrl: string,
 ): SlackPayload => {
-  const attachments: SlackAttachment[] = failures.map(f => ({
-    color: colorForPhase(f.phase),
+  const lines = failures.map(formatFailureItem);
+
+  if (lines.length === 0) {
+    lines.push(
+      "One or more matrix jobs failed. Check the workflow run for details.",
+    );
+  }
+
+  return {
     blocks: [
       {
         type: "section",
         text: {
           type: "mrkdwn",
-          text: `${labelForPhase(f.phase)}\n${formatFailureItem(f)}`,
+          text: `:warning: *Cross-version tests failing*\n${lines.join("\n")}\n<${runUrl}|View full run>`,
         },
       },
     ],
-  }));
-
-  if (attachments.length === 0) {
-    attachments.push({
-      color: COLOR_E2E,
-      blocks: [
-        {
-          type: "section",
-          text: {
-            type: "mrkdwn",
-            text: "One or more matrix jobs failed. Check the workflow run for details.",
-          },
-        },
-      ],
-    });
-  }
-
-  // Add "View full run" to the last attachment
-  attachments[attachments.length - 1].blocks.push({
-    type: "context",
-    elements: [{ type: "mrkdwn", text: `<${runUrl}|View full run>` }],
-  });
-
-  return {
-    blocks: [
-      {
-        type: "header",
-        text: {
-          type: "plain_text",
-          text: ":warning: Cross-version tests failing",
-          emoji: true,
-        },
-      },
-    ],
-    attachments,
   };
 };
 
@@ -165,12 +120,11 @@ export const sendCrossVersionSlackNotification = async (
   channel = "engineering-ci",
 ): Promise<void> => {
   const slack = new WebClient(slackBotToken);
-  const { blocks, attachments } = buildSlackPayload(failures, runUrl);
+  const { blocks } = buildSlackPayload(failures, runUrl);
 
   await slack.chat.postMessage({
     channel,
     text: "Cross-version tests failing",
     blocks,
-    attachments,
   });
 };

--- a/release/src/cross-version-slack.ts
+++ b/release/src/cross-version-slack.ts
@@ -1,0 +1,88 @@
+/**
+ * Slack notification helpers for cross-version migration test failures.
+ *
+ * Pure functions that build Slack Block Kit payloads from structured
+ * failure results. Used by the cross-version workflow's notify job.
+ */
+
+export interface FailureResult {
+  phase: "migration" | "e2e";
+  source: string;
+  target: string;
+  detail: string;
+}
+
+interface SlackBlock {
+  type: string;
+  text?: { type: string; text: string; emoji?: boolean };
+  elements?: Array<{ type: string; text: string }>;
+}
+
+export interface SlackPayload {
+  blocks: SlackBlock[];
+}
+
+export const buildSlackPayload = (
+  failures: FailureResult[],
+  runUrl: string,
+): SlackPayload => {
+  const migration = failures.filter(f => f.phase === "migration");
+  const e2e = failures.filter(f => f.phase === "e2e");
+
+  const sections: SlackBlock[] = [];
+
+  if (migration.length > 0) {
+    const items = migration
+      .map(f => `• ${f.source} → ${f.target} — ${f.detail}`)
+      .join("\n");
+    sections.push({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `:rotating_light: *Migration failures*\n${items}`,
+      },
+    });
+  }
+
+  if (e2e.length > 0) {
+    const items = e2e
+      .map(f => `• ${f.source} → ${f.target} — ${f.detail}`)
+      .join("\n");
+    sections.push({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `:test_tube: *E2E failures*\n${items}`,
+      },
+    });
+  }
+
+  if (sections.length === 0) {
+    sections.push({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: "One or more matrix jobs failed. Check the workflow run for details.",
+      },
+    });
+  }
+
+  sections.push({
+    type: "context",
+    elements: [{ type: "mrkdwn", text: `<${runUrl}|View full run>` }],
+  });
+
+  return {
+    blocks: [
+      {
+        type: "header",
+        text: {
+          type: "plain_text",
+          text: ":warning: Cross-version tests failing",
+          emoji: true,
+        },
+      },
+      ...sections,
+    ],
+  };
+};

--- a/release/src/cross-version-slack.unit.spec.ts
+++ b/release/src/cross-version-slack.unit.spec.ts
@@ -41,7 +41,6 @@ describe("cross-version-slack", () => {
             phase: "migration",
             source: "HEAD",
             target: "v1.59.x",
-            detail: "migrate down failed",
           },
         ],
       ]);
@@ -81,7 +80,6 @@ describe("cross-version-slack", () => {
           phase: "e2e",
           source: "v1.58.x",
           target: "HEAD",
-          detail: "e2e tests failed",
           jobUrl: "https://job/2",
         },
       ];

--- a/release/src/cross-version-slack.unit.spec.ts
+++ b/release/src/cross-version-slack.unit.spec.ts
@@ -55,7 +55,7 @@ describe("cross-version-slack", () => {
       expect(results[0].jobUrl).toBe("https://job/1");
     });
 
-    it("falls back to unknown when no artifact exists", () => {
+    it("defaults to e2e phase when no artifact exists", () => {
       const failedJobs: FailedJob[] = [
         { name: "test-matrix (v1.58.x, HEAD)", url: "https://job/2" },
       ];
@@ -63,7 +63,7 @@ describe("cross-version-slack", () => {
       const results = buildFailureResults(failedJobs, new Map());
 
       expect(results).toHaveLength(1);
-      expect(results[0].phase).toBe("unknown");
+      expect(results[0].phase).toBe("e2e");
       expect(results[0].source).toBe("v1.58.x");
       expect(results[0].target).toBe("HEAD");
       expect(results[0].detail).toBe("check job logs for details");
@@ -79,13 +79,11 @@ describe("cross-version-slack", () => {
       const results = buildFailureResults(failedJobs, new Map());
 
       expect(results).toHaveLength(3);
-      expect(results[2].phase).toBe("unknown");
-      expect(results[2].detail).toBe("something-else");
     });
   });
 
   describe("buildSlackPayload", () => {
-    it("categorizes migration and e2e failures separately", () => {
+    it("creates one attachment per failure with correct colors", () => {
       const failures: FailureResult[] = [
         {
           phase: "migration",
@@ -102,16 +100,19 @@ describe("cross-version-slack", () => {
       ];
 
       const payload = buildSlackPayload(failures, RUN_URL);
-      const blocks = payload.attachments[0].blocks;
 
-      expect(blocks).toHaveLength(3); // migration + e2e + context
-      expect(blocks[0].text?.text).toContain("Migration failures");
-      expect(blocks[0].text?.text).toContain("migrate down failed");
-      expect(blocks[1].text?.text).toContain("E2E failures");
-      expect(blocks[1].text?.text).toContain("e2e tests failed after upgrade");
+      expect(payload.attachments).toHaveLength(2);
+      expect(payload.attachments[0].color).toBe("#f85149"); // red
+      expect(payload.attachments[0].blocks[0].text?.text).toContain(
+        "Migration failures",
+      );
+      expect(payload.attachments[1].color).toBe("#ffce33"); // yellow
+      expect(payload.attachments[1].blocks[0].text?.text).toContain(
+        "E2E failures",
+      );
     });
 
-    it("shows only migration section when there are no e2e failures", () => {
+    it("includes changeset detail in migration failure", () => {
       const failures: FailureResult[] = [
         {
           phase: "migration",
@@ -123,78 +124,20 @@ describe("cross-version-slack", () => {
       ];
 
       const payload = buildSlackPayload(failures, RUN_URL);
-      const blocks = payload.attachments[0].blocks;
 
-      expect(blocks).toHaveLength(2); // migration + context
-      expect(blocks[0].text?.text).toContain("Migration failures");
-      expect(blocks[0].text?.text).toContain("not rolled back");
-    });
-
-    it("shows only e2e section when there are no migration failures", () => {
-      const failures: FailureResult[] = [
-        {
-          phase: "e2e",
-          source: "v1.58.x",
-          target: "HEAD",
-          detail: "e2e tests failed after upgrade",
-        },
-      ];
-
-      const payload = buildSlackPayload(failures, RUN_URL);
-      const blocks = payload.attachments[0].blocks;
-
-      expect(blocks).toHaveLength(2); // e2e + context
-      expect(blocks[0].text?.text).toContain("E2E failures");
-    });
-
-    it("shows unknown failures in a separate section", () => {
-      const failures: FailureResult[] = [
-        {
-          phase: "unknown",
-          source: "HEAD",
-          target: "v1.58.x",
-          detail: "check job logs for details",
-        },
-      ];
-
-      const payload = buildSlackPayload(failures, RUN_URL);
-      const blocks = payload.attachments[0].blocks;
-
-      expect(blocks).toHaveLength(2); // unknown + context
-      expect(blocks[0].text?.text).toContain("Other failures");
+      expect(payload.attachments).toHaveLength(1);
+      expect(payload.attachments[0].blocks[0].text?.text).toContain(
+        "not rolled back",
+      );
     });
 
     it("shows generic message when no failures exist", () => {
       const payload = buildSlackPayload([], RUN_URL);
-      const blocks = payload.attachments[0].blocks;
 
-      expect(blocks).toHaveLength(2); // generic + context
-      expect(blocks[0].text?.text).toContain(
+      expect(payload.attachments).toHaveLength(1);
+      expect(payload.attachments[0].blocks[0].text?.text).toContain(
         "One or more matrix jobs failed",
       );
-    });
-
-    it("groups multiple failures of the same type", () => {
-      const failures: FailureResult[] = [
-        {
-          phase: "migration",
-          source: "HEAD",
-          target: "v1.57.x",
-          detail: "migrate down failed",
-        },
-        {
-          phase: "migration",
-          source: "HEAD",
-          target: "v1.58.x",
-          detail: "migrate down failed",
-        },
-      ];
-
-      const payload = buildSlackPayload(failures, RUN_URL);
-      const migrationBlock = payload.attachments[0].blocks[0];
-
-      expect(migrationBlock.text?.text).toContain("v1.57.x");
-      expect(migrationBlock.text?.text).toContain("v1.58.x");
     });
 
     it("includes job URLs as links when provided", () => {
@@ -204,24 +147,44 @@ describe("cross-version-slack", () => {
           source: "HEAD",
           target: "v1.59.x",
           detail: "migrate down failed",
-          jobUrl: "https://github.com/metabase/metabase/actions/runs/123/job/456",
+          jobUrl:
+            "https://github.com/metabase/metabase/actions/runs/123/job/456",
         },
       ];
 
       const payload = buildSlackPayload(failures, RUN_URL);
-      const block = payload.attachments[0].blocks[0];
 
-      expect(block.text?.text).toContain("<https://github.com/metabase/metabase/actions/runs/123/job/456|HEAD → v1.59.x>");
+      expect(payload.attachments[0].blocks[0].text?.text).toContain(
+        "<https://github.com/metabase/metabase/actions/runs/123/job/456|HEAD → v1.59.x>",
+      );
     });
 
-    it("includes a link to the workflow run", () => {
-      const payload = buildSlackPayload([], RUN_URL);
-      const blocks = payload.attachments[0].blocks;
-      const contextBlock = blocks[blocks.length - 1];
+    it("appends 'View full run' to the last attachment", () => {
+      const failures: FailureResult[] = [
+        {
+          phase: "migration",
+          source: "HEAD",
+          target: "v1.57.x",
+          detail: "migrate down failed",
+        },
+        {
+          phase: "e2e",
+          source: "v1.58.x",
+          target: "HEAD",
+          detail: "e2e tests failed",
+        },
+      ];
 
-      expect(contextBlock.type).toBe("context");
-      expect(contextBlock.elements?.[0].text).toContain(RUN_URL);
-      expect(contextBlock.elements?.[0].text).toContain("View full run");
+      const payload = buildSlackPayload(failures, RUN_URL);
+
+      // First attachment: no context block
+      expect(payload.attachments[0].blocks).toHaveLength(1);
+      // Last attachment: has context block
+      const lastAttachment =
+        payload.attachments[payload.attachments.length - 1];
+      const lastBlock = lastAttachment.blocks[lastAttachment.blocks.length - 1];
+      expect(lastBlock.type).toBe("context");
+      expect(lastBlock.elements?.[0].text).toContain("View full run");
     });
 
     it("always starts with a header block", () => {
@@ -235,54 +198,6 @@ describe("cross-version-slack", () => {
           emoji: true,
         },
       });
-    });
-
-    it("uses red color when there are migration failures", () => {
-      const failures: FailureResult[] = [
-        {
-          phase: "migration",
-          source: "HEAD",
-          target: "v1.57.x",
-          detail: "migrate down failed",
-        },
-      ];
-
-      const payload = buildSlackPayload(failures, RUN_URL);
-      expect(payload.attachments[0].color).toBe("#f85149");
-    });
-
-    it("uses yellow color for e2e-only failures", () => {
-      const failures: FailureResult[] = [
-        {
-          phase: "e2e",
-          source: "v1.58.x",
-          target: "HEAD",
-          detail: "e2e tests failed after upgrade",
-        },
-      ];
-
-      const payload = buildSlackPayload(failures, RUN_URL);
-      expect(payload.attachments[0].color).toBe("#ffce33");
-    });
-
-    it("uses red color when both migration and e2e failures exist", () => {
-      const failures: FailureResult[] = [
-        {
-          phase: "migration",
-          source: "HEAD",
-          target: "v1.57.x",
-          detail: "migrate down failed",
-        },
-        {
-          phase: "e2e",
-          source: "v1.58.x",
-          target: "HEAD",
-          detail: "e2e tests failed after upgrade",
-        },
-      ];
-
-      const payload = buildSlackPayload(failures, RUN_URL);
-      expect(payload.attachments[0].color).toBe("#f85149");
     });
   });
 });

--- a/release/src/cross-version-slack.unit.spec.ts
+++ b/release/src/cross-version-slack.unit.spec.ts
@@ -1,8 +1,89 @@
-import { buildSlackPayload, type FailureResult } from "./cross-version-slack";
+import {
+  buildFailureResults,
+  buildSlackPayload,
+  parseJobName,
+  type FailedJob,
+  type FailureResult,
+} from "./cross-version-slack";
 
 const RUN_URL = "https://github.com/metabase/metabase/actions/runs/12345";
 
 describe("cross-version-slack", () => {
+  describe("parseJobName", () => {
+    it("parses source and target from matrix job name", () => {
+      expect(parseJobName("test-matrix (HEAD, v1.59.x)")).toEqual({
+        source: "HEAD",
+        target: "v1.59.x",
+      });
+    });
+
+    it("handles version-to-HEAD format", () => {
+      expect(parseJobName("test-matrix (v1.58.x, HEAD)")).toEqual({
+        source: "v1.58.x",
+        target: "HEAD",
+      });
+    });
+
+    it("returns null for unparseable names", () => {
+      expect(parseJobName("generate-matrix")).toBeNull();
+      expect(parseJobName("notify-on-failure")).toBeNull();
+    });
+  });
+
+  describe("buildFailureResults", () => {
+    it("enriches jobs with artifact data when available", () => {
+      const failedJobs: FailedJob[] = [
+        { name: "test-matrix (HEAD, v1.59.x)", url: "https://job/1" },
+      ];
+      const artifactData = new Map<string, FailureResult>([
+        [
+          "HEAD-v1.59.x",
+          {
+            phase: "migration",
+            source: "HEAD",
+            target: "v1.59.x",
+            detail: "migrate down failed: not rolled back",
+          },
+        ],
+      ]);
+
+      const results = buildFailureResults(failedJobs, artifactData);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].phase).toBe("migration");
+      expect(results[0].detail).toBe("migrate down failed: not rolled back");
+      expect(results[0].jobUrl).toBe("https://job/1");
+    });
+
+    it("falls back to unknown when no artifact exists", () => {
+      const failedJobs: FailedJob[] = [
+        { name: "test-matrix (v1.58.x, HEAD)", url: "https://job/2" },
+      ];
+
+      const results = buildFailureResults(failedJobs, new Map());
+
+      expect(results).toHaveLength(1);
+      expect(results[0].phase).toBe("unknown");
+      expect(results[0].source).toBe("v1.58.x");
+      expect(results[0].target).toBe("HEAD");
+      expect(results[0].detail).toBe("check job logs for details");
+    });
+
+    it("handles all failed jobs including those without parseable names", () => {
+      const failedJobs: FailedJob[] = [
+        { name: "test-matrix (HEAD, v1.59.x)", url: "https://job/1" },
+        { name: "test-matrix (v1.58.x, HEAD)", url: "https://job/2" },
+        { name: "something-else", url: "https://job/3" },
+      ];
+
+      const results = buildFailureResults(failedJobs, new Map());
+
+      expect(results).toHaveLength(3);
+      expect(results[2].phase).toBe("unknown");
+      expect(results[2].detail).toBe("something-else");
+    });
+  });
+
   describe("buildSlackPayload", () => {
     it("categorizes migration and e2e failures separately", () => {
       const failures: FailureResult[] = [
@@ -25,13 +106,9 @@ describe("cross-version-slack", () => {
 
       expect(blocks).toHaveLength(3); // migration + e2e + context
       expect(blocks[0].text?.text).toContain("Migration failures");
-      expect(blocks[0].text?.text).toContain(
-        "HEAD → v1.57.x — migrate down failed",
-      );
+      expect(blocks[0].text?.text).toContain("migrate down failed");
       expect(blocks[1].text?.text).toContain("E2E failures");
-      expect(blocks[1].text?.text).toContain(
-        "v1.58.x → HEAD — e2e tests failed after upgrade",
-      );
+      expect(blocks[1].text?.text).toContain("e2e tests failed after upgrade");
     });
 
     it("shows only migration section when there are no e2e failures", () => {
@@ -40,7 +117,8 @@ describe("cross-version-slack", () => {
           phase: "migration",
           source: "HEAD",
           target: "v1.59.x",
-          detail: "migrate down failed: not rolled back. Likely because they are not in the changelog file: v59.2026-03-17T10:30:03",
+          detail:
+            "migrate down failed: not rolled back. Likely because they are not in the changelog file: v59.2026-03-17T10:30:03",
         },
       ];
 
@@ -69,7 +147,24 @@ describe("cross-version-slack", () => {
       expect(blocks[0].text?.text).toContain("E2E failures");
     });
 
-    it("shows generic message when no categorized failures exist", () => {
+    it("shows unknown failures in a separate section", () => {
+      const failures: FailureResult[] = [
+        {
+          phase: "unknown",
+          source: "HEAD",
+          target: "v1.58.x",
+          detail: "check job logs for details",
+        },
+      ];
+
+      const payload = buildSlackPayload(failures, RUN_URL);
+      const blocks = payload.attachments[0].blocks;
+
+      expect(blocks).toHaveLength(2); // unknown + context
+      expect(blocks[0].text?.text).toContain("Other failures");
+    });
+
+    it("shows generic message when no failures exist", () => {
       const payload = buildSlackPayload([], RUN_URL);
       const blocks = payload.attachments[0].blocks;
 
@@ -98,8 +193,25 @@ describe("cross-version-slack", () => {
       const payload = buildSlackPayload(failures, RUN_URL);
       const migrationBlock = payload.attachments[0].blocks[0];
 
-      expect(migrationBlock.text?.text).toContain("HEAD → v1.57.x");
-      expect(migrationBlock.text?.text).toContain("HEAD → v1.58.x");
+      expect(migrationBlock.text?.text).toContain("v1.57.x");
+      expect(migrationBlock.text?.text).toContain("v1.58.x");
+    });
+
+    it("includes job URLs as links when provided", () => {
+      const failures: FailureResult[] = [
+        {
+          phase: "migration",
+          source: "HEAD",
+          target: "v1.59.x",
+          detail: "migrate down failed",
+          jobUrl: "https://github.com/metabase/metabase/actions/runs/123/job/456",
+        },
+      ];
+
+      const payload = buildSlackPayload(failures, RUN_URL);
+      const block = payload.attachments[0].blocks[0];
+
+      expect(block.text?.text).toContain("<https://github.com/metabase/metabase/actions/runs/123/job/456|HEAD → v1.59.x>");
     });
 
     it("includes a link to the workflow run", () => {

--- a/release/src/cross-version-slack.unit.spec.ts
+++ b/release/src/cross-version-slack.unit.spec.ts
@@ -1,0 +1,123 @@
+import { buildSlackPayload, type FailureResult } from "./cross-version-slack";
+
+const RUN_URL = "https://github.com/metabase/metabase/actions/runs/12345";
+
+describe("cross-version-slack", () => {
+  describe("buildSlackPayload", () => {
+    it("categorizes migration and e2e failures separately", () => {
+      const failures: FailureResult[] = [
+        {
+          phase: "migration",
+          source: "HEAD",
+          target: "v1.57.x",
+          detail: "migrate down failed",
+        },
+        {
+          phase: "e2e",
+          source: "v1.58.x",
+          target: "HEAD",
+          detail: "e2e tests failed after upgrade",
+        },
+      ];
+
+      const payload = buildSlackPayload(failures, RUN_URL);
+
+      expect(payload.blocks).toHaveLength(4); // header + migration + e2e + context
+      expect(payload.blocks[1].text?.text).toContain("Migration failures");
+      expect(payload.blocks[1].text?.text).toContain(
+        "HEAD → v1.57.x — migrate down failed",
+      );
+      expect(payload.blocks[2].text?.text).toContain("E2E failures");
+      expect(payload.blocks[2].text?.text).toContain(
+        "v1.58.x → HEAD — e2e tests failed after upgrade",
+      );
+    });
+
+    it("shows only migration section when there are no e2e failures", () => {
+      const failures: FailureResult[] = [
+        {
+          phase: "migration",
+          source: "HEAD",
+          target: "v1.59.x",
+          detail: "migrate down failed: not rolled back. Likely because they are not in the changelog file: v59.2026-03-17T10:30:03",
+        },
+      ];
+
+      const payload = buildSlackPayload(failures, RUN_URL);
+
+      expect(payload.blocks).toHaveLength(3); // header + migration + context
+      expect(payload.blocks[1].text?.text).toContain("Migration failures");
+      expect(payload.blocks[1].text?.text).toContain("not rolled back");
+    });
+
+    it("shows only e2e section when there are no migration failures", () => {
+      const failures: FailureResult[] = [
+        {
+          phase: "e2e",
+          source: "v1.58.x",
+          target: "HEAD",
+          detail: "e2e tests failed after upgrade",
+        },
+      ];
+
+      const payload = buildSlackPayload(failures, RUN_URL);
+
+      expect(payload.blocks).toHaveLength(3); // header + e2e + context
+      expect(payload.blocks[1].text?.text).toContain("E2E failures");
+    });
+
+    it("shows generic message when no categorized failures exist", () => {
+      const payload = buildSlackPayload([], RUN_URL);
+
+      expect(payload.blocks).toHaveLength(3); // header + generic + context
+      expect(payload.blocks[1].text?.text).toContain(
+        "One or more matrix jobs failed",
+      );
+    });
+
+    it("groups multiple failures of the same type", () => {
+      const failures: FailureResult[] = [
+        {
+          phase: "migration",
+          source: "HEAD",
+          target: "v1.57.x",
+          detail: "migrate down failed",
+        },
+        {
+          phase: "migration",
+          source: "HEAD",
+          target: "v1.58.x",
+          detail: "migrate down failed",
+        },
+      ];
+
+      const payload = buildSlackPayload(failures, RUN_URL);
+      const migrationBlock = payload.blocks[1];
+
+      expect(migrationBlock.text?.text).toContain("HEAD → v1.57.x");
+      expect(migrationBlock.text?.text).toContain("HEAD → v1.58.x");
+    });
+
+    it("includes a link to the workflow run", () => {
+      const payload = buildSlackPayload([], RUN_URL);
+      const contextBlock = payload.blocks[payload.blocks.length - 1];
+
+      expect(contextBlock.type).toBe("context");
+      expect(contextBlock.elements?.[0].text).toContain(RUN_URL);
+      expect(contextBlock.elements?.[0].text).toContain("View full run");
+    });
+
+    it("always starts with a header block", () => {
+      const payload = buildSlackPayload([], RUN_URL);
+
+      expect(payload.blocks[0]).toEqual({
+        type: "header",
+        text: {
+          type: "plain_text",
+          text: ":warning: Cross-version tests failing",
+          emoji: true,
+        },
+      });
+    });
+  });
+});

--- a/release/src/cross-version-slack.unit.spec.ts
+++ b/release/src/cross-version-slack.unit.spec.ts
@@ -73,7 +73,6 @@ describe("cross-version-slack", () => {
           phase: "migration",
           source: "HEAD",
           target: "v1.59.x",
-          detail: "migrate down failed",
           jobUrl: "https://job/1",
         },
         {
@@ -106,7 +105,6 @@ describe("cross-version-slack", () => {
           phase: "migration",
           source: "HEAD",
           target: "v1.59.x",
-          detail: "migrate down failed",
         },
       ];
 

--- a/release/src/cross-version-slack.unit.spec.ts
+++ b/release/src/cross-version-slack.unit.spec.ts
@@ -21,14 +21,15 @@ describe("cross-version-slack", () => {
       ];
 
       const payload = buildSlackPayload(failures, RUN_URL);
+      const blocks = payload.attachments[0].blocks;
 
-      expect(payload.blocks).toHaveLength(4); // header + migration + e2e + context
-      expect(payload.blocks[1].text?.text).toContain("Migration failures");
-      expect(payload.blocks[1].text?.text).toContain(
+      expect(blocks).toHaveLength(3); // migration + e2e + context
+      expect(blocks[0].text?.text).toContain("Migration failures");
+      expect(blocks[0].text?.text).toContain(
         "HEAD → v1.57.x — migrate down failed",
       );
-      expect(payload.blocks[2].text?.text).toContain("E2E failures");
-      expect(payload.blocks[2].text?.text).toContain(
+      expect(blocks[1].text?.text).toContain("E2E failures");
+      expect(blocks[1].text?.text).toContain(
         "v1.58.x → HEAD — e2e tests failed after upgrade",
       );
     });
@@ -44,10 +45,11 @@ describe("cross-version-slack", () => {
       ];
 
       const payload = buildSlackPayload(failures, RUN_URL);
+      const blocks = payload.attachments[0].blocks;
 
-      expect(payload.blocks).toHaveLength(3); // header + migration + context
-      expect(payload.blocks[1].text?.text).toContain("Migration failures");
-      expect(payload.blocks[1].text?.text).toContain("not rolled back");
+      expect(blocks).toHaveLength(2); // migration + context
+      expect(blocks[0].text?.text).toContain("Migration failures");
+      expect(blocks[0].text?.text).toContain("not rolled back");
     });
 
     it("shows only e2e section when there are no migration failures", () => {
@@ -61,16 +63,18 @@ describe("cross-version-slack", () => {
       ];
 
       const payload = buildSlackPayload(failures, RUN_URL);
+      const blocks = payload.attachments[0].blocks;
 
-      expect(payload.blocks).toHaveLength(3); // header + e2e + context
-      expect(payload.blocks[1].text?.text).toContain("E2E failures");
+      expect(blocks).toHaveLength(2); // e2e + context
+      expect(blocks[0].text?.text).toContain("E2E failures");
     });
 
     it("shows generic message when no categorized failures exist", () => {
       const payload = buildSlackPayload([], RUN_URL);
+      const blocks = payload.attachments[0].blocks;
 
-      expect(payload.blocks).toHaveLength(3); // header + generic + context
-      expect(payload.blocks[1].text?.text).toContain(
+      expect(blocks).toHaveLength(2); // generic + context
+      expect(blocks[0].text?.text).toContain(
         "One or more matrix jobs failed",
       );
     });
@@ -92,7 +96,7 @@ describe("cross-version-slack", () => {
       ];
 
       const payload = buildSlackPayload(failures, RUN_URL);
-      const migrationBlock = payload.blocks[1];
+      const migrationBlock = payload.attachments[0].blocks[0];
 
       expect(migrationBlock.text?.text).toContain("HEAD → v1.57.x");
       expect(migrationBlock.text?.text).toContain("HEAD → v1.58.x");
@@ -100,7 +104,8 @@ describe("cross-version-slack", () => {
 
     it("includes a link to the workflow run", () => {
       const payload = buildSlackPayload([], RUN_URL);
-      const contextBlock = payload.blocks[payload.blocks.length - 1];
+      const blocks = payload.attachments[0].blocks;
+      const contextBlock = blocks[blocks.length - 1];
 
       expect(contextBlock.type).toBe("context");
       expect(contextBlock.elements?.[0].text).toContain(RUN_URL);
@@ -118,6 +123,54 @@ describe("cross-version-slack", () => {
           emoji: true,
         },
       });
+    });
+
+    it("uses red color when there are migration failures", () => {
+      const failures: FailureResult[] = [
+        {
+          phase: "migration",
+          source: "HEAD",
+          target: "v1.57.x",
+          detail: "migrate down failed",
+        },
+      ];
+
+      const payload = buildSlackPayload(failures, RUN_URL);
+      expect(payload.attachments[0].color).toBe("#f85149");
+    });
+
+    it("uses yellow color for e2e-only failures", () => {
+      const failures: FailureResult[] = [
+        {
+          phase: "e2e",
+          source: "v1.58.x",
+          target: "HEAD",
+          detail: "e2e tests failed after upgrade",
+        },
+      ];
+
+      const payload = buildSlackPayload(failures, RUN_URL);
+      expect(payload.attachments[0].color).toBe("#ffce33");
+    });
+
+    it("uses red color when both migration and e2e failures exist", () => {
+      const failures: FailureResult[] = [
+        {
+          phase: "migration",
+          source: "HEAD",
+          target: "v1.57.x",
+          detail: "migrate down failed",
+        },
+        {
+          phase: "e2e",
+          source: "v1.58.x",
+          target: "HEAD",
+          detail: "e2e tests failed after upgrade",
+        },
+      ];
+
+      const payload = buildSlackPayload(failures, RUN_URL);
+      expect(payload.attachments[0].color).toBe("#f85149");
     });
   });
 });

--- a/release/src/cross-version-slack.unit.spec.ts
+++ b/release/src/cross-version-slack.unit.spec.ts
@@ -26,7 +26,6 @@ describe("cross-version-slack", () => {
 
     it("returns null for unparseable names", () => {
       expect(parseJobName("generate-matrix")).toBeNull();
-      expect(parseJobName("notify-on-failure")).toBeNull();
     });
   });
 
@@ -42,7 +41,7 @@ describe("cross-version-slack", () => {
             phase: "migration",
             source: "HEAD",
             target: "v1.59.x",
-            detail: "migrate down failed: not rolled back",
+            detail: "migrate down failed",
           },
         ],
       ]);
@@ -51,7 +50,6 @@ describe("cross-version-slack", () => {
 
       expect(results).toHaveLength(1);
       expect(results[0].phase).toBe("migration");
-      expect(results[0].detail).toBe("migrate down failed: not rolled back");
       expect(results[0].jobUrl).toBe("https://job/1");
     });
 
@@ -66,138 +64,56 @@ describe("cross-version-slack", () => {
       expect(results[0].phase).toBe("e2e");
       expect(results[0].source).toBe("v1.58.x");
       expect(results[0].target).toBe("HEAD");
-      expect(results[0].detail).toBe("check job logs for details");
-    });
-
-    it("handles all failed jobs including those without parseable names", () => {
-      const failedJobs: FailedJob[] = [
-        { name: "test-matrix (HEAD, v1.59.x)", url: "https://job/1" },
-        { name: "test-matrix (v1.58.x, HEAD)", url: "https://job/2" },
-        { name: "something-else", url: "https://job/3" },
-      ];
-
-      const results = buildFailureResults(failedJobs, new Map());
-
-      expect(results).toHaveLength(3);
     });
   });
 
   describe("buildSlackPayload", () => {
-    it("creates one attachment per failure with correct colors", () => {
-      const failures: FailureResult[] = [
-        {
-          phase: "migration",
-          source: "HEAD",
-          target: "v1.57.x",
-          detail: "migrate down failed",
-        },
-        {
-          phase: "e2e",
-          source: "v1.58.x",
-          target: "HEAD",
-          detail: "e2e tests failed after upgrade",
-        },
-      ];
-
-      const payload = buildSlackPayload(failures, RUN_URL);
-
-      expect(payload.attachments).toHaveLength(2);
-      expect(payload.attachments[0].color).toBe("#f85149"); // red
-      expect(payload.attachments[0].blocks[0].text?.text).toContain(
-        "Migration failures",
-      );
-      expect(payload.attachments[1].color).toBe("#ffce33"); // yellow
-      expect(payload.attachments[1].blocks[0].text?.text).toContain(
-        "E2E failures",
-      );
-    });
-
-    it("includes changeset detail in migration failure", () => {
-      const failures: FailureResult[] = [
-        {
-          phase: "migration",
-          source: "HEAD",
-          target: "v1.59.x",
-          detail:
-            "migrate down failed: not rolled back. Likely because they are not in the changelog file: v59.2026-03-17T10:30:03",
-        },
-      ];
-
-      const payload = buildSlackPayload(failures, RUN_URL);
-
-      expect(payload.attachments).toHaveLength(1);
-      expect(payload.attachments[0].blocks[0].text?.text).toContain(
-        "not rolled back",
-      );
-    });
-
-    it("shows generic message when no failures exist", () => {
-      const payload = buildSlackPayload([], RUN_URL);
-
-      expect(payload.attachments).toHaveLength(1);
-      expect(payload.attachments[0].blocks[0].text?.text).toContain(
-        "One or more matrix jobs failed",
-      );
-    });
-
-    it("includes job URLs as links when provided", () => {
+    it("lists failures with phase labels", () => {
       const failures: FailureResult[] = [
         {
           phase: "migration",
           source: "HEAD",
           target: "v1.59.x",
           detail: "migrate down failed",
-          jobUrl:
-            "https://github.com/metabase/metabase/actions/runs/123/job/456",
-        },
-      ];
-
-      const payload = buildSlackPayload(failures, RUN_URL);
-
-      expect(payload.attachments[0].blocks[0].text?.text).toContain(
-        "<https://github.com/metabase/metabase/actions/runs/123/job/456|HEAD → v1.59.x>",
-      );
-    });
-
-    it("appends 'View full run' to the last attachment", () => {
-      const failures: FailureResult[] = [
-        {
-          phase: "migration",
-          source: "HEAD",
-          target: "v1.57.x",
-          detail: "migrate down failed",
+          jobUrl: "https://job/1",
         },
         {
           phase: "e2e",
           source: "v1.58.x",
           target: "HEAD",
           detail: "e2e tests failed",
+          jobUrl: "https://job/2",
         },
       ];
 
       const payload = buildSlackPayload(failures, RUN_URL);
+      const text = payload.blocks[0].text?.text ?? "";
 
-      // First attachment: no context block
-      expect(payload.attachments[0].blocks).toHaveLength(1);
-      // Last attachment: has context block
-      const lastAttachment =
-        payload.attachments[payload.attachments.length - 1];
-      const lastBlock = lastAttachment.blocks[lastAttachment.blocks.length - 1];
-      expect(lastBlock.type).toBe("context");
-      expect(lastBlock.elements?.[0].text).toContain("View full run");
+      expect(text).toContain("Cross-version tests failing");
+      expect(text).toContain("<https://job/1|HEAD → v1.59.x> (migration failure)");
+      expect(text).toContain("<https://job/2|v1.58.x → HEAD> (e2e failure)");
+      expect(text).toContain("View full run");
     });
 
-    it("always starts with a header block", () => {
+    it("shows generic message when no failures exist", () => {
       const payload = buildSlackPayload([], RUN_URL);
+      const text = payload.blocks[0].text?.text ?? "";
 
-      expect(payload.blocks[0]).toEqual({
-        type: "header",
-        text: {
-          type: "plain_text",
-          text: ":warning: Cross-version tests failing",
-          emoji: true,
+      expect(text).toContain("One or more matrix jobs failed");
+    });
+
+    it("renders as a single block", () => {
+      const failures: FailureResult[] = [
+        {
+          phase: "migration",
+          source: "HEAD",
+          target: "v1.59.x",
+          detail: "migrate down failed",
         },
-      });
+      ];
+
+      const payload = buildSlackPayload(failures, RUN_URL);
+      expect(payload.blocks).toHaveLength(1);
     });
   });
 });

--- a/release/src/index.ts
+++ b/release/src/index.ts
@@ -7,3 +7,4 @@ export * from "./release-status";
 export * from "./slack";
 export * from "./version-helpers";
 export * from "./version-info";
+export * from "./cross-version-slack";


### PR DESCRIPTION
Resolves DEV-1671

## Summary
Notify Slack CI channel (only) when nightly cross-version migration tests fail. This does not trigger for manual (workflow_dispatch) runs.

The notification queries the GitHub API for all failed matrix jobs so nothing gets missed, then enriches with structured result data from each job.

The notify job uses `@slack/web-api` via the release scripts bundle (no extra dependencies) and runs with `continue-on-error` so it can never break the workflow itself.

### Real-world example

- https://metaboat.slack.com/archives/C01BWAZJE0N/p1774558540971219

<img width="460" height="190" alt="image" src="https://github.com/user-attachments/assets/5647b49c-35e4-4884-8de1-e80e0dbbb25a" />

