### PR TITLE
Move table_transform_target_fk migrations from v60 to v61

### DIFF
--- a/resources/migrations/061/20260330_table_transform_target_fk.yaml
+++ b/resources/migrations/061/20260330_table_transform_target_fk.yaml
@@ -1,38 +1,6 @@
 ## Add target_table_id FK to transform and table FKs on workspace input/output columns
 
 databaseChangeLog:
-  - logicalFilePath: migrations/061_update_migrations.yaml
-
-  ## On rollback, clean up any stale v60 changeset rows left from before the version bump.
-  ## This changeset is a no-op on rollforward; the rollback action fires when downgrading.
-  - changeSet:
-      id: v61.2026-03-09T23:59:50
-      author: christruter
-      comment: >-
-        On rollback, delete old v60 changeset rows for table_transform_target_fk
-        migrations so a downgraded instance can re-run them cleanly.
-      changes:
-        - sql:
-            sql: SELECT 1
-      rollback:
-        - sql:
-            sql: >-
-              DELETE FROM ${databasechangelog.name} WHERE id IN (
-                'v60.2026-03-10T00:00:00',
-                'v60.2026-03-10T00:00:10',
-                'v60.2026-03-10T00:00:20',
-                'v60.2026-03-10T00:00:30',
-                'v60.2026-03-10T00:00:40',
-                'v60.2026-03-10T00:00:50',
-                'v60.2026-03-10T00:01:00',
-                'v60.2026-03-10T00:01:10',
-                'v60.2026-03-10T00:01:20',
-                'v60.2026-03-10T00:01:30',
-                'v60.2026-03-10T00:01:40',
-                'v60.2026-03-10T00:01:50',
-                'v60.2026-03-10T00:02:00',
-                'v60.2026-03-10T00:02:10'
-              );
 
   - changeSet:
       id: v61.2026-03-10T00:00:00
@@ -90,9 +58,6 @@ databaseChangeLog:
               id: v60.2026-03-10T00:00:20
               author: christruter
               changeLogFile: migrations/060_update_migrations.yaml
-        - not:
-            - foreignKeyConstraintExists:
-                foreignKeyName: fk_transform_target_table_id
       changes:
         - addForeignKeyConstraint:
             baseTableName: transform
@@ -152,9 +117,6 @@ databaseChangeLog:
               id: v60.2026-03-10T00:00:50
               author: christruter
               changeLogFile: migrations/060_update_migrations.yaml
-        - not:
-            - foreignKeyConstraintExists:
-                foreignKeyName: fk_workspace_output_global_table_id
       changes:
         - addForeignKeyConstraint:
             baseTableName: workspace_output
@@ -198,9 +160,6 @@ databaseChangeLog:
               id: v60.2026-03-10T00:01:10
               author: christruter
               changeLogFile: migrations/060_update_migrations.yaml
-        - not:
-            - foreignKeyConstraintExists:
-                foreignKeyName: fk_workspace_output_isolated_table_id
       changes:
         - addForeignKeyConstraint:
             baseTableName: workspace_output
@@ -244,9 +203,6 @@ databaseChangeLog:
               id: v60.2026-03-10T00:01:30
               author: christruter
               changeLogFile: migrations/060_update_migrations.yaml
-        - not:
-            - foreignKeyConstraintExists:
-                foreignKeyName: fk_workspace_input_external_table_id
       changes:
         - addForeignKeyConstraint:
             baseTableName: workspace_input_external
@@ -290,9 +246,6 @@ databaseChangeLog:
               id: v60.2026-03-10T00:01:50
               author: christruter
               changeLogFile: migrations/060_update_migrations.yaml
-        - not:
-            - foreignKeyConstraintExists:
-                foreignKeyName: fk_workspace_output_external_global_table_id
       changes:
         - addForeignKeyConstraint:
             baseTableName: workspace_output_external
@@ -336,9 +289,6 @@ databaseChangeLog:
               id: v60.2026-03-10T00:02:10
               author: christruter
               changeLogFile: migrations/060_update_migrations.yaml
