### PR TITLE
[Metabot] Hide metabot feedback buttons on non-hosted instances

### DIFF
--- a/enterprise/frontend/src/embedding-sdk-ee/metabot/MetabotChatHistory.tsx
+++ b/enterprise/frontend/src/embedding-sdk-ee/metabot/MetabotChatHistory.tsx
@@ -39,7 +39,6 @@ export function MetabotChatHistory() {
           errorMessages={errorMessages}
           onRetryMessage={metabot.retryMessage}
           isDoingScience={metabot.isDoingScience}
-          showFeedbackButtons={false}
           onInternalLinkClick={setNavigateToPath}
         />
       ) : null}

--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotChat.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotChat.tsx
@@ -4,7 +4,9 @@ import { t } from "ttag";
 
 import EmptyDashboardBot from "assets/img/dashboard-empty.svg?component";
 import { useGetSuggestedMetabotPromptsQuery } from "metabase/api";
+import { useSelector } from "metabase/lib/redux";
 import { MetabotResetLongChatButton } from "metabase/metabot/components/MetabotChat/MetabotResetLongChatButton";
+import { getIsHosted } from "metabase/setup/selectors";
 import {
   ActionIcon,
   Box,
@@ -43,6 +45,7 @@ export const MetabotChat = ({
 }: {
   config?: MetabotConfig;
 }) => {
+  const isHosted = useSelector(getIsHosted);
   const metabot = useMetabotAgent(config.agentId);
 
   const hasMessages =
@@ -160,7 +163,7 @@ export const MetabotChat = ({
                 config.preventRetryMessage ? undefined : metabot.retryMessage
               }
               isDoingScience={metabot.isDoingScience}
-              showFeedbackButtons
+              showFeedbackButtons={isHosted}
             />
             {/* loading */}
             {metabot.isDoingScience && (

--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotChatMessage.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotChatMessage.tsx
@@ -288,14 +288,14 @@ export const Messages = ({
   errorMessages,
   onRetryMessage,
   isDoingScience,
-  showFeedbackButtons,
+  showFeedbackButtons = false,
   onInternalLinkClick,
 }: {
   messages: MetabotChatMessage[];
   errorMessages: MetabotErrorMessage[];
   onRetryMessage?: (messageId: string) => void;
   isDoingScience: boolean;
-  showFeedbackButtons: boolean;
+  showFeedbackButtons?: boolean;
   onInternalLinkClick?: (navigateToPath: string) => void;
 }) => {
   const clipboard = useClipboard();

--- a/frontend/src/metabase/metabot/tests/feedback.unit.spec.ts
+++ b/frontend/src/metabase/metabot/tests/feedback.unit.spec.ts
@@ -3,19 +3,19 @@ import userEvent from "@testing-library/user-event";
 import { screen, within } from "__support__/ui";
 
 import {
-  setup as defaultSetup,
   enterChatMessage,
   feedbackModal,
   lastChatMessage,
   mockAgentEndpoint,
   mockFeedbackEndpoint,
+  setup,
   thumbsDown,
   thumbsUp,
   whoIsYourFavoriteResponse,
 } from "./utils";
 
-const setup = async () => {
-  defaultSetup();
+const setupWithNegativeFeedback = async () => {
+  setup({ isHosted: true });
   const feedbackEndpoint = mockFeedbackEndpoint();
   mockAgentEndpoint({ textChunks: whoIsYourFavoriteResponse });
 
@@ -51,8 +51,23 @@ const submitFeedback = async (modal: HTMLElement) => {
 };
 
 describe("metabot > feedback", () => {
-  it("should present the user an option to provide feedback", async () => {
-    defaultSetup();
+  it("should not show feedback buttons for non-hosted instances", async () => {
+    setup({ isHosted: false });
+    mockAgentEndpoint({ textChunks: whoIsYourFavoriteResponse });
+
+    await enterChatMessage("Who is your favorite?");
+    const lastMessage = (await lastChatMessage())!;
+
+    expect(
+      within(lastMessage).queryByTestId("metabot-chat-message-thumbs-up"),
+    ).not.toBeInTheDocument();
+    expect(
+      within(lastMessage).queryByTestId("metabot-chat-message-thumbs-down"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should present the user an option to provide feedback for hosted instances", async () => {
+    setup({ isHosted: true });
     const feedbackEndpoint = mockFeedbackEndpoint();
     mockAgentEndpoint({ textChunks: whoIsYourFavoriteResponse });
 
@@ -75,7 +90,7 @@ describe("metabot > feedback", () => {
   });
 
   it("should prevent submission when ui-bug is selected with empty feedback", async () => {
-    const { feedbackEndpoint, modal } = await setup();
+    const { feedbackEndpoint, modal } = await setupWithNegativeFeedback();
 
     await selectIssueType(modal, "UI bug");
     await submitFeedback(modal);
@@ -85,7 +100,7 @@ describe("metabot > feedback", () => {
   });
 
   it("should allow submission when ui-bug is selected with feedback text", async () => {
-    const { feedbackEndpoint, modal } = await setup();
+    const { feedbackEndpoint, modal } = await setupWithNegativeFeedback();
 
     await selectIssueType(modal, "UI bug");
     await typeFeedback(modal, "The button is in the wrong place");
@@ -95,7 +110,7 @@ describe("metabot > feedback", () => {
   });
 
   it("should prevent submission when other is selected with empty feedback", async () => {
-    const { feedbackEndpoint, modal } = await setup();
+    const { feedbackEndpoint, modal } = await setupWithNegativeFeedback();
 
     await selectIssueType(modal, "Other");
     await submitFeedback(modal);
@@ -105,7 +120,7 @@ describe("metabot > feedback", () => {
   });
 
   it("should allow submission when non-required issue types have empty feedback", async () => {
-    const { feedbackEndpoint, modal } = await setup();
+    const { feedbackEndpoint, modal } = await setupWithNegativeFeedback();
 
     await selectIssueType(modal, "Not factually correct");
     await submitFeedback(modal);

--- a/frontend/src/metabase/metabot/tests/utils.tsx
+++ b/frontend/src/metabase/metabot/tests/utils.tsx
@@ -145,10 +145,12 @@ export function setup(
     metabotInitialState?: MetabotState;
     currentUser?: User | null | undefined;
     promptSuggestions?: { prompt: string }[];
+    isHosted?: boolean;
   } | void,
 ) {
   const settings = mockSettings({
     "llm-metabot-configured?": true,
+    "is-hosted?": options?.isHosted ?? false,
     "token-features": createMockTokenFeatures({
       metabot_v3: true,
     }),


### PR DESCRIPTION
[BOT-1212: OSS should not show thumbs up + thumbs down on messages](https://linear.app/metabase/issue/BOT-1212/oss-should-not-show-thumbs-up-thumbs-down-on-messages)
