### PR TITLE
Re-check migration versions when base branches update

### DIFF
--- a/.github/workflows/check-migration-version.yml
+++ b/.github/workflows/check-migration-version.yml
@@ -1,0 +1,25 @@
+name: Check Migration Versions
+
+on:
+  pull_request:
+    paths:
+      - 'resources/migrations/**'
+
+concurrency:
+  group: check-migration-version-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check-migration-version:
+    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          filter: blob:none
+          fetch-depth: 1
+
+      - name: Check migration versions
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: bin/check-migration-versions

--- a/.github/workflows/recheck-migration-versions.yml
+++ b/.github/workflows/recheck-migration-versions.yml
@@ -1,0 +1,73 @@
+name: Re-check Migration Versions
+
+on:
+  push:
+    branches:
+      - master
+      - 'release-x.*.x'
+
+concurrency:
+  group: recheck-migration-versions-${{ github.ref_name }}
+  cancel-in-progress: true
+
+# This workflow needs a token with:
+#   actions: write    — to re-run workflow runs via `gh run rerun`
+#   pull-requests: read — to list open PRs and their changed files
+# The default GITHUB_TOKEN may not have actions:write depending on repo settings.
+# If re-runs fail with 403s, the repo owner needs to grant this permission.
+permissions:
+  actions: write
+  pull-requests: read
+
+jobs:
+  recheck-open-prs:
+    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    timeout-minutes: 10
+    steps:
+      - name: Re-trigger migration checks on affected PRs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH: ${{ github.ref_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          echo "Branch ${BRANCH} was updated — finding open PRs targeting it with migration changes..."
+
+          # Find open PRs targeting this branch that touch migration files.
+          # Uses the search API to filter in one call instead of looping per-PR.
+          pr_branches=$(gh pr list \
+            --repo "$REPO" \
+            --base "$BRANCH" \
+            --state open \
+            --json number,headRefName,files \
+            --jq '[.[] | select(.files | map(.path) | any(startswith("resources/migrations/"))) | {number, headRefName}]')
+
+          if [[ "$pr_branches" == "[]" || -z "$pr_branches" ]]; then
+            echo "No open PRs targeting ${BRANCH} with migration changes."
+            exit 0
+          fi
+
+          echo "Found PRs with migration changes:"
+          echo "$pr_branches" | jq -r '.[] | "  PR #\(.number) (\(.headRefName))"'
+          echo ""
+
+          echo "$pr_branches" | jq -c '.[]' | while IFS= read -r pr_json; do
+            pr_number=$(echo "$pr_json" | jq -r '.number')
+            head_branch=$(echo "$pr_json" | jq -r '.headRefName')
+
+            run_id=$(gh run list \
+              --repo "$REPO" \
+              --workflow "check-migration-version.yml" \
+              --branch "$head_branch" \
+              --json databaseId \
+              --jq '.[0].databaseId // empty')
+
+            if [[ -n "$run_id" ]]; then
+              gh run rerun "$run_id" --repo "$REPO" && \
+                echo "Re-triggered run ${run_id} for PR #${pr_number}." || \
+                echo "::warning::Failed to re-trigger run for PR #${pr_number}."
+            else
+              echo "No previous run found for PR #${pr_number} — it will be checked on next push."
+            fi
+          done

--- a/bin/check-migration-versions
+++ b/bin/check-migration-versions
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+#
+# Check that new migration changeset IDs target the correct version.
+#
+# Usage:
+#   bin/check-migration-versions [BASE_REF]
+#
+# In CI, BASE_REF is set by the workflow. Locally it can be passed as an
+# argument (defaults to master). The base ref is fetched if not already
+# available.
+#
+# The "current version" is detected empirically from the highest
+# release-x.N.x branch on the remote. PRs targeting master should use
+# current+1; PRs targeting a release branch should match that branch's version.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Resolve base ref
+# ---------------------------------------------------------------------------
+
+BASE_REF="${1:-${BASE_REF:-master}}"
+
+# ---------------------------------------------------------------------------
+# Detect current released version from remote release branches
+# ---------------------------------------------------------------------------
+
+detect_current_version() {
+  git ls-remote --heads origin 'refs/heads/release-x.*.x' \
+    | sed -n 's|.*refs/heads/release-x\.\([0-9][0-9]*\)\.x$|\1|p' \
+    | sort -n \
+    | tail -1
+}
+
+current_version=$(detect_current_version)
+
+if [[ -z "$current_version" ]]; then
+  echo "ERROR: Could not detect current version from release branches." >&2
+  exit 1
+fi
+
+echo "Detected current version from release branches: ${current_version}"
+
+# ---------------------------------------------------------------------------
+# Determine the expected migration version for this target branch
+# ---------------------------------------------------------------------------
+
+if [[ "$BASE_REF" == "master" ]]; then
+  expected_version=$(( current_version + 1 ))
+elif [[ "$BASE_REF" =~ ^release-x\.([0-9]+)\.x$ ]]; then
+  expected_version="${BASH_REMATCH[1]}"
+else
+  echo "Target branch '${BASE_REF}' is not master or a release branch — skipping check."
+  exit 0
+fi
+
+echo "Target branch: ${BASE_REF}"
+echo "Expected migration version: v${expected_version}"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Make sure we have the base ref available for diffing
+# ---------------------------------------------------------------------------
+
+if ! git rev-parse "origin/${BASE_REF}" &>/dev/null; then
+  git fetch origin "${BASE_REF}" --depth=1
+fi
+
+# ---------------------------------------------------------------------------
+# Parse the diff for added changeset IDs
+# ---------------------------------------------------------------------------
+
+errors=0
+found_any=false
+current_file=""
+
+while IFS= read -r line; do
+  # Track current file from diff headers
+  if [[ "$line" =~ ^\+\+\+\ b/(.*) ]]; then
+    current_file="${BASH_REMATCH[1]}"
+    continue
+  fi
+
+  # Match added lines containing a changeset id (with or without indentation)
+  if [[ "$line" =~ ^\+.*id:\ *v([0-9]+)\. ]]; then
+    found_any=true
+    actual_version="${BASH_REMATCH[1]}"
+
+    if [[ "$actual_version" != "$expected_version" ]]; then
+      echo "ERROR: ${current_file}: found migration version v${actual_version} but expected v${expected_version}" >&2
+      errors=$((errors + 1))
+    fi
+  fi
+done < <(git diff --no-color "origin/${BASE_REF}...HEAD" -- 'resources/migrations/*.yaml' 'resources/migrations/**/*.yaml')
+
+if [[ "$found_any" == "false" ]]; then
+  echo "No new changeset IDs in diff."
+  exit 0
+fi
+
+if [[ "$errors" -gt 0 ]]; then
+  echo "" >&2
+  echo "${errors} changeset(s) have the wrong version." >&2
+  echo "" >&2
+  if [[ "$BASE_REF" == "master" ]]; then
+    echo "PRs targeting master should use version v$(( current_version + 1 ))." >&2
+    echo "(Current version detected from release branches: ${current_version})" >&2
+  else
+    echo "PRs targeting ${BASE_REF} should use version v${expected_version}." >&2
+  fi
+  exit 1
+fi
+
+echo "All migration versions are correct (v${expected_version})."


### PR DESCRIPTION
Adds a workflow that triggers on pushes to master and release branches.
It finds open PRs targeting that branch which touch migration files, it re-runs their check-migration-version workflow to catch PRs that they have become stale after a new release branch is cut.

