### PR TITLE
Apply temporal bucketing on expressions

### DIFF
--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -708,28 +708,35 @@
            (isa? (or effective-type base-type)
                  :type/Text))))
 
+(defn apply-temporal-bucketing
+  "Apply temporal bucketing for the `:temporal-unit` in the options of a `:field` clause; return a new HoneySQL form that
+  buckets `honeysql-form` appropriately."
+  [driver {:keys [temporal-unit]} honeysql-form]
+  (date driver temporal-unit honeysql-form))
+
 (defmethod ->honeysql [:sql :expression]
   [driver [_ expression-name opts :as _clause]]
   (let [source-table (get opts driver-api/qp.add.source-table)
         source-alias (get opts driver-api/qp.add.source-alias)
         expression-definition (driver-api/expression-with-name *inner-query* expression-name)]
-    (->honeysql driver (cond (= source-table driver-api/qp.add.source)
-                             (apply h2x/identifier :field source-query-alias source-alias)
+    (cond->> (->honeysql driver (cond (= source-table driver-api/qp.add.source)
+                                      (apply h2x/identifier :field source-query-alias source-alias)
 
-                             (literal-text-value? expression-definition)
-                             [::expression-literal-text-value expression-definition]
+                                      (literal-text-value? expression-definition)
+                                      [::expression-literal-text-value expression-definition]
 
-                             ;; Handle raw string literals (not wrapped in :value) - needed for
-                             ;; expression definitions that are just string literals, e.g. from
-                             ;; custom columns like `"fixed literal string"`. Without this,
-                             ;; the string becomes a parameter placeholder without type info,
-                             ;; which some databases (like H2) can't handle.
-                             (string? expression-definition)
-                             [::expression-literal-text-value
-                              [:value expression-definition {:base_type :type/Text}]]
+                                      ;; Handle raw string literals (not wrapped in :value) - needed for
+                                      ;; expression definitions that are just string literals, e.g. from
+                                      ;; custom columns like `"fixed literal string"`. Without this,
+                                      ;; the string becomes a parameter placeholder without type info,
+                                      ;; which some databases (like H2) can't handle.
+                                      (string? expression-definition)
+                                      [::expression-literal-text-value
+                                       [:value expression-definition {:base_type :type/Text}]]
 
-                             :else
-                             expression-definition))))
+                                      :else
+                                      expression-definition))
+      (:temporal-unit opts) (apply-temporal-bucketing driver opts))))
 
 (defmethod ->honeysql [:sql :now]
   [driver _clause]
@@ -828,12 +835,6 @@
 (defmethod ->honeysql [:sql ::h2x/identifier]
   [_driver identifier]
   identifier)
-
-(defn apply-temporal-bucketing
-  "Apply temporal bucketing for the `:temporal-unit` in the options of a `:field` clause; return a new HoneySQL form that
-  buckets `honeysql-form` appropriately."
-  [driver {:keys [temporal-unit]} honeysql-form]
-  (date driver temporal-unit honeysql-form))
 
 (defn apply-binning
   "Apply `:binning` options from a `:field` clause; return a new HoneySQL form that bins `honeysql-form`

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -719,23 +719,24 @@
   (let [source-table (get opts driver-api/qp.add.source-table)
         source-alias (get opts driver-api/qp.add.source-alias)
         expression-definition (driver-api/expression-with-name *inner-query* expression-name)]
-    (cond->> (->honeysql driver (cond (= source-table driver-api/qp.add.source)
-                                      (apply h2x/identifier :field source-query-alias source-alias)
+    (cond->>
+     (->honeysql driver (cond (= source-table driver-api/qp.add.source)
+                              (apply h2x/identifier :field source-query-alias source-alias)
 
-                                      (literal-text-value? expression-definition)
-                                      [::expression-literal-text-value expression-definition]
+                              (literal-text-value? expression-definition)
+                              [::expression-literal-text-value expression-definition]
 
-                                      ;; Handle raw string literals (not wrapped in :value) - needed for
-                                      ;; expression definitions that are just string literals, e.g. from
-                                      ;; custom columns like `"fixed literal string"`. Without this,
-                                      ;; the string becomes a parameter placeholder without type info,
-                                      ;; which some databases (like H2) can't handle.
-                                      (string? expression-definition)
-                                      [::expression-literal-text-value
-                                       [:value expression-definition {:base_type :type/Text}]]
+                              ;; Handle raw string literals (not wrapped in :value) - needed for
+                              ;; expression definitions that are just string literals, e.g. from
+                              ;; custom columns like `"fixed literal string"`. Without this,
+                              ;; the string becomes a parameter placeholder without type info,
+                              ;; which some databases (like H2) can't handle.
+                              (string? expression-definition)
+                              [::expression-literal-text-value
+                               [:value expression-definition {:base_type :type/Text}]]
 
-                                      :else
-                                      expression-definition))
+                              :else
+                              expression-definition))
       (:temporal-unit opts) (apply-temporal-bucketing driver opts))))
 
 (defmethod ->honeysql [:sql :now]

--- a/test/metabase/query_processor/expressions_test.clj
+++ b/test/metabase/query_processor/expressions_test.clj
@@ -1189,7 +1189,7 @@
                     (qp/process-query query))))))))))
 
 (deftest ^:parallel expression-as-bucketed-join-key-test
-  (mt/test-drivers (mt/normal-drivers-with-feature :expressions :left-join)
+  (mt/test-drivers (mt/normal-driver-select {:+parent :sql :+features [:expressions :left-join]})
     (testing "can join a custom expression that uses temporal bucketing (#59614)"
       (let [mp                (mt/metadata-provider)
             orders-table      (lib.metadata/table mp (mt/id :orders))

--- a/test/metabase/query_processor/expressions_test.clj
+++ b/test/metabase/query_processor/expressions_test.clj
@@ -1191,35 +1191,27 @@
 (deftest ^:parallel expression-as-bucketed-join-key-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions :left-join)
     (testing "can join a custom expression that uses temporal bucketing (#59614)"
-      (let [mp               (mt/metadata-provider)
-            orders-table     (lib.metadata/table mp (mt/id :orders))
-            products-table   (lib.metadata/table mp (mt/id :products))
-            orders-id        (lib.metadata/field mp (mt/id :orders :id))
-            orders-quantity  (lib.metadata/field mp (mt/id :orders :quantity))
-            orders-created   (lib.metadata/field mp (mt/id :orders :created_at))
-            products-created (lib.metadata/field mp (mt/id :products :created_at))
-            ;; Build an expression that uses CASE to pick between two timestamp
-            ;; values. Both branches return orders.created_at, but wrapping it in
-            ;; a :case forces the compiler to go through the [:sql :expression]
-            ;; path rather than inlining a plain :field ref.
-            q                (-> (lib/query mp orders-table)
-                                 (lib/expression "effective_date"
-                                                 (lib/case
-                                                  [[(lib/> orders-quantity 0) orders-created]]
-                                                   orders-created)))
-            ;; Reference the expression with :day bucketing on the LHS of the
-            ;; join, and bucket products.created_at to :day on the RHS. Without
-            ;; the fix in [:sql :expression], the LHS stays as a raw timestamp
-            ;; CASE and the join never matches.
-            effective-ref    (-> (lib/expression-ref q "effective_date")
-                                 (lib/with-temporal-bucket :day))
-            products-day     (lib/with-temporal-bucket products-created :day)
-            query            (-> q
-                                 (lib/join (lib/join-clause products-table
-                                                            [(lib/= effective-ref products-day)]))
-                                 (lib/order-by orders-id :asc)
-                                 (lib/limit 3))]
-        (is (= [[1 1 14 37.65 2.07 39.72 nil "2019-02-11T21:40:27.892Z" 2 "2019-02-11T21:40:27.892Z" nil nil nil nil nil nil nil nil]
-                [2 1 123 110.93 6.1 117.03 nil "2018-05-15T08:04:04.58Z" 3 "2018-05-15T08:04:04.58Z" nil nil nil nil nil nil nil nil]
-                [3 1 105 52.72 2.9 49.2 6.42 "2019-12-06T22:22:48.544Z" 2 "2019-12-06T22:22:48.544Z" nil nil nil nil nil nil nil nil]]
+      (let [mp                (mt/metadata-provider)
+            orders-table      (lib.metadata/table mp (mt/id :orders))
+            products-table    (lib.metadata/table mp (mt/id :products))
+            orders-id         (lib.metadata/field mp (mt/id :orders :id))
+            orders-created    (lib.metadata/field mp (mt/id :orders :created_at))
+            products-id       (lib.metadata/field mp (mt/id :products :id))
+            products-created  (lib.metadata/field mp (mt/id :products :created_at))
+            q                 (-> (lib/query mp orders-table)
+                                  (lib/expression "X" (lib/datetime-add orders-created 1 :day)))
+            x-month             (-> (lib/expression-ref q "X")
+                                    (lib/with-temporal-bucket :month))
+            products-month    (lib/with-temporal-bucket products-created :month)
+            query             (-> q
+                                  (lib/join (-> (lib/join-clause products-table
+                                                                 [(lib/= x-month products-month)])
+                                                (lib/with-join-fields [products-id products-created])))
+                                  (lib/with-fields [orders-id (lib/expression-ref q "X")])
+                                  (lib/order-by orders-id :asc)
+                                  (lib/order-by products-id :asc)
+                                  (lib/limit 3))]
+        (is (= [[1 "2019-02-12T21:40:27.892Z" 9 "2019-02-07T08:26:25.647Z"]
+                [1 "2019-02-12T21:40:27.892Z" 137 "2019-02-16T22:36:43.143Z"]
+                [1 "2019-02-12T21:40:27.892Z" 188 "2019-02-07T19:03:43.752Z"]]
                (mt/rows (qp/process-query query))))))))

--- a/test/metabase/query_processor/expressions_test.clj
+++ b/test/metabase/query_processor/expressions_test.clj
@@ -1211,7 +1211,9 @@
                                   (lib/order-by orders-id :asc)
                                   (lib/order-by products-id :asc)
                                   (lib/limit 3))]
-        (is (= [[1 "2019-02-12T21:40:27.892Z" 9 "2019-02-07T08:26:25.647Z"]
-                [1 "2019-02-12T21:40:27.892Z" 137 "2019-02-16T22:36:43.143Z"]
-                [1 "2019-02-12T21:40:27.892Z" 188 "2019-02-07T19:03:43.752Z"]]
-               (mt/formatted-rows [int identity int identity] (qp/process-query query))))))))
+        (is (= [[1 "2019-02-12T21:40:27Z" 9 "2019-02-07T08:26:25Z"]
+                [1 "2019-02-12T21:40:27Z" 137 "2019-02-16T22:36:43Z"]
+                [1 "2019-02-12T21:40:27Z" 188 "2019-02-07T19:03:43Z"]]
+               (mt/formatted-rows
+                [int u.date/temporal-str->iso8601-str int u.date/temporal-str->iso8601-str]
+                (qp/process-query query))))))))

