### PR TITLE
[BOT-1247] Fix empty string content blocks in anthropic API

### DIFF
--- a/src/metabase/metabot/agent/core.clj
+++ b/src/metabase/metabot/agent/core.clj
@@ -584,6 +584,10 @@
                     result))
                 (catch Exception e
                   (prometheus/inc! :metabase-metabot/agent-errors labels)
+                  (when (:api-error (ex-data e))
+                    (log/debugf "API error details: status=%s body=%s"
+                                (:status (ex-data e))
+                                (pr-str (:body (ex-data e)))))
                   (if (:api-error (ex-data e))
                     (log/errorf "Agent loop API error: %s" (ex-message e))
                     (log/error e "Agent loop error"))

--- a/src/metabase/metabot/self/claude.clj
+++ b/src/metabase/metabot/self/claude.clj
@@ -118,9 +118,10 @@
 (defn- ->content-blocks
   "Coerce content into a sequence of Claude content blocks."
   [content]
-  (if (and (string? content) (not (str/blank? content)))
-    [{:type "text" :text content}]
-    content))
+  (cond
+    (and (string? content) (str/blank? content)) []
+    (string? content) [{:type "text" :text content}]
+    :else content))
 
 (defn- merge-consecutive
   "Merge consecutive assistant messages into a single message with combined content.

--- a/test/metabase/metabot/self/claude_test.clj
+++ b/test/metabase/metabot/self/claude_test.clj
@@ -128,3 +128,23 @@
                          :content #"Error:.*failed"}]}]
             (claude/parts->claude-messages
              [{:type :tool-output :id "call-1" :error {:message "Tool failed"}}])))))
+
+(deftest ^:parallel parts->claude-messages-blank-content-test
+  (testing "blank string content is filtered out during merge"
+    ;; When Claude streams tokens, whitespace-only chunks can arrive separately.
+    ;; These must not become bare strings in the content array (which would cause
+    ;; API errors), so they are dropped during merge-consecutive.
+    (is (=? [{:role    "assistant"
+              :content [{:type "text" :text "Hello"}
+                        {:type "text" :text "world"}]}]
+            (claude/parts->claude-messages
+             [{:type :text :text "Hello"}
+              {:type :text :text " "}
+              {:type :text :text "world"}]))))
+  (testing "empty string content is also filtered out"
+    (is (=? [{:role    "assistant"
+              :content [{:type "text" :text "Hello"}]}]
+            (claude/parts->claude-messages
+             [{:type :text :text ""}
+              {:type :text :text "Hello"}
+              {:type :text :text ""}])))))


### PR DESCRIPTION
Closes BOT-1247

Intermittent 400 errors from Anthropic API with message "messages.X.content.Y: Input should be a valid dictionary or object to extract fields from", resulting in elevated hesitation rates in benchmarks. See [slack](https://metaboat.slack.com/archives/C07SJT1P0ET/p1774976848499229)

In claude.clj, the ->content-blocks function returned blank strings (e.g., " ") as-is instead of wrapping them in a text block. When Claude streamed a whitespace-only token, it became a raw string in the content array. Clojure's mapcat then iterated over the string's characters, placing a bare Character into the array. When JSON-encoded and sent on subsequent API calls, this violated the API contract requiring all content array elements to be objects.

Post fix:
```bash
(ai) tplude ~ time poetry run python -m benchmarks.end_2_end.benchmarks.canonical_benchmark --profile nlq --sample 0.5 --seed 1337
Running 8 benchmarks with 91 total cases (sample: 50.0% sample ; seed: 1337) | Profile: nlq

Starting benchmark: NLQ Tables - Aggregations (no context)
Starting benchmark: NLQ Tables - Categorical filters (no context)
Starting benchmark: NLQ Tables - Numeric filters (no context)
Starting benchmark: NLQ Tables - Temporal filters (no context)
Starting benchmark: NLQ Tables - Grouping (no context)
Starting benchmark: NLQ Tables - Sorting and Limits (no context)
Starting benchmark: NLQ Tables - Complex Combined Queries (no context)
Running Benchmarks:  75%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████▊                                      | 6/8 [03:52<01:14, 37.20s/benchmarkERROR:benchmarks.end_2_end.test_case:Test case E2EAgentTestCase_ecf78ebf4ce9 timed out after 300 seconds                                                                                        | 0/7 [00:00<?, ?case/s]
ERROR:benchmarks.end_2_end.test_case:Error running test case E2EAgentTestCase_ecf78ebf4ce9: Test case timed out after 300 seconds
Starting benchmark: NLQ Tables - Measures and Segments (no context)
Running Benchmarks: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 8/8 [06:14<00:00, 46.81s/benchmark]
################# Benchmark Results #################
| benchmark                                          | score         | passing_rate   | hallucination_rate   | hesitation_rate   |   token_usage |   costs |   avg_duration |
|:---------------------------------------------------|:--------------|:---------------|:---------------------|:------------------|--------------:|--------:|---------------:|
| NLQ Tables - Aggregations (no context)             | 94% (85/90)   | 67% (10/15)    | 6% (5/90)            | 0% (0/90)         |       1259024 |       0 |          25.13 |
| NLQ Tables - Categorical filters (no context)      | 96% (111/116) | 74% (14/19)    | 4% (5/114)           | 0% (0/114)        |       1832374 |       0 |          29.26 |
| NLQ Tables - Complex Combined Queries (no context) | 83% (35/42)   | 71% (5/7)      | 3% (1/36)            | 0% (0/36)         |        578359 |       0 |          25.71 |
| NLQ Tables - Grouping (no context)                 | 97% (76/78)   | 85% (11/13)    | 3% (2/78)            | 0% (0/78)         |       1159647 |       0 |          27.23 |
| NLQ Tables - Measures and Segments (no context)    | 68% (25/37)   | 0% (0/5)       | 32% (12/37)          | 0% (0/37)         |        467791 |       0 |          29.6  |
| NLQ Tables - Numeric filters (no context)          | 94% (62/66)   | 64% (7/11)     | 6% (4/66)            | 0% (0/66)         |        942307 |       0 |          28.09 |
| NLQ Tables - Sorting and Limits (no context)       | 98% (59/60)   | 90% (9/10)     | 2% (1/60)            | 0% (0/60)         |        801956 |       0 |          23.2  |
| NLQ Tables - Temporal filters (no context)         | 86% (57/66)   | 27% (3/11)     | 14% (9/66)           | 0% (0/66)         |       1020938 |       0 |          30.73 |

Profile ID: nlq
Model: anthropic/claude-haiku-4-5
Sample Size: 91 (sampled 50%)
Seed: 1337
Ran at: 2026-03-31T111224
Duration: 374.47 seconds

Total score: 92% (510/555)
Passing Rate[^1]: 65% (59/91)
Action Hallucination Rate[^2]: 7%
Hesitation Rate[^3]: 0%
Total token usage across all tests: 8062396
Estimated costs: $0.000
Average response duration: 27.37 seconds
```