### PR TITLE
remove data studio link from the metrics viewer

### DIFF
--- a/e2e/test/scenarios/metrics/metrics-explorer.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/metrics-explorer.cy.spec.ts
@@ -194,26 +194,12 @@ describe("scenarios > metrics > explorer", () => {
 
       addMetric("Count of products");
 
+      H.echartsContainer().should("be.visible");
+
       cy.log("should persist state in url");
 
       cy.reload();
       verifyMetricCount(1);
-
-      cy.log("should navigate to data studio via right-click context menu");
-      cy.window().then((win) => {
-        cy.stub(win, "open").as("windowOpen");
-      });
-
-      H.MetricsViewer.searchBarPills()
-        .contains("Count of products")
-        .rightclick();
-      H.popover().findByText("Edit in Data Studio").click();
-
-      cy.get("@windowOpen").should(
-        "have.been.calledWith",
-        Cypress.sinon.match(/\/data-studio\/library\/metrics\/\d+/),
-        "_blank",
-      );
     });
 
     it("should not show Edit in Data Studio for users without data studio access", () => {

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricPill/MetricPill.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricPill/MetricPill.tsx
@@ -3,13 +3,7 @@ import { t } from "ttag";
 
 import { ForwardRefLink } from "metabase/common/components/Link";
 import { SourceColorIndicator } from "metabase/common/components/SourceColorIndicator";
-import { canAccessDataStudio } from "metabase/data-studio/selectors";
-import { useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
-import {
-  dataStudioMetric,
-  dataStudioPublishedTableMeasure,
-} from "metabase/lib/urls/data-studio";
 import { Box, Flex, Icon, Menu, Pill, Popover, Skeleton } from "metabase/ui";
 import type { ProjectionClause } from "metabase-lib/metric";
 import * as LibMetric from "metabase-lib/metric";
@@ -51,7 +45,6 @@ export function MetricPill({
   onOpen,
 }: MetricPillProps) {
   const [popoverState, setPopoverState] = useState<PillPopoverState>("closed");
-  const hasDataStudioAccess = useSelector(canAccessDataStudio);
 
   const dimensions = useMemo(
     () =>
@@ -101,18 +94,6 @@ export function MetricPill({
     e.stopPropagation();
     setPopoverState("context-menu");
   }, []);
-
-  const handleEditInDataStudio = useCallback(() => {
-    if (metric.sourceType === "measure" && metric.tableId != null) {
-      window.open(
-        dataStudioPublishedTableMeasure(metric.tableId, metric.id),
-        "_blank",
-      );
-    } else {
-      window.open(dataStudioMetric(metric.id), "_blank");
-    }
-    setPopoverState("closed");
-  }, [metric]);
 
   const handleOpenBreakoutPicker = useCallback(() => {
     setPopoverState("breakout-picker");
@@ -232,18 +213,9 @@ export function MetricPill({
               </Menu.Item>
             </>
           )}
-          {(hasDataStudioAccess || metric.sourceType === "metric") && (
-            <Menu.Divider role="separator" />
-          )}
-          {hasDataStudioAccess && (
-            <Menu.Item
-              leftSection={<Icon name="pencil" />}
-              rightSection={<Icon name="external" />}
-              onClick={handleEditInDataStudio}
-            >
-              {t`Edit in Data Studio`}
-            </Menu.Item>
-          )}
+          {metric.sourceType === "metric" &&
+            dimensions.size > 0 &&
+            definition && <Menu.Divider role="separator" />}
           {metric.sourceType === "metric" && (
             <Menu.Item
               leftSection={<Icon name="info" />}

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricPill/MetricPill.unit.spec.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricPill/MetricPill.unit.spec.tsx
@@ -1,45 +1,36 @@
 import { fireEvent, screen } from "@testing-library/react";
 
 import { renderWithProviders } from "__support__/ui";
-import { createMockUser } from "metabase-types/api/mocks";
-import { createMockState } from "metabase-types/store/mocks";
 
 import type {
   MetricsViewerDefinitionEntry,
   SelectedMetric,
 } from "../../../types/viewer-state";
+import {
+  REVENUE_METRIC,
+  createMetricMetadata,
+  setupDefinition,
+} from "../../../utils/__tests__/test-helpers";
 
 import { MetricPill } from "./MetricPill";
 
-const defaultDefinitionEntry: MetricsViewerDefinitionEntry = {
-  id: "measure:1",
-  definition: null,
-};
-
 function setup({
   metric,
-  hasDataStudioAccess = false,
+  definitionEntry,
 }: {
   metric: SelectedMetric;
-  hasDataStudioAccess?: boolean;
+  definitionEntry?: MetricsViewerDefinitionEntry;
 }) {
-  const state = createMockState({
-    currentUser: createMockUser({
-      is_superuser: hasDataStudioAccess,
-    }),
-  });
-
   renderWithProviders(
     <MetricPill
       metric={metric}
-      definitionEntry={defaultDefinitionEntry}
+      definitionEntry={definitionEntry ?? { id: "measure:1", definition: null }}
       selectedMetricIds={new Set()}
       selectedMeasureIds={new Set()}
       onSwap={jest.fn()}
       onRemove={jest.fn()}
       onSetBreakout={jest.fn()}
     />,
-    { storeInitialState: state },
   );
 }
 
@@ -49,37 +40,40 @@ function openContextMenu() {
 }
 
 describe("MetricPill context menu", () => {
-  it("should not show bottom menu items for a measure without data studio access", () => {
+  it("should not show bottom menu items for a measure", () => {
     setup({
       metric: { id: 1, name: "Revenue", sourceType: "measure" },
     });
     openContextMenu();
 
-    expect(screen.queryByRole("separatar")).not.toBeInTheDocument();
-
-    expect(screen.queryByText("Edit in Data Studio")).not.toBeInTheDocument();
+    expect(screen.queryByRole("separator")).not.toBeInTheDocument();
     expect(
       screen.queryByText("Go to metric home page"),
     ).not.toBeInTheDocument();
   });
 
-  it("should show 'Go to metric home page' for metric source type", () => {
+  it("should show 'Go to metric home page' without separator when no breakout items", () => {
     setup({
       metric: { id: 1, name: "Revenue", sourceType: "metric" },
     });
     openContextMenu();
 
-    expect(screen.getByRole("separator")).toBeInTheDocument();
+    expect(screen.queryByRole("separator")).not.toBeInTheDocument();
     expect(screen.getByText("Go to metric home page")).toBeInTheDocument();
   });
 
-  it("should show 'Edit in Data Studio' when user has data studio access", () => {
+  it("should show separator between breakout items and 'Go to metric home page'", () => {
+    const metadata = createMetricMetadata([REVENUE_METRIC]);
+    const definition = setupDefinition(metadata, REVENUE_METRIC.id);
+
     setup({
-      metric: { id: 1, name: "Revenue", sourceType: "measure" },
-      hasDataStudioAccess: true,
+      metric: { id: REVENUE_METRIC.id, name: "Revenue", sourceType: "metric" },
+      definitionEntry: { id: "metric:1", definition },
     });
     openContextMenu();
+
     expect(screen.getByRole("separator")).toBeInTheDocument();
-    expect(screen.getByText("Edit in Data Studio")).toBeInTheDocument();
+    expect(screen.getByText("Break out")).toBeInTheDocument();
+    expect(screen.getByText("Go to metric home page")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/UXW-3462/remove-data-studio-link-from-metric-explorer

### Description

Removes data studio link from the metric context menu in the Metrics Viewer.

### Demo

<img width="481" height="283" alt="Screenshot 2026-04-07 at 3 52 20 PM" src="https://github.com/user-attachments/assets/ef6561cf-fad8-48c5-9ace-52773d1061da" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [n/a] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
