### PR TITLE
Remove theme transition from dashbaord header, tabs, and parameters panel

### DIFF
--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.module.css
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.module.css
@@ -24,7 +24,6 @@
 .DashboardHeaderContainer {
   position: relative;
   z-index: 2;
-  transition: var(--transition-theme-change);
 
   &:not(.noBorder) {
     border-bottom: 1px solid var(--mb-color-border);

--- a/frontend/src/metabase/dashboard/components/DashboardParameterPanel/DashboardParameterPanel.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardParameterPanel/DashboardParameterPanel.tsx
@@ -1,7 +1,6 @@
 import cx from "classnames";
 import { useRef } from "react";
 
-import TransitionS from "metabase/css/core/transitions.module.css";
 import { DASHBOARD_HEADER_PARAMETERS_PDF_EXPORT_NODE_ID } from "metabase/dashboard/constants";
 import { useDashboardContext } from "metabase/dashboard/context";
 import { useIsParameterPanelSticky } from "metabase/dashboard/hooks/use-is-parameter-panel-sticky";
@@ -30,12 +29,10 @@ export function DashboardParameterPanel() {
   const allowSticky = isParametersWidgetContainersSticky(
     visibleParameters.length,
   );
-  const { isSticky, isStickyStateChanging } = useIsParameterPanelSticky({
+  const { isSticky } = useIsParameterPanelSticky({
     parameterPanelRef,
     disabled: !allowSticky || !hasVisibleParameters,
   });
-
-  const shouldApplyThemeChangeTransition = !isStickyStateChanging && isSticky;
 
   if (!hasVisibleParameters) {
     return null;
@@ -70,7 +67,6 @@ export function DashboardParameterPanel() {
     <span ref={parameterPanelRef}>
       <FullWidthContainer
         className={cx(S.ParametersWidgetContainer, {
-          [TransitionS.transitionThemeChange]: shouldApplyThemeChangeTransition,
           [S.allowSticky]: allowSticky,
           [S.isSticky]: isSticky,
           [S.isEmbeddingSdk]: isEmbeddingSdk(),

--- a/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.module.css
+++ b/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.module.css
@@ -8,7 +8,6 @@
     position: absolute;
     bottom: 0;
     width: 100%;
-    transition: var(--transition-theme-change);
   }
 }
 


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #71992
### Description

Small change to remove the 1s transition from the dashboard header container, tabs, and parameters panel when switching themes.

### How to verify

1. Open a dashboard
2. Use the keyboard shortcut to switch between light and dark themes (cmd+shift+L)

### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~