### PR TITLE
Scale progress bar value label font size with card height

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/Progress/Progress.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Progress/Progress.tsx
@@ -11,6 +11,7 @@ import type { VisualizationProps } from "metabase/visualizations/types";
 import { PROGRESS_CHART_DEFINITION } from "./chart-definition";
 import {
   calculateProgressMetrics,
+  computeLabelFontSize,
   extractProgressValue,
   findProgressColumn,
   getGoalValue,
@@ -98,6 +99,11 @@ export function Progress(props: VisualizationProps) {
       isMobile,
     });
 
+    // scale label font size based on available height
+    const labelFontSize = computeLabelFontSize(root.clientHeight);
+    label.style.fontSize = `${labelFontSize}px`;
+    container.style.height = `${labelFontSize + 6}px`;
+
     // reset the pointer transform for these computations
     pointer.style.transform = "";
 
@@ -149,7 +155,6 @@ export function Progress(props: VisualizationProps) {
         <div
           ref={containerRef}
           className={cx(CS.relative, CS.textBold, CS.textMedium)}
-          style={{ height: 20 }}
         >
           <div ref={labelRef} style={{ position: "absolute" }}>
             {hasValidValue ? formatValue(value, columnSettings) : t`No data`}

--- a/frontend/src/metabase/visualizations/visualizations/Progress/utils.ts
+++ b/frontend/src/metabase/visualizations/visualizations/Progress/utils.ts
@@ -144,6 +144,14 @@ export const getProgressColors = (
   };
 };
 
+const MIN_LABEL_FONT_SIZE = 14;
+const MAX_LABEL_FONT_SIZE = 36;
+
+export const computeLabelFontSize = (rootHeight: number): number => {
+  const scaled = Math.round(rootHeight * 0.1);
+  return Math.max(MIN_LABEL_FONT_SIZE, Math.min(MAX_LABEL_FONT_SIZE, scaled));
+};
+
 export const getProgressMessage = (metrics: ProgressMetrics): string => {
   const { value, goal, hasValidValue, hasValidGoal } = metrics;
 

--- a/frontend/src/metabase/visualizations/visualizations/Progress/utils.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/Progress/utils.unit.spec.ts
@@ -1,6 +1,25 @@
-import { getValue } from "./utils";
+import { computeLabelFontSize, getValue } from "./utils";
 
 describe("Visualizations > Progress > utils", () => {
+  describe("computeLabelFontSize", () => {
+    it("should return minimum font size for small components", () => {
+      expect(computeLabelFontSize(80)).toBe(14);
+      expect(computeLabelFontSize(100)).toBe(14);
+      expect(computeLabelFontSize(140)).toBe(14);
+    });
+
+    it("should scale font size with component height", () => {
+      expect(computeLabelFontSize(200)).toBe(20);
+      expect(computeLabelFontSize(250)).toBe(25);
+      expect(computeLabelFontSize(300)).toBe(30);
+    });
+
+    it("should cap font size at maximum for large components", () => {
+      expect(computeLabelFontSize(400)).toBe(36);
+      expect(computeLabelFontSize(600)).toBe(36);
+    });
+  });
+
   const valueTestCases = [
     [[[null]], 0],
     [[[undefined]], 0],


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #30570
### Description

The progress visualization value label was always rendered at the inherited browser default font size (~14px), making it look very small on larger dashboard cards. This adds responsive font scaling so the label grows from 14px to 36px based on the component height, matching the responsive behavior of other visualizations like Scalar.

### How to verify

1. Create a question with a Progress visualization (e.g., a native query like `SELECT 75 AS val` with goal set to 100)
2. Add it to a dashboard
3. Resize the card — the value number above the progress bar should scale larger as the card gets taller
4. At minimum card size, the number should still be readable (14px minimum)
5. At large card sizes, the number caps at 36px

### Checklist

- [x] Tests have been added/updated to cover changes in this PR