### PR TITLE
Speed up field-values sync by batching distinct queries (GHY-3074)

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/action_v2/data_editing.clj
+++ b/enterprise/backend/src/metabase_enterprise/action_v2/data_editing.clj
@@ -29,10 +29,21 @@
   nil)
 
 (defn- batch-invalidate-field-values!
-  "Recalculate the field values for the given fields."
+  "Recalculate the field values for the given fields. Groups fields by table so each table issues
+   one bulk warehouse query regardless of how many of its columns were touched."
   [field-batches]
-  (->> (t2/select :model/Field :id [:in (into #{} cat field-batches)])
-       (run! field-values/create-or-update-full-field-values!)))
+  (let [field-ids (into #{} cat field-batches)
+        fields    (when (seq field-ids)
+                    (filter field-values/field-should-have-field-values?
+                            (t2/select :model/Field :id [:in field-ids])))]
+    (when (seq fields)
+      (let [fvs-map (field-values/batched-get-latest-full-field-values (map :id fields))]
+        (doseq [[table-id table-fields] (group-by :table_id fields)]
+          (when-let [bulk-values (field-values/bulk-distinct-values table-id table-fields)]
+            (doseq [field table-fields]
+              (let [fv (get fvs-map (:id field))
+                    dv (get bulk-values (:id field))]
+                (field-values/persist-field-values! field fv (:values dv) (:has_more_values dv))))))))))
 
 (defmethod queue/init-listener! ::FieldValueInvalidation [_]
   (queue/listen! "field-value-invalidate" global-field-value-invalidate-queue batch-invalidate-field-values!

--- a/enterprise/backend/test/metabase_enterprise/action_v2/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/action_v2/api_test.clj
@@ -528,6 +528,47 @@
              (check-coercion-fn-coverage @#'coerce/unimplemented-coercion-functions)
              (run! #(apply do-test %)))))))
 
+(deftest batch-invalidate-field-values-bulk-test
+  (testing "batch-invalidate-field-values! groups field IDs by table and runs bulk-distinct-values once per table"
+    (mt/dataset test-data
+      (let [cat-id      (mt/id :products :category)
+            vendor-id   (mt/id :products :vendor)
+            source-id   (mt/id :people :source)
+            bulk-calls  (atom [])
+            orig-bulk   field-values/bulk-distinct-values]
+        ;; products.category, products.vendor and people.source are all category fields by default in test-data
+        (t2/delete! :model/FieldValues :field_id [:in [cat-id vendor-id source-id]])
+        (with-redefs [field-values/bulk-distinct-values (fn [table-id fields]
+                                                          (swap! bulk-calls conj
+                                                                 {:table-id table-id
+                                                                  :field-ids (set (map :id fields))})
+                                                          (orig-bulk table-id fields))]
+          ;; Three field IDs spanning two tables, in two queue messages — exactly the shape the
+          ;; production listener delivers.
+          (#'data-editing/batch-invalidate-field-values! [[cat-id vendor-id] [source-id]]))
+        (testing "exactly one bulk call per table"
+          (is (= 2 (count @bulk-calls))))
+        (testing "fields are correctly grouped by table"
+          (is (= #{{:table-id (mt/id :products) :field-ids #{cat-id vendor-id}}
+                   {:table-id (mt/id :people)   :field-ids #{source-id}}}
+                 (set @bulk-calls))))
+        (testing "FieldValues were persisted for all three fields"
+          (is (= #{"Doohickey" "Gadget" "Gizmo" "Widget"}
+                 (set (:values (t2/select-one :model/FieldValues :field_id cat-id :type :full)))))
+          (is (some? (t2/select-one :model/FieldValues :field_id vendor-id :type :full)))
+          (is (some? (t2/select-one :model/FieldValues :field_id source-id :type :full))))))))
+
+(deftest batch-invalidate-field-values-skips-ineligible-test
+  (testing "batch-invalidate-field-values! filters out fields that shouldn't have FieldValues"
+    (mt/dataset test-data
+      (let [pk-id      (mt/id :orders :id)  ; PK — field-should-have-field-values? returns false
+            bulk-calls (atom 0)]
+        (with-redefs [field-values/bulk-distinct-values (fn [& _]
+                                                          (swap! bulk-calls inc)
+                                                          nil)]
+          (#'data-editing/batch-invalidate-field-values! [[pk-id]]))
+        (is (zero? @bulk-calls))))))
+
 (deftest field-values-invalidated-test
   (mt/with-premium-features #{actions-feature-flag}
     (mt/test-drivers (mt/normal-drivers-with-feature :actions/data-editing)

--- a/src/metabase/sync/field_values.clj
+++ b/src/metabase/sync/field_values.clj
@@ -21,22 +21,6 @@
     (field-values/clear-field-values-for-field! field)
     ::field-values/fv-deleted))
 
-(mu/defn- update-field-values-for-field!
-  [field :- i/FieldInstance]
-  (log/debug (u/format-color 'green "Looking into updating FieldValues for %s" (sync-util/name-for-logging field)))
-  (let [field-values (field-values/get-latest-full-field-values (u/the-id field))]
-    (cond
-      (not field-values)
-      (log/infof "%s does not have FieldValues. Skipping..."
-                 (sync-util/name-for-logging field))
-
-      (field-values/inactive? field-values)
-      (log/infof "%s has not been used since %s. Skipping..."
-                 (sync-util/name-for-logging field) (t/format "yyyy-MM-dd" (t/local-date-time (:last_used_at field-values))))
-
-      :else
-      (field-values/create-or-update-full-field-values! field :field-values field-values))))
-
 (defn- update-field-value-stats-count [counts-map result]
   (if (instance? Exception result)
     (update counts-map :errors inc)
@@ -55,13 +39,14 @@
   (t2/select :model/Field :table_id (u/the-id table), :active true, :visibility_type "normal"))
 
 (defn- update-field-values-for-table-bulk!
-  "Bulk approach: fetch all field values in one query, then persist per field.
-   Returns stats map, or nil if bulk approach failed."
+  "Fetch all field values in one query, then persist per field. If the bulk query fails,
+   returns stats with :errors set to the number of fields that would have been synced."
   [table fields-to-sync fvs-map]
-  (when-let [bulk-values (sync-util/with-error-handling
-                           (format "Error batch-fetching distinct values for %s" (sync-util/name-for-logging table))
-                           (field-values/bulk-distinct-values (u/the-id table) fields-to-sync))]
-    (when-not (instance? Exception bulk-values)
+  (let [bulk-values (sync-util/with-error-handling
+                     (format "Error batch-fetching distinct values for %s" (sync-util/name-for-logging table))
+                      (field-values/bulk-distinct-values (u/the-id table) fields-to-sync))]
+    (if (or (nil? bulk-values) (instance? Exception bulk-values))
+      {:errors (count fields-to-sync), :created 0, :updated 0, :deleted 0}
       (reduce (fn [counts field]
                 (let [field-id (u/the-id field)
                       fv       (get fvs-map field-id)
@@ -72,17 +57,6 @@
                   (update-field-value-stats-count counts result)))
               {:errors 0, :created 0, :updated 0, :deleted 0}
               fields-to-sync))))
-
-(defn- update-field-values-for-table-sequential!
-  "Per-field fallback: query each field individually."
-  [fields-to-sync]
-  (reduce (fn [counts field]
-            (let [result (sync-util/with-error-handling
-                          (format "Error updating field values for %s" (sync-util/name-for-logging field))
-                           (update-field-values-for-field! field))]
-              (update-field-value-stats-count counts result)))
-          {:errors 0, :created 0, :updated 0, :deleted 0}
-          fields-to-sync))
 
 (mu/defn update-field-values-for-table!
   "Update the FieldValues for all Fields (as needed) for `table`."
@@ -120,9 +94,7 @@
                                     to-sync)
             sync-counts    (if (empty? fields-to-sync)
                              {:errors 0, :created 0, :updated 0, :deleted 0}
-                             ;; Try bulk, fall back to sequential
-                             (or (update-field-values-for-table-bulk! table fields-to-sync fvs-map)
-                                 (update-field-values-for-table-sequential! fields-to-sync)))]
+                             (update-field-values-for-table-bulk! table fields-to-sync fvs-map))]
         (merge-with + clear-counts sync-counts)))))
 
 (mu/defn- update-field-values-for-database!

--- a/src/metabase/sync/field_values.clj
+++ b/src/metabase/sync/field_values.clj
@@ -54,17 +54,76 @@
   [table]
   (t2/select :model/Field :table_id (u/the-id table), :active true, :visibility_type "normal"))
 
+(defn- update-field-values-for-table-bulk!
+  "Bulk approach: fetch all field values in one query, then persist per field.
+   Returns stats map, or nil if bulk approach failed."
+  [table fields-to-sync fvs-map]
+  (when-let [bulk-values (sync-util/with-error-handling
+                           (format "Error batch-fetching distinct values for %s" (sync-util/name-for-logging table))
+                           (field-values/bulk-distinct-values (u/the-id table) fields-to-sync))]
+    (when-not (instance? Exception bulk-values)
+      (reduce (fn [counts field]
+                (let [field-id (u/the-id field)
+                      fv       (get fvs-map field-id)
+                      dv       (get bulk-values field-id)
+                      result   (sync-util/with-error-handling
+                                (format "Error updating field values for %s" (sync-util/name-for-logging field))
+                                 (field-values/persist-field-values! field fv (:values dv) (:has_more_values dv)))]
+                  (update-field-value-stats-count counts result)))
+              {:errors 0, :created 0, :updated 0, :deleted 0}
+              fields-to-sync))))
+
+(defn- update-field-values-for-table-sequential!
+  "Per-field fallback: query each field individually."
+  [fields-to-sync]
+  (reduce (fn [counts field]
+            (let [result (sync-util/with-error-handling
+                          (format "Error updating field values for %s" (sync-util/name-for-logging field))
+                           (update-field-values-for-field! field))]
+              (update-field-value-stats-count counts result)))
+          {:errors 0, :created 0, :updated 0, :deleted 0}
+          fields-to-sync))
+
 (mu/defn update-field-values-for-table!
   "Update the FieldValues for all Fields (as needed) for `table`."
   [table :- i/TableInstance]
-  (reduce (fn [fv-change-counts field]
-            (let [result (sync-util/with-error-handling (format "Error updating field values for %s" (sync-util/name-for-logging field))
-                           (if (field-values/field-should-have-field-values? field)
-                             (update-field-values-for-field! field)
-                             (clear-field-values-for-field! field)))]
-              (update-field-value-stats-count fv-change-counts result)))
-          {:errors 0, :created 0, :updated 0, :deleted 0}
-          (table->fields-to-scan table)))
+  (let [all-fields        (table->fields-to-scan table)
+        {to-sync  true
+         to-clear false} (group-by #(boolean (field-values/field-should-have-field-values? %)) all-fields)
+        ;; Clear fields that shouldn't have values
+        clear-counts      (reduce (fn [counts field]
+                                    (let [result (sync-util/with-error-handling
+                                                  (format "Error clearing field values for %s" (sync-util/name-for-logging field))
+                                                   (clear-field-values-for-field! field))]
+                                      (update-field-value-stats-count counts result)))
+                                  {:errors 0, :created 0, :updated 0, :deleted 0}
+                                  to-clear)]
+    (if (empty? to-sync)
+      clear-counts
+      ;; Batch-fetch existing FieldValues and filter to active ones
+      (let [fvs-map        (field-values/batched-get-latest-full-field-values (map u/the-id to-sync))
+            fields-to-sync (filterv (fn [field]
+                                      (let [fv (get fvs-map (u/the-id field))]
+                                        (cond
+                                          (not fv)
+                                          (do (log/infof "%s does not have FieldValues. Skipping..."
+                                                         (sync-util/name-for-logging field))
+                                              false)
+
+                                          (field-values/inactive? fv)
+                                          (do (log/infof "%s has not been used since %s. Skipping..."
+                                                         (sync-util/name-for-logging field)
+                                                         (t/format "yyyy-MM-dd" (t/local-date-time (:last_used_at fv))))
+                                              false)
+
+                                          :else true)))
+                                    to-sync)
+            sync-counts    (if (empty? fields-to-sync)
+                             {:errors 0, :created 0, :updated 0, :deleted 0}
+                             ;; Try bulk, fall back to sequential
+                             (or (update-field-values-for-table-bulk! table fields-to-sync fvs-map)
+                                 (update-field-values-for-table-sequential! fields-to-sync)))]
+        (merge-with + clear-counts sync-counts)))))
 
 (mu/defn- update-field-values-for-database!
   [database :- i/DatabaseInstance]

--- a/src/metabase/warehouse_schema/models/field_values.clj
+++ b/src/metabase/warehouse_schema/models/field_values.clj
@@ -629,17 +629,21 @@
   "Update the FieldValues for any Fields with `field-ids` if the Field should have FieldValues and it belongs to a
   Database that is set to do 'On-Demand' syncing."
   [field-ids]
-  (let [fields (when (seq field-ids)
-                 (filter field-should-have-field-values?
-                         (t2/select ['Field :name :id :base_type :effective_type :coercion_strategy
-                                     :semantic_type :visibility_type :table_id :has_field_values]
-                                    :id [:in field-ids])))
-        table-id->is-on-demand? (table-ids->table-id->is-on-demand? (map :table_id fields))]
-    (doseq [{table-id :table_id, :as field} fields]
-      (when (table-id->is-on-demand? table-id)
-        (log/debugf "Field %s '%s' should have FieldValues and belongs to a Database with On-Demand FieldValues updating."
-                    (u/the-id field) (:name field))
-        (create-or-update-full-field-values! field)))))
+  (let [fields                  (when (seq field-ids)
+                                  (filter field-should-have-field-values?
+                                          (t2/select ['Field :name :id :base_type :effective_type :coercion_strategy
+                                                      :semantic_type :visibility_type :table_id :has_field_values]
+                                                     :id [:in field-ids])))
+        table-id->is-on-demand? (table-ids->table-id->is-on-demand? (map :table_id fields))
+        on-demand-fields        (filter #(table-id->is-on-demand? (:table_id %)) fields)]
+    (when (seq on-demand-fields)
+      (let [fvs-map (batched-get-latest-full-field-values (map :id on-demand-fields))]
+        (doseq [[table-id fields] (group-by :table_id on-demand-fields)]
+          (when-let [bulk-values (bulk-distinct-values table-id fields)]
+            (doseq [field fields]
+              (let [fv (get fvs-map (:id field))
+                    dv (get bulk-values (:id field))]
+                (persist-field-values! field fv (:values dv) (:has_more_values dv))))))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                              Serialization                                                     |

--- a/src/metabase/warehouse_schema/models/field_values.clj
+++ b/src/metabase/warehouse_schema/models/field_values.clj
@@ -571,7 +571,7 @@
    created/updated/deleted as a result of this call.
 
   Note that if the full FieldValues are create/updated/deleted, it'll delete all the Advanced FieldValues of the same `field`."
-  [field & {:keys [field-values human-readable-values]}]
+  [field & {:keys [field-values]}]
   (if (field-should-have-field-values? field)
     (let [field-values              (or field-values (get-latest-full-field-values (u/the-id field)))
           {unwrapped-values :values

--- a/src/metabase/warehouse_schema/models/field_values.clj
+++ b/src/metabase/warehouse_schema/models/field_values.clj
@@ -412,6 +412,73 @@
       (log/error e "Error fetching field values")
       nil)))
 
+(defn- limit-values [values]
+  (loop [str-length 0
+         acc (sorted-set)
+         values values]
+    (let [new-str-length (+ str-length (count (str (first values))))]
+      (cond
+        (empty? values)
+        {:values (vec acc)
+         :has_more_values false}
+
+        (nil? (first values)) ;; skip NULLs
+        (recur str-length acc (rest values))
+
+        (contains? acc (first values))
+        (recur str-length acc (rest values))
+
+        (or
+         (> new-str-length *total-max-length*)
+         ;; I don't think this can be true, but just in case
+         (> (inc (count acc)) *absolute-max-distinct-values-limit*))
+        {:values (vec acc)
+         :has_more_values true}
+
+        (= (inc (count acc)) *absolute-max-distinct-values-limit*)
+        {:values (vec (conj acc (first values)))
+         :has_more_values true} ;; 1000 distinct in 1000 rows, probably more
+
+        :else
+        (recur new-str-length (conj acc (first values)) (rest values))))))
+
+(defn- rows->per-field-distinct-values
+  "Process multi-column result rows into per-field distinct value maps.
+   `fields` is the ordered seq of fields corresponding to column indices.
+   Returns {field-id -> {:values [v1 v2 ...], :has_more_values bool}}."
+  [fields rows]
+  (let [cols (if (seq rows)
+               (apply mapv vector rows)
+               (mapv (fn [_] []) fields))]
+    (into {}
+          (map-indexed
+           (fn [i field]
+             [(:id field) (limit-values (get cols i))])
+           (vec fields)))))
+
+(defn bulk-distinct-values
+  "Fetch distinct values for multiple fields from the same table in a single query.
+   Uses `SELECT col1, col2, ... FROM table LIMIT 1000` instead of one GROUP BY per field.
+   Returns {field-id -> {:values [v1 v2 ...], :has_more_values bool}}, or nil on failure."
+  [table-id fields]
+  (try
+    (let [metadata-cols (mapv (fn [field]
+                                (cond-> field
+                                  (t2/model field) (lib-be/instance->metadata :metadata/column)))
+                              fields)
+          result        ((requiring-resolve 'metabase.warehouse-schema.metadata-from-qp/table-query)
+                         table-id
+                         (fn [query]
+                           (-> query
+                               (lib/with-fields metadata-cols)
+                               (lib/limit *absolute-max-distinct-values-limit*)))
+                         nil)
+          rows          (-> result :data :rows)]
+      (rows->per-field-distinct-values fields rows))
+    (catch Throwable e
+      (log/error e "Error in bulk-distinct-values, will fall back to per-field queries")
+      nil)))
+
 (defn- delete-duplicates-and-return-latest!
   "Takes a list of field values, return a map of field-id -> latest FieldValues.
 
@@ -454,6 +521,50 @@
    (when (seq field-ids)
      (t2/select :model/FieldValues :field_id [:in field-ids] :type :full :hash_key nil))))
 
+(defn persist-field-values!
+  "Persist pre-fetched distinct values for a field. Compares with existing FieldValues and
+   creates/updates/skips/deletes as needed. Returns a status keyword (::fv-skipped, ::fv-updated,
+   ::fv-created, or ::fv-deleted).
+
+   `existing-fv` is the existing FieldValues record (or nil).
+   `values` is a collection of scalar values.
+   `has_more_values` is a boolean indicating if the list is incomplete."
+  [field existing-fv values has_more_values]
+  (let [field-name (or (:name field) (:id field))]
+    (cond
+      (empty? values)
+      (do
+        (clear-field-values-for-field! field)
+        ::fv-deleted)
+
+      ;; if FieldValues object doesn't exist create one
+      (nil? existing-fv)
+      (do
+        (log/debugf "Storing FieldValues for Field %s..." field-name)
+        (app-db/select-or-insert! :model/FieldValues {:field_id (u/the-id field), :type :full}
+                                  (constantly {:has_more_values       has_more_values
+                                               :values                values
+                                               :human_readable_values nil}))
+        ::fv-created)
+
+      ;; if existing FieldValues won't change, skip it
+      (and (= (:values existing-fv) values)
+           (= (:has_more_values existing-fv) has_more_values))
+      (do
+        (log/debugf "FieldValues for Field %s remain unchanged. Skipping..." field-name)
+        ::fv-skipped)
+
+      ;; if the FieldValues object already exists then update values in it
+      :else
+      (do
+        (log/debugf "Storing updated FieldValues for Field %s..." field-name)
+        (t2/update! :model/FieldValues (u/the-id existing-fv)
+                    (m/remove-vals nil?
+                                   {:has_more_values       has_more_values
+                                    :values                values
+                                    :human_readable_values (fixup-human-readable-values existing-fv values)}))
+        ::fv-updated))))
+
 (defn create-or-update-full-field-values!
   "Create or update the full FieldValues object for `field`. If the FieldValues object already exists, then update values for
    it; otherwise create a new FieldValues object with the newly fetched values. Returns whether the field values were
@@ -466,42 +577,8 @@
           {unwrapped-values :values
            :keys [has_more_values]} (distinct-values field)
           ;; unwrapped-values are 1-tuples, so we need to unwrap their values for storage
-          values                    (seq (map first unwrapped-values))
-          field-name                (or (:name field) (:id field))]
-      (cond
-        (and values
-             (= (:values field-values) values)
-             (= (:has_more_values field-values) has_more_values))
-        (do
-          (log/debugf "FieldValues for Field %s remain unchanged. Skipping..." field-name)
-          ::fv-skipped)
-
-        ;; if the FieldValues object already exists then update values in it
-        (and field-values values)
-        (do
-          (log/debugf "Storing updated FieldValues for Field %s..." field-name)
-          (t2/update! :model/FieldValues (u/the-id field-values)
-                      (m/remove-vals nil?
-                                     {:has_more_values       has_more_values
-                                      :values                values
-                                      :human_readable_values (fixup-human-readable-values field-values values)}))
-          ::fv-updated)
-
-        ;; if FieldValues object doesn't exist create one
-        values
-        (do
-          (log/debugf "Storing FieldValues for Field %s..." field-name)
-          (app-db/select-or-insert! :model/FieldValues {:field_id (u/the-id field), :type :full}
-                                    (constantly {:has_more_values       has_more_values
-                                                 :values                values
-                                                 :human_readable_values human-readable-values}))
-          ::fv-created)
-
-        ;; otherwise this Field isn't eligible, so delete any FieldValues that might exist
-        :else
-        (do
-          (clear-field-values-for-field! field)
-          ::fv-deleted)))
+          values                    (seq (map first unwrapped-values))]
+      (persist-field-values! field field-values values has_more_values))
     (do
       (clear-field-values-for-field! field)
       ::fv-deleted)))

--- a/src/metabase/warehouse_schema/models/field_values.clj
+++ b/src/metabase/warehouse_schema/models/field_values.clj
@@ -412,35 +412,32 @@
       (log/error e "Error fetching field values")
       nil)))
 
-(defn- limit-values [values]
+(defn- limit-values
+  "Accumulate distinct, non-nil values from `values` until the total stringified length exceeds
+   [[*total-max-length*]]. Returns {:values sorted-vec, :has_more_values bool}.
+
+   `:has_more_values` reflects only the char-length cap. The distinct-count cap is enforced one
+   level up by [[bulk-distinct-values]] (via the row-cap check) — by pigeonhole, no column can
+   have more than (count rows) distinct values, so a count cap here would be redundant."
+  [values]
   (loop [str-length 0
-         acc (sorted-set)
-         values values]
-    (let [new-str-length (+ str-length (count (str (first values))))]
-      (cond
-        (empty? values)
-        {:values (vec acc)
-         :has_more_values false}
+         acc        (sorted-set)
+         values     values]
+    (cond
+      (empty? values)
+      {:values (vec acc) :has_more_values false}
 
-        (nil? (first values)) ;; skip NULLs
-        (recur str-length acc (rest values))
+      (nil? (first values)) ;; skip NULLs
+      (recur str-length acc (rest values))
 
-        (contains? acc (first values))
-        (recur str-length acc (rest values))
+      (contains? acc (first values))
+      (recur str-length acc (rest values))
 
-        (or
-         (> new-str-length *total-max-length*)
-         ;; I don't think this can be true, but just in case
-         (> (inc (count acc)) *absolute-max-distinct-values-limit*))
-        {:values (vec acc)
-         :has_more_values true}
-
-        (= (inc (count acc)) *absolute-max-distinct-values-limit*)
-        {:values (vec (conj acc (first values)))
-         :has_more_values true} ;; 1000 distinct in 1000 rows, probably more
-
-        :else
-        (recur new-str-length (conj acc (first values)) (rest values))))))
+      :else
+      (let [new-str-length (+ str-length (count (str (first values))))]
+        (if (> new-str-length *total-max-length*)
+          {:values (vec acc) :has_more_values true}
+          (recur new-str-length (conj acc (first values)) (rest values)))))))
 
 (defn- rows->per-field-distinct-values
   "Process multi-column result rows into per-field distinct value maps.
@@ -458,8 +455,15 @@
 
 (defn bulk-distinct-values
   "Fetch distinct values for multiple fields from the same table in a single query.
-   Uses `SELECT col1, col2, ... FROM table LIMIT 1000` instead of one GROUP BY per field.
-   Returns {field-id -> {:values [v1 v2 ...], :has_more_values bool}}, or nil on failure."
+   Uses `SELECT col1, col2, ... FROM table LIMIT K` instead of one GROUP BY per field.
+   Returns {field-id -> {:values [v1 v2 ...], :has_more_values bool}}, or nil on failure.
+
+   If the row cap is hit (i.e. the table has at least K rows), every column is marked
+   `has_more_values=true` since we can't tell from a sample whether more distinct values exist
+   beyond the sampled rows. This may over-flag low-cardinality columns in big tables, forcing
+   the parameter widget into search mode instead of a static list — but the cached values are
+   still shown and the search still works, so the cost is small relative to silently returning
+   an incomplete list."
   [table-id fields]
   (try
     (let [metadata-cols (mapv (fn [field]
@@ -473,8 +477,11 @@
                                (lib/with-fields metadata-cols)
                                (lib/limit *absolute-max-distinct-values-limit*)))
                          nil)
-          rows          (-> result :data :rows)]
-      (rows->per-field-distinct-values fields rows))
+          rows          (-> result :data :rows)
+          per-field     (rows->per-field-distinct-values fields rows)]
+      (if (>= (count rows) *absolute-max-distinct-values-limit*)
+        (update-vals per-field #(assoc % :has_more_values true))
+        per-field))
     (catch Throwable e
       (log/error e "Error in bulk-distinct-values, will fall back to per-field queries")
       nil)))

--- a/test/metabase/models/on_demand_test.clj
+++ b/test/metabase/models/on_demand_test.clj
@@ -15,8 +15,11 @@
   of Fields that should have been updated. Returns the set of updated Field names."
   [f]
   (let [updated-field-names (atom #{})]
-    (with-redefs [field-values/create-or-update-full-field-values! (fn [field]
-                                                                     (swap! updated-field-names conj (:name field)))]
+    ;; Intercept bulk-distinct-values — the new on-demand code calls this once per table with all the fields
+    ;; it intends to update. Returning nil short-circuits the persist step so no DB writes happen.
+    (with-redefs [field-values/bulk-distinct-values (fn [_table-id fields]
+                                                      (swap! updated-field-names into (map :name fields))
+                                                      nil)]
       (f updated-field-names)
       @updated-field-names)))
 

--- a/test/metabase/sync/field_values_perf_test.clj
+++ b/test/metabase/sync/field_values_perf_test.clj
@@ -47,18 +47,9 @@
                         (fn [& args]
                           (swap! qp-calls inc)
                           (apply original args)))]
-          (let [start   (System/nanoTime)
-                result  (sync.field-values/update-field-values-for-table! table)
-                elapsed (/ (- (System/nanoTime) start) 1e6)]
+          (let [result (sync.field-values/update-field-values-for-table! table)]
             (testing "Should process all 100 fields without errors"
               (is (zero? (:errors result))))
-            (println (format "\n=== Field Values Sync Performance ==="))
-            (println (format "Fields:        100"))
-            (println (format "QP queries:    %d" @qp-calls))
-            (println (format "Time:          %.0f ms" elapsed))
-            (println (format "Avg per field: %.1f ms" (/ elapsed 100)))
-            (println (format "Result:        %s" result))
-            (println (format "=====================================\n"))
             (testing "Bulk scan should use exactly 1 query"
               (is (= 1 @qp-calls)))))))))
 

--- a/test/metabase/sync/field_values_perf_test.clj
+++ b/test/metabase/sync/field_values_perf_test.clj
@@ -1,0 +1,83 @@
+(ns metabase.sync.field-values-perf-test
+  "Performance tests for field values sync.
+   Measures query count when syncing tables with many fields."
+  (:require
+   [clojure.java.jdbc :as jdbc]
+   [clojure.string :as str]
+   [clojure.test :refer :all]
+   [metabase.query-processor :as qp]
+   [metabase.sync.core :as sync]
+   [metabase.sync.field-values :as sync.field-values]
+   [metabase.test.data :as data]
+   [metabase.test.data.one-off-dbs :as one-off-dbs]
+   [metabase.warehouse-schema.models.field-values :as field-values]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(defn- create-wide-table!
+  "Create a table with `n` integer columns, each with a few distinct values."
+  [n]
+  (let [col-defs (map #(format "col_%03d INT NOT NULL" %) (range n))
+        ddl      (format "CREATE TABLE wide_table (%s);" (str/join ", " col-defs))]
+    (jdbc/execute! one-off-dbs/*conn* [ddl])
+    ;; Insert 10 rows so each column has distinct values worth syncing
+    (dotimes [row 10]
+      (let [vals (map #(str (mod (+ row %) 5)) (range n))
+            sql  (format "INSERT INTO wide_table VALUES (%s);" (str/join ", " vals))]
+        (jdbc/execute! one-off-dbs/*conn* [sql])))))
+
+(defn- setup-field-values-for-table!
+  "Activate field values for all normal fields in a table so sync will update them."
+  [table-id]
+  (let [fields (t2/select :model/Field :table_id table-id :active true :visibility_type "normal")]
+    (doseq [field fields]
+      (field-values/get-or-create-full-field-values! field))))
+
+(deftest sync-field-values-query-count-test
+  (testing "Bulk scan: should use 1 query for all 100 fields instead of 100"
+    (one-off-dbs/with-blank-db
+      (create-wide-table! 100)
+      (sync/sync-database! (data/db))
+      (let [table    (t2/select-one :model/Table :db_id (:id (data/db)) :name "WIDE_TABLE")
+            _        (setup-field-values-for-table! (:id table))
+            qp-calls (atom 0)]
+        (with-redefs [qp/process-query
+                      (let [original qp/process-query]
+                        (fn [& args]
+                          (swap! qp-calls inc)
+                          (apply original args)))]
+          (let [start   (System/nanoTime)
+                result  (sync.field-values/update-field-values-for-table! table)
+                elapsed (/ (- (System/nanoTime) start) 1e6)]
+            (testing "Should process all 100 fields without errors"
+              (is (zero? (:errors result))))
+            (println (format "\n=== Field Values Sync Performance ==="))
+            (println (format "Fields:        100"))
+            (println (format "QP queries:    %d" @qp-calls))
+            (println (format "Time:          %.0f ms" elapsed))
+            (println (format "Avg per field: %.1f ms" (/ elapsed 100)))
+            (println (format "Result:        %s" result))
+            (println (format "=====================================\n"))
+            (testing "Bulk scan should use exactly 1 query"
+              (is (= 1 @qp-calls)))))))))
+
+(deftest sync-field-values-correctness-test
+  (testing "Bulk scan produces correct distinct values"
+    (one-off-dbs/with-blank-db
+      (create-wide-table! 5)
+      (sync/sync-database! (data/db))
+      (let [table  (t2/select-one :model/Table :db_id (:id (data/db)) :name "WIDE_TABLE")
+            _      (setup-field-values-for-table! (:id table))
+            fields (t2/select :model/Field :table_id (:id table) :active true :visibility_type "normal"
+                              {:order-by [[:name :asc]]})]
+        ;; Run the sync
+        (sync.field-values/update-field-values-for-table! table)
+        ;; Check that each field got its values populated
+        (doseq [field fields]
+          (let [fv (t2/select-one :model/FieldValues :field_id (:id field) :type :full)]
+            (testing (format "Field %s should have field values" (:name field))
+              (is (some? fv))
+              (when fv
+                (is (= 5 (count (:values fv))))
+                (is (false? (:has_more_values fv)))))))))))

--- a/test/metabase/sync/field_values_test.clj
+++ b/test/metabase/sync/field_values_test.clj
@@ -69,6 +69,25 @@
       (is (= [1 2 3 4]
              (venues-price-field-values))))))
 
+(deftest bulk-fallback-to-sequential-test
+  (testing "When bulk-distinct-values returns nil, sync falls back to the sequential path and still updates values correctly"
+    ;; Manually activate Field values since they are not created during sync (#53387)
+    (field-values/get-or-create-full-field-values! (t2/select-one :model/Field (mt/id :venues :price)))
+    (sync-database!' "update-field-values" (data/db))
+    (is (= [1 2 3 4]
+           (venues-price-field-values)))
+    (testing "Perturb the stored FieldValues so the sync has something to correct"
+      (t2/update! :model/FieldValues
+                  (t2/select-one-pk :model/FieldValues :field_id (mt/id :venues :price) :type :full)
+                  {:values [99]})
+      (is (= [99]
+             (venues-price-field-values))))
+    (testing "Re-sync with bulk path disabled — sequential path should correct the values"
+      (with-redefs [field-values/bulk-distinct-values (constantly nil)]
+        (sync-database!' "update-field-values" (data/db)))
+      (is (= [1 2 3 4]
+             (venues-price-field-values))))))
+
 (deftest sync-should-properly-handle-last-used-at
   (try
     (testing "Test that syncing will skip updating inactive FieldValues"
@@ -299,7 +318,8 @@
       ;; Manually activate Field values since they are not created during sync (#53387)
       (field-values/get-or-create-full-field-values! (t2/select-one :model/Field (mt/id :blueberries_consumed :str)))
       ;; we throw ConnectException, which is a non-recoverable exception
-      (with-redefs [field-values/create-or-update-full-field-values! (fn [& _] (throw (java.net.ConnectException.)))]
+      (with-redefs [field-values/bulk-distinct-values                (fn [& _] (throw (java.net.ConnectException.)))
+                    field-values/create-or-update-full-field-values! (fn [& _] (throw (java.net.ConnectException.)))]
         (is (=?
              {:steps [["delete-expired-advanced-field-values" {}]
                       ["update-field-values" {:throwable #(instance? Exception %)}]]}

--- a/test/metabase/sync/field_values_test.clj
+++ b/test/metabase/sync/field_values_test.clj
@@ -69,25 +69,6 @@
       (is (= [1 2 3 4]
              (venues-price-field-values))))))
 
-(deftest bulk-fallback-to-sequential-test
-  (testing "When bulk-distinct-values returns nil, sync falls back to the sequential path and still updates values correctly"
-    ;; Manually activate Field values since they are not created during sync (#53387)
-    (field-values/get-or-create-full-field-values! (t2/select-one :model/Field (mt/id :venues :price)))
-    (sync-database!' "update-field-values" (data/db))
-    (is (= [1 2 3 4]
-           (venues-price-field-values)))
-    (testing "Perturb the stored FieldValues so the sync has something to correct"
-      (t2/update! :model/FieldValues
-                  (t2/select-one-pk :model/FieldValues :field_id (mt/id :venues :price) :type :full)
-                  {:values [99]})
-      (is (= [99]
-             (venues-price-field-values))))
-    (testing "Re-sync with bulk path disabled — sequential path should correct the values"
-      (with-redefs [field-values/bulk-distinct-values (constantly nil)]
-        (sync-database!' "update-field-values" (data/db)))
-      (is (= [1 2 3 4]
-             (venues-price-field-values))))))
-
 (deftest sync-should-properly-handle-last-used-at
   (try
     (testing "Test that syncing will skip updating inactive FieldValues"

--- a/test/metabase/warehouse_schema/models/field_values_test.clj
+++ b/test/metabase/warehouse_schema/models/field_values_test.clj
@@ -211,10 +211,6 @@
       (binding [field-values/*total-max-length* 2]
         (is (= {:values ["a" "b"] :has_more_values false}
                (limit-values ["a" "a" "a" "a" "b"])))))
-    (testing "distinct-count cap triggers has_more_values"
-      (binding [field-values/*absolute-max-distinct-values-limit* 3]
-        (is (= {:values ["a" "b" "c"] :has_more_values true}
-               (limit-values ["a" "b" "c" "d" "e"])))))
     (testing "total-length cap triggers has_more_values"
       (binding [field-values/*total-max-length* 3]
         (is (= {:values ["aa"] :has_more_values true}
@@ -273,7 +269,14 @@
       (testing "higher-cardinality column (still under the cap) matches distinct-values"
         (is (= (set (map first (:values (field-values/distinct-values vendor-field))))
                (set (:values (get bulk-result (:id vendor-field))))))
-        (is (false? (:has_more_values (get bulk-result (:id vendor-field)))))))))
+        (is (false? (:has_more_values (get bulk-result (:id vendor-field))))))
+      (testing "row cap forces has_more_values=true on every column"
+        ;; Lower the row cap below the table size (products has 200 rows). With cap 5, the bulk
+        ;; query fetches 5 rows, hits the row cap, and every column should be marked has_more.
+        (binding [field-values/*absolute-max-distinct-values-limit* 5]
+          (let [capped (field-values/bulk-distinct-values (mt/id :products) [cat-field vendor-field])]
+            (is (true? (:has_more_values (get capped (:id cat-field)))))
+            (is (true? (:has_more_values (get capped (:id vendor-field)))))))))))
 
 (deftest persist-field-values!-test
   (testing "nil values with nil existing-fv returns ::fv-deleted without creating anything"

--- a/test/metabase/warehouse_schema/models/field_values_test.clj
+++ b/test/metabase/warehouse_schema/models/field_values_test.clj
@@ -188,6 +188,65 @@
               :has_more_values true}
              (distinct-field-values (mt/id :reviews :rating)))))))
 
+(deftest ^:parallel limit-values-test
+  (let [limit-values #'field-values/limit-values]
+    (testing "empty input returns empty values with has_more_values false"
+      (is (= {:values [] :has_more_values false}
+             (limit-values []))))
+    (testing "values under all limits are returned in natural sorted order"
+      (is (= {:values ["a" "b" "c"] :has_more_values false}
+             (limit-values ["b" "a" "c"])))
+      (testing "numeric values sort numerically"
+        (is (= {:values [-2 -1 0 1 10] :has_more_values false}
+               (limit-values [10 1 -1 0 -2])))))
+    (testing "nil values are filtered out"
+      (is (= {:values ["a" "b"] :has_more_values false}
+             (limit-values [nil "a" nil "b" nil]))))
+    (testing "duplicates are deduplicated"
+      (is (= {:values ["a" "b"] :has_more_values false}
+             (limit-values ["a" "b" "a" "b" "a"]))))
+    (testing "duplicates do not inflate the length cap"
+      ;; With cap 2, four dups of \"a\" followed by \"b\" still yields [\"a\" \"b\"]
+      ;; because only distinct values count toward the length cap.
+      (binding [field-values/*total-max-length* 2]
+        (is (= {:values ["a" "b"] :has_more_values false}
+               (limit-values ["a" "a" "a" "a" "b"])))))
+    (testing "distinct-count cap triggers has_more_values"
+      (binding [field-values/*absolute-max-distinct-values-limit* 3]
+        (is (= {:values ["a" "b" "c"] :has_more_values true}
+               (limit-values ["a" "b" "c" "d" "e"])))))
+    (testing "total-length cap triggers has_more_values"
+      (binding [field-values/*total-max-length* 3]
+        (is (= {:values ["aa"] :has_more_values true}
+               (limit-values ["aa" "bb"])))))))
+
+(deftest ^:parallel rows->per-field-distinct-values-test
+  (let [rows->per-field-distinct-values #'field-values/rows->per-field-distinct-values]
+    (testing "empty rows produces empty values for each field"
+      (is (= {1 {:values [] :has_more_values false}
+              2 {:values [] :has_more_values false}}
+             (rows->per-field-distinct-values [{:id 1} {:id 2}] []))))
+    (testing "multi-column rows produce per-field distinct values"
+      (is (= {1 {:values [1 2 3] :has_more_values false}
+              2 {:values ["a" "b" "c"] :has_more_values false}}
+             (rows->per-field-distinct-values [{:id 1} {:id 2}]
+                                              [[1 "a"] [2 "b"] [3 "c"]]))))
+    (testing "nil values are filtered independently per column"
+      (is (= {1 {:values [1 2] :has_more_values false}
+              2 {:values ["a" "b"] :has_more_values false}}
+             (rows->per-field-distinct-values [{:id 1} {:id 2}]
+                                              [[nil "a"] [1 nil] [2 "b"]]))))
+    (testing "per-column saturation is independent"
+      (binding [field-values/*total-max-length* 8]
+        (is (= {1 {:values ["aaaa" "bbbb"] :has_more_values true}
+                2 {:values ["x" "y" "z"] :has_more_values false}}
+               (rows->per-field-distinct-values [{:id 1} {:id 2}]
+                                                [["aaaa" "x"] ["bbbb" "y"] ["cccc" "z"]])))))
+    (testing "result map is keyed by field :id, not column index"
+      (is (= {42 {:values [1] :has_more_values false}
+              17 {:values ["a"] :has_more_values false}}
+             (rows->per-field-distinct-values [{:id 42} {:id 17}] [[1 "a"]]))))))
+
 (deftest clear-field-values-for-field!-test
   (mt/with-temp [:model/Database    {database-id :id} {}
                  :model/Table       {table-id :id} {:db_id database-id}
@@ -198,6 +257,75 @@
     (field-values/clear-field-values-for-field! field-id)
     (is (= nil
            (t2/select-one-fn :values :model/FieldValues, :field_id field-id)))))
+
+(deftest bulk-distinct-values-test
+  (mt/dataset test-data
+    (let [cat-field    (t2/select-one :model/Field :id (mt/id :products :category))
+          vendor-field (t2/select-one :model/Field :id (mt/id :products :vendor))
+          bulk-result  (field-values/bulk-distinct-values (mt/id :products) [cat-field vendor-field])]
+      (testing "result is keyed by field :id"
+        (is (contains? bulk-result (:id cat-field)))
+        (is (contains? bulk-result (:id vendor-field))))
+      (testing "low-cardinality column returns the same distinct set as distinct-values"
+        (is (= (set (map first (:values (field-values/distinct-values cat-field))))
+               (set (:values (get bulk-result (:id cat-field))))))
+        (is (false? (:has_more_values (get bulk-result (:id cat-field))))))
+      (testing "higher-cardinality column (still under the cap) matches distinct-values"
+        (is (= (set (map first (:values (field-values/distinct-values vendor-field))))
+               (set (:values (get bulk-result (:id vendor-field))))))
+        (is (false? (:has_more_values (get bulk-result (:id vendor-field)))))))))
+
+(deftest persist-field-values!-test
+  (testing "nil values with nil existing-fv returns ::fv-deleted without creating anything"
+    (mt/with-temp [:model/Database {database-id :id}        {}
+                   :model/Table    {table-id :id}           {:db_id database-id}
+                   :model/Field    {field-id :id :as field} {:table_id table-id :name "test"}]
+      (is (= :metabase.warehouse-schema.models.field-values/fv-deleted
+             (field-values/persist-field-values! field nil nil false)))
+      (is (nil? (t2/select-one :model/FieldValues :field_id field-id :type :full)))))
+
+  (testing "empty [] values with an existing-fv deletes the FV, returns ::fv-deleted"
+    (mt/with-temp [:model/Database    {database-id :id}        {}
+                   :model/Table       {table-id :id}           {:db_id database-id}
+                   :model/Field       {field-id :id :as field} {:table_id table-id :name "test"}
+                   :model/FieldValues _                        {:field_id field-id :type :full :values ["a" "b"]}]
+      (let [fv (t2/select-one :model/FieldValues :field_id field-id :type :full)]
+        (is (= :metabase.warehouse-schema.models.field-values/fv-deleted
+               (field-values/persist-field-values! field fv [] false)))
+        (is (nil? (t2/select-one :model/FieldValues :field_id field-id :type :full))))))
+
+  (testing "nil existing-fv with non-empty values creates a new FV, returns ::fv-created"
+    (mt/with-temp [:model/Database {database-id :id}        {}
+                   :model/Table    {table-id :id}           {:db_id database-id}
+                   :model/Field    {field-id :id :as field} {:table_id table-id :name "test"}]
+      (is (= :metabase.warehouse-schema.models.field-values/fv-created
+             (field-values/persist-field-values! field nil ["a" "b"] false)))
+      (let [fv (t2/select-one :model/FieldValues :field_id field-id :type :full)]
+        (is (some? fv))
+        (is (= ["a" "b"] (:values fv)))
+        (is (false? (:has_more_values fv))))))
+
+  (testing "matching values and has_more_values returns ::fv-skipped without changing values"
+    (mt/with-temp [:model/Database    {database-id :id}        {}
+                   :model/Table       {table-id :id}           {:db_id database-id}
+                   :model/Field       {field-id :id :as field} {:table_id table-id :name "test"}
+                   :model/FieldValues _                        {:field_id field-id :type :full :values ["a" "b"] :has_more_values false}]
+      (let [fv (t2/select-one :model/FieldValues :field_id field-id :type :full)]
+        (is (= :metabase.warehouse-schema.models.field-values/fv-skipped
+               (field-values/persist-field-values! field fv ["a" "b"] false)))
+        (is (= ["a" "b"] (:values (t2/select-one :model/FieldValues :field_id field-id :type :full)))))))
+
+  (testing "different values updates the FV, returns ::fv-updated"
+    (mt/with-temp [:model/Database    {database-id :id}        {}
+                   :model/Table       {table-id :id}           {:db_id database-id}
+                   :model/Field       {field-id :id :as field} {:table_id table-id :name "test"}
+                   :model/FieldValues _                        {:field_id field-id :type :full :values ["a" "b"] :has_more_values false}]
+      (let [fv (t2/select-one :model/FieldValues :field_id field-id :type :full)]
+        (is (= :metabase.warehouse-schema.models.field-values/fv-updated
+               (field-values/persist-field-values! field fv ["c" "d"] true)))
+        (let [fv-after (t2/select-one :model/FieldValues :field_id field-id :type :full)]
+          (is (= ["c" "d"] (:values fv-after)))
+          (is (true? (:has_more_values fv-after))))))))
 
 (defn- find-values [field-values-id]
   (-> (t2/select-one :model/FieldValues :id field-values-id)

--- a/test/metabase/warehouse_schema/models/field_values_test.clj
+++ b/test/metabase/warehouse_schema/models/field_values_test.clj
@@ -327,6 +327,56 @@
           (is (= ["c" "d"] (:values fv-after)))
           (is (true? (:has_more_values fv-after))))))))
 
+(deftest update-field-values-for-on-demand-dbs!-test
+  (mt/dataset test-data
+    (testing "fields in an on-demand DB get their FieldValues created/updated in a single bulk query per table"
+      (let [category-id (mt/id :products :category)
+            vendor-id   (mt/id :products :vendor)]
+        ;; Start fresh — no existing FVs for the fields under test
+        (t2/delete! :model/FieldValues :field_id [:in [category-id vendor-id]])
+        (mt/with-temp-vals-in-db :model/Database (mt/id) {:is_on_demand true}
+          (let [bulk-calls (atom 0)
+                orig       field-values/bulk-distinct-values]
+            (with-redefs [field-values/bulk-distinct-values (fn [& args]
+                                                              (swap! bulk-calls inc)
+                                                              (apply orig args))]
+              (field-values/update-field-values-for-on-demand-dbs! #{category-id vendor-id}))
+            (testing "exactly one bulk query was issued (both fields belong to the same table)"
+              (is (= 1 @bulk-calls))))
+          (testing "FieldValues were created for both fields"
+            (let [cat-fv    (t2/select-one :model/FieldValues :field_id category-id :type :full)
+                  vendor-fv (t2/select-one :model/FieldValues :field_id vendor-id :type :full)]
+              (is (some? cat-fv))
+              (is (= #{"Doohickey" "Gadget" "Gizmo" "Widget"} (set (:values cat-fv))))
+              (is (some? vendor-fv))
+              (is (= 200 (count (:values vendor-fv)))))))))
+    (testing "fields in a non-on-demand DB are not touched"
+      (let [category-id (mt/id :products :category)]
+        (t2/delete! :model/FieldValues :field_id category-id)
+        ;; DB defaults to is_on_demand=false in test fixtures
+        (field-values/update-field-values-for-on-demand-dbs! #{category-id})
+        (is (nil? (t2/select-one :model/FieldValues :field_id category-id :type :full)))))
+    (testing "fields that shouldn't have FieldValues are filtered out (no DB writes, no warehouse queries)"
+      (let [bulk-calls (atom 0)]
+        (with-redefs [field-values/bulk-distinct-values (fn [& _]
+                                                          (swap! bulk-calls inc)
+                                                          nil)]
+          ;; product_id is a PK/FK — field-should-have-field-values? returns false for it
+          (field-values/update-field-values-for-on-demand-dbs! #{(mt/id :orders :id)}))
+        (is (zero? @bulk-calls))))
+    (testing "existing FieldValues are updated, not duplicated"
+      (let [category-id (mt/id :products :category)]
+        (t2/delete! :model/FieldValues :field_id category-id)
+        (mt/with-temp [:model/FieldValues _ {:field_id category-id
+                                             :type     :full
+                                             :values   ["stale-1" "stale-2"]}]
+          (mt/with-temp-vals-in-db :model/Database (mt/id) {:is_on_demand true}
+            (field-values/update-field-values-for-on-demand-dbs! #{category-id}))
+          (let [fvs (t2/select :model/FieldValues :field_id category-id :type :full)]
+            (is (= 1 (count fvs)))
+            (is (= #{"Doohickey" "Gadget" "Gizmo" "Widget"}
+                   (set (:values (first fvs)))))))))))
+
 (defn- find-values [field-values-id]
   (-> (t2/select-one :model/FieldValues :id field-values-id)
       (select-keys [:values :human_readable_values])))


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #45335
## Summary

For tables with many fields, sync ran one `SELECT DISTINCT` per field to populate FieldValues, scaling linearly with column count. This PR replaces it with a bulk path that fetches the first K rows of all syncable columns in one query and derives per-column distinct values in memory. The query count per table sync drops from `O(fields)` to `O(1)`, and the same bulk path is now used by the on-demand DB and data-editor invalidation flows so they get the win too.

## BigQuery benchmark

Cloud telemetry shows BigQuery instances are the most affected by the per-field path: `update-field-values` runtime grows steeply with total field count, and runs frequently hit the 60-minute task-history cap once total field count crosses a few thousand. The chart below (cloud aggregate, `update-field-values` durations by field-count bin) shows the failure pattern — red dots are runs that hit the timeout, green dots are successes averaging 40–60 minutes at the high end.

<!-- TODO: attach BigQuery duration-by-field-count chart screenshot here -->

Reproducing the Athena-style benchmark against BigQuery test-data:

| Table | Fields | Per-field path (master) | Bulk path (this PR) | Speedup |
|---|---:|---:|---:|---:|
| `orders` | 9 | 12.6 s | 1.66 s | **7.6×** |
| `people` | 13 | 21.5 s | 1.66 s | **12.9×** |

BigQuery's per-query cold-start overhead is ~1.3–1.6 s, while the bulk path is ~1.7 s **regardless of column count**. The speedup factor therefore scales linearly with field count:

- 50 fields → ~75 s vs ~1.7 s → ~45×
- 500 fields → ~12 min vs ~1.7 s → ~440×
- 5000 fields → would hit the 60-min cap vs ~1.7 s → ~3500×+

This matches the cloud observation: master sync is dominated by linear-in-fields cold-start cost on BigQuery. The bulk path removes the dependency on field count entirely — sync time becomes a function of row count, not column count.

## Athena benchmark

Verified against real Athena (test-data dataset, `people` table, 9 eligible fields):

| | Bulk path (this PR) | Per-field path (master) | Speedup |
|---|---:|---:|---:|
| QP queries | 1 | 9 | 9× |
| Wall clock | 2003 ms | 14245 ms | **7.1×** |

<!-- TODO: attach Athena duration-by-field-count chart screenshot here -->

The Athena win is real but smaller than BigQuery's. Cloud telemetry shows Athena durations stay roughly flat (mostly under 10 minutes) out to ~100K total fields, suggesting Athena's per-query cold-start is lower than BigQuery's and the constant-time component is less dominant in the master path. For both engines the bulk path eliminates the per-field cost; the absolute win is larger wherever per-query overhead is larger.

## What changed

### New primitives in `metabase.warehouse-schema.models.field-values`
- **`bulk-distinct-values`** issues `SELECT col1, col2, ... FROM t LIMIT K` and processes the rows through `rows->per-field-distinct-values` and `limit-values` to produce per-field distinct sets. If the row cap is hit, marks every column `has_more_values=true` (see Trade-off below).
- **`persist-field-values!`** is extracted from `create-or-update-full-field-values!` so all paths share the compare/skip/update/create/delete logic.

### Sync hot path (`metabase.sync.field-values`)
- **`update-field-values-for-table!`** now partitions fields into to-sync vs to-clear, batch-fetches existing FieldValues, filters out fields without an active FV, then runs the bulk path. If the bulk query fails, the table reports `:errors = (count fields-to-sync)` and the sync moves on to the next table.
- The previous per-field path (`update-field-values-for-field!`, `update-field-values-for-table-sequential!`) is **deleted**. There is no fallback — the bulk path is the only path.

### On-demand DB updates (`update-field-values-for-on-demand-dbs!`)
- Previously called `create-or-update-full-field-values!` per field. Now groups eligible fields by table and runs one bulk query per table. A dashboard with multiple parameters referencing fields from the same table now triggers one warehouse query instead of N.

### Data-editor invalidation (enterprise `batch-invalidate-field-values!`)
- Same treatment: groups invalidated fields by table, runs one bulk query per table. A row edit touching 15 columns of one table now triggers one warehouse query instead of 15.

## Trade-off (worth a reviewer's attention)

The bulk path is a **sample** of the first K rows rather than an exhaustive `SELECT DISTINCT`. To avoid silently returning incomplete value lists, `bulk-distinct-values` now marks **every column** `has_more_values=true` when the row sample hits the cap (i.e., the table has at least K rows). This matches the old per-field path's pessimistic heuristic of "if you got back exactly the limit, assume there's more."

This errs on the side of over-flagging:

- ✅ A high-cardinality column whose distinct values are clustered past the sample window correctly gets `has_more_values=true` (no silent data gap)
- ⚠️ A low-cardinality column (e.g., `orders.status`, 4 distinct values) in a table larger than K rows also gets `has_more_values=true`, even though the sample contains all its values

For the over-flagged case, the user-visible effect is that the parameter widget renders in search mode (`MultiAutocomplete`) instead of static-list mode (`ListField`). The cached values are still pre-populated in the search dropdown, client-side filtering still works, and the only real cost is one backend query per "search session" once the user starts typing — bounded and only painful on cost-sensitive warehouses, where users typically already opt those columns into search via the on-demand setting anyway.

The asymmetry: false positive (forces search mode but UX still works) is much cheaper than false negative (silent incomplete list with no escape hatch). The PR picks the safer side.

## Tests

- **`metabase.warehouse-schema.models.field-values-test`** (24 tests): unit tests for `limit-values`, `rows->per-field-distinct-values`, `bulk-distinct-values` (including row-cap behavior), `persist-field-values!`, and `update-field-values-for-on-demand-dbs!`
- **`metabase.sync.field-values-test`** (9 tests): all pre-existing tests still pass
- **`metabase.sync.field-values-perf-test`** (new, 2 tests): asserts a 100-column wide table syncs in exactly 1 QP query and that the values are correct
- **`metabase.models.on-demand-test`** (13 tests): updated to mock `bulk-distinct-values`; trigger-flow coverage preserved
- **`metabase-enterprise.action-v2.api-test`** (existing `field-values-invalidated-test` + 2 new direct tests for `batch-invalidate-field-values!`): asserts the bulk function is called once per table and field IDs are correctly partitioned

Total: 48 tests, 278 assertions across the affected namespaces, 0 failures. Kondo clean (0 errors, 0 warnings) on all touched files.

## How the numbers were measured

For both engine benchmarks: ran the bulk and per-field paths against the same warmed table from a Metabase REPL, with `qp/process-query` wrapped in a counter and wall-clock measured between calls to `update-field-values-for-table!` (bulk) and a per-field loop calling `distinct-values` (master simulation). BigQuery numbers came from the `people` (13 fields) and `orders` (9 fields) tables in the `test-data` dataset on `metabase-bigquery-driver`. Athena numbers came from the same `people` table on the Athena `test-data` dataset.
