### PR TITLE
Update description for logarithm value parameter

### DIFF
--- a/frontend/src/metabase/querying/expressions/config.ts
+++ b/frontend/src/metabase/querying/expressions/config.ts
@@ -1382,7 +1382,7 @@ const MATH = defineClauses(
         {
           name: t`column`,
           type: "number",
-          description: t`The column or number to return the natural logarithm value of.`,
+          description: t`The column or number to return the base 10 logarithm value of.`,
           example: dimension(t`Value`),
         },
       ],


### PR DESCRIPTION
natural != base 10. Our log is base 10 (the docstring for the function itself is correct, the mistake is specifically in parameter description)