### PR TITLE
Rename "New exploration" to "New question" in <metabase-browser>

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/metabase-browser.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/metabase-browser.cy.spec.ts
@@ -47,12 +47,12 @@ describe("scenarios > embedding > sdk iframe embedding > metabase-browser", () =
           cy.findByText("You don't have access to this collection").should(
             "be.visible",
           );
-          cy.findByText("New exploration").should("not.exist");
+          cy.findByText("New question").should("not.exist");
         });
       });
     });
 
-    it("should not show New exploration button when user has no curate permissions on initial-collection", () => {
+    it("should not show New question button when user has no curate permissions on initial-collection", () => {
       H.prepareSdkIframeEmbedTest({
         withToken: "bleeding-edge",
         signOut: false,
@@ -87,8 +87,8 @@ describe("scenarios > embedding > sdk iframe embedding > metabase-browser", () =
           // User can see the collection contents (they have read access)
           cy.findByText("Test Question").should("be.visible");
 
-          // But New exploration button should be hidden since they can't save
-          cy.findByText("New exploration").should("not.exist");
+          // But New question button should be hidden since they can't save
+          cy.findByText("New question").should("not.exist");
         });
       });
     });
@@ -147,7 +147,7 @@ describe("scenarios > embedding > sdk iframe embedding > metabase-browser", () =
     });
   });
 
