### PR TITLE
Throttle FE error API

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -951,6 +951,7 @@
    :api  #{metabase.frontend-errors.api}
    :uses #{analytics
            api
+           request
            util}}
 
   geojson

--- a/src/metabase/api/macros.clj
+++ b/src/metabase/api/macros.clj
@@ -827,9 +827,11 @@
        (resolve-handler))))
 
   ([nmspace & middleware :- [:sequential {:min 1} ::middleware]]
-   (apply-middleware
-    (ns-handler nmspace)
-    middleware)))
+   (let [handler (ns-handler nmspace)]
+     (open-api/handler-with-open-api-spec
+      (apply-middleware handler middleware)
+      (fn [prefix]
+        (open-api/open-api-spec handler prefix))))))
 
 (extend-protocol open-api/OpenAPISpec
   clojure.lang.Namespace

--- a/src/metabase/api_routes/routes.clj
+++ b/src/metabase/api_routes/routes.clj
@@ -180,7 +180,7 @@
    "/email"                metabase.channel.api/email-routes
    "/embed"                (+message-only-exceptions metabase.embedding-rest.api/embedding-routes)
    "/field"                (+auth metabase.warehouse-schema-rest.api/field-routes)
-   "/frontend-errors"      'metabase.frontend-errors.api
+   "/frontend-errors"      metabase.frontend-errors.api/routes
    "/geojson"              'metabase.geojson.api
    "/glossary"             (+auth 'metabase.glossary.api)
    "/google"               (+auth metabase.sso.api/google-auth-routes)

--- a/src/metabase/frontend_errors/api.clj
+++ b/src/metabase/frontend_errors/api.clj
@@ -13,11 +13,10 @@
 (mr/def ::frontend-error-type
   [:enum "component-crash" "chart-render-error"])
 
-;; This endpoint is unauthenticated and writes to a Prometheus counter, so it is a
-;; natural target for abuse (flooding to distort metrics or exhaust resources).
-;; Throttle anonymous clients by IP, which is derived server-side. Browser IDs are
-;; client-controlled cookies and can be rotated or omitted to evade throttling, so
-;; they must not be used as the authoritative throttle bucket here.
+;; This endpoint is unauthenticated and writes to a Prometheus counter, so it is a natural target
+;; for abuse (flooding to distort metrics or exhaust resources). Throttle anonymous clients by IP,
+;; which is derived server-side. Browser IDs are client-controlled cookies and can be rotated or
+;; omitted to evade throttling, so they must not be used as the authoritative throttle bucket here.
 (def ^:private frontend-errors-throttler
   (throttle/make-throttler :frontend-errors
                            :attempts-threshold 100

--- a/src/metabase/frontend_errors/api.clj
+++ b/src/metabase/frontend_errors/api.clj
@@ -3,10 +3,25 @@
    [metabase.analytics.prometheus :as prometheus]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
-   [metabase.util.malli.registry :as mr]))
+   [metabase.request.core :as request]
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.throttle :as u.throttle]
+   [throttle.core :as throttle])
+  (:import
+   (clojure.lang ExceptionInfo)))
 
 (mr/def ::frontend-error-type
   [:enum "component-crash" "chart-render-error"])
+
+;; This endpoint is unauthenticated and writes to a Prometheus counter, so it is a
+;; natural target for abuse (flooding to distort metrics or exhaust resources).
+;; Throttle by client IP. The threshold is generous enough to accommodate a page
+;; with many components reporting errors in a burst, but low enough to blunt a
+;; sustained flood from a single source.
+(def ^:private frontend-errors-throttler
+  (throttle/make-throttler :frontend-errors
+                           :attempts-threshold 100
+                           :attempt-ttl-ms     (* 60 1000)))
 
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :post "/"
@@ -14,9 +29,16 @@
    with the given `type` label."
   [_route-params
    _query-params
-   {:keys [type]} :- [:map [:type ::frontend-error-type]]]
-  (prometheus/inc! :metabase-frontend/errors {:type type})
-  api/generic-204-no-content)
+   {:keys [type]} :- [:map [:type ::frontend-error-type]]
+   req]
+  (try
+    (throttle/with-throttling [frontend-errors-throttler (request/ip-address req)]
+      (prometheus/inc! :metabase-frontend/errors {:type type})
+      api/generic-204-no-content)
+    (catch ExceptionInfo e
+      (if (u.throttle/throttle-exception? e)
+        (u.throttle/throttle-response e {:error (ex-message e)})
+        (throw e)))))
 
 ;;; !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ;;; !! Endpoints in this namespace do not currently require auth! Keep this in mind when adding new ones. !!

--- a/src/metabase/frontend_errors/api.clj
+++ b/src/metabase/frontend_errors/api.clj
@@ -15,21 +15,19 @@
 
 ;; This endpoint is unauthenticated and writes to a Prometheus counter, so it is a
 ;; natural target for abuse (flooding to distort metrics or exhaust resources).
