### PR TITLE
update invalid expression handling

### DIFF
--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.ts
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.ts
@@ -751,42 +751,69 @@ export function findInvalidRanges(
       });
     }
 
-    // Consecutive / leading / trailing operators, operator after "(", empty parens
+    // Token predecessor validity
     let prevSignificant: PositionedToken | null = null;
     for (const token of itemTokens) {
-      if (token.type === "operator") {
-        if (prevSignificant === null) {
+      if (token.type === "unknown") {
+        prevSignificant = token;
+        continue;
+      }
+
+      const prevType = prevSignificant?.type ?? null;
+
+      if (
+        token.type === "metric" ||
+        token.type === "constant" ||
+        token.type === "open-paren"
+      ) {
+        if (
+          prevType !== null &&
+          prevType !== "open-paren" &&
+          prevType !== "operator" &&
+          prevType !== "unknown"
+        ) {
           itemInvalid.push({
             from: token.from,
             to: token.to,
-            message: t`Expression cannot start with an operator`,
+            message: t`Missing operator`,
           });
-        } else if (prevSignificant.type === "operator") {
+        }
+      } else if (token.type === "operator") {
+        if (
+          prevType !== "metric" &&
+          prevType !== "constant" &&
+          prevType !== "close-paren" &&
+          prevType !== "unknown"
+        ) {
           itemInvalid.push({
             from: token.from,
             to: token.to,
-            message: t`Two operators in a row without a metric between them`,
+            message: t`Missing operand`,
           });
-        } else if (prevSignificant.type === "open-paren") {
+        }
+      } else if (token.type === "close-paren") {
+        if (
+          prevType !== "metric" &&
+          prevType !== "constant" &&
+          prevType !== "close-paren" &&
+          prevType !== "unknown"
+        ) {
           itemInvalid.push({
-            from: token.from,
+            from:
+              prevType === "open-paren"
+                ? (prevSignificant?.from ?? token.from)
+                : token.from,
             to: token.to,
-            message: t`Operator right after opening parenthesis`,
+            message:
+              prevType === "open-paren"
+                ? t`Empty parentheses`
+                : t`Missing operand before closing parenthesis`,
           });
         }
       }
-      if (
-        token.type === "close-paren" &&
-        prevSignificant?.type === "open-paren"
-      ) {
-        itemInvalid.push({
-          from: prevSignificant.from,
-          to: token.to,
-          message: t`Empty parentheses`,
-        });
-      }
       prevSignificant = token;
     }
+
     if (prevSignificant?.type === "operator") {
       itemInvalid.push({
         from: prevSignificant.from,
@@ -795,7 +822,6 @@ export function findInvalidRanges(
       });
     }
 
-    // Unknown tokens
     for (const token of itemTokens) {
       if (token.type === "unknown") {
         itemInvalid.push({
@@ -806,11 +832,8 @@ export function findInvalidRanges(
       }
     }
 
-    // No operands at all
-    const hasOperand = itemTokens.some(
-      (tok) => tok.type === "metric" || tok.type === "constant",
-    );
-    if (!hasOperand && itemInvalid.length === 0) {
+    const hasMetric = itemTokens.some((tok) => tok.type === "metric");
+    if (!hasMetric && itemInvalid.length === 0) {
       itemInvalid.push({
         from: itemTokens[0].from,
         to: itemTokens[itemTokens.length - 1].to,

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.unit.spec.ts
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.unit.spec.ts
@@ -780,6 +780,144 @@ describe("findInvalidRanges — unknown token detection", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// findInvalidRanges — predecessor validation
+// ---------------------------------------------------------------------------
+
+describe("findInvalidRanges — predecessor validation", () => {
+  const revenueEntry = makeMetricEntry("metric:1", "Revenue");
+  const costsEntry = makeMetricEntry("metric:2", "Costs");
+  const metricEntries = [revenueEntry, costsEntry];
+
+  it("flags missing operator between metric and constant", () => {
+    const errors = findInvalidRanges("Revenue 2", metricEntries);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({
+      from: 8,
+      to: 9,
+      message: expect.stringContaining("Missing operator"),
+    });
+  });
+
+  it("flags missing operator between two metrics", () => {
+    const errors = findInvalidRanges("Revenue Costs", metricEntries);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({
+      from: 8,
+      to: 13,
+      message: expect.stringContaining("Missing operator"),
+    });
+  });
+
+  it("flags missing operator between constant and metric", () => {
+    const errors = findInvalidRanges("2 Revenue", metricEntries);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({
+      from: 2,
+      to: 9,
+      message: expect.stringContaining("Missing operator"),
+    });
+  });
+
+  it("flags missing operator between close-paren and metric", () => {
+    const errors = findInvalidRanges(
+      "(Revenue + Costs) Revenue",
+      metricEntries,
+    );
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({
+      from: 18,
+      to: 25,
+      message: expect.stringContaining("Missing operator"),
+    });
+  });
+
+  it("flags operator before closing parenthesis", () => {
+    const errors = findInvalidRanges("(Revenue +)", metricEntries);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({
+      from: 10,
+      to: 11,
+      message: expect.stringContaining("closing parenthesis"),
+    });
+  });
+
+  it("flags consecutive operators", () => {
+    const errors = findInvalidRanges("Revenue + + Costs", metricEntries);
+    expect(errors.length).toBeGreaterThanOrEqual(1);
+    const messages = errors.map((e) => e.message);
+    expect(messages.some((m) => m.includes("Missing operand"))).toBe(true);
+  });
+
+  it("flags operator after opening parenthesis", () => {
+    const errors = findInvalidRanges("(+ Revenue)", metricEntries);
+    expect(errors.length).toBeGreaterThanOrEqual(1);
+    const messages = errors.map((e) => e.message);
+    expect(messages.some((m) => m.includes("Missing operand"))).toBe(true);
+  });
+
+  it("flags empty parentheses", () => {
+    const errors = findInvalidRanges("Revenue + ()", metricEntries);
+    expect(errors.length).toBeGreaterThanOrEqual(1);
+    const messages = errors.map((e) => e.message);
+    expect(messages.some((m) => m.includes("Empty parentheses"))).toBe(true);
+  });
+
+  it("flags leading operator", () => {
+    const errors = findInvalidRanges("+ Revenue", metricEntries);
+    expect(errors.length).toBeGreaterThanOrEqual(1);
+    const messages = errors.map((e) => e.message);
+    expect(messages.some((m) => m.includes("Missing operand"))).toBe(true);
+  });
+
+  it("flags trailing operator", () => {
+    const errors = findInvalidRanges("Revenue +", metricEntries);
+    expect(errors.length).toBeGreaterThanOrEqual(1);
+    const messages = errors.map((e) => e.message);
+    expect(messages.some((m) => m.includes("end with an operator"))).toBe(true);
+  });
+
+  it("flags constants-only expression as missing metric", () => {
+    const errors = findInvalidRanges("2 + 2", metricEntries);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({
+      message: expect.stringContaining("at least one metric"),
+    });
+  });
+
+  it("flags unmatched opening parenthesis", () => {
+    const errors = findInvalidRanges("(Revenue + Costs", metricEntries);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({
+      from: 0,
+      to: 1,
+      message: expect.stringContaining("Unmatched opening parenthesis"),
+    });
+  });
+
+  it("flags unmatched closing parenthesis", () => {
+    const errors = findInvalidRanges("Revenue + Costs)", metricEntries);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({
+      from: 15,
+      to: 16,
+      message: expect.stringContaining("Unmatched closing parenthesis"),
+    });
+  });
+
+  it("accepts valid nested parentheses", () => {
+    expect(findInvalidRanges("(2 * (Revenue + Costs))", metricEntries)).toEqual(
+      [],
+    );
+  });
+
+  it("accepts close-paren followed by operator", () => {
+    expect(findInvalidRanges("(Revenue + Costs) * 2", metricEntries)).toEqual(
+      [],
+    );
+  });
+});
+
 describe("getWordAtCursor — comma handling with metric entries", () => {
   const commaMetric = makeMetricEntry("metric:99", "Revenue, Total");
 

--- a/frontend/src/metabase/metrics-viewer/hooks/use-definition-queries.ts
+++ b/frontend/src/metabase/metrics-viewer/hooks/use-definition-queries.ts
@@ -171,7 +171,7 @@ function buildArithmeticRequest(
 
   const expr = parseExpression(tokens, leafRefs);
   if (!expr) {
-    return null;
+    return { error: t`Invalid expression` };
   }
 
   return {

--- a/frontend/src/metabase/metrics-viewer/utils/parse-expression.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/parse-expression.ts
@@ -103,5 +103,10 @@ export function parseExpression(
   tokens: ExpressionSubToken[],
   leafRefs: Map<number, ExpressionRef>,
 ): ExpressionRef | null {
-  return parseExpressionWithContext({ tokens, pos: 0, leafRefs });
+  const ctx: ParseCtx = { tokens, pos: 0, leafRefs };
+  const result = parseExpressionWithContext(ctx);
+  if (ctx.pos < tokens.length) {
+    return null;
+  }
+  return result;
 }

--- a/frontend/src/metabase/metrics-viewer/utils/parse-expression.unit.spec.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/parse-expression.unit.spec.ts
@@ -222,6 +222,25 @@ describe("parseExpression", () => {
     ]);
   });
 
+  it("should return null when tokens are not fully consumed", () => {
+    // "Metric1 2" — two operands with no operator
+    const tokens: ExpressionSubToken[] = [
+      { type: "metric", sourceId: "metric:1", count: 1 },
+      { type: "constant", value: 2 },
+    ];
+    const expr = parseExpression(tokens, createLeafRefs(tokens));
+    expect(expr).toBeNull();
+  });
+
+  it("should return null for metric followed by another metric without operator", () => {
+    const tokens: ExpressionSubToken[] = [
+      { type: "metric", sourceId: "metric:1", count: 1 },
+      { type: "metric", sourceId: "metric:2", count: 1 },
+    ];
+    const expr = parseExpression(tokens, createLeafRefs(tokens));
+    expect(expr).toBeNull();
+  });
+
   // 6 / 2 * 3  =>  (6 / 2) * 3 = 9, not 6 / (2 * 3) = 1
   it("should associate mixed * and / left-to-right", () => {
     const tokens: ExpressionSubToken[] = [


### PR DESCRIPTION
Closes [UXW-3364: Unknown operators are ignored in metric expressions](https://linear.app/metabase/issue/UXW-3364/unknown-operators-are-ignored-in-metric-expressions)

- Specifically fixes two types of expressions that should be invalid: "Metric 2" (missing operator) and "(Metric +)" (missing operand)
- More robust approach to validating tokens rather than handling special cases
- Adds a bunch of tests
- `parseExpression` no longer silently returns an expression if it didn't use all the tokens
