### PR TITLE
Hide the separator in breakout menu if not needed

### DIFF
--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricPill/MetricPill.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricPill/MetricPill.tsx
@@ -230,8 +230,10 @@ export function MetricPill({
               >
                 {breakoutDimension ? t`Change breakout` : t`Break out`}
               </Menu.Item>
-              <Menu.Divider />
             </>
+          )}
+          {(hasDataStudioAccess || metric.sourceType === "metric") && (
+            <Menu.Divider role="separator" />
           )}
           {hasDataStudioAccess && (
             <Menu.Item

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricPill/MetricPill.unit.spec.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricPill/MetricPill.unit.spec.tsx
@@ -1,0 +1,85 @@
+import { fireEvent, screen } from "@testing-library/react";
+
+import { renderWithProviders } from "__support__/ui";
+import { createMockUser } from "metabase-types/api/mocks";
+import { createMockState } from "metabase-types/store/mocks";
+
+import type {
+  MetricsViewerDefinitionEntry,
+  SelectedMetric,
+} from "../../../types/viewer-state";
+
+import { MetricPill } from "./MetricPill";
+
+const defaultDefinitionEntry: MetricsViewerDefinitionEntry = {
+  id: "measure:1",
+  definition: null,
+};
+
+function setup({
+  metric,
+  hasDataStudioAccess = false,
+}: {
+  metric: SelectedMetric;
+  hasDataStudioAccess?: boolean;
+}) {
+  const state = createMockState({
+    currentUser: createMockUser({
+      is_superuser: hasDataStudioAccess,
+    }),
+  });
+
+  renderWithProviders(
+    <MetricPill
+      metric={metric}
+      definitionEntry={defaultDefinitionEntry}
+      selectedMetricIds={new Set()}
+      selectedMeasureIds={new Set()}
+      onSwap={jest.fn()}
+      onRemove={jest.fn()}
+      onSetBreakout={jest.fn()}
+    />,
+    { storeInitialState: state },
+  );
+}
+
+function openContextMenu() {
+  const pill = screen.getByTestId("metrics-viewer-search-pill");
+  fireEvent.contextMenu(pill);
+}
+
+describe("MetricPill context menu", () => {
+  it("should not show bottom menu items for a measure without data studio access", () => {
+    setup({
+      metric: { id: 1, name: "Revenue", sourceType: "measure" },
+    });
+    openContextMenu();
+
+    expect(screen.queryByRole("separatar")).not.toBeInTheDocument();
+
+    expect(screen.queryByText("Edit in Data Studio")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Go to metric home page"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should show 'Go to metric home page' for metric source type", () => {
+    setup({
+      metric: { id: 1, name: "Revenue", sourceType: "metric" },
+    });
+    openContextMenu();
+
+    expect(screen.getByRole("separator")).toBeInTheDocument();
+    expect(screen.getByText("Go to metric home page")).toBeInTheDocument();
+  });
+
+  it("should show 'Edit in Data Studio' when user has data studio access", () => {
+    setup({
+      metric: { id: 1, name: "Revenue", sourceType: "measure" },
+      hasDataStudioAccess: true,
+    });
+    openContextMenu();
+    expect(screen.getByRole("separator")).toBeInTheDocument();
+    expect(screen.getByText("Edit in Data Studio")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #71626
### Description
Small change that should avoid showing an orphaned divider in the breakout menu of a measure when a user does not have access to data studio

### How to verify
1. Log in as someone who does not have access to data studio
2. Open the metric explorer and add a measure
3. right click on the measure. There should be no orphaned divider
4. Metrics should still have dividers before "Go to metric homepage", and users with data studio access should also see "Go to metric Home page"

### Demo
<img width="459" height="290" alt="image" src="https://github.com/user-attachments/assets/0cc9ee08-6805-478d-bf0d-f758512b26b2" />

Admin User:
<img width="364" height="299" alt="image" src="https://github.com/user-attachments/assets/f041f0f2-827d-42da-bbbf-1333e5e0116d" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR