### PR TITLE
[BOT-1260] Stub workflow for testing GH benchmark integrations

### DIFF
--- a/.github/workflows/ai-benchmark.yml
+++ b/.github/workflows/ai-benchmark.yml
@@ -1,0 +1,21 @@
+name: AI Benchmark
+
+# Runs the ai-benchmark E2E test suite against a Metabase instance.
+#
+# NOTE: This is a stub. The real workflow — which builds the benchmark Docker
+# image, boots Metabase + Postgres with a preloaded data dump, runs the
+# benchmark suite, and uploads results as artifacts — is being developed on a
+# feature branch. This stub exists on master so that the "Run workflow" button
+# is available in the GitHub Actions UI, which lets us dispatch the real
+# workflow against feature branches during development.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  placeholder:
+    name: Placeholder
+    runs-on: ubuntu-latest
+    steps:
+      - name: Stub
+        run: echo "ai-benchmark workflow stub — real implementation pending"


### PR DESCRIPTION
Related to BOT-1260

Creating a stub github workflow file for testing GH workflow integrations with the AI / metabot benchmarking system. Without a stub workflow checked into the default branch (master) you can't manually trigger the "in development" workflow version on a feature branch.