### PR TITLE
Support initializing group membership via config file

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/advanced_config/file/users.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_config/file/users.clj
@@ -3,6 +3,7 @@
    [clojure.spec.alpha :as s]
    [metabase-enterprise.advanced-config.file.interface
     :as advanced-config.file.i]
+   [metabase.permissions.core :as perms]
    [metabase.setup.core :as setup]
    [metabase.users.models.user :as user]
    [metabase.util :as u]
@@ -21,11 +22,15 @@
 (s/def :metabase-enterprise.advanced-config.file.users.config-file-spec/email
   string?)
 
+(s/def :metabase-enterprise.advanced-config.file.users.config-file-spec/groups
+  (s/coll-of string?))
+
 (s/def ::config-file-spec
   (s/keys :req-un [:metabase-enterprise.advanced-config.file.users.config-file-spec/first_name
                    :metabase-enterprise.advanced-config.file.users.config-file-spec/last_name
                    :metabase-enterprise.advanced-config.file.users.config-file-spec/password
-                   :metabase-enterprise.advanced-config.file.users.config-file-spec/email]))
+                   :metabase-enterprise.advanced-config.file.users.config-file-spec/email]
+          :opt-un [:metabase-enterprise.advanced-config.file.users.config-file-spec/groups]))
 
 (defmethod advanced-config.file.i/section-spec :users
   [_section]
@@ -35,23 +40,54 @@
   [email]
   (t2/select-one (vec (cons :model/User user/admin-or-self-visible-columns)) :email email))
 
+(defn- resolve-group-id
+  "Resolve a group name to an ID. Recognizes the Data Analysts magic group by name,
+  then falls back to finding or creating a custom group by name."
+  [group-name]
+  (let [lower-name (u/lower-case-en group-name)]
+    (or (when (= lower-name "data analysts")
+          (:id (perms/data-analyst-group)))
+        (when-let [group (t2/select-one :model/PermissionsGroup :%lower.name lower-name)]
+          (:id group))
+        (do
+          (log/info (u/format-color :green "Creating new permissions group %s" (pr-str group-name)))
+          (u/the-id (first (t2/insert-returning-instances! :model/PermissionsGroup {:name group-name})))))))
+
+(defn- set-user-groups!
+  "Set a user's group memberships based on the config file `groups` list. The Data Analysts magic group is
+  recognized by name; all other names are looked up or created as custom groups."
+  [user-id group-names]
+  (let [group-ids    (into #{(:id (perms/all-users-group))}
+                           (map resolve-group-id)
+                           group-names)
+        group-id-set (set (map (fn [id] {:id id}) group-ids))]
+    (log/info (u/format-color :blue "Setting groups for user %d: %s" user-id (pr-str group-names)))
+    (user/set-permissions-groups! user-id group-id-set)))
+
 (defn- init-from-config-file!
   [user]
-  (if-let [existing-user (select-user (:email user))]
-    (do
-      (log/info (u/format-color :blue "Updating User with email %s" (pr-str (:email user))))
-      (let [new-user (update user :login_attributes
-                             #(merge % (:login_attributes existing-user)))]
-        (t2/update! :model/User (:id existing-user) new-user)))
-    ;; create a new user. If they are the first non-internal User, force them to be an admin.
-    (let [user (cond-> user
-                 (not (setup/has-user-setup)) (assoc :is_superuser true))]
-      (log/info (u/colorize :green "Creating the first User for this instance. The first user is always created as an admin."))
-      (log/info (u/format-color :green
-                                "Creating new User %s with email %s"
-                                (pr-str (str (:first_name user) \space (:last_name user)))
-                                (pr-str (:email user))))
-      (t2/insert! :model/User user))))
+  (let [groups (:groups user)
+        user   (dissoc user :groups)]
+    (if-let [existing-user (select-user (:email user))]
+      (do
+        (log/info (u/format-color :blue "Updating User with email %s" (pr-str (:email user))))
+        (let [new-user (update user :login_attributes
+                               #(merge % (:login_attributes existing-user)))]
+          (t2/update! :model/User (:id existing-user) new-user))
+        (when (some? groups)
+          (set-user-groups! (:id existing-user) groups)))
+      ;; create a new user. If they are the first non-internal User, force them to be an admin.
+      (let [user (cond-> user
+                   (not (setup/has-user-setup)) (assoc :is_superuser true))]
+        (log/info (u/colorize :green "Creating the first User for this instance. The first user is always created as an admin."))
+        (log/info (u/format-color :green
+                                  "Creating new User %s with email %s"
+                                  (pr-str (str (:first_name user) \space (:last_name user)))
+                                  (pr-str (:email user))))
+        (t2/insert! :model/User user)
+        (when (some? groups)
+          (let [created-user (t2/select-one :model/User :email (:email user))]
+            (set-user-groups! (:id created-user) groups)))))))
 
 (defmethod advanced-config.file.i/initialize-section! :users
   [_section-name users]

--- a/enterprise/backend/test/metabase_enterprise/advanced_config/file/users_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_config/file/users_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.test :refer :all]
    [metabase-enterprise.advanced-config.file :as advanced-config.file]
+   [metabase.permissions.core :as perms]
    [metabase.setup.core :as setup]
    [metabase.test :as mt]
    [metabase.util.password :as u.password]
@@ -175,3 +176,90 @@
       (finally
         (t2/delete! :model/User :email "cam+config-file-test@metabase.com")
         (t2/delete! :model/User :email "Cam+config-file-test@metabase.com")))))
