### PR TITLE
[BOT-1272] Fix missing `metabot-id` in streaming request

### DIFF
--- a/src/metabase/metabot/api.clj
+++ b/src/metabase/metabot/api.clj
@@ -204,7 +204,8 @@
 
     (log/info "Using native Clojure agent" {:profile-id profile-id :debug? debug?})
     (native-agent-streaming-request
-     {:profile-id      profile-id
+     {:metabot-id      metabot-id
+      :profile-id      profile-id
       :message         message
       :context         context
       :history         history

--- a/test/metabase/metabot/api_test.clj
+++ b/test/metabase/metabot/api_test.clj
@@ -569,3 +569,27 @@
                {:type "dashboard"}
                {:type "model" :query native :chart_configs [{:query native}]}]
               result)))))
+
+(deftest streaming-request-passes-metabot-id-test
+  (testing "streaming-request passes metabot-id to native-agent-streaming-request"
+    (let [captured-args (atom nil)
+          test-metabot-id metabot.config/embedded-metabot-id]
+      (with-redefs [metabot.config/check-metabot-enabled! (constantly nil)
+                    api/store-aiservice-messages!         (constantly nil)
+                    api/native-agent-streaming-request    (fn [args]
+                                                            (reset! captured-args args)
+                                                            ;; Return a minimal streaming response
+                                                            nil)]
+        (api/streaming-request {:metabot_id      test-metabot-id
+                                :profile_id      nil
+                                :message         "test message"
+                                :context         {}
+                                :history         []
+                                :conversation_id (str (random-uuid))
+                                :state           {}
+                                :debug           false})
+        (testing "metabot-id is included in the arguments"
+          (is (some? (:metabot-id @captured-args))
+              "metabot-id should not be nil")
+          (is (= test-metabot-id (:metabot-id @captured-args))
+              "metabot-id should match the input metabot_id"))))))


### PR DESCRIPTION
Closes BOT-1272

  Line 198: metabot-id is properly resolved:
  metabot-id (metabot.config/resolve-dynamic-metabot-id metabot_id)

  Lines 206-213: But it's NOT passed to native-agent-streaming-request:
```clojure
  (native-agent-streaming-request
   {:profile-id      profile-id
    :message         message
    :context         context
    :history         history
    :conversation-id conversation_id
    :state           state
    :debug?          debug?})   ;; metabot-id is missing!
```

  Call Chain Impact

  1. streaming-request (api.clj:198) - Resolves metabot-id but doesn't pass it forward
  2. native-agent-streaming-request (api.clj:168) - Destructures :metabot-id but receives nil
  3. agent/run-agent-loop (api.clj:183) - Passes nil as :metabot-id
  4. init-agent (agent/core.clj:414) - Calls tools/wrap-tools-with-state with nil
  5. wrap-tools-with-state (tools.clj:133,136) - Binds shared/*metabot-id* to nil
  6. Tools execute with shared/*metabot-id* = nil
  7. answer-sources (entity_details.clj:354) - Throws "Invalid metabot_id null" when metabot-id is nil

  Affected Tools

  Tools that use shared/*metabot-id*:
  - list-available-data-sources-tool (metadata.clj:143) - calls answer-sources with nil
  - search-tool (search.clj:283) - passes nil to search functions

Profiles Using list-available-data-sources-tool

  From agent/profiles.clj:
```markdown
┌────────────────────────────┬──────┬───────────────────────────────┐
│          Profile           │ Line │           Use Case            │
├────────────────────────────┼──────┼───────────────────────────────┤
│ :embedding_next            │ 80   │ Embedded metabot contexts     │
├────────────────────────────┼──────┼───────────────────────────────┤
│ :document-generate-content │ 150  │ Document generation workflows │
└────────────────────────────┴──────┴───────────────────────────────┘
```
  Impact of nil metabot-id on Search Tool

  The search tool (search.clj:168-254) does not crash with nil metabot-id, but it silently degrades in several ways:

  1. Metabot Instance Lookup Fails (line 189)

```clojure
  metabot (t2/select-one :model/Metabot :entity_id
            (get-in metabot.config/metabot-config [metabot-id :entity-id] metabot-id))
```

  With metabot-id = nil:
  - `(get-in metabot.config/metabot-config [nil :entity-id] nil) → nil`
  - Query becomes `(t2/select-one :model/Metabot :entity_id nil) → returns nil`

  2. Verified Content Filtering Disabled (lines 190-192)

```clojure
  use-verified? (if metabot-id
                  (:use_verified_content metabot)
                  false)
```

  With metabot-id = nil, this defaults to false, ignoring the user's configured preference for verified-only content.

  3. Collection Scoping Broken (lines 193-195)

```clojure
  embedded-metabot? (= metabot-id metabot.config/embedded-metabot-id)
  collection-id     (when (or embedded-metabot? (= profile-id "nlq"))
                      (:collection_id metabot))
```

  - embedded-metabot? evaluates to false since nil != embedded-metabot-id
  - collection-id becomes nil even for embedded contexts
  - Search returns results from the entire instance instead of the metabot's scoped collection