### PR TITLE
BOT-1199 ORDERS table link points to an invalid path

### DIFF
--- a/resources/metabot/prompts/system/internal.selmer
+++ b/resources/metabot/prompts/system/internal.selmer
@@ -389,9 +389,11 @@ Examples of CORRECT links:
 ✓ [Regional Sales Breakdown](metabase://chart/8f26466c-164c-4e06-a1e7-1dfcce99b08b)
 ✓ [Customer Dashboard](metabase://dashboard/123)
 ✓ [Total Revenue Metric](metabase://metric/456)
+✓ [Orders Table](metabase://table/789)
 
 Examples of WRONG links (DO NOT USE):
 ✗ [Regional Sales](/chart/8f26466c-164c-4e06-a1e7-1dfcce99b08b) ← Missing metabase:// protocol
+✗ [Customers](/table/456) ← Missing metabase:// protocol, not a valid link
 ✗ [Chart 123](metabase://chart/123) ← Not descriptive
 
 ALWAYS:

--- a/src/metabase/metabot/agent/links.clj
+++ b/src/metabase/metabot/agent/links.clj
@@ -105,10 +105,9 @@
   (memoize/ttl
    (fn [table-id]
      (let [parsed-id (cond
-                       (int? table-id) table-id
-                       (string? table-id) (when (re-matches #"\d+" table-id)
-                                            (parse-long table-id))
-                       :else nil)]
+                       (int? table-id)    table-id
+                       (string? table-id) (parse-long table-id)
+                       :else              nil)]
        (if-not parsed-id
          (do
            (log/warn "Invalid table id for link resolution" {:table-id table-id})

--- a/src/metabase/metabot/agent/links.clj
+++ b/src/metabase/metabot/agent/links.clj
@@ -4,10 +4,13 @@
   (:require
    [buddy.core.codecs :as codecs]
    [clojure.string :as str]
+   [metabase.lib-be.metadata.jvm :as lib.metadata.jvm]
    [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
    [metabase.system.core :as system]
    [metabase.util.json :as json]
-   [metabase.util.log :as log]))
+   [metabase.util.log :as log]
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -92,9 +95,9 @@
       nil)))
 
 (defn- resolve-table-link
-  "Resolve a metabase://table/{id} link to a table page URL.
-  Note: This differs from ai-service (which links to /question#... by fetching database_id).
-  We avoid a DB lookup during streaming by linking directly to the table."
+  "Resolve a metabase://table/{id} link to an ad-hoc question URL.
+  Looks up the table's database_id and generates a /question#<base64> URL
+  with a query using that table as the source table."
   [table-id]
   (let [parsed-id (cond
                     (int? table-id) table-id
@@ -105,7 +108,14 @@
       (do
         (log/warn "Invalid table id for link resolution" {:table-id table-id})
         nil)
-      (str "/table/" parsed-id))))
+      (if-let [db-id (t2/select-one-fn :db_id :model/Table :id parsed-id)]
+        (let [mp    (lib.metadata.jvm/application-database-metadata-provider db-id)
+              table (lib.metadata/table mp parsed-id)
+              query (lib/query mp table)]
+          (str "/question#" (query->url-hash query)))
+        (do
+          (log/warn "Table not found for link resolution" {:table-id parsed-id})
+          nil)))))
 
 ;;; Main Link Resolution
 

--- a/src/metabase/metabot/agent/links.clj
+++ b/src/metabase/metabot/agent/links.clj
@@ -3,11 +3,13 @@
   Converts internal metabase:// links to proper Metabase URLs using agent memory state."
   (:require
    [buddy.core.codecs :as codecs]
+   [clojure.core.memoize :as memoize]
    [clojure.string :as str]
    [metabase.lib-be.metadata.jvm :as lib.metadata.jvm]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.system.core :as system]
+   [metabase.util :as u]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
    [toucan2.core :as t2]))
@@ -94,28 +96,32 @@
       (log/warn "Unknown entity type for link" {:type entity-type :id entity-id})
       nil)))
 
