### PR TITLE
Fix read only connection for security center

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/security_center/matching.clj
+++ b/enterprise/backend/src/metabase_enterprise/security_center/matching.clj
@@ -61,19 +61,18 @@
       (get matching-query :default)))
 
 (defn- query-read-only!
-  "Execute a HoneySQL query on a read-only appdb connection.
-   Sets the JDBC connection read-only so the driver rejects write statements.
-   Enforced by Postgres and MySQL; H2 treats it as an advisory hint."
+  "Execute a HoneySQL query on a fresh read-only appdb connection.
+   Gets a connection directly from the datasource so setReadOnly is called
+   before any transaction starts — avoids the JDBC restriction against
+   changing read-only mid-transaction."
   [hsql-query]
-  (t2/with-transaction [^java.sql.Connection conn]
-    (if (.isReadOnly conn)
-      (mdb/query hsql-query)
-      (do
-        (.setReadOnly conn true)
-        (try
-          (mdb/query hsql-query)
-          (finally
-            (.setReadOnly conn false)))))))
+  (with-open [^java.sql.Connection conn (.getConnection (mdb/data-source))]
+    (.setReadOnly conn true)
+    (try
+      (t2/with-connection [_ conn]
+        (mdb/query hsql-query))
+      (finally
+        (.setReadOnly conn false)))))
 
 (mu/defn execute-matching-query! :- QueryResult
   "Execute a matching query against the appdb.

--- a/enterprise/backend/test/metabase_enterprise/security_center/task/sync_advisories_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/security_center/task/sync_advisories_test.clj
@@ -5,7 +5,8 @@
    [metabase-enterprise.security-center.matching :as matching]
    [metabase-enterprise.security-center.task.sync-advisories :as sync-advisories]
    [metabase.premium-features.core :as premium-features]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [toucan2.core :as t2]))
 
 (deftest sync-and-evaluate-test
   (testing "skips when disabled"
@@ -29,3 +30,24 @@
                                   matching/evaluate-all-advisories!     #(swap! called conj :evaluate)]
         (#'sync-advisories/sync-and-evaluate!)
         (is (= [:evaluate] @called))))))
+
+(deftest sync-and-evaluate-e2e-test
+  (testing "full flow: sync-and-evaluate! runs matching queries and updates match_status"
+    (mt/test-helpers-set-global-values!
+      (mt/with-temp [:model/SecurityAdvisory advisory
+                     {:advisory_id       "SC-E2E-001"
+                      :severity          "critical"
+                      :title             "E2E test advisory"
+                      :description       "Tests the full sync-and-evaluate flow"
+                      :remediation       "Upgrade"
+                      :affected_versions [{:min "0.1.0" :fixed "99.99.99"}]
+                      :matching_query    {:default {:select [[1 :one]]}}
+                      ;; query returns rows unconditionally — tests the full evaluate flow
+                      :match_status      "not_affected"
+                      :published_at      #t "2026-03-24T00:00:00Z"}]
+        (mt/with-dynamic-fn-redefs [premium-features/security-center-enabled? (constantly true)
+                                    fetch/sync-advisories!                    (constantly nil)]
+          (#'sync-advisories/sync-and-evaluate!)
+          (let [updated (t2/select-one :model/SecurityAdvisory (:id advisory))]
+            (is (= :active (:match_status updated)))
+            (is (some? (:last_evaluated_at updated)))))))))


### PR DESCRIPTION
instead of changing mode during a transacstion, we get a new connection from the pool instead. this is safer since a transasction/connectino can be nested.