### PR TITLE
feat(sdk,embed-js): Enhance getEventTarget to support TouchEvent for improved mobile compatibility when showing a drill popup

### DIFF
--- a/e2e/support/helpers/e2e-mobile-device-helpers.ts
+++ b/e2e/support/helpers/e2e-mobile-device-helpers.ts
@@ -1,8 +1,18 @@
+const LONG_PRESS_MS = 600;
+
 export function enableTouchEmulation() {
   cy.then(() =>
     Cypress.automation("remote:debugger:protocol", {
       command: "Emulation.setTouchEmulationEnabled",
       params: { enabled: true, maxTouchPoints: 5 },
+    }),
+  );
+
+  // Make CSS @media (hover: none) match on emulated touch devices
+  cy.then(() =>
+    Cypress.automation("remote:debugger:protocol", {
+      command: "Emulation.setEmulatedMedia",
+      params: { features: [{ name: "hover", value: "none" }] },
     }),
   );
 
@@ -16,4 +26,55 @@ export function disableTouchEmulation() {
       params: { enabled: false },
     }),
   );
+
+  cy.then(() =>
+    Cypress.automation("remote:debugger:protocol", {
+      command: "Emulation.setEmulatedMedia",
+      params: { features: [] },
+    }),
+  );
+}
+
+export function longPressAndDrag(
+  selector: string,
+  startX: number,
+  startY: number,
+  endX: number,
+  holdMs = LONG_PRESS_MS,
+) {
+  cy.findByTestId(selector).trigger("pointerdown", startX, startY, {
+    force: true,
+    isPrimary: true,
+    button: 0,
+  });
+
+  cy.wait(holdMs);
+
+  cy.findByTestId(selector)
+    .trigger("mousemove", endX, startY)
+    .trigger("mouseup", endX, startY);
+}
+
+export function quickSwipe(
+  selector: string,
+  startX: number,
+  startY: number,
+  endX: number,
+) {
+  cy.findByTestId(selector)
+    .trigger("pointerdown", startX, startY, {
+      force: true,
+      isPrimary: true,
+      button: 0,
+    })
+    .trigger("pointermove", endX, startY, {
+      force: true,
+      isPrimary: true,
+      button: 0,
+    })
+    .trigger("pointerup", endX, startY, {
+      force: true,
+      isPrimary: true,
+      button: 0,
+    });
 }

--- a/e2e/test-component/scenarios/embedding-sdk/touch-chart-drill.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/touch-chart-drill.cy.spec.tsx
@@ -2,8 +2,6 @@ import { InteractiveDashboard } from "@metabase/embedding-sdk-react";
 
 const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import { cartesianChartCircle, popover } from "e2e/support/helpers";
-import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
 import { mountSdkContent } from "e2e/support/helpers/embedding-sdk-component-testing/component-embedding-sdk-helpers";
 import { signInAsAdminAndEnableEmbeddingSdk } from "e2e/support/helpers/embedding-sdk-testing";
 import { mockAuthProviderAndJwtSignIn } from "e2e/support/helpers/embedding-sdk-testing/embedding-sdk-helpers";

--- a/e2e/test-component/scenarios/embedding-sdk/touch-chart-drill.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/touch-chart-drill.cy.spec.tsx
@@ -5,6 +5,7 @@ import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { mountSdkContent } from "e2e/support/helpers/embedding-sdk-component-testing/component-embedding-sdk-helpers";
 import { signInAsAdminAndEnableEmbeddingSdk } from "e2e/support/helpers/embedding-sdk-testing";
 import { mockAuthProviderAndJwtSignIn } from "e2e/support/helpers/embedding-sdk-testing/embedding-sdk-helpers";
+import { getEventTarget } from "metabase/lib/dom";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 
@@ -64,7 +65,6 @@ describe("scenarios > embedding-sdk > touch chart drill popover", () => {
         touches: [],
       });
 
-      const { getEventTarget } = require("metabase/lib/dom");
       const target = getEventTarget(touchEvent);
 
       const left = parseFloat(target.style.left);

