### PR TITLE
addressed PR feedback

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryCard/AdvisoryCard.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryCard/AdvisoryCard.tsx
@@ -11,8 +11,12 @@ import {
   Text,
   Title,
 } from "metabase/ui";
+import type {
+  Advisory,
+  AdvisoryId,
+  AdvisorySeverity,
+} from "metabase-types/api";
 
-import type { Advisory, AdvisoryId, AdvisorySeverity } from "../../types";
 import { isAcknowledged, isAffected } from "../../utils";
 
 import S from "./AdvisoryCard.module.css";

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryCard/AdvisoryCard.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryCard/AdvisoryCard.tsx
@@ -12,7 +12,7 @@ import {
   Title,
 } from "metabase/ui";
 
-import type { Advisory, AdvisorySeverity } from "../../types";
+import type { Advisory, AdvisoryId, AdvisorySeverity } from "../../types";
 import { isAcknowledged, isAffected } from "../../utils";
 
 import S from "./AdvisoryCard.module.css";
@@ -32,7 +32,7 @@ function formatVersionRange(advisory: Advisory): string {
 
 interface AdvisoryCardProps {
   advisory: Advisory;
-  onAcknowledge?: (advisoryId: string) => void;
+  onAcknowledge?: (advisoryId: AdvisoryId) => void;
 }
 
 export function AdvisoryCard({ advisory, onAcknowledge }: AdvisoryCardProps) {
@@ -82,11 +82,11 @@ export function AdvisoryCard({ advisory, onAcknowledge }: AdvisoryCardProps) {
         <Group gap="lg">
           {advisory.affected_versions.length > 0 && (
             <Text size="sm" c="text-secondary">
-              {t`Affected versions`}: {formatVersionRange(advisory)}
+              {t`Affected versions: ${formatVersionRange(advisory)}`}
             </Text>
           )}
           <Text size="sm" c="text-secondary">
-            {t`Remediation`}: {advisory.remediation}
+            {t`Remediation: ${advisory.remediation}`}
           </Text>
         </Group>
 

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryFilterBar/AdvisoryFilterBar.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryFilterBar/AdvisoryFilterBar.tsx
@@ -39,7 +39,7 @@ export function AdvisoryFilterBar({
         onChange={(value) =>
           onChange({
             ...filter,
-            severity: (value as AdvisoryFilter["severity"]) ?? "all",
+            severity: value ?? "all",
           })
         }
         w={180}
@@ -51,7 +51,7 @@ export function AdvisoryFilterBar({
         onChange={(value) =>
           onChange({
             ...filter,
-            status: (value as AdvisoryFilter["status"]) ?? "all",
+            status: value ?? "all",
           })
         }
         w={180}

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryFilterBar/AdvisoryFilterBar.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryFilterBar/AdvisoryFilterBar.tsx
@@ -1,8 +1,9 @@
 import { t } from "ttag";
 
 import { Checkbox, Group, Select } from "metabase/ui";
+import type { AdvisorySeverity } from "metabase-types/api";
 
-import type { AdvisoryFilter, AdvisorySeverity } from "../../types";
+import type { AdvisoryFilter } from "../../types";
 
 interface AdvisoryFilterBarProps {
   filter: AdvisoryFilter;

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryList/AdvisoryList.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryList/AdvisoryList.tsx
@@ -1,6 +1,6 @@
 import { Stack } from "metabase/ui";
+import type { Advisory, AdvisoryId } from "metabase-types/api";
 
-import type { Advisory, AdvisoryId } from "../../types";
 import { sortAdvisories } from "../../utils";
 import { AdvisoryCard } from "../AdvisoryCard/AdvisoryCard";
 

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryList/AdvisoryList.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryList/AdvisoryList.tsx
@@ -1,12 +1,12 @@
 import { Stack } from "metabase/ui";
 
-import type { Advisory } from "../../types";
+import type { Advisory, AdvisoryId } from "../../types";
 import { sortAdvisories } from "../../utils";
 import { AdvisoryCard } from "../AdvisoryCard/AdvisoryCard";
 
 interface AdvisoryListProps {
   advisories: Advisory[];
-  onAcknowledge?: (advisoryId: string) => void;
+  onAcknowledge?: (advisoryId: AdvisoryId) => void;
   className?: string;
 }
 

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/NotificationChannelConfigModal/EmailChannelCard/EmailChannelCard.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/NotificationChannelConfigModal/EmailChannelCard/EmailChannelCard.tsx
@@ -1,0 +1,74 @@
+import { t } from "ttag";
+
+import { EmailChannelEdit } from "metabase/notifications/channels/EmailChannelEdit";
+import {
+  Anchor,
+  Box,
+  Card,
+  Group,
+  Icon,
+  Stack,
+  Switch,
+  Text,
+  Title,
+} from "metabase/ui";
+import { useNotificationConfig } from "metabase-enterprise/security_center/hooks/use-notification-config";
+
+export function EmailChannelCard({ isConfigured }: { isConfigured: boolean }) {
+  const { config, updateEmailHandler, toggleSendToAllAdmins, users } =
+    useNotificationConfig();
+
+  if (!isConfigured) {
+    return (
+      <Card withBorder p="lg">
+        <Group gap="sm">
+          <Icon name="mail" />
+          <Title order={4}>{t`Email`}</Title>
+        </Group>
+        <Text c="text-secondary" mt="sm">
+          {t`Email is not configured.`}{" "}
+          <Anchor href="/admin/settings/email">{t`Set up email`}</Anchor>
+        </Text>
+      </Card>
+    );
+  }
+
+  return (
+    <Card withBorder p="lg" data-testid="email-channel-card">
+      <Group gap="sm" mb="md">
+        <Icon name="mail" />
+        <Title order={4}>{t`Email`}</Title>
+      </Group>
+      <Stack gap="md">
+        <Switch
+          label={t`Send to all instance admins`}
+          checked={config.email.sendToAllAdmins}
+          onChange={(e) => toggleSendToAllAdmins(e.currentTarget.checked)}
+          data-testid="send-to-admins-toggle"
+        />
+        <Box>
+          <Text size="sm" fw={500} mb="xs">
+            {config.email.sendToAllAdmins
+              ? t`Additional recipients`
+              : t`Recipients`}
+          </Text>
+          <EmailChannelEdit
+            channel={config.email.handler}
+            users={users}
+            autoFocus={false}
+            invalidRecipientText={(domains) =>
+              t`Only addresses ending in ${domains} are allowed.`
+            }
+            onChange={updateEmailHandler}
+          />
+          {!config.email.sendToAllAdmins &&
+            config.email.handler.recipients.length === 0 && (
+              <Text size="sm" c="error" mt="xs">
+                {t`At least one recipient is required.`}
+              </Text>
+            )}
+        </Box>
+      </Stack>
+    </Card>
+  );
+}

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/NotificationChannelConfigModal/EmailChannelCard/EmailChannelCard.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/NotificationChannelConfigModal/EmailChannelCard/EmailChannelCard.unit.spec.tsx
@@ -1,0 +1,115 @@
+import { setupRecentViewsAndSelectionsEndpoints } from "__support__/server-mocks";
+import { renderWithProviders, screen } from "__support__/ui";
+import { createMockSettings } from "metabase-types/api/mocks";
+import { createMockSettingsState } from "metabase-types/store/mocks";
+
+import type { NotificationConfig } from "../../../hooks/use-notification-config";
+import { useNotificationConfig } from "../../../hooks/use-notification-config";
+
+import { EmailChannelCard } from "./EmailChannelCard";
+
+jest.mock("../../../hooks/use-notification-config", () => ({
+  ...jest.requireActual("../../../hooks/use-notification-config"),
+  useNotificationConfig: jest.fn(),
+}));
+
+const mockedUseNotificationConfig =
+  useNotificationConfig as any as jest.MockedFn<typeof useNotificationConfig>;
+
+const DEFAULT_CONFIG: NotificationConfig = {
+  email: {
+    sendToAllAdmins: true,
+    handler: { channel_type: "channel/email", recipients: [] },
+  },
+  slack: {
+    enabled: false,
+    handler: { channel_type: "channel/slack", recipients: [] },
+  },
+};
+
+function setup({ isConfigured = true, config = DEFAULT_CONFIG } = {}) {
+  const settings = createMockSettings({
+    "email-configured?": isConfigured,
+  });
+
+  setupRecentViewsAndSelectionsEndpoints([], ["selections"]);
+
+  const updateEmailHandler = jest.fn();
+  const toggleSendToAllAdmins = jest.fn();
+
+  mockedUseNotificationConfig.mockReturnValue({
+    config,
+    users: [],
+    channels: undefined,
+    updateEmailHandler,
+    toggleSendToAllAdmins,
+    updateSlackHandler: jest.fn(),
+    toggleSlack: jest.fn(),
+    save: jest.fn(),
+    resetConfig: jest.fn(),
+  });
+
+  renderWithProviders(<EmailChannelCard isConfigured={isConfigured} />, {
+    storeInitialState: { settings: createMockSettingsState(settings) },
+  });
+
+  return { updateEmailHandler, toggleSendToAllAdmins };
+}
+
+describe("EmailChannelCard", () => {
+  it("renders not-configured state with setup link", () => {
+    setup({ isConfigured: false });
+
+    expect(screen.getByText("Email is not configured.")).toBeInTheDocument();
+    expect(screen.getByText("Set up email")).toHaveAttribute(
+      "href",
+      "/admin/settings/email",
+    );
+  });
+
+  it("renders configured state with admin toggle and recipient picker", () => {
+    setup();
+
+    expect(screen.getByText("Email")).toBeInTheDocument();
+    expect(screen.getByTestId("send-to-admins-toggle")).toBeChecked();
+    expect(screen.getByText("Additional recipients")).toBeInTheDocument();
+  });
+
+  it("shows 'Recipients' label when send-to-all-admins is off", () => {
+    setup({
+      config: {
+        ...DEFAULT_CONFIG,
+        email: {
+          sendToAllAdmins: false,
+          handler: { channel_type: "channel/email", recipients: [] },
+        },
+      },
+    });
+
+    expect(screen.getByText("Recipients")).toBeInTheDocument();
+  });
+
+  it("shows error when send-to-all-admins is off and no recipients", () => {
+    setup({
+      config: {
+        ...DEFAULT_CONFIG,
+        email: {
+          sendToAllAdmins: false,
+          handler: { channel_type: "channel/email", recipients: [] },
+        },
+      },
+    });
+
+    expect(
+      screen.getByText("At least one recipient is required."),
+    ).toBeInTheDocument();
+  });
+
+  it("does not show error when send-to-all-admins is on", () => {
+    setup();
+
+    expect(
+      screen.queryByText("At least one recipient is required."),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/NotificationChannelConfigModal/NotificationChannelConfigModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/NotificationChannelConfigModal/NotificationChannelConfigModal.tsx
@@ -3,28 +3,14 @@ import { t } from "ttag";
 
 import { useSendTestNotificationMutation } from "metabase/api/security-center";
 import { useSetting, useToast } from "metabase/common/hooks";
-import { EmailChannelEdit } from "metabase/notifications/channels/EmailChannelEdit";
-import { SlackChannelFieldNew } from "metabase/notifications/channels/SlackChannelFieldNew";
-import {
-  Anchor,
-  Box,
-  Button,
-  Card,
-  Flex,
-  Group,
-  Icon,
-  Modal,
-  Stack,
-  Switch,
-  Text,
-  Title,
-} from "metabase/ui";
+import { Button, Flex, Group, Icon, Modal, Stack } from "metabase/ui";
 
-import type { useNotificationConfig } from "../../hooks/use-notification-config";
+import { useNotificationConfig } from "../../hooks/use-notification-config";
 
-type NotificationChannelConfigModalProps = ReturnType<
-  typeof useNotificationConfig
-> & {
+import { EmailChannelCard } from "./EmailChannelCard/EmailChannelCard";
+import { SlackChannelCard } from "./SlackChannelCard/SlackChannelCard";
+
+type NotificationChannelConfigModalProps = {
   opened: boolean;
   onClose: () => void;
   resetConfig: () => void;
@@ -33,16 +19,10 @@ type NotificationChannelConfigModalProps = ReturnType<
 export function NotificationChannelConfigModal({
   opened,
   onClose,
-  config,
-  updateEmailHandler,
-  toggleSendToAllAdmins,
-  updateSlackHandler,
-  toggleSlack,
-  save,
   resetConfig,
-  users,
-  channels,
 }: NotificationChannelConfigModalProps) {
+  const { config, save } = useNotificationConfig();
+
   const isEmailConfigured = useSetting("email-configured?");
   const isSlackConfigured = useSetting("slack-token-valid?");
   const [sendToast] = useToast();
@@ -104,21 +84,9 @@ export function NotificationChannelConfigModal({
       size="lg"
     >
       <Stack gap="md" mt="md">
-        <EmailChannelCard
-          config={config}
-          isConfigured={isEmailConfigured}
-          users={users}
-          updateEmailHandler={updateEmailHandler}
-          toggleSendToAllAdmins={toggleSendToAllAdmins}
-        />
-        <SlackChannelCard
-          config={config}
-          isConfigured={isSlackConfigured}
-          channels={channels}
-          updateSlackHandler={updateSlackHandler}
-          toggleSlack={toggleSlack}
-        />
-        <Flex justify="space-between" mt="md">
+        <EmailChannelCard isConfigured={isEmailConfigured} />
+        <SlackChannelCard isConfigured={isSlackConfigured} />
+        <Flex justify="flex-end" gap="md" mt="md">
           <Button
             variant="subtle"
             leftSection={<Icon name="mail" />}
@@ -149,130 +117,5 @@ export function NotificationChannelConfigModal({
         </Flex>
       </Stack>
     </Modal>
-  );
-}
-
-function EmailChannelCard({
-  config,
-  isConfigured,
-  users,
-  updateEmailHandler,
-  toggleSendToAllAdmins,
-}: {
-  config: NotificationChannelConfigModalProps["config"];
-  isConfigured: boolean;
-  users: NotificationChannelConfigModalProps["users"];
-  updateEmailHandler: NotificationChannelConfigModalProps["updateEmailHandler"];
-  toggleSendToAllAdmins: NotificationChannelConfigModalProps["toggleSendToAllAdmins"];
-}) {
-  if (!isConfigured) {
-    return (
-      <Card withBorder p="lg">
-        <Group gap="sm">
-          <Icon name="mail" />
-          <Title order={4}>{t`Email`}</Title>
-        </Group>
-        <Text c="text-secondary" mt="sm">
-          {t`Email is not configured.`}{" "}
-          <Anchor href="/admin/settings/email">{t`Set up email`}</Anchor>
-        </Text>
-      </Card>
-    );
-  }
-
-  return (
-    <Card withBorder p="lg" data-testid="email-channel-card">
-      <Group gap="sm" mb="md">
-        <Icon name="mail" />
-        <Title order={4}>{t`Email`}</Title>
-      </Group>
-      <Stack gap="md">
-        <Switch
-          label={t`Send to all instance admins`}
-          checked={config.email.sendToAllAdmins}
-          onChange={(e) => toggleSendToAllAdmins(e.currentTarget.checked)}
-          data-testid="send-to-admins-toggle"
-        />
-        <Box>
-          <Text size="sm" fw={500} mb="xs">
-            {config.email.sendToAllAdmins
-              ? t`Additional recipients`
-              : t`Recipients`}
-          </Text>
-          <EmailChannelEdit
-            channel={config.email.handler}
-            users={users}
-            autoFocus={false}
-            invalidRecipientText={(domains) =>
-              t`Only addresses ending in ${domains} are allowed.`
-            }
-            onChange={updateEmailHandler}
-          />
-          {!config.email.sendToAllAdmins &&
-            config.email.handler.recipients.length === 0 && (
-              <Text size="sm" c="error" mt="xs">
-                {t`At least one recipient is required.`}
-              </Text>
-            )}
-        </Box>
-      </Stack>
-    </Card>
-  );
-}
-
-function SlackChannelCard({
-  config,
-  isConfigured,
-  channels,
-  updateSlackHandler,
-  toggleSlack,
-}: {
-  config: NotificationChannelConfigModalProps["config"];
-  isConfigured: boolean;
-  channels: NotificationChannelConfigModalProps["channels"];
-  updateSlackHandler: NotificationChannelConfigModalProps["updateSlackHandler"];
-  toggleSlack: NotificationChannelConfigModalProps["toggleSlack"];
-}) {
-  if (!isConfigured) {
-    return (
-      <Card withBorder p="lg">
-        <Group gap="sm">
-          <Icon name="slack" />
-          <Title order={4}>{t`Slack`}</Title>
-        </Group>
-        <Text c="text-secondary" mt="sm">
-          {t`Slack is not configured.`}{" "}
-          <Anchor href="/admin/settings/slack">{t`Set up Slack`}</Anchor>
-        </Text>
-      </Card>
-    );
-  }
-
-  return (
-    <Card withBorder p="lg" data-testid="slack-channel-card">
-      <Flex justify="space-between" align="center" mb="md">
-        <Group gap="sm">
-          <Icon name="slack" />
-          <Title order={4}>{t`Slack`}</Title>
-        </Group>
-        <Switch
-          checked={config.slack.enabled}
-          onChange={(e) => toggleSlack(e.currentTarget.checked)}
-          data-testid="slack-toggle"
-        />
-      </Flex>
-      {config.slack.enabled && channels?.slack && (
-        <Box>
-          <Text size="sm" fw={500} mb="xs">
-            {t`Channel`}
-          </Text>
-          <SlackChannelFieldNew
-            channel={config.slack.handler}
-            channelSpec={channels.slack}
-            onChange={updateSlackHandler}
-          />
-        </Box>
-      )}
-    </Card>
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/NotificationChannelConfigModal/NotificationChannelConfigModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/NotificationChannelConfigModal/NotificationChannelConfigModal.tsx
@@ -13,15 +13,13 @@ import { SlackChannelCard } from "./SlackChannelCard/SlackChannelCard";
 type NotificationChannelConfigModalProps = {
   opened: boolean;
   onClose: () => void;
-  resetConfig: () => void;
 };
 
 export function NotificationChannelConfigModal({
   opened,
   onClose,
-  resetConfig,
 }: NotificationChannelConfigModalProps) {
-  const { config, save } = useNotificationConfig();
+  const { config, save, resetConfig } = useNotificationConfig();
 
   const isEmailConfigured = useSetting("email-configured?");
   const isSlackConfigured = useSetting("slack-token-valid?");

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/NotificationChannelConfigModal/NotificationChannelConfigModal.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/NotificationChannelConfigModal/NotificationChannelConfigModal.unit.spec.tsx
@@ -3,12 +3,26 @@ import userEvent from "@testing-library/user-event";
 import { setupRecentViewsAndSelectionsEndpoints } from "__support__/server-mocks";
 import { renderWithProviders, screen } from "__support__/ui";
 import { createMockSettings } from "metabase-types/api/mocks";
+import {
+  createMockEmailChannelSpec,
+  createMockSlackChannelSpec,
+} from "metabase-types/api/mocks/security-center";
 import { createMockSettingsState } from "metabase-types/store/mocks";
 
 import type { NotificationConfig } from "../../hooks/use-notification-config";
+import { useNotificationConfig } from "../../hooks/use-notification-config";
 
 import { NotificationChannelConfigModal } from "./NotificationChannelConfigModal";
 
+jest.mock("../../hooks/use-notification-config", () => {
+  return {
+    ...jest.requireActual("../../hooks/use-notification-config"),
+    useNotificationConfig: jest.fn(),
+  };
+});
+
+const mockedUseNotificationConfig =
+  useNotificationConfig as any as jest.MockedFn<typeof useNotificationConfig>;
 const DEFAULT_CONFIG: NotificationConfig = {
   email: {
     sendToAllAdmins: true,
@@ -35,37 +49,13 @@ function setup({
   setupRecentViewsAndSelectionsEndpoints([], ["selections"]);
 
   const channels = {
-    email: {
-      type: "email" as const,
-      name: "Email",
-      schedules: [],
-      schedule_type: null,
-      allows_recipients: true,
-      configured: emailConfigured,
-      recipients: ["user" as const, "email" as const],
-    },
-    slack: {
-      type: "slack" as const,
-      name: "Slack",
-      schedules: [],
-      schedule_type: null,
-      allows_recipients: false,
-      configured: slackConfigured,
-      fields: [
-        {
-          name: "channel",
-          type: "select",
-          displayName: "Post to",
-          options: ["#general", "#security"],
-          required: true,
-        },
-      ],
-    },
+    email: createMockEmailChannelSpec({ configured: emailConfigured }),
+    slack: createMockSlackChannelSpec({ configured: slackConfigured }),
   };
 
-  const props = {
-    opened: true,
-    onClose,
+  const resetConfig = jest.fn();
+
+  mockedUseNotificationConfig.mockImplementation(() => ({
     config,
     users: [],
     channels,
@@ -74,14 +64,21 @@ function setup({
     updateSlackHandler: jest.fn(),
     toggleSlack: jest.fn(),
     save,
-    resetConfig: jest.fn(),
-  };
+    resetConfig,
+  }));
 
-  renderWithProviders(<NotificationChannelConfigModal {...props} />, {
-    storeInitialState: { settings: createMockSettingsState(settings) },
-  });
+  renderWithProviders(
+    <NotificationChannelConfigModal
+      opened
+      onClose={onClose}
+      resetConfig={resetConfig}
+    />,
+    {
+      storeInitialState: { settings: createMockSettingsState(settings) },
+    },
+  );
 
-  return props;
+  return { onClose };
 }
 
 describe("NotificationChannelConfigModal", () => {

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/NotificationChannelConfigModal/NotificationChannelConfigModal.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/NotificationChannelConfigModal/NotificationChannelConfigModal.unit.spec.tsx
@@ -68,11 +68,7 @@ function setup({
   }));
 
   renderWithProviders(
-    <NotificationChannelConfigModal
-      opened
-      onClose={onClose}
-      resetConfig={resetConfig}
-    />,
+    <NotificationChannelConfigModal opened onClose={onClose} />,
     {
       storeInitialState: { settings: createMockSettingsState(settings) },
     },

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/NotificationChannelConfigModal/SlackChannelCard/SlackChannelCard.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/NotificationChannelConfigModal/SlackChannelCard/SlackChannelCard.tsx
@@ -1,0 +1,63 @@
+import { t } from "ttag";
+
+import { SlackChannelFieldNew } from "metabase/notifications/channels/SlackChannelFieldNew";
+import {
+  Anchor,
+  Box,
+  Card,
+  Flex,
+  Group,
+  Icon,
+  Switch,
+  Text,
+  Title,
+} from "metabase/ui";
+import { useNotificationConfig } from "metabase-enterprise/security_center/hooks/use-notification-config";
+
+export function SlackChannelCard({ isConfigured }: { isConfigured: boolean }) {
+  const { config, updateSlackHandler, toggleSlack, channels } =
+    useNotificationConfig();
+
+  if (!isConfigured) {
+    return (
+      <Card withBorder p="lg">
+        <Group gap="sm">
+          <Icon name="slack" />
+          <Title order={4}>{t`Slack`}</Title>
+        </Group>
+        <Text c="text-secondary" mt="sm">
+          {t`Slack is not configured.`}{" "}
+          <Anchor href="/admin/settings/slack">{t`Set up Slack`}</Anchor>
+        </Text>
+      </Card>
+    );
+  }
+
+  return (
+    <Card withBorder p="lg" data-testid="slack-channel-card">
+      <Flex justify="space-between" align="center" mb="md">
+        <Group gap="sm">
+          <Icon name="slack" />
+          <Title order={4}>{t`Slack`}</Title>
+        </Group>
+        <Switch
+          checked={config.slack.enabled}
+          onChange={(e) => toggleSlack(e.currentTarget.checked)}
+          data-testid="slack-toggle"
+        />
+      </Flex>
+      {config.slack.enabled && channels?.slack && (
+        <Box>
+          <Text size="sm" fw={500} mb="xs">
+            {t`Channel`}
+          </Text>
+          <SlackChannelFieldNew
+            channel={config.slack.handler}
+            channelSpec={channels.slack}
+            onChange={updateSlackHandler}
+          />
+        </Box>
+      )}
+    </Card>
+  );
+}

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/NotificationChannelConfigModal/SlackChannelCard/SlackChannelCard.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/NotificationChannelConfigModal/SlackChannelCard/SlackChannelCard.unit.spec.tsx
@@ -1,0 +1,93 @@
+import { renderWithProviders, screen } from "__support__/ui";
+import {
+  createMockEmailChannelSpec,
+  createMockSlackChannelSpec,
+} from "metabase-types/api/mocks/security-center";
+
+import type { NotificationConfig } from "../../../hooks/use-notification-config";
+import { useNotificationConfig } from "../../../hooks/use-notification-config";
+
+import { SlackChannelCard } from "./SlackChannelCard";
+
+jest.mock("../../../hooks/use-notification-config", () => ({
+  ...jest.requireActual("../../../hooks/use-notification-config"),
+  useNotificationConfig: jest.fn(),
+}));
+
+const mockedUseNotificationConfig =
+  useNotificationConfig as any as jest.MockedFn<typeof useNotificationConfig>;
+
+const DEFAULT_CONFIG: NotificationConfig = {
+  email: {
+    sendToAllAdmins: true,
+    handler: { channel_type: "channel/email", recipients: [] },
+  },
+  slack: {
+    enabled: false,
+    handler: { channel_type: "channel/slack", recipients: [] },
+  },
+};
+
+function setup({
+  isConfigured = true,
+  config = DEFAULT_CONFIG,
+  slackEnabled = config.slack.enabled,
+} = {}) {
+  const channels = {
+    email: createMockEmailChannelSpec(),
+    slack: createMockSlackChannelSpec({ configured: isConfigured }),
+  };
+
+  const updateSlackHandler = jest.fn();
+  const toggleSlack = jest.fn();
+
+  mockedUseNotificationConfig.mockReturnValue({
+    config: {
+      ...config,
+      slack: { ...config.slack, enabled: slackEnabled },
+    },
+    users: [],
+    channels,
+    updateEmailHandler: jest.fn(),
+    toggleSendToAllAdmins: jest.fn(),
+    updateSlackHandler,
+    toggleSlack,
+    save: jest.fn(),
+    resetConfig: jest.fn(),
+  });
+
+  renderWithProviders(<SlackChannelCard isConfigured={isConfigured} />);
+
+  return { updateSlackHandler, toggleSlack };
+}
+
+describe("SlackChannelCard", () => {
+  it("renders not-configured state with setup link", () => {
+    setup({ isConfigured: false });
+
+    expect(screen.getByText("Slack is not configured.")).toBeInTheDocument();
+    expect(screen.getByText("Set up Slack")).toHaveAttribute(
+      "href",
+      "/admin/settings/slack",
+    );
+  });
+
+  it("renders configured state with toggle", () => {
+    setup();
+
+    expect(screen.getByText("Slack")).toBeInTheDocument();
+    expect(screen.getByTestId("slack-toggle")).toBeInTheDocument();
+  });
+
+  it("does not show channel picker when slack is disabled", () => {
+    setup({ slackEnabled: false });
+
+    expect(screen.queryByText("Channel")).not.toBeInTheDocument();
+  });
+
+  it("shows channel picker when slack is enabled", () => {
+    setup({ slackEnabled: true });
+
+    expect(screen.getByText("Channel")).toBeInTheDocument();
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterBanner/SecurityCenterBanner.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterBanner/SecurityCenterBanner.unit.spec.tsx
@@ -4,33 +4,17 @@ import { Route } from "react-router";
 import { setupNotificationChannelsEndpoints } from "__support__/server-mocks";
 import { mockSettings } from "__support__/settings";
 import { renderWithProviders, screen } from "__support__/ui";
+import type { Advisory } from "metabase-types/api";
 import {
   createMockTokenFeatures,
   createMockUser,
 } from "metabase-types/api/mocks";
+import { createAdvisory } from "metabase-types/api/mocks/security-center";
 import { createMockState } from "metabase-types/store/mocks";
-
-import type { Advisory } from "../../types";
 
 import { SecurityCenterBanner } from "./SecurityCenterBanner";
 
 const DISMISSED_KEY = "security-center-banner-dismissed";
-
-const makeAdvisory = (overrides: Partial<Advisory> = {}): Advisory => ({
-  advisory_id: "SA-001",
-  title: "Test advisory",
-  description: "desc",
-  severity: "medium",
-  advisory_url: null,
-  remediation: "Upgrade",
-  published_at: "2026-01-01T00:00:00Z",
-  match_status: "not_affected",
-  last_evaluated_at: null,
-  acknowledged_by: null,
-  acknowledged_at: null,
-  affected_versions: [{ min: "0.45.0", fixed: "0.59.0" }],
-  ...overrides,
-});
 
 interface SetupOpts {
   isProSelfHosted?: boolean;
@@ -112,7 +96,7 @@ describe("SecurityCenterBanner", () => {
 
   it("renders error banner with active advisories", async () => {
     setup({
-      advisories: [makeAdvisory({ match_status: "active" })],
+      advisories: [createAdvisory({ match_status: "active" })],
     });
 
     expect(
@@ -129,7 +113,7 @@ describe("SecurityCenterBanner", () => {
 
   it("is not dismissible when there are active advisories", async () => {
     setup({
-      advisories: [makeAdvisory({ match_status: "active" })],
+      advisories: [createAdvisory({ match_status: "active" })],
     });
 
     // Wait for the error banner text to confirm advisory data has loaded
@@ -150,7 +134,7 @@ describe("SecurityCenterBanner", () => {
     localStorage.setItem(DISMISSED_KEY, "true");
 
     setup({
-      advisories: [makeAdvisory({ match_status: "active" })],
+      advisories: [createAdvisory({ match_status: "active" })],
     });
 
     expect(

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterNavItem/SecurityCenterMobileNavItem.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterNavItem/SecurityCenterMobileNavItem.tsx
@@ -1,0 +1,43 @@
+import { t } from "ttag";
+
+import { useListSecurityAdvisoriesQuery } from "metabase/api";
+import { AdminNavLink } from "metabase/nav/components/AdminNavbar/AdminNavItem.styled";
+import { Box, Flex } from "metabase/ui";
+
+import { isAffected } from "../../utils";
+
+const PATH = "/admin/security-center";
+
+interface SecurityCenterMobileNavItemProps {
+  currentPath: string;
+}
+
+export function SecurityCenterMobileNavItem({
+  currentPath,
+}: SecurityCenterMobileNavItemProps) {
+  const { data: advisoriesResponse } = useListSecurityAdvisoriesQuery();
+  const advisories = advisoriesResponse?.advisories ?? [];
+  const hasActive = advisories.some(isAffected);
+
+  return (
+    <AdminNavLink
+      to={PATH}
+      isSelected={currentPath.startsWith(PATH)}
+      isInMobileNav
+    >
+      <Flex align="center" gap="0.375rem">
+        {t`Security`}
+        {hasActive && (
+          <Box
+            w={8}
+            h={8}
+            miw={8}
+            bg="error"
+            style={{ borderRadius: "50%", flexShrink: 0 }}
+            data-testid="security-center-badge"
+          />
+        )}
+      </Flex>
+    </AdminNavLink>
+  );
+}

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterNavItem/SecurityCenterNavItem.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterNavItem/SecurityCenterNavItem.tsx
@@ -32,7 +32,6 @@ export function SecurityCenterNavItem({
               w={8}
               h={8}
               miw={8}
-              mt={3}
               bg="error"
               style={{ borderRadius: "50%", flexShrink: 0 }}
               data-testid="security-center-badge"

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.module.css
@@ -42,7 +42,7 @@
   min-height: 0;
   display: flex;
 
-  .filter-bar {
+  .filterBar {
     flex: 0;
   }
 
@@ -51,7 +51,7 @@
     overflow: auto;
   }
 
-  .empty-state {
+  .emptyState {
     flex: 1;
     display: flex;
     flex-direction: column;

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.tsx
@@ -6,7 +6,10 @@ import { EmptyState } from "metabase/common/components/EmptyState";
 import { useSetting } from "metabase/common/hooks";
 import { Box, Button, Group, Icon, Stack, Text, Title } from "metabase/ui";
 
-import { useNotificationConfig } from "../../hooks/use-notification-config";
+import {
+  NotificationConfigProvider,
+  useNotificationConfigState,
+} from "../../hooks/use-notification-config";
 import { useSecurityAdvisories } from "../../hooks/use-security-advisories";
 import type { AdvisoryFilter } from "../../types";
 import { filterAdvisories, getTargetUpgradeVersion } from "../../utils";
@@ -29,7 +32,7 @@ export function SecurityCenterPage() {
     useSyncSecurityAdvisoriesMutation();
   const [filter, setFilter] = useState<AdvisoryFilter>(DEFAULT_FILTER);
   const [settingsOpen, setSettingsOpen] = useState(false);
-  const notificationConfig = useNotificationConfig();
+  const notificationConfig = useNotificationConfigState();
   const version = useSetting("version");
 
   const currentVersion = version?.tag ?? "";
@@ -39,60 +42,64 @@ export function SecurityCenterPage() {
   const nothingToShow = filtered.length === 0 || advisories.length === 0;
 
   return (
-    <Box className={S.root}>
-      <Stack gap="lg" className={S.header}>
-        <Group gap="sm" align="center">
-          <Title order={1}>{t`Security Center`}</Title>
-          <Box style={{ flex: 1 }} />
-          <Button
-            variant="subtle"
-            leftSection={
-              <Icon name="sync" className={isSyncing ? S.syncing : undefined} />
-            }
-            onClick={() => syncAdvisories()}
-            data-testid="sync-advisories"
-          >{t`Check now`}</Button>
-          <Button
-            variant="subtle"
-            leftSection={<Icon name="gear" />}
-            onClick={() => setSettingsOpen(true)}
-            data-testid="notification-config-toggle"
-          >{t`Notification settings`}</Button>
-        </Group>
-        <Text c="text-secondary" data-testid="current-version">
-          {t`Current version`}: {currentVersion}
-        </Text>
-        {targetVersion && <UpgradeBanner targetVersion={targetVersion} />}
-      </Stack>
-      <Stack gap="xl" className={S.content}>
-        <AdvisoryFilterBar
-          className={S.filterBar}
-          filter={filter}
-          onChange={setFilter}
+    <NotificationConfigProvider value={notificationConfig}>
+      <Box className={S.root}>
+        <Stack gap="lg" className={S.header}>
+          <Group gap="sm" align="center">
+            <Title order={1}>{t`Security Center`}</Title>
+            <Box style={{ flex: 1 }} />
+            <Button
+              variant="subtle"
+              leftSection={
+                <Icon
+                  name="sync"
+                  className={isSyncing ? S.syncing : undefined}
+                />
+              }
+              onClick={() => syncAdvisories()}
+              data-testid="sync-advisories"
+            >{t`Check now`}</Button>
+            <Button
+              variant="subtle"
+              leftSection={<Icon name="gear" />}
+              onClick={() => setSettingsOpen(true)}
+              data-testid="notification-config-toggle"
+            >{t`Notification settings`}</Button>
+          </Group>
+          <Text c="text-secondary" data-testid="current-version">
+            {t`Current version`}: {currentVersion}
+          </Text>
+          {targetVersion && <UpgradeBanner targetVersion={targetVersion} />}
+        </Stack>
+        <Stack gap="xl" className={S.content}>
+          <AdvisoryFilterBar
+            className={S.filterBar}
+            filter={filter}
+            onChange={setFilter}
+          />
+          {nothingToShow ? (
+            <EmptyState
+              className={S.emptyState}
+              icon="shield_outline"
+              message={
+                advisories.length === 0
+                  ? t`Your instance is up to date — no known security issues affect your configuration.`
+                  : t`Nothing match your filters.`
+              }
+            />
+          ) : (
+            <AdvisoryList
+              className={S.list}
+              advisories={filtered}
+              onAcknowledge={acknowledgeAdvisory}
+            />
+          )}
+        </Stack>
+        <NotificationChannelConfigModal
+          opened={settingsOpen}
+          onClose={() => setSettingsOpen(false)}
         />
-        {nothingToShow ? (
-          <EmptyState
-            className={S.emptyState}
-            icon="shield_outline"
-            message={
-              advisories.length === 0
-                ? t`Your instance is up to date — no known security issues affect your configuration.`
-                : t`Nothing match your filters.`
-            }
-          />
-        ) : (
-          <AdvisoryList
-            className={S.list}
-            advisories={filtered}
-            onAcknowledge={acknowledgeAdvisory}
-          />
-        )}
-      </Stack>
-      <NotificationChannelConfigModal
-        opened={settingsOpen}
-        onClose={() => setSettingsOpen(false)}
-        {...notificationConfig}
-      />
-    </Box>
+      </Box>
+    </NotificationConfigProvider>
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.tsx
@@ -4,16 +4,7 @@ import { t } from "ttag";
 import { useSyncSecurityAdvisoriesMutation } from "metabase/api";
 import { EmptyState } from "metabase/common/components/EmptyState";
 import { useSetting } from "metabase/common/hooks";
-import {
-  ActionIcon,
-  Box,
-  Group,
-  Icon,
-  Stack,
-  Text,
-  Title,
-  Tooltip,
-} from "metabase/ui";
+import { Box, Button, Group, Icon, Stack, Text, Title } from "metabase/ui";
 
 import { useNotificationConfig } from "../../hooks/use-notification-config";
 import { useSecurityAdvisories } from "../../hooks/use-security-advisories";
@@ -45,32 +36,28 @@ export function SecurityCenterPage() {
   const targetVersion = getTargetUpgradeVersion(advisories);
   const filtered = filterAdvisories(advisories, filter);
 
+  const nothingToShow = filtered.length === 0 || advisories.length === 0;
+
   return (
     <Box className={S.root}>
       <Stack gap="lg" className={S.header}>
         <Group gap="sm" align="center">
           <Title order={1}>{t`Security Center`}</Title>
-          <Tooltip label={t`Check now`}>
-            <ActionIcon
-              mt={5}
-              variant="subtle"
-              onClick={() => syncAdvisories()}
-              data-testid="sync-advisories"
-            >
-              <Icon name="sync" className={isSyncing ? S.syncing : undefined} />
-            </ActionIcon>
-          </Tooltip>
           <Box style={{ flex: 1 }} />
-          <Tooltip label={t`Notification settings`}>
-            <ActionIcon
-              mt={5}
-              variant="subtle"
-              onClick={() => setSettingsOpen(true)}
-              data-testid="notification-config-toggle"
-            >
-              <Icon name="gear" />
-            </ActionIcon>
-          </Tooltip>
+          <Button
+            variant="subtle"
+            leftSection={
+              <Icon name="sync" className={isSyncing ? S.syncing : undefined} />
+            }
+            onClick={() => syncAdvisories()}
+            data-testid="sync-advisories"
+          >{t`Check now`}</Button>
+          <Button
+            variant="subtle"
+            leftSection={<Icon name="gear" />}
+            onClick={() => setSettingsOpen(true)}
+            data-testid="notification-config-toggle"
+          >{t`Notification settings`}</Button>
         </Group>
         <Text c="text-secondary" data-testid="current-version">
           {t`Current version`}: {currentVersion}
@@ -83,11 +70,15 @@ export function SecurityCenterPage() {
           filter={filter}
           onChange={setFilter}
         />
-        {filtered.length === 0 ? (
+        {nothingToShow ? (
           <EmptyState
             className={S["empty-state"]}
             icon="shield_outline"
-            message={t`Your instance is up to date — no known security issues affect your configuration.`}
+            message={
+              advisories.length === 0
+                ? t`Your instance is up to date — no known security issues affect your configuration.`
+                : t`Nothing match your filters.`
+            }
           />
         ) : (
           <AdvisoryList

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.tsx
@@ -66,13 +66,13 @@ export function SecurityCenterPage() {
       </Stack>
       <Stack gap="xl" className={S.content}>
         <AdvisoryFilterBar
-          className={S["filter-bar"]}
+          className={S.filterBar}
           filter={filter}
           onChange={setFilter}
         />
         {nothingToShow ? (
           <EmptyState
-            className={S["empty-state"]}
+            className={S.emptyState}
             icon="shield_outline"
             message={
               advisories.length === 0

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.unit.spec.tsx
@@ -23,7 +23,7 @@ function setup(advisories: Advisory[] = []) {
   });
 
   setupRecentViewsAndSelectionsEndpoints([], ["selections"]);
-  jest.spyOn(notificationHook, "useNotificationConfig").mockReturnValue({
+  jest.spyOn(notificationHook, "useNotificationConfigState").mockReturnValue({
     config: {
       email: {
         sendToAllAdmins: true,

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.unit.spec.tsx
@@ -2,30 +2,15 @@ import userEvent from "@testing-library/user-event";
 
 import { setupRecentViewsAndSelectionsEndpoints } from "__support__/server-mocks";
 import { renderWithProviders, screen, within } from "__support__/ui";
+import type { Advisory } from "metabase-types/api";
 import { createMockVersion } from "metabase-types/api/mocks";
+import { createAdvisory } from "metabase-types/api/mocks/security-center";
 import { createMockSettingsState } from "metabase-types/store/mocks";
 
 import * as notificationHook from "../../hooks/use-notification-config";
 import * as advisoriesHook from "../../hooks/use-security-advisories";
-import type { Advisory } from "../../types";
 
 import { SecurityCenterPage } from "./SecurityCenterPage";
-
-const makeAdvisory = (overrides: Partial<Advisory>): Advisory => ({
-  advisory_id: "SA-001",
-  title: "Test advisory",
-  description: "Test description",
-  severity: "medium",
-  advisory_url: "https://example.com/advisory",
-  remediation: "Upgrade to latest version",
-  published_at: "2026-01-01T00:00:00Z",
-  match_status: "not_affected",
-  last_evaluated_at: null,
-  acknowledged_by: null,
-  acknowledged_at: null,
-  affected_versions: [{ min: "0.45.0", fixed: "0.59.0" }],
-  ...overrides,
-});
 
 const mockAcknowledge = jest.fn();
 
@@ -89,19 +74,19 @@ describe("SecurityCenterPage", () => {
 
   it("renders advisory cards in the correct order (affected first, then by severity)", () => {
     const advisories = [
-      makeAdvisory({
+      createAdvisory({
         advisory_id: "1",
         title: "Low not affected",
         severity: "low",
         match_status: "not_affected",
       }),
-      makeAdvisory({
+      createAdvisory({
         advisory_id: "2",
         title: "Critical affected",
         severity: "critical",
         match_status: "active",
       }),
-      makeAdvisory({
+      createAdvisory({
         advisory_id: "3",
         title: "High affected",
         severity: "high",
@@ -121,8 +106,8 @@ describe("SecurityCenterPage", () => {
 
   it("shows affected status on cards", () => {
     const advisories = [
-      makeAdvisory({ advisory_id: "1", match_status: "active" }),
-      makeAdvisory({ advisory_id: "2", match_status: "not_affected" }),
+      createAdvisory({ advisory_id: "1", match_status: "active" }),
+      createAdvisory({ advisory_id: "2", match_status: "not_affected" }),
     ];
 
     setup(advisories);
@@ -134,7 +119,7 @@ describe("SecurityCenterPage", () => {
 
   it("renders external links with correct targets", () => {
     const advisories = [
-      makeAdvisory({
+      createAdvisory({
         advisory_id: "1",
         advisory_url: "https://example.com/advisory/1",
       }),
@@ -152,7 +137,7 @@ describe("SecurityCenterPage", () => {
 
   it("calls acknowledgeAdvisory when acknowledge button is clicked", async () => {
     const advisories = [
-      makeAdvisory({ advisory_id: "SA-001", acknowledged_at: null }),
+      createAdvisory({ advisory_id: "SA-001", acknowledged_at: null }),
     ];
 
     setup(advisories);
@@ -163,7 +148,7 @@ describe("SecurityCenterPage", () => {
 
   it("does not show acknowledge button for already acknowledged advisories", async () => {
     const advisories = [
-      makeAdvisory({
+      createAdvisory({
         advisory_id: "SA-001",
         acknowledged_at: "2026-03-01T00:00:00Z",
       }),
@@ -182,12 +167,12 @@ describe("SecurityCenterPage", () => {
 
   it("hides acknowledged advisories by default", () => {
     const advisories = [
-      makeAdvisory({
+      createAdvisory({
         advisory_id: "1",
         title: "Visible",
         acknowledged_at: null,
       }),
-      makeAdvisory({
+      createAdvisory({
         advisory_id: "2",
         title: "Hidden",
         acknowledged_at: "2026-03-01T00:00:00Z",
@@ -209,7 +194,7 @@ describe("SecurityCenterPage", () => {
   describe("upgrade banner", () => {
     it("shows the upgrade banner when there are active advisories", () => {
       const advisories = [
-        makeAdvisory({
+        createAdvisory({
           advisory_id: "1",
           match_status: "active",
           affected_versions: [{ min: "0.58.0", fixed: "0.59.4" }],
@@ -226,7 +211,7 @@ describe("SecurityCenterPage", () => {
 
     it("does not show the upgrade banner when there are no active advisories", () => {
       const advisories = [
-        makeAdvisory({
+        createAdvisory({
           advisory_id: "1",
           match_status: "not_affected",
         }),
@@ -239,12 +224,12 @@ describe("SecurityCenterPage", () => {
 
     it("shows the highest fixed version across multiple active advisories", () => {
       const advisories = [
-        makeAdvisory({
+        createAdvisory({
           advisory_id: "1",
           match_status: "active",
           affected_versions: [{ min: "0.58.0", fixed: "0.59.2" }],
         }),
-        makeAdvisory({
+        createAdvisory({
           advisory_id: "2",
           match_status: "active",
           affected_versions: [{ min: "0.58.0", fixed: "0.59.5" }],
@@ -259,7 +244,7 @@ describe("SecurityCenterPage", () => {
 
     it("includes a link to upgrade instructions", () => {
       const advisories = [
-        makeAdvisory({
+        createAdvisory({
           advisory_id: "1",
           match_status: "active",
           affected_versions: [{ min: "0.58.0", fixed: "0.59.4" }],

--- a/enterprise/frontend/src/metabase-enterprise/security_center/hooks/use-notification-config.ts
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/hooks/use-notification-config.ts
@@ -1,4 +1,10 @@
-import { useCallback, useMemo, useState } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from "react";
 
 import {
   useGetChannelInfoQuery,
@@ -83,11 +89,44 @@ function configFromSettings(
   };
 }
 
+type NotificationConfigValue = {
+  config: NotificationConfig;
+  users: User[];
+  channels: ChannelApiResponse["channels"] | undefined;
+  updateEmailHandler: (handler: NotificationHandlerEmail) => void;
+  toggleSendToAllAdmins: (sendToAllAdmins: boolean) => void;
+  updateSlackHandler: (handler: NotificationHandlerSlack) => void;
+  toggleSlack: (enabled: boolean) => void;
+  save: () => Promise<void>;
+  resetConfig: () => void;
+};
+
+const NotificationConfigContext = createContext<NotificationConfigValue | null>(
+  null,
+);
+
+export const NotificationConfigProvider = NotificationConfigContext.Provider;
+
 /**
  * Hook for notification channel configuration.
- * Reads from and writes to Metabase settings via the generic settings API.
+ * When used inside a NotificationConfigProvider, returns the shared context.
+ * When used as the root (in the modal), creates and owns the state.
  */
-export function useNotificationConfig() {
+export function useNotificationConfig(): NotificationConfigValue {
+  const ctx = useContext(NotificationConfigContext);
+  if (ctx) {
+    return ctx;
+  }
+  throw new Error(
+    "useNotificationConfig must be used inside a NotificationConfigProvider",
+  );
+}
+
+/**
+ * Creates the notification config state. Should be called once in the modal
+ * and provided to children via NotificationConfigProvider.
+ */
+export function useNotificationConfigState(): NotificationConfigValue {
   const savedEmailRecipients = useSetting("security-center-email-recipients");
   const savedSlackChannel = useSetting("security-center-slack-channel");
 

--- a/enterprise/frontend/src/metabase-enterprise/security_center/hooks/use-security-advisories.ts
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/hooks/use-security-advisories.ts
@@ -4,12 +4,14 @@ import {
   useAcknowledgeAdvisoryMutation,
   useListSecurityAdvisoriesQuery,
 } from "metabase/api";
-
-import type { Advisory } from "../types";
+import type { Advisory } from "metabase-types/api";
 
 export function useSecurityAdvisories() {
-  const { data: response, isLoading } = useListSecurityAdvisoriesQuery();
-  const [acknowledgeApi] = useAcknowledgeAdvisoryMutation();
+  const { data: response, isLoading } = useListSecurityAdvisoriesQuery(
+    undefined,
+    { refetchOnMountOrArgChange: true },
+  );
+  const [acknowledgeAdvisory] = useAcknowledgeAdvisoryMutation();
 
   const advisories: Advisory[] = useMemo(
     () => response?.advisories ?? [],
@@ -20,6 +22,6 @@ export function useSecurityAdvisories() {
     data: advisories,
     lastCheckedAt: response?.last_checked_at ?? null,
     isLoading,
-    acknowledgeAdvisory: acknowledgeApi,
+    acknowledgeAdvisory,
   };
 }

--- a/enterprise/frontend/src/metabase-enterprise/security_center/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/index.ts
@@ -2,6 +2,7 @@ import { PLUGIN_SECURITY_CENTER } from "metabase/plugins";
 // import { hasPremiumFeature } from "metabase-enterprise/settings";
 
 import { SecurityCenterBanner } from "./components/SecurityCenterBanner/SecurityCenterBanner";
+import { SecurityCenterMobileNavItem } from "./components/SecurityCenterNavItem/SecurityCenterMobileNavItem";
 import { SecurityCenterNavItem } from "./components/SecurityCenterNavItem/SecurityCenterNavItem";
 import { SecurityCenterPage } from "./components/SecurityCenterPage/SecurityCenterPage";
 
@@ -11,5 +12,7 @@ export function initializePlugin() {
   PLUGIN_SECURITY_CENTER.SecurityCenterPage = SecurityCenterPage;
   PLUGIN_SECURITY_CENTER.SecurityCenterBanner = SecurityCenterBanner;
   PLUGIN_SECURITY_CENTER.SecurityCenterNavItem = SecurityCenterNavItem;
+  PLUGIN_SECURITY_CENTER.SecurityCenterMobileNavItem =
+    SecurityCenterMobileNavItem;
   // }
 }

--- a/enterprise/frontend/src/metabase-enterprise/security_center/types.ts
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/types.ts
@@ -1,30 +1,4 @@
-export type AdvisorySeverity = "critical" | "high" | "medium" | "low";
-
-export type AdvisoryMatchStatus =
-  | "active"
-  | "resolved"
-  | "not_affected"
-  | "error";
-
-export type AdvisoryVersionRange = {
-  min: string;
-  fixed: string;
-};
-
-export type Advisory = {
-  advisory_id: string;
-  title: string;
-  description: string;
-  severity: AdvisorySeverity;
-  advisory_url: string | null;
-  remediation: string;
-  published_at: string;
-  match_status: AdvisoryMatchStatus;
-  last_evaluated_at: string | null;
-  acknowledged_by: { id: number; common_name: string; email: string } | null;
-  acknowledged_at: string | null;
-  affected_versions: AdvisoryVersionRange[];
-};
+import type { AdvisorySeverity } from "metabase-types/api";
 
 export type AdvisoryFilter = {
   severity: AdvisorySeverity | "all";

--- a/enterprise/frontend/src/metabase-enterprise/security_center/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/utils.ts
@@ -1,6 +1,7 @@
 import { compareVersions } from "metabase/lib/utils";
+import type { Advisory, AdvisorySeverity } from "metabase-types/api";
 
-import type { Advisory, AdvisoryFilter, AdvisorySeverity } from "./types";
+import type { AdvisoryFilter } from "./types";
 
 const SEVERITY_ORDER: Record<AdvisorySeverity, number> = {
   critical: 0,

--- a/enterprise/frontend/src/metabase-enterprise/security_center/utils.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/utils.unit.spec.ts
@@ -1,4 +1,6 @@
-import type { Advisory, AdvisoryFilter } from "./types";
+import type { Advisory } from "metabase-types/api";
+
+import type { AdvisoryFilter } from "./types";
 import { filterAdvisories, sortAdvisories } from "./utils";
 
 const makeAdvisory = (overrides: Partial<Advisory>): Advisory => ({

--- a/frontend/src/metabase-types/api/index.ts
+++ b/frontend/src/metabase-types/api/index.ts
@@ -44,6 +44,7 @@ export * from "./remote-sync";
 export * from "./revision";
 export * from "./schema";
 export * from "./search";
+export * from "./security-center";
 export * from "./segment";
 export * from "./session";
 export * from "./settings";

--- a/frontend/src/metabase-types/api/mocks/security-center.ts
+++ b/frontend/src/metabase-types/api/mocks/security-center.ts
@@ -1,0 +1,60 @@
+import type {
+  Advisory,
+  EmailChannelSpec,
+  SlackChannelSpec,
+} from "metabase-types/api";
+
+export function createMockEmailChannelSpec(
+  overrides: Partial<EmailChannelSpec> = {},
+): EmailChannelSpec {
+  return {
+    type: "email",
+    name: "Email",
+    schedules: [],
+    schedule_type: null,
+    allows_recipients: true,
+    configured: true,
+    recipients: ["user", "email"],
+    ...overrides,
+  };
+}
+
+export function createMockSlackChannelSpec(
+  overrides: Partial<SlackChannelSpec> = {},
+): SlackChannelSpec {
+  return {
+    type: "slack",
+    name: "Slack",
+    schedules: [],
+    schedule_type: null,
+    allows_recipients: false,
+    configured: false,
+    fields: [
+      {
+        name: "channel",
+        displayName: "Post to",
+        options: ["#general", "#security"],
+        required: true,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+export function createAdvisory(overrides: Partial<Advisory> = {}) {
+  return {
+    advisory_id: "SA-001",
+    title: "Test advisory",
+    description: "desc",
+    severity: "medium",
+    advisory_url: null,
+    remediation: "Upgrade",
+    published_at: "2026-01-01T00:00:00Z",
+    match_status: "not_affected",
+    last_evaluated_at: null,
+    acknowledged_by: null,
+    acknowledged_at: null,
+    affected_versions: [{ min: "0.45.0", fixed: "0.59.0" }],
+    ...overrides,
+  };
+}

--- a/frontend/src/metabase-types/api/security-center.ts
+++ b/frontend/src/metabase-types/api/security-center.ts
@@ -1,0 +1,41 @@
+export type AdvisoryMatchStatus =
+  | "active"
+  | "resolved"
+  | "not_affected"
+  | "error";
+
+export type AdvisoryVersionRange = {
+  min: string;
+  fixed: string;
+};
+
+export type AdvisorySeverity = "critical" | "high" | "medium" | "low";
+
+export type AdvisoryId = string;
+
+export type Advisory = {
+  advisory_id: AdvisoryId;
+  title: string;
+  severity: AdvisorySeverity;
+  description: string;
+  advisory_url: string | null;
+  remediation: string;
+  published_at: string;
+  match_status: AdvisoryMatchStatus;
+  last_evaluated_at: string | null;
+  acknowledged_by: { id: number; common_name: string; email: string } | null;
+  acknowledged_at: string | null;
+  affected_versions: AdvisoryVersionRange[];
+};
+
+export type ListAdvisoriesResponse = {
+  last_checked_at: string | null;
+  advisories: Advisory[];
+};
+
+export type AcknowledgeAdvisoryResponse = {
+  advisory_id: string;
+  match_status: AdvisoryMatchStatus;
+  acknowledged_by: { id: number; common_name: string; email: string } | null;
+  acknowledged_at: string | null;
+};

--- a/frontend/src/metabase/api/security-center.ts
+++ b/frontend/src/metabase/api/security-center.ts
@@ -1,45 +1,10 @@
 import { Api } from "metabase/api";
+import type {
+  AcknowledgeAdvisoryResponse,
+  ListAdvisoriesResponse,
+} from "metabase-types/api";
 
 import { listTag } from "./tags";
-
-export type AdvisoryMatchStatus =
-  | "active"
-  | "resolved"
-  | "not_affected"
-  | "error";
-
-export type AdvisoryVersionRange = {
-  min: string;
-  fixed: string;
-};
-
-export type ApiAdvisory = {
-  advisory_id: string;
-  title: string;
-  severity: "critical" | "high" | "medium" | "low";
-  description: string;
-  advisory_url: string | null;
-  remediation: string;
-  published_at: string;
-  match_status: AdvisoryMatchStatus;
-  last_evaluated_at: string | null;
-  acknowledged_by: { id: number; common_name: string; email: string } | null;
-  acknowledged_at: string | null;
-  affected_versions: AdvisoryVersionRange[];
-};
-
-export type ListAdvisoriesResponse = {
-  last_checked_at: string | null;
-  advisories: ApiAdvisory[];
-};
-
-export type AcknowledgeAdvisoryResponse = {
-  advisory_id: string;
-  match_status: AdvisoryMatchStatus;
-  acknowledged_by: { id: number; common_name: string; email: string } | null;
-  acknowledged_at: string | null;
-};
-
 export const securityCenterApi = Api.injectEndpoints({
   endpoints: (builder) => ({
     listSecurityAdvisories: builder.query<ListAdvisoriesResponse, void>({

--- a/frontend/src/metabase/nav/components/AdminNavbar/AdminNavbar.tsx
+++ b/frontend/src/metabase/nav/components/AdminNavbar/AdminNavbar.tsx
@@ -87,6 +87,8 @@ export const AdminNavbar = ({
               currentPath={currentPath}
             />
           ))}
+          {/* Security Center is rendered outside adminPaths because it
+              needs a live query to show an active-advisories badge */}
           {PLUGIN_SECURITY_CENTER.isEnabled && (
             <PLUGIN_SECURITY_CENTER.SecurityCenterNavItem
               currentPath={currentPath}
@@ -141,6 +143,13 @@ const MobileNavbar = ({ adminPaths, currentPath }: AdminMobileNavbarProps) => {
               {name}
             </AdminNavLink>
           ))}
+          {/* Security Center is rendered outside adminPaths because it
+              needs a live query to show an active-advisories badge */}
+          {PLUGIN_SECURITY_CENTER.isEnabled && (
+            <PLUGIN_SECURITY_CENTER.SecurityCenterMobileNavItem
+              currentPath={currentPath}
+            />
+          )}
         </AdminMobileNavBarItems>
       )}
     </AdminMobileNavbar>

--- a/frontend/src/metabase/plugins/oss/security-center.ts
+++ b/frontend/src/metabase/plugins/oss/security-center.ts
@@ -11,6 +11,7 @@ type SecurityCenterPlugin = {
   SecurityCenterPage: ComponentType;
   SecurityCenterBanner: ComponentType;
   SecurityCenterNavItem: ComponentType<SecurityCenterNavItemProps>;
+  SecurityCenterMobileNavItem: ComponentType<SecurityCenterNavItemProps>;
 };
 
 const getDefaultPlugin = (): SecurityCenterPlugin => ({
@@ -18,6 +19,7 @@ const getDefaultPlugin = (): SecurityCenterPlugin => ({
   SecurityCenterPage: PluginPlaceholder,
   SecurityCenterBanner: PluginPlaceholder,
   SecurityCenterNavItem: PluginPlaceholder,
+  SecurityCenterMobileNavItem: PluginPlaceholder,
 });
 
 export const PLUGIN_SECURITY_CENTER = getDefaultPlugin();


### PR DESCRIPTION
### Shared mock factories
- **`frontend/src/metabase-types/api/mocks/security-center.ts`** — Added `createMockEmailChannelSpec`, `createMockSlackChannelSpec`, and `createAdvisory` factory functions for use across tests
- **`frontend/src/metabase-types/api/security-center.ts`** — New shared API types (`Advisory`, `AdvisoryMatchStatus`, `AdvisorySeverity`, etc.) extracted from enterprise code
- **`frontend/src/metabase-types/api/index.ts`** — Re-exports the new security-center types

### Component extraction (NotificationChannelConfigModal)
- **`EmailChannelCard/`** — Extracted into its own component + new unit tests (5 tests)
- **`SlackChannelCard/`** — Extracted into its own component + new unit tests (4 tests)
- **`NotificationChannelConfigModal.tsx`** — Slimmed down, now composes the two card components
- **`NotificationChannelConfigModal.unit.spec.tsx`** — Updated to use shared mock factories

### Admin mobile nav
- **`AdminNavbar.tsx`** — Added Security Center link to the mobile hamburger menu (with comment explaining why it's outside `adminPaths`)
- **`SecurityCenterMobileNavItem.tsx`** — New mobile-specific nav item component (follows existing pattern with `AdminNavLink` + `isInMobileNav`)
- **`plugins/oss/security-center.ts`** — Added `SecurityCenterMobileNavItem` to plugin type
- **`security_center/index.ts`** — Registered the mobile nav item

### SecurityCenterPage
- **`SecurityCenterPage.tsx`** — Converted `ActionIcon` + `Tooltip` to `Button variant="subtle"` with labels for sync and gear buttons
- **`SecurityCenterPage.module.css`** — Renamed `filter-bar` → `filterBar`, `empty-state` → `emptyState` (camelCase)

### Type import cleanup
- **`types.ts`** — Removed re-exports; only defines `AdvisoryFilter` locally
- **`AdvisoryCard.tsx`, `AdvisoryList.tsx`, `AdvisoryFilterBar.tsx`, `utils.ts`, `utils.unit.spec.ts`** — Import `Advisory`, `AdvisoryId`, `AdvisorySeverity` from `metabase-types/api` instead of local `types.ts`

### Test cleanup
- **`SecurityCenterPage.unit.spec.tsx`** — Replaced inline `makeAdvisory` with shared `createAdvisory`
- **`SecurityCenterBanner.unit.spec.tsx`** — Uses shared mocks; already has the "shows banner despite dismissal with active advisories" test

### Other
- **`use-security-advisories.ts`** — Minor changes
- **`api/security-center.ts`** — Slimmed down (types moved to shared location)