### PR TITLE
Separate embedding_route from embedding_client

### DIFF
--- a/resources/migrations/060/20260326_enhanced_usage_analytics.yaml
+++ b/resources/migrations/060/20260326_enhanced_usage_analytics.yaml
@@ -260,6 +260,36 @@ databaseChangeLog:
               - column:
                   name: tenant_id
 
+  - changeSet:
+      id: v60.2026-03-26T00:00:21
+      author: bgrabow
+      comment: Add embedding_route column to view_log for API surface tracking
+      changes:
+        - addColumn:
+            tableName: view_log
+            columns:
+              - column:
+                  name: embedding_route
+                  type: varchar(64)
+                  remarks: API route surface (e.g. public, guest-embed, metabot, agent-api)
+                  constraints:
+                    nullable: true
+
+  - changeSet:
+      id: v60.2026-03-26T00:00:22
+      author: bgrabow
+      comment: Add embedding_route column to query_execution for API surface tracking
+      changes:
+        - addColumn:
+            tableName: query_execution
+            columns:
+              - column:
+                  name: embedding_route
+                  type: varchar(64)
+                  remarks: API route surface (e.g. public, guest-embed, metabot, agent-api)
+                  constraints:
+                    nullable: true
+
   # ============================================================
   # Analytics view updates - add embedding_client, surface, is_preview
   # ============================================================

--- a/resources/migrations/060/20260326_enhanced_usage_analytics.yaml
+++ b/resources/migrations/060/20260326_enhanced_usage_analytics.yaml
@@ -262,7 +262,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v60.2026-03-26T00:00:21
-      author: bgrabow
+      author: bcm
       comment: Add embedding_route column to view_log for API surface tracking
       changes:
         - addColumn:
@@ -277,7 +277,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v60.2026-03-26T00:00:22
-      author: bgrabow
+      author: bcm
       comment: Add embedding_route column to query_execution for API surface tracking
       changes:
         - addColumn:

--- a/resources/migrations/instance_analytics_views/query_log/v5/h2-query_log.sql
+++ b/resources/migrations/instance_analytics_views/query_log/v5/h2-query_log.sql
@@ -26,7 +26,12 @@ SELECT id AS entity_id,
        lens_params,
        query,
        embedding_client,
+       embedding_route,
        CASE
+         WHEN COALESCE(embedding_route, embedding_client) = 'public'       THEN 'public-link'
+         WHEN COALESCE(embedding_route, embedding_client) = 'guest-embed'  THEN 'static-embed'
+         WHEN COALESCE(embedding_route, embedding_client) = 'metabot'      THEN 'metabot'
+         WHEN COALESCE(embedding_route, embedding_client) = 'agent-api'    THEN 'agent-api'
          WHEN embedding_client = 'embedding-sdk-react'         THEN 'sdk'
          WHEN embedding_client = 'embedding-sdk-react-preview' THEN 'sdk-preview'
          WHEN embedding_client = 'embedding-iframe'            THEN 'iframe'
@@ -35,8 +40,6 @@ SELECT id AS entity_id,
          WHEN embedding_client = 'public-preview'              THEN 'public-link-preview'
          WHEN embedding_client = 'guest-embed'                 THEN 'static-embed'
          WHEN embedding_client = 'guest-embed-preview'         THEN 'static-embed-preview'
-         WHEN embedding_client = 'metabot'                     THEN 'metabot'
-         WHEN embedding_client = 'agent-api'                   THEN 'agent-api'
          WHEN embedding_client IS NULL OR embedding_client = '' THEN 'internal'
          ELSE embedding_client
        END AS surface,

--- a/resources/migrations/instance_analytics_views/query_log/v5/mysql-query_log.sql
+++ b/resources/migrations/instance_analytics_views/query_log/v5/mysql-query_log.sql
@@ -28,7 +28,12 @@ SELECT id AS entity_id,
        lens_params,
        query,
        embedding_client,
+       embedding_route,
        CASE
