### PR TITLE
Flatten root-level :or/:and/:multi into flat object schemas for MCP clients

### DIFF
--- a/src/metabase/api/macros/defendpoint/tools_manifest.clj
+++ b/src/metabase/api/macros/defendpoint/tools_manifest.clj
@@ -38,50 +38,95 @@
        (mc/into-schema (mc/type node) (mc/properties node) children (mc/options node))))
    {::mc/walk-refs true ::mc/walk-schema-refs true}))
 
-(defn- maybe-optional-keys
-  "Apply `mut/optional-keys` if the schema is map-like (has entries after deref).
-   Non-map schemas (e.g. `:enum`, `:string`) are returned unchanged."
+(defn- collect-root-maps
+  "Walk the root of a malli schema tree using a worklist, collecting leaf `:map` schemas.
+   Composite nodes (`:and`, `:or`, `:multi`) are expanded and their children enqueued.
+   Other non-map nodes (e.g. `:schema` wrappers) are deref'd and re-enqueued.
+
+   Returns a vector of `{:schema <map-schema> :optional? <bool>}` where `:optional?` is true
+   when the schema was reached through an `:or` or `:multi` branch (meaning all its keys
+   should become optional in the merged result).
+
+   Tracks already-deref'd schemas to detect cycles — composite types (`:and`, `:or`, `:multi`)
+   and `:map` always terminate, so only the deref fallback path needs cycle detection.
+
+   Only the outermost composite schemas are consumed — nested `anyOf`/`allOf` within `:map`
+   properties are preserved since LLM clients handle them fine."
   [schema]
-  (if (mc/-entry-schema? (mc/deref-all schema))
-    (mut/optional-keys schema)
-    schema))
+  (loop [worklist [{:schema schema :optional? false}]
+         results  []
+         seen     #{}]
+    (if (empty? worklist)
+      results
+      (let [{:keys [schema optional?]} (first worklist)
+            remaining                   (subvec worklist 1)]
+        (case (mc/type schema)
+          :map
+          (recur remaining (conj results {:schema schema :optional? optional?}) seen)
+
+          :and
+          (recur (into remaining
+                       (mapv (fn [child] {:schema child :optional? optional?})
+                             (mc/children schema)))
+                 results seen)
+
+          :or
+          (recur (into remaining
+                       (mapv (fn [child] {:schema child :optional? true})
+                             (mc/children schema)))
+                 results seen)
+
+          :multi
+          (recur (into remaining
+                       (mapv (fn [[_k _props child]] {:schema child :optional? true})
+                             (mc/children schema)))
+                 results seen)
+
+          ;; For other types (e.g. :schema wrapper), try deref and re-enqueue.
+          ;; Track by identity to detect cycles (e.g. recursive schema refs).
+          (let [derefed (mc/deref schema)]
+            (cond
+              ;; Cycle detected: emit an empty :map as a safe fallback (-> {"type":"object"}).
+              ;; In practice inline-malli-refs already breaks cycles via :any, so this is a safety net.
+              (contains? seen schema)
+              (recur remaining
+                     (conj results {:schema (mc/schema [:map]) :optional? optional?})
+                     seen)
+
+              ;; Deref made progress: re-enqueue the dereferenced schema.
+              (not (identical? derefed schema))
+              (recur (conj remaining {:schema derefed :optional? optional?})
+                     results (conj seen schema))
+
+              ;; Can't simplify (non-map leaf like :enum): keep as-is.
+              :else
+              (recur remaining (conj results {:schema schema :optional? optional?}) seen))))))))
 
 (defn- flatten-root-schema
-  "Iteratively simplify the root of a malli schema until it is a `:map`.
-   Only the outermost composite schemas are flattened — nested `anyOf`/`allOf` are preserved
-   since LLM clients handle them fine within properties.
+  "Flatten the root of a malli schema into a single `:map` for MCP inputSchema compatibility.
+   Only the outermost composite schemas (`:and`, `:or`, `:multi`) are consumed — nested
+   `anyOf`/`allOf` within `:map` properties are preserved.
 
-   - `:and`   → `:merge` then deref (flattens the `[:map ...] [:map {:encode/...}]` pattern)
-   - `:or`    → `:union` with all entries optional, then deref (merges branches, no required)
-   - `:multi` → same as `:or` but extracts schemas from `[dispatch-key props schema]` triples
+   Collects all leaf `:map` schemas from the root composite tree, marks keys as optional
+   when reached through `:or`/`:multi` branches, then merges everything into one `:map`.
 
    Returns the schema unchanged if it is already a `:map` or cannot be simplified."
   [schema]
-  (loop [s schema
-         fuel 10]
-    (if (or (= :map (mc/type s)) (zero? fuel))
-      s
-      (recur
-       (case (mc/type s)
-         :and
-         (mc/deref (mc/into-schema :merge (mc/properties s) (mc/children s) (mc/options s)))
-
-         :or
-         (mc/deref (mc/into-schema :union (mc/properties s)
-                                   (mapv (comp maybe-optional-keys flatten-root-schema)
-                                         (mc/children s))
-                                   (mc/options s)))
-
-         :multi
-         (mc/deref (mc/into-schema :union (dissoc (mc/properties s) :dispatch)
-                                   (mapv (fn [[_k _props schema]]
-                                           (maybe-optional-keys (flatten-root-schema schema)))
-                                         (mc/children s))
-                                   (mc/options s)))
-
-         ;; For any other type (e.g. :schema wrapper), try deref
-         (mc/deref s))
-       (dec fuel)))))
+  (let [leaves (collect-root-maps schema)]
+    (case (count leaves)
+      0 schema
+      1 (let [{:keys [schema optional?]} (first leaves)]
+          (cond-> schema
+            (and optional? (mc/-entry-schema? (mc/deref-all schema))) mut/optional-keys))
+      ;; Multiple leaves: merge via :union with optional-keys where needed
+      (mc/deref
+       (mc/into-schema :union nil
+                       (mapv (fn [{:keys [schema optional?]}]
+                               (cond-> schema
+                                 (and optional? (mc/-entry-schema? (mc/deref-all schema)))
+                                 mut/optional-keys))
+                             leaves)
+                       (mc/options schema))))))
 
 (defn- prefer-tool-descriptions
   "Pre-process a malli schema so that `:tool/description` takes precedence over `:description`

--- a/src/metabase/api/macros/defendpoint/tools_manifest.clj
+++ b/src/metabase/api/macros/defendpoint/tools_manifest.clj
@@ -20,56 +20,68 @@
 
 (set! *warn-on-reflection* true)
 
-(defn- merge-with-optional-keys
-  "Build a `:merge` schema from `schemas`, making all map entries optional.
-   Non-map children (e.g. `:enum`, `:string`) are left as-is since `mut/optional-keys`
-   only works on map-like schemas (`:map`, `:merge`, etc.)."
-  [props schemas options]
-  (mc/into-schema :merge props
-                  (mapv (fn [child]
-                          (if (mc/-entry-schema? (mc/deref-all child))
-                            (mut/optional-keys child)
-                            child))
-                        schemas)
-                  options))
-
 (defn- inline-malli-refs
-  "Walk a malli schema, replacing all registered-schema refs with their dereferenced content
-   and simplifying composite schemas into `:merge` for LLM-compatible JSON Schema output.
-
-   Transformations:
-   - Registered-schema refs → dereferenced content (no `$ref`/`$defs` in JSON Schema)
-   - `:and`   → `:merge` (eliminates `allOf` — merges the `[:map {:encode/...}]` pattern)
-   - `:or`    → `:merge` with all entries optional (eliminates `anyOf` — union of all branches)
-   - `:multi` → `:merge` with all entries optional (eliminates conditional dispatch)
-   - Cyclic refs → `:any` (fallback for recursive schemas)
-
-   Malli's `::mc/walked-refs` tracking prevents infinite recursion on cyclic schemas."
+  "Walk a malli schema, replacing all registered-schema refs with their dereferenced content.
+   This ensures `mjs/transform` never sees refs and thus never generates `$ref` or `$defs`.
+   Malli's `::mc/walked-refs` tracking prevents infinite recursion on cyclic schemas —
+   when a cycle is detected, the walker receives the raw ref name (a string) instead of a
+   walked schema, and we fall back to `:any`."
   [schema]
   (mc/walk
    schema
    (fn [node _path children _options]
-     (cond
-       (mc/-ref-schema? node)
+     (if (mc/-ref-schema? node)
        (let [child (first children)]
          (if (mc/schema? child)
            child
            (mc/schema :any)))
-
-       (= :and (mc/type node))
-       (mc/into-schema :merge (mc/properties node) children (mc/options node))
-
-       (= :or (mc/type node))
-       (merge-with-optional-keys (mc/properties node) children (mc/options node))
-
-       (= :multi (mc/type node))
-       (merge-with-optional-keys (dissoc (mc/properties node) :dispatch)
-                                 (mapv (fn [[_k _props schema]] schema) children)
-                                 (mc/options node))
-
-       :else
        (mc/into-schema (mc/type node) (mc/properties node) children (mc/options node))))
    {::mc/walk-refs true ::mc/walk-schema-refs true}))
+
+(defn- maybe-optional-keys
+  "Apply `mut/optional-keys` if the schema is map-like (has entries after deref).
+   Non-map schemas (e.g. `:enum`, `:string`) are returned unchanged."
+  [schema]
+  (if (mc/-entry-schema? (mc/deref-all schema))
+    (mut/optional-keys schema)
+    schema))
+
+(defn- flatten-root-schema
+  "Iteratively simplify the root of a malli schema until it is a `:map`.
+   Only the outermost composite schemas are flattened — nested `anyOf`/`allOf` are preserved
+   since LLM clients handle them fine within properties.
+
+   - `:and`   → `:merge` then deref (flattens the `[:map ...] [:map {:encode/...}]` pattern)
+   - `:or`    → `:union` with all entries optional, then deref (merges branches, no required)
+   - `:multi` → same as `:or` but extracts schemas from `[dispatch-key props schema]` triples
+
+   Returns the schema unchanged if it is already a `:map` or cannot be simplified."
+  [schema]
+  (loop [s schema
+         fuel 10]
+    (if (or (= :map (mc/type s)) (zero? fuel))
+      s
+      (recur
+       (case (mc/type s)
+         :and
+         (mc/deref (mc/into-schema :merge (mc/properties s) (mc/children s) (mc/options s)))
+
+         :or
+         (mc/deref (mc/into-schema :union (mc/properties s)
+                                   (mapv (comp maybe-optional-keys flatten-root-schema)
+                                         (mc/children s))
+                                   (mc/options s)))
+
+         :multi
+         (mc/deref (mc/into-schema :union (dissoc (mc/properties s) :dispatch)
+                                   (mapv (fn [[_k _props schema]]
+                                           (maybe-optional-keys (flatten-root-schema schema)))
+                                         (mc/children s))
+                                   (mc/options s)))
+
+         ;; For any other type (e.g. :schema wrapper), try deref
+         (mc/deref s))
+       (dec fuel)))))
 
 (defn- prefer-tool-descriptions
   "Pre-process a malli schema so that `:tool/description` takes precedence over `:description`
@@ -89,10 +101,11 @@
 
 (defn malli->json-schema
   "Transform a malli schema to JSON Schema with all refs inlined (no `$ref` or `$defs`).
-   First inlines all malli registered-schema refs, then applies tool-description preferences,
-   then transforms to JSON Schema."
+   Inlines registered-schema refs, flattens root-level composite schemas (`:or`, `:and`,
+   `:multi`) into a single `:map`, applies tool-description preferences, then transforms
+   to JSON Schema. Nested `anyOf`/`allOf` within properties are preserved."
   [malli-schema]
-  (let [prepared (-> malli-schema inline-malli-refs prefer-tool-descriptions)]
+  (let [prepared (-> malli-schema inline-malli-refs flatten-root-schema prefer-tool-descriptions)]
     (mjs/transform prepared)))
 
 (def ^:private annotation-key-mapping

--- a/test/metabase/api/macros/defendpoint/tools_manifest_test.clj
+++ b/test/metabase/api/macros/defendpoint/tools_manifest_test.clj
@@ -226,10 +226,10 @@
         "manifest should not have top-level $defs")))
 
 (deftest ^:parallel refs-are-inlined-in-manifest-test
-  (testing "malli->json-schema with :or produces flat object, no $ref or anyOf"
+  (testing "malli->json-schema with :or of mixed types preserves anyOf but inlines refs"
     (let [jss (tools-manifest/malli->json-schema [:or ::ref-target-a ::ref-target-b])]
-      (is (= "object" (:type jss)))
-      (is (not (contains? jss :anyOf)))
+      (is (contains? jss :anyOf)
+          "non-map :or branches stay as anyOf")
       (is (not (re-find #"\$ref" (pr-str jss))))))
   (testing "generate-tools-manifest output has no $ref or $defs anywhere"
     (let [manifest (test-manifest)

--- a/test/metabase/api/macros/defendpoint/tools_manifest_test.clj
+++ b/test/metabase/api/macros/defendpoint/tools_manifest_test.clj
@@ -81,6 +81,126 @@
       (is (= #{:x :y} (set (keys (:properties jss)))))
       (is (= [:x] (:required jss))))))
 
+(deftest ^:parallel deeply-nested-root-flattening-test
+  (testing ":and wrapping :and is fully flattened"
+    (let [jss (tools-manifest/malli->json-schema
+               [:and
+                [:and [:map [:a :int]] [:map [:b :string]]]
+                [:map [:c :boolean]]])]
+      (is (= "object" (:type jss)))
+      (is (= #{:a :b :c} (set (keys (:properties jss)))))
+      (is (not (contains? jss :allOf)))))
+  (testing ":or wrapping :or is fully flattened"
+    (let [jss (tools-manifest/malli->json-schema
+               [:or
+                [:or [:map [:a :int]] [:map [:b :string]]]
+                [:map [:c :boolean]]])]
+      (is (= "object" (:type jss)))
+      (is (= #{:a :b :c} (set (keys (:properties jss)))))
+      (is (not (contains? jss :anyOf)))
+      (is (nil? (:required jss))
+          "all entries optional after :or flattening")))
+  (testing ":and wrapping :or flattens both layers"
+    (let [jss (tools-manifest/malli->json-schema
+               [:and
+                [:or [:map [:a :int]] [:map [:b :string]]]
+                [:map [:c :boolean]]])]
+      (is (= "object" (:type jss)))
+      (is (= #{:a :b :c} (set (keys (:properties jss)))))
+      (is (not (contains? jss :allOf)))
+      (is (not (contains? jss :anyOf)))))
+  (testing ":or wrapping :and — flattens :and children"
+    (let [jss (tools-manifest/malli->json-schema
+               [:or
+                [:and [:map [:a :int]] [:map [:b :string]]]
+                [:map [:c :boolean]]])]
+      (is (= "object" (:type jss)))
+      (is (= #{:a :b :c} (set (keys (:properties jss)))))
+      (is (not (contains? jss :anyOf)))
+      (is (not (contains? jss :allOf)))
+      (is (nil? (:required jss))
+          "all entries optional — :or makes everything optional")))
+  (testing "triple-nested :and → :or → :and fully flattens"
+    (let [jss (tools-manifest/malli->json-schema
+               [:and
+                [:or
+                 [:and [:map [:a :int]] [:map [:b :string]]]
+                 [:map [:c :boolean]]]
+                [:map [:d :keyword]]])]
+      (is (= "object" (:type jss)))
+      (is (= #{:a :b :c :d} (set (keys (:properties jss)))))
+      (is (not (contains? jss :allOf)))
+      (is (not (contains? jss :anyOf)))))
+  (testing ":or wrapping :or wrapping :and — flattening through multiple layers"
+    (let [jss (tools-manifest/malli->json-schema
+               [:or
+                [:or
+                 [:and [:map [:a :int]] [:map [:b :string]]]
+                 [:map [:c :boolean]]]
+                [:map [:d :keyword]]])]
+      (is (= "object" (:type jss)))
+      (is (= #{:a :b :c :d} (set (keys (:properties jss)))))
+      (is (not (contains? jss :anyOf)))
+      (is (nil? (:required jss))))))
+
+(deftest ^:parallel nested-composite-within-properties-preserved-test
+  (testing ":or inside a property value is preserved as anyOf"
+    (let [jss (tools-manifest/malli->json-schema
+               [:map [:x [:or :int :string]]])]
+      (is (= "object" (:type jss)))
+      (is (contains? (get-in jss [:properties :x]) :anyOf)
+          "nested :or should remain as anyOf inside a property")))
+  (testing ":and inside a property value is preserved as allOf"
+    (let [jss (tools-manifest/malli->json-schema
+               [:map [:x [:and :int [:fn pos?]]]])]
+      (is (= "object" (:type jss)))
+      ;; :and with non-map children stays as allOf or gets simplified by malli,
+      ;; but the root schema should still be a flat object
+      (is (= [:x] (:required jss)))))
+  (testing "root :or flattened but nested :or within property preserved"
+    (let [jss (tools-manifest/malli->json-schema
+               [:or
+                [:map [:a :int] [:nested [:or :string :boolean]]]
+                [:map [:b :keyword]]])]
+      (is (= "object" (:type jss))
+          "root :or should be flattened to object")
+      (is (= #{:a :b :nested} (set (keys (:properties jss)))))
+      (is (not (contains? jss :anyOf))
+          "root-level anyOf should be gone")
+      (is (contains? (get-in jss [:properties :nested]) :anyOf)
+          "nested :or within a property should be preserved as anyOf")))
+  (testing "root :and flattened but nested :or within property preserved"
+    (let [jss (tools-manifest/malli->json-schema
+               [:and
+                [:map [:a :int] [:choice [:or :string :boolean]]]
+                [:map [:b :keyword]]])]
+      (is (= "object" (:type jss)))
+      (is (= #{:a :b :choice} (set (keys (:properties jss)))))
+      (is (not (contains? jss :allOf)))
+      (is (contains? (get-in jss [:properties :choice]) :anyOf)
+          "nested :or within property preserved even when root :and is flattened"))))
+
+(deftest ^:parallel multi-root-flattening-test
+  (testing ":multi at root is flattened with all entries optional"
+    (let [jss (tools-manifest/malli->json-schema
+               [:multi {:dispatch :type}
+                [:a [:map [:type [:= :a]] [:a-field :int]]]
+                [:b [:map [:type [:= :b]] [:b-field :string]]]])]
+      (is (= "object" (:type jss)))
+      (is (= #{:type :a-field :b-field} (set (keys (:properties jss)))))
+      (is (nil? (:required jss))
+          "all entries optional after :multi → union")))
+  (testing ":and wrapping :multi flattens both layers"
+    (let [jss (tools-manifest/malli->json-schema
+               [:and
+                [:multi {:dispatch :type}
+                 [:a [:map [:type [:= :a]] [:x :int]]]
+                 [:b [:map [:type [:= :b]] [:y :string]]]]
+                [:map [:z :boolean]]])]
+      (is (= "object" (:type jss)))
+      (is (= #{:type :x :y :z} (set (keys (:properties jss)))))
+      (is (not (contains? jss :allOf))))))
+
 (deftest ^:parallel endpoint->tool-definition-test
   (testing "Basic endpoint conversion"
     (let [form   {:method          :get


### PR DESCRIPTION
### Description

Only the outermost composite schemas are flattened — nested anyOf/allOf within properties are preserved since LLM clients handle them fine.

- :and → :merge then deref (flattens the [:map {:encode/...}] pattern)
- :or → :union with optional-keys, then deref (merges branches)
- :multi → same as :or, extracts schemas from dispatch triples

Also updates construct_query and query tool descriptions to explain which fields are mutually exclusive (table_id vs metric_id vs continuation_token).

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