-;; Throttle anonymous clients by browser ID, with IP as a fallback. The threshold
-;; is generous enough to accommodate a page with many components reporting errors
-;; in a burst, but low enough to blunt a sustained flood from a single source.
+;; Throttle anonymous clients by IP, which is derived server-side. Browser IDs are
+;; client-controlled cookies and can be rotated or omitted to evade throttling, so
+;; they must not be used as the authoritative throttle bucket here.
 (def ^:private frontend-errors-throttler
   (throttle/make-throttler :frontend-errors
                            :attempts-threshold 100
                            :attempt-ttl-ms     (* 60 1000)))
 
 (defn- frontend-errors-throttle-key
-  "Prefer the per-browser identifier for anonymous clients so unrelated users on the
-  same egress IP do not share a throttle bucket. Fall back to IP if the request does
-  not have a browser ID for some reason."
+  "Use the request IP as the throttle key. This keeps the bucket tied to a trusted,
+  server-derived identifier for this unauthenticated endpoint."
   [request]
-  (or (:browser-id request)
-      (request/ip-address request)))
+  (request/ip-address request))
 
 (defn- throttle-frontend-errors
   "Apply throttling before `defendpoint` body parsing/validation runs."

--- a/src/metabase/frontend_errors/api.clj
+++ b/src/metabase/frontend_errors/api.clj
@@ -32,9 +32,9 @@
    {:keys [type]} :- [:map [:type ::frontend-error-type]]
    req]
   (try
-    (throttle/with-throttling [frontend-errors-throttler (request/ip-address req)]
-      (prometheus/inc! :metabase-frontend/errors {:type type})
-      api/generic-204-no-content)
+    (throttle/check frontend-errors-throttler (request/ip-address req))
+    (prometheus/inc! :metabase-frontend/errors {:type type})
+    api/generic-204-no-content
     (catch ExceptionInfo e
       (if (u.throttle/throttle-exception? e)
         (u.throttle/throttle-response e {:error (ex-message e)})

--- a/src/metabase/frontend_errors/api.clj
+++ b/src/metabase/frontend_errors/api.clj
@@ -15,13 +15,33 @@
 
 ;; This endpoint is unauthenticated and writes to a Prometheus counter, so it is a
 ;; natural target for abuse (flooding to distort metrics or exhaust resources).
-;; Throttle by client IP. The threshold is generous enough to accommodate a page
-;; with many components reporting errors in a burst, but low enough to blunt a
-;; sustained flood from a single source.
+;; Throttle anonymous clients by browser ID, with IP as a fallback. The threshold
+;; is generous enough to accommodate a page with many components reporting errors
+;; in a burst, but low enough to blunt a sustained flood from a single source.
 (def ^:private frontend-errors-throttler
   (throttle/make-throttler :frontend-errors
                            :attempts-threshold 100
                            :attempt-ttl-ms     (* 60 1000)))
+
+(defn- frontend-errors-throttle-key
+  "Prefer the per-browser identifier for anonymous clients so unrelated users on the
+  same egress IP do not share a throttle bucket. Fall back to IP if the request does
+  not have a browser ID for some reason."
+  [request]
+  (or (:browser-id request)
+      (request/ip-address request)))
+
+(defn- throttle-frontend-errors
+  "Apply throttling before `defendpoint` body parsing/validation runs."
+  [handler]
+  (fn [request respond raise]
+    (try
+      (throttle/check frontend-errors-throttler (frontend-errors-throttle-key request))
+      (handler request respond raise)
+      (catch ExceptionInfo e
+        (if (u.throttle/throttle-exception? e)
+          (respond (u.throttle/throttle-response e {:error (ex-message e)}))
+          (raise e))))))
 
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :post "/"
@@ -30,15 +50,13 @@
   [_route-params
    _query-params
    {:keys [type]} :- [:map [:type ::frontend-error-type]]
-   req]
-  (try
-    (throttle/check frontend-errors-throttler (request/ip-address req))
-    (prometheus/inc! :metabase-frontend/errors {:type type})
-    api/generic-204-no-content
-    (catch ExceptionInfo e
-      (if (u.throttle/throttle-exception? e)
-        (u.throttle/throttle-response e {:error (ex-message e)})
-        (throw e)))))
+   _req]
+  (prometheus/inc! :metabase-frontend/errors {:type type})
+  api/generic-204-no-content)
+
+(def ^{:arglists '([request respond raise])} routes
+  "Routes for frontend error reporting."
+  (api.macros/ns-handler *ns* throttle-frontend-errors))
 
 ;;; !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ;;; !! Endpoints in this namespace do not currently require auth! Keep this in mind when adding new ones. !!

--- a/src/metabase/oauth_server/api/oauth.clj
+++ b/src/metabase/oauth_server/api/oauth.clj
@@ -12,6 +12,7 @@
    [metabase.request.core :as request]
    [metabase.system.core :as system]
    [metabase.util.log :as log]
+   [metabase.util.throttle :as u.throttle]
    [oidc-provider.core :as oidc]
    [oidc-provider.protocol :as proto]
    [oidc-provider.registration :as reg]
@@ -138,33 +139,17 @@
 (def ^:private authorize-decision-throttler
   (throttle/make-throttler :user-id :attempts-threshold 20 :attempt-ttl-ms one-hour-ms))
 
-(defn- throttle-response
-  "Build a 429 response from a throttle exception, extracting Retry-After when available."
-  [^ExceptionInfo e]
-  (let [message       (ex-message e)
-        retry-seconds (some->> message (re-find #"(\d+) seconds") second)]
-    (cond-> {:status  429
-             :headers {"Content-Type" "application/json"}
-             :body    {:error             "too_many_requests"
-                       :error_description message}}
-      retry-seconds (assoc-in [:headers "Retry-After"] retry-seconds))))
-
-(defn- throttle-exception?
-  "True when `e` is a throttle-limit exception thrown by [[metabase.throttle]].
-   Coupled to the library's `\"Too many attempts!\"` message prefix — update here if that changes."
-  [^ExceptionInfo e]
-  (str/starts-with? (ex-message e) "Too many attempts!"))
-
 (defmacro ^:private with-throttling-429
-  "Like [[throttle/with-throttling]], but returns HTTP 429 with Retry-After instead of
-   throwing an unhandled exception (which the generic middleware would turn into a 500)."
+  "Like [[throttle/with-throttling]], but turns a throttle exception into an
+   OAuth-flavoured 429 response (`too_many_requests`) with Retry-After."
   {:style/indent 1}
   [bindings & body]
   `(try
      (throttle/with-throttling ~bindings ~@body)
      (catch ExceptionInfo e#
-       (if (throttle-exception? e#)
-         (throttle-response e#)
+       (if (u.throttle/throttle-exception? e#)
+         (u.throttle/throttle-response e# {:error             "too_many_requests"
+                                           :error_description (ex-message e#)})
          (throw e#)))))
 
 ;;; ------------------------------------------------ Endpoints ----------------------------------------------------

--- a/src/metabase/oauth_server/api/oauth.clj
+++ b/src/metabase/oauth_server/api/oauth.clj
@@ -126,16 +126,16 @@
 (def ^:private token-ip-throttler
   (throttle/make-throttler :ip-address :attempts-threshold 50 :attempt-ttl-ms one-hour-ms))
 
-;; /oauth/register is unauthenticated and creates server-side state (client records).
-;; Without throttling, an attacker can exhaust storage or generate unlimited client_id/secret pairs.
-;; Per-IP only since there's no identity at registration time. Threshold allows burst setup of
-;; several agents without enabling sustained spam.
+;; /oauth/register is unauthenticated and creates server-side state (client records). Without
+;; throttling, an attacker can exhaust storage or generate unlimited client_id/secret pairs. Per-IP
+;; only since there's no identity at registration time. Threshold allows burst setup of several
+;; agents without enabling sustained spam.
 (def ^:private registration-throttler
   (throttle/make-throttler :ip-address :attempts-threshold 10 :attempt-ttl-ms one-minute-ms))
 
-;; /oauth/authorize/decision is lower risk (requires authentication + CSRF token),
-;; but a compromised session could automate consent-granting. A per-user cap limits the blast
-;; radius while allowing setup of many agents in a single session.
+;; /oauth/authorize/decision is lower risk (requires authentication + CSRF token), but a
+;; compromised session could automate consent-granting. A per-user cap limits the blast radius
+;; while allowing setup of many agents in a single session.
 (def ^:private authorize-decision-throttler
   (throttle/make-throttler :user-id :attempts-threshold 20 :attempt-ttl-ms one-hour-ms))
 

--- a/src/metabase/util/throttle.clj
+++ b/src/metabase/util/throttle.clj
@@ -1,0 +1,25 @@
+(ns metabase.util.throttle
+  "Shared helpers for turning throttle exceptions into HTTP 429 responses.
+   Coupled to the `throttle.core` library's `\"Too many attempts!\"` message prefix —
+   update [[throttle-exception?]] if that changes."
+  (:require
+   [clojure.string :as str])
+  (:import
+   (clojure.lang ExceptionInfo)))
+
+(set! *warn-on-reflection* true)
+
+(defn throttle-exception?
+  "True when `e` is a throttle-limit exception thrown by `throttle.core`."
+  [^ExceptionInfo e]
+  (str/starts-with? (ex-message e) "Too many attempts!"))
+
+(defn throttle-response
+  "Build a 429 Ring response from a throttle exception, extracting Retry-After when available.
+   `body` is the response `:body` (callers build whatever shape their endpoint wants)."
+  [^ExceptionInfo e body]
+  (let [retry-seconds (some->> (ex-message e) (re-find #"(\d+) seconds") second)]
+    (cond-> {:status  429
+             :headers {"Content-Type" "application/json"}
+             :body    body}
+      retry-seconds (assoc-in [:headers "Retry-After"] retry-seconds))))

--- a/src/metabase/util/throttle.clj
+++ b/src/metabase/util/throttle.clj
@@ -1,7 +1,5 @@
 (ns metabase.util.throttle
-  "Shared helpers for turning throttle exceptions into HTTP 429 responses.
-   Coupled to the `throttle.core` library's `\"Too many attempts!\"` message prefix —
-   update [[throttle-exception?]] if that changes."
+  "Helpers for turning throttle exceptions into HTTP 429 responses."
   (:require
    [clojure.string :as str])
   (:import

--- a/test/metabase/frontend_errors/api_test.clj
+++ b/test/metabase/frontend_errors/api_test.clj
@@ -4,6 +4,7 @@
    [clojure.test :refer :all]
    [metabase.frontend-errors.api :as frontend-errors.api]
    [metabase.request.settings :as request.settings]
+   [metabase.server.middleware.browser-cookie :as mw.browser-cookie]
    [metabase.test :as mt]
    [throttle.core :as throttle]))
 
@@ -25,13 +26,15 @@
            (select-keys (mt/user-http-request :rasta :post 400 "frontend-errors" {:type "bogus"})
                         [:errors]))))
 
-  (testing "POST /api/frontend-errors is throttled by IP once the threshold is exceeded"
+  (testing "POST /api/frontend-errors is throttled for the same browser once the threshold is exceeded"
     (mt/with-prometheus-system! [_ system]
       (with-redefs [frontend-errors.api/frontend-errors-throttler
                     (throttle/make-throttler :frontend-errors :attempts-threshold 1)
                     request.settings/source-address-header
                     (constantly "x-forwarded-for")]
-        (let [request-options {:request-options {:headers {"x-forwarded-for" "10.1.2.3"}}}
+        (let [browser-id-cookie-name @#'mw.browser-cookie/browser-id-cookie-name
+              request-options {:request-options {:headers {"x-forwarded-for" "10.1.2.3"
+                                                           "cookie"          (str browser-id-cookie-name "=device-a")}}}
               initial-count   (mt/metric-value system :metabase-frontend/errors {:type "component-crash"})]
           (is (nil? (mt/user-http-request :rasta :post 204 "frontend-errors" request-options
                                           {:type "component-crash"})))
@@ -42,5 +45,48 @@
                 count-after-throttling    (mt/metric-value system :metabase-frontend/errors {:type "component-crash"})]
             (is (< initial-count count-after-first-request))
             (is (= count-after-first-request count-after-throttling))
+            (is (str/starts-with? (get-in resp [:body :error]) "Too many attempts!"))
+            (is (string? (get-in resp [:headers "Retry-After"])))))))
+
+    (testing "POST /api/frontend-errors prefers browser-id over shared IP throttling"
+      (mt/with-prometheus-system! [_ system]
+        (with-redefs [frontend-errors.api/frontend-errors-throttler
+                      (throttle/make-throttler :frontend-errors :attempts-threshold 1)
+                      request.settings/source-address-header
+                      (constantly "x-forwarded-for")]
+          (let [browser-id-cookie-name @#'mw.browser-cookie/browser-id-cookie-name
+                device-a-opts          {:request-options {:headers {"x-forwarded-for" "10.1.2.3"
+                                                                    "cookie"          (str browser-id-cookie-name "=device-a")}}}
+                device-b-opts          {:request-options {:headers {"x-forwarded-for" "10.1.2.3"
+                                                                    "cookie"          (str browser-id-cookie-name "=device-b")}}}
+                initial-count          (mt/metric-value system :metabase-frontend/errors {:type "component-crash"})]
+            (is (nil? (mt/user-http-request :rasta :post 204 "frontend-errors" device-a-opts
+                                            {:type "component-crash"})))
+            (is (nil? (mt/user-http-request :crowberto :post 204 "frontend-errors" device-b-opts
+                                            {:type "component-crash"})))
+            (let [count-after-two-browsers (mt/metric-value system :metabase-frontend/errors {:type "component-crash"})
+                  resp                     (mt/user-http-request-full-response :lucky :post 429 "frontend-errors"
+                                                                               device-a-opts
+                                                                               {:type "component-crash"})
+                  count-after-throttling   (mt/metric-value system :metabase-frontend/errors {:type "component-crash"})]
+              (is (= (+ initial-count 2) count-after-two-browsers))
+              (is (= count-after-two-browsers count-after-throttling))
+              (is (str/starts-with? (get-in resp [:body :error]) "Too many attempts!")))))))
+
+    (testing "POST /api/frontend-errors throttles repeated invalid payloads before validation"
+      (with-redefs [frontend-errors.api/frontend-errors-throttler
+                    (throttle/make-throttler :frontend-errors :attempts-threshold 1)
+                    request.settings/source-address-header
+                    (constantly "x-forwarded-for")]
+        (let [browser-id-cookie-name @#'mw.browser-cookie/browser-id-cookie-name
+              request-options {:request-options {:headers {"x-forwarded-for" "10.1.2.3"
+                                                           "cookie"          (str browser-id-cookie-name "=device-a")}}}]
+          (is (= {:errors {:type "enum of component-crash, chart-render-error"}}
+                 (select-keys (mt/user-http-request :rasta :post 400 "frontend-errors" request-options
+                                                    {:type "bogus"})
+                              [:errors])))
+          (let [resp (mt/user-http-request-full-response :crowberto :post 429 "frontend-errors"
+                                                         request-options
+                                                         {:type "still-bogus"})]
             (is (str/starts-with? (get-in resp [:body :error]) "Too many attempts!"))
             (is (string? (get-in resp [:headers "Retry-After"])))))))))

--- a/test/metabase/frontend_errors/api_test.clj
+++ b/test/metabase/frontend_errors/api_test.clj
@@ -26,7 +26,7 @@
            (select-keys (mt/user-http-request :rasta :post 400 "frontend-errors" {:type "bogus"})
                         [:errors]))))
 
-  (testing "POST /api/frontend-errors is throttled for the same browser once the threshold is exceeded"
+  (testing "POST /api/frontend-errors is throttled for the same IP once the threshold is exceeded"
     (mt/with-prometheus-system! [_ system]
       (with-redefs [frontend-errors.api/frontend-errors-throttler
                     (throttle/make-throttler :frontend-errors :attempts-threshold 1)
@@ -48,7 +48,7 @@
             (is (str/starts-with? (get-in resp [:body :error]) "Too many attempts!"))
             (is (string? (get-in resp [:headers "Retry-After"])))))))
 
-    (testing "POST /api/frontend-errors prefers browser-id over shared IP throttling"
+    (testing "POST /api/frontend-errors throttles requests from the same IP even if the browser ID changes"
       (mt/with-prometheus-system! [_ system]
         (with-redefs [frontend-errors.api/frontend-errors-throttler
                       (throttle/make-throttler :frontend-errors :attempts-threshold 1)
@@ -62,15 +62,11 @@
                 initial-count          (mt/metric-value system :metabase-frontend/errors {:type "component-crash"})]
             (is (nil? (mt/user-http-request :rasta :post 204 "frontend-errors" device-a-opts
                                             {:type "component-crash"})))
-            (is (nil? (mt/user-http-request :crowberto :post 204 "frontend-errors" device-b-opts
-                                            {:type "component-crash"})))
-            (let [count-after-two-browsers (mt/metric-value system :metabase-frontend/errors {:type "component-crash"})
-                  resp                     (mt/user-http-request-full-response :lucky :post 429 "frontend-errors"
-                                                                               device-a-opts
-                                                                               {:type "component-crash"})
+            (let [resp                   (mt/user-http-request-full-response :crowberto :post 429 "frontend-errors"
+                                                                             device-b-opts
+                                                                             {:type "component-crash"})
                   count-after-throttling   (mt/metric-value system :metabase-frontend/errors {:type "component-crash"})]
-              (is (= (+ initial-count 2) count-after-two-browsers))
-              (is (= count-after-two-browsers count-after-throttling))
+              (is (= (inc initial-count) count-after-throttling))
               (is (str/starts-with? (get-in resp [:body :error]) "Too many attempts!")))))))
 
     (testing "POST /api/frontend-errors throttles repeated invalid payloads before validation"

--- a/test/metabase/frontend_errors/api_test.clj
+++ b/test/metabase/frontend_errors/api_test.clj
@@ -1,7 +1,12 @@
 (ns metabase.frontend-errors.api-test
   (:require
+   [clojure.string :as str]
    [clojure.test :refer :all]
-   [metabase.test :as mt]))
+   [metabase.frontend-errors.api :as frontend-errors.api]
+   [metabase.test :as mt]
+   [metabase.test.data.users :as test.users]
+   [metabase.test.http-client :as client]
+   [throttle.core :as throttle]))
 
 (deftest post-frontend-errors-test
   (testing "POST /api/frontend-errors increments the counter for component-crash and returns 204"
@@ -19,4 +24,14 @@
   (testing "POST /api/frontend-errors rejects unknown type values"
     (is (= {:errors {:type "enum of component-crash, chart-render-error"}}
            (select-keys (mt/user-http-request :rasta :post 400 "frontend-errors" {:type "bogus"})
-                        [:errors])))))
+                        [:errors]))))
+
+  (testing "POST /api/frontend-errors is throttled by IP once the threshold is exceeded"
+    (with-redefs [frontend-errors.api/frontend-errors-throttler
+                  (throttle/make-throttler :frontend-errors :attempts-threshold 1)]
+      (mt/user-http-request :rasta :post 204 "frontend-errors" {:type "component-crash"})
+      (let [resp (client/client-full-response (test.users/username->token :rasta)
+                                              :post 429 "frontend-errors"
+                                              {:type "component-crash"})]
+        (is (str/starts-with? (get-in resp [:body :error]) "Too many attempts!"))
+        (is (string? (get-in resp [:headers "Retry-After"])))))))

