### PR TITLE
fix(sdk,embed-js): Fix wrong `join on` dropdown items styles

### DIFF
--- a/frontend/src/metabase/common/components/BucketPickerPopover/BucketPickerPopover.module.css
+++ b/frontend/src/metabase/common/components/BucketPickerPopover/BucketPickerPopover.module.css
@@ -1,15 +1,16 @@
 .triggerButton {
   border-radius: 0;
   visibility: hidden;
-  color: var(
-    --select-list-item-text-color,
-    var(--mb-color-text-tertiary-inverse)
-  );
+  color: var(--mb-color-text-tertiary-inverse);
   border-left: 2px solid var(--mb-color-border-subtle);
 }
 
 *:hover > .triggerButton {
   visibility: visible;
+}
+
+.triggerButton:hover {
+  color: var(--mb-color-text-primary-inverse);
 }
 
 /* No hover on touch devices, so always show the button with readable text */
@@ -30,10 +31,7 @@
 }
 
 .chevronIcon {
-  color: var(
-    --select-list-item-text-color,
-    var(--mb-color-text-primary-inverse)
-  );
+  color: var(--mb-color-text-primary-inverse);
   flex: 0 0 auto;
 }
 

--- a/frontend/src/metabase/common/components/BucketPickerPopover/BucketPickerPopover.module.css
+++ b/frontend/src/metabase/common/components/BucketPickerPopover/BucketPickerPopover.module.css
@@ -1,32 +1,26 @@
 .triggerButton {
   border-radius: 0;
   visibility: hidden;
-  color: var(--mb-color-text-tertiary-inverse);
+  color: var(
+    --select-list-item-text-color,
+    var(--mb-color-text-tertiary-inverse)
+  );
   border-left: 2px solid var(--mb-color-border-subtle);
 }
 
 *:hover > .triggerButton {
   visibility: visible;
-  color: var(--mb-color-text-primary-inverse);
 }
 
 /* No hover on touch devices, so always show the button with readable text */
 @media (hover: none) and (pointer: coarse) {
   .triggerButton {
     visibility: visible;
-    color: var(--mb-color-brand);
-  }
-
-  :global([aria-selected="true"]) .triggerButton {
-    color: var(--mb-color-text-primary-inverse);
+    color: var(--select-list-item-text-color, var(--mb-color-brand));
   }
 
   .chevronIcon {
-    color: var(--mb-color-brand);
-  }
-
-  :global([aria-selected="true"]) .chevronIcon {
-    color: var(--mb-color-text-primary-inverse);
+    color: var(--select-list-item-text-color, var(--mb-color-brand));
   }
 }
 
@@ -36,7 +30,10 @@
 }
 
 .chevronIcon {
-  color: var(--mb-color-text-primary-inverse);
+  color: var(
+    --select-list-item-text-color,
+    var(--mb-color-text-primary-inverse)
+  );
   flex: 0 0 auto;
 }
 

--- a/frontend/src/metabase/common/components/BucketPickerPopover/BucketPickerPopover.module.css
+++ b/frontend/src/metabase/common/components/BucketPickerPopover/BucketPickerPopover.module.css
@@ -7,6 +7,7 @@
 
 *:hover > .triggerButton {
   visibility: visible;
+  color: var(--mb-color-text-primary-inverse);
 }
 
 /* No hover on touch devices, so always show the button with readable text */
@@ -16,8 +17,16 @@
     color: var(--mb-color-brand);
   }
 
+  :global([aria-selected="true"]) .triggerButton {
+    color: var(--mb-color-text-primary-inverse);
+  }
+
   .chevronIcon {
     color: var(--mb-color-brand);
+  }
+
+  :global([aria-selected="true"]) .chevronIcon {
+    color: var(--mb-color-text-primary-inverse);
   }
 }
 

--- a/frontend/src/metabase/common/components/BucketPickerPopover/BucketPickerPopover.tsx
+++ b/frontend/src/metabase/common/components/BucketPickerPopover/BucketPickerPopover.tsx
@@ -116,8 +116,8 @@ export function BucketPickerPopover({
         </Button>
       </Popover.Target>
       <Popover.Dropdown
-        // Prevent touch events from bubbling to the parent dropdown,
-        // which causes it to scroll/select items on mobile (metabase#EMB-1471)
+        // Prevent scroll from leaking to the parent on touch devices
+        style={{ overscrollBehavior: "contain", touchAction: "pan-y" }}
         onTouchStart={(e: TouchEvent) => e.stopPropagation()}
         onTouchMove={(e: TouchEvent) => e.stopPropagation()}
       >

--- a/frontend/src/metabase/css/components/list.module.css
+++ b/frontend/src/metabase/css/components/list.module.css
@@ -57,6 +57,8 @@
 .ListItem:not(.ListItemDisabled):hover,
 .ListItemSelected:not(.ListItemDisabled) {
   background-color: currentColor;
+  /* Used in BucketPickerPopover.module.css to properly use  */
+  --select-list-item-text-color: var(--mb-color-text-primary-inverse);
 }
 
 /* LIST ITEM TITLE */


### PR DESCRIPTION
Context:
The https://github.com/metabase/metabase/pull/71562 not fully adjusted styles, so in some cases there are wrong colors for `triggerButton` set.

This PR fixes it.

Desktop:
The `created at` item is not-selected and not hovered. The `by month` button is hidden.
<img width="692" height="842" alt="image" src="https://github.com/user-attachments/assets/c5aa2c79-733d-471f-8419-06e050278968" />

The `created at` item is selected/checked. The `by month` button is hidden.
<img width="702" height="818" alt="image" src="https://github.com/user-attachments/assets/149f67c8-fd97-4365-b417-0db96873481f" />

The `created at` item is hovered, The `by month` button is not hovered and has a kind of gray-ish color.
<img width="764" height="170" alt="image" src="https://github.com/user-attachments/assets/9c97100e-cf3a-4193-b78e-d5fbe31ce240" />

The `created at` item is hovered, The `by month` button is hovered and has a white color.
<img width="766" height="248" alt="image" src="https://github.com/user-attachments/assets/6abbb48d-c752-428a-aee7-631abfbc2e95" />

Mobile:
The `created at` item is not-selected and not hovered. The `by month` button is visible and has a brand color.
![telegram-cloud-photo-size-2-5368668451414677296-y](https://github.com/user-attachments/assets/e9023ab9-7d95-4d51-b89d-827cd00e3c72)

The `created at` item is selected. The `by month` button has the white color.
![telegram-cloud-photo-size-2-5368668451414677295-y](https://github.com/user-attachments/assets/1f0b0ed9-c536-443d-8d8d-2eccb5579fc1)

The `created at` item is hovered. The `by month` button has the white color.
![telegram-cloud-photo-size-2-5368668451414677297-y](https://github.com/user-attachments/assets/fc0f6b61-c944-4966-b3b1-9c3b9cf2e3e0)
