### PR TITLE
fix: handle is-locked for metabase AI provider

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot/api.clj
@@ -6,22 +6,24 @@
    [metabase.metabot.provider-util :as provider-util]
    [metabase.metabot.settings :as metabot.settings]
    [metabase.permissions.core :as perms]
-   [metabase.premium-features.core :as premium-features]))
+   [metabase.premium-features.core :as premium-features]
+   [metabase.util :as u]))
 
 (def ^:private metabot-usage-response-schema
   [:map
+   [:is-locked [:maybe boolean?]]
    [:tokens [:maybe int?]]
    [:updated-at [:maybe :string]]])
 
 (defn- meter-value
   [meters meter-key]
-  (or (some-> meter-key keyword meters)
-      (some-> meter-key meters)))
+  (some-> meter-key keyword meters))
 
 (defn- default-metabase-meter-key
   []
   (some-> metabot.settings/default-metabase-llm-metabot-provider
           provider-util/strip-metabase-prefix
+          u/qualified-name
           (str/replace-first "/" ":")
           (str ":tokens")))
 
@@ -39,5 +41,6 @@
   (perms/check-has-application-permission :setting)
   (let [meter (some-> (premium-features/token-status)
                       meter-entry)]
-    {:tokens     (:meter-value meter)
+    {:is-locked  (:is-locked meter)
+     :tokens     (:meter-value meter)
      :updated-at (:meter-updated-at meter)}))

