### PR TITLE
add common settings types to custom viz callbacks, improve column settings

### DIFF
--- a/enterprise/frontend/src/custom-viz/package.json
+++ b/enterprise/frontend/src/custom-viz/package.json
@@ -27,6 +27,7 @@
     "lint": "oxlint src/",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "type-check": "tsc --noEmit",
     "release": "bun run build && np"
   },
   "dependencies": {

--- a/enterprise/frontend/src/custom-viz/src/types/data.ts
+++ b/enterprise/frontend/src/custom-viz/src/types/data.ts
@@ -1,4 +1,5 @@
 import type { DateTimeUnit } from "./date-time";
+import type { FormatValueOptions } from "./format";
 
 export type RowValue = string | number | null | boolean | object;
 
@@ -106,4 +107,4 @@ export type Column = {
   settings?: ColumnVisualizationSettings;
 };
 
-export type ColumnVisualizationSettings = Record<string, unknown>; //TODO
+export type ColumnVisualizationSettings = FormatValueOptions;

--- a/enterprise/frontend/src/custom-viz/src/types/viz-settings.ts
+++ b/enterprise/frontend/src/custom-viz/src/types/viz-settings.ts
@@ -90,9 +90,9 @@ export type MultiselectProps = {
 
 type OmitBaseWidgetProps<P> = keyof BaseWidgetProps<
   unknown,
-  unknown
+  Record<string, unknown>
 > extends keyof P
-  ? Omit<P, keyof BaseWidgetProps<unknown, unknown>>
+  ? Omit<P, keyof BaseWidgetProps<unknown, Record<string, unknown>>>
   : P;
 
 type PropsFromWidget<W> = W extends WidgetName
@@ -101,16 +101,16 @@ type PropsFromWidget<W> = W extends WidgetName
     ? OmitBaseWidgetProps<P>
     : never;
 
-type CommonSettings = {
-  "card.title": string | undefined | null;
-  "card.description": string | undefined | null;
-  "card.hide_empty": boolean | undefined | null;
-  click_behavior: ClickBehavior | undefined;
+type CommonVisualizationSettings = {
+  "card.title"?: string | undefined | null;
+  "card.description"?: string | undefined | null;
+  "card.hide_empty"?: boolean | undefined | null;
+  click_behavior?: ClickBehavior | undefined;
 };
 
-export type FinalSettings<
-  CustomVisualizationSettings extends Record<string, unknown>,
-> = CustomVisualizationSettings & CommonSettings;
+export type CustomVisualizationSettings<
+  TSettings extends Record<string, unknown>,
+> = TSettings & CommonVisualizationSettings;
 
 export type CreateDefineSetting<TSettings extends Record<string, unknown>> =
   () => <
@@ -224,7 +224,10 @@ export type CreateDefineSetting<TSettings extends Record<string, unknown>> =
      * @param settings - All settings resolved so far, respecting `readDependencies` ordering.
      * @returns `true` to keep the stored value, `false` to fall back to`getDefault`.
      */
-    isValid?: (series: Series, settings: FinalSettings<TSettings>) => boolean;
+    isValid?: (
+      series: Series,
+      settings: CustomVisualizationSettings<TSettings>,
+    ) => boolean;
 
     /**
      * Computes the default value for this setting when no stored value exists,
@@ -241,7 +244,7 @@ export type CreateDefineSetting<TSettings extends Record<string, unknown>> =
      */
     getDefault?: (
       series: Series,
-      settings: FinalSettings<TSettings>,
+      settings: CustomVisualizationSettings<TSettings>,
     ) => TSettings[Key];
 
     /**
@@ -266,7 +269,7 @@ export type CreateDefineSetting<TSettings extends Record<string, unknown>> =
       ? never
       : (
           series: Series,
-          vizSettings: FinalSettings<TSettings>,
+          vizSettings: CustomVisualizationSettings<TSettings>,
         ) => PropsFromWidget<W>;
 
     /**
@@ -288,7 +291,7 @@ export type CreateDefineSetting<TSettings extends Record<string, unknown>> =
      */
     getValue?: (
       series: Series,
-      settings: FinalSettings<TSettings>,
+      settings: CustomVisualizationSettings<TSettings>,
     ) => TSettings[Key];
   }) => CustomVisualizationSettingDefinition<TSettings>;
 

--- a/enterprise/frontend/src/custom-viz/src/types/viz-settings.ts
+++ b/enterprise/frontend/src/custom-viz/src/types/viz-settings.ts
@@ -108,7 +108,7 @@ type CommonSettings = {
   click_behavior: ClickBehavior | undefined;
 };
 
-type FinalSettings<
+export type FinalSettings<
   CustomVisualizationSettings extends Record<string, unknown>,
 > = CustomVisualizationSettings & CommonSettings;
 

--- a/enterprise/frontend/src/custom-viz/src/types/viz-settings.ts
+++ b/enterprise/frontend/src/custom-viz/src/types/viz-settings.ts
@@ -112,189 +112,185 @@ export type FinalSettings<
   CustomVisualizationSettings extends Record<string, unknown>,
 > = CustomVisualizationSettings & CommonSettings;
 
-export type CreateDefineSetting<
-  CustomVisualizationSettings extends Record<string, unknown>,
-> = () => <
-  W extends WidgetName | ComponentType<any>,
-  Key extends keyof CustomVisualizationSettings,
->(settingDefinition: {
-  /**
-   * Unique key that identifies this setting. Must match the key used in your
-   * `CustomVisualizationSettings` type and in the `settings` map passed to
-   * `createCustomVisualization`.
-   */
-  id: Key;
+export type CreateDefineSetting<TSettings extends Record<string, unknown>> =
+  () => <
+    W extends WidgetName | ComponentType<any>,
+    Key extends keyof TSettings,
+  >(settingDefinition: {
+    /**
+     * Unique key that identifies this setting. Must match the key used in your
+     * `CustomVisualizationSettings` type and in the `settings` map passed to
+     * `createCustomVisualization`.
+     */
+    id: Key;
 
-  /**
-   * Top-level section that this setting appears under in the settings sidebar
-   * (e.g. `"Data"`, `"Display"`, `"Axes"`).
-   */
-  section?: string;
+    /**
+     * Top-level section that this setting appears under in the settings sidebar
+     * (e.g. `"Data"`, `"Display"`, `"Axes"`).
+     */
+    section?: string;
 
-  /** Human-readable label rendered above the widget in the sidebar. */
-  title?: string;
+    /** Human-readable label rendered above the widget in the sidebar. */
+    title?: string;
 
-  /**
-   * Sub-heading within a `section` used to cluster related settings
-   * visually (e.g. `"X-axis"`, `"Y-axis"`). Settings sharing the same
-   * `group` within a section are rendered under a common sub-heading.
-   */
-  group?: string;
+    /**
+     * Sub-heading within a `section` used to cluster related settings
+     * visually (e.g. `"X-axis"`, `"Y-axis"`). Settings sharing the same
+     * `group` within a section are rendered under a common sub-heading.
+     */
+    group?: string;
 
-  /**
-   * Controls the display order of settings when they're placed in the same group.
-   */
-  index?: number;
+    /**
+     * Controls the display order of settings when they're placed in the same group.
+     */
+    index?: number;
 
-  /**
-   * When `true`, the widget is rendered on the same line as its `title`
-   * label rather than below it. Best suited for compact widgets like
-   * `"toggle"`.
-   */
-  inline?: boolean;
+    /**
+     * When `true`, the widget is rendered on the same line as its `title`
+     * label rather than below it. Best suited for compact widgets like
+     * `"toggle"`.
+     */
+    inline?: boolean;
 
-  /**
-   * When `true`, the computed default value (from `getDefault`) is written
-   * into the card's stored `visualization_settings` the first time the query
-   * runs, even though the user never explicitly changed the setting.
-   *
-   * Use this for settings whose default depends on the query result and must
-   * survive subsequent renders without re-running `getDefault`. For example,
-   * auto-selected axis columns are persisted so that manually
-   * reordering series does not lose the original
-   * auto-selection when the question is saved and reopened.
-   *
-   * Without `persistDefault`, `getDefault` re-runs on every render and any
-   * derived state (e.g. user-applied series order) built on top of the
-   * default can be silently reset when data or column order changes.
-   */
-  persistDefault?: boolean;
+    /**
+     * When `true`, the computed default value (from `getDefault`) is written
+     * into the card's stored `visualization_settings` the first time the query
+     * runs, even though the user never explicitly changed the setting.
+     *
+     * Use this for settings whose default depends on the query result and must
+     * survive subsequent renders without re-running `getDefault`. For example,
+     * auto-selected axis columns are persisted so that manually
+     * reordering series does not lose the original
+     * auto-selection when the question is saved and reopened.
+     *
+     * Without `persistDefault`, `getDefault` re-runs on every render and any
+     * derived state (e.g. user-applied series order) built on top of the
+     * default can be silently reset when data or column order changes.
+     */
+    persistDefault?: boolean;
 
-  /**
-   * Setting IDs that must be computed before this setting.
-   *
-   * The settings engine resolves each listed ID first so their values are
-   * available in the `settings` argument passed to `getDefault`, `getValue`,
-   * `isValid`, and `getProps`. Required because computed settings are memoized —
-   * without an explicit ordering a dependency may still be `undefined` when
-   * this setting tries to read it.
-   */
-  readDependencies?: string[];
+    /**
+     * Setting IDs that must be computed before this setting.
+     *
+     * The settings engine resolves each listed ID first so their values are
+     * available in the `settings` argument passed to `getDefault`, `getValue`,
+     * `isValid`, and `getProps`. Required because computed settings are memoized —
+     * without an explicit ordering a dependency may still be `undefined` when
+     * this setting tries to read it.
+     */
+    readDependencies?: string[];
 
-  /**
-   * Setting IDs whose current computed values are persisted alongside this
-   * setting whenever it changes.
-   *
-   * On change, the engine snapshots each listed setting's current computed
-   * value into the write payload. Use this to "lock in" dynamic defaults of
-   * related settings so they aren't silently recalculated under the new
-   * context and lose user intent.
-   */
-  writeDependencies?: string[];
+    /**
+     * Setting IDs whose current computed values are persisted alongside this
+     * setting whenever it changes.
+     *
+     * On change, the engine snapshots each listed setting's current computed
+     * value into the write payload. Use this to "lock in" dynamic defaults of
+     * related settings so they aren't silently recalculated under the new
+     * context and lose user intent.
+     */
+    writeDependencies?: string[];
 
-  /**
-   * Setting IDs that are reset to `null` whenever this setting changes.
-   *
-   * On change, each listed setting is set to `null` in the persisted payload,
-   * forcing it to recompute from scratch on the next render. Use this to
-   * invalidate derived settings whose stored value becomes stale or meaningless
-   * after the change.
-   */
-  eraseDependencies?: string[];
+    /**
+     * Setting IDs that are reset to `null` whenever this setting changes.
+     *
+     * On change, each listed setting is set to `null` in the persisted payload,
+     * forcing it to recompute from scratch on the next render. Use this to
+     * invalidate derived settings whose stored value becomes stale or meaningless
+     * after the change.
+     */
+    eraseDependencies?: string[];
 
-  /**
-   * Widget to render for this setting: either a built-in widget name (`WidgetName`)
-   * or a custom React component (`React.ComponentType<P>`).
-   *
-   * When using a custom component, `getProps` should return only the non-base props;
-   * base widget props are provided by the settings renderer.
-   */
-  widget: W;
+    /**
+     * Widget to render for this setting: either a built-in widget name (`WidgetName`)
+     * or a custom React component (`React.ComponentType<P>`).
+     *
+     * When using a custom component, `getProps` should return only the non-base props;
+     * base widget props are provided by the settings renderer.
+     */
+    widget: W;
 
-  /**
-   * Determines whether the stored value for this setting is still valid given
-   * the current data and resolved settings. Called during the settings
-   * resolution pass before the visualization renders.
-   *
-   * When `isValid` returns `false`, the stored value is discarded and
-   * `getDefault` is used instead. This keeps settings coherent when the
-   * underlying query changes — for example, when a saved column reference no
-   * longer exists in the result set.
-   *
-   * @param series - The current query result (rows + column metadata).
-   * @param settings - All settings resolved so far, respecting `readDependencies` ordering.
-   * @returns `true` to keep the stored value, `false` to fall back to`getDefault`.
-   */
-  isValid?: (
-    series: Series,
-    settings: FinalSettings<CustomVisualizationSettings>,
-  ) => boolean;
+    /**
+     * Determines whether the stored value for this setting is still valid given
+     * the current data and resolved settings. Called during the settings
+     * resolution pass before the visualization renders.
+     *
+     * When `isValid` returns `false`, the stored value is discarded and
+     * `getDefault` is used instead. This keeps settings coherent when the
+     * underlying query changes — for example, when a saved column reference no
+     * longer exists in the result set.
+     *
+     * @param series - The current query result (rows + column metadata).
+     * @param settings - All settings resolved so far, respecting `readDependencies` ordering.
+     * @returns `true` to keep the stored value, `false` to fall back to`getDefault`.
+     */
+    isValid?: (series: Series, settings: FinalSettings<TSettings>) => boolean;
 
-  /**
-   * Computes the default value for this setting when no stored value exists,
-   * or when `isValid` returns `false` for the stored value.
-   *
-   * Called during the settings resolution pass before the visualization renders.
-   * The returned value is used transiently unless `persistDefault` is `true`,
-   * in which case it is written into the card's stored `visualization_settings`
-   * on the first query run.
-   *
-   * @param series - The current query result (rows + column metadata).
-   * @param settings - All settings resolved so far, respecting `readDependencies` ordering.
-   * @returns The default value for this setting.
-   */
-  getDefault?: (
-    series: Series,
-    settings: FinalSettings<CustomVisualizationSettings>,
-  ) => CustomVisualizationSettings[Key];
+    /**
+     * Computes the default value for this setting when no stored value exists,
+     * or when `isValid` returns `false` for the stored value.
+     *
+     * Called during the settings resolution pass before the visualization renders.
+     * The returned value is used transiently unless `persistDefault` is `true`,
+     * in which case it is written into the card's stored `visualization_settings`
+     * on the first query run.
+     *
+     * @param series - The current query result (rows + column metadata).
+     * @param settings - All settings resolved so far, respecting `readDependencies` ordering.
+     * @returns The default value for this setting.
+     */
+    getDefault?: (
+      series: Series,
+      settings: FinalSettings<TSettings>,
+    ) => TSettings[Key];
 
-  /**
-   * Returns additional props passed to the setting's `widget` component,
-   * beyond the base props the engine always provides.
-   *
-   * Called on every render. Use it to derive widget configuration from the
-   * current query result or resolved settings — for example, populating a
-   * dropdown's `options` list from the available columns.
-   *
-   * The return type is inferred from the `widget` value: props of the named
-   * built-in widget when `widget` is a `WidgetName`, or the component's own
-   * props (minus the base props the engine injects) when `widget` is a custom
-   * React component. Omit `getProps` entirely when the widget has no
-   * configurable props (`ToggleProps` is `never`).
-   *
-   * @param series - The current query result (rows + column metadata).
-   * @param vizSettings - All settings resolved so far, respecting `readDependencies` ordering.
-   * @returns Props object merged into the widget component's props.
-   */
-  getProps?: PropsFromWidget<W> extends never
-    ? never
-    : (
-        series: Series,
-        vizSettings: FinalSettings<CustomVisualizationSettings>,
-      ) => PropsFromWidget<W>;
+    /**
+     * Returns additional props passed to the setting's `widget` component,
+     * beyond the base props the engine always provides.
+     *
+     * Called on every render. Use it to derive widget configuration from the
+     * current query result or resolved settings — for example, populating a
+     * dropdown's `options` list from the available columns.
+     *
+     * The return type is inferred from the `widget` value: props of the named
+     * built-in widget when `widget` is a `WidgetName`, or the component's own
+     * props (minus the base props the engine injects) when `widget` is a custom
+     * React component. Omit `getProps` entirely when the widget has no
+     * configurable props (`ToggleProps` is `never`).
+     *
+     * @param series - The current query result (rows + column metadata).
+     * @param vizSettings - All settings resolved so far, respecting `readDependencies` ordering.
+     * @returns Props object merged into the widget component's props.
+     */
+    getProps?: PropsFromWidget<W> extends never
+      ? never
+      : (
+          series: Series,
+          vizSettings: FinalSettings<TSettings>,
+        ) => PropsFromWidget<W>;
 
-  /**
-   * Computes a derived value for this setting on every render, overriding both
-   * the stored value and the result of `getDefault`.
-   *
-   * Use this when the setting's effective value must always be derived from the
-   * current query result or other resolved settings, and storing a user-chosen
-   * value makes no sense. Unlike `getDefault`, `getValue` is always called —
-   * the stored value is never used.
-   *
-   * @param series - The current query result (rows + column metadata).
-   * @param settings - All settings resolved so far, respecting `readDependencies` ordering.
-   * @returns The computed value for this setting.
-   *
-   * @example
-   * // Always reflect the number of series currently in the result
-   * getValue: (series, _settings) => series.length,
-   */
-  getValue?: (
-    series: Series,
-    settings: FinalSettings<CustomVisualizationSettings>,
-  ) => CustomVisualizationSettings[Key];
-}) => CustomVisualizationSettingDefinition<CustomVisualizationSettings>;
+    /**
+     * Computes a derived value for this setting on every render, overriding both
+     * the stored value and the result of `getDefault`.
+     *
+     * Use this when the setting's effective value must always be derived from the
+     * current query result or other resolved settings, and storing a user-chosen
+     * value makes no sense. Unlike `getDefault`, `getValue` is always called —
+     * the stored value is never used.
+     *
+     * @param series - The current query result (rows + column metadata).
+     * @param settings - All settings resolved so far, respecting `readDependencies` ordering.
+     * @returns The computed value for this setting.
+     *
+     * @example
+     * // Always reflect the number of series currently in the result
+     * getValue: (series, _settings) => series.length,
+     */
+    getValue?: (
+      series: Series,
+      settings: FinalSettings<TSettings>,
+    ) => TSettings[Key];
+  }) => CustomVisualizationSettingDefinition<TSettings>;
 
 declare const SettingDefinitionSymbol: unique symbol;
 

--- a/enterprise/frontend/src/custom-viz/src/types/viz-settings.ts
+++ b/enterprise/frontend/src/custom-viz/src/types/viz-settings.ts
@@ -1,7 +1,7 @@
 import type { ComponentType, ReactNode } from "react";
 
 import type { Column, Series } from "./data";
-import type { BaseWidgetProps } from "./viz";
+import type { BaseWidgetProps, ClickBehavior } from "./viz";
 
 export type WidgetName = keyof Widgets;
 
@@ -100,6 +100,17 @@ type PropsFromWidget<W> = W extends WidgetName
   : W extends ComponentType<infer P>
     ? OmitBaseWidgetProps<P>
     : never;
+
+type CommonSettings = {
+  "card.title": string | undefined | null;
+  "card.description": string | undefined | null;
+  "card.hide_empty": boolean | undefined | null;
+  click_behavior: ClickBehavior | undefined;
+};
+
+type FinalSettings<
+  CustomVisualizationSettings extends Record<string, unknown>,
+> = CustomVisualizationSettings & CommonSettings;
 
 export type CreateDefineSetting<
   CustomVisualizationSettings extends Record<string, unknown>,
@@ -214,7 +225,10 @@ export type CreateDefineSetting<
    * @param settings - All settings resolved so far, respecting `readDependencies` ordering.
    * @returns `true` to keep the stored value, `false` to fall back to`getDefault`.
    */
-  isValid?: (series: Series, settings: CustomVisualizationSettings) => boolean;
+  isValid?: (
+    series: Series,
+    settings: FinalSettings<CustomVisualizationSettings>,
+  ) => boolean;
 
   /**
    * Computes the default value for this setting when no stored value exists,
@@ -231,7 +245,7 @@ export type CreateDefineSetting<
    */
   getDefault?: (
     series: Series,
-    settings: CustomVisualizationSettings,
+    settings: FinalSettings<CustomVisualizationSettings>,
   ) => CustomVisualizationSettings[Key];
 
   /**
@@ -255,8 +269,8 @@ export type CreateDefineSetting<
   getProps?: PropsFromWidget<W> extends never
     ? never
     : (
-        object: Series,
-        vizSettings: CustomVisualizationSettings,
+        series: Series,
+        vizSettings: FinalSettings<CustomVisualizationSettings>,
       ) => PropsFromWidget<W>;
 
   /**
@@ -278,7 +292,7 @@ export type CreateDefineSetting<
    */
   getValue?: (
     series: Series,
-    settings: CustomVisualizationSettings,
+    settings: FinalSettings<CustomVisualizationSettings>,
   ) => CustomVisualizationSettings[Key];
 }) => CustomVisualizationSettingDefinition<CustomVisualizationSettings>;
 

