### PR TITLE
fix unnecessary data grid row remounting

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
@@ -1223,6 +1223,32 @@ describe("scenarios > visualizations > table > time formatting (#11398)", () => 
     // And you should find the result
     cy.findByRole("gridcell", { name: "6:34:00.000 PM" });
   });
+
+  it("should preserve DOM elements for visible rows during scrolling", () => {
+    H.openOrdersTable();
+
+    const targetDatasetIndex = 15;
+
+    H.tableInteractiveBody()
+      .find(`[role=row][data-dataset-index="${targetDatasetIndex}"]`)
+      .then(($row) => {
+        const originalElement = $row[0];
+
+        H.tableInteractiveScrollContainer().then(($container) => {
+          const currentScroll = $container[0].scrollTop;
+          $container[0].scrollTop =
+            currentScroll + 36 * (targetDatasetIndex - 1);
+        });
+
+        H.tableInteractiveBody()
+          .find(`[role=row][data-dataset-index="${targetDatasetIndex}"]`)
+          .should("exist")
+          .then(($rowAfterScroll) => {
+            // Row has always been visible so it should use the same html node
+            expect($rowAfterScroll[0]).to.equal(originalElement);
+          });
+      });
+  });
 });
 
 function headerCells() {

--- a/frontend/src/metabase/data-grid/components/DataGrid/DataGrid.tsx
+++ b/frontend/src/metabase/data-grid/components/DataGrid/DataGrid.tsx
@@ -133,11 +133,10 @@ export const DataGrid = function DataGrid<TData>({
   const renderRow = (
     row: DataGridRowType<TData>,
     columns: DataGridColumnType<TData>[],
-    index: number,
     measureRef?: (element: Element | null) => void,
   ) => (
     <DataGridRow
-      key={index}
+      key={row.virtualItem?.key ?? row.origin.id}
       row={row}
       rowMeasureRef={measureRef}
       pinnedRowsCount={pinnedRows.length}
@@ -214,11 +213,9 @@ export const DataGrid = function DataGrid<TData>({
     minHeight?: string,
   ) =>
     renderGridPanels({
-      pinnedContent: rows.map((row, index) =>
-        renderRow(row, pinnedColumns, index),
-      ),
-      centerContent: rows.map((row, index) =>
-        renderRow(row, centerColumns, index, measureRef),
+      pinnedContent: rows.map((row) => renderRow(row, pinnedColumns)),
+      centerContent: rows.map((row) =>
+        renderRow(row, centerColumns, measureRef),
       ),
       minHeight,
       rowsSection,

--- a/frontend/src/metabase/data-grid/components/DataGridRow/DataGridRow.tsx
+++ b/frontend/src/metabase/data-grid/components/DataGridRow/DataGridRow.tsx
@@ -60,7 +60,6 @@ export const DataGridRow = <TData,>({
   return (
     <div
       role="row"
-      key={row.origin.id}
       ref={rowMeasureRef}
       {...{
         [datasetIndexAttributeName]: row.origin.index,


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/71277
Closes UXW-3390

### Description

Fix unnecessary row remounting when scrolling table visualization which causes popover to lose its position as its anchor got removed.

### Demo

https://www.loom.com/share/a2c94dea183b46c58b38341312a3bb80

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
