### PR TITLE
BOT-1226 Only run metabot internal tasks when the llm-metabot-provider-lite is configured

### DIFF
--- a/src/metabase/metabot/settings.clj
+++ b/src/metabase/metabot/settings.clj
@@ -82,15 +82,6 @@
                         (validate-metabot-provider! new-value))
                       (setting/set-value-of-type! :string :llm-metabot-provider-lite new-value)))
 
-(defsetting llm-metabot-internal-tasks-enabled?
-  (deferred-tru "Controls whether Metabot performs internal tasks that might require background tasks or additional LLM calls (e.g. user intent classification).")
-  :type             :boolean
-  :visibility       :settings-manager
-  :default          true
-  :export?          false
-  :deprecated-name  :ee-ai-metabot-internal-tasks-enabled?
-  :doc              false)
-
 (defn- token-configured?
   [token]
   (boolean (and (string? token)
@@ -105,16 +96,27 @@
     "openrouter" (llm.settings/llm-openrouter-api-key)
     nil))
 
-(defn- metabot-provider-prefix []
-  (some-> (llm-metabot-provider)
+(defn- provider-prefix [provider-and-model]
+  (some-> provider-and-model
           (str/split #"/" 2)
           first))
 
-(defn- -llm-metabot-configured? []
-  (some-> (metabot-provider-prefix)
+(defn- llm-provider-configured? [provider-and-model]
+  (some-> provider-and-model
+          provider-prefix
           configured-provider-api-key
-          token-configured?
-          boolean))
+          token-configured?))
+
+(defsetting llm-metabot-internal-tasks-enabled?
+  (deferred-tru "Controls whether Metabot performs internal tasks that might require background tasks or additional LLM calls (e.g. user intent classification).")
+  :type             :boolean
+  :visibility       :settings-manager
+  :default          false
+  :export?          false
+  :deprecated-name  :ee-ai-metabot-internal-tasks-enabled?
+  :doc              false
+  :getter           #(boolean (and (setting/get-value-of-type :boolean :llm-metabot-internal-tasks-enabled?)
+                                   (llm-provider-configured? (llm-metabot-provider-lite)))))
 
 (defsetting llm-metabot-configured?
   "Whether the API key for the selected Metabot provider is configured."
@@ -122,5 +124,5 @@
   :visibility :public
   :setter     :none
   :export?    false
-  :getter     #'-llm-metabot-configured?
+  :getter     #(boolean (llm-provider-configured? (llm-metabot-provider)))
   :doc        false)

--- a/src/metabase/metabot/settings.clj
+++ b/src/metabase/metabot/settings.clj
@@ -102,10 +102,10 @@
           first))
 
 (defn- llm-provider-configured? [provider-and-model]
-  (some-> provider-and-model
-          provider-prefix
-          configured-provider-api-key
-          token-configured?))
+  (boolean (some-> provider-and-model
+                   provider-prefix
+                   configured-provider-api-key
+                   token-configured?)))
 
 (defsetting llm-metabot-internal-tasks-enabled?
   (deferred-tru "Controls whether Metabot performs internal tasks that might require background tasks or additional LLM calls (e.g. user intent classification).")
@@ -115,8 +115,8 @@
   :export?          false
   :deprecated-name  :ee-ai-metabot-internal-tasks-enabled?
   :doc              false
-  :getter           #(boolean (and (setting/get-value-of-type :boolean :llm-metabot-internal-tasks-enabled?)
-                                   (llm-provider-configured? (llm-metabot-provider-lite)))))
+  :getter           #(and (setting/get-value-of-type :boolean :llm-metabot-internal-tasks-enabled?)
+                          (llm-provider-configured? (llm-metabot-provider-lite))))
 
 (defsetting llm-metabot-configured?
   "Whether the API key for the selected Metabot provider is configured."
@@ -124,5 +124,5 @@
   :visibility :public
   :setter     :none
   :export?    false
-  :getter     #(boolean (llm-provider-configured? (llm-metabot-provider)))
+  :getter     #(llm-provider-configured? (llm-metabot-provider))
   :doc        false)

