### PR TITLE
fix: accept metered transforms product types in cloud-add-ons endpoint

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/cloud_add_ons/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/cloud_add_ons/api.clj
@@ -108,7 +108,7 @@
 (api.macros/defendpoint :post "/:product-type"
   "Purchase an add-on."
   [{:keys [product-type]} :- [:map
-                              [:product-type [:enum "metabase-ai" "metabase-ai-tiered" "python-execution" "transforms" "transforms-basic" "transforms-advanced"]]]
+                              [:product-type [:enum "metabase-ai" "metabase-ai-tiered" "python-execution" "transforms" "transforms-basic" "transforms-advanced" "transforms-basic-metered" "transforms-advanced-metered"]]]
    _query-params
    {:keys            [quantity]
     terms-of-service :terms_of_service} :- [:map
@@ -140,6 +140,14 @@
     response-not-eligible
 
     (and (= product-type "transforms-advanced")
+         (premium-features/enable-python-transforms?))
+    response-not-eligible
+
+    (and (= product-type "transforms-basic-metered")
+         (premium-features/enable-basic-transforms?))
+    response-not-eligible
+
+    (and (= product-type "transforms-advanced-metered")
          (premium-features/enable-python-transforms?))
     response-not-eligible
 

--- a/enterprise/backend/src/metabase_enterprise/cloud_add_ons/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/cloud_add_ons/api.clj
@@ -127,27 +127,11 @@
          (not quantity))
     response-no-quantity
 
-    (and (= product-type "python-execution")
-         (premium-features/enable-python-transforms?))
-    response-not-eligible
-
-    (and (= product-type "transforms")
+    (and (#{"transforms" "transforms-basic" "transforms-basic-metered"} product-type)
          (premium-features/enable-basic-transforms?))
     response-not-eligible
 
-    (and (= product-type "transforms-basic")
-         (premium-features/enable-basic-transforms?))
-    response-not-eligible
-
-    (and (= product-type "transforms-advanced")
-         (premium-features/enable-python-transforms?))
-    response-not-eligible
-
-    (and (= product-type "transforms-basic-metered")
-         (premium-features/enable-basic-transforms?))
-    response-not-eligible
-
-    (and (= product-type "transforms-advanced-metered")
+    (and (#{"python-execution" "transforms-advanced" "transforms-advanced-metered"} product-type)
          (premium-features/enable-python-transforms?))
     response-not-eligible
 

--- a/enterprise/backend/test/metabase_enterprise/cloud_add_ons/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/cloud_add_ons/api_test.clj
@@ -183,6 +183,60 @@
             (is (=? {}
                     (mt/user-http-request user :post 200 "ee/cloud-add-ons/transforms-advanced" {})))))))))
 
