### PR TITLE
Downgrade all netty pins to 4.2.9.Final

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -90,8 +90,8 @@
                                              :git/sha "ffc4edc482c057cd9412c62f018a41e9140c618b"
                                              :git/url "https://github.com/eerohele/pp"}
   io.github.metabase/macaw                  {:mvn/version "0.2.36"}             ; Parse native SQL queries
-  io.netty/netty-codec-http                 {:mvn/version "4.2.12.Final"}        ; override of transitive dep from aws s3
-  io.netty/netty-codec-http2                {:mvn/version "4.2.12.Final"}        ; override of transitive dep from aws s3
+  io.netty/netty-codec-http                 {:mvn/version "4.2.9.Final"}        ; override of transitive dep from aws s3
+  io.netty/netty-codec-http2                {:mvn/version "4.2.9.Final"}        ; override of transitive dep from aws s3
   io.prometheus/simpleclient_hotspot        {:mvn/version "0.16.0"}             ; prometheus jvm collector
   junegunn/grouper                          {:mvn/version "0.1.1"}              ; Batch processing helper
   kixi/stats                                {:mvn/version "0.5.7"               ; Various statistic measures implemented as transducers

--- a/modules/drivers/hive-like/deps.edn
+++ b/modules/drivers/hive-like/deps.edn
@@ -245,11 +245,11 @@
 
   ;; Netty — pinned explicitly at safe versions for security scanning.
   ;; Driver JARs are scanned individually so these must be declared directly.
-  io.netty/netty-common                              {:mvn/version "4.2.12.Final"}
-  io.netty/netty-handler                             {:mvn/version "4.2.12.Final"}
-  io.netty/netty-transport                           {:mvn/version "4.2.12.Final"}
-  io.netty/netty-buffer                              {:mvn/version "4.2.12.Final"}
-  io.netty/netty-codec                               {:mvn/version "4.2.12.Final"}
-  io.netty/netty-resolver                            {:mvn/version "4.2.12.Final"}
-  io.netty/netty-transport-native-unix-common        {:mvn/version "4.2.12.Final"}
-  io.netty/netty-transport-native-epoll              {:mvn/version "4.2.12.Final"}}}
+  io.netty/netty-common                              {:mvn/version "4.2.9.Final"}
+  io.netty/netty-handler                             {:mvn/version "4.2.9.Final"}
+  io.netty/netty-transport                           {:mvn/version "4.2.9.Final"}
+  io.netty/netty-buffer                              {:mvn/version "4.2.9.Final"}
+  io.netty/netty-codec                               {:mvn/version "4.2.9.Final"}
+  io.netty/netty-resolver                            {:mvn/version "4.2.9.Final"}
+  io.netty/netty-transport-native-unix-common        {:mvn/version "4.2.9.Final"}
+  io.netty/netty-transport-native-epoll              {:mvn/version "4.2.9.Final"}}}


### PR DESCRIPTION
Netty 4.2.12 introduced a breaking change in HttpObjectEncoder that causes AWS SDK netty-nio-client to fail with "unexpected message type: LastHttpContent" errors. Revert to 4.2.9.Final which is compatible with the AWS SDK while still being in the 4.2.x line.

Closes: #72532