+
+(deftest init-from-config-file-with-groups-test
+  (testing "Users can be assigned to groups via the config file"
+    (try
+      (binding [advanced-config.file/*config* {:version 1
+                                               :config  {:users [{:first_name "Alice"
+                                                                  :last_name  "Analyst"
+                                                                  :email      "alice+config-file-groups-test@metabase.com"
+                                                                  :password   "123123123"
+                                                                  :groups     ["Data Analysts"]}]}}]
+        (testing "Create user with group assignment"
+          (is (= :ok
+                 (advanced-config.file/initialize!)))
+          (let [user           (t2/select-one :model/User :email "alice+config-file-groups-test@metabase.com")
+                group-ids      (t2/select-fn-set :group_id :model/PermissionsGroupMembership :user_id (:id user))
+                data-analyst-id (:id (perms/data-analyst-group))
+                all-users-id    (:id (perms/all-users-group))]
+            (is (some? user))
+            (is (contains? group-ids data-analyst-id)
+                "User should be in the Data Analysts group")
+            (is (contains? group-ids all-users-id)
+                "User should always be in the All Users group"))))
+
+      (testing "Re-running is idempotent"
+        (binding [advanced-config.file/*config* {:version 1
+                                                 :config  {:users [{:first_name "Alice"
+                                                                    :last_name  "Analyst"
+                                                                    :email      "alice+config-file-groups-test@metabase.com"
+                                                                    :password   "123123123"
+                                                                    :groups     ["Data Analysts"]}]}}]
+          (is (= :ok
+                 (advanced-config.file/initialize!)))))
+      (finally
+        (t2/delete! :model/User :email "alice+config-file-groups-test@metabase.com")))))
+
+(deftest init-from-config-file-with-custom-group-test
+  (testing "Users can be assigned to custom groups that get auto-created"
+    (try
+      (binding [advanced-config.file/*config* {:version 1
+                                               :config  {:users [{:first_name "Bob"
+                                                                  :last_name  "Builder"
+                                                                  :email      "bob+config-file-groups-test@metabase.com"
+                                                                  :password   "123123123"
+                                                                  :groups     ["Marketing Team"]}]}}]
+        (is (= :ok
+               (advanced-config.file/initialize!)))
+        (let [user      (t2/select-one :model/User :email "bob+config-file-groups-test@metabase.com")
+              group     (t2/select-one :model/PermissionsGroup :name "Marketing Team")
+              group-ids (t2/select-fn-set :group_id :model/PermissionsGroupMembership :user_id (:id user))]
+          (is (some? user))
+          (is (some? group)
+              "Custom group should be created")
+          (is (contains? group-ids (:id group))
+              "User should be in the custom group")))
+      (finally
+        (t2/delete! :model/User :email "bob+config-file-groups-test@metabase.com")
+        (t2/delete! :model/PermissionsGroup :name "Marketing Team")))))
+
+(deftest init-from-config-file-group-removal-test
+  (testing "Removing a group from the config file removes the user from that group"
+    (try
+      (testing "First, create user with a group"
+        (binding [advanced-config.file/*config* {:version 1
+                                                 :config  {:users [{:first_name "Carol"
+                                                                    :last_name  "Config"
+                                                                    :email      "carol+config-file-groups-test@metabase.com"
+                                                                    :password   "123123123"
+                                                                    :groups     ["Data Analysts"]}]}}]
+          (is (= :ok (advanced-config.file/initialize!)))
+          (let [user (t2/select-one :model/User :email "carol+config-file-groups-test@metabase.com")]
+            (is (contains? (t2/select-fn-set :group_id :model/PermissionsGroupMembership :user_id (:id user))
+                           (:id (perms/data-analyst-group)))))))
+
+      (testing "Then, update config without that group"
+        (binding [advanced-config.file/*config* {:version 1
+                                                 :config  {:users [{:first_name "Carol"
+                                                                    :last_name  "Config"
+                                                                    :email      "carol+config-file-groups-test@metabase.com"
+                                                                    :password   "123123123"
+                                                                    :groups     []}]}}]
+          (is (= :ok (advanced-config.file/initialize!)))
+          (let [user (t2/select-one :model/User :email "carol+config-file-groups-test@metabase.com")]
+            (is (not (contains? (t2/select-fn-set :group_id :model/PermissionsGroupMembership :user_id (:id user))
+                                (:id (perms/data-analyst-group))))
+                "User should no longer be in the Data Analysts group"))))
+      (finally
+        (t2/delete! :model/User :email "carol+config-file-groups-test@metabase.com")))))


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/UXW-3750/support-data-analyst-users-in-config-files

The design in this PR is not finalized. Keep in mind that currently API keys support a different convention for defining groups, which is `group: admin` or `group: all-users` (no other options).

### Description

Adds a new key `groups` to users provisioned via config file. Example:

```yaml
version: 1
config:
  users:
    - first_name: Admin
      last_name: McAdminface
      password: "123123123"
      email: admin@example.com
      is_superuser: true
    - first_name: Alice
      last_name: Analyst
      password: "123123123"
      email: alice@example.com
      groups:
        - Data Analysts
        - Bean Counters
```

`Data Analysts` (case-insensitive) is treated as a special case for the Data Analysts group.

For everything else, this behaves similar to SSO group mapping:

* If groups is explicitly empty, the user is removed from all groups
* If groups is not set, the user's groups are not touched. This is required to maintain backwards compatibility
* If groups is not empty, the user will belong to exactly the specified groups and no others. Any missing groups are created

### How to verify

1. Run Metabase with the above config file, note that Alice Analyst is created and is a Data Analyst
2. Change Alice's groups to anything else and restart Metabase, observe the changes are reflected
 
### Demo

N/A

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] ~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~
