### PR TITLE
remove client version header from EAJS

### DIFF
--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-init-data/use-init-data-internal.ts
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-init-data/use-init-data-internal.ts
@@ -80,6 +80,7 @@ export const useInitDataInternal = ({
   if (!api.requestClient) {
     api.requestClient = {
       name: EMBEDDING_SDK_CONFIG.metabaseClientRequestHeader,
+      // Note: this is *package* version, it's undefined in EAJS
       version: sdkPackageVersion,
     };
   }

--- a/frontend/src/metabase/utils/api.js
+++ b/frontend/src/metabase/utils/api.js
@@ -87,8 +87,9 @@ export class Api extends EventEmitter {
       }
       if (typeof self.requestClient === "object") {
         headers["X-Metabase-Client"] = self.requestClient.name;
-        headers["X-Metabase-Client-Version"] =
-          self.requestClient.version ?? "unknown";
+        if (self.requestClient.version) {
+          headers["X-Metabase-Client-Version"] = self.requestClient.version;
+        }
       } else {
         headers["X-Metabase-Client"] = self.requestClient;
       }


### PR DESCRIPTION
Closes [EMB-1455: Embedded Analytics JS shows client version as unknown](https://linear.app/metabase/issue/EMB-1455/embedded-analytics-js-shows-client-version-as-unknown)

### Description

That header is for the package version, we don't need to send it from EAJS
Addressing it as a part of [Enhance Usage Analytics for Embedding](https://linear.app/metabase/project/enhance-usage-analytics-for-embedding-8c80affee579/overview) to simplify our headers