### PR TITLE
Fix module update method to insert missing :model-X entries

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1539,7 +1539,10 @@
            request
            tiles
            util}
-   :model-imports #{:model/Card :model/Dashboard :model/DashboardCard :model/Document}}
+   :model-imports #{:model/Card
+                    :model/Dashboard
+                    :model/DashboardCard
+                    :model/Document}}
 
   pulse
   {:team "Gadget"
@@ -2233,12 +2236,12 @@
    :api  #{metabase.transforms-base.init
            metabase.transforms-base.interface
            metabase.transforms-base.util}
+   ;; TODO regressions — transforms-base should not depend on :model/Transform or
+   ;; :model/TransformRun directly. Remove once the module is agnostic to global
+   ;; versus workspace transforms. See https://linear.app/metabase/issue/BOT-1143
    :model-imports #{:model/Database
                     :model/DatabaseRouter
                     :model/Table
-                    ;; TODO regressions — transforms-base should not depend on
-                    ;; these directly. Remove once the module is agnostic to
-                    ;; global versus workspace transforms.
                     :model/Transform
                     :model/TransformRun}
    :uses #{driver

--- a/dev/src/dev/model_boundary_config.clj
+++ b/dev/src/dev/model_boundary_config.clj
@@ -142,15 +142,17 @@
                   (empty? computed)
                   root
 
-                  ;; Key missing — append `<newline><indent>:key <set>` to the module config map.
+                  ;; Key missing — append `<newline><indent>:key <set>` to the module config map,
+                  ;; splicing new children directly to avoid the separator spaces `append-child` inserts.
                   :else
-                  (z/root
-                   (-> mod-cfg
-                       (z/append-child (r.node/newlines 1))
-                       (z/append-child (r.node/spaces 3))
-                       (z/append-child config-key)
-                       (z/append-child (r.node/spaces 1))
-                       (z/append-child (r.parser/parse-string (model-set-str computed))))))))
+                  (let [m-node       (z/node mod-cfg)
+                        new-children (concat (r.node/children m-node)
+                                             [(r.node/newlines 1)
+                                              (r.node/spaces 3)
+                                              (r.node/keyword-node config-key)
+                                              (r.node/spaces 1)
+                                              (r.parser/parse-string (model-set-str computed))])]
+                    (z/root (z/replace mod-cfg (r.node/replace-children m-node new-children)))))))
             root
             [:model-exports :model-imports]))
          (z/root root-zloc)

--- a/dev/src/dev/model_boundary_config.clj
+++ b/dev/src/dev/model_boundary_config.clj
@@ -13,6 +13,7 @@
   (:require
    [clojure.string :as str]
    [dev.deps-graph :as deps-graph]
+   [rewrite-clj.node :as r.node]
    [rewrite-clj.parser :as r.parser]
    [rewrite-clj.zip :as z]))
 
@@ -124,15 +125,32 @@
            (reduce
             (fn [root config-key]
               (let [mod-cfg  (some-> (find-module-config root module-sym) z/right)
-                    val-zloc (when mod-cfg (find-key-value mod-cfg config-key))]
-                ;; Only update keys that already exist and are sets (skip :bypass, :any, etc.)
-                (if (and val-zloc (set? (z/sexpr val-zloc)))
-                  (let [computed (get-in boundaries [config-key module-sym] #{})]
-                    (if (seq computed)
-                      (z/root (z/replace val-zloc (r.parser/parse-string (model-set-str computed))))
-                      ;; Empty — remove the key-value pair
-                      (-> val-zloc z/remove z/remove z/root)))
-                  root)))
+                    val-zloc (when mod-cfg (find-key-value mod-cfg config-key))
+                    computed (get-in boundaries [config-key module-sym] #{})]
+                (cond
+                  ;; Key exists with a non-set value (e.g. :bypass, :any) — leave it alone.
+                  (and val-zloc (not (set? (z/sexpr val-zloc))))
+                  root
+
+                  ;; Key exists with a set value — replace or remove.
+                  val-zloc
+                  (if (seq computed)
+                    (z/root (z/replace val-zloc (r.parser/parse-string (model-set-str computed))))
+                    (-> val-zloc z/remove z/remove z/root))
+
+                  ;; Key missing and nothing to add.
+                  (empty? computed)
+                  root
+
+                  ;; Key missing — append `<newline><indent>:key <set>` to the module config map.
+                  :else
+                  (z/root
+                   (-> mod-cfg
+                       (z/append-child (r.node/newlines 1))
+                       (z/append-child (r.node/spaces 3))
+                       (z/append-child config-key)
+                       (z/append-child (r.node/spaces 1))
+                       (z/append-child (r.parser/parse-string (model-set-str computed))))))))
             root
             [:model-exports :model-imports]))
          (z/root root-zloc)


### PR DESCRIPTION
Before the script would only _update_ :model-imports and :model-exports entries, and not insert them.

With this change we can totally take our hands off.
