### PR TITLE
Use crypo.random

### DIFF
--- a/e2e/test/scenarios/documents/comments.cy.spec.ts
+++ b/e2e/test/scenarios/documents/comments.cy.spec.ts
@@ -3,7 +3,6 @@ import {
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
 import { deleteComment } from "e2e/support/helpers";
-import { uuid } from "metabase/utils/uuid";
 import type { CommentId, DocumentId } from "metabase-types/api";
 
 const { H } = cy;
@@ -1921,7 +1920,7 @@ function createComment(
       content: [
         {
           type: "paragraph",
-          attrs: { _id: uuid() },
+          attrs: { _id: crypto.randomUUID() },
           content: [{ type: "text", text }],
         },
       ],

--- a/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
+++ b/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
@@ -9,7 +9,6 @@ import {
   SECOND_COLLECTION_ID,
   THIRD_COLLECTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import { uuid } from "metabase/utils/uuid";
 import {
   createMockDashboardCard,
   createMockTextDashboardCard,
@@ -1829,7 +1828,7 @@ describe("scenarios > embedding > full app", () => {
           content: [
             {
               type: "paragraph",
-              attrs: { _id: uuid() },
+              attrs: { _id: crypto.randomUUID() },
               content: [{ type: "text", text: "Test comment" }],
             },
           ],

--- a/e2e/test/scenarios/question/offset.cy.spec.ts
+++ b/e2e/test/scenarios/question/offset.cy.spec.ts
@@ -1,7 +1,6 @@
 const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import type { StructuredQuestionDetails } from "e2e/support/helpers";
-import { uuid } from "metabase/utils/uuid";
 import type {
   Aggregation,
   Breakout,
@@ -1403,7 +1402,7 @@ function verifyInvalidColumnName(
 
 function createOffsetOptions(name = "offset") {
   return {
-    "lib/uuid": uuid(),
+    "lib/uuid": crypto.randomUUID(),
     name,
     "display-name": name,
   };

--- a/enterprise/frontend/src/embedding-sdk-package/cli/utils/xray-models.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/cli/utils/xray-models.ts
@@ -2,7 +2,6 @@ import type {
   MetabaseDashboard,
   SdkDashboardId,
 } from "embedding-sdk-bundle/types/dashboard";
-import { uuid } from "metabase/utils/uuid";
 
 import { propagateErrorResponse } from "./propagate-error-response";
 
@@ -19,7 +18,7 @@ export async function createXrayDashboardFromModel(
   const { modelId, instanceUrl, cookie = "" } = options;
 
   // Queries an auto-generated dashboard layout for the model
-  const dashboardLoadId = uuid();
+  const dashboardLoadId = crypto.randomUUID();
   const url = `${instanceUrl}/api/automagic-dashboards/model/${modelId}?&dashboard_load_id=${dashboardLoadId}`;
 
   let res = await fetch(url, {

--- a/frontend/src/metabase-types/api/mocks/document.ts
+++ b/frontend/src/metabase-types/api/mocks/document.ts
@@ -1,4 +1,3 @@
-import { uuid } from "metabase/utils/uuid";
 import type { Document, DocumentContent } from "metabase-types/api";
 
 import { createMockUser } from "./user";
@@ -33,7 +32,7 @@ export const createMockDocumentContentParagraph = (
 ): DocumentContent => ({
   type: "paragraph",
   attrs: {
-    _id: uuid(),
+    _id: crypto.randomUUID(),
   },
   content: [{ type: "text", text }],
 });

--- a/frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.tsx
@@ -13,7 +13,6 @@ import AdminS from "metabase/css/admin.module.css";
 import ButtonsS from "metabase/css/components/buttons.module.css";
 import CS from "metabase/css/core/index.css";
 import { Button, Ellipsified, Image, Stack, Text } from "metabase/ui";
-import { uuid } from "metabase/utils/uuid";
 import { LeafletChoropleth } from "metabase/visualizations/components/LeafletChoropleth";
 import type {
   CustomGeoJSONMap,
@@ -84,7 +83,7 @@ export const CustomGeoJSONWidget = () => {
       region_name: "",
     });
     setOriginalMap(undefined);
-    setCurrentId(uuid());
+    setCurrentId(crypto.randomUUID());
   }, []);
 
   const handleEditMap = useCallback(

--- a/frontend/src/metabase/dashboard/actions/data-fetching.ts
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.ts
@@ -44,7 +44,6 @@ import { entityCompatibleQuery } from "metabase/utils/entities";
 import type { Deferred } from "metabase/utils/promise";
 import { defer } from "metabase/utils/promise";
 import { createAsyncThunk, createThunkAction } from "metabase/utils/redux";
-import { uuid } from "metabase/utils/uuid";
 import { isVisualizerDashboardCard } from "metabase/visualizer/utils";
 import type { UiParameter } from "metabase-lib/v1/parameters/types";
 import { getParameterValuesByIdFromQueryParams } from "metabase-lib/v1/parameters/utils/parameter-parsing";
@@ -496,7 +495,7 @@ export const fetchDashboardCardData =
     }
 
     const selectedTabId = getSelectedTabId(getState());
-    const dashboardLoadId = uuid();
+    const dashboardLoadId = crypto.randomUUID();
     const loadingIds = getLoadingDashCards(getState()).loadingIds;
     const nonVirtualDashcards = getCurrentTabDashboardCards(
       dashboard,
@@ -686,7 +685,7 @@ export const fetchDashboard = createAsyncThunk(
     try {
       let entities;
       let result;
-      const dashboardLoadId = uuid();
+      const dashboardLoadId = crypto.randomUUID();
 
       const dashboardType = getDashboardType(dashId);
       const loadedDashboard = getDashboardById(getState(), dashId);

--- a/frontend/src/metabase/metabot/state/reducer-utils.ts
+++ b/frontend/src/metabase/metabot/state/reducer-utils.ts
@@ -3,8 +3,6 @@ import { merge } from "icepick";
 import type { WritableDraft } from "immer";
 import { match } from "ts-pattern";
 
-import { uuid } from "metabase/utils/uuid";
-
 import type {
   MetabotAgentId,
   MetabotConverstationState,
@@ -64,7 +62,7 @@ export const createConversation = (
     activeToolCalls: [],
     profileOverride: undefined,
     ...overrides,
-    conversationId: overrides?.conversationId ?? uuid(),
+    conversationId: overrides?.conversationId ?? crypto.randomUUID(),
     experimental: {
       developerMessage: "",
       metabotReqIdOverride: undefined,

--- a/frontend/src/metabase/metabot/state/reducer.ts
+++ b/frontend/src/metabase/metabot/state/reducer.ts
@@ -3,7 +3,6 @@ import { castDraft } from "immer";
 import _ from "underscore";
 
 import { logout } from "metabase/auth/actions";
-import { uuid } from "metabase/utils/uuid";
 import type {
   MetabotCodeEdit,
   MetabotHistory,
@@ -312,7 +311,7 @@ export const metabot = createSlice({
       convo.state = snapshotState ?? {};
       convo.activeToolCalls = activeToolCalls ?? [];
       convo.errorMessages = errorMessages ?? [];
-      convo.conversationId = conversationId ?? uuid();
+      convo.conversationId = conversationId ?? crypto.randomUUID();
       convo.isProcessing = false;
 
       state.reactions.suggestedTransforms = (suggestedTransforms ?? []) as any;

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp/TagEditorHelp.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp/TagEditorHelp.tsx
@@ -6,7 +6,6 @@ import { ExternalLink } from "metabase/common/components/ExternalLink";
 import { useDocsUrl } from "metabase/common/hooks";
 import CS from "metabase/css/core/index.css";
 import { Code } from "metabase/ui";
-import { uuid } from "metabase/utils/uuid";
 import type Database from "metabase-lib/v1/metadata/Database";
 import type { DatabaseId, NativeDatasetQuery } from "metabase-types/api";
 
@@ -18,7 +17,7 @@ const SQL_EXAMPLES: Record<string, NativeDatasetQuery> = {
       query: "SELECT count(*)\nFROM products\nWHERE category = {{category}}",
       "template-tags": {
         category: {
-          id: uuid(),
+          id: crypto.randomUUID(),
           name: "category",
           "display-name": "Category",
           type: "text",
@@ -35,7 +34,7 @@ const SQL_EXAMPLES: Record<string, NativeDatasetQuery> = {
       query: "SELECT count(*)\nFROM products\nWHERE {{created_at}}",
       "template-tags": {
         created_at: {
-          id: uuid(),
+          id: crypto.randomUUID(),
           name: "created_at",
           "display-name": "Created At",
           type: "dimension",
@@ -52,7 +51,7 @@ const SQL_EXAMPLES: Record<string, NativeDatasetQuery> = {
         "SELECT count(*)\nFROM products\n[[WHERE category = {{category}}]]",
       "template-tags": {
         category: {
-          id: uuid(),
+          id: crypto.randomUUID(),
           name: "category",
           "display-name": "Category",
           type: "text",
@@ -69,14 +68,14 @@ const SQL_EXAMPLES: Record<string, NativeDatasetQuery> = {
         "SELECT count(*)\nFROM products\nWHERE 1=1\n  [[AND id = {{id}}]]\n  [[AND category = {{category}}]]",
       "template-tags": {
         id: {
-          id: uuid(),
+          id: crypto.randomUUID(),
           name: "id",
           "display-name": "ID",
           type: "number",
           required: false,
         },
         category: {
-          id: uuid(),
+          id: crypto.randomUUID(),
           name: "category",
           "display-name": "Category",
           type: "text",
@@ -93,7 +92,7 @@ const SQL_EXAMPLES: Record<string, NativeDatasetQuery> = {
         "SELECT count(*)\nFROM products\nWHERE 1=1\n  [[AND {{category}}]]",
       "template-tags": {
         category: {
-          id: uuid(),
+          id: crypto.randomUUID(),
           name: "category",
           "display-name": "Category",
           type: "dimension",
@@ -112,7 +111,7 @@ const MONGO_EXAMPLES: Record<string, NativeDatasetQuery> = {
       query: "[{ $match: { price: {{price}} } }]",
       "template-tags": {
         category: {
-          id: uuid(),
+          id: crypto.randomUUID(),
           name: "price",
           "display-name": "Price",
           type: "number",
@@ -129,7 +128,7 @@ const MONGO_EXAMPLES: Record<string, NativeDatasetQuery> = {
       query: "[{ $match: {{created_at}} }]",
       "template-tags": {
         created_at: {
-          id: uuid(),
+          id: crypto.randomUUID(),
           name: "created_at",
           "display-name": "Created At",
           type: "dimension",
@@ -145,7 +144,7 @@ const MONGO_EXAMPLES: Record<string, NativeDatasetQuery> = {
       query: "[{ $match: { [[ _id: {{id}} ]] } }]",
       "template-tags": {
         category: {
-          id: uuid(),
+          id: crypto.randomUUID(),
           name: "id",
           "display-name": "ID",
           type: "text",
@@ -162,14 +161,14 @@ const MONGO_EXAMPLES: Record<string, NativeDatasetQuery> = {
         "[{ $match: { [[ _id: {{id}} [[, category: {{category}} ]]  ]] } }]",
       "template-tags": {
         id: {
-          id: uuid(),
+          id: crypto.randomUUID(),
           name: "id",
           "display-name": "ID",
           type: "number",
           required: false,
         },
         category: {
-          id: uuid(),
+          id: crypto.randomUUID(),
           name: "category",
           "display-name": "Category",
           type: "text",
@@ -185,7 +184,7 @@ const MONGO_EXAMPLES: Record<string, NativeDatasetQuery> = {
       query: "[{ $match: { $and: [ { _id: 1 } [[, {{category}} ]] ] } }]",
       "template-tags": {
         category: {
-          id: uuid(),
+          id: crypto.randomUUID(),
           name: "category",
           "display-name": "Category",
           type: "dimension",

--- a/frontend/src/metabase/rich_text_editing/tiptap/extensions/NodeIds/utils.ts
+++ b/frontend/src/metabase/rich_text_editing/tiptap/extensions/NodeIds/utils.ts
@@ -1,8 +1,6 @@
 import type { Attribute } from "@tiptap/core";
 import { Plugin } from "prosemirror-state";
 
-import { uuid } from "metabase/utils/uuid";
-
 import { ID_ATTRIBUTE_NAME } from "./constants";
 
 type Attributes = {
@@ -12,7 +10,7 @@ type Attributes = {
 export function createIdAttribute() {
   return {
     [ID_ATTRIBUTE_NAME]: {
-      default: () => uuid(),
+      default: () => crypto.randomUUID(),
       parseHTML: (el: HTMLElement) =>
         el.getAttribute(ID_ATTRIBUTE_NAME) || null,
       renderHTML: (attrs: Attributes) =>
@@ -44,7 +42,7 @@ export function createProseMirrorPlugin(nodeName: string) {
         }
 
         if ((isRightNode && hasNoId) || isDuplicate) {
-          tr.setNodeAttribute(pos, ID_ATTRIBUTE_NAME, uuid());
+          tr.setNodeAttribute(pos, ID_ATTRIBUTE_NAME, crypto.randomUUID());
           updated = true;
         }
       });

--- a/frontend/src/metabase/utils/uuid.ts
+++ b/frontend/src/metabase/utils/uuid.ts
@@ -1,37 +1,3 @@
-export function uuid() {
-  if (
-    typeof crypto !== "undefined" &&
-    typeof crypto.randomUUID === "function"
-  ) {
-    return crypto.randomUUID();
-  } else {
-    return uuidV4();
-  }
-}
-
-function uuidV4() {
-  return (
-    s4() +
-    s4() +
-    "-" +
-    s4() +
-    "-" +
-    s4() +
-    "-" +
-    s4() +
-    "-" +
-    s4() +
-    s4() +
-    s4()
-  );
-}
-
-function s4() {
-  return Math.floor((1 + Math.random()) * 0x10000)
-    .toString(16)
-    .substring(1);
-}
-
 export function isUuid(uuid: unknown) {
   return (
     typeof uuid === "string" &&

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/utils.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/utils.ts
@@ -4,7 +4,6 @@ import _ from "underscore";
 
 import { formatNumber } from "metabase/utils/formatting/numbers";
 import { measureText } from "metabase/utils/measure-text";
-import { uuid } from "metabase/utils/uuid";
 import { isEmpty } from "metabase/utils/validate";
 import { isDate, isNumeric } from "metabase-lib/v1/types/utils/isa";
 import type {
@@ -144,7 +143,7 @@ export function getDefaultComparison(
   if (!dateUnit) {
     return [
       {
-        id: uuid(),
+        id: crypto.randomUUID(),
         type: COMPARISON_TYPES.PREVIOUS_VALUE,
       },
     ];
@@ -152,7 +151,7 @@ export function getDefaultComparison(
 
   return [
     {
-      id: uuid(),
+      id: crypto.randomUUID(),
       type: COMPARISON_TYPES.PREVIOUS_PERIOD,
     },
   ];


### PR DESCRIPTION
All major browsers have had this for over 4 years. Fixes a boundary violation as well.

I was going to replace all usages but Metabase can be embedded in insecure environments that don't provide `crypto` 