### PR TITLE
Adding Details tab to table section

### DIFF
--- a/e2e/support/helpers/e2e-datamodel-helpers.ts
+++ b/e2e/support/helpers/e2e-datamodel-helpers.ts
@@ -48,6 +48,8 @@ export const DataModel = {
   },
   TableSection: {
     get: getTableSection,
+    clickFieldsTab,
+    clickDetailsTab,
     getNameInput: getTableNameInput,
     getDescriptionInput: getTableDescriptionInput,
     getQueryBuilderLink: getTableQueryBuilderLink,
@@ -318,6 +320,14 @@ function getTablePickerTables() {
 }
 
 /** table section helpers */
+
+function clickFieldsTab() {
+  cy.findByRole("tab", { name: /Fields/ }).click();
+}
+
+function clickDetailsTab() {
+  cy.findByRole("tab", { name: /Details/ }).click();
+}
 
 function getTableSection() {
   return cy.findByTestId("table-section");

--- a/e2e/test/scenarios/data-model/data-model-shared-1.cy.spec.ts
+++ b/e2e/test/scenarios/data-model/data-model-shared-1.cy.spec.ts
@@ -433,6 +433,9 @@ describe.each<Area>(areas)("data model > %s", (area: Area) => {
 
       TablePicker.getTables().should("have.length", 8);
 
+      if (area === "data studio") {
+        TableSection.clickFieldsTab();
+      }
       TableSection.clickField("ID");
 
       if (area === "data studio") {
@@ -547,6 +550,9 @@ describe.each<Area>(areas)("data model > %s", (area: Area) => {
         TablePicker.getSchema("Domestic").click();
         TablePicker.getTable("Animals").click();
 
+        if (area === "data studio") {
+          TableSection.clickFieldsTab();
+        }
         TableSection.get()
           .findByText("This table has no fields")
           .should("exist");
@@ -628,6 +634,9 @@ describe.each<Area>(areas)("data model > %s", (area: Area) => {
           tableId: ORDERS_ID,
         });
 
+        if (area === "data studio") {
+          TableSection.clickFieldsTab();
+        }
         TableSection.getFieldNameInput("Tax").clear().type("New tax").blur();
         cy.wait("@updateField");
         verifyAndCloseToast("Name of Tax updated");
@@ -657,6 +666,9 @@ describe.each<Area>(areas)("data model > %s", (area: Area) => {
           tableId: ORDERS_ID,
         });
 
+        if (area === "data studio") {
+          TableSection.clickFieldsTab();
+        }
         TableSection.getFieldDescriptionInput("Total")
           .clear()
           .type("New description")
@@ -693,6 +705,9 @@ describe.each<Area>(areas)("data model > %s", (area: Area) => {
           tableId: ORDERS_ID,
         });
 
+        if (area === "data studio") {
+          TableSection.clickFieldsTab();
+        }
         TableSection.getFieldDescriptionInput("Total").clear().blur();
         cy.wait("@updateField");
         verifyAndCloseToast("Description of Total updated");

--- a/e2e/test/scenarios/data-model/data-model-shared-2.cy.spec.ts
+++ b/e2e/test/scenarios/data-model/data-model-shared-2.cy.spec.ts
@@ -583,6 +583,9 @@ describe.each<Area>(areas)("data model > %s", (area: Area) => {
           cy.viewport(1280, viewportHeight);
           visit({ databaseId: SAMPLE_DB_ID });
           TablePicker.getTable("Reviews").scrollIntoView().click();
+          if (area === "data studio") {
+            TableSection.clickFieldsTab();
+          }
           TableSection.clickField("ID");
           FieldSection.getSemanticTypeInput().click();
 
@@ -617,6 +620,9 @@ describe.each<Area>(areas)("data model > %s", (area: Area) => {
 
             visit({ databaseId: WRITABLE_DB_ID });
             TablePicker.getTable("Many Data Types").click();
+            if (area === "data studio") {
+              TableSection.clickFieldsTab();
+            }
             TableSection.clickField("Json → D");
             FieldSection.getSemanticTypeInput().click();
             H.popover().findByText("Entity Name").click();
@@ -834,6 +840,9 @@ describe.each<Area>(areas)("data model > %s", (area: Area) => {
               tableId: ORDERS_ID,
             });
 
+            if (area === "data studio") {
+              TableSection.clickFieldsTab();
+            }
             TableSection.clickField("Tax");
             FieldSection.getVisibilityInput().click();
             H.popover().findByText("Do not include").click();

--- a/e2e/test/scenarios/data-model/data-model-shared-3.cy.spec.ts
+++ b/e2e/test/scenarios/data-model/data-model-shared-3.cy.spec.ts
@@ -253,6 +253,9 @@ describe.each<Area>(areas)("data model > %s", (area: Area) => {
 
           // edit "Product ID" column in "Orders" table
           TablePicker.getTable("Orders").click();
+          if (area === "data studio") {
+            TableSection.clickFieldsTab();
+          }
           TableSection.clickField("Product ID");
 
           // remap its original value to use foreign key
@@ -309,6 +312,9 @@ describe.each<Area>(areas)("data model > %s", (area: Area) => {
           visit({ databaseId: SAMPLE_DB_ID });
           // edit "Rating" values in "Reviews" table
           TablePicker.getTable("Reviews").click();
+          if (area === "data studio") {
+            TableSection.clickFieldsTab();
+          }
           TableSection.clickField("Rating");
 
           // apply custom remapping for "Rating" values 1-5
@@ -480,6 +486,9 @@ describe.each<Area>(areas)("data model > %s", (area: Area) => {
         it("should let you enable/disable 'Unfold JSON' for JSON columns", () => {
           visit({ databaseId: WRITABLE_DB_ID });
           TablePicker.getTable("Many Data Types").click();
+          if (area === "data studio") {
+            TableSection.clickFieldsTab();
+          }
 
           cy.log("json is unfolded initially and shows prefix");
           TableSection.getField("Json → A")
@@ -549,12 +558,18 @@ describe.each<Area>(areas)("data model > %s", (area: Area) => {
           // Check json field is not unfolded
           visit({ databaseId: WRITABLE_DB_ID });
           TablePicker.getTable("Many Data Types").click();
+          if (area === "data studio") {
+            TableSection.clickFieldsTab();
+          }
           TableSection.getField("Json → A").should("not.exist");
         });
 
         it("should let you change the name of JSON-unfolded columns (metabase#55563)", () => {
           visit({ databaseId: WRITABLE_DB_ID });
           TablePicker.getTable("Many Data Types").click();
+          if (area === "data studio") {
+            TableSection.clickFieldsTab();
+          }
           TableSection.clickField("Json → A");
 
           TableSection.getFieldNameInput("Json → A").clear().type("A").blur();
@@ -577,6 +592,9 @@ describe.each<Area>(areas)("data model > %s", (area: Area) => {
           const longPrefix = "Legendarily long column prefix";
           visit({ databaseId: WRITABLE_DB_ID });
           TablePicker.getTable("Many Data Types").click();
+          if (area === "data studio") {
+            TableSection.clickFieldsTab();
+          }
           TableSection.clickField("Json → A");
 
           cy.log("should not truncante short prefixes");

--- a/e2e/test/scenarios/data-model/data-model-shared-4.cy.spec.ts
+++ b/e2e/test/scenarios/data-model/data-model-shared-4.cy.spec.ts
@@ -87,6 +87,9 @@ describe.each<Area>(areas)("data model > %s", (area: Area) => {
 
       cy.log("table section");
 
+      if (area === "data studio") {
+        TableSection.clickDetailsTab();
+      }
       cy.log("name");
       TableSection.getNameInput().type("a").blur();
       verifyAndCloseToast("Failed to update table name");
@@ -95,6 +98,9 @@ describe.each<Area>(areas)("data model > %s", (area: Area) => {
       TableSection.getDescriptionInput().type("a").blur();
       verifyAndCloseToast("Failed to update table description");
 
+      if (area === "data studio") {
+        TableSection.clickFieldsTab();
+      }
       cy.log("predefined field order");
       TableSection.getSortButton().click();
       TableSection.getSortOrderInput()
@@ -110,6 +116,9 @@ describe.each<Area>(areas)("data model > %s", (area: Area) => {
       verifyAndCloseToast("Failed to update field order");
       TableSection.get().button("Done").click();
 
+      if (area === "data studio") {
+        TableSection.clickDetailsTab();
+      }
       cy.log("sync");
       TableSection.getSyncOptionsButton().click();
       H.modal().button("Sync table schema").click();
@@ -124,6 +133,9 @@ describe.each<Area>(areas)("data model > %s", (area: Area) => {
       verifyAndCloseToast("Failed to discard values");
       cy.realPress("Escape");
 
+      if (area === "data studio") {
+        TableSection.clickFieldsTab();
+      }
       cy.log("field name");
       TableSection.getFieldNameInput("Quantity").type("a").blur();
       verifyAndCloseToast("Failed to update name of Quantity");
@@ -175,6 +187,9 @@ describe.each<Area>(areas)("data model > %s", (area: Area) => {
       // components, so new undos will appear - this makes this test flaky, so we navigate with page reload instead
       visit({ databaseId: WRITABLE_DB_ID });
       TablePicker.getTable("Many Data Types").click();
+      if (area === "data studio") {
+        TableSection.clickFieldsTab();
+      }
       TableSection.clickField("Json");
       FieldSection.getUnfoldJsonInput().click();
       H.popover().findByText("No").click();
@@ -183,6 +198,9 @@ describe.each<Area>(areas)("data model > %s", (area: Area) => {
       cy.log("formatting");
       TablePicker.getDatabase("Sample Database").click();
       TablePicker.getTable("Orders").click();
+      if (area === "data studio") {
+        TableSection.clickFieldsTab();
+      }
       TableSection.clickField("Quantity");
       FieldSection.getPrefixInput().type("5").blur();
       verifyAndCloseToast("Failed to update formatting of Quantity");
@@ -225,6 +243,9 @@ describe.each<Area>(areas)("data model > %s", (area: Area) => {
 
       cy.log("table section");
 
+      if (area === "data studio") {
+        TableSection.clickDetailsTab();
+      }
       cy.log("name");
       TableSection.getNameInput().type("a").blur();
       verifyToastAndUndo("Table name updated");
@@ -238,6 +259,9 @@ describe.each<Area>(areas)("data model > %s", (area: Area) => {
         "Confirmed Sample Company orders for a product, from a user.",
       );
 
+      if (area === "data studio") {
+        TableSection.clickFieldsTab();
+      }
       cy.log("predefined field order");
       TableSection.getSortButton().click();
       TableSection.getSortOrderInput()
@@ -363,6 +387,9 @@ describe.each<Area>(areas)("data model > %s", (area: Area) => {
       cy.log("JSON unfolding");
       TablePicker.getDatabase("Writable Postgres12").click();
       TablePicker.getTable("Many Data Types").click();
+      if (area === "data studio") {
+        TableSection.clickFieldsTab();
+      }
       TableSection.clickField("Json");
       FieldSection.getUnfoldJsonInput().click();
       H.popover().findByText("No").click();
@@ -371,6 +398,9 @@ describe.each<Area>(areas)("data model > %s", (area: Area) => {
 
       cy.log("formatting");
       TablePicker.getTable("Orders").click();
+      if (area === "data studio") {
+        TableSection.clickFieldsTab();
+      }
       TableSection.clickField("Quantity");
 
       cy.log("prefix (ChartSettingInput)");

--- a/e2e/test/scenarios/data-model/data-model-shared-4.cy.spec.ts
+++ b/e2e/test/scenarios/data-model/data-model-shared-4.cy.spec.ts
@@ -100,6 +100,7 @@ describe.each<Area>(areas)("data model > %s", (area: Area) => {
 
       if (area === "data studio") {
         TableSection.clickFieldsTab();
+        // cy.pause();
       }
       cy.log("predefined field order");
       TableSection.getSortButton().click();
@@ -145,7 +146,7 @@ describe.each<Area>(areas)("data model > %s", (area: Area) => {
       verifyAndCloseToast("Failed to update description of Quantity");
 
       cy.log("field section");
-
+      TableSection.clickField("Quantity");
       cy.log("name");
       FieldSection.getNameInput().type("a").blur();
       verifyAndCloseToast("Failed to update name of Quantity");
@@ -300,6 +301,7 @@ describe.each<Area>(areas)("data model > %s", (area: Area) => {
       );
 
       cy.log("field section");
+      TableSection.clickField("Quantity");
 
       cy.log("name");
       FieldSection.getNameInput().type("a").blur();

--- a/e2e/test/scenarios/data-studio/data-model/datamodel-data-studio.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-model/datamodel-data-studio.cy.spec.ts
@@ -601,6 +601,7 @@ describe("scenarios > data studio > datamodel", () => {
         );
 
         cy.log("change field name");
+        TableSection.clickFieldsTab();
         TableSection.getFieldNameInput("Tax")
           .clear()
           .type("Analyst Tax")
@@ -665,6 +666,7 @@ describe("scenarios > data studio > datamodel", () => {
           tableId: ORDERS_ID,
         });
 
+        TableSection.clickFieldsTab();
         TableSection.getFieldDescriptionInput("Total").clear().blur();
         cy.wait("@updateField");
         verifyAndCloseToast("Description of Total updated");
@@ -698,6 +700,7 @@ describe("scenarios > data studio > datamodel", () => {
           tableId: ORDERS_ID,
         });
 
+        TableSection.clickFieldsTab();
         cy.log("change field name from table section");
         TableSection.getFieldNameInput("Tax")
           .clear()
@@ -775,6 +778,7 @@ describe("scenarios > data studio > datamodel", () => {
           tableId: PRODUCTS_ID,
         });
 
+        TableSection.clickFieldsTab();
         TableSection.getSortButton().click();
         TableSection.getSortOrderInput()
           .findByDisplayValue("database")
@@ -802,6 +806,7 @@ describe("scenarios > data studio > datamodel", () => {
           tableId: PRODUCTS_ID,
         });
 
+        TableSection.clickFieldsTab();
         TableSection.getSortButton().click();
         TableSection.getSortOrderInput()
           .findByLabelText("Alphabetical order")
@@ -834,6 +839,7 @@ describe("scenarios > data studio > datamodel", () => {
           tableId: PRODUCTS_ID,
         });
 
+        TableSection.clickFieldsTab();
         TableSection.getSortButton().click();
         TableSection.getSortOrderInput().findByLabelText("Auto order").click();
         cy.wait("@updateTable");
@@ -864,6 +870,7 @@ describe("scenarios > data studio > datamodel", () => {
           tableId: PRODUCTS_ID,
         });
 
+        TableSection.clickFieldsTab();
         TableSection.getSortButton().click();
         TableSection.getSortOrderInput()
           .findByDisplayValue("database")
@@ -909,6 +916,7 @@ describe("scenarios > data studio > datamodel", () => {
           tableId: PRODUCTS_ID,
         });
 
+        TableSection.clickFieldsTab();
         TableSection.getSortButton().click();
         TableSection.getSortOrderInput()
           .findByDisplayValue("database")
@@ -1281,6 +1289,7 @@ describe("scenarios > data studio > datamodel", () => {
         TablePicker.getDatabase("Writable Postgres12").click();
         TablePicker.getSchema("Domestic").click();
         TablePicker.getTable("Animals").click();
+        TableSection.clickFieldsTab();
         TableSection.clickField("Name");
         FieldSection.getPreviewButton().click();
 
@@ -1341,6 +1350,7 @@ describe("scenarios > data studio > datamodel", () => {
         fieldId: ORDERS.PRODUCT_ID,
       });
 
+      TableSection.clickDetailsTab();
       H.DataModel.TableSection.getVisibilityTypeInput().click();
       H.popover().findByText("Hidden").click();
       cy.wait("@updateTable");
@@ -1379,6 +1389,7 @@ describe("scenarios > data studio > datamodel", () => {
       "ensure that preview opened state was cleared and does not re-appear",
     );
     TablePicker.getTable("Orders").click();
+    TableSection.clickFieldsTab();
     TableSection.clickField("Subtotal");
     PreviewSection.get().should("not.exist");
     FieldSection.get().should("exist");

--- a/e2e/test/scenarios/data-studio/data-model/datamodel-data-studio.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-model/datamodel-data-studio.cy.spec.ts
@@ -1220,13 +1220,6 @@ describe("scenarios > data studio > datamodel", () => {
         FieldSection.getPreviewButton().click();
         PreviewSection.get().scrollIntoView().should("be.visible");
 
-        TableSection.getSyncOptionsButton().click();
-        H.modal().should("be.visible");
-
-        cy.realPress("Escape");
-        H.modal().should("not.exist");
-        PreviewSection.get().should("be.visible");
-
         FieldSection.getFieldValuesButton().click();
         H.modal().should("be.visible");
 
@@ -1347,13 +1340,15 @@ describe("scenarios > data studio > datamodel", () => {
         databaseId: SAMPLE_DB_ID,
         schemaId: SAMPLE_DB_SCHEMA_ID,
         tableId: ORDERS_ID,
-        fieldId: ORDERS.PRODUCT_ID,
       });
 
       TableSection.clickDetailsTab();
       H.DataModel.TableSection.getVisibilityTypeInput().click();
       H.popover().findByText("Hidden").click();
       cy.wait("@updateTable");
+
+      H.DataModel.TableSection.clickFieldsTab();
+      H.DataModel.TableSection.clickField("Product ID");
 
       FieldSection.getPreviewButton().click();
       PreviewSection.getPreviewTypeInput().findByText("Filtering").click();

--- a/e2e/test/scenarios/data-studio/transforms/transforms.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/transforms/transforms.cy.spec.ts
@@ -1384,6 +1384,7 @@ LIMIT
       getTransformsTargetContent()
         .findByText("Edit this table's metadata")
         .click();
+      H.DataModel.TableSection.clickFieldsTab();
       H.DataModel.TableSection.clickField("Name");
       H.DataModel.FieldSection.getNameInput().clear().type("New name").blur();
       cy.wait("@updateField");

--- a/e2e/test/scenarios/data-studio/transforms/transforms.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/transforms/transforms.cy.spec.ts
@@ -1392,6 +1392,7 @@ LIMIT
       cy.log("verify query metadata");
       cy.go("back");
       cy.go("back");
+      cy.go("back");
       getTableLink().click();
       H.assertTableData({ columns: ["New name", "Score"] });
     });

--- a/frontend/src/metabase/data-studio/data-model/components/TableSection/TableSection.tsx
+++ b/frontend/src/metabase/data-studio/data-model/components/TableSection/TableSection.tsx
@@ -235,7 +235,7 @@ const TableSectionBase = ({
     <Stack data-testid="table-section" gap="md" pb="xl">
       <Box>
         <Tabs value={activeTab} onChange={handleTabChange}>
-          <Tabs.List mb="md" grow>
+          <Tabs.List mb="md">
             <Tabs.Tab
               value="details"
               leftSection={<Icon name="info" />}

--- a/frontend/src/metabase/data-studio/data-model/components/TableSection/TableSection.tsx
+++ b/frontend/src/metabase/data-studio/data-model/components/TableSection/TableSection.tsx
@@ -233,90 +233,13 @@ const TableSectionBase = ({
 
   return (
     <Stack data-testid="table-section" gap="md" pb="xl">
-      <Box className={S.header}>
-        <NameDescriptionInput
-          description={table.description ?? ""}
-          descriptionPlaceholder={t`Give this table a description`}
-          name={table.display_name}
-          nameIcon="table2"
-          nameMaxLength={254}
-          namePlaceholder={t`Give this table a name`}
-          onNameChange={handleNameChange}
-          onDescriptionChange={handleDescriptionChange}
-        />
-      </Box>
-
-      <Group justify="stretch" gap="sm">
-        {canPublish && isLibraryEnabled && !remoteSyncReadOnly && (
-          <Button
-            flex="1"
-            p="sm"
-            leftSection={
-              <Icon name={table.is_published ? "unpublish" : "publish"} />
-            }
-            onClick={handlePublishToggle}
-          >
-            {table.is_published ? t`Unpublish` : t`Publish`}
-          </Button>
-        )}
-        {!table.db?.is_attached_dwh && (
-          <Button
-            flex="1"
-            leftSection={<Icon name="settings" />}
-            onClick={onSyncOptionsClick}
-          >
-            {t`Sync settings`}
-          </Button>
-        )}
-        <PLUGIN_REPLACEMENT.SourceReplacementButton>
-          {({ tooltip, isDisabled }) => (
-            <Tooltip label={tooltip ?? t`Find and replace`}>
-              <Button
-                p="sm"
-                w="2.5rem"
-                flex="0 1 auto"
-                leftSection={<Icon name="find_replace" />}
-                aria-label={t`Find and replace`}
-                disabled={isDisabled}
-                onClick={() => setModalType("replace")}
-              />
-            </Tooltip>
-          )}
-        </PLUGIN_REPLACEMENT.SourceReplacementButton>
-        {isDependencyGraphEnabled && (
-          <Tooltip label={t`Dependency graph`}>
-            <Button
-              component={ForwardRefLink}
-              to={dependencyGraph({
-                entry: { id: Number(table.id), type: "table" },
-              })}
-              p="sm"
-              w="2.5rem"
-              flex="0 1 auto"
-              leftSection={<Icon name="dependencies" />}
-              aria-label={t`Dependency graph`}
-              onClickCapture={registerDependencyGraphTrackingEvent}
-              onAuxClick={registerDependencyGraphTrackingEvent}
-            />
-          </Tooltip>
-        )}
-
-        <Box style={{ flexGrow: 0, width: 40 }}>
-          <TableLink table={table} />
-        </Box>
-      </Group>
-
-      <TableAttributesEditSingle table={table} onUpdate={onUpdate} />
-
-      <TableSectionGroup title={t`Metadata`}>
-        <TableMetadata table={table} />
-      </TableSectionGroup>
-
-      {table.is_published && <TableCollection table={table} />}
-
       <Box>
         <Tabs value={activeTab} onChange={handleTabChange}>
           <Tabs.List mb="md">
+            <Tabs.Tab
+              value="details"
+              leftSection={<Icon name="info" />}
+            >{t`Details`}</Tabs.Tab>
             <Tabs.Tab
               value="field"
               leftSection={<Icon name="list" />}
@@ -330,6 +253,93 @@ const TableSectionBase = ({
               leftSection={<Icon name="ruler" />}
             >{t`Measures`}</Tabs.Tab>
           </Tabs.List>
+
+          <Tabs.Panel value="details">
+            <Stack gap="md">
+              <Box className={S.header}>
+                <NameDescriptionInput
+                  description={table.description ?? ""}
+                  descriptionPlaceholder={t`Give this table a description`}
+                  name={table.display_name}
+                  nameIcon="table2"
+                  nameMaxLength={254}
+                  namePlaceholder={t`Give this table a name`}
+                  onNameChange={handleNameChange}
+                  onDescriptionChange={handleDescriptionChange}
+                />
+              </Box>
+
+              <Group justify="stretch" gap="sm">
+                {canPublish && isLibraryEnabled && !remoteSyncReadOnly && (
+                  <Button
+                    flex="1"
+                    p="sm"
+                    leftSection={
+                      <Icon
+                        name={table.is_published ? "unpublish" : "publish"}
+                      />
+                    }
+                    onClick={handlePublishToggle}
+                  >
+                    {table.is_published ? t`Unpublish` : t`Publish`}
+                  </Button>
+                )}
+                {!table.db?.is_attached_dwh && (
+                  <Button
+                    flex="1"
+                    leftSection={<Icon name="settings" />}
+                    onClick={onSyncOptionsClick}
+                  >
+                    {t`Sync settings`}
+                  </Button>
+                )}
+                <PLUGIN_REPLACEMENT.SourceReplacementButton>
+                  {({ tooltip, isDisabled }) => (
+                    <Tooltip label={tooltip ?? t`Find and replace`}>
+                      <Button
+                        p="sm"
+                        w="2.5rem"
+                        flex="0 1 auto"
+                        leftSection={<Icon name="find_replace" />}
+                        aria-label={t`Find and replace`}
+                        disabled={isDisabled}
+                        onClick={() => setModalType("replace")}
+                      />
+                    </Tooltip>
+                  )}
+                </PLUGIN_REPLACEMENT.SourceReplacementButton>
+                {isDependencyGraphEnabled && (
+                  <Tooltip label={t`Dependency graph`}>
+                    <Button
+                      component={ForwardRefLink}
+                      to={dependencyGraph({
+                        entry: { id: Number(table.id), type: "table" },
+                      })}
+                      p="sm"
+                      w="2.5rem"
+                      flex="0 1 auto"
+                      leftSection={<Icon name="dependencies" />}
+                      aria-label={t`Dependency graph`}
+                      onClickCapture={registerDependencyGraphTrackingEvent}
+                      onAuxClick={registerDependencyGraphTrackingEvent}
+                    />
+                  </Tooltip>
+                )}
+
+                <Box style={{ flexGrow: 0, width: 40 }}>
+                  <TableLink table={table} />
+                </Box>
+              </Group>
+
+              <TableAttributesEditSingle table={table} onUpdate={onUpdate} />
+
+              <TableSectionGroup title={t`Metadata`}>
+                <TableMetadata table={table} />
+              </TableSectionGroup>
+
+              {table.is_published && <TableCollection table={table} />}
+            </Stack>
+          </Tabs.Panel>
 
           <Tabs.Panel value="field">
             <Stack gap="md">

--- a/frontend/src/metabase/data-studio/data-model/components/TableSection/TableSection.tsx
+++ b/frontend/src/metabase/data-studio/data-model/components/TableSection/TableSection.tsx
@@ -235,7 +235,7 @@ const TableSectionBase = ({
     <Stack data-testid="table-section" gap="md" pb="xl">
       <Box>
         <Tabs value={activeTab} onChange={handleTabChange}>
-          <Tabs.List mb="md">
+          <Tabs.List mb="md" grow>
             <Tabs.Tab
               value="details"
               leftSection={<Icon name="info" />}

--- a/frontend/src/metabase/data-studio/data-model/components/TableSection/tests/setup.tsx
+++ b/frontend/src/metabase/data-studio/data-model/components/TableSection/tests/setup.tsx
@@ -42,7 +42,7 @@ export type SetupOpts = {
 export function setup({
   database = createMockDatabase(),
   table = createMockTable({ db: database }),
-  activeTab = "field",
+  activeTab = "details",
   segments,
   isAdmin = false,
   isDataAnalyst = false,

--- a/frontend/src/metabase/data-studio/data-model/pages/DataModel/DataModel.unit.spec.tsx
+++ b/frontend/src/metabase/data-studio/data-model/pages/DataModel/DataModel.unit.spec.tsx
@@ -67,7 +67,7 @@ const DEFAULT_ROUTE_PARAMS: ParsedRouteParams = {
   databaseId: undefined,
   schemaName: undefined,
   tableId: undefined,
-  tab: "field",
+  tab: "details",
   fieldId: undefined,
 };
 
@@ -265,7 +265,7 @@ async function setup({
         />
         <Redirect
           from="database/:databaseId/schema/:schemaId/table/:tableId"
-          to="database/:databaseId/schema/:schemaId/table/:tableId/field"
+          to="database/:databaseId/schema/:schemaId/table/:tableId/details"
         />
         <Route
           path="database/:databaseId/schema/:schemaId/table/:tableId/:tab"
@@ -385,6 +385,7 @@ describe("DataModel", () => {
         await findTablePickerTable(ORDERS_TABLE.display_name),
       );
       await waitForLoaderToBeRemoved();
+      await clickFieldsTab();
       await clickTableSectionField(ORDERS_DISCOUNT_FIELD.display_name);
       await userEvent.clear(
         getTableSectionFieldNameInput(ORDERS_DISCOUNT_FIELD.display_name),
@@ -403,6 +404,7 @@ describe("DataModel", () => {
         await findTablePickerTable(ORDERS_TABLE.display_name),
       );
       await waitForLoaderToBeRemoved();
+      await clickFieldsTab();
       await clickTableSectionField(ORDERS_DISCOUNT_FIELD.display_name);
       await userEvent.clear(getFieldNameInput());
       await userEvent.tab();
@@ -454,6 +456,7 @@ describe("DataModel", () => {
         await findTablePickerTable(ORDERS_TABLE.display_name),
       );
       await waitForLoaderToBeRemoved();
+      await clickFieldsTab();
       await userEvent.click(screen.getByRole("button", { name: /Sorting/ }));
 
       expect(screen.getByLabelText("Database order")).toBeInTheDocument();
@@ -469,6 +472,7 @@ describe("DataModel", () => {
         await findTablePickerTable(ORDERS_TABLE.display_name),
       );
       await waitForLoaderToBeRemoved();
+      await clickFieldsTab();
       await clickTableSectionField(ORDERS_DISCOUNT_FIELD.display_name);
 
       await userEvent.click(getFieldVisibilityInput());
@@ -486,6 +490,7 @@ describe("DataModel", () => {
         await findTablePickerTable(ORDERS_TABLE.display_name),
       );
       await waitForLoaderToBeRemoved();
+      await clickFieldsTab();
       await clickTableSectionField(ORDERS_DISCOUNT_FIELD.display_name);
 
       const input = getFieldSemanticTypeInput();
@@ -508,6 +513,7 @@ describe("DataModel", () => {
         await findTablePickerTable(ORDERS_TABLE.display_name),
       );
       await waitForLoaderToBeRemoved();
+      await clickFieldsTab();
       await clickTableSectionField(ORDERS_PRODUCT_ID_FIELD.display_name);
 
       const input = getFieldSemanticTypeFkTargetInput();
@@ -532,6 +538,7 @@ describe("DataModel", () => {
         await findTablePickerTable(ORDERS_TABLE.display_name),
       );
       await waitForLoaderToBeRemoved();
+      await clickFieldsTab();
       await clickTableSectionField(ORDERS_USER_ID_FIELD.display_name);
 
       const input = getFieldSemanticTypeFkTargetInput();
@@ -547,6 +554,7 @@ describe("DataModel", () => {
         await findTablePickerTable(ORDERS_TABLE.display_name),
       );
       await waitForLoaderToBeRemoved();
+      await clickFieldsTab();
       await clickTableSectionField(ORDERS_ID_FIELD.display_name);
 
       expect(
@@ -561,6 +569,7 @@ describe("DataModel", () => {
         await findTablePickerTable(ORDERS_TABLE.display_name),
       );
       await waitForLoaderToBeRemoved();
+      await clickFieldsTab();
       await clickTableSectionField(ORDERS_DISCOUNT_FIELD.display_name);
 
       const currencyInput = within(getFieldSection()).getByPlaceholderText(
@@ -587,6 +596,7 @@ describe("DataModel", () => {
         await findTablePickerTable(ORDERS_TABLE.display_name),
       );
       await waitForLoaderToBeRemoved();
+      await clickFieldsTab();
       await clickTableSectionField(ORDERS_ID_FIELD.display_name);
 
       expect(
@@ -675,6 +685,8 @@ describe("DataModel", () => {
 
       expect(getTableNameInput()).toBeInTheDocument();
       expect(getTableNameInput()).toHaveValue(JSON_TABLE.display_name);
+
+      await clickFieldsTab();
 
       expect(
         getTableSectionFieldNameInput(JSON_FIELD_ROOT.display_name),
@@ -1096,6 +1108,10 @@ async function findTablePickerItem(
 }
 
 /** table section helpers */
+
+async function clickFieldsTab() {
+  await userEvent.click(screen.getByRole("tab", { name: /Fields/ }));
+}
 
 function getTableSection() {
   return screen.getByTestId("table-section");

--- a/frontend/src/metabase/data-studio/data-model/pages/DataModel/constants.ts
+++ b/frontend/src/metabase/data-studio/data-model/pages/DataModel/constants.ts
@@ -8,7 +8,7 @@ export const COLUMN_CONFIG: Record<Column, ColumnSizeConfig> = {
   },
   table: {
     flex: "4 1 0",
-    min: 400,
+    min: 450,
     max: "100%",
   },
   field: {

--- a/frontend/src/metabase/data-studio/data-model/pages/DataModel/utils.ts
+++ b/frontend/src/metabase/data-studio/data-model/pages/DataModel/utils.ts
@@ -11,7 +11,7 @@ export function parseRouteParams(params: RouteParams): ParsedRouteParams {
       ? getSchemaName(params.schemaId)
       : params.schemaId,
     tableId: Urls.extractEntityId(params.tableId),
-    tab: isDataStudioTableMetadataTab(params.tab) ? params.tab : "field",
+    tab: isDataStudioTableMetadataTab(params.tab) ? params.tab : "details",
     fieldId: Urls.extractEntityId(params.fieldId),
   };
 }

--- a/frontend/src/metabase/data-studio/data-model/routes.tsx
+++ b/frontend/src/metabase/data-studio/data-model/routes.tsx
@@ -71,6 +71,10 @@ export function getDataStudioMetadataRoutes() {
           <IndexRoute component={PLUGIN_DEPENDENCIES.DependencyGraphPage} />
         </Route>
       )}
+      <Redirect
+        from="database/:databaseId/schema/:schemaId/table/:tableId"
+        to="database/:databaseId/schema/:schemaId/table/:tableId/details"
+      />
       <Route
         path="database/:databaseId/schema/:schemaId/table/:tableId/:tab"
         component={DataModel}
@@ -81,15 +85,7 @@ export function getDataStudioMetadataRoutes() {
       />
       <Redirect
         from="database/:databaseId/schema/:schemaId/table/:tableId/settings"
-        to="database/:databaseId/schema/:schemaId/table/:tableId/field"
-      />
-      <Redirect
-        from="database/:databaseId/schema/:schemaId/table/:tableId/field/:fieldId/:section"
-        to="database/:databaseId/schema/:schemaId/table/:tableId/field/:fieldId"
-      />
-      <Redirect
-        from="database/:databaseId/schema/:schemaId/table/:tableId/settings"
-        to="database/:databaseId/schema/:schemaId/table/:tableId/field"
+        to="database/:databaseId/schema/:schemaId/table/:tableId/details"
       />
       <Redirect
         from="database/:databaseId/schema/:schemaId/table/:tableId/field/:fieldId/:section"

--- a/frontend/src/metabase/lib/urls/data-studio.ts
+++ b/frontend/src/metabase/lib/urls/data-studio.ts
@@ -26,6 +26,7 @@ function getQueryString({ collectionId }: OptionalParams) {
 }
 
 export const DATA_STUDIO_TABLE_METADATA_TABS = [
+  "details",
   "field",
   "segments",
   "measures",

--- a/frontend/src/metabase/ui/components/inputs/TextInputBlurChange/TextInputBlurChange.tsx
+++ b/frontend/src/metabase/ui/components/inputs/TextInputBlurChange/TextInputBlurChange.tsx
@@ -35,8 +35,12 @@ export function TextInputBlurChange<T extends TextInputProps = TextInputProps>({
 }: TextInputBlurChangeProps<T>) {
   const [internalValue, setInternalValue] = useState<T["value"]>("");
   const ref = useRef<HTMLInputElement>(null);
+  const blurChangeFiredRef = useRef(false);
 
-  useLayoutEffect(() => setInternalValue(value), [value]);
+  useLayoutEffect(() => {
+    setInternalValue(value);
+    blurChangeFiredRef.current = false;
+  }, [value]);
 
   const handleChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
@@ -55,6 +59,7 @@ export function TextInputBlurChange<T extends TextInputProps = TextInputProps>({
       onBlur?.(event);
 
       if (onBlurChange && String(value ?? "") !== event.target.value) {
+        blurChangeFiredRef.current = true;
         onBlurChange(event);
         setInternalValue(normalize(event.target.value) ?? undefined);
       }
@@ -73,6 +78,10 @@ export function TextInputBlurChange<T extends TextInputProps = TextInputProps>({
   );
 
   useUnmountLayout(() => {
+    if (blurChangeFiredRef.current) {
+      return;
+    }
+
     const lastPropsValue = String(value ?? "");
     const currentValue = ref.current?.value || "";
 

--- a/frontend/src/metabase/ui/components/inputs/TextareaBlurChange/TextareaBlurChange.tsx
+++ b/frontend/src/metabase/ui/components/inputs/TextareaBlurChange/TextareaBlurChange.tsx
@@ -36,8 +36,12 @@ export function TextareaBlurChange<T extends TextareaProps = TextareaProps>({
 }: TextareaBlurChangeProps<T>) {
   const [internalValue, setInternalValue] = useState<T["value"]>("");
   const ref = useRef<HTMLTextAreaElement>(null);
+  const blurChangeFiredRef = useRef(false);
 
-  useLayoutEffect(() => setInternalValue(value), [value]);
+  useLayoutEffect(() => {
+    setInternalValue(value);
+    blurChangeFiredRef.current = false;
+  }, [value]);
 
   const handleChange = useCallback(
     (event: ChangeEvent<HTMLTextAreaElement>) => {
@@ -56,6 +60,7 @@ export function TextareaBlurChange<T extends TextareaProps = TextareaProps>({
       onBlur?.(event);
 
       if (onBlurChange && String(value ?? "") !== event.target.value) {
+        blurChangeFiredRef.current = true;
         onBlurChange(event);
         setInternalValue(normalize(event.target.value) ?? undefined);
       }
@@ -74,6 +79,10 @@ export function TextareaBlurChange<T extends TextareaProps = TextareaProps>({
   );
 
   useUnmountLayout(() => {
+    if (blurChangeFiredRef.current) {
+      return;
+    }
+
     const lastPropsValue = String(value ?? "");
     const currentValue = ref.current?.value || "";
 


### PR DESCRIPTION
Closes UXW-3500

### Description
Adds a new details tab to the Table Section in the data picker, which essentially contains everything above the Field / Segment / Measures tabs in the old layout. Tests were adjusted to accomodate the change (some tests require clicking the field tab now so that they're available), and the details tab is now the default tab when opening the table section (instead of field). One note is that the min width of the section was increased to prevent the tabs from wrapping

### How to verify
1. Go to Data Studio -> Data Structure -> Click on a table
2. Experience the joy of a well organized panel

### Demo

<img width="1314" height="938" alt="image" src="https://github.com/user-attachments/assets/a6e8ae96-2a2b-4600-8d62-247dd77e47fb" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR