### PR TITLE
Update permissions in embedding SDK tests to avoid permission errors in some cases

### DIFF
--- a/.github/workflows/embedding-sdk-host-sample-apps-tests.yml
+++ b/.github/workflows/embedding-sdk-host-sample-apps-tests.yml
@@ -106,6 +106,8 @@ jobs:
       SAMPLE_APP_ENVIRONMENT: ${{ matrix.environment }}
     permissions:
       id-token: write
+      contents: read
+      actions: read
 
     steps:
       - uses: actions/checkout@v4
@@ -213,6 +215,8 @@ jobs:
       SAMPLE_APP_ENVIRONMENT: ${{ matrix.environment }}
     permissions:
       id-token: write
+      contents: read
+      actions: read
 
     steps:
       - uses: actions/checkout@v4
@@ -277,6 +281,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      actions: read
 
     steps:
       - uses: actions/checkout@v4
@@ -362,6 +367,8 @@ jobs:
       HOST_APP_ENVIRONMENT: ${{ matrix.environment }}
     permissions:
       id-token: write
+      contents: read
+      actions: read
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Update permissions in embedding SDK tests to avoid permission errors in some cases

Context: https://metaboat.slack.com/archives/C063Q3F1HPF/p1774945517309199