### PR TITLE
seed advisories on first run

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/security_center/task/sync_advisories.clj
+++ b/enterprise/backend/src/metabase_enterprise/security_center/task/sync_advisories.clj
@@ -94,4 +94,7 @@
                     (cron/schedule
                      (cron/cron-schedule cron-str)
                      (cron/with-misfire-handling-instruction-do-nothing))))]
-      (task/schedule-task! job trigger))))
+      (task/schedule-task! job trigger)
+      ;; on first run of the feature, we sync immediately to seed advisories
+      (when-not (settings/security-center-last-synced-at)
+        (task/trigger-now! (jobs/key job-key))))))

--- a/enterprise/backend/test/metabase_enterprise/security_center/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/security_center/api_test.clj
@@ -4,10 +4,8 @@
    [metabase-enterprise.security-center.fetch :as fetch]
    [metabase-enterprise.security-center.matching :as matching]
    [metabase-enterprise.security-center.notification :as notification]
-   [metabase-enterprise.security-center.task.sync-advisories :as sync-advisories]
    [metabase.premium-features.core :as premium-features]
    [metabase.premium-features.token-check :as token-check]
-   [metabase.task.core :as task]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [toucan2.core :as t2]))
@@ -113,25 +111,22 @@
 (deftest sync-endpoint-test
   (testing "POST /api/ee/security-center/sync"
     (mt/with-premium-features #{:admin-security-center}
-      (mt/with-temp-scheduler!
-        (with-redefs [premium-features/security-center-enabled? (constantly true)]
-          (task/init! ::sync-advisories/SyncAdvisories))
-        (testing "calling twice only runs sync once"
-          (let [call-count (atom 0)
-                started    (promise)
-                finish     (promise)]
-            (with-redefs [premium-features/security-center-enabled? (constantly true)
-                          fetch/sync-advisories!
-                          (fn []
-                            (swap! call-count inc)
-                            (deliver started true)
-                            @finish)
-                          matching/evaluate-all-advisories! (constantly nil)]
-              (is (= {:status "started"} (mt/user-http-request :crowberto :post 200 "ee/security-center/sync")))
-              @started
-              (is (= {:status "already-in-progress"} (mt/user-http-request :crowberto :post 200 "ee/security-center/sync")))
-              (deliver finish true)
-              (is (= 1 @call-count) "sync should only run once despite two API calls")))))
+      (testing "calling twice only runs sync once"
+        (let [call-count (atom 0)
+              started    (promise)
+              finish     (promise)]
+          (with-redefs [premium-features/security-center-enabled? (constantly true)
+                        fetch/sync-advisories!
+                        (fn []
+                          (swap! call-count inc)
+                          (deliver started true)
+                          @finish)
+                        matching/evaluate-all-advisories! (constantly nil)]
+            (is (= {:status "started"} (mt/user-http-request :crowberto :post 200 "ee/security-center/sync")))
+            @started
+            (is (= {:status "already-in-progress"} (mt/user-http-request :crowberto :post 200 "ee/security-center/sync")))
+            (deliver finish true)
+            (is (= 1 @call-count) "sync should only run once despite two API calls"))))
       (testing "non-superuser gets 403"
         (mt/user-http-request :rasta :post 403 "ee/security-center/sync")))))
 


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-2238/sync-advisories-immediately-on-first-startup