### PR TITLE
Fix driver-related code scanning alerts

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -89,6 +89,7 @@
                                              :git/url "https://github.com/eerohele/pp"}
   io.github.metabase/macaw                  {:mvn/version "0.2.36"}             ; Parse native SQL queries
   io.netty/netty-codec-http                 {:mvn/version "4.2.9.Final"}        ; override of transitive dep from aws s3
+  io.netty/netty-codec-http2                {:mvn/version "4.2.9.Final"}        ; override of transitive dep from aws s3
   io.prometheus/simpleclient_hotspot        {:mvn/version "0.16.0"}             ; prometheus jvm collector
   junegunn/grouper                          {:mvn/version "0.1.1"}              ; Batch processing helper
   kixi/stats                                {:mvn/version "0.5.7"               ; Various statistic measures implemented as transducers

--- a/modules/drivers/databricks/deps.edn
+++ b/modules/drivers/databricks/deps.edn
@@ -2,4 +2,8 @@
  ["src" "resources"]
 
  :deps
- {com.databricks/databricks-jdbc-thin {:mvn/version "3.3.1"}}}
+ {at.yawk.lz4/lz4-java                {:mvn/version "1.10.4"} ; pin newer version because version included in JDBC driver has security warnings
+  com.databricks/databricks-jdbc-thin {:mvn/version "3.3.1"
+                                       ;; lang3 is a dep in top-level deps.edn, so not actually used anyway; exclusion
+                                       ;; here fixes security warnings about version used in JDBC driver
+                                       :exclusions  [org.apache.commons/commons-lang3]}}}

--- a/modules/drivers/snowflake/deps.edn
+++ b/modules/drivers/snowflake/deps.edn
@@ -8,6 +8,7 @@
                                                    ;; since it's a top-level dep in `/deps.edn` but adding the
                                                    ;; exclusion here will (hopefully?) prevent code scanning alerts
                                                    ;; from complaining about it as well.
-                                                   io.netty/netty-codec-http]}
+                                                   io.netty/netty-codec-http
+                                                   io.netty/netty-codec-http2]}
   ;; drop when snowflake update driver to the one without the vulnerabilities
   io.grpc/grpc-netty-shaded         {:mvn/version "1.77.0"}}}


### PR DESCRIPTION
Fixes QUE2-477
Fixes QUE2-478
Fixes QUE2-479

Fix security warnings with transitive deps in driver deps.

Two of these are not real alerts since the transitive deps are overridden by the ones in top-level `deps.edn` anyway; for the other one I pinned a newer version of the dep in question.