### PR TITLE
fix breakouts axis split in metrics viewer

### DIFF
--- a/frontend/src/metabase/metrics-viewer/utils/legend.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/legend.ts
@@ -42,11 +42,6 @@ export function buildLegendGroups(
     }
 
     const colors = activeBreakoutColors[entry.id];
-    const color = getSingleColor(colors);
-    if (!color) {
-      continue;
-    }
-
     const definitionName = getDefinitionName(entry.definition);
     const breakoutProjection = getEntryBreakout(entry);
 
@@ -78,7 +73,8 @@ export function buildLegendGroups(
         items,
       });
     } else {
-      if (!definitionName) {
+      const color = getSingleColor(colors);
+      if (!color || !definitionName) {
         continue;
       }
       groups.push({

--- a/frontend/src/metabase/metrics-viewer/utils/series.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/series.ts
@@ -13,11 +13,13 @@ import type {
   Card,
   CardId,
   Dataset,
+  DatasetColumn,
   DatasetData,
   DimensionId,
   MetricBreakoutValuesResponse,
   RowValue,
   RowValues,
+  SeriesSettings,
   SingleSeries,
   VisualizationDisplay,
   VisualizationSettings,
@@ -52,15 +54,17 @@ function getDefinitionCardId(def: MetricDefinition): number | null {
   return null;
 }
 
+interface SourceColorEntry {
+  sourceId: MetricSourceId;
+  keys: string[];
+  keyToBreakoutValue: Record<string, string>;
+}
+
 export function computeSourceBreakoutColors(
   definitions: MetricsViewerDefinitionEntry[],
   breakoutValuesBySourceId?: Map<MetricSourceId, MetricBreakoutValuesResponse>,
 ): SourceBreakoutColorMap {
-  const entries: {
-    sourceId: MetricSourceId;
-    keys: string[];
-    keyToBreakoutValue: Record<string, string>;
-  }[] = [];
+  const entries: SourceColorEntry[] = [];
 
   for (const entry of definitions) {
     if (!entry.definition) {
@@ -130,9 +134,50 @@ export function getSingleColor(
       : undefined;
 }
 
-// Column layout with breakout:
-// - 3 cols when dimension != breakout: [dimension, breakout, metric] → output: [dimension, metric]
-// - 2 cols when dimension == breakout: [breakout, metric] → output: [breakout, metric]
+// Result data columns layout: [dimension, breakout, metric].
+const DIMENSION_COLUMN_INDEX = 0;
+const BREAKOUT_COLUMN_INDEX = 1;
+const METRIC_COLUMN_INDEX = 2;
+
+// When the breakout dimension is the same as the tab's dimension,
+// the query avoids adding it twice, so we get [breakout, metric] instead of [dimension, breakout, metric].
+function getBreakoutColumnDescriptor(cols: DatasetColumn[]): {
+  index: number;
+  column: DatasetColumn;
+} {
+  const breakoutIsSameAsDimension = cols.length === 2;
+  const index = breakoutIsSameAsDimension
+    ? DIMENSION_COLUMN_INDEX
+    : BREAKOUT_COLUMN_INDEX;
+  return { index, column: cols[index] };
+}
+
+function getMetricColumnIndex(cols: DatasetColumn[]): number {
+  const breakoutIsSameAsDimension = cols.length === 2;
+  return breakoutIsSameAsDimension
+    ? BREAKOUT_COLUMN_INDEX
+    : METRIC_COLUMN_INDEX;
+}
+
+function filterBreakoutColorsByData(
+  breakoutColors: BreakoutColorMap,
+  data: DatasetData,
+): BreakoutColorMap {
+  const breakoutCol = data.cols[BREAKOUT_COLUMN_INDEX];
+  const presentValues = new Set(
+    data.rows.map((row) =>
+      formatBreakoutValue(row[BREAKOUT_COLUMN_INDEX], breakoutCol),
+    ),
+  );
+  const filtered: BreakoutColorMap = new Map();
+  for (const [value, color] of breakoutColors) {
+    if (presentValues.has(value)) {
+      filtered.set(value, color);
+    }
+  }
+  return filtered;
+}
+
 export function splitByBreakout(
   series: SingleSeries,
   seriesCount: number,
@@ -145,19 +190,17 @@ export function splitByBreakout(
   const { card, data } = series;
   const { cols } = data;
 
-  const hasSeparateDimension = cols.length === 3;
-  const breakoutColumnIndex = hasSeparateDimension ? 1 : 0;
-  const metricColumnIndex = hasSeparateDimension ? 2 : 1;
-  const breakoutCol = cols[breakoutColumnIndex];
+  const breakout = getBreakoutColumnDescriptor(cols);
+  const metricColumnIndex = getMetricColumnIndex(cols);
   const metricCol = cols[metricColumnIndex];
-  const outputCols = [cols[0], metricCol];
+  const outputCols = [cols[DIMENSION_COLUMN_INDEX], metricCol];
 
   const rowsByBreakoutValue = new Map<RowValue, RowValues[]>();
 
   for (const row of data.rows) {
     const breakoutValue = formatBreakoutValue(
-      row[breakoutColumnIndex],
-      breakoutCol,
+      row[breakout.index],
+      breakout.column,
     );
     let groupedRows = rowsByBreakoutValue.get(breakoutValue);
     if (!groupedRows) {
@@ -170,7 +213,10 @@ export function splitByBreakout(
         };
       }
     }
-    groupedRows.push([row[0], row[metricColumnIndex]] as RowValues);
+    groupedRows.push([
+      row[DIMENSION_COLUMN_INDEX],
+      row[metricColumnIndex],
+    ] as RowValues);
   }
 
   const activeBreakoutColorMap: BreakoutColorMap = new Map();
@@ -186,7 +232,7 @@ export function splitByBreakout(
 
       const name = getBreakoutSeriesName(
         breakoutValue,
-        breakoutCol,
+        breakout.column,
         seriesCount > 1,
         card.name,
       );
@@ -224,52 +270,27 @@ export function buildCartesianVizSettings(
   hasBreakout: boolean,
   hasMultipleCards: boolean,
   cardName: string | null,
-  sourceColors?: string[],
+  breakoutColors?: BreakoutColorMap,
 ): VisualizationSettings {
   const { cols } = data;
-  const metricCol = cols[cols.length - 1];
-
-  const dimensions = [cols[0].name];
+  const dimensions = [cols[DIMENSION_COLUMN_INDEX].name];
   if (hasBreakout) {
-    dimensions.push(cols[1].name);
-  }
-
-  const colorSettings: Record<string, { color: string }> = {};
-
-  if (hasBreakout && sourceColors) {
-    const breakoutColumnIndex = 1;
-    const breakoutCol = cols[breakoutColumnIndex];
-    const seenValues = new Set<RowValue>();
-
-    for (const row of data.rows) {
-      const breakoutValue = row[breakoutColumnIndex];
-      if (seenValues.has(breakoutValue)) {
-        continue;
-      }
-      seenValues.add(breakoutValue);
-
-      const colorIndex = seenValues.size - 1;
-      if (colorIndex < sourceColors.length) {
-        const seriesName = getBreakoutSeriesName(
-          breakoutValue,
-          breakoutCol,
-          hasMultipleCards,
-          cardName,
-        );
-
-        colorSettings[seriesName] = { color: sourceColors[colorIndex] };
-      }
-    }
-  } else if (sourceColors?.[0]) {
-    colorSettings[metricCol.name] = { color: sourceColors[0] };
+    dimensions.push(cols[BREAKOUT_COLUMN_INDEX].name);
   }
 
   return {
     "graph.x_axis.labels_enabled": false,
     "graph.y_axis.labels_enabled": false,
     "graph.dimensions": dimensions,
-    "graph.metrics": [metricCol.name],
-    series_settings: colorSettings,
+    "graph.metrics": [cols[cols.length - 1].name],
+    ...(hasBreakout && breakoutColors
+      ? computeBreakoutColorSettings(
+          breakoutColors,
+          cols[BREAKOUT_COLUMN_INDEX],
+          hasMultipleCards,
+          cardName,
+        )
+      : {}),
   };
 }
 
@@ -365,22 +386,25 @@ export function buildRawSeriesFromDefinitions(
     const colors = sourceBreakoutColors[entry.id];
     const color = getSingleColor(colors);
     const hasBreakout = entryHasBreakout(entry) && result.data.rows.length > 0;
-    const needsManualBreakoutSplit =
-      hasBreakout && !displayType.supportsMultipleSeries;
+    const breakoutIsSameAsDimension =
+      hasBreakout && result.data.cols.length === 2;
+    const nativeBreakout =
+      hasBreakout &&
+      !breakoutIsSameAsDimension &&
+      displayType.supportsMultipleSeries;
+    const needsManualBreakoutSplit = hasBreakout && !nativeBreakout;
 
     let vizSettings: VisualizationSettings;
-    if (hasBreakout && !needsManualBreakoutSplit) {
-      const sourceColors =
-        colors instanceof Map ? Array.from(colors.values()) : undefined;
+    if (nativeBreakout) {
       vizSettings = buildCartesianVizSettings(
         result.data,
         true,
         definitions.length > 1,
         name,
-        sourceColors,
+        colors instanceof Map ? colors : undefined,
       );
     } else {
-      const seriesKey = isFirstSeries ? result.data.cols[1]?.name : name;
+      const seriesKey = isFirstSeries ? result.data.cols[1].name : name;
       vizSettings = {
         ...baseSettings,
         ...computeColorVizSettings({
@@ -412,8 +436,14 @@ export function buildRawSeriesFromDefinitions(
       activeBreakoutColors[entry.id] = activeBreakoutColorMap;
     } else {
       entrySeries = [singleSeries];
-      activeBreakoutColors[entry.id] =
-        hasBreakout && !needsManualBreakoutSplit ? colors : color;
+      if (hasBreakout && !needsManualBreakoutSplit && colors instanceof Map) {
+        activeBreakoutColors[entry.id] = filterBreakoutColorsByData(
+          colors,
+          result.data,
+        );
+      } else {
+        activeBreakoutColors[entry.id] = color;
+      }
     }
     isFirstSeries = false;
 
@@ -433,15 +463,38 @@ export function buildRawSeriesFromDefinitions(
   return { series, cardIdToDefinitionId, activeBreakoutColors };
 }
 
-function computeColorVizSettings({
-  displayType,
-  seriesKey,
-  color,
-}: {
+export function computeBreakoutColorSettings(
+  breakoutColors: BreakoutColorMap,
+  breakoutCol: DatasetColumn,
+  hasMultipleCards: boolean,
+  cardName: string | null,
+): Pick<VisualizationSettings, "series_settings"> {
+  const seriesSettings: Record<string, SeriesSettings> = {};
+  for (const [formattedValue, color] of breakoutColors) {
+    const seriesName = getBreakoutSeriesName(
+      formattedValue,
+      breakoutCol,
+      hasMultipleCards,
+      cardName,
+    );
+    seriesSettings[seriesName] = { color };
+  }
+  return { series_settings: seriesSettings };
+}
+
+interface ColorVizSettingsParams {
   displayType: VisualizationDisplay;
   seriesKey: string;
   color: string | undefined;
-}): Partial<Pick<VisualizationSettings, "series_settings" | "map.colors">> {
+}
+
+export function computeColorVizSettings({
+  displayType,
+  seriesKey,
+  color,
+}: ColorVizSettingsParams): Partial<
+  Pick<VisualizationSettings, "series_settings" | "map.colors">
+> {
   if (color == null) {
     return {};
   }
@@ -449,15 +502,14 @@ function computeColorVizSettings({
     return {
       "map.colors": getColorplethColorScale(color),
     };
-  } else {
-    return {
-      series_settings: {
-        [seriesKey]: {
-          color,
-        },
-      },
-    };
   }
+  return {
+    series_settings: {
+      [seriesKey]: {
+        color,
+      },
+    },
+  };
 }
 
 function computeAvailableOptions(

--- a/frontend/src/metabase/metrics-viewer/utils/series.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/series.ts
@@ -1,10 +1,11 @@
 import type { DimensionOption } from "metabase/common/components/DimensionPill";
-import { NULL_DISPLAY_VALUE } from "metabase/lib/constants";
-import { formatValue } from "metabase/lib/formatting";
-import { isEmpty } from "metabase/lib/validate";
 import type { DimensionItem } from "metabase/metrics-viewer/components/DimensionPillBar";
 import { getColorsForValues } from "metabase/ui/colors/charts";
 import { getColorplethColorScale } from "metabase/visualizations/components/ChoroplethMap";
+import {
+  formatBreakoutValue,
+  getBreakoutSeriesName,
+} from "metabase/visualizations/echarts/cartesian/model/series";
 import { MAX_SERIES } from "metabase/visualizations/lib/utils";
 import type { DimensionMetadata, MetricDefinition } from "metabase-lib/metric";
 import * as LibMetric from "metabase-lib/metric";
@@ -12,7 +13,7 @@ import type {
   Card,
   CardId,
   Dataset,
-  DatasetColumn,
+  DatasetData,
   DimensionId,
   MetricBreakoutValuesResponse,
   RowValue,
@@ -51,14 +52,6 @@ function getDefinitionCardId(def: MetricDefinition): number | null {
   return null;
 }
 
-function formatBreakoutValue(value: RowValue, column: DatasetColumn): string {
-  return String(
-    formatValue(isEmpty(value) ? NULL_DISPLAY_VALUE : value, {
-      column,
-    }),
-  );
-}
-
 export function computeSourceBreakoutColors(
   definitions: MetricsViewerDefinitionEntry[],
   breakoutValuesBySourceId?: Map<MetricSourceId, MetricBreakoutValuesResponse>,
@@ -80,13 +73,16 @@ export function computeSourceBreakoutColors(
 
     const response = breakoutValuesBySourceId?.get(entry.id);
     if (entryHasBreakout(entry) && response && response.values.length > 0) {
-      // getColorsForValues needs unique keys
       const keys: string[] = [];
-      // but we want to return the (possibly non-unique) breakout values to be displayed in the legend
       const keyToBreakoutValue: Record<string, string> = {};
       response.values.forEach((val) => {
         const breakoutValue = formatBreakoutValue(val, response.col);
-        const key = `${displayName}: ${breakoutValue}`;
+        const key = getBreakoutSeriesName(
+          val,
+          response.col,
+          definitions.length > 1,
+          displayName,
+        );
         keys.push(key);
         keyToBreakoutValue[key] = breakoutValue;
       });
@@ -188,9 +184,12 @@ export function splitByBreakout(
 
       activeBreakoutColorMap.set(breakoutValue, color);
 
-      const name = [seriesCount > 1 && card.name, breakoutValue]
-        .filter(Boolean)
-        .join(": ");
+      const name = getBreakoutSeriesName(
+        breakoutValue,
+        breakoutCol,
+        seriesCount > 1,
+        card.name,
+      );
 
       const seriesKey = isFirstSeries ? metricCol?.name : name;
       isFirstSeries = false;
@@ -218,6 +217,60 @@ export function splitByBreakout(
     })
     .filter((s) => s != null);
   return { series: breakoutSeries, activeBreakoutColorMap };
+}
+
+export function buildCartesianVizSettings(
+  data: DatasetData,
+  hasBreakout: boolean,
+  hasMultipleCards: boolean,
+  cardName: string | null,
+  sourceColors?: string[],
+): VisualizationSettings {
+  const { cols } = data;
+  const metricCol = cols[cols.length - 1];
+
+  const dimensions = [cols[0].name];
+  if (hasBreakout) {
+    dimensions.push(cols[1].name);
+  }
+
+  const colorSettings: Record<string, { color: string }> = {};
+
+  if (hasBreakout && sourceColors) {
+    const breakoutColumnIndex = 1;
+    const breakoutCol = cols[breakoutColumnIndex];
+    const seenValues = new Set<RowValue>();
+
+    for (const row of data.rows) {
+      const breakoutValue = row[breakoutColumnIndex];
+      if (seenValues.has(breakoutValue)) {
+        continue;
+      }
+      seenValues.add(breakoutValue);
+
+      const colorIndex = seenValues.size - 1;
+      if (colorIndex < sourceColors.length) {
+        const seriesName = getBreakoutSeriesName(
+          breakoutValue,
+          breakoutCol,
+          hasMultipleCards,
+          cardName,
+        );
+
+        colorSettings[seriesName] = { color: sourceColors[colorIndex] };
+      }
+    }
+  } else if (sourceColors?.[0]) {
+    colorSettings[metricCol.name] = { color: sourceColors[0] };
+  }
+
+  return {
+    "graph.x_axis.labels_enabled": false,
+    "graph.y_axis.labels_enabled": false,
+    "graph.dimensions": dimensions,
+    "graph.metrics": [metricCol.name],
+    series_settings: colorSettings,
+  };
 }
 
 function createSeriesCard(
@@ -309,33 +362,46 @@ export function buildRawSeriesFromDefinitions(
       return [];
     }
 
-    const seriesKey = isFirstSeries ? result.data.cols[1]?.name : name;
-
     const colors = sourceBreakoutColors[entry.id];
     const color = getSingleColor(colors);
+    const hasBreakout = entryHasBreakout(entry) && result.data.rows.length > 0;
+    const needsManualBreakoutSplit =
+      hasBreakout && !displayType.supportsMultipleSeries;
 
-    const singleSeries: SingleSeries = {
-      card: createSeriesCard(cardId, name, display, {
+    let vizSettings: VisualizationSettings;
+    if (hasBreakout && !needsManualBreakoutSplit) {
+      const sourceColors =
+        colors instanceof Map ? Array.from(colors.values()) : undefined;
+      vizSettings = buildCartesianVizSettings(
+        result.data,
+        true,
+        definitions.length > 1,
+        name,
+        sourceColors,
+      );
+    } else {
+      const seriesKey = isFirstSeries ? result.data.cols[1]?.name : name;
+      vizSettings = {
         ...baseSettings,
         ...computeColorVizSettings({
           displayType: display,
           seriesKey,
           color,
         }),
-        ...extraVizSettings,
-      }),
+      };
+    }
+
+    if (extraVizSettings) {
+      vizSettings = { ...vizSettings, ...extraVizSettings };
+    }
+
+    const singleSeries: SingleSeries = {
+      card: createSeriesCard(cardId, name, display, vizSettings),
       data: result.data,
     };
 
     let entrySeries: SingleSeries[];
-    if (
-      !entryHasBreakout(entry) ||
-      singleSeries.data.rows.length === 0 ||
-      !(colors instanceof Map)
-    ) {
-      entrySeries = [singleSeries];
-      activeBreakoutColors[entry.id] = color;
-    } else {
+    if (needsManualBreakoutSplit && colors instanceof Map) {
       const { series, activeBreakoutColorMap } = splitByBreakout(
         singleSeries,
         definitions.length,
@@ -344,6 +410,10 @@ export function buildRawSeriesFromDefinitions(
       );
       entrySeries = series;
       activeBreakoutColors[entry.id] = activeBreakoutColorMap;
+    } else {
+      entrySeries = [singleSeries];
+      activeBreakoutColors[entry.id] =
+        hasBreakout && !needsManualBreakoutSplit ? colors : color;
     }
     isFirstSeries = false;
 

--- a/frontend/src/metabase/metrics-viewer/utils/series.unit.spec.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/series.unit.spec.ts
@@ -20,6 +20,8 @@ import {
 } from "./__tests__/test-helpers";
 import {
   buildCartesianVizSettings,
+  computeBreakoutColorSettings,
+  computeColorVizSettings,
   computeSourceBreakoutColors,
   getSelectedMetricsInfo,
   splitByBreakout,
@@ -423,7 +425,7 @@ describe("buildCartesianVizSettings", () => {
       ],
     });
 
-    it("sets single dimension and metric", () => {
+    it("sets single dimension and metric from data columns", () => {
       const result = buildCartesianVizSettings(data, false, false, "Revenue");
 
       expect(result["graph.dimensions"]).toEqual(["CREATED_AT"]);
@@ -435,16 +437,6 @@ describe("buildCartesianVizSettings", () => {
 
       expect(result["graph.x_axis.labels_enabled"]).toBe(false);
       expect(result["graph.y_axis.labels_enabled"]).toBe(false);
-    });
-
-    it("sets color keyed by metric column name", () => {
-      const result = buildCartesianVizSettings(data, false, false, "Revenue", [
-        "#509EE3",
-      ]);
-
-      expect(result.series_settings).toEqual({
-        COUNT: { color: "#509EE3" },
-      });
     });
   });
 
@@ -459,18 +451,21 @@ describe("buildCartesianVizSettings", () => {
       ],
     });
 
-    it("sets both dimension and breakout columns in graph.dimensions", () => {
+    it("includes breakout column in graph.dimensions", () => {
       const result = buildCartesianVizSettings(data, true, false, "Revenue");
 
       expect(result["graph.dimensions"]).toEqual(["CREATED_AT", "CATEGORY"]);
       expect(result["graph.metrics"]).toEqual(["COUNT"]);
     });
 
-    it("sets series_settings colors keyed by formatted breakout values", () => {
-      const result = buildCartesianVizSettings(data, true, false, "Revenue", [
-        "#509EE3",
-        "#88BF4D",
-      ]);
+    it("sets series_settings colors from breakout color map", () => {
+      const result = buildCartesianVizSettings(
+        data,
+        true,
+        false,
+        "Revenue",
+        makeColorMap(["Gadgets", "Widgets"]),
+      );
 
       expect(result.series_settings).toEqual({
         Gadgets: { color: "#509EE3" },
@@ -479,16 +474,115 @@ describe("buildCartesianVizSettings", () => {
     });
 
     it("prefixes color keys with card name when hasMultipleCards is true", () => {
-      const result = buildCartesianVizSettings(data, true, true, "Revenue", [
-        "#509EE3",
-        "#88BF4D",
-      ]);
+      const result = buildCartesianVizSettings(
+        data,
+        true,
+        true,
+        "Revenue",
+        makeColorMap(["Gadgets", "Widgets"]),
+      );
 
       expect(result.series_settings).toEqual({
         "Revenue: Gadgets": { color: "#509EE3" },
         "Revenue: Widgets": { color: "#88BF4D" },
       });
     });
+
+    it("preserves breakout colors regardless of data row order", () => {
+      const reorderedData = createMockDatasetData({
+        cols: [dimensionCol, breakoutCol, metricCol],
+        rows: [
+          ["2024-01", "Widgets", 20],
+          ["2024-01", "Gadgets", 10],
+        ],
+      });
+
+      const result = buildCartesianVizSettings(
+        reorderedData,
+        true,
+        false,
+        "Revenue",
+        makeColorMap(["Gadgets", "Widgets"]),
+      );
+
+      expect(result.series_settings).toEqual({
+        Gadgets: { color: "#509EE3" },
+        Widgets: { color: "#88BF4D" },
+      });
+    });
+  });
+});
+
+describe("computeBreakoutColorSettings", () => {
+  it("maps breakout values to series_settings keyed by formatted name", () => {
+    const colorMap = makeColorMap(["Gadgets", "Widgets"]);
+    const result = computeBreakoutColorSettings(
+      colorMap,
+      breakoutCol,
+      false,
+      "Revenue",
+    );
+
+    expect(result).toEqual({
+      series_settings: {
+        Gadgets: { color: "#509EE3" },
+        Widgets: { color: "#88BF4D" },
+      },
+    });
+  });
+
+  it("prefixes series names with card name when hasMultipleCards is true", () => {
+    const colorMap = makeColorMap(["Gadgets", "Widgets"]);
+    const result = computeBreakoutColorSettings(
+      colorMap,
+      breakoutCol,
+      true,
+      "Revenue",
+    );
+
+    expect(result).toEqual({
+      series_settings: {
+        "Revenue: Gadgets": { color: "#509EE3" },
+        "Revenue: Widgets": { color: "#88BF4D" },
+      },
+    });
+  });
+});
+
+describe("computeColorVizSettings", () => {
+  it("returns empty object when color is undefined", () => {
+    expect(
+      computeColorVizSettings({
+        displayType: "line",
+        seriesKey: "COUNT",
+        color: undefined,
+      }),
+    ).toEqual({});
+  });
+
+  it("returns series_settings for non-map display types", () => {
+    expect(
+      computeColorVizSettings({
+        displayType: "line",
+        seriesKey: "COUNT",
+        color: "#509EE3",
+      }),
+    ).toEqual({
+      series_settings: {
+        COUNT: { color: "#509EE3" },
+      },
+    });
+  });
+
+  it("returns map.colors for map display type", () => {
+    const result = computeColorVizSettings({
+      displayType: "map",
+      seriesKey: "COUNT",
+      color: "#509EE3",
+    });
+
+    expect(result).toHaveProperty(["map.colors"]);
+    expect(result).not.toHaveProperty("series_settings");
   });
 });
 

--- a/frontend/src/metabase/metrics-viewer/utils/series.unit.spec.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/series.unit.spec.ts
@@ -3,6 +3,7 @@ import type {
   RowValues,
 } from "metabase-types/api";
 import { createMockColumn } from "metabase-types/api/mocks";
+import { createMockDatasetData } from "metabase-types/api/mocks/dataset";
 import { ORDERS_ID } from "metabase-types/api/mocks/presets";
 import { createMockSingleSeries } from "metabase-types/api/mocks/series";
 
@@ -18,6 +19,7 @@ import {
   setupMeasureDefinition,
 } from "./__tests__/test-helpers";
 import {
+  buildCartesianVizSettings,
   computeSourceBreakoutColors,
   getSelectedMetricsInfo,
   splitByBreakout,
@@ -408,6 +410,85 @@ describe("computeSourceBreakoutColors", () => {
     );
 
     expect(typeof result["metric:1"]).toBe("string");
+  });
+});
+
+describe("buildCartesianVizSettings", () => {
+  describe("without breakout", () => {
+    const data = createMockDatasetData({
+      cols: [dimensionCol, metricCol],
+      rows: [
+        ["2024-01", 10],
+        ["2024-02", 20],
+      ],
+    });
+
+    it("sets single dimension and metric", () => {
+      const result = buildCartesianVizSettings(data, false, false, "Revenue");
+
+      expect(result["graph.dimensions"]).toEqual(["CREATED_AT"]);
+      expect(result["graph.metrics"]).toEqual(["COUNT"]);
+    });
+
+    it("disables axis labels", () => {
+      const result = buildCartesianVizSettings(data, false, false, "Revenue");
+
+      expect(result["graph.x_axis.labels_enabled"]).toBe(false);
+      expect(result["graph.y_axis.labels_enabled"]).toBe(false);
+    });
+
+    it("sets color keyed by metric column name", () => {
+      const result = buildCartesianVizSettings(data, false, false, "Revenue", [
+        "#509EE3",
+      ]);
+
+      expect(result.series_settings).toEqual({
+        COUNT: { color: "#509EE3" },
+      });
+    });
+  });
+
+  describe("with breakout", () => {
+    const data = createMockDatasetData({
+      cols: [dimensionCol, breakoutCol, metricCol],
+      rows: [
+        ["2024-01", "Gadgets", 10],
+        ["2024-01", "Widgets", 20],
+        ["2024-02", "Gadgets", 30],
+        ["2024-02", "Widgets", 40],
+      ],
+    });
+
+    it("sets both dimension and breakout columns in graph.dimensions", () => {
+      const result = buildCartesianVizSettings(data, true, false, "Revenue");
+
+      expect(result["graph.dimensions"]).toEqual(["CREATED_AT", "CATEGORY"]);
+      expect(result["graph.metrics"]).toEqual(["COUNT"]);
+    });
+
+    it("sets series_settings colors keyed by formatted breakout values", () => {
+      const result = buildCartesianVizSettings(data, true, false, "Revenue", [
+        "#509EE3",
+        "#88BF4D",
+      ]);
+
+      expect(result.series_settings).toEqual({
+        Gadgets: { color: "#509EE3" },
+        Widgets: { color: "#88BF4D" },
+      });
+    });
+
+    it("prefixes color keys with card name when hasMultipleCards is true", () => {
+      const result = buildCartesianVizSettings(data, true, true, "Revenue", [
+        "#509EE3",
+        "#88BF4D",
+      ]);
+
+      expect(result.series_settings).toEqual({
+        "Revenue: Gadgets": { color: "#509EE3" },
+        "Revenue: Widgets": { color: "#88BF4D" },
+      });
+    });
   });
 });
 

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/series.ts
@@ -2,6 +2,7 @@ import { memoize } from "metabase/common/hooks/use-memoized-callback";
 import { NULL_DISPLAY_VALUE } from "metabase/lib/constants";
 import { formatValue } from "metabase/lib/formatting";
 import type { OptionsType } from "metabase/lib/formatting/types";
+import { isEmpty } from "metabase/lib/validate";
 import { getDatasetKey } from "metabase/visualizations/echarts/cartesian/model/dataset";
 import type {
   ChartDataset,
@@ -77,6 +78,29 @@ export const getSeriesVizSettingsKey = (
     breakoutName ?? (hasMultipleCards ? column.display_name : column.name);
 
   return prefix + columnNameOrFormattedBreakoutValue;
+};
+
+export const formatBreakoutValue = (
+  value: RowValue,
+  column: DatasetColumn,
+): string => {
+  return String(
+    formatValue(isEmpty(value) ? NULL_DISPLAY_VALUE : value, { column }),
+  );
+};
+
+export const getBreakoutSeriesName = (
+  breakoutValue: RowValue,
+  breakoutColumn: DatasetColumn,
+  hasMultipleCards: boolean,
+  cardName?: string | null,
+): string => {
+  return [
+    hasMultipleCards && cardName,
+    formatBreakoutValue(breakoutValue, breakoutColumn),
+  ]
+    .filter(Boolean)
+    .join(": ");
 };
 
 // HACK: creates a pseudo legacy series object to integrate with the `series` function in computed settings.
@@ -246,14 +270,10 @@ export const getCardSeriesModels = (
   return breakoutValues.map((breakoutValue) => {
     // Unfortunately, breakout series include formatted breakout values in the key
     // which can be different based on a user's locale.
-    const formattedBreakoutValue =
-      breakoutValue != null && breakoutValue !== ""
-        ? String(
-            formatValue(breakoutValue, {
-              column: breakout.column,
-            }),
-          )
-        : NULL_DISPLAY_VALUE;
+    const formattedBreakoutValue = formatBreakoutValue(
+      breakoutValue,
+      breakout.column,
+    );
 
     const displayValue = breakoutDisplayValueMap.get(breakoutValue);
     const formattedDisplayValue =

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/chart-definition-legacy.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/chart-definition-legacy.ts
@@ -1,8 +1,6 @@
 import _ from "underscore";
 
-import { NULL_DISPLAY_VALUE } from "metabase/lib/constants";
-import { formatValue } from "metabase/lib/formatting";
-import { isEmpty } from "metabase/lib/validate";
+import { getBreakoutSeriesName } from "metabase/visualizations/echarts/cartesian/model/series";
 import { getComputedSettingsForSeries } from "metabase/visualizations/lib/settings/visualization";
 import { MAX_SERIES } from "metabase/visualizations/lib/utils";
 import type {
@@ -107,17 +105,12 @@ function transformSingleSeries(
       card: {
         ...card,
         // if multiseries include the card title as well as the breakout value
-        name: [
-          // show series title if it's multiseries
-          series.length > 1 && card.name,
-          // always show grouping value
-          formatValue(
-            isEmpty(breakoutValue) ? NULL_DISPLAY_VALUE : breakoutValue,
-            { column: cols[seriesColumnIndex] },
-          ),
-        ]
-          .filter((n) => n)
-          .join(": "),
+        name: getBreakoutSeriesName(
+          breakoutValue,
+          cols[seriesColumnIndex],
+          series.length > 1,
+          card.name,
+        ),
         originalCardName: card.name,
         _breakoutValue: breakoutValue,
         _breakoutColumn: cols[seriesColumnIndex],


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/UXW-3544/breakouts-can-show-inconsistent-y-axis-ranges

### Description

Fixes Y-axis split in the metrics viewer works differently than in all other places when a metric has a breakout. The difference was caused by splitting a broken out metric into multiple datasets that have different cardId which makes it behave differently from built-in breakout of the cartesian chart. We still need to perform manual dataset split for maps.

### Demo

Before (splits breakout series into two axes)
<img width="1728" height="983" alt="Screenshot 2026-04-07 at 8 23 08 PM" src="https://github.com/user-attachments/assets/b63f2915-039e-4035-b7d9-c90b14b1af39" />

After (no splitting)
<img width="1706" height="982" alt="Screenshot 2026-04-07 at 8 22 32 PM" src="https://github.com/user-attachments/assets/391b34ab-3621-4ad2-bacb-6cf24b945a91" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [n/a] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
