### PR TITLE
hides overview tab of the metrics pages if no dimensions

### DIFF
--- a/e2e/test/scenarios/metrics/metric-page.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/metric-page.cy.spec.ts
@@ -216,6 +216,28 @@ describe("scenarios > metrics > metric page", () => {
     });
   });
 
+  it("should hide overview tab when metric has no dimensions", () => {
+    H.createQuestion(ORDERS_SCALAR_METRIC).then(({ body: metric }) => {
+      cy.intercept("GET", `/api/metric/${metric.id}`, (req) => {
+        req.continue((res) => {
+          res.body.dimensions = [];
+        });
+      });
+      H.visitMetric(metric.id);
+
+      H.MetricPage.aboutPage().should("be.visible");
+      H.MetricPage.aboutTab().should("be.visible");
+      H.MetricPage.overviewTab().should("not.exist");
+      H.MetricPage.historyTab().should("be.visible");
+
+      // Should redirect if visited by URL
+      cy.visit(`/metric/${metric.id}/overview`);
+
+      H.MetricPage.aboutPage().should("be.visible");
+      cy.location("pathname").should("not.include", "/overview");
+    });
+  });
+
   it("should edit, save, and cancel metric definition changes", () => {
     cy.intercept("PUT", "/api/card/*").as("updateCard");
 

--- a/e2e/test/scenarios/metrics/metric-page.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/metric-page.cy.spec.ts
@@ -216,28 +216,6 @@ describe("scenarios > metrics > metric page", () => {
     });
   });
 