--- a/enterprise/backend/test/metabase_enterprise/metabot/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot/api_test.clj
@@ -50,7 +50,8 @@
     (with-redefs [premium-features/token-status (constantly {:meters {:anthropic:claude-sonnet-4-6:tokens {:meter-value      12345
                                                                                                            :meter-updated-at "2026-04-02T19:29:12Z"}}})]
       (is (= {:tokens 12345
-              :updated-at "2026-04-02T19:29:12Z"}
+              :updated-at "2026-04-02T19:29:12Z"
+              :is-locked nil}
              (mt/user-http-request :crowberto :get 200 "ee/metabot/usage"))))))
 
 (deftest usage-permissions-test

--- a/enterprise/frontend/src/metabase-enterprise/api/metabot.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/metabot.ts
@@ -3,6 +3,7 @@ import { EnterpriseApi } from "./api";
 export type MetabotUsageResponse = {
   tokens: number | null;
   "updated-at": string | null;
+  "is-locked": boolean;
 };
 
 export const metabotApi = EnterpriseApi.injectEndpoints({

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabaseAIProviderSetup.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabaseAIProviderSetup.tsx
@@ -6,6 +6,7 @@ import { useUpdateMetabotSettingsMutation } from "metabase/api";
 import { getErrorMessage } from "metabase/api/utils";
 import { useSetting } from "metabase/common/hooks";
 import { useMetabotSetupContext } from "metabase/metabot/components/MetabotAdmin/MetabotSetup";
+import { MetabotManagedProviderLimitActions } from "metabase/metabot/components/MetabotManagedProviderLimit";
 import { getStoreUsers } from "metabase/selectors/store-users";
 import {
   Anchor,
@@ -55,10 +56,9 @@ export function MetabaseAIProviderSetup() {
   );
   const hasDeprecatedMetabaseAiProvider =
     !!hasPremiumFeature(METABOT_V3_FEATURE);
+  const isConfigured = !!useSetting("llm-metabot-configured?");
 
   const { isStoreUser, anyStoreUserEmailAddress } = useSelector(getStoreUsers);
-
-  const isConfigured = useSetting("llm-metabot-configured?");
 
   const [updateMetabotSettings, updateMetabotSettingsResult] =
     useUpdateMetabotSettingsMutation();
@@ -155,7 +155,7 @@ export function MetabaseAIProviderSetup() {
     removeCloudAddOn,
   ]);
 
-  const { isLoading } = useMetabotSetupContext(onConnect, onDisconnect);
+  const { isLoading, handleDisconnect, resetProvider, isModal } = useMetabotSetupContext(onConnect, onDisconnect);
 
   const metabaseManagedAiPurchaseError = metabaseManagedAiPurchase.error
     ? getErrorMessage(
@@ -189,6 +189,9 @@ export function MetabaseAIProviderSetup() {
             hasMetabaseManagedAiProviderFeature
           }
           offerMetabaseManagedAi={offerMetabaseManagedAi}
+          isModal={isModal}
+          resetProvider={resetProvider}
+          handleDisconnect={handleDisconnect}
         />
       ) : (
         <>
@@ -295,14 +298,21 @@ function MetabaseManagedProviderCard({
   hasDeprecatedMetabaseAiProvider,
   hasMetabaseManagedAiProviderFeature,
   offerMetabaseManagedAi,
+  isModal,
+  resetProvider,
+  handleDisconnect,
 }: {
   isLoadingPricing: boolean;
   pricing: MetabaseManagedAiPricing | null;
   hasDeprecatedMetabaseAiProvider: boolean;
   hasMetabaseManagedAiProviderFeature: boolean;
   offerMetabaseManagedAi: boolean;
+  isModal: boolean;
+  resetProvider: VoidFunction;
+  handleDisconnect: VoidFunction;
 }) {
   const { data: metabotUsage } = useGetMetabotUsageQuery();
+  const isLocked = metabotUsage?.["is-locked"];
   const totalCost = getMetabaseUsageCost(metabotUsage?.tokens, pricing);
 
   return (
@@ -315,28 +325,48 @@ function MetabaseManagedProviderCard({
           </Text>
         )}
 
-      {hasMetabaseManagedAiProviderFeature && (
-        <>
-          <Text c="text-secondary" lh="1">{t`Current billing cycle`}</Text>
-          <MetabaseUsageRow
-            label={t`Total tokens`}
-            value={formatNumber(metabotUsage?.tokens ?? 0)}
-          />
-          {isLoadingPricing ? (
-            <Flex align="center" justify="space-between" gap="md">
-              <Skeleton h="1rem" w="7rem" />
-              <Box flex={1} h={1} bg="border" />
-              <Skeleton h="1rem" w="8rem" />
-            </Flex>
-          ) : pricing ? (
-            <MetabasePricingRow pricing={pricing} />
-          ) : null}
-          <MetabaseUsageRow
-            label={t`Total cost`}
-            value={formatMetabaseCost(totalCost)}
-          />
-        </>
-      )}
+      {match({
+        hasMetabaseManagedAiProviderFeature,
+        isLocked,
+      })
+        .with({ hasMetabaseManagedAiProviderFeature: false }, () => null)
+        .with({ isLocked: true }, () => (
+          <Flex direction="column" gap="xs">
+            <Text c="text-primary" fw={500} lh={1.4}>
+              {t`You've run out of AI service tokens`}
+            </Text>
+            <Text c="text-secondary" fz="sm" lh={1.4}>
+              {t`You've used all of your included AI service tokens. To keep using AI features you can either end your trial early and start your subscription, or stay in the trial and add your own AI provider API key.`}
+            </Text>
+            <MetabotManagedProviderLimitActions
+              inline
+              mt="sm"
+              onConfigure={isModal ? resetProvider : handleDisconnect}
+            />
+          </Flex>
+        ))
+        .otherwise(() => (
+          <>
+            <Text c="text-secondary" lh="1">{t`Current billing cycle`}</Text>
+            <MetabaseUsageRow
+              label={t`Total tokens`}
+              value={formatNumber(metabotUsage?.tokens ?? 0)}
+            />
+            {!isLoadingPricing && pricing ? (
+              <MetabasePricingRow pricing={pricing} />
+            ) : (
+              <Flex align="center" justify="space-between" gap="md">
+                <Skeleton h="1rem" w="7rem" />
+                <Box flex={1} h={1} bg="border" />
+                <Skeleton h="1rem" w="8rem" />
+              </Flex>
+            )}
+            <MetabaseUsageRow
+              label={t`Total cost`}
+              value={formatMetabaseCost(totalCost)}
+            />
+          </>
+        ))}
     </Stack>
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabaseAIProviderSetup.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabaseAIProviderSetup.tsx
@@ -155,7 +155,8 @@ export function MetabaseAIProviderSetup() {
     removeCloudAddOn,
   ]);
 
-  const { isLoading, handleDisconnect, resetProvider, isModal } = useMetabotSetupContext(onConnect, onDisconnect);
+  const { isLoading, handleDisconnect, resetProvider, isModal } =
+    useMetabotSetupContext(onConnect, onDisconnect);
 
   const metabaseManagedAiPurchaseError = metabaseManagedAiPurchase.error
     ? getErrorMessage(

--- a/frontend/src/metabase/api/ai-streaming/requests.ts
+++ b/frontend/src/metabase/api/ai-streaming/requests.ts
@@ -69,18 +69,25 @@ export async function aiStreamingQuery(
     });
 
     if (!response.ok) {
-      let serverMessage: string | undefined;
+      let responseBody: unknown;
       try {
-        const body = await response.json();
-        if (typeof body?.message === "string") {
-          serverMessage = body.message;
-        }
+        responseBody = await response.json();
       } catch {
         // ignore json parse errors
       }
-      // Throw a string when we have a server message (matches P.string in error handler),
-      // otherwise throw an Error (falls through to the generic default message).
-      throw serverMessage ?? new Error(`Response status: ${response.status}`);
+
+      if (typeof responseBody === "string") {
+        throw { status: response.status, message: responseBody };
+      }
+
+      if (responseBody && typeof responseBody === "object") {
+        throw {
+          status: response.status,
+          ...(responseBody as Record<string, unknown>),
+        };
+      }
+
+      throw new Error(`Response status: ${response.status}`);
     }
 
     if (!response.body) {

--- a/frontend/src/metabase/api/ai-streaming/requests.unit.spec.ts
+++ b/frontend/src/metabase/api/ai-streaming/requests.unit.spec.ts
@@ -100,7 +100,7 @@ describe("ai requests", () => {
         status: 402,
         body: {
           message: "You've used all of your included AI service tokens.",
-          "error-code": "metabase-ai-managed-locked",
+          "error-code": "metabase_ai_managed_locked",
         },
       });
 
@@ -109,7 +109,7 @@ describe("ai requests", () => {
       ).rejects.toMatchObject({
         status: 402,
         message: "You've used all of your included AI service tokens.",
-        "error-code": "metabase-ai-managed-locked",
+        "error-code": "metabase_ai_managed_locked",
       });
     });
 

--- a/frontend/src/metabase/api/ai-streaming/requests.unit.spec.ts
+++ b/frontend/src/metabase/api/ai-streaming/requests.unit.spec.ts
@@ -95,6 +95,24 @@ describe("ai requests", () => {
       ).rejects.toThrow(/Response status: 500/);
     });
 
+    it("preserves structured JSON error responses", async () => {
+      fetchMock.post(`path:${endpoint}`, {
+        status: 402,
+        body: {
+          message: "You've used all of your included AI service tokens.",
+          "error-code": "metabase-ai-managed-locked",
+        },
+      });
+
+      await expect(
+        aiStreamingQuery({ url: endpoint, body: {} }),
+      ).rejects.toMatchObject({
+        status: 402,
+        message: "You've used all of your included AI service tokens.",
+        "error-code": "metabase-ai-managed-locked",
+      });
+    });
+
     it("throw error if no response", async () => {
       mockStreamedEndpoint(endpoint, {
         textChunks: undefined,

--- a/frontend/src/metabase/common/components/UndoListing.styled.tsx
+++ b/frontend/src/metabase/common/components/UndoListing.styled.tsx
@@ -29,8 +29,14 @@ export const ToastCard = styled(Card)<{
   padding: 10px var(--mantine-spacing-md);
   margin-top: var(--mantine-spacing-sm);
   max-width: calc(100vw - 2 * ${LIST_H_MARGINS});
-  background-color: var(--mb-color-background-primary-inverse);
-  color: var(--mb-color-text-secondary-inverse);
+  background-color: ${(props) =>
+    props.dark
+      ? "var(--mb-color-background-primary-inverse)"
+      : "var(--mb-color-background-primary)"};
+  color: ${(props) =>
+    props.dark
+      ? "var(--mb-color-text-secondary-inverse)"
+      : "var(--mb-color-text-primary)"};
   ${({ noBorder }) =>
     noBorder &&
     css`

--- a/frontend/src/metabase/common/components/UndoListing.tsx
+++ b/frontend/src/metabase/common/components/UndoListing.tsx
@@ -92,7 +92,7 @@ function UndoToast({
   return (
     <ToastCard
       ref={undo.ref}
-      dark
+      dark={undo.dark ?? true}
       data-testid="toast-undo"
       color={undo.toastColor}
       role="status"
@@ -100,7 +100,7 @@ function UndoToast({
       className={CS.toast}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
-      style={style}
+      style={{ ...style, ...undo.style }}
     >
       {undo.showProgress && (
         <Progress

--- a/frontend/src/metabase/metabot/components/FixSqlQueryButton/FixSqlQueryButton.tsx
+++ b/frontend/src/metabase/metabot/components/FixSqlQueryButton/FixSqlQueryButton.tsx
@@ -1,5 +1,9 @@
+import { isFulfilled } from "@reduxjs/toolkit";
 import { t } from "ttag";
 
+import { useToast } from "metabase/common/hooks";
+import { getMetabotManagedProviderLimitToastProps } from "metabase/metabot/components/MetabotManagedProviderLimit";
+import { METABOT_ERR_MSG } from "metabase/metabot/constants";
 import {
   useMetabotAgent,
   useMetabotName,
@@ -15,6 +19,7 @@ export function FixSqlQueryButton() {
   const dispatch = useDispatch();
   const { canUseSqlGeneration } = useUserMetabotPermissions();
   const metabotName = useMetabotName();
+  const [sendToast] = useToast();
   const { submitInput, isDoingScience } = useMetabotAgent("sql");
 
   if (!canUseSqlGeneration) {
@@ -25,7 +30,24 @@ export function FixSqlQueryButton() {
     trackQueryFixClicked();
     await dispatch(setIsNativeEditorOpen(true));
     // SQL and error message are included in the context.
-    await submitInput("Fix this SQL query");
+    const action = await submitInput("Fix this SQL query", {
+      preventOpenSidebar: true,
+    });
+
+    if (!isFulfilled(action) || action.payload.success) {
+      return;
+    }
+
+    if (action.payload.errorMessage?.type === "locked") {
+      sendToast(getMetabotManagedProviderLimitToastProps());
+      return;
+    }
+
+    sendToast({
+      icon: "warning",
+      toastColor: "error",
+      message: action.payload.errorMessage?.message ?? METABOT_ERR_MSG.default,
+    });
   };
 
   return (

--- a/frontend/src/metabase/metabot/components/FixSqlQueryButton/FixSqlQueryButton.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/components/FixSqlQueryButton/FixSqlQueryButton.unit.spec.tsx
@@ -1,6 +1,8 @@
 import userEvent from "@testing-library/user-event";
 
 import { renderWithProviders, screen } from "__support__/ui";
+import { useToast } from "metabase/common/hooks/use-toast";
+import { METABOT_ERR_MSG } from "metabase/metabot/constants";
 import {
   useMetabotAgent,
   useUserMetabotPermissions,
@@ -14,6 +16,7 @@ import { FixSqlQueryButton } from "./FixSqlQueryButton";
 
 const mockSubmitInput = jest.fn();
 const mockDispatch = jest.fn();
+const mockSendToast = jest.fn();
 const mockSetIsNativeEditorOpen = jest.fn();
 
 jest.mock("../../analytics", () => ({
@@ -23,6 +26,11 @@ jest.mock("../../analytics", () => ({
 jest.mock("metabase/utils/redux", () => ({
   ...jest.requireActual("metabase/utils/redux"),
   useDispatch: jest.fn(),
+}));
+
+jest.mock("metabase/common/hooks/use-toast", () => ({
+  ...jest.requireActual("metabase/common/hooks/use-toast"),
+  useToast: jest.fn(),
 }));
 
 jest.mock("metabase/metabot/hooks", () => ({
@@ -54,19 +62,20 @@ function setup(options?: {
     submitInput: mockSubmitInput,
     isDoingScience,
   } as any);
+  jest.mocked(useToast).mockReturnValue([mockSendToast, jest.fn()]);
   jest.mocked(useDispatch).mockReturnValue(mockDispatch as any);
   jest
     .mocked(setIsNativeEditorOpen)
     .mockImplementation(mockSetIsNativeEditorOpen as any);
 
-  renderWithProviders(<FixSqlQueryButton />);
+  return renderWithProviders(<FixSqlQueryButton />);
 }
 
 describe("FixSqlQueryButton", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockSubmitInput.mockResolvedValue(undefined);
-    mockDispatch.mockResolvedValue(undefined);
+    mockDispatch.mockImplementation((action) => action);
     mockSetIsNativeEditorOpen.mockReturnValue({
       type: "metabase/qb/SET_IS_NATIVE_EDITOR_OPEN",
       isNativeEditorOpen: true,
@@ -101,7 +110,9 @@ describe("FixSqlQueryButton", () => {
       type: "metabase/qb/SET_IS_NATIVE_EDITOR_OPEN",
       isNativeEditorOpen: true,
     });
-    expect(mockSubmitInput).toHaveBeenCalledWith("Fix this SQL query");
+    expect(mockSubmitInput).toHaveBeenCalledWith("Fix this SQL query", {
+      preventOpenSidebar: true,
+    });
   });
 
   it("should show a loading state while the SQL agent is processing", () => {
@@ -112,5 +123,79 @@ describe("FixSqlQueryButton", () => {
         name: /Have Metabot fix it/,
       }),
     ).toBeDisabled();
+  });
+
+  it("shows the managed-provider lockout toast when SQL fixing is locked", async () => {
+    mockSubmitInput.mockResolvedValue({
+      meta: { requestStatus: "fulfilled", requestId: "1" },
+      payload: {
+        success: false,
+        errorMessage: {
+          type: "locked",
+          message: "unused",
+        },
+      },
+    });
+
+    setup();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /Have Metabot fix it/ }),
+    );
+
+    expect(mockSendToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "metabot-managed-provider-limit",
+        icon: null,
+        timeout: 0,
+        toastColor: "error",
+      }),
+    );
+  });
+
+  it("shows the error when fixing SQL fails", async () => {
+    mockSubmitInput.mockResolvedValue({
+      meta: { requestStatus: "fulfilled", requestId: "1" },
+      payload: {
+        success: false,
+        errorMessage: {
+          type: "alert",
+          message: "Something went wrong",
+        },
+      },
+    });
+
+    setup();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /Have Metabot fix it/ }),
+    );
+
+    expect(mockSendToast).toHaveBeenCalledWith({
+      icon: "warning",
+      toastColor: "error",
+      message: "Something went wrong",
+    });
+  });
+
+  it("falls back to the default Metabot error message when none is returned", async () => {
+    mockSubmitInput.mockResolvedValue({
+      meta: { requestStatus: "fulfilled", requestId: "1" },
+      payload: {
+        success: false,
+      },
+    });
+
+    setup();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /Have Metabot fix it/ }),
+    );
+
+    expect(mockSendToast).toHaveBeenCalledWith({
+      icon: "warning",
+      toastColor: "error",
+      message: METABOT_ERR_MSG.default,
+    });
   });
 });

--- a/frontend/src/metabase/metabot/components/MetabotAdmin/MetabotSetup.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotAdmin/MetabotSetup.tsx
@@ -369,7 +369,7 @@ export function MetabotSetupInner({
         {envSettingName && <SetByEnvVar varName={envSettingName} />}
 
         <Flex justify="end">
-          {match({ isCurrentConfigured, isModal })
+          {match({ isCurrentConfigured, isConnectButtonEnabled, isModal })
             .with({ isModal: true, isCurrentConfigured: true }, () => (
               <Button
                 variant="filled"
@@ -380,46 +380,40 @@ export function MetabotSetupInner({
                 {t`Done`}
               </Button>
             ))
-            .when(
-              () => isCurrentConfigured && isConnectButtonEnabled,
+            .with(
+              { isCurrentConfigured: true, isConnectButtonEnabled: false },
+              () => (
+                <Button
+                  c="danger"
+                  loading={isLoading}
+                  disabled={isLoading}
+                  onClick={async () => {
+                    setIsDisconnecting(true);
+                    try {
+                      await handleDisconnect();
+                    } finally {
+                      setIsDisconnecting(false);
+                    }
+                  }}
+                >
+                  {t`Disconnect`}
+                </Button>
+              ),
+            )
+            .with(
+              { isCurrentConfigured: false },
+              { isCurrentConfigured: true, isConnectButtonEnabled: true },
               () => (
                 <Button
                   variant="filled"
                   loading={isLoading}
-                  disabled={isLoading}
+                  disabled={isLoading || !isConnectButtonEnabled}
                   onClick={handleConnect}
                 >
                   {t`Connect`}
                 </Button>
               ),
             )
-            .with({ isCurrentConfigured: true }, () => (
-              <Button
-                c="danger"
-                loading={isLoading}
-                disabled={isLoading}
-                onClick={async () => {
-                  setIsDisconnecting(true);
-                  try {
-                    await handleDisconnect();
-                  } finally {
-                    setIsDisconnecting(false);
-                  }
-                }}
-              >
-                {t`Disconnect`}
-              </Button>
-            ))
-            .with({ isCurrentConfigured: false }, () => (
-              <Button
-                variant="filled"
-                loading={isLoading}
-                disabled={isLoading || !isConnectButtonEnabled}
-                onClick={handleConnect}
-              >
-                {t`Connect`}
-              </Button>
-            ))
             .exhaustive()}
         </Flex>
       </Stack>

--- a/frontend/src/metabase/metabot/components/MetabotAdmin/MetabotSetup.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotAdmin/MetabotSetup.tsx
@@ -71,12 +71,18 @@ const MetabotSetupContext = createContext<{
   isLoading: boolean;
   isConnectButtonEnabled: boolean;
   setIsConnectButtonEnabled: (enabled: boolean) => void;
+  resetProvider: VoidFunction;
+  handleDisconnect: VoidFunction;
+  isModal: boolean;
 }>({
   isLoading: false,
   connectHandlerRef: null,
   disconnectHandlerRef: null,
   isConnectButtonEnabled: false,
   setIsConnectButtonEnabled: () => {},
+  resetProvider: () => {},
+  handleDisconnect: () => {},
+  isModal: false,
 });
 
 export function useMetabotSetupContext(
@@ -88,6 +94,9 @@ export function useMetabotSetupContext(
     disconnectHandlerRef,
     isLoading,
     setIsConnectButtonEnabled,
+    resetProvider,
+    handleDisconnect,
+    isModal,
   } = useContext(MetabotSetupContext);
 
   useEffect(() => {
@@ -116,10 +125,54 @@ export function useMetabotSetupContext(
     };
   }, [disconnectHandlerRef, onDisconnect]);
 
-  return { isLoading };
+  return { isLoading, resetProvider, handleDisconnect, isModal };
 }
 
 export function MetabotSetup({ id }: { id?: string }) {
+  const offerMetabaseAiManaged = PLUGIN_METABOT.isEnabled;
+  const { value: savedProviderValue } = useAdminSetting("llm-metabot-provider");
+  const config = useMemo(
+    () => parseProviderAndModel(savedProviderValue),
+    [savedProviderValue],
+  );
+  const isConfigured = !!useSetting("llm-metabot-configured?");
+  const connectedProvider = isConfigured ? config?.provider : undefined;
+
+  return (
+    <SettingsSection
+      id={id}
+      title={
+        <Flex justify="space-between" align="center">
+          <Group gap="xs" wrap="nowrap">
+            {isConfigured ? (
+              <Badge circle size="12" bg="success" mr="sm" />
+            ) : null}
+            <div>
+              {connectedProvider
+                ? t`Connected to ${getProviderOptions(offerMetabaseAiManaged)[connectedProvider]?.label}`
+                : t`Connect to an AI provider`}
+            </div>
+          </Group>
+        </Flex>
+      }
+      description={
+        !connectedProvider
+          ? t`Select your AI provider to use AI explorations, SQL generation and Metabot.`
+          : undefined
+      }
+    >
+      <MetabotSetupInner />
+    </SettingsSection>
+  );
+}
+
+export function MetabotSetupInner({
+  isModal = false,
+  onClose,
+}: {
+  isModal?: boolean;
+  onClose?: VoidFunction;
+}) {
   const MetabaseAIProviderSetup = PLUGIN_METABOT.MetabaseAIProviderSetup;
   const offerMetabaseAiManaged = PLUGIN_METABOT.isEnabled;
   const [sendToast] = useToast();
@@ -133,20 +186,26 @@ export function MetabotSetup({ id }: { id?: string }) {
     !!settingDetails.env_name;
   const envSettingName = isEnvSetting ? settingDetails?.env_name : undefined;
 
+  const isConfigured = !!useSetting("llm-metabot-configured?");
+
   const config = useMemo(
     () => parseProviderAndModel(savedProviderValue),
     [savedProviderValue],
   );
-  const isConfigured = useSetting("llm-metabot-configured?");
   const connectedProvider = isConfigured ? config?.provider : undefined;
   const connectedModel = isConfigured ? config?.model : undefined;
   const [provider, setProvider] = useState<MetabotProvider | undefined>(
-    connectedProvider,
+    isModal ? undefined : connectedProvider,
   );
 
+  const isCurrentConfigured = connectedProvider === provider && isConfigured;
+
   useEffect(() => {
+    if (isModal) {
+      return;
+    }
     setProvider(connectedProvider);
-  }, [connectedProvider]);
+  }, [isModal, connectedProvider]);
 
   const [updateSettings, updateSettingsResult] = useUpdateSettingsMutation();
   const disconnectHandlerRef = useRef<(() => Promise<void>) | null>(null);
@@ -240,6 +299,10 @@ export function MetabotSetup({ id }: { id?: string }) {
     }
   };
 
+  const resetProvider = () => {
+    setProvider(undefined);
+  };
+
   const isLoading =
     isConnecting || isDisconnecting || updateSettingsResult.isLoading;
   const [isConnectButtonEnabled, setIsConnectButtonEnabled] = useState(false);
@@ -252,79 +315,85 @@ export function MetabotSetup({ id }: { id?: string }) {
         isLoading,
         setIsConnectButtonEnabled,
         isConnectButtonEnabled,
+        resetProvider,
+        handleDisconnect,
+        isModal: !!isModal,
       }}
     >
-      <SettingsSection
-        id={id}
-        title={
-          <Flex justify="space-between" align="center">
-            <Group gap="xs" wrap="nowrap">
-              {isConfigured ? (
-                <Badge circle size="12" bg="success" mr="sm" />
-              ) : null}
-              <div>
-                {connectedProvider
-                  ? t`Connected to ${getProviderOptions(offerMetabaseAiManaged)[connectedProvider]?.label}`
-                  : t`Connect to an AI provider`}
-              </div>
-            </Group>
-          </Flex>
-        }
-        description={
-          !connectedProvider
-            ? t`Select your AI provider to use AI explorations, SQL generation and Metabot.`
-            : undefined
-        }
-      >
-        <Stack gap="md">
-          {!isConfigured && (
-            <Select
-              label={t`Provider`}
-              placeholder={t`Select a provider`}
-              data={providerOptions}
-              value={provider}
-              onChange={setProvider}
-              disabled={isEnvSetting || isLoading}
-              renderOption={({ option }) => (
-                <Group
-                  gap="xs"
-                  p="sm"
-                  justify="space-between"
-                  wrap="nowrap"
-                  w="100%"
+      <Stack gap="md">
+        {!isCurrentConfigured && (
+          <Select
+            label={t`Provider`}
+            placeholder={t`Select a provider`}
+            data={providerOptions}
+            value={provider}
+            onChange={setProvider}
+            disabled={isEnvSetting || isLoading}
+            renderOption={({ option }) => (
+              <Group
+                gap="xs"
+                p="sm"
+                justify="space-between"
+                wrap="nowrap"
+                w="100%"
+              >
+                <Text
+                  lh="1rem"
+                  c={option.disabled ? "text-tertiary" : undefined}
                 >
-                  <Text
-                    lh="1rem"
-                    c={option.disabled ? "text-tertiary" : undefined}
-                  >
-                    {option.label}
+                  {option.label}
+                </Text>
+                {!isAvailableProvider(option.value as MetabotProvider) && (
+                  <Text c="text-tertiary" lh="1rem" size="sm">
+                    {t`Coming soon`}
                   </Text>
-                  {!isAvailableProvider(option.value as MetabotProvider) && (
-                    <Text c="text-tertiary" lh="1rem" size="sm">
-                      {t`Coming soon`}
-                    </Text>
-                  )}
-                </Group>
-              )}
+                )}
+              </Group>
+            )}
+          />
+        )}
+
+        {match(provider)
+          .with("metabase", () => <MetabaseAIProviderSetup />)
+          .with(P.nonNullable, (selectedProvider) => (
+            <AIProviderSetup
+              selectedProvider={selectedProvider}
+              connectedModel={connectedModel}
+              isCurrentConfigured={isCurrentConfigured}
+              isEnvSetting={isEnvSetting}
             />
-          )}
+          ))
+          .with(P.nullish, () => null)
+          .exhaustive()}
 
-          {match(provider)
-            .with("metabase", () => <MetabaseAIProviderSetup />)
-            .with(P.nonNullable, (selectedProvider) => (
-              <AIProviderSetup
-                selectedProvider={selectedProvider}
-                connectedModel={connectedModel}
-                isEnvSetting={isEnvSetting}
-              />
+        {envSettingName && <SetByEnvVar varName={envSettingName} />}
+
+        <Flex justify="end">
+          {match({ isCurrentConfigured, isModal })
+            .with({ isModal: true, isCurrentConfigured: true }, () => (
+              <Button
+                variant="filled"
+                loading={isLoading}
+                disabled={isLoading}
+                onClick={onClose}
+              >
+                {t`Done`}
+              </Button>
             ))
-            .with(P.nullish, () => null)
-            .exhaustive()}
-
-          {envSettingName && <SetByEnvVar varName={envSettingName} />}
-
-          <Flex justify="end">
-            {isConfigured ? (
+            .when(
+              () => isCurrentConfigured && isConnectButtonEnabled,
+              () => (
+                <Button
+                  variant="filled"
+                  loading={isLoading}
+                  disabled={isLoading}
+                  onClick={handleConnect}
+                >
+                  {t`Connect`}
+                </Button>
+              ),
+            )
+            .with({ isCurrentConfigured: true }, () => (
               <Button
                 c="danger"
                 loading={isLoading}
@@ -340,7 +409,8 @@ export function MetabotSetup({ id }: { id?: string }) {
               >
                 {t`Disconnect`}
               </Button>
-            ) : (
+            ))
+            .with({ isCurrentConfigured: false }, () => (
               <Button
                 variant="filled"
                 loading={isLoading}
@@ -349,10 +419,10 @@ export function MetabotSetup({ id }: { id?: string }) {
               >
                 {t`Connect`}
               </Button>
-            )}
-          </Flex>
-        </Stack>
-      </SettingsSection>
+            ))
+            .exhaustive()}
+        </Flex>
+      </Stack>
     </MetabotSetupContext.Provider>
   );
 }
@@ -360,10 +430,12 @@ export function MetabotSetup({ id }: { id?: string }) {
 const AIProviderSetup = ({
   selectedProvider,
   connectedModel,
+  isCurrentConfigured,
   isEnvSetting,
 }: {
   selectedProvider: Exclude<MetabotProvider, "metabase">;
   connectedModel: string | undefined;
+  isCurrentConfigured: boolean;
   isEnvSetting: boolean;
 }) => {
   const [model, setModel] = useState<string | undefined>(connectedModel);
@@ -386,7 +458,11 @@ const AIProviderSetup = ({
     setApiKeyLocalValue(null);
   };
 
-  const { isLoading } = useMetabotSetupContext(onConnect);
+  const hasDirtyApiKey = apiKeyLocalValue !== null;
+  const connectHandler =
+    !isCurrentConfigured || hasDirtyApiKey ? onConnect : null;
+
+  const { isLoading } = useMetabotSetupContext(connectHandler);
 
   const { details: providerApiKeyDetails } = useAdminSettings([
     "llm-anthropic-api-key",

--- a/frontend/src/metabase/metabot/components/MetabotAdmin/MetabotSetup.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotAdmin/MetabotSetup.unit.spec.tsx
@@ -24,7 +24,7 @@ import {
   createMockTokenStatus,
 } from "metabase-types/api/mocks";
 
-import { MetabotSetup } from "./MetabotSetup";
+import { MetabotSetup, MetabotSetupInner } from "./MetabotSetup";
 import type { MetabotApiKeyProvider } from "./utils";
 
 const DEFAULT_RESPONSES: Record<MetabotProvider, MetabotSettingsResponse> = {
@@ -80,6 +80,7 @@ const DEFAULT_RESPONSES: Record<MetabotProvider, MetabotSettingsResponse> = {
 };
 
 type MetabotUsageQuota = {
+  "is-locked"?: boolean;
   tokens: number | null;
   updated_at: string | null;
 };
@@ -124,6 +125,7 @@ type SetupOptions = {
   settingUpdateResponse?: number | { status: number; body?: unknown };
   responses?: Partial<Record<MetabotProvider, MetabotSettingsApiResponse>>;
   updateResponse?: MetabotSettingsResponse;
+  renderAsModal?: boolean;
 };
 
 async function setup({
@@ -152,6 +154,7 @@ async function setup({
     value: "anthropic/claude-sonnet-4-5",
     models: DEFAULT_RESPONSES.anthropic.models,
   },
+  renderAsModal = false,
 }: SetupOptions = {}) {
   fetchMock.removeRoutes();
   fetchMock.clearHistory();
@@ -350,18 +353,21 @@ async function setup({
     return 204;
   });
 
-  const { history, store } = renderWithProviders(
-    <Route path="/admin/metabot*" component={MetabotSetup} />,
-    {
-      withRouter: true,
-      initialRoute: "/admin/metabot",
-      storeInitialState: {
-        settings,
-      },
-    },
-  );
+  const storeInitialState = { settings };
+  const view = renderAsModal
+    ? renderWithProviders(<MetabotSetupInner isModal onClose={jest.fn()} />, {
+        storeInitialState,
+      })
+    : renderWithProviders(
+        <Route path="/admin/metabot*" component={MetabotSetup} />,
+        {
+          withRouter: true,
+          initialRoute: "/admin/metabot",
+          storeInitialState,
+        },
+      );
 
-  if (!isHosted) {
+  if (!isHosted && !renderAsModal) {
     await screen.findByText(
       isConfigured
         ? /Connected to|Connect to an AI provider/
@@ -370,8 +376,7 @@ async function setup({
   }
 
   return {
-    history,
-    store,
+    ...view,
   };
 }
 
@@ -450,6 +455,51 @@ describe("MetabotSetup", () => {
       screen.getByRole("button", { name: "Disconnect" }),
     ).toBeInTheDocument();
     expect(screen.queryByText("Not connected")).not.toBeInTheDocument();
+  });
+
+  it("shows Connect instead of Disconnect when the configured API key input is dirty", async () => {
+    await setup();
+    await screen.findByLabelText("API key");
+
+    expect(
+      screen.getByRole("button", { name: "Disconnect" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Connect" }),
+    ).not.toBeInTheDocument();
+
+    await userEvent.clear(screen.getByLabelText("API key"));
+    await userEvent.type(screen.getByLabelText("API key"), "sk-ant-rotated");
+
+    expect(screen.getByRole("button", { name: "Connect" })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Disconnect" }),
+    ).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Connect" }));
+
+    await waitFor(() => {
+      expect(fetchMock.callHistory.called("path:/api/metabot/settings")).toBe(
+        true,
+      );
+    });
+
+    const request = fetchMock.callHistory
+      .calls("path:/api/metabot/settings")
+      .find(
+        (call) =>
+          call.request?.method === "PUT" || call.options?.method === "PUT",
+      );
+
+    expect(request?.options?.body).toBe(
+      JSON.stringify({ provider: "anthropic", "api-key": "sk-ant-rotated" }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Disconnect" }),
+      ).toBeInTheDocument();
+    });
   });
 
   it("shows the disconnected title when not configured", async () => {
@@ -854,6 +904,96 @@ describe("MetabotSetup", () => {
     expect(screen.getByText("Total tokens")).toBeInTheDocument();
     expect(screen.getByText("Total cost")).toBeInTheDocument();
     expect(screen.getByText("$1.06")).toBeInTheDocument();
+  });
+
+  it("disconnects when clicking use a different AI provider from the locked managed-provider state", async () => {
+    await setup({
+      isHosted: true,
+      savedProviderValue: "metabase/anthropic/claude-sonnet-4-6",
+      tokenStatusFeatures: ["metabase-ai-managed"],
+      metabotUsageQuotas: [
+        {
+          "is-locked": true,
+          tokens: 250000,
+          updated_at: "2026-04-02T19:29:12Z",
+        },
+      ],
+    });
+
+    expect(
+      await screen.findByText("You've run out of AI service tokens"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/You've used all of your included AI service tokens\./),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Current billing cycle")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Use a different AI provider" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Start paid subscription" }),
+    ).toBeInTheDocument();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Use a different AI provider" }),
+    );
+
+    await waitFor(() => {
+      expect(fetchMock.callHistory.called("path:/api/setting")).toBe(true);
+    });
+
+    const request = fetchMock.callHistory
+      .calls("path:/api/setting")
+      .find((call) => call.request?.method === "PUT");
+
+    expect(request?.options?.body).toBe(
+      JSON.stringify({
+        "llm-metabot-provider": null,
+      }),
+    );
+
+    expect(
+      await screen.findByText("Connect to an AI provider"),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Provider")).toHaveValue("");
+    expect(
+      screen.queryByText("You've run out of AI service tokens"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("resets the form in modal mode without updating settings", async () => {
+    await setup({
+      isHosted: true,
+      savedProviderValue: "metabase/anthropic/claude-sonnet-4-6",
+      tokenStatusFeatures: ["metabase-ai-managed"],
+      metabotUsageQuotas: [
+        {
+          "is-locked": true,
+          tokens: 250000,
+          updated_at: "2026-04-02T19:29:12Z",
+        },
+      ],
+      renderAsModal: true,
+    });
+
+    expect(await screen.findByLabelText("Provider")).toHaveValue("");
+
+    await selectProvider("Metabase");
+    await userEvent.click(
+      await screen.findByRole("button", {
+        name: "Use a different AI provider",
+      }),
+    );
+
+    expect(await screen.findByLabelText("Provider")).toHaveValue("");
+    expect(
+      screen.queryByRole("button", { name: "Use a different AI provider" }),
+    ).not.toBeInTheDocument();
+    expect(
+      fetchMock.callHistory
+        .calls("path:/api/setting")
+        .some((call) => call.request?.method === "PUT"),
+    ).toBe(false);
   });
 
   it("saves when picking a model", async () => {

--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotChatEditor/MetabotChatEditor.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotChatEditor/MetabotChatEditor.unit.spec.tsx
@@ -86,7 +86,7 @@ describe("MetabotChatEditor", () => {
     setup({ value: "[Test Model](metabase://model/123)" });
 
     const editor = await screen.findByTestId("metabot-chat-input");
-    expect(editor).toHaveTextContent("Test Model");
+    await waitFor(() => expect(editor).toHaveTextContent("Test Model"));
   });
 
   it("should emit onChange events with properly serialized content", async () => {

--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotChatMessage.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotChatMessage.tsx
@@ -1,10 +1,12 @@
 import { useClipboard } from "@mantine/hooks";
 import cx from "classnames";
 import { forwardRef, useCallback, useState } from "react";
+import { match } from "ts-pattern";
 import { t } from "ttag";
 
 import { useSubmitMetabotFeedbackMutation } from "metabase/api/metabot";
 import { useToast } from "metabase/common/hooks";
+import { MetabotManagedProviderLimitActions } from "metabase/metabot/components/MetabotManagedProviderLimit";
 import type {
   MetabotAgentChatMessage,
   MetabotAgentTextChatMessage,
@@ -240,20 +242,39 @@ export const AgentErrorMessage = ({
   ...props
 }: FlexProps & {
   message: MetabotErrorMessage;
-}) => (
-  <MessageContainer chatRole="agent" {...props}>
-    {message.type === "alert" ? (
-      <Flex gap="sm">
-        <Icon name="warning" c="error" size="1rem" mt="2px" flex="0 0 auto" />
-        <Text c="error" className={Styles.message}>
-          {message.message}
-        </Text>
-      </Flex>
-    ) : (
-      <Text className={Styles.message}>{message.message}</Text>
-    )}
-  </MessageContainer>
-);
+}) => {
+  return (
+    <MessageContainer chatRole="agent" {...props}>
+      {match(message.type)
+        .with("alert", () => (
+          <Flex gap="sm">
+            <Icon
+              name="warning"
+              c="error"
+              size="1rem"
+              mt="2px"
+              flex="0 0 auto"
+            />
+            <Text c="error" className={Styles.message}>
+              {message.message}
+            </Text>
+          </Flex>
+        ))
+        .with("locked", () => (
+          <Flex direction="column" gap="md" flex={1}>
+            <Text className={Styles.message}>
+              {t`You've used all of your included AI service tokens. To keep using AI features you can either end your trial early and start your subscription, or stay in the trial and add your own AI provider API key.`}
+            </Text>
+            <MetabotManagedProviderLimitActions />
+          </Flex>
+        ))
+        .with("message", () => (
+          <Text className={Styles.message}>{message.message}</Text>
+        ))
+        .exhaustive()}
+    </MessageContainer>
+  );
+};
 
 export const getFullAgentReply = (
   messages: MetabotChatMessage[],

--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotChatMessage.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotChatMessage.unit.spec.tsx
@@ -1,0 +1,29 @@
+import { renderWithProviders, screen } from "__support__/ui";
+
+import { AgentErrorMessage } from "./MetabotChatMessage";
+
+describe("AgentErrorMessage", () => {
+  it("shows the managed-provider lockout message and actions", () => {
+    renderWithProviders(
+      <AgentErrorMessage
+        message={{
+          type: "locked",
+          message: "unused",
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByText(/You've used all of your included AI service tokens\./),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Use a different AI provider" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Start paid subscription" }),
+    ).toHaveAttribute(
+      "href",
+      "https://store.staging.metabase.com/account/manage/plans",
+    );
+  });
+});

--- a/frontend/src/metabase/metabot/components/MetabotInlineSQLPrompt/MetabotInlineSQLPrompt.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotInlineSQLPrompt/MetabotInlineSQLPrompt.tsx
@@ -3,8 +3,10 @@ import { tinykeys } from "tinykeys";
 import { t } from "ttag";
 
 import type { MetabotPromptInputRef } from "metabase/metabot";
+import { MetabotManagedProviderLimitHoverCard } from "metabase/metabot/components/MetabotManagedProviderLimit";
 import { MetabotPromptInput } from "metabase/metabot/components/MetabotPromptInput";
 import { useMetabotName } from "metabase/metabot/hooks";
+import type { MetabotErrorMessage } from "metabase/metabot/state";
 import type { SuggestionModel } from "metabase/rich_text_editing/tiptap/extensions/shared/types";
 import { Box, Button, Flex, Icon, Loader, Tooltip } from "metabase/ui";
 import type { DatabaseId } from "metabase-types/api";
@@ -15,7 +17,7 @@ interface MetabotInlineSQLPromptProps {
   databaseId: DatabaseId | null;
   onClose: () => void;
   isLoading: boolean;
-  error: string | undefined;
+  error: MetabotErrorMessage | undefined;
   generate: (options: { prompt: string; sourceSql?: string }) => Promise<void>;
   cancelRequest: () => void;
   suggestionModels: SuggestionModel[];
@@ -89,7 +91,11 @@ export const MetabotInlineSQLPrompt = ({
       </Box>
       <Flex justify="space-between" align="center" gap="sm" mt="xs">
         <Box data-testid="metabot-inline-sql-error" w="100%" fz="sm" c="error">
-          {error}
+          {error?.type === "locked" ? (
+            <MetabotManagedProviderLimitHoverCard />
+          ) : (
+            error?.message
+          )}
         </Box>
         <Flex gap="xs" flex="1 0 auto">
           <Tooltip disabled={isLoading} label={t`Send to ${metabotName}`}>

--- a/frontend/src/metabase/metabot/components/MetabotManagedProviderLimit.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotManagedProviderLimit.tsx
@@ -1,0 +1,178 @@
+import { useDisclosure } from "@mantine/hooks";
+import { useCallback } from "react";
+import { t } from "ttag";
+
+import { ExternalLink } from "metabase/common/components/ExternalLink";
+import { useStoreUrl } from "metabase/common/hooks";
+import { dismissUndo } from "metabase/redux/undo";
+import {
+  Button,
+  Flex,
+  type FlexProps,
+  HoverCard,
+  Modal,
+  Text,
+} from "metabase/ui";
+import { useDispatch } from "metabase/utils/redux";
+
+import { MetabotSetupInner } from "./MetabotAdmin/MetabotSetup";
+
+const METABOT_MANAGED_PROVIDER_LIMIT_TOAST_ID =
+  "metabot-managed-provider-limit";
+
+type MetabotManagedProviderLimitActionsProps = {
+  inline?: boolean;
+  onConfigure?: VoidFunction;
+  onConfigureClose?: VoidFunction;
+} & FlexProps;
+
+export const MetabotManagedProviderLimitActions = ({
+  inline = false,
+  onConfigure,
+  onConfigureClose,
+  ...rest
+}: MetabotManagedProviderLimitActionsProps) => {
+  const [isOpen, { open, close }] = useDisclosure(false, {
+    onClose: onConfigureClose,
+  });
+  const handleConfigure = useCallback(() => {
+    (onConfigure ?? open)();
+  }, [onConfigure, open]);
+
+  const configureModal = (
+    <Modal
+      title="Connect to an AI provider"
+      onClose={close}
+      opened={isOpen}
+      size="lg"
+    >
+      <MetabotSetupInner isModal onClose={close} />
+    </Modal>
+  );
+
+  const storeUrl = useStoreUrl("account/manage/plans");
+
+  if (inline) {
+    return (
+      <Flex align="center" gap="sm" wrap="wrap" {...rest}>
+        <Button
+          h="1rem"
+          variant="subtle"
+          size="xs"
+          fz="sm"
+          p={0}
+          onClick={handleConfigure}
+        >
+          {t`Use a different AI provider`}
+        </Button>
+        <Text span c="text-secondary" fz="sm" lh="1rem">
+          •
+        </Text>
+        <Button
+          h="1rem"
+          component={ExternalLink}
+          href={storeUrl}
+          target="_blank"
+          variant="subtle"
+          size="xs"
+          fz="sm"
+          p={0}
+        >
+          {t`Start paid subscription`}
+        </Button>
+        {configureModal}
+      </Flex>
+    );
+  }
+
+  return (
+    <Flex direction="column" align="start" gap="xs" {...rest}>
+      <Button
+        variant="subtle"
+        size="xs"
+        p={0}
+        onClick={handleConfigure}
+      >{t`Use a different AI provider`}</Button>
+      <Button
+        component={ExternalLink}
+        href={storeUrl}
+        target="_blank"
+        variant="subtle"
+        size="xs"
+        p={0}
+      >
+        {t`Start paid subscription`}
+      </Button>
+      {configureModal}
+    </Flex>
+  );
+};
+
+export const MetabotManagedProviderLimitHoverCard = () => {
+  return (
+    <HoverCard
+      closeDelay={100}
+      openDelay={150}
+      position="top-start"
+      shadow="md"
+      width="26rem"
+    >
+      <HoverCard.Target>
+        <Text
+          component="span"
+          fz="sm"
+          td="underline dotted"
+          style={{ cursor: "pointer", textUnderlineOffset: "2px" }}
+        >
+          {t`You've run out of AI service tokens`}
+        </Text>
+      </HoverCard.Target>
+      <HoverCard.Dropdown p="md">
+        <Flex direction="column" gap="sm">
+          <Text fz="sm" lh={1.5}>
+            {t`You've used all of your included AI service tokens. To keep using AI features you can either end your trial early and start your subscription, or stay in the trial and add your own AI provider API key.`}
+          </Text>
+          <MetabotManagedProviderLimitActions inline />
+        </Flex>
+      </HoverCard.Dropdown>
+    </HoverCard>
+  );
+};
+
+const MetabotManagedProviderLimitToastContent = () => {
+  const dispatch = useDispatch();
+
+  const dismissToast = useCallback(() => {
+    dispatch(dismissUndo({ undoId: METABOT_MANAGED_PROVIDER_LIMIT_TOAST_ID }));
+  }, [dispatch]);
+
+  return (
+    <Flex direction="column" gap="xs">
+      <Text c="text-primary" fw={500} lh={1.4}>
+        {t`You've run out of AI service tokens`}
+      </Text>
+      <Text c="text-secondary" fz="sm" lh={1.4}>
+        {t`You've used all of your included AI service tokens. To keep using AI features you can either end your trial early and start your subscription, or stay in the trial and add your own AI provider API key.`}
+      </Text>
+      <MetabotManagedProviderLimitActions
+        inline
+        mt="sm"
+        onConfigureClose={dismissToast}
+      />
+    </Flex>
+  );
+};
+
+export const getMetabotManagedProviderLimitToastProps = () => ({
+  id: METABOT_MANAGED_PROVIDER_LIMIT_TOAST_ID,
+  dark: false,
+  icon: null,
+  toastColor: "error",
+  dismissIconColor: "text-secondary" as const,
+  timeout: 0,
+  style: {
+    padding: "1rem",
+    width: "min(24rem, calc(100vw - 2 * var(--mantine-spacing-md)))",
+  },
+  renderChildren: () => <MetabotManagedProviderLimitToastContent />,
+});

--- a/frontend/src/metabase/metabot/components/MetabotManagedProviderLimit.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotManagedProviderLimit.unit.spec.tsx
@@ -1,0 +1,58 @@
+import userEvent from "@testing-library/user-event";
+
+import { renderWithProviders, screen, waitFor } from "__support__/ui";
+
+import * as metabotSetupModule from "./MetabotAdmin/MetabotSetup";
+import { getMetabotManagedProviderLimitToastProps } from "./MetabotManagedProviderLimit";
+
+describe("getMetabotManagedProviderLimitToastProps", () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest
+      .spyOn(metabotSetupModule, "MetabotSetupInner")
+      .mockImplementation(() => <div>Mocked Metabot Setup</div>);
+  });
+
+  it("dismisses the toast only when the configure modal closes", async () => {
+    const { store } = renderWithProviders(
+      getMetabotManagedProviderLimitToastProps().renderChildren(),
+      {
+        storeInitialState: {
+          undo: [
+            {
+              id: "metabot-managed-provider-limit",
+              timeoutId: null,
+            } as any,
+          ],
+        },
+      },
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Use a different AI provider" }),
+    );
+
+    expect(screen.getByText("Mocked Metabot Setup")).toBeInTheDocument();
+    expect(store.getState().undo).toHaveLength(1);
+
+    await userEvent.click(screen.getByRole("button", { name: "Close" }));
+
+    await waitFor(() => {
+      expect(store.getState().undo).not.toContainEqual(
+        expect.objectContaining({
+          id: "metabot-managed-provider-limit",
+        }),
+      );
+    });
+  });
+
+  it("renders the paid subscription link in the toast", () => {
+    renderWithProviders(
+      getMetabotManagedProviderLimitToastProps().renderChildren(),
+    );
+
+    expect(
+      screen.getByRole("link", { name: "Start paid subscription" }),
+    ).toHaveAttribute("href", expect.stringContaining("/account/manage/plans"));
+  });
+});

--- a/frontend/src/metabase/metabot/constants.ts
+++ b/frontend/src/metabase/metabot/constants.ts
@@ -32,6 +32,9 @@ export const METABOT_ERR_MSG = {
   unauthenticated(metabotName: string) {
     return t`${metabotName} could not authenticate your request. Please contact your administrator.`;
   },
+  get locked() {
+    return t`You've used all of your included AI service tokens. To keep using AI features you can either end your trial early and start your subscription, or stay in the trial and add your own AI provider API key.`;
+  },
   format(msg: string) {
     return t`Sorry, an error occurred: ${msg}. If this persists, please contact your administrator.`;
   },

--- a/frontend/src/metabase/metabot/hooks/use-metabot-sql-suggestion.tsx
+++ b/frontend/src/metabase/metabot/hooks/use-metabot-sql-suggestion.tsx
@@ -1,9 +1,12 @@
 import { isFulfilled, isRejected } from "@reduxjs/toolkit";
 import { useCallback, useMemo, useState } from "react";
-import { t } from "ttag";
 
-import { METABOT_PROFILE_OVERRIDES } from "metabase/metabot/constants";
 import {
+  METABOT_ERR_MSG,
+  METABOT_PROFILE_OVERRIDES,
+} from "metabase/metabot/constants";
+import {
+  type MetabotErrorMessage,
   addDeveloperMessage,
   getMetabotSuggestedCodeEdit,
   removeSuggestedCodeEdit,
@@ -44,7 +47,7 @@ export function useMetabotSQLSuggestion({
 }: UseMetabotSQLSuggestionOptions) {
   const { isDoingScience, submitInput, cancelRequest } = useMetabotAgent("sql");
 
-  const [hasError, setHasError] = useState(false);
+  const [error, setError] = useState<MetabotErrorMessage>();
 
   const dispatch = useDispatch();
   const source = useSelector((state) =>
@@ -59,18 +62,29 @@ export function useMetabotSQLSuggestion({
       sourceSql?: string;
       referencedEntities?: unknown;
     }) => {
-      setHasError(false);
+      setError(undefined);
       const action = await submitInput(prompt, {
         profile: METABOT_PROFILE_OVERRIDES.SQL,
         preventOpenSidebar: true,
       });
+
+      const nextError =
+        isFulfilled(action) &&
+        !action.payload.success &&
+        action.payload.errorMessage;
+
       if (
         isRejected(action) ||
         (isFulfilled(action) && !action.payload?.success) ||
         !responseHasCodeEdit(action)
       ) {
-        setHasError(true);
-        throw new Error(t`Something went wrong. Please try again.`);
+        const error = nextError || {
+          type: "message",
+          message: METABOT_ERR_MSG.default,
+        };
+
+        setError(error);
+        throw new Error(error.message);
       } else {
         onGenerated?.();
       }
@@ -105,7 +119,7 @@ export function useMetabotSQLSuggestion({
     source,
     isLoading: isDoingScience,
     generate,
-    error: hasError ? t`Something went wrong. Please try again.` : undefined,
+    error,
     cancelRequest,
     clear,
     reject,

--- a/frontend/src/metabase/metabot/state/actions.ts
+++ b/frontend/src/metabase/metabot/state/actions.ts
@@ -71,10 +71,15 @@ export const {
   removeSuggestedCodeEdit,
 } = metabot.actions;
 
-type PromptErrorOutcome = {
-  errorMessage: MetabotErrorMessage | false;
-  shouldRetry: boolean;
-};
+type PromptErrorOutcome =
+  | {
+      errorMessage: MetabotErrorMessage;
+      shouldRetry: boolean;
+    }
+  | {
+      errorMessage: false;
+      shouldRetry: boolean;
+    };
 
 const handleResponseError = (
   error: unknown,
@@ -92,6 +97,17 @@ const handleResponseError = (
         errorMessage: {
           type: "alert" as const,
           message: METABOT_ERR_MSG.unauthenticated(metabotName),
+        },
+        shouldRetry: true,
+      }),
+    )
+    .with(
+      { message: P.string.startsWith("Response status: 402") },
+      { status: 402 },
+      () => ({
+        errorMessage: {
+          type: "locked" as const,
+          message: METABOT_ERR_MSG.locked,
         },
         shouldRetry: true,
       }),
@@ -172,8 +188,20 @@ export type MetabotPromptSubmissionResult =
       shouldRetry?: void;
       data?: SendAgentRequestResult;
     }
-  | { prompt: string; success: false; shouldRetry: false; data?: void }
-  | { prompt: string; success: false; shouldRetry: true; data?: void };
+  | {
+      prompt: string;
+      success: false;
+      shouldRetry: false;
+      errorMessage?: MetabotErrorMessage;
+      data?: void;
+    }
+  | {
+      prompt: string;
+      success: false;
+      shouldRetry: true;
+      errorMessage?: MetabotErrorMessage;
+      data?: void;
+    };
 
 export const submitInput = createAsyncThunk<
   MetabotPromptSubmissionResult,
@@ -270,7 +298,15 @@ export const submitInput = createAsyncThunk<
             "shouldRetry" in result.payload &&
             (result.payload?.shouldRetry ?? {})) ??
           false;
-        return { prompt: rawPrompt, success: false, shouldRetry };
+        return {
+          prompt: rawPrompt,
+          success: false,
+          shouldRetry,
+          errorMessage:
+            result.payload?.type === "error"
+              ? result.payload.errorMessage || undefined
+              : undefined,
+        };
       }
 
       return { prompt, success: true, data: result.payload };
@@ -278,7 +314,15 @@ export const submitInput = createAsyncThunk<
       // NOTE: all errors should be caught above, this is is a catch-all
       // to make sure that this async action always resolves to a value
       console.error(error);
-      return { prompt, success: false, shouldRetry: true };
+      return {
+        prompt,
+        success: false,
+        shouldRetry: true,
+        errorMessage: {
+          type: "message",
+          message: METABOT_ERR_MSG.default,
+        },
+      };
     }
   },
 );

--- a/frontend/src/metabase/metabot/state/actions.ts
+++ b/frontend/src/metabase/metabot/state/actions.ts
@@ -101,7 +101,7 @@ const handleResponseError = (
         shouldRetry: true,
       }),
     )
-    .with({ status: 402, "error-code": "metabase-ai-managed-locked" }, () => ({
+    .with({ status: 402, "error-code": "metabase_ai_managed_locked" }, () => ({
       errorMessage: {
         type: "locked" as const,
         message: METABOT_ERR_MSG.locked,

--- a/frontend/src/metabase/metabot/state/actions.ts
+++ b/frontend/src/metabase/metabot/state/actions.ts
@@ -101,17 +101,20 @@ const handleResponseError = (
         shouldRetry: true,
       }),
     )
-    .with(
-      { message: P.string.startsWith("Response status: 402") },
-      { status: 402 },
-      () => ({
-        errorMessage: {
-          type: "locked" as const,
-          message: METABOT_ERR_MSG.locked,
-        },
-        shouldRetry: true,
-      }),
-    )
+    .with({ status: 402, "error-code": "metabase-ai-managed-locked" }, () => ({
+      errorMessage: {
+        type: "locked" as const,
+        message: METABOT_ERR_MSG.locked,
+      },
+      shouldRetry: true,
+    }))
+    .with({ status: P.number, message: P.string }, ({ message }) => ({
+      errorMessage: {
+        type: "message" as const,
+        message: METABOT_ERR_MSG.format(message),
+      },
+      shouldRetry: true,
+    }))
     .with(P.string, (err) => ({
       errorMessage: {
         type: "message" as const,

--- a/frontend/src/metabase/metabot/state/types.ts
+++ b/frontend/src/metabase/metabot/state/types.ts
@@ -74,10 +74,15 @@ export type MetabotChatMessage =
   | MetabotAgentChatMessage
   | MetabotDebugChatMessage;
 
-export type MetabotErrorMessage = {
-  type: "message" | "alert";
-  message: string;
-};
+export type MetabotErrorMessage =
+  | {
+      type: "message" | "alert";
+      message: string;
+    }
+  | {
+      type: "locked";
+      message: string;
+    };
 
 export type MetabotToolCall = {
   id: string;

--- a/frontend/src/metabase/metabot/tests/errors.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/tests/errors.unit.spec.tsx
@@ -42,6 +42,19 @@ describe("metabot > errors", () => {
     expect(await input()).toHaveTextContent("Who is your favorite?");
   });
 
+  it("should keep the prompt for locked requests so it can be retried", async () => {
+    setup();
+    fetchMock.post(`path:/api/metabot/agent-streaming`, 402);
+
+    await enterChatMessage("Who is your favorite?");
+
+    await assertConversation([
+      ["user", "Who is your favorite?"],
+      ["agent", METABOT_ERR_MSG.locked],
+    ]);
+    expect(await input()).toHaveTextContent("Who is your favorite?");
+  });
+
   it("should handle show error if data error part is in response", async () => {
     setup();
     mockAgentEndpoint({ textChunks: erroredResponse });

--- a/frontend/src/metabase/metabot/tests/errors.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/tests/errors.unit.spec.tsx
@@ -48,7 +48,7 @@ describe("metabot > errors", () => {
       status: 402,
       body: {
         message: "You've used all of your included AI service tokens.",
-        "error-code": "metabase-ai-managed-locked",
+        "error-code": "metabase_ai_managed_locked",
       },
     });
 

--- a/frontend/src/metabase/metabot/tests/errors.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/tests/errors.unit.spec.tsx
@@ -44,13 +44,38 @@ describe("metabot > errors", () => {
 
   it("should keep the prompt for locked requests so it can be retried", async () => {
     setup();
-    fetchMock.post(`path:/api/metabot/agent-streaming`, 402);
+    fetchMock.post(`path:/api/metabot/agent-streaming`, {
+      status: 402,
+      body: {
+        message: "You've used all of your included AI service tokens.",
+        "error-code": "metabase-ai-managed-locked",
+      },
+    });
 
     await enterChatMessage("Who is your favorite?");
 
     await assertConversation([
       ["user", "Who is your favorite?"],
       ["agent", METABOT_ERR_MSG.locked],
+    ]);
+    expect(await input()).toHaveTextContent("Who is your favorite?");
+  });
+
+  it("should not show the managed-provider lockout for unrelated 402 errors", async () => {
+    setup();
+    fetchMock.post(`path:/api/metabot/agent-streaming`, {
+      status: 402,
+      body: {
+        message: "A different billing problem happened",
+        "error-code": "billing-problem",
+      },
+    });
+
+    await enterChatMessage("Who is your favorite?");
+
+    await assertConversation([
+      ["user", "Who is your favorite?"],
+      ["agent", /A different billing problem happened/],
     ]);
     expect(await input()).toHaveTextContent("Who is your favorite?");
   });

--- a/frontend/src/metabase/redux/store/undo.ts
+++ b/frontend/src/metabase/redux/store/undo.ts
@@ -1,4 +1,4 @@
-import type { ReactNode, RefObject } from "react";
+import type { CSSProperties, ReactNode, RefObject } from "react";
 
 import type { IconName } from "metabase/ui";
 import type { ColorName } from "metabase/ui/colors/types";
@@ -15,7 +15,9 @@ export interface Undo {
   showProgress?: boolean;
   icon?: IconName | null;
   toastColor?: string;
+  dark?: boolean;
   iconColor?: ColorName;
+  style?: CSSProperties;
   actionLabel?: string;
   canDismiss?: boolean;
   startedAt?: number;

--- a/frontend/src/metabase/redux/undo.ts
+++ b/frontend/src/metabase/redux/undo.ts
@@ -144,6 +144,16 @@ export function undoReducer(
       count: payload.count || 1,
     };
 
+    const existingUndoIndex = state.findIndex(
+      (existingUndo) => existingUndo.id === undo.id,
+    );
+
+    if (existingUndoIndex !== -1) {
+      const nextState = state.slice();
+      nextState[existingUndoIndex] = undo;
+      return nextState;
+    }
+
     const previous: Undo = state[state.length - 1];
     // if last undo was same verb then merge them
     if (previous && undo.verb != null && undo.verb === previous.verb) {

--- a/frontend/src/metabase/redux/undo.unit.spec.ts
+++ b/frontend/src/metabase/redux/undo.unit.spec.ts
@@ -36,6 +36,16 @@ describe("metabase/redux/undo", () => {
 
       expect(clearTimeoutSpy).toHaveBeenCalledTimes(1);
     });
+
+    it("should replace an existing undo when adding another one with the same id", async () => {
+      const store = createMockStore();
+
+      await store.dispatch(addUndo({ id: MOCK_ID, message: "First toast" }));
+      await store.dispatch(addUndo({ id: MOCK_ID, message: "Updated toast" }));
+
+      expect(store.getState().undo).toHaveLength(1);
+      expect(store.getState().undo[0].message).toBe("Updated toast");
+    });
   });
 
   describe("performUndo", () => {

--- a/frontend/test/__support__/server-mocks/metabot.ts
+++ b/frontend/test/__support__/server-mocks/metabot.ts
@@ -165,6 +165,7 @@ type SetupMetabaseManagedAiEndpointsOptions = {
   billingPeriodMonths?: number;
   metabasePricePerUnit?: number;
   metabotUsageQuota?: {
+    "is-locked"?: boolean;
     tokens: number | null;
     updated_at: string | null;
   } | null;
@@ -180,6 +181,7 @@ export function setupMetabaseManagedAiEndpoints({
   removeCloudAddOnResponse = 200,
 }: SetupMetabaseManagedAiEndpointsOptions = {}) {
   fetchMock.get("path:/api/ee/metabot/usage", {
+    "is-locked": metabotUsageQuota?.["is-locked"] ?? false,
     tokens: metabotUsageQuota?.tokens ?? null,
     updated_at: metabotUsageQuota?.updated_at ?? null,
   });

--- a/src/metabase/metabot/api.clj
+++ b/src/metabase/metabot/api.clj
@@ -26,6 +26,7 @@
    [metabase.metabot.self :as metabot.self]
    [metabase.metabot.self.core :as self.core]
    [metabase.metabot.settings :as metabot.settings]
+   [metabase.metabot.usage :as metabot.usage]
    [metabase.permissions.core :as perms]
    [metabase.server.streaming-response :as sr]
    [metabase.settings.core :as setting]
@@ -215,6 +216,7 @@
   (let [message    (metabot.envelope/user-message message)
         metabot-id (metabot.config/resolve-dynamic-metabot-id metabot_id)
         _          (metabot.config/check-metabot-enabled! metabot-id)
+        _          (metabot.usage/check-metabase-managed-free-limit!)
         profile-id (metabot.config/resolve-dynamic-profile-id profile_id metabot-id)
         ;; Only allow debug mode in dev — never in production
         debug?     (and config/is-dev? (boolean debug))]
@@ -332,10 +334,9 @@
 
 (defn- effective-provider-model
   [provider model]
-  (cond
-    (nil? model) nil
-    (and (= provider provider-util/metabase-provider-prefix) (str/blank? model)) metabot.settings/default-llm-metabot-provider
-    :else (non-blank-string model)))
+  (when (some? model)
+    (or (non-blank-string model)
+        (metabot.settings/default-model-for-provider provider))))
 
 (def ^:private invalid-api-key-statuses
   #{401 403})
@@ -442,6 +443,10 @@
   []
   (provider-util/provider-and-model->provider (metabot.settings/llm-metabot-provider)))
 
+(defn- current-setting-provider
+  []
+  (provider-util/provider-and-model->outer-provider (metabot.settings/llm-metabot-provider)))
+
 (defn- throw-api-key-error!
   [response]
   (when-let [api-key-error (:api-key-error response)]
@@ -466,8 +471,19 @@
    _query-params
    body :- metabot-settings-request-schema]
   (perms/check-has-application-permission :setting)
-  (let [{:keys [provider model api-key]} body
-        model (effective-provider-model provider model)
+  (let [{:keys [provider api-key] request-model :model} body
+        current-provider (current-setting-provider)
+        provider-changed? (not= current-provider provider)
+        model (cond
+                (non-blank-string request-model)
+                (effective-provider-model provider request-model)
+
+                provider-changed?
+                (or (effective-provider-model provider request-model)
+                    (metabot.settings/default-model-for-provider provider))
+
+                :else
+                nil)
         response (-> (settings-response provider api-key)
                      throw-api-key-error!)]
     (when (contains? body :api-key)

--- a/src/metabase/metabot/api/document.clj
+++ b/src/metabase/metabot/api/document.clj
@@ -7,6 +7,7 @@
    [metabase.metabot.agent.core :as metabot.agent]
    [metabase.metabot.config :as metabot.config]
    [metabase.metabot.context :as metabot.context]
+   [metabase.metabot.usage :as metabot.usage]
    [metabase.util.malli.schema :as ms]))
 
 (set! *warn-on-reflection* true)
@@ -91,6 +92,7 @@
 
    {:keys [instructions references]} :- generate-content-body-schema]
   (metabot.config/check-metabot-enabled!)
+  (metabot.usage/check-metabase-managed-free-limit!)
   (let [context      (assoc
                       (metabot.context/create-context {:capabilities #{"permission:write_sql_queries"}})
                       :references references)

--- a/src/metabase/metabot/api/entity_analysis.clj
+++ b/src/metabase/metabot/api/entity_analysis.clj
@@ -4,7 +4,8 @@
    [metabase.api.macros :as api.macros]
    [metabase.api.routes.common :refer [+auth]]
    [metabase.metabot.config :as metabot.config]
-   [metabase.metabot.core :as metabot]))
+   [metabase.metabot.core :as metabot]
+   [metabase.metabot.usage :as metabot.usage]))
 
 (set! *warn-on-reflection* true)
 
@@ -27,6 +28,7 @@
                                                                                                                         [:timestamp :string]]]]]]]
 
   (metabot.config/check-metabot-enabled!)
+  (metabot.usage/check-metabase-managed-free-limit!)
   (let [chart-data {:image_base64 image_base64
                     :chart {:name name
                             :description description}

--- a/src/metabase/metabot/api/metabot.clj
+++ b/src/metabase/metabot/api/metabot.clj
@@ -7,6 +7,7 @@
    [metabase.app-db.core :as mdb]
    [metabase.metabot.suggested-prompts :as metabot.suggested-prompts]
    [metabase.metabot.tools.util :as metabot.tools.u]
+   [metabase.metabot.usage :as metabot.usage]
    [metabase.premium-features.core :as premium-features]
    [metabase.request.core :as request]
    [metabase.util.i18n :refer [tru]]
@@ -55,8 +56,9 @@
     (let [old-vals (select-keys old-metabot (keys metabot-updates))]
       (when (not= old-vals metabot-updates)
         (t2/update! :model/Metabot id metabot-updates)
-        (metabot.suggested-prompts/delete-all-metabot-prompts id)
-        (metabot.suggested-prompts/generate-sample-prompts id))
+        (when-not (metabot.usage/managed-free-limit-reached?)
+          (metabot.suggested-prompts/delete-all-metabot-prompts id)
+          (metabot.suggested-prompts/generate-sample-prompts id)))
       (t2/select-one :model/Metabot :id id))))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
@@ -69,6 +71,7 @@
   (api/check-superuser)
   (t2/with-transaction [_conn]
     (api/check-404 (t2/exists? :model/Metabot :id id))
+    (metabot.usage/check-metabase-managed-free-limit!)
     (metabot.suggested-prompts/delete-all-metabot-prompts id)
     (metabot.suggested-prompts/generate-sample-prompts id))
   api/generic-204-no-content)

--- a/src/metabase/metabot/settings.clj
+++ b/src/metabase/metabot/settings.clj
@@ -100,9 +100,21 @@
   "Providers that can be used directly (not via the metabase/ proxy prefix)."
   #{"anthropic" "openai" "openrouter"})
 
+(def ^:private default-anthropic-llm-metabot-model
+  "Default Anthropic model used for Metabot when no explicit model is selected."
+  "claude-sonnet-4-6")
+
 (def default-llm-metabot-provider
   "Default provider/model used for Metabot when no explicit model is selected."
-  "anthropic/claude-sonnet-4-6")
+  (str "anthropic/" default-anthropic-llm-metabot-model))
+
+(def default-llm-metabot-model-by-provider
+  "Default model payload keyed by provider for `PUT /api/metabot/settings`.
+
+  Values match the shape expected in the request body for each provider: direct providers use a bare model ID, while the
+  managed `metabase` provider uses the proxied `provider/model` form."
+  {"anthropic"                       default-anthropic-llm-metabot-model
+   provider-util/metabase-provider-prefix default-llm-metabot-provider})
 
 (def default-metabase-llm-metabot-provider
   "Managed-provider version of [[default-llm-metabot-provider]]."
@@ -175,6 +187,14 @@
                        :provider    inner-provider
                        :model       inner-model
                        :supported   allowed-models})))))
+(defn default-model-for-provider
+  "Return the default request-model payload for a provider.
+
+  When `provider` is nil, fall back to the global default provider/model string."
+  [provider]
+  (if (nil? provider)
+    default-llm-metabot-provider
+    (get default-llm-metabot-model-by-provider provider)))
 
 (defn- validate-metabot-provider!
   "Validate that `value` has the format `provider/model` with a supported provider prefix.

--- a/src/metabase/metabot/suggested_prompts.clj
+++ b/src/metabase/metabot/suggested_prompts.clj
@@ -5,6 +5,7 @@
    [metabase.metabot.example-question-generator :as native-generator]
    [metabase.metabot.tools.entity-details :as metabot.tools.entity-details]
    [metabase.metabot.tools.util :as metabot.tools.u]
+   [metabase.metabot.usage :as metabot.usage]
    [metabase.util.log :as log]
    [toucan2.core :as t2]))
 
@@ -48,35 +49,38 @@
 (defn generate-sample-prompts
   "Generate suggested prompts for instance of Metabot."
   [metabot-id & {:as opts}]
-  (let [opts (merge default-opts opts)]
-    (lib-be/with-metadata-provider-cache
-      (let [{metrics :metric models :model} (->> (metabot.tools.u/get-metrics-and-models metabot-id opts)
-                                                 (sort-by :view_count >)
-                                                 (group-by :type))
-            ;; Limit to 5 metrics and 5 models
-            limited-cards (concat (take 5 metrics) (take 5 models))
-            {metrics :metric, models :model}
-            (->> (for [[[card-type database-id] group-cards] (group-by (juxt :type :database_id) limited-cards)
-                       detail (map (fn [detail card] (assoc detail ::origin card))
-                                   (metabot.tools.entity-details/cards-details card-type database-id group-cards nil)
-                                   group-cards)]
-                   detail)
-                 (group-by :type))
-            metric-inputs (map metric-input metrics)
-            model-inputs (map model-input models)
-            {:keys [table_questions metric_questions]}
-            (generate-questions-with-fallback {:metrics metric-inputs, :tables model-inputs})
-            ->prompt (fn [{:keys [questions]} {::keys [origin]}]
-                       (let [base {:metabot_id metabot-id
-                                   :model      (:type origin)
-                                   :card_id    (:id origin)}]
-                         (map #(assoc base :prompt %) questions)))
-            metric-prompts (mapcat ->prompt metric_questions metrics)
-            model-prompts (mapcat ->prompt table_questions models)]
-        (when (seq metric-prompts)
-          (t2/insert! :model/MetabotPrompt metric-prompts))
-        (when (seq model-prompts)
-          (t2/insert! :model/MetabotPrompt model-prompts))))))
+  (if (metabot.usage/managed-free-limit-reached?)
+    (log/info "Skipping suggested prompt generation because the managed AI free limit has been reached."
+              {:metabot-id metabot-id})
+    (let [opts (merge default-opts opts)]
+      (lib-be/with-metadata-provider-cache
+        (let [{metrics :metric models :model} (->> (metabot.tools.u/get-metrics-and-models metabot-id opts)
+                                                   (sort-by :view_count >)
+                                                   (group-by :type))
+              ;; Limit to 5 metrics and 5 models
+              limited-cards (concat (take 5 metrics) (take 5 models))
+              {metrics :metric, models :model}
+              (->> (for [[[card-type database-id] group-cards] (group-by (juxt :type :database_id) limited-cards)
+                         detail (map (fn [detail card] (assoc detail ::origin card))
+                                     (metabot.tools.entity-details/cards-details card-type database-id group-cards nil)
+                                     group-cards)]
+                     detail)
+                   (group-by :type))
+              metric-inputs (map metric-input metrics)
+              model-inputs (map model-input models)
+              {:keys [table_questions metric_questions]}
+              (generate-questions-with-fallback {:metrics metric-inputs, :tables model-inputs})
+              ->prompt (fn [{:keys [questions]} {::keys [origin]}]
+                         (let [base {:metabot_id metabot-id
+                                     :model      (:type origin)
+                                     :card_id    (:id origin)}]
+                           (map #(assoc base :prompt %) questions)))
+              metric-prompts (mapcat ->prompt metric_questions metrics)
+              model-prompts (mapcat ->prompt table_questions models)]
+          (when (seq metric-prompts)
+            (t2/insert! :model/MetabotPrompt metric-prompts))
+          (when (seq model-prompts)
+            (t2/insert! :model/MetabotPrompt model-prompts)))))))
 
 (defn delete-all-metabot-prompts
   "Drop suggested prompts for instance of Metabot."

--- a/src/metabase/metabot/usage.clj
+++ b/src/metabase/metabot/usage.clj
@@ -62,16 +62,17 @@
         default-key (default-metabase-meter-key)]
     (meter-value meters default-key)))
 
-(defn- managed-free-limit-reached?
-  [token-status]
-  (some-> (meter-entry token-status)
-          :is-locked))
+(defn managed-free-limit-reached?
+  "True when the configured managed Metabase provider is locked for free-tier usage."
+  ([] (and (provider-util/metabase-provider? (metabot.settings/llm-metabot-provider))
+           (some-> (premium-features/token-status) managed-free-limit-reached?)))
+  ([token-status]
+   (some-> (meter-entry token-status)
+           :is-locked)))
 
 (defn check-metabase-managed-free-limit!
   "Return the free-trial lock message when the managed Metabase provider is locked."
   []
-  (api/check (not (and
-                   (provider-util/metabase-provider? (metabot.settings/llm-metabot-provider))
-                   (some-> (premium-features/token-status) managed-free-limit-reached?)))
+  (api/check (not (managed-free-limit-reached?))
              [402 {:message    (tru "You''ve used all of your included AI service tokens. To keep using AI features, end your trial early and start your subscription, or add your own AI provider API key.")
                    :error-code "metabase-ai-managed-locked"}]))

--- a/src/metabase/metabot/usage.clj
+++ b/src/metabase/metabot/usage.clj
@@ -75,4 +75,4 @@
   []
   (api/check (not (managed-free-limit-reached?))
              [402 {:message    (tru "You''ve used all of your included AI service tokens. To keep using AI features, end your trial early and start your subscription, or add your own AI provider API key.")
-                   :error-code "metabase-ai-managed-locked"}]))
+                   :error-code "metabase_ai_managed_locked"}]))

--- a/src/metabase/metabot/usage.clj
+++ b/src/metabase/metabot/usage.clj
@@ -6,7 +6,13 @@
   Limit checking: [[check-usage-limits!]] checks instance, tenant, and user limits.
   In OSS, no limits are enforced and no usage is logged."
   (:require
-   [metabase.premium-features.core :refer [defenterprise defenterprise-schema]]
+   [clojure.string :as str]
+   [metabase.api.common :as api]
+   [metabase.metabot.provider-util :as provider-util]
+   [metabase.metabot.settings :as metabot.settings]
+   [metabase.premium-features.core :as premium-features :refer [defenterprise defenterprise-schema]]
+   [metabase.util :as u]
+   [metabase.util.i18n :refer [tru]]
    [metabase.util.malli.schema :as ms]))
 
 (def ^:private usage-map-schema
@@ -37,3 +43,35 @@
   metabase-enterprise.metabot.usage
   []
   nil)
+
+(defn- meter-value
+  [meters meter-key]
+  (some-> meter-key keyword meters))
+
+(defn- default-metabase-meter-key
+  []
+  (some-> metabot.settings/default-metabase-llm-metabot-provider
+          provider-util/strip-metabase-prefix
+          u/qualified-name
+          (str/replace-first "/" ":")
+          (str ":tokens")))
+
+(defn- meter-entry
+  [token-status]
+  (let [meters      (:meters token-status)
+        default-key (default-metabase-meter-key)]
+    (meter-value meters default-key)))
+
+(defn- managed-free-limit-reached?
+  [token-status]
+  (some-> (meter-entry token-status)
+          :is-locked))
+
+(defn check-metabase-managed-free-limit!
+  "Return the free-trial lock message when the managed Metabase provider is locked."
+  []
+  (api/check (not (and
+                   (provider-util/metabase-provider? (metabot.settings/llm-metabot-provider))
+                   (some-> (premium-features/token-status) managed-free-limit-reached?)))
+             [402 {:message    (tru "You''ve used all of your included AI service tokens. To keep using AI features, end your trial early and start your subscription, or add your own AI provider API key.")
+                   :error-code "metabase-ai-managed-locked"}]))

--- a/src/metabase/slackbot/streaming.clj
+++ b/src/metabase/slackbot/streaming.clj
@@ -13,6 +13,7 @@
    [metabase.metabot.persistence :as metabot.persistence]
    [metabase.metabot.self.core :as self.core]
    [metabase.metabot.settings :as metabot.settings]
+   [metabase.metabot.usage :as metabot.usage]
    [metabase.metabot.util :as metabot.u]
    [metabase.permissions.core :as perms]
    [metabase.slackbot.channel :as slackbot.channel]
@@ -478,6 +479,12 @@
                 :negative_button {:text  {:type "plain_text" :text "Bad"}
                                   :value (json/encode {:conversation_id conversation-id :positive false})}}]}])
 
+(defn- free-limit-error-message
+  [e]
+  (let [{:keys [error-code message]} (ex-data e)]
+    (when (= error-code "metabase-ai-managed-locked")
+      (or message (ex-message e)))))
+
 (defn- prepare-response-context
   "Fetch thread/auth context shared by DM and channel delivery paths."
   [client event]
@@ -576,17 +583,27 @@
   ([client event]
    (send-response client event nil))
   ([client event extra-history]
-   (let [ctx (prepare-response-context client event)]
-     (if (slackbot.events/dm? event)
-       (send-dm-response client event extra-history ctx)
-       (slackbot.channel/send-channel-response client
-                                               event
-                                               extra-history
-                                               ctx
-                                               {:tool-name->friendly        tool-friendly-names
-                                                :make-streaming-ai-request  make-streaming-ai-request
-                                                :collect-viz-blocks         collect-viz-blocks
-                                                :feedback-blocks            feedback-blocks
-                                                :post-viz-error!            post-viz-error!
-                                                :make-viz-prefetch-callback make-viz-prefetch-callback
-                                                :cancel-prefetched-viz!     cancel-prefetched-viz!})))))
+   (let [message-ctx (slackbot.events/event->reply-context event)]
+     (try
+       (metabot.usage/check-metabase-managed-free-limit!)
+       (let [ctx (prepare-response-context client event)]
+         (if (slackbot.events/dm? event)
+           (send-dm-response client event extra-history ctx)
+           (slackbot.channel/send-channel-response client
+                                                   event
+                                                   extra-history
+                                                   ctx
+                                                   {:tool-name->friendly        tool-friendly-names
+                                                    :make-streaming-ai-request  make-streaming-ai-request
+                                                    :collect-viz-blocks         collect-viz-blocks
+                                                    :feedback-blocks            feedback-blocks
+                                                    :post-viz-error!            post-viz-error!
+                                                    :make-viz-prefetch-callback make-viz-prefetch-callback
+                                                    :cancel-prefetched-viz!     cancel-prefetched-viz!})))
+       (catch Exception e
+         (if-let [message (free-limit-error-message e)]
+           (let [result (slackbot.client/post-thread-reply client message-ctx message)]
+             (when-not (:ok result)
+               (log/errorf "[slackbot] Failed to post managed free limit error message: %s" (:error result))
+               (throw e)))
+           (throw e)))))))

--- a/src/metabase/slackbot/streaming.clj
+++ b/src/metabase/slackbot/streaming.clj
@@ -482,7 +482,7 @@
 (defn- free-limit-error-message
   [e]
   (let [{:keys [error-code message]} (ex-data e)]
-    (when (= error-code "metabase-ai-managed-locked")
+    (when (= error-code "metabase_ai_managed_locked")
       (or message (ex-message e)))))
 
 (defn- prepare-response-context

--- a/test/metabase/metabot/api/entity_analysis_test.clj
+++ b/test/metabase/metabot/api/entity_analysis_test.clj
@@ -2,6 +2,8 @@
   (:require
    [clojure.test :refer :all]
    [metabase.metabot.core :as metabot]
+   [metabase.metabot.settings :as metabot.settings]
+   [metabase.premium-features.core :as premium-features]
    [metabase.test :as mt]))
 
 (deftest analyze-chart-test
@@ -16,3 +18,21 @@
                                                                :timestamp "2023-04-15"}]})]
         (is (= {:summary "This chart shows a steady increase in sales over time, with a notable peak in Q4."}
                response))))))
