### PR TITLE
Add Snowplow tracking for Security Center

### DIFF
--- a/e2e/test/scenarios/admin/security-center-snowplow.cy.spec.ts
+++ b/e2e/test/scenarios/admin/security-center-snowplow.cy.spec.ts
@@ -1,0 +1,30 @@
+const { H } = cy;
+
+describe("Security Center > Snowplow tracking", () => {
+  beforeEach(() => {
+    H.resetSnowplow();
+    H.restore();
+    cy.signInAsAdmin();
+    H.enableTracking();
+    H.mockSessionPropertiesTokenFeatures({
+      "admin-security-center": true,
+    });
+    // Stub the API so the page renders without a real EE backend
+    cy.intercept("GET", "/api/ee/security-center", {
+      last_checked_at: null,
+      advisories: [],
+    });
+  });
+
+  afterEach(() => {
+    H.expectNoBadSnowplowEvents();
+  });
+
+  it("should send a page viewed event when visiting the security center", () => {
+    cy.visit("/admin/security-center");
+    cy.findByRole("heading", { name: "Security Center" });
+    H.expectUnstructuredSnowplowEvent({
+      event: "security_center_page_viewed",
+    });
+  });
+});

--- a/enterprise/backend/src/metabase_enterprise/security_center/models/security_advisory.clj
+++ b/enterprise/backend/src/metabase_enterprise/security_center/models/security_advisory.clj
@@ -1,5 +1,6 @@
 (ns metabase-enterprise.security-center.models.security-advisory
   (:require
+   [metabase.analytics.snowplow :as snowplow]
    [metabase.events.core :as events]
    [metabase.models.interface :as mi]
    [methodical.core :as methodical]
@@ -49,5 +50,8 @@
     (events/publish-event! :event/security-advisory-acknowledge
                            {:object  advisory
                             :user-id user-id})
+    (snowplow/track-event! :snowplow/simple_event
+                           {:event        "security_advisory_acknowledged"
+                            :event_detail (name (:severity advisory))})
     (-> (t2/select-one :model/SecurityAdvisory :id (:id advisory))
         (t2/hydrate :acknowledged_by))))

--- a/enterprise/backend/src/metabase_enterprise/security_center/notification.clj
+++ b/enterprise/backend/src/metabase_enterprise/security_center/notification.clj
@@ -10,6 +10,7 @@
    included as a recipient when set."
   (:require
    [metabase-enterprise.security-center.settings :as settings]
+   [metabase.analytics.snowplow :as snowplow]
    [metabase.channel.settings :as channel.settings]
    [metabase.events.core :as events]
    [metabase.models.interface :as mi]
@@ -78,6 +79,23 @@
                   :event_topic :event/security-advisory-match}
    :handlers     (build-handlers)})
 
