### PR TITLE
show error message on remote sync pull changes or branches error

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/GitSyncControls/BranchDropdown.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/GitSyncControls/BranchDropdown.tsx
@@ -39,8 +39,11 @@ export const BranchDropdown = ({
 }: BranchDropdownProps) => {
   const [sendToast] = useToast();
   const [searchValue, setSearchValue] = useState("");
-  const { data: branchesData, isLoading: branchesLoading } =
-    useGetBranchesQuery();
+  const {
+    data: branchesData,
+    isLoading: branchesLoading,
+    isError: branchesError,
+  } = useGetBranchesQuery();
   const [createBranch, { isLoading: isCreating }] = useCreateBranchMutation();
 
   const branches = useMemo(() => branchesData?.items || [], [branchesData]);
@@ -118,6 +121,12 @@ export const BranchDropdown = ({
           <Flex justify="center" align="center" p="xl">
             <Loader size="sm" />
           </Flex>
+        ) : branchesError ? (
+          <Box p="md">
+            <Text size="sm" c="error" ta="center">
+              {t`Failed to load branches — check your authentication token`}
+            </Text>
+          </Box>
         ) : (
           <>
             {filteredBranches.length === 0 && !showCreateOption ? (

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/GitSyncControls/BranchDropdown.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/GitSyncControls/BranchDropdown.unit.spec.tsx
@@ -79,13 +79,11 @@ describe("BranchDropdown", () => {
         <WrapperComponent value="main" onChange={onChange} />,
       );
 
-      await waitFor(() => {
-        expect(
-          screen.getByText(
-            "Failed to load branches — check your authentication token",
-          ),
-        ).toBeInTheDocument();
-      });
+      expect(
+        await screen.findByText(
+          "Failed to load branches — check your authentication token",
+        ),
+      ).toBeInTheDocument();
     });
   });
 

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/GitSyncControls/BranchDropdown.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/GitSyncControls/BranchDropdown.unit.spec.tsx
@@ -67,6 +67,28 @@ describe("BranchDropdown", () => {
     jest.clearAllMocks();
   });
 
+  describe("error handling", () => {
+    it("should show error message when branches fail to load", async () => {
+      const onChange = jest.fn();
+      fetchMock.get("path:/api/ee/remote-sync/branches", {
+        status: 401,
+        body: { message: "Unauthorized" },
+      });
+
+      renderWithProviders(
+        <WrapperComponent value="main" onChange={onChange} />,
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            "Failed to load branches — check your authentication token",
+          ),
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
   describe("rendering", () => {
     it("should render search input", async () => {
       setup();

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/GitSyncControls/GitSyncControls.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/GitSyncControls/GitSyncControls.tsx
@@ -47,6 +47,7 @@ export const GitSyncControls = () => {
   const {
     currentData: hasRemoteChangesData,
     isFetching: isFetchingRemoteChanges,
+    isError: hasRemoteChangesError,
   } = useGetHasRemoteChangesQuery(undefined, {
     refetchOnMountOrArgChange: 10, // only refetch if the cache is more than 10 seconds stale
     skip: !combobox.dropdownOpened,
@@ -201,6 +202,7 @@ export const GitSyncControls = () => {
         {dropdownView === "options" ? (
           <GitSyncOptionsDropdown
             isPullDisabled={!hasRemoteChanges}
+            isPullError={hasRemoteChangesError}
             isLoadingPull={isFetchingRemoteChanges}
             isPushDisabled={!isDirty || isLoading}
             onPullClick={handlePullClick}

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/GitSyncControls/GitSyncControls.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/GitSyncControls/GitSyncControls.unit.spec.tsx
@@ -1,13 +1,7 @@
 import userEvent from "@testing-library/user-event";
 import fetchMock from "fetch-mock";
 
-import {
-  setupRemoteSyncBranchesEndpoint,
-  setupRemoteSyncDirtyEndpoint,
-  setupRemoteSyncEndpoints,
-  setupRemoteSyncImportEndpoint,
-  setupRemoteSyncSettingsEndpoint,
-} from "__support__/server-mocks";
+import { setupRemoteSyncEndpoints } from "__support__/server-mocks";
 import { renderWithProviders, screen, waitFor, within } from "__support__/ui";
 
 import { GitSyncControls } from "./GitSyncControls";
@@ -23,6 +17,7 @@ const setup = ({
   remoteSyncEnabled = true,
   hasRemoteChanges = true,
   hasRemoteChangesDelay = 0,
+  hasRemoteChangesError = false,
   currentBranch = "main",
   syncType = "read-write",
   dirty = [],
@@ -32,6 +27,7 @@ const setup = ({
   remoteSyncEnabled?: boolean;
   hasRemoteChanges?: boolean;
   hasRemoteChangesDelay?: number;
+  hasRemoteChangesError?: boolean;
   currentBranch?: string | null;
   syncType?: "read-only" | "read-write";
   dirty?: ReturnType<typeof createMockDirtyEntity>[];
@@ -42,6 +38,7 @@ const setup = ({
     dirty,
     hasRemoteChanges,
     hasRemoteChangesDelay,
+    hasRemoteChangesError,
   });
   setupCollectionEndpoints();
   setupSessionEndpoints({ remoteSyncEnabled, currentBranch, syncType });
@@ -254,49 +251,16 @@ describe("GitSyncControls", () => {
   });
 
   describe("pull error handling", () => {
-    it("is disabled and shows error tooltip when remote changes check fails", async () => {
-      // Set up all endpoints except has-remote-changes manually
-      setupRemoteSyncBranchesEndpoint(["main", "develop"]);
-      setupRemoteSyncDirtyEndpoint({ dirty: [] });
-      setupRemoteSyncImportEndpoint();
-      setupRemoteSyncSettingsEndpoint();
-      fetchMock.post("path:/api/ee/remote-sync/create-branch", {});
-      fetchMock.get("path:/api/ee/remote-sync/current-task", {
-        status: "idle",
-      });
+    it("shows error message when remote changes check fails", async () => {
+      setup({ hasRemoteChangesError: true });
 
-      // Set up has-remote-changes to return a 401 auth error
-      fetchMock.get("path:/api/ee/remote-sync/has-remote-changes", 401);
+      await userEvent.click(await screen.findByTestId("git-sync-controls"));
 
-      setupCollectionEndpoints();
-      setupSessionEndpoints({
-        remoteSyncEnabled: true,
-        currentBranch: "main",
-        syncType: "read-write",
-      });
-
-      renderWithProviders(<GitSyncControls />, {
-        storeInitialState: createRemoteSyncStoreState({
-          isAdmin: true,
-          remoteSyncEnabled: true,
-          currentBranch: "main",
-          syncType: "read-write",
-        }),
-      });
-
-      await waitFor(() => {
-        expect(getBranchButton(/main/)).toBeInTheDocument();
-      });
-
-      await userEvent.click(getBranchButton(/main/));
-
-      await waitFor(() => {
-        expect(
-          screen.getByText(
-            "Failed to check for changes — check your authentication token",
-          ),
-        ).toBeInTheDocument();
-      });
+      expect(
+        await screen.findByText(
+          "Failed to check for changes — check your authentication token",
+        ),
+      ).toBeInTheDocument();
     });
   });
 

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/GitSyncControls/GitSyncControls.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/GitSyncControls/GitSyncControls.unit.spec.tsx
@@ -1,7 +1,13 @@
 import userEvent from "@testing-library/user-event";
 import fetchMock from "fetch-mock";
 
-import { setupRemoteSyncEndpoints } from "__support__/server-mocks";
+import {
+  setupRemoteSyncBranchesEndpoint,
+  setupRemoteSyncDirtyEndpoint,
+  setupRemoteSyncEndpoints,
+  setupRemoteSyncImportEndpoint,
+  setupRemoteSyncSettingsEndpoint,
+} from "__support__/server-mocks";
 import { renderWithProviders, screen, waitFor, within } from "__support__/ui";
 
 import { GitSyncControls } from "./GitSyncControls";
@@ -244,6 +250,53 @@ describe("GitSyncControls", () => {
       ).toBeInTheDocument();
       jest.advanceTimersByTime(10000);
       jest.useRealTimers();
+    });
+  });
+
+  describe("pull error handling", () => {
+    it("is disabled and shows error tooltip when remote changes check fails", async () => {
+      // Set up all endpoints except has-remote-changes manually
+      setupRemoteSyncBranchesEndpoint(["main", "develop"]);
+      setupRemoteSyncDirtyEndpoint({ dirty: [] });
+      setupRemoteSyncImportEndpoint();
+      setupRemoteSyncSettingsEndpoint();
+      fetchMock.post("path:/api/ee/remote-sync/create-branch", {});
+      fetchMock.get("path:/api/ee/remote-sync/current-task", {
+        status: "idle",
+      });
+
+      // Set up has-remote-changes to return a 401 auth error
+      fetchMock.get("path:/api/ee/remote-sync/has-remote-changes", 401);
+
+      setupCollectionEndpoints();
+      setupSessionEndpoints({
+        remoteSyncEnabled: true,
+        currentBranch: "main",
+        syncType: "read-write",
+      });
+
+      renderWithProviders(<GitSyncControls />, {
+        storeInitialState: createRemoteSyncStoreState({
+          isAdmin: true,
+          remoteSyncEnabled: true,
+          currentBranch: "main",
+          syncType: "read-write",
+        }),
+      });
+
+      await waitFor(() => {
+        expect(getBranchButton(/main/)).toBeInTheDocument();
+      });
+
+      await userEvent.click(getBranchButton(/main/));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            "Failed to check for changes — check your authentication token",
+          ),
+        ).toBeInTheDocument();
+      });
     });
   });
 

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/components/GitSyncControls/GitSyncOptionsDropdown.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/components/GitSyncControls/GitSyncOptionsDropdown.tsx
@@ -1,9 +1,10 @@
 import { t } from "ttag";
 
-import { Combobox, Group, Icon, Loader, Text, Tooltip } from "metabase/ui";
+import { Box, Combobox, Group, Icon, Loader, Text, Tooltip } from "metabase/ui";
 
 export interface GitSyncOptionsDropdownProps {
   isPullDisabled: boolean;
+  isPullError: boolean;
   isLoadingPull: boolean;
   isPushDisabled: boolean;
   onPullClick: VoidFunction;
@@ -13,12 +14,25 @@ export interface GitSyncOptionsDropdownProps {
 
 export const GitSyncOptionsDropdown = ({
   isPullDisabled,
+  isPullError,
   isLoadingPull,
   isPushDisabled,
   onPullClick,
   onPushClick,
   onSwitchBranchClick,
 }: GitSyncOptionsDropdownProps) => {
+  if (isPullError) {
+    return (
+      <Combobox.Dropdown p={0}>
+        <Box p="md">
+          <Text size="sm" c="error" ta="center">
+            {t`Failed to check for changes — check your authentication token`}
+          </Text>
+        </Box>
+      </Combobox.Dropdown>
+    );
+  }
+
   return (
     <Combobox.Dropdown p={0}>
       <Combobox.Options>

--- a/frontend/test/__support__/server-mocks/remote-sync.ts
+++ b/frontend/test/__support__/server-mocks/remote-sync.ts
@@ -128,6 +128,7 @@ export const setupRemoteSyncEndpoints = ({
   changedCollections = {},
   hasRemoteChanges = false,
   hasRemoteChangesDelay = 0,
+  hasRemoteChangesError = false,
   settingsResponse = { success: true },
 }: {
   branches?: string[];
@@ -135,6 +136,7 @@ export const setupRemoteSyncEndpoints = ({
   changedCollections?: Record<number, boolean>;
   hasRemoteChanges?: boolean;
   hasRemoteChangesDelay?: number;
+  hasRemoteChangesError?: boolean;
   settingsResponse?: Partial<RemoteSyncSettingsResponse> & {
     error?: { status: number; message: string };
   };
@@ -147,9 +149,11 @@ export const setupRemoteSyncEndpoints = ({
   fetchMock.post("path:/api/ee/remote-sync/create-branch", {});
   fetchMock.get(
     "path:/api/ee/remote-sync/has-remote-changes",
-    {
-      has_changes: hasRemoteChanges,
-    },
+    hasRemoteChangesError
+      ? 401
+      : {
+          has_changes: hasRemoteChanges,
+        },
     {
       delay: hasRemoteChangesDelay,
     },


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #71148
Closes UXW-3345

### Description
Updates GitSyncOptionsDropdown and BranchDropdown components to show an error if the API returns a non 200 response when either fetching remote branch changes, or a list of branches.

### How to verify
1. Set up remote sync on an instance
2. roll the token that was used to initialize
3. Open the Git Sync Controls in the app bar

### Demo

https://github.com/user-attachments/assets/59d8dc27-cacc-4859-b4d5-5a74a3a64598

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