--- a/test/metabase/query_processor/expressions_test.clj
+++ b/test/metabase/query_processor/expressions_test.clj
@@ -1214,4 +1214,4 @@
         (is (= [[1 "2019-02-12T21:40:27.892Z" 9 "2019-02-07T08:26:25.647Z"]
                 [1 "2019-02-12T21:40:27.892Z" 137 "2019-02-16T22:36:43.143Z"]
                 [1 "2019-02-12T21:40:27.892Z" 188 "2019-02-07T19:03:43.752Z"]]
-               (mt/rows (qp/process-query query))))))))
+               (mt/formatted-rows [int identity int identity] (qp/process-query query))))))))

--- a/test/metabase/query_processor/expressions_test.clj
+++ b/test/metabase/query_processor/expressions_test.clj
@@ -5,6 +5,8 @@
    [java-time.api :as t]
    [medley.core :as m]
    [metabase.driver :as driver]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
    [metabase.query-processor.test :as qp]
    [metabase.test :as mt]
    [metabase.util :as u]
@@ -1185,3 +1187,39 @@
                    (mt/formatted-rows
                     [u.date/temporal-str->iso8601-str int int]
                     (qp/process-query query))))))))))
+
+(deftest ^:parallel expression-as-bucketed-join-key-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :expressions :left-join)
+    (testing "can join a custom expression that uses temporal bucketing (#59614)"
+      (let [mp               (mt/metadata-provider)
+            orders-table     (lib.metadata/table mp (mt/id :orders))
+            products-table   (lib.metadata/table mp (mt/id :products))
+            orders-id        (lib.metadata/field mp (mt/id :orders :id))
+            orders-quantity  (lib.metadata/field mp (mt/id :orders :quantity))
+            orders-created   (lib.metadata/field mp (mt/id :orders :created_at))
+            products-created (lib.metadata/field mp (mt/id :products :created_at))
+            ;; Build an expression that uses CASE to pick between two timestamp
+            ;; values. Both branches return orders.created_at, but wrapping it in
+            ;; a :case forces the compiler to go through the [:sql :expression]
+            ;; path rather than inlining a plain :field ref.
+            q                (-> (lib/query mp orders-table)
+                                 (lib/expression "effective_date"
+                                                 (lib/case
+                                                  [[(lib/> orders-quantity 0) orders-created]]
+                                                   orders-created)))
+            ;; Reference the expression with :day bucketing on the LHS of the
+            ;; join, and bucket products.created_at to :day on the RHS. Without
+            ;; the fix in [:sql :expression], the LHS stays as a raw timestamp
+            ;; CASE and the join never matches.
+            effective-ref    (-> (lib/expression-ref q "effective_date")
+                                 (lib/with-temporal-bucket :day))
+            products-day     (lib/with-temporal-bucket products-created :day)
+            query            (-> q
+                                 (lib/join (lib/join-clause products-table
+                                                            [(lib/= effective-ref products-day)]))
+                                 (lib/order-by orders-id :asc)
+                                 (lib/limit 3))]
+        (is (= [[1 1 14 37.65 2.07 39.72 nil "2019-02-11T21:40:27.892Z" 2 "2019-02-11T21:40:27.892Z" nil nil nil nil nil nil nil nil]
+                [2 1 123 110.93 6.1 117.03 nil "2018-05-15T08:04:04.58Z" 3 "2018-05-15T08:04:04.58Z" nil nil nil nil nil nil nil nil]
+                [3 1 105 52.72 2.9 49.2 6.42 "2019-12-06T22:22:48.544Z" 2 "2019-12-06T22:22:48.544Z" nil nil nil nil nil nil nil nil]]
+               (mt/rows (qp/process-query query))))))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/59614

### Description

Applies temporal bucketing on an expression that has a temporal unit. Using @ranquild's suggestion in original issue. 

### How to verify

1. Create a custom expression that produces a date type
2. Join this custom expression to a date in another table. Bucket both of them by month. 
3. Before the fix none of the joined table values are present. After the fix the values are present.

### Demo

[loom](https://www.loom.com/share/de0a7e70ae424f66ac79c85c8da3564f)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