+
+(deftest analyze-chart-returns-free-trial-limit-error-when-managed-provider-is-locked-test
+  (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
+                                     "metabase/anthropic/claude-sonnet-4-6"]
+    (with-redefs [premium-features/token-status
+                  (constantly {:meters {:anthropic:claude-sonnet-4-6:tokens {:meter-value 1000000
+                                                                             :is-locked   true}}})
+                  metabot/analyze-chart
+                  (fn [& _]
+                    (throw (ex-info "should not call analyze-chart" {})))]
+      (let [response (mt/user-http-request :rasta :post 402 "ai-entity-analysis/analyze-chart"
+                                           {:image_base64 "base64encodedimage"
+                                            :name         "Sales Trend"
+                                            :description  "Quarterly sales data"})]
+        (is (= "You've used all of your included AI service tokens. To keep using AI features, end your trial early and start your subscription, or add your own AI provider API key."
+               (if (map? response)
+                 (:message response)
+                 response)))))))

--- a/test/metabase/metabot/api/metabot_test.clj
+++ b/test/metabase/metabot/api/metabot_test.clj
@@ -6,9 +6,11 @@
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.metabot.example-question-generator :as metabot.example-question-generator]
+   [metabase.metabot.settings :as metabot.settings]
    [metabase.metabot.suggested-prompts :as metabot.suggested-prompts]
    [metabase.permissions.core :as perms]
    [metabase.permissions.models.permissions-group :as perms-group]
