### PR TITLE
Add testing endpoint for security advisories

### DIFF
--- a/e2e/support/helpers/api/index.ts
+++ b/e2e/support/helpers/api/index.ts
@@ -28,6 +28,8 @@ export type {
 export { createQuestionAndAddToDashboard } from "./createQuestionAndAddToDashboard";
 export { createQuestionAndDashboard } from "./createQuestionAndDashboard";
 export { createReaction } from "./createReaction";
+export { seedSecurityAdvisories } from "./seedSecurityAdvisories";
+export type { SecurityAdvisorySpec } from "./seedSecurityAdvisories";
 export { createSnippet } from "./createSnippet";
 export { createSnippetFolder } from "./createSnippetFolder";
 export { createTestQuery, createTestNativeQuery } from "./createTestQuery";

--- a/e2e/support/helpers/api/seedSecurityAdvisories.ts
+++ b/e2e/support/helpers/api/seedSecurityAdvisories.ts
@@ -1,0 +1,21 @@
+export type SecurityAdvisorySpec = {
+  advisory_id: string;
+  severity: "critical" | "high" | "medium" | "low";
+  title: string;
+  description: string;
+  remediation: string;
+  advisory_url?: string | null;
+  affected_versions: { min: string; fixed: string }[];
+  matching_query?: Record<string, string> | null;
+  match_status: "unknown" | "active" | "resolved" | "not_affected" | "error";
+  published_at: string;
+  updated_at?: string;
+};
+
+export function seedSecurityAdvisories(
+  advisories: SecurityAdvisorySpec[],
+): Cypress.Chainable {
+  return cy.request("POST", "/api/testing/security-advisories", {
+    advisories,
+  });
+}

--- a/e2e/test/scenarios/admin-2/security-center.cy.spec.ts
+++ b/e2e/test/scenarios/admin-2/security-center.cy.spec.ts
@@ -1,0 +1,284 @@
+const { H } = cy;
+
+const ADVISORIES = {
+  critical: {
+    advisory_id: "TEST-001",
+    severity: "critical",
+    title: "Critical RCE vulnerability",
+    description: "Remote code execution via crafted input.",
+    remediation: "Upgrade to 0.59.5",
+    advisory_url: "https://example.com/advisory/TEST-001",
+    affected_versions: [{ min: "0.58.0", fixed: "0.59.5" }],
+    match_status: "active",
+    published_at: "2026-03-20T00:00:00Z",
+    updated_at: "2026-03-20T00:00:00Z",
+  },
+  high: {
+    advisory_id: "TEST-002",
+    severity: "high",
+    title: "SQL injection in query builder",
+    description: "Postgres databases are vulnerable to SQL injection.",
+    remediation: "Upgrade to 0.58.8",
+    affected_versions: [{ min: "0.54.0", fixed: "0.58.8" }],
+    match_status: "resolved",
+    published_at: "2026-03-15T00:00:00Z",
+    updated_at: "2026-03-15T00:00:00Z",
+  },
+  medium: {
+    advisory_id: "TEST-003",
+    severity: "medium",
+    title: "SSRF in GeoJSON endpoint",
+    description: "Custom GeoJSON endpoints can be used for SSRF.",
+    remediation: "Upgrade to 0.58.7",
+    affected_versions: [{ min: "0.50.0", fixed: "0.58.7" }],
+    match_status: "not_affected",
+    published_at: "2026-03-10T00:00:00Z",
+    updated_at: "2026-03-10T00:00:00Z",
+  },
+} as const;
+
+function seedAllAdvisories() {
+  H.seedSecurityAdvisories([
+    ADVISORIES.critical,
+    ADVISORIES.high,
+    ADVISORIES.medium,
+  ]);
+}
+
+function securityCenterContent() {
+  return cy.findByTestId("security-center-page");
+}
+
+describe("scenarios > admin > security center", { tags: "@EE" }, () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+    H.activateToken("pro-self-hosted");
+  });
+
+  describe("feature gating", () => {
+    it("should not show security center without a valid token", () => {
+      H.deleteToken();
+      cy.visit("/admin/security-center");
+      cy.findByTestId("security-center-page").should("not.exist");
+    });
+
+    it("should render the security center page with a valid token", () => {
+      seedAllAdvisories();
+      cy.visit("/admin/security-center");
+      securityCenterContent().within(() => {
+        cy.findByText("Security Center").should("be.visible");
+        cy.findByTestId("current-version").should("be.visible");
+      });
+    });
+  });
+
+  describe("advisory list", () => {
+    beforeEach(() => {
+      seedAllAdvisories();
+      cy.visit("/admin/security-center");
+      securityCenterContent().within(() => {
+        cy.findByText("Security Center").should("be.visible");
+      });
+    });
+
+    it("should display advisory cards with severity and affected status", () => {
+      cy.findAllByTestId("advisory-card").should("have.length", 3);
+      securityCenterContent().within(() => {
+        cy.findByText("Critical RCE vulnerability").should("be.visible");
+        cy.findByText("SQL injection in query builder").should("be.visible");
+        cy.findByText("SSRF in GeoJSON endpoint")
+          .scrollIntoView()
+          .should("be.visible");
+      });
+    });
+
+    it("should sort advisories with affected first, then by severity", () => {
+      cy.findAllByTestId("advisory-card")
+        .first()
+        .within(() => {
+          cy.findByText("Critical RCE vulnerability").should("exist");
+          cy.findByTestId("affected-status").should("have.text", "Affected");
+        });
+    });
+
+    it("should show empty state when no advisories exist", () => {
+      // Don't seed any — restore already cleared them
+      H.restore();
+      cy.signInAsAdmin();
+      H.activateToken("pro-self-hosted");
+      cy.visit("/admin/security-center");
+      securityCenterContent().within(() => {
+        cy.findByText(/up to date/).should("be.visible");
+      });
+    });
+  });
+
+  describe("filtering", () => {
+    beforeEach(() => {
+      seedAllAdvisories();
+      cy.visit("/admin/security-center");
+      securityCenterContent().within(() => {
+        cy.findByText("Security Center").should("be.visible");
+      });
+    });
+
+    it("should filter by severity", () => {
+      cy.findByTestId("severity-filter").click();
+      cy.findByRole("option", { name: "Critical" }).click();
+      cy.findAllByTestId("advisory-card").should("have.length", 1);
+      securityCenterContent().within(() => {
+        cy.findByText("Critical RCE vulnerability").should("be.visible");
+      });
+    });
+
+    it("should filter by affected status", () => {
+      cy.findByTestId("status-filter").click();
+      cy.findByRole("option", { name: "Affected" }).click();
+      cy.findAllByTestId("advisory-card").should("have.length", 1);
+      securityCenterContent().within(() => {
+        cy.findByText("Critical RCE vulnerability").should("be.visible");
+      });
+    });
+
+    it("should toggle show acknowledged", () => {
+      // Acknowledge the critical advisory first
+      cy.findAllByTestId("advisory-card")
+        .first()
+        .findByTestId("acknowledge-button")
+        .click();
+
+      // It should be hidden by default (acknowledged are hidden)
+      cy.findAllByTestId("advisory-card").should("have.length", 2);
+
+      // Show acknowledged
+      cy.findByTestId("show-acknowledged-filter").click();
+      cy.findAllByTestId("advisory-card").should("have.length", 3);
+    });
+  });
+
+  describe("acknowledge advisory", () => {
+    beforeEach(() => {
+      seedAllAdvisories();
+      cy.visit("/admin/security-center");
+      securityCenterContent().within(() => {
+        cy.findByText("Security Center").should("be.visible");
+      });
+    });
+
+    it("should acknowledge an advisory and show the badge", () => {
+      cy.intercept("POST", "/api/ee/security-center/*/acknowledge").as(
+        "acknowledge",
+      );
+
+      cy.findAllByTestId("advisory-card")
+        .first()
+        .findByTestId("acknowledge-button")
+        .click();
+
+      cy.wait("@acknowledge");
+
+      cy.findByTestId("show-acknowledged-filter").click();
+      cy.findAllByTestId("advisory-card")
+        .first()
+        .findByTestId("acknowledged-badge")
+        .should("have.text", "Acknowledged");
+    });
+
+    it("should hide acknowledged advisories by default", () => {
+      cy.findAllByTestId("advisory-card")
+        .first()
+        .findByTestId("acknowledge-button")
+        .click();
+
+      // After acknowledging, the card should disappear
+      cy.findAllByTestId("advisory-card").should("have.length", 2);
+    });
+  });
+
+  describe("navigation and badge", () => {
+    it("should show Security nav item with badge when active advisories exist", () => {
+      seedAllAdvisories();
+      cy.visit("/admin/security-center");
+      cy.findByTestId("admin-navbar").within(() => {
+        cy.findByText("Security").should("be.visible");
+      });
+      cy.findByTestId("security-center-badge").should("be.visible");
+    });
+
+    it("should navigate to security center when clicking nav item", () => {
+      seedAllAdvisories();
+      cy.visit("/admin");
+      cy.findByTestId("admin-navbar").within(() => {
+        cy.findByText("Security").click();
+      });
+      cy.url().should("include", "/admin/security-center");
+      securityCenterContent().within(() => {
+        cy.findByText("Security Center").should("be.visible");
+      });
+    });
+  });
+
+  describe("notification settings modal", () => {
+    beforeEach(() => {
+      seedAllAdvisories();
+      cy.visit("/admin/security-center");
+      securityCenterContent().within(() => {
+        cy.findByText("Security Center").should("be.visible");
+      });
+    });
+
+    it("should open the notification settings modal", () => {
+      cy.findByTestId("notification-config-toggle").click();
+      H.modal().within(() => {
+        cy.findByText("Notification settings").should("be.visible");
+        cy.findByText("Email").should("be.visible");
+        cy.findByText("Slack").should("be.visible");
+      });
+    });
+
+    it("should show send-to-all-admins toggle checked by default", () => {
+      H.setupSMTP();
+      cy.visit("/admin/security-center");
+      securityCenterContent().within(() => {
+        cy.findByText("Security Center").should("be.visible");
+      });
+      cy.findByTestId("notification-config-toggle").click();
+      cy.findByTestId("send-to-admins-toggle").should("be.checked");
+    });
+
+    it("should show Slack not configured state", () => {
+      cy.findByTestId("notification-config-toggle").click();
+      H.modal().within(() => {
+        cy.findByText("Slack is not configured.").should("be.visible");
+        cy.findByText("Set up Slack").should("be.visible");
+      });
+    });
+
+    it("should save notification settings", () => {
+      cy.intercept("PUT", "/api/setting").as("saveSettings");
+
+      cy.findByTestId("notification-config-toggle").click();
+      cy.findByRole("button", { name: "Save" }).click();
+
+      cy.wait("@saveSettings").then(({ request }) => {
+        expect(request.body).to.have.property(
+          "security-center-email-recipients",
+        );
+      });
+    });
+  });
+
+  describe("sync", () => {
+    it("should trigger sync when clicking Check now", () => {
+      cy.intercept("POST", "/api/ee/security-center/sync").as("sync");
+      cy.visit("/admin/security-center");
+      securityCenterContent().within(() => {
+        cy.findByText("Security Center").should("be.visible");
+      });
+
+      cy.findByTestId("sync-advisories").click();
+      cy.wait("@sync");
+    });
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.tsx
@@ -103,7 +103,7 @@ export function SecurityCenterPage() {
 
   return (
     <NotificationConfigProvider value={notificationConfig}>
-      <Box className={S.root}>
+      <Box className={S.root} data-testid="security-center-page">
         <Stack gap="lg" className={S.header}>
           <Group gap="sm" align="center">
             <Title order={1}>{t`Security Center`}</Title>

--- a/src/metabase/testing_api/api.clj
+++ b/src/metabase/testing_api/api.clj
@@ -266,8 +266,7 @@
    {:keys [advisories]} :- [:map
                             [:advisories [:sequential :map]]]]
   (t2/delete! :model/SecurityAdvisory)
-  (t2/insert! :model/SecurityAdvisory advisories)
-  {:inserted (count advisories)})
+  (t2/insert-returning-instances! :model/SecurityAdvisory advisories))
 
 (api.macros/defendpoint :post "/native-query" :- ::lib.schema/query
   "Creates a native query from a test query spec."

--- a/src/metabase/testing_api/api.clj
+++ b/src/metabase/testing_api/api.clj
@@ -266,8 +266,7 @@
    {:keys [advisories]} :- [:map
                             [:advisories [:sequential :map]]]]
   (t2/delete! :model/SecurityAdvisory)
-  (doseq [advisory advisories]
-    (t2/insert! :model/SecurityAdvisory advisory))
+  (t2/insert! :model/SecurityAdvisory advisories)
   {:inserted (count advisories)})
 
 (api.macros/defendpoint :post "/native-query" :- ::lib.schema/query

--- a/src/metabase/testing_api/api.clj
+++ b/src/metabase/testing_api/api.clj
@@ -267,7 +267,7 @@
    [:advisory_url      {:optional true} [:maybe ms/NonBlankString]]
    [:remediation       ms/NonBlankString]
    [:affected_versions [:sequential [:map [:min :string] [:fixed :string]]]]
-   [:matching_query    {:optional true} [:maybe [:map-of :keyword :map]]]
+   [:matching_query    {:optional true} [:maybe [:map-of :keyword :string]]]
    [:match_status      [:enum "unknown" "active" "resolved" "not_affected" "error"]]
    [:published_at      :any]
    [:updated_at        :any]])