--- a/test/metabase/frontend_errors/api_test.clj
+++ b/test/metabase/frontend_errors/api_test.clj
@@ -3,9 +3,8 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.frontend-errors.api :as frontend-errors.api]
+   [metabase.request.settings :as request.settings]
    [metabase.test :as mt]
-   [metabase.test.data.users :as test.users]
-   [metabase.test.http-client :as client]
    [throttle.core :as throttle]))
 
 (deftest post-frontend-errors-test
@@ -27,11 +26,21 @@
                         [:errors]))))
 
   (testing "POST /api/frontend-errors is throttled by IP once the threshold is exceeded"
-    (with-redefs [frontend-errors.api/frontend-errors-throttler
-                  (throttle/make-throttler :frontend-errors :attempts-threshold 1)]
-      (mt/user-http-request :rasta :post 204 "frontend-errors" {:type "component-crash"})
-      (let [resp (client/client-full-response (test.users/username->token :rasta)
-                                              :post 429 "frontend-errors"
-                                              {:type "component-crash"})]
-        (is (str/starts-with? (get-in resp [:body :error]) "Too many attempts!"))
-        (is (string? (get-in resp [:headers "Retry-After"])))))))
+    (mt/with-prometheus-system! [_ system]
+      (with-redefs [frontend-errors.api/frontend-errors-throttler
+                    (throttle/make-throttler :frontend-errors :attempts-threshold 1)
+                    request.settings/source-address-header
+                    (constantly "x-forwarded-for")]
+        (let [request-options {:request-options {:headers {"x-forwarded-for" "10.1.2.3"}}}
+              initial-count   (mt/metric-value system :metabase-frontend/errors {:type "component-crash"})]
+          (is (nil? (mt/user-http-request :rasta :post 204 "frontend-errors" request-options
+                                          {:type "component-crash"})))
+          (let [count-after-first-request (mt/metric-value system :metabase-frontend/errors {:type "component-crash"})
+                resp                      (mt/user-http-request-full-response :crowberto :post 429 "frontend-errors"
+                                                                              request-options
+                                                                              {:type "component-crash"})
+                count-after-throttling    (mt/metric-value system :metabase-frontend/errors {:type "component-crash"})]
+            (is (< initial-count count-after-first-request))
+            (is (= count-after-first-request count-after-throttling))
+            (is (str/starts-with? (get-in resp [:body :error]) "Too many attempts!"))
+            (is (string? (get-in resp [:headers "Retry-After"])))))))))

