### PR TITLE
GDGT-1930: Custom viz l10n — expose locale to plugins, support JSON/glob assets

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/custom_viz/custom-viz-plugins.ts
+++ b/enterprise/frontend/src/metabase-enterprise/custom_viz/custom-viz-plugins.ts
@@ -291,7 +291,12 @@ export async function loadCustomVizPlugin(
     const cacheBust = cacheBustSuffix ? `&t=${Date.now()}` : "";
     const getAssetUrl = (path: string) =>
       `${getPluginAssetUrl(plugin.id, path) ?? ""}${cacheBust}`;
+    const locale =
+      window.MetabaseUserLocalization?.headers?.language ??
+      window.MetabaseSiteLocalization?.headers?.language ??
+      "en";
     const props = buildCustomVizProps({
+      locale,
       measureText,
       measureTextWidth,
       measureTextHeight,

--- a/enterprise/frontend/src/metabase-enterprise/custom_viz/custom-viz-plugins.ts
+++ b/enterprise/frontend/src/metabase-enterprise/custom_viz/custom-viz-plugins.ts
@@ -9,9 +9,7 @@ import {
   measureTextHeight,
   measureTextWidth,
 } from "metabase/lib/measure-text";
-import visualizations, {
-  registerVisualization,
-} from "metabase/visualizations";
+import visualizations, { registerVisualization } from "metabase/visualizations";
 import type { Visualization } from "metabase/visualizations/types/visualization";
 import type {
   CustomVizPluginRuntime,

--- a/enterprise/frontend/src/metabase-enterprise/custom_viz/custom-viz-plugins.ts
+++ b/enterprise/frontend/src/metabase-enterprise/custom_viz/custom-viz-plugins.ts
@@ -9,7 +9,9 @@ import {
   measureTextHeight,
   measureTextWidth,
 } from "metabase/lib/measure-text";
-import visualizations, { registerVisualization } from "metabase/visualizations";
+import visualizations, {
+  registerVisualization,
+} from "metabase/visualizations";
 import type { Visualization } from "metabase/visualizations/types/visualization";
 import type {
   CustomVizPluginRuntime,

--- a/enterprise/frontend/src/metabase-enterprise/custom_viz/custom-viz-props.ts
+++ b/enterprise/frontend/src/metabase-enterprise/custom_viz/custom-viz-props.ts
@@ -13,6 +13,7 @@ type TextWidthMeasurer = (text: string, style: FontStyle) => number;
 type TextHeightMeasurer = (text: string, style: FontStyle) => number;
 
 interface BuildCustomVizPropsOptions {
+  locale: string;
   measureText: TextMeasurer;
   measureTextWidth: TextWidthMeasurer;
   measureTextHeight: TextHeightMeasurer;
@@ -23,6 +24,7 @@ export function buildCustomVizProps(
   opts: BuildCustomVizPropsOptions,
 ): CreateCustomVisualizationProps {
   return {
+    locale: opts.locale,
     translate: (text: string) => t`${text}`,
     columnTypes: {
       isDate: isa.isDate,

--- a/frontend/src/custom-viz/src/types/viz.ts
+++ b/frontend/src/custom-viz/src/types/viz.ts
@@ -18,6 +18,11 @@ export type CreateCustomVisualization<CustomVisualizationSettings> = (
 
 export type CreateCustomVisualizationProps = {
   /**
+   * Current user's locale (e.g., "de", "ja", "en").
+   */
+  locale: string;
+
+  /**
    * Translates text using ttag function used in Metabase.
    */
   translate: (text: string) => string;

--- a/frontend/src/types/global.d.ts
+++ b/frontend/src/types/global.d.ts
@@ -1,8 +1,21 @@
+interface MetabaseLocalization {
+  headers: {
+    language: string;
+    "plural-forms"?: string;
+  };
+  translations: Record<
+    string,
+    Record<string, { msgid?: string; msgstr: string[] }>
+  >;
+}
+
 interface Window {
   MetabaseBootstrap: any;
   MetabaseRoot?: string;
   MetabaseNonce?: string;
   MetabaseUserColorScheme?: string;
+  MetabaseSiteLocalization?: MetabaseLocalization;
+  MetabaseUserLocalization?: MetabaseLocalization;
 
   overrideIsWithinIframe?: boolean; // Mock that we're embedding, so we could test embed components
   METABASE?: boolean; // Add a global so we can check if the parent iframe is Metabase

--- a/src/metabase/custom_viz_plugin/api.clj
+++ b/src/metabase/custom_viz_plugin/api.clj
@@ -204,12 +204,18 @@
     (catch Throwable e
       (raise e))))
 
-(defn- image-content-type
-  "Return the MIME content type for an image file, or nil if not a recognized image."
+(defn- asset-content-type
+  "Return the MIME content type for an allowed asset file, or nil if not recognized.
+   Allows image files and JSON files (for locale translations)."
   [^String path]
-  (let [ct (java.net.URLConnection/guessContentTypeFromName path)]
-    (when (and ct (str/starts-with? ct "image/"))
-      ct)))
+  (cond
+    (str/ends-with? path ".json")
+    "application/json"
+
+    :else
+    (let [ct (java.net.URLConnection/guessContentTypeFromName path)]
+      (when (and ct (str/starts-with? ct "image/"))
+        ct))))
 
 (defn- validate-asset-path
   "Validate that an asset path is a simple filename (no directory traversal).
@@ -238,9 +244,9 @@
   (check-custom-viz-enabled)
   (try
     (let [asset-path   (validate-asset-path path)
-          content-type (image-content-type asset-path)]
+          content-type (asset-content-type asset-path)]
       (when-not content-type
-        (throw (ex-info "Only image assets are served" {:status-code 404})))
+        (throw (ex-info "Unsupported asset type" {:status-code 404})))
       (let [_plugin (api/check-404 (t2/select-one :model/CustomVizPlugin :id id))
             dev?    (contains? @dev-bundle-urls id)
             bytes   (cache/resolve-asset id asset-path)]

--- a/src/metabase/custom_viz_plugin/cache.clj
+++ b/src/metabase/custom_viz_plugin/cache.clj
@@ -106,15 +106,27 @@
     (< (/ (- (System/nanoTime) last-failure-ns) 1e6)
        fetch-failure-cooldown-ms)))
 
+(defn- repo-asset-paths
+  "List all file paths under `dist/assets/` in the repo, returned relative to that prefix."
+  [conn commit-sha]
+  (let [prefix "dist/assets/"]
+    (->> (git/list-files conn commit-sha)
+         (filter #(str/starts-with? % prefix))
+         (map #(subs % (count prefix))))))
+
 (defn- fetch-and-cache-assets!
   "Fetch and cache static assets from the plugin repo based on the manifest whitelist.
-   Asset names from the manifest (e.g. `icon.svg`) map to `dist/assets/<name>` in the repo."
+   Asset names from the manifest (e.g. `icon.svg`) map to `dist/assets/<name>` in the repo.
+   Supports glob patterns (e.g. `locales/*`) which are expanded against available files."
   [conn commit-sha plugin-id parsed-manifest]
   (when parsed-manifest
-    (doseq [asset-name (manifest/asset-paths parsed-manifest)]
-      (when-let [bytes (git/read-file-bytes conn commit-sha (str "dist/assets/" asset-name))]
-        (swap! asset-cache assoc-in [plugin-id asset-name] bytes)
-        (write-asset-to-disk! plugin-id asset-name bytes)))))
+    (let [declared     (manifest/asset-paths parsed-manifest)
+          available    (repo-asset-paths conn commit-sha)
+          asset-names  (manifest/expand-globs declared available)]
+      (doseq [asset-name asset-names]
+        (when-let [bytes (git/read-file-bytes conn commit-sha (str "dist/assets/" asset-name))]
+          (swap! asset-cache assoc-in [plugin-id asset-name] bytes)
+          (write-asset-to-disk! plugin-id asset-name bytes))))))
 
 (defn fetch-and-cache!
   "Fetch index.js and manifest from the plugin's git repo, update both caches and DB record.

--- a/src/metabase/custom_viz_plugin/manifest.clj
+++ b/src/metabase/custom_viz_plugin/manifest.clj
@@ -6,6 +6,7 @@
    [metabase.config.core :as config]
    [metabase.util.log :as log])
   (:import
+   (java.nio.file FileSystems)
    (org.semver4j Semver SemverException)))
 
 (set! *warn-on-reflection* true)
@@ -57,13 +58,52 @@
   (let [lower (str/lower-case path)]
     (some #(str/ends-with? lower %) image-extensions)))
 
+(def ^:private allowed-asset-extensions
+  "File extensions allowed for static asset serving (images + locale JSON)."
+  (into image-extensions #{".json"}))
+
+(defn- allowed-asset-file?
+  "Returns true if the file path has a recognized allowed extension."
+  [^String path]
+  (let [lower (str/lower-case path)]
+    (some #(str/ends-with? lower %) allowed-asset-extensions)))
+
+(defn- glob?
+  "Returns true if the path contains glob characters (*, ?, or {})."
+  [^String path]
+  (boolean (re-find #"[*?\[\{]" path)))
+
+(defn- path-matcher
+  "Create a java.nio.file PathMatcher for a glob pattern."
+  [^String pattern]
+  (.getPathMatcher (FileSystems/getDefault) (str "glob:" pattern)))
+
+(defn expand-globs
+  "Expand glob patterns in asset paths against a list of available file paths.
+   Non-glob paths are returned as-is (if they have an allowed extension).
+   Glob paths are matched against `available-paths` and only matches with
+   allowed extensions are returned."
+  [asset-entries available-paths]
+  (let [{globs true literals false} (group-by glob? asset-entries)]
+    (distinct
+     (concat
+      (filter allowed-asset-file? literals)
+      (when (seq globs)
+        (let [matchers (map path-matcher globs)]
+          (filter (fn [^String path]
+                    (and (allowed-asset-file? path)
+                         (let [p (java.nio.file.Path/of path (into-array String []))]
+                           (some #(.matches ^java.nio.file.PathMatcher % p) matchers))))
+                  available-paths)))))))
+
 (defn asset-paths
-  "List the static image asset names whitelisted by the manifest.
+  "List the static asset names whitelisted by the manifest.
    Includes names from the `assets` array and the `icon` (if it's an image filename).
-   Only image files are included. Returns simple filenames like `icon.svg`.
-   These map to `dist/assets/<name>` in the repo."
+   Supports glob patterns (e.g. `locales/*`) which are expanded by the caller.
+   Returns literal paths and glob patterns; use [[expand-globs]] to resolve globs
+   against available files."
   [manifest]
-  (let [declared  (filter image-file? (get manifest :assets []))
+  (let [declared  (get manifest :assets [])
         icon-name (when-let [icon (:icon manifest)]
                     (when (image-file? icon) icon))]
     (distinct (concat declared (when icon-name [icon-name])))))


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-1930/custom-viz-l10n

### Description

Adds localization support for custom visualization plugins:

**Frontend:**
- Expose `locale: string` (user locale with site locale fallback) to plugins via `CreateCustomVisualizationProps`
- Add `MetabaseLocalization` type declaration on `Window` for `MetabaseUserLocalization` and `MetabaseSiteLocalization`

**Backend:**
- Allow serving `.json` assets (not just images) from the plugin asset endpoint — needed for locale translation files
- Add glob pattern support in manifest `assets` array (e.g., `"locales/*"`) using `java.nio.file.PathMatcher`, so plugin authors don't need to enumerate every locale file
- Auto-expand globs against repo file listing during `fetch-and-cache-assets!`

Plugin authors can now:
1. Bundle locale files under `dist/assets/locales/{locale}.json`
2. List them in manifest with `"locales/*"`
3. Use `getAssetUrl("locales/" + locale + ".json")` to fetch translations at runtime
4. Handle translation logic in their own code using the provided `locale` prop

### How to verify

1. Create a custom viz plugin with `public/assets/locales/fr.json` containing `{"Hello": "Bonjour"}`
2. Add `"locales/*"` to the manifest `assets` array
3. Register the plugin in Metabase
4. Verify `GET /api/custom-viz-plugin/{id}/asset?path=locales/fr.json` returns the JSON
5. In the plugin factory, check that `props.locale` reflects the current user/site locale