### PR TITLE
gate dev plugins behind an env var

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -2822,6 +2822,7 @@
            models
            premium-features
            server
+           settings
            util
            enterprise/remote-sync}
    :model-exports #{:model/CustomVizPlugin}}

--- a/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/api.clj
@@ -7,6 +7,7 @@
    [metabase-enterprise.custom-viz-plugin.cache :as cache]
    [metabase-enterprise.custom-viz-plugin.manifest :as manifest]
    [metabase-enterprise.custom-viz-plugin.models.custom-viz-plugin]
+   [metabase-enterprise.custom-viz-plugin.settings :as custom-viz.settings]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.events.core :as events]
@@ -18,6 +19,14 @@
    (java.io BufferedReader InputStream InputStreamReader OutputStream)))
 
 (set! *warn-on-reflection* true)
+
+;;; ------------------------------------------------ Dev-mode guard ------------------------------------------------
+
+(defn- check-dev-mode-enabled!
+  "Throws a 403 if dev mode is not enabled via MB_CUSTOM_VIZ_PLUGIN_DEV_MODE_ENABLED."
+  []
+  (api/check (custom-viz.settings/custom-viz-plugin-dev-mode-enabled)
+             [403 "Custom visualization plugin dev mode is not enabled."]))
 
 ;;; ------------------------------------------------ Schemas ------------------------------------------------
 
