### PR TITLE
Refactor Metric Viewer to use mantine accordion

### DIFF
--- a/frontend/src/metabase/common/components/DimensionPickerList/DimensionPickerList.module.css
+++ b/frontend/src/metabase/common/components/DimensionPickerList/DimensionPickerList.module.css
@@ -1,0 +1,3 @@
+.root {
+  overflow: auto;
+}

--- a/frontend/src/metabase/common/components/DimensionPickerList/DimensionPickerList.tsx
+++ b/frontend/src/metabase/common/components/DimensionPickerList/DimensionPickerList.tsx
@@ -1,0 +1,79 @@
+import type { ReactNode } from "react";
+
+import type { ListSection } from "metabase/common/components/DimensionPill/utils";
+import { Box, NavLink, Stack, Text } from "metabase/ui";
+
+import S from "./DimensionPickerList.module.css";
+
+interface DimensionPickerListProps<TItem> {
+  sections: ListSection<TItem>[];
+  onChange: (item: TItem) => void;
+  renderItemName: (item: TItem) => string | undefined;
+  renderItemIcon?: (item: TItem) => ReactNode;
+  renderItemExtra?: (item: TItem, isSelected: boolean) => ReactNode;
+  renderItemWrapper?: (content: ReactNode, item: TItem) => ReactNode;
+  itemIsSelected?: (item: TItem) => boolean;
+  className?: string;
+  w?: string | number;
+}
+
+export function DimensionPickerList<TItem>({
+  sections,
+  onChange,
+  renderItemName,
+  renderItemIcon,
+  renderItemExtra,
+  renderItemWrapper,
+  itemIsSelected,
+  className,
+  w,
+}: DimensionPickerListProps<TItem>) {
+  const showSectionHeaders =
+    sections.length > 1 && sections.some((s) => s.name);
+
+  return (
+    <Box role="listbox" className={`${S.root} ${className ?? ""}`} w={w}>
+      {sections.map((section, sectionIndex) => (
+        <Box key={section.name ?? sectionIndex}>
+          {showSectionHeaders && section.name && (
+            <Text
+              size="xs"
+              tt="uppercase"
+              fw={700}
+              c="brand"
+              px="md"
+              pt="md"
+              pb="sm"
+            >
+              {section.name}
+            </Text>
+          )}
+          <Stack gap="xs">
+            {section.items?.map((item, itemIndex) => {
+              const isSelected = itemIsSelected?.(item) ?? false;
+              const navLink = (
+                <NavLink
+                  variant="default"
+                  role="option"
+                  aria-selected={isSelected}
+                  active={isSelected}
+                  label={renderItemName(item)}
+                  leftSection={renderItemIcon?.(item)}
+                  rightSection={renderItemExtra?.(item, isSelected)}
+                  onClick={() => onChange(item)}
+                />
+              );
+              return (
+                <Box key={itemIndex} mx="sm">
+                  {renderItemWrapper
+                    ? renderItemWrapper(navLink, item)
+                    : navLink}
+                </Box>
+              );
+            })}
+          </Stack>
+        </Box>
+      ))}
+    </Box>
+  );
+}

--- a/frontend/src/metabase/common/components/DimensionPickerList/index.ts
+++ b/frontend/src/metabase/common/components/DimensionPickerList/index.ts
@@ -1,0 +1,1 @@
+export { DimensionPickerList } from "./DimensionPickerList";

--- a/frontend/src/metabase/common/components/DimensionPill/DimensionPill.module.css
+++ b/frontend/src/metabase/common/components/DimensionPill/DimensionPill.module.css
@@ -17,7 +17,3 @@
 .dropdown {
   overflow-y: auto;
 }
-
-.dimensionList {
-  color: var(--mb-color-brand);
-}

--- a/frontend/src/metabase/common/components/DimensionPill/DimensionPill.tsx
+++ b/frontend/src/metabase/common/components/DimensionPill/DimensionPill.tsx
@@ -2,17 +2,14 @@ import cx from "classnames";
 import { useCallback, useMemo, useState } from "react";
 import { t } from "ttag";
 
