### PR TITLE
bundle: exclude lazy loaded libs from vendor bundle again

### DIFF
--- a/rspack.main.config.js
+++ b/rspack.main.config.js
@@ -226,24 +226,28 @@ const config = {
     splitChunks: {
       cacheGroups: {
         vendors: {
-          test: /[\\/]node_modules[\\/](?!(sql-formatter|jspdf|html2canvas|html2canvas-pro)[\\/])/,
-          chunks: "all",
+          test: /[\\/]node_modules[\\/]/,
+          chunks: "initial",
           name: "vendor",
+          priority: -10,
         },
         sqlFormatter: {
-          test: /[\\/]node_modules[\\/]sql-formatter[\\/]/,
+          test: /[\\/]sql-formatter[\\/]/,
           chunks: "all",
           name: "sql-formatter",
+          priority: 10,
         },
         jspdf: {
-          test: /[\\/]node_modules[\\/]jspdf[\\/]/,
+          test: /[\\/]jspdf[\\/]/,
           chunks: "all",
           name: "jspdf",
+          priority: 10,
         },
         html2canvas: {
-          test: /[\\/]node_modules[\\/](html2canvas|html2canvas-pro)[\\/]/,
+          test: /[\\/](html2canvas|html2canvas-pro)[\\/]/,
           chunks: "all",
           name: "html2canvas",
+          priority: 10,
         },
       },
     },


### PR DESCRIPTION
exclude lazy loaded libs from the bundle. became broken after migration to bun. bun has a bit different file structure, so old regexps didn't match modules

### Before (vendor 5.6Mb)
<img width="402" height="165" alt="Screenshot 2026-04-08 at 19 33 45" src="https://github.com/user-attachments/assets/108c9f15-178d-4d66-a657-91460063a016" />


### After (vendor 4.7Mb)
<img width="409" height="197" alt="Screenshot 2026-04-08 at 19 32 18" src="https://github.com/user-attachments/assets/9f9a6071-4387-4db6-8e3b-fbf0675fe1f9" />
