### PR TITLE
fixed translation issue with funnels

### DIFF
--- a/e2e/test/scenarios/admin/i18n/content-translation/dashboards.cy.spec.ts
+++ b/e2e/test/scenarios/admin/i18n/content-translation/dashboards.cy.spec.ts
@@ -988,4 +988,80 @@ describe("scenarios > content translation > static embeds > dashboards", () => {
   });
 
   describe("Boolean content", () => {});
+
+  describe("funnel chart with translated dimension values (metabase#71488)", () => {
+    beforeEach(() => {
+      H.restore();
+      cy.signInAsAdmin();
+      H.activateToken("bleeding-edge");
+
+      uploadTranslationDictionaryViaAPI([
+        { locale: "fr", msgid: "Gadget", msgstr: "Le gadget" },
+        { locale: "fr", msgid: "Doohickey", msgstr: "Le doohickey" },
+        { locale: "fr", msgid: "Gizmo", msgstr: "Le gizmo" },
+        { locale: "fr", msgid: "Widget", msgstr: "Le widget" },
+      ]);
+
+      cy.intercept("GET", "/api/embed/dashboard/*").as("dashboard");
+      cy.intercept("POST", "/api/card/*/query").as("cardQuery");
+
+      cy.signInAsAdmin();
+    });
+
+    it("should render funnel with translated dimension labels in a static embed", () => {
+      H.createQuestion({
+        name: "Products Funnel",
+        display: "funnel",
+        query: {
+          "source-table": PRODUCTS_ID,
+          aggregation: [["count"]],
+          breakout: [["field", PRODUCTS.CATEGORY, null]],
+        },
+        visualization_settings: {
+          "funnel.metric": "count",
+          "funnel.dimension": "CATEGORY",
+        },
+      }).then(({ body: card }) => {
+        H.createDashboard({
+          name: "funnel_dashboard",
+        }).then(({ body: { id: dashboardId } }) => {
+          // Add the funnel card to the dashboard
+          H.addOrUpdateDashboardCard({
+            dashboard_id: dashboardId,
+            card_id: card.id,
+            card: { size_x: 16, size_y: 8 },
+          });
+          H.visitDashboard(dashboardId);
+          H.openLegacyStaticEmbeddingModal({
+            resource: "dashboard",
+            resourceId: dashboardId,
+          });
+          H.publishChanges("dashboard", () => {});
+          H.visitEmbeddedPage(
+            {
+              resource: { dashboard: dashboardId as number },
+              params: {},
+            },
+            {
+              additionalHashOptions: {
+                locale: "fr",
+              },
+            },
+          );
+          cy.wait("@dashboard");
+          // cy.wait("@cardQuery");
+          // The funnel should render without crashing
+          cy.findByTestId("funnel-chart").should("exist");
+          // Dimension labels should be translated
+          cy.findAllByTestId("funnel-chart-header").should("have.length", 4);
+          cy.findByTestId("funnel-chart").within(() => {
+            cy.findByText("Le gadget").should("exist");
+            cy.findByText("Le doohickey").should("exist");
+            cy.findByText("Le gizmo").should("exist");
+            cy.findByText("Le widget").should("exist");
+          });
+        });
+      });
+    });
+  });
 });

--- a/e2e/test/scenarios/admin/i18n/content-translation/dashboards.cy.spec.ts
+++ b/e2e/test/scenarios/admin/i18n/content-translation/dashboards.cy.spec.ts
@@ -1048,9 +1048,8 @@ describe("scenarios > content translation > static embeds > dashboards", () => {
               },
             },
           );
-          cy.wait("@dashboard");
           // The funnel should render without crashing
