### PR TITLE
[devex] Add `:test/pre` and `:test/post` conditions to `mu/defn`

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -459,6 +459,7 @@
 
   :cljs
   {:extra-paths ["test"]
+   :jvm-opts    ["-Dmb.run.mode=dev"]
    :extra-deps
    {binaryage/devtools                 {:mvn/version "1.0.7"}
     cider/cider-nrepl                  {:mvn/version "0.58.0"}

--- a/src/metabase/util/malli.cljc
+++ b/src/metabase/util/malli.cljc
@@ -97,8 +97,8 @@
                                                           (symbol multifn))
                                     :dispatch-value ~dispatch-value-symb}
               f#                   ~(if instrument?
-                                      (mu.fn/instrumented-fn-form error-context-symb (mu.fn/parse-fn-tail fn-tail))
-                                      (mu.fn/deparameterized-fn-form (mu.fn/parse-fn-tail fn-tail)))]
+                                      (mu.fn/instrumented-fn-form error-context-symb :clj (mu.fn/parse-fn-tail fn-tail))
+                                      (mu.fn/deparameterized-fn-form :clj (mu.fn/parse-fn-tail fn-tail)))]
           (.addMethod ~(vary-meta multifn assoc :tag 'clojure.lang.MultiFn)
                       ~dispatch-value-symb
                       f#)))))
@@ -107,7 +107,7 @@
      "Impl for [[defmethod]] for ClojureScript."
      [multifn dispatch-value & fn-tail]
      `(core/defmethod ~multifn ~dispatch-value
-        ~@(mu.fn/deparameterized-fn-tail (mu.fn/parse-fn-tail fn-tail)))))
+        ~@(mu.fn/deparameterized-fn-tail :cljs (mu.fn/parse-fn-tail fn-tail)))))
 
 #?(:clj
    (defmacro defmethod

--- a/src/metabase/util/malli/defn.clj
+++ b/src/metabase/util/malli/defn.clj
@@ -69,16 +69,28 @@
   Unless it's in a skipped namespace during prod, (see: [[mu.fn/instrument-ns?]]) this macro emits clojure code to
   validate its inputs and outputs based on its malli schema annotations.
 
+  Supports a map after the arg list with `:pre` and `:post`, like regular Clojure functions, but also allows `:test/pre`
+  and `:test/post` which are \"weightless\" in release builds. The `:pre` and `:post` are always included, and are
+  handled by the CLJ(S) compiler as normal. The `:test/pre` and `:test/post` are combined with the un-namespaced ones
+  only when [[metabase.configuration.core/is-prod?]] is false. Additionally, each predicate from the `:test/*` variants
+  is wrapped with `(or (not mu.fn/*enforce*) ...)` so it only applies *dynamically* when [[mu.fn/*enforce*]] is true.
+  That means the test variants can be disabled by e.g. a test that does known-broken things and wants to check the prod
+  code actually rejects it, not just the dev/test-only assertions.
+
   Example macroexpansion:
 
     (mu/defn f :- :int
       [x :- :int]
+      {:post      [(pos? %)]
+       :test/post [(even? %)]}
       (inc x))
 
     ;; =>
 
     (def f
-      (let [&f (fn [x] (inc x))]
+      (let [&f (fn [x]
+                 {:post [(pos? %) (or (not *enforce*) (even? %))]}
+                 (inc x))]
         (fn ([a]
              (metabase.util.malli.fn/validate-input :int a)
              (->> (&f a)
@@ -106,9 +118,9 @@
        ~(if instrument?
           (macros/case
             :clj  (let [error-context {:fn-name (list 'quote fn-name)}]
-                    (mu.fn/instrumented-fn-form error-context parsed cosmetic-name))
-            :cljs (mu.fn/deparameterized-fn-form parsed cosmetic-name))
-          (mu.fn/deparameterized-fn-form parsed)))))
+                    (mu.fn/instrumented-fn-form error-context :clj parsed cosmetic-name))
+            :cljs (mu.fn/deparameterized-fn-form :cljs parsed cosmetic-name))
+          (mu.fn/deparameterized-fn-form (macros/case :clj :clj, :cljs :cljs) parsed)))))
 
 (defmacro defn-
   "Same as defn, but creates a private def."

--- a/src/metabase/util/malli/fn.clj
+++ b/src/metabase/util/malli/fn.clj
@@ -143,23 +143,54 @@
                        (for [arity (:arities arities-value)]
                          (arity-schema (:values arity) return-schema options)))))))
 
-(defn- deparameterized-arity [{:keys [body args prepost], :as _arity}]
+(def ^:dynamic *enforce*
+  "Whether [[validate-input]] and [[validate-output]] should validate things or not.
+
+  Setting this to false disables the `:test/pre` and `:test/post` assertions, but not mainstream `:pre` and `:post`.
+
+  Use [[metabase.util.malli/disable-enforcement]] to bind this to false in a dynamic context.
+
+  Note that this var only exists in CLJ land and not in CLJS; in CLJS Malli schemas are just stripped off."
+  true)
+
+(defn- maybe-test-prepost [lang preds]
+  ;; Perhaps surprisingly, we want to generate the preconditions in CLJS in dev and prod mode - that's because the CLJ
+  ;; side compiler is always in prod mode when compiling CLJS. The `:pre` and `:post` conditions are stripped out
+  ;; entirely by the shadow-cljs compiler in release mode.
+  (when (or (not config/is-prod?)
+            (= lang :cljs))
+    (case lang
+      :cljs preds
+      :clj  (for [pred preds]
+              `(or (not *enforce*) ~pred)))))
+
+(defn- deparameterized-arity [lang {:keys [body args prepost], :as _arity}]
   (concat
    [(:arglist (md/parse args))]
    (when prepost
-     [prepost])
+     (if (empty? body)
+       ;; If the arity is just args and a map literal, it gets parsed as prepost with an empty body.
+       ;; That's not really a prepost, but rather the body, so return it untouched.
+       [prepost]
+       (let [test-pre  (maybe-test-prepost lang (:test/pre  prepost))
+             test-post (maybe-test-prepost lang (:test/post prepost))
+             pre       (not-empty (into (vec (:pre  prepost)) test-pre))
+             post      (not-empty (into (vec (:post prepost)) test-post))]
+         [(cond-> {}
+            pre  (assoc :pre  pre)
+            post (assoc :post post))])))
    body))
 
 (defn deparameterized-fn-tail
   "Generate a deparameterized `fn` tail (the contents of a `fn` form after the `fn` symbol)."
-  [parsed]
+  [lang parsed]
   (let [arities (:arities (:values parsed))
         arities-type (:key arities)
         arities-value (:values (:value arities))
         body (case arities-type
-               :single   (deparameterized-arity arities-value)
+               :single   (deparameterized-arity lang arities-value)
                :multiple (for [arity (:arities arities-value)]
-                           (deparameterized-arity (:values arity))))]
+                           (deparameterized-arity lang (:values arity))))]
     body))
 
 (defn deparameterized-fn-form
@@ -169,13 +200,8 @@
     (deparameterized-fn-form (parse-fn-tail '[:- :int [x :- :int] (inc x)]))
     ;; =>
     (fn [x] (inc x))"
-  [parsed & [fn-name]]
-  `(core/fn ~@(when fn-name [fn-name]) ~@(deparameterized-fn-tail parsed)))
-
-(def ^:dynamic *enforce*
-  "Whether [[validate-input]] and [[validate-output]] should validate things or not. In Cljc code, you can
-  use [[metabase.util.malli/disable-enforcement]] to bind this only in Clojure code."
-  true)
+  [lang parsed & [fn-name]]
+  `(core/fn ~@(when fn-name [fn-name]) ~@(deparameterized-fn-tail lang parsed)))
 
 (defn- validate [error-context schema value error-type]
   (when *enforce*
@@ -376,9 +402,9 @@
 
     (mc/-instrument {:schema [:=> [:cat :int :any] :any]}
                     (fn [x y] (+ 1 2)))"
-  [error-context parsed & [fn-name]]
+  [error-context lang parsed & [fn-name]]
   (let [[fn-schema captured] (capture-schemas (fn-schema parsed))]
-    `(let [~'&f ~(deparameterized-fn-form parsed fn-name)
+    `(let [~'&f ~(deparameterized-fn-form lang parsed fn-name)
            ~@(into [] cat captured)]
        (core/fn ~@(instrumented-fn-tail error-context fn-schema)))))
 
@@ -449,10 +475,11 @@
         ;; Match mu/defn behavior:
         instrument? (macros/case
                       :cljs false
-                      :clj (instrument-ns? *ns*))]
+                      :clj (instrument-ns? *ns*))
+        lang        (macros/case :cljs :cljs, :clj :clj)]
     (if-not instrument?
-      (deparameterized-fn-form parsed)
+      (deparameterized-fn-form lang parsed)
       (let [error-context (if (symbol? (first fn-tail))
                             ;; We want the quoted symbol of first fn-tail:
                             {:fn-name (list 'quote (first fn-tail))} {})]
-        (instrumented-fn-form error-context parsed)))))
+        (instrumented-fn-form error-context lang parsed)))))

--- a/test/metabase/util/malli/fn_test.clj
+++ b/test/metabase/util/malli/fn_test.clj
@@ -386,7 +386,7 @@
 (deftest ^:parallel pre-post-conditions-test-1-vanilla-pass-through
   (testing "plain :pre and :post pass through the macros"
     (testing "single arity"
-      (let [expansion (macroexpand '(mu.fn/fn [{:keys [a]}]
+      (let [expansion (macroexpand '(metabase.util.malli.fn/fn [{:keys [a]}]
                                       {:pre [(pos? a)] :post [(even? %)]}
                                       (* a 2)))]
         (is (=? '(let* [&f (clojure.core/fn [{:keys [a]}]
@@ -395,7 +395,7 @@
                         &input-schema-0-a [:maybe :map]])
                 (take 2 expansion)))))
     (testing "multiple arity"
-      (let [expansion (macroexpand '(mu.fn/fn
+      (let [expansion (macroexpand '(metabase.util.malli.fn/fn
                                       ([{:keys [a]}]
                                        {:pre [(pos? a)] :post [(even? %)]}
                                        (* a 2))
@@ -415,7 +415,7 @@
 (deftest ^:synchronized pre-post-conditions-test-2-include-test-variants
   (testing ":test/pre and :test/post conditions"
     (testing "single arity"
-      (let [form '(mu.fn/fn [{:keys [a]}]
+      (let [form '(metabase.util.malli.fn/fn [{:keys [a]}]
                     {:pre       [(pos? a)]
                      :post      [(even? %)]
                      :test/pre  [(int? a)]
@@ -441,7 +441,7 @@
                             &input-schema-0-a [:maybe :map]])
                     (take 2 (macroexpand form))))))))
     (testing "multiple arity"
-      (let [form '(mu.fn/fn
+      (let [form '(metabase.util.malli.fn/fn
                     ([{:keys [a]}]
                      {:pre       [(pos? a)]
                       :post      [(even? %)]

--- a/test/metabase/util/malli/fn_test.clj
+++ b/test/metabase/util/malli/fn_test.clj
@@ -88,7 +88,7 @@
 
 (deftest ^:parallel instrumented-fn-form-test
   (are [form expected] (= expected
-                          (walk/macroexpand-all (mu.fn/instrumented-fn-form {} (mu.fn/parse-fn-tail form))))
+                          (walk/macroexpand-all (mu.fn/instrumented-fn-form {} :clj (mu.fn/parse-fn-tail form))))
     '([x :- :int y])
     '(let* [&f (fn* ([x y]))]
        (fn* ([a b]
@@ -382,3 +382,108 @@
                     (f)))
              (catch Exception _e
                (is false "it threw a schema error")))))))
+
+(deftest ^:parallel pre-post-conditions-test-1-vanilla-pass-through
+  (testing "plain :pre and :post pass through the macros"
+    (testing "single arity"
+      (let [expansion (macroexpand '(mu.fn/fn [{:keys [a]}]
+                                      {:pre [(pos? a)] :post [(even? %)]}
+                                      (* a 2)))]
+        (is (=? '(let* [&f (clojure.core/fn [{:keys [a]}]
+                             {:pre [(pos? a)] :post [(even? %)]}
+                             (* a 2))
+                        &input-schema-0-a [:maybe :map]])
+                (take 2 expansion)))))
+    (testing "multiple arity"
+      (let [expansion (macroexpand '(mu.fn/fn
+                                      ([{:keys [a]}]
+                                       {:pre [(pos? a)] :post [(even? %)]}
+                                       (* a 2))
+                                      ([m k]
+                                       {:pre [(map? m)] :post [(map? %)]}
+                                       (update m k * 2))))]
+        (is (=? '(let* [&f (clojure.core/fn
+                             ([{:keys [a]}]
+                              {:pre [(pos? a)] :post [(even? %)]}
+                              (* a 2))
+                             ([m k]
+                              {:pre [(map? m)] :post [(map? %)]}
+                              (update m k * 2)))
+                        &input-schema-0-a [:maybe :map]])
+                (take 2 expansion)))))))
+
+(deftest ^:synchronized pre-post-conditions-test-2-include-test-variants
+  (testing ":test/pre and :test/post conditions"
+    (testing "single arity"
+      (let [form '(mu.fn/fn [{:keys [a]}]
+                    {:pre       [(pos? a)]
+                     :post      [(even? %)]
+                     :test/pre  [(int? a)]
+                     :test/post [(int? %)]}
+                    (* a 2))]
+        (testing "are included in dev and test"
+          (is (=? '(let* [&f (clojure.core/fn [{:keys [a]}]
+                               {:pre  [(pos? a)
+                                       (clojure.core/or (clojure.core/not metabase.util.malli.fn/*enforce*)
+                                                        (int? a))]
+                                :post [(even? %)
+                                       (clojure.core/or (clojure.core/not metabase.util.malli.fn/*enforce*)
+                                                        (int? %))]}
+                               (* a 2))
+                          &input-schema-0-a [:maybe :map]])
+                  (take 2 (macroexpand form)))))
+        (testing "are excluded in prod"
+          (with-redefs [config/is-prod? true]
+            (is (=? '(let* [&f (clojure.core/fn [{:keys [a]}]
+                                 {:pre  [(pos? a)],
+                                  :post [(even? %)]}
+                                 (* a 2))
+                            &input-schema-0-a [:maybe :map]])
+                    (take 2 (macroexpand form))))))))
+    (testing "multiple arity"
+      (let [form '(mu.fn/fn
+                    ([{:keys [a]}]
+                     {:pre       [(pos? a)]
+                      :post      [(even? %)]
+                      :test/pre  [(int? a)]
+                      :test/post [(int? %)]}
+                     (* a 2))
+                    ([m k]
+                     {:pre       [(map? m)]
+                      :post      [(map? %)]
+                      :test/pre  [(some? k)]
+                      :test/post [(contains? m k)]}
+                     (update m k * 2)))]
+        (testing "are included in dev and test"
+          (is (=? '(let* [&f (clojure.core/fn
+                               ([{:keys [a]}]
+                                {:pre  [(pos? a)
+                                        (clojure.core/or (clojure.core/not metabase.util.malli.fn/*enforce*)
+                                                         (int? a))]
+                                 :post [(even? %)
+                                        (clojure.core/or (clojure.core/not metabase.util.malli.fn/*enforce*)
+                                                         (int? %))]}
+                                (* a 2))
+                               ([m k]
+                                {:pre  [(map? m)
+                                        (clojure.core/or (clojure.core/not metabase.util.malli.fn/*enforce*)
+                                                         (some? k))]
+                                 :post [(map? %)
+                                        (clojure.core/or (clojure.core/not metabase.util.malli.fn/*enforce*)
+                                                         (contains? m k))]}
+                                (update m k * 2)))
+                          &input-schema-0-a [:maybe :map]])
+                  (take 2 (macroexpand form)))))
+        (testing "are excluded in prod"
+          (with-redefs [config/is-prod? true]
+            (is (=? '(let* [&f (clojure.core/fn
+                                 ([{:keys [a]}]
+                                  {:pre  [(pos? a)]
+                                   :post [(even? %)]}
+                                  (* a 2))
+                                 ([m k]
+                                  {:pre  [(map? m)]
+                                   :post [(map? %)]}
+                                  (update m k * 2)))
+                            &input-schema-0-a [:maybe :map]])
+                    (take 2 (macroexpand form))))))))))


### PR DESCRIPTION
Closes QUE2-496.

### Description

These work like Clojure's built-in `:pre` and `:post` conditions, but
are only enabled in non-prod modes on both CLJ and CLJS.

Core `:pre` and `:post` are treated as assertions. Our shadow-cljs
configuration drops assertions in release mode, but Metabase on the
JVM runs with assertions enabled even in prod, since they're used to
check some important conditions.

That's weird and might change, but in the meantime `:test/pre` and
`:test/post for now give us "weightless", test-like pre- and
postconditions.


### How to verify

Try them out in the code, or see the example usage on `lib.metadata.calculation/visible-columns`.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
