### PR TITLE
BOT-1321 Add ai_usage_log migration to v60

### DIFF
--- a/resources/migrations/060/20260415_ai_usage_log.yaml
+++ b/resources/migrations/060/20260415_ai_usage_log.yaml
@@ -1,101 +1,19 @@
-## AI usage log table
+## Backport of ai_usage_log table from v61
 
 databaseChangeLog:
-  - changeSet:
-      id: v61.t42424d
-      author: nvoxland
-      comment: Create metabot_instance_limit table
-      changes:
-        - createTable:
-            tableName: metabot_instance_limit
-            remarks: Metabot usage limits at the instance or tenant level
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: tenant_id
-                  type: int
-                  remarks: The tenant ID, or null for instance-wide limit
-                  constraints:
-                    nullable: true
-                    unique: true
-              - column:
-                  name: max_usage
-                  type: int
-                  remarks: The maximum usage value, interpreted according to the metabot-limit-unit setting. Null is unlimited
+  - logicalFilePath: migrations/060_update_migrations.yaml
 
   - changeSet:
-      id: v61.44ga4
-      author: nvoxland
-      comment: Add foreign key on metabot_instance_limit.tenant_id referencing tenant
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: metabot_instance_limit
-            baseColumnNames: tenant_id
-            referencedTableName: tenant
-            referencedColumnNames: id
-            constraintName: fk_metabot_instance_limit_ref_tenant
-            onDelete: CASCADE
-
-  - changeSet:
-      id: v61.gr34fp
-      author: nvoxland
-      comment: Create metabot_group_limit table
-      changes:
-        - createTable:
-            tableName: metabot_group_limit
-            remarks: Metabot usage limits per group
-            columns:
-              - column:
-                  name: id
-                  type: int
-                  autoIncrement: true
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: group_id
-                  type: int
-                  remarks: The ID of the associated permissions group
-                  constraints:
-                    nullable: false
-                    unique: true
-              - column:
-                  name: max_usage
-                  type: int
-                  remarks: The maximum usage value, interpreted according to the metabot-limit-unit setting
-                  constraints:
-                    nullable: false
-
-  - changeSet:
-      id: v61.gr34fp-fk
-      author: nvoxland
-      comment: Add foreign key on metabot_group_limit.group_id referencing permissions_group
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: metabot_group_limit
-            baseColumnNames: group_id
-            referencedTableName: permissions_group
-            referencedColumnNames: id
-            constraintName: fk_metabot_group_limit_ref_permissions_group
-            onDelete: CASCADE
-
-  - changeSet:
-      id: v61.gresdvx
+      id: v60.gresdvx
       author: nvoxland
       comment: Create the ai_usage_log
       preConditions:
         - onFail: MARK_RAN
         - not:
             changeSetExecuted:
-              id: v60.gresdvx
+              id: v61.gresdvx
               author: nvoxland
-              changeLogFile: migrations/060_update_migrations.yaml
+              changeLogFile: migrations/061/20260330_ai_usage_log.yaml
       changes:
         - createTable:
             tableName: ai_usage_log
@@ -165,19 +83,18 @@ databaseChangeLog:
                   name: request_id
                   type: varchar(36)
                   remarks: 'UUID for correlating with Snowplow events'
-      rollback: ""
 
   - changeSet:
-      id: v61.8g8esw
+      id: v60.8g8esw
       author: nvoxland
       comment: Index on ai_usage_log.user_id
       preConditions:
         - onFail: MARK_RAN
         - not:
             changeSetExecuted:
-              id: v60.8g8esw
+              id: v61.8g8esw
               author: nvoxland
-              changeLogFile: migrations/060_update_migrations.yaml
+              changeLogFile: migrations/061/20260330_ai_usage_log.yaml
       changes:
         - createIndex:
             indexName: idx_ai_usage_log_user_id
@@ -185,4 +102,3 @@ databaseChangeLog:
             columns:
               - column:
                   name: user_id
-      rollback: ""

--- a/resources/migrations/060/20260415_ai_usage_log_ai_proxied.yaml
+++ b/resources/migrations/060/20260415_ai_usage_log_ai_proxied.yaml
@@ -1,0 +1,18 @@
+## Track whether ai_usage_log entries were routed through the AI proxy
+
+databaseChangeLog:
+  - logicalFilePath: migrations/060_update_migrations.yaml
+  - changeSet:
+      id: v60.kdhxne
+      author: mappleby
+      comment: Add ai_proxied flag to ai_usage_log to track proxy vs BYOK routing
+      changes:
+        - addColumn:
+            tableName: ai_usage_log
+            columns:
+              - column:
+                  name: ai_proxied
+                  type: ${boolean.type}
+                  remarks: Whether this call was routed through the Metabase Cloud AI proxy (true) or directly via BYOK keys (false). Null for rows created before this migration.
+                  constraints:
+                    nullable: true


### PR DESCRIPTION
Refs [BOT-1321: Use `ai_usage_log` for billing token reporting](https://linear.app/metabase/issue/BOT-1321/use-ai-usage-log-for-billing-token-reporting)

https://metaboat.slack.com/archives/C0AP8MCUE4U/p1776268073914229

See also

* #72662

### Description

* Backport `ai_usage_log` migration to v60
* Add `ai_proxied` column to `ai_usage_log` table

This is just backporting the migrations. I'll send a follow-up PR targeting the 60 release branch with a partial backport of just the code to populate `ai_usage_log`, plus another switching the metabot metering over to the new table.

Tested the following migrations locally, only with postgres.

* 60/61 fresh install
* 60 before -> 60 after these changes
* 61 before -> 61 after these changes
* 61 -> 60 -> 59 -> 60 -> 61
* 60 -> 61
* 59 -> 61

### Demo

#### v60 fresh install
```
2026-04-15 11:58:35,220 INFO liquibase.changelog :: Table ai_usage_log created
2026-04-15 11:58:35,221 INFO liquibase.changelog :: ChangeSet migrations/060_update_migrations.yaml::v60.gresdvx::nvoxland ran successfully in 20ms
2026-04-15 11:58:35,226 INFO liquibase.changelog :: Index idx_ai_usage_log_user_id created
2026-04-15 11:58:35,226 INFO liquibase.changelog :: ChangeSet migrations/060_update_migrations.yaml::v60.8g8esw::nvoxland ran successfully in 2ms
2026-04-15 11:58:35,229 INFO liquibase.changelog :: Columns ai_proxied(boolean) added to ai_usage_log
2026-04-15 11:58:35,229 INFO liquibase.changelog :: ChangeSet migrations/060_update_migrations.yaml::v60.kdhxne::mappleby ran successfully in 2ms
```


#### v61 with already run ai_usage_log migration
```
2026-04-15 18:05:05,033 INFO liquibase.changelog :: Marking ChangeSet: "migrations/060_update_migrations.yaml::v60.gresdvx::nvoxland" as ran despite precondition failure due to onFail='MARK_RAN':
          liquibase.yaml : Not precondition failed

2026-04-15 18:05:05,044 INFO liquibase.changelog :: Marking ChangeSet: "migrations/060_update_migrations.yaml::v60.8g8esw::nvoxland" as ran despite precondition failure due to onFail='MARK_RAN':
          liquibase.yaml : Not precondition failed

2026-04-15 18:05:05,048 INFO liquibase.changelog :: Columns ai_proxied(boolean) added to ai_usage_log
2026-04-15 18:05:05,049 INFO liquibase.changelog :: ChangeSet migrations/060_update_migrations.yaml::v60.kdhxne::mappleby ran successfully in 3ms
```

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
