### PR TITLE
Fix metric explorer for metrics with implicit joins

### DIFF
--- a/src/metabase/lib_metric/ast/build.cljc
+++ b/src/metabase/lib_metric/ast/build.cljc
@@ -243,6 +243,13 @@
   (fn [agg-type _mbql-clause] agg-type)
   :hierarchy #'mbql-agg-hierarchy)
 
+(defn- field-ref->column-node
+  "Build an AST column node from a simple [:field opts id] ref, preserving
+  `:source-field` so implicit-join metrics compile to queries the QP can resolve."
+  [[_field opts field-id]]
+  (cond-> (column-node field-id)
+    (:source-field opts) (assoc :source-field (:source-field opts))))
+
 (defmethod mbql-aggregation->node* :count
   [_ mbql-clause]
   (let [[_agg-type _opts & args] mbql-clause
@@ -251,8 +258,7 @@
       {:node/type :aggregation/count}
       (if (simple-field-ref? first-arg)
         {:node/type :aggregation/count
-         :column    (let [[_field _opts field-id] first-arg]
-                      (column-node field-id))}
+         :column    (field-ref->column-node first-arg)}
         {:node/type :aggregation/mbql
          :clause    mbql-clause}))))
 
@@ -262,8 +268,7 @@
         first-arg (first args)]
     (if (simple-field-ref? first-arg)
       {:node/type (keyword "aggregation" (name agg-type))
-       :column    (let [[_field _opts field-id] first-arg]
-                    (column-node field-id))}
+       :column    (field-ref->column-node first-arg)}
       {:node/type :aggregation/mbql
        :clause    mbql-clause})))
 

--- a/src/metabase/lib_metric/ast/build.cljc
+++ b/src/metabase/lib_metric/ast/build.cljc
@@ -248,6 +248,13 @@
   (fn [agg-type _mbql-clause] agg-type)
   :hierarchy #'mbql-agg-hierarchy)
 
+(defn- field-ref->column-node
+  "Build an AST column node from a simple [:field opts id] ref, preserving
+  `:source-field` so implicit-join metrics compile to queries the QP can resolve."
+  [[_field opts field-id]]
+  (cond-> (column-node field-id)
+    (:source-field opts) (assoc :source-field (:source-field opts))))
+
 (defmethod mbql-aggregation->node* :count
   [_ mbql-clause]
   (let [[_agg-type _opts & args] mbql-clause
@@ -256,8 +263,7 @@
       {:node/type :aggregation/count}
       (if (simple-field-ref? first-arg)
         {:node/type :aggregation/count
-         :column    (let [[_field _opts field-id] first-arg]
-                      (column-node field-id))}
+         :column    (field-ref->column-node first-arg)}
         {:node/type :aggregation/mbql
          :clause    mbql-clause}))))
 
@@ -267,8 +273,7 @@
         first-arg (first args)]
     (if (simple-field-ref? first-arg)
       {:node/type (keyword "aggregation" (name agg-type))
-       :column    (let [[_field _opts field-id] first-arg]
-                    (column-node field-id))}
+       :column    (field-ref->column-node first-arg)}
       {:node/type :aggregation/mbql
        :clause    mbql-clause})))
 

--- a/test/metabase/lib_metric/ast/build_test.cljc
+++ b/test/metabase/lib_metric/ast/build_test.cljc
@@ -182,6 +182,23 @@
     (testing "extracts sum aggregation"
       (is (= :aggregation/sum (get-in ast [:expression :ast :source :aggregation :node/type]))))))
 
+(deftest ^:parallel aggregation-preserves-source-field-test
+  (testing "aggregation field refs with :source-field (implicit join) carry it through to the column node"
+    (let [mbql-agg->node @#'ast.build/mbql-aggregation->node
+          sum-node       (mbql-agg->node [:sum {:lib/uuid "c1"} [:field {:source-field 3} 53]])
+          count-node     (mbql-agg->node [:count {:lib/uuid "c2"} [:field {:source-field 3} 53]])]
+      (is (= {:node/type :aggregation/sum
+              :column    {:node/type :ast/column :id 53 :source-field 3}}
+             sum-node))
+      (is (= {:node/type :aggregation/count
+              :column    {:node/type :ast/column :id 53 :source-field 3}}
+             count-node))))
+  (testing "aggregation field refs without :source-field produce a plain column node"
+    (let [mbql-agg->node @#'ast.build/mbql-aggregation->node]
+      (is (= {:node/type :aggregation/sum
+              :column    {:node/type :ast/column :id 53}}
+             (mbql-agg->node [:sum {:lib/uuid "c3"} [:field {} 53]]))))))
+
 ;;; -------------------------------------------------- Dimension Reference Conversion --------------------------------------------------
 
 (deftest ^:parallel dimension-ref->ast-dimension-ref-test

--- a/test/metabase/lib_metric/ast/build_test.cljc
+++ b/test/metabase/lib_metric/ast/build_test.cljc
@@ -170,6 +170,23 @@
     (testing "extracts sum aggregation"
       (is (= :aggregation/sum (get-in ast [:expression :ast :source :aggregation :node/type]))))))
 