--- a/enterprise/frontend/src/custom-viz/src/types/viz.ts
+++ b/enterprise/frontend/src/custom-viz/src/types/viz.ts
@@ -5,21 +5,22 @@ import type { TextHeightMeasurer, TextWidthMeasurer } from "./measure-text";
 import type {
   CreateDefineSetting,
   CustomVisualizationSettingDefinition,
+  FinalSettings,
 } from "./viz-settings";
 
 /**
  * Export this function to define a custom visualization.
  */
 export type CreateCustomVisualization<
-  CustomVisualizationSettings extends Record<string, unknown>,
+  TSettings extends Record<string, unknown>,
 > = (
-  props: CreateCustomVisualizationProps<CustomVisualizationSettings>,
-) => CustomVisualization<CustomVisualizationSettings>;
+  props: CreateCustomVisualizationProps<TSettings>,
+) => CustomVisualization<TSettings>;
 
 export type CreateCustomVisualizationProps<
-  CustomVisualizationSettings extends Record<string, unknown>,
+  TSettings extends Record<string, unknown>,
 > = {
-  defineSetting: ReturnType<CreateDefineSetting<CustomVisualizationSettings>>;
+  defineSetting: ReturnType<CreateDefineSetting<TSettings>>;
 
   /**
    * Returns a URL for a static asset declared in the plugin manifest.
@@ -34,7 +35,7 @@ export type CreateCustomVisualizationProps<
   locale: string;
 };
 
-export type CustomVisualization<CustomVisualizationSettings> = {
+export type CustomVisualization<TSettings extends Record<string, unknown>> = {
   /**
    * A unique visualization identifier. It's not shown in the UI.
    */
@@ -51,7 +52,7 @@ export type CustomVisualization<CustomVisualizationSettings> = {
   canSavePng?: boolean;
 
   /**
-   * Set to true to disable the default visulization header.
+   * Set to true to disable the default visualization header.
    */
   noHeader?: boolean;
 
@@ -69,8 +70,8 @@ export type CustomVisualization<CustomVisualizationSettings> = {
    * Visualization settings definitions.
    */
   settings?: Record<
-    keyof CustomVisualizationSettings,
-    CustomVisualizationSettingDefinition<CustomVisualizationSettings>
+    keyof TSettings,
+    CustomVisualizationSettingDefinition<TSettings>
   >;
 
   /**
@@ -78,29 +79,27 @@ export type CustomVisualization<CustomVisualizationSettings> = {
    */
   checkRenderable: (
     series: Series,
-    settings: CustomVisualizationSettings,
+    settings: FinalSettings<TSettings>,
   ) => void | never;
 
   /**
    * Component that renders the visualization.
    */
-  VisualizationComponent: ComponentType<
-    CustomVisualizationProps<CustomVisualizationSettings>
-  >;
+  VisualizationComponent: ComponentType<CustomVisualizationProps<TSettings>>;
 
   /**
    * Component that renders the visualization.
    */
   StaticVisualizationComponent?: ComponentType<
-    CustomStaticVisualizationProps<CustomVisualizationSettings>
+    CustomStaticVisualizationProps<TSettings>
   >;
 };
 
-export type BaseWidgetProps<TValue, CustomVisualizationSettings> = {
+export type BaseWidgetProps<TValue, TSettings> = {
   id: string;
   value: TValue | undefined;
   onChange: (value?: TValue | null) => void;
-  onChangeSettings: (settings: Partial<CustomVisualizationSettings>) => void;
+  onChangeSettings: (settings: Partial<TSettings>) => void;
 };
 
 export type VisualizationGridSize = {
@@ -115,18 +114,18 @@ export type VisualizationGridSize = {
   height: number;
 };
 
-export type CustomVisualizationProps<CustomVisualizationSettings> = {
+export type CustomVisualizationProps<
+  TSettings extends Record<string, unknown>,
+> = {
   width: number | null;
 
   height: number | null;
 
   series: Series;
 
-  settings: CustomVisualizationSettings;
+  settings: FinalSettings<TSettings>;
 
-  onClick: (
-    clickObject: ClickObject<CustomVisualizationSettings> | null,
-  ) => void;
+  onClick: (clickObject: ClickObject<FinalSettings<TSettings>> | null) => void;
 
   onHover: (hoverObject?: HoverObject | null) => void;
 };
@@ -142,15 +141,15 @@ export interface RenderingContext {
 }
 
 // Equivalent of StaticVisualizationProps
-export type CustomStaticVisualizationProps<CustomVisualizationSettings> = {
+export type CustomStaticVisualizationProps<TSettings> = {
   series: Series;
   renderingContext: RenderingContext;
   isStorybook?: boolean;
-  settings: CustomVisualizationSettings;
+  settings: TSettings;
   hasDevWatermark?: boolean;
 };
 
-export type ClickObject<CustomVisualizationSettings> = {
+export type ClickObject<TSettings extends Record<string, unknown>> = {
   value?: RowValue;
   column?: Column;
   dimensions?: ClickObjectDimension[];
@@ -158,7 +157,7 @@ export type ClickObject<CustomVisualizationSettings> = {
   element?: Element;
   // seriesIndex?: number;
   // cardId?: CardId;
-  settings?: CustomVisualizationSettings;
+  settings?: FinalSettings<TSettings>;
   // columnShortcuts?: boolean;
   origin?: {
     row: RowValue[];
@@ -195,4 +194,14 @@ export type HoverObject = {
   event?: MouseEvent;
 };
 
-export type ClickBehavior = Record<string, unknown>;
+declare const ClickBehaviorSymbol: unique symbol;
+
+/**
+ * Opaque/engine-owned click behavior config.
+ *
+ * This is intentionally not a structural type: custom visualization authors
+ * should treat it as an opaque value (pass through only).
+ */
+export type ClickBehavior = {
+  readonly [ClickBehaviorSymbol]: "ClickBehavior";
+};

--- a/enterprise/frontend/src/custom-viz/src/types/viz.ts
+++ b/enterprise/frontend/src/custom-viz/src/types/viz.ts
@@ -5,7 +5,7 @@ import type { TextHeightMeasurer, TextWidthMeasurer } from "./measure-text";
 import type {
   CreateDefineSetting,
   CustomVisualizationSettingDefinition,
-  FinalSettings,
+  CustomVisualizationSettings,
 } from "./viz-settings";
 
 /**
@@ -79,7 +79,7 @@ export type CustomVisualization<TSettings extends Record<string, unknown>> = {
    */
   checkRenderable: (
     series: Series,
-    settings: FinalSettings<TSettings>,
+    settings: CustomVisualizationSettings<TSettings>,
   ) => void | never;
 
   /**
@@ -95,11 +95,16 @@ export type CustomVisualization<TSettings extends Record<string, unknown>> = {
   >;
 };
 
-export type BaseWidgetProps<TValue, TSettings> = {
+export type BaseWidgetProps<
+  TValue,
+  TSettings extends Record<string, unknown>,
+> = {
   id: string;
   value: TValue | undefined;
   onChange: (value?: TValue | null) => void;
-  onChangeSettings: (settings: Partial<TSettings>) => void;
+  onChangeSettings: (
+    settings: Partial<CustomVisualizationSettings<TSettings>>,
+  ) => void;
 };
 
 export type VisualizationGridSize = {
@@ -123,9 +128,11 @@ export type CustomVisualizationProps<
 
   series: Series;
 
-  settings: FinalSettings<TSettings>;
+  settings: CustomVisualizationSettings<TSettings>;
 
-  onClick: (clickObject: ClickObject<FinalSettings<TSettings>> | null) => void;
+  onClick: (
+    clickObject: ClickObject<CustomVisualizationSettings<TSettings>> | null,
+  ) => void;
 
   onHover: (hoverObject?: HoverObject | null) => void;
 };
@@ -141,11 +148,13 @@ export interface RenderingContext {
 }
 
 // Equivalent of StaticVisualizationProps
-export type CustomStaticVisualizationProps<TSettings> = {
+export type CustomStaticVisualizationProps<
+  TSettings extends Record<string, unknown>,
+> = {
   series: Series;
   renderingContext: RenderingContext;
   isStorybook?: boolean;
-  settings: TSettings;
+  settings: CustomVisualizationSettings<TSettings>;
   hasDevWatermark?: boolean;
 };
 
@@ -157,7 +166,7 @@ export type ClickObject<TSettings extends Record<string, unknown>> = {
   element?: Element;
   // seriesIndex?: number;
   // cardId?: CardId;
-  settings?: FinalSettings<TSettings>;
+  settings?: CustomVisualizationSettings<TSettings>;
   // columnShortcuts?: boolean;
   origin?: {
     row: RowValue[];

--- a/enterprise/frontend/src/custom-viz/src/types/viz.ts
+++ b/enterprise/frontend/src/custom-viz/src/types/viz.ts
@@ -194,3 +194,5 @@ export type HoverObject = {
   element?: Element;
   event?: MouseEvent;
 };
+
+export type ClickBehavior = Record<string, unknown>;


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-2199/improve-typing-of-settings-passed-to-getprops-and-column-settings-in

### Description

- Added common settings that are automatically added to all visualizations `"card.title"`, `"card.description"`, `"card.hide_empty"` and `click_behaviors`
- added missing column settings (formatting options type)
