### PR TITLE
Handle non-dates in sqlite date columns

### DIFF
--- a/modules/drivers/sqlite/src/metabase/driver/sqlite.clj
+++ b/modules/drivers/sqlite/src/metabase/driver/sqlite.clj
@@ -517,7 +517,7 @@
         ;; For other types, fallback to sqlite-jdbc's parser
         ;; Even in DATE column, it is possible to put DATETIME, so always treat as DATETIME
         (some? obj) (t/local-date-time (.getTimestamp rs i)))
-      (catch Exception e
+      (catch Exception _
         ;; Just return the object as is if we are unable to parse it as a date.
         ;; This can happen when there are non-date objects in the column (#71205).
         obj))))

--- a/modules/drivers/sqlite/src/metabase/driver/sqlite.clj
+++ b/modules/drivers/sqlite/src/metabase/driver/sqlite.clj
@@ -510,12 +510,17 @@
 (defn- sqlite-handle-timestamp
   [^ResultSet rs ^Integer i]
   (let [obj (.getObject rs i)]
-    (cond
-      ;; For strings, use our own parser which is more flexible than sqlite-jdbc's and handles timezones correctly
-      (instance? String obj) (u.date/parse obj)
-      ;; For other types, fallback to sqlite-jdbc's parser
-      ;; Even in DATE column, it is possible to put DATETIME, so always treat as DATETIME
-      (some? obj) (t/local-date-time (.getTimestamp rs i)))))
+    (try
+      (cond
+        ;; For strings, use our own parser which is more flexible than sqlite-jdbc's and handles timezones correctly
+        (instance? String obj) (u.date/parse obj)
+        ;; For other types, fallback to sqlite-jdbc's parser
+        ;; Even in DATE column, it is possible to put DATETIME, so always treat as DATETIME
+        (some? obj) (t/local-date-time (.getTimestamp rs i)))
+      (catch Exception e
+        ;; Just return the object as is if we are unable to parse it as a date.
+        ;; This can happen when there are non-date objects in the column (#71205).
+        obj))))
 
 (defmethod sql-jdbc.execute/read-column-thunk [:sqlite Types/DATE]
   [_ ^ResultSet rs _ ^Integer i]

--- a/modules/drivers/sqlite/test/metabase/driver/sqlite_test.clj
+++ b/modules/drivers/sqlite/test/metabase/driver/sqlite_test.clj
@@ -6,6 +6,8 @@
    [metabase.driver :as driver]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql.query-processor-test-util :as sql.qp-test-util]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
    [metabase.query-processor.test :as qp]
    [metabase.sync.core :as sync]
    [metabase.test :as mt]
@@ -254,3 +256,23 @@
                clojure.lang.ExceptionInfo
                #"SQL error or missing database \(no such table: fdw_test\.products\)"
                (qp/process-query (mt/native-query {:query "SELECT count(*) FROM fdw_test.products;"})))))))))
+
+(deftest ^:parallel non-date-in-date-columns-are-returned-test
+  (mt/test-driver :sqlite
+    (mt/dataset (mt/dataset-definition
+                 "sqlite_mixed_dates"
+                 [["mixed_dates_table"
+                   [{:field-name "dates"
+                     :base-type :type/Date}]
+                   [["2026-01-01"]
+                    ["not available"]
+                    ["2026-03-01"]]]])
+      (let [mp (mt/metadata-provider)]
+        (is (= [[1 "2026-01-01T00:00:00Z"]
+                [2 "not available"]
+                [3 "2026-03-01T00:00:00Z"]]
+               (->> (mt/id :mixed_dates_table)
+                    (lib.metadata/table mp)
+                    (lib/query mp)
+                    (qp/process-query)
+                    (mt/rows))))))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/71205

### Description

SQLite doesn't have a dedicated date/time type, so you can store non-date values in a column that we try to parse as a date. This would throw and prevent the user from seeing any data. The fix in this PR is to catch those exceptions and return the object as is. 

### How to verify

See the steps in the original issue. You should be able to query the data now. 

### Demo

https://www.loom.com/share/0c8a6a09b8994a8fa19420f5d6626c25

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
