### PR TITLE
GDGT-2117: Show custom viz icon everywhere

### DIFF
--- a/frontend/src/metabase/browse/models/ModelsTable.tsx
+++ b/frontend/src/metabase/browse/models/ModelsTable.tsx
@@ -225,7 +225,7 @@ function NameCell({ model }: { model?: ModelResult }) {
         onClick={preventDefault}
       >
         <EntityIcon
-          size={16}
+          size="1rem"
           {...icon}
           color="icon-brand"
           style={{ flexShrink: 0 }}

--- a/frontend/src/metabase/browse/models/ModelsTable.tsx
+++ b/frontend/src/metabase/browse/models/ModelsTable.tsx
@@ -5,6 +5,7 @@ import { t } from "ttag";
 
 import { getCollectionName } from "metabase/collections/utils";
 import { EllipsifiedCollectionPath } from "metabase/common/components/EllipsifiedPath/EllipsifiedCollectionPath";
+import { EntityIcon } from "metabase/common/components/EntityIcon";
 import { EntityItem } from "metabase/common/components/EntityItem";
 import { SortableColumnHeader } from "metabase/common/components/ItemsTable/BaseItemsTable";
 import {
@@ -25,7 +26,6 @@ import {
   Ellipsified,
   FixedSizeIcon,
   Flex,
-  Icon,
   Repeat,
   Skeleton,
 } from "metabase/ui";
@@ -224,7 +224,12 @@ function NameCell({ model }: { model?: ModelResult }) {
         }}
         onClick={preventDefault}
       >
-        <Icon size={16} {...icon} c="icon-brand" style={{ flexShrink: 0 }} />
+        <EntityIcon
+          size={16}
+          {...icon}
+          color="icon-brand"
+          style={{ flexShrink: 0 }}
+        />
         {
           <EntityItem.Name
             name={model?.name || ""}

--- a/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.tsx
@@ -131,7 +131,7 @@ function PinnedItemCard({
             {iconData.iconUrl ? (
               <EntityIcon
                 {...iconData}
-                size={24}
+                size="1.5rem"
                 style={{ color: "var(--mb-color-brand)" }}
               />
             ) : (

--- a/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.tsx
@@ -28,7 +28,6 @@ import {
   Description,
   Header,
   ItemCard,
-  ItemIcon,
   ItemLink,
   Title,
 } from "./PinnedItemCard.styled";
@@ -128,15 +127,7 @@ function PinnedItemCard({
       <ItemCard flat>
         <Body>
           <Header>
-            {iconData.iconUrl ? (
-              <EntityIcon
-                {...iconData}
-                size="1.5rem"
-                style={{ color: "var(--mb-color-brand)" }}
-              />
-            ) : (
-              <ItemIcon name={iconData.name} />
-            )}
+            <EntityIcon {...iconData} size="1.5rem" color="brand" />
             <ActionsContainer h={item ? undefined : "2rem"}>
               {hasActions && (
                 // This component is used within a `<Link>` component,

--- a/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.tsx
@@ -7,6 +7,7 @@ import type {
   CreateBookmark,
   DeleteBookmark,
 } from "metabase/collections/types";
+import { EntityIcon } from "metabase/common/components/EntityIcon";
 import { EventSandbox } from "metabase/common/components/EventSandbox";
 import { getIcon } from "metabase/lib/icon";
 import { modelToUrl } from "metabase/lib/urls";
@@ -94,12 +95,13 @@ function PinnedItemCard({
   iconForSkeleton,
 }: PinnedItemCardProps) {
   const [showTitleTooltip, setShowTitleTooltip] = useState(false);
-  const icon =
-    iconForSkeleton ??
-    getIcon({
-      model: item.model,
-      moderated_status: item.moderated_status,
-    }).name;
+  const iconData = iconForSkeleton
+    ? { name: iconForSkeleton }
+    : getIcon({
+        model: item.model,
+        display: item.display,
+        moderated_status: item.moderated_status,
+      });
 
   const maybeEnableTooltip = (
     event: MouseEvent<HTMLDivElement>,
@@ -126,7 +128,15 @@ function PinnedItemCard({
       <ItemCard flat>
         <Body>
           <Header>
-            <ItemIcon name={icon as unknown as IconName} />
+            {iconData.iconUrl ? (
+              <EntityIcon
+                {...iconData}
+                size={24}
+                style={{ color: "var(--mb-color-brand)" }}
+              />
+            ) : (
+              <ItemIcon name={iconData.name} />
+            )}
             <ActionsContainer h={item ? undefined : "2rem"}>
               {hasActions && (
                 // This component is used within a `<Link>` component,

--- a/frontend/src/metabase/common/components/EntityIcon/EntityIcon.tsx
+++ b/frontend/src/metabase/common/components/EntityIcon/EntityIcon.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties } from "react";
+import type { CSSProperties, ImgHTMLAttributes } from "react";
 
 import type { IconData } from "metabase/lib/icon";
 import { Icon, type IconProps } from "metabase/ui";
@@ -10,7 +10,8 @@ export type EntityIconProps = Omit<IconProps, "name" | "color"> & {
   color?: ColorName | "inherit";
   size?: string | number;
   style?: CSSProperties;
-};
+  alt?: string;
+} & Omit<ImgHTMLAttributes<HTMLImageElement>, keyof IconProps>;
 
 /**
  * Renders either a custom visualization icon (via iconUrl) or a standard
@@ -23,17 +24,17 @@ export function EntityIcon({
   size = "1rem",
   color,
   style,
+  alt = "",
   ...rest
 }: EntityIconProps) {
   if (iconUrl) {
     return (
       <img
+        {...(rest as ImgHTMLAttributes<HTMLImageElement>)}
+        aria-hidden={alt ? undefined : "true"}
         src={iconUrl}
-        alt=""
-        width={size}
-        height={size}
-        style={style}
-        aria-hidden="true"
+        alt={alt}
+        style={{ ...style, width: size, height: size }}
       />
     );
   }

--- a/frontend/src/metabase/common/components/EntityIcon/EntityIcon.tsx
+++ b/frontend/src/metabase/common/components/EntityIcon/EntityIcon.tsx
@@ -28,13 +28,14 @@ export function EntityIcon({
   ...rest
 }: EntityIconProps) {
   if (iconUrl) {
+    // color is intentionally not applied — CSS color has no effect on <img>
     return (
       <img
-        {...(rest as ImgHTMLAttributes<HTMLImageElement>)}
         aria-hidden={alt ? undefined : "true"}
         src={iconUrl}
         alt={alt}
         style={{ ...style, width: size, height: size }}
+        {...(rest as ImgHTMLAttributes<HTMLImageElement>)}
       />
     );
   }

--- a/frontend/src/metabase/common/components/EntityIcon/EntityIcon.tsx
+++ b/frontend/src/metabase/common/components/EntityIcon/EntityIcon.tsx
@@ -1,0 +1,50 @@
+import type { CSSProperties } from "react";
+
+import type { IconData } from "metabase/lib/icon";
+import { Icon, type IconProps } from "metabase/ui";
+import type { ColorName } from "metabase/ui/colors";
+
+export type EntityIconProps = Omit<IconProps, "name" | "color"> & {
+  name?: IconData["name"];
+  iconUrl?: string;
+  color?: ColorName | "inherit";
+  size?: number;
+  style?: CSSProperties;
+};
+
+/**
+ * Renders either a custom visualization icon (via iconUrl) or a standard
+ * Metabase Icon (via name).  Drop-in replacement for `<Icon {...iconData} />`
+ * wherever iconUrl may be present.
+ */
+export function EntityIcon({
+  iconUrl,
+  name = "unknown",
+  size = 16,
+  color,
+  style,
+  ...rest
+}: EntityIconProps) {
+  if (iconUrl) {
+    return (
+      <img
+        src={iconUrl}
+        alt=""
+        width={size}
+        height={size}
+        style={style}
+        aria-hidden="true"
+      />
+    );
+  }
+
+  return (
+    <Icon
+      name={name}
+      size={size}
+      color={color as ColorName}
+      style={style}
+      {...rest}
+    />
+  );
+}

--- a/frontend/src/metabase/common/components/EntityIcon/EntityIcon.tsx
+++ b/frontend/src/metabase/common/components/EntityIcon/EntityIcon.tsx
@@ -8,7 +8,7 @@ export type EntityIconProps = Omit<IconProps, "name" | "color"> & {
   name?: IconData["name"];
   iconUrl?: string;
   color?: ColorName | "inherit";
-  size?: number;
+  size?: string | number;
   style?: CSSProperties;
 };
 
@@ -20,7 +20,7 @@ export type EntityIconProps = Omit<IconProps, "name" | "color"> & {
 export function EntityIcon({
   iconUrl,
   name = "unknown",
-  size = 16,
+  size = "1rem",
   color,
   style,
   ...rest

--- a/frontend/src/metabase/common/components/EntityIcon/index.ts
+++ b/frontend/src/metabase/common/components/EntityIcon/index.ts
@@ -1,0 +1,1 @@
+export { EntityIcon, type EntityIconProps } from "./EntityIcon";

--- a/frontend/src/metabase/common/components/EntityItem/EntityItem.tsx
+++ b/frontend/src/metabase/common/components/EntityItem/EntityItem.tsx
@@ -22,12 +22,14 @@ import {
   isPreviewShown,
 } from "metabase/collections/utils";
 import { CheckBox } from "metabase/common/components/CheckBox";
+import { EntityIcon } from "metabase/common/components/EntityIcon";
 import { EntityMenu } from "metabase/common/components/EntityMenu";
 import { Swapper } from "metabase/common/components/Swapper";
 import CS from "metabase/css/core/index.css";
+import type { IconData } from "metabase/lib/icon";
 import * as Urls from "metabase/lib/urls";
 import type { IconName, IconProps } from "metabase/ui";
-import { Ellipsified, Icon } from "metabase/ui";
+import { Ellipsified } from "metabase/ui";
 import type { CollectionItem } from "metabase-types/api";
 
 import {
@@ -40,7 +42,7 @@ import {
 
 type EntityIconCheckBoxProps = {
   variant?: string;
-  icon: IconProps;
+  icon: IconProps | IconData;
   pinned?: boolean;
   selectable?: boolean;
   selected?: boolean;
@@ -78,9 +80,9 @@ const EntityIconCheckBox = ({
       {selectable ? (
         <Swapper
           defaultElement={
-            <Icon
-              name={icon.name}
-              c={icon.color ?? "inherit"}
+            <EntityIcon
+              {...icon}
+              color={icon.color ?? "inherit"}
               size={iconSize}
             />
           }
@@ -88,7 +90,7 @@ const EntityIconCheckBox = ({
           isSwapped={selected || showCheckbox}
         />
       ) : (
-        <Icon name={icon.name} c={icon.color ?? "inherit"} size={iconSize} />
+        <EntityIcon {...icon} color={icon.color ?? "inherit"} size={iconSize} />
       )}
     </EntityIconWrapper>
   );

--- a/frontend/src/metabase/common/components/Pickers/EntityPicker/components/ItemLists/ItemList.tsx
+++ b/frontend/src/metabase/common/components/Pickers/EntityPicker/components/ItemLists/ItemList.tsx
@@ -1,6 +1,7 @@
 import type React from "react";
 import { useMemo } from "react";
 
+import { EntityIcon } from "metabase/common/components/EntityIcon";
 import { VirtualizedList } from "metabase/common/components/VirtualizedList";
 import { useTranslateContent } from "metabase/i18n/hooks";
 import { useSelector } from "metabase/lib/redux";
@@ -130,7 +131,7 @@ export function ItemList({
                 </Flex>
               }
               active={isSelected}
-              leftSection={<Icon {...icon} />}
+              leftSection={<EntityIcon {...icon} />}
               onClick={(e: React.MouseEvent) => {
                 e.preventDefault(); // prevent form submission
                 e.stopPropagation(); // prevent parent onClick

--- a/frontend/src/metabase/common/components/Pickers/EntityPicker/components/ItemLists/SearchResults.tsx
+++ b/frontend/src/metabase/common/components/Pickers/EntityPicker/components/ItemLists/SearchResults.tsx
@@ -100,7 +100,7 @@ export const SearchResults = ({
               leftSection={
                 <EntityIcon
                   {...getEntityPickerIcon(item, { isSelected })}
-                  size={16}
+                  size="1rem"
                 />
               }
               onClick={(e: React.MouseEvent) => {

--- a/frontend/src/metabase/common/components/Pickers/EntityPicker/components/ItemLists/SearchResults.tsx
+++ b/frontend/src/metabase/common/components/Pickers/EntityPicker/components/ItemLists/SearchResults.tsx
@@ -1,6 +1,7 @@
 import { t } from "ttag";
 
 import { EmptyState } from "metabase/common/components/EmptyState";
+import { EntityIcon } from "metabase/common/components/EntityIcon";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { VirtualizedList } from "metabase/common/components/VirtualizedList";
 import { NoObjectError } from "metabase/common/components/errors/NoObjectError";
@@ -97,7 +98,7 @@ export const SearchResults = ({
               }
               active={isSelected}
               leftSection={
-                <Icon
+                <EntityIcon
                   {...getEntityPickerIcon(item, { isSelected })}
                   size={16}
                 />

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItem.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItem.tsx
@@ -1,3 +1,4 @@
+import { EntityIcon } from "metabase/common/components/EntityIcon";
 import { getIcon } from "metabase/lib/icon";
 import { Ellipsified } from "metabase/ui";
 import { Box, Icon, Menu, type MenuItemProps } from "metabase/ui";
@@ -27,7 +28,7 @@ export const MiniPickerItem = ({
     <Box px="sm" py="2px">
       <Menu.Item
         leftSection={
-          model ? <Icon {...getIcon({ model, display })} /> : undefined
+          model ? <EntityIcon {...getIcon({ model, display })} /> : undefined
         }
         rightSection={isFolder ? <Icon name="chevronright" /> : undefined}
         onClick={onClick}

--- a/frontend/src/metabase/common/components/SelectList/SelectListItem.tsx
+++ b/frontend/src/metabase/common/components/SelectList/SelectListItem.tsx
@@ -1,6 +1,7 @@
 import cx from "classnames";
 import _ from "underscore";
 
+import { EntityIcon } from "metabase/common/components/EntityIcon";
 import type { IconProps } from "metabase/ui";
 import { Ellipsified } from "metabase/ui";
 
@@ -11,7 +12,7 @@ import { ItemIcon, ItemRoot, ItemTitle } from "./SelectListItem.styled";
 export interface SelectListItemProps
   extends Omit<BaseSelectListItemProps, "children"> {
   name: string;
-  icon?: string | IconProps;
+  icon?: string | IconProps | (IconProps & { iconUrl?: string });
   rightIcon?: string | IconProps;
   children?: React.ReactNode;
   classNames?: {
@@ -34,6 +35,8 @@ export function SelectListItem({
 }: SelectListItemProps) {
   const iconProps = getIconProps(icon);
   const rightIconProps = getIconProps(rightIcon);
+  const iconUrl =
+    _.isObject(icon) && "iconUrl" in icon ? icon.iconUrl : undefined;
 
   return (
     <BaseSelectListItem
@@ -45,9 +48,18 @@ export function SelectListItem({
       hasLeftIcon={!!icon}
       hasRightIcon={!!rightIcon}
     >
-      {icon && (
-        <ItemIcon className={classNames.icon} c="brand" {...iconProps} />
-      )}
+      {icon &&
+        (iconUrl ? (
+          <EntityIcon
+            name={iconProps.name}
+            iconUrl={iconUrl}
+            size={iconProps.size as number}
+            className={classNames.icon}
+            color="brand"
+          />
+        ) : (
+          <ItemIcon className={classNames.icon} c="brand" {...iconProps} />
+        ))}
       <ItemTitle
         className={classNames.label}
         fw="bold"

--- a/frontend/src/metabase/common/components/SelectList/SelectListItem.tsx
+++ b/frontend/src/metabase/common/components/SelectList/SelectListItem.tsx
@@ -48,18 +48,14 @@ export function SelectListItem({
       hasLeftIcon={!!icon}
       hasRightIcon={!!rightIcon}
     >
-      {icon &&
-        (iconUrl ? (
-          <EntityIcon
-            name={iconProps.name}
-            iconUrl={iconUrl}
-            size={iconProps.size as number}
-            className={classNames.icon}
-            color="brand"
-          />
-        ) : (
-          <ItemIcon className={classNames.icon} c="brand" {...iconProps} />
-        ))}
+      {icon && (
+        <EntityIcon
+          {...iconProps}
+          iconUrl={iconUrl}
+          className={classNames.icon}
+          color="brand"
+        />
+      )}
       <ItemTitle
         className={classNames.label}
         fw="bold"

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/QuestionList.tsx
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/QuestionList.tsx
@@ -146,7 +146,7 @@ export function QuestionList({
               className={S.QuestionListItem}
               name={item.getName()}
               icon={{
-                name: getIcon(item).name,
+                ...getIcon(item),
                 size: item.model === "dataset" ? 18 : 16,
                 className: S.QuestionListItemIcon,
               }}

--- a/frontend/src/metabase/dashboard/visualizations/LinkViz/EntityDisplay.tsx
+++ b/frontend/src/metabase/dashboard/visualizations/LinkViz/EntityDisplay.tsx
@@ -1,6 +1,8 @@
 import { t } from "ttag";
 
+import { EntityIcon } from "metabase/common/components/EntityIcon";
 import { Markdown } from "metabase/common/components/Markdown";
+import type { IconData } from "metabase/lib/icon";
 import { getIcon } from "metabase/lib/icon";
 import { isEmpty } from "metabase/lib/validate";
 import { Icon } from "metabase/ui";
@@ -22,7 +24,7 @@ export const EntityDisplay = ({
   return (
     <EntityDisplayContainer>
       <LeftContainer>
-        <Icon c="brand" name={getSearchIconName(entity)} />
+        <EntityIcon color="brand" {...getSearchIcon(entity)} />
         <EllipsifiedEntityContainer>{entity?.name}</EllipsifiedEntityContainer>
       </LeftContainer>
       {showDescription && entity?.description && (
@@ -65,13 +67,13 @@ export const UrlLinkDisplay = ({ url }: { url?: string }) => {
   );
 };
 
-function getSearchIconName(entity: UnrestrictedLinkEntity) {
-  const entityIcon = getIcon(entity) ?? { name: "link" };
+function getSearchIcon(entity: UnrestrictedLinkEntity): IconData {
+  const entityIcon = getIcon(entity) ?? { name: "link" as const };
 
   // we need to change this icon to make it match the icon in the search results
   if (entity.model === "table") {
     entityIcon.name = "database";
   }
 
-  return entityIcon.name;
+  return entityIcon;
 }

--- a/frontend/src/metabase/documents/components/Editor/shared/MenuComponents.tsx
+++ b/frontend/src/metabase/documents/components/Editor/shared/MenuComponents.tsx
@@ -1,6 +1,7 @@
 import type { DOMAttributes, MouseEvent } from "react";
 import { t } from "ttag";
 
+import { EntityIcon } from "metabase/common/components/EntityIcon";
 import type { SuggestionModel } from "metabase/rich_text_editing/tiptap/extensions/shared/types";
 import {
   Avatar,
@@ -22,6 +23,7 @@ interface ExtraItemProps extends DOMAttributes<HTMLButtonElement> {
 
 export interface MenuItem {
   icon: IconName;
+  iconUrl?: string;
   iconColor?: ColorName;
   label: string;
   description?: string;
@@ -53,7 +55,12 @@ export const MenuItemComponent = ({
       {item.model === "user" && <Avatar name={item.label} size={16} />}
 
       {item.model !== "user" && (
-        <Icon name={item.icon} size={16} c={item.iconColor || "inherit"} />
+        <EntityIcon
+          name={item.icon}
+          iconUrl={item.iconUrl}
+          size={16}
+          color={item.iconColor || "inherit"}
+        />
       )}
 
       <Stack gap={2} className={S.menuItemStack}>

--- a/frontend/src/metabase/documents/components/Editor/shared/MenuComponents.tsx
+++ b/frontend/src/metabase/documents/components/Editor/shared/MenuComponents.tsx
@@ -58,7 +58,7 @@ export const MenuItemComponent = ({
         <EntityIcon
           name={item.icon}
           iconUrl={item.iconUrl}
-          size={16}
+          size="1rem"
           color={item.iconColor || "inherit"}
         />
       )}

--- a/frontend/src/metabase/documents/components/EmbedQuestionSettingsSidebar.tsx
+++ b/frontend/src/metabase/documents/components/EmbedQuestionSettingsSidebar.tsx
@@ -2,6 +2,7 @@ import type { Editor } from "@tiptap/react";
 import { useCallback } from "react";
 import { t } from "ttag";
 
+import { EntityIcon } from "metabase/common/components/EntityIcon";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import {
   ActionIcon,
@@ -134,8 +135,11 @@ export const EmbedQuestionSettingsSidebar = ({
                   disabled={!selectedElem}
                   rightSection={<Icon ml="xs" size={10} name="chevrondown" />}
                   leftSection={
-                    selectedElem?.iconName ? (
-                      <Icon name={selectedElem.iconName} />
+                    selectedElem?.iconName || selectedElem?.iconUrl ? (
+                      <EntityIcon
+                        name={selectedElem.iconName ?? undefined}
+                        iconUrl={selectedElem.iconUrl}
+                      />
                     ) : null
                   }
                   justify="space-between"
@@ -144,26 +148,40 @@ export const EmbedQuestionSettingsSidebar = ({
                 </Button>
               </Menu.Target>
               <Menu.Dropdown>
-                {sensibleItems.map(({ iconName, label, value }, index) => (
-                  <Menu.Item
-                    key={`${value}/${index}`}
-                    onClick={() => handleVisualizationTypeChange(value)}
-                    leftSection={iconName ? <Icon name={iconName} /> : null}
-                  >
-                    {label}
-                  </Menu.Item>
-                ))}
+                {sensibleItems.map(
+                  ({ iconName, iconUrl, label, value }, index) => (
+                    <Menu.Item
+                      key={`${value}/${index}`}
+                      onClick={() => handleVisualizationTypeChange(value)}
+                      leftSection={
+                        iconName || iconUrl ? (
+                          <EntityIcon
+                            name={iconName ?? undefined}
+                            iconUrl={iconUrl}
+                          />
+                        ) : null
+                      }
+                    >
+                      {label}
+                    </Menu.Item>
+                  ),
+                )}
 
                 {nonsensibleItems.length > 0 && (
                   <>
                     <Menu.Label>{t`More charts`}</Menu.Label>
                     {nonsensibleItems.map(
-                      ({ iconName, label, value }, index) => (
+                      ({ iconName, iconUrl, label, value }, index) => (
                         <Menu.Item
                           key={`${value}/${index}`}
                           onClick={() => handleVisualizationTypeChange(value)}
                           leftSection={
-                            iconName ? <Icon name={iconName} /> : null
+                            iconName || iconUrl ? (
+                              <EntityIcon
+                                name={iconName ?? undefined}
+                                iconUrl={iconUrl}
+                              />
+                            ) : null
                           }
                         >
                           {label}

--- a/frontend/src/metabase/documents/utils/visualizationUtils.ts
+++ b/frontend/src/metabase/documents/utils/visualizationUtils.ts
@@ -10,6 +10,7 @@ export interface VisualizationItem {
   value: VisualizationDisplay;
   label: string;
   iconName: IconName | null;
+  iconUrl?: string;
 }
 
 /**
@@ -27,6 +28,7 @@ export function getVisualizationItem(
     value: visualizationType,
     label: visualization.getUiName(),
     iconName: visualization.iconName,
+    iconUrl: visualization.iconUrl,
   };
 }
 

--- a/frontend/src/metabase/home/components/HomeModelCard/HomeModelCard.styled.tsx
+++ b/frontend/src/metabase/home/components/HomeModelCard/HomeModelCard.styled.tsx
@@ -1,13 +1,7 @@
 // eslint-disable-next-line no-restricted-imports
 import styled from "@emotion/styled";
 
-import { Ellipsified, Icon } from "metabase/ui";
-
-export const CardIcon = styled(Icon)`
-  display: block;
-  flex: 0 0 auto;
-  color: var(--mb-color-brand);
-`;
+import { Ellipsified } from "metabase/ui";
 
 export const CardTitle = styled(Ellipsified)`
   color: var(--mb-color-text-primary);

--- a/frontend/src/metabase/home/components/HomeModelCard/HomeModelCard.tsx
+++ b/frontend/src/metabase/home/components/HomeModelCard/HomeModelCard.tsx
@@ -1,17 +1,14 @@
-import type { IconName } from "metabase/ui";
+import { EntityIcon } from "metabase/common/components/EntityIcon";
+import type { IconData } from "metabase/lib/icon";
 
 import { HomeCard } from "../HomeCard";
 
-import { CardIcon, CardTitle } from "./HomeModelCard.styled";
+import { CardTitle } from "./HomeModelCard.styled";
 
 interface HomeModelCardProps {
   title: string;
-  icon: HomeModelIconProps;
+  icon: IconData;
   url: string;
-}
-
-export interface HomeModelIconProps {
-  name: IconName;
 }
 
 export const HomeModelCard = ({
@@ -21,7 +18,11 @@ export const HomeModelCard = ({
 }: HomeModelCardProps): JSX.Element => {
   return (
     <HomeCard url={url}>
-      <CardIcon {...icon} />
+      <EntityIcon
+        {...icon}
+        color="brand"
+        style={{ display: "block", flex: "0 0 auto" }}
+      />
       <CardTitle>{title}</CardTitle>
     </HomeCard>
   );

--- a/frontend/src/metabase/home/components/HomeModelCard/HomeModelCard.unit.spec.tsx
+++ b/frontend/src/metabase/home/components/HomeModelCard/HomeModelCard.unit.spec.tsx
@@ -1,11 +1,11 @@
 import { render, screen } from "__support__/ui";
+import type { IconData } from "metabase/lib/icon";
 
-import type { HomeModelIconProps } from "./HomeModelCard";
 import { HomeModelCard } from "./HomeModelCard";
 
 interface SetupOpts {
   title: string;
-  icon: HomeModelIconProps;
+  icon: IconData;
   url: string;
 }
 

--- a/frontend/src/metabase/lib/icon.ts
+++ b/frontend/src/metabase/lib/icon.ts
@@ -67,12 +67,13 @@ export const modelIconMap: Record<IconModel, IconName> = {
 export type IconData = {
   name: IconName;
   color?: ColorName;
+  iconUrl?: string;
 };
 
 /** get an Icon for any entity object, doesn't depend on the entity system */
 export const getIconBase = (item: ObjectWithModel): IconData => {
   if (item.model === "card" && item.display) {
-    return { name: getIconForVisualizationType(item.display) };
+    return getIconForVisualizationType(item.display);
   }
 
   if (item.model === "collection" && item.id === PERSONAL_COLLECTIONS.id) {

--- a/frontend/src/metabase/metabot/components/AIMarkdown/components/MarkdownSmartLink.tsx
+++ b/frontend/src/metabase/metabot/components/AIMarkdown/components/MarkdownSmartLink.tsx
@@ -1,11 +1,11 @@
 import { match } from "ts-pattern";
 
+import { EntityIcon } from "metabase/common/components/EntityIcon";
 import { getIcon } from "metabase/lib/icon";
 import { modelToUrl } from "metabase/lib/urls";
 import type { MetabaseProtocolEntityModel } from "metabase/metabot/utils/links";
 import { useEntityData } from "metabase/rich_text_editing/tiptap/extensions/SmartLink/SmartLinkNode";
 import { entityToUrlableModel } from "metabase/rich_text_editing/tiptap/extensions/shared/suggestionUtils";
-import { Icon } from "metabase/ui";
 
 import S from "../AIMarkdown.module.css";
 
@@ -44,7 +44,7 @@ export const MarkdownSmartLink = ({
       className={S.smartLink}
     >
       <span className={S.smartLinkInner}>
-        <Icon name={icon.name} className={S.icon} />
+        <EntityIcon {...icon} className={S.icon} />
         {name}
       </span>
     </InternalLink>

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarLink.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarLink.tsx
@@ -65,28 +65,23 @@ function SidebarLink({
     if (isValidElement(icon)) {
       return icon;
     }
-    const iconProps = isIconPropsObject(icon)
-      ? icon
-      : { name: icon, iconUrl: undefined };
-    const iconUrl =
-      "iconUrl" in iconProps && iconProps.iconUrl
-        ? iconProps.iconUrl
-        : undefined;
+    const iconProps = isIconPropsObject(icon) ? icon : { name: icon };
 
-    if (iconUrl) {
+    if ("iconUrl" in iconProps && iconProps.iconUrl) {
       return (
         <TreeNode.IconContainer transparent={false}>
-          <EntityIcon name={iconProps.name} iconUrl={iconUrl} size="1rem" />
+          <EntityIcon
+            name={iconProps.name}
+            iconUrl={iconProps.iconUrl}
+            size="1rem"
+          />
         </TreeNode.IconContainer>
       );
     }
 
     return (
       <TreeNode.IconContainer transparent={false}>
-        <SidebarIcon
-          {...(_.omit(iconProps, "iconUrl") as IconProps)}
-          isSelected={isSelected}
-        />
+        <SidebarIcon {...iconProps} isSelected={isSelected} />
       </TreeNode.IconContainer>
     );
   }, [icon, isSelected]);

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarLink.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarLink.tsx
@@ -65,9 +65,14 @@ function SidebarLink({
     if (isValidElement(icon)) {
       return icon;
     }
-    const iconProps = isIconPropsObject(icon) ? icon : { name: icon };
+    const iconProps = isIconPropsObject(icon)
+      ? icon
+      : { name: icon, iconUrl: undefined };
     const iconUrl =
-      "iconUrl" in iconProps ? (iconProps.iconUrl as string) : undefined;
+      "iconUrl" in iconProps && iconProps.iconUrl
+        ? iconProps.iconUrl
+        : undefined;
+
     if (iconUrl) {
       return (
         <TreeNode.IconContainer transparent={false}>
@@ -75,9 +80,13 @@ function SidebarLink({
         </TreeNode.IconContainer>
       );
     }
+
     return (
       <TreeNode.IconContainer transparent={false}>
-        <SidebarIcon {...(iconProps as IconProps)} isSelected={isSelected} />
+        <SidebarIcon
+          {...(_.omit(iconProps, "iconUrl") as IconProps)}
+          isSelected={isSelected}
+        />
       </TreeNode.IconContainer>
     );
   }, [icon, isSelected]);

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarLink.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarLink.tsx
@@ -2,7 +2,9 @@ import type { MouseEvent, ReactNode } from "react";
 import { isValidElement, useCallback, useMemo } from "react";
 import _ from "underscore";
 
+import { EntityIcon } from "metabase/common/components/EntityIcon";
 import { TreeNode } from "metabase/common/components/tree/TreeNode";
+import type { IconData } from "metabase/lib/icon";
 import type { IconName, IconProps } from "metabase/ui";
 
 import {
@@ -19,7 +21,7 @@ import {
 interface SidebarLinkProps {
   children: string;
   url?: string;
-  icon?: IconName | IconProps;
+  icon?: IconName | IconProps | IconData;
   isSelected?: boolean;
   hasDefaultIconStyle?: boolean;
   left?: ReactNode;
@@ -31,7 +33,9 @@ type ContentProps = {
   children: ReactNode;
 };
 
-function isIconPropsObject(icon: string | IconProps): icon is IconProps {
+function isIconPropsObject(
+  icon: string | IconProps | IconData,
+): icon is IconProps | IconData {
   return _.isObject(icon);
 }
 
@@ -62,9 +66,18 @@ function SidebarLink({
       return icon;
     }
     const iconProps = isIconPropsObject(icon) ? icon : { name: icon };
+    const iconUrl =
+      "iconUrl" in iconProps ? (iconProps.iconUrl as string) : undefined;
+    if (iconUrl) {
+      return (
+        <TreeNode.IconContainer transparent={false}>
+          <EntityIcon name={iconProps.name} iconUrl={iconUrl} size={16} />
+        </TreeNode.IconContainer>
+      );
+    }
     return (
       <TreeNode.IconContainer transparent={false}>
-        <SidebarIcon {...iconProps} isSelected={isSelected} />
+        <SidebarIcon {...(iconProps as IconProps)} isSelected={isSelected} />
       </TreeNode.IconContainer>
     );
   }, [icon, isSelected]);

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarLink.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarLink.tsx
@@ -71,7 +71,7 @@ function SidebarLink({
     if (iconUrl) {
       return (
         <TreeNode.IconContainer transparent={false}>
-          <EntityIcon name={iconProps.name} iconUrl={iconUrl} size={16} />
+          <EntityIcon name={iconProps.name} iconUrl={iconUrl} size="1rem" />
         </TreeNode.IconContainer>
       );
     }

--- a/frontend/src/metabase/palette/components/PaletteResultItem.tsx
+++ b/frontend/src/metabase/palette/components/PaletteResultItem.tsx
@@ -1,7 +1,8 @@
+import { EntityIcon } from "metabase/common/components/EntityIcon";
 import { ExternalLink } from "metabase/common/components/ExternalLink";
 import { Link } from "metabase/common/components/Link";
 import { PLUGIN_MODERATION } from "metabase/plugins";
-import { Box, Flex, Group, Icon, Stack, Text } from "metabase/ui";
+import { Box, Flex, Group, Stack, Text } from "metabase/ui";
 
 import type { PaletteActionImpl } from "../types";
 import {
@@ -39,8 +40,9 @@ export const PaletteResultItem = ({ item, active }: PaletteResultItemProps) => {
       wrap="nowrap"
     >
       {icon && (
-        <Icon
+        <EntityIcon
           {...icon}
+          iconUrl={item.iconUrl}
           style={{
             flexBasis: "16px",
           }}

--- a/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
@@ -188,6 +188,7 @@ export const useCommandPalette = ({
             name: result.name,
             subtitle: result.description || "",
             icon: icon.name,
+            iconUrl: icon.iconUrl,
             section: "search",
             keywords: debouncedSearchText,
             priority: Priority.NORMAL - index,
@@ -251,6 +252,7 @@ export const useCommandPalette = ({
           id: `recent-item-${getName(item)}-${item.model}-${item.id}`,
           name: getName(item),
           icon: icon.name,
+          iconUrl: icon.iconUrl,
           section: "recent",
           perform: () => {},
           extra: {

--- a/frontend/src/metabase/palette/types.ts
+++ b/frontend/src/metabase/palette/types.ts
@@ -29,12 +29,14 @@ export type PaletteAction = Action &
   PaletteActionExtras & {
     subtitle?: Action["subtitle"];
     icon?: IconName;
+    iconUrl?: string;
   };
 
 export type PaletteActionImpl = ActionImpl &
   PaletteActionExtras & {
     subtitle?: Action["subtitle"];
     icon?: IconName;
+    iconUrl?: string;
   };
 
 export type ShortcutGroup = keyof typeof GROUP_LABELS;

--- a/frontend/src/metabase/rich_text_editing/tiptap/extensions/SmartLink/SmartLinkNode.tsx
+++ b/frontend/src/metabase/rich_text_editing/tiptap/extensions/SmartLink/SmartLinkNode.tsx
@@ -20,6 +20,7 @@ import {
   useGetTransformQuery,
   useListMentionsQuery,
 } from "metabase/api";
+import { EntityIcon } from "metabase/common/components/EntityIcon";
 import { Link } from "metabase/common/components/Link";
 import { updateMentionsCache } from "metabase/documents/documents.slice";
 import {
@@ -532,7 +533,7 @@ export const SmartLinkComponent = memo(
           className={styles.smartLink}
         >
           <span className={styles.smartLinkInner}>
-            <Icon name={iconData.name} className={styles.icon} />
+            <EntityIcon {...iconData} className={styles.icon} />
             {getName(entity)}
           </span>
         </Link>

--- a/frontend/src/metabase/rich_text_editing/tiptap/extensions/shared/suggestionUtils.ts
+++ b/frontend/src/metabase/rich_text_editing/tiptap/extensions/shared/suggestionUtils.ts
@@ -32,6 +32,7 @@ export function buildSearchMenuItems(
     const href = modelToUrl(urlableModel);
     return {
       icon: iconData.name,
+      iconUrl: iconData.iconUrl,
       label: result.name,
       id: result.id,
       model: result.model,
@@ -51,6 +52,7 @@ export function buildRecentsMenuItems(
     const href = modelToUrl(urlableModel);
     return {
       icon: iconData.name,
+      iconUrl: iconData.iconUrl,
       label: getName(recent),
       id: recent.id,
       model: recent.model as SuggestionModel,

--- a/frontend/src/metabase/search/components/SearchResult/components/DefaultIcon.tsx
+++ b/frontend/src/metabase/search/components/SearchResult/components/DefaultIcon.tsx
@@ -1,5 +1,5 @@
+import { EntityIcon } from "metabase/common/components/EntityIcon";
 import { getIcon } from "metabase/lib/icon";
-import { Icon } from "metabase/ui";
 
 import type { IconComponentProps } from "./ItemIcon";
 import { DEFAULT_ICON_SIZE } from "./constants";
@@ -7,5 +7,5 @@ import { DEFAULT_ICON_SIZE } from "./constants";
 export function DefaultIcon({ item }: { item: IconComponentProps["item"] }) {
   const iconData = getIcon(item);
 
-  return <Icon {...iconData} size={DEFAULT_ICON_SIZE} />;
+  return <EntityIcon {...iconData} size={DEFAULT_ICON_SIZE} />;
 }

--- a/frontend/src/metabase/visualizations/components/skeletons/StaticSkeleton/StaticSkeleton.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/skeletons/StaticSkeleton/StaticSkeleton.styled.tsx
@@ -20,13 +20,6 @@ export const SkeletonDescription = styled(MarkdownPreview)`
   line-height: 1.5rem;
 `;
 
-export const SkeletonIcon = styled(Icon)`
-  display: block;
-  color: var(--mb-color-text-secondary);
-  width: 1.5rem;
-  height: 1.5rem;
-`;
-
 export const SkeletonTooltipIcon = styled(Icon)`
   display: block;
   color: var(--mb-color-text-tertiary);

--- a/frontend/src/metabase/visualizations/components/skeletons/StaticSkeleton/StaticSkeleton.tsx
+++ b/frontend/src/metabase/visualizations/components/skeletons/StaticSkeleton/StaticSkeleton.tsx
@@ -1,5 +1,6 @@
 import type { HTMLAttributes, ReactNode } from "react";
 
+import { EntityIcon } from "metabase/common/components/EntityIcon";
 import type { IconName } from "metabase/ui";
 import { Group, Tooltip } from "metabase/ui";
 
@@ -23,6 +24,7 @@ export interface StaticSkeletonProps extends HTMLAttributes<HTMLDivElement> {
 
 export interface StaticSkeletonIconProps {
   name: IconName;
+  iconUrl?: string;
 }
 
 const StaticSkeleton = ({
@@ -40,7 +42,15 @@ const StaticSkeleton = ({
       {icon && (
         <Tooltip label={tooltip} disabled={!tooltip}>
           <SkeletonIconContainer>
-            <SkeletonIcon {...icon} />
+            {icon.iconUrl ? (
+              <EntityIcon
+                name={icon.name}
+                iconUrl={icon.iconUrl}
+                size={24}
+              />
+            ) : (
+              <SkeletonIcon {...icon} />
+            )}
             {tooltip && (
               <SkeletonTooltipIconContainer>
                 <SkeletonTooltipIcon name="eye_crossed_out" />

--- a/frontend/src/metabase/visualizations/components/skeletons/StaticSkeleton/StaticSkeleton.tsx
+++ b/frontend/src/metabase/visualizations/components/skeletons/StaticSkeleton/StaticSkeleton.tsx
@@ -46,7 +46,7 @@ const StaticSkeleton = ({
               <EntityIcon
                 name={icon.name}
                 iconUrl={icon.iconUrl}
-                size={24}
+                size="1.5rem"
               />
             ) : (
               <SkeletonIcon {...icon} />

--- a/frontend/src/metabase/visualizations/components/skeletons/StaticSkeleton/StaticSkeleton.tsx
+++ b/frontend/src/metabase/visualizations/components/skeletons/StaticSkeleton/StaticSkeleton.tsx
@@ -6,7 +6,6 @@ import { Group, Tooltip } from "metabase/ui";
 
 import {
   SkeletonDescription,
-  SkeletonIcon,
   SkeletonIconContainer,
   SkeletonRoot,
   SkeletonTitle,
@@ -42,15 +41,12 @@ const StaticSkeleton = ({
       {icon && (
         <Tooltip label={tooltip} disabled={!tooltip}>
           <SkeletonIconContainer>
-            {icon.iconUrl ? (
-              <EntityIcon
-                name={icon.name}
-                iconUrl={icon.iconUrl}
-                size="1.5rem"
-              />
-            ) : (
-              <SkeletonIcon {...icon} />
-            )}
+            <EntityIcon
+              {...icon}
+              size="1.5rem"
+              color="text-secondary"
+              style={{ display: "block" }}
+            />
             {tooltip && (
               <SkeletonTooltipIconContainer>
                 <SkeletonTooltipIcon name="eye_crossed_out" />

--- a/frontend/src/metabase/visualizations/index.ts
+++ b/frontend/src/metabase/visualizations/index.ts
@@ -2,6 +2,7 @@ import { t } from "ttag";
 import _ from "underscore";
 
 import { isStorybookActive } from "metabase/env";
+import type { IconName } from "metabase/ui";
 import type {
   DatasetData,
   RawSeries,
@@ -116,9 +117,15 @@ export function getVisualizationTransformed(
   return { series, visualization };
 }
 
-export function getIconForVisualizationType(display: VisualizationDisplay) {
+export function getIconForVisualizationType(display: VisualizationDisplay): {
+  name: IconName;
+  iconUrl?: string;
+} {
   const viz = visualizations.get(display);
-  return viz?.iconName ?? "unknown";
+  return {
+    name: viz?.iconName ?? "unknown",
+    iconUrl: viz?.iconUrl,
+  };
 }
 
 export const extractRemappings = (series: Series) => {

--- a/frontend/src/metabase/visualizer/components/VisualizationPicker/VisualizationPicker.tsx
+++ b/frontend/src/metabase/visualizer/components/VisualizationPicker/VisualizationPicker.tsx
@@ -1,7 +1,8 @@
 import { useMemo } from "react";
 
+import { EntityIcon } from "metabase/common/components/EntityIcon";
 import { trackSimpleEvent } from "metabase/lib/analytics";
-import { Center, Icon, SegmentedControl } from "metabase/ui";
+import { Center, SegmentedControl } from "metabase/ui";
 import visualizations from "metabase/visualizations";
 import type { VisualizationDisplay } from "metabase-types/api";
 
@@ -23,6 +24,7 @@ export function VisualizationPicker({
           label: viz.getUiName(),
           value: vizType,
           icon: viz.iconName,
+          iconUrl: viz.iconUrl,
         };
       });
   }, []);
@@ -55,7 +57,11 @@ export function VisualizationPicker({
               }}
               p="sm"
             >
-              <Icon data-testid={o.value} name={o.icon} />
+              <EntityIcon
+                data-testid={o.value}
+                name={o.icon}
+                iconUrl={o.iconUrl}
+              />
             </Center>
           ),
         }))}


### PR DESCRIPTION
## Summary

- Add `iconUrl` to `IconData` type and propagate it through `getIconForVisualizationType` so custom visualization plugin icons appear in all icon rendering sites
- Introduce `EntityIcon` component — renders `<img>` for URL-based icons, falls back to `<Icon>` for standard icon names
- Update multiple rendering sites: search + command palette, collections, entity picker, home sections, bookmarks, dashboard, documents, visualization picker