### PR TITLE
GDGT-2119 omit BaseWidgetProps for Widgets

### DIFF
--- a/frontend/src/custom-viz/src/lib/defineSetting.ts
+++ b/frontend/src/custom-viz/src/lib/defineSetting.ts
@@ -1,14 +1,22 @@
 import type {
+  BaseWidgetProps,
   CustomVisualizationSettingDefinition,
   Series,
   WidgetName,
   Widgets,
 } from "../types";
 
+type OmitBaseWidgetProps<P> = keyof BaseWidgetProps<
+  unknown,
+  unknown
+> extends keyof P
+  ? Omit<P, keyof BaseWidgetProps<unknown, unknown>>
+  : P;
+
 type PropsFromWidget<W> = W extends WidgetName
   ? Widgets[W]
   : W extends (props: infer P) => any
-    ? P
+    ? OmitBaseWidgetProps<P>
     : never;
 
 export function defineSetting<


### PR DESCRIPTION
### Description

Omit BaseWidgetProps if a widget for the settings isn't a string. This enables clean `getProps` in [custom-viz-calendar-heatmap](https://github.com/metabase/custom-viz-calendar-heatmap):
<img width="475" height="258" alt="image" src="https://github.com/user-attachments/assets/68c6fd3c-c660-4d9c-8553-561d7b01bdca" />

As `CellShapeWidget` only expects `BaseWidgetProps` which are injected automatically. So, basically, `getProps` means `getAdditionalProps`. 
