### PR TITLE
Fixed doc backport

### DIFF
--- a/docs/embedding/components.md
+++ b/docs/embedding/components.md
@@ -58,6 +58,17 @@ To render a question (chart):
 <metabase-question question-id="1"></metabase-question>
 ```
 
+You can also use the question component to create new questions:
+
+- `question-id="new"` — opens the visual query builder.
+- `question-id="new-native"` — opens the SQL editor.
+
+For example, to embed the SQL editor:
+
+```html
+<metabase-question question-id="new-native"></metabase-question>
+```
+
 ### Attributes
 
 {% include_file "{{ dirname }}/eajs/snippets/MetabaseQuestionAttributes.md" snippet="properties" %}


### PR DESCRIPTION
#70319 removed the mention of `new-native` for modular embedding `metabase-question`.

closes [EMB-1539: Fix bad backport for embedding docs in v59](https://linear.app/metabase/issue/EMB-1539/fix-bad-backport-for-embedding-docs-in-v59)