### PR TITLE
Hide Regenerate Key button if form field is readonly

### DIFF
--- a/frontend/src/metabase/forms/components/FormSecretKey/FormSecretKey.tsx
+++ b/frontend/src/metabase/forms/components/FormSecretKey/FormSecretKey.tsx
@@ -22,11 +22,27 @@ export interface FormSecretKeyProps
 }
 
 export const FormSecretKey = forwardRef(function FormSecretKey(
-  { name, nullable, onChange, onBlur, ...props }: FormSecretKeyProps,
+  { name, nullable, onChange, onBlur, readOnly, ...props }: FormSecretKeyProps,
   ref: Ref<HTMLInputElement>,
 ) {
   const [showModal, { open: openModal, close: closeModal }] = useDisclosure();
   const [{ value }, { error }, { setValue }] = useField(name);
+
+  const generateSecretButtonProps = readOnly
+    ? null
+    : {
+        rightSection: (
+          <Button
+            className={S.generateButton}
+            miw={value ? undefined : "10rem"}
+            onClick={openModal}
+            variant="filled"
+          >
+            {value ? t`Regenerate key` : t`Set up key`}
+          </Button>
+        ),
+        rightSectionProps: { className: S.rightSection },
+      };
 
   return (
     <>
@@ -43,17 +59,7 @@ export const FormSecretKey = forwardRef(function FormSecretKey(
               [S.unset]: !value, // Just show the 'Set up key' button when no key is set yet
             }),
           }}
-          rightSection={
-            <Button
-              className={S.generateButton}
-              miw={value ? undefined : "10rem"}
-              onClick={openModal}
-              variant="filled"
-            >
-              {value ? t`Regenerate key` : t`Set up key`}
-            </Button>
-          }
-          rightSectionProps={{ className: S.rightSection }}
+          {...generateSecretButtonProps}
         />
         {!!error && <Text c="error">{error}</Text>}
       </Stack>

--- a/frontend/src/metabase/forms/components/FormSecretKey/FormSecretKey.unit.spec.tsx
+++ b/frontend/src/metabase/forms/components/FormSecretKey/FormSecretKey.unit.spec.tsx
@@ -13,6 +13,7 @@ interface FormValues {
 
 interface SetupOpts {
   initialValues?: FormValues;
+  readOnly?: boolean;
 }
 
 const GENERATED_TOKEN = "newly-generated-token-xyz";
@@ -21,7 +22,10 @@ const EXISTING_VALUE = "my-super-secret-token-abc123";
 const OBFUSCATED_EXISTING = "**********23";
 const OBFUSCATED_GENERATED = "**********yz";
 
-const setup = ({ initialValues = { secret: undefined } }: SetupOpts = {}) => {
+const setup = ({
+  initialValues = { secret: undefined },
+  readOnly = false,
+}: SetupOpts = {}) => {
   const onSubmit = jest.fn();
 
   setupGenerateRandomTokenEndpoint(GENERATED_TOKEN);
@@ -29,7 +33,7 @@ const setup = ({ initialValues = { secret: undefined } }: SetupOpts = {}) => {
   renderWithProviders(
     <FormProvider initialValues={initialValues} onSubmit={onSubmit}>
       <Form>
-        <FormSecretKey name="secret" label="Signing Key" />
+        <FormSecretKey name="secret" label="Signing Key" readOnly={readOnly} />
         <FormSubmitButton />
       </Form>
     </FormProvider>,
@@ -186,6 +190,13 @@ describe("FormSecretKey", () => {
           /This will cause existing tokens to stop working/,
         ),
       ).toBeInTheDocument();
+    });
+  });
+
+  describe("when readOnly is true (env var controlled)", () => {
+    it("does not show 'Regenerate key' or 'Set up key' buttons", () => {
+      setup({ initialValues: { secret: EXISTING_VALUE }, readOnly: true });
+      expect(screen.queryByRole("button")).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/src/metabase/forms/components/FormSecretKey/FormSecretKey.unit.spec.tsx
+++ b/frontend/src/metabase/forms/components/FormSecretKey/FormSecretKey.unit.spec.tsx
@@ -33,7 +33,14 @@ const setup = ({
   renderWithProviders(
     <FormProvider initialValues={initialValues} onSubmit={onSubmit}>
       <Form>
-        <FormSecretKey name="secret" label="Signing Key" readOnly={readOnly} />
+        <FormSecretKey
+          name="secret"
+          label="Signing Key"
+          readOnly={readOnly}
+          wrapperProps={{
+            "data-testid": "inputWrapper",
+          }}
+        />
         <FormSubmitButton />
       </Form>
     </FormProvider>,
@@ -170,7 +177,9 @@ describe("FormSecretKey", () => {
       setup({ initialValues: { secret: EXISTING_VALUE } });
 
       await userEvent.click(
-        screen.getByRole("button", { name: "Regenerate key" }),
+        within(screen.getByTestId("inputWrapper")).getByRole("button", {
+          name: "Regenerate key",
+        }),
       );
 
       expect(
@@ -196,7 +205,9 @@ describe("FormSecretKey", () => {
   describe("when readOnly is true (env var controlled)", () => {
     it("does not show 'Regenerate key' or 'Set up key' buttons", () => {
       setup({ initialValues: { secret: EXISTING_VALUE }, readOnly: true });
-      expect(screen.queryByRole("button")).not.toBeInTheDocument();
+      expect(
+        within(screen.getByTestId("inputWrapper")).queryByRole("button"),
+      ).not.toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #70327
Closes UXW-3232

### Description
Small change to `FormSecretKey` to not show a regenerate or setup button if the field is marked as readonly, which is something that is passed when the value comes for an environment variable

### How to verify
1. Start metabase with MB_JWT_SHARED_SECRET set to something
2. Go Admin -> Authentication -> JWT
3. You should see that the "regenerate" button is not shown

### Demo

<img width="1317" height="937" alt="image" src="https://github.com/user-attachments/assets/d79a8708-9374-41e5-ac7d-17d895ec9005" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] ~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~
