### PR TITLE
Metrics explorer dimension picker and tab creation fixes

### DIFF
--- a/e2e/test/scenarios/metrics/metrics-explorer.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/metrics-explorer.cy.spec.ts
@@ -431,6 +431,47 @@ describe("scenarios > metrics > explorer", () => {
       H.MetricsViewer.assertVizType("Line");
     });
 
+    it("should not show dimensions that are already in tabs in the dimension picker", () => {
+      addMetric("Count of products");
+      cy.wait("@dataset");
+      H.MetricsViewer.tabsShouldBe([
+        "Created At",
+        "State",
+        "Title",
+        "Category",
+      ]);
+
+      H.MetricsViewer.getAddDimensionButton().click();
+      H.popover().within(() => {
+        cy.findByText("Rating").should("exist");
+        // Created At exists on the users table so would be a false positive
+        // testing the other tabs is sufficent
+        cy.findByText("State").should("not.exist");
+        cy.findByText("Title").should("not.exist");
+        cy.findByText("Category").should("not.exist");
+      });
+    });
+
+    it("should map shared dimensions to all metrics when adding a tab from the picker", () => {
+      addMetric("Count of products");
+      cy.wait("@dataset");
+
+      H.MetricsViewer.getAddDimensionButton().click();
+      H.popover().within(() => {
+        cy.findByText("Shared").should("exist");
+        cy.findByText("Rating").click();
+      });
+      cy.wait("@dataset");
+
+      H.MetricsViewer.tablist()
+        .findByRole("tab", { name: "Rating" })
+        .should("have.attr", "aria-selected", "true");
+
+      H.MetricsViewer.getDimensionPillContainer().within(() => {
+        cy.findAllByText("Select a dimension").should("not.exist");
+      });
+    });
+
     it("should add a dimension tab and remove it", () => {
       addMetric("Count of feedback");
       H.MetricsViewer.tabsShouldBe([

--- a/frontend/src/metabase/metrics-viewer/components/MetricsViewerTabs/AddDimensionPopover/AddDimensionPopover.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricsViewerTabs/AddDimensionPopover/AddDimensionPopover.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useState } from "react";
 import { t } from "ttag";
 
 import { AccordionList } from "metabase/common/components/AccordionList";
+import type { TabInfo } from "metabase/metrics-viewer/utils/tabs";
 import { ActionIcon, Icon, Popover } from "metabase/ui";
 
 import type { MetricSourceId } from "../../../types/viewer-state";
@@ -19,7 +20,7 @@ type AddDimensionPopoverProps = {
   sourceOrder: MetricSourceId[];
   sourceDataById: Record<MetricSourceId, SourceDisplayInfo>;
   hasMultipleSources: boolean;
-  onAddTab: (dimensionId: string) => void;
+  onAddTab: (tabInfo: TabInfo) => void;
 };
 
 export function AddDimensionPopover({
@@ -44,7 +45,7 @@ export function AddDimensionPopover({
 
   const handleSelect = useCallback(
     (item: DimensionPickerItem) => {
-      onAddTab(item.dimensionId);
+      onAddTab(item.tabInfo);
       setIsOpen(false);
     },
     [onAddTab],

--- a/frontend/src/metabase/metrics-viewer/components/MetricsViewerTabs/MetricsViewerTabs.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricsViewerTabs/MetricsViewerTabs.tsx
@@ -1,6 +1,7 @@
 import { useCallback } from "react";
 import { t } from "ttag";
 
+import type { TabInfo } from "metabase/metrics-viewer/utils/tabs";
 import { ActionIcon, Icon, Skeleton, Tabs } from "metabase/ui";
 
 import type {
@@ -23,7 +24,7 @@ type MetricsViewerTabsProps = {
   sourceOrder: MetricSourceId[];
   sourceDataById: Record<MetricSourceId, SourceDisplayInfo>;
   onTabChange: (tabId: string) => void;
-  onAddTab: (dimensionId: string) => void;
+  onAddTab: (tabInfo: TabInfo) => void;
   onRemoveTab: (tabId: string) => void;
 };
 

--- a/frontend/src/metabase/metrics-viewer/hooks/use-metrics-viewer.ts
+++ b/frontend/src/metabase/metrics-viewer/hooks/use-metrics-viewer.ts
@@ -1,6 +1,7 @@
 import { useCallback, useMemo } from "react";
 
 import { getObjectEntries, objectFromEntries } from "metabase/lib/objects";
+import { isNotNull } from "metabase/lib/types";
 import type {
   DimensionMetadata,
   MetricDefinition,
@@ -41,7 +42,8 @@ import {
   createSourceId,
 } from "../utils/source-ids";
 import {
-  createTabFromDimension,
+  type TabInfo,
+  createTabFromTabInfo,
   getDimensionsByType,
   resolveCommonTabLabel,
 } from "../utils/tabs";
@@ -73,7 +75,7 @@ export interface UseMetricsViewerResult {
   swapMetric: (oldMetric: SelectedMetric, newMetric: SelectedMetric) => void;
   removeMetric: (id: number, sourceType: "metric" | "measure") => void;
   changeTab: (tabId: string) => void;
-  addAndSelectTab: (dimensionId: string) => void;
+  addAndSelectTab: (tabInfo: TabInfo) => void;
   removeTab: (tabId: string) => void;
   updateTab: (tabId: string, updates: Partial<MetricsViewerTabState>) => void;
   updateActiveTab: (updates: Partial<MetricsViewerTabState>) => void;
@@ -254,8 +256,13 @@ export function useMetricsViewer({
     return result;
   }, [state.definitions]);
 
-  const existingTabIds = useMemo(
-    () => new Set(state.tabs.map((tab) => tab.id)),
+  const existingTabDimensionIds = useMemo(
+    () =>
+      new Set(
+        state.tabs
+          .flatMap((tab) => Object.values(tab.dimensionMapping))
+          .filter(isNotNull),
+      ),
     [state.tabs],
   );
 
@@ -293,9 +300,9 @@ export function useMetricsViewer({
       getAvailableDimensionsForPicker(
         definitionsBySourceId,
         sourceOrder,
-        existingTabIds,
+        existingTabDimensionIds,
       ),
-    [definitionsBySourceId, sourceOrder, existingTabIds],
+    [definitionsBySourceId, sourceOrder, existingTabDimensionIds],
   );
 
   const addMetric = useCallback(
@@ -336,12 +343,8 @@ export function useMetricsViewer({
   );
 
   const addAndSelectTab = useCallback(
-    (dimensionId: string) => {
-      const newTab = createTabFromDimension(
-        dimensionId,
-        definitionsBySourceId,
-        sourceOrder,
-      );
+    (tabInfo: TabInfo) => {
+      const newTab = createTabFromTabInfo(tabInfo);
       if (!newTab) {
         return;
       }
@@ -349,7 +352,7 @@ export function useMetricsViewer({
       addTab(newTab);
       changeTab(newTab.id);
     },
-    [definitionsBySourceId, sourceOrder, addTab, changeTab],
+    [addTab, changeTab],
   );
 
   const updateActiveTab = useCallback(

--- a/frontend/src/metabase/metrics-viewer/utils/dimension-picker.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/dimension-picker.ts
@@ -13,17 +13,14 @@ import type {
   MetricsViewerTabType,
 } from "../types/viewer-state";
 
-import { getDimensionIcon, getDimensionsByType } from "./tabs";
+import { type TabInfo, getDimensionIcon, getDimensionsByType } from "./tabs";
 
 // ── Dimension picker ──
 
 export interface AvailableDimension {
-  dimensionId: string;
-  label: string;
   icon: IconName;
-  sourceIds: MetricSourceId[];
-  tabType: MetricsViewerTabType;
   group?: DimensionGroup;
+  tabInfo: TabInfo;
 }
 
 export interface AvailableDimensionsResult {
@@ -44,7 +41,7 @@ interface DimensionEntry {
 function collectAllDimensionEntries(
   sourceOrder: MetricSourceId[],
   definitionsBySourceId: Record<MetricSourceId, MetricDefinition | null>,
-  existingTabIds: Set<string>,
+  existingTabDimensionIds: Set<string>,
 ): DimensionEntry[] {
   const entries: DimensionEntry[] = [];
 
@@ -55,7 +52,7 @@ function collectAllDimensionEntries(
     }
 
     for (const [id, info] of getDimensionsByType(def)) {
-      if (existingTabIds.has(id)) {
+      if (existingTabDimensionIds.has(id)) {
         continue;
       }
 
@@ -96,7 +93,7 @@ function groupBySource(entries: DimensionEntry[]): DimensionEntry[][] {
 export function getAvailableDimensionsForPicker(
   definitionsBySourceId: Record<MetricSourceId, MetricDefinition | null>,
   sourceOrder: MetricSourceId[],
-  existingTabIds: Set<string>,
+  existingTabDimensionIds: Set<string>,
 ): AvailableDimensionsResult {
   const result: AvailableDimensionsResult = { shared: [], bySource: {} };
 
@@ -107,7 +104,7 @@ export function getAvailableDimensionsForPicker(
   const entries = collectAllDimensionEntries(
     sourceOrder,
     definitionsBySourceId,
-    existingTabIds,
+    existingTabDimensionIds,
   );
   const groups = groupBySource(entries);
   const loadedSourceCount = new Set(entries.map((entry) => entry.sourceId))
@@ -120,34 +117,38 @@ export function getAvailableDimensionsForPicker(
 
     if (hasMultipleSources && uniqueSources.length >= 2) {
       result.shared.push({
-        dimensionId: first.id,
-        label: first.label,
         icon: first.icon,
-        tabType: first.tabType,
-        sourceIds: uniqueSources,
         group: first.group,
+        tabInfo: {
+          type: first.tabType,
+          label: first.label,
+          dimensionMapping: Object.fromEntries(
+            group.map((entry) => [entry.sourceId, entry.id]),
+          ),
+        },
       });
     } else {
       for (const entry of group) {
         const arr = (result.bySource[entry.sourceId] ??= []);
         arr.push({
-          dimensionId: entry.id,
-          label: entry.label,
           icon: entry.icon,
-          tabType: entry.tabType,
-          sourceIds: [entry.sourceId],
           group: entry.group,
+          tabInfo: {
+            type: entry.tabType,
+            label: entry.label,
+            dimensionMapping: { [entry.sourceId]: entry.id },
+          },
         });
       }
     }
   }
 
   result.shared.sort((first, second) =>
-    first.label.localeCompare(second.label),
+    first.tabInfo.label.localeCompare(second.tabInfo.label),
   );
   for (const sourceId of sourceOrder) {
     result.bySource[sourceId]?.sort((first, second) =>
-      first.label.localeCompare(second.label),
+      first.tabInfo.label.localeCompare(second.tabInfo.label),
     );
   }
 
@@ -205,7 +206,7 @@ export function buildDimensionPickerSections({
         name: sectionName,
         items: dimensions.map((dimension) => ({
           ...dimension,
-          name: dimension.label,
+          name: dimension.tabInfo.label,
         })),
       });
       return;
@@ -218,7 +219,7 @@ export function buildDimensionPickerSections({
         name,
         items: groupDimensions.map((dimension) => ({
           ...dimension,
-          name: dimension.label,
+          name: dimension.tabInfo.label,
         })),
       });
     }

--- a/frontend/src/metabase/metrics-viewer/utils/dimension-picker.unit.spec.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/dimension-picker.unit.spec.ts
@@ -37,49 +37,61 @@ const ORDERS_SOURCE_ID: MetricSourceId = `metric:${ORDERS_METRIC.id}`;
 
 const REVENUE_DIMENSIONS = [
   {
-    dimensionId: "dim-amount",
-    label: "Amount",
     icon: "int",
-    tabType: "numeric",
-    sourceIds: [REVENUE_SOURCE_ID],
+    group: undefined,
+    tabInfo: {
+      type: "numeric",
+      label: "Amount",
+      dimensionMapping: { [REVENUE_SOURCE_ID]: "dim-amount" },
+    },
   },
   {
-    dimensionId: "dim-category",
-    label: "Category",
     icon: "string",
-    tabType: "category",
-    sourceIds: [REVENUE_SOURCE_ID],
+    group: undefined,
+    tabInfo: {
+      type: "category",
+      label: "Category",
+      dimensionMapping: { [REVENUE_SOURCE_ID]: "dim-category" },
+    },
   },
   {
-    dimensionId: "dim-created-at",
-    label: "Created At",
     icon: "calendar",
-    tabType: "time",
-    sourceIds: [REVENUE_SOURCE_ID],
+    group: undefined,
+    tabInfo: {
+      type: "time",
+      label: "Created At",
+      dimensionMapping: { [REVENUE_SOURCE_ID]: "dim-created-at" },
+    },
   },
   {
-    dimensionId: "dim-active",
-    label: "Is Active",
     icon: "io",
-    tabType: "boolean",
-    sourceIds: [REVENUE_SOURCE_ID],
+    group: undefined,
+    tabInfo: {
+      type: "boolean",
+      label: "Is Active",
+      dimensionMapping: { [REVENUE_SOURCE_ID]: "dim-active" },
+    },
   },
 ];
 
 const ORDERS_DIMENSIONS = [
   {
-    dimensionId: "dim-created-at",
-    label: "Created At",
     icon: "calendar",
-    tabType: "time",
-    sourceIds: [ORDERS_SOURCE_ID],
+    group: undefined,
+    tabInfo: {
+      type: "time",
+      label: "Created At",
+      dimensionMapping: { [ORDERS_SOURCE_ID]: "dim-created-at" },
+    },
   },
   {
-    dimensionId: "dim-status",
-    label: "Status",
     icon: "string",
-    tabType: "category",
-    sourceIds: [ORDERS_SOURCE_ID],
+    group: undefined,
+    tabInfo: {
+      type: "category",
+      label: "Status",
+      dimensionMapping: { [ORDERS_SOURCE_ID]: "dim-status" },
+    },
   },
 ];
 
@@ -139,8 +151,10 @@ describe("getAvailableDimensionsForPicker", () => {
     });
   });
 
-  it("filters out dimensions whose id matches existingTabIds", () => {
-    const allIds = REVENUE_DIMENSIONS.map((dimension) => dimension.dimensionId);
+  it("filters out dimensions whose id matches existingTabDimensionIds", () => {
+    const allIds = REVENUE_DIMENSIONS.flatMap((dimension) =>
+      Object.values(dimension.tabInfo.dimensionMapping),
+    );
 
     const result = getAvailableDimensionsForPicker(
       { [REVENUE_SOURCE_ID]: revenueDefinition },

--- a/frontend/src/metabase/metrics-viewer/utils/tabs.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/tabs.ts
@@ -452,43 +452,27 @@ export function computeDefaultTabs(
 
 // ── Manual tab creation ──
 
-export function createTabFromDimension(
-  dimensionId: string,
-  definitionsBySourceId: Record<MetricSourceId, MetricDefinition | null>,
-  sourceOrder: MetricSourceId[],
+export interface TabInfo {
+  type: MetricsViewerTabType;
+  label: string;
+  dimensionMapping: Record<MetricSourceId, string>;
+}
+
+export function createTabFromTabInfo(
+  tabInfo: TabInfo,
 ): MetricsViewerTabState | null {
-  const mapping: Record<MetricSourceId, string> = {};
-  let tabType: MetricsViewerTabType = "category";
-  let displayName: string | null = null;
-
-  for (const sourceId of sourceOrder) {
-    const def = definitionsBySourceId[sourceId];
-    if (!def) {
-      continue;
-    }
-
-    const dimensionInfo = getDimensionsByType(def).get(dimensionId);
-    if (!dimensionInfo) {
-      continue;
-    }
-
-    mapping[sourceId] = dimensionId;
-    tabType = dimensionInfo.dimensionType;
-    displayName ??= dimensionInfo.displayName;
-  }
-
-  if (Object.keys(mapping).length === 0) {
+  const { type, label, dimensionMapping } = tabInfo;
+  const id = Object.values(dimensionMapping)[0];
+  if (id == null) {
     return null;
   }
-
-  const display = getTabConfig(tabType).defaultDisplayType;
-
+  const display = getTabConfig(type).defaultDisplayType;
   return {
-    id: dimensionId,
-    type: tabType,
-    label: displayName ?? dimensionId,
+    id,
+    type,
+    label,
     display,
-    dimensionMapping: mapping,
+    dimensionMapping,
     projectionConfig: {},
   };
 }

--- a/frontend/src/metabase/metrics-viewer/utils/tabs.unit.spec.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/tabs.unit.spec.ts
@@ -37,15 +37,14 @@ describe("resolveCommonTabLabel", () => {
   });
 });
 
-function createMockAvailableDimension(
-  overrides: Partial<AvailableDimension> & { dimensionId: string },
-): AvailableDimension {
+function createMockAvailableDimension(label: string): AvailableDimension {
   return {
-    label: overrides.dimensionId,
     icon: "string",
-    sourceIds: [],
-    tabType: "category",
-    ...overrides,
+    tabInfo: {
+      type: "category",
+      label,
+      dimensionMapping: {},
+    },
   };
 }
 
@@ -55,14 +54,8 @@ describe("buildDimensionPickerSections", () => {
       shared: [],
       bySource: {
         "metric:1": [
-          createMockAvailableDimension({
-            dimensionId: "category",
-            label: "Category",
-          }),
-          createMockAvailableDimension({
-            dimensionId: "state",
-            label: "State",
-          }),
+          createMockAvailableDimension("Category"),
+          createMockAvailableDimension("State"),
         ],
       },
     };
@@ -80,38 +73,21 @@ describe("buildDimensionPickerSections", () => {
       {
         name: undefined,
         items: [
-          expect.objectContaining({
-            name: "Category",
-            dimensionId: "category",
-          }),
-          expect.objectContaining({ name: "State", dimensionId: "state" }),
+          expect.objectContaining({ name: "Category" }),
+          expect.objectContaining({ name: "State" }),
         ],
       },
     ]);
   });
 
   it("splits by source and includes shared section for multiple sources", () => {
-    const sharedDimension = createMockAvailableDimension({
-      dimensionId: "created_at",
-      label: "Created At",
-      sourceIds: ["metric:1", "metric:2"],
-    });
+    const sharedDimension = createMockAvailableDimension("Created At");
 
     const dimensions: AvailableDimensionsResult = {
       shared: [sharedDimension],
       bySource: {
-        "metric:1": [
-          createMockAvailableDimension({
-            dimensionId: "category",
-            label: "Category",
-          }),
-        ],
-        "metric:2": [
-          createMockAvailableDimension({
-            dimensionId: "status",
-            label: "Status",
-          }),
-        ],
+        "metric:1": [createMockAvailableDimension("Category")],
+        "metric:2": [createMockAvailableDimension("Status")],
       },
     };
 
@@ -128,27 +104,15 @@ describe("buildDimensionPickerSections", () => {
     expect(sections).toEqual([
       {
         name: "Shared",
-        items: [
-          expect.objectContaining({
-            name: "Created At",
-            dimensionId: "created_at",
-          }),
-        ],
+        items: [expect.objectContaining({ name: "Created At" })],
       },
       {
         name: "Revenue",
-        items: [
-          expect.objectContaining({
-            name: "Category",
-            dimensionId: "category",
-          }),
-        ],
+        items: [expect.objectContaining({ name: "Category" })],
       },
       {
         name: "Orders",
-        items: [
-          expect.objectContaining({ name: "Status", dimensionId: "status" }),
-        ],
+        items: [expect.objectContaining({ name: "Status" })],
       },
     ]);
   });


### PR DESCRIPTION
Closes [UXW-3417](https://linear.app/metabase/issue/UXW-3417/add-dimension-popover-shows-dimensions-that-are-already-in-tabs)
Closes [UXW-3418](https://linear.app/metabase/issue/UXW-3418/adding-a-tab-with-a-shared-dimension-does-not-assign-the-dimension-to)

### Description

Fixes two bugs:

- Dimensions would appear in the dimension picker that were already in tabs. This is fixed by passing the complete set of dimensions from the tab's `dimensionMapping` into `getAvailableDimensionsForPicker`, not just the tab `id`
- Shared dimensions would not be added for all metrics when creating a tab. The bug here was using a single `dimensionId` across multiple metrics, but a shared dimension gets different uuids across metrics. `getAvailableDimensionsForPicker` was correctly using `LibMetric.isSameSource` to determine which dimensions are shared. Rather than recreating the mapping logic when creating a tab, we can have `getAvailableDimensionsForPicker` pass along the mapping in a `TabInfo` object to use during tab creation

### How to verify

Follow the steps in the demo video and verify it's working as expected.

### Demo

[Loom](https://www.loom.com/share/a4501de97b12432793e2976576939e6b)

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
