### PR TITLE
Clamp :max-results-bare-rows with pivot-limit if it's set

### DIFF
--- a/src/metabase/query_processor/pivot.clj
+++ b/src/metabase/query_processor/pivot.clj
@@ -515,6 +515,8 @@
            query       (-> query
                            (assoc-in [:middleware :pivot-options] pivot-opts)
                            (assoc-in [:constraints :max-results] pivot-limit)
+                           (cond-> (get-in query [:constraints :max-results-bare-rows])
+                             (update-in [:constraints :max-results-bare-rows] min pivot-limit))
                            add-canonical-col-info)
            all-queries (generate-queries query pivot-opts)]
        (process-multiple-queries all-queries rff pivot-limit)))))

--- a/test/metabase/query_processor/pivot_test.clj
+++ b/test/metabase/query_processor/pivot_test.clj
@@ -13,9 +13,11 @@
    [metabase.lib.test-util.notebook-helpers :as lib.tu.notebook]
    [metabase.permissions.models.data-permissions :as data-perms]
    [metabase.permissions.models.permissions-group :as perms-group]
+   [metabase.query-processor.middleware.constraints :as qp.constraints]
    [metabase.query-processor.pivot :as qp.pivot]
    [metabase.query-processor.pivot.common :as pivot.common]
    [metabase.query-processor.pivot.test-util :as qp.pivot.test-util]
+   [metabase.query-processor.settings :as qp.settings]
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.test :as qp]
    [metabase.test :as mt]
@@ -871,3 +873,20 @@
           (testing "The result includes pivot_rows_truncated flag"
             (is (= 10 (get-in results [:data :pivot_rows_truncated]))
                 "Should signal truncation with the row count")))))))
+
+(deftest pivot-query-with-high-unaggregated-row-limit-test
+  (testing "Pivot queries don't fail when MB_UNAGGREGATED_QUERY_ROW_LIMIT exceeds the pivot row limit (#72157)"
+    (mt/test-drivers (qp.pivot.test-util/applicable-drivers)
+      ;; pivot-query has 2 aggregations, so pivot-limit = 20/2 = 10.
+      ;; Setting unaggregated-query-row-limit to 15 means max-results-bare-rows (15) > max-results (10),
+      ;; which violates the constraint schema without the fix.
+      ;; Pre-set :constraints like the API layer does (see qp.api/run-query-async+pivot).
+      (binding [qp.pivot/*pivot-max-result-rows* 20]
+        (mt/with-temporary-setting-values [qp.settings/unaggregated-query-row-limit 15]
+          (let [query   (-> (qp.pivot.test-util/pivot-query)
+                            (assoc :constraints (qp.constraints/default-query-constraints)))
+                results (qp.pivot/run-pivot-query query)]
+            (is (<= 2 (count (get-in query [:query :aggregation])))
+                "Sanity check: pivot-query should have at least 2 aggregations")
+            (is (not= :failed (:status results))
+                "Pivot query should not fail with a constraint violation")))))))


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #72157
Closes QUE2-506

### Description

`max-results-bare-rows` should not be higher than `max-results`, so clamp it to pivot-limit too, if it's set.

### How to verify

See the new regression test.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
-  ~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~
