### PR TITLE
GDGT-1552 feat: i18n workspace permission error msgs

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -23,7 +23,7 @@
    [metabase.driver.util :as driver.u]
    [metabase.util :as u]
    [metabase.util.date-2 :as u.date]
-   [metabase.util.i18n :refer [tru]]
+   [metabase.util.i18n :refer [deferred-tru tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.performance :refer [mapv some empty? not-empty]]
@@ -1457,20 +1457,20 @@
       (let [init-result (try
                           (driver/init-workspace-isolation! driver database test-workspace)
                           (catch Exception e
-                            (throw (ex-info (format "Failed to initialize workspace isolation: %s" (ex-message e))
+                            (throw (ex-info (str (deferred-tru "Failed to initialize workspace isolation: {0}" (ex-message e)))
                                             {:step :init} e))))
             workspace-with-details (merge test-workspace init-result)]
         (when test-table
           (try
             (driver/grant-workspace-read-access! driver database workspace-with-details [test-table])
             (catch Exception e
-              (throw (ex-info (format "Failed to grant read access to table %s.%s: %s"
-                                      (:schema test-table) (:name test-table) (ex-message e))
+              (throw (ex-info (str (deferred-tru "Failed to grant read access to table {0}.{1}: {2}"
+                                                 (:schema test-table) (:name test-table) (ex-message e)))
                               {:step :grant :table test-table} e)))))
         (try
           (driver/destroy-workspace-isolation! driver database workspace-with-details)
           (catch Exception e
-            (throw (ex-info (format "Failed to destroy workspace isolation: %s" (ex-message e))
+            (throw (ex-info (str (deferred-tru "Failed to destroy workspace isolation: {0}" (ex-message e)))
                             {:step :destroy} e)))))
       nil
       (catch Exception e

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -23,7 +23,7 @@
    [metabase.driver.util :as driver.u]
    [metabase.util :as u]
    [metabase.util.date-2 :as u.date]
-   [metabase.util.i18n :refer [deferred-tru tru]]
+   [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.performance :refer [mapv some empty? not-empty]]
@@ -1457,20 +1457,20 @@
       (let [init-result (try
                           (driver/init-workspace-isolation! driver database test-workspace)
                           (catch Exception e
-                            (throw (ex-info (str (deferred-tru "Failed to initialize workspace isolation: {0}" (ex-message e)))
+                            (throw (ex-info (tru "Failed to initialize workspace isolation: {0}" (ex-message e))
                                             {:step :init} e))))
             workspace-with-details (merge test-workspace init-result)]
         (when test-table
           (try
             (driver/grant-workspace-read-access! driver database workspace-with-details [test-table])
             (catch Exception e
-              (throw (ex-info (str (deferred-tru "Failed to grant read access to table {0}.{1}: {2}"
-                                                 (:schema test-table) (:name test-table) (ex-message e)))
+              (throw (ex-info (tru "Failed to grant read access to table {0}.{1}: {2}"
+                                   (:schema test-table) (:name test-table) (ex-message e))
                               {:step :grant :table test-table} e)))))
         (try
           (driver/destroy-workspace-isolation! driver database workspace-with-details)
           (catch Exception e
-            (throw (ex-info (str (deferred-tru "Failed to destroy workspace isolation: {0}" (ex-message e)))
+            (throw (ex-info (tru "Failed to destroy workspace isolation: {0}" (ex-message e))
                             {:step :destroy} e)))))
       nil
       (catch Exception e

--- a/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
+++ b/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
@@ -20,7 +20,7 @@
    [metabase.driver.sql.util :as sql.u]
    [metabase.driver.util :as driver.u]
    [metabase.util :as u]
-   [metabase.util.i18n :refer [deferred-tru]]
+   [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
    [metabase.util.performance :refer [not-empty]])
   (:import
@@ -398,7 +398,7 @@
                                  (sql.u/quote-name :clickhouse :table (:name table))
                                  qu))]
     (when-not read-user-name
-      (throw (ex-info (str (deferred-tru "Workspace isolation is not properly initialized - missing read user name"))
+      (throw (ex-info (tru "Workspace isolation is not properly initialized - missing read user name")
                       {:workspace-id (:id workspace) :step :grant})))
     (jdbc/with-db-transaction [t-conn (sql-jdbc.conn/db->pooled-connection-spec (:id database))]
       (with-open [stmt (.createStatement ^Connection (:connection t-conn))]

--- a/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
+++ b/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
@@ -20,6 +20,7 @@
    [metabase.driver.sql.util :as sql.u]
    [metabase.driver.util :as driver.u]
    [metabase.util :as u]
+   [metabase.util.i18n :refer [deferred-tru]]
    [metabase.util.log :as log]
    [metabase.util.performance :refer [not-empty]])
   (:import
@@ -397,7 +398,7 @@
                                  (sql.u/quote-name :clickhouse :table (:name table))
                                  qu))]
     (when-not read-user-name
-      (throw (ex-info "Workspace isolation is not properly initialized - missing read user name"
+      (throw (ex-info (str (deferred-tru "Workspace isolation is not properly initialized - missing read user name"))
                       {:workspace-id (:id workspace) :step :grant})))
     (jdbc/with-db-transaction [t-conn (sql-jdbc.conn/db->pooled-connection-spec (:id database))]
       (with-open [stmt (.createStatement ^Connection (:connection t-conn))]

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -32,7 +32,7 @@
    [metabase.util :as u]
    [metabase.util.date-2 :as u.date]
    [metabase.util.honey-sql-2 :as h2x]
-   [metabase.util.i18n :refer [tru]]
+   [metabase.util.i18n :refer [deferred-tru tru]]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
@@ -1061,10 +1061,10 @@
                      :password (driver.u/random-workspace-password)}
         conn-spec   (sql-jdbc.conn/db->pooled-connection-spec (:id database))]
     (when-not db-name
-      (throw (ex-info "Snowflake database configuration is missing required 'db' (database name) setting"
+      (throw (ex-info (str (deferred-tru "Snowflake database configuration is missing required ''db'' (database name) setting"))
                       {:database-id (:id database) :step :init})))
     (when-not warehouse
-      (throw (ex-info "Snowflake database configuration is missing required 'warehouse' setting"
+      (throw (ex-info (str (deferred-tru "Snowflake database configuration is missing required ''warehouse'' setting"))
                       {:database-id (:id database) :step :init})))
     ;; Snowflake RBAC: create schema -> create role -> grant privileges to role -> create user -> grant role to user
     (doseq [sql [(format "CREATE SCHEMA IF NOT EXISTS \"%s\".\"%s\"" db-name schema-name)
@@ -1090,7 +1090,7 @@
         username    (driver.u/workspace-isolation-user-name workspace)
         conn-spec   (sql-jdbc.conn/db->pooled-connection-spec (:id database))]
     (when-not db-name
-      (throw (ex-info "Snowflake database configuration is missing required 'db' (database name) setting"
+      (throw (ex-info (str (deferred-tru "Snowflake database configuration is missing required ''db'' (database name) setting"))
                       {:database-id (:id database) :step :destroy})))
     ;; Drop in reverse order of creation: schema (CASCADE handles tables) -> user -> role
     (doseq [sql [(format "DROP SCHEMA IF EXISTS \"%s\".\"%s\" CASCADE" db-name schema-name)
@@ -1104,10 +1104,10 @@
         db-name   (:db (driver.conn/effective-details database))
         role-name (-> workspace :database_details :role)]
     (when-not db-name
-      (throw (ex-info "Snowflake database configuration is missing required 'db' (database name) setting"
+      (throw (ex-info (str (deferred-tru "Snowflake database configuration is missing required ''db'' (database name) setting"))
                       {:database-id (:id database) :step :grant})))
     (when-not role-name
-      (throw (ex-info "Workspace isolation is not properly initialized - missing role name"
+      (throw (ex-info (str (deferred-tru "Workspace isolation is not properly initialized - missing role name"))
                       {:workspace-id (:id workspace) :step :grant})))
     (let [qdb (sql.u/quote-name :snowflake :schema db-name)
           qr  (sql.u/quote-name :snowflake :field role-name)]

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -32,7 +32,7 @@
    [metabase.util :as u]
    [metabase.util.date-2 :as u.date]
    [metabase.util.honey-sql-2 :as h2x]
-   [metabase.util.i18n :refer [deferred-tru tru]]
+   [metabase.util.i18n :refer [tru]]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
@@ -1061,10 +1061,10 @@
                      :password (driver.u/random-workspace-password)}
         conn-spec   (sql-jdbc.conn/db->pooled-connection-spec (:id database))]
     (when-not db-name
-      (throw (ex-info (str (deferred-tru "Snowflake database configuration is missing required ''db'' (database name) setting"))
+      (throw (ex-info (tru "Snowflake database configuration is missing required ''db'' (database name) setting")
                       {:database-id (:id database) :step :init})))
     (when-not warehouse
-      (throw (ex-info (str (deferred-tru "Snowflake database configuration is missing required ''warehouse'' setting"))
+      (throw (ex-info (tru "Snowflake database configuration is missing required ''warehouse'' setting")
                       {:database-id (:id database) :step :init})))
     ;; Snowflake RBAC: create schema -> create role -> grant privileges to role -> create user -> grant role to user
     (doseq [sql [(format "CREATE SCHEMA IF NOT EXISTS \"%s\".\"%s\"" db-name schema-name)
@@ -1090,7 +1090,7 @@
         username    (driver.u/workspace-isolation-user-name workspace)
         conn-spec   (sql-jdbc.conn/db->pooled-connection-spec (:id database))]
     (when-not db-name
-      (throw (ex-info (str (deferred-tru "Snowflake database configuration is missing required ''db'' (database name) setting"))
+      (throw (ex-info (tru "Snowflake database configuration is missing required ''db'' (database name) setting")
                       {:database-id (:id database) :step :destroy})))
     ;; Drop in reverse order of creation: schema (CASCADE handles tables) -> user -> role
     (doseq [sql [(format "DROP SCHEMA IF EXISTS \"%s\".\"%s\" CASCADE" db-name schema-name)
@@ -1104,10 +1104,10 @@
         db-name   (:db (driver.conn/effective-details database))
         role-name (-> workspace :database_details :role)]
     (when-not db-name
-      (throw (ex-info (str (deferred-tru "Snowflake database configuration is missing required ''db'' (database name) setting"))
+      (throw (ex-info (tru "Snowflake database configuration is missing required ''db'' (database name) setting")
                       {:database-id (:id database) :step :grant})))
     (when-not role-name
-      (throw (ex-info (str (deferred-tru "Workspace isolation is not properly initialized - missing role name"))
+      (throw (ex-info (tru "Workspace isolation is not properly initialized - missing role name")
                       {:workspace-id (:id workspace) :step :grant})))
     (let [qdb (sql.u/quote-name :snowflake :schema db-name)
           qr  (sql.u/quote-name :snowflake :field role-name)]

--- a/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
+++ b/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
@@ -29,7 +29,7 @@
    [metabase.sql-tools.core :as sql-tools]
    [metabase.util :as u]
    [metabase.util.honey-sql-2 :as h2x]
-   [metabase.util.i18n :refer [deferred-tru]]
+   [metabase.util.i18n :refer [tru]]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
@@ -1171,7 +1171,7 @@
   (let [conn-spec (sql-jdbc.conn/db->pooled-connection-spec (:id database))
         username  (-> workspace :database_details :user)]
     (when-not username
-      (throw (ex-info (str (deferred-tru "Workspace isolation is not properly initialized - missing read user name"))
+      (throw (ex-info (tru "Workspace isolation is not properly initialized - missing read user name")
                       {:workspace-id (:id workspace) :step :grant})))
     ;; Grant SELECT on each specific table only - no schema-level grants
     (let [qu (sql.u/quote-name :sqlserver :field username)]

--- a/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
+++ b/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
@@ -29,6 +29,7 @@
    [metabase.sql-tools.core :as sql-tools]
    [metabase.util :as u]
    [metabase.util.honey-sql-2 :as h2x]
+   [metabase.util.i18n :refer [deferred-tru]]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
@@ -1170,7 +1171,7 @@
   (let [conn-spec (sql-jdbc.conn/db->pooled-connection-spec (:id database))
         username  (-> workspace :database_details :user)]
     (when-not username
-      (throw (ex-info "Workspace isolation is not properly initialized - missing read user name"
+      (throw (ex-info (str (deferred-tru "Workspace isolation is not properly initialized - missing read user name"))
                       {:workspace-id (:id workspace) :step :grant})))
     ;; Grant SELECT on each specific table only - no schema-level grants
     (let [qu (sql.u/quote-name :sqlserver :field username)]

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -31,7 +31,7 @@
    [metabase.util :as u]
    [metabase.util.date-2 :as u.date]
    [metabase.util.honey-sql-2 :as h2x]
-   [metabase.util.i18n :refer [deferred-tru]]
+   [metabase.util.i18n :refer [deferred-tru tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.performance :as perf :refer [get-in not-empty some]])
@@ -1310,22 +1310,22 @@
                       (let [init-result (try
                                           (driver/init-workspace-isolation! driver database test-workspace)
                                           (catch Exception e
-                                            (throw (ex-info (str (deferred-tru "Failed to initialize workspace isolation (CREATE DATABASE/USER): {0}"
-                                                                               (ex-message e)))
+                                            (throw (ex-info (tru "Failed to initialize workspace isolation (CREATE DATABASE/USER): {0}"
+                                                                 (ex-message e))
                                                             {:step :init} e))))
                             workspace-with-details (merge test-workspace init-result)]
                         (when test-table
                           (try
                             (driver/grant-workspace-read-access! driver database workspace-with-details [test-table])
                             (catch Exception e
-                              (throw (ex-info (str (deferred-tru "Failed to grant read access to table {0}.{1}: {2}"
-                                                                 (:schema test-table) (:name test-table) (ex-message e)))
+                              (throw (ex-info (tru "Failed to grant read access to table {0}.{1}: {2}"
+                                                   (:schema test-table) (:name test-table) (ex-message e))
                                               {:step :grant :table test-table} e)))))
                         (try
                           (driver/destroy-workspace-isolation! driver database workspace-with-details)
                           (catch Exception e
-                            (throw (ex-info (str (deferred-tru "Failed to destroy workspace isolation (DROP DATABASE/USER): {0}"
-                                                               (ex-message e)))
+                            (throw (ex-info (tru "Failed to destroy workspace isolation (DROP DATABASE/USER): {0}"
+                                                 (ex-message e))
                                             {:step :destroy} e))))
                         nil)
                       (catch Exception e

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -1310,22 +1310,22 @@
                       (let [init-result (try
                                           (driver/init-workspace-isolation! driver database test-workspace)
                                           (catch Exception e
-                                            (throw (ex-info (format "Failed to initialize workspace isolation (CREATE DATABASE/USER): %s"
-                                                                    (ex-message e))
+                                            (throw (ex-info (str (deferred-tru "Failed to initialize workspace isolation (CREATE DATABASE/USER): {0}"
+                                                                               (ex-message e)))
                                                             {:step :init} e))))
                             workspace-with-details (merge test-workspace init-result)]
                         (when test-table
                           (try
                             (driver/grant-workspace-read-access! driver database workspace-with-details [test-table])
                             (catch Exception e
-                              (throw (ex-info (format "Failed to grant read access to table %s.%s: %s"
-                                                      (:schema test-table) (:name test-table) (ex-message e))
+                              (throw (ex-info (str (deferred-tru "Failed to grant read access to table {0}.{1}: {2}"
+                                                                 (:schema test-table) (:name test-table) (ex-message e)))
                                               {:step :grant :table test-table} e)))))
                         (try
                           (driver/destroy-workspace-isolation! driver database workspace-with-details)
                           (catch Exception e
-                            (throw (ex-info (format "Failed to destroy workspace isolation (DROP DATABASE/USER): %s"
-                                                    (ex-message e))
+                            (throw (ex-info (str (deferred-tru "Failed to destroy workspace isolation (DROP DATABASE/USER): {0}"
+                                                               (ex-message e)))
                                             {:step :destroy} e))))
                         nil)
                       (catch Exception e

--- a/src/metabase/driver/sql_jdbc.clj
+++ b/src/metabase/driver/sql_jdbc.clj
@@ -20,6 +20,7 @@
    [metabase.driver.sql.query-processor :as sql.qp]
    [metabase.driver.sync :as driver.s]
    [metabase.util.honey-sql-2 :as h2x]
+   [metabase.util.i18n :refer [deferred-tru]]
    [metabase.util.malli :as mu]
    [metabase.util.performance :refer [mapv]])
   (:import
@@ -396,22 +397,22 @@
          (let [init-result (try
                              (driver/init-workspace-isolation! driver database test-workspace)
                              (catch Exception e
-                               (throw (ex-info (format "Failed to initialize workspace isolation (CREATE SCHEMA/USER): %s"
-                                                       (ex-message e))
+                               (throw (ex-info (str (deferred-tru "Failed to initialize workspace isolation (CREATE SCHEMA/USER): {0}"
+                                                                  (ex-message e)))
                                                {:step :init} e))))
                workspace-with-details (merge test-workspace init-result)]
            (when test-table
              (try
                (driver/grant-workspace-read-access! driver database workspace-with-details [test-table])
                (catch Exception e
-                 (throw (ex-info (format "Failed to grant read access to table %s.%s: %s"
-                                         (:schema test-table) (:name test-table) (ex-message e))
+                 (throw (ex-info (str (deferred-tru "Failed to grant read access to table {0}.{1}: {2}"
+                                                    (:schema test-table) (:name test-table) (ex-message e)))
                                  {:step :grant :table test-table} e)))))
            (try
              (driver/destroy-workspace-isolation! driver database workspace-with-details)
              (catch Exception e
-               (throw (ex-info (format "Failed to destroy workspace isolation (DROP SCHEMA/USER): %s"
-                                       (ex-message e))
+               (throw (ex-info (str (deferred-tru "Failed to destroy workspace isolation (DROP SCHEMA/USER): {0}"
+                                                  (ex-message e)))
                                {:step :destroy} e)))))
          nil
          (catch Exception e

--- a/src/metabase/driver/sql_jdbc.clj
+++ b/src/metabase/driver/sql_jdbc.clj
@@ -20,7 +20,7 @@
    [metabase.driver.sql.query-processor :as sql.qp]
    [metabase.driver.sync :as driver.s]
    [metabase.util.honey-sql-2 :as h2x]
-   [metabase.util.i18n :refer [deferred-tru]]
+   [metabase.util.i18n :refer [tru]]
    [metabase.util.malli :as mu]
    [metabase.util.performance :refer [mapv]])
   (:import
@@ -397,22 +397,22 @@
          (let [init-result (try
                              (driver/init-workspace-isolation! driver database test-workspace)
                              (catch Exception e
-                               (throw (ex-info (str (deferred-tru "Failed to initialize workspace isolation (CREATE SCHEMA/USER): {0}"
-                                                                  (ex-message e)))
+                               (throw (ex-info (tru "Failed to initialize workspace isolation (CREATE SCHEMA/USER): {0}"
+                                                    (ex-message e))
                                                {:step :init} e))))
                workspace-with-details (merge test-workspace init-result)]
            (when test-table
              (try
                (driver/grant-workspace-read-access! driver database workspace-with-details [test-table])
                (catch Exception e
-                 (throw (ex-info (str (deferred-tru "Failed to grant read access to table {0}.{1}: {2}"
-                                                    (:schema test-table) (:name test-table) (ex-message e)))
+                 (throw (ex-info (tru "Failed to grant read access to table {0}.{1}: {2}"
+                                      (:schema test-table) (:name test-table) (ex-message e))
                                  {:step :grant :table test-table} e)))))
            (try
              (driver/destroy-workspace-isolation! driver database workspace-with-details)
              (catch Exception e
-               (throw (ex-info (str (deferred-tru "Failed to destroy workspace isolation (DROP SCHEMA/USER): {0}"
-                                                  (ex-message e)))
+               (throw (ex-info (tru "Failed to destroy workspace isolation (DROP SCHEMA/USER): {0}"
+                                    (ex-message e))
                                {:step :destroy} e)))))
          nil
          (catch Exception e


### PR DESCRIPTION
Closes GDGT-1552

### Description

When checking workspace permissions via check-isolation-permissions, the error messages returned are plain English strings built with format. These are displayed to users in the admin UI when workspace permission checks fail, but they are not localized.

There's also other such untranslated strings in workspace methods that we update in this PR to use the proper i18n string types so they are translated to the user's locale.

Since this is different from `format`, we also convert `%s` placeholders to `{0}, {1}` following Java MessageFormat syntax.

### How to verify

1. Add Italian translations for the error message strings to locales/it.po                    
2. Build translation resources: ./bin/i18n/build-translation-resources
3. Start Metabase with Postgres app DB (:run mode, not :e2e which forces H2)                  
4. Add a Postgres database with a restricted user (no CREATE SCHEMA privileges)               
5. Set admin user locale to Italian via PUT /api/user/:id with {"locale": "it"}               
6. Call POST /api/database/:id/permission/workspace/check with {"cached": false}              
7. Error message should have the translated strings   

### Demo

Before:

[non-i18n.webm](https://github.com/user-attachments/assets/0d1ba8f0-be94-49d8-b595-f69aab84a26e)

After:

(with tru)

[i18n-tru.webm](https://github.com/user-attachments/assets/5d0c2b23-777a-4c54-843b-2435f6979c8a)
