### PR TITLE
GDGT-2255 Custom visualizations button is present in admin panels top

### DIFF
--- a/frontend/src/metabase/admin/app/reducers.ts
+++ b/frontend/src/metabase/admin/app/reducers.ts
@@ -54,11 +54,6 @@ export const getAdminPaths: () => AdminPath[] = () => {
       path: "/admin/tools",
       key: "tools",
     },
-    {
-      name: t`Custom visualizations`,
-      path: "/admin/settings/custom-visualizations",
-      key: "custom-visualizations",
-    },
   ];
 
   return items;

--- a/frontend/src/metabase/admin/settingsRoutes.tsx
+++ b/frontend/src/metabase/admin/settingsRoutes.tsx
@@ -7,6 +7,7 @@ import {
   PLUGIN_REMOTE_SYNC,
   PLUGIN_TRANSFORMS_PYTHON,
 } from "metabase/plugins";
+import { IsAdmin } from "metabase/route-guards";
 
 import { GoogleAuthForm } from "./settings/auth/components/GoogleAuthForm";
 import { SettingsLdapForm } from "./settings/components/SettingsLdapForm";
@@ -29,7 +30,6 @@ import { SlackSettingsPage } from "./settings/components/SettingsPages/SlackSett
 import { UpdatesSettingsPage } from "./settings/components/SettingsPages/UpdatesSettingsPage";
 import { UploadSettingsPage } from "./settings/components/SettingsPages/UploadSettingsPage";
 import { WebhooksSettingsPage } from "./settings/components/SettingsPages/WebhooksSettingsPage";
-import { createAdminRouteGuard } from "./utils";
 
 export const getSettingsRoutes = () => (
   <Route
@@ -80,7 +80,7 @@ export const getSettingsRoutes = () => (
     <Route
       path="custom-visualizations"
       /* do not allow users with "Settings access" permissions to access custom viz pages */
-      component={createAdminRouteGuard("custom-visualizations")}
+      component={IsAdmin}
     >
       <IndexRoute component={CustomVisualizationsManagePage} />
       <Route path="new" component={CustomVisualizationsFormPage} />

--- a/frontend/src/metabase/redux/store/admin.ts
+++ b/frontend/src/metabase/redux/store/admin.ts
@@ -18,8 +18,7 @@ export type AdminPathKey =
   | "performance"
   | "performance-models"
   | "performance-dashboards-and-questions"
-  | "performance-databases"
-  | "custom-visualizations";
+  | "performance-databases";
 
 export type AdminPath = {
   key: AdminPathKey;


### PR DESCRIPTION
Closes [GDGT-2255](https://linear.app/metabase/issue/GDGT-2255/custom-visualizations-button-is-present-in-admin-panels-top-navbar)

### Description

Removes button accidentally added to the top nav.

Previous, reverted attempt: #72602