### PR TITLE
Fix custom viz not rendering in static viz context (emails/notifications)

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/static-viz-overrides.ts
+++ b/enterprise/frontend/src/metabase-enterprise/static-viz-overrides.ts
@@ -1,6 +1,8 @@
+import { initializePlugin as initializeCustomVizPlugin } from "./custom_viz";
 import { applyWhitelabelOverride } from "./whitelabel/static-viz-overrides";
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage
 export default function apply() {
   applyWhitelabelOverride();
+  initializeCustomVizPlugin();
 }

--- a/frontend/src/metabase/static-viz/index.js
+++ b/frontend/src/metabase/static-viz/index.js
@@ -6,25 +6,9 @@ import React from "react";
 import * as jsxRuntime from "react/jsx-runtime";
 import ReactDOMServer from "react-dom/server";
 
-// eslint-disable-next-line import/order
 import enterpriseOverrides from "ee-overrides";
 import "metabase/lib/dayjs";
-
 import { formatValue as internalFormatValue } from "metabase/lib/formatting/value";
-import * as isa from "metabase-lib/v1/types/utils/isa";
-
-// Expose React, jsxRuntime, and utils for custom viz bundles that reference
-// window.__METABASE_VIZ_API__ via the metabaseVizExternals Vite plugin.
-window.__METABASE_VIZ_API__ = {
-  React,
-  jsxRuntime,
-  columnTypes: isa,
-  formatValue: (value, options) => {
-    const result = internalFormatValue(value, { ...options, jsx: false });
-    return String(result ?? "");
-  },
-};
-
 import { updateStartOfWeek } from "metabase/lib/i18n";
 import MetabaseSettings from "metabase/lib/settings";
 import { PLUGIN_CUSTOM_VIZ } from "metabase/plugins";
@@ -40,8 +24,21 @@ import {
   shouldSplitVisualizerSeries,
   splitVisualizerSeries,
 } from "metabase/visualizer/utils";
+import * as isa from "metabase-lib/v1/types/utils/isa";
 
 import { LegacyStaticChart } from "./containers/LegacyStaticChart";
