### PR TITLE
Metrics Viewer UX tweaks

### DIFF
--- a/e2e/test/scenarios/data-studio/measures/measures-data-studio.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/measures/measures-data-studio.cy.spec.ts
@@ -150,7 +150,7 @@ describe("scenarios > data studio > data model > measures", () => {
       verifyMeasureInQueryBuilder("Total Revenue");
     });
 
-    it("should add aggregation and show preview in menu", () => {
+    it("should add aggregation and show explore in menu", () => {
       visitDataStudioMeasures(PRODUCTS_ID);
 
       MeasureList.getNewMeasureLink().scrollIntoView().click();
@@ -164,9 +164,9 @@ describe("scenarios > data studio > data model > measures", () => {
         .findByText(/Average of Price/i)
         .should("exist");
 
-      cy.log("verify preview is available in menu");
+      cy.log("verify explore is available in menu");
       MeasureEditor.getActionsButton().click();
-      H.popover().findByText("Preview").should("be.visible");
+      H.popover().findByText("Explore").should("be.visible");
     });
   });
 
@@ -471,7 +471,7 @@ describe("scenarios > data studio > data model > measures", () => {
 
         cy.log("verify Remove measure option is hidden in actions menu");
         MeasureEditor.getActionsButton().click();
-        H.popover().findByText("Preview").should("be.visible");
+        H.popover().findByText("Explore").should("be.visible");
         H.popover().findByText("Remove measure").should("not.exist");
         cy.realPress("Escape");
 

--- a/frontend/src/metabase/data-studio/common/components/MoreMenu/MoreMenu.tsx
+++ b/frontend/src/metabase/data-studio/common/components/MoreMenu/MoreMenu.tsx
@@ -7,6 +7,7 @@ import { ActionIcon, Icon, Menu } from "metabase/ui";
 
 type MoreMenuProps = {
   previewUrl?: string;
+  previewLabel?: string;
   onRemove?: () => void;
   ariaLabel: string;
   removeLabel: string;
@@ -16,6 +17,7 @@ type MoreMenuProps = {
 
 export function MoreMenu({
   previewUrl,
+  previewLabel,
   onRemove,
   ariaLabel,
   removeLabel,
@@ -50,7 +52,7 @@ export function MoreMenu({
               target="_blank"
               leftSection={<Icon name="share" />}
             >
-              {t`Preview`}
+              {previewLabel ?? t`Preview`}
             </Menu.Item>
           )}
           {onRemove && (

--- a/frontend/src/metabase/data-studio/measures/components/MeasureHeader/MeasureHeader.unit.spec.tsx
+++ b/frontend/src/metabase/data-studio/measures/components/MeasureHeader/MeasureHeader.unit.spec.tsx
@@ -44,13 +44,13 @@ describe("MeasureHeader", () => {
     );
   });
 
-  it("shows preview and remove options in the actions menu", async () => {
+  it("shows explore and remove options in the actions menu", async () => {
     setup();
     await userEvent.click(
       screen.getByRole("button", { name: "Measure actions" }),
     );
     expect(
-      screen.getByRole("menuitem", { name: /Preview/ }),
+      screen.getByRole("menuitem", { name: /Explore/ }),
     ).toBeInTheDocument();
     expect(
       screen.getByRole("menuitem", { name: /Remove measure/ }),
@@ -69,7 +69,7 @@ describe("MeasureHeader", () => {
         screen.getByRole("button", { name: "Measure actions" }),
       );
       expect(
-        screen.getByRole("menuitem", { name: /Preview/ }),
+        screen.getByRole("menuitem", { name: /Explore/ }),
       ).toBeInTheDocument();
       expect(
         screen.queryByRole("menuitem", { name: /Remove measure/ }),

--- a/frontend/src/metabase/data-studio/measures/components/MeasureMoreMenu/MeasureMoreMenu.tsx
+++ b/frontend/src/metabase/data-studio/measures/components/MeasureMoreMenu/MeasureMoreMenu.tsx
@@ -14,6 +14,7 @@ export function MeasureMoreMenu({
   return (
     <MoreMenu
       previewUrl={previewUrl}
+      previewLabel={t`Explore`}
       onRemove={onRemove}
       ariaLabel={t`Measure actions`}
       removeLabel={t`Remove measure`}

--- a/frontend/src/metabase/data-studio/measures/pages/MeasureDetailPage/MeasureDetailPage.tsx
+++ b/frontend/src/metabase/data-studio/measures/pages/MeasureDetailPage/MeasureDetailPage.tsx
@@ -6,12 +6,12 @@ import { t } from "ttag";
 import { useUpdateMeasureMutation } from "metabase/api";
 import { LeaveRouteConfirmModal } from "metabase/common/components/LeaveConfirmModal";
 import { PageContainer } from "metabase/data-studio/common/components/PageContainer";
-import { getDatasetQueryPreviewUrl } from "metabase/data-studio/common/utils/get-dataset-query-preview-url";
 import { getUserCanWriteMeasures } from "metabase/data-studio/selectors";
 import { useMetadataToasts } from "metabase/metadata/hooks";
 import { getMetadata } from "metabase/selectors/metadata";
 import { Button, Group } from "metabase/ui";
 import { useSelector } from "metabase/utils/redux";
+import * as Urls from "metabase/utils/urls";
 import * as Lib from "metabase-lib";
 import type { Measure } from "metabase-types/api";
 
@@ -56,9 +56,7 @@ export function MeasureDetailPage({
   );
 
   const isValid = aggregations.length === 1;
-  const previewUrl = isValid
-    ? getDatasetQueryPreviewUrl(definition)
-    : undefined;
+  const previewUrl = isValid ? Urls.exploreMeasure(measure.id) : undefined;
 
   const setQuery = useCallback((newQuery: Lib.Query) => {
     setDefinition(Lib.toJsQuery(newQuery));

--- a/frontend/src/metabase/metrics-viewer/hooks/use-viewer-url.ts
+++ b/frontend/src/metabase/metrics-viewer/hooks/use-viewer-url.ts
@@ -55,9 +55,13 @@ export function useViewerUrl(
       if (!hash) {
         const params = new URLSearchParams(location.search);
         const metricId = params.get("metricId");
-        if (metricId) {
+        const measureId = params.get("measureId");
+        if (metricId || measureId) {
+          const entity = metricId
+            ? { type: "metric" as const, id: parseInt(metricId, 10) }
+            : { type: "measure" as const, id: parseInt(measureId!, 10) };
           serializedState = {
-            formulaEntities: [{ type: "metric", id: parseInt(metricId, 10) }],
+            formulaEntities: [entity],
             tabs: [],
             selectedTabId: null,
           };

--- a/frontend/src/metabase/metrics/components/MetricHeader/MetricHeader.tsx
+++ b/frontend/src/metabase/metrics/components/MetricHeader/MetricHeader.tsx
@@ -50,7 +50,7 @@ export function MetricHeader({
       icon="metric"
       tabs={<MetricTabs card={card} urls={urls} />}
       actions={
-        <Group wrap="nowrap" gap="sm" align="center">
+        <Group wrap="nowrap" align="center">
           {actions}
           <MetricToolbar
             card={card}

--- a/frontend/src/metabase/metrics/components/MetricHeader/MetricToolbar/MetricToolbar.tsx
+++ b/frontend/src/metabase/metrics/components/MetricHeader/MetricToolbar/MetricToolbar.tsx
@@ -10,6 +10,7 @@ import {
 } from "metabase/api";
 import { ForwardRefLink } from "metabase/common/components/Link";
 import { ToolbarButton } from "metabase/common/components/ToolbarButton";
+import { canAccessDataStudio as canAccessDataStudioSelector } from "metabase/data-studio/selectors";
 import { getLibraryCollectionType } from "metabase/data-studio/utils";
 import { isNumericMetric } from "metabase/metrics/utils/validation";
 import { QuestionAlertListModal } from "metabase/notifications/modals/QuestionAlertListModal";
@@ -77,7 +78,7 @@ interface MetricToolbarButtonsProps {
 
 function MetricToolbarButtons({
   card,
-  showDataStudioLink,
+  showDataStudioLink: showDataStudioLinkProp,
   onOpenModal,
 }: MetricToolbarButtonsProps) {
   const metadata = useSelector(getMetadata);
@@ -100,15 +101,17 @@ function MetricToolbarButtons({
 
   const dispatch = useDispatch();
 
-  const isInLibrary =
-    showDataStudioLink &&
-    getLibraryCollectionType(card.collection?.type) != null;
+  const canAccessDataStudio = useSelector(canAccessDataStudioSelector);
+
+  const showDataStudioLink =
+    showDataStudioLinkProp &&
+    getLibraryCollectionType(card.collection?.type) != null &&
+    canAccessDataStudio;
 
   return (
     <Group wrap="nowrap" gap="sm">
       {isNumericMetric(card) && (
         <Button
-          size="sm"
           component={ForwardRefLink}
           to={Urls.exploreMetric(card.id)}
           target="_blank"
@@ -173,11 +176,11 @@ function MetricToolbarButtons({
             </Menu.Item>
           )}
 
-          {(PLUGIN_AUDIT.isEnabled || isInLibrary) && (
+          {(PLUGIN_AUDIT.isEnabled || showDataStudioLink) && (
             <Menu.Divider role="separator" />
           )}
 
-          {isInLibrary && (
+          {showDataStudioLink && (
             <Menu.Item
               leftSection={<Icon name="grid_bordered" />}
               onClick={() => dispatch(openUrl(Urls.dataStudioMetric(card.id)))}

--- a/frontend/src/metabase/metrics/components/MetricHeader/MetricToolbar/MetricToolbar.unit.spec.tsx
+++ b/frontend/src/metabase/metrics/components/MetricHeader/MetricToolbar/MetricToolbar.unit.spec.tsx
@@ -148,6 +148,7 @@ describe("MetricToolbar", () => {
       setup({
         showDataStudioLink: true,
         collectionType: "library-metrics",
+        isAdmin: true,
       });
       await openMenu();
 
@@ -157,7 +158,7 @@ describe("MetricToolbar", () => {
     });
 
     it("should hide 'Open in Data Studio' when not in library collection", async () => {
-      setup({ showDataStudioLink: true, collectionType: null });
+      setup({ showDataStudioLink: true, collectionType: null, isAdmin: true });
       await openMenu();
 
       expect(screen.queryByText("Open in Data Studio")).not.toBeInTheDocument();
@@ -169,7 +170,17 @@ describe("MetricToolbar", () => {
       setup({
         showDataStudioLink: false,
         collectionType: "library-metrics",
+        isAdmin: true,
       });
+      await openMenu();
+
+      expect(screen.queryByText("Open in Data Studio")).not.toBeInTheDocument();
+      expect(getDividers()).toHaveLength(2);
+      expectNoConsecutiveOrTrailingDividers();
+    });
+
+    it("should hide 'Open in Data Studio' when user is not an admin", async () => {
+      setup({ showDataStudioLink: true, collectionType: "library-metrics" });
       await openMenu();
 
       expect(screen.queryByText("Open in Data Studio")).not.toBeInTheDocument();

--- a/frontend/src/metabase/utils/urls/metrics.ts
+++ b/frontend/src/metabase/utils/urls/metrics.ts
@@ -22,6 +22,10 @@ export function exploreMetric(metricId: number): string {
   return `${METRICS_VIEWER_ROOT}?metricId=${metricId}`;
 }
 
+export function exploreMeasure(measureId: number): string {
+  return `${METRICS_VIEWER_ROOT}?measureId=${measureId}`;
+}
+
 export interface ExploreMetricDimensionOptions {
   metricId: number;
   dimensionId: string;


### PR DESCRIPTION
Closes #71625
Closes #71624
Closes [UXW-3451](https://linear.app/metabase/issue/UXW-3451/add-another-way-to-open-a-measure-in-metric-viewer)

### Description

1. Don’t show Open in Data Studio action if the user doesn’t have permission
2. Fix Explore button alignment
3. Allow opening measures in Metrics Viewer

### How to verify

1. Go to the metric homepage for a Data Studio metric as a non-admin and non-data analyst user. "Open in Data Studio" should not appear in the actions menu
2. Go to a metric homepage -> Definition tab, then edit the definition so the Save and Cancel buttons appear. Verify that the Save, Cancel, and Explore buttons have the same height and gap between them
3. In Data Studio, open a measure. The action menu should have an "Explore" button that takes you to the Metric Viewer

### Demo

1:
<img width="267" height="268" alt="image" src="https://github.com/user-attachments/assets/7aa09443-e379-4a4d-a1f9-5f8fbb90a14d" />

2:
<img width="314" height="67" alt="image" src="https://github.com/user-attachments/assets/d204e540-89ca-4770-80cd-8731f4484b10" />

3:
<img width="365" height="225" alt="image" src="https://github.com/user-attachments/assets/9b543f49-6ba9-4b17-944e-5ae889fcfe5d" />

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
