### PR TITLE
Fix finish part usage format to match what benchmarks expect

### DIFF
--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -271,20 +271,9 @@
                              error (assoc :error (json/encode error)))))))
 
 (defn- format-usage
-  "Convert internal usage map to expected output format.
-
-  The format accumulated in the usage map is `{model {:promptTokens N :completionTokens N}}` but the benchmarks expect
-  per-model entries to have `:prompt` and `:completion` keys, plus a top-level `promptTokens`/`completionTokens` with
-  aggregated totals."
+  "Convert internal usage map to the format expected by benchmarks."
   [usage]
-  (let [per-model (update-vals usage #(set/rename-keys % {:promptTokens :prompt :completionTokens :completion}))
-        totals    (reduce-kv (fn [acc _model {:keys [prompt completion]}]
-                               (-> acc
-                                   (update :promptTokens + prompt)
-                                   (update :completionTokens + completion)))
-                             {:promptTokens 0 :completionTokens 0}
-                             per-model)]
-    (merge per-model totals)))
+  (update-vals usage #(set/rename-keys % {:promptTokens :prompt :completionTokens :completion})))
 
 (defn format-finish-line
   "Format finish part as AI SDK line: d:{\"finishReason\":\"stop\",\"usage\":{...}}"

--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -2,6 +2,7 @@
   (:require
    [clj-http.client :as http]
    [clojure.java.io :as io]
+   [clojure.set :as set]
    [clojure.string :as str]
    [metabase.llm.settings :as llm]
    [metabase.premium-features.core :as premium-features]
@@ -269,10 +270,27 @@
                                     :result     (or output "")}
                              error (assoc :error (json/encode error)))))))
 
+(defn- format-usage
+  "Convert internal usage map to expected output format.
+
+  The format accumulated in the usage map is `{model {:promptTokens N :completionTokens N}}` but the benchmarks expect
+  per-model entries to have `:prompt` and `:completion` keys, plus a top-level `promptTokens`/`completionTokens` with
+  aggregated totals."
+  [usage]
+  (let [per-model (update-vals usage #(set/rename-keys % {:promptTokens :prompt :completionTokens :completion}))
+        totals    (reduce-kv (fn [acc _model {:keys [prompt completion]}]
+                               (-> acc
+                                   (update :promptTokens + prompt)
+                                   (update :completionTokens + completion)))
+                             {:promptTokens 0 :completionTokens 0}
+                             per-model)]
+    (merge per-model totals)))
+
 (defn format-finish-line
   "Format finish part as AI SDK line: d:{\"finishReason\":\"stop\",\"usage\":{...}}"
   [error? usage]
-  (str "d:" (json/encode {:finishReason (if error? "error" "stop") :usage (or usage {})})))
+  (str "d:" (json/encode {:finishReason (if error? "error" "stop")
+                          :usage        (format-usage (or usage {}))})))
 
 (defn format-start-line
   "Format start part as AI SDK line: f:{\"messageId\":...}"
@@ -300,7 +318,7 @@
   ([{:keys [emit-usage?]}]
    (fn [rf]
      (let [error? (volatile! false)
-           usage  (volatile! nil)]
+           usage  (volatile! {})]
        (fn
          ([] (rf))
          ([result]
@@ -320,7 +338,7 @@
             :start       (rf result (format-start-line part))
             :finish      result ;; Don't emit here, we emit in completion arity
             :usage       (do
-                           (vreset! usage (:usage part))
+                           (vswap! usage assoc (:model part) (:usage part))
                            result)
             ;; Pass through unknown types as data
             (rf result (format-data-line part)))))))))

--- a/test/metabase/metabot/self_test.clj
+++ b/test/metabase/metabot/self_test.clj
@@ -453,9 +453,7 @@
     (let [line (self.core/format-finish-line false {"claude-sonnet-4-5-20250929" {:promptTokens 100 :completionTokens 50}})]
       (is (str/starts-with? line "d:"))
       (is (=? {:finishReason "stop"
-               :usage        {:claude-sonnet-4-5-20250929 {:prompt 100 :completion 50}
-                              :promptTokens               100
-                              :completionTokens           50}}
+               :usage        {:claude-sonnet-4-5-20250929 {:prompt 100 :completion 50}}}
               (json/decode+kw (subs line 2)))))))
 
 (deftest format-start-line-test
@@ -492,9 +490,7 @@
                #"0:.*"
                #"d:.*"]
               lines))
