### PR TITLE
GHY-3378: Block source replacement when sandboxing policies are affected

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -3054,6 +3054,7 @@
                     :model/Field
                     :model/Measure
                     :model/PersistedInfo
+                    :model/Sandbox
                     :model/Segment
                     :model/Table
                     :model/Transform}}

--- a/enterprise/backend/src/metabase_enterprise/replacement/schema.clj
+++ b/enterprise/backend/src/metabase_enterprise/replacement/schema.clj
@@ -44,7 +44,7 @@
    [:semantic_type  [:maybe :string]]])
 
 (mr/def ::error-type
-  [:enum :cycle-detected :database-mismatch :incompatible-implicit-joins])
+  [:enum :cycle-detected :database-mismatch :incompatible-implicit-joins :affects-gtap-policies])
 
 (mr/def ::column-mapping
   [:map

--- a/enterprise/backend/src/metabase_enterprise/replacement/source_check.clj
+++ b/enterprise/backend/src/metabase_enterprise/replacement/source_check.clj
@@ -13,6 +13,16 @@
 
 (set! *warn-on-reflection* true)
 
+(mu/defn- has-gtap-policies? :- :boolean
+  "Returns true if any sandbox (GTAP) policy references `table-id`, either directly
+  via `sandbox.table_id` or indirectly via a scoping card whose `table_id` matches."
+  [table-id :- ::lib.schema.id/table]
+  (or (t2/exists? :model/Sandbox :table_id table-id)
+      (let [sandbox-card-ids (t2/select-fn-set :card_id :model/Sandbox :card_id [:not= nil])]
+        (boolean
+         (when (seq sandbox-card-ids)
+           (t2/exists? :model/Card :id [:in sandbox-card-ids] :table_id table-id))))))
+
 (mu/defn- has-incoming-fks? :- :boolean
   "Returns true if any active field has a FK pointing to a field in `table-id`."
   [table-id :- ::lib.schema.id/table]
@@ -64,11 +74,13 @@
           has-missing?    (some (fn [m] (and (:source m) (nil? (:target m)))) mappings)
           has-col-errors? (seq (mapcat :errors mappings))
           implicit-joins? (and (= old-type :table) (has-incoming-fks? old-id))
-          success?        (not (or db-mismatch? cycle? has-missing? has-col-errors? implicit-joins?))
+          gtap?           (and (= old-type :table) (has-gtap-policies? old-id))
+          success?        (not (or db-mismatch? cycle? has-missing? has-col-errors? implicit-joins? gtap?))
           reported-errors (cond-> []
                             db-mismatch?    (conj :database-mismatch)
                             cycle?          (conj :cycle-detected)
-                            implicit-joins? (conj :incompatible-implicit-joins))]
+                            implicit-joins? (conj :incompatible-implicit-joins)
+                            gtap?           (conj :affects-gtap-policies))]
       (cond-> {:success success?}
         (seq reported-errors) (assoc :errors reported-errors)
         (seq mappings)        (assoc :column_mappings mappings)))))

