### PR TITLE
Fix /api/database/:id/metadata to return inactive tables when remove_inactive=false

### DIFF
--- a/src/metabase/warehouses/models/database.clj
+++ b/src/metabase/warehouses/models/database.clj
@@ -532,7 +532,7 @@
   "Return the `Tables` associated with this `Database`."
   [{:keys [id]}]
   ;; TODO - do we want to include tables that should be `:hidden`?
-  (t2/select :model/Table :db_id id :active true {:order-by [[:%lower.display_name :asc]]}))
+  (t2/select :model/Table :db_id id {:order-by [[:%lower.display_name :asc]]}))
 
 (methodical/defmethod t2/batched-hydrate [:model/Database :tables]
   "Batch hydrate `Tables` for the given `Database`."
@@ -543,7 +543,6 @@
               ;; TODO - do we want to include tables that should be `:hidden`?
               (t2/select :model/Table
                          :db_id  [:in (map :id databases)]
-                         :active true
                          {:order-by [[:db_id :asc] [:%lower.display_name :asc]]}))
    :id
    {:default []}))

--- a/test/metabase/warehouses_rest/api_test.clj
+++ b/test/metabase/warehouses_rest/api_test.clj
@@ -817,11 +817,20 @@
 
 (deftest ^:parallel fetch-database-metadata-remove-inactive-test
   (mt/with-temp [:model/Database {db-id :id} {}
-                 :model/Table    _ {:db_id db-id, :active false}]
-    (testing "GET /api/database/:id/metadata?include_hidden=true"
+                 :model/Table    _ {:db_id db-id, :active false, :name "INACTIVE_TABLE"}
+                 :model/Table    _ {:db_id db-id, :active true, :name "ACTIVE_TABLE"}]
+    (testing "remove_inactive=true excludes inactive tables"
       (let [tables (->> (mt/user-http-request :rasta :get 200 (format "database/%d/metadata?remove_inactive=true" db-id))
                         :tables)]
-        (is (= () tables))))))
+        (is (= ["ACTIVE_TABLE"] (map :name tables)))))
+    (testing "remove_inactive=false includes inactive tables"
+      (let [tables (->> (mt/user-http-request :rasta :get 200 (format "database/%d/metadata?remove_inactive=false" db-id))
+                        :tables)]
+        (is (= #{"ACTIVE_TABLE" "INACTIVE_TABLE"} (set (map :name tables))))))
+    (testing "default (no remove_inactive param) includes inactive tables"
+      (let [tables (->> (mt/user-http-request :rasta :get 200 (format "database/%d/metadata" db-id))
+                        :tables)]
+        (is (= #{"ACTIVE_TABLE" "INACTIVE_TABLE"} (set (map :name tables))))))))
 
 (deftest fetch-database-metadata-skip-fields-test
   (mt/with-empty-h2-app-db!

--- a/test/metabase/warehouses_rest/api_test.clj
+++ b/test/metabase/warehouses_rest/api_test.clj
@@ -819,15 +819,15 @@
   (mt/with-temp [:model/Database {db-id :id} {}
                  :model/Table    _ {:db_id db-id, :active false, :name "INACTIVE_TABLE"}
                  :model/Table    _ {:db_id db-id, :active true, :name "ACTIVE_TABLE"}]
-    (testing "remove_inactive=true excludes inactive tables"
+    (testing "GET /api/database/:id/metadata?remove_inactive=true"
       (let [tables (->> (mt/user-http-request :rasta :get 200 (format "database/%d/metadata?remove_inactive=true" db-id))
                         :tables)]
         (is (= ["ACTIVE_TABLE"] (map :name tables)))))
-    (testing "remove_inactive=false includes inactive tables"
+    (testing "GET /api/database/:id/metadata?remove_inactive=false"
       (let [tables (->> (mt/user-http-request :rasta :get 200 (format "database/%d/metadata?remove_inactive=false" db-id))
                         :tables)]
         (is (= #{"ACTIVE_TABLE" "INACTIVE_TABLE"} (set (map :name tables))))))
-    (testing "default (no remove_inactive param) includes inactive tables"
+    (testing "GET /api/database/:id/metadata"
       (let [tables (->> (mt/user-http-request :rasta :get 200 (format "database/%d/metadata" db-id))
                         :tables)]
         (is (= #{"ACTIVE_TABLE" "INACTIVE_TABLE"} (set (map :name tables))))))))


### PR DESCRIPTION
## Summary

- Remove hard-coded `:active true` from the `batched-hydrate [:model/Database :tables]` method in `database.clj`, which was filtering out inactive tables before the API-level `remove_inactive` parameter could take effect
- The API layer already correctly filters inactive tables when `remove_inactive=true`; the hydration just needs to provide all tables so `remove_inactive=false` (the default) actually works

Fixes #71822

## Test plan

- [x] Added test case: `remove_inactive=true` excludes inactive tables (returns only active)
- [x] Added test case: `remove_inactive=false` includes inactive tables
- [x] Added test case: default (no param) includes inactive tables
- [x] Verified `hydrate-tables-test` still passes (sample DB has no inactive tables)

🤖 Generated with [Claude Code](https://claude.com/claude-code)