### PR TITLE
Remove colorScheme from static viz

### DIFF
--- a/enterprise/frontend/src/custom-viz/src/types/viz.ts
+++ b/enterprise/frontend/src/custom-viz/src/types/viz.ts
@@ -146,7 +146,6 @@ export interface RenderingContext {
   measureText: TextWidthMeasurer;
   measureTextHeight: TextHeightMeasurer;
   fontFamily: string;
-  colorScheme: "light" | "dark";
 }
 
 // Equivalent of StaticVisualizationProps
@@ -155,7 +154,6 @@ export type CustomStaticVisualizationProps<
 > = {
   series: Series;
   renderingContext: RenderingContext;
-  colorScheme: "light" | "dark";
   isStorybook?: boolean;
   settings: CustomVisualizationSettings<TSettings>;
   hasDevWatermark?: boolean;

--- a/frontend/src/metabase/plugins/oss/custom-viz.ts
+++ b/frontend/src/metabase/plugins/oss/custom-viz.ts
@@ -28,9 +28,11 @@ const getDefaultPluginCustomViz = () => ({
   isCustomVizDisplay,
 
   // Static viz rendering (GraalJS context)
-  customVizRegistry: new Map<string, Record<string, any>>(),
+  customVizRegistry: new Map<string, Record<string, ComponentType<any>>>(),
   registerCustomVizPlugin: (
-    _factory: (props: Record<string, unknown>) => Record<string, any>,
+    _factory: (
+      props: Record<string, unknown>,
+    ) => Record<string, ComponentType<any>>,
     _identifier: string,
     _assets: Record<string, string> | undefined,
   ) => {},

--- a/frontend/src/metabase/static-viz/components/StaticVisualization/StaticVisualization.tsx
+++ b/frontend/src/metabase/static-viz/components/StaticVisualization/StaticVisualization.tsx
@@ -72,7 +72,6 @@ export const StaticVisualization = ({
         <StaticVisualizationComponent
           series={rawSeries}
           renderingContext={renderingContext}
-          colorScheme={renderingContext.colorScheme ?? "light"}
           settings={settings}
           isStorybook={isStorybook}
           hasDevWatermark={hasDevWatermark}

--- a/frontend/src/metabase/static-viz/lib/rendering-context.ts
+++ b/frontend/src/metabase/static-viz/lib/rendering-context.ts
@@ -35,7 +35,6 @@ export const createStaticRenderingContext = (
         typeof style.size === "number" ? style.size : parseInt(style.size),
       ),
     fontFamily: "Lato, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-    colorScheme: "light",
     theme: DEFAULT_VISUALIZATION_THEME,
   };
 };


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-2231/remove-colorscheme-from-static-custom-viz-api

### Description

Removed references of `colorScheme` from static viz runtime & types.