### PR TITLE
Allow Metabase forks (including private ones) to sync automatically

### DIFF
--- a/.github/workflows/cache-generator.yml
+++ b/.github/workflows/cache-generator.yml
@@ -39,6 +39,7 @@ concurrency:
 
 jobs:
   get-cache-keys:
+    if: ${{ github.event_name != 'schedule' || github.repository == 'metabase/metabase' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   codespell:
+    if: ${{ github.event_name != 'schedule' || github.repository == 'metabase/metabase' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 30
     permissions:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   fe-test-coverage:
+    if: ${{ github.event_name != 'schedule' || github.repository == 'metabase/metabase' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 60
     steps:

--- a/.github/workflows/disabled-drivers-slack-notification.yml
+++ b/.github/workflows/disabled-drivers-slack-notification.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   notify-disabled-drivers:
+    if: ${{ github.event_name != 'schedule' || github.repository == 'metabase/metabase' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 5
     steps:

--- a/.github/workflows/docs-master-generate.yml
+++ b/.github/workflows/docs-master-generate.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   update-master-docs:
+    if: ${{ github.event_name != 'schedule' || github.repository == 'metabase/metabase' }}
     name: Call documentation update for master
     uses: ./.github/workflows/docs-generate-base.yml
     with:

--- a/.github/workflows/docs-release-generate.yml
+++ b/.github/workflows/docs-release-generate.yml
@@ -13,6 +13,7 @@ on:
 
 jobs:
   update-release-docs:
+    if: ${{ github.event_name != 'schedule' || github.repository == 'metabase/metabase' }}
     name: Call documentation update for release branch
     uses: ./.github/workflows/docs-generate-base.yml
     with:

--- a/.github/workflows/js-stats-update.yml
+++ b/.github/workflows/js-stats-update.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   js-stats:
+    if: ${{ github.event_name != 'schedule' || github.repository == 'metabase/metabase' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 5
     steps:

--- a/.github/workflows/module-boundaries-stats.yml
+++ b/.github/workflows/module-boundaries-stats.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   module-boundaries-stats:
+    if: ${{ github.event_name != 'schedule' || github.repository == 'metabase/metabase' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 10
     steps:

--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -1,0 +1,84 @@
+name: Sync Fork with Upstream
+
+on:
+  schedule:
+    - cron: "0 */6 * * *" # Every 6 hours
+  workflow_dispatch:
+    inputs:
+      release_branch_count:
+        description: "Number of most recent release branches to sync (0 to skip)"
+        required: false
+        default: "5"
+        type: number
+
+jobs:
+  sync-master:
+    # ONLY run on a fork — NEVER on the main Metabase repo
+    if: github.repository != 'metabase/metabase'
+    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: master
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Add upstream remote
+        run: git remote add metabase https://github.com/metabase/metabase.git
+
+      - name: Fetch upstream master
+        run: git fetch metabase master
+
+      - name: Force-sync master from upstream
+        run: |
+          if git diff --quiet master metabase/master; then
+            echo "master is already up to date — skipping push"
+          else
+            git checkout master
+            git reset --hard metabase/master
+            git push origin master --force
+          fi
+
+  sync-release-branches:
+    # ONLY run on a fork — NEVER on the main Metabase repo
+    if: github.repository != 'metabase/metabase'
+    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Add upstream remote
+        run: git remote add metabase https://github.com/metabase/metabase.git
+
+      - name: Fetch upstream release branches
+        run: git fetch metabase 'refs/heads/release-*:refs/remotes/metabase/release-*'
+
+      - name: Force-sync most recent release branches from upstream
+        env:
+          BRANCH_COUNT: ${{ inputs.release_branch_count || '5' }}
+        run: |
+          # Get only canonical release branches (release-x.NN.x), skip ad-hoc branches like backports
+          branches=$(git branch -r --list 'metabase/release-*' | sed 's|^ *||' | grep -E '^metabase/release-x\.[0-9]+\.x$' | sort -t. -k2,2rn | head -n "$BRANCH_COUNT")
+
+          for branch in $branches; do
+            branch_name="${branch#metabase/}"
+            echo "::group::$branch_name"
+
+            # Check if branch exists locally (on origin)
+            if git rev-parse --verify "origin/$branch_name" &>/dev/null; then
+              if git diff --quiet "origin/$branch_name" "$branch"; then
+                echo "$branch_name is already up to date — skipping push"
+                echo "::endgroup::"
+                continue
+              fi
+            fi
+
+            echo "Syncing $branch_name..."
+            git checkout -B "$branch_name" "$branch"
+            git push origin "$branch_name" --force
+            echo "::endgroup::"
+          done

--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -2,7 +2,7 @@ name: Sync Fork with Upstream
 
 on:
   schedule:
-    - cron: "0 */6 * * *" # Every 6 hours
+    - cron: "0 2 * * *" # Every day at 2 AM UTC
   workflow_dispatch:
     inputs:
       release_branch_count:

--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -13,8 +13,8 @@ on:
 
 jobs:
   sync-master:
-    # ONLY run on a fork — NEVER on the main Metabase repo
-    if: github.repository != 'metabase/metabase'
+    # ONLY run on internal metabase org forks — NEVER on the public repo or external forks
+    if: github.repository_owner == 'metabase' && github.repository != 'metabase/metabase'
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     steps:
       - name: Checkout
@@ -41,8 +41,8 @@ jobs:
           fi
 
   sync-release-branches:
-    # ONLY run on a fork — NEVER on the main Metabase repo
-    if: github.repository != 'metabase/metabase'
+    # ONLY run on internal metabase org forks — NEVER on the public repo or external forks
+    if: github.repository_owner == 'metabase' && github.repository != 'metabase/metabase'
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     steps:
       - name: Checkout

--- a/.github/workflows/translation-context.yml
+++ b/.github/workflows/translation-context.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   harvest:
+    if: ${{ github.event_name != 'schedule' || github.repository == 'metabase/metabase' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     permissions:
       contents: read

--- a/.github/workflows/translation-update.yml
+++ b/.github/workflows/translation-update.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   synchronize-translations:
+    if: ${{ github.event_name != 'schedule' || github.repository == 'metabase/metabase' }}
     name: Synchronize Translations
     env:
       BRANCH_NAME: update-translations-${{ github.run_id }}

--- a/.github/workflows/update-e2e-timings.yml
+++ b/.github/workflows/update-e2e-timings.yml
@@ -18,6 +18,7 @@ on:
 
 jobs:
   collect-and-average-timings:
+    if: ${{ github.event_name != 'schedule' || github.repository == 'metabase/metabase' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 30
     env:

--- a/.github/workflows/upgrade-deps.yml
+++ b/.github/workflows/upgrade-deps.yml
@@ -17,6 +17,7 @@ permissions:
 
 jobs:
   bump-deps:
+    if: ${{ github.event_name != 'schedule' || github.repository == 'metabase/metabase' }}
     name: Open PRs to Bump Backend Deps
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 20


### PR DESCRIPTION
Add a new sync-fork workflow that automatically syncs Metabase forks (including private ones) with upstream `metabase/metabase` (master + 5 most recent release branches). Force-syncs from upstream as source of truth, skips push when no diff to avoid unnecessary CI runs. Only runs on forks, never on the public repo.

Guard all scheduled workflows with repository check so they only run on schedule for metabase/metabase, not on a fork (manual dispatch still works on both).
