### PR TITLE
Strip bloat fields from :tool-output; add logging/metrics around stored metabot message size

### DIFF
--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -594,6 +594,11 @@
                           :labels [:profile-id]
                           ;; 100ms -> 10 minutes
                           :buckets [100 500 1000 5000 10000 30000 60000 120000 300000 600000]})
+   (prometheus/histogram :metabase-metabot/message-persist-bytes
+                         {:description "Size in bytes of persisted metabot message data (JSON)"
+                          :labels [:profile-id]
+                          ;; 1KB -> 5MB
+                          :buckets [1000 5000 10000 50000 100000 500000 1000000 5000000]})
 
    ;; release dashboard metrics
    (prometheus/counter :metabase-sync/failures

--- a/src/metabase/metabot/api.clj
+++ b/src/metabase/metabot/api.clj
@@ -4,6 +4,7 @@
    [clojure.core.async :as a]
    [clojure.string :as str]
    [medley.core :as m]
+   [metabase.analytics.prometheus :as prometheus]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.api.routes.common :refer [+auth]]
@@ -87,6 +88,16 @@
    {}
    parts))
 
+(defn- strip-tool-output-bloat
+  "For :tool-output parts, keep only :output in the result map.
+  Both LLM adapters only read (get-in part [:result :output]) when replaying history.
+  Everything else (:structured-output, :resources, :data-parts, etc.) is transient
+  runtime data that can be very large."
+  [{:keys [type result] :as part}]
+  (if (= :tool-output type)
+    (assoc part :result {:output (:output result)})
+    part))
+
 (defn- store-native-parts!
   "Store assistant response parts directly to the database.
 
@@ -104,7 +115,10 @@
         ;; :data is like `:navigate_to`
         content    (->> parts
                         (remove #(#{:start :usage :finish :data} (:type %)))
-                        vec)]
+                        (mapv strip-tool-output-bloat))]
+    (prometheus/observe! :metabase-metabot/message-persist-bytes
+                         {:profile-id (or profile-id "unknown")}
+                         (count (pr-str content)))
     (t2/with-transaction [_conn]
       (when state-part
         (app-db/update-or-insert! :model/MetabotConversation {:id conversation-id}

--- a/src/metabase/metabot/api.clj
+++ b/src/metabase/metabot/api.clj
@@ -92,8 +92,8 @@
 (defn- strip-tool-output-bloat
   "For :tool-output parts, keep only :output in the result map.
   Both LLM adapters only read (get-in part [:result :output]) when replaying history.
-  Everything else (:structured-output, :resources, :data-parts, etc.) is transient
-  runtime data that can be very large."
+  Everything else (:structured-output, :resources, :data-parts, :reactions, etc.)
+  is transient runtime data consumed during streaming and can be very large."
   [{:keys [type] :as part}]
   (cond-> part
     (= :tool-output type) (update :result select-keys [:output])))

--- a/src/metabase/metabot/api.clj
+++ b/src/metabase/metabot/api.clj
@@ -31,6 +31,7 @@
    [metabase.settings.core :as setting]
    [metabase.slackbot.api]
    [metabase.util :as u]
+   [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
@@ -115,10 +116,11 @@
         ;; :data is like `:navigate_to`
         content    (->> parts
                         (remove #(#{:start :usage :finish :data} (:type %)))
-                        (mapv strip-tool-output-bloat))]
+                        (mapv strip-tool-output-bloat))
+        content-json (json/encode content)]
     (prometheus/observe! :metabase-metabot/message-persist-bytes
                          {:profile-id (or profile-id "unknown")}
-                         (count (pr-str content)))
+                         (u/string-byte-count content-json))
     (t2/with-transaction [_conn]
       (when state-part
         (app-db/update-or-insert! :model/MetabotConversation {:id conversation-id}
@@ -126,7 +128,7 @@
                                                :state   (:data state-part)})))
       (t2/insert! :model/MetabotMessage
                   {:conversation_id conversation-id
-                   :data            content
+                   :data            content-json
                    :usage           usage
                    :role            :assistant
                    :profile_id      profile-id

--- a/src/metabase/metabot/api.clj
+++ b/src/metabase/metabot/api.clj
@@ -94,10 +94,9 @@
   Both LLM adapters only read (get-in part [:result :output]) when replaying history.
   Everything else (:structured-output, :resources, :data-parts, etc.) is transient
   runtime data that can be very large."
-  [{:keys [type result] :as part}]
-  (if (= :tool-output type)
-    (assoc part :result {:output (:output result)})
-    part))
+  [{:keys [type] :as part}]
+  (cond-> part
+    (= :tool-output type) (update :result select-keys [:output])))
 
 (defn- store-native-parts!
   "Store assistant response parts directly to the database.
@@ -116,11 +115,10 @@
         ;; :data is like `:navigate_to`
         content    (->> parts
                         (remove #(#{:start :usage :finish :data} (:type %)))
-                        (mapv strip-tool-output-bloat))
-        content-json (json/encode content)]
+                        (mapv strip-tool-output-bloat))]
     (prometheus/observe! :metabase-metabot/message-persist-bytes
                          {:profile-id (or profile-id "unknown")}
-                         (u/string-byte-count content-json))
+                         (u/string-byte-count (json/encode content)))
     (t2/with-transaction [_conn]
       (when state-part
         (app-db/update-or-insert! :model/MetabotConversation {:id conversation-id}
@@ -128,7 +126,7 @@
                                                :state   (:data state-part)})))
       (t2/insert! :model/MetabotMessage
                   {:conversation_id conversation-id
-                   :data            content-json
+                   :data            content
                    :usage           usage
                    :role            :assistant
                    :profile_id      profile-id

--- a/test/metabase/metabot/api_test.clj
+++ b/test/metabase/metabot/api_test.clj
@@ -603,6 +603,26 @@
       (is (= {:claude-sonnet-4-6 {:prompt 100 :completion 50}}
              (:usage msg))))))
 
