### PR TITLE
Clean up workspace schema and user-name code

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -3302,7 +3302,6 @@
            request
            settings
            sql-tools
-           system
            transforms
            transforms-base
            util

--- a/enterprise/backend/src/metabase_enterprise/workspaces/api/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/api/common.clj
@@ -588,7 +588,7 @@
       (not (or target-db-id ws-db-id))
       {:status 403 :body (deferred-tru "Must target a database")}
 
-      (when-let [schema (:schema target)] (str/starts-with? schema "mb__isolation_"))
+      (when-let [schema (:schema target)] (driver.u/workspace-isolated-schema? schema))
       {:status 403 :body (deferred-tru "Must not target an isolated workspace schema")}
 
       ;; Within a workspace, we defer blocking on conflicts outside the workspace

--- a/enterprise/backend/src/metabase_enterprise/workspaces/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/common.clj
@@ -5,6 +5,7 @@
    [metabase-enterprise.workspaces.models.workspace-log :as ws.log]
    [metabase-enterprise.workspaces.util :as ws.u]
    [metabase.api.common :as api]
+   [metabase.driver.util :as driver.u]
    [metabase.transforms-base.interface :as transforms-base.i]
    [metabase.util.log :as log]
    [metabase.util.quick-task :as quick-task]
@@ -86,7 +87,7 @@
    and transitions db_status to :pending. Returns the updated workspace with schema set."
   [workspace database-id]
   (let [database (t2/select-one :model/Database database-id)
-        schema   (ws.u/isolation-namespace-name workspace)
+        schema   (driver.u/workspace-isolation-namespace-name workspace)
         res      (t2/update! :model/Workspace {:id        (:id workspace)
                                                :db_status :uninitialized}
                              {:database_id database-id

--- a/enterprise/backend/src/metabase_enterprise/workspaces/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/workspaces/util.clj
@@ -1,7 +1,5 @@
 (ns metabase-enterprise.workspaces.util
   (:require
-   [clojure.string :as str]
-   [metabase.system.core :as system]
    [metabase.util.log :as log]
    [toucan2.core :as t2]))
 
@@ -51,29 +49,6 @@
 
 ;;; Naming
 
-;; re-using https://github.com/metabase/metabase/pull/61887/commits/c92e4a9cc451c61a13fef19ed9d6107873b17f07
-;; (original ws isolation code)
-(defn- instance-uuid-slug
-  "Create a slug from the site UUID, taking the first character of each section."
-  [site-uuid-string]
-  (->> (str/split site-uuid-string #"-")
-       (map first)
-       (apply str)))
-
-;; WARNING: Changing this prefix requires backwards compatibility handling for existing workspaces.
-;; The prefix is used to identify isolation namespaces in the database, and existing workspaces
-;; will have namespaces created with the current prefix.
-(def ^:private isolated-prefix "mb__isolation")
-
-(defn isolation-namespace-name
-  "Generate namespace/database name for workspace isolation following mb__isolation_<slug>_<workspace-id> pattern.
-  Uses 'namespace' as the generic term that maps to 'schema' in Postgres, 'database' in ClickHouse, etc."
-  [workspace]
-  (assert (some? (:id workspace)) "Workspace must have an :id")
-  (let [instance-slug      (instance-uuid-slug (str (system/site-uuid)))
-        clean-workspace-id (str/replace (str (:id workspace)) #"[^a-zA-Z0-9]" "_")]
-    (format "%s_%s_%s" isolated-prefix instance-slug clean-workspace-id)))
-
 (defn isolated-table-name
   "Generate name for a table mirroring transform target table in the isolated database namespace.
    Returns schema__name when schema is present, or __name when schema is nil (to distinguish from global tables)."
@@ -84,12 +59,6 @@
   (if schema
     (format "%s__%s" schema name)
     (format "__%s" name)))
-
-(defn isolation-user-name
-  "Generate username for workspace isolation."
-  [workspace]
-  (let [instance-slug (instance-uuid-slug (str (system/site-uuid)))]
-    (format "%s_%s_%s" isolated-prefix instance-slug (:id workspace))))
 
 (def ^:private password-char-sets
   "Character sets for password generation. Cycles through these to ensure representation from each."

--- a/enterprise/backend/test/metabase_enterprise/workspaces/isolation_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/workspaces/isolation_test.clj
@@ -4,7 +4,6 @@
    [clojure.test :refer :all]
    [metabase-enterprise.workspaces.common :as ws.common]
    [metabase-enterprise.workspaces.test-util :as ws.tu]
-   [metabase-enterprise.workspaces.util :as ws.u]
    [metabase.driver :as driver]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql.util :as sql.u]
@@ -34,8 +33,8 @@
 
 (defmethod workspace-isolation-resources-exist? :postgres
   [database workspace]
-  (let [schema-name (ws.u/isolation-namespace-name workspace)
-        username    (ws.u/isolation-user-name workspace)
+  (let [schema-name (driver.u/workspace-isolation-namespace-name workspace)
+        username    (driver.u/workspace-isolation-user-name workspace)
         conn-spec   (sql-jdbc.conn/db->pooled-connection-spec (:id database))]
     {:schema (has-results? conn-spec
                            ["SELECT 1 FROM information_schema.schemata WHERE schema_name = ?" schema-name])
@@ -54,10 +53,10 @@
 
 (defmethod workspace-isolation-resources-exist? :snowflake
   [database workspace]
-  (let [schema-name (ws.u/isolation-namespace-name workspace)
+  (let [schema-name (driver.u/workspace-isolation-namespace-name workspace)
         db-name     (-> database :details :db)
         role-name   (format "MB_ISOLATION_ROLE_%s" (:id workspace))
-        username    (ws.u/isolation-user-name workspace)
+        username    (driver.u/workspace-isolation-user-name workspace)
         conn-spec   (sql-jdbc.conn/db->pooled-connection-spec (:id database))]
     {:schema (has-results? conn-spec
                            [(format "SHOW SCHEMAS LIKE '%s' IN DATABASE \"%s\"" schema-name db-name)])
@@ -68,8 +67,8 @@
 
 (defmethod workspace-isolation-resources-exist? :sqlserver
   [database workspace]
-  (let [schema-name (ws.u/isolation-namespace-name workspace)
-        username    (ws.u/isolation-user-name workspace)
+  (let [schema-name (driver.u/workspace-isolation-namespace-name workspace)
+        username    (driver.u/workspace-isolation-user-name workspace)
         conn-spec   (sql-jdbc.conn/db->pooled-connection-spec (:id database))]
     {:schema (has-results? conn-spec
                            ["SELECT 1 FROM sys.schemas WHERE name = ?" schema-name])
@@ -80,8 +79,8 @@
 
 (defmethod workspace-isolation-resources-exist? :clickhouse
   [database workspace]
-  (let [db-name   (ws.u/isolation-namespace-name workspace)
-        username  (ws.u/isolation-user-name workspace)
+  (let [db-name   (driver.u/workspace-isolation-namespace-name workspace)
+        username  (driver.u/workspace-isolation-user-name workspace)
         conn-spec (sql-jdbc.conn/db->pooled-connection-spec (:id database))]
     {:database (has-results? conn-spec
                              ["SELECT 1 FROM system.databases WHERE name = ?" db-name])
@@ -90,8 +89,8 @@
 
 (defmethod workspace-isolation-resources-exist? :mysql
   [database workspace]
-  (let [db-name   (ws.u/isolation-namespace-name workspace)
-        username  (ws.u/isolation-user-name workspace)
+  (let [db-name   (driver.u/workspace-isolation-namespace-name workspace)
+        username  (driver.u/workspace-isolation-user-name workspace)
         conn-spec (sql-jdbc.conn/db->pooled-connection-spec (:id database))]
     {:database (has-results? conn-spec
                              ["SELECT 1 FROM information_schema.schemata WHERE schema_name = ?" db-name])

--- a/modules/drivers/redshift/test/metabase/test/data/redshift.clj
+++ b/modules/drivers/redshift/test/metabase/test/data/redshift.clj
@@ -20,6 +20,7 @@
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.driver.sql.test-util.unique-prefix :as sql.tu.unique-prefix]
+   [metabase.driver.util :as driver.u]
    [metabase.test :as mt]
    [metabase.test.data.impl :as data.impl]
    [metabase.test.data.interface :as tx]
@@ -33,11 +34,6 @@
 
 ;;; need to load this so we can properly override the implementation of `describe-database` below
 (comment metabase.driver.redshift/keep-me)
-
-(def ^:private workspace-isolation-prefix (or
-                                           @(requiring-resolve 'metabase-enterprise.workspaces.util/isolated-prefix)
-                                           ;; OSS might not be able to require it
-                                           "mb__isolation"))
 
 (defmethod driver/database-supports? [:redshift :test/time-type]
   [_driver _feature _database]
@@ -211,15 +207,14 @@
   left behind by workspace tests. Only deletes isolation schemas older than [[hours-before-expired-threshold]]
   to avoid interfering with parallel test runs."
   [^java.sql.Connection conn]
-  (let [isolation-pattern (str workspace-isolation-prefix "_")
-        {old-convention   :old
+  (let [{old-convention   :old
          caches-with-info :cache
          isolation        :isolation} (reduce (fn [acc s]
                                                 (cond (sql.tu.unique-prefix/old-dataset-name? s)
                                                       (update acc :old conj s)
                                                       (str/starts-with? s "metabase_cache_")
                                                       (update acc :cache conj s)
-                                                      (str/starts-with? s isolation-pattern)
+                                                      (driver.u/workspace-isolated-schema? s)
                                                       (update acc :isolation conj s)
                                                       :else acc))
                                               {:old [] :cache [] :isolation []}

--- a/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
+++ b/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
@@ -121,6 +121,7 @@
    {:write? false}
    (fn [^java.sql.Connection conn]
      (with-open [stmt (.createStatement conn)
+                 ;; Prefix must match driver.u/workspace-isolated-prefix
                  rs (.executeQuery stmt "SHOW SCHEMAS LIKE 'mb__isolation_%' IN ACCOUNT")]
        (let [three-hours-ago (-> (Instant/now)
                                  (.minus 3 ChronoUnit/HOURS)

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -772,10 +772,21 @@
        (map first)
        (apply str)))
 
-;; WARNING: Changing this prefix requires backwards compatibility handling for existing workspaces.
-;; The prefix is used to identify isolation namespaces in the database, and existing workspaces
-;; will have namespaces created with the current prefix.
+;; WARNING: Do NOT change this prefix. It is baked into existing workspace schemas in production databases.
+;; Changing it would require extreme care for backwards compatibility. If you need to match against this
+;; prefix, use [[workspace-isolated-schema?]] or [[workspace-isolated-schema-clause]] rather than hardcoding it.
 (def ^:private workspace-isolated-prefix "mb__isolation")
+
+(defn workspace-isolated-schema?
+  "Returns true if the given schema name belongs to a workspace isolation namespace."
+  [schema-name]
+  (str/starts-with? schema-name (str workspace-isolated-prefix "_")))
+
+(defn workspace-isolated-schema-clause
+  "Returns a HoneySQL [:like column pattern] clause that matches workspace isolation schemas.
+   `column` is typically `:schema`."
+  [column]
+  [:like column (str workspace-isolated-prefix "_%")])
 
 (defn workspace-isolation-namespace-name
   "Generate namespace/database name for workspace isolation following mb__isolation_<slug>_<workspace-id> pattern.

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -776,7 +776,8 @@
 ;; Changing it would require extreme care for backwards compatibility. If you need to match against this
 ;; prefix, use [[workspace-isolated-schema?]] or [[workspace-isolated-schema-clause]] rather than hardcoding it.
 (def ^:private workspace-isolated-prefix "mb__isolation_")
-(def ^:private workspace-isolated-like-pattern (str workspace-isolated-prefix "%"))
+;; Escaped for SQL LIKE: underscores are wildcards, so we escape them with backslash.
+(def ^:private workspace-isolated-like-pattern "mb\\_\\_isolation\\_%")
 
 (defn workspace-isolated-schema?
   "Returns true if the given schema name belongs to a workspace isolation namespace."

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -777,12 +777,16 @@
 ;; prefix, use [[workspace-isolated-schema?]] or [[workspace-isolated-schema-clause]] rather than hardcoding it.
 (def ^:private workspace-isolated-prefix "mb__isolation_")
 ;; Escaped for SQL LIKE: underscores are wildcards, so we escape them with backslash.
-(def ^:private workspace-isolated-like-pattern "mb\\_\\_isolation\\_%")
+;; The default escape character works across all supported app-database engines (H2, Postgres, MySQL, MariaDB),
+;; so an explicit ESCAPE clause is not necessary.
+(def ^:private workspace-isolated-like-pattern
+  (str (str/replace workspace-isolated-prefix "_" "\\_") "%"))
 
 (defn workspace-isolated-schema?
   "Returns true if the given schema name belongs to a workspace isolation namespace."
   [schema-name]
-  (str/starts-with? schema-name workspace-isolated-prefix))
+  (and (some? schema-name)
+       (str/starts-with? schema-name workspace-isolated-prefix)))
 
 (defn workspace-isolated-schema-clause
   "Returns a HoneySQL [:like column pattern] clause that matches workspace isolation schemas.

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -775,18 +775,19 @@
 ;; WARNING: Do NOT change this prefix. It is baked into existing workspace schemas in production databases.
 ;; Changing it would require extreme care for backwards compatibility. If you need to match against this
 ;; prefix, use [[workspace-isolated-schema?]] or [[workspace-isolated-schema-clause]] rather than hardcoding it.
-(def ^:private workspace-isolated-prefix "mb__isolation")
+(def ^:private workspace-isolated-prefix "mb__isolation_")
+(def ^:private workspace-isolated-like-pattern (str workspace-isolated-prefix "%"))
 
 (defn workspace-isolated-schema?
   "Returns true if the given schema name belongs to a workspace isolation namespace."
   [schema-name]
-  (str/starts-with? schema-name (str workspace-isolated-prefix "_")))
+  (str/starts-with? schema-name workspace-isolated-prefix))
 
 (defn workspace-isolated-schema-clause
   "Returns a HoneySQL [:like column pattern] clause that matches workspace isolation schemas.
    `column` is typically `:schema`."
   [column]
-  [:like column (str workspace-isolated-prefix "_%")])
+  [:like column workspace-isolated-like-pattern])
 
 (defn workspace-isolation-namespace-name
   "Generate namespace/database name for workspace isolation following mb__isolation_<slug>_<workspace-id> pattern.
@@ -795,13 +796,13 @@
   (assert (some? (:id workspace)) "Workspace must have an :id")
   (let [instance-slug      (instance-uuid-slug (str (system/site-uuid)))
         clean-workspace-id (str/replace (str (:id workspace)) #"[^a-zA-Z0-9]" "_")]
-    (format "%s_%s_%s" workspace-isolated-prefix instance-slug clean-workspace-id)))
+    (format "%s%s_%s" workspace-isolated-prefix instance-slug clean-workspace-id)))
 
 (defn workspace-isolation-user-name
   "Generate username for workspace isolation."
   [workspace]
   (let [instance-slug (instance-uuid-slug (str (system/site-uuid)))]
-    (format "%s_%s_%s" workspace-isolated-prefix instance-slug (:id workspace))))
+    (format "%s%s_%s" workspace-isolated-prefix instance-slug (:id workspace))))
 
 (def ^:private workspace-password-char-sets
   "Character sets for password generation. Cycles through these to ensure representation from each."

--- a/src/metabase/warehouses_rest/api.clj
+++ b/src/metabase/warehouses_rest/api.clj
@@ -1320,8 +1320,7 @@
                           (not include-workspace?) (conj [:or
                                                           [:= :schema nil]
                                                           [:not
-                                                          ;; TODO (Chris 2025-12-09) -- dislike coupling to a constant, at least until we have an e2e test
-                                                           [:like :schema "mb__isolation_%"]
+                                                           (driver.u/workspace-isolated-schema-clause :schema)
                                                           ;; TODO (Chris 2025-12-09) -- this might behave terribly without an index when there are lots of workspaces
                                                            #_[:exists {:select [1]
                                                                        :from   [[(t2/table-name :model/Workspace) :w]]

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -20,6 +20,7 @@
    [metabase.collections.models.collection :as collection]
    [metabase.config.core :as config]
    [metabase.content-verification.models.moderation-review :as moderation-review]
+   [metabase.driver.util :as driver.u]
    [metabase.lib.core :as lib]
    [metabase.permissions-rest.data-permissions.graph :as data-perms.graph]
    [metabase.permissions.core :as perms]
@@ -381,7 +382,7 @@
    (fn [_]
      (default-timestamped
       {:name   (str "Test Workspace " (u/generate-nano-id))
-       :schema (str "mb__isolation_" (u/generate-nano-id))}))
+       :schema (str @#'driver.u/workspace-isolated-prefix (u/generate-nano-id))}))
 
    :model/WorkspaceTransform
    (fn [_]


### PR DESCRIPTION
1. Protect against false positives in queries due to wildcard.
2. Single source of truth for the prefix "mb__isolation".
3. In-memory and in SQL matching methods to encapsulate things further.
4. Remove duplicate methods for schema and username generated.
5. Save unnecessary string building.
6. Remove requiring-resolve hack in the redshift test.

Closes [GDGT-2157: redshift tests require enterprise alias](https://linear.app/metabase/issue/GDGT-2157/redshift-tests-require-enterprise-alias)
