### PR TITLE
Publish deploy time and day as Prometheus gauges

### DIFF
--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -239,6 +239,9 @@
                      {:description "Duration in milliseconds from JVM start to Metabase initialization complete."})
    (prometheus/gauge :metabase-startup/init-duration-millis
                      {:description "Duration in milliseconds of the init!* function execution."})
+   (prometheus/gauge :metabase-cloud/deploy-completed-at
+                     {:description "Unix epoch seconds when this instance was last deployed, from HM_DEPLOY_TIME."
+                      :labels [:version]})
    (prometheus/counter :metabase-csv-upload/failed
                        {:description "Number of failures when uploading CSV."})
    (prometheus/counter :metabase-email/messages

--- a/src/metabase/core/core.clj
+++ b/src/metabase/core/core.clj
@@ -39,6 +39,7 @@
    [metabase.warehouses.models.database :as database])
   (:import
    (java.lang.management ManagementFactory)
+   (java.time OffsetDateTime)
    (sun.misc Signal SignalHandler)))
 
 (set! *warn-on-reflection* true)
@@ -246,7 +247,16 @@
                  (u/format-milliseconds jvm-to-complete-ms))
       (system/startup-time-millis! init-duration-ms)
       (prometheus/set! :metabase-startup/init-duration-millis init-duration-ms)
-      (prometheus/set! :metabase-startup/jvm-to-complete-millis jvm-to-complete-ms))))
+      (prometheus/set! :metabase-startup/jvm-to-complete-millis jvm-to-complete-ms)
+      (when-let [deploy-time-str (:hm-deploy-time env/env)]
+        (try
+          (let [epoch-seconds (.toEpochSecond (.toInstant (OffsetDateTime/parse deploy-time-str)))]
+            (log/infof "Recording deploy time from HM_DEPLOY_TIME: %s (epoch: %d)" deploy-time-str epoch-seconds)
+            (prometheus/set! :metabase-cloud/deploy-completed-at
+                             {:version config/mb-version-string}
+                             epoch-seconds))
+          (catch Exception e
+            (log/warnf e "Failed to parse HM_DEPLOY_TIME: %s" deploy-time-str)))))))
 
 ;;; -------------------------------------------------- Normal Start --------------------------------------------------
 


### PR DESCRIPTION
This adds both a granular and truncated-to-the-day metrics for when Harbomaster last deployed a particular instance.

Refs [BOT-1189: Track release cohorts in release dashboard](https://linear.app/metabase/issue/BOT-1189/track-release-cohorts-in-release-dashboard)