### PR TITLE
Stop aborting Redshift test runs on concurrent schema-drop races (GDGT-2126)

### DIFF
--- a/modules/drivers/redshift/test/metabase/test/data/redshift.clj
+++ b/modules/drivers/redshift/test/metabase/test/data/redshift.clj
@@ -225,7 +225,6 @@
         {expired-isolation :expired}  (classify-isolation-schemas conn isolation)
         drop-sql                      (fn [schema-name] (format "DROP SCHEMA IF EXISTS \"%s\" CASCADE;" schema-name))]
     (with-open [stmt (.createStatement conn)]
-      ;; Drop schemas first
       (doseq [[collection fmt-str] [[old-convention "Dropping old data schema: %s"]
                                     [expired "Dropping expired cache schema: %s"]
                                     [lacking-created-at "Dropping cache without created-at info: %s"]
@@ -233,7 +232,10 @@
                                     [expired-isolation "Dropping expired workspace isolation schema: %s"]]
               schema               collection]
         (log/infof fmt-str schema)
-        (.execute stmt (drop-sql schema))))))
+        (try
+          (.execute stmt (drop-sql schema))
+          (catch Throwable e
+            (log/infof "Failed to drop %s, skipping: %s" schema (ex-message e))))))))
 
 (defn- create-session-schema! [^java.sql.Connection conn]
   (with-open [stmt (.createStatement conn)]


### PR DESCRIPTION
Redshift is a shared cluster, so all CI jobs run `delete-old-schemas!` against the same schemas. When two jobs try to drop the same schema at the same time, one wins and the other errors with `was dropped by a concurrent transaction` — which aborts the whole test suite at setup.

The test it gets blamed on is whichever happens to be first in the run; it's not actually broken. Same race, many flaky-test records.

Fix: drops here are best-effort janitorial cleanup, so wrap each one in try/catch and keep going.

- Linear: https://linear.app/metabase/issue/GDGT-2126
- Trunk (all same root cause, this one fix should collapse them):
  - https://app.trunk.io/metabase/flaky-tests/test/349debb5-068d-553e-8479-7bc4df06896b
  - https://app.trunk.io/metabase/flaky-tests/repo/56d8e0ad-ae87-4941-a147-3082557f1178/test/686b9209-33cb-5f5f-ab73-23cee9083d15
  - https://app.trunk.io/metabase/flaky-tests/repo/56d8e0ad-ae87-4941-a147-3082557f1178/test/761fc0ba-f18d-5151-a1d9-fd0f60438918
  - https://app.trunk.io/metabase/flaky-tests/repo/56d8e0ad-ae87-4941-a147-3082557f1178/test/01fe183e-1dab-56fb-81d2-ff8901ca31cf
  - https://app.trunk.io/metabase/flaky-tests/repo/56d8e0ad-ae87-4941-a147-3082557f1178/test/b7d158d5-af54-54be-9b23-de689307abee

I believe there are more but one can open so many tabs.
