### PR TITLE
GDGT-1431 Delete notifications orphaned from deleted cards

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1640,6 +1640,7 @@
                     :model/Field
                     :model/ModerationReview
                     :model/NativeQuerySnippet
+                    :model/Notification
                     :model/Revision
                     :model/Table
                     :model/User}}

--- a/src/metabase/notification/send.clj
+++ b/src/metabase/notification/send.clj
@@ -140,6 +140,13 @@
       (try
         (log/info "Sending")
         (prometheus/inc! :metabase-notification/concurrent-tasks)
+        ;; Guard against orphaned card notifications whose payload record was cascade-deleted
+        (when (and (= :notification/card payload_type)
+                   (not (t2/exists? :model/NotificationCard (:payload_id notification-info))))
+          (log/warnf "Payload for notification %d no longer exists, deleting" id)
+          (t2/delete! :model/Notification id)
+          (throw (ex-info "Card no longer exists, notification deleted"
+                          {:notification-id id})))
         (let [hydrated-notification (hydrate-notification notification-info)
               handlers              (:handlers hydrated-notification)]
           (task-history/with-task-history {:task          "notification-send"

--- a/src/metabase/notification/send.clj
+++ b/src/metabase/notification/send.clj
@@ -140,13 +140,16 @@
       (try
         (log/info "Sending")
         (prometheus/inc! :metabase-notification/concurrent-tasks)
-        ;; Guard against orphaned card notifications whose payload record was cascade-deleted
-        (when (and (= :notification/card payload_type)
-                   (not (t2/exists? :model/NotificationCard (:payload_id notification-info))))
-          (log/warnf "Payload for notification %d no longer exists, deleting" id)
-          (t2/delete! :model/Notification id)
-          (throw (ex-info "Card no longer exists, notification deleted"
-                          {:notification-id id})))
+        ;; Guard against orphaned card notifications whose payload record was cascade-deleted.
+        ;; Only applies to persisted notifications (with a non-nil :payload_id); Pulse-converted
+        ;; notifications pass through :payload instead and have no :payload_id.
+        (when-let [payload-id (when (= :notification/card payload_type)
+                                (:payload_id notification-info))]
+          (when-not (t2/exists? :model/NotificationCard payload-id)
+            (log/warnf "Payload for notification %d no longer exists, deleting" id)
+            (t2/delete! :model/Notification id)
+            (throw (ex-info "Card no longer exists, notification deleted"
+                            {:notification-id id}))))
         (let [hydrated-notification (hydrate-notification notification-info)
               handlers              (:handlers hydrated-notification)]
           (task-history/with-task-history {:task          "notification-send"

--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -847,7 +847,16 @@
   ;; delete any ParameterCard linked to this card
   (t2/delete! :model/ParameterCard :card_id id)
   (t2/delete! :model/ModerationReview :moderated_item_type "card", :moderated_item_id id)
-  (t2/delete! :model/Revision :model "Card", :model_id id))
+  (t2/delete! :model/Revision :model "Card", :model_id id)
+  ;; delete any card-type notifications for this card — must materialize IDs first because
+  ;; Notification's before-delete deletes the NotificationCard, which would make a subquery
+  ;; return empty by the time the actual DELETE executes.
+  (when-let [notification-ids (seq (t2/select-pks-set :model/Notification
+                                                      :payload_type :notification/card
+                                                      :payload_id [:in {:select [:id]
+                                                                        :from   [:notification_card]
+                                                                        :where  [:= :card_id id]}]))]
+    (t2/delete! :model/Notification :id [:in notification-ids])))
 
 (defmethod serdes/hash-fields :model/Card
   [_card]

--- a/test/metabase/notification/models_test.clj
+++ b/test/metabase/notification/models_test.clj
@@ -81,23 +81,32 @@
           (is (not (t2/exists? :model/NotificationCard notification-card-id))))))))
 
 (deftest delete-card-cleans-up-notifications-test
-  (testing "deleting a card should remove all associated active notifications"
+  (testing "deleting a card should remove all associated notifications, both active and inactive"
     (notification.tu/with-notification-cleanup!
       (mt/with-temp [:model/Card {card-id :id} {:name          "alert cleanup test card"
                                                 :dataset_query (mt/mbql-query products {:aggregation [[:count]]})}]
-        (let [notification (models.notification/create-notification!
-                            {:payload_type :notification/card
-                             :payload      {:card_id card-id}
-                             :creator_id   (mt/user->id :crowberto)}
-                            []
-                            [])]
-          (testing "sanity: notification and notification card exist"
-            (is (t2/exists? :model/Notification (:id notification)))
-            (is (t2/exists? :model/NotificationCard :card_id card-id)))
+        (let [active-notification   (models.notification/create-notification!
+                                     {:payload_type :notification/card
+                                      :payload      {:card_id card-id}
+                                      :creator_id   (mt/user->id :crowberto)}
+                                     []
+                                     [])
+              inactive-notification (models.notification/create-notification!
+                                     {:payload_type :notification/card
+                                      :payload      {:card_id card-id}
+                                      :active       false
+                                      :creator_id   (mt/user->id :crowberto)}
+                                     []
+                                     [])]
+          (testing "sanity: both notifications and notification cards exist"
+            (is (t2/exists? :model/Notification (:id active-notification)))
+            (is (t2/exists? :model/Notification (:id inactive-notification)))
+            (is (= 2 (t2/count :model/NotificationCard :card_id card-id))))
           (t2/delete! :model/Card card-id)
-          (testing "notification should be removed when the card is deleted"
-            (is (not (t2/exists? :model/Notification (:id notification)))))
-          (testing "notification card payload should also be removed"
+          (testing "both notifications should be removed when the card is deleted"
+            (is (not (t2/exists? :model/Notification (:id active-notification))))
+            (is (not (t2/exists? :model/Notification (:id inactive-notification)))))
+          (testing "notification card payloads should also be removed"
             (is (not (t2/exists? :model/NotificationCard :card_id card-id)))))))))
 
 (deftest notification-subscription-type-test

--- a/test/metabase/notification/models_test.clj
+++ b/test/metabase/notification/models_test.clj
@@ -80,6 +80,26 @@
           (t2/delete! :model/Notification (:id notification))
           (is (not (t2/exists? :model/NotificationCard notification-card-id))))))))
 
+(deftest delete-card-cleans-up-notifications-test
+  (testing "deleting a card should remove all associated active notifications"
+    (notification.tu/with-notification-cleanup!
+      (mt/with-temp [:model/Card {card-id :id} {:name          "alert cleanup test card"
+                                                :dataset_query (mt/mbql-query products {:aggregation [[:count]]})}]
+        (let [notification (models.notification/create-notification!
+                            {:payload_type :notification/card
+                             :payload      {:card_id card-id}
+                             :creator_id   (mt/user->id :crowberto)}
+                            []
+                            [])]
+          (testing "sanity: notification and notification card exist"
+            (is (t2/exists? :model/Notification (:id notification)))
+            (is (t2/exists? :model/NotificationCard :card_id card-id)))
+          (t2/delete! :model/Card card-id)
+          (testing "notification should be removed when the card is deleted"
+            (is (not (t2/exists? :model/Notification (:id notification)))))
+          (testing "notification card payload should also be removed"
+            (is (not (t2/exists? :model/NotificationCard :card_id card-id)))))))))
+
 (deftest notification-subscription-type-test
   (mt/with-temp [:model/Notification {n-id :id} {}]
     (testing "success path"

--- a/test/metabase/notification/payload/impl/card_test.clj
+++ b/test/metabase/notification/payload/impl/card_test.clj
@@ -576,14 +576,14 @@
           (testing "sanity: notification still exists but its payload record is gone"
             (is (t2/exists? :model/Notification (:id notification)))
             (is (not (t2/exists? :model/NotificationCard (:payload_id notification)))))
-          (testing "sending the orphaned notification should deactivate it rather than crash forever"
+          (testing "sending the orphaned notification should delete it rather than crash forever"
             (is (thrown-with-msg?
                  clojure.lang.ExceptionInfo
                  #"Card no longer exists"
                  (#'notification.send/send-notification-sync!
                   (t2/select-one :model/Notification (:id notification))))))
-          (testing "the notification should now be inactive"
-            (is (false? (t2/select-one-fn :active :model/Notification (:id notification))))))))))
+          (testing "the notification should be deleted"
+            (is (not (t2/exists? :model/Notification (:id notification))))))))))
 
 (defn- email->attachment-line-count
   [email]

--- a/test/metabase/notification/payload/impl/card_test.clj
+++ b/test/metabase/notification/payload/impl/card_test.clj
@@ -6,6 +6,7 @@
    [medley.core :as m]
    [metabase.channel.core :as channel]
    [metabase.notification.core :as notification]
+   [metabase.notification.models :as models.notification]
    [metabase.notification.payload.core :as notification.payload]
    [metabase.notification.payload.execute :as notification.payload.execute]
    [metabase.notification.send :as notification.send]
@@ -554,6 +555,35 @@
                 :task_details {:message (mt/malli=? [:fn #(str/includes? % "Division by zero")])}}]
               (t2/select [:model/TaskHistory :status :task_details] :task "notification-send"
                          {:order-by [[:started_at :asc]]}))))))
