### PR TITLE
Center buttons vertically in CreateOrEditQuestionAlertModal footer

### DIFF
--- a/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx
+++ b/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { P, match } from "ts-pattern";
 import { t } from "ttag";
 import { isEqual } from "underscore";
 
@@ -162,9 +163,9 @@ export const CreateOrEditQuestionAlertModal = ({
     useGetChannelInfoQuery();
   const { data: hookChannels } = useListChannelsQuery();
 
-  const [createNotification, { isLoading: isCreating }] =
+  const [createNotification, { isLoading: isCreating, error: errorCreating }] =
     useCreateNotificationMutation();
-  const [updateNotification, { isLoading: isUpdating }] =
+  const [updateNotification, { isLoading: isUpdating, error: errorUpdating }] =
     useUpdateNotificationMutation();
   const [sendUnsavedNotification, { isLoading }] =
     useSendUnsavedNotificationMutation();
@@ -304,6 +305,16 @@ export const CreateOrEditQuestionAlertModal = ({
 
   const isValid = alertIsValid(notification, channelSpec);
   const hasChanges = !isEqual(editingNotification, notification);
+  const hasError = errorCreating || errorUpdating;
+
+  const submitButtonLabel = match({
+    hasError,
+    isEditMode,
+    hasChanges,
+  })
+    .with({ hasError: P.nonNullable }, () => t`Save failed`)
+    .with({ isEditMode: true, hasChanges: true }, () => t`Save changes`)
+    .otherwise(() => t`Done`);
 
   return (
     <Modal
@@ -434,11 +445,12 @@ export const CreateOrEditQuestionAlertModal = ({
           <Button onClick={onClose}>{t`Cancel`}</Button>
           <Button
             variant="filled"
+            bg={hasError ? "error" : "brand"}
             disabled={!isValid || isCreating || isUpdating}
             loading={isCreating || isUpdating}
             onClick={onCreateOrEditAlert}
           >
-            {isEditMode && hasChanges ? t`Save changes` : t`Done`}
+            {submitButtonLabel}
           </Button>
         </Flex>
       </Flex>

--- a/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx
+++ b/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx
@@ -9,7 +9,6 @@ import {
   useSendUnsavedNotificationMutation,
   useUpdateNotificationMutation,
 } from "metabase/api";
-import { ActionButton } from "metabase/common/components/ActionButton";
 import CS from "metabase/css/core/index.css";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import { getDefaultQuestionAlertRequest } from "metabase/notifications/utils";
@@ -163,8 +162,10 @@ export const CreateOrEditQuestionAlertModal = ({
     useGetChannelInfoQuery();
   const { data: hookChannels } = useListChannelsQuery();
 
-  const [createNotification] = useCreateNotificationMutation();
-  const [updateNotification] = useUpdateNotificationMutation();
+  const [createNotification, { isLoading: isCreating }] =
+    useCreateNotificationMutation();
+  const [updateNotification, { isLoading: isUpdating }] =
+    useUpdateNotificationMutation();
   const [sendUnsavedNotification, { isLoading }] =
     useSendUnsavedNotificationMutation();
 
@@ -233,8 +234,7 @@ export const CreateOrEditQuestionAlertModal = ({
           }),
         );
 
-        // need to throw to show error in ActionButton
-        throw result.error;
+        return;
       }
 
       dispatch(
@@ -430,15 +430,16 @@ export const CreateOrEditQuestionAlertModal = ({
         >
           {isLoading ? t`Sending…` : t`Send now`}
         </Button>
-        <Flex gap="md">
+        <Flex align="center" gap="sm">
           <Button onClick={onClose}>{t`Cancel`}</Button>
-          <ActionButton
-            primary
-            disabled={!isValid}
-            actionFn={onCreateOrEditAlert}
+          <Button
+            variant="filled"
+            disabled={!isValid || isCreating || isUpdating}
+            loading={isCreating || isUpdating}
+            onClick={onCreateOrEditAlert}
           >
             {isEditMode && hasChanges ? t`Save changes` : t`Done`}
-          </ActionButton>
+          </Button>
         </Flex>
       </Flex>
     </Modal>

--- a/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx
+++ b/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx
@@ -317,6 +317,7 @@ export const CreateOrEditQuestionAlertModal = ({
         body: {
           paddingLeft: 0,
           paddingRight: 0,
+          paddingBottom: "1.5rem",
         },
       }}
     >
@@ -416,6 +417,7 @@ export const CreateOrEditQuestionAlertModal = ({
       </Stack>
       <Flex
         justify="space-between"
+        align="center"
         px="2.5rem"
         pt="lg"
         className={CS.borderTop}
@@ -428,8 +430,8 @@ export const CreateOrEditQuestionAlertModal = ({
         >
           {isLoading ? t`Sending…` : t`Send now`}
         </Button>
-        <div>
-          <Button onClick={onClose} className={CS.mr2}>{t`Cancel`}</Button>
+        <Flex gap="md">
+          <Button onClick={onClose}>{t`Cancel`}</Button>
           <ActionButton
             primary
             disabled={!isValid}
@@ -437,7 +439,7 @@ export const CreateOrEditQuestionAlertModal = ({
           >
             {isEditMode && hasChanges ? t`Save changes` : t`Done`}
           </ActionButton>
-        </div>
+        </Flex>
       </Flex>
     </Modal>
   );

--- a/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.unit.spec.tsx
+++ b/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.unit.spec.tsx
@@ -334,6 +334,58 @@ describe("CreateOrEditQuestionAlertModalWithQuestion", () => {
     expect(onAlertCreatedMock).toHaveBeenCalledTimes(1);
   });
 
+  it("should update submit button label through Done → Save changes → Save failed", async () => {
+    const notificationId = 42;
+    fetchMock.putOnce(`path:/api/notification/${notificationId}`, {
+      status: 500,
+      body: { message: "Internal server error" },
+    });
+
+    const mockNotification = createMockNotification({
+      id: notificationId,
+      subscriptions: [
+        createMockNotificationCronSubscription({
+          cron_schedule: "0 0 14 ? * 2 *",
+        }),
+      ],
+      payload: {
+        card_id: 1,
+        send_once: false,
+        send_condition: "has_result",
+      },
+    });
+
+    setup({
+      isAdmin: true,
+      isEmailSetup: true,
+      editingNotification: mockNotification,
+    });
+
+    await screen.findByText("Edit alert");
+
+    // No changes yet — button should say "Done"
+    expect(screen.getByRole("button", { name: /done/i })).toBeInTheDocument();
+
+    // Make a change — button should say "Save changes"
+    const weekdaySelector = screen.getByTestId("select-weekday");
+    await userEvent.click(weekdaySelector);
+    const tuesdayOption = screen.getByRole("option", { name: /Tuesday/i });
+    await userEvent.click(tuesdayOption);
+
+    expect(
+      screen.getByRole("button", { name: /save changes/i }),
+    ).toBeInTheDocument();
+
+    // Submit with a failing API — button should say "Save failed"
+    await userEvent.click(
+      screen.getByRole("button", { name: /save changes/i }),
+    );
+
+    expect(
+      await screen.findByRole("button", { name: /save failed/i }),
+    ).toBeInTheDocument();
+  });
+
   it("should update an existing notification when in edit mode", async () => {
     const notificationId = 42;
     // Setup fetchMock for API call


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #71945
### Description

Very small change that fixes a layout issue in the Alert modal for quesitons

### How to verify

1. Go to any question and set up an alert
2. scroll to the bottom of the modal and see that the buttons are properly aligned
3. I also adjusted the padding at the bottom of the modal. it was bothering me that there was `1.5rem` of padding on the top, and `2rem` on the bottom haha

### Demo

<img width="809" height="518" alt="image" src="https://github.com/user-attachments/assets/e2a7fc16-7fa7-4a2d-b1d2-3e94de2829f8" />


### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~