### PR TITLE
feat(sdk,embed-js): Replace PointerSensor with MouseSensor and add TouchSensor for improved drag-and-drop support

### DIFF
--- a/e2e/support/helpers/e2e-ui-elements-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-helpers.js
@@ -362,7 +362,7 @@ export const moveDnDKitListElement = (
  * @param {Object} options
  * @param {number} [options.horizontal=0] - Horizontal distance to move in pixels
  * @param {number} [options.vertical=0] - Vertical distance to move in pixels
- * @param {boolean} [options.usePointerEvents=false] - Use pointer events instead of mouse events (for components using PointerSensor)
+ * @param {boolean} [options.useMouseEvents=false] - Use mouse events instead of pointer events (for components using MouseSensor)
  * @param {Function} [options.onBeforeDragEnd] - Optional callback executed before releasing the drag
  */
 export const moveDnDKitElementByAlias = (alias, options) => {
@@ -379,7 +379,7 @@ export const moveDnDKitElementByAlias = (alias, options) => {
  * @param {Object} options
  * @param {number} [options.horizontal=0] - Horizontal distance to move in pixels
  * @param {number} [options.vertical=0] - Vertical distance to move in pixels
- * @param {boolean} [options.usePointerEvents=false] - Use pointer events instead of mouse events (for components using PointerSensor)
+ * @param {boolean} [options.useMouseEvents=false] - Use mouse events instead of pointer events (for components using MouseSensor)
  * @param {Function} [options.onBeforeDragEnd] - Optional callback executed before releasing the drag
  */
 const moveDnDKitElementByGetter = (
@@ -387,16 +387,16 @@ const moveDnDKitElementByGetter = (
   {
     horizontal = 0,
     vertical = 0,
-    usePointerEvents = false,
+    useMouseEvents = false,
     onBeforeDragEnd = () => {},
   } = {},
 ) => {
-  const down = usePointerEvents ? "pointerdown" : "mousedown";
-  const move = usePointerEvents ? "pointermove" : "mousemove";
-  const up = usePointerEvents ? "pointerup" : "mouseup";
-  const extraProps = usePointerEvents
-    ? { isPrimary: true }
-    : { eventConstructor: "MouseEvent" };
+  const down = useMouseEvents ? "mousedown" : "pointerdown";
+  const move = useMouseEvents ? "mousemove" : "pointermove";
+  const up = useMouseEvents ? "mouseup" : "pointerup";
+  const extraProps = useMouseEvents
+    ? { eventConstructor: "MouseEvent" }
+    : { isPrimary: true };
 
   getElement()
     .trigger(down, 0, 0, {

--- a/e2e/support/helpers/e2e-ui-elements-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-helpers.js
@@ -362,6 +362,7 @@ export const moveDnDKitListElement = (
  * @param {Object} options
  * @param {number} [options.horizontal=0] - Horizontal distance to move in pixels
  * @param {number} [options.vertical=0] - Vertical distance to move in pixels
+ * @param {boolean} [options.usePointerEvents=false] - Use pointer events instead of mouse events (for components using PointerSensor)
  * @param {Function} [options.onBeforeDragEnd] - Optional callback executed before releasing the drag
  */
 export const moveDnDKitElementByAlias = (alias, options) => {
@@ -378,45 +379,58 @@ export const moveDnDKitElementByAlias = (alias, options) => {
  * @param {Object} options
  * @param {number} [options.horizontal=0] - Horizontal distance to move in pixels
  * @param {number} [options.vertical=0] - Vertical distance to move in pixels
+ * @param {boolean} [options.usePointerEvents=false] - Use pointer events instead of mouse events (for components using PointerSensor)
  * @param {Function} [options.onBeforeDragEnd] - Optional callback executed before releasing the drag
  */
 const moveDnDKitElementByGetter = (
   getElement,
-  { horizontal = 0, vertical = 0, onBeforeDragEnd = () => {} } = {},
+  {
+    horizontal = 0,
+    vertical = 0,
+    usePointerEvents = false,
+    onBeforeDragEnd = () => {},
+  } = {},
 ) => {
+  const down = usePointerEvents ? "pointerdown" : "mousedown";
+  const move = usePointerEvents ? "pointermove" : "mousemove";
+  const up = usePointerEvents ? "pointerup" : "mouseup";
+  const extraProps = usePointerEvents
+    ? { isPrimary: true }
+    : { eventConstructor: "MouseEvent" };
+
   getElement()
-    .trigger("pointerdown", 0, 0, {
+    .trigger(down, 0, 0, {
       force: true,
-      isPrimary: true,
       button: 0,
+      ...extraProps,
     })
     .wait(200);
 
   // This initial move needs to be greater than the activation constraint
-  // of the pointer sensor
+  // of the sensor
   getElement()
-    .trigger("pointermove", 20, 20, {
+    .trigger(move, 20, 20, {
       force: true,
-      isPrimary: true,
       button: 0,
+      ...extraProps,
     })
     .wait(200);
 
   getElement()
-    .trigger("pointermove", horizontal, vertical, {
+    .trigger(move, horizontal, vertical, {
       force: true,
-      isPrimary: true,
       button: 0,
+      ...extraProps,
     })
     .wait(200);
 
   onBeforeDragEnd();
 
   cy.document()
-    .trigger("pointerup", {
+    .trigger(up, {
       force: true,
-      isPrimary: true,
       button: 0,
+      ...extraProps,
     })
     .wait(200);
 };

--- a/e2e/support/helpers/e2e-ui-elements-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-helpers.js
@@ -325,11 +325,17 @@ export const moveColumnDown = (column, distance) => {
  * @param {Object} options
  * @param {number} options.startIndex - The index of the element to drag
  * @param {number} options.dropIndex - The index where the element should be dropped
+ * @param {boolean} [options.useMouseEvents=false] - Use mouse events instead of pointer events (for components using MouseSensor)
  * @param {Function} [options.onBeforeDragEnd] - Optional callback executed before releasing the drag
  */
 export const moveDnDKitListElement = (
   dataTestId,
-  { startIndex, dropIndex, onBeforeDragEnd = () => {} } = {},
+  {
+    startIndex,
+    dropIndex,
+    onBeforeDragEnd = () => {},
+    useMouseEvents = false,
+  } = {},
 ) => {
   const selector = new RegExp(dataTestId);
   const getElement = () =>
@@ -350,6 +356,7 @@ export const moveDnDKitListElement = (
     moveDnDKitElementByGetter(getElement, {
       vertical: dropPoint.clientY - dragPoint.clientY,
       horizontal: dropPoint.clientX - dragPoint.clientX,
+      useMouseEvents,
       onBeforeDragEnd,
     });
   });

--- a/e2e/test-component/scenarios/embedding-sdk/styles-tests.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/styles-tests.cy.spec.tsx
@@ -562,6 +562,7 @@ describe("scenarios > embedding-sdk > styles", () => {
         H.moveDnDKitListElement("draggable-item-", {
           startIndex: 0,
           dropIndex: 1,
+          useMouseEvents: true,
           onBeforeDragEnd: () => {
             cy.get(".drag-overlay").within(() => {
               cy.findByTestId("draggable-item-ID").should(

--- a/e2e/test/scenarios/custom-column/custom-column-3.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/custom-column-3.cy.spec.js
@@ -559,7 +559,10 @@ describe("scenarios > question > custom column > aggregation", () => {
       .should("have.length", 2)
       .last()
       .as("dragElement");
-    H.moveDnDKitElementByAlias("@dragElement", { horizontal: -400 });
+    H.moveDnDKitElementByAlias("@dragElement", {
+      horizontal: -400,
+      useMouseEvents: true,
+    });
 
     cy.log("The values should not have changed, but the order should have");
     H.visualize();
@@ -1026,7 +1029,10 @@ describe("scenarios > question > custom column > aggregation", () => {
         .should("have.length", 2)
         .last()
         .as("dragElement");
-      H.moveDnDKitElementByAlias("@dragElement", { horizontal: -400 });
+      H.moveDnDKitElementByAlias("@dragElement", {
+        horizontal: -400,
+        useMouseEvents: true,
+      });
 
       H.visualize();
       H.assertTableData({

--- a/e2e/test/scenarios/dashboard-cards/visualization-options.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/visualization-options.cy.spec.js
@@ -94,6 +94,7 @@ describe("scenarios > dashboard cards > visualization options", () => {
       H.getDraggableElements().contains("ID").as("dragElement");
       H.moveDnDKitElementByAlias("@dragElement", {
         vertical: 100,
+        useMouseEvents: true,
       });
       const idButton = () =>
         cy.get('[data-testid="draggable-item-ID"]').closest("[role=button]");

--- a/e2e/test/scenarios/native-filters/native-filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/native-filters-reproductions.cy.spec.js
@@ -40,6 +40,7 @@ describe("issue 9357", () => {
       H.filterWidget().findAllByRole("listitem").first().as("dragElement");
       H.moveDnDKitElementByAlias("@dragElement", {
         vertical: 50,
+        useMouseEvents: true,
       });
 
       // Ensure they're in the right order

--- a/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/native/native-reproductions.cy.spec.ts
@@ -1045,10 +1045,10 @@ describe("issue 69160", () => {
       .first()
       .as("param");
 
-    cy.get("@param").trigger("pointerdown", 5, 5, options).wait(200);
-    cy.get("@param").trigger("pointermove", 20, 20, options).wait(200);
-    cy.get("@param").trigger("pointermove", 200, 0, options).wait(200);
-    cy.get("@param").trigger("pointerup", options).wait(200);
+    cy.get("@param").trigger("mousedown", 5, 5, options).wait(200);
+    cy.get("@param").trigger("mousemove", 20, 20, options).wait(200);
+    cy.get("@param").trigger("mousemove", 200, 0, options).wait(200);
+    cy.get("@param").trigger("mouseup", options).wait(200);
 
     cy.findByTestId("native-query-top-bar")
       .findAllByRole("textbox")

--- a/e2e/test/scenarios/question-reproductions/reproductions-1.cy.spec.js
+++ b/e2e/test/scenarios/question-reproductions/reproductions-1.cy.spec.js
@@ -646,10 +646,11 @@ function moveColumnToTop(column) {
     cy.findByText(column)
       .should("be.visible")
       .closest("[data-testid^=draggable-item]")
-      .trigger("mousedown", 0, 0, { force: true })
-      .trigger("mousemove", 5, 5, { force: true })
-      .trigger("mousemove", 0, -600, { force: true })
-      .trigger("mouseup", 0, -600, { force: true });
+      .as("dragColumn");
+  });
+  H.moveDnDKitElementByAlias("@dragColumn", {
+    vertical: -130,
+    useMouseEvents: true,
   });
 }
 

--- a/e2e/test/scenarios/question/notebook.cy.spec.js
+++ b/e2e/test/scenarios/question/notebook.cy.spec.js
@@ -622,6 +622,7 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
       H.moveDnDKitElementByAlias("@dragElement", {
         horizontal,
         vertical,
+        useMouseEvents: true,
       });
       // eslint-disable-next-line metabase/no-unsafe-element-filtering
       cy.findAllByTestId("notebook-cell-item")
@@ -662,6 +663,7 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
         H.moveDnDKitElementByAlias("@dragElement", {
           horizontal,
           vertical,
+          useMouseEvents: true,
         });
       });
       // eslint-disable-next-line metabase/no-unsafe-element-filtering

--- a/e2e/test/scenarios/question/settings.cy.spec.js
+++ b/e2e/test/scenarios/question/settings.cy.spec.js
@@ -90,7 +90,10 @@ describe("scenarios > question > settings", () => {
 
       getSidebarColumns().eq("5").as("total").contains("Total");
 
-      H.moveDnDKitElementByAlias("@total", { vertical: -100 });
+      H.moveDnDKitElementByAlias("@total", {
+        vertical: -100,
+        useMouseEvents: true,
+      });
 
       getSidebarColumns().eq("3").should("contain.text", "Total");
 
@@ -104,7 +107,10 @@ describe("scenarios > question > settings", () => {
         expect($el.scrollTop).to.eql(0);
       });
 
-      H.moveDnDKitElementByAlias("@title", { vertical: 15 });
+      H.moveDnDKitElementByAlias("@title", {
+        vertical: 15,
+        useMouseEvents: true,
+      });
 
       cy.findByTestId("chartsettings-list-container").should(([$el]) => {
         expect($el.scrollTop).to.be.greaterThan(0);
@@ -159,7 +165,10 @@ describe("scenarios > question > settings", () => {
         .contains(/Products? → Category/);
 
       // Drag and drop this column between "Tax" and "Discount" (index 5 in @sidebarColumns array)
-      H.moveDnDKitElementByAlias("@prod-category", { vertical: -360 });
+      H.moveDnDKitElementByAlias("@prod-category", {
+        vertical: -360,
+        useMouseEvents: true,
+      });
 
       refreshResultsInHeader();
 
@@ -188,7 +197,10 @@ describe("scenarios > question > settings", () => {
       findColumnAtIndex("User → Address", -1).as("user-address");
 
       // Move it one place up
-      H.moveDnDKitElementByAlias("@user-address", { vertical: -100 });
+      H.moveDnDKitElementByAlias("@user-address", {
+        vertical: -100,
+        useMouseEvents: true,
+      });
 
       findColumnAtIndex("User → Address", -3);
 

--- a/e2e/test/scenarios/visualizations-charts/bar_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/bar_chart.cy.spec.js
@@ -136,7 +136,10 @@ describe("scenarios > visualizations > bar chart", () => {
 
     it("should allow you to show/hide and reorder columns", () => {
       H.getDraggableElements().eq(0).as("dragElement");
-      H.moveDnDKitElementByAlias("@dragElement", { vertical: 100 });
+      H.moveDnDKitElementByAlias("@dragElement", {
+        vertical: 100,
+        useMouseEvents: true,
+      });
 
       cy.findAllByTestId("legend-item").eq(0).should("contain.text", "Gadget");
       cy.findAllByTestId("legend-item").eq(1).should("contain.text", "Gizmo");
@@ -176,7 +179,10 @@ describe("scenarios > visualizations > bar chart", () => {
 
     it("should gracefully handle removing filtered items, and adding new items to the end of the list", () => {
       H.getDraggableElements().first().as("dragElement");
-      H.moveDnDKitElementByAlias("@dragElement", { vertical: 100 });
+      H.moveDnDKitElementByAlias("@dragElement", {
+        vertical: 100,
+        useMouseEvents: true,
+      });
 
       H.getDraggableElements().eq(1).icon("close").click({ force: true }); // Hide Gizmo
 

--- a/e2e/test/scenarios/visualizations-charts/funnel.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/funnel.cy.spec.js
@@ -41,6 +41,7 @@ describe("scenarios > visualizations > funnel chart", () => {
         H.getDraggableElements().first().as("dragElement");
         H.moveDnDKitElementByAlias("@dragElement", {
           vertical: 100,
+          useMouseEvents: true,
         });
 
         H.getDraggableElements().eq(2).should("have.text", name);
@@ -68,7 +69,10 @@ describe("scenarios > visualizations > funnel chart", () => {
 
   it("should handle row items being filterd out and returned gracefully", () => {
     H.getDraggableElements().first().as("dragElement");
-    H.moveDnDKitElementByAlias("@dragElement", { vertical: 100 });
+    H.moveDnDKitElementByAlias("@dragElement", {
+      vertical: 100,
+      useMouseEvents: true,
+    });
 
     H.getDraggableElements()
       .eq(1)

--- a/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
@@ -557,6 +557,7 @@ describe("scenarios > visualizations > line chart", () => {
           cy.findAllByTestId("drag-handle").first().as("dragElement");
           H.moveDnDKitElementByAlias("@dragElement", {
             vertical: 50,
+            useMouseEvents: true,
           });
         });
 

--- a/e2e/test/scenarios/visualizations-charts/pie_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/pie_chart.cy.spec.js
@@ -222,6 +222,7 @@ describe("scenarios > visualizations > pie chart", () => {
     H.getDraggableElements().contains("Woooget").as("dragElement");
     H.moveDnDKitElementByAlias("@dragElement", {
       vertical: 100,
+      useMouseEvents: true,
     });
 
     ensurePieChartRendered(["Woooget", "Gadget", "Gizmo", "Doohickey"]);
@@ -245,6 +246,7 @@ describe("scenarios > visualizations > pie chart", () => {
     H.getDraggableElements().contains("Katget").as("dragElement");
     H.moveDnDKitElementByAlias("@dragElement", {
       vertical: 30,
+      useMouseEvents: true,
     });
 
     changeRowLimit(2, 4);

--- a/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/visualizations-charts/visualizations-charts-reproductions.cy.spec.ts
@@ -88,7 +88,10 @@ describe("issue 45255", () => {
     // Can reorder (empty)
     H.getDraggableElements().eq(2).should("have.text", "(empty)");
     H.getDraggableElements().first().as("dragElement");
-    H.moveDnDKitElementByAlias("@dragElement", { vertical: 100 });
+    H.moveDnDKitElementByAlias("@dragElement", {
+      vertical: 100,
+      useMouseEvents: true,
+    });
     H.getDraggableElements().eq(1).should("have.text", "(empty)");
 
     // Has (empty) in the chart

--- a/e2e/test/scenarios/visualizations-tabular/object_detail.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/object_detail.cy.spec.js
@@ -584,7 +584,10 @@ describe("scenarios > question > object details", { tags: "@slow" }, () => {
         .eq("7")
         .as("stateItem")
         .should("have.text", "State");
-      H.moveDnDKitElementByAlias("@stateItem", { vertical: -300 });
+      H.moveDnDKitElementByAlias("@stateItem", {
+        vertical: -300,
+        useMouseEvents: true,
+      });
     });
 
     H.openObjectDetail(0);

--- a/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
@@ -1100,6 +1100,7 @@ describe("scenarios > visualizations > table > conditional formatting", () => {
       cy.findAllByTestId("formatting-rule-preview").eq(2).as("dragElement");
       H.moveDnDKitElementByAlias("@dragElement", {
         vertical: -300,
+        useMouseEvents: true,
       });
 
       cy.findAllByTestId("formatting-rule-preview")

--- a/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
@@ -546,6 +546,7 @@ describe("issue 25250", () => {
     H.getDraggableElements().contains("Product ID").as("dragElement");
     H.moveDnDKitElementByAlias("@dragElement", {
       vertical: -100,
+      useMouseEvents: true,
     });
     H.getDraggableElements().eq(0).should("contain", "Product ID");
   });

--- a/frontend/src/metabase/common/components/TabRow/TabRow.tsx
+++ b/frontend/src/metabase/common/components/TabRow/TabRow.tsx
@@ -1,9 +1,8 @@
 import {
+  DndContext,
   type DragEndEvent,
-  TouchSensor,
   type UniqueIdentifier,
 } from "@dnd-kit/core";
-import { DndContext, MouseSensor, useSensor } from "@dnd-kit/core";
 import {
   restrictToHorizontalAxis,
   restrictToParentElement,
@@ -26,6 +25,7 @@ import {
 import { usePreviousDistinct } from "react-use";
 
 import { ExplicitSize } from "metabase/common/components/ExplicitSize";
+import { useDndSensors } from "metabase/common/hooks";
 import { Icon } from "metabase/ui";
 
 import type { TabListProps } from "../TabList/TabList";
@@ -64,12 +64,7 @@ const TabRowInner = forwardRef<HTMLDivElement, TabRowProps<unknown>>(
     const itemsCount = itemIds?.length ?? 0;
     const previousItemsCount = usePreviousDistinct(itemsCount) ?? 0;
 
-    const mouseSensor = useSensor(MouseSensor, {
-      activationConstraint: { distance: 10 },
-    });
-    const touchSensor = useSensor(TouchSensor, {
-      activationConstraint: { distance: 10 },
-    });
+    const sensors = useDndSensors({ distance: 10 });
 
     const scroll = useCallback(
       (direction: "left" | "right") => {
@@ -121,7 +116,7 @@ const TabRowInner = forwardRef<HTMLDivElement, TabRowProps<unknown>>(
         <DndContext
           onDragEnd={onDragEnd}
           modifiers={[restrictToHorizontalAxis, restrictToParentElement]}
-          sensors={[mouseSensor, touchSensor]}
+          sensors={sensors}
           collisionDetection={tabsCollisionDetection}
         >
           <SortableContext

--- a/frontend/src/metabase/common/components/TabRow/TabRow.tsx
+++ b/frontend/src/metabase/common/components/TabRow/TabRow.tsx
@@ -1,10 +1,9 @@
-import type { DragEndEvent, UniqueIdentifier } from "@dnd-kit/core";
 import {
-  DndContext,
-  MouseSensor,
-  PointerSensor,
-  useSensor,
+  type DragEndEvent,
+  TouchSensor,
+  type UniqueIdentifier,
 } from "@dnd-kit/core";
+import { DndContext, MouseSensor, useSensor } from "@dnd-kit/core";
 import {
   restrictToHorizontalAxis,
   restrictToParentElement,
@@ -65,13 +64,10 @@ const TabRowInner = forwardRef<HTMLDivElement, TabRowProps<unknown>>(
     const itemsCount = itemIds?.length ?? 0;
     const previousItemsCount = usePreviousDistinct(itemsCount) ?? 0;
 
-    const pointerSensor = useSensor(PointerSensor, {
+    const mouseSensor = useSensor(MouseSensor, {
       activationConstraint: { distance: 10 },
     });
-
-    // Needed for DnD e2e tests to work
-    // See https://github.com/clauderic/dnd-kit/issues/208#issuecomment-824469766
-    const mouseSensor = useSensor(MouseSensor, {
+    const touchSensor = useSensor(TouchSensor, {
       activationConstraint: { distance: 10 },
     });
 
@@ -125,7 +121,7 @@ const TabRowInner = forwardRef<HTMLDivElement, TabRowProps<unknown>>(
         <DndContext
           onDragEnd={onDragEnd}
           modifiers={[restrictToHorizontalAxis, restrictToParentElement]}
-          sensors={[pointerSensor, mouseSensor]}
+          sensors={[mouseSensor, touchSensor]}
           collisionDetection={tabsCollisionDetection}
         >
           <SortableContext

--- a/frontend/src/metabase/common/hooks/index.ts
+++ b/frontend/src/metabase/common/hooks/index.ts
@@ -1,5 +1,6 @@
 export * from "./entity-framework";
 export * from "./use-confirmation";
+export * from "./use-dnd-sensors";
 export * from "./use-docs-url";
 export * from "./use-get-personal-collection";
 export * from "./use-has-token-feature";

--- a/frontend/src/metabase/common/hooks/use-dnd-sensors.ts
+++ b/frontend/src/metabase/common/hooks/use-dnd-sensors.ts
@@ -1,0 +1,18 @@
+import { MouseSensor, TouchSensor, useSensor, useSensors } from "@dnd-kit/core";
+
+interface UseDndSensorsOptions {
+  distance: number;
+}
+
+/**
+ * Custom hook to create dnd-kit sensors that work well both for Desktop and Mobile devices
+ */
+export const useDndSensors = ({ distance }: UseDndSensorsOptions) =>
+  useSensors(
+    useSensor(MouseSensor, {
+      activationConstraint: { distance },
+    }),
+    useSensor(TouchSensor, {
+      activationConstraint: { distance },
+    }),
+  );

--- a/frontend/src/metabase/parameters/components/ParametersList/ParametersList.tsx
+++ b/frontend/src/metabase/parameters/components/ParametersList/ParametersList.tsx
@@ -1,4 +1,4 @@
-import { PointerSensor, useSensor } from "@dnd-kit/core";
+import { MouseSensor, TouchSensor, useSensor } from "@dnd-kit/core";
 import cx from "classnames";
 import { forwardRef, useCallback, useMemo } from "react";
 
@@ -48,7 +48,10 @@ export const ParametersList = forwardRef<HTMLDivElement, ParametersListProps>(
     },
     ref,
   ) {
-    const pointerSensor = useSensor(PointerSensor, {
+    const mouseSensor = useSensor(MouseSensor, {
+      activationConstraint: { distance: 15 },
+    });
+    const touchSensor = useSensor(TouchSensor, {
       activationConstraint: { distance: 15 },
     });
 
@@ -133,7 +136,7 @@ export const ParametersList = forwardRef<HTMLDivElement, ParametersListProps>(
             getId={getId}
             renderItem={renderItem}
             onSortEnd={handleSortEnd}
-            sensors={[pointerSensor]}
+            sensors={[mouseSensor, touchSensor]}
           />
         ) : (
           <>

--- a/frontend/src/metabase/parameters/components/ParametersList/ParametersList.tsx
+++ b/frontend/src/metabase/parameters/components/ParametersList/ParametersList.tsx
@@ -1,4 +1,3 @@
-import { MouseSensor, TouchSensor, useSensor } from "@dnd-kit/core";
 import cx from "classnames";
 import { forwardRef, useCallback, useMemo } from "react";
 
@@ -7,6 +6,7 @@ import type {
   RenderItemProps,
 } from "metabase/common/components/Sortable";
 import { SortableList } from "metabase/common/components/Sortable";
+import { useDndSensors } from "metabase/common/hooks";
 import CS from "metabase/css/core/index.css";
 import type { ParametersListProps } from "metabase/parameters/components/ParametersList/types";
 import { getVisibleParameters } from "metabase/parameters/utils/ui";
@@ -48,12 +48,7 @@ export const ParametersList = forwardRef<HTMLDivElement, ParametersListProps>(
     },
     ref,
   ) {
-    const mouseSensor = useSensor(MouseSensor, {
-      activationConstraint: { distance: 15 },
-    });
-    const touchSensor = useSensor(TouchSensor, {
-      activationConstraint: { distance: 15 },
-    });
+    const sensors = useDndSensors({ distance: 15 });
 
     const visibleValuePopulatedParameters = useMemo(
       () => getVisibleParameters(parameters, hideParameters),
@@ -136,7 +131,7 @@ export const ParametersList = forwardRef<HTMLDivElement, ParametersListProps>(
             getId={getId}
             renderItem={renderItem}
             onSortEnd={handleSortEnd}
-            sensors={[mouseSensor, touchSensor]}
+            sensors={sensors}
           />
         ) : (
           <>

--- a/frontend/src/metabase/querying/notebook/components/ClauseStep/ClauseStep.tsx
+++ b/frontend/src/metabase/querying/notebook/components/ClauseStep/ClauseStep.tsx
@@ -2,9 +2,6 @@ import {
   DndContext,
   type DndContextProps,
   type DragEndEvent,
-  MouseSensor,
-  TouchSensor,
-  useSensor,
 } from "@dnd-kit/core";
 import { restrictToParentElement } from "@dnd-kit/modifiers";
 import { SortableContext, useSortable } from "@dnd-kit/sortable";
@@ -13,6 +10,7 @@ import { useMergedRef } from "@mantine/hooks";
 import type { ReactNode, Ref } from "react";
 import { forwardRef, useCallback } from "react";
 
+import { useDndSensors } from "metabase/common/hooks";
 import { Icon } from "metabase/ui";
 import type { ColorName } from "metabase/ui/colors/types";
 
@@ -142,12 +140,7 @@ function ClauseStepDndContext<T>({
   children,
   onReorder,
 }: ClauseStepDndContextProps<T>) {
-  const mouseSensor = useSensor(MouseSensor, {
-    activationConstraint: { distance: 15 },
-  });
-  const touchSensor = useSensor(TouchSensor, {
-    activationConstraint: { distance: 15 },
-  });
+  const sensors = useDndSensors({ distance: 15 });
 
   const handleSortEnd: DndContextProps["onDragEnd"] = useCallback(
     (input: DragEndEvent) => {
@@ -162,7 +155,7 @@ function ClauseStepDndContext<T>({
 
   return (
     <DndContext
-      sensors={[mouseSensor, touchSensor]}
+      sensors={sensors}
       modifiers={[restrictToParentElement]}
       onDragEnd={handleSortEnd}
     >

--- a/frontend/src/metabase/querying/notebook/components/ClauseStep/ClauseStep.tsx
+++ b/frontend/src/metabase/querying/notebook/components/ClauseStep/ClauseStep.tsx
@@ -1,5 +1,11 @@
-import type { DndContextProps, DragEndEvent } from "@dnd-kit/core";
-import { DndContext, PointerSensor, useSensor } from "@dnd-kit/core";
+import {
+  DndContext,
+  type DndContextProps,
+  type DragEndEvent,
+  MouseSensor,
+  TouchSensor,
+  useSensor,
+} from "@dnd-kit/core";
 import { restrictToParentElement } from "@dnd-kit/modifiers";
 import { SortableContext, useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
@@ -136,7 +142,10 @@ function ClauseStepDndContext<T>({
   children,
   onReorder,
 }: ClauseStepDndContextProps<T>) {
-  const pointerSensor = useSensor(PointerSensor, {
+  const mouseSensor = useSensor(MouseSensor, {
+    activationConstraint: { distance: 15 },
+  });
+  const touchSensor = useSensor(TouchSensor, {
     activationConstraint: { distance: 15 },
   });
 
@@ -153,7 +162,7 @@ function ClauseStepDndContext<T>({
 
   return (
     <DndContext
-      sensors={[pointerSensor]}
+      sensors={[mouseSensor, touchSensor]}
       modifiers={[restrictToParentElement]}
       onDragEnd={handleSortEnd}
     >

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import { PointerSensor, useSensor } from "@dnd-kit/core";
+import { MouseSensor, TouchSensor, useSensor } from "@dnd-kit/core";
 import cx from "classnames";
 import { useCallback, useMemo } from "react";
 import { match } from "ts-pattern";
@@ -42,7 +42,10 @@ export const ChartSettingFieldsPicker = ({
   );
   const getId = useCallback((field) => field, []);
 
-  const pointerSensor = useSensor(PointerSensor, {
+  const mouseSensor = useSensor(MouseSensor, {
+    activationConstraint: { distance: 15 },
+  });
+  const touchSensor = useSensor(TouchSensor, {
     activationConstraint: { distance: 15 },
   });
 
@@ -137,7 +140,7 @@ export const ChartSettingFieldsPicker = ({
           renderItem={renderItem}
           items={sortableFields}
           onSortEnd={handleDragEnd}
-          sensors={[pointerSensor]}
+          sensors={[mouseSensor, touchSensor]}
           dividers={[]}
         />
       ) : (

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx
@@ -1,11 +1,11 @@
 /* eslint-disable react/prop-types */
-import { MouseSensor, TouchSensor, useSensor } from "@dnd-kit/core";
 import cx from "classnames";
 import { useCallback, useMemo } from "react";
 import { match } from "ts-pattern";
 import { t } from "ttag";
 
 import { Sortable, SortableList } from "metabase/common/components/Sortable";
+import { useDndSensors } from "metabase/common/hooks";
 import CS from "metabase/css/core/index.css";
 import { moveElement } from "metabase/lib/arrays";
 
@@ -42,12 +42,7 @@ export const ChartSettingFieldsPicker = ({
   );
   const getId = useCallback((field) => field, []);
 
-  const mouseSensor = useSensor(MouseSensor, {
-    activationConstraint: { distance: 15 },
-  });
-  const touchSensor = useSensor(TouchSensor, {
-    activationConstraint: { distance: 15 },
-  });
+  const sensors = useDndSensors({ distance: 15 });
 
   const handleDragEnd = ({ id: sortableField, newIndex }) => {
     const field = convertField(sortableField);
@@ -140,7 +135,7 @@ export const ChartSettingFieldsPicker = ({
           renderItem={renderItem}
           items={sortableFields}
           onSortEnd={handleDragEnd}
-          sensors={[mouseSensor, touchSensor]}
+          sensors={sensors}
           dividers={[]}
         />
       ) : (

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedItems/ChartSettingOrderedItems.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedItems/ChartSettingOrderedItems.tsx
@@ -1,4 +1,3 @@
-import { MouseSensor, TouchSensor, useSensor } from "@dnd-kit/core";
 import { useCallback } from "react";
 
 import type {
@@ -6,6 +5,7 @@ import type {
   SortableDivider,
 } from "metabase/common/components/Sortable";
 import { Sortable, SortableList } from "metabase/common/components/Sortable";
+import { useDndSensors } from "metabase/common/hooks";
 import type { IconProps } from "metabase/ui";
 import type { AccentColorOptions } from "metabase/ui/colors/types";
 
@@ -56,12 +56,7 @@ export function ChartSettingOrderedItems<T extends SortableItem>({
   dividers = [],
 }: ChartSettingOrderedItemsProps<T>) {
   const isDragDisabled = items.length < 1;
-  const mouseSensor = useSensor(MouseSensor, {
-    activationConstraint: { distance: 15 },
-  });
-  const touchSensor = useSensor(TouchSensor, {
-    activationConstraint: { distance: 15 },
-  });
+  const sensors = useDndSensors({ distance: 15 });
 
   const renderItem = useCallback(
     ({ item, id }: { item: T; id: string | number }) =>
@@ -122,7 +117,7 @@ export function ChartSettingOrderedItems<T extends SortableItem>({
       renderItem={renderItem}
       items={items}
       onSortEnd={onSortEnd}
-      sensors={[mouseSensor, touchSensor]}
+      sensors={sensors}
       dividers={dividers}
     />
   );

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedItems/ChartSettingOrderedItems.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedItems/ChartSettingOrderedItems.tsx
@@ -1,4 +1,4 @@
-import { PointerSensor, useSensor } from "@dnd-kit/core";
+import { MouseSensor, TouchSensor, useSensor } from "@dnd-kit/core";
 import { useCallback } from "react";
 
 import type {
@@ -56,7 +56,10 @@ export function ChartSettingOrderedItems<T extends SortableItem>({
   dividers = [],
 }: ChartSettingOrderedItemsProps<T>) {
   const isDragDisabled = items.length < 1;
-  const pointerSensor = useSensor(PointerSensor, {
+  const mouseSensor = useSensor(MouseSensor, {
+    activationConstraint: { distance: 15 },
+  });
+  const touchSensor = useSensor(TouchSensor, {
     activationConstraint: { distance: 15 },
   });
 
@@ -119,7 +122,7 @@ export function ChartSettingOrderedItems<T extends SortableItem>({
       renderItem={renderItem}
       items={items}
       onSortEnd={onSortEnd}
-      sensors={[pointerSensor]}
+      sensors={[mouseSensor, touchSensor]}
       dividers={dividers}
     />
   );

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting/SortableRuleList.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting/SortableRuleList.tsx
@@ -1,4 +1,4 @@
-import { PointerSensor, useSensor } from "@dnd-kit/core";
+import { MouseSensor, TouchSensor, useSensor } from "@dnd-kit/core";
 import { useMemo } from "react";
 
 import { Sortable, SortableList } from "metabase/common/components/Sortable";
@@ -34,7 +34,10 @@ export const SortableRuleList = ({
 
   const getId = (rule: RuleWithId) => rule.id.toString();
 
-  const pointerSensor = useSensor(PointerSensor, {
+  const mouseSensor = useSensor(MouseSensor, {
+    activationConstraint: { distance: 15 },
+  });
+  const touchSensor = useSensor(TouchSensor, {
     activationConstraint: { distance: 15 },
   });
 
@@ -74,7 +77,7 @@ export const SortableRuleList = ({
         items={rulesWithIDs}
         getId={getId}
         renderItem={renderItem}
-        sensors={[pointerSensor]}
+        sensors={[mouseSensor, touchSensor]}
         onSortEnd={handleSortEnd}
       />
     </div>

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting/SortableRuleList.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting/SortableRuleList.tsx
@@ -1,7 +1,7 @@
-import { MouseSensor, TouchSensor, useSensor } from "@dnd-kit/core";
 import { useMemo } from "react";
 
 import { Sortable, SortableList } from "metabase/common/components/Sortable";
+import { useDndSensors } from "metabase/common/hooks";
 import type {
   ColumnFormattingSetting,
   DatasetColumn,
@@ -34,12 +34,7 @@ export const SortableRuleList = ({
 
   const getId = (rule: RuleWithId) => rule.id.toString();
 
-  const mouseSensor = useSensor(MouseSensor, {
-    activationConstraint: { distance: 15 },
-  });
-  const touchSensor = useSensor(TouchSensor, {
-    activationConstraint: { distance: 15 },
-  });
+  const sensors = useDndSensors({ distance: 15 });
 
   const handleSortEnd = ({
     id,
@@ -77,7 +72,7 @@ export const SortableRuleList = ({
         items={rulesWithIDs}
         getId={getId}
         renderItem={renderItem}
-        sensors={[mouseSensor, touchSensor]}
+        sensors={sensors}
         onSortEnd={handleSortEnd}
       />
     </div>


### PR DESCRIPTION
closes EMB-1459

Replace PointerSensor with MouseSensor and add TouchSensor for improved drag-and-drop support.

Context:
- we use PointerSensor everywhere.
- it does not work well with touch devices (scrolling issue, see https://dndkit.com/legacy/api-documentation/sensors/pointer)
- for SDK dnd places this PR replaces PointerSensor with MouseSensor + TouchSensor which is the recommended solution.
- initially i tried to replace it globally for all DND usages, but some non-sdk places were broken (unclear why, i did not went to deep into that), so i did a different approach and just changed some places that are used in SDK and manually tested all of these places.

How to verify:
- CI should pass
- you can enable touch events in Chrome Devtools, then open the main app in the devices emulation mode, then go through places that are shown/used in SDK and check DND there using touch events

Video:


https://github.com/user-attachments/assets/7fa227f0-26b2-403d-98e8-d960d33793b6