+   [metabase.premium-features.core :as premium-features]
    [metabase.test :as mt]
    [toucan2.core :as t2]))
 
@@ -271,6 +273,66 @@
                    (:message (mt/user-http-request :crowberto :put 402
                                                    (format "metabot/metabot/%d" metabot-id)
                                                    {:use_verified_content true}))))))))))
+
+(deftest metabot-put-skips-prompt-regeneration-when-managed-provider-is-locked-test
+  (mt/dataset test-data
+    (let [model-query {:type :query, :database (mt/id), :query {:source-table (mt/id :products)}}]
+      (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
+                                         "metabase/anthropic/claude-sonnet-4-6"]
+        (mt/with-temp [:model/Collection {collection-id :id} {:name "Collection"}
+                       :model/Metabot {metabot-id :id} {:name "Test Metabot"
+                                                        :collection_id collection-id}
+                       :model/Card {card-id :id} {:name "Test Model Card"
+                                                  :type :model
+                                                  :dataset_query model-query}
+                       :model/MetabotPrompt {prompt-id :id} {:metabot_id metabot-id
+                                                             :prompt "existing prompt"
+                                                             :model :model
+                                                             :card_id card-id}]
+          (with-redefs [premium-features/token-status
+                        (constantly {:meters {:anthropic:claude-sonnet-4-6:tokens {:meter-value 1000000
+                                                                                   :is-locked   true}}})
+                        metabot.suggested-prompts/delete-all-metabot-prompts
+                        (fn [& _]
+                          (throw (ex-info "should not delete prompts" {})))
+                        metabot.suggested-prompts/generate-sample-prompts
+                        (fn [& _]
+                          (throw (ex-info "should not generate prompts" {})))]
+            (let [response (mt/user-http-request :crowberto :put 200
+                                                 (format "metabot/metabot/%d" metabot-id)
+                                                 {:collection_id nil})]
+              (is (nil? (:collection_id response)))
+              (is (= #{prompt-id}
+                     (t2/select-pks-set :model/MetabotPrompt :metabot_id metabot-id))))))))))
+
+(deftest metabot-prompt-regenerate-returns-free-trial-limit-error-when-managed-provider-is-locked-test
+  (mt/dataset test-data
+    (let [model-query {:type :query, :database (mt/id), :query {:source-table (mt/id :products)}}]
+      (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
+                                         "metabase/anthropic/claude-sonnet-4-6"]
+        (mt/with-temp [:model/Metabot {metabot-id :id} {:name "Test Metabot"}
+                       :model/Card {card-id :id} {:name "Test Model Card"
+                                                  :type :model
+                                                  :dataset_query model-query}
+                       :model/MetabotPrompt {prompt-id :id} {:metabot_id metabot-id
+                                                             :prompt "existing prompt"
+                                                             :model :model
+                                                             :card_id card-id}]
+          (with-redefs [premium-features/token-status
+                        (constantly {:meters {:anthropic:claude-sonnet-4-6:tokens {:meter-value 1000000
+                                                                                   :is-locked   true}}})
+                        metabot.suggested-prompts/delete-all-metabot-prompts
+                        (fn [& _]
+                          (throw (ex-info "should not delete prompts" {})))
+                        metabot.suggested-prompts/generate-sample-prompts
+                        (fn [& _]
+                          (throw (ex-info "should not generate prompts" {})))]
+            (let [response (mt/user-http-request :crowberto :post 402
+                                                 (format "metabot/metabot/%d/prompt-suggestions/regenerate" metabot-id))]
+              (is (= "You've used all of your included AI service tokens. To keep using AI features, end your trial early and start your subscription, or add your own AI provider API key."
+                     (:message response))))
+            (is (= #{prompt-id}
+                   (t2/select-pks-set :model/MetabotPrompt :metabot_id metabot-id)))))))))
 
 (deftest metabot-prompt-regeneration-on-config-change-test
   (mt/dataset test-data

--- a/test/metabase/metabot/api_test.clj
+++ b/test/metabase/metabot/api_test.clj
@@ -406,7 +406,7 @@
 
 (deftest settings-put-api-key-switches-from-metabase-to-provider-default-model-test
   (mt/with-temp-env-var-value! [mb-llm-anthropic-api-key nil]
-    (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider "metabase/anthropic/claude-opus-4-1"
+    (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider "metabase/anthropic/claude-sonnet-4-6"
                                        llm.settings/llm-anthropic-api-key nil]
       (let [calls (atom 0)]
         (with-redefs [metabot.self/list-models (fn [provider {:keys [api-key]}]

--- a/test/metabase/metabot/api_test.clj
+++ b/test/metabase/metabot/api_test.clj
@@ -422,12 +422,12 @@
                                                             :display_name "Claude Opus 4.1"
                                                             :group "Opus"}]})]
           (is (= {:value  "anthropic/claude-sonnet-4-6"
-                  :models [{:id "claude-sonnet-4-6"
-                            :display_name "Claude Sonnet 4.6"
-                            :group "Sonnet"}
-                           {:id "claude-opus-4-1"
+                  :models [{:id "claude-opus-4-1"
                             :display_name "Claude Opus 4.1"
-                            :group "Opus"}]}
+                            :group "Opus"}
+                           {:id "claude-sonnet-4-6"
+                            :display_name "Claude Sonnet 4.6"
+                            :group "Sonnet"}]}
                  (mt/user-http-request :crowberto :put 200 "metabot/settings"
                                        {:provider "anthropic"
                                         :api-key  "sk-ant-valid"})))
@@ -450,12 +450,12 @@
                                                        {:id "claude-opus-4-1"
                                                         :display_name "Claude Opus 4.1"}]})]
       (is (= {:value  "anthropic/claude-opus-4-1"
-              :models [{:id "claude-sonnet-4-6"
-                        :display_name "Claude Sonnet 4.6"
-                        :group "Sonnet"}
-                       {:id "claude-opus-4-1"
+              :models [{:id "claude-opus-4-1"
                         :display_name "Claude Opus 4.1"
-                        :group "Opus"}]}
+                        :group "Opus"}
+                       {:id "claude-sonnet-4-6"
+                        :display_name "Claude Sonnet 4.6"
+                        :group "Sonnet"}]}
              (mt/user-http-request :crowberto :put 200 "metabot/settings"
                                    {:provider "anthropic"
                                     :model    ""})))

