### PR TITLE
Adjust search schemas

### DIFF
--- a/src/metabase/metabot/tools/search.clj
+++ b/src/metabase/metabot/tools/search.clj
@@ -292,8 +292,8 @@
 
 (def ^:private search-schema
   [:map {:closed true}
-   [:semantic_queries {:feature :semantic-search} [:sequential :string]]
-   [:keyword_queries [:sequential :string]]
+   [:semantic_queries {:optional true :feature :semantic-search} [:sequential :string]]
+   [:keyword_queries {:optional true} [:sequential :string]]
    [:entity_types {:optional true}
     [:maybe [:sequential [:enum "table" "model" "metric" "dashboard" "question"]]]]])
 
@@ -305,8 +305,8 @@
 
 (def ^:private sql-search-schema
   [:map {:closed true}
-   [:semantic_queries {:feature :semantic-search} [:sequential :string]]
-   [:keyword_queries [:sequential :string]]
+   [:semantic_queries {:optional true :feature :semantic-search} [:sequential :string]]
+   [:keyword_queries {:optional true} [:sequential :string]]
    [:database_id :int]
    [:entity_types {:optional true}
     [:maybe [:sequential [:enum "table" "model"]]]]])
@@ -320,8 +320,8 @@
 
 (def ^:private nlq-search-schema
   [:map {:closed true}
-   [:semantic_queries {:feature :semantic-search} [:sequential :string]]
-   [:keyword_queries [:sequential :string]]
+   [:semantic_queries {:optional true :feature :semantic-search} [:sequential :string]]
+   [:keyword_queries {:optional true} [:sequential :string]]
    [:entity_types {:optional true}
     [:maybe [:sequential [:enum "model" "metric" "table"]]]]])
 
@@ -334,8 +334,8 @@
 
 (def ^:private transform-search-schema
   [:map {:closed true}
-   [:semantic_queries {:feature :semantic-search} [:sequential :string]]
-   [:keyword_queries [:sequential :string]]
+   [:semantic_queries {:optional true :feature :semantic-search} [:sequential :string]]
+   [:keyword_queries {:optional true} [:sequential :string]]
    [:search_native_query {:optional true} [:maybe :boolean]]
    [:entity_types {:optional true}
     [:maybe [:sequential [:enum "table" "model" "transform"]]]]])


### PR DESCRIPTION
Today I've hit tool call errors as follow:
```
0:"I"
0:" need to check the context of what was previously being"
0:" worked on, and also explore the relevant table structure to"
0:" understand the fields available."
9:{"toolCallId":"toolu_01AV8DCXkf8xXDCaX6xcPYzs","toolName":"search","args":"{\"keyword_queries\":[\"plan\",\"subscription\",\"pro\"]}"}
a:{"toolCallId":"toolu_01AV8DCXkf8xXDCaX6xcPYzs","result":"Invalid tool arguments: {:semantic_queries [\"missing required key, got: nil\"]}","error":"{\"message\":\"Invalid tool arguments: {:semantic_queries [\\\"missing required key, got: nil\\\"]}\",\"type\":\"class clojure.lang.ExceptionInfo\"}"}
f:{"messageId":"msg_01TuXhNgue8kkEVcXSLqJFN8"}
9:{"toolCallId":"toolu_01Ddm9BE6RwEHPnLSJMfM5g7","toolName":"search","args":"{\"keyword_queries\":[\"plan\",\"subscription\",\"pro\"],\"entity_types\":[\"table\",\"model\"]}"}
```

This PR relaxes the schema so it is fine to use just one of those parameters.