### PR TITLE
Get MariaDB table privileges from table_privileges table.

### DIFF
--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -223,9 +223,30 @@
 
 (defmethod sql-jdbc.sync/current-user-table-privileges :mysql
   [_driver conn-spec & {:as _options}]
-  ;; MariaDB doesn't allow users to query the privileges of roles a user might have (unless they have select privileges
-  ;; for the mysql database), so we can't query the full privileges of the current user.
-  (when-not (some-> conn-spec :connection mariadb-connection?)
+  ;; MariaDB and MySQL handle privilege fetching differently here.
+  ;; MariaDB uses the standard `information_schema.table_privileges` view,
+  ;; which is generally more robust and aligns with other drivers.
+  ;; The original MySQL implementation uses `SHOW GRANTS`, which requires
+  ;; parsing the output string and handling different grant levels.
+  ;; This older approach is retained for MySQL compatibility.
+  ;; TODO: mariadb-connection? always returns false in tests, because conn-spec has no :connection key
+  (if (re-find #"mariadb" (:classname conn-spec "")) ;(some-> conn-spec :connection mariadb-connection?)
+    ;; MariaDB uses information_schema.table_privileges like other drivers
+    (let [rows (jdbc/query conn-spec
+                           [(str "SELECT table_schema, table_name, privilege_type"
+                                 " FROM information_schema.table_privileges"
+                                 " WHERE grantee = ?")
+                            (format "'%s'@'%%'" (:user conn-spec))])]
+      (for [[[table_schema table_name] grp] (group-by (juxt :table_schema :table_name) rows)
+            :let [privs (set (map :privilege_type grp))]]
+        {:role   nil
+         :schema table_schema
+         :table  table_name
+         :select (contains? privs "SELECT")
+         :insert (contains? privs "INSERT")
+         :update (contains? privs "UPDATE")
+         :delete (contains? privs "DELETE")}))
+    ;; Original MySQL logic using SHOW GRANTS
     (let [sql->tuples (fn [sql] (drop 1 (jdbc/query conn-spec sql {:as-arrays? true})))
           db-name     (ffirst (sql->tuples "SELECT DATABASE()"))
           table-names (map first (sql->tuples "SHOW TABLES"))]
@@ -233,7 +254,7 @@
                                                              db-name
                                                              table-names)]
         {:role   nil
-         :schema nil
+         :schema nil ; MySQL SHOW GRANTS doesn't easily provide schema info in this context
          :table  table-name
          :select (contains? privileges :select)
          :update (contains? privileges :update)

--- a/src/metabase/driver/sql_jdbc/sync/describe_database.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_database.clj
@@ -190,8 +190,8 @@
           tables       ...]
       (filter #(privilege-fn % :select) tables))"
   [driver conn]
-  ;; `sql-jdbc.sync.interface/have-select-privilege?` is slow because we're doing a SELECT query on each table
-  ;; It's basically a N+1 operation where N is the number of tables in the database
+  ;; `sql-jdbc.sync.interface/have-select-privilege?` is slow for some drivers because we're doing a SELECT query on
+  ;; each table; It's basically a N+1 operation where N is the number of tables in the database
   (if (driver/database-supports? driver :table-privileges nil)
     (let [privilege-map (build-privilege-map driver conn)]
       (fn [{schema :schema table :name ttype :type} privilege]

--- a/test/metabase/driver/mysql_test.clj
+++ b/test/metabase/driver/mysql_test.clj
@@ -859,57 +859,70 @@
                                             "test-data"
                                             ["foo" "bar"])))))
 
+(defn- get-privileges [details]
+  (let [new-connection-details (assoc details
+                                      :user "table_privileges_test_user"
+                                      :password "password"
+                                      :ssl true
+                                      :additional-options "trustServerCertificate=true")]
+    (sql-jdbc.conn/with-connection-spec-for-testing-connection [spec [:mysql new-connection-details]]
+      (with-redefs [sql-jdbc.conn/db->pooled-connection-spec (fn [_] spec)]
+        (sql-jdbc.sync/current-user-table-privileges driver/*driver* spec {})))))
+
 (deftest table-privileges-test
   (mt/test-driver :mysql
-    (when-not (mysql/mariadb? (mt/db))
-      (testing "`table-privileges` should return the correct data for current_user and role privileges"
-        (tx/drop-if-exists-and-create-db! driver/*driver* "table_privileges_test")
-        (let [details          (tx/dbdef->connection-details :mysql :db {:database-name "table_privileges_test"})
-              spec             (sql-jdbc.conn/connection-details->spec :mysql details)
-              get-privileges   (fn []
-                                 (let [new-connection-details (assoc details
-                                                                     :user "table_privileges_test_user",
-                                                                     :password "password"
-                                                                     :ssl true
-                                                                     :additional-options "trustServerCertificate=true")]
-                                   (sql-jdbc.conn/with-connection-spec-for-testing-connection
-                                    [spec [:mysql new-connection-details]]
-                                     (with-redefs [sql-jdbc.conn/db->pooled-connection-spec (fn [_] spec)]
-                                       (sql-jdbc.sync/current-user-table-privileges driver/*driver* spec {})))))]
-          (try
-            (doseq [stmt ["CREATE TABLE `bar` (id INTEGER);"
-                          "CREATE TABLE `baz` (id INTEGER);"
-                          "CREATE USER 'table_privileges_test_user' IDENTIFIED BY 'password';"
-                          "GRANT SELECT ON table_privileges_test.`bar` TO 'table_privileges_test_user'"]]
-              (jdbc/execute! spec stmt))
-            (testing "should return privileges on the table"
-              (is (= [{:role   nil
-                       :schema nil
-                       :table  "bar"
-                       :select true
-                       :update false
-                       :insert false
-                       :delete false}]
-                     (get-privileges))))
-            (testing "should return privileges on the database"
-              (jdbc/execute! spec "GRANT UPDATE ON `table_privileges_test`.* TO 'table_privileges_test_user'")
-              (is (= [{:role nil, :schema nil, :table "bar", :select true, :update true, :insert false, :delete false}
-                      {:role nil, :schema nil, :table "baz", :select false, :update true, :insert false, :delete false}]
-                     (get-privileges))))
+    (testing "`table-privileges` should return the correct data for current_user and role privileges"
+      (tx/drop-if-exists-and-create-db! driver/*driver* "table_privileges_test")
+      (let [db-name "table_privileges_test"
+            schema (if (mysql/mariadb? (mt/db)) db-name nil)
+            details (tx/dbdef->connection-details :mysql :db {:database-name db-name})
+            spec (sql-jdbc.conn/connection-details->spec :mysql details)]
+        (try
+          (doseq [stmt ["CREATE TABLE `bar` (id INTEGER);"
+                        "CREATE TABLE `baz` (id INTEGER);"
+                        "CREATE USER 'table_privileges_test_user' IDENTIFIED BY 'password';"
+                        "GRANT SELECT ON table_privileges_test.`bar` TO 'table_privileges_test_user'"]]
+            (jdbc/execute! spec stmt))
+          (testing "should return privileges on the table"
+            (is (= #{{:role   nil
+                      :schema schema
+                      :table  "bar"
+                      :select true :update false :insert false :delete false}}
+                   (set (get-privileges details)))))
+          (testing "should return privileges on the database"
+            (jdbc/execute! spec "GRANT UPDATE ON `table_privileges_test`.bar TO 'table_privileges_test_user'")
+            (jdbc/execute! spec "GRANT UPDATE ON `table_privileges_test`.baz TO 'table_privileges_test_user'")
+            (is (= #{{:role nil
+                      :schema schema
+                      :table "bar"
+                      :select true :update true :insert false :delete false}
+                     {:role nil
+                      :schema schema
+                      :table "baz"
+                      :select false :update true :insert false :delete false}}
+                   (set (get-privileges details)))))
+          ;; TODO: mariadb privilege checks don't support role grants yet
+          (when-not (mysql/mariadb? (mt/db))
             (testing "should return privileges on roles that the user has been granted"
               (doseq [stmt ["CREATE ROLE 'table_privileges_test_role'"
                             "GRANT INSERT ON `bar` TO 'table_privileges_test_role'"
                             "GRANT 'table_privileges_test_role' TO 'table_privileges_test_user'"]]
                 (jdbc/execute! spec stmt))
-              (is (= [{:role nil, :schema nil, :table "bar", :select true, :update true, :insert true, :delete false}
-                      {:role nil, :schema nil, :table "baz", :select false, :update true, :insert false, :delete false}]
-                     (get-privileges))))
-            (finally
-              (jdbc/execute! spec "DROP USER IF EXISTS 'table_privileges_test_user';")
-              (doseq [stmt ["DROP ROLE IF EXISTS 'table_privileges_test_role';"
-                            "DROP ROLE IF EXISTS 'table_privileges_test_role_2';"
-                            "DROP ROLE IF EXISTS 'table_privileges_test_role_3';"]]
-                (jdbc/execute! spec stmt)))))))))
+              (is (= #{{:role nil
+                        :schema schema
+                        :table "bar"
+                        :select true :update true :insert true :delete false}
+                       {:role nil
+                        :schema schema
+                        :table "baz"
+                        :select false :update true :insert false :delete false}}
+                     (set (get-privileges details))))))
+          (finally
+            (jdbc/execute! spec "DROP USER IF EXISTS 'table_privileges_test_user';")
+            (doseq [stmt ["DROP ROLE IF EXISTS 'table_privileges_test_role';"
+                          "DROP ROLE IF EXISTS 'table_privileges_test_role_2';"
+                          "DROP ROLE IF EXISTS 'table_privileges_test_role_3';"]]
+              (jdbc/execute! spec stmt))))))))
 
 (deftest ^:parallel temporal-column-with-binning-keeps-type
   (mt/test-driver :mysql


### PR DESCRIPTION
### Description

This is taken from earlier work done in https://github.com/metabase/metabase/pull/57000

MariaDB has a view called `information_schema.table_privileges` similar to postgres, but MySQL doesn't have this. Currently we treat the two DBs the same, so we fall back to MySQL-style processing of `SHOW GRANTS` output.

This patch updates it to use the `table_privileges` approach for MariaDB.

There are a couple issues here still needing to be resolved. The main one is that the MariaDB path only shows grants for users, not roles. This seems like a step backwards; the existing implementation is tacky in how it has to parse SHOW GRANTS output, but at least it catches this stuff.

The other problem (and this appears to be an issue even on the master branch) is that the predicate for determining whether the conn-spec is MariaDB or not appears to be broken, at least with the conn-spec values in test.

    (some-> conn-spec :connection mariadb-connection?)

This never succeeds, because there is no :connection field at all, so all MariaDB connections are treated like MySQL. I've replaced it with a very tacky check on the conn-spec's `:classname` field but this clearly needs a better solution.

### Checklist

- [X] Tests have been added/updated to cover changes in this PR