### PR TITLE
Fix admins unable to browse shared collections in question picker

### DIFF
--- a/e2e/test/scenarios/organization/entity-picker-shared-tenant-collection.cy.spec.ts
+++ b/e2e/test/scenarios/organization/entity-picker-shared-tenant-collection.cy.spec.ts
@@ -354,7 +354,31 @@ describe("scenarios > organization > entity picker > shared-tenant-collection na
   });
 
   describe("dashboard edit question picker sidebar", () => {
-    it("should allow admins to browse shared collections with correct breadcrumbs and add questions", () => {
+    it("should not show shared collections when tenants are disabled", () => {
+      setupTenantCollections().then(() => {
+        H.updateSetting("use-tenants", false);
+
+        H.createDashboard({
+          name: "Test Dashboard",
+        }).then(({ body: dashboard }) => {
+          H.visitDashboard(dashboard.id);
+          H.editDashboard();
+          H.openQuestionsSidebar();
+
+          H.sidebar().findByText(TENANT_ROOT_NAME).should("not.exist");
+
+          H.sidebar()
+            .findByTestId("breadcrumbs")
+            .should("contain", "Our analytics");
+
+          H.sidebar()
+            .findByTestId("breadcrumbs")
+            .should("not.contain", "Collections");
+        });
+      });
+    });
+
+    it("should allow admins to browse shared collections via breadcrumbs and add questions", () => {
       setupTenantCollections().then(({ tenantCollectionId }) => {
         H.createQuestion({
           name: "Tenant Orders Question",
@@ -369,18 +393,20 @@ describe("scenarios > organization > entity picker > shared-tenant-collection na
           H.editDashboard();
           H.openQuestionsSidebar();
 
-          // The breadcrumb should show "Collections" as the top level
-          // since shared collections exist
+          cy.log(
+            "breadcrumb should show 'Collections' as the top level as shared collections exist",
+          );
           H.sidebar()
             .findByTestId("breadcrumbs")
             .should("contain", "Collections")
             .and("contain", "Our analytics");
 
-          // Navigate to the top level to see both namespaces
+          cy.log("navigate to the top level to see both namespaces");
           H.sidebar()
             .findByTestId("breadcrumbs")
             .findByText("Collections")
             .click();
+
           H.sidebar().findByText("Our analytics").should("be.visible");
           H.sidebar().findByText(TENANT_ROOT_NAME).should("be.visible");
 
@@ -412,21 +438,23 @@ describe("scenarios > organization > entity picker > shared-tenant-collection na
               H.editDashboard();
               H.openQuestionsSidebar();
 
-              // Navigate to top level first
+              cy.log("navigate to top level");
               H.sidebar()
                 .findByTestId("breadcrumbs")
                 .findByText("Collections")
                 .click();
 
-              // Navigate into Our analytics
+              cy.log("navigate into Our Analytics");
               H.sidebar().findByText("Our analytics").click();
+
               H.sidebar()
                 .findByTestId("breadcrumbs")
                 .should("contain", "Collections")
                 .and("contain", "Our analytics");
 
-              // Navigate into a sub-collection under Our Analytics
+              cy.log("navigate into a sub-collection under our analytics");
               H.sidebar().findByText("Our Analytics Sub").click();
+
               H.sidebar()
                 .findByTestId("breadcrumbs")
                 .should("contain", "Collections")
@@ -434,22 +462,6 @@ describe("scenarios > organization > entity picker > shared-tenant-collection na
                 .and("contain", "Our Analytics Sub");
             },
           );
-        });
-      });
-    });
-
-    it("should not show shared collections when tenants are disabled", () => {
-      setupTenantCollections().then(() => {
-        H.updateSetting("use-tenants", false);
-
-        H.createDashboard({
-          name: "Test Dashboard",
-        }).then(({ body: dashboard }) => {
-          H.visitDashboard(dashboard.id);
-          H.editDashboard();
-          H.openQuestionsSidebar();
-
-          H.sidebar().findByText(TENANT_ROOT_NAME).should("not.exist");
         });
       });
     });

--- a/e2e/test/scenarios/organization/entity-picker-shared-tenant-collection.cy.spec.ts
+++ b/e2e/test/scenarios/organization/entity-picker-shared-tenant-collection.cy.spec.ts
@@ -403,6 +403,41 @@ describe("scenarios > organization > entity picker > shared-tenant-collection na
       });
     });
 
+    it("should show 'Collections' in breadcrumb when navigating into Our Analytics sub-collections", () => {
+      setupTenantCollections().then(() => {
+        H.createCollection({ name: "Our Analytics Sub" }).then(() => {
+          H.createDashboard({ name: "Test Dashboard" }).then(
+            ({ body: dashboard }) => {
+              H.visitDashboard(dashboard.id);
+              H.editDashboard();
+              H.openQuestionsSidebar();
+
+              // Navigate to top level first
+              H.sidebar()
+                .findByTestId("breadcrumbs")
+                .findByText("Collections")
+                .click();
+
+              // Navigate into Our analytics
+              H.sidebar().findByText("Our analytics").click();
+              H.sidebar()
+                .findByTestId("breadcrumbs")
+                .should("contain", "Collections")
+                .and("contain", "Our analytics");
+
+              // Navigate into a sub-collection under Our Analytics
+              H.sidebar().findByText("Our Analytics Sub").click();
+              H.sidebar()
+                .findByTestId("breadcrumbs")
+                .should("contain", "Collections")
+                .and("contain", "Our analytics")
+                .and("contain", "Our Analytics Sub");
+            },
+          );
+        });
+      });
+    });
+
     it("should not show shared collections when tenants are disabled", () => {
       setupTenantCollections().then(() => {
         H.updateSetting("use-tenants", false);

--- a/e2e/test/scenarios/organization/entity-picker-shared-tenant-collection.cy.spec.ts
+++ b/e2e/test/scenarios/organization/entity-picker-shared-tenant-collection.cy.spec.ts
@@ -369,16 +369,31 @@ describe("scenarios > organization > entity picker > shared-tenant-collection na
           H.editDashboard();
           H.openQuestionsSidebar();
 
+          // The breadcrumb should show "Collections" as the top level
+          // since shared collections exist
+          H.sidebar()
+            .findByTestId("breadcrumbs")
+            .should("contain", "Collections")
+            .and("contain", "Our analytics");
+
+          // Navigate to the top level to see both namespaces
+          H.sidebar()
+            .findByTestId("breadcrumbs")
+            .findByText("Collections")
+            .click();
+          H.sidebar().findByText("Our analytics").should("be.visible");
+          H.sidebar().findByText(TENANT_ROOT_NAME).should("be.visible");
+
           H.sidebar().findByText(TENANT_ROOT_NAME).click();
           H.sidebar()
             .findByTestId("breadcrumbs")
-            .should("contain", "Our analytics")
+            .should("contain", "Collections")
             .and("contain", TENANT_ROOT_NAME);
 
           H.sidebar().findByText("Test Tenant Collection").click();
           H.sidebar()
             .findByTestId("breadcrumbs")
-            .should("contain", "Our analytics")
+            .should("contain", "Collections")
             .and("contain", TENANT_ROOT_NAME)
             .and("contain", "Test Tenant Collection");
 

--- a/e2e/test/scenarios/organization/entity-picker-shared-tenant-collection.cy.spec.ts
+++ b/e2e/test/scenarios/organization/entity-picker-shared-tenant-collection.cy.spec.ts
@@ -1,5 +1,8 @@
 const { H } = cy;
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
+
+const { ORDERS_ID } = SAMPLE_DATABASE;
 
 const TENANT_ROOT_NAME = "Shared collections";
 const TENANT_NAMESPACE = "shared-tenant-collection";
@@ -345,6 +348,79 @@ describe("scenarios > organization > entity picker > shared-tenant-collection na
         H.entityPickerModal().within(() => {
           cy.findByText(TENANT_ROOT_NAME).click();
           cy.button(/New dashboard/).should("be.disabled");
+        });
+      });
+    });
+  });
+
+  describe("dashboard edit question picker sidebar", () => {
+    it("should allow admins to browse shared collections and add questions", () => {
+      setupTenantCollections().then(({ tenantCollectionId }) => {
+        H.createQuestion({
+          name: "Tenant Orders Question",
+          collection_id: tenantCollectionId,
+          query: { "source-table": ORDERS_ID },
+        });
+
+        H.createDashboard({
+          name: "Test Dashboard",
+        }).then(({ body: dashboard }) => {
+          H.visitDashboard(dashboard.id);
+          H.editDashboard();
+          H.openQuestionsSidebar();
+
+          H.sidebar().findByText(TENANT_ROOT_NAME).click();
+          H.sidebar().findByText("Test Tenant Collection").click();
+          H.sidebar().findByText("Tenant Orders Question").click();
+
+          H.getDashboardCards().should("have.length", 1);
+        });
+      });
+    });
+
+    it("should show correct breadcrumbs when browsing shared collections", () => {
+      setupTenantCollections().then(({ tenantCollectionId }) => {
+        H.createQuestion({
+          name: "Nested Tenant Question",
+          collection_id: tenantCollectionId,
+          query: { "source-table": ORDERS_ID },
+        });
+
+        H.createDashboard({
+          name: "Test Dashboard",
+        }).then(({ body: dashboard }) => {
+          H.visitDashboard(dashboard.id);
+          H.editDashboard();
+          H.openQuestionsSidebar();
+
+          H.sidebar().findByText(TENANT_ROOT_NAME).click();
+          H.sidebar()
+            .findByTestId("breadcrumbs")
+            .should("contain", "Our analytics")
+            .and("contain", TENANT_ROOT_NAME);
+
+          H.sidebar().findByText("Test Tenant Collection").click();
+          H.sidebar()
+            .findByTestId("breadcrumbs")
+            .should("contain", "Our analytics")
+            .and("contain", TENANT_ROOT_NAME)
+            .and("contain", "Test Tenant Collection");
+        });
+      });
+    });
+
+    it("should not show shared collections when tenants are disabled", () => {
+      setupTenantCollections().then(() => {
+        H.updateSetting("use-tenants", false);
+
+        H.createDashboard({
+          name: "Test Dashboard",
+        }).then(({ body: dashboard }) => {
+          H.visitDashboard(dashboard.id);
+          H.editDashboard();
+          H.openQuestionsSidebar();
+
+          H.sidebar().findByText(TENANT_ROOT_NAME).should("not.exist");
         });
       });
     });

--- a/e2e/test/scenarios/organization/entity-picker-shared-tenant-collection.cy.spec.ts
+++ b/e2e/test/scenarios/organization/entity-picker-shared-tenant-collection.cy.spec.ts
@@ -354,34 +354,10 @@ describe("scenarios > organization > entity picker > shared-tenant-collection na
   });
 
   describe("dashboard edit question picker sidebar", () => {
-    it("should allow admins to browse shared collections and add questions", () => {
+    it("should allow admins to browse shared collections with correct breadcrumbs and add questions", () => {
       setupTenantCollections().then(({ tenantCollectionId }) => {
         H.createQuestion({
           name: "Tenant Orders Question",
-          collection_id: tenantCollectionId,
-          query: { "source-table": ORDERS_ID },
-        });
-
-        H.createDashboard({
-          name: "Test Dashboard",
-        }).then(({ body: dashboard }) => {
-          H.visitDashboard(dashboard.id);
-          H.editDashboard();
-          H.openQuestionsSidebar();
-
-          H.sidebar().findByText(TENANT_ROOT_NAME).click();
-          H.sidebar().findByText("Test Tenant Collection").click();
-          H.sidebar().findByText("Tenant Orders Question").click();
-
-          H.getDashboardCards().should("have.length", 1);
-        });
-      });
-    });
-
-    it("should show correct breadcrumbs when browsing shared collections", () => {
-      setupTenantCollections().then(({ tenantCollectionId }) => {
-        H.createQuestion({
-          name: "Nested Tenant Question",
           collection_id: tenantCollectionId,
           query: { "source-table": ORDERS_ID },
         });
@@ -405,6 +381,9 @@ describe("scenarios > organization > entity picker > shared-tenant-collection na
             .should("contain", "Our analytics")
             .and("contain", TENANT_ROOT_NAME)
             .and("contain", "Test Tenant Collection");
+
+          H.sidebar().findByText("Tenant Orders Question").click();
+          H.getDashboardCards().should("have.length", 1);
         });
       });
     });

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/QuestionPicker.tsx
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/QuestionPicker.tsx
@@ -27,6 +27,10 @@ import type { Collection, CollectionId } from "metabase-types/api";
 import { QuestionList } from "./QuestionList";
 import S from "./QuestionPicker.module.css";
 import { addDashboardQuestion } from "./actions";
+import {
+  SHARED_TENANT_COLLECTIONS_ROOT_ID,
+  useCollectionsWithTenants,
+} from "./hooks/use-collections-with-tenants";
 
 interface QuestionPickerInnerProps {
   onSelect: BaseSelectListItemProps["onSelect"];
@@ -35,7 +39,7 @@ interface QuestionPickerInnerProps {
 
 function QuestionPickerInner({
   onSelect,
-  collectionsById,
+  collectionsById: baseCollectionsById,
 }: QuestionPickerInnerProps) {
   const dispatch = useDispatch();
   const dashboard = useSelector(getDashboard);
@@ -49,6 +53,10 @@ function QuestionPickerInner({
     SEARCH_DEBOUNCE_DURATION,
   );
 
+  const collectionsById = useCollectionsWithTenants(baseCollectionsById);
+
+  const isAtSharedTenantRoot =
+    currentCollectionId === SHARED_TENANT_COLLECTIONS_ROOT_ID;
   const collection = collectionsById[currentCollectionId];
   const crumbs = getCollectionBreadCrumbs(
     collection,
@@ -143,13 +151,15 @@ function QuestionPickerInner({
         </>
       )}
 
-      <QuestionList
-        hasCollections={collections.length > 0}
-        searchText={debouncedSearchText}
-        collectionId={currentCollectionId}
-        onSelect={onSelect}
-        showOnlyPublicCollections={showOnlyPublicCollections}
-      />
+      {(!isAtSharedTenantRoot || debouncedSearchText) && (
+        <QuestionList
+          hasCollections={collections.length > 0}
+          searchText={debouncedSearchText}
+          collectionId={currentCollectionId}
+          onSelect={onSelect}
+          showOnlyPublicCollections={showOnlyPublicCollections}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/QuestionPicker.tsx
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/QuestionPicker.tsx
@@ -28,6 +28,7 @@ import { QuestionList } from "./QuestionList";
 import S from "./QuestionPicker.module.css";
 import { addDashboardQuestion } from "./actions";
 import {
+  COLLECTIONS_TOP_LEVEL_ID,
   SHARED_TENANT_COLLECTIONS_ROOT_ID,
   useCollectionsWithTenants,
 } from "./hooks/use-collections-with-tenants";
@@ -55,6 +56,7 @@ function QuestionPickerInner({
 
   const collectionsById = useCollectionsWithTenants(baseCollectionsById);
 
+  const isAtTopLevel = currentCollectionId === COLLECTIONS_TOP_LEVEL_ID;
   const isAtSharedTenantRoot =
     currentCollectionId === SHARED_TENANT_COLLECTIONS_ROOT_ID;
   const collection = collectionsById[currentCollectionId];
@@ -151,7 +153,7 @@ function QuestionPickerInner({
         </>
       )}
 
-      {(!isAtSharedTenantRoot || debouncedSearchText) && (
+      {((!isAtSharedTenantRoot && !isAtTopLevel) || debouncedSearchText) && (
         <QuestionList
           hasCollections={collections.length > 0}
           searchText={debouncedSearchText}

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/QuestionPicker.tsx
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/QuestionPicker.tsx
@@ -153,6 +153,9 @@ function QuestionPickerInner({
         </>
       )}
 
+      {/* Hide the question list at top-level "Collections"
+          and "Shared collections" root. These have fake IDs that don't map to
+          real collections, so querying questions against them would fail. */}
       {((!isAtSharedTenantRoot && !isAtTopLevel) || debouncedSearchText) && (
         <QuestionList
           hasCollections={collections.length > 0}

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.ts
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.ts
@@ -160,6 +160,26 @@ export function mergeSharedCollections(
     } as ExpandedCollectionNode;
   }
 
+  // Rewrite paths for all base collections (children of Our Analytics / root)
+  // so that "Collections" appears at the top of the breadcrumb when navigating
+  // into sub-collections under Our Analytics.
+  for (const [id, collection] of Object.entries(baseCollectionsById)) {
+    if (id === String(ROOT_COLLECTION.id)) {
+      continue; // already rewritten above
+    }
+
+    const col = collection as ExpandedCollectionNode;
+    if (!col.path) {
+      continue;
+    }
+
+    mergedCollectionsById[id as CollectionId] = {
+      ...col,
+      // Rewrite path: Collections > Our Analytics > ...
+      path: [COLLECTIONS_TOP_LEVEL_ID, ...col.path],
+    } as ExpandedCollectionNode;
+  }
+
   mergedCollectionsById[SHARED_TENANT_COLLECTIONS_ROOT_ID] =
     sharedSyntheticRoot;
   mergedCollectionsById[COLLECTIONS_TOP_LEVEL_ID] = topLevel;

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.ts
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.ts
@@ -165,9 +165,9 @@ export function mergeSharedCollections(
           ]
         : null,
 
-      // The shared namespace tree also uses ROOT_COLLECTION.id as its root,
-      // so top-level tenant collections appear as children of "root" in
-      // sharedCollectionsById. Re-parent them to sharedSyntheticRoot instead.
+      // This loop only processes sharedCollectionsById (tenant collections),
+      // never baseCollectionsById (Our Analytics collections), so there is no risk
+      // of re-parenting "Our Analytics" sub-collections here.
       parent:
         collection.parent?.id === ROOT_COLLECTION.id
           ? sharedSyntheticRoot

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.ts
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.ts
@@ -165,6 +165,9 @@ export function mergeSharedCollections(
           ]
         : null,
 
+      // The shared namespace tree also uses ROOT_COLLECTION.id as its root,
+      // so top-level tenant collections appear as children of "root" in
+      // sharedCollectionsById. Re-parent them to sharedSyntheticRoot instead.
       parent:
         collection.parent?.id === ROOT_COLLECTION.id
           ? sharedSyntheticRoot

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.ts
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.ts
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { t } from "ttag";
 
 import { skipToken, useListCollectionsTreeQuery } from "metabase/api";
 import { useSetting } from "metabase/common/hooks/use-setting";
@@ -21,9 +22,18 @@ export type ExpandedCollectionNode = Collection & {
 export const SHARED_TENANT_COLLECTIONS_ROOT_ID =
   "shared-tenant-collections-root" as CollectionId;
 
+export const COLLECTIONS_TOP_LEVEL_ID = "collections-top-level" as CollectionId;
+
 /**
  * When tenants are enabled, fetches shared tenant collections and merges them
  * into the collectionsById map so they appear as a top-level browsable entry.
+ *
+ * The tree structure becomes:
+ *   Collections (top level)
+ *   ├── Our analytics (root collection)
+ *   └── Shared collections (synthetic root for shared collections)
+ *       ├── Shared collection A
+ *       └── Shared collection B
  */
 export function useCollectionsWithTenants(
   collectionsById: Record<CollectionId, Collection>,
@@ -71,7 +81,8 @@ export function useCollectionsWithTenants(
 
 /**
  * Merge shared tenant collections into the base collections map,
- * inserting a synthetic "Shared collections" root under Our analytics.
+ * creating a top-level "Collections" node that contains both
+ * "Our analytics" and "Shared collections" as siblings.
  */
 export function mergeSharedCollections(
   baseCollectionsById: Record<CollectionId, Collection>,
@@ -79,27 +90,52 @@ export function mergeSharedCollections(
   displayName: string,
 ): Record<CollectionId, Collection> {
   const sharedRoot = sharedCollectionsById[ROOT_COLLECTION.id];
+  const rootCollection = baseCollectionsById[
+    ROOT_COLLECTION.id
+  ] as ExpandedCollectionNode;
 
-  const syntheticRoot: ExpandedCollectionNode = {
+  // Create the top-level "Collections" node that parents both namespaces
+  const topLevel = {
+    ...rootCollection,
+    id: COLLECTIONS_TOP_LEVEL_ID,
+    name: t`Collections`,
+    path: [],
+    parent: null,
+    children: [],
+  } as ExpandedCollectionNode;
+
+  // Create the shared collections synthetic root as a sibling of Our analytics
+  const sharedSyntheticRoot: ExpandedCollectionNode = {
     ...sharedRoot,
     id: SHARED_TENANT_COLLECTIONS_ROOT_ID,
     name: displayName,
-    path: [ROOT_COLLECTION.id],
-    parent: baseCollectionsById[ROOT_COLLECTION.id] as ExpandedCollectionNode,
+    path: [COLLECTIONS_TOP_LEVEL_ID],
+    parent: topLevel,
     children: (sharedRoot?.children ?? []).map((child) => ({
       ...child,
       parent: null,
     })) as ExpandedCollectionNode[],
   };
 
-  // Fix circular parent reference now that syntheticRoot exists
-  syntheticRoot.children = syntheticRoot.children.map((child) => ({
+  // Fix circular parent reference now that sharedSyntheticRoot exists
+  sharedSyntheticRoot.children = sharedSyntheticRoot.children.map((child) => ({
     ...child,
-    parent: syntheticRoot,
+    parent: sharedSyntheticRoot,
   })) as ExpandedCollectionNode[];
+
+  // Wire up the top-level children
+  topLevel.children = [rootCollection, sharedSyntheticRoot];
 
   const mergedCollectionsById = { ...baseCollectionsById };
 
+  // Rewrite root collection to point to top-level parent
+  mergedCollectionsById[ROOT_COLLECTION.id] = {
+    ...rootCollection,
+    path: [COLLECTIONS_TOP_LEVEL_ID],
+    parent: topLevel,
+  } as ExpandedCollectionNode;
+
+  // Merge shared collections with rewritten paths
   for (const [id, collection] of Object.entries(sharedCollectionsById)) {
     if (id === String(ROOT_COLLECTION.id)) {
       continue;
@@ -108,10 +144,10 @@ export function mergeSharedCollections(
     mergedCollectionsById[id as CollectionId] = {
       ...collection,
 
-      // Rewrite path so breadcrumbs show "Our analytics > Shared collections > ..."
+      // Rewrite path: Collections > Shared collections > ...
       path: collection.path
         ? [
-            ROOT_COLLECTION.id,
+            COLLECTIONS_TOP_LEVEL_ID,
             SHARED_TENANT_COLLECTIONS_ROOT_ID,
             ...collection.path.filter((s) => s !== ROOT_COLLECTION.id),
           ]
@@ -119,24 +155,14 @@ export function mergeSharedCollections(
 
       parent:
         collection.parent?.id === ROOT_COLLECTION.id
-          ? syntheticRoot
+          ? sharedSyntheticRoot
           : collection.parent,
     } as ExpandedCollectionNode;
   }
 
-  mergedCollectionsById[SHARED_TENANT_COLLECTIONS_ROOT_ID] = syntheticRoot;
-
-  // Append synthetic root to Our analytics children
-  const rootCollection = mergedCollectionsById[ROOT_COLLECTION.id];
-
-  if (rootCollection) {
-    const children = rootCollection.children ?? [];
-
-    mergedCollectionsById[ROOT_COLLECTION.id] = {
-      ...rootCollection,
-      children: [...children, syntheticRoot],
-    } as ExpandedCollectionNode;
-  }
+  mergedCollectionsById[SHARED_TENANT_COLLECTIONS_ROOT_ID] =
+    sharedSyntheticRoot;
+  mergedCollectionsById[COLLECTIONS_TOP_LEVEL_ID] = topLevel;
 
   return mergedCollectionsById;
 }

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.ts
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.ts
@@ -1,0 +1,111 @@
+import { useMemo } from "react";
+
+import { skipToken, useListCollectionsTreeQuery } from "metabase/api";
+import { useSetting } from "metabase/common/hooks/use-setting";
+import { ROOT_COLLECTION } from "metabase/entities/collections";
+import getExpandedCollectionsById from "metabase/entities/collections/getExpandedCollectionsById";
+import { useSelector } from "metabase/lib/redux";
+import { PLUGIN_TENANTS } from "metabase/plugins";
+import { getUserPersonalCollectionId } from "metabase/selectors/user";
+import type { Collection, CollectionId } from "metabase-types/api";
+
+export const SHARED_TENANT_COLLECTIONS_ROOT_ID =
+  "shared-tenant-collections-root" as CollectionId;
+
+/**
+ * When tenants are enabled, fetches shared tenant collections and merges them
+ * into the collectionsById map so they appear as a top-level browsable entry.
+ */
+export function useCollectionsWithTenants(
+  baseCollectionsById: Record<CollectionId, Collection>,
+): Record<CollectionId, Collection> {
+  const useTenants = useSetting("use-tenants");
+  const userPersonalCollectionId = useSelector(getUserPersonalCollectionId);
+
+  const isTenantsActive = useTenants && PLUGIN_TENANTS.isEnabled;
+
+  const { data: sharedTenantCollections } = useListCollectionsTreeQuery(
+    isTenantsActive
+      ? {
+          namespace: PLUGIN_TENANTS.SHARED_TENANT_NAMESPACE ?? undefined,
+          "exclude-archived": true,
+        }
+      : skipToken,
+  );
+
+  return useMemo(() => {
+    if (!isTenantsActive || !sharedTenantCollections?.length) {
+      return baseCollectionsById;
+    }
+
+    const sharedCollectionsById: Record<CollectionId, any> =
+      getExpandedCollectionsById(
+        sharedTenantCollections,
+        userPersonalCollectionId,
+      );
+
+    const sharedRoot = sharedCollectionsById[ROOT_COLLECTION.id];
+
+    const syntheticSharedRoot = {
+      ...sharedRoot,
+      id: SHARED_TENANT_COLLECTIONS_ROOT_ID,
+      name: PLUGIN_TENANTS.getNamespaceDisplayName(
+        PLUGIN_TENANTS.SHARED_TENANT_NAMESPACE,
+      ),
+      path: [ROOT_COLLECTION.id],
+      parent: baseCollectionsById[ROOT_COLLECTION.id],
+      children: sharedRoot?.children ?? [],
+    };
+
+    // Re-parent children so their parent points to the synthetic root
+    for (const child of syntheticSharedRoot.children) {
+      child.parent = syntheticSharedRoot;
+    }
+
+    // Also merge all shared collections into the map for navigation
+    const merged: Record<CollectionId, any> = { ...baseCollectionsById };
+    for (const [id, col] of Object.entries(sharedCollectionsById)) {
+      if (id !== String(ROOT_COLLECTION.id)) {
+        // Rewrite path: replace "root" prefix with "root" > synthetic shared root
+        // so breadcrumbs show "Our analytics > Shared collections > ..."
+        const fixedPath = col.path
+          ? [
+              ROOT_COLLECTION.id,
+              SHARED_TENANT_COLLECTIONS_ROOT_ID,
+              ...col.path.filter(
+                (segment: CollectionId) => segment !== ROOT_COLLECTION.id,
+              ),
+            ]
+          : null;
+
+        merged[id as CollectionId] = {
+          ...col,
+          path: fixedPath,
+          // Fix parent references: if parent was the shared root, point to synthetic root
+          parent:
+            col.parent?.id === ROOT_COLLECTION.id
+              ? syntheticSharedRoot
+              : col.parent,
+        };
+      }
+    }
+
+    merged[SHARED_TENANT_COLLECTIONS_ROOT_ID] = syntheticSharedRoot;
+
+    // Add shared collections entry to root's children
+    const rootCollection = merged[ROOT_COLLECTION.id];
+    if (rootCollection) {
+      merged[ROOT_COLLECTION.id] = {
+        ...rootCollection,
+        children: [...(rootCollection.children ?? []), syntheticSharedRoot],
+      };
+    }
+
+    return merged;
+  }, [
+    isTenantsActive,
+    sharedTenantCollections,
+    baseCollectionsById,
+    userPersonalCollectionId,
+  ]);
+}

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.ts
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.ts
@@ -168,20 +168,22 @@ export function mergeSharedCollections(
       continue; // already rewritten above
     }
 
-    const col = collection as ExpandedCollectionNode;
-    if (!col.path) {
+    const collectionNode = collection as ExpandedCollectionNode;
+
+    if (!collectionNode.path) {
       continue;
     }
 
     mergedCollectionsById[id as CollectionId] = {
-      ...col,
+      ...collectionNode,
       // Rewrite path: Collections > Our Analytics > ...
-      path: [COLLECTIONS_TOP_LEVEL_ID, ...col.path],
+      path: [COLLECTIONS_TOP_LEVEL_ID, ...collectionNode.path],
     } as ExpandedCollectionNode;
   }
 
   mergedCollectionsById[SHARED_TENANT_COLLECTIONS_ROOT_ID] =
     sharedSyntheticRoot;
+
   mergedCollectionsById[COLLECTIONS_TOP_LEVEL_ID] = topLevel;
 
   return mergedCollectionsById;

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.ts
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.ts
@@ -5,9 +5,9 @@ import { skipToken, useListCollectionsTreeQuery } from "metabase/api";
 import { useSetting } from "metabase/common/hooks/use-setting";
 import { ROOT_COLLECTION } from "metabase/entities/collections";
 import getExpandedCollectionsById from "metabase/entities/collections/getExpandedCollectionsById";
-import { useSelector } from "metabase/lib/redux";
 import { PLUGIN_TENANTS } from "metabase/plugins";
 import { getUserPersonalCollectionId } from "metabase/selectors/user";
+import { useSelector } from "metabase/utils/redux";
 import type { Collection, CollectionId } from "metabase-types/api";
 
 // getExpandedCollectionsById produces path as CollectionId[] at runtime,

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.ts
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.ts
@@ -9,6 +9,15 @@ import { PLUGIN_TENANTS } from "metabase/plugins";
 import { getUserPersonalCollectionId } from "metabase/selectors/user";
 import type { Collection, CollectionId } from "metabase-types/api";
 
+// getExpandedCollectionsById produces path as CollectionId[] at runtime,
+// but ExpandedCollection types it as string, so we use a corrected type.
+export type ExpandedCollectionNode = Collection & {
+  path: CollectionId[] | null;
+  parent: Collection | null;
+  children: Collection[];
+  is_personal?: boolean;
+};
+
 export const SHARED_TENANT_COLLECTIONS_ROOT_ID =
   "shared-tenant-collections-root" as CollectionId;
 
@@ -17,11 +26,10 @@ export const SHARED_TENANT_COLLECTIONS_ROOT_ID =
  * into the collectionsById map so they appear as a top-level browsable entry.
  */
 export function useCollectionsWithTenants(
-  baseCollectionsById: Record<CollectionId, Collection>,
+  collectionsById: Record<CollectionId, Collection>,
 ): Record<CollectionId, Collection> {
   const useTenants = useSetting("use-tenants");
   const userPersonalCollectionId = useSelector(getUserPersonalCollectionId);
-
   const isTenantsActive = useTenants && PLUGIN_TENANTS.isEnabled;
 
   const { data: sharedTenantCollections } = useListCollectionsTreeQuery(
@@ -35,80 +43,100 @@ export function useCollectionsWithTenants(
 
   return useMemo(() => {
     if (!isTenantsActive || !sharedTenantCollections?.length) {
-      return baseCollectionsById;
+      return collectionsById;
     }
 
-    const sharedCollectionsById: Record<CollectionId, any> =
-      getExpandedCollectionsById(
-        sharedTenantCollections,
-        userPersonalCollectionId,
-      );
+    const sharedCollectionsById = getExpandedCollectionsById(
+      sharedTenantCollections,
+      userPersonalCollectionId,
+    ) as Record<CollectionId, ExpandedCollectionNode>;
 
-    const sharedRoot = sharedCollectionsById[ROOT_COLLECTION.id];
-
-    const syntheticSharedRoot = {
-      ...sharedRoot,
-      id: SHARED_TENANT_COLLECTIONS_ROOT_ID,
-      name: PLUGIN_TENANTS.getNamespaceDisplayName(
+    const displayName =
+      PLUGIN_TENANTS.getNamespaceDisplayName(
         PLUGIN_TENANTS.SHARED_TENANT_NAMESPACE,
-      ),
-      path: [ROOT_COLLECTION.id],
-      parent: baseCollectionsById[ROOT_COLLECTION.id],
-      children: [],
-    };
+      ) ?? "";
 
-    // Re-parent children immutably so their parent points to the synthetic root
-    syntheticSharedRoot.children = (sharedRoot?.children ?? []).map(
-      (child: any) => ({
-        ...child,
-        parent: syntheticSharedRoot,
-      }),
+    return mergeSharedCollections(
+      collectionsById,
+      sharedCollectionsById,
+      displayName,
     );
-
-    // Also merge all shared collections into the map for navigation
-    const merged: Record<CollectionId, any> = { ...baseCollectionsById };
-    for (const [id, col] of Object.entries(sharedCollectionsById)) {
-      if (id !== String(ROOT_COLLECTION.id)) {
-        // Rewrite path: replace "root" prefix with "root" > synthetic shared root
-        // so breadcrumbs show "Our analytics > Shared collections > ..."
-        const fixedPath = col.path
-          ? [
-              ROOT_COLLECTION.id,
-              SHARED_TENANT_COLLECTIONS_ROOT_ID,
-              ...col.path.filter(
-                (segment: CollectionId) => segment !== ROOT_COLLECTION.id,
-              ),
-            ]
-          : null;
-
-        merged[id as CollectionId] = {
-          ...col,
-          path: fixedPath,
-          // Fix parent references: if parent was the shared root, point to synthetic root
-          parent:
-            col.parent?.id === ROOT_COLLECTION.id
-              ? syntheticSharedRoot
-              : col.parent,
-        };
-      }
-    }
-
-    merged[SHARED_TENANT_COLLECTIONS_ROOT_ID] = syntheticSharedRoot;
-
-    // Add shared collections entry to root's children
-    const rootCollection = merged[ROOT_COLLECTION.id];
-    if (rootCollection) {
-      merged[ROOT_COLLECTION.id] = {
-        ...rootCollection,
-        children: [...(rootCollection.children ?? []), syntheticSharedRoot],
-      };
-    }
-
-    return merged;
   }, [
     isTenantsActive,
     sharedTenantCollections,
-    baseCollectionsById,
+    collectionsById,
     userPersonalCollectionId,
   ]);
+}
+
+/**
+ * Merge shared tenant collections into the base collections map,
+ * inserting a synthetic "Shared collections" root under Our analytics.
+ */
+export function mergeSharedCollections(
+  baseCollectionsById: Record<CollectionId, Collection>,
+  sharedCollectionsById: Record<CollectionId, ExpandedCollectionNode>,
+  displayName: string,
+): Record<CollectionId, Collection> {
+  const sharedRoot = sharedCollectionsById[ROOT_COLLECTION.id];
+
+  const syntheticRoot: ExpandedCollectionNode = {
+    ...sharedRoot,
+    id: SHARED_TENANT_COLLECTIONS_ROOT_ID,
+    name: displayName,
+    path: [ROOT_COLLECTION.id],
+    parent: baseCollectionsById[ROOT_COLLECTION.id] as ExpandedCollectionNode,
+    children: (sharedRoot?.children ?? []).map((child) => ({
+      ...child,
+      parent: null,
+    })) as ExpandedCollectionNode[],
+  };
+
+  // Fix circular parent reference now that syntheticRoot exists
+  syntheticRoot.children = syntheticRoot.children.map((child) => ({
+    ...child,
+    parent: syntheticRoot,
+  })) as ExpandedCollectionNode[];
+
+  const mergedCollectionsById = { ...baseCollectionsById };
+
+  for (const [id, collection] of Object.entries(sharedCollectionsById)) {
+    if (id === String(ROOT_COLLECTION.id)) {
+      continue;
+    }
+
+    mergedCollectionsById[id as CollectionId] = {
+      ...collection,
+
+      // Rewrite path so breadcrumbs show "Our analytics > Shared collections > ..."
+      path: collection.path
+        ? [
+            ROOT_COLLECTION.id,
+            SHARED_TENANT_COLLECTIONS_ROOT_ID,
+            ...collection.path.filter((s) => s !== ROOT_COLLECTION.id),
+          ]
+        : null,
+
+      parent:
+        collection.parent?.id === ROOT_COLLECTION.id
+          ? syntheticRoot
+          : collection.parent,
+    } as ExpandedCollectionNode;
+  }
+
+  mergedCollectionsById[SHARED_TENANT_COLLECTIONS_ROOT_ID] = syntheticRoot;
+
+  // Append synthetic root to Our analytics children
+  const rootCollection = mergedCollectionsById[ROOT_COLLECTION.id];
+
+  if (rootCollection) {
+    const children = rootCollection.children ?? [];
+
+    mergedCollectionsById[ROOT_COLLECTION.id] = {
+      ...rootCollection,
+      children: [...children, syntheticRoot],
+    } as ExpandedCollectionNode;
+  }
+
+  return mergedCollectionsById;
 }

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.ts
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.ts
@@ -159,7 +159,9 @@ export function mergeSharedCollections(
         ? [
             COLLECTIONS_TOP_LEVEL_ID,
             SHARED_TENANT_COLLECTIONS_ROOT_ID,
-            ...collection.path.filter((s) => s !== ROOT_COLLECTION.id),
+            ...collection.path.filter(
+              (pathId) => pathId !== ROOT_COLLECTION.id,
+            ),
           ]
         : null,
 

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.ts
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.ts
@@ -54,13 +54,16 @@ export function useCollectionsWithTenants(
       ),
       path: [ROOT_COLLECTION.id],
       parent: baseCollectionsById[ROOT_COLLECTION.id],
-      children: sharedRoot?.children ?? [],
+      children: [],
     };
 
-    // Re-parent children so their parent points to the synthetic root
-    for (const child of syntheticSharedRoot.children) {
-      child.parent = syntheticSharedRoot;
-    }
+    // Re-parent children immutably so their parent points to the synthetic root
+    syntheticSharedRoot.children = (sharedRoot?.children ?? []).map(
+      (child: any) => ({
+        ...child,
+        parent: syntheticSharedRoot,
+      }),
+    );
 
     // Also merge all shared collections into the map for navigation
     const merged: Record<CollectionId, any> = { ...baseCollectionsById };

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.ts
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.ts
@@ -45,7 +45,7 @@ export function useCollectionsWithTenants(
   const { data: sharedTenantCollections } = useListCollectionsTreeQuery(
     isTenantsActive
       ? {
-          namespace: PLUGIN_TENANTS.SHARED_TENANT_NAMESPACE ?? undefined,
+          namespace: PLUGIN_TENANTS.SHARED_TENANT_NAMESPACE,
           "exclude-archived": true,
         }
       : skipToken,
@@ -95,22 +95,32 @@ export function mergeSharedCollections(
   ] as ExpandedCollectionNode;
 
   // Create the top-level "Collections" node that parents both namespaces
-  const topLevel = {
-    ...rootCollection,
+  const syntheticTopLevel: ExpandedCollectionNode = {
     id: COLLECTIONS_TOP_LEVEL_ID,
     name: t`Collections`,
+    description: null,
+    can_write: false,
+    can_restore: false,
+    can_delete: false,
+    namespace: null,
+    location: null,
     path: [],
     parent: null,
     children: [],
-  } as ExpandedCollectionNode;
+  };
 
   // Create the shared collections synthetic root as a sibling of Our analytics
   const sharedSyntheticRoot: ExpandedCollectionNode = {
-    ...sharedRoot,
     id: SHARED_TENANT_COLLECTIONS_ROOT_ID,
     name: displayName,
+    description: null,
+    can_write: false,
+    can_restore: false,
+    can_delete: false,
+    namespace: PLUGIN_TENANTS.SHARED_TENANT_NAMESPACE,
+    location: null,
     path: [COLLECTIONS_TOP_LEVEL_ID],
-    parent: topLevel,
+    parent: syntheticTopLevel,
     children: (sharedRoot?.children ?? []).map((child) => ({
       ...child,
       parent: null,
@@ -124,7 +134,7 @@ export function mergeSharedCollections(
   })) as ExpandedCollectionNode[];
 
   // Wire up the top-level children
-  topLevel.children = [rootCollection, sharedSyntheticRoot];
+  syntheticTopLevel.children = [rootCollection, sharedSyntheticRoot];
 
   const mergedCollectionsById = { ...baseCollectionsById };
 
@@ -132,7 +142,7 @@ export function mergeSharedCollections(
   mergedCollectionsById[ROOT_COLLECTION.id] = {
     ...rootCollection,
     path: [COLLECTIONS_TOP_LEVEL_ID],
-    parent: topLevel,
+    parent: syntheticTopLevel,
   } as ExpandedCollectionNode;
 
   // Merge shared collections with rewritten paths
@@ -184,7 +194,7 @@ export function mergeSharedCollections(
   mergedCollectionsById[SHARED_TENANT_COLLECTIONS_ROOT_ID] =
     sharedSyntheticRoot;
 
-  mergedCollectionsById[COLLECTIONS_TOP_LEVEL_ID] = topLevel;
+  mergedCollectionsById[COLLECTIONS_TOP_LEVEL_ID] = syntheticTopLevel;
 
   return mergedCollectionsById;
 }

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.unit.spec.ts
@@ -3,6 +3,7 @@ import type { Collection, CollectionId } from "metabase-types/api";
 import { createMockCollection } from "metabase-types/api/mocks";
 
 import {
+  COLLECTIONS_TOP_LEVEL_ID,
   SHARED_TENANT_COLLECTIONS_ROOT_ID,
   mergeSharedCollections,
 } from "./use-collections-with-tenants";
@@ -67,33 +68,40 @@ function setup() {
 }
 
 describe("mergeSharedCollections", () => {
-  it("should insert a synthetic shared root under Our analytics", () => {
+  it("should create a top-level Collections node with Our analytics and Shared collections as siblings", () => {
     const result = setup() as any;
+
+    const topLevel = result[COLLECTIONS_TOP_LEVEL_ID];
+    expect(topLevel.name).toBe("Collections");
+    expect(topLevel.parent).toBeNull();
+    expect(topLevel.children).toHaveLength(2);
+    expect(topLevel.children[0].id).toBe(ROOT_COLLECTION.id);
+    expect(topLevel.children[1].id).toBe(SHARED_TENANT_COLLECTIONS_ROOT_ID);
+
+    const root = result[ROOT_COLLECTION.id];
+    expect(root.parent.id).toBe(COLLECTIONS_TOP_LEVEL_ID);
+    expect(root.path).toEqual([COLLECTIONS_TOP_LEVEL_ID]);
 
     const syntheticRoot = result[SHARED_TENANT_COLLECTIONS_ROOT_ID];
     expect(syntheticRoot.name).toBe("Shared collections");
-    expect(syntheticRoot.parent.id).toBe(ROOT_COLLECTION.id);
-
-    const rootChildren = result[ROOT_COLLECTION.id].children;
-    expect(rootChildren).toContainEqual(
-      expect.objectContaining({ id: SHARED_TENANT_COLLECTIONS_ROOT_ID }),
-    );
+    expect(syntheticRoot.parent.id).toBe(COLLECTIONS_TOP_LEVEL_ID);
+    expect(syntheticRoot.path).toEqual([COLLECTIONS_TOP_LEVEL_ID]);
   });
 
-  it("should re-parent children and rewrite paths through the synthetic root", () => {
+  it("should re-parent children and rewrite paths through the top-level and synthetic root", () => {
     const result = setup() as any;
 
     const tenantA = result[100 as CollectionId];
     expect(tenantA.parent.id).toBe(SHARED_TENANT_COLLECTIONS_ROOT_ID);
     expect(tenantA.path).toEqual([
-      ROOT_COLLECTION.id,
+      COLLECTIONS_TOP_LEVEL_ID,
       SHARED_TENANT_COLLECTIONS_ROOT_ID,
     ]);
 
     const subcollection = result[300 as CollectionId];
     expect(subcollection.parent.id).toBe(100);
     expect(subcollection.path).toEqual([
-      ROOT_COLLECTION.id,
+      COLLECTIONS_TOP_LEVEL_ID,
       SHARED_TENANT_COLLECTIONS_ROOT_ID,
       100,
     ]);

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.unit.spec.ts
@@ -28,8 +28,29 @@ function setup() {
     path: [],
   });
 
+  const ourAnalyticsSubCollection = createMockExpandedCollection({
+    id: 200 as CollectionId,
+    name: "Our Analytics Sub",
+    location: "/",
+    path: ["root" as CollectionId],
+  });
+
+  const ourAnalyticsNestedCollection = createMockExpandedCollection({
+    id: 201 as CollectionId,
+    name: "Nested Sub",
+    location: "/200/",
+    path: ["root" as CollectionId, 200 as CollectionId],
+  });
+
+  baseRoot.children = [ourAnalyticsSubCollection];
+  ourAnalyticsSubCollection.parent = baseRoot;
+  ourAnalyticsSubCollection.children = [ourAnalyticsNestedCollection];
+  ourAnalyticsNestedCollection.parent = ourAnalyticsSubCollection;
+
   const baseCollectionsById = {
     [ROOT_COLLECTION.id]: baseRoot,
+    [200 as CollectionId]: ourAnalyticsSubCollection,
+    [201 as CollectionId]: ourAnalyticsNestedCollection,
   } as Record<CollectionId, Collection>;
 
   const sharedRoot = createMockExpandedCollection({
@@ -86,6 +107,16 @@ describe("mergeSharedCollections", () => {
     expect(syntheticRoot.name).toBe("Shared collections");
     expect(syntheticRoot.parent.id).toBe(COLLECTIONS_TOP_LEVEL_ID);
     expect(syntheticRoot.path).toEqual([COLLECTIONS_TOP_LEVEL_ID]);
+  });
+
+  it("should rewrite paths for Our Analytics sub-collections to include the top-level Collections node", () => {
+    const result = setup() as any;
+
+    const sub = result[200 as CollectionId];
+    expect(sub.path).toEqual([COLLECTIONS_TOP_LEVEL_ID, "root"]);
+
+    const nested = result[201 as CollectionId];
+    expect(nested.path).toEqual([COLLECTIONS_TOP_LEVEL_ID, "root", 200]);
   });
 
   it("should re-parent children and rewrite paths through the top-level and synthetic root", () => {

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.unit.spec.ts
@@ -1,11 +1,21 @@
+import { setupEnterprisePlugins } from "__support__/enterprise";
+import { setupCollectionTreeEndpoint } from "__support__/server-mocks/collection";
+import { mockSettings } from "__support__/settings";
+import { renderHookWithProviders, waitFor } from "__support__/ui";
 import { ROOT_COLLECTION } from "metabase/entities/collections";
+import { createMockState } from "metabase/redux/store/mocks";
 import type { Collection, CollectionId } from "metabase-types/api";
-import { createMockCollection } from "metabase-types/api/mocks";
+import {
+  createMockCollection,
+  createMockTokenFeatures,
+} from "metabase-types/api/mocks";
 
 import {
   COLLECTIONS_TOP_LEVEL_ID,
+  type ExpandedCollectionNode,
   SHARED_TENANT_COLLECTIONS_ROOT_ID,
   mergeSharedCollections,
+  useCollectionsWithTenants,
 } from "./use-collections-with-tenants";
 
 const createMockExpandedCollection = (
@@ -20,6 +30,90 @@ const createMockExpandedCollection = (
   parent: null,
   children: [],
   is_personal: false,
+});
+
+function setupHook({
+  useTenants = false,
+  sharedCollections = [] as Collection[],
+} = {}) {
+  setupCollectionTreeEndpoint(sharedCollections);
+
+  const baseRoot = createMockExpandedCollection({
+    ...ROOT_COLLECTION,
+    path: [],
+  });
+
+  const collectionsById = {
+    [ROOT_COLLECTION.id]: baseRoot,
+  } as Record<CollectionId, Collection>;
+
+  return renderHookWithProviders(
+    () => useCollectionsWithTenants(collectionsById),
+    {
+      storeInitialState: createMockState({
+        settings: mockSettings({
+          "use-tenants": useTenants,
+          "token-features": createMockTokenFeatures({ tenants: true }),
+        }),
+      }),
+    },
+  );
+}
+
+describe("useCollectionsWithTenants", () => {
+  beforeAll(() => {
+    mockSettings({
+      "token-features": createMockTokenFeatures({ tenants: true }),
+    });
+
+    setupEnterprisePlugins();
+  });
+
+  it("should return collectionsById unchanged when tenants are disabled", () => {
+    const { result } = setupHook({ useTenants: false });
+
+    expect(result.current).not.toHaveProperty(String(COLLECTIONS_TOP_LEVEL_ID));
+
+    expect(result.current).not.toHaveProperty(
+      String(SHARED_TENANT_COLLECTIONS_ROOT_ID),
+    );
+  });
+
+  it("should return collectionsById unchanged when tenants are enabled but no shared collections exist", async () => {
+    const { result } = setupHook({ useTenants: true, sharedCollections: [] });
+
+    await waitFor(() => {
+      expect(result.current).not.toHaveProperty(
+        String(COLLECTIONS_TOP_LEVEL_ID),
+      );
+    });
+
+    expect(result.current).not.toHaveProperty(
+      String(SHARED_TENANT_COLLECTIONS_ROOT_ID),
+    );
+  });
+
+  it("should merge shared collections when tenants are enabled", async () => {
+    const tenantCollection = createMockCollection({
+      id: 100 as CollectionId,
+      name: "Tenant A",
+      location: "/",
+      namespace: "shared-tenant-collection" as any,
+    });
+
+    const { result } = setupHook({
+      useTenants: true,
+      sharedCollections: [tenantCollection],
+    });
+
+    await waitFor(() => {
+      expect(result.current).toHaveProperty(String(COLLECTIONS_TOP_LEVEL_ID));
+    });
+
+    expect(result.current).toHaveProperty(
+      String(SHARED_TENANT_COLLECTIONS_ROOT_ID),
+    );
+  });
 });
 
 function setup() {
@@ -77,7 +171,7 @@ function setup() {
   tenantA.children = [subCollection];
   subCollection.parent = tenantA;
 
-  return mergeSharedCollections(
+  const collectionsById = mergeSharedCollections(
     baseCollectionsById,
     {
       [ROOT_COLLECTION.id]: sharedRoot,
@@ -86,55 +180,82 @@ function setup() {
     },
     "Shared collections",
   );
+
+  return {
+    collectionsById,
+    ourAnalyticsSubCollection,
+    ourAnalyticsNestedCollection,
+    tenantA,
+    subCollection,
+  };
 }
 
 describe("mergeSharedCollections", () => {
   it("should create a top-level Collections node with Our analytics and Shared collections as siblings", () => {
-    const result = setup() as any;
+    const { collectionsById } = setup();
+    const expanded = collectionsById as Record<
+      CollectionId,
+      ExpandedCollectionNode
+    >;
 
-    const topLevel = result[COLLECTIONS_TOP_LEVEL_ID];
+    const topLevel = expanded[COLLECTIONS_TOP_LEVEL_ID];
     expect(topLevel.name).toBe("Collections");
     expect(topLevel.parent).toBeNull();
     expect(topLevel.children).toHaveLength(2);
     expect(topLevel.children[0].id).toBe(ROOT_COLLECTION.id);
     expect(topLevel.children[1].id).toBe(SHARED_TENANT_COLLECTIONS_ROOT_ID);
 
-    const root = result[ROOT_COLLECTION.id];
-    expect(root.parent.id).toBe(COLLECTIONS_TOP_LEVEL_ID);
+    const root = expanded[ROOT_COLLECTION.id];
+    expect(root.parent?.id).toBe(COLLECTIONS_TOP_LEVEL_ID);
     expect(root.path).toEqual([COLLECTIONS_TOP_LEVEL_ID]);
 
-    const syntheticRoot = result[SHARED_TENANT_COLLECTIONS_ROOT_ID];
+    const syntheticRoot = expanded[SHARED_TENANT_COLLECTIONS_ROOT_ID];
     expect(syntheticRoot.name).toBe("Shared collections");
-    expect(syntheticRoot.parent.id).toBe(COLLECTIONS_TOP_LEVEL_ID);
+    expect(syntheticRoot.parent?.id).toBe(COLLECTIONS_TOP_LEVEL_ID);
     expect(syntheticRoot.path).toEqual([COLLECTIONS_TOP_LEVEL_ID]);
   });
 
   it("should rewrite paths for Our Analytics sub-collections to include the top-level Collections node", () => {
-    const result = setup() as any;
+    const {
+      collectionsById,
+      ourAnalyticsSubCollection,
+      ourAnalyticsNestedCollection,
+    } = setup();
 
-    const sub = result[200 as CollectionId];
-    expect(sub.path).toEqual([COLLECTIONS_TOP_LEVEL_ID, "root"]);
+    expect(collectionsById[ourAnalyticsSubCollection.id].path).toEqual([
+      COLLECTIONS_TOP_LEVEL_ID,
+      "root",
+    ]);
 
-    const nested = result[201 as CollectionId];
-    expect(nested.path).toEqual([COLLECTIONS_TOP_LEVEL_ID, "root", 200]);
+    expect(collectionsById[ourAnalyticsNestedCollection.id].path).toEqual([
+      COLLECTIONS_TOP_LEVEL_ID,
+      "root",
+      ourAnalyticsSubCollection.id,
+    ]);
   });
 
   it("should re-parent children and rewrite paths through the top-level and synthetic root", () => {
-    const result = setup() as any;
+    const { collectionsById, tenantA, subCollection } = setup();
+    const expanded = collectionsById as Record<
+      CollectionId,
+      ExpandedCollectionNode
+    >;
 
-    const tenantA = result[100 as CollectionId];
-    expect(tenantA.parent.id).toBe(SHARED_TENANT_COLLECTIONS_ROOT_ID);
-    expect(tenantA.path).toEqual([
+    const mergedTenantA = expanded[tenantA.id];
+
+    expect(mergedTenantA.parent?.id).toBe(SHARED_TENANT_COLLECTIONS_ROOT_ID);
+    expect(mergedTenantA.path).toEqual([
       COLLECTIONS_TOP_LEVEL_ID,
       SHARED_TENANT_COLLECTIONS_ROOT_ID,
     ]);
 
-    const subcollection = result[300 as CollectionId];
-    expect(subcollection.parent.id).toBe(100);
-    expect(subcollection.path).toEqual([
+    const mergedSubCollection = expanded[subCollection.id];
+
+    expect(mergedSubCollection.parent?.id).toBe(tenantA.id);
+    expect(mergedSubCollection.path).toEqual([
       COLLECTIONS_TOP_LEVEL_ID,
       SHARED_TENANT_COLLECTIONS_ROOT_ID,
-      100,
+      tenantA.id,
     ]);
   });
 });

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.unit.spec.ts
@@ -1,0 +1,101 @@
+import { ROOT_COLLECTION } from "metabase/entities/collections";
+import type { Collection, CollectionId } from "metabase-types/api";
+import { createMockCollection } from "metabase-types/api/mocks";
+
+import {
+  SHARED_TENANT_COLLECTIONS_ROOT_ID,
+  mergeSharedCollections,
+} from "./use-collections-with-tenants";
+
+const createMockExpandedCollection = (
+  overrides: Partial<Collection> & { path?: CollectionId[] | null },
+): Collection & {
+  parent: Collection | null;
+  path: CollectionId[];
+  children: Collection[];
+} => ({
+  ...createMockCollection(overrides),
+  path: overrides.path ?? [],
+  parent: null,
+  children: [],
+  is_personal: false,
+});
+
+function setup() {
+  const baseRoot = createMockExpandedCollection({
+    ...ROOT_COLLECTION,
+    path: [],
+  });
+
+  const baseCollectionsById = {
+    [ROOT_COLLECTION.id]: baseRoot,
+  } as Record<CollectionId, Collection>;
+
+  const sharedRoot = createMockExpandedCollection({
+    ...ROOT_COLLECTION,
+    path: [],
+  });
+
+  const tenantA = createMockExpandedCollection({
+    id: 100 as CollectionId,
+    name: "Tenant A",
+    location: "/",
+    path: ["root" as CollectionId],
+  });
+
+  const subCollection = createMockExpandedCollection({
+    id: 300 as CollectionId,
+    name: "Subcollection",
+    location: "/100/",
+    path: ["root" as CollectionId, 100 as CollectionId],
+  });
+
+  sharedRoot.children = [tenantA];
+  tenantA.parent = sharedRoot;
+  tenantA.children = [subCollection];
+  subCollection.parent = tenantA;
+
+  return mergeSharedCollections(
+    baseCollectionsById,
+    {
+      [ROOT_COLLECTION.id]: sharedRoot,
+      [100 as CollectionId]: tenantA,
+      [300 as CollectionId]: subCollection,
+    },
+    "Shared collections",
+  );
+}
+
+describe("mergeSharedCollections", () => {
+  it("should insert a synthetic shared root under Our analytics", () => {
+    const result = setup() as any;
+
+    const syntheticRoot = result[SHARED_TENANT_COLLECTIONS_ROOT_ID];
+    expect(syntheticRoot.name).toBe("Shared collections");
+    expect(syntheticRoot.parent.id).toBe(ROOT_COLLECTION.id);
+
+    const rootChildren = result[ROOT_COLLECTION.id].children;
+    expect(rootChildren).toContainEqual(
+      expect.objectContaining({ id: SHARED_TENANT_COLLECTIONS_ROOT_ID }),
+    );
+  });
+
+  it("should re-parent children and rewrite paths through the synthetic root", () => {
+    const result = setup() as any;
+
+    const tenantA = result[100 as CollectionId];
+    expect(tenantA.parent.id).toBe(SHARED_TENANT_COLLECTIONS_ROOT_ID);
+    expect(tenantA.path).toEqual([
+      ROOT_COLLECTION.id,
+      SHARED_TENANT_COLLECTIONS_ROOT_ID,
+    ]);
+
+    const subcollection = result[300 as CollectionId];
+    expect(subcollection.parent.id).toBe(100);
+    expect(subcollection.path).toEqual([
+      ROOT_COLLECTION.id,
+      SHARED_TENANT_COLLECTIONS_ROOT_ID,
+      100,
+    ]);
+  });
+});


### PR DESCRIPTION
Closes #71936
Closes EMB-1543

### Description

The QuestionPicker sidebar (used when editing a dashboard to add questions) fetched collections without a `namespace` parameter, so the backend only returned default-namespace collections. Shared tenant collections were completely excluded.

Added `useCollectionsWithTenants` hook that:
- Fetches the shared tenant collection tree when tenants are enabled
- Merges them into the existing `collectionsById` map under a top-level "Collections" node
- Places "Our analytics" and "Shared collections" as **siblings** under this top-level node
- Rewrites `path` arrays so breadcrumbs display correctly (e.g. `Collections > Shared collections > Tenant A`)
- Defaults to "Our analytics" on open — no extra click for the common case

The tree structure when tenants are enabled:

```
Collections (top level, shown in breadcrumb)
├── Our analytics (default view on open)
└── Shared collections
    ├── Tenant A
    └── Tenant B
```

No-op when tenants are disabled — behavior is identical to before.

### How to verify

1. Enable multi-tenancy and create shared tenant collections with questions in them
2. Open a dashboard and click Edit
3. Open the question picker sidebar (Add questions)
4. Verify breadcrumb shows `Collections > Our analytics`
5. Click "Collections" in the breadcrumb to navigate up
6. Verify both "Our analytics" and "Shared collections" appear as siblings
7. Navigate into shared collections, verify breadcrumbs update correctly
8. Add a question from a shared collection to the dashboard
9. Disable tenants and verify shared collections do not appear

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)