### PR TITLE
Fix serdes export perf with database metadata - id lookup

### DIFF
--- a/src/metabase/actions/models.clj
+++ b/src/metabase/actions/models.clj
@@ -426,7 +426,7 @@
    :skip      [;; this is a temporary column to power v57 => v56 rollbacks, and we can remove it in v58.
                :legacy_query]
    :transform {:action_id     (serdes/parent-ref)
-               :database_id   (serdes/fk :model/Database :name)
+               :database_id   (serdes/fk :model/Database)
                :dataset_query {:export serdes/export-mbql :import serdes/import-mbql}}})
 
 (defmethod serdes/generate-path "HTTPAction" [_ _] nil)

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -1087,7 +1087,8 @@
 ;;; ## Tables
 
 (defn- batch-load-tables
-  "Loads the table with `id` plus FK-connected tables, up to `max-batch` total."
+  "Loads the table with `id` plus FK-connected tables, up to `max-batch` total.
+   A database may have millions of tables due to partitioning, so we must respect the limit."
   [id max-batch]
   (let [target       (t2/select-pk->fn identity [:model/Table :id :db_id :name :schema] :id id)
         remaining    (- max-batch (count target))
@@ -1204,7 +1205,8 @@
 
 (defn- batch-load-fields
   "Loads the requested field, its parent_id chain (via recursive CTE), and additional
-   fields from the same table and FK-connected tables, up to `max-batch` total."
+   fields from the same table and FK-connected tables, up to `max-batch` total.
+   A table may have millions of fields due to JSON unfolding, so we must respect the limit."
   [field-id max-batch]
   (let [required  (load-field-hierarchy field-id)
         remaining (- max-batch (count required))]

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -1033,10 +1033,11 @@
   50000)
 
 (defn- make-batch-cache
-  "Returns a fn `(f id) -> entity`. On miss, calls `(load-fn id)` which must
-   return a map of `{id entity, ...}`. All returned entries are merged into
-   the cache so sibling lookups become hits.
-   When the cache exceeds `*batch-cache-max-size*`, the oldest half is dropped."
+  "Returns a fn `(f id) -> entity`. On miss, calls `(load-fn id max-batch)` which must
+   return a map of `{id entity, ...}`. `max-batch` is the maximum number of entries to return.
+   All returned entries are merged into the cache so sibling lookups become hits.
+   When the cache exceeds `*batch-cache-max-size*`, enough old entries are dropped to make room,
+   dropping at least half the cache."
   [load-fn]
   (let [cache (atom {})
         order (atom clojure.lang.PersistentQueue/EMPTY)]
@@ -1044,19 +1045,25 @@
       (let [v (get @cache id ::not-found)]
         (if-not (identical? v ::not-found)
           v
-          (let [new-batch (load-fn id)]
+          (let [new-batch (load-fn id *batch-cache-max-size*)]
             (swap! cache merge new-batch)
             (swap! order into (keys new-batch))
             (when (> (count @cache) *batch-cache-max-size*)
-              (let [to-drop (quot (count @cache) 2)]
+              (let [to-drop (max (quot (count @cache) 2)
+                                 (- (count @cache) *batch-cache-max-size*))]
                 (swap! order #(into clojure.lang.PersistentQueue/EMPTY (drop to-drop) %))
                 (swap! cache #(select-keys % @order))))
             (get new-batch id)))))))
 
 (defn- batch-load-databases
-  "Loads all databases as a map of `{id entity}`."
-  [_id]
-  (t2/select-pk->fn identity [:model/Database :id :name]))
+  "Loads the requested database plus other databases up to `max-batch`."
+  [id max-batch]
+  (let [target (t2/select-pk->fn identity [:model/Database :id :name] :id id)
+        others (when (> max-batch 1)
+                 (t2/select-pk->fn identity [:model/Database :id :name]
+                                   :id [:not= id]
+                                   {:limit (dec max-batch)}))]
+    (merge target others)))
 
 (defn- export-database-fk
   "Given a numeric database ID and a fn that resolves it to a database entity,
@@ -1080,20 +1087,21 @@
 ;;; ## Tables
 
 (defn- batch-load-tables
-  "Loads the table with `id` plus all tables referenced via FK target fields,
-   returned as a map of `{id entity}`."
-  [id]
-  (t2/select-pk->fn identity [:model/Table :id :db_id :name :schema]
-                    {:where [:or
-                             [:= :id id]
-                             [:in :id {:select [[:mf2.table_id]]
-                                       :from   [[:metabase_field :mf2]]
-                                       :where  [:in :mf2.id
-                                                {:select [[:mf.fk_target_field_id]]
-                                                 :from   [[:metabase_field :mf]]
-                                                 :where  [:and
-                                                          [:= :mf.table_id id]
-                                                          [:!= :mf.fk_target_field_id nil]]}]}]]}))
+  "Loads the table with `id` plus FK-connected tables, up to `max-batch` total."
+  [id max-batch]
+  (let [target       (t2/select-pk->fn identity [:model/Table :id :db_id :name :schema] :id id)
+        remaining    (- max-batch (count target))
+        fk-field-ids (when (pos? remaining)
+                       (t2/select-fn-set :fk_target_field_id :model/Field
+                                         :table_id id
+                                         :fk_target_field_id [:not= nil]))
+        fk-table-ids (when (seq fk-field-ids)
+                       (t2/select-fn-set :table_id :model/Field :id [:in fk-field-ids]))
+        fk-tables    (when (seq fk-table-ids)
+                       (t2/select-pk->fn identity [:model/Table :id :db_id :name :schema]
+                                         :id [:in fk-table-ids]
+                                         {:limit remaining}))]
+    (merge target fk-tables)))
 
 (defn- export-table-fk
   "Given a numeric table ID, a fn that resolves it to a table entity, and a fn
@@ -1177,23 +1185,43 @@
           field-names (field-name-chain field-id field-fn)]
       (into table-ref field-names))))
 
+(defn- load-field-hierarchy
+  "Loads the field with `id` and all its ancestors (via parent_id) in a single
+   recursive CTE query. Returns a map of `{id entity}`."
+  [id]
+  (into {}
+        (map (juxt :id identity))
+        (t2/select :model/Field
+                   {:with-recursive [[[:parents {:columns [:id :name :parent_id :table_id]}]
+                                      {:union-all [{:from   [[:metabase_field :mf]]
+                                                    :select [:mf.id :mf.name :mf.parent_id :mf.table_id]
+                                                    :where  [:= :id id]}
+                                                   {:from   [[:metabase_field :pf]]
+                                                    :select [:pf.id :pf.name :pf.parent_id :pf.table_id]
+                                                    :join   [[:parents :p] [:= :p.parent_id :pf.id]]}]}]]
+                    :from           [:parents]
+                    :select         [:id :name :parent_id :table_id]})))
+
 (defn- batch-load-fields
-  "Loads all fields for the same table as `field-id`, plus all fields in
-   FK-connected tables, returned as a map of `{id entity}`."
-  [field-id]
-  (t2/select-pk->fn identity [:model/Field :id :name :table_id :parent_id]
-                    {:where [:in :table_id
-                             {:select [:table_id]
-                              :from   [:metabase_field]
-                              :where  [:or
-                                       [:= :id field-id]
-                                       [:in :id {:select [:fk_target_field_id]
-                                                 :from   [:metabase_field]
-                                                 :where  [:and
-                                                          [:= :table_id {:select [:table_id]
-                                                                         :from   [:metabase_field]
-                                                                         :where  [:= :id field-id]}]
-                                                          [:!= :fk_target_field_id nil]]}]]}]}))
+  "Loads the requested field, its parent_id chain (via recursive CTE), and additional
+   fields from the same table and FK-connected tables, up to `max-batch` total."
+  [field-id max-batch]
+  (let [required  (load-field-hierarchy field-id)
+        remaining (- max-batch (count required))]
+    (if-not (pos? remaining)
+      required
+      (let [table-id      (:table_id (get required field-id))
+            fk-field-ids  (t2/select-fn-set :fk_target_field_id :model/Field
+                                            :table_id table-id
+                                            :fk_target_field_id [:not= nil])
+            fk-table-ids  (when (seq fk-field-ids)
+                            (t2/select-fn-set :table_id :model/Field :id [:in fk-field-ids]))
+            all-table-ids (cond-> #{table-id} (seq fk-table-ids) (into fk-table-ids))
+            extras        (t2/select-pk->fn identity [:model/Field :id :name :table_id :parent_id]
+                                            :id [:not-in (set (keys required))]
+                                            :table_id [:in all-table-ids]
+                                            {:limit remaining})]
+        (merge required extras)))))
 
 (defn recursively-find-field-q
   "Build a query to find a field among parents (should start with bottom-most field first), i.e.:

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -1028,7 +1028,7 @@
 
 ;;; ## Databases
 
-(def ^:private ^:dynamic *batch-cache-max-size*
+(def ^:dynamic *batch-cache-max-size*
   "Maximum number of entries in a batch cache before old entries are dropped."
   50000)
 
@@ -1036,8 +1036,9 @@
   "Returns a fn `(f id) -> entity`. On miss, calls `(load-fn id max-batch)` which must
    return a map of `{id entity, ...}`. `max-batch` is the maximum number of entries to return.
    All returned entries are merged into the cache so sibling lookups become hits.
-   When the cache exceeds `*batch-cache-max-size*`, enough old entries are dropped to make room,
-   dropping at least half the cache."
+   When old entries plus new batch exceed `*batch-cache-max-size*`, old entries are dropped.
+   New batch entries are never evicted, so the cache may temporarily exceed the limit
+   (e.g. a field parent_id chain longer than the limit)."
   [load-fn]
   (let [cache (atom {})
         order (atom clojure.lang.PersistentQueue/EMPTY)]
@@ -1045,14 +1046,17 @@
       (let [v (get @cache id ::not-found)]
         (if-not (identical? v ::not-found)
           v
-          (let [new-batch (load-fn id *batch-cache-max-size*)]
+          (let [new-batch  (load-fn id *batch-cache-max-size*)
+                new-keys   (set (keys new-batch))
+                ;; drop old entries to make room, but never drop new-batch entries
+                old-count  (- (count @cache) (count (filter new-keys (keys @cache))))
+                keep-old   (max 0 (- *batch-cache-max-size* (count new-batch)))]
+            (when (> old-count keep-old)
+              (let [to-drop (- old-count keep-old)]
+                (swap! order #(into clojure.lang.PersistentQueue/EMPTY (drop to-drop) %))
+                (swap! cache #(select-keys % (into new-keys @order)))))
             (swap! cache merge new-batch)
             (swap! order into (keys new-batch))
-            (when (> (count @cache) *batch-cache-max-size*)
-              (let [to-drop (max (quot (count @cache) 2)
-                                 (- (count @cache) *batch-cache-max-size*))]
-                (swap! order #(into clojure.lang.PersistentQueue/EMPTY (drop to-drop) %))
-                (swap! cache #(select-keys % @order))))
             (get new-batch id)))))))
 
 (defn- batch-load-databases

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -1028,11 +1028,39 @@
 
 ;;; ## Databases
 
-(defn ^:dynamic ^::cache *export-database-fk*
+(def ^:private cache-miss (Object.))
+
+(defn- make-batch-cache
+  "Returns a fn `(f id) -> entity`. On miss, calls `(load-fn id)` which must
+   return a map of `{id entity, ...}`. All returned entries are merged into
+   the cache so sibling lookups become hits."
+  [load-fn]
+  (let [cache (atom {})]
+    (fn [id]
+      (let [v (get @cache id cache-miss)]
+        (if-not (identical? v cache-miss)
+          v
+          (let [id->entity (load-fn id)]
+            (swap! cache merge id->entity)
+            (get id->entity id)))))))
+
+(defn- batch-load-databases
+  "Loads all databases as a map of `{id entity}`."
+  [_id]
+  (t2/select-pk->fn identity [:model/Database :id :name]))
+
+(defn- export-database-fk
+  "Given a numeric database ID and a fn that resolves it to a database entity,
+   return its name as a portable reference."
+  [id db-fn]
+  (when id
+    (:name (db-fn id))))
+
+(defn ^:dynamic *export-database-fk*
   "Given a numeric database ID, return its name as a portable reference.
   [[*import-database-fk*]] is the inverse."
   [id]
-  (*export-fk-keyed* id :model/Database :name))
+  (export-database-fk id #(t2/select-one [:model/Database :id :name] :id %)))
 
 (defn ^:dynamic ^::cache *import-database-fk*
   "Given a portable database name, resolve it back to a numeric ID.
@@ -1042,16 +1070,39 @@
 
 ;;; ## Tables
 
-(mu/defn ^:dynamic ^::cache *export-table-fk*
+(defn- batch-load-tables
+  "Loads the table with `id` plus all tables referenced via FK target fields,
+   returned as a map of `{id entity}`."
+  [id]
+  (t2/select-pk->fn identity [:model/Table :id :db_id :name :schema]
+                    {:where [:or
+                             [:= :id id]
+                             [:in :id {:select [[:mf2.table_id]]
+                                       :from   [[:metabase_field :mf2]]
+                                       :where  [:in :mf2.id
+                                                {:select [[:mf.fk_target_field_id]]
+                                                 :from   [[:metabase_field :mf]]
+                                                 :where  [:and
+                                                          [:= :mf.table_id id]
+                                                          [:!= :mf.fk_target_field_id nil]]}]}]]}))
+
+(defn- export-table-fk
+  "Given a numeric table ID, a fn that resolves it to a table entity, and a fn
+   that resolves a database ID to a database entity, return `[db-name schema table-name]`."
+  [id table-fn db-fn]
+  (when id
+    (let [table (table-fn id)]
+      [(export-database-fk (:db_id table) db-fn) (:schema table) (:name table)])))
+
+(mu/defn ^:dynamic *export-table-fk*
   "Given a numeric `table_id`, return a portable table reference.
   If the `table_id` is `nil`, return `nil`. This is legal for a native question.
   That has the form `[db-name schema table-name]`, where the `schema` might be nil.
   [[import-table-fk]] is the inverse."
   [table-id :- [:maybe ::lib.schema.id/table]]
-  (when table-id
-    (let [{:keys [db_id name schema]} (t2/select-one :model/Table :id table-id)
-          db-name                     (t2/select-one-fn :name :model/Database :id db_id)]
-      [db-name schema name])))
+  (export-table-fk table-id
+                   #(t2/select-one [:model/Table :id :db_id :name :schema] :id %)
+                   #(t2/select-one [:model/Database :id :name] :id %)))
 
 (mu/defn ^:dynamic ^::cache *import-table-fk*
   "Given a `table_id` as exported by [[export-table-fk]], resolve it back into a numeric `table_id`.
@@ -1096,18 +1147,44 @@
 
 ;;; ## Fields
 
-(defn- field-hierarchy [id]
-  (reverse
-   (t2/select :model/Field
-              {:with-recursive [[[:parents {:columns [:id :name :parent_id :table_id]}]
-                                 {:union-all [{:from   [[:metabase_field :mf]]
-                                               :select [:mf.id :mf.name :mf.parent_id :mf.table_id]
-                                               :where  [:= :id id]}
-                                              {:from   [[:metabase_field :pf]]
-                                               :select [:pf.id :pf.name :pf.parent_id :pf.table_id]
-                                               :join   [[:parents :p] [:= :p.parent_id :pf.id]]}]}]]
-               :from           [:parents]
-               :select         [:name :table_id]})))
+(defn- field-name-chain
+  "Walks parent_id chain in memory using `field-fn` to resolve each field.
+   Returns a seq of field names from root parent to the given field."
+  [field-id field-fn]
+  (loop [id field-id
+         names ()]
+    (let [field (field-fn id)]
+      (if-let [pid (:parent_id field)]
+        (recur pid (cons (:name field) names))
+        (cons (:name field) names)))))
+
+(defn- export-field-fk
+  "Given a numeric field ID and lookup fns for fields, tables, and databases,
+   return `[db-name schema table-name & field-names]`."
+  [field-id field-fn table-fn db-fn]
+  (when field-id
+    (let [field (field-fn field-id)
+          table-ref (export-table-fk (:table_id field) table-fn db-fn)
+          names (field-name-chain field-id field-fn)]
+      (into table-ref names))))
+
+(defn- batch-load-fields
+  "Loads all fields for the same table as `field-id`, plus all fields in
+   FK-connected tables, returned as a map of `{id entity}`."
+  [field-id]
+  (t2/select-pk->fn identity [:model/Field :id :name :table_id :parent_id]
+                    {:where [:in :table_id
+                             {:select [:table_id]
+                              :from   [:metabase_field]
+                              :where  [:or
+                                       [:= :id field-id]
+                                       [:in :id {:select [:fk_target_field_id]
+                                                 :from   [:metabase_field]
+                                                 :where  [:and
+                                                          [:= :table_id {:select [:table_id]
+                                                                         :from   [:metabase_field]
+                                                                         :where  [:= :id field-id]}]
+                                                          [:!= :fk_target_field_id nil]]}]]}]})))
 
 (defn recursively-find-field-q
   "Build a query to find a field among parents (should start with bottom-most field first), i.e.:
@@ -1122,15 +1199,15 @@
               [:= :name field]
               [:= :parent_id (recursively-find-field-q table-id rest)]]}))
 
-(mu/defn ^:dynamic ^::cache *export-field-fk*
+(mu/defn ^:dynamic *export-field-fk*
   "Given a numeric `field_id`, return a portable field reference.
   That has the form `[db-name schema table-name field-name]`, where the `schema` might be nil.
   [[*import-field-fk*]] is the inverse."
   [field-id :- [:maybe ::lib.schema.id/field]]
-  (when field-id
-    (let [fields                      (field-hierarchy field-id)
-          [db-name schema field-name] (*export-table-fk* (:table_id (first fields)))]
-      (into [db-name schema field-name] (map :name fields)))))
+  (export-field-fk field-id
+                   #(t2/select-one [:model/Field :id :name :table_id :parent_id] :id %)
+                   #(t2/select-one [:model/Table :id :db_id :name :schema] :id %)
+                   #(t2/select-one [:model/Database :id :name] :id %)))
 
 (mu/defn ^:dynamic ^::cache *import-field-fk* :- [:maybe pos-int?]
   "Given a `field_id` as exported by [[*export-field-fk*]], resolve it back into a numeric `field_id`."
@@ -1919,7 +1996,7 @@
 
 ;;; ## Memoizing appdb lookups
 
-(defmacro with-cache
+(defmacro with-memoize-cache
   "Runs body with all functions marked with ::cache re-bound to memoized versions for performance."
   [& body]
   (let [ns* 'metabase.models.serialization]
@@ -1929,3 +2006,23 @@
                              :let [fq-sym (symbol (name ns*) (name var-sym))]]
                          [fq-sym `(memoize ~fq-sym)]))
        ~@body)))
+
+(defmacro with-batch-cache
+  "Rebinds database/table export fns to versions backed by batch-loading caches."
+  [& body]
+  `(let [db-cache#    (make-batch-cache batch-load-databases)
+         table-cache# (make-batch-cache batch-load-tables)
+         field-cache# (make-batch-cache batch-load-fields)]
+     (binding [*export-database-fk* (fn [id#]
+                                      (export-database-fk id# db-cache#))
+               *export-table-fk*    (fn [table-id#]
+                                      (export-table-fk table-id# table-cache# db-cache#))
+               *export-field-fk*    (fn [field-id#]
+                                      (export-field-fk field-id# field-cache# table-cache# db-cache#))]
+       ~@body)))
+
+(defmacro with-cache
+  "Runs body with all functions marked with ::cache re-bound to memoized versions for performance,
+   and with database/table lookups backed by batch-loading caches."
+  [& body]
+  `(with-batch-cache (with-memoize-cache ~@body)))

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -1030,19 +1030,30 @@
 
 (def ^:private cache-miss (Object.))
 
+(def ^:private ^:dynamic *batch-cache-max-size*
+  "Maximum number of entries in a batch cache before old entries are dropped."
+  50000)
+
 (defn- make-batch-cache
   "Returns a fn `(f id) -> entity`. On miss, calls `(load-fn id)` which must
    return a map of `{id entity, ...}`. All returned entries are merged into
-   the cache so sibling lookups become hits."
+   the cache so sibling lookups become hits.
+   When the cache exceeds `*batch-cache-max-size*`, the oldest half is dropped."
   [load-fn]
-  (let [cache (atom {})]
+  (let [cache (atom {})
+        order (atom (clojure.lang.PersistentQueue/EMPTY))]
     (fn [id]
       (let [v (get @cache id cache-miss)]
         (if-not (identical? v cache-miss)
           v
-          (let [id->entity (load-fn id)]
-            (swap! cache merge id->entity)
-            (get id->entity id)))))))
+          (let [new-batch (load-fn id)]
+            (swap! cache merge new-batch)
+            (swap! order into (keys new-batch))
+            (when (> (count @cache) *batch-cache-max-size*)
+              (let [to-drop (quot (count @cache) 2)]
+                (swap! order #(into (clojure.lang.PersistentQueue/EMPTY) (drop to-drop) %))
+                (swap! cache #(select-keys % @order))))
+            (get new-batch id)))))))
 
 (defn- batch-load-databases
   "Loads all databases as a map of `{id entity}`."
@@ -1184,7 +1195,7 @@
                                                           [:= :table_id {:select [:table_id]
                                                                          :from   [:metabase_field]
                                                                          :where  [:= :id field-id]}]
-                                                          [:!= :fk_target_field_id nil]]}]]}]})))
+                                                          [:!= :fk_target_field_id nil]]}]]}]}))
 
 (defn recursively-find-field-q
   "Build a query to find a field among parents (should start with bottom-most field first), i.e.:
@@ -2007,22 +2018,19 @@
                          [fq-sym `(memoize ~fq-sym)]))
        ~@body)))
 
-(defmacro with-batch-cache
-  "Rebinds database/table export fns to versions backed by batch-loading caches."
-  [& body]
-  `(let [db-cache#    (make-batch-cache batch-load-databases)
-         table-cache# (make-batch-cache batch-load-tables)
-         field-cache# (make-batch-cache batch-load-fields)]
-     (binding [*export-database-fk* (fn [id#]
-                                      (export-database-fk id# db-cache#))
-               *export-table-fk*    (fn [table-id#]
-                                      (export-table-fk table-id# table-cache# db-cache#))
-               *export-field-fk*    (fn [field-id#]
-                                      (export-field-fk field-id# field-cache# table-cache# db-cache#))]
-       ~@body)))
+(defn- with-batch-cache
+  "Runs `thunk` with the batch cache bound to the export functions."
+  [thunk]
+  (let [db-cache    (make-batch-cache batch-load-databases)
+        table-cache (make-batch-cache batch-load-tables)
+        field-cache (make-batch-cache batch-load-fields)]
+    (binding [*export-database-fk* #(export-database-fk % db-cache)
+              *export-table-fk*    #(export-table-fk % table-cache db-cache)
+              *export-field-fk*    #(export-field-fk % field-cache table-cache db-cache)]
+      (thunk))))
 
 (defmacro with-cache
   "Runs body with all functions marked with ::cache re-bound to memoized versions for performance,
    and with database/table lookups backed by batch-loading caches."
   [& body]
-  `(with-batch-cache (with-memoize-cache ~@body)))
+  `(with-batch-cache (fn [] (with-memoize-cache ~@body))))

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -1039,7 +1039,7 @@
    When the cache exceeds `*batch-cache-max-size*`, the oldest half is dropped."
   [load-fn]
   (let [cache (atom {})
-        order (atom (clojure.lang.PersistentQueue/EMPTY))]
+        order (atom clojure.lang.PersistentQueue/EMPTY)]
     (fn [id]
       (let [v (get @cache id ::not-found)]
         (if-not (identical? v ::not-found)
@@ -1049,7 +1049,7 @@
             (swap! order into (keys new-batch))
             (when (> (count @cache) *batch-cache-max-size*)
               (let [to-drop (quot (count @cache) 2)]
-                (swap! order #(into (clojure.lang.PersistentQueue/EMPTY) (drop to-drop) %))
+                (swap! order #(into clojure.lang.PersistentQueue/EMPTY (drop to-drop) %))
                 (swap! cache #(select-keys % @order))))
             (get new-batch id)))))))
 

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -1028,8 +1028,6 @@
 
 ;;; ## Databases
 
-(def ^:private cache-miss (Object.))
-
 (def ^:private ^:dynamic *batch-cache-max-size*
   "Maximum number of entries in a batch cache before old entries are dropped."
   50000)
@@ -1043,8 +1041,8 @@
   (let [cache (atom {})
         order (atom (clojure.lang.PersistentQueue/EMPTY))]
     (fn [id]
-      (let [v (get @cache id cache-miss)]
-        (if-not (identical? v cache-miss)
+      (let [v (get @cache id ::not-found)]
+        (if-not (identical? v ::not-found)
           v
           (let [new-batch (load-fn id)]
             (swap! cache merge new-batch)

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -1176,8 +1176,8 @@
   (when field-id
     (let [field (field-fn field-id)
           table-ref (export-table-fk (:table_id field) table-fn db-fn)
-          names (field-name-chain field-id field-fn)]
-      (into table-ref names))))
+          field-names (field-name-chain field-id field-fn)]
+      (into table-ref field-names))))
 
 (defn- batch-load-fields
   "Loads all fields for the same table as `field-id`, plus all fields in
@@ -2018,7 +2018,7 @@
                          [fq-sym `(memoize ~fq-sym)]))
        ~@body)))
 
-(defn- with-batch-cache
+(defn with-batch-cache
   "Runs `thunk` with the batch cache bound to the export functions."
   [thunk]
   (let [db-cache    (make-batch-cache batch-load-databases)

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -35,7 +35,7 @@
 
   ## Existing transformations
 
-  - `(serdes/fk :model/Card)` or `(serdes/fk :model/Database :name)` - export foreign key in a portable way
+  - `(serdes/fk :model/Card)` or `(serdes/fk :model/Database)` - export foreign key in a portable way
   - `(serdes/nested :model/DashboardCard :dashboard_id opts)` - include some entities in your entity export
   - `(serdes/parent-ref)` - symmetrical call for `serdes/nested` to handle parent ids (you'd use it on `:dashboard_id`
     in that case)

--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -1328,7 +1328,7 @@
           :legacy_query]
    :transform
    {:created_at             (serdes/date)
-    :database_id            (serdes/fk :model/Database :name)
+    :database_id            (serdes/fk :model/Database)
     :table_id               (serdes/fk :model/Table)
     :source_card_id         (serdes/fk :model/Card)
     :collection_id          (serdes/fk :model/Collection)

--- a/src/metabase/transforms/models/transform.clj
+++ b/src/metabase/transforms/models/transform.clj
@@ -364,7 +364,7 @@
                :creator_id         (serdes/fk :model/User)
                :owner_user_id      (serdes/fk :model/User)
                :collection_id      (serdes/fk :model/Collection)
-               :source_database_id (serdes/fk :model/Database :name)
+               :source_database_id (serdes/fk :model/Database)
                :source             {:export (fn [source]
                                               (-> source
                                                   (m/update-existing :query serdes/export-mbql)

--- a/src/metabase/warehouse_schema/models/field.clj
+++ b/src/metabase/warehouse_schema/models/field.clj
@@ -420,8 +420,8 @@
 
 ;; In order to retrieve the dependencies for a field its table_id needs to be serialized as [database schema table],
 ;; a trio of strings with schema maybe nil.
-(defmethod serdes/generate-path "Field" [_ field]
-  (let [[db schema table & fields] (serdes/*export-field-fk* (:id field))]
+(defmethod serdes/generate-path "Field" [_ {:keys [id]}]
+  (let [[db schema table & fields] (serdes/*export-field-fk* id)]
     (->> (into (serdes/table->path [db schema table])
                (map (fn [n] {:model "Field" :id n}) fields))
          (filterv some?))))

--- a/src/metabase/warehouse_schema/models/field_user_settings.clj
+++ b/src/metabase/warehouse_schema/models/field_user_settings.clj
@@ -41,9 +41,8 @@
 (defmethod serdes/entity-id "FieldUserSettings" [_ _] nil)
 
 (defmethod serdes/generate-path "FieldUserSettings" [_ {:keys [field_id]}]
-  (let [field (t2/select-one 'Field :id field_id)]
-    (conj (serdes/generate-path "Field" field)
-          {:model "FieldUserSettings" :id "1"})))
+  (conj (serdes/generate-path "Field" {:id field_id})
+        {:model "FieldUserSettings" :id "1"}))
 
 (defmethod serdes/dependencies "FieldUserSettings" [fv]
   ;; Take the path, but drop the FieldUserSettings section at the end, to get the parent Field's path instead.

--- a/src/metabase/warehouse_schema/models/field_values.clj
+++ b/src/metabase/warehouse_schema/models/field_values.clj
@@ -571,9 +571,8 @@
 (defmethod serdes/entity-id "FieldValues" [_ _] nil)
 
 (defmethod serdes/generate-path "FieldValues" [_ {:keys [field_id]}]
-  (let [field (t2/select-one 'Field :id field_id)]
-    (conj (serdes/generate-path "Field" field)
-          {:model "FieldValues" :id "0"})))
+  (conj (serdes/generate-path "Field" {:id field_id})
+        {:model "FieldValues" :id "0"}))
 
 (defmethod serdes/dependencies "FieldValues" [fv]
   ;; Take the path, but drop the FieldValues section at the end, to get the parent Field's path instead.

--- a/src/metabase/warehouse_schema/models/table.clj
+++ b/src/metabase/warehouse_schema/models/table.clj
@@ -708,7 +708,7 @@
                :archived_at    (serdes/date)
                :deactivated_at (serdes/date)
                :data_layer     (serdes/optional-kw)
-               :db_id          (serdes/fk :model/Database :name)
+               :db_id          (serdes/fk :model/Database)
                :collection_id  (serdes/fk :model/Collection)
                :transform_id   (serdes/fk :model/Transform)}
    :defaults {:is_defective_duplicate  false

--- a/src/metabase/warehouse_schema/models/table.clj
+++ b/src/metabase/warehouse_schema/models/table.clj
@@ -680,7 +680,7 @@
     (merge fields segments measures)))
 
 (defmethod serdes/generate-path "Table" [_ table]
-  (let [db-name (t2/select-one-fn :name :model/Database :id (:db_id table))]
+  (let [db-name (serdes/*export-database-fk* (:db_id table))]
     (filterv some? [{:model "Database" :id db-name}
                     (when (:schema table)
                       {:model "Schema" :id (:schema table)})

--- a/src/metabase/warehouses/models/database.clj
+++ b/src/metabase/warehouses/models/database.clj
@@ -648,7 +648,7 @@
                                         ::serdes/skip))
                                     :import identity}
                :creator_id          (serdes/fk :model/User)
-               :router_database_id (serdes/fk :model/Database :name)
+               :router_database_id (serdes/fk :model/Database)
                :initial_sync_status {:export identity :import (constantly "complete")}}
    :defaults {:auto_run_queries true
               :is_attached_dwh  false

--- a/test/metabase/models/serialization_test.clj
+++ b/test/metabase/models/serialization_test.clj
@@ -3,7 +3,8 @@
    [clojure.test :refer :all]
    [metabase.lib.core :as lib]
    [metabase.lib.test-metadata :as meta]
-   [metabase.models.serialization :as serdes]))
+   [metabase.models.serialization :as serdes]
+   [metabase.test :as mt]))
 
 (deftest ^:parallel drop-mbql-5-uuids-on-export-test
   (binding [serdes/*export-field-fk* (constantly ::field-id)]
@@ -194,3 +195,46 @@
                                        :values_source_type   :card
                                        :values_source_config {:card_id 1, :value_field [:field 53 nil]}
                                        :position             0}])))))
+
+(deftest export-database-fk-with-cache-test
+  (testing "3 databases with cache limit 2: evicts and re-loads on miss"
+    (mt/with-temp [:model/Database {db1-id :id} {:name "db1" :engine :h2}
+                   :model/Database {db2-id :id} {:name "db2" :engine :h2}
+                   :model/Database {db3-id :id} {:name "db3" :engine :h2}]
+      (binding [serdes/*batch-cache-max-size* 2]
+        (serdes/with-cache
+          (is (= "db1" (serdes/*export-database-fk* db1-id)))
+          (is (= "db2" (serdes/*export-database-fk* db2-id)))
+          (is (= "db3" (serdes/*export-database-fk* db3-id)))
+          (is (= "db1" (serdes/*export-database-fk* db1-id))))))))
+
+(deftest export-table-fk-with-cache-test
+  (testing "3 tables with FK and cache limit 2: batch-loads FK target, evicts and re-loads"
+    (mt/with-temp [:model/Database {db-id :id} {:name "db" :engine :h2}
+                   :model/Table    {t1-id :id} {:name "t1" :schema "public" :db_id db-id}
+                   :model/Table    {t2-id :id} {:name "t2" :schema "public" :db_id db-id}
+                   :model/Table    {t3-id :id} {:name "t3" :schema nil :db_id db-id}
+                   :model/Field    {f1-id :id} {:name "f1" :table_id t2-id :base_type :type/Integer}
+                   :model/Field    _f2         {:name "f2" :table_id t1-id :base_type :type/Integer
+                                                :fk_target_field_id f1-id}]
+      (binding [serdes/*batch-cache-max-size* 2]
+        (serdes/with-cache
+          (is (= ["db" "public" "t1"] (serdes/*export-table-fk* t1-id)))
+          (is (= ["db" "public" "t2"] (serdes/*export-table-fk* t2-id)))
+          (is (= ["db" nil "t3"]      (serdes/*export-table-fk* t3-id)))
+          (is (= ["db" "public" "t1"] (serdes/*export-table-fk* t1-id))))))))
+
+(deftest export-field-fk-with-cache-test
+  (testing "3-level parent chain with cache limit 2: all ancestors kept even when exceeding limit"
+    (mt/with-temp [:model/Database {db-id :id} {:name "db" :engine :h2}
+                   :model/Table    {t-id :id}  {:name "t" :schema nil :db_id db-id}
+                   :model/Field    {f1-id :id} {:name "f1" :table_id t-id :base_type :type/JSON}
+                   :model/Field    {f2-id :id} {:name "f2" :table_id t-id :base_type :type/JSON
+                                                :parent_id f1-id}
+                   :model/Field    {f3-id :id} {:name "f3" :table_id t-id :base_type :type/Text
+                                                :parent_id f2-id}]
+      (binding [serdes/*batch-cache-max-size* 2]
+        (serdes/with-cache
+          (is (= ["db" nil "t" "f1" "f2" "f3"] (serdes/*export-field-fk* f3-id)))
+          (is (= ["db" nil "t" "f1" "f2"]      (serdes/*export-field-fk* f2-id)))
+          (is (= ["db" nil "t" "f1"]           (serdes/*export-field-fk* f1-id))))))))


### PR DESCRIPTION
Implements on-demand batch cache for databases, tables, fields in serdes. `*export-database-fk*`, `*export-table-fk*`, `*export-field-fk*` are replaced with cached versions.

The default max cache size is 50k, roughly 17mb per model. I.e. max 17mb of tables + 17mb of fields.

`*export-database-fk*`
- loads the requested database plus all other databases up to the batch size limit

`*export-table-fk*`
- loads the main table, plus all FK-connected tables, up to the batch size limit.

`*export-field-fk*`
- loads the requested field and all parent fields, regardless of the batch size, since all of them are immediately needed to compute the FK
- if the field chain (field + parent fields) is less than the batch size, loads fields from the same table + fields from FK tables, up to the limit

cache logic:
- returns a function `(f id)` that returns the requested entity. Caching happens under the hood. Can be replaced with a `t2/select-one` call; this is what uncached versions do by default
- if there is a hit in the cache, returns the entity
- On miss, loads the new batch by using the functions above, passing the max cache size to limit results
- When the new batch is loaded but the cache exceeds the limit, removes the half of the max size of entities from the old cache, and **never** removes entities just loaded in the new batch; so the cache can temporary exceed the limit. This is needed in case the field chain is more than 50k fields. We don't except that for real, but the implementation should be complete.