### PR TITLE
[Viz] Row charts pass raw values to drill-thru, not formatted strings

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.tsx
@@ -219,7 +219,13 @@ const RowChartVisualization = ({
 
   const handleSelectSeries = (event: React.MouseEvent, seriesIndex: number) => {
     const clickData = {
-      ...getLegendClickData(seriesIndex, series, settings, chartColumns),
+      ...getLegendClickData(
+        seriesIndex,
+        series,
+        settings,
+        chartColumns,
+        groupedData,
+      ),
       element: event.currentTarget,
     };
 

--- a/frontend/src/metabase/visualizations/visualizations/RowChart/utils/events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/utils/events.ts
@@ -16,6 +16,7 @@ import type {
   Series,
 } from "metabase/visualizations/shared/components/RowChart/types";
 import type {
+  GroupedDataset,
   GroupedDatum,
   MetricDatum,
   SeriesInfo,
@@ -32,6 +33,7 @@ import type {
 import { isMetric } from "metabase-lib/v1/types/utils/isa";
 import type {
   DatasetColumn,
+  RowValue,
   RowValues,
   VisualizationSettings,
 } from "metabase-types/api";
@@ -151,19 +153,22 @@ export const getClickData = (
   );
 
   const xValue = series.xAccessor(datum);
-  const yValue = series.yAccessor(datum);
 
   const dimensions: ClickObjectDimension[] = [
     {
       column: chartColumns.dimension.column,
-      value: yValue,
+      value: datum.dimensionValue,
     },
   ];
 
   if ("breakout" in chartColumns) {
+    const breakoutRawRows =
+      datum.breakout?.[series.seriesKey]?.rawRows ?? datum.rawRows;
+    const rawBreakoutValue =
+      breakoutRawRows[0]?.[chartColumns.breakout.index] ?? null;
     dimensions.push({
       column: chartColumns.breakout.column,
-      value: series.seriesInfo?.breakoutValue ?? null,
+      value: rawBreakoutValue,
     });
   }
 
@@ -176,11 +181,26 @@ export const getClickData = (
   };
 };
 
+const getRawBreakoutValue = (
+  groupedData: GroupedDataset,
+  seriesKey: string,
+  breakoutColumnIndex: number,
+): RowValue => {
+  for (const datum of groupedData) {
+    const rawRows = datum.breakout?.[seriesKey]?.rawRows;
+    if (rawRows && rawRows.length > 0) {
+      return rawRows[0][breakoutColumnIndex] ?? null;
+    }
+  }
+  return null;
+};
+
 export const getLegendClickData = (
   seriesIndex: number,
   series: Series<GroupedDatum, SeriesInfo>[],
   visualizationSettings: VisualizationSettings,
   chartColumns: CartesianChartColumns,
+  groupedData: GroupedDataset,
 ) => {
   const currentSeries = series[seriesIndex];
 
@@ -189,7 +209,11 @@ export const getLegendClickData = (
       ? [
           {
             column: chartColumns.breakout.column,
-            value: currentSeries.seriesInfo?.breakoutValue ?? null,
+            value: getRawBreakoutValue(
+              groupedData,
+              currentSeries.seriesKey,
+              chartColumns.breakout.index,
+            ),
           },
         ]
       : undefined;

--- a/frontend/src/metabase/visualizations/visualizations/RowChart/utils/events.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/utils/events.unit.spec.ts
@@ -20,7 +20,12 @@ import {
   createMockNumericColumn,
 } from "metabase-types/api/mocks";
 
-import { getHoverData, getStackedTooltipRows } from "./events";
+import {
+  getClickData,
+  getHoverData,
+  getLegendClickData,
+  getStackedTooltipRows,
+} from "./events";
 
 const datasetColumns = [
   { name: "y", display_name: "Y" } as RemappingHydratedDatasetColumn,
@@ -474,6 +479,131 @@ describe("events utils", () => {
         tooltipData.data?.find(({ col }) => col?.name === "TOTALSPEND")?.value,
       ).toBe(600);
     });
+  });
+});
+
+describe("getClickData", () => {
+  it("passes raw null dimension value through to drill-thru (QUE2-97)", () => {
+    const dimensionColumn = createMockColumn({
+      name: "label",
+      display_name: "Label",
+    });
+    const breakoutColumn = createMockColumn({
+      name: "quarter",
+      display_name: "Quarter",
+    });
+    const metricColumn = createMockNumericColumn({
+      name: "count",
+      display_name: "Count",
+    });
+    const datasetColumns = [dimensionColumn, breakoutColumn, metricColumn];
+
+    const chartColumns: BreakoutChartColumns = {
+      dimension: { index: 0, column: dimensionColumn },
+      breakout: { index: 1, column: breakoutColumn },
+      metric: { index: 2, column: metricColumn },
+    };
+
+    const datum: GroupedDatum = {
+      dimensionValue: null,
+      metrics: { count: 5 },
+      isClickable: true,
+      rawRows: [[null, null, 5]],
+      breakout: {
+        "(empty)": {
+          metrics: { count: 5 },
+          rawRows: [[null, null, 5]],
+        },
+      },
+    };
+
+    const series: Series<GroupedDatum, SeriesInfo> = {
+      seriesKey: "(empty)",
+      seriesName: "(empty)",
+      seriesInfo: {
+        metricColumn,
+        dimensionColumn,
+        breakoutValue: "(empty)",
+      },
+      xAccessor: (datum: GroupedDatum) => datum.metrics["count"],
+      yAccessor: SERIES_Y_ACCESSOR,
+    };
+
+    const bar: BarData<GroupedDatum, SeriesInfo> = {
+      isNegative: false,
+      xStartValue: 0,
+      xEndValue: 5,
+      yValue: "(empty)",
+      datum,
+      datumIndex: 0,
+      series,
+      seriesIndex: 0,
+    };
+
+    const clickData = getClickData(bar, {}, chartColumns, datasetColumns);
+
+    expect(clickData.dimensions).toEqual([
+      { column: dimensionColumn, value: null },
+      { column: breakoutColumn, value: null },
+    ]);
+  });
+});
+
+describe("getLegendClickData", () => {
+  it("passes raw null breakout value through to drill-thru (QUE2-97)", () => {
+    const dimensionColumn = createMockColumn({
+      name: "label",
+      display_name: "Label",
+    });
+    const breakoutColumn = createMockColumn({
+      name: "quarter",
+      display_name: "Quarter",
+    });
+    const metricColumn = createMockNumericColumn({
+      name: "count",
+      display_name: "Count",
+    });
+
+    const chartColumns: BreakoutChartColumns = {
+      dimension: { index: 0, column: dimensionColumn },
+      breakout: { index: 1, column: breakoutColumn },
+      metric: { index: 2, column: metricColumn },
+    };
+
+    const groupedData: GroupedDatum[] = [
+      {
+        dimensionValue: "A",
+        metrics: { count: 5 },
+        isClickable: true,
+        rawRows: [["A", null, 5]],
+        breakout: {
+          "(empty)": {
+            metrics: { count: 5 },
+            rawRows: [["A", null, 5]],
+          },
+        },
+      },
+    ];
+
+    const series: Series<GroupedDatum, SeriesInfo>[] = [
+      {
+        seriesKey: "(empty)",
+        seriesName: "(empty)",
+        seriesInfo: {
+          metricColumn,
+          dimensionColumn,
+          breakoutValue: "(empty)",
+        },
+        xAccessor: (datum: GroupedDatum) => datum.metrics["count"],
+        yAccessor: SERIES_Y_ACCESSOR,
+      },
+    ];
+
+    const result = getLegendClickData(0, series, {}, chartColumns, groupedData);
+
+    expect(result.dimensions).toEqual([
+      { column: breakoutColumn, value: null },
+    ]);
   });
 });
 


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #67079
Fixes QUE2-97.

### Description

Row charts were passing formatting strings like "(empty)" as the `value`
in the drill-thru context map, rather than the proper value `null`. That
breaks at least the `underlying-records` drill and perhaps others too,
when the formatted string is different from the value's usual
representation.

### How to verify

Easy repro steps on the bug. Make sure to use a Row chart; bar charts and spark lines already work fine.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
