### PR TITLE
Adjust format-native-query to accept legacy mbql

### DIFF
--- a/src/metabase/metabot/agent/user_context.clj
+++ b/src/metabase/metabot/agent/user_context.clj
@@ -167,16 +167,16 @@
       (str id)
       (str/join ", " (map-indexed (fn [idx _] (str id "-" idx)) chart_configs)))))
 
-(defn- query-details
-  "Extract query details from legacy or modern mbql query."
+(defn- native-query-details
+  "Extract query details from legacy or modern native query."
   [query]
   {:database-id (:database query)
-   :query-str (metabot.u/extract-sql-content query)})
+   :query-str   (metabot.u/extract-sql-content query)})
 
 (defn- format-native-query
   "Format viewing `item`"
   [item]
-  (let [{:keys [database-id query-str]} (query-details (:query item))]
+  (let [{:keys [database-id query-str]} (native-query-details (:query item))]
     (te/lines
      "The user is currently in the SQL editor."
      (when (:id item)

--- a/src/metabase/metabot/agent/user_context.clj
+++ b/src/metabase/metabot/agent/user_context.clj
@@ -10,6 +10,7 @@
    [metabase.metabot.tmpl :as te]
    [metabase.metabot.tools.entity-details :as entity-details]
    [metabase.metabot.tools.shared.llm-representations :as llm-rep]
+   [metabase.metabot.util :as metabot.u]
    [metabase.util :as u]
    [metabase.util.log :as log])
   (:import
@@ -166,26 +167,30 @@
       (str id)
       (str/join ", " (map-indexed (fn [idx _] (str id "-" idx)) chart_configs)))))
 
+(defn- query-details
+  "Extract query details from legacy or modern mbql query."
+  [query]
+  {:database-id (:database query)
+   :query-str (metabot.u/extract-sql-content query)})
+
 (defn- format-native-query
   "Format viewing `item`"
   [item]
-  (assert (lib/native-only-query? (:query item))
-          "Native MBQL5 query expected.")
-  (te/lines
-   "The user is currently in the SQL editor."
-   (when (:id item)
-     (te/field "Query ID" (:id item)))
-   (te/field "Current SQL query"
-             (te/code (lib/raw-native-query (:query item)) "sql"))
-   (te/field "Database ID" (get-in item [:query :database]))
-   (te/field "Database SQL engine" (:sql_engine item))
-   (when-some [error (:error item)]
-     (te/field "Query error" (te/code error)))
-   (when-let [config-ids (format-chart-config-ids item)]
-     (te/field "Chart Config IDs (for analyze_chart tool)" config-ids))
-   (te/field "Tables used" (some->> (:used_tables item)
-                                    (map format-entity)
-                                    te/lines))))
+  (let [{:keys [database-id query-str]} (query-details (:query item))]
+    (te/lines
+     "The user is currently in the SQL editor."
+     (when (:id item)
+       (te/field "Query ID" (:id item)))
+     (te/field "Current SQL query" (te/code query-str "sql"))
+     (te/field "Database ID" database-id)
+     (te/field "Database SQL engine" (:sql_engine item))
+     (when-some [error (:error item)]
+       (te/field "Query error" (te/code error)))
+     (when-let [config-ids (format-chart-config-ids item)]
+       (te/field "Chart Config IDs (for analyze_chart tool)" config-ids))
+     (te/field "Tables used" (some->> (:used_tables item)
+                                      (map format-entity)
+                                      te/lines)))))
 
 (defmethod format-entity "question"
   [entity]

--- a/src/metabase/metabot/tools/sql/edit.clj
+++ b/src/metabase/metabot/tools/sql/edit.clj
@@ -4,21 +4,12 @@
    [clojure.string :as str]
    [metabase.metabot.tools.sql.common :as metabot.tools.sql.common]
    [metabase.metabot.tools.sql.validation :as metabot.tools.sql.validation]
+   [metabase.metabot.util :as metabot.u]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]))
 
 (set! *warn-on-reflection* true)