@@ -124,13 +133,15 @@
 
 (api.macros/defendpoint :post "/dev" :- CustomVizPluginResponse
   "Register a dev-only custom visualization plugin from a local dev server.
-   No git repository is required — the bundle is served from the dev server URL."
+   No git repository is required — the bundle is served from the dev server URL.
+   Requires custom viz plugin dev mode to be enabled."
   [_route-params
    _query-params
    {:keys [identifier dev_bundle_url]} :- [:map
                                            [:identifier     {:optional true} [:maybe ms/NonBlankString]]
                                            [:dev_bundle_url ms/NonBlankString]]]
   (api/check-superuser)
+  (check-dev-mode-enabled!)
   (let [manifest     (cache/fetch-dev-manifest dev_bundle_url)
         identifier   (or identifier
                          (:name manifest)
@@ -171,16 +182,19 @@
 
 (api.macros/defendpoint :get "/list" :- [:sequential CustomVizPluginRuntimeResponse]
   "List active and enabled custom visualization plugins. Available to any authenticated user.
-   Plugins with incompatible Metabase version requirements are excluded."
+   Plugins with incompatible Metabase version requirements are excluded.
+   Dev-only plugins are excluded when dev mode is disabled."
   []
-  (let [plugins (t2/select [:model/CustomVizPlugin
-                            :id :identifier :display_name :icon :resolved_commit
-                            :manifest :metabase_version :dev_bundle_url]
-                           :status :active
-                           :enabled true
-                           {:order-by [[:display_name :asc]]})]
+  (let [dev-mode? (custom-viz.settings/custom-viz-plugin-dev-mode-enabled)
+        plugins   (t2/select [:model/CustomVizPlugin
+                              :id :identifier :display_name :icon :resolved_commit
+                              :manifest :metabase_version :dev_bundle_url :repo_url]
+                             :status :active
+                             :enabled true
+                             {:order-by [[:display_name :asc]]})]
     (->> plugins
          (filter manifest/compatible?)
+         (remove #(and (not dev-mode?) (dev-only-plugin? %)))
          (map plugin->runtime-response))))
 
 (api.macros/defendpoint :delete "/:id" :- :nil
@@ -282,11 +296,13 @@
 (api.macros/defendpoint :put "/:id/dev-url" :- [:map [:dev_bundle_url [:maybe :string]]]
   "Set or clear the dev base URL for a plugin (e.g. `http://localhost:5174`).
    The bundle is fetched from `{base}/index.js` and assets from `{base}/assets/{name}`.
-   Persisted to the database so it survives server restarts."
+   Persisted to the database so it survives server restarts.
+   Requires custom viz plugin dev mode to be enabled."
   [{:keys [id]} :- [:map [:id ms/PositiveInt]]
    _query-params
    {:keys [dev_bundle_url]} :- [:map [:dev_bundle_url [:maybe :string]]]]
   (api/check-superuser)
+  (check-dev-mode-enabled!)
   (api/check-404 (t2/select-one :model/CustomVizPlugin :id id))
   (cache/set-or-clear-dev-bundle! id dev_bundle_url)
   {:dev_bundle_url (cache/resolve-dev-bundle id)})
@@ -294,8 +310,10 @@
 (api.macros/defendpoint :get "/:id/dev-sse" :- :any
   "Proxy Server-Sent Events from the plugin's dev server.
    Connects to `{dev_bundle_url}/__sse` and forwards events to the browser.
-   This avoids the need for a CSP exception for the dev server origin."
+   This avoids the need for a CSP exception for the dev server origin.
+   Requires custom viz plugin dev mode to be enabled."
   [{:keys [id]} :- [:map [:id ms/PositiveInt]]]
+  (check-dev-mode-enabled!)
   (let [dev-url (cache/resolve-dev-bundle id)]
     (when-not dev-url
       (throw (ex-info "No dev server URL configured" {:status-code 404})))

--- a/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/cache.clj
+++ b/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/cache.clj
@@ -199,9 +199,11 @@
     (t2/update! :model/CustomVizPlugin id {:dev_bundle_url url})))
 
 (defn resolve-dev-bundle
-  "Resolve the dev bundle URL for a plugin from the database. Returns the URL string or nil."
+  "Resolve the dev bundle URL for a plugin from the database. Returns the URL string or nil.
+   Always returns nil when dev mode is disabled."
   [id]
-  (not-empty (t2/select-one-fn :dev_bundle_url :model/CustomVizPlugin :id id)))
+  (when (custom-viz.settings/custom-viz-plugin-dev-mode-enabled)
+    (not-empty (t2/select-one-fn :dev_bundle_url :model/CustomVizPlugin :id id))))
 
 ;;; ------------------------------------------------ Resolve ------------------------------------------------
 

--- a/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/cache.clj
+++ b/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/cache.clj
@@ -8,6 +8,7 @@
    [clj-http.client :as http]
    [clojure.string :as str]
    [metabase-enterprise.custom-viz-plugin.manifest :as manifest]
+   [metabase-enterprise.custom-viz-plugin.settings :as custom-viz.settings]
    [metabase-enterprise.remote-sync.source.git :as rs.git]
    [metabase.config.core :as config]
    [metabase.util :as u]

--- a/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/init.clj
+++ b/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/init.clj
@@ -1,4 +1,5 @@
 (ns metabase-enterprise.custom-viz-plugin.init
   (:require
    [metabase-enterprise.custom-viz-plugin.api]
-   [metabase-enterprise.custom-viz-plugin.core]))
+   [metabase-enterprise.custom-viz-plugin.core]
+   [metabase-enterprise.custom-viz-plugin.settings]))

--- a/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/settings.clj
@@ -1,0 +1,14 @@
+(ns metabase-enterprise.custom-viz-plugin.settings
+  (:require
+   [metabase.config.core :as config]
+   [metabase.settings.core :refer [defsetting]]
+   [metabase.util.i18n :refer [deferred-tru]]))
+
+(defsetting custom-viz-plugin-dev-mode-enabled
+  (deferred-tru "Whether custom visualization plugin dev mode is enabled. When false, the dev endpoints (POST /dev, PUT /:id/dev-url, GET /:id/dev-sse) are disabled.")
+  :type       :boolean
+  :visibility :public
+  :setter     :none
+  :audit      :never
+  :export?    false
+  :getter     (fn [] (boolean (config/config-bool :mb-custom-viz-plugin-dev-mode-enabled))))

--- a/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/api_test.clj
@@ -535,3 +535,60 @@
             (is (= {:previous {:resolved_commit "old-sha"}
                     :new      {:resolved_commit "new-sha"}}
                    (select-keys (:details entry) [:previous :new])))))))))
