### PR TITLE
[Slackbot] Make slackbot auth req messages in channel an ephemeral message

### DIFF
--- a/src/metabase/slackbot/api.clj
+++ b/src/metabase/slackbot/api.clj
@@ -90,27 +90,30 @@
 
 (defn- send-auth-link
   "Respond to an incoming slack message with a request to authorize.
-   For DMs, always threads the reply. For channel @mentions, only threads
-   if the original message was in a thread."
+   In channels, sends an ephemeral message (only visible to the user).
+   In DMs, sends a regular threaded reply."
   [client event]
-  (let [user-mention (slackbot.events/user-mention (:user event))
-        msg-prefix (if (slackbot.events/dm? event) "" (str user-mention " "))
-        msg (str msg-prefix "Connect your Slack account to Metabase. Once linked, I can use your permissions to query data on your behalf.")]
-    (slackbot.client/post-message
-     client
-     (merge (slackbot.events/event->reply-context event)
-            {;; DMs: always thread. Channels: only thread if already in a thread.
-             :thread_ts (or (:thread_ts event) (:ts event))
-             :text msg
-             :blocks [{:type "section"
-                       :text {:type "mrkdwn"
-                              :text msg}}
-                      {:type "actions"
-                       :elements [{:type "button"
-                                   :text {:type "plain_text"
-                                          :text ":link: Connect to Metabase"
-                                          :emoji true}
-                                   :url (slack-user-authorize-link)}]}]}))))
+  (let [msg     "Connect your Slack account to Metabase. Once linked, I can use your permissions to query data on your behalf."
+        dm?     (slackbot.events/dm? event)
+        ;; always thread dms, but only thread in channels if message is within a thread already
+        thread-ts (if dm?
+                    (or (:thread_ts event) (:ts event))
+                    (:thread_ts event))
+        payload (cond-> {:channel (:channel event)
+                         :text msg
+                         :blocks [{:type "section"
+                                   :text {:type "mrkdwn"
+                                          :text msg}}
+                                  {:type "actions"
+                                   :elements [{:type "button"
+                                               :text {:type "plain_text"
+                                                      :text ":link: Connect to Metabase"
+                                                      :emoji true}
+                                               :url (slack-user-authorize-link)}]}]}
+                  thread-ts (assoc :thread_ts thread-ts))]
+    (if dm?
+      (slackbot.client/post-message client payload)
+      (slackbot.client/post-ephemeral-message client (assoc payload :user (:user event))))))
 
 (defn- require-authenticated-slack-user!
   "Returns Metabase user-id if authenticated, nil otherwise.

--- a/test/metabase/slackbot/api_test.clj
+++ b/test/metabase/slackbot/api_test.clj
@@ -389,16 +389,14 @@
                 (is (=? [{:channel "C123"
                           :thread_ts "1234567890.000001"
                           :text #"(?i).*connect.*slack.*metabase.*"}]
-                        @post-calls)))
-              (testing "DM auth message does not include user mention prefix"
-                (is (not (str/starts-with? (:text (first @post-calls)) "<@")))))))))))
+                        @post-calls))))))))))
 
 (deftest app-mention-unlinked-user-test
-  (testing "POST /events with app_mention from unlinked user sends auth message"
+  (testing "POST /events with app_mention from unlinked user sends ephemeral auth message"
     (tu/with-slackbot-setup
       (doseq [[desc thread-ts expected-thread-ts]
-              [["top-level @mention" nil "1234567890.000002"]
-               ["@mention in thread" "1234567890.000001" "1234567890.000001"]]]
+              [["top-level @mention (no thread)" nil nil]
+               ["@mention in thread"             "1234567890.000001" "1234567890.000001"]]]
         (testing desc
           (let [event-body (cond-> (update tu/base-mention-event :event merge
                                            {:user     "U-UNKNOWN"
@@ -408,18 +406,18 @@
             (tu/with-slackbot-mocks
               {:ai-text "Should not be called"
                :user-id ::tu/no-user}
-              (fn [{:keys [post-calls]}]
+              (fn [{:keys [post-calls ephemeral-calls]}]
                 (is (= "ok" (mt/client :post 200 "metabot/slack/events"
                                        (tu/slack-request-options event-body) event-body)))
-                (u/poll {:thunk #(= 1 (count @post-calls))
+                (u/poll {:thunk #(= 1 (count @ephemeral-calls))
                          :done? true?
                          :timeout-ms 5000})
-                (is (=? {:channel "C123"
-                         :thread_ts expected-thread-ts
-                         :text #"(?i).*connect.*slack.*metabase.*"}
-                        (first @post-calls)))
-                (testing "channel auth message includes user mention prefix"
-                  (is (str/starts-with? (:text (first @post-calls)) "<@U-UNKNOWN>")))))))))))
+                (is (= 0 (count @post-calls)))
+                (is (=? (cond-> {:channel "C123"
+                                 :user    "U-UNKNOWN"
+                                 :text    #"(?i).*connect.*slack.*metabase.*"}
+                          expected-thread-ts (assoc :thread_ts expected-thread-ts))
+                        (first @ephemeral-calls)))))))))))
 
 (deftest slack-id->user-id-test
   (testing "slack-id->user-id only returns active users with sso_source 'slack'"


### PR DESCRIPTION
Closes [BOT-1205: Slackbot channel auth request message confuses folks](https://linear.app/metabase/issue/BOT-1205/slackbot-channel-auth-request-message-confuses-folks)
Discussion: https://metaboat.slack.com/archives/C0ACBV3THC3/p1774645416001199