### PR TITLE
GDGT-2255 Custom visualizations button is present in admin panels top

### DIFF
--- a/frontend/src/metabase/admin/app/reducers.ts
+++ b/frontend/src/metabase/admin/app/reducers.ts
@@ -54,11 +54,6 @@ export const getAdminPaths: () => AdminPath[] = () => {
       path: "/admin/tools",
       key: "tools",
     },
-    {
-      name: t`Custom visualizations`,
-      path: "/admin/settings/custom-visualizations",
-      key: "custom-visualizations",
-    },
   ];
 
   return items;

--- a/frontend/src/metabase/redux/store/admin.ts
+++ b/frontend/src/metabase/redux/store/admin.ts
@@ -18,8 +18,7 @@ export type AdminPathKey =
   | "performance"
   | "performance-models"
   | "performance-dashboards-and-questions"
-  | "performance-databases"
-  | "custom-visualizations";
+  | "performance-databases";
 
 export type AdminPath = {
   key: AdminPathKey;


### PR DESCRIPTION
Closes [GDGT-2255](https://linear.app/metabase/issue/GDGT-2255/custom-visualizations-button-is-present-in-admin-panels-top-navbar)

### Description

Removes button accidentally added to the top nav.