### PR TITLE
Don't send alerts to deactivated users (GDGT-1927)

### DIFF
--- a/src/metabase/notification/models.clj
+++ b/src/metabase/notification/models.clj
@@ -264,12 +264,19 @@
    {:default []}))
 
 (methodical/defmethod t2/batched-hydrate [:default :recipients-detail]
-  "Batch hydration of details (user, group members) for NotificationRecipients"
+  "Batch hydration of details (user, group members) for NotificationRecipients.
+  Deactivated users have :user set to nil so they don't receive notifications (GDGT-1927)."
   [_model _k recipients]
   (-> (group-by :type recipients)
       (m/update-existing :notification-recipient/user
                          (fn [recipients]
-                           (t2/hydrate recipients :user)))
+                           (let [hydrated (t2/hydrate recipients :user)
+                                 inactive-ids (when (seq hydrated)
+                                                (t2/select-pks-set :model/User
+                                                                   :id [:in (map :user_id hydrated)]
+                                                                   :is_active false))]
+                             (mapv #(cond-> % (contains? inactive-ids (:user_id %)) (assoc :user nil))
+                                   hydrated))))
       (m/update-existing :notification-recipient/group
                          (fn [recipients]
                            (t2/hydrate recipients [:permissions_group :members])))
@@ -507,43 +514,14 @@
                          [:payload ::NotificationCard]]]
     [::mc/default       :map]]])
 
-(defn- remove-deactivated-user-recipients
-  "Drop user recipients whose user is deactivated, so disabled accounts stop receiving
-  notifications (GDGT-1927). Group-type recipients are unaffected because the group
-  members hydration already excludes deactivated users."
-  [notifications]
-  (let [collection? (sequential? notifications)
-        notis       (if collection? notifications [notifications])
-        user-ids    (->> notis
-                         (mapcat :handlers)
-                         (mapcat :recipients)
-                         (filter #(= :notification-recipient/user (:type %)))
-                         (keep :user_id)
-                         distinct)
-        inactive-ids (when (seq user-ids)
-                       (t2/select-pks-set :model/User
-                                          :id [:in user-ids]
-                                          :is_active false))
-        active-recipient? (fn [{:keys [type user_id]}]
-                            (not (and (= :notification-recipient/user type)
-                                      (contains? inactive-ids user_id))))
-        result (mapv (fn [noti]
-                       (update noti :handlers
-                               (fn [handlers]
-                                 (mapv #(update % :recipients (partial filterv active-recipient?))
-                                       handlers))))
-                     notis)]
-    (if collection? result (first result))))
-
 (mu/defn hydrate-notification :- [:or ::FullyHydratedNotification [:sequential ::FullyHydratedNotification]]
   "Fully hydrate notifictitons."
   [notification-or-notifications]
-  (-> (t2/hydrate notification-or-notifications
-                  :creator
-                  :payload
-                  :subscriptions
-                  [:handlers :channel :template [:recipients :recipients-detail]])
-      remove-deactivated-user-recipients))
+  (t2/hydrate notification-or-notifications
+              :creator
+              :payload
+              :subscriptions
+              [:handlers :channel :template [:recipients :recipients-detail]]))
 
 (mu/defn notifications-for-card :- [:sequential ::FullyHydratedNotification]
   "Find all active card notifications for a given card-id."

--- a/src/metabase/notification/models.clj
+++ b/src/metabase/notification/models.clj
@@ -265,18 +265,17 @@
 
 (methodical/defmethod t2/batched-hydrate [:default :recipients-detail]
   "Batch hydration of details (user, group members) for NotificationRecipients.
-  Deactivated users have :user set to nil so they don't receive notifications (GDGT-1927)."
+  Only active users are attached as :user; deactivated users get :user nil so they
+  don't receive notifications (GDGT-1927)."
   [_model _k recipients]
   (-> (group-by :type recipients)
       (m/update-existing :notification-recipient/user
                          (fn [recipients]
-                           (let [hydrated (t2/hydrate recipients :user)
-                                 inactive-ids (when (seq hydrated)
-                                                (t2/select-pks-set :model/User
-                                                                   :id [:in (map :user_id hydrated)]
-                                                                   :is_active false))]
-                             (mapv #(cond-> % (contains? inactive-ids (:user_id %)) (assoc :user nil))
-                                   hydrated))))
+                           (let [id->user (when (seq recipients)
+                                            (t2/select-fn->fn :id identity :model/User
+                                                              :id [:in (map :user_id recipients)]
+                                                              :is_active true))]
+                             (mapv #(assoc % :user (id->user (:user_id %))) recipients))))
       (m/update-existing :notification-recipient/group
                          (fn [recipients]
                            (t2/hydrate recipients [:permissions_group :members])))

--- a/src/metabase/notification/models.clj
+++ b/src/metabase/notification/models.clj
@@ -507,14 +507,43 @@
                          [:payload ::NotificationCard]]]
     [::mc/default       :map]]])
 
