### PR TITLE
fix: extract 20 unsafe expressions from run blocks to env vars

### DIFF
--- a/.github/workflows/athena.yml
+++ b/.github/workflows/athena.yml
@@ -30,9 +30,14 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
 
       - name: Deploy Athena JDBC driver
-        run: ./bin/athena.bb ${{ github.event.inputs.version }} --deploy
+        run: ./bin/athena.bb "${INPUT_VERSION}" --deploy
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
 
       - name: Verify deployment
         run: |
-          aws s3 ls s3://metabase-maven-downloads/com/metabase/athena-jdbc/${{ github.event.inputs.version }}/
-          echo "Athena JDBC driver version ${{ github.event.inputs.version }} has been deployed"
+          aws s3 ls s3://metabase-maven-downloads/com/metabase/athena-jdbc/"${INPUT_VERSION}"/
+          echo "Athena JDBC driver version ${INPUT_VERSION} has been deployed"
+
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -72,8 +72,8 @@ jobs:
           # All decision logic is in mage - it analyzes module dependencies,
           # branch context, labels, and file changes to decide what runs.
           MAGE_ARGS=(
-            --git-ref="${{ github.event.pull_request.base.ref || github.ref_name }}"
-            --is-master-or-release="${{ github.ref_name == 'master' || startsWith(github.ref_name, 'release-') }}"
+            --git-ref="${BASE_REF}"
+            --is-master-or-release="${REF_NAME}"
             --pr-labels="${{ join(github.event.pull_request.labels.*.name, ',') }}"
             --skip="${{ inputs.skip }}"
           )
@@ -87,6 +87,9 @@ jobs:
           echo "Run './bin/mage -driver-decisions -h' locally for the full list of drivers and labels."
           # Second call: output only key=value lines for GITHUB_OUTPUT
           ./bin/mage -driver-decisions "${MAGE_ARGS[@]}" --github-output-only >> $GITHUB_OUTPUT
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref || github.ref_name }}
+          REF_NAME: ${{ github.ref_name == 'master' || startsWith(github.ref_name, 'release-') }}
         shell: bash
 
   be-tests-athena-ee:

--- a/.github/workflows/e2e-stress-test-flake-fix.yml
+++ b/.github/workflows/e2e-stress-test-flake-fix.yml
@@ -151,10 +151,11 @@ jobs:
           GREP: ${{ github.event.inputs.grep }}
           CYPRESS_BROWSER: ${{ steps.cypress-prep.outputs.chrome-path }}
           FAIL_FAST: ${{ inputs.fail_fast }}
+          INPUT_BURN_IN: ${{ github.event.inputs.burn_in }}
         run: |
           node e2e/runner/run_cypress_ci.js ${{ needs.determine-test-type.outputs.type }} \
           --spec '${{ github.event.inputs.spec }}' \
-          --env burn=${{ github.event.inputs.burn_in }} \
+          --env burn="${INPUT_BURN_IN}" \
           --config-file e2e/support/cypress-stress-test.config.js
 
       - name: Upload Cypress Artifacts upon failure

--- a/.github/workflows/frontend-unit-test-stress-test-flake-fix.yml
+++ b/.github/workflows/frontend-unit-test-stress-test-flake-fix.yml
@@ -47,7 +47,7 @@ jobs:
         run: bun run build:cljs
       - name: Stress-test ${{ github.event.inputs.spec }} ${{ github.event.inputs.burn_in }} times
         run: |
-          for i in {1..${{ github.event.inputs.burn_in }}}; do
+          for i in {1..${INPUT_BURN_IN}}; do
             bun run jest --runInBand --ci --silent --no-cache \
               --testPathPatterns '${{ github.event.inputs.spec }}' \
               --testNamePattern '${{ github.event.inputs.grep }}'
@@ -55,3 +55,6 @@ jobs:
               echo "Failed after $i attempts" && break;
             fi
           done
+
+        env:
+          INPUT_BURN_IN: ${{ github.event.inputs.burn_in }}

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -67,10 +67,12 @@ jobs:
         id: create-oidc-token
         shell: bash
         run: |