+
+(deftest orphaned-notification-deactivates-on-send-test
+  (testing "A notification whose card no longer exists should deactivate itself instead of crashing forever"
+    (notification.tu/with-notification-cleanup!
+      (mt/with-temp [:model/Card {card-id :id} {:name          notification.tu/default-card-name
+                                                :dataset_query (mt/mbql-query products {:aggregation [[:count]]})}]
+        (let [notification (models.notification/create-notification!
+                            {:payload_type :notification/card
+                             :payload      {:card_id card-id}
+                             :creator_id   (mt/user->id :crowberto)}
+                            []
+                            [@notification.tu/default-email-handler])]
+          (testing "sanity: notification is active"
+            (is (true? (t2/select-one-fn :active :model/Notification (:id notification)))))
+          ;; Simulate an orphaned notification: delete the NotificationCard directly.
+          ;; This mirrors what happens in prod when there is no Malli validation and a card is deleted (FK cascade deletes NotificationCard)
+          ;; but the Notification row itself survives.
+          (t2/delete! :model/NotificationCard (:payload_id notification))
+          (testing "sanity: notification still exists but its payload record is gone"
+            (is (t2/exists? :model/Notification (:id notification)))
+            (is (not (t2/exists? :model/NotificationCard (:payload_id notification)))))
+          (testing "sending the orphaned notification should deactivate it rather than crash forever"
+            (is (thrown-with-msg?
+                 clojure.lang.ExceptionInfo
+                 #"Card no longer exists"
+                 (#'notification.send/send-notification-sync!
+                  (t2/select-one :model/Notification (:id notification))))))
+          (testing "the notification should now be inactive"
+            (is (false? (t2/select-one-fn :active :model/Notification (:id notification))))))))))
 
 (defn- email->attachment-line-count
   [email]


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/67492

### Description

When a card with an alert is permanently deleted, the Notification record and its Quartz cron trigger survive.   
The trigger keeps firing and crashing every time, clogging logs and task history indefinitely.                                                                             

The root cause is that Card's before-delete hook cleans up ParameterCards, ModerationReviews, and Revisions — but not Notifications. The notification_card table has a deleteCascade FK to report_card, so the NotificationCard payload row gets cascade-deleted, but the Notification row itself survives with a dangling payload_id. 

There's 2 fixes in this PR:
*  Add notification cleanup to Card's before-delete hook. Materializes notification IDs first because Notification's own before-delete deletes the NotificationCard, which would invalidate a delete that depends on a subquery by the time the actual DELETE executes.
*  For notifications orphaned before this fix is deployed, guard in `send-notification-sync!` checks if the NotificationCard payload still exists before hydration. If not, it deletes the notification and throws a clean error.

We fully delete rather than deactivate (setting `:active false`) because an orphaned notification with a deleted card has no value — its handlers, subscriptions, and recipients would just be dead rows. This matches what happens when users manually delete an alert via `delete-alert-and-notify!`.

### How to verify

1. Create a card, set up a per-minute alert on it

2. Move the card to a dashboard

3. Trash the dashboard, then permanently delete it

4. Logs should not show the notification failing.

_Reproduced runs on a dev db snapshot, hence the existing set of notifications in the log view_
Before (notice the error log appearing):

[reproduced-error-log.webm](https://github.com/user-attachments/assets/dae84d5d-4feb-4c79-a1b6-f473ecca4a64)

After (no more error log):

[happy-path.webm](https://github.com/user-attachments/assets/c58cf486-847f-40df-96f6-864cc8cc1810)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR

