### PR TITLE
GDGT-2203

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/manifest_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/manifest_test.clj
@@ -75,7 +75,12 @@
     (is (not (some #{"../secret.svg"} (manifest/asset-paths {:icon "../secret.svg"})))))
   (testing "deduplicates"
     (is (= ["icon.svg"]
-           (manifest/asset-paths {:icon "icon.svg" :assets ["icon.svg"]})))))
+           (manifest/asset-paths {:icon "icon.svg" :assets ["icon.svg"]}))))
+  (testing "icon and iconDark are auto-included without being listed in assets"
+    (is (= #{"icon.svg" "icon-dark.svg" "thumbs-up.png" "thumbs-down.png"}
+           (set (manifest/asset-paths {:icon     "icon.svg"
+                                       :iconDark "icon-dark.svg"
+                                       :assets   ["thumbs-up.png" "thumbs-down.png"]}))))))
 
 ;;; ------------------------------------------------ Content Type ------------------------------------------------
 

--- a/enterprise/frontend/src/custom-viz/src/templates/metabase-plugin.json
+++ b/enterprise/frontend/src/custom-viz/src/templates/metabase-plugin.json
@@ -2,7 +2,7 @@
   "name": "__CUSTOM_VIZ_NAME__",
   "icon": "icon.svg",
   "iconDark": "icon-dark.svg",
-  "assets": ["icon.svg", "icon-dark.svg", "thumbs-up.png", "thumbs-down.png"],
+  "assets": ["thumbs-up.png", "thumbs-down.png"],
   "metabase": {
     "version": ">=1.60.0"
   }


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-2203/do-not-require-adding-icon-and-icondark-to-assets-array