### PR TITLE
Auto-classify password fields as sensitive (#1694)

### DIFF
--- a/src/metabase/analyze/classifiers/core.clj
+++ b/src/metabase/analyze/classifiers/core.clj
@@ -38,6 +38,7 @@
   A classifier may see the original field (before any classifiers were run) in the metadata of the field at
   `:sync.classify/original`."
   [#'classifiers.name/infer-and-assoc-semantic-type-by-name
+   #'classifiers.name/infer-and-assoc-visibility-type-by-name
    #'classifiers.category/infer-is-category
    #'classifiers.no-preview-display/infer-no-preview-display
    #'classifiers.text-fingerprint/infer-semantic-type])

--- a/src/metabase/analyze/classifiers/name.clj
+++ b/src/metabase/analyze/classifiers/name.clj
@@ -137,7 +137,8 @@
     ;; Some DBs such as MSSQL can return columns with blank name
     [:name      :string]
     [:base_type :keyword]
-    [:semantic_type {:optional true} [:maybe :keyword]]]
+    [:semantic_type {:optional true} [:maybe :keyword]]
+    [:visibility_type {:optional true} [:maybe [:or :keyword :string]]]]
    ::analyze.schema/qp-results-cased-map])
 
 (mu/defn infer-semantic-type-by-name :- [:maybe :keyword]
@@ -158,6 +159,29 @@
                 (sync-util/name-for-logging field-or-column)
                 inferred-semantic-type)
     (assoc field-or-column :semantic_type inferred-semantic-type)))
+
+(def ^:private password-or-token-pattern
+  #"(?i)password|token|secret|salt")
+
+(mu/defn infer-visibility-type-by-name :- [:maybe :keyword]
+  "Classifier that infers the visibility type of a `field` based on its name."
+  [field-or-column :- FieldOrColumn]
+  (when (and (not= (:visibility_type field-or-column) :sensitive)
+             (not= (:visibility_type field-or-column) "sensitive")
+             (not (str/blank? (:name field-or-column))))
+    (let [field-name (u/lower-case-en (:name field-or-column))]
+      (when (re-find password-or-token-pattern field-name)
+        :sensitive))))
+
+(mu/defn infer-and-assoc-visibility-type-by-name :- [:maybe FieldOrColumn]
+  "Returns `field-or-column` with `:visibility_type` set to `:sensitive` if its name contains sensitive words"
+  [field-or-column :- FieldOrColumn
+   _fingerprint    :- [:maybe ::lib.schema.metadata.fingerprint/fingerprint]]
+  (when-let [inferred-visibility-type (infer-visibility-type-by-name field-or-column)]
+    (log/debugf "Based on the name of %s, we're giving it a visibility type of %s."
+                (sync-util/name-for-logging field-or-column)
+                inferred-visibility-type)
+    (assoc field-or-column :visibility_type inferred-visibility-type)))
 
 (defn- prefix-or-postfix
   [s]

--- a/src/metabase/sync/analyze/classify.clj
+++ b/src/metabase/sync/analyze/classify.clj
@@ -41,7 +41,7 @@
   "Columns of Field or Table that classifiers are allowed to be set."
   [model]
   (case model
-    :model/Field #{:semantic_type :preview_display :has_field_values}
+    :model/Field #{:semantic_type :preview_display :has_field_values :visibility_type}
     :model/Table #{:entity_type}))
 
 (def ^:private FieldOrTableInstance

--- a/test/metabase/analyze/classifiers/name_test.clj
+++ b/test/metabase/analyze/classifiers/name_test.clj
@@ -78,3 +78,23 @@
     (testing "Doesn't mark state columns (#2735)"
       (doseq [column-name ["state" "order_state" "state_of_order"]]
         (is (not= :type/State (infer column-name)))))))
+
+(deftest ^:parallel infer-visibility-type-test
+  (let [infer (fn infer [column-name]
+                (classifiers.name/infer-visibility-type-by-name
+                 {:name column-name, :base_type :type/Text}))]
+    (testing "sensitive names"
+      (are [column-name] (= :sensitive (infer column-name))
+        "password"
+        "PASSWORD"
+        "my_password"
+        "api_token"
+        "token_id"
+        "tenant_secret"
+        "password_salt"))
+    (testing "non-sensitive names"
+      (are [column-name] (nil? (infer column-name))
+        "id"
+        "name"
+        "description"
+        "email"))))


### PR DESCRIPTION
Resolves https://github.com/metabase/metabase/issues/1694

### Description
This PR resolves #1694 by implementing an automated classifier for sensitive credentials during the metadata sync process.
Previously, fields containing sensitive information like passwords or tokens were treated equivalently to standard text fields, requiring administrators to manually toggle them to "Do Not Include" in the Data Model to preserve security and prevent accidental leakage in cards/dashboards.
Now, during the schema classification phase, fields matching common sensitive nomenclatures (e.g., `password`, `token`, `secret`, `salt`) are intercepted and mapped directly to a `:sensitive` visibility type. 

### What's been done?
- **Schema classification update**: Adds `infer-visibility-type-by-name` utilizing a case-insensitive regex pattern.
- **Identifies typical sensitive keywords**: Intercepts `password`, `token`, `secret`, and `salt` natively.
- **Pipeline registration**: Adds the new classifier directly into the core analysis run-loop in `classifiers.core`.
- **Database synchronization whitelist**: Permitted `:visibility_type` mutations in `updateable-columns` so initial discovery gracefully saves the state.
- **Unit testing branch**: Built dedicated unit test suites validating standard string variations (e.g. `API_TOKEN`, `pass_salt`) resolve strictly to `:sensitive`.

### How to verify
1. Start a fresh Metabase instance or force a re-sync of the native `Sample Database`.
2. Navigate to **Settings -> Admin settings -> Data Model**.
3. Select the `Sample Database` and click into the `People` table.
4. Locate the `Password` field configuring panel on the right.
5. Verify that the visibility dropdown has been technically restricted to **Do Not Include**.

### Demo
#### Before Change (Visibility: Everywhere)

<img width="1440" height="779" alt="after" src="https://github.com/user-attachments/assets/c79addb1-58b8-4e9b-92d2-1404c7e75981" />

#### After Change (Visibility: Do Not Include)
<img width="1439" height="816" alt="before" src="https://github.com/user-attachments/assets/9fdcad45-78b4-467f-9064-7fa52973b814" />

### Checklist
- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
