### PR TITLE
GDGT-2220 Viz icons throughout the app are black

### DIFF
--- a/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.styled.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.styled.tsx
@@ -6,7 +6,7 @@ import styled from "@emotion/styled";
 import { RawMaybeLink } from "metabase/common/components/Badge/Badge.styled";
 import { Card } from "metabase/common/components/Card";
 import { MarkdownPreview } from "metabase/common/components/MarkdownPreview";
-import { Box, type BoxProps, Icon } from "metabase/ui";
+import { Box, type BoxProps } from "metabase/ui";
 
 export const ItemCard = styled(Card)``;
 
@@ -21,12 +21,6 @@ export const ItemLink = styled(RawMaybeLink)<{ to?: string }>`
             cursor: default;
           }
         `}
-`;
-
-export const ItemIcon = styled(Icon)`
-  color: var(--mb-color-brand);
-  height: 1.5rem;
-  width: 1.5rem;
 `;
 
 export const ActionsContainer = styled(Box)<BoxProps>`

--- a/frontend/src/metabase/common/components/EntityIcon/EntityIcon.tsx
+++ b/frontend/src/metabase/common/components/EntityIcon/EntityIcon.tsx
@@ -46,5 +46,5 @@ export function EntityIcon({
     );
   }
 
-  return <Icon name={name} size={size} color={color} style={style} {...rest} />;
+  return <Icon name={name} size={size} c={color} style={style} {...rest} />;
 }

--- a/frontend/src/metabase/common/components/EntityIcon/EntityIcon.tsx
+++ b/frontend/src/metabase/common/components/EntityIcon/EntityIcon.tsx
@@ -31,7 +31,7 @@ export function EntityIcon({
 }: EntityIconProps) {
   const theme = useMantineTheme();
   const isDarkMode = theme.other.colorScheme === "dark";
-  const resolvedIconUrl = (isDarkMode && iconDarkUrl) || iconUrl;
+  const resolvedIconUrl = isDarkMode ? (iconDarkUrl ?? iconUrl) : iconUrl;
 
   if (resolvedIconUrl) {
     // color is intentionally not applied — CSS color has no effect on <img>

--- a/frontend/src/metabase/common/components/EntityIcon/EntityIcon.tsx
+++ b/frontend/src/metabase/common/components/EntityIcon/EntityIcon.tsx
@@ -46,13 +46,5 @@ export function EntityIcon({
     );
   }
 
-  return (
-    <Icon
-      name={name}
-      size={size}
-      color={color as ColorName}
-      style={style}
-      {...rest}
-    />
-  );
+  return <Icon name={name} size={size} color={color} style={style} {...rest} />;
 }

--- a/frontend/src/metabase/common/components/SelectList/SelectListItem.styled.tsx
+++ b/frontend/src/metabase/common/components/SelectList/SelectListItem.styled.tsx
@@ -3,14 +3,16 @@ import { css } from "@emotion/react";
 // eslint-disable-next-line no-restricted-imports
 import styled from "@emotion/styled";
 
-import { Icon, Text, type TextProps } from "metabase/ui";
+import { Text, type TextProps } from "metabase/ui";
+
+import { EntityIcon } from "../EntityIcon";
 
 export const ItemTitle = styled(Text)<TextProps>`
   margin: 0;
   word-break: break-word;
 ` as unknown as typeof Text;
 
-export const ItemIcon = styled(Icon)`
+export const ItemIcon = styled(EntityIcon)`
   justify-self: end;
 `;
 

--- a/frontend/src/metabase/common/components/SelectList/SelectListItem.tsx
+++ b/frontend/src/metabase/common/components/SelectList/SelectListItem.tsx
@@ -50,10 +50,11 @@ export function SelectListItem({
     >
       {icon && (
         <EntityIcon
-          {...iconProps}
           iconUrl={iconUrl}
           className={classNames.icon}
           color="brand"
+          size="1.5rem"
+          {...iconProps}
         />
       )}
       <ItemTitle

--- a/frontend/src/metabase/common/components/SelectList/SelectListItem.tsx
+++ b/frontend/src/metabase/common/components/SelectList/SelectListItem.tsx
@@ -1,7 +1,6 @@
 import cx from "classnames";
 import _ from "underscore";
 
-import { EntityIcon } from "metabase/common/components/EntityIcon";
 import type { IconProps } from "metabase/ui";
 import { Ellipsified } from "metabase/ui";
 
@@ -49,11 +48,10 @@ export function SelectListItem({
       hasRightIcon={!!rightIcon}
     >
       {icon && (
-        <EntityIcon
+        <ItemIcon
           iconUrl={iconUrl}
           className={classNames.icon}
           color="brand"
-          size="1.5rem"
           {...iconProps}
         />
       )}

--- a/frontend/src/metabase/ui/components/icons/Icon/Icon.tsx
+++ b/frontend/src/metabase/ui/components/icons/Icon/Icon.tsx
@@ -22,7 +22,7 @@ export type IconProps = Omit<SVGAttributes<SVGSVGElement>, "color"> &
     tooltipPosition?: FloatingPosition;
     onClick?: (event: MouseEvent<HTMLImageElement | SVGElement>) => void;
     className?: string;
-    color?: ColorName;
+    color?: ColorName | "inherit";
   };
 
 export const Icon = forwardRef<SVGSVGElement, IconProps>(function Icon(


### PR DESCRIPTION
Closes [GDGT-2220](https://linear.app/metabase/issue/GDGT-2220/viz-icons-throughout-the-app-are-black)

### Description

I went through all changes in #71990 and made sure things work as expected.
