### PR TITLE
Content translations for parameters values without custom labels

### DIFF
--- a/e2e/test/scenarios/admin/i18n/content-translation/dashboards.cy.spec.ts
+++ b/e2e/test/scenarios/admin/i18n/content-translation/dashboards.cy.spec.ts
@@ -881,6 +881,79 @@ describe("scenarios > content translation > static embeds > dashboards", () => {
           H.filterWidget().findByText("Gerät").should("be.visible");
         });
       });
+
+      it("translates selected static-list filter label in guest embed for values without labels", () => {
+        const staticListFilter = {
+          name: "String",
+          slug: "string",
+          id: "static-list-id",
+          type: "string/=",
+          sectionId: "string",
+          values_source_type: "static-list" as const,
+          values_source_config: {
+            values: [["Gadget"], ["Widget"]],
+          },
+        };
+
+        cy.signInAsAdmin();
+        H.createQuestionAndDashboard({
+          questionDetails: {
+            name: "Expression Question",
+            query: {
+              "source-table": PEOPLE_ID,
+            },
+          },
+          dashboardDetails: {
+            parameters: [staticListFilter as any], // current API isn't set to accept string[][] as values
+            enable_embedding: true,
+            embedding_params: {
+              [staticListFilter.slug]: "enabled",
+            },
+          },
+        }).then(({ body: { id, card_id, dashboard_id } }) => {
+          // Map the parameter to an expression column so the filter widget
+          // is visible, but hasFields() returns false (testing the tc()
+          // fix in FormattedParameterValue)
+          cy.request("PUT", `/api/dashboard/${dashboard_id}`, {
+            dashcards: [
+              {
+                id,
+                card_id,
+                row: 0,
+                col: 0,
+                size_x: 24,
+                size_y: 9,
+                parameter_mappings: [
+                  {
+                    parameter_id: staticListFilter.id,
+                    card_id,
+                    target: [
+                      "dimension",
+                      ["expression", "Thing", { "base-type": "type/Integer" }],
+                      { "stage-number": 0 },
+                    ],
+                  },
+                ],
+              },
+            ],
+          });
+
+          H.visitEmbeddedPage(
+            {
+              resource: { dashboard: dashboard_id as number },
+              params: {},
+            },
+            {
+              setFilters: { [staticListFilter.slug]: "Gadget" },
+              additionalHashOptions: {
+                locale: "de",
+              },
+            },
+          );
+
+          H.filterWidget().findByText("Gerät").should("be.visible");
+        });
+      });
     });
   });
 

--- a/enterprise/frontend/src/metabase-enterprise/content_translation/use-translate-content.ts
+++ b/enterprise/frontend/src/metabase-enterprise/content_translation/use-translate-content.ts
@@ -23,8 +23,7 @@ export const useTranslateContent = (): ContentTranslationFunction => {
   const dictionary = useListContentTranslations();
 
   const tc = useCallback<ContentTranslationFunction>(
-    <T = string | null | undefined>(msgid: T) =>
-      translateContentString<T>(dictionary || [], locale, msgid),
+    (msgid) => translateContentString(dictionary || [], locale, msgid),
     [locale, dictionary],
   );
 

--- a/enterprise/frontend/src/metabase-enterprise/content_translation/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/content_translation/utils.ts
@@ -18,26 +18,25 @@ import type {
 
 import { hasTranslations, useTranslateContent } from "./use-translate-content";
 
-export type TranslateContentStringFunction = <
-  MsgidType = string | boolean | string[] | boolean[] | null | undefined,
->(
-  dictionary: DictionaryArray | undefined,
-  locale: string | undefined,
-  /** This argument will be translated only if it is a string. If it is not a
-   * string, it will be returned untranslated. */
-  msgid: MsgidType,
-) => string | MsgidType;
+export type TranslateContentStringFunction = typeof translateContentString;
 
-/** Translate a user-generated string
+/**
+ * Translate a user-generated string
  *
  * Terminology: A "msgid" is a 'raw', untranslated string. A "msgstr" is a
  * translation of a msgid.
- * */
-export const translateContentString: TranslateContentStringFunction = (
-  dictionary,
-  locale,
-  rawMsgid,
-) => {
+ *
+ * @param dictionary - The dictionary to use for translations
+ * @param locale - The locale to translate string to
+ * @param rawMsgid -
+ *   The value to translate
+ *   This argument will be translated only if it is a string or boolean.
+ */
+export function translateContentString<T>(
+  dictionary: DictionaryArray | undefined,
+  locale: string | undefined,
+  rawMsgid: T,
+): string | T {
   if (!locale) {
     return rawMsgid;
   }
@@ -45,7 +44,7 @@ export const translateContentString: TranslateContentStringFunction = (
   if (Array.isArray(rawMsgid)) {
     return rawMsgid.map((msgid) =>
       translateContentString(dictionary, locale, msgid),
-    );
+    ) as T;
   }
 
   if (typeof rawMsgid !== "string" && typeof rawMsgid !== "boolean") {
@@ -71,7 +70,7 @@ export const translateContentString: TranslateContentStringFunction = (
   }
 
   return msgstr;
-};
+}
 
 /**
  * Translates a column display name by parsing it into translatable and static

--- a/enterprise/frontend/src/metabase-enterprise/content_translation/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/content_translation/utils.ts
@@ -19,7 +19,7 @@ import type {
 import { hasTranslations, useTranslateContent } from "./use-translate-content";
 
 export type TranslateContentStringFunction = <
-  MsgidType = string | boolean | null | undefined,
+  MsgidType = string | boolean | string[] | boolean[] | null | undefined,
 >(
   dictionary: DictionaryArray | undefined,
   locale: string | undefined,
@@ -40,6 +40,12 @@ export const translateContentString: TranslateContentStringFunction = (
 ) => {
   if (!locale) {
     return rawMsgid;
+  }
+
+  if (Array.isArray(rawMsgid)) {
+    return rawMsgid.map((msgid) =>
+      translateContentString(dictionary, locale, msgid),
+    );
   }
 
   if (typeof rawMsgid !== "string" && typeof rawMsgid !== "boolean") {

--- a/frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx
+++ b/frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx
@@ -90,7 +90,9 @@ function FormattedParameterValue({
     }
 
     return (
-      <span>{formatParameterValue(value, parameter, formattingSettings)}</span>
+      <span>
+        {formatParameterValue(tc(value), parameter, formattingSettings)}
+      </span>
     );
   };
 


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> Closes #69170
Closes GHY-3091

Fixes content translation for values that have no custom labels.


There were two issues:
- the content translation function does not work on arrays of values. This PR fixes that.
- raw string values were not being translated at all. This PR fixes that too.