### PR TITLE
fix(sdk,embed-js): Adjust disabled state opacity for EditableText component

### DIFF
--- a/frontend/src/embedding-sdk-bundle/components/private/PublicComponentStylesWrapper.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/PublicComponentStylesWrapper.tsx
@@ -62,4 +62,13 @@ export const SCOPED_CSS_RESET = css`
   :where(.mb-wrapper) *:where(svg) {
     display: inline;
   }
+
+  // Mobile Safari sets the opacity of disabled inputs/textareas to 0.4 which we don't want
+  // https://github.com/metabase/metabase/issues/49170
+  @supports (-webkit-touch-callout: none) {
+    :where(.mb-wrapper) *:where(input),
+    :where(.mb-wrapper) *:where(textarea) {
+      opacity: 1;
+    }
+  }
 `;

--- a/frontend/src/metabase/css/core/base.styled.ts
+++ b/frontend/src/metabase/css/core/base.styled.ts
@@ -45,9 +45,10 @@ export const baseStyle = css`
     list-style-type: none;
   }
 
-  // Mobile Safari sets the opacity of disabled inputs to 0.4 which we don't want
+  // Mobile Safari sets the opacity of disabled inputs/textareas to 0.4 which we don't want
   // https://github.com/metabase/metabase/issues/49170
   @supports (-webkit-touch-callout: none) {
+    textarea:disabled,
     input:disabled {
       opacity: 1;
     }


### PR DESCRIPTION
Adjust disabled state opacity for colors on IOS for inputs/textarea elements.
In the SDK case it affects dashboard titles and tab font colors

Root cause:
- on IOS it sets default `opacity: 0.4` for disabled input/textarea elements, so the title is gray-ish. We fix it by setting opacity to the expected `1` value.
- we already had a partial fix on the level of the main app for inputs, so i added there textareas as well
- we didn't had such a style reset for SDK, so i added it

### Main app: 

Before:
![telegram-cloud-photo-size-2-5361547348393270291-y](https://github.com/user-attachments/assets/4643075d-a30d-4f2a-92a5-b46c1f608e44)

After:
![telegram-cloud-photo-size-2-5361547348393270292-y](https://github.com/user-attachments/assets/7b106bbd-22f4-4a7b-85ef-634b0518f3c7)

### SDK:

Before:
<img width="1179" height="704" alt="image" src="https://github.com/user-attachments/assets/1ce24e52-7f9d-4975-8d19-0dae5e1b4121" />

After: 
![telegram-cloud-photo-size-2-5361547348393270394-y](https://github.com/user-attachments/assets/40792128-3ce1-4730-9102-a3adeeb5369a)


How to test:
- test the main app dashboard with tabs on the mobile device, check title and tab colors
- we should also test SDK fix: build uberjar and use it in our sample app with local-dist (or rely on images below)
