### PR TITLE
metabot llm calls: tools are optional/maybe

### DIFF
--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -46,7 +46,7 @@
    [:model       {:optional true} :string]
    [:system      {:optional true} [:maybe :string]]
    [:input       {:optional true} [:sequential :map]]
-   [:tools       {:optional true} [:sequential ToolEntry]]
+   [:tools       {:optional true} [:maybe [:sequential ToolEntry]]]
    [:tool_choice {:optional true} [:maybe [:enum "auto" "required"]]]
    [:temperature {:optional true} [:maybe number?]]
    [:max-tokens  {:optional true} [:maybe :int]]
@@ -94,6 +94,9 @@
                 (recur acc)
 
                 (str/starts-with? line ":")
+                (recur acc)
+
+                (str/starts-with? line "event:")
                 (recur acc)
 
                 :else

--- a/test/metabase/metabot/test_util.clj
+++ b/test/metabase/metabot/test_util.clj
@@ -53,10 +53,14 @@
 ;;; ──────────────────────────────────────────────────────────────────
 
 (defn make-sse
-  "Encode a sequence of values as an SSE data stream string."
+  "Encode a sequence of values as an SSE data stream string.
+  Includes `event:` lines like the real Anthropic/OpenAI APIs do."
   ^String [v]
-  (->> (map json/encode v)
-       (map #(str "data: " % "\n\n"))
+  (->> v
+       (map (fn [item]
+              (let [event-type (or (some-> (:type item) name)
+                                   "message")]
+                (str "event: " event-type "\ndata: " (json/encode item) "\n\n"))))
        (str/join)))
 
 ;;; ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
When tools are not provided, they now come as `{:tools nil}` and that breaks the call, at least in dev.

Also silenced warnings on `event: ...` lines in SSE which we don't use for parsing actual responses.