### PR TITLE
[BOT-1316] Improve native agent API error logging

### DIFF
--- a/src/metabase/metabot/agent/core.clj
+++ b/src/metabase/metabot/agent/core.clj
@@ -619,12 +619,16 @@
                     result))
                 (catch Exception e
                   (prometheus/inc! :metabase-metabot/agent-errors labels)
-                  (when (:api-error (ex-data e))
-                    (log/debugf "API error details: status=%s body=%s"
-                                (:status (ex-data e))
-                                (pr-str (:body (ex-data e)))))
                   (if (:api-error (ex-data e))
-                    (log/errorf "Agent loop API error: %s" (ex-message e))
+                    (if (:status (ex-data e))
+                      (log/errorf "Agent loop API error: %s status=%s provider=%s body=%s"
+                                  (ex-message e)
+                                  (:status (ex-data e))
+                                  (:provider (ex-data e))
+                                  (pr-str (:body (ex-data e))))
+                      (log/error e (format "Agent loop API error: %s provider=%s"
+                                           (ex-message e)
+                                           (:provider (ex-data e)))))
                     (log/error e "Agent loop error"))
                   (rf init (error-part e)))
                 (finally

--- a/src/metabase/metabot/agent/core.clj
+++ b/src/metabase/metabot/agent/core.clj
@@ -626,9 +626,9 @@
                                   (:status (ex-data e))
                                   (:provider (ex-data e))
                                   (pr-str (:body (ex-data e))))
-                      (log/error e (format "Agent loop API error: %s provider=%s"
-                                           (ex-message e)
-                                           (:provider (ex-data e)))))
+                      (log/errorf e "Agent loop API error: %s provider=%s"
+                                  (ex-message e)
+                                  (:provider (ex-data e))))
                     (log/error e "Agent loop error"))
                   (rf init (error-part e)))
                 (finally

--- a/src/metabase/metabot/self/claude.clj
+++ b/src/metabase/metabot/self/claude.clj
@@ -184,15 +184,19 @@
      :input_schema (mjs/transform params {:additionalProperties false})}))
 
 (defn- anthropic-errors [res]
-  (case (long (:status res 0))
-    401 (tru "Anthropic API key expired or invalid")
-    403 (tru "Anthropic API key has insufficient permissions")
-    404 (tru "Anthropic API endpoint is unavailable or the model was not found")
-    413 (tru "Anthropic API rejected our request because it was too large")
-    429 (tru "Anthropic API has rate limited us")
-    500 (tru "Anthropic API is not working but not saying why")
-    529 (tru "Anthropic API is overloaded and is asking us to wait")
-    (tru "Unhandled error accessing Anthropic API")))
+  (let [status    (long (:status res 0))
+        error-msg (get-in res [:body :error :message])]
+    (case status
+      401 (tru "Anthropic API key expired or invalid")
+      403 (tru "Anthropic API key has insufficient permissions")
+      404 (tru "Anthropic API endpoint is unavailable or the model was not found")
+      413 (tru "Anthropic API rejected our request because it was too large")
+      429 (tru "Anthropic API has rate limited us")
+      500 (tru "Anthropic API is not working but not saying why")
+      529 (tru "Anthropic API is overloaded and is asking us to wait")
+      (if error-msg
+        (tru "Anthropic API error (HTTP {0}): {1}" status error-msg)
+        (tru "Anthropic API error (HTTP {0})" status)))))
 
 (defn list-models
   "List available Anthropic models.

--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -505,7 +505,11 @@
                                                  :provider   provider
                                                  :error-code :provider-api-error)
                                           e)))
-      :else             (throw e))))
+      :else             (throw (ex-info (tru "{0} API request failed: {1}" provider (ex-message e))
+                                        {:api-error  true
+                                         :provider   provider
+                                         :error-code :provider-request-failed}
+                                        e)))))
 
 (defn missing-api-key-ex
   "Create a standardized missing-API-key exception for provider adapters."

--- a/src/metabase/metabot/self/openai.clj
+++ b/src/metabase/metabot/self/openai.clj
@@ -160,13 +160,17 @@
      :parameters  (mjs/transform params {:additionalProperties false})}))
 
 (defn- openai-errors [res]
-  (case (long (:status res 0))
-    401 (tru "OpenAI API key expired or invalid")
-    403 (tru "OpenAI API key has insufficient permissions")
-    404 (tru "OpenAI API endpoint or model listing is unavailable")
-    429 (tru "OpenAI API has rate limited us")
-    500 (tru "OpenAI API is not working but not saying why")
-    (tru "Unhandled error accessing OpenAI API")))
+  (let [status    (long (:status res 0))
+        error-msg (get-in res [:body :error :message])]
+    (case status
+      401 (tru "OpenAI API key expired or invalid")
+      403 (tru "OpenAI API key has insufficient permissions")
+      404 (tru "OpenAI API endpoint or model listing is unavailable")
+      429 (tru "OpenAI API has rate limited us")
+      500 (tru "OpenAI API is not working but not saying why")
+      (if error-msg
+        (tru "OpenAI API error (HTTP {0}): {1}" status error-msg)
+        (tru "OpenAI API error (HTTP {0})" status)))))
 
 (defn list-models
   "List available OpenAI models.

--- a/src/metabase/metabot/self/openrouter.clj
+++ b/src/metabase/metabot/self/openrouter.clj
@@ -92,17 +92,20 @@
                 :parameters  (mjs/transform params {:additionalProperties false})}}))
 
 (defn- openrouter-errors [res]
-  (case (long (:status res 0))
-    401 (tru "OpenRouter API key expired or invalid")
-    402 (tru "OpenRouter has insufficient credits")
-    403 (tru "OpenRouter API key has insufficient permissions")
-    404 (tru "OpenRouter model listing endpoint is unavailable")
-    429 (tru "OpenRouter has rate limited us")
-    500 (tru "OpenRouter returned an internal server error")
-    502 (tru "OpenRouter upstream provider returned an error")
-    503 (tru "OpenRouter service is unavailable")
-    (or (-> res :body :error :message)
-        (tru "Unhandled error accessing OpenRouter API"))))
+  (let [status    (long (:status res 0))
+        error-msg (get-in res [:body :error :message])]
+    (case status
+      401 (tru "OpenRouter API key expired or invalid")
+      402 (tru "OpenRouter has insufficient credits")
+      403 (tru "OpenRouter API key has insufficient permissions")
+      404 (tru "OpenRouter model listing endpoint is unavailable")
+      429 (tru "OpenRouter has rate limited us")
+      500 (tru "OpenRouter returned an internal server error")
+      502 (tru "OpenRouter upstream provider returned an error")
+      503 (tru "OpenRouter service is unavailable")
+      (if error-msg
+        (tru "OpenRouter API error (HTTP {0}): {1}" status error-msg)
+        (tru "OpenRouter API error (HTTP {0})" status)))))
 
 (defn list-models
   "List available OpenRouter models.


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #72471
Closes [BOT-1316: Make Anthropic API errors and SSE parsing more explicit](https://linear.app/metabase/issue/BOT-1316/make-anthropic-api-errors-and-sse-parsing-more-explicit)

  - Improve default-case error messages in provider error functions (claude.clj, openai.clj, openrouter.clj) to include the actual HTTP status code and upstream error message instead of a
   generic "Unhandled error" string
  - Wrap non-HTTP errors (connection timeouts, DNS failures, etc.) in rethrow-api-error! with :api-error true so they flow through the same error-handling path as HTTP errors
  - Consolidate redundant debug + error logging in the agent loop catch block into a single structured log line