### PR TITLE
Update PATH_WITH_COLLAPSED_NAVBAR to not close on all routes with question

### DIFF
--- a/frontend/src/metabase/nav/containers/Navbar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/Navbar.unit.spec.tsx
@@ -131,6 +131,16 @@ describe("nav > containers > Navbar > Core App", () => {
     await expectNavbarClosed();
   });
 
+  it("should stay open when navigating to the database reference questions page (metabase#72001)", async () => {
+    const store = await setup({ pathname: "/reference/databases/1" });
+    await expectNavbarOpen();
+    dispatchLocationChange({
+      store,
+      pathname: "/reference/databases/1/tables/2/questions",
+    });
+    await expectNavbarOpen();
+  });
+
   it("should hide when visiting a question and stay hidden when returning to collection", async () => {
     const store = await setup({ pathname: "/collection/1" });
     await expectNavbarOpen();

--- a/frontend/src/metabase/redux/app.ts
+++ b/frontend/src/metabase/redux/app.ts
@@ -66,9 +66,10 @@ const errorPage = handleActions(
 );
 
 // regexr.com/7r89i
-// A word boundary is added to /model so it doesn't match /browse/models
+// Word boundaries are added so partial matches don't collapse the navbar
+// e.g. /model shouldn't match /browse/models, /question shouldn't match /reference/.../questions
 const PATH_WITH_COLLAPSED_NAVBAR =
-  /\/(model\b|question|dashboard|metabot|document|explore).*/;
+  /\/(model\b|question\b|dashboard|metabot|document|explore).*/;
 
 export function isNavbarOpenForPathname(pathname: string, prevState: boolean) {
   return (


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #72001
### Description
Updates PATH_WITH_COLLAPSED_NAVBAR to have a word boundary anchor after question. This means that we still match the usual question routes, but we don't match the reference route in the issue (`/reference/databases/1/tables/2/questions`)

### How to verify
1. Go to browse -> databases
2. Click one of the books next to a table name. It should appear on hover
3. Ensure that the side nav is open (you can use the `[` shortcut if it is closed)
4. Click on `Questions about this table`. The sidenav should stay open

### Demo

https://github.com/user-attachments/assets/96f008ce-fb57-4b35-a84e-8f26b968e1ac


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