--- a/test/metabase/metabot/api_test.clj
+++ b/test/metabase/metabot/api_test.clj
@@ -20,6 +20,7 @@
    [metabase.metabot.self.openrouter :as openrouter]
    [metabase.metabot.settings :as metabot.settings]
    [metabase.metabot.test-util :as mut]
+   [metabase.premium-features.core :as premium-features]
    [metabase.search.test-util :as search.tu]
    [metabase.server.instance :as server.instance]
    [metabase.server.streaming-response :as sr]
@@ -373,6 +374,94 @@
               "should verify before saving and reuse the verified response")
           (is (= "sk-ant-valid"
                  (llm.settings/llm-anthropic-api-key))))))))
+
+(deftest settings-put-api-key-rotation-does-not-reset-non-default-model-test
+  (mt/with-temp-env-var-value! [mb-llm-anthropic-api-key nil]
+    (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider "anthropic/claude-opus-4-1"
+                                       llm.settings/llm-anthropic-api-key nil]
+      (let [calls (atom 0)]
+        (with-redefs [metabot.self/list-models (fn [provider {:keys [api-key]}]
+                                                 (swap! calls inc)
+                                                 (is (= "anthropic" provider))
+                                                 (is (= "sk-ant-valid" api-key))
+                                                 (is (nil? (llm.settings/llm-anthropic-api-key))
+                                                     "verification should happen before saving the key")
+                                                 {:models [{:id "claude-opus-4-1"
+                                                            :display_name "Claude Opus 4.1"
+                                                            :group "Opus"}]})]
+          (is (= {:value  "anthropic/claude-opus-4-1"
+                  :models [{:id "claude-opus-4-1"
+                            :display_name "Claude Opus 4.1"
+                            :group "Opus"}]}
+                 (mt/user-http-request :crowberto :put 200 "metabot/settings"
+                                       {:provider "anthropic"
+                                        :api-key  "sk-ant-valid"})))
+          (is (= 1 @calls)
+              "should verify before saving and reuse the verified response")
+          (is (= "anthropic/claude-opus-4-1"
+                 (metabot.settings/llm-metabot-provider))
+              "rotating an API key should not reset the selected model")
+          (is (= "sk-ant-valid"
+                 (llm.settings/llm-anthropic-api-key))))))))
+
+(deftest settings-put-api-key-switches-from-metabase-to-provider-default-model-test
+  (mt/with-temp-env-var-value! [mb-llm-anthropic-api-key nil]
+    (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider "metabase/anthropic/claude-opus-4-1"
+                                       llm.settings/llm-anthropic-api-key nil]
+      (let [calls (atom 0)]
+        (with-redefs [metabot.self/list-models (fn [provider {:keys [api-key]}]
+                                                 (swap! calls inc)
+                                                 (is (= "anthropic" provider))
+                                                 (is (= "sk-ant-valid" api-key))
+                                                 (is (nil? (llm.settings/llm-anthropic-api-key))
+                                                     "verification should happen before saving the key")
+                                                 {:models [{:id "claude-sonnet-4-6"
+                                                            :display_name "Claude Sonnet 4.6"
+                                                            :group "Sonnet"}
+                                                           {:id "claude-opus-4-1"
+                                                            :display_name "Claude Opus 4.1"
+                                                            :group "Opus"}]})]
+          (is (= {:value  "anthropic/claude-sonnet-4-6"
+                  :models [{:id "claude-sonnet-4-6"
+                            :display_name "Claude Sonnet 4.6"
+                            :group "Sonnet"}
+                           {:id "claude-opus-4-1"
+                            :display_name "Claude Opus 4.1"
+                            :group "Opus"}]}
+                 (mt/user-http-request :crowberto :put 200 "metabot/settings"
+                                       {:provider "anthropic"
+                                        :api-key  "sk-ant-valid"})))
+          (is (= 1 @calls)
+              "should verify before saving and reuse the verified response")
+          (is (= "anthropic/claude-sonnet-4-6"
+                 (metabot.settings/llm-metabot-provider))
+              "switching away from the managed provider should pick the anthropic default model")
+          (is (= "sk-ant-valid"
+                 (llm.settings/llm-anthropic-api-key))))))))
+
+(deftest settings-put-blank-model-does-not-reset-when-provider-is-unchanged-test
+  (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider "anthropic/claude-opus-4-1"
+                                     llm.settings/llm-anthropic-api-key "sk-ant-valid"]
+    (with-redefs [metabot.self/list-models (fn [provider {:keys [api-key]}]
+                                             (is (= "anthropic" provider))
+                                             (is (= "sk-ant-valid" api-key))
+                                             {:models [{:id "claude-sonnet-4-6"
+                                                        :display_name "Claude Sonnet 4.6"}
+                                                       {:id "claude-opus-4-1"
+                                                        :display_name "Claude Opus 4.1"}]})]
+      (is (= {:value  "anthropic/claude-opus-4-1"
+              :models [{:id "claude-sonnet-4-6"
+                        :display_name "Claude Sonnet 4.6"
+                        :group "Sonnet"}
+                       {:id "claude-opus-4-1"
+                        :display_name "Claude Opus 4.1"
+                        :group "Opus"}]}
+             (mt/user-http-request :crowberto :put 200 "metabot/settings"
+                                   {:provider "anthropic"
+                                    :model    ""})))
+      (is (= "anthropic/claude-opus-4-1"
+             (metabot.settings/llm-metabot-provider))
+          "blank model should not reset the selection when the provider is unchanged"))))
 
 (deftest settings-put-rejects-invalid-api-key-test
   (mt/with-temporary-setting-values [llm.settings/llm-openai-api-key nil]
@@ -730,3 +819,20 @@
               "metabot-id should not be nil")
           (is (= test-metabot-id (:metabot-id @captured-args))
               "metabot-id should match the input metabot_id"))))))
