### PR TITLE
UI feedback on Security Center

### DIFF
--- a/e2e/test/scenarios/admin-2/security-center.cy.spec.ts
+++ b/e2e/test/scenarios/admin-2/security-center.cy.spec.ts
@@ -141,23 +141,23 @@ describe("scenarios > admin > security center", { tags: "@EE" }, () => {
       });
     });
 
-    it("should toggle show acknowledged", () => {
-      // Acknowledge the critical advisory first
+    it("should toggle show dismissed", () => {
+      // Dismiss the critical advisory first
       cy.findAllByTestId("advisory-card")
         .first()
         .findByTestId("acknowledge-button")
         .click();
 
-      // It should be hidden by default (acknowledged are hidden)
+      // It should be hidden by default (dismissed are hidden)
       cy.findAllByTestId("advisory-card").should("have.length", 2);
 
-      // Show acknowledged
+      // Show dismissed
       cy.findByTestId("show-acknowledged-filter").click();
       cy.findAllByTestId("advisory-card").should("have.length", 3);
     });
   });
 
-  describe("acknowledge advisory", () => {
+  describe("dismiss advisory", () => {
     beforeEach(() => {
       seedAllAdvisories();
       cy.visit("/admin/security-center");
@@ -166,7 +166,7 @@ describe("scenarios > admin > security center", { tags: "@EE" }, () => {
       });
     });
 
-    it("should acknowledge an advisory and show the badge", () => {
+    it("should dismiss an advisory and show the badge", () => {
       cy.intercept("POST", "/api/ee/security-center/*/acknowledge").as(
         "acknowledge",
       );
@@ -182,16 +182,16 @@ describe("scenarios > admin > security center", { tags: "@EE" }, () => {
       cy.findAllByTestId("advisory-card")
         .first()
         .findByTestId("acknowledged-badge")
-        .should("have.text", "Acknowledged");
+        .should("have.text", "Dismissed");
     });
 
-    it("should hide acknowledged advisories by default", () => {
+    it("should hide dismissed advisories by default", () => {
       cy.findAllByTestId("advisory-card")
         .first()
         .findByTestId("acknowledge-button")
         .click();
 
-      // After acknowledging, the card should disappear
+      // After dismissing, the card should disappear
       cy.findAllByTestId("advisory-card").should("have.length", 2);
     });
   });

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryCard/AdvisoryCard.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryCard/AdvisoryCard.tsx
@@ -49,7 +49,7 @@ export function AdvisoryCard({ advisory, onAcknowledge }: AdvisoryCardProps) {
       </Badge>
       {acknowledged && (
         <Badge color="brand" variant="light" data-testid="acknowledged-badge">
-          {t`Acknowledged`}
+          {t`Dismissed`}
         </Badge>
       )}
     </>
@@ -62,7 +62,7 @@ export function AdvisoryCard({ advisory, onAcknowledge }: AdvisoryCardProps) {
       onClick={() => onAcknowledge(advisory.advisory_id)}
       data-testid="acknowledge-button"
     >
-      {t`Acknowledge`}
+      {t`Dismiss`}
     </Anchor>
   );
 

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryCard/AdvisoryCard.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryCard/AdvisoryCard.tsx
@@ -1,16 +1,7 @@
 import { t } from "ttag";
 
 import { useIsSmallScreen } from "metabase/common/hooks/use-is-small-screen";
-import {
-  Anchor,
-  Badge,
-  Button,
-  Card,
-  Group,
-  Stack,
-  Text,
-  Title,
-} from "metabase/ui";
+import { Anchor, Badge, Card, Group, Stack, Text, Title } from "metabase/ui";
 import type {
   Advisory,
   AdvisoryId,
@@ -65,14 +56,14 @@ export function AdvisoryCard({ advisory, onAcknowledge }: AdvisoryCardProps) {
   );
 
   const acknowledgeButton = !acknowledged && onAcknowledge && (
-    <Button
-      variant="subtle"
-      size="compact-sm"
+    <Anchor
+      component="button"
+      size="sm"
       onClick={() => onAcknowledge(advisory.advisory_id)}
       data-testid="acknowledge-button"
     >
-      {t`Acknowledge`}
-    </Button>
+      {t`Dismiss`}
+    </Anchor>
   );
 
   return (
@@ -114,6 +105,7 @@ export function AdvisoryCard({ advisory, onAcknowledge }: AdvisoryCardProps) {
 
         {(advisory.advisory_url || !isSmallScreen) && (
           <Group gap="md" h={28}>
+            {!isSmallScreen && acknowledgeButton}
             {advisory.advisory_url && (
               <Anchor
                 href={advisory.advisory_url}
@@ -124,7 +116,6 @@ export function AdvisoryCard({ advisory, onAcknowledge }: AdvisoryCardProps) {
                 {t`View advisory`}
               </Anchor>
             )}
-            {!isSmallScreen && acknowledgeButton}
           </Group>
         )}
       </Stack>

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryCard/AdvisoryCard.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryCard/AdvisoryCard.tsx
@@ -62,7 +62,7 @@ export function AdvisoryCard({ advisory, onAcknowledge }: AdvisoryCardProps) {
       onClick={() => onAcknowledge(advisory.advisory_id)}
       data-testid="acknowledge-button"
     >
-      {t`Dismiss`}
+      {t`Acknowledge`}
     </Anchor>
   );
 

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryFilterBar/AdvisoryFilterBar.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/AdvisoryFilterBar/AdvisoryFilterBar.tsx
@@ -64,7 +64,7 @@ export function AdvisoryFilterBar({
         data-testid="status-filter"
       />
       <Checkbox
-        label={t`Show acknowledged`}
+        label={t`Show dismissed`}
         checked={filter.showAcknowledged}
         onChange={(e) =>
           onChange({ ...filter, showAcknowledged: e.currentTarget.checked })

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/NotificationChannelConfigModal/EmailChannelCard/EmailChannelCard.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/NotificationChannelConfigModal/EmailChannelCard/EmailChannelCard.tsx
@@ -35,11 +35,11 @@ export function EmailChannelCard({ isConfigured }: { isConfigured: boolean }) {
 
   return (
     <Card withBorder p="lg" data-testid="email-channel-card">
-      <Group gap="sm" mb="md">
+      <Group gap="sm" mb="lg">
         <Icon name="mail" />
         <Title order={4}>{t`Email`}</Title>
       </Group>
-      <Stack gap="md">
+      <Stack gap="lg">
         <Switch
           label={t`Send to all instance admins`}
           checked={config.email.sendToAllAdmins}

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/NotificationChannelConfigModal/NotificationChannelConfigModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/NotificationChannelConfigModal/NotificationChannelConfigModal.tsx
@@ -87,7 +87,7 @@ export function NotificationChannelConfigModal({
       <Stack gap="md" mt="md">
         <EmailChannelCard isConfigured={isEmailConfigured} />
         <SlackChannelCard isConfigured={isSlackConfigured} />
-        <Flex justify="flex-end" gap="md" mt="md">
+        <Flex justify="space-between" gap="md" mt="md">
           <Button
             variant="subtle"
             leftSection={<Icon name="mail" />}

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/NotificationChannelConfigModal/SlackChannelCard/SlackChannelCard.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/NotificationChannelConfigModal/SlackChannelCard/SlackChannelCard.tsx
@@ -35,7 +35,7 @@ export function SlackChannelCard({ isConfigured }: { isConfigured: boolean }) {
 
   return (
     <Card withBorder p="lg" data-testid="slack-channel-card">
-      <Flex justify="space-between" align="center" mb="md">
+      <Flex justify="space-between" align="center" mb="lg">
         <Group gap="sm">
           <Icon name="slack" />
           <Title order={4}>{t`Slack`}</Title>

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterBanner/SecurityCenterBanner.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterBanner/SecurityCenterBanner.tsx
@@ -94,7 +94,7 @@ export function SecurityCenterBanner() {
       icon="warning_round_filled"
       bg="warning"
       body={
-        <Text lh="inherit">
+        <Text lh="inherit" c="text-primary">
           {jt`No notification channels are configured for security alerts. ${settingsLink}`}
         </Text>
       }

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.module.css
@@ -27,20 +27,6 @@
   }
 }
 
-@keyframes spin {
-  from {
-    transform: rotate(0deg);
-  }
-
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-.syncing {
-  animation: spin 1s linear infinite;
-}
-
 .content {
   flex: 1;
   min-height: 0;

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.module.css
@@ -60,5 +60,8 @@
     display: flex;
     flex-direction: column;
     justify-content: center;
+    max-width: 400px;
+    margin-inline: auto;
+    text-align: center;
   }
 }

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.tsx
@@ -5,7 +5,16 @@ import { useSyncSecurityAdvisoriesMutation } from "metabase/api";
 import { EmptyState } from "metabase/common/components/EmptyState";
 import { useSetting, useToast } from "metabase/common/hooks";
 import { useIsSmallScreen } from "metabase/common/hooks/use-is-small-screen";
-import { Box, Button, Group, Icon, Stack, Text, Title } from "metabase/ui";
+import {
+  Box,
+  Button,
+  Group,
+  Icon,
+  Loader,
+  Stack,
+  Text,
+  Title,
+} from "metabase/ui";
 
 import { trackSecurityCenterPageViewed } from "../../analytics";
 import {
@@ -136,10 +145,7 @@ export function SecurityCenterPage() {
             <Button
               variant="subtle"
               leftSection={
-                <Icon
-                  name="sync"
-                  className={isSyncInProgress ? S.syncing : undefined}
-                />
+                isSyncInProgress ? <Loader size="1rem" /> : <Icon name="sync" />
               }
               onClick={handleSync}
               disabled={isSyncInProgress}

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/SecurityCenterPage/SecurityCenterPage.unit.spec.tsx
@@ -140,7 +140,7 @@ describe("SecurityCenterPage", () => {
     expect(advisoryLink).toHaveAttribute("target", "_blank");
   });
 
-  it("calls acknowledgeAdvisory when acknowledge button is clicked", async () => {
+  it("calls acknowledgeAdvisory when dismiss button is clicked", async () => {
     const advisories = [
       createAdvisory({ advisory_id: "SA-001", acknowledged_at: null }),
     ];
@@ -151,7 +151,7 @@ describe("SecurityCenterPage", () => {
     expect(mockAcknowledge).toHaveBeenCalledWith("SA-001");
   });
 
-  it("does not show acknowledge button for already acknowledged advisories", async () => {
+  it("does not show dismiss button for already dismissed advisories", async () => {
     const advisories = [
       createAdvisory({
         advisory_id: "SA-001",
@@ -161,16 +161,16 @@ describe("SecurityCenterPage", () => {
 
     setup(advisories);
 
-    // Acknowledged advisories are hidden by default — enable the checkbox first
+    // Dismissed advisories are hidden by default — enable the checkbox first
     await userEvent.click(screen.getByTestId("show-acknowledged-filter"));
 
     expect(screen.queryByTestId("acknowledge-button")).not.toBeInTheDocument();
     expect(screen.getByTestId("acknowledged-badge")).toHaveTextContent(
-      "Acknowledged",
+      "Dismissed",
     );
   });
 
-  it("hides acknowledged advisories by default", () => {
+  it("hides dismissed advisories by default", () => {
     const advisories = [
       createAdvisory({
         advisory_id: "1",


### PR DESCRIPTION
 - Use the primary text color on the yellow “No notification channels are configured” banner.
 - Cap the empty state text width for “Your instance is up to date...” at 400px.
 - Fix inconsistent spacing in the Notification settings modal, including wider vertical gaps in the Email section and consistent padding in the Slack section.
 - Move the Send test notification button to the left side of the modal so it is not grouped with Save and Cancel.
 - Replace the animated Check now icon with a loader while checking is in progress.
  - In advisory items, left-align the Acknowledge button with the text above it and use the same text size for Acknowledge and View advisory.
 - Keep Acknowledge on the left when multiple buttons are shown.


Not done:
 - Revisit the Acknowledge button label so it is clearer that the item will be hidden after clicking it (waiting for #writing)