### PR TITLE
Wire token renewal into dashboard/question components and add E2E tests

### DIFF
--- a/e2e/support/helpers/e2e-embedding-iframe-sdk-helpers.ts
+++ b/e2e/support/helpers/e2e-embedding-iframe-sdk-helpers.ts
@@ -26,6 +26,7 @@ export interface BaseEmbedTestPageOptions {
   // Passed to defineMetabaseConfig
   metabaseConfig?: {
     isGuest?: boolean;
+    guestEmbedProviderUri?: string;
     instanceUrl?: string;
     apiKey?: string;
     useExistingUserSession?: boolean;
@@ -318,6 +319,7 @@ export const getNewEmbedScriptTag = ({
 export const getNewEmbedConfigurationScript = ({
   instanceUrl = "http://localhost:4000",
   isGuest,
+  guestEmbedProviderUri,
   theme,
   apiKey,
   useExistingUserSession,
@@ -327,6 +329,7 @@ export const getNewEmbedConfigurationScript = ({
   const config = {
     instanceUrl,
     isGuest,
+    guestEmbedProviderUri,
     apiKey,
     useExistingUserSession,
     theme,

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/guest-token-refresh.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/guest-token-refresh.cy.spec.ts
@@ -1,0 +1,965 @@
+import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import { createQuestion } from "e2e/support/helpers";
+import { JWT_SHARED_SECRET } from "e2e/support/helpers/embedding-sdk-helpers/constants";
+
+const { H } = cy;
+const { ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
+
+const IS_ENTERPRISE = Cypress.expose("IS_ENTERPRISE");
+const IS_OSS = !IS_ENTERPRISE;
+
+const PROVIDER_PATH = "/api/mock-guest-token-provider";
+const PROVIDER_INTERCEPT = { method: "POST", pathname: PROVIDER_PATH } as const;
+
+type SignJwtParams = (
+  | { dashboardId: number; questionId?: never }
+  | { questionId: number; dashboardId?: never }
+) & { expirationSeconds: number; params?: Record<string, unknown> };
+
+function signJwt({
+  dashboardId,
+  questionId,
+  expirationSeconds,
+  params = {},
+}: SignJwtParams): Cypress.Chainable<string> {
+  const resource =
+    dashboardId !== undefined
+      ? { dashboard: dashboardId }
+      : { question: questionId };
+
+  return cy
+    .task<string>("signJwt", {
+      payload: {
+        resource,
+        params,
+        exp: Math.round(Date.now() / 1000) + expirationSeconds,
+      },
+      secret: JWT_SHARED_SECRET,
+    })
+    .then((token) => token);
+}
+
+const PRICE_DASHBOARD_PARAMETER = {
+  name: "Price greater than",
+  slug: "price",
+  id: "aaaaaaaa",
+  type: "number/>=",
+  sectionId: "number",
+};
+
+const CATEGORY_DASHBOARD_PARAMETER = {
+  name: "Category",
+  slug: "category",
+  id: "bbbbbbbb",
+  type: "string/=",
+  sectionId: "string",
+};
+
+describe(
+  `scenarios > embedding > sdk iframe embedding > guest token refresh > ${IS_OSS ? "oss" : "ee"}`,
+  { ...(IS_OSS && { tags: "@OSS" }) },
+  () => {
+    function createDashboardWithQuestion() {
+      createQuestion({
+        name: "Orders",
+        query: { "source-table": ORDERS_ID },
+      }).then(({ body: question }) => {
+        cy.request("POST", "/api/dashboard", {
+          name: "Guest Token Refresh Dashboard",
+        }).then(({ body: dashboard }) => {
+          cy.wrap(dashboard.id).as("dashboardId");
+
+          cy.request("PUT", `/api/dashboard/${dashboard.id}`, {
+            enable_embedding: true,
+            embedding_type: "guest-embed",
+            dashcards: [
+              {
+                id: -1,
+                card_id: question.id,
+                row: 0,
+                col: 0,
+                size_x: 11,
+                size_y: 6,
+              },
+            ],
+          });
+        });
+      });
+    }
+
+    function createDashboardWithPriceFilter() {
+      H.createTestQuery({
+        database: SAMPLE_DB_ID,
+        stages: [
+          {
+            source: { type: "table", id: PRODUCTS_ID },
+            fields: [
+              { type: "column", name: "ID", sourceName: "PRODUCTS" },
+              { type: "column", name: "TITLE", sourceName: "PRODUCTS" },
+              { type: "column", name: "PRICE", sourceName: "PRODUCTS" },
+            ],
+            limit: 10,
+          },
+        ],
+      }).then((datasetQuery) => {
+        H.createCard({
+          dataset_query: datasetQuery,
+          name: "Products with price filter",
+        }).then((question) => {
+          cy.request("POST", "/api/dashboard", {
+            name: "Guest Token Refresh Dashboard with Price Filter",
+            parameters: [PRICE_DASHBOARD_PARAMETER],
+          }).then(({ body: dashboard }) => {
+            cy.wrap(dashboard.id).as("dashboardId");
+
+            cy.request("PUT", `/api/dashboard/${dashboard.id}`, {
+              enable_embedding: true,
+              embedding_type: "guest-embed",
+              embedding_params: { price: "enabled" },
+              dashcards: [
+                {
+                  id: -1,
+                  card_id: question.id,
+                  row: 0,
+                  col: 0,
+                  size_x: 24,
+                  size_y: 6,
+                  parameter_mappings: [
+                    {
+                      parameter_id: "aaaaaaaa",
+                      card_id: question.id,
+                      target: ["dimension", ["field", PRODUCTS.PRICE, null]],
+                    },
+                  ],
+                },
+              ],
+            });
+          });
+        });
+      });
+    }
+
+    function createDashboardWithCategoryFilter() {
+      H.createTestQuery({
+        database: SAMPLE_DB_ID,
+        stages: [
+          {
+            source: { type: "table", id: PRODUCTS_ID },
+            fields: [
+              { type: "column", name: "ID", sourceName: "PRODUCTS" },
+              { type: "column", name: "TITLE", sourceName: "PRODUCTS" },
+              { type: "column", name: "CATEGORY", sourceName: "PRODUCTS" },
+            ],
+            limit: 10,
+          },
+        ],
+      }).then((datasetQuery) => {
+        H.createCard({
+          dataset_query: datasetQuery,
+          name: "Products with category filter",
+        }).then((question) => {
+          cy.request("POST", "/api/dashboard", {
+            name: "Guest Token Refresh Dashboard with Category Filter",
+            parameters: [CATEGORY_DASHBOARD_PARAMETER],
+          }).then(({ body: dashboard }) => {
+            cy.wrap(dashboard.id).as("dashboardId");
+
+            cy.request("PUT", `/api/dashboard/${dashboard.id}`, {
+              enable_embedding: true,
+              embedding_type: "guest-embed",
+              embedding_params: { category: "enabled" },
+              dashcards: [
+                {
+                  id: -1,
+                  card_id: question.id,
+                  row: 0,
+                  col: 0,
+                  size_x: 24,
+                  size_y: 6,
+                  parameter_mappings: [
+                    {
+                      parameter_id: "bbbbbbbb",
+                      card_id: question.id,
+                      target: ["dimension", ["field", PRODUCTS.CATEGORY, null]],
+                    },
+                  ],
+                },
+              ],
+            });
+          });
+        });
+      });
+    }
+
+    function createStandaloneQuestion() {
+      createQuestion({
+        name: "Orders",
+        enable_embedding: true,
+        embedding_type: "guest-embed",
+        query: { "source-table": ORDERS_ID },
+      }).then(({ body: question }) => {
+        cy.wrap(question.id).as("questionId");
+      });
+    }
+
+    function createQuestionWithPriceFilter() {
+      H.createNativeQuestion({
+        name: "Products with price filter",
+        native: {
+          query:
+            "SELECT ID, TITLE, PRICE FROM PRODUCTS WHERE PRICE >= {{price}} LIMIT 10",
+          "template-tags": {
+            price: {
+              id: "cccccccc",
+              name: "price",
+              "display-name": "Price greater than",
+              type: "number",
+              required: false,
+            },
+          },
+        },
+        enable_embedding: true,
+        embedding_params: { price: "enabled" },
+        embedding_type: "guest-embed",
+      }).then(({ body: question }) => {
+        cy.wrap(question.id).as("questionId");
+      });
+    }
+
+    function createQuestionWithCategoryFilter() {
+      H.createNativeQuestion({
+        name: "Products with category filter",
+        native: {
+          query:
+            "SELECT ID, TITLE, CATEGORY FROM PRODUCTS WHERE {{category}} LIMIT 10",
+          "template-tags": {
+            category: {
+              id: "dddddddd",
+              name: "category",
+              "display-name": "Category",
+              type: "dimension",
+              dimension: ["field", PRODUCTS.CATEGORY, null],
+              "widget-type": "category",
+              required: false,
+            },
+          },
+        },
+        enable_embedding: true,
+        embedding_params: { category: "enabled" },
+        embedding_type: "guest-embed",
+      }).then(({ body: question }) => {
+        cy.wrap(question.id).as("questionId");
+      });
+    }
+
+    describe("dashboard refresh-only", () => {
+      describe("happy path", () => {
+        beforeEach(() => {
+          H.prepareGuestEmbedSdkIframeEmbedTest({
+            onPrepare: createDashboardWithQuestion,
+          });
+        });
+
+        it("calls guestEmbedProviderUri with { entityType, entityId } and loads dashboard after token refresh", () => {
+          cy.get<number>("@dashboardId").then((dashboardId) => {
+            signJwt({ dashboardId, expirationSeconds: -60 }).then(
+              (expiredToken) => {
+                signJwt({ dashboardId, expirationSeconds: 600 }).then(
+                  (freshToken) => {
+                    cy.intercept(PROVIDER_INTERCEPT, (req) => {
+                      req.reply({ statusCode: 200, body: { jwt: freshToken } });
+                    }).as("guestTokenProvider");
+
+                    H.visitCustomHtmlPage(`
+                      ${H.getNewEmbedScriptTag({ loadType: "sync" })}
+                      <script>
+                        defineMetabaseConfig({
+                          instanceUrl: "http://localhost:4000",
+                          isGuest: true,
+                          guestEmbedProviderUri: "${PROVIDER_PATH}",
+                        });
+                      </script>
+                      <style>metabase-dashboard { height: 100vh; }</style>
+                      <metabase-dashboard token="${expiredToken}" />
+                    `);
+
+                    cy.wait("@guestTokenProvider").then((interception) => {
+                      expect(interception.request.body).to.deep.include({
+                        entityType: "dashboard",
+                        entityId: dashboardId,
+                      });
+                    });
+
+                    H.getSimpleEmbedIframeContent().should("contain", "Orders");
+                  },
+                );
+              },
+            );
+          });
+        });
+      });
+
+      describe("provider error shows error state", () => {
+        beforeEach(() => {
+          H.prepareGuestEmbedSdkIframeEmbedTest({
+            onPrepare: createDashboardWithQuestion,
+          });
+        });
+
+        it("shows an error in the embed when the provider returns an HTTP error", () => {
+          cy.get<number>("@dashboardId").then((dashboardId) => {
+            signJwt({ dashboardId, expirationSeconds: -60 }).then(
+              (expiredToken) => {
+                cy.intercept(PROVIDER_INTERCEPT, (req) => {
+                  req.reply({ statusCode: 500, body: null });
+                }).as("guestTokenProvider");
+
+                H.visitCustomHtmlPage(`
+                  ${H.getNewEmbedScriptTag({ loadType: "sync" })}
+                  <script>
+                    defineMetabaseConfig({
+                      instanceUrl: "http://localhost:4000",
+                      isGuest: true,
+                      guestEmbedProviderUri: "${PROVIDER_PATH}",
+                    });
+                  </script>
+                  <style>metabase-dashboard { height: 100vh; }</style>
+                  <metabase-dashboard
+                    token="${expiredToken}"
+                  />
+                `);
+
+                cy.wait("@guestTokenProvider");
+                H.getSimpleEmbedIframeContent()
+                  .findByText(
+                    "Failed to fetch JWT token from /api/mock-guest-token-provider, status: 500.",
+                  )
+                  .should("be.visible");
+              },
+            );
+          });
+        });
+
+        it("shows an error when the provider returns a wrong response shape", () => {
+          cy.get<number>("@dashboardId").then((dashboardId) => {
+            signJwt({ dashboardId, expirationSeconds: -60 }).then(
+              (expiredToken) => {
+                signJwt({ dashboardId, expirationSeconds: 600 }).then(
+                  (freshToken) => {
+                    cy.intercept(PROVIDER_INTERCEPT, (req) => {
+                      req.reply({
+                        statusCode: 200,
+                        body: { token: freshToken },
+                      });
+                    }).as("guestTokenProvider");
+
+                    H.visitCustomHtmlPage(`
+                      ${H.getNewEmbedScriptTag({ loadType: "sync" })}
+                      <script>
+                        defineMetabaseConfig({
+                          instanceUrl: "http://localhost:4000",
+                          isGuest: true,
+                          guestEmbedProviderUri: "${PROVIDER_PATH}",
+                        });
+                      </script>
+                      <style>metabase-dashboard { height: 100vh; }</style>
+                      <metabase-dashboard token="${expiredToken}" />
+                    `);
+
+                    cy.wait("@guestTokenProvider");
+                    H.getSimpleEmbedIframeContent()
+                      .findByText(
+                        'Your JWT server endpoint must return an object with the shape { jwt: string }, but instead received {"token":"YOUR_JWT"}',
+                      )
+                      .should("be.visible");
+                  },
+                );
+              },
+            );
+          });
+        });
+      });
+
+      describe("number filter interaction after token refresh", () => {
+        beforeEach(() => {
+          H.prepareGuestEmbedSdkIframeEmbedTest({
+            onPrepare: createDashboardWithPriceFilter,
+          });
+        });
+
+        it("applying a number filter after token refresh returns filtered results", () => {
+          cy.get<number>("@dashboardId").then((dashboardId) => {
+            signJwt({ dashboardId, expirationSeconds: 5 }).then(
+              (shortLivedToken) => {
+                signJwt({ dashboardId, expirationSeconds: 600 }).then(
+                  (freshToken) => {
+                    cy.intercept(PROVIDER_INTERCEPT, (req) => {
+                      req.reply({ statusCode: 200, body: { jwt: freshToken } });
+                    }).as("guestTokenProvider");
+
+                    H.visitCustomHtmlPage(`
+                      ${H.getNewEmbedScriptTag({ loadType: "sync" })}
+                      <script>
+                        defineMetabaseConfig({
+                          instanceUrl: "http://localhost:4000",
+                          isGuest: true,
+                          guestEmbedProviderUri: "${PROVIDER_PATH}",
+                        });
+                      </script>
+                      <style>metabase-dashboard { height: 100vh; }</style>
+                      <metabase-dashboard token="${shortLivedToken}" />
+                    `);
+
+                    H.getSimpleEmbedIframeContent().within(() => {
+                      cy.findByLabelText("Price greater than").should(
+                        "be.visible",
+                      );
+                    });
+
+                    cy.get("iframe[data-metabase-embed]")
+                      .its("0.contentWindow")
+                      .should("exist")
+                      .then((contentWindow) => {
+                        (
+                          contentWindow as any
+                        ).FORCE_REFRESH_GUEST_EMBED_TOKEN_IN_CYPRESS = true;
+                      });
+
+                    H.getSimpleEmbedIframeContent().within(() => {
+                      cy.findByLabelText("Price greater than").click();
+                      H.popover().within(() => {
+                        cy.findByPlaceholderText("Enter a number").type(
+                          "50{enter}",
+                        );
+                      });
+                      cy.log(
+                        "ensure the token is refreshed after applying a filter value",
+                      );
+                      cy.wait("@guestTokenProvider");
+
+                      H.assertTableData({
+                        columns: ["ID", "Title", "Price"],
+                        firstRows: [["2", "Small Marble Shoes", "70.08"]],
+                      });
+                    });
+                  },
+                );
+              },
+            );
+          });
+        });
+      });
+
+      describe("category filter interaction after token refresh", () => {
+        beforeEach(() => {
+          H.prepareGuestEmbedSdkIframeEmbedTest({
+            onPrepare: createDashboardWithCategoryFilter,
+          });
+        });
+
+        it("applying a category filter after token refresh returns filtered results", () => {
+          cy.get<number>("@dashboardId").then((dashboardId) => {
+            signJwt({ dashboardId, expirationSeconds: 5 }).then(
+              (shortLivedToken) => {
+                signJwt({ dashboardId, expirationSeconds: 600 }).then(
+                  (freshToken) => {
+                    cy.intercept(PROVIDER_INTERCEPT, (req) => {
+                      req.reply({ statusCode: 200, body: { jwt: freshToken } });
+                    }).as("guestTokenProvider");
+
+                    H.visitCustomHtmlPage(`
+                      ${H.getNewEmbedScriptTag({ loadType: "sync" })}
+                      <script>
+                        defineMetabaseConfig({
+                          instanceUrl: "http://localhost:4000",
+                          isGuest: true,
+                          guestEmbedProviderUri: "${PROVIDER_PATH}",
+                        });
+                      </script>
+                      <style>metabase-dashboard { height: 100vh; }</style>
+                      <metabase-dashboard token="${shortLivedToken}" />
+                    `);
+
+                    H.getSimpleEmbedIframeContent().within(() => {
+                      cy.findByLabelText("Category").should("be.visible");
+                    });
+
+                    cy.get("iframe[data-metabase-embed]")
+                      .its("0.contentWindow")
+                      .should("exist")
+                      .then((contentWindow) => {
+                        (
+                          contentWindow as any
+                        ).FORCE_REFRESH_GUEST_EMBED_TOKEN_IN_CYPRESS = true;
+                      });
+
+                    H.getSimpleEmbedIframeContent().within(() => {
+                      cy.findByLabelText("Category").click();
+
+                      cy.log(
+                        "ensure the token is refreshed after the filter values endpoint is called",
+                      );
+                      cy.wait("@guestTokenProvider");
+
+                      H.popover().within(() => {
+                        cy.findByText("Doohickey").click();
+                        cy.button("Add filter").click();
+                      });
+
+                      H.assertTableData({
+                        columns: ["ID", "Title", "Category"],
+                        firstRows: [["2", "Small Marble Shoes", "Doohickey"]],
+                      });
+                    });
+                  },
+                );
+              },
+            );
+          });
+        });
+      });
+    });
+
+    describe("dashboard initial-token", () => {
+      describe("happy path", () => {
+        beforeEach(() => {
+          H.prepareGuestEmbedSdkIframeEmbedTest({
+            onPrepare: createDashboardWithQuestion,
+          });
+        });
+
+        it("calls guestEmbedProviderUri with { entityType, entityId } and loads dashboard (initial token fetch)", () => {
+          cy.get<number>("@dashboardId").then((dashboardId) => {
+            signJwt({ dashboardId, expirationSeconds: 600 }).then(
+              (freshToken) => {
+                cy.intercept(PROVIDER_INTERCEPT, (req) => {
+                  req.reply({ statusCode: 200, body: { jwt: freshToken } });
+                }).as("guestTokenProvider");
+
+                H.visitCustomHtmlPage(`
+                  ${H.getNewEmbedScriptTag({ loadType: "sync" })}
+                  <script>
+                    defineMetabaseConfig({
+                      instanceUrl: "http://localhost:4000",
+                      isGuest: true,
+                      guestEmbedProviderUri: "${PROVIDER_PATH}",
+                    });
+                  </script>
+                  <style>metabase-dashboard { height: 100vh; }</style>
+                  <metabase-dashboard dashboard-id="${dashboardId}" />
+                `);
+
+                cy.wait("@guestTokenProvider").then((interception) => {
+                  expect(interception.request.url).to.include("response=json");
+                  expect(interception.request.body).to.deep.include({
+                    entityType: "dashboard",
+                    entityId: dashboardId,
+                  });
+                });
+
+                H.getSimpleEmbedIframeContent().should("contain", "Orders");
+              },
+            );
+          });
+        });
+      });
+
+      describe("provider error shows error state", () => {
+        beforeEach(() => {
+          H.prepareGuestEmbedSdkIframeEmbedTest({
+            onPrepare: createDashboardWithQuestion,
+          });
+        });
+
+        it("shows an error when the initial token fetch fails", () => {
+          cy.get<number>("@dashboardId").then((dashboardId) => {
+            cy.intercept(PROVIDER_INTERCEPT, (req) => {
+              req.reply({ statusCode: 500 });
+            }).as("guestTokenProvider");
+
+            H.visitCustomHtmlPage(`
+              ${H.getNewEmbedScriptTag({ loadType: "sync" })}
+              <script>
+                defineMetabaseConfig({
+                  instanceUrl: "http://localhost:4000",
+                  isGuest: true,
+                  guestEmbedProviderUri: "${PROVIDER_PATH}",
+                });
+              </script>
+              <style>metabase-dashboard { height: 100vh; }</style>
+              <metabase-dashboard dashboard-id="${dashboardId}" />
+            `);
+
+            cy.wait("@guestTokenProvider");
+            H.getSimpleEmbedIframeContent()
+              .findByText(
+                "A valid JWT token is required to be passed in guest embeds mode.",
+              )
+              .should("be.visible");
+          });
+        });
+      });
+    });
+
+    describe("question refresh-only", () => {
+      describe("happy path", () => {
+        beforeEach(() => {
+          H.prepareGuestEmbedSdkIframeEmbedTest({
+            onPrepare: createStandaloneQuestion,
+          });
+        });
+
+        it("calls guestEmbedProviderUri with { entityType: question, entityId } and loads question after token refresh", () => {
+          cy.get<number>("@questionId").then((questionId) => {
+            signJwt({ questionId, expirationSeconds: -60 }).then(
+              (expiredToken) => {
+                signJwt({ questionId, expirationSeconds: 600 }).then(
+                  (freshToken) => {
+                    cy.intercept(PROVIDER_INTERCEPT, (req) => {
+                      req.reply({ statusCode: 200, body: { jwt: freshToken } });
+                    }).as("guestTokenProvider");
+
+                    H.visitCustomHtmlPage(`
+                      ${H.getNewEmbedScriptTag({ loadType: "sync" })}
+                      <script>
+                        defineMetabaseConfig({
+                          instanceUrl: "http://localhost:4000",
+                          isGuest: true,
+                          guestEmbedProviderUri: "${PROVIDER_PATH}",
+                        });
+                      </script>
+                      <style>metabase-question { height: 100vh; }</style>
+                      <metabase-question
+                        token="${expiredToken}"
+                      />
+                    `);
+
+                    cy.wait("@guestTokenProvider").then((interception) => {
+                      expect(interception.request.body).to.deep.include({
+                        entityType: "question",
+                        entityId: questionId,
+                      });
+                    });
+
+                    H.getSimpleEmbedIframeContent()
+                      .findByTestId("visualization-root")
+                      .should("exist");
+                  },
+                );
+              },
+            );
+          });
+        });
+      });
+
+      describe("provider error shows error state", () => {
+        beforeEach(() => {
+          H.prepareGuestEmbedSdkIframeEmbedTest({
+            onPrepare: createStandaloneQuestion,
+          });
+        });
+
+        it("shows an error in the embed when the provider returns an HTTP error", () => {
+          cy.get<number>("@questionId").then((questionId) => {
+            signJwt({ questionId, expirationSeconds: -60 }).then(
+              (expiredToken) => {
+                cy.intercept(PROVIDER_INTERCEPT, (req) => {
+                  req.reply({ statusCode: 500 });
+                }).as("guestTokenProvider");
+
+                H.visitCustomHtmlPage(`
+                  ${H.getNewEmbedScriptTag({ loadType: "sync" })}
+                  <script>
+                    defineMetabaseConfig({
+                      instanceUrl: "http://localhost:4000",
+                      isGuest: true,
+                      guestEmbedProviderUri: "${PROVIDER_PATH}",
+                    });
+                  </script>
+                  <style>metabase-question { height: 100vh; }</style>
+                  <metabase-question
+                    question-id="${questionId}"
+                    token="${expiredToken}"
+                  />
+                `);
+
+                cy.wait("@guestTokenProvider");
+                H.getSimpleEmbedIframeContent()
+                  .findByText(
+                    "Failed to fetch JWT token from /api/mock-guest-token-provider, status: 500.",
+                  )
+                  .should("be.visible");
+              },
+            );
+          });
+        });
+
+        it("shows an error when the provider returns a wrong response shape", () => {
+          cy.get<number>("@questionId").then((questionId) => {
+            signJwt({ questionId, expirationSeconds: -60 }).then(
+              (expiredToken) => {
+                signJwt({ questionId, expirationSeconds: 600 }).then(
+                  (freshToken) => {
+                    cy.intercept(PROVIDER_INTERCEPT, (req) => {
+                      req.reply({
+                        statusCode: 200,
+                        body: { token: freshToken },
+                      });
+                    }).as("guestTokenProvider");
+
+                    H.visitCustomHtmlPage(`
+                      ${H.getNewEmbedScriptTag({ loadType: "sync" })}
+                      <script>
+                        defineMetabaseConfig({
+                          instanceUrl: "http://localhost:4000",
+                          isGuest: true,
+                          guestEmbedProviderUri: "${PROVIDER_PATH}",
+                        });
+                      </script>
+                      <style>metabase-question { height: 100vh; }</style>
+                      <metabase-question
+                        question-id="${questionId}"
+                        token="${expiredToken}"
+                      />
+                    `);
+
+                    cy.wait("@guestTokenProvider");
+                    H.getSimpleEmbedIframeContent()
+                      .findByText(
+                        'Your JWT server endpoint must return an object with the shape { jwt: string }, but instead received {"token":"YOUR_JWT"}',
+                      )
+                      .should("be.visible");
+                  },
+                );
+              },
+            );
+          });
+        });
+      });
+
+      describe("number filter interaction after token refresh", () => {
+        beforeEach(() => {
+          H.prepareGuestEmbedSdkIframeEmbedTest({
+            onPrepare: createQuestionWithPriceFilter,
+          });
+        });
+
+        it("applying a number filter after token refresh returns filtered results", () => {
+          cy.get<number>("@questionId").then((questionId) => {
+            signJwt({ questionId, expirationSeconds: 5 }).then(
+              (shortLivedToken) => {
+                signJwt({ questionId, expirationSeconds: 600 }).then(
+                  (freshToken) => {
+                    cy.intercept(PROVIDER_INTERCEPT, (req) => {
+                      req.reply({ statusCode: 200, body: { jwt: freshToken } });
+                    }).as("guestTokenProvider");
+
+                    H.visitCustomHtmlPage(`
+                      ${H.getNewEmbedScriptTag({ loadType: "sync" })}
+                      <script>
+                        defineMetabaseConfig({
+                          instanceUrl: "http://localhost:4000",
+                          isGuest: true,
+                          guestEmbedProviderUri: "${PROVIDER_PATH}",
+                        });
+                      </script>
+                      <style>metabase-question { height: 100vh; }</style>
+                      <metabase-question token="${shortLivedToken}" />
+                    `);
+
+                    H.getSimpleEmbedIframeContent().within(() => {
+                      cy.findByText("Products with price filter").should(
+                        "be.visible",
+                      );
+                    });
+
+                    cy.get("iframe[data-metabase-embed]")
+                      .its("0.contentWindow")
+                      .should("exist")
+                      .then((contentWindow) => {
+                        (
+                          contentWindow as any
+                        ).FORCE_REFRESH_GUEST_EMBED_TOKEN_IN_CYPRESS = true;
+                      });
+
+                    H.getSimpleEmbedIframeContent().within(() => {
+                      cy.findByLabelText("Price greater than").type(
+                        "50{enter}",
+                      );
+                      cy.log(
+                        "ensure the token is refreshed after applying a filter value",
+                      );
+                      cy.wait("@guestTokenProvider");
+
+                      H.assertTableData({
+                        columns: ["ID", "TITLE", "PRICE"],
+                        firstRows: [["2", "Small Marble Shoes", "70.08"]],
+                      });
+                    });
+                  },
+                );
+              },
+            );
+          });
+        });
+      });
+
+      describe("category filter interaction after token refresh", () => {
+        beforeEach(() => {
+          H.prepareGuestEmbedSdkIframeEmbedTest({
+            onPrepare: createQuestionWithCategoryFilter,
+          });
+        });
+
+        it("applying a category filter after token refresh returns filtered results", () => {
+          cy.get<number>("@questionId").then((questionId) => {
+            signJwt({ questionId, expirationSeconds: 5 }).then(
+              (shortLivedToken) => {
+                signJwt({ questionId, expirationSeconds: 600 }).then(
+                  (freshToken) => {
+                    cy.intercept(PROVIDER_INTERCEPT, (req) => {
+                      req.reply({ statusCode: 200, body: { jwt: freshToken } });
+                    }).as("guestTokenProvider");
+
+                    H.visitCustomHtmlPage(`
+                      ${H.getNewEmbedScriptTag({ loadType: "sync" })}
+                      <script>
+                        defineMetabaseConfig({
+                          instanceUrl: "http://localhost:4000",
+                          isGuest: true,
+                          guestEmbedProviderUri: "${PROVIDER_PATH}",
+                        });
+                      </script>
+                      <style>metabase-question { height: 100vh; }</style>
+                      <metabase-question token="${shortLivedToken}" />
+                    `);
+
+                    H.getSimpleEmbedIframeContent().within(() => {
+                      cy.findByText("Products with category filter").should(
+                        "be.visible",
+                      );
+                    });
+
+                    cy.get("iframe[data-metabase-embed]")
+                      .its("0.contentWindow")
+                      .should("exist")
+                      .then((contentWindow) => {
+                        (
+                          contentWindow as any
+                        ).FORCE_REFRESH_GUEST_EMBED_TOKEN_IN_CYPRESS = true;
+                      });
+
+                    H.getSimpleEmbedIframeContent().within(() => {
+                      cy.findByLabelText("Category").click();
+
+                      cy.log(
+                        "ensure the token is refreshed after the filter values endpoint is called",
+                      );
+                      cy.wait("@guestTokenProvider");
+
+                      H.popover().within(() => {
+                        cy.findByRole("checkbox", {
+                          name: "Doohickey",
+                        }).click();
+                        cy.button("Add filter").click();
+                      });
+
+                      H.assertTableData({
+                        columns: ["ID", "TITLE", "CATEGORY"],
+                        firstRows: [["2", "Small Marble Shoes", "Doohickey"]],
+                      });
+                    });
+                  },
+                );
+              },
+            );
+          });
+        });
+      });
+    });
+
+    describe("question initial-token", () => {
+      describe("happy path", () => {
+        beforeEach(() => {
+          H.prepareGuestEmbedSdkIframeEmbedTest({
+            onPrepare: createStandaloneQuestion,
+          });
+        });
+
+        it("calls guestEmbedProviderUri with { entityType: question, entityId } and loads question (initial token fetch)", () => {
+          cy.get<number>("@questionId").then((questionId) => {
+            signJwt({ questionId, expirationSeconds: 600 }).then(
+              (freshToken) => {
+                cy.intercept(PROVIDER_INTERCEPT, (req) => {
+                  req.reply({ statusCode: 200, body: { jwt: freshToken } });
+                }).as("guestTokenProvider");
+
+                H.visitCustomHtmlPage(`
+                  ${H.getNewEmbedScriptTag({ loadType: "sync" })}
+                  <script>
+                    defineMetabaseConfig({
+                      instanceUrl: "http://localhost:4000",
+                      isGuest: true,
+                      guestEmbedProviderUri: "${PROVIDER_PATH}",
+                    });
+                  </script>
+                  <style>metabase-question { height: 100vh; }</style>
+                  <metabase-question question-id="${questionId}" />
+                `);
+
+                cy.wait("@guestTokenProvider").then((interception) => {
+                  expect(interception.request.url).to.include("response=json");
+                  expect(interception.request.body).to.deep.include({
+                    entityType: "question",
+                    entityId: questionId,
+                  });
+                });
+
+                H.getSimpleEmbedIframeContent()
+                  .findByTestId("visualization-root")
+                  .should("exist");
+              },
+            );
+          });
+        });
+      });
+
+      describe("provider error shows error state", () => {
+        beforeEach(() => {
+          H.prepareGuestEmbedSdkIframeEmbedTest({
+            onPrepare: createStandaloneQuestion,
+          });
+        });
+
+        it("shows an error when the initial token fetch fails", () => {
+          cy.get<number>("@questionId").then((questionId) => {
+            cy.intercept(PROVIDER_INTERCEPT, (req) => {
+              req.reply({ statusCode: 500 });
+            }).as("guestTokenProvider");
+
+            H.visitCustomHtmlPage(`
+              ${H.getNewEmbedScriptTag({ loadType: "sync" })}
+              <script>
+                defineMetabaseConfig({
+                  instanceUrl: "http://localhost:4000",
+                  isGuest: true,
+                  guestEmbedProviderUri: "${PROVIDER_PATH}",
+                });
+              </script>
+              <style>metabase-question { height: 100vh; }</style>
+              <metabase-question question-id="${questionId}" />
+            `);
+
+            cy.wait("@guestTokenProvider");
+            H.getSimpleEmbedIframeContent()
+              .findByText(
+                "A valid JWT token is required to be passed in guest embeds mode.",
+              )
+              .should("be.visible");
+          });
+        });
+      });
+    });
+  },
+);

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/guest-token-refresh.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/guest-token-refresh.cy.spec.ts
@@ -314,7 +314,7 @@ describe(
             signJwt({ dashboardId, expirationSeconds: -60 }).then(
               (expiredToken) => {
                 cy.intercept(PROVIDER_INTERCEPT, (req) => {
-                  req.reply({ statusCode: 500, body: null });
+                  req.reply({ statusCode: 500 });
                 }).as("guestTokenProvider");
 
                 H.visitCustomHtmlPage(`
@@ -505,7 +505,9 @@ describe(
                       cy.wait("@guestTokenProvider");
 
                       H.popover().within(() => {
-                        cy.findByText("Doohickey").click();
+                        cy.findByRole("checkbox", {
+                          name: "Doohickey",
+                        }).click();
                         cy.button("Add filter").click();
                       });
 
@@ -680,10 +682,7 @@ describe(
                     });
                   </script>
                   <style>metabase-question { height: 100vh; }</style>
-                  <metabase-question
-                    question-id="${questionId}"
-                    token="${expiredToken}"
-                  />
+                  <metabase-question token="${expiredToken}" />
                 `);
 
                 cy.wait("@guestTokenProvider");
@@ -720,10 +719,7 @@ describe(
                         });
                       </script>
                       <style>metabase-question { height: 100vh; }</style>
-                      <metabase-question
-                        question-id="${questionId}"
-                        token="${expiredToken}"
-                      />
+                      <metabase-question token="${expiredToken}" />
                     `);
 
                     cy.wait("@guestTokenProvider");

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/guest-token-refresh.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/guest-token-refresh.cy.spec.ts
@@ -208,13 +208,15 @@ describe(
         name: "Products with price filter",
         native: {
           query:
-            "SELECT ID, TITLE, PRICE FROM PRODUCTS WHERE PRICE >= {{price}} LIMIT 10",
+            "SELECT ID, TITLE, PRICE FROM PRODUCTS WHERE {{price}} LIMIT 10",
           "template-tags": {
             price: {
               id: "cccccccc",
               name: "price",
               "display-name": "Price greater than",
-              type: "number",
+              type: "dimension",
+              dimension: ["field", PRODUCTS.PRICE, null],
+              "widget-type": "number/>=",
               required: false,
             },
           },
@@ -370,7 +372,7 @@ describe(
                     cy.wait("@guestTokenProvider");
                     H.getSimpleEmbedIframeContent()
                       .findByText(
-                        'Your JWT server endpoint must return an object with the shape { jwt: string }, but instead received {"token":"YOUR_JWT"}',
+                        /Your JWT server endpoint must return an object with the shape { jwt: string }, but instead received {"token":/,
                       )
                       .should("be.visible");
                   },
@@ -594,7 +596,7 @@ describe(
             cy.wait("@guestTokenProvider");
             H.getSimpleEmbedIframeContent()
               .findByText(
-                "A valid JWT token is required to be passed in guest embeds mode.",
+                "Failed to fetch JWT token from /api/mock-guest-token-provider, status: 500.",
               )
               .should("be.visible");
           });
@@ -727,7 +729,7 @@ describe(
                     cy.wait("@guestTokenProvider");
                     H.getSimpleEmbedIframeContent()
                       .findByText(
-                        'Your JWT server endpoint must return an object with the shape { jwt: string }, but instead received {"token":"YOUR_JWT"}',
+                        /Your JWT server endpoint must return an object with the shape { jwt: string }, but instead received {"token":/,
                       )
                       .should("be.visible");
                   },
@@ -784,9 +786,12 @@ describe(
                       });
 
                     H.getSimpleEmbedIframeContent().within(() => {
-                      cy.findByLabelText("Price greater than").type(
-                        "50{enter}",
-                      );
+                      cy.findByLabelText("Price greater than").click();
+                      H.popover().within(() => {
+                        cy.findByPlaceholderText("Enter a number").type(
+                          "50{enter}",
+                        );
+                      });
                       cy.log(
                         "ensure the token is refreshed after applying a filter value",
                       );
@@ -954,7 +959,7 @@ describe(
             cy.wait("@guestTokenProvider");
             H.getSimpleEmbedIframeContent()
               .findByText(
-                "A valid JWT token is required to be passed in guest embeds mode.",
+                "Failed to fetch JWT token from /api/mock-guest-token-provider, status: 500.",
               )
               .should("be.visible");
           });

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/guest-token-refresh.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/guest-token-refresh.cy.spec.ts
@@ -6,9 +6,6 @@ import { JWT_SHARED_SECRET } from "e2e/support/helpers/embedding-sdk-helpers/con
 const { H } = cy;
 const { ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
 
-const IS_ENTERPRISE = Cypress.expose("IS_ENTERPRISE");
-const IS_OSS = !IS_ENTERPRISE;
-
 const PROVIDER_PATH = "/api/mock-guest-token-provider";
 const PROVIDER_INTERCEPT = { method: "POST", pathname: PROVIDER_PATH } as const;
 
@@ -40,6 +37,37 @@ function signJwt({
     .then((token) => token);
 }
 
+const COMPONENT_TAGS = {
+  dashboard: "metabase-dashboard",
+  question: "metabase-question",
+} as const;
+
+function visitGuestEmbedPage({
+  component,
+  attributes = {},
+}: {
+  component: "dashboard" | "question";
+  attributes?: Record<string, string | number>;
+}) {
+  const tagName = COMPONENT_TAGS[component];
+  const attrString = Object.entries(attributes)
+    .map(([k, v]) => `${k}="${v}"`)
+    .join(" ");
+
+  H.visitCustomHtmlPage(`
+    ${H.getNewEmbedScriptTag({ loadType: "sync" })}
+    <script>
+      defineMetabaseConfig({
+        instanceUrl: "http://localhost:4000",
+        isGuest: true,
+        guestEmbedProviderUri: "${PROVIDER_PATH}",
+      });
+    </script>
+    <style>${tagName} { height: 100vh; }</style>
+    <${tagName} ${attrString} />
+  `);
+}
+
 const PRICE_DASHBOARD_PARAMETER = {
   name: "Price greater than",
   slug: "price",
@@ -56,981 +84,852 @@ const CATEGORY_DASHBOARD_PARAMETER = {
   sectionId: "string",
 };
 
-describe(
-  `scenarios > embedding > sdk iframe embedding > guest token refresh > ${IS_OSS ? "oss" : "ee"}`,
-  { ...(IS_OSS && { tags: "@OSS" }) },
-  () => {
-    function createDashboardWithQuestion() {
-      createQuestion({
-        name: "Orders",
-        query: { "source-table": ORDERS_ID },
-      }).then(({ body: question }) => {
+describe("scenarios > embedding > sdk iframe embedding > guest token refresh", () => {
+  function createDashboardWithQuestion() {
+    createQuestion({
+      name: "Orders",
+      query: { "source-table": ORDERS_ID },
+    }).then(({ body: question }) => {
+      cy.request("POST", "/api/dashboard", {
+        name: "Guest Token Refresh Dashboard",
+      }).then(({ body: dashboard }) => {
+        cy.wrap(dashboard.id).as("dashboardId");
+
+        cy.request("PUT", `/api/dashboard/${dashboard.id}`, {
+          enable_embedding: true,
+          embedding_type: "guest-embed",
+          dashcards: [
+            {
+              id: -1,
+              card_id: question.id,
+              row: 0,
+              col: 0,
+              size_x: 11,
+              size_y: 6,
+            },
+          ],
+        });
+      });
+    });
+  }
+
+  function createDashboardWithPriceFilter() {
+    H.createTestQuery({
+      database: SAMPLE_DB_ID,
+      stages: [
+        {
+          source: { type: "table", id: PRODUCTS_ID },
+          fields: [
+            { type: "column", name: "ID", sourceName: "PRODUCTS" },
+            { type: "column", name: "TITLE", sourceName: "PRODUCTS" },
+            { type: "column", name: "PRICE", sourceName: "PRODUCTS" },
+          ],
+          limit: 10,
+        },
+      ],
+    }).then((datasetQuery) => {
+      H.createCard({
+        dataset_query: datasetQuery,
+        name: "Products with price filter",
+      }).then((question) => {
         cy.request("POST", "/api/dashboard", {
-          name: "Guest Token Refresh Dashboard",
+          name: "Guest Token Refresh Dashboard with Price Filter",
+          parameters: [PRICE_DASHBOARD_PARAMETER],
         }).then(({ body: dashboard }) => {
           cy.wrap(dashboard.id).as("dashboardId");
 
           cy.request("PUT", `/api/dashboard/${dashboard.id}`, {
             enable_embedding: true,
             embedding_type: "guest-embed",
+            embedding_params: { price: "enabled" },
             dashcards: [
               {
                 id: -1,
                 card_id: question.id,
                 row: 0,
                 col: 0,
-                size_x: 11,
+                size_x: 24,
                 size_y: 6,
+                parameter_mappings: [
+                  {
+                    parameter_id: "aaaaaaaa",
+                    card_id: question.id,
+                    target: ["dimension", ["field", PRODUCTS.PRICE, null]],
+                  },
+                ],
               },
             ],
           });
         });
       });
-    }
+    });
+  }
 
-    function createDashboardWithPriceFilter() {
-      H.createTestQuery({
-        database: SAMPLE_DB_ID,
-        stages: [
-          {
-            source: { type: "table", id: PRODUCTS_ID },
-            fields: [
-              { type: "column", name: "ID", sourceName: "PRODUCTS" },
-              { type: "column", name: "TITLE", sourceName: "PRODUCTS" },
-              { type: "column", name: "PRICE", sourceName: "PRODUCTS" },
-            ],
-            limit: 10,
-          },
-        ],
-      }).then((datasetQuery) => {
-        H.createCard({
-          dataset_query: datasetQuery,
-          name: "Products with price filter",
-        }).then((question) => {
-          cy.request("POST", "/api/dashboard", {
-            name: "Guest Token Refresh Dashboard with Price Filter",
-            parameters: [PRICE_DASHBOARD_PARAMETER],
-          }).then(({ body: dashboard }) => {
-            cy.wrap(dashboard.id).as("dashboardId");
-
-            cy.request("PUT", `/api/dashboard/${dashboard.id}`, {
-              enable_embedding: true,
-              embedding_type: "guest-embed",
-              embedding_params: { price: "enabled" },
-              dashcards: [
-                {
-                  id: -1,
-                  card_id: question.id,
-                  row: 0,
-                  col: 0,
-                  size_x: 24,
-                  size_y: 6,
-                  parameter_mappings: [
-                    {
-                      parameter_id: "aaaaaaaa",
-                      card_id: question.id,
-                      target: ["dimension", ["field", PRODUCTS.PRICE, null]],
-                    },
-                  ],
-                },
-              ],
-            });
-          });
-        });
-      });
-    }
-
-    function createDashboardWithCategoryFilter() {
-      H.createTestQuery({
-        database: SAMPLE_DB_ID,
-        stages: [
-          {
-            source: { type: "table", id: PRODUCTS_ID },
-            fields: [
-              { type: "column", name: "ID", sourceName: "PRODUCTS" },
-              { type: "column", name: "TITLE", sourceName: "PRODUCTS" },
-              { type: "column", name: "CATEGORY", sourceName: "PRODUCTS" },
-            ],
-            limit: 10,
-          },
-        ],
-      }).then((datasetQuery) => {
-        H.createCard({
-          dataset_query: datasetQuery,
-          name: "Products with category filter",
-        }).then((question) => {
-          cy.request("POST", "/api/dashboard", {
-            name: "Guest Token Refresh Dashboard with Category Filter",
-            parameters: [CATEGORY_DASHBOARD_PARAMETER],
-          }).then(({ body: dashboard }) => {
-            cy.wrap(dashboard.id).as("dashboardId");
-
-            cy.request("PUT", `/api/dashboard/${dashboard.id}`, {
-              enable_embedding: true,
-              embedding_type: "guest-embed",
-              embedding_params: { category: "enabled" },
-              dashcards: [
-                {
-                  id: -1,
-                  card_id: question.id,
-                  row: 0,
-                  col: 0,
-                  size_x: 24,
-                  size_y: 6,
-                  parameter_mappings: [
-                    {
-                      parameter_id: "bbbbbbbb",
-                      card_id: question.id,
-                      target: ["dimension", ["field", PRODUCTS.CATEGORY, null]],
-                    },
-                  ],
-                },
-              ],
-            });
-          });
-        });
-      });
-    }
-
-    function createStandaloneQuestion() {
-      createQuestion({
-        name: "Orders",
-        enable_embedding: true,
-        embedding_type: "guest-embed",
-        query: { "source-table": ORDERS_ID },
-      }).then(({ body: question }) => {
-        cy.wrap(question.id).as("questionId");
-      });
-    }
-
-    function createQuestionWithPriceFilter() {
-      H.createNativeQuestion({
-        name: "Products with price filter",
-        native: {
-          query:
-            "SELECT ID, TITLE, PRICE FROM PRODUCTS WHERE {{price}} LIMIT 10",
-          "template-tags": {
-            price: {
-              id: "cccccccc",
-              name: "price",
-              "display-name": "Price greater than",
-              type: "dimension",
-              dimension: ["field", PRODUCTS.PRICE, null],
-              "widget-type": "number/>=",
-              required: false,
-            },
-          },
+  function createDashboardWithCategoryFilter() {
+    H.createTestQuery({
+      database: SAMPLE_DB_ID,
+      stages: [
+        {
+          source: { type: "table", id: PRODUCTS_ID },
+          fields: [
+            { type: "column", name: "ID", sourceName: "PRODUCTS" },
+            { type: "column", name: "TITLE", sourceName: "PRODUCTS" },
+            { type: "column", name: "CATEGORY", sourceName: "PRODUCTS" },
+          ],
+          limit: 10,
         },
-        enable_embedding: true,
-        embedding_params: { price: "enabled" },
-        embedding_type: "guest-embed",
-      }).then(({ body: question }) => {
-        cy.wrap(question.id).as("questionId");
-      });
-    }
-
-    function createQuestionWithCategoryFilter() {
-      H.createNativeQuestion({
+      ],
+    }).then((datasetQuery) => {
+      H.createCard({
+        dataset_query: datasetQuery,
         name: "Products with category filter",
-        native: {
-          query:
-            "SELECT ID, TITLE, CATEGORY FROM PRODUCTS WHERE {{category}} LIMIT 10",
-          "template-tags": {
-            category: {
-              id: "dddddddd",
-              name: "category",
-              "display-name": "Category",
-              type: "dimension",
-              dimension: ["field", PRODUCTS.CATEGORY, null],
-              "widget-type": "category",
-              required: false,
-            },
+      }).then((question) => {
+        cy.request("POST", "/api/dashboard", {
+          name: "Guest Token Refresh Dashboard with Category Filter",
+          parameters: [CATEGORY_DASHBOARD_PARAMETER],
+        }).then(({ body: dashboard }) => {
+          cy.wrap(dashboard.id).as("dashboardId");
+
+          cy.request("PUT", `/api/dashboard/${dashboard.id}`, {
+            enable_embedding: true,
+            embedding_type: "guest-embed",
+            embedding_params: { category: "enabled" },
+            dashcards: [
+              {
+                id: -1,
+                card_id: question.id,
+                row: 0,
+                col: 0,
+                size_x: 24,
+                size_y: 6,
+                parameter_mappings: [
+                  {
+                    parameter_id: "bbbbbbbb",
+                    card_id: question.id,
+                    target: ["dimension", ["field", PRODUCTS.CATEGORY, null]],
+                  },
+                ],
+              },
+            ],
+          });
+        });
+      });
+    });
+  }
+
+  function createStandaloneQuestion() {
+    createQuestion({
+      name: "Orders",
+      enable_embedding: true,
+      embedding_type: "guest-embed",
+      query: { "source-table": ORDERS_ID },
+    }).then(({ body: question }) => {
+      cy.wrap(question.id).as("questionId");
+    });
+  }
+
+  function createQuestionWithPriceFilter() {
+    H.createNativeQuestion({
+      name: "Products with price filter",
+      native: {
+        query: "SELECT ID, TITLE, PRICE FROM PRODUCTS WHERE {{price}} LIMIT 10",
+        "template-tags": {
+          price: {
+            id: "cccccccc",
+            name: "price",
+            "display-name": "Price greater than",
+            type: "dimension",
+            dimension: ["field", PRODUCTS.PRICE, null],
+            "widget-type": "number/>=",
+            required: false,
           },
         },
-        enable_embedding: true,
-        embedding_params: { category: "enabled" },
-        embedding_type: "guest-embed",
-      }).then(({ body: question }) => {
-        cy.wrap(question.id).as("questionId");
-      });
-    }
+      },
+      enable_embedding: true,
+      embedding_params: { price: "enabled" },
+      embedding_type: "guest-embed",
+    }).then(({ body: question }) => {
+      cy.wrap(question.id).as("questionId");
+    });
+  }
 
-    describe("dashboard refresh-only", () => {
-      describe("happy path", () => {
-        beforeEach(() => {
-          H.prepareGuestEmbedSdkIframeEmbedTest({
-            onPrepare: createDashboardWithQuestion,
-          });
-        });
+  function createQuestionWithCategoryFilter() {
+    H.createNativeQuestion({
+      name: "Products with category filter",
+      native: {
+        query:
+          "SELECT ID, TITLE, CATEGORY FROM PRODUCTS WHERE {{category}} LIMIT 10",
+        "template-tags": {
+          category: {
+            id: "dddddddd",
+            name: "category",
+            "display-name": "Category",
+            type: "dimension",
+            dimension: ["field", PRODUCTS.CATEGORY, null],
+            "widget-type": "category",
+            required: false,
+          },
+        },
+      },
+      enable_embedding: true,
+      embedding_params: { category: "enabled" },
+      embedding_type: "guest-embed",
+    }).then(({ body: question }) => {
+      cy.wrap(question.id).as("questionId");
+    });
+  }
 
-        it("calls guestEmbedProviderUri with { entityType, entityId } and loads dashboard after token refresh", () => {
-          cy.get<number>("@dashboardId").then((dashboardId) => {
-            signJwt({ dashboardId, expirationSeconds: -60 }).then(
-              (expiredToken) => {
-                signJwt({ dashboardId, expirationSeconds: 600 }).then(
-                  (freshToken) => {
-                    cy.intercept(PROVIDER_INTERCEPT, (req) => {
-                      req.reply({ statusCode: 200, body: { jwt: freshToken } });
-                    }).as("guestTokenProvider");
-
-                    H.visitCustomHtmlPage(`
-                      ${H.getNewEmbedScriptTag({ loadType: "sync" })}
-                      <script>
-                        defineMetabaseConfig({
-                          instanceUrl: "http://localhost:4000",
-                          isGuest: true,
-                          guestEmbedProviderUri: "${PROVIDER_PATH}",
-                        });
-                      </script>
-                      <style>metabase-dashboard { height: 100vh; }</style>
-                      <metabase-dashboard token="${expiredToken}" custom-context="test-custom-context" />
-                    `);
-
-                    cy.wait("@guestTokenProvider").then((interception) => {
-                      expect(interception.request.body).to.deep.include({
-                        entityType: "dashboard",
-                        entityId: dashboardId,
-                        customContext: "test-custom-context",
-                      });
-                    });
-
-                    H.getSimpleEmbedIframeContent().should("contain", "Orders");
-                  },
-                );
-              },
-            );
-          });
+  describe("dashboard refresh-only", () => {
+    describe("happy path", () => {
+      beforeEach(() => {
+        H.prepareGuestEmbedSdkIframeEmbedTest({
+          onPrepare: createDashboardWithQuestion,
         });
       });
 
-      describe("provider error shows error state", () => {
-        beforeEach(() => {
-          H.prepareGuestEmbedSdkIframeEmbedTest({
-            onPrepare: createDashboardWithQuestion,
-          });
-        });
+      it("calls guestEmbedProviderUri with { entityType, entityId } and loads dashboard after token refresh", () => {
+        cy.get<number>("@dashboardId").then((dashboardId) => {
+          signJwt({ dashboardId, expirationSeconds: -60 }).then(
+            (expiredToken) => {
+              signJwt({ dashboardId, expirationSeconds: 600 }).then(
+                (freshToken) => {
+                  cy.intercept(PROVIDER_INTERCEPT, (req) => {
+                    req.reply({ statusCode: 200, body: { jwt: freshToken } });
+                  }).as("guestTokenProvider");
 
-        it("shows an error when the provider returns an HTTP error", () => {
-          cy.get<number>("@dashboardId").then((dashboardId) => {
-            signJwt({ dashboardId, expirationSeconds: -60 }).then(
-              (expiredToken) => {
-                cy.intercept(PROVIDER_INTERCEPT, (req) => {
-                  req.reply({ statusCode: 500 });
-                }).as("guestTokenProvider");
+                  visitGuestEmbedPage({
+                    component: "dashboard",
+                    attributes: {
+                      token: expiredToken,
+                      "custom-context": "test-custom-context",
+                    },
+                  });
 
-                H.visitCustomHtmlPage(`
-                  ${H.getNewEmbedScriptTag({ loadType: "sync" })}
-                  <script>
-                    defineMetabaseConfig({
-                      instanceUrl: "http://localhost:4000",
-                      isGuest: true,
-                      guestEmbedProviderUri: "${PROVIDER_PATH}",
+                  cy.wait("@guestTokenProvider").then((interception) => {
+                    expect(interception.request.body).to.deep.include({
+                      entityType: "dashboard",
+                      entityId: dashboardId,
+                      customContext: "test-custom-context",
                     });
-                  </script>
-                  <style>metabase-dashboard { height: 100vh; }</style>
-                  <metabase-dashboard token="${expiredToken}" />
-                `);
+                  });
 
-                cy.wait("@guestTokenProvider");
-                H.getSimpleEmbedIframeContent()
-                  .findByText(
-                    "Failed to fetch JWT token from /api/mock-guest-token-provider, status: 500.",
-                  )
-                  .should("be.visible");
-              },
-            );
-          });
+                  H.getSimpleEmbedIframeContent().should("contain", "Orders");
+                },
+              );
+            },
+          );
         });
+      });
+    });
 
-        it("shows an error when the provider returns a wrong response shape", () => {
-          cy.get<number>("@dashboardId").then((dashboardId) => {
-            signJwt({ dashboardId, expirationSeconds: -60 }).then(
-              (expiredToken) => {
-                signJwt({ dashboardId, expirationSeconds: 600 }).then(
-                  (freshToken) => {
-                    cy.intercept(PROVIDER_INTERCEPT, (req) => {
-                      req.reply({
-                        statusCode: 200,
-                        body: { token: freshToken },
-                      });
-                    }).as("guestTokenProvider");
+    describe("provider error shows error state", () => {
+      beforeEach(() => {
+        H.prepareGuestEmbedSdkIframeEmbedTest({
+          onPrepare: createDashboardWithQuestion,
+        });
+      });
 
-                    H.visitCustomHtmlPage(`
-                      ${H.getNewEmbedScriptTag({ loadType: "sync" })}
-                      <script>
-                        defineMetabaseConfig({
-                          instanceUrl: "http://localhost:4000",
-                          isGuest: true,
-                          guestEmbedProviderUri: "${PROVIDER_PATH}",
-                        });
-                      </script>
-                      <style>metabase-dashboard { height: 100vh; }</style>
-                      <metabase-dashboard token="${expiredToken}" />
-                    `);
+      it("shows an error when the provider returns an HTTP error", () => {
+        cy.get<number>("@dashboardId").then((dashboardId) => {
+          signJwt({ dashboardId, expirationSeconds: -60 }).then(
+            (expiredToken) => {
+              cy.intercept(PROVIDER_INTERCEPT, (req) => {
+                req.reply({ statusCode: 500 });
+              }).as("guestTokenProvider");
 
+              visitGuestEmbedPage({
+                component: "dashboard",
+                attributes: { token: expiredToken },
+              });
+
+              cy.wait("@guestTokenProvider");
+              H.getSimpleEmbedIframeContent()
+                .findByText(
+                  "Failed to fetch JWT token from /api/mock-guest-token-provider, status: 500.",
+                )
+                .should("be.visible");
+            },
+          );
+        });
+      });
+
+      it("shows an error when the provider returns a wrong response shape", () => {
+        cy.get<number>("@dashboardId").then((dashboardId) => {
+          signJwt({ dashboardId, expirationSeconds: -60 }).then(
+            (expiredToken) => {
+              signJwt({ dashboardId, expirationSeconds: 600 }).then(
+                (freshToken) => {
+                  cy.intercept(PROVIDER_INTERCEPT, (req) => {
+                    req.reply({
+                      statusCode: 200,
+                      body: { token: freshToken },
+                    });
+                  }).as("guestTokenProvider");
+
+                  visitGuestEmbedPage({
+                    component: "dashboard",
+                    attributes: { token: expiredToken },
+                  });
+
+                  cy.wait("@guestTokenProvider");
+                  H.getSimpleEmbedIframeContent()
+                    .findByText(
+                      /Your JWT server endpoint must return an object with the shape { jwt: string }, but instead received {"token":/,
+                    )
+                    .should("be.visible");
+                },
+              );
+            },
+          );
+        });
+      });
+    });
+
+    describe("number filter interaction after token refresh", () => {
+      beforeEach(() => {
+        H.prepareGuestEmbedSdkIframeEmbedTest({
+          onPrepare: createDashboardWithPriceFilter,
+        });
+      });
+
+      it("applying a number filter after token refresh returns filtered results", () => {
+        cy.get<number>("@dashboardId").then((dashboardId) => {
+          signJwt({ dashboardId, expirationSeconds: 5 }).then(
+            (shortLivedToken) => {
+              signJwt({ dashboardId, expirationSeconds: 600 }).then(
+                (freshToken) => {
+                  cy.intercept(PROVIDER_INTERCEPT, (req) => {
+                    req.reply({ statusCode: 200, body: { jwt: freshToken } });
+                  }).as("guestTokenProvider");
+
+                  visitGuestEmbedPage({
+                    component: "dashboard",
+                    attributes: { token: shortLivedToken },
+                  });
+
+                  H.getSimpleEmbedIframeContent().within(() => {
+                    cy.findByLabelText("Price greater than").should(
+                      "be.visible",
+                    );
+                  });
+
+                  cy.get("iframe[data-metabase-embed]")
+                    .its("0.contentWindow")
+                    .should("exist")
+                    .then((contentWindow) => {
+                      contentWindow.FORCE_REFRESH_GUEST_EMBED_TOKEN_IN_CYPRESS =
+                        true;
+                    });
+
+                  H.getSimpleEmbedIframeContent().within(() => {
+                    cy.findByLabelText("Price greater than").click();
+                    H.popover().within(() => {
+                      cy.findByPlaceholderText("Enter a number").type(
+                        "50{enter}",
+                      );
+                    });
+                    cy.log(
+                      "ensure the token is refreshed after applying a filter value",
+                    );
                     cy.wait("@guestTokenProvider");
-                    H.getSimpleEmbedIframeContent()
-                      .findByText(
-                        /Your JWT server endpoint must return an object with the shape { jwt: string }, but instead received {"token":/,
-                      )
-                      .should("be.visible");
-                  },
-                );
-              },
-            );
-          });
+
+                    H.assertTableData({
+                      columns: ["ID", "Title", "Price"],
+                      firstRows: [["2", "Small Marble Shoes", "70.08"]],
+                    });
+                  });
+                },
+              );
+            },
+          );
+        });
+      });
+    });
+
+    describe("category filter interaction after token refresh", () => {
+      beforeEach(() => {
+        H.prepareGuestEmbedSdkIframeEmbedTest({
+          onPrepare: createDashboardWithCategoryFilter,
         });
       });
 
-      describe("number filter interaction after token refresh", () => {
-        beforeEach(() => {
-          H.prepareGuestEmbedSdkIframeEmbedTest({
-            onPrepare: createDashboardWithPriceFilter,
-          });
+      it("applying a category filter after token refresh returns filtered results", () => {
+        cy.get<number>("@dashboardId").then((dashboardId) => {
+          signJwt({ dashboardId, expirationSeconds: 5 }).then(
+            (shortLivedToken) => {
+              signJwt({ dashboardId, expirationSeconds: 600 }).then(
+                (freshToken) => {
+                  cy.intercept(PROVIDER_INTERCEPT, (req) => {
+                    req.reply({ statusCode: 200, body: { jwt: freshToken } });
+                  }).as("guestTokenProvider");
+
+                  visitGuestEmbedPage({
+                    component: "dashboard",
+                    attributes: { token: shortLivedToken },
+                  });
+
+                  H.getSimpleEmbedIframeContent().within(() => {
+                    cy.findByLabelText("Category").should("be.visible");
+                  });
+
+                  cy.get("iframe[data-metabase-embed]")
+                    .its("0.contentWindow")
+                    .should("exist")
+                    .then((contentWindow) => {
+                      contentWindow.FORCE_REFRESH_GUEST_EMBED_TOKEN_IN_CYPRESS =
+                        true;
+                    });
+
+                  H.getSimpleEmbedIframeContent().within(() => {
+                    cy.findByLabelText("Category").click();
+
+                    cy.log(
+                      "ensure the token is refreshed after the filter values endpoint is called",
+                    );
+                    cy.wait("@guestTokenProvider");
+
+                    H.popover().within(() => {
+                      cy.findByRole("checkbox", {
+                        name: "Doohickey",
+                      }).click();
+                      cy.button("Add filter").click();
+                    });
+
+                    H.assertTableData({
+                      columns: ["ID", "Title", "Category"],
+                      firstRows: [["2", "Small Marble Shoes", "Doohickey"]],
+                    });
+                  });
+                },
+              );
+            },
+          );
         });
+      });
+    });
+  });
 
-        it("applying a number filter after token refresh returns filtered results", () => {
-          cy.get<number>("@dashboardId").then((dashboardId) => {
-            signJwt({ dashboardId, expirationSeconds: 5 }).then(
-              (shortLivedToken) => {
-                signJwt({ dashboardId, expirationSeconds: 600 }).then(
-                  (freshToken) => {
-                    cy.intercept(PROVIDER_INTERCEPT, (req) => {
-                      req.reply({ statusCode: 200, body: { jwt: freshToken } });
-                    }).as("guestTokenProvider");
-
-                    H.visitCustomHtmlPage(`
-                      ${H.getNewEmbedScriptTag({ loadType: "sync" })}
-                      <script>
-                        defineMetabaseConfig({
-                          instanceUrl: "http://localhost:4000",
-                          isGuest: true,
-                          guestEmbedProviderUri: "${PROVIDER_PATH}",
-                        });
-                      </script>
-                      <style>metabase-dashboard { height: 100vh; }</style>
-                      <metabase-dashboard token="${shortLivedToken}" />
-                    `);
-
-                    H.getSimpleEmbedIframeContent().within(() => {
-                      cy.findByLabelText("Price greater than").should(
-                        "be.visible",
-                      );
-                    });
-
-                    cy.get("iframe[data-metabase-embed]")
-                      .its("0.contentWindow")
-                      .should("exist")
-                      .then((contentWindow) => {
-                        (
-                          contentWindow as any
-                        ).FORCE_REFRESH_GUEST_EMBED_TOKEN_IN_CYPRESS = true;
-                      });
-
-                    H.getSimpleEmbedIframeContent().within(() => {
-                      cy.findByLabelText("Price greater than").click();
-                      H.popover().within(() => {
-                        cy.findByPlaceholderText("Enter a number").type(
-                          "50{enter}",
-                        );
-                      });
-                      cy.log(
-                        "ensure the token is refreshed after applying a filter value",
-                      );
-                      cy.wait("@guestTokenProvider");
-
-                      H.assertTableData({
-                        columns: ["ID", "Title", "Price"],
-                        firstRows: [["2", "Small Marble Shoes", "70.08"]],
-                      });
-                    });
-                  },
-                );
-              },
-            );
-          });
+  describe("dashboard initial-token", () => {
+    describe("happy path", () => {
+      beforeEach(() => {
+        H.prepareGuestEmbedSdkIframeEmbedTest({
+          onPrepare: createDashboardWithQuestion,
         });
       });
 
-      describe("category filter interaction after token refresh", () => {
-        beforeEach(() => {
-          H.prepareGuestEmbedSdkIframeEmbedTest({
-            onPrepare: createDashboardWithCategoryFilter,
-          });
+      it("calls guestEmbedProviderUri with { entityType, entityId } and loads dashboard (initial token fetch)", () => {
+        cy.get<number>("@dashboardId").then((dashboardId) => {
+          signJwt({ dashboardId, expirationSeconds: 600 }).then(
+            (freshToken) => {
+              cy.intercept(PROVIDER_INTERCEPT, (req) => {
+                req.reply({ statusCode: 200, body: { jwt: freshToken } });
+              }).as("guestTokenProvider");
+
+              visitGuestEmbedPage({
+                component: "dashboard",
+                attributes: {
+                  "dashboard-id": dashboardId,
+                  "custom-context": "test-custom-context",
+                },
+              });
+
+              cy.wait("@guestTokenProvider").then((interception) => {
+                expect(interception.request.url).to.include("response=json");
+                expect(interception.request.body).to.deep.include({
+                  entityType: "dashboard",
+                  entityId: dashboardId,
+                  customContext: "test-custom-context",
+                });
+              });
+
+              H.getSimpleEmbedIframeContent().should("contain", "Orders");
+            },
+          );
         });
+      });
+    });
 
-        it("applying a category filter after token refresh returns filtered results", () => {
-          cy.get<number>("@dashboardId").then((dashboardId) => {
-            signJwt({ dashboardId, expirationSeconds: 5 }).then(
-              (shortLivedToken) => {
-                signJwt({ dashboardId, expirationSeconds: 600 }).then(
-                  (freshToken) => {
-                    cy.intercept(PROVIDER_INTERCEPT, (req) => {
-                      req.reply({ statusCode: 200, body: { jwt: freshToken } });
-                    }).as("guestTokenProvider");
+    describe("provider error shows error state", () => {
+      beforeEach(() => {
+        H.prepareGuestEmbedSdkIframeEmbedTest({
+          onPrepare: createDashboardWithQuestion,
+        });
+      });
 
-                    H.visitCustomHtmlPage(`
-                      ${H.getNewEmbedScriptTag({ loadType: "sync" })}
-                      <script>
-                        defineMetabaseConfig({
-                          instanceUrl: "http://localhost:4000",
-                          isGuest: true,
-                          guestEmbedProviderUri: "${PROVIDER_PATH}",
-                        });
-                      </script>
-                      <style>metabase-dashboard { height: 100vh; }</style>
-                      <metabase-dashboard token="${shortLivedToken}" />
-                    `);
+      it("shows an error when the provider returns an HTTP error", () => {
+        cy.get<number>("@dashboardId").then((dashboardId) => {
+          cy.intercept(PROVIDER_INTERCEPT, (req) => {
+            req.reply({ statusCode: 500 });
+          }).as("guestTokenProvider");
 
-                    H.getSimpleEmbedIframeContent().within(() => {
-                      cy.findByLabelText("Category").should("be.visible");
+          visitGuestEmbedPage({
+            component: "dashboard",
+            attributes: { "dashboard-id": dashboardId },
+          });
+
+          cy.wait("@guestTokenProvider");
+          H.getSimpleEmbedIframeContent()
+            .findByText(
+              "Failed to fetch JWT token from /api/mock-guest-token-provider, status: 500.",
+            )
+            .should("be.visible");
+        });
+      });
+
+      it("shows an error when the provider returns a wrong response shape", () => {
+        cy.get<number>("@dashboardId").then((dashboardId) => {
+          signJwt({ dashboardId, expirationSeconds: 600 }).then(
+            (freshToken) => {
+              cy.intercept(PROVIDER_INTERCEPT, (req) => {
+                req.reply({
+                  statusCode: 200,
+                  body: { token: freshToken },
+                });
+              }).as("guestTokenProvider");
+
+              visitGuestEmbedPage({
+                component: "dashboard",
+                attributes: { "dashboard-id": dashboardId },
+              });
+
+              cy.wait("@guestTokenProvider");
+              H.getSimpleEmbedIframeContent()
+                .findByText(
+                  /Your JWT server endpoint must return an object with the shape { jwt: string }, but instead received {"token":/,
+                )
+                .should("be.visible");
+            },
+          );
+        });
+      });
+    });
+  });
+
+  describe("question refresh-only", () => {
+    describe("happy path", () => {
+      beforeEach(() => {
+        H.prepareGuestEmbedSdkIframeEmbedTest({
+          onPrepare: createStandaloneQuestion,
+        });
+      });
+
+      it("calls guestEmbedProviderUri with { entityType: question, entityId } and loads question after token refresh", () => {
+        cy.get<number>("@questionId").then((questionId) => {
+          signJwt({ questionId, expirationSeconds: -60 }).then(
+            (expiredToken) => {
+              signJwt({ questionId, expirationSeconds: 600 }).then(
+                (freshToken) => {
+                  cy.intercept(PROVIDER_INTERCEPT, (req) => {
+                    req.reply({ statusCode: 200, body: { jwt: freshToken } });
+                  }).as("guestTokenProvider");
+
+                  visitGuestEmbedPage({
+                    component: "question",
+                    attributes: {
+                      token: expiredToken,
+                      "custom-context": "test-custom-context",
+                    },
+                  });
+
+                  cy.wait("@guestTokenProvider").then((interception) => {
+                    expect(interception.request.body).to.deep.include({
+                      entityType: "question",
+                      entityId: questionId,
+                      customContext: "test-custom-context",
+                    });
+                  });
+
+                  H.getSimpleEmbedIframeContent()
+                    .findByTestId("visualization-root")
+                    .should("exist");
+                },
+              );
+            },
+          );
+        });
+      });
+    });
+
+    describe("provider error shows error state", () => {
+      beforeEach(() => {
+        H.prepareGuestEmbedSdkIframeEmbedTest({
+          onPrepare: createStandaloneQuestion,
+        });
+      });
+
+      it("shows an error when the provider returns an HTTP error", () => {
+        cy.get<number>("@questionId").then((questionId) => {
+          signJwt({ questionId, expirationSeconds: -60 }).then(
+            (expiredToken) => {
+              cy.intercept(PROVIDER_INTERCEPT, (req) => {
+                req.reply({ statusCode: 500 });
+              }).as("guestTokenProvider");
+
+              visitGuestEmbedPage({
+                component: "question",
+                attributes: { token: expiredToken },
+              });
+
+              cy.wait("@guestTokenProvider");
+              H.getSimpleEmbedIframeContent()
+                .findByText(
+                  "Failed to fetch JWT token from /api/mock-guest-token-provider, status: 500.",
+                )
+                .should("be.visible");
+            },
+          );
+        });
+      });
+
+      it("shows an error when the provider returns a wrong response shape", () => {
+        cy.get<number>("@questionId").then((questionId) => {
+          signJwt({ questionId, expirationSeconds: -60 }).then(
+            (expiredToken) => {
+              signJwt({ questionId, expirationSeconds: 600 }).then(
+                (freshToken) => {
+                  cy.intercept(PROVIDER_INTERCEPT, (req) => {
+                    req.reply({
+                      statusCode: 200,
+                      body: { token: freshToken },
+                    });
+                  }).as("guestTokenProvider");
+
+                  visitGuestEmbedPage({
+                    component: "question",
+                    attributes: { token: expiredToken },
+                  });
+
+                  cy.wait("@guestTokenProvider");
+                  H.getSimpleEmbedIframeContent()
+                    .findByText(
+                      /Your JWT server endpoint must return an object with the shape { jwt: string }, but instead received {"token":/,
+                    )
+                    .should("be.visible");
+                },
+              );
+            },
+          );
+        });
+      });
+    });
+
+    describe("number filter interaction after token refresh", () => {
+      beforeEach(() => {
+        H.prepareGuestEmbedSdkIframeEmbedTest({
+          onPrepare: createQuestionWithPriceFilter,
+        });
+      });
+
+      it("applying a number filter after token refresh returns filtered results", () => {
+        cy.get<number>("@questionId").then((questionId) => {
+          signJwt({ questionId, expirationSeconds: 5 }).then(
+            (shortLivedToken) => {
+              signJwt({ questionId, expirationSeconds: 600 }).then(
+                (freshToken) => {
+                  cy.intercept(PROVIDER_INTERCEPT, (req) => {
+                    req.reply({ statusCode: 200, body: { jwt: freshToken } });
+                  }).as("guestTokenProvider");
+
+                  visitGuestEmbedPage({
+                    component: "question",
+                    attributes: { token: shortLivedToken },
+                  });
+
+                  H.getSimpleEmbedIframeContent().within(() => {
+                    cy.findByText("Products with price filter").should(
+                      "be.visible",
+                    );
+                  });
+
+                  cy.get("iframe[data-metabase-embed]")
+                    .its("0.contentWindow")
+                    .should("exist")
+                    .then((contentWindow) => {
+                      contentWindow.FORCE_REFRESH_GUEST_EMBED_TOKEN_IN_CYPRESS =
+                        true;
                     });
 
-                    cy.get("iframe[data-metabase-embed]")
-                      .its("0.contentWindow")
-                      .should("exist")
-                      .then((contentWindow) => {
-                        (
-                          contentWindow as any
-                        ).FORCE_REFRESH_GUEST_EMBED_TOKEN_IN_CYPRESS = true;
-                      });
-
-                    H.getSimpleEmbedIframeContent().within(() => {
-                      cy.findByLabelText("Category").click();
-
-                      cy.log(
-                        "ensure the token is refreshed after the filter values endpoint is called",
+                  H.getSimpleEmbedIframeContent().within(() => {
+                    cy.findByLabelText("Price greater than").click();
+                    H.popover().within(() => {
+                      cy.findByPlaceholderText("Enter a number").type(
+                        "50{enter}",
                       );
-                      cy.wait("@guestTokenProvider");
-
-                      H.popover().within(() => {
-                        cy.findByRole("checkbox", {
-                          name: "Doohickey",
-                        }).click();
-                        cy.button("Add filter").click();
-                      });
-
-                      H.assertTableData({
-                        columns: ["ID", "Title", "Category"],
-                        firstRows: [["2", "Small Marble Shoes", "Doohickey"]],
-                      });
                     });
-                  },
-                );
+                    cy.log(
+                      "ensure the token is refreshed after applying a filter value",
+                    );
+                    cy.wait("@guestTokenProvider");
+
+                    H.assertTableData({
+                      columns: ["ID", "TITLE", "PRICE"],
+                      firstRows: [["2", "Small Marble Shoes", "70.08"]],
+                    });
+                  });
+                },
+              );
+            },
+          );
+        });
+      });
+    });
+
+    describe("category filter interaction after token refresh", () => {
+      beforeEach(() => {
+        H.prepareGuestEmbedSdkIframeEmbedTest({
+          onPrepare: createQuestionWithCategoryFilter,
+        });
+      });
+
+      it("applying a category filter after token refresh returns filtered results", () => {
+        cy.get<number>("@questionId").then((questionId) => {
+          signJwt({ questionId, expirationSeconds: 5 }).then(
+            (shortLivedToken) => {
+              signJwt({ questionId, expirationSeconds: 600 }).then(
+                (freshToken) => {
+                  cy.intercept(PROVIDER_INTERCEPT, (req) => {
+                    req.reply({ statusCode: 200, body: { jwt: freshToken } });
+                  }).as("guestTokenProvider");
+
+                  visitGuestEmbedPage({
+                    component: "question",
+                    attributes: { token: shortLivedToken },
+                  });
+
+                  H.getSimpleEmbedIframeContent().within(() => {
+                    cy.findByText("Products with category filter").should(
+                      "be.visible",
+                    );
+                  });
+
+                  cy.get("iframe[data-metabase-embed]")
+                    .its("0.contentWindow")
+                    .should("exist")
+                    .then((contentWindow) => {
+                      contentWindow.FORCE_REFRESH_GUEST_EMBED_TOKEN_IN_CYPRESS =
+                        true;
+                    });
+
+                  H.getSimpleEmbedIframeContent().within(() => {
+                    cy.findByLabelText("Category").click();
+
+                    cy.log(
+                      "ensure the token is refreshed after the filter values endpoint is called",
+                    );
+                    cy.wait("@guestTokenProvider");
+
+                    H.popover().within(() => {
+                      cy.findByRole("checkbox", {
+                        name: "Doohickey",
+                      }).click();
+                      cy.button("Add filter").click();
+                    });
+
+                    H.assertTableData({
+                      columns: ["ID", "TITLE", "CATEGORY"],
+                      firstRows: [["2", "Small Marble Shoes", "Doohickey"]],
+                    });
+                  });
+                },
+              );
+            },
+          );
+        });
+      });
+    });
+  });
+
+  describe("question initial-token", () => {
+    describe("happy path", () => {
+      beforeEach(() => {
+        H.prepareGuestEmbedSdkIframeEmbedTest({
+          onPrepare: createStandaloneQuestion,
+        });
+      });
+
+      it("calls guestEmbedProviderUri with { entityType: question, entityId } and loads question (initial token fetch)", () => {
+        cy.get<number>("@questionId").then((questionId) => {
+          signJwt({ questionId, expirationSeconds: 600 }).then((freshToken) => {
+            cy.intercept(PROVIDER_INTERCEPT, (req) => {
+              req.reply({ statusCode: 200, body: { jwt: freshToken } });
+            }).as("guestTokenProvider");
+
+            visitGuestEmbedPage({
+              component: "question",
+              attributes: {
+                "question-id": questionId,
+                "custom-context": "test-custom-context",
               },
-            );
+            });
+
+            cy.wait("@guestTokenProvider").then((interception) => {
+              expect(interception.request.url).to.include("response=json");
+              expect(interception.request.body).to.deep.include({
+                entityType: "question",
+                entityId: questionId,
+                customContext: "test-custom-context",
+              });
+            });
+
+            H.getSimpleEmbedIframeContent()
+              .findByTestId("visualization-root")
+              .should("exist");
           });
         });
       });
     });
 
-    describe("dashboard initial-token", () => {
-      describe("happy path", () => {
-        beforeEach(() => {
-          H.prepareGuestEmbedSdkIframeEmbedTest({
-            onPrepare: createDashboardWithQuestion,
-          });
-        });
-
-        it("calls guestEmbedProviderUri with { entityType, entityId } and loads dashboard (initial token fetch)", () => {
-          cy.get<number>("@dashboardId").then((dashboardId) => {
-            signJwt({ dashboardId, expirationSeconds: 600 }).then(
-              (freshToken) => {
-                cy.intercept(PROVIDER_INTERCEPT, (req) => {
-                  req.reply({ statusCode: 200, body: { jwt: freshToken } });
-                }).as("guestTokenProvider");
-
-                H.visitCustomHtmlPage(`
-                  ${H.getNewEmbedScriptTag({ loadType: "sync" })}
-                  <script>
-                    defineMetabaseConfig({
-                      instanceUrl: "http://localhost:4000",
-                      isGuest: true,
-                      guestEmbedProviderUri: "${PROVIDER_PATH}",
-                    });
-                  </script>
-                  <style>metabase-dashboard { height: 100vh; }</style>
-                  <metabase-dashboard dashboard-id="${dashboardId}" custom-context="test-custom-context" />
-                `);
-
-                cy.wait("@guestTokenProvider").then((interception) => {
-                  expect(interception.request.url).to.include("response=json");
-                  expect(interception.request.body).to.deep.include({
-                    entityType: "dashboard",
-                    entityId: dashboardId,
-                    customContext: "test-custom-context",
-                  });
-                });
-
-                H.getSimpleEmbedIframeContent().should("contain", "Orders");
-              },
-            );
-          });
+    describe("provider error shows error state", () => {
+      beforeEach(() => {
+        H.prepareGuestEmbedSdkIframeEmbedTest({
+          onPrepare: createStandaloneQuestion,
         });
       });
 
-      describe("provider error shows error state", () => {
-        beforeEach(() => {
-          H.prepareGuestEmbedSdkIframeEmbedTest({
-            onPrepare: createDashboardWithQuestion,
-          });
-        });
+      it("shows an error when the provider returns an HTTP error", () => {
+        cy.get<number>("@questionId").then((questionId) => {
+          cy.intercept(PROVIDER_INTERCEPT, (req) => {
+            req.reply({ statusCode: 500 });
+          }).as("guestTokenProvider");
 
-        it("shows an error when the provider returns an HTTP error", () => {
-          cy.get<number>("@dashboardId").then((dashboardId) => {
+          visitGuestEmbedPage({
+            component: "question",
+            attributes: { "question-id": questionId },
+          });
+
+          cy.wait("@guestTokenProvider");
+          H.getSimpleEmbedIframeContent()
+            .findByText(
+              "Failed to fetch JWT token from /api/mock-guest-token-provider, status: 500.",
+            )
+            .should("be.visible");
+        });
+      });
+
+      it("shows an error when the provider returns a wrong response shape", () => {
+        cy.get<number>("@questionId").then((questionId) => {
+          signJwt({ questionId, expirationSeconds: 600 }).then((freshToken) => {
             cy.intercept(PROVIDER_INTERCEPT, (req) => {
-              req.reply({ statusCode: 500 });
+              req.reply({
+                statusCode: 200,
+                body: { token: freshToken },
+              });
             }).as("guestTokenProvider");
 
-            H.visitCustomHtmlPage(`
-              ${H.getNewEmbedScriptTag({ loadType: "sync" })}
-              <script>
-                defineMetabaseConfig({
-                  instanceUrl: "http://localhost:4000",
-                  isGuest: true,
-                  guestEmbedProviderUri: "${PROVIDER_PATH}",
-                });
-              </script>
-              <style>metabase-dashboard { height: 100vh; }</style>
-              <metabase-dashboard dashboard-id="${dashboardId}" />
-            `);
+            visitGuestEmbedPage({
+              component: "question",
+              attributes: { "question-id": questionId },
+            });
 
             cy.wait("@guestTokenProvider");
             H.getSimpleEmbedIframeContent()
               .findByText(
-                "Failed to fetch JWT token from /api/mock-guest-token-provider, status: 500.",
+                /Your JWT server endpoint must return an object with the shape { jwt: string }, but instead received {"token":/,
               )
               .should("be.visible");
           });
         });
-
-        it("shows an error when the provider returns a wrong response shape", () => {
-          cy.get<number>("@dashboardId").then((dashboardId) => {
-            signJwt({ dashboardId, expirationSeconds: 600 }).then(
-              (freshToken) => {
-                cy.intercept(PROVIDER_INTERCEPT, (req) => {
-                  req.reply({
-                    statusCode: 200,
-                    body: { token: freshToken },
-                  });
-                }).as("guestTokenProvider");
-
-                H.visitCustomHtmlPage(`
-                  ${H.getNewEmbedScriptTag({ loadType: "sync" })}
-                  <script>
-                    defineMetabaseConfig({
-                      instanceUrl: "http://localhost:4000",
-                      isGuest: true,
-                      guestEmbedProviderUri: "${PROVIDER_PATH}",
-                    });
-                  </script>
-                  <style>metabase-dashboard { height: 100vh; }</style>
-                  <metabase-dashboard dashboard-id="${dashboardId}" />
-                `);
-
-                cy.wait("@guestTokenProvider");
-                H.getSimpleEmbedIframeContent()
-                  .findByText(
-                    /Your JWT server endpoint must return an object with the shape { jwt: string }, but instead received {"token":/,
-                  )
-                  .should("be.visible");
-              },
-            );
-          });
-        });
       });
     });
-
-    describe("question refresh-only", () => {
-      describe("happy path", () => {
-        beforeEach(() => {
-          H.prepareGuestEmbedSdkIframeEmbedTest({
-            onPrepare: createStandaloneQuestion,
-          });
-        });
-
-        it("calls guestEmbedProviderUri with { entityType: question, entityId } and loads question after token refresh", () => {
-          cy.get<number>("@questionId").then((questionId) => {
-            signJwt({ questionId, expirationSeconds: -60 }).then(
-              (expiredToken) => {
-                signJwt({ questionId, expirationSeconds: 600 }).then(
-                  (freshToken) => {
-                    cy.intercept(PROVIDER_INTERCEPT, (req) => {
-                      req.reply({ statusCode: 200, body: { jwt: freshToken } });
-                    }).as("guestTokenProvider");
-
-                    H.visitCustomHtmlPage(`
-                      ${H.getNewEmbedScriptTag({ loadType: "sync" })}
-                      <script>
-                        defineMetabaseConfig({
-                          instanceUrl: "http://localhost:4000",
-                          isGuest: true,
-                          guestEmbedProviderUri: "${PROVIDER_PATH}",
-                        });
-                      </script>
-                      <style>metabase-question { height: 100vh; }</style>
-                      <metabase-question token="${expiredToken}" custom-context="test-custom-context" />
-                    `);
-
-                    cy.wait("@guestTokenProvider").then((interception) => {
-                      expect(interception.request.body).to.deep.include({
-                        entityType: "question",
-                        entityId: questionId,
-                        customContext: "test-custom-context",
-                      });
-                    });
-
-                    H.getSimpleEmbedIframeContent()
-                      .findByTestId("visualization-root")
-                      .should("exist");
-                  },
-                );
-              },
-            );
-          });
-        });
-      });
-
-      describe("provider error shows error state", () => {
-        beforeEach(() => {
-          H.prepareGuestEmbedSdkIframeEmbedTest({
-            onPrepare: createStandaloneQuestion,
-          });
-        });
-
-        it("shows an error when the provider returns an HTTP error", () => {
-          cy.get<number>("@questionId").then((questionId) => {
-            signJwt({ questionId, expirationSeconds: -60 }).then(
-              (expiredToken) => {
-                cy.intercept(PROVIDER_INTERCEPT, (req) => {
-                  req.reply({ statusCode: 500 });
-                }).as("guestTokenProvider");
-
-                H.visitCustomHtmlPage(`
-                  ${H.getNewEmbedScriptTag({ loadType: "sync" })}
-                  <script>
-                    defineMetabaseConfig({
-                      instanceUrl: "http://localhost:4000",
-                      isGuest: true,
-                      guestEmbedProviderUri: "${PROVIDER_PATH}",
-                    });
-                  </script>
-                  <style>metabase-question { height: 100vh; }</style>
-                  <metabase-question token="${expiredToken}" />
-                `);
-
-                cy.wait("@guestTokenProvider");
-                H.getSimpleEmbedIframeContent()
-                  .findByText(
-                    "Failed to fetch JWT token from /api/mock-guest-token-provider, status: 500.",
-                  )
-                  .should("be.visible");
-              },
-            );
-          });
-        });
-
-        it("shows an error when the provider returns a wrong response shape", () => {
-          cy.get<number>("@questionId").then((questionId) => {
-            signJwt({ questionId, expirationSeconds: -60 }).then(
-              (expiredToken) => {
-                signJwt({ questionId, expirationSeconds: 600 }).then(
-                  (freshToken) => {
-                    cy.intercept(PROVIDER_INTERCEPT, (req) => {
-                      req.reply({
-                        statusCode: 200,
-                        body: { token: freshToken },
-                      });
-                    }).as("guestTokenProvider");
-
-                    H.visitCustomHtmlPage(`
-                      ${H.getNewEmbedScriptTag({ loadType: "sync" })}
-                      <script>
-                        defineMetabaseConfig({
-                          instanceUrl: "http://localhost:4000",
-                          isGuest: true,
-                          guestEmbedProviderUri: "${PROVIDER_PATH}",
-                        });
-                      </script>
-                      <style>metabase-question { height: 100vh; }</style>
-                      <metabase-question token="${expiredToken}" />
-                    `);
-
-                    cy.wait("@guestTokenProvider");
-                    H.getSimpleEmbedIframeContent()
-                      .findByText(
-                        /Your JWT server endpoint must return an object with the shape { jwt: string }, but instead received {"token":/,
-                      )
-                      .should("be.visible");
-                  },
-                );
-              },
-            );
-          });
-        });
-      });
-
-      describe("number filter interaction after token refresh", () => {
-        beforeEach(() => {
-          H.prepareGuestEmbedSdkIframeEmbedTest({
-            onPrepare: createQuestionWithPriceFilter,
-          });
-        });
-
-        it("applying a number filter after token refresh returns filtered results", () => {
-          cy.get<number>("@questionId").then((questionId) => {
-            signJwt({ questionId, expirationSeconds: 5 }).then(
-              (shortLivedToken) => {
-                signJwt({ questionId, expirationSeconds: 600 }).then(
-                  (freshToken) => {
-                    cy.intercept(PROVIDER_INTERCEPT, (req) => {
-                      req.reply({ statusCode: 200, body: { jwt: freshToken } });
-                    }).as("guestTokenProvider");
-
-                    H.visitCustomHtmlPage(`
-                      ${H.getNewEmbedScriptTag({ loadType: "sync" })}
-                      <script>
-                        defineMetabaseConfig({
-                          instanceUrl: "http://localhost:4000",
-                          isGuest: true,
-                          guestEmbedProviderUri: "${PROVIDER_PATH}",
-                        });
-                      </script>
-                      <style>metabase-question { height: 100vh; }</style>
-                      <metabase-question token="${shortLivedToken}" />
-                    `);
-
-                    H.getSimpleEmbedIframeContent().within(() => {
-                      cy.findByText("Products with price filter").should(
-                        "be.visible",
-                      );
-                    });
-
-                    cy.get("iframe[data-metabase-embed]")
-                      .its("0.contentWindow")
-                      .should("exist")
-                      .then((contentWindow) => {
-                        (
-                          contentWindow as any
-                        ).FORCE_REFRESH_GUEST_EMBED_TOKEN_IN_CYPRESS = true;
-                      });
-
-                    H.getSimpleEmbedIframeContent().within(() => {
-                      cy.findByLabelText("Price greater than").click();
-                      H.popover().within(() => {
-                        cy.findByPlaceholderText("Enter a number").type(
-                          "50{enter}",
-                        );
-                      });
-                      cy.log(
-                        "ensure the token is refreshed after applying a filter value",
-                      );
-                      cy.wait("@guestTokenProvider");
-
-                      H.assertTableData({
-                        columns: ["ID", "TITLE", "PRICE"],
-                        firstRows: [["2", "Small Marble Shoes", "70.08"]],
-                      });
-                    });
-                  },
-                );
-              },
-            );
-          });
-        });
-      });
-
-      describe("category filter interaction after token refresh", () => {
-        beforeEach(() => {
-          H.prepareGuestEmbedSdkIframeEmbedTest({
-            onPrepare: createQuestionWithCategoryFilter,
-          });
-        });
-
-        it("applying a category filter after token refresh returns filtered results", () => {
-          cy.get<number>("@questionId").then((questionId) => {
-            signJwt({ questionId, expirationSeconds: 5 }).then(
-              (shortLivedToken) => {
-                signJwt({ questionId, expirationSeconds: 600 }).then(
-                  (freshToken) => {
-                    cy.intercept(PROVIDER_INTERCEPT, (req) => {
-                      req.reply({ statusCode: 200, body: { jwt: freshToken } });
-                    }).as("guestTokenProvider");
-
-                    H.visitCustomHtmlPage(`
-                      ${H.getNewEmbedScriptTag({ loadType: "sync" })}
-                      <script>
-                        defineMetabaseConfig({
-                          instanceUrl: "http://localhost:4000",
-                          isGuest: true,
-                          guestEmbedProviderUri: "${PROVIDER_PATH}",
-                        });
-                      </script>
-                      <style>metabase-question { height: 100vh; }</style>
-                      <metabase-question token="${shortLivedToken}" />
-                    `);
-
-                    H.getSimpleEmbedIframeContent().within(() => {
-                      cy.findByText("Products with category filter").should(
-                        "be.visible",
-                      );
-                    });
-
-                    cy.get("iframe[data-metabase-embed]")
-                      .its("0.contentWindow")
-                      .should("exist")
-                      .then((contentWindow) => {
-                        (
-                          contentWindow as any
-                        ).FORCE_REFRESH_GUEST_EMBED_TOKEN_IN_CYPRESS = true;
-                      });
-
-                    H.getSimpleEmbedIframeContent().within(() => {
-                      cy.findByLabelText("Category").click();
-
-                      cy.log(
-                        "ensure the token is refreshed after the filter values endpoint is called",
-                      );
-                      cy.wait("@guestTokenProvider");
-
-                      H.popover().within(() => {
-                        cy.findByRole("checkbox", {
-                          name: "Doohickey",
-                        }).click();
-                        cy.button("Add filter").click();
-                      });
-
-                      H.assertTableData({
-                        columns: ["ID", "TITLE", "CATEGORY"],
-                        firstRows: [["2", "Small Marble Shoes", "Doohickey"]],
-                      });
-                    });
-                  },
-                );
-              },
-            );
-          });
-        });
-      });
-    });
-
-    describe("question initial-token", () => {
-      describe("happy path", () => {
-        beforeEach(() => {
-          H.prepareGuestEmbedSdkIframeEmbedTest({
-            onPrepare: createStandaloneQuestion,
-          });
-        });
-
-        it("calls guestEmbedProviderUri with { entityType: question, entityId } and loads question (initial token fetch)", () => {
-          cy.get<number>("@questionId").then((questionId) => {
-            signJwt({ questionId, expirationSeconds: 600 }).then(
-              (freshToken) => {
-                cy.intercept(PROVIDER_INTERCEPT, (req) => {
-                  req.reply({ statusCode: 200, body: { jwt: freshToken } });
-                }).as("guestTokenProvider");
-
-                H.visitCustomHtmlPage(`
-                  ${H.getNewEmbedScriptTag({ loadType: "sync" })}
-                  <script>
-                    defineMetabaseConfig({
-                      instanceUrl: "http://localhost:4000",
-                      isGuest: true,
-                      guestEmbedProviderUri: "${PROVIDER_PATH}",
-                    });
-                  </script>
-                  <style>metabase-question { height: 100vh; }</style>
-                  <metabase-question question-id="${questionId}" custom-context="test-custom-context" />
-                `);
-
-                cy.wait("@guestTokenProvider").then((interception) => {
-                  expect(interception.request.url).to.include("response=json");
-                  expect(interception.request.body).to.deep.include({
-                    entityType: "question",
-                    entityId: questionId,
-                    customContext: "test-custom-context",
-                  });
-                });
-
-                H.getSimpleEmbedIframeContent()
-                  .findByTestId("visualization-root")
-                  .should("exist");
-              },
-            );
-          });
-        });
-      });
-
-      describe("provider error shows error state", () => {
-        beforeEach(() => {
-          H.prepareGuestEmbedSdkIframeEmbedTest({
-            onPrepare: createStandaloneQuestion,
-          });
-        });
-
-        it("shows an error when the provider returns an HTTP error", () => {
-          cy.get<number>("@questionId").then((questionId) => {
-            cy.intercept(PROVIDER_INTERCEPT, (req) => {
-              req.reply({ statusCode: 500 });
-            }).as("guestTokenProvider");
-
-            H.visitCustomHtmlPage(`
-              ${H.getNewEmbedScriptTag({ loadType: "sync" })}
-              <script>
-                defineMetabaseConfig({
-                  instanceUrl: "http://localhost:4000",
-                  isGuest: true,
-                  guestEmbedProviderUri: "${PROVIDER_PATH}",
-                });
-              </script>
-              <style>metabase-question { height: 100vh; }</style>
-              <metabase-question question-id="${questionId}" />
-            `);
-
-            cy.wait("@guestTokenProvider");
-            H.getSimpleEmbedIframeContent()
-              .findByText(
-                "Failed to fetch JWT token from /api/mock-guest-token-provider, status: 500.",
-              )
-              .should("be.visible");
-          });
-        });
-
-        it("shows an error when the provider returns a wrong response shape", () => {
-          cy.get<number>("@questionId").then((questionId) => {
-            signJwt({ questionId, expirationSeconds: 600 }).then(
-              (freshToken) => {
-                cy.intercept(PROVIDER_INTERCEPT, (req) => {
-                  req.reply({
-                    statusCode: 200,
-                    body: { token: freshToken },
-                  });
-                }).as("guestTokenProvider");
-
-                H.visitCustomHtmlPage(`
-                  ${H.getNewEmbedScriptTag({ loadType: "sync" })}
-                  <script>
-                    defineMetabaseConfig({
-                      instanceUrl: "http://localhost:4000",
-                      isGuest: true,
-                      guestEmbedProviderUri: "${PROVIDER_PATH}",
-                    });
-                  </script>
-                  <style>metabase-question { height: 100vh; }</style>
-                  <metabase-question question-id="${questionId}" />
-                `);
-
-                cy.wait("@guestTokenProvider");
-                H.getSimpleEmbedIframeContent()
-                  .findByText(
-                    /Your JWT server endpoint must return an object with the shape { jwt: string }, but instead received {"token":/,
-                  )
-                  .should("be.visible");
-              },
-            );
-          });
-        });
-      });
-    });
-  },
-);
+  });
+});

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/guest-token-refresh.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/guest-token-refresh.cy.spec.ts
@@ -37,37 +37,6 @@ function signJwt({
     .then((token) => token);
 }
 
-const COMPONENT_TAGS = {
-  dashboard: "metabase-dashboard",
-  question: "metabase-question",
-} as const;
-
-function visitGuestEmbedPage({
-  component,
-  attributes = {},
-}: {
-  component: "dashboard" | "question";
-  attributes?: Record<string, string | number>;
-}) {
-  const tagName = COMPONENT_TAGS[component];
-  const attrString = Object.entries(attributes)
-    .map(([k, v]) => `${k}="${v}"`)
-    .join(" ");
-
-  H.visitCustomHtmlPage(`
-    ${H.getNewEmbedScriptTag({ loadType: "sync" })}
-    <script>
-      defineMetabaseConfig({
-        instanceUrl: "http://localhost:4000",
-        isGuest: true,
-        guestEmbedProviderUri: "${PROVIDER_PATH}",
-      });
-    </script>
-    <style>${tagName} { height: 100vh; }</style>
-    <${tagName} ${attrString} />
-  `);
-}
-
 const PRICE_DASHBOARD_PARAMETER = {
   name: "Price greater than",
   slug: "price",
@@ -86,30 +55,19 @@ const CATEGORY_DASHBOARD_PARAMETER = {
 
 describe("scenarios > embedding > sdk iframe embedding > guest token refresh", () => {
   function createDashboardWithQuestion() {
-    createQuestion({
-      name: "Orders",
-      query: { "source-table": ORDERS_ID },
-    }).then(({ body: question }) => {
-      cy.request("POST", "/api/dashboard", {
+    H.createQuestionAndDashboard({
+      questionDetails: {
+        name: "Orders",
+        query: { "source-table": ORDERS_ID },
+      },
+      dashboardDetails: {
         name: "Guest Token Refresh Dashboard",
-      }).then(({ body: dashboard }) => {
-        cy.wrap(dashboard.id).as("dashboardId");
-
-        cy.request("PUT", `/api/dashboard/${dashboard.id}`, {
-          enable_embedding: true,
-          embedding_type: "guest-embed",
-          dashcards: [
-            {
-              id: -1,
-              card_id: question.id,
-              row: 0,
-              col: 0,
-              size_x: 11,
-              size_y: 6,
-            },
-          ],
-        });
-      });
+        enable_embedding: true,
+        embedding_type: "guest-embed",
+      },
+      cardDetails: { row: 0, col: 0, size_x: 11, size_y: 6 },
+    }).then(({ body: { dashboard_id } }) => {
+      cy.wrap(dashboard_id).as("dashboardId");
     });
   }
 
@@ -297,12 +255,20 @@ describe("scenarios > embedding > sdk iframe embedding > guest token refresh", (
                     req.reply({ statusCode: 200, body: { jwt: freshToken } });
                   }).as("guestTokenProvider");
 
-                  visitGuestEmbedPage({
-                    component: "dashboard",
-                    attributes: {
-                      token: expiredToken,
-                      "custom-context": "test-custom-context",
+                  H.loadSdkIframeEmbedTestPage({
+                    metabaseConfig: {
+                      isGuest: true,
+                      guestEmbedProviderUri: PROVIDER_PATH,
                     },
+                    elements: [
+                      {
+                        component: "metabase-dashboard",
+                        attributes: {
+                          token: expiredToken,
+                          "custom-context": "test-custom-context",
+                        },
+                      },
+                    ],
                   });
 
                   cy.wait("@guestTokenProvider").then((interception) => {
@@ -337,9 +303,17 @@ describe("scenarios > embedding > sdk iframe embedding > guest token refresh", (
                 req.reply({ statusCode: 500 });
               }).as("guestTokenProvider");
 
-              visitGuestEmbedPage({
-                component: "dashboard",
-                attributes: { token: expiredToken },
+              H.loadSdkIframeEmbedTestPage({
+                metabaseConfig: {
+                  isGuest: true,
+                  guestEmbedProviderUri: PROVIDER_PATH,
+                },
+                elements: [
+                  {
+                    component: "metabase-dashboard",
+                    attributes: { token: expiredToken },
+                  },
+                ],
               });
 
               cy.wait("@guestTokenProvider");
@@ -366,9 +340,17 @@ describe("scenarios > embedding > sdk iframe embedding > guest token refresh", (
                     });
                   }).as("guestTokenProvider");
 
-                  visitGuestEmbedPage({
-                    component: "dashboard",
-                    attributes: { token: expiredToken },
+                  H.loadSdkIframeEmbedTestPage({
+                    metabaseConfig: {
+                      isGuest: true,
+                      guestEmbedProviderUri: PROVIDER_PATH,
+                    },
+                    elements: [
+                      {
+                        component: "metabase-dashboard",
+                        attributes: { token: expiredToken },
+                      },
+                    ],
                   });
 
                   cy.wait("@guestTokenProvider");
@@ -402,9 +384,17 @@ describe("scenarios > embedding > sdk iframe embedding > guest token refresh", (
                     req.reply({ statusCode: 200, body: { jwt: freshToken } });
                   }).as("guestTokenProvider");
 
-                  visitGuestEmbedPage({
-                    component: "dashboard",
-                    attributes: { token: shortLivedToken },
+                  H.loadSdkIframeEmbedTestPage({
+                    metabaseConfig: {
+                      isGuest: true,
+                      guestEmbedProviderUri: PROVIDER_PATH,
+                    },
+                    elements: [
+                      {
+                        component: "metabase-dashboard",
+                        attributes: { token: shortLivedToken },
+                      },
+                    ],
                   });
 
                   H.getSimpleEmbedIframeContent().within(() => {
@@ -463,9 +453,17 @@ describe("scenarios > embedding > sdk iframe embedding > guest token refresh", (
                     req.reply({ statusCode: 200, body: { jwt: freshToken } });
                   }).as("guestTokenProvider");
 
-                  visitGuestEmbedPage({
-                    component: "dashboard",
-                    attributes: { token: shortLivedToken },
+                  H.loadSdkIframeEmbedTestPage({
+                    metabaseConfig: {
+                      isGuest: true,
+                      guestEmbedProviderUri: PROVIDER_PATH,
+                    },
+                    elements: [
+                      {
+                        component: "metabase-dashboard",
+                        attributes: { token: shortLivedToken },
+                      },
+                    ],
                   });
 
                   H.getSimpleEmbedIframeContent().within(() => {
@@ -525,12 +523,20 @@ describe("scenarios > embedding > sdk iframe embedding > guest token refresh", (
                 req.reply({ statusCode: 200, body: { jwt: freshToken } });
               }).as("guestTokenProvider");
 
-              visitGuestEmbedPage({
-                component: "dashboard",
-                attributes: {
-                  "dashboard-id": dashboardId,
-                  "custom-context": "test-custom-context",
+              H.loadSdkIframeEmbedTestPage({
+                metabaseConfig: {
+                  isGuest: true,
+                  guestEmbedProviderUri: PROVIDER_PATH,
                 },
+                elements: [
+                  {
+                    component: "metabase-dashboard",
+                    attributes: {
+                      "dashboard-id": dashboardId,
+                      "custom-context": "test-custom-context",
+                    },
+                  },
+                ],
               });
 
               cy.wait("@guestTokenProvider").then((interception) => {
@@ -562,9 +568,17 @@ describe("scenarios > embedding > sdk iframe embedding > guest token refresh", (
             req.reply({ statusCode: 500 });
           }).as("guestTokenProvider");
 
-          visitGuestEmbedPage({
-            component: "dashboard",
-            attributes: { "dashboard-id": dashboardId },
+          H.loadSdkIframeEmbedTestPage({
+            metabaseConfig: {
+              isGuest: true,
+              guestEmbedProviderUri: PROVIDER_PATH,
+            },
+            elements: [
+              {
+                component: "metabase-dashboard",
+                attributes: { "dashboard-id": dashboardId },
+              },
+            ],
           });
 
           cy.wait("@guestTokenProvider");
@@ -587,9 +601,17 @@ describe("scenarios > embedding > sdk iframe embedding > guest token refresh", (
                 });
               }).as("guestTokenProvider");
 
-              visitGuestEmbedPage({
-                component: "dashboard",
-                attributes: { "dashboard-id": dashboardId },
+              H.loadSdkIframeEmbedTestPage({
+                metabaseConfig: {
+                  isGuest: true,
+                  guestEmbedProviderUri: PROVIDER_PATH,
+                },
+                elements: [
+                  {
+                    component: "metabase-dashboard",
+                    attributes: { "dashboard-id": dashboardId },
+                  },
+                ],
               });
 
               cy.wait("@guestTokenProvider");
@@ -623,12 +645,20 @@ describe("scenarios > embedding > sdk iframe embedding > guest token refresh", (
                     req.reply({ statusCode: 200, body: { jwt: freshToken } });
                   }).as("guestTokenProvider");
 
-                  visitGuestEmbedPage({
-                    component: "question",
-                    attributes: {
-                      token: expiredToken,
-                      "custom-context": "test-custom-context",
+                  H.loadSdkIframeEmbedTestPage({
+                    metabaseConfig: {
+                      isGuest: true,
+                      guestEmbedProviderUri: PROVIDER_PATH,
                     },
+                    elements: [
+                      {
+                        component: "metabase-question",
+                        attributes: {
+                          token: expiredToken,
+                          "custom-context": "test-custom-context",
+                        },
+                      },
+                    ],
                   });
 
                   cy.wait("@guestTokenProvider").then((interception) => {
@@ -665,9 +695,17 @@ describe("scenarios > embedding > sdk iframe embedding > guest token refresh", (
                 req.reply({ statusCode: 500 });
               }).as("guestTokenProvider");
 
-              visitGuestEmbedPage({
-                component: "question",
-                attributes: { token: expiredToken },
+              H.loadSdkIframeEmbedTestPage({
+                metabaseConfig: {
+                  isGuest: true,
+                  guestEmbedProviderUri: PROVIDER_PATH,
+                },
+                elements: [
+                  {
+                    component: "metabase-question",
+                    attributes: { token: expiredToken },
+                  },
+                ],
               });
 
               cy.wait("@guestTokenProvider");
@@ -694,9 +732,17 @@ describe("scenarios > embedding > sdk iframe embedding > guest token refresh", (
                     });
                   }).as("guestTokenProvider");
 
-                  visitGuestEmbedPage({
-                    component: "question",
-                    attributes: { token: expiredToken },
+                  H.loadSdkIframeEmbedTestPage({
+                    metabaseConfig: {
+                      isGuest: true,
+                      guestEmbedProviderUri: PROVIDER_PATH,
+                    },
+                    elements: [
+                      {
+                        component: "metabase-question",
+                        attributes: { token: expiredToken },
+                      },
+                    ],
                   });
 
                   cy.wait("@guestTokenProvider");
@@ -730,9 +776,17 @@ describe("scenarios > embedding > sdk iframe embedding > guest token refresh", (
                     req.reply({ statusCode: 200, body: { jwt: freshToken } });
                   }).as("guestTokenProvider");
 
-                  visitGuestEmbedPage({
-                    component: "question",
-                    attributes: { token: shortLivedToken },
+                  H.loadSdkIframeEmbedTestPage({
+                    metabaseConfig: {
+                      isGuest: true,
+                      guestEmbedProviderUri: PROVIDER_PATH,
+                    },
+                    elements: [
+                      {
+                        component: "metabase-question",
+                        attributes: { token: shortLivedToken },
+                      },
+                    ],
                   });
 
                   H.getSimpleEmbedIframeContent().within(() => {
@@ -791,9 +845,17 @@ describe("scenarios > embedding > sdk iframe embedding > guest token refresh", (
                     req.reply({ statusCode: 200, body: { jwt: freshToken } });
                   }).as("guestTokenProvider");
 
-                  visitGuestEmbedPage({
-                    component: "question",
-                    attributes: { token: shortLivedToken },
+                  H.loadSdkIframeEmbedTestPage({
+                    metabaseConfig: {
+                      isGuest: true,
+                      guestEmbedProviderUri: PROVIDER_PATH,
+                    },
+                    elements: [
+                      {
+                        component: "metabase-question",
+                        attributes: { token: shortLivedToken },
+                      },
+                    ],
                   });
 
                   H.getSimpleEmbedIframeContent().within(() => {
@@ -854,12 +916,20 @@ describe("scenarios > embedding > sdk iframe embedding > guest token refresh", (
               req.reply({ statusCode: 200, body: { jwt: freshToken } });
             }).as("guestTokenProvider");
 
-            visitGuestEmbedPage({
-              component: "question",
-              attributes: {
-                "question-id": questionId,
-                "custom-context": "test-custom-context",
+            H.loadSdkIframeEmbedTestPage({
+              metabaseConfig: {
+                isGuest: true,
+                guestEmbedProviderUri: PROVIDER_PATH,
               },
+              elements: [
+                {
+                  component: "metabase-question",
+                  attributes: {
+                    "question-id": questionId,
+                    "custom-context": "test-custom-context",
+                  },
+                },
+              ],
             });
 
             cy.wait("@guestTokenProvider").then((interception) => {
@@ -892,9 +962,17 @@ describe("scenarios > embedding > sdk iframe embedding > guest token refresh", (
             req.reply({ statusCode: 500 });
           }).as("guestTokenProvider");
 
-          visitGuestEmbedPage({
-            component: "question",
-            attributes: { "question-id": questionId },
+          H.loadSdkIframeEmbedTestPage({
+            metabaseConfig: {
+              isGuest: true,
+              guestEmbedProviderUri: PROVIDER_PATH,
+            },
+            elements: [
+              {
+                component: "metabase-question",
+                attributes: { "question-id": questionId },
+              },
+            ],
           });
 
           cy.wait("@guestTokenProvider");
@@ -916,9 +994,17 @@ describe("scenarios > embedding > sdk iframe embedding > guest token refresh", (
               });
             }).as("guestTokenProvider");
 
-            visitGuestEmbedPage({
-              component: "question",
-              attributes: { "question-id": questionId },
+            H.loadSdkIframeEmbedTestPage({
+              metabaseConfig: {
+                isGuest: true,
+                guestEmbedProviderUri: PROVIDER_PATH,
+              },
+              elements: [
+                {
+                  component: "metabase-question",
+                  attributes: { "question-id": questionId },
+                },
+              ],
             });
 
             cy.wait("@guestTokenProvider");

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/guest-token-refresh.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/guest-token-refresh.cy.spec.ts
@@ -280,6 +280,7 @@ describe(
                           instanceUrl: "http://localhost:4000",
                           isGuest: true,
                           guestEmbedProviderUri: "${PROVIDER_PATH}",
+                          customContext: "test-custom-context",
                         });
                       </script>
                       <style>metabase-dashboard { height: 100vh; }</style>
@@ -290,6 +291,7 @@ describe(
                       expect(interception.request.body).to.deep.include({
                         entityType: "dashboard",
                         entityId: dashboardId,
+                        customContext: "test-custom-context",
                       });
                     });
 
@@ -309,7 +311,7 @@ describe(
           });
         });
 
-        it("shows an error in the embed when the provider returns an HTTP error", () => {
+        it("shows an error when the provider returns an HTTP error", () => {
           cy.get<number>("@dashboardId").then((dashboardId) => {
             signJwt({ dashboardId, expirationSeconds: -60 }).then(
               (expiredToken) => {
@@ -548,6 +550,7 @@ describe(
                       instanceUrl: "http://localhost:4000",
                       isGuest: true,
                       guestEmbedProviderUri: "${PROVIDER_PATH}",
+                      customContext: "test-custom-context",
                     });
                   </script>
                   <style>metabase-dashboard { height: 100vh; }</style>
@@ -559,6 +562,7 @@ describe(
                   expect(interception.request.body).to.deep.include({
                     entityType: "dashboard",
                     entityId: dashboardId,
+                    customContext: "test-custom-context",
                   });
                 });
 
@@ -576,7 +580,7 @@ describe(
           });
         });
 
-        it("shows an error when the initial token fetch fails", () => {
+        it("shows an error when the provider returns an HTTP error", () => {
           cy.get<number>("@dashboardId").then((dashboardId) => {
             cy.intercept(PROVIDER_INTERCEPT, (req) => {
               req.reply({ statusCode: 500 });
@@ -601,6 +605,41 @@ describe(
                 "Failed to fetch JWT token from /api/mock-guest-token-provider, status: 500.",
               )
               .should("be.visible");
+          });
+        });
+
+        it("shows an error when the provider returns a wrong response shape", () => {
+          cy.get<number>("@dashboardId").then((dashboardId) => {
+            signJwt({ dashboardId, expirationSeconds: 600 }).then(
+              (freshToken) => {
+                cy.intercept(PROVIDER_INTERCEPT, (req) => {
+                  req.reply({
+                    statusCode: 200,
+                    body: { token: freshToken },
+                  });
+                }).as("guestTokenProvider");
+
+                H.visitCustomHtmlPage(`
+                  ${H.getNewEmbedScriptTag({ loadType: "sync" })}
+                  <script>
+                    defineMetabaseConfig({
+                      instanceUrl: "http://localhost:4000",
+                      isGuest: true,
+                      guestEmbedProviderUri: "${PROVIDER_PATH}",
+                    });
+                  </script>
+                  <style>metabase-dashboard { height: 100vh; }</style>
+                  <metabase-dashboard dashboard-id="${dashboardId}" />
+                `);
+
+                cy.wait("@guestTokenProvider");
+                H.getSimpleEmbedIframeContent()
+                  .findByText(
+                    /Your JWT server endpoint must return an object with the shape { jwt: string }, but instead received {"token":/,
+                  )
+                  .should("be.visible");
+              },
+            );
           });
         });
       });
@@ -631,6 +670,7 @@ describe(
                           instanceUrl: "http://localhost:4000",
                           isGuest: true,
                           guestEmbedProviderUri: "${PROVIDER_PATH}",
+                          customContext: "test-custom-context",
                         });
                       </script>
                       <style>metabase-question { height: 100vh; }</style>
@@ -643,6 +683,7 @@ describe(
                       expect(interception.request.body).to.deep.include({
                         entityType: "question",
                         entityId: questionId,
+                        customContext: "test-custom-context",
                       });
                     });
 
@@ -664,7 +705,7 @@ describe(
           });
         });
 
-        it("shows an error in the embed when the provider returns an HTTP error", () => {
+        it("shows an error when the provider returns an HTTP error", () => {
           cy.get<number>("@questionId").then((questionId) => {
             signJwt({ questionId, expirationSeconds: -60 }).then(
               (expiredToken) => {
@@ -903,6 +944,7 @@ describe(
                       instanceUrl: "http://localhost:4000",
                       isGuest: true,
                       guestEmbedProviderUri: "${PROVIDER_PATH}",
+                      customContext: "test-custom-context",
                     });
                   </script>
                   <style>metabase-question { height: 100vh; }</style>
@@ -914,6 +956,7 @@ describe(
                   expect(interception.request.body).to.deep.include({
                     entityType: "question",
                     entityId: questionId,
+                    customContext: "test-custom-context",
                   });
                 });
 
@@ -933,7 +976,7 @@ describe(
           });
         });
 
-        it("shows an error when the initial token fetch fails", () => {
+        it("shows an error when the provider returns an HTTP error", () => {
           cy.get<number>("@questionId").then((questionId) => {
             cy.intercept(PROVIDER_INTERCEPT, (req) => {
               req.reply({ statusCode: 500 });
@@ -958,6 +1001,41 @@ describe(
                 "Failed to fetch JWT token from /api/mock-guest-token-provider, status: 500.",
               )
               .should("be.visible");
+          });
+        });
+
+        it("shows an error when the provider returns a wrong response shape", () => {
+          cy.get<number>("@questionId").then((questionId) => {
+            signJwt({ questionId, expirationSeconds: 600 }).then(
+              (freshToken) => {
+                cy.intercept(PROVIDER_INTERCEPT, (req) => {
+                  req.reply({
+                    statusCode: 200,
+                    body: { token: freshToken },
+                  });
+                }).as("guestTokenProvider");
+
+                H.visitCustomHtmlPage(`
+                  ${H.getNewEmbedScriptTag({ loadType: "sync" })}
+                  <script>
+                    defineMetabaseConfig({
+                      instanceUrl: "http://localhost:4000",
+                      isGuest: true,
+                      guestEmbedProviderUri: "${PROVIDER_PATH}",
+                    });
+                  </script>
+                  <style>metabase-question { height: 100vh; }</style>
+                  <metabase-question question-id="${questionId}" />
+                `);
+
+                cy.wait("@guestTokenProvider");
+                H.getSimpleEmbedIframeContent()
+                  .findByText(
+                    /Your JWT server endpoint must return an object with the shape { jwt: string }, but instead received {"token":/,
+                  )
+                  .should("be.visible");
+              },
+            );
           });
         });
       });

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/guest-token-refresh.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/guest-token-refresh.cy.spec.ts
@@ -280,11 +280,10 @@ describe(
                           instanceUrl: "http://localhost:4000",
                           isGuest: true,
                           guestEmbedProviderUri: "${PROVIDER_PATH}",
-                          customContext: "test-custom-context",
                         });
                       </script>
                       <style>metabase-dashboard { height: 100vh; }</style>
-                      <metabase-dashboard token="${expiredToken}" />
+                      <metabase-dashboard token="${expiredToken}" custom-context="test-custom-context" />
                     `);
 
                     cy.wait("@guestTokenProvider").then((interception) => {
@@ -329,9 +328,7 @@ describe(
                     });
                   </script>
                   <style>metabase-dashboard { height: 100vh; }</style>
-                  <metabase-dashboard
-                    token="${expiredToken}"
-                  />
+                  <metabase-dashboard token="${expiredToken}" />
                 `);
 
                 cy.wait("@guestTokenProvider");
@@ -550,11 +547,10 @@ describe(
                       instanceUrl: "http://localhost:4000",
                       isGuest: true,
                       guestEmbedProviderUri: "${PROVIDER_PATH}",
-                      customContext: "test-custom-context",
                     });
                   </script>
                   <style>metabase-dashboard { height: 100vh; }</style>
-                  <metabase-dashboard dashboard-id="${dashboardId}" />
+                  <metabase-dashboard dashboard-id="${dashboardId}" custom-context="test-custom-context" />
                 `);
 
                 cy.wait("@guestTokenProvider").then((interception) => {
@@ -670,13 +666,10 @@ describe(
                           instanceUrl: "http://localhost:4000",
                           isGuest: true,
                           guestEmbedProviderUri: "${PROVIDER_PATH}",
-                          customContext: "test-custom-context",
                         });
                       </script>
                       <style>metabase-question { height: 100vh; }</style>
-                      <metabase-question
-                        token="${expiredToken}"
-                      />
+                      <metabase-question token="${expiredToken}" custom-context="test-custom-context" />
                     `);
 
                     cy.wait("@guestTokenProvider").then((interception) => {
@@ -944,11 +937,10 @@ describe(
                       instanceUrl: "http://localhost:4000",
                       isGuest: true,
                       guestEmbedProviderUri: "${PROVIDER_PATH}",
-                      customContext: "test-custom-context",
                     });
                   </script>
                   <style>metabase-question { height: 100vh; }</style>
-                  <metabase-question question-id="${questionId}" />
+                  <metabase-question question-id="${questionId}" custom-context="test-custom-context" />
                 `);
 
                 cy.wait("@guestTokenProvider").then((interception) => {

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/context/SdkQuestionProvider.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/context/SdkQuestionProvider.tsx
@@ -4,6 +4,7 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useState,
 } from "react";
 import { t } from "ttag";
 
@@ -79,7 +80,7 @@ export const SdkQuestionProvider = ({
   const isGuestEmbed = useSdkSelector(getIsGuestEmbed);
   const dispatch = useSdkDispatch();
   const navigation = useSdkInternalNavigationOptional();
-
+  const [isFirstRender, setIsFirstRender] = useState(true);
   const { rawToken: tokenFromStore, error: tokenFetchError } =
     useSdkSelector(getSessionTokenState);
 
@@ -90,6 +91,10 @@ export const SdkQuestionProvider = ({
     }
   }, [rawToken, isGuestEmbed, dispatch]);
 
+  useEffect(() => {
+    setIsFirstRender(false);
+  }, []);
+
   const {
     resourceId: questionId,
     token,
@@ -97,7 +102,9 @@ export const SdkQuestionProvider = ({
   } = useExtractResourceIdFromJwtToken({
     isGuestEmbed,
     resourceId: rawQuestionId,
-    token: tokenFromStore ?? rawToken ?? undefined,
+    // Skip stale Redux token on first render (e.g. wizard re-issuing a token when toggling parameters); rawToken prop takes precedence.
+    // From the next render onward, tokenFromStore is used and the value is from a refreshed token.
+    token: (!isFirstRender ? tokenFromStore : null) ?? rawToken ?? undefined,
   });
 
   useSetupContentTranslations({ token });

--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-load-question.ts
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-load-question.ts
@@ -82,6 +82,18 @@ export function useLoadQuestion({
 
   const isGuestEmbed = useSdkSelector(getIsGuestEmbed);
 
+  /**
+   * Token change isn't an indicator to re-run the query. When users are refreshing
+   * the guest embeds token, the token will change, but not questionId. So we can
+   * rely on questionId that will change the loadAndQueryQuestion value and trigger
+   * the query again.
+   *
+   * As a reference, dashboards don't use this approach. It detects if the
+   * dashboardId has changed before triggering the query. So, the idea is quite similar.
+   */
+  const tokenRef = useRef(token);
+  tokenRef.current = token;
+
   const deferredRef = useRef<Deferred>();
 
   function deferred() {
@@ -115,7 +127,7 @@ export function useLoadQuestion({
           options,
           deserializedCard,
           questionId,
-          token,
+          token: tokenRef.current,
           initialSqlParameters,
           targetDashboardId,
         }),
@@ -126,7 +138,7 @@ export function useLoadQuestion({
       const results = await runQuestionQuerySdk({
         question: questionState.question,
         isGuestEmbed,
-        token,
+        token: tokenRef.current,
         originalQuestion: questionState.originalQuestion,
         parameterValues: questionState.parameterValues,
         cancelDeferred: deferred(),
@@ -169,7 +181,6 @@ export function useLoadQuestion({
     isGuestEmbed,
     sqlParameterKey,
     questionId,
-    token,
     targetDashboardId,
   ]);
 

--- a/frontend/src/embedding-sdk-bundle/store/guest-embed/auth.ts
+++ b/frontend/src/embedding-sdk-bundle/store/guest-embed/auth.ts
@@ -78,10 +78,10 @@ export const getOrRefreshGuestSession = createAsyncThunk(
     let forceRefreshForCypress;
     if (typeof window !== "undefined") {
       forceRefreshForCypress =
-        (window as any).FORCE_REFRESH_GUEST_EMBED_TOKEN_IN_CYPRESS === true;
+        window.FORCE_REFRESH_GUEST_EMBED_TOKEN_IN_CYPRESS === true;
     }
     if (forceRefreshForCypress) {
-      (window as any).FORCE_REFRESH_GUEST_EMBED_TOKEN_IN_CYPRESS = false;
+      window.FORCE_REFRESH_GUEST_EMBED_TOKEN_IN_CYPRESS = false;
     }
 
     const shouldRefreshToken =

--- a/frontend/src/embedding-sdk-shared/types/globals.d.ts
+++ b/frontend/src/embedding-sdk-shared/types/globals.d.ts
@@ -12,4 +12,5 @@ interface Window {
   METABASE_EMBEDDING_SDK_BUNDLE_BUILD_INFO?: import("metabase/embedding-sdk/types/build-info").BuildInfo;
   METABASE_EMBEDDING_SDK_IS_HOST_APP_IN_DEV_MODE?: boolean; // Added in v59
   METABASE_EMBEDDING_SDK_AUTH_STATE?: import("embedding-sdk-shared/types/auth-state").SdkAuthState;
+  FORCE_REFRESH_GUEST_EMBED_TOKEN_IN_CYPRESS?: boolean;
 }

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx
@@ -170,11 +170,7 @@ const SdkIframeEmbedView = ({
         /**
          * Need for initial token flow with JWT provider when the provider returns errors.
          * Without this, the InteractiveDashboard component will be rendered because
-         * there is no `token`. And the error component will not be rendered because
-         * guest embed doesn't support InteractiveDashboard.
-         *
-         * We don't need to check guestEmbedProviderUri for questions because it seems to
-         * already render correctly.
+         * there is no `token`, so it won't match this pattern.
          */
         {
           componentName: "metabase-dashboard",
@@ -228,6 +224,14 @@ const SdkIframeEmbedView = ({
           />
         ),
       )
+      // Exists solely to discriminate type from the pattern below when matching `guestEmbedProviderUri: P.nonNullable`
+      .with(
+        {
+          componentName: "metabase-question",
+          template: "exploration",
+        },
+        () => null,
+      )
       .with(
         // Embedding based on a questionId (Metabase Account auth type) with disabled drills
         {
@@ -244,6 +248,15 @@ const SdkIframeEmbedView = ({
           componentName: "metabase-question",
           token: P.nonNullable,
         },
+        /**
+         * Need for initial token flow with JWT provider when the provider returns errors.
+         * Without this, the InteractiveDashboard component will be rendered because
+         * there is no `token`, so it won't match this pattern.
+         */
+        {
+          componentName: "metabase-question",
+          guestEmbedProviderUri: P.nonNullable,
+        },
         (settings) => {
           const entityProps: SdkQuestionEntityPublicProps = settings.token
             ? {
@@ -252,7 +265,6 @@ const SdkIframeEmbedView = ({
             : {
                 questionId: settings.questionId ?? null,
               };
-
           return (
             <StaticQuestion
               key={rerenderKey}

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx
@@ -250,7 +250,7 @@ const SdkIframeEmbedView = ({
         },
         /**
          * Need for initial token flow with JWT provider when the provider returns errors.
-         * Without this, the InteractiveDashboard component will be rendered because
+         * Without this, nothing will be rendered because
          * there is no `token`, so it won't match this pattern.
          */
         {
@@ -265,6 +265,7 @@ const SdkIframeEmbedView = ({
             : {
                 questionId: settings.questionId ?? null,
               };
+
           return (
             <StaticQuestion
               key={rerenderKey}

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx
@@ -167,6 +167,19 @@ const SdkIframeEmbedView = ({
           componentName: "metabase-dashboard",
           token: P.nonNullable,
         },
+        /**
+         * Need for initial token flow with JWT provider when the provider returns errors.
+         * Without this, the InteractiveDashboard component will be rendered because
+         * there is no `token`. And the error component will not be rendered because
+         * guest embed doesn't support InteractiveDashboard.
+         *
+         * We don't need to check guestEmbedProviderUri for questions because it seems to
+         * already render correctly.
+         */
+        {
+          componentName: "metabase-dashboard",
+          guestEmbedProviderUri: P.nonNullable,
+        },
         (settings) => {
           const entityProps: SdkDashboardEntityPublicProps = settings.token
             ? {


### PR DESCRIPTION
part 3/3 of [EMB-1319](https://linear.app/metabase/issue/EMB-1319)

### Description

This properly wired up the rest of the JWT refresh token mechanics including handling error messages.

### How to verify

You can try to follow each E2E test case, and replicate them yourself. One more thing to test is to pass an object to `custom-context` with React 19.

Here's how you can set it up for an example scenario.
1. Use guest embed. Either SQL questions or dashboards. Make sure there are enabled parameters. These are the only cases we would need the refresh token.
2. Pass `token` via the HTML, set the token to something short like 10s
3. Set `guestEmbedProviderUri` to your endpoint that will create a sign jwt token using the same jwt secret.
4. After 10s, try to change the filter and observe the network tab. There should be a call to your `guestEmbedProviderUri`

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
