### PR TITLE
BOT-1285 Restrict metabase managed AI to anthropic and claude-sonnet-4-6

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/internal_stats/metabot_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/internal_stats/metabot_test.clj
@@ -73,14 +73,12 @@
           conv-5       (str (random-uuid))
           conv-6       (str (random-uuid))
           all-convs    [conv-1 conv-2 conv-3 conv-4 conv-5 conv-6]
-          ;; OpenRouter returns model names like "anthropic/claude-haiku-4-5" in its API.
-          ;; This is the bare model name that flows from the SSE adapter → extract-usage → DB.
-          model        "anthropic/claude-haiku-4-5"]
+          model        "claude-sonnet-4-6"]
       (t/with-clock clock
         (try
           ;; -- AI proxy conversations (metabase/ prefix) --
           (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
-                                             "metabase/openrouter/anthropic/claude-haiku-4-5"]
+                                             "metabase/anthropic/claude-sonnet-4-6"]
             ;; conv-1: yesterday, one model
             (send-message! conv-1 "What is 2+2?" model 100 50)
             (backdate-messages! conv-1 yesterday)
@@ -103,7 +101,7 @@
 
           ;; -- BYOK conversation (no metabase/ prefix) --
           (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
-                                             "openrouter/anthropic/claude-haiku-4-5"]
+                                             "anthropic/claude-sonnet-4-6"]
             (send-message! conv-5 "BYOK question" model 777 777)
             (backdate-messages! conv-5 yesterday))
 
