### PR TITLE
Fix Trivy sarif failing to upload

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,6 +16,7 @@ permissions:
   actions: read
   checks: write
   pull-requests: write
+  security-events: write
 
 jobs:
   files-changed:


### PR DESCRIPTION
Resolves DEV-1780

## Root Cause

#71608 added an explicit permissions block to run-tests.yml for AWS assume-role. This restricted the GITHUB_TOKEN to only the listed scopes, dropping security-events: write — which upload-sarif needs in the called `containerize-uberjar.yml` workflow.

## Summary

This PR adds the missing permission.

## Alternative Approach

A better approach would be to remove the top-level permissions block from run-tests.yml entirely and instead add permissions: { id-token: write } only to the specific called workflows/jobs that actually need AWS assume-role. This avoids accumulating blanket grants on the caller every time a called workflow needs a new scope.
