### PR TITLE
Require authentication for eid-translation API endpoints

### DIFF
--- a/src/metabase/api_routes/routes.clj
+++ b/src/metabase/api_routes/routes.clj
@@ -176,7 +176,7 @@
    "/dataset"              (+auth 'metabase.query-processor.api)
    "/docs"                 (metabase.api.docs/make-routes #'routes)
    "/document"             (+auth metabase.documents.api/routes)
-   "/eid-translation"      'metabase.eid-translation.api
+   "/eid-translation"      (+auth 'metabase.eid-translation.api)
    "/email"                metabase.channel.api/email-routes
    "/embed"                (+message-only-exceptions metabase.embedding-rest.api/embedding-routes)
    "/field"                (+auth metabase.warehouse-schema-rest.api/field-routes)

--- a/src/metabase/eid_translation/api.clj
+++ b/src/metabase/eid_translation/api.clj
@@ -4,9 +4,6 @@
    [metabase.api.macros :as api.macros]
    [metabase.eid-translation.util :as eid-translation]))
 
-;;; endpoints in this namespace are not currently gated with `+auth` or whatever -- meaning they are public facing --
-;;; keep this in mind!
-
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
 ;;


### PR DESCRIPTION
### Description

The /api/eid-translation routes were unauthenticated despite only being used by frontend routes behind the IsAuthenticated guard. Wrap with +auth and remove the stale "public facing" comment.

Fixes: UXW-3570