### PR TITLE
Replace manual transaction management with jdbc/with-db-transaction i…

### DIFF
--- a/src/metabase/app_db/setup.clj
+++ b/src/metabase/app_db/setup.clj
@@ -73,9 +73,7 @@
   [data-source :- (ms/InstanceOfClass javax.sql.DataSource)
    direction   :- :keyword
    & args]
-  ;; TODO: use [[jdbc/with-db-transaction]] instead of manually commit/rollback
-  (with-open [conn (.getConnection ^javax.sql.DataSource data-source)]
-    (.setAutoCommit conn false)
+  (jdbc/with-db-transaction [conn data-source]
     ;; Set up liquibase and let it do its thing
     (log/info "Setting up Liquibase...")
     (liquibase/with-liquibase [liquibase conn]
@@ -95,19 +93,14 @@
           :down-force    (apply liquibase/rollback-major-version! conn liquibase true args)
           :print         (print-migrations-and-quit-if-needed! liquibase data-source)
           :release-locks (liquibase/force-release-locks! liquibase))
-       ;; Migrations were successful; commit everything and re-enable auto-commit
-        (.commit conn)
-        (.setAutoCommit conn true)
         :done
        ;; In the Throwable block, we're releasing the lock assuming we have the lock and we failed while in the
        ;; middle of a migration. It's possible that we failed because we couldn't get the lock. We don't want to
        ;; clear the lock in that case, so handle that case separately
         (catch LockException e
-          (.rollback conn)
           (throw e))
        ;; If for any reason any part of the migrations fail then rollback all changes
         (catch Throwable e
-          (.rollback conn)
          ;; With some failures, it's possible that the lock won't be released. To make this worse, if we retry the
          ;; operation without releasing the lock first, the real error will get hidden behind a lock error
           (liquibase/release-lock-if-needed! liquibase)


### PR DESCRIPTION
…n migrate!

This improves code maintainability and reliability by using Clojure's standard JDBC transaction handling instead of manual connection and transaction management. The change preserves all existing exception handling behavior while simplifying the code and reducing the risk of transaction-related bugs.

Replace Manual Transaction Management with jdbc/with-db-transaction in migrate!
Problem
The migrate! function in [setup.clj](vscode-file://vscode-app/c:/Users/gurji/AppData/Local/Programs/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) was using manual JDBC transaction management with low-level calls:

(.setAutoCommit conn false) to disable auto-commit
Manual (.commit conn) on success
Manual (.rollback conn) in catch blocks
Manual (.setAutoCommit conn true) to restore auto-commit
This approach was error-prone, verbose, and could lead to transaction-related bugs if not handled correctly.
Solution
Replaced the manual transaction management with Clojure's standard jdbc/with-db-transaction macro, which provides:

Automatic commit on successful completion
Automatic rollback on exceptions
Cleaner, more idiomatic code
Better error handling guarantees.
Checklist:

 Code compiles and runs
 No breaking changes
 Follows Metabase coding standards
 Includes appropriate error handling
 Ready for review