### PR TITLE
Add token renewal infrastructure for guest embeds

### DIFF
--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/context/SdkQuestionProvider.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/context/SdkQuestionProvider.tsx
@@ -14,11 +14,13 @@ import { QuestionAlertModalProvider } from "embedding-sdk-bundle/components/priv
 import { useExtractResourceIdFromJwtToken } from "embedding-sdk-bundle/hooks/private/use-extract-resource-id-from-jwt-token";
 import { useLoadQuestion } from "embedding-sdk-bundle/hooks/private/use-load-question";
 import { useSetupContentTranslations } from "embedding-sdk-bundle/hooks/private/use-setup-content-translations";
-import { useSdkSelector } from "embedding-sdk-bundle/store";
+import { useSdkDispatch, useSdkSelector } from "embedding-sdk-bundle/store";
+import { setInitialGuestToken } from "embedding-sdk-bundle/store/guest-embed";
 import {
   getError,
   getIsGuestEmbed,
   getPlugins,
+  getSessionTokenState,
 } from "embedding-sdk-bundle/store/selectors";
 import type { MetabasePluginsConfig } from "embedding-sdk-bundle/types/plugins";
 import { EmbeddingEntityContextProvider } from "metabase/embedding/context";
@@ -75,7 +77,18 @@ export const SdkQuestionProvider = ({
   onVisualizationChange,
 }: SdkQuestionProviderProps) => {
   const isGuestEmbed = useSdkSelector(getIsGuestEmbed);
+  const dispatch = useSdkDispatch();
   const navigation = useSdkInternalNavigationOptional();
+
+  const { rawToken: tokenFromStore, error: tokenFetchError } =
+    useSdkSelector(getSessionTokenState);
+
+  // Store token so the refresh handler can check expiry. No need to await — not used here.
+  useEffect(() => {
+    if (rawToken && isGuestEmbed) {
+      dispatch(setInitialGuestToken(rawToken));
+    }
+  }, [rawToken, isGuestEmbed, dispatch]);
 
   const {
     resourceId: questionId,
@@ -84,7 +97,7 @@ export const SdkQuestionProvider = ({
   } = useExtractResourceIdFromJwtToken({
     isGuestEmbed,
     resourceId: rawQuestionId,
-    token: rawToken ?? undefined,
+    token: tokenFromStore ?? rawToken ?? undefined,
   });
 
   useSetupContentTranslations({ token });
@@ -268,6 +281,10 @@ export const SdkQuestionProvider = ({
 
   if (tokenError) {
     return <SdkError message={tokenError} />;
+  }
+
+  if (tokenFetchError) {
+    return <SdkError message={tokenFetchError.message} />;
   }
 
   if (error) {

--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboard.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboard.tsx
@@ -221,6 +221,8 @@ const SdkDashboardInner = ({
   } = useExtractResourceIdFromJwtToken({
     isGuestEmbed,
     resourceId: rawDashboardId,
+    // Skip stale Redux token on first render (e.g. wizard re-issuing a token when toggling parameters); rawToken prop takes precedence.
+    // From the next render onward, tokenFromStore is used and the value is from a refreshed token.
     token: (!isFirstRender ? tokenFromStore : null) ?? rawToken ?? undefined,
   });
 

--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboard.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboard.tsx
@@ -199,7 +199,7 @@ const SdkDashboardInner = ({
 }: SdkDashboardInnerProps) => {
   const isGuestEmbed = useSdkSelector(getIsGuestEmbed);
   const dispatch = useSdkDispatch();
-
+  const [isFirstRender, setIsFirstRender] = useState(true);
   const { rawToken: tokenFromStore, error: tokenFetchError } =
     useSdkSelector(getSessionTokenState);
 
@@ -210,6 +210,10 @@ const SdkDashboardInner = ({
     }
   }, [rawToken, isGuestEmbed, dispatch]);
 
+  useEffect(() => {
+    setIsFirstRender(false);
+  }, []);
+
   const {
     resourceId: dashboardId,
     token,
@@ -217,7 +221,7 @@ const SdkDashboardInner = ({
   } = useExtractResourceIdFromJwtToken({
     isGuestEmbed,
     resourceId: rawDashboardId,
-    token: tokenFromStore ?? rawToken ?? undefined,
+    token: (!isFirstRender ? tokenFromStore : null) ?? rawToken ?? undefined,
   });
 
   useSetupContentTranslations({ token });

--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboard.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboard.tsx
@@ -31,7 +31,11 @@ import {
 } from "embedding-sdk-bundle/hooks/private/use-sdk-dashboard-params";
 import { useSetupContentTranslations } from "embedding-sdk-bundle/hooks/private/use-setup-content-translations";
 import { useSdkDispatch, useSdkSelector } from "embedding-sdk-bundle/store";
-import { getIsGuestEmbed } from "embedding-sdk-bundle/store/selectors";
+import { setInitialGuestToken } from "embedding-sdk-bundle/store/guest-embed";
+import {
+  getIsGuestEmbed,
+  getSessionTokenState,
+} from "embedding-sdk-bundle/store/selectors";
 import type { MetabaseQuestion } from "embedding-sdk-bundle/types";
 import type {
   DashboardEventHandlersProps,
@@ -194,6 +198,17 @@ const SdkDashboardInner = ({
   onVisualizationChange,
 }: SdkDashboardInnerProps) => {
   const isGuestEmbed = useSdkSelector(getIsGuestEmbed);
+  const dispatch = useSdkDispatch();
+
+  const { rawToken: tokenFromStore, error: tokenFetchError } =
+    useSdkSelector(getSessionTokenState);
+
+  // Store token so the refresh handler can check expiry. No need to await — not used here.
+  useEffect(() => {
+    if (rawToken && isGuestEmbed) {
+      dispatch(setInitialGuestToken(rawToken));
+    }
+  }, [rawToken, isGuestEmbed, dispatch]);
 
   const {
     resourceId: dashboardId,
@@ -202,7 +217,7 @@ const SdkDashboardInner = ({
   } = useExtractResourceIdFromJwtToken({
     isGuestEmbed,
     resourceId: rawDashboardId,
-    token: rawToken ?? undefined,
+    token: tokenFromStore ?? rawToken ?? undefined,
   });
 
   useSetupContentTranslations({ token });
@@ -275,7 +290,6 @@ const SdkDashboardInner = ({
   ]);
 
   const errorPage = useSdkSelector(getErrorPage);
-  const dispatch = useSdkDispatch();
   useEffect(() => {
     if (dashboardId) {
       dispatch(resetErrorPage());
@@ -355,6 +369,10 @@ const SdkDashboardInner = ({
         <SdkError message={tokenError} />;
       </SdkDashboardStyledWrapper>
     );
+  }
+
+  if (tokenFetchError) {
+    return <SdkError message={tokenFetchError.message} />;
   }
 
   if (isStaticEmbeddingEntityLoadingError(errorPage, { isGuestEmbed })) {

--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-init-data/use-init-data-internal.ts
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-init-data/use-init-data-internal.ts
@@ -115,7 +115,7 @@ export const useInitDataInternal = ({
     }
 
     if (isGuestEmbed) {
-      dispatch(initGuestEmbed());
+      dispatch(initGuestEmbed(authConfig));
     } else {
       dispatch(initAuth({ ...authConfig, isLocalHost }));
     }

--- a/frontend/src/embedding-sdk-bundle/store/guest-embed/auth.ts
+++ b/frontend/src/embedding-sdk-bundle/store/guest-embed/auth.ts
@@ -1,0 +1,126 @@
+// This file reflects the structure in enterprise/frontend/src/embedding-sdk-ee/auth/auth.ts
+import type { AsyncThunkAction, SerializedError } from "@reduxjs/toolkit";
+import { createAction } from "@reduxjs/toolkit";
+
+import type { SdkStoreState } from "embedding-sdk-bundle/store/types";
+import type { MetabaseAuthConfig } from "embedding-sdk-bundle/types/auth-config";
+import { requestSessionTokenFromEmbedJs } from "metabase/embedding/embedding-iframe-sdk/utils/request-session-token";
+import { isWithinIframe } from "metabase/lib/dom";
+import { decodeJwt } from "metabase/lib/jwt";
+import { createAsyncThunk } from "metabase/lib/redux";
+
+import { getSessionTokenState } from "../selectors";
+
+// Module-level promise for preventing concurrent refreshes
+let refreshGuestSessionPromise: ReturnType<
+  AsyncThunkAction<string | null, unknown, any>
+> | null = null;
+
+/**
+ * Sets the initial guest embed token when a component first loads.
+ * This is different from refreshing - it stores the token that was
+ * passed as a prop to the dashboard or question component.
+ */
+export const setInitialGuestToken = createAction<string>(
+  "sdk/guest-embed/SET_INITIAL_TOKEN",
+);
+
+/**
+ * Records a token fetch error so dashboard/question components can display it
+ * via the existing tokenFetchError path, even before the component has mounted.
+ */
+export const setGuestTokenFetchError = createAction<SerializedError | null>(
+  "sdk/guest-embed/SET_TOKEN_FETCH_ERROR",
+);
+
+/**
+ * Fetches a new guest embed token from the configured refresh endpoint.
+ * For iframe embeds, delegates to embed.js via postMessage (CSP-safe).
+ * Returns the raw JWT string.
+ */
+export const refreshGuestSession = createAsyncThunk(
+  "sdk/guest-embed/REFRESH_SESSION",
+  async ({
+    authConfig,
+    expiredToken,
+  }: {
+    authConfig: MetabaseAuthConfig & { guestEmbedProviderUri?: string };
+    expiredToken: string;
+  }): Promise<string> => {
+    if (!authConfig.guestEmbedProviderUri) {
+      throw new Error(
+        "guestEmbedProviderUri is required for guest embed token refresh",
+      );
+    }
+
+    // For iframe embeds, delegate refresh to embed.js (avoids CSP)
+    if (!isWithinIframe()) {
+      throw new Error(
+        "Guest embed token refresh is only supported in iframe embeds",
+      );
+    }
+
+    const token = await requestSessionTokenFromEmbedJs({ expiredToken });
+    return token;
+  },
+);
+
+/**
+ * Gets or refreshes the current guest token.
+ * Unlike the SSO counterpart, returns the raw JWT string, not the decoded session object.
+ */
+export const getOrRefreshGuestSession = createAsyncThunk(
+  "sdk/guest-embed/GET_OR_REFRESH_TOKEN",
+  async (
+    authConfig: MetabaseAuthConfig & { guestEmbedProviderUri?: string },
+    { dispatch, getState },
+  ) => {
+    const state = getState() as SdkStoreState;
+    const tokenState = getSessionTokenState(state);
+    const currentToken = tokenState.rawToken;
+
+    // No token in Redux yet — useEffect hasn't run. Skip; initial JWTs are rarely expired in the first load.
+    if (!currentToken) {
+      return null;
+    }
+
+    const session = decodeJwt(currentToken);
+
+    // Cypress can't mock time inside an iframe, so we support a window flag
+    // that forces a token refresh for testing purposes.
+    let forceRefreshForCypress;
+    if (typeof window !== "undefined") {
+      forceRefreshForCypress =
+        (window as any).FORCE_REFRESH_GUEST_EMBED_TOKEN_IN_CYPRESS === true;
+    }
+    if (forceRefreshForCypress) {
+      (window as any).FORCE_REFRESH_GUEST_EMBED_TOKEN_IN_CYPRESS = false;
+    }
+
+    const shouldRefreshToken =
+      forceRefreshForCypress ||
+      !session ||
+      (typeof session?.exp === "number" && session.exp * 1000 < Date.now());
+
+    if (!shouldRefreshToken || !authConfig.guestEmbedProviderUri) {
+      return currentToken;
+    }
+
+    if (refreshGuestSessionPromise) {
+      return refreshGuestSessionPromise.unwrap();
+    }
+
+    refreshGuestSessionPromise = dispatch(
+      refreshGuestSession({
+        authConfig,
+        expiredToken: currentToken!,
+      }),
+    );
+
+    refreshGuestSessionPromise.finally(() => {
+      refreshGuestSessionPromise = null;
+    });
+
+    return refreshGuestSessionPromise.unwrap();
+  },
+);

--- a/frontend/src/embedding-sdk-bundle/store/guest-embed/auth.ts
+++ b/frontend/src/embedding-sdk-bundle/store/guest-embed/auth.ts
@@ -11,24 +11,15 @@ import { createAsyncThunk } from "metabase/lib/redux";
 
 import { getSessionTokenState } from "../selectors";
 
-// Module-level promise for preventing concurrent refreshes
 let refreshGuestSessionPromise: ReturnType<
   AsyncThunkAction<string | null, unknown, any>
 > | null = null;
 
-/**
- * Sets the initial guest embed token when a component first loads.
- * This is different from refreshing - it stores the token that was
- * passed as a prop to the dashboard or question component.
- */
+// Sets the initial guest embed token when a component first loads.
 export const setInitialGuestToken = createAction<string>(
   "sdk/guest-embed/SET_INITIAL_TOKEN",
 );
 
-/**
- * Records a token fetch error so dashboard/question components can display it
- * via the existing tokenFetchError path, even before the component has mounted.
- */
 export const setGuestTokenFetchError = createAction<SerializedError | null>(
   "sdk/guest-embed/SET_TOKEN_FETCH_ERROR",
 );
@@ -44,10 +35,10 @@ export const refreshGuestSession = createAsyncThunk(
     authConfig,
     expiredToken,
   }: {
-    authConfig: MetabaseAuthConfig & { guestEmbedProviderUri?: string };
+    authConfig: MetabaseAuthConfig;
     expiredToken: string;
   }): Promise<string> => {
-    if (!authConfig.guestEmbedProviderUri) {
+    if (authConfig.isGuest && !authConfig.guestEmbedProviderUri) {
       throw new Error(
         "guestEmbedProviderUri is required for guest embed token refresh",
       );
@@ -60,34 +51,31 @@ export const refreshGuestSession = createAsyncThunk(
       );
     }
 
-    const token = await requestSessionTokenFromEmbedJs({ expiredToken });
-    return token;
+    return await requestSessionTokenFromEmbedJs({ expiredToken });
   },
 );
 
-/**
- * Gets or refreshes the current guest token.
- * Unlike the SSO counterpart, returns the raw JWT string, not the decoded session object.
- */
+// Unlike the SSO counterpart, returns the raw JWT string, not the decoded session object.
 export const getOrRefreshGuestSession = createAsyncThunk(
   "sdk/guest-embed/GET_OR_REFRESH_TOKEN",
-  async (
-    authConfig: MetabaseAuthConfig & { guestEmbedProviderUri?: string },
-    { dispatch, getState },
-  ) => {
+  async (authConfig: MetabaseAuthConfig, { dispatch, getState }) => {
     const state = getState() as SdkStoreState;
     const tokenState = getSessionTokenState(state);
     const currentToken = tokenState.rawToken;
 
-    // No token in Redux yet — useEffect hasn't run. Skip; initial JWTs are rarely expired in the first load.
+    // No token in Redux yet, so we can't check expiration.
     if (!currentToken) {
       return null;
     }
 
     const session = decodeJwt(currentToken);
 
-    // Cypress can't mock time inside an iframe, so we support a window flag
-    // that forces a token refresh for testing purposes.
+    /**
+     * Cypress can't mock time inside an iframe, so we support a window flag
+     * that forces a token refresh for testing purposes.
+     *
+     * We also, couldn't check window.CYPRESS because that only exists in the parent window.
+     */
     let forceRefreshForCypress;
     if (typeof window !== "undefined") {
       forceRefreshForCypress =
@@ -102,7 +90,7 @@ export const getOrRefreshGuestSession = createAsyncThunk(
       !session ||
       (typeof session?.exp === "number" && session.exp * 1000 < Date.now());
 
-    if (!shouldRefreshToken || !authConfig.guestEmbedProviderUri) {
+    if (!shouldRefreshToken) {
       return currentToken;
     }
 

--- a/frontend/src/embedding-sdk-bundle/store/guest-embed/auth.ts
+++ b/frontend/src/embedding-sdk-bundle/store/guest-embed/auth.ts
@@ -40,7 +40,7 @@ export const refreshGuestSession = createAsyncThunk(
   }): Promise<string> => {
     if (authConfig.isGuest && !authConfig.guestEmbedProviderUri) {
       throw new Error(
-        "guestEmbedProviderUri is required for guest embed token refresh",
+        "guestEmbedProviderUri is required to refresh the guest embed token",
       );
     }
 

--- a/frontend/src/embedding-sdk-bundle/store/guest-embed/auth.ts
+++ b/frontend/src/embedding-sdk-bundle/store/guest-embed/auth.ts
@@ -5,7 +5,7 @@ import { createAction } from "@reduxjs/toolkit";
 import type { SdkStoreState } from "embedding-sdk-bundle/store/types";
 import type { MetabaseAuthConfig } from "embedding-sdk-bundle/types/auth-config";
 import { requestSessionTokenFromEmbedJs } from "metabase/embedding/embedding-iframe-sdk/utils/request-session-token";
-import { isWithinIframe } from "metabase/lib/dom";
+import { isEmbeddingEajs } from "metabase/embedding-sdk/config";
 import { decodeJwt } from "metabase/lib/jwt";
 import { createAsyncThunk } from "metabase/lib/redux";
 
@@ -44,14 +44,13 @@ export const refreshGuestSession = createAsyncThunk(
       );
     }
 
-    // For iframe embeds, delegate refresh to embed.js (avoids CSP)
-    if (!isWithinIframe()) {
-      throw new Error(
-        "Guest embed token refresh is only supported in iframe embeds",
-      );
+    if (isEmbeddingEajs()) {
+      return await requestSessionTokenFromEmbedJs({ expiredToken });
     }
 
-    return await requestSessionTokenFromEmbedJs({ expiredToken });
+    throw new Error(
+      "Guest embed token refresh is only supported in iframe embeds",
+    );
   },
 );
 

--- a/frontend/src/embedding-sdk-bundle/store/guest-embed/guest-embed.ts
+++ b/frontend/src/embedding-sdk-bundle/store/guest-embed/guest-embed.ts
@@ -1,11 +1,63 @@
+import { merge } from "icepick";
+
+import type { MetabaseAuthConfig } from "embedding-sdk-bundle/types/auth-config";
 import { overrideRequestsForGuestEmbeds } from "metabase/embedding/lib/override-requests-for-embeds";
+import { isJWT } from "metabase/lib/jwt";
 import { createAsyncThunk } from "metabase/lib/redux";
+import { PLUGIN_EMBEDDING_SDK } from "metabase/plugins";
+import type { OnBeforeRequestHandlerConfig } from "metabase/plugins/oss/api";
 import { refreshSiteSettings } from "metabase/redux/settings";
 
-export const initGuestEmbed = createAsyncThunk<void, undefined>(
+import { getOrRefreshGuestSession } from "./auth";
+
+export const initGuestEmbed = createAsyncThunk<void, MetabaseAuthConfig>(
   "sdk/token/INIT_GUEST_EMBED",
-  async (_: any, { dispatch }) => {
+  async (authConfig: MetabaseAuthConfig, { dispatch }) => {
     overrideRequestsForGuestEmbeds();
+
+    // Check `isGuest` to narrow the type.
+    if (authConfig.isGuest && authConfig.guestEmbedProviderUri) {
+      // Replaces the request token with the newly refreshed guest embed token.
+      PLUGIN_EMBEDDING_SDK.onBeforeRequestHandlers.getOrRefreshGuestSessionHandler =
+        async (config: OnBeforeRequestHandlerConfig) => {
+          const newToken = await dispatch(
+            getOrRefreshGuestSession(authConfig),
+          ).unwrap();
+
+          if (newToken && "entityIdentifier" in config.data) {
+            return merge(config, {
+              data: {
+                entityIdentifier: newToken,
+              },
+            });
+          }
+
+          if (newToken && "token" in config.data) {
+            return merge(config, {
+              data: {
+                token: newToken,
+              },
+            });
+          }
+
+          // The token value is inlined in the URL path (e.g. /api/embed/card/{jwt}/query).
+          // Replace it with :entityIdentifier so the parameter substitution in api.js
+          // can bake the refreshed token into the URL.
+          if (newToken) {
+            const jwtInUrl = config.url
+              .split("/")
+              .find((segment) => isJWT(segment));
+
+            if (jwtInUrl) {
+              return merge(config, {
+                url: config.url.replace(jwtInUrl, ":entityIdentifier"),
+                data: { entityIdentifier: newToken },
+              });
+            }
+          }
+        };
+    }
+
     await dispatch(refreshSiteSettings());
   },
 );

--- a/frontend/src/embedding-sdk-bundle/store/guest-embed/guest-embed.ts
+++ b/frontend/src/embedding-sdk-bundle/store/guest-embed/guest-embed.ts
@@ -15,7 +15,6 @@ export const initGuestEmbed = createAsyncThunk<void, MetabaseAuthConfig>(
   async (authConfig: MetabaseAuthConfig, { dispatch }) => {
     overrideRequestsForGuestEmbeds();
 
-    // Check `isGuest` to narrow the type.
     if (authConfig.isGuest && authConfig.guestEmbedProviderUri) {
       // Replaces the request token with the newly refreshed guest embed token.
       PLUGIN_EMBEDDING_SDK.onBeforeRequestHandlers.getOrRefreshGuestSessionHandler =
@@ -24,6 +23,7 @@ export const initGuestEmbed = createAsyncThunk<void, MetabaseAuthConfig>(
             getOrRefreshGuestSession(authConfig),
           ).unwrap();
 
+          // The URL is templated (e.g. /api/embed/card/:entityIdentifier/params/:paramId/values or /api/embed/card/:token/query)
           if (newToken && "entityIdentifier" in config.data) {
             return merge(config, {
               data: {

--- a/frontend/src/embedding-sdk-bundle/store/guest-embed/index.ts
+++ b/frontend/src/embedding-sdk-bundle/store/guest-embed/index.ts
@@ -1,1 +1,2 @@
 export * from "./guest-embed";
+export * from "./auth";

--- a/frontend/src/embedding-sdk-bundle/store/reducer.ts
+++ b/frontend/src/embedding-sdk-bundle/store/reducer.ts
@@ -59,6 +59,7 @@ const initialState: SdkState = {
   metabaseInstanceVersion: null,
   token: {
     token: null,
+    rawToken: null,
     loading: false,
     error: null,
   },
@@ -79,6 +80,7 @@ export const sdk = createReducer(initialState, (builder) => {
   builder.addCase(refreshTokenAsync.fulfilled, (state, action) => {
     state.token = {
       token: action.payload,
+      rawToken: null,
       loading: false,
       error: null,
     };
@@ -160,7 +162,6 @@ export const sdk = createReducer(initialState, (builder) => {
   });
 
   builder.addCase(setInitialGuestToken, (state, action) => {
-    // Store the raw JWT string
     state.token = {
       ...state.token,
       rawToken: action.payload,
@@ -175,7 +176,6 @@ export const sdk = createReducer(initialState, (builder) => {
   });
 
   builder.addCase(refreshGuestSession.fulfilled, (state, action) => {
-    // Store the raw JWT string returned from refresh
     state.token = {
       ...state.token,
       rawToken: action.payload,
@@ -186,7 +186,6 @@ export const sdk = createReducer(initialState, (builder) => {
 
   builder.addCase(refreshGuestSession.rejected, (state, action) => {
     const error = action.error;
-    console.error("Failed to refresh guest token:", error);
     state.token = {
       ...state.token,
       loading: false,

--- a/frontend/src/embedding-sdk-bundle/store/reducer.ts
+++ b/frontend/src/embedding-sdk-bundle/store/reducer.ts
@@ -11,7 +11,12 @@ import type { SdkUsageProblem } from "embedding-sdk-bundle/types/usage-problem";
 import type { MetabaseFetchRequestTokenFn } from "metabase/embedding-sdk/types/refresh-token";
 
 import { initAuth, refreshTokenAsync } from "./auth";
-import { initGuestEmbed } from "./guest-embed";
+import {
+  initGuestEmbed,
+  refreshGuestSession,
+  setGuestTokenFetchError,
+  setInitialGuestToken,
+} from "./guest-embed";
 const SET_IS_GUEST_EMBED = "sdk/SET_IS_GUEST_EMBED";
 const SET_METABASE_INSTANCE_VERSION = "sdk/SET_METABASE_INSTANCE_VERSION";
 const SET_METABASE_CLIENT_URL = "sdk/SET_METABASE_CLIENT_URL";
@@ -147,5 +152,45 @@ export const sdk = createReducer(initialState, (builder) => {
 
   builder.addCase(setUsageProblem, (state, action) => {
     state.usageProblem = action.payload;
+  });
+
+  // Guest embed token management
+  builder.addCase(setGuestTokenFetchError, (state, action) => {
+    state.token = { ...state.token, loading: false, error: action.payload };
+  });
+
+  builder.addCase(setInitialGuestToken, (state, action) => {
+    // Store the raw JWT string
+    state.token = {
+      ...state.token,
+      rawToken: action.payload,
+    };
+  });
+
+  builder.addCase(refreshGuestSession.pending, (state) => {
+    state.token = {
+      ...state.token,
+      loading: true,
+    };
+  });
+
+  builder.addCase(refreshGuestSession.fulfilled, (state, action) => {
+    // Store the raw JWT string returned from refresh
+    state.token = {
+      ...state.token,
+      rawToken: action.payload,
+      loading: false,
+      error: null,
+    };
+  });
+
+  builder.addCase(refreshGuestSession.rejected, (state, action) => {
+    const error = action.error;
+    console.error("Failed to refresh guest token:", error);
+    state.token = {
+      ...state.token,
+      loading: false,
+      error,
+    };
   });
 });

--- a/frontend/src/embedding-sdk-bundle/store/reducer.ts
+++ b/frontend/src/embedding-sdk-bundle/store/reducer.ts
@@ -165,6 +165,8 @@ export const sdk = createReducer(initialState, (builder) => {
     state.token = {
       ...state.token,
       rawToken: action.payload,
+      loading: false,
+      error: null,
     };
   });
 

--- a/frontend/src/embedding-sdk-bundle/store/types.ts
+++ b/frontend/src/embedding-sdk-bundle/store/types.ts
@@ -20,6 +20,7 @@ import type { State } from "metabase-types/store";
 
 export type EmbeddingSessionTokenState = {
   token: MetabaseEmbeddingSessionToken | null;
+  rawToken?: string | null; // Raw JWT string for guest embeds
   loading: boolean;
   error: SerializedError | null;
 };

--- a/frontend/src/embedding-sdk-bundle/store/types.ts
+++ b/frontend/src/embedding-sdk-bundle/store/types.ts
@@ -20,7 +20,7 @@ import type { State } from "metabase-types/store";
 
 export type EmbeddingSessionTokenState = {
   token: MetabaseEmbeddingSessionToken | null;
-  rawToken?: string | null; // Raw JWT string for guest embeds
+  rawToken: string | null; // Raw JWT string for guest embeds token refresh
   loading: boolean;
   error: SerializedError | null;
 };

--- a/frontend/src/embedding-sdk-bundle/test/mocks/state.ts
+++ b/frontend/src/embedding-sdk-bundle/test/mocks/state.ts
@@ -7,7 +7,7 @@ import type { LoginStatus } from "embedding-sdk-bundle/types/user";
 export const createMockTokenState = ({
   ...opts
 }: Partial<EmbeddingSessionTokenState> = {}): EmbeddingSessionTokenState => {
-  return { error: null, loading: false, token: null, ...opts };
+  return { error: null, loading: false, token: null, rawToken: null, ...opts };
 };
 
 export const createMockLoginStatusState = ({

--- a/frontend/src/embedding-sdk-bundle/types/auth-config.ts
+++ b/frontend/src/embedding-sdk-bundle/types/auth-config.ts
@@ -69,8 +69,8 @@ export type MetabaseIsGuestAuthConfig = BaseMetabaseAuthConfig & {
 
   /**
    * URL endpoint for fetching and refreshing guest embed JWT tokens (iframe only, not applicable for SDK's guest mode).
-   * Supports token refresh on expiry. Optionally also handles the initial token fetch
-   * when no static token is provided to the guest embed components (e.g. metabase-dashboard, metabase-question).
+   * Supports both token refresh on expiry and initial token fetch when no static token is provided.
+   * In both cases, this works with guest embed components (metabase-dashboard and metabase-question).
    * The endpoint should return { jwt: string } with the new token.
    */
   guestEmbedProviderUri?: string;

--- a/frontend/src/embedding-sdk-bundle/types/auth-config.ts
+++ b/frontend/src/embedding-sdk-bundle/types/auth-config.ts
@@ -66,6 +66,15 @@ export type MetabaseIsGuestAuthConfig = BaseMetabaseAuthConfig & {
    * Defines if SDK should work in a Guest Embed mode
    */
   isGuest: true;
+
+  /**
+   * URL endpoint for fetching and refreshing guest embed JWT tokens (iframe only, not applicable for SDK's guest mode).
+   * Supports token refresh on expiry. Optionally also handles the initial token fetch
+   * when no static token is provided to the guest embed components (e.g. metabase-dashboard, metabase-question).
+   * The endpoint should return { jwt: string } with the new token.
+   */
+  guestEmbedProviderUri?: string;
+
   apiKey?: never;
   preferredAuthMethod?: never;
   fetchRequestToken?: never;

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx
@@ -52,6 +52,7 @@ createTracker(store);
 export const SdkIframeEmbedRoute = () => {
   const { embedSettings } = useSdkIframeEmbedEventBus({
     onSettingsChanged,
+    store,
   });
 
   const adjustedTheme = useMemo(
@@ -94,6 +95,7 @@ export const SdkIframeEmbedRoute = () => {
     isGuest: embedSettings.isGuest,
     metabaseInstanceUrl: embedSettings.instanceUrl,
     apiKey: embedSettings.apiKey,
+    guestEmbedProviderUri: embedSettings.guestEmbedProviderUri,
   } as MetabaseAuthConfig;
 
   return (

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/constants.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/constants.ts
@@ -28,6 +28,7 @@ export const ALLOWED_EMBED_SETTING_KEYS_MAP = {
     "isGuest",
     "jwtProviderUri",
     "pluginsConfig",
+    "guestEmbedProviderUri",
   ] satisfies (keyof SdkIframeEmbedBaseSettings)[],
   dashboard: [
     "dashboardId",
@@ -39,6 +40,7 @@ export const ALLOWED_EMBED_SETTING_KEYS_MAP = {
     "hiddenParameters",
     "drills",
     "enableEntityNavigation",
+    "customContext",
   ] satisfies (keyof DashboardEmbedOptions)[],
   chart: [
     "questionId",
@@ -50,6 +52,7 @@ export const ALLOWED_EMBED_SETTING_KEYS_MAP = {
     "hiddenParameters",
     "drills",
     "entityTypes",
+    "customContext",
   ] satisfies (keyof QuestionEmbedOptions)[],
   exploration: [
     "template",

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.ts
@@ -582,8 +582,6 @@ export abstract class MetabaseEmbedElement<T extends string[] = string[]>
     const { guestEmbedProviderUri, componentName, dashboardId, questionId } =
       this.properties;
 
-    // Callers always guard guestEmbedProviderUri before invoking this function.
-    // This check is only to satisfy TypeScript's type narrowing.
     if (!guestEmbedProviderUri) {
       return "";
     }
@@ -599,10 +597,8 @@ export abstract class MetabaseEmbedElement<T extends string[] = string[]>
 
     const isRefreshingToken = expiredToken !== undefined;
 
-    // If the user supplies dashboardId/questionId without a static token prop
-    // (token fetch and refresh handled by their JWT endpoint), use those attributes.
-    // Otherwise, for the static token case (token={jwt}), fall back to decoding
-    // the expired token's payload to extract the entity ID.
+    // Prefer the attribute entity ID; fall back to decoding the expired token
+    // for the static token case (no dashboardId/questionId attribute).
     const attributeEntityId =
       componentName === "metabase-dashboard" ? dashboardId : questionId;
     const tokenEntityId = isRefreshingToken

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.ts
@@ -1,10 +1,12 @@
 import { MetabaseError, SSO_NOT_ALLOWED } from "embedding-sdk-bundle/errors";
+import * as MetabaseErrors from "embedding-sdk-bundle/errors";
 import { PLUGIN_EMBED_JS_EE } from "metabase/embedding/embedding-iframe-sdk/plugin";
 import type {
   EmbedAuthManager,
   EmbedAuthManagerContext,
 } from "metabase/embedding/embedding-iframe-sdk/types/auth-manager";
 import type { ComponentToAttributes } from "metabase/embedding/embedding-iframe-sdk/types/modular-embedding";
+import { decodeJwt } from "metabase/lib/jwt";
 
 import { debouncedReportAnalytics } from "./analytics";
 import {
@@ -157,6 +159,12 @@ export abstract class MetabaseEmbedElement<T extends string[] = string[]>
     Set<SdkIframeEmbedEventHandler>
   > = new Map();
   private _authManager: EmbedAuthManager | null = null;
+  ["custom-context"]: unknown;
+
+  constructor() {
+    super();
+    this["custom-context"] = undefined;
+  }
 
   get globalSettings() {
     return (window as any).metabaseConfig || {};
@@ -428,12 +436,25 @@ export abstract class MetabaseEmbedElement<T extends string[] = string[]>
         // this is used from tests to await the loading of the iframe
         this._iframe.setAttribute("data-iframe-loaded", "true");
       }
-      this._updateSettings(this.properties);
+
+      const { guestEmbedProviderUri, token } = this.properties;
+
+      // No static token provided — fetch initial guest token first, then send settings
+      if (guestEmbedProviderUri && !token) {
+        await this._fetchInitialGuestToken();
+      } else {
+        this._updateSettings(this.properties);
+      }
+
       this._emitEvent({ type: "ready" });
     }
 
     if (event.data.type === "metabase.embed.requestSessionToken") {
       await this._authenticate();
+    }
+
+    if (event.data.type === "metabase.embed.requestGuestTokenRefresh") {
+      await this._refreshGuestToken(event.data.data.expiredToken);
     }
 
     // Note: if we wrap other functions like this, let's come up with a generic utility function
@@ -498,6 +519,122 @@ export abstract class MetabaseEmbedElement<T extends string[] = string[]>
     }
 
     await this._authManager.authenticate();
+  }
+
+  /**
+   * Handles token refresh, and the initial token fetch if no static token is provided.
+   * Unlike the SSO counterpart which lives in the plugin system (EE-only),
+   * guest embeds are OSS so this is implemented directly here in embed.ts.
+   */
+  private async _callGuestTokenProvider(
+    expiredToken?: string,
+  ): Promise<string> {
+    const { guestEmbedProviderUri, componentName, dashboardId, questionId } =
+      this.properties;
+
+    // Callers always guard guestEmbedProviderUri before invoking this function.
+    // This check is only to satisfy TypeScript's type narrowing.
+    if (!guestEmbedProviderUri) {
+      return "";
+    }
+
+    const guestEmbedProviderUrl = new URL(
+      guestEmbedProviderUri,
+      window.location.origin,
+    );
+    guestEmbedProviderUrl.searchParams.set("response", "json");
+
+    const entityType =
+      componentName === "metabase-dashboard" ? "dashboard" : "question";
+
+    const isRefreshingToken = expiredToken !== undefined;
+
+    // If the user supplies dashboardId/questionId without a static token prop
+    // (token fetch and refresh handled by their JWT endpoint), use those attributes.
+    // Otherwise, for the static token case (token={jwt}), fall back to decoding
+    // the expired token's payload to extract the entity ID.
+    const attributeEntityId =
+      componentName === "metabase-dashboard" ? dashboardId : questionId;
+    const tokenEntityId = isRefreshingToken
+      ? decodeJwt(expiredToken)?.resource?.[entityType]
+      : undefined;
+    const entityId = attributeEntityId ?? tokenEntityId;
+
+    const customContext = this["custom-context"];
+    const body = {
+      entityType,
+      entityId,
+      ...(customContext !== undefined && { customContext }),
+    };
+
+    const response = await fetch(guestEmbedProviderUrl.toString(), {
+      method: "POST",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      throw MetabaseErrors.CANNOT_FETCH_JWT_TOKEN({
+        url: guestEmbedProviderUri,
+        status: String(response.status),
+      });
+    }
+
+    const data = await response.json();
+
+    if (typeof data !== "object" || typeof data.jwt !== "string") {
+      throw MetabaseErrors.DEFAULT_ENDPOINT_ERROR({
+        actual: JSON.stringify(data),
+      });
+    }
+
+    return data.jwt;
+  }
+
+  /**
+   * Fetches the initial guest token when no static token is provided.
+   * Stores the result and sends settings to the iframe.
+   */
+  private async _fetchInitialGuestToken(): Promise<void> {
+    try {
+      const token = await this._callGuestTokenProvider();
+      this._updateSettings({ token });
+    } catch (error) {
+      this.sendMessage("metabase.embed.reportAuthenticationError", {
+        error:
+          error instanceof MetabaseError
+            ? error
+            : MetabaseErrors.CANNOT_FETCH_JWT_TOKEN({
+                url: this.properties.guestEmbedProviderUri ?? "",
+                message: error instanceof Error ? error.message : String(error),
+              }),
+      });
+      // Send settings without a token so ComponentProvider can mount and display the error.
+      this._updateSettings(this.properties);
+    }
+  }
+
+  /**
+   * Called when the iframe requests a token refresh.
+   */
+  private async _refreshGuestToken(expiredToken: string): Promise<void> {
+    try {
+      const token = await this._callGuestTokenProvider(expiredToken);
+      this.sendMessage("metabase.embed.submitRefreshedGuestToken", {
+        guestToken: token,
+      });
+    } catch (error) {
+      this.sendMessage("metabase.embed.reportAuthenticationError", {
+        error:
+          error instanceof MetabaseError
+            ? error
+            : MetabaseErrors.CANNOT_FETCH_JWT_TOKEN({
+                url: this.properties.guestEmbedProviderUri ?? "",
+                message: error instanceof Error ? error.message : String(error),
+              }),
+      });
+    }
   }
 }
 

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.ts
@@ -521,9 +521,59 @@ export abstract class MetabaseEmbedElement<T extends string[] = string[]>
     await this._authManager.authenticate();
   }
 
+  private async _fetchInitialGuestToken(): Promise<void> {
+    try {
+      const token = await this._callGuestTokenProvider();
+      this._updateSettings({
+        token,
+        /**
+         * Clear these so SdkIframeEmbedRoute routes via the guest token branch, not the
+         * other branches (which matches on dashboardId/questionId). This applies to the
+         * call below too.
+         */
+        dashboardId: undefined,
+        questionId: undefined,
+      });
+    } catch (error) {
+      this.sendMessage("metabase.embed.reportAuthenticationError", {
+        error:
+          error instanceof MetabaseError
+            ? error
+            : MetabaseErrors.CANNOT_FETCH_JWT_TOKEN({
+                url: this.properties.guestEmbedProviderUri ?? "",
+                message: error instanceof Error ? error.message : String(error),
+              }),
+      });
+      // Send settings without a token so ComponentProvider can mount and display the error.
+      this._updateSettings({
+        dashboardId: undefined,
+        questionId: undefined,
+      });
+    }
+  }
+
+  private async _refreshGuestToken(expiredToken: string): Promise<void> {
+    try {
+      const token = await this._callGuestTokenProvider(expiredToken);
+      this.sendMessage("metabase.embed.submitRefreshedGuestToken", {
+        guestToken: token,
+      });
+    } catch (error) {
+      this.sendMessage("metabase.embed.reportAuthenticationError", {
+        error:
+          error instanceof MetabaseError
+            ? error
+            : MetabaseErrors.CANNOT_FETCH_JWT_TOKEN({
+                url: this.properties.guestEmbedProviderUri ?? "",
+                message: error instanceof Error ? error.message : String(error),
+              }),
+      });
+    }
+  }
+
   /**
    * Handles token refresh, and the initial token fetch if no static token is provided.
-   * Unlike the SSO counterpart which lives in the plugin system (EE-only),
+   * Unlike the SSO counterpart which lives in the plugin system (AuthManager.ts),
    * guest embeds are OSS so this is implemented directly here in embed.ts.
    */
   private async _callGuestTokenProvider(
@@ -590,51 +640,6 @@ export abstract class MetabaseEmbedElement<T extends string[] = string[]>
     }
 
     return data.jwt;
-  }
-
-  /**
-   * Fetches the initial guest token when no static token is provided.
-   * Stores the result and sends settings to the iframe.
-   */
-  private async _fetchInitialGuestToken(): Promise<void> {
-    try {
-      const token = await this._callGuestTokenProvider();
-      this._updateSettings({ token });
-    } catch (error) {
-      this.sendMessage("metabase.embed.reportAuthenticationError", {
-        error:
-          error instanceof MetabaseError
-            ? error
-            : MetabaseErrors.CANNOT_FETCH_JWT_TOKEN({
-                url: this.properties.guestEmbedProviderUri ?? "",
-                message: error instanceof Error ? error.message : String(error),
-              }),
-      });
-      // Send settings without a token so ComponentProvider can mount and display the error.
-      this._updateSettings(this.properties);
-    }
-  }
-
-  /**
-   * Called when the iframe requests a token refresh.
-   */
-  private async _refreshGuestToken(expiredToken: string): Promise<void> {
-    try {
-      const token = await this._callGuestTokenProvider(expiredToken);
-      this.sendMessage("metabase.embed.submitRefreshedGuestToken", {
-        guestToken: token,
-      });
-    } catch (error) {
-      this.sendMessage("metabase.embed.reportAuthenticationError", {
-        error:
-          error instanceof MetabaseError
-            ? error
-            : MetabaseErrors.CANNOT_FETCH_JWT_TOKEN({
-                url: this.properties.guestEmbedProviderUri ?? "",
-                message: error instanceof Error ? error.message : String(error),
-              }),
-      });
-    }
   }
 }
 

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.ts
@@ -509,11 +509,21 @@ export abstract class MetabaseEmbedElement<T extends string[] = string[]>
     }
   }
 
+  private reportAuthenticationError(error: unknown) {
+    this.sendMessage("metabase.embed.reportAuthenticationError", {
+      error:
+        error instanceof MetabaseError
+          ? error
+          : MetabaseErrors.CANNOT_FETCH_JWT_TOKEN({
+              url: this.properties.guestEmbedProviderUri ?? "",
+              message: error instanceof Error ? error.message : String(error),
+            }),
+    });
+  }
+
   private async _authenticate() {
     if (!this._authManager) {
-      this.sendMessage("metabase.embed.reportAuthenticationError", {
-        error: SSO_NOT_ALLOWED(),
-      });
+      this.reportAuthenticationError(SSO_NOT_ALLOWED());
 
       return;
     }
@@ -535,15 +545,7 @@ export abstract class MetabaseEmbedElement<T extends string[] = string[]>
         questionId: undefined,
       });
     } catch (error) {
-      this.sendMessage("metabase.embed.reportAuthenticationError", {
-        error:
-          error instanceof MetabaseError
-            ? error
-            : MetabaseErrors.CANNOT_FETCH_JWT_TOKEN({
-                url: this.properties.guestEmbedProviderUri ?? "",
-                message: error instanceof Error ? error.message : String(error),
-              }),
-      });
+      this.reportAuthenticationError(error);
       // Send settings without a token so ComponentProvider can mount and display the error.
       this._updateSettings({
         dashboardId: undefined,
@@ -559,15 +561,7 @@ export abstract class MetabaseEmbedElement<T extends string[] = string[]>
         guestToken: token,
       });
     } catch (error) {
-      this.sendMessage("metabase.embed.reportAuthenticationError", {
-        error:
-          error instanceof MetabaseError
-            ? error
-            : MetabaseErrors.CANNOT_FETCH_JWT_TOKEN({
-                url: this.properties.guestEmbedProviderUri ?? "",
-                message: error instanceof Error ? error.message : String(error),
-              }),
-      });
+      this.reportAuthenticationError(error);
     }
   }
 
@@ -583,28 +577,31 @@ export abstract class MetabaseEmbedElement<T extends string[] = string[]>
       this.properties;
 
     if (!guestEmbedProviderUri) {
-      return "";
+      throw MetabaseErrors.CANNOT_FETCH_JWT_TOKEN({
+        url: String(guestEmbedProviderUri),
+        message: "Guest embed provider URI is not configured.",
+      });
     }
 
-    const guestEmbedProviderUrl = new URL(
+    const guestEmbedProviderUriFullPath = new URL(
       guestEmbedProviderUri,
       window.location.origin,
     );
-    guestEmbedProviderUrl.searchParams.set("response", "json");
+    guestEmbedProviderUriFullPath.searchParams.set("response", "json");
 
     const entityType =
       componentName === "metabase-dashboard" ? "dashboard" : "question";
 
     const isRefreshingToken = expiredToken !== undefined;
 
-    // Prefer the attribute entity ID; fall back to decoding the expired token
+    // Prefer the attribute resource ID; fall back to decoding the expired token
     // for the static token case (no dashboardId/questionId attribute).
-    const attributeEntityId =
+    const attributeResourceId =
       componentName === "metabase-dashboard" ? dashboardId : questionId;
-    const tokenEntityId = isRefreshingToken
+    const tokenResourceId = isRefreshingToken
       ? decodeJwt(expiredToken)?.resource?.[entityType]
       : undefined;
-    const entityId = attributeEntityId ?? tokenEntityId;
+    const resourceId = attributeResourceId ?? tokenResourceId;
 
     // Only works in React 19
     const objectCustomContext = this["custom-context"];
@@ -612,11 +609,11 @@ export abstract class MetabaseEmbedElement<T extends string[] = string[]>
     const customContext = objectCustomContext ?? stringCustomContext;
     const body = {
       entityType,
-      entityId,
+      entityId: resourceId,
       ...(customContext !== undefined && { customContext }),
     };
 
-    const response = await fetch(guestEmbedProviderUrl.toString(), {
+    const response = await fetch(guestEmbedProviderUriFullPath.toString(), {
       method: "POST",
       credentials: "include",
       headers: { "Content-Type": "application/json" },
@@ -632,7 +629,11 @@ export abstract class MetabaseEmbedElement<T extends string[] = string[]>
 
     const data = await response.json();
 
-    if (typeof data !== "object" || typeof data.jwt !== "string") {
+    if (
+      data == null ||
+      typeof data !== "object" ||
+      typeof data.jwt !== "string"
+    ) {
       throw MetabaseErrors.DEFAULT_ENDPOINT_ERROR({
         actual: JSON.stringify(data),
       });

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.ts
@@ -606,7 +606,10 @@ export abstract class MetabaseEmbedElement<T extends string[] = string[]>
       : undefined;
     const entityId = attributeEntityId ?? tokenEntityId;
 
-    const customContext = this["custom-context"];
+    // Only works in React 19
+    const objectCustomContext = this["custom-context"];
+    const stringCustomContext = this.getAttribute("custom-context");
+    const customContext = objectCustomContext ?? stringCustomContext;
     const body = {
       entityType,
       entityId,

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.unit.spec.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.unit.spec.ts
@@ -232,9 +232,8 @@ describe("embed.js script tag for sdk iframe embedding", () => {
       if (token) {
         embed.setAttribute("token", token);
       }
-      // custom-context is a class property, not a reflected attribute
       if (customContext && embed instanceof MetabaseEmbedElement) {
-        embed["custom-context"] = customContext;
+        embed.setAttribute("custom-context", customContext);
       }
       document.body.appendChild(embed);
 

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.unit.spec.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.unit.spec.ts
@@ -405,7 +405,9 @@ describe("embed.js script tag for sdk iframe embedding", () => {
               // The rest of the properties
               instanceUrl: "http://localhost:3000",
               guestEmbedProviderUri: "/mock-provider",
-              dashboardId: 1,
+              // dashboardId and questionId are not sent — the token already encodes the resource
+              dashboardId: undefined,
+              questionId: undefined,
               componentName: "metabase-dashboard",
               _isLocalhost: true,
             },
@@ -432,6 +434,18 @@ describe("embed.js script tag for sdk iframe embedding", () => {
                 code: "CANNOT_FETCH_JWT_TOKEN",
               }),
             },
+          }),
+          "*",
+        );
+
+        expect(iframePostMessageSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: "metabase.embed.setSettings",
+            data: expect.objectContaining({
+              // dashboardId and questionId are not sent on error path either
+              dashboardId: undefined,
+              questionId: undefined,
+            }),
           }),
           "*",
         );

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.unit.spec.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.unit.spec.ts
@@ -1,6 +1,8 @@
+import fetchMock from "fetch-mock";
+import jwt from "jsonwebtoken";
 import { act } from "react-dom/test-utils";
 
-import type { MetabaseEmbedElement } from "./embed";
+import { MetabaseEmbedElement } from "./embed";
 
 const defineMetabaseConfig = (config: unknown) => {
   (window as any).metabaseConfig = config;
@@ -204,5 +206,259 @@ describe("embed.js script tag for sdk iframe embedding", () => {
     expect(iframe?.src).toMatch(
       /^https:\/\/example\.com\/embed\/sdk\/v1\?embed-js-identifier=\d+$/,
     );
+  });
+
+  describe("guest embed token provider", () => {
+    // Wait for all fetch mocks, and async/await to finish
+    const flushPromises = () =>
+      new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+    function setupGuestEmbed({
+      dashboardId,
+      token,
+      customContext,
+    }: {
+      dashboardId: string;
+      token?: string;
+      customContext?: string;
+    }) {
+      defineMetabaseConfig({
+        instanceUrl: "http://localhost:3000",
+        guestEmbedProviderUri: "/mock-provider",
+      });
+
+      const embed = document.createElement("metabase-dashboard");
+      embed.setAttribute("dashboard-id", dashboardId);
+      if (token) {
+        embed.setAttribute("token", token);
+      }
+      // custom-context is a class property, not a reflected attribute
+      if (customContext && embed instanceof MetabaseEmbedElement) {
+        embed["custom-context"] = customContext;
+      }
+      document.body.appendChild(embed);
+
+      const iframe = embed.querySelector("iframe") as HTMLIFrameElement;
+      const iframePostMessageSpy = jest.spyOn(
+        iframe.contentWindow!,
+        "postMessage",
+      );
+
+      const triggerIframeMessage = (data: unknown) => {
+        window.dispatchEvent(
+          new MessageEvent("message", { data, source: iframe.contentWindow }),
+        );
+      };
+
+      return { embed, iframe, iframePostMessageSpy, triggerIframeMessage };
+    }
+
+    describe("refresh token only (static token)", () => {
+      it("skips provider fetch and sends setSettings directly with static token", async () => {
+        const { triggerIframeMessage, iframePostMessageSpy } = setupGuestEmbed({
+          dashboardId: "1",
+          token: "static-jwt-token",
+        });
+
+        triggerIframeMessage({ type: "metabase.embed.iframeReady" });
+        await flushPromises();
+
+        expect(fetchMock.callHistory.calls("path:/mock-provider")).toHaveLength(
+          0,
+        );
+        expect(iframePostMessageSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: "metabase.embed.setSettings",
+            data: expect.objectContaining({ token: "static-jwt-token" }),
+          }),
+          "*",
+        );
+      });
+
+      it("POSTs { entityType, entityId, customContext } to provider and sends submitRefreshedGuestToken", async () => {
+        const expiredToken = jwt.sign(
+          {
+            resource: { dashboard: 1 },
+            /**
+             * 60 seconds ago. By the way, the expiration isn't verified here.
+             * But why mock any other value when we're passing an expired token here.
+             */
+            exp: Math.floor(Date.now() / 1000) - 60,
+          },
+          "jwt-secret",
+        );
+
+        fetchMock.post("path:/mock-provider", { jwt: "refreshed-token" });
+
+        const { triggerIframeMessage, iframePostMessageSpy } = setupGuestEmbed({
+          dashboardId: "1",
+          customContext: "my-context",
+        });
+
+        triggerIframeMessage({
+          type: "metabase.embed.requestGuestTokenRefresh",
+          data: { expiredToken },
+        });
+        await flushPromises();
+
+        const call = fetchMock.callHistory.lastCall("path:/mock-provider");
+        expect(call?.url).toContain("response=json");
+        expect(call?.options).toMatchObject({
+          method: "post",
+          body: JSON.stringify({
+            entityType: "dashboard",
+            entityId: 1,
+            customContext: "my-context",
+          }),
+        });
+
+        expect(iframePostMessageSpy).toHaveBeenCalledWith(
+          {
+            type: "metabase.embed.submitRefreshedGuestToken",
+            data: { guestToken: "refreshed-token" },
+          },
+          "*",
+        );
+      });
+
+      it("sends reportAuthenticationError to iframe when provider returns HTTP error", async () => {
+        fetchMock.post("path:/mock-provider", 403);
+
+        const { triggerIframeMessage, iframePostMessageSpy } = setupGuestEmbed({
+          dashboardId: "1",
+        });
+
+        triggerIframeMessage({
+          type: "metabase.embed.requestGuestTokenRefresh",
+          data: { expiredToken: "any.expired.token" },
+        });
+        await flushPromises();
+
+        expect(iframePostMessageSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: "metabase.embed.reportAuthenticationError",
+            data: {
+              error: expect.objectContaining({
+                code: "CANNOT_FETCH_JWT_TOKEN",
+              }),
+            },
+          }),
+          "*",
+        );
+      });
+
+      it("sends reportAuthenticationError to iframe when provider returns invalid JSON shape", async () => {
+        fetchMock.post("path:/mock-provider", { token: "wrong-field-name" });
+
+        const { triggerIframeMessage, iframePostMessageSpy } = setupGuestEmbed({
+          dashboardId: "1",
+        });
+
+        triggerIframeMessage({
+          type: "metabase.embed.requestGuestTokenRefresh",
+          data: { expiredToken: "any.expired.token" },
+        });
+        await flushPromises();
+
+        expect(iframePostMessageSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: "metabase.embed.reportAuthenticationError",
+            data: {
+              error: expect.objectContaining({
+                code: "DEFAULT_ENDPOINT_ERROR",
+              }),
+            },
+          }),
+          "*",
+        );
+      });
+    });
+
+    describe("initial token (no static token)", () => {
+      it("fetches initial token from provider with { entityType, entityId, customContext } and sends setSettings", async () => {
+        fetchMock.post("path:/mock-provider", { jwt: "initial-token" });
+
+        const { triggerIframeMessage, iframePostMessageSpy } = setupGuestEmbed({
+          dashboardId: "1",
+          customContext: "my-context",
+        });
+
+        triggerIframeMessage({ type: "metabase.embed.iframeReady" });
+        await flushPromises();
+
+        const call = fetchMock.callHistory.lastCall("path:/mock-provider");
+        expect(call?.url).toContain("response=json");
+        expect(call?.options).toMatchObject({
+          method: "post",
+          body: JSON.stringify({
+            entityType: "dashboard",
+            entityId: 1,
+            customContext: "my-context",
+          }),
+        });
+
+        expect(iframePostMessageSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: "metabase.embed.setSettings",
+            data: {
+              token: "initial-token",
+              // The rest of the properties
+              instanceUrl: "http://localhost:3000",
+              guestEmbedProviderUri: "/mock-provider",
+              dashboardId: 1,
+              componentName: "metabase-dashboard",
+              _isLocalhost: true,
+            },
+          }),
+          "*",
+        );
+      });
+
+      it("sends reportAuthenticationError when initial token fetch returns HTTP error", async () => {
+        fetchMock.post("path:/mock-provider", 500);
+
+        const { triggerIframeMessage, iframePostMessageSpy } = setupGuestEmbed({
+          dashboardId: "1",
+        });
+
+        triggerIframeMessage({ type: "metabase.embed.iframeReady" });
+        await flushPromises();
+
+        expect(iframePostMessageSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: "metabase.embed.reportAuthenticationError",
+            data: {
+              error: expect.objectContaining({
+                code: "CANNOT_FETCH_JWT_TOKEN",
+              }),
+            },
+          }),
+          "*",
+        );
+      });
+
+      it("sends reportAuthenticationError when initial token fetch returns invalid JSON shape", async () => {
+        fetchMock.post("path:/mock-provider", { token: "wrong-field" });
+
+        const { triggerIframeMessage, iframePostMessageSpy } = setupGuestEmbed({
+          dashboardId: "1",
+        });
+
+        triggerIframeMessage({ type: "metabase.embed.iframeReady" });
+        await flushPromises();
+
+        expect(iframePostMessageSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: "metabase.embed.reportAuthenticationError",
+            data: {
+              error: expect.objectContaining({
+                code: "DEFAULT_ENDPOINT_ERROR",
+              }),
+            },
+          }),
+          "*",
+        );
+      });
+    });
   });
 });

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/hooks/use-sdk-iframe-embed-event-bus.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/hooks/use-sdk-iframe-embed-event-bus.ts
@@ -54,6 +54,12 @@ export function useSdkIframeEmbedEventBus({
             embedHostUrl: data.embedHostUrl,
           });
         })
+
+        /**
+         * This handler is needed for the guest embed initial token flow. It also handles
+         * the refresh flow, but `request-session-token.ts` handles that too — that file
+         * covers both the SSO and the JWT refresh token flows.
+         */
         .with(
           { type: "metabase.embed.reportAuthenticationError" },
           ({ data }) => {

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/hooks/use-sdk-iframe-embed-event-bus.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/hooks/use-sdk-iframe-embed-event-bus.ts
@@ -1,6 +1,8 @@
 import { useEffect, useState } from "react";
 import { match } from "ts-pattern";
 
+import { setGuestTokenFetchError } from "embedding-sdk-bundle/store/guest-embed";
+import type { SdkStore } from "embedding-sdk-bundle/store/types";
 import { trackSchemaEvent } from "metabase/lib/analytics";
 import { isWithinIframe } from "metabase/lib/dom";
 import type { EmbeddedAnalyticsJsEventSchema } from "metabase-types/analytics/embedded-analytics-js";
@@ -24,8 +26,10 @@ const sendMessage = (message: SdkIframeEmbedTagMessage) => {
 
 export function useSdkIframeEmbedEventBus({
   onSettingsChanged,
+  store,
 }: {
   onSettingsChanged?: (settings: SdkIframeEmbedSettings) => void;
+  store: SdkStore;
 }) {
   const [embedSettings, setEmbedSettings] =
     useState<SdkIframeEmbedSettings | null>(null);
@@ -49,7 +53,15 @@ export function useSdkIframeEmbedEventBus({
             usage: data.usageAnalytics,
             embedHostUrl: data.embedHostUrl,
           });
-        });
+        })
+        .with(
+          { type: "metabase.embed.reportAuthenticationError" },
+          ({ data }) => {
+            store.dispatch(
+              setGuestTokenFetchError({ message: data.error?.message }),
+            );
+          },
+        );
     };
 
     window.addEventListener("message", messageHandler);
@@ -60,7 +72,7 @@ export function useSdkIframeEmbedEventBus({
     return () => {
       window.removeEventListener("message", messageHandler);
     };
-  }, [onSettingsChanged]);
+  }, [onSettingsChanged, store]);
 
   useEffect(() => {
     if (embedSettings?.instanceUrl && usageAnalytics) {

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/types/embed.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/types/embed.ts
@@ -26,7 +26,8 @@ import type { EmbeddingEntityType } from "metabase-types/store/embedding-data-pi
 export type SdkIframeEmbedTagMessage =
   | SdkIframeEmbedTagIframeReadyMessage
   | SdkIframeEmbedTagRequestSessionTokenMessage
-  | SdkIframeEmbedTagHandleLinkMessage;
+  | SdkIframeEmbedTagHandleLinkMessage
+  | SdkIframeEmbedTagRequestGuestTokenRefreshMessage;
 
 export type SdkIframeEmbedTagIframeReadyMessage = {
   type: "metabase.embed.iframeReady";
@@ -38,6 +39,12 @@ export type SdkIframeEmbedTagHandleLinkMessage = {
   type: "metabase.embed.handleLink";
   data: { url: string; requestId: string };
 };
+export type SdkIframeEmbedTagRequestGuestTokenRefreshMessage = {
+  type: "metabase.embed.requestGuestTokenRefresh";
+  data: {
+    expiredToken: string;
+  };
+};
 
 /** Events that the sdk embed route listens for */
 export type SdkIframeEmbedMessage =
@@ -45,7 +52,8 @@ export type SdkIframeEmbedMessage =
   | SdkIframeEmbedSubmitSessionTokenMessage
   | SdkIframeEmbedReportAuthenticationError
   | SdkIframeEmbedReportAnalytics
-  | SdkIframeEmbedHandleLinkResponse;
+  | SdkIframeEmbedHandleLinkResponse
+  | SdkIframeEmbedSubmitRefreshedGuestTokenMessage;
 
 export type SdkIframeEmbedSetSettingsMessage = {
   type: "metabase.embed.setSettings";
@@ -75,6 +83,12 @@ export type SdkIframeEmbedHandleLinkResponse = {
   type: "metabase.embed.handleLinkResponse";
   data: { requestId: string; handled: boolean };
 };
+export type SdkIframeEmbedSubmitRefreshedGuestTokenMessage = {
+  type: "metabase.embed.submitRefreshedGuestToken";
+  data: {
+    guestToken: string;
+  };
+};
 
 // --- Embed Option Interfaces ---
 
@@ -93,6 +107,8 @@ export type DashboardEmbedOptions = StrictUnion<
   initialParameters?: ParameterValues;
   hiddenParameters?: string[];
   enableEntityNavigation?: boolean;
+
+  customContext?: string | Record<string, unknown>;
 
   // incompatible options
   template?: never;
@@ -115,6 +131,8 @@ export type QuestionEmbedOptions = StrictUnion<
   // parameters
   initialSqlParameters?: SqlParameterValues;
   hiddenParameters?: string[];
+
+  customContext?: string | Record<string, unknown>;
 
   // incompatible options
   template?: never;
@@ -212,6 +230,14 @@ export type SdkIframeEmbedBaseSettings = {
 
   /** Whether we should use the existing user session (i.e. admin user's cookie) */
   useExistingUserSession?: boolean;
+
+  /**
+   * URL endpoint for fetching and refreshing guest embed JWT tokens (iframe only, not applicable for SDK's guest mode).
+   * Supports token refresh on expiry. Optionally also handles the initial token fetch
+   * when no static token is provided to the guest embed components (e.g. metabase-dashboard, metabase-question).
+   * The endpoint should return { jwt: string } with the new token.
+   */
+  guestEmbedProviderUri?: string;
 
   // Whether the embed is running on localhost. Cannot be set by the user.
   _isLocalhost?: boolean;

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/types/embed.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/types/embed.ts
@@ -233,8 +233,8 @@ export type SdkIframeEmbedBaseSettings = {
 
   /**
    * URL endpoint for fetching and refreshing guest embed JWT tokens (iframe only, not applicable for SDK's guest mode).
-   * Supports token refresh on expiry. Optionally also handles the initial token fetch
-   * when no static token is provided to the guest embed components (e.g. metabase-dashboard, metabase-question).
+   * Supports both token refresh on expiry and initial token fetch when no static token is provided.
+   * In both cases, this works with guest embed components (metabase-dashboard and metabase-question).
    * The endpoint should return { jwt: string } with the new token.
    */
   guestEmbedProviderUri?: string;

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/types/modular-embedding.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/types/modular-embedding.ts
@@ -90,6 +90,13 @@ export interface MetabaseDashboardAttributes {
    * @remarks Pro/Enterprise
    */
   "enable-entity-navigation"?: boolean;
+
+  /**
+   * Optional custom context string passed through to the guest token endpoint.
+   *
+   * @remarks Guest embed
+   */
+  "custom-context"?: string;
 }
 
 /**
@@ -185,6 +192,13 @@ export interface MetabaseQuestionAttributes {
    * @remarks Pro/Enterprise, Guest embed
    */
   "entity-types"?: ("model" | "table")[];
+
+  /**
+   * Optional custom context string passed through to the guest token endpoint.
+   *
+   * @remarks Guest embed
+   */
+  "custom-context"?: string;
 }
 
 /**

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/utils/request-session-token.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/utils/request-session-token.ts
@@ -11,50 +11,80 @@ import type {
 
 /**
  * Requests a refresh token from the embed.js script which lives in the parent window.
+ * Supports both SSO authentication and guest token refresh.
  */
-export function requestSessionTokenFromEmbedJs(): Promise<MetabaseEmbeddingSessionToken> {
-  return new Promise<MetabaseEmbeddingSessionToken>((resolve, reject) => {
-    const timeout = setTimeout(() => {
-      window.removeEventListener("message", handler);
-      reject(AUTH_TIMEOUT());
-    }, WAIT_FOR_SESSION_TOKEN_TIMEOUT);
+export function requestSessionTokenFromEmbedJs(): Promise<MetabaseEmbeddingSessionToken>;
+export function requestSessionTokenFromEmbedJs(options: {
+  expiredToken: string;
+}): Promise<string>;
+export function requestSessionTokenFromEmbedJs(options?: {
+  expiredToken: string;
+}): Promise<MetabaseEmbeddingSessionToken | string> {
+  const isGuestRefresh = Boolean(options?.expiredToken);
 
-    const handler = (event: MessageEvent<SdkIframeEmbedMessage>) => {
-      if (!isWithinIframe() || !event.data) {
-        return;
-      }
+  return new Promise<MetabaseEmbeddingSessionToken | string>(
+    (resolve, reject) => {
+      const timeout = setTimeout(() => {
+        window.removeEventListener("message", handler);
+        reject(AUTH_TIMEOUT());
+      }, WAIT_FOR_SESSION_TOKEN_TIMEOUT);
 
-      const action = event.data;
-
-      if (action.type === "metabase.embed.submitSessionToken") {
-        const { authMethod, sessionToken } = action.data;
-
-        // Persist the session token to the iframe's local storage,
-        // so we don't show the popup again.
-        if (authMethod === "saml") {
-          samlTokenStorage.set(sessionToken);
+      const handler = (event: MessageEvent<SdkIframeEmbedMessage>) => {
+        if (!isWithinIframe() || !event.data) {
+          return;
         }
 
-        window.removeEventListener("message", handler);
-        clearTimeout(timeout);
-        resolve(sessionToken);
+        const action = event.data;
+
+        // Handle SSO session token response
+        if (action.type === "metabase.embed.submitSessionToken") {
+          const { authMethod, sessionToken } = action.data;
+
+          // Persist the session token to the iframe's local storage,
+          // so we don't show the popup again.
+          if (authMethod === "saml") {
+            samlTokenStorage.set(sessionToken);
+          }
+
+          window.removeEventListener("message", handler);
+          clearTimeout(timeout);
+          resolve(sessionToken);
+        }
+
+        // Handle guest token refresh response
+        if (action.type === "metabase.embed.submitRefreshedGuestToken") {
+          const { guestToken } = action.data;
+
+          window.removeEventListener("message", handler);
+          clearTimeout(timeout);
+          resolve(guestToken);
+        }
+
+        // Handle errors from both flows
+        if (action.type === "metabase.embed.reportAuthenticationError") {
+          const { error } = action.data;
+
+          window.removeEventListener("message", handler);
+          clearTimeout(timeout);
+          reject(error);
+        }
+      };
+
+      window.addEventListener("message", handler);
+
+      // Send appropriate request message based on flow
+      if (isGuestRefresh) {
+        const guestEmbedSessionRefreshMessage: SdkIframeEmbedTagMessage = {
+          type: "metabase.embed.requestGuestTokenRefresh",
+          data: { expiredToken: options!.expiredToken },
+        };
+        window.parent.postMessage(guestEmbedSessionRefreshMessage, "*");
+      } else {
+        const requestTokenMessage: SdkIframeEmbedTagMessage = {
+          type: "metabase.embed.requestSessionToken",
+        };
+        window.parent.postMessage(requestTokenMessage, "*");
       }
-
-      if (action.type === "metabase.embed.reportAuthenticationError") {
-        const { error } = action.data;
-
-        window.removeEventListener("message", handler);
-        clearTimeout(timeout);
-        reject(error);
-      }
-    };
-
-    window.addEventListener("message", handler);
-
-    const requestTokenMessage: SdkIframeEmbedTagMessage = {
-      type: "metabase.embed.requestSessionToken",
-    };
-
-    window.parent.postMessage(requestTokenMessage, "*");
-  });
+    },
+  );
 }

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/utils/request-session-token.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/utils/request-session-token.ts
@@ -20,8 +20,6 @@ export function requestSessionTokenFromEmbedJs(options: {
 export function requestSessionTokenFromEmbedJs(options?: {
   expiredToken: string;
 }): Promise<MetabaseEmbeddingSessionToken | string> {
-  const isGuestRefresh = Boolean(options?.expiredToken);
-
   return new Promise<MetabaseEmbeddingSessionToken | string>(
     (resolve, reject) => {
       const timeout = setTimeout(() => {
@@ -73,13 +71,15 @@ export function requestSessionTokenFromEmbedJs(options?: {
       window.addEventListener("message", handler);
 
       // Send appropriate request message based on flow
-      if (isGuestRefresh) {
+      if (options?.expiredToken) {
+        // is guest embed token refresh flow
         const guestEmbedSessionRefreshMessage: SdkIframeEmbedTagMessage = {
           type: "metabase.embed.requestGuestTokenRefresh",
-          data: { expiredToken: options!.expiredToken },
+          data: { expiredToken: options.expiredToken },
         };
         window.parent.postMessage(guestEmbedSessionRefreshMessage, "*");
       } else {
+        // SSO flow
         const requestTokenMessage: SdkIframeEmbedTagMessage = {
           type: "metabase.embed.requestSessionToken",
         };

--- a/frontend/src/metabase/embedding/lib/override-requests-for-embeds.ts
+++ b/frontend/src/metabase/embedding/lib/override-requests-for-embeds.ts
@@ -4,7 +4,7 @@ import {
   PLUGIN_CONTENT_TRANSLATION,
   PLUGIN_EMBEDDING_SDK,
 } from "metabase/plugins";
-import type { OnBeforeRequestHandlerData } from "metabase/plugins/oss/api";
+import type { OnBeforeRequestHandlerConfig } from "metabase/plugins/oss/api";
 import { getEmbedBase, internalBase, publicBase } from "metabase/services";
 import type { CardId, DashboardId, ParameterId } from "metabase-types/api";
 
@@ -187,7 +187,8 @@ const overrideRequests = async ({
   method,
   url,
   options,
-}: OnBeforeRequestHandlerData & {
+  data,
+}: OnBeforeRequestHandlerConfig & {
   embedType: EmbedType;
 }) => {
   const transformation = getRequestTransformation({
@@ -198,7 +199,7 @@ const overrideRequests = async ({
   });
 
   if (!transformation) {
-    return { method, url, options };
+    return { method, url, options, data };
   }
 
   if (!options.headers) {
@@ -214,6 +215,7 @@ const overrideRequests = async ({
     method: transformation.method,
     url: replaceWithEmbedBase({ embedType, url: transformation.url }),
     options: transformation.options,
+    data,
   };
 };
 

--- a/frontend/src/metabase/lib/api.js
+++ b/frontend/src/metabase/lib/api.js
@@ -125,15 +125,15 @@ export class Api extends EventEmitter {
       };
 
       return async (rawData, invocationOptions = {}) => {
-        let { url, method, options } =
+        let { url, method, options, data } =
           await this.apiRequestManipulationMiddleware({
             url: urlTemplate,
             method: methodTemplate,
             options: { ...defaultOptions, ...invocationOptions },
+            // this will transform arrays to objects with numeric keys
+            // we shouldn't be using top level-arrays in the API
+            data: { ...rawData },
           });
-        // this will transform arrays to objects with numeric keys
-        // we shouldn't be using top level-arrays in the API
-        const data = { ...rawData };
         for (const tag of url.match(/:\w+/g) || []) {
           const paramName = tag.slice(1);
           let value = data[paramName];
@@ -376,16 +376,16 @@ export class Api extends EventEmitter {
   }
 
   /**
-   * @param data {import('metabase/plugins').OnBeforeRequestHandlerData}
-   * @return data {Promise<import('metabase/plugins').OnBeforeRequestHandlerData>}
+   * @param {import('metabase/plugins/oss/api').OnBeforeRequestHandlerConfig} data
+   * @return {Promise<import('metabase/plugins/oss/api').OnBeforeRequestHandlerConfig>}
    */
-  async apiRequestManipulationMiddleware(data) {
-    let { method, url, options } = data;
+  async apiRequestManipulationMiddleware(requestConfig) {
+    let { method, url, options, data } = requestConfig;
 
     /**
      * Handlers order is important.
      * Handlers are executed in order and each handler uses the data returned by a previous handler.
-     * @type {import('metabase/plugins').OnBeforeRequestHandler[]}
+     * @type {import('metabase/plugins/oss/api').OnBeforeRequestHandler[]}
      */
     const handlers = [];
 
@@ -394,6 +394,8 @@ export class Api extends EventEmitter {
         ...[
           PLUGIN_EMBEDDING_SDK.onBeforeRequestHandlers
             .getOrRefreshSessionHandler,
+          PLUGIN_EMBEDDING_SDK.onBeforeRequestHandlers
+            .getOrRefreshGuestSessionHandler,
           PLUGIN_EMBEDDING_SDK.onBeforeRequestHandlers
             .overrideRequestsForGuestEmbeds,
         ],
@@ -413,6 +415,7 @@ export class Api extends EventEmitter {
           method,
           url,
           options,
+          data,
         });
 
         if (onBeforeRequestHandlerResult) {
@@ -430,11 +433,18 @@ export class Api extends EventEmitter {
               ...onBeforeRequestHandlerResult.options,
             };
           }
+
+          if (onBeforeRequestHandlerResult.data) {
+            data = {
+              ...data,
+              ...onBeforeRequestHandlerResult.data,
+            };
+          }
         }
       }
     }
 
-    return { method, url, options };
+    return { method, url, options, data };
   }
 }
 

--- a/frontend/src/metabase/plugins/oss/api.ts
+++ b/frontend/src/metabase/plugins/oss/api.ts
@@ -1,26 +1,27 @@
 import type { CardId, DashboardId, ParameterId } from "metabase-types/api";
 
-export type OnBeforeRequestHandlerData = {
+export type OnBeforeRequestHandlerConfig = {
   method: "GET" | "POST";
   url: string;
   options: {
     headers?: Record<string, string>;
     hasBody: boolean;
   } & Record<string, unknown>;
+  data: Record<string, unknown>;
 };
 
 export type OnBeforeRequestHandler = (
-  data: OnBeforeRequestHandlerData,
-) => Promise<void | OnBeforeRequestHandlerData>;
+  data: OnBeforeRequestHandlerConfig,
+) => Promise<void | OnBeforeRequestHandlerConfig>;
 
 const getDefaultPluginApi = () => ({
   onBeforeRequestHandlers: {
     overrideRequestsForPublicEmbeds: async (
-      _data: OnBeforeRequestHandlerData,
-    ): Promise<OnBeforeRequestHandlerData | void> => {},
+      _data: OnBeforeRequestHandlerConfig,
+    ): Promise<OnBeforeRequestHandlerConfig | void> => {},
     overrideRequestsForStaticEmbeds: async (
-      _data: OnBeforeRequestHandlerData,
-    ): Promise<OnBeforeRequestHandlerData | void> => {},
+      _data: OnBeforeRequestHandlerConfig,
+    ): Promise<OnBeforeRequestHandlerConfig | void> => {},
   },
   getRemappedCardParameterValueUrl: (
     cardId: CardId | string | undefined,

--- a/frontend/src/metabase/plugins/oss/embedding-sdk.ts
+++ b/frontend/src/metabase/plugins/oss/embedding-sdk.ts
@@ -1,12 +1,15 @@
-import type { OnBeforeRequestHandlerData } from "metabase/plugins/oss/api";
+import type { OnBeforeRequestHandlerConfig } from "metabase/plugins/oss/api";
 
 const getDefaultPluginEmbeddingSdk = () => ({
   isEnabled: () => false,
   onBeforeRequestHandlers: {
     getOrRefreshSessionHandler: async () => {},
+    getOrRefreshGuestSessionHandler: async (
+      _data: OnBeforeRequestHandlerConfig,
+    ): Promise<OnBeforeRequestHandlerConfig | void> => {},
     overrideRequestsForGuestEmbeds: async (
-      _data: OnBeforeRequestHandlerData,
-    ): Promise<OnBeforeRequestHandlerData | void> => {},
+      _data: OnBeforeRequestHandlerConfig,
+    ): Promise<OnBeforeRequestHandlerConfig | void> => {},
   },
 });
 


### PR DESCRIPTION
part 2/3 of [EMB-1319](https://linear.app/metabase/issue/EMB-1319)


### Description

Actually... This is supposed to have no behavior change, but with everything set up. We verify by just hooking the token to redux store. Everything should behave the same except the part where we fix the error in both components. But if we pass `guestEmbedProviderUri` now, you might see some failure, because it's only partially working.

https://github.com/metabase/metabase/blob/33d8e1cee400500107851ebf169a63eb534fd7dc/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboard.tsx#L378-L380

and

https://github.com/metabase/metabase/blob/33d8e1cee400500107851ebf169a63eb534fd7dc/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/context/SdkQuestionProvider.tsx#L286-L288

This sets up for the tests that will be added in the next PR, so we have changes for these 2 files completely without having to just add these 2 changes in the next PR. Which I think is a bit cleaner.

### How to verify

All tests should pass. It should behave 99.9% the same, except the error I mentioned above.

Also, I think you should test the next PR to ensure everything here looks good. I try to slice the PR up to make it more manageable, but maybe I split it unideally.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