-
-(defn- extract-sql-content
-  "Extract SQL content from a dataset_query map.
-  Handles both legacy format and lib/query format."
-  [query]
-  (or
-   ;; Try lib/query format (with stages)
-   (get-in query [:stages 0 :native])
-   ;; Try legacy format
-   (get-in query [:native :query])))
 
 (defn- apply-sql-edit
   "Apply a targeted string replacement to SQL content."
@@ -68,7 +59,7 @@
                        :query-id query-id
                        :available-queries (keys queries-state)})))
 
-    (let [current-sql (extract-sql-content query)]
+    (let [current-sql (metabot.u/extract-sql-content query)]
       (when-not current-sql
         (throw (ex-info (tru "Query {0} is not a SQL query" query-id)
                         {:agent-error? true

--- a/src/metabase/metabot/util.clj
+++ b/src/metabase/metabot/util.clj
@@ -4,6 +4,7 @@
    [clojure.set :as set]
    [clojure.string :as str]
    [clojure.walk :as walk]
+   [metabase.lib.core :as lib]
    [metabase.util :as u]
    [metabase.util.json :as json]))
 
@@ -99,3 +100,15 @@
                   (str/starts-with? res "<?xml") (subs (inc (.indexOf res "\n"))))))]
     (->> (map fmt bits)
          (str/join "\n"))))
+
+;;; MBQL utils (needed until we erradicate legacy from Metabot module)
+
+(defn extract-sql-content
+  "Extract SQL content from a dataset_query map.
+  Handles both legacy format and lib/query format."
+  [query]
+  (or
+   (and (lib/native-only-query? query)
+        (lib/raw-native-query query))
+   ;; Try legacy format
+   (get-in query [:native :query])))

--- a/src/metabase/metabot/util.clj
+++ b/src/metabase/metabot/util.clj
@@ -4,7 +4,6 @@
    [clojure.set :as set]
    [clojure.string :as str]
    [clojure.walk :as walk]
-   [metabase.lib.core :as lib]
    [metabase.util :as u]
    [metabase.util.json :as json]))
 
@@ -108,7 +107,10 @@
   Handles both legacy format and lib/query format."
   [query]
   (or
-   (and (lib/native-only-query? query)
-        (lib/raw-native-query query))
+   ;; Following should be ideally handled by lib functions. However we have test in place that checks this piece
+   ;; is able to handle not-normalized mblq5 with e.g. string value for type. Lib functions throw on such input.
+   ;;
+   ;; Try lib/query format (with stages)
+   (get-in query [:stages 0 :native])
    ;; Try legacy format
    (get-in query [:native :query])))

--- a/test/metabase/metabot/agent/user_context_test.clj
+++ b/test/metabase/metabot/agent/user_context_test.clj
@@ -452,5 +452,5 @@
         "Formatting result should be a string.")
     (is (str/includes? result "select 1")
         "Formatting result should contain the native query string")
-    (is (str/includes? result "select 1")
+    (is (str/includes? result "1111")
         "Formatting result should contain database id")))

--- a/test/metabase/metabot/agent/user_context_test.clj
+++ b/test/metabase/metabot/agent/user_context_test.clj
@@ -1,5 +1,6 @@
 (ns metabase.metabot.agent.user-context-test
   (:require
+   [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
@@ -435,3 +436,21 @@
                     {:user_is_viewing [{:type "table" :id (mt/id :orders)}]})]
         (is (re-find #"(?i)orders" result))
         (is (re-find #"(?i)field" result))))))
+
+(deftest ^:parallel format-user-context-with-legacy-query-test
+  (let [lq {:database 1111
+            :type :native
+            :native {:query "select 1"}}
+        {:keys [result error]}
+        (try {:result (user-context/format-viewing-context
+                       {:user_is_viewing [{:type "adhoc" :query lq}]})}
+             (catch Throwable t
+               {:error t}))]
+    (is (nil? error)
+        "Formatting of context with legacy query should yield no error.")
+    (is (string? result)
+        "Formatting result should be a string.")
+    (is (str/includes? result "select 1")
+        "Formatting result should contain the native query string")
+    (is (str/includes? result "select 1")
+        "Formatting result should contain database id")))


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/BOT-1280/metabot-query-fails-intermittently

This PR re-adds ability to handle legacy mbql to formatting code.