### PR TITLE
support negative numbers in metrics viewer expressions

### DIFF
--- a/frontend/src/metabase-types/api/metric.ts
+++ b/frontend/src/metabase-types/api/metric.ts
@@ -23,11 +23,11 @@ export type Metric = {
   result_column_name?: string;
 };
 
-export type MathOperator = "+" | "-" | "*" | "/";
-export const MATH_OPERATORS: MathOperator[] = ["+", "-", "*", "/"];
+export const MATH_OPERATORS = ["+", "-", "*", "/"] as const;
+export type MathOperator = (typeof MATH_OPERATORS)[number];
 
 export function isMathOperator(key: string): key is MathOperator {
-  return key === "+" || key === "-" || key === "*" || key === "/";
+  return (MATH_OPERATORS as readonly string[]).includes(key);
 }
 
 export type ExpressionRef =

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.ts
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.ts
@@ -509,26 +509,31 @@ export type PositionedToken = (
   | { type: "unknown"; text: string }
 ) & { from: number; to: number };
 
+function isDigit(ch: string | undefined): boolean {
+  return ch !== undefined && ch >= "0" && ch <= "9";
+}
+
+function skipDigits(text: string, index: number): number {
+  while (index < text.length && isDigit(text[index])) {
+    index++;
+  }
+  return index;
+}
+
 function consumeNumber(text: string, startIndex: number): number | null {
   let index = startIndex;
-  if (index >= text.length || text[index] < "0" || text[index] > "9") {
+
+  const startsWithDot = text[index] === "." && isDigit(text[index + 1]);
+  if (!startsWithDot && !isDigit(text[index])) {
     return null;
   }
-  while (index < text.length && text[index] >= "0" && text[index] <= "9") {
-    index++;
+
+  index = skipDigits(text, index);
+
+  if (text[index] === "." && isDigit(text[index + 1])) {
+    index = skipDigits(text, index + 1);
   }
-  if (
-    index < text.length &&
-    text[index] === "." &&
-    index + 1 < text.length &&
-    text[index + 1] >= "0" &&
-    text[index + 1] <= "9"
-  ) {
-    index++;
-    while (index < text.length && text[index] >= "0" && text[index] <= "9") {
-      index++;
-    }
-  }
+
   return index;
 }
 
@@ -609,7 +614,8 @@ export function parseFullTextWithPositions(
       continue;
     }
 
-    if (ch >= "0" && ch <= "9") {
+    const isNumberStart = isDigit(ch) || (ch === "." && isDigit(text[i + 1]));
+    if (isNumberStart) {
       const endIndex = consumeNumber(text, i)!;
       tokens.push({
         type: "constant",
@@ -656,7 +662,7 @@ export function parseFullTextWithPositions(
         if (
           EXPRESSION_DELIMITERS.has(char) ||
           char === " " ||
-          (char >= "0" && char <= "9")
+          isDigit(char)
         ) {
           break;
         }

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.ts
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.ts
@@ -1,6 +1,6 @@
 import { t } from "ttag";
 
-import type { MathOperator } from "metabase-types/api";
+import { MATH_OPERATORS, isMathOperator } from "metabase-types/api";
 
 import type {
   ExpressionSubToken,
@@ -26,7 +26,9 @@ export function buildExpressionForPill(
   for (let i = 0; i < tokens.length; i++) {
     const token = tokens[i];
     const prev = tokens[i - 1];
-    if (i > 0 && prev?.type !== "open-paren" && token.type !== "close-paren") {
+    const needsSpace =
+      i > 0 && prev?.type !== "open-paren" && token.type !== "close-paren";
+    if (needsSpace) {
       curr += " ";
     }
     if (token.type === "open-paren") {
@@ -93,10 +95,12 @@ export function buildFullText(
 
 const COMMA = ",";
 
-const EXPRESSION_DELIMITERS = new Set(["+", "-", "*", "/", "(", ")", COMMA]);
-
-/** Delimiters that are always boundaries (everything except comma). */
-const NON_COMMA_DELIMITERS = new Set(["+", "-", "*", "/", "(", ")"]);
+const PAREN_DELIMITERS = ["(", ")"] as const;
+const NON_COMMA_DELIMITERS = new Set<string>([
+  ...MATH_OPERATORS,
+  ...PAREN_DELIMITERS,
+]);
+const EXPRESSION_DELIMITERS = new Set<string>([...NON_COMMA_DELIMITERS, COMMA]);
 
 /** Returns true for characters that form word continuations (letters, digits, underscore). */
 function isWordChar(ch: string): boolean {
@@ -169,13 +173,15 @@ export function getWordAtCursor(
     // Check if `before` ends with a known metric name
     const beforeLower = before.toLowerCase();
     for (const name of metricNamesLower) {
-      if (
-        beforeLower.endsWith(name) &&
-        (before.length === name.length ||
-          NON_COMMA_DELIMITERS.has(before[before.length - name.length - 1]) ||
-          before[before.length - name.length - 1] === COMMA ||
-          before[before.length - name.length - 1] === " ")
-      ) {
+      const charBeforeName = before[before.length - name.length - 1];
+      const isAtTextStart = before.length === name.length;
+      const hasDelimiterBefore =
+        NON_COMMA_DELIMITERS.has(charBeforeName) ||
+        charBeforeName === COMMA ||
+        charBeforeName === " ";
+      const endsWithMetricName =
+        beforeLower.endsWith(name) && (isAtTextStart || hasDelimiterBefore);
+      if (endsWithMetricName) {
         return true;
       }
     }
@@ -227,10 +233,11 @@ function findSeparatorCommaPositions(
   const metricRanges = allTokens.filter((t) => t.type === "metric");
   const commas: number[] = [];
   for (let i = 0; i < text.length; i++) {
-    if (
-      text[i] === COMMA &&
-      !metricRanges.some((r) => i >= r.from && i < r.to)
-    ) {
+    const isComma = text[i] === COMMA;
+    const isInsideMetricToken = metricRanges.some(
+      (r) => i >= r.from && i < r.to,
+    );
+    if (isComma && !isInsideMetricToken) {
       commas.push(i);
     }
   }
@@ -265,22 +272,20 @@ function groupTokensBySegment(
 
 /** Strip position info from a positioned token, dropping unknown tokens. */
 function stripPositions(token: PositionedToken): ExpressionSubToken | null {
-  if (token.type === "metric") {
-    return { type: "metric", sourceId: token.sourceId, count: 0 };
+  switch (token.type) {
+    case "metric":
+      return { type: "metric", sourceId: token.sourceId, count: 0 };
+    case "operator":
+      return { type: "operator", op: token.op };
+    case "constant":
+      return { type: "constant", value: token.value };
+    case "open-paren":
+      return { type: "open-paren" };
+    case "close-paren":
+      return { type: "close-paren" };
+    case "unknown":
+      return null;
   }
-  if (token.type === "operator") {
-    return { type: "operator", op: token.op };
-  }
-  if (token.type === "constant") {
-    return { type: "constant", value: token.value };
-  }
-  if (token.type === "open-paren") {
-    return { type: "open-paren" };
-  }
-  if (token.type === "unknown") {
-    return null;
-  }
-  return { type: "close-paren" };
 }
 
 /**
@@ -479,10 +484,9 @@ export function validateExpression(
         return t`Operator right after opening parenthesis`;
       }
     }
-    if (
-      token.type === "close-paren" &&
-      prevSignificant?.type === "open-paren"
-    ) {
+    const isEmptyParens =
+      token.type === "close-paren" && prevSignificant?.type === "open-paren";
+    if (isEmptyParens) {
       return t`Empty parentheses`;
     }
     prevSignificant = token;
@@ -559,7 +563,8 @@ export function parseFullTextWithPositions(
   while (i < text.length) {
     const ch = text[i];
 
-    if (ch === " " || ch === "\t") {
+    const isWhitespace = ch === " " || ch === "\t";
+    if (isWhitespace) {
       i++;
       continue;
     }
@@ -583,7 +588,7 @@ export function parseFullTextWithPositions(
       continue;
     }
 
-    if (ch === "+" || ch === "-" || ch === "*" || ch === "/") {
+    if (isMathOperator(ch)) {
       const lastToken = tokens.length > 0 ? tokens[tokens.length - 1] : null;
       const isUnaryContext =
         lastToken === null ||
@@ -606,7 +611,7 @@ export function parseFullTextWithPositions(
 
       tokens.push({
         type: "operator",
-        op: ch as MathOperator,
+        op: ch,
         from: i,
         to: i + 1,
       });
@@ -634,11 +639,9 @@ export function parseFullTextWithPositions(
         const nextCh = text[nextI];
         // Accept the match unless the next character continues an
         // alphanumeric word (e.g. "Revenue" inside "Revenues").
-        if (
-          !nextCh ||
-          !isWordChar(nextCh) ||
-          !isWordChar(name[name.length - 1])
-        ) {
+        const isWordBoundary =
+          !nextCh || !isWordChar(nextCh) || !isWordChar(name[name.length - 1]);
+        if (isWordBoundary) {
           tokens.push({
             type: "metric",
             sourceId,
@@ -659,11 +662,9 @@ export function parseFullTextWithPositions(
       i++;
       while (i < text.length) {
         const char = text[i];
-        if (
-          EXPRESSION_DELIMITERS.has(char) ||
-          char === " " ||
-          isDigit(char)
-        ) {
+        const isTokenBoundary =
+          EXPRESSION_DELIMITERS.has(char) || char === " " || isDigit(char);
+        if (isTokenBoundary) {
           break;
         }
         // Check if a metric name starts here — if so, stop the unknown span
@@ -672,11 +673,11 @@ export function parseFullTextWithPositions(
           if (lower.startsWith(name, i)) {
             const nameEndIndex = i + name.length;
             const afterNameChar = text[nameEndIndex];
-            if (
+            const isMetricBoundary =
               !afterNameChar ||
               afterNameChar === " " ||
-              EXPRESSION_DELIMITERS.has(afterNameChar)
-            ) {
+              EXPRESSION_DELIMITERS.has(afterNameChar);
+            if (isMetricBoundary) {
               metricStartsHere = true;
               break;
             }
@@ -829,15 +830,17 @@ export function filterSearchResults<T extends SearchResultLike>(
   selectedMeasureIds: Set<number>,
   excludeMetric?: ExcludeMetric,
 ): T[] {
-  return results.filter(
-    (result) =>
-      (result.model === "metric"
-        ? !selectedMetricIds.has(result.id)
-        : !selectedMeasureIds.has(result.id)) &&
-      (!excludeMetric ||
-        result.id !== excludeMetric.id ||
-        result.model !== excludeMetric.sourceType),
-  );
+  return results.filter((result) => {
+    const isAlreadySelected =
+      result.model === "metric"
+        ? selectedMetricIds.has(result.id)
+        : selectedMeasureIds.has(result.id);
+    const isExcluded =
+      excludeMetric &&
+      result.id === excludeMetric.id &&
+      result.model === excludeMetric.sourceType;
+    return !isAlreadySelected && !isExcluded;
+  });
 }
 
 /**

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.ts
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.ts
@@ -509,6 +509,29 @@ export type PositionedToken = (
   | { type: "unknown"; text: string }
 ) & { from: number; to: number };
 
+function consumeNumber(text: string, startIndex: number): number | null {
+  let index = startIndex;
+  if (index >= text.length || text[index] < "0" || text[index] > "9") {
+    return null;
+  }
+  while (index < text.length && text[index] >= "0" && text[index] <= "9") {
+    index++;
+  }
+  if (
+    index < text.length &&
+    text[index] === "." &&
+    index + 1 < text.length &&
+    text[index + 1] >= "0" &&
+    text[index + 1] <= "9"
+  ) {
+    index++;
+    while (index < text.length && text[index] >= "0" && text[index] <= "9") {
+      index++;
+    }
+  }
+  return index;
+}
+
 /** Same as the main parser but records character positions for each token. */
 export function parseFullTextWithPositions(
   text: string,
@@ -556,6 +579,26 @@ export function parseFullTextWithPositions(
     }
 
     if (ch === "+" || ch === "-" || ch === "*" || ch === "/") {
+      const lastToken = tokens.length > 0 ? tokens[tokens.length - 1] : null;
+      const isUnaryContext =
+        lastToken === null ||
+        lastToken.type === "operator" ||
+        lastToken.type === "open-paren";
+
+      if (ch === "-" && isUnaryContext) {
+        const endIndex = consumeNumber(text, i + 1);
+        if (endIndex !== null) {
+          tokens.push({
+            type: "constant",
+            value: parseFloat(text.slice(i, endIndex)),
+            from: i,
+            to: endIndex,
+          });
+          i = endIndex;
+          continue;
+        }
+      }
+
       tokens.push({
         type: "operator",
         op: ch as MathOperator,
@@ -567,29 +610,14 @@ export function parseFullTextWithPositions(
     }
 
     if (ch >= "0" && ch <= "9") {
-      const start = i;
-      let numStr = "";
-      while (i < text.length && text[i] >= "0" && text[i] <= "9") {
-        numStr += text[i++];
-      }
-      if (
-        i < text.length &&
-        text[i] === "." &&
-        i + 1 < text.length &&
-        text[i + 1] >= "0" &&
-        text[i + 1] <= "9"
-      ) {
-        numStr += text[i++];
-        while (i < text.length && text[i] >= "0" && text[i] <= "9") {
-          numStr += text[i++];
-        }
-      }
+      const endIndex = consumeNumber(text, i)!;
       tokens.push({
         type: "constant",
-        value: parseFloat(numStr),
-        from: start,
-        to: i,
+        value: parseFloat(text.slice(i, endIndex)),
+        from: i,
+        to: endIndex,
       });
+      i = endIndex;
       continue;
     }
 

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.unit.spec.ts
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.unit.spec.ts
@@ -358,6 +358,33 @@ describe("parseFullText — numeric literal parsing", () => {
     });
   });
 
+  it("parses a leading-dot decimal like .5", () => {
+    const result = parseFullText(".5 * Revenue", metricEntries);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      type: "expression",
+      tokens: [k(0.5), op("*"), m("metric:1")],
+    });
+  });
+
+  it("parses a metric multiplied by a leading-dot decimal", () => {
+    const result = parseFullText("Revenue * .85", metricEntries);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      type: "expression",
+      tokens: [m("metric:1"), op("*"), k(0.85)],
+    });
+  });
+
+  it("parses a negative leading-dot decimal", () => {
+    const result = parseFullText("-.5 * Revenue", metricEntries);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      type: "expression",
+      tokens: [k(-0.5), op("*"), m("metric:1")],
+    });
+  });
+
   it("does not parse a trailing dot as part of the number", () => {
     // "1." — trailing dot with no digit after it; "1" is the constant, "." is
     // dropped (unknown tokens are filtered out of committed data)
@@ -516,6 +543,34 @@ describe("parseFullText — negative numbers", () => {
     "Revenue * -0.85",
   ])("does not report validation errors for: %s", (text) => {
     expect(findInvalidRanges(text, metricEntries)).toEqual([]);
+  });
+
+  it("parses metric minus negative constant without spaces (Revenue--50)", () => {
+    const result = parseFullText("Revenue--50", metricEntries);
+    expect(result).toEqual([
+      {
+        id: "expression:Revenue - -50",
+        type: "expression",
+        name: "Revenue - -50",
+        tokens: [metric("metric:1"), op("-"), constant(-50)],
+      },
+    ]);
+  });
+
+  it("parses metric minus negative decimal without spaces (Revenue--0.5)", () => {
+    const result = parseFullText("Revenue--0.5", metricEntries);
+    expect(result).toEqual([
+      {
+        id: "expression:Revenue - -0.5",
+        type: "expression",
+        name: "Revenue - -0.5",
+        tokens: [metric("metric:1"), op("-"), constant(-0.5)],
+      },
+    ]);
+  });
+
+  it("does not report validation errors for Revenue--50", () => {
+    expect(findInvalidRanges("Revenue--50", metricEntries)).toEqual([]);
   });
 
   it("still treats minus as binary operator after a metric", () => {

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.unit.spec.ts
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.unit.spec.ts
@@ -399,6 +399,151 @@ describe("parseFullText — numeric literal parsing", () => {
 });
 
 // ---------------------------------------------------------------------------
+// parseFullText — negative numbers
+// ---------------------------------------------------------------------------
+
+describe("parseFullText — negative numbers", () => {
+  const revenueEntry = makeMetricEntry("metric:1", "Revenue");
+  const costsEntry = makeMetricEntry("metric:2", "Costs");
+  const metricEntries = [revenueEntry, costsEntry];
+
+  const metric = (sourceId: MetricSourceId): ExpressionSubToken => ({
+    type: "metric",
+    sourceId,
+    count: 1,
+  });
+  const op = (o: "+" | "-" | "*" | "/"): ExpressionSubToken => ({
+    type: "operator",
+    op: o,
+  });
+  const constant = (v: number): ExpressionSubToken => ({
+    type: "constant",
+    value: v,
+  });
+  const open: ExpressionSubToken = { type: "open-paren" };
+  const close: ExpressionSubToken = { type: "close-paren" };
+
+  it("parses a standalone negative integer", () => {
+    const result = parseFullText("-50", metricEntries);
+    expect(result).toEqual([
+      {
+        id: "expression:-50",
+        type: "expression",
+        name: "-50",
+        tokens: [constant(-50)],
+      },
+    ]);
+  });
+
+  it("parses metric plus negative constant", () => {
+    const result = parseFullText("Revenue + -50", metricEntries);
+    expect(result).toEqual([
+      {
+        id: "expression:Revenue + -50",
+        type: "expression",
+        name: "Revenue + -50",
+        tokens: [metric("metric:1"), op("+"), constant(-50)],
+      },
+    ]);
+  });
+
+  it("parses metric multiplied by negative decimal", () => {
+    const result = parseFullText("Revenue * -0.85", metricEntries);
+    expect(result).toEqual([
+      {
+        id: "expression:Revenue * -0.85",
+        type: "expression",
+        name: "Revenue * -0.85",
+        tokens: [metric("metric:1"), op("*"), constant(-0.85)],
+      },
+    ]);
+  });
+
+  it("parses negative constant at the start of expression", () => {
+    const result = parseFullText("-50 * Revenue", metricEntries);
+    expect(result).toEqual([
+      {
+        id: "expression:-50 * Revenue",
+        type: "expression",
+        name: "-50 * Revenue",
+        tokens: [constant(-50), op("*"), metric("metric:1")],
+      },
+    ]);
+  });
+
+  it("parses negative constant after open-paren", () => {
+    const result = parseFullText("(-50 + Revenue)", metricEntries);
+    expect(result).toEqual([
+      {
+        id: "expression:(-50 + Revenue)",
+        type: "expression",
+        name: "(-50 + Revenue)",
+        tokens: [open, constant(-50), op("+"), metric("metric:1"), close],
+      },
+    ]);
+  });
+
+  it("parses subtraction of a negative constant", () => {
+    const result = parseFullText("Revenue - -50", metricEntries);
+    expect(result).toEqual([
+      {
+        id: "expression:Revenue - -50",
+        type: "expression",
+        name: "Revenue - -50",
+        tokens: [metric("metric:1"), op("-"), constant(-50)],
+      },
+    ]);
+  });
+
+  it("round-trips negative constants through buildExpressionText", () => {
+    const text = "Revenue + -50";
+    const result = parseFullText(text, metricEntries);
+    expect(result).toHaveLength(1);
+    const entry = result[0];
+    if (entry.type === "expression") {
+      // eslint-disable-next-line jest/no-conditional-expect
+      expect(buildExpressionText(entry.tokens, metricEntries)).toBe(text);
+    } else {
+      throw new Error("Expected expression entry");
+    }
+  });
+
+  it.each([
+    "-50 * Revenue",
+    "Revenue + -50",
+    "Revenue - -50",
+    "(-50 + Revenue)",
+    "Revenue * -0.85",
+  ])("does not report validation errors for: %s", (text) => {
+    expect(findInvalidRanges(text, metricEntries)).toEqual([]);
+  });
+
+  it("still treats minus as binary operator after a metric", () => {
+    const result = parseFullText("Revenue - 50", metricEntries);
+    expect(result).toEqual([
+      {
+        id: "expression:Revenue - 50",
+        type: "expression",
+        name: "Revenue - 50",
+        tokens: [metric("metric:1"), op("-"), constant(50)],
+      },
+    ]);
+  });
+
+  it("still treats minus as binary operator after a constant", () => {
+    const result = parseFullText("100 - Revenue", metricEntries);
+    expect(result).toEqual([
+      {
+        id: "expression:100 - Revenue",
+        type: "expression",
+        name: "100 - Revenue",
+        tokens: [constant(100), op("-"), metric("metric:1")],
+      },
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // parseFullText — metric names containing commas
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes [UXW-3440](https://linear.app/metabase/issue/UXW-3440/cant-use-negative-numbers-in-metric-math)

### Description

Adds support of negative numbers to the metrics viewer

### Demo

<img width="1728" height="979" alt="Screenshot 2026-03-31 at 7 20 47 PM" src="https://github.com/user-attachments/assets/725b7d87-4a0f-4b65-89d7-d3ca34c713f2" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [n/a] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
