### PR TITLE
Add `useMetabot` storybook stories

### DIFF
--- a/enterprise/frontend/src/embedding-sdk-ee/metabot/MetabotChatHistory.tsx
+++ b/enterprise/frontend/src/embedding-sdk-ee/metabot/MetabotChatHistory.tsx
@@ -35,7 +35,7 @@ export function MetabotChatHistory() {
     >
       {hasMessages ? (
         <Messages
-          messages={messages}
+          messages={messages.filter((message) => message.type !== "chart")}
           errorMessages={errorMessages}
           onRetryMessage={metabot.retryMessage}
           isDoingScience={metabot.isDoingScience}

--- a/enterprise/frontend/src/embedding-sdk-ee/metabot/MetabotChatHistory.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk-ee/metabot/MetabotChatHistory.unit.spec.tsx
@@ -1,0 +1,59 @@
+import { assocIn } from "icepick";
+
+import { screen } from "__support__/ui";
+import { getMetabotInitialState } from "metabase/metabot/state/reducer-utils";
+import { setup } from "metabase/metabot/tests/utils";
+
+import { MetabotChatHistory } from "./MetabotChatHistory";
+
+const makeVisibleState = (
+  messages: {
+    id: string;
+    role: "agent" | "user";
+    type: string;
+    [key: string]: unknown;
+  }[],
+) =>
+  assocIn(
+    assocIn(
+      getMetabotInitialState(),
+      ["conversations", "omnibot", "visible"],
+      true,
+    ),
+    ["conversations", "omnibot", "messages"],
+    messages,
+  );
+
+describe("MetabotChatHistory", () => {
+  it("should not render chart messages in the message list", () => {
+    setup({
+      ui: <MetabotChatHistory />,
+      metabotInitialState: makeVisibleState([
+        {
+          id: "1",
+          role: "agent",
+          type: "chart",
+          navigateTo: "/question#abc",
+        },
+      ]),
+    });
+
+    expect(
+      screen.queryByTestId("metabot-chat-message"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should render non-chart messages normally", async () => {
+    setup({
+      ui: <MetabotChatHistory />,
+      metabotInitialState: makeVisibleState([
+        { id: "1", role: "agent", type: "text", message: "Hello world" },
+      ]),
+    });
+
+    expect(
+      await screen.findByTestId("metabot-chat-message"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Hello world")).toBeInTheDocument();
+  });
+});

--- a/enterprise/frontend/src/embedding-sdk-ee/metabot/MetabotChatHistory.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk-ee/metabot/MetabotChatHistory.unit.spec.tsx
@@ -2,18 +2,12 @@ import { assocIn } from "icepick";
 
 import { screen } from "__support__/ui";
 import { getMetabotInitialState } from "metabase/metabot/state/reducer-utils";
+import type { MetabotChatMessage } from "metabase/metabot/state/types";
 import { setup } from "metabase/metabot/tests/utils";
 
 import { MetabotChatHistory } from "./MetabotChatHistory";
 
-const makeVisibleState = (
-  messages: {
-    id: string;
-    role: "agent" | "user";
-    type: string;
-    [key: string]: unknown;
-  }[],
-) =>
+const makeVisibleState = (messages: MetabotChatMessage[]) =>
   assocIn(
     assocIn(
       getMetabotInitialState(),

--- a/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot-crm.stories.tsx
+++ b/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot-crm.stories.tsx
@@ -5,7 +5,6 @@ import { useMetabot } from "./use-metabot";
 import {
   BotIcon,
   Composer,
-  InstructionsDrawer,
   MessageList,
   SharedKeyframes,
   makeSdkWrapper,
@@ -354,14 +353,10 @@ const CrmDemo = () => {
             isProcessing={metabot.isProcessing}
             scrollRef={scrollRef}
             palette={crm}
+            onRetry={metabot.retryMessage}
           />
         </div>
 
-        <InstructionsDrawer
-          customInstructions={metabot.customInstructions}
-          setCustomInstructions={metabot.setCustomInstructions}
-          palette={crm}
-        />
         <Composer
           value={inputValue}
           onChange={setInputValue}

--- a/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot-crm.stories.tsx
+++ b/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot-crm.stories.tsx
@@ -91,12 +91,12 @@ const AcmeCRMBg = () => (
       <span style={{ fontWeight: 800, fontSize: 14, color: crm.text }}>
         <span style={{ color: crm.accentLight }}>Acme</span>CRM
       </span>
-      {["Home", "Leads", "Opportunities", "Accounts", "Reports"].map((t) => (
+      {["Home", "Leads", "Opportunities", "Accounts", "Reports"].map((tab) => (
         <span
-          key={t}
+          key={tab}
           style={{ fontSize: 12, color: crm.textSecondary, cursor: "pointer" }}
         >
-          {t}
+          {tab}
         </span>
       ))}
     </div>
@@ -286,9 +286,9 @@ const CrmDemo = () => {
         </div>
 
         {/* Errors */}
-        {metabot.errorMessages.map((err, i) => (
+        {metabot.errorMessages.map((errorMessage, index) => (
           <div
-            key={i}
+            key={index}
             style={{
               padding: "5px 14px",
               fontSize: 12,
@@ -296,7 +296,7 @@ const CrmDemo = () => {
               background: crm.redDim,
             }}
           >
-            {err.message}
+            {errorMessage.message}
           </div>
         ))}
 
@@ -318,12 +318,12 @@ const CrmDemo = () => {
                 "Which customers have the highest total spend?",
                 "Show orders by acquisition source",
                 "Average order value by state",
-              ].map((p) => (
+              ].map((prompt) => (
                 <button
-                  key={p}
+                  key={prompt}
                   onClick={() => {
                     if (!metabot.isProcessing) {
-                      metabot.submitMessage(p);
+                      metabot.submitMessage(prompt);
                     }
                   }}
                   style={{
@@ -341,7 +341,7 @@ const CrmDemo = () => {
                     marginBottom: 6,
                   }}
                 >
-                  {p}
+                  {prompt}
                 </button>
               ))}
             </div>

--- a/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot-crm.stories.tsx
+++ b/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot-crm.stories.tsx
@@ -1,0 +1,389 @@
+import type { Meta, StoryFn } from "@storybook/react";
+import { useEffect, useRef, useState } from "react";
+
+import { useMetabot } from "./use-metabot";
+import {
+  BotIcon,
+  Composer,
+  InstructionsDrawer,
+  MessageList,
+  SharedKeyframes,
+  makeSdkWrapper,
+} from "./use-metabot.stories.utils";
+
+// ============================================================================
+// CRM (AcmeCRM) palette
+// ============================================================================
+
+const crm = {
+  bg: "#16325c",
+  surface: "#1b3d72",
+  surfaceRaised: "#214886",
+  surfaceHover: "#27529a",
+  border: "#2b5dae",
+  borderSubtle: "#1f4480",
+  text: "#e8f0fe",
+  textSecondary: "#7faad4",
+  textMuted: "#4d7ab0",
+  accent: "#0176d3",
+  accentLight: "#58b0ff",
+  accentDim: "#0176d325",
+  gradient: "linear-gradient(135deg, #0176d3 0%, #58b0ff 100%)",
+  red: "#f87171",
+  redDim: "#f8717120",
+};
+
+// ============================================================================
+// Fake AcmeCRM background
+// ============================================================================
+
+const deals = [
+  { name: "Acme Corp", stage: "Proposal", amount: "$48,000", owner: "Sarah" },
+  {
+    name: "TechStart Inc",
+    stage: "Negotiation",
+    amount: "$92,000",
+    owner: "James",
+  },
+  { name: "Global Retail", stage: "Demo", amount: "$24,500", owner: "Priya" },
+  {
+    name: "FinCo Ltd",
+    stage: "Prospecting",
+    amount: "$130,000",
+    owner: "Alex",
+  },
+  { name: "CloudSoft", stage: "Closed Won", amount: "$76,000", owner: "Maria" },
+];
+
+const stageColor = (stage: string) => {
+  if (stage === "Closed Won") {
+    return crm.accentLight;
+  }
+  if (stage === "Negotiation") {
+    return "#fbbf24";
+  }
+  if (stage === "Proposal") {
+    return "#a78bfa";
+  }
+  return crm.textMuted;
+};
+
+const AcmeCRMBg = () => (
+  <div
+    style={{
+      position: "absolute",
+      inset: 0,
+      background: crm.bg,
+      overflow: "hidden",
+      zIndex: 0,
+    }}
+  >
+    {/* Top nav */}
+    <div
+      style={{
+        height: 44,
+        borderBottom: `1px solid ${crm.border}`,
+        display: "flex",
+        alignItems: "center",
+        padding: "0 20px",
+        gap: 20,
+      }}
+    >
+      <span style={{ fontWeight: 800, fontSize: 14, color: crm.text }}>
+        <span style={{ color: crm.accentLight }}>Acme</span>CRM
+      </span>
+      {["Home", "Leads", "Opportunities", "Accounts", "Reports"].map((t) => (
+        <span
+          key={t}
+          style={{ fontSize: 12, color: crm.textSecondary, cursor: "pointer" }}
+        >
+          {t}
+        </span>
+      ))}
+    </div>
+    {/* Pipeline header */}
+    <div style={{ padding: "16px 20px 0" }}>
+      <div
+        style={{
+          fontSize: 16,
+          fontWeight: 700,
+          color: crm.text,
+          marginBottom: 4,
+        }}
+      >
+        Pipeline Q2 2025
+      </div>
+      <div style={{ fontSize: 12, color: crm.textMuted, marginBottom: 16 }}>
+        Total: $370,500 · 5 open deals
+      </div>
+      {/* Deal list */}
+      <div
+        style={{
+          background: crm.surface,
+          border: `1px solid ${crm.border}`,
+          borderRadius: 10,
+          overflow: "hidden",
+        }}
+      >
+        <div
+          style={{
+            padding: "10px 14px",
+            borderBottom: `1px solid ${crm.border}`,
+            display: "grid",
+            gridTemplateColumns: "2fr 1fr 1fr 1fr",
+            fontSize: 11,
+            fontWeight: 600,
+            color: crm.textMuted,
+          }}
+        >
+          <span>Account</span>
+          <span>Stage</span>
+          <span>Amount</span>
+          <span>Owner</span>
+        </div>
+        {deals.map((deal, i) => (
+          <div
+            key={deal.name}
+            style={{
+              padding: "10px 14px",
+              display: "grid",
+              gridTemplateColumns: "2fr 1fr 1fr 1fr",
+              fontSize: 13,
+              color: crm.textSecondary,
+              borderBottom:
+                i < deals.length - 1 ? `1px solid ${crm.borderSubtle}` : "none",
+              alignItems: "center",
+            }}
+          >
+            <span style={{ color: crm.text, fontWeight: 500 }}>
+              {deal.name}
+            </span>
+            <span style={{ color: stageColor(deal.stage) }}>{deal.stage}</span>
+            <span style={{ fontWeight: 600, color: crm.text }}>
+              {deal.amount}
+            </span>
+            <span style={{ color: crm.textMuted }}>{deal.owner}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  </div>
+);
+
+// ============================================================================
+// Story — persistent right side panel (always visible)
+// ============================================================================
+
+const CrmDemo = () => {
+  const metabot = useMetabot();
+  const [inputValue, setInputValue] = useState("");
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    scrollRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [metabot.messages, metabot.isProcessing]);
+
+  const handleSubmit = () => {
+    if (inputValue.trim() && !metabot.isProcessing) {
+      metabot.submitMessage(inputValue.trim());
+      setInputValue("");
+    }
+  };
+
+  const canSend = inputValue.trim().length > 0 && !metabot.isProcessing;
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        width: "100%",
+        height: "100vh",
+        overflow: "hidden",
+        fontFamily: '"Inter", -apple-system, BlinkMacSystemFont, sans-serif',
+      }}
+    >
+      <SharedKeyframes />
+      <div style={{ flex: 1, position: "relative" }}>
+        {metabot.CurrentChart ? (
+          <div
+            style={{
+              position: "absolute",
+              inset: 0,
+              background: crm.bg,
+            }}
+          >
+            <metabot.CurrentChart drills isSaveEnabled={false} height="100%" />
+          </div>
+        ) : (
+          <AcmeCRMBg />
+        )}
+      </div>
+
+      {/* Persistent right panel — pinned alongside the deal list */}
+      <div
+        style={{
+          width: 320,
+          height: "100%",
+          background: crm.surface,
+          borderLeft: `1px solid ${crm.border}`,
+          display: "flex",
+          flexDirection: "column",
+        }}
+      >
+        {/* Header */}
+        <div
+          style={{
+            padding: "12px 14px",
+            background: crm.surfaceRaised,
+            borderBottom: `1px solid ${crm.border}`,
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            flexShrink: 0,
+          }}
+        >
+          <div
+            style={{
+              width: 28,
+              height: 28,
+              borderRadius: 7,
+              background: crm.gradient,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              color: "#fff",
+            }}
+          >
+            <BotIcon size={14} />
+          </div>
+          <div style={{ flex: 1 }}>
+            <div style={{ fontSize: 13, fontWeight: 700, color: crm.text }}>
+              Metabot
+            </div>
+            <div
+              style={{
+                fontSize: 10,
+                color: metabot.isProcessing ? crm.accentLight : crm.textMuted,
+              }}
+            >
+              {metabot.isProcessing ? "Analyzing pipeline..." : "CRM analytics"}
+            </div>
+          </div>
+          {metabot.messages.length > 0 && (
+            <button
+              onClick={() => metabot.resetConversation()}
+              style={{
+                background: "none",
+                border: "none",
+                color: crm.textMuted,
+                fontSize: 11,
+                cursor: "pointer",
+                fontFamily: "inherit",
+              }}
+            >
+              Clear
+            </button>
+          )}
+        </div>
+
+        {/* Errors */}
+        {metabot.errorMessages.map((err, i) => (
+          <div
+            key={i}
+            style={{
+              padding: "5px 14px",
+              fontSize: 12,
+              color: crm.red,
+              background: crm.redDim,
+            }}
+          >
+            {err.message}
+          </div>
+        ))}
+
+        {/* Messages */}
+        <div style={{ flex: 1, overflowY: "auto", padding: "10px 12px" }}>
+          {metabot.messages.length === 0 && !metabot.isProcessing && (
+            <div style={{ padding: "8px 0" }}>
+              <div
+                style={{
+                  fontSize: 11,
+                  color: crm.textMuted,
+                  fontWeight: 600,
+                  marginBottom: 8,
+                }}
+              >
+                SUGGESTED QUESTIONS
+              </div>
+              {[
+                "Which customers have the highest total spend?",
+                "Show orders by acquisition source",
+                "Average order value by state",
+              ].map((p) => (
+                <button
+                  key={p}
+                  onClick={() => {
+                    if (!metabot.isProcessing) {
+                      metabot.submitMessage(p);
+                    }
+                  }}
+                  style={{
+                    display: "block",
+                    width: "100%",
+                    textAlign: "left",
+                    background: crm.surfaceRaised,
+                    border: `1px solid ${crm.border}`,
+                    borderRadius: 7,
+                    padding: "8px 10px",
+                    fontSize: 12,
+                    color: crm.textSecondary,
+                    cursor: "pointer",
+                    fontFamily: "inherit",
+                    marginBottom: 6,
+                  }}
+                >
+                  {p}
+                </button>
+              ))}
+            </div>
+          )}
+          <MessageList
+            messages={metabot.messages.filter(
+              (message) => message.type !== "chart",
+            )}
+            isProcessing={metabot.isProcessing}
+            scrollRef={scrollRef}
+            palette={crm}
+          />
+        </div>
+
+        <InstructionsDrawer
+          customInstructions={metabot.customInstructions}
+          setCustomInstructions={metabot.setCustomInstructions}
+          palette={crm}
+        />
+        <Composer
+          value={inputValue}
+          onChange={setInputValue}
+          onSubmit={handleSubmit}
+          canSend={canSend}
+          placeholder="Ask about customers, orders..."
+          onCancel={metabot.cancelRequest}
+          isProcessing={metabot.isProcessing}
+          palette={crm}
+        />
+      </div>
+    </div>
+  );
+};
+
+const meta: Meta<typeof CrmDemo> = {
+  title: "EmbeddingSDK/useMetabot/CRM (AcmeCRM)",
+  component: CrmDemo,
+  parameters: { layout: "fullscreen" },
+  decorators: [makeSdkWrapper()],
+};
+
+export default meta;
+
+export const AcmeCRM: StoryFn = () => <CrmDemo />;

--- a/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot-devops.stories.tsx
+++ b/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot-devops.stories.tsx
@@ -60,14 +60,16 @@ const InfraWatchBg = () => (
       <span style={{ fontWeight: 800, fontSize: 14, color: dv.accentLight }}>
         InfraWatch
       </span>
-      {["Dashboards", "Monitors", "APM", "Logs", "Infrastructure"].map((t) => (
-        <span
-          key={t}
-          style={{ fontSize: 12, color: dv.textSecondary, cursor: "pointer" }}
-        >
-          {t}
-        </span>
-      ))}
+      {["Dashboards", "Monitors", "APM", "Logs", "Infrastructure"].map(
+        (tab) => (
+          <span
+            key={tab}
+            style={{ fontSize: 12, color: dv.textSecondary, cursor: "pointer" }}
+          >
+            {tab}
+          </span>
+        ),
+      )}
       <span style={{ marginLeft: "auto", fontSize: 12, color: dv.textMuted }}>
         Press ⌘K to open Metabot
       </span>
@@ -144,12 +146,12 @@ const DevopsDemo = () => {
 
   // Open/close with Cmd+K
   useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.key === "k") {
-        e.preventDefault();
-        setOpen((v) => !v);
+    const handler = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key === "k") {
+        event.preventDefault();
+        setOpen((isOpen) => !isOpen);
       }
-      if (e.key === "Escape") {
+      if (event.key === "Escape") {
         setOpen(false);
       }
     };
@@ -239,8 +241,8 @@ const DevopsDemo = () => {
                   fontFamily: "inherit",
                 }}
                 value={inputValue}
-                onChange={(e) => setInputValue(e.target.value)}
-                onKeyDown={(e) => e.key === "Enter" && handleSubmit()}
+                onChange={(event) => setInputValue(event.target.value)}
+                onKeyDown={(event) => event.key === "Enter" && handleSubmit()}
                 placeholder="Ask about products, orders..."
               />
               <button
@@ -259,9 +261,9 @@ const DevopsDemo = () => {
             </div>
 
             {/* Errors */}
-            {metabot.errorMessages.map((err, i) => (
+            {metabot.errorMessages.map((errorMessage, index) => (
               <div
-                key={i}
+                key={index}
                 style={{
                   padding: "6px 16px",
                   fontSize: 12,
@@ -269,7 +271,7 @@ const DevopsDemo = () => {
                   background: dv.redDim,
                 }}
               >
-                {err.message}
+                {errorMessage.message}
               </div>
             ))}
 
@@ -303,12 +305,12 @@ const DevopsDemo = () => {
                     "Which products have the lowest ratings?",
                     "Show order volume over time",
                     "Average review rating by category",
-                  ].map((p) => (
+                  ].map((prompt) => (
                     <div
-                      key={p}
+                      key={prompt}
                       onClick={() => {
                         if (!metabot.isProcessing) {
-                          metabot.submitMessage(p);
+                          metabot.submitMessage(prompt);
                         }
                       }}
                       style={{
@@ -322,7 +324,7 @@ const DevopsDemo = () => {
                         border: `1px solid ${dv.border}`,
                       }}
                     >
-                      {p}
+                      {prompt}
                     </div>
                   ))}
                 </div>

--- a/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot-devops.stories.tsx
+++ b/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot-devops.stories.tsx
@@ -1,0 +1,444 @@
+import type { Meta, StoryFn } from "@storybook/react";
+import { useEffect, useRef, useState } from "react";
+
+import { useMetabot } from "./use-metabot";
+import {
+  CloseIcon,
+  MessageList,
+  SharedKeyframes,
+  SparkleIcon,
+  makeSdkWrapper,
+} from "./use-metabot.stories.utils";
+
+// ============================================================================
+// DevOps (InfraWatch) palette
+// ============================================================================
+
+const dv = {
+  bg: "#1b1e2e",
+  surface: "#20243a",
+  surfaceRaised: "#272b42",
+  surfaceHover: "#2f3450",
+  border: "#363b5a",
+  borderSubtle: "#2a2f4a",
+  text: "#e2e4f0",
+  textSecondary: "#8b90b0",
+  textMuted: "#585d7e",
+  accent: "#774aa4",
+  accentLight: "#b39ddb",
+  accentDim: "#774aa425",
+  gradient: "linear-gradient(135deg, #774aa4 0%, #b39ddb 100%)",
+  red: "#f87171",
+  redDim: "#f8717120",
+};
+
+// ============================================================================
+// Fake InfraWatch monitoring background
+// ============================================================================
+
+const InfraWatchBg = () => (
+  <div
+    style={{
+      position: "absolute",
+      inset: 0,
+      background: dv.bg,
+      overflow: "hidden",
+      zIndex: 0,
+    }}
+  >
+    {/* Top nav */}
+    <div
+      style={{
+        height: 44,
+        borderBottom: `1px solid ${dv.border}`,
+        display: "flex",
+        alignItems: "center",
+        padding: "0 20px",
+        gap: 20,
+      }}
+    >
+      <span style={{ fontWeight: 800, fontSize: 14, color: dv.accentLight }}>
+        InfraWatch
+      </span>
+      {["Dashboards", "Monitors", "APM", "Logs", "Infrastructure"].map((t) => (
+        <span
+          key={t}
+          style={{ fontSize: 12, color: dv.textSecondary, cursor: "pointer" }}
+        >
+          {t}
+        </span>
+      ))}
+      <span style={{ marginLeft: "auto", fontSize: 12, color: dv.textMuted }}>
+        Press ⌘K to open Metabot
+      </span>
+    </div>
+    {/* Alert list */}
+    <div style={{ padding: "20px 24px" }}>
+      <div
+        style={{
+          fontSize: 15,
+          fontWeight: 700,
+          color: dv.text,
+          marginBottom: 16,
+        }}
+      >
+        Active monitors
+      </div>
+      {[
+        ["P1", "API error rate > 5%", "web-api", "3m ago", true],
+        ["P2", "CPU usage > 90%", "worker-fleet", "12m ago", true],
+        ["P3", "Memory spike", "cache-cluster", "1h ago", false],
+        ["P3", "Latency p99 > 800ms", "checkout-service", "2h ago", false],
+      ].map(([prio, name, service, time, active]) => (
+        <div
+          key={String(name)}
+          style={{
+            background: dv.surface,
+            border: `1px solid ${active ? dv.red + "50" : dv.border}`,
+            borderLeft: `4px solid ${active ? dv.red : dv.textMuted}`,
+            borderRadius: 8,
+            padding: "10px 14px",
+            marginBottom: 8,
+            display: "flex",
+            alignItems: "center",
+            gap: 12,
+            fontSize: 13,
+          }}
+        >
+          <span
+            style={{
+              fontSize: 11,
+              fontWeight: 700,
+              color: active ? dv.red : dv.textMuted,
+              background: dv.surfaceRaised,
+              padding: "2px 6px",
+              borderRadius: 4,
+            }}
+          >
+            {String(prio)}
+          </span>
+          <span style={{ flex: 1, color: dv.text }}>{String(name)}</span>
+          <span style={{ color: dv.textMuted }}>{String(service)}</span>
+          <span style={{ color: dv.textMuted, fontSize: 11 }}>
+            {String(time)}
+          </span>
+        </div>
+      ))}
+    </div>
+  </div>
+);
+
+// ============================================================================
+// Story — command palette (Cmd+K modal)
+// ============================================================================
+
+const DevopsDemo = () => {
+  const metabot = useMetabot();
+  const [open, setOpen] = useState(false);
+  const [inputValue, setInputValue] = useState("");
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    scrollRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [metabot.messages, metabot.isProcessing]);
+
+  // Open/close with Cmd+K
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+        e.preventDefault();
+        setOpen((v) => !v);
+      }
+      if (e.key === "Escape") {
+        setOpen(false);
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, []);
+
+  const handleSubmit = () => {
+    if (inputValue.trim() && !metabot.isProcessing) {
+      metabot.submitMessage(inputValue.trim());
+      setInputValue("");
+    }
+  };
+
+  const canSend = inputValue.trim().length > 0 && !metabot.isProcessing;
+
+  return (
+    <div
+      style={{
+        position: "relative",
+        width: "100%",
+        height: "100vh",
+        overflow: "hidden",
+        fontFamily: '"Inter", -apple-system, BlinkMacSystemFont, sans-serif',
+      }}
+    >
+      <SharedKeyframes />
+      <InfraWatchBg />
+
+      {/* Command palette overlay */}
+      {open && (
+        <>
+          {/* Backdrop */}
+          <div
+            onClick={() => setOpen(false)}
+            style={{
+              position: "fixed",
+              inset: 0,
+              background: "rgba(0,0,0,0.6)",
+              zIndex: 999,
+            }}
+          />
+          {/* Modal */}
+          <div
+            style={{
+              position: "fixed",
+              top: "10%",
+              left: "50%",
+              transform: "translateX(-50%)",
+              width: 600,
+              maxHeight: 480,
+              background: dv.surface,
+              border: `1px solid ${dv.border}`,
+              borderRadius: 14,
+              boxShadow: "0 32px 80px rgba(0,0,0,0.6)",
+              display: "flex",
+              flexDirection: "column",
+              overflow: "hidden",
+              zIndex: 1000,
+              animation: "metabotFadeUp 0.2s ease",
+            }}
+          >
+            {/* Search bar */}
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 10,
+                padding: "12px 16px",
+                borderBottom: `1px solid ${dv.border}`,
+                flexShrink: 0,
+                color: dv.accentLight,
+              }}
+            >
+              <SparkleIcon size={16} />
+              <style>{`.dv-search-input::placeholder { color: ${dv.textSecondary}; opacity: 1; }`}</style>
+              <input
+                autoFocus
+                className="dv-search-input"
+                style={{
+                  flex: 1,
+                  background: "none",
+                  border: "none",
+                  outline: "none",
+                  fontSize: 15,
+                  color: dv.text,
+                  fontFamily: "inherit",
+                }}
+                value={inputValue}
+                onChange={(e) => setInputValue(e.target.value)}
+                onKeyDown={(e) => e.key === "Enter" && handleSubmit()}
+                placeholder="Ask about products, orders..."
+              />
+              <button
+                onClick={() => setOpen(false)}
+                style={{
+                  background: "none",
+                  border: "none",
+                  color: dv.textMuted,
+                  cursor: "pointer",
+                  padding: 4,
+                  display: "flex",
+                }}
+              >
+                <CloseIcon />
+              </button>
+            </div>
+
+            {/* Errors */}
+            {metabot.errorMessages.map((err, i) => (
+              <div
+                key={i}
+                style={{
+                  padding: "6px 16px",
+                  fontSize: 12,
+                  color: dv.red,
+                  background: dv.redDim,
+                }}
+              >
+                {err.message}
+              </div>
+            ))}
+
+            {/* Messages */}
+            <div
+              style={{
+                flex: 1,
+                overflowY: "auto",
+                padding: "10px 14px",
+                minHeight: 0,
+              }}
+            >
+              {metabot.messages.length === 0 && !metabot.isProcessing && (
+                <div
+                  style={{
+                    color: dv.textMuted,
+                    fontSize: 13,
+                    padding: "16px 0",
+                  }}
+                >
+                  <div
+                    style={{
+                      marginBottom: 8,
+                      fontWeight: 600,
+                      color: dv.textSecondary,
+                    }}
+                  >
+                    Suggested
+                  </div>
+                  {[
+                    "Which products have the lowest ratings?",
+                    "Show order volume over time",
+                    "Average review rating by category",
+                  ].map((p) => (
+                    <div
+                      key={p}
+                      onClick={() => {
+                        if (!metabot.isProcessing) {
+                          metabot.submitMessage(p);
+                        }
+                      }}
+                      style={{
+                        padding: "8px 10px",
+                        borderRadius: 6,
+                        cursor: "pointer",
+                        fontSize: 13,
+                        color: dv.text,
+                        marginBottom: 4,
+                        background: dv.surfaceRaised,
+                        border: `1px solid ${dv.border}`,
+                      }}
+                    >
+                      {p}
+                    </div>
+                  ))}
+                </div>
+              )}
+              <MessageList
+                messages={metabot.messages}
+                isProcessing={metabot.isProcessing}
+                scrollRef={scrollRef}
+                palette={dv}
+              />
+            </div>
+
+            {/* Footer controls */}
+            <div
+              style={{
+                borderTop: `1px solid ${dv.border}`,
+                padding: "6px 16px",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                flexShrink: 0,
+              }}
+            >
+              <div style={{ fontSize: 11, color: dv.textMuted }}>
+                {metabot.messages.length > 0 && (
+                  <button
+                    onClick={() => metabot.resetConversation()}
+                    style={{
+                      background: "none",
+                      border: "none",
+                      color: dv.textMuted,
+                      cursor: "pointer",
+                      fontSize: 11,
+                      fontFamily: "inherit",
+                    }}
+                  >
+                    Clear conversation
+                  </button>
+                )}
+              </div>
+              <button
+                onClick={handleSubmit}
+                disabled={!canSend}
+                style={{
+                  background: canSend ? dv.accent : dv.surfaceRaised,
+                  border: "none",
+                  borderRadius: 6,
+                  padding: "5px 14px",
+                  color: canSend ? "#fff" : dv.textMuted,
+                  fontSize: 12,
+                  fontWeight: 600,
+                  cursor: canSend ? "pointer" : "default",
+                  fontFamily: "inherit",
+                }}
+              >
+                {metabot.isProcessing ? "Stop" : "Ask →"}
+              </button>
+            </div>
+          </div>
+        </>
+      )}
+
+      {/* Cmd+K hint button */}
+      {!open && (
+        <button
+          onClick={() => setOpen(true)}
+          style={{
+            position: "fixed",
+            bottom: 24,
+            right: 24,
+            background: dv.surface,
+            border: `1px solid ${dv.border}`,
+            borderRadius: 10,
+            padding: "8px 14px",
+            color: dv.textSecondary,
+            fontSize: 13,
+            fontWeight: 600,
+            cursor: "pointer",
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            fontFamily: "inherit",
+            boxShadow: "0 4px 20px rgba(0,0,0,0.4)",
+            zIndex: 100,
+          }}
+        >
+          <SparkleIcon size={14} />
+          Ask Metabot
+          <kbd
+            style={{
+              background: dv.surfaceRaised,
+              padding: "1px 6px",
+              borderRadius: 4,
+              fontSize: 11,
+              color: dv.textMuted,
+            }}
+          >
+            ⌘K
+          </kbd>
+        </button>
+      )}
+    </div>
+  );
+};
+
+const meta: Meta<typeof DevopsDemo> = {
+  title: "EmbeddingSDK/useMetabot/DevOps (InfraWatch Monitoring)",
+  component: DevopsDemo,
+  parameters: {
+    layout: "fullscreen",
+    // Raise SDK popovers above the command palette modal (z-index: 1000)
+    sdkThemeOverride: { components: { popover: { zIndex: 1001 } } },
+  },
+  decorators: [makeSdkWrapper()],
+};
+
+export default meta;
+
+export const InfraWatchMonitoring: StoryFn = () => <DevopsDemo />;

--- a/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot-ecommerce.stories.tsx
+++ b/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot-ecommerce.stories.tsx
@@ -136,7 +136,7 @@ const StorefrontBg = () => (
           ["Total customers", "48,291", "+8.3%"],
           ["Returning", "61%", "+2.1%"],
           ["Avg. order value", "$84.20", "+12%"],
-        ].map(([label, val, delta]) => (
+        ].map(([label, value, delta]) => (
           <div
             key={label}
             style={{
@@ -155,7 +155,7 @@ const StorefrontBg = () => (
                 margin: "4px 0",
               }}
             >
-              {val}
+              {value}
             </div>
             <div style={{ fontSize: 12, color: ec.accentLight }}>{delta}</div>
           </div>
@@ -344,9 +344,9 @@ const EcommerceDemo = () => {
           </div>
 
           {/* Errors */}
-          {metabot.errorMessages.map((err, i) => (
+          {metabot.errorMessages.map((errorMessage, index) => (
             <div
-              key={i}
+              key={index}
               style={{
                 padding: "6px 16px",
                 fontSize: 12,
@@ -354,7 +354,7 @@ const EcommerceDemo = () => {
                 background: ec.redDim,
               }}
             >
-              {err.message}
+              {errorMessage.message}
             </div>
           ))}
 
@@ -429,12 +429,12 @@ const EcommerceDemo = () => {
                     "Show top products by revenue this month",
                     "Why did orders drop last Tuesday?",
                     "Which customers ordered the most?",
-                  ].map((p) => (
+                  ].map((prompt) => (
                     <button
-                      key={p}
+                      key={prompt}
                       onClick={() => {
                         if (!metabot.isProcessing) {
-                          metabot.submitMessage(p);
+                          metabot.submitMessage(prompt);
                         }
                       }}
                       style={{
@@ -452,7 +452,7 @@ const EcommerceDemo = () => {
                         marginBottom: 6,
                       }}
                     >
-                      {p}
+                      {prompt}
                     </button>
                   ))}
                 </div>

--- a/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot-ecommerce.stories.tsx
+++ b/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot-ecommerce.stories.tsx
@@ -6,7 +6,6 @@ import {
   BotIcon,
   CloseIcon,
   Composer,
-  InstructionsDrawer,
   MessageList,
   SharedKeyframes,
   makeSdkWrapper,
@@ -359,6 +358,24 @@ const EcommerceDemo = () => {
             </div>
           ))}
 
+          {/* Pinned latest chart */}
+          {metabot.CurrentChart && (
+            <div
+              style={{
+                height: 260,
+                borderBottom: `1px solid ${ec.border}`,
+                background: ec.surfaceRaised,
+                flexShrink: 0,
+              }}
+            >
+              <metabot.CurrentChart
+                drills
+                isSaveEnabled={false}
+                height="100%"
+              />
+            </div>
+          )}
+
           {/* Messages */}
           <div style={{ flex: 1, overflowY: "auto", padding: "12px 14px" }}>
             {metabot.messages.length === 0 && !metabot.isProcessing && (
@@ -442,18 +459,15 @@ const EcommerceDemo = () => {
               </div>
             )}
             <MessageList
-              messages={metabot.messages}
+              messages={metabot.messages.filter(
+                (message) => message.type !== "chart",
+              )}
               isProcessing={metabot.isProcessing}
               scrollRef={scrollRef}
               palette={ec}
             />
           </div>
 
-          <InstructionsDrawer
-            customInstructions={metabot.customInstructions}
-            setCustomInstructions={metabot.setCustomInstructions}
-            palette={ec}
-          />
           <Composer
             value={inputValue}
             onChange={setInputValue}

--- a/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot-ecommerce.stories.tsx
+++ b/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot-ecommerce.stories.tsx
@@ -1,0 +1,512 @@
+import type { Meta, StoryFn } from "@storybook/react";
+import { useEffect, useRef, useState } from "react";
+
+import { useMetabot } from "./use-metabot";
+import {
+  BotIcon,
+  CloseIcon,
+  Composer,
+  InstructionsDrawer,
+  MessageList,
+  SharedKeyframes,
+  makeSdkWrapper,
+} from "./use-metabot.stories.utils";
+
+// ============================================================================
+// E-commerce (Storefront) palette
+// ============================================================================
+
+const ec = {
+  bg: "#1a1c1e",
+  surface: "#202325",
+  surfaceRaised: "#282b2d",
+  surfaceHover: "#303336",
+  border: "#3d4144",
+  borderSubtle: "#2d3033",
+  text: "#e3e5e8",
+  textSecondary: "#9ba3a8",
+  textMuted: "#5e666b",
+  accent: "#008060",
+  accentLight: "#34d399",
+  accentDim: "#00806025",
+  gradient: "linear-gradient(135deg, #008060 0%, #34d399 100%)",
+  red: "#f87171",
+  redDim: "#f8717120",
+};
+
+// ============================================================================
+// Fake Storefront Admin background
+// ============================================================================
+
+const StorefrontBg = () => (
+  <div
+    style={{
+      position: "absolute",
+      inset: 0,
+      background: ec.bg,
+      overflow: "hidden",
+      zIndex: 0,
+      display: "flex",
+    }}
+  >
+    {/* Left sidebar */}
+    <div
+      style={{
+        width: 200,
+        background: "#111314",
+        borderRight: `1px solid ${ec.border}`,
+        padding: "16px 0",
+        flexShrink: 0,
+      }}
+    >
+      <div
+        style={{
+          padding: "0 16px 16px",
+          fontWeight: 800,
+          fontSize: 15,
+          color: ec.text,
+        }}
+      >
+        Storefront
+      </div>
+      {[
+        "Orders",
+        "Products",
+        "Customers",
+        "Analytics",
+        "Marketing",
+        "Discounts",
+      ].map((item, i) => (
+        <div
+          key={item}
+          style={{
+            padding: "8px 16px",
+            fontSize: 13,
+            color: i === 2 ? ec.text : ec.textSecondary,
+            background: i === 2 ? ec.surfaceRaised : "none",
+            borderLeft:
+              i === 2 ? `3px solid ${ec.accent}` : "3px solid transparent",
+            cursor: "pointer",
+          }}
+        >
+          {item}
+        </div>
+      ))}
+    </div>
+
+    {/* Main content */}
+    <div style={{ flex: 1, padding: 24, overflowY: "auto" }}>
+      {/* Top bar */}
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          marginBottom: 24,
+        }}
+      >
+        <div style={{ fontSize: 20, fontWeight: 700, color: ec.text }}>
+          Customers
+        </div>
+        <button
+          style={{
+            background: ec.accent,
+            border: "none",
+            borderRadius: 6,
+            padding: "8px 16px",
+            color: "#fff",
+            fontSize: 13,
+            fontWeight: 600,
+            cursor: "pointer",
+            fontFamily: "inherit",
+          }}
+        >
+          Export
+        </button>
+      </div>
+      {/* Stat cards */}
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "1fr 1fr 1fr",
+          gap: 16,
+          marginBottom: 24,
+        }}
+      >
+        {[
+          ["Total customers", "48,291", "+8.3%"],
+          ["Returning", "61%", "+2.1%"],
+          ["Avg. order value", "$84.20", "+12%"],
+        ].map(([label, val, delta]) => (
+          <div
+            key={label}
+            style={{
+              background: ec.surface,
+              border: `1px solid ${ec.border}`,
+              borderRadius: 10,
+              padding: 16,
+            }}
+          >
+            <div style={{ fontSize: 12, color: ec.textMuted }}>{label}</div>
+            <div
+              style={{
+                fontSize: 24,
+                fontWeight: 800,
+                color: ec.text,
+                margin: "4px 0",
+              }}
+            >
+              {val}
+            </div>
+            <div style={{ fontSize: 12, color: ec.accentLight }}>{delta}</div>
+          </div>
+        ))}
+      </div>
+      {/* Order table */}
+      <div
+        style={{
+          background: ec.surface,
+          border: `1px solid ${ec.border}`,
+          borderRadius: 10,
+          overflow: "hidden",
+        }}
+      >
+        <div
+          style={{
+            padding: "12px 16px",
+            borderBottom: `1px solid ${ec.border}`,
+            fontWeight: 600,
+            fontSize: 13,
+            color: ec.text,
+          }}
+        >
+          Recent orders
+        </div>
+        {[
+          ["#1204", "Sarah Chen", "$142.00", "Fulfilled"],
+          ["#1203", "James Park", "$89.50", "Pending"],
+          ["#1202", "Maria Santos", "$214.00", "Fulfilled"],
+          ["#1201", "Alex Kim", "$56.80", "Cancelled"],
+        ].map(([id, name, amount, status], i) => (
+          <div
+            key={id}
+            style={{
+              padding: "12px 16px",
+              display: "flex",
+              gap: 16,
+              fontSize: 13,
+              color: ec.textSecondary,
+              borderBottom: i < 3 ? `1px solid ${ec.borderSubtle}` : "none",
+            }}
+          >
+            <span style={{ color: ec.accentLight, fontWeight: 600 }}>{id}</span>
+            <span style={{ flex: 1 }}>{name}</span>
+            <span>{amount}</span>
+            <span
+              style={{
+                color:
+                  status === "Fulfilled"
+                    ? ec.accentLight
+                    : status === "Cancelled"
+                      ? ec.red
+                      : ec.textMuted,
+              }}
+            >
+              {status}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  </div>
+);
+
+// ============================================================================
+// Story
+// ============================================================================
+
+const EcommerceDemo = () => {
+  const metabot = useMetabot();
+  const [open, setOpen] = useState(false);
+  const [inputValue, setInputValue] = useState("");
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    scrollRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [metabot.messages, metabot.isProcessing]);
+
+  const handleSubmit = () => {
+    if (inputValue.trim() && !metabot.isProcessing) {
+      metabot.submitMessage(inputValue.trim());
+      setInputValue("");
+    }
+  };
+
+  const canSend = inputValue.trim().length > 0 && !metabot.isProcessing;
+
+  return (
+    <div
+      style={{
+        position: "relative",
+        width: "100%",
+        height: "100vh",
+        overflow: "hidden",
+        fontFamily: '"Inter", -apple-system, BlinkMacSystemFont, sans-serif',
+      }}
+    >
+      <SharedKeyframes />
+      <StorefrontBg />
+
+      {/* Slide-in drawer from right */}
+      {open && (
+        <div
+          style={{
+            position: "fixed",
+            top: 0,
+            right: 0,
+            width: 400,
+            height: "100%",
+            background: ec.surface,
+            borderLeft: `1px solid ${ec.border}`,
+            boxShadow: "-24px 0 80px rgba(0,0,0,0.5)",
+            display: "flex",
+            flexDirection: "column",
+            zIndex: 1000,
+            animation: "metabotFadeUp 0.25s ease",
+          }}
+        >
+          {/* Header */}
+          <div
+            style={{
+              padding: "14px 16px",
+              background: ec.surfaceRaised,
+              borderBottom: `1px solid ${ec.border}`,
+              display: "flex",
+              alignItems: "center",
+              gap: 10,
+              flexShrink: 0,
+            }}
+          >
+            <div
+              style={{
+                width: 32,
+                height: 32,
+                borderRadius: 8,
+                background: ec.gradient,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                color: "#fff",
+              }}
+            >
+              <BotIcon size={16} />
+            </div>
+            <div style={{ flex: 1 }}>
+              <div style={{ fontSize: 14, fontWeight: 700, color: ec.text }}>
+                Metabot
+              </div>
+              <div
+                style={{
+                  fontSize: 11,
+                  color: metabot.isProcessing ? ec.accentLight : ec.textMuted,
+                }}
+              >
+                {metabot.isProcessing
+                  ? "Thinking..."
+                  : "Ask about your store data"}
+              </div>
+            </div>
+            <button
+              onClick={() => metabot.resetConversation()}
+              style={{
+                background: "none",
+                border: "none",
+                color: ec.textMuted,
+                fontSize: 11,
+                cursor: "pointer",
+                fontFamily: "inherit",
+              }}
+            >
+              Clear
+            </button>
+            <button
+              onClick={() => setOpen(false)}
+              style={{
+                background: "none",
+                border: "none",
+                color: ec.textSecondary,
+                cursor: "pointer",
+                padding: 4,
+                display: "flex",
+              }}
+            >
+              <CloseIcon />
+            </button>
+          </div>
+
+          {/* Errors */}
+          {metabot.errorMessages.map((err, i) => (
+            <div
+              key={i}
+              style={{
+                padding: "6px 16px",
+                fontSize: 12,
+                color: ec.red,
+                background: ec.redDim,
+              }}
+            >
+              {err.message}
+            </div>
+          ))}
+
+          {/* Messages */}
+          <div style={{ flex: 1, overflowY: "auto", padding: "12px 14px" }}>
+            {metabot.messages.length === 0 && !metabot.isProcessing && (
+              <div
+                style={{
+                  textAlign: "center",
+                  padding: "40px 20px",
+                  color: ec.textMuted,
+                }}
+              >
+                <div
+                  style={{
+                    width: 48,
+                    height: 48,
+                    borderRadius: 12,
+                    background: ec.gradient,
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    color: "#fff",
+                    margin: "0 auto 12px",
+                  }}
+                >
+                  <BotIcon size={24} />
+                </div>
+                <div
+                  style={{
+                    fontSize: 14,
+                    fontWeight: 700,
+                    color: ec.text,
+                    marginBottom: 8,
+                  }}
+                >
+                  Ask about your store
+                </div>
+                <div
+                  style={{ marginTop: 16, width: "100%", textAlign: "left" }}
+                >
+                  <div
+                    style={{
+                      fontSize: 11,
+                      color: ec.textMuted,
+                      fontWeight: 600,
+                      marginBottom: 8,
+                      textAlign: "center",
+                    }}
+                  >
+                    SUGGESTED QUESTIONS
+                  </div>
+                  {[
+                    "Show top products by revenue this month",
+                    "Why did orders drop last Tuesday?",
+                    "Which customers ordered the most?",
+                  ].map((p) => (
+                    <button
+                      key={p}
+                      onClick={() => {
+                        if (!metabot.isProcessing) {
+                          metabot.submitMessage(p);
+                        }
+                      }}
+                      style={{
+                        display: "block",
+                        width: "100%",
+                        textAlign: "left",
+                        background: ec.surfaceRaised,
+                        border: `1px solid ${ec.border}`,
+                        borderRadius: 7,
+                        padding: "8px 10px",
+                        fontSize: 12,
+                        color: ec.textSecondary,
+                        cursor: "pointer",
+                        fontFamily: "inherit",
+                        marginBottom: 6,
+                      }}
+                    >
+                      {p}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+            <MessageList
+              messages={metabot.messages}
+              isProcessing={metabot.isProcessing}
+              scrollRef={scrollRef}
+              palette={ec}
+            />
+          </div>
+
+          <InstructionsDrawer
+            customInstructions={metabot.customInstructions}
+            setCustomInstructions={metabot.setCustomInstructions}
+            palette={ec}
+          />
+          <Composer
+            value={inputValue}
+            onChange={setInputValue}
+            onSubmit={handleSubmit}
+            canSend={canSend}
+            placeholder="Ask about orders, products..."
+            onCancel={metabot.cancelRequest}
+            isProcessing={metabot.isProcessing}
+            palette={ec}
+          />
+        </div>
+      )}
+
+      {/* FAB to open drawer */}
+      {!open && (
+        <button
+          onClick={() => setOpen(true)}
+          style={{
+            position: "fixed",
+            bottom: 24,
+            right: 24,
+            width: 52,
+            height: 52,
+            borderRadius: 14,
+            border: "none",
+            background: ec.gradient,
+            color: "#fff",
+            cursor: "pointer",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            boxShadow: `0 4px 24px ${ec.accent}50`,
+            zIndex: 1000,
+          }}
+        >
+          <BotIcon size={24} />
+        </button>
+      )}
+    </div>
+  );
+};
+
+const meta: Meta<typeof EcommerceDemo> = {
+  title: "EmbeddingSDK/useMetabot/Ecommerce (Storefront)",
+  component: EcommerceDemo,
+  parameters: {
+    layout: "fullscreen",
+    // Raise SDK popovers above the slide-in drawer (z-index: 1000)
+    sdkThemeOverride: { components: { popover: { zIndex: 1001 } } },
+  },
+  decorators: [makeSdkWrapper()],
+};
+
+export default meta;
+
+export const Storefront: StoryFn = () => <EcommerceDemo />;

--- a/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot-fintech.stories.tsx
+++ b/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot-fintech.stories.tsx
@@ -5,7 +5,6 @@ import { useMetabot } from "./use-metabot";
 import {
   BotIcon,
   Composer,
-  InstructionsDrawer,
   MessageList,
   SharedKeyframes,
   makeSdkWrapper,
@@ -210,7 +209,19 @@ const FintechDemo = () => {
     >
       <SharedKeyframes />
       <div style={{ flex: 1, position: "relative" }}>
-        <PayFlowBg />
+        {metabot.CurrentChart ? (
+          <div
+            style={{
+              position: "absolute",
+              inset: 0,
+              background: ft.bg,
+            }}
+          >
+            <metabot.CurrentChart drills isSaveEnabled={false} height="100%" />
+          </div>
+        ) : (
+          <PayFlowBg />
+        )}
       </div>
 
       {/* Inline side panel — always visible on the right */}
@@ -336,18 +347,15 @@ const FintechDemo = () => {
             </div>
           )}
           <MessageList
-            messages={metabot.messages}
+            messages={metabot.messages.filter(
+              (message) => message.type !== "chart",
+            )}
             isProcessing={metabot.isProcessing}
             scrollRef={scrollRef}
             palette={ft}
           />
         </div>
 
-        <InstructionsDrawer
-          customInstructions={metabot.customInstructions}
-          setCustomInstructions={metabot.setCustomInstructions}
-          palette={ft}
-        />
         <Composer
           value={inputValue}
           onChange={setInputValue}

--- a/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot-fintech.stories.tsx
+++ b/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot-fintech.stories.tsx
@@ -1,0 +1,375 @@
+import type { Meta, StoryFn } from "@storybook/react";
+import { useEffect, useRef, useState } from "react";
+
+import { useMetabot } from "./use-metabot";
+import {
+  BotIcon,
+  Composer,
+  InstructionsDrawer,
+  MessageList,
+  SharedKeyframes,
+  makeSdkWrapper,
+} from "./use-metabot.stories.utils";
+
+// ============================================================================
+// FinTech (PayFlow) palette
+// ============================================================================
+
+const ft = {
+  bg: "#0a2540",
+  surface: "#0d2d4a",
+  surfaceRaised: "#133558",
+  surfaceHover: "#1a3f67",
+  border: "#1e4976",
+  borderSubtle: "#153560",
+  text: "#e8f0fe",
+  textSecondary: "#8bafd4",
+  textMuted: "#4a7499",
+  accent: "#635bff",
+  accentLight: "#a29bfe",
+  accentDim: "#635bff25",
+  gradient: "linear-gradient(135deg, #635bff 0%, #a29bfe 100%)",
+  red: "#f87171",
+  redDim: "#f8717120",
+};
+
+// ============================================================================
+// Fake PayFlow Dashboard background
+// ============================================================================
+
+const PayFlowBg = () => (
+  <div
+    style={{
+      position: "absolute",
+      inset: 0,
+      background: ft.bg,
+      overflow: "hidden",
+      zIndex: 0,
+    }}
+  >
+    {/* Top nav */}
+    <div
+      style={{
+        height: 48,
+        borderBottom: `1px solid ${ft.border}`,
+        display: "flex",
+        alignItems: "center",
+        padding: "0 24px",
+        gap: 24,
+      }}
+    >
+      <span style={{ fontWeight: 800, fontSize: 15, color: ft.text }}>
+        <span style={{ color: ft.accentLight }}>Pay</span>Flow
+      </span>
+      {["Home", "Payments", "Customers", "Reports", "Developers"].map((t) => (
+        <span
+          key={t}
+          style={{ fontSize: 13, color: ft.textSecondary, cursor: "pointer" }}
+        >
+          {t}
+        </span>
+      ))}
+    </div>
+    {/* Stat cards */}
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "1fr 1fr 1fr 1fr",
+        gap: 16,
+        padding: 24,
+      }}
+    >
+      {[
+        ["Gross volume", "$2.41M", "+18.2%"],
+        ["MRR", "$142K", "+6.4%"],
+        ["Churn", "2.8%", "-0.3%"],
+        ["Active subs", "8,214", "+12.1%"],
+      ].map(([label, val, delta]) => (
+        <div
+          key={label}
+          style={{
+            background: ft.surface,
+            border: `1px solid ${ft.border}`,
+            borderRadius: 10,
+            padding: 16,
+          }}
+        >
+          <div style={{ fontSize: 12, color: ft.textMuted }}>{label}</div>
+          <div
+            style={{
+              fontSize: 22,
+              fontWeight: 800,
+              color: ft.text,
+              margin: "6px 0 4px",
+            }}
+          >
+            {val}
+          </div>
+          <div
+            style={{
+              fontSize: 12,
+              color: delta?.startsWith("-") ? ft.red : ft.accentLight,
+            }}
+          >
+            {delta}
+          </div>
+        </div>
+      ))}
+    </div>
+    {/* Payments table */}
+    <div style={{ padding: "0 24px" }}>
+      <div
+        style={{
+          background: ft.surface,
+          border: `1px solid ${ft.border}`,
+          borderRadius: 10,
+          overflow: "hidden",
+        }}
+      >
+        <div
+          style={{
+            padding: "12px 16px",
+            borderBottom: `1px solid ${ft.border}`,
+            fontWeight: 600,
+            fontSize: 13,
+            color: ft.text,
+          }}
+        >
+          Recent payments
+        </div>
+        {[
+          ["Jane Cooper", "Enterprise plan", "$2,400", "Succeeded"],
+          ["Acme Corp", "Starter plan", "$149", "Succeeded"],
+          ["Bob Martin", "Pro plan", "$490", "Failed"],
+          ["TechCo Ltd", "Enterprise plan", "$2,400", "Refunded"],
+        ].map(([name, plan, amount, status], i) => (
+          <div
+            key={name}
+            style={{
+              padding: "12px 16px",
+              display: "flex",
+              gap: 16,
+              fontSize: 13,
+              color: ft.textSecondary,
+              borderBottom: i < 3 ? `1px solid ${ft.borderSubtle}` : "none",
+            }}
+          >
+            <span style={{ flex: 1 }}>{name}</span>
+            <span style={{ color: ft.textMuted }}>{plan}</span>
+            <span style={{ fontWeight: 600, color: ft.text }}>{amount}</span>
+            <span
+              style={{
+                color:
+                  status === "Succeeded"
+                    ? ft.accentLight
+                    : status === "Failed"
+                      ? ft.red
+                      : ft.textMuted,
+              }}
+            >
+              {status}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  </div>
+);
+
+// ============================================================================
+// Story
+// ============================================================================
+
+const FintechDemo = () => {
+  const metabot = useMetabot();
+  const [inputValue, setInputValue] = useState("");
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    scrollRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [metabot.messages, metabot.isProcessing]);
+
+  const handleSubmit = () => {
+    if (inputValue.trim() && !metabot.isProcessing) {
+      metabot.submitMessage(inputValue.trim());
+      setInputValue("");
+    }
+  };
+
+  const canSend = inputValue.trim().length > 0 && !metabot.isProcessing;
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        width: "100%",
+        height: "100vh",
+        overflow: "hidden",
+        fontFamily: '"Inter", -apple-system, BlinkMacSystemFont, sans-serif',
+      }}
+    >
+      <SharedKeyframes />
+      <div style={{ flex: 1, position: "relative" }}>
+        <PayFlowBg />
+      </div>
+
+      {/* Inline side panel — always visible on the right */}
+      <div
+        style={{
+          width: 360,
+          height: "100%",
+          background: ft.surface,
+          borderLeft: `1px solid ${ft.border}`,
+          display: "flex",
+          flexDirection: "column",
+        }}
+      >
+        {/* Header */}
+        <div
+          style={{
+            padding: "14px 16px",
+            background: ft.surfaceRaised,
+            borderBottom: `1px solid ${ft.border}`,
+            display: "flex",
+            alignItems: "center",
+            gap: 10,
+            flexShrink: 0,
+          }}
+        >
+          <div
+            style={{
+              width: 30,
+              height: 30,
+              borderRadius: 8,
+              background: ft.gradient,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              color: "#fff",
+            }}
+          >
+            <BotIcon size={14} />
+          </div>
+          <div style={{ flex: 1 }}>
+            <div style={{ fontSize: 14, fontWeight: 700, color: ft.text }}>
+              Metabot
+            </div>
+            <div
+              style={{
+                fontSize: 11,
+                color: metabot.isProcessing ? ft.accentLight : ft.textMuted,
+              }}
+            >
+              {metabot.isProcessing ? "Analyzing..." : "Financial analytics"}
+            </div>
+          </div>
+          <button
+            onClick={() => metabot.resetConversation()}
+            style={{
+              background: "none",
+              border: "none",
+              color: ft.textMuted,
+              fontSize: 11,
+              cursor: "pointer",
+              fontFamily: "inherit",
+            }}
+          >
+            Clear
+          </button>
+        </div>
+
+        {/* Errors */}
+        {metabot.errorMessages.map((err, i) => (
+          <div
+            key={i}
+            style={{
+              padding: "6px 16px",
+              fontSize: 12,
+              color: ft.red,
+              background: ft.redDim,
+            }}
+          >
+            {err.message}
+          </div>
+        ))}
+
+        {/* Messages */}
+        <div style={{ flex: 1, overflowY: "auto", padding: "12px 14px" }}>
+          {metabot.messages.length === 0 && !metabot.isProcessing && (
+            <div
+              style={{
+                textAlign: "center",
+                padding: "40px 16px",
+                color: ft.textMuted,
+              }}
+            >
+              <div
+                style={{
+                  width: 44,
+                  height: 44,
+                  borderRadius: 12,
+                  background: ft.gradient,
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  color: "#fff",
+                  margin: "0 auto 12px",
+                }}
+              >
+                <BotIcon size={22} />
+              </div>
+              <div
+                style={{
+                  fontSize: 13,
+                  fontWeight: 700,
+                  color: ft.text,
+                  marginBottom: 8,
+                }}
+              >
+                Revenue insights
+              </div>
+              <div style={{ fontSize: 12, lineHeight: 1.5 }}>
+                {
+                  'Try: "What\'s the total revenue this month?" or "Show revenue trend over time"'
+                }
+              </div>
+            </div>
+          )}
+          <MessageList
+            messages={metabot.messages}
+            isProcessing={metabot.isProcessing}
+            scrollRef={scrollRef}
+            palette={ft}
+          />
+        </div>
+
+        <InstructionsDrawer
+          customInstructions={metabot.customInstructions}
+          setCustomInstructions={metabot.setCustomInstructions}
+          palette={ft}
+        />
+        <Composer
+          value={inputValue}
+          onChange={setInputValue}
+          onSubmit={handleSubmit}
+          canSend={canSend}
+          placeholder="Ask about revenue, orders..."
+          onCancel={metabot.cancelRequest}
+          isProcessing={metabot.isProcessing}
+          palette={ft}
+        />
+      </div>
+    </div>
+  );
+};
+
+const meta: Meta<typeof FintechDemo> = {
+  title: "EmbeddingSDK/useMetabot/FinTech (PayFlow)",
+  component: FintechDemo,
+  parameters: { layout: "fullscreen" },
+  decorators: [makeSdkWrapper()],
+};
+
+export default meta;
+
+export const PayFlow: StoryFn = () => <FintechDemo />;

--- a/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot-fintech.stories.tsx
+++ b/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot-fintech.stories.tsx
@@ -60,12 +60,12 @@ const PayFlowBg = () => (
       <span style={{ fontWeight: 800, fontSize: 15, color: ft.text }}>
         <span style={{ color: ft.accentLight }}>Pay</span>Flow
       </span>
-      {["Home", "Payments", "Customers", "Reports", "Developers"].map((t) => (
+      {["Home", "Payments", "Customers", "Reports", "Developers"].map((tab) => (
         <span
-          key={t}
+          key={tab}
           style={{ fontSize: 13, color: ft.textSecondary, cursor: "pointer" }}
         >
-          {t}
+          {tab}
         </span>
       ))}
     </div>
@@ -83,7 +83,7 @@ const PayFlowBg = () => (
         ["MRR", "$142K", "+6.4%"],
         ["Churn", "2.8%", "-0.3%"],
         ["Active subs", "8,214", "+12.1%"],
-      ].map(([label, val, delta]) => (
+      ].map(([label, value, delta]) => (
         <div
           key={label}
           style={{
@@ -102,7 +102,7 @@ const PayFlowBg = () => (
               margin: "6px 0 4px",
             }}
           >
-            {val}
+            {value}
           </div>
           <div
             style={{
@@ -290,9 +290,9 @@ const FintechDemo = () => {
         </div>
 
         {/* Errors */}
-        {metabot.errorMessages.map((err, i) => (
+        {metabot.errorMessages.map((errorMessage, index) => (
           <div
-            key={i}
+            key={index}
             style={{
               padding: "6px 16px",
               fontSize: 12,
@@ -300,7 +300,7 @@ const FintechDemo = () => {
               background: ft.redDim,
             }}
           >
-            {err.message}
+            {errorMessage.message}
           </div>
         ))}
 

--- a/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot-hr.stories.tsx
+++ b/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot-hr.stories.tsx
@@ -62,12 +62,12 @@ const PeopleHQBg = () => (
       <span style={{ fontWeight: 800, fontSize: 15, color: hr.text }}>
         PeopleHQ
       </span>
-      {["People", "Time Off", "Performance", "Reports", "Hiring"].map((t) => (
+      {["People", "Time Off", "Performance", "Reports", "Hiring"].map((tab) => (
         <span
-          key={t}
+          key={tab}
           style={{ fontSize: 13, color: hr.textSecondary, cursor: "pointer" }}
         >
-          {t}
+          {tab}
         </span>
       ))}
     </div>
@@ -96,7 +96,7 @@ const PeopleHQBg = () => (
           ["Avg. tenure", "3.2 yrs", ""],
           ["Attrition", "8.4%", "-1.2% YoY"],
           ["Open roles", "42", "+7 this week"],
-        ].map(([label, val, note]) => (
+        ].map(([label, value, note]) => (
           <div
             key={label}
             style={{
@@ -115,7 +115,7 @@ const PeopleHQBg = () => (
                 margin: "4px 0 2px",
               }}
             >
-              {val}
+              {value}
             </div>
             {note && (
               <div style={{ fontSize: 11, color: hr.accentLight }}>{note}</div>
@@ -203,13 +203,13 @@ const HrDemo = () => {
   const scrollRef = useRef<HTMLDivElement>(null);
   const dragRef = useRef<{ startY: number; startHeight: number } | null>(null);
 
-  const handleDragStart = (e: React.MouseEvent) => {
-    dragRef.current = { startY: e.clientY, startHeight: drawerHeight };
-    const onMove = (ev: MouseEvent) => {
+  const handleDragStart = (event: React.MouseEvent) => {
+    dragRef.current = { startY: event.clientY, startHeight: drawerHeight };
+    const onMove = (moveEvent: MouseEvent) => {
       if (!dragRef.current) {
         return;
       }
-      const delta = dragRef.current.startY - ev.clientY;
+      const delta = dragRef.current.startY - moveEvent.clientY;
       const next = Math.max(
         120,
         Math.min(
@@ -365,9 +365,9 @@ const HrDemo = () => {
           </div>
 
           {/* Errors */}
-          {metabot.errorMessages.map((err, i) => (
+          {metabot.errorMessages.map((errorMessage, index) => (
             <div
-              key={i}
+              key={index}
               style={{
                 padding: "5px 16px",
                 fontSize: 12,
@@ -375,7 +375,7 @@ const HrDemo = () => {
                 background: hr.redDim,
               }}
             >
-              {err.message}
+              {errorMessage.message}
             </div>
           ))}
 
@@ -405,12 +405,12 @@ const HrDemo = () => {
                   "How many customers joined each month?",
                   "Show customer distribution by state",
                   "What's the most common acquisition source?",
-                ].map((p) => (
+                ].map((prompt) => (
                   <button
-                    key={p}
+                    key={prompt}
                     onClick={() => {
                       if (!metabot.isProcessing) {
-                        metabot.submitMessage(p);
+                        metabot.submitMessage(prompt);
                       }
                     }}
                     style={{
@@ -425,7 +425,7 @@ const HrDemo = () => {
                       whiteSpace: "nowrap",
                     }}
                   >
-                    {p}
+                    {prompt}
                   </button>
                 ))}
               </div>

--- a/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot-hr.stories.tsx
+++ b/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot-hr.stories.tsx
@@ -1,0 +1,487 @@
+import type { Meta, StoryFn } from "@storybook/react";
+import { useEffect, useRef, useState } from "react";
+
+import { useMetabot } from "./use-metabot";
+import {
+  BotIcon,
+  CloseIcon,
+  Composer,
+  InstructionsDrawer,
+  MessageList,
+  SharedKeyframes,
+  SparkleIcon,
+  makeSdkWrapper,
+} from "./use-metabot.stories.utils";
+
+// ============================================================================
+// HR / People Analytics (PeopleHQ) palette
+// ============================================================================
+
+const hr = {
+  bg: "#1c1c1e",
+  surface: "#232325",
+  surfaceRaised: "#2c2c2e",
+  surfaceHover: "#363638",
+  border: "#3a3a3c",
+  borderSubtle: "#2c2c2e",
+  text: "#f0f0f2",
+  textSecondary: "#98989e",
+  textMuted: "#636366",
+  accent: "#e35b00",
+  accentLight: "#ff9f5a",
+  accentDim: "#e35b0025",
+  gradient: "linear-gradient(135deg, #e35b00 0%, #ff9f5a 100%)",
+  red: "#f87171",
+  redDim: "#f8717120",
+};
+
+// ============================================================================
+// Fake PeopleHQ background
+// ============================================================================
+
+const PeopleHQBg = () => (
+  <div
+    style={{
+      position: "absolute",
+      inset: 0,
+      background: hr.bg,
+      overflow: "hidden",
+      zIndex: 0,
+    }}
+  >
+    {/* Top nav */}
+    <div
+      style={{
+        height: 48,
+        borderBottom: `1px solid ${hr.border}`,
+        display: "flex",
+        alignItems: "center",
+        padding: "0 24px",
+        gap: 24,
+      }}
+    >
+      <span style={{ fontWeight: 800, fontSize: 15, color: hr.text }}>
+        PeopleHQ
+      </span>
+      {["People", "Time Off", "Performance", "Reports", "Hiring"].map((t) => (
+        <span
+          key={t}
+          style={{ fontSize: 13, color: hr.textSecondary, cursor: "pointer" }}
+        >
+          {t}
+        </span>
+      ))}
+    </div>
+    {/* People metrics header */}
+    <div style={{ padding: "20px 24px 0" }}>
+      <div
+        style={{
+          fontSize: 18,
+          fontWeight: 700,
+          color: hr.text,
+          marginBottom: 16,
+        }}
+      >
+        People Overview
+      </div>
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "1fr 1fr 1fr 1fr",
+          gap: 14,
+          marginBottom: 24,
+        }}
+      >
+        {[
+          ["Headcount", "1,284", "+18 this month"],
+          ["Avg. tenure", "3.2 yrs", ""],
+          ["Attrition", "8.4%", "-1.2% YoY"],
+          ["Open roles", "42", "+7 this week"],
+        ].map(([label, val, note]) => (
+          <div
+            key={label}
+            style={{
+              background: hr.surface,
+              border: `1px solid ${hr.border}`,
+              borderRadius: 10,
+              padding: 14,
+            }}
+          >
+            <div style={{ fontSize: 11, color: hr.textMuted }}>{label}</div>
+            <div
+              style={{
+                fontSize: 22,
+                fontWeight: 800,
+                color: hr.text,
+                margin: "4px 0 2px",
+              }}
+            >
+              {val}
+            </div>
+            {note && (
+              <div style={{ fontSize: 11, color: hr.accentLight }}>{note}</div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+    {/* Employee table */}
+    <div style={{ padding: "0 24px" }}>
+      <div
+        style={{
+          background: hr.surface,
+          border: `1px solid ${hr.border}`,
+          borderRadius: 10,
+          overflow: "hidden",
+        }}
+      >
+        <div
+          style={{
+            padding: "12px 16px",
+            borderBottom: `1px solid ${hr.border}`,
+            fontWeight: 600,
+            fontSize: 13,
+            color: hr.text,
+          }}
+        >
+          Employees
+        </div>
+        {[
+          ["Alice Wang", "Engineering", "Senior IC", "4.2 yrs"],
+          ["James Torres", "Sales", "Account Exec", "1.8 yrs"],
+          ["Priya Sharma", "Product", "PM II", "3.1 yrs"],
+          ["Marcus Lee", "Design", "Lead Designer", "5.6 yrs"],
+        ].map(([name, dept, title, tenure], i) => (
+          <div
+            key={name}
+            style={{
+              padding: "10px 16px",
+              display: "flex",
+              gap: 16,
+              fontSize: 13,
+              color: hr.textSecondary,
+              borderBottom: i < 3 ? `1px solid ${hr.borderSubtle}` : "none",
+              alignItems: "center",
+            }}
+          >
+            <div
+              style={{
+                width: 28,
+                height: 28,
+                borderRadius: "50%",
+                background: hr.gradient,
+                color: "#fff",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                fontSize: 11,
+                fontWeight: 700,
+                flexShrink: 0,
+              }}
+            >
+              {String(name)[0]}
+            </div>
+            <span style={{ flex: 1, color: hr.text }}>{name}</span>
+            <span>{dept}</span>
+            <span style={{ color: hr.textMuted }}>{title}</span>
+            <span style={{ fontSize: 11, color: hr.textMuted }}>{tenure}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  </div>
+);
+
+// ============================================================================
+// Story — bottom drawer that slides up
+// ============================================================================
+
+const HrDemo = () => {
+  const metabot = useMetabot();
+  const [open, setOpen] = useState(false);
+  const [inputValue, setInputValue] = useState("");
+  const [drawerHeight, setDrawerHeight] = useState(340);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const dragRef = useRef<{ startY: number; startHeight: number } | null>(null);
+
+  const handleDragStart = (e: React.MouseEvent) => {
+    dragRef.current = { startY: e.clientY, startHeight: drawerHeight };
+    const onMove = (ev: MouseEvent) => {
+      if (!dragRef.current) {
+        return;
+      }
+      const delta = dragRef.current.startY - ev.clientY;
+      const next = Math.max(
+        120,
+        Math.min(
+          window.innerHeight * 0.85,
+          dragRef.current.startHeight + delta,
+        ),
+      );
+      setDrawerHeight(next);
+    };
+    const onUp = () => {
+      dragRef.current = null;
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+    };
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+  };
+
+  useEffect(() => {
+    scrollRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [metabot.messages, metabot.isProcessing]);
+
+  const handleSubmit = () => {
+    if (inputValue.trim() && !metabot.isProcessing) {
+      metabot.submitMessage(inputValue.trim());
+      setInputValue("");
+    }
+  };
+
+  const canSend = inputValue.trim().length > 0 && !metabot.isProcessing;
+
+  return (
+    <div
+      style={{
+        position: "relative",
+        width: "100%",
+        height: "100vh",
+        overflow: "hidden",
+        fontFamily: '"Inter", -apple-system, BlinkMacSystemFont, sans-serif',
+      }}
+    >
+      <SharedKeyframes />
+      <PeopleHQBg />
+
+      {/* Bottom drawer */}
+      {open && (
+        <div
+          style={{
+            position: "fixed",
+            bottom: 0,
+            left: 0,
+            right: 0,
+            height: drawerHeight,
+            background: hr.surface,
+            borderTop: `1px solid ${hr.border}`,
+            boxShadow: "0 -16px 60px rgba(0,0,0,0.5)",
+            display: "flex",
+            flexDirection: "column",
+            zIndex: 1000,
+            animation: "metabotFadeUp 0.25s ease",
+          }}
+        >
+          {/* Drag handle */}
+          <div
+            onMouseDown={handleDragStart}
+            style={{
+              height: 16,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              cursor: "row-resize",
+              flexShrink: 0,
+              background: hr.surfaceRaised,
+            }}
+          >
+            <div
+              style={{
+                width: 32,
+                height: 3,
+                borderRadius: 2,
+                background: hr.border,
+              }}
+            />
+          </div>
+
+          {/* Header */}
+          <div
+            style={{
+              padding: "10px 16px",
+              background: hr.surfaceRaised,
+              borderBottom: `1px solid ${hr.border}`,
+              display: "flex",
+              alignItems: "center",
+              gap: 10,
+              flexShrink: 0,
+            }}
+          >
+            <div
+              style={{
+                width: 28,
+                height: 28,
+                borderRadius: 7,
+                background: hr.gradient,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                color: "#fff",
+              }}
+            >
+              <BotIcon size={14} />
+            </div>
+            <div style={{ flex: 1 }}>
+              <div style={{ fontSize: 13, fontWeight: 700, color: hr.text }}>
+                Metabot
+              </div>
+              <div
+                style={{
+                  fontSize: 11,
+                  color: metabot.isProcessing ? hr.accentLight : hr.textMuted,
+                }}
+              >
+                {metabot.isProcessing
+                  ? "Thinking..."
+                  : "People analytics assistant"}
+              </div>
+            </div>
+            <button
+              onClick={() => metabot.resetConversation()}
+              style={{
+                background: "none",
+                border: "none",
+                color: hr.textMuted,
+                fontSize: 11,
+                cursor: "pointer",
+                fontFamily: "inherit",
+              }}
+            >
+              Clear
+            </button>
+            <button
+              onClick={() => setOpen(false)}
+              style={{
+                background: "none",
+                border: "none",
+                color: hr.textSecondary,
+                cursor: "pointer",
+                padding: 4,
+                display: "flex",
+              }}
+            >
+              <CloseIcon />
+            </button>
+          </div>
+
+          {/* Errors */}
+          {metabot.errorMessages.map((err, i) => (
+            <div
+              key={i}
+              style={{
+                padding: "5px 16px",
+                fontSize: 12,
+                color: hr.red,
+                background: hr.redDim,
+              }}
+            >
+              {err.message}
+            </div>
+          ))}
+
+          {/* Messages */}
+          <div style={{ flex: 1, overflowY: "auto", padding: "8px 16px" }}>
+            {metabot.messages.length === 0 && !metabot.isProcessing && (
+              <div style={{ display: "flex", gap: 10, paddingTop: 8 }}>
+                {[
+                  "How many customers joined each month?",
+                  "Show customer distribution by state",
+                  "What's the most common acquisition source?",
+                ].map((p) => (
+                  <button
+                    key={p}
+                    onClick={() => {
+                      if (!metabot.isProcessing) {
+                        metabot.submitMessage(p);
+                      }
+                    }}
+                    style={{
+                      background: hr.surfaceRaised,
+                      border: `1px solid ${hr.border}`,
+                      borderRadius: 8,
+                      padding: "6px 12px",
+                      fontSize: 12,
+                      color: hr.textSecondary,
+                      cursor: "pointer",
+                      fontFamily: "inherit",
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    {p}
+                  </button>
+                ))}
+              </div>
+            )}
+            <MessageList
+              messages={metabot.messages}
+              isProcessing={metabot.isProcessing}
+              scrollRef={scrollRef}
+              palette={hr}
+            />
+          </div>
+
+          <InstructionsDrawer
+            customInstructions={metabot.customInstructions}
+            setCustomInstructions={metabot.setCustomInstructions}
+            palette={hr}
+          />
+          <Composer
+            value={inputValue}
+            onChange={setInputValue}
+            onSubmit={handleSubmit}
+            canSend={canSend}
+            placeholder="Ask about people data..."
+            onCancel={metabot.cancelRequest}
+            isProcessing={metabot.isProcessing}
+            palette={hr}
+          />
+        </div>
+      )}
+
+      {/* Trigger button */}
+      {!open && (
+        <button
+          onClick={() => setOpen(true)}
+          style={{
+            position: "fixed",
+            bottom: 24,
+            right: 24,
+            background: hr.gradient,
+            border: "none",
+            borderRadius: 12,
+            padding: "10px 18px",
+            color: "#fff",
+            fontSize: 13,
+            fontWeight: 600,
+            cursor: "pointer",
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            fontFamily: "inherit",
+            boxShadow: `0 4px 20px ${hr.accent}40`,
+            zIndex: 100,
+          }}
+        >
+          <SparkleIcon size={14} />
+          Ask Metabot
+        </button>
+      )}
+    </div>
+  );
+};
+
+const meta: Meta<typeof HrDemo> = {
+  title: "EmbeddingSDK/useMetabot/HR (PeopleHQ)",
+  component: HrDemo,
+  parameters: {
+    layout: "fullscreen",
+    // Raise SDK popovers above the bottom drawer (z-index: 1000)
+    sdkThemeOverride: { components: { popover: { zIndex: 1001 } } },
+  },
+  decorators: [makeSdkWrapper()],
+};
+
+export default meta;
+
+export const PeopleHQ: StoryFn = () => <HrDemo />;

--- a/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot-hr.stories.tsx
+++ b/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot-hr.stories.tsx
@@ -6,7 +6,6 @@ import {
   BotIcon,
   CloseIcon,
   Composer,
-  InstructionsDrawer,
   MessageList,
   SharedKeyframes,
   SparkleIcon,
@@ -380,6 +379,24 @@ const HrDemo = () => {
             </div>
           ))}
 
+          {/* Pinned latest chart */}
+          {metabot.CurrentChart && (
+            <div
+              style={{
+                height: 240,
+                borderBottom: `1px solid ${hr.border}`,
+                background: hr.surfaceRaised,
+                flexShrink: 0,
+              }}
+            >
+              <metabot.CurrentChart
+                drills
+                isSaveEnabled={false}
+                height="100%"
+              />
+            </div>
+          )}
+
           {/* Messages */}
           <div style={{ flex: 1, overflowY: "auto", padding: "8px 16px" }}>
             {metabot.messages.length === 0 && !metabot.isProcessing && (
@@ -414,18 +431,15 @@ const HrDemo = () => {
               </div>
             )}
             <MessageList
-              messages={metabot.messages}
+              messages={metabot.messages.filter(
+                (message) => message.type !== "chart",
+              )}
               isProcessing={metabot.isProcessing}
               scrollRef={scrollRef}
               palette={hr}
             />
           </div>
 
-          <InstructionsDrawer
-            customInstructions={metabot.customInstructions}
-            setCustomInstructions={metabot.setCustomInstructions}
-            palette={hr}
-          />
           <Composer
             value={inputValue}
             onChange={setInputValue}

--- a/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot.stories.utils.tsx
+++ b/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot.stories.utils.tsx
@@ -1,0 +1,535 @@
+import type { ReactNode } from "react";
+import { useState } from "react";
+
+import { CommonSdkStoryWrapper } from "embedding-sdk-bundle/test/CommonSdkStoryWrapper";
+import type { defineMetabaseTheme } from "metabase/embedding-sdk/theme";
+
+import type {
+  MetabotAgentChartMessage,
+  MetabotMessage,
+} from "../../types/metabot";
+
+// ============================================================================
+// Shared keyframes
+// ============================================================================
+
+export const SharedKeyframes = () => (
+  <style>{`
+    @keyframes metabotPulse {
+      0%, 100% { opacity: 0.4; transform: scale(1); }
+      50% { opacity: 1; transform: scale(1.15); }
+    }
+    @keyframes metabotFadeUp {
+      from { opacity: 0; transform: translateY(8px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+    @keyframes metabotShimmer {
+      0% { background-position: -200% center; }
+      100% { background-position: 200% center; }
+    }
+    @keyframes metabotGlow {
+      0%, 100% { opacity: 0.4; }
+      50% { opacity: 0.8; }
+    }
+  `}</style>
+);
+
+// ============================================================================
+// Icons
+// ============================================================================
+
+export const BotIcon = ({ size = 18 }: { size?: number }) => (
+  <svg width={size} height={size} viewBox="0 0 20 20" fill="none">
+    <circle cx="7" cy="8.5" r="1.4" fill="currentColor" />
+    <circle cx="13" cy="8.5" r="1.4" fill="currentColor" />
+    <path
+      d="M7 13c0 0 1.5 1.8 3 1.8s3-1.8 3-1.8"
+      stroke="currentColor"
+      strokeWidth="1.3"
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
+export const SendIcon = () => (
+  <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+    <path d="M14.5 8L2 14V9.5L9 8L2 6.5V2L14.5 8Z" fill="currentColor" />
+  </svg>
+);
+
+export const CloseIcon = () => (
+  <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+    <path
+      d="M11 3L3 11M3 3L11 11"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
+export const SparkleIcon = ({ size = 14 }: { size?: number }) => (
+  <svg width={size} height={size} viewBox="0 0 16 16" fill="none">
+    <path
+      d="M8 1L9.5 6.5L15 8L9.5 9.5L8 15L6.5 9.5L1 8L6.5 6.5L8 1Z"
+      fill="currentColor"
+    />
+  </svg>
+);
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+export const stripMarkdownLinks = (text: string) =>
+  text.replace(/\[([^\]]+)\]\([^)]+\)/g, "$1");
+
+const formatTime = () => {
+  const d = new Date();
+  return `${d.getHours() % 12 || 12}:${d.getMinutes().toString().padStart(2, "0")} ${d.getHours() >= 12 ? "PM" : "AM"}`;
+};
+
+// ============================================================================
+// InlineChart
+// ============================================================================
+
+export const InlineChart = ({
+  Component,
+}: {
+  Component: MetabotAgentChartMessage["Component"];
+}) => (
+  <div
+    style={{
+      height: 500,
+      width: "100%",
+      flexShrink: 0,
+      borderRadius: 8,
+      overflow: "hidden",
+      margin: "6px 0",
+      background: "var(--mb-color-background-secondary)",
+    }}
+  >
+    <Component drills isSaveEnabled={false} height="500px" />
+  </div>
+);
+
+// ============================================================================
+// MessageList
+// ============================================================================
+
+export type MessageListPalette = {
+  accent: string;
+  accentLight: string;
+  accentDim: string;
+  surface: string;
+  surfaceRaised: string;
+  border: string;
+  text: string;
+  textMuted: string;
+  textSecondary: string;
+  gradient: string;
+  red: string;
+  redDim: string;
+};
+
+export const MessageList = ({
+  messages,
+  isProcessing,
+  scrollRef,
+  palette,
+}: {
+  messages: MetabotMessage[];
+  isProcessing: boolean;
+  scrollRef: React.RefObject<HTMLDivElement>;
+  palette: MessageListPalette;
+}) => (
+  <>
+    {messages.map((msg) => {
+      const isUser = msg.role === "user";
+
+      if (msg.type === "tool_call") {
+        return (
+          <div
+            key={msg.id}
+            style={{ padding: "3px 0", animation: "metabotFadeUp 0.2s ease" }}
+          >
+            <span
+              style={{
+                fontSize: 11,
+                fontFamily: "monospace",
+                color: palette.accentLight,
+                background: palette.accentDim,
+                padding: "2px 8px",
+                borderRadius: 4,
+              }}
+            >
+              {msg.status === "started" ? "Running" : "Ran"} {msg.name}
+            </span>
+          </div>
+        );
+      }
+
+      if (msg.type === "chart") {
+        return <InlineChart key={msg.id} Component={msg.Component} />;
+      }
+
+      const content: ReactNode =
+        "message" in msg && msg.message ? (
+          stripMarkdownLinks(msg.message)
+        ) : "payload" in msg && msg.payload ? (
+          <pre
+            style={{
+              margin: 0,
+              whiteSpace: "pre-wrap",
+              fontSize: 12,
+              fontFamily: "monospace",
+              color: palette.textSecondary,
+            }}
+          >
+            {JSON.stringify(msg.payload, null, 2)}
+          </pre>
+        ) : null;
+
+      if (!content) {
+        return null;
+      }
+
+      return (
+        <div
+          key={msg.id}
+          style={{
+            display: "flex",
+            gap: 8,
+            padding: "6px 0",
+            animation: "metabotFadeUp 0.25s ease",
+          }}
+        >
+          {!isUser && (
+            <div
+              style={{
+                width: 24,
+                height: 24,
+                borderRadius: 6,
+                background: palette.gradient,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                color: "#fff",
+                flexShrink: 0,
+                marginTop: 1,
+              }}
+            >
+              <BotIcon size={13} />
+            </div>
+          )}
+          <div
+            style={{
+              flex: 1,
+              minWidth: 0,
+              ...(isUser ? { textAlign: "right" as const } : {}),
+            }}
+          >
+            <div
+              style={{
+                display: "inline-block",
+                maxWidth: "85%",
+                textAlign: "left",
+                padding: "7px 12px",
+                borderRadius: 12,
+                fontSize: 13,
+                lineHeight: 1.45,
+                ...(isUser
+                  ? {
+                      background: palette.accent,
+                      color: "#fff",
+                      borderBottomRightRadius: 4,
+                    }
+                  : {
+                      background: palette.surfaceRaised,
+                      color: palette.text,
+                      border: `1px solid ${palette.border}`,
+                      borderBottomLeftRadius: 4,
+                    }),
+              }}
+            >
+              {content}
+            </div>
+            <div
+              style={{
+                fontSize: 10,
+                color: palette.textMuted,
+                marginTop: 2,
+                ...(isUser ? { paddingRight: 2 } : { paddingLeft: 2 }),
+              }}
+            >
+              {formatTime()}
+            </div>
+          </div>
+        </div>
+      );
+    })}
+
+    {isProcessing && (
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 6,
+          padding: "6px 0",
+          animation: "metabotFadeUp 0.2s ease",
+        }}
+      >
+        <div
+          style={{
+            width: 24,
+            height: 24,
+            borderRadius: 6,
+            background: palette.gradient,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            color: "#fff",
+            flexShrink: 0,
+          }}
+        >
+          <BotIcon size={13} />
+        </div>
+        <div style={{ display: "flex", gap: 4, padding: "4px 0" }}>
+          {[0, 0.15, 0.3].map((delay) => (
+            <div
+              key={delay}
+              style={{
+                width: 6,
+                height: 6,
+                borderRadius: "50%",
+                background: palette.accentLight,
+                animation: `metabotPulse 1.4s ${delay}s infinite`,
+              }}
+            />
+          ))}
+        </div>
+      </div>
+    )}
+
+    <div ref={scrollRef} />
+  </>
+);
+
+// ============================================================================
+// Composer
+// ============================================================================
+
+export const Composer = ({
+  value,
+  onChange,
+  onSubmit,
+  canSend,
+  placeholder,
+  onCancel,
+  isProcessing,
+  palette,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  onSubmit: () => void;
+  canSend: boolean;
+  placeholder?: string;
+  onCancel?: () => void;
+  isProcessing: boolean;
+  palette: MessageListPalette;
+}) => (
+  <div
+    style={{
+      display: "flex",
+      alignItems: "center",
+      gap: 6,
+      padding: "8px 12px",
+      borderTop: `1px solid ${palette.border}`,
+      background: palette.surface,
+    }}
+  >
+    <input
+      style={{
+        flex: 1,
+        background: palette.surfaceRaised,
+        border: `1px solid ${palette.border}`,
+        borderRadius: 8,
+        padding: "8px 12px",
+        fontSize: 13,
+        color: palette.text,
+        outline: "none",
+        fontFamily: "inherit",
+      }}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      onKeyDown={(e) => e.key === "Enter" && onSubmit()}
+      placeholder={placeholder ?? "Ask something..."}
+    />
+    {isProcessing && onCancel && (
+      <button
+        onClick={onCancel}
+        style={{
+          background: palette.redDim,
+          border: `1px solid ${palette.red}40`,
+          borderRadius: 6,
+          padding: "6px 8px",
+          color: palette.red,
+          cursor: "pointer",
+          fontSize: 11,
+          fontWeight: 600,
+          fontFamily: "inherit",
+        }}
+      >
+        Stop
+      </button>
+    )}
+    <button
+      onClick={onSubmit}
+      disabled={!canSend}
+      style={{
+        width: 32,
+        height: 32,
+        borderRadius: 8,
+        border: "none",
+        background: canSend ? palette.accent : palette.surfaceRaised,
+        color: canSend ? "#fff" : palette.textMuted,
+        cursor: canSend ? "pointer" : "default",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        transition: "all 0.15s",
+      }}
+    >
+      <SendIcon />
+    </button>
+  </div>
+);
+
+// ============================================================================
+// InstructionsDrawer
+// ============================================================================
+
+export const InstructionsDrawer = ({
+  customInstructions,
+  setCustomInstructions,
+  palette,
+}: {
+  customInstructions: string | undefined;
+  setCustomInstructions: (v: string | undefined) => void;
+  palette: MessageListPalette;
+}) => {
+  const [open, setOpen] = useState(false);
+  const [draft, setDraft] = useState(customInstructions ?? "");
+
+  return (
+    <div
+      style={{
+        borderTop: `1px solid ${palette.border}`,
+        background: palette.surface,
+      }}
+    >
+      <button
+        onClick={() => setOpen(!open)}
+        style={{
+          width: "100%",
+          display: "flex",
+          alignItems: "center",
+          gap: 6,
+          padding: "6px 12px",
+          background: "none",
+          border: "none",
+          color: customInstructions ? palette.accentLight : palette.textMuted,
+          fontSize: 11,
+          fontWeight: 600,
+          cursor: "pointer",
+          fontFamily: "inherit",
+        }}
+      >
+        <SparkleIcon size={10} />
+        {customInstructions ? "Custom instructions active" : "Add instructions"}
+        <span style={{ marginLeft: "auto", fontSize: 10 }}>
+          {open ? "Hide" : "Edit"}
+        </span>
+      </button>
+      {open && (
+        <div
+          style={{
+            padding: "0 12px 8px",
+            display: "flex",
+            flexDirection: "column",
+            gap: 6,
+          }}
+        >
+          <textarea
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            placeholder="e.g. Always respond in bullet points."
+            rows={2}
+            style={{
+              background: palette.surfaceRaised,
+              border: `1px solid ${palette.border}`,
+              borderRadius: 6,
+              padding: "6px 10px",
+              fontSize: 12,
+              color: palette.text,
+              outline: "none",
+              resize: "vertical",
+              fontFamily: "inherit",
+              lineHeight: 1.4,
+            }}
+          />
+          <div style={{ display: "flex", gap: 6, justifyContent: "flex-end" }}>
+            {customInstructions && (
+              <button
+                onClick={() => {
+                  setCustomInstructions(undefined);
+                  setDraft("");
+                }}
+                style={{
+                  background: "none",
+                  border: "none",
+                  color: palette.textMuted,
+                  fontSize: 11,
+                  cursor: "pointer",
+                  fontFamily: "inherit",
+                }}
+              >
+                Clear
+              </button>
+            )}
+            <button
+              onClick={() => {
+                setCustomInstructions(draft.trim() || undefined);
+                setOpen(false);
+              }}
+              style={{
+                background: palette.accent,
+                border: "none",
+                borderRadius: 4,
+                padding: "3px 12px",
+                color: "#fff",
+                fontSize: 11,
+                fontWeight: 600,
+                cursor: "pointer",
+                fontFamily: "inherit",
+              }}
+            >
+              Apply
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+// ============================================================================
+// SDK Wrapper factory
+// ============================================================================
+
+// CommonSdkStoryWrapper already handles auth + ComponentProvider + theme via
+// Storybook globals. makeSdkWrapper returns it directly; the theme param is
+// accepted for call-site compatibility but theme selection is done via globals.
+export const makeSdkWrapper = (
+  _theme?: ReturnType<typeof defineMetabaseTheme>,
+) => CommonSdkStoryWrapper;

--- a/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot.stories.utils.tsx
+++ b/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot.stories.utils.tsx
@@ -5,7 +5,7 @@ import type { defineMetabaseTheme } from "metabase/embedding-sdk/theme";
 
 import type { MetabotMessage } from "../../types/metabot";
 
-type ChartComponent = Extract<MetabotMessage, { type: "chart" }>["Component"];
+type ChartComponent = Extract<MetabotMessage, { type: "chart" }>["Chart"];
 
 // ============================================================================
 // Shared keyframes
@@ -140,16 +140,16 @@ export const MessageList = ({
   onRetry?: (messageId: string) => void;
 }) => (
   <>
-    {messages.map((msg) => {
-      const isUser = msg.role === "user";
+    {messages.map((message) => {
+      const isUser = message.role === "user";
 
-      if (msg.type === "chart") {
-        return <InlineChart key={msg.id} Component={msg.Component} />;
+      if (message.type === "chart") {
+        return <InlineChart key={message.id} Component={message.Chart} />;
       }
 
       const content: ReactNode =
-        msg.type === "text" && msg.message
-          ? stripMarkdownLinks(msg.message)
+        message.type === "text" && message.message
+          ? stripMarkdownLinks(message.message)
           : null;
 
       if (!content) {
@@ -158,7 +158,7 @@ export const MessageList = ({
 
       return (
         <div
-          key={msg.id}
+          key={message.id}
           style={{
             display: "flex",
             gap: 8,
@@ -232,7 +232,7 @@ export const MessageList = ({
               <span>{formatTime()}</span>
               {!isUser && onRetry && !isProcessing && (
                 <button
-                  onClick={() => onRetry(msg.id)}
+                  onClick={() => onRetry(message.id)}
                   style={{
                     background: "none",
                     border: "none",
@@ -314,7 +314,7 @@ export const Composer = ({
   palette,
 }: {
   value: string;
-  onChange: (v: string) => void;
+  onChange: (value: string) => void;
   onSubmit: () => void;
   canSend: boolean;
   placeholder?: string;
@@ -345,8 +345,8 @@ export const Composer = ({
         fontFamily: "inherit",
       }}
       value={value}
-      onChange={(e) => onChange(e.target.value)}
-      onKeyDown={(e) => e.key === "Enter" && onSubmit()}
+      onChange={(event) => onChange(event.target.value)}
+      onKeyDown={(event) => event.key === "Enter" && onSubmit()}
       placeholder={placeholder ?? "Ask something..."}
     />
     {isProcessing && onCancel && (

--- a/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot.stories.utils.tsx
+++ b/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot.stories.utils.tsx
@@ -1,13 +1,11 @@
 import type { ReactNode } from "react";
-import { useState } from "react";
 
 import { CommonSdkStoryWrapper } from "embedding-sdk-bundle/test/CommonSdkStoryWrapper";
 import type { defineMetabaseTheme } from "metabase/embedding-sdk/theme";
 
-import type {
-  MetabotAgentChartMessage,
-  MetabotMessage,
-} from "../../types/metabot";
+import type { MetabotMessage } from "../../types/metabot";
+
+type ChartComponent = Extract<MetabotMessage, { type: "chart" }>["Component"];
 
 // ============================================================================
 // Shared keyframes
@@ -93,11 +91,7 @@ const formatTime = () => {
 // InlineChart
 // ============================================================================
 
-export const InlineChart = ({
-  Component,
-}: {
-  Component: MetabotAgentChartMessage["Component"];
-}) => (
+export const InlineChart = ({ Component }: { Component: ChartComponent }) => (
   <div
     style={{
       height: 500,
@@ -137,58 +131,26 @@ export const MessageList = ({
   isProcessing,
   scrollRef,
   palette,
+  onRetry,
 }: {
   messages: MetabotMessage[];
   isProcessing: boolean;
   scrollRef: React.RefObject<HTMLDivElement>;
   palette: MessageListPalette;
+  onRetry?: (messageId: string) => void;
 }) => (
   <>
     {messages.map((msg) => {
       const isUser = msg.role === "user";
-
-      if (msg.type === "tool_call") {
-        return (
-          <div
-            key={msg.id}
-            style={{ padding: "3px 0", animation: "metabotFadeUp 0.2s ease" }}
-          >
-            <span
-              style={{
-                fontSize: 11,
-                fontFamily: "monospace",
-                color: palette.accentLight,
-                background: palette.accentDim,
-                padding: "2px 8px",
-                borderRadius: 4,
-              }}
-            >
-              {msg.status === "started" ? "Running" : "Ran"} {msg.name}
-            </span>
-          </div>
-        );
-      }
 
       if (msg.type === "chart") {
         return <InlineChart key={msg.id} Component={msg.Component} />;
       }
 
       const content: ReactNode =
-        "message" in msg && msg.message ? (
-          stripMarkdownLinks(msg.message)
-        ) : "payload" in msg && msg.payload ? (
-          <pre
-            style={{
-              margin: 0,
-              whiteSpace: "pre-wrap",
-              fontSize: 12,
-              fontFamily: "monospace",
-              color: palette.textSecondary,
-            }}
-          >
-            {JSON.stringify(msg.payload, null, 2)}
-          </pre>
-        ) : null;
+        msg.type === "text" && msg.message
+          ? stripMarkdownLinks(msg.message)
+          : null;
 
       if (!content) {
         return null;
@@ -256,13 +218,35 @@ export const MessageList = ({
             </div>
             <div
               style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
                 fontSize: 10,
                 color: palette.textMuted,
                 marginTop: 2,
-                ...(isUser ? { paddingRight: 2 } : { paddingLeft: 2 }),
+                ...(isUser
+                  ? { justifyContent: "flex-end", paddingRight: 2 }
+                  : { paddingLeft: 2 }),
               }}
             >
-              {formatTime()}
+              <span>{formatTime()}</span>
+              {!isUser && onRetry && !isProcessing && (
+                <button
+                  onClick={() => onRetry(msg.id)}
+                  style={{
+                    background: "none",
+                    border: "none",
+                    color: palette.textMuted,
+                    cursor: "pointer",
+                    fontSize: 10,
+                    fontFamily: "inherit",
+                    padding: 0,
+                    textDecoration: "underline",
+                  }}
+                >
+                  Retry
+                </button>
+              )}
             </div>
           </div>
         </div>
@@ -404,124 +388,6 @@ export const Composer = ({
     </button>
   </div>
 );
-
-// ============================================================================
-// InstructionsDrawer
-// ============================================================================
-
-export const InstructionsDrawer = ({
-  customInstructions,
-  setCustomInstructions,
-  palette,
-}: {
-  customInstructions: string | undefined;
-  setCustomInstructions: (v: string | undefined) => void;
-  palette: MessageListPalette;
-}) => {
-  const [open, setOpen] = useState(false);
-  const [draft, setDraft] = useState(customInstructions ?? "");
-
-  return (
-    <div
-      style={{
-        borderTop: `1px solid ${palette.border}`,
-        background: palette.surface,
-      }}
-    >
-      <button
-        onClick={() => setOpen(!open)}
-        style={{
-          width: "100%",
-          display: "flex",
-          alignItems: "center",
-          gap: 6,
-          padding: "6px 12px",
-          background: "none",
-          border: "none",
-          color: customInstructions ? palette.accentLight : palette.textMuted,
-          fontSize: 11,
-          fontWeight: 600,
-          cursor: "pointer",
-          fontFamily: "inherit",
-        }}
-      >
-        <SparkleIcon size={10} />
-        {customInstructions ? "Custom instructions active" : "Add instructions"}
-        <span style={{ marginLeft: "auto", fontSize: 10 }}>
-          {open ? "Hide" : "Edit"}
-        </span>
-      </button>
-      {open && (
-        <div
-          style={{
-            padding: "0 12px 8px",
-            display: "flex",
-            flexDirection: "column",
-            gap: 6,
-          }}
-        >
-          <textarea
-            value={draft}
-            onChange={(e) => setDraft(e.target.value)}
-            placeholder="e.g. Always respond in bullet points."
-            rows={2}
-            style={{
-              background: palette.surfaceRaised,
-              border: `1px solid ${palette.border}`,
-              borderRadius: 6,
-              padding: "6px 10px",
-              fontSize: 12,
-              color: palette.text,
-              outline: "none",
-              resize: "vertical",
-              fontFamily: "inherit",
-              lineHeight: 1.4,
-            }}
-          />
-          <div style={{ display: "flex", gap: 6, justifyContent: "flex-end" }}>
-            {customInstructions && (
-              <button
-                onClick={() => {
-                  setCustomInstructions(undefined);
-                  setDraft("");
-                }}
-                style={{
-                  background: "none",
-                  border: "none",
-                  color: palette.textMuted,
-                  fontSize: 11,
-                  cursor: "pointer",
-                  fontFamily: "inherit",
-                }}
-              >
-                Clear
-              </button>
-            )}
-            <button
-              onClick={() => {
-                setCustomInstructions(draft.trim() || undefined);
-                setOpen(false);
-              }}
-              style={{
-                background: palette.accent,
-                border: "none",
-                borderRadius: 4,
-                padding: "3px 12px",
-                color: "#fff",
-                fontSize: 11,
-                fontWeight: 600,
-                cursor: "pointer",
-                fontFamily: "inherit",
-              }}
-            >
-              Apply
-            </button>
-          </div>
-        </div>
-      )}
-    </div>
-  );
-};
 
 // ============================================================================
 // SDK Wrapper factory

--- a/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot.tsx
+++ b/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot.tsx
@@ -52,7 +52,10 @@ export const useMetabot = (): UseMetabotResult => {
   );
 
   const messages = useMemo<MetabotMessage[]>(
-    () => agent.messages.filter(isPublicMessage).map(mapMessage),
+    () =>
+      agent.messages
+        .filter(isPublicMessage)
+        .map((message) => mapMessage(message, chartComponentsCache.current)),
     [agent.messages],
   );
 
@@ -110,7 +113,10 @@ const isPublicMessage = (
   message.type !== "action" &&
   message.type !== "todo_list";
 
-const mapMessage = (message: PublicChatMessage): MetabotMessage =>
+const mapMessage = (
+  message: PublicChatMessage,
+  cache: Map<string, ReturnType<typeof createChartComponent>>,
+): MetabotMessage =>
   match(message)
     .with(
       { role: "user", type: "text" },
@@ -121,5 +127,16 @@ const mapMessage = (message: PublicChatMessage): MetabotMessage =>
       { role: "agent", type: "text" },
       ({ id, message }) =>
         ({ id, role: "agent", type: "text", message }) as const,
+    )
+    .with(
+      { role: "agent", type: "chart" },
+      ({ id, navigateTo }) =>
+        ({
+          id,
+          role: "agent",
+          type: "chart",
+          questionPath: navigateTo,
+          Component: getCachedChartComponent(navigateTo, cache),
+        }) as const,
     )
     .exhaustive();

--- a/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot.tsx
+++ b/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot.tsx
@@ -136,7 +136,7 @@ const mapMessage = (
           role: "agent",
           type: "chart",
           questionPath: navigateTo,
-          Component: getCachedChartComponent(navigateTo, cache),
+          Chart: getCachedChartComponent(navigateTo, cache),
         }) as const,
     )
     .exhaustive();

--- a/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot.unit.spec.tsx
@@ -32,17 +32,14 @@ jest.mock("embedding-sdk-bundle/components/public/StaticQuestion", () => {
   const Component = ({ query }: { query?: string }) => (
     <div data-testid="mock-static-question" data-query={query} />
   );
-  return { StaticQuestion: Component, StaticQuestionInternal: Component };
+  return { StaticQuestionInternal: Component };
 });
 
 jest.mock("embedding-sdk-bundle/components/public/InteractiveQuestion", () => {
   const Component = ({ query }: { query?: string }) => (
     <div data-testid="mock-interactive-question" data-query={query} />
   );
-  return {
-    InteractiveQuestion: Component,
-    InteractiveQuestionInternal: Component,
-  };
+  return { InteractiveQuestionInternal: Component };
 });
 
 describe("useMetabot", () => {

--- a/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot.unit.spec.tsx
@@ -170,6 +170,15 @@ describe("useMetabot", () => {
 
       act(() => {
         store.dispatch(
+          // `addAgentMessage`/`addUserMessage` in reducer.ts type their payload
+          // as `Omit<UnionType, ...>`. Non-distributive `Omit` collapses the
+          // discriminated union to common keys only, so branch-specific fields
+          // (message, navigateTo, payload, ...) fail excess-property checks
+          // without `as any`. Switching to a DistributiveOmit would unblock
+          // call sites here but surfaces more errors elsewhere (e.g. the
+          // edit_suggestion payload hits the "infinite TS errors" noted in
+          // reducer.ts). Keeping `as any` for now — applies to every dispatch
+          // below.
           metabotActions.addAgentMessage({
             agentId: "omnibot",
             type: "text",

--- a/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot.unit.spec.tsx
@@ -354,7 +354,7 @@ describe("useMetabot", () => {
   describe("messages[n].Component", () => {
     const TestMessageComponent = ({ drills }: { drills?: true }) => {
       const { messages } = useMetabot();
-      const chartMessage = messages.find((m) => m.type === "chart");
+      const chartMessage = messages.find((message) => message.type === "chart");
       if (!chartMessage) {
         return null;
       }
@@ -403,7 +403,9 @@ describe("useMetabot", () => {
 
       const TestCapture = () => {
         const { messages } = useMetabot();
-        const chartMessages = messages.filter((m) => m.type === "chart");
+        const chartMessages = messages.filter(
+          (message) => message.type === "chart",
+        );
         if (chartMessages[0]) {
           firstComponent = chartMessages[0].Component;
         }

--- a/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot.unit.spec.tsx
@@ -197,7 +197,7 @@ describe("useMetabot", () => {
       // `Component` is a React component reference — JSON.stringify drops
       // functions, so it appears as `undefined` in the serialized snapshot
       // the harness reads. We assert only the serializable fields here;
-      // component wiring is covered by `CurrentChart` tests.
+      // `Component` wiring is covered by the `messages[n].Component` describe.
       expect(message).toEqual({
         id: expect.any(String),
         role: "agent",
@@ -348,6 +348,101 @@ describe("useMetabot", () => {
 
       await waitFor(() => expect(onResolved).toHaveBeenCalled());
       expect(onResolved).toHaveBeenCalledWith(undefined);
+    });
+  });
+
+  describe("messages[n].Component", () => {
+    const TestMessageComponent = ({ drills }: { drills?: true }) => {
+      const { messages } = useMetabot();
+      const chartMessage = messages.find((m) => m.type === "chart");
+      if (!chartMessage) {
+        return null;
+      }
+      const { Component } = chartMessage;
+      return <Component drills={drills} />;
+    };
+
+    it("renders StaticQuestion when drills is absent", async () => {
+      const { store } = setup({ ui: <TestMessageComponent /> });
+
+      act(() => {
+        store.dispatch(
+          metabotActions.addAgentMessage({
+            agentId: "omnibot",
+            type: "chart",
+            navigateTo: "/question#abc",
+          } as any),
+        );
+      });
+
+      expect(
+        await screen.findByTestId("mock-static-question"),
+      ).toBeInTheDocument();
+    });
+
+    it("renders InteractiveQuestion when drills is true", async () => {
+      const { store } = setup({ ui: <TestMessageComponent drills /> });
+
+      act(() => {
+        store.dispatch(
+          metabotActions.addAgentMessage({
+            agentId: "omnibot",
+            type: "chart",
+            navigateTo: "/question#abc",
+          } as any),
+        );
+      });
+
+      expect(
+        await screen.findByTestId("mock-interactive-question"),
+      ).toBeInTheDocument();
+    });
+
+    it("Component reference is stable after a second chart message arrives", async () => {
+      let firstComponent: unknown = null;
+
+      const TestCapture = () => {
+        const { messages } = useMetabot();
+        const chartMessages = messages.filter((m) => m.type === "chart");
+        if (chartMessages[0]) {
+          firstComponent = chartMessages[0].Component;
+        }
+        return <div data-testid="chart-count">{chartMessages.length}</div>;
+      };
+
+      const { store } = setup({ ui: <TestCapture /> });
+
+      act(() => {
+        store.dispatch(
+          metabotActions.addAgentMessage({
+            agentId: "omnibot",
+            type: "chart",
+            navigateTo: "/question#abc",
+          } as any),
+        );
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("chart-count")).toHaveTextContent("1");
+      });
+      const capturedComponent = firstComponent;
+      expect(capturedComponent).not.toBeNull();
+
+      act(() => {
+        store.dispatch(
+          metabotActions.addAgentMessage({
+            agentId: "omnibot",
+            type: "chart",
+            navigateTo: "/question#xyz",
+          } as any),
+        );
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("chart-count")).toHaveTextContent("2");
+      });
+
+      expect(firstComponent).toBe(capturedComponent);
     });
   });
 });

--- a/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot.unit.spec.tsx
@@ -12,6 +12,16 @@ import {
 
 import { useMetabot } from "./use-metabot";
 
+/**
+ * This file covers hook wiring for non-passthrough behavior. The following
+ * result properties are deliberately not tested here because they forward
+ * directly to `useMetabotAgent` with no transformation:
+ *   - retryMessage       → agent.retryMessage(messageId)
+ *   - cancelRequest      → agent.cancelRequest
+ *   - resetConversation  → agent.resetConversation
+ *   - errorMessages      → agent.errorMessages
+ *   - isProcessing       → agent.isDoingScience (renamed)
+ */
 // These tests verify `useMetabot().CurrentChart` wiring only: renders nothing
 // before `navigate_to`, StaticQuestion vs InteractiveQuestion based on
 // `drills`, and `query` forwarding. Mocks surface `data-testid` + `data-query`

--- a/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot.unit.spec.tsx
@@ -194,10 +194,10 @@ describe("useMetabot", () => {
       });
 
       const [message] = await readMessages();
-      // `Component` is a React component reference — JSON.stringify drops
+      // `Chart` is a React component reference — JSON.stringify drops
       // functions, so it appears as `undefined` in the serialized snapshot
       // the harness reads. We assert only the serializable fields here;
-      // `Component` wiring is covered by the `messages[n].Component` describe.
+      // `Chart` wiring is covered by the `messages[n].Chart` describe.
       expect(message).toEqual({
         id: expect.any(String),
         role: "agent",
@@ -351,15 +351,15 @@ describe("useMetabot", () => {
     });
   });
 
-  describe("messages[n].Component", () => {
+  describe("messages[n].Chart", () => {
     const TestMessageComponent = ({ drills }: { drills?: true }) => {
       const { messages } = useMetabot();
       const chartMessage = messages.find((message) => message.type === "chart");
       if (!chartMessage) {
         return null;
       }
-      const { Component } = chartMessage;
-      return <Component drills={drills} />;
+      const { Chart } = chartMessage;
+      return <Chart drills={drills} />;
     };
 
     it("renders StaticQuestion when drills is absent", async () => {
@@ -398,8 +398,8 @@ describe("useMetabot", () => {
       ).toBeInTheDocument();
     });
 
-    it("Component reference is stable after a second chart message arrives", async () => {
-      let firstComponent: unknown = null;
+    it("Chart reference is stable after a second chart message arrives", async () => {
+      let firstChart: unknown = null;
 
       const TestCapture = () => {
         const { messages } = useMetabot();
@@ -407,7 +407,7 @@ describe("useMetabot", () => {
           (message) => message.type === "chart",
         );
         if (chartMessages[0]) {
-          firstComponent = chartMessages[0].Component;
+          firstChart = chartMessages[0].Chart;
         }
         return <div data-testid="chart-count">{chartMessages.length}</div>;
       };
@@ -427,8 +427,8 @@ describe("useMetabot", () => {
       await waitFor(() => {
         expect(screen.getByTestId("chart-count")).toHaveTextContent("1");
       });
-      const capturedComponent = firstComponent;
-      expect(capturedComponent).not.toBeNull();
+      const capturedChart = firstChart;
+      expect(capturedChart).not.toBeNull();
 
       act(() => {
         store.dispatch(
@@ -444,7 +444,7 @@ describe("useMetabot", () => {
         expect(screen.getByTestId("chart-count")).toHaveTextContent("2");
       });
 
-      expect(firstComponent).toBe(capturedComponent);
+      expect(firstChart).toBe(capturedChart);
     });
   });
 });

--- a/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot.unit.spec.tsx
@@ -180,6 +180,32 @@ describe("useMetabot", () => {
       });
     });
 
+    it("renames `navigateTo` to `questionPath` on agent.chart", async () => {
+      const { store } = setup({ ui: <TestMessages /> });
+
+      act(() => {
+        store.dispatch(
+          metabotActions.addAgentMessage({
+            agentId: "omnibot",
+            type: "chart",
+            navigateTo: "/question#base64",
+          } as any),
+        );
+      });
+
+      const [message] = await readMessages();
+      // `Component` is a React component reference — JSON.stringify drops
+      // functions, so it appears as `undefined` in the serialized snapshot
+      // the harness reads. We assert only the serializable fields here;
+      // component wiring is covered by `CurrentChart` tests.
+      expect(message).toEqual({
+        id: expect.any(String),
+        role: "agent",
+        type: "chart",
+        questionPath: "/question#base64",
+      });
+    });
+
     it("filters out internal-only variants (tool_call, edit_suggestion, user action, todo_list)", async () => {
       const { store } = setup({ ui: <TestMessages /> });
 

--- a/frontend/src/embedding-sdk-bundle/test/CommonSdkStoryWrapper.tsx
+++ b/frontend/src/embedding-sdk-bundle/test/CommonSdkStoryWrapper.tsx
@@ -7,6 +7,7 @@ import "embedding-sdk-bundle";
 
 import { ComponentProvider } from "embedding-sdk-bundle/components/public/ComponentProvider";
 import type { MetabaseAuthConfig } from "embedding-sdk-bundle/types/auth-config";
+import type { MetabaseTheme } from "metabase/embedding-sdk/theme";
 
 import { USERS } from "../../../../e2e/support/cypress_data";
 
@@ -48,7 +49,27 @@ export const storybookSdkAuthDefaultConfig =
 
 export const CommonSdkStoryWrapper = (Story: StoryFn, context: any) => {
   const sdkTheme = context.globals.sdkTheme;
-  const theme = sdkTheme ? storybookThemes[sdkTheme] : undefined;
+  const globalTheme: MetabaseTheme | undefined = sdkTheme
+    ? storybookThemes[sdkTheme]
+    : undefined;
+
+  // Per-story theme overrides passed via `parameters.sdkThemeOverride`.
+  // Useful for stories that render their chat UI inside a fixed overlay and
+  // need SDK popovers to stack above the host app's modal backdrop.
+  const themeOverride: MetabaseTheme | undefined =
+    context.parameters?.sdkThemeOverride;
+
+  const theme: MetabaseTheme | undefined = themeOverride
+    ? {
+        ...globalTheme,
+        ...themeOverride,
+        components: {
+          ...globalTheme?.components,
+          ...themeOverride?.components,
+        },
+      }
+    : globalTheme;
+
   const locale = context.globals.locale;
   const user = context.globals.user;
 

--- a/frontend/src/embedding-sdk-bundle/types/metabot.ts
+++ b/frontend/src/embedding-sdk-bundle/types/metabot.ts
@@ -71,6 +71,10 @@ export type UseMetabotResult = {
   messages: MetabotMessage[];
   /** Errors are conversation-level, not attached to individual messages. */
   errorMessages: MetabotErrorMessage[];
+  /**
+   * `true` from the moment a message is submitted until the response
+   * completes — including success, error, or cancellation.
+   */
   isProcessing: boolean;
 
   /**

--- a/frontend/src/embedding-sdk-bundle/types/metabot.ts
+++ b/frontend/src/embedding-sdk-bundle/types/metabot.ts
@@ -21,12 +21,22 @@ type MetabotAgentTextMessage = {
   message: string;
 };
 
+type MetabotAgentChartMessage = {
+  id: string;
+  role: "agent";
+  type: "chart";
+  /** URL path to the question, e.g. `/question#<base64>` */
+  questionPath: string;
+  /** A pre-wired React component that renders the chart. */
+  Component: React.ComponentType<MetabotChartProps>;
+};
+
 // Internal variants intentionally omitted. `use-metabot.tsx` filters these out before mapping:
 // - `tool_call`: debug-only, gated on metabot's `debugMode`.
 // - `edit_suggestion`: targets the in-app Transform editor, which the SDK does not render.
 // - `action`: unused in shipped code.
 // - `todo_list`: only reachable via the `codegen/transforms` profile, not the SDK.
-type MetabotAgentMessage = MetabotAgentTextMessage;
+type MetabotAgentMessage = MetabotAgentTextMessage | MetabotAgentChartMessage;
 
 export type MetabotMessage = MetabotUserTextMessage | MetabotAgentMessage;
 
@@ -57,7 +67,7 @@ export type UseMetabotResult = {
   /** Clear all messages and start fresh. */
   resetConversation: () => void;
 
-  /** All messages in the conversation. */
+  /** All messages in the conversation. Chart messages include a `Component` property. */
   messages: MetabotMessage[];
   /** Errors are conversation-level, not attached to individual messages. */
   errorMessages: MetabotErrorMessage[];

--- a/frontend/src/embedding-sdk-bundle/types/metabot.ts
+++ b/frontend/src/embedding-sdk-bundle/types/metabot.ts
@@ -28,7 +28,7 @@ type MetabotAgentChartMessage = {
   /** URL path to the question, e.g. `/question#<base64>` */
   questionPath: string;
   /** A pre-wired React component that renders the chart. */
-  Component: React.ComponentType<MetabotChartProps>;
+  Chart: React.ComponentType<MetabotChartProps>;
 };
 
 // Internal variants intentionally omitted. `use-metabot.tsx` filters these out before mapping:
@@ -67,7 +67,7 @@ export type UseMetabotResult = {
   /** Clear all messages and start fresh. */
   resetConversation: () => void;
 
-  /** All messages in the conversation. Chart messages include a `Component` property. */
+  /** All messages in the conversation. Chart messages include a `Chart` property. */
   messages: MetabotMessage[];
   /** Errors are conversation-level, not attached to individual messages. */
   errorMessages: MetabotErrorMessage[];

--- a/frontend/src/metabase/metabot/state/actions.ts
+++ b/frontend/src/metabase/metabot/state/actions.ts
@@ -38,6 +38,7 @@ import {
   getUserPromptForMessageId,
 } from "./selectors";
 import type {
+  MetabotAgentChartMessage,
   MetabotAgentEditSuggestionChatMessage,
   MetabotAgentId,
   MetabotAgentTodoListChatMessage,
@@ -355,6 +356,9 @@ export const sendAgentRequest = createAsyncThunk<
     try {
       let state = {};
       let error: unknown = undefined;
+      let pendingChartMessage:
+        | { type: "chart"; navigateTo: string }
+        | undefined = undefined;
 
       const response = await aiStreamingQuery(
         {
@@ -390,6 +394,13 @@ export const sendAgentRequest = createAsyncThunk<
               })
               .with({ type: "navigate_to" }, (part) => {
                 dispatch(setNavigateToPath(part.value));
+
+                if (isEmbeddingSdk()) {
+                  pendingChartMessage = {
+                    type: "chart",
+                    navigateTo: part.value,
+                  };
+                }
 
                 if (!isEmbeddingSdk()) {
                   dispatch(push(part.value) as UnknownAction);
@@ -455,6 +466,12 @@ export const sendAgentRequest = createAsyncThunk<
           // so fallback to the state used when the request was issued
           state: Object.keys(state).length === 0 ? request.state : state,
         });
+      }
+
+      if (pendingChartMessage != null) {
+        const chartMsg: Omit<MetabotAgentChartMessage, "id" | "role"> =
+          pendingChartMessage;
+        dispatch(addAgentMessage({ ...chartMsg, agentId }));
       }
 
       return fulfillWithValue({

--- a/frontend/src/metabase/metabot/state/actions.ts
+++ b/frontend/src/metabase/metabot/state/actions.ts
@@ -356,6 +356,8 @@ export const sendAgentRequest = createAsyncThunk<
     try {
       let state = {};
       let error: unknown = undefined;
+      // Last navigate_to wins, matching setNavigateToPath/CurrentChart semantics.
+      // In practice we don't expect more than one navigate_to in a single stream.
       let pendingChartMessage:
         | { type: "chart"; navigateTo: string }
         | undefined = undefined;

--- a/frontend/src/metabase/metabot/state/actions.ts
+++ b/frontend/src/metabase/metabot/state/actions.ts
@@ -405,6 +405,12 @@ export const sendAgentRequest = createAsyncThunk<
                 dispatch(setNavigateToPath(part.value));
 
                 if (isEmbeddingSdk()) {
+                  if (pendingChartMessage) {
+                    console.warn("Overwriting pending navigate_to: ", {
+                      previous: pendingChartMessage.navigateTo,
+                      next: part.value,
+                    });
+                  }
                   pendingChartMessage = {
                     type: "chart",
                     navigateTo: part.value,

--- a/frontend/src/metabase/metabot/state/actions.ts
+++ b/frontend/src/metabase/metabot/state/actions.ts
@@ -356,8 +356,15 @@ export const sendAgentRequest = createAsyncThunk<
     try {
       let state = {};
       let error: unknown = undefined;
-      // Last navigate_to wins, matching setNavigateToPath/CurrentChart semantics.
-      // In practice we don't expect more than one navigate_to in a single stream.
+      /**
+       * Hold the chart message until the stream finishes so it renders after
+       * the agent's final text. `navigate_to` arrives mid-stream, before the
+       * last message, so inserting it eagerly would show the chart above later
+       * text.
+       *
+       * Last navigate_to wins, matching setNavigateToPath/CurrentChart semantics.
+       * In practice we don't expect more than one navigate_to in a single stream.
+       */
       let pendingChartMessage:
         | { type: "chart"; navigateTo: string }
         | undefined = undefined;
@@ -471,9 +478,9 @@ export const sendAgentRequest = createAsyncThunk<
       }
 
       if (pendingChartMessage != null) {
-        const chartMsg: Omit<MetabotAgentChartMessage, "id" | "role"> =
+        const chartMessage: Omit<MetabotAgentChartMessage, "id" | "role"> =
           pendingChartMessage;
-        dispatch(addAgentMessage({ ...chartMsg, agentId }));
+        dispatch(addAgentMessage({ ...chartMessage, agentId }));
       }
 
       return fulfillWithValue({

--- a/frontend/src/metabase/metabot/state/types.ts
+++ b/frontend/src/metabase/metabot/state/types.ts
@@ -57,11 +57,19 @@ export type MetabotDebugToolCallMessage = {
   is_error?: boolean;
 };
 
+export type MetabotAgentChartMessage = {
+  id: string;
+  role: "agent";
+  type: "chart";
+  navigateTo: string;
+};
+
 export type MetabotAgentChatMessage =
   | MetabotAgentTextChatMessage
   | MetabotAgentTodoListChatMessage
   | MetabotAgentEditSuggestionChatMessage
-  | MetabotDebugToolCallMessage;
+  | MetabotDebugToolCallMessage
+  | MetabotAgentChartMessage;
 
 export type MetabotUserChatMessage =
   | MetabotUserTextChatMessage


### PR DESCRIPTION
closes EMB-1524

### Description

I mostly want you to play with the stories. Focus on the first 2. The remaining 3 are purely stylings.

1. CRM: This renders `CurrentChart` and filter out `chart` type from the message sidebar
2. Devops: This renders all `messages` so the `chart` type is also rendered here.

### How to verify

1. Run BE
2. Run storybook
    ```sh
    bun run storybook-embedding-sdk
    ```
3. Visit the `useMetabot` stories. There are 5 of them.

### Demo
<img width="1344" height="981" alt="image" src="https://github.com/user-attachments/assets/f2eb72a6-7df4-43aa-bacf-47b67052d8b4" />
<img width="1344" height="981" alt="image" src="https://github.com/user-attachments/assets/fead31cc-74ce-4c4e-9c47-c067e47cd8f6" />
<img width="1346" height="986" alt="image" src="https://github.com/user-attachments/assets/94532567-f100-43d9-92a3-17ed72eaa7ac" />
<img width="1345" height="983" alt="image" src="https://github.com/user-attachments/assets/4d36e735-0ed7-4e5a-a139-4515c30db3a5" />
<img width="1350" height="980" alt="image" src="https://github.com/user-attachments/assets/f7aebdc8-b2ad-4c2e-830a-b451ed0e9502" />

### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~ Purely storybooks
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