+
+(deftest agent-streaming-returns-free-trial-limit-error-when-managed-provider-is-locked-test
+  (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
+                                     "metabase/anthropic/claude-sonnet-4-6"]
+    (with-redefs [premium-features/token-status             (constantly {:meters {:anthropic:claude-sonnet-4-6:tokens {:meter-value 1000000
+                                                                                                                       :is-locked   true}}})
+                  metabot.config/check-metabot-enabled!     (constantly nil)
+                  api/store-aiservice-messages!             (fn [& _]
+                                                              (throw (ex-info "should not store messages" {})))
+                  api/native-agent-streaming-request        (fn [& _]
+                                                              (throw (ex-info "should not call agent" {})))]
+      (mt/user-http-request :rasta :post 402 "metabot/agent-streaming"
+                            {:message         "test message"
+                             :context         {}
+                             :conversation_id (str (random-uuid))
+                             :history         []
+                             :state           {}}))))

--- a/test/metabase/metabot/task/suggested_prompts_generator_test.clj
+++ b/test/metabase/metabot/task/suggested_prompts_generator_test.clj
@@ -6,7 +6,9 @@
    [metabase.lib.metadata :as lib.metadata]
    [metabase.metabot.config :as metabot.config]
    [metabase.metabot.example-question-generator :as metabot.example-question-generator]
