### PR TITLE
Fix flaky test

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/authentication.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/authentication.cy.spec.ts
@@ -150,10 +150,11 @@ describe("scenarios > embedding > sdk iframe embedding > authentication", () => 
     });
 
     frame.within(() => {
-      cy.findByTestId("sdk-error-container", { timeout: 10_000 }).should(
-        "contain",
-        /Failed to authenticate using an existing Metabase user session./,
-      );
+      cy.findByTestId("sdk-error-container")
+        .findByText(
+          "Failed to authenticate using an existing Metabase user session.",
+        )
+        .should("be.visible");
 
       cy.findByRole("link", { name: "Read more." })
         .should("have.attr", "href")


### PR DESCRIPTION
closes EMB-1515

I have no idea why this flaked, but switching up the assertions seemed to have done the trick.

[Stress test master](https://github.com/metabase/metabase/actions/runs/23708542140): ❌ 10/20 passed
[Stress test PR](https://github.com/metabase/metabase/actions/runs/23708543114): ✅ 20/20 passed