+(deftest ^:sequential post-transforms-basic-metered-test
+  (testing "POST /api/ee/cloud-add-ons/transforms-basic-metered"
+    (testing "requires superuser"
+      (mt/with-premium-features #{}
+        (is (=? "You don't have permissions to do that."
+                (mt/user-http-request :rasta :post 403 "ee/cloud-add-ons/transforms-basic-metered" {})))))
+    (testing "requires token feature 'hosting'"
+      (mt/with-premium-features #{}
+        (is (=? "Can only access Store API for Metabase Cloud instances."
+                (mt/user-http-request :crowberto :post 400 "ee/cloud-add-ons/transforms-basic-metered" {})))))
+    (testing "not eligible if already has 'transforms-basic'"
+      (mt/with-premium-features #{:hosting :transforms-basic}
+        (is (=? "Can only purchase add-ons for eligible subscriptions."
+                (mt/user-http-request :crowberto :post 400 "ee/cloud-add-ons/transforms-basic-metered" {})))))
+    (testing "requires current user being a store user"
+      (mt/with-temp [:model/User user {:is_superuser true}]
+        (mt/with-premium-features #{:hosting}
+          (is (=? "Only Metabase Store users can purchase add-ons."
+                  (mt/user-http-request user :post 403 "ee/cloud-add-ons/transforms-basic-metered" {}))))))
+    (testing "succeeds when all conditions are met"
+      (mt/with-temp [:model/User user {:is_superuser true}]
+        (mt/with-premium-features #{:hosting}
+          (with-redefs [premium-features/token-status (constantly {:store-users [{:email (:email user)}]})
+                        hm.client/call (constantly nil)]
+            (is (=? {}
+                    (mt/user-http-request user :post 200 "ee/cloud-add-ons/transforms-basic-metered" {})))))))))
+
+(deftest ^:sequential post-transforms-advanced-metered-test
+  (testing "POST /api/ee/cloud-add-ons/transforms-advanced-metered"
+    (testing "requires superuser"
+      (mt/with-premium-features #{}
+        (is (=? "You don't have permissions to do that."
+                (mt/user-http-request :rasta :post 403 "ee/cloud-add-ons/transforms-advanced-metered" {})))))
+    (testing "requires token feature 'hosting'"
+      (mt/with-premium-features #{}
+        (is (=? "Can only access Store API for Metabase Cloud instances."
+                (mt/user-http-request :crowberto :post 400 "ee/cloud-add-ons/transforms-advanced-metered" {})))))
+    (testing "not eligible if already has 'transforms-python'"
+      (mt/with-premium-features #{:hosting :transforms-python}
+        (is (=? "Can only purchase add-ons for eligible subscriptions."
+                (mt/user-http-request :crowberto :post 400 "ee/cloud-add-ons/transforms-advanced-metered" {})))))
+    (testing "requires current user being a store user"
+      (mt/with-temp [:model/User user {:is_superuser true}]
+        (mt/with-premium-features #{:hosting}
+          (is (=? "Only Metabase Store users can purchase add-ons."
+                  (mt/user-http-request user :post 403 "ee/cloud-add-ons/transforms-advanced-metered" {}))))))
+    (testing "succeeds when all conditions are met"
+      (mt/with-temp [:model/User user {:is_superuser true}]
+        (mt/with-premium-features #{:hosting}
+          (with-redefs [premium-features/token-status (constantly {:store-users [{:email (:email user)}]})
+                        hm.client/call (constantly nil)]
+            (is (=? {}
+                    (mt/user-http-request user :post 200 "ee/cloud-add-ons/transforms-advanced-metered" {})))))))))
+
 (deftest ^:sequential get-plans-test
   (testing "GET /api/ee/cloud-add-ons/plans"
     (testing "requires superuser"

--- a/enterprise/backend/test/metabase_enterprise/cloud_add_ons/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/cloud_add_ons/api_test.clj
@@ -104,10 +104,10 @@
 
 (deftest ^:sequential post-transforms-test
   (doseq [[product-type feature] [["transforms"                  :transforms-basic]
-                                   ["transforms-basic"            :transforms-basic]
-                                   ["transforms-basic-metered"    :transforms-basic]
-                                   ["transforms-advanced"         :transforms-python]
-                                   ["transforms-advanced-metered" :transforms-python]]]
+                                  ["transforms-basic"            :transforms-basic]
+                                  ["transforms-basic-metered"    :transforms-basic]
+                                  ["transforms-advanced"         :transforms-python]
+                                  ["transforms-advanced-metered" :transforms-python]]]
     (testing (str "POST /api/ee/cloud-add-ons/" product-type)
       (testing "requires superuser"
         (mt/with-premium-features #{}

--- a/enterprise/backend/test/metabase_enterprise/cloud_add_ons/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/cloud_add_ons/api_test.clj
@@ -103,139 +103,36 @@
                   (mt/user-http-request user :post 403 "ee/cloud-add-ons/python-execution" {}))))))))
 
 (deftest ^:sequential post-transforms-test
-  (testing "POST /api/ee/cloud-add-ons/transforms"
-    (testing "requires superuser"
-      (mt/with-premium-features #{}
-        (is (=? "You don't have permissions to do that."
-                (mt/user-http-request :rasta :post 403 "ee/cloud-add-ons/transforms" {})))))
-    (testing "requires token feature 'hosting'"
-      (mt/with-premium-features #{}
-        (is (=? "Can only access Store API for Metabase Cloud instances."
-                (mt/user-http-request :crowberto :post 400 "ee/cloud-add-ons/transforms" {})))))
-    (testing "not eligible if already has 'transforms'"
-      (mt/with-premium-features #{:hosting :transforms-basic}
-        (is (=? "Can only purchase add-ons for eligible subscriptions."
-                (mt/user-http-request :crowberto :post 400 "ee/cloud-add-ons/transforms" {})))))
-    (testing "requires current user being a store user"
-      (mt/with-temp [:model/User user {:is_superuser true}]
-        (mt/with-premium-features #{:hosting}
-          (is (=? "Only Metabase Store users can purchase add-ons."
-                  (mt/user-http-request user :post 403 "ee/cloud-add-ons/transforms" {}))))))
-    (testing "succeeds when all conditions are met"
-      (mt/with-temp [:model/User user {:is_superuser true}]
-        (mt/with-premium-features #{:hosting}
-          (with-redefs [premium-features/token-status (constantly {:store-users [{:email (:email user)}]})
-                        hm.client/call (constantly nil)]
-            (is (=? {}
-                    (mt/user-http-request user :post 200 "ee/cloud-add-ons/transforms" {})))))))))
-
-(deftest ^:sequential post-transforms-basic-test
-  (testing "POST /api/ee/cloud-add-ons/transforms-basic"
-    (testing "requires superuser"
-      (mt/with-premium-features #{}
-        (is (=? "You don't have permissions to do that."
-                (mt/user-http-request :rasta :post 403 "ee/cloud-add-ons/transforms-basic" {})))))
-    (testing "requires token feature 'hosting'"
-      (mt/with-premium-features #{}
-        (is (=? "Can only access Store API for Metabase Cloud instances."
-                (mt/user-http-request :crowberto :post 400 "ee/cloud-add-ons/transforms-basic" {})))))
-    (testing "not eligible if already has 'transforms'"
-      (mt/with-premium-features #{:hosting :transforms-basic}
-        (is (=? "Can only purchase add-ons for eligible subscriptions."
-                (mt/user-http-request :crowberto :post 400 "ee/cloud-add-ons/transforms-basic" {})))))
-    (testing "requires current user being a store user"
-      (mt/with-temp [:model/User user {:is_superuser true}]
-        (mt/with-premium-features #{:hosting}
-          (is (=? "Only Metabase Store users can purchase add-ons."
-                  (mt/user-http-request user :post 403 "ee/cloud-add-ons/transforms-basic" {}))))))
-    (testing "succeeds when all conditions are met"
-      (mt/with-temp [:model/User user {:is_superuser true}]
-        (mt/with-premium-features #{:hosting}
-          (with-redefs [premium-features/token-status (constantly {:store-users [{:email (:email user)}]})
-                        hm.client/call (constantly nil)]
-            (is (=? {}
-                    (mt/user-http-request user :post 200 "ee/cloud-add-ons/transforms-basic" {})))))))))
-
-(deftest ^:sequential post-transforms-advanced-test
-  (testing "POST /api/ee/cloud-add-ons/transforms-advanced"
-    (testing "requires superuser"
-      (mt/with-premium-features #{}
-        (is (=? "You don't have permissions to do that."
-                (mt/user-http-request :rasta :post 403 "ee/cloud-add-ons/transforms-advanced" {})))))
-    (testing "requires token feature 'hosting'"
-      (mt/with-premium-features #{}
-        (is (=? "Can only access Store API for Metabase Cloud instances."
-                (mt/user-http-request :crowberto :post 400 "ee/cloud-add-ons/transforms-advanced" {})))))
-    (testing "not eligible if already has 'transforms-python'"
-      (mt/with-premium-features #{:hosting :transforms-python}
-        (is (=? "Can only purchase add-ons for eligible subscriptions."
-                (mt/user-http-request :crowberto :post 400 "ee/cloud-add-ons/transforms-advanced" {})))))
-    (testing "requires current user being a store user"
-      (mt/with-temp [:model/User user {:is_superuser true}]
-        (mt/with-premium-features #{:hosting}
-          (is (=? "Only Metabase Store users can purchase add-ons."
-                  (mt/user-http-request user :post 403 "ee/cloud-add-ons/transforms-advanced" {}))))))
-    (testing "succeeds when all conditions are met"
-      (mt/with-temp [:model/User user {:is_superuser true}]
-        (mt/with-premium-features #{:hosting}
-          (with-redefs [premium-features/token-status (constantly {:store-users [{:email (:email user)}]})
-                        hm.client/call (constantly nil)]
-            (is (=? {}
-                    (mt/user-http-request user :post 200 "ee/cloud-add-ons/transforms-advanced" {})))))))))
-
-(deftest ^:sequential post-transforms-basic-metered-test
-  (testing "POST /api/ee/cloud-add-ons/transforms-basic-metered"
-    (testing "requires superuser"
-      (mt/with-premium-features #{}
-        (is (=? "You don't have permissions to do that."
-                (mt/user-http-request :rasta :post 403 "ee/cloud-add-ons/transforms-basic-metered" {})))))
-    (testing "requires token feature 'hosting'"
-      (mt/with-premium-features #{}
-        (is (=? "Can only access Store API for Metabase Cloud instances."
-                (mt/user-http-request :crowberto :post 400 "ee/cloud-add-ons/transforms-basic-metered" {})))))
-    (testing "not eligible if already has 'transforms-basic'"
-      (mt/with-premium-features #{:hosting :transforms-basic}
-        (is (=? "Can only purchase add-ons for eligible subscriptions."
-                (mt/user-http-request :crowberto :post 400 "ee/cloud-add-ons/transforms-basic-metered" {})))))
-    (testing "requires current user being a store user"
-      (mt/with-temp [:model/User user {:is_superuser true}]
-        (mt/with-premium-features #{:hosting}
-          (is (=? "Only Metabase Store users can purchase add-ons."
-                  (mt/user-http-request user :post 403 "ee/cloud-add-ons/transforms-basic-metered" {}))))))
-    (testing "succeeds when all conditions are met"
-      (mt/with-temp [:model/User user {:is_superuser true}]
-        (mt/with-premium-features #{:hosting}
-          (with-redefs [premium-features/token-status (constantly {:store-users [{:email (:email user)}]})
-                        hm.client/call (constantly nil)]
-            (is (=? {}
-                    (mt/user-http-request user :post 200 "ee/cloud-add-ons/transforms-basic-metered" {})))))))))
-
-(deftest ^:sequential post-transforms-advanced-metered-test
-  (testing "POST /api/ee/cloud-add-ons/transforms-advanced-metered"
-    (testing "requires superuser"
-      (mt/with-premium-features #{}
-        (is (=? "You don't have permissions to do that."
-                (mt/user-http-request :rasta :post 403 "ee/cloud-add-ons/transforms-advanced-metered" {})))))
-    (testing "requires token feature 'hosting'"
-      (mt/with-premium-features #{}
-        (is (=? "Can only access Store API for Metabase Cloud instances."
-                (mt/user-http-request :crowberto :post 400 "ee/cloud-add-ons/transforms-advanced-metered" {})))))
-    (testing "not eligible if already has 'transforms-python'"
-      (mt/with-premium-features #{:hosting :transforms-python}
-        (is (=? "Can only purchase add-ons for eligible subscriptions."
-                (mt/user-http-request :crowberto :post 400 "ee/cloud-add-ons/transforms-advanced-metered" {})))))
-    (testing "requires current user being a store user"
-      (mt/with-temp [:model/User user {:is_superuser true}]
-        (mt/with-premium-features #{:hosting}
-          (is (=? "Only Metabase Store users can purchase add-ons."
-                  (mt/user-http-request user :post 403 "ee/cloud-add-ons/transforms-advanced-metered" {}))))))
-    (testing "succeeds when all conditions are met"
-      (mt/with-temp [:model/User user {:is_superuser true}]
-        (mt/with-premium-features #{:hosting}
-          (with-redefs [premium-features/token-status (constantly {:store-users [{:email (:email user)}]})
-                        hm.client/call (constantly nil)]
-            (is (=? {}
-                    (mt/user-http-request user :post 200 "ee/cloud-add-ons/transforms-advanced-metered" {})))))))))
+  (doseq [[product-type feature] [["transforms"                  :transforms-basic]
+                                   ["transforms-basic"            :transforms-basic]
+                                   ["transforms-basic-metered"    :transforms-basic]
+                                   ["transforms-advanced"         :transforms-python]
+                                   ["transforms-advanced-metered" :transforms-python]]]
+    (testing (str "POST /api/ee/cloud-add-ons/" product-type)
+      (testing "requires superuser"
+        (mt/with-premium-features #{}
+          (is (=? "You don't have permissions to do that."
+                  (mt/user-http-request :rasta :post 403 (str "ee/cloud-add-ons/" product-type) {})))))
+      (testing "requires token feature 'hosting'"
+        (mt/with-premium-features #{}
+          (is (=? "Can only access Store API for Metabase Cloud instances."
+                  (mt/user-http-request :crowberto :post 400 (str "ee/cloud-add-ons/" product-type) {})))))
+      (testing (str "not eligible if already has '" (name feature) "'")
+        (mt/with-premium-features #{:hosting feature}
+          (is (=? "Can only purchase add-ons for eligible subscriptions."
+                  (mt/user-http-request :crowberto :post 400 (str "ee/cloud-add-ons/" product-type) {})))))
+      (testing "requires current user being a store user"
+        (mt/with-temp [:model/User user {:is_superuser true}]
+          (mt/with-premium-features #{:hosting}
+            (is (=? "Only Metabase Store users can purchase add-ons."
+                    (mt/user-http-request user :post 403 (str "ee/cloud-add-ons/" product-type) {}))))))
+      (testing "succeeds when all conditions are met"
+        (mt/with-temp [:model/User user {:is_superuser true}]
+          (mt/with-premium-features #{:hosting}
+            (with-redefs [premium-features/token-status (constantly {:store-users [{:email (:email user)}]})
+                          hm.client/call (constantly nil)]
+              (is (=? {}
+                      (mt/user-http-request user :post 200 (str "ee/cloud-add-ons/" product-type) {}))))))))))
 
 (deftest ^:sequential get-plans-test
   (testing "GET /api/ee/cloud-add-ons/plans"

--- a/enterprise/backend/test/metabase_enterprise/cloud_add_ons/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/cloud_add_ons/api_test.clj
@@ -66,44 +66,9 @@
                       (is (= (:id user) user_id))
                       (is (= {:add-on {:product-type "metabase-ai"}} details)))))))))))))
 
