### PR TITLE
Skipping GridMapPdfExport loki test

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/Map/GridMapPdfExport.stories.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Map/GridMapPdfExport.stories.tsx
@@ -208,4 +208,7 @@ export const GridMapPdfExport = {
     const asyncCallback = createAsyncCallback();
     await triggerPdfExport(canvasElement, asyncCallback);
   },
+  parameters: {
+    loki: { skip: true },
+  },
 };


### PR DESCRIPTION
### Description

Skips a flakey loki test. This test has external elements (like a leaflet tile server), and an animation component, making the test hard to keep consistent

### How to verify
Green CI 

