### PR TITLE
Handle multi-touch events to improve pinch-to-zoom functionality on mobile devices for visualizations

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/touch-brush.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/touch-brush.cy.spec.tsx
@@ -68,6 +68,48 @@ describe("scenarios > embedding-sdk > touch-brush", () => {
       });
     });
 
+    it("should NOT trigger brush on pinch-to-zoom", () => {
+      mountInteractiveQuestion();
+      waitForChart();
+
+      // First finger down
+      cy.findByTestId("chart-container").trigger("pointerdown", 100, 150, {
+        force: true,
+        isPrimary: true,
+        pointerId: 1,
+        button: 0,
+      });
+
+      // Second finger down before long press completes — should cancel brush
+      cy.findByTestId("chart-container").trigger("pointerdown", 200, 150, {
+        force: true,
+        isPrimary: false,
+        pointerId: 2,
+        button: 0,
+      });
+
+      // Wait longer than the long press duration
+      cy.wait(700);
+
+      // Release both fingers
+      cy.findByTestId("chart-container")
+        .trigger("pointerup", 100, 150, {
+          force: true,
+          isPrimary: true,
+          pointerId: 1,
+        })
+        .trigger("pointerup", 200, 150, {
+          force: true,
+          isPrimary: false,
+          pointerId: 2,
+        });
+
+      cy.wait(1000);
+      getSdkRoot().within(() => {
+        cy.findByText("Count by Product ID").should("not.exist");
+      });
+    });
+
     it("should NOT trigger brush on quick horizontal swipe", () => {
       mountInteractiveQuestion();
       waitForChart();

--- a/e2e/test-component/scenarios/embedding-sdk/touch-brush.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/touch-brush.cy.spec.tsx
@@ -68,48 +68,6 @@ describe("scenarios > embedding-sdk > touch-brush", () => {
       });
     });
 
