### PR TITLE
fix: allow use of legacy metabase AI

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1105,7 +1105,8 @@
   {:team "Metabot"
    :api  #{metabase.llm.api
            metabase.llm.init
-           metabase.llm.settings}
+           metabase.llm.settings
+           metabase.llm.startup}
    :uses #{analytics
            api
            driver
@@ -1113,6 +1114,7 @@
            lib-be
            metabot
            models
+           premium-features
            request
            settings
            sql-tools
@@ -1939,7 +1941,8 @@
   settings
   {:team "DevEx"
    :api  #{metabase.settings.core
-           metabase.settings.init}
+           metabase.settings.init
+           metabase.settings.models.setting}
    :uses #{api
            app-db
            config

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1941,8 +1941,7 @@
   settings
   {:team "DevEx"
    :api  #{metabase.settings.core
-           metabase.settings.init
-           metabase.settings.models.setting}
+           metabase.settings.init}
    :uses #{api
            app-db
            config

--- a/enterprise/backend/test/metabase_enterprise/api/session_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/api/session_test.clj
@@ -38,6 +38,7 @@
                               :embedding-hub
                               :hosting
                               :metabase-ai-managed
+                              :metabot-v3
                               :offer-metabase-ai-managed
                               :no-upsell
                               :official-collections
@@ -87,6 +88,7 @@
             :embedding_simple               true
             :hosting                        true
             :metabase-ai-managed            true
