### PR TITLE
Gdgt 2245 icons have wrong colors

### DIFF
--- a/frontend/src/metabase/common/components/EntityIcon/EntityIcon.tsx
+++ b/frontend/src/metabase/common/components/EntityIcon/EntityIcon.tsx
@@ -16,10 +16,8 @@ export type EntityIconProps = Omit<IconProps, "name" | "color"> & {
   alt?: string;
 } & Omit<ImgHTMLAttributes<HTMLImageElement>, keyof IconProps>;
 
-function resolveIconMaskColor(
-  color: EntityIconProps["color"] | undefined = "brand",
-): string {
-  if (color === "inherit") {
+function resolveIconMaskColor(color: EntityIconProps["color"]): string {
+  if (!color || color === "inherit") {
     return "currentColor";
   }
   return maybeColor(color) ?? "currentColor";

--- a/frontend/src/metabase/common/components/EntityIcon/EntityIcon.tsx
+++ b/frontend/src/metabase/common/components/EntityIcon/EntityIcon.tsx
@@ -16,6 +16,15 @@ export type EntityIconProps = Omit<IconProps, "name" | "color"> & {
   alt?: string;
 } & Omit<ImgHTMLAttributes<HTMLImageElement>, keyof IconProps>;
 
+function resolveIconMaskColor(
+  color: EntityIconProps["color"] | undefined = "brand",
+): string {
+  if (color === "inherit") {
+    return "currentColor";
+  }
+  return maybeColor(color) ?? "currentColor";
+}
+
 /**
  * Renders either a custom visualization icon (via iconUrl) or a standard
  * Metabase Icon (via name).  Drop-in replacement for `<Icon {...iconData} />`
@@ -25,13 +34,13 @@ export function EntityIcon({
   iconUrl,
   name = "unknown",
   size = "1rem",
-  color = "brand",
+  color,
   style,
   alt = "",
   ...rest
 }: EntityIconProps) {
   if (iconUrl) {
-    const bg = color === "inherit" ? "currentColor" : maybeColor(color);
+    const backgroundColor = resolveIconMaskColor(color);
 
     return (
       <span
@@ -44,7 +53,7 @@ export function EntityIcon({
           verticalAlign: "middle",
           width: size,
           height: size,
-          backgroundColor: bg,
+          backgroundColor,
           maskImage: `url(${iconUrl})`,
           maskSize: "contain",
           maskRepeat: "no-repeat",

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarLink.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarLink.tsx
@@ -75,6 +75,7 @@ function SidebarLink({
             name={iconProps.name}
             iconUrl={iconProps.iconUrl}
             size="1rem"
+            color="brand"
           />
         ) : (
           <SidebarIcon {...iconProps} isSelected={isSelected} />

--- a/frontend/src/metabase/query_builder/components/chart-type-selector/ChartTypeOption/ChartTypeOption.tsx
+++ b/frontend/src/metabase/query_builder/components/chart-type-selector/ChartTypeOption/ChartTypeOption.tsx
@@ -69,7 +69,7 @@ export const ChartTypeOption = ({
             name={iconName ?? "unknown"}
             iconUrl={visualization?.iconUrl}
             alt={displayName}
-            c={isSelected ? "white" : "brand"}
+            color={isSelected ? "white" : "brand"}
             size={20}
             style={
               hasCustomIcon && isSelected


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-2245/icons-have-wrong-colors

### Description

[This commit](https://github.com/metabase/metabase/pull/72433/changes#diff-cac4af2d123e1d71b525ba3af7c151a3dccf19a94a7f668122792cc76cb7d790R26)  has introduced a default `brand` color for all `EntityIcon` elements - this change was not correct. This PR removes this default completely and let's the callers to set custom color (which happened in most cases) or use current color as default.

### Demo

| before | after |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/82beaea8-3bbd-425b-a8eb-9605a43d272c) | ![image](https://github.com/user-attachments/assets/e4f664a2-2777-4700-bf37-8bf2de368cd0) | 

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
