### PR TITLE
GDGT-2234 Fallback custom viz to the default one if it's a public question or dashboard.

### DIFF
--- a/e2e/test/scenarios/admin/custom-viz/custom-viz.cy.spec.ts
+++ b/e2e/test/scenarios/admin/custom-viz/custom-viz.cy.spec.ts
@@ -457,6 +457,52 @@ describe("admin > custom visualizations", () => {
           .findByText(/"demo-viz" visualization is currently unavailable/)
           .should("be.visible");
       });
+
+      it("falls back to the default viz when the bundle endpoint fails, then recovers on revisit", () => {
+        const bundleMatcher = {
+          method: "GET",
+          pathname: "/api/ee/custom-viz-plugin/*/bundle",
+        };
+
+        cy.intercept(bundleMatcher, {
+          statusCode: 503,
+          body: { error: "Bundle not available" },
+        }).as("bundleUnavailable");
+
+        H.createQuestion(
+          {
+            name: "Custom Viz — Bundle Recovery",
+            query: {
+              "source-table": SAMPLE_DB_TABLES.STATIC_ORDERS_ID,
+              aggregation: [["count"]],
+            },
+            display: H.CUSTOM_VIZ_DISPLAY,
+          },
+          { wrapId: true, idAlias: "recoveryCardId", visitQuestion: true },
+        );
+
+        cy.wait("@bundleUnavailable");
+
+        cy.findByTestId("visualization-root")
+          .findByTestId("table-root")
+          .should("be.visible");
+
+        H.undoToastList()
+          .findByText(/visualization is currently unavailable/i)
+          .should("be.visible");
+
+        cy.intercept(bundleMatcher, (req) => req.continue()).as(
+          "bundleRestored",
+        );
+
+        cy.findByTestId("main-logo-link").click();
+        cy.go("back");
+        cy.wait("@bundleRestored");
+
+        H.main()
+          .findByText("Custom viz rendered successfully")
+          .should("be.visible");
+      });
     });
 
     it("falls back to the default viz on a public question (metabase#GDGT-2234)", () => {

--- a/e2e/test/scenarios/admin/custom-viz/custom-viz.cy.spec.ts
+++ b/e2e/test/scenarios/admin/custom-viz/custom-viz.cy.spec.ts
@@ -3,6 +3,7 @@ import type {
   DashboardDetails,
   StructuredQuestionDetails,
 } from "e2e/support/helpers";
+import { checkNotNull } from "metabase/utils/types";
 import type { CustomVizPlugin, Parameter } from "metabase-types/api";
 
 const { H } = cy;
@@ -481,8 +482,6 @@ describe("admin > custom visualizations", () => {
           { wrapId: true, idAlias: "recoveryCardId", visitQuestion: true },
         );
 
-        cy.wait("@bundleUnavailable");
-
         cy.findByTestId("visualization-root")
           .findByTestId("table-root")
           .should("be.visible");
@@ -495,9 +494,7 @@ describe("admin > custom visualizations", () => {
           "bundleRestored",
         );
 
-        cy.findByTestId("main-logo-link").click();
-        cy.go("back");
-        cy.wait("@bundleRestored");
+        cy.reload();
 
         H.main()
           .findByText("Custom viz rendered successfully")
@@ -632,7 +629,7 @@ describe("admin > custom visualizations", () => {
       H.updateSetting("enable-public-sharing", true);
 
       createCustomVizDashboard().then(({ body: dashcard }) => {
-        H.visitPublicDashboard(Number(dashcard.dashboard_id));
+        H.visitPublicDashboard(checkNotNull(dashcard.dashboard_id));
       });
 
       H.getDashboardCard().findByTestId("table-root").should("be.visible");

--- a/e2e/test/scenarios/admin/custom-viz/custom-viz.cy.spec.ts
+++ b/e2e/test/scenarios/admin/custom-viz/custom-viz.cy.spec.ts
@@ -459,6 +459,26 @@ describe("admin > custom visualizations", () => {
       });
     });
 
+    it("falls back to the default viz on a public question (metabase#GDGT-2234)", () => {
+      H.updateSetting("enable-public-sharing", true);
+
+      H.createQuestion(
+        {
+          name: "Public Custom Viz Fallback",
+          query: {
+            "source-table": SAMPLE_DB_TABLES.STATIC_ORDERS_ID,
+            aggregation: [["count"]],
+          },
+          display: H.CUSTOM_VIZ_DISPLAY,
+        },
+        { wrapId: true, idAlias: "publicQuestionId" },
+      );
+
+      cy.get<number>("@publicQuestionId").then(H.visitPublicQuestion);
+
+      cy.findByTestId("table-root").should("be.visible");
+    });
+
     it("calls onClick when the viz fires a click", () => {
       H.visitQuestion("@questionId");
       switchToDemoViz();
@@ -562,17 +582,14 @@ describe("admin > custom visualizations", () => {
         .should("be.visible");
     });
 
-    // TODO: public dashboard support for custom viz. Tracked by GDGT-2234 subtask.
-    it.skip("renders a custom viz question on a public dashboard", () => {
-      cy.request("PUT", "/api/setting/enable-public-sharing", { value: true });
+    it("falls back to the default viz on a public dashboard (metabase#GDGT-2234)", () => {
+      H.updateSetting("enable-public-sharing", true);
 
       createCustomVizDashboard().then(({ body: dashcard }) => {
-        H.visitPublicDashboard(dashcard.dashboard_id);
+        H.visitPublicDashboard(Number(dashcard.dashboard_id));
       });
 
-      H.getDashboardCard()
-        .findByText("Custom viz rendered successfully")
-        .should("be.visible");
+      H.getDashboardCard().findByTestId("table-root").should("be.visible");
     });
 
     it("exports the dashboard as a PDF", () => {

--- a/enterprise/frontend/src/metabase-enterprise/custom_viz/custom-viz-plugins.ts
+++ b/enterprise/frontend/src/metabase-enterprise/custom_viz/custom-viz-plugins.ts
@@ -63,7 +63,7 @@ export function useCustomVizPlugins({
     skip: !shouldLoad,
   });
 
-  return { plugins, isLoading };
+  return { plugins, isLoading, disabled: isPublicOrStaticEmbed };
 }
 
 /**
@@ -127,7 +127,7 @@ function useCustomVizDevReload(
 export function useAutoLoadCustomVizPlugin(display: string | undefined): {
   loading: boolean;
 } {
-  const { plugins } = useCustomVizPlugins();
+  const { plugins, disabled } = useCustomVizPlugins();
   const [sendToast] = useToast();
   const [loading, setLoading] = useState(false);
   const loadingRef = useRef<string | null>(null);
@@ -187,6 +187,13 @@ export function useAutoLoadCustomVizPlugin(display: string | undefined): {
   }
 
   const needsCustomViz = isCustomVizDisplay(display);
+
+  /**
+   * Short-circuit if custom-viz plugins are disabled (e.g., public or embedded questions/dashboards).
+   */
+  if (disabled) {
+    return { loading: false };
+  }
 
   // Plugin list loaded but no matching plugin found — the custom viz was
   // removed or is otherwise unavailable.  Stop loading so the visualization


### PR DESCRIPTION
Closes [GDGT-2234: Custom visualizations do not work in public questions](https://linear.app/metabase/issue/GDGT-2234/custom-visualizations-do-not-work-in-public-questions)

### Description
Fallback custom viz to the default one if it's a public question or dashboard.

Also added promised test from the https://github.com/metabase/metabase/pull/72531/changes


### How to verify

1. Create a question with custom viz
2. Create a share link for this question
3. Open this link
4. The question should be rendered with a default (Table) viz type.

### Demo

https://github.com/user-attachments/assets/092c75d6-492b-4486-98aa-2bb46df1f374


