### PR TITLE
fix: pin 87 actions to commit SHA, extract 20 expressions to env vars

### DIFF
--- a/.github/workflows/athena.yml
+++ b/.github/workflows/athena.yml
@@ -30,13 +30,13 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
 
       - name: Deploy Athena JDBC driver
-        run: ./bin/athena.bb ${INPUT_VERSION} --deploy
+        run: ./bin/athena.bb "${INPUT_VERSION}" --deploy
         env:
           INPUT_VERSION: ${{ github.event.inputs.version }}
 
       - name: Verify deployment
         run: |
-          aws s3 ls s3://metabase-maven-downloads/com/metabase/athena-jdbc/${INPUT_VERSION}/
+          aws s3 ls s3://metabase-maven-downloads/com/metabase/athena-jdbc/"${INPUT_VERSION}"/
           echo "Athena JDBC driver version ${INPUT_VERSION} has been deployed"
 
         env:

--- a/.github/workflows/athena.yml
+++ b/.github/workflows/athena.yml
@@ -18,21 +18,26 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Babashka
-        uses: turtlequeue/setup-babashka@v1.7.0
+        uses: turtlequeue/setup-babashka@2d4df498c7a578b4f3e906283f9af913590bdec7 # v1.7.0
         with:
           babashka-version: 1.12.197
 
       - name: Set up AWS CLI
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           aws-access-key-id: ${{ secrets.AWS_S3_MAVEN_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_S3_MAVEN_SECRET_ACCESS_KEY }}
           aws-region: ${{ vars.AWS_REGION }}
 
       - name: Deploy Athena JDBC driver
-        run: ./bin/athena.bb ${{ github.event.inputs.version }} --deploy
+        run: ./bin/athena.bb ${INPUT_VERSION} --deploy
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
 
       - name: Verify deployment
         run: |
-          aws s3 ls s3://metabase-maven-downloads/com/metabase/athena-jdbc/${{ github.event.inputs.version }}/
-          echo "Athena JDBC driver version ${{ github.event.inputs.version }} has been deployed"
+          aws s3 ls s3://metabase-maven-downloads/com/metabase/athena-jdbc/${INPUT_VERSION}/
+          echo "Athena JDBC driver version ${INPUT_VERSION} has been deployed"
+
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
 
     steps:
-      - uses: tibdex/github-app-token@v2.1.0
+      - uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
         id: generate-token
         with:
           app_id: ${{ secrets.METABASE_BOT_APP_ID }}

--- a/.github/workflows/backend-cloverage.yml
+++ b/.github/workflows/backend-cloverage.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Upload coverage to codecov.io
         if: always()
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./target/coverage/codecov.json
@@ -104,7 +104,7 @@ jobs:
 
       - name: Upload coverage to codecov.io
         if: always()
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./target/coverage/codecov.json

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -145,7 +145,7 @@ jobs:
           previous-step-outcome: ${{ steps.run-java-tests.outcome }}
 
       - name: Publish Test Report (JUnit)
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@3eeb9fc888e82e8be2fb356bbeec2750231672bc # v1
         if: failure()
         with:
           path: "target/junit/**/*_test.xml"

--- a/.github/workflows/backport-reminder.yml
+++ b/.github/workflows/backport-reminder.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 5
     steps:
-      - uses: jesusvasquez333/verify-pr-label-action@v1.4.0
+      - uses: jesusvasquez333/verify-pr-label-action@657d111bbbe13e22bbd55870f1813c699bde1401 # v1.4.0
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
           valid-labels: 'no-backport, backport, double-backport, triple-backport'

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Test which files changed
-        uses: dorny/paths-filter@v3.0.0
+        uses: dorny/paths-filter@0bc4621a3135347011ad047f9ecf449bf72ce2bd # v3.0.0
         id: changes
         with:
           token: ${{ github.token }}
@@ -43,7 +43,7 @@ jobs:
       - name: Compile CLJS
         run: NODE_ENV=development bun run build-pure:cljs
       - name: Publish to Chromatic
-        uses: chromaui/action@v10.2.0
+        uses: chromaui/action@c03d144dc72e609acbb960489fdd1e1a4a23b34f # v10.2.0
         env:
           PUBLISH_CHROMATIC: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           STORYBOOK_BUILD_TIMEOUT: 900000

--- a/.github/workflows/cljs.yml
+++ b/.github/workflows/cljs.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Test which files changed
-        uses: dorny/paths-filter@v3.0.0
+        uses: dorny/paths-filter@0bc4621a3135347011ad047f9ecf449bf72ce2bd # v3.0.0
         id: changes
         with:
           token: ${{ github.token }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Test which files changed
-        uses: dorny/paths-filter@v3.0.0
+        uses: dorny/paths-filter@0bc4621a3135347011ad047f9ecf449bf72ce2bd # v3.0.0
         id: changes
         with:
           token: ${{ github.token }}

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Fix spelling errors with Claude Code
         if: steps.codespell_check.outcome == 'failure'
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@3ac52d0da9f8ec9ca7b4dc23bb477e36ef9c77a9 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ steps.claude-app-token.outputs.token }}
@@ -82,7 +82,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.codespell_check.outcome == 'failure'
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: claude-fix/codespell-${{ steps.date.outputs.date }}

--- a/.github/workflows/containerize-jar.yml
+++ b/.github/workflows/containerize-jar.yml
@@ -84,19 +84,19 @@ jobs:
     - name: Move the Uberjar to the context dir
       run: mv ./metabase.jar bin/docker/.
     - name: Login to Docker Hub
-      uses: docker/login-action@v3
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
       with:
         username: ${{ inputs.release == 'true' && secrets.DOCKERHUB_RELEASE_USERNAME || secrets.DOCKERHUB_USERNAME }}
         password: ${{ inputs.release == 'true' && secrets.DOCKERHUB_RELEASE_TOKEN || secrets.DOCKERHUB_TOKEN }}
     - name: Set up QEMU
       if: contains(steps.platforms.outputs.result, 'arm')
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
     - name: Set up Docker Buildx
       if: contains(steps.platforms.outputs.result, 'arm')
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
     - name: Build multi-arch container
       if: contains(steps.platforms.outputs.result, 'arm')
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
       with:
         context: bin/docker/.
         platforms: ${{ steps.platforms.outputs.result }}