--- a/e2e/test-component/scenarios/embedding-sdk/touch-chart-drill.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/touch-chart-drill.cy.spec.tsx
@@ -1,0 +1,116 @@
+import { InteractiveDashboard } from "@metabase/embedding-sdk-react";
+
+const { H } = cy;
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import { cartesianChartCircle, popover } from "e2e/support/helpers";
+import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
+import {
+  disableTouchEmulation,
+  enableTouchEmulation,
+} from "e2e/support/helpers/e2e-mobile-device-helpers";
+import { mountSdkContent } from "e2e/support/helpers/embedding-sdk-component-testing/component-embedding-sdk-helpers";
+import { signInAsAdminAndEnableEmbeddingSdk } from "e2e/support/helpers/embedding-sdk-testing";
+import { mockAuthProviderAndJwtSignIn } from "e2e/support/helpers/embedding-sdk-testing/embedding-sdk-helpers";
+
+const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
+
+describe("scenarios > embedding-sdk > touch chart drill popover", () => {
+  beforeEach(() => {
+    signInAsAdminAndEnableEmbeddingSdk();
+
+    H.createDashboardWithQuestions({
+      dashboardName: "Touch drill test dashboard",
+      questions: [
+        {
+          name: "Line chart for touch drill",
+          display: "line",
+          query: {
+            "source-table": ORDERS_ID,
+            aggregation: [["count"]],
+            breakout: [
+              ["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }],
+            ],
+            limit: 5,
+          },
+        },
+      ],
+    }).then(({ dashboard }) => {
+      cy.wrap(dashboard.id).as("dashboardId");
+    });
+
+    cy.signOut();
+    mockAuthProviderAndJwtSignIn();
+
+    cy.intercept("GET", "/api/dashboard/*").as("getDashboard");
+    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
+      "dashcardQuery",
+    );
+  });
+
+  describe("touch device", () => {
+    beforeEach(() => {
+      cy.viewport("iphone-x");
+      enableTouchEmulation();
+    });
+
+    afterEach(() => {
+      disableTouchEmulation();
+    });
+
+    it("should show drill popover near the tapped data point, not offscreen", () => {
+      cy.get<string>("@dashboardId").then((dashboardId) => {
+        mountSdkContent(<InteractiveDashboard dashboardId={dashboardId} />);
+      });
+
+      cy.wait("@dashcardQuery");
+
+      // Use realTouch() from cypress-real-events to dispatch native touch
+      // events via CDP (Input.dispatchTouchEvent). This goes through the full
+      // browser pipeline — zrender receives real touchstart/touchend, simulates
+      // a click with the original TouchEvent, and our fix in getEventTarget()
+      // extracts clientX/clientY from changedTouches.
+      // Cypress .click() sends a MouseEvent which always has clientX/clientY
+      // and wouldn't exercise the TouchEvent code path.
+      let circleRect: DOMRect;
+
+      getSdkRoot().within(() => {
+        H.getDashboardCard(0).within(() => {
+          cartesianChartCircle()
+            .first()
+            .then(($circle) => {
+              circleRect = $circle[0].getBoundingClientRect();
+            })
+            .realTouch();
+        });
+
+        popover()
+          .should("be.visible")
+          .then(($popover) => {
+            const popoverRect = $popover[0].getBoundingClientRect();
+
+            // The popover should be positioned near the tapped data point,
+            // not at some arbitrary position far away. We allow a generous
+            // threshold because floating-ui may flip/shift the popover to
+            // keep it in the viewport, but it should remain in the vicinity
+            // of the data point (within 300px).
+            // Before the touch fix, the popover anchor received NaN
+            // coordinates on touch devices, placing it far offscreen.
+            const MAX_DISTANCE = 300;
+            const popoverCenterX = popoverRect.left + popoverRect.width / 2;
+            const popoverCenterY = popoverRect.top + popoverRect.height / 2;
+            const circleCenterX = circleRect.left + circleRect.width / 2;
+            const circleCenterY = circleRect.top + circleRect.height / 2;
+
+            const distance = Math.sqrt(
+              (popoverCenterX - circleCenterX) ** 2 +
+                (popoverCenterY - circleCenterY) ** 2,
+            );
+            expect(
+              distance,
+              "popover should be near the tapped data point",
+            ).to.be.lessThan(MAX_DISTANCE);
+          });
+      });
+    });
+  });
+});

