### PR TITLE
Remove stale archived_message instructions

### DIFF
--- a/resources/metabot/prompts/tools/read_resource.md
+++ b/resources/metabot/prompts/tools/read_resource.md
@@ -5,21 +5,6 @@ You can request multiple resources in a single call by providing a list of URIs,
 
 # Supported URI Patterns
 
-
-## Archived Message resources
-- metabase://archived_message/{id} - Get archived message details
-
-**Examples:**
-- Want to see the full contents of a specific archived message? → `metabase://archived_message/123`
-
-**Best Practices:**
-
-- Use archived message URIs to read the full contents of an archived message when needed for context.
-- Always check the archived message summary for relevant information before making decisions or generating responses.
-- Only fetch specific archived messages via read_resource when the archived message summary indicates they may be
-  relevant to the current task.
-
-
 ## Table resources
 - metabase://table/{id} - Get basic table info
 - metabase://table/{id}/fields - Get table details with available fields


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/BOT-1219/the-archived-message-link-handling-is-missing-on-the-clojure-side

Removes the remnants of context pruning experiment.