+
+;;; ------------------------------------------------ Dev Mode Gating ------------------------------------------------
+
+(deftest dev-mode-gating-test
+  (mt/with-premium-features #{:custom-viz}
+    (testing "POST /dev returns 403 when dev mode is disabled"
+      (is (= "Custom visualization plugin dev mode is not enabled."
+             (mt/user-http-request :crowberto :post 403 "ee/custom-viz-plugin/dev"
+                                   {:dev_bundle_url "http://localhost:5174"}))))
+    (testing "PUT /:id/dev-url returns 403 when dev mode is disabled"
+      (mt/with-temp [:model/CustomVizPlugin {id :id} {:repo_url     "https://github.com/test/dev-gate"
+                                                      :identifier   "dev-gate"
+                                                      :display_name "dev-gate"
+                                                      :status       :active}]
+        (is (= "Custom visualization plugin dev mode is not enabled."
+               (mt/user-http-request :crowberto :put 403 (str "ee/custom-viz-plugin/" id "/dev-url")
+                                     {:dev_bundle_url "http://localhost:5174"})))))
+    (testing "GET /:id/dev-sse returns 403 when dev mode is disabled"
+      (mt/with-temp [:model/CustomVizPlugin {id :id} {:repo_url     "https://github.com/test/dev-gate-sse"
+                                                      :identifier   "dev-gate-sse"
+                                                      :display_name "dev-gate-sse"
+                                                      :status       :active}]
+        (is (= "Custom visualization plugin dev mode is not enabled."
+               (mt/user-http-request :crowberto :get 403 (str "ee/custom-viz-plugin/" id "/dev-sse"))))))
+    (testing "dev endpoints work when dev mode is enabled"
+      (with-dev-mode-enabled
+        (mt/with-model-cleanup [:model/CustomVizPlugin]
+          (with-redefs [cache/fetch-dev-manifest    (constantly {:name "gated-dev" :icon "icon.svg"})
+                        cache/set-or-clear-dev-bundle! (constantly nil)]
+            (let [resp (mt/user-http-request :crowberto :post 200 "ee/custom-viz-plugin/dev"
+                                             {:dev_bundle_url "http://localhost:5174"})]
+              (is (= "gated-dev" (:identifier resp))))))))))
+
+(deftest list-excludes-dev-plugins-when-dev-mode-disabled-test
+  (mt/with-premium-features #{:custom-viz}
+    (mt/with-temp [:model/CustomVizPlugin _ {:repo_url     "https://github.com/test/git-viz-list"
+                                             :identifier   "git-viz-list"
+                                             :display_name "Git Viz"
+                                             :status       :active
+                                             :enabled      true}
+                   :model/CustomVizPlugin _ {:repo_url       "dev://local/dev-viz-list"
+                                             :identifier     "dev-viz-list"
+                                             :display_name   "Dev Viz"
+                                             :status         :active
+                                             :enabled        true
+                                             :dev_bundle_url "http://localhost:5174"}]
+      (testing "dev-only plugins are hidden from /list when dev mode is off"
+        (let [result      (mt/user-http-request :rasta :get 200 "ee/custom-viz-plugin/list")
+              identifiers (set (map :identifier result))]
+          (is (contains? identifiers "git-viz-list"))
+          (is (not (contains? identifiers "dev-viz-list")))))
+      (testing "dev-only plugins are visible in /list when dev mode is on"
+        (with-dev-mode-enabled
+          (let [result      (mt/user-http-request :rasta :get 200 "ee/custom-viz-plugin/list")
+                identifiers (set (map :identifier result))]
+            (is (contains? identifiers "git-viz-list"))
+            (is (contains? identifiers "dev-viz-list"))))))))

--- a/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/api_test.clj
@@ -4,6 +4,7 @@
    [clojure.test :refer :all]
    [metabase-enterprise.custom-viz-plugin.api :as custom-viz-plugin.api]
    [metabase-enterprise.custom-viz-plugin.cache :as cache]
+   [metabase-enterprise.custom-viz-plugin.settings :as custom-viz.settings]
    [metabase.config.core :as config]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