-        - not:
-            - foreignKeyConstraintExists:
-                foreignKeyName: fk_workspace_output_external_isolated_table_id
       changes:
         - addForeignKeyConstraint:
             baseTableName: workspace_output_external

--- a/resources/migrations/061/20260330_table_transform_target_fk.yaml
+++ b/resources/migrations/061/20260330_table_transform_target_fk.yaml
@@ -1,11 +1,50 @@
 ## Add target_table_id FK to transform and table FKs on workspace input/output columns
 
 databaseChangeLog:
-  - logicalFilePath: migrations/060_update_migrations.yaml
+  - logicalFilePath: migrations/061_update_migrations.yaml
+
+  ## On rollback, clean up any stale v60 changeset rows left from before the version bump.
+  ## This changeset is a no-op on rollforward; the rollback action fires when downgrading.
   - changeSet:
-      id: v60.2026-03-10T00:00:00
+      id: v61.2026-03-09T23:59:50
+      author: christruter
+      comment: >-
+        On rollback, delete old v60 changeset rows for table_transform_target_fk
+        migrations so a downgraded instance can re-run them cleanly.
+      changes:
+        - sql:
+            sql: SELECT 1
+      rollback:
+        - sql:
+            sql: >-
+              DELETE FROM ${databasechangelog.name} WHERE id IN (
+                'v60.2026-03-10T00:00:00',
+                'v60.2026-03-10T00:00:10',
+                'v60.2026-03-10T00:00:20',
+                'v60.2026-03-10T00:00:30',
+                'v60.2026-03-10T00:00:40',
+                'v60.2026-03-10T00:00:50',
+                'v60.2026-03-10T00:01:00',
+                'v60.2026-03-10T00:01:10',
+                'v60.2026-03-10T00:01:20',
+                'v60.2026-03-10T00:01:30',
+                'v60.2026-03-10T00:01:40',
+                'v60.2026-03-10T00:01:50',
+                'v60.2026-03-10T00:02:00',
+                'v60.2026-03-10T00:02:10'
+              );
+
+  - changeSet:
+      id: v61.2026-03-10T00:00:00
       author: christruter
       comment: Add target_table_id column to transform table
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            changeSetExecuted:
+              id: v60.2026-03-10T00:00:00
+              author: christruter
+              changeLogFile: migrations/060_update_migrations.yaml
       changes:
         - addColumn:
             tableName: transform
@@ -22,9 +61,16 @@ databaseChangeLog:
             columnName: target_table_id
 
   - changeSet:
-      id: v60.2026-03-10T00:00:10
+      id: v61.2026-03-10T00:00:10
       author: christruter
       comment: Add index on transform.target_table_id
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            changeSetExecuted:
+              id: v60.2026-03-10T00:00:10
+              author: christruter
+              changeLogFile: migrations/060_update_migrations.yaml
       changes:
         - createIndex:
             tableName: transform
@@ -34,11 +80,16 @@ databaseChangeLog:
                   name: target_table_id
 
   - changeSet:
-      id: v60.2026-03-10T00:00:20
+      id: v61.2026-03-10T00:00:20
       author: christruter
       comment: Add FK from transform.target_table_id to metabase_table with SET NULL
       preConditions:
         - onFail: MARK_RAN
+        - not:
+            changeSetExecuted:
+              id: v60.2026-03-10T00:00:20
+              author: christruter
+              changeLogFile: migrations/060_update_migrations.yaml
         - not:
             - foreignKeyConstraintExists:
                 foreignKeyName: fk_transform_target_table_id
@@ -56,18 +107,32 @@ databaseChangeLog:
             constraintName: fk_transform_target_table_id
 
   - changeSet:
