### PR TITLE
reconile state on expressions change

### DIFF
--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/MetricSearchInput.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/MetricSearchInput.tsx
@@ -27,19 +27,25 @@ import { MetricExpressionPill } from "../MetricExpressionPill";
 import { MetricPill } from "../MetricPill";
 import { MetricSearchDropdown } from "../MetricSearchDropdown";
 import {
+  applyTrackedDefinitions,
   buildFullText,
   cleanupParens,
   findInvalidRanges,
   getWordAtCursor,
   parseFullText,
-  reconcileBreakoutState,
   removeUnmatchedParens,
   validateExpression,
 } from "../utils";
 
 import S from "./MetricSearchInput.module.css";
 import { errorHighlight, setErrorDecoration } from "./errorHighlight";
-import { metricTokenHighlight, setMetricEntries } from "./metricTokenHighlight";
+import {
+  buildMetricIdentities,
+  metricTokenHighlight,
+  readMetricIdentities,
+  setMetricEntries,
+  setMetricIdentities,
+} from "./metricTokenHighlight";
 import { operatorHighlight } from "./operatorHighlight";
 
 // Metrics in the expression input can be used multiple times, so nothing is filtered out
@@ -183,9 +189,17 @@ export function MetricSearchInput({
       const view = editorRef.current?.view;
       if (view) {
         const endPos = view.state.doc.length;
+        const identities = buildMetricIdentities(
+          fullText,
+          metricEntriesRef.current,
+          formulaEntitiesRef.current,
+        );
         view.dispatch({
           selection: EditorSelection.cursor(endPos),
-          effects: setMetricEntries.of(metricEntriesRef.current),
+          effects: [
+            setMetricEntries.of(metricEntriesRef.current),
+            setMetricIdentities.of(identities),
+          ],
           annotations: isolateHistory.of("full"),
         });
         const coords = view.coordsAtPos(endPos);
@@ -198,15 +212,19 @@ export function MetricSearchInput({
 
   /** Commits the current text: parses formula entities, removes unreferenced metrics, and collapses. */
   const commitAndCollapse = useCallback(() => {
-    const parsedEntities = parseFullText(
-      editTextRef.current,
-      metricEntriesRef.current,
-    );
+    const newText = editTextRef.current;
+    const parsedEntities = parseFullText(newText, metricEntriesRef.current);
 
-    // Preserve per-instance breakout definitions from old formula entities
-    const reconciledEntities = reconcileBreakoutState(
+    // Read tracked identities from the CodeMirror StateField —
+    // positions are already mapped through all edits automatically.
+    const view = editorRef.current?.view;
+    const trackedIdentities = view ? readMetricIdentities(view) : [];
+
+    const reconciledEntities = applyTrackedDefinitions(
       parsedEntities,
-      formulaEntitiesRef.current,
+      trackedIdentities,
+      newText,
+      metricEntriesRef.current,
     );
 
     // Find which metric sourceIds are referenced in the parsed entities
@@ -322,10 +340,14 @@ export function MetricSearchInput({
 
   const handleSelect = useCallback(
     (metric: SelectedMetric) => {
-      const cursorPos =
-        editorRef.current?.view?.state.selection.main.head ?? editText.length;
+      const view = editorRef.current?.view;
+      if (!view) {
+        return;
+      }
+      const docText = view.state.doc.toString();
+      const cursorPos = view.state.selection.main.head;
       const { start, end } = getWordAtCursor(
-        editText,
+        docText,
         cursorPos,
         metricEntriesRef.current,
       );
@@ -333,43 +355,46 @@ export function MetricSearchInput({
       const metricName = metric.name ?? "";
 
       // Check if we need to auto-insert a separator before this metric.
-      const textBeforeWord = editText.slice(0, start).trimEnd();
+      const textBeforeWord = docText.slice(0, start).trimEnd();
       const lastChar = textBeforeWord[textBeforeWord.length - 1];
       const NO_COMMA_CHARS = new Set(["+", "-", "*", "/", "(", ","]);
       const needsComma =
         textBeforeWord.length > 0 && !NO_COMMA_CHARS.has(lastChar);
 
-      let newText: string;
+      // Dispatch through the view (not setEditText) — the value-prop sync
+      // in @uiw/react-codemirror does a full doc replacement that destroys
+      // all RangeSet-tracked identities.
+      let insertText: string;
+      let replaceFrom: number;
       let newCursorPos: number;
       if (needsComma) {
-        newText = textBeforeWord + ", " + metricName + editText.slice(end);
-        newCursorPos = textBeforeWord.length + 2 + metricName.length;
+        insertText = ", " + metricName;
+        replaceFrom = textBeforeWord.length;
+        newCursorPos = replaceFrom + insertText.length;
       } else {
-        newText = editText.slice(0, start) + metricName + editText.slice(end);
+        insertText = metricName;
+        replaceFrom = start;
         newCursorPos = start + metricName.length;
       }
 
-      setEditText(newText);
-      setIsExpressionDirty(true);
+      view.dispatch({
+        changes: { from: replaceFrom, to: end, insert: insertText },
+        selection: EditorSelection.cursor(newCursorPos),
+      });
 
+      setIsExpressionDirty(true);
       onAddMetric(metric);
 
       setCurrentWord("");
       setIsOpen(false);
       dropdownHasSelectionRef.current = false;
 
-      // Reposition cursor right after the inserted metric name
+      // Return focus to the editor after dropdown closes
       setTimeout(() => {
-        const view = editorRef.current?.view;
-        if (view) {
-          view.dispatch({
-            selection: EditorSelection.cursor(newCursorPos),
-          });
-          view.focus();
-        }
+        editorRef.current?.view?.focus();
       }, 0);
     },
-    [editText, onAddMetric],
+    [onAddMetric],
   );
 
   // Remove one formula entity by index

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/metricTokenHighlight.ts
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/metricTokenHighlight.ts
@@ -1,4 +1,10 @@
-import { StateEffect, StateField } from "@codemirror/state";
+import {
+  MapMode,
+  RangeSet,
+  RangeValue,
+  StateEffect,
+  StateField,
+} from "@codemirror/state";
 import {
   Decoration,
   type DecorationSet,
@@ -7,8 +13,15 @@ import {
   keymap,
 } from "@codemirror/view";
 
-import type { MetricDefinitionEntry } from "../../../types/viewer-state";
-import { parseFullTextWithPositions } from "../utils";
+import type { MetricDefinition } from "metabase-lib/metric";
+
+import type {
+  MetricDefinitionEntry,
+  MetricSourceId,
+  MetricsViewerFormulaEntity,
+} from "../../../types/viewer-state";
+import type { MetricIdentityEntry } from "../utils";
+import { parseFullTextWithPositions, traverseMetricTokens } from "../utils";
 
 import S from "./MetricSearchInput.module.css";
 
@@ -46,6 +59,94 @@ const metricEntriesField = StateField.define<MetricDefinitionEntry[]>({
     return entries;
   },
 });
+
+// ── Identity tracking ──────────────────────────────────────────────────────
+
+class MetricIdentity extends RangeValue {
+  override mapMode = MapMode.TrackDel;
+  // Don't absorb text inserted at range boundaries — the identity
+  // must track exactly the original token span, not grow with adjacent edits.
+  override startSide = 1;
+  override endSide = -1;
+
+  constructor(
+    readonly sourceId: MetricSourceId,
+    readonly definition: MetricDefinition | null,
+  ) {
+    super();
+  }
+
+  override eq(other: MetricIdentity) {
+    return (
+      this.sourceId === other.sourceId && this.definition === other.definition
+    );
+  }
+}
+
+export const setMetricIdentities =
+  StateEffect.define<RangeSet<MetricIdentity>>();
+
+export const metricIdentityField = StateField.define<RangeSet<MetricIdentity>>({
+  create: () => RangeSet.empty,
+  update(identities, tr) {
+    for (const effect of tr.effects) {
+      if (effect.is(setMetricIdentities)) {
+        return effect.value;
+      }
+    }
+    if (tr.docChanged) {
+      return identities.map(tr.changes);
+    }
+    return identities;
+  },
+});
+
+export function buildMetricIdentities(
+  text: string,
+  metricEntries: MetricDefinitionEntry[],
+  entities: MetricsViewerFormulaEntity[],
+): RangeSet<MetricIdentity> {
+  const ranges: ReturnType<MetricIdentity["range"]>[] = [];
+
+  traverseMetricTokens(text, metricEntries, entities, (visit) => {
+    const sourceId =
+      visit.kind === "standalone" ? visit.entity.id : visit.exprToken.sourceId;
+    const definition =
+      visit.kind === "standalone"
+        ? visit.entity.definition
+        : (visit.exprToken.definition ?? null);
+
+    ranges.push(
+      new MetricIdentity(sourceId, definition).range(
+        visit.positioned.from,
+        visit.positioned.to,
+      ),
+    );
+  });
+
+  return RangeSet.of(ranges, true);
+}
+
+/**
+ * Reads the current metric identities from the CodeMirror state.
+ * Positions are already in current-document coordinates (mapped automatically).
+ */
+export function readMetricIdentities(view: EditorView): MetricIdentityEntry[] {
+  const identities = view.state.field(metricIdentityField);
+  const result: MetricIdentityEntry[] = [];
+  const docLength = view.state.doc.length;
+  identities.between(0, docLength, (from, to, value) => {
+    result.push({
+      sourceId: value.sourceId,
+      from,
+      to,
+      definition: value.definition,
+    });
+  });
+  return result;
+}
+
+// ── Token highlighting ─────────────────────────────────────────────────────
 
 type MetricRange = { from: number; to: number; name: string };
 
@@ -104,19 +205,13 @@ const metricTokenRangesField = StateField.define<MetricRange[]>({
   },
 });
 
-/** Derives replace decorations from the metric ranges. */
+/** Derives replace decorations from the metric ranges field (no re-parse). */
 const metricDecorationsField = StateField.define<DecorationSet>({
   create: () => Decoration.none,
   update(deco, tr) {
-    const entries = tr.state.field(metricEntriesField);
     const entriesChanged = tr.effects.some((e) => e.is(setMetricEntries));
     if (tr.docChanged || entriesChanged) {
-      const ranges = computeMetricTokenRanges(
-        tr.newDoc.toString(),
-        tr.newDoc.length,
-        entries,
-      );
-      return rangesToDecorations(ranges);
+      return rangesToDecorations(tr.state.field(metricTokenRangesField));
     }
     return deco;
   },
@@ -195,6 +290,7 @@ const metricTokenKeymap = keymap.of([
 
 export const metricTokenHighlight = [
   metricEntriesField,
+  metricIdentityField,
   metricTokenRangesField,
   metricDecorationsField,
   EditorView.atomicRanges.of((view) =>

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.ts
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.ts
@@ -977,10 +977,10 @@ export function applyTrackedDefinitions(
     if (!identityByPosition.has(key)) {
       return;
     }
-    const tracked = identityByPosition.get(key)!;
+    const tracked = identityByPosition.get(key);
 
     if (visit.kind === "standalone") {
-      metricOverrides.set(visit.entity, tracked);
+      metricOverrides.set(visit.entity, tracked ?? null);
       return;
     }
 
@@ -989,6 +989,7 @@ export function applyTrackedDefinitions(
       tokenMap = new Map();
       exprTokenOverrides.set(visit.entity, tokenMap);
     }
+    // remove any existing breakouts - not supported in math expressions
     const definition =
       tracked != null ? stripDefinitionProjections(tracked) : undefined;
     tokenMap.set(visit.exprTokenIndex, definition);
@@ -996,7 +997,7 @@ export function applyTrackedDefinitions(
 
   return newEntities.map((entity) => {
     if (metricOverrides.has(entity)) {
-      return { ...entity, definition: metricOverrides.get(entity)! };
+      return { ...entity, definition: metricOverrides.get(entity) ?? null };
     }
 
     const tokenMap = exprTokenOverrides.get(entity);

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.ts
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.ts
@@ -1,8 +1,11 @@
 import { t } from "ttag";
 
+import type { MetricDefinition } from "metabase-lib/metric";
+import * as LibMetric from "metabase-lib/metric";
 import { MATH_OPERATORS, isMathOperator } from "metabase-types/api";
 
 import type {
+  ExpressionDefinitionEntry,
   ExpressionSubToken,
   MetricDefinitionEntry,
   MetricSourceId,
@@ -268,6 +271,87 @@ function groupTokensBySegment(
   }
   segments.push(current);
   return segments;
+}
+
+type MetricPositionedToken = PositionedToken & { type: "metric" };
+
+type MetricSubToken = Extract<ExpressionSubToken, { type: "metric" }>;
+
+export type MetricTokenVisit =
+  | {
+      kind: "standalone";
+      positioned: MetricPositionedToken;
+      entity: MetricDefinitionEntry;
+    }
+  | {
+      kind: "expression";
+      positioned: MetricPositionedToken;
+      entity: ExpressionDefinitionEntry;
+      exprToken: MetricSubToken;
+      exprTokenIndex: number;
+    };
+
+/**
+ * Parses text into segments aligned with entities, then calls `visitor`
+ * for each metric token with its positioned counterpart and parent entity.
+ */
+export function traverseMetricTokens(
+  text: string,
+  metricEntries: MetricDefinitionEntry[],
+  entities: MetricsViewerFormulaEntity[],
+  visitor: (visit: MetricTokenVisit) => void,
+): void {
+  const allTokens = parseFullTextWithPositions(text, metricEntries);
+  const separators = findSeparatorCommaPositions(text, allTokens);
+  const segments = groupTokensBySegment(allTokens, separators);
+
+  let entityIndex = 0;
+  for (const segmentTokens of segments) {
+    if (segmentTokens.length === 0) {
+      continue;
+    }
+
+    const entity = entities[entityIndex++];
+    if (!entity) {
+      continue;
+    }
+
+    const metricTokens = segmentTokens.filter(
+      (token): token is MetricPositionedToken => token.type === "metric",
+    );
+
+    if (isMetricEntry(entity)) {
+      const positioned = metricTokens[0];
+      if (!positioned) {
+        continue;
+      }
+      visitor({ kind: "standalone", positioned, entity });
+      continue;
+    }
+
+    if (!isExpressionEntry(entity)) {
+      continue;
+    }
+
+    let metricIdx = 0;
+    for (let tokenIndex = 0; tokenIndex < entity.tokens.length; tokenIndex++) {
+      const exprToken = entity.tokens[tokenIndex];
+      if (exprToken.type !== "metric") {
+        continue;
+      }
+      const positioned = metricTokens[metricIdx++];
+      if (!positioned) {
+        continue;
+      }
+      visitor({
+        kind: "expression",
+        positioned,
+        entity,
+        exprToken,
+        exprTokenIndex: tokenIndex,
+      });
+    }
+  }
 }
 
 /** Strip position info from a positioned token, dropping unknown tokens. */
@@ -843,40 +927,92 @@ export function filterSearchResults<T extends SearchResultLike>(
   });
 }
 
-/**
- * Preserves per-instance breakout definitions from old formula entities
- * onto newly parsed entities. Matches by sourceId and occurrence order:
- * the Nth occurrence of a given sourceId in the new array is matched to
- * the Nth occurrence in the old array.
- */
-export function reconcileBreakoutState(
+export type MetricIdentityEntry = {
+  sourceId: MetricSourceId;
+  from: number;
+  to: number;
+  definition: MetricDefinition | null;
+};
+
+export function stripDefinitionProjections(
+  definition: MetricDefinition,
+): MetricDefinition {
+  const projections = LibMetric.projections(definition);
+  if (projections.length === 0) {
+    return definition;
+  }
+  return projections.reduce(
+    (def, projection) => LibMetric.removeClause(def, projection),
+    definition,
+  );
+}
+
+const getPositionKey = (from: number, to: number) => `${from}:${to}`;
+
+export function applyTrackedDefinitions(
   newEntities: MetricsViewerFormulaEntity[],
-  oldEntities: MetricsViewerFormulaEntity[],
+  trackedIdentities: MetricIdentityEntry[],
+  text: string,
+  metricEntries: MetricDefinitionEntry[],
 ): MetricsViewerFormulaEntity[] {
-  const oldBySourceId = new Map<MetricSourceId, MetricDefinitionEntry[]>();
-  for (const e of oldEntities) {
-    if (isMetricEntry(e)) {
-      const queue = oldBySourceId.get(e.id) ?? [];
-      queue.push(e);
-      oldBySourceId.set(e.id, queue);
-    }
+  const identityByPosition = new Map<string, MetricDefinition | null>();
+  for (const identity of trackedIdentities) {
+    identityByPosition.set(
+      getPositionKey(identity.from, identity.to),
+      identity.definition,
+    );
   }
 
-  const consumed = new Map<MetricSourceId, number>();
-  return newEntities.map((entry) => {
-    if (!isMetricEntry(entry)) {
-      return entry;
+  const metricOverrides = new Map<
+    MetricsViewerFormulaEntity,
+    MetricDefinition | null
+  >();
+  const exprTokenOverrides = new Map<
+    MetricsViewerFormulaEntity,
+    Map<number, MetricDefinition | undefined>
+  >();
+
+  traverseMetricTokens(text, metricEntries, newEntities, (visit) => {
+    const key = getPositionKey(visit.positioned.from, visit.positioned.to);
+    if (!identityByPosition.has(key)) {
+      return;
     }
-    const queue = oldBySourceId.get(entry.id);
-    if (!queue) {
-      return entry;
+    const tracked = identityByPosition.get(key)!;
+
+    if (visit.kind === "standalone") {
+      metricOverrides.set(visit.entity, tracked);
+      return;
     }
-    const idx = consumed.get(entry.id) ?? 0;
-    consumed.set(entry.id, idx + 1);
-    const oldEntry = queue[idx];
-    if (oldEntry?.definition) {
-      return { ...entry, definition: oldEntry.definition };
+
+    let tokenMap = exprTokenOverrides.get(visit.entity);
+    if (!tokenMap) {
+      tokenMap = new Map();
+      exprTokenOverrides.set(visit.entity, tokenMap);
     }
-    return entry;
+    const definition =
+      tracked != null ? stripDefinitionProjections(tracked) : undefined;
+    tokenMap.set(visit.exprTokenIndex, definition);
+  });
+
+  return newEntities.map((entity) => {
+    if (metricOverrides.has(entity)) {
+      return { ...entity, definition: metricOverrides.get(entity)! };
+    }
+
+    const tokenMap = exprTokenOverrides.get(entity);
+    if (tokenMap && isExpressionEntry(entity)) {
+      const newTokens = entity.tokens.map((token, index) => {
+        if (!tokenMap.has(index)) {
+          return token;
+        }
+        return { ...token, definition: tokenMap.get(index) };
+      });
+      const hasChanges = newTokens.some(
+        (token, index) => token !== entity.tokens[index],
+      );
+      return hasChanges ? { ...entity, tokens: newTokens } : entity;
+    }
+
+    return entity;
   });
 }

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.unit.spec.ts
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.unit.spec.ts
@@ -1,17 +1,30 @@
+import * as LibMetric from "metabase-lib/metric";
+
 import type {
+  ExpressionDefinitionEntry,
   ExpressionSubToken,
   MetricDefinitionEntry,
   MetricSourceId,
+  MetricsViewerFormulaEntity,
 } from "../../types/viewer-state";
-
+import { isExpressionEntry } from "../../types/viewer-state";
 import {
+  GEO_METRIC,
+  REVENUE_METRIC,
+  createMetricMetadata,
+  setupDefinition,
+  setupDefinitionWithBreakout,
+} from "../../utils/__tests__/test-helpers";
+
+import type { MetricIdentityEntry } from "./utils";
+import {
+  applyTrackedDefinitions,
   buildExpressionText,
   cleanupParens,
   filterSearchResults,
   findInvalidRanges,
   getWordAtCursor,
   parseFullText,
-  reconcileBreakoutState,
 } from "./utils";
 
 jest.mock("../../utils/definition-builder", () => ({
@@ -831,112 +844,209 @@ describe("getWordAtCursor — comma handling with metric entries", () => {
   });
 });
 
-describe("reconcileBreakoutState", () => {
-  const breakoutDef = {
-    "display-name": "MetricA",
-    breakout: true,
-  } as unknown as MetricDefinitionEntry["definition"];
+function sourceId(id: number): MetricSourceId {
+  return `metric:${id}`;
+}
 
-  function metricEntry(
-    sourceId: MetricSourceId,
-    definition: MetricDefinitionEntry["definition"] = null,
-  ): MetricDefinitionEntry {
-    return { id: sourceId, type: "metric", definition };
+function getExprTokenDefinitions(
+  entities: MetricsViewerFormulaEntity[],
+  entityIndex: number,
+): (LibMetric.MetricDefinition | undefined)[] {
+  const entity = entities[entityIndex];
+  if (!isExpressionEntry(entity)) {
+    return [];
   }
+  return entity.tokens
+    .filter((token) => token.type === "metric")
+    .map((token) =>
+      token.type === "metric" ? (token.definition ?? undefined) : undefined,
+    );
+}
 
-  it("preserves breakout definition from old entities onto matching new entities", () => {
-    const oldEntities = [
-      metricEntry("metric:1" as MetricSourceId, breakoutDef),
-    ];
-    const newEntities = [metricEntry("metric:1" as MetricSourceId)];
+const mockDef = (name: string) =>
+  ({ "display-name": name }) as unknown as MetricDefinitionEntry["definition"];
 
-    const result = reconcileBreakoutState(newEntities, oldEntities);
+const metricEntryWithDef = (
+  id: MetricSourceId,
+  name: string,
+): MetricDefinitionEntry => ({
+  id,
+  type: "metric",
+  definition: mockDef(name),
+});
+
+function identity(
+  metricSourceId: MetricSourceId,
+  from: number,
+  to: number,
+  definition: MetricDefinitionEntry["definition"] = null,
+): MetricIdentityEntry {
+  return { sourceId: metricSourceId, from, to, definition };
+}
+
+describe("applyTrackedDefinitions", () => {
+  const entries = [
+    metricEntryWithDef(sourceId(1), "Revenue"),
+    metricEntryWithDef(sourceId(2), "Geo Revenue"),
+  ];
+  const metadata = createMetricMetadata([REVENUE_METRIC, GEO_METRIC]);
+  const revenueDef = setupDefinition(metadata, REVENUE_METRIC.id);
+  const revenueBreakoutDef = setupDefinitionWithBreakout(
+    metadata,
+    REVENUE_METRIC.id,
+    0,
+  );
+  const geoBreakoutDef = setupDefinitionWithBreakout(
+    metadata,
+    GEO_METRIC.id,
+    0,
+  );
+
+  it("returns empty array for empty inputs", () => {
+    expect(applyTrackedDefinitions([], [], "", entries)).toEqual([]);
+  });
+
+  it("applies tracked definition to a standalone metric by position", () => {
+    const text = "Revenue";
+    const parsed = parseFullText(text, entries);
+    const tracked = [identity(sourceId(1), 0, 7, revenueBreakoutDef)];
+    const result = applyTrackedDefinitions(parsed, tracked, text, entries);
     expect(result).toHaveLength(1);
-    expect(result[0]).toHaveProperty("definition", breakoutDef);
+    expect((result[0] as MetricDefinitionEntry).definition).toBe(
+      revenueBreakoutDef,
+    );
   });
 
-  it("does not add breakout to entities that had no breakout before", () => {
-    const oldEntities = [metricEntry("metric:1" as MetricSourceId, null)];
-    const newEntities = [metricEntry("metric:1" as MetricSourceId)];
-
-    const result = reconcileBreakoutState(newEntities, oldEntities);
-    expect(result[0]).toHaveProperty("definition", null);
+  it("preserves null definition when tracked identity has null", () => {
+    const text = "Revenue";
+    const parsed = parseFullText(text, entries);
+    const tracked = [identity(sourceId(1), 0, 7, null)];
+    const result = applyTrackedDefinitions(parsed, tracked, text, entries);
+    expect((result[0] as MetricDefinitionEntry).definition).toBeNull();
   });
 
-  it("matches by occurrence order for duplicate sourceIds", () => {
-    const oldEntities = [
-      metricEntry("metric:1" as MetricSourceId, breakoutDef),
-      metricEntry("metric:1" as MetricSourceId, null),
-    ];
-    const newEntities = [
-      metricEntry("metric:1" as MetricSourceId),
-      metricEntry("metric:1" as MetricSourceId),
-    ];
-
-    const result = reconcileBreakoutState(newEntities, oldEntities);
-    expect(result[0]).toHaveProperty("definition", breakoutDef);
-    expect(result[1]).toHaveProperty("definition", null);
+  it("leaves entity unchanged when no tracked identity matches its position", () => {
+    const text = "Revenue";
+    const parsed = parseFullText(text, entries);
+    const result = applyTrackedDefinitions(parsed, [], text, entries);
+    expect(result).toEqual(parsed);
   });
 
-  it("leaves extra new entities without breakout when old has fewer instances", () => {
-    const oldEntities = [
-      metricEntry("metric:1" as MetricSourceId, breakoutDef),
+  it("matches definitions by exact position for comma-separated metrics", () => {
+    const text = "Revenue, Geo Revenue";
+    const parsed = parseFullText(text, entries);
+    const tracked = [
+      identity(sourceId(1), 0, 7, revenueBreakoutDef),
+      identity(sourceId(2), 9, 20, geoBreakoutDef),
     ];
-    const newEntities = [
-      metricEntry("metric:1" as MetricSourceId),
-      metricEntry("metric:1" as MetricSourceId),
-    ];
-
-    const result = reconcileBreakoutState(newEntities, oldEntities);
-    expect(result[0]).toHaveProperty("definition", breakoutDef);
-    expect(result[1]).toHaveProperty("definition", null);
+    const result = applyTrackedDefinitions(parsed, tracked, text, entries);
+    expect((result[0] as MetricDefinitionEntry).definition).toBe(
+      revenueBreakoutDef,
+    );
+    expect((result[1] as MetricDefinitionEntry).definition).toBe(
+      geoBreakoutDef,
+    );
   });
 
-  it("ignores removed entities from old when new has fewer instances", () => {
-    const oldEntities = [
-      metricEntry("metric:1" as MetricSourceId, breakoutDef),
-      metricEntry("metric:1" as MetricSourceId, breakoutDef),
-    ];
-    const newEntities = [metricEntry("metric:1" as MetricSourceId)];
-
-    const result = reconcileBreakoutState(newEntities, oldEntities);
-    expect(result).toHaveLength(1);
-    expect(result[0]).toHaveProperty("definition", breakoutDef);
+  it("strips breakout projections from expression token definitions", () => {
+    const text = "Revenue + 5";
+    const parsed = parseFullText(text, entries);
+    const tracked = [identity(sourceId(1), 0, 7, revenueBreakoutDef)];
+    const result = applyTrackedDefinitions(parsed, tracked, text, entries);
+    const [tokenDef] = getExprTokenDefinitions(result, 0);
+    expect(tokenDef).toBeDefined();
+    expect(LibMetric.projections(tokenDef!)).toEqual([]);
   });
 
-  it("passes through expression entries unchanged", () => {
-    const exprEntry = {
-      id: "expression:MetricA + 5" as const,
-      type: "expression" as const,
-      name: "MetricA + 5",
-      tokens: [] as ExpressionSubToken[],
-    };
-    const oldEntities = [
-      metricEntry("metric:1" as MetricSourceId, breakoutDef),
-      exprEntry,
-    ];
-    const newEntities = [
-      metricEntry("metric:1" as MetricSourceId),
-      { ...exprEntry },
-    ];
-
-    const result = reconcileBreakoutState(newEntities, oldEntities);
-    expect(result[0]).toHaveProperty("definition", breakoutDef);
-    expect(result[1]).toHaveProperty("type", "expression");
-    expect(result[1]).not.toHaveProperty("definition");
+  it("preserves non-breakout definitions on expression tokens", () => {
+    const text = "Revenue + 5";
+    const parsed = parseFullText(text, entries);
+    const tracked = [identity(sourceId(1), 0, 7, revenueDef)];
+    const result = applyTrackedDefinitions(parsed, tracked, text, entries);
+    const [tokenDef] = getExprTokenDefinitions(result, 0);
+    expect(tokenDef).toBe(revenueDef);
   });
 
-  it("handles new entities with no matching old entities", () => {
-    const oldEntities = [
-      metricEntry("metric:1" as MetricSourceId, breakoutDef),
-    ];
-    const newEntities = [
-      metricEntry("metric:1" as MetricSourceId),
-      metricEntry("metric:2" as MetricSourceId),
-    ];
+  it("preserves reference identity for expression entries when no tokens change", () => {
+    const text = "5 + 5";
+    const parsed = parseFullText(text, entries);
+    const result = applyTrackedDefinitions(parsed, [], text, entries);
+    expect(result[0]).toBe(parsed[0]);
+  });
 
-    const result = reconcileBreakoutState(newEntities, oldEntities);
-    expect(result[0]).toHaveProperty("definition", breakoutDef);
-    expect(result[1]).toHaveProperty("definition", null);
+  it("does not touch non-metric tokens inside expressions", () => {
+    const text = "Revenue + 5";
+    const parsed = parseFullText(text, entries);
+    const tracked = [identity(sourceId(1), 0, 7, revenueDef)];
+    const result = applyTrackedDefinitions(parsed, tracked, text, entries);
+    const resultExpr = result[0] as ExpressionDefinitionEntry;
+    const parsedExpr = parsed[0] as ExpressionDefinitionEntry;
+    expect(resultExpr.tokens[1]).toBe(parsedExpr.tokens[1]);
+    expect(resultExpr.tokens[2]).toBe(parsedExpr.tokens[2]);
+  });
+
+  it("applies definition only to standalone metric, not expression token at different position", () => {
+    const text = "Revenue, Revenue + 5";
+    const parsed = parseFullText(text, entries);
+    // Only the standalone Revenue (0-7) has a tracked identity
+    const tracked = [identity(sourceId(1), 0, 7, revenueBreakoutDef)];
+    const result = applyTrackedDefinitions(parsed, tracked, text, entries);
+    expect((result[0] as MetricDefinitionEntry).definition).toBe(
+      revenueBreakoutDef,
+    );
+    const [tokenDef] = getExprTokenDefinitions(result, 1);
+    expect(tokenDef).toBeUndefined();
+  });
+
+  it("does not carry definition to a token at a non-matching position", () => {
+    // Tracked identity at [100,107] — token was deleted (TrackDel).
+    // New Revenue at [0,7] is a fresh instance, gets no override.
+    const text = "Revenue";
+    const parsed = parseFullText(text, entries);
+    const tracked = [identity(sourceId(1), 100, 107, revenueDef)];
+    const result = applyTrackedDefinitions(parsed, tracked, text, entries);
+    expect((result[0] as MetricDefinitionEntry).definition).not.toBe(
+      revenueDef,
+    );
+  });
+
+  it("newly added duplicate of same metric gets no definition from the tracked one", () => {
+    const text = "Revenue, Revenue";
+    const parsed = parseFullText(text, entries);
+    // Only one tracked identity at position [0,7]
+    const tracked = [identity(sourceId(1), 0, 7, revenueBreakoutDef)];
+    const result = applyTrackedDefinitions(parsed, tracked, text, entries);
+    // First Revenue at [0,7] — exact position match
+    expect((result[0] as MetricDefinitionEntry).definition).toBe(
+      revenueBreakoutDef,
+    );
+    // Second Revenue at [9,16] — no match, independent new instance
+    expect((result[1] as MetricDefinitionEntry).definition).not.toBe(
+      revenueBreakoutDef,
+    );
+  });
+
+  it("preserves definition when token survives edit (position tracked by RangeSet)", () => {
+    // "Revenue + 5" — Revenue token at [0,7] survived the edit
+    const text = "Revenue + 5";
+    const parsed = parseFullText(text, entries);
+    const tracked = [identity(sourceId(1), 0, 7, revenueDef)];
+    const result = applyTrackedDefinitions(parsed, tracked, text, entries);
+    const [tokenDef] = getExprTokenDefinitions(result, 0);
+    expect(tokenDef).toBe(revenueDef);
+  });
+
+  it("two instances of same metric at different positions keep independent definitions", () => {
+    const text = "Revenue, Revenue";
+    const parsed = parseFullText(text, entries);
+    const tracked = [
+      identity(sourceId(1), 0, 7, revenueBreakoutDef),
+      identity(sourceId(1), 9, 16, revenueDef),
+    ];
+    const result = applyTrackedDefinitions(parsed, tracked, text, entries);
+    expect((result[0] as MetricDefinitionEntry).definition).toBe(
+      revenueBreakoutDef,
+    );
+    expect((result[1] as MetricDefinitionEntry).definition).toBe(revenueDef);
   });
 });

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.unit.spec.ts
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.unit.spec.ts
@@ -968,7 +968,7 @@ describe("applyTrackedDefinitions", () => {
   });
 
   it("preserves reference identity for expression entries when no tokens change", () => {
-    const text = "5 + 5";
+    const text = "Revenue + 5";
     const parsed = parseFullText(text, entries);
     const result = applyTrackedDefinitions(parsed, [], text, entries);
     expect(result[0]).toBe(parsed[0]);


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/UXW-3414/breakout-remains-when-switching-to-metric-math
Closes https://linear.app/metabase/issue/UXW-3517/preserve-filtersdimension-mapping-across-edits-in-the-formula-bar

### Description

Tracks metrics identities in the expression so that editing it does not remove filters. Also, clears breakouts if a metric becomes an expression.

### Demo

Loom: https://www.loom.com/share/e1a124760e2f442e98c8bc6bf1dfc347