### PR TITLE
do not suggest city as a geo dimension for tabs with map viz

### DIFF
--- a/e2e/test/scenarios/metrics/metric-page.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/metric-page.cy.spec.ts
@@ -204,15 +204,16 @@ describe("scenarios > metrics > metric page", () => {
       cy.findByText("By Created At").should("exist");
       cy.findByText("By State").should("exist");
       cy.findByText("By Category").should("exist");
-      cy.findByText("By Name").should("exist");
+      cy.findByText("By City").should("exist");
       cy.findAllByText(/^By /).should("have.length", 4);
 
       cy.findByText("Show more").scrollIntoView().click();
 
+      cy.findByText("By Name").should("exist");
       cy.findByText("By Source").should("exist");
       cy.findByText("By Title").should("exist");
       cy.findByText("By Vendor").should("exist");
-      cy.findAllByText(/^By /).should("have.length", 7);
+      cy.findAllByText(/^By /).should("have.length", 8);
     });
   });
 

--- a/frontend/src/metabase/metrics-viewer/utils/__tests__/test-helpers.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/__tests__/test-helpers.ts
@@ -99,6 +99,15 @@ export const GEO_METRIC = createMockNormalizedMetric({
   ],
 });
 
+export const GEO_DIM_IDX = {
+  STATE: 0,
+  COUNTRY: 1,
+  CITY: 2,
+  LATITUDE: 3,
+  LONGITUDE: 4,
+  DATE_TIME: 5,
+};
+
 export function createMetricMetadata(metrics: NormalizedMetric[]): Metadata {
   const metadata = new Metadata();
   metadata.metrics = {};

--- a/frontend/src/metabase/metrics-viewer/utils/geo-dimensions.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/geo-dimensions.ts
@@ -10,8 +10,5 @@ export function getMapRegionForDimension(
   if (LibMetric.isCountry(dimension)) {
     return "world_countries";
   }
-  if (LibMetric.isCity(dimension)) {
-    return "us_states";
-  }
   return null;
 }

--- a/frontend/src/metabase/metrics-viewer/utils/geo-dimensions.unit.spec.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/geo-dimensions.unit.spec.ts
@@ -1,0 +1,51 @@
+import * as LibMetric from "metabase-lib/metric";
+
+import {
+  GEO_DIM_IDX,
+  GEO_METRIC,
+  createMetricMetadata,
+  setupDefinition,
+} from "./__tests__/test-helpers";
+import { getMapRegionForDimension } from "./geo-dimensions";
+
+const metadata = createMetricMetadata([GEO_METRIC]);
+const geoDefinition = setupDefinition(metadata, GEO_METRIC.id);
+const geoDimensions = LibMetric.projectionableDimensions(geoDefinition);
+
+describe("getMapRegionForDimension", () => {
+  it("returns us_states for state dimensions", () => {
+    expect(getMapRegionForDimension(geoDimensions[GEO_DIM_IDX.STATE])).toBe(
+      "us_states",
+    );
+  });
+
+  it("returns world_countries for country dimensions", () => {
+    expect(getMapRegionForDimension(geoDimensions[GEO_DIM_IDX.COUNTRY])).toBe(
+      "world_countries",
+    );
+  });
+
+  it("returns null for city dimensions", () => {
+    expect(
+      getMapRegionForDimension(geoDimensions[GEO_DIM_IDX.CITY]),
+    ).toBeNull();
+  });
+
+  it("returns null for latitude dimensions", () => {
+    expect(
+      getMapRegionForDimension(geoDimensions[GEO_DIM_IDX.LATITUDE]),
+    ).toBeNull();
+  });
+
+  it("returns null for longitude dimensions", () => {
+    expect(
+      getMapRegionForDimension(geoDimensions[GEO_DIM_IDX.LONGITUDE]),
+    ).toBeNull();
+  });
+
+  it("returns null for datetime dimensions", () => {
+    expect(
+      getMapRegionForDimension(geoDimensions[GEO_DIM_IDX.DATE_TIME]),
+    ).toBeNull();
+  });
+});

--- a/frontend/src/metabase/metrics-viewer/utils/tab-config.unit.spec.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/tab-config.unit.spec.ts
@@ -1,6 +1,7 @@
 import * as LibMetric from "metabase-lib/metric";
 
 import {
+  GEO_DIM_IDX,
   GEO_METRIC,
   REVENUE_METRIC,
   createMetricMetadata,
@@ -19,15 +20,6 @@ const REV_DIM_IDX = {
   CATEGORY: 1,
   AMOUNT: 2,
   BOOLEAN: 3,
-};
-
-const GEO_DIM_IDX = {
-  STATE: 0,
-  COUNTRY: 1,
-  CITY: 2,
-  LATITUDE: 3,
-  LONGITUDE: 4,
-  DATE_TIME: 5,
 };
 
 describe("getTabConfig", () => {
@@ -152,6 +144,12 @@ describe("TAB_TYPE_REGISTRY", () => {
       expect(
         geoConfig.dimensionPredicate(geoDimensions[GEO_DIM_IDX.COUNTRY]),
       ).toBe(true);
+    });
+
+    it("geo predicate rejects city dimensions", () => {
+      expect(
+        geoConfig.dimensionPredicate(geoDimensions[GEO_DIM_IDX.CITY]),
+      ).toBe(false);
     });
 
     it("geo predicate rejects latitude dimensions", () => {

--- a/frontend/src/metabase/metrics/common/utils/dimension-types.ts
+++ b/frontend/src/metabase/metrics/common/utils/dimension-types.ts
@@ -3,29 +3,13 @@ import * as LibMetric from "metabase-lib/metric";
 
 export type DimensionType = "time" | "geo" | "category" | "boolean" | "numeric";
 
-export type GeoSubtype = "country" | "state" | "city";
+export type GeoSubtype = "country" | "state";
 
 export function isGeoDimension(dimension: DimensionMetadata): boolean {
-  if (
-    LibMetric.isCoordinate(dimension) ||
-    LibMetric.isLatitude(dimension) ||
-    LibMetric.isLongitude(dimension)
-  ) {
-    return false;
-  }
-
-  return (
-    LibMetric.isState(dimension) ||
-    LibMetric.isCountry(dimension) ||
-    LibMetric.isCity(dimension)
-  );
+  return LibMetric.isState(dimension) || LibMetric.isCountry(dimension);
 }
 
-export const GEO_SUBTYPE_PRIORITY: readonly GeoSubtype[] = [
-  "country",
-  "state",
-  "city",
-];
+export const GEO_SUBTYPE_PRIORITY: readonly GeoSubtype[] = ["country", "state"];
 
 const GEO_SUBTYPE_PREDICATES: Array<{
   subtype: GeoSubtype;
@@ -33,7 +17,6 @@ const GEO_SUBTYPE_PREDICATES: Array<{
 }> = [
   { subtype: "country", predicate: LibMetric.isCountry },
   { subtype: "state", predicate: LibMetric.isState },
-  { subtype: "city", predicate: LibMetric.isCity },
 ];
 
 export function getGeoSubtype(dimension: DimensionMetadata): GeoSubtype | null {


### PR DESCRIPTION
Closes [UXW-3454](https://linear.app/metabase/issue/UXW-3454/do-not-show-region-maps-for-city-fields)

### Description

Cities are wrongly suggested for geo tab with map visualization because there is no built-in map for cities.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [n/a] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
