### PR TITLE
Reject multi statement queries

### DIFF
--- a/docs/developers-guide/driver-changelog.md
+++ b/docs/developers-guide/driver-changelog.md
@@ -4,10 +4,12 @@ title: Driver interface changelog
 
 # Driver Interface Changelog
 
-## Metabase 0.59.0
+## Metabase 0.60.0
 
 - Added `validate-impersonated-query` multimethod. This is used for drivers to perform validation on impersonated native queries.
   It should return the query if it is valid and throw otherwise.
+
+## Metabase 0.59.0
 
 - Added `sql-jdbc.execute/db-type-name` multimethod. Override this method to customize how your SQL JDBC driver
   retrieves database type names from result set metadata. See the `:mysql` implementation for an example of remapping

--- a/docs/developers-guide/driver-changelog.md
+++ b/docs/developers-guide/driver-changelog.md
@@ -6,6 +6,9 @@ title: Driver interface changelog
 
 ## Metabase 0.59.0
 
+- Added `validate-impersonated-query` multimethod. This is used for drivers to perform validation on impersonated native queries.
+  It should return the query if it is valid and throw otherwise.
+
 - Added `sql-jdbc.execute/db-type-name` multimethod. Override this method to customize how your SQL JDBC driver
   retrieves database type names from result set metadata. See the `:mysql` implementation for an example of remapping
   `TINYINT` to `BIT` based on precision.

