### PR TITLE
Deref schema model from a protocol not field access

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/checker/format/serdes.clj
+++ b/enterprise/backend/src/metabase_enterprise/checker/format/serdes.clj
@@ -45,7 +45,8 @@
    [clojure.java.io :as io]
    [clojure.string :as str]
    [metabase-enterprise.checker.source :as source]
-   [metabase.util.yaml :as yaml])
+   [metabase.util.yaml :as yaml]
+   [potemkin.types :as p.types])
   (:import
    (java.io File)
    (java.util Locale)))
@@ -425,6 +426,11 @@
                                     (for [schema (list-schemas databases-dir db-name->dir db-name)]
                                       [schema ::not-indexed]))}]))))
 
+(p.types/defprotocol+ ISchemaModelDebug
+  "Non exported protocol to get the schema of the SerdesSource. Useful for debugging and asserting on the schema model
+  built up during serdes."
+  (schema-model [_] "Deref and return the schema model. See [[init-schema-model]] for details of this structure."))
+
 (deftype SerdesSource [databases-dir assets-index db-name->dir
                        ;; See init-schema-model for shape documentation
                        schema-model]
@@ -524,7 +530,9 @@
 
   (resolve-measure [_ entity-id]
     (when-let [file (get-in assets-index [:measure entity-id])]
-      (load-yaml file))))
+      (load-yaml file)))
+  ISchemaModelDebug
+  (schema-model [_] (deref schema-model)))
 
 (defn make-source
   "Create a MetadataSource for a serdes export directory.

--- a/enterprise/backend/test/metabase_enterprise/checker/format/serdes_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/checker/format/serdes_test.clj
@@ -282,19 +282,19 @@
           (is (=? {"DB" {:db-file string?
                          :schemas {"s1" not-indexed
                                    "s2" not-indexed}}}
-                  @(.-schema-model source)))
+                  (serdes/schema-model source)))
           ;; After resolving a table in s1: s1 indexed with tables, s2 untouched
           (source/resolve-table source ["DB" "s1" "T1"])
           (is (=? {"DB" {:schemas {"s1" {"T1" {:table-file string?
                                                :fields     not-indexed}}
                                    "s2" not-indexed}}}
-                  @(.-schema-model source)))
+                  (serdes/schema-model source)))
           ;; After resolving fields for T1: T1 fields indexed, s2 still untouched
           (source/fields-for-table source ["DB" "s1" "T1"])
           (is (=? {"DB" {:schemas {"s1" {"T1" {:table-file string?
                                                :fields     {"F1" string?}}}
                                    "s2" not-indexed}}}
-                  @(.-schema-model source))))))))
+                  (serdes/schema-model source))))))))
 
 (deftest case-insensitive-schema-resolution-test
   (testing "schemas with different casing on disk vs YAML resolve correctly"
@@ -311,7 +311,7 @@
           (is (some? (source/resolve-table source ["DB" "PUBLIC" "ORDERS"])))
           (is (some? (source/resolve-field source ["DB" "PUBLIC" "ORDERS" "ID"])))
           (is (=? {"DB" {:schemas {"PUBLIC" {"ORDERS" {:fields {"ID" string?}}}}}}
-                  @(.-schema-model source))))))))
+                  (serdes/schema-model source))))))))
 
 ;;; ===========================================================================
 ;;; Segments and measures — indexed from export dir, NOT schema dir


### PR DESCRIPTION
it's internal but we don't need to use field access on the type. I don't want to export the type, etc. Just make a debug protocol and this won't be exported so it's not for anyone else.

Before:

```
serdes-test=>
Reflection warning, metabase_enterprise/checker/format/serdes_test.clj:286:20 - reference to field schema_model can't be resolved.
Reflection warning, metabase_enterprise/checker/format/serdes_test.clj:292:20 - reference to field schema_model can't be resolved.
Reflection warning, metabase_enterprise/checker/format/serdes_test.clj:298:20 - reference to field schema_model can't be resolved.
Reflection warning, metabase_enterprise/checker/format/serdes_test.clj:315:20 - reference to field schema_model can't be resolved.
nil
```

After:

```
serdes-test=> (clojure.test/run-tests)

Testing metabase-enterprise.checker.format.serdes-test

Ran 28 tests containing 87 assertions.
0 failures, 0 errors.
{:test 28, :pass 87, :fail 0, :error 0, :type :summary}
```

<img width="977" height="189" alt="image" src="https://github.com/user-attachments/assets/d38174ff-22c8-4eda-af12-885ab9770019" />

