### PR TITLE
Fix colors in metrics viewer

### DIFF
--- a/e2e/test/scenarios/metrics/metrics-explorer.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/metrics-explorer.cy.spec.ts
@@ -1,3 +1,5 @@
+import Color from "color";
+
 const { H } = cy;
 import { SAMPLE_DB_ID, WRITABLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
@@ -906,6 +908,79 @@ describe("scenarios > metrics > explorer", () => {
         event: "metrics_viewer_filter_removed",
         triggered_from: "dimension_filter",
       });
+    });
+
+    it("should preserve breakout colors when a dimension filter hides some values", () => {
+      selectBreakout("Count of orders", "Quantity");
+      cy.wait("@dataset");
+
+      const colorsBefore: Record<string, string> = {};
+
+      H.MetricsViewer.breakoutLegend()
+        .find("[class*=dot]")
+        .each(($dot) => {
+          const color = $dot.css("background-color");
+          const label = $dot.next().text();
+          colorsBefore[label] = color;
+        })
+        .then(() => {
+          expect(Object.keys(colorsBefore).length).to.be.greaterThan(0);
+        });
+
+      H.MetricsViewer.getMerticControls()
+        .findByRole("button", { name: /All time/i })
+        .click();
+      H.popover()
+        .findByText(/Fixed date/)
+        .click();
+      H.popover().within(() => {
+        cy.findByRole("textbox", { name: "Start date" })
+          .clear()
+          .type("February 1, 2024");
+        cy.findByRole("textbox", { name: "End date" })
+          .clear()
+          .type("February 7, 2024");
+        cy.button("Add filter").click();
+      });
+
+      cy.wait("@dataset");
+
+      H.MetricsViewer.breakoutLegend()
+        .find("[class*=dot]")
+        .then(($dots) => {
+          expect($dots.length).to.be.lessThan(
+            Object.keys(colorsBefore).length,
+            "Filtering should reduce the number of legend items",
+          );
+
+          const legendHexColors: string[] = [];
+
+          $dots.each((_i, dot) => {
+            const $dot = Cypress.$(dot);
+            const color = $dot.css("background-color");
+            const label = $dot.next().text();
+            expect(colorsBefore[label]).to.equal(
+              color,
+              `Color for "${label}" should be stable after filtering`,
+            );
+            legendHexColors.push(Color(color).hex());
+          });
+
+          cy.log("Chart series colors should match legend colors");
+          for (const hex of legendHexColors) {
+            H.echartsContainer().find(`path[stroke="${hex}"]`).should("exist");
+          }
+
+          cy.log("Search pill color indicator should match legend count");
+          H.MetricsViewer.searchBarPills()
+            .contains(
+              "[data-testid=metrics-viewer-search-pill]",
+              "Count of orders",
+            )
+            .findByTestId("color-indicator-container")
+            .children()
+            .should("have.length", legendHexColors.length);
+        });
     });
   });
 

