### PR TITLE
Fix race condition in test and reset mocks

### DIFF
--- a/frontend/src/metabase/dashboard/actions/cards.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/actions/cards.unit.spec.ts
@@ -232,6 +232,10 @@ describe("dashboard/actions/cards", () => {
   });
 
   describe("replaceCard", () => {
+    beforeEach(() => {
+      jest.restoreAllMocks();
+    });
+
     it("should correctly update the dashcard", async () => {
       const { nextDashCard } = await runReplaceCardAction({
         dashcardId: TABLE_DASHCARD.id,
@@ -333,11 +337,11 @@ async function runReplaceCardAction({
 }: RunReplaceCardOpts) {
   const { store } = setup(opts);
 
-  await replaceCard({ dashcardId, nextCardId })(store.dispatch, store.getState);
-  const nextState = store.getState();
-
   const dispatchSpy = jest.spyOn(store, "dispatch");
   const cardQueryEndpointSpy = jest.spyOn(CardApi, "query");
+
+  await replaceCard({ dashcardId, nextCardId })(store.dispatch, store.getState);
+  const nextState = store.getState();
 
   return {
     nextDashCard: getDashCardById(nextState, dashcardId),


### PR DESCRIPTION
Fixes a race condition in test that was hidden due to dirty mock state.

On `master`, the test suite in `frontend/src/metabase/dashboard/actions/cards.unit.spec.ts` works when running as a whole, but the test `should run a new card query` breaks when run in isolation.

This PR: 
- makes it so that tests run independently by resetting mock
- fixes the test by setting up mocks _before_ calling them 