-    it("should NOT trigger brush on pinch-to-zoom", () => {
-      mountInteractiveQuestion();
-      waitForChart();
-
-      // First finger down
-      cy.findByTestId("chart-container").trigger("pointerdown", 100, 150, {
-        force: true,
-        isPrimary: true,
-        pointerId: 1,
-        button: 0,
-      });
-
-      // Second finger down before long press completes — should cancel brush
-      cy.findByTestId("chart-container").trigger("pointerdown", 200, 150, {
-        force: true,
-        isPrimary: false,
-        pointerId: 2,
-        button: 0,
-      });
-
-      // Wait longer than the long press duration
-      cy.wait(700);
-
-      // Release both fingers
-      cy.findByTestId("chart-container")
-        .trigger("pointerup", 100, 150, {
-          force: true,
-          isPrimary: true,
-          pointerId: 1,
-        })
-        .trigger("pointerup", 200, 150, {
-          force: true,
-          isPrimary: false,
-          pointerId: 2,
-        });
-
-      cy.wait(1000);
-      getSdkRoot().within(() => {
-        cy.findByText("Count by Product ID").should("not.exist");
-      });
-    });
-
     it("should NOT trigger brush on quick horizontal swipe", () => {
       mountInteractiveQuestion();
       waitForChart();

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-brush.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-brush.ts
@@ -194,6 +194,9 @@ function useTouchBrush({
 
         if (activeRef.current) {
           activeRef.current = false;
+          // Defer so ECharts finishes processing the current pointer event
+          // before we yank brush mode away. Without this, ECharts can get
+          // stuck with brush enabled after both fingers are released.
           setTimeout(disableBrush, 0);
         }
 

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-brush.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-brush.ts
@@ -187,6 +187,19 @@ function useTouchBrush({
     };
 
     const onPointerDown = (event: PointerEvent) => {
+      // A second finger means pinch-to-zoom, not a long press.
+      // Cancel whether the timer is still pending or brush is already active.
+      if (!event.isPrimary) {
+        cancel();
+
+        if (activeRef.current) {
+          activeRef.current = false;
+          setTimeout(disableBrush, 0);
+        }
+
+        return;
+      }
+
       if (activeRef.current) {
         return;
       }

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-brush.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-brush.unit.spec.ts
@@ -12,11 +12,15 @@ import {
 
 class PointerEventPolyfill extends MouseEvent {
   readonly pointerType: string;
+  readonly isPrimary: boolean;
+  readonly pointerId: number;
 
   constructor(type: string, init: PointerEventInit = {}) {
     super(type, init);
 
     this.pointerType = init.pointerType ?? "";
+    this.isPrimary = init.isPrimary ?? false;
+    this.pointerId = init.pointerId ?? 0;
   }
 }
 
@@ -50,12 +54,24 @@ const createMockContainerRef = () => {
 const firePointer = (
   element: HTMLElement,
   type: string,
-  { clientX = 0, clientY = 0 }: { clientX?: number; clientY?: number } = {},
+  {
+    clientX = 0,
+    clientY = 0,
+    isPrimary = true,
+    pointerId = 1,
+  }: {
+    clientX?: number;
+    clientY?: number;
+    isPrimary?: boolean;
+    pointerId?: number;
+  } = {},
 ) => {
   element.dispatchEvent(
     new PointerEvent(type, {
       clientX,
       clientY,
+      isPrimary,
+      pointerId,
       bubbles: true,
       cancelable: true,
     }),
@@ -332,6 +348,57 @@ describe("use-brush", () => {
         el.dispatchEvent(touchmove);
 
         expect(touchmove.defaultPrevented).toBe(true);
+      });
+
+      it("cancels long press when a second finger touches (pinch-to-zoom)", () => {
+        const { el, dispatchAction } = setupTouchBrush();
+
+        // First finger down
+        firePointer(el, "pointerdown", {
+          clientX: 100,
+          clientY: 100,
+          isPrimary: true,
+          pointerId: 1,
+        });
+
+        // Second finger down before timer fires
+        firePointer(el, "pointerdown", {
+          clientX: 200,
+          clientY: 100,
+          isPrimary: false,
+          pointerId: 2,
+        });
+
+        // Wait past the long press duration
+        act(() => jest.advanceTimersByTime(500));
+
+        expectBrushNotEnabled(dispatchAction);
+      });
+
+      it("deactivates brush when a second finger touches during active brush", () => {
+        const { el, dispatchAction } = setupTouchBrush();
+
+        // First finger down, wait for long press to activate brush
+        firePointer(el, "pointerdown", {
+          clientX: 100,
+          clientY: 100,
+          isPrimary: true,
+          pointerId: 1,
+        });
+        act(() => jest.advanceTimersByTime(500));
+        expectBrushEnabled(dispatchAction);
+        dispatchAction.mockClear();
+
+        // Second finger down while brush is active
+        firePointer(el, "pointerdown", {
+          clientX: 200,
+          clientY: 100,
+          isPrimary: false,
+          pointerId: 2,
+        });
+        act(() => jest.runAllTimers());
+
+        expectBrushDisabled(dispatchAction);
       });
     });
   });

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-brush.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-brush.unit.spec.ts
@@ -400,6 +400,55 @@ describe("use-brush", () => {
 
         expectBrushDisabled(dispatchAction);
       });
+
+      it("does not freeze brush mode after second finger tap during active brush", () => {
+        const { el, dispatchAction } = setupTouchBrush();
+
+        // Long press activates brush
+        firePointer(el, "pointerdown", {
+          clientX: 100,
+          clientY: 100,
+          isPrimary: true,
+          pointerId: 1,
+        });
+        act(() => jest.advanceTimersByTime(500));
+        expectBrushEnabled(dispatchAction);
+        dispatchAction.mockClear();
+
+        // Second finger tap while brush is active
+        firePointer(el, "pointerdown", {
+          clientX: 200,
+          clientY: 100,
+          isPrimary: false,
+          pointerId: 2,
+        });
+
+        // disableBrush must be deferred — calling it synchronously during
+        // the pointer event causes ECharts to get stuck with brush enabled.
+        expect(dispatchAction).not.toHaveBeenCalled();
+
+        act(() => jest.runAllTimers());
+        expectBrushDisabled(dispatchAction);
+        dispatchAction.mockClear();
+
+        // Both fingers released
+        firePointer(el, "pointerup", { isPrimary: false, pointerId: 2 });
+        firePointer(el, "pointerup", { isPrimary: true, pointerId: 1 });
+        act(() => jest.runAllTimers());
+
+        // Brush should not be re-enabled — no stuck brush mode
+        expectBrushNotEnabled(dispatchAction);
+
+        // A new long press should work normally
+        firePointer(el, "pointerdown", {
+          clientX: 100,
+          clientY: 100,
+          isPrimary: true,
+          pointerId: 1,
+        });
+        act(() => jest.advanceTimersByTime(500));
+        expectBrushEnabled(dispatchAction);
+      });
     });
   });
 });


### PR DESCRIPTION
Handle multi-touch events to improve pinch-to-zoom functionality on mobile devices for visualizations

Context: it's a follow-up for https://github.com/metabase/metabase/pull/71374
I've found that trying to pinch-zoom sometimes triggers range selection.

So this PR fixes it.

Demo:

https://github.com/user-attachments/assets/662906fc-be3c-4c40-9acb-2d39a7e31b61

