### PR TITLE
[Metabot] Temporary removal of analyze chart button on dashboard page

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenuItems.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenuItems.tsx
@@ -2,15 +2,12 @@ import { useMemo } from "react";
 import { t } from "ttag";
 
 import { useSdkDashboardContext } from "embedding-sdk-bundle/components/public/dashboard/context";
-import { editQuestion, setSidebar } from "metabase/dashboard/actions";
-import { SIDEBAR_NAME } from "metabase/dashboard/constants";
+import { editQuestion } from "metabase/dashboard/actions";
 import { useDashboardContext } from "metabase/dashboard/context";
 import { transformSdkQuestion } from "metabase/embedding-sdk/lib/transform-question";
 import type { DashboardCardCustomMenuItem } from "metabase/embedding-sdk/types/plugins";
 import { canDownloadResults } from "metabase/lib/downloads";
 import { useDispatch } from "metabase/lib/redux";
-import { useMetabotEnabledEmbeddingAware } from "metabase/metabot/hooks";
-import { canAnalyzeQuestion } from "metabase/metabot/utils/chart-analysis";
 import { Icon, Menu } from "metabase/ui";
 import type Question from "metabase-lib/v1/Question";
 import type { DashCardId, Dataset } from "metabase-types/api";
@@ -33,11 +30,9 @@ export const DashCardMenuItems = ({
   isDownloadingData,
   onDownload,
   onEditVisualization,
-  dashcardId,
   canEdit,
 }: DashCardMenuItemsProps) => {
   const dispatch = useDispatch();
-  const isMetabotEnabled = useMetabotEnabledEmbeddingAware();
 
   const {
     onEditQuestion = (
@@ -108,26 +103,6 @@ export const DashCardMenuItems = ({
       });
     }
 
-    if (
-      isMetabotEnabled &&
-      canAnalyzeQuestion(question.card().display) &&
-      dashcardId != null
-    ) {
-      items.push({
-        key: "MB_ANALYZE_CHART",
-        iconName: "metabot",
-        label: t`Analyze chart`,
-        onClick: () => {
-          dispatch(
-            setSidebar({
-              name: SIDEBAR_NAME.analyze,
-              props: { dashcardId },
-            }),
-          );
-        },
-      });
-    }
-
     if (customItems) {
       items.push(
         ...customItems.map((item) => {
@@ -148,7 +123,6 @@ export const DashCardMenuItems = ({
   }, [
     customItems,
     isDownloadingData,
-    isMetabotEnabled,
     onDownload,
     onEditQuestion,
     question,
@@ -156,8 +130,6 @@ export const DashCardMenuItems = ({
     withDownloads,
     withEditLink,
     onEditVisualization,
-    dashcardId,
-    dispatch,
     canEdit,
   ]);
 


### PR DESCRIPTION
[BOT-1213: Analyze chart button on dashboards does not work](https://linear.app/metabase/issue/BOT-1213/analyze-chart-button-on-dashboards-does-not-work)

We need to make this work properly, we broke it in the clojure port of ai-service. In the mean time, let's remove the button.