### PR TITLE
GHY-3213: Sync updates to column comments

### DIFF
--- a/src/metabase/sync/sync_metadata/fields/sync_metadata.clj
+++ b/src/metabase/sync/sync_metadata/fields/sync_metadata.clj
@@ -3,7 +3,6 @@
   the base type, database type, semantic type, and comment/remark (description) properties. This primarily affects
   Fields that were not newly created; newly created Fields are given appropriate metadata when first synced."
   (:require
-   [clojure.string :as str]
    [metabase.sync.interface :as i]
    [metabase.sync.sync-metadata.crufty :as crufty]
    [metabase.sync.sync-metadata.fields.common :as common]
@@ -80,8 +79,7 @@
              (not= old-semantic-type new-semantic-type))
 
         new-comment?
-        (and (str/blank? old-field-comment)
-             (not (str/blank? new-field-comment)))
+        (not= old-field-comment new-field-comment)
 
         new-database-position?
         (not= old-database-position new-database-position)
@@ -134,8 +132,10 @@
                       new-semantic-type)
            {:semantic_type new-semantic-type})
          (when new-comment?
-           (log/infof "Comment has been added for %s."
-                      (common/field-metadata-name-for-logging table metabase-field))
+           (log/infof "Comment of %s has changed from '%s' to '%s'."
+                      (common/field-metadata-name-for-logging table metabase-field)
+                      old-field-comment
+                      new-field-comment)
            {:description new-field-comment})
          (when new-database-position?
            (log/infof "Database position of %s has changed from '%s' to '%s'."

--- a/src/metabase/sync/sync_metadata/fields/sync_metadata.clj
+++ b/src/metabase/sync/sync_metadata/fields/sync_metadata.clj
@@ -73,7 +73,6 @@
         new-base-type?
         (not= old-base-type new-base-type)
 
-        ;; only sync comment if old value was blank so we don't overwrite user-set values
         new-semantic-type?
         (and (nil? old-semantic-type)
              (not= old-semantic-type new-semantic-type))

--- a/test/metabase/sync/sync_metadata/fields/sync_metadata_test.clj
+++ b/test/metabase/sync/sync_metadata/fields/sync_metadata_test.clj
@@ -6,6 +6,7 @@
    [metabase.sync.sync-metadata.fields.sync-metadata :as sync-metadata]
    [metabase.test :as mt]
    [metabase.util :as u]
+   [metabase.warehouse-schema.models.field-user-settings :as schema.field-user-settings]
    [next.jdbc :as next.jdbc]
    [toucan2.core :as t2]))
 
@@ -250,6 +251,32 @@
               {:field_order :alphabetical}
               {:auto-cruft-columns ["updated_at"]}))))))
 
+(deftest field-comment-sync-test
+  (testing "description is updated when DB comment changes"
+    (is (= [["Field" 1 {:description "A different description."}]]
+           (updates-that-will-be-performed!
+            (merge default-metadata {:field-comment "A different description."})
+            (merge default-metadata {:field-comment "The original description."
+                                     :id            1})))))
+  (testing "description is set when DB comment is added to a field with no description"
+    (is (= [["Field" 1 {:description "New comment."}]]
+           (updates-that-will-be-performed!
+            (merge default-metadata {:field-comment "New comment."})
+            (merge default-metadata {:field-comment nil
+                                     :id            1})))))
+  (testing "description is cleared when DB comment is removed"
+    (is (= [["Field" 1 {:description nil}]]
+           (updates-that-will-be-performed!
+            (merge default-metadata {:field-comment nil})
+            (merge default-metadata {:field-comment "Old comment."
+                                     :id            1})))))
+  (testing "no update when DB comment hasn't changed"
+    (is (= []
+           (updates-that-will-be-performed!
+            (merge default-metadata {:field-comment "Same comment."})
+            (merge default-metadata {:field-comment "Same comment."
+                                     :id            1}))))))
+
 (deftest dont-overwrite-semantic-type-test
   (testing "We should not override non-nil `semantic_type`s"
     (is (= []
@@ -333,3 +360,40 @@
                 (is (not= (:fingerprint original-field) (:fingerprint new-field))))))
           (finally
             (t2/delete! :model/Database (mt/id))))))))
+
+(deftest user-set-description-protected-during-sync-test
+  (testing "When a user has explicitly set a field description, sync should not overwrite it"
+    (mt/with-temp-test-data [["table"
+                              [{:field-name "field"
+                                :base-type  :type/Text}]
+                              [["value"]]]]
+      (try
+        (sync/sync-table! (t2/select-one :model/Table (mt/id :table)))
+        (let [field (t2/select-one :model/Field (mt/id :table :field))]
+          (sql-jdbc.execute/do-with-connection-with-options
+           :h2 (mt/db) {}
+           (fn [conn]
+             (next.jdbc/execute! conn ["COMMENT ON COLUMN \"TABLE\".\"FIELD\" IS 'Initial DB comment'"])))
+          (sync/sync-table! (t2/select-one :model/Table (mt/id :table)))
+
+          (testing "The description comes from the column comment"
+            (is (= "Initial DB comment" (:description (t2/select-one :model/Field (mt/id :table :field))))))
+
+          ;; Simulate user setting a description via the API
+          (schema.field-user-settings/upsert-user-settings field {:description "User-set description"})
+          (t2/update! :model/Field (:id field) {:description "User-set description"})
+
+          (testing "A user-set description overrides the column comment"
+            (is (= "User-set description" (:description (t2/select-one :model/Field (mt/id :table :field))))))
+
+          ;; Now change the DB comment and re-sync
+          (sql-jdbc.execute/do-with-connection-with-options
+           :h2 (mt/db) {}
+           (fn [conn]
+             (next.jdbc/execute! conn ["COMMENT ON COLUMN \"TABLE\".\"FIELD\" IS 'Changed DB comment'"])))
+          (sync/sync-table! (t2/select-one :model/Table (mt/id :table)))
+
+          (testing "The user-set description continues to override column comments when the column comments are updated"
+            (is (= "User-set description" (:description (t2/select-one :model/Field (mt/id :table :field)))))))
+        (finally
+          (t2/delete! :model/Database (mt/id)))))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/70029
Closes https://linear.app/metabase/issue/GHY-3213/sync-doesnt-update-column-descriptions-from-db-after-the-first-sync

### Description

Previously (written circa 2019) during sync we would skip updating a field description if it had a value already. A nearby comment suggests that this was done to prevent overriding user-set descriptions on fields. However, that skip logic also prevents updates to the field description when the DWH column has multiple comment values over time, and no user-set description exists.

More recently (2025) we added [handling of the user-set values](https://github.com/metabase/metabase/blob/8f62ee5f3a47687e03af4f9ab2ed395124b022b0/src/metabase/warehouse_schema/models/field.clj#L153) that merges the user-set values on top of whatever values came from the sync. This effectively prevents comment values from a DWH sync from overriding user-set description values. Since this code exists now, we no longer need the skip logic in the sync from DWH comments.

Now:
- If no user-set description exists, the description will reflect the latest synced comment value from the DWH
- If a user-set description exists, the latest user-set description will override any comment value from the DWH even if the column comment was set after the user-set description. (This was already true before this PR, and it will remain true after the PR.)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR