### PR TITLE
Expose chart in messages

### DIFF
--- a/enterprise/frontend/src/embedding-sdk-ee/metabot/MetabotChatHistory.tsx
+++ b/enterprise/frontend/src/embedding-sdk-ee/metabot/MetabotChatHistory.tsx
@@ -35,7 +35,7 @@ export function MetabotChatHistory() {
     >
       {hasMessages ? (
         <Messages
-          messages={messages}
+          messages={messages.filter((message) => message.type !== "chart")}
           errorMessages={errorMessages}
           onRetryMessage={metabot.retryMessage}
           isDoingScience={metabot.isDoingScience}

--- a/enterprise/frontend/src/embedding-sdk-ee/metabot/MetabotChatHistory.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk-ee/metabot/MetabotChatHistory.unit.spec.tsx
@@ -1,0 +1,59 @@
+import { assocIn } from "icepick";
+
+import { screen } from "__support__/ui";
+import { getMetabotInitialState } from "metabase/metabot/state/reducer-utils";
+import { setup } from "metabase/metabot/tests/utils";
+
+import { MetabotChatHistory } from "./MetabotChatHistory";
+
+const makeVisibleState = (
+  messages: {
+    id: string;
+    role: "agent" | "user";
+    type: string;
+    [key: string]: unknown;
+  }[],
+) =>
+  assocIn(
+    assocIn(
+      getMetabotInitialState(),
+      ["conversations", "omnibot", "visible"],
+      true,
+    ),
+    ["conversations", "omnibot", "messages"],
+    messages,
+  );
+
+describe("MetabotChatHistory", () => {
+  it("should not render chart messages in the message list", () => {
+    setup({
+      ui: <MetabotChatHistory />,
+      metabotInitialState: makeVisibleState([
+        {
+          id: "1",
+          role: "agent",
+          type: "chart",
+          navigateTo: "/question#abc",
+        },
+      ]),
+    });
+
+    expect(
+      screen.queryByTestId("metabot-chat-message"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should render non-chart messages normally", async () => {
+    setup({
+      ui: <MetabotChatHistory />,
+      metabotInitialState: makeVisibleState([
+        { id: "1", role: "agent", type: "text", message: "Hello world" },
+      ]),
+    });
+
+    expect(
+      await screen.findByTestId("metabot-chat-message"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Hello world")).toBeInTheDocument();
+  });
+});

--- a/enterprise/frontend/src/embedding-sdk-ee/metabot/MetabotChatHistory.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk-ee/metabot/MetabotChatHistory.unit.spec.tsx
@@ -2,18 +2,12 @@ import { assocIn } from "icepick";
 
 import { screen } from "__support__/ui";
 import { getMetabotInitialState } from "metabase/metabot/state/reducer-utils";
+import type { MetabotChatMessage } from "metabase/metabot/state/types";
 import { setup } from "metabase/metabot/tests/utils";
 
 import { MetabotChatHistory } from "./MetabotChatHistory";
 
-const makeVisibleState = (
-  messages: {
-    id: string;
-    role: "agent" | "user";
-    type: string;
-    [key: string]: unknown;
-  }[],
-) =>
+const makeVisibleState = (messages: MetabotChatMessage[]) =>
   assocIn(
     assocIn(
       getMetabotInitialState(),

--- a/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot.tsx
+++ b/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot.tsx
@@ -52,7 +52,10 @@ export const useMetabot = (): UseMetabotResult => {
   );
 
   const messages = useMemo<MetabotMessage[]>(
-    () => agent.messages.filter(isPublicMessage).map(mapMessage),
+    () =>
+      agent.messages
+        .filter(isPublicMessage)
+        .map((message) => mapMessage(message, chartComponentsCache.current)),
     [agent.messages],
   );
 
@@ -110,7 +113,10 @@ const isPublicMessage = (
   message.type !== "action" &&
   message.type !== "todo_list";
 
-const mapMessage = (message: PublicChatMessage): MetabotMessage =>
+const mapMessage = (
+  message: PublicChatMessage,
+  cache: Map<string, ReturnType<typeof createChartComponent>>,
+): MetabotMessage =>
   match(message)
     .with(
       { role: "user", type: "text" },
@@ -121,5 +127,16 @@ const mapMessage = (message: PublicChatMessage): MetabotMessage =>
       { role: "agent", type: "text" },
       ({ id, message }) =>
         ({ id, role: "agent", type: "text", message }) as const,
+    )
+    .with(
+      { role: "agent", type: "chart" },
+      ({ id, navigateTo }) =>
+        ({
+          id,
+          role: "agent",
+          type: "chart",
+          questionPath: navigateTo,
+          Component: getCachedChartComponent(navigateTo, cache),
+        }) as const,
     )
     .exhaustive();

--- a/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot.tsx
+++ b/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot.tsx
@@ -136,7 +136,7 @@ const mapMessage = (
           role: "agent",
           type: "chart",
           questionPath: navigateTo,
-          Component: getCachedChartComponent(navigateTo, cache),
+          Chart: getCachedChartComponent(navigateTo, cache),
         }) as const,
     )
     .exhaustive();

--- a/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot.unit.spec.tsx
@@ -32,17 +32,14 @@ jest.mock("embedding-sdk-bundle/components/public/StaticQuestion", () => {
   const Component = ({ query }: { query?: string }) => (
     <div data-testid="mock-static-question" data-query={query} />
   );
-  return { StaticQuestion: Component, StaticQuestionInternal: Component };
+  return { StaticQuestionInternal: Component };
 });
 
 jest.mock("embedding-sdk-bundle/components/public/InteractiveQuestion", () => {
   const Component = ({ query }: { query?: string }) => (
     <div data-testid="mock-interactive-question" data-query={query} />
   );
-  return {
-    InteractiveQuestion: Component,
-    InteractiveQuestionInternal: Component,
-  };
+  return { InteractiveQuestionInternal: Component };
 });
 
 describe("useMetabot", () => {

--- a/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot.unit.spec.tsx
@@ -170,6 +170,15 @@ describe("useMetabot", () => {
 
       act(() => {
         store.dispatch(
+          // `addAgentMessage`/`addUserMessage` in reducer.ts type their payload
+          // as `Omit<UnionType, ...>`. Non-distributive `Omit` collapses the
+          // discriminated union to common keys only, so branch-specific fields
+          // (message, navigateTo, payload, ...) fail excess-property checks
+          // without `as any`. Switching to a DistributiveOmit would unblock
+          // call sites here but surfaces more errors elsewhere (e.g. the
+          // edit_suggestion payload hits the "infinite TS errors" noted in
+          // reducer.ts). Keeping `as any` for now — applies to every dispatch
+          // below.
           metabotActions.addAgentMessage({
             agentId: "omnibot",
             type: "text",

--- a/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot.unit.spec.tsx
@@ -354,7 +354,7 @@ describe("useMetabot", () => {
   describe("messages[n].Component", () => {
     const TestMessageComponent = ({ drills }: { drills?: true }) => {
       const { messages } = useMetabot();
-      const chartMessage = messages.find((m) => m.type === "chart");
+      const chartMessage = messages.find((message) => message.type === "chart");
       if (!chartMessage) {
         return null;
       }
@@ -403,7 +403,9 @@ describe("useMetabot", () => {
 
       const TestCapture = () => {
         const { messages } = useMetabot();
-        const chartMessages = messages.filter((m) => m.type === "chart");
+        const chartMessages = messages.filter(
+          (message) => message.type === "chart",
+        );
         if (chartMessages[0]) {
           firstComponent = chartMessages[0].Component;
         }

--- a/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot.unit.spec.tsx
@@ -197,7 +197,7 @@ describe("useMetabot", () => {
       // `Component` is a React component reference — JSON.stringify drops
       // functions, so it appears as `undefined` in the serialized snapshot
       // the harness reads. We assert only the serializable fields here;
-      // component wiring is covered by `CurrentChart` tests.
+      // `Component` wiring is covered by the `messages[n].Component` describe.
       expect(message).toEqual({
         id: expect.any(String),
         role: "agent",
@@ -348,6 +348,101 @@ describe("useMetabot", () => {
 
       await waitFor(() => expect(onResolved).toHaveBeenCalled());
       expect(onResolved).toHaveBeenCalledWith(undefined);
+    });
+  });
+
+  describe("messages[n].Component", () => {
+    const TestMessageComponent = ({ drills }: { drills?: true }) => {
+      const { messages } = useMetabot();
+      const chartMessage = messages.find((m) => m.type === "chart");
+      if (!chartMessage) {
+        return null;
+      }
+      const { Component } = chartMessage;
+      return <Component drills={drills} />;
+    };
+
+    it("renders StaticQuestion when drills is absent", async () => {
+      const { store } = setup({ ui: <TestMessageComponent /> });
+
+      act(() => {
+        store.dispatch(
+          metabotActions.addAgentMessage({
+            agentId: "omnibot",
+            type: "chart",
+            navigateTo: "/question#abc",
+          } as any),
+        );
+      });
+
+      expect(
+        await screen.findByTestId("mock-static-question"),
+      ).toBeInTheDocument();
+    });
+
+    it("renders InteractiveQuestion when drills is true", async () => {
+      const { store } = setup({ ui: <TestMessageComponent drills /> });
+
+      act(() => {
+        store.dispatch(
+          metabotActions.addAgentMessage({
+            agentId: "omnibot",
+            type: "chart",
+            navigateTo: "/question#abc",
+          } as any),
+        );
+      });
+
+      expect(
+        await screen.findByTestId("mock-interactive-question"),
+      ).toBeInTheDocument();
+    });
+
+    it("Component reference is stable after a second chart message arrives", async () => {
+      let firstComponent: unknown = null;
+
+      const TestCapture = () => {
+        const { messages } = useMetabot();
+        const chartMessages = messages.filter((m) => m.type === "chart");
+        if (chartMessages[0]) {
+          firstComponent = chartMessages[0].Component;
+        }
+        return <div data-testid="chart-count">{chartMessages.length}</div>;
+      };
+
+      const { store } = setup({ ui: <TestCapture /> });
+
+      act(() => {
+        store.dispatch(
+          metabotActions.addAgentMessage({
+            agentId: "omnibot",
+            type: "chart",
+            navigateTo: "/question#abc",
+          } as any),
+        );
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("chart-count")).toHaveTextContent("1");
+      });
+      const capturedComponent = firstComponent;
+      expect(capturedComponent).not.toBeNull();
+
+      act(() => {
+        store.dispatch(
+          metabotActions.addAgentMessage({
+            agentId: "omnibot",
+            type: "chart",
+            navigateTo: "/question#xyz",
+          } as any),
+        );
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("chart-count")).toHaveTextContent("2");
+      });
+
+      expect(firstComponent).toBe(capturedComponent);
     });
   });
 });

--- a/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot.unit.spec.tsx
@@ -12,6 +12,16 @@ import {
 
 import { useMetabot } from "./use-metabot";
 
+/**
+ * This file covers hook wiring for non-passthrough behavior. The following
+ * result properties are deliberately not tested here because they forward
+ * directly to `useMetabotAgent` with no transformation:
+ *   - retryMessage       → agent.retryMessage(messageId)
+ *   - cancelRequest      → agent.cancelRequest
+ *   - resetConversation  → agent.resetConversation
+ *   - errorMessages      → agent.errorMessages
+ *   - isProcessing       → agent.isDoingScience (renamed)
+ */
 // These tests verify `useMetabot().CurrentChart` wiring only: renders nothing
 // before `navigate_to`, StaticQuestion vs InteractiveQuestion based on
 // `drills`, and `query` forwarding. Mocks surface `data-testid` + `data-query`

--- a/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot.unit.spec.tsx
@@ -194,10 +194,10 @@ describe("useMetabot", () => {
       });
 
       const [message] = await readMessages();
-      // `Component` is a React component reference — JSON.stringify drops
+      // `Chart` is a React component reference — JSON.stringify drops
       // functions, so it appears as `undefined` in the serialized snapshot
       // the harness reads. We assert only the serializable fields here;
-      // `Component` wiring is covered by the `messages[n].Component` describe.
+      // `Chart` wiring is covered by the `messages[n].Chart` describe.
       expect(message).toEqual({
         id: expect.any(String),
         role: "agent",
@@ -351,15 +351,15 @@ describe("useMetabot", () => {
     });
   });
 
-  describe("messages[n].Component", () => {
+  describe("messages[n].Chart", () => {
     const TestMessageComponent = ({ drills }: { drills?: true }) => {
       const { messages } = useMetabot();
       const chartMessage = messages.find((message) => message.type === "chart");
       if (!chartMessage) {
         return null;
       }
-      const { Component } = chartMessage;
-      return <Component drills={drills} />;
+      const { Chart } = chartMessage;
+      return <Chart drills={drills} />;
     };
 
     it("renders StaticQuestion when drills is absent", async () => {
@@ -398,8 +398,8 @@ describe("useMetabot", () => {
       ).toBeInTheDocument();
     });
 
-    it("Component reference is stable after a second chart message arrives", async () => {
-      let firstComponent: unknown = null;
+    it("Chart reference is stable after a second chart message arrives", async () => {
+      let firstChart: unknown = null;
 
       const TestCapture = () => {
         const { messages } = useMetabot();
@@ -407,7 +407,7 @@ describe("useMetabot", () => {
           (message) => message.type === "chart",
         );
         if (chartMessages[0]) {
-          firstComponent = chartMessages[0].Component;
+          firstChart = chartMessages[0].Chart;
         }
         return <div data-testid="chart-count">{chartMessages.length}</div>;
       };
@@ -427,8 +427,8 @@ describe("useMetabot", () => {
       await waitFor(() => {
         expect(screen.getByTestId("chart-count")).toHaveTextContent("1");
       });
-      const capturedComponent = firstComponent;
-      expect(capturedComponent).not.toBeNull();
+      const capturedChart = firstChart;
+      expect(capturedChart).not.toBeNull();
 
       act(() => {
         store.dispatch(
@@ -444,7 +444,7 @@ describe("useMetabot", () => {
         expect(screen.getByTestId("chart-count")).toHaveTextContent("2");
       });
 
-      expect(firstComponent).toBe(capturedComponent);
+      expect(firstChart).toBe(capturedChart);
     });
   });
 });

--- a/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/hooks/public/use-metabot.unit.spec.tsx
@@ -180,6 +180,32 @@ describe("useMetabot", () => {
       });
     });
 
+    it("renames `navigateTo` to `questionPath` on agent.chart", async () => {
+      const { store } = setup({ ui: <TestMessages /> });
+
+      act(() => {
+        store.dispatch(
+          metabotActions.addAgentMessage({
+            agentId: "omnibot",
+            type: "chart",
+            navigateTo: "/question#base64",
+          } as any),
+        );
+      });
+
+      const [message] = await readMessages();
+      // `Component` is a React component reference — JSON.stringify drops
+      // functions, so it appears as `undefined` in the serialized snapshot
+      // the harness reads. We assert only the serializable fields here;
+      // component wiring is covered by `CurrentChart` tests.
+      expect(message).toEqual({
+        id: expect.any(String),
+        role: "agent",
+        type: "chart",
+        questionPath: "/question#base64",
+      });
+    });
+
     it("filters out internal-only variants (tool_call, edit_suggestion, user action, todo_list)", async () => {
       const { store } = setup({ ui: <TestMessages /> });
 

--- a/frontend/src/embedding-sdk-bundle/types/metabot.ts
+++ b/frontend/src/embedding-sdk-bundle/types/metabot.ts
@@ -71,6 +71,10 @@ export type UseMetabotResult = {
   messages: MetabotMessage[];
   /** Errors are conversation-level, not attached to individual messages. */
   errorMessages: MetabotErrorMessage[];
+  /**
+   * `true` from the moment a message is submitted until the response
+   * completes — including success, error, or cancellation.
+   */
   isProcessing: boolean;
 
   /**

--- a/frontend/src/embedding-sdk-bundle/types/metabot.ts
+++ b/frontend/src/embedding-sdk-bundle/types/metabot.ts
@@ -21,12 +21,22 @@ type MetabotAgentTextMessage = {
   message: string;
 };
 
+type MetabotAgentChartMessage = {
+  id: string;
+  role: "agent";
+  type: "chart";
+  /** URL path to the question, e.g. `/question#<base64>` */
+  questionPath: string;
+  /** A pre-wired React component that renders the chart. */
+  Component: React.ComponentType<MetabotChartProps>;
+};
+
 // Internal variants intentionally omitted. `use-metabot.tsx` filters these out before mapping:
 // - `tool_call`: debug-only, gated on metabot's `debugMode`.
 // - `edit_suggestion`: targets the in-app Transform editor, which the SDK does not render.
 // - `action`: unused in shipped code.
 // - `todo_list`: only reachable via the `codegen/transforms` profile, not the SDK.
-type MetabotAgentMessage = MetabotAgentTextMessage;
+type MetabotAgentMessage = MetabotAgentTextMessage | MetabotAgentChartMessage;
 
 export type MetabotMessage = MetabotUserTextMessage | MetabotAgentMessage;
 
@@ -57,7 +67,7 @@ export type UseMetabotResult = {
   /** Clear all messages and start fresh. */
   resetConversation: () => void;
 
-  /** All messages in the conversation. */
+  /** All messages in the conversation. Chart messages include a `Component` property. */
   messages: MetabotMessage[];
   /** Errors are conversation-level, not attached to individual messages. */
   errorMessages: MetabotErrorMessage[];

--- a/frontend/src/embedding-sdk-bundle/types/metabot.ts
+++ b/frontend/src/embedding-sdk-bundle/types/metabot.ts
@@ -28,7 +28,7 @@ type MetabotAgentChartMessage = {
   /** URL path to the question, e.g. `/question#<base64>` */
   questionPath: string;
   /** A pre-wired React component that renders the chart. */
-  Component: React.ComponentType<MetabotChartProps>;
+  Chart: React.ComponentType<MetabotChartProps>;
 };
 
 // Internal variants intentionally omitted. `use-metabot.tsx` filters these out before mapping:
@@ -67,7 +67,7 @@ export type UseMetabotResult = {
   /** Clear all messages and start fresh. */
   resetConversation: () => void;
 
-  /** All messages in the conversation. Chart messages include a `Component` property. */
+  /** All messages in the conversation. Chart messages include a `Chart` property. */
   messages: MetabotMessage[];
   /** Errors are conversation-level, not attached to individual messages. */
   errorMessages: MetabotErrorMessage[];

--- a/frontend/src/metabase/metabot/state/actions.ts
+++ b/frontend/src/metabase/metabot/state/actions.ts
@@ -38,6 +38,7 @@ import {
   getUserPromptForMessageId,
 } from "./selectors";
 import type {
+  MetabotAgentChartMessage,
   MetabotAgentEditSuggestionChatMessage,
   MetabotAgentId,
   MetabotAgentTodoListChatMessage,
@@ -355,6 +356,9 @@ export const sendAgentRequest = createAsyncThunk<
     try {
       let state = {};
       let error: unknown = undefined;
+      let pendingChartMessage:
+        | { type: "chart"; navigateTo: string }
+        | undefined = undefined;
 
       const response = await aiStreamingQuery(
         {
@@ -390,6 +394,13 @@ export const sendAgentRequest = createAsyncThunk<
               })
               .with({ type: "navigate_to" }, (part) => {
                 dispatch(setNavigateToPath(part.value));
+
+                if (isEmbeddingSdk()) {
+                  pendingChartMessage = {
+                    type: "chart",
+                    navigateTo: part.value,
+                  };
+                }
 
                 if (!isEmbeddingSdk()) {
                   dispatch(push(part.value) as UnknownAction);
@@ -455,6 +466,12 @@ export const sendAgentRequest = createAsyncThunk<
           // so fallback to the state used when the request was issued
           state: Object.keys(state).length === 0 ? request.state : state,
         });
+      }
+
+      if (pendingChartMessage != null) {
+        const chartMsg: Omit<MetabotAgentChartMessage, "id" | "role"> =
+          pendingChartMessage;
+        dispatch(addAgentMessage({ ...chartMsg, agentId }));
       }
 
       return fulfillWithValue({

--- a/frontend/src/metabase/metabot/state/actions.ts
+++ b/frontend/src/metabase/metabot/state/actions.ts
@@ -356,6 +356,8 @@ export const sendAgentRequest = createAsyncThunk<
     try {
       let state = {};
       let error: unknown = undefined;
+      // Last navigate_to wins, matching setNavigateToPath/CurrentChart semantics.
+      // In practice we don't expect more than one navigate_to in a single stream.
       let pendingChartMessage:
         | { type: "chart"; navigateTo: string }
         | undefined = undefined;

--- a/frontend/src/metabase/metabot/state/actions.ts
+++ b/frontend/src/metabase/metabot/state/actions.ts
@@ -405,6 +405,12 @@ export const sendAgentRequest = createAsyncThunk<
                 dispatch(setNavigateToPath(part.value));
 
                 if (isEmbeddingSdk()) {
+                  if (pendingChartMessage) {
+                    console.warn("Overwriting pending navigate_to: ", {
+                      previous: pendingChartMessage.navigateTo,
+                      next: part.value,
+                    });
+                  }
                   pendingChartMessage = {
                     type: "chart",
                     navigateTo: part.value,

--- a/frontend/src/metabase/metabot/state/actions.ts
+++ b/frontend/src/metabase/metabot/state/actions.ts
@@ -356,8 +356,15 @@ export const sendAgentRequest = createAsyncThunk<
     try {
       let state = {};
       let error: unknown = undefined;
-      // Last navigate_to wins, matching setNavigateToPath/CurrentChart semantics.
-      // In practice we don't expect more than one navigate_to in a single stream.
+      /**
+       * Hold the chart message until the stream finishes so it renders after
+       * the agent's final text. `navigate_to` arrives mid-stream, before the
+       * last message, so inserting it eagerly would show the chart above later
+       * text.
+       *
+       * Last navigate_to wins, matching setNavigateToPath/CurrentChart semantics.
+       * In practice we don't expect more than one navigate_to in a single stream.
+       */
       let pendingChartMessage:
         | { type: "chart"; navigateTo: string }
         | undefined = undefined;
@@ -471,9 +478,9 @@ export const sendAgentRequest = createAsyncThunk<
       }
 
       if (pendingChartMessage != null) {
-        const chartMsg: Omit<MetabotAgentChartMessage, "id" | "role"> =
+        const chartMessage: Omit<MetabotAgentChartMessage, "id" | "role"> =
           pendingChartMessage;
-        dispatch(addAgentMessage({ ...chartMsg, agentId }));
+        dispatch(addAgentMessage({ ...chartMessage, agentId }));
       }
 
       return fulfillWithValue({

--- a/frontend/src/metabase/metabot/state/types.ts
+++ b/frontend/src/metabase/metabot/state/types.ts
@@ -57,11 +57,19 @@ export type MetabotDebugToolCallMessage = {
   is_error?: boolean;
 };
 
+export type MetabotAgentChartMessage = {
+  id: string;
+  role: "agent";
+  type: "chart";
+  navigateTo: string;
+};
+
 export type MetabotAgentChatMessage =
   | MetabotAgentTextChatMessage
   | MetabotAgentTodoListChatMessage
   | MetabotAgentEditSuggestionChatMessage
-  | MetabotDebugToolCallMessage;
+  | MetabotDebugToolCallMessage
+  | MetabotAgentChartMessage;
 
 export type MetabotUserChatMessage =
   | MetabotUserTextChatMessage


### PR DESCRIPTION
closes EMB-1562

### Description

This PR exposes `messages[n].Chart`

Note that there was a plan to add E2E test here, but it was extracted to EMB-1616 because it's too complex to be in here.

### How to verify
Checkout https://github.com/metabase/metabase/pull/71996
1. Run BE
2. Run storybook
    ```sh
    bun run storybook-embedding-sdk
    ```
3. Visit The Devops story http://localhost:6006/?path=/story/embeddingsdk-usemetabot-devops-infrawatch-monitoring--infra-watch-monitoring

### Demo
<img width="944" height="616" alt="image" src="https://github.com/user-attachments/assets/605b84d5-4074-40ff-9351-c36e420e5cbc" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
