### PR TITLE
GDGT-2143 Use subscription creator's perms for attachment check

### DIFF
--- a/dev/src/dev/render_png.clj
+++ b/dev/src/dev/render_png.clj
@@ -118,7 +118,7 @@
   [part]
   (-> part
       (assoc-in [:card :include_csv] true)
-      result-attachment
+      (result-attachment (mt/user->id :crowberto))
       first
       :content
       slurp

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/subscription_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/subscription_test.clj
@@ -2,7 +2,10 @@
   "Permissions tests for API that needs to be enforced by Application Permissions to create and edit alerts/subscriptions."
   (:require
    [clojure.test :refer :all]
+   [metabase.notification.test-util :as notification.tu]
    [metabase.permissions.core :as perms]
+   [metabase.permissions.test-util :as perms.test-util]
+   [metabase.pulse.send :as pulse.send]
    [metabase.test :as mt]
    [metabase.util :as u]))
 
@@ -68,3 +71,63 @@
                   (create-pulse 200)
                   (update-pulse 200)
                   (get-form 200))))))))))
+
+(deftest send-time-attachment-perm-drift-test
+  (testing "Subscription attachments are gated by the subscription creator's send-time download perms (GH #71696)"
+    ;; Regression test for PR #66827. The bug: result-attachment used (:creator_id card) — the card author —
+    ;; instead of the subscription creator. The check must use the subscription creator at send time so that
+    ;; perm drift between save time and send time is honored, and so the card author's perms (which are
+    ;; unrelated to the subscription) don't accidentally gate every subscription using their cards.
+    ;;
+    ;; with-restored-data-perms! is required because this test mutates the All Users group perms,
+    ;; which would otherwise leak into subsequent tests in the same namespace.
+    (mt/with-premium-features #{:advanced-permissions}
+      (perms.test-util/with-restored-data-perms!
+        (notification.tu/with-notification-testing-setup!
+          (notification.tu/with-channel-fixtures [:channel/email]
+            (mt/with-temp [:model/User                       {sub-creator-id :id} {:email "drift@example.com"}
+                           :model/PermissionsGroup           {group-id :id}       {}
+                           :model/PermissionsGroupMembership _                    {:user_id sub-creator-id :group_id group-id}]
+            ;; Subscription creator initially has full download perms on the products table.
+            ;; The card is authored by crowberto (admin) — never the subscription creator.
+              (perms/set-database-permission! group-id (mt/id) :perms/view-data :unrestricted)
+              (perms/set-table-permission! group-id (mt/id :products) :perms/create-queries :query-builder)
+              (perms/set-table-permission! group-id (mt/id :products) :perms/download-results :one-million-rows)
+              (mt/with-temp [:model/Dashboard    {dash-id :id}              {:name "drift-test-dashboard"}
+                             :model/Card         {card-id :id}              {:creator_id    (mt/user->id :crowberto)
+                                                                             :dataset_query (mt/mbql-query products {:limit 5})}
+                             :model/DashboardCard {dashcard-id :id}         {:dashboard_id dash-id
+                                                                             :card_id      card-id
+                                                                             :row          0
+                                                                             :col          0}
+                             :model/Pulse        {pulse-id :id, :as pulse}  {:creator_id   sub-creator-id
+                                                                             :name         "drift-test-pulse"
+                                                                             :dashboard_id dash-id}
+                             :model/PulseCard    _                          {:pulse_id          pulse-id
+                                                                             :card_id           card-id
+                                                                             :dashboard_card_id dashcard-id
+                                                                             :position          0
+                                                                             :include_csv       true}
+                             :model/PulseChannel {pc-id :id}                {:pulse_id     pulse-id
+                                                                             :channel_type "email"
+                                                                             :details      {}}
+                             :model/PulseChannelRecipient _                 {:user_id          sub-creator-id
+                                                                             :pulse_channel_id pc-id}]
+                (letfn [(csv-attachments-of [captured]
+                          (->> (get captured :channel/email)
+                               (mapcat :message)
+                               (filter #(= "text/csv" (:content-type %)))))]
+                  (testing "subscription creator with full download perms → CSV attachment included"
+                    (let [captured (notification.tu/with-captured-channel-send!
+                                     (pulse.send/send-pulse! pulse))]
+                      (is (seq (csv-attachments-of captured))
+                          "expected at least one CSV attachment when subscription creator has full perms")))
+                  (testing "after subscription creator's perms drift to :no → CSV attachment is dropped"
+                  ;; Must revoke from BOTH the user's group AND the All Users group, since the user
+                  ;; is implicitly in All Users and download-perms-level takes the max across groups.
+                    (perms/set-table-permission! group-id (mt/id :products) :perms/download-results :no)
+                    (perms/set-table-permission! (perms/all-users-group) (mt/id :products) :perms/download-results :no)
+                    (let [captured (notification.tu/with-captured-channel-send!
+                                     (pulse.send/send-pulse! pulse))]
+                      (is (empty? (csv-attachments-of captured))
+                          "expected CSV attachment to be dropped after subscription creator's perms drift to :no"))))))))))))

--- a/src/metabase/channel/email/result_attachment.clj
+++ b/src/metabase/channel/email/result_attachment.clj
@@ -86,14 +86,20 @@
      :description  (format "More results for '%s'" card-name)}))
 
 (defn result-attachment
-  "Create result attachments for an email."
+  "Create result attachments for an email.
+
+  `creator-id` is the user ID of the subscription/notification creator. Their download permissions
+  are checked at send time so attachments are dropped if their permissions have drifted since the
+  subscription was created. This is intentionally NOT `(:creator_id card)` (the card author) — the
+  card author's permissions are unrelated to whether the subscription should still send data."
   [{{original-card-name :name format-rows :format_rows pivot-results :pivot_results :as card} :card
     dashcard :dashcard
     result :result
-    :as part}]
+    :as part}
+   creator-id]
   (when (and (or (:include_csv card) (:include_xls card))
              (pos-int? (:row_count result))
-             (not= (perms/download-perms-level (:dataset_query card) (:creator_id card))  :no))
+             (not= (perms/download-perms-level (:dataset_query card) creator-id) :no))
     (let [maybe-realize-data-rows (requiring-resolve 'metabase.channel.shared/maybe-realize-data-rows)
           result            (:result (maybe-realize-data-rows part))
           visualizer-title (when (and dashcard (get-in dashcard [:visualization_settings :visualization]))

--- a/src/metabase/channel/email/result_attachment.clj
+++ b/src/metabase/channel/email/result_attachment.clj
@@ -86,12 +86,8 @@
      :description  (format "More results for '%s'" card-name)}))
 
 (defn result-attachment
-  "Create result attachments for an email.
-
-  `creator-id` is the user ID of the subscription/notification creator. Their download permissions
-  are checked at send time so attachments are dropped if their permissions have drifted since the
-  subscription was created. This is intentionally NOT `(:creator_id card)` (the card author) — the
-  card author's permissions are unrelated to whether the subscription should still send data."
+  "Create result attachments for an email. `creator-id` is the subscription creator, whose download
+  permissions gate the attachment at send time."
   [{{original-card-name :name format-rows :format_rows pivot-results :pivot_results :as card} :card
     dashcard :dashcard
     result :result

--- a/src/metabase/channel/impl/email.clj
+++ b/src/metabase/channel/impl/email.clj
@@ -208,7 +208,7 @@
 ;; ------------------------------------------------------------------------------------------------;;
 
 (mu/defmethod channel/render-notification [:channel/email :notification/card] :- [:sequential EmailMessage]
-  [_channel-type {:keys [payload payload_type] :as notification-payload} {:keys [template recipients]}]
+  [_channel-type {:keys [payload payload_type creator_id] :as notification-payload} {:keys [template recipients]}]
   (let [{:keys [card_part
                 notification_card
                 subscriptions
@@ -222,7 +222,8 @@
         result-attachments (email.result-attachment/result-attachment
                             (first (assoc-attachment-booleans
                                     [(assoc notification_card :include_csv true :format_rows true)]
-                                    [card_part])))
+                                    [card_part]))
+                            creator_id)
         attachments        (concat [icon-attachment] card-attachments result-attachments)
         html-content       (html (:content rendered-card))
         goal               (ui-logic/find-goal-value payload)
@@ -252,7 +253,7 @@
 ;; ------------------------------------------------------------------------------------------------;;
 
 (mu/defmethod channel/render-notification [:channel/email :notification/dashboard] :- [:sequential EmailMessage]
-  [_channel-type {:keys [payload payload_type] :as notification-payload} {:keys [template recipients attachment_only]}]
+  [_channel-type {:keys [payload payload_type creator_id] :as notification-payload} {:keys [template recipients attachment_only]}]
   (let [{:keys [dashboard_parts
                 dashboard_subscription
                 parameters
@@ -270,7 +271,7 @@
                              (fn [[merged-attachments result-attachments html-contents] part]
                                (let [{:keys [attachments content]} (render-part timezone part {:channel.render/include-title? true
                                                                                                :channel.render/disable-links? (boolean (:disable_links dashboard_subscription))})
-                                     result-attachment             (email.result-attachment/result-attachment part)]
+                                     result-attachment             (email.result-attachment/result-attachment part creator_id)]
                                  [(merge merged-attachments attachments)
                                   (into result-attachments result-attachment)
                                   (when-not attachment_only

--- a/src/metabase/channel/render/preview.clj
+++ b/src/metabase/channel/render/preview.clj
@@ -8,6 +8,7 @@
    [hickory.core :as hik]
    [hickory.render :as hik.r]
    [hickory.zip :as hik.z]
+   [metabase.api.common :as api]
    [metabase.channel.email.result-attachment :as email.result-attachment]
    [metabase.channel.render.card :as render.card]
    [metabase.channel.render.image-bundle :as img]
@@ -41,7 +42,7 @@
   [part]
   (-> part
       (assoc-in [:card :include_csv] true)
-      email.result-attachment/result-attachment
+      (email.result-attachment/result-attachment api/*current-user-id*)
       first
       :content
       slurp

--- a/src/metabase/notification/payload/core.clj
+++ b/src/metabase/notification/payload/core.clj
@@ -145,7 +145,7 @@
 (mu/defn notification-payload :- ::NotificationPayload
   "Realize notification-info with :context and :payload."
   [notification :- ::Notification]
-  (assoc (select-keys notification [:payload_type])
+  (assoc (select-keys notification [:payload_type :creator_id])
          :creator (t2/select-one [:model/User :id :first_name :last_name :email] (:creator_id notification))
          :payload (w/prewalk (fn [x]
                                (if (and (map? x) (:lib/metadata x))

--- a/test/metabase/channel/email/result_attachment_test.clj
+++ b/test/metabase/channel/email/result_attachment_test.clj
@@ -1,7 +1,8 @@
 (ns metabase.channel.email.result-attachment-test
   (:require
    [clojure.test :refer :all]
-   [metabase.channel.email.result-attachment :as email.result-attachment])
+   [metabase.channel.email.result-attachment :as email.result-attachment]
+   [metabase.permissions.core :as perms])
   (:import
    (java.io IOException)))
 
@@ -19,3 +20,39 @@
        (re-pattern (format "Unable to create temp file in `%s`" (System/getProperty "java.io.tmpdir")))
        (with-create-temp-failure!
          (#'email.result-attachment/create-temp-file-or-throw! "txt")))))
+
+(deftest result-attachment-uses-passed-creator-id-for-perm-check-test
+  (testing "result-attachment checks the passed creator-id's download perms, not the card author's"
+    ;; Regression test for GH #71696 (Linear GDGT-2143):
+    ;; PR #66827 added a send-time download-perms gate but used (:creator_id card) — the card author —
+    ;; instead of the subscription creator. When the card author later loses download perms, every
+    ;; existing subscription for that card silently drops attachments, even when the subscription
+    ;; creator has full perms.
+    (let [card-author-id           1
+          subscription-creator-id  2
+          card                     {:id            99
+                                    :name          "test-card"
+                                    :include_csv   true
+                                    :creator_id    card-author-id
+                                    :dataset_query {:database 1}}
+          part                     {:card   card
+                                    :result {:row_count 5
+                                             :data      {:rows [[1] [2] [3] [4] [5]]}}}]
+      (with-redefs [perms/download-perms-level (fn [_query user-id]
+                                                 (case (long user-id)
+                                                   1 :no
+                                                   2 :one-million-rows
+                                                   :one-million-rows))
+                    ;; Sentinel: if execution reaches the streaming path, the perm check passed.
+                    ;; We avoid exercising real CSV streaming machinery in a unit test.
+                    email.result-attachment/create-temp-file! (fn [_]
+                                                                (throw (ex-info "PERM-CHECK-PASSED" {})))]
+        (testing "passes perm check when subscription creator has download perms (even if card author does not)"
+          (is (thrown-with-msg?
+               clojure.lang.ExceptionInfo
+               #"PERM-CHECK-PASSED"
+               (email.result-attachment/result-attachment part subscription-creator-id))
+              "expected to reach the streaming code path because subscription creator has perms"))
+        (testing "drops attachment when the passed creator-id has :no download perms"
+          (is (nil? (email.result-attachment/result-attachment part card-author-id))
+              "expected nil because the passed creator-id has :no download perms"))))))

--- a/test/metabase/pulse/dashboard_subscription_test.clj
+++ b/test/metabase/pulse/dashboard_subscription_test.clj
@@ -1087,7 +1087,7 @@
                  (pulse.test-util/thunk->boolean pulse-results)))))}}))
 
 (defn- result-attachment!
-  [part]
+  [part _creator-id]
   (let [{{{:keys [rows]} :data, :as result} :result} (channel.shared/maybe-realize-data-rows part)]
     (when (seq rows)
       [(let [^java.io.ByteArrayOutputStream baos (java.io.ByteArrayOutputStream.)]


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #71696
Fixes [GDGT-2143](https://linear.app/metabase/issue/GDGT-2143) / metabase/metabase#71696.

Subscription emails silently drop CSV/XLSX attachments when the underlying card's author lacks download permissions, even if the subscription creator has full perms.

**Introduced in:** #66827 (v59), backported to v58.1 in #67175. The PR added a send-time download-perms check to `result-attachment` but used `(:creator_id card)` — the card author — instead of the subscription creator.

**Fix:** thread the subscription creator's user-id from `notification-payload` through to `result-attachment` and check that user's perms instead.