### PR TITLE
Fix alert modal footer button sizing mismatch (#71945)

### DIFF
--- a/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx
+++ b/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx
@@ -9,7 +9,6 @@ import {
   useSendUnsavedNotificationMutation,
   useUpdateNotificationMutation,
 } from "metabase/api";
-import { ActionButton } from "metabase/common/components/ActionButton";
 import CS from "metabase/css/core/index.css";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import { getResponseErrorMessage } from "metabase/lib/errors";
@@ -165,8 +164,10 @@ export const CreateOrEditQuestionAlertModal = ({
     useGetChannelInfoQuery();
   const { data: hookChannels } = useListChannelsQuery();
 
-  const [createNotification] = useCreateNotificationMutation();
-  const [updateNotification] = useUpdateNotificationMutation();
+  const [createNotification, { isLoading: isCreating }] =
+    useCreateNotificationMutation();
+  const [updateNotification, { isLoading: isUpdating }] =
+    useUpdateNotificationMutation();
   const [sendUnsavedNotification, { isLoading }] =
     useSendUnsavedNotificationMutation();
 
@@ -236,8 +237,7 @@ export const CreateOrEditQuestionAlertModal = ({
           }),
         );
 
-        // need to throw to show error in ActionButton
-        throw result.error;
+        return;
       }
 
       dispatch(
@@ -419,6 +419,7 @@ export const CreateOrEditQuestionAlertModal = ({
       </Stack>
       <Flex
         justify="space-between"
+        align="center"
         px="2.5rem"
         pt="lg"
         className={CS.borderTop}
@@ -431,16 +432,17 @@ export const CreateOrEditQuestionAlertModal = ({
         >
           {isLoading ? t`Sending…` : t`Send now`}
         </Button>
-        <div>
-          <Button onClick={onClose} className={CS.mr2}>{t`Cancel`}</Button>
-          <ActionButton
-            primary
-            disabled={!isValid}
-            actionFn={onCreateOrEditAlert}
+        <Flex align="center" gap="sm">
+          <Button onClick={onClose}>{t`Cancel`}</Button>
+          <Button
+            variant="filled"
+            disabled={!isValid || isCreating || isUpdating}
+            loading={isCreating || isUpdating}
+            onClick={onCreateOrEditAlert}
           >
             {isEditMode && hasChanges ? t`Save changes` : t`Done`}
-          </ActionButton>
-        </div>
+          </Button>
+        </Flex>
       </Flex>
     </Modal>
   );


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/71945

### Description

The footer of the alert creation modal had a sizing mismatch. `Done` would appear shorter than `Send now` and `Cancel` at narrow viewports, and taller at wide viewports. This is because `Send now` and `Cancel` both use a Mantine `Button` (fixed height) while `Done` used `ActionButton`, which wraps `metabase/common/components/Button` (an Emotion-based component the project is moving away from). That old button has responsive padding from `buttons.module.css` which fights against Mantine's layout.

I fixed it by replacing `ActionButton` with a Mantine `Button` wired to the `isCreating`/`isUpdating` loading states from the RTK Query mutations. I also swapped the wrapping `<div>` for a `<Flex align="center" gap="sm">` and added `align="center"` to the outer footer flex so both button groups stay vertically centered with each other.

Also removed a `throw result.error` that only existed to drive `ActionButton`'s internal error state since errors are already shown via the toast.

Before:

<img width="1328" height="152" alt="button-before-fix" src="https://github.com/user-attachments/assets/d98e66d7-6b5f-4f88-ba55-06ef057f1f0f" />

After:

<img width="1323" height="143" alt="button-after-fix" src="https://github.com/user-attachments/assets/eeaa9251-2602-46d2-a62e-ff571eb42bbc" />

Demo:

https://github.com/user-attachments/assets/2ce342e1-9a52-479a-a736-f026cd810b96

### Contributor License Agreement

This is my first contribution. I have submitted the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform).

### Checklist

- [ ] ~~Tests have been added/updated to cover changes in this PR~~ (N/A - pure component swap with no logic changes)
- [ ] ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~