### PR TITLE
Switch to released versions of malli and pp.

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -84,9 +84,7 @@
   inflections/inflections                   {:mvn/version "0.15.0"}             ; Clojure/Script library used for prularizing words
   instaparse/instaparse                     {:mvn/version "1.5.0"}              ; Make your own parser
   io.github.camsaul/toucan2                 {:mvn/version "1.0.571"}
-  io.github.eerohele/pp                     {#_#_:git/tag "2024-11-13.77"       ; super fast pretty-printing library
-                                             :git/sha "ffc4edc482c057cd9412c62f018a41e9140c618b"
-                                             :git/url "https://github.com/eerohele/pp"}
+  me.flowthing/pp                           {:mvn/version "2026-03-01.107"}     ; super fast pretty-printing library
   io.github.metabase/macaw                  {:mvn/version "0.2.36"}             ; Parse native SQL queries
   io.netty/netty-codec-http                 {:mvn/version "4.2.9.Final"}        ; override of transitive dep from aws s3
   io.netty/netty-codec-http2                {:mvn/version "4.2.9.Final"}        ; override of transitive dep from aws s3
@@ -104,8 +102,7 @@
                                                           org.bouncycastle/bcprov-jdk18on]}
   metabase/throttle                         {:mvn/version "1.0.2"}              ; Tools for throttling access to API endpoints and other code pathways
   methodical/methodical                     {:mvn/version "1.0.127"}            ; drop-in replacements for Clojure multimethods and adds several advanced features
-  metosin/malli                             {:git/url "https://github.com/metabase/malli" ; Data-driven Schemas for Clojure/Script and babashka
-                                             :git/sha "b4a2d78647a049870b316753d7aae7fb4ade3ae5"} ; patched to resolve an issue causing OOM
+  metosin/malli                             {:mvn/version "0.20.1"}             ; Data-driven Schemas for Clojure/Script and babashka
   net.carcdr/oidc-provider                  {:mvn/version "0.6.2"}              ; OAuth/OIDC server abstract implementation
   net.cgrand/macrovich                      {:mvn/version "0.2.2"}              ; utils for writing macros for both Clojure & ClojureScript
   net.redhogs.cronparser/cron-parser-core   {:mvn/version "3.5"                 ; describe Cron schedule in human-readable language
@@ -188,8 +185,9 @@
   pretty/pretty                             {:mvn/version "1.0.5"}              ; protocol for defining how custom types should be pretty printed
   ;; Dependency below is our fork of redux - utility functions for building and composing transducers. The
   ;; group/artifact name is the same as with the upstream so that it overrides the original dependency everywhere.
+  ;; We are using a fork because the upstream appears to be abandoned.
   redux/redux                               {:git/url "https://github.com/metabase/redux"
-                                             :sha "4a37feaf817a2a6b5ef688c927f6fd4375964433"}
+                                             :git/sha "4a37feaf817a2a6b5ef688c927f6fd4375964433"}
   riddley/riddley                           {:mvn/version "0.2.0"}              ; code walking lib -- used interally by Potemkin, manifold, etc.
   ring/ring-core                            {:mvn/version "1.15.3"}             ; HTTP abstraction
   ring/ring-jetty-adapter                   {:mvn/version "1.15.3"              ; Ring adapter for Jetty


### PR DESCRIPTION
### Description

In both cases, the commit we were pinned to has made it into the latest stable release, so there's no need to pin to a specific commit any more.

The only remaining pinned dependency is redux, whose upstream appears to be abandonware. I've added a comment explaining this. We could publish our own `metabase/redux` fork to Clojars if we're planning on continuing maintenance of this, but leaving it alone is fine too.

### How to verify

CI, I guess?