### PR TITLE
Gdgt 2170 figure out dependency on custom viz package

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/custom_viz/custom-viz-common.ts
+++ b/enterprise/frontend/src/metabase-enterprise/custom_viz/custom-viz-common.ts
@@ -1,4 +1,4 @@
-import type { CustomVisualization } from "custom-viz/src/types";
+import type { CustomVisualization } from "custom-viz";
 
 import type { Visualization } from "metabase/visualizations/types/visualization";
 

--- a/enterprise/frontend/src/metabase-enterprise/custom_viz/custom-viz-globals.ts
+++ b/enterprise/frontend/src/metabase-enterprise/custom_viz/custom-viz-globals.ts
@@ -1,5 +1,4 @@
-import type { ColumnTypes } from "custom-viz/src/types/column-types";
-import type { CreateCustomVisualization } from "custom-viz/src/types/viz";
+import type { ColumnTypes, CreateCustomVisualization } from "custom-viz";
 import React from "react";
 import * as jsxRuntime from "react/jsx-runtime";
 

--- a/enterprise/frontend/src/metabase-enterprise/custom_viz/custom-viz-plugins.ts
+++ b/enterprise/frontend/src/metabase-enterprise/custom_viz/custom-viz-plugins.ts
@@ -3,7 +3,7 @@ import type {
   CustomVisualizationSettingDefinition,
   ClickObject as CustomVizClickObject,
   HoverObject as CustomVizHoverObject,
-} from "custom-viz/src/types";
+} from "custom-viz";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { t } from "ttag";
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -970,6 +970,23 @@ const configs = [
     },
   },
   {
+    files: ["frontend/**/*.{ts,tsx}"],
+    rules: {
+      "@typescript-eslint/no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            {
+              name: "custom-viz",
+              allowTypeImports: true,
+              message: "Please use only type-only imports from 'custom-viz'.",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
     files: ["enterprise/frontend/src/embedding-sdk-package/bin/**/*"],
     rules: {
       "metabase/no-literal-metabase-strings": "off",

--- a/frontend/src/metabase-lib/v1/types/utils/custom-viz-column-types.ts
+++ b/frontend/src/metabase-lib/v1/types/utils/custom-viz-column-types.ts
@@ -1,4 +1,4 @@
-import type { ColumnTypes } from "custom-viz/src/types/column-types";
+import type { ColumnTypes } from "custom-viz";
 
 import {
   hasLatitudeAndLongitudeColumns,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
       ],
       "build-configs/*": ["./frontend/build/*"],
       "cljs/*": ["./target/cljs_dev/*"],
-      "sdk-ee-plugins": ["./frontend/src/metabase/plugins/noop"]
+      "sdk-ee-plugins": ["./frontend/src/metabase/plugins/noop"],
+      "custom-viz": ["./enterprise/frontend/src/custom-viz/src/index.ts"]
     },
     "plugins": [
       {


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-2170/figure-out-dependency-on-custom-viz-package

### Description

Allow imports from `custom-viz` in our top level TS config.

```ts
   "paths": {
      "custom-viz": ["./enterprise/frontend/src/custom-viz/src/index.ts"]
   }
```

Additionally we've introduced here new `@typescript-eslint/no-restricted-imports` rule that allows type only imports from `custom-viz` in non-enterprise files.

### How to verify

Try to import runtime code from `custom-viz` in `frontend/src` - you should see eslint error after running `bun run lint`

```
2:1   error  'custom-viz' import is restricted from being used. Please use only type-only imports from 'custom-viz'  @typescript-eslint/no-restricted-imports
```

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