@@ -13,6 +14,10 @@
 (def ^:private parse-repo-name @#'custom-viz-plugin.api/parse-repo-name)
 
 (use-fixtures :once (fixtures/initialize :db :web-server :test-users))
+
+(defmacro ^:private with-dev-mode-enabled [& body]
+  `(with-redefs [custom-viz.settings/custom-viz-plugin-dev-mode-enabled (constantly true)]
+     ~@body))
 
 ;;; ------------------------------------------------ Auth & Permissions ------------------------------------------------
 
@@ -180,32 +185,33 @@
 
 (deftest dev-url-security-test
   (mt/with-premium-features #{:custom-viz}
-    (mt/with-temp [:model/CustomVizPlugin {id :id} {:repo_url     "https://github.com/test/dev-sec"
-                                                    :identifier   "dev-sec"
-                                                    :display_name "dev-sec"
-                                                    :status       :active}]
-      (testing "SECURITY: rejects file:// dev URL via API"
-        (is (= 400
-               (:status-code
-                (ex-data
-                 (try
-                   (cache/set-or-clear-dev-bundle! id "file:///etc/passwd")
-                   (catch Exception e e)))))))
-      (testing "SECURITY: rejects ftp:// dev URL via API"
-        (is (= 400
-               (:status-code
-                (ex-data
-                 (try
-                   (cache/set-or-clear-dev-bundle! id "ftp://evil.com/bundle")
-                   (catch Exception e e)))))))
-      (testing "admin can set valid http dev URL"
-        (let [resp (mt/user-http-request :crowberto :put 200 (str "ee/custom-viz-plugin/" id "/dev-url")
-                                         {:dev_bundle_url "http://localhost:5174"})]
-          (is (= "http://localhost:5174" (:dev_bundle_url resp)))))
-      (testing "admin can clear dev URL"
-        (let [resp (mt/user-http-request :crowberto :put 200 (str "ee/custom-viz-plugin/" id "/dev-url")
-                                         {:dev_bundle_url nil})]
-          (is (nil? (:dev_bundle_url resp))))))))
+    (with-dev-mode-enabled
+      (mt/with-temp [:model/CustomVizPlugin {id :id} {:repo_url     "https://github.com/test/dev-sec"
+                                                      :identifier   "dev-sec"
+                                                      :display_name "dev-sec"
+                                                      :status       :active}]
+        (testing "SECURITY: rejects file:// dev URL via API"
+          (is (= 400
+                 (:status-code
+                  (ex-data
+                   (try
+                     (cache/set-or-clear-dev-bundle! id "file:///etc/passwd")
+                     (catch Exception e e)))))))
+        (testing "SECURITY: rejects ftp:// dev URL via API"
+          (is (= 400
+                 (:status-code
+                  (ex-data
+                   (try
+                     (cache/set-or-clear-dev-bundle! id "ftp://evil.com/bundle")
+                     (catch Exception e e)))))))
+        (testing "admin can set valid http dev URL"
+          (let [resp (mt/user-http-request :crowberto :put 200 (str "ee/custom-viz-plugin/" id "/dev-url")
+                                           {:dev_bundle_url "http://localhost:5174"})]
+            (is (= "http://localhost:5174" (:dev_bundle_url resp)))))
+        (testing "admin can clear dev URL"
+          (let [resp (mt/user-http-request :crowberto :put 200 (str "ee/custom-viz-plugin/" id "/dev-url")
+                                           {:dev_bundle_url nil})]
+            (is (nil? (:dev_bundle_url resp)))))))))
 
 ;;; ------------------------------------------------ Asset Endpoint Security ------------------------------------------------
 
@@ -288,39 +294,40 @@
 
 (deftest register-dev-plugin-test
   (mt/with-premium-features #{:custom-viz}
-    (mt/with-model-cleanup [:model/CustomVizPlugin]
-      (testing "dev plugin registration with manifest name"
-        (with-redefs [cache/fetch-dev-manifest (constantly {:name "dev-chart" :icon "icon.svg"})
-                      cache/set-or-clear-dev-bundle! (constantly nil)]
-          (let [resp (mt/user-http-request :crowberto :post 200 "ee/custom-viz-plugin/dev"
-                                           {:dev_bundle_url "http://localhost:5174"})]
-            (is (= "dev-chart" (:identifier resp)))
-            (is (= "dev-chart" (:display_name resp))
-                "display_name comes from manifest name")
-            (is (true? (:dev_only resp))
-                "dev-registered plugins are dev-only")
-            (is (= "active" (:status resp))
-                "dev plugins are immediately active"))))
-      (testing "dev plugin registration with explicit identifier overrides manifest"
-        (with-redefs [cache/fetch-dev-manifest (constantly {:name "manifest-name"})
-                      cache/set-or-clear-dev-bundle! (constantly nil)]
-          (let [resp (mt/user-http-request :crowberto :post 200 "ee/custom-viz-plugin/dev"
-                                           {:dev_bundle_url "http://localhost:5174"
-                                            :identifier     "my-override"})]
-            (is (= "my-override" (:identifier resp))
-                "explicit identifier takes precedence over manifest name"))))
-      (testing "dev plugin registration fails with helpful message when no identifier and no manifest"
-        (with-redefs [cache/fetch-dev-manifest (constantly nil)]
-          (let [resp (mt/user-http-request :crowberto :post 400 "ee/custom-viz-plugin/dev"
-                                           {:dev_bundle_url "http://localhost:5174"})]
-            (is (str/includes? resp "metabase-plugin.json")
-                "error should mention the manifest file"))))
-      (testing "dev plugin registration fails with helpful message when manifest missing name"
-        (with-redefs [cache/fetch-dev-manifest (constantly {:icon "icon.svg"})]
-          (let [resp (mt/user-http-request :crowberto :post 400 "ee/custom-viz-plugin/dev"
-                                           {:dev_bundle_url "http://localhost:5174"})]
-            (is (str/includes? resp "name")
-                "error should mention the missing name field")))))))
+    (with-dev-mode-enabled
+      (mt/with-model-cleanup [:model/CustomVizPlugin]
+        (testing "dev plugin registration with manifest name"
+          (with-redefs [cache/fetch-dev-manifest (constantly {:name "dev-chart" :icon "icon.svg"})
+                        cache/set-or-clear-dev-bundle! (constantly nil)]
+            (let [resp (mt/user-http-request :crowberto :post 200 "ee/custom-viz-plugin/dev"
+                                             {:dev_bundle_url "http://localhost:5174"})]
+              (is (= "dev-chart" (:identifier resp)))
+              (is (= "dev-chart" (:display_name resp))
+                  "display_name comes from manifest name")
+              (is (true? (:dev_only resp))
+                  "dev-registered plugins are dev-only")
+              (is (= "active" (:status resp))
+                  "dev plugins are immediately active"))))
+        (testing "dev plugin registration with explicit identifier overrides manifest"
+          (with-redefs [cache/fetch-dev-manifest (constantly {:name "manifest-name"})
+                        cache/set-or-clear-dev-bundle! (constantly nil)]
+            (let [resp (mt/user-http-request :crowberto :post 200 "ee/custom-viz-plugin/dev"
+                                             {:dev_bundle_url "http://localhost:5174"
+                                              :identifier     "my-override"})]
+              (is (= "my-override" (:identifier resp))
+                  "explicit identifier takes precedence over manifest name"))))
+        (testing "dev plugin registration fails with helpful message when no identifier and no manifest"
+          (with-redefs [cache/fetch-dev-manifest (constantly nil)]
+            (let [resp (mt/user-http-request :crowberto :post 400 "ee/custom-viz-plugin/dev"
+                                             {:dev_bundle_url "http://localhost:5174"})]
+              (is (str/includes? resp "metabase-plugin.json")
+                  "error should mention the manifest file"))))
+        (testing "dev plugin registration fails with helpful message when manifest missing name"
+          (with-redefs [cache/fetch-dev-manifest (constantly {:icon "icon.svg"})]
+            (let [resp (mt/user-http-request :crowberto :post 400 "ee/custom-viz-plugin/dev"
+                                             {:dev_bundle_url "http://localhost:5174"})]
+              (is (str/includes? resp "name")
+                  "error should mention the missing name field"))))))))
 
 ;;; ------------------------------------------------ Update / Refresh ------------------------------------------------
 
@@ -366,16 +373,17 @@
 
 (deftest refresh-dev-plugin-test
   (mt/with-premium-features #{:custom-viz}
-    (testing "refresh re-fetches manifest for dev-only plugins"
-      (mt/with-temp [:model/CustomVizPlugin {id :id} {:repo_url       "dev://local/dev-refresh"
-                                                      :identifier     "dev-refresh"
-                                                      :display_name   "dev-refresh"
-                                                      :status         :active
-                                                      :dev_bundle_url "http://localhost:5174"}]
-        (with-redefs [cache/resolve-dev-bundle (constantly "http://localhost:5174")
-                      cache/fetch-dev-manifest (constantly {:name "Updated Name" :icon "new-icon.svg"})]
-          (let [resp (mt/user-http-request :crowberto :post 200 (str "ee/custom-viz-plugin/" id "/refresh"))]
-            (is (= "Updated Name" (:display_name resp)))))))))
+    (with-dev-mode-enabled
+      (testing "refresh re-fetches manifest for dev-only plugins"
+        (mt/with-temp [:model/CustomVizPlugin {id :id} {:repo_url       "dev://local/dev-refresh"
+                                                        :identifier     "dev-refresh"
+                                                        :display_name   "dev-refresh"
+                                                        :status         :active
+                                                        :dev_bundle_url "http://localhost:5174"}]
+          (with-redefs [cache/resolve-dev-bundle (constantly "http://localhost:5174")
+                        cache/fetch-dev-manifest (constantly {:name "Updated Name" :icon "new-icon.svg"})]
+            (let [resp (mt/user-http-request :crowberto :post 200 (str "ee/custom-viz-plugin/" id "/refresh"))]
+              (is (= "Updated Name" (:display_name resp))))))))))
 
 ;;; ------------------------------------------------ /list compatibility filtering ------------------------------------------------
 
@@ -449,20 +457,21 @@
 
 (deftest audit-log-create-dev-test
   (mt/with-premium-features #{:custom-viz :audit-app}
-    (mt/with-model-cleanup [:model/CustomVizPlugin]
-      (testing "registering a dev plugin records a custom-viz-plugin-create audit event"
-        (with-redefs [cache/fetch-dev-manifest    (constantly {:name "audit-dev-chart" :icon "icon.svg"})
-                      cache/set-or-clear-dev-bundle! (constantly nil)]
-          (let [resp  (mt/user-http-request :crowberto :post 200 "ee/custom-viz-plugin/dev"
-                                            {:dev_bundle_url "http://localhost:5174"})
-                entry (mt/latest-audit-log-entry "custom-viz-plugin-create" (:id resp))]
-            (is (partial=
-                 {:topic    :custom-viz-plugin-create
-                  :user_id  (mt/user->id :crowberto)
-                  :model    "CustomVizPlugin"
-                  :model_id (:id resp)}
-                 entry))
-            (is (= "audit-dev-chart" (get-in entry [:details :identifier])))))))))
+    (with-dev-mode-enabled
+      (mt/with-model-cleanup [:model/CustomVizPlugin]
+        (testing "registering a dev plugin records a custom-viz-plugin-create audit event"
+          (with-redefs [cache/fetch-dev-manifest    (constantly {:name "audit-dev-chart" :icon "icon.svg"})
+                        cache/set-or-clear-dev-bundle! (constantly nil)]
+            (let [resp  (mt/user-http-request :crowberto :post 200 "ee/custom-viz-plugin/dev"
+                                              {:dev_bundle_url "http://localhost:5174"})
+                  entry (mt/latest-audit-log-entry "custom-viz-plugin-create" (:id resp))]
+              (is (partial=
+                   {:topic    :custom-viz-plugin-create
+                    :user_id  (mt/user->id :crowberto)
+                    :model    "CustomVizPlugin"
+                    :model_id (:id resp)}
+                   entry))
+              (is (= "audit-dev-chart" (get-in entry [:details :identifier]))))))))))
 
 (deftest audit-log-delete-test
   (mt/with-premium-features #{:custom-viz :audit-app}

--- a/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/cache_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/cache_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.test :refer :all]
    [metabase-enterprise.custom-viz-plugin.cache :as cache]
+   [metabase-enterprise.custom-viz-plugin.settings :as custom-viz.settings]
    [metabase-enterprise.remote-sync.source.git :as rs.git]
    [metabase.config.core :as config]
    [metabase.test :as mt]
@@ -165,17 +166,18 @@
 (deftest resolve-bundle-dev-url-takes-precedence-test
   (testing "resolve-bundle prefers dev URL over git when both are available"
     (mt/with-premium-features #{:custom-viz}
-      (mt/with-temp [:model/CustomVizPlugin {id :id} {:repo_url        "https://github.com/test/precedence"
-                                                      :identifier      "precedence"
-                                                      :display_name    "precedence"
-                                                      :status          :active
-                                                      :resolved_commit "abc123"
-                                                      :dev_bundle_url  "http://localhost:5174"}]
-        (let [dev-called? (atom false)
-              git-called? (atom false)]
-          (with-redefs [cache/fetch-dev-bundle (fn [_] (reset! dev-called? true) {:content "dev-js" :hash "d1"})
-                        cache/get-bundle      (fn [_] (reset! git-called? true) {:content "git-js" :hash "g1"})]
-            (let [result (cache/resolve-bundle {:id id})]
-              (is (true? @dev-called?) "dev bundle fetch should be called")
-              (is (false? @git-called?) "git bundle should not be called when dev URL is set")
-              (is (= "dev-js" (:content result))))))))))
+      (with-redefs [custom-viz.settings/custom-viz-plugin-dev-mode-enabled (constantly true)]
+        (mt/with-temp [:model/CustomVizPlugin {id :id} {:repo_url        "https://github.com/test/precedence"
+                                                        :identifier      "precedence"
+                                                        :display_name    "precedence"
+                                                        :status          :active
+                                                        :resolved_commit "abc123"
+                                                        :dev_bundle_url  "http://localhost:5174"}]
+          (let [dev-called? (atom false)
+                git-called? (atom false)]
+            (with-redefs [cache/fetch-dev-bundle (fn [_] (reset! dev-called? true) {:content "dev-js" :hash "d1"})
+                          cache/get-bundle      (fn [_] (reset! git-called? true) {:content "git-js" :hash "g1"})]
+              (let [result (cache/resolve-bundle {:id id})]
+                (is (true? @dev-called?) "dev bundle fetch should be called")
+                (is (false? @git-called?) "git bundle should not be called when dev URL is set")
+                (is (= "dev-js" (:content result)))))))))))

--- a/frontend/src/metabase-types/api/mocks/settings.ts
+++ b/frontend/src/metabase-types/api/mocks/settings.ts
@@ -171,6 +171,7 @@ export const createMockSettings = (
   "analytics-uuid": "eefb3320-1d3f-4686-a22a-1d30ae729525",
   "admin-email": "admin@metabase.test",
   "airgap-enabled": false,
+  "custom-viz-plugin-dev-mode-enabled": false,
   "allowed-iframe-hosts": "*",
   "anon-tracking-enabled": false,
   "application-colors": {},

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -628,6 +628,7 @@ interface PublicSettings {
   version: Version;
   "version-info-last-checked": string | null;
   "airgap-enabled": boolean;
+  "custom-viz-plugin-dev-mode-enabled": boolean;
   "non-table-chart-generated": boolean;
   "use-tenants": boolean;
 }

--- a/frontend/src/metabase/admin/settings/components/SettingsNav/SettingsNav.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsNav/SettingsNav.tsx
@@ -29,6 +29,9 @@ export function SettingsNav() {
   const hasPythonTransforms = useHasTokenFeature("transforms-python");
   const isHosted = useSetting("is-hosted?");
   const hasCustomViz = useHasTokenFeature("custom-viz");
+  const customVizDevModeEnabled = useSetting(
+    "custom-viz-plugin-dev-mode-enabled",
+  );
   const isAdmin = useSelector(getUserIsAdmin);
 
   return (
@@ -84,11 +87,15 @@ export function SettingsNav() {
               path="custom-visualizations"
               label={t`Manage visualizations`}
             />,
-            <SettingsNavItem
-              key="dev"
-              path="custom-visualizations/development"
-              label={t`Development`}
-            />,
+            ...(customVizDevModeEnabled
+              ? [
+                  <SettingsNavItem
+                    key="dev"
+                    path="custom-visualizations/development"
+                    label={t`Development`}
+                  />,
+                ]
+              : []),
           ]}
         </SettingsNavItem>
       )}

--- a/frontend/src/metabase/admin/settings/components/SettingsNav/SettingsNav.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsNav/SettingsNav.unit.spec.tsx
@@ -11,6 +11,7 @@ import {
 import {
   createMockSettings,
   createMockTokenFeatures,
+  createMockUser,
   createMockVersionInfo,
 } from "metabase-types/api/mocks";
 
@@ -19,15 +20,19 @@ import { SettingsNav } from "./SettingsNav";
 const setup = async ({
   initialRoute,
   isHosted,
+  customVizDevModeEnabled,
 }: {
   initialRoute: string;
   isHosted?: boolean;
+  customVizDevModeEnabled?: boolean;
 }) => {
   const versionInfo = createMockVersionInfo();
   const settings = createMockSettings({
     "version-info": versionInfo,
+    "custom-viz-plugin-dev-mode-enabled": Boolean(customVizDevModeEnabled),
     "token-features": createMockTokenFeatures({
       hosting: Boolean(isHosted),
+      "custom-viz": true,
     }),
   });
 
@@ -40,6 +45,7 @@ const setup = async ({
     withRouter: true,
     initialRoute,
     storeInitialState: {
+      currentUser: createMockUser({ is_superuser: true }),
       routing: createMockRoutingState({
         locationBeforeTransitions: createMockLocation({
           pathname: initialRoute,
@@ -122,5 +128,34 @@ describe("SettingsNav", () => {
   it("should only show Updates nav item when hosted", async () => {
     await setup({ initialRoute: "/admin/settings/general", isHosted: true });
     expect(screen.queryByText("Updates")).not.toBeInTheDocument();
+  });
+
+  it("should show Development nav item when custom viz dev mode is enabled", async () => {
+    await setup({
+      initialRoute: "/admin/settings/custom-visualizations",
+      customVizDevModeEnabled: true,
+    });
+
+    const customVizNavItem = await screen.findByRole("link", {
+      name: /Custom visualizations/,
+    });
+    await userEvent.click(customVizNavItem);
+
+    expect(screen.getByText("Development")).toBeInTheDocument();
+  });
+
+  it("should hide Development nav item when custom viz dev mode is disabled", async () => {
+    await setup({
+      initialRoute: "/admin/settings/custom-visualizations",
+      customVizDevModeEnabled: false,
+    });
+
+    const customVizNavItem = await screen.findByRole("link", {
+      name: /Custom visualizations/,
+    });
+    await userEvent.click(customVizNavItem);
+
+    expect(screen.getByText("Manage visualizations")).toBeInTheDocument();
+    expect(screen.queryByText("Development")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/CustomVisualizationsSettingsPage.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/CustomVisualizationsSettingsPage.tsx
@@ -2,7 +2,7 @@ import { t } from "ttag";
 
 import { SettingsPageWrapper } from "metabase/admin/components/SettingsSection";
 import { UpsellCustomViz } from "metabase/admin/upsells";
-import { useHasTokenFeature } from "metabase/common/hooks";
+import { useHasTokenFeature, useSetting } from "metabase/common/hooks";
 import { PLUGIN_CUSTOM_VIZ } from "metabase/plugins";
 
 export function CustomVisualizationsManagePage() {
@@ -39,6 +39,7 @@ export function CustomVisualizationsFormPage({
 
 export function CustomVisualizationsDevelopmentPage() {
   const hasCustomViz = useHasTokenFeature("custom-viz");
+  const devModeEnabled = useSetting("custom-viz-plugin-dev-mode-enabled");
 
   if (!hasCustomViz) {
     return (
@@ -46,6 +47,10 @@ export function CustomVisualizationsDevelopmentPage() {
         <UpsellCustomViz location="settings-custom-viz" />
       </SettingsPageWrapper>
     );
+  }
+
+  if (!devModeEnabled) {
+    return null;
   }
 
   return <PLUGIN_CUSTOM_VIZ.CustomVizDevPage />;


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-2289/gate-dev-plugin-feature-behind-environment-variable

Enable via `MB_CUSTOM_VIZ_PLUGIN_DEV_MODE_ENABLED=true`