@@ -130,10 +128,10 @@
               (is (every? false? (map :ai_proxied logs)))))
 
           (testing "usage keys are provider/model (metabase/ prefix stripped)"
-            ;; accumulate-usage-xf strips metabase/ prefix → "openrouter/anthropic/claude-haiku-4-5"
-            ;; JSON roundtrip keywordizes → :openrouter/anthropic/claude-haiku-4-5
+            ;; accumulate-usage-xf strips metabase/ prefix → "anthropic/claude-sonnet-4-6"
+            ;; JSON roundtrip keywordizes → :anthropic/claude-sonnet-4-6
             (let [msg (t2/select-one :model/MetabotMessage :conversation_id conv-1 :role :assistant)]
-              (is (contains? (:usage msg) (keyword "openrouter" "anthropic/claude-haiku-4-5"))
+              (is (contains? (:usage msg) (keyword "anthropic" "claude-sonnet-4-6"))
                   "usage key should be provider/model without metabase/ prefix")))
 
           ;; -- Verify stats aggregation --
@@ -144,7 +142,7 @@
               (is (= 430 (:metabot-tokens stats))))
 
             (testing ":metabot-usage aggregates combined tokens by model"
-              (is (= {"openrouter:anthropic/claude-haiku-4-5:tokens" 430}
+              (is (= {"anthropic:claude-sonnet-4-6:tokens" 430}
                      (:metabot-usage stats))))
 
             (testing ":metabot-queries counts ai-proxied user messages for yesterday"
@@ -157,7 +155,7 @@
               (is (= "2026-03-31" (:metabot-usage-date stats))))
 
             (testing ":metabot-rolling-usage aggregates today's combined tokens by model"
-              (is (= {"openrouter:anthropic/claude-haiku-4-5:tokens" 1976}
+              (is (= {"anthropic:claude-sonnet-4-6:tokens" 1976}
                      (:metabot-rolling-usage stats))))
 
             (testing ":metabot-rolling-usage-date is today's date"
@@ -219,8 +217,10 @@
           conv-id   (str (random-uuid))]
       (t/with-clock clock
         (try
-          (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
-                                             "metabase/openai/gpt-4o"]
+          ;; openai is not currently in the metabase managed allow-list, but we still
+          ;; want to test metering in case we ever enable these providers — bypass the
+          ;; validator with `with-redefs` to set the provider directly.
+          (with-redefs [metabot.settings/llm-metabot-provider (constantly "metabase/openai/gpt-4o")]
             (send-message! conv-id "Hello" "gpt-4o" 600 200)
             (backdate-messages! conv-id yesterday))
           (let [stats (sut/metabot-stats)]
@@ -238,16 +238,19 @@
           conv-3    (str (random-uuid))]
       (t/with-clock clock
         (try
-          (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
-                                             "metabase/openrouter/anthropic/claude-haiku-4-5"]
+          ;; openrouter/openai are not currently in the metabase managed allow-list,
+          ;; but we still want to test metering in case we ever enable these providers
+          ;; — bypass the validator with `with-redefs` to set the provider directly.
+          (with-redefs [metabot.settings/llm-metabot-provider
+                        (constantly "metabase/openrouter/anthropic/claude-haiku-4-5")]
             (send-message! conv-1 "Q1" "anthropic/claude-haiku-4-5" 100 50)
             (backdate-messages! conv-1 yesterday))
           (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
                                              "metabase/anthropic/claude-sonnet-4-6"]
             (send-message! conv-2 "Q2" "claude-sonnet-4-6" 200 80)
             (backdate-messages! conv-2 yesterday))
-          (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
-                                             "metabase/openai/gpt-4o"]
+          (with-redefs [metabot.settings/llm-metabot-provider
+                        (constantly "metabase/openai/gpt-4o")]
             (send-message! conv-3 "Q3" "gpt-4o" 300 120)
             (backdate-messages! conv-3 yesterday))
           (let [stats (sut/metabot-stats)]
@@ -300,12 +303,12 @@
           clock     (t/mock-clock (t/instant "2026-04-01T12:00:00Z") "UTC")
           yesterday (t/offset-date-time 2026 3 31 10 0 0 0 (t/zone-offset "+00"))
           today     (t/offset-date-time 2026 4 1 9 0 0 0 (t/zone-offset "+00"))
-          model     "anthropic/claude-haiku-4-5"
+          model     "claude-sonnet-4-6"
           tables    [{:name "Orders" :fields [{:name "id"} {:name "total"}]}]]
       (t/with-clock clock
         (try
           (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
-                                             "metabase/openrouter/anthropic/claude-haiku-4-5"]
+                                             "metabase/anthropic/claude-sonnet-4-6"]
             ;; Yesterday's generation
             (generate-example-questions! tables model 400 100)
 
@@ -325,9 +328,9 @@
                           {:created_at today})))
 
           (testing "metabot-stats includes yesterday totals and today's rolling usage"
-            (is (=? {:metabot-tokens            500
-                     :metabot-usage             {"openrouter:anthropic/claude-haiku-4-5:tokens" 500}
-                     :metabot-rolling-usage      {"openrouter:anthropic/claude-haiku-4-5:tokens" 260}
+            (is (=? {:metabot-tokens             500
+                     :metabot-usage              {"anthropic:claude-sonnet-4-6:tokens" 500}
+                     :metabot-rolling-usage      {"anthropic:claude-sonnet-4-6:tokens" 260}
                      :metabot-rolling-usage-date "2026-04-01"}
                     (sut/metabot-stats))))
           (finally
@@ -363,13 +366,13 @@
     (let [baseline  (max-usage-log-id)
           clock     (t/mock-clock (t/instant "2026-04-01T12:00:00Z") "UTC")
           yesterday (t/offset-date-time 2026 3 31 10 0 0 0 (t/zone-offset "+00"))
-          model     "anthropic/claude-haiku-4-5"
+          model     "claude-sonnet-4-6"
           tables    [{:name "Orders" :fields [{:name "id"} {:name "total"}]}]
           conv-id   (str (random-uuid))]
       (t/with-clock clock
         (try
           (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
-                                             "metabase/openrouter/anthropic/claude-haiku-4-5"]
+                                             "metabase/anthropic/claude-sonnet-4-6"]
             ;; Chat conversation
             (send-message! conv-id "What is 2+2?" model 200 50)
             (backdate-messages! conv-id yesterday)
@@ -384,7 +387,7 @@
             ;; chat: 250, eqg: 400 → total 650
             (is (=? {:metabot-tokens  650
                      :metabot-queries 1
-                     :metabot-usage   {"openrouter:anthropic/claude-haiku-4-5:tokens" 650}}
+                     :metabot-usage   {"anthropic:claude-sonnet-4-6:tokens" 650}}
                     (sut/metabot-stats))))
           (finally
             (cleanup-usage-logs-after! baseline)

--- a/src/metabase/metabot/settings.clj
+++ b/src/metabase/metabot/settings.clj
@@ -96,10 +96,6 @@
 
 ;;; ------------------------------------------------- LLM Provider ------------------------------------------------
 
-(def supported-metabot-providers
-  "Set of supported LLM provider prefixes for the `llm-metabot-provider` setting."
-  #{"anthropic" "openai" "openrouter" provider-util/metabase-provider-prefix})
-
 (def ^:private direct-providers
   "Providers that can be used directly (not via the metabase/ proxy prefix)."
   #{"anthropic" "openai" "openrouter"})
@@ -112,39 +108,86 @@
   "Managed-provider version of [[default-llm-metabot-provider]]."
   (str provider-util/metabase-provider-prefix "/" default-llm-metabot-provider))
 
+(def ^:private proxied-providers-and-models
+  "Providers and models that can be used via the metabase managed AI proxy.
+
+  The keys of this map must be a subset of the [[direct-providers]]."
+  {"anthropic" #{"claude-sonnet-4-6"}})
+
+(def supported-metabot-providers
+  "Set of supported LLM provider prefixes for the `llm-metabot-provider` setting."
+  (conj direct-providers provider-util/metabase-provider-prefix))
+
+(defn- validate-direct-provider!
+  "Validate that `value` is a `provider/model` string for one of the [[direct-providers]]
+  (i.e. *not* using the `metabase/` proxy prefix). Throws on invalid input."
+  [value]
+  (when (provider-util/metabase-provider? value)
+    (throw (ex-info (tru "Invalid direct provider {0}. Must not start with {1}/."
+                         (pr-str value) provider-util/metabase-provider-prefix)
+                    {:status-code 400
+                     :value       value})))
+  (let [provider (provider-util/provider-and-model->provider value)
+        model    (provider-util/provider-and-model->model value)]
+    (when-not (contains? direct-providers provider)
+      (throw (ex-info (tru "Unknown provider {0}. Supported providers: {1}"
+                           (pr-str provider)
+                           (str/join ", " (sort supported-metabot-providers)))
+                      {:status-code 400
+                       :provider    provider
+                       :supported   supported-metabot-providers})))
+    (when (str/blank? model)
+      (throw (ex-info (tru "Model name is required. Expected format: provider/model, e.g. \"anthropic/claude-haiku-4-5\"")
+                      {:status-code 400
+                       :value       value})))))
+
+(defn- validate-metabase-managed-provider!
+  "Validate that `value` is a `metabase/provider/model` string whose inner provider and
+  model are in the [[proxied-providers-and-models]] allow-list. Throws on invalid input."
+  [value]
+  (when-not (provider-util/metabase-provider? value)
+    (throw (ex-info (tru "Invalid metabase managed AI provider {0}. Must start with {1}/."
+                         (pr-str value) provider-util/metabase-provider-prefix)
+                    {:status-code 400
+                     :value       value})))
+  (let [inner-provider    (provider-util/provider-and-model->provider value)
+        inner-model       (provider-util/provider-and-model->model value)
+        allowed-providers (sort (keys proxied-providers-and-models))
+        allowed-models    (get proxied-providers-and-models inner-provider)]
+    (when-not (contains? proxied-providers-and-models inner-provider)
+      (throw (ex-info (tru "Unsupported provider {0} for metabase managed AI. Supported providers: {1}"
+                           (pr-str inner-provider)
+                           (str/join ", " allowed-providers))
+                      {:status-code 400
+                       :provider    inner-provider
+                       :supported   (set (keys proxied-providers-and-models))})))
+    (when (str/blank? inner-model)
+      (throw (ex-info (tru "Model name is required. Expected format: metabase/provider/model, e.g. {0}"
+                           (pr-str default-metabase-llm-metabot-provider))
+                      {:status-code 400
+                       :value       value})))
+    (when-not (contains? allowed-models inner-model)
+      (throw (ex-info (tru "Unsupported model {0} for metabase managed provider {1}. Supported models: {2}"
+                           (pr-str inner-model)
+                           (pr-str inner-provider)
+                           (str/join ", " (sort allowed-models)))
+                      {:status-code 400
+                       :provider    inner-provider
+                       :model       inner-model
+                       :supported   allowed-models})))))
+
 (defn- validate-metabot-provider!
   "Validate that `value` has the format `provider/model` with a supported provider prefix.
-  For `metabase/` prefix, validates the inner provider too (e.g. `metabase/anthropic/model`).
+  Dispatches to [[validate-metabase-managed-provider!]] when `value` uses the
+  `metabase/` proxy prefix and to [[validate-direct-provider!]] otherwise.
   Throws an exception with `:status-code 400` on invalid input."
   [value]
   (when-not (string? value)
     (throw (ex-info (tru "Metabot provider must be a string, got: {0}" (pr-str value))
                     {:status-code 400})))
-  (let [outer-provider (provider-util/provider-and-model->outer-provider value)]
-    (when-not (contains? supported-metabot-providers outer-provider)
-      (throw (ex-info (tru "Unknown provider {0}. Supported providers: {1}"
-                           (pr-str outer-provider) (str/join ", " (sort supported-metabot-providers)))
-                      {:status-code 400
-                       :provider    outer-provider
-                       :supported   supported-metabot-providers})))
-    (when (str/blank? (provider-util/provider-and-model->model value))
-      (throw (ex-info (tru "Model name is required. Expected format: provider/model, e.g. \"anthropic/claude-haiku-4-5\"")
-                      {:status-code 400
-                       :value       value})))
-    ;; For metabase/ prefix, validate the inner provider
-    (when (= outer-provider provider-util/metabase-provider-prefix)
-      (let [inner-provider (provider-util/provider-and-model->provider value)
-            inner-model    (provider-util/provider-and-model->model value)]
-        (when-not (contains? direct-providers inner-provider)
-          (throw (ex-info (tru "Unknown inner provider {0} in metabase/ prefix. Supported: {1}"
-                               (pr-str inner-provider) (str/join ", " (sort direct-providers)))
-                          {:status-code 400
-                           :provider    inner-provider
-                           :supported   direct-providers})))
-        (when (str/blank? inner-model)
-          (throw (ex-info (tru "Model name is required. Expected format: metabase/provider/model, e.g. \"metabase/anthropic/claude-haiku-4-5\"")
-                          {:status-code 400
-                           :value       value})))))))
+  (if (provider-util/metabase-provider? value)
+    (validate-metabase-managed-provider! value)
+    (validate-direct-provider! value)))
 
 (defsetting llm-metabot-provider
   (deferred-tru "The AI provider and model for Metabot. Format: provider/model-name, e.g. `anthropic/claude-haiku-4-5`, `openai/gpt-4.1-mini`, `openrouter/anthropic/claude-haiku-4-5`.")

--- a/test/metabase/metabot/api_test.clj
+++ b/test/metabase/metabot/api_test.clj
@@ -319,14 +319,14 @@
                                               {:models [{:id "claude-haiku-4-5" :display_name "Claude Haiku 4.5"}
                                                         {:id "claude-sonnet-4-6" :display_name "Claude Sonnet 4.6"}
                                                         {:id "claude-opus-4-1" :display_name "Claude Opus 4.1"}]}))]
-      (is (= {:value  "metabase/anthropic/claude-opus-4-1"
+      (is (= {:value  "metabase/anthropic/claude-sonnet-4-6"
               :models [{:id "anthropic/claude-haiku-4-5" :display_name "Claude Haiku 4.5"}
                        {:id "anthropic/claude-sonnet-4-6" :display_name "Claude Sonnet 4.6"}
                        {:id "anthropic/claude-opus-4-1" :display_name "Claude Opus 4.1"}]}
              (mt/user-http-request :crowberto :put 200 "metabot/settings"
                                    {:provider "metabase"
-                                    :model    "anthropic/claude-opus-4-1"})))
-      (is (= "metabase/anthropic/claude-opus-4-1"
+                                    :model    "anthropic/claude-sonnet-4-6"})))
+      (is (= "metabase/anthropic/claude-sonnet-4-6"
              (metabot.settings/llm-metabot-provider))))))
 
 (deftest settings-put-defaults-empty-metabase-model-test

--- a/test/metabase/metabot/settings_test.clj
+++ b/test/metabase/metabot/settings_test.clj
@@ -79,34 +79,34 @@
 (deftest metabot-configured-with-metabase-provider-and-proxy-url-test
   (testing "returns true when metabase-proxied provider and proxy URL is set"
     (mt/with-premium-features #{:metabase-ai-managed}
-      (mt/with-temporary-setting-values [llm-metabot-provider "metabase/anthropic/claude-sonnet-4"
+      (mt/with-temporary-setting-values [llm-metabot-provider "metabase/anthropic/claude-sonnet-4-6"
                                          llm-proxy-base-url   "https://proxy.example.com"]
         (is (true? (metabot.settings/llm-metabot-configured?)))))))
 
 (deftest metabot-configured-with-metabase-provider-no-proxy-url-test
   (testing "returns false when metabase-proxied provider and no proxy URL"
     (mt/with-premium-features #{:metabase-ai-managed}
-      (mt/with-temporary-setting-values [llm-metabot-provider "metabase/anthropic/claude-sonnet-4"
+      (mt/with-temporary-setting-values [llm-metabot-provider "metabase/anthropic/claude-sonnet-4-6"
                                          llm-proxy-base-url   nil]
         (is (false? (metabot.settings/llm-metabot-configured?)))))))
 
 (deftest metabot-configured-with-direct-provider-and-api-key-test
   (testing "returns true when direct provider has API key set"
-    (mt/with-temporary-setting-values [llm-metabot-provider  "anthropic/claude-sonnet-4"
+    (mt/with-temporary-setting-values [llm-metabot-provider  "anthropic/claude-sonnet-4-6"
                                        llm-anthropic-api-key "sk-ant-test"]
       (is (true? (metabot.settings/llm-metabot-configured?))))))
 
 (deftest metabot-configured-with-direct-provider-no-api-key-test
   (testing "returns false when direct provider has no API key"
     (with-redefs [llm.settings/llm-anthropic-api-key (constantly nil)]
-      (mt/with-temporary-setting-values [llm-metabot-provider "anthropic/claude-sonnet-4"]
+      (mt/with-temporary-setting-values [llm-metabot-provider "anthropic/claude-sonnet-4-6"]
         (is (false? (metabot.settings/llm-metabot-configured?)))))))
 
 (deftest metabot-configured-proxy-url-not-fallback-for-direct-provider-test
   (testing "proxy URL alone does not make a direct provider configured"
     (mt/with-premium-features #{:metabase-ai-managed}
       (with-redefs [llm.settings/llm-anthropic-api-key (constantly nil)]
-        (mt/with-temporary-setting-values [llm-metabot-provider "anthropic/claude-sonnet-4"
+        (mt/with-temporary-setting-values [llm-metabot-provider "anthropic/claude-sonnet-4-6"
                                            llm-proxy-base-url   "https://proxy.example.com"]
           (is (false? (metabot.settings/llm-metabot-configured?))))))))
 
@@ -131,12 +131,34 @@
          clojure.lang.ExceptionInfo #"Model name is required"
          (metabot.settings/llm-metabot-provider! "anthropic/")))))
 
-(deftest validate-metabot-provider-rejects-unknown-inner-provider-test
+(deftest validate-metabot-provider-rejects-unknown-metabase-managed-provider-test
   (testing "rejects unknown inner provider under metabase/ prefix"
     (mt/with-premium-features #{:metabase-ai-managed}
       (is (thrown-with-msg?
-           clojure.lang.ExceptionInfo #"Unknown inner provider"
+           clojure.lang.ExceptionInfo #"Unsupported provider \"foobar\" for metabase managed AI"
            (metabot.settings/llm-metabot-provider! "metabase/foobar/some-model"))))))
+
+(deftest validate-metabot-provider-rejects-direct-only-provider-as-managed-openai-test
+  (testing "rejects openai under metabase/ prefix (not in the managed allow-list)"
+    (mt/with-premium-features #{:metabase-ai-managed}
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"Unsupported provider \"openai\" for metabase managed AI"
+           (metabot.settings/llm-metabot-provider! "metabase/openai/gpt-4.1-mini"))))))
+
+(deftest validate-metabot-provider-rejects-direct-only-provider-as-managed-openrouter-test
+  (testing "rejects openrouter under metabase/ prefix (not in the managed allow-list)"
+    (mt/with-premium-features #{:metabase-ai-managed}
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"Unsupported provider \"openrouter\" for metabase managed AI"
+           (metabot.settings/llm-metabot-provider! "metabase/openrouter/anthropic/claude-haiku-4-5"))))))
+
+(deftest validate-metabot-provider-rejects-unsupported-metabase-managed-model-test
+  (testing "rejects unsupported model for an allowed metabase managed provider"
+    (mt/with-premium-features #{:metabase-ai-managed}
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"Unsupported model \"claude-haiku-4-5\" for metabase managed provider \"anthropic\""
+           (metabot.settings/llm-metabot-provider! "metabase/anthropic/claude-haiku-4-5"))))))
 
 (deftest validate-metabot-provider-rejects-metabase-prefix-without-model-test
   (testing "rejects metabase/provider with no model"
@@ -145,19 +167,23 @@
            clojure.lang.ExceptionInfo #"Model name is required"
            (metabot.settings/llm-metabot-provider! "metabase/anthropic/"))))))
 
-(deftest validate-metabot-provider-accepts-valid-direct-providers-test
-  (testing "accepts valid direct provider strings"
-    (mt/with-temporary-setting-values [llm-metabot-provider "anthropic/claude-sonnet-4"]
-      (is (= "anthropic/claude-sonnet-4" (metabot.settings/llm-metabot-provider))))
+(deftest validate-metabot-provider-accepts-valid-direct-anthropic-test
+  (testing "accepts valid direct anthropic provider string"
+    (mt/with-temporary-setting-values [llm-metabot-provider "anthropic/claude-sonnet-4-6"]
+      (is (= "anthropic/claude-sonnet-4-6" (metabot.settings/llm-metabot-provider))))))
+
+(deftest validate-metabot-provider-accepts-valid-direct-openai-test
+  (testing "accepts valid direct openai provider string"
     (mt/with-temporary-setting-values [llm-metabot-provider "openai/gpt-4.1-mini"]
-      (is (= "openai/gpt-4.1-mini" (metabot.settings/llm-metabot-provider))))
+      (is (= "openai/gpt-4.1-mini" (metabot.settings/llm-metabot-provider))))))
+
+(deftest validate-metabot-provider-accepts-valid-direct-openrouter-test
+  (testing "accepts valid direct openrouter provider string"
     (mt/with-temporary-setting-values [llm-metabot-provider "openrouter/anthropic/claude-haiku-4-5"]
       (is (= "openrouter/anthropic/claude-haiku-4-5" (metabot.settings/llm-metabot-provider))))))
 
-(deftest validate-metabot-provider-accepts-valid-metabase-prefixed-test
-  (testing "accepts valid metabase/ prefixed provider strings"
+(deftest validate-metabot-provider-accepts-allowed-metabase-managed-provider-and-model-test
+  (testing "accepts allow-listed metabase managed provider/model"
     (mt/with-premium-features #{:metabase-ai-managed}
-      (mt/with-temporary-setting-values [llm-metabot-provider "metabase/anthropic/claude-sonnet-4"]
-        (is (= "metabase/anthropic/claude-sonnet-4" (metabot.settings/llm-metabot-provider))))
-      (mt/with-temporary-setting-values [llm-metabot-provider "metabase/openrouter/anthropic/claude-haiku-4-5"]
-        (is (= "metabase/openrouter/anthropic/claude-haiku-4-5" (metabot.settings/llm-metabot-provider)))))))
+      (mt/with-temporary-setting-values [llm-metabot-provider "metabase/anthropic/claude-sonnet-4-6"]
+        (is (= "metabase/anthropic/claude-sonnet-4-6" (metabot.settings/llm-metabot-provider)))))))

--- a/test/metabase/slackbot/streaming_test.clj
+++ b/test/metabase/slackbot/streaming_test.clj
@@ -157,7 +157,7 @@
         (tu/with-slackbot-mocks
           {:ai-text "Hello!"}
           (fn [{:keys [stop-stream-calls]}]
-            (mt/with-temporary-setting-values [llm-metabot-provider "metabase/anthropic/claude-haiku-4-5"]
+            (mt/with-temporary-setting-values [llm-metabot-provider "metabase/anthropic/claude-sonnet-4-6"]
               (with-redefs [metabot.persistence/store-message!
                             (fn [_conv-id _profile-id _messages & {:as opts}]
                               (swap! store-opts conj opts)


### PR DESCRIPTION
Closes [BOT-1285: Restrict metabase providers to anthropic and model to claude-sonnet-4-6](https://linear.app/metabase/issue/BOT-1285/restrict-metabase-providers-to-anthropic-and-model-to-claude-sonnet-4)

### Description

We only support anthropic and claude-sonnet-4-6 for billing purposes, so update the provider validation logic in metabase to reject anything else. Currently the FE only ever configures anthropic + sonnet, but we should also enforce it in the BE.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
