### PR TITLE
Between filter for ranges on filters including temporal units

### DIFF
--- a/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/filters-reproductions/filters-reproductions.cy.spec.js
@@ -1566,3 +1566,34 @@ describe("issue QUE-2567 (bis)", () => {
     });
   });
 });
+
+describe("issue 69229", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+    H.createQuestion(
+      {
+        name: "69229",
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: [["count"]],
+          breakout: [
+            ["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }],
+          ],
+        },
+      },
+      {
+        visitQuestion: true,
+      },
+    );
+  });
+  it("should render a date range when filtering a bucketed column (metabase#69229)", () => {
+    H.tableInteractiveBody().findByText("19").click();
+    H.popover().findByText("See this month by week").click();
+    cy.findByTestId("filter-pill").click();
+    H.popover()
+      .findByText("Between")
+      .parent()
+      .should("have.attr", "aria-selected", "true");
+  });
+});

--- a/src/metabase/lib/fe_util.cljc
+++ b/src/metabase/lib/fe_util.cljc
@@ -519,14 +519,14 @@
         date-col-with-bucketing? #(clojure.core/and
                                    (date-col? %)
                                    (lib.util/clause? %)
-                                   (clojure.core/contains? lib.schema.temporal-bucketing/datetime-truncation-units (:temporal-unit (second %))))
+                                   (clojure.core/contains? #{:week :month :quarter :year} (:temporal-unit (second %))))
         result    (fn [op col-ref args]
                     (let [date? (some u.time/matches-date? args)
                           values (mapv u.time/coerce-to-timestamp args)]
                       (when (every? u.time/valid? values)
                         {:operator op, :column (ref->col col-ref), :values values, :with-time? (not date?)})))]
     (lib.util.match/match-lite filter-clause
-      ;; exactly 1 argument, but the column has a temporal bucketing
+      ; exactly 1 argument, but the column has a temporal bucketing
       [(op :guard #{:=}) _ (col-ref :guard date-col-with-bucketing?) & (args :len 1 :guard (every? string? args))]
       (let [unit       (:temporal-unit (second col-ref))
             with-time? (not (u.time/matches-date? (first args)))

--- a/src/metabase/lib/fe_util.cljc
+++ b/src/metabase/lib/fe_util.cljc
@@ -530,9 +530,11 @@
       ;; exactly 1 argument, but the column has a temporal bucketing
       [(op :guard #{:=}) _ (col-ref :guard date-col?) & (args :len 1 :guard (every? string? args))]
       (let [unit (:temporal-unit (second col-ref))
-            start (first args)
-            end (u.time/add start unit 1)]
-        (result :between col-ref [start end]))
+            start (u.time/coerce-to-timestamp (first args))
+            range (u.time/to-range start {:unit unit})]
+        {:operator :between
+         :column (ref->col col-ref)
+         :values range})
 
       (:or
        ;; exactly 1 argument

--- a/src/metabase/lib/fe_util.cljc
+++ b/src/metabase/lib/fe_util.cljc
@@ -516,11 +516,10 @@
    filter-clause :- ::lib.schema.expression/expression]
   (let [ref->col  #(column-metadata-from-ref query stage-number (lib.temporal-bucket/with-temporal-bucket % nil))
         date-col? #(ref-clause-with-type? % [:type/Date :type/DateTime])
-        temporal? #(lib.util/original-isa? % :type/Temporal)
-        with-bucketing? #(clojure.core/and
-                          (temporal? %)
-                          (lib.util/clause? %)
-                          (clojure.core/contains? lib.schema.temporal-bucketing/datetime-truncation-units (:temporal-unit (second %))))
+        date-col-with-bucketing? #(clojure.core/and
+                                   (date-col? %)
+                                   (lib.util/clause? %)
+                                   (clojure.core/contains? lib.schema.temporal-bucketing/datetime-truncation-units (:temporal-unit (second %))))
         result    (fn [op col-ref args]
                     (let [date? (some u.time/matches-date? args)
                           values (mapv u.time/coerce-to-timestamp args)]
@@ -528,13 +527,13 @@
                         {:operator op, :column (ref->col col-ref), :values values, :with-time? (not date?)})))]
     (lib.util.match/match-lite filter-clause
       ;; exactly 1 argument, but the column has a temporal bucketing
-      [(op :guard #{:=}) _ (col-ref :guard date-col?) & (args :len 1 :guard (every? string? args))]
-      (let [unit (:temporal-unit (second col-ref))
-            start (u.time/coerce-to-timestamp (first args))
-            range (u.time/to-range start {:unit unit})]
+      [(op :guard #{:=}) _ (col-ref :guard date-col-with-bucketing?) & (args :len 1 :guard (every? string? args))]
+      (let [unit   (:temporal-unit (second col-ref))
+            start  (u.time/coerce-to-timestamp (first args))
+            values (u.time/to-range start {:unit unit})]
         {:operator :between
-         :column (ref->col col-ref)
-         :values range})
+         :column   (ref->col col-ref)
+         :values   values})
 
       (:or
        ;; exactly 1 argument

--- a/src/metabase/lib/fe_util.cljc
+++ b/src/metabase/lib/fe_util.cljc
@@ -528,12 +528,14 @@
     (lib.util.match/match-lite filter-clause
       ;; exactly 1 argument, but the column has a temporal bucketing
       [(op :guard #{:=}) _ (col-ref :guard date-col-with-bucketing?) & (args :len 1 :guard (every? string? args))]
-      (let [unit   (:temporal-unit (second col-ref))
-            start  (u.time/coerce-to-timestamp (first args))
-            values (u.time/to-range start {:unit unit})]
-        {:operator :between
-         :column   (ref->col col-ref)
-         :values   values})
+      (let [unit       (:temporal-unit (second col-ref))
+            with-time? (not (u.time/matches-date? (first args)))
+            start      (u.time/coerce-to-timestamp (first args))
+            date-range (u.time/to-range start {:unit unit})
+            values     (mapv #(u.time/format-date-for-filter % with-time?) date-range)]
+        (if (= (first values) (second values))
+          (result := col-ref [(first values)])
+          (result :between col-ref values)))
 
       (:or
        ;; exactly 1 argument

--- a/src/metabase/lib/fe_util.cljc
+++ b/src/metabase/lib/fe_util.cljc
@@ -516,12 +516,24 @@
    filter-clause :- ::lib.schema.expression/expression]
   (let [ref->col  #(column-metadata-from-ref query stage-number (lib.temporal-bucket/with-temporal-bucket % nil))
         date-col? #(ref-clause-with-type? % [:type/Date :type/DateTime])
+        temporal? #(lib.util/original-isa? % :type/Temporal)
+        with-bucketing? #(clojure.core/and
+                          (temporal? %)
+                          (lib.util/clause? %)
+                          (clojure.core/contains? lib.schema.temporal-bucketing/datetime-truncation-units (:temporal-unit (second %))))
         result    (fn [op col-ref args]
                     (let [date? (some u.time/matches-date? args)
                           values (mapv u.time/coerce-to-timestamp args)]
                       (when (every? u.time/valid? values)
                         {:operator op, :column (ref->col col-ref), :values values, :with-time? (not date?)})))]
     (lib.util.match/match-lite filter-clause
+      ;; exactly 1 argument, but the column has a temporal bucketing
+      [(op :guard #{:=}) _ (col-ref :guard date-col?) & (args :len 1 :guard (every? string? args))]
+      (let [unit (:temporal-unit (second col-ref))
+            start (first args)
+            end (u.time/add start unit 1)]
+        (result :between col-ref [start end]))
+
       (:or
        ;; exactly 1 argument
        [(op :guard #{:= :> :<}) _ (col-ref :guard date-col?) & (args :len 1 :guard (every? string? args))]

--- a/test/metabase/lib/fe_util_test.cljc
+++ b/test/metabase/lib/fe_util_test.cljc
@@ -657,26 +657,28 @@
   (let [query  (lib.tu/venues-query)
         column (-> (m/filter-vals some? (meta/field-metadata :checkins :date))
                    (assoc :base-type :type/DateTime :effective-type :type/DateTime))]
+    (testing "= with temporal bucketing returns between filter where range is a single day"
+      (let [date        "2024-11-28"
+            bucketed-col (lib/with-temporal-bucket column :day)
+            clause       (lib.filter/= bucketed-col date)
+            result       (lib.fe-util/specific-date-filter-parts query -1 clause)]
+        (is (=? {:operator   :=
+                 :values     [date]
+                 :with-time? false}
+                (format-date-filter-parts result)))))
+
     (testing "= with temporal bucketing returns between filter"
       (doseq [[unit date expected-end]
-              [[:day     "2024-11-28" "2024-11-29"]
-               [:week    "2024-11-25" "2024-12-02"]
-               [:month   "2024-11-01" "2024-12-01"]
-               [:quarter "2024-10-01" "2025-01-01"]
-               [:year    "2024-01-01" "2025-01-01"]]]
+              [[:week    "2024-11-24" "2024-11-30"]
+               [:month   "2024-11-01" "2024-11-30"]
+               [:quarter "2024-10-01" "2024-12-31"]
+               [:year    "2024-01-01" "2024-12-31"]]]
         (testing (str "unit=" unit)
           (let [bucketed-col (lib/with-temporal-bucket column unit)
                 clause       (lib.filter/= bucketed-col date)
                 result       (lib.fe-util/specific-date-filter-parts query -1 clause)]
             (is (=? {:operator   :between
-                     :values     [(u.time/local-date
-                                   (parse-long (subs date 0 4))
-                                   (parse-long (subs date 5 7))
-                                   (parse-long (subs date 8 10)))
-                                  (u.time/local-date
-                                   (parse-long (subs expected-end 0 4))
-                                   (parse-long (subs expected-end 5 7))
-                                   (parse-long (subs expected-end 8 10)))]
+                     :values     [date expected-end]
                      :with-time? false}
                     (format-date-filter-parts result)))))))))
 

--- a/test/metabase/lib/fe_util_test.cljc
+++ b/test/metabase/lib/fe_util_test.cljc
@@ -653,6 +653,33 @@
         (lib.filter/> (meta/field-metadata :venues :price) 10)
         (lib.filter/and (lib.filter/< column "2024-11-28") true)))))
 
+(deftest ^:parallel specific-date-filter-parts-temporal-bucketing-test
+  (let [query  (lib.tu/venues-query)
+        column (-> (m/filter-vals some? (meta/field-metadata :checkins :date))
+                   (assoc :base-type :type/DateTime :effective-type :type/DateTime))]
+    (testing "= with temporal bucketing returns between filter"
+      (doseq [[unit date expected-end]
+              [[:day     "2024-11-28" "2024-11-29"]
+               [:week    "2024-11-25" "2024-12-02"]
+               [:month   "2024-11-01" "2024-12-01"]
+               [:quarter "2024-10-01" "2025-01-01"]
+               [:year    "2024-01-01" "2025-01-01"]]]
+        (testing (str "unit=" unit)
+          (let [bucketed-col (lib/with-temporal-bucket column unit)
+                clause       (lib.filter/= bucketed-col date)
+                result       (lib.fe-util/specific-date-filter-parts query -1 clause)]
+            (is (=? {:operator   :between
+                     :values     [(u.time/local-date
+                                   (parse-long (subs date 0 4))
+                                   (parse-long (subs date 5 7))
+                                   (parse-long (subs date 8 10)))
+                                  (u.time/local-date
+                                   (parse-long (subs expected-end 0 4))
+                                   (parse-long (subs expected-end 5 7))
+                                   (parse-long (subs expected-end 8 10)))]
+                     :with-time? false}
+                    (format-date-filter-parts result)))))))))
+
 (deftest ^:parallel relative-date-filter-parts-test
   (let [query  (lib.tu/venues-query)
         column (m/filter-vals some? (meta/field-metadata :checkins :date))]


### PR DESCRIPTION
Closes #69229


Currently when a specific date filter is targeting a column with a temporal unit we correctly show the range in the filter pill, but the filter picker itself only renders the first date in the range (as in "On this date").

This PR fixes that by rendering the date picker as a "Between" range.

##### Before 

<img width="400" height="636" alt="Screenshot 2026-04-06 at 21 03 12" src="https://github.com/user-attachments/assets/f9c36db7-e625-4d9e-b7ca-fd634c9f5bda" />


##### After
<img width="648" height="560" alt="Screenshot 2026-04-06 at 21 16 33" src="https://github.com/user-attachments/assets/a4b3689a-13a5-4c16-ac45-9ae43e122040" />
