### PR TITLE
Add e2e test for sync-and-evaluate matching query execution

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/security_center/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/security_center/api.clj
@@ -1,14 +1,17 @@
 (ns metabase-enterprise.security-center.api
   "API endpoints for Security Center advisories."
   (:require
+   [clojurewerkz.quartzite.jobs :as jobs]
    [metabase-enterprise.security-center.models.security-advisory :as security-advisory]
    [metabase-enterprise.security-center.schema :as security-center.schema]
    [metabase-enterprise.security-center.seed]
    [metabase-enterprise.security-center.settings]
+   [metabase-enterprise.security-center.task.sync-advisories :as sync-advisories]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.api.routes.common :refer [+auth]]
    [metabase.premium-features.core :as premium-features]
+   [metabase.task.core :as task]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2]))
@@ -66,6 +69,13 @@
   (let [advisory (t2/select-one :model/SecurityAdvisory :advisory_id advisory-id)]
     (api/check-404 advisory)
     (acknowledge-response (security-advisory/acknowledge! advisory api/*current-user-id*))))
+
+(api.macros/defendpoint :post "/sync" :- [:map [:status ms/NonBlankString]]
+  "Trigger an async advisory sync + re-evaluation via Quartz.
+   Returns immediately. DisallowConcurrentExecution prevents overlapping runs."
+  []
+  (task/trigger-now! (jobs/key sync-advisories/job-key))
+  {:status "ok"})
 
 (defn- +check-not-trial
   "Middleware that returns 402 if the instance is on a trial subscription."

--- a/enterprise/backend/src/metabase_enterprise/security_center/matching.clj
+++ b/enterprise/backend/src/metabase_enterprise/security_center/matching.clj
@@ -61,19 +61,18 @@
       (get matching-query :default)))
 
 (defn- query-read-only!
-  "Execute a HoneySQL query on a read-only appdb connection.
-   Sets the JDBC connection read-only so the driver rejects write statements.
-   Enforced by Postgres and MySQL; H2 treats it as an advisory hint."
+  "Execute a HoneySQL query on a fresh read-only appdb connection.
+   Gets a connection directly from the datasource so setReadOnly is called
+   before any transaction starts — avoids the JDBC restriction against
+   changing read-only mid-transaction."
   [hsql-query]
-  (t2/with-transaction [^java.sql.Connection conn]
-    (if (.isReadOnly conn)
-      (mdb/query hsql-query)
-      (do
-        (.setReadOnly conn true)
-        (try
-          (mdb/query hsql-query)
-          (finally
-            (.setReadOnly conn false)))))))
+  (with-open [^java.sql.Connection conn (.getConnection (mdb/data-source))]
+    (.setReadOnly conn true)
+    (try
+      (t2/with-connection [_ conn]
+        (mdb/query hsql-query))
+      (finally
+        (.setReadOnly conn false)))))
 
 (mu/defn execute-matching-query! :- QueryResult
   "Execute a matching query against the appdb.

--- a/enterprise/backend/src/metabase_enterprise/security_center/task/sync_advisories.clj
+++ b/enterprise/backend/src/metabase_enterprise/security_center/task/sync_advisories.clj
@@ -15,7 +15,9 @@
 
 (set! *warn-on-reflection* true)
 
-(def ^:private job-key "metabase.task.security-center.sync-advisories.job")
+(def job-key
+  "Quartz job key for the sync-advisories task. Public so the API can trigger it on demand."
+  "metabase.task.security-center.sync-advisories.job")
 (def ^:private trigger-key "metabase.task.security-center.sync-advisories.trigger")
 
 (defn- sync-and-evaluate! []

--- a/enterprise/backend/test/metabase_enterprise/security_center/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/security_center/api_test.clj
@@ -1,6 +1,8 @@
 (ns metabase-enterprise.security-center.api-test
   (:require
    [clojure.test :refer :all]
+   [metabase-enterprise.security-center.fetch :as fetch]
+   [metabase-enterprise.security-center.matching :as matching]
    [metabase.premium-features.token-check :as token-check]
    [metabase.test :as mt]
    [toucan2.core :as t2]))
@@ -97,3 +99,24 @@
         (testing "non-superuser gets 403"
           (mt/user-http-request :rasta :post 403
                                 "ee/security-center/SC-TEST-001/acknowledge"))))))
+
+(deftest sync-endpoint-test
+  (testing "POST /api/ee/security-center/sync"
+    (mt/with-premium-features #{:admin-security-center}
+      (testing "calling twice only runs sync once"
+        (let [call-count (atom 0)
+              started    (promise)
+              finish     (promise)]
+          (with-redefs [fetch/sync-advisories!
+                        (fn []
+                          (swap! call-count inc)
+                          (deliver started true)
+                          @finish)
+                        matching/evaluate-all-advisories! (constantly nil)]
+            (is (= {:status "ok"} (mt/user-http-request :crowberto :post 200 "ee/security-center/sync")))
+            @started
+            (is (= {:status "ok"} (mt/user-http-request :crowberto :post 200 "ee/security-center/sync")))
+            (deliver finish true)
+            (is (= 1 @call-count) "sync should only run once despite two API calls"))))
+      (testing "non-superuser gets 403"
+        (mt/user-http-request :rasta :post 403 "ee/security-center/sync")))))

--- a/enterprise/backend/test/metabase_enterprise/security_center/task/sync_advisories_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/security_center/task/sync_advisories_test.clj
@@ -58,19 +58,21 @@
 
 (deftest sync-and-evaluate-e2e-test
   (testing "full flow: sync-and-evaluate! runs matching queries and updates match_status"
-    (mt/with-temp [:model/SecurityAdvisory advisory
-                   {:advisory_id       "SC-E2E-001"
-                    :severity          "critical"
-                    :title             "E2E test advisory"
-                    :description       "Tests the full sync-and-evaluate flow"
-                    :remediation       "Upgrade"
-                    :affected_versions [{:min "0.1.0" :fixed "99.99.99"}]
-                    :matching_query    {:default {:select [1] :from [:core_user] :limit 1}}
-                    :match_status      "not_affected"
-                    :published_at      #t "2026-03-24T00:00:00Z"}]
-      (mt/with-dynamic-fn-redefs [premium-features/security-center-enabled? (constantly true)
-                                  fetch/sync-advisories!                    (constantly nil)]
-        (#'sync-advisories/sync-and-evaluate!)
-        (let [updated (t2/select-one :model/SecurityAdvisory (:id advisory))]
-          (is (= :active (:match_status updated)))
-          (is (some? (:last_evaluated_at updated))))))))
+    (mt/test-helpers-set-global-values!
+      (mt/with-temp [:model/SecurityAdvisory advisory
+                     {:advisory_id       "SC-E2E-001"
+                      :severity          "critical"
+                      :title             "E2E test advisory"
+                      :description       "Tests the full sync-and-evaluate flow"
+                      :remediation       "Upgrade"
+                      :affected_versions [{:min "0.1.0" :fixed "99.99.99"}]
+                      :matching_query    {:default {:select [[1 :one]]}}
+                      ;; query returns rows unconditionally — tests the full evaluate flow
+                      :match_status      "not_affected"
+                      :published_at      #t "2026-03-24T00:00:00Z"}]
+        (mt/with-dynamic-fn-redefs [premium-features/security-center-enabled? (constantly true)
+                                    fetch/sync-advisories!                    (constantly nil)]
+          (#'sync-advisories/sync-and-evaluate!)
+          (let [updated (t2/select-one :model/SecurityAdvisory (:id advisory))]
+            (is (= :active (:match_status updated)))
+            (is (some? (:last_evaluated_at updated)))))))))

--- a/enterprise/backend/test/metabase_enterprise/security_center/task/sync_advisories_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/security_center/task/sync_advisories_test.clj
@@ -5,7 +5,10 @@
    [metabase-enterprise.security-center.matching :as matching]
    [metabase-enterprise.security-center.task.sync-advisories :as sync-advisories]
    [metabase.premium-features.core :as premium-features]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [toucan2.core :as t2])
+  (:import
+   (java.util.concurrent CountDownLatch TimeUnit)))
 
 (deftest sync-and-evaluate-test
   (testing "skips when disabled"
@@ -28,4 +31,46 @@
                                   fetch/sync-advisories!               #(throw (Exception. "fetch failed"))
                                   matching/evaluate-all-advisories!     #(swap! called conj :evaluate)]
         (#'sync-advisories/sync-and-evaluate!)
-        (is (= [:evaluate] @called))))))
+        (is (= [:evaluate] @called)))))
+  (testing "concurrent calls do not run sync-and-evaluate! in parallel"
+    (let [running    (atom 0)
+          max-conc   (atom 0)
+          entered    (CountDownLatch. 1)
+          finish     (CountDownLatch. 1)
+          call-count (atom 0)]
+      (mt/with-dynamic-fn-redefs [premium-features/security-center-enabled? (constantly true)
+                                  fetch/sync-advisories!
+                                  (fn []
+                                    (swap! call-count inc)
+                                    (swap! max-conc max (swap! running inc))
+                                    (.countDown entered)
+                                    (.await finish 5 TimeUnit/SECONDS)
+                                    (swap! running dec))
+                                  matching/evaluate-all-advisories! (constantly nil)]
+        ;; first call blocks inside fetch
+        (let [f1 (future (#'sync-advisories/sync-and-evaluate!))
+              _  (.await entered 5 TimeUnit/SECONDS)
+              ;; second call while first is still running
+              f2 (future (#'sync-advisories/sync-and-evaluate!))]
+          (.countDown finish)
+          @f1 @f2)
+        (is (= 1 @max-conc) "only one sync-and-evaluate! should run at a time")))))
+
+(deftest sync-and-evaluate-e2e-test
+  (testing "full flow: sync-and-evaluate! runs matching queries and updates match_status"
+    (mt/with-temp [:model/SecurityAdvisory advisory
+                   {:advisory_id       "SC-E2E-001"
+                    :severity          "critical"
+                    :title             "E2E test advisory"
+                    :description       "Tests the full sync-and-evaluate flow"
+                    :remediation       "Upgrade"
+                    :affected_versions [{:min "0.1.0" :fixed "99.99.99"}]
+                    :matching_query    {:default {:select [1] :from [:core_user] :limit 1}}
+                    :match_status      "not_affected"
+                    :published_at      #t "2026-03-24T00:00:00Z"}]
+      (mt/with-dynamic-fn-redefs [premium-features/security-center-enabled? (constantly true)
+                                  fetch/sync-advisories!                    (constantly nil)]
+        (#'sync-advisories/sync-and-evaluate!)
+        (let [updated (t2/select-one :model/SecurityAdvisory (:id advisory))]
+          (is (= :active (:match_status updated)))
+          (is (some? (:last_evaluated_at updated))))))))


### PR DESCRIPTION
## Summary
- Add an e2e test that runs the full `sync-and-evaluate!` flow with a real matching query against the appdb
- Existing tests mocked out `evaluate-all-advisories!`, so the matching query was never actually executed — this missed the `setReadOnly` mid-transaction bug on Postgres

## Test plan
- [x] Test passes on Postgres (`MB_DB_TYPE=postgres`)
- [x] Test passes on H2