### PR TITLE
Security center admin page and advisory list

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/api_routes/routes.clj
+++ b/enterprise/backend/src/metabase_enterprise/api_routes/routes.clj
@@ -121,7 +121,7 @@
    "/transforms-python"            (premium-handler metabase-enterprise.transforms-python.api/routes :transforms-python)
    "/scim"                         (premium-handler metabase-enterprise.scim.routes/routes :scim)
    "/semantic-search"              (premium-handler metabase-enterprise.semantic-search.api/routes :semantic-search)
-   "/security-center"              (premium-handler metabase-enterprise.security-center.api/routes :security-center)
+   "/security-center"              metabase-enterprise.security-center.api/routes ;; TODO: restore (premium-handler ... :security-center) once token is sorted
    "/serialization"                (premium-handler metabase-enterprise.serialization.api/routes :serialization)
    "/stale"                        (premium-handler metabase-enterprise.stale.api/routes :collection-cleanup)
    "/support-access-grant" (premium-handler metabase-enterprise.support-access-grants.api/routes :support-users)

--- a/enterprise/frontend/src/metabase-enterprise/plugins.ts
+++ b/enterprise/frontend/src/metabase-enterprise/plugins.ts
@@ -35,6 +35,7 @@ import { initializePlugin as initializeRemoteSync } from "./remote_sync";
 import { initializePlugin as initializeReplacement } from "./replacement";
 import { initializePlugin as initializeResourceDownloads } from "./resource_downloads";
 import { initializePlugin as initializeSandboxes } from "./sandboxes";
+import { initializePlugin as initializeSecurityCenter } from "./security_center";
 import { initializePlugin as initializeSemanticSearch } from "./semantic_search";
 import { initializePlugin as initializeSharing } from "./sharing";
 import { initializePlugin as initializeSmtpOverride } from "./smtp-override";
@@ -89,6 +90,7 @@ export function initializePlugins() {
   initializeDatabaseReplication();
   initializeTableEditing();
   initializeDependencies();
+  initializeSecurityCenter();
   initializeSemanticSearch();
   initializeTransforms();
   initializeTransformsInspector();

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryCard/AdvisoryCard.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryCard/AdvisoryCard.module.css
@@ -21,3 +21,15 @@
   background-color: var(--mb-color-success);
   color: var(--mb-color-white);
 }
