### PR TITLE
set line height to 'normal' for textareas

### DIFF
--- a/frontend/src/metabase/ui/components/inputs/Textarea/Textarea.config.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Textarea/Textarea.config.tsx
@@ -14,5 +14,8 @@ export const textareaOverrides: MantineThemeOverride["components"] = {
     classNames: {
       error: TextInputStyles.error,
     },
+    styles: {
+      input: { lineHeight: "normal" },
+    },
   }),
 };


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #55103
Closes UXW-222

### Description
Simple change to textarea components to use`line-height: normal`, which fixes the issue of scrollbars occasionally appearing when autosize: true. The issue appears to have been caused by the line-height of 122% defined in theme.ts, which was causing a pixel size that was not a whole number. My best guess is that mantine was chopping off the decimal value when setting the height for the growing text areas, causing the scrollbars to appear (50.2px doesn't technically fit in 50px).

### How to verify
1. Find a text area that grows in the app. I was using the  SAML identity provider certificate in admin
2. Add some new lines so that the text area grows. You should only see a scrollbar after 6 rows, where before you would see a scroll bar at 3 and 5 as well that wouldn't do anything

### Demo

https://github.com/user-attachments/assets/9c2234b6-47cd-4d83-966a-2e541ccc965e


### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~
