### PR TITLE
Fix flaky E2E test in connection impersonation step scenarios

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
@@ -1642,6 +1642,13 @@ describe("scenarios - embedding hub", () => {
 
       cy.visit("/admin/embedding/setup-guide/permissions");
 
+      cy.log(
+        "wait for checklist to load and page to settle on the summary step",
+      );
+      H.main()
+        .findByRole("listitem", { name: "Summary", timeout: 10_000 })
+        .should("have.attr", "aria-current", "step");
+
       cy.log("reopen the strategy step and switch to connection impersonation");
       H.main()
         .findByRole("listitem", {

--- a/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/ConnectionImpersonationStepContent.tsx
+++ b/frontend/src/metabase/embedding/embedding-hub/components/SetupPermissionsAndTenantsPage/ConnectionImpersonationStepContent.tsx
@@ -26,7 +26,8 @@ export const ConnectionImpersonationStepContent = ({
   const [isUpdatingPermissions, setUpdatingPermissions] = useState(false);
 
   const { data: databasesResponse } = useListDatabasesQuery();
-  const { updateDataAccess } = useUpdateAllTenantUsersGroupPermissions();
+  const { updateDataAccess, isReady } =
+    useUpdateAllTenantUsersGroupPermissions();
 
   const databases = useMemo(
     () => databasesResponse?.data ?? [],
@@ -65,7 +66,7 @@ export const ConnectionImpersonationStepContent = ({
     }
   }, [selectedDatabaseIds, updateDataAccess, onNext, sendToast]);
 
-  const isNextDisabled = selectedDatabaseIds.length === 0;
+  const isNextDisabled = !isReady || selectedDatabaseIds.length === 0;
 
   if (!hasCompatibleDatabases) {
     return (


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/EMB-1511

### Stress test
PR
> ✅ **20/20 passes** — https://github.com/metabase/metabase/actions/runs/24237149451

Master
> ❌  Failed the first time - https://github.com/metabase/metabase/actions/runs/24241639528
### Description

Fixes two race conditions that caused the `connection impersonation step - reopens the create tenants step after changing the segregation strategy` test to be the #1 most-failed E2E test (187 failures, ~45% failure rate).

**Race condition 1 — test clicks strategy step before checklist loads**

`OnboardingStepper` initializes with `activeStep = "enable-tenants"` before the checklist API responds. When the checklist arrives and marks all steps complete, `useAutoAdvanceStep` fires — but because it sees the current step was previously "incomplete" (pre-load state), it auto-advances to Summary and closes the strategy step, destroying the radio buttons the test was trying to click.

Fix: wait for the Summary step to have `aria-current="step"` (timeout 10s) before clicking to reopen the strategy step.

**Race condition 2 — "Next" clicked before permissions group query resolves**

`ConnectionImpersonationStepContent` only mounts when the `select-data` step is active, so `useListPermissionsGroupsQuery` only starts fetching at that moment. `updateDataAccess` silently returns early when `allTenantUsersGroupId` is undefined, meaning no PUT to `/api/permissions/graph` ever occurred. The `isReady` flag was available on the hook but unused.

Fix: disable the "Next" button until `isReady` is true. This also fixes a real UX bug where clicking Next before data loaded would silently do nothing.

### How to verify

Stress tests are passing (yes)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