-  it("should hide overview tab when metric has no dimensions", () => {
-    H.createQuestion(ORDERS_SCALAR_METRIC).then(({ body: metric }) => {
-      cy.intercept("GET", `/api/metric/${metric.id}`, (req) => {
-        req.continue((res) => {
-          res.body.dimensions = [];
-        });
-      });
-      H.visitMetric(metric.id);
-
-      H.MetricPage.aboutPage().should("be.visible");
-      H.MetricPage.aboutTab().should("be.visible");
-      H.MetricPage.overviewTab().should("not.exist");
-      H.MetricPage.historyTab().should("be.visible");
-
-      // Should redirect if visited by URL
-      cy.visit(`/metric/${metric.id}/overview`);
-
-      H.MetricPage.aboutPage().should("be.visible");
-      cy.location("pathname").should("not.include", "/overview");
-    });
-  });
-
   it("should edit, save, and cancel metric definition changes", () => {
     cy.intercept("PUT", "/api/card/*").as("updateCard");
 

--- a/frontend/src/metabase/metrics/components/MetricHeader/MetricTabs/MetricTabs.tsx
+++ b/frontend/src/metabase/metrics/components/MetricHeader/MetricTabs/MetricTabs.tsx
@@ -72,6 +72,7 @@ function getTabs(
   }
 
   const isCacheableQuestion =
+    card.can_write &&
     PLUGIN_CACHING.isGranularCachingEnabled() &&
     PLUGIN_CACHING.hasQuestionCacheSection(new Question(card));
 

--- a/frontend/src/metabase/metrics/components/MetricHeader/MetricTabs/MetricTabs.tsx
+++ b/frontend/src/metabase/metrics/components/MetricHeader/MetricTabs/MetricTabs.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { t } from "ttag";
 
+import { useGetMetricQuery } from "metabase/api/metric";
 import {
   type PaneHeaderTab,
   PaneHeaderTabs,
@@ -23,9 +24,12 @@ interface MetricTabsProps {
 
 export function MetricTabs({ card, urls }: MetricTabsProps) {
   const metadata = useSelector(getMetadata);
+  const { data: metric } = useGetMetricQuery(card.id);
+  const hasDimensions =
+    metric?.dimensions != null && metric.dimensions.length > 0;
   const tabs = useMemo(
-    () => getTabs(card, metadata, urls),
-    [card, metadata, urls],
+    () => getTabs(card, metadata, urls, hasDimensions),
+    [card, metadata, urls, hasDimensions],
   );
   return <PaneHeaderTabs tabs={tabs} />;
 }
@@ -34,6 +38,7 @@ function getTabs(
   card: Card,
   metadata: Metadata,
   urls: MetricUrls,
+  hasDimensions: boolean,
 ): PaneHeaderTab[] {
   const tabs: PaneHeaderTab[] = [
     {
@@ -46,12 +51,13 @@ function getTabs(
   const queryInfo = Lib.queryDisplayInfo(query);
 
   if (queryInfo.isEditable) {
-    if (isNumericMetric(card)) {
+    if (isNumericMetric(card) && hasDimensions) {
       tabs.push({
         label: t`Overview`,
         to: urls.overview(card.id),
       });
     }
+
     tabs.push({
       label: t`Definition`,
       to: urls.query(card.id),

--- a/frontend/src/metabase/metrics/components/MetricHeader/MetricTabs/MetricTabs.unit.spec.tsx
+++ b/frontend/src/metabase/metrics/components/MetricHeader/MetricTabs/MetricTabs.unit.spec.tsx
@@ -6,6 +6,7 @@ import { renderWithProviders, waitFor } from "__support__/ui";
 import type { Card } from "metabase-types/api";
 import {
   createMockCard,
+  createMockField,
   createMockTokenFeatures,
 } from "metabase-types/api/mocks";
 import {
@@ -51,6 +52,7 @@ describe("MetricTabs", () => {
       type: "metric",
       can_write: true,
       last_query_start: "2024-01-01T00:00:00Z",
+      result_metadata: [createMockField({ base_type: "type/Integer" })],
       ...cardOverrides,
     });
 

--- a/frontend/src/metabase/metrics/components/MetricHeader/MetricTabs/MetricTabs.unit.spec.tsx
+++ b/frontend/src/metabase/metrics/components/MetricHeader/MetricTabs/MetricTabs.unit.spec.tsx
@@ -1,0 +1,129 @@
+import { setupEnterprisePlugins } from "__support__/enterprise";
+import { setupMetricEndpoint } from "__support__/server-mocks/metric";
+import { mockSettings } from "__support__/settings";
+import { createMockEntitiesState } from "__support__/store";
+import { renderWithProviders, waitFor } from "__support__/ui";
+import type { Card } from "metabase-types/api";
+import {
+  createMockCard,
+  createMockTokenFeatures,
+} from "metabase-types/api/mocks";
+import {
+  createMockMetric,
+  createMockMetricDimension,
+} from "metabase-types/api/mocks/metric";
+import { createSampleDatabase } from "metabase-types/api/mocks/presets";
+import { createMockState } from "metabase-types/store/mocks";
+
+import type { MetricUrls } from "../../../types";
+
+import { MetricTabs } from "./MetricTabs";
+
+const urls: MetricUrls = {
+  about: (id) => `/metric/${id}/about`,
+  overview: (id) => `/metric/${id}/overview`,
+  query: (id) => `/metric/${id}/query`,
+  dependencies: (id) => `/metric/${id}/dependencies`,
+  caching: (id) => `/metric/${id}/caching`,
+  history: (id) => `/metric/${id}/history`,
+};
+
+describe("MetricTabs", () => {
+  beforeAll(() => {
+    mockSettings({
+      "token-features": createMockTokenFeatures({
+        cache_granular_controls: true,
+      }),
+    });
+    setupEnterprisePlugins();
+  });
+
+  function setup({
+    card: cardOverrides,
+    hasDimensions = true,
+    hasDataPermissions = true,
+  }: {
+    card?: Partial<Card>;
+    hasDimensions?: boolean;
+    hasDataPermissions?: boolean;
+  } = {}) {
+    const card = createMockCard({
+      type: "metric",
+      can_write: true,
+      last_query_start: "2024-01-01T00:00:00Z",
+      ...cardOverrides,
+    });
+
+    const metric = createMockMetric({
+      id: card.id,
+      dimensions: hasDimensions ? [createMockMetricDimension()] : [],
+    });
+
+    setupMetricEndpoint(metric);
+
+    const state = createMockState({
+      entities: createMockEntitiesState({
+        databases: hasDataPermissions ? [createSampleDatabase()] : [],
+        questions: [card],
+      }),
+    });
+
+    renderWithProviders(<MetricTabs card={card} urls={urls} />, {
+      storeInitialState: state,
+    });
+  }
+
+  function getTabLabels() {
+    return Array.from(
+      document.querySelectorAll(".mb-mantine-Button-label"),
+    ).map((element) => element.textContent);
+  }
+
+  it("should show the caching tab when the user has write access", async () => {
+    setup({ card: { can_write: true } });
+    await waitFor(() => {
+      expect(getTabLabels()).toEqual([
+        "About",
+        "Overview",
+        "Definition",
+        "Caching",
+        "History",
+      ]);
+    });
+  });
+
+  it("should not show the caching tab when the user has no write access", async () => {
+    setup({ card: { can_write: false } });
+    await waitFor(() => {
+      expect(getTabLabels()).toEqual([
+        "About",
+        "Overview",
+        "Definition",
+        "History",
+      ]);
+    });
+  });
+
+  it("should hide the overview tab when metric has no dimensions", async () => {
+    setup({ hasDimensions: false });
+    await waitFor(() => {
+      expect(getTabLabels()).toEqual([
+        "About",
+        "Definition",
+        "Caching",
+        "History",
+      ]);
+    });
+  });
+
+  it("should hide the overview and definition tabs when the query is not editable", async () => {
+    setup({
+      hasDataPermissions: false,
+      hasDimensions: true,
+      card: { can_write: false },
+    });
+    await waitFor(() => {
+      expect(getTabLabels()).toEqual(["About", "History"]);
+    });
+  });
+});

--- a/frontend/src/metabase/metrics/pages/MetricOverviewPage/MetricOverviewPage.tsx
+++ b/frontend/src/metabase/metrics/pages/MetricOverviewPage/MetricOverviewPage.tsx
@@ -1,6 +1,11 @@
+import { useEffect } from "react";
+import { replace } from "react-router-redux";
+
+import { useGetMetricQuery } from "metabase/api/metric";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { PageContainer } from "metabase/data-studio/common/components/PageContainer";
 import { useLoadCardWithMetadata } from "metabase/data-studio/common/hooks/use-load-card-with-metadata";
+import { useDispatch } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
 import { Center } from "metabase/ui";
 
@@ -17,7 +22,26 @@ export function MetricOverviewPage({
   showDataStudioLink = true,
 }: MetricPageProps) {
   const cardId = Urls.extractEntityId(params.cardId);
-  const { card, isLoading, error } = useLoadCardWithMetadata(cardId);
+  const dispatch = useDispatch();
+  const {
+    card,
+    isLoading: isCardLoading,
+    error,
+  } = useLoadCardWithMetadata(cardId);
+  const { data: metric, isLoading: isMetricLoading } = useGetMetricQuery(
+    cardId!,
+    { skip: cardId == null },
+  );
+
+  const isLoading = isCardLoading || isMetricLoading;
+  const hasDimensions =
+    metric?.dimensions != null && metric.dimensions.length > 0;
+
+  useEffect(() => {
+    if (!isLoading && card != null && !hasDimensions) {
+      dispatch(replace(urls.about(card.id)));
+    }
+  }, [isLoading, card, hasDimensions, dispatch, urls]);
 
   if (isLoading || error != null || card == null) {
     return (
@@ -25,6 +49,10 @@ export function MetricOverviewPage({
         <LoadingAndErrorWrapper loading={isLoading} error={error} />
       </Center>
     );
+  }
+
+  if (!hasDimensions) {
+    return null;
   }
 
   return (


### PR DESCRIPTION
Related to [UXW-3490](https://linear.app/metabase/issue/UXW-3490/metric-home-page-is-blank-for-sql-models)
Closes [UXW-3479](https://linear.app/metabase/issue/UXW-3479/hide-tabs-users-cannot-access-in-metric-homepage)

### Description

- Hides metric caching tab for users who don't have write access to cards — [UXW-3479](https://linear.app/metabase/issue/UXW-3479/hide-tabs-users-cannot-access-in-metric-homepage)

- While a proper fix for [UXW-3490](https://linear.app/metabase/issue/UXW-3490/metric-home-page-is-blank-for-sql-models) would be to make the backend to return dimensions for such metrics, this PR just hides the overview tab if there are no dimensions available.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [-] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