-          cy.findByTestId("funnel-chart").should("exist");
+          cy.findByTestId("funnel-chart", { timeout: 10_000 }).should("exist");
           // Dimension labels should be translated
           cy.findAllByTestId("funnel-chart-header").should("have.length", 4);
           cy.findByTestId("funnel-chart").within(() => {

--- a/e2e/test/scenarios/admin/i18n/content-translation/dashboards.cy.spec.ts
+++ b/e2e/test/scenarios/admin/i18n/content-translation/dashboards.cy.spec.ts
@@ -1049,7 +1049,6 @@ describe("scenarios > content translation > static embeds > dashboards", () => {
             },
           );
           cy.wait("@dashboard");
-          // cy.wait("@cardQuery");
           // The funnel should render without crashing
           cy.findByTestId("funnel-chart").should("exist");
           // Dimension labels should be translated

--- a/frontend/src/metabase/visualizations/components/FunnelNormal.tsx
+++ b/frontend/src/metabase/visualizations/components/FunnelNormal.tsx
@@ -31,6 +31,7 @@ import type {
   VisualizationProps,
 } from "metabase/visualizations/types";
 import type { RowValue } from "metabase-types/api";
+import { getRowsForStableKeys } from "metabase-types/api";
 
 import { computeChange } from "../lib/numeric";
 
@@ -71,12 +72,21 @@ export function FunnelNormal({
     (col) => col.name === settings["funnel.metric"],
   );
 
+  // funnel.rows keys are generated from untranslated rows (via
+  // getRowsForStableKeys in Funnel.tsx) so that they stay stable across
+  // locales. We must match against the same untranslated values here,
+  // otherwise content-translated dimension values won't match their keys
+  // and the funnel renders empty (metabase#71488).
+  const rowsForKeys = getRowsForStableKeys(series.data);
   const sortedRows = settings["funnel.rows"]
     ? settings["funnel.rows"]
         .filter((fr) => fr.enabled)
-        .map((fr) =>
-          rows.find((row) => formatNullable(row[dimensionIndex]) === fr.key),
-        )
+        .map((fr) => {
+          const idx = rowsForKeys.findIndex(
+            (row) => formatNullable(row[dimensionIndex]) === fr.key,
+          );
+          return idx !== -1 ? rows[idx] : undefined;
+        })
         .filter(isNotNull)
     : rows;
 

--- a/frontend/src/metabase/visualizations/components/FunnelNormal.tsx
+++ b/frontend/src/metabase/visualizations/components/FunnelNormal.tsx
@@ -30,7 +30,7 @@ import type {
   HoveredObject,
   VisualizationProps,
 } from "metabase/visualizations/types";
-import type { RowValue } from "metabase-types/api";
+import type { RowValue, RowValues } from "metabase-types/api";
 import { getRowsForStableKeys } from "metabase-types/api";
 
 import { computeChange } from "../lib/numeric";
@@ -48,6 +48,27 @@ type FunnelStepInfo = {
   hovered?: HoveredObject;
   clicked?: ClickObject;
 };
+
+export function getSortedRows(
+  rows: RowValues[],
+  rowsForKeys: RowValues[],
+  dimensionIndex: number,
+  funnelRows: { key: string | number; enabled: boolean }[] | undefined,
+) {
+  if (!funnelRows) {
+    return rows;
+  }
+
+  return funnelRows
+    .filter((fr) => fr.enabled)
+    .map((fr) => {
+      const idx = rowsForKeys.findIndex(
+        (row) => formatNullable(row[dimensionIndex]) === fr.key,
+      );
+      return idx !== -1 ? rows[idx] : undefined;
+    })
+    .filter(isNotNull);
+}
 
 export function FunnelNormal({
   className,
@@ -78,17 +99,12 @@ export function FunnelNormal({
   // otherwise content-translated dimension values won't match their keys
   // and the funnel renders empty (metabase#71488).
   const rowsForKeys = getRowsForStableKeys(series.data);
-  const sortedRows = settings["funnel.rows"]
-    ? settings["funnel.rows"]
-        .filter((fr) => fr.enabled)
-        .map((fr) => {
-          const idx = rowsForKeys.findIndex(
-            (row) => formatNullable(row[dimensionIndex]) === fr.key,
-          );
-          return idx !== -1 ? rows[idx] : undefined;
-        })
-        .filter(isNotNull)
-    : rows;
+  const sortedRows = getSortedRows(
+    rows,
+    rowsForKeys,
+    dimensionIndex,
+    settings["funnel.rows"],
+  );
 
   const isNarrow = Boolean(gridSize && gridSize.width < 7);
   const isShort = Boolean(gridSize && gridSize.height <= 5);

--- a/frontend/src/metabase/visualizations/components/FunnelNormal.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/components/FunnelNormal.unit.spec.ts
@@ -1,0 +1,123 @@
+import { formatNullable } from "metabase/lib/formatting/nullable";
+import { isNotNull } from "metabase/lib/types";
+import { calculateFunnelSteps } from "metabase/visualizations/lib/funnel/utils";
+import type { RowValues } from "metabase-types/api";
+import { getRowsForStableKeys } from "metabase-types/api";
+
+/**
+ * These tests replicate the data flow inside FunnelNormal to demonstrate the
+ * bug in https://github.com/metabase/metabase/issues/71488.
+ *
+ * When content translation is active, `data.rows` contains translated values
+ * while `data.untranslatedRows` contains the originals. The `funnel.rows`
+ * setting keys are generated from `getRowsForStableKeys` (which prefers
+ * untranslatedRows), but FunnelNormal must match those keys against the
+ * untranslated rows and then return the *translated* rows for display.
+ */
+describe("FunnelNormal row matching (metabase#71488)", () => {
+  /**
+   * Mirrors the fixed matching logic in FunnelNormal.tsx:
+   * uses untranslated rows for key lookup, returns translated rows for display.
+   */
+  const getSortedRows = (
+    rows: RowValues[],
+    rowsForKeys: RowValues[],
+    dimensionIndex: number,
+    funnelRows: { key: string | number; enabled: boolean }[],
+  ) => {
+    return funnelRows
+      .filter((fr) => fr.enabled)
+      .map((fr) => {
+        const idx = rowsForKeys.findIndex(
+          (row) => formatNullable(row[dimensionIndex]) === fr.key,
+        );
+        return idx !== -1 ? rows[idx] : undefined;
+      })
+      .filter(isNotNull);
+  };
+
+  const untranslatedRows: RowValues[] = [
+    ["Awareness", 1000],
+    ["Consideration", 600],
+    ["Purchase", 200],
+  ];
+
+  const translatedRows: RowValues[] = [
+    ["Povědomí", 1000],
+    ["Zvažování", 600],
+    ["Nákup", 200],
+  ];
+
+  // Keys generated from untranslatedRows via getRowsForStableKeys,
+  // matching how Funnel.tsx getValue computes funnel.rows
+  const funnelRowsSettings = [
+    { key: "Awareness", name: "Awareness", enabled: true },
+    { key: "Consideration", name: "Consideration", enabled: true },
+    { key: "Purchase", name: "Purchase", enabled: true },
+  ];
+
+  const dimensionIndex = 0;
+
+  it("getRowsForStableKeys prefers untranslatedRows", () => {
+    const data = {
+      rows: translatedRows,
+      untranslatedRows,
+    };
+    expect(getRowsForStableKeys(data)).toBe(untranslatedRows);
+  });
+
+  it("matches rows when there is no content translation", () => {
+    const sortedRows = getSortedRows(
+      untranslatedRows,
+      untranslatedRows,
+      dimensionIndex,
+      funnelRowsSettings,
+    );
+    expect(sortedRows).toHaveLength(3);
+  });
+
+  it("returns translated rows for display while matching on untranslated keys", () => {
+    const data = { rows: translatedRows, untranslatedRows };
+    const rowsForKeys = getRowsForStableKeys(data);
+    const sortedRows = getSortedRows(
+      data.rows,
+      rowsForKeys,
+      dimensionIndex,
+      funnelRowsSettings,
+    );
+
+    expect(sortedRows).toHaveLength(3);
+
+    // The displayed dimension values should be the translated ones
+    expect(sortedRows[0][dimensionIndex]).toBe("Povědomí");
+    expect(sortedRows[1][dimensionIndex]).toBe("Zvažování");
+    expect(sortedRows[2][dimensionIndex]).toBe("Nákup");
+
+    // Metrics should still be correct
+    const metrics = sortedRows.map((row) => row[1]) as number[];
+    const funnelData = metrics.map(
+      (metric, i) => [i, metric] as [number, number],
+    );
+    expect(() => calculateFunnelSteps(funnelData, 1, 1)).not.toThrow();
+  });
+
+  it("handles disabled rows correctly", () => {
+    const data = { rows: translatedRows, untranslatedRows };
+    const rowsForKeys = getRowsForStableKeys(data);
+    const settingsWithDisabled = [
+      { key: "Awareness", name: "Awareness", enabled: true },
+      { key: "Consideration", name: "Consideration", enabled: false },
+      { key: "Purchase", name: "Purchase", enabled: true },
+    ];
+    const sortedRows = getSortedRows(
+      data.rows,
+      rowsForKeys,
+      dimensionIndex,
+      settingsWithDisabled,
+    );
+
+    expect(sortedRows).toHaveLength(2);
+    expect(sortedRows[0][dimensionIndex]).toBe("Povědomí");
+    expect(sortedRows[1][dimensionIndex]).toBe("Nákup");
+  });
+});

--- a/frontend/src/metabase/visualizations/components/FunnelNormal.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/components/FunnelNormal.unit.spec.ts
@@ -1,8 +1,8 @@
-import { formatNullable } from "metabase/lib/formatting/nullable";
-import { isNotNull } from "metabase/lib/types";
 import { calculateFunnelSteps } from "metabase/visualizations/lib/funnel/utils";
 import type { RowValues } from "metabase-types/api";
 import { getRowsForStableKeys } from "metabase-types/api";
+
+import { getSortedRows } from "./FunnelNormal";
 
 /**
  * These tests replicate the data flow inside FunnelNormal to demonstrate the
@@ -15,27 +15,6 @@ import { getRowsForStableKeys } from "metabase-types/api";
  * untranslated rows and then return the *translated* rows for display.
  */
 describe("FunnelNormal row matching (metabase#71488)", () => {
-  /**
-   * Mirrors the fixed matching logic in FunnelNormal.tsx:
-   * uses untranslated rows for key lookup, returns translated rows for display.
-   */
-  const getSortedRows = (
-    rows: RowValues[],
-    rowsForKeys: RowValues[],
-    dimensionIndex: number,
-    funnelRows: { key: string | number; enabled: boolean }[],
-  ) => {
-    return funnelRows
-      .filter((fr) => fr.enabled)
-      .map((fr) => {
-        const idx = rowsForKeys.findIndex(
-          (row) => formatNullable(row[dimensionIndex]) === fr.key,
-        );
-        return idx !== -1 ? rows[idx] : undefined;
-      })
-      .filter(isNotNull);
-  };
-
   const untranslatedRows: RowValues[] = [
     ["Awareness", 1000],
     ["Consideration", 600],
@@ -57,14 +36,6 @@ describe("FunnelNormal row matching (metabase#71488)", () => {
   ];
 
   const dimensionIndex = 0;
-
-  it("getRowsForStableKeys prefers untranslatedRows", () => {
-    const data = {
-      rows: translatedRows,
-      untranslatedRows,
-    };
-    expect(getRowsForStableKeys(data)).toBe(untranslatedRows);
-  });
 
   it("matches rows when there is no content translation", () => {
     const sortedRows = getSortedRows(


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #71488
Closes [EMB-1492: 59 broke funnel visualization with different locale in Static embedding](https://linear.app/metabase/issue/EMB-1492/59-broke-funnel-visualization-with-different-locale-in-static)

### Description

#63067 introduced content translation of row values in v59. It added an `untranslatedRows` field to `DatasetData` and started putting translated values in `data.rows`. Before this, `data.rows` always contained the original untranslated values.

The `funnel.rows` setting keys are generated from untranslated dimension values. `FunnelNormal` matched those keys against `data.rows`, which now contains translated values. With any non-English locale, no rows match, `sortedRows` is empty, and `calculateFunnelSteps` crashes on `undefined[1]`

### How to verify

1. Be on an enterprise instance
2. Set up content translations (a dictionary with entries for the funnel's dimension values)
3. Set locale to a non-English language that has translations in the dictionary
4. View a funnel chart via static embed


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
