### PR TITLE
Version slack secret and expire linked accounts on rotation

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -2046,6 +2046,7 @@
               permissions
               premium-features
               request
+              server
               settings
               system
               util}

--- a/src/metabase/auth_identity/models/auth_identity.clj
+++ b/src/metabase/auth_identity/models/auth_identity.clj
@@ -6,6 +6,7 @@
    [metabase.auth-identity.provider :as provider]
    [metabase.models.interface :as mi]
    [metabase.models.serialization :as serdes]
+   [metabase.server.settings :as server.settings]
    [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.password :as u.password]
@@ -76,7 +77,9 @@
 (t2/define-before-insert :model/AuthIdentity
   [{:keys [provider] :as auth-identity}]
   (provider/validate (provider/provider-string->keyword provider) auth-identity)
-  auth-identity)
+  (cond-> auth-identity
+    (= provider "slack-connect")
+    (update :metadata assoc :signing_secret_version (server.settings/slack-connect-signing-secret-version))))
 
 (t2/define-before-update :model/AuthIdentity
   [{:keys [provider] :as auth-identity}]

--- a/src/metabase/auth_identity/models/auth_identity.clj
+++ b/src/metabase/auth_identity/models/auth_identity.clj
@@ -6,7 +6,6 @@
    [metabase.auth-identity.provider :as provider]
    [metabase.models.interface :as mi]
    [metabase.models.serialization :as serdes]
-   [metabase.server.settings :as server.settings]
    [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.password :as u.password]
@@ -77,9 +76,7 @@
 (t2/define-before-insert :model/AuthIdentity
   [{:keys [provider] :as auth-identity}]
   (provider/validate (provider/provider-string->keyword provider) auth-identity)
-  (cond-> auth-identity
-    (= provider "slack-connect")
-    (update :metadata assoc :signing_secret_version (server.settings/slack-connect-signing-secret-version))))
+  auth-identity)
 
 (t2/define-before-update :model/AuthIdentity
   [{:keys [provider] :as auth-identity}]

--- a/src/metabase/server/settings.clj
+++ b/src/metabase/server/settings.clj
@@ -105,3 +105,10 @@ x.com")
   "Get the unobfuscated value of [[metabot-slack-signing-secret]]."
   []
   (setting/get-value-of-type :string :metabot-slack-signing-secret))
+
+(defsetting slack-connect-signing-secret-version
+  (deferred-tru "Monotonically increasing version number for the Slack signing secret. Incremented each time the signing secret is rotated. Slack-connect auth identities are stamped with this version and only valid when it matches the current value.")
+  :type       :integer
+  :visibility :internal
+  :default    0
+  :export?    false)

--- a/src/metabase/server/settings.clj
+++ b/src/metabase/server/settings.clj
@@ -107,7 +107,7 @@ x.com")
   (setting/get-value-of-type :string :metabot-slack-signing-secret))
 
 (defsetting slack-connect-signing-secret-version
-  (deferred-tru "Monotonically increasing version number for the Slack signing secret. Incremented each time the signing secret is rotated. Slack-connect auth identities are stamped with this version and only valid when it matches the current value.")
+  (deferred-tru "Monotonically increasing version number for the Slack signing secret. Incremented each time the signing secret is rotated. Slack-connect auth identities are stamped with this version and only valid when it matches the current value. Legacy identities without a version are treated as version 0 for backwards compatibility.")
   :type       :integer
   :visibility :internal
   :default    0

--- a/src/metabase/slackbot/api.clj
+++ b/src/metabase/slackbot/api.clj
@@ -11,6 +11,7 @@
    [metabase.metabot.feedback :as metabot.feedback]
    [metabase.permissions.core :as perms]
    [metabase.request.core :as request]
+   [metabase.server.settings :as server.settings]
    [metabase.settings.core :as setting]
    [metabase.slackbot.client :as slackbot.client]
    [metabase.slackbot.config :as slackbot.config]
@@ -72,15 +73,18 @@
 ;; ------------------------- AUTHENTICATION ------------------------------
 
 (defn- slack-id->user-id
-  "Look up a Metabase user ID from Slack user ID."
+  "Look up a Metabase user ID from Slack user ID. Only returns a match if the identity was created under the current
+  signing secret version, so that rotating the secret automatically invalidates existing identity links."
   [slack-user-id]
-  (t2/select-one-fn :user_id
-                    :model/AuthIdentity
-                    :provider "slack-connect"
-                    :provider_id slack-user-id
-                    {:join  [[:core_user :user] [:= :user.id :auth_identity.user_id]]
-                     :where [:= :user.is_active true]
-                     :order-by [[:created_at :desc]]}))
+  (let [identity (t2/select-one [:model/AuthIdentity :user_id :metadata]
+                                :provider "slack-connect"
+                                :provider_id slack-user-id
+                                {:join     [[:core_user :user] [:= :user.id :auth_identity.user_id]]
+                                 :where    [:= :user.is_active true]
+                                 :order-by [[:created_at :desc]]})]
+    (when (= (:signing_secret_version (:metadata identity))
+             (server.settings/slack-connect-signing-secret-version))
+      (:user_id identity))))
 
 (defn- slack-user-authorize-link
   "Link to page where user can initiate SSO auth flow to authorize slackbot"
@@ -457,6 +461,9 @@
                         :slack-connect-client-secret  slack-connect-client-secret
                         :metabot-slack-signing-secret metabot-slack-signing-secret
                         :slack-connect-enabled        (boolean all-set?)})
