### PR TITLE
GDGT-26 Fix discard-setting-changes helper for settings that use init

### DIFF
--- a/test/metabase/settings/models/setting_test.clj
+++ b/test/metabase/settings/models/setting_test.clj
@@ -247,6 +247,17 @@
              #"Cannot initialize setting before the db is set up"
              (setting/get :test-setting-custom-init)))))))
 
+(deftest discard-setting-changes-with-init-test
+  (testing "discard-setting-changes correctly handles settings with :init"
+    (clear-setting-if-leak!)
+    (let [value-inside (atom nil)]
+      (mt/discard-setting-changes [:test-setting-custom-init]
+        (reset! value-inside (test-setting-custom-init))
+        (testing "the setting returns its initialized value inside the macro, not nil"
+          (is (some? @value-inside))))
+      (testing "after the macro, the setting's initialized value is preserved (not re-initialized)"
+        (is (= @value-inside (test-setting-custom-init)))))))
+
 (def ^:private base-options
   {:setter   :none
    :default  "totally-basic"})

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -641,8 +641,8 @@
   ((reduce
     (fn [thunk setting-k]
       (fn []
-        (let [value (setting/read-setting setting-k)]
-          (do-with-temporary-setting-value! setting-k value thunk :skip-init? true))))
+        (let [value (setting/get setting-k)]
+          (do-with-temporary-setting-value! setting-k value thunk))))
     thunk
     settings)))
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/45707

### Description
The issue reported that `discard-setting-changes` is broken for settings that use `:init` (e.g. `query-analysis-native-disabled`). The report predicted that calling the setting getter inside the macro would return `nil`, and that the value would be corrupted afterward.

`do-with-discarded-setting-changes!` used `setting/read-setting` to capture the "original" value before the thunk. `read-setting` binds `*disable-init*` to `true`, so for settings whose value comes from an `:init` function (and which haven't been initialized yet), it returns `nil`. This `nil` is then passed as both:

* (outer capture) The "temporary" value to set during the thunk (via `do-with-temporary-setting-value!`)
* (inner capture) The value to restore in the `finally` block (via the `:skip-init?` flag)

The key fix here is to use `setting/get` instead of `setting/read-setting`. We also remove the `:skip-init?` flag since it was there to match the semantics of `read-setting` and suppress the init call. 

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
