### PR TITLE
Rename Data Structure to Tables

### DIFF
--- a/frontend/src/metabase/data-studio/app/pages/DataSectionLayout/DataSectionLayout.tsx
+++ b/frontend/src/metabase/data-studio/app/pages/DataSectionLayout/DataSectionLayout.tsx
@@ -10,7 +10,7 @@ type DataSectionLayoutProps = {
 };
 
 export function DataSectionLayout({ children }: DataSectionLayoutProps) {
-  usePageTitle(t`Data structure`);
+  usePageTitle(t`Tables`);
 
   return <SectionLayout>{children}</SectionLayout>;
 }

--- a/frontend/src/metabase/data-studio/app/pages/DataStudioLayout/DataStudioLayout.tsx
+++ b/frontend/src/metabase/data-studio/app/pages/DataStudioLayout/DataStudioLayout.tsx
@@ -136,7 +136,7 @@ function DataStudioNav({ isNavbarOpened, onNavbarToggle }: DataStudioNavProps) {
 
           {canAccessDataModel && (
             <DataStudioTab
-              label={t`Data structure`}
+              label={t`Tables`}
               icon="open_folder"
               to={Urls.dataStudioData()}
               isSelected={currentTab === "data"}

--- a/frontend/src/metabase/data-studio/app/pages/DataStudioLayout/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/data-studio/app/pages/DataStudioLayout/tests/common.unit.spec.tsx
@@ -23,7 +23,7 @@ describe("DataStudioLayout", () => {
         expect(screen.getByTestId("data-studio-nav")).toBeInTheDocument();
       });
 
-      expect(screen.getByText("Data structure")).toBeInTheDocument();
+      expect(screen.getByText("Tables")).toBeInTheDocument();
     });
 
     it("should render content area", async () => {

--- a/frontend/src/metabase/data-studio/data-model/pages/DataModel/DataModel.tsx
+++ b/frontend/src/metabase/data-studio/data-model/pages/DataModel/DataModel.tsx
@@ -192,7 +192,7 @@ function DataModelContent({ params }: Props) {
       >
         <PaneHeader
           breadcrumbs={
-            <DataStudioBreadcrumbs>{t`Data structure`}</DataStudioBreadcrumbs>
+            <DataStudioBreadcrumbs>{t`Tables`}</DataStudioBreadcrumbs>
           }
         />
         <RouterTablePicker


### PR DESCRIPTION
### Description

Small PR that changes the name of "Data Structure" to "Tables" in Data Studio. This should only affect the Data Studio nav sidebar, breadcrumb on the Table Picker page, and page title in the browser.

### How to verify

1. Open up Data Studio
2. Click "Tables" in the side nav
3. All 3 places should say Tables

### Demo

<img width="1171" height="1056" alt="image" src="https://github.com/user-attachments/assets/1d8cf3a0-9edd-431e-a2af-974ecbff5d54" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR (A test was updated that covers the navbar change)