+(defn- configured-channels
+  "Return a set of channel keywords currently configured for notification delivery."
+  []
+  (cond-> #{}
+    (channel.settings/email-configured?) (conj :email)
+    (seq (slack-recipients))             (conj :slack)))
+
+(defn- track-notification-sent!
+  "Track a Snowplow event for each configured notification channel."
+  [triggered-from result]
+  (doseq [channel (configured-channels)]
+    (snowplow/track-event! :snowplow/simple_event
+                           {:event          "security_advisory_notification_sent"
+                            :event_detail   (name channel)
+                            :triggered_from triggered-from
+                            :result         result})))
+
 (def ^:private test-advisory
   "A synthetic advisory used for test notifications so admins can verify delivery."
   {:advisory_id      "TEST-0000"
@@ -99,21 +117,33 @@
       (throw (ex-info "No notification channels are configured."
                       {:status-code 400})))
     (log/info "Sending test security center notification")
-    (notification/send-notification! (build-notification test-advisory) :notification/sync? true)))
+    (try
+      (notification/send-notification! (build-notification test-advisory) :notification/sync? true)
+      (track-notification-sent! "test" "success")
+      (catch Exception e
+        (track-notification-sent! "test" "failure")
+        (throw e)))))
 
 (defn notify-advisory!
   "Send notifications for a security advisory and update `last_notified_at`.
    Publishes the system event for audit logging, then sends email (to admins or
    configured recipients) and Slack (to configured channel) via the notification
    pipeline."
-  [advisory]
-  (log/infof "Sending notification for advisory %s (severity=%s, status=%s)"
-             (:advisory_id advisory) (name (:severity advisory)) (name (:match_status advisory)))
-  ;; Publish event for audit log
-  (events/publish-event! :event/security-advisory-match
-                         (advisory-event-info advisory))
-  ;; Send email + Slack via notification pipeline
-  ;; sync, so failure doesn't set last_notified_at
-  (notification/send-notification! (build-notification advisory) :notification/sync? true)
-  (t2/update! :model/SecurityAdvisory (:id advisory)
-              {:last_notified_at (mi/now)}))
+  ([advisory]
+   (notify-advisory! advisory "scheduled"))
+  ([advisory triggered-from]
+   (log/infof "Sending notification for advisory %s (severity=%s, status=%s)"
+              (:advisory_id advisory) (name (:severity advisory)) (name (:match_status advisory)))
+   ;; Publish event for audit log
+   (events/publish-event! :event/security-advisory-match
+                          (advisory-event-info advisory))
+   ;; Send email + Slack via notification pipeline
+   ;; sync, so failure doesn't set last_notified_at
+   (try
+     (notification/send-notification! (build-notification advisory) :notification/sync? true)
+     (track-notification-sent! triggered-from "success")
+     (catch Exception e
+       (track-notification-sent! triggered-from "failure")
+       (throw e)))
+   (t2/update! :model/SecurityAdvisory (:id advisory)
+               {:last_notified_at (mi/now)})))

--- a/enterprise/backend/src/metabase_enterprise/security_center/notification.clj
+++ b/enterprise/backend/src/metabase_enterprise/security_center/notification.clj
@@ -79,20 +79,18 @@
                   :event_topic :event/security-advisory-match}
    :handlers     (build-handlers)})
 
-(defn- configured-channels
-  "Return a set of channel keywords currently configured for notification delivery."
-  []
-  (cond-> #{}
-    (channel.settings/email-configured?) (conj :email)
-    (seq (slack-recipients))             (conj :slack)))
+(def ^:private channel-type->name
+  "Map channel_type keywords to short names for Snowplow tracking."
+  {:channel/email "email"
+   :channel/slack "slack"})
 
 (defn- track-notification-sent!
-  "Track a Snowplow event for each configured notification channel."
-  [triggered-from result]
-  (doseq [channel (configured-channels)]
+  "Track a Snowplow event for each channel in the notification's handlers."
+  [notification triggered-from result]
+  (doseq [{:keys [channel_type]} (:handlers notification)]
     (snowplow/track-event! :snowplow/simple_event
                            {:event          "security_advisory_notification_sent"
-                            :event_detail   (name channel)
+                            :event_detail   (channel-type->name channel_type)
                             :triggered_from triggered-from
                             :result         result})))
 
@@ -117,12 +115,13 @@
       (throw (ex-info "No notification channels are configured."
                       {:status-code 400})))
     (log/info "Sending test security center notification")
-    (try
-      (notification/send-notification! (build-notification test-advisory) :notification/sync? true)
-      (track-notification-sent! "test" "success")
-      (catch Exception e
-        (track-notification-sent! "test" "failure")
-        (throw e)))))
+    (let [notif (build-notification test-advisory)]
+      (try
+        (notification/send-notification! notif :notification/sync? true)
+        (track-notification-sent! notif "test" "success")
+        (catch Exception e
+          (track-notification-sent! notif "test" "failure")
+          (throw e))))))
 
 (defn notify-advisory!
   "Send notifications for a security advisory and update `last_notified_at`.
@@ -139,11 +138,12 @@
                           (advisory-event-info advisory))
    ;; Send email + Slack via notification pipeline
    ;; sync, so failure doesn't set last_notified_at
