### PR TITLE
Block database routing when transforms already exist

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -2815,7 +2815,8 @@
            warehouse-schema
            warehouses}
    :model-exports #{:model/DatabaseRouter}
-   :model-imports #{:model/Database}}
+   :model-imports #{:model/Database
+                    :model/Transform}}
 
   enterprise/dependencies
   {:team "Graphy"
@@ -2942,7 +2943,6 @@
            premium-features}
    :model-imports #{:model/Card :model/Collection :model/Table}}
 
-
   enterprise/metabot
   {:team    "Metabot"
    :api     #{}
@@ -2959,7 +2959,6 @@
               enterprise/dependencies
               enterprise/transforms-python}
    :model-imports #{:model/Card :model/Transform}}
-
 
   enterprise/permission-debug
   {:team "UX West"

--- a/enterprise/backend/src/metabase_enterprise/database_routing/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/database_routing/api.clj
@@ -110,6 +110,7 @@
     (api/check-400 (not (:router_database_id db)) "Cannot make a destination database a router database")
     (api/check-400 (not (:uploads_enabled db)) "Cannot enable database routing for a database with uploads enabled")
     (api/check-400 (not (:write_data_details db)) "Cannot enable database routing for a database with a write connection configured")
+    (api/check-400 (not (t2/exists? :model/Transform :source_database_id id)) "Cannot enable database routing for a database with transforms")
     (setting/with-database db
       (api/check-400 (not (setting/get :persist-models-enabled)) "Cannot enable database routing for a database with model persistence enabled")
       (api/check-400 (not (setting/get :database-enable-actions)) "Cannot enable database routing for a database with actions enabled")))