--- a/test/metabase/metabot/agent/core_test.clj
+++ b/test/metabase/metabot/agent/core_test.clj
@@ -681,7 +681,9 @@
     :model "test-model" :id "msg-1"}])
 
 (deftest user-intent-snowplow-fires-event-test
-  (mt/with-temporary-setting-values [llm-metabot-provider test-provider]
+  (mt/with-temporary-setting-values [llm-metabot-provider                test-provider
+                                     llm-metabot-internal-tasks-enabled? true
+                                     llm-anthropic-api-key               "sk-ant-test"]
     (testing "fires :snowplow/ai_service_event 'user_intent' when :track-user-intent? is true"
       (let [rasta-id (mt/user->id :rasta)]
         (with-redefs [openrouter/openrouter (fn [_] (mut/mock-llm-response mock-llm-response-for-intent))
@@ -738,16 +740,28 @@
                     agent-analytics/classify-and-track-user-intent-async!
                     (fn [_ _] (swap! classify-called inc))]
         (testing "does not call classify-and-track-user-intent-async! when llm-metabot-internal-tasks-enabled? is false"
-          (mt/with-temporary-setting-values [llm-metabot-internal-tasks-enabled? false]
+          (mt/with-temporary-setting-values [llm-metabot-internal-tasks-enabled? false
+                                             llm-metabot-provider-lite           "anthropic/claude-haiku-4-5"
+                                             llm-anthropic-api-key               "sk-ant-test"]
+            (run-agent-loop! opts)
+            (is (zero? @classify-called))))
+        (testing "does not call classify-and-track-user-intent-async! when api key is not configured"
+          (mt/with-temporary-setting-values [llm-metabot-internal-tasks-enabled? true
+                                             llm-metabot-provider-lite           "anthropic/claude-haiku-4-5"
+                                             llm-anthropic-api-key               nil]
             (run-agent-loop! opts)
             (is (zero? @classify-called))))
         (testing "calls classify-and-track-user-intent-async! when llm-metabot-internal-tasks-enabled? is true"
-          (mt/with-temporary-setting-values [llm-metabot-internal-tasks-enabled? true]
+          (mt/with-temporary-setting-values [llm-metabot-internal-tasks-enabled? true
+                                             llm-metabot-provider-lite           "anthropic/claude-haiku-4-5"
+                                             llm-anthropic-api-key               "sk-ant-test"]
             (run-agent-loop! opts)
             (is (= 1 @classify-called))))))))
 
 (deftest user-intent-classifier-exception-swallowed-test
-  (mt/with-temporary-setting-values [llm-metabot-provider test-provider]
+  (mt/with-temporary-setting-values [llm-metabot-provider                test-provider
+                                     llm-metabot-internal-tasks-enabled? true
+                                     llm-anthropic-api-key               "sk-ant-test"]
     (testing "does not propagate exception if classify-user-intent throws"
       (let [classify-called (atom false)]
         (with-redefs [openrouter/openrouter (fn [_] (mut/mock-llm-response mock-llm-response-for-intent))

--- a/test/metabase/metabot/settings_test.clj
+++ b/test/metabase/metabot/settings_test.clj
@@ -1,0 +1,32 @@
+(ns metabase.metabot.settings-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.metabot.settings :as metabot.settings]
+   [metabase.test :as mt]))
+
+(deftest internal-tasks-disabled-by-default-test
+  (testing "returns false when the setting is not explicitly enabled"
+    (mt/with-temporary-setting-values [llm-metabot-internal-tasks-enabled? nil
+                                       llm-anthropic-api-key               "sk-ant-test"]
+      (is (false? (metabot.settings/llm-metabot-internal-tasks-enabled?))))))
+
+(deftest internal-tasks-requires-lite-api-key-test
+  (testing "returns false when enabled but lite provider has no api key"
+    (mt/with-temporary-setting-values [llm-metabot-internal-tasks-enabled? true
+                                       llm-metabot-provider-lite           "anthropic/claude-haiku-4-5"
+                                       llm-anthropic-api-key               nil]
+      (is (false? (metabot.settings/llm-metabot-internal-tasks-enabled?))))))
+
+(deftest internal-tasks-enabled-with-anthropic-test
+  (testing "returns true when enabled and anthropic lite provider api key is configured"
+    (mt/with-temporary-setting-values [llm-metabot-internal-tasks-enabled? true
+                                       llm-metabot-provider-lite           "anthropic/claude-haiku-4-5"
+                                       llm-anthropic-api-key               "sk-ant-test"]
+      (is (true? (metabot.settings/llm-metabot-internal-tasks-enabled?))))))
+
+(deftest internal-tasks-enabled-with-openai-test
+  (testing "works with openai lite provider"
+    (mt/with-temporary-setting-values [llm-metabot-internal-tasks-enabled? true
+                                       llm-metabot-provider-lite           "openai/gpt-4.1-mini"
+                                       llm-openai-api-key                  "sk-openai-test"]
+      (is (true? (metabot.settings/llm-metabot-internal-tasks-enabled?))))))


### PR DESCRIPTION
Closes [BOT-1226: Don't try to classify the request if `llm-metabot-provider-lite` setting is not set](https://linear.app/metabase/issue/BOT-1226/dont-try-to-classify-the-request-if-llm-metabot-provider-lite-setting)

### Description

The agent loop was already checking `llm-metabot-internal-tasks-enabled?` before running internal background tasks like user-intent classification. Switch the default value for `llm-metabot-internal-tasks-enabled?` from true to false and also update the `:getter` to check that the corresponding `llm-metabot-provider-lite` is configured.

### How to verify

Run snowplow collector: `cd snowplow && docker compose up`
Set these env vars when starting up metabase backend:
```
MB_SNOWPLOW_AVAILABLE "true"
MB_SNOWPLOW_URL="http://localhost:9090"
```

Try out following combos of env vars when starting metabase backend. You can check snowplow events at http://localhost:9090/micro/ui/

### user_intent snowplow metric fired (enabled and configured)
```
MB_LLM_METABOT_INTERNAL_TASKS_ENABLED=true
MB_LLM_METABOT_PROVIDER_LITE="anthropic/claude-haiku-4-5"
MB_LLM_ANTHROPIC_API_KEY="<your anthropic api key>"
```

### No user_intent snowplow metric fired (explicitly disabled)
```
MB_LLM_METABOT_INTERNAL_TASKS_ENABLED=false
```

### No user_intent snowplow metric fired (missing api key)
```
MB_LLM_METABOT_INTERNAL_TASKS_ENABLED=true
MB_LLM_METABOT_PROVIDER_LITE="openai/gpt-5.4-mini"
unset MB_LLM_OPENAI_API_KEY
```

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
