### PR TITLE
Fix serdes breaking on IDs for db/table/fields for non-existent entities

### DIFF
--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -1102,8 +1102,7 @@
                                          :fk_target_field_id [:not= nil]))
         fk-table-ids (when (seq fk-field-ids)
                        (t2/select-fn-set :table_id :model/Field
-                                         :id [:in fk-field-ids]
-                                         :table_id [:not= nil]))
+                                         :id [:in fk-field-ids]))
         fk-tables    (when (seq fk-table-ids)
                        (t2/select-pk->fn identity [:model/Table :id :db_id :name :schema]
                                          :id [:in fk-table-ids]
@@ -1224,8 +1223,7 @@
                                             :fk_target_field_id [:not= nil])
             fk-table-ids  (when (seq fk-field-ids)
                             (t2/select-fn-set :table_id :model/Field
-                                              :id [:in fk-field-ids]
-                                              :table_id [:not= nil]))
+                                              :id [:in fk-field-ids]))
             all-table-ids (into #{table-id} fk-table-ids)
             extras        (t2/select-pk->fn identity [:model/Field :id :name :table_id :parent_id]
                                             :id [:not-in (set (keys required))]

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -1227,9 +1227,8 @@
                                               :id [:in fk-field-ids]
                                               :table_id [:not= nil]))
             all-table-ids (into #{table-id} fk-table-ids)
-            required-ids  (set (keys required))
             extras        (t2/select-pk->fn identity [:model/Field :id :name :table_id :parent_id]
-                                            :id [:not-in required-ids]
+                                            :id [:not-in (set (keys required))]
                                             :table_id [:in all-table-ids]
                                             {:limit remaining})]
         (merge required extras)))))

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -1224,8 +1224,9 @@
                                             :fk_target_field_id [:not= nil])
             fk-table-ids  (when (seq fk-field-ids)
                             (t2/select-fn-set :table_id :model/Field
-                                              :id [:in fk-field-ids]))
-            all-table-ids (into (if table-id #{table-id} #{}) fk-table-ids)
+                                              :id [:in fk-field-ids]
+                                              :table_id [:not= nil]))
+            all-table-ids (into #{table-id} fk-table-ids)
             required-ids  (set (keys required))
             extras        (t2/select-pk->fn identity [:model/Field :id :name :table_id :parent_id]
                                             :id [:not-in required-ids]

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -1101,8 +1101,7 @@
                                          :table_id id
                                          :fk_target_field_id [:not= nil]))
         fk-table-ids (when (seq fk-field-ids)
-                       (t2/select-fn-set :table_id :model/Field
-                                         :id [:in fk-field-ids]))
+                       (t2/select-fn-set :table_id :model/Field :id [:in fk-field-ids]))
         fk-tables    (when (seq fk-table-ids)
                        (t2/select-pk->fn identity [:model/Table :id :db_id :name :schema]
                                          :id [:in fk-table-ids]
@@ -1222,8 +1221,7 @@
                                             :table_id table-id
                                             :fk_target_field_id [:not= nil])
             fk-table-ids  (when (seq fk-field-ids)
-                            (t2/select-fn-set :table_id :model/Field
-                                              :id [:in fk-field-ids]))
+                            (t2/select-fn-set :table_id :model/Field :id [:in fk-field-ids]))
             all-table-ids (into #{table-id} fk-table-ids)
             extras        (t2/select-pk->fn identity [:model/Field :id :name :table_id :parent_id]
                                             :id [:not-in (set (keys required))]

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -1216,26 +1216,21 @@
   [field-id max-batch]
   (let [required  (load-field-hierarchy field-id)
         remaining (- max-batch (count required))]
-    (if-not (pos? remaining)
+    (if (or (empty? required) (not (pos? remaining)))
       required
       (let [table-id      (:table_id (get required field-id))
-            fk-field-ids  (when table-id
-                            (t2/select-fn-set :fk_target_field_id :model/Field
-                                              :table_id table-id
-                                              :fk_target_field_id [:not= nil]))
+            fk-field-ids  (t2/select-fn-set :fk_target_field_id :model/Field
+                                            :table_id table-id
+                                            :fk_target_field_id [:not= nil])
             fk-table-ids  (when (seq fk-field-ids)
                             (t2/select-fn-set :table_id :model/Field
-                                              :id [:in fk-field-ids]
-                                              :table_id [:not= nil]))
-            all-table-ids (cond-> #{}
-                            table-id           (conj table-id)
-                            (seq fk-table-ids) (into fk-table-ids))
+                                              :id [:in fk-field-ids]))
+            all-table-ids (into (if table-id #{table-id} #{}) fk-table-ids)
             required-ids  (set (keys required))
-            extras        (when (and (seq all-table-ids) (seq required-ids))
-                            (t2/select-pk->fn identity [:model/Field :id :name :table_id :parent_id]
-                                              :id [:not-in required-ids]
-                                              :table_id [:in all-table-ids]
-                                              {:limit remaining}))]
+            extras        (t2/select-pk->fn identity [:model/Field :id :name :table_id :parent_id]
+                                            :id [:not-in required-ids]
+                                            :table_id [:in all-table-ids]
+                                            {:limit remaining})]
         (merge required extras)))))
 
 (defn recursively-find-field-q

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -1073,8 +1073,8 @@
   "Given a numeric database ID and a fn that resolves it to a database entity,
    return its name as a portable reference."
   [id db-fn]
-  (when id
-    (:name (db-fn id))))
+  (when-let [db (and id (db-fn id))]
+    (:name db)))
 
 (defn ^:dynamic *export-database-fk*
   "Given a numeric database ID, return its name as a portable reference.
@@ -1112,9 +1112,8 @@
   "Given a numeric table ID, a fn that resolves it to a table entity, and a fn
    that resolves a database ID to a database entity, return `[db-name schema table-name]`."
   [id table-fn db-fn]
-  (when id
-    (let [table (table-fn id)]
-      [(export-database-fk (:db_id table) db-fn) (:schema table) (:name table)])))
+  (when-let [table (and id (table-fn id))]
+    [(export-database-fk (:db_id table) db-fn) (:schema table) (:name table)]))
 
 (mu/defn ^:dynamic *export-table-fk*
   "Given a numeric `table_id`, return a portable table reference.
@@ -1184,9 +1183,8 @@
   "Given a numeric field ID and lookup fns for fields, tables, and databases,
    return `[db-name schema table-name & field-names]`."
   [field-id field-fn table-fn db-fn]
-  (when field-id
-    (let [field (field-fn field-id)
-          table-ref (export-table-fk (:table_id field) table-fn db-fn)
+  (when-let [field (and field-id (field-fn field-id))]
+    (let [table-ref (export-table-fk (:table_id field) table-fn db-fn)
           field-names (field-name-chain field-id field-fn)]
       (into table-ref field-names))))
 

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -1101,7 +1101,9 @@
                                          :table_id id
                                          :fk_target_field_id [:not= nil]))
         fk-table-ids (when (seq fk-field-ids)
-                       (t2/select-fn-set :table_id :model/Field :id [:in fk-field-ids]))
+                       (t2/select-fn-set :table_id :model/Field
+                                         :id [:in fk-field-ids]
+                                         :table_id [:not= nil]))
         fk-tables    (when (seq fk-table-ids)
                        (t2/select-pk->fn identity [:model/Table :id :db_id :name :schema]
                                          :id [:in fk-table-ids]
@@ -1217,16 +1219,23 @@
     (if-not (pos? remaining)
       required
       (let [table-id      (:table_id (get required field-id))
-            fk-field-ids  (t2/select-fn-set :fk_target_field_id :model/Field
-                                            :table_id table-id
-                                            :fk_target_field_id [:not= nil])
+            fk-field-ids  (when table-id
+                            (t2/select-fn-set :fk_target_field_id :model/Field
+                                              :table_id table-id
+                                              :fk_target_field_id [:not= nil]))
             fk-table-ids  (when (seq fk-field-ids)
-                            (t2/select-fn-set :table_id :model/Field :id [:in fk-field-ids]))
-            all-table-ids (cond-> #{table-id} (seq fk-table-ids) (into fk-table-ids))
-            extras        (t2/select-pk->fn identity [:model/Field :id :name :table_id :parent_id]
-                                            :id [:not-in (set (keys required))]
-                                            :table_id [:in all-table-ids]
-                                            {:limit remaining})]
+                            (t2/select-fn-set :table_id :model/Field
+                                              :id [:in fk-field-ids]
+                                              :table_id [:not= nil]))
+            all-table-ids (cond-> #{}
+                            table-id           (conj table-id)
+                            (seq fk-table-ids) (into fk-table-ids))
+            required-ids  (set (keys required))
+            extras        (when (and (seq all-table-ids) (seq required-ids))
+                            (t2/select-pk->fn identity [:model/Field :id :name :table_id :parent_id]
+                                              :id [:not-in required-ids]
+                                              :table_id [:in all-table-ids]
+                                              {:limit remaining}))]
         (merge required extras)))))
 
 (defn recursively-find-field-q

--- a/test/metabase/models/serialization_test.clj
+++ b/test/metabase/models/serialization_test.clj
@@ -260,7 +260,6 @@
                    :model/Field    {f-id :id}        {:name "f" :table_id t-id :base_type :type/Integer
                                                       :fk_target_field_id nil}
                    :model/Field    {target-id :id}   {:name "target" :table_id t-id :base_type :type/Integer}]
