### PR TITLE
Treat error match_status as affected (fail-open)

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/security_center/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/utils.ts
@@ -11,7 +11,9 @@ const SEVERITY_ORDER: Record<AdvisorySeverity, number> = {
 };
 
 export function isAffected(advisory: Advisory): boolean {
-  return advisory.match_status === "active";
+  return (
+    advisory.match_status === "active" || advisory.match_status === "error"
+  );
 }
 
 export function isAcknowledged(advisory: Advisory): boolean {

--- a/enterprise/frontend/src/metabase-enterprise/security_center/utils.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/utils.unit.spec.ts
@@ -1,7 +1,7 @@
 import type { Advisory } from "metabase-types/api";
 
 import type { AdvisoryFilter } from "./types";
-import { filterAdvisories, sortAdvisories } from "./utils";
+import { filterAdvisories, isAffected, sortAdvisories } from "./utils";
 
 const makeAdvisory = (overrides: Partial<Advisory>): Advisory => ({
   advisory_id: "SA-001",
@@ -24,6 +24,23 @@ const ALL_PASS_FILTER: AdvisoryFilter = {
   status: "all",
   showAcknowledged: true,
 };
+
+describe("isAffected", () => {
+  it("should return true for active advisories", () => {
+    expect(isAffected(makeAdvisory({ match_status: "active" }))).toBe(true);
+  });
+
+  it("should return true for error advisories (fail-open)", () => {
+    expect(isAffected(makeAdvisory({ match_status: "error" }))).toBe(true);
+  });
+
+  it.each(["not_affected", "resolved"] as const)(
+    "should return false for %s advisories",
+    (status) => {
+      expect(isAffected(makeAdvisory({ match_status: status }))).toBe(false);
+    },
+  );
+});
 
 describe("sortAdvisories", () => {
   it("should place affected items before non-affected items", () => {

--- a/frontend/src/metabase-types/api/mocks/security-center.ts
+++ b/frontend/src/metabase-types/api/mocks/security-center.ts
@@ -41,7 +41,7 @@ export function createMockSlackChannelSpec(
   };
 }
 
-export function createAdvisory(overrides: Partial<Advisory> = {}) {
+export function createAdvisory(overrides: Partial<Advisory> = {}): Advisory {
   return {
     advisory_id: "SA-001",
     title: "Test advisory",


### PR DESCRIPTION
Fixes GDGT-2183
- `isAffected()` now treats `error` match status as affected, per the matching engine spec's fail-open requirement
- Adds test coverage for `isAffected` across all match statuses