### PR TITLE
Metrics home page and viewer cleanup

### DIFF
--- a/frontend/src/metabase/metrics-viewer/components/MetricsViewerTabs/MetricsViewerTabContent/MetricsViewerTabContent.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricsViewerTabs/MetricsViewerTabContent/MetricsViewerTabContent.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo } from "react";
+import { t } from "ttag";
 
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { getObjectKeys, getObjectValues } from "metabase/lib/objects";
@@ -83,7 +84,7 @@ export function MetricsViewerTabContent({
     for (const series of rawSeries) {
       const cols = series.data.cols;
       if (!cols.some((col) => isMetric(col))) {
-        return "Non-numeric metrics are not supported";
+        return t`Non-numeric metrics are not supported`;
       }
     }
 

--- a/frontend/src/metabase/metrics-viewer/components/MetricsViewerTabs/MetricsViewerTabContent/MetricsViewerTabContent.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricsViewerTabs/MetricsViewerTabContent/MetricsViewerTabContent.tsx
@@ -3,9 +3,10 @@ import { useCallback, useMemo } from "react";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { getObjectKeys, getObjectValues } from "metabase/lib/objects";
 import { isNotNull } from "metabase/lib/types";
-import { Flex, Stack } from "metabase/ui";
+import { Center, Flex, Stack } from "metabase/ui";
 import type { DimensionMetadata, MetricDefinition } from "metabase-lib/metric";
 import * as LibMetric from "metabase-lib/metric";
+import { isMetric } from "metabase-lib/v1/types/utils/isa";
 import type { Dataset, TemporalUnit } from "metabase-types/api";
 
 import type {
@@ -58,18 +59,6 @@ export function MetricsViewerTabContent({
     return getObjectKeys(tab.dimensionMapping).some(isExecuting);
   }, [tab.dimensionMapping, isExecuting]);
 
-  const firstError = useMemo(() => {
-    for (const sourceId of getObjectKeys(tab.dimensionMapping)) {
-      const err = errorsByDefinitionId.get(sourceId);
-      if (err) {
-        return err;
-      }
-    }
-    return null;
-  }, [tab.dimensionMapping, errorsByDefinitionId]);
-
-  const dimensionFilter = getTabConfig(tab.type).dimensionPredicate;
-
   const { series: rawSeries, cardIdToDimensionId } = useMemo(
     () =>
       buildRawSeriesFromDefinitions(
@@ -89,6 +78,25 @@ export function MetricsViewerTabContent({
       sourceColors,
     ],
   );
+
+  const firstError = useMemo(() => {
+    for (const series of rawSeries) {
+      const cols = series.data.cols;
+      if (!cols.some((col) => isMetric(col))) {
+        return "Non-numeric metrics are not supported";
+      }
+    }
+
+    for (const sourceId of getObjectKeys(tab.dimensionMapping)) {
+      const err = errorsByDefinitionId.get(sourceId);
+      if (err) {
+        return err;
+      }
+    }
+    return null;
+  }, [tab.dimensionMapping, errorsByDefinitionId, rawSeries]);
+
+  const dimensionFilter = getTabConfig(tab.type).dimensionPredicate;
 
   const dimensionItems = useMemo(
     () =>
@@ -202,7 +210,11 @@ export function MetricsViewerTabContent({
     mappedDimensionCount > 1 ? onDimensionRemove : undefined;
 
   if (isLoading || firstError) {
-    return <LoadingAndErrorWrapper loading={isLoading} error={firstError} />;
+    return (
+      <Center h="100%">
+        <LoadingAndErrorWrapper loading={isLoading} error={firstError} />
+      </Center>
+    );
   }
 
   if (rawSeries.length === 0) {

--- a/frontend/src/metabase/metrics-viewer/components/MetricsViewerVisualization/MetricsViewerVisualization.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricsViewerVisualization/MetricsViewerVisualization.tsx
@@ -94,6 +94,7 @@ export function MetricsViewerVisualization({
                   mode={clickActionsMode}
                   onChangeCardAndRun={noop}
                   autoAdjustSettings
+                  isMetricsViewer
                 />
               </DebouncedFrame>
             </Stack>

--- a/frontend/src/metabase/metrics-viewer/utils/series.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/series.ts
@@ -300,7 +300,7 @@ export function buildRawSeriesFromDefinitions(
     };
 
     let entrySeries: SingleSeries[];
-    if (!entryHasBreakout(entry)) {
+    if (!entryHasBreakout(entry) || singleSeries.data.rows.length === 0) {
       entrySeries = [singleSeries];
     } else {
       entrySeries = splitByBreakout(

--- a/frontend/src/metabase/metrics/components/MetricDimensionGrid/MetricDimensionGrid.tsx
+++ b/frontend/src/metabase/metrics/components/MetricDimensionGrid/MetricDimensionGrid.tsx
@@ -134,6 +134,7 @@ function MetricDimensionCard({
               isQueryBuilder={false}
               hideLegend
               onChangeCardAndRun={_.noop}
+              isMetricsViewer
             />
           ) : (
             <ChartSkeleton display={displayType} className={S.visualization} />

--- a/frontend/src/metabase/metrics/components/MetricHeader/MetricTabs/MetricTabs.tsx
+++ b/frontend/src/metabase/metrics/components/MetricHeader/MetricTabs/MetricTabs.tsx
@@ -6,6 +6,7 @@ import {
   PaneHeaderTabs,
 } from "metabase/data-studio/common/components/PaneHeader";
 import { useSelector } from "metabase/lib/redux";
+import { isNumericMetric } from "metabase/metrics/utils/validation";
 import { PLUGIN_CACHING, PLUGIN_DEPENDENCIES } from "metabase/plugins";
 import { getMetadata } from "metabase/selectors/metadata";
 import * as Lib from "metabase-lib";
@@ -45,10 +46,12 @@ function getTabs(
   const queryInfo = Lib.queryDisplayInfo(query);
 
   if (queryInfo.isEditable) {
-    tabs.push({
-      label: t`Overview`,
-      to: urls.overview(card.id),
-    });
+    if (isNumericMetric(card)) {
+      tabs.push({
+        label: t`Overview`,
+        to: urls.overview(card.id),
+      });
+    }
     tabs.push({
       label: t`Definition`,
       to: urls.query(card.id),

--- a/frontend/src/metabase/metrics/components/MetricHeader/MetricToolbar/MetricToolbar.tsx
+++ b/frontend/src/metabase/metrics/components/MetricHeader/MetricToolbar/MetricToolbar.tsx
@@ -13,6 +13,7 @@ import { ToolbarButton } from "metabase/common/components/ToolbarButton";
 import { getLibraryCollectionType } from "metabase/data-studio/utils";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
+import { isNumericMetric } from "metabase/metrics/utils/validation";
 import { QuestionAlertListModal } from "metabase/notifications/modals/QuestionAlertListModal";
 import { PLUGIN_AUDIT, PLUGIN_MODERATION } from "metabase/plugins";
 import { AddToDashSelectDashModal } from "metabase/query_builder/components/AddToDashSelectDashModal";
@@ -105,16 +106,18 @@ function MetricToolbarButtons({
 
   return (
     <Group wrap="nowrap" gap="sm">
-      <Button
-        size="sm"
-        component={ForwardRefLink}
-        to={Urls.exploreMetric(card.id)}
-        target="_blank"
-        leftSection={<Icon name="external" />}
-        data-testid="explore-link"
-      >
-        {t`Explore`}
-      </Button>
+      {isNumericMetric(card) && (
+        <Button
+          size="sm"
+          component={ForwardRefLink}
+          to={Urls.exploreMetric(card.id)}
+          target="_blank"
+          leftSection={<Icon name="external" />}
+          data-testid="explore-link"
+        >
+          {t`Explore`}
+        </Button>
+      )}
       <Menu position="bottom-end">
         <Menu.Target>
           <ToolbarButton icon="ellipsis" aria-label={t`More options`} />

--- a/frontend/src/metabase/metrics/utils/validation.ts
+++ b/frontend/src/metabase/metrics/utils/validation.ts
@@ -1,4 +1,6 @@
 import * as Lib from "metabase-lib";
+import { isSummable } from "metabase-lib/v1/types/utils/isa";
+import type { Card } from "metabase-types/api";
 
 export type ValidationResult = {
   isValid: boolean;
@@ -7,4 +9,8 @@ export type ValidationResult = {
 
 export function getValidationResult(query: Lib.Query): ValidationResult {
   return { isValid: Lib.canSave(query, "metric") };
+}
+
+export function isNumericMetric(card: Card): boolean {
+  return card.result_metadata?.some(isSummable) ?? false;
 }

--- a/frontend/src/metabase/visualizations/components/ChartWithLegend.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartWithLegend.tsx
@@ -52,6 +52,7 @@ type ChartWithLegendProps = {
   showLegend?: boolean;
   isDashboard?: boolean;
   isDocument?: boolean;
+  isMetricsViewer?: boolean;
   onToggleSeriesVisibility?: (event: MouseEvent, index: number) => void;
   forwardedRef?: Ref<HTMLDivElement>;
 };
@@ -73,6 +74,7 @@ const ChartWithLegendInner = ({
   showLegend = true,
   isDashboard,
   isDocument,
+  isMetricsViewer,
   onToggleSeriesVisibility = () => {},
   forwardedRef,
 }: ChartWithLegendProps) => {
@@ -167,7 +169,7 @@ const ChartWithLegendInner = ({
         titles={layout.processedLegendTitles}
         hiddenIndices={legendHiddenIndices}
         colors={legendColors}
-        dotSize={isDashboard ? "8px" : "12px"}
+        dotSize={isDashboard || isMetricsViewer ? "8px" : "12px"}
         hovered={hovered}
         onHoverChange={onHoverChange}
         onToggleSeriesVisibility={onToggleSeriesVisibility}
@@ -211,7 +213,9 @@ const ChartWithLegendInner = ({
         <div
           className={cx(styles.LegendSpacer)}
           // don't center the chart on dashboards
-          style={isDashboard || isDocument ? { flexBasis: 0 } : {}}
+          style={
+            isDashboard || isDocument || isMetricsViewer ? { flexBasis: 0 } : {}
+          }
           data-testid="chart-legend-spacer"
         >
           {legend}

--- a/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
+++ b/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
@@ -411,6 +411,7 @@ class ChoroplethMapInner extends Component {
         onHoverChange={onHoverChange}
         isDashboard={this.props.isDashboard}
         isDocument={this.props.isDocument}
+        isMetricsViewer={this.props.isMetricsViewer}
       >
         {projection ? (
           <LegacyChoropleth

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
@@ -141,6 +141,7 @@ type VisualizationOwnProps = {
   isAction?: boolean;
   isDashboard?: boolean;
   isDocument?: boolean;
+  isMetricsViewer?: boolean;
   isMobile?: boolean;
   isRunning?: boolean;
   isShowingSummarySidebar?: boolean;
@@ -272,6 +273,7 @@ class Visualization extends PureComponent<
     isEditing: false,
     isEmbeddingSdk: false,
     isFullscreen: false,
+    isMetricsViewer: false,
     isPreviewing: false,
     isQueryBuilder: false,
     isSettings: false,
@@ -668,6 +670,7 @@ class Visualization extends PureComponent<
       isEditing,
       isEmbeddingSdk,
       isFullscreen,
+      isMetricsViewer,
       isMobile,
       isObjectDetail,
       isPreviewing,
@@ -761,6 +764,7 @@ class Visualization extends PureComponent<
             e instanceof ChartSettingsError &&
             visualization?.hasEmptyState &&
             !isDashboard &&
+            !isMetricsViewer &&
             // For the SDK the EmptyVizState component in some cases (a small container) looks really weird,
             // so at least temporarily we don't display it when rendered in the SDK.
             !isEmbeddingSdk
@@ -936,6 +940,7 @@ class Visualization extends PureComponent<
                     isEditing={!!isEditing}
                     isEmbeddingSdk={isEmbeddingSdk}
                     isFullscreen={!!isFullscreen}
+                    isMetricsViewer={!!isMetricsViewer}
                     isMobile={!!isMobile}
                     isVisualizer={!!isVisualizer}
                     isVisualizerCard={isVisualizerDashCard}

--- a/frontend/src/metabase/visualizations/types/visualization.ts
+++ b/frontend/src/metabase/visualizations/types/visualization.ts
@@ -156,6 +156,7 @@ export interface VisualizationProps {
   // Is this visualization made by the visualizer
   isVisualizerCard: boolean;
   isEditing: boolean;
+  isMetricsViewer: boolean;
   isMobile: boolean;
   isSettings: boolean;
   showAllLegendItems?: boolean;

--- a/frontend/src/metabase/visualizations/visualizations/Funnel/Funnel.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Funnel/Funnel.unit.spec.tsx
@@ -72,6 +72,7 @@ const setup = (
     isVisualizer: false,
     isVisualizerCard: false,
     isEditing: false,
+    isMetricsViewer: false,
     isMobile: false,
     isSettings: false,
     width: 500,

--- a/frontend/src/metabase/visualizations/visualizations/Map/Map.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Map/Map.jsx
@@ -5,7 +5,7 @@ import _ from "underscore";
 
 import { ColorRangeSelector } from "metabase/common/components/ColorRangeSelector";
 import MetabaseSettings from "metabase/lib/settings";
-import { getAccentColors } from "metabase/ui/colors/groups";
+import { getAccentColors, getPreferredColor } from "metabase/ui/colors/groups";
 import { ChartSettingsError } from "metabase/visualizations/lib/errors";
 import { columnSettings } from "metabase/visualizations/lib/settings/column";
 import {
@@ -249,8 +249,12 @@ export class Map extends Component {
         ),
         isQuantile: true,
       }),
-      getDefault: () => getColorplethColorScale(getAccentColors()[0]),
+      getDefault: (series, vizSettings) =>
+        getColorplethColorScale(
+          getPreferredColor(vizSettings["map.metric"]) ?? getAccentColors()[0],
+        ),
       getHidden: (series, vizSettings) => vizSettings["map.type"] !== "region",
+      readDependencies: ["map.metric"],
     },
     "map.zoom": {},
     "map.center_latitude": {},


### PR DESCRIPTION
Closes [UXW-3432](https://linear.app/metabase/issue/UXW-3432/non-numeric-metrics-break-things)
Closes [UXW-3372](https://linear.app/metabase/issue/UXW-3372/map-legend-is-cut-off-on-metrics-homepage)
Closes [UXW-3456](https://linear.app/metabase/issue/UXW-3456/fix-empty-states-in-metrics-viewer-visualizations)
Closes [UXW-3425](https://linear.app/metabase/issue/UXW-3425/metrics-viewer-doesnt-show-the-min-rows-error-message-when-theres-a)

### Description

- Handle non-numeric metrics:
  - Hide overview tab and explore button
  - Handle errors in metric explorer
- Improve map viz
  - Use `isMetricsViewer` prop to collapse spacer div to the right of the map like we do on dashboards
  - Use `getPreferredColor` so the map color matches the color of the other vizzes in the metric homepage
- Better handling of empty states
  - Don't show `EmptyVizState` in metrics viewer since the CTAs don't make sense
  - Show zero rows error message when there's a breakout (previously was blank)

### How to verify

- Create a non-numeric metric, like a max of a date or string. Ensure the overview tab and explore button are hidden on the metrics homepage and that the metric explorer shows an error message.
- Open a metric like Revenue that's based on a sum in the metric homepage overview tab. Ensure the legend is readable and that the color matches the other visualizations.
- Add a date filter far in the future in the metrics explorer and add a breakout. Ensure you still see the zero rows error message.

### Demo

Non-numeric metric homepage - before (overview tab and metric explorer don't show anything, so should be hidden):
<img width="1131" height="529" alt="image" src="https://github.com/user-attachments/assets/0375112a-f877-47f3-8868-526a43b9d5b1" />

Non-numeric metric homepage - after:
<img width="1110" height="519" alt="image" src="https://github.com/user-attachments/assets/79faa0f3-6673-4450-8e59-60ddad639680" />

Non-numeric metric explorer - before (not clear what's happening):
<img width="978" height="489" alt="image" src="https://github.com/user-attachments/assets/3ee88ece-ba36-4efe-9bbd-bf32ef425030" />

Non-numeric metric explorer - after:
<img width="1100" height="517" alt="image" src="https://github.com/user-attachments/assets/9d0a10d5-3da8-4d7a-8adb-19ddf528decc" />

Map - before (legend not readable and colors don't match):
<img width="1120" height="501" alt="image" src="https://github.com/user-attachments/assets/de01807e-2fc1-4d60-9657-af387190e87d" />

Map - after:
<img width="1133" height="498" alt="image" src="https://github.com/user-attachments/assets/02a6cf94-5b57-4a91-a1e3-3480bbcc112f" />

Empty state with breakout - before (no error message):
<img width="1236" height="566" alt="image" src="https://github.com/user-attachments/assets/55f49c33-c7e7-4763-8d04-5fc08b2e4b10" />

Empty state with breakout - after:
<img width="1111" height="479" alt="image" src="https://github.com/user-attachments/assets/92000b94-bfae-47b4-b952-27a93214abd1" />

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR