### PR TITLE
Grant admin access to Helping Hand support user

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/support_access_grants/models/support_access_grant_log.clj
+++ b/enterprise/backend/src/metabase_enterprise/support_access_grants/models/support_access_grant_log.clj
@@ -4,6 +4,7 @@
    [metabase-enterprise.support-access-grants.settings :as sag.settings]
    [metabase.models.interface :as mi]
    [metabase.util :as u]
+   [metabase.util.log :as log]
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
 
@@ -20,18 +21,19 @@
 
 (defn fetch-or-create-support-user!
   "Fetch or Create the support user account from settings.
-  If the user exists but is deactivated, reactivate them."
+  If the user exists but is deactivated, reactivate them.
+  Always ensures the support user has superuser access."
   []
   (if-let [user (t2/select-one :model/User :email (sag.settings/support-access-grant-email))]
     (do
-      (when-not (:is_active user)
-        (t2/update! :model/User (:id user) {:is_active true}))
-      (assoc user :is_active true))
+      (t2/update! :model/User (:id user) {:is_active true :is_superuser true})
+      (assoc user :is_active true :is_superuser true))
     (t2/insert-returning-instance! :model/User
                                    {:email (sag.settings/support-access-grant-email)
                                     :first_name (sag.settings/support-access-grant-first-name)
                                     :last_name (sag.settings/support-access-grant-last-name)
-                                    :password (str (random-uuid))})))
+                                    :password (str (random-uuid))
+                                    :is_superuser true})))
 
 (methodical/defmethod t2/batched-hydrate [:model/SupportAccessGrantLog :user_info]
   [_model _k grants]
@@ -50,7 +52,14 @@
   [{revoked-at :revoked_at :as grant}]
   (u/prog1 grant
     (when revoked-at
-      (let [support-user-id (:id (fetch-or-create-support-user!))
-            auth-identity-ids (t2/select-pks-vec :model/AuthIdentity :user_id support-user-id)]
-        (t2/update! :model/AuthIdentity :id [:in auth-identity-ids] {:expires_at revoked-at})
-        (t2/delete! :model/Session :user_id support-user-id)))))
+      (when-let [support-user (t2/select-one :model/User :email (sag.settings/support-access-grant-email))]
+        (let [support-user-id (:id support-user)
+              auth-identity-ids (t2/select-pks-vec :model/AuthIdentity :user_id support-user-id)]
+          (try
+            (t2/update! :model/User support-user-id {:is_superuser false})
+            (catch Exception e
+              ;; If the support user is somehow the last admin, we can't remove superuser via model hooks.
+              ;; Sessions and auth identities are still cleaned up below, preventing further access.
+              (log/warnf e "Could not remove superuser from support user %d" support-user-id)))
+          (t2/update! :model/AuthIdentity :id [:in auth-identity-ids] {:expires_at revoked-at})
+          (t2/delete! :model/Session :user_id support-user-id))))))

--- a/enterprise/backend/test/metabase_enterprise/support_access_grants/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/support_access_grants/core_test.clj
@@ -282,10 +282,44 @@
               (is (= support-last-name (:last_name created-user)))
               (is (some? (:token grant)) "Token should be created for the new support user")
               (is (string? (:token grant)))
+              (is (:is_superuser created-user) "Support user should have admin access")
               (let [auth-identity (t2/select-one :model/AuthIdentity
                                                  :user_id (:id created-user)
                                                  :provider "support-access-grant")]
                 (is (some? auth-identity) "AuthIdentity should be created for new support user")))))))))
+
+(deftest create-grant-gives-support-user-admin-access-test
+  (testing "create-grant! sets is_superuser on existing support user"
+    (let [support-email "support-admin@example.com"]
+      (mt/with-temp [:model/User {creator-id :id} {}
+                     :model/User {support-user-id :id} {:email support-email :is_superuser false}]
+        (mt/with-model-cleanup [:model/SupportAccessGrantLog :model/AuthIdentity]
+          (with-redefs [sag.settings/support-access-grant-email (constantly support-email)]
+            (grants/create-grant! creator-id 240 "SUPPORT-ADMIN-1" "test notes")
+            (let [updated-user (t2/select-one :model/User :id support-user-id)]
+              (is (:is_superuser updated-user) "Support user should have admin access after grant creation")))))))
+  (testing "revoking a grant removes is_superuser from support user"
+    (let [support-email "support-admin-revoke@example.com"]
+      (mt/with-temp [:model/User {creator-id :id} {:is_superuser true}
+                     :model/User {support-user-id :id} {:email support-email :is_superuser false}]
+        (mt/with-model-cleanup [:model/SupportAccessGrantLog :model/AuthIdentity]
+          (with-redefs [sag.settings/support-access-grant-email (constantly support-email)]
+            (let [grant (grants/create-grant! creator-id 240 "SUPPORT-ADMIN-2" "test notes")]
+              (grants/revoke-grant! creator-id (:id grant))
+              (let [updated-user (t2/select-one :model/User :id support-user-id)]
+                (is (not (:is_superuser updated-user)) "Support user should lose admin access after grant revocation")))))))))
+
+(deftest create-grant-reactivates-support-user-with-admin-access-test
+  (testing "create-grant! reactivates a deactivated support user and gives them admin access"
+    (let [support-email "support-reactivate@example.com"]
+      (mt/with-temp [:model/User {creator-id :id} {}
+                     :model/User {support-user-id :id} {:email support-email :is_active false :is_superuser false}]
+        (mt/with-model-cleanup [:model/SupportAccessGrantLog :model/AuthIdentity]
+          (with-redefs [sag.settings/support-access-grant-email (constantly support-email)]
+            (grants/create-grant! creator-id 240 "SUPPORT-REACTIVATE-1" "test notes")
+            (let [updated-user (t2/select-one [:model/User :id :is_active :is_superuser] :id support-user-id)]
+              (is (:is_active updated-user) "Support user should be reactivated")
+              (is (:is_superuser updated-user) "Reactivated support user should have admin access"))))))))
 
 (deftest create-grant-publishes-event-test
   (testing "Creating a grant publishes :event/support-access-grant-created event"


### PR DESCRIPTION
### Description

fetch-or-create-support-user! now sets is_superuser=true on all paths (new user, reactivation, and existing active user). On grant revocation, is_superuser is set back to false. This ensures the support user has full admin access as promised by the grant access dialog.

Fixes: UXW-3725

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
