### PR TITLE
Gdgt 2285 fix custom viz icon not handling mantine c prop

### DIFF
--- a/frontend/src/metabase/common/components/EntityIcon/EntityIcon.tsx
+++ b/frontend/src/metabase/common/components/EntityIcon/EntityIcon.tsx
@@ -33,12 +33,16 @@ export function EntityIcon({
   name = "unknown",
   size = "1rem",
   color,
+  c,
   style,
   alt = "",
   ...rest
 }: EntityIconProps) {
   if (iconUrl) {
-    const backgroundColor = resolveIconMaskColor(color);
+    // `c` from Mantine's BoxProps can be a responsive breakpoint object, not
+    // just a string, so guard before using it as a fallback for `color`.
+    const effectiveColor = color ?? (typeof c === "string" ? c : undefined);
+    const backgroundColor = resolveIconMaskColor(effectiveColor);
 
     return (
       <span
@@ -62,5 +66,7 @@ export function EntityIcon({
     );
   }
 
-  return <Icon name={name} size={size} c={color} style={style} {...rest} />;
+  return (
+    <Icon name={name} size={size} c={color ?? c} style={style} {...rest} />
+  );
 }


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-2285/fix-custom-viz-icon-not-handling-mantine-c-prop

### Description

The external icon code branch of `EntityIcon` was not handling Mantine's `c` prop correctly.

### How to verify

### Demo

| Header | Header |
|--------|--------|
| <img width="1446" height="908" alt="image" src="https://github.com/user-attachments/assets/1869ed59-a928-45cd-9582-e7728c7bb449" /> | <img width="1466" height="810" alt="image" src="https://github.com/user-attachments/assets/7b5cb2ea-7b2b-498a-8a08-dc762283e331" /> | 

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
