### PR TITLE
[AI Controls] Show validation error for group limits above instance limit

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotCustomizationPage/MetabotIconField.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotCustomizationPage/MetabotIconField.tsx
@@ -151,7 +151,7 @@ export function MetabotIconField() {
           </Text>
           <Group gap="lg">
             <Text fz="md" c="text-secondary">
-              {t`Show Metabot illustrations in chat sidebar and natural language query page`}
+              {t`Show Metabot illustrations in chat sidebar and AI exploration page`}
             </Text>
             <Switch
               aria-label={t`Show Metabot illustrations`}

--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotUsageLimitsPage/GroupLimitsSettingsSection/GroupLimitsTab/GroupLimitsTab.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotUsageLimitsPage/GroupLimitsSettingsSection/GroupLimitsTab/GroupLimitsTab.tsx
@@ -107,7 +107,13 @@ export function GroupLimitsTab(props: GroupLimitsTabProps) {
   const handleChange = (group: GroupInfo, inputValue: string) => {
     const maxUsage = sanitizeUsageLimitValue(inputValue);
     setLocalLimitsMap((prev) => ({ ...prev, [group.id]: maxUsage }));
-    debouncedSaveGroupLimit(group, maxUsage);
+
+    const isOverInstanceLimit =
+      Number(maxUsage || 0) > Number(instanceLimit || 0);
+
+    if (!isOverInstanceLimit) {
+      debouncedSaveGroupLimit(group, maxUsage);
+    }
   };
 
   return (
@@ -132,8 +138,16 @@ export function GroupLimitsTab(props: GroupLimitsTabProps) {
               </thead>
               <tbody>
                 {groups.map((group) => {
+                  const inputValue = String(localLimitsMap?.[group.id] ?? "");
+                  const maxUsage = sanitizeUsageLimitValue(inputValue);
+                  const isOverInstanceLimit =
+                    maxUsage != null &&
+                    instanceLimit != null &&
+                    maxUsage > instanceLimit;
                   const showAllUsersOverrideTooltip =
-                    isAllUsersGroupOverridingLimit(group) && !!allUsersGroup;
+                    isAllUsersGroupOverridingLimit(group) &&
+                    !!allUsersGroup &&
+                    !isOverInstanceLimit;
 
                   return (
                     <tr key={group.id} className={S.BodyRow}>
@@ -142,7 +156,7 @@ export function GroupLimitsTab(props: GroupLimitsTabProps) {
                         <div className={S.InputWrapper}>
                           <TextInput
                             placeholder={placeholder}
-                            value={localLimitsMap?.[group.id] ?? ""}
+                            value={inputValue}
                             onChange={(e) =>
                               handleChange(group, e.target.value)
                             }
@@ -153,13 +167,20 @@ export function GroupLimitsTab(props: GroupLimitsTabProps) {
                               limitType,
                               group.name,
                             )}
+                            error={
+                              isOverInstanceLimit
+                                ? t`Can't be higher than the instance limit`
+                                : undefined
+                            }
+                            rightSection={
+                              showAllUsersOverrideTooltip ? (
+                                <AllUsersHigherAccessTooltipIcon
+                                  groupName={allUsersGroup.name}
+                                  variant="group-limits"
+                                />
+                              ) : undefined
+                            }
                           />
-                          {showAllUsersOverrideTooltip && (
-                            <AllUsersHigherAccessTooltipIcon
-                              groupName={allUsersGroup.name}
-                              variant="group-limits"
-                            />
-                          )}
                         </div>
                       </td>
                     </tr>

--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotUsageLimitsPage/GroupLimitsSettingsSection/GroupLimitsTab/GroupLimitsTab.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotUsageLimitsPage/GroupLimitsSettingsSection/GroupLimitsTab/GroupLimitsTab.unit.spec.tsx
@@ -1,7 +1,7 @@
 import userEvent from "@testing-library/user-event";
 
 import { setupUpdateAIControlsGroupLimitEndpoint } from "__support__/server-mocks/metabot";
-import { renderWithProviders, screen, within } from "__support__/ui";
+import { renderWithProviders, screen, waitFor, within } from "__support__/ui";
 import type {
   GroupInfo,
   MetabotGroupLimit,
@@ -163,6 +163,23 @@ describe("GroupLimitsTab", () => {
     setup({ limitPeriod: "weekly", limitType: "tokens" });
 
     expect(screen.getByText(/each week/)).toBeInTheDocument();
+  });
+
+  it("shows error when value exceeds the instance limit", async () => {
+    setup({ instanceLimit: 100 });
+
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    const adminsGroupInput = screen.getByLabelText(
+      /Max tokens per user for Administrators/,
+    );
+    await userEvent.type(adminsGroupInput, "200");
+
+    await waitFor(() => {
+      const alert = screen.getByRole("alert");
+      expect(alert).toHaveTextContent(
+        /Can't be higher than the instance limit/,
+      );
+    });
   });
 
   describe("'All Users' group override warning icons", () => {

--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotUsageLimitsPage/GroupLimitsSettingsSection/TenantLimitsTab/TenantLimitsTab.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotUsageLimitsPage/GroupLimitsSettingsSection/TenantLimitsTab/TenantLimitsTab.tsx
@@ -79,7 +79,12 @@ export function TenantLimitsTab(props: SpecificTenantsTabProps) {
       ...prev,
       [tenant.id]: maxUsage,
     }));
-    debouncedSaveTenantLimit(tenant, maxUsage);
+    const isOverInstanceLimit =
+      maxUsage != null && instanceLimit != null && maxUsage > instanceLimit;
+
+    if (!isOverInstanceLimit) {
+      debouncedSaveTenantLimit(tenant, maxUsage);
+    }
   };
 
   const filteredTenants = useMemo(() => {
@@ -134,28 +139,44 @@ export function TenantLimitsTab(props: SpecificTenantsTabProps) {
                     </tr>
                   </thead>
                   <tbody>
-                    {filteredTenants.map((tenant) => (
-                      <tr key={tenant.id} className={S.BodyRow}>
-                        <td className={S.BodyCell}>{tenant.name}</td>
-                        <td className={S.BodyCell}>
-                          <TextInput
-                            placeholder={placeholder}
-                            value={localLimitsMap?.[tenant.id] ?? ""}
-                            onChange={(e) =>
-                              handleChange(tenant, e.target.value)
-                            }
-                            classNames={{ input: S.LimitInput }}
-                            type="number"
-                            min={1}
-                            aria-label={getInputLabel(
-                              tenant.name,
-                              limitType,
-                              limitPeriod,
-                            )}
-                          />
-                        </td>
-                      </tr>
-                    ))}
+                    {filteredTenants.map((tenant) => {
+                      const inputValue = String(
+                        localLimitsMap?.[tenant.id] ?? "",
+                      );
+                      const maxUsage = sanitizeUsageLimitValue(inputValue);
+                      const isOverInstanceLimit =
+                        maxUsage != null &&
+                        instanceLimit != null &&
+                        maxUsage > instanceLimit;
+
+                      return (
+                        <tr key={tenant.id} className={S.BodyRow}>
+                          <td className={S.BodyCell}>{tenant.name}</td>
+                          <td className={S.BodyCell}>
+                            <TextInput
+                              placeholder={placeholder}
+                              value={inputValue}
+                              onChange={(e) =>
+                                handleChange(tenant, e.target.value)
+                              }
+                              classNames={{ input: S.LimitInput }}
+                              error={
+                                isOverInstanceLimit
+                                  ? t`Can't be higher than the instance limit`
+                                  : undefined
+                              }
+                              type="number"
+                              min={1}
+                              aria-label={getInputLabel(
+                                tenant.name,
+                                limitType,
+                                limitPeriod,
+                              )}
+                            />
+                          </td>
+                        </tr>
+                      );
+                    })}
                   </tbody>
                 </table>
               </Box>

--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotUsageLimitsPage/GroupLimitsSettingsSection/TenantLimitsTab/TenantLimitsTab.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/pages/MetabotUsageLimitsPage/GroupLimitsSettingsSection/TenantLimitsTab/TenantLimitsTab.unit.spec.tsx
@@ -1,7 +1,7 @@
 import userEvent from "@testing-library/user-event";
 
 import { setupUpdateAIControlsTenantLimitEndpoint } from "__support__/server-mocks/metabot";
-import { renderWithProviders, screen } from "__support__/ui";
+import { renderWithProviders, screen, waitFor } from "__support__/ui";
 import type {
   MetabotLimitPeriod,
   MetabotLimitType,
@@ -144,5 +144,22 @@ describe("TenantLimitsTab", () => {
     await userEvent.type(acmeInput, "300");
 
     expect(acmeInput).toHaveValue(300);
+  });
+
+  it("shows error when value exceeds the instance limit", async () => {
+    setup({ instanceLimit: 100 });
+
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    const tenantInput = screen.getByLabelText(
+      /Max total monthly tokens for Acme Corp/,
+    );
+    await userEvent.type(tenantInput, "200");
+
+    await waitFor(() => {
+      const alert = screen.getByRole("alert");
+      expect(alert).toHaveTextContent(
+        /Can't be higher than the instance limit/,
+      );
+    });
   });
 });


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/UXW-3583/show-validation-error-for-group-limits-above-instance-limit
Closes https://linear.app/metabase/issue/UXW-3582/rename-natural-language-query-page-to-ai-exploration-page

### Description

Shows an input error when user tries to set a group or tenant limit greater than the current instance limit.
Additionally, this PR also updates a copy on the AI Customization page

### How to verify

1. Admin > AI > AI usage limits
2. Define a instance level limit (e.g. 10)
3. For any user group, try to set a higher limit (e.g. 11). The error message should appear below the input

### Demo

https://github.com/user-attachments/assets/7d59290a-5bef-4b5d-b02c-47079093bae6

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
