### PR TITLE
Switch Athena driver from uber-jar to thin jar with pinned deps

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -90,8 +90,8 @@
                                              :git/sha "ffc4edc482c057cd9412c62f018a41e9140c618b"
                                              :git/url "https://github.com/eerohele/pp"}
   io.github.metabase/macaw                  {:mvn/version "0.2.36"}             ; Parse native SQL queries
-  io.netty/netty-codec-http                 {:mvn/version "4.2.12.Final"}        ; override of transitive dep from aws s3
-  io.netty/netty-codec-http2                {:mvn/version "4.2.12.Final"}        ; override of transitive dep from aws s3
+  io.netty/netty-codec-http                 {:mvn/version "4.2.9.Final"}        ; override of transitive dep from aws s3
+  io.netty/netty-codec-http2                {:mvn/version "4.2.9.Final"}        ; override of transitive dep from aws s3
   io.prometheus/simpleclient_hotspot        {:mvn/version "0.16.0"}             ; prometheus jvm collector
   junegunn/grouper                          {:mvn/version "0.1.1"}              ; Batch processing helper
   kixi/stats                                {:mvn/version "0.5.7"               ; Various statistic measures implemented as transducers

--- a/modules/drivers/athena/deps.edn
+++ b/modules/drivers/athena/deps.edn
@@ -9,4 +9,7 @@
  ;; https://github.com/metabase/metabase/actions/workflows/athena.yml
  ;; new versions of athena-jdbc appear here:
  ;; https://docs.aws.amazon.com/athena/latest/ug/jdbc-v3-driver.html#jdbc-v3-driver-download-uber-jar
- {com.metabase/athena-jdbc {:mvn/version "3.7.0"}}}
+ {com.metabase/athena-jdbc-thin {:mvn/version "3.7.0"
+                                :exclusions [software.amazon.awssdk/athena-streaming]}
+  ;; not on Maven Central; published to our private maven by the athena workflow
+  com.metabase/athena-streaming {:mvn/version "2.0"}}}

--- a/modules/drivers/hive-like/deps.edn
+++ b/modules/drivers/hive-like/deps.edn
@@ -245,11 +245,11 @@
 
   ;; Netty — pinned explicitly at safe versions for security scanning.
   ;; Driver JARs are scanned individually so these must be declared directly.
-  io.netty/netty-common                              {:mvn/version "4.2.12.Final"}
-  io.netty/netty-handler                             {:mvn/version "4.2.12.Final"}
-  io.netty/netty-transport                           {:mvn/version "4.2.12.Final"}
-  io.netty/netty-buffer                              {:mvn/version "4.2.12.Final"}
-  io.netty/netty-codec                               {:mvn/version "4.2.12.Final"}
-  io.netty/netty-resolver                            {:mvn/version "4.2.12.Final"}
-  io.netty/netty-transport-native-unix-common        {:mvn/version "4.2.12.Final"}
-  io.netty/netty-transport-native-epoll              {:mvn/version "4.2.12.Final"}}}
+  io.netty/netty-common                              {:mvn/version "4.2.9.Final"}
+  io.netty/netty-handler                             {:mvn/version "4.2.9.Final"}
+  io.netty/netty-transport                           {:mvn/version "4.2.9.Final"}
+  io.netty/netty-buffer                              {:mvn/version "4.2.9.Final"}
+  io.netty/netty-codec                               {:mvn/version "4.2.9.Final"}
+  io.netty/netty-resolver                            {:mvn/version "4.2.9.Final"}
+  io.netty/netty-transport-native-unix-common        {:mvn/version "4.2.9.Final"}
+  io.netty/netty-transport-native-epoll              {:mvn/version "4.2.9.Final"}}}


### PR DESCRIPTION
### Description

Use athena-jdbc-thin instead of the bundled uber-jar so transitive deps are visible to security scanners. ~Pin netty at 4.2.12.Final to match root deps.edn~. Add athena-streaming from our private maven repo (not available on Maven Central).

Closes: #72532

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