--- a/test/metabase/frontend_errors/api_test.clj
+++ b/test/metabase/frontend_errors/api_test.clj
@@ -8,6 +8,26 @@
    [metabase.test :as mt]
    [throttle.core :as throttle]))
 
+(def ^:private throttled-response
+  {:status  429
+   :headers {"Retry-After" string?}
+   :body    {:error #(str/starts-with? % "Too many attempts!")}})
+
+(defn- request-options
+  ([]
+   {:request-options {:headers {"x-forwarded-for" "10.1.2.3"}}})
+  ([device-id]
+   (let [browser-id-cookie-name @#'mw.browser-cookie/browser-id-cookie-name]
+     {:request-options {:headers {"x-forwarded-for" "10.1.2.3"
+                                  "cookie"          (str browser-id-cookie-name "=" device-id)}}})))
+
+(defmacro ^:private with-throttled-frontend-errors [& body]
+  `(with-redefs [frontend-errors.api/frontend-errors-throttler
+                 (throttle/make-throttler :frontend-errors :attempts-threshold 1)
+                 request.settings/source-address-header
+                 (constantly "x-forwarded-for")]
+     ~@body))
+
 (deftest post-frontend-errors-test
   (testing "POST /api/frontend-errors increments the counter for component-crash and returns 204"
     (mt/with-prometheus-system! [_ system]
@@ -28,13 +48,8 @@
 
   (testing "POST /api/frontend-errors is throttled for the same IP once the threshold is exceeded"
     (mt/with-prometheus-system! [_ system]
-      (with-redefs [frontend-errors.api/frontend-errors-throttler
-                    (throttle/make-throttler :frontend-errors :attempts-threshold 1)
-                    request.settings/source-address-header
-                    (constantly "x-forwarded-for")]
-        (let [browser-id-cookie-name @#'mw.browser-cookie/browser-id-cookie-name
-              request-options {:request-options {:headers {"x-forwarded-for" "10.1.2.3"
-                                                           "cookie"          (str browser-id-cookie-name "=device-a")}}}
+      (with-throttled-frontend-errors
+        (let [request-options (request-options "device-a")
               initial-count   (mt/metric-value system :metabase-frontend/errors {:type "component-crash"})]
           (is (nil? (mt/user-http-request :rasta :post 204 "frontend-errors" request-options
                                           {:type "component-crash"})))
@@ -45,22 +60,13 @@
                 count-after-throttling    (mt/metric-value system :metabase-frontend/errors {:type "component-crash"})]
             (is (< initial-count count-after-first-request))
             (is (= count-after-first-request count-after-throttling))
-            (is (=? {:status  429
-                     :headers {"Retry-After" string?}
-                     :body    {:error #(str/starts-with? % "Too many attempts!")}}
-                    resp))))))
+            (is (=? throttled-response resp)))))))
 
     (testing "POST /api/frontend-errors throttles requests from the same IP even if the browser ID changes"
       (mt/with-prometheus-system! [_ system]
-        (with-redefs [frontend-errors.api/frontend-errors-throttler
-                      (throttle/make-throttler :frontend-errors :attempts-threshold 1)
-                      request.settings/source-address-header
-                      (constantly "x-forwarded-for")]
-          (let [browser-id-cookie-name @#'mw.browser-cookie/browser-id-cookie-name
-                device-a-opts          {:request-options {:headers {"x-forwarded-for" "10.1.2.3"
-                                                                    "cookie"          (str browser-id-cookie-name "=device-a")}}}
-                device-b-opts          {:request-options {:headers {"x-forwarded-for" "10.1.2.3"
-                                                                    "cookie"          (str browser-id-cookie-name "=device-b")}}}
+        (with-throttled-frontend-errors
+          (let [device-a-opts          (request-options "device-a")
+                device-b-opts          (request-options "device-b")
                 initial-count          (mt/metric-value system :metabase-frontend/errors {:type "component-crash"})]
             (is (nil? (mt/user-http-request :rasta :post 204 "frontend-errors" device-a-opts
                                             {:type "component-crash"})))
@@ -69,17 +75,12 @@
                                                                              {:type "component-crash"})
                   count-after-throttling   (mt/metric-value system :metabase-frontend/errors {:type "component-crash"})]
               (is (= (inc initial-count) count-after-throttling))
-              (is (=? {:status 429
-                       :body   {:error #(str/starts-with? % "Too many attempts!")}}
-                      resp)))))))
+              (is (=? throttled-response resp)))))))
 
     (testing "POST /api/frontend-errors throttles repeated requests from the same IP even without a browser cookie"
       (mt/with-prometheus-system! [_ system]
-        (with-redefs [frontend-errors.api/frontend-errors-throttler
-                      (throttle/make-throttler :frontend-errors :attempts-threshold 1)
-                      request.settings/source-address-header
-                      (constantly "x-forwarded-for")]
-          (let [request-options {:request-options {:headers {"x-forwarded-for" "10.1.2.3"}}}
+        (with-throttled-frontend-errors
+          (let [request-options (request-options)
                 initial-count   (mt/metric-value system :metabase-frontend/errors {:type "component-crash"})]
             (is (nil? (mt/user-http-request :rasta :post 204 "frontend-errors" request-options
                                             {:type "component-crash"})))
@@ -88,19 +89,11 @@
                                                                             {:type "component-crash"})
                   count-after-throttling (mt/metric-value system :metabase-frontend/errors {:type "component-crash"})]
               (is (= (inc initial-count) count-after-throttling))
-              (is (=? {:status  429
-                       :headers {"Retry-After" string?}
-                       :body    {:error #(str/starts-with? % "Too many attempts!")}}
-                      resp)))))))
+              (is (=? throttled-response resp)))))))
 
     (testing "POST /api/frontend-errors throttles repeated invalid payloads before validation"
-      (with-redefs [frontend-errors.api/frontend-errors-throttler
-                    (throttle/make-throttler :frontend-errors :attempts-threshold 1)
-                    request.settings/source-address-header
-                    (constantly "x-forwarded-for")]
-        (let [browser-id-cookie-name @#'mw.browser-cookie/browser-id-cookie-name
-              request-options {:request-options {:headers {"x-forwarded-for" "10.1.2.3"
-                                                           "cookie"          (str browser-id-cookie-name "=device-a")}}}]
+      (with-throttled-frontend-errors
+        (let [request-options (request-options "device-a")]
           (is (= {:errors {:type "enum of component-crash, chart-render-error"}}
                  (select-keys (mt/user-http-request :rasta :post 400 "frontend-errors" request-options
                                                     {:type "bogus"})
@@ -108,7 +101,4 @@
           (let [resp (mt/user-http-request-full-response :crowberto :post 429 "frontend-errors"
                                                          request-options
                                                          {:type "still-bogus"})]
-            (is (=? {:status  429
-                     :headers {"Retry-After" string?}
-                     :body    {:error #(str/starts-with? % "Too many attempts!")}}
-                    resp))))))))
+            (is (=? throttled-response resp))))))))

--- a/test/metabase/frontend_errors/api_test.clj
+++ b/test/metabase/frontend_errors/api_test.clj
@@ -69,6 +69,24 @@
               (is (= (inc initial-count) count-after-throttling))
               (is (str/starts-with? (get-in resp [:body :error]) "Too many attempts!")))))))
 
+    (testing "POST /api/frontend-errors throttles repeated requests from the same IP even without a browser cookie"
+      (mt/with-prometheus-system! [_ system]
+        (with-redefs [frontend-errors.api/frontend-errors-throttler
+                      (throttle/make-throttler :frontend-errors :attempts-threshold 1)
+                      request.settings/source-address-header
+                      (constantly "x-forwarded-for")]
+          (let [request-options {:request-options {:headers {"x-forwarded-for" "10.1.2.3"}}}
+                initial-count   (mt/metric-value system :metabase-frontend/errors {:type "component-crash"})]
+            (is (nil? (mt/user-http-request :rasta :post 204 "frontend-errors" request-options
+                                            {:type "component-crash"})))
+            (let [resp                  (mt/user-http-request-full-response :crowberto :post 429 "frontend-errors"
+                                                                            request-options
+                                                                            {:type "component-crash"})
+                  count-after-throttling (mt/metric-value system :metabase-frontend/errors {:type "component-crash"})]
+              (is (= (inc initial-count) count-after-throttling))
+              (is (str/starts-with? (get-in resp [:body :error]) "Too many attempts!"))
+              (is (string? (get-in resp [:headers "Retry-After"]))))))))
+
     (testing "POST /api/frontend-errors throttles repeated invalid payloads before validation"
       (with-redefs [frontend-errors.api/frontend-errors-throttler
                     (throttle/make-throttler :frontend-errors :attempts-threshold 1)

--- a/test/metabase/frontend_errors/api_test.clj
+++ b/test/metabase/frontend_errors/api_test.clj
@@ -45,8 +45,10 @@
                 count-after-throttling    (mt/metric-value system :metabase-frontend/errors {:type "component-crash"})]
             (is (< initial-count count-after-first-request))
             (is (= count-after-first-request count-after-throttling))
-            (is (str/starts-with? (get-in resp [:body :error]) "Too many attempts!"))
-            (is (string? (get-in resp [:headers "Retry-After"])))))))
+            (is (=? {:status  429
+                     :headers {"Retry-After" string?}
+                     :body    {:error #(str/starts-with? % "Too many attempts!")}}
+                    resp))))))
 
     (testing "POST /api/frontend-errors throttles requests from the same IP even if the browser ID changes"
       (mt/with-prometheus-system! [_ system]
@@ -67,7 +69,9 @@
                                                                              {:type "component-crash"})
                   count-after-throttling   (mt/metric-value system :metabase-frontend/errors {:type "component-crash"})]
               (is (= (inc initial-count) count-after-throttling))
-              (is (str/starts-with? (get-in resp [:body :error]) "Too many attempts!")))))))
+              (is (=? {:status 429
+                       :body   {:error #(str/starts-with? % "Too many attempts!")}}
+                      resp)))))))
 
     (testing "POST /api/frontend-errors throttles repeated requests from the same IP even without a browser cookie"
       (mt/with-prometheus-system! [_ system]
@@ -84,8 +88,10 @@
                                                                             {:type "component-crash"})
                   count-after-throttling (mt/metric-value system :metabase-frontend/errors {:type "component-crash"})]
               (is (= (inc initial-count) count-after-throttling))
-              (is (str/starts-with? (get-in resp [:body :error]) "Too many attempts!"))
-              (is (string? (get-in resp [:headers "Retry-After"]))))))))
+              (is (=? {:status  429
+                       :headers {"Retry-After" string?}
+                       :body    {:error #(str/starts-with? % "Too many attempts!")}}
+                      resp)))))))
 
     (testing "POST /api/frontend-errors throttles repeated invalid payloads before validation"
       (with-redefs [frontend-errors.api/frontend-errors-throttler
@@ -102,5 +108,7 @@
           (let [resp (mt/user-http-request-full-response :crowberto :post 429 "frontend-errors"
                                                          request-options
                                                          {:type "still-bogus"})]
-            (is (str/starts-with? (get-in resp [:body :error]) "Too many attempts!"))
-            (is (string? (get-in resp [:headers "Retry-After"])))))))))
+            (is (=? {:status  429
+                     :headers {"Retry-After" string?}
+                     :body    {:error #(str/starts-with? % "Too many attempts!")}}
+                    resp))))))))

--- a/test/metabase/frontend_errors/api_test.clj
+++ b/test/metabase/frontend_errors/api_test.clj
@@ -60,7 +60,7 @@
                 count-after-throttling    (mt/metric-value system :metabase-frontend/errors {:type "component-crash"})]
             (is (< initial-count count-after-first-request))
             (is (= count-after-first-request count-after-throttling))
-            (is (=? throttled-response resp)))))))
+            (is (=? throttled-response resp))))))
 
     (testing "POST /api/frontend-errors throttles requests from the same IP even if the browser ID changes"
       (mt/with-prometheus-system! [_ system]


### PR DESCRIPTION
Adds an IP-based throttle to the unauthorized "track frontend exceptions" API