### PR TITLE
Fix infinite rerender in dashboard chart settings

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashboardChartSettings/DashboardChartSettings.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardChartSettings/DashboardChartSettings.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import _ from "underscore";
 
 import { useDashboardContext } from "metabase/dashboard/context";
@@ -77,7 +77,7 @@ export const DashboardChartSettings = ({
     transformedSeries,
     handleChangeSettings,
     isDashboard: true,
-    extra: { dashboardId: dashboard?.id },
+    extra: useMemo(() => ({ dashboardId: dashboard?.id }), [dashboard?.id]),
   });
 
   return (


### PR DESCRIPTION
### Description

The `extra` prop passed to `useChartSettingsState` was a new object literal on every render, causing downstream hooks/effects to treat it as changed each time and triggering an infinite rerender loop in dashboard chart settings.

Memoize `extra` with `useMemo` keyed on `dashboard?.id`.

https://github.com/user-attachments/assets/d380b7d9-9103-48c7-86f2-ba216f907746


