### PR TITLE
Fix duplicated dimensions in Metrics Viewer tab picker and incorrect 'Multiple dimensions' label

### DIFF
--- a/e2e/test/scenarios/metrics/metrics-explorer.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/metrics-explorer.cy.spec.ts
@@ -915,7 +915,11 @@ describe("scenarios > metrics > explorer", () => {
     });
 
     it("should not show dimensions that are already in tabs in the dimension picker", () => {
-      addMetric("Count of products");
+      addMetricMath([
+        { metricName: "Count of orders" },
+        "+",
+        { metricName: "Count of products" },
+      ]);
       cy.wait("@dataset");
       H.MetricsViewer.tabsShouldBe([
         "Created At",
@@ -932,6 +936,16 @@ describe("scenarios > metrics > explorer", () => {
         cy.findByText("State").should("not.exist");
         cy.findByText("Title").should("not.exist");
         cy.findByText("Category").should("not.exist");
+
+        // metric math should not cause dimensions to be repeated
+        cy.findAllByText("Birth Date").should("have.length", 1);
+
+        cy.findByText("Rating").click();
+      });
+
+      H.MetricsViewer.getDimensionPillContainer().within(() => {
+        cy.findAllByText("Product → Rating").should("exist");
+        cy.findAllByText("Multiple dimensions").should("not.exist");
       });
     });
 

--- a/e2e/test/scenarios/metrics/metrics-explorer.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/metrics-explorer.cy.spec.ts
@@ -774,9 +774,7 @@ describe("scenarios > metrics > explorer", () => {
       H.popover().findAllByTestId("expression-metric-header").eq(1).click();
 
       H.popover().within(() => {
-        cy.get("[data-element-id=list-item][aria-selected=false]")
-          .contains(/Created At/)
-          .click();
+        cy.findByText("Birth Date").click();
       });
 
       cy.wait("@dataset");
@@ -811,9 +809,7 @@ describe("scenarios > metrics > explorer", () => {
 
       // Pick a non-default dimension (e.g. "Created At" for Products)
       H.popover().within(() => {
-        cy.get("[data-element-id=list-item][aria-selected=false]")
-          .contains(/Created At/)
-          .click();
+        cy.findByText("Birth Date").click();
       });
 
       cy.wait("@dataset");

--- a/frontend/src/metabase/metrics-viewer/components/DimensionPillBar/DimensionPillBar.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/DimensionPillBar/DimensionPillBar.tsx
@@ -28,6 +28,7 @@ export interface ExpressionMetricSource {
   metricName: string;
   metricCount?: number;
   colors?: string[];
+  currentDimension?: DimensionMetadata;
   currentDimensionLabel?: string;
   currentDimensionIcon?: IconName;
   availableOptions: DimensionOption[];

--- a/frontend/src/metabase/metrics-viewer/hooks/use-metrics-viewer.ts
+++ b/frontend/src/metabase/metrics-viewer/hooks/use-metrics-viewer.ts
@@ -294,10 +294,11 @@ export function useMetricsViewer({
     () =>
       getAvailableDimensionsForPicker(
         definitionsBySourceId,
+        sourceOrder,
         metricSlots,
         existingTabDimensionIds,
       ),
-    [definitionsBySourceId, metricSlots, existingTabDimensionIds],
+    [definitionsBySourceId, sourceOrder, metricSlots, existingTabDimensionIds],
   );
 
   const addMetric = useCallback(

--- a/frontend/src/metabase/metrics-viewer/utils/__tests__/test-helpers.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/__tests__/test-helpers.ts
@@ -33,6 +33,7 @@ export const REVENUE_METRIC = createMockNormalizedMetric({
       display_name: "Created At",
       effective_type: "type/DateTime",
       semantic_type: "type/CreationTimestamp",
+      sources: [{ type: "field", "field-id": 1 }],
     }),
     createMockMetricDimension({
       id: "dim-category",
@@ -95,6 +96,7 @@ export const GEO_METRIC = createMockNormalizedMetric({
       display_name: "Created At",
       effective_type: "type/DateTime",
       semantic_type: "type/CreationTimestamp",
+      sources: [{ type: "field", "field-id": 1 }],
     }),
   ],
 });

--- a/frontend/src/metabase/metrics-viewer/utils/dimension-picker.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/dimension-picker.ts
@@ -37,18 +37,17 @@ interface DimensionEntry {
   tabType: MetricsViewerTabType;
   group?: DimensionGroup;
   sourceId: MetricSourceId;
-  slotIndex: number;
 }
 
 function collectAllDimensionEntries(
-  metricSlots: MetricSlot[],
+  sourceOrder: MetricSourceId[],
   definitionsBySourceId: Record<MetricSourceId, MetricDefinition | null>,
   existingTabDimensionIds: Set<string>,
 ): DimensionEntry[] {
   const entries: DimensionEntry[] = [];
 
-  for (const slot of metricSlots) {
-    const def = definitionsBySourceId[slot.sourceId];
+  for (const sourceId of sourceOrder) {
+    const def = definitionsBySourceId[sourceId];
     if (!def) {
       continue;
     }
@@ -65,8 +64,7 @@ function collectAllDimensionEntries(
         icon: getDimensionIcon(info.dimensionMetadata),
         tabType: info.dimensionType,
         group: info.group,
-        sourceId: slot.sourceId,
-        slotIndex: slot.slotIndex,
+        sourceId,
       });
     }
   }
@@ -95,17 +93,18 @@ function groupBySource(entries: DimensionEntry[]): DimensionEntry[][] {
 
 export function getAvailableDimensionsForPicker(
   definitionsBySourceId: Record<MetricSourceId, MetricDefinition | null>,
+  sourceOrder: MetricSourceId[],
   metricSlots: MetricSlot[],
   existingTabDimensionIds: Set<string>,
 ): AvailableDimensionsResult {
   const result: AvailableDimensionsResult = { shared: [], bySource: {} };
 
-  if (metricSlots.length === 0) {
+  if (sourceOrder.length === 0) {
     return result;
   }
 
   const entries = collectAllDimensionEntries(
-    metricSlots,
+    sourceOrder,
     definitionsBySourceId,
     existingTabDimensionIds,
   );
@@ -113,6 +112,18 @@ export function getAvailableDimensionsForPicker(
   const loadedSourceCount = new Set(entries.map((entry) => entry.sourceId))
     .size;
   const hasMultipleSources = loadedSourceCount > 1;
+
+  const sourceIdToSlotIndices = metricSlots.reduce(
+    (acc, slot) => {
+      if (acc[slot.sourceId]) {
+        acc[slot.sourceId].push(slot.slotIndex);
+      } else {
+        acc[slot.sourceId] = [slot.slotIndex];
+      }
+      return acc;
+    },
+    {} as Record<MetricSourceId, number[]>,
+  );
 
   for (const group of groups) {
     const uniqueSources = [...new Set(group.map((entry) => entry.sourceId))];
@@ -126,7 +137,12 @@ export function getAvailableDimensionsForPicker(
           type: first.tabType,
           label: first.label,
           dimensionMapping: Object.fromEntries(
-            group.map((entry) => [entry.slotIndex, entry.id]),
+            group.flatMap((entry) =>
+              (sourceIdToSlotIndices[entry.sourceId] ?? []).map((slotIndex) => [
+                slotIndex,
+                entry.id,
+              ]),
+            ),
           ),
         },
       });
@@ -139,7 +155,12 @@ export function getAvailableDimensionsForPicker(
           tabInfo: {
             type: entry.tabType,
             label: entry.label,
-            dimensionMapping: { [entry.slotIndex]: entry.id },
+            dimensionMapping: Object.fromEntries(
+              (sourceIdToSlotIndices[entry.sourceId] ?? []).map((slotIndex) => [
+                slotIndex,
+                entry.id,
+              ]),
+            ),
           },
         });
       }
@@ -149,8 +170,8 @@ export function getAvailableDimensionsForPicker(
   result.shared.sort((first, second) =>
     first.tabInfo.label.localeCompare(second.tabInfo.label),
   );
-  for (const slot of metricSlots) {
-    result.bySource[slot.sourceId]?.sort((first, second) =>
+  for (const sourceId of sourceOrder) {
+    result.bySource[sourceId]?.sort((first, second) =>
       first.tabInfo.label.localeCompare(second.tabInfo.label),
     );
   }

--- a/frontend/src/metabase/metrics-viewer/utils/dimension-picker.unit.spec.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/dimension-picker.unit.spec.ts
@@ -97,7 +97,7 @@ const ORDERS_DIMENSIONS = [
 
 describe("getAvailableDimensionsForPicker", () => {
   it("returns empty result for empty source order", () => {
-    const result = getAvailableDimensionsForPicker({}, [], new Set());
+    const result = getAvailableDimensionsForPicker({}, [], [], new Set());
 
     expect(result).toEqual({ shared: [], bySource: {} });
   });
@@ -105,6 +105,7 @@ describe("getAvailableDimensionsForPicker", () => {
   it("returns dimensions for a single metric source", () => {
     const result = getAvailableDimensionsForPicker(
       { [REVENUE_SOURCE_ID]: revenueDefinition },
+      [REVENUE_SOURCE_ID],
       [{ slotIndex: 0, entityIndex: 0, sourceId: REVENUE_SOURCE_ID }],
       new Set(),
     );
@@ -120,6 +121,7 @@ describe("getAvailableDimensionsForPicker", () => {
   it("returns dimensions for a second metric source", () => {
     const result = getAvailableDimensionsForPicker(
       { [ORDERS_SOURCE_ID]: ordersDefinition },
+      [ORDERS_SOURCE_ID],
       [{ slotIndex: 0, entityIndex: 0, sourceId: ORDERS_SOURCE_ID }],
       new Set(),
     );
@@ -138,6 +140,7 @@ describe("getAvailableDimensionsForPicker", () => {
         [REVENUE_SOURCE_ID]: revenueDefinition,
         [ORDERS_SOURCE_ID]: ordersDefinition,
       },
+      [REVENUE_SOURCE_ID, ORDERS_SOURCE_ID],
       [
         { slotIndex: 0, entityIndex: 0, sourceId: REVENUE_SOURCE_ID },
         { slotIndex: 1, entityIndex: 1, sourceId: ORDERS_SOURCE_ID },
@@ -173,6 +176,32 @@ describe("getAvailableDimensionsForPicker", () => {
     });
   });
 
+  it("does not duplicate dimensions when a metric appears in multiple slots", () => {
+    const result = getAvailableDimensionsForPicker(
+      { [REVENUE_SOURCE_ID]: revenueDefinition },
+      [REVENUE_SOURCE_ID],
+      [
+        { slotIndex: 0, entityIndex: 0, sourceId: REVENUE_SOURCE_ID },
+        { slotIndex: 1, entityIndex: 1, sourceId: REVENUE_SOURCE_ID },
+      ],
+      new Set(),
+    );
+
+    const allDimensions = result.bySource[REVENUE_SOURCE_ID] ?? [];
+    expect(allDimensions).toHaveLength(REVENUE_DIMENSIONS.length);
+
+    const labels = allDimensions.map((d) => d.tabInfo.label);
+    expect(labels).toEqual([...new Set(labels)]);
+
+    for (const dim of allDimensions) {
+      const dimId = Object.values(dim.tabInfo.dimensionMapping)[0];
+      expect(dim.tabInfo.dimensionMapping).toEqual({
+        0: dimId,
+        1: dimId,
+      });
+    }
+  });
+
   it("filters out dimensions whose id matches existingTabDimensionIds", () => {
     const allIds = REVENUE_DIMENSIONS.flatMap((dimension) =>
       Object.values(dimension.tabInfo.dimensionMapping),
@@ -180,6 +209,7 @@ describe("getAvailableDimensionsForPicker", () => {
 
     const result = getAvailableDimensionsForPicker(
       { [REVENUE_SOURCE_ID]: revenueDefinition },
+      [REVENUE_SOURCE_ID],
       [{ slotIndex: 0, entityIndex: 0, sourceId: REVENUE_SOURCE_ID }],
       new Set(allIds),
     );

--- a/frontend/src/metabase/metrics-viewer/utils/series.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/series.ts
@@ -9,13 +9,14 @@ import type {
 } from "metabase/metrics-viewer/components/DimensionPillBar";
 import type { IconName } from "metabase/ui";
 import { getColorsForValues } from "metabase/ui/colors/charts";
+import { isNotNull } from "metabase/utils/types";
 import { getColorplethColorScale } from "metabase/visualizations/components/ChoroplethMap";
 import {
   formatBreakoutValue,
   getBreakoutSeriesName,
 } from "metabase/visualizations/echarts/cartesian/model/series";
 import { MAX_SERIES } from "metabase/visualizations/lib/utils";
-import type { MetricDefinition } from "metabase-lib/metric";
+import type { DimensionMetadata, MetricDefinition } from "metabase-lib/metric";
 import * as LibMetric from "metabase-lib/metric";
 import type {
   Card,
@@ -692,16 +693,22 @@ export function buildDimensionItemsFromDefinitions(
       );
 
       // Derive aggregate label and icon from selected dimensions.
-      const selectedLabels = metricSources
-        .map((s) => s.currentDimensionLabel)
-        .filter(Boolean);
-      const uniqueLabels = [...new Set(selectedLabels)];
-      const label =
-        uniqueLabels.length === 1
-          ? uniqueLabels[0]
-          : uniqueLabels.length > 1
-            ? t`Multiple dimensions`
-            : undefined;
+      const selectedDimensions = metricSources
+        .map((s) => s.currentDimension)
+        .filter(isNotNull);
+      const allSameDimension =
+        selectedDimensions.length > 0 &&
+        selectedDimensions.every((d) =>
+          LibMetric.isSameSource(d, selectedDimensions[0]),
+        );
+      let label: string | undefined;
+      if (allSameDimension) {
+        label = metricSources.find(
+          (s) => s.currentDimensionLabel,
+        )?.currentDimensionLabel;
+      } else if (selectedDimensions.length > 1) {
+        label = t`Multiple dimensions`;
+      }
       const selectedIcons = metricSources
         .map((s) => s.currentDimensionIcon)
         .filter(Boolean);
@@ -846,21 +853,21 @@ function buildExpressionMetricSources(
         ) ?? undefined;
     }
 
+    let currentDimension: DimensionMetadata | undefined;
     let currentDimensionLabel: string | undefined;
     let currentDimensionIcon: IconName | undefined;
     if (dimensionId != null && modifiedDefinition) {
       const projections = LibMetric.projections(modifiedDefinition);
       if (projections.length > 0) {
-        const projDim = LibMetric.projectionDimension(
-          modifiedDefinition,
-          projections[0],
-        );
-        if (projDim) {
+        currentDimension =
+          LibMetric.projectionDimension(modifiedDefinition, projections[0]) ??
+          undefined;
+        if (currentDimension) {
           currentDimensionLabel = LibMetric.displayInfo(
             modifiedDefinition,
-            projDim,
+            currentDimension,
           ).longDisplayName;
-          currentDimensionIcon = getDimensionIcon(projDim);
+          currentDimensionIcon = getDimensionIcon(currentDimension);
         }
       }
     }
@@ -878,6 +885,7 @@ function buildExpressionMetricSources(
           return token?.type === "metric" ? token.count : undefined;
         })(),
         colors: entryColors,
+        currentDimension,
         currentDimensionLabel,
         currentDimensionIcon,
         availableOptions: computeAvailableOptions(

--- a/frontend/src/metabase/metrics-viewer/utils/series.unit.spec.ts
+++ b/frontend/src/metabase/metrics-viewer/utils/series.unit.spec.ts
@@ -8,9 +8,15 @@ import { createMockDatasetData } from "metabase-types/api/mocks/dataset";
 import { ORDERS_ID } from "metabase-types/api/mocks/presets";
 import { createMockSingleSeries } from "metabase-types/api/mocks/series";
 
-import type { BreakoutColorMap, MetricSourceId } from "../types/viewer-state";
+import type { ExpressionDimensionItem } from "../components/DimensionPillBar";
+import type {
+  BreakoutColorMap,
+  MetricSourceId,
+  MetricsViewerFormulaEntity,
+} from "../types/viewer-state";
 
 import {
+  GEO_METRIC,
   REVENUE_METRIC,
   TOTAL_MEASURE,
   createMetricMetadata,
@@ -21,6 +27,7 @@ import {
 } from "./__tests__/test-helpers";
 import {
   buildCartesianVizSettings,
+  buildDimensionItemsFromDefinitions,
   computeBreakoutColorSettings,
   computeColorVizSettings,
   computeSourceBreakoutColors,
@@ -737,5 +744,138 @@ describe("getSelectedMetricsInfo", () => {
         tableId: ORDERS_ID,
       },
     ]);
+  });
+});
+
+describe("buildDimensionItemsFromDefinitions", () => {
+  const revenueMetadata = createMetricMetadata([REVENUE_METRIC]);
+  const revenueDefinition = setupDefinition(revenueMetadata, REVENUE_METRIC.id);
+  const revenueSourceId: MetricSourceId = `metric:${REVENUE_METRIC.id}`;
+  const revenueProjected = setupDefinitionWithBreakout(
+    revenueMetadata,
+    REVENUE_METRIC.id,
+    0,
+  );
+  const geoMetadata = createMetricMetadata([GEO_METRIC]);
+  const geoDefinition = setupDefinition(geoMetadata, GEO_METRIC.id);
+  const geoSourceId: MetricSourceId = `metric:${GEO_METRIC.id}`;
+  const definitions = {
+    [revenueSourceId]: {
+      id: revenueSourceId,
+      definition: revenueDefinition,
+    },
+    [geoSourceId]: {
+      id: geoSourceId,
+      definition: geoDefinition,
+    },
+  };
+  const emptyProjectionConfig = {};
+
+  describe("standalone metric entities", () => {
+    it("produces a metric item with label when a dimension is selected", () => {
+      const dimensionMapping = { 0: "dim-created-at" };
+      const modifiedDefinitionsBySlotIndex = new Map([[0, revenueProjected]]);
+      const sourceColors = { 0: ["#509EE3"] };
+      const metricSlots = [
+        { slotIndex: 0, entityIndex: 0, sourceId: revenueSourceId },
+      ];
+      const formulaEntities: MetricsViewerFormulaEntity[] = [
+        {
+          id: revenueSourceId,
+          type: "metric",
+          definition: revenueDefinition,
+        },
+      ];
+      const items = buildDimensionItemsFromDefinitions(
+        definitions,
+        dimensionMapping,
+        modifiedDefinitionsBySlotIndex,
+        sourceColors,
+        metricSlots,
+        formulaEntities,
+        emptyProjectionConfig,
+      );
+
+      expect(items).toHaveLength(1);
+      expect(items[0].type).toBe("metric");
+      expect(items[0].label).toBe("Created At");
+      expect(items[0].icon).toBeDefined();
+    });
+  });
+
+  describe("expression entities", () => {
+    const formulaEntities: MetricsViewerFormulaEntity[] = [
+      {
+        id: "expression:test",
+        type: "expression",
+        name: "Test Expression",
+        tokens: [
+          {
+            type: "metric",
+            sourceId: revenueSourceId,
+            count: 1,
+          },
+          {
+            type: "operator",
+            op: "+",
+          },
+          {
+            type: "metric",
+            sourceId: geoSourceId,
+            count: 1,
+          },
+        ],
+      },
+    ];
+    const sourceColors = { 0: ["#509EE3"] };
+    const metricSlots = [
+      { slotIndex: 0, entityIndex: 0, sourceId: revenueSourceId },
+      { slotIndex: 1, entityIndex: 0, sourceId: geoSourceId },
+    ];
+    // modifiedDefinitionsBySlotIndex is not used for expressions
+    // which could be cleaned up. why do we call getModifiedDefinition in buildExpressionMetricSources when we have the modified definitions already?
+    const modifiedDefinitionsBySlotIndex = new Map();
+
+    it("shows a unified label when the dimensions are the same", () => {
+      const dimensionMapping = { 0: "dim-created-at", 1: "dim-created-at" };
+
+      const items = buildDimensionItemsFromDefinitions(
+        definitions,
+        dimensionMapping,
+        modifiedDefinitionsBySlotIndex,
+        sourceColors,
+        metricSlots,
+        formulaEntities,
+        emptyProjectionConfig,
+      );
+
+      expect(items).toHaveLength(1);
+      const expressionItem = items[0] as ExpressionDimensionItem;
+      expect(expressionItem.type).toBe("expression");
+      expect(expressionItem.label).toBe("Created At");
+      expect(expressionItem.icon).toBeDefined();
+      expect(expressionItem.metricSources).toHaveLength(2);
+    });
+
+    it("shows 'multiple dimensions' label when the dimensions are different", () => {
+      const dimensionMapping = { 0: "dim-category", 1: "dim-created-at" };
+
+      const items = buildDimensionItemsFromDefinitions(
+        definitions,
+        dimensionMapping,
+        modifiedDefinitionsBySlotIndex,
+        sourceColors,
+        metricSlots,
+        formulaEntities,
+        emptyProjectionConfig,
+      );
+
+      expect(items).toHaveLength(1);
+      const expressionItem = items[0] as ExpressionDimensionItem;
+      expect(expressionItem.type).toBe("expression");
+      expect(expressionItem.label).toBe("Multiple dimensions");
+      expect(expressionItem.icon).toBeUndefined();
+      expect(expressionItem.metricSources).toHaveLength(2);
+    });
   });
 });


### PR DESCRIPTION
Closes [UXW-3742](https://linear.app/metabase/issue/UXW-3742/fix-dimensions-appearing-multiple-times-in-new-tab-picker)
Closes [UXW-3747](https://linear.app/metabase/issue/UXW-3747/dimensions-pill-shows-multiple-dimensions-even-when-dimensions-are-the)

### Description

Dimensions were being duplicated in the Metrics Viewer tab because we were iterating over `metricSlots` to collect dimensions, and metrics can be duplicated in `metricSlots`. The fix is to use the unique `sourceOrder` while still using `metricSlots` to construct the new tab's `dimensionMapping`.

After adding the tab, the dimension pill sometimes incorrectly showed "Multiple dimensions". This is because we were comparing labels using the dimension's `longDisplayName`, which changes depending on whether the dimension comes from an implicit join. The fix is to compare the dimensions themselves using `LibMetric.isSameSource`.

### How to verify

Follow the steps in the demo video and verify the fixes are working as expected.

### Demo

[Loom](https://www.loom.com/share/e5e6d10b1ec74b15b92a90877e6508ab)

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
