### PR TITLE
Fix metrics on models with custom column dims

### DIFF
--- a/src/metabase/lib_metric/ast/build.cljc
+++ b/src/metabase/lib_metric/ast/build.cljc
@@ -52,12 +52,14 @@
   "Create a dimension mapping node from a persisted mapping."
   [{:keys [dimension-id table-id target]}]
   (let [[_field opts field-id] target
-        source-field (:source-field opts)]
+        source-field (:source-field opts)
+        base-type    (:base-type opts)]
     {:node/type    :ast/dimension-mapping
      :dimension-id dimension-id
      :table-id     table-id
      :column       (cond-> (column-node field-id nil table-id)
-                     source-field (assoc :source-field source-field))}))
+                     source-field (assoc :source-field source-field)
+                     base-type    (assoc :base-type base-type))}))
 
 ;;; -------------------- Dimension Reference Construction --------------------
 
@@ -312,11 +314,12 @@
    For source-card queries (metrics based on models or saved questions),
    falls back to the table-id from the entity metadata."
   [source-type id metadata mbql5-query]
-  (let [table-id      (or (lib.util/source-table-id mbql5-query)
-                          (:table-id metadata))
-        aggregation   (first (lib/aggregations mbql5-query 0))
-        source-filter (extract-source-filters mbql5-query)
-        source-joins  (extract-source-joins mbql5-query)]
+  (let [source-card-id (lib.util/source-card-id mbql5-query)
+        table-id       (or (lib.util/source-table-id mbql5-query)
+                           (:table-id metadata))
+        aggregation    (first (lib/aggregations mbql5-query 0))
+        source-filter  (extract-source-filters mbql5-query)
+        source-joins   (extract-source-joins mbql5-query)]
     (cond-> {:node/type   source-type
              :id          id
              :name        (:name metadata)
@@ -324,8 +327,9 @@
                               {:node/type :aggregation/count})
              :base-table  (table-node table-id)
              :metadata    metadata}
-      source-joins  (assoc :joins source-joins)
-      source-filter (assoc :filters source-filter))))
+      source-card-id (assoc :source-card-id source-card-id)
+      source-joins   (assoc :joins source-joins)
+      source-filter  (assoc :filters source-filter))))
 
 ;;; -------------------- Main Construction --------------------
 

--- a/src/metabase/lib_metric/ast/compile.cljc
+++ b/src/metabase/lib_metric/ast/compile.cljc
@@ -21,9 +21,10 @@
 
 (defn- column-node->field-ref
   "Convert column node to MBQL field reference."
-  [{:keys [id source-field]} options]
+  [{:keys [id source-field base-type]} options]
   [:field (cond-> (merge {:lib/uuid (random-uuid-str)} options)
-            source-field (assoc :source-field source-field))
+            source-field (assoc :source-field source-field)
+            base-type    (assoc :base-type base-type))
    id])
 
 (defn- resolve-dimension-ref
@@ -167,6 +168,24 @@
   [source]
   (seq (:joins source)))
 
