### PR TITLE
GDGT-2227 remove the confirmation checkbox when editing a custom viz

### DIFF
--- a/e2e/test/scenarios/admin/custom-viz/custom-viz.cy.spec.js
+++ b/e2e/test/scenarios/admin/custom-viz/custom-viz.cy.spec.js
@@ -207,7 +207,6 @@ describe("admin > custom visualizations", () => {
         cy.findByLabelText(/Pinned version/)
           .clear()
           .type("main");
-        cy.findByLabelText(/I understand/).click();
 
         cy.intercept("PUT", `/api/ee/custom-viz-plugin/${plugin.id}`).as(
           "pluginUpdate",

--- a/enterprise/frontend/src/metabase-enterprise/custom_viz/components/CustomVizPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/custom_viz/components/CustomVizPage.tsx
@@ -50,12 +50,14 @@ export function CustomVizPage({ params }: Props) {
   const validationSchema = useMemo(
     () =>
       Yup.object({
-        acknowledgedRisk: Yup.boolean().oneOf(
-          [true],
-          t`You must acknowledge the security risk before proceeding.`,
-        ),
+        acknowledgedRisk: isEdit
+          ? Yup.boolean()
+          : Yup.boolean().oneOf(
+              [true],
+              t`You must acknowledge the security risk before proceeding.`,
+            ),
       }),
-    [],
+    [isEdit],
   );
 
   const initialValues = useMemo<FormState>(
@@ -63,9 +65,9 @@ export function CustomVizPage({ params }: Props) {
       repoUrl: plugin?.repo_url ?? "",
       accessToken: "",
       pinnedVersion: plugin?.pinned_version ?? "",
-      acknowledgedRisk: false,
+      acknowledgedRisk: isEdit,
     }),
-    [plugin],
+    [plugin, isEdit],
   );
 
   const handleSubmit = useCallback(
@@ -151,10 +153,12 @@ export function CustomVizPage({ params }: Props) {
                     description={t`Branch, tag, or commit SHA to pin to.`}
                     placeholder="main"
                   />
-                  <FormCheckbox
-                    name="acknowledgedRisk"
-                    label={t`I understand that custom visualizations can execute arbitrary code and should only be added from trusted sources.`}
-                  />
+                  {!isEdit && (
+                    <FormCheckbox
+                      name="acknowledgedRisk"
+                      label={t`I understand that custom visualizations can execute arbitrary code and should only be added from trusted sources.`}
+                    />
+                  )}
                   <FormErrorMessage />
                   <Group gap="sm" justify="flex-end">
                     <Button variant="default" onClick={handleCancel}>

--- a/enterprise/frontend/src/metabase-enterprise/custom_viz/components/CustomVizPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/custom_viz/components/CustomVizPage.tsx
@@ -42,21 +42,21 @@ export function CustomVizPage({ params }: Props) {
   const pluginId = params?.id ? parseInt(params.id, 10) : undefined;
   const { data: plugins } = useListAllCustomVizPluginsQuery();
   const plugin = pluginId ? plugins?.find((p) => p.id === pluginId) : undefined;
-  const isEdit = pluginId != null;
+  const isEdit = pluginId !== undefined;
 
   const [createPlugin] = useCreateCustomVizPluginMutation();
   const [updatePlugin] = useUpdateCustomVizPluginMutation();
 
   const validationSchema = useMemo(
     () =>
-      Yup.object({
-        acknowledgedRisk: isEdit
-          ? Yup.boolean()
-          : Yup.boolean().oneOf(
+      isEdit
+        ? undefined
+        : Yup.object({
+            acknowledgedRisk: Yup.boolean().oneOf(
               [true],
               t`You must acknowledge the security risk before proceeding.`,
             ),
-      }),
+          }),
     [isEdit],
   );
 


### PR DESCRIPTION
Closes [GDGT-2227: Remove confirmation checkbox when editing a custom viz](https://linear.app/metabase/issue/GDGT-2227/remove-confirmation-checkbox-when-editing-a-custom-viz)

### Description

It removes the confirmation checkbox when editing a custom viz.

### How to verify
1. Go to `/admin/settings/custom-visualizations/` -> Add
2. Fill the form -> the confirmation checkbox is here -> Save
3. Click on the existing custom viz and see that there is no confirmation checkbox anymore.

### Demo

<img width="875" height="641" alt="image" src="https://github.com/user-attachments/assets/76e5c28d-4990-4239-87d8-830b7320d246" />