+            :metabot-v3                     true
             :offer-metabase-ai-managed      true
             :official_collections           true
             :query_reference_validation     true

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabaseAIProviderSetup.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabaseAIProviderSetup.tsx
@@ -29,6 +29,8 @@ import { useGetMetabotUsageQuery } from "../../../api";
 import {
   METABASE_MANAGED_AI_FEATURE,
   METABASE_MANAGED_AI_TERMS_URL,
+  METABOT_V3_FEATURE,
+  OFFER_METABASE_MANAGED_AI_FEATURE,
 } from "../../constants";
 import { formatMetabaseCost } from "../../format";
 import {
@@ -40,10 +42,15 @@ import { usePurchaseMetabaseManagedAi } from "../../usePurchaseMetabaseManagedAi
 import { MetabotSettingUpModal } from "./MetabotSettingUpModal";
 
 export function MetabaseAIProviderSetup() {
-  const llmProxyConfigured = useSetting("llm-proxy-configured?");
+  const offerMetabaseManagedAi = !!hasPremiumFeature(
+    OFFER_METABASE_MANAGED_AI_FEATURE,
+  );
   const hasMetabaseManagedAiProviderFeature = !!hasPremiumFeature(
     METABASE_MANAGED_AI_FEATURE,
   );
+  const hasDeprecatedMetabaseAiProvider =
+    !!hasPremiumFeature(METABOT_V3_FEATURE);
+
   const { isStoreUser, anyStoreUserEmailAddress } = useSelector(getStoreUsers);
 
   const isConfigured = useSetting("llm-metabot-configured?");
@@ -58,7 +65,9 @@ export function MetabaseAIProviderSetup() {
   const {
     pricing: metabaseManagedAiPricing,
     isLoading: isLoadingMetabaseManagedAiPricing,
-  } = useMetabaseManagedAiPricing(!!llmProxyConfigured);
+  } = useMetabaseManagedAiPricing(
+    !hasDeprecatedMetabaseAiProvider || hasMetabaseManagedAiProviderFeature,
+  );
 
   const metabaseManagedAiPurchase = usePurchaseMetabaseManagedAi();
 
@@ -80,15 +89,17 @@ export function MetabaseAIProviderSetup() {
   const onConnect = match({
     hasAcceptedTerms,
     hasMetabaseManagedAiProviderFeature,
+    hasDeprecatedMetabaseAiProvider,
     isConfigured,
     isStoreUser,
   })
+    .with({ isConfigured: true }, () => null)
+    .with({ hasMetabaseManagedAiProviderFeature: true }, () => handleConnect)
+    .with({ hasDeprecatedMetabaseAiProvider: true }, () => handleConnect)
     .with(
       { hasMetabaseManagedAiProviderFeature: false, hasAcceptedTerms: false },
       () => null,
     )
-    .with({ isConfigured: true }, () => null)
-    .with({ hasMetabaseManagedAiProviderFeature: true }, () => handleConnect)
     .with({ isStoreUser: false }, () => null)
     .otherwise(() => handleMetabasePurchase);
 
@@ -114,6 +125,11 @@ export function MetabaseAIProviderSetup() {
         <MetabaseManagedProviderCard
           isLoadingPricing={isLoadingMetabaseManagedAiPricing}
           pricing={metabaseManagedAiPricing}
+          hasDeprecatedMetabaseAiProvider={hasDeprecatedMetabaseAiProvider}
+          hasMetabaseManagedAiProviderFeature={
+            hasMetabaseManagedAiProviderFeature
+          }
+          offerMetabaseManagedAi={offerMetabaseManagedAi}
         />
       ) : (
         <>
@@ -137,9 +153,24 @@ export function MetabaseAIProviderSetup() {
           </Stack>
 
           {match({
+            hasDeprecatedMetabaseAiProvider,
             hasMetabaseManagedAiProviderFeature,
+            offerMetabaseManagedAi,
             isStoreUser,
           })
+            .with(
+              {
+                hasDeprecatedMetabaseAiProvider: true,
+                hasMetabaseManagedAiProviderFeature: false,
+                offerMetabaseManagedAi: true,
+              },
+              () => (
+                <Text>
+                  {t`You're on legacy tiered AI pricing today. On your next billing cycle, you'll switch to metered AI pricing.`}
+                </Text>
+              ),
+            )
+            .with({ hasDeprecatedMetabaseAiProvider: true }, () => null)
             .with({ hasMetabaseManagedAiProviderFeature: true }, () => null)
             .with({ isStoreUser: false }, () => (
               <Text fw="bold">
@@ -196,36 +227,51 @@ export function MetabaseAIProviderSetup() {
 function MetabaseManagedProviderCard({
   isLoadingPricing,
   pricing,
+  hasDeprecatedMetabaseAiProvider,
+  hasMetabaseManagedAiProviderFeature,
+  offerMetabaseManagedAi,
 }: {
   isLoadingPricing: boolean;
   pricing: MetabaseManagedAiPricing | null;
+  hasDeprecatedMetabaseAiProvider: boolean;
+  hasMetabaseManagedAiProviderFeature: boolean;
+  offerMetabaseManagedAi: boolean;
 }) {
   const { data: metabotUsage } = useGetMetabotUsageQuery();
   const totalCost = getMetabaseUsageCost(metabotUsage?.tokens, pricing);
 
   return (
     <Stack gap="md">
-      <Text c="text-secondary" lh="1">{t`Current billing cycle`}</Text>
+      {!hasMetabaseManagedAiProviderFeature &&
+        hasDeprecatedMetabaseAiProvider &&
+        offerMetabaseManagedAi && (
+          <Text c="text-secondary">
+            {t`You're on legacy tiered AI pricing today. On your next billing cycle, you'll switch to metered AI pricing. If you'd like to switch to a third-party AI provider and use their API, click Disconnect.`}
+          </Text>
+        )}
 
-      <MetabaseUsageRow
-        label={t`Total tokens`}
-        value={formatNumber(metabotUsage?.tokens ?? 0)}
-      />
-
-      {isLoadingPricing ? (
-        <Flex align="center" justify="space-between" gap="md">
-          <Skeleton h="1rem" w="7rem" />
-          <Box flex={1} h={1} bg="border" />
-          <Skeleton h="1rem" w="8rem" />
-        </Flex>
-      ) : pricing ? (
-        <MetabasePricingRow pricing={pricing} />
-      ) : null}
-
-      <MetabaseUsageRow
-        label={t`Total cost`}
-        value={formatMetabaseCost(totalCost)}
-      />
+      {hasMetabaseManagedAiProviderFeature && (
+        <>
+          <Text c="text-secondary" lh="1">{t`Current billing cycle`}</Text>
+          <MetabaseUsageRow
+            label={t`Total tokens`}
+            value={formatNumber(metabotUsage?.tokens ?? 0)}
+          />
+          {isLoadingPricing ? (
+            <Flex align="center" justify="space-between" gap="md">
+              <Skeleton h="1rem" w="7rem" />
+              <Box flex={1} h={1} bg="border" />
+              <Skeleton h="1rem" w="8rem" />
+            </Flex>
+          ) : pricing ? (
+            <MetabasePricingRow pricing={pricing} />
+          ) : null}
+          <MetabaseUsageRow
+            label={t`Total cost`}
+            value={formatMetabaseCost(totalCost)}
+          />
+        </>
+      )}
     </Stack>
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/metabot/constants.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/constants.ts
@@ -1,3 +1,5 @@
+export const METABOT_V3_FEATURE = "metabot-v3";
+export const OFFER_METABASE_MANAGED_AI_FEATURE = "offer-metabase-ai-managed";
 export const METABASE_MANAGED_AI_FEATURE = "metabase-ai-managed";
 export const METABASE_MANAGED_AI_PRODUCT_TYPE = "metabase-ai-managed";
 export const METABASE_MANAGED_AI_TERMS_URL =

--- a/frontend/src/metabase-types/api/mocks/settings.ts
+++ b/frontend/src/metabase-types/api/mocks/settings.ts
@@ -113,6 +113,7 @@ export const createMockTokenFeatures = (
   etl_connections_pg: false,
   hosting: false,
   "metabase-ai-managed": false,
+  "metabot-v3": false,
   "offer-metabase-ai-managed": false,
   official_collections: false,
   sandboxes: false,

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -331,6 +331,7 @@ export const tokenFeatures = [
   "hosting",
   "offer-metabase-ai-managed",
   "metabase-ai-managed",
+  "metabot-v3",
   "official_collections",
   "sandboxes",
   "scim",

--- a/frontend/src/metabase/metabot/components/MetabotAdmin/MetabotSetup.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotAdmin/MetabotSetup.unit.spec.tsx
@@ -103,6 +103,7 @@ type MetabotSettingsUpdateBody = {
 
 type SetupOptions = {
   isHosted?: boolean;
+  hasDeprecatedMetabaseAiProvider?: boolean;
   llmProxyConfigured?: boolean;
   savedProviderValue?: string | null;
   isConfigured?: boolean;
@@ -125,6 +126,7 @@ type SetupOptions = {
 
 async function setup({
   isHosted = false,
+  hasDeprecatedMetabaseAiProvider = false,
   llmProxyConfigured = isHosted,
   savedProviderValue = "anthropic/claude-haiku-4-5",
   isConfigured = true,
@@ -168,6 +170,7 @@ async function setup({
       "metabase-ai-managed": tokenStatusFeatures.includes(
         "metabase-ai-managed",
       ),
+      "metabot-v3": hasDeprecatedMetabaseAiProvider,
     }),
     "token-status": createMockTokenStatus({
       features: tokenStatusFeatures,
@@ -233,6 +236,7 @@ async function setup({
         "metabase-ai-managed": refreshedTokenStatusFeatures.includes(
           "metabase-ai-managed",
         ),
+        "metabot-v3": hasDeprecatedMetabaseAiProvider,
       });
       sessionProperties["token-status"] = createMockTokenStatus({
         features: refreshedTokenStatusFeatures,
@@ -571,6 +575,7 @@ describe("MetabotSetup", () => {
     await setup({
       isHosted: true,
       savedProviderValue: "metabase/anthropic/claude-sonnet-4-6",
+      tokenStatusFeatures: ["metabase-ai-managed"],
     });
 
     expect(
@@ -578,6 +583,23 @@ describe("MetabotSetup", () => {
     ).toBeInTheDocument();
     expect(screen.queryByLabelText("API key")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Model")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Disconnect" }),
+    ).toBeInTheDocument();
+  });
+
+  it("explains the legacy Metabase AI pricing migration", async () => {
+    await setup({
+      isHosted: true,
+      hasDeprecatedMetabaseAiProvider: true,
+      savedProviderValue: "metabase/anthropic/claude-sonnet-4-6",
+    });
+
+    expect(
+      await screen.findByText(
+        "You're on legacy tiered AI pricing today. On your next billing cycle, you'll switch to metered AI pricing. If you'd like to switch to a third-party AI provider and use their API, click Disconnect.",
+      ),
+    ).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Disconnect" }),
     ).toBeInTheDocument();
@@ -791,6 +813,7 @@ describe("MetabotSetup", () => {
     await setup({
       isHosted: true,
       savedProviderValue: "metabase/anthropic/claude-sonnet-4-6",
+      tokenStatusFeatures: ["metabase-ai-managed"],
       metabasePricePerUnit: 4.25,
     });
 
@@ -803,6 +826,7 @@ describe("MetabotSetup", () => {
     await setup({
       isHosted: true,
       savedProviderValue: "metabase/anthropic/claude-sonnet-4-6",
+      tokenStatusFeatures: ["metabase-ai-managed"],
       metabasePricePerUnit: 4.25,
       metabotUsageQuotas: [
         {
@@ -898,6 +922,7 @@ describe("MetabotSetup", () => {
     await setup({
       isHosted: true,
       savedProviderValue: "metabase/anthropic/claude-sonnet-4-6",
+      tokenStatusFeatures: ["metabase-ai-managed"],
     });
 
     await screen.findByText("Current billing cycle");

--- a/src/metabase/core/core.clj
+++ b/src/metabase/core/core.clj
@@ -19,6 +19,7 @@
    [metabase.embedding.settings :as embed.settings]
    [metabase.events.core :as events]
    [metabase.initialization-status.core :as init-status]
+   [metabase.llm.startup :as llm.startup]
    [metabase.logger.core :as logger]
    [metabase.notification.core :as notification]
    [metabase.permissions.core :as perms]
@@ -221,6 +222,7 @@
 
   (init-status/set-progress! 0.85)
   (embed.settings/check-and-sync-settings-on-startup! env/env)
+  (llm.startup/check-and-sync-settings-on-startup!)
   (init-status/set-progress! 0.9)
   (setting/migrate-encrypted-settings!)
   (database/check-health!)

--- a/src/metabase/llm/settings.clj
+++ b/src/metabase/llm/settings.clj
@@ -2,6 +2,7 @@
   "Settings for LLM integration (API keys, model defaults, provider configuration)."
   (:require
    [clojure.string :as str]
+   [metabase.premium-features.core :as premium-features]
    [metabase.settings.core :as setting :refer [defsetting]]
    [metabase.util.i18n :refer [deferred-tru]]))
 
@@ -124,7 +125,8 @@
 
 (defsetting llm-proxy-base-url
   (deferred-tru "Base URL for the LLM proxy. When set, requests to the managed Metabase AI service are routed through this proxy and authenticated with the instance token instead of a provider API key.")
-  :feature          :metabase-ai-managed
+  :enabled?         #(or (premium-features/has-feature? :metabase-ai-managed)
+                         (premium-features/has-feature? :metabot-v3))
   :encryption       :no
   :visibility       :internal
   :default          nil
@@ -133,7 +135,8 @@
 
 (defsetting ai-service-base-url
   (deferred-tru "Base URL for the managed Metabase AI service.")
-  :feature          :metabase-ai-managed
+  :enabled?         #(or (premium-features/has-feature? :metabase-ai-managed)
+                         (premium-features/has-feature? :metabot-v3))
   :encryption       :no
   :visibility       :internal
   :default          nil

--- a/src/metabase/llm/startup.clj
+++ b/src/metabase/llm/startup.clj
@@ -1,0 +1,44 @@
+(ns metabase.llm.startup
+  "Startup-time reconciliation for managed Metabot configuration."
+  (:require
+   [clojure.string :as str]
+   [metabase.metabot.settings :as metabot.settings]
+   [metabase.premium-features.core :as premium-features]
+   [metabase.settings.core :as setting]
+   [metabase.settings.models.setting :as setting.models]
+   [metabase.util.log :as log]))
+
+(set! *warn-on-reflection* true)
+
+(defn- raw-setting
+  [k]
+  ((var-get #'setting.models/db-or-cache-value) k))
+
+(defn- sync-managed-metabot-provider!
+  []
+  (let [raw-provider (raw-setting :llm-metabot-provider)
+        configured?  (metabot.settings/llm-metabot-configured?)]
+    (if (and (str/blank? raw-provider)
+             (not configured?))
+      (do
+        (log/infof "Configuring llm-metabot-provider to %s for legacy Metabot entitlement"
+                   metabot.settings/default-metabase-llm-metabot-provider)
+        (setting/set! :llm-metabot-provider metabot.settings/default-metabase-llm-metabot-provider))
+      nil)))
+
+(defn- maybe-sync-managed-metabot-provider!
+  []
+  (let [legacy-result  (premium-features/canonically-has-feature? :metabot-v3)
+        managed-result (premium-features/canonically-has-feature? :metabase-ai-managed)]
+    (case [legacy-result managed-result]
+      [true false]  (sync-managed-metabot-provider!)
+      [nil _]       :retry
+      [_ nil]       :retry
+      nil)))
+
+(defn check-and-sync-settings-on-startup!
+  "For legacy `:metabot-v3` customers that do not have `:metabase-ai-managed`,
+  switch the default unmanaged Metabot provider to the managed `metabase/...`
+  provider on startup."
+  []
+  (maybe-sync-managed-metabot-provider!))

--- a/src/metabase/llm/startup.clj
+++ b/src/metabase/llm/startup.clj
@@ -5,18 +5,13 @@
    [metabase.metabot.settings :as metabot.settings]
    [metabase.premium-features.core :as premium-features]
    [metabase.settings.core :as setting]
-   [metabase.settings.models.setting :as setting.models]
    [metabase.util.log :as log]))
 
 (set! *warn-on-reflection* true)
 
-(defn- raw-setting
-  [k]
-  ((var-get #'setting.models/db-or-cache-value) k))
-
 (defn- sync-managed-metabot-provider!
   []
-  (let [raw-provider (raw-setting :llm-metabot-provider)
+  (let [raw-provider (setting/db-stored-value :llm-metabot-provider)
         configured?  (metabot.settings/llm-metabot-configured?)]
     (if (and (str/blank? raw-provider)
              (not configured?))
@@ -30,11 +25,9 @@
   []
   (let [legacy-result  (premium-features/canonically-has-feature? :metabot-v3)
         managed-result (premium-features/canonically-has-feature? :metabase-ai-managed)]
-    (case [legacy-result managed-result]
-      [true false]  (sync-managed-metabot-provider!)
-      [nil _]       :retry
-      [_ nil]       :retry
-      nil)))
+    (cond
+      (or (nil? legacy-result) (nil? managed-result))   nil
+      (and legacy-result (not managed-result))          (sync-managed-metabot-provider!))))
 
 (defn check-and-sync-settings-on-startup!
   "For legacy `:metabot-v3` customers that do not have `:metabase-ai-managed`,

--- a/src/metabase/metabot/api.clj
+++ b/src/metabase/metabot/api.clj
@@ -316,9 +316,6 @@
    [:model {:optional true} [:maybe :string]]
    [:api-key {:optional true} [:maybe :string]]])
 
-(def ^:private metabase-default-model
-  "anthropic/claude-sonnet-4-6")
-
 (defn- provider-api-key-setting-key
   [provider]
   (case provider
@@ -337,7 +334,7 @@
   [provider model]
   (cond
     (nil? model) nil
-    (and (= provider provider-util/metabase-provider-prefix) (str/blank? model)) metabase-default-model
+    (and (= provider provider-util/metabase-provider-prefix) (str/blank? model)) metabot.settings/default-llm-metabot-provider
     :else (non-blank-string model)))
 
 (def ^:private invalid-api-key-statuses

--- a/src/metabase/metabot/settings.clj
+++ b/src/metabase/metabot/settings.clj
@@ -104,6 +104,14 @@
   "Providers that can be used directly (not via the metabase/ proxy prefix)."
   #{"anthropic" "openai" "openrouter"})
 
+(def default-llm-metabot-provider
+  "Default provider/model used for Metabot when no explicit model is selected."
+  "anthropic/claude-sonnet-4-6")
+
+(def default-metabase-llm-metabot-provider
+  "Managed-provider version of [[default-llm-metabot-provider]]."
+  (str provider-util/metabase-provider-prefix "/" default-llm-metabot-provider))
+
 (defn- validate-metabot-provider!
   "Validate that `value` has the format `provider/model` with a supported provider prefix.
   For `metabase/` prefix, validates the inner provider too (e.g. `metabase/anthropic/model`).
@@ -142,7 +150,7 @@
   (deferred-tru "The AI provider and model for Metabot. Format: provider/model-name, e.g. `anthropic/claude-haiku-4-5`, `openai/gpt-4.1-mini`, `openrouter/anthropic/claude-haiku-4-5`.")
   :type             :string
   :encryption       :no
-  :default          "anthropic/claude-sonnet-4-6"
+  :default          default-llm-metabot-provider
   :visibility       :settings-manager
   :export?          false
   :deprecated-name  :ee-ai-metabot-provider

--- a/src/metabase/premium_features/core.clj
+++ b/src/metabase/premium_features/core.clj
@@ -59,6 +59,7 @@
   enable-database-routing?
   enable-library?
   enable-metabase-ai-managed?
+  enable-metabot-v3?
   enable-dependencies?
   enable-email-allow-list?
   enable-email-restrict-recipients?

--- a/src/metabase/premium_features/settings.clj
+++ b/src/metabase/premium_features/settings.clj
@@ -313,6 +313,10 @@
   "Should we allow users to use workspaces?"
   :workspaces)
 
+(define-premium-feature enable-metabot-v3?
+  "Should we allow users to use the Metabase-managed tiered AI provider?"
+  :metabot-v3)
+
 (define-premium-feature ^{:added "0.60.0"} enable-metabase-ai-managed?
   "Should we allow users to use the Metabase-managed AI provider?"
   :metabase-ai-managed)
@@ -356,6 +360,7 @@
    :etl_connections                (enable-etl-connections?)
    :etl_connections_pg             (enable-etl-connections-pg?)
    :hosting                        (is-hosted?)
+   :metabot-v3                     (enable-metabot-v3?)
    :metabase-ai-managed            (enable-metabase-ai-managed?)
    :offer-metabase-ai-managed      (enable-offer-metabase-ai-managed?)
    :official_collections           (enable-official-collections?)

--- a/src/metabase/settings/core.clj
+++ b/src/metabase/settings/core.clj
@@ -91,6 +91,7 @@
   can-read-setting?
   current-user-readable-visibilities
   custom-disabled-reasons!
+  db-stored-value
   default-value
   defsetting
   disabled-for-db-reasons

--- a/src/metabase/settings/models/setting.clj
+++ b/src/metabase/settings/models/setting.clj
@@ -568,6 +568,14 @@
                              dep-key (setting-name setting))))
               v))))))
 
+(defn db-stored-value
+  "Return the raw value persisted in the DB/cache for `setting-definition-or-name`, or nil if none.
+
+  Unlike [[get-raw-value]], this does not consult user-local values, database-local values, env vars, defaults, or
+  init functions."
+  ^String [setting-definition-or-name]
+  (db-or-cache-value setting-definition-or-name))
+
 (defonce ^:private ^ReentrantLock init-lock (ReentrantLock.))
 
 (defn- init! [setting-definition-or-name]

--- a/test/metabase/analytics/stats_test.clj
+++ b/test/metabase/analytics/stats_test.clj
@@ -570,6 +570,7 @@
     :offer-metabase-ai-managed
     :query-reference-validation
     :metabase-ai-managed
+    :metabot-v3
     :cloud-custom-smtp
     :session-timeout-config
     :sso-oidc

--- a/test/metabase/llm/settings_test.clj
+++ b/test/metabase/llm/settings_test.clj
@@ -50,11 +50,19 @@
           (mt/with-premium-features #{}
             (is (nil? (llm.settings/llm-proxy-base-url))))))))
 
-  (testing "cannot be set when :metabase-ai-managed feature is not enabled"
+  (testing "can be set and read when :metabot-v3 feature is enabled"
+    (mt/with-premium-features #{:metabot-v3}
+      (mt/with-temporary-setting-values [llm-proxy-base-url "https://proxy.example"]
+        (is (= "https://proxy.example" (llm.settings/llm-proxy-base-url)))
+        (testing "returns default (nil) when neither managed-ai feature is enabled, even if a value is set"
+          (mt/with-premium-features #{}
+            (is (nil? (llm.settings/llm-proxy-base-url))))))))
+
+  (testing "cannot be set when neither managed-ai feature is enabled"
     (mt/with-premium-features #{}
       (is (thrown-with-msg?
            clojure.lang.ExceptionInfo
-           #"Setting llm-proxy-base-url is not enabled because feature :metabase-ai-managed is not available"
+           #"Setting llm-proxy-base-url is not enabled"
            (llm.settings/llm-proxy-base-url! "https://proxy.example"))))))
 
 (deftest ai-service-base-url-feature-guard-test
@@ -66,11 +74,19 @@
           (mt/with-premium-features #{}
             (is (nil? (llm.settings/ai-service-base-url))))))))
 
-  (testing "cannot be set when :metabase-ai-managed feature is not enabled"
+  (testing "can be set and read when :metabot-v3 feature is enabled"
+    (mt/with-premium-features #{:metabot-v3}
+      (mt/with-temporary-setting-values [ai-service-base-url "https://ai-service.example"]
+        (is (= "https://ai-service.example" (llm.settings/ai-service-base-url)))
+        (testing "returns default (nil) when neither managed-ai feature is enabled, even if a value is set"
+          (mt/with-premium-features #{}
+            (is (nil? (llm.settings/ai-service-base-url))))))))
+
+  (testing "cannot be set when neither managed-ai feature is enabled"
     (mt/with-premium-features #{}
       (is (thrown-with-msg?
            clojure.lang.ExceptionInfo
-           #"Setting ai-service-base-url is not enabled because feature :metabase-ai-managed is not available"
+           #"Setting ai-service-base-url is not enabled"
            (llm.settings/ai-service-base-url! "https://ai-service.example"))))))
 
 ;;; ------------------------------------------- Settings Defaults Tests -------------------------------------------

--- a/test/metabase/llm/startup_test.clj
+++ b/test/metabase/llm/startup_test.clj
@@ -1,9 +1,10 @@
 (ns metabase.llm.startup-test
   (:require
-   [clojure.test :refer [deftest is use-fixtures]]
+   [clojure.test :refer [deftest is testing use-fixtures]]
    [metabase.llm.startup :as llm.startup]
    [metabase.metabot.settings :as metabot.settings]
    [metabase.premium-features.core :as premium-features]
+   [metabase.settings.core :as setting]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]))
 
@@ -21,6 +22,24 @@
         (llm.startup/check-and-sync-settings-on-startup!)
         (is (= metabot.settings/default-metabase-llm-metabot-provider
                (metabot.settings/llm-metabot-provider)))))))
+
+(deftest check-and-sync-settings-on-startup-feature-permutations-test
+  (doseq [legacy-result [nil false true]
+          managed-result [nil false true]]
+    (testing (format ":metabot-v3=%s :metabase-ai-managed=%s" legacy-result managed-result)
+      (mt/discard-setting-changes [llm-metabot-provider]
+        (mt/with-temporary-raw-setting-values [llm-metabot-provider nil]
+          (with-redefs [premium-features/canonically-has-feature?
+                        (fn [feature]
+                          (case feature
+                            :metabot-v3 legacy-result
+                            :metabase-ai-managed managed-result))
+                        metabot.settings/llm-metabot-configured? (constantly false)]
+            (llm.startup/check-and-sync-settings-on-startup!)
+            (is (= (case [legacy-result managed-result]
+                     [true false] metabot.settings/default-metabase-llm-metabot-provider
+                     nil)
+                   (setting/db-stored-value :llm-metabot-provider)))))))))
 
 (deftest check-and-sync-settings-on-startup-does-not-overwrite-configured-byok-test
   (mt/discard-setting-changes [llm-metabot-provider]

--- a/test/metabase/llm/startup_test.clj
+++ b/test/metabase/llm/startup_test.clj
@@ -1,0 +1,62 @@
+(ns metabase.llm.startup-test
+  (:require
+   [clojure.test :refer [deftest is use-fixtures]]
+   [metabase.llm.startup :as llm.startup]
+   [metabase.metabot.settings :as metabot.settings]
+   [metabase.premium-features.core :as premium-features]
+   [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]))
+
+(use-fixtures :once (fixtures/initialize :db))
+
+(deftest check-and-sync-settings-on-startup-syncs-legacy-metabot-default-test
+  (mt/discard-setting-changes [llm-metabot-provider]
+    (mt/with-temporary-raw-setting-values [llm-metabot-provider nil]
+      (with-redefs [premium-features/canonically-has-feature?
+                    (fn [feature]
+                      (case feature
+                        :metabot-v3 true
+                        :metabase-ai-managed false))
+                    metabot.settings/llm-metabot-configured? (constantly false)]
+        (llm.startup/check-and-sync-settings-on-startup!)
+        (is (= metabot.settings/default-metabase-llm-metabot-provider
+               (metabot.settings/llm-metabot-provider)))))))
+
+(deftest check-and-sync-settings-on-startup-does-not-overwrite-configured-byok-test
+  (mt/discard-setting-changes [llm-metabot-provider]
+    (mt/with-temporary-raw-setting-values [llm-metabot-provider nil]
+      (with-redefs [premium-features/canonically-has-feature?
+                    (fn [feature]
+                      (case feature
+                        :metabot-v3 true
+                        :metabase-ai-managed false))
+                    metabot.settings/llm-metabot-configured? (constantly true)]
+        (llm.startup/check-and-sync-settings-on-startup!)
+        (is (= metabot.settings/default-llm-metabot-provider
+               (metabot.settings/llm-metabot-provider)))))))
+
+(deftest check-and-sync-settings-on-startup-does-not-overwrite-explicit-provider-test
+  (mt/discard-setting-changes [llm-metabot-provider]
+    (mt/with-temporary-setting-values [llm-metabot-provider "openai/gpt-4.1-mini"]
+      (with-redefs [premium-features/canonically-has-feature?
+                    (fn [feature]
+                      (case feature
+                        :metabot-v3 true
+                        :metabase-ai-managed false))
+                    metabot.settings/llm-metabot-configured? (constantly false)]
+        (llm.startup/check-and-sync-settings-on-startup!)
+        (is (= "openai/gpt-4.1-mini"
+               (metabot.settings/llm-metabot-provider)))))))
+
+(deftest check-and-sync-settings-on-startup-syncs-blank-provider-test
+  (mt/discard-setting-changes [llm-metabot-provider]
+    (mt/with-temporary-raw-setting-values [llm-metabot-provider ""]
+      (with-redefs [premium-features/canonically-has-feature?
+                    (fn [feature]
+                      (case feature
+                        :metabot-v3 true
+                        :metabase-ai-managed false))
+                    metabot.settings/llm-metabot-configured? (constantly false)]
+        (llm.startup/check-and-sync-settings-on-startup!)
+        (is (= metabot.settings/default-metabase-llm-metabot-provider
+               (metabot.settings/llm-metabot-provider)))))))

--- a/test/metabase/premium_features/api_test.clj
+++ b/test/metabase/premium_features/api_test.clj
@@ -35,23 +35,22 @@
   (testing "POST /api/premium-features/token/refresh"
     (testing "clears cache and returns fresh token status"
       (let [cleared? (atom false)]
-        (mt/with-temporary-setting-values [llm-proxy-base-url nil]
-          (with-redefs [premium-features/token-status           (constantly fake-token-status)
-                        premium-features/premium-embedding-token (constantly nil)
-                        token-check/clear-cache!                (fn [] (reset! cleared? true))]
-            (is (=? (dissoc fake-token-status :trial)
-                    (mt/user-http-request :crowberto :post 200 "premium-features/token/refresh")))
-            (is (true? @cleared?))))))
+        (with-redefs [premium-features/token-status           (constantly fake-token-status)
+                      premium-features/premium-embedding-token (constantly nil)
+                      token-check/clear-cache!                (fn [] (reset! cleared? true))]
+          (is (=? (dissoc fake-token-status :trial)
+                  (mt/user-http-request :crowberto :post 200 "premium-features/token/refresh")))
+          (is (true? @cleared?))))))
 
-    (testing "requires superusers"
-      (is (= "You don't have permissions to do that."
-             (mt/user-http-request :rasta :post 403 "premium-features/token/refresh"))))
+  (testing "requires superusers"
+    (is (= "You don't have permissions to do that."
+           (mt/user-http-request :rasta :post 403 "premium-features/token/refresh"))))
 
-    (testing "returns 404 if no token is set"
-      (with-redefs [premium-features/token-status (constantly nil)
-                    premium-features/premium-embedding-token (constantly nil)]
-        (is (= "Not found."
-               (mt/user-http-request :crowberto :post 404 "premium-features/token/refresh")))))))
+  (testing "returns 404 if no token is set"
+    (with-redefs [premium-features/token-status (constantly nil)
+                  premium-features/premium-embedding-token (constantly nil)]
+      (is (= "Not found."
+             (mt/user-http-request :crowberto :post 404 "premium-features/token/refresh"))))))
 
 (deftest post-token-refresh-invalidates-llm-proxy-cache-test
   (testing "POST /api/premium-features/token/refresh invalidates the AI service token cache when explicitly configured"
@@ -72,21 +71,19 @@
                          @request*))))))))))
 
   (testing "POST /api/premium-features/token/refresh does not invalidate the AI service cache when it is not configured"
-    (mt/with-temporary-setting-values [llm-proxy-base-url nil]
-      (with-redefs [premium-features/token-status            (constantly fake-token-status)
-                    premium-features/premium-embedding-token (constantly "proxy-token")
-                    http/post                                (fn [& _]
-                                                               (throw (ex-info "should not be called" {})))]
-        (is (=? (dissoc fake-token-status :trial)
-                (mt/user-http-request :crowberto :post 200 "premium-features/token/refresh")))))))
+    (with-redefs [premium-features/token-status            (constantly fake-token-status)
+                  premium-features/premium-embedding-token (constantly "proxy-token")
+                  http/post                                (fn [& _]
+                                                             (throw (ex-info "should not be called" {})))]
+      (is (=? (dissoc fake-token-status :trial)
+              (mt/user-http-request :crowberto :post 200 "premium-features/token/refresh"))))))
 
 (deftest token-refresh-sets-premium-features-cookie-test
   (testing "POST /api/premium-features/token/refresh sets the premium-features-last-updated cookie"
-    (mt/with-temporary-setting-values [llm-proxy-base-url nil]
-      (with-redefs [premium-features/token-status            (constantly fake-token-status)
-                    premium-features/premium-embedding-token (constantly nil)]
-        (let [cs (cookies/cookie-store)]
-          (mt/user-real-request :crowberto :post 200 "premium-features/token/refresh"
-                                {:request-options {:cookie-store cs}})
-          (let [pf-cookie (get (cookies/get-cookies cs) "metabase.PREMIUM_FEATURES_LAST_UPDATED")]
-            (is (some? pf-cookie) "No premium-features-last-updated cookie set")))))))
+    (with-redefs [premium-features/token-status            (constantly fake-token-status)
+                  premium-features/premium-embedding-token (constantly nil)]
+      (let [cs (cookies/cookie-store)]
+        (mt/user-real-request :crowberto :post 200 "premium-features/token/refresh"
+                              {:request-options {:cookie-store cs}})
+        (let [pf-cookie (get (cookies/get-cookies cs) "metabase.PREMIUM_FEATURES_LAST_UPDATED")]
+          (is (some? pf-cookie) "No premium-features-last-updated cookie set"))))))

--- a/test/metabase/settings/models/setting_test.clj
+++ b/test/metabase/settings/models/setting_test.clj
@@ -575,6 +575,12 @@
   (is (= {:a 100, :b 200}
          (test-json-setting))))
 
+(deftest db-stored-value-test
+  (testing "should expose the raw DB/cache value through the public API"
+    (is (= "raw-value"
+           (with-redefs [setting/db-or-cache-value (constantly "raw-value")]
+             (setting/db-stored-value :test-setting-1))))))
+
 ;;; -------------------------------------------------- CSV Settings --------------------------------------------------
 
 (defn- fetch-csv-setting-value! [v]


### PR DESCRIPTION
Closes [BOT-1201: Build UX for existing customers on Legacy plan i.e. "You're on a legacy plan, you should move"](https://linear.app/metabase/issue/BOT-1201/build-ux-for-existing-customers-on-legacy-plan-ie-youre-on-a-legacy)

AI service PR: https://github.com/metabase/ai-service/pull/638
This needs to be merged with this PR so `metabot-v3` feature is accepted for LLM proxy, otherwise the legacy -tiered users would not be able to use metabot.

### Description

For existing customers with `metabot-v3` feature enabled, on instance startup we automatically prefill the llm provider to metabase AI managed model, thus the metabot continues to work as expected.


### How to verify

Describe the steps to verify that the changes are working as expected.

0. Don't forget to set llm proxy env
1. Have `metabot-v3` token feature enabled but not `metabase-ai-managed`
2. Start metabase instance.
3. Metabot should work as expected

### Demo

#### With `offer-metabase-ai-managed` (we'll auto-convert)
<img width="1666" height="496" alt="image" src="https://github.com/user-attachments/assets/b2077bd1-700e-4978-8489-269665a26787" />
<img width="1672" height="868" alt="image" src="https://github.com/user-attachments/assets/d4fe2239-8882-4bc6-8b2b-8120ba16eb5c" />

#### Without `offer-metabase-ai-managed` (we won't auto-convert)
<img width="1818" height="492" alt="image" src="https://github.com/user-attachments/assets/20b4f911-c088-4496-bd46-7b6bfc3e6e24" />
<img width="1684" height="768" alt="image" src="https://github.com/user-attachments/assets/6f216fac-83b3-4168-a858-1c06be51f52f" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