+         WHEN COALESCE(embedding_route, embedding_client) = 'public'       THEN 'public-link'
+         WHEN COALESCE(embedding_route, embedding_client) = 'guest-embed'  THEN 'static-embed'
+         WHEN COALESCE(embedding_route, embedding_client) = 'metabot'      THEN 'metabot'
+         WHEN COALESCE(embedding_route, embedding_client) = 'agent-api'    THEN 'agent-api'
          WHEN embedding_client = 'embedding-sdk-react'         THEN 'sdk'
          WHEN embedding_client = 'embedding-sdk-react-preview' THEN 'sdk-preview'
          WHEN embedding_client = 'embedding-iframe'            THEN 'iframe'
@@ -37,8 +42,6 @@ SELECT id AS entity_id,
          WHEN embedding_client = 'public-preview'              THEN 'public-link-preview'
          WHEN embedding_client = 'guest-embed'                 THEN 'static-embed'
          WHEN embedding_client = 'guest-embed-preview'         THEN 'static-embed-preview'
-         WHEN embedding_client = 'metabot'                     THEN 'metabot'
-         WHEN embedding_client = 'agent-api'                   THEN 'agent-api'
          WHEN embedding_client IS NULL OR embedding_client = '' THEN 'internal'
          ELSE embedding_client
        END AS surface,

--- a/resources/migrations/instance_analytics_views/query_log/v5/postgres-query_log.sql
+++ b/resources/migrations/instance_analytics_views/query_log/v5/postgres-query_log.sql
@@ -26,7 +26,12 @@ SELECT id AS entity_id,
        lens_params,
        query,
        embedding_client,
+       embedding_route,
        CASE
+         WHEN COALESCE(embedding_route, embedding_client) = 'public'       THEN 'public-link'
+         WHEN COALESCE(embedding_route, embedding_client) = 'guest-embed'  THEN 'static-embed'
+         WHEN COALESCE(embedding_route, embedding_client) = 'metabot'      THEN 'metabot'
+         WHEN COALESCE(embedding_route, embedding_client) = 'agent-api'    THEN 'agent-api'
          WHEN embedding_client = 'embedding-sdk-react'         THEN 'sdk'
          WHEN embedding_client = 'embedding-sdk-react-preview' THEN 'sdk-preview'
          WHEN embedding_client = 'embedding-iframe'            THEN 'iframe'
@@ -35,8 +40,6 @@ SELECT id AS entity_id,
          WHEN embedding_client = 'public-preview'              THEN 'public-link-preview'
          WHEN embedding_client = 'guest-embed'                 THEN 'static-embed'
          WHEN embedding_client = 'guest-embed-preview'         THEN 'static-embed-preview'
-         WHEN embedding_client = 'metabot'                     THEN 'metabot'
-         WHEN embedding_client = 'agent-api'                   THEN 'agent-api'
          WHEN embedding_client IS NULL OR embedding_client = '' THEN 'internal'
          ELSE embedding_client
        END AS surface,

--- a/resources/migrations/instance_analytics_views/view_log/v4/h2-view_log.sql
+++ b/resources/migrations/instance_analytics_views/view_log/v4/h2-view_log.sql
@@ -7,7 +7,12 @@ CREATE OR REPLACE VIEW v_view_log AS
                          model_id AS entity_id,
                          model || '_' || model_id AS entity_qualified_id,
                          embedding_client,
+                         embedding_route,
                          CASE
+                           WHEN COALESCE(embedding_route, embedding_client) = 'public'       THEN 'public-link'
+                           WHEN COALESCE(embedding_route, embedding_client) = 'guest-embed'  THEN 'static-embed'
+                           WHEN COALESCE(embedding_route, embedding_client) = 'metabot'      THEN 'metabot'
+                           WHEN COALESCE(embedding_route, embedding_client) = 'agent-api'    THEN 'agent-api'
                            WHEN embedding_client = 'embedding-sdk-react'         THEN 'sdk'
                            WHEN embedding_client = 'embedding-sdk-react-preview' THEN 'sdk-preview'
                            WHEN embedding_client = 'embedding-iframe'            THEN 'iframe'
@@ -16,8 +21,6 @@ CREATE OR REPLACE VIEW v_view_log AS
                            WHEN embedding_client = 'public-preview'              THEN 'public-link-preview'
                            WHEN embedding_client = 'guest-embed'                 THEN 'static-embed'
                            WHEN embedding_client = 'guest-embed-preview'         THEN 'static-embed-preview'
