### PR TITLE
Pick random host when testing Redshift from `MB_REDSHIFT_TEST_HOSTS`

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -1205,7 +1205,7 @@ jobs:
       MB_REDSHIFT_TEST_USER: metabase_ci
       MB_REDSHIFT_TEST_DB: testdb
       MB_REDSHIFT_TEST_DB_ROUTING: dev
-      MB_REDSHIFT_TEST_HOST: ${{ secrets.MB_REDSHIFT_TEST_HOST }}
+      MB_REDSHIFT_TEST_HOSTS: ${{ secrets.MB_REDSHIFT_TEST_HOSTS }}
       MB_REDSHIFT_TEST_PASSWORD: ${{ secrets.MB_REDSHIFT_TEST_PASSWORD }}
     name: ${{ matrix.job.name }}
     steps:

--- a/modules/drivers/redshift/test/metabase/test/data/redshift.clj
+++ b/modules/drivers/redshift/test/metabase/test/data/redshift.clj
@@ -96,8 +96,8 @@
 (def db-connection-details
   (delay {:host                    @host
           :port                    (parse-long (tx/db-test-env-var :redshift :port "5439"))
-          :db                      (tx/db-test-env-var-or-throw :redshift :db)
-          :user                    (tx/db-test-env-var-or-throw :redshift :user)
+          :db                      (tx/db-test-env-var :redshift :db "testdb")
+          :user                    (tx/db-test-env-var :redshift :user "metabase_ci")
           :password                (tx/db-test-env-var-or-throw :redshift :password)
           :schema-filters-type     "inclusion"
           :schema-filters-patterns (str "spectrum," (unique-session-schema))}))

--- a/modules/drivers/redshift/test/metabase/test/data/redshift.clj
+++ b/modules/drivers/redshift/test/metabase/test/data/redshift.clj
@@ -103,7 +103,7 @@
           :schema-filters-patterns (str "spectrum," (unique-session-schema))}))
 
 (def db-routing-connection-details
-  (delay {:host                    (tx/db-test-env-var-or-throw :redshift :host)
+  (delay {:host                    @host
           :port                    (parse-long (tx/db-test-env-var :redshift :port "5439"))
           :db                      (tx/db-test-env-var :redshift :db-routing "dev")
           :user                    (tx/db-test-env-var-or-throw :redshift :user)

--- a/modules/drivers/redshift/test/metabase/test/data/redshift.clj
+++ b/modules/drivers/redshift/test/metabase/test/data/redshift.clj
@@ -66,14 +66,23 @@
 (defn unique-session-schema []
   (str (sql.tu.unique-prefix/unique-prefix) "schema"))
 
-;; MB_REDSHIFT_TEST_HOSTS
+;;; `MB_REDSHIFT_TEST_HOSTS`
+;;;
+;;; We've had lots of problems with Redshift timing out because of too much CPU load on our single cluster in the past;
+;;; instead of continuing to increase the size of the cluster (which doesn't seem to help much) we're switching to a
+;;; handful of smaller clusters, and picking one randomly; there is nothing shared between test runs and no reason they
+;;; all need to be done on a single cluster anyway. Other than the `:host` these are all configured identically with the
+;;; same user, password, and database name.
+
 (defonce ^:private hosts
   (delay
     (when-let [hosts (not-empty (tx/db-test-env-var :redshift :hosts))]
       (str/split hosts #","))))
 
-(defn- random-host []
-  (println "(seq @hosts):" (seq @hosts)) ; NOCOMMIT
+(defn- random-host
+  "Pick a random host to test against from `MB_REDSHIFT_TEST_HOSTS` if it's set; otherwise fall back to the host in
+  `MB_REDSHIFT_TEST_HOST`."
+  []
   (u/prog1 (if (seq @hosts)
              (rand-nth @hosts)
              (tx/db-test-env-var-or-throw :redshift :host))

--- a/modules/drivers/redshift/test/metabase/test/data/redshift.clj
+++ b/modules/drivers/redshift/test/metabase/test/data/redshift.clj
@@ -103,13 +103,8 @@
           :schema-filters-patterns (str "spectrum," (unique-session-schema))}))
 
 (def db-routing-connection-details
-  (delay {:host                    @host
-          :port                    (parse-long (tx/db-test-env-var :redshift :port "5439"))
-          :db                      (tx/db-test-env-var :redshift :db-routing "dev")
-          :user                    (tx/db-test-env-var-or-throw :redshift :user)
-          :password                (tx/db-test-env-var-or-throw :redshift :password)
-          :schema-filters-type     "inclusion"
-          :schema-filters-patterns (str "spectrum," (unique-session-schema))}))
+  (delay
+    (assoc @db-connection-details :db (tx/db-test-env-var :redshift :db-routing "dev"))))
 
 (defmethod tx/dbdef->connection-details :redshift
   [& _]

--- a/modules/drivers/redshift/test/metabase/test/data/redshift.clj
+++ b/modules/drivers/redshift/test/metabase/test/data/redshift.clj
@@ -66,8 +66,25 @@
 (defn unique-session-schema []
   (str (sql.tu.unique-prefix/unique-prefix) "schema"))
 
+;; MB_REDSHIFT_TEST_HOSTS
+(defonce ^:private hosts
+  (delay
+    (when-let [hosts (not-empty (tx/db-test-env-var :redshift :hosts))]
+      (str/split hosts #","))))
+
+(defn- random-host []
+  (u/prog1 (if (seq @hosts)
+             (rand-nth @hosts)
+             (tx/db-test-env-var-or-throw :redshift :host))
+    ;; using println on purpose here for purposes of debugging CI, we can remove in the future when we're happy that
+    ;; multiple hosts works as expected
+    #_{:clj-kondo/ignore [:discouraged-var]}
+    (println "Using Redshift host" (pr-str (first (str/split <> #"\."))))))
+
+(defonce ^:private host (delay (random-host)))
+
 (def db-connection-details
-  (delay {:host                    (tx/db-test-env-var-or-throw :redshift :host)
+  (delay {:host                    @host
           :port                    (parse-long (tx/db-test-env-var :redshift :port "5439"))
           :db                      (tx/db-test-env-var-or-throw :redshift :db)
           :user                    (tx/db-test-env-var-or-throw :redshift :user)

--- a/modules/drivers/redshift/test/metabase/test/data/redshift.clj
+++ b/modules/drivers/redshift/test/metabase/test/data/redshift.clj
@@ -73,6 +73,7 @@
       (str/split hosts #","))))
 
 (defn- random-host []
+  (println "(seq @hosts):" (seq @hosts)) ; NOCOMMIT
   (u/prog1 (if (seq @hosts)
              (rand-nth @hosts)
              (tx/db-test-env-var-or-throw :redshift :host))


### PR DESCRIPTION
Experimental way to fix the issues with Redshift in CI: instead of having one massive shared cluster, create a series of smaller clusters and have each CI run pick one randomly. There is nothing shared between test runs so this should help deal solve our CI issues with Redshift

For now I've spun up two additional smaller Redshift clusters to test this out and see if it works, if it does I might spin up a few more.

Update: after testing this seems to be working very well

Fixes QUE2-510