--- a/enterprise/backend/test/metabase_enterprise/database_routing/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/database_routing/api_test.clj
@@ -134,6 +134,12 @@
                  :model/Database {db-id :id} {:router_database_id router-db-id}]
     (is (= "Cannot make a destination database a router database"
            (mt/user-http-request :crowberto :put 400 (str "ee/database-routing/router-database/" db-id)
+                                 {:user_attribute "db_name"}))))
+  (mt/with-temp [:model/Database {db-id :id} {}
+                 :model/Transform _ {:source_database_id db-id
+                                     :name "Test Transform"}]
+    (is (= "Cannot enable database routing for a database with transforms"
+           (mt/user-http-request :crowberto :put 400 (str "ee/database-routing/router-database/" db-id)
                                  {:user_attribute "db_name"})))))
 
 (deftest can-delete-router-databases

--- a/enterprise/frontend/src/metabase-enterprise/database_routing/DatabaseRoutingSection/DatabaseRoutingSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/database_routing/DatabaseRoutingSection/DatabaseRoutingSection.tsx
@@ -85,10 +85,11 @@ export const DatabaseRoutingSection = ({
   const userAttributeOptions =
     userAttrsReq.data ?? (userAttribute ? [userAttribute] : []);
 
-  const transformsReq = useListTransformsQuery(
+  const transformsQuery = useListTransformsQuery(
     shouldHideSection ? skipToken : { "database-id": database.id },
   );
-  const hasTransforms = (transformsReq.data?.length ?? 0) > 0;
+  const transforms = transformsQuery.data ?? [];
+  const hasTransforms = transforms.length > 0;
 
   const disabledFeatMsg = getDisabledFeatureMessage(database, {
     hasTransforms,

--- a/enterprise/frontend/src/metabase-enterprise/database_routing/DatabaseRoutingSection/DatabaseRoutingSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/database_routing/DatabaseRoutingSection/DatabaseRoutingSection.tsx
@@ -11,7 +11,11 @@ import {
   DatabaseInfoSectionDivider,
 } from "metabase/admin/databases/components/DatabaseInfoSection";
 import { hasDbRoutingEnabled } from "metabase/admin/databases/utils";
-import { skipToken, useListUserAttributesQuery } from "metabase/api";
+import {
+  skipToken,
+  useListTransformsQuery,
+  useListUserAttributesQuery,
+} from "metabase/api";
 import { getErrorMessage } from "metabase/api/utils";
 import { useSetting } from "metabase/common/hooks";
 import { useToast } from "metabase/common/hooks/use-toast";
@@ -81,7 +85,14 @@ export const DatabaseRoutingSection = ({
   const userAttributeOptions =
     userAttrsReq.data ?? (userAttribute ? [userAttribute] : []);
 
-  const disabledFeatMsg = getDisabledFeatureMessage(database);
+  const transformsReq = useListTransformsQuery(
+    shouldHideSection ? skipToken : { "database-id": database.id },
+  );
+  const hasTransforms = (transformsReq.data?.length ?? 0) > 0;
+
+  const disabledFeatMsg = getDisabledFeatureMessage(database, {
+    hasTransforms,
+  });
   const errMsg = getSelectErrorMessage({
     userAttribute,
     disabledFeatureMessage: disabledFeatMsg,

--- a/enterprise/frontend/src/metabase-enterprise/database_routing/DatabaseRoutingSection/DatabaseRoutingSection.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/database_routing/DatabaseRoutingSection/DatabaseRoutingSection.unit.spec.tsx
@@ -1,5 +1,6 @@
 import {
   setupDatabasesEndpoints,
+  setupListTransformsEndpoint,
   setupUserAttributesEndpoint,
 } from "__support__/server-mocks";
 import { renderWithProviders, screen } from "__support__/ui";
@@ -22,6 +23,7 @@ interface SetupOpts {
 const setup = ({ database = createMockDatabase() }: SetupOpts = {}) => {
   setupUserAttributesEndpoint(["cool_guy", "boss_gal"]);
   setupDatabasesEndpoints([database]);
+  setupListTransformsEndpoint([]);
 
   renderWithProviders(<DatabaseRoutingSection database={database} />, {
     storeInitialState: {

--- a/enterprise/frontend/src/metabase-enterprise/database_routing/DatabaseRoutingSection/utils.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/database_routing/DatabaseRoutingSection/utils.tsx
@@ -12,7 +12,10 @@ import {
 import { Text } from "metabase/ui";
 import type { Database } from "metabase-types/api";
 
-export const getDisabledFeatureMessage = (database: Database) => {
+export const getDisabledFeatureMessage = (
+  database: Database,
+  { hasTransforms = false }: { hasTransforms?: boolean } = {},
+) => {
   return match({
     hasActionsEnabled: hasActionsEnabled(database),
     hasWorkspacesEnabled: hasWorkspacesEnabled(database),
@@ -21,6 +24,7 @@ export const getDisabledFeatureMessage = (database: Database) => {
     isUploadDb: database.uploads_enabled,
     supportsRouting: !!database.features?.includes("database-routing"),
     hasWritableConnection: hasWritableConnectionDetails(database),
+    hasTransforms,
   })
     .with(
       { supportsRouting: false },
@@ -57,6 +61,10 @@ export const getDisabledFeatureMessage = (database: Database) => {
     .with(
       { hasTableEditingEnabled: true },
       () => t`Database routing can't be enabled when table editing is enabled.`,
+    )
+    .with(
+      { hasTransforms: true },
+      () => t`Database routing can't be enabled when transforms exist.`,
     )
     .otherwise(() => undefined);
 };

--- a/frontend/src/metabase-types/api/transform.ts
+++ b/frontend/src/metabase-types/api/transform.ts
@@ -253,6 +253,7 @@ export type ListTransformsRequest = {
   "last-run-start-time"?: string;
   "last-run-statuses"?: TransformRunStatus[];
   "tag-ids"?: TransformTagId[];
+  "database-id"?: DatabaseId;
 };
 
 export type ListTransformJobsRequest = {

--- a/src/metabase/transforms/crud.clj
+++ b/src/metabase/transforms/crud.clj
@@ -66,10 +66,12 @@
 
 (defn get-transforms
   "Get a list of transforms."
-  [& {:keys [last-run-start-time last-run-statuses tag-ids]}]
+  [& {:keys [last-run-start-time last-run-statuses tag-ids database-id]}]
   (let [enabled-types (transforms.u/enabled-source-types-for-user)]
     (api/check-403 (seq enabled-types))
-    (let [transforms (t2/select :model/Transform {:where    [:in :source_type enabled-types]
+    (let [transforms (t2/select :model/Transform {:where    (into [:and [:in :source_type enabled-types]]
+                                                                  (when database-id
+                                                                    [[:= :source_database_id database-id]]))
                                                   :order-by [[:id :asc]]})]
       (->> (t2/hydrate transforms :last_run :transform_tag_ids :creator :owner)
            (into []


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #71891
## Summary
- Prevent enabling database routing on a database that already has transforms, since running transforms on databases with DB routing is not supported
- Backend: added validation check in `PUT /api/ee/database-routing/router-database/:id` that returns 400 if transforms exist for the database
- Frontend: disables the routing toggle in the UI when transforms exist, with a descriptive message
- Also wired through the existing but unused `database-id` filter param in the transforms list API

## Test plan
- [x] Backend test added and passing: `cannot-enable-db-routing-when-other-features-enabled`
- [x] Verify toggle is disabled in the UI when a database has transforms
- [x] Verify enabling routing via API returns 400 when transforms exist
- [x] Verify routing can still be enabled when no transforms exist

Fixes GIT-9695