### PR TITLE
Force color on select item hover in question picker

### DIFF
--- a/frontend/src/metabase/common/components/SelectList/SelectListItem.styled.tsx
+++ b/frontend/src/metabase/common/components/SelectList/SelectListItem.styled.tsx
@@ -12,6 +12,7 @@ export const ItemTitle = styled(Text)<TextProps>`
 
 export const ItemIcon = styled(Icon)`
   justify-self: end;
+  color: var(--mb-color-brand);
 `;
 
 const activeItemCss = css`

--- a/frontend/src/metabase/common/components/SelectList/SelectListItem.tsx
+++ b/frontend/src/metabase/common/components/SelectList/SelectListItem.tsx
@@ -45,9 +45,7 @@ export function SelectListItem({
       hasLeftIcon={!!icon}
       hasRightIcon={!!rightIcon}
     >
-      {icon && (
-        <ItemIcon className={classNames.icon} c="brand" {...iconProps} />
-      )}
+      {icon && <ItemIcon className={classNames.icon} {...iconProps} />}
       <ItemTitle
         className={classNames.label}
         fw="bold"

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/QuestionList.module.css
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/QuestionList.module.css
@@ -5,7 +5,7 @@
 
   &:hover {
     .QuestionListItemIcon {
-      color: var(--mb-color-text-primary-inverse) !important;
+      color: var(--mb-color-text-primary-inverse);
     }
   }
 

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/QuestionList.module.css
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/QuestionList.module.css
@@ -5,7 +5,7 @@
 
   &:hover {
     .QuestionListItemIcon {
-      color: var(--mb-color-text-primary);
+      color: var(--mb-color-text-primary-inverse) !important;
     }
   }
 


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #71649
Closes UXW-3510

### Description
Really small fix that forces viz icons to use `text-primary-inverse` on hover.

### How to verify
1. Open a dashboard and go into edit mode
2. Go to add a new question, and in the list hover over the options and observe the hover styles.
3. Collection icons should remain unchanged, but question viz icons should be the same color as the text 

### Demo

https://github.com/user-attachments/assets/ca4dcca3-748c-408e-94da-4a2ac2a35473

### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~