### PR TITLE
Fix nested WHERE clause in remove-unsynced! for TransformTag

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
@@ -97,27 +97,25 @@
                 scope-key (get-in model-spec [:removal :scope-key])
                 ;; Get non-entity_id conditions from spec
                 other-conditions (into [] cat (dissoc removal-conds :entity_id))]]
-    (if scope-key
-      ;; Collection-scoped: delete only within synced collections
-      (when (seq synced-collection-ids)
-        (if entity-id-where
-          (apply t2/delete! model-key
-                 {:where [:and
-                          [:in scope-key synced-collection-ids]
-                          entity-id-where]}
-                 other-conditions)
-          (apply t2/delete! model-key
-                 scope-key [:in synced-collection-ids]
-                 other-conditions)))
-      ;; Global: delete by entity_id
-      (if entity-id-where
-        (apply t2/delete! model-key
-               {:where entity-id-where}
-               other-conditions)
-        ;; No entity_id conditions - delete all (respecting other spec conditions if any)
-        (if (seq other-conditions)
-          (apply t2/delete! model-key other-conditions)
-          (t2/delete! model-key))))))
+    (let [conditions (cond-> []
+                       (and scope-key (seq synced-collection-ids))
+                       (conj [:in scope-key synced-collection-ids])
+
+                       entity-id-where
+                       (conj entity-id-where)
+
+                       (and (not scope-key) (seq other-conditions))
+                       (into (for [[k v] (partition 2 other-conditions)]
+                               [:= k v])))
+          where-clause (when (seq conditions)
+                         (if (= 1 (count conditions))
+                           (first conditions)
+                           (into [:and] conditions)))]
+      (cond
+        ;; Scoped models with no collections to scope to — nothing to delete
+        (and scope-key (empty? synced-collection-ids)) nil
+        where-clause (t2/delete! model-key {:where where-clause})
+        :else        (t2/delete! model-key)))))
 
 (defn source-error-message
   "Constructs user-friendly error messages from remote sync source exceptions.

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/test_helpers.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/test_helpers.clj
@@ -676,3 +676,16 @@ serdes/meta:
 "
           name entity-id content (or collection-id "null")
           entity-id (str/replace (u/lower-case-en name) #"\s+" "_")))
+
+(defn generate-transform-tag-yaml
+  "Generates YAML content for a TransformTag with the given `entity-id` and `name`."
+  [entity-id name]
+  (format "created_at: '2024-08-28T09:46:18.671622Z'
+entity_id: %s
+name: %s
+serdes/meta:
+- id: %s
+  label: %s
+  model: TransformTag
+"
+          entity-id name entity-id (str/replace (u/lower-case-en name) #"\s+" "_")))

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/transforms_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/transforms_test.clj
@@ -908,3 +908,30 @@ serdes/meta:
                 "Built-in PythonLibrary should be in export roots")
             (is (contains? exported-ids (:id custom-lib))
                 "Custom PythonLibrary should be in export roots")))))))
+
+(deftest import-removes-transform-tag-not-on-remote-test
+  (testing "Import removes non-built-in TransformTags that don't exist on the remote (regression: UXW-3710)"
+    (mt/with-premium-features #{:transforms-basic}
+      (mt/with-temporary-setting-values [remote-sync-transforms true
+                                         remote-sync-enabled true]
+        (mt/with-model-cleanup [:model/RemoteSyncTask :model/TransformTag :model/Collection]
+          (let [task-id (t2/insert-returning-pk! :model/RemoteSyncTask {:sync_task_type "import" :initiated_by (mt/user->id :rasta)})
+                local-tag-entity-id (u/generate-nano-id)
+                remote-tag-entity-id (u/generate-nano-id)
+                coll-entity-id (u/generate-nano-id)]
+            (mt/with-temp [:model/TransformTag {local-tag-id :id} {:name "Local Tag"
+                                                                   :entity_id local-tag-entity-id
+                                                                   :built_in_type nil}]
+              (is (t2/exists? :model/TransformTag :id local-tag-id))
+              (let [test-files {"main" {"collections/transforms/transforms_collection/transforms_collection.yaml"
+                                        (generate-transforms-namespace-collection-yaml coll-entity-id "Transforms Collection")
+                                        "transforms/transform_tags/remote_tag.yaml"
+                                        (test-helpers/generate-transform-tag-yaml remote-tag-entity-id "Remote Tag")}}
+                    mock-source (test-helpers/create-mock-source :initial-files test-files)
+                    result (impl/import! (source.p/snapshot mock-source) task-id :force? true)]
+                (is (= :success (:status result))
+                    (str "Import should succeed but got: " (:message result)))
+                (is (not (t2/exists? :model/TransformTag :id local-tag-id))
+                    "Local transform tag should be deleted after import since it wasn't on remote")
+                (is (t2/exists? :model/TransformTag :entity_id remote-tag-entity-id)
+                    "Remote transform tag should be imported")))))))))


### PR DESCRIPTION
### Description

Mixing a {:where ...} HoneySQL map with kv-pair conditions in t2/delete! caused toucan2 to misinterpret the map as a condition key, producing invalid SQL with a WHERE inside a WHERE. Convert other-conditions into the {:where} clause directly and remove unreachable scoped-path code that had the same bug.

I checked and this is present in 59 and 60. 

Closes: https://github.com/metabase/metabase/issues/72284

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
