### PR TITLE
preserve navbar status in the url update at the end of handleQBInit

### DIFF
--- a/frontend/src/metabase/nav/containers/Navbar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/Navbar.unit.spec.tsx
@@ -140,6 +140,19 @@ describe("nav > containers > Navbar > Core App", () => {
     await expectNavbarClosed();
   });
 
+  it("should not close navbar when preserveNavbarState is set", async () => {
+    const store = await setup({ isOpen: true });
+    await expectNavbarOpen();
+    store.dispatch({
+      type: "@@router/LOCATION_CHANGE",
+      payload: {
+        pathname: "/question/1",
+        state: { preserveNavbarState: true },
+      },
+    });
+    await expectNavbarOpen();
+  });
+
   it("should preserve state when navigating collections", async () => {
     const store = await setup({ pathname: "/collection/1" });
     await expectNavbarOpen();

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
@@ -427,6 +427,7 @@ async function handleQBInit(
       updateUrl(question, {
         replaceState: true,
         preserveParameters: hasCard,
+        preserveNavbarState: true,
         objectId,
       }),
     );

--- a/frontend/src/metabase/query_builder/actions/url.ts
+++ b/frontend/src/metabase/query_builder/actions/url.ts
@@ -35,6 +35,7 @@ export const updateUrl = createThunkAction(
       dirty,
       replaceState,
       preserveParameters = true,
+      preserveNavbarState = false,
       queryBuilderMode,
       datasetEditorTab,
       objectId,
@@ -128,7 +129,13 @@ export const updateUrl = createThunkAction(
 
       try {
         if (replaceState) {
-          dispatch(replace(locationDescriptor));
+          const replaceDescriptor = preserveNavbarState
+            ? {
+                ...locationDescriptor,
+                state: { ...locationDescriptor.state, preserveNavbarState },
+              }
+            : locationDescriptor;
+          dispatch(replace(replaceDescriptor));
         } else {
           dispatch(push(locationDescriptor));
         }


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #44602
Closes UXW-225

### Description
Updates the `updateUrl` action in the query builder to accept and pass along a perserveNavbarState when it's replacing the url, and updates the call at the end of handleQBInit to set that to true.

### How to verify
1. Ensure you have some bookmarked questions
2. Click one of the bookmarks, and you'll notice the navbar close
3. Open the navbar while the quesiton is loading (you may need to throttle your browser to make this work
4. The navbar state should not change when the question has loaded. Previously, it would have closed

### Demo

https://github.com/user-attachments/assets/123491ef-84da-4d88-a666-91ddf052992b


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