-      (is (=? {:usage {:claude-sonnet-4-5-20250929 {:prompt 10 :completion 5}
-                       :promptTokens 10
-                       :completionTokens 5}}
+      (is (=? {:usage {:claude-sonnet-4-5-20250929 {:prompt 10 :completion 5}}}
               (-> (last lines) (subs 2) (json/decode+kw)))))))
 
 ;;; ===================== Retry Logic Tests =====================

--- a/test/metabase/metabot/self_test.clj
+++ b/test/metabase/metabot/self_test.clj
@@ -450,12 +450,13 @@
 
 (deftest format-finish-line-test
   (testing "formats finish message with usage"
-    (let [line (self.core/format-finish-line false {"claude-sonnet-4-5-20250929" {:prompt 100 :completion 50}})]
+    (let [line (self.core/format-finish-line false {"claude-sonnet-4-5-20250929" {:promptTokens 100 :completionTokens 50}})]
       (is (str/starts-with? line "d:"))
-      (let [parsed (json/decode+kw (subs line 2))]
-        (is (= "stop" (:finishReason parsed)))
-        ;; Keys are keywordized when parsing JSON
-        (is (= 100 (get-in parsed [:usage :claude-sonnet-4-5-20250929 :prompt])))))))
+      (is (=? {:finishReason "stop"
+               :usage        {:claude-sonnet-4-5-20250929 {:prompt 100 :completion 50}
+                              :promptTokens               100
+                              :completionTokens           50}}
+              (json/decode+kw (subs line 2)))))))
 
 (deftest format-start-line-test
   (testing "formats start message with messageId"
@@ -491,7 +492,9 @@
                #"0:.*"
                #"d:.*"]
               lines))
-      (is (=? {:usage {:promptTokens 10 :completionTokens 5}}
+      (is (=? {:usage {:claude-sonnet-4-5-20250929 {:prompt 10 :completion 5}
+                       :promptTokens 10
+                       :completionTokens 5}}
               (-> (last lines) (subs 2) (json/decode+kw)))))))
 
 ;;; ===================== Retry Logic Tests =====================


### PR DESCRIPTION
### Description

Fix the issue reported in [#632](https://github.com/metabase/ai-service/pull/632) but on the Clojure side rather than the ai-service benchmarks side.

Update `metabase.metabot.self.core/format-finish-line` to emit `:usage` in the format expected by the benchmarks.

**before:**
` d:{"finishReason":"stop","usage":{"promptTokens":18886,"completionTokens":32}}`
**after:** 
`d:{"finishReason":"stop","usage":{"anthropic/claude-sonnet-4-6":{"prompt":81374,"completion":551}}}`

We only emit `:usage` in [dev mode specifically for benchmarks](https://github.com/metabase/metabase/blob/fix-aisdk-usage-format/src/metabase/metabot/self/core.clj#L294), so originally I thought this was probably just a minor bug in the original Clojure port that the formats didn't quite match, but the [aisdk v4 docs](https://ai-sdk.dev/v4/docs/ai-sdk-ui/stream-protocol#finish-message-part) match what we have in the Clojure port, so debatable whether we should "fix" this on the Clojure side to match the old ai-service format or on the benchmarks side to consume the standard aisdk v4 format.

Note, you also need to update ai-service to include `claude-sonnet-4-6` in [`AvailableModels`](https://github.com/metabase/ai-service/blob/60eeedf1c2d29160285a0246556e4b7267648b87/ai_service/types.py#L33) but given the in-flight changes around benchmarks, holding off on that for now.

### Demo

```
################# Benchmark Results #################
| benchmark   | score      | passing_rate   | hallucination_rate   | hesitation_rate   |   token_usage |   costs |   avg_duration |
|:------------|:-----------|:---------------|:---------------------|:------------------|--------------:|--------:|---------------:|
| SQL Fixing  | 100% (8/8) | 100% (2/2)     | 0% (0/8)             | 0% (0/8)          |         38134 |       0 |            7.5 |

Profile ID: sql
Model: openrouter/anthropic/claude-haiku-4.5
Sample Size: 2 (limited to 2 cases per benchmark)
Seed: 42
Ran at: 2026-04-08T155538
Duration: 12.54 seconds

Total score: 100% (8/8)
Passing Rate[^1]: 100% (2/2)
Action Hallucination Rate[^2]: 0%
Hesitation Rate[^3]: 0%
Total token usage across all tests: 38134
```

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
