### PR TITLE
Fix flaky metrics-editing.cy.spec.js test

### DIFF
--- a/e2e/test/scenarios/metrics/metrics-editing.cy.spec.js
+++ b/e2e/test/scenarios/metrics/metrics-editing.cy.spec.js
@@ -229,13 +229,14 @@ describe("scenarios > metrics > editing", () => {
 
     it("should be able to change the query definition of a metric based on a model", () => {
       cy.intercept("PUT", "/api/card/*").as("updateCard");
+      cy.intercept("GET", "/api/card/*").as("getCard");
       H.createQuestion(ORDERS_SCALAR_MODEL_METRIC).then(({ body: card }) =>
         cy.visit(`/metric/${card.id}/query`),
       );
       H.MetricPage.queryEditor().should("be.visible");
       addBreakout({ tableName: "Product", columnName: "Created At" });
       H.MetricPage.saveButton().click();
-      cy.wait("@updateCard");
+      cy.wait(["@updateCard", "@getCard", "@getCard"]);
       H.MetricPage.aboutTab().click();
       verifyLineAreaBarChart({
         xAxis: "Product → Created At: Month",


### PR DESCRIPTION
Fix EMB-1546

It fails because Metabase thinks it's still dirty when navigating away. The fix is to wait for proper API calls.

<img width="2450" height="1548" alt="image" src="https://github.com/user-attachments/assets/a550861b-641d-450f-a848-c52052118865" />


Only backport to 60, because I couldn't find [it fails on 59 on trunk](https://app.trunk.io/metabase/flaky-tests/test/8b293adb-dbab-5ecc-8239-9490263a1f46?repo=metabase/metabase)

[Stress test master](https://github.com/metabase/metabase/actions/runs/23948606337): 0/20 ❌
[Stress test PR](https://github.com/metabase/metabase/actions/runs/23948607283): 20/20 ✅ 