-      id: v60.2026-03-10T00:00:30
+      id: v61.2026-03-10T00:00:30
       author: christruter
       comment: Backfill transform.target_table_id from target JSON column
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            changeSetExecuted:
+              id: v60.2026-03-10T00:00:30
+              author: christruter
+              changeLogFile: migrations/060_update_migrations.yaml
       changes:
         - customChange:
             class: metabase.app_db.custom_migrations.BackfillTransformTargetTableId
       rollback:
 
   - changeSet:
-      id: v60.2026-03-10T00:00:40
+      id: v61.2026-03-10T00:00:40
       author: christruter
       comment: Add index on workspace_output.global_table_id
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            changeSetExecuted:
+              id: v60.2026-03-10T00:00:40
+              author: christruter
+              changeLogFile: migrations/060_update_migrations.yaml
       changes:
         - createIndex:
             tableName: workspace_output
@@ -77,11 +142,16 @@ databaseChangeLog:
                   name: global_table_id
 
   - changeSet:
-      id: v60.2026-03-10T00:00:50
+      id: v61.2026-03-10T00:00:50
       author: christruter
       comment: Add FK from workspace_output.global_table_id to metabase_table with SET NULL
       preConditions:
         - onFail: MARK_RAN
+        - not:
+            changeSetExecuted:
+              id: v60.2026-03-10T00:00:50
+              author: christruter
+              changeLogFile: migrations/060_update_migrations.yaml
         - not:
             - foreignKeyConstraintExists:
                 foreignKeyName: fk_workspace_output_global_table_id
@@ -99,9 +169,16 @@ databaseChangeLog:
             constraintName: fk_workspace_output_global_table_id
 
   - changeSet:
-      id: v60.2026-03-10T00:01:00
+      id: v61.2026-03-10T00:01:00
       author: christruter
       comment: Add index on workspace_output.isolated_table_id
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            changeSetExecuted:
+              id: v60.2026-03-10T00:01:00
+              author: christruter
+              changeLogFile: migrations/060_update_migrations.yaml
       changes:
         - createIndex:
             tableName: workspace_output
@@ -111,11 +188,16 @@ databaseChangeLog:
                   name: isolated_table_id
 
   - changeSet:
-      id: v60.2026-03-10T00:01:10
+      id: v61.2026-03-10T00:01:10
       author: christruter
       comment: Add FK from workspace_output.isolated_table_id to metabase_table with SET NULL
       preConditions:
         - onFail: MARK_RAN
+        - not:
+            changeSetExecuted:
+              id: v60.2026-03-10T00:01:10
+              author: christruter
+              changeLogFile: migrations/060_update_migrations.yaml
         - not:
             - foreignKeyConstraintExists:
                 foreignKeyName: fk_workspace_output_isolated_table_id
@@ -133,9 +215,16 @@ databaseChangeLog:
             constraintName: fk_workspace_output_isolated_table_id
 
   - changeSet:
-      id: v60.2026-03-10T00:01:20
+      id: v61.2026-03-10T00:01:20
       author: christruter
       comment: Add index on workspace_input_external.table_id
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            changeSetExecuted:
+              id: v60.2026-03-10T00:01:20
+              author: christruter
+              changeLogFile: migrations/060_update_migrations.yaml
       changes:
         - createIndex:
             tableName: workspace_input_external
@@ -145,11 +234,16 @@ databaseChangeLog:
                   name: table_id
 
   - changeSet:
-      id: v60.2026-03-10T00:01:30
+      id: v61.2026-03-10T00:01:30
       author: christruter
       comment: Add FK from workspace_input_external.table_id to metabase_table with SET NULL
       preConditions:
         - onFail: MARK_RAN
+        - not:
+            changeSetExecuted:
+              id: v60.2026-03-10T00:01:30
+              author: christruter
+              changeLogFile: migrations/060_update_migrations.yaml
         - not:
             - foreignKeyConstraintExists:
                 foreignKeyName: fk_workspace_input_external_table_id
@@ -167,9 +261,16 @@ databaseChangeLog:
             constraintName: fk_workspace_input_external_table_id
 
   - changeSet:
