### PR TITLE
Bump databricks jdbc driver to 3.3.1

### DIFF
--- a/modules/drivers/databricks/deps.edn
+++ b/modules/drivers/databricks/deps.edn
@@ -2,4 +2,4 @@
  ["src" "resources"]
 
  :deps
- {com.databricks/databricks-jdbc-thin {:mvn/version "3.0.7"}}}
+ {com.databricks/databricks-jdbc-thin {:mvn/version "3.3.1"}}}

--- a/modules/drivers/databricks/test/metabase/driver/databricks_test.clj
+++ b/modules/drivers/databricks/test/metabase/driver/databricks_test.clj
@@ -485,3 +485,12 @@
                       (assoc :use-m2m true
                              :client-id (tx/db-test-env-var-or-throw :databricks :client-id)
                              :oauth-secret (tx/db-test-env-var-or-throw :databricks :oauth-secret)))))))))
+
+(deftest ^:parallel mulit-line-comment-test
+  (mt/test-driver :databricks
+    (testing "queries with multi line block comments work (#68667)"
+      (is (= [[1]]
+             (->> "/*\n*/\nselect 1;"
+                  (lib/native-query (mt/metadata-provider))
+                  (qp/process-query)
+                  (mt/rows)))))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/68667
Closes https://github.com/metabase/metabase/issues/70175

### Description

Upgrade databricks jdbc driver to 3.3.1 which has https://github.com/databricks/databricks-jdbc/pull/1207, which should fix the issues above. 

### How to verify

1. You should be able to execute a query that starts with a multi-line block comment.
2. You should be able to complete the query in the second issue

### Demo

https://www.loom.com/share/582adbc5e5ae403cafbb77010b07217d

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
