### PR TITLE
BOT-1223 Fix zero-arity tool call schemas for anthropic provider

### DIFF
--- a/src/metabase/metabot/self/claude.clj
+++ b/src/metabase/metabot/self/claude.clj
@@ -153,7 +153,7 @@
                                :content [{:type  "tool_use"
                                           :id    (:id part)
                                           :name  (:function part)
-                                          :input (:arguments part)}]}
+                                          :input (or (:arguments part) {})}]}
                  :tool-output {:role    "user"
                                :content [{:type        "tool_result"
                                           :tool_use_id (:id part)

--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -416,7 +416,7 @@
                          (= (:type chunk) :tool-output-available) (assoc ::duration-ms duration-ms))))
           results  (try
                      (let [{:keys [arguments]} (into {} (aisdk-xf) chunks)
-                           arguments (coerce-stringified-json arguments)
+                           arguments (or (coerce-stringified-json arguments) {})
                            decode    (tool-decode-fn tool)
                            arguments (cond-> arguments decode decode)]
                        (log/debug "Executing tool" {:tool-name tool-name :arguments arguments})

--- a/src/metabase/metabot/self/openrouter.clj
+++ b/src/metabase/metabot/self/openrouter.clj
@@ -63,7 +63,7 @@
                                             :type     "function"
                                             :function {:name      (:function part)
                                                        :arguments (let [args (:arguments part)]
-                                                                    (if (string? args) args (json/encode args)))}}]}
+                                                                    (if (string? args) args (json/encode (or args {}))))}}]}
                 :tool-output {:role         "tool"
                               :tool_call_id (:id part)
                               :content      (or (get-in part [:result :output])

--- a/src/metabase/metabot/tools/document.clj
+++ b/src/metabase/metabot/tools/document.clj
@@ -91,7 +91,7 @@
 - Use this tool when an existing model or metric does not answer the user's question.
 - Do NOT use this tool if there is a model or metric that can answer the user's question
   unless the user is requesting SQL."
-  [_args :- [:maybe [:map {:closed true}]]]
+  [_args :- [:map {:closed true}]]
   (try
     (let [refs         (context-references)
           database-ids (referenced-database-ids refs)]

--- a/src/metabase/metabot/tools/metadata.clj
+++ b/src/metabase/metabot/tools/metadata.clj
@@ -136,7 +136,7 @@
 (mu/defn ^{:tool-name "list_available_data_sources"}
   list-available-data-sources-tool
   "List all data sources (metrics and models) available to the metabot instance."
-  [_args :- [:maybe [:map {:closed true}]]]
+  [_args :- [:map {:closed true}]]
   (add-output
    (entity-details-tools/answer-sources {:metabot-id         shared/*metabot-id*
                                          :with-field-values? false})

--- a/src/metabase/metabot/tools/snippets.clj
+++ b/src/metabase/metabot/tools/snippets.clj
@@ -62,7 +62,7 @@
   Use this tool before editing or creating SQL transforms to understand what
   snippets are available. If any snippets may be relevant to the user's request,
   fetch their content using the get_snippet_details tool."
-  [_args :- [:maybe [:map {:closed true}]]]
+  [_args :- [:map {:closed true}]]
   (add-output (get-snippets {}) format-snippet-list-output))
 
 (mu/defn ^{:tool-name    "get_snippet_details"

--- a/src/metabase/metabot/tools/todo.clj
+++ b/src/metabase/metabot/tools/todo.clj
@@ -133,7 +133,7 @@
   todo-read-tool
   "Read the current todo list from memory.
   Returns the list of todos that have been created during this conversation."
-  [_args :- [:maybe [:map {:closed true}]]]
+  [_args :- [:map {:closed true}]]
   (try
     (add-output
      (todo-read {:memory-atom shared/*memory-atom*})

--- a/test/metabase/metabot/self/claude_test.clj
+++ b/test/metabase/metabot/self/claude_test.clj
@@ -121,6 +121,16 @@
               {:type :tool-output :id "call-1" :result {:output "2025-02-13T14:00:00+02:00"}}
               {:type :text :text "It's 2:00 PM in Kyiv."}])))))
 
+(deftest ^:parallel parts->claude-messages-nil-arguments-test
+  (testing "tool call with nil arguments defaults to empty object"
+    (is (=? [{:role    "assistant"
+              :content [{:type  "tool_use"
+                         :id    "call-1"
+                         :name  "todo_read"
+                         :input {}}]}]
+            (claude/parts->claude-messages
+             [{:type :tool-input :id "call-1" :function "todo_read" :arguments nil}])))))
+
 (deftest ^:parallel parts->claude-messages-error-result-test
   (testing "tool error is formatted as error string"
     (is (=? [{:role    "user"

--- a/test/metabase/metabot/self/openrouter_test.clj
+++ b/test/metabase/metabot/self/openrouter_test.clj
@@ -60,6 +60,17 @@
              [{:type :tool-output :id "call-1" :result {:output "Result 1"}}
               {:type :tool-output :id "call-2" :result {:output "Result 2"}}])))))
 
+(deftest ^:parallel parts->cc-messages-nil-arguments-test
+  (testing "tool call with nil arguments defaults to empty object JSON string"
+    (is (=? [{:role       "assistant"
+              :content    nil
+              :tool_calls [{:id       "call-1"
+                            :type     "function"
+                            :function {:name      "todo_read"
+                                       :arguments "{}"}}]}]
+            (openrouter/parts->cc-messages
+             [{:type :tool-input :id "call-1" :function "todo_read" :arguments nil}])))))
+
 (deftest ^:parallel parts->cc-messages-full-conversation-test
   (testing "full conversation with tool round-trip"
     (is (=? [{:role "user"      :content "What time is it in Kyiv?"}

--- a/test/metabase/metabot/self_test.clj
+++ b/test/metabase/metabot/self_test.clj
@@ -235,13 +235,23 @@
                    {:type :tool-input :id "call-err" :function "get-time" :arguments {:tz "Invalid/Timezone"}}])
           result (into [] (self.core/tool-executor-xf test-util/TOOLS) chunks)]
       (is (= (count chunks) (dec (count result))))
-      (let [tool-result (last result)]
-        (is (=? {:type       :tool-output-available
-                 :toolCallId "call-err"
-                 :toolName   "get-time"
-                 :error      {:message string?
-                              :type    string?}}
-                tool-result)))))
+      (is (=? {:type       :tool-output-available
+               :toolCallId "call-err"
+               :toolName   "get-time"
+               :error      {:message string?
+                            :type    string?}}
+              (last result)))))
+
+  (testing "tool-executor-xf handles nil arguments for no-arg tools"
+    (let [chunks (test-util/parts->aisdk-chunks
+                  [{:type :start :id "msg-nil"}
+                   {:type :tool-input :id "call-nil" :function "no-arg" :arguments nil}])
+          result (into [] (self.core/tool-executor-xf test-util/TOOLS) chunks)]
+      (is (=? {:type       :tool-output-available
+               :toolCallId "call-nil"
+               :toolName   "no-arg"
+               :result     {:output "ok"}}
+              (last result)))))
 
   (testing "tool-executor-xf ignores unknown tool names"
     (let [chunks (test-util/parts->aisdk-chunks

--- a/test/metabase/metabot/test_util.clj
+++ b/test/metabase/metabot/test_util.clj
@@ -145,7 +145,13 @@
                     (reduce [_ rf init]
                       (reduce rf init chunks)))))})
 
+(defn no-arg-tool []
+  {:tool-name "no-arg"
+   :doc       "A tool that takes no arguments."
+   :schema    [:=> [:cat [:map {:closed true}]] :any]
+   :fn        (fn [_] {:output "ok"})})
+
 (def TOOLS
   "Tool map for tests — keyed by tool name string."
-  (let [tool-defs (map #(%) [get-time-tool convert-currency-tool mock-llm-tool])]
+  (let [tool-defs (map #(%) [get-time-tool convert-currency-tool mock-llm-tool no-arg-tool])]
     (into {} (map (juxt :tool-name identity)) tool-defs)))


### PR DESCRIPTION
Closes [BOT-1223 Metabot transforms chat broken: Unhandled error accessing Anthropic API.](https://linear.app/metabase/issue/BOT-1223/metabot-transforms-chat-broken-unhandled-error-accessing-anthropic-api)


### Description

Anthropic is stricter than openrouter about schemas for tool calls with no arguments. A schema like `[:maybe :map]` produces a JSON schema like `{"oneOf": [{"type": "object", ...}, {"type": "null"}]}` but Anthropic's API requires `input_schema` to be `{"type": "object", ...}` at the top level. A `oneOf` with a null variant is invalid.

Update all the zero-arg tool schemas from `[:maybe [:map {:closed true}]]` to `[:map {:closed true}]` and modify tool calling code accordingly to pass an empty map rather than `nil`.

### How to verify

Configure metabot to use the anthropic provider directly rather than openrouter. E.g. `MB_LLM_METABOT_PROVIDER="anthropic/claude-sonnet-4-6"` (this is the default)

1. Data Studio -> Transforms
2. Open metabot chat
3. Say "hi metabot" or ask it to create a transform

### Demo

#### before

<img width="1402" height="306" alt="Screenshot 2026-03-27 at 5 07 51 PM" src="https://github.com/user-attachments/assets/75a34d21-7e20-4f12-b313-bad69b0912ba" />

#### after

<img width="1398" height="336" alt="Screenshot 2026-03-27 at 5 10 22 PM" src="https://github.com/user-attachments/assets/ae21d314-202e-407f-8137-2584125496f6" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
