### PR TITLE
BOT-1282 Report combined in + out tokens in :metabot-usage metering

### DIFF
--- a/src/metabase/internal_stats/metabot.clj
+++ b/src/metabase/internal_stats/metabot.clj
@@ -28,8 +28,7 @@
                              (->> (for [usage               usages
                                         [prov-model tokens] usage
                                         :let [k (str/replace-first (u/qualified-name prov-model) "/" ":")]]
-                                    {(str k ":in")  (:prompt tokens)
-                                     (str k ":out") (:completion tokens)})
+                                    {(str k ":tokens") (+ (:prompt tokens) (:completion tokens))})
                                   (apply merge-with +)))
        :metabot-queries    (t2/select-one-fn :cnt
                                              [:model/MetabotMessage [:%count.id :cnt]]

--- a/test/metabase/internal_stats/metabot_test.clj
+++ b/test/metabase/internal_stats/metabot_test.clj
@@ -3,6 +3,8 @@
    [clojure.test :refer [deftest is testing]]
    [java-time.api :as t]
    [metabase.internal-stats.metabot :as sut]
+   [metabase.metabot.self.claude :as claude]
+   [metabase.metabot.self.openai :as openai]
    [metabase.metabot.self.openrouter :as openrouter]
    [metabase.metabot.settings :as metabot.settings]
    [metabase.metabot.test-util :as mut]
@@ -18,8 +20,7 @@
   "Send a message through the real streaming endpoint, returning the HTTP response body.
    The LLM is mocked to return a simple text response with the given model/usage."
   [conversation-id message model prompt-tokens completion-tokens]
-  (with-redefs [openrouter/openrouter
-                (fn [_]
+  (let [mock-fn (fn [_]
                   (mut/mock-llm-response
                    [{:type :start :id "msg-1"}
                     {:type :text  :text "Hello!"}
@@ -27,12 +28,15 @@
                      :model model
                      :usage {:promptTokens prompt-tokens :completionTokens completion-tokens}
                      :id    "msg-1"}]))]
-    (mt/user-http-request :rasta :post 202 "metabot/agent-streaming"
-                          {:message         message
-                           :context         {}
-                           :conversation_id conversation-id
-                           :history         []
-                           :state           {}})))
+    (with-redefs [openrouter/openrouter mock-fn
+                  claude/claude         mock-fn
+                  openai/openai         mock-fn]
+      (mt/user-http-request :rasta :post 202 "metabot/agent-streaming"
+                            {:message         message
+                             :context         {}
+                             :conversation_id conversation-id
+                             :history         []
+                             :state           {}}))))
 
 (defn- backdate-messages!
   "Update created_at on all messages for a conversation to the given timestamp."
@@ -138,3 +142,66 @@
 
           (finally
             (apply cleanup! all-convs)))))))
+
+(deftest metabot-usage-anthropic-provider-test
+  (search.tu/with-index-disabled
+    (let [clock     (t/mock-clock (t/instant "2026-04-01T12:00:00Z") "UTC")
+          yesterday (t/offset-date-time 2026 3 31 10 0 0 0 (t/zone-offset "+00"))
+          conv-id   (str (random-uuid))]
+      (t/with-clock clock
+        (try
+          (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
+                                             "metabase/anthropic/claude-sonnet-4-6"]
+            (send-message! conv-id "Hello" "claude-sonnet-4-6" 1000 250)
+            (backdate-messages! conv-id yesterday))
+          (let [stats (sut/metabot-stats)]
+            (is (= {"anthropic:claude-sonnet-4-6:tokens" 1250}
+                   (:metabot-usage stats))))
+          (finally
+            (cleanup! conv-id)))))))
+
+(deftest metabot-usage-openai-provider-test
+  (search.tu/with-index-disabled
+    (let [clock     (t/mock-clock (t/instant "2026-04-01T12:00:00Z") "UTC")
+          yesterday (t/offset-date-time 2026 3 31 10 0 0 0 (t/zone-offset "+00"))
+          conv-id   (str (random-uuid))]
+      (t/with-clock clock
+        (try
+          (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
+                                             "metabase/openai/gpt-4o"]
+            (send-message! conv-id "Hello" "gpt-4o" 600 200)
+            (backdate-messages! conv-id yesterday))
+          (let [stats (sut/metabot-stats)]
+            (is (= {"openai:gpt-4o:tokens" 800}
+                   (:metabot-usage stats))))
+          (finally
+            (cleanup! conv-id)))))))
+
+(deftest metabot-usage-multiple-providers-test
+  (search.tu/with-index-disabled
+    (let [clock     (t/mock-clock (t/instant "2026-04-01T12:00:00Z") "UTC")
+          yesterday (t/offset-date-time 2026 3 31 10 0 0 0 (t/zone-offset "+00"))
+          conv-1    (str (random-uuid))
+          conv-2    (str (random-uuid))
+          conv-3    (str (random-uuid))]
+      (t/with-clock clock
+        (try
+          (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
+                                             "metabase/openrouter/anthropic/claude-haiku-4-5"]
+            (send-message! conv-1 "Q1" "anthropic/claude-haiku-4-5" 100 50)
+            (backdate-messages! conv-1 yesterday))
+          (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
+                                             "metabase/anthropic/claude-sonnet-4-6"]
+            (send-message! conv-2 "Q2" "claude-sonnet-4-6" 200 80)
+            (backdate-messages! conv-2 yesterday))
+          (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
+                                             "metabase/openai/gpt-4o"]
+            (send-message! conv-3 "Q3" "gpt-4o" 300 120)
+            (backdate-messages! conv-3 yesterday))
+          (let [stats (sut/metabot-stats)]
+            (is (= {"openrouter:anthropic/claude-haiku-4-5:tokens" 150
+                    "anthropic:claude-sonnet-4-6:tokens"           280
+                    "openai:gpt-4o:tokens"                         420}
+                   (:metabot-usage stats))))
+          (finally
+            (cleanup! conv-1 conv-2 conv-3)))))))

--- a/test/metabase/internal_stats/metabot_test.clj
+++ b/test/metabase/internal_stats/metabot_test.clj
@@ -117,9 +117,8 @@
               ;; conv-1: 150, conv-2: 280 → total 430
               (is (= 430 (:metabot-tokens stats))))
 
-            (testing ":metabot-usage aggregates by model:in/out"
-              (is (= {"openrouter:anthropic/claude-haiku-4-5:in"  300
-                      "openrouter:anthropic/claude-haiku-4-5:out" 130}
+            (testing ":metabot-usage aggregates combined tokens by model"
+              (is (= {"openrouter:anthropic/claude-haiku-4-5:tokens" 430}
                      (:metabot-usage stats))))
 
             (testing ":metabot-queries counts ai-proxied user messages for yesterday"


### PR DESCRIPTION
Closes [BOT-1282: Combine token counts before sending usage to Harbormaster](https://linear.app/metabase/issue/BOT-1282/combine-token-counts-before-sending-usage-to-harbormaster)

https://metaboat.slack.com/archives/C0AP8MCUE4U/p1775672719034349

### Description

Report the combined `:prompt` + `:completion` tokens in the `:metabot-usage` metering.

### Demo

```
{:metabot-tokens 19141,
 :metabot-usage {"anthropic:claude-sonnet-4-6:tokens" 19141},
 :metabot-queries 2,
 :metabot-users 1,
:metabot-usage-date "2026-04-08"}
```
### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
