### PR TITLE
GDGT-2031 Fix custom viz being vertically shifted down in dashboards

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/custom_viz/custom-viz-plugins.ts
+++ b/enterprise/frontend/src/metabase-enterprise/custom_viz/custom-viz-plugins.ts
@@ -1,8 +1,10 @@
+import type { ComponentType } from "react";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import * as jsxRuntime from "react/jsx-runtime";
 import { t } from "ttag";
 
 import { useListCustomVizPluginsQuery } from "metabase/api";
+import { ExplicitSize } from "metabase/common/components/ExplicitSize";
 import { useToast } from "metabase/common/hooks";
 import { useEmbeddingEntityContext } from "metabase/embedding/context";
 import type { OptionsType } from "metabase/lib/formatting/types";
@@ -13,7 +15,10 @@ import {
   measureTextWidth,
 } from "metabase/lib/measure-text";
 import visualizations, { registerVisualization } from "metabase/visualizations";
-import type { Visualization } from "metabase/visualizations/types/visualization";
+import type {
+  Visualization,
+  VisualizationProps,
+} from "metabase/visualizations/types/visualization";
 import * as isa from "metabase-lib/v1/types/utils/isa";
 import type {
   CustomVizPluginRuntime,
@@ -342,7 +347,12 @@ export async function loadCustomVizPlugin(
     const identifier = `custom:${plugin.identifier}` as VisualizationDisplay;
 
     // Attach the required static properties onto the component function
-    const Component = vizDef.VisualizationComponent as Visualization;
+    const Component = ExplicitSize<VisualizationProps>()(
+      vizDef.VisualizationComponent as ComponentType<
+        VisualizationProps & { width: number | null; height: number | null }
+      >,
+    ) as Visualization;
+
     Object.assign(Component, {
       identifier,
       getUiName: () => plugin.display_name,

--- a/frontend/src/custom-viz/src/templates/index.tsx
+++ b/frontend/src/custom-viz/src/templates/index.tsx
@@ -70,10 +70,14 @@ const createVisualization: CreateCustomVisualization<Settings> = ({
   };
 };
 
-const makeVisualizationComponent = (getAssetUrl: (path: string) => string) => (props: CustomVisualizationProps<Settings>) => {
+const makeVisualizationComponent = (_getAssetUrl: (path: string) => string) => (props: CustomVisualizationProps<Settings>) => {
   const { height, series, settings, width } = props;
   const { threshold } = settings;
   const value = series[0].data.rows[0][0];
+
+  if (!height || !width) {
+    return null;
+  }
 
   if (typeof value !== "number" || typeof threshold !== "number") {
     throw new Error("Value and threshold need to be numbers");

--- a/frontend/src/custom-viz/src/types/viz.ts
+++ b/frontend/src/custom-viz/src/types/viz.ts
@@ -124,9 +124,9 @@ export type VisualizationGridSize = {
 };
 
 export type CustomVisualizationProps<CustomVisualizationSettings> = {
-  width: number;
+  width: number | null;
 
-  height: number;
+  height: number | null;
 
   series: Series;
 


### PR DESCRIPTION
Closes [GDGT-2031](https://linear.app/metabase/issue/GDGT-2031/custom-viz-is-vertically-shifted-down-in-dashboards)

### Description

The `height` prop received by Visualization component did not account for `DASHCARD_HEADER_HEIGHT` in dashboards.
In other visualization components this is handled by wrapping them with `ExplicitSize` HOC.
This PR uses the same approach.

PR also updates types of `height` and `width` props to allow `null`, since they're actually `null` on the first render.

### Demo

[before](https://github.com/user-attachments/assets/9503bea0-f177-449f-a748-68da65bd80c3) vs [after](https://github.com/user-attachments/assets/0b12d083-c814-447f-9dc0-73fe255571d4)
