### PR TITLE
don't recompute sensible chart groupings while sidebar is mounted

### DIFF
--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/hooks/use-sensible-visualizations.ts
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/hooks/use-sensible-visualizations.ts
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useRef } from "react";
 
 import { getSensibleVisualizations } from "metabase/query_builder/components/chart-type-selector";
 
@@ -9,9 +9,11 @@ export const useSensibleVisualizations = () => {
 
   const result = queryResults?.[0];
 
+  const initialResultRef = useRef(result);
   const { sensibleVisualizations, nonSensibleVisualizations } = useMemo(
-    () => getSensibleVisualizations({ result }),
-    [result],
+    () => getSensibleVisualizations({ result: initialResultRef.current }),
+
+    [],
   );
 
   return {

--- a/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar/ChartTypeSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar/ChartTypeSidebar.tsx
@@ -1,5 +1,5 @@
 import cx from "classnames";
-import { useMemo } from "react";
+import { useMemo, useRef } from "react";
 import { t } from "ttag";
 
 import { SidebarContent } from "metabase/common/components/SidebarContent";
@@ -45,9 +45,11 @@ export const ChartTypeSidebar = ({
     }
   };
 
+  // Pinned to mount so chart type grouping stays stable while browsing (metabase#70013)
+  const initialResultRef = useRef(result);
   const { sensibleVisualizations, nonSensibleVisualizations } = useMemo(
-    () => getSensibleVisualizations({ result }),
-    [result],
+    () => getSensibleVisualizations({ result: initialResultRef.current }),
+    [],
   );
 
   const { selectedVisualization, updateQuestionVisualization } =

--- a/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar/ChartTypeSidebar.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar/ChartTypeSidebar.unit.spec.tsx
@@ -1,0 +1,53 @@
+import { renderWithProviders, screen, within } from "__support__/ui";
+import registerVisualizations from "metabase/visualizations/register";
+import type { Dataset } from "metabase-types/api";
+import { createMockDataset } from "metabase-types/api/mocks";
+
+import { ChartTypeSidebar } from "./ChartTypeSidebar";
+
+registerVisualizations();
+
+const createResult = (insights: any[] | undefined): Dataset =>
+  createMockDataset({
+    data: {
+      rows: [[1]],
+      cols: [{ name: "count", base_type: "type/Integer" }] as any,
+      insights,
+    },
+  });
+
+const setup = (result: Dataset) => {
+  return renderWithProviders(
+    <ChartTypeSidebar question={null as any} result={result} />,
+  );
+};
+
+const getSensibleChartNames = () => {
+  const sensibleList = screen.getByTestId("display-options-sensible");
+  return within(sensibleList)
+    .getAllByRole("option")
+    .map((el) => el.getAttribute("aria-label"));
+};
+
+describe("ChartTypeSidebar", () => {
+  it("should not change the sensible chart list when result changes", () => {
+    const resultWithInsights = createResult([
+      { col: "count", unit: "month", "last-value": 1 },
+    ]);
+
+    const { rerender } = setup(resultWithInsights);
+    const initialCharts = getSensibleChartNames();
+
+    // Simulate what happens when pivot is selected — result loses insights
+    const resultWithoutInsights = createResult(undefined);
+
+    rerender(
+      <ChartTypeSidebar
+        question={null as any}
+        result={resultWithoutInsights}
+      />,
+    );
+
+    expect(getSensibleChartNames()).toEqual(initialCharts);
+  });
+});


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #70013
Closes UXW-3170

### Description
Adjusts the ChartTypeSidebar to only compute sensible viz types for a result dataset on mount. This allows us to pick viz types that change the result dataset (currently only pivot I think) without having the elements shift around. Though, if you go into the settings and return, the list may have changed, since the component has re-mounted

### How to verify
1. New -> Question
2. Take the orders table, and count by month
3. Hit visualize and open the viz type picker
4. You can now select pivot without the groupings changing. Before, trend would disappear.

### Demo


https://github.com/user-attachments/assets/aac2171a-88bd-4d47-8e6c-19bc0a6bf781



### Checklist

- [x] Tests have been added/updated to cover changes in this PR
