### PR TITLE
Fix drilling Metabot quesitons hides drilled questions

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/metabot-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/metabot-question.cy.spec.tsx
@@ -71,6 +71,30 @@ describe("scenarios > embedding-sdk > metabot-question", () => {
     mockAuthProviderAndJwtSignIn();
   };
 
+  it("should show drill-through results after drilling from a metabot question", () => {
+    setup(metabotResponseWithNavigateTo);
+
+    mountSdkContent(<MetabotQuestion />);
+
+    getSdkRoot().within(() => {
+      cy.findByTestId("metabot-chat-input").type("Show orders {enter}");
+      cy.findByTestId("visualization-root").should("exist");
+
+      H.tableInteractiveBody().findAllByRole("gridcell", { name: "2" }).click();
+    });
+
+    H.popover().findByText("View this Product's Orders").click();
+
+    getSdkRoot().within(() => {
+      cy.findByTestId("visualization-root").should("be.visible");
+
+      H.assertTableData({
+        columns: ["Product ID", "Max of Quantity"],
+        firstRows: [["2", "18"]],
+      });
+    });
+  });
+
   it("should automatically show the ad-hoc question for the last agent message containing ad-hoc question link", () => {
     setup(metabotResponseWithNavigateTo);
 

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkInternalNavigation/context.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkInternalNavigation/context.tsx
@@ -23,7 +23,7 @@ export type SdkInternalNavigationEntry =
     })
   | (BaseEntry & {
       type: "question";
-      id: SdkQuestionId;
+      id: SdkQuestionId | null;
       name: string;
       virtual?: true;
       parameters?: ParameterValues;

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/context/SdkQuestionProvider.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/context/SdkQuestionProvider.tsx
@@ -264,15 +264,10 @@ export const SdkQuestionProvider = ({
   // Push the question name to the stack if the stack is empty (ie: this is the root question)
   // We need to wait for the question to load to have the name
   useEffect(() => {
-    if (
-      question &&
-      !!questionId &&
-      navigation &&
-      navigation.stack.length === 0
-    ) {
+    if (question && navigation && navigation.stack.length === 0) {
       navigation.push({
         type: "question",
-        id: questionId,
+        id: questionId ?? null,
         name: question.displayName() || t`Question`,
       });
     }

--- a/frontend/src/embedding-sdk-bundle/components/public/SdkQuestion/SdkQuestion.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/SdkQuestion/SdkQuestion.unit.spec.tsx
@@ -22,6 +22,10 @@ import {
   within,
 } from "__support__/ui";
 import {
+  SdkInternalNavigationContext,
+  type SdkInternalNavigationContextValue,
+} from "embedding-sdk-bundle/components/private/SdkInternalNavigation/context";
+import {
   SdkQuestionDefaultView,
   type SdkQuestionDefaultViewProps,
 } from "embedding-sdk-bundle/components/private/SdkQuestionDefaultView";
@@ -97,6 +101,21 @@ const TEST_CARD = createMockCard({
   parameters: [TEST_PARAM],
 });
 
+function makeMockNavigation(
+  overrides: Partial<SdkInternalNavigationContextValue> = {},
+): SdkInternalNavigationContextValue {
+  return {
+    stack: [],
+    push: jest.fn(),
+    pop: jest.fn(),
+    canGoBack: false,
+    currentEntry: undefined,
+    previousEntry: undefined,
+    initWithDashboard: jest.fn(),
+    ...overrides,
+  };
+}
+
 const setup = async ({
   isValidCard = true,
   title,
@@ -105,12 +124,16 @@ const setup = async ({
   initialSqlParameters,
   cardId = TEST_CARD_ID,
   preventWaitForLoader = false,
+  mockNavigation,
 }: Partial<
   Pick<BaseSdkQuestionProps, "initialSqlParameters"> &
     Pick<SdkQuestionDefaultViewProps, "withChartTypeSelector" | "title"> & {
       isValidCard?: boolean;
       withCustomLayout?: boolean;
-    } & { cardId: BaseEntityId | CardId; preventWaitForLoader?: boolean }
+      cardId: BaseEntityId | CardId | null;
+      preventWaitForLoader?: boolean;
+      mockNavigation?: SdkInternalNavigationContextValue;
+    }
 > = {}) => {
   const { state } = setupSdkState({
     currentUser: TEST_USER,
@@ -151,14 +174,16 @@ const setup = async ({
   });
 
   renderWithSDKProviders(
-    <SdkQuestion
-      questionId={cardId}
-      title={title}
-      withChartTypeSelector={withChartTypeSelector}
-      initialSqlParameters={initialSqlParameters}
-    >
-      {withCustomLayout ? <InteractiveQuestionCustomLayout /> : undefined}
-    </SdkQuestion>,
+    <SdkInternalNavigationContext.Provider value={mockNavigation ?? null}>
+      <SdkQuestion
+        questionId={cardId}
+        title={title}
+        withChartTypeSelector={withChartTypeSelector}
+        initialSqlParameters={initialSqlParameters}
+      >
+        {withCustomLayout ? <InteractiveQuestionCustomLayout /> : undefined}
+      </SdkQuestion>
+    </SdkInternalNavigationContext.Provider>,
     {
       componentProviderProps: {
         authConfig: createMockSdkConfig(),
@@ -356,5 +381,30 @@ describe("InteractiveQuestion", () => {
       screen.queryByText("Query results will appear here."),
     ).not.toBeInTheDocument();
     expect(screen.getByTestId("query-visualization-root")).toBeInTheDocument();
+  });
+
+  describe("navigation stack initialization", () => {
+    it("should push a question entry with id=null for an ad-hoc question (questionId is null)", async () => {
+      const mockNavigation = makeMockNavigation();
+      await setup({ cardId: null, mockNavigation });
+
+      expect(mockNavigation.push).toHaveBeenCalledWith({
+        type: "question",
+        id: null,
+        name: expect.any(String),
+      });
+    });
+
+    it("should not push to the navigation stack when the stack is already populated", async () => {
+      const existingEntry = {
+        type: "dashboard" as const,
+        id: 1,
+        name: "Sales Dashboard",
+      };
+      const mockNavigation = makeMockNavigation({ stack: [existingEntry] });
+      await setup({ mockNavigation });
+
+      expect(mockNavigation.push).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #72207
closes EMB-1552
closes EMB-1555

### Description

Nicolo fix the code, I added the tests. The reason this failed was because we haven't accounted for the first question to not have a question ID. But Metabot question doesn't have an ID because it starts off as an ad-hoc question.

### How to verify

1. Run Metabase BE with EE token
1. Run embedding storybook with bun run storybook-embedding-sdk
1. Visit the MetabotQuestions story
1. Ask something to Metabot that it would return a question
1. Drill the question

### Demo

#### Before 
<img width="2224" height="1260" alt="image" src="https://github.com/user-attachments/assets/cd0373d6-92e6-4e83-947a-a249534d8f34" />


#### After
Now you see will also see the back button to go to the original question

<img width="1182" height="990" alt="image" src="https://github.com/user-attachments/assets/c732429b-3e00-4497-8e3b-c0c8dce19511" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