-      ;; create a valid FK reference, then delete the target to simulate an orphaned reference
       (t2/update! :model/Field f-id {:fk_target_field_id target-id})
       (t2/delete! :model/Field :id target-id)
       (binding [serdes/*batch-cache-max-size* 2]

--- a/test/metabase/models/serialization_test.clj
+++ b/test/metabase/models/serialization_test.clj
@@ -4,7 +4,8 @@
    [metabase.lib.core :as lib]
    [metabase.lib.test-metadata :as meta]
    [metabase.models.serialization :as serdes]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [toucan2.core :as t2]))
 
 (deftest ^:parallel drop-mbql-5-uuids-on-export-test
   (binding [serdes/*export-field-fk* (constantly ::field-id)]
@@ -238,3 +239,30 @@
           (is (= ["db" nil "t" "f1" "f2" "f3"] (serdes/*export-field-fk* f3-id)))
           (is (= ["db" nil "t" "f1" "f2"]      (serdes/*export-field-fk* f2-id)))
           (is (= ["db" nil "t" "f1"]           (serdes/*export-field-fk* f1-id))))))))
+
+(deftest export-table-fk-with-orphaned-fk-target-test
+  (testing "table with FK field pointing to a nonexistent target field does not crash"
+    (mt/with-temp [:model/Database {db-id :id}       {:name "db" :engine :h2}
+                   :model/Table    {t1-id :id}       {:name "t1" :schema "public" :db_id db-id}
+                   :model/Field    {f-id :id}        {:name "f" :table_id t1-id :base_type :type/Integer
+                                                      :fk_target_field_id nil}
+                   :model/Field    {target-id :id}   {:name "target" :table_id t1-id :base_type :type/Integer}]
+      (t2/update! :model/Field f-id {:fk_target_field_id target-id})
+      (t2/delete! :model/Field :id target-id)
+      (binding [serdes/*batch-cache-max-size* 2]
+        (serdes/with-cache
+          (is (= ["db" "public" "t1"] (serdes/*export-table-fk* t1-id))))))))
+
+(deftest export-field-fk-with-orphaned-fk-target-test
+  (testing "field with fk_target_field_id pointing to a nonexistent field does not crash"
+    (mt/with-temp [:model/Database {db-id :id}       {:name "db" :engine :h2}
+                   :model/Table    {t-id :id}        {:name "t" :schema nil :db_id db-id}
+                   :model/Field    {f-id :id}        {:name "f" :table_id t-id :base_type :type/Integer
+                                                      :fk_target_field_id nil}
+                   :model/Field    {target-id :id}   {:name "target" :table_id t-id :base_type :type/Integer}]
+      ;; create a valid FK reference, then delete the target to simulate an orphaned reference
+      (t2/update! :model/Field f-id {:fk_target_field_id target-id})
+      (t2/delete! :model/Field :id target-id)
+      (binding [serdes/*batch-cache-max-size* 2]
+        (serdes/with-cache
+          (is (= ["db" nil "t" "f"] (serdes/*export-field-fk* f-id))))))))

--- a/test/metabase/models/serialization_test.clj
+++ b/test/metabase/models/serialization_test.clj
@@ -4,8 +4,7 @@
    [metabase.lib.core :as lib]
    [metabase.lib.test-metadata :as meta]
    [metabase.models.serialization :as serdes]
-   [metabase.test :as mt]
-   [toucan2.core :as t2]))
+   [metabase.test :as mt]))
 
 (deftest ^:parallel drop-mbql-5-uuids-on-export-test
   (binding [serdes/*export-field-fk* (constantly ::field-id)]
@@ -207,7 +206,10 @@
           (is (= "db1" (serdes/*export-database-fk* db1-id)))
           (is (= "db2" (serdes/*export-database-fk* db2-id)))
           (is (= "db3" (serdes/*export-database-fk* db3-id)))
-          (is (= "db1" (serdes/*export-database-fk* db1-id))))))))
+          (is (= "db1" (serdes/*export-database-fk* db1-id)))))))
+  (testing "non-existent database ID returns nil"
+    (serdes/with-cache
+      (is (nil? (serdes/*export-database-fk* Integer/MAX_VALUE))))))
 
 (deftest export-table-fk-with-cache-test
   (testing "3 tables with FK and cache limit 2: batch-loads FK target, evicts and re-loads"
@@ -223,7 +225,10 @@
           (is (= ["db" "public" "t1"] (serdes/*export-table-fk* t1-id)))
           (is (= ["db" "public" "t2"] (serdes/*export-table-fk* t2-id)))
           (is (= ["db" nil "t3"]      (serdes/*export-table-fk* t3-id)))
-          (is (= ["db" "public" "t1"] (serdes/*export-table-fk* t1-id))))))))
+          (is (= ["db" "public" "t1"] (serdes/*export-table-fk* t1-id)))))))
+  (testing "non-existent table ID returns nil"
+    (serdes/with-cache
+      (is (nil? (serdes/*export-table-fk* Integer/MAX_VALUE))))))
 
 (deftest export-field-fk-with-cache-test
   (testing "3-level parent chain with cache limit 2: all ancestors kept even when exceeding limit"
@@ -238,30 +243,7 @@
         (serdes/with-cache
           (is (= ["db" nil "t" "f1" "f2" "f3"] (serdes/*export-field-fk* f3-id)))
           (is (= ["db" nil "t" "f1" "f2"]      (serdes/*export-field-fk* f2-id)))
-          (is (= ["db" nil "t" "f1"]           (serdes/*export-field-fk* f1-id))))))))
-
-(deftest export-table-fk-with-orphaned-fk-target-test
-  (testing "table with FK field pointing to a nonexistent target field does not crash"
-    (mt/with-temp [:model/Database {db-id :id}       {:name "db" :engine :h2}
-                   :model/Table    {t1-id :id}       {:name "t1" :schema "public" :db_id db-id}
-                   :model/Field    {f-id :id}        {:name "f" :table_id t1-id :base_type :type/Integer
-                                                      :fk_target_field_id nil}
-                   :model/Field    {target-id :id}   {:name "target" :table_id t1-id :base_type :type/Integer}]
-      (t2/update! :model/Field f-id {:fk_target_field_id target-id})
-      (t2/delete! :model/Field :id target-id)
-      (binding [serdes/*batch-cache-max-size* 2]
-        (serdes/with-cache
-          (is (= ["db" "public" "t1"] (serdes/*export-table-fk* t1-id))))))))
-
-(deftest export-field-fk-with-orphaned-fk-target-test
-  (testing "field with fk_target_field_id pointing to a nonexistent field does not crash"
-    (mt/with-temp [:model/Database {db-id :id}       {:name "db" :engine :h2}
-                   :model/Table    {t-id :id}        {:name "t" :schema nil :db_id db-id}
-                   :model/Field    {f-id :id}        {:name "f" :table_id t-id :base_type :type/Integer
-                                                      :fk_target_field_id nil}
-                   :model/Field    {target-id :id}   {:name "target" :table_id t-id :base_type :type/Integer}]
-      (t2/update! :model/Field f-id {:fk_target_field_id target-id})
-      (t2/delete! :model/Field :id target-id)
-      (binding [serdes/*batch-cache-max-size* 2]
-        (serdes/with-cache
-          (is (= ["db" nil "t" "f"] (serdes/*export-field-fk* f-id))))))))
+          (is (= ["db" nil "t" "f1"]           (serdes/*export-field-fk* f1-id)))))))
+  (testing "non-existent field ID returns nil"
+    (serdes/with-cache
+      (is (nil? (serdes/*export-field-fk* Integer/MAX_VALUE))))))


### PR DESCRIPTION
Bug: field with fk_target_field_id: N where N doesn't exist at all, fully deleted from the app db. In this case we should return `null` and not generate invalid SQL and crash.