-                           WHEN embedding_client = 'metabot'                     THEN 'metabot'
-                           WHEN embedding_client = 'agent-api'                   THEN 'agent-api'
                            WHEN embedding_client IS NULL OR embedding_client = '' THEN 'internal'
                            ELSE embedding_client
                          END AS surface,

--- a/resources/migrations/instance_analytics_views/view_log/v4/mysql-view_log.sql
+++ b/resources/migrations/instance_analytics_views/view_log/v4/mysql-view_log.sql
@@ -9,7 +9,12 @@ VIEW v_view_log AS
                          model_id AS entity_id,
                          concat(model, '_', model_id) AS entity_qualified_id,
                          embedding_client,
+                         embedding_route,
                          CASE
+                           WHEN COALESCE(embedding_route, embedding_client) = 'public'       THEN 'public-link'
+                           WHEN COALESCE(embedding_route, embedding_client) = 'guest-embed'  THEN 'static-embed'
+                           WHEN COALESCE(embedding_route, embedding_client) = 'metabot'      THEN 'metabot'
+                           WHEN COALESCE(embedding_route, embedding_client) = 'agent-api'    THEN 'agent-api'
                            WHEN embedding_client = 'embedding-sdk-react'         THEN 'sdk'
                            WHEN embedding_client = 'embedding-sdk-react-preview' THEN 'sdk-preview'
                            WHEN embedding_client = 'embedding-iframe'            THEN 'iframe'
@@ -18,8 +23,6 @@ VIEW v_view_log AS
                            WHEN embedding_client = 'public-preview'              THEN 'public-link-preview'
                            WHEN embedding_client = 'guest-embed'                 THEN 'static-embed'
                            WHEN embedding_client = 'guest-embed-preview'         THEN 'static-embed-preview'
-                           WHEN embedding_client = 'metabot'                     THEN 'metabot'
-                           WHEN embedding_client = 'agent-api'                   THEN 'agent-api'
                            WHEN embedding_client IS NULL OR embedding_client = '' THEN 'internal'
                            ELSE embedding_client
                          END AS surface,

--- a/resources/migrations/instance_analytics_views/view_log/v4/postgres-view_log.sql
+++ b/resources/migrations/instance_analytics_views/view_log/v4/postgres-view_log.sql
@@ -7,7 +7,12 @@ CREATE OR REPLACE VIEW v_view_log AS
                          model_id AS entity_id,
                          model || '_' || model_id AS entity_qualified_id,
                          embedding_client,
+                         embedding_route,
                          CASE
+                           WHEN COALESCE(embedding_route, embedding_client) = 'public'       THEN 'public-link'
+                           WHEN COALESCE(embedding_route, embedding_client) = 'guest-embed'  THEN 'static-embed'
+                           WHEN COALESCE(embedding_route, embedding_client) = 'metabot'      THEN 'metabot'
+                           WHEN COALESCE(embedding_route, embedding_client) = 'agent-api'    THEN 'agent-api'
                            WHEN embedding_client = 'embedding-sdk-react'         THEN 'sdk'
                            WHEN embedding_client = 'embedding-sdk-react-preview' THEN 'sdk-preview'
                            WHEN embedding_client = 'embedding-iframe'            THEN 'iframe'
@@ -16,8 +21,6 @@ CREATE OR REPLACE VIEW v_view_log AS
                            WHEN embedding_client = 'public-preview'              THEN 'public-link-preview'
                            WHEN embedding_client = 'guest-embed'                 THEN 'static-embed'
                            WHEN embedding_client = 'guest-embed-preview'         THEN 'static-embed-preview'
-                           WHEN embedding_client = 'metabot'                     THEN 'metabot'
-                           WHEN embedding_client = 'agent-api'                   THEN 'agent-api'
                            WHEN embedding_client IS NULL OR embedding_client = '' THEN 'internal'
                            ELSE embedding_client
                          END AS surface,

--- a/src/metabase/analytics/core.clj
+++ b/src/metabase/analytics/core.clj
@@ -58,6 +58,7 @@
   pii-request-info
   with-auth-method! get-auth-method
   with-client! get-client
