### PR TITLE
Resolve MultiAutocomplete translation plugin

### DIFF
--- a/frontend/src/metabase/common/components/DatabaseMultiSelect/DatabaseMultiSelect.tsx
+++ b/frontend/src/metabase/common/components/DatabaseMultiSelect/DatabaseMultiSelect.tsx
@@ -2,14 +2,8 @@ import { useMemo } from "react";
 import { t } from "ttag";
 
 import { useListDatabasesQuery } from "metabase/api";
-import {
-  type ComboboxItem,
-  Flex,
-  Icon,
-  MultiAutocomplete,
-  Text,
-  Tooltip,
-} from "metabase/ui";
+import { MultiAutocomplete } from "metabase/common/components/MultiAutocomplete";
+import { type ComboboxItem, Flex, Icon, Text, Tooltip } from "metabase/ui";
 import type { Database, DatabaseId } from "metabase-types/api";
 
 import S from "./DatabaseMultiSelect.module.css";

--- a/frontend/src/metabase/common/components/DatabaseMultiSelect/DatabaseMultiSelect.tsx
+++ b/frontend/src/metabase/common/components/DatabaseMultiSelect/DatabaseMultiSelect.tsx
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 import { t } from "ttag";
 
 import { useListDatabasesQuery } from "metabase/api";
-import { MultiAutocomplete } from "metabase/common/components/MultiAutocomplete";
+import { MultiAutocompleteWithTranslation } from "metabase/common/components/MultiAutocomplete";
 import { type ComboboxItem, Flex, Icon, Text, Tooltip } from "metabase/ui";
 import type { Database, DatabaseId } from "metabase-types/api";
 