+(defn- remove-deactivated-user-recipients
+  "Drop user recipients whose user is deactivated, so disabled accounts stop receiving
+  notifications (GDGT-1927). Group-type recipients are unaffected because the group
+  members hydration already excludes deactivated users."
+  [notifications]
+  (let [collection? (sequential? notifications)
+        notis       (if collection? notifications [notifications])
+        user-ids    (->> notis
+                         (mapcat :handlers)
+                         (mapcat :recipients)
+                         (filter #(= :notification-recipient/user (:type %)))
+                         (keep :user_id)
+                         distinct)
+        inactive-ids (when (seq user-ids)
+                       (t2/select-pks-set :model/User
+                                          :id [:in user-ids]
+                                          :is_active false))
+        active-recipient? (fn [{:keys [type user_id]}]
+                            (not (and (= :notification-recipient/user type)
+                                      (contains? inactive-ids user_id))))
+        result (mapv (fn [noti]
+                       (update noti :handlers
+                               (fn [handlers]
+                                 (mapv #(update % :recipients (partial filterv active-recipient?))
+                                       handlers))))
+                     notis)]
+    (if collection? result (first result))))
+
 (mu/defn hydrate-notification :- [:or ::FullyHydratedNotification [:sequential ::FullyHydratedNotification]]
   "Fully hydrate notifictitons."
   [notification-or-notifications]
-  (t2/hydrate notification-or-notifications
-              :creator
-              :payload
-              :subscriptions
-              [:handlers :channel :template [:recipients :recipients-detail]]))
+  (-> (t2/hydrate notification-or-notifications
+                  :creator
+                  :payload
+                  :subscriptions
+                  [:handlers :channel :template [:recipients :recipients-detail]])
+      remove-deactivated-user-recipients))
 
 (mu/defn notifications-for-card :- [:sequential ::FullyHydratedNotification]
   "Find all active card notifications for a given card-id."

--- a/test/metabase/notification/models_test.clj
+++ b/test/metabase/notification/models_test.clj
@@ -218,8 +218,8 @@
                                                           :email "rasta@metabase.com"}]}}]
                       (:recipients (t2/hydrate noti-handler [:recipients :recipients-detail])))))))))))
 
-(deftest hydrate-notification-filters-deactivated-users-test
-  (testing "hydrate-notification excludes user recipients whose user is deactivated (GDGT-1927)"
+(deftest recipients-detail-nils-deactivated-users-test
+  (testing "recipients-detail hydration leaves :user nil for deactivated users so they don't get notifications (GDGT-1927)"
     (mt/with-model-cleanup [:model/Notification]
       (mt/with-temp [:model/Channel chn (assoc api.channel-test/default-test-channel :name "Channel")
                      :model/User    deactivated-user {:email "deactivated@metabase.com" :is_active false}
@@ -231,13 +231,12 @@
                       :channel_id   (:id chn)
                       :recipients   [{:type :notification-recipient/user :user_id (:id deactivated-user)}
                                      {:type :notification-recipient/user :user_id (:id active-user)}]}])
-              hydrated (models.notification/hydrate-notification (t2/select-one :model/Notification (:id noti)))
-              recipients (->> hydrated :handlers first :recipients)
-              user-ids   (set (map :user_id recipients))]
-          (testing "active user is still in the hydrated recipients"
-            (is (contains? user-ids (:id active-user))))
-          (testing "deactivated user is filtered out"
-            (is (not (contains? user-ids (:id deactivated-user))))))))))
+              handler (t2/select-one :model/NotificationHandler :notification_id (:id noti))
+              by-user-id (->> (t2/hydrate handler [:recipients :recipients-detail])
+                              :recipients
+                              (into {} (map (juxt :user_id identity))))]
+          (is (some? (get-in by-user-id [(:id active-user) :user])) "active user :user is hydrated")
+          (is (nil? (get-in by-user-id [(:id deactivated-user) :user])) "deactivated user :user is nil"))))))
 
 (deftest delete-template-set-null-on-existing-handlers-test
   (testing "if a channel template is deleted, then set null on existing notification_handler"

--- a/test/metabase/notification/models_test.clj
+++ b/test/metabase/notification/models_test.clj
@@ -218,6 +218,27 @@
                                                           :email "rasta@metabase.com"}]}}]
                       (:recipients (t2/hydrate noti-handler [:recipients :recipients-detail])))))))))))
 
