### PR TITLE
Guard export-viz-click-behavior-link against nil link models

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -590,6 +590,7 @@
           field1s    (atom nil)
           field2s    (atom nil)
           field3s    (atom nil)
+          field4s    (atom nil)
           dash1s     (atom nil)
           dash2s     (atom nil)
           tab2s      (atom nil)
@@ -618,6 +619,7 @@
             (reset! field1s  (ts/create! :model/Field :name "subtotal" :table_id (:id @table1s)))
             (reset! field2s  (ts/create! :model/Field :name "invoice" :table_id (:id @table1s)))
             (reset! field3s  (ts/create! :model/Field :name "discount" :table_id (:id @table1s)))
+            (reset! field4s  (ts/create! :model/Field :name "quantity" :table_id (:id @table1s)))
             (reset! user1s   (ts/create! :model/User  :first_name "Tom" :last_name "Scholz" :email "tom@bost.on"))
             (reset! dash1s   (ts/create! :model/Dashboard :name "My Dashboard" :collection_id (:id @coll1s) :creator_id (:id @user1s)))
             (reset! dash2s   (ts/create! :model/Dashboard :name "Linked dashboard" :collection_id (:id @coll1s) :creator_id (:id @user1s)))
@@ -674,7 +676,12 @@
                                                  :parameterMapping
                                                  {"qweqwe" {:id     "qweqwe"
                                                             :source {:id "DISCOUNT" :name "Discount" :type "column"}
-                                                            :target {:id "amount_between" :type "variable"}}}}}}
+                                                            :target {:id "amount_between" :type "variable"}}}}}
+                                               (json/encode [:ref [:field (:id @field4s) nil]])
+                                               {:click_behavior
+                                                {:type     "link"
+                                                 :linkType "url"
+                                                 :linkTemplate "https://example.com/order/{{QUANTITY}}"}}}
                                               :click_behavior     {:type     "link"
                                                                    :linkType "question"
                                                                    :targetId (:id @card1s)}}
@@ -747,7 +754,13 @@
                                                   :parameterMapping
                                                   {"qweqwe" {:id "qweqwe"
                                                              :source {:id "DISCOUNT" :name "Discount" :type "column"}
-                                                             :target {:id "amount_between" :type "variable"}}}}))]
+                                                             :target {:id "amount_between" :type "variable"}}}})
+                                       (assoc-in [:column_settings
+                                                  (json/encode [:ref [:field [:my-db nil :orders :quantity] nil]])
+                                                  :click_behavior]
+                                                 {:type     "link"
+                                                  :linkType "url"
+                                                  :linkTemplate "https://example.com/order/{{QUANTITY}}"}))]
                   (is (= exp-card
                          (:visualization_settings card)))
                   (is (= exp-dashcard

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -1518,7 +1518,9 @@
   [{:keys [linkType type] :as click-behavior}]
   (fk-elide
    (cond-> click-behavior
-     (= type "link") (-> (update :targetId *export-fk* (link-card-model->toucan-model linkType))
+     (= type "link") (-> (u/update-some :targetId (fn [id]
+                                                    (when-let [model (link-card-model->toucan-model linkType)]
+                                                      (*export-fk* id model))))
                          (u/update-some :tabId *export-fk* :model/DashboardTab)))))
 
 (defn- import-viz-click-behavior-link

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -1494,7 +1494,9 @@
             {:id (case model
                    "table"    (*export-table-fk* id)
                    "database" (*export-database-fk* id)
-                   (*export-fk* id (link-card-model->toucan-model model)))}))))
+                   (if-let [model (link-card-model->toucan-model model)]
+                     (*export-fk* id model)
+                     id))}))))
 
 (defn- json-export-mbql
   "Converts IDs to fully qualified names inside a JSON string.
@@ -1518,9 +1520,11 @@
   [{:keys [linkType type] :as click-behavior}]
   (fk-elide
    (cond-> click-behavior
-     (= type "link") (-> (u/update-some :targetId (fn [id]
-                                                    (when-let [model (link-card-model->toucan-model linkType)]
-                                                      (*export-fk* id model))))
+     (= type "link") (-> (u/update-some :targetId
+                                        (fn [id]
+                                          (if-let [model (link-card-model->toucan-model linkType)]
+                                            (*export-fk* id model)
+                                            id)))
                          (u/update-some :tabId *export-fk* :model/DashboardTab)))))
 
 (defn- import-viz-click-behavior-link
@@ -1657,7 +1661,9 @@
             {:id (case model
                    "table"    (*import-table-fk* id)
                    "database" (*import-database-fk* id)
-                   (*import-fk* id (link-card-model->toucan-model model)))}))))
+                   (if-let [model (link-card-model->toucan-model model)]
+                     (*import-fk* id model)
+                     id))}))))
 
 (defn- import-visualizations [entity]
   (lib.util.match/replace-lite entity


### PR DESCRIPTION
## Summary

- `export-viz-click-behavior-link` used bare `update` on `:targetId`, calling `*export-fk*` even when `link-card-model->toucan-model` returns nil (e.g. for unknown `linkType` values)
- The import counterpart (`import-viz-click-behavior-link`) already guards against this with `u/update-some` + `if-let`
- This change makes export symmetric with import by applying the same guard pattern


Every call site of `*export-fk*` / `*import-fk*` in serialization.clj now falls into one of two categories:
  - Hardcoded model (e.g., `*export-fk*` id :model/Card) - always safe, model is a literal
  - Dynamic model from link-card-model->toucan-model - all 4 sites now use `if-let`guards to skip the call when the model is nil

## Test plan

- [x] `metabase.models.serialization-test` - all 8 tests pass