### PR TITLE
[AI Controls] Add tooltip explaining most-permissive group access

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/components/AllUsersHigherAccessTooltipIcon.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/components/AllUsersHigherAccessTooltipIcon.module.css
@@ -1,0 +1,8 @@
+.InfoIcon {
+  align-self: center;
+  color: var(--mb-color-text-tertiary);
+  cursor: pointer;
+  flex-shrink: 0;
+  position: absolute;
+  right: -22px;
+}

--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/components/AllUsersHigherAccessTooltipIcon.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/components/AllUsersHigherAccessTooltipIcon.tsx
@@ -1,0 +1,36 @@
+import { t } from "ttag";
+
+import { Icon, Tooltip } from "metabase/ui";
+
+import S from "./AllUsersHigherAccessTooltipIcon.module.css";
+
+type AllUsersHigherAccessTooltipIconProps = {
+  groupName: string;
+  variant: "tool-permission" | "group-limits";
+};
+
+export function AllUsersHigherAccessTooltipIcon({
+  groupName,
+  variant,
+}: AllUsersHigherAccessTooltipIconProps) {
+  let tooltipLabel =
+    t`The "${groupName}" group has this feature enabled, which will override this setting. ` +
+    t`To restrict access, limit or disable it for the "${groupName}" group first.`;
+
+  if (variant === "group-limits") {
+    tooltipLabel =
+      t`The "${groupName}" group limit is higher or unlimited, which will override this setting. ` +
+      t`To restrict usage, lower or set a limit for the "${groupName}" group first.`;
+  }
+
+  return (
+    <Tooltip label={tooltipLabel}>
+      <Icon
+        aria-label={t`Group limit warning`}
+        className={S.InfoIcon}
+        name="info"
+        size={16}
+      />
+    </Tooltip>
+  );
+}

--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotFeatureAccessPage/AiFeatureAccessTable.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotFeatureAccessPage/AiFeatureAccessTable.tsx
@@ -3,6 +3,7 @@ import { useMemo } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
+import { isDefaultGroup } from "metabase/lib/groups";
 import {
   AIToolKey,
   type GroupInfo,
@@ -31,6 +32,19 @@ export function AiFeatureAccessTable(props: AiFeatureAccessTableProps) {
     [groupPermissions],
   );
 
+  const allUsersGroup = useMemo(
+    () =>
+      groups.find(
+        (g) => isDefaultGroup(g) || g.magic_group_type === "all-external-users",
+      ),
+    [groups],
+  );
+
+  const allUsersGroupPermissions = useMemo(
+    () => (allUsersGroup ? (permissionsByGroup[allUsersGroup.id] ?? []) : []),
+    [allUsersGroup, permissionsByGroup],
+  );
+
   return (
     <div className={S.CardContainer} data-testid="ai-feature-access-table">
       <table className={S.Table}>
@@ -56,6 +70,8 @@ export function AiFeatureAccessTable(props: AiFeatureAccessTableProps) {
               initialPermissions={permissionsByGroup[group.id] || []}
               key={group.id}
               onPermissionChange={onPermissionChange}
+              allUsersGroup={allUsersGroup}
+              allUsersGroupPermissions={allUsersGroupPermissions}
             />
           ))}
         </tbody>