+
+.statusAffected {
+  background-color: var(--mb-color-background-error);
+  border-color: var(--mb-color-error);
+  color: var(--mb-color-error);
+}
+
+.statusNotAffected {
+  background-color: var(--mb-color-background-success);
+  border-color: var(--mb-color-success);
+  color: var(--mb-color-success);
+}

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryCard/AdvisoryCard.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryCard/AdvisoryCard.module.css
@@ -1,6 +1,5 @@
 .affectedCard {
   background-color: var(--mb-color-bg-error);
-  border-left: 3px solid var(--mb-color-error);
 }
 
 .severityCritical {
@@ -14,8 +13,8 @@
 }
 
 .severityMedium {
-  background-color: var(--mb-color-gold);
-  color: var(--mb-color-text-primary);
+  background-color: var(--mb-color-bronze);
+  color: var(--mb-color-white);
 }
 
 .severityLow {

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryCard/AdvisoryCard.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryCard/AdvisoryCard.module.css
@@ -1,0 +1,24 @@
+.affectedCard {
+  background-color: var(--mb-color-bg-error);
+  border-left: 3px solid var(--mb-color-error);
+}
+
+.severityCritical {
+  background-color: var(--mb-color-error);
+  color: var(--mb-color-white);
+}
+
+.severityHigh {
+  background-color: var(--mb-color-warning);
+  color: var(--mb-color-white);
+}
+
+.severityMedium {
+  background-color: var(--mb-color-gold);
+  color: var(--mb-color-text-primary);
+}
+
+.severityLow {
+  background-color: var(--mb-color-text-tertiary);
+  color: var(--mb-color-white);
+}

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryCard/AdvisoryCard.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryCard/AdvisoryCard.module.css
@@ -13,11 +13,11 @@
 }
 
 .severityMedium {
-  background-color: var(--mb-color-bronze);
-  color: var(--mb-color-white);
+  background-color: var(--mb-color-gold);
+  color: var(--mb-color-text-primary);
 }
 
 .severityLow {
-  background-color: var(--mb-color-text-tertiary);
+  background-color: var(--mb-color-success);
   color: var(--mb-color-white);
 }

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryCard/AdvisoryCard.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryCard/AdvisoryCard.tsx
@@ -1,0 +1,111 @@
+import { t } from "ttag";
+
+import {
+  Anchor,
+  Badge,
+  Button,
+  Card,
+  Flex,
+  Group,
+  Stack,
+  Text,
+  Title,
+} from "metabase/ui";
+
+import type { Advisory, AdvisorySeverity } from "../../types";
+
+import S from "./AdvisoryCard.module.css";
+
+const SEVERITY_CLASS: Record<AdvisorySeverity, string> = {
+  critical: S.severityCritical,
+  high: S.severityHigh,
+  medium: S.severityMedium,
+  low: S.severityLow,
+};
+
+interface AdvisoryCardProps {
+  advisory: Advisory;
+  onAcknowledge?: (advisoryId: string) => void;
+}
+
+export function AdvisoryCard({ advisory, onAcknowledge }: AdvisoryCardProps) {
+  return (
+    <Card
+      p="lg"
+      withBorder
+      className={advisory.affected ? S.affectedCard : undefined}
+      data-testid="advisory-card"
+    >
+      <Stack gap="sm">
+        <Flex justify="space-between" align="center" wrap="wrap" gap="sm">
+          <Group gap="sm">
+            <Badge className={SEVERITY_CLASS[advisory.severity]}>
+              {advisory.severity}
+            </Badge>
+            <Title order={4}>{advisory.title}</Title>
+          </Group>
+          <Group gap="sm">
+            {advisory.acknowledged && (
+              <Badge
+                color="brand"
+                variant="light"
+                data-testid="acknowledged-badge"
+              >
+                {t`Acknowledged`}
+              </Badge>
+            )}
+            <Badge
+              color={advisory.affected ? "error" : "success"}
+              variant={advisory.affected ? "filled" : "light"}
+              data-testid="affected-status"
+            >
+              {advisory.affected ? t`Affected` : t`Not affected`}
+            </Badge>
+          </Group>
+        </Flex>
+
+        <Text lineClamp={2} c="text-secondary">
+          {advisory.description}
+        </Text>
+
+        <Group gap="lg">
+          <Text size="sm" c="text-secondary">
+            {t`Affected versions`}: {advisory.affectedVersionRange}
+          </Text>
+          <Text size="sm" c="text-secondary">
+            {t`Fixed in`}: {advisory.fixedVersion}
+          </Text>
+        </Group>
+
+        <Group gap="md">
+          <Anchor
+            href={advisory.advisoryUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            size="sm"
+          >
+            {t`View advisory`}
+          </Anchor>
+          <Anchor
+            href={advisory.upgradeUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            size="sm"
+          >
+            {t`Upgrade guide`}
+          </Anchor>
+          {!advisory.acknowledged && onAcknowledge && (
+            <Button
+              variant="subtle"
+              size="compact-sm"
+              onClick={() => onAcknowledge(advisory.id)}
+              data-testid="acknowledge-button"
+            >
+              {t`Acknowledge`}
+            </Button>
+          )}
+        </Group>
+      </Stack>
+    </Card>
+  );
+}

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryCard/AdvisoryCard.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryCard/AdvisoryCard.tsx
@@ -13,6 +13,7 @@ import {
 } from "metabase/ui";
 
 import type { Advisory, AdvisorySeverity } from "../../types";
+import { isAcknowledged, isAffected } from "../../utils";
 
 import S from "./AdvisoryCard.module.css";
 
@@ -23,17 +24,26 @@ const SEVERITY_CLASS: Record<AdvisorySeverity, string> = {
   low: S.severityLow,
 };
 
+function formatVersionRange(advisory: Advisory): string {
+  return advisory.affected_versions
+    .map((v) => `${v.min} – ${v.fixed}`)
+    .join(", ");
+}
+
 interface AdvisoryCardProps {
   advisory: Advisory;
   onAcknowledge?: (advisoryId: string) => void;
 }
 
 export function AdvisoryCard({ advisory, onAcknowledge }: AdvisoryCardProps) {
+  const affected = isAffected(advisory);
+  const acknowledged = isAcknowledged(advisory);
+
   return (
     <Card
       p="lg"
       withBorder
-      className={advisory.affected ? S.affectedCard : undefined}
+      className={affected ? S.affectedCard : undefined}
       data-testid="advisory-card"
       mih={184}
     >
@@ -46,7 +56,7 @@ export function AdvisoryCard({ advisory, onAcknowledge }: AdvisoryCardProps) {
             <Title order={4}>{advisory.title}</Title>
           </Group>
           <Group gap="sm">
-            {advisory.acknowledged && (
+            {acknowledged && (
               <Badge
                 color="brand"
                 variant="light"
@@ -57,12 +67,10 @@ export function AdvisoryCard({ advisory, onAcknowledge }: AdvisoryCardProps) {
             )}
             <Badge
               variant="outline"
-              className={
-                advisory.affected ? S.statusAffected : S.statusNotAffected
-              }
+              className={affected ? S.statusAffected : S.statusNotAffected}
               data-testid="affected-status"
             >
-              {advisory.affected ? t`Affected` : t`Not affected`}
+              {affected ? t`Affected` : t`Not affected`}
             </Badge>
           </Group>
         </Flex>
@@ -72,36 +80,32 @@ export function AdvisoryCard({ advisory, onAcknowledge }: AdvisoryCardProps) {
         </Text>
 
         <Group gap="lg">
+          {advisory.affected_versions.length > 0 && (
+            <Text size="sm" c="text-secondary">
+              {t`Affected versions`}: {formatVersionRange(advisory)}
+            </Text>
+          )}
           <Text size="sm" c="text-secondary">
-            {t`Affected versions`}: {advisory.affectedVersionRange}
-          </Text>
-          <Text size="sm" c="text-secondary">
-            {t`Fixed in`}: {advisory.fixedVersion}
+            {t`Remediation`}: {advisory.remediation}
           </Text>
         </Group>
 
         <Group gap="md" h={28}>
-          <Anchor
-            href={advisory.advisoryUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            size="sm"
-          >
-            {t`View advisory`}
-          </Anchor>
-          <Anchor
-            href={advisory.upgradeUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            size="sm"
-          >
-            {t`Upgrade guide`}
-          </Anchor>
-          {!advisory.acknowledged && onAcknowledge && (
+          {advisory.advisory_url && (
+            <Anchor
+              href={advisory.advisory_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              size="sm"
+            >
+              {t`View advisory`}
+            </Anchor>
+          )}
+          {!acknowledged && onAcknowledge && (
             <Button
               variant="subtle"
               size="compact-sm"
-              onClick={() => onAcknowledge(advisory.id)}
+              onClick={() => onAcknowledge(advisory.advisory_id)}
               data-testid="acknowledge-button"
             >
               {t`Acknowledge`}

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryCard/AdvisoryCard.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryCard/AdvisoryCard.tsx
@@ -55,8 +55,10 @@ export function AdvisoryCard({ advisory, onAcknowledge }: AdvisoryCardProps) {
               </Badge>
             )}
             <Badge
-              color={advisory.affected ? "error" : "success"}
-              variant={advisory.affected ? "filled" : "light"}
+              variant="outline"
+              className={
+                advisory.affected ? S.statusAffected : S.statusNotAffected
+              }
               data-testid="affected-status"
             >
               {advisory.affected ? t`Affected` : t`Not affected`}
@@ -77,7 +79,7 @@ export function AdvisoryCard({ advisory, onAcknowledge }: AdvisoryCardProps) {
           </Text>
         </Group>
 
-        <Group gap="md">
+        <Group gap="md" h={28}>
           <Anchor
             href={advisory.advisoryUrl}
             target="_blank"

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryCard/AdvisoryCard.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryCard/AdvisoryCard.tsx
@@ -35,6 +35,7 @@ export function AdvisoryCard({ advisory, onAcknowledge }: AdvisoryCardProps) {
       withBorder
       className={advisory.affected ? S.affectedCard : undefined}
       data-testid="advisory-card"
+      mih={184}
     >
       <Stack gap="sm">
         <Flex justify="space-between" align="center" wrap="wrap" gap="sm">

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryFilterBar/AdvisoryFilterBar.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryFilterBar/AdvisoryFilterBar.tsx
@@ -1,0 +1,66 @@
+import { t } from "ttag";
+
+import { Checkbox, Group, Select } from "metabase/ui";
+
+import type { AdvisoryFilter } from "../../types";
+
+interface AdvisoryFilterBarProps {
+  filter: AdvisoryFilter;
+  onChange: (filter: AdvisoryFilter) => void;
+}
+
+export function AdvisoryFilterBar({
+  filter,
+  onChange,
+}: AdvisoryFilterBarProps) {
+  const severityOptions = [
+    { value: "all", label: t`All severities` },
+    { value: "critical", label: t`Critical` },
+    { value: "high", label: t`High` },
+    { value: "medium", label: t`Medium` },
+    { value: "low", label: t`Low` },
+  ];
+
+  const statusOptions = [
+    { value: "all", label: t`All statuses` },
+    { value: "affected", label: t`Affected` },
+    { value: "not-affected", label: t`Not affected` },
+  ];
+
+  return (
+    <Group gap="md" data-testid="advisory-filter-bar">
+      <Select
+        data={severityOptions}
+        value={filter.severity}
+        onChange={(value) =>
+          onChange({
+            ...filter,
+            severity: (value as AdvisoryFilter["severity"]) ?? "all",
+          })
+        }
+        w={180}
+        data-testid="severity-filter"
+      />
+      <Select
+        data={statusOptions}
+        value={filter.status}
+        onChange={(value) =>
+          onChange({
+            ...filter,
+            status: (value as AdvisoryFilter["status"]) ?? "all",
+          })
+        }
+        w={180}
+        data-testid="status-filter"
+      />
+      <Checkbox
+        label={t`Show acknowledged`}
+        checked={filter.showAcknowledged}
+        onChange={(e) =>
+          onChange({ ...filter, showAcknowledged: e.currentTarget.checked })
+        }
+        data-testid="show-acknowledged-filter"
+      />
+    </Group>
+  );
+}

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryFilterBar/AdvisoryFilterBar.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryFilterBar/AdvisoryFilterBar.tsx
@@ -7,6 +7,7 @@ import type { AdvisoryFilter, AdvisorySeverity } from "../../types";
 interface AdvisoryFilterBarProps {
   filter: AdvisoryFilter;
   onChange: (filter: AdvisoryFilter) => void;
+  className?: string;
 }
 
 type SelectOption<T extends string> = { value: T; label: string };
@@ -14,6 +15,7 @@ type SelectOption<T extends string> = { value: T; label: string };
 export function AdvisoryFilterBar({
   filter,
   onChange,
+  className,
 }: AdvisoryFilterBarProps) {
   const severityOptions: SelectOption<AdvisorySeverity | "all">[] = [
     { value: "all", label: t`All severities` },
@@ -30,7 +32,7 @@ export function AdvisoryFilterBar({
   ];
 
   return (
-    <Group gap="md" data-testid="advisory-filter-bar">
+    <Group gap="md" data-testid="advisory-filter-bar" className={className}>
       <Select
         data={severityOptions}
         value={filter.severity}

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryFilterBar/AdvisoryFilterBar.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryFilterBar/AdvisoryFilterBar.tsx
@@ -2,18 +2,20 @@ import { t } from "ttag";
 
 import { Checkbox, Group, Select } from "metabase/ui";
 
-import type { AdvisoryFilter } from "../../types";
+import type { AdvisoryFilter, AdvisorySeverity } from "../../types";
 
 interface AdvisoryFilterBarProps {
   filter: AdvisoryFilter;
   onChange: (filter: AdvisoryFilter) => void;
 }
 
+type SelectOption<T extends string> = { value: T; label: string };
+
 export function AdvisoryFilterBar({
   filter,
   onChange,
 }: AdvisoryFilterBarProps) {
-  const severityOptions = [
+  const severityOptions: SelectOption<AdvisorySeverity | "all">[] = [
     { value: "all", label: t`All severities` },
     { value: "critical", label: t`Critical` },
     { value: "high", label: t`High` },
@@ -21,7 +23,7 @@ export function AdvisoryFilterBar({
     { value: "low", label: t`Low` },
   ];
 
-  const statusOptions = [
+  const statusOptions: SelectOption<AdvisoryFilter["status"]>[] = [
     { value: "all", label: t`All statuses` },
     { value: "affected", label: t`Affected` },
     { value: "not-affected", label: t`Not affected` },

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryList/AdvisoryList.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryList/AdvisoryList.tsx
@@ -10,14 +10,20 @@ import { AdvisoryCard } from "../AdvisoryCard/AdvisoryCard";
 interface AdvisoryListProps {
   advisories: Advisory[];
   onAcknowledge?: (advisoryId: string) => void;
+  className?: string;
 }
 
-export function AdvisoryList({ advisories, onAcknowledge }: AdvisoryListProps) {
+export function AdvisoryList({
+  advisories,
+  onAcknowledge,
+  className,
+}: AdvisoryListProps) {
   const sorted = sortAdvisories(advisories);
 
   if (sorted.length === 0) {
     return (
       <EmptyState
+        className={className}
         icon="shield_outline"
         message={t`Your instance is up to date — no known security issues affect your configuration.`}
       />
@@ -25,7 +31,7 @@ export function AdvisoryList({ advisories, onAcknowledge }: AdvisoryListProps) {
   }
 
   return (
-    <Stack gap="md">
+    <Stack gap="md" className={className}>
       {sorted.map((advisory) => (
         <AdvisoryCard
           key={advisory.id}

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryList/AdvisoryList.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryList/AdvisoryList.tsx
@@ -1,6 +1,7 @@
 import { t } from "ttag";
 
-import { Stack, Text } from "metabase/ui";
+import { EmptyState } from "metabase/common/components/EmptyState";
+import { Stack } from "metabase/ui";
 
 import type { Advisory } from "../../types";
 import { sortAdvisories } from "../../utils";
@@ -16,9 +17,10 @@ export function AdvisoryList({ advisories, onAcknowledge }: AdvisoryListProps) {
 
   if (sorted.length === 0) {
     return (
-      <Text c="text-secondary" data-testid="empty-state">
-        {t`Your instance is up to date — no known security issues affect your configuration.`}
-      </Text>
+      <EmptyState
+        icon="shield"
+        message={t`Your instance is up to date — no known security issues affect your configuration.`}
+      />
     );
   }
 

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryList/AdvisoryList.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryList/AdvisoryList.tsx
@@ -1,6 +1,3 @@
-import { t } from "ttag";
-
-import { EmptyState } from "metabase/common/components/EmptyState";
 import { Stack } from "metabase/ui";
 
 import type { Advisory } from "../../types";
@@ -20,21 +17,11 @@ export function AdvisoryList({
 }: AdvisoryListProps) {
   const sorted = sortAdvisories(advisories);
 
-  if (sorted.length === 0) {
-    return (
-      <EmptyState
-        className={className}
-        icon="shield_outline"
-        message={t`Your instance is up to date — no known security issues affect your configuration.`}
-      />
-    );
-  }
-
   return (
     <Stack gap="md" className={className}>
       {sorted.map((advisory) => (
         <AdvisoryCard
-          key={advisory.id}
+          key={advisory.advisory_id}
           advisory={advisory}
           onAcknowledge={onAcknowledge}
         />

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryList/AdvisoryList.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryList/AdvisoryList.tsx
@@ -1,0 +1,36 @@
+import { t } from "ttag";
+
+import { Stack, Text } from "metabase/ui";
+
+import type { Advisory } from "../../types";
+import { sortAdvisories } from "../../utils";
+import { AdvisoryCard } from "../AdvisoryCard/AdvisoryCard";
+
+interface AdvisoryListProps {
+  advisories: Advisory[];
+  onAcknowledge?: (advisoryId: string) => void;
+}
+
+export function AdvisoryList({ advisories, onAcknowledge }: AdvisoryListProps) {
+  const sorted = sortAdvisories(advisories);
+
+  if (sorted.length === 0) {
+    return (
+      <Text c="text-secondary" data-testid="empty-state">
+        {t`Your instance is up to date — no known security issues affect your configuration.`}
+      </Text>
+    );
+  }
+
+  return (
+    <Stack gap="md">
+      {sorted.map((advisory) => (
+        <AdvisoryCard
+          key={advisory.id}
+          advisory={advisory}
+          onAcknowledge={onAcknowledge}
+        />
+      ))}
+    </Stack>
+  );
+}

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryList/AdvisoryList.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryList/AdvisoryList.tsx
@@ -18,7 +18,7 @@ export function AdvisoryList({ advisories, onAcknowledge }: AdvisoryListProps) {
   if (sorted.length === 0) {
     return (
       <EmptyState
-        icon="shield"
+        icon="shield_outline"
         message={t`Your instance is up to date — no known security issues affect your configuration.`}
       />
     );

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/NotificationChannelConfig/NotificationChannelConfig.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/NotificationChannelConfig/NotificationChannelConfig.tsx
@@ -1,17 +1,19 @@
+import { useCallback, useState } from "react";
 import { t } from "ttag";
 
-import { SettingsSection } from "metabase/admin/components/SettingsSection";
 import { ActionButton } from "metabase/common/components/ActionButton";
-import { useSetting } from "metabase/common/hooks";
+import { useSetting, useToast } from "metabase/common/hooks";
 import { RecipientPicker } from "metabase/notifications/channels/RecipientPicker";
 import {
   Anchor,
   Autocomplete,
   Box,
+  Button,
   Card,
   Flex,
   Group,
   Icon,
+  Modal,
   Stack,
   Switch,
   Text,
@@ -20,14 +22,22 @@ import {
 
 import type { useNotificationConfig } from "../../hooks/use-notification-config";
 
-type NotificationChannelConfigProps = ReturnType<typeof useNotificationConfig>;
+type NotificationChannelConfigProps = ReturnType<
+  typeof useNotificationConfig
+> & {
+  opened: boolean;
+  onClose: () => void;
+};
 
-export function NotificationChannelConfig({
+export function NotificationChannelConfigModal({
+  opened,
+  onClose,
   config,
   updateEmailRecipients,
   toggleSendToAllAdmins,
   updateSlackChannel,
   toggleSlack,
+  save,
   sendTestEmail,
   sendTestSlack,
   users,
@@ -35,13 +45,41 @@ export function NotificationChannelConfig({
 }: NotificationChannelConfigProps) {
   const isEmailConfigured = useSetting("email-configured?");
   const isSlackConfigured = useSetting("slack-token-valid?");
+  const [sendToast] = useToast();
+  const [isSaving, setIsSaving] = useState(false);
+
+  const handleSave = useCallback(async () => {
+    setIsSaving(true);
+    try {
+      await save();
+      sendToast({
+        message: t`Notification settings saved`,
+        toastColor: "success",
+      });
+      onClose();
+    } catch {
+      sendToast({
+        icon: "warning",
+        toastColor: "error",
+        message: t`Failed to save notification settings`,
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  }, [save, sendToast, onClose]);
+
+  const emailHasRecipients =
+    config.email.sendToAllAdmins || config.email.recipients.length > 0;
+  const canSave = emailHasRecipients || !isEmailConfigured;
 
   return (
-    <SettingsSection
-      title={t`Notification channels`}
-      description={t`Configure where security notifications are delivered.`}
+    <Modal
+      opened={opened}
+      onClose={onClose}
+      title={t`Notification settings`}
+      size="lg"
     >
-      <Stack gap="md">
+      <Stack gap="md" mt="md">
         <EmailChannelCard
           config={config}
           isConfigured={isEmailConfigured}
@@ -58,8 +96,21 @@ export function NotificationChannelConfig({
           toggleSlack={toggleSlack}
           sendTestSlack={sendTestSlack}
         />
+        <Flex justify="flex-end" gap="md" mt="md">
+          <Button variant="subtle" onClick={onClose}>
+            {t`Cancel`}
+          </Button>
+          <Button
+            variant="filled"
+            onClick={handleSave}
+            loading={isSaving}
+            disabled={!canSave}
+          >
+            {t`Save`}
+          </Button>
+        </Flex>
       </Stack>
-    </SettingsSection>
+    </Modal>
   );
 }
 

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/NotificationChannelConfig/NotificationChannelConfig.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/NotificationChannelConfig/NotificationChannelConfig.tsx
@@ -1,0 +1,222 @@
+import { t } from "ttag";
+
+import { SettingsSection } from "metabase/admin/components/SettingsSection";
+import { ActionButton } from "metabase/common/components/ActionButton";
+import { useSetting } from "metabase/common/hooks";
+import { RecipientPicker } from "metabase/notifications/channels/RecipientPicker";
+import {
+  Anchor,
+  Autocomplete,
+  Box,
+  Card,
+  Flex,
+  Group,
+  Icon,
+  Stack,
+  Switch,
+  Text,
+  Title,
+} from "metabase/ui";
+
+import type { useNotificationConfig } from "../../hooks/use-notification-config";
+
+type NotificationChannelConfigProps = ReturnType<typeof useNotificationConfig>;
+
+export function NotificationChannelConfig({
+  config,
+  updateEmailRecipients,
+  toggleSendToAllAdmins,
+  updateSlackChannel,
+  toggleSlack,
+  sendTestEmail,
+  sendTestSlack,
+  users,
+  slackChannelOptions,
+}: NotificationChannelConfigProps) {
+  const isEmailConfigured = useSetting("email-configured?");
+  const isSlackConfigured = useSetting("slack-token-valid?");
+
+  return (
+    <SettingsSection
+      title={t`Notification channels`}
+      description={t`Configure where security notifications are delivered.`}
+    >
+      <Stack gap="md">
+        <EmailChannelCard
+          config={config}
+          isConfigured={isEmailConfigured}
+          users={users}
+          updateEmailRecipients={updateEmailRecipients}
+          toggleSendToAllAdmins={toggleSendToAllAdmins}
+          sendTestEmail={sendTestEmail}
+        />
+        <SlackChannelCard
+          config={config}
+          isConfigured={isSlackConfigured}
+          channelOptions={slackChannelOptions}
+          updateSlackChannel={updateSlackChannel}
+          toggleSlack={toggleSlack}
+          sendTestSlack={sendTestSlack}
+        />
+      </Stack>
+    </SettingsSection>
+  );
+}
+
+function EmailChannelCard({
+  config,
+  isConfigured,
+  users,
+  updateEmailRecipients,
+  toggleSendToAllAdmins,
+  sendTestEmail,
+}: {
+  config: NotificationChannelConfigProps["config"];
+  isConfigured: boolean;
+  users: NotificationChannelConfigProps["users"];
+  updateEmailRecipients: NotificationChannelConfigProps["updateEmailRecipients"];
+  toggleSendToAllAdmins: NotificationChannelConfigProps["toggleSendToAllAdmins"];
+  sendTestEmail: NotificationChannelConfigProps["sendTestEmail"];
+}) {
+  const hasRecipients =
+    config.email.sendToAllAdmins || config.email.recipients.length > 0;
+
+  if (!isConfigured) {
+    return (
+      <Card withBorder p="lg">
+        <Group gap="sm">
+          <Icon name="mail" />
+          <Title order={4}>{t`Email`}</Title>
+        </Group>
+        <Text c="text-secondary" mt="sm">
+          {t`Email is not configured.`}{" "}
+          <Anchor href="/admin/settings/email">{t`Set up email`}</Anchor>
+        </Text>
+      </Card>
+    );
+  }
+
+  return (
+    <Card withBorder p="lg" data-testid="email-channel-card">
+      <Group gap="sm" mb="md">
+        <Icon name="mail" />
+        <Title order={4}>{t`Email`}</Title>
+      </Group>
+      <Stack gap="md">
+        <Switch
+          label={t`Send to all instance admins`}
+          checked={config.email.sendToAllAdmins}
+          onChange={(e) => toggleSendToAllAdmins(e.currentTarget.checked)}
+          data-testid="send-to-admins-toggle"
+        />
+        {!config.email.sendToAllAdmins && (
+          <Box>
+            <Text size="sm" fw={500} mb="xs">
+              {t`Recipients`}
+            </Text>
+            <RecipientPicker
+              recipients={config.email.recipients}
+              users={users}
+              onRecipientsChange={updateEmailRecipients}
+              autoFocus={false}
+              invalidRecipientText={(domains) =>
+                t`Only addresses ending in ${domains} are allowed.`
+              }
+            />
+            {config.email.recipients.length === 0 && (
+              <Text size="sm" c="error" mt="xs">
+                {t`At least one recipient is required.`}
+              </Text>
+            )}
+          </Box>
+        )}
+        <Box>
+          <ActionButton
+            actionFn={sendTestEmail}
+            normalText={t`Send test email`}
+            activeText={t`Sending...`}
+            successText={t`Email sent`}
+            failedText={t`Failed to send`}
+            disabled={!hasRecipients}
+            data-testid="send-test-email"
+          />
+        </Box>
+      </Stack>
+    </Card>
+  );
+}
+
+function SlackChannelCard({
+  config,
+  isConfigured,
+  channelOptions,
+  updateSlackChannel,
+  toggleSlack,
+  sendTestSlack,
+}: {
+  config: NotificationChannelConfigProps["config"];
+  isConfigured: boolean;
+  channelOptions: string[];
+  updateSlackChannel: NotificationChannelConfigProps["updateSlackChannel"];
+  toggleSlack: NotificationChannelConfigProps["toggleSlack"];
+  sendTestSlack: NotificationChannelConfigProps["sendTestSlack"];
+}) {
+  if (!isConfigured) {
+    return (
+      <Card withBorder p="lg">
+        <Group gap="sm">
+          <Icon name="slack" />
+          <Title order={4}>{t`Slack`}</Title>
+        </Group>
+        <Text c="text-secondary" mt="sm">
+          {t`Slack is not configured.`}{" "}
+          <Anchor href="/admin/settings/slack">{t`Set up Slack`}</Anchor>
+        </Text>
+      </Card>
+    );
+  }
+
+  return (
+    <Card withBorder p="lg" data-testid="slack-channel-card">
+      <Flex justify="space-between" align="center" mb="md">
+        <Group gap="sm">
+          <Icon name="slack" />
+          <Title order={4}>{t`Slack`}</Title>
+        </Group>
+        <Switch
+          checked={config.slack.enabled}
+          onChange={(e) => toggleSlack(e.currentTarget.checked)}
+          data-testid="slack-toggle"
+        />
+      </Flex>
+      {config.slack.enabled && (
+        <Stack gap="md">
+          <Box>
+            <Text size="sm" fw={500} mb="xs">
+              {t`Channel`}
+            </Text>
+            <Autocomplete
+              data={channelOptions}
+              value={config.slack.channel}
+              onChange={updateSlackChannel}
+              placeholder={t`Pick a channel...`}
+              limit={300}
+              data-testid="slack-channel-input"
+            />
+          </Box>
+          <Box>
+            <ActionButton
+              actionFn={sendTestSlack}
+              normalText={t`Send test message`}
+              activeText={t`Sending...`}
+              successText={t`Message sent`}
+              failedText={t`Failed to send`}
+              disabled={!config.slack.channel}
+              data-testid="send-test-slack"
+            />
+          </Box>
+        </Stack>
+      )}
+    </Card>
+  );
+}

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.module.css
@@ -23,4 +23,11 @@
     flex: 1;
     overflow: auto;
   }
+
+  .empty-state {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
 }

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.module.css
@@ -1,7 +1,26 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 65px - 4rem);
+  min-height: 0;
+}
+
 .header {
-  position: sticky;
-  top: 0;
-  z-index: 1;
+  flex-shrink: 0;
   padding-bottom: var(--mantine-spacing-lg);
-  background-color: var(--mb-color-background-secondary);
+}
+
+.content {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+
+  .filter-bar {
+    flex: 0;
+  }
+
+  .list {
+    flex: 1;
+    overflow: auto;
+  }
 }

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.module.css
@@ -1,0 +1,7 @@
+.header {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  padding-bottom: var(--mantine-spacing-lg);
+  background-color: var(--mb-color-background-secondary);
+}

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.tsx
@@ -1,0 +1,41 @@
+import { useState } from "react";
+import { t } from "ttag";
+
+import { Box, Stack, Text, Title } from "metabase/ui";
+
+import { useSecurityAdvisories } from "../../hooks/use-security-advisories";
+import type { AdvisoryFilter } from "../../types";
+import { filterAdvisories } from "../../utils";
+import { AdvisoryFilterBar } from "../AdvisoryFilterBar/AdvisoryFilterBar";
+import { AdvisoryList } from "../AdvisoryList/AdvisoryList";
+
+import S from "./SecurityCenterPage.module.css";
+
+// TODO: replace with actual version from settings once available
+const CURRENT_VERSION = "v0.59.3";
+
+const DEFAULT_FILTER: AdvisoryFilter = {
+  severity: "all",
+  status: "all",
+  showAcknowledged: false,
+};
+
+export function SecurityCenterPage() {
+  const { data: advisories, acknowledgeAdvisory } = useSecurityAdvisories();
+  const [filter, setFilter] = useState<AdvisoryFilter>(DEFAULT_FILTER);
+
+  const filtered = filterAdvisories(advisories, filter);
+
+  return (
+    <Box>
+      <Stack gap="lg" className={S.header}>
+        <Title order={1}>{t`Security Center`}</Title>
+        <Text c="text-secondary" data-testid="current-version">
+          {t`Current version`}: {CURRENT_VERSION}
+        </Text>
+        <AdvisoryFilterBar filter={filter} onChange={setFilter} />
+      </Stack>
+      <AdvisoryList advisories={filtered} onAcknowledge={acknowledgeAdvisory} />
+    </Box>
+  );
+}

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { t } from "ttag";
 
+import { EmptyState } from "metabase/common/components/EmptyState";
 import {
   ActionIcon,
   Box,
@@ -65,11 +66,19 @@ export function SecurityCenterPage() {
           filter={filter}
           onChange={setFilter}
         />
-        <AdvisoryList
-          className={S.list}
-          advisories={filtered}
-          onAcknowledge={acknowledgeAdvisory}
-        />
+        {filtered.length === 0 ? (
+          <EmptyState
+            className={S["empty-state"]}
+            icon="shield_outline"
+            message={t`Your instance is up to date — no known security issues affect your configuration.`}
+          />
+        ) : (
+          <AdvisoryList
+            className={S.list}
+            advisories={filtered}
+            onAcknowledge={acknowledgeAdvisory}
+          />
+        )}
       </Stack>
       <NotificationChannelConfigModal
         opened={settingsOpen}

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.tsx
@@ -1,7 +1,16 @@
 import { useState } from "react";
 import { t } from "ttag";
 
-import { Box, Divider, Stack, Text, Title } from "metabase/ui";
+import {
+  ActionIcon,
+  Box,
+  Group,
+  Icon,
+  Stack,
+  Text,
+  Title,
+  Tooltip,
+} from "metabase/ui";
 
 import { useNotificationConfig } from "../../hooks/use-notification-config";
 import { useSecurityAdvisories } from "../../hooks/use-security-advisories";
@@ -9,7 +18,7 @@ import type { AdvisoryFilter } from "../../types";
 import { filterAdvisories } from "../../utils";
 import { AdvisoryFilterBar } from "../AdvisoryFilterBar/AdvisoryFilterBar";
 import { AdvisoryList } from "../AdvisoryList/AdvisoryList";
-import { NotificationChannelConfig } from "../NotificationChannelConfig/NotificationChannelConfig";
+import { NotificationChannelConfigModal } from "../NotificationChannelConfig/NotificationChannelConfig";
 
 import S from "./SecurityCenterPage.module.css";
 
@@ -25,29 +34,48 @@ const DEFAULT_FILTER: AdvisoryFilter = {
 export function SecurityCenterPage() {
   const { data: advisories, acknowledgeAdvisory } = useSecurityAdvisories();
   const [filter, setFilter] = useState<AdvisoryFilter>(DEFAULT_FILTER);
+  const [settingsOpen, setSettingsOpen] = useState(false);
   const notificationConfig = useNotificationConfig();
 
   const filtered = filterAdvisories(advisories, filter);
 
   return (
-    <Box>
+    <Box className={S.root}>
       <Stack gap="lg" className={S.header}>
-        <Title order={1}>{t`Security Center`}</Title>
+        <Group gap="sm" align="center">
+          <Title order={1}>{t`Security Center`}</Title>
+          <Tooltip label={t`Notification settings`}>
+            <ActionIcon
+              mt={5}
+              variant="subtle"
+              onClick={() => setSettingsOpen(true)}
+              data-testid="notification-config-toggle"
+            >
+              <Icon name="gear" />
+            </ActionIcon>
+          </Tooltip>
+        </Group>
         <Text c="text-secondary" data-testid="current-version">
           {t`Current version`}: {CURRENT_VERSION}
         </Text>
       </Stack>
-      <Stack gap="xl">
-        <NotificationChannelConfig {...notificationConfig} />
-        <Divider />
-        <Box>
-          <AdvisoryFilterBar filter={filter} onChange={setFilter} />
-        </Box>
+      <Stack gap="xl" className={S.content}>
+        <AdvisoryFilterBar
+          className={S["filter-bar"]}
+          filter={filter}
+          onChange={setFilter}
+        />
         <AdvisoryList
+          className={S.list}
           advisories={filtered}
           onAcknowledge={acknowledgeAdvisory}
         />
       </Stack>
+      <NotificationChannelConfigModal
+        opened={settingsOpen}
+        onClose={() => setSettingsOpen(false)}
+        {...notificationConfig}
+      />
     </Box>
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.tsx
@@ -1,13 +1,15 @@
 import { useState } from "react";
 import { t } from "ttag";
 
-import { Box, Stack, Text, Title } from "metabase/ui";
+import { Box, Divider, Stack, Text, Title } from "metabase/ui";
 
+import { useNotificationConfig } from "../../hooks/use-notification-config";
 import { useSecurityAdvisories } from "../../hooks/use-security-advisories";
 import type { AdvisoryFilter } from "../../types";
 import { filterAdvisories } from "../../utils";
 import { AdvisoryFilterBar } from "../AdvisoryFilterBar/AdvisoryFilterBar";
 import { AdvisoryList } from "../AdvisoryList/AdvisoryList";
+import { NotificationChannelConfig } from "../NotificationChannelConfig/NotificationChannelConfig";
 
 import S from "./SecurityCenterPage.module.css";
 
@@ -23,6 +25,7 @@ const DEFAULT_FILTER: AdvisoryFilter = {
 export function SecurityCenterPage() {
   const { data: advisories, acknowledgeAdvisory } = useSecurityAdvisories();
   const [filter, setFilter] = useState<AdvisoryFilter>(DEFAULT_FILTER);
+  const notificationConfig = useNotificationConfig();
 
   const filtered = filterAdvisories(advisories, filter);
 
@@ -33,9 +36,18 @@ export function SecurityCenterPage() {
         <Text c="text-secondary" data-testid="current-version">
           {t`Current version`}: {CURRENT_VERSION}
         </Text>
-        <AdvisoryFilterBar filter={filter} onChange={setFilter} />
       </Stack>
-      <AdvisoryList advisories={filtered} onAcknowledge={acknowledgeAdvisory} />
+      <Stack gap="xl">
+        <NotificationChannelConfig {...notificationConfig} />
+        <Divider />
+        <Box>
+          <AdvisoryFilterBar filter={filter} onChange={setFilter} />
+        </Box>
+        <AdvisoryList
+          advisories={filtered}
+          onAcknowledge={acknowledgeAdvisory}
+        />
+      </Stack>
     </Box>
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.unit.spec.tsx
@@ -53,9 +53,7 @@ describe("SecurityCenterPage", () => {
   it("renders the empty state when there are no advisories", () => {
     setup([]);
 
-    expect(screen.getByTestId("empty-state")).toHaveTextContent(
-      "Your instance is up to date",
-    );
+    expect(screen.getByText(/Your instance is up to date/)).toBeInTheDocument();
   });
 
   it("renders advisory cards in the correct order (affected first, then by severity)", () => {

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.unit.spec.tsx
@@ -10,17 +10,18 @@ import type { Advisory } from "../../types";
 import { SecurityCenterPage } from "./SecurityCenterPage";
 
 const makeAdvisory = (overrides: Partial<Advisory>): Advisory => ({
-  id: "SA-001",
+  advisory_id: "SA-001",
   title: "Test advisory",
   description: "Test description",
   severity: "medium",
-  affectedVersionRange: ">=0.45.0 <0.59.0",
-  fixedVersion: "v0.59.0",
-  publishedAt: "2026-01-01T00:00:00Z",
-  advisoryUrl: "https://example.com/advisory",
-  upgradeUrl: "https://example.com/upgrade",
-  affected: false,
-  acknowledged: false,
+  advisory_url: "https://example.com/advisory",
+  remediation: "Upgrade to latest version",
+  published_at: "2026-01-01T00:00:00Z",
+  match_status: "not_affected",
+  last_evaluated_at: null,
+  acknowledged_by: null,
+  acknowledged_at: null,
+  affected_versions: [{ min: "0.45.0", fixed: "0.59.0" }],
   ...overrides,
 });
 
@@ -29,6 +30,7 @@ const mockAcknowledge = jest.fn();
 function setup(advisories: Advisory[] = []) {
   jest.spyOn(advisoriesHook, "useSecurityAdvisories").mockReturnValue({
     data: advisories,
+    lastCheckedAt: null,
     isLoading: false,
     acknowledgeAdvisory: mockAcknowledge,
   });
@@ -75,22 +77,22 @@ describe("SecurityCenterPage", () => {
   it("renders advisory cards in the correct order (affected first, then by severity)", () => {
     const advisories = [
       makeAdvisory({
-        id: "1",
+        advisory_id: "1",
         title: "Low not affected",
         severity: "low",
-        affected: false,
+        match_status: "not_affected",
       }),
       makeAdvisory({
-        id: "2",
+        advisory_id: "2",
         title: "Critical affected",
         severity: "critical",
-        affected: true,
+        match_status: "active",
       }),
       makeAdvisory({
-        id: "3",
+        advisory_id: "3",
         title: "High affected",
         severity: "high",
-        affected: true,
+        match_status: "active",
       }),
     ];
 
@@ -106,8 +108,8 @@ describe("SecurityCenterPage", () => {
 
   it("shows affected status on cards", () => {
     const advisories = [
-      makeAdvisory({ id: "1", affected: true }),
-      makeAdvisory({ id: "2", affected: false }),
+      makeAdvisory({ advisory_id: "1", match_status: "active" }),
+      makeAdvisory({ advisory_id: "2", match_status: "not_affected" }),
     ];
 
     setup(advisories);
@@ -120,9 +122,8 @@ describe("SecurityCenterPage", () => {
   it("renders external links with correct targets", () => {
     const advisories = [
       makeAdvisory({
-        id: "1",
-        advisoryUrl: "https://example.com/advisory/1",
-        upgradeUrl: "https://example.com/upgrade/1",
+        advisory_id: "1",
+        advisory_url: "https://example.com/advisory/1",
       }),
     ];
 
@@ -134,17 +135,12 @@ describe("SecurityCenterPage", () => {
       "https://example.com/advisory/1",
     );
     expect(advisoryLink).toHaveAttribute("target", "_blank");
-
-    const upgradeLink = screen.getByText("Upgrade guide");
-    expect(upgradeLink).toHaveAttribute(
-      "href",
-      "https://example.com/upgrade/1",
-    );
-    expect(upgradeLink).toHaveAttribute("target", "_blank");
   });
 
   it("calls acknowledgeAdvisory when acknowledge button is clicked", async () => {
-    const advisories = [makeAdvisory({ id: "SA-001", acknowledged: false })];
+    const advisories = [
+      makeAdvisory({ advisory_id: "SA-001", acknowledged_at: null }),
+    ];
 
     setup(advisories);
 
@@ -153,7 +149,12 @@ describe("SecurityCenterPage", () => {
   });
 
   it("does not show acknowledge button for already acknowledged advisories", async () => {
-    const advisories = [makeAdvisory({ id: "SA-001", acknowledged: true })];
+    const advisories = [
+      makeAdvisory({
+        advisory_id: "SA-001",
+        acknowledged_at: "2026-03-01T00:00:00Z",
+      }),
+    ];
 
     setup(advisories);
 
@@ -168,8 +169,16 @@ describe("SecurityCenterPage", () => {
 
   it("hides acknowledged advisories by default", () => {
     const advisories = [
-      makeAdvisory({ id: "1", title: "Visible", acknowledged: false }),
-      makeAdvisory({ id: "2", title: "Hidden", acknowledged: true }),
+      makeAdvisory({
+        advisory_id: "1",
+        title: "Visible",
+        acknowledged_at: null,
+      }),
+      makeAdvisory({
+        advisory_id: "2",
+        title: "Hidden",
+        acknowledged_at: "2026-03-01T00:00:00Z",
+      }),
     ];
 
     setup(advisories);

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.unit.spec.tsx
@@ -1,0 +1,172 @@
+import userEvent from "@testing-library/user-event";
+
+import { setupRecentViewsAndSelectionsEndpoints } from "__support__/server-mocks";
+import { renderWithProviders, screen, within } from "__support__/ui";
+
+import * as advisoriesHook from "../../hooks/use-security-advisories";
+import type { Advisory } from "../../types";
+
+import { SecurityCenterPage } from "./SecurityCenterPage";
+
+const makeAdvisory = (overrides: Partial<Advisory>): Advisory => ({
+  id: "SA-001",
+  title: "Test advisory",
+  description: "Test description",
+  severity: "medium",
+  affectedVersionRange: ">=0.45.0 <0.59.0",
+  fixedVersion: "v0.59.0",
+  publishedAt: "2026-01-01T00:00:00Z",
+  advisoryUrl: "https://example.com/advisory",
+  upgradeUrl: "https://example.com/upgrade",
+  affected: false,
+  acknowledged: false,
+  ...overrides,
+});
+
+const mockAcknowledge = jest.fn();
+
+function setup(advisories: Advisory[] = []) {
+  jest.spyOn(advisoriesHook, "useSecurityAdvisories").mockReturnValue({
+    data: advisories,
+    isLoading: false,
+    acknowledgeAdvisory: mockAcknowledge,
+  });
+
+  setupRecentViewsAndSelectionsEndpoints([], ["selections"]);
+
+  renderWithProviders(<SecurityCenterPage />);
+}
+
+describe("SecurityCenterPage", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    mockAcknowledge.mockClear();
+  });
+
+  it("renders the title and current version", () => {
+    setup();
+
+    expect(screen.getByText("Security Center")).toBeInTheDocument();
+    expect(screen.getByTestId("current-version")).toHaveTextContent("v0.59.3");
+  });
+
+  it("renders the empty state when there are no advisories", () => {
+    setup([]);
+
+    expect(screen.getByTestId("empty-state")).toHaveTextContent(
+      "Your instance is up to date",
+    );
+  });
+
+  it("renders advisory cards in the correct order (affected first, then by severity)", () => {
+    const advisories = [
+      makeAdvisory({
+        id: "1",
+        title: "Low not affected",
+        severity: "low",
+        affected: false,
+      }),
+      makeAdvisory({
+        id: "2",
+        title: "Critical affected",
+        severity: "critical",
+        affected: true,
+      }),
+      makeAdvisory({
+        id: "3",
+        title: "High affected",
+        severity: "high",
+        affected: true,
+      }),
+    ];
+
+    setup(advisories);
+
+    const cards = screen.getAllByTestId("advisory-card");
+    expect(cards).toHaveLength(3);
+
+    expect(within(cards[0]).getByText("Critical affected")).toBeInTheDocument();
+    expect(within(cards[1]).getByText("High affected")).toBeInTheDocument();
+    expect(within(cards[2]).getByText("Low not affected")).toBeInTheDocument();
+  });
+
+  it("shows affected status on cards", () => {
+    const advisories = [
+      makeAdvisory({ id: "1", affected: true }),
+      makeAdvisory({ id: "2", affected: false }),
+    ];
+
+    setup(advisories);
+
+    const statuses = screen.getAllByTestId("affected-status");
+    expect(statuses[0]).toHaveTextContent("Affected");
+    expect(statuses[1]).toHaveTextContent("Not affected");
+  });
+
+  it("renders external links with correct targets", () => {
+    const advisories = [
+      makeAdvisory({
+        id: "1",
+        advisoryUrl: "https://example.com/advisory/1",
+        upgradeUrl: "https://example.com/upgrade/1",
+      }),
+    ];
+
+    setup(advisories);
+
+    const advisoryLink = screen.getByText("View advisory");
+    expect(advisoryLink).toHaveAttribute(
+      "href",
+      "https://example.com/advisory/1",
+    );
+    expect(advisoryLink).toHaveAttribute("target", "_blank");
+
+    const upgradeLink = screen.getByText("Upgrade guide");
+    expect(upgradeLink).toHaveAttribute(
+      "href",
+      "https://example.com/upgrade/1",
+    );
+    expect(upgradeLink).toHaveAttribute("target", "_blank");
+  });
+
+  it("calls acknowledgeAdvisory when acknowledge button is clicked", async () => {
+    const advisories = [makeAdvisory({ id: "SA-001", acknowledged: false })];
+
+    setup(advisories);
+
+    await userEvent.click(screen.getByTestId("acknowledge-button"));
+    expect(mockAcknowledge).toHaveBeenCalledWith("SA-001");
+  });
+
+  it("does not show acknowledge button for already acknowledged advisories", async () => {
+    const advisories = [makeAdvisory({ id: "SA-001", acknowledged: true })];
+
+    setup(advisories);
+
+    // Acknowledged advisories are hidden by default — enable the checkbox first
+    await userEvent.click(screen.getByTestId("show-acknowledged-filter"));
+
+    expect(screen.queryByTestId("acknowledge-button")).not.toBeInTheDocument();
+    expect(screen.getByTestId("acknowledged-badge")).toHaveTextContent(
+      "Acknowledged",
+    );
+  });
+
+  it("hides acknowledged advisories by default", () => {
+    const advisories = [
+      makeAdvisory({ id: "1", title: "Visible", acknowledged: false }),
+      makeAdvisory({ id: "2", title: "Hidden", acknowledged: true }),
+    ];
+
+    setup(advisories);
+
+    expect(screen.getByText("Visible")).toBeInTheDocument();
+    expect(screen.queryByText("Hidden")).not.toBeInTheDocument();
+  });
+
+  it("renders the filter bar", () => {
+    setup([]);
+
+    expect(screen.getByTestId("advisory-filter-bar")).toBeInTheDocument();
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.unit.spec.tsx
@@ -45,6 +45,7 @@ function setup(advisories: Advisory[] = []) {
     toggleSendToAllAdmins: jest.fn(),
     updateSlackChannel: jest.fn(),
     toggleSlack: jest.fn(),
+    save: jest.fn(),
     sendTestEmail: jest.fn(),
     sendTestSlack: jest.fn(),
   });

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.unit.spec.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { setupRecentViewsAndSelectionsEndpoints } from "__support__/server-mocks";
 import { renderWithProviders, screen, within } from "__support__/ui";
 
+import * as notificationHook from "../../hooks/use-notification-config";
 import * as advisoriesHook from "../../hooks/use-security-advisories";
 import type { Advisory } from "../../types";
 
@@ -33,6 +34,20 @@ function setup(advisories: Advisory[] = []) {
   });
 
   setupRecentViewsAndSelectionsEndpoints([], ["selections"]);
+  jest.spyOn(notificationHook, "useNotificationConfig").mockReturnValue({
+    config: {
+      email: { sendToAllAdmins: true, recipients: [] },
+      slack: { enabled: false, channel: "" },
+    },
+    users: [],
+    slackChannelOptions: [],
+    updateEmailRecipients: jest.fn(),
+    toggleSendToAllAdmins: jest.fn(),
+    updateSlackChannel: jest.fn(),
+    toggleSlack: jest.fn(),
+    sendTestEmail: jest.fn(),
+    sendTestSlack: jest.fn(),
+  });
 
   renderWithProviders(<SecurityCenterPage />);
 }

--- a/enterprise/frontend/src/metabase-enterprise/security_center/hooks/use-notification-config.ts
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/hooks/use-notification-config.ts
@@ -81,6 +81,10 @@ export function useNotificationConfig() {
   }, []);
 
   // TODO: replace with actual API calls
+  const save = useCallback(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }, []);
+
   const sendTestEmail = useCallback(async () => {
     await new Promise((resolve) => setTimeout(resolve, 1000));
   }, []);
@@ -97,6 +101,7 @@ export function useNotificationConfig() {
     toggleSendToAllAdmins,
     updateSlackChannel,
     toggleSlack,
+    save,
     sendTestEmail,
     sendTestSlack,
   };

--- a/enterprise/frontend/src/metabase-enterprise/security_center/hooks/use-notification-config.ts
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/hooks/use-notification-config.ts
@@ -1,0 +1,103 @@
+import { useCallback, useMemo, useState } from "react";
+
+import {
+  useGetChannelInfoQuery,
+  useListUserRecipientsQuery,
+} from "metabase/api";
+import type { RecipientPickerValue } from "metabase/lib/pulse";
+import type { User } from "metabase-types/api";
+
+export interface NotificationConfig {
+  email: {
+    sendToAllAdmins: boolean;
+    recipients: RecipientPickerValue[];
+  };
+  slack: {
+    enabled: boolean;
+    channel: string;
+  };
+}
+
+const DEFAULT_CONFIG: NotificationConfig = {
+  email: {
+    sendToAllAdmins: true,
+    recipients: [],
+  },
+  slack: {
+    enabled: false,
+    channel: "",
+  },
+};
+
+/**
+ * Mock hook for notification channel configuration.
+ * TODO: replace with RTK Query endpoints (e.g. GET/PUT /api/ee/security-center/notification-config)
+ */
+export function useNotificationConfig() {
+  const [config, setConfig] = useState<NotificationConfig>(DEFAULT_CONFIG);
+
+  const { data: userRecipients } = useListUserRecipientsQuery();
+  const { data: channelInfo } = useGetChannelInfoQuery();
+
+  const users: User[] = userRecipients?.data ?? [];
+
+  const slackChannelOptions: string[] = useMemo(() => {
+    const slackSpec = channelInfo?.channels?.slack;
+    const channelField = slackSpec?.fields?.find(
+      (field) => field.name === "channel",
+    );
+    return channelField?.options ?? [];
+  }, [channelInfo]);
+
+  const updateEmailRecipients = useCallback(
+    (recipients: RecipientPickerValue[]) => {
+      setConfig((prev) => ({
+        ...prev,
+        email: { ...prev.email, recipients },
+      }));
+    },
+    [],
+  );
+
+  const toggleSendToAllAdmins = useCallback((sendToAllAdmins: boolean) => {
+    setConfig((prev) => ({
+      ...prev,
+      email: { ...prev.email, sendToAllAdmins },
+    }));
+  }, []);
+
+  const updateSlackChannel = useCallback((channel: string) => {
+    setConfig((prev) => ({
+      ...prev,
+      slack: { ...prev.slack, channel },
+    }));
+  }, []);
+
+  const toggleSlack = useCallback((enabled: boolean) => {
+    setConfig((prev) => ({
+      ...prev,
+      slack: { ...prev.slack, enabled },
+    }));
+  }, []);
+
+  // TODO: replace with actual API calls
+  const sendTestEmail = useCallback(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  }, []);
+
+  const sendTestSlack = useCallback(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  }, []);
+
+  return {
+    config,
+    users,
+    slackChannelOptions,
+    updateEmailRecipients,
+    toggleSendToAllAdmins,
+    updateSlackChannel,
+    toggleSlack,
+    sendTestEmail,
+    sendTestSlack,
+  };
+}

--- a/enterprise/frontend/src/metabase-enterprise/security_center/hooks/use-notification-config.ts
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/hooks/use-notification-config.ts
@@ -4,6 +4,7 @@ import {
   useGetChannelInfoQuery,
   useListUserRecipientsQuery,
 } from "metabase/api";
+import { useSendTestEmailMutation } from "metabase/api/email";
 import type { RecipientPickerValue } from "metabase/lib/pulse";
 import type { User } from "metabase-types/api";
 
@@ -30,14 +31,16 @@ const DEFAULT_CONFIG: NotificationConfig = {
 };
 
 /**
- * Mock hook for notification channel configuration.
- * TODO: replace with RTK Query endpoints (e.g. GET/PUT /api/ee/security-center/notification-config)
+ * Hook for notification channel configuration.
+ * TODO: replace save with RTK Query endpoint (e.g. PUT /api/ee/security-center/notification-config)
+ * TODO: replace sendTestSlack with a dedicated endpoint once available
  */
 export function useNotificationConfig() {
   const [config, setConfig] = useState<NotificationConfig>(DEFAULT_CONFIG);
 
   const { data: userRecipients } = useListUserRecipientsQuery();
   const { data: channelInfo } = useGetChannelInfoQuery();
+  const [sendTestEmailApi] = useSendTestEmailMutation();
 
   const users: User[] = userRecipients?.data ?? [];
 
@@ -80,15 +83,16 @@ export function useNotificationConfig() {
     }));
   }, []);
 
-  // TODO: replace with actual API calls
+  // TODO: replace with PUT /api/ee/security-center/notification-config
   const save = useCallback(async () => {
     await new Promise((resolve) => setTimeout(resolve, 500));
   }, []);
 
   const sendTestEmail = useCallback(async () => {
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-  }, []);
+    await sendTestEmailApi().unwrap();
+  }, [sendTestEmailApi]);
 
+  // TODO: backend needs a `can-connect?` impl for :channel/slack before this can use testSlackChannelApi
   const sendTestSlack = useCallback(async () => {
     await new Promise((resolve) => setTimeout(resolve, 1000));
   }, []);

--- a/enterprise/frontend/src/metabase-enterprise/security_center/hooks/use-security-advisories.ts
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/hooks/use-security-advisories.ts
@@ -1,0 +1,83 @@
+import { useCallback, useState } from "react";
+
+import type { Advisory } from "../types";
+
+const INITIAL_ADVISORIES: Advisory[] = [
+  {
+    id: "SA-2026-001",
+    title: "SQL injection in native query endpoint",
+    description:
+      "A SQL injection vulnerability was found in the native query execution endpoint that could allow authenticated users to execute arbitrary SQL commands beyond their permission scope.",
+    severity: "critical",
+    affectedVersionRange: ">=0.45.0 <0.59.4",
+    fixedVersion: "v0.59.4",
+    publishedAt: "2026-03-15T00:00:00Z",
+    advisoryUrl:
+      "https://github.com/metabase/metabase/security/advisories/SA-2026-001",
+    upgradeUrl: "https://example.com/docs/latest/releases",
+    affected: true,
+    acknowledged: false,
+  },
+  {
+    id: "SA-2026-002",
+    title: "Cross-site scripting in dashboard text cards",
+    description:
+      "A stored XSS vulnerability was identified in dashboard text cards. An attacker with edit access could inject malicious scripts that execute when other users view the dashboard.",
+    severity: "high",
+    affectedVersionRange: ">=0.50.0 <0.59.2",
+    fixedVersion: "v0.59.2",
+    publishedAt: "2026-02-20T00:00:00Z",
+    advisoryUrl:
+      "https://github.com/metabase/metabase/security/advisories/SA-2026-002",
+    upgradeUrl: "https://example.com/docs/latest/releases",
+    affected: true,
+    acknowledged: false,
+  },
+  {
+    id: "SA-2026-003",
+    title: "Information disclosure via API response headers",
+    description:
+      "Certain API responses included internal server configuration details in response headers, which could aid attackers in reconnaissance.",
+    severity: "medium",
+    affectedVersionRange: ">=0.40.0 <0.58.0",
+    fixedVersion: "v0.58.0",
+    publishedAt: "2026-01-10T00:00:00Z",
+    advisoryUrl:
+      "https://github.com/metabase/metabase/security/advisories/SA-2026-003",
+    upgradeUrl: "https://example.com/docs/latest/releases",
+    affected: false,
+    acknowledged: false,
+  },
+  {
+    id: "SA-2025-010",
+    title: "CSRF token validation bypass on older browsers",
+    description:
+      "A CSRF token validation bypass was discovered that could be exploited on older browsers lacking SameSite cookie support, allowing cross-origin form submissions.",
+    severity: "low",
+    affectedVersionRange: ">=0.42.0 <0.57.0",
+    fixedVersion: "v0.57.0",
+    publishedAt: "2025-11-05T00:00:00Z",
+    advisoryUrl:
+      "https://github.com/metabase/metabase/security/advisories/SA-2025-010",
+    upgradeUrl: "https://example.com/docs/latest/releases",
+    affected: false,
+    acknowledged: true,
+  },
+];
+
+export function useSecurityAdvisories() {
+  const [data, setData] = useState<Advisory[]>(INITIAL_ADVISORIES);
+
+  // TODO: replace with RTK Query mutation (e.g. PUT /api/ee/security-center/advisories/:id/acknowledge)
+  const acknowledgeAdvisory = useCallback((advisoryId: string) => {
+    setData((prev) =>
+      prev.map((a) => (a.id === advisoryId ? { ...a, acknowledged: true } : a)),
+    );
+  }, []);
+
+  return {
+    data,
+    isLoading: false,
+    acknowledgeAdvisory,
+  };
+}

--- a/enterprise/frontend/src/metabase-enterprise/security_center/hooks/use-security-advisories.ts
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/hooks/use-security-advisories.ts
@@ -1,83 +1,30 @@
-import { useCallback, useState } from "react";
+import { useCallback } from "react";
+
+import {
+  useAcknowledgeAdvisoryMutation,
+  useListSecurityAdvisoriesQuery,
+} from "metabase/api";
 
 import type { Advisory } from "../types";
 
-const INITIAL_ADVISORIES: Advisory[] = [
-  {
-    id: "SA-2026-001",
-    title: "SQL injection in native query endpoint",
-    description:
-      "A SQL injection vulnerability was found in the native query execution endpoint that could allow authenticated users to execute arbitrary SQL commands beyond their permission scope.",
-    severity: "critical",
-    affectedVersionRange: ">=0.45.0 <0.59.4",
-    fixedVersion: "v0.59.4",
-    publishedAt: "2026-03-15T00:00:00Z",
-    advisoryUrl:
-      "https://github.com/metabase/metabase/security/advisories/SA-2026-001",
-    upgradeUrl: "https://example.com/docs/latest/releases",
-    affected: true,
-    acknowledged: false,
-  },
-  {
-    id: "SA-2026-002",
-    title: "Cross-site scripting in dashboard text cards",
-    description:
-      "A stored XSS vulnerability was identified in dashboard text cards. An attacker with edit access could inject malicious scripts that execute when other users view the dashboard.",
-    severity: "high",
-    affectedVersionRange: ">=0.50.0 <0.59.2",
-    fixedVersion: "v0.59.2",
-    publishedAt: "2026-02-20T00:00:00Z",
-    advisoryUrl:
-      "https://github.com/metabase/metabase/security/advisories/SA-2026-002",
-    upgradeUrl: "https://example.com/docs/latest/releases",
-    affected: true,
-    acknowledged: false,
-  },
-  {
-    id: "SA-2026-003",
-    title: "Information disclosure via API response headers",
-    description:
-      "Certain API responses included internal server configuration details in response headers, which could aid attackers in reconnaissance.",
-    severity: "medium",
-    affectedVersionRange: ">=0.40.0 <0.58.0",
-    fixedVersion: "v0.58.0",
-    publishedAt: "2026-01-10T00:00:00Z",
-    advisoryUrl:
-      "https://github.com/metabase/metabase/security/advisories/SA-2026-003",
-    upgradeUrl: "https://example.com/docs/latest/releases",
-    affected: false,
-    acknowledged: false,
-  },
-  {
-    id: "SA-2025-010",
-    title: "CSRF token validation bypass on older browsers",
-    description:
-      "A CSRF token validation bypass was discovered that could be exploited on older browsers lacking SameSite cookie support, allowing cross-origin form submissions.",
-    severity: "low",
-    affectedVersionRange: ">=0.42.0 <0.57.0",
-    fixedVersion: "v0.57.0",
-    publishedAt: "2025-11-05T00:00:00Z",
-    advisoryUrl:
-      "https://github.com/metabase/metabase/security/advisories/SA-2025-010",
-    upgradeUrl: "https://example.com/docs/latest/releases",
-    affected: false,
-    acknowledged: true,
-  },
-];
-
 export function useSecurityAdvisories() {
-  const [data, setData] = useState<Advisory[]>(INITIAL_ADVISORIES);
+  const { data: response, isLoading } = useListSecurityAdvisoriesQuery();
+  const [acknowledgeApi] = useAcknowledgeAdvisoryMutation();
 
-  // TODO: replace with RTK Query mutation (e.g. PUT /api/ee/security-center/advisories/:id/acknowledge)
-  const acknowledgeAdvisory = useCallback((advisoryId: string) => {
-    setData((prev) =>
-      prev.map((a) => (a.id === advisoryId ? { ...a, acknowledged: true } : a)),
-    );
-  }, []);
+  const advisories: Advisory[] = response?.advisories ?? [];
+  const lastCheckedAt = response?.last_checked_at ?? null;
+
+  const acknowledgeAdvisory = useCallback(
+    (advisoryId: string) => {
+      acknowledgeApi(advisoryId);
+    },
+    [acknowledgeApi],
+  );
 
   return {
-    data,
-    isLoading: false,
+    data: advisories,
+    lastCheckedAt,
+    isLoading,
     acknowledgeAdvisory,
   };
 }

--- a/enterprise/frontend/src/metabase-enterprise/security_center/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/index.ts
@@ -1,0 +1,11 @@
+import { PLUGIN_SECURITY_CENTER } from "metabase/plugins";
+// import { hasPremiumFeature } from "metabase-enterprise/settings";
+
+import { SecurityCenterPage } from "./components/SecurityCenterPage/SecurityCenterPage";
+
+export function initializePlugin() {
+  // if (hasPremiumFeature("security_advisories")) {
+  PLUGIN_SECURITY_CENTER.isEnabled = true;
+  PLUGIN_SECURITY_CENTER.SecurityCenterPage = SecurityCenterPage;
+  // }
+}

--- a/enterprise/frontend/src/metabase-enterprise/security_center/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/index.ts
@@ -4,7 +4,7 @@ import { PLUGIN_SECURITY_CENTER } from "metabase/plugins";
 import { SecurityCenterPage } from "./components/SecurityCenterPage/SecurityCenterPage";
 
 export function initializePlugin() {
-  // if (hasPremiumFeature("security_advisories")) {
+  // if (hasPremiumFeature("admin_security_center")) {
   PLUGIN_SECURITY_CENTER.isEnabled = true;
   PLUGIN_SECURITY_CENTER.SecurityCenterPage = SecurityCenterPage;
   // }

--- a/enterprise/frontend/src/metabase-enterprise/security_center/types.ts
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/types.ts
@@ -1,17 +1,29 @@
 export type AdvisorySeverity = "critical" | "high" | "medium" | "low";
 
+export type AdvisoryMatchStatus =
+  | "active"
+  | "resolved"
+  | "not_affected"
+  | "error";
+
+export type AdvisoryVersionRange = {
+  min: string;
+  fixed: string;
+};
+
 export type Advisory = {
-  id: string;
+  advisory_id: string;
   title: string;
   description: string;
   severity: AdvisorySeverity;
-  affectedVersionRange: string;
-  fixedVersion: string;
-  publishedAt: string;
-  advisoryUrl: string;
-  upgradeUrl: string;
-  affected: boolean;
-  acknowledged: boolean;
+  advisory_url: string | null;
+  remediation: string;
+  published_at: string;
+  match_status: AdvisoryMatchStatus;
+  last_evaluated_at: string | null;
+  acknowledged_by: { id: number; common_name: string; email: string } | null;
+  acknowledged_at: string | null;
+  affected_versions: AdvisoryVersionRange[];
 };
 
 export type AdvisoryFilter = {

--- a/enterprise/frontend/src/metabase-enterprise/security_center/types.ts
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/types.ts
@@ -1,0 +1,21 @@
+export type AdvisorySeverity = "critical" | "high" | "medium" | "low";
+
+export type Advisory = {
+  id: string;
+  title: string;
+  description: string;
+  severity: AdvisorySeverity;
+  affectedVersionRange: string;
+  fixedVersion: string;
+  publishedAt: string;
+  advisoryUrl: string;
+  upgradeUrl: string;
+  affected: boolean;
+  acknowledged: boolean;
+};
+
+export type AdvisoryFilter = {
+  severity: AdvisorySeverity | "all";
+  status: "all" | "affected" | "not-affected";
+  showAcknowledged: boolean;
+};

--- a/enterprise/frontend/src/metabase-enterprise/security_center/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/utils.ts
@@ -1,0 +1,50 @@
+import type { Advisory, AdvisoryFilter, AdvisorySeverity } from "./types";
+
+const SEVERITY_ORDER: Record<AdvisorySeverity, number> = {
+  critical: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+};
+
+export function filterAdvisories(
+  advisories: Advisory[],
+  filter: AdvisoryFilter,
+): Advisory[] {
+  return advisories.filter((a) => {
+    if (filter.severity !== "all" && a.severity !== filter.severity) {
+      return false;
+    }
+    if (filter.status === "affected" && !a.affected) {
+      return false;
+    }
+    if (filter.status === "not-affected" && a.affected) {
+      return false;
+    }
+    if (!filter.showAcknowledged && a.acknowledged) {
+      return false;
+    }
+    return true;
+  });
+}
+
+export function sortAdvisories(advisories: Advisory[]): Advisory[] {
+  return [...advisories].sort((a, b) => {
+    // Affected items first
+    if (a.affected !== b.affected) {
+      return a.affected ? -1 : 1;
+    }
+
+    // Then by severity (critical → low)
+    const severityDiff =
+      SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity];
+    if (severityDiff !== 0) {
+      return severityDiff;
+    }
+
+    // Then by publishedAt descending (newest first)
+    return (
+      new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime()
+    );
+  });
+}

--- a/enterprise/frontend/src/metabase-enterprise/security_center/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/utils.ts
@@ -7,6 +7,14 @@ const SEVERITY_ORDER: Record<AdvisorySeverity, number> = {
   low: 3,
 };
 
+export function isAffected(advisory: Advisory): boolean {
+  return advisory.match_status === "active";
+}
+
+export function isAcknowledged(advisory: Advisory): boolean {
+  return advisory.acknowledged_at != null;
+}
+
 export function filterAdvisories(
   advisories: Advisory[],
   filter: AdvisoryFilter,
@@ -15,13 +23,13 @@ export function filterAdvisories(
     if (filter.severity !== "all" && a.severity !== filter.severity) {
       return false;
     }
-    if (filter.status === "affected" && !a.affected) {
+    if (filter.status === "affected" && !isAffected(a)) {
       return false;
     }
-    if (filter.status === "not-affected" && a.affected) {
+    if (filter.status === "not-affected" && isAffected(a)) {
       return false;
     }
-    if (!filter.showAcknowledged && a.acknowledged) {
+    if (!filter.showAcknowledged && isAcknowledged(a)) {
       return false;
     }
     return true;
@@ -30,9 +38,12 @@ export function filterAdvisories(
 
 export function sortAdvisories(advisories: Advisory[]): Advisory[] {
   return [...advisories].sort((a, b) => {
+    const aAffected = isAffected(a);
+    const bAffected = isAffected(b);
+
     // Affected items first
-    if (a.affected !== b.affected) {
-      return a.affected ? -1 : 1;
+    if (aAffected !== bAffected) {
+      return aAffected ? -1 : 1;
     }
 
     // Then by severity (critical → low)
@@ -42,9 +53,9 @@ export function sortAdvisories(advisories: Advisory[]): Advisory[] {
       return severityDiff;
     }
 
-    // Then by publishedAt descending (newest first)
+    // Then by published_at descending (newest first)
     return (
-      new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime()
+      new Date(b.published_at).getTime() - new Date(a.published_at).getTime()
     );
   });
 }

--- a/enterprise/frontend/src/metabase-enterprise/security_center/utils.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/utils.unit.spec.ts
@@ -2,17 +2,18 @@ import type { Advisory, AdvisoryFilter } from "./types";
 import { filterAdvisories, sortAdvisories } from "./utils";
 
 const makeAdvisory = (overrides: Partial<Advisory>): Advisory => ({
-  id: "SA-001",
+  advisory_id: "SA-001",
   title: "Test advisory",
   description: "Test description",
   severity: "medium",
-  affectedVersionRange: ">=0.45.0 <0.59.0",
-  fixedVersion: "v0.59.0",
-  publishedAt: "2026-01-01T00:00:00Z",
-  advisoryUrl: "https://example.com/advisory",
-  upgradeUrl: "https://example.com/upgrade",
-  affected: false,
-  acknowledged: false,
+  advisory_url: "https://example.com/advisory",
+  remediation: "Upgrade to latest version",
+  published_at: "2026-01-01T00:00:00Z",
+  match_status: "not_affected",
+  last_evaluated_at: null,
+  acknowledged_by: null,
+  acknowledged_at: null,
+  affected_versions: [{ min: "0.45.0", fixed: "0.59.0" }],
   ...overrides,
 });
 
@@ -25,25 +26,49 @@ const ALL_PASS_FILTER: AdvisoryFilter = {
 describe("sortAdvisories", () => {
   it("should place affected items before non-affected items", () => {
     const advisories = [
-      makeAdvisory({ id: "1", affected: false, severity: "critical" }),
-      makeAdvisory({ id: "2", affected: true, severity: "low" }),
+      makeAdvisory({
+        advisory_id: "1",
+        match_status: "not_affected",
+        severity: "critical",
+      }),
+      makeAdvisory({
+        advisory_id: "2",
+        match_status: "active",
+        severity: "low",
+      }),
     ];
 
     const sorted = sortAdvisories(advisories);
-    expect(sorted[0].id).toBe("2");
-    expect(sorted[1].id).toBe("1");
+    expect(sorted[0].advisory_id).toBe("2");
+    expect(sorted[1].advisory_id).toBe("1");
   });
 
   it("should sort by severity within the same affected status", () => {
     const advisories = [
-      makeAdvisory({ id: "low", severity: "low", affected: true }),
-      makeAdvisory({ id: "critical", severity: "critical", affected: true }),
-      makeAdvisory({ id: "medium", severity: "medium", affected: true }),
-      makeAdvisory({ id: "high", severity: "high", affected: true }),
+      makeAdvisory({
+        advisory_id: "low",
+        severity: "low",
+        match_status: "active",
+      }),
+      makeAdvisory({
+        advisory_id: "critical",
+        severity: "critical",
+        match_status: "active",
+      }),
+      makeAdvisory({
+        advisory_id: "medium",
+        severity: "medium",
+        match_status: "active",
+      }),
+      makeAdvisory({
+        advisory_id: "high",
+        severity: "high",
+        match_status: "active",
+      }),
     ];
 
     const sorted = sortAdvisories(advisories);
-    expect(sorted.map((a) => a.id)).toEqual([
+    expect(sorted.map((a) => a.advisory_id)).toEqual([
       "critical",
       "high",
       "medium",
@@ -51,25 +76,25 @@ describe("sortAdvisories", () => {
     ]);
   });
 
-  it("should sort by publishedAt descending within the same severity", () => {
+  it("should sort by published_at descending within the same severity", () => {
     const advisories = [
       makeAdvisory({
-        id: "older",
+        advisory_id: "older",
         severity: "high",
-        affected: true,
-        publishedAt: "2026-01-01T00:00:00Z",
+        match_status: "active",
+        published_at: "2026-01-01T00:00:00Z",
       }),
       makeAdvisory({
-        id: "newer",
+        advisory_id: "newer",
         severity: "high",
-        affected: true,
-        publishedAt: "2026-03-01T00:00:00Z",
+        match_status: "active",
+        published_at: "2026-03-01T00:00:00Z",
       }),
     ];
 
     const sorted = sortAdvisories(advisories);
-    expect(sorted[0].id).toBe("newer");
-    expect(sorted[1].id).toBe("older");
+    expect(sorted[0].advisory_id).toBe("newer");
+    expect(sorted[1].advisory_id).toBe("older");
   });
 
   it("should return an empty array when given an empty array", () => {
@@ -78,8 +103,8 @@ describe("sortAdvisories", () => {
 
   it("should not mutate the original array", () => {
     const advisories = [
-      makeAdvisory({ id: "2", affected: true }),
-      makeAdvisory({ id: "1", affected: false }),
+      makeAdvisory({ advisory_id: "2", match_status: "active" }),
+      makeAdvisory({ advisory_id: "1", match_status: "not_affected" }),
     ];
     const original = [...advisories];
 
@@ -91,28 +116,28 @@ describe("sortAdvisories", () => {
 describe("filterAdvisories", () => {
   const advisories = [
     makeAdvisory({
-      id: "1",
+      advisory_id: "1",
       severity: "critical",
-      affected: true,
-      acknowledged: false,
+      match_status: "active",
+      acknowledged_at: null,
     }),
     makeAdvisory({
-      id: "2",
+      advisory_id: "2",
       severity: "high",
-      affected: true,
-      acknowledged: true,
+      match_status: "active",
+      acknowledged_at: "2026-03-01T00:00:00Z",
     }),
     makeAdvisory({
-      id: "3",
+      advisory_id: "3",
       severity: "medium",
-      affected: false,
-      acknowledged: false,
+      match_status: "not_affected",
+      acknowledged_at: null,
     }),
     makeAdvisory({
-      id: "4",
+      advisory_id: "4",
       severity: "low",
-      affected: false,
-      acknowledged: true,
+      match_status: "not_affected",
+      acknowledged_at: "2026-02-01T00:00:00Z",
     }),
   ];
 
@@ -127,7 +152,7 @@ describe("filterAdvisories", () => {
       severity: "critical",
     });
     expect(result).toHaveLength(1);
-    expect(result[0].id).toBe("1");
+    expect(result[0].advisory_id).toBe("1");
   });
 
   it("should filter by affected status", () => {
@@ -135,7 +160,7 @@ describe("filterAdvisories", () => {
       ...ALL_PASS_FILTER,
       status: "affected",
     });
-    expect(result.every((a) => a.affected)).toBe(true);
+    expect(result.every((a) => a.match_status === "active")).toBe(true);
     expect(result).toHaveLength(2);
   });
 
@@ -144,7 +169,7 @@ describe("filterAdvisories", () => {
       ...ALL_PASS_FILTER,
       status: "not-affected",
     });
-    expect(result.every((a) => !a.affected)).toBe(true);
+    expect(result.every((a) => a.match_status !== "active")).toBe(true);
     expect(result).toHaveLength(2);
   });
 
@@ -153,7 +178,7 @@ describe("filterAdvisories", () => {
       ...ALL_PASS_FILTER,
       showAcknowledged: false,
     });
-    expect(result.every((a) => !a.acknowledged)).toBe(true);
+    expect(result.every((a) => a.acknowledged_at == null)).toBe(true);
     expect(result).toHaveLength(2);
   });
 
@@ -164,6 +189,6 @@ describe("filterAdvisories", () => {
       showAcknowledged: false,
     });
     expect(result).toHaveLength(1);
-    expect(result[0].id).toBe("1");
+    expect(result[0].advisory_id).toBe("1");
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/security_center/utils.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/utils.unit.spec.ts
@@ -1,0 +1,169 @@
+import type { Advisory, AdvisoryFilter } from "./types";
+import { filterAdvisories, sortAdvisories } from "./utils";
+
+const makeAdvisory = (overrides: Partial<Advisory>): Advisory => ({
+  id: "SA-001",
+  title: "Test advisory",
+  description: "Test description",
+  severity: "medium",
+  affectedVersionRange: ">=0.45.0 <0.59.0",
+  fixedVersion: "v0.59.0",
+  publishedAt: "2026-01-01T00:00:00Z",
+  advisoryUrl: "https://example.com/advisory",
+  upgradeUrl: "https://example.com/upgrade",
+  affected: false,
+  acknowledged: false,
+  ...overrides,
+});
+
+const ALL_PASS_FILTER: AdvisoryFilter = {
+  severity: "all",
+  status: "all",
+  showAcknowledged: true,
+};
+
+describe("sortAdvisories", () => {
+  it("should place affected items before non-affected items", () => {
+    const advisories = [
+      makeAdvisory({ id: "1", affected: false, severity: "critical" }),
+      makeAdvisory({ id: "2", affected: true, severity: "low" }),
+    ];
+
+    const sorted = sortAdvisories(advisories);
+    expect(sorted[0].id).toBe("2");
+    expect(sorted[1].id).toBe("1");
+  });
+
+  it("should sort by severity within the same affected status", () => {
+    const advisories = [
+      makeAdvisory({ id: "low", severity: "low", affected: true }),
+      makeAdvisory({ id: "critical", severity: "critical", affected: true }),
+      makeAdvisory({ id: "medium", severity: "medium", affected: true }),
+      makeAdvisory({ id: "high", severity: "high", affected: true }),
+    ];
+
+    const sorted = sortAdvisories(advisories);
+    expect(sorted.map((a) => a.id)).toEqual([
+      "critical",
+      "high",
+      "medium",
+      "low",
+    ]);
+  });
+
+  it("should sort by publishedAt descending within the same severity", () => {
+    const advisories = [
+      makeAdvisory({
+        id: "older",
+        severity: "high",
+        affected: true,
+        publishedAt: "2026-01-01T00:00:00Z",
+      }),
+      makeAdvisory({
+        id: "newer",
+        severity: "high",
+        affected: true,
+        publishedAt: "2026-03-01T00:00:00Z",
+      }),
+    ];
+
+    const sorted = sortAdvisories(advisories);
+    expect(sorted[0].id).toBe("newer");
+    expect(sorted[1].id).toBe("older");
+  });
+
+  it("should return an empty array when given an empty array", () => {
+    expect(sortAdvisories([])).toEqual([]);
+  });
+
+  it("should not mutate the original array", () => {
+    const advisories = [
+      makeAdvisory({ id: "2", affected: true }),
+      makeAdvisory({ id: "1", affected: false }),
+    ];
+    const original = [...advisories];
+
+    sortAdvisories(advisories);
+    expect(advisories).toEqual(original);
+  });
+});
+
+describe("filterAdvisories", () => {
+  const advisories = [
+    makeAdvisory({
+      id: "1",
+      severity: "critical",
+      affected: true,
+      acknowledged: false,
+    }),
+    makeAdvisory({
+      id: "2",
+      severity: "high",
+      affected: true,
+      acknowledged: true,
+    }),
+    makeAdvisory({
+      id: "3",
+      severity: "medium",
+      affected: false,
+      acknowledged: false,
+    }),
+    makeAdvisory({
+      id: "4",
+      severity: "low",
+      affected: false,
+      acknowledged: true,
+    }),
+  ];
+
+  it("should return all advisories when no filters are active", () => {
+    const result = filterAdvisories(advisories, ALL_PASS_FILTER);
+    expect(result).toHaveLength(4);
+  });
+
+  it("should filter by severity", () => {
+    const result = filterAdvisories(advisories, {
+      ...ALL_PASS_FILTER,
+      severity: "critical",
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("1");
+  });
+
+  it("should filter by affected status", () => {
+    const result = filterAdvisories(advisories, {
+      ...ALL_PASS_FILTER,
+      status: "affected",
+    });
+    expect(result.every((a) => a.affected)).toBe(true);
+    expect(result).toHaveLength(2);
+  });
+
+  it("should filter by not-affected status", () => {
+    const result = filterAdvisories(advisories, {
+      ...ALL_PASS_FILTER,
+      status: "not-affected",
+    });
+    expect(result.every((a) => !a.affected)).toBe(true);
+    expect(result).toHaveLength(2);
+  });
+
+  it("should hide acknowledged advisories when showAcknowledged is false", () => {
+    const result = filterAdvisories(advisories, {
+      ...ALL_PASS_FILTER,
+      showAcknowledged: false,
+    });
+    expect(result.every((a) => !a.acknowledged)).toBe(true);
+    expect(result).toHaveLength(2);
+  });
+
+  it("should combine multiple filters", () => {
+    const result = filterAdvisories(advisories, {
+      severity: "all",
+      status: "affected",
+      showAcknowledged: false,
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("1");
+  });
+});

--- a/frontend/src/metabase-types/api/mocks/settings.ts
+++ b/frontend/src/metabase-types/api/mocks/settings.ts
@@ -147,6 +147,7 @@ export const createMockTokenFeatures = (
   tenants: false,
   workspaces: false,
   writable_connection: false,
+  security_advisories: false,
   ...opts,
 });
 

--- a/frontend/src/metabase-types/api/mocks/settings.ts
+++ b/frontend/src/metabase-types/api/mocks/settings.ts
@@ -147,7 +147,7 @@ export const createMockTokenFeatures = (
   tenants: false,
   workspaces: false,
   writable_connection: false,
-  security_advisories: false,
+  admin_security_center: false,
   ...opts,
 });
 

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -365,6 +365,7 @@ export const tokenFeatures = [
   "tenants",
   "workspaces",
   "writable_connection",
+  "security_advisories",
 ] as const;
 
 export type TokenFeature = (typeof tokenFeatures)[number];

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -365,7 +365,7 @@ export const tokenFeatures = [
   "tenants",
   "workspaces",
   "writable_connection",
-  "security_advisories",
+  "admin_security_center",
 ] as const;
 
 export type TokenFeature = (typeof tokenFeatures)[number];

--- a/frontend/src/metabase/admin/settings/components/SettingsNav/SettingsNav.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsNav/SettingsNav.tsx
@@ -10,7 +10,7 @@ import {
 import { UpsellGem } from "metabase/common/components/upsells/components/UpsellGem";
 import { useHasTokenFeature, useSetting } from "metabase/common/hooks";
 import { useSelector } from "metabase/lib/redux";
-import { PLUGIN_REMOTE_SYNC } from "metabase/plugins";
+import { PLUGIN_REMOTE_SYNC, PLUGIN_SECURITY_CENTER } from "metabase/plugins";
 import { getLocation } from "metabase/selectors/routing";
 import { Divider, Flex } from "metabase/ui";
 
@@ -115,6 +115,16 @@ export function SettingsNav() {
         }
         icon="cloud"
       />
+      {PLUGIN_SECURITY_CENTER.isEnabled && (
+        <>
+          <NavDivider />
+          <SettingsNavItem
+            path="security-center"
+            label={t`Security Center`}
+            icon="shield_outline"
+          />
+        </>
+      )}
     </AdminNavWrapper>
   );
 }

--- a/frontend/src/metabase/admin/settingsRoutes.tsx
+++ b/frontend/src/metabase/admin/settingsRoutes.tsx
@@ -5,6 +5,7 @@ import { NotFound } from "metabase/common/components/ErrorPages";
 import {
   PLUGIN_AUTH_PROVIDERS,
   PLUGIN_REMOTE_SYNC,
+  PLUGIN_SECURITY_CENTER,
   PLUGIN_TRANSFORMS_PYTHON,
 } from "metabase/plugins";
 
@@ -92,6 +93,12 @@ export const getSettingsRoutes = () => (
       component={() => <AppearanceSettingsPage tab="conceal-metabase" />}
     />
     <Route path="cloud" component={CloudSettingsPage} />
+    {PLUGIN_SECURITY_CENTER.isEnabled && (
+      <Route
+        path="security-center"
+        component={PLUGIN_SECURITY_CENTER.SecurityCenterPage}
+      />
+    )}
     <Route path="*" component={NotFound} />
   </Route>
 );

--- a/frontend/src/metabase/api/channel.ts
+++ b/frontend/src/metabase/api/channel.ts
@@ -25,6 +25,16 @@ const channelApi = Api.injectEndpoints({
         },
       }),
     }),
+    testSlackChannel: builder.mutation<Record<string, never>, string>({
+      query: (channel) => ({
+        method: "POST",
+        url: "/api/channel/test",
+        body: {
+          type: "channel/slack",
+          details: { channel },
+        },
+      }),
+    }),
     createChannel: builder.mutation<
       NotificationChannel[],
       Omit<NotificationChannel, "created_at" | "updated_at" | "active" | "id">
@@ -69,5 +79,6 @@ export const {
   useCreateChannelMutation,
   useDeleteChannelMutation,
   useTestChannelMutation,
+  useTestSlackChannelMutation,
   endpoints: { listChannels },
 } = channelApi;

--- a/frontend/src/metabase/api/index.ts
+++ b/frontend/src/metabase/api/index.ts
@@ -31,6 +31,7 @@ export * from "./permission";
 export * from "./persist";
 export * from "./premium-features";
 export * from "./revision";
+export * from "./security-center";
 export * from "./group-table-access-policy";
 export * from "./search";
 export * from "./segment";

--- a/frontend/src/metabase/api/security-center.ts
+++ b/frontend/src/metabase/api/security-center.ts
@@ -1,0 +1,65 @@
+import { Api } from "metabase/api";
+
+import { listTag } from "./tags";
+
+export type AdvisoryMatchStatus =
+  | "active"
+  | "resolved"
+  | "not_affected"
+  | "error";
+
+export type AdvisoryVersionRange = {
+  min: string;
+  fixed: string;
+};
+
+export type ApiAdvisory = {
+  advisory_id: string;
+  title: string;
+  severity: "critical" | "high" | "medium" | "low";
+  description: string;
+  advisory_url: string | null;
+  remediation: string;
+  published_at: string;
+  match_status: AdvisoryMatchStatus;
+  last_evaluated_at: string | null;
+  acknowledged_by: { id: number; common_name: string; email: string } | null;
+  acknowledged_at: string | null;
+  affected_versions: AdvisoryVersionRange[];
+};
+
+export type ListAdvisoriesResponse = {
+  last_checked_at: string | null;
+  advisories: ApiAdvisory[];
+};
+
+export type AcknowledgeAdvisoryResponse = {
+  advisory_id: string;
+  match_status: AdvisoryMatchStatus;
+  acknowledged_by: { id: number; common_name: string; email: string } | null;
+  acknowledged_at: string | null;
+};
+
+export const securityCenterApi = Api.injectEndpoints({
+  endpoints: (builder) => ({
+    listSecurityAdvisories: builder.query<ListAdvisoriesResponse, void>({
+      query: () => ({
+        method: "GET",
+        url: "/api/ee/security-center",
+      }),
+      providesTags: [listTag("security-advisory")],
+    }),
+    acknowledgeAdvisory: builder.mutation<AcknowledgeAdvisoryResponse, string>({
+      query: (advisoryId) => ({
+        method: "POST",
+        url: `/api/ee/security-center/${advisoryId}/acknowledge`,
+      }),
+      invalidatesTags: [listTag("security-advisory")],
+    }),
+  }),
+});
+
+export const {
+  useListSecurityAdvisoriesQuery,
+  useAcknowledgeAdvisoryMutation,
+} = securityCenterApi;

--- a/frontend/src/metabase/api/tags/constants.ts
+++ b/frontend/src/metabase/api/tags/constants.ts
@@ -66,6 +66,7 @@ export const TAG_TYPES = [
   "metabot",
   "metabot-entities-list",
   "metabot-prompt-suggestions",
+  "security-advisory",
 ] as const;
 
 export const TAG_TYPE_MAPPING = {

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -145,6 +145,7 @@ export {
   PLUGIN_WRITABLE_CONNECTION,
   type WritableConnectionInfoSectionProps,
 } from "./oss/writable-connection";
+export { PLUGIN_SECURITY_CENTER } from "./oss/security-center";
 export { PLUGIN_SUPPORT } from "./oss/support";
 export { PLUGIN_TENANTS } from "./oss/tenants";
 
@@ -181,6 +182,7 @@ import { reinitialize as reinitializePermissions } from "./oss/permissions";
 import { reinitialize as reinitializeRemoteSync } from "./oss/remote-sync";
 import { reinitialize as reinitializeReplacement } from "./oss/replacement";
 import { reinitialize as reinitializeResourceDownloads } from "./oss/resource-downloads";
+import { reinitialize as reinitializeSecurityCenter } from "./oss/security-center";
 import { reinitialize as reinitializeSemanticSearch } from "./oss/semantic-search";
 import { reinitialize as reinitializeSettings } from "./oss/settings";
 import { reinitialize as reinitializeSmtpOverride } from "./oss/smtp-override";
@@ -220,6 +222,7 @@ export function reinitialize() {
   reinitializeRemoteSync();
   reinitializeReplacement();
   reinitializeResourceDownloads();
+  reinitializeSecurityCenter();
   reinitializeSemanticSearch();
   reinitializeSettings();
   reinitializeSmtpOverride();

--- a/frontend/src/metabase/plugins/oss/security-center.ts
+++ b/frontend/src/metabase/plugins/oss/security-center.ts
@@ -1,0 +1,22 @@
+import type { ComponentType } from "react";
+
+import { PluginPlaceholder } from "metabase/plugins/components/PluginPlaceholder";
+
+type SecurityCenterPlugin = {
+  isEnabled: boolean;
+  SecurityCenterPage: ComponentType;
+};
+
+const getDefaultPlugin = (): SecurityCenterPlugin => ({
+  isEnabled: false,
+  SecurityCenterPage: PluginPlaceholder,
+});
+
+export const PLUGIN_SECURITY_CENTER = getDefaultPlugin();
+
+/**
+ * @internal Do not call directly. Use the main reinitialize function from metabase/plugins instead.
+ */
+export function reinitialize() {
+  Object.assign(PLUGIN_SECURITY_CENTER, getDefaultPlugin());
+}


### PR DESCRIPTION
Mostly wired UI for advisories list and notifications (slack/email) config.
<img width="1614" height="846" alt="SCR-20260331-mlbb-2" src="https://github.com/user-attachments/assets/8d2a4cc5-e3d9-4b3f-8c75-85736a310805" />
<img width="1614" height="846" alt="SCR-20260331-mlad-2" src="https://github.com/user-attachments/assets/42e2570a-9a53-41bc-bb10-01b3bfd0869e" />

### Wired up (working)
- `GET /api/ee/security-center` — advisory list (**done**)
- `POST /api/ee/security-center/:id/acknowledge` — acknowledge advisory (**done**)
- `POST /api/email/test` — send test email (**done**, fails gracefully if SMTP not configured)
- `GET /api/pulse/form_input` — Slack channel options (**done**)
- `GET /api/user/recipients` — email recipient picker (**done**)

### Still mocked (needs backend work)
1. **Save notification config** — `use-notification-config.ts:86` — currently a 500ms fake delay. Needs a `PUT /api/ee/security-center/notification-config` endpoint to persist email recipients, send-to-admins toggle, Slack enabled/channel.
2. **Slack test message** — `use-notification-config.ts:95` — currently a 1s fake delay. The `POST /api/channel/test` endpoint doesn't implement `can-connect?` for `:channel/slack`. Backend needs to add that multimethod.

### Bypassed (token issue)
3. **FE feature gate** — `index.ts` — `hasPremiumFeature("admin_security_center")` is commented out. Needs the token to include the feature.
4. **BE feature gate** — `routes.clj` — `premium-handler` bypassed for `/security-center`. Same token issue.

### Other TODOs
5. **Current version** — `SecurityCenterPage.tsx:26` — hardcoded as `"v0.59.3"`. Should read from `useSetting("version")` or similar.

