### PR TITLE
BOT-1221 Resolve metabase://transform links to new data-studio path

### DIFF
--- a/src/metabase/metabot/agent/links.clj
+++ b/src/metabase/metabot/agent/links.clj
@@ -24,7 +24,7 @@
    "metric"    "/metric"
    "dashboard" "/dashboard"
    "question"  "/question"
-   "transform" "/admin/transforms"})
+   "transform" "/data-studio/transforms"})
 
 ;;; Query/Chart URL Generation
 

--- a/test/metabase/metabot/agent/links_test.clj
+++ b/test/metabase/metabot/agent/links_test.clj
@@ -31,7 +31,7 @@
     (is (= "/metric/456" (links/resolve-metabase-uri "metabase://metric/456" {} {})))
     (is (= "/dashboard/789" (links/resolve-metabase-uri "metabase://dashboard/789" {} {})))
     (is (= "/question/101" (links/resolve-metabase-uri "metabase://question/101" {} {})))
-    (is (= "/admin/transforms/202" (links/resolve-metabase-uri "metabase://transform/202" {} {})))))
+    (is (= "/data-studio/transforms/202" (links/resolve-metabase-uri "metabase://transform/202" {} {})))))
 
 (deftest ^:parallel resolve-metabase-uri-table-link-test
   (testing "resolves table links to ad-hoc question URLs"
@@ -384,8 +384,8 @@
     (let [registry (atom {})
           text     "[Dash](metabase://dashboard/10) [Tx](metabase://transform/30)"
           _result  (links/resolve-links text {} {} registry)]
-      (is (= {"/dashboard/10"        "metabase://dashboard/10"
-              "/admin/transforms/30" "metabase://transform/30"}
+      (is (= {"/dashboard/10"              "metabase://dashboard/10"
+              "/data-studio/transforms/30" "metabase://transform/30"}
              @registry)))))
 
 (deftest ^:parallel resolve-links-does-not-record-failed-resolutions-test

--- a/test/metabase/metabot/agent/markdown_link_buffer_test.clj
+++ b/test/metabase/metabot/agent/markdown_link_buffer_test.clj
@@ -151,6 +151,11 @@
   (testing "resolves metabase://dashboard links"
     (let [[output flushed] (process "[Sales Dashboard](metabase://dashboard/789)")]
       (is (= "[Sales Dashboard](/dashboard/789)" output))
+      (is (= "" flushed))))
+
+  (testing "resolves metabase://transform links"
+    (let [[output flushed] (process "[My Transform](metabase://transform/42)")]
+      (is (= "[My Transform](/data-studio/transforms/42)" output))
       (is (= "" flushed)))))
 
 (deftest ^:parallel resolve-link-split-across-chunks-test


### PR DESCRIPTION
Closes [BOT-1221: Metabot resolves metabase://transform links incorrectly](https://linear.app/metabase/issue/BOT-1221/metabot-resolves-metabasetransform-links-incorrectly)

### Description

`metabase.metabot.agent.links/resolve-entity-link` was resolving `metabase://transform/<id>` links to the old `/admin/transforms/<id>` path. Update it to resolve to the new `/data-studio/transform/<id>` path

### Demo

<img width="481" height="294" alt="Screenshot 2026-03-27 at 4 32 20 PM" src="https://github.com/user-attachments/assets/5ccfb6e7-777c-4ef8-bfc6-49eb78016240" />
<img width="682" height="131" alt="Screenshot 2026-03-27 at 4 32 52 PM" src="https://github.com/user-attachments/assets/2ed9f761-462e-4821-a73b-9e81a8e758fc" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