+   [metabase.metabot.settings :as metabot.settings]
    [metabase.metabot.task.suggested-prompts-generator :as metabot.task.suggested-prompts-generator]
+   [metabase.premium-features.core :as premium-features]
    [metabase.test :as mt]
    [toucan2.core :as t2]))
 
@@ -76,3 +78,29 @@
 
             ;; Reset metabot state
               (t2/update! :model/Metabot (:id original-metabot) {:use_verified_content false}))))))))
+
+(deftest suggested-prompts-generator-skips-generation-when-managed-provider-is-locked-test
+  (mt/with-premium-features #{:content-verification}
+    (mt/with-empty-h2-app-db!
+      (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
+                                         "metabase/anthropic/claude-sonnet-4-6"]
+        (let [original-metabot (t2/select-one :model/Metabot
+                                              :entity_id (get-in metabot.config/metabot-config
+                                                                 [metabot.config/internal-metabot-id :entity-id]))
+              mp (mt/metadata-provider)
+              query (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
+                        lib.convert/->legacy-MBQL)]
+          (mt/with-model-cleanup [:model/MetabotPrompt]
+            (mt/with-temp [:model/Card
+                           {card-id :id}
+                           {:type :model
+                            :dataset_query query}]
+              (t2/update! :model/Metabot (:id original-metabot) {:use_verified_content false})
+              (with-redefs [premium-features/token-status
+                            (constantly {:meters {:anthropic:claude-sonnet-4-6:tokens {:meter-value 1000000
+                                                                                       :is-locked   true}}})
+                            metabot.example-question-generator/generate-example-questions
+                            (fn [& _]
+                              (throw (ex-info "should not generate prompts" {})))]
+                (#'metabot.task.suggested-prompts-generator/maybe-generate-suggested-prompts!)
+                (is (empty? (t2/select :model/MetabotPrompt :card_id card-id)))))))))))

