### PR TITLE
GDGT-2214 OSS version contains empty custom visualization in admin

### DIFF
--- a/e2e/test/scenarios/admin/custom-viz/custom-viz.cy.spec.js
+++ b/e2e/test/scenarios/admin/custom-viz/custom-viz.cy.spec.js
@@ -9,24 +9,37 @@ describe("admin > custom visualizations", () => {
   });
 
   describe("feature gating", () => {
-    it("should show upsell when feature is locked", () => {
-      // No token activation — feature is locked
-      H.visitCustomVizSettings();
+    describe("EE", () => {
+      it("should show upsell when feature is locked", () => {
+        // No token activation — feature is locked
+        H.visitCustomVizSettings();
 
-      cy.findByRole("heading", {
-        name: /Build your own visualizations/,
-      }).should("be.visible");
-      H.getAddVisualizationLink().should("not.exist");
+        cy.findByRole("heading", {
+          name: /Build your own visualizations/,
+        }).should("be.visible");
+        H.getAddVisualizationLink().should("not.exist");
+      });
+
+      it("should show manage page with valid token", () => {
+        H.activateToken("bleeding-edge");
+        H.visitCustomVizSettings();
+
+        cy.get("main")
+          .findByText("Manage custom visualizations")
+          .should("be.visible");
+        H.getAddVisualizationLink().should("be.visible");
+      });
     });
 
-    it("should show manage page with valid token", () => {
-      H.activateToken("bleeding-edge");
-      H.visitCustomVizSettings();
+    describe("OSS", { tags: "@OSS" }, () => {
+      it("should show upsell when feature is locked", () => {
+        H.visitCustomVizSettings();
 
-      cy.get("main")
-        .findByText("Manage custom visualizations")
-        .should("be.visible");
-      H.getAddVisualizationLink().should("be.visible");
+        cy.findByRole("heading", {
+          name: /Build your own visualizations/,
+        }).should("be.visible");
+        H.getAddVisualizationLink().should("not.exist");
+      });
     });
   });
 

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/CustomVisualizationsSettingsPage.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/CustomVisualizationsSettingsPage.tsx
@@ -29,7 +29,7 @@ export function CustomVisualizationsFormPage({
   if (!hasCustomViz) {
     return (
       <SettingsPageWrapper title={t`Custom visualizations`}>
-        <UpsellCustomViz location="settings-custom-viz" />;
+        <UpsellCustomViz location="settings-custom-viz" />
       </SettingsPageWrapper>
     );
   }
@@ -43,7 +43,7 @@ export function CustomVisualizationsDevelopmentPage() {
   if (!hasCustomViz) {
     return (
       <SettingsPageWrapper title={t`Custom visualizations`}>
-        <UpsellCustomViz location="settings-custom-viz" />;
+        <UpsellCustomViz location="settings-custom-viz" />
       </SettingsPageWrapper>
     );
   }

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/CustomVisualizationsSettingsPage.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/CustomVisualizationsSettingsPage.tsx
@@ -1,3 +1,6 @@
+import { t } from "ttag";
+
+import { SettingsPageWrapper } from "metabase/admin/components/SettingsSection";
 import { UpsellCustomViz } from "metabase/admin/upsells";
 import { useHasTokenFeature } from "metabase/common/hooks";
 import { PLUGIN_CUSTOM_VIZ } from "metabase/plugins";
@@ -6,7 +9,11 @@ export function CustomVisualizationsManagePage() {
   const hasCustomViz = useHasTokenFeature("custom-viz");
 
   if (!hasCustomViz) {
-    return <UpsellCustomViz source="settings-custom-viz" />;
+    return (
+      <SettingsPageWrapper title={t`Custom visualizations`}>
+        <UpsellCustomViz location="settings-custom-viz" />
+      </SettingsPageWrapper>
+    );
   }
 
   return <PLUGIN_CUSTOM_VIZ.ManageCustomVizPage />;
@@ -20,7 +27,11 @@ export function CustomVisualizationsFormPage({
   const hasCustomViz = useHasTokenFeature("custom-viz");
 
   if (!hasCustomViz) {
-    return <UpsellCustomViz source="settings-custom-viz" />;
+    return (
+      <SettingsPageWrapper title={t`Custom visualizations`}>
+        <UpsellCustomViz location="settings-custom-viz" />;
+      </SettingsPageWrapper>
+    );
   }
 
   return <PLUGIN_CUSTOM_VIZ.CustomVizPage params={params} />;
@@ -30,7 +41,11 @@ export function CustomVisualizationsDevelopmentPage() {
   const hasCustomViz = useHasTokenFeature("custom-viz");
 
   if (!hasCustomViz) {
-    return <UpsellCustomViz source="settings-custom-viz" />;
+    return (
+      <SettingsPageWrapper title={t`Custom visualizations`}>
+        <UpsellCustomViz location="settings-custom-viz" />;
+      </SettingsPageWrapper>
+    );
   }
 
   return <PLUGIN_CUSTOM_VIZ.CustomVizDevPage />;

--- a/frontend/src/metabase/admin/upsells/UpsellCustomViz.tsx
+++ b/frontend/src/metabase/admin/upsells/UpsellCustomViz.tsx
@@ -1,16 +1,16 @@
 import { t } from "ttag";
 
-import { UpsellBigCard } from "metabase/common/components/upsells/components";
+import { UpsellBanner } from "metabase/common/components/upsells/components";
 import { UPGRADE_URL } from "metabase/common/components/upsells/constants";
 import { useHasTokenFeature } from "metabase/common/hooks";
 import { PLUGIN_ADMIN_SETTINGS } from "metabase/plugins";
 
-export const UpsellCustomViz = ({ source }: { source: string }) => {
+export const UpsellCustomViz = ({ location }: { location: string }) => {
   const hasCustomViz = useHasTokenFeature("custom-viz");
   const campaign = "custom-viz";
   const { triggerUpsellFlow } = PLUGIN_ADMIN_SETTINGS.useUpsellFlow({
     campaign,
-    location: source,
+    location,
   });
 
   if (hasCustomViz) {
@@ -18,15 +18,15 @@ export const UpsellCustomViz = ({ source }: { source: string }) => {
   }
 
   return (
-    <UpsellBigCard
+    <UpsellBanner
       title={t`Build your own visualizations`}
       campaign={campaign}
       buttonText={t`Try for free`}
       buttonLink={UPGRADE_URL}
-      source={source}
+      location={location}
       onClick={triggerUpsellFlow}
     >
-      {t`Create custom chart types tailored to your data using the Custom Visualization SDK. Add them to any question in your Metabase instance.`}
-    </UpsellBigCard>
+      {t`Create custom chart types tailored to your data using the Custom visualizations SDK. Use them with any question in your Metabase instance.`}
+    </UpsellBanner>
   );
 };

--- a/frontend/src/metabase/admin/upsells/UpsellCustomViz.tsx
+++ b/frontend/src/metabase/admin/upsells/UpsellCustomViz.tsx
@@ -26,7 +26,7 @@ export const UpsellCustomViz = ({ location }: { location: string }) => {
       location={location}
       onClick={triggerUpsellFlow}
     >
-      {t`Create custom chart types tailored to your data using the Custom visualizations SDK. Use them with any question in your Metabase instance.`}
+      {t`Create custom chart types tailored to your data using the Custom visualizations SDK.`}
     </UpsellBanner>
   );
 };


### PR DESCRIPTION
Closes [GDGT-2214](https://linear.app/metabase/issue/GDGT-2214/oss-version-contains-empty-custom-visualization-in-admin)

### Description

This already worked but:
- component was too narrow
- it didn't have an illustration
- the page didn't have a heading (like e.g. upsell Admin > Cloud page does).
- copy suggested that all questions can use custom viz, but e.g. embedded ones can't
- there was no e2e test for OSS

Hiding whitespace changes recommended.

### Demo

[before](https://github.com/user-attachments/assets/1bbaef13-9adb-48f3-9a32-65fda47d5a64) vs [after](https://github.com/user-attachments/assets/63d2606b-1508-4ac8-8ed3-b83e68050b0c)