--- a/e2e/test-component/scenarios/embedding-sdk/touch-chart-drill.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/touch-chart-drill.cy.spec.tsx
@@ -42,15 +42,6 @@ describe("scenarios > embedding-sdk > touch chart drill popover", () => {
   });
 
   it("should position popover anchor correctly for TouchEvents (iOS Safari)", () => {
-    // On iOS Safari, ECharts/zrender passes a TouchEvent through to
-    // getEventTarget(). TouchEvent lacks clientX/clientY (those live on
-    // individual Touch objects in changedTouches). Without the fix,
-    // the #popover-event-target gets "left: NaNpx; top: NaNpx" which
-    // the browser ignores, placing it far offscreen.
-    //
-    // CDP touch emulation in desktop Chrome doesn't reliably reproduce
-    // this because Chrome may fire PointerEvent instead of TouchEvent.
-    // So we call getEventTarget() directly with a real TouchEvent.
     cy.get<string>("@dashboardId").then((dashboardId) => {
       mountSdkContent(<InteractiveDashboard dashboardId={dashboardId} />);
     });
@@ -73,7 +64,6 @@ describe("scenarios > embedding-sdk > touch chart drill popover", () => {
         touches: [],
       });
 
-      // Access getEventTarget via the app's module system
       const { getEventTarget } = require("metabase/lib/dom");
       const target = getEventTarget(touchEvent);
 

--- a/e2e/test-component/scenarios/embedding-sdk/touch-chart-drill.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/touch-chart-drill.cy.spec.tsx
@@ -2,12 +2,61 @@ import { InteractiveDashboard } from "@metabase/embedding-sdk-react";
 
 const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import { popover } from "e2e/support/helpers";
+import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
+import {
+  disableTouchEmulation,
+  enableTouchEmulation,
+} from "e2e/support/helpers/e2e-mobile-device-helpers";
 import { mountSdkContent } from "e2e/support/helpers/embedding-sdk-component-testing/component-embedding-sdk-helpers";
 import { signInAsAdminAndEnableEmbeddingSdk } from "e2e/support/helpers/embedding-sdk-testing";
 import { mockAuthProviderAndJwtSignIn } from "e2e/support/helpers/embedding-sdk-testing/embedding-sdk-helpers";
-import { getEventTarget } from "metabase/lib/dom";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
+
+const CIRCLE_PATH = "M1 0A1 1 0 1 1 1 -0.0001";
+
+function touchTapOnDataPoint(
+  $container: JQuery<HTMLElement>,
+  win: Cypress.AUTWindow,
+) {
+  const circle = $container[0].querySelector(`path[d="${CIRCLE_PATH}"]`);
+  expect(circle, "chart should have a data point circle").to.not.be.null;
+
+  const circleRect = circle!.getBoundingClientRect();
+  const clientX = circleRect.left + circleRect.width / 2;
+  const clientY = circleRect.top + circleRect.height / 2;
+
+  const touch = new win.Touch({
+    identifier: 0,
+    target: circle!,
+    clientX,
+    clientY,
+  });
+
+  // touchstart — zrender reads targetTouches[0] for this event type
+  circle!.dispatchEvent(
+    new win.TouchEvent("touchstart", {
+      bubbles: true,
+      cancelable: true,
+      touches: [touch],
+      targetTouches: [touch],
+      changedTouches: [touch],
+    }),
+  );
+
+  circle!.dispatchEvent(
+    new win.TouchEvent("touchend", {
+      bubbles: true,
+      cancelable: true,
+      touches: [],
+      targetTouches: [],
+      changedTouches: [touch],
+    }),
+  );
+
+  return { clientX, clientY };
+}
 
 describe("scenarios > embedding-sdk > touch chart drill popover", () => {
   beforeEach(() => {
@@ -42,42 +91,64 @@ describe("scenarios > embedding-sdk > touch chart drill popover", () => {
     );
   });
 
-  it("should position popover anchor correctly for TouchEvents (iOS Safari)", () => {
-    cy.get<string>("@dashboardId").then((dashboardId) => {
-      mountSdkContent(<InteractiveDashboard dashboardId={dashboardId} />);
+  describe("touch device", () => {
+    beforeEach(() => {
+      cy.viewport("iphone-x");
+      enableTouchEmulation();
+
+      cy.window().then((win) => {
+        if (!("ontouchstart" in win)) {
+          (win as any).ontouchstart = null;
+        }
+      });
     });
 
-    cy.wait("@dashcardQuery");
+    afterEach(() => {
+      disableTouchEmulation();
+    });
 
-    cy.window().then((win) => {
-      const expectedX = 150;
-      const expectedY = 200;
-
-      const touch = new win.Touch({
-        identifier: 0,
-        target: win.document.body,
-        clientX: expectedX,
-        clientY: expectedY,
+    it("should show drill popover near the tapped data point, not offscreen", () => {
+      cy.get<string>("@dashboardId").then((dashboardId) => {
+        mountSdkContent(<InteractiveDashboard dashboardId={dashboardId} />);
       });
 
-      const touchEvent = new win.TouchEvent("touchend", {
-        changedTouches: [touch],
-        touches: [],
+      cy.wait("@dashcardQuery");
+
+      let tapCoords: { clientX: number; clientY: number };
+
+      getSdkRoot().within(() => {
+        H.getDashboardCard(0).within(() => {
+          cy.findByTestId("chart-container").then(($container) => {
+            // Wait for circles to render
+            cy.wrap($container)
+              .find(`path[d="${CIRCLE_PATH}"]`)
+              .should("exist");
+
+            cy.window().then((win) => {
+              tapCoords = touchTapOnDataPoint($container, win);
+            });
+          });
+        });
+
+        popover()
+          .should("be.visible")
+          .then(($popover) => {
+            const popoverRect = $popover[0].getBoundingClientRect();
+
+            const MAX_DISTANCE = 300;
+            const popoverCenterX = popoverRect.left + popoverRect.width / 2;
+            const popoverCenterY = popoverRect.top + popoverRect.height / 2;
+
+            const distance = Math.sqrt(
+              (popoverCenterX - tapCoords.clientX) ** 2 +
+                (popoverCenterY - tapCoords.clientY) ** 2,
+            );
+            expect(
+              distance,
+              "popover should be near the tapped data point",
+            ).to.be.lessThan(MAX_DISTANCE);
+          });
       });
-
-      const target = getEventTarget(touchEvent);
-
-      const left = parseFloat(target.style.left);
-      const top = parseFloat(target.style.top);
-
-      expect(left, "anchor left should not be NaN").to.not.be.NaN;
-      expect(top, "anchor top should not be NaN").to.not.be.NaN;
-      expect(left, "anchor left should match touch clientX").to.equal(
-        expectedX - 3,
-      );
-      expect(top, "anchor top should match touch clientY").to.equal(
-        expectedY - 3,
-      );
     });
   });
 });

--- a/e2e/test-component/scenarios/embedding-sdk/touch-chart-drill.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/touch-chart-drill.cy.spec.tsx
@@ -4,10 +4,6 @@ const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { cartesianChartCircle, popover } from "e2e/support/helpers";
 import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
-import {
-  disableTouchEmulation,
-  enableTouchEmulation,
-} from "e2e/support/helpers/e2e-mobile-device-helpers";
 import { mountSdkContent } from "e2e/support/helpers/embedding-sdk-component-testing/component-embedding-sdk-helpers";
 import { signInAsAdminAndEnableEmbeddingSdk } from "e2e/support/helpers/embedding-sdk-testing";
 import { mockAuthProviderAndJwtSignIn } from "e2e/support/helpers/embedding-sdk-testing/embedding-sdk-helpers";
@@ -47,70 +43,95 @@ describe("scenarios > embedding-sdk > touch chart drill popover", () => {
     );
   });
 
-  describe("touch device", () => {
-    beforeEach(() => {
-      cy.viewport("iphone-x");
-      enableTouchEmulation();
+  it("should show drill popover near the clicked data point", () => {
+    cy.get<string>("@dashboardId").then((dashboardId) => {
+      mountSdkContent(<InteractiveDashboard dashboardId={dashboardId} />);
     });
 
-    afterEach(() => {
-      disableTouchEmulation();
-    });
+    cy.wait("@dashcardQuery");
 
-    it("should show drill popover near the tapped data point, not offscreen", () => {
-      cy.get<string>("@dashboardId").then((dashboardId) => {
-        mountSdkContent(<InteractiveDashboard dashboardId={dashboardId} />);
+    let circleRect: DOMRect;
+
+    getSdkRoot().within(() => {
+      H.getDashboardCard(0).within(() => {
+        cartesianChartCircle()
+          .first()
+          .then(($circle) => {
+            circleRect = $circle[0].getBoundingClientRect();
+          })
+          .click({ force: true });
       });
 
-      cy.wait("@dashcardQuery");
+      popover()
+        .should("be.visible")
+        .then(($popover) => {
+          const popoverRect = $popover[0].getBoundingClientRect();
 
-      // Use realTouch() from cypress-real-events to dispatch native touch
-      // events via CDP (Input.dispatchTouchEvent). This goes through the full
-      // browser pipeline — zrender receives real touchstart/touchend, simulates
-      // a click with the original TouchEvent, and our fix in getEventTarget()
-      // extracts clientX/clientY from changedTouches.
-      // Cypress .click() sends a MouseEvent which always has clientX/clientY
-      // and wouldn't exercise the TouchEvent code path.
-      let circleRect: DOMRect;
+          const MAX_DISTANCE = 300;
+          const popoverCenterX = popoverRect.left + popoverRect.width / 2;
+          const popoverCenterY = popoverRect.top + popoverRect.height / 2;
+          const circleCenterX = circleRect.left + circleRect.width / 2;
+          const circleCenterY = circleRect.top + circleRect.height / 2;
 
-      getSdkRoot().within(() => {
-        H.getDashboardCard(0).within(() => {
-          cartesianChartCircle()
-            .first()
-            .then(($circle) => {
-              circleRect = $circle[0].getBoundingClientRect();
-            })
-            .realTouch();
+          const distance = Math.sqrt(
+            (popoverCenterX - circleCenterX) ** 2 +
+              (popoverCenterY - circleCenterY) ** 2,
+          );
+          expect(
+            distance,
+            "popover should be near the clicked data point",
+          ).to.be.lessThan(MAX_DISTANCE);
         });
+    });
+  });
 
-        popover()
-          .should("be.visible")
-          .then(($popover) => {
-            const popoverRect = $popover[0].getBoundingClientRect();
+  it("should position popover anchor correctly for TouchEvents (iOS Safari)", () => {
+    // On iOS Safari, ECharts/zrender passes a TouchEvent through to
+    // getEventTarget(). TouchEvent lacks clientX/clientY (those live on
+    // individual Touch objects in changedTouches). Without the fix,
+    // the #popover-event-target gets "left: NaNpx; top: NaNpx" which
+    // the browser ignores, placing it far offscreen.
+    //
+    // CDP touch emulation in desktop Chrome doesn't reliably reproduce
+    // this because Chrome may fire PointerEvent instead of TouchEvent.
+    // So we call getEventTarget() directly with a real TouchEvent.
+    cy.get<string>("@dashboardId").then((dashboardId) => {
+      mountSdkContent(<InteractiveDashboard dashboardId={dashboardId} />);
+    });
 
-            // The popover should be positioned near the tapped data point,
-            // not at some arbitrary position far away. We allow a generous
-            // threshold because floating-ui may flip/shift the popover to
-            // keep it in the viewport, but it should remain in the vicinity
-            // of the data point (within 300px).
-            // Before the touch fix, the popover anchor received NaN
-            // coordinates on touch devices, placing it far offscreen.
-            const MAX_DISTANCE = 300;
-            const popoverCenterX = popoverRect.left + popoverRect.width / 2;
-            const popoverCenterY = popoverRect.top + popoverRect.height / 2;
-            const circleCenterX = circleRect.left + circleRect.width / 2;
-            const circleCenterY = circleRect.top + circleRect.height / 2;
+    cy.wait("@dashcardQuery");
 
-            const distance = Math.sqrt(
-              (popoverCenterX - circleCenterX) ** 2 +
-                (popoverCenterY - circleCenterY) ** 2,
-            );
-            expect(
-              distance,
-              "popover should be near the tapped data point",
-            ).to.be.lessThan(MAX_DISTANCE);
-          });
+    cy.window().then((win) => {
+      const expectedX = 150;
+      const expectedY = 200;
+
+      const touch = new win.Touch({
+        identifier: 0,
+        target: win.document.body,
+        clientX: expectedX,
+        clientY: expectedY,
       });
+
+      const touchEvent = new win.TouchEvent("touchend", {
+        changedTouches: [touch],
+        touches: [],
+      });
+
+      // Access getEventTarget via the app's module system
+      const { getEventTarget } = require("metabase/lib/dom");
+      const target = getEventTarget(touchEvent);
+
+      const left = parseFloat(target.style.left);
+      const top = parseFloat(target.style.top);
+
+      expect(left, "anchor left should not be NaN").to.not.be.NaN;
+      expect(top, "anchor top should not be NaN").to.not.be.NaN;
+      expect(left, "anchor left should match touch clientX").to.equal(
+        expectedX - 3,
+      );
+      expect(top, "anchor top should match touch clientY").to.equal(
+        expectedY - 3,
+      );
     });
   });
 });

--- a/e2e/test-component/scenarios/embedding-sdk/touch-chart-drill.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/touch-chart-drill.cy.spec.tsx
@@ -43,48 +43,6 @@ describe("scenarios > embedding-sdk > touch chart drill popover", () => {
     );
   });
 
-  it("should show drill popover near the clicked data point", () => {
-    cy.get<string>("@dashboardId").then((dashboardId) => {
-      mountSdkContent(<InteractiveDashboard dashboardId={dashboardId} />);
-    });
-
-    cy.wait("@dashcardQuery");
-
-    let circleRect: DOMRect;
-
-    getSdkRoot().within(() => {
-      H.getDashboardCard(0).within(() => {
-        cartesianChartCircle()
-          .first()
-          .then(($circle) => {
-            circleRect = $circle[0].getBoundingClientRect();
-          })
-          .click({ force: true });
-      });
-
-      popover()
-        .should("be.visible")
-        .then(($popover) => {
-          const popoverRect = $popover[0].getBoundingClientRect();
-
-          const MAX_DISTANCE = 300;
-          const popoverCenterX = popoverRect.left + popoverRect.width / 2;
-          const popoverCenterY = popoverRect.top + popoverRect.height / 2;
-          const circleCenterX = circleRect.left + circleRect.width / 2;
-          const circleCenterY = circleRect.top + circleRect.height / 2;
-
-          const distance = Math.sqrt(
-            (popoverCenterX - circleCenterX) ** 2 +
-              (popoverCenterY - circleCenterY) ** 2,
-          );
-          expect(
-            distance,
-            "popover should be near the clicked data point",
-          ).to.be.lessThan(MAX_DISTANCE);
-        });
-    });
-  });
-
   it("should position popover anchor correctly for TouchEvents (iOS Safari)", () => {
     // On iOS Safari, ECharts/zrender passes a TouchEvent through to
     // getEventTarget(). TouchEvent lacks clientX/clientY (those live on

--- a/frontend/src/metabase/lib/dom.ts
+++ b/frontend/src/metabase/lib/dom.ts
@@ -420,7 +420,7 @@ export function isSmallScreen(): boolean {
 }
 
 export const getEventTarget = (
-  event: MouseEvent | React.MouseEvent,
+  event: MouseEvent | React.MouseEvent | TouchEvent,
 ): HTMLElement => {
   let target = document.getElementById("popover-event-target");
   if (!target) {
@@ -428,8 +428,21 @@ export const getEventTarget = (
     target.id = "popover-event-target";
     document.body.appendChild(target);
   }
-  target.style.left = event.clientX - 3 + "px";
-  target.style.top = event.clientY - 3 + "px";
+
+  // TouchEvent (e.g. from iOS Safari via ECharts/zrender) doesn't have
+  // clientX/clientY directly — they live on individual Touch objects.
+  let clientX: number;
+  let clientY: number;
+  if ("changedTouches" in event && event.changedTouches?.length) {
+    clientX = event.changedTouches[0].clientX;
+    clientY = event.changedTouches[0].clientY;
+  } else {
+    clientX = (event as MouseEvent).clientX;
+    clientY = (event as MouseEvent).clientY;
+  }
+
+  target.style.left = clientX - 3 + "px";
+  target.style.top = clientY - 3 + "px";
 
   return target;
 };


### PR DESCRIPTION
closes EMB-1460

Enhance getEventTarget to support TouchEvent for improved mobile compatibility when showing a drill popup

Context:
- on mobile devices we can't get clientX/clientY as a direct fields of a touch event. 
- this causes a wrong drills popup position when tapping a data point
- to fix it we get a touch coordinates from `event.changedTouches[0].clientX/Y`

How to test:
- the e2e test covers it, i checked, it fails without the fix
- CI should be green
- you can test it manually as well but it requires a local setup to be able opening MB app from a mobile device

Before:
<img width="552" height="944" alt="image" src="https://github.com/user-attachments/assets/397e2f62-db17-40a8-8281-a8511fc28052" />


After:
<img width="510" height="960" alt="image" src="https://github.com/user-attachments/assets/2366a86a-6931-4cbe-938c-9e39caf831e9" />