@@ -98,7 +98,7 @@ export const DatabaseMultiSelect = ({
   };
 
   return (
-    <MultiAutocomplete
+    <MultiAutocompleteWithTranslation
       value={databaseIds}
       data={options}
       placeholder={placeholder}

--- a/frontend/src/metabase/common/components/MultiAutocomplete/MultiAutocomplete.tsx
+++ b/frontend/src/metabase/common/components/MultiAutocomplete/MultiAutocomplete.tsx
@@ -1,0 +1,21 @@
+import { useCallback } from "react";
+
+import { useTranslateContent } from "metabase/i18n/hooks";
+import { PLUGIN_CONTENT_TRANSLATION } from "metabase/plugins";
+import {
+  MultiAutocomplete as MultiAutocompleteBase,
+  type MultiAutocompleteProps,
+} from "metabase/ui";
+
+export function MultiAutocomplete(props: MultiAutocompleteProps) {
+  const tc = useTranslateContent();
+  const sortByTranslation =
+    PLUGIN_CONTENT_TRANSLATION.useSortByContentTranslation();
+
+  const sortComparator = useCallback(
+    (a: string, b: string) => sortByTranslation(tc(a), tc(b)),
+    [tc, sortByTranslation],
+  );
+
+  return <MultiAutocompleteBase {...props} sortComparator={sortComparator} />;
+}

--- a/frontend/src/metabase/common/components/MultiAutocomplete/MultiAutocomplete.tsx
+++ b/frontend/src/metabase/common/components/MultiAutocomplete/MultiAutocomplete.tsx
@@ -7,7 +7,9 @@ import {
   type MultiAutocompleteProps,
 } from "metabase/ui";
 
-export function MultiAutocomplete(props: MultiAutocompleteProps) {
+export function MultiAutocompleteWithTranslation(
+  props: MultiAutocompleteProps,
+) {
   const tc = useTranslateContent();
   const sortByTranslation =
     PLUGIN_CONTENT_TRANSLATION.useSortByContentTranslation();

--- a/frontend/src/metabase/common/components/MultiAutocomplete/index.ts
+++ b/frontend/src/metabase/common/components/MultiAutocomplete/index.ts
@@ -1,1 +1,1 @@
-export { MultiAutocomplete } from "./MultiAutocomplete";
+export { MultiAutocompleteWithTranslation } from "./MultiAutocomplete";

--- a/frontend/src/metabase/common/components/MultiAutocomplete/index.ts
+++ b/frontend/src/metabase/common/components/MultiAutocomplete/index.ts
@@ -1,0 +1,1 @@
+export { MultiAutocomplete } from "./MultiAutocomplete";

--- a/frontend/src/metabase/metrics/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
+++ b/frontend/src/metabase/metrics/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
@@ -2,7 +2,7 @@ import type { FormEvent } from "react";
 import { useMemo } from "react";
 import { t } from "ttag";
 
-import { MultiAutocomplete } from "metabase/common/components/MultiAutocomplete";
+import { MultiAutocompleteWithTranslation } from "metabase/common/components/MultiAutocomplete";
 import { Box, Checkbox, Flex } from "metabase/ui";
 import type * as Lib from "metabase-lib";
 import * as LibMetric from "metabase-lib/metric";
@@ -141,7 +141,7 @@ function StringValueInput({
   if (type === "partial") {
     return (
       <Box p="md" pb={0} mah="40vh" style={{ overflow: "auto" }}>
-        <MultiAutocomplete
+        <MultiAutocompleteWithTranslation
           value={values}
           placeholder={t`Enter some text`}
           comboboxProps={COMBOBOX_PROPS}

--- a/frontend/src/metabase/metrics/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
+++ b/frontend/src/metabase/metrics/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
@@ -2,7 +2,8 @@ import type { FormEvent } from "react";
 import { useMemo } from "react";
 import { t } from "ttag";
 
-import { Box, Checkbox, Flex, MultiAutocomplete } from "metabase/ui";
+import { MultiAutocomplete } from "metabase/common/components/MultiAutocomplete";
+import { Box, Checkbox, Flex } from "metabase/ui";
 import type * as Lib from "metabase-lib";
 import * as LibMetric from "metabase-lib/metric";
 

--- a/frontend/src/metabase/parameters/components/widgets/NumberInputWidget/NumberInputWidget.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/NumberInputWidget/NumberInputWidget.tsx
@@ -2,6 +2,7 @@ import { type FormEvent, useMemo, useState } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
+import { MultiAutocomplete } from "metabase/common/components/MultiAutocomplete";
 import { NumericInput } from "metabase/common/components/NumericInput";
 import CS from "metabase/css/core/index.css";
 import { UpdateFilterButton } from "metabase/parameters/components/UpdateFilterButton";
@@ -10,7 +11,7 @@ import {
   deserializeNumberParameterValue,
   serializeNumberParameterValue,
 } from "metabase/querying/parameters/utils/parsing";
-import { Box, type ComboboxItem, MultiAutocomplete } from "metabase/ui";
+import { Box, type ComboboxItem } from "metabase/ui";
 import { parseNumber } from "metabase/utils/number";
 import { isNotNull } from "metabase/utils/types";
 import { hasValue } from "metabase-lib/v1/parameters/utils/parameter-values";

--- a/frontend/src/metabase/parameters/components/widgets/NumberInputWidget/NumberInputWidget.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/NumberInputWidget/NumberInputWidget.tsx
@@ -2,7 +2,7 @@ import { type FormEvent, useMemo, useState } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
-import { MultiAutocomplete } from "metabase/common/components/MultiAutocomplete";
+import { MultiAutocompleteWithTranslation } from "metabase/common/components/MultiAutocomplete";
 import { NumericInput } from "metabase/common/components/NumericInput";
 import CS from "metabase/css/core/index.css";
 import { UpdateFilterButton } from "metabase/parameters/components/UpdateFilterButton";
@@ -103,7 +103,7 @@ export function NumberInputWidget({
       {label && <WidgetLabel>{label}</WidgetLabel>}
       {arity === "n" || options.length > 0 ? (
         <TokenFieldWrapper>
-          <MultiAutocomplete
+          <MultiAutocompleteWithTranslation
             value={filteredUnsavedArrayValue.map((value) => value?.toString())}
             data={options}
             placeholder={placeholder}

--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/FieldValuesWidget.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/FieldValuesWidget.tsx
@@ -19,7 +19,7 @@ import {
 } from "metabase/api";
 import { ExplicitSize } from "metabase/common/components/ExplicitSize";
 import { LoadingSpinner } from "metabase/common/components/LoadingSpinner";
-import { MultiAutocomplete } from "metabase/common/components/MultiAutocomplete";
+import { MultiAutocompleteWithTranslation } from "metabase/common/components/MultiAutocomplete";
 import {
   TokenField,
   parseStringValue,
@@ -454,7 +454,7 @@ export const FieldValuesWidgetInner = forwardRef<
             checkedColor={checkedColor}
           />
         ) : multi ? (
-          <MultiAutocomplete
+          <MultiAutocompleteWithTranslation
             value={value.filter(isNotNull).map((value) => String(value))}
             data={options
               .filter((option) => getValue(option) != null)

--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/FieldValuesWidget.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/FieldValuesWidget.tsx
@@ -19,6 +19,7 @@ import {
 } from "metabase/api";
 import { ExplicitSize } from "metabase/common/components/ExplicitSize";
 import { LoadingSpinner } from "metabase/common/components/LoadingSpinner";
+import { MultiAutocomplete } from "metabase/common/components/MultiAutocomplete";
 import {
   TokenField,
   parseStringValue,
@@ -38,7 +39,6 @@ import { addRemappings } from "metabase/redux/metadata";
 import {
   type ComboboxItem,
   Loader,
-  MultiAutocomplete,
   MultiAutocompleteOption,
   MultiAutocompleteValue,
 } from "metabase/ui";

--- a/frontend/src/metabase/parameters/components/widgets/StringInputWidget/StringInputWidget.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/StringInputWidget/StringInputWidget.tsx
@@ -1,9 +1,10 @@
 import { type ChangeEvent, type FormEvent, useState } from "react";
 import { t } from "ttag";
 
+import { MultiAutocomplete } from "metabase/common/components/MultiAutocomplete";
 import { UpdateFilterButton } from "metabase/parameters/components/UpdateFilterButton";
 import { deserializeStringParameterValue } from "metabase/querying/parameters/utils/parsing";
-import { Box, MultiAutocomplete, TextInput } from "metabase/ui";
+import { Box, TextInput } from "metabase/ui";
 import { hasValue } from "metabase-lib/v1/parameters/utils/parameter-values";
 import type { Parameter, ParameterValueOrArray } from "metabase-types/api";
 

--- a/frontend/src/metabase/parameters/components/widgets/StringInputWidget/StringInputWidget.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/StringInputWidget/StringInputWidget.tsx
@@ -1,7 +1,7 @@
 import { type ChangeEvent, type FormEvent, useState } from "react";
 import { t } from "ttag";
 
-import { MultiAutocomplete } from "metabase/common/components/MultiAutocomplete";
+import { MultiAutocompleteWithTranslation } from "metabase/common/components/MultiAutocomplete";
 import { UpdateFilterButton } from "metabase/parameters/components/UpdateFilterButton";
 import { deserializeStringParameterValue } from "metabase/querying/parameters/utils/parsing";
 import { Box, TextInput } from "metabase/ui";
@@ -69,7 +69,7 @@ export function StringInputWidget({
       {label && <WidgetLabel>{label}</WidgetLabel>}
       <Box m="sm">
         {isMultiSelect ? (
-          <MultiAutocomplete
+          <MultiAutocompleteWithTranslation
             value={unsavedValue}
             placeholder={placeholder}
             autoFocus={autoFocus}

--- a/frontend/src/metabase/querying/common/components/FieldValuePicker/SearchValuePicker/SearchValuePicker.tsx
+++ b/frontend/src/metabase/querying/common/components/FieldValuePicker/SearchValuePicker/SearchValuePicker.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useDebounce } from "react-use";
 import { t } from "ttag";
 
-import { MultiAutocomplete } from "metabase/common/components/MultiAutocomplete";
+import { MultiAutocompleteWithTranslation } from "metabase/common/components/MultiAutocomplete";
 import {
   getFieldOption,
   getFieldOptions,
@@ -97,7 +97,7 @@ export function SearchValuePicker({
   useDebounce(handleSearchTimeout, SEARCH_DEBOUNCE, [searchValue]);
 
   return (
-    <MultiAutocomplete
+    <MultiAutocompleteWithTranslation
       value={selectedValues}
       data={searchOptions}
       placeholder={placeholder}

--- a/frontend/src/metabase/querying/common/components/FieldValuePicker/SearchValuePicker/SearchValuePicker.tsx
+++ b/frontend/src/metabase/querying/common/components/FieldValuePicker/SearchValuePicker/SearchValuePicker.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useDebounce } from "react-use";
 import { t } from "ttag";
 
+import { MultiAutocomplete } from "metabase/common/components/MultiAutocomplete";
 import {
   getFieldOption,
   getFieldOptions,
@@ -10,7 +11,6 @@ import {
   type ComboboxItem,
   type ComboboxProps,
   Loader,
-  MultiAutocomplete,
   MultiAutocompleteOption,
   MultiAutocompleteValue,
 } from "metabase/ui";

--- a/frontend/src/metabase/querying/common/components/FieldValuePicker/StaticValuePicker/StaticValuePicker.tsx
+++ b/frontend/src/metabase/querying/common/components/FieldValuePicker/StaticValuePicker/StaticValuePicker.tsx
@@ -1,6 +1,6 @@
 import { t } from "ttag";
 
-import { MultiAutocomplete } from "metabase/common/components/MultiAutocomplete";
+import { MultiAutocompleteWithTranslation } from "metabase/common/components/MultiAutocomplete";
 import type { ComboboxProps } from "metabase/ui";
 
 interface StaticValuePickerProps {
@@ -21,7 +21,7 @@ export function StaticValuePicker({
   onChange,
 }: StaticValuePickerProps) {
   return (
-    <MultiAutocomplete
+    <MultiAutocompleteWithTranslation
       value={selectedValues}
       placeholder={placeholder}
       autoFocus={autoFocus}

--- a/frontend/src/metabase/querying/common/components/FieldValuePicker/StaticValuePicker/StaticValuePicker.tsx
+++ b/frontend/src/metabase/querying/common/components/FieldValuePicker/StaticValuePicker/StaticValuePicker.tsx
@@ -1,6 +1,7 @@
 import { t } from "ttag";
 
-import { type ComboboxProps, MultiAutocomplete } from "metabase/ui";
+import { MultiAutocomplete } from "metabase/common/components/MultiAutocomplete";
+import type { ComboboxProps } from "metabase/ui";
 
 interface StaticValuePickerProps {
   selectedValues: string[];

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
@@ -2,7 +2,7 @@ import type { FormEvent } from "react";
 import { useMemo } from "react";
 import { t } from "ttag";
 
-import { MultiAutocomplete } from "metabase/common/components/MultiAutocomplete";
+import { MultiAutocompleteWithTranslation } from "metabase/common/components/MultiAutocomplete";
 import { Box, Checkbox, Flex } from "metabase/ui";
 import * as Lib from "metabase-lib";
 
@@ -160,7 +160,7 @@ function StringValueInput({
   if (type === "partial") {
     return (
       <Box p="md" pb={0} mah="40vh" style={{ overflow: "auto" }}>
-        <MultiAutocomplete
+        <MultiAutocompleteWithTranslation
           value={values}
           placeholder={t`Enter some text`}
           comboboxProps={COMBOBOX_PROPS}

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
@@ -2,7 +2,8 @@ import type { FormEvent } from "react";
 import { useMemo } from "react";
 import { t } from "ttag";
 
-import { Box, Checkbox, Flex, MultiAutocomplete } from "metabase/ui";
+import { MultiAutocomplete } from "metabase/common/components/MultiAutocomplete";
+import { Box, Checkbox, Flex } from "metabase/ui";
 import * as Lib from "metabase-lib";
 
 import { FilterOperatorPicker } from "../FilterOperatorPicker";

--- a/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.tsx
+++ b/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.tsx
@@ -19,9 +19,6 @@ import type { ReactNode } from "react";
 import { useMemo } from "react";
 import { t } from "ttag";
 
-import { useTranslateContent } from "metabase/i18n/hooks";
-import { PLUGIN_CONTENT_TRANSLATION } from "metabase/plugins";
-
 import { Icon } from "../../icons";
 
 import S from "./MultiAutocomplete.module.css";
@@ -51,6 +48,7 @@ export type MultiAutocompleteProps = BoxProps &
     parseValue?: (rawValue: string) => string | null;
     renderValue?: (props: MultiAutocompleteRenderValueProps) => ReactNode;
     renderOption?: (props: MultiAutocompleteRenderOptionProps) => ReactNode;
+    sortComparator?: (a: string, b: string) => number;
     onChange: (newValues: string[]) => void;
     onSearchChange?: (newValue: string) => void;
   };
@@ -86,6 +84,7 @@ export function MultiAutocomplete({
   parseValue = defaultParseValue,
   renderValue = defaultRenderValue,
   renderOption,
+  sortComparator,
   onChange,
   onSearchChange,
   onDropdownOpen,
@@ -93,42 +92,30 @@ export function MultiAutocomplete({
   onOptionSubmit,
   ...otherProps
 }: MultiAutocompleteProps) {
-  const tc = useTranslateContent();
-  const sortByTranslation =
-    PLUGIN_CONTENT_TRANSLATION.useSortByContentTranslation();
-
   const sortedData = useMemo(() => {
     const parsedData = getParsedComboboxData(data);
-
-    const hasTranslations = parsedData.some((item) => {
-      if (isOptionsGroup(item)) {
-        return item.items.some((option) => tc(option.value) !== option.value);
-      }
-      return tc(item.value) !== item.value;
-    });
-
-    if (hasTranslations) {
-      return parsedData
-        .map((item) => {
-          if (isOptionsGroup(item)) {
-            return {
-              ...item,
-              items: [...item.items].sort((a, b) =>
-                sortByTranslation(tc(a.value), tc(b.value)),
-              ),
-            };
-          }
-          return item;
-        })
-        .sort((a, b) => {
-          const aValue = isOptionsGroup(a) ? a.group : a.value;
-          const bValue = isOptionsGroup(b) ? b.group : b.value;
-          return sortByTranslation(tc(aValue), tc(bValue));
-        });
+    if (!sortComparator) {
+      return parsedData;
     }
 
-    return parsedData;
-  }, [data, tc, sortByTranslation]);
+    return parsedData
+      .map((item) => {
+        if (isOptionsGroup(item)) {
+          return {
+            ...item,
+            items: [...item.items].sort((a, b) =>
+              sortComparator(a.value, b.value),
+            ),
+          };
+        }
+        return item;
+      })
+      .sort((a, b) => {
+        const aValue = isOptionsGroup(a) ? a.group : a.value;
+        const bValue = isOptionsGroup(b) ? b.group : b.value;
+        return sortComparator(aValue, bValue);
+      });
+  }, [data, sortComparator]);
 
   const {
     combobox,

--- a/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.tsx
+++ b/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.tsx
@@ -53,6 +53,11 @@ export type MultiAutocompleteProps = BoxProps &
     onSearchChange?: (newValue: string) => void;
   };
 
+/**
+ * Base multi-value autocomplete component. For most use cases, prefer
+ * {@link MultiAutocompleteWithTranslation} from `metabase/common/components/MultiAutocomplete`
+ * which adds content translation and translation-aware sorting.
+ */
 export function MultiAutocomplete({
   value,
   data = [],


### PR DESCRIPTION
Previously, MultiAutocomplete (basic/ui) imported `PLUGIN_CONTENT_TRANSLATION` (shared/plugins) directly, violating module boundaries

I considered many options for resolving this. First I tried using Context to inject the plugin into the component via a hook. This technically worked, but it felt weird to add that indirection when plugins already have a layer of indiretion/dependency injection. 

Next I considered whether plugins should actually be `lib` tier. The argument for that is plugins are simply placeholders that have real values injected in later. The problem is the plugin typing would require moving types into lib for the plugins, a pattern we're trying to avoid generally. But more fundamentally, it seems weird for lower tiers to need to know about plugins because the plugins are generally domain concerns.

MultiAutocomplete is good example, because it's quite a complicated component. I considered just moving the whole component into shared, but it uses several mantine primitives that we don't export from core. It would be possible to just export them, but the approach I used felt simpler. Namely, ui exports a simpler version of the MultiAutocomplete with a prop to customize the sorting function. Then a shared component that wraps MultiAutocomplete and provides the content translation sorting via the plugin.

The name `MultiAutocompleteWithTranslation` is clunky, but I preferred being explicit. having `ui/MultiAutocomplete` and `common/MultiAutocomplete` would be confusing (I know we overload component names elsewhere, but I always find it confusing). Another option would be `ui/MultiAutocompleteBase` and `shared/MultiAutocomplete`, but I went for `MultiAutocompleteWithTranslation` because it reflects that the common version is more specialised. Open to bikeshedding, though
