### PR TITLE
Add admin view to see how many things fire in parallel

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/monitoring_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/monitoring_test.clj
@@ -17,28 +17,37 @@
                   (mt/user-http-request user :get status (format "task/%d" (:id task))))
                 (get-task-info [user status]
                   (testing (format "get task info with %s user" (mt/user-descriptor user))
-                    (mt/user-http-request user :get status "task/info")))]
+                    (mt/user-http-request user :get status "task/info")))
+                (get-task-info-with-firings [user status]
+                  (testing (format "get task info with firings with %s user" (mt/user-descriptor user))
+                    (mt/user-http-request user :get status "task/info"
+                                          :start "2025-06-01T00:00:00Z"
+                                          :end   "2025-06-08T00:00:00Z")))]
           (testing "if `advanced-permissions` is disabled, require admins"
             (mt/with-premium-features #{}
               (get-tasks user 403)
               (get-single-task user 403)
               (get-task-info user 403)
+              (get-task-info-with-firings user 403)
               (get-tasks :crowberto 200)
               (get-single-task :crowberto 200)
-              (get-task-info :crowberto 200)))
+              (get-task-info :crowberto 200)
+              (get-task-info-with-firings :crowberto 200)))
 
           (testing "if `advanced-permissions` is enabled"
             (mt/with-premium-features #{:advanced-permissions}
               (testing "still fail if user's group doesn't have `monitoring` permission"
                 (get-tasks user 403)
                 (get-single-task user 403)
-                (get-task-info user 403))
+                (get-task-info user 403)
+                (get-task-info-with-firings user 403))
 
               (testing "allowed if user's group has `monitoring` permission"
                 (perms/grant-application-permissions! group :monitoring)
                 (get-tasks user 200)
                 (get-single-task user 200)
-                (get-task-info user 200)))))))))
+                (get-task-info user 200)
+                (get-task-info-with-firings user 200)))))))))
 
 (deftest logs-permissions-test
   (testing "GET /api/logger/logs"

--- a/frontend/src/metabase-types/api/task.ts
+++ b/frontend/src/metabase-types/api/task.ts
@@ -59,9 +59,39 @@ export type Job = {
   triggers: Trigger[];
 };
 
+export type TaskScheduleFiring = {
+  at: string;
+  job_key: string;
+  trigger_key: string;
+  description?: string | null;
+  schedule?: string | null;
+  timezone?: string | null;
+};
+
+export type TaskScheduleFiringTruncation = {
+  job_key: string;
+  trigger_key: string;
+  truncated: boolean;
+};
+
+export type TaskScheduleFiringsMeta = {
+  truncations: TaskScheduleFiringTruncation[];
+  global_cap_exhausted: boolean;
+  max_firings_per_trigger: number;
+  max_firings_global: number;
+};
+
 export type TaskInfo = {
-  scheduler: string[];
-  jobs: Job[];
+  scheduler: string[] | null;
+  jobs: Job[] | null;
+  firings?: TaskScheduleFiring[];
+  firings_meta?: TaskScheduleFiringsMeta;
+};
+
+/** Query params for `GET /api/task/info` when loading projected Quartz firings. */
+export type TaskInfoScheduleParams = {
+  start: string;
+  end: string;
 };
 
 export type TaskRunType = "subscription" | "alert" | "sync" | "fingerprint";

--- a/frontend/src/metabase/admin/routes.tsx
+++ b/frontend/src/metabase/admin/routes.tsx
@@ -33,6 +33,7 @@ import {
 } from "metabase/admin/settings/components/EmbeddingSettings";
 import { Help } from "metabase/admin/tools/components/Help";
 import { JobInfoApp } from "metabase/admin/tools/components/JobInfoApp";
+import { JobSchedulePage } from "metabase/admin/tools/components/JobSchedulePage/JobSchedulePage";
 import { JobTriggersModal } from "metabase/admin/tools/components/JobTriggersModal";
 import { LogLevelsModal } from "metabase/admin/tools/components/LogLevelsModal";
 import { Logs } from "metabase/admin/tools/components/Logs";
@@ -292,6 +293,7 @@ export const getRoutes = (
               )}
             </Route>
             <Route path="tasks">{getTasksRoutes()}</Route>
+            <Route path="schedule" component={JobSchedulePage} />
             <Route path="jobs" component={JobInfoApp}>
               <ModalRoute
                 path=":jobKey"

--- a/frontend/src/metabase/admin/tools/components/JobInfoApp.tsx
+++ b/frontend/src/metabase/admin/tools/components/JobInfoApp.tsx
@@ -16,7 +16,7 @@ import { useDispatch } from "metabase/utils/redux";
 import type { Job } from "metabase-types/api";
 
 interface SchedulerInfoProps {
-  scheduler?: string[];
+  scheduler?: string[] | null;
 }
 
 const SchedulerInfo = ({ scheduler }: SchedulerInfoProps) => {
@@ -30,7 +30,7 @@ const SchedulerInfo = ({ scheduler }: SchedulerInfoProps) => {
 };
 
 interface JobsTableProps {
-  jobs?: Job[];
+  jobs?: Job[] | null;
 }
 
 const JobsTable = ({ jobs }: JobsTableProps) => {
@@ -80,7 +80,7 @@ interface JobInfoAppProps {
 }
 
 export const JobInfoApp = ({ children }: JobInfoAppProps) => {
-  const { data, error, isFetching } = useGetTasksInfoQuery();
+  const { data, error, isFetching } = useGetTasksInfoQuery(undefined);
 
   return (
     <SettingsPageWrapper title={t`Scheduler Info`}>

--- a/frontend/src/metabase/admin/tools/components/JobSchedulePage/JobSchedulePage.tsx
+++ b/frontend/src/metabase/admin/tools/components/JobSchedulePage/JobSchedulePage.tsx
@@ -1,0 +1,374 @@
+import dayjs from "dayjs";
+import { useCallback, useMemo, useState } from "react";
+import { push } from "react-router-redux";
+import { t } from "ttag";
+
+import {
+  SettingsPageWrapper,
+  SettingsSection,
+} from "metabase/admin/components/SettingsSection";
+import { useGetTasksInfoQuery } from "metabase/api";
+import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
+import { useSetting } from "metabase/common/hooks";
+import "metabase/utils/dayjs";
+import {
+  Anchor,
+  Box,
+  Button,
+  Flex,
+  MultiSelect,
+  Popover,
+  ScrollArea,
+  Stack,
+  Text,
+  TextInput,
+  Title,
+  Tooltip,
+} from "metabase/ui";
+import { useDispatch } from "metabase/utils/redux";
+import * as Urls from "metabase/utils/urls";
+import type { TaskScheduleFiring } from "metabase-types/api";
+
+import {
+  filterFirings,
+  heatCellBackground,
+  maxPerDayFromCells,
+  uniqueJobKeyOptions,
+} from "./jobScheduleUtils";
+
+const HOURS = Array.from({ length: 24 }, (_, h) => h);
+const WEEKDAY_OFFSETS = [0, 1, 2, 3, 4, 5, 6];
+
+function displayZoneId(reportTimezone: string | null): string {
+  return reportTimezone || dayjs.tz.guess();
+}
+
+function weekRangeUtcIso(
+  weekOffset: number,
+  zone: string,
+): { start: string; end: string } {
+  const anchor = dayjs.tz(new Date(), zone).add(weekOffset, "week");
+  const start = anchor.startOf("isoWeek");
+  const end = start.add(1, "week");
+  return {
+    start: start.utc().toISOString(),
+    end: end.utc().toISOString(),
+  };
+}
+
+function buildHourlyCells(
+  firings: TaskScheduleFiring[],
+  weekStartUtc: dayjs.Dayjs,
+  zone: string,
+): TaskScheduleFiring[][][] {
+  const cells: TaskScheduleFiring[][][] = HOURS.map(() =>
+    WEEKDAY_OFFSETS.map(() => []),
+  );
+  const weekStartZ = weekStartUtc.tz(zone);
+  const weekEndZ = weekStartZ.add(1, "week");
+
+  for (const f of firings) {
+    const local = dayjs.utc(f.at).tz(zone);
+    if (!local.isBefore(weekEndZ) || local.isBefore(weekStartZ)) {
+      continue;
+    }
+    const dayIdx = local.startOf("day").diff(weekStartZ.startOf("day"), "day");
+    const hour = local.hour();
+    if (dayIdx >= 0 && dayIdx < 7 && hour >= 0 && hour < 24) {
+      cells[hour][dayIdx].push(f);
+    }
+  }
+  return cells;
+}
+
+export function JobSchedulePage() {
+  const dispatch = useDispatch();
+  const reportTimezone = useSetting("report-timezone");
+  const zone = displayZoneId(reportTimezone);
+  const [weekOffset, setWeekOffset] = useState(0);
+  const [selectedJobKeys, setSelectedJobKeys] = useState<string[]>([]);
+  const [searchText, setSearchText] = useState("");
+
+  const { start, end } = useMemo(
+    () => weekRangeUtcIso(weekOffset, zone),
+    [weekOffset, zone],
+  );
+
+  const { data, error, isFetching } = useGetTasksInfoQuery({ start, end });
+
+  const weekStartUtc = useMemo(() => {
+    const anchor = dayjs.tz(new Date(), zone).add(weekOffset, "week");
+    return anchor.startOf("isoWeek").utc();
+  }, [weekOffset, zone]);
+
+  const dayLabels = useMemo(() => {
+    const weekStartLocal = weekStartUtc.tz(zone);
+    return WEEKDAY_OFFSETS.map((d) =>
+      weekStartLocal.add(d, "day").format("ddd LL"),
+    );
+  }, [weekStartUtc, zone]);
+
+  const filteredFirings = useMemo(
+    () => filterFirings(data?.firings ?? [], selectedJobKeys, searchText),
+    [data?.firings, selectedJobKeys, searchText],
+  );
+
+  const cells = useMemo(
+    () => buildHourlyCells(filteredFirings, weekStartUtc, zone),
+    [filteredFirings, weekStartUtc, zone],
+  );
+
+  const maxPerDay = useMemo(() => maxPerDayFromCells(cells), [cells]);
+
+  const jobFilterOptions = useMemo(
+    () => uniqueJobKeyOptions(data?.firings ?? [], data?.jobs ?? null),
+    [data?.firings, data?.jobs],
+  );
+
+  const peak = useMemo(() => {
+    let max = 0;
+    let maxH = 0;
+    let maxD = 0;
+    cells.forEach((row, h) =>
+      row.forEach((c, d) => {
+        if (c.length > max) {
+          max = c.length;
+          maxH = h;
+          maxD = d;
+        }
+      }),
+    );
+    return max > 0 ? { count: max, hour: maxH, dayIdx: maxD } : null;
+  }, [cells]);
+
+  const onOpenJob = useCallback(
+    (jobKey: string) => {
+      dispatch(push(`${Urls.adminToolsJobs()}/${encodeURIComponent(jobKey)}`));
+    },
+    [dispatch],
+  );
+
+  const displayTzLabel = reportTimezone
+    ? reportTimezone
+    : `${t`Browser local`} (${dayjs.tz.guess()})`;
+
+  return (
+    <SettingsPageWrapper title={t`Scheduled jobs`}>
+      <LoadingAndErrorWrapper loading={isFetching} error={error}>
+        <Stack gap="lg">
+          <SettingsSection>
+            <Stack gap="sm">
+              <Text size="sm" c="text-secondary">
+                {t`Times shown in:`} {displayTzLabel}
+              </Text>
+              <Text size="sm" c="text-secondary">
+                {t`Each cell is one hour. Click a count to see firings and open the Quartz job.`}
+              </Text>
+              <Text size="sm" c="text-secondary">
+                {t`Cell color intensity is relative to that day’s busiest hour (not across the whole week).`}
+              </Text>
+              <Flex gap="sm" wrap="wrap">
+                <Button
+                  variant="default"
+                  onClick={() => setWeekOffset((w) => w - 1)}
+                >{t`Previous week`}</Button>
+                <Button variant="default" onClick={() => setWeekOffset(0)}>
+                  {t`This week`}
+                </Button>
+                <Button
+                  variant="default"
+                  onClick={() => setWeekOffset((w) => w + 1)}
+                >{t`Next week`}</Button>
+              </Flex>
+            </Stack>
+          </SettingsSection>
+
+          <SettingsSection>
+            <Stack gap="md">
+              <MultiSelect
+                data={jobFilterOptions}
+                label={t`Filter by job`}
+                description={t`Leave empty to include all jobs. Selection applies to the grid below.`}
+                placeholder={t`All jobs`}
+                searchable
+                clearable
+                value={selectedJobKeys}
+                onChange={setSelectedJobKeys}
+                comboboxProps={{ withinPortal: true }}
+              />
+              <TextInput
+                label={t`Search job or description`}
+                placeholder={t`Substring match`}
+                value={searchText}
+                onChange={(e) => setSearchText(e.currentTarget.value)}
+              />
+            </Stack>
+          </SettingsSection>
+
+          {data?.firings_meta &&
+            (data.firings_meta.truncations.length > 0 ||
+              data.firings_meta.global_cap_exhausted) && (
+              <SettingsSection>
+                <Stack gap="xs">
+                  {data.firings_meta.global_cap_exhausted && (
+                    <Text c="text-secondary" size="sm">
+                      {t`Some firings were omitted because the global safety cap was reached.`}{" "}
+                      ({data.firings_meta.max_firings_global})
+                    </Text>
+                  )}
+                  {data.firings_meta.truncations.length > 0 && (
+                    <Text c="text-secondary" size="sm">
+                      {t`One or more triggers hit the per-trigger cap.`} (
+                      {data.firings_meta.max_firings_per_trigger})
+                    </Text>
+                  )}
+                </Stack>
+              </SettingsSection>
+            )}
+
+          {peak && (
+            <SettingsSection>
+              <Text size="sm">
+                {t`Peak scheduled firings in a single hour (after filters):`}{" "}
+                {peak.count} ({dayLabels[peak.dayIdx]?.split(",")[0]}{" "}
+                {String(peak.hour).padStart(2, "0")}:00)
+              </Text>
+            </SettingsSection>
+          )}
+
+          <SettingsSection>
+            <ScrollArea.Autosize mah="70vh" type="scroll">
+              <Box
+                component="table"
+                style={{ borderCollapse: "collapse", width: "100%" }}
+              >
+                <thead>
+                  <tr>
+                    <Box component="th" style={{ width: "4rem" }} />
+                    {dayLabels.map((label) => (
+                      <Box
+                        component="th"
+                        key={label}
+                        style={{
+                          textAlign: "left",
+                          padding: "0.5rem",
+                          borderBottom: "1px solid var(--mb-color-border)",
+                          fontSize: "0.75rem",
+                        }}
+                      >
+                        {label}
+                      </Box>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {HOURS.map((hour) => (
+                    <tr key={hour}>
+                      <Box
+                        component="td"
+                        style={{
+                          padding: "0.25rem",
+                          fontSize: "0.75rem",
+                          color: "var(--mb-color-text-secondary)",
+                          verticalAlign: "top",
+                        }}
+                      >
+                        {String(hour).padStart(2, "0")}:00
+                      </Box>
+                      {WEEKDAY_OFFSETS.map((d) => {
+                        const list = cells[hour][d];
+                        const n = list.length;
+                        const dayMax = maxPerDay[d] ?? 0;
+                        const title = list
+                          .slice(0, 12)
+                          .map(
+                            (f) =>
+                              `${f.description || f.job_key} (${f.job_key})`,
+                          )
+                          .join("\n");
+                        return (
+                          <Box
+                            component="td"
+                            key={d}
+                            style={{
+                              border: "1px solid var(--mb-color-border)",
+                              padding: "0.15rem",
+                              minWidth: "4.5rem",
+                              verticalAlign: "top",
+                              backgroundColor: heatCellBackground(n, dayMax),
+                            }}
+                          >
+                            {n === 0 ? null : (
+                              <Popover position="bottom" withArrow shadow="md">
+                                <Popover.Target>
+                                  <Tooltip
+                                    label={title || t`Scheduled firings`}
+                                  >
+                                    <Button
+                                      variant="subtle"
+                                      size="compact-xs"
+                                      p={2}
+                                      h="auto"
+                                      style={{ minWidth: "100%" }}
+                                    >
+                                      <Text size="xs" fw={700}>
+                                        {n}
+                                      </Text>
+                                    </Button>
+                                  </Tooltip>
+                                </Popover.Target>
+                                <Popover.Dropdown maw={360}>
+                                  <Stack gap="xs">
+                                    <Title order={6}>
+                                      {t`Firings`} ({n})
+                                    </Title>
+                                    <Stack gap={4}>
+                                      {list.slice(0, 20).map((f) => (
+                                        <Box key={`${f.at}-${f.trigger_key}`}>
+                                          <Anchor
+                                            size="sm"
+                                            onClick={(e) => {
+                                              e.preventDefault();
+                                              onOpenJob(f.job_key);
+                                            }}
+                                          >
+                                            {f.description || f.job_key}
+                                          </Anchor>
+                                          <Text size="xs" c="text-secondary">
+                                            {f.trigger_key}
+                                            {f.timezone && f.timezone !== zone
+                                              ? ` · ${t`Trigger TZ`}: ${f.timezone}`
+                                              : ""}
+                                          </Text>
+                                          <Text size="xs" c="text-tertiary">
+                                            {dayjs
+                                              .utc(f.at)
+                                              .tz(zone)
+                                              .format("LLL")}
+                                          </Text>
+                                        </Box>
+                                      ))}
+                                      {list.length > 20 && (
+                                        <Text size="xs" c="text-secondary">
+                                          {t`Showing`} 20 {t`of`} {list.length}
+                                        </Text>
+                                      )}
+                                    </Stack>
+                                  </Stack>
+                                </Popover.Dropdown>
+                              </Popover>
+                            )}
+                          </Box>
+                        );
+                      })}
+                    </tr>
+                  ))}
+                </tbody>
+              </Box>
+            </ScrollArea.Autosize>
+          </SettingsSection>
+        </Stack>
+      </LoadingAndErrorWrapper>
+    </SettingsPageWrapper>
+  );
+}

--- a/frontend/src/metabase/admin/tools/components/JobSchedulePage/JobSchedulePage.unit.spec.tsx
+++ b/frontend/src/metabase/admin/tools/components/JobSchedulePage/JobSchedulePage.unit.spec.tsx
@@ -1,0 +1,83 @@
+import userEvent from "@testing-library/user-event";
+import dayjs from "dayjs";
+
+import { setupTaskInfoEndpoint } from "__support__/server-mocks";
+import {
+  renderWithProviders,
+  screen,
+  waitForLoaderToBeRemoved,
+} from "__support__/ui";
+import { createMockState } from "metabase/redux/store/mocks";
+import { createMockSettingsState } from "metabase/redux/store/mocks/settings";
+import type { TaskInfo } from "metabase-types/api";
+import "metabase/utils/dayjs";
+
+import { JobSchedulePage } from "./JobSchedulePage";
+
+function firingThisWeekAt(): string {
+  return dayjs
+    .tz(new Date(), "UTC")
+    .startOf("isoWeek")
+    .add(2, "day")
+    .hour(14)
+    .minute(0)
+    .second(0)
+    .utc()
+    .toISOString();
+}
+
+function mockTaskInfo(): TaskInfo {
+  return {
+    scheduler: [],
+    jobs: [],
+    firings: [
+      {
+        at: firingThisWeekAt(),
+        job_key: "metabase.task.example.job",
+        trigger_key: "example-trigger",
+        description: "Example scheduled task",
+      },
+    ],
+    firings_meta: {
+      truncations: [],
+      global_cap_exhausted: false,
+      max_firings_per_trigger: 400,
+      max_firings_global: 25000,
+    },
+  };
+}
+
+function setup() {
+  setupTaskInfoEndpoint(mockTaskInfo(), { delay: 10 });
+
+  return renderWithProviders(<JobSchedulePage />, {
+    storeInitialState: createMockState({
+      settings: createMockSettingsState({ "report-timezone": "UTC" }),
+    }),
+  });
+}
+
+describe("JobSchedulePage", () => {
+  it("shows the schedule grid after loading", async () => {
+    setup();
+    expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
+    await waitForLoaderToBeRemoved();
+    expect(screen.getByText("Scheduled jobs")).toBeInTheDocument();
+    expect(screen.getByText(/Times shown in:/)).toBeInTheDocument();
+    expect(screen.getByText(/UTC/)).toBeInTheDocument();
+    expect(screen.getByText(/Filter by job/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Cell color intensity is relative to that day/),
+    ).toBeInTheDocument();
+  });
+
+  it("opens a popover with firing details", async () => {
+    setup();
+    await waitForLoaderToBeRemoved();
+    const trigger = screen.getAllByRole("button", { name: "1" })[0];
+    await userEvent.click(trigger);
+    expect(
+      await screen.findByText("Example scheduled task"),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/admin/tools/components/JobSchedulePage/jobScheduleUtils.ts
+++ b/frontend/src/metabase/admin/tools/components/JobSchedulePage/jobScheduleUtils.ts
@@ -1,0 +1,82 @@
+import type { Job, TaskScheduleFiring } from "metabase-types/api";
+
+const NUM_HOURS = 24;
+const NUM_DAYS = 7;
+
+/** `cells[hour][day]` lists firings for that slot. */
+export type HourlyCells = TaskScheduleFiring[][][];
+
+export function maxPerDayFromCells(cells: HourlyCells): number[] {
+  return Array.from({ length: NUM_DAYS }, (_, d) => {
+    let max = 0;
+    for (let h = 0; h < NUM_HOURS; h++) {
+      const n = cells[h][d].length;
+      if (n > max) {
+        max = n;
+      }
+    }
+    return max;
+  });
+}
+
+/**
+ * Linear heat within a day column: `count / dayMax` maps to brand mix percentage.
+ * Returns undefined when the cell should have no heat fill.
+ */
+export function heatBrandMixPercent(
+  count: number,
+  dayMax: number,
+  minPct = 6,
+  maxPct = 48,
+): number | undefined {
+  if (count <= 0 || dayMax <= 0) {
+    return undefined;
+  }
+  const intensity = Math.min(1, count / dayMax);
+  return minPct + intensity * (maxPct - minPct);
+}
+
+export function heatCellBackground(
+  count: number,
+  dayMax: number,
+): string | undefined {
+  const pct = heatBrandMixPercent(count, dayMax);
+  if (pct == null) {
+    return undefined;
+  }
+  return `color-mix(in srgb, var(--mb-color-brand) ${pct}%, transparent)`;
+}
+
+export function uniqueJobKeyOptions(
+  firings: TaskScheduleFiring[],
+  jobs: Job[] | null | undefined,
+): { value: string; label: string }[] {
+  const keys = new Set<string>();
+  for (const f of firings) {
+    keys.add(f.job_key);
+  }
+  for (const j of jobs ?? []) {
+    keys.add(j.key);
+  }
+  return [...keys].sort().map((k) => ({ value: k, label: k }));
+}
+
+export function filterFirings(
+  firings: TaskScheduleFiring[],
+  selectedJobKeys: string[],
+  searchText: string,
+): TaskScheduleFiring[] {
+  const needle = searchText.trim().toLowerCase();
+  return firings.filter((f) => {
+    if (selectedJobKeys.length > 0 && !selectedJobKeys.includes(f.job_key)) {
+      return false;
+    }
+    if (needle) {
+      const hay = `${f.job_key} ${f.description ?? ""}`.toLowerCase();
+      if (!hay.includes(needle)) {
+        return false;
+      }
+    }
+    return true;
+  });
+}

--- a/frontend/src/metabase/admin/tools/components/JobSchedulePage/jobScheduleUtils.unit.spec.ts
+++ b/frontend/src/metabase/admin/tools/components/JobSchedulePage/jobScheduleUtils.unit.spec.ts
@@ -1,0 +1,94 @@
+import type { Job, TaskScheduleFiring } from "metabase-types/api";
+
+import {
+  filterFirings,
+  heatBrandMixPercent,
+  maxPerDayFromCells,
+  uniqueJobKeyOptions,
+} from "./jobScheduleUtils";
+
+function emptyCells(): TaskScheduleFiring[][][] {
+  return Array.from({ length: 24 }, () =>
+    Array.from({ length: 7 }, () => [] as TaskScheduleFiring[]),
+  );
+}
+
+describe("jobScheduleUtils", () => {
+  describe("maxPerDayFromCells", () => {
+    it("returns per-day max hour count", () => {
+      const cells = emptyCells();
+      cells[10][2].push({} as TaskScheduleFiring);
+      cells[10][2].push({} as TaskScheduleFiring);
+      cells[11][2].push({} as TaskScheduleFiring);
+      cells[5][0].push({} as TaskScheduleFiring);
+      const max = maxPerDayFromCells(cells);
+      expect(max[0]).toBe(1);
+      expect(max[2]).toBe(2);
+      expect(max[1]).toBe(0);
+    });
+  });
+
+  describe("heatBrandMixPercent", () => {
+    it("scales intensity within a day so mid counts differ from peak", () => {
+      const dayMax = 33;
+      const low = heatBrandMixPercent(15, dayMax);
+      const peak = heatBrandMixPercent(33, dayMax);
+      expect(low).toBeDefined();
+      expect(peak).toBeDefined();
+      expect(peak!).toBeGreaterThan(low!);
+    });
+
+    it("returns undefined for empty cells or zero day max", () => {
+      expect(heatBrandMixPercent(0, 10)).toBeUndefined();
+      expect(heatBrandMixPercent(5, 0)).toBeUndefined();
+    });
+  });
+
+  describe("filterFirings", () => {
+    const a: TaskScheduleFiring = {
+      at: "2025-01-01T00:00:00Z",
+      job_key: "job.a",
+      trigger_key: "t1",
+      description: "Alpha task",
+    };
+    const b: TaskScheduleFiring = {
+      at: "2025-01-01T01:00:00Z",
+      job_key: "job.b",
+      trigger_key: "t2",
+    };
+
+    it("filters by selected job keys", () => {
+      expect(filterFirings([a, b], ["job.a"], "")).toEqual([a]);
+    });
+
+    it("filters by search substring on job key or description", () => {
+      expect(filterFirings([a, b], [], "alpha")).toEqual([a]);
+      expect(filterFirings([a, b], [], "job.b")).toEqual([b]);
+    });
+
+    it("applies job key and search together", () => {
+      expect(filterFirings([a, b], ["job.a", "job.b"], "alpha")).toEqual([a]);
+    });
+  });
+
+  describe("uniqueJobKeyOptions", () => {
+    it("merges and sorts keys from firings and jobs", () => {
+      const opts = uniqueJobKeyOptions(
+        [
+          {
+            at: "x",
+            job_key: "z.job",
+            trigger_key: "t",
+          },
+          {
+            at: "y",
+            job_key: "a.job",
+            trigger_key: "t",
+          },
+        ],
+        [{ key: "m.job" } as Job],
+      );
+      expect(opts.map((o) => o.value)).toEqual(["a.job", "m.job", "z.job"]);
+    });
+  });
+});

--- a/frontend/src/metabase/admin/tools/components/JobTriggersModal.tsx
+++ b/frontend/src/metabase/admin/tools/components/JobTriggersModal.tsx
@@ -60,7 +60,7 @@ export const JobTriggersModal = ({
   params,
   onClose,
 }: JobTriggersModalProps) => {
-  const { data, error, isFetching } = useGetTasksInfoQuery();
+  const { data, error, isFetching } = useGetTasksInfoQuery(undefined);
 
   const { jobKey } = params;
   const jobs = data?.jobs;

--- a/frontend/src/metabase/admin/tools/components/ToolsApp.tsx
+++ b/frontend/src/metabase/admin/tools/components/ToolsApp.tsx
@@ -41,6 +41,12 @@ export function ToolsApp({ location, children }: ToolsAppProps) {
             location={location}
           />
           <ToolsNavItem
+            label={t`Schedule`}
+            path={Urls.adminToolsSchedule()}
+            icon="calendar"
+            location={location}
+          />
+          <ToolsNavItem
             label={t`Logs`}
             path={Urls.adminToolsLogs()}
             icon="audit"

--- a/frontend/src/metabase/api/task.ts
+++ b/frontend/src/metabase/api/task.ts
@@ -7,6 +7,7 @@ import type {
   RunEntity,
   Task,
   TaskInfo,
+  TaskInfoScheduleParams,
   TaskRunExtended,
 } from "metabase-types/api";
 
@@ -45,10 +46,11 @@ export const taskApi = Api.injectEndpoints({
       }),
       providesTags: (task) => (task ? provideTaskTags(task) : []),
     }),
-    getTasksInfo: builder.query<TaskInfo, void>({
-      query: () => ({
+    getTasksInfo: builder.query<TaskInfo, TaskInfoScheduleParams | void>({
+      query: (params) => ({
         method: "GET",
         url: "/api/task/info",
+        params: params ?? {},
       }),
     }),
     listTaskRuns: builder.query<

--- a/frontend/src/metabase/utils/urls/admin.ts
+++ b/frontend/src/metabase/utils/urls/admin.ts
@@ -165,6 +165,10 @@ export function adminToolsJobs() {
   return "/admin/tools/jobs";
 }
 
+export function adminToolsSchedule() {
+  return "/admin/tools/schedule";
+}
+
 export function adminToolsLogs() {
   return "/admin/tools/logs";
 }

--- a/frontend/test/__support__/server-mocks/task.ts
+++ b/frontend/test/__support__/server-mocks/task.ts
@@ -4,6 +4,7 @@ import type {
   ListTaskRunsResponse,
   ListTasksResponse,
   Task,
+  TaskInfo,
   TaskRunExtended,
 } from "metabase-types/api";
 
@@ -24,6 +25,13 @@ export function setupUniqueTasksEndpoint(
   options?: UserRouteConfig,
 ) {
   fetchMock.get(`path:/api/task/unique-tasks`, tasks, options);
+}
+
+export function setupTaskInfoEndpoint(
+  response: TaskInfo,
+  options?: UserRouteConfig,
+) {
+  fetchMock.get(/\/api\/task\/info(\?.*)?$/, response, options);
 }
 
 export function setupTaskRunsEndpoints(

--- a/src/metabase/task/core.clj
+++ b/src/metabase/task/core.clj
@@ -25,6 +25,7 @@
   schedule-task!
   scheduler
   scheduler-info
+  scheduled-firings-between
   start-scheduler!
   stop-scheduler!
   trigger-now!])

--- a/src/metabase/task/impl.clj
+++ b/src/metabase/task/impl.clj
@@ -28,13 +28,17 @@
    [metabase.task.job-factory :as job-factory]
    [metabase.tracing.core :as tracing]
    [metabase.util :as u]
+   [metabase.util.date-2 :as u.date]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms])
   (:import
+   (java.time Instant)
+   (java.util Date)
    (org.quartz CronTrigger JobDetail JobExecutionContext JobExecutionException JobKey JobListener
                JobPersistenceException ObjectAlreadyExistsException Scheduler Trigger TriggerKey
-               TriggerListener)))
+               TriggerListener)
+   (org.quartz.spi OperableTrigger)))
 
 (set! *warn-on-reflection* true)
 
@@ -339,6 +343,105 @@
   []
   {:scheduler (some-> (scheduler) .getMetaData .getSummary str/split-lines)
    :jobs      (jobs-info)})
+
+(def ^:private max-firings-window-days 14)
+
+(def ^:private max-firings-per-trigger 400)
+
+(def ^:private max-firings-global 25000)
+
+(defn- ^Date instant->date ^Date [^Instant i]
+  (Date/from i))
+
+(defn- firing-in-window? [^Date fire ^Date window-start ^Date window-end]
+  (let [t (.getTime fire)]
+    (and (not (< t (.getTime window-start)))
+         (< t (.getTime window-end)))))
+
+(defn- firing-row [job-key ^Trigger trigger ^Date fire]
+  (merge {:at           (u.date/format (.toInstant fire))
+          :job_key      job-key
+          :trigger_key  (-> ^Trigger trigger .getKey .getName)
+          :description  (.getDescription trigger)}
+         (when (instance? CronTrigger trigger)
+           (let [^CronTrigger ct trigger]
+             {:schedule (.getCronExpression ct)
+              :timezone (.getID (.getTimeZone ct))}))))
+
+(defn- safe-next-fire-time!
+  [^OperableTrigger trigger ^Date cursor job-key]
+  (try
+    (.getFireTimeAfter trigger cursor)
+    (catch Throwable e
+      (log/warnf e "Could not compute next fire time for trigger %s of job %s"
+                 (-> ^Trigger trigger .getKey .getName)
+                 job-key)
+      nil)))
+
+(defn- collect-firings-for-trigger!
+  [job-key ^OperableTrigger trigger ^Date window-start ^Date window-end per-cap ^clojure.lang.IRef remaining-global]
+  (let [cursor-init (Date. (dec (.getTime window-start)))]
+    (loop [out        (transient [])
+           ^Date cursor cursor-init
+           truncated? false]
+      (cond
+        (>= (count out) per-cap)
+        {:rows (persistent! out) :truncated? true}
+
+        (<= (long @remaining-global) 0)
+        {:rows (persistent! out) :truncated? true}
+
+        :else
+        (if-let [^Date next (safe-next-fire-time! trigger cursor job-key)]
+          (if (>= (.getTime next) (.getTime window-end))
+            {:rows (persistent! out) :truncated? truncated?}
+            (if-not (firing-in-window? next window-start window-end)
+              (recur out next truncated?)
+              (do
+                (vswap! remaining-global dec)
+                (recur (conj! out (firing-row job-key trigger next))
+                       next
+                       truncated?))))
+          {:rows (persistent! out) :truncated? truncated?})))))
+
+(mu/defn scheduled-firings-between
+  "Project Quartz trigger firings in the half-open window `[start, end)` (`end` exclusive), using each trigger's
+  live `OperableTrigger` definition. Returns `{:firings [...] :firings-meta ...}`. Assumes `start` is strictly before
+  `end` and that the window length does not exceed [[max-firings-window-days]] (caller should validate)."
+  [start :- (ms/InstanceOfClass Instant)
+   end :- (ms/InstanceOfClass Instant)]
+  (if-not (scheduler)
+    {:firings      []
+     :firings_meta {:truncations             []
+                    :global_cap_exhausted    false
+                    :max_firings_per_trigger max-firings-per-trigger
+                    :max_firings_global      max-firings-global}}
+    (let [window-start (instant->date start)
+          window-end   (instant->date end)
+          remaining    (volatile! max-firings-global)
+          truncations  (volatile! [])
+          all-rows     (volatile! [])]
+      (doseq [^JobKey jk (sort-by #(.getName ^JobKey %) (.getJobKeys ^Scheduler (scheduler) nil))
+              :let [job-name (.getName jk)]]
+        (doseq [^Trigger trig (try (qs/get-triggers-of-job (scheduler) jk)
+                                   (catch Throwable e
+                                     (log/warnf e "Error listing triggers for job %s" job-name)
+                                     []))]
+          (when (instance? OperableTrigger trig)
+            (let [{:keys [rows truncated?]} (collect-firings-for-trigger!
+                                             job-name ^OperableTrigger trig window-start window-end
+                                             max-firings-per-trigger remaining)]
+              (when (seq rows)
+                (vswap! all-rows into rows))
+              (when truncated?
+                (vswap! truncations conj {:job_key      job-name
+                                          :trigger_key (-> ^Trigger trig .getKey .getName)
+                                          :truncated   true}))))))
+      {:firings      (vec (sort-by :at @all-rows))
+       :firings_meta {:truncations             @truncations
+                      :global_cap_exhausted    (<= (long @remaining) 0)
+                      :max_firings_per_trigger max-firings-per-trigger
+                      :max_firings_global      max-firings-global}})))
 
 (defmacro rerun-on-error
   "Retry the current Job if an exception is thrown by the enclosed code."

--- a/src/metabase/task_history/api.clj
+++ b/src/metabase/task_history/api.clj
@@ -1,6 +1,7 @@
 (ns metabase.task-history.api
   "/api/task endpoints"
   (:require
+   [java-time.api :as t]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.permissions.core :as perms]
@@ -13,7 +14,9 @@
    [metabase.util.i18n :refer [tru]]
    [metabase.util.malli.registry :as mr]
    [metabase.util.malli.schema :as ms]
-   [toucan2.core :as t2]))
+   [toucan2.core :as t2])
+  (:import
+   (java.time Duration Instant)))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
@@ -39,15 +42,93 @@
                     [:id ms/PositiveInt]]]
   (api/check-404 (api/read-check :model/TaskHistory id)))
 
-;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
-;; use our API + we will need it when we make auto-TypeScript-signature generation happen
-;;
-#_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
+(mr/def ::TaskInfoQueryParams
+  [:maybe
+   [:map
+    [:start {:optional true} ms/NonBlankString]
+    [:end   {:optional true} ms/NonBlankString]]])
+
+(mr/def ::FiringRow
+  [:map
+   [:at          :string]
+   [:job_key     :string]
+   [:trigger_key :string]
+   [:description {:optional true} [:maybe :string]]
+   [:schedule    {:optional true} [:maybe :string]]
+   [:timezone    {:optional true} [:maybe :string]]])
+
+(mr/def ::FiringsTruncation
+  [:map
+   [:job_key      :string]
+   [:trigger_key  :string]
+   [:truncated    :boolean]])
+
+(mr/def ::FiringsMeta
+  [:map
+   [:truncations             [:sequential ::FiringsTruncation]]
+   [:global_cap_exhausted    :boolean]
+   [:max_firings_per_trigger :int]
+   [:max_firings_global      :int]])
+
+(mr/def ::TaskInfoResponse
+  [:map
+   [:scheduler    [:maybe [:sequential :string]]]
+   [:jobs         [:maybe [:sequential :any]]]
+   [:firings      {:optional true} [:sequential ::FiringRow]]
+   [:firings_meta {:optional true} ::FiringsMeta]])
+
+(def ^:private max-firings-window-ms (* 14 24 60 60 1000))
+
+(defn- ^Instant query-str->instant [s]
+  (let [parsed (u.date/parse s)]
+    (api/check-400 parsed (tru "{0} must be a valid ISO-8601 timestamp." s))
+    (cond
+      (instance? Instant parsed)
+      parsed
+
+      (t/zoned-date-time? parsed)
+      (.toInstant ^java.time.ZonedDateTime parsed)
+
+      (t/offset-date-time? parsed)
+      (.toInstant ^java.time.OffsetDateTime parsed)
+
+      (t/local-date-time? parsed)
+      (.toInstant (.atOffset ^java.time.LocalDateTime parsed java.time.ZoneOffset/UTC))
+
+      (t/local-date? parsed)
+      (.toInstant (.atStartOfDay ^java.time.LocalDate parsed java.time.ZoneOffset/UTC))
+
+      :else
+      (api/check-400 false (tru "Unsupported timestamp format; use an ISO-8601 date or datetime.")))))
+
+(defn- validate-firings-window! [^Instant start ^Instant end]
+  (api/check-400 (.isBefore start end) (tru "`start` must be strictly before `end`."))
+  (let [^Duration dur (Duration/between start end)]
+    (api/check-400 (<= (.toMillis dur) max-firings-window-ms)
+                   (tru "Time window between `start` and `end` must be at most 14 days."))))
+
 (api.macros/defendpoint :get "/info"
-  "Return raw data about all scheduled tasks (i.e., Quartz Jobs and Triggers)."
-  []
+  :- ::TaskInfoResponse
+  "Return raw data about all scheduled tasks (i.e., Quartz Jobs and Triggers).
+
+  Optional query parameters `start` and `end` (ISO-8601, both required together) add a `:firings` projection: trigger
+  fire instants in the half-open interval `[start, end)` (`end` is exclusive), capped for safety."
+  [_route-params
+   {:keys [start end]} :- ::TaskInfoQueryParams]
   (perms/check-has-application-permission :monitoring)
-  (task/scheduler-info))
+  (let [base (task/scheduler-info)]
+    (cond
+      (and start end)
+      (let [start-i (query-str->instant start)
+            end-i   (query-str->instant end)]
+        (validate-firings-window! start-i end-i)
+        (merge base (task/scheduled-firings-between start-i end-i)))
+
+      (or start end)
+      (api/check-400 false (tru "Both `start` and `end` query parameters are required to load scheduled firings."))
+
+      :else
+      base)))
 
 ;;; TODO -- this is not necessarily a 'task history' thing and maybe belongs in the `task` module's API rather than
 ;;; here... maybe a problem for another day.

--- a/test/metabase/task_history/api_test.clj
+++ b/test/metabase/task_history/api_test.clj
@@ -122,9 +122,31 @@
   (testing "Superusers could get task info"
     (is (malli= [:map
                  [:scheduler :any]
-                 [:jobs      [:sequential
-                              [:map-of :any :any]]]]
+                 [:jobs      :any]]
                 (mt/user-http-request :crowberto :get 200 "task/info")))))
+
+(deftest fetch-info-firings-window-test
+  (testing "firings query requires both start and end"
+    (is (string? (mt/user-http-request :crowberto :get 400 "task/info" :start "2025-01-01T00:00:00Z"))))
+  (testing "firings query rejects start after end"
+    (is (string? (mt/user-http-request :crowberto :get 400 "task/info"
+                                       :start "2025-01-10T00:00:00Z"
+                                       :end   "2025-01-01T00:00:00Z"))))
+  (testing "firings query rejects windows longer than 14 days"
+    (is (string? (mt/user-http-request :crowberto :get 400 "task/info"
+                                       :start "2025-01-01T00:00:00Z"
+                                       :end   "2025-01-20T00:00:00Z"))))
+  (testing "firings query returns firings and meta for a valid window"
+    (let [resp (mt/user-http-request :crowberto :get 200 "task/info"
+                                     :start "2025-06-01T00:00:00Z"
+                                     :end   "2025-06-08T00:00:00Z")]
+      (is (sequential? (:firings resp)))
+      (is (malli= [:map
+                   [:truncations             [:sequential :any]]
+                   [:global_cap_exhausted    :boolean]
+                   [:max_firings_per_trigger :int]
+                   [:max_firings_global      :int]]
+                  (:firings_meta resp))))))
 
 (deftest ^:synchronized single-filter-test
   (testing "Check that paging information is applied when provided and included in the response"


### PR DESCRIPTION
This is just a PoC to expose an admin view to show how many things fire in parallel. This can help admins to allocate jobs better (only subscriptions, alerts and such)
<img width="2556" height="1228" alt="image" src="https://github.com/user-attachments/assets/070cb86f-03f1-4d81-9eca-fe7f98befaeb" />
