### PR TITLE
Skip cancelation on closed statements

### DIFF
--- a/src/metabase/driver/sql_jdbc/execute.clj
+++ b/src/metabase/driver/sql_jdbc/execute.clj
@@ -811,12 +811,13 @@
                   ;; TODO: Following `when` is in place just to find out if vertica is flaking because of cancelations.
                   ;;       It should be removed afterwards!
                     (when-not (= :vertica driver)
-                      (try (.cancel stmt)
+                      (try (when-not (.isClosed stmt)
+                             (.cancel stmt))
                            (catch SQLFeatureNotSupportedException _
                              (log/warnf "Statemet's `.cancel` method is not supported by the `%s` driver."
                                         (name driver)))
-                           (catch Throwable _
-                             (log/warn "Statement cancelation failed.")))))))))))))
+                           (catch Throwable e
+                             (log/info e "Statement cancelation failed.")))))))))))))
 
 (defn reducible-query
   "Returns a reducible collection of rows as maps from `db` and a given SQL query. This is similar to [[jdbc/reducible-query]] but reuses the


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #72428
Closes QUE2-513

### Description

When calling .cancel on a statement, the only condition when the JDBC spec says a non-SQLFeatureNotSupportedException should be thrown is when it's already closed. This PR makes sure we don't try to cancel closed statements and logs any generic exception at info level instead of warning, since the symptom is benign.

### How to verify

There should be no change in the behavior.

### Checklist

- ~Tests have been added/updated to cover changes in this PR~
- ~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~