-(defn- resolve-table-link
+(def ^:private resolve-table-link
   "Resolve a metabase://table/{id} link to an ad-hoc question URL.
   Looks up the table's database_id and generates a /question#<base64> URL
-  with a query using that table as the source table."
-  [table-id]
-  (let [parsed-id (cond
-                    (int? table-id) table-id
-                    (string? table-id) (when (re-matches #"\d+" table-id)
-                                         (parse-long table-id))
-                    :else nil)]
-    (if-not parsed-id
-      (do
-        (log/warn "Invalid table id for link resolution" {:table-id table-id})
-        nil)
-      (if-let [db-id (t2/select-one-fn :db_id :model/Table :id parsed-id)]
-        (let [mp    (lib.metadata.jvm/application-database-metadata-provider db-id)
-              table (lib.metadata/table mp parsed-id)
-              query (lib/query mp table)]
-          (str "/question#" (query->url-hash query)))
-        (do
-          (log/warn "Table not found for link resolution" {:table-id parsed-id})
-          nil)))))
+  with a query using that table as the source table.
+
+  Results are cached for 10 minutes."
+  (memoize/ttl
+   (fn [table-id]
+     (let [parsed-id (cond
+                       (int? table-id) table-id
+                       (string? table-id) (when (re-matches #"\d+" table-id)
+                                            (parse-long table-id))
+                       :else nil)]
+       (if-not parsed-id
+         (do
+           (log/warn "Invalid table id for link resolution" {:table-id table-id})
+           nil)
+         (if-let [db-id (t2/select-one-fn :db_id :model/Table :id parsed-id)]
+           (let [mp    (lib.metadata.jvm/application-database-metadata-provider db-id)
+                 table (lib.metadata/table mp parsed-id)
+                 query (lib/query mp table)]
+             (str "/question#" (query->url-hash query)))
+           (do
+             (log/warn "Table not found for link resolution" {:table-id parsed-id})
+             nil)))))
+   :ttl/threshold (u/minutes->ms 10)))
 
 ;;; Main Link Resolution
 

--- a/src/metabase/metabot/agent/links.clj
+++ b/src/metabase/metabot/agent/links.clj
@@ -5,7 +5,7 @@
    [buddy.core.codecs :as codecs]
    [clojure.core.memoize :as memoize]
    [clojure.string :as str]
-   [metabase.lib-be.metadata.jvm :as lib.metadata.jvm]
+   [metabase.lib-be.core :as lib-be]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.system.core :as system]
@@ -113,7 +113,7 @@
            (log/warn "Invalid table id for link resolution" {:table-id table-id})
            nil)
          (if-let [db-id (t2/select-one-fn :db_id :model/Table :id parsed-id)]
-           (let [mp    (lib.metadata.jvm/application-database-metadata-provider db-id)
+           (let [mp    (lib-be/application-database-metadata-provider db-id)
                  table (lib.metadata/table mp parsed-id)
                  query (lib/query mp table)]
              (str "/question#" (query->url-hash query)))

--- a/test/metabase/metabot/agent/links_test.clj
+++ b/test/metabase/metabot/agent/links_test.clj
@@ -31,8 +31,15 @@
     (is (= "/metric/456" (links/resolve-metabase-uri "metabase://metric/456" {} {})))
     (is (= "/dashboard/789" (links/resolve-metabase-uri "metabase://dashboard/789" {} {})))
     (is (= "/question/101" (links/resolve-metabase-uri "metabase://question/101" {} {})))
-    (is (= "/admin/transforms/202" (links/resolve-metabase-uri "metabase://transform/202" {} {})))
-    (is (= "/table/123" (links/resolve-metabase-uri "metabase://table/123" {} {})))))
+    (is (= "/admin/transforms/202" (links/resolve-metabase-uri "metabase://transform/202" {} {})))))
+
+(deftest ^:parallel resolve-metabase-uri-table-link-test
+  (testing "resolves table links to ad-hoc question URLs"
+    (let [result (links/resolve-metabase-uri (str "metabase://table/" (mt/id :venues)) {} {})]
+      (is (string? result))
+      (is (str/starts-with? result "/question#"))))
+  (testing "returns nil for non-existent table"
+    (is (nil? (links/resolve-metabase-uri "metabase://table/999999999" {} {})))))
 
 (deftest ^:parallel resolve-metabase-uri-unknown-entity-type-test
   (testing "returns nil for unknown entity types"
@@ -372,13 +379,12 @@
       (is (= 1 (count @registry)))
       (is (= "metabase://query/q1" (get @registry resolved-url))))))
 
