### PR TITLE
[Feat#68228] Support for `Not between` filter in querying

### DIFF
--- a/frontend/src/metabase-lib/metric/types.ts
+++ b/frontend/src/metabase-lib/metric/types.ts
@@ -153,6 +153,7 @@ export type StringFilterParts = {
 export type NumberFilterParts = {
   operator: NumberFilterOperator;
   dimension: DimensionMetadata;
+  isNot?: boolean;
   values: NumberFilterValue[];
 };
 
@@ -160,6 +161,7 @@ export type CoordinateFilterParts = {
   operator: CoordinateFilterOperator;
   dimension: DimensionMetadata;
   longitudeDimension: DimensionMetadata | null;
+  isNot?: boolean;
   values: NumberFilterValue[];
 };
 
@@ -172,6 +174,7 @@ export type BooleanFilterParts = {
 export type SpecificDateFilterParts = {
   operator: SpecificDateFilterOperator;
   dimension: DimensionMetadata;
+  isNot?: boolean;
   values: Date[];
   hasTime: boolean;
 };
@@ -195,6 +198,7 @@ export type ExcludeDateFilterParts = {
 export type TimeFilterParts = {
   operator: TimeFilterOperator;
   dimension: DimensionMetadata;
+  isNot?: boolean;
   values: Date[];
 };
 

--- a/frontend/src/metabase-lib/query/filter.ts
+++ b/frontend/src/metabase-lib/query/filter.ts
@@ -86,9 +86,10 @@ export function stringFilterParts(
 export function numberFilterClause({
   operator,
   column,
+  isNot,
   values,
 }: NumberFilterParts): ExpressionClause {
-  return ML.number_filter_clause(operator, column, values);
+  return ML.number_filter_clause(operator, column, values, isNot ?? false);
 }
 
 export function numberFilterParts(
@@ -103,9 +104,16 @@ export function coordinateFilterClause({
   operator,
   column,
   longitudeColumn,
+  isNot,
   values,
 }: CoordinateFilterParts): ExpressionClause {
-  return ML.coordinate_filter_clause(operator, column, longitudeColumn, values);
+  return ML.coordinate_filter_clause(
+    operator,
+    column,
+    longitudeColumn,
+    values,
+    isNot ?? false,
+  );
 }
 
 export function coordinateFilterParts(
@@ -136,9 +144,16 @@ export function specificDateFilterClause({
   operator,
   column,
   values,
+  isNot,
   hasTime,
 }: SpecificDateFilterParts): ExpressionClause {
-  return ML.specific_date_filter_clause(operator, column, values, hasTime);
+  return ML.specific_date_filter_clause(
+    operator,
+    column,
+    values,
+    isNot ?? false,
+    hasTime,
+  );
 }
 
 export function specificDateFilterParts(
@@ -195,12 +210,14 @@ export function excludeDateFilterParts(
 export function timeFilterClause({
   operator,
   column,
+  isNot,
   values,
 }: TimeFilterParts): ExpressionClause {
   return ML.time_filter_clause(
     operator,
     column,
     values.map((value) => dayjs(value)),
+    isNot ?? false,
   );
 }
 

--- a/frontend/src/metabase-lib/query/types.ts
+++ b/frontend/src/metabase-lib/query/types.ts
@@ -363,6 +363,7 @@ export type StringFilterParts = {
 export type NumberFilterParts = {
   operator: NumberFilterOperator;
   column: ColumnMetadata;
+  isNot?: boolean;
   values: NumberFilterValue[];
 };
 
@@ -370,6 +371,7 @@ export type CoordinateFilterParts = {
   operator: CoordinateFilterOperator;
   column: ColumnMetadata;
   longitudeColumn: ColumnMetadata | null;
+  isNot?: boolean;
   values: NumberFilterValue[];
 };
 
@@ -382,6 +384,7 @@ export type BooleanFilterParts = {
 export type SpecificDateFilterParts = {
   operator: SpecificDateFilterOperator;
   column: ColumnMetadata;
+  isNot?: boolean;
   values: Date[];
   hasTime: boolean;
 };
@@ -412,6 +415,7 @@ export type ExcludeDateFilterParts = {
 export type TimeFilterParts = {
   operator: TimeFilterOperator;
   column: ColumnMetadata;
+  isNot?: boolean;
   values: Date[];
 };
 

--- a/frontend/src/metabase/metrics/utils/dates.ts
+++ b/frontend/src/metabase/metrics/utils/dates.ts
@@ -144,8 +144,9 @@ function getSpecificFilterClause(
   value: SpecificDatePickerValue,
 ): LibMetric.FilterClause {
   return LibMetric.specificDateFilterClause({
-    operator: value.operator,
+    operator: value.operator === "not-between" ? "between" : value.operator,
     dimension,
+    isNot: value.operator === "not-between",
     values: value.values,
     hasTime: value.hasTime,
   });

--- a/frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts
+++ b/frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/constants.ts
@@ -17,6 +17,12 @@ export const TABS: Tab[] = [
   },
   {
     get label() {
+      return t`Not between`;
+    },
+    operator: "not-between",
+  },
+  {
+    get label() {
       return t`On`;
     },
     operator: "=",

--- a/frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/utils.ts
+++ b/frontend/src/metabase/querying/common/components/DatePicker/SpecificDatePicker/utils.ts
@@ -33,6 +33,7 @@ export function getOperatorDefaultValue(
 
   switch (operator) {
     case "between":
+    case "not-between":
       return {
         type: "specific",
         operator,
@@ -75,6 +76,7 @@ export function setOperator(
     case ">":
       return { ...value, operator, values: [date] };
     case "between":
+    case "not-between":
       return value.operator === ">"
         ? { ...value, operator, values: [date, next30Days] }
         : { ...value, operator, values: [past30Days, date] };
@@ -125,7 +127,7 @@ export function coerceValue(
   value: SpecificDatePickerValue,
 ): SpecificDatePickerValue {
   const { type, operator, values, hasTime } = value;
-  if (operator === "between") {
+  if (operator === "between" || operator === "not-between") {
     const [startDate, endDate] = values;
 
     return {

--- a/frontend/src/metabase/querying/common/constants.ts
+++ b/frontend/src/metabase/querying/common/constants.ts
@@ -3,6 +3,7 @@ export const SPECIFIC_DATE_PICKER_OPERATORS = [
   "<" as const,
   ">" as const,
   "between" as const,
+  "not-between" as const,
 ];
 
 export const EXCLUDE_DATE_PICKER_OPERATORS = [

--- a/frontend/src/metabase/querying/common/utils/dates.ts
+++ b/frontend/src/metabase/querying/common/utils/dates.ts
@@ -48,6 +48,12 @@ export function getDateFilterDisplayName(
       },
     )
     .with(
+      { type: "specific", operator: "not-between" },
+      ({ values: [startDate, endDate], hasTime }) => {
+        return t`Not ${formatDate(startDate, hasTime, formattingSettings)} - ${formatDate(endDate, hasTime, formattingSettings)}`;
+      },
+    )
+    .with(
       { type: "relative" },
       ({ value, unit, offsetValue, offsetUnit, options }) => {
         if (offsetValue != null && offsetUnit != null) {

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/CoordinateFilterPicker/CoordinateFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/CoordinateFilterPicker/CoordinateFilterPicker.tsx
@@ -16,7 +16,7 @@ import type { FilterChangeOpts, FilterPickerWidgetProps } from "../types";
 
 import { CoordinateColumnPicker } from "./CoordinateColumnPicker";
 import { useCoordinateFilter } from "./hooks";
-import type { NumberOrEmptyValue } from "./types";
+import type { CoordinatePickerOperator, NumberOrEmptyValue } from "./types";
 
 export function CoordinateFilterPicker({
   autoFocus,
@@ -58,7 +58,7 @@ export function CoordinateFilterPicker({
     filter,
   });
 
-  const handleOperatorChange = (newOperator: Lib.CoordinateFilterOperator) => {
+  const handleOperatorChange = (newOperator: CoordinatePickerOperator) => {
     setOperator(newOperator);
     setValues(getDefaultValues(newOperator, values));
   };

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/CoordinateFilterPicker/CoordinateFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/CoordinateFilterPicker/CoordinateFilterPicker.unit.spec.tsx
@@ -35,6 +35,7 @@ const EXPECTED_OPERATORS = [
   "Is not",
   "Inside",
   "Between",
+  "Not between",
   "Greater than",
   "Greater than or equal to",
   "Less than",
@@ -223,6 +224,28 @@ describe("CoordinateFilterPicker", () => {
         const filterParts = getNextFilterParts();
         expect(filterParts).toMatchObject({
           operator: "between",
+          column: expect.anything(),
+          values: [-10.5, 5],
+        });
+        expect(getNextFilterColumnNames().column).toBe("User → Latitude");
+      });
+
+      it("should add a not between filter", async () => {
+        const { getNextFilterParts, getNextFilterColumnNames } = setup();
+        const addFilterButton = screen.getByRole("button", {
+          name: "Add filter",
+        });
+
+        await setOperator("Not between");
+        const leftInput = screen.getByPlaceholderText("Min");
+        const rightInput = screen.getByPlaceholderText("Max");
+        await userEvent.type(leftInput, "5");
+        await userEvent.type(rightInput, "-10.5");
+        await userEvent.click(addFilterButton);
+
+        expect(getNextFilterParts()).toMatchObject({
+          operator: "between",
+          isNot: true,
           column: expect.anything(),
           values: [-10.5, 5],
         });
@@ -455,6 +478,20 @@ describe("CoordinateFilterPicker", () => {
           expect(screen.getByText("Update filter")).toBeEnabled();
         },
       );
+
+      it("should render a not between filter", () => {
+        setup(
+          createQueryWithCoordinateFilter({
+            operator: "between",
+            isNot: true,
+            values: [1, 9],
+          }),
+        );
+
+        expect(screen.getByText("Not between")).toBeInTheDocument();
+        expect(screen.getByDisplayValue("1")).toBeInTheDocument();
+        expect(screen.getByDisplayValue("9")).toBeInTheDocument();
+      });
 
       it.each(BETWEEN_TEST_CASES)(
         "should update a filter with %i to %i values",

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/CoordinateFilterPicker/constants.ts
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/CoordinateFilterPicker/constants.ts
@@ -1,9 +1,10 @@
-import type * as Lib from "metabase-lib";
-
-import type { CoordinateFilterOperatorInfo } from "./types";
+import type {
+  CoordinateFilterOperatorInfo,
+  CoordinatePickerOperator,
+} from "./types";
 
 export const OPERATORS: Record<
-  Lib.CoordinateFilterOperator,
+  CoordinatePickerOperator,
   CoordinateFilterOperatorInfo
 > = {
   "=": {
@@ -30,6 +31,10 @@ export const OPERATORS: Record<
   },
   between: {
     operator: "between",
+    valueCount: 2,
+  },
+  "not-between": {
+    operator: "not-between",
     valueCount: 2,
   },
   ">=": {

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/CoordinateFilterPicker/hooks.ts
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/CoordinateFilterPicker/hooks.ts
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react";
 
 import * as Lib from "metabase-lib";
 
-import type { NumberOrEmptyValue } from "./types";
+import type { CoordinatePickerOperator, NumberOrEmptyValue } from "./types";
 import {
   canPickColumns,
   getAvailableColumns,
@@ -41,8 +41,12 @@ export function useCoordinateFilter({
     [query, stageIndex, column],
   );
 
-  const [operator, setOperator] = useState(
-    filterParts ? filterParts.operator : getDefaultOperator(),
+  const [operator, setOperator] = useState<CoordinatePickerOperator>(
+    filterParts
+      ? filterParts.operator === "between" && filterParts.isNot
+        ? "not-between"
+        : filterParts.operator
+      : getDefaultOperator(),
   );
   const [values, setValues] = useState(
     getDefaultValues(operator, filterParts ? filterParts.values : []),
@@ -66,7 +70,7 @@ export function useCoordinateFilter({
     isValid,
     getDefaultValues,
     getFilterClause: (
-      operator: Lib.CoordinateFilterOperator,
+      operator: CoordinatePickerOperator,
       secondColumn: Lib.ColumnMetadata | undefined,
       values: NumberOrEmptyValue[],
     ) => getFilterClause(operator, column, secondColumn, values),

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/CoordinateFilterPicker/types.ts
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/CoordinateFilterPicker/types.ts
@@ -7,6 +7,7 @@ export type CoordinatePickerOperator =
   | ">"
   | "<"
   | "between"
+  | "not-between"
   | "inside"
   | ">="
   | "<=";

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/CoordinateFilterPicker/utils.ts
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/CoordinateFilterPicker/utils.ts
@@ -1,24 +1,30 @@
+import { t } from "ttag";
+
 import { isNotNull } from "metabase/lib/types";
 import * as Lib from "metabase-lib";
 
 import { OPERATORS } from "./constants";
 import type {
   CoordinateFilterOperatorOption,
+  CoordinatePickerOperator,
   NumberOrEmptyValue,
 } from "./types";
 
 export function getAvailableOptions(): CoordinateFilterOperatorOption[] {
   return Object.values(OPERATORS).map(({ operator }) => ({
     operator,
-    displayName: Lib.describeFilterOperator(operator),
+    displayName:
+      operator === "not-between"
+        ? t`Not between`
+        : Lib.describeFilterOperator(operator),
   }));
 }
 
-export function getOptionByOperator(operator: Lib.CoordinateFilterOperator) {
+export function getOptionByOperator(operator: CoordinatePickerOperator) {
   return OPERATORS[operator];
 }
 
-export function getDefaultOperator(): Lib.CoordinateFilterOperator {
+export function getDefaultOperator(): CoordinatePickerOperator {
   return "between";
 }
 
@@ -44,14 +50,14 @@ export function getDefaultSecondColumn(
 }
 
 export function canPickColumns(
-  operator: Lib.CoordinateFilterOperator,
+  operator: CoordinatePickerOperator,
   columns: Lib.ColumnMetadata[],
 ) {
   return operator === "inside" && columns.length > 1;
 }
 
 export function getDefaultValues(
-  operator: Lib.CoordinateFilterOperator,
+  operator: CoordinatePickerOperator,
   values: NumberOrEmptyValue[],
 ): NumberOrEmptyValue[] {
   const { valueCount, hasMultipleValues } = OPERATORS[operator];
@@ -65,7 +71,7 @@ export function getDefaultValues(
 }
 
 export function isValidFilter(
-  operator: Lib.CoordinateFilterOperator,
+  operator: CoordinatePickerOperator,
   column: Lib.ColumnMetadata,
   secondColumn: Lib.ColumnMetadata | undefined,
   values: NumberOrEmptyValue[],
@@ -74,7 +80,7 @@ export function isValidFilter(
 }
 
 export function getFilterClause(
-  operator: Lib.CoordinateFilterOperator,
+  operator: CoordinatePickerOperator,
   column: Lib.ColumnMetadata,
   secondColumn: Lib.ColumnMetadata | undefined,
   values: NumberOrEmptyValue[],
@@ -86,13 +92,14 @@ export function getFilterClause(
 }
 
 function getFilterParts(
-  operator: Lib.CoordinateFilterOperator,
+  operator: CoordinatePickerOperator,
   column: Lib.ColumnMetadata,
   secondColumn: Lib.ColumnMetadata | undefined,
   values: NumberOrEmptyValue[],
 ): Lib.CoordinateFilterParts | undefined {
   switch (operator) {
     case "between":
+    case "not-between":
       return getBetweenFilterParts(operator, column, values);
     case "inside":
       return getInsideFilterParts(operator, column, secondColumn, values);
@@ -123,7 +130,7 @@ function getSimpleFilterParts(
 }
 
 function getBetweenFilterParts(
-  operator: Lib.CoordinateFilterOperator,
+  operator: Extract<CoordinatePickerOperator, "between" | "not-between">,
   column: Lib.ColumnMetadata,
   values: NumberOrEmptyValue[],
 ): Lib.CoordinateFilterParts | undefined {
@@ -133,11 +140,14 @@ function getBetweenFilterParts(
     const maxValue = startValue < endValue ? endValue : startValue;
 
     return {
-      operator,
+      operator: "between",
       column,
       longitudeColumn: null,
+      isNot: operator === "not-between",
       values: [minValue, maxValue],
     };
+  } else if (operator === "not-between") {
+    return undefined;
   } else if (isNotNull(startValue)) {
     return {
       operator: ">=",

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/DateFilterPicker/DateFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/DateFilterPicker/DateFilterPicker.unit.spec.tsx
@@ -161,6 +161,36 @@ describe("DateFilterPicker", () => {
     });
   });
 
+  it("should update a not between specific date filter", async () => {
+    const { query, filter } = createQueryWithSpecificDateFilter({
+      query: initialQuery,
+      operator: "between",
+      isNot: true,
+      values: [new Date(2020, 1, 10), new Date(2020, 1, 15)],
+    });
+    const { getNextFilterColumnName, getNextSpecificFilterParts } = setup({
+      query,
+      column,
+      filter,
+    });
+
+    expect(screen.getByText("Not between")).toBeInTheDocument();
+
+    await userEvent.clear(screen.getByLabelText("Start date"));
+    await userEvent.type(screen.getByLabelText("Start date"), "Feb 20, 2020");
+    await userEvent.clear(screen.getByLabelText("End date"));
+    await userEvent.type(screen.getByLabelText("End date"), "Feb 5, 2020");
+    await userEvent.click(screen.getByText("Update filter"));
+
+    expect(getNextFilterColumnName()).toBe(COLUMN_NAME);
+    expect(getNextSpecificFilterParts()).toMatchObject({
+      operator: "between",
+      isNot: true,
+      column: expect.anything(),
+      values: [new Date(2020, 1, 5), new Date(2020, 1, 20)],
+    });
+  });
+
   it("should add a relative date filter", async () => {
     const { getNextFilterColumnName, getNextRelativeFilterParts } = setup({
       query: initialQuery,

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/FilterOperatorPicker/FilterOperatorPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/FilterOperatorPicker/FilterOperatorPicker.tsx
@@ -2,17 +2,16 @@ import { t } from "ttag";
 
 import type { FilterOperatorOption } from "metabase/querying/filters/types";
 import { Button, Icon, Menu } from "metabase/ui";
-import type * as Lib from "metabase-lib";
 
 import S from "./FilterOperatorPicker.module.css";
 
-interface FilterOperatorPickerProps<T extends Lib.FilterOperator> {
+interface FilterOperatorPickerProps<T extends string> {
   value: T;
   options: FilterOperatorOption<T>[];
   onChange: (operator: T) => void;
 }
 
-export function FilterOperatorPicker<T extends Lib.FilterOperator>({
+export function FilterOperatorPicker<T extends string>({
   value,
   options,
   onChange,

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/NumberFilterPicker/NumberFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/NumberFilterPicker/NumberFilterPicker.tsx
@@ -14,7 +14,11 @@ import { NumberFilterValuePicker } from "../FilterValuePicker";
 import { COMBOBOX_PROPS, WIDTH } from "../constants";
 import type { FilterChangeOpts, FilterPickerWidgetProps } from "../types";
 
-import { type NumberOrEmptyValue, useNumberFilter } from "./hooks";
+import {
+  type NumberOrEmptyValue,
+  type NumberPickerOperator,
+  useNumberFilter,
+} from "./hooks";
 
 export function NumberFilterPicker({
   autoFocus,
@@ -52,7 +56,7 @@ export function NumberFilterPicker({
     filter,
   });
 
-  const handleOperatorChange = (newOperator: Lib.NumberFilterOperator) => {
+  const handleOperatorChange = (newOperator: NumberPickerOperator) => {
     setOperator(newOperator);
     setValues(getDefaultValues(newOperator, values));
   };

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/NumberFilterPicker/NumberFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/NumberFilterPicker/NumberFilterPicker.unit.spec.tsx
@@ -34,6 +34,7 @@ const EXPECTED_OPERATORS = [
   "Equal to",
   "Not equal to",
   "Between",
+  "Not between",
   "Greater than",
   "Greater than or equal to",
   "Less than",
@@ -245,6 +246,25 @@ describe("NumberFilterPicker", () => {
         expect(getNextFilterColumnName()).toBe("Total");
       });
 
+      it("should add a not between filter", async () => {
+        const { getNextFilterParts, getNextFilterColumnName } = setup();
+
+        await setOperator("Not between");
+        const leftInput = screen.getByPlaceholderText("Min");
+        const rightInput = screen.getByPlaceholderText("Max");
+        await userEvent.type(leftInput, "5");
+        await userEvent.type(rightInput, "-10.5");
+        await userEvent.click(screen.getByText("Add filter"));
+
+        expect(getNextFilterParts()).toMatchObject({
+          operator: "between",
+          isNot: true,
+          column: expect.anything(),
+          values: [-10.5, 5],
+        });
+        expect(getNextFilterColumnName()).toBe("Total");
+      });
+
       it("should add a filter via keyboard", async () => {
         const { onChange, getNextFilterParts, getNextFilterColumnName } =
           setup();
@@ -408,6 +428,20 @@ describe("NumberFilterPicker", () => {
           expect(screen.getByText("Update filter")).toBeEnabled();
         },
       );
+
+      it("should render a not between filter", () => {
+        setup(
+          createQueryWithNumberFilter({
+            operator: "between",
+            isNot: true,
+            values: [1, 9],
+          }),
+        );
+
+        expect(screen.getByText("Not between")).toBeInTheDocument();
+        expect(screen.getByDisplayValue("1")).toBeInTheDocument();
+        expect(screen.getByDisplayValue("9")).toBeInTheDocument();
+      });
 
       it.each(BETWEEN_TEST_CASES)(
         "should update a filter with %i to %i values",

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/NumberFilterPicker/constants.ts
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/NumberFilterPicker/constants.ts
@@ -1,47 +1,47 @@
-import type * as Lib from "metabase-lib";
+import type { NumberFilterOperatorInfo, NumberPickerOperator } from "./types";
 
-import type { NumberFilterOperatorInfo } from "./types";
-
-export const OPERATORS: Record<
-  Lib.NumberFilterOperator,
-  NumberFilterOperatorInfo
-> = {
-  "=": {
-    operator: "=",
-    valueCount: 1,
-    hasMultipleValues: true,
-  },
-  "!=": {
-    operator: "!=",
-    valueCount: 1,
-    hasMultipleValues: true,
-  },
-  ">": {
-    operator: ">",
-    valueCount: 1,
-  },
-  "<": {
-    operator: "<",
-    valueCount: 1,
-  },
-  between: {
-    operator: "between",
-    valueCount: 2,
-  },
-  ">=": {
-    operator: ">=",
-    valueCount: 1,
-  },
-  "<=": {
-    operator: "<=",
-    valueCount: 1,
-  },
-  "is-null": {
-    operator: "is-null",
-    valueCount: 0,
-  },
-  "not-null": {
-    operator: "not-null",
-    valueCount: 0,
-  },
-};
+export const OPERATORS: Record<NumberPickerOperator, NumberFilterOperatorInfo> =
+  {
+    "=": {
+      operator: "=",
+      valueCount: 1,
+      hasMultipleValues: true,
+    },
+    "!=": {
+      operator: "!=",
+      valueCount: 1,
+      hasMultipleValues: true,
+    },
+    ">": {
+      operator: ">",
+      valueCount: 1,
+    },
+    "<": {
+      operator: "<",
+      valueCount: 1,
+    },
+    between: {
+      operator: "between",
+      valueCount: 2,
+    },
+    "not-between": {
+      operator: "not-between",
+      valueCount: 2,
+    },
+    ">=": {
+      operator: ">=",
+      valueCount: 1,
+    },
+    "<=": {
+      operator: "<=",
+      valueCount: 1,
+    },
+    "is-null": {
+      operator: "is-null",
+      valueCount: 0,
+    },
+    "not-null": {
+      operator: "not-null",
+      valueCount: 0,
+    },
+  };

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/NumberFilterPicker/hooks.ts
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/NumberFilterPicker/hooks.ts
@@ -2,8 +2,8 @@ import { useMemo, useState } from "react";
 
 import * as Lib from "metabase-lib";
 
-import type { NumberOrEmptyValue } from "./types";
-export type { NumberOrEmptyValue } from "./types";
+import type { NumberOrEmptyValue, NumberPickerOperator } from "./types";
+export type { NumberOrEmptyValue, NumberPickerOperator } from "./types";
 import {
   getAvailableOptions,
   getDefaultOperator,
@@ -33,8 +33,12 @@ export function useNumberFilter({
 
   const availableOptions = useMemo(() => getAvailableOptions(column), [column]);
 
-  const [operator, setOperator] = useState(() =>
-    filterParts ? filterParts.operator : getDefaultOperator(query, column),
+  const [operator, setOperator] = useState<NumberPickerOperator>(() =>
+    filterParts
+      ? filterParts.operator === "between" && filterParts.isNot
+        ? "not-between"
+        : filterParts.operator
+      : getDefaultOperator(query, column),
   );
 
   const [values, setValues] = useState(() =>
@@ -53,7 +57,7 @@ export function useNumberFilter({
     isValid,
     getDefaultValues,
     getFilterClause: (
-      operator: Lib.NumberFilterOperator,
+      operator: NumberPickerOperator,
       values: NumberOrEmptyValue[],
     ) => getFilterClause(operator, column, values),
     setOperator,

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/NumberFilterPicker/types.ts
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/NumberFilterPicker/types.ts
@@ -1,11 +1,13 @@
 import type { FilterOperatorOption } from "metabase/querying/filters/types";
 import type * as Lib from "metabase-lib";
 
+export type NumberPickerOperator = Lib.NumberFilterOperator | "not-between";
+
 export type NumberFilterOperatorOption =
-  FilterOperatorOption<Lib.NumberFilterOperator>;
+  FilterOperatorOption<NumberPickerOperator>;
 
 export type NumberFilterOperatorInfo = {
-  operator: Lib.NumberFilterOperator;
+  operator: NumberPickerOperator;
   valueCount: number;
   hasMultipleValues?: boolean;
 };

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/NumberFilterPicker/utils.ts
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/NumberFilterPicker/utils.ts
@@ -1,8 +1,14 @@
+import { t } from "ttag";
+
 import { isNotNull } from "metabase/lib/types";
 import * as Lib from "metabase-lib";
 
 import { OPERATORS } from "./constants";
-import type { NumberFilterOperatorOption, NumberOrEmptyValue } from "./types";
+import type {
+  NumberFilterOperatorOption,
+  NumberOrEmptyValue,
+  NumberPickerOperator,
+} from "./types";
 
 export function getAvailableOptions(
   column: Lib.ColumnMetadata,
@@ -12,18 +18,21 @@ export function getAvailableOptions(
 
   return Object.values(OPERATORS).map(({ operator }) => ({
     operator,
-    displayName: Lib.describeFilterOperator(operator, variant),
+    displayName:
+      operator === "not-between"
+        ? t`Not between`
+        : Lib.describeFilterOperator(operator, variant),
   }));
 }
 
-export function getOptionByOperator(operator: Lib.NumberFilterOperator) {
+export function getOptionByOperator(operator: NumberPickerOperator) {
   return OPERATORS[operator];
 }
 
 export function getDefaultOperator(
   query: Lib.Query,
   column: Lib.ColumnMetadata,
-): Lib.NumberFilterOperator {
+): NumberPickerOperator {
   const fieldValuesInfo = Lib.fieldValuesSearchInfo(query, column);
 
   return Lib.isPrimaryKey(column) ||
@@ -34,7 +43,7 @@ export function getDefaultOperator(
 }
 
 export function getDefaultValues(
-  operator: Lib.NumberFilterOperator,
+  operator: NumberPickerOperator,
   values: NumberOrEmptyValue[],
 ): NumberOrEmptyValue[] {
   const { valueCount, hasMultipleValues } = OPERATORS[operator];
@@ -48,7 +57,7 @@ export function getDefaultValues(
 }
 
 export function isValidFilter(
-  operator: Lib.NumberFilterOperator,
+  operator: NumberPickerOperator,
   column: Lib.ColumnMetadata,
   values: NumberOrEmptyValue[],
 ) {
@@ -56,7 +65,7 @@ export function isValidFilter(
 }
 
 export function getFilterClause(
-  operator: Lib.NumberFilterOperator,
+  operator: NumberPickerOperator,
   column: Lib.ColumnMetadata,
   values: NumberOrEmptyValue[],
 ) {
@@ -65,12 +74,13 @@ export function getFilterClause(
 }
 
 function getFilterParts(
-  operator: Lib.NumberFilterOperator,
+  operator: NumberPickerOperator,
   column: Lib.ColumnMetadata,
   values: NumberOrEmptyValue[],
 ): Lib.NumberFilterParts | undefined {
   switch (operator) {
     case "between":
+    case "not-between":
       return getBetweenFilterParts(operator, column, values);
     default:
       return getSimpleFilterParts(operator, column, values);
@@ -98,7 +108,7 @@ function getSimpleFilterParts(
 }
 
 function getBetweenFilterParts(
-  operator: Lib.NumberFilterOperator,
+  operator: Extract<NumberPickerOperator, "between" | "not-between">,
   column: Lib.ColumnMetadata,
   values: NumberOrEmptyValue[],
 ): Lib.NumberFilterParts | undefined {
@@ -108,10 +118,13 @@ function getBetweenFilterParts(
     const maxValue = startValue < endValue ? endValue : startValue;
 
     return {
-      operator,
+      operator: "between",
       column,
+      isNot: operator === "not-between",
       values: [minValue, maxValue],
     };
+  } else if (operator === "not-between") {
+    return undefined;
   } else if (isNotNull(startValue)) {
     return {
       operator: ">=",

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.tsx
@@ -12,7 +12,7 @@ import { WIDTH } from "../constants";
 import type { FilterChangeOpts, FilterPickerWidgetProps } from "../types";
 
 import { useTimeFilter } from "./hooks";
-import type { TimeValue } from "./types";
+import type { TimePickerOperator, TimeValue } from "./types";
 
 export function TimeFilterPicker({
   autoFocus,
@@ -48,7 +48,7 @@ export function TimeFilterPicker({
     filter,
   });
 
-  const handleOperatorChange = (newOperator: Lib.TimeFilterOperator) => {
+  const handleOperatorChange = (newOperator: TimePickerOperator) => {
     setOperator(newOperator);
     setValues(getDefaultValues(newOperator, values));
   };

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.unit.spec.tsx
@@ -17,6 +17,7 @@ const EXPECTED_OPERATORS = [
   "Before",
   "After",
   "Between",
+  "Not between",
   "Is empty",
   "Not empty",
 ];
@@ -242,6 +243,30 @@ describe("TimeFilterPicker", () => {
       expect(getNextFilterColumnName()).toBe("Time");
     });
 
+    it("should add a not between filter", async () => {
+      const { getNextFilterParts, getNextFilterColumnName } = setup();
+
+      await setOperator("Not between");
+
+      const [leftInput, rightInput] = screen.getAllByDisplayValue(
+        "00:00",
+      ) as HTMLInputElement[];
+      await typeTime(leftInput, "12:30");
+      await typeTime(rightInput, "11:15");
+      await userEvent.click(screen.getByText("Add filter"));
+
+      expect(getNextFilterParts()).toMatchObject({
+        operator: "between",
+        isNot: true,
+        column: expect.anything(),
+        values: [
+          dayjs("11:15", "HH:mm").toDate(),
+          dayjs("12:30", "HH:mm").toDate(),
+        ],
+      });
+      expect(getNextFilterColumnName()).toBe("Time");
+    });
+
     it("should add a filter with no values", async () => {
       const { getNextFilterParts, getNextFilterColumnName } = setup();
 
@@ -348,6 +373,23 @@ describe("TimeFilterPicker", () => {
         expect(screen.getByDisplayValue("11:15")).toBeInTheDocument();
         expect(screen.getByDisplayValue("13:00")).toBeInTheDocument();
         expect(screen.getByText("Update filter")).toBeEnabled();
+      });
+
+      it("should render a not between filter", () => {
+        setup(
+          createQueryWithTimeFilter({
+            operator: "between",
+            isNot: true,
+            values: [
+              dayjs("11:15", "HH:mm").toDate(),
+              dayjs("13:00", "HH:mm").toDate(),
+            ],
+          }),
+        );
+
+        expect(screen.getByText("Not between")).toBeInTheDocument();
+        expect(screen.getByDisplayValue("11:15")).toBeInTheDocument();
+        expect(screen.getByDisplayValue("13:00")).toBeInTheDocument();
       });
 
       it("should update a filter", async () => {

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/TimeFilterPicker/constants.ts
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/TimeFilterPicker/constants.ts
@@ -1,27 +1,28 @@
-import type * as Lib from "metabase-lib";
+import type { TimeFilterOperatorInfo, TimePickerOperator } from "./types";
 
-import type { TimeFilterOperatorInfo } from "./types";
-
-export const OPERATORS: Record<Lib.TimeFilterOperator, TimeFilterOperatorInfo> =
-  {
-    "<": {
-      operator: "<",
-      valueCount: 1,
-    },
-    ">": {
-      operator: ">",
-      valueCount: 1,
-    },
-    between: {
-      operator: "between",
-      valueCount: 2,
-    },
-    "is-null": {
-      operator: "is-null",
-      valueCount: 0,
-    },
-    "not-null": {
-      operator: "not-null",
-      valueCount: 0,
-    },
-  };
+export const OPERATORS: Record<TimePickerOperator, TimeFilterOperatorInfo> = {
+  "<": {
+    operator: "<",
+    valueCount: 1,
+  },
+  ">": {
+    operator: ">",
+    valueCount: 1,
+  },
+  between: {
+    operator: "between",
+    valueCount: 2,
+  },
+  "not-between": {
+    operator: "not-between",
+    valueCount: 2,
+  },
+  "is-null": {
+    operator: "is-null",
+    valueCount: 0,
+  },
+  "not-null": {
+    operator: "not-null",
+    valueCount: 0,
+  },
+};

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/TimeFilterPicker/hooks.ts
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/TimeFilterPicker/hooks.ts
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react";
 
 import * as Lib from "metabase-lib";
 
-import type { TimeValue } from "./types";
+import type { TimePickerOperator, TimeValue } from "./types";
 import {
   getAvailableOptions,
   getDefaultOperator,
@@ -31,8 +31,12 @@ export function useTimeFilter({
 
   const availableOptions = useMemo(() => getAvailableOptions(), []);
 
-  const [operator, setOperator] = useState(
-    filterParts ? filterParts.operator : getDefaultOperator(),
+  const [operator, setOperator] = useState<TimePickerOperator>(
+    filterParts
+      ? filterParts.operator === "between" && filterParts.isNot
+        ? "not-between"
+        : filterParts.operator
+      : getDefaultOperator(),
   );
   const [values, setValues] = useState(() =>
     getDefaultValues(operator, filterParts ? filterParts.values : []),
@@ -47,7 +51,7 @@ export function useTimeFilter({
     availableOptions,
     isValid,
     getDefaultValues,
-    getFilterClause: (operator: Lib.TimeFilterOperator, values: TimeValue[]) =>
+    getFilterClause: (operator: TimePickerOperator, values: TimeValue[]) =>
       getFilterClause(operator, column, values),
     setOperator,
     setValues,

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/TimeFilterPicker/types.ts
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/TimeFilterPicker/types.ts
@@ -1,11 +1,12 @@
 import type { FilterOperatorOption } from "metabase/querying/filters/types";
 import type * as Lib from "metabase-lib";
 
-export type TimeFilterOperatorOption =
-  FilterOperatorOption<Lib.TimeFilterOperator>;
+export type TimePickerOperator = Lib.TimeFilterOperator | "not-between";
+
+export type TimeFilterOperatorOption = FilterOperatorOption<TimePickerOperator>;
 
 export type TimeFilterOperatorInfo = {
-  operator: Lib.TimeFilterOperator;
+  operator: TimePickerOperator;
   valueCount: number;
 };
 

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/TimeFilterPicker/utils.ts
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/TimeFilterPicker/utils.ts
@@ -1,23 +1,31 @@
 import dayjs from "dayjs";
+import { t } from "ttag";
 
 import { isNotNull } from "metabase/lib/types";
 import * as Lib from "metabase-lib";
 
 import { OPERATORS } from "./constants";
-import type { TimeFilterOperatorOption, TimeValue } from "./types";
+import type {
+  TimeFilterOperatorOption,
+  TimePickerOperator,
+  TimeValue,
+} from "./types";
 
 export function getAvailableOptions(): TimeFilterOperatorOption[] {
   return Object.values(OPERATORS).map(({ operator }) => ({
     operator,
-    displayName: Lib.describeFilterOperator(operator, "temporal"),
+    displayName:
+      operator === "not-between"
+        ? t`Not between`
+        : Lib.describeFilterOperator(operator, "temporal"),
   }));
 }
 
-export function getOptionByOperator(operator: Lib.TimeFilterOperator) {
+export function getOptionByOperator(operator: TimePickerOperator) {
   return OPERATORS[operator];
 }
 
-export function getDefaultOperator(): Lib.TimeFilterOperator {
+export function getDefaultOperator(): TimePickerOperator {
   return "<";
 }
 
@@ -26,7 +34,7 @@ function getDefaultValue() {
 }
 
 export function getDefaultValues(
-  operator: Lib.TimeFilterOperator,
+  operator: TimePickerOperator,
   values: TimeValue[],
 ): TimeValue[] {
   const { valueCount } = OPERATORS[operator];
@@ -37,7 +45,7 @@ export function getDefaultValues(
 }
 
 export function isValidFilter(
-  operator: Lib.TimeFilterOperator,
+  operator: TimePickerOperator,
   column: Lib.ColumnMetadata,
   values: TimeValue[],
 ) {
@@ -45,7 +53,7 @@ export function isValidFilter(
 }
 
 export function getFilterClause(
-  operator: Lib.TimeFilterOperator,
+  operator: TimePickerOperator,
   column: Lib.ColumnMetadata,
   values: TimeValue[],
 ) {
@@ -58,7 +66,7 @@ export function getFilterClause(
 }
 
 function getFilterParts(
-  operator: Lib.TimeFilterOperator,
+  operator: TimePickerOperator,
   column: Lib.ColumnMetadata,
   values: TimeValue[],
 ): Lib.TimeFilterParts | undefined {
@@ -66,11 +74,12 @@ function getFilterParts(
     return undefined;
   }
 
-  if (operator === "between") {
+  if (operator === "between" || operator === "not-between") {
     const [startTime, endTime] = values;
     return {
-      operator,
+      operator: "between",
       column,
+      isNot: operator === "not-between",
       values: dayjs(endTime).isBefore(startTime)
         ? [endTime, startTime]
         : [startTime, endTime],

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/test-utils.ts
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/test-utils.ts
@@ -215,8 +215,9 @@ export function createQueryWithNumberFilter({
   column = findNumericColumn(query),
   operator = "=",
   values = [0],
+  ...parts
 }: NumberFilterQueryOpts = {}) {
-  const clause = Lib.numberFilterClause({ operator, column, values });
+  const clause = Lib.numberFilterClause({ operator, column, values, ...parts });
   return createFilteredQuery(query, clause);
 }
 
@@ -263,12 +264,14 @@ export function createQueryWithSpecificDateFilter({
   operator = "=",
   values = [new Date(2020, 1, 15)],
   hasTime = false,
+  ...parts
 }: SpecificDateFilterOpts = {}) {
   const clause = Lib.specificDateFilterClause({
     operator,
     column,
     values,
     hasTime,
+    ...parts,
   });
   return createFilteredQuery(query, clause);
 }
@@ -333,8 +336,9 @@ export function createQueryWithTimeFilter({
   column = findTimeColumn(query),
   operator = ">",
   values = [dayjs().startOf("day").toDate()],
+  ...parts
 }: TimeFilterOpts = {}) {
-  const clause = Lib.timeFilterClause({ operator, column, values });
+  const clause = Lib.timeFilterClause({ operator, column, values, ...parts });
   return createFilteredQuery(query, clause);
 }
 

--- a/frontend/src/metabase/querying/filters/types.ts
+++ b/frontend/src/metabase/querying/filters/types.ts
@@ -1,6 +1,6 @@
 import type * as Lib from "metabase-lib";
 
-export type FilterOperatorOption<T extends Lib.FilterOperator> = {
+export type FilterOperatorOption<T extends string = Lib.FilterOperator> = {
   operator: T;
   displayName: string;
 };

--- a/frontend/src/metabase/querying/filters/utils/dates.ts
+++ b/frontend/src/metabase/querying/filters/utils/dates.ts
@@ -80,7 +80,10 @@ function getSpecificDateValue(
 
   return {
     type: "specific",
-    operator: filterParts.operator,
+    operator:
+      filterParts.operator === "between" && filterParts.isNot
+        ? "not-between"
+        : filterParts.operator,
     values: filterParts.values,
     hasTime: filterParts.hasTime,
   };
@@ -155,8 +158,9 @@ function getSpecificFilterClause(
   value: SpecificDatePickerValue,
 ): Lib.ExpressionClause {
   return Lib.specificDateFilterClause({
-    operator: value.operator,
+    operator: value.operator === "not-between" ? "between" : value.operator,
     column,
+    isNot: value.operator === "not-between",
     values: value.values,
     hasTime: value.hasTime,
   });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/68228

### Description

Created new `isNot` filterparts to handle the negation the created MBQL query from the frontend

### Below steps can be used to verify that the changes are working as expected.

1. Open local metabase setup running in browser
2. New > Question
3. In search input type `Orders` and select the table
4. Go to filter option after click select `Quantity` column from popped dropdown option
5. Select `Not between` from the new dropdown option and specify range 0 in min and 3 in max then click the `Add filter` button
6. Select Sort by `Quantity` column then click Visualize button to view the output in table format
7. You can compare the output table without applying the `Not between` filter to test the feature


### Demo
Table output without applying `Not between` filter
<img width="2664" height="1712" alt="image" src="https://github.com/user-attachments/assets/14699905-2641-41df-abc7-a8b36384dd28" />

Table output after applying `Not between` filter
<img width="2276" height="1676" alt="image" src="https://github.com/user-attachments/assets/731c62e0-6f22-49c3-bb71-e84f4d86578a" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)