### PR TITLE
Subtract scrollbar with from pivot table header when apropriate

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.tsx
@@ -360,7 +360,10 @@ const PivotTableInner = forwardRef<HTMLDivElement, VisualizationProps>(
 
     const topHeaderHeight = topHeaderRows * CELL_HEIGHT;
     const bodyHeight = height - topHeaderHeight;
-    const topHeaderWidth = viewPortWidth - leftHeaderWidth;
+    const verticalScrollBarSize =
+      rowCount * CELL_HEIGHT > bodyHeight ? getScrollBarSize() : 0;
+    const topHeaderWidth =
+      viewPortWidth - leftHeaderWidth - verticalScrollBarSize;
 
     function getCellClickHandler(clicked: PivotTableClicked) {
       if (!clicked) {
@@ -464,6 +467,7 @@ const PivotTableInner = forwardRef<HTMLDivElement, VisualizationProps>(
                   </PivotTableTopLeftCellsContainer>
                   {/* top header */}
                   <Collection
+                    aria-label="pivot-table-top-header"
                     style={{ minWidth: `${topHeaderWidth}px` }}
                     ref={topHeaderRef}
                     className={CS.scrollHideAll}

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.unit.spec.tsx
@@ -6,6 +6,7 @@ import { useState } from "react";
 
 import { createMockMetadata } from "__support__/metadata";
 import { renderWithProviders } from "__support__/ui";
+import * as domUtils from "metabase/lib/dom";
 import { QuestionChartSettings } from "metabase/visualizations/components/ChartSettings";
 import registerVisualizations from "metabase/visualizations/register";
 import Question from "metabase-lib/v1/Question";
@@ -50,7 +51,7 @@ const TEST_CASES = [
 function setupPivotTable(
   options?: ComponentProps<typeof PivotTableTestWrapper>,
 ) {
-  renderWithProviders(<PivotTableTestWrapper {...options} />);
+  return renderWithProviders(<PivotTableTestWrapper {...options} />);
 }
 
 function setupPivotSettings() {
@@ -265,6 +266,32 @@ describe("Visualizations > PivotTable > PivotTable", () => {
           ).toBeInTheDocument();
         });
       });
+    });
+  });
+
+  describe("scrollbar alignment", () => {
+    it("should reduce top header width by scrollbar size when body has vertical scrollbar", () => {
+      const scrollBarSize = 15;
+      jest.spyOn(domUtils, "getScrollBarSize").mockReturnValue(scrollBarSize);
+
+      // Use a small height to force vertical scrolling (4 rows * 30px = 120px body content)
+      const { rerender } = setupPivotTable({ height: 100 });
+
+      const getTopHeaderWidth = () => {
+        const topHeader = screen.getByLabelText("pivot-table-top-header");
+        return parseInt(topHeader.style.minWidth);
+      };
+
+      const widthWithScrollbar = getTopHeaderWidth();
+
+      // Re-render with enough height that no vertical scrollbar is needed
+      rerender(<PivotTableTestWrapper height={500} />);
+
+      const widthWithoutScrollbar = getTopHeaderWidth();
+
+      expect(widthWithoutScrollbar - widthWithScrollbar).toBe(scrollBarSize);
+
+      jest.restoreAllMocks();
     });
   });
 });


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #57986
Closes UXW-91

### Description
Small change that adjusts the width of the top header in pivot tables if there is a visible scrollbar. This means that when the pivot table is scrolled all the way to the right, the column dividers should all line up (previously they would be offset the width of the scrollbar). The test that was added asserts that the top header width appropriately removes the width of a scollbar if a vertical scrollbar is present

### How to verify
1. Set up a question for a pivot table (Orders, Count and Average of total, Group by year, category, and rating)
2. Ensure that the pivot table scrolls both horizontally and vertically. Scroll all the way to the left and ensure that the header column dividers align with the rest of the grid
3. Add filters to the question to have the table only scroll vertically, and ensure that things continue to line up
4. Do the same but for a table that only scrolls horziontally

### Demo
<img width="1413" height="884" alt="image" src="https://github.com/user-attachments/assets/ce245f51-aa31-41e5-8fe9-84bd707f1b70" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
