### PR TITLE
updating styling for Database Destination Connection Modal

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/database_routing/DestinationDatabaseConnectionModal/DestinationDatabaseConnectionModal.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/database_routing/DestinationDatabaseConnectionModal/DestinationDatabaseConnectionModal.module.css
@@ -1,7 +1,6 @@
 .modalRoot {
   display: flex;
   flex-direction: column;
-  overflow-y: hidden;
 }
 
 .modalHeader {
@@ -10,4 +9,8 @@
 
 .modalBody {
   padding-inline: 0;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow-y: hidden;
 }

--- a/enterprise/frontend/src/metabase-enterprise/database_routing/DestinationDatabaseConnectionModal/DestinationDatabaseConnectionModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/database_routing/DestinationDatabaseConnectionModal/DestinationDatabaseConnectionModal.tsx
@@ -113,42 +113,44 @@ export const DestinationDatabaseConnectionModal = ({
         body: S.modalBody,
       }}
     >
-      <LoadingAndErrorWrapper loading={isLoading} error={error}>
-        <Flex
-          py="sm"
-          px="md"
-          mx="xl"
-          my="md"
-          bg="background-secondary"
-          align="center"
-          justify="space-between"
-          bd="1px solid border"
-          style={{ borderRadius: ".5rem" }}
-        >
-          <Text>{t`You can also add databases programmatically via the API.`}</Text>
-          <ExternalLink
-            key="link"
-            href={docsUrl}
-            style={{ display: "flex", alignItems: "center", gap: 4 }}
+      <LoadingAndErrorWrapper loading={isLoading} error={error} noWrapper>
+        <>
+          <Flex
+            py="sm"
+            px="md"
+            mx="xl"
+            my="md"
+            bg="background-secondary"
+            align="center"
+            justify="space-between"
+            bd="1px solid border"
+            style={{ borderRadius: ".5rem" }}
           >
-            {t`Learn more`} <Icon name="share" aria-hidden />
-          </ExternalLink>
-        </Flex>
+            <Text>{t`You can also add databases programmatically via the API.`}</Text>
+            <ExternalLink
+              key="link"
+              href={docsUrl}
+              style={{ display: "flex", alignItems: "center", gap: 4 }}
+            >
+              {t`Learn more`} <Icon name="share" aria-hidden />
+            </ExternalLink>
+          </Flex>
 
-        <DatabaseEditConnectionForm
-          database={destinationDatabase}
-          isAttachedDWH={destinationDatabase?.is_attached_dwh ?? false}
-          handleSaveDb={handleSaveDatabase}
-          onSubmitted={handleOnSubmit}
-          onCancel={handleCloseModal}
-          route={route}
-          config={{
-            name: { isSlug: true },
-            engine: { fieldState: "hidden" },
-          }}
-          autofocusFieldName="name"
-          formLocation="admin"
-        />
+          <DatabaseEditConnectionForm
+            database={destinationDatabase}
+            isAttachedDWH={destinationDatabase?.is_attached_dwh ?? false}
+            handleSaveDb={handleSaveDatabase}
+            onSubmitted={handleOnSubmit}
+            onCancel={handleCloseModal}
+            route={route}
+            config={{
+              name: { isSlug: true },
+              engine: { fieldState: "hidden" },
+            }}
+            autofocusFieldName="name"
+            formLocation="admin"
+          />
+        </>
       </LoadingAndErrorWrapper>
     </Modal>
   );

--- a/frontend/src/metabase/admin/databases/components/DatabaseEditConnectionForm.tsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditConnectionForm.tsx
@@ -87,7 +87,11 @@ export const DatabaseEditConnectionForm = withRouter(
 
     return (
       <ErrorBoundary errorComponent={GenericError as ComponentType}>
-        <LoadingAndErrorWrapper loading={!database} error={initializeError}>
+        <LoadingAndErrorWrapper
+          loading={!database}
+          error={initializeError}
+          noWrapper
+        >
           {isDbModifiable({
             id: database?.id,
             is_attached_dwh: isAttachedDWH,

--- a/frontend/src/metabase/databases/components/DatabaseForm/DatabaseForm.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseForm/DatabaseForm.tsx
@@ -111,6 +111,11 @@ export const DatabaseForm = ({
       <Form
         data-testid="database-form"
         pt={location === "full-page" ? undefined : "md"}
+        mih={0}
+        style={{
+          display: "flex",
+          flexDirection: "column",
+        }}
       >
         <FormDirtyStateProvider onDirtyStateChange={onDirtyStateChange}>
           <DatabaseFormBody

--- a/frontend/src/metabase/databases/components/DatabaseForm/DatabaseFormBody.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseForm/DatabaseFormBody.tsx
@@ -54,7 +54,7 @@ export const DatabaseFormBody = ({
   const mah = location === "full-page" ? "100%" : "calc(100vh - 20rem)";
 
   return (
-    <Box mah={mah} mb="md" px={px} style={{ overflowY: "auto" }}>
+    <Box mah={mah} mb="md" px={px} flex={1} style={{ overflowY: "auto" }}>
       {engineFieldConfig?.fieldState !== "hidden" && (
         <>
           <DatabaseEngineField


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #71297
Closes UXW-3394

### Description
Adjusts some CSS so that the database connection modal renders properly, without any cut off buttons at the bottom. The form itself should be the only scrollable area in the modal

### How to verify
1. Go to Admin -> Databases -> select a database
2. Set up DB routing, and add a destination
3. notice that there is proper padding on the bottom of the modal
4. Open up the full page version by clocking edit database connection, or add a new db. The form should render properly there as well.

### Demo

After:
<img width="702" height="905" alt="image" src="https://github.com/user-attachments/assets/61b61be1-c9d2-40f4-be18-b06be5518649" />

Before:
<img width="707" height="922" alt="image" src="https://github.com/user-attachments/assets/b24348d3-8800-43f5-bbd0-60af2d2759ec" />


### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~