+(deftest ^:parallel aggregation-preserves-source-field-test
+  (testing "aggregation field refs with :source-field (implicit join) carry it through to the column node"
+    (let [mbql-agg->node @#'ast.build/mbql-aggregation->node
+          sum-node       (mbql-agg->node [:sum {:lib/uuid "c1"} [:field {:source-field 3} 53]])
+          count-node     (mbql-agg->node [:count {:lib/uuid "c2"} [:field {:source-field 3} 53]])]
+      (is (= {:node/type :aggregation/sum
+              :column    {:node/type :ast/column :id 53 :source-field 3}}
+             sum-node))
+      (is (= {:node/type :aggregation/count
+              :column    {:node/type :ast/column :id 53 :source-field 3}}
+             count-node))))
+  (testing "aggregation field refs without :source-field produce a plain column node"
+    (let [mbql-agg->node @#'ast.build/mbql-aggregation->node]
+      (is (= {:node/type :aggregation/sum
+              :column    {:node/type :ast/column :id 53}}
+             (mbql-agg->node [:sum {:lib/uuid "c3"} [:field {} 53]]))))))
+
 ;;; -------------------------------------------------- Dimension Reference Conversion --------------------------------------------------
 
 (deftest ^:parallel dimension-ref->ast-dimension-ref-test

--- a/test/metabase/lib_metric/ast/compile_test.cljc
+++ b/test/metabase/lib_metric/ast/compile_test.cljc
@@ -452,6 +452,21 @@
       (is (= 123 (nth field-ref 2)))
       (is (= 42 (get-in field-ref [1 :source-field]))))))
 
+(deftest ^:parallel compile-fk-aggregation-column-test
+  (testing "aggregation over an FK column produces :source-field on the compiled field ref (implicit join)"
+    (let [ast (assoc-in sample-ast [:source :aggregation]
+                        {:node/type :aggregation/sum
+                         :column    {:node/type :ast/column :id 53 :source-field 3}})
+          result (ast.compile/compile-to-mbql ast)
+          agg    (first (get-in result [:stages 0 :aggregation]))
+          field-ref (nth agg 2)]
+      (testing "stays single-stage (no explicit joins required)"
+        (is (= 1 (count (:stages result)))))
+      (is (= :sum (first agg)))
+      (is (= :field (first field-ref)))
+      (is (= 53 (nth field-ref 2)))
+      (is (= 3 (get-in field-ref [1 :source-field]))))))
+
 ;;; -------------------------------------------------- Options --------------------------------------------------
 
 (deftest ^:parallel compile-with-limit-test

--- a/test/metabase/lib_metric/ast/compile_test.cljc
+++ b/test/metabase/lib_metric/ast/compile_test.cljc
@@ -444,6 +444,21 @@
       (is (= 123 (nth field-ref 2)))
       (is (= 42 (get-in field-ref [1 :source-field]))))))
 
+(deftest ^:parallel compile-fk-aggregation-column-test
+  (testing "aggregation over an FK column produces :source-field on the compiled field ref (implicit join)"
+    (let [ast (assoc-in sample-ast [:source :aggregation]
+                        {:node/type :aggregation/sum
+                         :column    {:node/type :ast/column :id 53 :source-field 3}})
+          result (ast.compile/compile-to-mbql ast)
+          agg    (first (get-in result [:stages 0 :aggregation]))
+          field-ref (nth agg 2)]
+      (testing "stays single-stage (no explicit joins required)"
+        (is (= 1 (count (:stages result)))))
+      (is (= :sum (first agg)))
+      (is (= :field (first field-ref)))
+      (is (= 53 (nth field-ref 2)))
+      (is (= 3 (get-in field-ref [1 :source-field]))))))
+
 ;;; -------------------------------------------------- Options --------------------------------------------------
 
 (deftest ^:parallel compile-with-limit-test

--- a/test/metabase/lib_metric/ast/compile_test.cljc
+++ b/test/metabase/lib_metric/ast/compile_test.cljc
@@ -1,7 +1,10 @@
 (ns metabase.lib-metric.ast.compile-test
   (:require
+   #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))
    [clojure.test :refer [deftest is testing]]
    [metabase.lib-metric.ast.compile :as ast.compile]))
+
+#?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
 
 ;;; -------------------------------------------------- Test Data --------------------------------------------------
 
@@ -448,16 +451,10 @@
   (testing "aggregation over an FK column produces :source-field on the compiled field ref (implicit join)"
     (let [ast (assoc-in sample-ast [:source :aggregation]
                         {:node/type :aggregation/sum
-                         :column    {:node/type :ast/column :id 53 :source-field 3}})
-          result (ast.compile/compile-to-mbql ast)
-          agg    (first (get-in result [:stages 0 :aggregation]))
-          field-ref (nth agg 2)]
-      (testing "stays single-stage (no explicit joins required)"
-        (is (= 1 (count (:stages result)))))
-      (is (= :sum (first agg)))
-      (is (= :field (first field-ref)))
-      (is (= 53 (nth field-ref 2)))
-      (is (= 3 (get-in field-ref [1 :source-field]))))))
+                         :column    {:node/type :ast/column :id 53 :source-field 3}})]
+      ;; a single stage in the pattern also verifies we stay single-stage (no explicit joins required)
+      (is (=? {:stages [{:aggregation [[:sum {} [:field {:source-field 3} 53]]]}]}
+              (ast.compile/compile-to-mbql ast))))))
 
 ;;; -------------------------------------------------- Options --------------------------------------------------
 


### PR DESCRIPTION
PR #71741 fixed metric explorer for metrics with explicit joins but metrics using implicit (FK) joins still failed because mbql-aggregation->node* dropped the field-ref opts map, losing :source-field. The compiled MBQL then referenced the target column with no FK hint, so the QP could not materialize the implicit LEFT JOIN and produced "Column PRODUCTS.PRICE not found".

Preserve :source-field on the column node in both :count and :column-agg aggregation builders, mirroring the existing pattern in dimension-mapping-node. The QP's resolve-implicit-joins middleware handles the rest — no two-stage compilation needed.