+
+// Expose React, jsxRuntime, and utils for custom viz bundles that reference
+// window.__METABASE_VIZ_API__ via the metabaseVizExternals Vite plugin.
+window.__METABASE_VIZ_API__ = {
+  React,
+  jsxRuntime,
+  columnTypes: isa,
+  formatValue: (value, options) => {
+    const result = internalFormatValue(value, { ...options, jsx: false });
+    return String(result ?? "");
+  },
+};
 
 setPlatformAPI({
   measureText: measureTextEChartsAdapter,
@@ -114,15 +111,21 @@ export function registerCustomVizPlugin(factory, identifier, assets) {
   PLUGIN_CUSTOM_VIZ.registerCustomVizPlugin(factory, identifier, assets);
 }
 
-export function RenderChart(rawSeries, dashcardSettings, options) {
+/**
+ * Initialize the static viz context: set settings and apply enterprise overrides.
+ * Must be called before registerCustomVizPlugin so that the EE registry is active.
+ */
+export function initializeContext(options) {
   MetabaseSettings.set("token-features", options.tokenFeatures);
   MetabaseSettings.set("application-colors", options.applicationColors);
-
+  MetabaseSettings.set("custom-formatting", options.customFormatting);
   if (typeof enterpriseOverrides === "function") {
     enterpriseOverrides();
   }
+}
 
-  MetabaseSettings.set("custom-formatting", options.customFormatting);
+export function RenderChart(rawSeries, dashcardSettings, options) {
+  initializeContext(options);
 
   const renderingContext = createStaticRenderingContext(
     options.applicationColors,

--- a/resources/frontend_shared/static_viz_interface.js
+++ b/resources/frontend_shared/static_viz_interface.js
@@ -46,7 +46,11 @@ function register_custom_viz_plugin(identifier, assetsJson) {
     // Capture the factory now (before __customVizPlugin__ is overwritten by the next bundle load),
     // but defer the actual registration until javascript_visualization runs initializeContext,
     // which applies enterprise overrides and activates the real EE registerCustomVizPlugin.
-    __pendingCustomVizRegistrations__.push({ factory: __customVizPlugin__, identifier: identifier, assets: assets });
+    __pendingCustomVizRegistrations__.push({
+      factory: __customVizPlugin__,
+      identifier,
+      assets,
+    });
   }
 }
 
@@ -68,5 +72,5 @@ function javascript_visualization(rawSeries, dashcardSettings, options) {
   var content = StaticViz.RenderChart(parsedSeries, JSON.parse(dashcardSettings), parsedOptions);
   var type = content.startsWith("<svg") ? "svg" : "html";
 
-  return JSON.stringify({ type: type, content: content });
+  return JSON.stringify({ type, content });
 }

--- a/resources/frontend_shared/static_viz_interface.js
+++ b/resources/frontend_shared/static_viz_interface.js
@@ -37,23 +37,36 @@ function funnel(data, settings, tokenFeatures) {
 }
 
 
+// Pending custom viz plugin registrations, deferred until enterprise overrides are applied.
+var __pendingCustomVizRegistrations__ = [];
+
 function register_custom_viz_plugin(identifier, assetsJson) {
   if (typeof __customVizPlugin__ === "function") {
     var assets = assetsJson ? JSON.parse(assetsJson) : {};
-    StaticViz.registerCustomVizPlugin(__customVizPlugin__, identifier, assets);
+    // Capture the factory now (before __customVizPlugin__ is overwritten by the next bundle load),
+    // but defer the actual registration until javascript_visualization runs initializeContext,
+    // which applies enterprise overrides and activates the real EE registerCustomVizPlugin.
+    __pendingCustomVizRegistrations__.push({ factory: __customVizPlugin__, identifier: identifier, assets: assets });
   }
 }
 
 function javascript_visualization(rawSeries, dashcardSettings, options) {
-  const content = StaticViz.RenderChart(
-    JSON.parse(rawSeries),
-    JSON.parse(dashcardSettings),
-    JSON.parse(options),
-  );
-  const type = content.startsWith("<svg") ? "svg" : "html";
+  var parsedOptions = JSON.parse(options);
 
-  return JSON.stringify({
-    type,
-    content,
-  });
+  // Apply enterprise overrides (EE registerCustomVizPlugin + customVizRegistry become active).
+  // This must happen before plugin registration so the real EE registry is populated.
+  StaticViz.initializeContext(parsedOptions);
+
+  // Register all deferred custom viz plugins now that the EE registry is active.
+  for (var i = 0; i < __pendingCustomVizRegistrations__.length; i++) {
+    var r = __pendingCustomVizRegistrations__[i];
+    StaticViz.registerCustomVizPlugin(r.factory, r.identifier, r.assets);
+  }
+  __pendingCustomVizRegistrations__ = [];
+
+  var parsedSeries = JSON.parse(rawSeries);
+  var content = StaticViz.RenderChart(parsedSeries, JSON.parse(dashcardSettings), parsedOptions);
+  var type = content.startsWith("<svg") ? "svg" : "html";
+
+  return JSON.stringify({ type: type, content: content });
 }


### PR DESCRIPTION
## Summary

- **`static-viz-overrides.ts`** was missing `initializeCustomVizPlugin()`, so `PLUGIN_CUSTOM_VIZ.registerCustomVizPlugin` remained a no-op even in EE builds — plugins registered successfully but had no effect
- **`RenderChart`** applied enterprise overrides too late (after plugin registration). Extracted `initializeContext()` as a separate export so it can be called first
- **`static_viz_interface.js`** now defers plugin registration into a pending queue; `javascript_visualization` calls `initializeContext` first (activating EE overrides) then drains the queue — ensuring the real EE registry is populated before plugins are registered

## Root Cause

The static viz GraalVM context uses a separate `static-viz-overrides.ts` (not the main EE `overrides.ts`). That file only applied whitelabel color overrides and never initialized the custom viz plugin registry. Combined with the ordering issue (plugins registered before enterprise context initialized), custom viz components were never invoked and fell back to table rendering.