+(defn- source-card?
+  "Check if source originates from a source-card (model or saved question)."
+  [source]
+  (some? (:source-card-id source)))
+
+(defn- needs-two-stage?
+  "Source-card metrics and metrics with joins both compile to two-stage queries."
+  [source]
+  (or (has-joins? source) (source-card? source)))
+
+(defn- stage-0-source
+  "Return the [key value] pair for stage-0's source — :source-card if the metric
+   wraps a card, otherwise :source-table from the base table."
+  [source]
+  (if-let [card-id (:source-card-id source)]
+    [:source-card card-id]
+    [:source-table (perf/get-in source [:base-table :id])]))
+
 (defn- compile-join-nodes
   "Compile AST join nodes to MBQL 5 join clauses.
    Forces `:fields :all` so that all joined columns are visible in stage 1 of
@@ -212,15 +231,18 @@
      :stages   [stage]}))
 
 (defn- compile-two-stage-query
-  "Compile AST to two-stage MBQL query when joins are present.
+  "Compile AST to two-stage MBQL query when joins are present or the metric is
+   based on a source-card (model / saved question).
 
-   Stage 0: Data model - base table, joins, source filters
+   Stage 0: Data model - base table or source card, joins, source filters
    Stage 1: Analysis - user filters, breakouts, aggregation"
   [{:keys [source mappings filter group-by]} {:keys [limit]}]
-  (let [;; Stage 0: Data model
-        stage-0 (cond-> {:lib/type     :mbql.stage/mbql
-                         :source-table (perf/get-in source [:base-table :id])
-                         :joins        (compile-join-nodes (:joins source))}
+  (let [[source-key source-val] (stage-0-source source)
+        ;; Stage 0: Data model
+        stage-0 (cond-> {:lib/type  :mbql.stage/mbql
+                         source-key source-val}
+                  (seq (:joins source))
+                  (assoc :joins (compile-join-nodes (:joins source)))
                   (:filters source)
                   (assoc :filters [(compile-filter-node (:filters source) mappings)]))
 
@@ -242,15 +264,16 @@
 (mu/defn compile-to-mbql
   "Compile AST to MBQL query.
 
-   Generates a two-stage query when the source has joins:
-   - Stage 0: Data model (base table + joins + source filters)
+   Generates a two-stage query when the source has joins or is based on a
+   source-card (model / saved question):
+   - Stage 0: Data model (base table or source card + joins + source filters)
    - Stage 1: Analysis (user filters + breakouts + aggregation)
 
    Options:
    - :limit - add limit to query"
   [{:keys [source] :as ast} :- ::ast.schema/ast
    & {:as opts}]
-  (if (has-joins? source)
+  (if (needs-two-stage? source)
     (compile-two-stage-query ast opts)
     (compile-single-stage-query ast opts)))
 
@@ -282,12 +305,14 @@
 (defn- compile-two-stage-values-query
   "Compile AST to two-stage MBQL query for distinct values (no aggregation).
 
-   Stage 0: Data model - base table, joins, source filters
+   Stage 0: Data model - base table or source card, joins, source filters
    Stage 1: User filters, breakouts (no aggregation)"
   [{:keys [source mappings filter group-by]} {:keys [limit]}]
-  (let [stage-0 (cond-> {:lib/type     :mbql.stage/mbql
-                         :source-table (perf/get-in source [:base-table :id])
-                         :joins        (compile-join-nodes (:joins source))}
+  (let [[source-key source-val] (stage-0-source source)
+        stage-0 (cond-> {:lib/type  :mbql.stage/mbql
+                         source-key source-val}
+                  (seq (:joins source))
+                  (assoc :joins (compile-join-nodes (:joins source)))
                   (:filters source)
                   (assoc :filters [(compile-filter-node (:filters source) mappings)]))
         user-filters (when filter [(compile-filter-node filter mappings)])
@@ -312,6 +337,6 @@
    - :limit - add limit to query"
   [{:keys [source] :as ast} :- ::ast.schema/ast
    & {:as opts}]
-  (if (has-joins? source)
+  (if (needs-two-stage? source)
     (compile-two-stage-values-query ast opts)
     (compile-single-stage-values-query ast opts)))

--- a/src/metabase/lib_metric/ast/schema.cljc
+++ b/src/metabase/lib_metric/ast/schema.cljc
@@ -19,9 +19,10 @@
   "Reference to a database column/field."
   [:map
    [:node/type [:= :ast/column]]
-   [:id pos-int?]
+   [:id [:or pos-int? string?]]
    [:name {:optional true} [:maybe string?]]
-   [:table-id {:optional true} [:maybe pos-int?]]])
+   [:table-id {:optional true} [:maybe pos-int?]]
+   [:base-type {:optional true} [:maybe keyword?]]])
 
 ;;; -------------------- Dimension Nodes --------------------
 
@@ -229,6 +230,7 @@
    [:name {:optional true} [:maybe string?]]
    [:aggregation ::aggregation-node]
    [:base-table ::table-node]
+   [:source-card-id {:optional true} [:maybe pos-int?]]
    [:metadata {:optional true} [:maybe :map]]
    [:joins {:optional true} [:maybe [:sequential ::join-node]]]
    [:filters {:optional true} [:maybe [:ref ::filter-node]]]])

--- a/test/metabase/metrics/api_dataset_test.clj
+++ b/test/metabase/metrics/api_dataset_test.clj
@@ -1256,3 +1256,27 @@
           (is (= "completed" (:status response)))
           (is (= 49 (:row_count response))
               "should have 49 months of order data, same as table-based metric"))))))
+
+(deftest dataset-source-card-expression-dimension-projection-test
+  (testing "POST /api/metric/dataset with source-card metric, projecting on a custom column dimension"
+    (mt/with-temp [:model/Card model  {:name          "Orders Model with Expression"
+                                       :type          :model
+                                       :dataset_query (mt/mbql-query orders
+                                                        {:expressions {"Discount Plus One"
+                                                                       [:+ $discount 1]}})}
+                   :model/Card metric {:name          "Model Count Metric"
+                                       :type          :metric
+                                       :dataset_query {:database (mt/id)
+                                                       :type     :query
+                                                       :query    {:source-table (str "card__" (:id model))
+                                                                  :aggregation  [[:count]]}}}]
+      (let [hydrated  (hydrate-metric (:id metric))
+            expr-dim  (find-dimension-by-name hydrated "Discount Plus One")]
+        (is (some? expr-dim) "Expression dimension should exist for model-based metric")
+        (when expr-dim
+          (let [response (dataset-request
+                          {:expression  [:metric {:lib/uuid "a"} (:id metric)]
+                           :projections [{:type :metric :id (:id metric)
+                                          :projection [[:dimension {} (:id expr-dim)]]}]})]
+            (is (= "completed" (:status response)))
+            (is (< 1 (:row_count response)))))))))

--- a/test/metabase/metrics/api_dataset_test.clj
+++ b/test/metabase/metrics/api_dataset_test.clj
@@ -1276,7 +1276,7 @@
         (when expr-dim
           (let [response (dataset-request
                           {:expression  [:metric {:lib/uuid "a"} (:id metric)]
-                           :projections [{:type :metric :id (:id metric)
+                           :projections [{:type :metric :id (:id metric) :lib/uuid "a"
                                           :projection [[:dimension {} (:id expr-dim)]]}]})]
             (is (= "completed" (:status response)))
             (is (< 1 (:row_count response)))))))))


### PR DESCRIPTION
Just like with joins, a metric with a source-card needs to be compiled to a two-stage query rather than querying the table directly, so that we can query custom columns.
