### PR TITLE
Move slack connect tests over to oss + fix API routes

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -2651,7 +2651,6 @@
    :api  #{}
    :uses #{driver
            premium-features
-           sso
            enterprise/advanced-config
            enterprise/scim
            enterprise/semantic-search

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -3343,6 +3343,7 @@
      "test[-.]dataset"                      ; anything that contains `test.dataset` or `test-dataset`
      "test\\.impl"                          ; anything that contains `test.impl`
      "test-setup"                           ; anything that contains `test-setup`
+     "test[-_]helpers"                      ; anything that contains `test-helpers` or `test_helpers`
      "^metabase(?:-enterprise)?\\.test"}}}} ; anything starting with `metabase.test` or `metabase-enterprise.test`
 
 ;; !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/enterprise/backend/src/metabase_enterprise/analytics/stats.clj
+++ b/enterprise/backend/src/metabase_enterprise/analytics/stats.clj
@@ -6,7 +6,6 @@
    [metabase-enterprise.sso.settings :as ee-sso-settings]
    [metabase.driver :as driver]
    [metabase.premium-features.core :as premium-features :refer [defenterprise]]
-   [metabase.sso.settings :as sso-settings]
    [toucan2.core :as t2]))
 
 (defenterprise ee-snowplow-features-data
@@ -20,9 +19,6 @@
    {:name      :sso-saml
     :available (premium-features/enable-sso-saml?)
     :enabled   (ee-sso-settings/saml-enabled)}
-   {:name      :sso-slack
-    :available (premium-features/enable-sso-slack?)
-    :enabled   (sso-settings/slack-connect-enabled)}
    {:name      :scim
     :available (premium-features/enable-scim?)
     :enabled   (boolean (scim/scim-enabled))}

--- a/enterprise/backend/src/metabase_enterprise/sso/api/routes.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/api/routes.clj
@@ -3,7 +3,8 @@
    [metabase-enterprise.sso.api.oidc]
    [metabase-enterprise.sso.api.saml]
    [metabase-enterprise.sso.api.sso]
-   [metabase.api.util.handlers :as handlers]))
+   [metabase.api.util.handlers :as handlers]
+   [metabase.sso.api.slack-connect :as slack-connect.api]))
 
 (comment metabase-enterprise.sso.api.saml/keep-me
          metabase-enterprise.sso.api.sso/keep-me
@@ -19,8 +20,11 @@
 ;; NOTE: there is a wrapper in metabase.server.auth-wrapper to ensure that oss versions give nice error
 ;; messages. These must be kept in sync manually since compojure are opaque functions.
 (def ^{:arglists '([request respond raise])} routes
-  "Ring routes for auth (SAML) API endpoints."
+  "Ring routes for auth (SAML) API endpoints.
+   Slack Connect routes are defined in OSS and mounted here for both OSS and EE builds."
   (handlers/route-map-handler
-   {"/auth" {"/sso"  'metabase-enterprise.sso.api.sso}
+   {"/auth" {"/sso" (handlers/route-map-handler
+                     {"/slack-connect" slack-connect.api/routes
+                      "/"              'metabase-enterprise.sso.api.sso})}
     "/api"  {"/saml" 'metabase-enterprise.sso.api.saml
              "/ee"   {"/sso" {"/oidc" metabase-enterprise.sso.api.oidc/routes}}}}))

--- a/enterprise/backend/src/metabase_enterprise/sso/api/routes.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/api/routes.clj
@@ -3,8 +3,7 @@
    [metabase-enterprise.sso.api.oidc]
    [metabase-enterprise.sso.api.saml]
    [metabase-enterprise.sso.api.sso]
-   [metabase.api.util.handlers :as handlers]
-   [metabase.sso.api.slack-connect :as slack-connect.api]))
+   [metabase.api.util.handlers :as handlers]))
 
 (comment metabase-enterprise.sso.api.saml/keep-me
          metabase-enterprise.sso.api.sso/keep-me
@@ -20,11 +19,8 @@
 ;; NOTE: there is a wrapper in metabase.server.auth-wrapper to ensure that oss versions give nice error
 ;; messages. These must be kept in sync manually since compojure are opaque functions.
 (def ^{:arglists '([request respond raise])} routes
-  "Ring routes for auth (SAML) API endpoints.
-   Slack Connect routes are defined in OSS and mounted here for both OSS and EE builds."
+  "Ring routes for auth (SAML) API endpoints."
   (handlers/route-map-handler
-   {"/auth" {"/sso" (handlers/route-map-handler
-                     {"/slack-connect" slack-connect.api/routes
-                      "/"              'metabase-enterprise.sso.api.sso})}
+   {"/auth" {"/sso"  'metabase-enterprise.sso.api.sso}
     "/api"  {"/saml" 'metabase-enterprise.sso.api.saml
              "/ee"   {"/sso" {"/oidc" metabase-enterprise.sso.api.oidc/routes}}}}))

--- a/enterprise/backend/src/metabase_enterprise/sso/api/sso.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/api/sso.clj
@@ -12,7 +12,6 @@
    [metabase.api.macros :as api.macros]
    [metabase.request.core :as request]
    [metabase.session.core :as session]
-   [metabase.sso.integrations.slack-connect :as slack-connect-integration]
    [metabase.system.core :as system]
    [metabase.util :as u]
    [metabase.util.log :as log]
@@ -150,30 +149,6 @@
     (catch Throwable e
       (log/error e "Error handling SLO")
       (sso-error-page e :out))))
-
-;; GET /auth/sso/slack-connect
-;;
-#_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
-(api.macros/defendpoint :get "/slack-connect"
-  "Initiate Slack Connect SSO flow."
-  [_route-params _query-params _body request]
-  (try
-    (slack-connect-integration/sso-initiate request)
-    (catch Throwable e
-      (log/error e "Error initiating Slack Connect SSO")
-      (throw e))))
-
-;; GET /auth/sso/slack-connect/callback
-;;
-#_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
-(api.macros/defendpoint :get "/slack-connect/callback"
-  "Slack Connect OIDC callback."
-  [_route-params _query-params _body request]
-  (try
-    (slack-connect-integration/sso-callback request)
-    (catch Throwable e
-      (log/error e "Error handling Slack Connect callback")
-      (throw e))))
 
 ;; Key schema that excludes `/` so /:key does not greedily match /:key/callback
 (def ^:private ProviderKey

--- a/enterprise/backend/test/metabase_enterprise/api/session_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/api/session_test.clj
@@ -44,7 +44,6 @@
                               :sso-ldap
                               :sso-oidc
                               :sso-saml
-                              :sso-slack
                               :support-users
                               :transforms-basic
                               :transforms-python
@@ -90,7 +89,6 @@
             :sso_ldap                       true
             :sso_oidc                       true
             :sso_saml                       true
-            :sso_slack                      true
             :support-users                  true
             :table_data_editing             false
             :transforms-basic               true

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/slack_connect_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/slack_connect_test.clj
@@ -1,0 +1,29 @@
+(ns metabase-enterprise.sso.integrations.slack-connect-test
+  "EE-specific tests for Slack Connect that require EE SSO types like SAML."
+  (:require
+   [clojure.string :as str]
+   [clojure.test :refer :all]
+   [metabase.sso.integrations.slack-connect-test :as slack-connect-test]
+   [metabase.sso.test-helpers :as sso.test-helpers]
+   [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]))
+
+(set! *warn-on-reflection* true)
+
+(use-fixtures :once (fixtures/initialize :test-users))
+(use-fixtures :each slack-connect-test/do-with-url-prefix-disabled)
+
+(deftest multiple-sso-methods-test
+  (testing "with SAML and Slack Connect configured, a GET request to /auth/sso/slack-connect should redirect to Slack"
+    (slack-connect-test/with-test-encryption!
+      (sso.test-helpers/with-slack-default-setup!
+        (mt/with-temporary-setting-values
+          [saml-enabled                       true
+           saml-identity-provider-uri         "http://test.idp.metabase.com"
+           saml-identity-provider-certificate (slurp "test_resources/sso/auth0-public-idp.cert")]
+          (slack-connect-test/with-successful-oidc!
+            (let [result       (mt/client-full-response :get 302 "/auth/sso/slack-connect"
+                                                        {:request-options {:redirect-strategy :none}}
+                                                        :redirect slack-connect-test/default-redirect-uri)
+                  redirect-url (get-in result [:headers "Location"])]
+              (is (str/starts-with? redirect-url "http://example.com/slack")))))))))

--- a/enterprise/backend/test/metabase_enterprise/sso/test_setup.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/test_setup.clj
@@ -10,9 +10,26 @@
 
 (set! *warn-on-reflection* true)
 
-(def successful-login? sso.test-helpers/successful-login?)
-(def call-with-login-attributes-cleared! sso.test-helpers/call-with-login-attributes-cleared!)
-(def do-with-other-sso-types-disabled! sso.test-helpers/do-with-other-sso-types-disabled!)
+(def successful-login?
+  "Return true if the response indicates a successful user login."
+  sso.test-helpers/successful-login?)
+
+(def call-with-login-attributes-cleared!
+  "Execute thunk and ensure login_attributes are cleared afterward."
+  sso.test-helpers/call-with-login-attributes-cleared!)
+
+(defn do-with-other-sso-types-disabled!
+  "Execute `thunk` with LDAP, SAML, JWT, and Slack Connect SSO types disabled.
+   Useful when testing a specific SSO provider in isolation.
+
+   This EE version disables all SSO types including EE-only SAML and JWT."
+  [thunk]
+  (mt/with-temporary-setting-values
+    [ldap-enabled          false
+     saml-enabled          false
+     jwt-enabled           false
+     slack-connect-enabled false]
+    (thunk)))
 
 ;;; -------------------------------------------------- SAML Setup --------------------------------------------------
 

--- a/enterprise/backend/test/metabase_enterprise/sso/test_setup.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/test_setup.clj
@@ -1,55 +1,18 @@
 (ns metabase-enterprise.sso.test-setup
-  "Shared test helpers for SSO tests.
+  "Shared test helpers for enterprise SSO tests (SAML, JWT, OIDC).
 
-   These utilities are used across multiple SSO integration tests (SAML, JWT, Slack Connect, etc.)
-   to avoid circular dependencies between test namespaces."
+   For Slack Connect and generic SSO helpers, see [[metabase.sso.test-helpers]]."
   (:require
-   [clojure.string :as str]
-   [metabase.config.core :as config]
    [metabase.premium-features.token-check :as token-check]
-   [metabase.request.core :as request]
-   [metabase.server.instance :as server.instance]
+   [metabase.sso.test-helpers :as sso.test-helpers]
    [metabase.test :as mt]
-   [metabase.util :as u]
-   [metabase.util.random :as u.random]
-   [toucan2.core :as t2]))
+   [metabase.util.random :as u.random]))
 
 (set! *warn-on-reflection* true)
 
-;;; -------------------------------------------------- Generic Helpers --------------------------------------------------
-
-(defn successful-login?
-  "Return true if the response indicates a successful user login.
-   Checks for the presence of a session cookie in the response."
-  [resp]
-  (or
-   (string? (get-in resp [:cookies request/metabase-session-cookie :value]))
-   (some #(str/starts-with? % request/metabase-session-cookie) (get-in resp [:headers "Set-Cookie"]))))
-
-(defn call-with-login-attributes-cleared!
-  "Execute `thunk` and ensure login_attributes are cleared afterward.
-
-   If login_attributes remain after tests run, depending on the order that the tests run,
-   lots of tests will fail as the login_attributes data from this test is unexpected in
-   those other tests."
-  [thunk]
-  (try
-    (thunk)
-    (finally
-      (u/ignore-exceptions
-        (t2/update! :model/User {} {:login_attributes nil})
-        (t2/update! :model/User {:email "rasta@metabase.com"} {:first_name "Rasta" :last_name "Toucan" :sso_source nil})))))
-
-(defn do-with-other-sso-types-disabled!
-  "Execute `thunk` with LDAP, SAML, JWT, and Slack Connect SSO types disabled.
-   Useful when testing a specific SSO provider in isolation."
-  [thunk]
-  (mt/with-temporary-setting-values
-    [ldap-enabled          false
-     saml-enabled          false
-     jwt-enabled           false
-     slack-connect-enabled false]
-    (thunk)))
+(def successful-login? sso.test-helpers/successful-login?)
+(def call-with-login-attributes-cleared! sso.test-helpers/call-with-login-attributes-cleared!)
+(def do-with-other-sso-types-disabled! sso.test-helpers/do-with-other-sso-types-disabled!)
 
 ;;; -------------------------------------------------- SAML Setup --------------------------------------------------
 
@@ -93,26 +56,16 @@
   "Default JWT secret for tests. Note: this is regenerated on each test run."
   (u.random/secure-hex 32))
 
-(defn- localhost-site-url
-  "Return a valid localhost site URL for tests, even when no Jetty server is running.
-   The CLI test runner often executes without a live server instance, so `server-port`
-   can be nil in that mode."
-  []
-  (str "http://localhost:"
-       (or (server.instance/server-port)
-           (config/config-str :mb-jetty-port)
-           3000)))
-
 (defn call-with-default-jwt-config!
   "Execute `f` with default JWT configuration set up."
   [f]
   (let [current-features (token-check/*token-features*)]
     (mt/with-additional-premium-features #{:sso-jwt}
       (mt/with-temporary-setting-values
-        [jwt-enabled              true
+        [jwt-enabled               true
          jwt-identity-provider-uri default-jwt-idp-uri
-         jwt-shared-secret        default-jwt-secret
-         site-url                 (localhost-site-url)]
+         jwt-shared-secret         default-jwt-secret
+         site-url                  (sso.test-helpers/localhost-site-url)]
         (mt/with-premium-features current-features
           (f))))))
 
@@ -132,26 +85,6 @@
                   (fn []
                     ~@body)))))))))))
 
-;;; -------------------------------------------------- Slack Connect Setup --------------------------------------------------
-
-(def ^:private default-slack-client-id "test-slack-client-id")
-(def ^:private default-slack-client-secret "test-slack-client-secret")
-
-(defn call-with-default-slack-config!
-  "Execute `f` with default Slack Connect configuration set up."
-  [f]
-  (let [current-features (token-check/*token-features*)]
-    (mt/with-additional-premium-features #{:sso-slack}
-      (mt/with-temporary-setting-values
-        [slack-connect-enabled                  true
-         slack-connect-client-id                default-slack-client-id
-         slack-connect-client-secret            default-slack-client-secret
-         slack-connect-authentication-mode      "sso"
-         slack-connect-user-provisioning-enabled true
-         site-url                               (localhost-site-url)]
-        (mt/with-premium-features current-features
-          (f))))))
-
 ;;; -------------------------------------------------- OIDC (Generic) Setup --------------------------------------------------
 
 (def ^:private default-oidc-provider
@@ -170,7 +103,7 @@
     (mt/with-additional-premium-features #{:sso-oidc}
       (mt/with-temporary-setting-values
         [oidc-providers [default-oidc-provider]
-         site-url       (localhost-site-url)]
+         site-url       (sso.test-helpers/localhost-site-url)]
         (mt/with-premium-features current-features
           (f))))))
 
@@ -185,20 +118,5 @@
             (call-with-login-attributes-cleared!
              (fn []
                (call-with-default-oidc-config!
-                (fn []
-                  ~@body))))))))))
-
-(defmacro with-slack-default-setup!
-  "Set up default Slack Connect configuration for tests.
-   Includes premium features, other SSO types disabled, login attributes cleanup, and default Slack config."
-  [& body]
-  `(mt/test-helpers-set-global-values!
-     (mt/with-premium-features #{:audit-app}
-       (do-with-other-sso-types-disabled!
-        (fn []
-          (mt/with-additional-premium-features #{:sso-slack}
-            (call-with-login-attributes-cleared!
-             (fn []
-               (call-with-default-slack-config!
                 (fn []
                   ~@body))))))))))

--- a/src/metabase/analytics/stats.clj
+++ b/src/metabase/analytics/stats.clj
@@ -795,7 +795,7 @@
 
 (defn- ee-snowplow-features-data'
   []
-  (let [features [:sso-jwt :sso-saml :sso-slack :scim :sandboxes :email-allow-list :semantic-search]]
+  (let [features [:sso-jwt :sso-saml :scim :sandboxes :email-allow-list :semantic-search]]
     (map
      (fn [feature]
        {:name      feature

--- a/src/metabase/premium_features/core.clj
+++ b/src/metabase/premium_features/core.clj
@@ -74,7 +74,6 @@
   enable-sso-ldap?
   enable-sso-oidc?
   enable-sso-saml?
-  enable-sso-slack?
   enable-support-users?
   enable-basic-transforms?
   enable-python-transforms?

--- a/src/metabase/premium_features/settings.clj
+++ b/src/metabase/premium_features/settings.clj
@@ -146,10 +146,6 @@
   "Should we enable SAML-based authentication?"
   :sso-saml)
 
-(define-premium-feature ^{:added "0.59.0"} enable-sso-slack?
-  "Should we enable Slack Connect (OIDC) authentication?"
-  :sso-slack)
-
 (define-premium-feature ^{:added "0.59.0"} enable-sso-oidc?
   "Should we enable OIDC-based authentication?"
   :sso-oidc)
@@ -171,7 +167,6 @@
   []
   (or (enable-sso-jwt?)
       (enable-sso-saml?)
-      (enable-sso-slack?)
       (enable-sso-oidc?)
       (enable-sso-ldap?)
       (enable-sso-google?)))
@@ -354,7 +349,6 @@
    :sso_ldap                       (enable-sso-ldap?)
    :sso_saml                       (enable-sso-saml?)
    :sso_oidc                       (enable-sso-oidc?)
-   :sso_slack                      (enable-sso-slack?)
    :support-users                  (enable-support-users?)
    :table_data_editing             (table-data-editing?)
    :tenants                        (enable-tenants?)

--- a/src/metabase/server/auth_wrapper.clj
+++ b/src/metabase/server/auth_wrapper.clj
@@ -2,13 +2,30 @@
   (:require
    [metabase.api.util.handlers :as handlers]
    [metabase.config.core :as config]
-   [metabase.sso.api.slack-connect :as slack-connect.api]))
+   [metabase.sso.api.slack-connect :as slack-connect.api]
+   [ring.util.response :as response]))
+
+(let [bad-req (response/bad-request {:message "The auth/sso endpoint only exists in enterprise builds"
+                                     :status "ee-build-required"})]
+  (defn- not-enabled
+    [_req respond _raise]
+    (respond bad-req)))
+
+(def ^:private ee-missing-routes
+  "Fallback routes when EE is not available. Returns 'not enabled' for non-slack-connect SSO routes."
+  (handlers/route-map-handler
+   {"/auth" {"/sso" not-enabled}
+    "/api"  {"/saml" not-enabled
+             "/ee"   {"/sso" {"/oidc" not-enabled}}}}))
 
 ;; This needs to be injected into [[metabase.server.routes/routes]] -- not [[metabase.api-routes.core/routes]] !!!
 (def routes
   "Ring routes for auth API endpoints.
    Slack Connect (OSS) is always available. Other SSO routes (SAML, JWT, OIDC) require EE."
   (handlers/routes
+   ;; Slack Connect routes always available (OSS)
    (handlers/route-map-handler {"/auth" {"/sso" {"/slack-connect" slack-connect.api/routes}}})
-   (when (and config/ee-available? (not *compile-files*))
-     (requiring-resolve 'metabase-enterprise.sso.api.routes/routes))))
+   ;; Other SSO routes require EE
+   (if (and config/ee-available? (not *compile-files*))
+     (requiring-resolve 'metabase-enterprise.sso.api.routes/routes)
+     ee-missing-routes)))

--- a/src/metabase/server/auth_wrapper.clj
+++ b/src/metabase/server/auth_wrapper.clj
@@ -2,35 +2,13 @@
   (:require
    [metabase.api.util.handlers :as handlers]
    [metabase.config.core :as config]
-   [metabase.sso.api.slack-connect :as slack-connect.api]
-   [ring.util.response :as response]))
-
-(let [bad-req (response/bad-request {:message "The auth/sso endpoint only exists in enterprise builds"
-                                     :status "ee-build-required"})]
-  (defn- not-enabled
-    [_req respond _raise]
-    (respond bad-req)))
-
-(def ^{:arglists '([request respond raise])} ee-missing-routes
-  "Ring routes for auth (SAML) API endpoints.
-   Slack Connect routes are always available (OSS). Other SSO routes require EE."
-  ;; follows the same form as [[metabase-enterprise.sso.api.routes]]. Compojure is a bit opaque so need to manually keep
-  ;; them in sync.
-  (handlers/route-map-handler
-   {"/auth" {"/sso"  (handlers/route-map-handler
-                      {"/slack-connect" slack-connect.api/routes
-                       "/"              not-enabled})}
-    "/api"  {"/saml" not-enabled
-             "/ee"   {"/sso" {"/oidc" not-enabled}}}}))
+   [metabase.sso.api.slack-connect :as slack-connect.api]))
 
 ;; This needs to be injected into [[metabase.server.routes/routes]] -- not [[metabase.api-routes.core/routes]] !!!
-;;
-;; TODO -- should we make a `metabase-enterprise.routes` namespace where this can live instead of injecting it
-;; directly?
-;;
-;; TODO -- we need to feature-flag this based on the `:sso-` feature flags
 (def routes
-  "Ring routes for auth (SAML) api endpoints. If enterprise is not present, will return a nicer message"
-  (if (and config/ee-available? (not *compile-files*))
-    (requiring-resolve 'metabase-enterprise.sso.api.routes/routes)
-    ee-missing-routes))
+  "Ring routes for auth API endpoints.
+   Slack Connect (OSS) is always available. Other SSO routes (SAML, JWT, OIDC) require EE."
+  (handlers/routes
+   (handlers/route-map-handler {"/auth" {"/sso" {"/slack-connect" slack-connect.api/routes}}})
+   (when (and config/ee-available? (not *compile-files*))
+     (requiring-resolve 'metabase-enterprise.sso.api.routes/routes))))

--- a/src/metabase/slackbot/api.clj
+++ b/src/metabase/slackbot/api.clj
@@ -51,8 +51,7 @@
            ^Runnable (bound-fn* f)))
 
 (defn clear-slack-bot-settings!
-  "Clears all slackbot-related settings when Slack token is cleared.
-   This ensures enable-sso-slack? becomes false."
+  "Clears all slackbot-related settings when Slack token is cleared."
   []
   (setting/set-many! {:slack-connect-enabled        false
                       :slack-connect-client-id      nil

--- a/src/metabase/sso/api/slack_connect.clj
+++ b/src/metabase/sso/api/slack_connect.clj
@@ -8,7 +8,7 @@
 ;; GET /auth/sso/slack-connect
 ;;
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
-(api.macros/defendpoint :get "/slack-connect"
+(api.macros/defendpoint :get "/"
   "Initiate Slack Connect SSO flow."
   [_route-params _query-params _body request]
   (try
@@ -20,7 +20,7 @@
 ;; GET /auth/sso/slack-connect/callback
 ;;
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
-(api.macros/defendpoint :get "/slack-connect/callback"
+(api.macros/defendpoint :get "/callback"
   "Slack Connect OIDC callback."
   [_route-params _query-params _body request]
   (try
@@ -30,5 +30,5 @@
       (throw e))))
 
 (def ^{:arglists '([request respond raise])} routes
-  "`/auth/sso` Slack Connect routes."
+  "`/auth/sso/slack-connect` routes."
   (api.macros/ns-handler *ns*))

--- a/test/metabase/sso/integrations/slack_connect_test.clj
+++ b/test/metabase/sso/integrations/slack_connect_test.clj
@@ -1,11 +1,11 @@
-(ns metabase-enterprise.sso.integrations.slack-connect-test
+(ns metabase.sso.integrations.slack-connect-test
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]
-   [metabase-enterprise.sso.test-setup :as sso.test-setup]
    [metabase.auth-identity.core :as auth-identity]
    [metabase.sso.oidc.state :as oidc.state]
    [metabase.sso.settings :as sso-settings]
+   [metabase.sso.test-helpers :as sso.test-helpers]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [metabase.test.http-client :as client]
@@ -66,7 +66,7 @@
 
 (deftest sso-prereqs-test
   (with-test-encryption!
-    (sso.test-setup/do-with-other-sso-types-disabled!
+    (sso.test-helpers/do-with-other-sso-types-disabled!
      (fn []
        (testing "SSO requests fail if Slack Connect hasn't been configured or enabled"
          (mt/with-temporary-setting-values
@@ -108,7 +108,7 @@
 (deftest redirect-test
   (testing "with Slack Connect configured, a GET request should result in a redirect to Slack"
     (with-test-encryption!
-      (sso.test-setup/with-slack-default-setup!
+      (sso.test-helpers/with-slack-default-setup!
         (with-successful-oidc!
           (let [result (mt/client-full-response :get 302 "/auth/sso/slack-connect"
                                                 {:request-options {:redirect-strategy :none}}
@@ -133,7 +133,7 @@
 (deftest multiple-sso-methods-test
   (testing "with SAML and Slack Connect configured, a GET request to /auth/sso/slack-connect should redirect to Slack"
     (with-test-encryption!
-      (sso.test-setup/with-slack-default-setup!
+      (sso.test-helpers/with-slack-default-setup!
         (mt/with-temporary-setting-values
           [saml-enabled true
            saml-identity-provider-uri "http://test.idp.metabase.com"
@@ -149,7 +149,7 @@
 
 (deftest post-not-allowed-test
   (testing "slack-connect is no longer available via the old POST /auth/sso multimethod dispatch"
-    (sso.test-setup/with-slack-default-setup!
+    (sso.test-helpers/with-slack-default-setup!
       ;; The old endpoint returned 405 via the defmethod sso-post :slack-connect.
       ;; Now that slack-connect has been removed from the multimethod dispatch and
       ;; uses dedicated GET routes, POSTing with preferred_method=slack-connect
@@ -163,7 +163,7 @@
 (deftest callback-state-validation-test
   (testing "callback should fail if state cookie is missing"
     (with-test-encryption!
-      (sso.test-setup/with-slack-default-setup!
+      (sso.test-helpers/with-slack-default-setup!
         (let [response (mt/client-full-response :get 401 "/auth/sso/slack-connect/callback"
                                                 {:request-options {:redirect-strategy :none}}
                                                 :code "test-code"
@@ -174,7 +174,7 @@
 (deftest callback-state-validation-csrf-test
   (testing "callback with mismatched state should indicate possible CSRF attack"
     (with-test-encryption!
-      (sso.test-setup/with-slack-default-setup!
+      (sso.test-helpers/with-slack-default-setup!
         (with-successful-oidc!
         ;; First, initiate auth to set state cookie
           (let [init-response (mt/client-full-response :get 302 "/auth/sso/slack-connect"
@@ -196,7 +196,7 @@
 (deftest happy-path-callback-test
   (testing "successful callback with valid code and state"
     (with-test-encryption!
-      (sso.test-setup/with-slack-default-setup!
+      (sso.test-helpers/with-slack-default-setup!
         (with-successful-oidc!
         ;; First, initiate auth to set state cookie
           (let [init-response (mt/client-full-response :get 302 "/auth/sso/slack-connect"
@@ -212,7 +212,7 @@
                                                                      :headers {"Cookie" cookie-header}}}
                                                   :code "test-code"
                                                   :state "test-state")]
-            (is (sso.test-setup/successful-login? response))
+            (is (sso.test-helpers/successful-login? response))
             (is (= default-redirect-uri (get-in response [:headers "Location"])))))))))
 
 ;;; -------------------------------------------------- Link-Only Mode Tests --------------------------------------------------
@@ -220,7 +220,7 @@
 (deftest link-only-mode-requires-session-test
   (testing "link-only mode should require authenticated session for initial request"
     (with-test-encryption!
-      (sso.test-setup/with-slack-default-setup!
+      (sso.test-helpers/with-slack-default-setup!
         (mt/with-temporary-setting-values
           [slack-connect-authentication-mode "link-only"]
           (let [response (mt/client-full-response :get 401 "/auth/sso/slack-connect"
@@ -231,7 +231,7 @@
 (deftest link-only-mode-with-session-test
   (testing "link-only mode should work with authenticated session"
     (with-test-encryption!
-      (sso.test-setup/with-slack-default-setup!
+      (sso.test-helpers/with-slack-default-setup!
         (mt/with-temporary-setting-values
           [slack-connect-authentication-mode "link-only"]
           (with-successful-oidc!
@@ -245,7 +245,7 @@
 
 (deftest no-open-redirect-test
   (testing "Check that we prevent open redirects to untrusted sites"
-    (sso.test-setup/with-slack-default-setup!
+    (sso.test-helpers/with-slack-default-setup!
       (doseq [redirect-uri ["https://badsite.com"
                             "//badsite.com"
                             "https:///badsite.com"]]
@@ -259,7 +259,7 @@
 (deftest create-new-account-test
   (testing "A new account will be created for a Slack user we haven't seen before"
     (with-test-encryption!
-      (sso.test-setup/with-slack-default-setup!
+      (sso.test-helpers/with-slack-default-setup!
         (mt/with-model-cleanup [:model/User]
           (with-successful-oidc!
             (t2/delete! :model/User :email "example@slack.com")
@@ -281,7 +281,7 @@
                                                       :code "test-code"
                                                       :state "test-state")]
               ;; Complete callback
-                (is (sso.test-setup/successful-login? response))
+                (is (sso.test-helpers/successful-login? response))
                 (let [new-user (t2/select-one :model/User :email "example@slack.com")]
                   (testing "new user"
                     (is
@@ -308,7 +308,7 @@
 (deftest create-new-slack-user-no-user-provisioning-test
   (testing "When user provisioning is disabled, throw an error if we attempt to create a new user."
     (with-test-encryption!
-      (sso.test-setup/with-slack-default-setup!
+      (sso.test-helpers/with-slack-default-setup!
         (mt/with-temporary-setting-values [slack-connect-user-provisioning-enabled false
                                            site-name "test"]
           (with-successful-oidc!
@@ -336,7 +336,7 @@
 
 (deftest authentication-mode-validation-test
   (testing "authentication mode setting only accepts valid values"
-    ;; Don't use sso.test-setup/with-slack-default-setup! here because it sets env vars
+    ;; Don't use sso.test-helpers/with-slack-default-setup! here because it sets env vars
     ;; which take precedence over DB values when reading settings.
     ;; This test only needs to verify the setter validates input correctly.
     (mt/with-temporary-setting-values

--- a/test/metabase/sso/integrations/slack_connect_test.clj
+++ b/test/metabase/sso/integrations/slack_connect_test.clj
@@ -18,21 +18,21 @@
 
 (use-fixtures :once (fixtures/initialize :test-users))
 
-(def ^:private test-encryption-key
+(def test-encryption-key
   "Test encryption key for OIDC state encryption."
   "Orw0AAyzkO/kPTLJRxiyKoBHXa/d6ZcO+p+gpZO/wSQ=")
 
-(def ^:private test-secret
+(def test-secret
   "Hashed test encryption key."
   (encryption/secret-key->hash test-encryption-key))
 
-(defmacro ^:private with-test-encryption!
+(defmacro with-test-encryption!
   "Wraps body with test encryption key enabled. Use for tests that involve OIDC state cookies."
   [& body]
   `(with-redefs [encryption/default-secret-key test-secret]
      ~@body))
 
-(defn- do-with-url-prefix-disabled
+(defn do-with-url-prefix-disabled
   "Test fixture that disables API URL prefix."
   [thunk]
   (binding [client/*url-prefix* ""]
@@ -40,23 +40,23 @@
 
 (use-fixtures :each do-with-url-prefix-disabled)
 
-(def ^:private default-redirect-uri "/")
+(def default-redirect-uri "/")
 
 (methodical/defmethod auth-identity/authenticate :provider/test-successful-oidc
   [_provider request]
   (if (some #(contains? request %) [:code :error :state])
-    {:success? true
-     :claims {}
-     :user-data {:email "example@slack.com"}
+    {:success?    true
+     :claims      {}
+     :user-data   {:email "example@slack.com"}
      :provider-id "test-provider-id"}
-    {:success? :redirect
+    {:success?     :redirect
      :redirect-url "http://example.com/slack"
-     :state "test-state"
-     :nonce "test-nonce"}))
+     :state        "test-state"
+     :nonce        "test-nonce"}))
 
 (methodical/prefer-method! #'auth-identity/authenticate :provider/test-successful-oidc :provider/oidc)
 
-(defmacro ^:private with-successful-oidc! [& body]
+(defmacro with-successful-oidc! [& body]
   `(do
      (derive :provider/slack-connect :provider/test-successful-oidc)
      ~@body
@@ -129,21 +129,6 @@
                   (is (= "test-nonce" (:nonce state-data)))
                   (is (= "/" (:redirect state-data)))
                   (is (= "slack-connect" (:provider state-data))))))))))))
-
-(deftest multiple-sso-methods-test
-  (testing "with SAML and Slack Connect configured, a GET request to /auth/sso/slack-connect should redirect to Slack"
-    (with-test-encryption!
-      (sso.test-helpers/with-slack-default-setup!
-        (mt/with-temporary-setting-values
-          [saml-enabled true
-           saml-identity-provider-uri "http://test.idp.metabase.com"
-           saml-identity-provider-certificate (slurp "test_resources/sso/auth0-public-idp.cert")]
-          (with-successful-oidc!
-            (let [result (mt/client-full-response :get 302 "/auth/sso/slack-connect"
-                                                  {:request-options {:redirect-strategy :none}}
-                                                  :redirect default-redirect-uri)
-                  redirect-url (get-in result [:headers "Location"])]
-              (is (str/starts-with? redirect-url "http://example.com/slack")))))))))
 
 ;;; -------------------------------------------------- POST Not Allowed Tests --------------------------------------------------
 

--- a/test/metabase/sso/test_helpers.clj
+++ b/test/metabase/sso/test_helpers.clj
@@ -1,0 +1,88 @@
+(ns metabase.sso.test-helpers
+  "Shared test helpers for SSO tests."
+  (:require
+   [clojure.string :as str]
+   [metabase.config.core :as config]
+   [metabase.request.core :as request]
+   [metabase.server.instance :as server.instance]
+   [metabase.test :as mt]
+   [metabase.util :as u]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+;;; -------------------------------------------------- Generic Helpers --------------------------------------------------
+
+(defn successful-login?
+  "Return true if the response indicates a successful user login.
+   Checks for the presence of a session cookie in the response."
+  [resp]
+  (or
+   (string? (get-in resp [:cookies request/metabase-session-cookie :value]))
+   (some #(str/starts-with? % request/metabase-session-cookie) (get-in resp [:headers "Set-Cookie"]))))
+
+(defn call-with-login-attributes-cleared!
+  "Execute `thunk` and ensure login_attributes are cleared afterward.
+
+   If login_attributes remain after tests run, depending on the order that the tests run,
+   lots of tests will fail as the login_attributes data from this test is unexpected in
+   those other tests."
+  [thunk]
+  (try
+    (thunk)
+    (finally
+      (u/ignore-exceptions
+        (t2/update! :model/User {} {:login_attributes nil})
+        (t2/update! :model/User {:email "rasta@metabase.com"} {:first_name "Rasta" :last_name "Toucan" :sso_source nil})))))
+
+(defn do-with-other-sso-types-disabled!
+  "Execute `thunk` with LDAP, SAML, JWT, and Slack Connect SSO types disabled.
+   Useful when testing a specific SSO provider in isolation."
+  [thunk]
+  (mt/with-temporary-setting-values
+    [ldap-enabled          false
+     saml-enabled          false
+     jwt-enabled           false
+     slack-connect-enabled false]
+    (thunk)))
+
+(defn localhost-site-url
+  "Return a valid localhost site URL for tests, even when no Jetty server is running.
+   The CLI test runner often executes without a live server instance, so `server-port`
+   can be nil in that mode."
+  []
+  (str "http://localhost:"
+       (or (server.instance/server-port)
+           (config/config-str :mb-jetty-port)
+           3000)))
+
+;;; -------------------------------------------------- Slack Connect Setup --------------------------------------------------
+
+(def ^:private default-slack-client-id "test-slack-client-id")
+(def ^:private default-slack-client-secret "test-slack-client-secret")
+
+(defn call-with-default-slack-config!
+  "Execute `f` with default Slack Connect configuration set up."
+  [f]
+  (mt/with-temporary-setting-values
+    [slack-connect-enabled                   true
+     slack-connect-client-id                 default-slack-client-id
+     slack-connect-client-secret             default-slack-client-secret
+     slack-connect-authentication-mode       "sso"
+     slack-connect-user-provisioning-enabled true
+     site-url                                (localhost-site-url)]
+    (f)))
+
+(defmacro with-slack-default-setup!
+  "Set up default Slack Connect configuration for tests.
+   Includes other SSO types disabled, login attributes cleanup, and default Slack config."
+  [& body]
+  `(mt/test-helpers-set-global-values!
+     (mt/with-premium-features #{:audit-app}
+       (do-with-other-sso-types-disabled!
+        (fn []
+          (call-with-login-attributes-cleared!
+           (fn []
+             (call-with-default-slack-config!
+              (fn []
+                ~@body)))))))))

--- a/test/metabase/sso/test_helpers.clj
+++ b/test/metabase/sso/test_helpers.clj
@@ -36,13 +36,15 @@
         (t2/update! :model/User {:email "rasta@metabase.com"} {:first_name "Rasta" :last_name "Toucan" :sso_source nil})))))
 
 (defn do-with-other-sso-types-disabled!
-  "Execute `thunk` with LDAP, SAML, JWT, and Slack Connect SSO types disabled.
-   Useful when testing a specific SSO provider in isolation."
+  "Execute `thunk` with LDAP and Slack Connect SSO types disabled.
+   Useful when testing a specific SSO provider in isolation.
+
+   Note: This OSS version only disables OSS SSO types. EE tests should use
+   [[metabase-enterprise.sso.test-setup/do-with-other-sso-types-disabled!]]
+   which also disables SAML and JWT."
   [thunk]
   (mt/with-temporary-setting-values
     [ldap-enabled          false
-     saml-enabled          false
-     jwt-enabled           false
      slack-connect-enabled false]
     (thunk)))
 


### PR DESCRIPTION
* Fixes slack connect routes that had duplicated `slack-connect` path components after the move to OSS
* Moves slack connect tests + some related helpers to OSS