-  it("should reset `Exploration` editor state when clicking 'new exploration' breadcrumb after selecting a filter", () => {
+  it("should reset `New question` editor state when clicking 'New question' breadcrumb after selecting a filter", () => {
     H.prepareSdkIframeEmbedTest({
       withToken: "bleeding-edge",
       signOut: false,
@@ -161,7 +161,7 @@ describe("scenarios > embedding > sdk iframe embedding > metabase-browser", () =
       `);
 
     H.getSimpleEmbedIframeContent().within(() => {
-      cy.findByText("New exploration").click();
+      cy.findByText("New question").click();
 
       cy.findByText("Pick your starting data").should("be.visible");
 
@@ -175,7 +175,7 @@ describe("scenarios > embedding > sdk iframe embedding > metabase-browser", () =
       cy.wait("@datasetMetadata");
       cy.findByTestId("data-step-cell").should("have.text", "Orders");
 
-      cy.findByTestId("sdk-breadcrumbs").findByText("New exploration").click();
+      cy.findByTestId("sdk-breadcrumbs").findByText("New question").click();
 
       cy.findByText("Pick your starting data").should("be.visible");
       cy.findByText("Orders").should("not.exist");

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/view-and-curate-content.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/view-and-curate-content.cy.spec.ts
@@ -43,11 +43,11 @@ describe("scenarios > embedding > sdk iframe embedding > view and curate content
         .should("be.visible");
     });
 
-    it("should show New Exploration button and open data picker when clicked", () => {
+    it("should show New Question button and open data picker when clicked", () => {
       setupEmbed('<metabase-browser initial-collection="root" />');
 
       H.getSimpleEmbedIframeContent()
-        .findByText("New exploration")
+        .findByText("New question")
         .should("be.visible")
         .click();
 
@@ -84,7 +84,7 @@ describe("scenarios > embedding > sdk iframe embedding > view and curate content
         .should("have.length", 5);
     });
 
-    it("should hide New Exploration button when with-new-question is false", () => {
+    it("should hide New Question button when with-new-question is false", () => {
       setupEmbed(`
         <metabase-browser
           initial-collection="root"
@@ -93,7 +93,7 @@ describe("scenarios > embedding > sdk iframe embedding > view and curate content
       `);
 
       H.getSimpleEmbedIframeContent()
-        .findByText("New exploration")
+        .findByText("New question")
         .should("not.exist");
     });
   });
@@ -158,13 +158,13 @@ describe("scenarios > embedding > sdk iframe embedding > view and curate content
         .should("be.visible");
     });
 
-    it("should show New Exploration button and open data picker when clicked", () => {
+    it("should show New Question button and open data picker when clicked", () => {
       setupEmbed(
         '<metabase-browser initial-collection="root" read-only="false" />',
       );
 
       H.getSimpleEmbedIframeContent()
-        .findByText("New exploration")
+        .findByText("New question")
         .should("be.visible")
         .click();
 
@@ -179,7 +179,7 @@ describe("scenarios > embedding > sdk iframe embedding > view and curate content
         '<metabase-browser initial-collection="root" read-only="false" />',
       );
 
-      H.getSimpleEmbedIframeContent().findByText("New exploration").click();
+      H.getSimpleEmbedIframeContent().findByText("New question").click();
 
       cy.log("select data model");
       H.getSimpleEmbedIframeContent().findByText("Orders").click();
@@ -280,7 +280,7 @@ describe("scenarios > embedding > sdk iframe embedding > view and curate content
         .should("be.visible");
     });
 
-    it("should hide New Exploration button when with-new-question is false", () => {
+    it("should hide New Question button when with-new-question is false", () => {
       setupEmbed(`
         <metabase-browser
           initial-collection="root"
@@ -290,7 +290,7 @@ describe("scenarios > embedding > sdk iframe embedding > view and curate content
       `);
 
       H.getSimpleEmbedIframeContent()
-        .findByText("New exploration")
+        .findByText("New question")
         .should("not.exist");
     });
 
@@ -303,7 +303,7 @@ describe("scenarios > embedding > sdk iframe embedding > view and curate content
         />
       `);
 
-      H.getSimpleEmbedIframeContent().findByText("New exploration").click();
+      H.getSimpleEmbedIframeContent().findByText("New question").click();
 
       cy.log("should show data picker with limited entity types");
       H.getSimpleEmbedIframeContent()

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestionDefaultView/SdkQuestionDefaultView.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestionDefaultView/SdkQuestionDefaultView.tsx
@@ -133,7 +133,7 @@ export const SdkQuestionDefaultView = ({
       reportLocation({
         type: "question",
         id: originalId,
-        name: "New exploration",
+        name: "New question",
         onNavigate,
       });
     } else if (isExistingQuestion) {

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/components/MetabaseBrowser.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/components/MetabaseBrowser.tsx
@@ -31,7 +31,7 @@ type MetabaseBrowserView =
   | { type: "collection"; id: SdkCollectionId }
   | { type: "dashboard"; id: number | string }
   | { type: "question" | "metric" | "model"; id: number | string }
-  | { type: "exploration" }
+  | { type: "new-question" }
   | { type: "create-dashboard" };
 
 const BREADCRUMB_HEIGHT = "3.5rem";
@@ -81,7 +81,7 @@ export function MetabaseBrowser({ settings }: MetabaseBrowserProps) {
   const viewContent = hasNavigatedAway
     ? null
     : match(currentView)
-        .with({ type: "exploration" }, () => (
+        .with({ type: "new-question" }, () => (
           <Box px="xl" h="100%">
             <InteractiveQuestion
               questionId="new"
@@ -198,12 +198,12 @@ export function MetabaseBrowser({ settings }: MetabaseBrowserProps) {
         ))
         .otherwise(() => null);
 
-  const handleNewExploration = () => {
-    setCurrentView({ type: "exploration" });
+  const handleNewQuestion = () => {
+    setCurrentView({ type: "new-question" });
   };
 
-  // Only show "New exploration" button if user has write access and it's enabled
-  const showNewExplorationButton =
+  // Only show "New question" button if user has write access and it's enabled
+  const showNewQuestionButton =
     (settings.withNewQuestion ?? true) && canWriteToInitialCollection;
 
   // Only show "New dashboard" button if not read-only and user has write access
@@ -244,9 +244,9 @@ export function MetabaseBrowser({ settings }: MetabaseBrowserProps) {
 
           {currentView.type === "collection" && (
             <Group gap="sm">
-              {showNewExplorationButton && (
-                <Button justify="center" onClick={handleNewExploration}>
-                  {t`New exploration`}
+              {showNewQuestionButton && (
+                <Button justify="center" onClick={handleNewQuestion}>
+                  {t`New question`}
                 </Button>
               )}
 

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/types/embed.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/types/embed.ts
@@ -174,7 +174,7 @@ export interface BrowserEmbedOptions {
   /** Which entities to show on the question's data picker */
   dataPickerEntityTypes?: EmbeddingEntityType[];
 
-  /** Whether to show the "New exploration" button. Defaults to true. */
+  /** Whether to show the "New question" button. Defaults to true. */
   withNewQuestion?: boolean;
 
   /** Whether to show the "New dashboard" button. Defaults to true. Only applies when readOnly is false. */

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/types/modular-embedding.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/types/modular-embedding.ts
@@ -262,7 +262,7 @@ export interface MetabaseBrowserAttributes {
   "data-picker-entity-types"?: ("model" | "table")[];
 
   /**
-   * Whether to show the "New exploration" button.
+   * Whether to show the "New question" button.
    *
    * @defaultValue true
    */


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #71612
Closes [EMB-1513: Inconsistent terminology between "exploration" and "question" in embedded experience](https://linear.app/metabase/issue/EMB-1513/inconsistent-terminology-between-exploration-and-question-in-embedded)

### Description

Rename "New exploration" to "New question" in embedding UI

Before:
<img width="1614" height="681" alt="image" src="https://github.com/user-attachments/assets/b444911f-3bdb-4b4b-8f71-d704d045cc0f" />


After:
<img width="1617" height="682" alt="SCR-20260408-hncp-2" src="https://github.com/user-attachments/assets/abee86c5-da25-4910-8868-9c44071357f3" />
