### PR TITLE
Enable commented out drill-thru tests

### DIFF
--- a/test/metabase/lib/drill_thru_test.cljc
+++ b/test/metabase/lib/drill_thru_test.cljc
@@ -794,36 +794,37 @@
                                                                  {:name "≠"}]}
                     {:row-count 3, :table-name "Orders", :type :drill-thru/underlying-records}]}))
 
-;; FIXME: for some reason the results for aggregated query are not correct (#34223, #34341)
 (deftest ^:parallel available-drill-thrus-test-13
-  (testing "We expect column-filter and sort drills, but get distribution and summarize-column"
-    #_(lib.drill-thru.tu/test-available-drill-thrus
-       {:click-type  :header
-        :query-type  :aggregated
-        :column-name "count"
-        :expected    [{:type :drill-thru/column-filter}
-                      {:sort-directions [:asc :desc], :type :drill-thru/sort}]})))
+  (testing "Aggregated columns should get column-filter and sort drills, not distribution and summarize-column (#34223, #34341)"
+    (lib.drill-thru.tu/test-available-drill-thrus
+     {:click-type   :header
+      :query-type   :aggregated
+      :column-name  "count"
+      :query-kinds  [:mbql]
+      :expected     [{:type :drill-thru/column-filter}
+                     {:sort-directions [:asc :desc], :type :drill-thru/sort}]})))
 
-;; FIXME: for some reason the results for aggregated query are not correct (#34223, #34341)
 (deftest ^:parallel available-drill-thrus-test-14
-  (testing "We expect column-filter and sort drills, but get distribution and summarize-column"
-    #_(lib.drill-thru.tu/test-available-drill-thrus
-       {:click-type  :header
-        :query-type  :aggregated
-        :column-name "PRODUCT_ID"
-        :expected    [{:type :drill-thru/column-filter}
-                      {:sort-directions [:asc :desc], :type :drill-thru/sort}]})))
+  (testing "Breakout columns in aggregated query should get column-filter and sort drills (#34223, #34341)"
+    (lib.drill-thru.tu/test-available-drill-thrus
+     {:click-type   :header
+      :query-type   :aggregated
+      :column-name  "PRODUCT_ID"
+      :query-kinds  [:mbql]
+      :expected     [{:type :drill-thru/column-filter}
+                     {:sort-directions [:asc :desc], :type :drill-thru/sort}]})))
 
-;; FIXME: for some reason the results for aggregated query are not correct (#34223, #34341)
 (deftest ^:parallel available-drill-thrus-test-15
-  (testing "We expect column-filter and sort drills, but get distribution and summarize-column"
-    #_(lib.drill-thru.tu/test-available-drill-thrus
-       {:click-type  :header
-        :query-type  :aggregated
-        :column-name "CREATED_AT"
-        :expected    [{:type            :drill-thru/column-filter}
-                      {:type            :drill-thru/sort
-                       :sort-directions [:asc :desc]}]})))
+  (testing "Breakout columns in aggregated query should get column-filter and sort drills (#34223, #34341)"
+    (lib.drill-thru.tu/test-available-drill-thrus
+     {:click-type   :header
+      :query-type   :aggregated
+      :column-name  "CREATED_AT"
+      :query-kinds  [:mbql]
+      :expected     [{:type            :drill-thru/column-filter}
+                     {:type            :drill-thru/sort
+                      :sort-directions [:asc :desc]}
+                     {:type            :drill-thru/column-extract}]})))
 
 (deftest ^:parallel available-drill-thrus-no-column-drills-for-nil-dimension-values-test
   (testing "column header drills should not be returned when dimensions have nil values (#49740, #51741)"


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #34341
Closes QUE2-140

### Description

The original fix was tested against FE unit tests and merged on a feature branch, parallel to that, the tests were migrated to the BE in disabled state. This PR re-enables them.

### How to verify

The uncommented tests should pass.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