-   (try
-     (notification/send-notification! (build-notification advisory) :notification/sync? true)
-     (track-notification-sent! triggered-from "success")
-     (catch Exception e
-       (track-notification-sent! triggered-from "failure")
-       (throw e)))
+   (let [notif (build-notification advisory)]
+     (try
+       (notification/send-notification! notif :notification/sync? true)
+       (track-notification-sent! notif triggered-from "success")
+       (catch Exception e
+         (track-notification-sent! notif triggered-from "failure")
+         (throw e))))
    (t2/update! :model/SecurityAdvisory (:id advisory)
                {:last_notified_at (mi/now)})))

--- a/enterprise/backend/src/metabase_enterprise/security_center/notification.clj
+++ b/enterprise/backend/src/metabase_enterprise/security_center/notification.clj
@@ -142,8 +142,8 @@
      (try
        (notification/send-notification! notif :notification/sync? true)
        (track-notification-sent! notif triggered-from "success")
+       (t2/update! :model/SecurityAdvisory (:id advisory)
+                   {:last_notified_at (mi/now)})
        (catch Exception e
          (track-notification-sent! notif triggered-from "failure")
-         (throw e))))
-   (t2/update! :model/SecurityAdvisory (:id advisory)
-               {:last_notified_at (mi/now)})))
+         (throw e))))))

--- a/enterprise/frontend/src/metabase-enterprise/security_center/analytics.ts
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/analytics.ts
@@ -1,0 +1,7 @@
+import { trackSimpleEvent } from "metabase/lib/analytics";
+
+export const trackSecurityCenterPageViewed = () => {
+  trackSimpleEvent({
+    event: "security_center_page_viewed",
+  });
+};

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.tsx
@@ -6,6 +6,7 @@ import { EmptyState } from "metabase/common/components/EmptyState";
 import { useSetting, useToast } from "metabase/common/hooks";
 import { Box, Button, Group, Icon, Stack, Text, Title } from "metabase/ui";
 
+import { trackSecurityCenterPageViewed } from "../../analytics";
 import {
   NotificationConfigProvider,
   useNotificationConfigState,
@@ -94,6 +95,10 @@ export function SecurityCenterPage() {
   }, [isPolling, lastCheckedAt, sendToast]);
 
   const isSyncInProgress = isSyncing || isPolling;
+
+  useEffect(() => {
+    trackSecurityCenterPageViewed();
+  }, []);
 
   const currentVersion = version?.tag ?? "";
   const targetVersion = getTargetUpgradeVersion(advisories);

--- a/frontend/src/metabase-types/analytics/event.ts
+++ b/frontend/src/metabase-types/analytics/event.ts
@@ -733,6 +733,10 @@ export type UnsavedChangesWarningDisplayedEvent = ValidateEvent<{
   target_id: number | null;
 }>;
 
+export type SecurityCenterPageViewedEvent = ValidateEvent<{
+  event: "security_center_page_viewed";
+}>;
+
 export type SimpleEvent =
   | CustomSMTPSetupClickedEvent
   | CustomSMTPSetupSuccessEvent
@@ -792,4 +796,5 @@ export type SimpleEvent =
   | RemoteSyncEvent
   | ClickActionPerformedEvent
   | DataStudioEvent
-  | UnsavedChangesWarningDisplayedEvent;
+  | UnsavedChangesWarningDisplayedEvent
+  | SecurityCenterPageViewedEvent;


### PR DESCRIPTION
- Track 3 events using the existing `simple_event` schema (no new schemas needed):
  - `security_center_page_viewed` (FE) — fires on page mount
  - `security_advisory_acknowledged` (BE) — fires when admin acknowledges an advisory, includes severity
  - `security_advisory_notification_sent` (BE) — fires per channel (email/slack) on both real and test notifications, includes result and trigger source
  
  
Closes https://linear.app/metabase/issue/GDGT-2179/add-analytics-around-security-center