### PR TITLE
No request to pulse if user canot manage subscriptions

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeader.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeader.tsx
@@ -19,6 +19,7 @@ import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import { fetchPulseFormInput } from "metabase/notifications/pulse/actions";
 import { getSetting } from "metabase/selectors/settings";
+import { canManageSubscriptions as canManageSubscriptionsSelector } from "metabase/selectors/user";
 import { Flex, Loader } from "metabase/ui";
 import type { Dashboard } from "metabase-types/api";
 
@@ -36,9 +37,10 @@ export const DashboardHeaderInner = ({ dashboard }: DashboardHeaderProps) => {
 
   const dispatch = useDispatch();
   const { isGuestEmbed } = useDashboardContext();
+  const canManageSubscriptions = useSelector(canManageSubscriptionsSelector);
 
   useMount(() => {
-    if (!isGuestEmbed) {
+    if (!isGuestEmbed && canManageSubscriptions) {
       dispatch(fetchPulseFormInput());
     }
   });

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/tests/common.unit.spec.tsx
@@ -1,0 +1,45 @@
+import { waitFor } from "@testing-library/react";
+
+import { findRequests } from "__support__/server-mocks";
+import { PLUGIN_APPLICATION_PERMISSIONS } from "metabase/plugins";
+
+import { setup } from "./setup";
+
+async function getFormInputRequests() {
+  const gets = await findRequests("GET");
+  return gets.filter((req) =>
+    req.url.match(new RegExp("/api/pulse/form_input$")),
+  );
+}
+
+describe("DashboardHeader", () => {
+  describe("pulse form_input request (EMB-967)", () => {
+    it("should fetch pulse form_input when user can manage subscriptions", async () => {
+      await setup({ isAdmin: true, email: true });
+
+      await waitFor(async () => {
+        expect(await getFormInputRequests()).toHaveLength(1);
+      });
+    });
+
+    it("should not fetch pulse form_input when user cannot manage subscriptions", async () => {
+      const original =
+        PLUGIN_APPLICATION_PERMISSIONS.selectors.canManageSubscriptions;
+      PLUGIN_APPLICATION_PERMISSIONS.selectors.canManageSubscriptions = () =>
+        false;
+
+      try {
+        await setup({ isAdmin: false, email: true });
+
+        // Wait for the component to finish mounting, then verify no request was made
+        await waitFor(async () => {
+          const requests = await getFormInputRequests();
+          expect(requests).toHaveLength(0);
+        });
+      } finally {
+        PLUGIN_APPLICATION_PERMISSIONS.selectors.canManageSubscriptions =
+          original;
+      }
+    });
+  });
+});

--- a/frontend/src/metabase/notifications/pulse/actions.ts
+++ b/frontend/src/metabase/notifications/pulse/actions.ts
@@ -51,10 +51,10 @@ export const setEditingPulse = createThunkAction(
           dispatch(setErrorPage(e));
         }
       } else {
-        // HACK: need a way to wait for form_input to finish loading
         let channels = getPulseFormInput(getState())?.channels;
         if (!channels) {
           try {
+            // HACK: need a way to wait for form_input to finish loading
             channels = (await PulseApi.form_input()).channels;
           } catch {
             // form_input can fail when the user lacks subscription

--- a/frontend/src/metabase/notifications/pulse/actions.ts
+++ b/frontend/src/metabase/notifications/pulse/actions.ts
@@ -15,6 +15,7 @@ import { PulseApi } from "metabase/services";
 import type {
   ChannelApiResponse,
   ChannelSpec,
+  ChannelSpecs,
   DashboardSubscription,
   RegularCollectionId,
 } from "metabase-types/api";
@@ -51,12 +52,20 @@ export const setEditingPulse = createThunkAction(
         }
       } else {
         // HACK: need a way to wait for form_input to finish loading
-        const channels =
-          getPulseFormInput(getState())?.channels ||
-          (await PulseApi.form_input()).channels;
-        const defaultChannelSpec = getDefaultChannel(channels) as
-          | ChannelSpec
-          | undefined;
+        let channels = getPulseFormInput(getState())?.channels;
+        if (!channels) {
+          try {
+            channels = (await PulseApi.form_input()).channels;
+          } catch {
+            // form_input can fail when the user lacks subscription
+            // permissions — this is non-critical (EMB-967).
+          }
+        }
+        const defaultChannelSpec = channels
+          ? (getDefaultChannel(channels as ChannelSpecs) as
+              | ChannelSpec
+              | undefined)
+          : undefined;
         return {
           ...NEW_PULSE_TEMPLATE,
           channels: defaultChannelSpec
@@ -121,8 +130,15 @@ export const testPulse = createThunkAction(
 export const fetchPulseFormInput = createThunkAction(
   FETCH_PULSE_FORM_INPUT,
   function () {
-    return async function (): Promise<ChannelApiResponse> {
-      return await PulseApi.form_input();
+    return async function (): Promise<ChannelApiResponse | undefined> {
+      try {
+        return await PulseApi.form_input();
+      } catch {
+        // This request is expected to fail when the user lacks
+        // "Subscriptions and Alerts" permissions. Swallow the error
+        // so it doesn't surface as an unhandled rejection (EMB-967).
+        return undefined;
+      }
     };
   },
 );


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #65536
Closes [EMB-967: React SDK throws invalid unhandled rejection errors when non-critical requests fail](https://linear.app/metabase/issue/EMB-967/react-sdk-throws-invalid-unhandled-rejection-errors-when-non-critical)

### Description

Wraps API call in a try catch, and avoids doing a pulse request if the user cannot manage subscriptions.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
