### PR TITLE
activate token feature in security center e2e tests

### DIFF
--- a/e2e/support/helpers/e2e-token-helpers.ts
+++ b/e2e/support/helpers/e2e-token-helpers.ts
@@ -50,6 +50,10 @@ export const activateToken = (
   });
 };
 
+export const addTokenFeatures = (...features: string[]) => {
+  return cy.request("POST", "/api/testing/token-features", { features });
+};
+
 export const deleteToken = () => {
   throwIfNotEnterprise();
 

--- a/e2e/test/scenarios/admin-2/security-center.cy.spec.ts
+++ b/e2e/test/scenarios/admin-2/security-center.cy.spec.ts
@@ -54,6 +54,9 @@ describe("scenarios > admin > security center", { tags: "@EE" }, () => {
     H.restore();
     cy.signInAsAdmin();
     H.activateToken("pro-self-hosted");
+    H.mockSessionPropertiesTokenFeatures({
+      admin_security_center: true,
+    });
   });
 
   describe("feature gating", () => {

--- a/e2e/test/scenarios/admin-2/security-center.cy.spec.ts
+++ b/e2e/test/scenarios/admin-2/security-center.cy.spec.ts
@@ -54,9 +54,7 @@ describe("scenarios > admin > security center", { tags: "@EE" }, () => {
     H.restore();
     cy.signInAsAdmin();
     H.activateToken("pro-self-hosted");
-    H.mockSessionPropertiesTokenFeatures({
-      admin_security_center: true,
-    });
+    H.addTokenFeatures("admin-security-center");
   });
 
   describe("feature gating", () => {
@@ -110,6 +108,7 @@ describe("scenarios > admin > security center", { tags: "@EE" }, () => {
       H.restore();
       cy.signInAsAdmin();
       H.activateToken("pro-self-hosted");
+      H.addTokenFeatures("admin-security-center");
       cy.visit("/admin/security-center");
       securityCenterContent().within(() => {
         cy.findByText(/up to date/).should("be.visible");

--- a/e2e/test/scenarios/admin/security-center-snowplow.cy.spec.ts
+++ b/e2e/test/scenarios/admin/security-center-snowplow.cy.spec.ts
@@ -18,9 +18,7 @@ describe("Security Center > Snowplow tracking", { tags: "@enterprise" }, () => {
     cy.signInAsAdmin();
     H.enableTracking();
     H.activateToken("pro-self-hosted");
-    H.mockSessionPropertiesTokenFeatures({
-      admin_security_center: true,
-    });
+    H.addTokenFeatures("admin-security-center");
     // Stub the API so the page renders without a real EE backend
     cy.intercept("GET", "/api/ee/security-center", {
       last_checked_at: null,

--- a/e2e/test/scenarios/admin/security-center-snowplow.cy.spec.ts
+++ b/e2e/test/scenarios/admin/security-center-snowplow.cy.spec.ts
@@ -18,6 +18,9 @@ describe("Security Center > Snowplow tracking", { tags: "@enterprise" }, () => {
     cy.signInAsAdmin();
     H.enableTracking();
     H.activateToken("pro-self-hosted");
+    H.mockSessionPropertiesTokenFeatures({
+      admin_security_center: true,
+    });
     // Stub the API so the page renders without a real EE backend
     cy.intercept("GET", "/api/ee/security-center", {
       last_checked_at: null,

--- a/src/metabase/testing_api/api.clj
+++ b/src/metabase/testing_api/api.clj
@@ -288,6 +288,19 @@
   (t2/delete! :model/SecurityAdvisory)
   (t2/insert-returning-instances! :model/SecurityAdvisory advisories))
 
+#_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
+(api.macros/defendpoint :post "/token-features"
+  "Add token features for E2E tests. Alter-var-roots `*token-features*` to return
+   the union of the real token features and the provided ones."
+  [_route-params
+   _query-params
+   {:keys [features]} :- [:map [:features [:sequential ms/NonBlankString]]]]
+  (let [extra (set features)]
+    (alter-var-root (resolve 'metabase.premium-features.token-check/*token-features*)
+                    (fn [original-fn]
+                      (fn [] (into (original-fn) extra)))))
+  {:status "ok"})
+
 (api.macros/defendpoint :post "/native-query" :- ::lib.schema/query
   "Creates a native query from a test query spec."
   [_route-params


### PR DESCRIPTION
https://github.com/metabase/harbormaster/pull/7152 removed the feature from `pro-self-hosted`, the e2e tests need explicit mocking of the token feature