--- a/test/metabase/slackbot/streaming_test.clj
+++ b/test/metabase/slackbot/streaming_test.clj
@@ -2,7 +2,10 @@
   (:require
    [clojure.test :refer :all]
    [metabase.metabot.persistence :as metabot.persistence]
+   [metabase.metabot.settings :as metabot.settings]
+   [metabase.premium-features.core :as premium-features]
    [metabase.slackbot.client :as slackbot.client]
+   [metabase.slackbot.events :as slackbot.events]
    [metabase.slackbot.persistence :as slackbot.persistence]
    [metabase.slackbot.streaming :as slackbot.streaming]
    [metabase.slackbot.test-util :as tu]
@@ -149,6 +152,27 @@
                   (is (= "metabot_feedback" (:block_id (first blocks))))
                   (is (= "feedback_buttons" (:type (first (:elements (first blocks)))))))))))))))
 
+(deftest slackbot-posts-free-trial-limit-error-when-managed-provider-is-locked-test
+  (let [posted-message (atom nil)
+        event          {:channel "C1" :ts "123.456" :channel_type "im"}]
+    (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
+                                       "metabase/anthropic/claude-sonnet-4-6"]
+      (with-redefs [premium-features/token-status
+                    (constantly {:meters {:anthropic:claude-sonnet-4-6:tokens {:meter-value 1000000
+                                                                               :is-locked   true}}})
+                    slackbot.events/event->reply-context
+                    (constantly {:channel "C1" :thread_ts "123.456"})
+                    slackbot.events/dm?
+                    (constantly true)
+                    slackbot.client/post-thread-reply
+                    (fn [_ message-ctx text & _]
+                      (reset! posted-message {:message-ctx message-ctx :text text})
+                      {:ok true})]
+        (slackbot.streaming/send-response {:token "xoxb-test"} event)
+        (is (= {:message-ctx {:channel "C1" :thread_ts "123.456"}
+                :text        "You've used all of your included AI service tokens. To keep using AI features, end your trial early and start your subscription, or add your own AI provider API key."}
+               @posted-message))))))
+
 (deftest slackbot-streaming-sets-ai-proxied-on-messages-test
   (testing "store-message! receives ai-proxy? = true for metabase/ prefixed provider"
     (tu/with-slackbot-setup
@@ -158,7 +182,9 @@
           {:ai-text "Hello!"}
           (fn [{:keys [stop-stream-calls]}]
             (mt/with-temporary-setting-values [llm-metabot-provider "metabase/anthropic/claude-sonnet-4-6"]
-              (with-redefs [metabot.persistence/store-message!
+              (with-redefs [premium-features/token-status
+                            (constantly nil)
+                            metabot.persistence/store-message!
                             (fn [_conv-id _profile-id _messages & {:as opts}]
                               (swap! store-opts conj opts)
                               nil)]


### PR DESCRIPTION
Closes [BOT-1317: Handle `is-locked` for metabase AI provider](https://linear.app/metabase/issue/BOT-1317/handle-is-locked-for-metabase-ai-provider)
Closes [BOT-1312: Validate UX when running out of tokens on 14-day free trial](https://linear.app/metabase/issue/BOT-1312/validate-ux-when-running-out-of-tokens-on-14-day-free-trial)

### Description

Note for BE reviewers – I think I've added a guard to all places where we use AI to generate content, but lmk if I forgot anything!

Handle `is-locked` for the `metabase-ai-managed` meter. If locked, should display error when trying to make a request. The error is

```
You've used all of your included AI service tokens. To keep using AI features you can either end your trial early and start your subscription, or stay in the trial and add your own AI provider API key.
```

### How to verify

1. Set your `anthropic:claude-sonnet-4.6:tokens` meter to be locked
2. Try sending a message to metabot

### Demo

https://www.loom.com/share/5222ade1b46a4e27ba91ad1a00440122

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