+    (when all-set?
+      (server.settings/slack-connect-signing-secret-version!
+       (inc (server.settings/slack-connect-signing-secret-version))))
     {:ok true}))
 
 ;; ------------------------- FEEDBACK BUTTONS ------------------------------

--- a/src/metabase/slackbot/api.clj
+++ b/src/metabase/slackbot/api.clj
@@ -72,9 +72,18 @@
 
 ;; ------------------------- AUTHENTICATION ------------------------------
 
+(defn- current-signing-secret-version
+  []
+  (or (server.settings/slack-connect-signing-secret-version) 0))
+
+(defn- auth-identity-signing-secret-version
+  [identity]
+  (or (get-in identity [:metadata :signing_secret_version]) 0))
+
 (defn- slack-id->user-id
   "Look up a Metabase user ID from Slack user ID. Only returns a match if the identity was created under the current
-  signing secret version, so that rotating the secret automatically invalidates existing identity links."
+  signing secret version, so that rotating the secret automatically invalidates existing identity links. Legacy
+  identities without an explicit version are treated as version 0."
   [slack-user-id]
   (let [identity (t2/select-one [:model/AuthIdentity :user_id :metadata]
                                 :provider "slack-connect"
@@ -82,8 +91,8 @@
                                 {:join     [[:core_user :user] [:= :user.id :auth_identity.user_id]]
                                  :where    [:= :user.is_active true]
                                  :order-by [[:created_at :desc]]})]
-    (when (= (:signing_secret_version (:metadata identity))
-             (server.settings/slack-connect-signing-secret-version))
+    (when (= (auth-identity-signing-secret-version identity)
+             (current-signing-secret-version))
       (:user_id identity))))
 
 (defn- slack-user-authorize-link
@@ -452,7 +461,10 @@
                         metabot-slack-signing-secret)
         all-unset? (and (nil? slack-connect-client-id)
                         (nil? slack-connect-client-secret)
-                        (nil? metabot-slack-signing-secret))]
+                        (nil? metabot-slack-signing-secret))
+        signing-secret-changed? (and all-set?
+                                     (not= metabot-slack-signing-secret
+                                           (server.settings/unobfuscated-metabot-slack-signing-secret)))]
     ;; all values must be set together or unset together
     (when-not (or all-set? all-unset?)
       (throw (ex-info (tru "Must provide client id, client secret and signing secret together.")
@@ -461,9 +473,9 @@
                         :slack-connect-client-secret  slack-connect-client-secret
                         :metabot-slack-signing-secret metabot-slack-signing-secret
                         :slack-connect-enabled        (boolean all-set?)})
-    (when all-set?
+    (when signing-secret-changed?
       (server.settings/slack-connect-signing-secret-version!
-       (inc (server.settings/slack-connect-signing-secret-version))))
+       (inc (current-signing-secret-version))))
     {:ok true}))
 
 ;; ------------------------- FEEDBACK BUTTONS ------------------------------

