### PR TITLE
Add OAuth and MCP throttling

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1374,6 +1374,7 @@
    :uses #{api
            appearance
            models
+           request
            settings
            system
            util}}

--- a/src/metabase/mcp/api.clj
+++ b/src/metabase/mcp/api.clj
@@ -16,7 +16,8 @@
    [metabase.system.core :as system]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
-   [oidc-provider.store :as oidc.store])
+   [oidc-provider.store :as oidc.store]
+   [throttle.core :as throttle])
   (:import
    (java.io BufferedWriter OutputStreamWriter)
    (java.net URI)
@@ -246,6 +247,16 @@
     (or session-err
         {:status 200 :headers {"Content-Type" "application/json"} :body ""})))
 
+;;; -------------------------------------------------- Throttling --------------------------------------------------
+
+;; MCP is auth-gated (session cookie or bearer token), so the risk is lower than the
+;; unauthenticated OAuth endpoints. The threshold is generous to accommodate users running
+;; multiple concurrent agents (e.g. 5 agents × 200 req/min). throttle/check counts every
+;; request (not just failures) which is correct here — we want to cap total throughput
+;; regardless of success to prevent resource exhaustion from a compromised token.
+(def ^:private mcp-throttler
+  (throttle/make-throttler :user-id :attempts-threshold 1000 :attempt-ttl-ms (* 60 1000)))
+
 ;;; ---------------------------------------------------- Handler ---------------------------------------------------
 
 (defn- www-authenticate-discovery []
@@ -262,6 +273,7 @@
        (letfn [(dispatch [user-id token-scopes]
                  (request/with-current-user user-id
                    (try
+                     (throttle/check mcp-throttler user-id)
                      (let [request (assoc request :token-scopes token-scopes)]
                        (case (:request-method request)
                          :post   (respond (handle-post user-id request))

--- a/src/metabase/mcp/api.clj
+++ b/src/metabase/mcp/api.clj
@@ -257,6 +257,18 @@
 (def ^:private mcp-throttler
   (throttle/make-throttler :user-id :attempts-threshold 1000 :attempt-ttl-ms (* 60 1000)))
 
+(defn- check-throttle
+  "Returns a 429 JSON-RPC response if rate-limited, nil otherwise."
+  [user-id]
+  (try
+    (throttle/check mcp-throttler user-id)
+    nil
+    (catch clojure.lang.ExceptionInfo e
+      (let [message       (ex-message e)
+            retry-seconds (some->> message (re-find #"(\d+) seconds") second)]
+        (cond-> (json-response 429 (jsonrpc-error nil -32000 message))
+          retry-seconds (assoc-in [:headers "Retry-After"] retry-seconds))))))
+
 ;;; ---------------------------------------------------- Handler ---------------------------------------------------
 
 (defn- www-authenticate-discovery []
@@ -272,25 +284,17 @@
            session-auth    api/*current-user-id*]
        (letfn [(dispatch [user-id token-scopes]
                  (request/with-current-user user-id
-                   (try
-                     (throttle/check mcp-throttler user-id)
-                     (let [request (assoc request :token-scopes token-scopes)]
-                       (case (:request-method request)
-                         :post   (respond (handle-post user-id request))
-                         :get    (handle-get user-id request respond raise)
-                         :delete (respond (handle-delete user-id request))
-                         (respond (json-response 405 (jsonrpc-error nil -32600 "Method not allowed")))))
-                     (catch clojure.lang.ExceptionInfo e
-                       (if (:errors (ex-data e))
-                         ;; Throttle exceptions must return a JSON-RPC envelope so MCP clients
-                         ;; can parse the error, not a bare HTTP error from generic middleware.
-                         (let [message       (ex-message e)
-                               retry-seconds (some->> message (re-find #"(\d+) seconds") second)]
-                           (respond (cond-> (json-response 429 (jsonrpc-error nil -32000 message))
-                                      retry-seconds (assoc-in [:headers "Retry-After"] retry-seconds))))
-                         (raise e)))
-                     (catch Throwable e
-                       (raise e)))))]
+                   (if-let [throttle-err (check-throttle user-id)]
+                     (respond throttle-err)
+                     (try
+                       (let [request (assoc request :token-scopes token-scopes)]
+                         (case (:request-method request)
+                           :post   (respond (handle-post user-id request))
+                           :get    (handle-get user-id request respond raise)
+                           :delete (respond (handle-delete user-id request))
+                           (respond (json-response 405 (jsonrpc-error nil -32600 "Method not allowed")))))
+                       (catch Throwable e
+                         (raise e))))))]
          (cond
            (some? origin-error)
            (respond origin-error)

--- a/src/metabase/mcp/api.clj
+++ b/src/metabase/mcp/api.clj
@@ -254,8 +254,10 @@
 ;; multiple concurrent agents (e.g. 5 agents × 200 req/min). throttle/check counts every
 ;; request (not just failures) which is correct here — we want to cap total throughput
 ;; regardless of success to prevent resource exhaustion from a compromised token.
+(def ^:private one-minute-ms (* 60 1000))
+
 (def ^:private mcp-throttler
-  (throttle/make-throttler :user-id :attempts-threshold 1000 :attempt-ttl-ms (* 60 1000)))
+  (throttle/make-throttler :user-id :attempts-threshold 1000 :attempt-ttl-ms one-minute-ms))
 
 (defn- check-throttle
   "Returns a 429 JSON-RPC response if rate-limited, nil otherwise."

--- a/src/metabase/mcp/api.clj
+++ b/src/metabase/mcp/api.clj
@@ -280,6 +280,15 @@
                          :get    (handle-get user-id request respond raise)
                          :delete (respond (handle-delete user-id request))
                          (respond (json-response 405 (jsonrpc-error nil -32600 "Method not allowed")))))
+                     (catch clojure.lang.ExceptionInfo e
+                       (if (:errors (ex-data e))
+                         ;; Throttle exceptions must return a JSON-RPC envelope so MCP clients
+                         ;; can parse the error, not a bare HTTP error from generic middleware.
+                         (let [message       (ex-message e)
+                               retry-seconds (some->> message (re-find #"(\d+) seconds") second)]
+                           (respond (cond-> (json-response 429 (jsonrpc-error nil -32000 message))
+                                      retry-seconds (assoc-in [:headers "Retry-After"] retry-seconds))))
+                         (raise e)))
                      (catch Throwable e
                        (raise e)))))]
          (cond

--- a/src/metabase/oauth_server/api/oauth.clj
+++ b/src/metabase/oauth_server/api/oauth.clj
@@ -119,7 +119,6 @@
 ;; and is the primary target for brute-forcing client secrets or replaying authorization codes.
 ;; Per-client_id is tight (one agent per client), per-IP is wider to accommodate many agents
 ;; behind NAT each doing their own token refresh cycle.
-;; attempt-ttl-ms matches the library default (1h); explicit for clarity and to prevent silent drift on upgrade.
 (def ^:private token-throttlers
   {:client-id  (throttle/make-throttler :client-id :attempts-threshold 10 :attempt-ttl-ms one-hour-ms)
    :ip-address (throttle/make-throttler :ip-address :attempts-threshold 50 :attempt-ttl-ms one-hour-ms)})
@@ -134,7 +133,6 @@
 ;; /oauth/authorize/decision is lower risk (requires authentication + CSRF token),
 ;; but a compromised session could automate consent-granting. A per-user cap limits the blast
 ;; radius while allowing setup of many agents in a single session.
-;; attempt-ttl-ms matches the library default (1h); explicit for clarity and to prevent silent drift on upgrade.
 (def ^:private authorize-decision-throttler
   (throttle/make-throttler :user-id :attempts-threshold 20 :attempt-ttl-ms one-hour-ms))
 

--- a/src/metabase/oauth_server/api/oauth.clj
+++ b/src/metabase/oauth_server/api/oauth.clj
@@ -117,10 +117,12 @@
 
 ;; /oauth/token is the highest-risk endpoint: unauthenticated, accepts client credentials,
 ;; and is the primary target for brute-forcing client secrets or replaying authorization codes.
-;; Per-client_id is tight (one agent per client), per-IP is wider to accommodate many agents
-;; behind NAT each doing their own token refresh cycle.
+;; Per-client_id is tight (one agent per client)
+;;
 (def ^:private token-client-throttler
   (throttle/make-throttler :client-id :attempts-threshold 10 :attempt-ttl-ms one-hour-ms))
+
+;; Per-IP is wider to accommodate many agents behind NAT each doing their own token refresh cycle.
 (def ^:private token-ip-throttler
   (throttle/make-throttler :ip-address :attempts-threshold 50 :attempt-ttl-ms one-hour-ms))
 

--- a/src/metabase/oauth_server/api/oauth.clj
+++ b/src/metabase/oauth_server/api/oauth.clj
@@ -117,26 +117,37 @@
 ;; Per-client_id is tight (one agent per client), per-IP is wider to accommodate many agents
 ;; behind NAT each doing their own token refresh cycle.
 (def ^:private token-throttlers
-  {:client-id  (throttle/make-throttler :client-id :attempts-threshold 50)
-   :ip-address (throttle/make-throttler :ip-address :attempts-threshold 200)})
+  {:client-id  (throttle/make-throttler :client-id :attempts-threshold 10)
+   :ip-address (throttle/make-throttler :ip-address :attempts-threshold 50)})
 
 ;; /oauth/register is unauthenticated and creates server-side state (client records).
 ;; Without throttling, an attacker can exhaust storage or generate unlimited client_id/secret pairs.
 ;; Per-IP only since there's no identity at registration time. Threshold allows burst setup of
 ;; several agents without enabling sustained spam.
 (def ^:private registration-throttler
-  (throttle/make-throttler :ip-address :attempts-threshold 50 :attempt-ttl-ms (* 60 1000)))
+  (throttle/make-throttler :ip-address :attempts-threshold 10 :attempt-ttl-ms (* 60 1000)))
 
 ;; /oauth/authorize/decision is lower risk (requires authentication + CSRF token),
 ;; but a compromised session could automate consent-granting. A per-user cap limits the blast
 ;; radius while allowing setup of many agents in a single session.
 (def ^:private authorize-decision-throttler
-  (throttle/make-throttler :user-id :attempts-threshold 60))
+  (throttle/make-throttler :user-id :attempts-threshold 20))
+
+(defn- throttle-response
+  "Build a 429 response from a throttle exception, extracting Retry-After when available."
+  [^ExceptionInfo e]
+  (let [message       (ex-message e)
+        retry-seconds (some->> message (re-find #"(\d+) seconds") second)]
+    (cond-> {:status  429
+             :headers {"Content-Type" "application/json"}
+             :body    {:error             "too_many_requests"
+                       :error_description message}}
+      retry-seconds (assoc-in [:headers "Retry-After"] retry-seconds))))
 
 ;;; ------------------------------------------------ Endpoints ----------------------------------------------------
 
 (api.macros/defendpoint :post "/register"
-  :- [:map [:status [:enum 201 400 403 404]] [:body :any]]
+  :- [:map [:status [:enum 201 400 403 404 429]] [:body :any]]
   "Handles dynamic client registration (RFC 7591)."
   [_route-params _query-params body :- :any
    request]
@@ -144,42 +155,45 @@
     {:status  403
      :headers {"Content-Type" "application/json"}
      :body    {"error" "registration_not_supported"}}
-    (throttle/with-throttling [registration-throttler (request/ip-address request)]
-      (or (when-let [provider (oauth-server/get-provider)]
-            (if (nil? body)
-              {:status  400
-               :headers {"Content-Type" "application/json"}
-               :body    {"error"             "invalid_client_metadata"
-                         "error_description" "Invalid or missing JSON body"}}
-              (try
-                ;; MCP clients frequently omit application_type, scope, and may request
-                ;; unsupported grant types. We are required to support poorly-configured
-                ;; clients, so we apply sensible defaults here:
-                ;; - application_type defaults to "native" (not the RFC default "web") so
-                ;;   CLI tools and desktop apps can use HTTP loopback redirects.
-                ;; - scope defaults to all provider-supported scopes when not specified.
-                (let [body       (cond-> body
-                                   (not (contains? body :application_type))
-                                   (assoc :application_type "native")
-                                   (not (contains? body :scope))
-                                   (assoc :scope (str/join " " (oauth-server/all-agent-scopes)))
-                                   ;; Remove client_credentials grant type — tokens issued without a
-                                   ;; user context are unusable for MCP (validate-bearer-token requires
-                                   ;; a valid user-id).
-                                   (contains? body :grant_types)
-                                   (update :grant_types (fn [gts] (vec (remove #{"client_credentials"} gts)))))
-                      response   (oidc/dynamic-register-client provider body)
-                      client-id  (:client_id response)]
-                  ;; Mark as dynamically registered (the library doesn't know about registration_type)
-                  (proto/update-client (:client-store provider) client-id {:registration-type "dynamic"})
-                  {:status  201
-                   :headers {"Content-Type" "application/json"}
-                   :body    response})
-                (catch ExceptionInfo e
-                  (reg/registration-error-response
-                   (ex-message e)
-                   (:error_description (ex-data e)))))))
-          {:status 404 :body {:error "not_found"}}))))
+    (try
+      (throttle/with-throttling [registration-throttler (request/ip-address request)]
+        (or (when-let [provider (oauth-server/get-provider)]
+              (if (nil? body)
+                {:status  400
+                 :headers {"Content-Type" "application/json"}
+                 :body    {"error"             "invalid_client_metadata"
+                           "error_description" "Invalid or missing JSON body"}}
+                (try
+                  ;; MCP clients frequently omit application_type, scope, and may request
+                  ;; unsupported grant types. We are required to support poorly-configured
+                  ;; clients, so we apply sensible defaults here:
+                  ;; - application_type defaults to "native" (not the RFC default "web") so
+                  ;;   CLI tools and desktop apps can use HTTP loopback redirects.
+                  ;; - scope defaults to all provider-supported scopes when not specified.
+                  (let [body       (cond-> body
+                                     (not (contains? body :application_type))
+                                     (assoc :application_type "native")
+                                     (not (contains? body :scope))
+                                     (assoc :scope (str/join " " (oauth-server/all-agent-scopes)))
+                                     ;; Remove client_credentials grant type — tokens issued without a
+                                     ;; user context are unusable for MCP (validate-bearer-token requires
+                                     ;; a valid user-id).
+                                     (contains? body :grant_types)
+                                     (update :grant_types (fn [gts] (vec (remove #{"client_credentials"} gts)))))
+                        response   (oidc/dynamic-register-client provider body)
+                        client-id  (:client_id response)]
+                    ;; Mark as dynamically registered (the library doesn't know about registration_type)
+                    (proto/update-client (:client-store provider) client-id {:registration-type "dynamic"})
+                    {:status  201
+                     :headers {"Content-Type" "application/json"}
+                     :body    response})
+                  (catch ExceptionInfo e
+                    (reg/registration-error-response
+                     (ex-message e)
+                     (:error_description (ex-data e)))))))
+            {:status 404 :body {:error "not_found"}}))
+      (catch ExceptionInfo e
+        (throttle-response e)))))
 
 (api.macros/defendpoint :get "/register/:client-id"
   :- [:map [:status [:enum 200 401 404]] [:body :map]]
@@ -234,7 +248,7 @@
         {:status 404 :body {:error "not_found"}})))
 
 (api.macros/defendpoint :post "/authorize/decision"
-  :- [:map [:status [:enum 302 400 401 403 404]] [:body [:or :string :map]]]
+  :- [:map [:status [:enum 302 400 401 403 404 429]] [:body [:or :string :map]]]
   "Handles the authorization decision (POST /oauth/authorize/decision)."
   [_route-params _query-params body
    request]
@@ -242,69 +256,77 @@
     {:status  401
      :headers {"Content-Type" "application/json"}
      :body    {:error "unauthorized"}}
-    (throttle/with-throttling [authorize-decision-throttler (:metabase-user-id request)]
-      (or (when-let [provider (oauth-server/get-provider)]
-            (let [cookie-token (get-in request [:cookies csrf-cookie-name :value])
-                  form-token   (some-> (:csrf_token body) str)
-                  auth-params  (select-keys body oauth-param-keys)
-                  params-sig   (some-> (:params_sig body) str)]
-              (if (or (str/blank? cookie-token)
-                      (str/blank? form-token)
-                      (not (oidc-util/constant-time-eq? cookie-token form-token)))
-                {:status  403
-                 :headers {"Content-Type" "application/json"}
-                 :body    {:error "csrf_validation_failed"}}
-                (let [approved (= "true" (str (:approved body)))]
-                  (try
-                    (let [parsed        (oidc/parse-authorization-request provider auth-params)
-                          ;; Verify the HMAC against the *parsed* params (same normalized form as the consent page).
-                          ;; This must happen after parsing to ensure form-encoding round-trips don't cause mismatches.
-                          parsed-params (select-keys parsed oauth-param-keys)]
-                      (if (or (str/blank? params-sig)
-                              (not (re-matches #"[a-fA-F0-9]+" params-sig))
-                              (odd? (count params-sig))
-                              (not (verify-oauth-params-signature cookie-token parsed-params params-sig)))
-                        {:status  403
+    (try
+      (throttle/with-throttling [authorize-decision-throttler (:metabase-user-id request)]
+        (or (when-let [provider (oauth-server/get-provider)]
+              (let [cookie-token (get-in request [:cookies csrf-cookie-name :value])
+                    form-token   (some-> (:csrf_token body) str)
+                    auth-params  (select-keys body oauth-param-keys)
+                    params-sig   (some-> (:params_sig body) str)]
+                (if (or (str/blank? cookie-token)
+                        (str/blank? form-token)
+                        (not (oidc-util/constant-time-eq? cookie-token form-token)))
+                  {:status  403
+                   :headers {"Content-Type" "application/json"}
+                   :body    {:error "csrf_validation_failed"}}
+                  (let [approved (= "true" (str (:approved body)))]
+                    (try
+                      (let [parsed        (oidc/parse-authorization-request provider auth-params)
+                            ;; Verify the HMAC against the *parsed* params (same normalized form as the consent page).
+                            ;; This must happen after parsing to ensure form-encoding round-trips don't cause mismatches.
+                            parsed-params (select-keys parsed oauth-param-keys)]
+                        (if (or (str/blank? params-sig)
+                                (not (re-matches #"[a-fA-F0-9]+" params-sig))
+                                (odd? (count params-sig))
+                                (not (verify-oauth-params-signature cookie-token parsed-params params-sig)))
+                          {:status  403
+                           :headers {"Content-Type" "application/json"}
+                           :body    {:error "params_tampered"}}
+                          (redirect-authorization-decision provider parsed approved request)))
+                      (catch ExceptionInfo e
+                        (log/warn e "OAuth authorization decision failed")
+                        {:status  400
                          :headers {"Content-Type" "application/json"}
-                         :body    {:error "params_tampered"}}
-                        (redirect-authorization-decision provider parsed approved request)))
-                    (catch ExceptionInfo e
-                      (log/warn e "OAuth authorization decision failed")
-                      {:status  400
-                       :headers {"Content-Type" "application/json"}
-                       :body    {:error             "invalid_request"
-                                 :error_description "The authorization request is invalid."}}))))))
-          {:status 404 :body {:error "not_found"}}))))
+                         :body    {:error             "invalid_request"
+                                   :error_description "The authorization request is invalid."}}))))))
+            {:status 404 :body {:error "not_found"}}))
+      (catch ExceptionInfo e
+        (throttle-response e)))))
 
 (api.macros/defendpoint :post "/token"
-  :- [:map [:status [:enum 200 400 401 404]] [:body :map]]
+  :- [:map [:status [:enum 200 400 401 404 429]] [:body :map]]
   "Handles the token endpoint (POST /oauth/token)."
   [_route-params _query-params body
    request]
   (let [ip-address (request/ip-address request)
-        client-id  (or (:client_id body) "unknown")]
-    (throttle/with-throttling [(token-throttlers :client-id)  client-id
-                               (token-throttlers :ip-address) ip-address]
-      (or (when-let [provider (oauth-server/get-provider)]
-            (let [authorization-header (get-in request [:headers "authorization"])]
-              (try
-                (let [response (oidc/token-request provider body authorization-header)]
-                  {:status  200
-                   :headers {"Content-Type"  "application/json"
-                             "Cache-Control" "no-store"
-                             "Pragma"        "no-cache"}
-                   :body    response})
-                (catch ExceptionInfo e
-                  (log/warn e "OAuth token request failed")
-                  (let [data  (ex-data e)
-                        error (or (:error data) "invalid_request")]
-                    {:status  (if (= error "invalid_client") 401 400)
+        ;; Fall back to IP when client_id isn't in the body (e.g. confidential clients using
+        ;; HTTP Basic auth) to avoid pooling unrelated clients into a shared throttle bucket.
+        client-id  (or (:client_id body) ip-address)]
+    (try
+      (throttle/with-throttling [(token-throttlers :client-id)  client-id
+                                 (token-throttlers :ip-address) ip-address]
+        (or (when-let [provider (oauth-server/get-provider)]
+              (let [authorization-header (get-in request [:headers "authorization"])]
+                (try
+                  (let [response (oidc/token-request provider body authorization-header)]
+                    {:status  200
                      :headers {"Content-Type"  "application/json"
                                "Cache-Control" "no-store"
                                "Pragma"        "no-cache"}
-                     :body    {:error             error
-                               :error_description (or (:error_description data) "The token request is invalid.")}})))))
-          {:status 404 :body {:error "not_found"}}))))
+                     :body    response})
+                  (catch ExceptionInfo e
+                    (log/warn e "OAuth token request failed")
+                    (let [data  (ex-data e)
+                          error (or (:error data) "invalid_request")]
+                      {:status  (if (= error "invalid_client") 401 400)
+                       :headers {"Content-Type"  "application/json"
+                                 "Cache-Control" "no-store"
+                                 "Pragma"        "no-cache"}
+                       :body    {:error             error
+                                 :error_description (or (:error_description data) "The token request is invalid.")}})))))
+            {:status 404 :body {:error "not_found"}}))
+      (catch ExceptionInfo e
+        (throttle-response e)))))
 
 (api.macros/defendpoint :post "/revoke"
   :- [:map [:status [:enum 200 404]]]

--- a/src/metabase/oauth_server/api/oauth.clj
+++ b/src/metabase/oauth_server/api/oauth.clj
@@ -9,13 +9,15 @@
    [metabase.oauth-server.consent-page :as consent-page]
    [metabase.oauth-server.core :as oauth-server]
    [metabase.oauth-server.settings :as oauth-settings]
+   [metabase.request.core :as request]
    [metabase.system.core :as system]
    [metabase.util.log :as log]
    [oidc-provider.core :as oidc]
    [oidc-provider.protocol :as proto]
    [oidc-provider.registration :as reg]
    [oidc-provider.util :as oidc-util]
-   [ring.util.response :as response])
+   [ring.util.response :as response]
+   [throttle.core :as throttle])
   (:import
    (clojure.lang ExceptionInfo)
    (java.net URLEncoder)))
@@ -108,51 +110,76 @@
                       (str site-url "/auth/login"))]
     redirect))
 
+;;; ------------------------------------------------ Throttling ---------------------------------------------------
+
+;; /oauth/token is the highest-risk endpoint: unauthenticated, accepts client credentials,
+;; and is the primary target for brute-forcing client secrets or replaying authorization codes.
+;; Per-client_id is tight (one agent per client), per-IP is wider to accommodate many agents
+;; behind NAT each doing their own token refresh cycle.
+(def ^:private token-throttlers
+  {:client-id  (throttle/make-throttler :client-id :attempts-threshold 50)
+   :ip-address (throttle/make-throttler :ip-address :attempts-threshold 200)})
+
+;; /oauth/register is unauthenticated and creates server-side state (client records).
+;; Without throttling, an attacker can exhaust storage or generate unlimited client_id/secret pairs.
+;; Per-IP only since there's no identity at registration time. Threshold allows burst setup of
+;; several agents without enabling sustained spam.
+(def ^:private registration-throttler
+  (throttle/make-throttler :ip-address :attempts-threshold 50 :attempt-ttl-ms (* 60 1000)))
+
+;; /oauth/authorize/decision is lower risk (requires authentication + CSRF token),
+;; but a compromised session could automate consent-granting. A per-user cap limits the blast
+;; radius while allowing setup of many agents in a single session.
+(def ^:private authorize-decision-throttler
+  (throttle/make-throttler :user-id :attempts-threshold 60))
+
 ;;; ------------------------------------------------ Endpoints ----------------------------------------------------
 
 (api.macros/defendpoint :post "/register"
   :- [:map [:status [:enum 201 400 403 404]] [:body :any]]
   "Handles dynamic client registration (RFC 7591)."
-  [_route-params _query-params body :- :any]
+  [_route-params _query-params body :- :any
+   request]
   (if-not (oauth-settings/oauth-server-dynamic-registration-enabled)
     {:status  403
      :headers {"Content-Type" "application/json"}
      :body    {"error" "registration_not_supported"}}
-    (or (when-let [provider (oauth-server/get-provider)]
-          (if (nil? body)
-            {:status  400
-             :headers {"Content-Type" "application/json"}
-             :body    {"error"             "invalid_client_metadata"
-                       "error_description" "Invalid or missing JSON body"}}
-            (try
-              ;; MCP clients frequently omit application_type, scope, and may request
-              ;; unsupported grant types. We are required to support poorly-configured
-              ;; clients, so we apply sensible defaults here:
-              ;; - application_type defaults to "native" (not the RFC default "web") so
-              ;;   CLI tools and desktop apps can use HTTP loopback redirects.
-              ;; - scope defaults to all provider-supported scopes when not specified.
-              (let [body       (cond-> body
-                                 (not (contains? body :application_type))
-                                 (assoc :application_type "native")
-                                 (not (contains? body :scope))
-                                 (assoc :scope (str/join " " (oauth-server/all-agent-scopes)))
-                                 ;; Remove client_credentials grant type — tokens issued without a
-                                 ;; user context are unusable for MCP (validate-bearer-token requires
-                                 ;; a valid user-id).
-                                 (contains? body :grant_types)
-                                 (update :grant_types (fn [gts] (vec (remove #{"client_credentials"} gts)))))
-                    response   (oidc/dynamic-register-client provider body)
-                    client-id  (:client_id response)]
-                ;; Mark as dynamically registered (the library doesn't know about registration_type)
-                (proto/update-client (:client-store provider) client-id {:registration-type "dynamic"})
-                {:status  201
-                 :headers {"Content-Type" "application/json"}
-                 :body    response})
-              (catch ExceptionInfo e
-                (reg/registration-error-response
-                 (ex-message e)
-                 (:error_description (ex-data e)))))))
-        {:status 404 :body {:error "not_found"}})))
+    (throttle/with-throttling [registration-throttler (request/ip-address request)]
+      (or (when-let [provider (oauth-server/get-provider)]
+            (if (nil? body)
+              {:status  400
+               :headers {"Content-Type" "application/json"}
+               :body    {"error"             "invalid_client_metadata"
+                         "error_description" "Invalid or missing JSON body"}}
+              (try
+                ;; MCP clients frequently omit application_type, scope, and may request
+                ;; unsupported grant types. We are required to support poorly-configured
+                ;; clients, so we apply sensible defaults here:
+                ;; - application_type defaults to "native" (not the RFC default "web") so
+                ;;   CLI tools and desktop apps can use HTTP loopback redirects.
+                ;; - scope defaults to all provider-supported scopes when not specified.
+                (let [body       (cond-> body
+                                   (not (contains? body :application_type))
+                                   (assoc :application_type "native")
+                                   (not (contains? body :scope))
+                                   (assoc :scope (str/join " " (oauth-server/all-agent-scopes)))
+                                   ;; Remove client_credentials grant type — tokens issued without a
+                                   ;; user context are unusable for MCP (validate-bearer-token requires
+                                   ;; a valid user-id).
+                                   (contains? body :grant_types)
+                                   (update :grant_types (fn [gts] (vec (remove #{"client_credentials"} gts)))))
+                      response   (oidc/dynamic-register-client provider body)
+                      client-id  (:client_id response)]
+                  ;; Mark as dynamically registered (the library doesn't know about registration_type)
+                  (proto/update-client (:client-store provider) client-id {:registration-type "dynamic"})
+                  {:status  201
+                   :headers {"Content-Type" "application/json"}
+                   :body    response})
+                (catch ExceptionInfo e
+                  (reg/registration-error-response
+                   (ex-message e)
+                   (:error_description (ex-data e)))))))
+          {:status 404 :body {:error "not_found"}}))))
 
 (api.macros/defendpoint :get "/register/:client-id"
   :- [:map [:status [:enum 200 401 404]] [:body :map]]
@@ -215,64 +242,69 @@
     {:status  401
      :headers {"Content-Type" "application/json"}
      :body    {:error "unauthorized"}}
-    (or (when-let [provider (oauth-server/get-provider)]
-          (let [cookie-token (get-in request [:cookies csrf-cookie-name :value])
-                form-token   (some-> (:csrf_token body) str)
-                auth-params  (select-keys body oauth-param-keys)
-                params-sig   (some-> (:params_sig body) str)]
-            (if (or (str/blank? cookie-token)
-                    (str/blank? form-token)
-                    (not (oidc-util/constant-time-eq? cookie-token form-token)))
-              {:status  403
-               :headers {"Content-Type" "application/json"}
-               :body    {:error "csrf_validation_failed"}}
-              (let [approved (= "true" (str (:approved body)))]
-                (try
-                  (let [parsed        (oidc/parse-authorization-request provider auth-params)
-                        ;; Verify the HMAC against the *parsed* params (same normalized form as the consent page).
-                        ;; This must happen after parsing to ensure form-encoding round-trips don't cause mismatches.
-                        parsed-params (select-keys parsed oauth-param-keys)]
-                    (if (or (str/blank? params-sig)
-                            (not (re-matches #"[a-fA-F0-9]+" params-sig))
-                            (odd? (count params-sig))
-                            (not (verify-oauth-params-signature cookie-token parsed-params params-sig)))
-                      {:status  403
+    (throttle/with-throttling [authorize-decision-throttler (:metabase-user-id request)]
+      (or (when-let [provider (oauth-server/get-provider)]
+            (let [cookie-token (get-in request [:cookies csrf-cookie-name :value])
+                  form-token   (some-> (:csrf_token body) str)
+                  auth-params  (select-keys body oauth-param-keys)
+                  params-sig   (some-> (:params_sig body) str)]
+              (if (or (str/blank? cookie-token)
+                      (str/blank? form-token)
+                      (not (oidc-util/constant-time-eq? cookie-token form-token)))
+                {:status  403
+                 :headers {"Content-Type" "application/json"}
+                 :body    {:error "csrf_validation_failed"}}
+                (let [approved (= "true" (str (:approved body)))]
+                  (try
+                    (let [parsed        (oidc/parse-authorization-request provider auth-params)
+                          ;; Verify the HMAC against the *parsed* params (same normalized form as the consent page).
+                          ;; This must happen after parsing to ensure form-encoding round-trips don't cause mismatches.
+                          parsed-params (select-keys parsed oauth-param-keys)]
+                      (if (or (str/blank? params-sig)
+                              (not (re-matches #"[a-fA-F0-9]+" params-sig))
+                              (odd? (count params-sig))
+                              (not (verify-oauth-params-signature cookie-token parsed-params params-sig)))
+                        {:status  403
+                         :headers {"Content-Type" "application/json"}
+                         :body    {:error "params_tampered"}}
+                        (redirect-authorization-decision provider parsed approved request)))
+                    (catch ExceptionInfo e
+                      (log/warn e "OAuth authorization decision failed")
+                      {:status  400
                        :headers {"Content-Type" "application/json"}
-                       :body    {:error "params_tampered"}}
-                      (redirect-authorization-decision provider parsed approved request)))
-                  (catch ExceptionInfo e
-                    (log/warn e "OAuth authorization decision failed")
-                    {:status  400
-                     :headers {"Content-Type" "application/json"}
-                     :body    {:error             "invalid_request"
-                               :error_description "The authorization request is invalid."}}))))))
-        {:status 404 :body {:error "not_found"}})))
+                       :body    {:error             "invalid_request"
+                                 :error_description "The authorization request is invalid."}}))))))
+          {:status 404 :body {:error "not_found"}}))))
 
 (api.macros/defendpoint :post "/token"
   :- [:map [:status [:enum 200 400 401 404]] [:body :map]]
   "Handles the token endpoint (POST /oauth/token)."
   [_route-params _query-params body
    request]
-  (or (when-let [provider (oauth-server/get-provider)]
-        (let [authorization-header (get-in request [:headers "authorization"])]
-          (try
-            (let [response (oidc/token-request provider body authorization-header)]
-              {:status  200
-               :headers {"Content-Type"  "application/json"
-                         "Cache-Control" "no-store"
-                         "Pragma"        "no-cache"}
-               :body    response})
-            (catch ExceptionInfo e
-              (log/warn e "OAuth token request failed")
-              (let [data  (ex-data e)
-                    error (or (:error data) "invalid_request")]
-                {:status  (if (= error "invalid_client") 401 400)
-                 :headers {"Content-Type"  "application/json"
-                           "Cache-Control" "no-store"
-                           "Pragma"        "no-cache"}
-                 :body    {:error             error
-                           :error_description (or (:error_description data) "The token request is invalid.")}})))))
-      {:status 404 :body {:error "not_found"}}))
+  (let [ip-address (request/ip-address request)
+        client-id  (or (:client_id body) "unknown")]
+    (throttle/with-throttling [(token-throttlers :client-id)  client-id
+                               (token-throttlers :ip-address) ip-address]
+      (or (when-let [provider (oauth-server/get-provider)]
+            (let [authorization-header (get-in request [:headers "authorization"])]
+              (try
+                (let [response (oidc/token-request provider body authorization-header)]
+                  {:status  200
+                   :headers {"Content-Type"  "application/json"
+                             "Cache-Control" "no-store"
+                             "Pragma"        "no-cache"}
+                   :body    response})
+                (catch ExceptionInfo e
+                  (log/warn e "OAuth token request failed")
+                  (let [data  (ex-data e)
+                        error (or (:error data) "invalid_request")]
+                    {:status  (if (= error "invalid_client") 401 400)
+                     :headers {"Content-Type"  "application/json"
+                               "Cache-Control" "no-store"
+                               "Pragma"        "no-cache"}
+                     :body    {:error             error
+                               :error_description (or (:error_description data) "The token request is invalid.")}})))))
+          {:status 404 :body {:error "not_found"}}))))
 
 (api.macros/defendpoint :post "/revoke"
   :- [:map [:status [:enum 200 404]]]

--- a/src/metabase/oauth_server/api/oauth.clj
+++ b/src/metabase/oauth_server/api/oauth.clj
@@ -118,7 +118,6 @@
 ;; /oauth/token is the highest-risk endpoint: unauthenticated, accepts client credentials,
 ;; and is the primary target for brute-forcing client secrets or replaying authorization codes.
 ;; Per-client_id is tight (one agent per client)
-;;
 (def ^:private token-client-throttler
   (throttle/make-throttler :client-id :attempts-threshold 10 :attempt-ttl-ms one-hour-ms))
 

--- a/src/metabase/oauth_server/api/oauth.clj
+++ b/src/metabase/oauth_server/api/oauth.clj
@@ -144,6 +144,16 @@
                        :error_description message}}
       retry-seconds (assoc-in [:headers "Retry-After"] retry-seconds))))
 
+(defmacro ^:private with-throttling-429
+  "Like [[throttle/with-throttling]], but returns HTTP 429 with Retry-After instead of
+   throwing an unhandled exception (which the generic middleware would turn into a 500)."
+  {:style/indent 1}
+  [bindings & body]
+  `(try
+     (throttle/with-throttling ~bindings ~@body)
+     (catch ExceptionInfo e#
+       (throttle-response e#))))
+
 ;;; ------------------------------------------------ Endpoints ----------------------------------------------------
 
 (api.macros/defendpoint :post "/register"
@@ -155,45 +165,42 @@
     {:status  403
      :headers {"Content-Type" "application/json"}
      :body    {"error" "registration_not_supported"}}
-    (try
-      (throttle/with-throttling [registration-throttler (request/ip-address request)]
-        (or (when-let [provider (oauth-server/get-provider)]
-              (if (nil? body)
-                {:status  400
-                 :headers {"Content-Type" "application/json"}
-                 :body    {"error"             "invalid_client_metadata"
-                           "error_description" "Invalid or missing JSON body"}}
-                (try
-                  ;; MCP clients frequently omit application_type, scope, and may request
-                  ;; unsupported grant types. We are required to support poorly-configured
-                  ;; clients, so we apply sensible defaults here:
-                  ;; - application_type defaults to "native" (not the RFC default "web") so
-                  ;;   CLI tools and desktop apps can use HTTP loopback redirects.
-                  ;; - scope defaults to all provider-supported scopes when not specified.
-                  (let [body       (cond-> body
-                                     (not (contains? body :application_type))
-                                     (assoc :application_type "native")
-                                     (not (contains? body :scope))
-                                     (assoc :scope (str/join " " (oauth-server/all-agent-scopes)))
-                                     ;; Remove client_credentials grant type — tokens issued without a
-                                     ;; user context are unusable for MCP (validate-bearer-token requires
-                                     ;; a valid user-id).
-                                     (contains? body :grant_types)
-                                     (update :grant_types (fn [gts] (vec (remove #{"client_credentials"} gts)))))
-                        response   (oidc/dynamic-register-client provider body)
-                        client-id  (:client_id response)]
-                    ;; Mark as dynamically registered (the library doesn't know about registration_type)
-                    (proto/update-client (:client-store provider) client-id {:registration-type "dynamic"})
-                    {:status  201
-                     :headers {"Content-Type" "application/json"}
-                     :body    response})
-                  (catch ExceptionInfo e
-                    (reg/registration-error-response
-                     (ex-message e)
-                     (:error_description (ex-data e)))))))
-            {:status 404 :body {:error "not_found"}}))
-      (catch ExceptionInfo e
-        (throttle-response e)))))
+    (with-throttling-429 [registration-throttler (request/ip-address request)]
+      (or (when-let [provider (oauth-server/get-provider)]
+            (if (nil? body)
+              {:status  400
+               :headers {"Content-Type" "application/json"}
+               :body    {"error"             "invalid_client_metadata"
+                         "error_description" "Invalid or missing JSON body"}}
+              (try
+                ;; MCP clients frequently omit application_type, scope, and may request
+                ;; unsupported grant types. We are required to support poorly-configured
+                ;; clients, so we apply sensible defaults here:
+                ;; - application_type defaults to "native" (not the RFC default "web") so
+                ;;   CLI tools and desktop apps can use HTTP loopback redirects.
+                ;; - scope defaults to all provider-supported scopes when not specified.
+                (let [body       (cond-> body
+                                   (not (contains? body :application_type))
+                                   (assoc :application_type "native")
+                                   (not (contains? body :scope))
+                                   (assoc :scope (str/join " " (oauth-server/all-agent-scopes)))
+                                   ;; Remove client_credentials grant type — tokens issued without a
+                                   ;; user context are unusable for MCP (validate-bearer-token requires
+                                   ;; a valid user-id).
+                                   (contains? body :grant_types)
+                                   (update :grant_types (fn [gts] (vec (remove #{"client_credentials"} gts)))))
+                      response   (oidc/dynamic-register-client provider body)
+                      client-id  (:client_id response)]
+                  ;; Mark as dynamically registered (the library doesn't know about registration_type)
+                  (proto/update-client (:client-store provider) client-id {:registration-type "dynamic"})
+                  {:status  201
+                   :headers {"Content-Type" "application/json"}
+                   :body    response})
+                (catch ExceptionInfo e
+                  (reg/registration-error-response
+                   (ex-message e)
+                   (:error_description (ex-data e)))))))
+          {:status 404 :body {:error "not_found"}}))))
 
 (api.macros/defendpoint :get "/register/:client-id"
   :- [:map [:status [:enum 200 401 404]] [:body :map]]
@@ -256,42 +263,39 @@
     {:status  401
      :headers {"Content-Type" "application/json"}
      :body    {:error "unauthorized"}}
-    (try
-      (throttle/with-throttling [authorize-decision-throttler (:metabase-user-id request)]
-        (or (when-let [provider (oauth-server/get-provider)]
-              (let [cookie-token (get-in request [:cookies csrf-cookie-name :value])
-                    form-token   (some-> (:csrf_token body) str)
-                    auth-params  (select-keys body oauth-param-keys)
-                    params-sig   (some-> (:params_sig body) str)]
-                (if (or (str/blank? cookie-token)
-                        (str/blank? form-token)
-                        (not (oidc-util/constant-time-eq? cookie-token form-token)))
-                  {:status  403
-                   :headers {"Content-Type" "application/json"}
-                   :body    {:error "csrf_validation_failed"}}
-                  (let [approved (= "true" (str (:approved body)))]
-                    (try
-                      (let [parsed        (oidc/parse-authorization-request provider auth-params)
-                            ;; Verify the HMAC against the *parsed* params (same normalized form as the consent page).
-                            ;; This must happen after parsing to ensure form-encoding round-trips don't cause mismatches.
-                            parsed-params (select-keys parsed oauth-param-keys)]
-                        (if (or (str/blank? params-sig)
-                                (not (re-matches #"[a-fA-F0-9]+" params-sig))
-                                (odd? (count params-sig))
-                                (not (verify-oauth-params-signature cookie-token parsed-params params-sig)))
-                          {:status  403
-                           :headers {"Content-Type" "application/json"}
-                           :body    {:error "params_tampered"}}
-                          (redirect-authorization-decision provider parsed approved request)))
-                      (catch ExceptionInfo e
-                        (log/warn e "OAuth authorization decision failed")
-                        {:status  400
+    (with-throttling-429 [authorize-decision-throttler (:metabase-user-id request)]
+      (or (when-let [provider (oauth-server/get-provider)]
+            (let [cookie-token (get-in request [:cookies csrf-cookie-name :value])
+                  form-token   (some-> (:csrf_token body) str)
+                  auth-params  (select-keys body oauth-param-keys)
+                  params-sig   (some-> (:params_sig body) str)]
+              (if (or (str/blank? cookie-token)
+                      (str/blank? form-token)
+                      (not (oidc-util/constant-time-eq? cookie-token form-token)))
+                {:status  403
+                 :headers {"Content-Type" "application/json"}
+                 :body    {:error "csrf_validation_failed"}}
+                (let [approved (= "true" (str (:approved body)))]
+                  (try
+                    (let [parsed        (oidc/parse-authorization-request provider auth-params)
+                          ;; Verify the HMAC against the *parsed* params (same normalized form as the consent page).
+                          ;; This must happen after parsing to ensure form-encoding round-trips don't cause mismatches.
+                          parsed-params (select-keys parsed oauth-param-keys)]
+                      (if (or (str/blank? params-sig)
+                              (not (re-matches #"[a-fA-F0-9]+" params-sig))
+                              (odd? (count params-sig))
+                              (not (verify-oauth-params-signature cookie-token parsed-params params-sig)))
+                        {:status  403
                          :headers {"Content-Type" "application/json"}
-                         :body    {:error             "invalid_request"
-                                   :error_description "The authorization request is invalid."}}))))))
-            {:status 404 :body {:error "not_found"}}))
-      (catch ExceptionInfo e
-        (throttle-response e)))))
+                         :body    {:error "params_tampered"}}
+                        (redirect-authorization-decision provider parsed approved request)))
+                    (catch ExceptionInfo e
+                      (log/warn e "OAuth authorization decision failed")
+                      {:status  400
+                       :headers {"Content-Type" "application/json"}
+                       :body    {:error             "invalid_request"
+                                 :error_description "The authorization request is invalid."}}))))))
+          {:status 404 :body {:error "not_found"}}))))
 
 (api.macros/defendpoint :post "/token"
   :- [:map [:status [:enum 200 400 401 404 429]] [:body :map]]
@@ -302,31 +306,28 @@
         ;; Fall back to IP when client_id isn't in the body (e.g. confidential clients using
         ;; HTTP Basic auth) to avoid pooling unrelated clients into a shared throttle bucket.
         client-id  (or (:client_id body) ip-address)]
-    (try
-      (throttle/with-throttling [(token-throttlers :client-id)  client-id
-                                 (token-throttlers :ip-address) ip-address]
-        (or (when-let [provider (oauth-server/get-provider)]
-              (let [authorization-header (get-in request [:headers "authorization"])]
-                (try
-                  (let [response (oidc/token-request provider body authorization-header)]
-                    {:status  200
+    (with-throttling-429 [(token-throttlers :client-id)  client-id
+                          (token-throttlers :ip-address) ip-address]
+      (or (when-let [provider (oauth-server/get-provider)]
+            (let [authorization-header (get-in request [:headers "authorization"])]
+              (try
+                (let [response (oidc/token-request provider body authorization-header)]
+                  {:status  200
+                   :headers {"Content-Type"  "application/json"
+                             "Cache-Control" "no-store"
+                             "Pragma"        "no-cache"}
+                   :body    response})
+                (catch ExceptionInfo e
+                  (log/warn e "OAuth token request failed")
+                  (let [data  (ex-data e)
+                        error (or (:error data) "invalid_request")]
+                    {:status  (if (= error "invalid_client") 401 400)
                      :headers {"Content-Type"  "application/json"
                                "Cache-Control" "no-store"
                                "Pragma"        "no-cache"}
-                     :body    response})
-                  (catch ExceptionInfo e
-                    (log/warn e "OAuth token request failed")
-                    (let [data  (ex-data e)
-                          error (or (:error data) "invalid_request")]
-                      {:status  (if (= error "invalid_client") 401 400)
-                       :headers {"Content-Type"  "application/json"
-                                 "Cache-Control" "no-store"
-                                 "Pragma"        "no-cache"}
-                       :body    {:error             error
-                                 :error_description (or (:error_description data) "The token request is invalid.")}})))))
-            {:status 404 :body {:error "not_found"}}))
-      (catch ExceptionInfo e
-        (throttle-response e)))))
+                     :body    {:error             error
+                               :error_description (or (:error_description data) "The token request is invalid.")}})))))
+          {:status 404 :body {:error "not_found"}}))))
 
 (api.macros/defendpoint :post "/revoke"
   :- [:map [:status [:enum 200 404]]]

--- a/src/metabase/oauth_server/api/oauth.clj
+++ b/src/metabase/oauth_server/api/oauth.clj
@@ -119,9 +119,10 @@
 ;; and is the primary target for brute-forcing client secrets or replaying authorization codes.
 ;; Per-client_id is tight (one agent per client), per-IP is wider to accommodate many agents
 ;; behind NAT each doing their own token refresh cycle.
-(def ^:private token-throttlers
-  {:client-id  (throttle/make-throttler :client-id :attempts-threshold 10 :attempt-ttl-ms one-hour-ms)
-   :ip-address (throttle/make-throttler :ip-address :attempts-threshold 50 :attempt-ttl-ms one-hour-ms)})
+(def ^:private token-client-throttler
+  (throttle/make-throttler :client-id :attempts-threshold 10 :attempt-ttl-ms one-hour-ms))
+(def ^:private token-ip-throttler
+  (throttle/make-throttler :ip-address :attempts-threshold 50 :attempt-ttl-ms one-hour-ms))
 
 ;; /oauth/register is unauthenticated and creates server-side state (client records).
 ;; Without throttling, an attacker can exhaust storage or generate unlimited client_id/secret pairs.
@@ -317,8 +318,8 @@
         ;; Fall back to IP when client_id isn't in the body (e.g. confidential clients using
         ;; HTTP Basic auth) to avoid pooling unrelated clients into a shared throttle bucket.
         client-id  (or (:client_id body) ip-address)]
-    (with-throttling-429 [(token-throttlers :client-id)  client-id
-                          (token-throttlers :ip-address) ip-address]
+    (with-throttling-429 [token-client-throttler client-id
+                          token-ip-throttler     ip-address]
       (or (when-let [provider (oauth-server/get-provider)]
             (let [authorization-header (get-in request [:headers "authorization"])]
               (try

--- a/src/metabase/oauth_server/api/oauth.clj
+++ b/src/metabase/oauth_server/api/oauth.clj
@@ -119,6 +119,7 @@
 ;; and is the primary target for brute-forcing client secrets or replaying authorization codes.
 ;; Per-client_id is tight (one agent per client), per-IP is wider to accommodate many agents
 ;; behind NAT each doing their own token refresh cycle.
+;; attempt-ttl-ms matches the library default (1h); explicit for clarity and to prevent silent drift on upgrade.
 (def ^:private token-throttlers
   {:client-id  (throttle/make-throttler :client-id :attempts-threshold 10 :attempt-ttl-ms one-hour-ms)
    :ip-address (throttle/make-throttler :ip-address :attempts-threshold 50 :attempt-ttl-ms one-hour-ms)})
@@ -133,6 +134,7 @@
 ;; /oauth/authorize/decision is lower risk (requires authentication + CSRF token),
 ;; but a compromised session could automate consent-granting. A per-user cap limits the blast
 ;; radius while allowing setup of many agents in a single session.
+;; attempt-ttl-ms matches the library default (1h); explicit for clarity and to prevent silent drift on upgrade.
 (def ^:private authorize-decision-throttler
   (throttle/make-throttler :user-id :attempts-threshold 20 :attempt-ttl-ms one-hour-ms))
 
@@ -147,6 +149,12 @@
                        :error_description message}}
       retry-seconds (assoc-in [:headers "Retry-After"] retry-seconds))))
 
+(defn- throttle-exception?
+  "True when `e` is a throttle-limit exception thrown by [[metabase.throttle]].
+   Coupled to the library's `\"Too many attempts!\"` message prefix — update here if that changes."
+  [^ExceptionInfo e]
+  (str/starts-with? (ex-message e) "Too many attempts!"))
+
 (defmacro ^:private with-throttling-429
   "Like [[throttle/with-throttling]], but returns HTTP 429 with Retry-After instead of
    throwing an unhandled exception (which the generic middleware would turn into a 500)."
@@ -155,7 +163,7 @@
   `(try
      (throttle/with-throttling ~bindings ~@body)
      (catch ExceptionInfo e#
-       (if (str/starts-with? (ex-message e#) "Too many attempts!")
+       (if (throttle-exception? e#)
          (throttle-response e#)
          (throw e#)))))
 

--- a/src/metabase/oauth_server/api/oauth.clj
+++ b/src/metabase/oauth_server/api/oauth.clj
@@ -112,26 +112,29 @@
 
 ;;; ------------------------------------------------ Throttling ---------------------------------------------------
 
+(def ^:private one-minute-ms (* 60 1000))
+(def ^:private one-hour-ms (* 60 one-minute-ms))
+
 ;; /oauth/token is the highest-risk endpoint: unauthenticated, accepts client credentials,
 ;; and is the primary target for brute-forcing client secrets or replaying authorization codes.
 ;; Per-client_id is tight (one agent per client), per-IP is wider to accommodate many agents
 ;; behind NAT each doing their own token refresh cycle.
 (def ^:private token-throttlers
-  {:client-id  (throttle/make-throttler :client-id :attempts-threshold 10)
-   :ip-address (throttle/make-throttler :ip-address :attempts-threshold 50)})
+  {:client-id  (throttle/make-throttler :client-id :attempts-threshold 10 :attempt-ttl-ms one-hour-ms)
+   :ip-address (throttle/make-throttler :ip-address :attempts-threshold 50 :attempt-ttl-ms one-hour-ms)})
 
 ;; /oauth/register is unauthenticated and creates server-side state (client records).
 ;; Without throttling, an attacker can exhaust storage or generate unlimited client_id/secret pairs.
 ;; Per-IP only since there's no identity at registration time. Threshold allows burst setup of
 ;; several agents without enabling sustained spam.
 (def ^:private registration-throttler
-  (throttle/make-throttler :ip-address :attempts-threshold 10 :attempt-ttl-ms (* 60 1000)))
+  (throttle/make-throttler :ip-address :attempts-threshold 10 :attempt-ttl-ms one-minute-ms))
 
 ;; /oauth/authorize/decision is lower risk (requires authentication + CSRF token),
 ;; but a compromised session could automate consent-granting. A per-user cap limits the blast
 ;; radius while allowing setup of many agents in a single session.
 (def ^:private authorize-decision-throttler
-  (throttle/make-throttler :user-id :attempts-threshold 20))
+  (throttle/make-throttler :user-id :attempts-threshold 20 :attempt-ttl-ms one-hour-ms))
 
 (defn- throttle-response
   "Build a 429 response from a throttle exception, extracting Retry-After when available."
@@ -152,7 +155,9 @@
   `(try
      (throttle/with-throttling ~bindings ~@body)
      (catch ExceptionInfo e#
-       (throttle-response e#))))
+       (if (str/starts-with? (ex-message e#) "Too many attempts!")
+         (throttle-response e#)
+         (throw e#)))))
 
 ;;; ------------------------------------------------ Endpoints ----------------------------------------------------
 

--- a/test/metabase/mcp/api_test.clj
+++ b/test/metabase/mcp/api_test.clj
@@ -3,6 +3,7 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.api.macros.scope :as scope]
+   [metabase.mcp.api :as mcp.api]
    [metabase.mcp.tools :as mcp.tools]
    [metabase.oauth-server.core :as oauth-server]
    [metabase.search.test-util :as search.tu]
@@ -11,6 +12,7 @@
    [metabase.test.fixtures :as fixtures]
    [metabase.test.http-client :as client]
    [metabase.util.json :as json]
+   [throttle.core :as throttle]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
@@ -515,3 +517,29 @@
                      (#'mcp.tools/invoke-agent-api :get (str "/v1/table/" (mt/id :orders)) #{::scope/unrestricted} nil))]
         (is (not (:isError result))
             "Agent API should accept unrestricted scopes")))))
+
+;;; ------------------------------------------------- Throttling ---------------------------------------------------
+
+(deftest mcp-throttle-returns-429-test
+  (testing "MCP endpoint returns 429 with JSON-RPC error when rate-limited"
+    (let [[session-id _] (initialize!)
+          orig           (deref #'mcp.api/mcp-throttler)]
+      (try
+        ;; Replace throttler after initialization so the handshake doesn't consume attempts
+        (alter-var-root #'mcp.api/mcp-throttler (constantly (throttle/make-throttler :user-id :attempts-threshold 1)))
+        (let [;; First request succeeds (consumes the single attempt)
+              first-response (mcp-request (jsonrpc-request "ping")
+                                          {"mcp-session-id" session-id})
+              ;; Second request should be throttled
+              throttled-response (mcp-request (jsonrpc-request "ping")
+                                              {"mcp-session-id" session-id})]
+          (is (= 200 (:status first-response)))
+          (is (= 429 (:status throttled-response)))
+          (is (= -32000 (get-in throttled-response [:body :error :code]))
+              "Throttle response should use JSON-RPC error format")
+          (is (str/starts-with? (get-in throttled-response [:body :error :message]) "Too many attempts!")
+              "Error message should indicate rate limiting")
+          (is (contains? (:headers throttled-response) "Retry-After")
+              "Response should include Retry-After header"))
+        (finally
+          (alter-var-root #'mcp.api/mcp-throttler (constantly orig)))))))

--- a/test/metabase/mcp/api_test.clj
+++ b/test/metabase/mcp/api_test.clj
@@ -525,17 +525,14 @@
     (let [[session-id _] (initialize!)]
       ;; Replace throttler after initialization so the handshake doesn't consume attempts
       (with-redefs [mcp.api/mcp-throttler (throttle/make-throttler :user-id :attempts-threshold 1)]
-        (let [;; First request succeeds (consumes the single attempt)
-              first-response (mcp-request (jsonrpc-request "ping")
-                                          {"mcp-session-id" session-id})
-              ;; Second request should be throttled
-              throttled-response (mcp-request (jsonrpc-request "ping")
-                                              {"mcp-session-id" session-id})]
-          (is (= 200 (:status first-response)))
-          (is (= 429 (:status throttled-response)))
-          (is (= -32000 (get-in throttled-response [:body :error :code]))
-              "Throttle response should use JSON-RPC error format")
-          (is (str/starts-with? (get-in throttled-response [:body :error :message]) "Too many attempts!")
-              "Error message should indicate rate limiting")
-          (is (contains? (:headers throttled-response) "Retry-After")
-              "Response should include Retry-After header"))))))
+        ;; First request succeeds (consumes the single attempt)
+        (is (= 200 (:status (mcp-request (jsonrpc-request "ping")
+                                         {"mcp-session-id" session-id}))))
+        ;; Second request should be throttled
+        (is (=? {:status  429
+                 :headers {"Retry-After" string?}
+                 :body    {:jsonrpc "2.0"
+                           :error   {:code    -32000
+                                     :message #(str/starts-with? % "Too many attempts!")}}}
+                (mcp-request (jsonrpc-request "ping")
+                             {"mcp-session-id" session-id})))))))

--- a/test/metabase/mcp/api_test.clj
+++ b/test/metabase/mcp/api_test.clj
@@ -522,11 +522,9 @@
 
 (deftest mcp-throttle-returns-429-test
   (testing "MCP endpoint returns 429 with JSON-RPC error when rate-limited"
-    (let [[session-id _] (initialize!)
-          orig           (deref #'mcp.api/mcp-throttler)]
-      (try
-        ;; Replace throttler after initialization so the handshake doesn't consume attempts
-        (alter-var-root #'mcp.api/mcp-throttler (constantly (throttle/make-throttler :user-id :attempts-threshold 1)))
+    (let [[session-id _] (initialize!)]
+      ;; Replace throttler after initialization so the handshake doesn't consume attempts
+      (with-redefs [mcp.api/mcp-throttler (throttle/make-throttler :user-id :attempts-threshold 1)]
         (let [;; First request succeeds (consumes the single attempt)
               first-response (mcp-request (jsonrpc-request "ping")
                                           {"mcp-session-id" session-id})
@@ -540,6 +538,4 @@
           (is (str/starts-with? (get-in throttled-response [:body :error :message]) "Too many attempts!")
               "Error message should indicate rate limiting")
           (is (contains? (:headers throttled-response) "Retry-After")
-              "Response should include Retry-After header"))
-        (finally
-          (alter-var-root #'mcp.api/mcp-throttler (constantly orig)))))))
+              "Response should include Retry-After header"))))))

--- a/test/metabase/oauth_server/api_test.clj
+++ b/test/metabase/oauth_server/api_test.clj
@@ -964,4 +964,3 @@
               "Raw script tags must not appear in the consent page")
           (is (str/includes? body "&lt;script&gt;")
               "Script tags should be HTML-escaped"))))))
-

--- a/test/metabase/oauth_server/api_test.clj
+++ b/test/metabase/oauth_server/api_test.clj
@@ -2,12 +2,10 @@
   (:require
    [clojure.string :as str]
    [clojure.test :refer [deftest is testing use-fixtures]]
-   [metabase.oauth-server.api.oauth :as oauth]
    [metabase.oauth-server.core :as oauth-server]
    [metabase.test :as mt]
    [metabase.test.http-client :as client]
    [oidc-provider.util :as oidc-util]
-   [throttle.core :as throttle]
    [toucan2.core :as t2])
   (:import
    (java.net URLEncoder)
@@ -967,28 +965,3 @@
           (is (str/includes? body "&lt;script&gt;")
               "Script tags should be HTML-escaped"))))))
 
-;;; ------------------------------------------------ Throttling ---------------------------------------------------
-
-(defn- trigger-throttle-response
-  "Creates a throttler with threshold 0, triggers it, and returns the throttle-response.
-  With `:attempts-threshold 0` the first `check` call records the attempt and throws immediately
-  (zero attempts allowed), so we catch and discard that initial exception. The second call then
-  throws with a longer back-off delay, which is the exception we pass to `throttle-response`."
-  [user-id]
-  (let [throttler (throttle/make-throttler :test-key :attempts-threshold 0 :initial-delay-ms 15000)]
-    (try (throttle/check throttler user-id) (catch Exception _))
-    (try
-      (throttle/check throttler user-id)
-      (catch clojure.lang.ExceptionInfo e
-        (#'oauth/throttle-response e)))))
-
-(deftest throttle-response-format-test
-  (testing "throttle-response builds correct 429 response with Retry-After"
-    (let [response (trigger-throttle-response "user-1")]
-      (is (= 429 (:status response)))
-      (is (contains? (:headers response) "Retry-After"))
-      (is (= "too_many_requests" (get-in response [:body :error])))))
-
-  (testing "throttle-response includes descriptive error_description"
-    (let [response (trigger-throttle-response "user-2")]
-      (is (str/starts-with? (get-in response [:body :error_description]) "Too many attempts!")))))

--- a/test/metabase/oauth_server/api_test.clj
+++ b/test/metabase/oauth_server/api_test.clj
@@ -2,10 +2,12 @@
   (:require
    [clojure.string :as str]
    [clojure.test :refer [deftest is testing use-fixtures]]
+   [metabase.oauth-server.api.oauth :as oauth]
    [metabase.oauth-server.core :as oauth-server]
    [metabase.test :as mt]
    [metabase.test.http-client :as client]
    [oidc-provider.util :as oidc-util]
+   [throttle.core :as throttle]
    [toucan2.core :as t2])
   (:import
    (java.net URLEncoder)
@@ -964,3 +966,26 @@
               "Raw script tags must not appear in the consent page")
           (is (str/includes? body "&lt;script&gt;")
               "Script tags should be HTML-escaped"))))))
+
+;;; ------------------------------------------------ Throttling ---------------------------------------------------
+
+(deftest throttle-response-format-test
+  (testing "throttle-response builds correct 429 response with Retry-After"
+    (let [throttler (throttle/make-throttler :test-key :attempts-threshold 0 :initial-delay-ms 15000)
+          _         (try (throttle/check throttler "user-1") (catch Exception _))
+          response  (try
+                      (throttle/check throttler "user-1")
+                      (catch clojure.lang.ExceptionInfo e
+                        (#'oauth/throttle-response e)))]
+      (is (= 429 (:status response)))
+      (is (contains? (:headers response) "Retry-After"))
+      (is (= "too_many_requests" (get-in response [:body :error])))))
+
+  (testing "throttle-response includes descriptive error_description"
+    (let [throttler (throttle/make-throttler :test-key :attempts-threshold 0 :initial-delay-ms 15000)
+          _         (try (throttle/check throttler "user-2") (catch Exception _))
+          response  (try
+                      (throttle/check throttler "user-2")
+                      (catch clojure.lang.ExceptionInfo e
+                        (#'oauth/throttle-response e)))]
+      (is (str/starts-with? (get-in response [:body :error_description]) "Too many attempts!")))))

--- a/test/metabase/oauth_server/api_test.clj
+++ b/test/metabase/oauth_server/api_test.clj
@@ -969,23 +969,26 @@
 
 ;;; ------------------------------------------------ Throttling ---------------------------------------------------
 
+(defn- trigger-throttle-response
+  "Creates a throttler with threshold 0, triggers it, and returns the throttle-response.
+  With `:attempts-threshold 0` the first `check` call records the attempt and throws immediately
+  (zero attempts allowed), so we catch and discard that initial exception. The second call then
+  throws with a longer back-off delay, which is the exception we pass to `throttle-response`."
+  [user-id]
+  (let [throttler (throttle/make-throttler :test-key :attempts-threshold 0 :initial-delay-ms 15000)]
+    (try (throttle/check throttler user-id) (catch Exception _))
+    (try
+      (throttle/check throttler user-id)
+      (catch clojure.lang.ExceptionInfo e
+        (#'oauth/throttle-response e)))))
+
 (deftest throttle-response-format-test
   (testing "throttle-response builds correct 429 response with Retry-After"
-    (let [throttler (throttle/make-throttler :test-key :attempts-threshold 0 :initial-delay-ms 15000)
-          _         (try (throttle/check throttler "user-1") (catch Exception _))
-          response  (try
-                      (throttle/check throttler "user-1")
-                      (catch clojure.lang.ExceptionInfo e
-                        (#'oauth/throttle-response e)))]
+    (let [response (trigger-throttle-response "user-1")]
       (is (= 429 (:status response)))
       (is (contains? (:headers response) "Retry-After"))
       (is (= "too_many_requests" (get-in response [:body :error])))))
 
   (testing "throttle-response includes descriptive error_description"
-    (let [throttler (throttle/make-throttler :test-key :attempts-threshold 0 :initial-delay-ms 15000)
-          _         (try (throttle/check throttler "user-2") (catch Exception _))
-          response  (try
-                      (throttle/check throttler "user-2")
-                      (catch clojure.lang.ExceptionInfo e
-                        (#'oauth/throttle-response e)))]
+    (let [response (trigger-throttle-response "user-2")]
       (is (str/starts-with? (get-in response [:body :error_description]) "Too many attempts!")))))


### PR DESCRIPTION
Adds rate limiting to sensitive OAuth server endpoints and the MCP API to mitigate brute-force and resource-exhaustion abuse.

## Changes Made

- **`/oauth/register`**: Per-IP throttling to limit registration abuse.
- **`/oauth/authorize/decision`**: Per-user throttling on the consent decision endpoint.
- **`/oauth/token`**: Per-client-id + per-IP throttling on the token endpoint, with `client_id` extracted from the HTTP Basic `Authorization` header when absent from the request body to avoid conflating unrelated clients under a shared throttle key.
- **`/api/mcp`**: Per-user throttling on every MCP request. The throttle check is isolated in a dedicated `check-throttle` function that catches `ExceptionInfo` and returns a proper JSON-RPC `429` response with a `Retry-After` header directly, bypassing the generic `raise` exception path so the response body remains well-formed JSON-RPC.
- Response schemas for throttled endpoints updated to include HTTP `429` so the OpenAPI contract matches runtime behaviour.