-(deftest ^:sequential post-python-execution-test
-  (testing "POST /api/ee/cloud-add-ons/python-execution"
-    (testing "requires superuser"
-      (mt/with-premium-features #{}
-        (is (=? "You don't have permissions to do that."
-                (mt/user-http-request :rasta :post 403 "ee/cloud-add-ons/python-execution" {})))))
-    (testing "does not require terms of service"
-      (mt/with-temp [:model/User user {:is_superuser true}]
-        (mt/with-premium-features #{:hosting}
-          (with-redefs [premium-features/token-status (constantly {:store-users [{:email (:email user)}]})
-                        hm.client/call (constantly nil)]
-            (testing "succeeds without terms_of_service"
-              (is (=? {}
-                      (mt/user-http-request user :post 200 "ee/cloud-add-ons/python-execution" {}))))
-            (testing "succeeds with terms_of_service false"
-              (is (=? {}
-                      (mt/user-http-request user :post 200 "ee/cloud-add-ons/python-execution"
-                                            {:terms_of_service false}))))
-            (testing "succeeds with terms_of_service true"
-              (is (=? {}
-                      (mt/user-http-request user :post 200 "ee/cloud-add-ons/python-execution"
-                                            {:terms_of_service true}))))))))
-    (testing "requires token feature 'hosting'"
-      (mt/with-premium-features #{}
-        (is (=? "Can only access Store API for Metabase Cloud instances."
-                (mt/user-http-request :crowberto :post 400 "ee/cloud-add-ons/python-execution" {})))))
-    (testing "not eligible if already has 'transforms-python'"
-      (mt/with-premium-features #{:hosting :transforms-python}
-        (is (=? "Can only purchase add-ons for eligible subscriptions."
-                (mt/user-http-request :crowberto :post 400 "ee/cloud-add-ons/python-execution" {})))))
-    (testing "requires current user being a store user"
-      (mt/with-temp [:model/User user {:is_superuser true}]
-        (mt/with-premium-features #{:hosting}
-          (is (=? "Only Metabase Store users can purchase add-ons."
-                  (mt/user-http-request user :post 403 "ee/cloud-add-ons/python-execution" {}))))))))
-
 (deftest ^:sequential post-transforms-test
-  (doseq [[product-type feature] [["transforms"                  :transforms-basic]
+  (doseq [[product-type feature] [["python-execution"            :transforms-python]
+                                  ["transforms"                  :transforms-basic]
                                   ["transforms-basic"            :transforms-basic]
                                   ["transforms-basic-metered"    :transforms-basic]
                                   ["transforms-advanced"         :transforms-python]


### PR DESCRIPTION
The POST /api/ee/cloud-add-ons/:product-type endpoint rejected
transforms-basic-metered and transforms-advanced-metered with a 404
because they weren't in the product-type enum. Add them along with
their eligibility checks and tests.

Fixes CLO-5210
