### PR TITLE
BOT-1289 Send metabot-usage metering for both yesterday and today

### DIFF
--- a/src/metabase/internal_stats/metabot.clj
+++ b/src/metabase/internal_stats/metabot.clj
@@ -5,43 +5,54 @@
    [metabase.util :as u]
    [toucan2.core :as t2]))
 
+(defn- usage-by-model
+  "Aggregate combined tokens by provider:model for a given UTC date."
+  [date-utc]
+  (let [usages (t2/select-fn-vec :usage
+                                 [:model/MetabotMessage :usage]
+                                 {:where [:and
+                                          :ai_proxied
+                                          [:= [:cast :created_at :date] [:cast date-utc :date]]
+                                          [:not= :usage nil]]})]
+    (->> (for [usage               usages
+               [prov-model tokens] usage
+               :let [k (str/replace-first (u/qualified-name prov-model) "/" ":")]]
+           {(str k ":tokens") (+ (:prompt tokens) (:completion tokens))})
+         (apply merge-with +)
+         not-empty)))
+
 (defn metabot-stats
-  "Calculate total Metabot token usage over a window of the previous UTC day 00:00-23:59"
+  "Calculate total Metabot token usage over a window of the previous UTC day 00:00-23:59,
+   plus rolling usage stats for today."
   []
-  (let [yesterday-utc (-> (t/offset-date-time (t/zone-offset "+00"))
-                          (t/minus (t/days 1)))
+  (let [today-utc     (t/offset-date-time (t/zone-offset "+00"))
+        yesterday-utc (t/minus today-utc (t/days 1))
         tokens        (or (t2/select-one-fn :sum
                                             [:model/MetabotMessage [:%sum.total_tokens :sum]]
                                             {:where [:and
                                                      :ai_proxied
                                                      [:= [:cast :created_at :date] [:cast yesterday-utc :date]]
                                                      [:not= :usage nil]]})
-                          0)]
-    (when (pos? tokens)
-      {:metabot-tokens     (long tokens)
-       :metabot-usage      (let [usages (t2/select-fn-vec :usage
-                                                          [:model/MetabotMessage :usage]
-                                                          {:where [:and
-                                                                   :ai_proxied
-                                                                   [:= [:cast :created_at :date] [:cast yesterday-utc :date]]
-                                                                   [:not= :usage nil]]})]
-                             (->> (for [usage               usages
-                                        [prov-model tokens] usage
-                                        :let [k (str/replace-first (u/qualified-name prov-model) "/" ":")]]
-                                    {(str k ":tokens") (+ (:prompt tokens) (:completion tokens))})
-                                  (apply merge-with +)))
-       :metabot-queries    (t2/select-one-fn :cnt
-                                             [:model/MetabotMessage [:%count.id :cnt]]
-                                             ;; there are requests from users and responses from ai-service, in theory
-                                             ;; counting requests from users should be good enough
-                                             :role "user"
-                                             {:where [:and
-                                                      :ai_proxied
-                                                      [:= [:cast :created_at :date] [:cast yesterday-utc :date]]]})
-       :metabot-users      (:cnt (t2/query-one {:select [[[:count [:distinct :c.user_id]] :cnt]]
-                                                :from   [[:metabot_message :m]]
-                                                :join   [[:metabot_conversation :c] [:= :c.id :m.conversation_id]]
-                                                :where  [:and
-                                                         :ai_proxied
-                                                         [:= [:cast :m.created_at :date] [:cast yesterday-utc :date]]]}))
-       :metabot-usage-date (str (t/local-date yesterday-utc))})))
+                          0)
+        rolling-usage (usage-by-model today-utc)]
+    (when (or (pos? tokens) (seq rolling-usage))
+      (cond-> {}
+        (pos? tokens)
+        (merge {:metabot-tokens     (long tokens)
+                :metabot-usage      (usage-by-model yesterday-utc)
+                :metabot-queries    (t2/select-one-fn :cnt
+                                                      [:model/MetabotMessage [:%count.id :cnt]]
+                                                      :role "user"
+                                                      {:where [:and
+                                                               :ai_proxied
+                                                               [:= [:cast :created_at :date] [:cast yesterday-utc :date]]]})
+                :metabot-users      (:cnt (t2/query-one {:select [[[:count [:distinct :c.user_id]] :cnt]]
+                                                         :from   [[:metabot_message :m]]
+                                                         :join   [[:metabot_conversation :c] [:= :c.id :m.conversation_id]]
+                                                         :where  [:and
+                                                                  :ai_proxied
+                                                                  [:= [:cast :m.created_at :date] [:cast yesterday-utc :date]]]}))
+                :metabot-usage-date (str (t/local-date yesterday-utc))})
+        (seq rolling-usage)
+        (merge {:metabot-rolling-usage      rolling-usage
+                :metabot-rolling-usage-date (str (t/local-date today-utc))})))))