-(deftest ^:parallel resolve-links-records-dashboard-table-transform-links-test
-  (testing "records dashboard, table, and transform links"
+(deftest ^:parallel resolve-links-records-dashboard-transform-links-test
+  (testing "records dashboard and transform links"
     (let [registry (atom {})
-          text     "[Dash](metabase://dashboard/10) [Tbl](metabase://table/20) [Tx](metabase://transform/30)"
+          text     "[Dash](metabase://dashboard/10) [Tx](metabase://transform/30)"
           _result  (links/resolve-links text {} {} registry)]
       (is (= {"/dashboard/10"        "metabase://dashboard/10"
-              "/table/20"            "metabase://table/20"
               "/admin/transforms/30" "metabase://transform/30"}
              @registry)))))
 
@@ -459,12 +465,13 @@
       (is (= original inverted)))))
 
 (deftest ^:parallel round-trip-mixed-link-types-test
-  (testing "round-trip: mixed link types"
+  (testing "round-trip: mixed link types including table"
     (let [query-id      "q1"
           queries-state {query-id (lib.tu/venues-query)}
+          table-id      (mt/id :venues)
           original      (str "See [Model](metabase://model/1), "
                              "[Query](metabase://query/q1), and "
-                             "[Table](metabase://table/42)")
+                             "[Table](metabase://table/" table-id ")")
           registry      (atom {})
           resolved      (links/resolve-links original queries-state {} registry)
           inverted      (links/invert-links resolved @registry)]

--- a/test/metabase/metabot/agent/markdown_link_buffer_test.clj
+++ b/test/metabase/metabot/agent/markdown_link_buffer_test.clj
@@ -125,6 +125,18 @@
       (is (= "Chart" output))
       (is (= "" flushed)))))
 
+(deftest ^:parallel resolve-table-link-test
+  (testing "resolves metabase://table links to ad-hoc question URLs"
+    (let [table-id (mt/id :venues)
+          [output flushed] (process (str "[Users Table](metabase://table/" table-id ")"))]
+      (is (re-find #"\[Users Table\]\(/question#.+\)" output))
+      (is (= "" flushed))))
+
+  (testing "falls back to link text for unknown table"
+    (let [[output flushed] (process "[Unknown Table](metabase://table/999999999)")]
+      (is (= "Unknown Table" output))
+      (is (= "" flushed)))))
+
 (deftest ^:parallel resolve-entity-link-test
   (testing "resolves metabase://model links"
     (let [[output flushed] (process "[My Model](metabase://model/123)")]
@@ -139,11 +151,6 @@
   (testing "resolves metabase://dashboard links"
     (let [[output flushed] (process "[Sales Dashboard](metabase://dashboard/789)")]
       (is (= "[Sales Dashboard](/dashboard/789)" output))
-      (is (= "" flushed))))
-
-  (testing "resolves metabase://table links"
-    (let [[output flushed] (process "[Users Table](metabase://table/42)")]
-      (is (= "[Users Table](/table/42)" output))
       (is (= "" flushed)))))
 
 (deftest ^:parallel resolve-link-split-across-chunks-test


### PR DESCRIPTION
Closes [BOT-1199 ORDERS table link points to an invalid path](https://linear.app/metabase/issue/BOT-1199/orders-table-link-points-to-an-invalid-path)

### Description

* Add table-specific examples to the link examples section of the internal metabot system prompt
* Fix `metabase.metabot.agent.links/resolve-table-link` to resolve to valid ad-hoc question link

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
