### PR TITLE
fix(sdk,embed-js): Refactor query handling to show aggregations/breakout for the last non-empty stage

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/sdk-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/sdk-question.cy.spec.tsx
@@ -416,7 +416,10 @@ describe("scenarios > embedding-sdk > interactive-question", () => {
 
     cy.log("Remove both groupings from the popup");
     popover().within(() => {
-      cy.findAllByLabelText("close icon").should("have.length", 2).last().click();
+      cy.findAllByLabelText("close icon")
+        .should("have.length", 2)
+        .last()
+        .click();
     });
 
     popover().within(() => {

--- a/e2e/test-component/scenarios/embedding-sdk/sdk-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/sdk-question.cy.spec.tsx
@@ -414,8 +414,6 @@ describe("scenarios > embedding-sdk > interactive-question", () => {
       cy.findByText("2 groupings").click();
     });
 
-    cy.wait(200000);
-
     cy.log("Remove both groupings from the popup");
     popover().within(() => {
       // eslint-disable-next-line metabase/no-unsafe-element-filtering

--- a/e2e/test-component/scenarios/embedding-sdk/sdk-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/sdk-question.cy.spec.tsx
@@ -416,7 +416,6 @@ describe("scenarios > embedding-sdk > interactive-question", () => {
 
     cy.log("Remove both groupings from the popup");
     popover().within(() => {
-      // eslint-disable-next-line metabase/no-unsafe-element-filtering
       cy.findAllByLabelText("close icon").last().click();
     });
 

--- a/e2e/test-component/scenarios/embedding-sdk/sdk-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/sdk-question.cy.spec.tsx
@@ -442,12 +442,43 @@ describe("scenarios > embedding-sdk > interactive-question", () => {
     cy.log("Stage switch tooltip should appear on the summary button");
     cy.findByRole("tooltip").should(
       "contain.text",
-      "Switched to the previous stag",
+      "Switched to the previous stage",
     );
     getSdkRoot().within(() => {
       cy.log("Stage 0 (Count + Created At)");
       cy.findByText("1 summary").should("be.visible");
       cy.findByText("1 grouping").should("be.visible");
+
+      cy.log("Add a new summary to stage 0");
+      cy.findByText("1 summary").click();
+    });
+
+    popover().within(() => {
+      cy.findByText("Add another summary").click();
+    });
+
+    popover().within(() => {
+      cy.findByText("Sum of ...").click();
+      cy.findByText("Total").click();
+    });
+
+    getSdkRoot().within(() => {
+      cy.findByText("2 summaries").should("be.visible");
+
+      cy.log("Add a new grouping to stage 0");
+      cy.findByText("1 grouping").click();
+    });
+
+    popover().within(() => {
+      cy.findByText("Add another grouping").click();
+    });
+
+    popover().within(() => {
+      cy.findByText("Product ID").click();
+    });
+
+    getSdkRoot().within(() => {
+      cy.findByText("2 groupings").should("be.visible");
     });
   });
 

--- a/e2e/test-component/scenarios/embedding-sdk/sdk-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/sdk-question.cy.spec.tsx
@@ -444,8 +444,11 @@ describe("scenarios > embedding-sdk > interactive-question", () => {
       "contain.text",
       "Switched to the previous stag",
     );
-    cy.findByText("1 summary").should("be.visible");
-    cy.findByText("1 grouping").should("be.visible");
+    getSdkRoot().within(() => {
+      cy.log("Stage 0 (Count + Created At)");
+      cy.findByText("1 summary").should("be.visible");
+      cy.findByText("1 grouping").should("be.visible");
+    });
   });
 
   it("does not contain known console errors (metabase#48497)", () => {

--- a/e2e/test-component/scenarios/embedding-sdk/sdk-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/sdk-question.cy.spec.tsx
@@ -372,6 +372,69 @@ describe("scenarios > embedding-sdk > interactive-question", () => {
     });
   });
 
+  it.only("should show all summaries and groupings from multi-stage queries and handle removal correctly", () => {
+    mountSdkContent(<InteractiveQuestion questionId="new" />);
+
+    cy.log("Pick starting data");
+    H.popover().findByRole("link", { name: "Orders" }).click();
+
+    cy.log("Stage 0: add Count aggregation");
+    H.getNotebookStep("summarize")
+      .findByText("Pick a function or metric")
+      .click();
+    H.popover().findByRole("option", { name: "Count of rows" }).click();
+
+    cy.log("Stage 0: add Created At grouping");
+    H.getNotebookStep("summarize")
+      .findByText("Pick a column to group by")
+      .click();
+    H.popover().findByRole("heading", { name: "Created At" }).click();
+
+    cy.log("Stage 1: add a second summarize step");
+    cy.button("Summarize").click();
+
+    cy.log("Stage 1: add Max of Count aggregation");
+    H.addSummaryField({ metric: "Maximum of ...", field: "Count", stage: 1 });
+
+    cy.log("Stage 1: add Created At: Month grouping");
+    H.getNotebookStep("summarize", { stage: 1 })
+      .findByText("Pick a column to group by")
+      .click();
+    H.popover().findByText("Created At: Month").click();
+
+    cy.log("Visualize the 2-stage query");
+    H.visualize();
+
+    getSdkRoot().within(() => {
+      cy.log("Toolbar should show 2 summaries and 2 groupings");
+      cy.findByText("2 summaries").should("be.visible");
+      cy.findByText("2 groupings").should("be.visible");
+
+      cy.log("Open groupings popup and verify 2 badges");
+      cy.findByText("2 groupings").click();
+    });
+
+    cy.wait(200000);
+
+    cy.log("Remove both groupings from the popup");
+    popover().within(() => {
+      // eslint-disable-next-line metabase/no-unsafe-element-filtering
+      cy.findAllByLabelText("close icon").last().click();
+    });
+
+    popover().within(() => {
+      cy.findAllByLabelText("close icon").click();
+    });
+
+    getSdkRoot().within(() => {
+      cy.log(
+        "After removing both groupings, only 1 summary should remain (empty stage gets dropped)",
+      );
+      cy.findByText("1 summary").should("be.visible");
+      cy.findByText("Group").should("be.visible");
+    });
+  });
+
   it("does not contain known console errors (metabase#48497)", () => {
     cy.get<number>("@questionId").then((questionId) => {
       mountSdkContentAndAssertNoKnownErrors(

--- a/e2e/test-component/scenarios/embedding-sdk/sdk-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/sdk-question.cy.spec.tsx
@@ -372,7 +372,7 @@ describe("scenarios > embedding-sdk > interactive-question", () => {
     });
   });
 
-  it.only("should show the last visible stage and fall back to the previous stage when current is cleared", () => {
+  it("should show the last visible stage and fall back to the previous stage when current is cleared", () => {
     mountSdkContent(<InteractiveQuestion questionId="new" />);
 
     cy.log("Pick starting data");

--- a/e2e/test-component/scenarios/embedding-sdk/sdk-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/sdk-question.cy.spec.tsx
@@ -372,7 +372,7 @@ describe("scenarios > embedding-sdk > interactive-question", () => {
     });
   });
 
-  it("should show all summaries and groupings from multi-stage queries and handle removal correctly", () => {
+  it.only("should show the last visible stage and fall back to the previous stage when current is cleared", () => {
     mountSdkContent(<InteractiveQuestion questionId="new" />);
 
     cy.log("Pick starting data");
@@ -406,20 +406,25 @@ describe("scenarios > embedding-sdk > interactive-question", () => {
     H.visualize();
 
     getSdkRoot().within(() => {
-      cy.log("Toolbar should show 2 summaries and 2 groupings");
-      cy.findByText("2 summaries").should("be.visible");
-      cy.findByText("2 groupings").should("be.visible");
+      cy.log("Toolbar should show stage 1: 1 summary and 1 grouping");
+      cy.findByText("1 summary").should("be.visible");
+      cy.findByText("1 grouping").should("be.visible");
 
-      cy.log("Open groupings popup and verify 2 badges");
-      cy.findByText("2 groupings").click();
+      cy.log("Remove the grouping from stage 1");
+      cy.findByText("1 grouping").click();
     });
 
-    cy.log("Remove both groupings from the popup");
     popover().within(() => {
-      cy.findAllByLabelText("close icon")
-        .should("have.length", 2)
-        .last()
-        .click();
+      cy.findAllByLabelText("close icon").click();
+    });
+
+    getSdkRoot().within(() => {
+      cy.log("Stage 1 still has an aggregation, toolbar shows it");
+      cy.findByText("1 summary").should("be.visible");
+      cy.findByText("Group").should("be.visible");
+
+      cy.log("Remove the aggregation from stage 1");
+      cy.findByText("1 summary").click();
     });
 
     popover().within(() => {
@@ -428,11 +433,19 @@ describe("scenarios > embedding-sdk > interactive-question", () => {
 
     getSdkRoot().within(() => {
       cy.log(
-        "After removing both groupings, only 1 summary should remain (empty stage gets dropped)",
+        "Stage 1 is now empty — toolbar falls back to stage 0 (Count + Created At)",
       );
       cy.findByText("1 summary").should("be.visible");
-      cy.findByText("Group").should("be.visible");
+      cy.findByText("1 grouping").should("be.visible");
     });
+
+    cy.log("Stage switch tooltip should appear on the summary button");
+    cy.findByRole("tooltip").should(
+      "contain.text",
+      "Switched to the previous stag",
+    );
+    cy.findByText("1 summary").should("be.visible");
+    cy.findByText("1 grouping").should("be.visible");
   });
 
   it("does not contain known console errors (metabase#48497)", () => {

--- a/e2e/test-component/scenarios/embedding-sdk/sdk-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/sdk-question.cy.spec.tsx
@@ -416,7 +416,7 @@ describe("scenarios > embedding-sdk > interactive-question", () => {
 
     cy.log("Remove both groupings from the popup");
     popover().within(() => {
-      cy.findAllByLabelText("close icon").last().click();
+      cy.findAllByLabelText("close icon").should("have.length", 2).last().click();
     });
 
     popover().within(() => {

--- a/e2e/test-component/scenarios/embedding-sdk/sdk-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/sdk-question.cy.spec.tsx
@@ -372,7 +372,7 @@ describe("scenarios > embedding-sdk > interactive-question", () => {
     });
   });
 
-  it.only("should show all summaries and groupings from multi-stage queries and handle removal correctly", () => {
+  it("should show all summaries and groupings from multi-stage queries and handle removal correctly", () => {
     mountSdkContent(<InteractiveQuestion questionId="new" />);
 
     cy.log("Pick starting data");

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Breakout/BreakoutPicker/BreakoutPicker.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Breakout/BreakoutPicker/BreakoutPicker.tsx
@@ -68,7 +68,7 @@ export const BreakoutPicker = ({
 }) => {
   const {
     question,
-    updateQuestion,
+    updateAndNormalizeQuestion,
     lastVisibleStageIndex: stageIndex,
   } = useSdkQuestionContext();
 
@@ -80,7 +80,7 @@ export const BreakoutPicker = ({
 
   const onQueryChange = (nextQuery: Lib.Query) => {
     if (question) {
-      updateQuestion(question.setQuery(nextQuery), { run: true });
+      updateAndNormalizeQuestion(question.setQuery(nextQuery), { run: true });
     }
   };
 

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Breakout/BreakoutPicker/BreakoutPicker.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Breakout/BreakoutPicker/BreakoutPicker.tsx
@@ -73,7 +73,7 @@ export const BreakoutPicker = ({
   }
 
   const query = question.query();
-  const stageIndex = breakoutItem?.stageIndex ?? -1;
+  const stageIndex = -1;
 
   const onQueryChange = (nextQuery: Lib.Query) => {
     if (question) {

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Breakout/BreakoutPicker/BreakoutPicker.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Breakout/BreakoutPicker/BreakoutPicker.tsx
@@ -9,7 +9,6 @@ import { Button, Divider, Icon, Stack } from "metabase/ui";
 import * as Lib from "metabase-lib";
 
 import { useSdkQuestionContext } from "../../../context";
-import { LAST_STAGE_INDEX } from "../../../utils/stages";
 import type { SDKBreakoutItem } from "../use-breakout-data";
 
 export const BreakoutPickerInner = ({
@@ -67,7 +66,11 @@ export const BreakoutPicker = ({
   onClose?: () => void;
   breakoutItem?: SDKBreakoutItem;
 }) => {
-  const { question, updateQuestion } = useSdkQuestionContext();
+  const {
+    question,
+    updateQuestion,
+    lastVisibleStageIndex: stageIndex,
+  } = useSdkQuestionContext();
 
   if (!question) {
     return null;
@@ -89,7 +92,7 @@ export const BreakoutPicker = ({
       breakoutItem={breakoutItem}
       query={query}
       onQueryChange={onQueryChange}
-      stageIndex={LAST_STAGE_INDEX}
+      stageIndex={stageIndex}
     />
   );
 };

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Breakout/BreakoutPicker/BreakoutPicker.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Breakout/BreakoutPicker/BreakoutPicker.tsx
@@ -6,7 +6,7 @@ import {
 } from "metabase/query_builder/hooks";
 import { BreakoutPopover } from "metabase/querying/notebook/components/BreakoutStep";
 import { Button, Divider, Icon, Stack } from "metabase/ui";
-import type * as Lib from "metabase-lib";
+import * as Lib from "metabase-lib";
 
 import { useSdkQuestionContext } from "../../../context";
 import type { SDKBreakoutItem } from "../use-breakout-data";
@@ -73,11 +73,13 @@ export const BreakoutPicker = ({
   }
 
   const query = question.query();
-  const stageIndex = -1;
+  const stageIndex = breakoutItem?.stageIndex ?? -1;
 
-  const onQueryChange = (query: Lib.Query) => {
+  const onQueryChange = (nextQuery: Lib.Query) => {
     if (question) {
-      updateQuestion(question.setQuery(query), { run: true });
+      updateQuestion(question.setQuery(Lib.dropEmptyStages(nextQuery)), {
+        run: true,
+      });
     }
   };
 

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Breakout/BreakoutPicker/BreakoutPicker.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Breakout/BreakoutPicker/BreakoutPicker.tsx
@@ -6,7 +6,7 @@ import {
 } from "metabase/query_builder/hooks";
 import { BreakoutPopover } from "metabase/querying/notebook/components/BreakoutStep";
 import { Button, Divider, Icon, Stack } from "metabase/ui";
-import * as Lib from "metabase-lib";
+import type * as Lib from "metabase-lib";
 
 import { useSdkQuestionContext } from "../../../context";
 import type { SDKBreakoutItem } from "../use-breakout-data";
@@ -80,9 +80,7 @@ export const BreakoutPicker = ({
 
   const onQueryChange = (nextQuery: Lib.Query) => {
     if (question) {
-      updateQuestion(question.setQuery(Lib.dropEmptyStages(nextQuery)), {
-        run: true,
-      });
+      updateQuestion(question.setQuery(nextQuery), { run: true });
     }
   };
 

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Breakout/BreakoutPicker/BreakoutPicker.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Breakout/BreakoutPicker/BreakoutPicker.tsx
@@ -9,6 +9,7 @@ import { Button, Divider, Icon, Stack } from "metabase/ui";
 import * as Lib from "metabase-lib";
 
 import { useSdkQuestionContext } from "../../../context";
+import { LAST_STAGE_INDEX } from "../../../utils/stages";
 import type { SDKBreakoutItem } from "../use-breakout-data";
 
 export const BreakoutPickerInner = ({
@@ -73,7 +74,6 @@ export const BreakoutPicker = ({
   }
 
   const query = question.query();
-  const stageIndex = -1;
 
   const onQueryChange = (nextQuery: Lib.Query) => {
     if (question) {
@@ -89,7 +89,7 @@ export const BreakoutPicker = ({
       breakoutItem={breakoutItem}
       query={query}
       onQueryChange={onQueryChange}
-      stageIndex={stageIndex}
+      stageIndex={LAST_STAGE_INDEX}
     />
   );
 };

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Breakout/use-breakout-data.ts
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Breakout/use-breakout-data.ts
@@ -7,6 +7,7 @@ import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
 
 import { useSdkQuestionContext } from "../../context";
+import { hasAggregationWithoutBreakoutOnPrevStage } from "../../utils/stages";
 
 export interface SDKBreakoutItem extends BreakoutListItem {
   stageIndex: number;
@@ -85,20 +86,3 @@ export const useBreakoutData = (): SDKBreakoutItem[] => {
         });
     });
 };
-
-/**
- * Matches the notebook editor's logic: a stage is hidden when
- * the previous stage has aggregations but no breakouts.
- * See `getQuestionSteps` in notebook/utils/steps.ts.
- */
-function hasAggregationWithoutBreakoutOnPrevStage(
-  query: Lib.Query,
-  stageIndex: number,
-) {
-  if (stageIndex >= 1) {
-    const hasAggregations = Lib.aggregations(query, stageIndex - 1).length > 0;
-    const hasBreakouts = Lib.breakouts(query, stageIndex - 1).length > 0;
-    return hasAggregations && !hasBreakouts;
-  }
-  return false;
-}

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Breakout/use-breakout-data.ts
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Breakout/use-breakout-data.ts
@@ -7,7 +7,6 @@ import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
 
 import { useSdkQuestionContext } from "../../context";
-import { getLastVisibleStageIndex } from "../../utils/stages";
 
 export interface SDKBreakoutItem extends BreakoutListItem {
   breakoutIndex: number;
@@ -17,8 +16,11 @@ export interface SDKBreakoutItem extends BreakoutListItem {
 }
 
 export const useBreakoutData = (): SDKBreakoutItem[] => {
-  const { updateQuestion, ...interactiveQuestionContext } =
-    useSdkQuestionContext();
+  const {
+    updateQuestion,
+    lastVisibleStageIndex: stageIndex,
+    ...interactiveQuestionContext
+  } = useSdkQuestionContext();
   const question = interactiveQuestionContext.question as Question;
   const onQueryChange = (nextQuery: Lib.Query) => {
     if (question) {
@@ -33,8 +35,6 @@ export const useBreakoutData = (): SDKBreakoutItem[] => {
   if (!query) {
     return [];
   }
-
-  const stageIndex = getLastVisibleStageIndex(query);
   const breakouts = Lib.breakouts(query, stageIndex);
 
   return breakouts

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Breakout/use-breakout-data.ts
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Breakout/use-breakout-data.ts
@@ -7,10 +7,9 @@ import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
 
 import { useSdkQuestionContext } from "../../context";
-import { hasAggregationWithoutBreakoutOnPrevStage } from "../../utils/stages";
+import { getLastVisibleStageIndex } from "../../utils/stages";
 
 export interface SDKBreakoutItem extends BreakoutListItem {
-  stageIndex: number;
   breakoutIndex: number;
   removeBreakout: () => void;
   updateBreakout: (column: Lib.ColumnMetadata) => void;
@@ -35,54 +34,43 @@ export const useBreakoutData = (): SDKBreakoutItem[] => {
     return [];
   }
 
-  return Lib.stageIndexes(query)
-    .filter(
-      (stageIndex) =>
-        !hasAggregationWithoutBreakoutOnPrevStage(query, stageIndex),
-    )
-    .flatMap((stageIndex) => {
-      const breakouts = Lib.breakouts(query, stageIndex);
+  const stageIndex = getLastVisibleStageIndex(query);
+  const breakouts = Lib.breakouts(query, stageIndex);
 
-      return breakouts
-        .map((breakout) => getBreakoutListItem(query, stageIndex, breakout))
-        .filter(isNotNull)
-        .map((item, index) => {
-          const removeBreakout = () => {
-            if (item.breakout) {
-              const nextQuery = Lib.removeClause(
-                query,
-                stageIndex,
-                item.breakout,
-              );
-              onQueryChange(nextQuery);
-            }
-          };
+  return breakouts
+    .map((breakout) => getBreakoutListItem(query, stageIndex, breakout))
+    .filter(isNotNull)
+    .map((item, index) => {
+      const removeBreakout = () => {
+        if (item.breakout) {
+          const nextQuery = Lib.removeClause(query, stageIndex, item.breakout);
+          onQueryChange(nextQuery);
+        }
+      };
 
-          const updateBreakout = (column: Lib.ColumnMetadata) => {
-            if (item.breakout) {
-              const nextQuery = Lib.replaceClause(
-                query,
-                stageIndex,
-                item.breakout,
-                column,
-              );
-              onQueryChange(nextQuery);
-            }
-          };
-
-          const replaceBreakoutColumn = (column: Lib.ColumnMetadata) => {
-            const nextQuery = Lib.replaceBreakouts(query, stageIndex, column);
-            onQueryChange(nextQuery);
-          };
-
-          return {
-            ...item,
+      const updateBreakout = (column: Lib.ColumnMetadata) => {
+        if (item.breakout) {
+          const nextQuery = Lib.replaceClause(
+            query,
             stageIndex,
-            breakoutIndex: index,
-            removeBreakout,
-            updateBreakout,
-            replaceBreakoutColumn,
-          };
-        });
+            item.breakout,
+            column,
+          );
+          onQueryChange(nextQuery);
+        }
+      };
+
+      const replaceBreakoutColumn = (column: Lib.ColumnMetadata) => {
+        const nextQuery = Lib.replaceBreakouts(query, stageIndex, column);
+        onQueryChange(nextQuery);
+      };
+
+      return {
+        ...item,
+        breakoutIndex: index,
+        removeBreakout,
+        updateBreakout,
+        replaceBreakoutColumn,
+      };
     });
 };

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Breakout/use-breakout-data.ts
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Breakout/use-breakout-data.ts
@@ -24,9 +24,7 @@ export const useBreakoutData = (): SDKBreakoutItem[] => {
   const question = interactiveQuestionContext.question as Question;
   const onQueryChange = (nextQuery: Lib.Query) => {
     if (question) {
-      updateQuestion(question.setQuery(Lib.dropEmptyStages(nextQuery)), {
-        run: true,
-      });
+      updateQuestion(question.setQuery(nextQuery), { run: true });
     }
   };
 

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Breakout/use-breakout-data.ts
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Breakout/use-breakout-data.ts
@@ -2,7 +2,6 @@ import {
   type ListItem as BreakoutListItem,
   getBreakoutListItem,
 } from "metabase/query_builder/components/view/sidebars/SummarizeSidebar/BreakoutColumnList";
-import { useBreakoutQueryHandlers } from "metabase/query_builder/hooks";
 import { isNotNull } from "metabase/utils/types";
 import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
@@ -10,6 +9,7 @@ import type Question from "metabase-lib/v1/Question";
 import { useSdkQuestionContext } from "../../context";
 
 export interface SDKBreakoutItem extends BreakoutListItem {
+  stageIndex: number;
   breakoutIndex: number;
   removeBreakout: () => void;
   updateBreakout: (column: Lib.ColumnMetadata) => void;
@@ -20,49 +20,85 @@ export const useBreakoutData = (): SDKBreakoutItem[] => {
   const { updateQuestion, ...interactiveQuestionContext } =
     useSdkQuestionContext();
   const question = interactiveQuestionContext.question as Question;
-  const onQueryChange = (query: Lib.Query) => {
+  const onQueryChange = (nextQuery: Lib.Query) => {
     if (question) {
-      updateQuestion(question.setQuery(query), { run: true });
+      updateQuestion(question.setQuery(Lib.dropEmptyStages(nextQuery)), {
+        run: true,
+      });
     }
   };
 
   const query = question?.query();
-  const stageIndex = -1;
 
-  const { onUpdateBreakout, onRemoveBreakout, onReplaceBreakouts } =
-    useBreakoutQueryHandlers({ query, onQueryChange, stageIndex });
+  if (!query) {
+    return [];
+  }
 
-  const breakouts = query ? Lib.breakouts(query, stageIndex) : [];
+  return Lib.stageIndexes(query)
+    .filter(
+      (stageIndex) =>
+        !hasAggregationWithoutBreakoutOnPrevStage(query, stageIndex),
+    )
+    .flatMap((stageIndex) => {
+      const breakouts = Lib.breakouts(query, stageIndex);
 
-  const items: BreakoutListItem[] = query
-    ? breakouts
+      return breakouts
         .map((breakout) => getBreakoutListItem(query, stageIndex, breakout))
         .filter(isNotNull)
-    : [];
+        .map((item, index) => {
+          const removeBreakout = () => {
+            if (item.breakout) {
+              const nextQuery = Lib.removeClause(
+                query,
+                stageIndex,
+                item.breakout,
+              );
+              onQueryChange(nextQuery);
+            }
+          };
 
-  return items.map((item, index) => {
-    const removeBreakout = () => {
-      if (item.breakout) {
-        return onRemoveBreakout(item.breakout);
-      }
-    };
+          const updateBreakout = (column: Lib.ColumnMetadata) => {
+            if (item.breakout) {
+              const nextQuery = Lib.replaceClause(
+                query,
+                stageIndex,
+                item.breakout,
+                column,
+              );
+              onQueryChange(nextQuery);
+            }
+          };
 
-    const updateBreakout = (column: Lib.ColumnMetadata) => {
-      if (item.breakout) {
-        return onUpdateBreakout(item.breakout, column);
-      }
-    };
+          const replaceBreakoutColumn = (column: Lib.ColumnMetadata) => {
+            const nextQuery = Lib.replaceBreakouts(query, stageIndex, column);
+            onQueryChange(nextQuery);
+          };
 
-    const replaceBreakoutColumn = (column: Lib.ColumnMetadata) => {
-      return onReplaceBreakouts(column);
-    };
-
-    return {
-      ...item,
-      breakoutIndex: index,
-      removeBreakout,
-      updateBreakout,
-      replaceBreakoutColumn,
-    };
-  });
+          return {
+            ...item,
+            stageIndex,
+            breakoutIndex: index,
+            removeBreakout,
+            updateBreakout,
+            replaceBreakoutColumn,
+          };
+        });
+    });
 };
+
+/**
+ * Matches the notebook editor's logic: a stage is hidden when
+ * the previous stage has aggregations but no breakouts.
+ * See `getQuestionSteps` in notebook/utils/steps.ts.
+ */
+function hasAggregationWithoutBreakoutOnPrevStage(
+  query: Lib.Query,
+  stageIndex: number,
+) {
+  if (stageIndex >= 1) {
+    const hasAggregations = Lib.aggregations(query, stageIndex - 1).length > 0;
+    const hasBreakouts = Lib.breakouts(query, stageIndex - 1).length > 0;
+    return hasAggregations && !hasBreakouts;
+  }
+  return false;
+}

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Breakout/use-breakout-data.ts
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Breakout/use-breakout-data.ts
@@ -17,14 +17,14 @@ export interface SDKBreakoutItem extends BreakoutListItem {
 
 export const useBreakoutData = (): SDKBreakoutItem[] => {
   const {
-    updateQuestion,
+    updateAndNormalizeQuestion,
     lastVisibleStageIndex: stageIndex,
     ...interactiveQuestionContext
   } = useSdkQuestionContext();
   const question = interactiveQuestionContext.question as Question;
   const onQueryChange = (nextQuery: Lib.Query) => {
     if (question) {
-      updateQuestion(question.setQuery(nextQuery), { run: true });
+      updateAndNormalizeQuestion(question.setQuery(nextQuery), { run: true });
     }
   };
 

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Filter/FilterPicker/FilterPicker.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Filter/FilterPicker/FilterPicker.tsx
@@ -8,6 +8,7 @@ import { Box } from "metabase/ui";
 import type * as Lib from "metabase-lib";
 
 import { useSdkQuestionContext } from "../../../context";
+import { LAST_STAGE_INDEX } from "../../../utils/stages";
 import type { SDKFilterItem } from "../hooks/use-filter-data";
 import { useFilterHandlers } from "../hooks/use-filter-handlers";
 
@@ -76,7 +77,6 @@ export const FilterPicker = ({
   };
 
   const query = question.query();
-  const stageIndex = -1;
 
   return (
     <FilterPickerInner
@@ -86,7 +86,7 @@ export const FilterPicker = ({
       onClose={onClose}
       onBack={onBack}
       query={query}
-      stageIndex={stageIndex}
+      stageIndex={LAST_STAGE_INDEX}
       onQueryChange={onQueryChange}
     />
   );

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Filter/hooks/use-filter-data.ts
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Filter/hooks/use-filter-data.ts
@@ -5,6 +5,8 @@ import type { FilterItem } from "metabase/querying/filters/components/FilterPane
 import { getFilterItems } from "metabase/querying/filters/components/FilterPanel/utils";
 import * as Lib from "metabase-lib";
 
+import { LAST_STAGE_INDEX } from "../../../utils/stages";
+
 import { useFilterHandlers } from "./use-filter-handlers";
 
 type FilterItemWithDisplay = FilterItem & Lib.ClauseDisplayInfo;
@@ -19,7 +21,6 @@ export const useFilterData = (): SDKFilterItem[] => {
   const { question, updateQuestion } = useSdkQuestionContext();
 
   const query = question?.query();
-  const stageIndex = -1;
   const onQueryChange = useCallback(
     (newQuery: Lib.Query) => {
       if (question) {
@@ -34,7 +35,7 @@ export const useFilterData = (): SDKFilterItem[] => {
     onUpdateFilter: handleUpdateFilter,
   } = useFilterHandlers({
     query,
-    stageIndex,
+    stageIndex: LAST_STAGE_INDEX,
     onQueryChange,
   });
 

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Filter/hooks/use-filter-handlers.ts
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Filter/hooks/use-filter-handlers.ts
@@ -1,9 +1,11 @@
 import type { UpdateQueryHookProps } from "metabase/query_builder/hooks";
 import * as Lib from "metabase-lib";
 
+import { LAST_STAGE_INDEX } from "../../../utils/stages";
+
 export const useFilterHandlers = ({
   query,
-  stageIndex = -1,
+  stageIndex = LAST_STAGE_INDEX,
   onQueryChange,
 }: Partial<UpdateQueryHookProps>) => {
   const onAddFilter = (filter: Lib.Filterable) => {

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Summarize/SummarizeDropdown/SummarizeDropdown.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Summarize/SummarizeDropdown/SummarizeDropdown.tsx
@@ -7,8 +7,9 @@ import {
   MultiStepPopover,
   type MultiStepState,
 } from "embedding-sdk-bundle/components/private/util/MultiStepPopover";
-import type { PopoverProps } from "metabase/ui";
+import { type PopoverProps, Tooltip } from "metabase/ui";
 
+import { useStageChangeTooltip } from "../../../hooks/use-stage-change-tooltip";
 import { ToolbarButton } from "../../util/ToolbarButton";
 import { SummarizeBadgeList } from "../SummarizeBadgeList";
 import {
@@ -36,6 +37,7 @@ export const SummarizeDropdown = ({
   ...popoverProps
 }: SummarizeDropdownProps) => {
   const aggregationItems = useSummarizeData();
+  const showStageChangeTooltip = useStageChangeTooltip();
 
   const label = match(aggregationItems.length)
     .with(0, () => t`Summarize`)
@@ -67,20 +69,26 @@ export const SummarizeDropdown = ({
       {...popoverProps}
     >
       <MultiStepPopover.Target>
-        <ToolbarButton
-          label={label}
-          icon="sum"
-          isHighlighted={aggregationItems.length > 0}
-          onClick={() =>
-            setStep(
-              step === null
-                ? aggregationItems.length === 0
-                  ? "picker"
-                  : "list"
-                : null,
-            )
-          }
-        />
+        <Tooltip
+          label={t`Switched to the previous stage`}
+          opened={showStageChangeTooltip}
+          position="bottom"
+        >
+          <ToolbarButton
+            label={label}
+            icon="sum"
+            isHighlighted={aggregationItems.length > 0}
+            onClick={() =>
+              setStep(
+                step === null
+                  ? aggregationItems.length === 0
+                    ? "picker"
+                    : "list"
+                  : null,
+              )
+            }
+          />
+        </Tooltip>
       </MultiStepPopover.Target>
       <MultiStepPopover.Step value="picker">
         <SummarizePicker

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Summarize/SummarizePicker/SummarizePicker.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Summarize/SummarizePicker/SummarizePicker.tsx
@@ -7,7 +7,6 @@ import {
 import * as Lib from "metabase-lib";
 
 import { useSdkQuestionContext } from "../../../context";
-import { LAST_STAGE_INDEX } from "../../../utils/stages";
 import { BadgeList, type BadgeListProps } from "../../util/BadgeList";
 import {
   type SDKAggregationItem,
@@ -21,7 +20,11 @@ export const SummarizePicker = ({
 }: {
   aggregation?: SDKAggregationItem;
 } & Pick<AggregationPickerProps, "className" | "onClose" | "onBack">) => {
-  const { question, updateQuestion } = useSdkQuestionContext();
+  const {
+    question,
+    updateQuestion,
+    lastVisibleStageIndex: stageIndex,
+  } = useSdkQuestionContext();
 
   if (!question) {
     return null;
@@ -38,12 +41,12 @@ export const SummarizePicker = ({
     <AggregationPicker
       className={className}
       query={query}
-      stageIndex={LAST_STAGE_INDEX}
+      stageIndex={stageIndex}
       clause={aggregation?.aggregation}
       clauseIndex={aggregation?.aggregationIndex}
       operators={
         aggregation?.operators ??
-        Lib.availableAggregationOperators(query, LAST_STAGE_INDEX)
+        Lib.availableAggregationOperators(query, stageIndex)
       }
       onQueryChange={onQueryChange}
       onBack={aggregationPickerProps.onBack}

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Summarize/SummarizePicker/SummarizePicker.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Summarize/SummarizePicker/SummarizePicker.tsx
@@ -22,7 +22,7 @@ export const SummarizePicker = ({
 } & Pick<AggregationPickerProps, "className" | "onClose" | "onBack">) => {
   const {
     question,
-    updateQuestion,
+    updateAndNormalizeQuestion,
     lastVisibleStageIndex: stageIndex,
   } = useSdkQuestionContext();
 
@@ -32,7 +32,7 @@ export const SummarizePicker = ({
 
   const query = question.query();
   const onQueryChange = (newQuery: Lib.Query) => {
-    updateQuestion(question.setQuery(newQuery), { run: true });
+    updateAndNormalizeQuestion(question.setQuery(newQuery), { run: true });
   };
 
   return (

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Summarize/SummarizePicker/SummarizePicker.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Summarize/SummarizePicker/SummarizePicker.tsx
@@ -7,6 +7,7 @@ import {
 import * as Lib from "metabase-lib";
 
 import { useSdkQuestionContext } from "../../../context";
+import { LAST_STAGE_INDEX } from "../../../utils/stages";
 import { BadgeList, type BadgeListProps } from "../../util/BadgeList";
 import {
   type SDKAggregationItem,
@@ -27,7 +28,6 @@ export const SummarizePicker = ({
   }
 
   const query = question.query();
-  const stageIndex = -1;
   const onQueryChange = (newQuery: Lib.Query) => {
     updateQuestion(question.setQuery(Lib.dropEmptyStages(newQuery)), {
       run: true,
@@ -38,12 +38,12 @@ export const SummarizePicker = ({
     <AggregationPicker
       className={className}
       query={query}
-      stageIndex={stageIndex}
+      stageIndex={LAST_STAGE_INDEX}
       clause={aggregation?.aggregation}
       clauseIndex={aggregation?.aggregationIndex}
       operators={
         aggregation?.operators ??
-        Lib.availableAggregationOperators(query, stageIndex)
+        Lib.availableAggregationOperators(query, LAST_STAGE_INDEX)
       }
       onQueryChange={onQueryChange}
       onBack={aggregationPickerProps.onBack}

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Summarize/SummarizePicker/SummarizePicker.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Summarize/SummarizePicker/SummarizePicker.tsx
@@ -32,9 +32,7 @@ export const SummarizePicker = ({
 
   const query = question.query();
   const onQueryChange = (newQuery: Lib.Query) => {
-    updateQuestion(question.setQuery(Lib.dropEmptyStages(newQuery)), {
-      run: true,
-    });
+    updateQuestion(question.setQuery(newQuery), { run: true });
   };
 
   return (

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Summarize/SummarizePicker/SummarizePicker.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Summarize/SummarizePicker/SummarizePicker.tsx
@@ -27,9 +27,11 @@ export const SummarizePicker = ({
   }
 
   const query = question.query();
-  const stageIndex = -1;
+  const stageIndex = aggregation?.stageIndex ?? -1;
   const onQueryChange = (newQuery: Lib.Query) => {
-    updateQuestion(question.setQuery(newQuery), { run: true });
+    updateQuestion(question.setQuery(Lib.dropEmptyStages(newQuery)), {
+      run: true,
+    });
   };
 
   return (

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Summarize/SummarizePicker/SummarizePicker.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Summarize/SummarizePicker/SummarizePicker.tsx
@@ -27,7 +27,7 @@ export const SummarizePicker = ({
   }
 
   const query = question.query();
-  const stageIndex = aggregation?.stageIndex ?? -1;
+  const stageIndex = -1;
   const onQueryChange = (newQuery: Lib.Query) => {
     updateQuestion(question.setQuery(Lib.dropEmptyStages(newQuery)), {
       run: true,

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Summarize/use-summarize-data.ts
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Summarize/use-summarize-data.ts
@@ -30,9 +30,7 @@ export const useSummarizeData = () => {
   const onQueryChange = useCallback(
     (newQuery: Lib.Query) => {
       if (question) {
-        updateQuestion(question.setQuery(Lib.dropEmptyStages(newQuery)), {
-          run: true,
-        });
+        updateQuestion(question.setQuery(newQuery), { run: true });
       }
     },
     [question, updateQuestion],

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Summarize/use-summarize-data.ts
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Summarize/use-summarize-data.ts
@@ -10,7 +10,6 @@ import {
 import * as Lib from "metabase-lib";
 
 import { useSdkQuestionContext } from "../../context";
-import { getLastVisibleStageIndex } from "../../utils/stages";
 
 export interface SDKAggregationItem extends AggregationItem {
   onRemoveAggregation: () => void;
@@ -18,12 +17,15 @@ export interface SDKAggregationItem extends AggregationItem {
 }
 
 export const useSummarizeData = () => {
-  const { question, updateQuestion } = useSdkQuestionContext();
+  const {
+    question,
+    updateQuestion,
+    lastVisibleStageIndex: stageIndex,
+  } = useSdkQuestionContext();
   const tc = useTranslateContent();
   const { locale } = useLocale();
 
   const query = question?.query();
-  const stageIndex = getLastVisibleStageIndex(query);
 
   const onQueryChange = useCallback(
     (newQuery: Lib.Query) => {

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Summarize/use-summarize-data.ts
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Summarize/use-summarize-data.ts
@@ -10,10 +10,9 @@ import {
 import * as Lib from "metabase-lib";
 
 import { useSdkQuestionContext } from "../../context";
-import { hasAggregationWithoutBreakoutOnPrevStage } from "../../utils/stages";
+import { getLastVisibleStageIndex } from "../../utils/stages";
 
 export interface SDKAggregationItem extends AggregationItem {
-  stageIndex: number;
   onRemoveAggregation: () => void;
   onUpdateAggregation: (nextClause: Lib.Aggregable) => void;
 }
@@ -24,6 +23,7 @@ export const useSummarizeData = () => {
   const { locale } = useLocale();
 
   const query = question?.query();
+  const stageIndex = getLastVisibleStageIndex(query);
 
   const onQueryChange = useCallback(
     (newQuery: Lib.Query) => {
@@ -39,52 +39,42 @@ export const useSummarizeData = () => {
   const aggregationItems: SDKAggregationItem[] = useMemo(
     () =>
       query
-        ? Lib.stageIndexes(query)
-            .filter(
-              (stageIndex) =>
-                !hasAggregationWithoutBreakoutOnPrevStage(query, stageIndex),
-            )
-            .flatMap((stageIndex) =>
-              getAggregationItems({ query, stageIndex }).map(
-                (aggregationItem) => {
-                  const onRemoveAggregation = () => {
-                    if (query) {
-                      const nextQuery = Lib.removeClause(
-                        query,
-                        stageIndex,
-                        aggregationItem.aggregation,
-                      );
-                      onQueryChange(nextQuery);
-                    }
-                  };
+        ? getAggregationItems({ query, stageIndex }).map((aggregationItem) => {
+            const onRemoveAggregation = () => {
+              if (query) {
+                const nextQuery = Lib.removeClause(
+                  query,
+                  stageIndex,
+                  aggregationItem.aggregation,
+                );
+                onQueryChange(nextQuery);
+              }
+            };
 
-                  const onUpdateAggregation = (nextClause: Lib.Aggregable) => {
-                    const nextQuery = Lib.replaceClause(
-                      query,
-                      stageIndex,
-                      aggregationItem.aggregation,
-                      nextClause,
-                    );
-                    onQueryChange(nextQuery);
-                  };
+            const onUpdateAggregation = (nextClause: Lib.Aggregable) => {
+              const nextQuery = Lib.replaceClause(
+                query,
+                stageIndex,
+                aggregationItem.aggregation,
+                nextClause,
+              );
+              onQueryChange(nextQuery);
+            };
 
-                  return {
-                    ...aggregationItem,
-                    stageIndex,
-                    displayName:
-                      PLUGIN_CONTENT_TRANSLATION.translateColumnDisplayName({
-                        displayName: aggregationItem.displayName,
-                        tc,
-                        locale,
-                      }),
-                    onRemoveAggregation,
-                    onUpdateAggregation,
-                  };
-                },
-              ),
-            )
+            return {
+              ...aggregationItem,
+              displayName:
+                PLUGIN_CONTENT_TRANSLATION.translateColumnDisplayName({
+                  displayName: aggregationItem.displayName,
+                  tc,
+                  locale,
+                }),
+              onRemoveAggregation,
+              onUpdateAggregation,
+            };
+          })
         : [],
-    [onQueryChange, query, tc, locale],
+    [onQueryChange, query, stageIndex, tc, locale],
   );
 
   return aggregationItems;

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Summarize/use-summarize-data.ts
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Summarize/use-summarize-data.ts
@@ -10,6 +10,7 @@ import {
 import * as Lib from "metabase-lib";
 
 import { useSdkQuestionContext } from "../../context";
+import { hasAggregationWithoutBreakoutOnPrevStage } from "../../utils/stages";
 
 export interface SDKAggregationItem extends AggregationItem {
   stageIndex: number;
@@ -88,20 +89,3 @@ export const useSummarizeData = () => {
 
   return aggregationItems;
 };
-
-/**
- * Matches the notebook editor's logic: a stage is hidden when
- * the previous stage has aggregations but no breakouts.
- * See `getQuestionSteps` in notebook/utils/steps.ts.
- */
-function hasAggregationWithoutBreakoutOnPrevStage(
-  query: Lib.Query,
-  stageIndex: number,
-) {
-  if (stageIndex >= 1) {
-    const hasAggregations = Lib.aggregations(query, stageIndex - 1).length > 0;
-    const hasBreakouts = Lib.breakouts(query, stageIndex - 1).length > 0;
-    return hasAggregations && !hasBreakouts;
-  }
-  return false;
-}

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Summarize/use-summarize-data.ts
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Summarize/use-summarize-data.ts
@@ -19,7 +19,7 @@ export interface SDKAggregationItem extends AggregationItem {
 export const useSummarizeData = () => {
   const {
     question,
-    updateQuestion,
+    updateAndNormalizeQuestion,
     lastVisibleStageIndex: stageIndex,
   } = useSdkQuestionContext();
   const tc = useTranslateContent();
@@ -30,10 +30,10 @@ export const useSummarizeData = () => {
   const onQueryChange = useCallback(
     (newQuery: Lib.Query) => {
       if (question) {
-        updateQuestion(question.setQuery(newQuery), { run: true });
+        updateAndNormalizeQuestion(question.setQuery(newQuery), { run: true });
       }
     },
-    [question, updateQuestion],
+    [question, updateAndNormalizeQuestion],
   );
 
   const aggregationItems: SDKAggregationItem[] = useMemo(

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Summarize/use-summarize-data.ts
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Summarize/use-summarize-data.ts
@@ -12,6 +12,7 @@ import * as Lib from "metabase-lib";
 import { useSdkQuestionContext } from "../../context";
 
 export interface SDKAggregationItem extends AggregationItem {
+  stageIndex: number;
   onRemoveAggregation: () => void;
   onUpdateAggregation: (nextClause: Lib.Aggregable) => void;
 }
@@ -22,12 +23,13 @@ export const useSummarizeData = () => {
   const { locale } = useLocale();
 
   const query = question?.query();
-  const stageIndex = -1;
 
   const onQueryChange = useCallback(
     (newQuery: Lib.Query) => {
       if (question) {
-        updateQuestion(question.setQuery(newQuery), { run: true });
+        updateQuestion(question.setQuery(Lib.dropEmptyStages(newQuery)), {
+          run: true,
+        });
       }
     },
     [question, updateQuestion],
@@ -36,43 +38,70 @@ export const useSummarizeData = () => {
   const aggregationItems: SDKAggregationItem[] = useMemo(
     () =>
       query
-        ? getAggregationItems({ query, stageIndex }).map((aggregationItem) => {
-            const onRemoveAggregation = () => {
-              if (query) {
-                const nextQuery = Lib.removeClause(
-                  query,
-                  stageIndex,
-                  aggregationItem.aggregation,
-                );
-                onQueryChange(nextQuery);
-              }
-            };
+        ? Lib.stageIndexes(query)
+            .filter(
+              (stageIndex) =>
+                !hasAggregationWithoutBreakoutOnPrevStage(query, stageIndex),
+            )
+            .flatMap((stageIndex) =>
+              getAggregationItems({ query, stageIndex }).map(
+                (aggregationItem) => {
+                  const onRemoveAggregation = () => {
+                    if (query) {
+                      const nextQuery = Lib.removeClause(
+                        query,
+                        stageIndex,
+                        aggregationItem.aggregation,
+                      );
+                      onQueryChange(nextQuery);
+                    }
+                  };
 
-            const onUpdateAggregation = (nextClause: Lib.Aggregable) => {
-              const nextQuery = Lib.replaceClause(
-                query,
-                stageIndex,
-                aggregationItem.aggregation,
-                nextClause,
-              );
-              onQueryChange(nextQuery);
-            };
+                  const onUpdateAggregation = (nextClause: Lib.Aggregable) => {
+                    const nextQuery = Lib.replaceClause(
+                      query,
+                      stageIndex,
+                      aggregationItem.aggregation,
+                      nextClause,
+                    );
+                    onQueryChange(nextQuery);
+                  };
 
-            return {
-              ...aggregationItem,
-              displayName:
-                PLUGIN_CONTENT_TRANSLATION.translateColumnDisplayName({
-                  displayName: aggregationItem.displayName,
-                  tc,
-                  locale,
-                }),
-              onRemoveAggregation,
-              onUpdateAggregation,
-            };
-          })
+                  return {
+                    ...aggregationItem,
+                    stageIndex,
+                    displayName:
+                      PLUGIN_CONTENT_TRANSLATION.translateColumnDisplayName({
+                        displayName: aggregationItem.displayName,
+                        tc,
+                        locale,
+                      }),
+                    onRemoveAggregation,
+                    onUpdateAggregation,
+                  };
+                },
+              ),
+            )
         : [],
-    [onQueryChange, query, stageIndex, tc, locale],
+    [onQueryChange, query, tc, locale],
   );
 
   return aggregationItems;
 };
+
+/**
+ * Matches the notebook editor's logic: a stage is hidden when
+ * the previous stage has aggregations but no breakouts.
+ * See `getQuestionSteps` in notebook/utils/steps.ts.
+ */
+function hasAggregationWithoutBreakoutOnPrevStage(
+  query: Lib.Query,
+  stageIndex: number,
+) {
+  if (stageIndex >= 1) {
+    const hasAggregations = Lib.aggregations(query, stageIndex - 1).length > 0;
+    const hasBreakouts = Lib.breakouts(query, stageIndex - 1).length > 0;
+    return hasAggregations && !hasBreakouts;
+  }
+  return false;
+}

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/context/SdkQuestionProvider.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/context/SdkQuestionProvider.tsx
@@ -38,6 +38,8 @@ import { EmbeddingSdkMode } from "metabase/visualizations/click-actions/modes/Em
 import type { ClickActionModeGetter } from "metabase/visualizations/types";
 import type Question from "metabase-lib/v1/Question";
 
+import { getLastVisibleStageIndex } from "../utils/stages";
+
 import type { SdkQuestionContextType, SdkQuestionProviderProps } from "./types";
 
 /**
@@ -219,8 +221,15 @@ export const SdkQuestionProvider = ({
     [navigateToNewCard, navigation, question, loadAndQueryQuestion],
   );
 
+  const query = question?.query();
+  const lastVisibleStageIndex = useMemo(
+    () => getLastVisibleStageIndex(query),
+    [query],
+  );
+
   const questionContext: SdkQuestionContextType = {
     originalId: questionId,
+    lastVisibleStageIndex,
     token,
     isQuestionLoading,
     isQueryRunning,

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/context/SdkQuestionProvider.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/context/SdkQuestionProvider.tsx
@@ -36,6 +36,7 @@ import { EmbeddingDataPickerContextProvider } from "metabase/querying/notebook/c
 import { getEmbeddingMode } from "metabase/visualizations/click-actions/lib/modes";
 import { EmbeddingSdkMode } from "metabase/visualizations/click-actions/modes/EmbeddingSdkMode";
 import type { ClickActionModeGetter } from "metabase/visualizations/types";
+import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
 
 import { getLastVisibleStageIndex } from "../utils/stages";
@@ -227,6 +228,15 @@ export const SdkQuestionProvider = ({
     [query],
   );
 
+  const updateAndNormalizeQuestion = useCallback(
+    (nextQuestion: Question, options?: { run?: boolean }) =>
+      updateQuestion(
+        nextQuestion.setQuery(Lib.dropEmptyStages(nextQuestion.query())),
+        options,
+      ),
+    [updateQuestion],
+  );
+
   const questionContext: SdkQuestionContextType = {
     originalId: questionId,
     lastVisibleStageIndex,
@@ -239,6 +249,7 @@ export const SdkQuestionProvider = ({
     queryQuestion,
     replaceQuestion,
     updateQuestion,
+    updateAndNormalizeQuestion,
     updateParameterValues,
     navigateToNewCard:
       userNavigateToNewCard !== undefined

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/context/types.ts
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/context/types.ts
@@ -165,6 +165,7 @@ export type SdkQuestionContextType = Omit<
     originalId: SdkQuestionId | null;
     token: EntityToken | null | undefined;
     lastVisibleStageIndex: number;
+    updateAndNormalizeQuestion: LoadQuestionHookResult["updateQuestion"];
     resetQuestion: () => void;
     onReset: () => void;
     onCreate: (question: Question) => Promise<Question>;

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/context/types.ts
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/context/types.ts
@@ -164,6 +164,7 @@ export type SdkQuestionContextType = Omit<
     mode: QueryClickActionsMode | ClickActionsMode | null | undefined;
     originalId: SdkQuestionId | null;
     token: EntityToken | null | undefined;
+    lastVisibleStageIndex: number;
     resetQuestion: () => void;
     onReset: () => void;
     onCreate: (question: Question) => Promise<Question>;

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/hooks/use-stage-change-tooltip.ts
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/hooks/use-stage-change-tooltip.ts
@@ -1,0 +1,38 @@
+import { useEffect, useRef, useState } from "react";
+
+import { useSdkQuestionContext } from "../context";
+import { getLastVisibleStageIndex } from "../utils/stages";
+
+const TOOLTIP_DURATION_MS = 3000;
+
+/**
+ * Tracks the visible stage index and shows a tooltip for 3 seconds
+ * when the stage decreases (i.e. both parts of the current stage were removed,
+ * causing a fallback to a previous stage).
+ */
+export function useStageChangeTooltip() {
+  const { question } = useSdkQuestionContext();
+  const query = question?.query();
+  const stageIndex = getLastVisibleStageIndex(query);
+
+  const prevStageIndexRef = useRef(stageIndex);
+  const [showTooltip, setShowTooltip] = useState(false);
+
+  useEffect(() => {
+    const prevStageIndex = prevStageIndexRef.current;
+    prevStageIndexRef.current = stageIndex;
+
+    if (prevStageIndex > stageIndex) {
+      setShowTooltip(true);
+
+      const timer = setTimeout(
+        () => setShowTooltip(false),
+        TOOLTIP_DURATION_MS,
+      );
+
+      return () => clearTimeout(timer);
+    }
+  }, [stageIndex]);
+
+  return showTooltip;
+}

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/hooks/use-stage-change-tooltip.ts
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/hooks/use-stage-change-tooltip.ts
@@ -1,7 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 
 import { useSdkQuestionContext } from "../context";
-import { getLastVisibleStageIndex } from "../utils/stages";
 
 const TOOLTIP_DURATION_MS = 3000;
 
@@ -11,9 +10,7 @@ const TOOLTIP_DURATION_MS = 3000;
  * causing a fallback to a previous stage).
  */
 export function useStageChangeTooltip() {
-  const { question } = useSdkQuestionContext();
-  const query = question?.query();
-  const stageIndex = getLastVisibleStageIndex(query);
+  const { lastVisibleStageIndex: stageIndex } = useSdkQuestionContext();
 
   const prevStageIndexRef = useRef(stageIndex);
   const [showTooltip, setShowTooltip] = useState(false);
@@ -31,7 +28,10 @@ export function useStageChangeTooltip() {
       );
 
       return () => clearTimeout(timer);
+    } else if (showTooltip) {
+      setShowTooltip(false);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- showTooltip is intentionally excluded to avoid re-triggering the effect when it changes
   }, [stageIndex]);
 
   return showTooltip;

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/hooks/use-stage-change-tooltip.unit.spec.ts
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/hooks/use-stage-change-tooltip.unit.spec.ts
@@ -1,29 +1,31 @@
 import { act, renderHook } from "@testing-library/react";
 
-import { getLastVisibleStageIndex } from "../utils/stages";
+import { useSdkQuestionContext } from "../context";
 
 import { useStageChangeTooltip } from "./use-stage-change-tooltip";
 
 jest.mock("../context", () => ({
-  useSdkQuestionContext: jest.fn(() => ({
-    question: {
-      query: () => ({}),
-    },
-  })),
+  useSdkQuestionContext: jest.fn(() => ({ lastVisibleStageIndex: 1 })),
 }));
 
-jest.mock("../utils/stages", () => ({
-  getLastVisibleStageIndex: jest.fn(() => 1),
-}));
-
-const mockStageIndex = getLastVisibleStageIndex as jest.MockedFunction<
-  typeof getLastVisibleStageIndex
+const mockContext = useSdkQuestionContext as jest.MockedFunction<
+  typeof useSdkQuestionContext
 >;
+
+const setup = ({
+  lastVisibleStageIndex,
+}: {
+  lastVisibleStageIndex: number;
+}) => {
+  mockContext.mockReturnValue({
+    lastVisibleStageIndex,
+  } as ReturnType<typeof useSdkQuestionContext>);
+};
 
 describe("useStageChangeTooltip", () => {
   beforeEach(() => {
     jest.useFakeTimers();
-    mockStageIndex.mockReturnValue(1);
+    setup({ lastVisibleStageIndex: 1 });
   });
 
   afterEach(() => {
@@ -43,10 +45,10 @@ describe("useStageChangeTooltip", () => {
   ])(
     "returns $expected when stage index $desc ($from → $to)",
     ({ from, to, expected }) => {
-      mockStageIndex.mockReturnValue(from);
+      setup({ lastVisibleStageIndex: from });
       const { result, rerender } = renderHook(() => useStageChangeTooltip());
 
-      mockStageIndex.mockReturnValue(to);
+      setup({ lastVisibleStageIndex: to });
       rerender();
 
       expect(result.current).toBe(expected);
@@ -56,7 +58,7 @@ describe("useStageChangeTooltip", () => {
   it("auto-hides after 3 seconds", () => {
     const { result, rerender } = renderHook(() => useStageChangeTooltip());
 
-    mockStageIndex.mockReturnValue(0);
+    setup({ lastVisibleStageIndex: 0 });
     rerender();
     expect(result.current).toBe(true);
 
@@ -64,17 +66,31 @@ describe("useStageChangeTooltip", () => {
     expect(result.current).toBe(false);
   });
 
-  it("resets timer on consecutive stage decreases", () => {
-    mockStageIndex.mockReturnValue(2);
+  it("hides tooltip when stage index increases before timeout", () => {
     const { result, rerender } = renderHook(() => useStageChangeTooltip());
 
-    mockStageIndex.mockReturnValue(1);
+    setup({ lastVisibleStageIndex: 0 });
+    rerender();
+    expect(result.current).toBe(true);
+
+    act(() => jest.advanceTimersByTime(1000));
+
+    setup({ lastVisibleStageIndex: 1 });
+    rerender();
+    expect(result.current).toBe(false);
+  });
+
+  it("resets timer on consecutive stage decreases", () => {
+    setup({ lastVisibleStageIndex: 2 });
+    const { result, rerender } = renderHook(() => useStageChangeTooltip());
+
+    setup({ lastVisibleStageIndex: 1 });
     rerender();
     expect(result.current).toBe(true);
 
     act(() => jest.advanceTimersByTime(1500));
 
-    mockStageIndex.mockReturnValue(0);
+    setup({ lastVisibleStageIndex: 0 });
     rerender();
     expect(result.current).toBe(true);
 

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/hooks/use-stage-change-tooltip.unit.spec.ts
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/hooks/use-stage-change-tooltip.unit.spec.ts
@@ -1,0 +1,89 @@
+import { act, renderHook } from "@testing-library/react";
+
+import { getLastVisibleStageIndex } from "../utils/stages";
+
+import { useStageChangeTooltip } from "./use-stage-change-tooltip";
+
+jest.mock("../context", () => ({
+  useSdkQuestionContext: jest.fn(() => ({
+    question: {
+      query: () => ({}),
+    },
+  })),
+}));
+
+jest.mock("../utils/stages", () => ({
+  getLastVisibleStageIndex: jest.fn(() => 1),
+}));
+
+const mockStageIndex = getLastVisibleStageIndex as jest.MockedFunction<
+  typeof getLastVisibleStageIndex
+>;
+
+describe("useStageChangeTooltip", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockStageIndex.mockReturnValue(1);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("returns false initially", () => {
+    const { result } = renderHook(() => useStageChangeTooltip());
+    expect(result.current).toBe(false);
+  });
+
+  it.each([
+    { from: 1, to: 0, expected: true, desc: "decreases" },
+    { from: 2, to: 0, expected: true, desc: "decreases by more than 1" },
+    { from: 0, to: 1, expected: false, desc: "increases" },
+    { from: 1, to: 1, expected: false, desc: "stays the same" },
+  ])(
+    "returns $expected when stage index $desc ($from → $to)",
+    ({ from, to, expected }) => {
+      mockStageIndex.mockReturnValue(from);
+      const { result, rerender } = renderHook(() => useStageChangeTooltip());
+
+      mockStageIndex.mockReturnValue(to);
+      rerender();
+
+      expect(result.current).toBe(expected);
+    },
+  );
+
+  it("auto-hides after 3 seconds", () => {
+    const { result, rerender } = renderHook(() => useStageChangeTooltip());
+
+    mockStageIndex.mockReturnValue(0);
+    rerender();
+    expect(result.current).toBe(true);
+
+    act(() => jest.advanceTimersByTime(3000));
+    expect(result.current).toBe(false);
+  });
+
+  it("resets timer on consecutive stage decreases", () => {
+    mockStageIndex.mockReturnValue(2);
+    const { result, rerender } = renderHook(() => useStageChangeTooltip());
+
+    mockStageIndex.mockReturnValue(1);
+    rerender();
+    expect(result.current).toBe(true);
+
+    act(() => jest.advanceTimersByTime(1500));
+
+    mockStageIndex.mockReturnValue(0);
+    rerender();
+    expect(result.current).toBe(true);
+
+    // first timer (1500ms remaining) should be cleared, not fire here
+    act(() => jest.advanceTimersByTime(1500));
+    expect(result.current).toBe(true);
+
+    // second timer fires at 3000ms from second decrease
+    act(() => jest.advanceTimersByTime(1500));
+    expect(result.current).toBe(false);
+  });
+});

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/utils/stages.ts
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/utils/stages.ts
@@ -1,0 +1,20 @@
+import * as Lib from "metabase-lib";
+
+/**
+ * Matches the notebook editor's logic: a stage is hidden when
+ * the previous stage has aggregations but no breakouts.
+ * See `getQuestionSteps` in notebook/utils/steps.ts.
+ */
+export function hasAggregationWithoutBreakoutOnPrevStage(
+  query: Lib.Query,
+  stageIndex: number,
+) {
+  if (stageIndex < 1) {
+    return false;
+  }
+
+  const hasAggregations = Lib.aggregations(query, stageIndex - 1).length > 0;
+  const hasBreakouts = Lib.breakouts(query, stageIndex - 1).length > 0;
+
+  return hasAggregations && !hasBreakouts;
+}

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/utils/stages.ts
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/utils/stages.ts
@@ -1,5 +1,7 @@
 import * as Lib from "metabase-lib";
 
+export const LAST_STAGE_INDEX = -1;
+
 /**
  * Returns the last stage index that has aggregations or breakouts.
  * Walks backwards from the last stage — if a stage has nothing to show,
@@ -7,7 +9,7 @@ import * as Lib from "metabase-lib";
  */
 export function getLastVisibleStageIndex(query: Lib.Query | undefined): number {
   if (!query) {
-    return -1;
+    return LAST_STAGE_INDEX;
   }
 
   const indexes = Lib.stageIndexes(query);

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/utils/stages.ts
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/utils/stages.ts
@@ -1,20 +1,26 @@
 import * as Lib from "metabase-lib";
 
 /**
- * Matches the notebook editor's logic: a stage is hidden when
- * the previous stage has aggregations but no breakouts.
- * See `getQuestionSteps` in notebook/utils/steps.ts.
+ * Returns the last stage index that has aggregations or breakouts.
+ * Walks backwards from the last stage — if a stage has nothing to show,
+ * falls back to the previous one.
  */
-export function hasAggregationWithoutBreakoutOnPrevStage(
-  query: Lib.Query,
-  stageIndex: number,
-) {
-  if (stageIndex < 1) {
-    return false;
+export function getLastVisibleStageIndex(query: Lib.Query | undefined): number {
+  if (!query) {
+    return -1;
   }
 
-  const hasAggregations = Lib.aggregations(query, stageIndex - 1).length > 0;
-  const hasBreakouts = Lib.breakouts(query, stageIndex - 1).length > 0;
+  const indexes = Lib.stageIndexes(query);
 
-  return hasAggregations && !hasBreakouts;
+  for (let i = indexes.length - 1; i >= 0; i--) {
+    const stageIndex = indexes[i];
+    const hasAggregations = Lib.aggregations(query, stageIndex).length > 0;
+    const hasBreakouts = Lib.breakouts(query, stageIndex).length > 0;
+
+    if (hasAggregations || hasBreakouts) {
+      return stageIndex;
+    }
+  }
+
+  return 0;
 }

--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-load-question.ts
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-load-question.ts
@@ -18,7 +18,6 @@ import type {
 } from "embedding-sdk-bundle/types/question";
 import { isStaticEmbeddingEntityLoadingError } from "metabase/utils/errors/is-static-embedding-entity-loading-error";
 import { type Deferred, defer } from "metabase/utils/promise";
-import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
 import type { ParameterValuesMap } from "metabase-types/api";
 import type { EntityToken } from "metabase-types/api/entity";
@@ -218,10 +217,6 @@ export function useLoadQuestion({
       if (!question) {
         return;
       }
-
-      nextQuestion = nextQuestion.setQuery(
-        Lib.dropEmptyStages(nextQuestion.query()),
-      );
 
       const state = await dispatch(
         updateQuestionSdk({

--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-load-question.ts
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-load-question.ts
@@ -18,6 +18,7 @@ import type {
 } from "embedding-sdk-bundle/types/question";
 import { isStaticEmbeddingEntityLoadingError } from "metabase/utils/errors/is-static-embedding-entity-loading-error";
 import { type Deferred, defer } from "metabase/utils/promise";
+import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
 import type { ParameterValuesMap } from "metabase-types/api";
 import type { EntityToken } from "metabase-types/api/entity";
@@ -217,6 +218,10 @@ export function useLoadQuestion({
       if (!question) {
         return;
       }
+
+      nextQuestion = nextQuestion.setQuery(
+        Lib.dropEmptyStages(nextQuestion.query()),
+      );
 
       const state = await dispatch(
         updateQuestionSdk({


### PR DESCRIPTION
Refactor query handling to show aggregations/breakout for the last non-empty stage

Issue:
- we should show the last non-empty stage only (that has aggregation or breakout).
- currently if we setup 2 stages via QB, then from toolbar remove the last stage aggregation/breakout - we don't display anything, though we must switch to the previous non-empty stage

Fixed behavior:

https://github.com/user-attachments/assets/9e34af31-3468-4bc3-bfc8-52dc1ffcfd1a



How to test:
- i added an e2e to validate this exact case
- manually - embed SDK question, setup via QB 2 summaries/groups, click visualize
- you should see `1 summary` and `1 group` in SDK's toolbar, related to the last stage
- remove the summary and group
- you will see `1 summary` and `1 group` again, this time for the previous stage. 
- also to represent that the stage was changed, we show the tooltip, so you should see the tooltip