### PR TITLE
Handle API errors in ci-report

### DIFF
--- a/mage/src/mage/ci_report.clj
+++ b/mage/src/mage/ci_report.clj
@@ -9,10 +9,12 @@
 
 ;;; Utilities
 
-(defn- sh
+(defn- sh-nil
   "Run shell command, return stdout or nil on error.
-   Uses p/process (not p/shell) so non-zero exits don't throw - some tools like
-   `gh pr checks` return exit 1 with valid output when checks fail."
+   Use for commands where non-zero exit is expected - e.g., `gh pr checks`
+   returns exit 1 when checks fail but output is still valid JSON, and
+   `gh pr view` returns exit 1 when no PR exists for the branch.
+   For commands that should fail loudly, use `mage.util/sh` instead."
   [& args]
   (try
     (let [result @(apply p/process {:out :string :err :string :in nil} args)]
@@ -26,7 +28,7 @@
 (defn- gh-api
   "Call GitHub API via gh cli, return parsed JSON"
   [endpoint]
-  (when-let [result (sh "gh" "api" endpoint)]
+  (when-let [result (u/sh "gh" "api" endpoint)]
     (json/parse-string result true)))
 
 (defn- strip-ansi
@@ -71,15 +73,15 @@
 (defn- pr-info
   "Fetch PR metadata"
   [pr-number]
-  (when-let [result (sh "gh" "pr" "view" (str pr-number) "-R" repo
-                        "--json" "headRefName,headRefOid,title,url")]
+  (when-let [result (u/sh "gh" "pr" "view" (str pr-number) "-R" repo
+                          "--json" "headRefName,headRefOid,title,url")]
     (json/parse-string result true)))
 
 (defn- pr-checks
   "Fetch PR check statuses"
   [pr-number]
-  (when-let [result (sh "gh" "pr" "checks" (str pr-number) "-R" repo
-                        "--json" "name,state,link")]
+  (when-let [result (sh-nil "gh" "pr" "checks" (str pr-number) "-R" repo
+                            "--json" "name,state,link")]
     (json/parse-string result true)))
 
 (defn- find-test-report-start
@@ -472,7 +474,7 @@
 (defn- get-current-branch-pr
   "Get PR number for current branch, or nil if none"
   []
-  (when-let [result (sh "gh" "pr" "view" "--json" "number" "-q" ".number")]
+  (when-let [result (sh-nil "gh" "pr" "view" "--json" "number" "-q" ".number")]
     (when (re-matches #"\d+" result)
       result)))
 
@@ -606,7 +608,7 @@
                                      (do (log-success (format "Found PR #%s for current branch" pr))
                                          {:type :pr :value pr})
                                      ;; No PR — use current branch name
-                                     (let [branch (sh "git" "rev-parse" "--abbrev-ref" "HEAD")]
+                                     (let [branch (u/sh "git" "rev-parse" "--abbrev-ref" "HEAD")]
                                        (if branch
                                          (do (log-progress (format "No PR found, using branch: %s" branch))
                                              {:type :branch :value branch})

--- a/mage/src/mage/ci_report.clj
+++ b/mage/src/mage/ci_report.clj
@@ -2,17 +2,20 @@
   (:require
    [babashka.process :as p]
    [cheshire.core :as json]
-   [clojure.string :as str]))
+   [clojure.string :as str]
+   [mage.util :as u]))
 
 (def ^:private repo "metabase/metabase")
 
 ;;; Utilities
 
 (defn- sh
-  "Run shell command, return stdout or nil on error"
+  "Run shell command, return stdout or nil on error.
+   Uses p/process (not p/shell) so non-zero exits don't throw - some tools like
+   `gh pr checks` return exit 1 with valid output when checks fail."
   [& args]
   (try
-    (let [result (apply p/shell {:out :string :err :string :in nil} args)]
+    (let [result @(apply p/process {:out :string :err :string :in nil} args)]
       (when (zero? (:exit result))
         (str/trim (:out result))))
     (catch Exception e
@@ -391,6 +394,10 @@
 
     ;; Status message
     (cond
+      (zero? (count checks))
+      (do (println "⚠️ **No checks found.** CI may not have started yet, or check data was unavailable. Try again in a minute.")
+          (println))
+
       (and (zero? (count failed)) (zero? (count pending)))
       (do (println "✅ **All checks passing!**")
           (println))
@@ -542,22 +549,24 @@
       (System/exit 1))
     (log-success (format "Found PR on branch: %s" (:headRefName info)))
     (log-progress "Checking PR status...")
-    (let [checks (pr-checks pr-number)
-          {:keys [failed pending]} (categorize-checks checks)]
-      (log-progress (format "Found %d failed, %d pending check(s)"
-                            (count failed) (count pending)))
-      (log-progress "Fetching failed job logs...")
-      (let [logs-by-job-id (if (pos? (count failed))
-                             (fetch-failed-logs-parallel failed {:detailed? detailed?})
-                             {})]
-        (when (seq logs-by-job-id)
-          (log-success "Retrieved logs"))
-        (log-progress (str "Generating report" (when detailed? " (detailed mode)") "..."))
-        (println)
-        (generate-report pr-number info checks logs-by-job-id
-                         {:detailed? detailed?
-                          :progress-log *progress-log*})
-        (log-success "Done!")))))
+    (let [checks (pr-checks pr-number)]
+      (when-not checks
+        (u/exit (format "Error: Could not fetch checks for PR #%s (API error)" pr-number) 1))
+      (let [{:keys [failed pending]} (categorize-checks checks)]
+        (log-progress (format "Found %d failed, %d pending check(s)"
+                              (count failed) (count pending)))
+        (log-progress "Fetching failed job logs...")
+        (let [logs-by-job-id (if (pos? (count failed))
+                               (fetch-failed-logs-parallel failed {:detailed? detailed?})
+                               {})]
+          (when (seq logs-by-job-id)
+            (log-success "Retrieved logs"))
+          (log-progress (str "Generating report" (when detailed? " (detailed mode)") "..."))
+          (println)
+          (generate-report pr-number info checks logs-by-job-id
+                           {:detailed? detailed?
+                            :progress-log *progress-log*})
+          (log-success "Done!"))))))
 
 (defn- run-commit-report!
   "Generate report for a commit SHA (with optional branch name for display)."


### PR DESCRIPTION
- Use p/process instead of p/shell so non-zero exits don't throw away valid output
- Exit with error when pr-checks returns nil (API failure)
- Warn when checks list is empty (CI not started yet)

Tested: `bin/mage ci-report 72130` still works (9 failures, 211 total). `bin/mage ci-report 99999999` exits with error.

```
➜  metabase git:(ci-report-error-handling) ✗ bin/mage ci-report 72130
→ Fetching PR #72130 info...
✓ Found PR on branch: slugify-arg
→ Checking PR status...
→ Found 11 failed, 0 pending check(s)
→ Fetching failed job logs...
→   Fetching logs for 11 failed job(s) in parallel...
```

```                                                                                                                                                                                                           ➜  metabase git:(ci-report-error-handling) ✗ bin/mage ci-report 99999999
→ Fetching PR #99999999 info...
GraphQL: Could not resolve to a PullRequest with the number of 99999999. (repository.pullRequest)

Exception:
 {:exception-type clojure.lang.ExceptionInfo, :ex-message Error while executing task: ci-report, :data {:proc {:proc #object[java.lang.ProcessImpl 0x18b8c4d Process[pid=41769, exitValue=1]], :exit 1, :in #object[java.lang.ProcessBuilder$NullOutputStream 0x35bb8e55 java.lang.ProcessBuilder$NullOutputStream@35bb8e55], :out , :err #object[java.lang.ProcessBuilder$NullInputStream 0x5a71def6 java.lang.ProcessBuilder$NullInputStream@5a71def6], :prev nil, :cmd [gh pr view 99999999 -R metabase/metabase --json headRefName,headRefOid,title,url]}, :task #'babashka.tasks/*task*, :babashka/exit 1}}
ex-message :  Error while executing task: ci-report
ex-data    :  {:proc {:proc #object[java.lang.ProcessImpl 0x18b8c4d "Process[pid=41769, exitValue=1]"], :exit 1, :in #object[java.lang.ProcessBuilder$NullOutputStream 0x35bb8e55 "java.lang.ProcessBuilder$NullOutputStream@35bb8e55"], :out "", :err #object[java.lang.ProcessBuilder$NullInputStream 0x5a71def6 "java.lang.ProcessBuilder$NullInputStream@5a71def6"], :prev nil, :cmd ["gh" "pr" "view" "99999999" "-R" "metabase/metabase" "--json" "headRefName,headRefOid,title,url"]}, :task #'babashka.tasks/*task*, :babashka/exit 1}
```