### PR TITLE
Fix dashboard PUT response

### DIFF
--- a/src/metabase/dashboards_rest/api.clj
+++ b/src/metabase/dashboards_rest/api.clj
@@ -310,7 +310,7 @@
                              (when card
                                (let [dataset-query (or (:dataset_query card)
                                                        (t2/select-one-fn :dataset_query :model/Card :id (:id card)))
-                                     download-level (when dataset-query
+                                     download-level (when (seq dataset-query)
                                                       (perms/download-perms-level dataset-query api/*current-user-id*))]
                                  (assoc card :download_perms (case download-level
                                                                :no :none
@@ -318,6 +318,15 @@
                                                                :one-million-rows :full
                                                                :full :full
                                                                :none)))))))))))
+
+(defn- apply-card-permission-filters
+  "Apply collection-permission-aware filtering to dashboard cards. Hides details of
+   cards the current user cannot read and sets download permission levels."
+  [dashboard]
+  (-> dashboard
+      hide-unreadable-cards
+      add-query-average-durations
+      set-download-perms-on-dashcards))
 
 ;; TODO: This indirect memoization by *dashboard-load-id* could probably be turned into a macro for reuse elsewhere.
 (defn- get-dashboard*
@@ -330,10 +339,8 @@
         api/read-check
         hydrate-dashboard-details
         collection.root/hydrate-root-collection
-        hide-unreadable-cards
-        add-query-average-durations
-        (api/present-in-trash-if-archived-directly (collection/trash-collection-id))
-        set-download-perms-on-dashcards)))
+        apply-card-permission-filters
+        (api/present-in-trash-if-archived-directly (collection/trash-collection-id)))))
 
 (def ^:private get-dashboard-fn
   (memoize/ttl (fn [dashboard-load-id]
@@ -1057,6 +1064,8 @@
         (track-dashcard-and-tab-events! dashboard @changes-stats)
         (-> dashboard
             hydrate-dashboard-details
+            collection.root/hydrate-root-collection
+            apply-card-permission-filters
             (assoc :last-edit-info (revisions/edit-information-for-user @api/*current-user*)))))))
 
 (def ^:private DashUpdates

--- a/test/metabase/dashboards_rest/api_test.clj
+++ b/test/metabase/dashboards_rest/api_test.clj
@@ -688,6 +688,43 @@
           (is (= "You don't have permissions to do that."
                  (mt/user-http-request :rasta :get 403 (format "dashboard/%d" dashboard-id)))))))))
 
+(deftest put-dashboard-hides-unreadable-cards-test
+  (testing "PUT /api/dashboard/:id should hide card details from collections the user cannot access (#UXW-3571)"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (mt/with-temp [:model/Collection    {accessible-coll-id :id} {:name "Accessible Collection"}
+                     :model/Collection    {restricted-coll-id :id} {:name "Restricted Collection"}
+                     :model/Card          {readable-card-id :id}   {:name          "Readable Card"
+                                                                    :collection_id accessible-coll-id
+                                                                    :dataset_query (mt/mbql-query venues)}
+                     :model/Card          {restricted-card-id :id} {:name          "Restricted Card"
+                                                                    :collection_id restricted-coll-id
+                                                                    :dataset_query (mt/mbql-query venues)}
+                     :model/Dashboard     {dashboard-id :id}       {:name          "Test Dashboard"
+                                                                    :collection_id accessible-coll-id}
+                     :model/DashboardCard _                        {:dashboard_id dashboard-id
+                                                                    :card_id      readable-card-id}
+                     :model/DashboardCard _                        {:dashboard_id dashboard-id
+                                                                    :card_id      restricted-card-id}]
+        ;; Grant read+write to accessible collection, no access to restricted collection
+        (perms/grant-collection-readwrite-permissions! (perms-group/all-users) accessible-coll-id)
+        (let [get-response (mt/user-http-request :rasta :get 200 (format "dashboard/%d" dashboard-id))
+              put-response (mt/user-http-request :rasta :put 200 (str "dashboard/" dashboard-id)
+                                                 {:name "Test Dashboard"})
+              get-cards    (set (map :card (:dashcards get-response)))
+              put-cards    (set (map :card (:dashcards put-response)))]
+          (letfn [(restricted-card [cards]
+                    (first (filter #(= (:id %) restricted-card-id) cards)))
+                  (sensitive-keys [card]
+                    (select-keys card [:name :dataset_query :collection_id :creator_id :result_metadata :database_id]))]
+            (testing "GET hides restricted card details"
+              (is (empty? (sensitive-keys (restricted-card get-cards)))
+                  "Restricted card should not contain sensitive fields"))
+            (testing "PUT hides restricted card details the same way as GET"
+              (is (empty? (sensitive-keys (restricted-card put-cards)))
+                  "Restricted card should not contain sensitive fields"))
+            (testing "PUT and GET return the same card representations for restricted cards"
+              (is (= (restricted-card get-cards) (restricted-card put-cards))))))))))
+
 (deftest fetch-dashboard-in-personal-collection-test
   (testing "GET /api/dashboard/:id"
     (let [crowberto-personal-coll (t2/select-one :model/Collection :personal_owner_id (mt/user->id :crowberto))]


### PR DESCRIPTION
### Description

Extract shared `apply-card-permission-filters` helper used by both GET and PUT paths to ensure consistent card visibility filtering. Also fix `set-download-perms-on-dashcards` to handle empty dataset_query maps gracefully.

Fixes: UXW-3571

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