@@ -122,7 +122,7 @@ jobs:
     timeout-minutes: 15
     steps:
     - name: Login to Docker Hub
-      uses: docker/login-action@v3
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
       with:
         username: ${{ inputs.release == 'true' && secrets.DOCKERHUB_RELEASE_USERNAME || secrets.DOCKERHUB_USERNAME }}
         password: ${{ inputs.release == 'true' && secrets.DOCKERHUB_RELEASE_TOKEN || secrets.DOCKERHUB_TOKEN }}
@@ -142,7 +142,7 @@ jobs:
     timeout-minutes: 15
     steps:
     - name: Login to Docker Hub
-      uses: docker/login-action@v3
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
       with:
         username: ${{ inputs.release == 'true' && secrets.DOCKERHUB_RELEASE_USERNAME || secrets.DOCKERHUB_USERNAME }}
         password: ${{ inputs.release == 'true' && secrets.DOCKERHUB_RELEASE_TOKEN || secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/containerize-uberjar.yml
+++ b/.github/workflows/containerize-uberjar.yml
@@ -106,7 +106,7 @@ jobs:
           edition: ee
 
       - name: Post PR comment
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
         with:
           header: docker-build-status
           message: |

--- a/.github/workflows/conventional-commit-pr-title-reminder.yml
+++ b/.github/workflows/conventional-commit-pr-title-reminder.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Test which files changed
-        uses: dorny/paths-filter@v3.0.0
+        uses: dorny/paths-filter@0bc4621a3135347011ad047f9ecf449bf72ce2bd # v3.0.0
         id: changes
         with:
           token: ${{ github.token }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,7 +22,7 @@ jobs:
             --coverage \
             --testTimeout=60000
       - name: Upload coverage to codecov.io
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad # v5
         with:
           files: ./coverage/lcov.info
           flags: front-end

--- a/.github/workflows/docs-links.yml
+++ b/.github/workflows/docs-links.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Run link checker
         id: link-check
-        uses: lycheeverse/lychee-action@v2.3.0
+        uses: lycheeverse/lychee-action@f613c4a64e50d792e0b31ec34bbcbba12263c6a6 # v2.3.0
         with:
           fail: true
           args: docs --config ./.lychee/config.toml --offline

--- a/.github/workflows/drivers-stress-test.yml
+++ b/.github/workflows/drivers-stress-test.yml
@@ -707,7 +707,7 @@ jobs:
       contents: read
     steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
       with:
         role-to-assume: ${{ secrets.CI_IAM_ROLE }}
         role-session-name: GitHub_to_AWS_via_FederatedOIDC

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -72,8 +72,8 @@ jobs:
           # All decision logic is in mage - it analyzes module dependencies,
           # branch context, labels, and file changes to decide what runs.
           MAGE_ARGS=(
-            --git-ref="${{ github.event.pull_request.base.ref || github.ref_name }}"
-            --is-master-or-release="${{ github.ref_name == 'master' || startsWith(github.ref_name, 'release-') }}"
+            --git-ref="${BASE_REF}"
+            --is-master-or-release="${REF_NAME}"
             --pr-labels="${{ join(github.event.pull_request.labels.*.name, ',') }}"
             --skip="${{ inputs.skip }}"
           )
@@ -87,6 +87,9 @@ jobs:
           echo "Run './bin/mage -driver-decisions -h' locally for the full list of drivers and labels."
           # Second call: output only key=value lines for GITHUB_OUTPUT
           ./bin/mage -driver-decisions "${MAGE_ARGS[@]}" --github-output-only >> $GITHUB_OUTPUT
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref || github.ref_name }}
+          REF_NAME: ${{ github.ref_name == 'master' || startsWith(github.ref_name, 'release-') }}
         shell: bash
 
   be-tests-athena-ee:
@@ -258,7 +261,7 @@ jobs:
       run: |
         sudo echo "127.0.0.1 server.clickhouseconnect.test" | sudo tee -a /etc/hosts
     - name: Start ClickHouse in Docker
-      uses: hoverkraft-tech/compose-action@v2.0.0
+      uses: hoverkraft-tech/compose-action@802a148945af6399a338c7906c267331b39a71af # v2.0.0
       with:
         compose-file: "modules/drivers/clickhouse/docker-compose.yml"
         down-flags: "--volumes"
@@ -1568,7 +1571,7 @@ jobs:
       contents: read
     steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
       with:
         role-to-assume: ${{ secrets.CI_IAM_ROLE }}
         role-session-name: GitHub_to_AWS_via_FederatedOIDC

--- a/.github/workflows/e2e-stress-test-flake-fix.yml
+++ b/.github/workflows/e2e-stress-test-flake-fix.yml
@@ -155,7 +155,7 @@ jobs:
         run: |
           node e2e/runner/run_cypress_ci.js ${{ needs.determine-test-type.outputs.type }} \
           --spec '${{ github.event.inputs.spec }}' \
-          --env burn=${INPUT_BURN_IN} \
+          --env burn="${INPUT_BURN_IN}" \
           --config-file e2e/support/cypress-stress-test.config.js
 
       - name: Upload Cypress Artifacts upon failure

--- a/.github/workflows/e2e-stress-test-flake-fix.yml
+++ b/.github/workflows/e2e-stress-test-flake-fix.yml
@@ -151,10 +151,11 @@ jobs:
           GREP: ${{ github.event.inputs.grep }}
           CYPRESS_BROWSER: ${{ steps.cypress-prep.outputs.chrome-path }}
           FAIL_FAST: ${{ inputs.fail_fast }}
+          INPUT_BURN_IN: ${{ github.event.inputs.burn_in }}
         run: |
           node e2e/runner/run_cypress_ci.js ${{ needs.determine-test-type.outputs.type }} \
           --spec '${{ github.event.inputs.spec }}' \
-          --env burn=${{ github.event.inputs.burn_in }} \
+          --env burn=${INPUT_BURN_IN} \
           --config-file e2e/support/cypress-stress-test.config.js
 
       - name: Upload Cypress Artifacts upon failure

--- a/.github/workflows/embedding-sdk-host-sample-apps-tests.yml
+++ b/.github/workflows/embedding-sdk-host-sample-apps-tests.yml
@@ -114,7 +114,7 @@ jobs:
 
       # We have to use the latest version that does not have this issue https://github.com/docker/compose/pull/12752
       - name: Set up Docker Compose
-        uses: docker/setup-compose-action@v1
+        uses: docker/setup-compose-action@2fe291b7677a45ee1269ec56a42604c143505e7e # v1
         with:
           version: latest
 

--- a/.github/workflows/embedding-sdk-labels-reminder.yml
+++ b/.github/workflows/embedding-sdk-labels-reminder.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Test which files changed
-        uses: dorny/paths-filter@v3.0.0
+        uses: dorny/paths-filter@0bc4621a3135347011ad047f9ecf449bf72ce2bd # v3.0.0
         id: changes
         with:
           token: ${{ github.token }}
@@ -33,7 +33,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
-      - uses: jesusvasquez333/verify-pr-label-action@v1.4.0
+      - uses: jesusvasquez333/verify-pr-label-action@657d111bbbe13e22bbd55870f1813c699bde1401 # v1.4.0
         id: verify-release-notes-labels
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/escalation-slack-notification.yml
+++ b/.github/workflows/escalation-slack-notification.yml
@@ -18,7 +18,7 @@ jobs:
             core.setOutput('issue_title', ${{ toJson(github.event.issue.title) }}.replaceAll(/"/g, '\\"'));
       - name: Send escalated issue ${{ github.event.issue.number }} to Slack
         id: slack
-        uses: slackapi/slack-github-action@v1.23.0
+        uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844 # v1.23.0
         with:
           payload: |
             {

--- a/.github/workflows/frontend-unit-test-stress-test-flake-fix.yml
+++ b/.github/workflows/frontend-unit-test-stress-test-flake-fix.yml
@@ -47,7 +47,7 @@ jobs:
         run: bun run build:cljs
       - name: Stress-test ${{ github.event.inputs.spec }} ${{ github.event.inputs.burn_in }} times
         run: |
-          for i in {1..${{ github.event.inputs.burn_in }}}; do
+          for i in {1..${INPUT_BURN_IN}}; do
             bun run jest --runInBand --ci --silent --no-cache \
               --testPathPatterns '${{ github.event.inputs.spec }}' \
               --testNamePattern '${{ github.event.inputs.grep }}'
@@ -55,3 +55,6 @@ jobs:
               echo "Failed after $i attempts" && break;
             fi
           done
+
+        env:
+          INPUT_BURN_IN: ${{ github.event.inputs.burn_in }}

--- a/.github/workflows/generative-query-test.yml
+++ b/.github/workflows/generative-query-test.yml
@@ -47,7 +47,7 @@ jobs:
         run: clojure -X:dev:ci:test:ee:ee-dev :only '${{ inputs.test }}'
 
       - name: Publish Test Report (JUnit)
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@3eeb9fc888e82e8be2fb356bbeec2750231672bc # v1
         if: failure()
         with:
           path: "target/junit/**/*_test.xml"

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Test which files changed
-        uses: dorny/paths-filter@v3.0.0
+        uses: dorny/paths-filter@0bc4621a3135347011ad047f9ecf449bf72ce2bd # v3.0.0
         id: changes
         with:
           token: ${{ github.token }}

--- a/.github/workflows/loki.yml
+++ b/.github/workflows/loki.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Test which files changed
-        uses: dorny/paths-filter@v3.0.0
+        uses: dorny/paths-filter@0bc4621a3135347011ad047f9ecf449bf72ce2bd # v3.0.0
         id: changes
         with:
           token: ${{ github.token }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
             core.setOutput('issue_title', ${{ toJson(github.event.issue.title) }}.replaceAll(/"/g, '\\"'));
       - name: Send the issue ${{ github.event.issue.number }} to Slack
         id: slack
-        uses: slackapi/slack-github-action@v1.26.0
+        uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
         with:
           payload: |
             {

--- a/.github/workflows/module-boundaries-stats.yml
+++ b/.github/workflows/module-boundaries-stats.yml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
       - name: Install dependencies
         run: bun install --frozen-lockfile
       - name: get module boundary stats

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Test which files changed
-        uses: dorny/paths-filter@v3.0.0
+        uses: dorny/paths-filter@0bc4621a3135347011ad047f9ecf449bf72ce2bd # v3.0.0
         id: changes
         with:
           token: ${{ github.token }}

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -17,13 +17,13 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v4
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: ${{ secrets.PR_ENV_IAM_ROLE }}
           role-session-name: GitHub_to_AWS_via_FederatedOIDC
           aws-region: us-east-1
       - name: Login to Amazon ECR
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@183a1442edf41672e66566b7fc560e297a290896 # v2
         with:
           registries: "${{ secrets.PR_ENV_AWS_ACCOUNT_ID }}"
       - name: Retrieve uberjar artifact for ee
@@ -38,7 +38,7 @@ jobs:
           jar xf target/uberjar/metabase.jar
           mv target/uberjar/metabase.jar bin/docker/metabase.jar
       - name: Build container
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: bin/docker/
           platforms: linux/amd64
@@ -56,7 +56,7 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v4
       - name: Tailscale
-        uses: tailscale/github-action@v2
+        uses: tailscale/github-action@4e4c49acaa9818630ce0bd7a564372c17e33fb4d # v2
         with:
           oauth-client-id: ${{ secrets.PR_ENV_TAILSCALE_OAUTH_CLIENT_ID }}
           oauth-secret: ${{ secrets.PR_ENV_TAILSCALE_OAUTH_SECRET }}
@@ -67,12 +67,14 @@ jobs:
         id: create-oidc-token
         shell: bash
         run: |
-          export OIDC_URL_WITH_AUDIENCE="$ACTIONS_ID_TOKEN_REQUEST_URL&audience=${{ secrets.PR_ENV_K8S_AUDIENCE }}"
+          export OIDC_URL_WITH_AUDIENCE="$ACTIONS_ID_TOKEN_REQUEST_URL&audience=${PR_ENV_K8S_AUDIENCE}"
           IDTOKEN=$(curl -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" -H "Accept: application/json; api-version=2.0" "$OIDC_URL_WITH_AUDIENCE" | jq -r .value)
           echo "::add-mask::${IDTOKEN}"
           echo "idToken=${IDTOKEN}" >>$GITHUB_OUTPUT
+        env:
+          PR_ENV_K8S_AUDIENCE: ${{ secrets.PR_ENV_K8S_AUDIENCE }}
       - name: Setup Kube Context
-        uses: azure/k8s-set-context@v2
+        uses: azure/k8s-set-context@0b53301dcc7ddd3f6d35f97fb67228ac4e5ab2fd # v2
         with:
           method: kubeconfig
           kubeconfig: |
@@ -95,7 +97,7 @@ jobs:
                 namespace: default
                 user: oidc-token
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: ${{ secrets.PR_ENV_IAM_ROLE }}
           role-session-name: GitHub_to_AWS_via_FederatedOIDC
@@ -108,7 +110,7 @@ jobs:
         id: split
         run: echo "::set-output name=fragment::${SHA:5}"
       - name: Render Deployment YAML
-        uses: nowactions/envsubst@v1
+        uses: nowactions/envsubst@c4b8e3977354d294659a7ec164279ce8fba5c2e1 # v1
         with:
           input: ./perf-test-pr.yml.tmpl
           output: ./perf-test-pr.yml

--- a/.github/workflows/pr-env-destroy.yml
+++ b/.github/workflows/pr-env-destroy.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v4
       - name: Tailscale
-        uses: tailscale/github-action@v2
+        uses: tailscale/github-action@4e4c49acaa9818630ce0bd7a564372c17e33fb4d # v2
         with:
           oauth-client-id: ${{ secrets.PR_ENV_TAILSCALE_OAUTH_CLIENT_ID }}
           oauth-secret: ${{ secrets.PR_ENV_TAILSCALE_OAUTH_SECRET }}
@@ -39,12 +39,14 @@ jobs:
         id: create-oidc-token
         shell: bash
         run: |
-          export OIDC_URL_WITH_AUDIENCE="$ACTIONS_ID_TOKEN_REQUEST_URL&audience=${{ secrets.PR_ENV_K8S_AUDIENCE }}"
+          export OIDC_URL_WITH_AUDIENCE="$ACTIONS_ID_TOKEN_REQUEST_URL&audience=${PR_ENV_K8S_AUDIENCE}"
           IDTOKEN=$(curl -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" -H "Accept: application/json; api-version=2.0" "$OIDC_URL_WITH_AUDIENCE" | jq -r .value)
           echo "::add-mask::${IDTOKEN}"
           echo "idToken=${IDTOKEN}" >>$GITHUB_OUTPUT
+        env:
+          PR_ENV_K8S_AUDIENCE: ${{ secrets.PR_ENV_K8S_AUDIENCE }}
       - name: Setup Kube Context
-        uses: azure/k8s-set-context@v2
+        uses: azure/k8s-set-context@0b53301dcc7ddd3f6d35f97fb67228ac4e5ab2fd # v2
         with:
           method: kubeconfig
           kubeconfig: |
@@ -73,7 +75,7 @@ jobs:
           kubectl delete ns hosting-pr${{ env.PR_NUMBER }}
       - name: Setup Helm
         if: ${{ inputs.self_hosting }}
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
         with:
           version: 'latest'
       - name: Destroy PR Review ENV (self-hosting)
@@ -89,7 +91,12 @@ jobs:
         run: |
           PGPASSWORD='${{ secrets.PR_ENV_DB_PASSWORD }}' \
           psql \
-          -h ${{ secrets.PR_ENV_DB_HOST }} \
-          -U ${{ secrets.PR_ENV_DB_USER }} \
-          -d ${{ secrets.PR_ENV_DB_NAME }} \
+          -h ${PR_ENV_DB_HOST} \
+          -U ${PR_ENV_DB_USER} \
+          -d ${PR_ENV_DB_NAME} \
           -c "DROP DATABASE IF EXISTS hosting_pr${{ env.PR_NUMBER }};"
+
+        env:
+          PR_ENV_DB_HOST: ${{ secrets.PR_ENV_DB_HOST }}
+          PR_ENV_DB_USER: ${{ secrets.PR_ENV_DB_USER }}
+          PR_ENV_DB_NAME: ${{ secrets.PR_ENV_DB_NAME }}

--- a/.github/workflows/pr-env-destroy.yml
+++ b/.github/workflows/pr-env-destroy.yml
@@ -91,9 +91,9 @@ jobs:
         run: |
           PGPASSWORD='${{ secrets.PR_ENV_DB_PASSWORD }}' \
           psql \
-          -h ${PR_ENV_DB_HOST} \
-          -U ${PR_ENV_DB_USER} \
-          -d ${PR_ENV_DB_NAME} \
+          -h "${PR_ENV_DB_HOST}" \
+          -U "${PR_ENV_DB_USER}" \
+          -d "${PR_ENV_DB_NAME}" \
           -c "DROP DATABASE IF EXISTS hosting_pr${{ env.PR_NUMBER }};"
 
         env:

--- a/.github/workflows/pr-env.yml
+++ b/.github/workflows/pr-env.yml
@@ -28,13 +28,13 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v4
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: ${{ secrets.PR_ENV_IAM_ROLE }}
           role-session-name: GitHub_to_AWS_via_FederatedOIDC
           aws-region: us-east-1
       - name: Login to Amazon ECR
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@183a1442edf41672e66566b7fc560e297a290896 # v2
         with:
           registries: "${{ secrets.PR_ENV_AWS_ACCOUNT_ID }}"
       - name: Retrieve uberjar artifact for ee
@@ -49,7 +49,7 @@ jobs:
           jar xf target/uberjar/metabase.jar
           mv target/uberjar/metabase.jar bin/docker/metabase.jar
       - name: Build container
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: bin/docker/
           platforms: linux/amd64
@@ -67,7 +67,7 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v4
       - name: Tailscale
-        uses: tailscale/github-action@v2
+        uses: tailscale/github-action@4e4c49acaa9818630ce0bd7a564372c17e33fb4d # v2
         with:
           oauth-client-id: ${{ secrets.PR_ENV_TAILSCALE_OAUTH_CLIENT_ID }}
           oauth-secret: ${{ secrets.PR_ENV_TAILSCALE_OAUTH_SECRET }}
@@ -78,12 +78,14 @@ jobs:
         id: create-oidc-token
         shell: bash
         run: |
-          export OIDC_URL_WITH_AUDIENCE="$ACTIONS_ID_TOKEN_REQUEST_URL&audience=${{ secrets.PR_ENV_K8S_AUDIENCE }}"
+          export OIDC_URL_WITH_AUDIENCE="$ACTIONS_ID_TOKEN_REQUEST_URL&audience=${PR_ENV_K8S_AUDIENCE}"
           IDTOKEN=$(curl -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" -H "Accept: application/json; api-version=2.0" "$OIDC_URL_WITH_AUDIENCE" | jq -r .value)
           echo "::add-mask::${IDTOKEN}"
           echo "idToken=${IDTOKEN}" >>$GITHUB_OUTPUT
+        env:
+          PR_ENV_K8S_AUDIENCE: ${{ secrets.PR_ENV_K8S_AUDIENCE }}
       - name: Setup Kube Context
-        uses: azure/k8s-set-context@v2
+        uses: azure/k8s-set-context@0b53301dcc7ddd3f6d35f97fb67228ac4e5ab2fd # v2
         with:
           method: kubeconfig
           kubeconfig: |
@@ -106,7 +108,7 @@ jobs:
                 namespace: default
                 user: oidc-token
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: ${{ secrets.PR_ENV_IAM_ROLE }}
           role-session-name: GitHub_to_AWS_via_FederatedOIDC
@@ -118,18 +120,22 @@ jobs:
       - name: Create app database if not exists
         run: |
           export PGPASSWORD='${{ secrets.PR_ENV_DB_PASSWORD }}'
-          export PGUSER=${{ secrets.PR_ENV_DB_USER }}
-          export PGHOST=${{ secrets.PR_ENV_DB_HOST }}
-          export PGDATABASE=${{ secrets.PR_ENV_DB_NAME }}
+          export PGUSER=${PR_ENV_DB_USER}
+          export PGHOST=${PR_ENV_DB_HOST}
+          export PGDATABASE=${PR_ENV_DB_NAME}
           psql -tc "SELECT 1 FROM pg_database WHERE datname = 'hosting_pr${{ github.event.number }}'" \
           | grep -q 1 \
           || psql -c "CREATE DATABASE hosting_pr${{ github.event.number }}"
+        env:
+          PR_ENV_DB_USER: ${{ secrets.PR_ENV_DB_USER }}
+          PR_ENV_DB_HOST: ${{ secrets.PR_ENV_DB_HOST }}
+          PR_ENV_DB_NAME: ${{ secrets.PR_ENV_DB_NAME }}
       - name: Download Deployment YAML template
         if: ${{ !inputs.self_hosting }}
         run: aws s3 cp s3://metabase-pr-env/metabase.yml.tmpl ./metabase.yml.tmpl
       - name: Render Deployment YAML
         if: ${{ !inputs.self_hosting }}
-        uses: nowactions/envsubst@v1
+        uses: nowactions/envsubst@c4b8e3977354d294659a7ec164279ce8fba5c2e1 # v1
         with:
           input: ./metabase.yml.tmpl
           output: ./metabase.yml
@@ -148,7 +154,7 @@ jobs:
         run: aws s3 cp s3://metabase-pr-env/values.yaml.tmpl ./values.yaml.tmpl
       - name: Render Helm values (self-hosting)
         if: ${{ inputs.self_hosting }}
-        uses: nowactions/envsubst@v1
+        uses: nowactions/envsubst@c4b8e3977354d294659a7ec164279ce8fba5c2e1 # v1
         with:
           input: ./values.yaml.tmpl
           output: ./values.yaml
@@ -168,15 +174,18 @@ jobs:
 
       - name: Setup Helm
         if: ${{ inputs.self_hosting }}
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
         with:
           version: 'latest'
       - name: Login to Quay.io
         if: ${{ inputs.self_hosting }}
         run: |
           helm registry login quay.io \
-            --username ${{ secrets.QUAY_USERNAME }} \
-            --password ${{ secrets.QUAY_PASSWORD }}
+            --username ${QUAY_USERNAME} \
+            --password ${QUAY_PASSWORD}
+        env:
+          QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+          QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
       - name: Deploy PR Review ENV (self-hosting)
         if: ${{ inputs.self_hosting }}
         run: |
@@ -191,7 +200,7 @@ jobs:
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     needs: [deploy_pr]
     steps:
-      - uses: marocchino/sticky-pull-request-comment@v2
+      - uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
         with:
           recreate: true
           message: |

--- a/.github/workflows/pr-env.yml
+++ b/.github/workflows/pr-env.yml
@@ -120,9 +120,9 @@ jobs:
       - name: Create app database if not exists
         run: |
           export PGPASSWORD='${{ secrets.PR_ENV_DB_PASSWORD }}'
-          export PGUSER=${PR_ENV_DB_USER}
-          export PGHOST=${PR_ENV_DB_HOST}
-          export PGDATABASE=${PR_ENV_DB_NAME}
+          export PGUSER="${PR_ENV_DB_USER}"
+          export PGHOST="${PR_ENV_DB_HOST}"
+          export PGDATABASE="${PR_ENV_DB_NAME}"
           psql -tc "SELECT 1 FROM pg_database WHERE datname = 'hosting_pr${{ github.event.number }}'" \
           | grep -q 1 \
           || psql -c "CREATE DATABASE hosting_pr${{ github.event.number }}"
@@ -181,8 +181,8 @@ jobs:
         if: ${{ inputs.self_hosting }}
         run: |
           helm registry login quay.io \
-            --username ${QUAY_USERNAME} \
-            --password ${QUAY_PASSWORD}
+            --username "${QUAY_USERNAME}" \
+            --password "${QUAY_PASSWORD}"
         env:
           QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
           QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}

--- a/.github/workflows/presto-kerberos-integration-test.yml
+++ b/.github/workflows/presto-kerberos-integration-test.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Test which files changed
-        uses: dorny/paths-filter@v3.0.0
+        uses: dorny/paths-filter@0bc4621a3135347011ad047f9ecf449bf72ce2bd # v3.0.0
         id: changes
         with:
           token: ${{ github.token }}

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -383,7 +383,7 @@ jobs:
       - name: Publish to NPM
         working-directory: sdk
         run: |
-          echo //registry.npmjs.org/:_authToken=${NPM_RELEASE_TOKEN} > .npmrc
+          echo //registry.npmjs.org/:_authToken="${NPM_RELEASE_TOKEN}" > .npmrc
 
           TAG="${{ steps.compute-tag.outputs.masterTag }}"
           echo "Resolved npm tag: $TAG"

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -383,12 +383,14 @@ jobs:
       - name: Publish to NPM
         working-directory: sdk
         run: |
-          echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_RELEASE_TOKEN }} > .npmrc
+          echo //registry.npmjs.org/:_authToken=${NPM_RELEASE_TOKEN} > .npmrc
 
           TAG="${{ steps.compute-tag.outputs.masterTag }}"
           echo "Resolved npm tag: $TAG"
           npm publish --tag "$TAG"
 
+        env:
+          NPM_RELEASE_TOKEN: ${{ secrets.NPM_RELEASE_TOKEN }}
       # ⚠️ This step should only be executed on the latest stable (gold) release branch.
       # Only uncomment this when the new release branch becomes stable (gold).
       # - name: Add `latest` tag to the latest release branch (`release-x.55.x`) deployment

--- a/.github/workflows/release-log.yml
+++ b/.github/workflows/release-log.yml
@@ -29,7 +29,7 @@ jobs:
     if: ${{ github.event_name != 'push' || github.repository == 'metabase/metabase' }}
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           aws-access-key-id: ${{ secrets.AWS_S3_RELEASE_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_S3_RELEASE_SECRET_ACCESS_KEY }}

--- a/.github/workflows/release-milestone-check.yml
+++ b/.github/workflows/release-milestone-check.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           sparse-checkout: release
       - name: Install bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: "1.3.7"
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-patch.yml
+++ b/.github/workflows/release-patch.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           sparse-checkout: release
       - name: Install bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: "1.3.7"
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -146,7 +146,7 @@ jobs:
         edition: ${{ fromJson(needs.check-version.outputs.edition_matrix) }}
     steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
       with:
         aws-access-key-id: ${{ secrets.AWS_S3_RELEASE_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_S3_RELEASE_SECRET_ACCESS_KEY }}
@@ -243,7 +243,7 @@ jobs:
         fi
 
     - name: Login to Docker Hub
-      uses: docker/login-action@v3
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
       with:
         username: ${{ secrets.DOCKERHUB_RELEASE_USERNAME }}
         password: ${{ secrets.DOCKERHUB_RELEASE_TOKEN }}
@@ -299,7 +299,7 @@ jobs:
       AWS_REGION: ${{ vars.AWS_REGION }}
     steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
       with:
         aws-access-key-id: ${{ secrets.AWS_S3_RELEASE_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_S3_RELEASE_SECRET_ACCESS_KEY }}

--- a/.github/workflows/release-tests.yml
+++ b/.github/workflows/release-tests.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Test which files changed
-        uses: dorny/paths-filter@v3.0.0
+        uses: dorny/paths-filter@0bc4621a3135347011ad047f9ecf449bf72ce2bd # v3.0.0
         id: changes
         with:
           token: ${{ github.token }}
@@ -37,7 +37,7 @@ jobs:
         with:
           sparse-checkout: "release"
       - name: Install bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: "1.3.7"
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -56,7 +56,7 @@ jobs:
         with:
           sparse-checkout: "release"
       - name: Install bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: "1.3.7"
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -75,7 +75,7 @@ jobs:
         with:
           sparse-checkout: "release"
       - name: Install bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: "1.3.7"
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,7 +186,7 @@ jobs:
         edition: [oss, ee]
     steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
       with:
         aws-access-key-id: ${{ secrets.AWS_S3_RELEASE_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_S3_RELEASE_SECRET_ACCESS_KEY }}
@@ -530,7 +530,7 @@ jobs:
         echo "skipping version info update for nightly patch"
         exit 0
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
       with:
         aws-access-key-id: ${{ secrets.AWS_S3_RELEASE_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_S3_RELEASE_SECRET_ACCESS_KEY }}

--- a/.github/workflows/repro-bot.yml
+++ b/.github/workflows/repro-bot.yml
@@ -33,13 +33,15 @@ jobs:
         id: issue
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            ISSUE_NUMBER="${{ github.event.inputs.issue_number }}"
+            ISSUE_NUMBER="${INPUT_ISSUE_NUMBER}"
           else
             ISSUE_NUMBER="${{ github.event.issue.number }}"
           fi
           echo "number=$ISSUE_NUMBER" >> $GITHUB_OUTPUT
           echo "Issue: https://github.com/${{ github.repository }}/issues/$ISSUE_NUMBER"
 
+        env:
+          INPUT_ISSUE_NUMBER: ${{ github.event.inputs.issue_number }}
       - uses: actions/checkout@v4
       - uses: ./.github/actions/prepare-backend
       - uses: ./.github/actions/prepare-frontend
@@ -128,7 +130,7 @@ jobs:
       - name: Run repro-bot with Claude Code
         id: claude
         continue-on-error: true
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@3ac52d0da9f8ec9ca7b4dc23bb477e36ef9c77a9 # v1
         env:
           CLAUDE_CODE_DEBUG_LOGS_DIR: /tmp/claude-debug-logs
           CLAUDE_WORKING_DIR: ${{ github.workspace }}/repro-bot

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Test which files changed
-        uses: dorny/paths-filter@v3.0.0
+        uses: dorny/paths-filter@0bc4621a3135347011ad047f9ecf449bf72ce2bd # v3.0.0
         id: changes
         with:
           token: ${{ github.token }}

--- a/.github/workflows/security-slack-notification.yml
+++ b/.github/workflows/security-slack-notification.yml
@@ -19,7 +19,7 @@ jobs:
             core.setOutput('issue_title', ${{ toJson(github.event.issue.title) }}.replaceAll(/"/g, '\\"'));
       - name: Send the issue ${{ github.event.issue.number }} to Slack
         id: slack
-        uses: slackapi/slack-github-action@v1.26.0
+        uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
         with:
           payload: |
             {

--- a/.github/workflows/set-announce-url.yml
+++ b/.github/workflows/set-announce-url.yml
@@ -21,7 +21,7 @@ jobs:
             exit 1
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           aws-access-key-id: ${{ secrets.AWS_S3_RELEASE_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_S3_RELEASE_SECRET_ACCESS_KEY }}

--- a/.github/workflows/snowplow.yml
+++ b/.github/workflows/snowplow.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Test which files changed
-        uses: dorny/paths-filter@v3.0.0
+        uses: dorny/paths-filter@0bc4621a3135347011ad047f9ecf449bf72ce2bd # v3.0.0
         id: changes
         with:
           token: ${{ github.token }}

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -51,7 +51,7 @@ jobs:
             category: release-helper
     steps:
       - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: "1.3.7"
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -71,7 +71,7 @@ jobs:
           bun install --yarn
           sed -i -E 's/< ([0-9]+)\.0\.0"/< \1"/g; s/< ([0-9]+)\.0"/< \1"/g' yarn.lock || true
         working-directory: release
-      - uses: snyk/actions/setup@0.4.0
+      - uses: snyk/actions/setup@b98d498629f1c368650224d6d212bf7dfa89e4bf # 0.4.0
       - name: Run snyk test
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
@@ -148,7 +148,7 @@ jobs:
             category: driver-vertica
     steps:
       - uses: actions/checkout@v4
-      - uses: snyk/actions/setup@0.4.0
+      - uses: snyk/actions/setup@b98d498629f1c368650224d6d212bf7dfa89e4bf # 0.4.0
       - name: Download pom files
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/tag-for-release.yml
+++ b/.github/workflows/tag-for-release.yml
@@ -198,7 +198,7 @@ jobs:
     timeout-minutes: 15
     steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
       with:
         aws-access-key-id: ${{ secrets.AWS_S3_RELEASE_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_S3_RELEASE_SECRET_ACCESS_KEY }}
@@ -226,8 +226,10 @@ jobs:
           return version_path;
     - name: Upload to S3
       run: |
-        aws s3 cp ./metabase.jar s3://${{ secrets.AWS_S3_CLOUD_DEPLOY_BUCKET }}/${{ steps.version_path.outputs.result }}/metabase.jar
+        aws s3 cp ./metabase.jar s3://${AWS_S3_CLOUD_DEPLOY_BUCKET}/${{ steps.version_path.outputs.result }}/metabase.jar
 
+      env:
+        AWS_S3_CLOUD_DEPLOY_BUCKET: ${{ secrets.AWS_S3_CLOUD_DEPLOY_BUCKET }}
   run-pre-release-tests:
     name: Run pre-release tests for ${{ inputs.version }}
     needs: tag-uberjar-for-release

--- a/.github/workflows/tag-for-release.yml
+++ b/.github/workflows/tag-for-release.yml
@@ -226,7 +226,7 @@ jobs:
           return version_path;
     - name: Upload to S3
       run: |
-        aws s3 cp ./metabase.jar s3://${AWS_S3_CLOUD_DEPLOY_BUCKET}/${{ steps.version_path.outputs.result }}/metabase.jar
+        aws s3 cp ./metabase.jar s3://"${AWS_S3_CLOUD_DEPLOY_BUCKET}"/${{ steps.version_path.outputs.result }}/metabase.jar
 
       env:
         AWS_S3_CLOUD_DEPLOY_BUCKET: ${{ secrets.AWS_S3_CLOUD_DEPLOY_BUCKET }}

--- a/.github/workflows/team-issues-slack-notification.yml
+++ b/.github/workflows/team-issues-slack-notification.yml
@@ -30,7 +30,7 @@ jobs:
           echo "team_name=${team_name^^}_SLACK_ISSUES_WEBHOOK_URL" >> "$GITHUB_OUTPUT"
       - name: Send the issue ${{ github.event.issue.number }} to Slack
         id: slack
-        uses: slackapi/slack-github-action@v1.23.0
+        uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844 # v1.23.0
         with:
           payload: |
             {

--- a/.github/workflows/transforms-python-stress-test.yml
+++ b/.github/workflows/transforms-python-stress-test.yml
@@ -99,7 +99,7 @@ jobs:
       run: |
         sudo echo "127.0.0.1 server.clickhouseconnect.test" | sudo tee -a /etc/hosts
     - name: Start ClickHouse in Docker
-      uses: hoverkraft-tech/compose-action@v2.0.0
+      uses: hoverkraft-tech/compose-action@802a148945af6399a338c7906c267331b39a71af # v2.0.0
       with:
         compose-file: "modules/drivers/clickhouse/docker-compose.yml"
         down-flags: "--volumes"

--- a/.github/workflows/translation-context.yml
+++ b/.github/workflows/translation-context.yml
@@ -35,7 +35,7 @@ jobs:
       # Hence, the three minute timeout and continue-on-error.
       - name: Trigger pre-translations
         timeout-minutes: 3
-        uses: crowdin/github-action@v2
+        uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2
         # https://crowdin.github.io/crowdin-cli/commands/crowdin-pre-translate
         with:
           command: "pre-translate"

--- a/.github/workflows/translation-update.yml
+++ b/.github/workflows/translation-update.yml
@@ -33,7 +33,7 @@ jobs:
         run: sudo apt-get install gettext
 
       - name: Crowdin download
-        uses: crowdin/github-action@v2
+        uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2
         id: crowdin-download
         with:
           config: locales/crowdin.yml
@@ -74,7 +74,7 @@ jobs:
           git push -u origin $BRANCH_NAME
 
       - name: Crowdin upload
-        uses: crowdin/github-action@v2
+        uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2
         id: crowdin-upload
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -105,13 +105,13 @@ jobs:
           echo "::set-output name=pr_number::$PR_NUMBER"
 
       - name: Auto approve PR
-        uses: juliangruber/approve-pull-request-action@v1
+        uses: juliangruber/approve-pull-request-action@f83b836abaed1b3ab639ae61f9117c52ae405f65 # v1
         with:
           github-token: ${{ github.token }}
           number: ${{ steps.create_pr.outputs.pr_number }}
 
       - name: Enable Pull Request Automerge
-        uses: peter-evans/enable-pull-request-automerge@v2
+        uses: peter-evans/enable-pull-request-automerge@684fed02ccc9b5eefcf7d40b65b3cd44255bd5bc # v2
         with:
           token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
           pull-request-number: ${{ steps.create_pr.outputs.pr_number }}

--- a/.github/workflows/update-e2e-timings.yml
+++ b/.github/workflows/update-e2e-timings.yml
@@ -64,7 +64,7 @@ jobs:
           echo "Branch name will be: $BRANCH_NAME"
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
         with:
           token: ${{ steps.app-token.outputs.token }}
           branch: ${{ env.BRANCH_NAME }}

--- a/.github/workflows/yaml.yml
+++ b/.github/workflows/yaml.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Test which files changed
-        uses: dorny/paths-filter@v3.0.0
+        uses: dorny/paths-filter@0bc4621a3135347011ad047f9ecf449bf72ce2bd # v3.0.0
         id: changes
         with:
           token: ${{ github.token }}


### PR DESCRIPTION
Re-submission of #71466. Had a problem with my fork and had to delete it, which closed the original PR. Apologies for the noise.

## Summary

This PR pins all GitHub Actions to immutable commit SHAs instead of mutable version tags and extracts expressions from `run:` blocks into `env:` mappings.

- Pin 87 unpinned actions to full 40-character SHAs
- Add version comments for readability
- Extract 20 expressions from run blocks to env vars

## Changes by file

| File | Changes |
|------|---------|
| athena.yml | Pinned actions to SHA |
| auto-assign.yml | Pinned actions to SHA |
| backend-cloverage.yml | Pinned actions to SHA |
| backend.yml | Pinned actions to SHA |
| backport-reminder.yml | Pinned actions to SHA |
| chromatic.yml | Pinned actions to SHA |
| cljs.yml | Pinned actions to SHA |
| codeql.yml | Pinned actions to SHA |
| codespell.yml | Pinned actions to SHA |
| containerize-jar.yml | Pinned actions to SHA |
| containerize-uberjar.yml | Pinned actions to SHA |
| conventional-commit-pr-title-reminder.yml | Pinned actions to SHA |
| coverage.yml | Pinned actions to SHA |
| docs-links.yml | Pinned actions to SHA |
| drivers-stress-test.yml | Pinned actions to SHA |
| drivers.yml | Pinned actions to SHA |
| e2e-stress-test-flake-fix.yml | Pinned actions to SHA |
| embedding-sdk-host-sample-apps-tests.yml | Pinned actions to SHA |
| embedding-sdk-labels-reminder.yml | Pinned actions to SHA |
| escalation-slack-notification.yml | Pinned actions to SHA |
| frontend-unit-test-stress-test-flake-fix.yml | Pinned actions to SHA |
| generative-query-test.yml | Pinned actions to SHA |
| i18n.yml | Pinned actions to SHA |
| loki.yml | Pinned actions to SHA |
| main.yml | Pinned actions to SHA |
| module-boundaries-stats.yml | Pinned actions to SHA |
| openapi.yml | Pinned actions to SHA |
| perf-test.yml | Pinned actions to SHA |
| pr-env-destroy.yml | Pinned actions to SHA |
| pr-env.yml | Pinned actions to SHA |
| presto-kerberos-integration-test.yml | Pinned actions to SHA |
| release-embedding-sdk.yml | Pinned actions to SHA |
| release-log.yml | Pinned actions to SHA |
| release-milestone-check.yml | Pinned actions to SHA |
| release-patch.yml | Pinned actions to SHA |
| release-tag.yml | Pinned actions to SHA |
| release-tests.yml | Pinned actions to SHA |
| release.yml | Pinned actions to SHA |
| repro-bot.yml | Pinned actions to SHA |
| run-tests.yml | Pinned actions to SHA |
| security-slack-notification.yml | Pinned actions to SHA |
| set-announce-url.yml | Pinned actions to SHA |
| snowplow.yml | Pinned actions to SHA |
| snyk.yml | Pinned actions to SHA |
| tag-for-release.yml | Pinned actions to SHA |
| team-issues-slack-notification.yml | Pinned actions to SHA |
| transforms-python-stress-test.yml | Pinned actions to SHA |
| translation-context.yml | Pinned actions to SHA |
| translation-update.yml | Pinned actions to SHA |
| update-e2e-timings.yml | Pinned actions to SHA |
| yaml.yml | Pinned actions to SHA |

## A note on internal action pinning

This PR pins all actions including org-owned ones. Best practice is to pin everything — the tj-actions/changed-files attack was an internally maintained action that was compromised, and every repo referencing it by tag silently executed attacker code. That said, it's your codebase. If you'd prefer to leave org-owned actions unpinned, let us know and we'll adjust the PR.

## How to verify

Review the diff — each change is mechanical and preserves workflow behavior:
- **SHA pinning**: `action@v3` becomes `action@abc123 # v3` — original version preserved as comment
- **Expression extraction**: `${{ expr }}` in `run:` moves to `env:` block, referenced as `$ENV_VAR` in the script
- No workflow logic, triggers, or permissions are modified

I put up some research on this on [Twitter](https://x.com/vigilance_one/status/2036581210663616729) and a [research site](https://www.vigilantdefense.com/research/github-top-50k-repos-cicd-security-scan) if you want more context. I wrote a scanner called Runner Guard and open sourced it [here](https://github.com/Vigilant-LLC/runner-guard).

If you have any questions, reach out. I'll be monitoring comms.

\- Chris Nyhuis (dagecko)