### PR TITLE
Simplify static-viz custom plugin registration

### DIFF
--- a/frontend/src/metabase/static-viz/index.js
+++ b/frontend/src/metabase/static-viz/index.js
@@ -125,8 +125,6 @@ export function initializeContext(options) {
 }
 
 export function RenderChart(rawSeries, dashcardSettings, options) {
-  initializeContext(options);
-
   const renderingContext = createStaticRenderingContext(
     options.applicationColors,
   );

--- a/resources/frontend_shared/static_viz_interface.js
+++ b/resources/frontend_shared/static_viz_interface.js
@@ -37,39 +37,20 @@ function funnel(data, settings, tokenFeatures) {
 }
 
 
-// Pending custom viz plugin registrations, deferred until enterprise overrides are applied.
-var __pendingCustomVizRegistrations__ = [];
+function initialize_context(options) {
+  StaticViz.initializeContext(JSON.parse(options));
+}
 
 function register_custom_viz_plugin(identifier, assetsJson) {
   if (typeof __customVizPlugin__ === "function") {
     var assets = assetsJson ? JSON.parse(assetsJson) : {};
-    // Capture the factory now (before __customVizPlugin__ is overwritten by the next bundle load),
-    // but defer the actual registration until javascript_visualization runs initializeContext,
-    // which applies enterprise overrides and activates the real EE registerCustomVizPlugin.
-    __pendingCustomVizRegistrations__.push({
-      factory: __customVizPlugin__,
-      identifier,
-      assets,
-    });
+    StaticViz.registerCustomVizPlugin(__customVizPlugin__, identifier, assets);
   }
 }
 
 function javascript_visualization(rawSeries, dashcardSettings, options) {
-  var parsedOptions = JSON.parse(options);
-
-  // Apply enterprise overrides (EE registerCustomVizPlugin + customVizRegistry become active).
-  // This must happen before plugin registration so the real EE registry is populated.
-  StaticViz.initializeContext(parsedOptions);
-
-  // Register all deferred custom viz plugins now that the EE registry is active.
-  for (var i = 0; i < __pendingCustomVizRegistrations__.length; i++) {
-    var r = __pendingCustomVizRegistrations__[i];
-    StaticViz.registerCustomVizPlugin(r.factory, r.identifier, r.assets);
-  }
-  __pendingCustomVizRegistrations__ = [];
-
   var parsedSeries = JSON.parse(rawSeries);
-  var content = StaticViz.RenderChart(parsedSeries, JSON.parse(dashcardSettings), parsedOptions);
+  var content = StaticViz.RenderChart(parsedSeries, JSON.parse(dashcardSettings), JSON.parse(options));
   var type = content.startsWith("<svg") ? "svg" : "html";
 
   return JSON.stringify({ type, content });

--- a/src/metabase/channel/render/js/svg.clj
+++ b/src/metabase/channel/render/js/svg.clj
@@ -231,7 +231,12 @@
   "Clojure entrypoint to render javascript visualizations. This functions is dynamic only for testing purposes.
    `custom-viz-bundles` is an optional seq of `{:identifier str :source str :assets map}` maps for custom visualization plugins."
   [cards-with-data dashcard-viz-settings custom-viz-bundles]
-  (let [response (with-static-viz-context context
+  (let [options (json/encode {:applicationColors (appearance/application-colors)
+                              :startOfWeek      (lib-be/start-of-week)
+                              :customFormatting  (appearance/custom-formatting)
+                              :tokenFeatures    (premium-features/token-features)})
+        response (with-static-viz-context context
+                   (js.engine/execute-fn-name context "initialize_context" options)
                    (when (seq custom-viz-bundles)
                      (taint-context!)
                      (doseq [{:keys [identifier source assets]} custom-viz-bundles]
@@ -241,10 +246,7 @@
                    (.asString (js.engine/execute-fn-name context "javascript_visualization"
                                                          (json/encode cards-with-data)
                                                          (json/encode dashcard-viz-settings)
-                                                         (json/encode {:applicationColors (appearance/application-colors)
-                                                                       :startOfWeek (lib-be/start-of-week)
-                                                                       :customFormatting (appearance/custom-formatting)
-                                                                       :tokenFeatures (premium-features/token-features)}))))]
+                                                         options)))]
     (-> response
         json/decode+kw
         (update :type (fnil keyword "unknown")))))


### PR DESCRIPTION
## Summary

Previously the static visualization logic contained Enterprise options overrides executed just before rendering chart, and fetching and registration of custom bundles happened in the previous steps (basically, due to lack of understanding how whole pipeline works). Because of that, custom bundles couldn't be properly registered and were stored in a temporary array which was processed later after applying EE options and enabling custom viz support on the Metabase side.

By moving EE options initialization to a separate step we're now able to simplify custom plugins registration flow by removing this intermediate queue completely. 
