### PR TITLE
Make CLJS dev port configurable in CSP via MB_CLJS_DEV_PORT

### DIFF
--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -123,6 +123,7 @@
 
 (def ^:private frontend-dev-port (or (env/env :mb-frontend-dev-port) "8080"))
 (def ^:private frontend-address (str "http://localhost:" frontend-dev-port))
+(def ^:private cljs-dev-port (or (env/env :mb-cljs-dev-port) "9630"))
 
 (defn- content-security-policy-header
   "`Content-Security-Policy` header. See https://content-security-policy.com for more details."
@@ -146,7 +147,7 @@
                                  ;; CLJS REPL
                                  (when config/is-dev?
                                    ["'unsafe-eval'"
-                                    "http://localhost:9630"])
+                                    (str "http://localhost:" cljs-dev-port)])
                                  (when-not config/is-dev?
                                    (map (partial format "'sha256-%s'") inline-js-hashes)))
                   :child-src    ["'self'"
@@ -160,7 +161,7 @@
                                    frontend-address)
                                  ;; CLJS REPL
                                  (when config/is-dev?
-                                   "http://localhost:9630")
+                                   (str "http://localhost:" cljs-dev-port))
                                  "https://accounts.google.com"]
                   :style-src-attr ["'self'"]
                   :frame-src    (parse-allowed-iframe-hosts (server.settings/allowed-iframe-hosts))
@@ -180,7 +181,7 @@
                                    (str "*:" frontend-dev-port " ws://*:" frontend-dev-port))
                                  ;; CLJS REPL
                                  (when config/is-dev?
-                                   "ws://*:9630")]
+                                   (str "ws://*:" cljs-dev-port))]
                   :manifest-src ["'self'"]
                   :media-src    ["www.metabase.com"]}]
       (format "%s %s; " (name k) (str/join " " vs))))})


### PR DESCRIPTION
I'm working on a local dev setup that allows me to run multiple local Metabase instances, each with their own domain name, TLS and live reloading. For this to work, all the local development ports must not be hardcoded, so that each instance can use a different port for each individual service.

## Summary
- The frontend dev port was already configurable via `MB_FRONTEND_DEV_PORT`, but the CLJS REPL port (shadow-cljs HTTP server) was still hardcoded to `9630` in the CSP header
- This adds `MB_CLJS_DEV_PORT` (default `9630`) to make it configurable, matching the pattern already used for the frontend port
- Needed when running multiple Metabase dev instances with dynamic port allocation to avoid CSP violations

## Test plan
- [ ] Run Metabase in dev mode without setting `MB_CLJS_DEV_PORT` — verify CSP still includes `localhost:9630`
- [ ] Run with `MB_CLJS_DEV_PORT=9999` — verify CSP references port `9999` instead of `9630`

🤖 Generated with [Claude Code](https://claude.com/claude-code)