### PR TITLE
Fixed flaky custom elements api <metabase-question> test

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/embed-parameters-remapping.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/embed-parameters-remapping.cy.spec.ts
@@ -303,8 +303,8 @@ describe(suiteTitle, () => {
       H.getSimpleEmbedIframeContent().within(() => {
         cy.findByText("Question with Remapping").should("be.visible");
 
-        // Wait for the last parameter widget is rendered
-        cy.findByText("PK->Name").should("be.visible");
+        // Wait for all parameter widgets to be rendered
+        cy.findAllByTestId("parameter-widget").should("have.length", 3);
 
         cy.log("internal remapping - select N5 and verify it shows N5");
         cy.findAllByTestId("parameter-widget")

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/embed-parameters-remapping.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/embed-parameters-remapping.cy.spec.ts
@@ -303,8 +303,8 @@ describe(suiteTitle, () => {
       H.getSimpleEmbedIframeContent().within(() => {
         cy.findByText("Question with Remapping").should("be.visible");
 
-        // Wait for all parameter widgets to be rendered
-        cy.findAllByTestId("parameter-widget").should("have.length", 3);
+        // Wait for the last parameter widget is rendered
+        cy.findByText("PK->Name").should("be.visible");
 
         cy.log("internal remapping - select N5 and verify it shows N5");
         cy.findAllByTestId("parameter-widget")

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
@@ -302,6 +302,8 @@ describe("scenarios > embedding > sdk iframe embedding > custom elements api", (
         <metabase-question question-id="${questionId}" drills />
         `);
 
+        cy.wait("@getCardQuery");
+
         // Wait for the table to finish rendering before interacting,
         // as column auto-sizing can cause re-renders that detach elements.
         H.getSimpleEmbedIframeContent()
@@ -312,7 +314,7 @@ describe("scenarios > embedding > sdk iframe embedding > custom elements api", (
           .findAllByText("37.65")
           .first()
           .should("be.visible")
-          .click();
+          .click({ force: true });
         H.getSimpleEmbedIframeContent()
           .findByText(/Filter by this value/)
           .should("be.visible");

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
@@ -302,6 +302,12 @@ describe("scenarios > embedding > sdk iframe embedding > custom elements api", (
         <metabase-question question-id="${questionId}" drills />
         `);
 
+        // Wait for the table to finish rendering before interacting,
+        // as column auto-sizing can cause re-renders that detach elements.
+        H.getSimpleEmbedIframeContent()
+          .findByTestId("table-root")
+          .should("have.attr", "data-rows-count", "5");
+
         H.getSimpleEmbedIframeContent()
           .findAllByText("37.65")
           .first()


### PR DESCRIPTION
Closes [EMB-1491: \[Flaky Test\] \[e2e-tests\] <metabase-question> scenarios > embedding > sdk iframe embedding > custom elements api <metabase-question> should enable drill-through when drills is true](https://linear.app/metabase/issue/EMB-1491/flaky-test-e2e-tests-metabase-question-scenarios-embedding-sdk-iframe)

[Stress test with 100 burns](https://github.com/metabase/metabase/actions/runs/23600477805/job/68728825334)