### PR TITLE
[Metabot] Hide embedded settings if embedding is not available

### DIFF
--- a/frontend/src/metabase/metabot/components/MetabotAdmin/MetabotAdminPage.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotAdmin/MetabotAdminPage.tsx
@@ -27,7 +27,11 @@ import {
   FIXED_METABOT_ENTITY_IDS,
   FIXED_METABOT_IDS,
 } from "metabase/metabot/constants";
-import { PLUGIN_MODERATION } from "metabase/plugins";
+import {
+  PLUGIN_EMBEDDING_IFRAME_SDK,
+  PLUGIN_EMBEDDING_SDK,
+  PLUGIN_MODERATION,
+} from "metabase/plugins";
 import {
   Box,
   Button,
@@ -68,6 +72,9 @@ export function MetabotAdminPage() {
 
   const dispatch = useDispatch();
 
+  const hasEmbedding =
+    PLUGIN_EMBEDDING_SDK.isEnabled() || PLUGIN_EMBEDDING_IFRAME_SDK.isEnabled();
+
   const metabots = useMemo(() => _.sortBy(data?.items ?? [], "id"), [data]);
 
   useEffect(() => {
@@ -75,6 +82,12 @@ export function MetabotAdminPage() {
       dispatch(push("/admin/metabot/setup"));
     }
   }, [isConfigured, dispatch]);
+
+  useEffect(() => {
+    if (metabotId === FIXED_METABOT_IDS.EMBEDDED && !hasEmbedding) {
+      dispatch(push(`/admin/metabot/${FIXED_METABOT_IDS.DEFAULT}`));
+    }
+  }, [metabotId, hasEmbedding, dispatch]);
 
   useEffect(() => {
     if (!metabot && metabots.length) {

--- a/frontend/src/metabase/metabot/components/MetabotAdmin/MetabotAdminPage.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotAdmin/MetabotAdminPage.unit.spec.tsx
@@ -153,6 +153,15 @@ const getLastSettingUpdateCall = (settingKey: string) =>
     `path:/api/setting/${encodeURIComponent(settingKey)}`,
   );
 
+const setupEmbeddingPlugin = () => {
+  mockSettings({
+    "token-features": createMockTokenFeatures({
+      embedding_sdk: true,
+    }),
+  });
+  setupEnterprisePlugins();
+};
+
 const setupContentVerificationPlugin = () => {
   mockSettings({
     "token-features": createMockTokenFeatures({
@@ -216,7 +225,14 @@ describe("MetabotAdminPage", () => {
     expect(call?.options?.body).toBe(JSON.stringify({ value: false }));
   });
 
-  it("should render the metabots list", async () => {
+  it("should not show Embedded Metabot nav item without embedding features", async () => {
+    await setup();
+    expect(await screen.findByText("Metabot")).toBeInTheDocument();
+    expect(screen.queryByText("Embedded Metabot")).not.toBeInTheDocument();
+  });
+
+  it("should show Embedded Metabot nav item with embedding features", async () => {
+    setupEmbeddingPlugin();
     await setup();
     expect(await screen.findByText("Metabot")).toBeInTheDocument();
     expect(screen.getByText("Embedded Metabot")).toBeInTheDocument();
@@ -230,12 +246,31 @@ describe("MetabotAdminPage", () => {
     ).toBeInTheDocument();
   });
 
+  it("should redirect from embedded metabot page to default without embedding features", async () => {
+    const { history } = await setup(
+      FIXED_METABOT_IDS.EMBEDDED,
+      defaultMetabots,
+      defaultSeedCollections,
+      false,
+      createMockSettings({ "llm-metabot-configured?": true }),
+      false,
+    );
+
+    await waitFor(() => {
+      expect(history?.getCurrentLocation()?.pathname).toBe(
+        `/admin/metabot/${FIXED_METABOT_IDS.DEFAULT}`,
+      );
+    });
+  });
+
   it("should render a selected collection for embedded metabot", async () => {
+    setupEmbeddingPlugin();
     await setup(FIXED_METABOT_IDS.EMBEDDED);
     expect(await screen.findByText("Collection Two")).toBeInTheDocument();
   });
 
   it("should render a root collection if collection_id is null for metabot", async () => {
+    setupEmbeddingPlugin();
     await setup(FIXED_METABOT_IDS.EMBEDDED, [
       createMockMetabotInfo({
         id: FIXED_METABOT_IDS.EMBEDDED,
@@ -248,6 +283,7 @@ describe("MetabotAdminPage", () => {
   });
 
   it("should be able to switch between metabots", async () => {
+    setupEmbeddingPlugin();
     await setup(FIXED_METABOT_IDS.DEFAULT);
     expect(await screen.findByText("Configure Metabot")).toBeInTheDocument();
 
@@ -257,6 +293,7 @@ describe("MetabotAdminPage", () => {
   });
 
   it("should change selected collection for embedded metabot", async () => {
+    setupEmbeddingPlugin();
     await setup(FIXED_METABOT_IDS.EMBEDDED);
 
     expect(
@@ -293,6 +330,7 @@ describe("MetabotAdminPage", () => {
   });
 
   it("should show special copy for embedded metabot", async () => {
+    setupEmbeddingPlugin();
     await setup(FIXED_METABOT_IDS.EMBEDDED);
 
     expect(
@@ -301,6 +339,7 @@ describe("MetabotAdminPage", () => {
   });
 
   it("should toggle embedded metabot enabled state", async () => {
+    setupEmbeddingPlugin();
     await setup(FIXED_METABOT_IDS.EMBEDDED);
 
     // Shows title but NOT description for embedded

--- a/frontend/src/metabase/metabot/components/MetabotAdmin/MetabotNavPane.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotAdmin/MetabotNavPane.tsx
@@ -6,10 +6,16 @@ import {
 } from "metabase/admin/components/AdminNav";
 import { useSetting } from "metabase/common/hooks";
 import { FIXED_METABOT_IDS } from "metabase/metabot/constants";
+import {
+  PLUGIN_EMBEDDING_IFRAME_SDK,
+  PLUGIN_EMBEDDING_SDK,
+} from "metabase/plugins";
 import { Flex } from "metabase/ui";
 
 export function MetabotNavPane() {
   const isConfigured = useSetting("llm-metabot-configured?");
+  const hasEmbedding =
+    PLUGIN_EMBEDDING_SDK.isEnabled() || PLUGIN_EMBEDDING_IFRAME_SDK.isEnabled();
 
   return (
     <Flex direction="column" flex="0 0 auto">
@@ -26,11 +32,13 @@ export function MetabotNavPane() {
               label={t`Metabot`}
               path={`/admin/metabot/${FIXED_METABOT_IDS.DEFAULT}`}
             />
-            <AdminNavItem
-              icon="embed"
-              label={t`Embedded Metabot`}
-              path={`/admin/metabot/${FIXED_METABOT_IDS.EMBEDDED}`}
-            />
+            {hasEmbedding && (
+              <AdminNavItem
+                icon="embed"
+                label={t`Embedded Metabot`}
+                path={`/admin/metabot/${FIXED_METABOT_IDS.EMBEDDED}`}
+              />
+            )}
           </>
         )}
       </AdminNavWrapper>

--- a/frontend/src/metabase/metabot/components/MetabotAdmin/MetabotNavPane.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotAdmin/MetabotNavPane.unit.spec.tsx
@@ -1,6 +1,10 @@
 import { Route } from "react-router";
 
+import { setupEnterprisePlugins } from "__support__/enterprise";
+import { mockSettings } from "__support__/settings";
 import { renderWithProviders, screen } from "__support__/ui";
+import { reinitialize } from "metabase/plugins";
+import { createMockTokenFeatures } from "metabase-types/api/mocks";
 import { createMockSettingsState } from "metabase-types/store/mocks";
 
 import { MetabotNavPane } from "./MetabotNavPane";
@@ -23,7 +27,20 @@ const setup = ({
     },
   );
 
+const setupEmbeddingPlugin = () => {
+  mockSettings({
+    "token-features": createMockTokenFeatures({
+      embedding_sdk: true,
+    }),
+  });
+  setupEnterprisePlugins();
+};
+
 describe("MetabotNavPane", () => {
+  afterEach(() => {
+    reinitialize();
+  });
+
   it("should not show metabots if it isn't configured", async () => {
     setup({ isConfigured: false });
 
@@ -32,6 +49,27 @@ describe("MetabotNavPane", () => {
   });
 
   it("should show metabots if it is configured", async () => {
+    setup({ isConfigured: true });
+
+    expect(await screen.findByText("Metabot")).toBeInTheDocument();
+    expect(screen.queryByText("Embedded Metabot")).not.toBeInTheDocument();
+  });
+
+  it("should show Embedded Metabot with embedding_sdk feature", async () => {
+    setupEmbeddingPlugin();
+    setup({ isConfigured: true });
+
+    expect(await screen.findByText("Metabot")).toBeInTheDocument();
+    expect(await screen.findByText("Embedded Metabot")).toBeInTheDocument();
+  });
+
+  it("should show Embedded Metabot with embedding_simple feature", async () => {
+    mockSettings({
+      "token-features": createMockTokenFeatures({
+        embedding_simple: true,
+      }),
+    });
+    setupEnterprisePlugins();
     setup({ isConfigured: true });
 
     expect(await screen.findByText("Metabot")).toBeInTheDocument();


### PR DESCRIPTION
[BOT-1192: Hide Embedded Metabot settings on OSS](https://linear.app/metabase/issue/BOT-1192/hide-embedded-metabot-settings-on-oss)