### PR TITLE
feat(sdk,embed-js): Improve EntityPicker mobile UX

### DIFF
--- a/e2e/test/scenarios/organization/entity-picker.cy.spec.ts
+++ b/e2e/test/scenarios/organization/entity-picker.cy.spec.ts
@@ -943,6 +943,43 @@ describe("scenarios > organization > entity picker", () => {
         .and("eq", "1198px");
     });
 
+    it("should scroll to the left edge of the newly opened column", () => {
+      cy.viewport(375, 800);
+      cy.visit("/");
+
+      H.openNavigationSidebar();
+      H.startNewCollectionFromSidebar();
+      cy.findByTestId("new-collection-modal")
+        .findByLabelText(/Collection it's saved in/)
+        .click();
+
+      H.entityPickerModal().within(() => {
+        // After opening, the first column (level 0) should be visible
+        cy.findByTestId("item-picker-level-0").should("be.visible");
+
+        // Navigate into a collection
+        H.entityPickerModalItem(1, "First collection").click();
+
+        // The new column should be visible
+        cy.findByTestId("item-picker-level-2").should("be.visible");
+
+        // The scroll container should be scrolled so that the new column's
+        // left edge aligns with the container's left edge
+        cy.findByTestId("nested-item-picker").should(($container) => {
+          const container = $container[0];
+          const lastColumn = container.querySelector(
+            "[data-testid='item-picker-level-2']",
+          );
+
+          expect(lastColumn).to.not.be.null;
+
+          expect(container.scrollLeft).to.equal(
+            (lastColumn as HTMLElement).offsetLeft,
+          );
+        });
+      });
+    });
+
     it("should restore previous path when clearing search from search results", () => {
       cy.visit("/");
       H.startNewQuestion();

--- a/frontend/src/metabase/common/components/Pickers/EntityPicker/components/AutoScrollBox.tsx
+++ b/frontend/src/metabase/common/components/Pickers/EntityPicker/components/AutoScrollBox.tsx
@@ -6,15 +6,15 @@ import { Box } from "metabase/ui";
 
 import S from "./EntityPicker.module.css";
 
-const scrollRight = (
+const scrollToLastColumn = (
   container: HTMLDivElement | null,
   behavior: "smooth" | "auto",
 ) => {
-  if (!container) {
-    return;
+  const lastColumn = container?.firstElementChild?.lastElementChild;
+
+  if (container && lastColumn instanceof HTMLElement) {
+    container.scrollTo({ left: lastColumn.offsetLeft, behavior });
   }
-  const diff = container.scrollWidth - container.clientWidth;
-  container.scrollBy({ left: diff, behavior });
 };
 
 export const AutoScrollBox = ({
@@ -36,7 +36,7 @@ export const AutoScrollBox = ({
     }
 
     if (contentHash !== previousContentHash) {
-      scrollRight(
+      scrollToLastColumn(
         containerRef.current,
         !previousContainerRef ? "auto" : "smooth",
       );

--- a/frontend/src/metabase/common/components/Pickers/EntityPicker/components/ButtonBar.tsx
+++ b/frontend/src/metabase/common/components/Pickers/EntityPicker/components/ButtonBar.tsx
@@ -65,8 +65,10 @@ export const ButtonBar = ({
       justify="space-between"
       align="center"
       p="md"
+      miw={0}
       style={{
         borderTop: "1px solid var(--mb-color-border)",
+        overflowX: "auto",
       }}
     >
       <Flex gap="md">

--- a/frontend/src/metabase/common/components/Pickers/EntityPicker/components/EntityPickerModal.tsx
+++ b/frontend/src/metabase/common/components/Pickers/EntityPicker/components/EntityPickerModal.tsx
@@ -217,7 +217,7 @@ const SearchInput = ({
       data-autofocus
       type="search"
       leftSection={<Icon name="search" size={16} />}
-      miw={400}
+      miw="min(400px, 100%)"
       placeholder={t`Search…`}
       value={localValue}
       onChange={(e) => {

--- a/frontend/src/metabase/common/components/Pickers/EntityPicker/components/NewCollectionDialog/NewCollectionDialog.tsx
+++ b/frontend/src/metabase/common/components/Pickers/EntityPicker/components/NewCollectionDialog/NewCollectionDialog.tsx
@@ -108,7 +108,7 @@ export const NewCollectionDialog = () => {
 
   return (
     <>
-      <Button onClick={open} disabled={!canCreateHere}>
+      <Button onClick={open} disabled={!canCreateHere} mr="md">
         {lastCollection?.namespace === "transforms" ||
         lastCollection?.namespace === "snippets"
           ? t`New folder`


### PR DESCRIPTION
Adjust EntityPicker mobile UX:
- proper horizontal scrolling to the selected column
- fixed buttons spacing
- fixed layout on narrow screens

Before:
see here videos https://linear.app/metabase/issue/EMB-1469/sdk-mobile-collection-selector-initialized-with-a-wrong-horizontal

After:

https://github.com/user-attachments/assets/32d72c95-73ac-413c-95d5-6d38664ed196

How to reproduce:
- can be reproduced on Chrome Desktop on narrow screens
- open app
- make screen narrow
- select menu, click the `+` button on the right side of the `collections` header in the menu
- in modal click `our analytics` and play with the entity picker styles/scrolling 
