### PR TITLE
add dark mode support

### DIFF
--- a/enterprise/frontend/src/custom-viz/src/types/viz.ts
+++ b/enterprise/frontend/src/custom-viz/src/types/viz.ts
@@ -130,6 +130,8 @@ export type CustomVisualizationProps<
 
   settings: CustomVisualizationSettings<TSettings>;
 
+  colorScheme: "light" | "dark";
+
   onClick: (
     clickObject: ClickObject<CustomVisualizationSettings<TSettings>> | null,
   ) => void;
@@ -144,7 +146,8 @@ export interface RenderingContext {
   measureText: TextWidthMeasurer;
   measureTextHeight: TextHeightMeasurer;
   fontFamily: string;
-  // theme: VisualizationTheme;
+  /** The current color scheme used for rendering. Defaults to "light" when not provided. */
+  colorScheme?: "light" | "dark";
 }
 
 // Equivalent of StaticVisualizationProps

--- a/enterprise/frontend/src/custom-viz/src/types/viz.ts
+++ b/enterprise/frontend/src/custom-viz/src/types/viz.ts
@@ -146,8 +146,7 @@ export interface RenderingContext {
   measureText: TextWidthMeasurer;
   measureTextHeight: TextHeightMeasurer;
   fontFamily: string;
-  /** The current color scheme used for rendering. Defaults to "light" when not provided. */
-  colorScheme?: "light" | "dark";
+  colorScheme: "light" | "dark";
 }
 
 // Equivalent of StaticVisualizationProps
@@ -156,6 +155,7 @@ export type CustomStaticVisualizationProps<
 > = {
   series: Series;
   renderingContext: RenderingContext;
+  colorScheme: "light" | "dark";
   isStorybook?: boolean;
   settings: CustomVisualizationSettings<TSettings>;
   hasDevWatermark?: boolean;

--- a/enterprise/frontend/src/metabase-enterprise/custom_viz/custom-viz-plugins.ts
+++ b/enterprise/frontend/src/metabase-enterprise/custom_viz/custom-viz-plugins.ts
@@ -9,6 +9,7 @@ import { useListCustomVizPluginsQuery } from "metabase/api";
 import { ExplicitSize } from "metabase/common/components/ExplicitSize";
 import { useToast } from "metabase/common/hooks";
 import { useEmbeddingEntityContext } from "metabase/embedding/context";
+import { useColorScheme } from "metabase/ui";
 import visualizations, { registerVisualization } from "metabase/visualizations";
 import {
   getCustomPluginIdentifier,
@@ -287,12 +288,15 @@ export async function loadCustomVizPlugin(
     }: Omit<VisualizationProps, "width" | "height"> & {
       width: number | null;
       height: number | null;
-    }) =>
-      React.createElement(vizDef.VisualizationComponent, {
+    }) => {
+      const { resolvedColorScheme } = useColorScheme();
+      return React.createElement(vizDef.VisualizationComponent, {
         ...rest,
+        colorScheme: resolvedColorScheme,
         onClick: onVisualizationClick,
         onHover: onHoverChange,
       });
+    };
 
     // Attach the required static properties onto the component function
     const Component = ExplicitSize<VisualizationProps>({ wrapped: true })(

--- a/frontend/src/metabase/static-viz/components/StaticVisualization/StaticVisualization.tsx
+++ b/frontend/src/metabase/static-viz/components/StaticVisualization/StaticVisualization.tsx
@@ -72,6 +72,7 @@ export const StaticVisualization = ({
         <StaticVisualizationComponent
           series={rawSeries}
           renderingContext={renderingContext}
+          colorScheme={renderingContext.colorScheme ?? "light"}
           settings={settings}
           isStorybook={isStorybook}
           hasDevWatermark={hasDevWatermark}

--- a/frontend/src/metabase/static-viz/lib/rendering-context.ts
+++ b/frontend/src/metabase/static-viz/lib/rendering-context.ts
@@ -35,6 +35,7 @@ export const createStaticRenderingContext = (
         typeof style.size === "number" ? style.size : parseInt(style.size),
       ),
     fontFamily: "Lato, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+    colorScheme: "light",
     theme: DEFAULT_VISUALIZATION_THEME,
   };
 };

--- a/frontend/src/metabase/visualizations/hooks/use-browser-rendering-context.ts
+++ b/frontend/src/metabase/visualizations/hooks/use-browser-rendering-context.ts
@@ -32,6 +32,7 @@ export const useBrowserRenderingContext = (
       measureText: measureTextWidth,
       measureTextHeight,
       fontFamily: `${fontFamily}, Arial, sans-serif`,
+      colorScheme: theme.other?.colorScheme ?? "light",
       theme: style,
     };
   }, [fontFamily, palette, theme, isDashboard]);

--- a/frontend/src/metabase/visualizations/types/visualization.ts
+++ b/frontend/src/metabase/visualizations/types/visualization.ts
@@ -70,6 +70,8 @@ export interface RenderingContext {
   measureText: TextWidthMeasurer;
   measureTextHeight: TextHeightMeasurer;
   fontFamily: string;
+  /** Defaults to "light" when not provided. */
+  colorScheme?: "light" | "dark";
 
   theme: VisualizationTheme;
 }


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-2159/calendar-heatmap-dark-mode-support

### Description

Pass colorScheme to custom visualization so it can handle appropriate styling. 
The default was set to `light`.

### How to verify

Test with  calendar heatmap from https://github.com/metabase/custom-viz-calendar-heatmap/pull/10. It has added support for dark mode.

### Demo

![image](https://github.com/user-attachments/assets/c6a754d4-6b01-4f03-a786-9ab1b72d57aa)

