### PR TITLE
Fix notification send test retry config key (:max-attempts → :max-retries)

### DIFF
--- a/test/metabase/notification/send_test.clj
+++ b/test/metabase/notification/send_test.clj
@@ -399,7 +399,7 @@
                    [{:channel_type notification.tu/test-channel-type
                      :channel_id   (:id chn)
                      :recipients   [{:type :notification-recipient/user :user_id (mt/user->id :crowberto)}]}])]
-            (with-redefs [notification.send/default-retry-config (assoc @#'notification.send/default-retry-config :max-attempts 1)
+            (with-redefs [notification.send/default-retry-config (assoc @#'notification.send/default-retry-config :max-retries 1)
                           channel/send! (fn [& _]
                                           (throw (Exception. "test-channel-exception")))]
               (#'notification.send/send-notification-sync! n)


### PR DESCRIPTION
### Description

The test overrode :max-attempts but diehard uses :max-retries, so the override was silently ignored and all 6 retries ran with exponential backoff (~31s). With the correct key the test finishes in ~1s.