### PR TITLE
Add free_units field to ICloudAddOnProduct type

### DIFF
--- a/frontend/src/metabase-types/api/store.ts
+++ b/frontend/src/metabase-types/api/store.ts
@@ -64,6 +64,7 @@ export interface ICloudAddOnProduct {
   default_total_units: number;
   deployment: string;
   description: string | null;
+  free_units?: number | null;
   id: number;
   is_metered: boolean | null;
   name: string;


### PR DESCRIPTION
The harbormaster /addons endpoint now returns free_units for metered
products. Add the corresponding optional field to the frontend type.

Part of CLO-5190