+(deftest strip-tool-output-bloat-test
+  (testing "strips transient keys from tool-output results, keeping only :output"
+    (is (= {:type :tool-output :id "call-1" :result {:output "<result>XML</result>"}}
+           (#'api/strip-tool-output-bloat
+            {:type   :tool-output
+             :id     "call-1"
+             :result {:output            "<result>XML</result>"
+                      :resources         [{:id 1 :name "Orders" :columns [{:field_values [1 2 3]}]}]
+                      :structured-output {:result-type :search :data [{:id 1}]}
+                      :data-parts        [{:type :data :data-type "navigate_to"}]}}))))
+  (testing "leaves non-tool-output parts untouched"
+    (let [text-part {:type :text :text "hello"}]
+      (is (= text-part (#'api/strip-tool-output-bloat text-part)))))
+  (testing "handles result with no :output key"
+    (is (= {:type :tool-output :id "call-2" :result {:output nil}}
+           (#'api/strip-tool-output-bloat
+            {:type   :tool-output
+             :id     "call-2"
+             :result {:structured-output {:some "data"}}})))))
+
 (defn- legacy-query
   "A legacy inner-query-style map suitable for [[#'api/upgrade-viewing-queries]]."
   []

--- a/test/metabase/metabot/api_test.clj
+++ b/test/metabase/metabot/api_test.clj
@@ -617,7 +617,7 @@
     (let [text-part {:type :text :text "hello"}]
       (is (= text-part (#'api/strip-tool-output-bloat text-part)))))
   (testing "handles result with no :output key"
-    (is (= {:type :tool-output :id "call-2" :result {:output nil}}
+    (is (= {:type :tool-output :id "call-2" :result {}}
            (#'api/strip-tool-output-bloat
             {:type   :tool-output
              :id     "call-2"


### PR DESCRIPTION
Since the clojure port, tool call results stored in `metabot_message.data` have included `:resources`, `:structured-output`, and some other fields which can get very large but are transient runtime data not needed for reconstructing chat history. This switches persisted tool calls to just store `:output`. Additionally I've added debug logging + prometheus metrics around persisted metabot_message size.