### PR TITLE
set safe headers on asset/bundle

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/api.clj
@@ -232,14 +232,17 @@
           entry   (cache/resolve-bundle plugin)]
       (if entry
         (respond {:status  200
-                  :headers (cond-> {"Content-Type" "application/javascript"
-                                    "ETag"         (:hash entry)}
-                             dev-url     (assoc "Cache-Control" "no-store")
+                  :headers (cond-> {"Content-Type"                 "application/javascript"
+                                    "X-Content-Type-Options"       "nosniff"
+                                    "Cross-Origin-Resource-Policy" "same-origin"
+                                    "Referrer-Policy"              "no-referrer"
+                                    "ETag"                       (:hash entry)}
+                             dev-url       (assoc "Cache-Control" "no-store")
                              (not dev-url) (assoc "Cache-Control" "public, max-age=31536000, immutable"))
                   :body    (:content entry)})
-        (respond {:status 503
+        (respond {:status  503
                   :headers {"Content-Type" "application/json"}
-                  :body   "{\"error\": \"Bundle not available\"}"})))
+                  :body    "{\"error\": \"Bundle not available\"}"})))
     (catch Throwable e
       (raise e))))
 
@@ -263,7 +266,10 @@
           bytes        (cache/resolve-asset plugin path)]
       (if bytes
         (respond {:status  200
-                  :headers (cond-> {"Content-Type" content-type}
+                  :headers (cond-> {"Content-Type"                 content-type
+                                    "X-Content-Type-Options"       "nosniff"
+                                    "Cross-Origin-Resource-Policy" "same-origin"
+                                    "Referrer-Policy"              "no-referrer"}
                              dev?       (assoc "Cache-Control" "no-store")
                              (not dev?) (assoc "Cache-Control" "public, max-age=31536000, immutable"))
                   :body    (java.io.ByteArrayInputStream. bytes)})


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-2259/security-audit-m-2-asset-endpoint-svg-served-inline-executable
Closes https://linear.app/metabase/issue/GDGT-2264/security-audit-m-3-bundleasset-responses-missing-hardening-headers

n.b: not all suggestions from the tickets have been implemented, only the ones that make sense