### PR TITLE
middleware to prevent middleware that hits app-db

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/database_routing/middleware.clj
+++ b/enterprise/backend/src/metabase_enterprise/database_routing/middleware.clj
@@ -8,8 +8,10 @@
    [metabase.driver.util :as driver.u]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.premium-features.core :as premium-features :refer [defenterprise]]
+   [metabase.query-processor.interface :as qp.i]
    ;; legacy usage -- don't do things like this going forward
-   ^{:clj-kondo/ignore [:deprecated-namespace :discouraged-namespace]} [metabase.query-processor.store :as qp.store]
+   ^{:clj-kondo/ignore [:deprecated-namespace :discouraged-namespace]}
+   [metabase.query-processor.store :as qp.store]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]))
 
@@ -39,7 +41,8 @@
   :feature :none
   [query]
   (let [database (lib.metadata/database (qp.store/metadata-provider))
-        destination-db-id (router-db-or-id->destination-db-id database)]
+        destination-db-id (when-not qp.i/*skip-middleware-because-app-db-access*
+                            (router-db-or-id->destination-db-id database))]
     (when destination-db-id
       (premium-features/assert-has-feature :database-routing (tru "Database Routing"))
       (when-not (driver.u/supports? (:engine (lib.metadata/database (qp.store/metadata-provider)))

--- a/enterprise/backend/src/metabase_enterprise/impersonation/middleware.clj
+++ b/enterprise/backend/src/metabase_enterprise/impersonation/middleware.clj
@@ -3,6 +3,7 @@
    [metabase-enterprise.impersonation.driver :as impersonation.driver]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.premium-features.core :as premium-features :refer [defenterprise]]
+   [metabase.query-processor.interface :as qp.i]
    ;; legacy usage -- don't do things like this going forward
    ^{:clj-kondo/ignore [:deprecated-namespace :discouraged-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.util.i18n :refer [tru]]))
@@ -13,8 +14,9 @@
   ;; if impersonation is configured. (Throwing here is better than silently ignoring the configured impersonation.)
   :feature :none
   [query]
-  (if-let [role (impersonation.driver/connection-impersonation-role
-                 (lib.metadata/database (qp.store/metadata-provider)))]
+  (if-let [role (when-not qp.i/*skip-middleware-because-app-db-access*
+                  (impersonation.driver/connection-impersonation-role
+                   (lib.metadata/database (qp.store/metadata-provider))))]
     (do
       (premium-features/assert-has-feature :advanced-permissions (tru "Advanced Permissions"))
       (assoc query :impersonation/role role))

--- a/src/metabase/query_processor/interface.clj
+++ b/src/metabase/query_processor/interface.clj
@@ -13,3 +13,8 @@
   "Should we disable logging for the QP? (e.g., during sync we probably want to turn it off to keep logs less
   cluttered)."
   false)
+
+(def ^:dynamic *skip-middleware-because-app-db-access*
+  "Dynamic variable that skips middleware (when bound to true) because it accesses the app-db. Will be replaced in
+  QUE2-488"
+  false)


### PR DESCRIPTION
currently it is just two middleware: impersonation and db routing

this is necessary as we want to move into a world where we can compile a query from yaml files without an app db file. These middleware are not impportant for our purposes here.

This is also temporary work. This is slated to be fixed up in

[QUE2-488: Introduce an app-db protocol for QP
middleware](https://linear.app/metabase/issue/QUE2-488/introduce-an-app-db-protocol-for-qp-middleware)

