### PR TITLE
Fix static viz rendering for custom visualization plugins

### DIFF
--- a/src/metabase/channel/render/card.clj
+++ b/src/metabase/channel/render/card.clj
@@ -115,8 +115,8 @@
              (premium-features/enable-custom-viz?)
              (render.util/custom-viz-display? display-type)
              (let [identifier (subs (name display-type) (count "custom:"))
-                   plugin-id     (t2/select-one-pk :model/CustomVizPlugin :identifier identifier :enabled true)]
-               (some-> plugin-id custom-viz-plugin/resolve-bundle :content)))
+                   plugin     (t2/select-one :model/CustomVizPlugin :identifier identifier :enabled true)]
+               (some-> plugin custom-viz-plugin/resolve-bundle :content)))
         (chart-type :javascript_visualization "display-type is a custom visualization with static support")
 
         (#{:pin_map :state :country} display-type)


### PR DESCRIPTION
## Summary
- `detect-pulse-chart-type` passed a plugin ID (integer via `t2/select-one-pk`) to `resolve-bundle`, which expects a plugin map
- `resolve-bundle` called `(:id plugin)` on the integer, got nil, and silently returned nil — so static rendering always fell back to table for custom viz cards
- Changed to `t2/select-one` to pass the full plugin record