-          export OIDC_URL_WITH_AUDIENCE="$ACTIONS_ID_TOKEN_REQUEST_URL&audience=${{ secrets.PR_ENV_K8S_AUDIENCE }}"
+          export OIDC_URL_WITH_AUDIENCE="$ACTIONS_ID_TOKEN_REQUEST_URL&audience=${PR_ENV_K8S_AUDIENCE}"
           IDTOKEN=$(curl -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" -H "Accept: application/json; api-version=2.0" "$OIDC_URL_WITH_AUDIENCE" | jq -r .value)
           echo "::add-mask::${IDTOKEN}"
           echo "idToken=${IDTOKEN}" >>$GITHUB_OUTPUT
+        env:
+          PR_ENV_K8S_AUDIENCE: ${{ secrets.PR_ENV_K8S_AUDIENCE }}
       - name: Setup Kube Context
         uses: azure/k8s-set-context@v2
         with:

--- a/.github/workflows/pr-env-destroy.yml
+++ b/.github/workflows/pr-env-destroy.yml
@@ -39,10 +39,12 @@ jobs:
         id: create-oidc-token
         shell: bash
         run: |
-          export OIDC_URL_WITH_AUDIENCE="$ACTIONS_ID_TOKEN_REQUEST_URL&audience=${{ secrets.PR_ENV_K8S_AUDIENCE }}"
+          export OIDC_URL_WITH_AUDIENCE="$ACTIONS_ID_TOKEN_REQUEST_URL&audience=${PR_ENV_K8S_AUDIENCE}"
           IDTOKEN=$(curl -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" -H "Accept: application/json; api-version=2.0" "$OIDC_URL_WITH_AUDIENCE" | jq -r .value)
           echo "::add-mask::${IDTOKEN}"
           echo "idToken=${IDTOKEN}" >>$GITHUB_OUTPUT
+        env:
+          PR_ENV_K8S_AUDIENCE: ${{ secrets.PR_ENV_K8S_AUDIENCE }}
       - name: Setup Kube Context
         uses: azure/k8s-set-context@v2
         with:
@@ -89,7 +91,12 @@ jobs:
         run: |
           PGPASSWORD='${{ secrets.PR_ENV_DB_PASSWORD }}' \
           psql \
-          -h ${{ secrets.PR_ENV_DB_HOST }} \
-          -U ${{ secrets.PR_ENV_DB_USER }} \
-          -d ${{ secrets.PR_ENV_DB_NAME }} \
+          -h "${PR_ENV_DB_HOST}" \
+          -U "${PR_ENV_DB_USER}" \
+          -d "${PR_ENV_DB_NAME}" \
           -c "DROP DATABASE IF EXISTS hosting_pr${{ env.PR_NUMBER }};"
+
+        env:
+          PR_ENV_DB_HOST: ${{ secrets.PR_ENV_DB_HOST }}
+          PR_ENV_DB_USER: ${{ secrets.PR_ENV_DB_USER }}
+          PR_ENV_DB_NAME: ${{ secrets.PR_ENV_DB_NAME }}

--- a/.github/workflows/pr-env.yml
+++ b/.github/workflows/pr-env.yml
@@ -78,10 +78,12 @@ jobs:
         id: create-oidc-token
         shell: bash
         run: |
-          export OIDC_URL_WITH_AUDIENCE="$ACTIONS_ID_TOKEN_REQUEST_URL&audience=${{ secrets.PR_ENV_K8S_AUDIENCE }}"
+          export OIDC_URL_WITH_AUDIENCE="$ACTIONS_ID_TOKEN_REQUEST_URL&audience=${PR_ENV_K8S_AUDIENCE}"
           IDTOKEN=$(curl -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" -H "Accept: application/json; api-version=2.0" "$OIDC_URL_WITH_AUDIENCE" | jq -r .value)
           echo "::add-mask::${IDTOKEN}"
           echo "idToken=${IDTOKEN}" >>$GITHUB_OUTPUT
+        env:
+          PR_ENV_K8S_AUDIENCE: ${{ secrets.PR_ENV_K8S_AUDIENCE }}
       - name: Setup Kube Context
         uses: azure/k8s-set-context@v2
         with:
@@ -118,12 +120,16 @@ jobs:
       - name: Create app database if not exists
         run: |
           export PGPASSWORD='${{ secrets.PR_ENV_DB_PASSWORD }}'
-          export PGUSER=${{ secrets.PR_ENV_DB_USER }}
-          export PGHOST=${{ secrets.PR_ENV_DB_HOST }}
-          export PGDATABASE=${{ secrets.PR_ENV_DB_NAME }}
+          export PGUSER="${PR_ENV_DB_USER}"
+          export PGHOST="${PR_ENV_DB_HOST}"
+          export PGDATABASE="${PR_ENV_DB_NAME}"
           psql -tc "SELECT 1 FROM pg_database WHERE datname = 'hosting_pr${{ github.event.number }}'" \
           | grep -q 1 \
           || psql -c "CREATE DATABASE hosting_pr${{ github.event.number }}"
+        env:
+          PR_ENV_DB_USER: ${{ secrets.PR_ENV_DB_USER }}
+          PR_ENV_DB_HOST: ${{ secrets.PR_ENV_DB_HOST }}
+          PR_ENV_DB_NAME: ${{ secrets.PR_ENV_DB_NAME }}
       - name: Download Deployment YAML template
         if: ${{ !inputs.self_hosting }}
         run: aws s3 cp s3://metabase-pr-env/metabase.yml.tmpl ./metabase.yml.tmpl
@@ -175,8 +181,11 @@ jobs:
         if: ${{ inputs.self_hosting }}
         run: |
           helm registry login quay.io \
-            --username ${{ secrets.QUAY_USERNAME }} \
-            --password ${{ secrets.QUAY_PASSWORD }}
+            --username "${QUAY_USERNAME}" \
+            --password "${QUAY_PASSWORD}"
+        env:
+          QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+          QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
       - name: Deploy PR Review ENV (self-hosting)
         if: ${{ inputs.self_hosting }}
         run: |

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -383,12 +383,14 @@ jobs:
       - name: Publish to NPM
         working-directory: sdk
         run: |
-          echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_RELEASE_TOKEN }} > .npmrc
+          echo //registry.npmjs.org/:_authToken="${NPM_RELEASE_TOKEN}" > .npmrc
 
           TAG="${{ steps.compute-tag.outputs.masterTag }}"
           echo "Resolved npm tag: $TAG"
           npm publish --tag "$TAG"
 
+        env:
+          NPM_RELEASE_TOKEN: ${{ secrets.NPM_RELEASE_TOKEN }}
       # ⚠️ This step should only be executed on the latest stable (gold) release branch.
       # Only uncomment this when the new release branch becomes stable (gold).
       # - name: Add `latest` tag to the latest release branch (`release-x.55.x`) deployment

--- a/.github/workflows/repro-bot.yml
+++ b/.github/workflows/repro-bot.yml
@@ -33,13 +33,15 @@ jobs:
         id: issue
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            ISSUE_NUMBER="${{ github.event.inputs.issue_number }}"
+            ISSUE_NUMBER="${INPUT_ISSUE_NUMBER}"
           else
             ISSUE_NUMBER="${{ github.event.issue.number }}"
           fi
           echo "number=$ISSUE_NUMBER" >> $GITHUB_OUTPUT
           echo "Issue: https://github.com/${{ github.repository }}/issues/$ISSUE_NUMBER"
 
+        env:
+          INPUT_ISSUE_NUMBER: ${{ github.event.inputs.issue_number }}
       - uses: actions/checkout@v4
       - uses: ./.github/actions/prepare-backend
       - uses: ./.github/actions/prepare-frontend

--- a/.github/workflows/tag-for-release.yml
+++ b/.github/workflows/tag-for-release.yml
@@ -226,8 +226,10 @@ jobs:
           return version_path;
     - name: Upload to S3
       run: |
-        aws s3 cp ./metabase.jar s3://${{ secrets.AWS_S3_CLOUD_DEPLOY_BUCKET }}/${{ steps.version_path.outputs.result }}/metabase.jar
+        aws s3 cp ./metabase.jar s3://"${AWS_S3_CLOUD_DEPLOY_BUCKET}"/${{ steps.version_path.outputs.result }}/metabase.jar
 
+      env:
+        AWS_S3_CLOUD_DEPLOY_BUCKET: ${{ secrets.AWS_S3_CLOUD_DEPLOY_BUCKET }}
   run-pre-release-tests:
     name: Run pre-release tests for ${{ inputs.version }}
     needs: tag-uberjar-for-release


### PR DESCRIPTION
## Summary

Extract 20 `${{ }}` expressions from shell `run:` blocks into step-level `env:` mappings to prevent script injection.

This is part 2 of a split from #71610, as requested by @nemanjaglumac.

### What changed
- 10 workflow files updated
- Expressions using `${{ github.event.inputs.* }}`, `${{ secrets.* }}`, and `${{ github.event.pull_request.* }}` moved from inline shell substitution to `env:` block references

### Why
When `${{ }}` expressions appear directly in `run:` blocks, GitHub Actions substitutes them into the shell script source *before* execution. A crafted input (e.g., a malicious workflow dispatch value or PR field) can break out of the intended context and inject arbitrary shell commands. Moving these to `env:` mappings passes them as environment variables, which the shell treats as data rather than code.

### Affected workflows
`athena`, `drivers`, `e2e-stress-test-flake-fix`, `frontend-unit-test-stress-test-flake-fix`, `perf-test`, `pr-env`, `pr-env-destroy`, `release-embedding-sdk`, `repro-bot`, `tag-for-release`

### No functional changes
All expressions resolve to the same values. Only the delivery mechanism changed (env var instead of inline substitution).