### PR TITLE
update copy in Enable Transforms Page based on plan

### DIFF
--- a/frontend/src/metabase/transforms/pages/EnableTransformsPage/EnableTransformsPage.tsx
+++ b/frontend/src/metabase/transforms/pages/EnableTransformsPage/EnableTransformsPage.tsx
@@ -1,9 +1,11 @@
 import { t } from "ttag";
 
 import { useUpdateSettingMutation } from "metabase/api";
+import { getPlan } from "metabase/common/utils/plan";
 import { DataStudioBreadcrumbs } from "metabase/data-studio/common/components/DataStudioBreadcrumbs";
 import { PageContainer } from "metabase/data-studio/common/components/PageContainer";
 import { PaneHeader } from "metabase/data-studio/common/components/PaneHeader";
+import { getSetting } from "metabase/selectors/settings";
 import { getUserIsAdmin } from "metabase/selectors/user";
 import {
   Button,
@@ -20,6 +22,13 @@ import {
 import { useSelector } from "metabase/utils/redux";
 export const EnableTransformsPage = () => {
   const isAdmin = useSelector(getUserIsAdmin);
+  const plan = useSelector((state) =>
+    getPlan(getSetting(state, "token-features")),
+  );
+  const permissionsDescription =
+    plan === "pro-self-hosted"
+      ? t`Only Analysts and Admins can create and run transforms`
+      : t`Only Admins can create and run transforms`;
 
   const [updateSetting, { isLoading: updateSettingLoading }] =
     useUpdateSettingMutation();
@@ -75,7 +84,7 @@ export const EnableTransformsPage = () => {
             <SimpleCard
               icon="lock"
               title={t`Permissioned`}
-              description={t`Only Admins can create and run transforms`}
+              description={permissionsDescription}
             />
           </SimpleGrid>
         </Card>

--- a/frontend/src/metabase/transforms/pages/EnableTransformsPage/EnableTransformsPage.unit.spec.tsx
+++ b/frontend/src/metabase/transforms/pages/EnableTransformsPage/EnableTransformsPage.unit.spec.tsx
@@ -1,0 +1,64 @@
+import { Route } from "react-router";
+
+import {
+  setupPropertiesEndpoints,
+  setupUserMetabotPermissionsEndpoint,
+} from "__support__/server-mocks";
+import { mockSettings } from "__support__/settings";
+import { renderWithProviders, screen } from "__support__/ui";
+import { createMockState } from "metabase/redux/store/mocks";
+import type { TokenFeatures } from "metabase-types/api";
+import {
+  createMockSettings,
+  createMockTokenFeatures,
+  createMockUser,
+} from "metabase-types/api/mocks";
+
+import { EnableTransformsPage } from "./EnableTransformsPage";
+
+type SetupOpts = {
+  isAdmin?: boolean;
+  tokenFeatures?: Partial<TokenFeatures>;
+};
+
+const setup = ({ isAdmin = true, tokenFeatures = {} }: SetupOpts = {}) => {
+  setupPropertiesEndpoints(createMockSettings());
+  setupUserMetabotPermissionsEndpoint();
+  const state = createMockState({
+    currentUser: createMockUser({ is_superuser: isAdmin }),
+    settings: mockSettings({
+      "token-features": createMockTokenFeatures(tokenFeatures),
+    }),
+  });
+
+  const path = "/transforms";
+  renderWithProviders(<Route path={path} component={EnableTransformsPage} />, {
+    storeInitialState: state,
+    withRouter: true,
+    initialRoute: path,
+  });
+};
+
+const ADMINS_ONLY_COPY = "Only Admins can create and run transforms";
+const ANALYSTS_AND_ADMINS_COPY =
+  "Only Analysts and Admins can create and run transforms";
+
+describe("EnableTransformsPage", () => {
+  describe("Permissioned card copy", () => {
+    it("shows admins-only copy on OSS", () => {
+      setup({ tokenFeatures: {} });
+
+      expect(screen.getByText(ADMINS_ONLY_COPY)).toBeInTheDocument();
+      expect(
+        screen.queryByText(ANALYSTS_AND_ADMINS_COPY),
+      ).not.toBeInTheDocument();
+    });
+
+    it("shows analysts-and-admins copy on Pro self-hosted", () => {
+      setup({ tokenFeatures: { advanced_permissions: true } });
+
+      expect(screen.getByText(ANALYSTS_AND_ADMINS_COPY)).toBeInTheDocument();
+      expect(screen.queryByText(ADMINS_ONLY_COPY)).not.toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
### Description
Updated the copy in the Enable Transforms Page to include the data analyst group in applicable plans

### How to verify
1. Ensure that transforms are not yet enabled, and  Start up metabase in OSS (run `update setting set value='false' where key = 'transforms-enabled'` on your app DB to disable)
2. Go to the transforms page in data studio, and in the permissions box you should see that it includes admins, but no mention of data analysts
3. Give a self hosted license key and go back to the page. It should now mention `admins + data analysts`


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
