### PR TITLE
Preserve metadata edits for summary columns (#70235)

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -743,8 +743,7 @@
 
   lib
   {:team "Querying"
-   :api  #{metabase.lib.binning
-           metabase.lib.convert  ; Only so [[metabase.queries.models.card]] can set dynamic vars.
+   :api  #{metabase.lib.convert  ; Only so [[metabase.queries.models.card]] can set dynamic vars.
            metabase.lib.core
            metabase.lib.equality
            metabase.lib.field
@@ -786,7 +785,6 @@
            metabase.lib.schema.test-spec
            metabase.lib.schema.util
            metabase.lib.schema.validate
-           metabase.lib.temporal-bucket
            metabase.lib.types.isa
            metabase.lib.util
            metabase.lib.util.match

--- a/src/metabase/lib/card.cljc
+++ b/src/metabase/lib/card.cljc
@@ -213,35 +213,48 @@
 (mu/defn merge-model-metadata :- [:sequential ::lib.schema.metadata/column]
   "Merge metadata from source model metadata into result cols.
 
-  Overrides `:id` for native models only."
-  [result-cols   :- [:maybe [:sequential ::lib.schema.metadata/column]]
-   model-cols    :- [:maybe [:sequential ::lib.schema.metadata/column]]
-   native-model? :- :boolean]
-  (cond
-    (empty? model-cols)
-    (not-empty result-cols)
+  Options:
+  - `:native-model?`    — when true, also overrides `:id` from model metadata.
+  - `:own-model-query?` — when true, aggregation columns are also merged (the model's own aggregation results should
+    preserve user-customized names). When false (default), aggregation columns are skipped because the computed name
+    (e.g. 'Sum of Price') is better than the model's custom name when the model is used as a source for an outer query."
+  ([result-cols model-cols]
+   (merge-model-metadata result-cols model-cols {}))
+  ([result-cols :- [:maybe [:sequential ::lib.schema.metadata/column]]
+    model-cols  :- [:maybe [:sequential ::lib.schema.metadata/column]]
+    {:keys [native-model? own-model-query?]
+     :or   {native-model? false, own-model-query? false}}]
+   (cond
+     (empty? model-cols)
+     (not-empty result-cols)
 
-    (empty? result-cols)
-    (not-empty model-cols)
+     (empty? result-cols)
+     (not-empty model-cols)
 
-    :else ;; both not empty
-    (let [name->model-col (m/index-by :name model-cols)]
-      (mapv (fn [result-col]
-              (merge
-               result-col
-               ;; if the result col is aggregating something in the source column then don't flow display name and what
-               ;; not because the calculated one e.g. 'Sum of ____' is going to be better than '____'
-               (when-not (= (:lib/source result-col) :source/aggregations)
-                 (when-let [model-col (get name->model-col (:name result-col))]
-                   (let [model-col     (-> (u/select-non-nil-keys model-col (model-preserved-keys native-model?))
-                                           (assoc :lib/from-model? true))
-                         temporal-unit (lib.temporal-bucket/raw-temporal-bucket result-col)
-                         binning       (lib.binning/binning result-col)
-                         semantic-type ((some-fn model-col result-col) :semantic-type)]
-                     (cond-> model-col
-                       temporal-unit (update :display-name lib.temporal-bucket/ensure-ends-with-temporal-unit temporal-unit)
-                       binning       (update :display-name lib.binning/ensure-ends-with-binning binning semantic-type)))))))
-            result-cols))))
+     :else ;; both not empty
+     (let [name->model-col (m/index-by :name model-cols)]
+       (mapv (fn [result-col]
+               (merge
+                result-col
+                ;; if the result col is aggregating something in the source column then don't flow display name and what
+                ;; not because the calculated one e.g. 'Sum of ____' is going to be better than '____'
+                (when (or own-model-query?
+                          (not= (:lib/source result-col) :source/aggregations))
+                  (when-let [model-col (get name->model-col (:name result-col))]
+                    (let [model-col (-> (u/select-non-nil-keys model-col (model-preserved-keys native-model?))
+                                        (assoc :lib/from-model? true))]
+                      ;; For the model's own query, preserve the user-customized display name as-is.
+                      ;; For outer queries using the model as source, append temporal/binning suffixes
+                      ;; because the outer query may apply its own bucketing on top of the model columns.
+                      (if own-model-query?
+                        model-col
+                        (let [temporal-unit (lib.temporal-bucket/raw-temporal-bucket result-col)
+                              binning       (lib.binning/binning result-col)
+                              semantic-type ((some-fn model-col result-col) :semantic-type)]
+                          (cond-> model-col
+                            temporal-unit (update :display-name lib.temporal-bucket/ensure-ends-with-temporal-unit temporal-unit)
+                            binning       (update :display-name lib.binning/ensure-ends-with-binning binning semantic-type)))))))))
+             result-cols)))))
 
 (mu/defn card-returned-columns :- [:maybe ::maybe-columns]
   "Get a normalized version of the saved metadata associated with Card metadata."
@@ -269,7 +282,7 @@
                ;; See [[metabase.lib.card-test/propagate-crazy-long-identifiers-from-card-metadata-test]]
                (lib.field.util/add-source-and-desired-aliases-xform metadata-providerable (lib.util.unique-name-generator/non-truncating-unique-name-generator))
                (cond-> result-cols
-                 (seq model-cols) (merge-model-metadata model-cols native-model?))))))))
+                 (seq model-cols) (merge-model-metadata model-cols {:native-model? native-model?}))))))))
 
 (mu/defn saved-question-metadata :- ::maybe-columns
   "Metadata associated with a Saved Question with `card-id`."

--- a/src/metabase/lib/metadata/result_metadata.cljc
+++ b/src/metabase/lib/metadata/result_metadata.cljc
@@ -388,8 +388,14 @@
             ;; query stage itself is native.
             native-model? (if (contains? last-stage :source-query/native-model?)
                             (:source-query/native-model? last-stage)
-                            (lib.util/native-stage? last-stage))]
-        (lib.card/merge-model-metadata cols model-metadata native-model?)))))
+                            (lib.util/native-stage? last-stage))
+            ;; Set explicitly by [[metabase.query-processor.card]] when the card is run
+            ;; directly. When true, aggregation columns are merged and temporal/binning
+            ;; suffixes are NOT re-appended (preserving user-customized names).
+            ;; When absent/false, this is an outer query using the model as source.
+            own-model-query? (boolean (get-in query [:info :metadata/own-model-query?]))]
+        (lib.card/merge-model-metadata cols model-metadata {:native-model?    native-model?
+                                                            :own-model-query? own-model-query?})))))
 
 (defn- add-source-and-desired-aliases [query cols]
   (into []

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -16,11 +16,9 @@
    [medley.core :as m]
    ^{:clj-kondo/ignore [:discouraged-namespace]} [metabase.legacy-mbql.normalize :as mbql.normalize]
    ^{:clj-kondo/ignore [:discouraged-namespace]} [metabase.legacy-mbql.schema :as mbql.s]
-   [metabase.lib.binning :as lib.binning]
    [metabase.lib.core :as lib]
    [metabase.lib.normalize :as lib.normalize]
    [metabase.lib.schema.metadata :as lib.schema.metadata]
-   [metabase.lib.temporal-bucket :as lib.temporal-bucket]
    [metabase.models.dispatch :as models.dispatch]
    [metabase.models.json-migration :as jm]
    [metabase.models.resolution]
@@ -223,11 +221,8 @@
     (lib.normalize/normalize ::lib.schema.metadata/column col)
     ;; legacy usages -- do not use these going forward
     #_{:clj-kondo/ignore [:deprecated-var]}
-    (-> col
-        (->> (lib/normalize :metabase.query-processor.schema/result-metadata.column))
-        ;; This is necessary, because in the wild, there may be cards created prior to this change.
-        lib.temporal-bucket/ensure-temporal-unit-in-display-name
-        lib.binning/ensure-binning-in-display-name)))
+    (->> col
+         (lib/normalize :metabase.query-processor.schema/result-metadata.column))))
 
 (defn- result-metadata-out
   "Transform the Card result metadata as it comes out of the DB. Convert columns to keywords where appropriate."

--- a/src/metabase/queries/models/card/metadata.clj
+++ b/src/metabase/queries/models/card/metadata.clj
@@ -193,7 +193,8 @@ saved later when it is ready."
         model-metadata (when model? (:result_metadata card))
         ;; If this is a model, include that model metadata so QP will infer correctly overridden metadata.
         query          (cond-> query
-                         model-metadata (update :info merge {:metadata/model-metadata model-metadata}))]
+                         model-metadata (update :info merge {:metadata/model-metadata   model-metadata
+                                                             :metadata/own-model-query? true}))]
     (infer-metadata query)))
 
 ;; TODO: Refactor this to use idents rather than names, so it's more robust.