--- a/e2e/test/scenarios/metrics/metrics-explorer.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/metrics-explorer.cy.spec.ts
@@ -917,7 +917,7 @@ describe("scenarios > metrics > explorer", () => {
       const colorsBefore: Record<string, string> = {};
 
       H.MetricsViewer.breakoutLegend()
-        .find("[class*=dot]")
+        .findAllByTestId("breakout-legend-dot")
         .each(($dot) => {
           const color = $dot.css("background-color");
           const label = $dot.next().text();
@@ -946,7 +946,7 @@ describe("scenarios > metrics > explorer", () => {
       cy.wait("@dataset");
 
       H.MetricsViewer.breakoutLegend()
-        .find("[class*=dot]")
+        .findAllByTestId("breakout-legend-dot")
         .then(($dots) => {
           expect($dots.length).to.be.lessThan(
             Object.keys(colorsBefore).length,

--- a/frontend/src/metabase/metrics-viewer/components/BreakoutLegend/BreakoutLegend.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/BreakoutLegend/BreakoutLegend.tsx
@@ -56,6 +56,7 @@ export function BreakoutLegend({
                 <Flex key={item.label} align="center" gap="sm">
                   <Box
                     className={S.dot}
+                    data-testid="breakout-legend-dot"
                     w="0.625rem"
                     h="0.625rem"
                     bdrs="50%"

--- a/frontend/src/metabase/metrics-viewer/components/BreakoutLegend/BreakoutLegend.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/BreakoutLegend/BreakoutLegend.tsx
@@ -1,12 +1,10 @@
 import { useMemo } from "react";
 
 import { Box, Flex, Paper, Stack, Text, Title } from "metabase/ui";
-import type { MetricBreakoutValuesResponse } from "metabase-types/api";
 
 import type {
-  MetricSourceId,
   MetricsViewerDefinitionEntry,
-  SourceColorMap,
+  SourceBreakoutColorMap,
 } from "../../types/viewer-state";
 import { buildLegendGroups } from "../../utils/legend";
 
@@ -14,19 +12,16 @@ import S from "./BreakoutLegend.module.css";
 
 type BreakoutLegendProps = {
   definitions: MetricsViewerDefinitionEntry[];
-  breakoutValuesBySourceId: Map<MetricSourceId, MetricBreakoutValuesResponse>;
-  sourceColors: SourceColorMap;
+  activeBreakoutColors: SourceBreakoutColorMap;
 };
 
 export function BreakoutLegend({
   definitions,
-  breakoutValuesBySourceId,
-  sourceColors,
+  activeBreakoutColors,
 }: BreakoutLegendProps) {
   const groups = useMemo(
-    () =>
-      buildLegendGroups(definitions, breakoutValuesBySourceId, sourceColors),
-    [definitions, breakoutValuesBySourceId, sourceColors],
+    () => buildLegendGroups(definitions, activeBreakoutColors),
+    [definitions, activeBreakoutColors],
   );
 
   if (groups.length === 0) {

--- a/frontend/src/metabase/metrics-viewer/components/MetricsViewerTabs/MetricsViewerTabContent/MetricsViewerTabContent.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricsViewerTabs/MetricsViewerTabContent/MetricsViewerTabContent.tsx
@@ -8,7 +8,7 @@ import { Center, Flex, Stack } from "metabase/ui";
 import type { DimensionMetadata, MetricDefinition } from "metabase-lib/metric";
 import * as LibMetric from "metabase-lib/metric";
 import { isMetric } from "metabase-lib/v1/types/utils/isa";
-import type { Dataset, TemporalUnit } from "metabase-types/api";
+import type { CardId, SingleSeries, TemporalUnit } from "metabase-types/api";
 
 import type {
   MetricSourceId,
@@ -20,10 +20,7 @@ import type {
 } from "../../../types/viewer-state";
 import { getProjectionInfo } from "../../../utils/definition-builder";
 import type { DimensionFilterValue } from "../../../utils/dimension-filters";
-import {
-  buildDimensionItemsFromDefinitions,
-  buildRawSeriesFromDefinitions,
-} from "../../../utils/series";
+import { buildDimensionItemsFromDefinitions } from "../../../utils/series";
 import { getTabConfig } from "../../../utils/tab-config";
 import { MetricControls } from "../../MetricControls";
 import { MetricsViewerVisualization } from "../../MetricsViewerVisualization";
@@ -31,9 +28,10 @@ import { MetricsViewerVisualization } from "../../MetricsViewerVisualization";
 type MetricsViewerTabContentProps = {
   definitions: MetricsViewerDefinitionEntry[];
   tab: MetricsViewerTabState;
-  resultsByDefinitionId: Map<MetricSourceId, Dataset>;
   errorsByDefinitionId: Map<MetricSourceId, string>;
   modifiedDefinitions: Map<MetricSourceId, MetricDefinition>;
+  series: SingleSeries[];
+  cardIdToDefinitionId: Record<CardId, MetricSourceId>;
   sourceColors: SourceColorMap;
   isExecuting: (id: MetricSourceId) => boolean;
   onTabUpdate: (updates: Partial<MetricsViewerTabState>) => void;
@@ -47,9 +45,10 @@ type MetricsViewerTabContentProps = {
 export function MetricsViewerTabContent({
   definitions,
   tab,
-  resultsByDefinitionId,
   errorsByDefinitionId,
   modifiedDefinitions,
+  series: rawSeries,
+  cardIdToDefinitionId,
   sourceColors,
   isExecuting,
   onTabUpdate,
@@ -59,26 +58,6 @@ export function MetricsViewerTabContent({
   const isLoading = useMemo(() => {
     return getObjectKeys(tab.dimensionMapping).some(isExecuting);
   }, [tab.dimensionMapping, isExecuting]);
-
-  const { series: rawSeries, cardIdToDimensionId } = useMemo(
-    () =>
-      buildRawSeriesFromDefinitions(
-        definitions,
-        tab.dimensionMapping,
-        tab.display,
-        resultsByDefinitionId,
-        modifiedDefinitions,
-        sourceColors,
-      ),
-    [
-      definitions,
-      tab.dimensionMapping,
-      tab.display,
-      resultsByDefinitionId,
-      modifiedDefinitions,
-      sourceColors,
-    ],
-  );
 
   const firstError = useMemo(() => {
     for (const series of rawSeries) {
@@ -233,7 +212,7 @@ export function MetricsViewerTabContent({
         definitions={definitions}
         tab={tab}
         onTabUpdate={onTabUpdate}
-        cardIdToDimensionId={cardIdToDimensionId}
+        cardIdToDefinitionId={cardIdToDefinitionId}
       />
       {definitionForControls && (
         <Flex justify="center" align="center">

--- a/frontend/src/metabase/metrics-viewer/components/MetricsViewerVisualization/MetricsViewerVisualization.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricsViewerVisualization/MetricsViewerVisualization.tsx
@@ -33,7 +33,7 @@ type MetricsViewerVisualizationProps = {
   definitions: MetricsViewerDefinitionEntry[];
   tab: MetricsViewerTabState;
   onTabUpdate: (updates: Partial<MetricsViewerTabState>) => void;
-  cardIdToDimensionId: Record<CardId, MetricSourceId>;
+  cardIdToDefinitionId: Record<CardId, MetricSourceId>;
   interactive?: boolean;
 };
 
@@ -47,7 +47,7 @@ export function MetricsViewerVisualization({
   definitions,
   tab,
   onTabUpdate,
-  cardIdToDimensionId,
+  cardIdToDefinitionId,
   interactive = true,
 }: MetricsViewerVisualizationProps) {
   const { ref, width } = useElementSize();
@@ -60,10 +60,10 @@ export function MetricsViewerVisualization({
             definitions,
             tab,
             onTabUpdate,
-            cardIdToDimensionId,
+            cardIdToDefinitionId,
           })
         : undefined,
-    [cardIdToDimensionId, definitions, interactive, onTabUpdate, tab],
+    [cardIdToDefinitionId, definitions, interactive, onTabUpdate, tab],
   );
 
   return (

--- a/frontend/src/metabase/metrics-viewer/hooks/use-metrics-viewer.ts
+++ b/frontend/src/metabase/metrics-viewer/hooks/use-metrics-viewer.ts
@@ -8,7 +8,12 @@ import type {
   ProjectionClause,
 } from "metabase-lib/metric";
 import * as LibMetric from "metabase-lib/metric";
-import type { Dataset, MetricBreakoutValuesResponse } from "metabase-types/api";
+import type {
+  CardId,
+  Dataset,
+  MetricBreakoutValuesResponse,
+  SingleSeries,
+} from "metabase-types/api";
 
 import type { MetricsViewerPageProps } from "../pages/MetricsViewerPage/MetricsViewerPage";
 import type {
@@ -16,6 +21,7 @@ import type {
   MetricsViewerDefinitionEntry,
   MetricsViewerTabState,
   SelectedMetric,
+  SourceBreakoutColorMap,
   SourceColorMap,
 } from "../types/viewer-state";
 import {
@@ -35,7 +41,11 @@ import type {
   SourceDisplayInfo,
 } from "../utils/dimension-picker";
 import { getAvailableDimensionsForPicker } from "../utils/dimension-picker";
-import { computeSourceColors, getSelectedMetricsInfo } from "../utils/series";
+import {
+  buildRawSeriesFromDefinitions,
+  computeSourceBreakoutColors,
+  getSelectedMetricsInfo,
+} from "../utils/series";
 import {
   createMeasureSourceId,
   createMetricSourceId,
@@ -64,6 +74,9 @@ export interface UseMetricsViewerResult {
   modifiedDefinitions: Map<MetricSourceId, MetricDefinition>;
   isExecuting: (id: MetricSourceId) => boolean;
 
+  series: SingleSeries[];
+  cardIdToDefinitionId: Record<CardId, MetricSourceId>;
+  activeBreakoutColors: SourceBreakoutColorMap;
   sourceColors: SourceColorMap;
   breakoutValuesBySourceId: Map<MetricSourceId, MetricBreakoutValuesResponse>;
   selectedMetrics: SelectedMetric[];
@@ -215,9 +228,45 @@ export function useMetricsViewer({
     [state.definitions, loadingIds],
   );
 
-  const sourceColors = useMemo(
-    () => computeSourceColors(state.definitions, breakoutValuesBySourceId),
+  const sourceBreakoutColors = useMemo(
+    () =>
+      computeSourceBreakoutColors(state.definitions, breakoutValuesBySourceId),
     [state.definitions, breakoutValuesBySourceId],
+  );
+
+  const { series, cardIdToDefinitionId, activeBreakoutColors } = useMemo(() => {
+    if (!activeTab) {
+      return { series: [], cardIdToDefinitionId: {}, activeBreakoutColors: {} };
+    }
+    return buildRawSeriesFromDefinitions(
+      state.definitions,
+      activeTab?.dimensionMapping ?? {},
+      activeTab?.display ?? "line",
+      resultsByDefinitionId,
+      modifiedDefinitions,
+      sourceBreakoutColors,
+    );
+  }, [
+    state.definitions,
+    activeTab,
+    resultsByDefinitionId,
+    modifiedDefinitions,
+    sourceBreakoutColors,
+  ]);
+
+  const sourceColors = useMemo(
+    () =>
+      Object.fromEntries(
+        Object.entries(activeBreakoutColors).map(([sourceId, colors]) => [
+          sourceId,
+          colors === undefined
+            ? []
+            : typeof colors === "string"
+              ? [colors]
+              : Array.from(colors.values()),
+        ]),
+      ),
+    [activeBreakoutColors],
   );
 
   const definitionsBySourceId = useMemo(
@@ -377,6 +426,9 @@ export function useMetricsViewer({
     modifiedDefinitions,
     isExecuting,
 
+    series,
+    cardIdToDefinitionId,
+    activeBreakoutColors,
     sourceColors,
     breakoutValuesBySourceId,
     selectedMetrics,

--- a/frontend/src/metabase/metrics-viewer/hooks/use-metrics-viewer.ts
+++ b/frontend/src/metabase/metrics-viewer/hooks/use-metrics-viewer.ts
@@ -240,8 +240,8 @@ export function useMetricsViewer({
     }
     return buildRawSeriesFromDefinitions(
       state.definitions,
-      activeTab?.dimensionMapping ?? {},
-      activeTab?.display ?? "line",
+      activeTab.dimensionMapping,
+      activeTab.display,
       resultsByDefinitionId,
       modifiedDefinitions,
       sourceBreakoutColors,

--- a/frontend/src/metabase/metrics-viewer/pages/MetricsViewerPage/MetricsViewerPage.tsx
+++ b/frontend/src/metabase/metrics-viewer/pages/MetricsViewerPage/MetricsViewerPage.tsx
@@ -32,11 +32,12 @@ export function MetricsViewerPage(props: MetricsViewerPageProps) {
     tabs,
     activeTab,
     activeTabId,
-    resultsByDefinitionId,
     errorsByDefinitionId,
     modifiedDefinitions,
+    series,
+    cardIdToDefinitionId,
+    activeBreakoutColors,
     sourceColors,
-    breakoutValuesBySourceId,
     selectedMetrics,
     sourceOrder,
     sourceDataById,
@@ -123,9 +124,10 @@ export function MetricsViewerPage(props: MetricsViewerPageProps) {
                 <MetricsViewerTabContent
                   definitions={definitions}
                   tab={activeTab}
-                  resultsByDefinitionId={resultsByDefinitionId}
                   errorsByDefinitionId={errorsByDefinitionId}
                   modifiedDefinitions={modifiedDefinitions}
+                  series={series}
+                  cardIdToDefinitionId={cardIdToDefinitionId}
                   sourceColors={sourceColors}
                   isExecuting={isExecuting}
                   onTabUpdate={updateActiveTab}
@@ -142,8 +144,7 @@ export function MetricsViewerPage(props: MetricsViewerPageProps) {
             </Flex>
             <BreakoutLegend
               definitions={definitions}
-              breakoutValuesBySourceId={breakoutValuesBySourceId}
-              sourceColors={sourceColors}
+              activeBreakoutColors={activeBreakoutColors}
             />
           </Flex>
         </Stack>

--- a/frontend/src/metabase/metrics-viewer/types/viewer-state.ts
+++ b/frontend/src/metabase/metrics-viewer/types/viewer-state.ts
@@ -79,6 +79,21 @@ export function getInitialMetricsViewerPageState(): MetricsViewerPageState {
 
 // ── Color mapping ──
 
+/**
+ * A map of breakout display values to colors.
+ */
+export type BreakoutColorMap = Map<string, string>;
+
+/**
+ * Values are either BreakoutColorMap or a single color for non-breakout sources.
+ */
+export type SourceBreakoutColorMap = Partial<
+  Record<MetricSourceId, BreakoutColorMap | string>
+>;
+
+/**
+ * For consumers that expect an array of colors and don't care about breakout values.
+ */
 export type SourceColorMap = Partial<Record<MetricSourceId, string[]>>;
 
 // ── Shared display types ──

--- a/frontend/src/metabase/metrics-viewer/utils/MetricsViewerClickActionsMode.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/MetricsViewerClickActionsMode.ts
@@ -21,24 +21,24 @@ type MetricsViewerClickActionParams = {
   definitions: MetricsViewerDefinitionEntry[];
   tab: MetricsViewerTabState;
   onTabUpdate: (updates: Partial<MetricsViewerTabState>) => void;
-  cardIdToDimensionId: Record<CardId, MetricSourceId>;
+  cardIdToDefinitionId: Record<CardId, MetricSourceId>;
 };
 
 export class MetricsViewerClickActionsMode implements ClickActionsMode {
   private definitions: MetricsViewerDefinitionEntry[];
   private tab: MetricsViewerTabState;
   private onTabUpdate: (updates: Partial<MetricsViewerTabState>) => void;
-  private cardIdToDimensionId: Record<CardId, MetricSourceId>;
+  private cardIdToDefinitionId: Record<CardId, MetricSourceId>;
   constructor({
     definitions,
     tab,
     onTabUpdate,
-    cardIdToDimensionId,
+    cardIdToDefinitionId,
   }: MetricsViewerClickActionParams) {
     this.definitions = definitions;
     this.tab = tab;
     this.onTabUpdate = onTabUpdate;
-    this.cardIdToDimensionId = cardIdToDimensionId;
+    this.cardIdToDefinitionId = cardIdToDefinitionId;
   }
   actionsForClick(clickObject: ClickObject): ClickAction[] {
     const cardId = clickObject.cardId;
@@ -46,7 +46,7 @@ export class MetricsViewerClickActionsMode implements ClickActionsMode {
       return [];
     }
     const definition = this.definitions.find(
-      (definition) => definition.id === this.cardIdToDimensionId[cardId],
+      (definition) => definition.id === this.cardIdToDefinitionId[cardId],
     );
     const params = {
       definitions: this.definitions,

--- a/frontend/src/metabase/metrics-viewer/utils/legend.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/legend.ts
@@ -1,13 +1,8 @@
-import { NULL_DISPLAY_VALUE } from "metabase/lib/constants";
-import { formatValue } from "metabase/lib/formatting";
-import { isEmpty } from "metabase/lib/validate";
 import * as LibMetric from "metabase-lib/metric";
-import type { MetricBreakoutValuesResponse } from "metabase-types/api";
 
 import type {
-  MetricSourceId,
   MetricsViewerDefinitionEntry,
-  SourceColorMap,
+  SourceBreakoutColorMap,
 } from "../types/viewer-state";
 
 import { getDefinitionName } from "./definition-builder";
@@ -26,10 +21,14 @@ export interface LegendGroup {
 
 export function buildLegendGroups(
   definitions: MetricsViewerDefinitionEntry[],
-  breakoutValuesBySourceId: Map<MetricSourceId, MetricBreakoutValuesResponse>,
-  sourceColors: SourceColorMap,
+  activeBreakoutColors: SourceBreakoutColorMap,
 ): LegendGroup[] {
-  const hasAnyBreakout = definitions.some((entry) => entryHasBreakout(entry));
+  // if the breakout has more than MAX_SERIES values, we don't show the breakout
+  // in that case, the value in activeBreakoutColors is a string
+  const hasAnyBreakout = definitions.some(
+    (entry) =>
+      entryHasBreakout(entry) && activeBreakoutColors[entry.id] instanceof Map,
+  );
   if (!hasAnyBreakout) {
     return [];
   }
@@ -41,20 +40,21 @@ export function buildLegendGroups(
       continue;
     }
 
-    const colors = sourceColors[entry.id];
-    if (!colors || colors.length === 0) {
+    const colors = activeBreakoutColors[entry.id];
+    const color =
+      typeof colors === "string"
+        ? colors
+        : colors instanceof Map
+          ? colors.values().next().value
+          : undefined;
+    if (!color) {
       continue;
     }
 
     const definitionName = getDefinitionName(entry.definition);
     const breakoutProjection = getEntryBreakout(entry);
 
-    if (breakoutProjection) {
-      const response = breakoutValuesBySourceId.get(entry.id);
-      if (!response || response.values.length === 0) {
-        continue;
-      }
-
+    if (breakoutProjection && colors instanceof Map) {
       const rawDimension = LibMetric.projectionDimension(
         entry.definition,
         breakoutProjection,
@@ -63,14 +63,12 @@ export function buildLegendGroups(
         ? LibMetric.displayInfo(entry.definition, rawDimension)
         : null;
 
-      const items: LegendItem[] = response.values.map((val, index) => ({
-        label: String(
-          formatValue(isEmpty(val) ? NULL_DISPLAY_VALUE : val, {
-            column: response.col,
-          }),
-        ),
-        color: colors[index] ?? colors[colors.length - 1],
-      }));
+      const items: LegendItem[] = Array.from(colors.entries()).map(
+        ([breakoutValue, color]) => ({
+          label: breakoutValue,
+          color,
+        }),
+      );
 
       const header =
         dimensionInfo?.longDisplayName ?? dimensionInfo?.displayName;
@@ -89,7 +87,7 @@ export function buildLegendGroups(
       }
       groups.push({
         header: definitionName,
-        items: [{ label: definitionName, color: colors[0] }],
+        items: [{ label: definitionName, color }],
       });
     }
   }

--- a/frontend/src/metabase/metrics-viewer/utils/legend.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/legend.ts
@@ -7,6 +7,7 @@ import type {
 
 import { getDefinitionName } from "./definition-builder";
 import { entryHasBreakout, getEntryBreakout } from "./definition-entries";
+import { getSingleColor } from "./series";
 
 export interface LegendItem {
   label: string;
@@ -41,12 +42,7 @@ export function buildLegendGroups(
     }
 
     const colors = activeBreakoutColors[entry.id];
-    const color =
-      typeof colors === "string"
-        ? colors
-        : colors instanceof Map
-          ? colors.values().next().value
-          : undefined;
+    const color = getSingleColor(colors);
     if (!color) {
       continue;
     }

--- a/frontend/src/metabase/metrics-viewer/utils/legend.unit.spec.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/legend.unit.spec.ts
@@ -1,16 +1,14 @@
 import * as LibMetric from "metabase-lib/metric";
 import Metadata from "metabase-lib/v1/metadata/Metadata";
 import Metric from "metabase-lib/v1/metadata/Metric";
-import type { MetricBreakoutValuesResponse } from "metabase-types/api";
 import {
   createMockMetric,
   createMockMetricDimension,
 } from "metabase-types/api/mocks/metric";
 
 import type {
-  MetricSourceId,
   MetricsViewerDefinitionEntry,
-  SourceColorMap,
+  SourceBreakoutColorMap,
 } from "../types/viewer-state";
 
 import { buildLegendGroups } from "./legend";
@@ -89,13 +87,29 @@ describe("buildLegendGroups", () => {
     const definitions: MetricsViewerDefinitionEntry[] = [
       { id: "metric:1", definition },
     ];
-    const breakoutValues = new Map<
-      MetricSourceId,
-      MetricBreakoutValuesResponse
-    >();
-    const colors: SourceColorMap = { "metric:1": ["#509EE3"] };
+    const activeBreakoutColors: SourceBreakoutColorMap = {
+      "metric:1": "#509EE3",
+    };
 
-    expect(buildLegendGroups(definitions, breakoutValues, colors)).toEqual([]);
+    expect(buildLegendGroups(definitions, activeBreakoutColors)).toEqual([]);
+  });
+
+  it("returns empty array when activeBreakoutColors has only string values", () => {
+    const metadata = createMetadata([REVENUE_METRIC]);
+    const revenueDefinition = setupDefinitionWithBreakout(
+      metadata,
+      REVENUE_METRIC.id,
+      1,
+    );
+
+    const definitions: MetricsViewerDefinitionEntry[] = [
+      { id: "metric:1", definition: revenueDefinition },
+    ];
+    const activeBreakoutColors: SourceBreakoutColorMap = {
+      "metric:1": "#509EE3",
+    };
+
+    expect(buildLegendGroups(definitions, activeBreakoutColors)).toEqual([]);
   });
 
   it("builds legend groups for definitions with and without breakouts", () => {
@@ -112,25 +126,15 @@ describe("buildLegendGroups", () => {
       { id: "metric:2", definition: ordersDefinition },
     ];
 
-    const breakoutValues = new Map<
-      MetricSourceId,
-      MetricBreakoutValuesResponse
-    >([
-      [
-        "metric:1",
-        {
-          values: ["Gadgets", "Widgets"],
-          col: { name: "CATEGORY" } as any,
-        },
-      ],
-    ]);
-
-    const colors: SourceColorMap = {
-      "metric:1": ["#509EE3", "#88BF4D"],
-      "metric:2": ["#A989C5"],
+    const activeBreakoutColors: SourceBreakoutColorMap = {
+      "metric:1": new Map([
+        ["Gadgets", "#509EE3"],
+        ["Widgets", "#88BF4D"],
+      ]),
+      "metric:2": "#A989C5",
     };
 
-    expect(buildLegendGroups(definitions, breakoutValues, colors)).toEqual([
+    expect(buildLegendGroups(definitions, activeBreakoutColors)).toEqual([
       {
         header: "Category",
         subtitle: "Revenue",

--- a/frontend/src/metabase/metrics-viewer/utils/series.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/series.ts
@@ -124,6 +124,16 @@ export function computeSourceBreakoutColors(
   return result;
 }
 
+export function getSingleColor(
+  colors: BreakoutColorMap | string | undefined,
+): string | undefined {
+  return typeof colors === "string"
+    ? colors
+    : colors instanceof Map
+      ? colors.values().next().value
+      : undefined;
+}
+
 // Column layout with breakout:
 // - 3 cols when dimension != breakout: [dimension, breakout, metric] → output: [dimension, metric]
 // - 2 cols when dimension == breakout: [breakout, metric] → output: [breakout, metric]
@@ -160,7 +170,7 @@ export function splitByBreakout(
       if (rowsByBreakoutValue.size > MAX_SERIES) {
         return {
           series: [series],
-          activeBreakoutColorMap: breakoutColorMap.values().next().value,
+          activeBreakoutColorMap: getSingleColor(breakoutColorMap),
         };
       }
     }
@@ -301,12 +311,7 @@ export function buildRawSeriesFromDefinitions(
     const seriesKey = isFirstSeries ? result.data.cols[1]?.name : name;
 
     const colors = sourceBreakoutColors[entry.id];
-    const color =
-      typeof colors === "string"
-        ? colors
-        : colors instanceof Map
-          ? colors.values().next().value
-          : undefined;
+    const color = getSingleColor(colors);
 
     const singleSeries: SingleSeries = {
       card: createSeriesCard(cardId, name, display, {

--- a/frontend/src/metabase/metrics-viewer/utils/series.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/series.ts
@@ -5,7 +5,6 @@ import { isEmpty } from "metabase/lib/validate";
 import type { DimensionItem } from "metabase/metrics-viewer/components/DimensionPillBar";
 import { getColorsForValues } from "metabase/ui/colors/charts";
 import { getColorplethColorScale } from "metabase/visualizations/components/ChoroplethMap";
-import { getSeriesVizSettingsKey } from "metabase/visualizations/echarts/cartesian/model/series";
 import { MAX_SERIES } from "metabase/visualizations/lib/utils";
 import type { DimensionMetadata, MetricDefinition } from "metabase-lib/metric";
 import * as LibMetric from "metabase-lib/metric";
@@ -13,6 +12,7 @@ import type {
   Card,
   CardId,
   Dataset,
+  DatasetColumn,
   DimensionId,
   MetricBreakoutValuesResponse,
   RowValue,
@@ -23,17 +23,16 @@ import type {
 } from "metabase-types/api";
 
 import type {
+  BreakoutColorMap,
   MetricSourceId,
   MetricsViewerDefinitionEntry,
   MetricsViewerDisplayType,
   SelectedMetric,
+  SourceBreakoutColorMap,
   SourceColorMap,
 } from "../types/viewer-state";
 
-import {
-  getDefinitionColumnName,
-  getDefinitionName,
-} from "./definition-builder";
+import { getDefinitionName } from "./definition-builder";
 import { entryHasBreakout, getEntryBreakout } from "./definition-entries";
 import { findDimensionById } from "./dimension-lookup";
 import { nextSyntheticCardId, parseSourceId } from "./source-ids";
@@ -52,19 +51,23 @@ function getDefinitionCardId(def: MetricDefinition): number | null {
   return null;
 }
 
-/**
- * Computes colors for each definition by building the same series key array
- * that the chart pipeline would produce, then passing it to getColorsForValues.
- *
- * Chart key rules (from transformSeries → keyForSingleSeries):
- *   - First series key = col.name (slugified metric/measure card name)
- *   - Subsequent series keys = card.name (displayName or "displayName: breakoutValue")
- */
-export function computeSourceColors(
+function formatBreakoutValue(value: RowValue, column: DatasetColumn): string {
+  return String(
+    formatValue(isEmpty(value) ? NULL_DISPLAY_VALUE : value, {
+      column,
+    }),
+  );
+}
+
+export function computeSourceBreakoutColors(
   definitions: MetricsViewerDefinitionEntry[],
   breakoutValuesBySourceId?: Map<MetricSourceId, MetricBreakoutValuesResponse>,
-): SourceColorMap {
-  const entries: { sourceId: MetricSourceId; keys: string[] }[] = [];
+): SourceBreakoutColorMap {
+  const entries: {
+    sourceId: MetricSourceId;
+    keys: string[];
+    keyToBreakoutValue: Record<string, string>;
+  }[] = [];
 
   for (const entry of definitions) {
     if (!entry.definition) {
@@ -77,19 +80,23 @@ export function computeSourceColors(
 
     const response = breakoutValuesBySourceId?.get(entry.id);
     if (entryHasBreakout(entry) && response && response.values.length > 0) {
-      const keys = response.values.map((val) => {
-        const formatted = String(
-          formatValue(isEmpty(val) ? NULL_DISPLAY_VALUE : val, {
-            column: response.col,
-          }),
-        );
-        return definitions.length > 1
-          ? `${displayName}: ${formatted}`
-          : formatted;
+      // getColorsForValues needs unique keys
+      const keys: string[] = [];
+      // but we want to return the (possibly non-unique) breakout values to be displayed in the legend
+      const keyToBreakoutValue: Record<string, string> = {};
+      response.values.forEach((val) => {
+        const breakoutValue = formatBreakoutValue(val, response.col);
+        const key = `${displayName}: ${breakoutValue}`;
+        keys.push(key);
+        keyToBreakoutValue[key] = breakoutValue;
       });
-      entries.push({ sourceId: entry.id, keys });
+      entries.push({ sourceId: entry.id, keys, keyToBreakoutValue });
     } else {
-      entries.push({ sourceId: entry.id, keys: [displayName] });
+      entries.push({
+        sourceId: entry.id,
+        keys: [displayName],
+        keyToBreakoutValue: {},
+      });
     }
   }
 
@@ -97,27 +104,22 @@ export function computeSourceColors(
     return {};
   }
 
-  const allKeys = entries.flatMap((entry) => entry.keys);
+  const colorMapping = getColorsForValues(
+    entries.flatMap((entry) => entry.keys),
+  );
 
-  const firstDefinition = definitions.find(
-    (definition) => definition.id === entries[0].sourceId,
-  )?.definition;
-  if (firstDefinition) {
-    const columnName = getDefinitionColumnName(firstDefinition);
-    if (columnName) {
-      allKeys[0] = columnName;
-    }
-  }
-
-  const colorMapping = getColorsForValues(allKeys);
-
-  const result: SourceColorMap = {};
-  let idx = 0;
+  const result: SourceBreakoutColorMap = {};
   for (const entry of entries) {
-    result[entry.sourceId] = entry.keys.map(
-      (_, i) => colorMapping[allKeys[idx + i]],
-    );
-    idx += entry.keys.length;
+    if (entry.keys.length === 1) {
+      result[entry.sourceId] = colorMapping[entry.keys[0]];
+    } else {
+      result[entry.sourceId] = new Map(
+        Object.entries(entry.keyToBreakoutValue).map(([key, breakoutValue]) => [
+          breakoutValue,
+          colorMapping[key],
+        ]),
+      );
+    }
   }
   return result;
 }
@@ -128,8 +130,12 @@ export function computeSourceColors(
 export function splitByBreakout(
   series: SingleSeries,
   seriesCount: number,
-  sourceColors?: string[],
-): SingleSeries[] {
+  isFirstSeries: boolean,
+  breakoutColorMap: BreakoutColorMap,
+): {
+  series: SingleSeries[];
+  activeBreakoutColorMap: BreakoutColorMap | string | undefined;
+} {
   const { card, data } = series;
   const { cols } = data;
 
@@ -143,58 +149,65 @@ export function splitByBreakout(
   const rowsByBreakoutValue = new Map<RowValue, RowValues[]>();
 
   for (const row of data.rows) {
-    const breakoutValue = row[breakoutColumnIndex];
+    const breakoutValue = formatBreakoutValue(
+      row[breakoutColumnIndex],
+      breakoutCol,
+    );
     let groupedRows = rowsByBreakoutValue.get(breakoutValue);
     if (!groupedRows) {
       groupedRows = [];
       rowsByBreakoutValue.set(breakoutValue, groupedRows);
       if (rowsByBreakoutValue.size > MAX_SERIES) {
-        return [series];
+        return {
+          series: [series],
+          activeBreakoutColorMap: breakoutColorMap.values().next().value,
+        };
       }
     }
     groupedRows.push([row[0], row[metricColumnIndex]] as RowValues);
   }
 
-  return Array.from(rowsByBreakoutValue.keys()).map((breakoutValue, i) => {
-    const name = [
-      seriesCount > 1 && card.name,
-      formatValue(isEmpty(breakoutValue) ? NULL_DISPLAY_VALUE : breakoutValue, {
-        column: breakoutCol,
-      }),
-    ]
-      .filter(Boolean)
-      .join(": ");
+  const activeBreakoutColorMap: BreakoutColorMap = new Map();
 
-    const seriesKey = getSeriesVizSettingsKey(
-      metricCol,
-      false,
-      true,
-      1,
-      null,
-      name,
-    );
+  const breakoutSeries = Array.from(breakoutColorMap)
+    .map(([breakoutValue, color]) => {
+      const rows = rowsByBreakoutValue.get(breakoutValue);
+      if (!rows) {
+        return null;
+      }
 
-    return {
-      ...series,
-      card: {
-        ...card,
-        id: nextSyntheticCardId(),
-        name,
-        visualization_settings: {
-          ...computeColorVizSettings({
-            displayType: card.display,
-            seriesKey,
-            color: sourceColors?.[i],
-          }),
+      activeBreakoutColorMap.set(breakoutValue, color);
+
+      const name = [seriesCount > 1 && card.name, breakoutValue]
+        .filter(Boolean)
+        .join(": ");
+
+      const seriesKey = isFirstSeries ? metricCol?.name : name;
+      isFirstSeries = false;
+
+      return {
+        ...series,
+        card: {
+          ...card,
+          id: nextSyntheticCardId(),
+          name,
+          visualization_settings: {
+            ...computeColorVizSettings({
+              displayType: card.display,
+              seriesKey,
+              color,
+            }),
+          },
         },
-      },
-      data: {
-        ...data,
-        rows: rowsByBreakoutValue.get(breakoutValue)!,
-        cols: outputCols,
-      },
-    };
-  });
+        data: {
+          ...data,
+          rows,
+          cols: outputCols,
+        },
+      };
+    })
+    .filter((s) => s != null);
+  return { series: breakoutSeries, activeBreakoutColorMap };
 }
 
 function createSeriesCard(
@@ -217,10 +230,11 @@ export function buildRawSeriesFromDefinitions(
   display: MetricsViewerDisplayType,
   resultsByDefinitionId: Map<MetricSourceId, Dataset>,
   modifiedDefinitions: Map<MetricSourceId, MetricDefinition>,
-  sourceColors: SourceColorMap,
+  sourceBreakoutColors: SourceBreakoutColorMap,
 ): {
   series: SingleSeries[];
-  cardIdToDimensionId: Record<CardId, MetricSourceId>;
+  cardIdToDefinitionId: Record<CardId, MetricSourceId>;
+  activeBreakoutColors: SourceBreakoutColorMap;
 } {
   const firstSettingsEntry = definitions.reduce<{
     def: MetricDefinition;
@@ -245,15 +259,18 @@ export function buildRawSeriesFromDefinitions(
   }, null);
 
   if (!firstSettingsEntry) {
-    return { series: [], cardIdToDimensionId: {} };
+    return { series: [], cardIdToDefinitionId: {}, activeBreakoutColors: {} };
   }
 
-  const baseSettings = DISPLAY_TYPE_REGISTRY[display].getSettings(
+  const displayType = DISPLAY_TYPE_REGISTRY[display];
+  const baseSettings = displayType.getSettings(
     firstSettingsEntry.def,
     firstSettingsEntry.dimension,
   );
 
-  const cardIdToDimensionId: Record<CardId, MetricSourceId> = {};
+  let isFirstSeries = true;
+  const cardIdToDefinitionId: Record<CardId, MetricSourceId> = {};
+  const activeBreakoutColors: SourceBreakoutColorMap = {};
 
   const series = definitions.flatMap((entry) => {
     const dimensionId = dimensionMapping[entry.id];
@@ -277,15 +294,19 @@ export function buildRawSeriesFromDefinitions(
     }
 
     const name = getDefinitionName(entry.definition);
+    if (!name) {
+      return [];
+    }
 
-    const seriesKey = getSeriesVizSettingsKey(
-      result.data.cols[1], // metric API returns [projection_cols..., aggregation_col]
-      false,
-      true,
-      1,
-      null,
-      name ?? undefined,
-    );
+    const seriesKey = isFirstSeries ? result.data.cols[1]?.name : name;
+
+    const colors = sourceBreakoutColors[entry.id];
+    const color =
+      typeof colors === "string"
+        ? colors
+        : colors instanceof Map
+          ? colors.values().next().value
+          : undefined;
 
     const singleSeries: SingleSeries = {
       card: createSeriesCard(cardId, name, display, {
@@ -293,31 +314,46 @@ export function buildRawSeriesFromDefinitions(
         ...computeColorVizSettings({
           displayType: display,
           seriesKey,
-          color: sourceColors[entry.id]?.[0],
+          color,
         }),
       }),
       data: result.data,
     };
 
     let entrySeries: SingleSeries[];
-    if (!entryHasBreakout(entry) || singleSeries.data.rows.length === 0) {
+    if (
+      !entryHasBreakout(entry) ||
+      singleSeries.data.rows.length === 0 ||
+      !(colors instanceof Map)
+    ) {
       entrySeries = [singleSeries];
+      activeBreakoutColors[entry.id] = color;
     } else {
-      entrySeries = splitByBreakout(
+      const { series, activeBreakoutColorMap } = splitByBreakout(
         singleSeries,
         definitions.length,
-        sourceColors[entry.id],
+        isFirstSeries,
+        colors,
       );
+      entrySeries = series;
+      activeBreakoutColors[entry.id] = activeBreakoutColorMap;
     }
+    isFirstSeries = false;
 
     for (const s of entrySeries) {
-      cardIdToDimensionId[s.card.id] = entry.id;
+      cardIdToDefinitionId[s.card.id] = entry.id;
     }
 
     return entrySeries;
   });
 
-  return { series, cardIdToDimensionId };
+  if (series.length > 1 && displayType.combineSettings) {
+    series[0].card.visualization_settings = displayType.combineSettings(
+      series.map((s) => s.card.visualization_settings),
+    );
+  }
+
+  return { series, cardIdToDefinitionId, activeBreakoutColors };
 }
 
 function computeColorVizSettings({

--- a/frontend/src/metabase/metrics-viewer/utils/series.unit.spec.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/series.unit.spec.ts
@@ -1,9 +1,12 @@
-import type { RowValues } from "metabase-types/api";
+import type {
+  MetricBreakoutValuesResponse,
+  RowValues,
+} from "metabase-types/api";
 import { createMockColumn } from "metabase-types/api/mocks";
 import { ORDERS_ID } from "metabase-types/api/mocks/presets";
 import { createMockSingleSeries } from "metabase-types/api/mocks/series";
 
-import type { MetricSourceId } from "../types/viewer-state";
+import type { BreakoutColorMap, MetricSourceId } from "../types/viewer-state";
 
 import {
   REVENUE_METRIC,
@@ -11,9 +14,14 @@ import {
   createMetricMetadata,
   measureMetadata,
   setupDefinition,
+  setupDefinitionWithBreakout,
   setupMeasureDefinition,
 } from "./__tests__/test-helpers";
-import { getSelectedMetricsInfo, splitByBreakout } from "./series";
+import {
+  computeSourceBreakoutColors,
+  getSelectedMetricsInfo,
+  splitByBreakout,
+} from "./series";
 
 const dimensionCol = createMockColumn({
   name: "CREATED_AT",
@@ -35,6 +43,18 @@ const metricCol = createMockColumn({
 
 const CARD_OPTS = { id: 1, name: "Revenue", display: "line" } as const;
 
+function makeColorMap(values: string[]): BreakoutColorMap {
+  const palette = [
+    "#509EE3",
+    "#88BF4D",
+    "#A989C5",
+    "#EF8C8C",
+    "#F9D45C",
+    "#F2A86F",
+  ];
+  return new Map(values.map((v, i) => [v, palette[i % palette.length]]));
+}
+
 describe("splitByBreakout", () => {
   describe("3 columns: [dimension, breakout, metric]", () => {
     it("splits rows by breakout value and strips breakout column", () => {
@@ -50,7 +70,12 @@ describe("splitByBreakout", () => {
         },
       });
 
-      const result = splitByBreakout(series, 1);
+      const { series: result } = splitByBreakout(
+        series,
+        1,
+        true,
+        makeColorMap(["Gadgets", "Widgets"]),
+      );
 
       expect(result).toHaveLength(2);
 
@@ -80,7 +105,12 @@ describe("splitByBreakout", () => {
         },
       });
 
-      const result = splitByBreakout(series, 2);
+      const { series: result } = splitByBreakout(
+        series,
+        2,
+        true,
+        makeColorMap(["Gadgets", "Widgets"]),
+      );
 
       expect(result[0].card.name).toBe("Revenue: Gadgets");
       expect(result[1].card.name).toBe("Revenue: Widgets");
@@ -100,7 +130,12 @@ describe("splitByBreakout", () => {
         },
       });
 
-      const result = splitByBreakout(series, 1);
+      const { series: result } = splitByBreakout(
+        series,
+        1,
+        true,
+        makeColorMap(["Gadgets", "Widgets"]),
+      );
 
       expect(result).toHaveLength(2);
 
@@ -128,7 +163,12 @@ describe("splitByBreakout", () => {
       },
     });
 
-    const result = splitByBreakout(series, 1);
+    const { series: result } = splitByBreakout(
+      series,
+      1,
+      true,
+      makeColorMap(["Gadgets", "Widgets"]),
+    );
 
     const ids = result.map((s) => s.card.id);
     expect(new Set(ids).size).toBe(ids.length);
@@ -145,23 +185,26 @@ describe("splitByBreakout", () => {
       },
     });
 
-    const result = splitByBreakout(series, 1, ["#509EE3", "#88BF4D"]);
+    const colorMap = makeColorMap(["Gadgets", "Widgets"]);
+    const { series: result } = splitByBreakout(series, 1, true, colorMap);
 
     expect(result[0].card.visualization_settings.series_settings).toBeDefined();
     expect(result[1].card.visualization_settings.series_settings).toBeDefined();
   });
 
   it("returns original series when breakout values exceed MAX_SERIES", () => {
-    const rows: RowValues[] = Array.from({ length: 102 }, (_, i) => [
-      "2024-01",
-      `Value ${i}`,
-      i,
-    ]);
+    const values = Array.from({ length: 102 }, (_, i) => `Value ${i}`);
+    const rows: RowValues[] = values.map((v, i) => ["2024-01", v, i]);
     const series = createMockSingleSeries(CARD_OPTS, {
       data: { cols: [dimensionCol, breakoutCol, metricCol], rows },
     });
 
-    const result = splitByBreakout(series, 1);
+    const { series: result } = splitByBreakout(
+      series,
+      1,
+      true,
+      makeColorMap(values),
+    );
 
     expect(result).toHaveLength(1);
     expect(result[0]).toBe(series);
@@ -178,9 +221,193 @@ describe("splitByBreakout", () => {
       },
     });
 
-    const result = splitByBreakout(series, 1);
+    const { series: result } = splitByBreakout(
+      series,
+      1,
+      true,
+      makeColorMap(["Gadgets", "Widgets"]),
+    );
 
     expect(result[0].data.cols).toBe(result[1].data.cols);
+  });
+
+  it("skips breakout values not present in data", () => {
+    const series = createMockSingleSeries(CARD_OPTS, {
+      data: {
+        cols: [dimensionCol, breakoutCol, metricCol],
+        rows: [
+          ["2024-01", "Widgets", 20],
+          ["2024-02", "Widgets", 40],
+        ],
+      },
+    });
+
+    const colorMap: BreakoutColorMap = new Map([
+      ["Gadgets", "#509EE3"],
+      ["Widgets", "#88BF4D"],
+      ["Gizmos", "#A989C5"],
+    ]);
+
+    const { series: result, activeBreakoutColorMap } = splitByBreakout(
+      series,
+      1,
+      true,
+      colorMap,
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].card.name).toBe("Widgets");
+    expect(activeBreakoutColorMap).toEqual(new Map([["Widgets", "#88BF4D"]]));
+  });
+
+  it("preserves color assignment regardless of data order", () => {
+    const series = createMockSingleSeries(CARD_OPTS, {
+      data: {
+        cols: [dimensionCol, breakoutCol, metricCol],
+        rows: [
+          ["2024-01", "Widgets", 20],
+          ["2024-01", "Gadgets", 10],
+        ],
+      },
+    });
+
+    const colorMap: BreakoutColorMap = new Map([
+      ["Gadgets", "#509EE3"],
+      ["Widgets", "#88BF4D"],
+    ]);
+
+    const { series: result } = splitByBreakout(series, 1, true, colorMap);
+
+    expect(result).toHaveLength(2);
+    // series order follows colorMap iteration order, not data order
+    expect(result[0].card.name).toBe("Gadgets");
+    expect(result[1].card.name).toBe("Widgets");
+
+    const gadgetColor =
+      result[0].card.visualization_settings.series_settings?.[
+        Object.keys(
+          result[0].card.visualization_settings.series_settings ?? {},
+        )[0]
+      ]?.color;
+    const widgetColor =
+      result[1].card.visualization_settings.series_settings?.[
+        Object.keys(
+          result[1].card.visualization_settings.series_settings ?? {},
+        )[0]
+      ]?.color;
+
+    expect(gadgetColor).toBe("#509EE3");
+    expect(widgetColor).toBe("#88BF4D");
+  });
+});
+
+describe("computeSourceBreakoutColors", () => {
+  it("returns empty object for empty definitions", () => {
+    expect(computeSourceBreakoutColors([])).toEqual({});
+  });
+
+  it("returns a string color for a definition without breakout", () => {
+    const metadata = createMetricMetadata([REVENUE_METRIC]);
+    const definition = setupDefinition(metadata, REVENUE_METRIC.id);
+
+    const result = computeSourceBreakoutColors([
+      { id: "metric:1", definition },
+    ]);
+
+    expect(typeof result["metric:1"]).toBe("string");
+  });
+
+  it("returns a Map for a definition with breakout and breakout values", () => {
+    const metadata = createMetricMetadata([REVENUE_METRIC]);
+    const definition = setupDefinitionWithBreakout(
+      metadata,
+      REVENUE_METRIC.id,
+      1,
+    );
+
+    const breakoutValues = new Map<
+      MetricSourceId,
+      MetricBreakoutValuesResponse
+    >([
+      [
+        "metric:1",
+        {
+          values: ["Gadgets", "Widgets"],
+          col: createMockColumn({
+            name: "CATEGORY",
+            display_name: "Category",
+            base_type: "type/Text",
+          }),
+        },
+      ],
+    ]);
+
+    const result = computeSourceBreakoutColors(
+      [{ id: "metric:1", definition }],
+      breakoutValues,
+    );
+
+    expect(result["metric:1"]).toBeInstanceOf(Map);
+    const colorMap = result["metric:1"] as Map<string, string>;
+    expect(colorMap.size).toBe(2);
+    expect(colorMap.has("Gadgets")).toBe(true);
+    expect(colorMap.has("Widgets")).toBe(true);
+    expect(typeof colorMap.get("Gadgets")).toBe("string");
+    expect(typeof colorMap.get("Widgets")).toBe("string");
+  });
+
+  it("returns mixed types for definitions with and without breakouts", () => {
+    const metadata = createMetricMetadata([REVENUE_METRIC]);
+    const withBreakout = setupDefinitionWithBreakout(
+      metadata,
+      REVENUE_METRIC.id,
+      1,
+    );
+    const withoutBreakout = setupDefinition(metadata, REVENUE_METRIC.id);
+
+    const breakoutValues = new Map<
+      MetricSourceId,
+      MetricBreakoutValuesResponse
+    >([
+      [
+        "metric:1",
+        {
+          values: ["Gadgets", "Widgets"],
+          col: createMockColumn({
+            name: "CATEGORY",
+            display_name: "Category",
+            base_type: "type/Text",
+          }),
+        },
+      ],
+    ]);
+
+    const result = computeSourceBreakoutColors(
+      [
+        { id: "metric:1", definition: withBreakout },
+        { id: "metric:2" as MetricSourceId, definition: withoutBreakout },
+      ],
+      breakoutValues,
+    );
+
+    expect(result["metric:1"]).toBeInstanceOf(Map);
+    expect(typeof result["metric:2" as MetricSourceId]).toBe("string");
+  });
+
+  it("falls back to string when breakout definition has no breakout values", () => {
+    const metadata = createMetricMetadata([REVENUE_METRIC]);
+    const definition = setupDefinitionWithBreakout(
+      metadata,
+      REVENUE_METRIC.id,
+      1,
+    );
+
+    const result = computeSourceBreakoutColors(
+      [{ id: "metric:1", definition }],
+      new Map(),
+    );
+
+    expect(typeof result["metric:1"]).toBe("string");
   });
 });
 

--- a/frontend/src/metabase/metrics-viewer/utils/tab-config.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/tab-config.ts
@@ -27,6 +27,9 @@ interface DisplayTypeDefinition {
     def: MetricDefinition,
     dimension: DimensionMetadata,
   ) => VisualizationSettings;
+  combineSettings?: (
+    settings: VisualizationSettings[],
+  ) => VisualizationSettings;
 }
 
 interface BaseTabTypeDefinition {
@@ -197,13 +200,40 @@ function getMapSettings(
   };
 }
 
+function combineColors(
+  settings: VisualizationSettings[],
+): VisualizationSettings {
+  // getStoredSettingsForSeries only looks at settings on the first series
+  return settings.reduce((acc, setting) => {
+    return {
+      ...acc,
+      series_settings: {
+        ...acc["series_settings"],
+        ...setting["series_settings"],
+      },
+    };
+  });
+}
+
 export const DISPLAY_TYPE_REGISTRY: Record<
   MetricsViewerDisplayType,
   DisplayTypeDefinition
 > = {
-  line: { supportsMultipleSeries: true, getSettings: getChartSettings },
-  area: { supportsMultipleSeries: true, getSettings: getChartSettings },
-  bar: { supportsMultipleSeries: true, getSettings: getChartSettings },
+  line: {
+    supportsMultipleSeries: true,
+    getSettings: getChartSettings,
+    combineSettings: combineColors,
+  },
+  area: {
+    supportsMultipleSeries: true,
+    getSettings: getChartSettings,
+    combineSettings: combineColors,
+  },
+  bar: {
+    supportsMultipleSeries: true,
+    getSettings: getChartSettings,
+    combineSettings: combineColors,
+  },
   row: { supportsMultipleSeries: true, getSettings: getChartSettings },
   scatter: { supportsMultipleSeries: true, getSettings: getScatterSettings },
   map: { supportsMultipleSeries: false, getSettings: getMapSettings },


### PR DESCRIPTION
Closes [UXW-3523: Fix colors on master](https://linear.app/metabase/issue/UXW-3523/fix-colors-on-master)

### Description

Previously, `splitByBreakout` iterated through breakout values in the order that they appeared in the data, but this order is not guaranteed to match the order of the values in `breakoutValuesBySourceId`, and, if the user uses a dimension filter, not every breakout value is guaranteed to appear in the data. This means that storing colors in an array and assigning based on index can't work properly.

Summary of changes:

- `computeSourceBreakoutColors` returns a new `SourceBreakoutColorMap` type
- `buildRawSeriesFromDefinitions` returns `activeBreakoutColors`, which is the subset of breakout colors actually used in the series
- `sourceColors` is computed from `activeBreakoutColors` and retains the old `SourceColorMap` type for compatibility
- The legend shows only the breakout values in `activeBreakoutColors`
- In `splitByBreakout`, iterate over breakout values in order. This is especially important so that the grid of map breakouts is rendered in order
- Fixes issues that prevent colors from being passed to ECharts:
  - `seriesKey` was not always calculated correctly
  - `getStoredSettingsForSeries` only looks at settings on the first series, so added a new `combineSettings` option on `DISPLAY_TYPE_REGISTRY`
  - It might seem surprising that colors worked at all given that ECharts was not receiving the settings. The hash based color assignment in `getColorsForValues` meant that colors usually worked despite these issues
- Renamed the poorly named `cardIdToDimensionId` to `cardIdToDefinitionId`

### How to verify

To recreate the below screenshots: view a Number of Orders metric, break out by Quantity auto-binned, zoom in on April 2026 by week.

### Demo

Before - note the chart colors don't match the legend, the legend includes breakout values that aren't present, and the pills include colors that aren't present:
<img width="1499" height="638" alt="image" src="https://github.com/user-attachments/assets/3dcd0330-ff1d-45d9-b9a9-292ecc4f258a" />

After:
<img width="1505" height="629" alt="image" src="https://github.com/user-attachments/assets/d40e9eab-3154-4724-b142-3772d3057ad8" />

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