--- a/src/metabase/sso/providers/slack_connect.clj
+++ b/src/metabase/sso/providers/slack_connect.clj
@@ -3,6 +3,7 @@
    and adds Slack-specific configuration and claim extraction."
   (:require
    [metabase.auth-identity.core :as auth-identity]
+   [metabase.server.settings :as server.settings]
    [metabase.sso.settings :as sso-settings]
    [metabase.util.i18n :refer [tru]]
    [methodical.core :as methodical]
@@ -172,6 +173,12 @@
 
 (methodical/defmethod auth-identity/login! :after :provider/slack-connect
   [_provider result]
+  (when (:success? result)
+    (when-let [user-id (or (some-> result :user :id)
+                           (some-> result :authenticated-user deref :id))]
+      (t2/update! :model/AuthIdentity
+                  {:user_id user-id :provider provider-name}
+                  {:metadata {:signing_secret_version (server.settings/slack-connect-signing-secret-version)}})))
   (if (= sso-settings/slack-connect-auth-mode-link-only (sso-settings/slack-connect-authentication-mode))
     (dissoc result :user)
     result))

--- a/src/metabase/sso/providers/slack_connect.clj
+++ b/src/metabase/sso/providers/slack_connect.clj
@@ -151,8 +151,8 @@
                           :user_id user-id
                           :provider provider-name)
       (t2/insert! :model/AuthIdentity
-                  {:user_id user-id
-                   :provider provider-name
+                  {:user_id     user-id
+                   :provider    provider-name
                    :provider_id provider-id}))))
 
 (methodical/defmethod auth-identity/login! :provider/slack-connect

--- a/test/metabase/slackbot/api_test.clj
+++ b/test/metabase/slackbot/api_test.clj
@@ -423,72 +423,74 @@
 (deftest slack-id->user-id-test
   (testing "slack-id->user-id only returns active users with sso_source 'slack'"
     (let [slack-id "U12345SLACK"]
-      (mt/with-temp [:model/User {active-slack-user-id :id}   {:email      "active-slack@example.com"
-                                                               :is_active  true
-                                                               :sso_source "slack"}
-                     :model/User {inactive-slack-user-id :id} {:email      "inactive-slack@example.com"
-                                                               :is_active  false
-                                                               :sso_source "slack"}
-                     :model/User {active-google-user-id :id}  {:email      "active-google@example.com"
-                                                               :is_active  true
-                                                               :sso_source "google"}]
-        (testing "returns user ID for active user with sso_source 'slack'"
-          (mt/with-temp [:model/AuthIdentity _ {:user_id     active-slack-user-id
-                                                :provider    "slack-connect"
-                                                :provider_id slack-id}]
-            (is (= active-slack-user-id
-                   (#'slackbot/slack-id->user-id slack-id)))))
+      (mt/with-temporary-setting-values [server.settings/slack-connect-signing-secret-version 0]
+        (mt/with-temp [:model/User {active-slack-user-id :id}   {:email      "active-slack@example.com"
+                                                                 :is_active  true
+                                                                 :sso_source "slack"}
+                       :model/User {inactive-slack-user-id :id} {:email      "inactive-slack@example.com"
+                                                                 :is_active  false
+                                                                 :sso_source "slack"}
+                       :model/User {active-google-user-id :id}  {:email      "active-google@example.com"
+                                                                 :is_active  true
+                                                                 :sso_source "google"}]
+          (testing "returns user ID for active user with sso_source 'slack'"
+            (mt/with-temp [:model/AuthIdentity _ {:user_id     active-slack-user-id
+                                                  :provider    "slack-connect"
+                                                  :provider_id slack-id
+                                                  :metadata    {:signing_secret_version 0}}]
+              (is (= active-slack-user-id
+                     (#'slackbot/slack-id->user-id slack-id)))))
 
-        (testing "returns user ID for active user with sso_source 'google'"
-          (mt/with-temp [:model/AuthIdentity _ {:user_id     active-google-user-id
-                                                :provider    "slack-connect"
-                                                :provider_id slack-id}]
-            (is (= active-google-user-id
-                   (#'slackbot/slack-id->user-id slack-id)))))
+          (testing "returns user ID for active user with sso_source 'google'"
+            (mt/with-temp [:model/AuthIdentity _ {:user_id     active-google-user-id
+                                                  :provider    "slack-connect"
+                                                  :provider_id slack-id
+                                                  :metadata    {:signing_secret_version 0}}]
+              (is (= active-google-user-id
+                     (#'slackbot/slack-id->user-id slack-id)))))
 
-        (testing "returns nil for inactive user with sso_source 'slack'"
-          (mt/with-temp [:model/AuthIdentity _ {:user_id     inactive-slack-user-id
-                                                :provider    "slack-connect"
-                                                :provider_id slack-id}]
-            (is (nil? (#'slackbot/slack-id->user-id slack-id)))))
+          (testing "returns nil for inactive user with sso_source 'slack'"
+            (mt/with-temp [:model/AuthIdentity _ {:user_id     inactive-slack-user-id
+                                                  :provider    "slack-connect"
+                                                  :provider_id slack-id
+                                                  :metadata    {:signing_secret_version 0}}]
+              (is (nil? (#'slackbot/slack-id->user-id slack-id)))))
 
-        (testing "returns nil for active user with different provider"
-          (mt/with-temp [:model/AuthIdentity _ {:user_id     active-google-user-id
-                                                :provider    "google"
-                                                :provider_id slack-id}]
-            (is (nil? (#'slackbot/slack-id->user-id slack-id)))))
+          (testing "returns nil for active user with different provider"
+            (mt/with-temp [:model/AuthIdentity _ {:user_id     active-google-user-id
+                                                  :provider    "google"
+                                                  :provider_id slack-id}]
+              (is (nil? (#'slackbot/slack-id->user-id slack-id)))))
 
-        (testing "returns nil when no AuthIdentity exists"
-          (is (nil? (#'slackbot/slack-id->user-id slack-id))))))))
+          (testing "returns nil when no AuthIdentity exists"
+            (is (nil? (#'slackbot/slack-id->user-id slack-id)))))))))
 
 (deftest slack-id->user-id-signing-secret-version-test
   (testing "slack-id->user-id respects signing secret version"
     (let [slack-id "U12345VERSION"]
       (mt/with-temp [:model/User {user-id :id} {:email     "version-test@example.com"
                                                 :is_active true}]
-        (testing "identity created under current version is accepted"
+        (testing "identity with current version is accepted"
           (mt/with-temporary-setting-values [server.settings/slack-connect-signing-secret-version 1]
             (mt/with-temp [:model/AuthIdentity _ {:user_id     user-id
                                                   :provider    "slack-connect"
-                                                  :provider_id slack-id}]
+                                                  :provider_id slack-id
+                                                  :metadata    {:signing_secret_version 1}}]
               (is (= user-id (#'slackbot/slack-id->user-id slack-id))))))
 
-        (testing "identity created under old version is rejected after rotation"
-          (mt/with-temporary-setting-values [server.settings/slack-connect-signing-secret-version 1]
+        (testing "identity with old version is rejected after rotation"
+          (mt/with-temporary-setting-values [server.settings/slack-connect-signing-secret-version 2]
             (mt/with-temp [:model/AuthIdentity _ {:user_id     user-id
                                                   :provider    "slack-connect"
-                                                  :provider_id slack-id}]
-              ;; simulate signing secret rotation
-              (server.settings/slack-connect-signing-secret-version! 2)
+                                                  :provider_id slack-id
+                                                  :metadata    {:signing_secret_version 1}}]
               (is (nil? (#'slackbot/slack-id->user-id slack-id))))))
 
         (testing "identity with no version (legacy) is rejected"
           (mt/with-temporary-setting-values [server.settings/slack-connect-signing-secret-version 1]
-            (mt/with-temp [:model/AuthIdentity {identity-id :id} {:user_id     user-id
-                                                                  :provider    "slack-connect"
-                                                                  :provider_id slack-id}]
-              ;; clear the version that before-insert stamped, to simulate a legacy row
-              (t2/update! :model/AuthIdentity identity-id {:metadata nil})
+            (mt/with-temp [:model/AuthIdentity _ {:user_id     user-id
+                                                  :provider    "slack-connect"
+                                                  :provider_id slack-id}]
               (is (nil? (#'slackbot/slack-id->user-id slack-id))))))))))
 
 (deftest channel-message-without-mention-no-auth-test

--- a/test/metabase/slackbot/api_test.clj
+++ b/test/metabase/slackbot/api_test.clj
@@ -5,6 +5,7 @@
    [metabase.analytics.prometheus-test :as prometheus-test]
    [metabase.metabot.agent.core :as agent]
    [metabase.metabot.feedback :as metabot.feedback]
+   [metabase.server.settings :as server.settings]
    [metabase.slackbot.api :as slackbot]
    [metabase.slackbot.client :as slackbot.client]
    [metabase.slackbot.persistence :as slackbot.persistence]
@@ -459,6 +460,36 @@
 
         (testing "returns nil when no AuthIdentity exists"
           (is (nil? (#'slackbot/slack-id->user-id slack-id))))))))
+
+(deftest slack-id->user-id-signing-secret-version-test
+  (testing "slack-id->user-id respects signing secret version"
+    (let [slack-id "U12345VERSION"]
+      (mt/with-temp [:model/User {user-id :id} {:email     "version-test@example.com"
+                                                :is_active true}]
+        (testing "identity created under current version is accepted"
+          (mt/with-temporary-setting-values [server.settings/slack-connect-signing-secret-version 1]
+            (mt/with-temp [:model/AuthIdentity _ {:user_id     user-id
+                                                  :provider    "slack-connect"
+                                                  :provider_id slack-id}]
+              (is (= user-id (#'slackbot/slack-id->user-id slack-id))))))
+
+        (testing "identity created under old version is rejected after rotation"
+          (mt/with-temporary-setting-values [server.settings/slack-connect-signing-secret-version 1]
+            (mt/with-temp [:model/AuthIdentity _ {:user_id     user-id
+                                                  :provider    "slack-connect"
+                                                  :provider_id slack-id}]
+              ;; simulate signing secret rotation
+              (server.settings/slack-connect-signing-secret-version! 2)
+              (is (nil? (#'slackbot/slack-id->user-id slack-id))))))
+
+        (testing "identity with no version (legacy) is rejected"
+          (mt/with-temporary-setting-values [server.settings/slack-connect-signing-secret-version 1]
+            (mt/with-temp [:model/AuthIdentity {identity-id :id} {:user_id     user-id
+                                                                  :provider    "slack-connect"
+                                                                  :provider_id slack-id}]
+              ;; clear the version that before-insert stamped, to simulate a legacy row
+              (t2/update! :model/AuthIdentity identity-id {:metadata nil})
+              (is (nil? (#'slackbot/slack-id->user-id slack-id))))))))))
 
 (deftest channel-message-without-mention-no-auth-test
   (testing "POST /events with channel message (no @mention) from unlinked user should NOT send auth message"

--- a/test/metabase/slackbot/api_test.clj
+++ b/test/metabase/slackbot/api_test.clj
@@ -486,7 +486,14 @@
                                                   :metadata    {:signing_secret_version 1}}]
               (is (nil? (#'slackbot/slack-id->user-id slack-id))))))
 
-        (testing "identity with no version (legacy) is rejected"
+        (testing "legacy identity with no version is accepted before any rotation"
+          (mt/with-temporary-setting-values [server.settings/slack-connect-signing-secret-version 0]
+            (mt/with-temp [:model/AuthIdentity _ {:user_id     user-id
+                                                  :provider    "slack-connect"
+                                                  :provider_id slack-id}]
+              (is (= user-id (#'slackbot/slack-id->user-id slack-id))))))
+
+        (testing "legacy identity with no version is rejected after rotation"
           (mt/with-temporary-setting-values [server.settings/slack-connect-signing-secret-version 1]
             (mt/with-temp [:model/AuthIdentity _ {:user_id     user-id
                                                   :provider    "slack-connect"
@@ -708,6 +715,35 @@
     (testing "non-admin returns 403"
       (is (= "You don't have permissions to do that."
              (mt/user-http-request :rasta :put 403 "metabot/slack/settings" creds))))))
+
+(deftest put-slack-settings-signing-secret-version-test
+  (testing "resaving the same signing secret does not increment the version"
+    (mt/with-temporary-setting-values [sso-settings/slack-connect-enabled true
+                                       server.settings/slack-connect-signing-secret-version 7]
+      (mt/with-temporary-raw-setting-values [slack-connect-client-id "old-id"
+                                             slack-connect-client-secret "old-secret"
+                                             metabot-slack-signing-secret "same-signing-secret"]
+        (is (= {:ok true}
+               (mt/user-http-request :crowberto :put 200 "metabot/slack/settings"
+                                     {:slack-connect-client-id "new-id"
+                                      :slack-connect-client-secret "new-secret"
+                                      :metabot-slack-signing-secret "same-signing-secret"})))
+        (is (= 7
+               (server.settings/slack-connect-signing-secret-version))))))
+
+  (testing "changing the signing secret increments the version"
+    (mt/with-temporary-setting-values [sso-settings/slack-connect-enabled true
+                                       server.settings/slack-connect-signing-secret-version 7]
+      (mt/with-temporary-raw-setting-values [slack-connect-client-id "old-id"
+                                             slack-connect-client-secret "old-secret"
+                                             metabot-slack-signing-secret "old-signing-secret"]
+        (is (= {:ok true}
+               (mt/user-http-request :crowberto :put 200 "metabot/slack/settings"
+                                     {:slack-connect-client-id "new-id"
+                                      :slack-connect-client-secret "new-secret"
+                                      :metabot-slack-signing-secret "new-signing-secret"})))
+        (is (= 8
+               (server.settings/slack-connect-signing-secret-version)))))))
 
 (deftest feedback-modal-view-test
   (testing "positive feedback modal has no issue type dropdown"


### PR DESCRIPTION
Versions the slack secret so that we can auto-expire linked accounts when the secret is rotated. It's a soft-deletion so that we have a record of linked accounts for audit purposes.

https://linear.app/metabase/issue/BOT-1314/slack-key-rotation-should-invalidate-previous-account-links