--- a/src/metabase/query_processor/card.clj
+++ b/src/metabase/query_processor/card.clj
@@ -351,7 +351,8 @@
                             :dashboard-id           dashboard-id
                             :visualization-settings merged-viz}
                      (and (= (:type card) :model) (seq (:result_metadata card)))
-                     (assoc :metadata/model-metadata (:result_metadata card)))]
+                     (assoc :metadata/model-metadata (:result_metadata card)
+                            :metadata/own-model-query? true))]
     (when (seq parameters)
       (validate-card-parameters card-id (lib/normalize ::lib.schema.parameter/parameters parameters)))
     (log/tracef "Running query for Card %d:\n%s" card-id

--- a/src/metabase/query_processor/util.clj
+++ b/src/metabase/query_processor/util.clj
@@ -130,9 +130,8 @@
   [fresh pre-existing]
   #_{:clj-kondo/ignore [:deprecated-var]}
   (let [by-name (m/index-by :name pre-existing)]
-    (for [{:keys [source] :as col} fresh]
-      (if-let [existing (and (not= :aggregation source)
-                             (get by-name (:name col)))]
+    (for [col fresh]
+      (if-let [existing (get by-name (:name col))]
         (merge col (select-keys existing preserved-keys))
         col))))
 

--- a/test/metabase/lib/card_test.cljc
+++ b/test/metabase/lib/card_test.cljc
@@ -722,13 +722,13 @@
                          :semantic-type :type/Quantity)]
     (testing "result-cols only, no model-cols"
       (is (= [result-col]
-             (lib.card/merge-model-metadata [result-col] [] false))))
+             (lib.card/merge-model-metadata [result-col] []))))
     (testing "model-cols only, no result-cols"
       (is (= [model-col]
-             (lib.card/merge-model-metadata [] [model-col] false))))
+             (lib.card/merge-model-metadata [] [model-col]))))
     (testing "both present — model metadata merged onto result"
       (is (=? [model-col]
-              (lib.card/merge-model-metadata [result-col] [model-col] false))))))
+              (lib.card/merge-model-metadata [result-col] [model-col]))))))
 
 (deftest ^:parallel merge-model-metadata-temporal-and-aggregation-test
   (let [result-col {:lib/type :metadata/column
@@ -741,19 +741,32 @@
         model-col (assoc result-col
                          :display-name "Custom Foo"
                          :semantic-type :type/Quantity)]
-    (testing "temporal unit appended to display name"
+    (testing "temporal unit appended to display name for outer queries"
       (let [temporal-result (assoc result-col
                                    :base-type :type/Date
                                    :effective-type :type/Date
                                    :metabase.lib.field/temporal-unit :month)]
         (is (=? [{:display-name "Custom Foo: Month"}]
-                (lib.card/merge-model-metadata [temporal-result] [model-col] false)))))
-    (testing "aggregation source columns are not overridden by model metadata"
+                (lib.card/merge-model-metadata [temporal-result] [model-col])))))
+    (testing "temporal unit NOT appended for model's own query"
+      (let [temporal-result (assoc result-col
+                                   :base-type :type/Date
+                                   :effective-type :type/Date
+                                   :lib/temporal-unit :month)]
+        (is (=? [{:display-name "Custom Foo"}]
+                (lib.card/merge-model-metadata [temporal-result] [model-col] {:own-model-query? true})))))
+    (testing "aggregation source columns are not overridden by model metadata (outer query)"
       (let [agg-result (assoc result-col
                               :display-name "Sum of Foo"
                               :lib/source :source/aggregations)]
         (is (=? [{:display-name "Sum of Foo"}]
-                (lib.card/merge-model-metadata [agg-result] [model-col] false)))))))
+                (lib.card/merge-model-metadata [agg-result] [model-col])))))
+    (testing "aggregation source columns are merged when own-model-query?"
+      (let [agg-result (assoc result-col
+                              :display-name "Sum of Foo"
+                              :lib/source :source/aggregations)]
+        (is (=? [{:display-name "Custom Foo"}]
+                (lib.card/merge-model-metadata [agg-result] [model-col] {:own-model-query? true})))))))
 
 (deftest ^:parallel merge-model-metadata-binning-test
   (let [result-col {:lib/type :metadata/column
@@ -767,10 +780,13 @@
         model-col (assoc result-col
                          :display-name "Custom Foo"
                          :semantic-type :type/Quantity)]
-    (testing "binning appended to display name"
+    (testing "binning appended to display name for outer queries"
       (is (=? [{:display-name "Custom Foo: 10 bins"}]
-              (lib.card/merge-model-metadata [result-col] [model-col] false)))))
-  (testing "bin-width with coordinate semantic type includes degree symbol"
+              (lib.card/merge-model-metadata [result-col] [model-col]))))
+    (testing "binning NOT appended for model's own query"
+      (is (=? [{:display-name "Custom Foo"}]
+              (lib.card/merge-model-metadata [result-col] [model-col] {:own-model-query? true})))))
+  (testing "bin-width with coordinate semantic type"
     (let [result-col {:lib/type :metadata/column
                       :name "LAT"
                       :base-type :type/Float
@@ -782,8 +798,12 @@
                       :metabase.lib.field/binning {:strategy :bin-width :bin-width 1.0}}
           model-col (assoc result-col
                            :display-name "Custom Lat")]
-      (is (=? [{:display-name "Custom Lat: 1°"}]
-              (lib.card/merge-model-metadata [result-col] [model-col] false))))))
+      (testing "appended for outer queries"
+        (is (=? [{:display-name "Custom Lat: 1°"}]
+                (lib.card/merge-model-metadata [result-col] [model-col]))))
+      (testing "NOT appended for model's own query"
+        (is (=? [{:display-name "Custom Lat"}]
+                (lib.card/merge-model-metadata [result-col] [model-col] {:own-model-query? true})))))))
 
 (deftest ^:parallel merge-model-metadata-preserved-keys-test
   (let [result-col {:lib/type :metadata/column
@@ -807,13 +827,13 @@
                 :visibility-type :details-only
                 :fk-target-field-id 42
                 :lib/source-display-name "Original Foo"}]
-              (lib.card/merge-model-metadata [result-col] [model-col] false))))
+              (lib.card/merge-model-metadata [result-col] [model-col]))))
     (testing "native model also preserves :id"
       (is (=? [{:id 200}]
-              (lib.card/merge-model-metadata [result-col] [model-col] true))))
+              (lib.card/merge-model-metadata [result-col] [model-col] {:native-model? true}))))
     (testing "non-native model does not override :id"
       (is (=? [{:id 100}]
-              (lib.card/merge-model-metadata [result-col] [model-col] false))))))
+              (lib.card/merge-model-metadata [result-col] [model-col]))))))
 
 (deftest ^:parallel fallback-display-name-test
   (is (= "Question 42" (lib.card/fallback-display-name 42)))

--- a/test/metabase/pulse/pulse_integration_test.clj
+++ b/test/metabase/pulse/pulse_integration_test.clj
@@ -426,16 +426,29 @@
                         "Example Month"
                         "Example Day"
                         "Example Week Number"
-                        "Example Week: Week"
+                        "Example Week"
                         "Example Hour"
                         "Example Minute"
                         "Example Second"]
                        (map :display_name model-card-metadata))))
