### PR TITLE
Call utils/slugify from mc.c.m.collection with a map as the second arg.

### DIFF
--- a/src/metabase/collections/models/collection.clj
+++ b/src/metabase/collections/models/collection.clj
@@ -281,7 +281,7 @@
   (when (str/blank? collection-name)
     (throw (ex-info (tru "Collection name cannot be blank!")
                     {:status-code 400, :errors {:name (tru "cannot be blank")}})))
-  (u/slugify collection-name collection-slug-max-length))
+  (u/slugify collection-name {:max-length collection-slug-max-length}))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                       Nested Collections: Location Paths                                       |

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -337,7 +337,9 @@
 
 (defmethod generate-path :default [model-name entity]
   ;; This default works for most models, but needs overriding for those that don't rely on entity_id.
-  (maybe-labeled model-name entity :name))
+  (maybe-labeled model-name entity #(if (string? (:name %))
+                                      (:name %)
+                                      (:format-string (:name %)))))
 
 (defn log-path-str
   "Returns a string for logging from a serdes path sequence (i.e. in :serdes/meta)"

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -543,7 +543,7 @@
                                               [:map
                                                {:closed true}
                                                [:max-length {:optional true} pos-int?]
-                                               [:unicode?   {:optional true} any?]]]]
+                                               [:unicode?   {:optional true} [:maybe boolean?]]]]]
    (when (seq s)
      (cond->> (remove-diacritical-marks (lower-case-en s))
        true (map #(slugify-char % (not unicode?)))

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -26,6 +26,7 @@
    [metabase.util.format :as u.format]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
+   [metabase.util.malli :as mu]
    [metabase.util.memoize :as memoize]
    [metabase.util.namespaces :as u.ns]
    [metabase.util.number :as u.number]
@@ -525,7 +526,7 @@
          :cljs (js/encodeURIComponent c))
       c)))
 
-(defn slugify
+(mu/defn slugify
   "Return a version of String `s` appropriate for use as a URL slug.
   Downcase the name and remove diacritcal marks, and replace non-alphanumeric *ASCII* characters with underscores.
 
@@ -537,7 +538,11 @@
   Optionally specify `:max-length` which will truncate the slug after that many characters."
   (^String [^String s]
    (slugify s {}))
-  (^String [s {:keys [max-length unicode?]}]
+  (^String [s :- [:maybe :string]
+            {:keys [max-length unicode?]} :- [:map
+                                              {:closed true}
+                                              [:max-length {:optional true} pos-int?]
+                                              [:unicode?   {:optional true} boolean?]]]
    (when (seq s)
      (cond->> (remove-diacritical-marks (lower-case-en s))
        true (map #(slugify-char % (not unicode?)))

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -539,10 +539,11 @@
   (^String [^String s]
    (slugify s {}))
   (^String [s :- [:maybe :string]
-            {:keys [max-length unicode?]} :- [:map
-                                              {:closed true}
-                                              [:max-length {:optional true} pos-int?]
-                                              [:unicode?   {:optional true} boolean?]]]
+            {:keys [max-length unicode?]} :- [:maybe
+                                              [:map
+                                               {:closed true}
+                                               [:max-length {:optional true} pos-int?]
+                                               [:unicode?   {:optional true} any?]]]]
    (when (seq s)
      (cond->> (remove-diacritical-marks (lower-case-en s))
        true (map #(slugify-char % (not unicode?)))

--- a/src/metabase/util/malli/defn.clj
+++ b/src/metabase/util/malli/defn.clj
@@ -4,7 +4,7 @@
    [clojure.core :as core]
    [clojure.string :as str]
    [malli.destructure]
-   [metabase.util :as u]
+   [me.flowthing.pp :as pp]
    [metabase.util.malli.fn :as mu.fn]
    [net.cgrand.macrovich :as macros]))
 
@@ -53,7 +53,9 @@
                                                 (map (comp pr-str :args :values)
                                                      (:arities arities-value)))
                                       ")"))
-          "\n  Return: " (str/replace (u/pprint-to-str (:schema (:values return) :any))
+          "\n  Return: " (str/replace (with-out-str
+                                        #_{:clj-kondo/ignore [:discouraged-var]}
+                                        (pp/pprint (:schema (:values return) :any)))
                                       "\n"
                                       "\n          ")
           (when (not-empty doc)

--- a/src/metabase/util/malli/defn.clj
+++ b/src/metabase/util/malli/defn.clj
@@ -55,7 +55,8 @@
                                       ")"))
           "\n  Return: " (str/replace (with-out-str
                                         #_{:clj-kondo/ignore [:discouraged-var]}
-                                        (pp/pprint (:schema (:values return) :any)))
+                                        (pp/pprint (:schema (:values return) :any)
+                                                   {:max-width 120}))
                                       "\n"
                                       "\n          ")
           (when (not-empty doc)

--- a/test/metabase/collections/models/collection_test.clj
+++ b/test/metabase/collections/models/collection_test.clj
@@ -39,11 +39,11 @@
 (deftest format-personal-collection-name-length-test
   (testing "test that an unrealistically long collection name with unicode letters is still less than the max length for a slug (metabase#33917)"
     (mt/with-temporary-setting-values [site-locale "ru"]
-      (is (< (count (#'collection/slugify (collection/format-personal-collection-name (apply str (repeat 34 "Б"))
-                                                                                      (apply str (repeat 35 "Б"))
-                                                                                      "MetaBase@metabase.com"
-                                                                                      :site)))
-             (var-get #'collection/collection-slug-max-length))))))
+      (is (<= (count (#'collection/slugify (collection/format-personal-collection-name (apply str (repeat 256 "Б"))
+                                                                                       (apply str (repeat 256 "Б"))
+                                                                                       "MetaBase@metabase.com"
+                                                                                       :site)))
+              (var-get #'collection/collection-slug-max-length))))))
 
 (deftest user->personal-collection-name-test
   (testing "test that we can get the name of a user's personal collection as :site"


### PR DESCRIPTION
### Description

There was a bug where `utils/slugify` was called with a number as the second options argument where a map was expected.

This caused test failures on Debian that weren't reproducible elsewhere (including CI):

```
FAIL in metabase.collections.models.collection-test/format-personal-collection-name-length-test (collection_test.clj:42)
test that an unrealistically long collection name with unicode letters is still less than the max length for a slug (metabase#33917) 
Setting :site-locale = "ru"

expected: (<
           (count
            ((var collection/slugify)
             (collection/format-personal-collection-name
              (apply str (repeat 34 "Б"))
              (apply str (repeat 35 "Б"))
              "MetaBase@metabase.com"
              :site)))
           (var-get (var collection/collection-slug-max-length)))
  actual: (not (< 543 510))
```

Change the `utils/slugify` function to a malli defn so that other calls with the wrong arguments will be caught in the future.

This also uncovered a bug where `generate-path` called `maybe-labeled` with a map as the slug, which should have been a string.

Had to remove a call to `pprint-to-str` from `metabase.util.malli.defn` in order to break a circular dependency; replaced it with `with-out-str`+`pprint` since most of the point of `pprint-to-str` is to be cljs compatible, and this is a .clj file which will not run in cljs anyway.

### Changes

* Fix the broken call in `metabase.collections.models.collection`
* Make `utils/slugify` a malli defn rather than a regular defn
* Update `m.u.m.defn/annotated-docstring` to not require `m.utils` to break circularity
* Fix `generate-path` to pass a string for the slug itself.

### How to verify

Run the tests on Debian stable; they pass now! (well, except for `metabase.channel.render.body-test/render-correct-whitelabel-colors` but let's pretend we didn't see that)