-import {
-  AccordionList,
-  type Section,
-} from "metabase/common/components/AccordionList";
+import { DimensionPickerList } from "metabase/common/components/DimensionPickerList";
 import { SourceColorIndicator } from "metabase/common/components/SourceColorIndicator";
 import type { IconName } from "metabase/ui";
 import { Divider, Flex, Icon, Popover, Text } from "metabase/ui";
 import type { DimensionGroup, DimensionMetadata } from "metabase-lib/metric";
 
 import S from "./DimensionPill.module.css";
-import { groupIntoSections } from "./utils";
+import { type ListSection, groupIntoSections } from "./utils";
 
 export interface DimensionOption {
   name: string;
@@ -47,7 +44,9 @@ const REMOVE_ACTION: RemoveAction = {
   icon: "close",
 };
 
-const REMOVE_SECTIONS: Section<RemoveAction>[] = [{ items: [REMOVE_ACTION] }];
+const REMOVE_SECTIONS: ListSection<RemoveAction>[] = [
+  { items: [REMOVE_ACTION] },
+];
 
 function renderItemName(item: DimensionOption | RemoveAction) {
   return item.displayName;
@@ -106,7 +105,7 @@ export function DimensionPill({
     pillLabel = label;
   }
 
-  const sections: Section<DimensionOption>[] = useMemo(
+  const sections: ListSection<DimensionOption>[] = useMemo(
     () => groupIntoSections(options),
     [options],
   );
@@ -134,31 +133,25 @@ export function DimensionPill({
       </Popover.Target>
       <Popover.Dropdown px={0} py="xs" mah={300} className={S.dropdown}>
         {hasMultipleOptions && (
-          <AccordionList
-            className={S.dimensionList}
+          <DimensionPickerList
             sections={sections}
             onChange={handleSelect}
             renderItemName={renderItemName}
             renderItemIcon={renderItemIcon}
             itemIsSelected={dimensionItemIsSelected}
-            alwaysExpanded
-            maxHeight={Infinity}
-            width={240}
+            w={240}
           />
         )}
         {canRemove && (
           <>
             {hasMultipleOptions && <Divider my="xs" />}
-            <AccordionList
-              className={S.dimensionList}
+            <DimensionPickerList
               sections={REMOVE_SECTIONS}
               onChange={handleRemove}
               renderItemName={renderItemName}
               renderItemIcon={renderItemIcon}
               itemIsSelected={removeItemIsSelected}
-              alwaysExpanded
-              maxHeight={Infinity}
-              width={240}
+              w={240}
             />
           </>
         )}

--- a/frontend/src/metabase/common/components/DimensionPill/index.ts
+++ b/frontend/src/metabase/common/components/DimensionPill/index.ts
@@ -1,3 +1,4 @@
 export { DimensionPill } from "./DimensionPill";
 export type { DimensionPillProps, DimensionOption } from "./DimensionPill";
 export { groupIntoSections } from "./utils";
+export type { ListSection } from "./utils";

--- a/frontend/src/metabase/common/components/DimensionPill/utils.ts
+++ b/frontend/src/metabase/common/components/DimensionPill/utils.ts
@@ -1,5 +1,9 @@
-import type { Section } from "metabase/common/components/AccordionList";
 import type { DimensionGroup } from "metabase-lib/metric";
+
+export type ListSection<TItem> = {
+  name?: string;
+  items?: TItem[];
+};
 
 interface Groupable {
   group?: DimensionGroup;
@@ -7,7 +11,7 @@ interface Groupable {
 
 export function groupIntoSections<T extends Groupable>(
   items: T[],
-): Section<T>[] {
+): ListSection<T>[] {
   const groups = new Map<
     string | undefined,
     { groupName: string; items: T[] }

--- a/frontend/src/metabase/metrics-viewer/components/BreakoutDimensionPicker/BreakoutDimensionPicker.module.css
+++ b/frontend/src/metabase/metrics-viewer/components/BreakoutDimensionPicker/BreakoutDimensionPicker.module.css
@@ -2,10 +2,6 @@
   overflow-y: auto;
 }
 
-.dimensionList {
-  color: var(--mb-color-brand);
-}
-
 .itemWrapper:hover [data-bucket-trigger] {
   visibility: visible;
 }

--- a/frontend/src/metabase/metrics-viewer/components/BreakoutDimensionPicker/BreakoutDimensionPicker.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/BreakoutDimensionPicker/BreakoutDimensionPicker.tsx
@@ -1,12 +1,10 @@
 import type { ReactNode } from "react";
 import { useCallback, useMemo } from "react";
 
-import {
-  AccordionList,
-  type Section,
-} from "metabase/common/components/AccordionList";
+import { DimensionPickerList } from "metabase/common/components/DimensionPickerList";
 import {
   type DimensionOption,
+  type ListSection,
   groupIntoSections,
 } from "metabase/common/components/DimensionPill";
 import { HoverParent } from "metabase/common/components/MetadataInfo/ColumnInfoIcon";
@@ -40,7 +38,7 @@ export function BreakoutDimensionPicker({
     [definition],
   );
 
-  const sections: Section<DimensionOption>[] = useMemo(() => {
+  const sections: ListSection<DimensionOption>[] = useMemo(() => {
     const items: DimensionOption[] = [...dimensions.values()].map((dim) => ({
       ...dim,
       dimension: dim.dimensionMetadata,
@@ -126,8 +124,7 @@ export function BreakoutDimensionPicker({
 
   return (
     <Flex direction="column" mah="25rem" py="xs" className={S.pickerContainer}>
-      <AccordionList
-        className={S.dimensionList}
+      <DimensionPickerList
         sections={sections}
         onChange={handleChange}
         renderItemName={renderItemName}
@@ -135,9 +132,7 @@ export function BreakoutDimensionPicker({
         renderItemExtra={renderItemExtra}
         renderItemWrapper={renderItemWrapper}
         itemIsSelected={itemIsSelected}
-        alwaysExpanded
-        maxHeight={Infinity}
-        width="16rem"
+        w="16rem"
       />
     </Flex>
   );

--- a/frontend/src/metabase/metrics-viewer/components/DimensionPillBar/ExpressionDimensionPill.module.css
+++ b/frontend/src/metabase/metrics-viewer/components/DimensionPillBar/ExpressionDimensionPill.module.css
@@ -6,7 +6,6 @@
 
 .dimensionList {
   max-width: 100%;
-  color: var(--mb-color-brand);
 }
 
 .accordionItem {

--- a/frontend/src/metabase/metrics-viewer/components/DimensionPillBar/ExpressionDimensionPill.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/DimensionPillBar/ExpressionDimensionPill.tsx
@@ -2,13 +2,13 @@ import cx from "classnames";
 import { useCallback, useMemo, useState } from "react";
 import { t } from "ttag";
 
-import {
-  AccordionList,
-  type Section,
-} from "metabase/common/components/AccordionList";
+import { DimensionPickerList } from "metabase/common/components/DimensionPickerList";
 import type { DimensionOption } from "metabase/common/components/DimensionPill";
 import DPS from "metabase/common/components/DimensionPill/DimensionPill.module.css";
-import { groupIntoSections } from "metabase/common/components/DimensionPill/utils";
+import {
+  type ListSection,
+  groupIntoSections,
+} from "metabase/common/components/DimensionPill/utils";
 import { SourceColorIndicator } from "metabase/common/components/SourceColorIndicator";
 import {
   Badge,
@@ -166,16 +166,14 @@ function SingleMetricContent({
   );
 
   return (
-    <AccordionList
+    <DimensionPickerList
       className={S.dimensionList}
       sections={sections}
       onChange={handleSelect}
       renderItemName={renderItemName}
       renderItemIcon={renderItemIcon}
       itemIsSelected={itemIsSelected}
-      alwaysExpanded
-      maxHeight={Infinity}
-      width={240}
+      w={240}
     />
   );
 }
@@ -237,7 +235,7 @@ function MetricAccordionItem({
   onDimensionChange,
   onClose,
 }: MetricAccordionItemProps) {
-  const sections: Section<DimensionOption>[] = useMemo(
+  const sections: ListSection<DimensionOption>[] = useMemo(
     () => groupIntoSections(source.availableOptions),
     [source.availableOptions],
   );
@@ -275,16 +273,14 @@ function MetricAccordionItem({
       </UnstyledButton>
       {showDimensions && (
         <Box pb="sm">
-          <AccordionList
+          <DimensionPickerList
             className={S.dimensionList}
             sections={sections}
             onChange={handleSelect}
             renderItemName={renderItemName}
             renderItemIcon={renderItemIcon}
             itemIsSelected={itemIsSelected}
-            alwaysExpanded
-            maxHeight={Infinity}
-            width="100%"
+            w="100%"
           />
         </Box>
       )}

--- a/frontend/src/metabase/metrics-viewer/components/FilterPopover/FilterPopover.module.css
+++ b/frontend/src/metabase/metrics-viewer/components/FilterPopover/FilterPopover.module.css
@@ -18,7 +18,6 @@
 
 .dimensionList {
   max-width: 100%;
-  color: var(--mb-color-brand);
 }
 
 .accordionItem {

--- a/frontend/src/metabase/metrics-viewer/components/FilterPopover/FilterPopoverContent.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/FilterPopover/FilterPopoverContent.tsx
@@ -2,7 +2,7 @@ import cx from "classnames";
 import { useCallback, useMemo, useState } from "react";
 import { t } from "ttag";
 
-import { AccordionList } from "metabase/common/components/AccordionList";
+import { DimensionPickerList } from "metabase/common/components/DimensionPickerList";
 import { SourceColorIndicator } from "metabase/common/components/SourceColorIndicator";
 import type {
   DimensionListItem,
@@ -177,16 +177,13 @@ function DimensionList({
   }, []);
 
   return (
-    <AccordionList<DimensionListItem, DimensionSection>
+    <DimensionPickerList
       className={S.dimensionList}
       sections={sections}
       onChange={onSelect}
       renderItemName={(item) => item.name}
       renderItemIcon={renderItemIcon}
-      width="100%"
-      maxHeight={Infinity}
-      searchable={false}
-      alwaysExpanded
+      w="100%"
     />
   );
 }

--- a/frontend/src/metabase/metrics-viewer/components/MetricsViewerTabs/AddDimensionPopover/AddDimensionPopover.module.css
+++ b/frontend/src/metabase/metrics-viewer/components/MetricsViewerTabs/AddDimensionPopover/AddDimensionPopover.module.css
@@ -3,9 +3,16 @@
 }
 
 .dropdown {
+  display: flex;
+  flex-direction: column;
   overflow: hidden;
 }
 
-.dimensionPicker {
-  color: var(--mb-color-brand);
+.searchSection {
+  border-bottom: 1px solid var(--mb-color-border);
+}
+
+.listSection {
+  overflow-y: auto;
+  max-height: 300px;
 }

--- a/frontend/src/metabase/metrics-viewer/components/MetricsViewerTabs/AddDimensionPopover/AddDimensionPopover.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricsViewerTabs/AddDimensionPopover/AddDimensionPopover.tsx
@@ -1,10 +1,10 @@
 import { useCallback, useMemo, useState } from "react";
 import { t } from "ttag";
 
-import { AccordionList } from "metabase/common/components/AccordionList";
+import { DimensionPickerList } from "metabase/common/components/DimensionPickerList";
 import { trackMetricsViewerDimensionTabAdded } from "metabase/metrics-viewer/analytics";
 import type { TabInfo } from "metabase/metrics-viewer/utils/tabs";
-import { ActionIcon, Icon, Popover } from "metabase/ui";
+import { ActionIcon, Box, Icon, Popover, Text, TextInput } from "metabase/ui";
 
 import type { MetricSourceId } from "../../../types/viewer-state";
 import type {
@@ -27,6 +27,24 @@ type AddDimensionPopoverProps = {
   onAddTab: (tabInfo: TabInfo) => void;
 };
 
+function filterSectionsBySearch(
+  sections: DimensionPickerSection[],
+  searchText: string,
+): DimensionPickerSection[] {
+  if (!searchText) {
+    return sections;
+  }
+  const lower = searchText.toLowerCase();
+  return sections
+    .map((section) => ({
+      ...section,
+      items: section.items.filter((item) =>
+        item.name.toLowerCase().includes(lower),
+      ),
+    }))
+    .filter((section) => section.items.length > 0);
+}
+
 export function AddDimensionPopover({
   availableDimensions,
   sourceOrder,
@@ -36,6 +54,7 @@ export function AddDimensionPopover({
   canAddScalarTab,
 }: AddDimensionPopoverProps) {
   const [isOpen, setIsOpen] = useState(false);
+  const [searchText, setSearchText] = useState("");
 
   const sections = useMemo(
     () =>
@@ -82,8 +101,24 @@ export function AddDimensionPopover({
     ];
   }
 
+  const filteredSections = useMemo(
+    () => filterSectionsBySearch(finalSections, searchText),
+    [finalSections, searchText],
+  );
+
+  const hasNoResults = filteredSections.length === 0 && searchText.length > 0;
+
   return (
-    <Popover opened={isOpen} onChange={setIsOpen} position="bottom-start">
+    <Popover
+      opened={isOpen}
+      onChange={(open) => {
+        setIsOpen(open);
+        if (!open) {
+          setSearchText("");
+        }
+      }}
+      position="bottom-start"
+    >
       <Popover.Target>
         <ActionIcon
           className={S.addButton}
@@ -95,17 +130,33 @@ export function AddDimensionPopover({
         </ActionIcon>
       </Popover.Target>
       <Popover.Dropdown p={0} className={S.dropdown}>
-        <AccordionList
-          className={S.dimensionPicker}
-          sections={finalSections}
-          onChange={handleSelect}
-          renderItemIcon={renderItemIcon}
-          alwaysExpanded
-          globalSearch
-          searchable
-          maxHeight={300}
-          width="17.5rem"
-        />
+        <Box className={S.searchSection} p="sm">
+          <TextInput
+            placeholder={t`Search for a dimension...`}
+            value={searchText}
+            onChange={(event) => setSearchText(event.currentTarget.value)}
+            leftSection={<Icon name="search" size={16} />}
+            size="sm"
+            radius="md"
+          />
+        </Box>
+        <Box className={S.listSection}>
+          {hasNoResults ? (
+            <Box p="xl" w="17.5rem">
+              <Text c="text-secondary" ta="center" size="sm">
+                {t`No dimensions found`}
+              </Text>
+            </Box>
+          ) : (
+            <DimensionPickerList
+              sections={filteredSections}
+              onChange={handleSelect}
+              renderItemIcon={renderItemIcon}
+              renderItemName={(item) => item.name}
+              w="17.5rem"
+            />
+          )}
+        </Box>
       </Popover.Dropdown>
     </Popover>
   );

--- a/frontend/src/metabase/metrics/components/FilterPicker/FilterDimensionPicker/types.ts
+++ b/frontend/src/metabase/metrics/components/FilterPicker/FilterDimensionPicker/types.ts
@@ -1,4 +1,4 @@
-import type { Section as BaseSection } from "metabase/common/components/AccordionList";
+import type { ListSection } from "metabase/common/components/DimensionPill";
 import type * as LibMetric from "metabase-lib/metric";
 
 export type DimensionListItem = {
@@ -8,7 +8,7 @@ export type DimensionListItem = {
   dimension: LibMetric.DimensionMetadata;
 };
 
-export type DimensionSection = BaseSection<DimensionListItem>;
+export type DimensionSection = ListSection<DimensionListItem>;
 
 export type MetricGroup = {
   id: number;


### PR DESCRIPTION
Address https://github.com/metabase/metabase/pull/70733#discussion_r3057547192

### Description

We change dimensions and filters columns to be based of mantine `Accordion` component rather than legacy `common/AccordionList`

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
