### PR TITLE
Remove accidental semicolon in JSX

### DIFF
--- a/frontend/src/metabase/common/components/Pickers/EntityPicker/components/ItemLists/SearchResults.tsx
+++ b/frontend/src/metabase/common/components/Pickers/EntityPicker/components/ItemLists/SearchResults.tsx
@@ -42,7 +42,7 @@ export const SearchResults = ({
   if (isLoading || error) {
     return (
       <Box h="100%" w="40rem">
-        <LoadingAndErrorWrapper loading={isLoading} error={error} />;
+        <LoadingAndErrorWrapper loading={isLoading} error={error} />
       </Box>
     );
   }


### PR DESCRIPTION
### Description

Removes accidental semicolon in JSX.

### Before

<img width="2773" height="1583" alt="image" src="https://github.com/user-attachments/assets/2a099a47-5d33-479a-8fd4-71dd61132867" />

