### PR TITLE
GDGT-232 fix: dashboard subscriptions should work even if Slack channels are renamed

### DIFF
--- a/e2e/support/helpers/e2e-slack-helpers.js
+++ b/e2e/support/helpers/e2e-slack-helpers.js
@@ -9,7 +9,10 @@ const mockedSlack = {
       name: "channel",
       type: "select",
       displayName: "Post to",
-      options: ["#work", "#play"],
+      options: [
+        { displayName: "#work", id: "C001" },
+        { displayName: "#play", id: "C002" },
+      ],
       required: true,
     },
   ],

--- a/e2e/test/scenarios/sharing/alert/email-alert.cy.spec.js
+++ b/e2e/test/scenarios/sharing/alert/email-alert.cy.spec.js
@@ -91,6 +91,33 @@ describe("scenarios > alert > email_alert", { tags: "@external" }, () => {
     cy.findByRole("button", { name: "Delete this alert" }).click();
   });
 
+  it("should persist the immutable Slack channel_id alongside the channel name", () => {
+    H.mockSlackConfigured();
+
+    openAlertForQuestion(ORDERS_QUESTION_ID);
+
+    H.removeNotificationHandlerChannel("Email");
+    H.addNotificationHandlerChannel("Slack", { hasNoChannelsAdded: true });
+
+    H.modal()
+      .findByPlaceholderText(/Pick a user or channel/)
+      .click();
+    H.popover().findByText("#work").click();
+
+    H.modal().within(() => {
+      cy.button("Done").click();
+    });
+
+    cy.wait("@saveAlert").then(({ response: { body } }) => {
+      // The mocked channel `#work` has id `C001` in e2e-slack-helpers.js.
+      // Storing the immutable channel_id at save time is what makes the
+      // subscription survive future channel renames in Slack.
+      const slackDetails = body.handlers[0].recipients[0].details;
+      expect(slackDetails.value).to.eq("#work");
+      expect(slackDetails.channel_id).to.eq("C001");
+    });
+  });
+
   it("should set up an email alert for newly created question", () => {
     H.openTable({
       table: PEOPLE_ID,

--- a/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
+++ b/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
@@ -514,6 +514,28 @@ describe("scenarios > dashboard > subscriptions", () => {
       H.openDashboardMenu();
       H.popover().findByText("Subscriptions").should("be.visible");
     });
+
+    it("should persist the immutable Slack channel_id alongside the channel name", () => {
+      cy.intercept("POST", "/api/pulse").as("createPulse");
+
+      openSlackCreationForm();
+
+      cy.findByPlaceholderText("Pick a user or channel...").click();
+      H.popover().findByText("#work").click();
+
+      H.sidebar().findByRole("button", { name: "Done" }).click();
+
+      cy.wait("@createPulse").then(({ request: { body } }) => {
+        // The mocked channel `#work` has id `C001` in e2e-slack-helpers.js.
+        // Storing the immutable channel_id at save time is what makes the
+        // subscription survive future channel renames in Slack.
+        const slackChannel = body.channels.find(
+          (c) => c.channel_type === "slack",
+        );
+        expect(slackChannel.details.channel).to.eq("#work");
+        expect(slackChannel.details.channel_id).to.eq("C001");
+      });
+    });
   });
 
   describe("OSS email subscriptions", { tags: ["@OSS", "external"] }, () => {

--- a/enterprise/frontend/src/metabase-enterprise/security_center/components/NotificationChannelConfigModal/NotificationChannelConfigModal.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/components/NotificationChannelConfigModal/NotificationChannelConfigModal.unit.spec.tsx
@@ -295,7 +295,11 @@ function setupWithRealHook({
         {
           name: "channel",
           displayName: "Post to",
-          options: ["#general", "#security", "#alerts"],
+          options: [
+            { displayName: "#general", id: "C001" },
+            { displayName: "#security", id: "C002" },
+            { displayName: "#alerts", id: "C003" },
+          ],
           required: true,
         },
       ],

--- a/frontend/src/metabase-types/api/mocks/security-center.ts
+++ b/frontend/src/metabase-types/api/mocks/security-center.ts
@@ -33,7 +33,10 @@ export function createMockSlackChannelSpec(
       {
         name: "channel",
         displayName: "Post to",
-        options: ["#general", "#security"],
+        options: [
+          { displayName: "#general", id: "C001" },
+          { displayName: "#security", id: "C002" },
+        ],
         required: true,
       },
     ],

--- a/frontend/src/metabase-types/api/notification-channels.ts
+++ b/frontend/src/metabase-types/api/notification-channels.ts
@@ -5,9 +5,11 @@ import type {
 import type { User } from "metabase-types/api/user";
 import { isObject } from "metabase-types/guards";
 
+export type SlackChannelId = string;
+
 export type SlackChannelOption = {
   displayName: string;
-  id: string;
+  id: SlackChannelId;
 };
 
 type ChannelField = {

--- a/frontend/src/metabase-types/api/notification-channels.ts
+++ b/frontend/src/metabase-types/api/notification-channels.ts
@@ -13,7 +13,7 @@ export type SlackChannelOption = {
 type ChannelField = {
   name: string;
   displayName: string;
-  options?: string[] | SlackChannelOption[];
+  options?: SlackChannelOption[];
   required?: boolean;
 };
 

--- a/frontend/src/metabase-types/api/notification-channels.ts
+++ b/frontend/src/metabase-types/api/notification-channels.ts
@@ -5,10 +5,15 @@ import type {
 import type { User } from "metabase-types/api/user";
 import { isObject } from "metabase-types/guards";
 
+export type SlackChannelOption = {
+  displayName: string;
+  id: string;
+};
+
 type ChannelField = {
   name: string;
   displayName: string;
-  options?: string[];
+  options?: string[] | SlackChannelOption[];
   required?: boolean;
 };
 

--- a/frontend/src/metabase-types/api/notification.ts
+++ b/frontend/src/metabase-types/api/notification.ts
@@ -1,5 +1,5 @@
 import type { Card, CardId } from "./card";
-import type { Channel } from "./notification-channels";
+import type { Channel, SlackChannelId } from "./notification-channels";
 import type { PaginationRequest } from "./pagination";
 import type { ScheduleDisplayType } from "./settings";
 import type { UserId, UserInfo } from "./user";
@@ -50,6 +50,7 @@ export type NotificationRecipientRawValue = {
   type: "notification-recipient/raw-value";
   details: {
     value: string;
+    channel_id?: SlackChannelId;
   };
 
   id?: number;

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/tests/setup.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/tests/setup.tsx
@@ -101,7 +101,11 @@ export const setup = async ({
           name: "channel",
           type: "select",
           displayName: "Post to",
-          options: ["#general", "#random", "#alerts"],
+          options: [
+            { displayName: "#general", id: "C001" },
+            { displayName: "#random", id: "C002" },
+            { displayName: "#alerts", id: "C003" },
+          ],
           required: true,
         },
       ],

--- a/frontend/src/metabase/notifications/DashboardSubscriptionsSidebar/tests/setup.tsx
+++ b/frontend/src/metabase/notifications/DashboardSubscriptionsSidebar/tests/setup.tsx
@@ -148,7 +148,11 @@ export function setup({
           name: "channel",
           type: "select",
           displayName: "Post to",
-          options: ["#general", "#random", "#alerts"],
+          options: [
+            { displayName: "#general", id: "C001" },
+            { displayName: "#random", id: "C002" },
+            { displayName: "#alerts", id: "C003" },
+          ],
           required: true,
         },
       ],

--- a/frontend/src/metabase/notifications/channels/SlackChannelField.tsx
+++ b/frontend/src/metabase/notifications/channels/SlackChannelField.tsx
@@ -3,36 +3,28 @@ import { useState } from "react";
 import { t } from "ttag";
 
 import CS from "metabase/css/core/index.css";
+import {
+  findChannelId,
+  getDisplayNames,
+} from "metabase/notifications/channels/utils";
 import { getApplicationName } from "metabase/selectors/whitelabel";
 import { Autocomplete } from "metabase/ui";
 import { useSelector } from "metabase/utils/redux";
-import type {
-  Channel,
-  ChannelSpec,
-  SlackChannelOption,
-} from "metabase-types/api";
+import type { Channel, ChannelSpec } from "metabase-types/api";
 
 const CHANNEL_FIELD_NAME = "channel";
 const CHANNEL_PREFIX = "#";
 const USER_PREFIX = "@";
-
-export function getDisplayNames(options: SlackChannelOption[]): string[] {
-  return options.map((o) => o.displayName);
-}
-
-export function findChannelId(
-  options: SlackChannelOption[],
-  displayName: string,
-): string | undefined {
-  return options.find((o) => o.displayName === displayName)?.id;
-}
 
 const ALLOWED_PREFIXES = [CHANNEL_PREFIX, USER_PREFIX];
 
 interface SlackChannelFieldProps {
   channel: Channel;
   channelSpec: ChannelSpec;
-  onChannelPropertyChange: any;
+  onChannelPropertyChange: (
+    key: string,
+    value: Record<string, string | boolean>,
+  ) => void;
 }
 
 export const SlackChannelField = ({
@@ -46,7 +38,7 @@ export const SlackChannelField = ({
   const channelField = channelSpec.fields?.find(
     (field) => field.name === CHANNEL_FIELD_NAME,
   );
-  const slackOptions = (channelField?.options ?? []) as SlackChannelOption[];
+  const slackOptions = channelField?.options ?? [];
   const displayNames = getDisplayNames(slackOptions);
   const value = String(channel?.details?.[CHANNEL_FIELD_NAME] ?? "");
 
@@ -56,7 +48,7 @@ export const SlackChannelField = ({
     onChannelPropertyChange("details", {
       ...restDetails,
       [CHANNEL_FIELD_NAME]: value,
-      ...(newChannelId != null && { channel_id: newChannelId }),
+      ...(newChannelId && { channel_id: newChannelId }),
     });
   };
 

--- a/frontend/src/metabase/notifications/channels/SlackChannelField.tsx
+++ b/frontend/src/metabase/notifications/channels/SlackChannelField.tsx
@@ -6,11 +6,26 @@ import CS from "metabase/css/core/index.css";
 import { getApplicationName } from "metabase/selectors/whitelabel";
 import { Autocomplete } from "metabase/ui";
 import { useSelector } from "metabase/utils/redux";
-import type { Channel, ChannelSpec } from "metabase-types/api";
+import type {
+  Channel,
+  ChannelSpec,
+  SlackChannelOption,
+} from "metabase-types/api";
 
 const CHANNEL_FIELD_NAME = "channel";
 const CHANNEL_PREFIX = "#";
 const USER_PREFIX = "@";
+
+export function getDisplayNames(options: SlackChannelOption[]): string[] {
+  return options.map((o) => o.displayName);
+}
+
+export function findChannelId(
+  options: SlackChannelOption[],
+  displayName: string,
+): string | undefined {
+  return options.find((o) => o.displayName === displayName)?.id;
+}
 
 const ALLOWED_PREFIXES = [CHANNEL_PREFIX, USER_PREFIX];
 
@@ -31,13 +46,19 @@ export const SlackChannelField = ({
   const channelField = channelSpec.fields?.find(
     (field) => field.name === CHANNEL_FIELD_NAME,
   );
+  const slackOptions = (channelField?.options ?? []) as SlackChannelOption[];
+  const displayNames = getDisplayNames(slackOptions);
   const value = String(channel?.details?.[CHANNEL_FIELD_NAME] ?? "");
 
-  const updateChannel = (value: string) =>
+  const updateChannel = (value: string) => {
+    const { channel_id: _, ...restDetails } = channel.details ?? {};
+    const newChannelId = findChannelId(slackOptions, value);
     onChannelPropertyChange("details", {
-      ...channel.details,
+      ...restDetails,
       [CHANNEL_FIELD_NAME]: value,
+      ...(newChannelId != null && { channel_id: newChannelId }),
     });
+  };
 
   const handleChange = (value: string) => {
     updateChannel(value);
@@ -55,8 +76,7 @@ export const SlackChannelField = ({
       updateChannel(fullChannelName);
     }
 
-    const isPrivate =
-      value.trim().length > 0 && !channelField?.options?.includes(value);
+    const isPrivate = value.trim().length > 0 && !displayNames.includes(value);
 
     setHasPrivateChannelWarning(isPrivate);
   };
@@ -69,7 +89,7 @@ export const SlackChannelField = ({
         {channelField?.displayName}
       </span>
       <Autocomplete
-        data={channelField?.options || []}
+        data={displayNames}
         value={value}
         placeholder={t`Pick a user or channel...`}
         limit={300}

--- a/frontend/src/metabase/notifications/channels/SlackChannelField.unit.spec.tsx
+++ b/frontend/src/metabase/notifications/channels/SlackChannelField.unit.spec.tsx
@@ -68,27 +68,23 @@ function setup({ channel }: { channel: Channel }) {
   return { spy };
 }
 
-describe("SlackChannelField stale channel_id prevention", () => {
-  it("does not carry over old channel_id when user changes to a different known channel", async () => {
+describe("SlackChannelField channel_id storage", () => {
+  it("stores channel_id when user selects a known channel", async () => {
     const { spy } = setup({
-      channel: {
-        channel_type: "slack",
-        details: { channel: "#general", channel_id: "C001" },
-      },
+      channel: { channel_type: "slack", details: { channel: "" } },
     });
 
     const input = screen.getByPlaceholderText("Pick a user or channel...");
-    await userEvent.clear(input);
-    await userEvent.type(input, "#random");
+    await userEvent.type(input, "#general");
 
     const lastCall = spy.mock.calls[spy.mock.calls.length - 1];
     const [propName, details] = lastCall;
     expect(propName).toBe("details");
-    expect(details.channel).toBe("#random");
-    expect(details.channel_id).toBe("C002");
+    expect(details.channel).toBe("#general");
+    expect(details.channel_id).toBe("C001");
   });
 
-  it("strips channel_id when user types an unknown channel name", async () => {
+  it("omits channel_id when user types an unknown channel name", async () => {
     const { spy } = setup({
       channel: {
         channel_type: "slack",
@@ -105,5 +101,24 @@ describe("SlackChannelField stale channel_id prevention", () => {
     expect(propName).toBe("details");
     expect(details.channel).toBe("#private-stuff");
     expect(details).not.toHaveProperty("channel_id");
+  });
+
+  it("updates channel_id when user switches from one known channel to another", async () => {
+    const { spy } = setup({
+      channel: {
+        channel_type: "slack",
+        details: { channel: "#general", channel_id: "C001" },
+      },
+    });
+
+    const input = screen.getByPlaceholderText("Pick a user or channel...");
+    await userEvent.clear(input);
+    await userEvent.type(input, "#random");
+
+    const lastCall = spy.mock.calls[spy.mock.calls.length - 1];
+    const [propName, details] = lastCall;
+    expect(propName).toBe("details");
+    expect(details.channel).toBe("#random");
+    expect(details.channel_id).toBe("C002");
   });
 });

--- a/frontend/src/metabase/notifications/channels/SlackChannelField.unit.spec.tsx
+++ b/frontend/src/metabase/notifications/channels/SlackChannelField.unit.spec.tsx
@@ -2,56 +2,12 @@ import userEvent from "@testing-library/user-event";
 import { useState } from "react";
 
 import { renderWithProviders, screen } from "__support__/ui";
+import { SlackChannelField } from "metabase/notifications/channels/SlackChannelField";
 import type {
   Channel,
   ChannelSpec,
   SlackChannelOption,
 } from "metabase-types/api";
-
-import {
-  SlackChannelField,
-  findChannelId,
-  getDisplayNames,
-} from "./SlackChannelField";
-
-describe("getDisplayNames", () => {
-  it("extracts display names from enriched options", () => {
-    const options: SlackChannelOption[] = [
-      { displayName: "#general", id: "C001" },
-      { displayName: "#random", id: "C002" },
-      { displayName: "@user1", id: "U001" },
-    ];
-    expect(getDisplayNames(options)).toEqual(["#general", "#random", "@user1"]);
-  });
-
-  it("returns empty array for empty input", () => {
-    expect(getDisplayNames([])).toEqual([]);
-  });
-});
-
-describe("findChannelId", () => {
-  const options: SlackChannelOption[] = [
-    { displayName: "#general", id: "C001" },
-    { displayName: "#random", id: "C002" },
-    { displayName: "@user1", id: "U001" },
-  ];
-
-  it("returns the ID for a known channel name", () => {
-    expect(findChannelId(options, "#general")).toBe("C001");
-  });
-
-  it("returns undefined for an unknown channel name", () => {
-    expect(findChannelId(options, "#nonexistent")).toBeUndefined();
-  });
-
-  it("returns undefined for empty string", () => {
-    expect(findChannelId(options, "")).toBeUndefined();
-  });
-
-  it("returns undefined for empty options", () => {
-    expect(findChannelId([], "#general")).toBeUndefined();
-  });
-});
 
 const SLACK_OPTIONS: SlackChannelOption[] = [
   { displayName: "#general", id: "C001" },
@@ -69,21 +25,26 @@ const CHANNEL_SPEC: ChannelSpec = {
     {
       name: "channel",
       displayName: "Post to",
-      options: SLACK_OPTIONS as any,
+      options: SLACK_OPTIONS,
       required: true,
     },
   ],
 };
+
+type OnChannelPropertyChange = (
+  key: string,
+  value: Record<string, string | boolean>,
+) => void;
 
 function StatefulWrapper({
   initialChannel,
   spy,
 }: {
   initialChannel: Channel;
-  spy: jest.Mock;
+  spy: jest.MockedFunction<OnChannelPropertyChange>;
 }) {
   const [channel, setChannel] = useState(initialChannel);
-  const onChannelPropertyChange = (prop: string, value: any) => {
+  const onChannelPropertyChange: OnChannelPropertyChange = (prop, value) => {
     spy(prop, value);
     if (prop === "details") {
       setChannel((prev) => ({ ...prev, details: value }));
@@ -99,7 +60,10 @@ function StatefulWrapper({
 }
 
 function setup({ channel }: { channel: Channel }) {
-  const spy = jest.fn();
+  const spy = jest.fn<
+    ReturnType<OnChannelPropertyChange>,
+    Parameters<OnChannelPropertyChange>
+  >();
   renderWithProviders(<StatefulWrapper initialChannel={channel} spy={spy} />);
   return { spy };
 }
@@ -117,7 +81,6 @@ describe("SlackChannelField stale channel_id prevention", () => {
     await userEvent.clear(input);
     await userEvent.type(input, "#random");
 
-    // The last call should have the NEW channel_id, not the old one
     const lastCall = spy.mock.calls[spy.mock.calls.length - 1];
     const [propName, details] = lastCall;
     expect(propName).toBe("details");

--- a/frontend/src/metabase/notifications/channels/SlackChannelField.unit.spec.tsx
+++ b/frontend/src/metabase/notifications/channels/SlackChannelField.unit.spec.tsx
@@ -1,4 +1,5 @@
 import userEvent from "@testing-library/user-event";
+import type { ComponentProps } from "react";
 import { useState } from "react";
 
 import { renderWithProviders, screen } from "__support__/ui";
@@ -8,6 +9,10 @@ import type {
   ChannelSpec,
   SlackChannelOption,
 } from "metabase-types/api";
+
+type OnChannelPropertyChange = ComponentProps<
+  typeof SlackChannelField
+>["onChannelPropertyChange"];
 
 const SLACK_OPTIONS: SlackChannelOption[] = [
   { displayName: "#general", id: "C001" },
@@ -30,11 +35,6 @@ const CHANNEL_SPEC: ChannelSpec = {
     },
   ],
 };
-
-type OnChannelPropertyChange = (
-  key: string,
-  value: Record<string, string | boolean>,
-) => void;
 
 function StatefulWrapper({
   initialChannel,

--- a/frontend/src/metabase/notifications/channels/SlackChannelField.unit.spec.tsx
+++ b/frontend/src/metabase/notifications/channels/SlackChannelField.unit.spec.tsx
@@ -1,0 +1,146 @@
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+
+import { renderWithProviders, screen } from "__support__/ui";
+import type {
+  Channel,
+  ChannelSpec,
+  SlackChannelOption,
+} from "metabase-types/api";
+
+import {
+  SlackChannelField,
+  findChannelId,
+  getDisplayNames,
+} from "./SlackChannelField";
+
+describe("getDisplayNames", () => {
+  it("extracts display names from enriched options", () => {
+    const options: SlackChannelOption[] = [
+      { displayName: "#general", id: "C001" },
+      { displayName: "#random", id: "C002" },
+      { displayName: "@user1", id: "U001" },
+    ];
+    expect(getDisplayNames(options)).toEqual(["#general", "#random", "@user1"]);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(getDisplayNames([])).toEqual([]);
+  });
+});
+
+describe("findChannelId", () => {
+  const options: SlackChannelOption[] = [
+    { displayName: "#general", id: "C001" },
+    { displayName: "#random", id: "C002" },
+    { displayName: "@user1", id: "U001" },
+  ];
+
+  it("returns the ID for a known channel name", () => {
+    expect(findChannelId(options, "#general")).toBe("C001");
+  });
+
+  it("returns undefined for an unknown channel name", () => {
+    expect(findChannelId(options, "#nonexistent")).toBeUndefined();
+  });
+
+  it("returns undefined for empty string", () => {
+    expect(findChannelId(options, "")).toBeUndefined();
+  });
+
+  it("returns undefined for empty options", () => {
+    expect(findChannelId([], "#general")).toBeUndefined();
+  });
+});
+
+const SLACK_OPTIONS: SlackChannelOption[] = [
+  { displayName: "#general", id: "C001" },
+  { displayName: "#random", id: "C002" },
+];
+
+const CHANNEL_SPEC: ChannelSpec = {
+  type: "slack",
+  name: "Slack",
+  schedules: ["hourly"],
+  schedule_type: null,
+  allows_recipients: false,
+  configured: true,
+  fields: [
+    {
+      name: "channel",
+      displayName: "Post to",
+      options: SLACK_OPTIONS as any,
+      required: true,
+    },
+  ],
+};
+
+function StatefulWrapper({
+  initialChannel,
+  spy,
+}: {
+  initialChannel: Channel;
+  spy: jest.Mock;
+}) {
+  const [channel, setChannel] = useState(initialChannel);
+  const onChannelPropertyChange = (prop: string, value: any) => {
+    spy(prop, value);
+    if (prop === "details") {
+      setChannel((prev) => ({ ...prev, details: value }));
+    }
+  };
+  return (
+    <SlackChannelField
+      channel={channel}
+      channelSpec={CHANNEL_SPEC}
+      onChannelPropertyChange={onChannelPropertyChange}
+    />
+  );
+}
+
+function setup({ channel }: { channel: Channel }) {
+  const spy = jest.fn();
+  renderWithProviders(<StatefulWrapper initialChannel={channel} spy={spy} />);
+  return { spy };
+}
+
+describe("SlackChannelField stale channel_id prevention", () => {
+  it("does not carry over old channel_id when user changes to a different known channel", async () => {
+    const { spy } = setup({
+      channel: {
+        channel_type: "slack",
+        details: { channel: "#general", channel_id: "C001" },
+      },
+    });
+
+    const input = screen.getByPlaceholderText("Pick a user or channel...");
+    await userEvent.clear(input);
+    await userEvent.type(input, "#random");
+
+    // The last call should have the NEW channel_id, not the old one
+    const lastCall = spy.mock.calls[spy.mock.calls.length - 1];
+    const [propName, details] = lastCall;
+    expect(propName).toBe("details");
+    expect(details.channel).toBe("#random");
+    expect(details.channel_id).toBe("C002");
+  });
+
+  it("strips channel_id when user types an unknown channel name", async () => {
+    const { spy } = setup({
+      channel: {
+        channel_type: "slack",
+        details: { channel: "#general", channel_id: "C001" },
+      },
+    });
+
+    const input = screen.getByPlaceholderText("Pick a user or channel...");
+    await userEvent.clear(input);
+    await userEvent.type(input, "#private-stuff");
+
+    const lastCall = spy.mock.calls[spy.mock.calls.length - 1];
+    const [propName, details] = lastCall;
+    expect(propName).toBe("details");
+    expect(details.channel).toBe("#private-stuff");
+    expect(details).not.toHaveProperty("channel_id");
+  });
+});

--- a/frontend/src/metabase/notifications/channels/SlackChannelFieldNew.tsx
+++ b/frontend/src/metabase/notifications/channels/SlackChannelFieldNew.tsx
@@ -2,16 +2,14 @@ import { useState } from "react";
 import { t } from "ttag";
 
 import CS from "metabase/css/core/index.css";
+import {
+  findChannelId,
+  getDisplayNames,
+} from "metabase/notifications/channels/utils";
 import { getApplicationName } from "metabase/selectors/whitelabel";
 import { Autocomplete } from "metabase/ui";
 import { useSelector } from "metabase/utils/redux";
-import type {
-  ChannelSpec,
-  NotificationHandlerSlack,
-  SlackChannelOption,
-} from "metabase-types/api";
-
-import { findChannelId, getDisplayNames } from "./SlackChannelField";
+import type { ChannelSpec, NotificationHandlerSlack } from "metabase-types/api";
 
 const CHANNEL_FIELD_NAME = "channel";
 const CHANNEL_PREFIX = "#";
@@ -37,7 +35,7 @@ export const SlackChannelFieldNew = ({
   const channelField = channelSpec.fields?.find(
     (field) => field.name === CHANNEL_FIELD_NAME,
   );
-  const slackOptions = (channelField?.options ?? []) as SlackChannelOption[];
+  const slackOptions = channelField?.options ?? [];
   const displayNames = getDisplayNames(slackOptions);
   const value = channel.recipients[0]?.details.value ?? "";
 

--- a/frontend/src/metabase/notifications/channels/SlackChannelFieldNew.tsx
+++ b/frontend/src/metabase/notifications/channels/SlackChannelFieldNew.tsx
@@ -5,7 +5,13 @@ import CS from "metabase/css/core/index.css";
 import { getApplicationName } from "metabase/selectors/whitelabel";
 import { Autocomplete } from "metabase/ui";
 import { useSelector } from "metabase/utils/redux";
-import type { ChannelSpec, NotificationHandlerSlack } from "metabase-types/api";
+import type {
+  ChannelSpec,
+  NotificationHandlerSlack,
+  SlackChannelOption,
+} from "metabase-types/api";
+
+import { findChannelId, getDisplayNames } from "./SlackChannelField";
 
 const CHANNEL_FIELD_NAME = "channel";
 const CHANNEL_PREFIX = "#";
@@ -31,9 +37,12 @@ export const SlackChannelFieldNew = ({
   const channelField = channelSpec.fields?.find(
     (field) => field.name === CHANNEL_FIELD_NAME,
   );
+  const slackOptions = (channelField?.options ?? []) as SlackChannelOption[];
+  const displayNames = getDisplayNames(slackOptions);
   const value = channel.recipients[0]?.details.value ?? "";
 
   const updateChannel = (value: string) => {
+    const newChannelId = findChannelId(slackOptions, value);
     onChange({
       ...channel,
       recipients: [
@@ -41,6 +50,7 @@ export const SlackChannelFieldNew = ({
           type: "notification-recipient/raw-value",
           details: {
             value,
+            ...(newChannelId != null && { channel_id: newChannelId }),
           },
         },
       ],
@@ -63,8 +73,7 @@ export const SlackChannelFieldNew = ({
       updateChannel(fullChannelName);
     }
 
-    const isPrivate =
-      value.trim().length > 0 && !channelField?.options?.includes(value);
+    const isPrivate = value.trim().length > 0 && !displayNames.includes(value);
 
     setHasPrivateChannelWarning(isPrivate);
   };
@@ -74,7 +83,7 @@ export const SlackChannelFieldNew = ({
   return (
     <div>
       <Autocomplete
-        data={channelField?.options || []}
+        data={displayNames}
         value={value}
         placeholder={t`Pick a user or channel...`}
         limit={300}

--- a/frontend/src/metabase/notifications/channels/SlackChannelFieldNew.unit.spec.tsx
+++ b/frontend/src/metabase/notifications/channels/SlackChannelFieldNew.unit.spec.tsx
@@ -1,0 +1,116 @@
+import userEvent from "@testing-library/user-event";
+import type { ComponentProps } from "react";
+import { useState } from "react";
+
+import { renderWithProviders, screen } from "__support__/ui";
+import { SlackChannelFieldNew } from "metabase/notifications/channels/SlackChannelFieldNew";
+import type {
+  ChannelSpec,
+  NotificationHandlerSlack,
+  SlackChannelOption,
+} from "metabase-types/api";
+import { createMockNotificationHandlerSlack } from "metabase-types/api/mocks";
+
+type OnChange = ComponentProps<typeof SlackChannelFieldNew>["onChange"];
+
+const SLACK_OPTIONS: SlackChannelOption[] = [
+  { displayName: "#general", id: "C001" },
+  { displayName: "#random", id: "C002" },
+];
+
+const CHANNEL_SPEC: ChannelSpec = {
+  type: "slack",
+  name: "Slack",
+  schedules: ["hourly"],
+  schedule_type: null,
+  allows_recipients: false,
+  configured: true,
+  fields: [
+    {
+      name: "channel",
+      displayName: "Post to",
+      options: SLACK_OPTIONS,
+      required: true,
+    },
+  ],
+};
+
+function StatefulWrapper({
+  initialChannel,
+  spy,
+}: {
+  initialChannel: NotificationHandlerSlack;
+  spy: jest.MockedFunction<OnChange>;
+}) {
+  const [channel, setChannel] = useState(initialChannel);
+  const onChange: OnChange = (newConfig) => {
+    spy(newConfig);
+    setChannel(newConfig);
+  };
+  return (
+    <SlackChannelFieldNew
+      channel={channel}
+      channelSpec={CHANNEL_SPEC}
+      onChange={onChange}
+    />
+  );
+}
+
+function setup({
+  channel = createMockNotificationHandlerSlack(),
+}: { channel?: NotificationHandlerSlack } = {}) {
+  const spy = jest.fn<ReturnType<OnChange>, Parameters<OnChange>>();
+  renderWithProviders(<StatefulWrapper initialChannel={channel} spy={spy} />);
+  return { spy };
+}
+
+function getLastDetails(spy: jest.MockedFunction<OnChange>) {
+  const lastCall = spy.mock.calls[spy.mock.calls.length - 1];
+  const [handler] = lastCall;
+  return handler.recipients[0]?.details;
+}
+
+describe("SlackChannelFieldNew channel_id storage", () => {
+  it("stores channel_id when user selects a known channel", async () => {
+    const { spy } = setup();
+
+    const input = screen.getByPlaceholderText("Pick a user or channel...");
+    await userEvent.type(input, "#general");
+
+    const details = getLastDetails(spy);
+    expect(details?.value).toBe("#general");
+    expect(details?.channel_id).toBe("C001");
+  });
+
+  it("omits channel_id when user types an unknown channel name", async () => {
+    const { spy } = setup();
+
+    const input = screen.getByPlaceholderText("Pick a user or channel...");
+    await userEvent.type(input, "#private-stuff");
+
+    const details = getLastDetails(spy);
+    expect(details?.value).toBe("#private-stuff");
+    expect(details).not.toHaveProperty("channel_id");
+  });
+
+  it("updates channel_id when user switches from one known channel to another", async () => {
+    const { spy } = setup({
+      channel: createMockNotificationHandlerSlack({
+        recipients: [
+          {
+            type: "notification-recipient/raw-value",
+            details: { value: "#general", channel_id: "C001" },
+          },
+        ],
+      }),
+    });
+
+    const input = screen.getByPlaceholderText("Pick a user or channel...");
+    await userEvent.clear(input);
+    await userEvent.type(input, "#random");
+
+    const details = getLastDetails(spy);
+    expect(details?.value).toBe("#random");
+    expect(details?.channel_id).toBe("C002");
+  });
+});

--- a/frontend/src/metabase/notifications/channels/utils.ts
+++ b/frontend/src/metabase/notifications/channels/utils.ts
@@ -1,4 +1,4 @@
-import type { SlackChannelOption } from "metabase-types/api";
+import type { SlackChannelId, SlackChannelOption } from "metabase-types/api";
 
 export function getDisplayNames(options: SlackChannelOption[]): string[] {
   return options.map((o) => o.displayName);
@@ -7,6 +7,6 @@ export function getDisplayNames(options: SlackChannelOption[]): string[] {
 export function findChannelId(
   options: SlackChannelOption[],
   displayName: string,
-): string | undefined {
+): SlackChannelId | undefined {
   return options.find((o) => o.displayName === displayName)?.id;
 }

--- a/frontend/src/metabase/notifications/channels/utils.ts
+++ b/frontend/src/metabase/notifications/channels/utils.ts
@@ -1,0 +1,12 @@
+import type { SlackChannelOption } from "metabase-types/api";
+
+export function getDisplayNames(options: SlackChannelOption[]): string[] {
+  return options.map((o) => o.displayName);
+}
+
+export function findChannelId(
+  options: SlackChannelOption[],
+  displayName: string,
+): string | undefined {
+  return options.find((o) => o.displayName === displayName)?.id;
+}

--- a/frontend/src/metabase/notifications/channels/utils.unit.spec.ts
+++ b/frontend/src/metabase/notifications/channels/utils.unit.spec.ts
@@ -1,0 +1,44 @@
+import {
+  findChannelId,
+  getDisplayNames,
+} from "metabase/notifications/channels/utils";
+import type { SlackChannelOption } from "metabase-types/api";
+
+describe("getDisplayNames", () => {
+  it("extracts display names from enriched options", () => {
+    const options: SlackChannelOption[] = [
+      { displayName: "#general", id: "C001" },
+      { displayName: "#random", id: "C002" },
+      { displayName: "@user1", id: "U001" },
+    ];
+    expect(getDisplayNames(options)).toEqual(["#general", "#random", "@user1"]);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(getDisplayNames([])).toEqual([]);
+  });
+});
+
+describe("findChannelId", () => {
+  const options: SlackChannelOption[] = [
+    { displayName: "#general", id: "C001" },
+    { displayName: "#random", id: "C002" },
+    { displayName: "@user1", id: "U001" },
+  ];
+
+  it("returns the ID for a known channel name", () => {
+    expect(findChannelId(options, "#random")).toBe("C002");
+  });
+
+  it("returns undefined for an unknown channel name", () => {
+    expect(findChannelId(options, "#nonexistent")).toBeUndefined();
+  });
+
+  it("returns undefined for empty string", () => {
+    expect(findChannelId(options, "")).toBeUndefined();
+  });
+
+  it("returns undefined for empty options", () => {
+    expect(findChannelId([], "#general")).toBeUndefined();
+  });
+});

--- a/src/metabase/channel/impl/slack.clj
+++ b/src/metabase/channel/impl/slack.clj
@@ -15,9 +15,14 @@
    [metabase.util.markdown :as markdown]))
 
 (defn- notification-recipient->channel
+  "Returns the Slack channel target for a raw-value notification recipient.
+  Prefers the immutable `:channel_id` (e.g. \"C0ABC123\") over the display `:value`
+  (e.g. \"#my-channel\") so that delivery survives channel renames. Falls back to
+  `:value` for legacy subscriptions that pre-date channel ID storage."
   [notification-recipient]
   (when (= (:type notification-recipient) :notification-recipient/raw-value)
-    (-> notification-recipient :details :value)))
+    (let [details (:details notification-recipient)]
+      (or (:channel_id details) (:value details)))))
 
 (defn- escape-mkdwn
   "Escapes slack mkdwn special characters in the string, as specified here:

--- a/src/metabase/notification/models.clj
+++ b/src/metabase/notification/models.clj
@@ -352,7 +352,8 @@
     [:notification-recipient/raw-value
      [:map
       [:details                               [:map {:closed true}
-                                               [:value :any]]]
+                                               [:value :any]
+                                               [:channel_id {:optional true} [:maybe :string]]]]
       [:user_id              {:optional true} [:fn nil?]]
       [:permissions_group_id {:optional true} [:fn nil?]]]]
     [:notification-recipient/template

--- a/src/metabase/pulse/api/pulse.clj
+++ b/src/metabase/pulse/api/pulse.clj
@@ -308,8 +308,9 @@
                              [:slack :fields 0 :options]
                              (->> (channel.settings/slack-cached-channels-and-usernames)
                                   :channels
-                                  (map :display-name)
-                                  distinct))
+                                  (m/distinct-by :id)
+                                  (m/distinct-by :display-name)
+                                  (map #(select-keys % [:display-name :id]))))
                    (catch Throwable e
                      (assoc-in chan-types [:slack :error] (.getMessage e)))))}))
 

--- a/src/metabase/pulse/api/pulse.clj
+++ b/src/metabase/pulse/api/pulse.clj
@@ -310,7 +310,8 @@
                                   :channels
                                   (m/distinct-by :id)
                                   (m/distinct-by :display-name)
-                                  (map #(select-keys % [:display-name :id]))))
+                                  (mapv (fn [{:keys [display-name id]}]
+                                          {:displayName display-name :id id}))))
                    (catch Throwable e
                      (assoc-in chan-types [:slack :error] (.getMessage e)))))}))
 

--- a/src/metabase/pulse/send.clj
+++ b/src/metabase/pulse/send.clj
@@ -24,7 +24,11 @@
   (case (keyword (:channel_type pulse-channel))
     :slack
     [{:type    :notification-recipient/raw-value
-      :details {:value (get-in pulse-channel [:details :channel])}}]
+      :details (let [details    {:value (get-in pulse-channel [:details :channel])}
+                     channel-id (get-in pulse-channel [:details :channel_id])]
+                 (if channel-id
+                   (assoc details :channel_id channel-id)
+                   details))}]
     :email
     (for [recipient (:recipients pulse-channel)]
       (if-not (:id recipient)

--- a/test/metabase/channel/impl/slack_test.clj
+++ b/test/metabase/channel/impl/slack_test.clj
@@ -9,6 +9,27 @@
 
 (set! *warn-on-reflection* true)
 
+(deftest notification-recipient->channel-prefers-channel-id-test
+  (testing "prefers channel_id over value when both are present"
+    (is (= "C0ABC123"
+           (#'channel.slack/notification-recipient->channel
+            {:type    :notification-recipient/raw-value
+             :details {:value "#my-channel" :channel_id "C0ABC123"}}))))
+  (testing "falls back to value when channel_id is absent"
+    (is (= "#my-channel"
+           (#'channel.slack/notification-recipient->channel
+            {:type    :notification-recipient/raw-value
+             :details {:value "#my-channel"}}))))
+  (testing "returns channel_id even when value is nil"
+    (is (= "C0ABC123"
+           (#'channel.slack/notification-recipient->channel
+            {:type    :notification-recipient/raw-value
+             :details {:channel_id "C0ABC123"}}))))
+  (testing "returns nil for non-raw-value recipient types"
+    (is (nil? (#'channel.slack/notification-recipient->channel
+               {:type    :notification-recipient/user
+                :details {:value "#my-channel" :channel_id "C0ABC123"}})))))
+
 (deftest slack-post-receives-at-most-50-blocks-test
   (let [block-inputs (atom [])]
     (with-redefs [slack/post-chat-message! (fn [message-content] (swap! block-inputs conj (:blocks message-content)))]

--- a/test/metabase/pulse/api/pulse_test.clj
+++ b/test/metabase/pulse/api/pulse_test.clj
@@ -1292,9 +1292,9 @@
                                                       :id "U1DYU9W3WZ2"
                                                       :display-name "@user1"}]}]
         (is (= [{:name "channel", :type "select", :displayName "Post to",
-                 :options [{:display-name "#foo"     :id "CAAS3DD9XND"}
-                           {:display-name "#general" :id "C3MJRZ9EUVA"}
-                           {:display-name "@user1"   :id "U1DYU9W3WZ2"}], :required true}]
+                 :options [{:displayName "#foo"     :id "CAAS3DD9XND"}
+                           {:displayName "#general" :id "C3MJRZ9EUVA"}
+                           {:displayName "@user1"   :id "U1DYU9W3WZ2"}], :required true}]
                (-> (mt/user-http-request :rasta :get 200 "pulse/form_input")
                    (get-in [:channels :slack :fields]))))))
 
@@ -1317,14 +1317,14 @@
                                                       :name "general"
                                                       :display-name "#general"
                                                       :id "C003"}]}]
-        (is (= [{:display-name "#channel" :id "C001"}
-                {:display-name "#general" :id "C003"}]
+        (is (= [{:displayName "#channel" :id "C001"}
+                {:displayName "#general" :id "C003"}]
                (-> (mt/user-http-request :rasta :get 200 "pulse/form_input")
                    (get-in [:channels :slack :fields])
                    first
                    :options)))
         (is (apply distinct?
-                   (map :display-name
+                   (map :displayName
                         (-> (mt/user-http-request :rasta :get 200 "pulse/form_input")
                             (get-in [:channels :slack :fields])
                             first
@@ -1349,8 +1349,8 @@
                                                       :name "general"
                                                       :display-name "#general"
                                                       :id "C003"}]}]
-        (is (= [{:display-name "#old-name" :id "C001"}
-                {:display-name "#general"  :id "C003"}]
+        (is (= [{:displayName "#old-name" :id "C001"}
+                {:displayName "#general"  :id "C003"}]
                (-> (mt/user-http-request :rasta :get 200 "pulse/form_input")
                    (get-in [:channels :slack :fields])
                    first

--- a/test/metabase/pulse/api/pulse_test.clj
+++ b/test/metabase/pulse/api/pulse_test.clj
@@ -1292,7 +1292,9 @@
                                                       :id "U1DYU9W3WZ2"
                                                       :display-name "@user1"}]}]
         (is (= [{:name "channel", :type "select", :displayName "Post to",
-                 :options ["#foo" "#general" "@user1"], :required true}]
+                 :options [{:display-name "#foo"     :id "CAAS3DD9XND"}
+                           {:display-name "#general" :id "C3MJRZ9EUVA"}
+                           {:display-name "@user1"   :id "U1DYU9W3WZ2"}], :required true}]
                (-> (mt/user-http-request :rasta :get 200 "pulse/form_input")
                    (get-in [:channels :slack :fields]))))))
 
@@ -1315,16 +1317,44 @@
                                                       :name "general"
                                                       :display-name "#general"
                                                       :id "C003"}]}]
-        (is (= ["#channel" "#general"]
+        (is (= [{:display-name "#channel" :id "C001"}
+                {:display-name "#general" :id "C003"}]
                (-> (mt/user-http-request :rasta :get 200 "pulse/form_input")
                    (get-in [:channels :slack :fields])
                    first
                    :options)))
         (is (apply distinct?
-                   (-> (mt/user-http-request :rasta :get 200 "pulse/form_input")
-                       (get-in [:channels :slack :fields])
-                       first
-                       :options)))))
+                   (map :display-name
+                        (-> (mt/user-http-request :rasta :get 200 "pulse/form_input")
+                            (get-in [:channels :slack :fields])
+                            first
+                            :options))))))
+
+    (testing "Duplicate Slack channel IDs are deduplicated, keeping the first entry"
+      (mt/with-temporary-setting-values [channel.settings/slack-channels-and-usernames-last-updated
+                                         (t/zoned-date-time)
+
+                                         channel.settings/slack-app-token "test-token"
+
+                                         channel.settings/slack-cached-channels-and-usernames
+                                         {:channels [{:type "channel"
+                                                      :name "old-name"
+                                                      :display-name "#old-name"
+                                                      :id "C001"}
+                                                     {:type "channel"
+                                                      :name "new-name"
+                                                      :display-name "#new-name"
+                                                      :id "C001"}
+                                                     {:type "channel"
+                                                      :name "general"
+                                                      :display-name "#general"
+                                                      :id "C003"}]}]
+        (is (= [{:display-name "#old-name" :id "C001"}
+                {:display-name "#general"  :id "C003"}]
+               (-> (mt/user-http-request :rasta :get 200 "pulse/form_input")
+                   (get-in [:channels :slack :fields])
+                   first
+                   :options)))))
 
     (testing "When slack is not configured, `form_input` returns no channels"
       (mt/with-temporary-setting-values [channel.settings/slack-app-token nil]

--- a/test/metabase/pulse/send_test.clj
+++ b/test/metabase/pulse/send_test.clj
@@ -24,6 +24,26 @@
     (testing "[PRO TIP] If this test fails, you may need to rebuild the bundle with `bun run build-static-viz`\n\n"
       (thunk))))
 
+(deftest channel-recipients-includes-channel-id-test
+  (testing "Slack channel-recipients includes channel_id when present in pulse_channel details"
+    (is (= [{:type    :notification-recipient/raw-value
+             :details {:value "#my-channel" :channel_id "C0ABC123"}}]
+           (#'pulse.send/channel-recipients
+            {:channel_type "slack"
+             :details      {:channel "#my-channel" :channel_id "C0ABC123"}}))))
+  (testing "Slack channel-recipients omits channel_id when absent from pulse_channel details"
+    (is (= [{:type    :notification-recipient/raw-value
+             :details {:value "#my-channel"}}]
+           (#'pulse.send/channel-recipients
+            {:channel_type "slack"
+             :details      {:channel "#my-channel"}}))))
+  (testing "Email recipients are unaffected"
+    (is (= [{:type    :notification-recipient/raw-value
+             :details {:value "test@example.com"}}]
+           (#'pulse.send/channel-recipients
+            {:channel_type "email"
+             :recipients   [{:email "test@example.com"}]})))))
+
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                               Util Fns & Macros                                                |
 ;;; +----------------------------------------------------------------------------------------------------------------+


### PR DESCRIPTION

Closes https://github.com/metabase/metabase/issues/19496

### Description

Dashboard subscriptions store Slack channels by name (e.g. `"#alerts"`). Slack channel IDs are immutable, but names are not. Renaming a channel breaks all subscriptions targeting it with just the name.

This PR fixes this by storing the immutable Slack channel ID alongside the display name at subscription creation time. At send time, we prefer the ID over the name - this maintains backwards compatibility with legacy subscriptions. The UI remains entirely name-based - users never see or interact with channel IDs.

There remains related issues we may follow up on in separate PRs:
* Backfilling old subscriptions with a custom migration
* Keeping slack channel display names synced (this is now possible since we persist the immutable channel IDs) - this is to maintain a more consistent UX for users when viewing channels in the picker (which shows names, not IDs)

Possible UX issue:
* Slack channel pickers cache the list of Slack channels, so if a slack channel changes its name within the 10 minute interval after that list of cached, the user does not see the newly renamed channel display name till after the cache expires.

### How to verify
Prereqs:
* Slack integrated into your Metabase instance - https://www.metabase.com/docs/latest/configuring-metabase/slack

1. Create a dashboard 
2. Set up a subscription to send to Slack
3. Pick a channel from the list of channels available. (e.g. `#old-channel`)
4. Rename the channel in slack (`#new-channel`)
5. Create a new channel in slack with the old name (`old-channel`)
6. Press the test send to Slack button - this should post the results of the dashboard to the channel `#new-channel` even though the Slack channel displayed in Metabase was the old channel `#old-channel`.
7. Save the subscription, and wait for the normal send job to complete at the hourly mark. The dashboard should be sent to `#old-channel`

This proves subscriptions are persisted with the channel ID and prioritise that as the identifier when sending to subscribed Slack channels.

### Demo

This shows the test slack send flow:

https://github.com/user-attachments/assets/7584b8dd-6e97-4a29-b31d-a5a361bc29cb

Hourly job sent to the right channel by ID:
<img width="1390" height="917" alt="hourly-subscription-sends-to-slack-id" src="https://github.com/user-attachments/assets/56cd91fc-1194-47f5-926a-83fef3572ae0" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR

