### PR TITLE
Fix sync_schema silently dropping when executor is busy (GHY-3254)

### DIFF
--- a/src/metabase/util/quick_task.clj
+++ b/src/metabase/util/quick_task.clj
@@ -4,6 +4,8 @@
   (:require
    [clojure.string :as str]
    [metabase.classloader.core :as classloader]
+   [metabase.config.core :as config]
+   [metabase.util :as u]
    [metabase.util.log :as log])
   (:import
    (java.util.concurrent Callable Executors ExecutorService Future FutureTask ThreadFactory TimeUnit TimeoutException)))
@@ -22,17 +24,11 @@
 (defonce ^:private executor
   (delay (Executors/newFixedThreadPool 1 ^ThreadFactory thread-factory)))
 
-(def ^:private default-task-timeout-minutes 120)
-
 (defn task-timeout-ms
   "Returns the task timeout in milliseconds. Reads from the `MB_QUICK_TASK_TIMEOUT_MINUTES` env var,
    defaulting to 120 minutes (2 hours)."
   []
-  (let [env-val (System/getenv "MB_QUICK_TASK_TIMEOUT_MINUTES")]
-    (* (long (if (some? env-val)
-               (parse-long env-val)
-               default-task-timeout-minutes))
-       60 1000)))
+  (u/minutes->ms (or (config/config-int :mb-quick-task-timeout-minutes) 120)))
 
 (defn submit-task!
   "Submit a task to the single thread executor. Each task is run on a separate thread with a timeout

--- a/src/metabase/util/quick_task.clj
+++ b/src/metabase/util/quick_task.clj
@@ -2,9 +2,11 @@
   "Namespace with helpers for quick tasks. Intended for quick, one-off tasks like re-syncing a table,
   fingerprinting a field, etc."
   (:require
-   [metabase.classloader.core :as classloader])
+   [clojure.string :as str]
+   [metabase.classloader.core :as classloader]
+   [metabase.util.log :as log])
   (:import
-   (java.util.concurrent Callable Executors ExecutorService Future ThreadFactory)))
+   (java.util.concurrent Callable Executors ExecutorService Future FutureTask ThreadFactory TimeUnit TimeoutException)))
 
 (set! *warn-on-reflection* true)
 
@@ -20,10 +22,32 @@
 (defonce ^:private executor
   (delay (Executors/newFixedThreadPool 1 ^ThreadFactory thread-factory)))
 
+(def ^:dynamic *task-timeout-ms*
+  "Maximum time in milliseconds a quick-task is allowed to run before being cancelled.
+   Default is 2 hours."
+  (* 2 60 60 1000))
+
 (defn submit-task!
-  "Submit a task to the single thread executor. This will attempt to serialize repeated requests to sync tables. It
-  obviously cannot work across multiple instances."
+  "Submit a task to the single thread executor. Each task is run on a separate thread with a timeout
+   of [[*task-timeout-ms*]]. If a task exceeds the timeout, it is cancelled and the executor moves on
+   to the next queued task. This prevents a single stuck task from blocking all subsequent tasks."
   ^Future [^Callable f]
   {:pre [(some? f)]}
-  (let [task (bound-fn* f)]
-    (.submit ^ExecutorService @executor ^Callable task)))
+  (let [timeout-ms (long *task-timeout-ms*)
+        task       (bound-fn* f)
+        wrapped    (fn []
+                     (let [fut (FutureTask. ^Callable task)
+                           t   (.newThread ^ThreadFactory thread-factory ^Runnable fut)]
+                       (.start t)
+                       (try
+                         (.get fut timeout-ms TimeUnit/MILLISECONDS)
+                         (catch TimeoutException _
+                           (log/warnf "quick-task exceeded timeout of %d ms, cancelling. Stuck thread stack trace:\n%s"
+                                      timeout-ms
+                                      (str/join "\n" (map #(str "  " %) (.getStackTrace t))))
+                           (.cancel fut true))
+                         (catch InterruptedException _
+                           (.interrupt (Thread/currentThread)))
+                         (catch Exception e
+                           (log/warn e "quick-task threw exception")))))]
+    (.submit ^ExecutorService @executor ^Callable wrapped)))

--- a/src/metabase/util/quick_task.clj
+++ b/src/metabase/util/quick_task.clj
@@ -22,18 +22,26 @@
 (defonce ^:private executor
   (delay (Executors/newFixedThreadPool 1 ^ThreadFactory thread-factory)))
 
-(def ^:dynamic *task-timeout-ms*
-  "Maximum time in milliseconds a quick-task is allowed to run before being cancelled.
-   Default is 2 hours."
-  (* 2 60 60 1000))
+(def ^:private default-task-timeout-minutes 120)
+
+(defn task-timeout-ms
+  "Returns the task timeout in milliseconds. Reads from the `MB_QUICK_TASK_TIMEOUT_MINUTES` env var,
+   defaulting to 120 minutes (2 hours)."
+  []
+  (let [env-val (System/getenv "MB_QUICK_TASK_TIMEOUT_MINUTES")]
+    (* (long (if (some? env-val)
+               (parse-long env-val)
+               default-task-timeout-minutes))
+       60 1000)))
 
 (defn submit-task!
   "Submit a task to the single thread executor. Each task is run on a separate thread with a timeout
-   of [[*task-timeout-ms*]]. If a task exceeds the timeout, it is cancelled and the executor moves on
-   to the next queued task. This prevents a single stuck task from blocking all subsequent tasks."
+   controlled by the `MB_QUICK_TASK_TIMEOUT_MINUTES` env var (default 120 minutes). If a task exceeds
+   the timeout, it is cancelled and the executor moves on to the next queued task. This prevents a
+   single stuck task from blocking all subsequent tasks."
   ^Future [^Callable f]
   {:pre [(some? f)]}
-  (let [timeout-ms (long *task-timeout-ms*)
+  (let [timeout-ms (long (task-timeout-ms))
         task       (bound-fn* f)
         wrapped    (fn []
                      (let [fut (FutureTask. ^Callable task)

--- a/test/metabase/warehouses_rest/api_test.clj
+++ b/test/metabase/warehouses_rest/api_test.clj
@@ -47,6 +47,7 @@
    [toucan2.core :as t2])
   (:import
    (java.sql Connection)
+   (java.util.concurrent CountDownLatch)
    (org.quartz JobDetail TriggerKey)))
 
 (set! *warn-on-reflection* true)
@@ -1513,6 +1514,26 @@
                 (is (=?
                      {"event" "database_manual_sync", "target_id" db-id}
                      (:data (last (snowplow-test/pop-event-data-and-user-id!)))))))))))))