-      id: v60.2026-03-10T00:01:40
+      id: v61.2026-03-10T00:01:40
       author: christruter
       comment: Add index on workspace_output_external.global_table_id
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            changeSetExecuted:
+              id: v60.2026-03-10T00:01:40
+              author: christruter
+              changeLogFile: migrations/060_update_migrations.yaml
       changes:
         - createIndex:
             tableName: workspace_output_external
@@ -179,11 +280,16 @@ databaseChangeLog:
                   name: global_table_id
 
   - changeSet:
-      id: v60.2026-03-10T00:01:50
+      id: v61.2026-03-10T00:01:50
       author: christruter
       comment: Add FK from workspace_output_external.global_table_id to metabase_table with SET NULL
       preConditions:
         - onFail: MARK_RAN
+        - not:
+            changeSetExecuted:
+              id: v60.2026-03-10T00:01:50
+              author: christruter
+              changeLogFile: migrations/060_update_migrations.yaml
         - not:
             - foreignKeyConstraintExists:
                 foreignKeyName: fk_workspace_output_external_global_table_id
@@ -201,9 +307,16 @@ databaseChangeLog:
             constraintName: fk_workspace_output_external_global_table_id
 
   - changeSet:
-      id: v60.2026-03-10T00:02:00
+      id: v61.2026-03-10T00:02:00
       author: christruter
       comment: Add index on workspace_output_external.isolated_table_id
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            changeSetExecuted:
+              id: v60.2026-03-10T00:02:00
+              author: christruter
+              changeLogFile: migrations/060_update_migrations.yaml
       changes:
         - createIndex:
             tableName: workspace_output_external
@@ -213,11 +326,16 @@ databaseChangeLog:
                   name: isolated_table_id
 
   - changeSet:
-      id: v60.2026-03-10T00:02:10
+      id: v61.2026-03-10T00:02:10
       author: christruter
       comment: Add FK from workspace_output_external.isolated_table_id to metabase_table with SET NULL
       preConditions:
         - onFail: MARK_RAN
+        - not:
+            changeSetExecuted:
+              id: v60.2026-03-10T00:02:10
+              author: christruter
+              changeLogFile: migrations/060_update_migrations.yaml
         - not:
             - foreignKeyConstraintExists:
                 foreignKeyName: fk_workspace_output_external_isolated_table_id
@@ -233,3 +351,31 @@ databaseChangeLog:
         - dropForeignKeyConstraint:
             baseTableName: workspace_output_external
             constraintName: fk_workspace_output_external_isolated_table_id
+
+  ## On rollforward, clean up any stale v60 changeset rows left from before the version bump.
+  - changeSet:
+      id: v61.2026-03-10T00:02:20
+      author: christruter
+      comment: >-
+        Delete old v60 changeset rows for table_transform_target_fk migrations
+        so the databasechangelog table only contains the v61 versions.
+      changes:
+        - sql:
+            sql: >-
+              DELETE FROM ${databasechangelog.name} WHERE id IN (
+                'v60.2026-03-10T00:00:00',
+                'v60.2026-03-10T00:00:10',
+                'v60.2026-03-10T00:00:20',
+                'v60.2026-03-10T00:00:30',
+                'v60.2026-03-10T00:00:40',
+                'v60.2026-03-10T00:00:50',
+                'v60.2026-03-10T00:01:00',
+                'v60.2026-03-10T00:01:10',
+                'v60.2026-03-10T00:01:20',
+                'v60.2026-03-10T00:01:30',
+                'v60.2026-03-10T00:01:40',
+                'v60.2026-03-10T00:01:50',
+                'v60.2026-03-10T00:02:00',
+                'v60.2026-03-10T00:02:10'
+              );
+      rollback: # nothing to undo - these rows should not exist in v61


### PR DESCRIPTION
These migrations merged to master only after v60 was cut.

At first I thought, let's just backport them, but then I realized we'd still need to force the backport to run again in v61.

So on second thought, I think it's best to just go through the renaming exercise again.
