### PR TITLE
Update Measure Icon in Data Studio and Metric Explorer

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/tables/pages/TableMeasuresPage/TableMeasures.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/tables/pages/TableMeasuresPage/TableMeasures.tsx
@@ -27,7 +27,7 @@ export function TableMeasures({ table }: TableMeasuresProps) {
         items={measures}
         title={t`Measures`}
         emptyState={{
-          icon: "sum",
+          icon: "ruler",
           title: t`No measures yet`,
           message: t`Create a measure to define aggregations for this table.`,
         }}
@@ -46,7 +46,7 @@ export function TableMeasures({ table }: TableMeasuresProps) {
             key={measure.id}
             name={measure.name}
             description={measure.definition_description}
-            icon="sum"
+            icon="ruler"
             href={Urls.dataStudioPublishedTableMeasure(table.id, measure.id)}
           />
         )}

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/utils.ts
@@ -116,7 +116,7 @@ export function getNodeIconWithType(
     case "segment":
       return "segment";
     case "measure":
-      return "sum";
+      return "ruler";
   }
 }
 

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchResults/MetricSearchResults.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchResults/MetricSearchResults.tsx
@@ -1,6 +1,7 @@
 import type React from "react";
 import { t } from "ttag";
 
+import { getIcon } from "metabase/lib/icon";
 import { Box, Repeat, Skeleton, Stack, Text } from "metabase/ui";
 
 import type { MetricOrMeasureResult } from "../../../hooks/use-metric-measure-search";
@@ -58,7 +59,7 @@ export function MetricSearchResults({
           ref={getRef(item)}
           name={item.name}
           slug={item.table_name ?? undefined}
-          icon={item.model === "metric" ? "metric" : "sum"}
+          icon={getIcon(item).name}
           active={cursorIndex === index}
           onClick={() => onSelectResult(item.id, item.model)}
         />


### PR DESCRIPTION
Closes UXW-3453

### Description

Couple small changes to ensure that the correct icon is used for measures in the metric explorer and data studio

### How to verify
1. Ensure that you have a measure created
2. Open the metric explorer and search for that measure
3. You should see a ruler next to the name
4. Go to the data studio, and open the table where the measure exists
5. You should see a ruler icon next to the measure
6. Click the measure, and go to the dependencies graph
7. The measure should have a ruler icon in the graph as well. Finally, go to a table with no measure, and see the ruler icon next to the "No Measures Yet" message.

### Demo
<img width="554" height="380" alt="image" src="https://github.com/user-attachments/assets/563249eb-7bdc-4bd7-9689-24141c1522e2" />
<img width="515" height="356" alt="image" src="https://github.com/user-attachments/assets/b3bf1a14-d72f-4c05-87f8-2d7dcaf1bc20" />
<img width="653" height="458" alt="image" src="https://github.com/user-attachments/assets/33c01539-1769-465b-9992-186008b43699" />
<img width="700" height="399" alt="image" src="https://github.com/user-attachments/assets/d85d3da2-bf4a-4527-a52e-be04813086da" />
<img width="840" height="480" alt="image" src="https://github.com/user-attachments/assets/f6aaffd0-875b-49a3-8e1e-c7b9b0b05c6b" />



### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~
