### PR TITLE
BOT-1292 Do not convert metering values to string in send-metering-events!

### DIFF
--- a/src/metabase/premium_features/token_check.clj
+++ b/src/metabase/premium_features/token_check.clj
@@ -211,13 +211,10 @@
   (when-let [token (premium-features.settings/premium-embedding-token)]
     (when (mr/validate [:re RemoteCheckedToken] token)
       (tracing/with-span :tasks "metering.send-events" {}
-        (let [site-uuid (premium-features.settings/site-uuid-for-premium-features-token-checks)
-              stats (-> (metering-stats)
-                        ;; for backwards compatibility, we send values as strings
-                        (update-vals str))]
+        (let [site-uuid (premium-features.settings/site-uuid-for-premium-features-token-checks)]
           (try
             (http/post (metering-url token token-check-url)
-                       {:body (json/encode (merge stats
+                       {:body (json/encode (merge (metering-stats)
                                                   {:site-uuid site-uuid
                                                    :mb-version (:tag config/mb-version-info)}))
                         :content-type :json

--- a/test/metabase/premium_features/token_check_test.clj
+++ b/test/metabase/premium_features/token_check_test.clj
@@ -315,6 +315,31 @@
               (is (contains? body "users")
                   "Request body should include users count"))))))))
 
+(deftest send-metering-events-preserves-value-types-test
+  (testing "metering values are not converted to strings before sending"
+    (let [fake-usage {"anthropic:claude-sonnet-4-6:tokens" 500
+                      "openai:gpt-4:tokens"                300}
+          request-data (atom nil)]
+      (mt/with-random-premium-token! [_token]
+        (with-redefs [token-check/metering-stats (constantly {:users          10
+                                                              :external-users 2
+                                                              :internal-users 8
+                                                              :domains        1
+                                                              :metabot-usage  fake-usage
+                                                              :metabot-tokens 800})
+                      http/post                 (fn [_url opts]
+                                                  (reset! request-data opts)
+                                                  {:status 200 :body "{}"})]
+          (token-check/send-metering-events!)
+          (let [body (json/decode (:body @request-data) keyword)]
+            (is (= 10 (:users body))
+                "numeric values should remain numeric after JSON round-trip")
+            (is (map? (:metabot-usage body))
+                "map values should remain maps after JSON round-trip")
+            (is (= fake-usage
+                   (update-keys (:metabot-usage body) name))
+                "nested map values should round-trip intact")))))))
+
 (deftest send-metering-events-error-handling-test
   (testing "send-metering-events! handles errors gracefully"
     (mt/with-random-premium-token! [_token]


### PR DESCRIPTION
Closes [BOT-1292: Do not convert metering values to string](https://linear.app/metabase/issue/BOT-1292/do-not-convert-metering-values-to-string)

### Description

Do not convert metering values to string. This breaks for richer map values like `:metabot-usage` and harbormaster does not need the values to be converted.

https://metaboat.slack.com/archives/C0AP8MCUE4U/p1775818018315689?thread_ts=1775672719.034349&cid=C0AP8MCUE4U

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