--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotFeatureAccessPage/GroupPermissionRow.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotFeatureAccessPage/GroupPermissionRow.module.css
@@ -1,8 +1,9 @@
 .Cell {
-  vertical-align: middle;
   background: var(--mb-color-background-primary);
   box-sizing: border-box;
   padding: 0.5rem 1rem;
+  text-align: center;
+  vertical-align: middle;
 
   &.CenterText {
     text-align: center;
@@ -24,4 +25,13 @@
 
 .InputBody {
   justify-content: center;
+}
+
+.CellContent {
+  align-items: center;
+  display: inline-flex;
+  gap: 0.375rem;
+  justify-content: center;
+  overflow: visible;
+  position: relative;
 }

--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotFeatureAccessPage/GroupPermissionRow.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotFeatureAccessPage/GroupPermissionRow.tsx
@@ -1,9 +1,11 @@
 import cx from "classnames";
-import { type ChangeEvent, useEffect, useState } from "react";
+import { type ChangeEvent, useEffect, useMemo, useState } from "react";
 import { c, t } from "ttag";
 import _, { type Dictionary } from "underscore";
 
-import { Checkbox, Switch, Text } from "metabase/ui";
+import { isDefaultGroup } from "metabase/lib/groups";
+import { Box, Checkbox, Switch, Text } from "metabase/ui";
+import { AllUsersHigherAccessTooltipIcon } from "metabase-enterprise/ai-controls/components/AllUsersHigherAccessTooltipIcon";
 import {
   AIToolKey,
   type GroupInfo,
@@ -21,14 +23,24 @@ type GroupPermissionRowProps = {
     toolKey: AIToolKey,
     value: "yes" | "no",
   ) => void;
+  allUsersGroup?: GroupInfo;
+  allUsersGroupPermissions?: MetabotGroupPermission[];
 };
 
 export function GroupPermissionRow(props: GroupPermissionRowProps) {
-  const { onPermissionChange, initialPermissions, group } = props;
+  const {
+    onPermissionChange,
+    initialPermissions,
+    group,
+    allUsersGroup,
+    allUsersGroupPermissions,
+  } = props;
   const [permissionMap, setPermissionMap] =
     useState<Dictionary<MetabotGroupPermission>>();
 
   const isAdminGroup = group.magic_group_type === "admin";
+  const isAllUsersGroup =
+    isDefaultGroup(group) || group.magic_group_type === "all-external-users";
 
   useEffect(() => {
     // Initialize permission map
@@ -37,8 +49,34 @@ export function GroupPermissionRow(props: GroupPermissionRowProps) {
     }
   }, [permissionMap, initialPermissions]);
 
-  const isMetabotEnabled =
+  const allUsersGroupPermissionsMap = useMemo(
+    () =>
+      allUsersGroupPermissions
+        ? _.indexBy(allUsersGroupPermissions, "perm_type")
+        : {},
+    [allUsersGroupPermissions],
+  );
+
+  const isMetabotEnabledForThisGroup =
     isAdminGroup || permissionMap?.[AIToolKey.Metabot]?.perm_value === "yes";
+
+  const isAllUsersGroupOverriding = (toolKey: AIToolKey): boolean => {
+    if (!allUsersGroup || isAdminGroup || isAllUsersGroup) {
+      return false;
+    }
+
+    const isMetabotEnabledForAllUsers =
+      allUsersGroupPermissionsMap[AIToolKey.Metabot]?.perm_value === "yes";
+
+    if (!isMetabotEnabledForAllUsers) {
+      return false;
+    }
+
+    const allUsersValue = allUsersGroupPermissionsMap[toolKey]?.perm_value;
+    const thisGroupValue = permissionMap?.[toolKey]?.perm_value;
+
+    return allUsersValue === "yes" && thisGroupValue === "no";
+  };
 
   const handlePermissionChange = (key: AIToolKey, value: "yes" | "no") => {
     setPermissionMap((prev) => ({
@@ -62,37 +100,56 @@ export function GroupPermissionRow(props: GroupPermissionRowProps) {
         <Text>{group.name}</Text>
       </td>
       {getAIToolItems().map(({ key, label }) => {
+        const showAllUsersOverrideTooltip =
+          isAllUsersGroupOverriding(key) && !!allUsersGroup;
+
         if (key === AIToolKey.Metabot) {
           return (
             <td key={key} className={cx(S.Cell, S.AiFeatureCell)}>
-              <Switch
-                aria-label={t`Allow ${group.name} user group to access AI features.`}
-                size="sm"
-                checked={isMetabotEnabled}
-                onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                  handlePermissionChange(key, e.target.checked ? "yes" : "no")
-                }
-                classNames={{ body: S.InputBody }}
-                disabled={isAdminGroup}
-              />
+              <Box className={S.CellContent}>
+                <Switch
+                  aria-label={t`Allow ${group.name} user group to access AI features.`}
+                  size="sm"
+                  checked={isMetabotEnabledForThisGroup}
+                  onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                    handlePermissionChange(key, e.target.checked ? "yes" : "no")
+                  }
+                  classNames={{ body: S.InputBody }}
+                  disabled={isAdminGroup}
+                />
+                {showAllUsersOverrideTooltip && (
+                  <AllUsersHigherAccessTooltipIcon
+                    groupName={allUsersGroup.name}
+                    variant="tool-permission"
+                  />
+                )}
+              </Box>
             </td>
           );
         }
 
         return (
           <td key={key} className={S.Cell}>
-            <Checkbox
-              aria-label={t`Allow ${group.name} user group to access ${label} AI tool.`}
-              size="md"
-              checked={
-                isAdminGroup || permissionMap?.[key]?.perm_value === "yes"
-              }
-              onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                handlePermissionChange(key, e.target.checked ? "yes" : "no")
-              }
-              classNames={{ body: S.InputBody }}
-              disabled={isAdminGroup || !isMetabotEnabled}
-            />
+            <Box className={S.CellContent}>
+              <Checkbox
+                aria-label={t`Allow ${group.name} user group to access ${label} AI tool.`}
+                size="md"
+                checked={
+                  isAdminGroup || permissionMap?.[key]?.perm_value === "yes"
+                }
+                onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                  handlePermissionChange(key, e.target.checked ? "yes" : "no")
+                }
+                classNames={{ body: S.InputBody }}
+                disabled={isAdminGroup || !isMetabotEnabledForThisGroup}
+              />
+              {showAllUsersOverrideTooltip && (
+                <AllUsersHigherAccessTooltipIcon
+                  groupName={allUsersGroup.name}
+                  variant="tool-permission"
+                />
+              )}
+            </Box>
           </td>
         );
       })}

--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotFeatureAccessPage/MetabotFeatureAccessPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotFeatureAccessPage/MetabotFeatureAccessPage.unit.spec.tsx
@@ -77,6 +77,13 @@ function getPermissionRow(groupName: string) {
   });
 }
 
+const dataAnalystsGroup = createMockGroup({
+  id: 4,
+  name: "Data Analysts",
+  member_count: 2,
+  magic_group_type: "data-analyst",
+});
+
 describe("MetabotFeatureAccessPage", () => {
   it("renders groups with their permission states", async () => {
     setup();
@@ -205,5 +212,151 @@ describe("MetabotFeatureAccessPage", () => {
 
     expect(screen.getByText("User groups")).toBeInTheDocument();
     expect(screen.getByText("Tenant groups")).toBeInTheDocument();
+  });
+
+  describe("'All Users' group override warning icons", () => {
+    // defaultPermissions: All Users group has everything enabled; Data Analysts has everything disabled
+    const defaultPermissions = [
+      ...createMockMetabotGroupPermissions(adminGroup.id),
+      ...createMockMetabotGroupPermissions(allUsersGroup.id),
+      ...createMockMetabotGroupPermissions(dataAnalystsGroup.id, {
+        [AIToolKey.Metabot]: "no",
+        [AIToolKey.ChatAndNLQ]: "no",
+        [AIToolKey.SQLGeneration]: "no",
+        [AIToolKey.OtherTools]: "no",
+      }),
+    ];
+
+    it("shows info icons on a group's row when 'All Users' has higher access", async () => {
+      setup({
+        groups: [adminGroup, allUsersGroup, dataAnalystsGroup],
+        permissions: defaultPermissions,
+      });
+
+      await screen.findByTestId("ai-feature-access-table");
+
+      const dataAnalystsRow = getPermissionRow("Data Analysts");
+
+      // Wait for permissions to propagate
+      await waitFor(() => {
+        const infoIcons = within(dataAnalystsRow).getAllByRole("img", {
+          name: "Group limit warning",
+        });
+        // One icon per tool column (AI features switch + 3 checkboxes)
+        expect(infoIcons).toHaveLength(4);
+      });
+    });
+
+    it("shows info icon only for tools where 'All Users' has higher access", async () => {
+      const permissions = [
+        ...createMockMetabotGroupPermissions(adminGroup.id),
+        ...createMockMetabotGroupPermissions(allUsersGroup.id, {
+          [AIToolKey.SQLGeneration]: "no",
+        }),
+        ...createMockMetabotGroupPermissions(dataAnalystsGroup.id, {
+          [AIToolKey.ChatAndNLQ]: "no",
+          [AIToolKey.SQLGeneration]: "no",
+          [AIToolKey.OtherTools]: "no",
+        }),
+      ];
+
+      setup({
+        groups: [adminGroup, allUsersGroup, dataAnalystsGroup],
+        permissions,
+      });
+
+      await screen.findByTestId("ai-feature-access-table");
+
+      const dataAnalystsRow = getPermissionRow("Data Analysts");
+
+      await waitFor(() => {
+        // Only ChatAndNLQ and OtherTools are overridden — SQLGeneration is "no" for both
+        const infoIcons = within(dataAnalystsRow).getAllByRole("img", {
+          name: "Group limit warning",
+        });
+        expect(infoIcons).toHaveLength(2);
+      });
+    });
+
+    it("does not show info icons on the 'All Users' row itself", async () => {
+      setup();
+      await screen.findByTestId("ai-feature-access-table");
+
+      const allUsersRow = getPermissionRow("All Users");
+
+      await waitFor(() => {
+        expect(within(allUsersRow).getByRole("switch")).toBeInTheDocument();
+      });
+
+      expect(
+        within(allUsersRow).queryByRole("img", { name: "Group limit warning" }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("does not show info icons when 'All Users' has equal or lower access", async () => {
+      // All Users has SQL generation disabled; Data Analysts also has it disabled — no override
+      const permissions = [
+        ...createMockMetabotGroupPermissions(adminGroup.id),
+        ...createMockMetabotGroupPermissions(allUsersGroup.id, {
+          [AIToolKey.SQLGeneration]: "no",
+        }),
+        ...createMockMetabotGroupPermissions(dataAnalystsGroup.id, {
+          [AIToolKey.SQLGeneration]: "no",
+        }),
+      ];
+
+      setup({
+        groups: [adminGroup, allUsersGroup, dataAnalystsGroup],
+        permissions,
+      });
+
+      await screen.findByTestId("ai-feature-access-table");
+
+      const dataAnalystsRow = getPermissionRow("Data Analysts");
+
+      await waitFor(() => {
+        expect(within(dataAnalystsRow).getByRole("switch")).toBeInTheDocument();
+      });
+
+      expect(
+        within(dataAnalystsRow).queryByRole("img", {
+          name: "Group limit warning",
+        }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("does not show info icons when 'All Users' AI features switch is off, even if sub-tools are on", async () => {
+      const permissions = [
+        ...createMockMetabotGroupPermissions(adminGroup.id),
+        ...createMockMetabotGroupPermissions(allUsersGroup.id, {
+          [AIToolKey.Metabot]: "no",
+          // ChatAndNLQ, SQLGeneration, OtherTools remain "yes" in state
+        }),
+        ...createMockMetabotGroupPermissions(dataAnalystsGroup.id, {
+          [AIToolKey.ChatAndNLQ]: "no",
+          [AIToolKey.SQLGeneration]: "no",
+          [AIToolKey.OtherTools]: "no",
+        }),
+      ];
+
+      setup({
+        groups: [adminGroup, allUsersGroup, dataAnalystsGroup],
+        permissions,
+      });
+
+      await screen.findByTestId("ai-feature-access-table");
+
+      const dataAnalystsRow = getPermissionRow("Data Analysts");
+
+      await waitFor(() => {
+        expect(within(dataAnalystsRow).getByRole("switch")).toBeInTheDocument();
+      });
+
+      expect(
+        within(dataAnalystsRow).queryByRole("img", {
+          name: "Group limit warning",
+        }),
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotUsageLimitsPage/GroupLimitsSettingsSection/GroupLimitsSettingsSection.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotUsageLimitsPage/GroupLimitsSettingsSection/GroupLimitsSettingsSection.tsx
@@ -1,9 +1,10 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { t } from "ttag";
 
 import { SettingsSection } from "metabase/admin/components/SettingsSection";
 import { useListPermissionsGroupsQuery } from "metabase/api";
 import { useSetting } from "metabase/common/hooks";
+import { isDefaultGroup } from "metabase/lib/groups";
 import { PLUGIN_TENANTS } from "metabase/plugins";
 import { Tabs } from "metabase/ui";
 import {
@@ -68,6 +69,33 @@ export function GroupLimitsSettingsSection() {
 
   const instanceLimit = instanceLimitData?.max_usage ?? null;
 
+  const allUsersGroup = useMemo(
+    () => userGroups.find((g) => isDefaultGroup(g)),
+    [userGroups],
+  );
+  const allUsersGroupLimit = useMemo(() => {
+    if (!allUsersGroup) {
+      return undefined;
+    }
+    const limitEntry = groupLimits.find((l) => l.group_id === allUsersGroup.id);
+    // No entry means unlimited (null)
+    return limitEntry?.max_usage ?? null;
+  }, [allUsersGroup, groupLimits]);
+
+  const allTenantUsersGroup = useMemo(
+    () => tenantGroups.find((g) => g.magic_group_type === "all-external-users"),
+    [tenantGroups],
+  );
+  const allTenantUsersGroupLimit = useMemo(() => {
+    if (!allTenantUsersGroup) {
+      return undefined;
+    }
+    const limitEntry = groupLimits.find(
+      (l) => l.group_id === allTenantUsersGroup.id,
+    );
+    return limitEntry?.max_usage ?? null;
+  }, [allTenantUsersGroup, groupLimits]);
+
   const commonLimitPeriodProps = {
     instanceLimit,
     limitPeriod,
@@ -85,6 +113,8 @@ export function GroupLimitsSettingsSection() {
           groups={userGroups}
           isLoading={isLoadingUserGroups || isLoadingGroupLimits}
           variant="regular-groups"
+          allUsersGroup={allUsersGroup}
+          allUsersGroupLimit={allUsersGroupLimit}
         />
       </SettingsSection>
     );
@@ -110,6 +140,8 @@ export function GroupLimitsSettingsSection() {
             groups={userGroups}
             isLoading={isLoadingUserGroups || isLoadingGroupLimits}
             variant="regular-groups"
+            allUsersGroup={allUsersGroup}
+            allUsersGroupLimit={allUsersGroupLimit}
           />
         </Tabs.Panel>
 
@@ -121,6 +153,8 @@ export function GroupLimitsSettingsSection() {
             groups={tenantGroups}
             isLoading={isLoadingTenantGroups || isLoadingGroupLimits}
             variant="tenant-groups"
+            allUsersGroup={allTenantUsersGroup}
+            allUsersGroupLimit={allTenantUsersGroupLimit}
           />
         </Tabs.Panel>
 

--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotUsageLimitsPage/GroupLimitsSettingsSection/GroupLimitsTab/GroupLimitsTab.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotUsageLimitsPage/GroupLimitsSettingsSection/GroupLimitsTab/GroupLimitsTab.module.css
@@ -42,3 +42,8 @@
 .LimitInput {
   max-width: 10rem;
 }
+
+.InputWrapper {
+  display: inline-flex;
+  position: relative;
+}

--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotUsageLimitsPage/GroupLimitsSettingsSection/GroupLimitsTab/GroupLimitsTab.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotUsageLimitsPage/GroupLimitsSettingsSection/GroupLimitsTab/GroupLimitsTab.tsx
@@ -4,8 +4,10 @@ import { t } from "ttag";
 import { isEmpty } from "underscore";
 
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
+import { isDefaultGroup } from "metabase/lib/groups";
 import { useMetadataToasts } from "metabase/metadata/hooks";
 import { Box, Stack, Text, TextInput } from "metabase/ui";
+import { AllUsersHigherAccessTooltipIcon } from "metabase-enterprise/ai-controls/components/AllUsersHigherAccessTooltipIcon";
 import { useUpdateAIControlsGroupLimitMutation } from "metabase-enterprise/api";
 import type { GroupInfo } from "metabase-types/api";
 
@@ -31,6 +33,8 @@ export function GroupLimitsTab(props: GroupLimitsTabProps) {
     limitType,
     groupLimits,
     instanceLimit,
+    allUsersGroup,
+    allUsersGroupLimit,
   } = props;
 
   const [updateGroupLimit] = useUpdateAIControlsGroupLimitMutation();
@@ -73,6 +77,30 @@ export function GroupLimitsTab(props: GroupLimitsTabProps) {
     SAVE_DEBOUNCE_MS,
   );
 
+  /**
+   * The "all users" group overrides this group's limit when:
+   * - it exists and this group is not itself the "all users" group
+   * - the "all users" limit is null (unlimited) OR higher than the group's own limit
+   */
+  const isAllUsersGroupOverridingLimit = (group: GroupInfo): boolean => {
+    if (
+      !allUsersGroup ||
+      isDefaultGroup(group) ||
+      group.magic_group_type === "all-external-users" ||
+      allUsersGroupLimit === undefined
+    ) {
+      return false;
+    }
+    const thisGroupLimit = localLimitsMap?.[group.id] ?? null;
+
+    if (thisGroupLimit === null) {
+      // this group is set to unlimited
+      return false;
+    }
+
+    return allUsersGroupLimit === null || allUsersGroupLimit > thisGroupLimit;
+  };
+
   const placeholder =
     instanceLimit != null ? String(instanceLimit) : t`Unlimited`;
 
@@ -103,25 +131,40 @@ export function GroupLimitsTab(props: GroupLimitsTabProps) {
                 </tr>
               </thead>
               <tbody>
-                {groups.map((group) => (
-                  <tr key={group.id} className={S.BodyRow}>
-                    <td className={S.BodyCell}>{group.name}</td>
-                    <td className={S.BodyCell}>
-                      <TextInput
-                        placeholder={placeholder}
-                        value={localLimitsMap?.[group.id] ?? ""}
-                        onChange={(e) => handleChange(group, e.target.value)}
-                        classNames={{ input: S.LimitInput }}
-                        type="number"
-                        min={1}
-                        aria-label={getGroupLimitAriaLabel(
-                          limitType,
-                          group.name,
-                        )}
-                      />
-                    </td>
-                  </tr>
-                ))}
+                {groups.map((group) => {
+                  const showAllUsersOverrideTooltip =
+                    isAllUsersGroupOverridingLimit(group) && !!allUsersGroup;
+
+                  return (
+                    <tr key={group.id} className={S.BodyRow}>
+                      <td className={S.BodyCell}>{group.name}</td>
+                      <td className={S.BodyCell}>
+                        <div className={S.InputWrapper}>
+                          <TextInput
+                            placeholder={placeholder}
+                            value={localLimitsMap?.[group.id] ?? ""}
+                            onChange={(e) =>
+                              handleChange(group, e.target.value)
+                            }
+                            classNames={{ input: S.LimitInput }}
+                            type="number"
+                            min={1}
+                            aria-label={getGroupLimitAriaLabel(
+                              limitType,
+                              group.name,
+                            )}
+                          />
+                          {showAllUsersOverrideTooltip && (
+                            <AllUsersHigherAccessTooltipIcon
+                              groupName={allUsersGroup.name}
+                              variant="group-limits"
+                            />
+                          )}
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
               </tbody>
             </table>
           </Box>

--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotUsageLimitsPage/GroupLimitsSettingsSection/GroupLimitsTab/GroupLimitsTab.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotUsageLimitsPage/GroupLimitsSettingsSection/GroupLimitsTab/GroupLimitsTab.unit.spec.tsx
@@ -1,7 +1,7 @@
 import userEvent from "@testing-library/user-event";
 
 import { setupUpdateAIControlsGroupLimitEndpoint } from "__support__/server-mocks/metabot";
-import { renderWithProviders, screen } from "__support__/ui";
+import { renderWithProviders, screen, within } from "__support__/ui";
 import type {
   GroupInfo,
   MetabotGroupLimit,
@@ -17,8 +17,13 @@ const adminGroup = createMockGroup({
   name: "Administrators",
   magic_group_type: "admin",
 });
-const marketingGroup = createMockGroup({
+const allUsersGroup = createMockGroup({
   id: 2,
+  name: "All Users",
+  magic_group_type: "all-internal-users",
+});
+const marketingGroup = createMockGroup({
+  id: 3,
   name: "Marketing",
   magic_group_type: null,
 });
@@ -33,6 +38,8 @@ type SetupOpts = Partial<{
   variant: "regular-groups" | "tenant-groups";
   hasError: boolean;
   isLoading: boolean;
+  allUsersGroupProp: GroupInfo;
+  allUsersGroupLimit: number | null | undefined;
 }>;
 
 function setup({
@@ -44,6 +51,8 @@ function setup({
   variant = "regular-groups",
   hasError = false,
   isLoading = false,
+  allUsersGroupProp = undefined,
+  allUsersGroupLimit = undefined,
 }: SetupOpts = {}) {
   setupUpdateAIControlsGroupLimitEndpoint();
 
@@ -57,6 +66,8 @@ function setup({
       limitPeriod={limitPeriod}
       limitType={limitType}
       variant={variant}
+      allUsersGroup={allUsersGroupProp}
+      allUsersGroupLimit={allUsersGroupLimit}
     />,
   );
 }
@@ -99,8 +110,8 @@ describe("GroupLimitsTab", () => {
   it("populates inputs from existing group limits", () => {
     setup({
       groupLimits: [
-        { group_id: 1, max_usage: 100 },
-        { group_id: 2, max_usage: 50 },
+        { group_id: adminGroup.id, max_usage: 100 },
+        { group_id: marketingGroup.id, max_usage: 50 },
       ],
     });
 
@@ -152,5 +163,108 @@ describe("GroupLimitsTab", () => {
     setup({ limitPeriod: "weekly", limitType: "tokens" });
 
     expect(screen.getByText(/each week/)).toBeInTheDocument();
+  });
+
+  describe("'All Users' group override warning icons", () => {
+    it("shows info icon next to a group's input when 'All Users' has a higher limit", () => {
+      // All Users limit = 500 (unlimited from perspective of Marketing which has 100)
+      setup({
+        groups: [allUsersGroup, marketingGroup],
+        groupLimits: [
+          { group_id: allUsersGroup.id, max_usage: 500 },
+          { group_id: marketingGroup.id, max_usage: 100 },
+        ],
+        allUsersGroupProp: allUsersGroup,
+        allUsersGroupLimit: 500,
+      });
+
+      const marketingRow = screen.getByRole("row", { name: /Marketing/ });
+      expect(
+        within(marketingRow).getByRole("img", { name: "Group limit warning" }),
+      ).toBeInTheDocument();
+    });
+
+    it("shows info icon when 'All Users' limit is unlimited (null) and group has a limit set", () => {
+      setup({
+        groups: [allUsersGroup, marketingGroup],
+        groupLimits: [{ group_id: marketingGroup.id, max_usage: 100 }],
+        allUsersGroupProp: allUsersGroup,
+        allUsersGroupLimit: null, // unlimited
+      });
+
+      const marketingRow = screen.getByRole("row", { name: /Marketing/ });
+      expect(
+        within(marketingRow).getByRole("img", { name: "Group limit warning" }),
+      ).toBeInTheDocument();
+    });
+
+    it("does not show info icon when group has no limit set (unlimited input)", () => {
+      // Marketing has no limit — no icon, nothing to override
+      setup({
+        groups: [allUsersGroup, marketingGroup],
+        groupLimits: [],
+        allUsersGroupProp: allUsersGroup,
+        allUsersGroupLimit: null,
+      });
+
+      const marketingRow = screen.getByRole("row", { name: /Marketing/ });
+      expect(
+        within(marketingRow).queryByRole("img", {
+          name: "Group limit warning",
+        }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("does not show info icon when 'All Users' limit equals the group's limit", () => {
+      setup({
+        groups: [allUsersGroup, marketingGroup],
+        groupLimits: [
+          { group_id: allUsersGroup.id, max_usage: 100 },
+          { group_id: marketingGroup.id, max_usage: 100 },
+        ],
+        allUsersGroupProp: allUsersGroup,
+        allUsersGroupLimit: 100,
+      });
+
+      const marketingRow = screen.getByRole("row", { name: /Marketing/ });
+      expect(
+        within(marketingRow).queryByRole("img", {
+          name: "Group limit warning",
+        }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("does not show info icon when 'All Users' limit is lower than the group's limit", () => {
+      setup({
+        groups: [allUsersGroup, marketingGroup],
+        groupLimits: [
+          { group_id: allUsersGroup.id, max_usage: 50 },
+          { group_id: marketingGroup.id, max_usage: 100 },
+        ],
+        allUsersGroupProp: allUsersGroup,
+        allUsersGroupLimit: 50,
+      });
+
+      const marketingRow = screen.getByRole("row", { name: /Marketing/ });
+      expect(
+        within(marketingRow).queryByRole("img", {
+          name: "Group limit warning",
+        }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("does not show info icon on the 'All Users' row itself", () => {
+      setup({
+        groups: [allUsersGroup, marketingGroup],
+        groupLimits: [{ group_id: marketingGroup.id, max_usage: 100 }],
+        allUsersGroupProp: allUsersGroup,
+        allUsersGroupLimit: null,
+      });
+
+      const allUsersRow = screen.getByRole("row", { name: /All Users/ });
+      expect(
+        within(allUsersRow).queryByRole("img", { name: "Group limit warning" }),
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotUsageLimitsPage/GroupLimitsSettingsSection/GroupLimitsTab/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotUsageLimitsPage/GroupLimitsSettingsSection/GroupLimitsTab/utils.ts
@@ -17,6 +17,8 @@ export type GroupLimitsTabProps = {
   limitPeriod: MetabotLimitPeriod;
   limitType: MetabotLimitType;
   variant: "regular-groups" | "tenant-groups";
+  allUsersGroup?: GroupInfo;
+  allUsersGroupLimit?: number | null;
 };
 
 export type GroupLimitsMap = Record<number, number | null>;


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/UXW-3562/add-tooltip-explaining-most-permissive-group-access

### Description

Add a tooltip explaining that group limits and group access will be overridden by All users group, similar to data permissions.

### How to verify

1. Go to Admin > AI > Usage Controls > AI feature access
2. Try to restrict tools permissions to a group while keeping the "All users" group with more permissions
  2.1. You should see an info icon with tooltip explaining that the all users group will override that setting
3. You should see a similar behavior on AI usage limits > Group limits section 

### Demo
https://www.loom.com/share/a5a334edf9a5473882f74247eddf933e

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
