### PR TITLE
Move export formats to common instead of utils and merge duplicate definitions

### DIFF
--- a/frontend/src/metabase/common/components/QuestionDownloadWidget/QuestionDownloadWidget.tsx
+++ b/frontend/src/metabase/common/components/QuestionDownloadWidget/QuestionDownloadWidget.tsx
@@ -9,6 +9,7 @@ import type {
   ExportFormat,
   TableExportFormat,
 } from "metabase/common/types/export";
+import { exportFormatPng, exportFormats } from "metabase/common/types/export";
 import CS from "metabase/css/core/index.css";
 import { PLUGIN_FEATURE_LEVEL_PERMISSIONS } from "metabase/plugins";
 import {
@@ -22,7 +23,6 @@ import {
   Text,
   Title,
 } from "metabase/ui";
-import { exportFormatPng, exportFormats } from "metabase/utils/urls";
 import { canSavePng } from "metabase/visualizations";
 import type Question from "metabase-lib/v1/Question";
 import type { Dataset } from "metabase-types/api";

--- a/frontend/src/metabase/common/types/export.ts
+++ b/frontend/src/metabase/common/types/export.ts
@@ -1,2 +1,9 @@
 export type TableExportFormat = "csv" | "xlsx" | "json";
 export type ExportFormat = TableExportFormat | "png";
+
+export const exportFormats: TableExportFormat[] = [
+  "csv",
+  "xlsx",
+  "json",
+] as const;
+export const exportFormatPng: ExportFormat = "png" as const;

--- a/frontend/src/metabase/embedding/components/PublicLinkPopover/PublicLinkCopyPanel.tsx
+++ b/frontend/src/metabase/embedding/components/PublicLinkPopover/PublicLinkCopyPanel.tsx
@@ -1,6 +1,7 @@
 import type { MouseEventHandler } from "react";
 import { t } from "ttag";
 
+import type { ExportFormat } from "metabase/common/types/export";
 import {
   Anchor,
   Box,
@@ -15,7 +16,6 @@ import {
   PublicLinkCopyButton,
   RemoveLinkAnchor,
 } from "./PublicLinkCopyPanel.styled";
-import type { ExportFormatType } from "./types";
 
 export const PublicLinkCopyPanel = ({
   loading = false,
@@ -31,9 +31,9 @@ export const PublicLinkCopyPanel = ({
   loading?: boolean;
   url: string | null;
   onRemoveLink?: MouseEventHandler;
-  selectedExtension?: ExportFormatType;
-  onChangeExtension?: (extension: ExportFormatType) => void;
-  extensions?: ExportFormatType[];
+  selectedExtension?: ExportFormat;
+  onChangeExtension?: (extension: ExportFormat) => void;
+  extensions?: ExportFormat[];
   removeButtonLabel?: string;
   removeTooltipLabel?: string;
   onCopy?: () => void;

--- a/frontend/src/metabase/embedding/components/PublicLinkPopover/PublicLinkCopyPanel.tsx
+++ b/frontend/src/metabase/embedding/components/PublicLinkPopover/PublicLinkCopyPanel.tsx
@@ -31,8 +31,8 @@ export const PublicLinkCopyPanel = ({
   loading?: boolean;
   url: string | null;
   onRemoveLink?: MouseEventHandler;
-  selectedExtension?: ExportFormat;
-  onChangeExtension?: (extension: ExportFormat) => void;
+  selectedExtension?: ExportFormat | null;
+  onChangeExtension?: (extension: ExportFormat | null) => void;
   extensions?: ExportFormat[];
   removeButtonLabel?: string;
   removeTooltipLabel?: string;

--- a/frontend/src/metabase/embedding/components/PublicLinkPopover/PublicLinkPopover.tsx
+++ b/frontend/src/metabase/embedding/components/PublicLinkPopover/PublicLinkPopover.tsx
@@ -1,12 +1,12 @@
 import { useAsync } from "react-use";
 import { t } from "ttag";
 
+import type { ExportFormat } from "metabase/common/types/export";
 import { getUserIsAdmin } from "metabase/selectors/user";
 import { Box, Popover, Text, Title } from "metabase/ui";
 import { useSelector } from "metabase/utils/redux";
 
 import { PublicLinkCopyPanel } from "./PublicLinkCopyPanel";
-import type { ExportFormatType } from "./types";
 
 export type PublicLinkPopoverProps = {
   target: JSX.Element;
@@ -15,9 +15,9 @@ export type PublicLinkPopoverProps = {
   createPublicLink: () => Promise<void>;
   deletePublicLink: () => void;
   url: string | null;
-  extensions?: ExportFormatType[];
-  selectedExtension?: ExportFormatType | null;
-  setSelectedExtension?: (extension: ExportFormatType) => void;
+  extensions?: ExportFormat[];
+  selectedExtension?: ExportFormat | null;
+  setSelectedExtension?: (extension: ExportFormat) => void;
   onCopyLink?: () => void;
 };
 

--- a/frontend/src/metabase/embedding/components/PublicLinkPopover/PublicLinkPopover.tsx
+++ b/frontend/src/metabase/embedding/components/PublicLinkPopover/PublicLinkPopover.tsx
@@ -17,7 +17,7 @@ export type PublicLinkPopoverProps = {
   url: string | null;
   extensions?: ExportFormat[];
   selectedExtension?: ExportFormat | null;
-  setSelectedExtension?: (extension: ExportFormat) => void;
+  setSelectedExtension?: (extension: ExportFormat | null) => void;
   onCopyLink?: () => void;
 };
 

--- a/frontend/src/metabase/embedding/components/PublicLinkPopover/PublicLinkPopover.unit.spec.tsx
+++ b/frontend/src/metabase/embedding/components/PublicLinkPopover/PublicLinkPopover.unit.spec.tsx
@@ -2,7 +2,7 @@ import userEvent from "@testing-library/user-event";
 import { useState } from "react";
 
 import { renderWithProviders, screen } from "__support__/ui";
-import type { ExportFormatType } from "metabase/embedding/components/PublicLinkPopover/types";
+import type { ExportFormat } from "metabase/common/types/export";
 import { createMockState } from "metabase/redux/store/mocks";
 import { createMockUser } from "metabase-types/api/mocks";
 
@@ -23,7 +23,7 @@ const TestComponent = ({
     </button>
   );
   const [isOpen, setIsOpen] = useState(mockIsOpen);
-  const [extension, setExtension] = useState<ExportFormatType | null>(null);
+  const [extension, setExtension] = useState<ExportFormat | null>(null);
 
   const linkExtension = extension ? `.${extension}` : "";
   const publicUrl = url ? `sample-public-link${linkExtension}` : null;
@@ -56,7 +56,7 @@ const setup = ({
 }: {
   hasUUID?: boolean;
   isOpen?: boolean;
-  extensions?: ExportFormatType[];
+  extensions?: ExportFormat[];
   isAdmin?: boolean;
 } = {}) => {
   const createPublicLink = jest.fn();

--- a/frontend/src/metabase/embedding/components/PublicLinkPopover/QuestionPublicLinkPopover.tsx
+++ b/frontend/src/metabase/embedding/components/PublicLinkPopover/QuestionPublicLinkPopover.tsx
@@ -4,18 +4,15 @@ import {
   useCreateCardPublicLinkMutation,
   useDeleteCardPublicLinkMutation,
 } from "metabase/api";
+import { type ExportFormat, exportFormats } from "metabase/common/types/export";
 import {
   trackPublicLinkCopied,
   trackPublicLinkRemoved,
 } from "metabase/public/lib/analytics";
-import {
-  exportFormats,
-  publicQuestion as getPublicQuestionUrl,
-} from "metabase/utils/urls";
+import { publicQuestion as getPublicQuestionUrl } from "metabase/utils/urls";
 import type Question from "metabase-lib/v1/Question";
 
 import { PublicLinkPopover } from "./PublicLinkPopover";
-import type { ExportFormatType } from "./types";
 
 export const QuestionPublicLinkPopover = ({
   question,
@@ -30,7 +27,7 @@ export const QuestionPublicLinkPopover = ({
 }) => {
   const uuid = question.publicUUID();
 
-  const [extension, setExtension] = useState<ExportFormatType | null>(null);
+  const [extension, setExtension] = useState<ExportFormat | null>(null);
 
   const url = uuid
     ? getPublicQuestionUrl({

--- a/frontend/src/metabase/embedding/components/PublicLinkPopover/types.ts
+++ b/frontend/src/metabase/embedding/components/PublicLinkPopover/types.ts
@@ -1,3 +1,0 @@
-import type { exportFormats } from "metabase/utils/urls";
-
-export type ExportFormatType = (typeof exportFormats)[number] | null;

--- a/frontend/src/metabase/public/lib/analytics.ts
+++ b/frontend/src/metabase/public/lib/analytics.ts
@@ -1,4 +1,4 @@
-import type { ExportFormatType } from "metabase/embedding/components/PublicLinkPopover/types";
+import type { ExportFormat } from "metabase/common/types/export";
 import { trackSchemaEvent } from "metabase/utils/analytics";
 
 import type {
@@ -129,7 +129,7 @@ export const trackPublicLinkCopied = ({
   format = null,
 }: {
   artifact: EmbedResourceType;
-  format?: ExportFormatType | "html";
+  format?: ExportFormat | "html" | null;
 }): void => {
   trackSchemaEvent(SCHEMA_NAME, {
     event: "public_link_copied",

--- a/frontend/src/metabase/redux/downloads.ts
+++ b/frontend/src/metabase/redux/downloads.ts
@@ -8,6 +8,7 @@ import {
 import { t } from "ttag";
 import _ from "underscore";
 
+import { exportFormatPng } from "metabase/common/types/export";
 import { waitUntilNextFramePainted } from "metabase/common/utils/wait-until-next-frame-paints";
 import { trackExportDashboardToPDF } from "metabase/dashboard/analytics";
 import { DASHBOARD_PDF_EXPORT_ROOT_ID } from "metabase/dashboard/constants";
@@ -227,7 +228,7 @@ export const downloadQueryResults = createAsyncThunk(
       exportType: opts.type,
     });
 
-    if (opts.type === Urls.exportFormatPng) {
+    if (opts.type === exportFormatPng) {
       await dispatch(downloadToImage({ opts, id: Date.now() }));
     } else {
       await dispatch(downloadDataset({ opts, id: Date.now() }));

--- a/frontend/src/metabase/utils/urls/misc.ts
+++ b/frontend/src/metabase/utils/urls/misc.ts
@@ -1,11 +1,3 @@
-import type {
-  ExportFormat,
-  TableExportFormat,
-} from "metabase/common/types/export";
-
-export const exportFormats: TableExportFormat[] = ["csv", "xlsx", "json"];
-export const exportFormatPng: ExportFormat = "png";
-
 export function accountSettings() {
   return "/account/profile";
 }


### PR DESCRIPTION
- removes one module violation
- merges duplicate definitions of `ExportFormat`
- Removes `ExportFormat` from `metabase/utils/urls` which was a weird place anyways.