-              (testing "metamodel card"
-                (is (= (map :display_name model-card-metadata)
+              (testing "metamodel card — QP adds temporal suffix since it computes display names fresh"
+                (is (= ["Full Datetime Utc"
+                        "Full Datetime Pacific"
+                        "Example Timestamp"
+                        "Example Timestamp With Time Zone"
+                        "Example Date"
+                        "Example Time"
+                        "Example Year"
+                        "Example Month"
+                        "Example Day"
+                        "Example Week Number"
+                        "Example Week: Week"
+                        "Example Hour"
+                        "Example Minute"
+                        "Example Second"]
                        (map :display_name meta-model-card-metadata))))
               (testing "metamodel results"
-                (is (= (sort (map :display_name model-card-metadata))
+                (is (= (sort (map :display_name meta-model-card-metadata))
                        (sort (keys metamodel-results))))))
             ;; Note that these values are obtained by inspection since the UI formats are in the FE code.
             ;;
@@ -471,7 +484,7 @@
                       "Example Month"                    "12"
                       "Example Day"                      "11"
                       "Example Week Number"              "50"
-                      "Example Week: Week"               "December 10, 2023 - December 16, 2023"
+                      "Example Week"                     "December 10, 2023 - December 16, 2023"
                       "Example Hour"                     "15"
                       "Example Minute"                   "30"
                       "Example Second"                   "45"}

--- a/test/metabase/queries_rest/api/card_test.clj
+++ b/test/metabase/queries_rest/api/card_test.clj
@@ -1098,6 +1098,52 @@
             (is (= ["UPDATED" "UPDATED"]
                    (map :display_name (:result_metadata updated))))))))))
 
