### PR TITLE
Ensure we can always parse formulas

### DIFF
--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricExpressionPill/MetricExpressionPill.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricExpressionPill/MetricExpressionPill.tsx
@@ -4,13 +4,13 @@ import { SourceColorIndicator } from "metabase/common/components/SourceColorIndi
 import { Badge, Flex, Pill } from "metabase/ui";
 
 import type { ExpressionDefinitionEntry } from "../../../types/viewer-state";
-import { type MetricNames, buildExpressionForPill } from "../utils";
+import { type MetricNameMap, buildExpressionForPill } from "../utils";
 
 import S from "./MetricExpressionPill.module.css";
 
 type MetricExpressionPillProps = {
   expressionEntry: ExpressionDefinitionEntry;
-  metricNames: MetricNames;
+  metricNames: MetricNameMap;
   colors?: string[];
   onClick: (e: React.MouseEvent) => void;
   onRemove: () => void;

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricExpressionPill/MetricExpressionPill.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricExpressionPill/MetricExpressionPill.tsx
@@ -3,17 +3,14 @@ import { t } from "ttag";
 import { SourceColorIndicator } from "metabase/common/components/SourceColorIndicator";
 import { Badge, Flex, Pill } from "metabase/ui";
 
-import type {
-  ExpressionDefinitionEntry,
-  MetricsViewerDefinitionEntry,
-} from "../../../types/viewer-state";
-import { buildExpressionForPill } from "../utils";
+import type { ExpressionDefinitionEntry } from "../../../types/viewer-state";
+import { type MetricNames, buildExpressionForPill } from "../utils";
 
 import S from "./MetricExpressionPill.module.css";
 
 type MetricExpressionPillProps = {
   expressionEntry: ExpressionDefinitionEntry;
-  metricEntries: MetricsViewerDefinitionEntry[];
+  metricNames: MetricNames;
   colors?: string[];
   onClick: (e: React.MouseEvent) => void;
   onRemove: () => void;
@@ -21,14 +18,14 @@ type MetricExpressionPillProps = {
 
 export function MetricExpressionPill({
   expressionEntry,
-  metricEntries,
+  metricNames,
   colors,
   onClick,
   onRemove,
 }: MetricExpressionPillProps) {
   const expression = buildExpressionForPill(
     expressionEntry.tokens,
-    metricEntries,
+    metricNames,
   );
   return (
     <Pill

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/MetricSearchInput.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/MetricSearchInput.tsx
@@ -7,7 +7,7 @@ import { t } from "ttag";
 
 import { CodeMirror } from "metabase/common/components/CodeMirror";
 import { Button, Flex, Icon, Popover } from "metabase/ui";
-import type { ProjectionClause } from "metabase-lib/metric";
+import type { MetricDefinition, ProjectionClause } from "metabase-lib/metric";
 
 import type {
   MetricDefinitionEntry,
@@ -18,16 +18,19 @@ import type {
   SourceColorMap,
 } from "../../../types/viewer-state";
 import { isExpressionEntry, isMetricEntry } from "../../../types/viewer-state";
+import { getDefinitionName } from "../../../utils/definition-builder";
 import { getEffectiveDefinitionEntry } from "../../../utils/definition-entries";
 import { computeMetricSlots } from "../../../utils/metric-slots";
 import {
   createMeasureSourceId,
   createMetricSourceId,
+  createSourceId,
 } from "../../../utils/source-ids";
 import { MetricExpressionPill } from "../MetricExpressionPill";
 import { MetricPill } from "../MetricPill";
 import { MetricSearchDropdown } from "../MetricSearchDropdown";
 import {
+  type MetricNames,
   applyTrackedDefinitions,
   buildFullText,
   cleanupParens,
@@ -44,8 +47,8 @@ import {
   buildMetricIdentities,
   metricTokenHighlight,
   readMetricIdentities,
-  setMetricEntries,
   setMetricIdentities,
+  setMetricNames,
 } from "./metricTokenHighlight";
 import { operatorHighlight } from "./operatorHighlight";
 
@@ -126,16 +129,25 @@ export function MetricSearchInput({
   // issues with comparing editText vs textAtFocus across async state updates.
   const [isExpressionDirty, setIsExpressionDirty] = useState(false);
 
-  const metricEntries = useMemo(
-    () =>
-      Object.values(definitions).map(
-        (e): MetricDefinitionEntry => ({ ...e, type: "metric" as const }),
+  const [localMetricNames, setLocalMetricNames] = useState<MetricNames>({});
+  const metricNames: MetricNames = useMemo(
+    () => ({
+      ...localMetricNames,
+      ...Object.fromEntries(
+        Object.values(definitions)
+          .filter(
+            (e): e is { id: MetricSourceId; definition: MetricDefinition } =>
+              e.definition !== null,
+          )
+          .map((e) => [e.id, getDefinitionName(e.definition)])
+          .filter(([, name]) => name !== null),
       ),
-    [definitions],
+    }),
+    [localMetricNames, definitions],
   );
 
-  const metricEntriesRef = useRef(metricEntries);
-  metricEntriesRef.current = metricEntries;
+  const metricNamesRef = useRef<MetricNames>(metricNames);
+  metricNamesRef.current = metricNames;
 
   // Clean up parens per expression entry (only when not actively editing)
   useEffect(() => {
@@ -177,7 +189,7 @@ export function MetricSearchInput({
     isEditingSessionActiveRef.current = true;
     const fullText = buildFullText(
       formulaEntitiesRef.current,
-      definitionsRef.current,
+      metricNamesRef.current,
     );
     setTextAtFocus(fullText);
     setIsFocused(true);
@@ -195,13 +207,13 @@ export function MetricSearchInput({
         const endPos = view.state.doc.length;
         const identities = buildMetricIdentities(
           fullText,
-          metricEntriesRef.current,
+          metricNamesRef.current,
           formulaEntitiesRef.current,
         );
         view.dispatch({
           selection: EditorSelection.cursor(endPos),
           effects: [
-            setMetricEntries.of(metricEntriesRef.current),
+            setMetricNames.of(metricNamesRef.current),
             setMetricIdentities.of(identities),
           ],
           annotations: isolateHistory.of("full"),
@@ -217,7 +229,7 @@ export function MetricSearchInput({
   /** Commits the current text: parses formula entities, removes unreferenced metrics, and collapses. */
   const commitAndCollapse = useCallback(() => {
     const newText = editTextRef.current;
-    const parsedEntities = parseFullText(newText, metricEntriesRef.current);
+    const parsedEntities = parseFullText(newText, metricNamesRef.current);
 
     // Read tracked identities from the CodeMirror StateField —
     // positions are already mapped through all edits automatically.
@@ -229,7 +241,7 @@ export function MetricSearchInput({
         parsedEntities,
         trackedIdentities,
         newText,
-        metricEntriesRef.current,
+        metricNamesRef.current,
       );
 
     // Find which metric sourceIds are referenced in the parsed entities
@@ -293,7 +305,7 @@ export function MetricSearchInput({
     // The expression is only executed when the user explicitly clicks "Run".
     const invalidRanges = findInvalidRanges(
       editTextRef.current,
-      metricEntriesRef.current,
+      metricNamesRef.current,
     );
     if (invalidRanges.length > 0) {
       setValidationError(invalidRanges[0].message);
@@ -302,7 +314,7 @@ export function MetricSearchInput({
 
     const newEntities = parseFullText(
       editTextRef.current,
-      metricEntriesRef.current,
+      metricNamesRef.current,
     );
     // Validate each expression entry
     for (const entry of newEntities) {
@@ -330,7 +342,7 @@ export function MetricSearchInput({
     const { word, start: wordStart } = getWordAtCursor(
       newText,
       cursorPos,
-      metricEntriesRef.current,
+      metricNamesRef.current,
     );
     // Anchor the dropdown at the word's left edge / line bottom in the viewport
     if (view) {
@@ -354,7 +366,7 @@ export function MetricSearchInput({
       const { start, end } = getWordAtCursor(
         docText,
         cursorPos,
-        metricEntriesRef.current,
+        metricNamesRef.current,
       );
 
       const metricName = metric.name ?? "";
@@ -389,6 +401,10 @@ export function MetricSearchInput({
 
       setIsExpressionDirty(true);
       onAddMetric(metric);
+      setLocalMetricNames((prev) => ({
+        ...prev,
+        [createSourceId(metric.id, metric.sourceType)]: metric.name,
+      }));
 
       setCurrentWord("");
       setIsOpen(false);
@@ -501,7 +517,7 @@ export function MetricSearchInput({
     const { word, start: wordStart } = getWordAtCursor(
       text,
       cursorPos,
-      metricEntriesRef.current,
+      metricNamesRef.current,
     );
     // Update the anchor position so the dropdown is correctly placed
     const coords = view.coordsAtPos(wordStart);
@@ -532,7 +548,7 @@ export function MetricSearchInput({
     // that would otherwise be silently dropped.
     const invalidRanges = findInvalidRanges(
       editTextRef.current,
-      metricEntriesRef.current,
+      metricNamesRef.current,
     );
     if (invalidRanges.length > 0) {
       setValidationError(invalidRanges[0].message);
@@ -541,7 +557,7 @@ export function MetricSearchInput({
 
     const newEntities = parseFullText(
       editTextRef.current,
-      metricEntriesRef.current,
+      metricNamesRef.current,
     );
     // Validate each expression entry
     for (const entry of newEntities) {
@@ -566,7 +582,7 @@ export function MetricSearchInput({
     }
     const ranges =
       validationError !== null
-        ? findInvalidRanges(editTextRef.current, metricEntriesRef.current)
+        ? findInvalidRanges(editTextRef.current, metricNamesRef.current)
         : [];
     view.dispatch({ effects: setErrorDecoration.of(ranges) });
   }, [validationError]);
@@ -577,8 +593,8 @@ export function MetricSearchInput({
     if (!view || !isFocused) {
       return;
     }
-    view.dispatch({ effects: setMetricEntries.of(metricEntries) });
-  }, [metricEntries, isFocused]);
+    view.dispatch({ effects: setMetricNames.of(metricNames) });
+  }, [metricNames, isFocused]);
 
   // CodeMirror extensions for the formula editor.
   // basicSetup is disabled, so we add history() explicitly for undo/redo.
@@ -690,7 +706,7 @@ export function MetricSearchInput({
                   <span key={`${entry.id}-${entryIndex}`}>
                     <MetricExpressionPill
                       expressionEntry={entry}
-                      metricEntries={metricEntries}
+                      metricNames={metricNames}
                       colors={expressionColors}
                       onClick={(e: React.MouseEvent) => {
                         e.stopPropagation();

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/MetricSearchInput.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/MetricSearchInput.tsx
@@ -30,7 +30,7 @@ import { MetricExpressionPill } from "../MetricExpressionPill";
 import { MetricPill } from "../MetricPill";
 import { MetricSearchDropdown } from "../MetricSearchDropdown";
 import {
-  type MetricNames,
+  type MetricNameMap,
   applyTrackedDefinitions,
   buildFullText,
   cleanupParens,
@@ -129,8 +129,8 @@ export function MetricSearchInput({
   // issues with comparing editText vs textAtFocus across async state updates.
   const [isExpressionDirty, setIsExpressionDirty] = useState(false);
 
-  const [localMetricNames, setLocalMetricNames] = useState<MetricNames>({});
-  const metricNames: MetricNames = useMemo(
+  const [localMetricNames, setLocalMetricNames] = useState<MetricNameMap>({});
+  const metricNames: MetricNameMap = useMemo(
     () => ({
       ...localMetricNames,
       ...Object.fromEntries(
@@ -146,8 +146,50 @@ export function MetricSearchInput({
     [localMetricNames, definitions],
   );
 
-  const metricNamesRef = useRef<MetricNames>(metricNames);
+  const metricNamesRef = useRef<MetricNameMap>(metricNames);
   metricNamesRef.current = metricNames;
+
+  const handleAddMetric = useCallback(
+    (metric: SelectedMetric) => {
+      onAddMetric(metric);
+      if (metric.name != null) {
+        setLocalMetricNames((prev) => ({
+          ...prev,
+          [createSourceId(metric.id, metric.sourceType)]: metric.name!,
+        }));
+      }
+    },
+    [onAddMetric],
+  );
+
+  const handleRemoveMetric = useCallback(
+    (metricId: number, sourceType: "metric" | "measure") => {
+      onRemoveMetric(metricId, sourceType);
+      const sourceId = createSourceId(metricId, sourceType);
+      setLocalMetricNames((prev) => {
+        const next = { ...prev };
+        delete next[sourceId];
+        return next;
+      });
+    },
+    [onRemoveMetric],
+  );
+
+  const handleSwapMetric = useCallback(
+    (oldMetric: SelectedMetric, newMetric: SelectedMetric) => {
+      onSwapMetric(oldMetric, newMetric);
+      setLocalMetricNames((prev) => {
+        const next = { ...prev };
+        delete next[createSourceId(oldMetric.id, oldMetric.sourceType)];
+        if (newMetric.name != null) {
+          next[createSourceId(newMetric.id, newMetric.sourceType)] =
+            newMetric.name;
+        }
+        return next;
+      });
+    },
+    [onSwapMetric],
+  );
 
   // Clean up parens per expression entry (only when not actively editing)
   useEffect(() => {
@@ -269,7 +311,7 @@ export function MetricSearchInput({
           return sid === entry.id;
         });
         if (metricId) {
-          onRemoveMetric(metricId.id, metricId.sourceType);
+          handleRemoveMetric(metricId.id, metricId.sourceType);
         }
       }
     }
@@ -282,7 +324,7 @@ export function MetricSearchInput({
     setEditText("");
     setValidationError(null);
     setIsExpressionDirty(false);
-  }, [onRemoveMetric, onFormulaEntitiesChange, selectedMetrics]);
+  }, [handleRemoveMetric, onFormulaEntitiesChange, selectedMetrics]);
 
   const handleInputBlur = useCallback(() => {
     // If the text hasn't changed since focus, collapse back to pills view
@@ -400,11 +442,7 @@ export function MetricSearchInput({
       });
 
       setIsExpressionDirty(true);
-      onAddMetric(metric);
-      setLocalMetricNames((prev) => ({
-        ...prev,
-        [createSourceId(metric.id, metric.sourceType)]: metric.name,
-      }));
+      handleAddMetric(metric);
 
       setCurrentWord("");
       setIsOpen(false);
@@ -415,7 +453,7 @@ export function MetricSearchInput({
         editorRef.current?.view?.focus();
       }, 0);
     },
-    [onAddMetric],
+    [handleAddMetric],
   );
 
   // Remove one formula entity by index
@@ -463,7 +501,7 @@ export function MetricSearchInput({
             return sid === sourceId;
           });
           if (metric) {
-            onRemoveMetric(metric.id, metric.sourceType);
+            handleRemoveMetric(metric.id, metric.sourceType);
           }
         }
       }
@@ -482,7 +520,12 @@ export function MetricSearchInput({
 
       onFormulaEntitiesChange(newFormulaEntities, slotMapping);
     },
-    [formulaEntities, selectedMetrics, onRemoveMetric, onFormulaEntitiesChange],
+    [
+      formulaEntities,
+      selectedMetrics,
+      handleRemoveMetric,
+      onFormulaEntitiesChange,
+    ],
   );
 
   const handleContainerClick = useCallback((e: React.MouseEvent) => {
@@ -685,7 +728,7 @@ export function MetricSearchInput({
                       metric={metric}
                       colors={metricColors[entryIndex]}
                       definitionEntry={definition}
-                      onSwap={onSwapMetric}
+                      onSwap={handleSwapMetric}
                       onRemove={(_id, _sourceType) =>
                         handleRemoveItem(entryIndex)
                       }

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/metricTokenHighlight.ts
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/metricTokenHighlight.ts
@@ -19,7 +19,7 @@ import type {
   MetricSourceId,
   MetricsViewerFormulaEntity,
 } from "../../../types/viewer-state";
-import type { MetricIdentityEntry, MetricNames } from "../utils";
+import type { MetricIdentityEntry, MetricNameMap } from "../utils";
 import { parseFullTextWithPositions, traverseMetricTokens } from "../utils";
 
 import S from "./MetricSearchInput.module.css";
@@ -45,9 +45,9 @@ class MetricTokenWidget extends WidgetType {
   }
 }
 
-export const setMetricNames = StateEffect.define<MetricNames>();
+export const setMetricNames = StateEffect.define<MetricNameMap>();
 
-const metricNamesField = StateField.define<MetricNames>({
+const metricNamesField = StateField.define<MetricNameMap>({
   create: () => ({}),
   update(entries, tr) {
     for (const effect of tr.effects) {
@@ -105,7 +105,7 @@ export const metricIdentityField = StateField.define<RangeSet<MetricIdentity>>({
 
 export function buildMetricIdentities(
   text: string,
-  metricNames: MetricNames,
+  metricNames: MetricNameMap,
   entities: MetricsViewerFormulaEntity[],
 ): RangeSet<MetricIdentity> {
   const ranges: ReturnType<MetricIdentity["range"]>[] = [];
@@ -158,7 +158,7 @@ type MetricRange = { from: number; to: number; name: string };
 function computeMetricTokenRanges(
   docText: string,
   docLength: number,
-  metricNames: MetricNames,
+  metricNames: MetricNameMap,
 ): MetricRange[] {
   if (Object.keys(metricNames).length === 0) {
     return [];

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/metricTokenHighlight.ts
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/metricTokenHighlight.ts
@@ -16,11 +16,10 @@ import {
 import type { MetricDefinition } from "metabase-lib/metric";
 
 import type {
-  MetricDefinitionEntry,
   MetricSourceId,
   MetricsViewerFormulaEntity,
 } from "../../../types/viewer-state";
-import type { MetricIdentityEntry } from "../utils";
+import type { MetricIdentityEntry, MetricNames } from "../utils";
 import { parseFullTextWithPositions, traverseMetricTokens } from "../utils";
 
 import S from "./MetricSearchInput.module.css";
@@ -46,13 +45,13 @@ class MetricTokenWidget extends WidgetType {
   }
 }
 
-export const setMetricEntries = StateEffect.define<MetricDefinitionEntry[]>();
+export const setMetricNames = StateEffect.define<MetricNames>();
 
-const metricEntriesField = StateField.define<MetricDefinitionEntry[]>({
-  create: () => [],
+const metricNamesField = StateField.define<MetricNames>({
+  create: () => ({}),
   update(entries, tr) {
     for (const effect of tr.effects) {
-      if (effect.is(setMetricEntries)) {
+      if (effect.is(setMetricNames)) {
         return effect.value;
       }
     }
@@ -106,13 +105,13 @@ export const metricIdentityField = StateField.define<RangeSet<MetricIdentity>>({
 
 export function buildMetricIdentities(
   text: string,
-  metricEntries: MetricDefinitionEntry[],
+  metricNames: MetricNames,
   entities: MetricsViewerFormulaEntity[],
 ): RangeSet<MetricIdentity> {
   const ranges: ReturnType<MetricIdentity["range"]>[] = [];
   let slotCounter = 0;
 
-  traverseMetricTokens(text, metricEntries, entities, (visit) => {
+  traverseMetricTokens(text, metricNames, entities, (visit) => {
     const slotIndex = slotCounter++;
     const sourceId =
       visit.kind === "standalone" ? visit.entity.id : visit.exprToken.sourceId;
@@ -159,13 +158,13 @@ type MetricRange = { from: number; to: number; name: string };
 function computeMetricTokenRanges(
   docText: string,
   docLength: number,
-  metricEntries: MetricDefinitionEntry[],
+  metricNames: MetricNames,
 ): MetricRange[] {
-  if (metricEntries.length === 0) {
+  if (Object.keys(metricNames).length === 0) {
     return [];
   }
 
-  const tokens = parseFullTextWithPositions(docText, metricEntries);
+  const tokens = parseFullTextWithPositions(docText, metricNames);
   return tokens
     .filter(
       (t) =>
@@ -198,13 +197,13 @@ function rangesToDecorations(ranges: MetricRange[]): DecorationSet {
 const metricTokenRangesField = StateField.define<MetricRange[]>({
   create: () => [],
   update(ranges, tr) {
-    const entries = tr.state.field(metricEntriesField);
-    const entriesChanged = tr.effects.some((e) => e.is(setMetricEntries));
-    if (tr.docChanged || entriesChanged) {
+    const metricNames = tr.state.field(metricNamesField);
+    const metricNamesChanged = tr.effects.some((e) => e.is(setMetricNames));
+    if (tr.docChanged || metricNamesChanged) {
       return computeMetricTokenRanges(
         tr.newDoc.toString(),
         tr.newDoc.length,
-        entries,
+        metricNames,
       );
     }
     return ranges;
@@ -215,8 +214,8 @@ const metricTokenRangesField = StateField.define<MetricRange[]>({
 const metricDecorationsField = StateField.define<DecorationSet>({
   create: () => Decoration.none,
   update(deco, tr) {
-    const entriesChanged = tr.effects.some((e) => e.is(setMetricEntries));
-    if (tr.docChanged || entriesChanged) {
+    const metricNamesChanged = tr.effects.some((e) => e.is(setMetricNames));
+    if (tr.docChanged || metricNamesChanged) {
       return rangesToDecorations(tr.state.field(metricTokenRangesField));
     }
     return deco;
@@ -295,7 +294,7 @@ const metricTokenKeymap = keymap.of([
 ]);
 
 export const metricTokenHighlight = [
-  metricEntriesField,
+  metricNamesField,
   metricIdentityField,
   metricTokenRangesField,
   metricDecorationsField,

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.ts
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.ts
@@ -14,7 +14,7 @@ import type {
 import { isExpressionEntry, isMetricEntry } from "../../types/viewer-state";
 import { stampMetricCounts } from "../../utils/expression";
 
-export type MetricNames = Partial<Record<MetricSourceId, string>>;
+export type MetricNameMap = Partial<Record<MetricSourceId, string>>;
 
 /**
  * Returns an array of human-readable expression strings interleaved with numbers
@@ -22,7 +22,7 @@ export type MetricNames = Partial<Record<MetricSourceId, string>>;
  */
 export function buildExpressionForPill(
   tokens: ExpressionSubToken[],
-  metricNames: MetricNames,
+  metricNames: MetricNameMap,
 ): (string | number)[] {
   const result: (string | number)[] = [];
   let curr = "";
@@ -61,7 +61,7 @@ export function buildExpressionForPill(
  */
 export function buildExpressionText(
   tokens: ExpressionSubToken[],
-  metricNames: MetricNames,
+  metricNames: MetricNameMap,
 ): string {
   return buildExpressionForPill(tokens, metricNames)
     .filter((x) => typeof x === "string")
@@ -70,7 +70,7 @@ export function buildExpressionText(
 
 export function buildFullText(
   formulaEntities: MetricsViewerFormulaEntity[],
-  metricNames: MetricNames,
+  metricNames: MetricNameMap,
 ): string {
   return formulaEntities
     .map((entity) => {
@@ -115,7 +115,7 @@ function isWordChar(ch: string): boolean {
 export function getWordAtCursor(
   text: string,
   cursorPos: number,
-  metricNames?: MetricNames,
+  metricNames?: MetricNameMap,
 ): { word: string; start: number; end: number } {
   // Build a set of metric names (lowercased) for quick lookup.
   let metricNamesLower: Set<string> | null = null;
@@ -282,7 +282,7 @@ export type MetricTokenVisit =
  */
 export function traverseMetricTokens(
   text: string,
-  metricNames: MetricNames,
+  metricNames: MetricNameMap,
   entities: MetricsViewerFormulaEntity[],
   visitor: (visit: MetricTokenVisit) => void,
 ): void {
@@ -370,7 +370,7 @@ function stripPositions(token: PositionedToken): ExpressionSubToken | null {
  */
 export function parseFullText(
   text: string,
-  metricNames: MetricNames,
+  metricNames: MetricNameMap,
 ): MetricsViewerFormulaEntity[] {
   const allTokens = parseFullTextWithPositions(text, metricNames);
   const separators = findSeparatorCommaPositions(text, allTokens);
@@ -617,7 +617,7 @@ function consumeNumber(text: string, startIndex: number): number | null {
 /** Same as the main parser but records character positions for each token. */
 export function parseFullTextWithPositions(
   text: string,
-  metricNames: MetricNames,
+  metricNames: MetricNameMap,
 ): PositionedToken[] {
   const sortedMetrics = Object.entries(metricNames)
     .map(([id, name]) => ({ id, name: (name ?? "").toLowerCase() }))
@@ -782,7 +782,7 @@ export type ErrorRange = { from: number; to: number; message: string };
  */
 export function findInvalidRanges(
   text: string,
-  metricNames: MetricNames,
+  metricNames: MetricNameMap,
 ): ErrorRange[] {
   const allTokens = parseFullTextWithPositions(text, metricNames);
   const separators = findSeparatorCommaPositions(text, allTokens);
@@ -947,7 +947,7 @@ export function applyTrackedDefinitions(
   newEntities: MetricsViewerFormulaEntity[],
   trackedIdentities: MetricIdentityEntry[],
   text: string,
-  metricNames: MetricNames,
+  metricNames: MetricNameMap,
 ): ApplyTrackedDefinitionsResult {
   const identityByPosition = new Map<
     string,

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.ts
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.ts
@@ -9,12 +9,12 @@ import type {
   ExpressionSubToken,
   MetricDefinitionEntry,
   MetricSourceId,
-  MetricsViewerDefinitionEntry,
   MetricsViewerFormulaEntity,
 } from "../../types/viewer-state";
 import { isExpressionEntry, isMetricEntry } from "../../types/viewer-state";
-import { getDefinitionName } from "../../utils/definition-builder";
 import { stampMetricCounts } from "../../utils/expression";
+
+export type MetricNames = Partial<Record<MetricSourceId, string>>;
 
 /**
  * Returns an array of human-readable expression strings interleaved with numbers
@@ -22,7 +22,7 @@ import { stampMetricCounts } from "../../utils/expression";
  */
 export function buildExpressionForPill(
   tokens: ExpressionSubToken[],
-  metricEntries: MetricsViewerDefinitionEntry[],
+  metricNames: MetricNames,
 ): (string | number)[] {
   const result: (string | number)[] = [];
   let curr = "";
@@ -41,10 +41,7 @@ export function buildExpressionForPill(
     } else if (token.type === "operator") {
       curr += token.op;
     } else if (token.type === "metric") {
-      const entry = metricEntries.find((e) => e.id === token.sourceId);
-      const name = entry?.definition
-        ? getDefinitionName(entry.definition)
-        : null;
+      const name = metricNames[token.sourceId];
       curr += name ?? "";
       if (token.count > 1) {
         result.push(curr);
@@ -64,32 +61,24 @@ export function buildExpressionForPill(
  */
 export function buildExpressionText(
   tokens: ExpressionSubToken[],
-  metricEntries: MetricsViewerDefinitionEntry[],
+  metricNames: MetricNames,
 ): string {
-  return buildExpressionForPill(tokens, metricEntries)
+  return buildExpressionForPill(tokens, metricNames)
     .filter((x) => typeof x === "string")
     .join("");
 }
 
-/**
- * Builds the full editable text for all formula entities, joined by ", ".
- * Metric entries become their display name (looked up from definitions map);
- * expression entries are reconstructed from their sub-tokens.
- */
 export function buildFullText(
   formulaEntities: MetricsViewerFormulaEntity[],
-  definitions: Record<MetricSourceId, MetricsViewerDefinitionEntry>,
+  metricNames: MetricNames,
 ): string {
-  const definitionEntries = Object.values(definitions);
   return formulaEntities
     .map((entity) => {
       if (isExpressionEntry(entity)) {
-        return buildExpressionText(entity.tokens, definitionEntries);
+        return buildExpressionText(entity.tokens, metricNames);
       }
       if (isMetricEntry(entity)) {
-        const def = definitions[entity.id];
-        const name = def?.definition ? getDefinitionName(def.definition) : null;
-        return name ?? "";
+        return metricNames[entity.id] ?? "";
       }
       return "";
     })
@@ -126,18 +115,14 @@ function isWordChar(ch: string): boolean {
 export function getWordAtCursor(
   text: string,
   cursorPos: number,
-  metricEntries?: MetricDefinitionEntry[],
+  metricNames?: MetricNames,
 ): { word: string; start: number; end: number } {
   // Build a set of metric names (lowercased) for quick lookup.
   let metricNamesLower: Set<string> | null = null;
-  if (metricEntries && metricEntries.length > 0) {
+  if (metricNames && Object.values(metricNames).length > 0) {
     metricNamesLower = new Set(
-      metricEntries
-        .map((e) =>
-          (
-            (e.definition ? getDefinitionName(e.definition) : null) ?? ""
-          ).toLowerCase(),
-        )
+      Object.values(metricNames)
+        .map((name) => name?.toLowerCase() ?? "")
         .filter((n) => n.length > 0),
     );
   }
@@ -297,11 +282,11 @@ export type MetricTokenVisit =
  */
 export function traverseMetricTokens(
   text: string,
-  metricEntries: MetricDefinitionEntry[],
+  metricNames: MetricNames,
   entities: MetricsViewerFormulaEntity[],
   visitor: (visit: MetricTokenVisit) => void,
 ): void {
-  const allTokens = parseFullTextWithPositions(text, metricEntries);
+  const allTokens = parseFullTextWithPositions(text, metricNames);
   const separators = findSeparatorCommaPositions(text, allTokens);
   const segments = groupTokensBySegment(allTokens, separators);
 
@@ -385,9 +370,9 @@ function stripPositions(token: PositionedToken): ExpressionSubToken | null {
  */
 export function parseFullText(
   text: string,
-  metricEntries: MetricDefinitionEntry[],
+  metricNames: MetricNames,
 ): MetricsViewerFormulaEntity[] {
-  const allTokens = parseFullTextWithPositions(text, metricEntries);
+  const allTokens = parseFullTextWithPositions(text, metricNames);
   const separators = findSeparatorCommaPositions(text, allTokens);
   const segments = groupTokensBySegment(allTokens, separators);
   const result: MetricsViewerFormulaEntity[] = [];
@@ -406,15 +391,19 @@ export function parseFullText(
     // Single metric reference without operators → standalone metric entry
     const firstToken = subTokens[0];
     if (subTokens.length === 1 && firstToken.type === "metric") {
-      const existing = metricEntries.find((e) => e.id === firstToken.sourceId);
-      if (existing) {
-        result.push({ ...existing }); // each formulaEntity should be a unique object
+      const name = metricNames[firstToken.sourceId];
+      if (name) {
+        result.push({
+          id: firstToken.sourceId,
+          type: "metric",
+          definition: null,
+        });
         continue;
       }
     }
 
     // Multiple tokens or operators → expression entry
-    const name = buildExpressionText(subTokens, metricEntries);
+    const name = buildExpressionText(subTokens, metricNames);
     result.push({
       id: `expression:${name}`,
       type: "expression",
@@ -628,16 +617,14 @@ function consumeNumber(text: string, startIndex: number): number | null {
 /** Same as the main parser but records character positions for each token. */
 export function parseFullTextWithPositions(
   text: string,
-  metricEntries: MetricDefinitionEntry[],
+  metricNames: MetricNames,
 ): PositionedToken[] {
-  const sortedMetrics = metricEntries
-    .map((entry) => ({
-      name: (
-        (entry.definition ? getDefinitionName(entry.definition) : null) ?? ""
-      ).toLowerCase(),
-      sourceId: entry.id,
-    }))
-    .filter((m) => m.name.length > 0)
+  const sortedMetrics = Object.entries(metricNames)
+    .map(([id, name]) => ({ id, name: (name ?? "").toLowerCase() }))
+    .filter(
+      (m): m is { id: MetricSourceId; name: string } =>
+        (m.name?.length ?? 0) > 0,
+    )
     .sort((a, b) => b.name.length - a.name.length);
 
   const lower = text.toLowerCase();
@@ -717,7 +704,7 @@ export function parseFullTextWithPositions(
     }
 
     let matched = false;
-    for (const { name, sourceId } of sortedMetrics) {
+    for (const { name, id } of sortedMetrics) {
       if (lower.startsWith(name, i)) {
         const nextI = i + name.length;
         const nextCh = text[nextI];
@@ -728,7 +715,7 @@ export function parseFullTextWithPositions(
         if (isWordBoundary) {
           tokens.push({
             type: "metric",
-            sourceId,
+            sourceId: id,
             count: 0,
             from: i,
             to: nextI,
@@ -795,9 +782,9 @@ export type ErrorRange = { from: number; to: number; message: string };
  */
 export function findInvalidRanges(
   text: string,
-  metricEntries: MetricDefinitionEntry[],
+  metricNames: MetricNames,
 ): ErrorRange[] {
-  const allTokens = parseFullTextWithPositions(text, metricEntries);
+  const allTokens = parseFullTextWithPositions(text, metricNames);
   const separators = findSeparatorCommaPositions(text, allTokens);
   const segments = groupTokensBySegment(allTokens, separators);
 
@@ -960,7 +947,7 @@ export function applyTrackedDefinitions(
   newEntities: MetricsViewerFormulaEntity[],
   trackedIdentities: MetricIdentityEntry[],
   text: string,
-  metricEntries: MetricDefinitionEntry[],
+  metricNames: MetricNames,
 ): ApplyTrackedDefinitionsResult {
   const identityByPosition = new Map<
     string,
@@ -984,7 +971,7 @@ export function applyTrackedDefinitions(
   const slotMapping = new Map<number, number>();
   let newSlotCounter = 0;
 
-  traverseMetricTokens(text, metricEntries, newEntities, (visit) => {
+  traverseMetricTokens(text, metricNames, newEntities, (visit) => {
     const newSlotIndex = newSlotCounter++;
     const key = getPositionKey(visit.positioned.from, visit.positioned.to);
     const tracked = identityByPosition.get(key);

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.unit.spec.ts
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.unit.spec.ts
@@ -16,7 +16,7 @@ import {
   setupDefinitionWithBreakout,
 } from "../../utils/__tests__/test-helpers";
 
-import type { MetricIdentityEntry, MetricNames } from "./utils";
+import type { MetricIdentityEntry, MetricNameMap } from "./utils";
 import {
   applyTrackedDefinitions,
   buildExpressionText,
@@ -206,7 +206,7 @@ describe("cleanupParens", () => {
 // ---------------------------------------------------------------------------
 
 describe("buildExpressionText", () => {
-  const metricNames: MetricNames = {
+  const metricNames: MetricNameMap = {
     "metric:1": "Revenue",
     "metric:2": "Costs",
   };
@@ -261,7 +261,7 @@ describe("buildExpressionText", () => {
 // ---------------------------------------------------------------------------
 
 describe("parseFullText — numeric literal parsing", () => {
-  const metricNames: MetricNames = {
+  const metricNames: MetricNameMap = {
     "metric:1": "Revenue",
     "metric:2": "Costs",
   };
@@ -424,7 +424,7 @@ describe("parseFullText — numeric literal parsing", () => {
 // ---------------------------------------------------------------------------
 
 describe("parseFullText — negative numbers", () => {
-  const metricNames: MetricNames = {
+  const metricNames: MetricNameMap = {
     "metric:1": "Revenue",
     "metric:2": "Costs",
   };
@@ -613,7 +613,7 @@ describe("parseFullText — metric names with commas", () => {
   });
 
   it("parses a single metric whose name contains a comma", () => {
-    const names: MetricNames = {
+    const names: MetricNameMap = {
       "metric:10": "Revenue, Total",
       "metric:2": "Costs",
     };
@@ -623,7 +623,7 @@ describe("parseFullText — metric names with commas", () => {
   });
 
   it("parses metric-with-comma followed by another metric", () => {
-    const names: MetricNames = {
+    const names: MetricNameMap = {
       "metric:10": "Revenue, Total",
       "metric:2": "Costs",
     };
@@ -634,7 +634,7 @@ describe("parseFullText — metric names with commas", () => {
   });
 
   it("parses metric-with-comma in an expression", () => {
-    const names: MetricNames = {
+    const names: MetricNameMap = {
       "metric:10": "Revenue, Total",
       "metric:2": "Costs",
     };
@@ -647,7 +647,7 @@ describe("parseFullText — metric names with commas", () => {
   });
 
   it("parses two metrics whose names each contain commas", () => {
-    const names: MetricNames = {
+    const names: MetricNameMap = {
       "metric:10": "Revenue, Total",
       "metric:11": "Costs, Annual",
     };
@@ -659,7 +659,7 @@ describe("parseFullText — metric names with commas", () => {
 
   it("prefers longer metric name over shorter one when both match", () => {
     // "Revenue, Total" should match as one metric, not "Revenue" + separator
-    const names: MetricNames = {
+    const names: MetricNameMap = {
       "metric:10": "Revenue, Total",
       "metric:1": "Revenue",
       "metric:2": "Costs",
@@ -672,7 +672,7 @@ describe("parseFullText — metric names with commas", () => {
 
   it("falls back to shorter metric when longer does not match", () => {
     // Only "Revenue" is known, not "Revenue, Total"
-    const names: MetricNames = { "metric:1": "Revenue", "metric:2": "Costs" };
+    const names: MetricNameMap = { "metric:1": "Revenue", "metric:2": "Costs" };
     const result = parseFullText("Revenue, Costs", names);
     expect(result).toHaveLength(2);
     expect(result[0]).toMatchObject({ type: "metric", id: "metric:1" });
@@ -680,7 +680,7 @@ describe("parseFullText — metric names with commas", () => {
   });
 
   it("handles metric-with-comma multiplied by a constant", () => {
-    const names: MetricNames = { "metric:10": "Revenue, Total" };
+    const names: MetricNameMap = { "metric:10": "Revenue, Total" };
     const result = parseFullText("Revenue, Total * 0.85", names);
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({
@@ -695,7 +695,7 @@ describe("parseFullText — metric names with commas", () => {
 // ---------------------------------------------------------------------------
 
 describe("findInvalidRanges — unknown token detection", () => {
-  const metricNames: MetricNames = {
+  const metricNames: MetricNameMap = {
     "metric:1": "Revenue",
     "metric:2": "Costs",
   };
@@ -773,7 +773,7 @@ describe("findInvalidRanges — unknown token detection", () => {
   });
 
   it("flags trailing characters after a metric name with special chars", () => {
-    const names: MetricNames = { "metric:99": "People Q H2 Orders, Count!" };
+    const names: MetricNameMap = { "metric:99": "People Q H2 Orders, Count!" };
     const errors = findInvalidRanges("People Q H2 Orders, Count!!!!", names);
     expect(errors).toHaveLength(1);
     expect(errors[0]).toMatchObject({
@@ -785,7 +785,7 @@ describe("findInvalidRanges — unknown token detection", () => {
 });
 
 describe("getWordAtCursor — comma handling with metric entries", () => {
-  const commaMetricNames: MetricNames = { "metric:99": "Revenue, Total" };
+  const commaMetricNames: MetricNameMap = { "metric:99": "Revenue, Total" };
 
   it("without entries, comma is always a delimiter", () => {
     const text = "Revenue, Total";
@@ -869,7 +869,7 @@ describe("applyTrackedDefinitions", () => {
     nextSlotIndex = 0;
   });
 
-  const metricNames: MetricNames = {
+  const metricNames: MetricNameMap = {
     [sourceId(1)]: "Revenue",
     [sourceId(2)]: "Geo Revenue",
   };

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.unit.spec.ts
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.unit.spec.ts
@@ -16,7 +16,7 @@ import {
   setupDefinitionWithBreakout,
 } from "../../utils/__tests__/test-helpers";
 
-import type { MetricIdentityEntry } from "./utils";
+import type { MetricIdentityEntry, MetricNames } from "./utils";
 import {
   applyTrackedDefinitions,
   buildExpressionText,
@@ -33,27 +33,6 @@ jest.mock("../../utils/definition-builder", () => ({
 
 function makeSearchResult(id: number, model: "metric" | "measure") {
   return { id, model, name: `Result ${id}` };
-}
-
-/**
- * Helper to create a fake MetricDefinitionEntry with a minimal definition
- * that has the given name. The definition is cast to satisfy the type but
- * only supports getDefinitionName (which reads displayName from lib).
- */
-function makeMetricEntry(
-  sourceId: MetricSourceId,
-  name: string,
-): MetricDefinitionEntry {
-  // getDefinitionName calls LibMetric.displayName which returns the
-  // `display-name` key from the definition JS object. We fake it here.
-  const fakeDefinition = {
-    "display-name": name,
-  } as unknown as MetricDefinitionEntry["definition"];
-  return {
-    id: sourceId,
-    type: "metric",
-    definition: fakeDefinition,
-  };
 }
 
 describe("filterSearchResults", () => {
@@ -227,9 +206,10 @@ describe("cleanupParens", () => {
 // ---------------------------------------------------------------------------
 
 describe("buildExpressionText", () => {
-  const revenueEntry = makeMetricEntry("metric:1", "Revenue");
-  const costsEntry = makeMetricEntry("metric:2", "Costs");
-  const metricEntries = [revenueEntry, costsEntry];
+  const metricNames: MetricNames = {
+    "metric:1": "Revenue",
+    "metric:2": "Costs",
+  };
 
   const m = (sourceId: MetricSourceId): ExpressionSubToken => ({
     type: "metric",
@@ -249,13 +229,13 @@ describe("buildExpressionText", () => {
 
   it("renders a metric scaled by a decimal constant", () => {
     expect(
-      buildExpressionText([m("metric:1"), op("*"), k(0.85)], metricEntries),
+      buildExpressionText([m("metric:1"), op("*"), k(0.85)], metricNames),
     ).toBe("Revenue * 0.85");
   });
 
   it("renders an integer constant", () => {
     expect(
-      buildExpressionText([m("metric:1"), op("*"), k(100)], metricEntries),
+      buildExpressionText([m("metric:1"), op("*"), k(100)], metricNames),
     ).toBe("Revenue * 100");
   });
 
@@ -264,14 +244,14 @@ describe("buildExpressionText", () => {
     expect(
       buildExpressionText(
         [open, m("metric:1"), op("+"), m("metric:2"), close, op("*"), k(0.85)],
-        metricEntries,
+        metricNames,
       ),
     ).toBe("(Revenue + Costs) * 0.85");
   });
 
   it("renders a constant divided by a metric", () => {
     expect(
-      buildExpressionText([k(1), op("/"), m("metric:1")], metricEntries),
+      buildExpressionText([k(1), op("/"), m("metric:1")], metricNames),
     ).toBe("1 / Revenue");
   });
 });
@@ -281,9 +261,10 @@ describe("buildExpressionText", () => {
 // ---------------------------------------------------------------------------
 
 describe("parseFullText — numeric literal parsing", () => {
-  const revenueEntry = makeMetricEntry("metric:1", "Revenue");
-  const costsEntry = makeMetricEntry("metric:2", "Costs");
-  const metricEntries = [revenueEntry, costsEntry];
+  const metricNames: MetricNames = {
+    "metric:1": "Revenue",
+    "metric:2": "Costs",
+  };
 
   const m = (sourceId: MetricSourceId): ExpressionSubToken => ({
     type: "metric",
@@ -300,7 +281,7 @@ describe("parseFullText — numeric literal parsing", () => {
   });
 
   it("parses a metric multiplied by a decimal constant", () => {
-    const result = parseFullText("Revenue * 0.85", metricEntries);
+    const result = parseFullText("Revenue * 0.85", metricNames);
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({
       type: "expression",
@@ -309,7 +290,7 @@ describe("parseFullText — numeric literal parsing", () => {
   });
 
   it("parses a metric multiplied by an integer constant", () => {
-    const result = parseFullText("Revenue * 100", metricEntries);
+    const result = parseFullText("Revenue * 100", metricNames);
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({
       type: "expression",
@@ -318,7 +299,7 @@ describe("parseFullText — numeric literal parsing", () => {
   });
 
   it("parses a constant on the left side", () => {
-    const result = parseFullText("0.5 * Revenue", metricEntries);
+    const result = parseFullText("0.5 * Revenue", metricNames);
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({
       type: "expression",
@@ -327,7 +308,7 @@ describe("parseFullText — numeric literal parsing", () => {
   });
 
   it("parses a constant inside parentheses — (Revenue + Costs) * 0.85", () => {
-    const result = parseFullText("(Revenue + Costs) * 0.85", metricEntries);
+    const result = parseFullText("(Revenue + Costs) * 0.85", metricNames);
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({
       type: "expression",
@@ -345,7 +326,7 @@ describe("parseFullText — numeric literal parsing", () => {
 
   it("parses multiple constants in one expression", () => {
     // 0.5 * Revenue + 0.5 * Costs
-    const result = parseFullText("0.5 * Revenue + 0.5 * Costs", metricEntries);
+    const result = parseFullText("0.5 * Revenue + 0.5 * Costs", metricNames);
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({
       type: "expression",
@@ -363,7 +344,7 @@ describe("parseFullText — numeric literal parsing", () => {
 
   it("handles an integer that looks like it could start a decimal (no dot follows)", () => {
     // "1 + Revenue" — "1" is an integer with no fractional part
-    const result = parseFullText("1 + Revenue", metricEntries);
+    const result = parseFullText("1 + Revenue", metricNames);
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({
       type: "expression",
@@ -372,7 +353,7 @@ describe("parseFullText — numeric literal parsing", () => {
   });
 
   it("parses a leading-dot decimal like .5", () => {
-    const result = parseFullText(".5 * Revenue", metricEntries);
+    const result = parseFullText(".5 * Revenue", metricNames);
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({
       type: "expression",
@@ -381,7 +362,7 @@ describe("parseFullText — numeric literal parsing", () => {
   });
 
   it("parses a metric multiplied by a leading-dot decimal", () => {
-    const result = parseFullText("Revenue * .85", metricEntries);
+    const result = parseFullText("Revenue * .85", metricNames);
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({
       type: "expression",
@@ -390,7 +371,7 @@ describe("parseFullText — numeric literal parsing", () => {
   });
 
   it("parses a negative leading-dot decimal", () => {
-    const result = parseFullText("-.5 * Revenue", metricEntries);
+    const result = parseFullText("-.5 * Revenue", metricNames);
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({
       type: "expression",
@@ -401,7 +382,7 @@ describe("parseFullText — numeric literal parsing", () => {
   it("does not parse a trailing dot as part of the number", () => {
     // "1." — trailing dot with no digit after it; "1" is the constant, "." is
     // dropped (unknown tokens are filtered out of committed data)
-    const result = parseFullText("1.", metricEntries);
+    const result = parseFullText("1.", metricNames);
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({
       type: "expression",
@@ -411,7 +392,7 @@ describe("parseFullText — numeric literal parsing", () => {
 
   it("parses constants and metrics as separate items separated by a comma", () => {
     // "Revenue * 0.85, Costs"
-    const result = parseFullText("Revenue * 0.85, Costs", metricEntries);
+    const result = parseFullText("Revenue * 0.85, Costs", metricNames);
     expect(result).toHaveLength(2);
     expect(result[0]).toMatchObject({
       type: "expression",
@@ -426,12 +407,12 @@ describe("parseFullText — numeric literal parsing", () => {
 
   it("round-trips through buildExpressionText", () => {
     const text = "(Revenue + Costs) * 0.85";
-    const result = parseFullText(text, metricEntries);
+    const result = parseFullText(text, metricNames);
     expect(result).toHaveLength(1);
     const entry = result[0];
     if (entry.type === "expression") {
       // eslint-disable-next-line jest/no-conditional-expect
-      expect(buildExpressionText(entry.tokens, metricEntries)).toBe(text);
+      expect(buildExpressionText(entry.tokens, metricNames)).toBe(text);
     } else {
       throw new Error("Expected expression entry");
     }
@@ -443,9 +424,10 @@ describe("parseFullText — numeric literal parsing", () => {
 // ---------------------------------------------------------------------------
 
 describe("parseFullText — negative numbers", () => {
-  const revenueEntry = makeMetricEntry("metric:1", "Revenue");
-  const costsEntry = makeMetricEntry("metric:2", "Costs");
-  const metricEntries = [revenueEntry, costsEntry];
+  const metricNames: MetricNames = {
+    "metric:1": "Revenue",
+    "metric:2": "Costs",
+  };
 
   const metric = (sourceId: MetricSourceId): ExpressionSubToken => ({
     type: "metric",
@@ -464,7 +446,7 @@ describe("parseFullText — negative numbers", () => {
   const close: ExpressionSubToken = { type: "close-paren" };
 
   it("parses a standalone negative integer", () => {
-    const result = parseFullText("-50", metricEntries);
+    const result = parseFullText("-50", metricNames);
     expect(result).toEqual([
       {
         id: "expression:-50",
@@ -476,7 +458,7 @@ describe("parseFullText — negative numbers", () => {
   });
 
   it("parses metric plus negative constant", () => {
-    const result = parseFullText("Revenue + -50", metricEntries);
+    const result = parseFullText("Revenue + -50", metricNames);
     expect(result).toEqual([
       {
         id: "expression:Revenue + -50",
@@ -488,7 +470,7 @@ describe("parseFullText — negative numbers", () => {
   });
 
   it("parses metric multiplied by negative decimal", () => {
-    const result = parseFullText("Revenue * -0.85", metricEntries);
+    const result = parseFullText("Revenue * -0.85", metricNames);
     expect(result).toEqual([
       {
         id: "expression:Revenue * -0.85",
@@ -500,7 +482,7 @@ describe("parseFullText — negative numbers", () => {
   });
 
   it("parses negative constant at the start of expression", () => {
-    const result = parseFullText("-50 * Revenue", metricEntries);
+    const result = parseFullText("-50 * Revenue", metricNames);
     expect(result).toEqual([
       {
         id: "expression:-50 * Revenue",
@@ -512,7 +494,7 @@ describe("parseFullText — negative numbers", () => {
   });
 
   it("parses negative constant after open-paren", () => {
-    const result = parseFullText("(-50 + Revenue)", metricEntries);
+    const result = parseFullText("(-50 + Revenue)", metricNames);
     expect(result).toEqual([
       {
         id: "expression:(-50 + Revenue)",
@@ -524,7 +506,7 @@ describe("parseFullText — negative numbers", () => {
   });
 
   it("parses subtraction of a negative constant", () => {
-    const result = parseFullText("Revenue - -50", metricEntries);
+    const result = parseFullText("Revenue - -50", metricNames);
     expect(result).toEqual([
       {
         id: "expression:Revenue - -50",
@@ -537,12 +519,12 @@ describe("parseFullText — negative numbers", () => {
 
   it("round-trips negative constants through buildExpressionText", () => {
     const text = "Revenue + -50";
-    const result = parseFullText(text, metricEntries);
+    const result = parseFullText(text, metricNames);
     expect(result).toHaveLength(1);
     const entry = result[0];
     if (entry.type === "expression") {
       // eslint-disable-next-line jest/no-conditional-expect
-      expect(buildExpressionText(entry.tokens, metricEntries)).toBe(text);
+      expect(buildExpressionText(entry.tokens, metricNames)).toBe(text);
     } else {
       throw new Error("Expected expression entry");
     }
@@ -555,11 +537,11 @@ describe("parseFullText — negative numbers", () => {
     "(-50 + Revenue)",
     "Revenue * -0.85",
   ])("does not report validation errors for: %s", (text) => {
-    expect(findInvalidRanges(text, metricEntries)).toEqual([]);
+    expect(findInvalidRanges(text, metricNames)).toEqual([]);
   });
 
   it("parses metric minus negative constant without spaces (Revenue--50)", () => {
-    const result = parseFullText("Revenue--50", metricEntries);
+    const result = parseFullText("Revenue--50", metricNames);
     expect(result).toEqual([
       {
         id: "expression:Revenue - -50",
@@ -571,7 +553,7 @@ describe("parseFullText — negative numbers", () => {
   });
 
   it("parses metric minus negative decimal without spaces (Revenue--0.5)", () => {
-    const result = parseFullText("Revenue--0.5", metricEntries);
+    const result = parseFullText("Revenue--0.5", metricNames);
     expect(result).toEqual([
       {
         id: "expression:Revenue - -0.5",
@@ -583,11 +565,11 @@ describe("parseFullText — negative numbers", () => {
   });
 
   it("does not report validation errors for Revenue--50", () => {
-    expect(findInvalidRanges("Revenue--50", metricEntries)).toEqual([]);
+    expect(findInvalidRanges("Revenue--50", metricNames)).toEqual([]);
   });
 
   it("still treats minus as binary operator after a metric", () => {
-    const result = parseFullText("Revenue - 50", metricEntries);
+    const result = parseFullText("Revenue - 50", metricNames);
     expect(result).toEqual([
       {
         id: "expression:Revenue - 50",
@@ -599,7 +581,7 @@ describe("parseFullText — negative numbers", () => {
   });
 
   it("still treats minus as binary operator after a constant", () => {
-    const result = parseFullText("100 - Revenue", metricEntries);
+    const result = parseFullText("100 - Revenue", metricNames);
     expect(result).toEqual([
       {
         id: "expression:100 - Revenue",
@@ -616,11 +598,6 @@ describe("parseFullText — negative numbers", () => {
 // ---------------------------------------------------------------------------
 
 describe("parseFullText — metric names with commas", () => {
-  const revTotalEntry = makeMetricEntry("metric:10", "Revenue, Total");
-  const costsEntry = makeMetricEntry("metric:2", "Costs");
-  const costsAnnualEntry = makeMetricEntry("metric:11", "Costs, Annual");
-  const revenueEntry = makeMetricEntry("metric:1", "Revenue");
-
   const m = (sourceId: MetricSourceId): ExpressionSubToken => ({
     type: "metric",
     sourceId,
@@ -636,23 +613,32 @@ describe("parseFullText — metric names with commas", () => {
   });
 
   it("parses a single metric whose name contains a comma", () => {
-    const entries = [revTotalEntry, costsEntry];
-    const result = parseFullText("Revenue, Total", entries);
+    const names: MetricNames = {
+      "metric:10": "Revenue, Total",
+      "metric:2": "Costs",
+    };
+    const result = parseFullText("Revenue, Total", names);
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({ type: "metric", id: "metric:10" });
   });
 
   it("parses metric-with-comma followed by another metric", () => {
-    const entries = [revTotalEntry, costsEntry];
-    const result = parseFullText("Revenue, Total, Costs", entries);
+    const names: MetricNames = {
+      "metric:10": "Revenue, Total",
+      "metric:2": "Costs",
+    };
+    const result = parseFullText("Revenue, Total, Costs", names);
     expect(result).toHaveLength(2);
     expect(result[0]).toMatchObject({ type: "metric", id: "metric:10" });
     expect(result[1]).toMatchObject({ type: "metric", id: "metric:2" });
   });
 
   it("parses metric-with-comma in an expression", () => {
-    const entries = [revTotalEntry, costsEntry];
-    const result = parseFullText("Revenue, Total + Costs", entries);
+    const names: MetricNames = {
+      "metric:10": "Revenue, Total",
+      "metric:2": "Costs",
+    };
+    const result = parseFullText("Revenue, Total + Costs", names);
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({
       type: "expression",
@@ -661,8 +647,11 @@ describe("parseFullText — metric names with commas", () => {
   });
 
   it("parses two metrics whose names each contain commas", () => {
-    const entries = [revTotalEntry, costsAnnualEntry];
-    const result = parseFullText("Revenue, Total, Costs, Annual", entries);
+    const names: MetricNames = {
+      "metric:10": "Revenue, Total",
+      "metric:11": "Costs, Annual",
+    };
+    const result = parseFullText("Revenue, Total, Costs, Annual", names);
     expect(result).toHaveLength(2);
     expect(result[0]).toMatchObject({ type: "metric", id: "metric:10" });
     expect(result[1]).toMatchObject({ type: "metric", id: "metric:11" });
@@ -670,8 +659,12 @@ describe("parseFullText — metric names with commas", () => {
 
   it("prefers longer metric name over shorter one when both match", () => {
     // "Revenue, Total" should match as one metric, not "Revenue" + separator
-    const entries = [revTotalEntry, revenueEntry, costsEntry];
-    const result = parseFullText("Revenue, Total, Costs", entries);
+    const names: MetricNames = {
+      "metric:10": "Revenue, Total",
+      "metric:1": "Revenue",
+      "metric:2": "Costs",
+    };
+    const result = parseFullText("Revenue, Total, Costs", names);
     expect(result).toHaveLength(2);
     expect(result[0]).toMatchObject({ type: "metric", id: "metric:10" });
     expect(result[1]).toMatchObject({ type: "metric", id: "metric:2" });
@@ -679,16 +672,16 @@ describe("parseFullText — metric names with commas", () => {
 
   it("falls back to shorter metric when longer does not match", () => {
     // Only "Revenue" is known, not "Revenue, Total"
-    const entries = [revenueEntry, costsEntry];
-    const result = parseFullText("Revenue, Costs", entries);
+    const names: MetricNames = { "metric:1": "Revenue", "metric:2": "Costs" };
+    const result = parseFullText("Revenue, Costs", names);
     expect(result).toHaveLength(2);
     expect(result[0]).toMatchObject({ type: "metric", id: "metric:1" });
     expect(result[1]).toMatchObject({ type: "metric", id: "metric:2" });
   });
 
   it("handles metric-with-comma multiplied by a constant", () => {
-    const entries = [revTotalEntry];
-    const result = parseFullText("Revenue, Total * 0.85", entries);
+    const names: MetricNames = { "metric:10": "Revenue, Total" };
+    const result = parseFullText("Revenue, Total * 0.85", names);
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({
       type: "expression",
@@ -702,20 +695,21 @@ describe("parseFullText — metric names with commas", () => {
 // ---------------------------------------------------------------------------
 
 describe("findInvalidRanges — unknown token detection", () => {
-  const revenueEntry = makeMetricEntry("metric:1", "Revenue");
-  const costsEntry = makeMetricEntry("metric:2", "Costs");
-  const metricEntries = [revenueEntry, costsEntry];
+  const metricNames: MetricNames = {
+    "metric:1": "Revenue",
+    "metric:2": "Costs",
+  };
 
   it("returns no errors for valid expression", () => {
-    expect(findInvalidRanges("Revenue + Costs", metricEntries)).toEqual([]);
+    expect(findInvalidRanges("Revenue + Costs", metricNames)).toEqual([]);
   });
 
   it("returns no errors for valid expression with constant", () => {
-    expect(findInvalidRanges("Revenue * 0.85", metricEntries)).toEqual([]);
+    expect(findInvalidRanges("Revenue * 0.85", metricNames)).toEqual([]);
   });
 
   it("flags a single unknown word", () => {
-    const errors = findInvalidRanges("Revenue + xyz", metricEntries);
+    const errors = findInvalidRanges("Revenue + xyz", metricNames);
     expect(errors).toHaveLength(1);
     expect(errors[0]).toMatchObject({
       from: 10,
@@ -725,7 +719,7 @@ describe("findInvalidRanges — unknown token detection", () => {
   });
 
   it("flags unknown text that is not a known metric", () => {
-    const errors = findInvalidRanges("Foo", metricEntries);
+    const errors = findInvalidRanges("Foo", metricNames);
     expect(errors).toHaveLength(1);
     expect(errors[0]).toMatchObject({
       message: expect.stringContaining("Foo"),
@@ -733,15 +727,12 @@ describe("findInvalidRanges — unknown token detection", () => {
   });
 
   it("flags multiple unknown tokens in different segments", () => {
-    const errors = findInvalidRanges("abc, def", metricEntries);
+    const errors = findInvalidRanges("abc, def", metricNames);
     expect(errors.length).toBeGreaterThanOrEqual(2);
   });
 
   it("flags unknown token mixed with valid tokens", () => {
-    const errors = findInvalidRanges(
-      "Revenue + unknown + Costs",
-      metricEntries,
-    );
+    const errors = findInvalidRanges("Revenue + unknown + Costs", metricNames);
     expect(errors).toHaveLength(1);
     expect(errors[0]).toMatchObject({
       message: expect.stringContaining("unknown"),
@@ -749,21 +740,21 @@ describe("findInvalidRanges — unknown token detection", () => {
   });
 
   it("does not flag numbers as unknown", () => {
-    expect(findInvalidRanges("Revenue * 100", metricEntries)).toEqual([]);
+    expect(findInvalidRanges("Revenue * 100", metricNames)).toEqual([]);
   });
 
   it("does not flag parentheses as unknown", () => {
-    expect(findInvalidRanges("(Revenue + Costs)", metricEntries)).toEqual([]);
+    expect(findInvalidRanges("(Revenue + Costs)", metricNames)).toEqual([]);
   });
 
   it("does not flag operators as unknown", () => {
-    expect(
-      findInvalidRanges("Revenue + Costs - Revenue", metricEntries),
-    ).toEqual([]);
+    expect(findInvalidRanges("Revenue + Costs - Revenue", metricNames)).toEqual(
+      [],
+    );
   });
 
   it("flags unknown token at the start of expression", () => {
-    const errors = findInvalidRanges("xyz + Revenue", metricEntries);
+    const errors = findInvalidRanges("xyz + Revenue", metricNames);
     expect(errors).toHaveLength(1);
     expect(errors[0]).toMatchObject({
       from: 0,
@@ -774,7 +765,7 @@ describe("findInvalidRanges — unknown token detection", () => {
 
   it("returns both structural and unknown errors", () => {
     // "xyz +" has an unknown token AND a trailing operator
-    const errors = findInvalidRanges("xyz +", metricEntries);
+    const errors = findInvalidRanges("xyz +", metricNames);
     expect(errors.length).toBeGreaterThanOrEqual(2);
     const messages = errors.map((e) => e.message);
     expect(messages.some((m) => m.includes("xyz"))).toBe(true);
@@ -782,8 +773,8 @@ describe("findInvalidRanges — unknown token detection", () => {
   });
 
   it("flags trailing characters after a metric name with special chars", () => {
-    const entry = makeMetricEntry("metric:99", "People Q H2 Orders, Count!");
-    const errors = findInvalidRanges("People Q H2 Orders, Count!!!!", [entry]);
+    const names: MetricNames = { "metric:99": "People Q H2 Orders, Count!" };
+    const errors = findInvalidRanges("People Q H2 Orders, Count!!!!", names);
     expect(errors).toHaveLength(1);
     expect(errors[0]).toMatchObject({
       from: 26,
@@ -794,7 +785,7 @@ describe("findInvalidRanges — unknown token detection", () => {
 });
 
 describe("getWordAtCursor — comma handling with metric entries", () => {
-  const commaMetric = makeMetricEntry("metric:99", "Revenue, Total");
+  const commaMetricNames: MetricNames = { "metric:99": "Revenue, Total" };
 
   it("without entries, comma is always a delimiter", () => {
     const text = "Revenue, Total";
@@ -805,19 +796,17 @@ describe("getWordAtCursor — comma handling with metric entries", () => {
 
   it("with entries, comma inside a known metric name is not a delimiter", () => {
     const text = "Revenue, Total";
-    const result = getWordAtCursor(text, text.length, [commaMetric]);
+    const result = getWordAtCursor(text, text.length, commaMetricNames);
     expect(result.word).toBe("Revenue, Total");
   });
 
   it("with entries, separator comma between two metrics is still a delimiter", () => {
-    const revenueEntry = makeMetricEntry("metric:1", "Revenue");
-    const ordersEntry = makeMetricEntry("metric:2", "Orders");
     const text = "Revenue, Orders";
     // cursor at end (inside "Orders")
-    const result = getWordAtCursor(text, text.length, [
-      revenueEntry,
-      ordersEntry,
-    ]);
+    const result = getWordAtCursor(text, text.length, {
+      "metric:1": "Revenue",
+      "metric:2": "Orders",
+    });
     expect(result.word).toBe("Orders");
   });
 
@@ -826,20 +815,20 @@ describe("getWordAtCursor — comma handling with metric entries", () => {
     // The comma is NOT a separator because "Revenue" alone is not a known
     // metric in this set — the only known metric is "Revenue, Total".
     const text = "Revenue, T";
-    const result = getWordAtCursor(text, text.length, [commaMetric]);
+    const result = getWordAtCursor(text, text.length, commaMetricNames);
     expect(result.word).toBe("Revenue, T");
   });
 
   it("math-operator delimiters still work with metric entries", () => {
     const text = "Revenue, Total + 1";
-    const result = getWordAtCursor(text, text.length, [commaMetric]);
+    const result = getWordAtCursor(text, text.length, commaMetricNames);
     expect(result.word).toBe("1");
   });
 
   it("returns full metric name when cursor is in the middle", () => {
     const text = "Revenue, Total";
     // cursor after the comma+space (position 9, inside "Total")
-    const result = getWordAtCursor(text, 9, [commaMetric]);
+    const result = getWordAtCursor(text, 9, commaMetricNames);
     expect(result.word).toBe("Revenue, Total");
   });
 });
@@ -863,18 +852,6 @@ function getExprTokenDefinitions(
     );
 }
 
-const mockDef = (name: string) =>
-  ({ "display-name": name }) as unknown as MetricDefinitionEntry["definition"];
-
-const metricEntryWithDef = (
-  id: MetricSourceId,
-  name: string,
-): MetricDefinitionEntry => ({
-  id,
-  type: "metric",
-  definition: mockDef(name),
-});
-
 let nextSlotIndex = 0;
 
 function identity(
@@ -892,10 +869,10 @@ describe("applyTrackedDefinitions", () => {
     nextSlotIndex = 0;
   });
 
-  const entries = [
-    metricEntryWithDef(sourceId(1), "Revenue"),
-    metricEntryWithDef(sourceId(2), "Geo Revenue"),
-  ];
+  const metricNames: MetricNames = {
+    [sourceId(1)]: "Revenue",
+    [sourceId(2)]: "Geo Revenue",
+  };
   const metadata = createMetricMetadata([REVENUE_METRIC, GEO_METRIC]);
   const revenueDef = setupDefinition(metadata, REVENUE_METRIC.id);
   const revenueBreakoutDef = setupDefinitionWithBreakout(
@@ -910,20 +887,20 @@ describe("applyTrackedDefinitions", () => {
   );
 
   it("returns empty array for empty inputs", () => {
-    const result = applyTrackedDefinitions([], [], "", entries);
+    const result = applyTrackedDefinitions([], [], "", metricNames);
     expect(result.entities).toEqual([]);
     expect(result.slotMapping.size).toBe(0);
   });
 
   it("applies tracked definition to a standalone metric by position", () => {
     const text = "Revenue";
-    const parsed = parseFullText(text, entries);
+    const parsed = parseFullText(text, metricNames);
     const tracked = [identity(sourceId(1), 0, 7, revenueBreakoutDef)];
     const { entities } = applyTrackedDefinitions(
       parsed,
       tracked,
       text,
-      entries,
+      metricNames,
     );
     expect(entities).toHaveLength(1);
     expect((entities[0] as MetricDefinitionEntry).definition).toBe(
@@ -933,27 +910,27 @@ describe("applyTrackedDefinitions", () => {
 
   it("preserves null definition when tracked identity has null", () => {
     const text = "Revenue";
-    const parsed = parseFullText(text, entries);
+    const parsed = parseFullText(text, metricNames);
     const tracked = [identity(sourceId(1), 0, 7, null)];
     const { entities } = applyTrackedDefinitions(
       parsed,
       tracked,
       text,
-      entries,
+      metricNames,
     );
     expect((entities[0] as MetricDefinitionEntry).definition).toBeNull();
   });
 
   it("leaves entity unchanged when no tracked identity matches its position", () => {
     const text = "Revenue";
-    const parsed = parseFullText(text, entries);
-    const { entities } = applyTrackedDefinitions(parsed, [], text, entries);
+    const parsed = parseFullText(text, metricNames);
+    const { entities } = applyTrackedDefinitions(parsed, [], text, metricNames);
     expect(entities).toEqual(parsed);
   });
 
   it("matches definitions by exact position for comma-separated metrics", () => {
     const text = "Revenue, Geo Revenue";
-    const parsed = parseFullText(text, entries);
+    const parsed = parseFullText(text, metricNames);
     const tracked = [
       identity(sourceId(1), 0, 7, revenueBreakoutDef),
       identity(sourceId(2), 9, 20, geoBreakoutDef),
@@ -962,7 +939,7 @@ describe("applyTrackedDefinitions", () => {
       parsed,
       tracked,
       text,
-      entries,
+      metricNames,
     );
     expect((entities[0] as MetricDefinitionEntry).definition).toBe(
       revenueBreakoutDef,
@@ -974,13 +951,13 @@ describe("applyTrackedDefinitions", () => {
 
   it("strips breakout projections from expression token definitions", () => {
     const text = "Revenue + 5";
-    const parsed = parseFullText(text, entries);
+    const parsed = parseFullText(text, metricNames);
     const tracked = [identity(sourceId(1), 0, 7, revenueBreakoutDef)];
     const { entities } = applyTrackedDefinitions(
       parsed,
       tracked,
       text,
-      entries,
+      metricNames,
     );
     const [tokenDef] = getExprTokenDefinitions(entities, 0);
     expect(tokenDef).toBeDefined();
@@ -989,13 +966,13 @@ describe("applyTrackedDefinitions", () => {
 
   it("preserves non-breakout definitions on expression tokens", () => {
     const text = "Revenue + 5";
-    const parsed = parseFullText(text, entries);
+    const parsed = parseFullText(text, metricNames);
     const tracked = [identity(sourceId(1), 0, 7, revenueDef)];
     const { entities } = applyTrackedDefinitions(
       parsed,
       tracked,
       text,
-      entries,
+      metricNames,
     );
     const [tokenDef] = getExprTokenDefinitions(entities, 0);
     expect(tokenDef).toBe(revenueDef);
@@ -1003,20 +980,20 @@ describe("applyTrackedDefinitions", () => {
 
   it("preserves reference identity for expression entries when no tokens change", () => {
     const text = "Revenue + 5";
-    const parsed = parseFullText(text, entries);
-    const { entities } = applyTrackedDefinitions(parsed, [], text, entries);
+    const parsed = parseFullText(text, metricNames);
+    const { entities } = applyTrackedDefinitions(parsed, [], text, metricNames);
     expect(entities[0]).toBe(parsed[0]);
   });
 
   it("does not touch non-metric tokens inside expressions", () => {
     const text = "Revenue + 5";
-    const parsed = parseFullText(text, entries);
+    const parsed = parseFullText(text, metricNames);
     const tracked = [identity(sourceId(1), 0, 7, revenueDef)];
     const { entities } = applyTrackedDefinitions(
       parsed,
       tracked,
       text,
-      entries,
+      metricNames,
     );
     const resultExpr = entities[0] as ExpressionDefinitionEntry;
     const parsedExpr = parsed[0] as ExpressionDefinitionEntry;
@@ -1026,14 +1003,14 @@ describe("applyTrackedDefinitions", () => {
 
   it("applies definition only to standalone metric, not expression token at different position", () => {
     const text = "Revenue, Revenue + 5";
-    const parsed = parseFullText(text, entries);
+    const parsed = parseFullText(text, metricNames);
     // Only the standalone Revenue (0-7) has a tracked identity
     const tracked = [identity(sourceId(1), 0, 7, revenueBreakoutDef)];
     const { entities } = applyTrackedDefinitions(
       parsed,
       tracked,
       text,
-      entries,
+      metricNames,
     );
     expect((entities[0] as MetricDefinitionEntry).definition).toBe(
       revenueBreakoutDef,
@@ -1046,13 +1023,13 @@ describe("applyTrackedDefinitions", () => {
     // Tracked identity at [100,107] — token was deleted (TrackDel).
     // New Revenue at [0,7] is a fresh instance, gets no override.
     const text = "Revenue";
-    const parsed = parseFullText(text, entries);
+    const parsed = parseFullText(text, metricNames);
     const tracked = [identity(sourceId(1), 100, 107, revenueDef)];
     const { entities } = applyTrackedDefinitions(
       parsed,
       tracked,
       text,
-      entries,
+      metricNames,
     );
     expect((entities[0] as MetricDefinitionEntry).definition).not.toBe(
       revenueDef,
@@ -1061,14 +1038,14 @@ describe("applyTrackedDefinitions", () => {
 
   it("newly added duplicate of same metric gets no definition from the tracked one", () => {
     const text = "Revenue, Revenue";
-    const parsed = parseFullText(text, entries);
+    const parsed = parseFullText(text, metricNames);
     // Only one tracked identity at position [0,7]
     const tracked = [identity(sourceId(1), 0, 7, revenueBreakoutDef)];
     const { entities } = applyTrackedDefinitions(
       parsed,
       tracked,
       text,
-      entries,
+      metricNames,
     );
     // First Revenue at [0,7] — exact position match
     expect((entities[0] as MetricDefinitionEntry).definition).toBe(
@@ -1083,13 +1060,13 @@ describe("applyTrackedDefinitions", () => {
   it("preserves definition when token survives edit (position tracked by RangeSet)", () => {
     // "Revenue + 5" — Revenue token at [0,7] survived the edit
     const text = "Revenue + 5";
-    const parsed = parseFullText(text, entries);
+    const parsed = parseFullText(text, metricNames);
     const tracked = [identity(sourceId(1), 0, 7, revenueDef)];
     const { entities } = applyTrackedDefinitions(
       parsed,
       tracked,
       text,
-      entries,
+      metricNames,
     );
     const [tokenDef] = getExprTokenDefinitions(entities, 0);
     expect(tokenDef).toBe(revenueDef);
@@ -1097,7 +1074,7 @@ describe("applyTrackedDefinitions", () => {
 
   it("two instances of same metric at different positions keep independent definitions", () => {
     const text = "Revenue, Revenue";
-    const parsed = parseFullText(text, entries);
+    const parsed = parseFullText(text, metricNames);
     const tracked = [
       identity(sourceId(1), 0, 7, revenueBreakoutDef, 0),
       identity(sourceId(1), 9, 16, revenueDef, 1),
@@ -1106,7 +1083,7 @@ describe("applyTrackedDefinitions", () => {
       parsed,
       tracked,
       text,
-      entries,
+      metricNames,
     );
     expect((entities[0] as MetricDefinitionEntry).definition).toBe(
       revenueBreakoutDef,

--- a/frontend/src/metabase/metrics-viewer/hooks/use-metrics-viewer.ts
+++ b/frontend/src/metabase/metrics-viewer/hooks/use-metrics-viewer.ts
@@ -47,7 +47,7 @@ export interface UseMetricsViewerResult {
   tabs: MetricsViewerTabState[];
   activeTab: MetricsViewerTabState | null;
   activeTabId: string | null;
-
+  initialLoadComplete: boolean;
   loadingIds: Set<MetricSourceId>;
   resultsByEntityIndex: Map<number, Dataset>;
   errorsByDefinitionId: Map<MetricSourceId, string>;
@@ -91,6 +91,8 @@ export function useMetricsViewer({
   const {
     state,
     loadingIds,
+    initialLoadComplete,
+    setInitialLoadComplete,
     removeDefinition,
     setFormulaEntities,
     selectTab: changeTab,
@@ -125,6 +127,7 @@ export function useMetricsViewer({
     handleLoadSources,
     location,
     setFormulaEntities,
+    setInitialLoadComplete,
   );
 
   const activeTab = useMemo((): MetricsViewerTabState | null => {
@@ -312,7 +315,7 @@ export function useMetricsViewer({
     tabs: effectiveTabs,
     activeTab,
     activeTabId: state.selectedTabId,
-
+    initialLoadComplete,
     loadingIds,
     resultsByEntityIndex,
     errorsByDefinitionId,

--- a/frontend/src/metabase/metrics-viewer/hooks/use-viewer-state.ts
+++ b/frontend/src/metabase/metrics-viewer/hooks/use-viewer-state.ts
@@ -206,6 +206,8 @@ function areTabDimensionsValid(tab: MetricsViewerTabState): boolean {
 export interface UseViewerStateResult {
   state: MetricsViewerPageState;
   loadingIds: Set<MetricSourceId>;
+  initialLoadComplete: boolean;
+  setInitialLoadComplete: (initialLoadComplete: boolean) => void;
 
   removeDefinition: (id: MetricSourceId) => void;
   updateDefinition: (id: MetricSourceId, definition: MetricDefinition) => void;
@@ -260,6 +262,8 @@ export function useViewerState(): UseViewerStateResult {
 
   const loadingRef = useRef<Set<MetricSourceId>>(new Set());
   const [loadingIds, setLoadingIds] = useState<Set<MetricSourceId>>(new Set());
+
+  const [initialLoadComplete, setInitialLoadComplete] = useState(false);
 
   const initialize: (newState: MetricsViewerPageState) => void = setState;
 
@@ -609,6 +613,9 @@ export function useViewerState(): UseViewerStateResult {
 
   const clearLoading = useCallback((id: MetricSourceId) => {
     loadingRef.current.delete(id);
+    if (loadingRef.current.size === 0) {
+      setInitialLoadComplete(true);
+    }
     setLoadingIds((prev) => {
       const next = new Set(prev);
       next.delete(id);
@@ -805,6 +812,8 @@ export function useViewerState(): UseViewerStateResult {
   return {
     state,
     loadingIds,
+    initialLoadComplete,
+    setInitialLoadComplete,
 
     removeDefinition,
     updateDefinition,

--- a/frontend/src/metabase/metrics-viewer/hooks/use-viewer-url.ts
+++ b/frontend/src/metabase/metrics-viewer/hooks/use-viewer-url.ts
@@ -1,7 +1,9 @@
 import type { Location } from "history";
 import { useEffect, useRef } from "react";
 import { push, replace } from "react-router-redux";
+import { t } from "ttag";
 
+import { useToast } from "metabase/common/hooks";
 import { useDispatch } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
 import type { MeasureId } from "metabase-types/api";
@@ -41,6 +43,7 @@ export function useViewerUrl(
   setInitialLoadComplete: (initialLoadComplete: boolean) => void,
 ): void {
   const dispatch = useDispatch();
+  const [sendToast] = useToast();
   const lastHashRef = useRef<string | null>(null);
 
   // sync URL to state
@@ -133,6 +136,11 @@ export function useViewerUrl(
     } catch (error) {
       console.error(error);
       setInitialLoadComplete(true);
+      sendToast({
+        icon: "warning_triangle_filled",
+        iconColor: "warning",
+        message: t`There was a problem restoring the page state`,
+      });
     }
   }, [
     location,
@@ -141,6 +149,7 @@ export function useViewerUrl(
     onLoadSources,
     setFormulaEntities,
     setInitialLoadComplete,
+    sendToast,
   ]);
 
   // sync state to URL

--- a/frontend/src/metabase/metrics-viewer/hooks/use-viewer-url.ts
+++ b/frontend/src/metabase/metrics-viewer/hooks/use-viewer-url.ts
@@ -38,92 +38,110 @@ export function useViewerUrl(
     entities: MetricsViewerFormulaEntity[],
     slotMapping?: Map<number, number>,
   ) => void,
+  setInitialLoadComplete: (initialLoadComplete: boolean) => void,
 ): void {
   const dispatch = useDispatch();
   const lastHashRef = useRef<string | null>(null);
 
   // sync URL to state
   useEffect(() => {
-    let hash = location.hash.slice(1);
-    let serializedState: SerializedMetricsViewerPageState;
+    try {
+      let hash = location.hash.slice(1);
+      let serializedState: SerializedMetricsViewerPageState;
 
-    if (!hash) {
-      const params = new URLSearchParams(location.search);
-      const metricId = params.get("metricId");
-      if (metricId) {
-        serializedState = {
-          formulaEntities: [{ type: "metric", id: parseInt(metricId, 10) }],
-          tabs: [],
-          selectedTabId: null,
-        };
-        const encodedHash = encodeState(serializedState);
-        if (encodedHash === undefined) {
-          return;
+      if (!hash) {
+        const params = new URLSearchParams(location.search);
+        const metricId = params.get("metricId");
+        if (metricId) {
+          serializedState = {
+            formulaEntities: [{ type: "metric", id: parseInt(metricId, 10) }],
+            tabs: [],
+            selectedTabId: null,
+          };
+          const encodedHash = encodeState(serializedState);
+          if (encodedHash === undefined) {
+            setInitialLoadComplete(true);
+            return;
+          }
+          hash = encodedHash;
+        } else {
+          serializedState = decodeState(hash);
         }
-        hash = encodedHash;
       } else {
         serializedState = decodeState(hash);
       }
-    } else {
-      serializedState = decodeState(hash);
-    }
 
-    if (hash === lastHashRef.current) {
-      return;
-    }
-    lastHashRef.current = hash;
-
-    if (serializedState.tabs.length > 0) {
-      const tabs: MetricsViewerTabState[] =
-        serializedState.tabs.map(deserializeTab);
-
-      initialize({
-        definitions: {},
-        formulaEntities: [],
-        tabs,
-        selectedTabId: serializedState.selectedTabId,
-      });
-    }
-
-    const metricIds: MetricId[] = [];
-    const measureIds: MeasureId[] = [];
-
-    const restoredFormulaEntities = deserializeFormulaEntities(serializedState);
-
-    restoredFormulaEntities.forEach((entity) => {
-      if (isMetricEntry(entity)) {
-        const { type, id } = parseSourceId(entity.id);
-        if (type === "metric") {
-          metricIds.push(id);
-        } else if (type === "measure") {
-          measureIds.push(id);
-        }
+      if (hash === lastHashRef.current) {
+        setInitialLoadComplete(true);
+        return;
       }
-      if (isExpressionEntry(entity)) {
-        entity.tokens.forEach((token) => {
-          if (token.type === "metric") {
-            const { type, id } = parseSourceId(token.sourceId);
-            if (type === "metric") {
-              metricIds.push(id);
-            } else if (type === "measure") {
-              measureIds.push(id);
-            }
-          }
+      lastHashRef.current = hash;
+
+      if (serializedState.tabs.length > 0) {
+        const tabs: MetricsViewerTabState[] =
+          serializedState.tabs.map(deserializeTab);
+
+        initialize({
+          definitions: {},
+          formulaEntities: [],
+          tabs,
+          selectedTabId: serializedState.selectedTabId,
         });
       }
-    });
 
-    if (metricIds.length > 0 || measureIds.length > 0) {
-      onLoadSources({
-        metricIds,
-        measureIds,
+      const metricIds: MetricId[] = [];
+      const measureIds: MeasureId[] = [];
+
+      const restoredFormulaEntities =
+        deserializeFormulaEntities(serializedState);
+
+      restoredFormulaEntities.forEach((entity) => {
+        if (isMetricEntry(entity)) {
+          const { type, id } = parseSourceId(entity.id);
+          if (type === "metric") {
+            metricIds.push(id);
+          } else if (type === "measure") {
+            measureIds.push(id);
+          }
+        }
+        if (isExpressionEntry(entity)) {
+          entity.tokens.forEach((token) => {
+            if (token.type === "metric") {
+              const { type, id } = parseSourceId(token.sourceId);
+              if (type === "metric") {
+                metricIds.push(id);
+              } else if (type === "measure") {
+                measureIds.push(id);
+              }
+            }
+          });
+        }
       });
-    }
 
-    if (restoredFormulaEntities.length > 0) {
-      setFormulaEntities(restoredFormulaEntities);
+      if (metricIds.length > 0 || measureIds.length > 0) {
+        onLoadSources({
+          metricIds,
+          measureIds,
+        });
+      } else {
+        setInitialLoadComplete(true);
+      }
+
+      if (restoredFormulaEntities.length > 0) {
+        setFormulaEntities(restoredFormulaEntities);
+      }
+    } catch (error) {
+      console.error(error);
+      setInitialLoadComplete(true);
     }
-  }, [location, dispatch, initialize, onLoadSources, setFormulaEntities]);
+  }, [
+    location,
+    dispatch,
+    initialize,
+    onLoadSources,
+    setFormulaEntities,
+    setInitialLoadComplete,
+  ]);
 
   // sync state to URL
   useEffect(() => {

--- a/frontend/src/metabase/metrics-viewer/pages/MetricsViewerPage/MetricsViewerPage.tsx
+++ b/frontend/src/metabase/metrics-viewer/pages/MetricsViewerPage/MetricsViewerPage.tsx
@@ -1,6 +1,7 @@
 import type { Location } from "history";
 
-import { Box, Flex, Stack } from "metabase/ui";
+import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
+import { Box, Center, Flex, Stack } from "metabase/ui";
 
 import { BreakoutLegend } from "../../components/BreakoutLegend/BreakoutLegend";
 import {
@@ -29,6 +30,7 @@ export function MetricsViewerPage(props: MetricsViewerPageProps) {
     tabs,
     activeTab,
     activeTabId,
+    initialLoadComplete,
     resultsByEntityIndex,
     errorsByDefinitionId,
     modifiedDefinitionsByIndex,
@@ -52,6 +54,15 @@ export function MetricsViewerPage(props: MetricsViewerPageProps) {
     setBreakoutDimension,
     setFormulaEntities,
   } = useMetricsViewerResult;
+
+  if (!initialLoadComplete) {
+    // parsing formulas won't work until the initial set of definitions are loaded
+    return (
+      <Center h="100%">
+        <LoadingAndErrorWrapper loading />
+      </Center>
+    );
+  }
 
   const hasDefinitions = Object.keys(definitions).length > 0;
   const hasLoadedDefinitions = Object.values(definitions).some(

--- a/frontend/src/metabase/metrics-viewer/utils/legend.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/legend.ts
@@ -1,12 +1,10 @@
 import { NULL_DISPLAY_VALUE } from "metabase/lib/constants";
 import { formatValue } from "metabase/lib/formatting";
 import { isEmpty } from "metabase/lib/validate";
-import { buildExpressionText } from "metabase/metrics-viewer/components/MetricSearch/utils";
 import * as LibMetric from "metabase-lib/metric";
 import type { MetricBreakoutValuesResponse } from "metabase-types/api";
 
 import {
-  type MetricDefinitionEntry,
   type MetricSourceId,
   type MetricsViewerDefinitionEntry,
   type MetricsViewerFormulaEntity,
@@ -51,10 +49,6 @@ export function buildLegendGroups(
     return [];
   }
 
-  const metricEntries = Object.values(definitions).map(
-    (e): MetricDefinitionEntry => ({ ...e, type: "metric" as const }),
-  );
-
   const groups: LegendGroup[] = [];
 
   formulaEntities.forEach((entity, entityIndex) => {
@@ -64,14 +58,11 @@ export function buildLegendGroups(
     }
 
     if (isExpressionEntry(entity)) {
-      const definitionName = buildExpressionText(entity.tokens, metricEntries);
-
       groups.push({
         key: entityIndex,
-        header: definitionName,
-        items: [{ label: definitionName, color: colors[0] }],
+        header: entity.name,
+        items: [{ label: entity.name, color: colors[0] }],
       });
-
       return;
     }
 


### PR DESCRIPTION
Closes [UXW-3552: Selecting a metric before load shows a formula error](https://linear.app/metabase/issue/UXW-3552/selecting-a-metric-before-load-shows-a-formula-error)

- Don't show formula bar until initial set of definitions have loaded (we need their names to parse formulas)
- Use local state inside MetricSearchInput to ensure we have names needed to parse formulas without waiting for definitions to load
