### PR TITLE
Re-add new dashboard button in move modal and collection picker when dashboards are selectable

### DIFF
--- a/frontend/src/metabase/collections/containers/FormCollectionAndDashboardPicker/FormCollectionAndDashboardPicker.tsx
+++ b/frontend/src/metabase/collections/containers/FormCollectionAndDashboardPicker/FormCollectionAndDashboardPicker.tsx
@@ -159,6 +159,9 @@ export function FormCollectionAndDashboardPicker({
     filterPersonalCollections !== "only" ||
     isOpenCollectionInPersonalCollection;
 
+  const canCreateDashboards =
+    collectionPickerModalProps?.models?.includes("dashboard") ?? false;
+
   const options = useMemo<EntityPickerOptions>(
     () => ({
       hasPersonalCollections: filterPersonalCollections !== "exclude",
@@ -169,12 +172,18 @@ export function FormCollectionAndDashboardPicker({
       hasConfirmButtons: true,
       namespaces: type === "snippet-collections" ? ["snippets"] : undefined,
       canCreateCollections: showCreateNewCollectionOption,
+      canCreateDashboards,
       confirmButtonText: (item) =>
         item?.model === "dashboard"
           ? t`Select this dashboard`
           : t`Select this collection`,
     }),
-    [filterPersonalCollections, type, showCreateNewCollectionOption],
+    [
+      filterPersonalCollections,
+      type,
+      showCreateNewCollectionOption,
+      canCreateDashboards,
+    ],
   );
 
   const [fetchDashboard] = useLazyGetDashboardQuery();

--- a/frontend/src/metabase/collections/containers/FormCollectionAndDashboardPicker/FormCollectionAndDashboardPicker.unit.spec.tsx
+++ b/frontend/src/metabase/collections/containers/FormCollectionAndDashboardPicker/FormCollectionAndDashboardPicker.unit.spec.tsx
@@ -1,0 +1,113 @@
+import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
+
+import {
+  setupCollectionByIdEndpoint,
+  setupCollectionItemsEndpoint,
+  setupCollectionsEndpoints,
+  setupDatabasesEndpoints,
+  setupRecentViewsAndSelectionsEndpoints,
+  setupRootCollectionItemsEndpoint,
+} from "__support__/server-mocks";
+import {
+  mockGetBoundingClientRect,
+  renderWithProviders,
+  screen,
+  waitForLoaderToBeRemoved,
+} from "__support__/ui";
+import type { OmniPickerItem } from "metabase/common/components/Pickers";
+import { ROOT_COLLECTION } from "metabase/entities/collections";
+import { FormProvider } from "metabase/forms";
+import {
+  createMockCollection,
+  createMockCollectionItem,
+} from "metabase-types/api/mocks";
+
+import { FormCollectionAndDashboardPicker } from "./FormCollectionAndDashboardPicker";
+
+const rootCollection = createMockCollection(ROOT_COLLECTION);
+
+const collection1 = createMockCollection({
+  id: 11,
+  name: "First Collection",
+  here: ["card"],
+  below: ["card"],
+  location: "/",
+  can_write: true,
+});
+
+const rootCollectionItems = [
+  createMockCollectionItem({
+    id: 11,
+    model: "collection",
+    name: collection1.name,
+    here: ["collection"],
+    below: ["collection", "card"],
+    collection_id: null,
+    can_write: true,
+  }),
+];
+
+function setup({ models }: { models: OmniPickerItem["model"][] }) {
+  process.env.OVERSCAN = "20";
+  mockGetBoundingClientRect();
+
+  setupRecentViewsAndSelectionsEndpoints([], ["views", "selections"]);
+  setupDatabasesEndpoints([]);
+  setupCollectionsEndpoints({
+    collections: [collection1],
+    rootCollection,
+  });
+  setupCollectionByIdEndpoint({ collections: [collection1] });
+  setupRootCollectionItemsEndpoint({ rootCollectionItems });
+  setupCollectionItemsEndpoint({
+    collection: collection1,
+    collectionItems: [],
+  });
+  fetchMock.get("path:/api/search", { data: [] });
+  fetchMock.get("path:/api/user/recipients", { data: [] });
+
+  renderWithProviders(
+    <FormProvider
+      initialValues={{ collection_id: "root", dashboard_id: undefined }}
+      onSubmit={jest.fn()}
+    >
+      <FormCollectionAndDashboardPicker
+        collectionIdFieldName="collection_id"
+        dashboardIdFieldName="dashboard_id"
+        title="Where do you want to save this?"
+        collectionPickerModalProps={{ models }}
+      />
+    </FormProvider>,
+  );
+}
+
+describe("FormCollectionAndDashboardPicker", () => {
+  it('should show "New dashboard" button when models include "dashboard"', async () => {
+    setup({ models: ["collection", "dashboard"] });
+
+    await userEvent.click(
+      screen.getByTestId("dashboard-and-collection-picker-button"),
+    );
+    await waitForLoaderToBeRemoved();
+
+    expect(
+      await screen.findByRole("button", { name: /new dashboard/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('should not show "New dashboard" button when models do not include "dashboard"', async () => {
+    setup({ models: ["collection"] });
+
+    await userEvent.click(
+      screen.getByTestId("dashboard-and-collection-picker-button"),
+    );
+    await waitForLoaderToBeRemoved();
+
+    // Wait for picker content to load
+    expect(await screen.findByText("Our analytics")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /new dashboard/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.tsx
+++ b/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.tsx
@@ -1,5 +1,4 @@
 import { useField } from "formik";
-import type { HTMLAttributes } from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { t } from "ttag";
 
@@ -22,11 +21,11 @@ import { TransformCollectionName } from "metabase/common/components/TransformCol
 import { useUniqueId } from "metabase/common/hooks/use-unique-id";
 import { Collections } from "metabase/entities/collections";
 import { PLUGIN_TENANTS } from "metabase/plugins";
-import { Button, Icon, Input } from "metabase/ui";
+import { Button, Icon, Input, type InputWrapperProps } from "metabase/ui";
 import { useSelector } from "metabase/utils/redux";
 import type { CollectionId, CollectionNamespace } from "metabase-types/api";
 
-interface FormCollectionPickerProps extends HTMLAttributes<HTMLDivElement> {
+interface FormCollectionPickerProps extends InputWrapperProps {
   name: string;
   title?: string;
   placeholder?: string;
@@ -75,6 +74,7 @@ function FormCollectionPicker({
   entityType,
   collectionPickerModalProps,
   onCollectionSelect,
+  ...rest
 }: FormCollectionPickerProps) {
   const id = useUniqueId();
 
@@ -161,6 +161,7 @@ function FormCollectionPicker({
         label={title}
         labelProps={{ htmlFor: id }}
         error={touched ? error : undefined}
+        {...rest}
       >
         <Button
           data-testid="collection-picker-button"

--- a/frontend/src/metabase/common/components/Pickers/EntityPicker/components/ButtonBar.tsx
+++ b/frontend/src/metabase/common/components/Pickers/EntityPicker/components/ButtonBar.tsx
@@ -71,7 +71,7 @@ export const ButtonBar = ({
         overflowX: "auto",
       }}
     >
-      <Flex gap="md">
+      <Flex gap="md" mr="md">
         <NewCollectionDialog />
         <NewDashboardDialog />
       </Flex>

--- a/frontend/src/metabase/common/components/Pickers/EntityPicker/components/NewCollectionDialog/NewCollectionDialog.tsx
+++ b/frontend/src/metabase/common/components/Pickers/EntityPicker/components/NewCollectionDialog/NewCollectionDialog.tsx
@@ -108,7 +108,7 @@ export const NewCollectionDialog = () => {
 
   return (
     <>
-      <Button onClick={open} disabled={!canCreateHere} mr="md">
+      <Button onClick={open} disabled={!canCreateHere}>
         {lastCollection?.namespace === "transforms" ||
         lastCollection?.namespace === "snippets"
           ? t`New folder`

--- a/frontend/src/metabase/common/components/Pickers/MoveModal/MoveModal.render.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MoveModal/MoveModal.render.unit.spec.tsx
@@ -1,0 +1,126 @@
+import fetchMock from "fetch-mock";
+
+import {
+  setupCollectionByIdEndpoint,
+  setupCollectionItemsEndpoint,
+  setupCollectionsEndpoints,
+  setupDatabasesEndpoints,
+  setupRecentViewsAndSelectionsEndpoints,
+  setupRootCollectionItemsEndpoint,
+} from "__support__/server-mocks";
+import {
+  mockGetBoundingClientRect,
+  renderWithProviders,
+  screen,
+  waitForLoaderToBeRemoved,
+} from "__support__/ui";
+import { ROOT_COLLECTION } from "metabase/entities/collections";
+import {
+  createMockCollection,
+  createMockCollectionItem,
+} from "metabase-types/api/mocks";
+
+import type { OmniPickerCollectionItem } from "../EntityPicker";
+
+import { MoveModal } from "./MoveModal";
+
+const rootCollection = createMockCollection(ROOT_COLLECTION);
+
+const collection1 = createMockCollection({
+  id: 11,
+  name: "First Collection",
+  here: ["card"],
+  below: ["card"],
+  location: "/",
+  can_write: true,
+});
+
+const rootCollectionItems = [
+  createMockCollectionItem({
+    id: 11,
+    model: "collection",
+    name: collection1.name,
+    here: ["collection"],
+    below: ["collection", "card"],
+    collection_id: null,
+    can_write: true,
+  }),
+];
+
+function setupEndpoints() {
+  process.env.OVERSCAN = "20";
+  mockGetBoundingClientRect();
+
+  setupRecentViewsAndSelectionsEndpoints([], ["views", "selections"]);
+  setupDatabasesEndpoints([]);
+  setupCollectionsEndpoints({
+    collections: [collection1],
+    rootCollection,
+  });
+  setupCollectionByIdEndpoint({ collections: [collection1] });
+  setupRootCollectionItemsEndpoint({ rootCollectionItems });
+  setupCollectionItemsEndpoint({
+    collection: collection1,
+    collectionItems: [],
+  });
+  fetchMock.get("path:/api/search", { data: [] });
+  fetchMock.get("path:/api/user/recipients", { data: [] });
+}
+
+const movingCard = {
+  id: 1,
+  name: "Test Question",
+  model: "card",
+  collection: { id: 11, name: "First Collection", authority_level: null },
+} as OmniPickerCollectionItem;
+
+const movingDashboard = {
+  id: 2,
+  name: "Test Dashboard",
+  model: "dashboard",
+  collection: { id: 11, name: "First Collection", authority_level: null },
+} as OmniPickerCollectionItem;
+
+describe("MoveModal", () => {
+  beforeEach(() => {
+    setupEndpoints();
+  });
+
+  it('should show "New dashboard" button when moving a question (canMoveToDashboard=true)', async () => {
+    renderWithProviders(
+      <MoveModal
+        title="Move question"
+        onClose={jest.fn()}
+        onMove={jest.fn()}
+        movingItem={movingCard}
+        canMoveToDashboard
+      />,
+    );
+
+    await waitForLoaderToBeRemoved();
+
+    expect(
+      await screen.findByRole("button", { name: /new dashboard/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('should not show "New dashboard" button when canMoveToDashboard is false', async () => {
+    renderWithProviders(
+      <MoveModal
+        title="Move dashboard"
+        onClose={jest.fn()}
+        onMove={jest.fn()}
+        movingItem={movingDashboard}
+        canMoveToDashboard={false}
+      />,
+    );
+
+    await waitForLoaderToBeRemoved();
+
+    // Wait for picker content to load
+    expect(await screen.findByText("Our analytics")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /new dashboard/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/common/components/Pickers/MoveModal/MoveModal.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MoveModal/MoveModal.tsx
@@ -183,6 +183,7 @@ export const MoveModal = ({
         hasRootCollection: true,
         hasConfirmButtons: true,
         canCreateCollections: true,
+        canCreateDashboards: canMoveToDashboard ?? false,
         hasPersonalCollections: true,
         confirmButtonText: t`Move`,
       }}
@@ -336,6 +337,7 @@ export const BulkMoveModal = ({
         hasRootCollection: true,
         hasConfirmButtons: true,
         canCreateCollections: true,
+        canCreateDashboards: canMoveToDashboard,
         confirmButtonText: t`Move`,
       }}
       isDisabledItem={shouldDisableItem}

--- a/frontend/src/metabase/dashboard/containers/CopyDashboardForm.tsx
+++ b/frontend/src/metabase/dashboard/containers/CopyDashboardForm.tsx
@@ -138,6 +138,7 @@ function CopyDashboardForm({
 
         {!hideShallowCopy && (
           <FormCheckbox
+            mt="1rem"
             name="is_shallow_copy"
             label={
               <Group align="center" gap="xs">
@@ -153,7 +154,7 @@ function CopyDashboardForm({
           />
         )}
 
-        <FormFooter>
+        <FormFooter mt="1.5rem">
           <FormErrorMessage inline />
           {!!onClose && (
             <Button type="button" onClick={onClose}>{t`Cancel`}</Button>

--- a/frontend/src/metabase/ui/components/inputs/Input/index.ts
+++ b/frontend/src/metabase/ui/components/inputs/Input/index.ts
@@ -1,2 +1,2 @@
-export { Input } from "@mantine/core";
+export { Input, type InputWrapperProps } from "@mantine/core";
 export { inputOverrides } from "./Input.config";


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #71873
Closes UXW-3538

### Description
Updates the FormCollectionAndDashboard picker and MoveModal to support the new dashboard dialog when appropriate. 

As a bonus, this also fixes some styling around duplicating dashboards, as the styling around the `Only duplicate the dashboard` checkbox was broken. (In stats, there is no spacing between the collection picker button and the bottom bar, or the checkbox)

### How to verify
1. Go to any question and in the menu, select move. You should see an option in the entity picker to create a new dashboard
2. Save with duplicating the question
3. Same with saving a new quesiton
4. Next, go to a dashboard, and in the entity menu choose duplicate
5. If your dashboard does not contain Dashboard Questions, then you should see an option for shallow duplication

### Demo

Question Move Modal:
<img width="1132" height="935" alt="image" src="https://github.com/user-attachments/assets/31946661-0a3d-4075-ace6-da370d0bb5c7" />

Question Duplicate Modal:
<img width="1132" height="933" alt="image" src="https://github.com/user-attachments/assets/8a64f4ab-ffbe-4191-b5b7-33664b54695e" />

Question Save Modal:
<img width="1131" height="934" alt="image" src="https://github.com/user-attachments/assets/02af7550-cf88-4843-9c0d-a7559a2a0789" />


Dashboard Duplicate modal when shallow copy is possible:
<img width="952" height="794" alt="image" src="https://github.com/user-attachments/assets/d3be4b29-302c-4186-9cfd-9cdf14b2b16a" />

Duplicate Dashboard when shallow copy is not possible:
<img width="817" height="627" alt="image" src="https://github.com/user-attachments/assets/5e205d63-492f-417d-8495-77ecf4549c22" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