--- a/src/metabase/testing_api/api.clj
+++ b/src/metabase/testing_api/api.clj
@@ -257,14 +257,28 @@
   (-> (lib-be/application-database-metadata-provider database)
       (lib/test-query query-spec)))
 
+(def ^:private TestAdvisory
+  "Schema for a single advisory in the testing seed endpoint."
+  [:map
+   [:advisory_id       ms/NonBlankString]
+   [:title             ms/NonBlankString]
+   [:severity          [:enum "critical" "high" "medium" "low"]]
+   [:description       ms/NonBlankString]
+   [:advisory_url      {:optional true} [:maybe ms/NonBlankString]]
+   [:remediation       ms/NonBlankString]
+   [:affected_versions [:sequential [:map [:min :string] [:fixed :string]]]]
+   [:matching_query    {:optional true} [:maybe [:map-of :keyword :map]]]
+   [:match_status      [:enum "unknown" "active" "resolved" "not_affected" "error"]]
+   [:published_at      :any]
+   [:updated_at        :any]])
+
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :post "/security-advisories"
-  "Nuke all existing security advisories and insert the provided ones.
-   Expects a JSON body with an `advisories` key containing an array of advisory objects."
+  "Nuke all existing security advisories and insert the provided ones."
   [_route-params
    _query-params
    {:keys [advisories]} :- [:map
-                            [:advisories [:sequential :map]]]]
+                            [:advisories [:sequential TestAdvisory]]]]
   (t2/delete! :model/SecurityAdvisory)
   (t2/insert-returning-instances! :model/SecurityAdvisory advisories))
 

--- a/src/metabase/testing_api/api.clj
+++ b/src/metabase/testing_api/api.clj
@@ -257,6 +257,19 @@
   (-> (lib-be/application-database-metadata-provider database)
       (lib/test-query query-spec)))
 
+#_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
+(api.macros/defendpoint :post "/security-advisories"
+  "Nuke all existing security advisories and insert the provided ones.
+   Expects a JSON body with an `advisories` key containing an array of advisory objects."
+  [_route-params
+   _query-params
+   {:keys [advisories]} :- [:map
+                            [:advisories [:sequential :map]]]]
+  (t2/delete! :model/SecurityAdvisory)
+  (doseq [advisory advisories]
+    (t2/insert! :model/SecurityAdvisory advisory))
+  {:inserted (count advisories)})
+
 (api.macros/defendpoint :post "/native-query" :- ::lib.schema/query
   "Creates a native query from a test query spec."
   [_route-params


### PR DESCRIPTION
- Adds `POST /api/testing/security-advisories` endpoint that deletes all existing advisories and inserts the provided ones
- Gated by the existing `enable-testing-routes?` flag (dev/test only)