+
+(deftest sync-schema-executes-when-executor-busy-test
+  (testing "POST /api/database/:id/sync_schema should execute sync even when quick-task executor is busy (GHY-3254)"
+    (let [sync-called?  (promise)
+          blocker-latch (CountDownLatch. 1)]
+      (mt/with-temp [:model/Database {db-id :id} {:engine "h2" :details (:details (mt/db))}]
+        (with-redefs [sync-metadata/sync-db-metadata! (deliver-when-db sync-called? db-id)
+                      analyze/analyze-db!             (constantly nil)]
+          ;; Block the quick-task executor's single thread with a long-running task.
+          ;; This simulates a stuck sync (e.g., hanging JDBC connection).
+          (quick-task/submit-task! (fn [] (.await blocker-latch)))
+          (try
+            (mt/user-http-request :crowberto :post 200 (format "database/%d/sync_schema" db-id))
+            ;; The sync task is now queued behind the blocker. It should still execute
+            ;; within a reasonable time. Currently it won't because the executor has only
+            ;; one thread, so this test will fail with :sync-never-called.
+            (testing "sync should still execute within reasonable time"
+              (is (true? (deref sync-called? 5000 :sync-never-called))))
+            (finally
+              (.countDown blocker-latch))))))))
 
 (deftest ^:parallel dismiss-spinner-test
   (testing "Can we dismiss the spinner? (#20863)"

--- a/test/metabase/warehouses_rest/api_test.clj
+++ b/test/metabase/warehouses_rest/api_test.clj
@@ -1522,16 +1522,17 @@
       (mt/with-temp [:model/Database {db-id :id} {:engine "h2" :details (:details (mt/db))}]
         (with-redefs [sync-metadata/sync-db-metadata! (deliver-when-db sync-called? db-id)
                       analyze/analyze-db!             (constantly nil)]
-          ;; Block the quick-task executor's single thread with a long-running task.
-          ;; This simulates a stuck sync (e.g., hanging JDBC connection).
-          (quick-task/submit-task! (fn [] (.await blocker-latch)))
+          ;; Submit a blocking task with a short timeout so it gets cancelled quickly.
+          ;; This simulates a stuck sync (e.g., hanging JDBC connection) that exceeds
+          ;; the quick-task timeout and gets evicted.
+          (binding [quick-task/*task-timeout-ms* 1000]
+            (quick-task/submit-task! (fn [] (.await blocker-latch))))
           (try
             (mt/user-http-request :crowberto :post 200 (format "database/%d/sync_schema" db-id))
-            ;; The sync task is now queued behind the blocker. It should still execute
-            ;; within a reasonable time. Currently it won't because the executor has only
-            ;; one thread, so this test will fail with :sync-never-called.
-            (testing "sync should still execute within reasonable time"
-              (is (true? (deref sync-called? 5000 :sync-never-called))))
+            ;; The sync task is queued behind the blocker. After the blocker times out
+            ;; and is cancelled, the sync task should execute.
+            (testing "sync executes after stuck task is evicted"
+              (is (true? (deref sync-called? 10000 :sync-never-called))))
             (finally
               (.countDown blocker-latch))))))))
 

--- a/test/metabase/warehouses_rest/api_test.clj
+++ b/test/metabase/warehouses_rest/api_test.clj
@@ -1522,10 +1522,10 @@
       (mt/with-temp [:model/Database {db-id :id} {:engine "h2" :details (:details (mt/db))}]
         (with-redefs [sync-metadata/sync-db-metadata! (deliver-when-db sync-called? db-id)
                       analyze/analyze-db!             (constantly nil)]
-          ;; Submit a blocking task with a short timeout so it gets cancelled quickly.
+          ;; Submit a blocking task with a 1-second timeout so it gets cancelled quickly.
           ;; This simulates a stuck sync (e.g., hanging JDBC connection) that exceeds
           ;; the quick-task timeout and gets evicted.
-          (binding [quick-task/*task-timeout-ms* 1000]
+          (with-redefs [quick-task/task-timeout-ms (constantly 1000)]
             (quick-task/submit-task! (fn [] (.await blocker-latch))))
           (try
             (mt/user-http-request :crowberto :post 200 (format "database/%d/sync_schema" db-id))


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #70628
## Summary

Fixes [GHY-3254](https://linear.app/metabase/issue/GHY-3254): `POST /api/database/:id/sync_schema` returns 200 but no sync executes.

### Root cause

The `sync_schema` endpoint submits work to a single-threaded executor (`quick-task/submit-task!`) and immediately returns 200. If any previous task in that executor hangs (e.g., a stuck JDBC connection), all subsequent manual sync requests queue forever — silently dropped from the user's perspective.

This executor is shared by 14 different call sites (manual sync, field value rescans, table sync, database health checks, etc.), so a single stuck task blocks everything.

This explains all reported symptoms:
- **Affects ALL databases** (including Sample Database) — the executor is a global singleton, not per-DB
- **Restart fixes temporarily** — fresh JVM means fresh thread pool
- **Workaround (modifying sync schedule) works** — scheduled syncs use Quartz's own thread pool, bypassing `quick-task` entirely
- **No errors in logs** — the task is successfully queued, it just never executes

### Fix

Each task submitted to the quick-task executor now runs on a child thread with a configurable timeout (`*task-timeout-ms*`, default 2 hours). If a task exceeds the timeout, it is cancelled and the executor moves on to the next queued task.

The stuck thread's stack trace is logged at WARN level so operators can diagnose the underlying cause.

Note: `Thread.interrupt()` won't terminate a thread stuck in classic socket I/O (e.g., JDBC reads), but those calls already have a 30-minute network timeout via `Connection.setNetworkTimeout`. The per-task timeout here is a safety net for any case where an individual task hangs beyond what's reasonable.

### Other possible fixes

Timing out tasks is an important safety net. However, this does not address the root cause, which is whatever is being stuck. There are 13 operations that share this queue.

  1. warehouses_rest/api.clj — manual sync (sync_schema endpoint)                                                                                                                                                                                                            
  2. warehouses_rest/api.clj — rescan field values                                                                                                                                                                                                                           
  3. warehouses/models/database.clj — health check + details migration                                                                                                                                                                                                       
  4. warehouse_schema_rest/api/table.clj — sync unhidden tables                                                                                                                                                                                                              
  5. warehouse_schema_rest/api/table.clj — rescan field values for table                                                                                                                                                                                                     
  6. warehouse_schema_rest/api/table.clj — sync table schema                                                                                                                                                                                                                 
  7. warehouse_schema_rest/api/field.clj — sync table for JSON unfolding                                                                                                                                                                                                     
  8. warehouse_schema_rest/api/field.clj — refingerprint after type change                                                                                                                                                                                                   
  9. sync/events/sync_database.clj — sync on database creation                                                                                                                                                                                                               
  10. data_studio/api/table.clj — sync table schema (data studio)                                                                                                                                                                                                            
  11. data_studio/api/table.clj — rescan field values (data studio)                                                                                                                                                                                                          
  12. metabase_enterprise/workspaces/common.clj — workspace setup                                                                                                                                                                                                            
  13. metabase_enterprise/advanced_config/file/databases.clj — sync from config file                                                                                                                                                                                         

  
The actual root cause could be in any of them. Anything that never returns (or takes a very long time), could block this queue. 

Another idea is to have separate queues.