### PR TITLE
update release workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ on:
 
 permissions:
   id-token: write
-  contents: read
+  contents: write
   actions: read
   checks: write
 
@@ -453,7 +453,6 @@ jobs:
     needs: add-extra-tags
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 15
-    permissions: write-all
     env:
       AWS_S3_DOWNLOADS_BUCKET: ${{ vars.AWS_S3_DOWNLOADS_BUCKET }}
       DOCKERHUB_OWNER: ${{ vars.DOCKERHUB_OWNER }}

--- a/.github/workflows/tag-for-release.yml
+++ b/.github/workflows/tag-for-release.yml
@@ -18,7 +18,7 @@ on:
 
 permissions:
   id-token: write
-  contents: read
+  contents: write
   actions: read
   checks: write
 


### PR DESCRIPTION
Updates release workflow permissions.

Release notes generation requires contents: write permissions.  Write-all was probably way too permissive for that action step.

https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idpermissions