+(deftest model-aggregation-metadata-preserved-on-query-test
+  (testing "Custom display_name on aggregation columns should be preserved when querying a model (#26755)"
+    (let [mp    (mt/metadata-provider)
+          query (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
+                    (lib/aggregate (lib/count))
+                    (lib/aggregate (lib/sum (lib.metadata/field mp (mt/id :orders :quantity))))
+                    (lib/breakout (lib.metadata/field mp (mt/id :orders :product_id)))
+                    (lib/breakout (lib/with-temporal-bucket
+                                    (lib.metadata/field mp (mt/id :orders :created_at))
+                                    :year)))]
+      (t2/with-transaction [_conn nil {:rollback-only true}]
+        (let [card    (mt/user-http-request :crowberto :post 200 "card"
+                                            {:name                   "model-metadata-test"
+                                             :type                   "model"
+                                             :display                "table"
+                                             :dataset_query          query
+                                             :visualization_settings {}})
+              card-id (:id card)]
+          ;; Verify initial metadata has default display names
+          (is (= ["Product ID" "Created At: Year" "Count" "Sum of Quantity"]
+                 (map :display_name (:result_metadata card))))
+          ;; Rename all columns
+          (let [renames         {"PRODUCT_ID"  "Termekazonosito"
+                                 "CREATED_AT"  "Keszites eve"
+                                 "count"       "Darabszam"
+                                 "sum"         "Osszes mennyiseg"}
+                new-metadata    (mapv (fn [col]
+                                        (if-let [new-name (get renames (:name col))]
+                                          (assoc col :display_name new-name)
+                                          col))
+                                      (:result_metadata card))
+                expected-names  ["Termekazonosito" "Keszites eve" "Darabszam" "Osszes mennyiseg"]
+                updated-card    (mt/user-http-request :crowberto :put 200 (str "card/" card-id)
+                                                      {:result_metadata new-metadata})]
+            ;; Verify the PUT response has the custom display names.
+            ;; ": Year" should NOT be re-appended to a user-customized temporal column name.
+            (is (= expected-names
+                   (map :display_name (:result_metadata updated-card))))
+            ;; Now query the model and verify custom display names are preserved in the response
+            (let [query-response (mt/user-http-request :crowberto :post 202 (format "card/%d/query" card-id))]
+              (is (= expected-names
+                     (map :display_name (get-in query-response [:data :results_metadata :columns]))))
+              ;; Also verify the card's stored metadata in DB wasn't overwritten
+              (is (= expected-names
+                     (map :display_name (t2/select-one-fn :result_metadata :model/Card :id card-id)))))))))))
+
 (deftest ^:parallel updating-native-card-preserves-metadata
   (testing "A trivial change in a native question should not remove result_metadata (#37009)"
     (let [query (to-native (updating-card-updates-metadata-query))


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #71481
Closes QUE2-471

### Description

The original fix was backported to 60.

### How to verify

The repro steps should show that the metadata can now be edited.

### Demo

<img width="719" height="189" alt="image" src="https://github.com/user-attachments/assets/ff570591-1c63-4cee-877b-1bf61b0d6842" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
