### PR TITLE
decrease font size in click behavior sidebar

### DIFF
--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarComponents.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarComponents.tsx
@@ -7,7 +7,7 @@ import S from "./ClickBehaviorSidebar.module.css";
 export const Heading = (props: TitleProps) => {
   const { className, ...rest } = props;
 
-  return <Title order={4} className={cx(S.Heading, className)} {...rest} />;
+  return <Title order={5} className={cx(S.Heading, className)} {...rest} />;
 };
 
 export const SidebarContent = (

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/SidebarItem/SidebarItemComponents.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/SidebarItem/SidebarItemComponents.tsx
@@ -1,6 +1,6 @@
 import cx from "classnames";
 
-import { Flex, type FlexProps, Title, type TitleProps } from "metabase/ui";
+import { Flex, type FlexProps, Text, type TextProps } from "metabase/ui";
 
 import S from "./SidebarItem.module.css";
 
@@ -49,6 +49,12 @@ export const Content = (props: FlexProps) => {
   return <Flex align="center" w="100%" {...props} />;
 };
 
-export const Name = (props: TitleProps) => (
-  <Title order={4} ta="left" textWrap="wrap" {...props} />
+export const Name = (props: React.PropsWithChildren<TextProps>) => (
+  <Text
+    fw="bold"
+    ta="left"
+    c="inherit"
+    style={{ textWrap: "wrap" }}
+    {...props}
+  />
 );


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #70242
Closes UXW-3188

### Description
Makes a very simple change to decrease the font size of items in the click behaviour sidebar. Essentially decreasing the font size from 17px to 14px

### How to verify
1. Go to a dashboard and open click actions for a dashcard
2. Take note of the font size, it should be a little less intense.
3. Do the same thing in stats to see a comparison

### Demo

<img width="1919" height="1055" alt="image" src="https://github.com/user-attachments/assets/847182b4-46a9-4117-8d9d-66064b13a252" />

### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~