--- a/enterprise/backend/src/metabase_enterprise/impersonation/middleware.clj
+++ b/enterprise/backend/src/metabase_enterprise/impersonation/middleware.clj
@@ -1,6 +1,7 @@
 (ns metabase-enterprise.impersonation.middleware
   (:require
    [metabase-enterprise.impersonation.driver :as impersonation.driver]
+   [metabase.driver :as driver]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.premium-features.core :as premium-features :refer [defenterprise]]
    ;; legacy usage -- don't do things like this going forward
@@ -17,7 +18,8 @@
                  (lib.metadata/database (qp.store/metadata-provider)))]
     (do
       (premium-features/assert-has-feature :advanced-permissions (tru "Advanced Permissions"))
-      (assoc query :impersonation/role role))
+      (-> (driver/validate-impersonated-query driver/*driver* query)
+          (assoc :impersonation/role role)))
     query))
 
 (defenterprise apply-impersonation-postprocessing

--- a/enterprise/backend/test/metabase_enterprise/impersonation/driver_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/impersonation/driver_test.clj
@@ -1,7 +1,6 @@
 (ns ^:mb/driver-tests metabase-enterprise.impersonation.driver-test
   (:require
    [clojure.java.jdbc :as jdbc]
-   [clojure.set :as set]
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase-enterprise.impersonation.driver :as impersonation.driver]
@@ -13,7 +12,10 @@
    [metabase.driver.settings :as driver.settings]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
    [metabase.query-processor :as qp]
+   [metabase.query-processor.compile :as qp.compile]
    [metabase.request.core :as request]
    [metabase.sync.core :as sync]
    [metabase.test :as mt]
@@ -436,8 +438,7 @@
                      (mt/rows (mt/run-mbql-query venues))))))))))))
 
 (deftest conn-impersonation-column-and-row-test
-  (mt/test-drivers (set/intersection (mt/normal-drivers-with-feature :test/rls-impersonation)
-                                     (mt/normal-drivers-with-feature :test/column-impersonation))
+  (mt/test-drivers (mt/normal-driver-select {:+features [:test/rls-impersonation :test/column-impersonation]})
     (mt/with-premium-features #{:advanced-permissions}
       (let [venues-table (sql.tx/qualify-and-quote driver/*driver* "test-data" "venues")
             products-table (sql.tx/qualify-and-quote driver/*driver* "test-data" "products")
@@ -926,3 +927,47 @@
                        java.lang.Exception
                        (mt/run-mbql-query checkins
                          {:aggregation [[:count]]}))))))))))))
+
+(deftest reject-multiple-and-non-select-statements-impersonation-test
+  (testing "Impersonated native queries with multiple or non-select statements are rejected under impersonation"
+    (mt/test-drivers (mt/normal-drivers-with-feature :connection-impersonation)
+      (mt/with-premium-features #{:advanced-permissions}
+        (let [venues-table (sql.tx/qualify-and-quote driver/*driver* "test-data" "venues")
+              role-a (u/lower-case-en (mt/random-name))]
+          (tx/with-temp-roles! driver/*driver*
+            (impersonation-granting-details driver/*driver* (mt/db))
+            {role-a {venues-table {}}}
+            (impersonation-default-user driver/*driver*)
+            (impersonation-default-role driver/*driver*)
+            (mt/with-temp [:model/Database database {:engine driver/*driver*,
+                                                     :details (impersonation-details driver/*driver* (mt/db))}]
+              (mt/with-db database
+                (when (driver/database-supports? driver/*driver* :connection-impersonation-requires-role nil)
+                  (t2/update! :model/Database :id (mt/id) (assoc-in (mt/db) [:details :role] (impersonation-default-role driver/*driver*))))
+                (sync/sync-database! database {:scan :schema})
+                (impersonation.util-test/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+                                                               :attributes     {"impersonation_attr" role-a}}
+                  (testing "A single SELECT statement works with normal impersonation"
+                    (let [mp (mt/metadata-provider)
+                          run-native-query (fn [table] (->> (-> (lib/query mp (lib.metadata/table mp (mt/id table)))
+                                                                (lib/aggregate (lib/count)))
+                                                            (qp.compile/compile-with-inline-parameters)
+                                                            :query
+                                                            (lib/native-query mp)
+                                                            (qp/process-query)
+                                                            (mt/rows)))]
+                      (is (= [[100]] (run-native-query :venues)))
+                      (is (thrown? java.lang.Exception (run-native-query :checkins)))))
+                  (testing "All other queries are rejected"
+                    (are [sql] (thrown?
+                                java.lang.Exception
+                                (-> (lib/native-query (mt/metadata-provider) sql)
+                                    (qp/process-query)
+                                    (mt/rows)))
+                      "SELECT ("
+                      "SELECT 1; SELECT 2"
+                      "SET ROLE NONE"
+                      "DROP TABLE table"
+                      "SET ROLE NONE; DROP TABLE table"
+                      "SELECT set_config('role', 'none', false); DROP TABLE table"
+                      "DO $$ BEGIN EXECUTE 'SET ROLE NONE; DROP TABLE table'; END $$;")))))))))))

--- a/enterprise/backend/test/metabase_enterprise/impersonation/driver_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/impersonation/driver_test.clj
@@ -930,7 +930,8 @@
 
 (deftest reject-multiple-and-non-select-statements-impersonation-test
   (testing "Impersonated native queries with multiple or non-select statements are rejected under impersonation"
-    (mt/test-drivers (mt/normal-drivers-with-feature :connection-impersonation)
+    #_{:clj-kondo/ignore [:metabase/disallow-hardcoded-driver-names-in-tests]}
+    (mt/test-drivers (disj (mt/normal-drivers-with-feature :connection-impersonation) :postgres) ;; Postgres is only fixed in >= 60
       (mt/with-premium-features #{:advanced-permissions}
         (let [venues-table (sql.tx/qualify-and-quote driver/*driver* "test-data" "venues")
               role-a (u/lower-case-en (mt/random-name))]

--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -758,3 +758,7 @@
 
 (defmethod driver/llm-sql-dialect-resource :redshift [_]
   "llm/prompts/dialects/redshift.md")
+
+(defmethod driver/validate-impersonated-query :redshift
+  [driver query]
+  (driver.sql/validate-impersonated-query* driver query))

--- a/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
+++ b/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
@@ -1185,3 +1185,7 @@
 
 (defmethod driver/llm-sql-dialect-resource :sqlserver [_]
   "llm/prompts/dialects/sqlserver.md")
+
+(defmethod driver/validate-impersonated-query :sqlserver
+  [driver query]
+  (driver.sql/validate-impersonated-query* driver query))

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -1835,3 +1835,11 @@
   {:added "0.59.0" :arglists '([driver database test-table])}
   dispatch-on-initialized-driver
   :hierarchy #'hierarchy)
+
+(defmulti validate-impersonated-query
+  "Validates a query for impersonation. Returns the query if it is valid and throws otherwise."
+  {:added "0.60.0" :arglists '([driver query])}
+  dispatch-on-initialized-driver
+  :hierarchy #'hierarchy)
+
+(defmethod validate-impersonated-query :default [_driver query] query)

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -1389,7 +1389,3 @@
 
 (defmethod driver/llm-sql-dialect-resource :postgres [_]
   "llm/prompts/dialects/postgresql.md")
-
-(defmethod driver/validate-impersonated-query :postgres
-  [driver query]
-  (driver.sql/validate-impersonated-query* driver query))

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -1389,3 +1389,7 @@
 
 (defmethod driver/llm-sql-dialect-resource :postgres [_]
   "llm/prompts/dialects/postgresql.md")
+
+(defmethod driver/validate-impersonated-query :postgres
+  [driver query]
+  (driver.sql/validate-impersonated-query* driver query))

--- a/src/metabase/driver/sql.clj
+++ b/src/metabase/driver/sql.clj
@@ -1,6 +1,6 @@
 (ns metabase.driver.sql
   "Shared code for all drivers that use SQL under the hood."
-  (:refer-clojure :exclude [some])
+  (:refer-clojure :exclude [some mapv])
   (:require
    [clojure.set :as set]
    ;; TODO (Cam 10/1/25) -- Isn't having drivers use Macaw directly against the spirt of all the work we did to make a
@@ -17,11 +17,18 @@
    [metabase.driver.sql.references :as sql.references]
    [metabase.driver.sql.util :as sql.u]
    [metabase.driver.util :as driver.u]
+   [metabase.lib.util :as lib.util]
    [metabase.util.humanization :as u.humanization]
+   [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.performance :refer [some]]
-   [potemkin :as p]))
+   [metabase.util.performance :refer [some mapv]]
+   [potemkin :as p])
+  (:import
+   [net.sf.jsqlparser.parser CCJSqlParserUtil]
+   [net.sf.jsqlparser.statement.select PlainSelect Select]))
+
+(set! *warn-on-reflection* true)
 
 (comment sql.params.substitution/keep-me) ; this is so `cljr-clean-ns` and the linter don't remove the `:require`
 
@@ -407,3 +414,35 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 (p/import-vars [sql.params.substitution ->prepared-substitution PreparedStatementSubstitution])
+
+(defn- is-single-select-stmt?
+  "Parses a query and checks that it is a single SELECT statement.
+   Also returns the query reconstructed from the parsed AST.
+
+   We're using JSqlParser because macaw doesn't handle SQL strings containing multiple statements
+   such as `SELECT 1; SELECT 2`. This should be updated to use SQLGlot in a version that has it."
+  [sql]
+  (try
+    (let [stmts (CCJSqlParserUtil/parseStatements sql)]
+      (cond-> {:is-single-select? false}
+        (and (= 1 (count stmts)) (some #(instance? % (first stmts)) [PlainSelect Select]))
+        (assoc :is-single-select? true :sql (.toString ^Object (first stmts)))))
+    (catch Exception e
+      {:is-single-select? false :error (.getMessage e)})))
+
+(defn validate-impersonated-query*
+  "Validates a native query by parsing it and ensuring that it is a single select statement."
+  [_driver query]
+  (update query :stages
+          (fn [stages]
+            (mapv (fn [stage]
+                    (if (lib.util/native-stage? stage)
+                      (let [{:keys [is-single-select? sql error]} (is-single-select-stmt? (:native stage))]
+                        (when error
+                          (log/warnf "Failed to parse native query: %s\n: Query: %s" error (:native stage)))
+                        (if is-single-select?
+                          (assoc stage :native sql)
+                          (throw (ex-info (tru "Invalid impersonated native query. Must be a single select statement.")
+                                          {:sql (:native stage)}))))
+                      stage))
+                  stages))))

--- a/src/metabase/driver/sql.clj
+++ b/src/metabase/driver/sql.clj
@@ -426,7 +426,7 @@
     (let [stmts (CCJSqlParserUtil/parseStatements sql)]
       (cond-> {:is-single-select? false}
         (and (= 1 (count stmts)) (some #(instance? % (first stmts)) [PlainSelect Select]))
-        (assoc :is-single-select? true :sql (.toString ^Object (first stmts)))))
+        (assoc :is-single-select? true :sql (str (first stmts)))))
     (catch Exception e
       {:is-single-select? false :error (.getMessage e)})))
 

--- a/test/metabase/driver/sql_test.clj
+++ b/test/metabase/driver/sql_test.clj
@@ -1,0 +1,36 @@
+(ns ^:mb/driver-tests metabase.driver.sql-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.driver.sql :as driver.sql]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
+   [metabase.query-processor.compile :as qp.compile]
+   [metabase.test :as mt]))
+
+(deftest ^:parallel is-single-select-stmt?-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :connection-impersonation)
+    (let [mp (mt/metadata-provider)
+          products (lib.metadata/table mp (mt/id :products))
+          orders (lib.metadata/table mp (mt/id :orders))
+          query (-> (lib/query mp products)
+                    (lib/join (lib/join-clause orders [(lib/= (mt/id :products :id)
+                                                              (mt/id :orders :product_id))])))
+          native-query (:query (qp.compile/compile-with-inline-parameters query))]
+      (testing "A single SELECT statement returns true and the reconstructed SQL"
+        (are [sql] (=? {:is-single-select? true, :sql string?}
+                       (#'driver.sql/is-single-select-stmt? sql))
+          native-query
+          "SELECT 1"
+          "SELECT * FROM table"
+          "WITH x AS (SELECT * FROM foo) SELECT * from x"
+          "WITH x AS (SELECT a FROM foo), y AS (SELECT b FROM bar), z AS (SELECT c FROM baz) SELECT x.a, y.b, z.c FROM x, y, z")))
+    (testing "All other queries are rejected"
+      (are [sql] (=? {:is-single-select? false}
+                     (#'driver.sql/is-single-select-stmt? sql))
+        "SELECT ("
+        "SELECT 1; SELECT 2"
+        "SET ROLE NONE"
+        "DROP TABLE table"
+        "SET ROLE NONE; DROP TABLE table"
+        "SELECT set_config('role', 'none', false); DROP TABLE table"
+        "DO $$ BEGIN EXECUTE 'SET ROLE NONE; DROP TABLE table'; END $$;"))))

--- a/test/metabase/driver/sql_test.clj
+++ b/test/metabase/driver/sql_test.clj
@@ -11,10 +11,9 @@
   (mt/test-drivers (mt/normal-drivers-with-feature :connection-impersonation)
     (let [mp (mt/metadata-provider)
           products (lib.metadata/table mp (mt/id :products))
-          orders (lib.metadata/table mp (mt/id :orders))
+          product-category (lib.metadata/field mp (mt/id :products :category))
           query (-> (lib/query mp products)
-                    (lib/join (lib/join-clause orders [(lib/= (mt/id :products :id)
-                                                              (mt/id :orders :product_id))])))
+                    (lib/filter (lib/= product-category "Widget")))
           native-query (:query (qp.compile/compile-with-inline-parameters query))]
       (testing "A single SELECT statement returns true and the reconstructed SQL"
         (are [sql] (=? {:is-single-select? true, :sql string?}


### PR DESCRIPTION
Closes QUE2-451

### Description

Uses JSqlParser to parse impersonated native queries, and reject them if they are not a single select statement.

Validation is applied for Redshift and SQLServer only.

Context: https://metaboat.slack.com/archives/C97M2U8M6/p1774049003353019

### How to verify

1. Attempt to send an impersonated native query with multiple statements
2. It should be rejected and not executed against the db server

### Demo

[loom](https://www.loom.com/share/9cb036316af0405f800d677affff6a25)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