--- a/enterprise/backend/test/metabase_enterprise/replacement/source_check_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/replacement/source_check_test.clj
@@ -78,6 +78,76 @@
         (is (false? (:success result)))
         (is (some #{:incompatible-implicit-joins} (:errors result)))))))
 
+(deftest gtap-policy-blocks-replacement-test
+  (testing "table with a sandbox (GTAP) policy produces :affects-gtap-policies"
+    (mt/with-temp [:model/Database       {db-id :id}    {}
+                   :model/Table          {t1-id :id}    {:db_id db-id}
+                   :model/Table          {t2-id :id}    {:db_id db-id}
+                   :model/Field          _               {:table_id t1-id :name "id" :base_type :type/Integer
+                                                          :effective_type :type/Integer}
+                   :model/Field          _               {:table_id t2-id :name "id" :base_type :type/Integer
+                                                          :effective_type :type/Integer}
+                   :model/PermissionsGroup {group-id :id} {}
+                   :model/Sandbox        _               {:table_id t1-id :group_id group-id}]
+      (let [result (replacement.source-check/check-replace-source
+                    [:table t1-id] [:table t2-id])]
+        (is (false? (:success result)))
+        (is (some #{:affects-gtap-policies} (:errors result)))))))
+
+(deftest gtap-scoping-card-blocks-replacement-test
+  (testing "table referenced by a sandbox scoping card produces :affects-gtap-policies"
+    (mt/with-temp [:model/Database         {db-id :id}    {}
+                   :model/Table            {t1-id :id}    {:db_id db-id}
+                   :model/Table            {t2-id :id}    {:db_id db-id}
+                   :model/Table            {t3-id :id}    {:db_id db-id}
+                   :model/Field            _               {:table_id t1-id :name "id" :base_type :type/Integer
+                                                            :effective_type :type/Integer}
+                   :model/Field            _               {:table_id t2-id :name "id" :base_type :type/Integer
+                                                            :effective_type :type/Integer}
+                   :model/PermissionsGroup {group-id :id}  {}
+                   ;; Scoping card queries t1 (source table) but sandboxes t3
+                   :model/Card             {card-id :id}   {:database_id db-id :table_id t1-id}
+                   :model/Sandbox          _                {:table_id t3-id :group_id group-id :card_id card-id}]
+      (let [result (replacement.source-check/check-replace-source
+                    [:table t1-id] [:table t2-id])]
+        (is (false? (:success result)))
+        (is (some #{:affects-gtap-policies} (:errors result)))))))
+
+(deftest no-gtap-policy-no-error-test
+  (testing "table without sandbox policies does not produce :affects-gtap-policies"
+    (mt/with-temp [:model/Database {db-id :id} {}
+                   :model/Table {t1-id :id} {:db_id db-id}
+                   :model/Table {t2-id :id} {:db_id db-id}
+                   :model/Field _ {:table_id t1-id :name "id" :base_type :type/Integer
+                                   :effective_type :type/Integer}
+                   :model/Field _ {:table_id t2-id :name "id" :base_type :type/Integer
+                                   :effective_type :type/Integer}]
+      (let [result (replacement.source-check/check-replace-source
+                    [:table t1-id] [:table t2-id])]
+        (is (nil? (some #{:affects-gtap-policies} (:errors result))))))))
+
+(deftest gtap-check-not-applied-to-card-source-test
+  (testing "GTAP check only applies to :table sources, not :card sources"
+    (mt/with-temp [:model/Database         {db-id :id}    {}
+                   :model/Table            {t1-id :id}    {:db_id db-id}
+                   :model/PermissionsGroup {group-id :id} {}
+                   :model/Sandbox          _               {:table_id t1-id :group_id group-id}
+                   :model/Card {c1-id :id} {:database_id db-id
+                                            :result_metadata [{:name "id"
+                                                               :base_type :type/Integer
+                                                               :effective_type :type/Integer
+                                                               :display_name "ID"
+                                                               :field_ref [:field "id" {:base-type :type/Integer}]}]}
+                   :model/Card {c2-id :id} {:database_id db-id
+                                            :result_metadata [{:name "id"
+                                                               :base_type :type/Integer
+                                                               :effective_type :type/Integer
+                                                               :display_name "ID"
+                                                               :field_ref [:field "id" {:base-type :type/Integer}]}]}]
+      (let [result (replacement.source-check/check-replace-source
+                    [:card c1-id] [:card c2-id])]
+        (is (nil? (some #{:affects-gtap-policies} (:errors result))))))))
+
 (deftest no-implicit-joins-without-incoming-fks-test
   (testing "table source without incoming FKs does not produce :incompatible-implicit-joins"
     (mt/with-temp [:model/Database {db-id :id} {}

--- a/enterprise/frontend/src/metabase-enterprise/replacement/components/SourceReplacementModal/ModalSidebar/utils.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/replacement/components/SourceReplacementModal/ModalSidebar/utils.unit.spec.ts
@@ -33,6 +33,16 @@ describe("getSourceError", () => {
         "The original table can't be referenced by a foreign key by another table.",
     },
     {
+      name: "checkInfo has affects-gtap-policies error",
+      checkInfo: createMockCheckReplaceSourceInfo({
+        success: false,
+        errors: ["affects-gtap-policies"],
+      }),
+      dependentsCount: 5,
+      expected:
+        "This table has sandboxing policies that block this replacement.",
+    },
+    {
       name: "checkInfo has no source-level errors",
       checkInfo: createMockCheckReplaceSourceInfo({
         success: false,

--- a/enterprise/frontend/src/metabase-enterprise/replacement/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/replacement/utils.ts
@@ -23,6 +23,8 @@ export function getSourceErrorMessage(
   switch (error) {
     case "incompatible-implicit-joins":
       return t`The original table can't be referenced by a foreign key by another table.`;
+    case "affects-gtap-policies":
+      return t`This table has sandboxing policies that block this replacement.`;
     default:
       return undefined;
   }

--- a/frontend/src/metabase-types/api/replacement.ts
+++ b/frontend/src/metabase-types/api/replacement.ts
@@ -33,6 +33,7 @@ export const SOURCE_REPLACEMENT_ERROR_TYPES = [
   "database-mismatch",
   "cycle-detected",
   "incompatible-implicit-joins",
+  "affects-gtap-policies",
 ] as const;
 export type SourceReplacementErrorType =
   (typeof SOURCE_REPLACEMENT_ERROR_TYPES)[number];


### PR DESCRIPTION
## Summary

- Block data source replacement if the source table is referenced by any sandboxing (GTAP) policy
- Checks both direct references (`sandbox.table_id`) and indirect ones (sandbox scoping card queries the source table)
- Returns `affects-gtap-policies` error type; displayed as a source-side error in the replacement modal

Without this, replacement silently breaks sandboxing: the policy's `table_id` still points to the old table, and the new table gets no sandbox at all.

## Test plan

- [x] Backend: `./bin/test-agent :only '[metabase-enterprise.replacement.source-check-test]'` - 4 new tests (direct policy, scoping card, no policy, card source)
- [x] Frontend: `bun run test-unit -- --testPathPatterns="ModalSidebar/utils.unit.spec"` - 1 new test case
- [x] Manual: create a sandbox policy on a table, try to replace it - should show error

``` shell
curl -X POST http://localhost:3041/api/ee/replacement/check-replace-source \
    -H "Content-Type: application/json" \
    -H "x-api-key: mb_adminapikey" \
    -d '{"source_entity_type": "table", "source_entity_id": 2, "target_entity_type": "table", "target_entity_id": 5}' \
    | jq ".errors"
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2393  100  2285  100   108  30803   1455 --:--:-- --:--:-- --:--:-- 32337
[
  "affects-gtap-policies"
]
```