+(deftest hydrate-notification-filters-deactivated-users-test
+  (testing "hydrate-notification excludes user recipients whose user is deactivated (GDGT-1927)"
+    (mt/with-model-cleanup [:model/Notification]
+      (mt/with-temp [:model/Channel chn (assoc api.channel-test/default-test-channel :name "Channel")
+                     :model/User    deactivated-user {:email "deactivated@metabase.com" :is_active false}
+                     :model/User    active-user      {:email "active@metabase.com"      :is_active true}]
+        (let [noti (models.notification/create-notification!
+                    default-system-event-notification
+                    [default-user-invited-subscription]
+                    [{:channel_type (:type chn)
+                      :channel_id   (:id chn)
+                      :recipients   [{:type :notification-recipient/user :user_id (:id deactivated-user)}
+                                     {:type :notification-recipient/user :user_id (:id active-user)}]}])
+              hydrated (models.notification/hydrate-notification (t2/select-one :model/Notification (:id noti)))
+              recipients (->> hydrated :handlers first :recipients)
+              user-ids   (set (map :user_id recipients))]
+          (testing "active user is still in the hydrated recipients"
+            (is (contains? user-ids (:id active-user))))
+          (testing "deactivated user is filtered out"
+            (is (not (contains? user-ids (:id deactivated-user))))))))))
+
 (deftest delete-template-set-null-on-existing-handlers-test
   (testing "if a channel template is deleted, then set null on existing notification_handler"
     (mt/with-model-cleanup [:model/Notification]

--- a/test/metabase/notification/models_test.clj
+++ b/test/metabase/notification/models_test.clj
@@ -218,26 +218,6 @@
                                                           :email "rasta@metabase.com"}]}}]
                       (:recipients (t2/hydrate noti-handler [:recipients :recipients-detail])))))))))))
 
-(deftest recipients-detail-nils-deactivated-users-test
-  (testing "recipients-detail hydration leaves :user nil for deactivated users so they don't get notifications (GDGT-1927)"
-    (mt/with-model-cleanup [:model/Notification]
-      (mt/with-temp [:model/Channel chn (assoc api.channel-test/default-test-channel :name "Channel")
-                     :model/User    deactivated-user {:email "deactivated@metabase.com" :is_active false}
-                     :model/User    active-user      {:email "active@metabase.com"      :is_active true}]
-        (let [noti (models.notification/create-notification!
-                    default-system-event-notification
-                    [default-user-invited-subscription]
-                    [{:channel_type (:type chn)
-                      :channel_id   (:id chn)
-                      :recipients   [{:type :notification-recipient/user :user_id (:id deactivated-user)}
-                                     {:type :notification-recipient/user :user_id (:id active-user)}]}])
-              handler (t2/select-one :model/NotificationHandler :notification_id (:id noti))
-              by-user-id (->> (t2/hydrate handler [:recipients :recipients-detail])
-                              :recipients
-                              (into {} (map (juxt :user_id identity))))]
-          (is (some? (get-in by-user-id [(:id active-user) :user])) "active user :user is hydrated")
-          (is (nil? (get-in by-user-id [(:id deactivated-user) :user])) "deactivated user :user is nil"))))))
-
 (deftest delete-template-set-null-on-existing-handlers-test
   (testing "if a channel template is deleted, then set null on existing notification_handler"
     (mt/with-model-cleanup [:model/Notification]

--- a/test/metabase/notification/payload/impl/card_test.clj
+++ b/test/metabase/notification/payload/impl/card_test.clj
@@ -236,6 +236,25 @@
                     (map (comp set :recipients))
                     set))))})))
 
+(deftest deactivated-user-recipients-are-not-emailed-test
+  (testing "card alert emails are not sent to deactivated user recipients (GDGT-1927)"
+    (mt/with-temp [:model/User {deactivated-id :id} {:email "deactivated@metabase.com" :is_active false}
+                   :model/User {active-id :id}      {:email "active@metabase.com"      :is_active true}]
+      (notification.tu/with-card-notification
+        [notification {:handlers [{:channel_type :channel/email
+                                   :recipients   [{:type :notification-recipient/user :user_id deactivated-id}
+                                                  {:type :notification-recipient/user :user_id active-id}
+                                                  {:type :notification-recipient/raw-value :details {:value "external@metabase.com"}}]}]}]
+        (notification.tu/test-send-notification!
+         notification
+         {:channel/email
+          (fn [emails]
+            (let [all-recipients (into #{} (mapcat :recipients) emails)]
+              (is (contains? all-recipients "active@metabase.com"))
+              (is (contains? all-recipients "external@metabase.com"))
+              (is (not (contains? all-recipients "deactivated@metabase.com"))
+                  "deactivated user must not receive the alert")))})))))
+
 (deftest send-condition-has-result-test
   (testing "no result should skip sending"
     (doseq [has-result [true false]]


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #70686
Card alerts continued to be delivered to deactivated users. The new notification system did not filter by `core_user.is_active` when resolving user recipients, so disabled accounts kept receiving emails.

The legacy pulse system (`pulse_channel` recipients hydration) and the `PermissionsGroup :members` hydration both filter by `is_active`. Direct user recipients in the new notification system were the remaining gap.


Fixes [GDGT-1927](https://linear.app/metabase/issue/GDGT-1927/alerts-continue-to-be-sent-to-deactivated-users).