### PR TITLE
Implement table privileges support for SQLite.

### DIFF
--- a/modules/drivers/sqlite/src/metabase/driver/sqlite.clj
+++ b/modules/drivers/sqlite/src/metabase/driver/sqlite.clj
@@ -2,6 +2,7 @@
   (:refer-clojure :exclude [mapv])
   (:require
    [clojure.java.io :as io]
+   [clojure.java.jdbc :as jdbc]
    [clojure.math :as math]
    [clojure.set :as set]
    [clojure.string :as str]
@@ -46,6 +47,7 @@
                               :case-sensitivity-string-filter-options false
                               ;; Index sync is turned off across the application as it is not used ATM.
                               :index-info                             false
+                              :table-privileges                       true
                               :database-routing                       true
                               :describe-default-expr                  true
                               :describe-is-nullable                   true
@@ -129,6 +131,20 @@
   (sql.qp/format-honeysql driver {:select [:*]
                                   :from   [[(h2x/identifier :table table-name)]]
                                   :limit  1}))
+
+(defmethod sql-jdbc.sync/current-user-table-privileges :sqlite
+  [_driver conn-spec & _options]
+  ;; SQLite has no per-user privileges; allow SELECT on all tables and views
+  (let [rows (jdbc/query conn-spec ["SELECT name AS \"table\" FROM sqlite_master WHERE type IN ('table','view')"])]
+    (map (fn [{:keys [table]}]
+           {:role   nil
+            :schema nil
+            :table  table
+            :select true
+            :insert false
+            :update false
+            :delete false})
+         rows)))
 
 (defn- ->date [& args]
   (-> (into [:date] args)

--- a/modules/drivers/sqlite/src/metabase/driver/sqlite.clj
+++ b/modules/drivers/sqlite/src/metabase/driver/sqlite.clj
@@ -141,9 +141,9 @@
             :schema nil
             :table  table
             :select true
-            :insert false
-            :update false
-            :delete false})
+            :insert true
+            :update true
+            :delete true})
          rows)))
 
 (defn- ->date [& args]

--- a/modules/drivers/sqlite/test/metabase/driver/sqlite_test.clj
+++ b/modules/drivers/sqlite/test/metabase/driver/sqlite_test.clj
@@ -25,14 +25,14 @@
 (deftest current-user-table-privileges-test
   (testing "SQLite table privileges normalization"
     (mt/test-driver :sqlite
-      (is (= {"people"     {:role nil, :schema nil, :table "people", :select true, :insert false, :update false, :delete false}
-              "reviews"    {:role nil, :schema nil, :table "reviews", :select true, :insert false, :update false, :delete false}
-              "checkins"   {:role nil, :schema nil, :table "checkins", :select true, :insert false, :update false, :delete false}
-              "users"      {:role nil, :schema nil, :table "users", :select true, :insert false, :update false, :delete false}
-              "orders"     {:role nil, :schema nil, :table "orders", :select true, :insert false, :update false, :delete false}
-              "venues"     {:role nil, :schema nil, :table "venues", :select true, :insert false, :update false, :delete false}
-              "categories" {:role nil, :schema nil, :table "categories", :select true, :insert false, :update false, :delete false}
-              "products"   {:role nil, :schema nil, :table "products", :select true, :insert false, :update false, :delete false}}
+      (is (= {"people"     {:role nil, :schema nil, :table "people", :select true, :insert true, :update true, :delete true}
+              "reviews"    {:role nil, :schema nil, :table "reviews", :select true, :insert true, :update true, :delete true}
+              "checkins"   {:role nil, :schema nil, :table "checkins", :select true, :insert true, :update true, :delete true}
+              "users"      {:role nil, :schema nil, :table "users", :select true, :insert true, :update true, :delete true}
+              "orders"     {:role nil, :schema nil, :table "orders", :select true, :insert true, :update true, :delete true}
+              "venues"     {:role nil, :schema nil, :table "venues", :select true, :insert true, :update true, :delete true}
+              "categories" {:role nil, :schema nil, :table "categories", :select true, :insert true, :update true, :delete true}
+              "products"   {:role nil, :schema nil, :table "products", :select true, :insert true, :update true, :delete true}}
              (into {}
                    (map (fn [m] [(:table m) m])
                         (sql-jdbc.sync/current-user-table-privileges
@@ -136,7 +136,7 @@
   {:name        table-name
    :schema      nil
    :description nil
-   :is_writable false})
+   :is_writable true})
 
 (deftest timestamp-test-db
   (let [driver :sqlite]

--- a/modules/drivers/sqlite/test/metabase/driver/sqlite_test.clj
+++ b/modules/drivers/sqlite/test/metabase/driver/sqlite_test.clj
@@ -5,6 +5,7 @@
    [clojure.test :refer :all]
    [metabase.driver :as driver]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
+   [metabase.driver.sql-jdbc.sync :as sql-jdbc.sync]
    [metabase.driver.sql.query-processor-test-util :as sql.qp-test-util]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
@@ -20,6 +21,23 @@
   (mt/test-driver :sqlite
     (is (= "UTC"
            (driver/db-default-timezone :sqlite (mt/db))))))
+
+(deftest current-user-table-privileges-test
+  (testing "SQLite table privileges normalization"
+    (mt/test-driver :sqlite
+      (is (= {"people"     {:role nil, :schema nil, :table "people", :select true, :insert false, :update false, :delete false}
+              "reviews"    {:role nil, :schema nil, :table "reviews", :select true, :insert false, :update false, :delete false}
+              "checkins"   {:role nil, :schema nil, :table "checkins", :select true, :insert false, :update false, :delete false}
+              "users"      {:role nil, :schema nil, :table "users", :select true, :insert false, :update false, :delete false}
+              "orders"     {:role nil, :schema nil, :table "orders", :select true, :insert false, :update false, :delete false}
+              "venues"     {:role nil, :schema nil, :table "venues", :select true, :insert false, :update false, :delete false}
+              "categories" {:role nil, :schema nil, :table "categories", :select true, :insert false, :update false, :delete false}
+              "products"   {:role nil, :schema nil, :table "products", :select true, :insert false, :update false, :delete false}}
+             (into {}
+                   (map (fn [m] [(:table m) m])
+                        (sql-jdbc.sync/current-user-table-privileges
+                         :sqlite
+                         (sql-jdbc.conn/db->pooled-connection-spec (mt/db))))))))))
 
 (deftest ^:parallel filter-by-date-test
   (testing "Make sure filtering against a LocalDate works correctly in SQLite"
@@ -118,7 +136,7 @@
   {:name        table-name
    :schema      nil
    :description nil
-   :is_writable nil})
+   :is_writable false})
 
 (deftest timestamp-test-db
   (let [driver :sqlite]


### PR DESCRIPTION
### Description

**Problem Solved**: As described in issue #37742, the default database synchronization process is inefficient. When fetching table metadata, Metabase checked if the connected user had `SELECT` privileges for each table individually by running a `SELECT TRUE FROM table LIMIT 1` query. This resulted in an N+1 query problem, significantly slowing down the sync process for databases with many tables.

**Approach** This change allows Metabase to fetch the privileges for all relevant tables in a single query for SQLite. The sync process then uses this information to filter the tables it describes, avoiding the inefficient per-table check. This approach was previously implemented for Postgres, Redshift, and MySQL.

This is based on code from https://github.com/metabase/metabase/pull/57000 but breaks it down into more manageable chunks.

### How to verify

Unfortunately it's unlikely that with SQLite a there would be a noticeable performance difference with the new approach; I've just chosen to start with this one because the tests run easily without any additional setup.

I've run the tests with `DRIVERS=sqlite` to verify, and of course CI should tell us.

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