+  with-route! get-route
   with-version! get-version]
 
  [metabase.analytics.settings

--- a/src/metabase/analytics/sdk.clj
+++ b/src/metabase/analytics/sdk.clj
@@ -38,6 +38,15 @@
 
 (defn get-client "Returns [[*client*]] dynamic var" [] *client*)
 
+(def ^:dynamic *route* "The API route surface that served this request (e.g. \"public\", \"guest-embed\")." nil)
+
+(defmacro with-route! "Binds [[*route*]] for the duration of `body`."
+  [[value] & body]
+  `(binding [*route* ~value]
+     ~@body))
+
+(defn get-route "Returns [[*route*]]." [] *route*)
+
 (def ^:dynamic *auth-method* "Used to track the authentication method for the current request (e.g. \"password\", \"jwt\", \"api-key\")." nil)
 
 (defmacro with-auth-method! "Binds [[*auth-method*]] for the duration of `body`."
@@ -96,6 +105,7 @@
   [m :- :map]
   (-> m
       (update :embedding_client (fn [client] (or *client* client)))
+      (update :embedding_route (fn [route] (or *route* route)))
       (update :embedding_version (fn [version] (or *version* version)))
       (update :auth_method (fn [method] (or *auth-method* method)))
       (merge (pii-fields))))
@@ -126,35 +136,34 @@
    ["/api/metabot/" "metabot"]
    ["/api/agent/" "agent-api"]])
 
-(defn- derived-client
-  [{:keys [uri metabase-client-header]}]
-  (let [route-client (first (keep (fn [[prefix client]]
-                                    (when (str/starts-with? (or uri "") prefix) client))
-                                  route-client-mapping))]
-    (or route-client metabase-client-header)))
+(defn- route-surface
+  "Returns the route-based surface identifier for the given URI, or nil if no route matches."
+  [uri]
+  (first (keep (fn [[prefix surface]]
+                 (when (str/starts-with? (or uri "") prefix) surface))
+               route-client-mapping)))
 
 (defn embedding-mw
-  "Reads Metabase Client and Version headers and binds them to *metabase-client{-version}*."
+  "Reads Metabase Client and Version headers and binds them to *client*, *version*, and *route*."
   [handler]
   (fn embedding-mw-fn
     [request respond raise]
-    (let [metabase-client-header (get-in request [:headers "x-metabase-client"])
-          version (get-in request [:headers "x-metabase-client-version"])
-          preview? (= (get-in request [:headers "x-metabase-embedded-preview"]) "true")
-          sdk-client (derived-client {:uri (:uri request) :metabase-client-header metabase-client-header})]
-      ;; Keep "-preview" suffix so preview requests are distinguishable for auditing
-      ;; (admins can query sensitive data via the embed preview wizard). Usage analytics
-      ;; views (EMB-1503) will de-emphasize preview but still surface it.
-      (binding [*client* (if preview? (str sdk-client "-preview") sdk-client)
+    (let [client-header (get-in request [:headers "x-metabase-client"])
+          version       (get-in request [:headers "x-metabase-client-version"])
+          preview?      (= (get-in request [:headers "x-metabase-embedded-preview"]) "true")
+          route         (route-surface (:uri request))
+          client        (cond-> client-header preview? (some-> (str "-preview")))]
+      (binding [*client*  client
+                *route*   route
                 *version* version]
         (handler request
                  (fn responder [response]
-                   (when (embedding-context? sdk-client)
-                     (track-sdk-response sdk-client response))
+                   (when (and (not route) (embedding-context? client-header))
+                     (track-sdk-response client-header response))
                    (respond response))
                  (fn raiser [response]
-                   (when (embedding-context? sdk-client)
-                     (track-sdk-response sdk-client
+                   (when (and (not route) (embedding-context? client-header))
+                     (track-sdk-response client-header
                                          (if (:status response)
                                            response
                                            {:status 500})))

--- a/test/metabase/server/middleware/sdk_test.clj
+++ b/test/metabase/server/middleware/sdk_test.clj
@@ -157,64 +157,89 @@
                  (fn [_ respond _] (respond {:status 200 :body (sdk/get-client)})))]
     (:body (handler request identity identity))))
 
+(defn- route-from-mw
+  "Runs a request through embedding-mw and returns the *route* value bound inside the handler."
+  [request]
+  (let [handler (analytics/embedding-mw
+                 (fn [_ respond _] (respond {:status 200 :body (sdk/get-route)})))]
+    (:body (handler request identity identity))))
+
 (deftest route-based-client-derivation-test
-  (testing "route prefix determines client value, ignoring any header"
-    (are [uri expected]
-         (= expected (client-from-mw (assoc (ring.mock/request :get uri)
-                                            :uri uri)))
+  (testing "route prefix populates *route*, not *client*"
+    (are [uri expected-route]
+         (= expected-route (route-from-mw (assoc (ring.mock/request :get uri) :uri uri)))
       "/api/public/card/1"         "public"
       "/api/embed/dashboard/42"    "guest-embed"
       "/api/preview-embed/card/1"  "guest-embed"
       "/api/metabot/query"         "metabot"
       "/api/agent/chat"            "agent-api"))
-  (testing "route wins over X-Metabase-Client header"
+  (testing "route requests without header give nil *client*"
+    (is (nil? (client-from-mw (assoc (ring.mock/request :get "/api/public/card/1")
+                                     :uri "/api/public/card/1")))))
+  (testing "header populates *client* independently of route"
     (let [request (-> (ring.mock/request :get "/api/public/card/1")
                       (assoc :uri "/api/public/card/1")
                       (ring.mock/header "x-metabase-client" "embedding-sdk-react"))]
-      (is (= "public" (client-from-mw request)))))
-  (testing "falls back to header when no route matches"
+      (is (= "embedding-sdk-react" (client-from-mw request)))
+      (is (= "public" (route-from-mw request)))))
+  (testing "header populates *client* when no route matches"
     (let [request (-> (ring.mock/request :get "/api/card/1")
                       (ring.mock/header "x-metabase-client" "embedding-sdk-react"))]
       (is (= "embedding-sdk-react" (client-from-mw request)))))
   (testing "nil when no route match and no header"
-    (is (nil? (client-from-mw (ring.mock/request :get "/api/card/1"))))))
+    (is (nil? (client-from-mw (ring.mock/request :get "/api/card/1"))))
+    (is (nil? (route-from-mw (ring.mock/request :get "/api/card/1"))))))
 
 (deftest preview-suffix-test
-  (testing "preview header appends -preview to route-derived client"
-    (let [request (-> (ring.mock/request :get "/api/embed/dashboard/42")
-                      (assoc :uri "/api/embed/dashboard/42")
-                      (ring.mock/header "x-metabase-embedded-preview" "true"))]
-      (is (= "guest-embed-preview" (client-from-mw request)))))
   (testing "preview header appends -preview to header-derived client"
     (let [request (-> (ring.mock/request :get "/api/card/1")
                       (ring.mock/header "x-metabase-client" "embedding-sdk-react")
                       (ring.mock/header "x-metabase-embedded-preview" "true"))]
       (is (= "embedding-sdk-react-preview" (client-from-mw request)))))
+  (testing "preview with route but no header gives nil client (no string to suffix)"
+    (let [request (-> (ring.mock/request :get "/api/embed/dashboard/42")
+                      (assoc :uri "/api/embed/dashboard/42")
+                      (ring.mock/header "x-metabase-embedded-preview" "true"))]
+      (is (nil? (client-from-mw request)))
+      (is (= "guest-embed" (route-from-mw request)))))
+  (testing "preview does not affect *route*"
+    (let [request (-> (ring.mock/request :get "/api/embed/dashboard/42")
+                      (assoc :uri "/api/embed/dashboard/42")
+                      (ring.mock/header "x-metabase-client" "embedding-sdk-react")
+                      (ring.mock/header "x-metabase-embedded-preview" "true"))]
+      (is (= "embedding-sdk-react-preview" (client-from-mw request)))
+      (is (= "guest-embed" (route-from-mw request)))))
   (testing "no -preview without the header"
     (let [request (-> (ring.mock/request :get "/api/embed/dashboard/42")
-                      (assoc :uri "/api/embed/dashboard/42"))]
-      (is (= "guest-embed" (client-from-mw request))))))
+                      (assoc :uri "/api/embed/dashboard/42")
+                      (ring.mock/header "x-metabase-client" "embedding-iframe"))]
+      (is (= "embedding-iframe" (client-from-mw request))))))
 
 (deftest include-analytics-is-idempotent
   (let [m (atom {})]
     (analytics/with-client! ["client-C"]
-      (analytics/with-version! ["1.33.7"]
-        (is (= {:embedding_client "client-C"
-                :embedding_version "1.33.7"
-                :auth_method       nil}
-               (analytics/include-sdk-info @m)))
-        (swap! m analytics/include-sdk-info)))
-    ;; unset the vars:
-    (analytics/with-client! [nil]
-      (analytics/with-version! [nil]
-        (is (= {:embedding_client "client-C"
-                :embedding_version "1.33.7"
-                :auth_method       nil} @m))
-        (testing "the values in m are used when the vars are not set"
-          (is (= {:embedding_client "client-C"
+      (analytics/with-route! ["public"]
+        (analytics/with-version! ["1.33.7"]
+          (is (= {:embedding_client  "client-C"
+                  :embedding_route   "public"
                   :embedding_version "1.33.7"
                   :auth_method       nil}
-                 (analytics/include-sdk-info @m))))))))
+                 (analytics/include-sdk-info @m)))
+          (swap! m analytics/include-sdk-info))))
+    ;; unset the vars:
+    (analytics/with-client! [nil]
+      (analytics/with-route! [nil]
+        (analytics/with-version! [nil]
+          (is (= {:embedding_client  "client-C"
+                  :embedding_route   "public"
+                  :embedding_version "1.33.7"
+                  :auth_method       nil} @m))
+          (testing "the values in m are used when the vars are not set"
+            (is (= {:embedding_client  "client-C"
+                    :embedding_route   "public"
+                    :embedding_version "1.33.7"
+                    :auth_method       nil}
+                   (analytics/include-sdk-info @m)))))))))
 
 (deftest include-sdk-info-pii-fields-test
   (let [request (-> (ring.mock/request :get "/api/public/card/1")

--- a/test/metabase/view_log/events/view_log_test.clj
+++ b/test/metabase/view_log/events/view_log_test.clj
@@ -272,7 +272,7 @@
           (testing "GET /api/public/card/:uuid/query"
             (client/client :get 202 (str "public/card/" (:public_uuid card) "/query"))
             (is (partial= {:model "card", :model_id (:id card), :has_access true, :context :question
-                           :embedding_client "public"}
+                           :embedding_route "public"}
                           (latest-view nil (:id card))))))))))
 
 (deftest public-dashboard-card-query-view-log-test
@@ -304,7 +304,7 @@
           (testing "GET /api/embed/card/:token/query"
             (client/client :get 202 (str (embed-test/card-url card) "/query"))
             (is (partial= {:model "card", :model_id (:id card), :has_access true
-                           :embedding_client "guest-embed"}
+                           :embedding_route "guest-embed"}
                           (latest-view nil (:id card))))))))))
 
 (deftest embedded-dashboard-card-query-view-log-test
@@ -330,15 +330,16 @@
             (is (partial= {:model "dashboard", :model_id (:id dash), :has_access true}
                           (latest-view nil (:id dash))))))))))
 
-(deftest server-side-binding-wins-over-client-header-test
+(deftest client-and-route-stored-independently-test
   (mt/with-premium-features #{:audit-app}
-    (testing "Server-side embedding_client binding wins over X-Metabase-Client header"
+    (testing "Header goes to embedding_client, route goes to embedding_route"
       (mt/with-temporary-setting-values [enable-public-sharing true]
         (public-test/with-temp-public-card [card]
           (client/client :get 202 (str "public/card/" (:public_uuid card) "/query")
                          {:request-options {:headers {"x-metabase-client" "embedding-sdk-react"}}})
-          (is (= "public"
-                 (:embedding_client (latest-view nil (:id card))))))))))
+          (let [view (latest-view nil (:id card))]
+            (is (= "embedding-sdk-react" (:embedding_client view)))
+            (is (= "public" (:embedding_route view)))))))))
 
 (defn- latest-qe
   "Returns the most recent QueryExecution for a given card ID."
@@ -415,7 +416,7 @@
                   (is (= "TestAgent/1.0"   (:sanitized_user_agent view)))))
               (testing "in query_execution"
                 (let [qe (latest-qe (:id card))]
-                  (is (= "public"          (:embedding_client qe)))
+                  (is (= "public"          (:embedding_route qe)))
                   (is (= "app.example.com" (:embedding_hostname qe)))
                   (is (= "/dashboard/1"    (:embedding_path qe)))
                   (is (= "TestAgent/1.0"   (:sanitized_user_agent qe))))))))
@@ -457,7 +458,7 @@
                   (is (= "DashAgent/2.0"    (:sanitized_user_agent view)))))
               (testing "in query_execution"
                 (let [qe (latest-qe (:id card))]
-                  (is (= "public"           (:embedding_client qe)))
+                  (is (= "public"           (:embedding_route qe)))
                   (is (= "dash.example.com" (:embedding_hostname qe)))
                   (is (= "/analytics"       (:embedding_path qe)))
                   (is (= "DashAgent/2.0"    (:sanitized_user_agent qe))))))))))))
@@ -482,15 +483,15 @@
               (is (nil? (:auth_method view)))
               (is (nil? (:auth_method qe))))))))))
 
-(deftest route-client-mapping-test
-  (testing "combinations of routes and header values"
-    (testing "Some routes override the header value"
-      (is (= "public" (#'sdk/derived-client {:uri "/api/public/something" :metabase-client-header "header"})))
-      (is (= "guest-embed" (#'sdk/derived-client {:uri "/api/embed/something" :metabase-client-header "header"})))
-      (is (= "guest-embed" (#'sdk/derived-client {:uri "/api/preview-embed/something" :metabase-client-header "header"})))
-      (is (= "metabot" (#'sdk/derived-client {:uri "/api/metabot/something" :metabase-client-header "header"})))
-      (is (= "agent-api" (#'sdk/derived-client {:uri "/api/agent/something" :metabase-client-header "header"}))))
-    (testing "The rest of the routes use the header value"
-      (is (= "header" (#'sdk/derived-client {:uri "no-mapping" :metabase-client-header "header"}))))))
+(deftest route-surface-test
+  (testing "route-surface returns the surface for known route prefixes"
+    (is (= "public" (#'sdk/route-surface "/api/public/something")))
+    (is (= "guest-embed" (#'sdk/route-surface "/api/embed/something")))
+    (is (= "guest-embed" (#'sdk/route-surface "/api/preview-embed/something")))
+    (is (= "metabot" (#'sdk/route-surface "/api/metabot/something")))
+    (is (= "agent-api" (#'sdk/route-surface "/api/agent/something"))))
+  (testing "returns nil for unrecognized routes"
+    (is (nil? (#'sdk/route-surface "no-mapping")))
+    (is (nil? (#'sdk/route-surface "/api/card/1")))))
 
 ;;; ---------------------------------------- API tests end -----------------------------------------


### PR DESCRIPTION
## Summary

`embedding_client` was conflating two distinct concepts into one column:
1. **Which SDK/client made the request** (from `X-Metabase-Client` header - e.g., `embedding-sdk-react`, `embedding-iframe`)
2. **Which API route/surface served the request** (from route-level mapping - e.g., `public`, `guest-embed`, `metabot`)

This made it impossible to distinguish e.g. React SDK vs EAJS hitting the same embed route (Nicolo flagged this).

**Fix:** Store them independently in two columns:
- `embedding_client` = raw `X-Metabase-Client` header value (the SDK identity)
- `embedding_route` = route surface match (`public`, `guest-embed`, `metabot`, `agent-api`)

No precedence logic at write time - both are recorded as-is. The analytics views derive `surface` from `COALESCE(embedding_route, embedding_client)` so historical rows (which have route values baked into `embedding_client`) still work correctly.

### Changes
- **`sdk.clj`**: Added `*route*` dynamic var, replaced `derived-client` with `route-surface`, updated middleware to bind both independently
- **Migration**: Added `embedding_route` varchar(64) to `view_log` and `query_execution`
- **6 analytics view SQL files**: Added `embedding_route`, updated `surface` CASE to use COALESCE
- **Tests**: Updated to reflect two-column behavior

### Design decisions
- Prometheus tracking preserved: route requests skip prometheus even if header is an SDK client (matches old behavior)
- `-preview` suffix only applies to `*client*`, not `*route*` (`is_preview` derives from `embedding_client LIKE '%-preview'`)
- Additive and reversible - new nullable column, no destructive changes

## Test plan
- [x] `metabase.server.middleware.sdk-test` (13 tests, 75 assertions)
- [x] `metabase.view-log.events.view-log-test` (29 tests, 94 assertions)