### PR TITLE
Relax before-update check to block enabling actions, not all edits

### DIFF
--- a/src/metabase/warehouses/models/database.clj
+++ b/src/metabase/warehouses/models/database.clj
@@ -431,7 +431,6 @@
         {new-engine        :engine
          new-settings      :settings} changes
         {is-sample?        :is_sample
-         existing-settings :settings
          existing-engine   :engine}   (t2/original database)
         new-engine                    (some-> new-engine keyword)]
     (if (and is-sample?
@@ -462,17 +461,17 @@
 
                  (:uploads_enabled changes)
                  maybe-disable-uploads-for-all-dbs!)
-        ;; This maintains a constraint that if a driver doesn't support actions, it can never be enabled
-        ;; If we drop support for actions for a driver, we'd need to add a migration to disable actions for all databases
-        (when (and (:database-enable-actions (or new-settings existing-settings))
+        ;; This maintains a constraint that if a driver doesn't support actions, it can never be enabled.
+        ;; Only enforce this when the setting is actually being turned on in this update — otherwise an
+        ;; orphaned setting (e.g. from a prior engine swap) would block all further edits to the DB.
+        (when (and (:database-enable-actions new-settings)
                    (not (driver.u/supports? (or new-engine existing-engine) :actions database)))
           (throw (ex-info (trs "The database does not support actions.")
                           {:status-code     400
                            :existing-engine existing-engine
                            :new-engine      new-engine})))
-        ;; This maintains a constraint that if a driver doesn't support data editing, it can never be enabled
-        ;; If we drop support for a driver, we'd need to add a migration to disable it for all databases
-        (when (and (:database-enable-table-editing (or new-settings existing-settings))
+        ;; Same rationale as the :database-enable-actions check above: only enforce on actual enablement.
+        (when (and (:database-enable-table-editing new-settings)
                    (not (driver.u/supports? (or new-engine existing-engine) :actions/data-editing database)))
           (throw (ex-info (trs "The database does not support table editing.")
                           {:status-code     400

--- a/src/metabase/warehouses/models/database.clj
+++ b/src/metabase/warehouses/models/database.clj
@@ -466,7 +466,6 @@
         {new-engine        :engine
          new-settings      :settings} changes
         {is-sample?        :is_sample
-         existing-settings :settings
          existing-engine   :engine}   (t2/original database)
         new-engine                    (some-> new-engine keyword)]
     (if (and is-sample?
@@ -498,17 +497,17 @@
 
                  (:uploads_enabled changes)
                  maybe-disable-uploads-for-all-dbs!)
-        ;; This maintains a constraint that if a driver doesn't support actions, it can never be enabled
-        ;; If we drop support for actions for a driver, we'd need to add a migration to disable actions for all databases
-        (when (and (:database-enable-actions (or new-settings existing-settings))
+        ;; This maintains a constraint that if a driver doesn't support actions, it can never be enabled.
+        ;; Only enforce this when the setting is actually being turned on in this update — otherwise an
+        ;; orphaned setting (e.g. from a prior engine swap) would block all further edits to the DB.
+        (when (and (:database-enable-actions new-settings)
                    (not (driver.u/supports? (or new-engine existing-engine) :actions database)))
           (throw (ex-info (trs "The database does not support actions.")
                           {:status-code     400
                            :existing-engine existing-engine
                            :new-engine      new-engine})))
-        ;; This maintains a constraint that if a driver doesn't support data editing, it can never be enabled
-        ;; If we drop support for a driver, we'd need to add a migration to disable it for all databases
-        (when (and (:database-enable-table-editing (or new-settings existing-settings))
+        ;; Same rationale as the :database-enable-actions check above: only enforce on actual enablement.
+        (when (and (:database-enable-table-editing new-settings)
                    (not (driver.u/supports? (or new-engine existing-engine) :actions/data-editing database)))
           (throw (ex-info (trs "The database does not support table editing.")
                           {:status-code     400

--- a/test/metabase/warehouses_rest/api_test.clj
+++ b/test/metabase/warehouses_rest/api_test.clj
@@ -662,6 +662,22 @@
                                                {:settings {:database-enable-actions true}})
                          [:settings :database-enable-actions]))))))
 
+(deftest ^:synchronized update-database-with-stale-enable-actions-setting-test
+  (testing (str "PUT /api/database/:id should succeed for a DB whose stored :database-enable-actions is true "
+                "but whose driver no longer supports :actions (QUE2-69)")
+    ;; Customer scenario: a Postgres database had `database-enable-actions` enabled, then the engine was
+    ;; swapped to Snowflake (which doesn't support :actions). The orphaned setting remains in storage and
+    ;; now blocks any edits to the connection, because the `before-update` hook on :model/Database rejects
+    ;; the row as soon as it sees the stale setting paired with a driver that doesn't support :actions.
+    (mt/with-temp [:model/Database {db-id :id} {:engine   :h2
+                                                :details  (:details (mt/db))
+                                                :settings {:database-enable-actions true}}]
+      (tx/with-driver-supports-feature! [:h2 :actions false]
+        (is (=? {:name "que2-69-renamed"}
+                (mt/user-http-request :crowberto :put 200
+                                      (format "database/%s" db-id)
+                                      {:name "que2-69-renamed"})))))))
+
 (deftest update-database-settings-only-validates-changed-settings-test
   (testing "PUT /api/database/:id only validates settings that are being changed"
     (testing "should not validate existing settings that aren't being changed"


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #68629
Fixes QUE2-69.

### Description

If you have a `:model/Database` that that has actions enabled, and then
change the DB engine from a driver (e.g. Postgres) which supports actions
to another that doesn't (e.g. ClickHouse) the before-update hook on
`:model/Database` would detect that the final state had an illegal
setting and block even unrelated updates.

This change relaxes that check to only disallow edits that explicitly
want to set the actions to enabled when the engine doesn't support
them.

### How to verify

Set up a Postgres database and enable actions, then switch it to a ClickHouse database which is linked to the Postgres. The questions will still work but any edit to the database would be denied, previously (e.g. changing the name). Now you can make edits and it will work fine. If you disable actions and try to re-enable them, that edit is still blocked.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
