### PR TITLE
[QP] Handle Snowflake tables with UUID columns more gracefully

### DIFF
--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -23,6 +23,7 @@
    [metabase.driver.sql-jdbc.sync.common :as sql-jdbc.sync.common]
    [metabase.driver.sql-jdbc.sync.describe-database :as sql-jdbc.describe-database]
    [metabase.driver.sql-jdbc.sync.describe-table :as sql-jdbc.describe-table]
+   [metabase.driver.sql-jdbc.sync.interface :as sql-jdbc.sync.interface]
    [metabase.driver.sql.query-processor :as sql.qp]
    [metabase.driver.sql.query-processor.util :as sql.qp.u]
    [metabase.driver.sql.util :as sql.u]
@@ -716,6 +717,22 @@
                           ;; for more info.
                           (vec (sql-jdbc.describe-database/db-tables driver (.getMetaData conn) "%" db-name)))}))))))
 
+(defn- fallback-fields-metadata
+  "When JDBC DatabaseMetaData.getColumns() fails (e.g. due to unsupported column types like UUID),
+  fall back to using SELECT * to get field metadata from ResultSetMetaData."
+  [driver ^java.sql.Connection conn table ^String db-name-or-nil]
+  (let [{:keys [schema name]} table
+        [sql & params] (sql-jdbc.sync.interface/fallback-metadata-query driver db-name-or-nil schema name)]
+    (with-open [stmt (sql-jdbc.sync.common/prepare-statement driver conn sql params)
+                rs   (.executeQuery stmt)]
+      (let [rsmeta (.getMetaData rs)]
+        (into #{}
+              (sql-jdbc.describe-table/describe-table-fields-xf driver table)
+              (for [i (range 1 (inc (.getColumnCount rsmeta)))]
+                {:name                       (.getColumnName rsmeta (int i))
+                 :database-type              (.getColumnTypeName rsmeta (int i))
+                 :database-is-auto-increment (.isAutoIncrement rsmeta (int i))}))))))
+
 (defmethod sql-jdbc.sync/describe-table-fields :snowflake
   [driver conn table database]
   ;; The default implementation of [[sql-jdbc.sync/describe-table-fields]] doesn't use both Database Type (`NUMBER`)
@@ -723,8 +740,16 @@
   ;; our own logic.
   (letfn [(fix-base-type [col]
             (assoc col :base-type (database-type->base-type (:database-type col) (:jdbc-type col))))]
-    (mapv fix-base-type
-          ((get-method sql-jdbc.sync/describe-table-fields :sql-jdbc) driver conn table database))))
+    (try
+      (mapv fix-base-type
+            ((get-method sql-jdbc.sync/describe-table-fields :sql-jdbc) driver conn table database))
+      (catch Exception e
+        ;; The Snowflake JDBC driver may throw for unsupported column types (e.g. UUID) during
+        ;; DatabaseMetaData.getColumns() iteration. Fall back to SELECT * metadata which doesn't
+        ;; hit the same code path. See #71595.
+        (log/warnf e "Error reading JDBC metadata for table %s, falling back to SELECT * metadata" (:name table))
+        (mapv fix-base-type
+              (fallback-fields-metadata driver conn table database))))))
 
 (defmethod driver/describe-table :snowflake
   [driver database table]

--- a/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
+++ b/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
@@ -441,6 +441,39 @@
                #_{:clj-kondo/ignore [:deprecated-var]}
                (is (= #{} (driver/describe-table-fks :snowflake (mt/db) dynamic-table)))))))))))
 
+(deftest ^:sequential describe-table-fields-uuid-column-test
+  (mt/test-driver :snowflake
+    (testing "Snowflake tables with UUID columns should sync successfully (#71595)"
+      (let [db-name    (#'driver.snowflake/db-name (mt/db))
+            table-name (str "uuid_test_" (u.random/random-name))]
+        (sql-jdbc.execute/do-with-connection-with-options
+         :snowflake
+         (mt/db)
+         nil
+         (fn [^java.sql.Connection conn]
+           (try
+             (doseq [stmt [(format "CREATE OR REPLACE TABLE \"%s\".\"PUBLIC\".\"%s\" (\"uuid_col\" UUID, \"name\" VARCHAR, \"description\" VARCHAR);"
+                                   db-name table-name)
+                           (format "INSERT INTO \"%s\".\"PUBLIC\".\"%s\" VALUES ('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'test', 'a row');"
+                                   db-name table-name)]]
+               (jdbc/execute! {:connection conn} [stmt] {:transaction? false}))
+             (let [table  {:name table-name :schema "PUBLIC"}
+                   fields (sql-jdbc.sync/describe-table-fields :snowflake conn table db-name)]
+               (testing "All columns including UUID should be synced"
+                 (is (= #{"uuid_col" "name" "description"}
+                        (into #{} (map :name) fields))))
+               (testing "UUID column should have a usable base type"
+                 (let [uuid-field (first (filter #(= "uuid_col" (:name %)) fields))]
+                   (is (some? uuid-field)
+                       "UUID column should exist as a synced field")
+                   (when uuid-field
+                     (is (isa? (:base-type uuid-field) :type/*)
+                         "UUID column should have a valid base type")))))
+             (finally
+               (jdbc/execute! {:connection conn}
+                              [(format "DROP TABLE IF EXISTS \"%s\".\"PUBLIC\".\"%s\";" db-name table-name)]
+                              {:transaction? false})))))))))
+
 (deftest ^:sequential describe-table-test
   (mt/test-driver :snowflake
     (testing "make sure describe-table uses the NAME FROM DETAILS too"


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #71595
Closes QUE2-476.

### Description

An upstream Snowflake JDBC driver issue causes an exception to be thrown
because the UUID column type is not present in an enum.

This adds logic to fall back to the more generic `SELECT *` sync mode if
this error occurs during a sync.

### How to verify

Try to sync a Snowflake table containing a UUID column; see #71595 for an example table and data.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