--- a/test/metabase/internal_stats/metabot_test.clj
+++ b/test/metabase/internal_stats/metabot_test.clj
@@ -64,7 +64,8 @@
           conv-3       (str (random-uuid))
           conv-4       (str (random-uuid))
           conv-5       (str (random-uuid))
-          all-convs    [conv-1 conv-2 conv-3 conv-4 conv-5]
+          conv-6       (str (random-uuid))
+          all-convs    [conv-1 conv-2 conv-3 conv-4 conv-5 conv-6]
           ;; OpenRouter returns model names like "anthropic/claude-haiku-4-5" in its API.
           ;; This is the bare model name that flows from the SSE adapter → extract-usage → DB.
           model        "anthropic/claude-haiku-4-5"]
@@ -85,9 +86,13 @@
             (send-message! conv-3 "Old question" model 999 999)
             (backdate-messages! conv-3 two-days-ago)
 
-            ;; conv-4: today — out of window
+            ;; conv-4: today — in rolling window
             (send-message! conv-4 "Today's question" model 888 888)
-            (backdate-messages! conv-4 today))
+            (backdate-messages! conv-4 today)
+
+            ;; conv-6: today, same model — exercises rolling aggregation
+            (send-message! conv-6 "Another today question" model 100 100)
+            (backdate-messages! conv-6 today))
 
           ;; -- BYOK conversation (no metabase/ prefix) --
           (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
@@ -132,16 +137,46 @@
               (is (= 1 (:metabot-users stats))))
 
             (testing ":metabot-usage-date is yesterday's date"
-              (is (= "2026-03-31" (:metabot-usage-date stats)))))
+              (is (= "2026-03-31" (:metabot-usage-date stats))))
+
+            (testing ":metabot-rolling-usage aggregates today's combined tokens by model"
+              (is (= {"openrouter:anthropic/claude-haiku-4-5:tokens" 1976}
+                     (:metabot-rolling-usage stats))))
+
+            (testing ":metabot-rolling-usage-date is today's date"
+              (is (= "2026-04-01" (:metabot-rolling-usage-date stats)))))
 
           ;; -- BYOK-only scenario --
-          (cleanup! conv-1 conv-2 conv-3 conv-4)
+          (cleanup! conv-1 conv-2 conv-3 conv-4 conv-6)
 
           (testing "returns nil when only BYOK (non-proxied) messages exist yesterday"
             (is (nil? (sut/metabot-stats))))
 
           (finally
             (apply cleanup! all-convs)))))))
+
+(deftest metabot-stats-rolling-only-test
+  (search.tu/with-index-disabled
+    (let [clock   (t/mock-clock (t/instant "2026-04-01T12:00:00Z") "UTC")
+          today   (t/offset-date-time 2026 4 1 9 0 0 0 (t/zone-offset "+00"))
+          conv-id (str (random-uuid))]
+      (t/with-clock clock
+        (try
+          (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
+                                             "metabase/anthropic/claude-sonnet-4-6"]
+            (send-message! conv-id "Hello" "claude-sonnet-4-6" 500 100)
+            (backdate-messages! conv-id today))
+          (let [stats (sut/metabot-stats)]
+            (testing "returns rolling keys when only today has data"
+              (is (= {"anthropic:claude-sonnet-4-6:tokens" 600}
+                     (:metabot-rolling-usage stats)))
+              (is (= "2026-04-01" (:metabot-rolling-usage-date stats))))
+            (testing "yesterday keys are absent when no yesterday data"
+              (is (nil? (:metabot-tokens stats)))
+              (is (nil? (:metabot-usage stats)))
+              (is (nil? (:metabot-usage-date stats)))))
+          (finally
+            (cleanup! conv-id)))))))
 
 (deftest metabot-usage-anthropic-provider-test
   (search.tu/with-index-disabled


### PR DESCRIPTION
Closes [BOT-1289: Send yesterday and today metering for Metabot](https://linear.app/metabase/issue/BOT-1289/send-yesterday-and-today-metering-for-metabot)

https://metaboat.slack.com/archives/C0AP8MCUE4U/p1775834777574049?thread_ts=1775672719.034349&cid=C0AP8MCUE4U

### Description

Send metering for today's usage under a new `:metabot-rolling-usage` key with corresponding `:metabot-rolling-usage-date`.

All other keys only send yesterday's values for backwards compat.

Keys are omitted if there is no usage for the corresponding day.

### Demo

```
{:metabot-tokens 139098,
 :metabot-usage {"anthropic:claude-sonnet-4-6:tokens" 139098},
 :metabot-queries 6,
 :metabot-users 2,
 :metabot-usage-date "2026-04-09",
 :metabot-rolling-usage {"anthropic:claude-sonnet-4-6:tokens" 19179},
:metabot-rolling-usage-date "2026-04-10"}
```
### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
