### PR TITLE
Fix styling for chart png download in Firefox

### DIFF
--- a/frontend/src/metabase/visualizations/lib/image-exports.ts
+++ b/frontend/src/metabase/visualizations/lib/image-exports.ts
@@ -73,6 +73,7 @@ export const getDomToCanvas = async (
   const { default: html2canvas } = await import("html2canvas-pro");
   return html2canvas(element, {
     useCORS: options.useCORS ?? true,
+    cspNonce: window.MetabaseNonce,
     width: options.width,
     height: options.height,
     scale: options.scale,

--- a/frontend/src/metabase/visualizations/lib/save-chart-image.ts
+++ b/frontend/src/metabase/visualizations/lib/save-chart-image.ts
@@ -47,6 +47,7 @@ export const saveChartImage = async ({
   const canvas = await html2canvas(node, {
     scale: 2,
     useCORS: true,
+    cspNonce: window.MetabaseNonce,
     height: canvasHeight,
     onclone: (_doc: Document, node: HTMLElement) => {
       node.classList.add(SAVING_DOM_IMAGE_CLASS);


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/66416

### Description

Fix issue for chart export as png in Firefox.
Because of missing nonce, which is required in Firefox, styles were ignored by the browser for created `canvas` element.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Open a dashboard with a dashcard that has visualization.
2. Click three dots menu > Download results
3. Pick png > Download
4. Downloaded image should have padding and valid fonts.

### Demo

| Before | After |
|--------|--------|
| <img width="2096" height="724" alt="Revenue and orders over time-09_04_2026, 00_27_09" src="https://github.com/user-attachments/assets/fada0ba0-e3a9-4581-9ebe-6b1f2432741a" /> | <img width="2096" height="724" alt="Revenue and orders over time-09_04_2026, 00_44_23" src="https://github.com/user-attachments/assets/99708e66-e151-41c8-a1fd-19bd80b6eeaf" /> | 

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
