### PR TITLE
Fix a collection picker flake in cross-version tests

### DIFF
--- a/e2e/cross-version/57/01-pivot.cy.spec.ts
+++ b/e2e/cross-version/57/01-pivot.cy.spec.ts
@@ -10,7 +10,11 @@ describe("Cross-version questions - pivot", () => {
     cy.signIn("admin", { skipCache: true });
 
     cy.log("-- Create a pivot table --");
-    X.startQuestionFromTable("People");
+    // Intentionally start from the root collection to prevent ambiguity
+    // in the collection picker when we attempt to save the question
+    cy.visit("/collection/root");
+    H.newButton("Question").click();
+    H.modal().contains("People").should("be.visible").click();
 
     cy.log(
       "-- Add filter: Narrow down the states that start with K (only two) --",

--- a/e2e/cross-version/57/helpers.ts
+++ b/e2e/cross-version/57/helpers.ts
@@ -1,11 +1,5 @@
 const { H } = cy;
 
-export function startQuestionFromTable(table: string) {
-  cy.visit("/");
-  H.newButton("Question").click();
-  H.modal().contains(table).should("be.visible").click();
-}
-
 export function saveQuestion(name: string) {
   cy.log(`-- Save question: ${name}`);
   cy.intercept("POST", "/api/card").as("saveQuestion");
@@ -15,6 +9,7 @@ export function saveQuestion(name: string) {
     cy.button("Save").click();
     cy.wait("@saveQuestion");
   });
+  cy.findByTestId("save-question-modal").should("not.exist");
 }
 
 export function assertRowCount(count: string) {

--- a/e2e/cross-version/latest/01-pivot.cy.spec.ts
+++ b/e2e/cross-version/latest/01-pivot.cy.spec.ts
@@ -10,7 +10,12 @@ describe("Cross-version questions - pivot", () => {
     cy.signIn("admin", { skipCache: true });
 
     cy.log("-- Create a pivot table --");
-    X.startQuestionFromTable("People");
+    // Intentionally start from the root collection to prevent ambiguity
+    // in the collection picker when we attempt to save the question
+    cy.visit("/collection/root");
+    H.newButton("Question").click();
+    X.selectFromPopover("Sample Database");
+    X.selectFromPopover("People");
 
     cy.log(
       "-- Add filter: Narrow down the states that start with K (only two) --",

--- a/e2e/cross-version/latest/helpers.ts
+++ b/e2e/cross-version/latest/helpers.ts
@@ -1,12 +1,5 @@
 const { H } = cy;
 
-export function startQuestionFromTable(table: string) {
-  cy.visit("/");
-  H.newButton("Question").click();
-  selectFromPopover("Sample Database");
-  selectFromPopover(table);
-}
-
 export function saveQuestion(name: string) {
   cy.log(`-- Save question: ${name}`);
   cy.intercept("POST", "/api/card").as("saveQuestion");
@@ -16,6 +9,7 @@ export function saveQuestion(name: string) {
     cy.button("Save").click();
     cy.wait("@saveQuestion");
   });
+  cy.findByTestId("save-question-modal").should("not.exist");
 }
 
 export function assertRowCount(count: string) {


### PR DESCRIPTION
Resolves DEV-1753

Possible race condition makes the collection picker have non-deterministic starting value. We need to ensure it always saves in "Our analytics", which is why we will start a new question from that exact collection.

## Test run

https://github.com/metabase/metabase/actions/runs/23666990844 :white_check_mark: 