### PR TITLE
Split source

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/checker/format/serdes_assets.clj
+++ b/enterprise/backend/src/metabase_enterprise/checker/format/serdes_assets.clj
@@ -47,8 +47,7 @@
    [metabase-enterprise.checker.source :as source]
    [metabase.util.yaml :as yaml])
   (:import
-   (java.io File)
-   (java.util Locale)))
+   (java.io File)))
 
 (set! *warn-on-reflection* true)
 

--- a/enterprise/backend/src/metabase_enterprise/checker/format/serdes_assets.clj
+++ b/enterprise/backend/src/metabase_enterprise/checker/format/serdes_assets.clj
@@ -1,4 +1,4 @@
-(ns metabase-enterprise.checker.format.serdes
+(ns metabase-enterprise.checker.format.serdes-assets
   "Serdes export format — directory structure, path parsing, entity loading.
 
    Directory structure (on disk, names may be slugified):

--- a/enterprise/backend/src/metabase_enterprise/checker/format/serdes_assets.clj
+++ b/enterprise/backend/src/metabase_enterprise/checker/format/serdes_assets.clj
@@ -45,8 +45,7 @@
    [clojure.java.io :as io]
    [clojure.string :as str]
    [metabase-enterprise.checker.source :as source]
-   [metabase.util.yaml :as yaml]
-   [potemkin.types :as p.types])
+   [metabase.util.yaml :as yaml])
   (:import
    (java.io File)
    (java.util Locale)))
@@ -62,6 +61,12 @@
   [path]
   (yaml/parse-string (slurp path)))
 
+(defn- db-dir
+  "Resolve a real database name to its directory on disk."
+  ^File [^File databases-dir db-name->dir db-name]
+  (let [dir-name (get db-name->dir db-name db-name)]
+    (io/file databases-dir dir-name)))
+
 (defn quick-extract
   "Extract a field from YAML using regex (fast) with full parse fallback."
   [file-path field-name pattern]
@@ -71,6 +76,15 @@
         (str/trim value)
         (get (yaml/parse-string content) (keyword field-name))))
     (catch Exception _ nil)))
+
+(defn- read-yaml-name
+  "Read the `name:` field from a YAML file using regex (fast).
+   Falls back to `fallback` if the file doesn't exist or can't be read."
+  [^File yaml-file ^String fallback]
+  (if (.exists yaml-file)
+    (or (quick-extract (.getPath yaml-file) "name" #"(?m)^name:\s*(.+)")
+        fallback)
+    fallback))
 
 (defn extract-entity-id
   "Extract the entity id from a yaml file without parsing it. Looking for a top level entity_id at start of line."
@@ -87,20 +101,22 @@
         (str/trim model)))
     (catch Exception _ nil)))
 
-(defn- read-yaml-name
-  "Read the `name:` field from a YAML file using regex (fast).
-   Falls back to `fallback` if the file doesn't exist or can't be read."
-  [^File yaml-file ^String fallback]
-  (if (.exists yaml-file)
-    (or (quick-extract (.getPath yaml-file) "name" #"(?m)^name:\s*(.+)")
-        fallback)
-    fallback))
-
-(defn- db-dir
-  "Resolve a real database name to its directory on disk."
-  ^File [^File databases-dir db-name->dir db-name]
-  (let [dir-name (get db-name->dir db-name db-name)]
-    (io/file databases-dir dir-name)))
+(defn- index-segments-and-measures
+  "Walk a table directory's segments/ and measures/ subdirectories.
+   Reads entity_id from each YAML (only a handful exist).
+   Returns a seq of {:kind :ref :file} entries."
+  [^File table-dir]
+  (into []
+        (mapcat
+         (fn [[subdir kind]]
+           (let [^File d (io/file table-dir subdir)]
+             (when (.isDirectory d)
+               (keep (fn [^File f]
+                       (when (and (.isFile f) (str/ends-with? (.getName f) ".yaml"))
+                         (when-let [eid (extract-entity-id (.getPath f))]
+                           {:kind kind :ref eid :file (.getPath f)})))
+                     (.listFiles d))))))
+        [["segments" :segment] ["measures" :measure]]))
 
 (defn- list-table-dirs
   "Return a seq of table directory Files for a database.
@@ -123,23 +139,6 @@
                 :when (.isDirectory td)]
           (vswap! result conj td))))
     @result))
-
-(defn- index-segments-and-measures
-  "Walk a table directory's segments/ and measures/ subdirectories.
-   Reads entity_id from each YAML (only a handful exist).
-   Returns a seq of {:kind :ref :file} entries."
-  [^File table-dir]
-  (into []
-        (mapcat
-         (fn [[subdir kind]]
-           (let [^File d (io/file table-dir subdir)]
-             (when (.isDirectory d)
-               (keep (fn [^File f]
-                       (when (and (.isFile f) (str/ends-with? (.getName f) ".yaml"))
-                         (when-let [eid (extract-entity-id (.getPath f))]
-                           {:kind kind :ref eid :file (.getPath f)})))
-                     (.listFiles d))))))
-        [["segments" :segment] ["measures" :measure]]))
 
 (defn- index-schema-dir
   "Walk a databases directory and index databases, segments, and measures.
@@ -229,22 +228,8 @@
                               (when (> (count files) 1)
                                 {:kind kind :ref ref :files files})))
                       by-key)]
-    {:index        (cond-> index
-                     (seq dupes) (assoc :duplicates dupes))
-     :db-name->dir (:db-name->dir schema-result)}))
-
-(defn build-database-dir-index
-  "Build index of databases from a schema directory.
-   Tables and fields are resolved on demand.
-
-   Returns `{:index {:database {name file-path}} :db-name->dir {real-name dir-name}}`."
-  [databases-dir]
-  (let [{:keys [entries db-name->dir]} (index-schema-dir databases-dir)]
-    {:index        (reduce (fn [idx {:keys [kind ref file]}]
-                             (assoc-in idx [kind ref] file))
-                           {}
-                           entries)
-     :db-name->dir db-name->dir}))
+    (cond-> index
+      (seq dupes) (assoc :duplicates dupes))))
 
 (defn index-stats
   "Get statistics about a file index.
@@ -261,244 +246,7 @@
    :collections    (count (:collection index))
    :database-names (vec (keys (:database index)))})
 
-;;; ===========================================================================
-;;; MetadataSource Implementation
-;;;
-;;; Returns raw YAML data - the checker handles conversion to lib format.
-;;; This keeps format knowledge here, lib knowledge in checker.
-;;; ===========================================================================
-
-(defn- table-real-name
-  "Read the real table name from its YAML file via regex. Falls back to dir name."
-  [^File table-dir]
-  (let [dir-name (.getName table-dir)
-        ^File yaml (io/file table-dir (str dir-name ".yaml"))]
-    (read-yaml-name yaml dir-name)))
-
-(defn- field-real-name
-  "Read the real field name from its YAML file via regex. Falls back to filename without extension."
-  [^File field-yaml]
-  (let [fname (.getName field-yaml)
-        fallback (str/replace fname #"\.yaml$" "")]
-    (read-yaml-name field-yaml fallback)))
-
-(defn- read-yaml-schema
-  "Read the `schema:` field from a YAML file using regex (fast).
-   Returns nil if not found or if the value is `null`."
-  [^File yaml-file]
-  (when (.exists yaml-file)
-    (let [v (quick-extract (.getPath yaml-file) "schema" #"(?m)^schema:\s*(\S+)")]
-      (when (and v (not= v "null"))
-        v))))
-
-(defn- index-schema-tables
-  "Walk a single schema's tables directory and return:
-   {:real-schema-name string-or-nil  ; the real schema name from YAML (may differ from dir name)
-    :tables {real-table-name {:table-file \"path\", :fields ::not-indexed} ...}}
-   Reads real table names from YAMLs via fast regex.
-   Fields are NOT indexed here — they are indexed lazily per-table."
-  [^File tables-dir]
-  (when (.isDirectory tables-dir)
-    (let [real-schema (volatile! nil)
-          tables (into {}
-                       (keep (fn [^File td]
-                               (when (.isDirectory td)
-                                 (let [table-name (table-real-name td)
-                                       dir-name   (.getName td)
-                                       ^File yaml (io/file td (str dir-name ".yaml"))]
-                                   (when (.exists yaml)
-                                     (when-not @real-schema
-                                       (vreset! real-schema (read-yaml-schema yaml)))
-                                     [table-name {:table-file (.getPath yaml) :fields ::not-indexed}])))))
-                       (.listFiles tables-dir))]
-      {:real-schema-name @real-schema
-       :tables           tables})))
-
-(defn- index-table-fields
-  "Walk a table's fields/ directory and return a map of:
-   {real-field-name File ...}
-   Reads real field names from YAMLs via fast regex.
-   Skips FieldValues and FieldUserSettings files."
-  [table-file-path]
-  (let [^File table-dir (.getParentFile (io/file table-file-path))
-        ^File fields-dir (io/file table-dir "fields")]
-    (if (.isDirectory fields-dir)
-      (into {}
-            (keep (fn [^File f]
-                    (let [fname (.getName f)]
-                      (when (and (.isFile f)
-                                 (str/ends-with? fname ".yaml")
-                                 (not (str/includes? fname "___")))
-                        [(field-real-name f) (.getPath f)]))))
-            (.listFiles fields-dir))
-      {})))
-
-(defn- resolve-schema-name
-  "Resolve a real schema name to the key used in the model.
-
-   Schema names are the one entity type with no canonical YAML file — the directory
-   name is the filesystem key, and the real name comes from the `schema:` field in
-   table YAMLs. These may differ (e.g. dir=`public`, real=`PUBLIC` for H2).
-
-   Strategy:
-   1. Exact match in the model's :schemas
-   2. Case-insensitive match (handles H2-style uppercasing)
-   3. nil for schema-less databases
-
-   To change schema resolution in the future, modify this function."
-  [model db-name schema]
-  (let [schemas (:schemas (get model db-name))
-        lower (fn [s] (.toLowerCase (str s) Locale/US))]
-    (cond
-      (contains? schemas schema) schema
-      schema (let [lowered (lower schema)]
-               (some (fn [k] (when (and (string? k) (= (lower k) lowered)) k))
-                     (keys schemas)))
-      :else (when (contains? schemas nil) nil))))
-
-(defn- ensure-schema-indexed!
-  "Ensure a schema's tables are indexed in the model. No-op if already done.
-
-   Resolves the requested schema name to a model key (possibly case-insensitive),
-   walks the table directories, reads real names from YAMLs, and stores the results.
-   If the real schema name (from the table YAML `schema:` field) differs from the
-   directory name, the model entry is re-keyed under the real name."
-  [^File databases-dir db-name->dir db-name schema model]
-  (let [model-key (resolve-schema-name @model db-name schema)]
-    (when (= ::not-indexed (get-in @model [db-name :schemas model-key]))
-      (let [^File db (db-dir databases-dir db-name->dir db-name)
-            ^File tables-dir (if model-key
-                               (io/file db "schemas" model-key "tables")
-                               (io/file db "tables"))
-            {:keys [real-schema-name tables]} (index-schema-tables tables-dir)
-            tables       (or tables {})
-            ;; The real schema name (from YAML) is the canonical key.
-            ;; Falls back to model-key (dir name) or the requested name.
-            final-key    (or real-schema-name model-key schema)]
-        (swap! model (fn [m]
-                       (cond-> m
-                         ;; Remove old key if re-keying
-                         (and model-key (not= model-key final-key))
-                         (update-in [db-name :schemas] dissoc model-key)
-                         ;; Store under canonical name
-                         true
-                         (assoc-in [db-name :schemas final-key] tables))))))))
-
-(defn- ensure-fields-indexed!
-  "Ensure a table's fields are indexed in the model. No-op if already done."
-  [^File databases-dir db-name->dir db-name schema table-name model]
-  (ensure-schema-indexed! databases-dir db-name->dir db-name schema model)
-  (when (= ::not-indexed (get-in @model [db-name :schemas schema table-name :fields]))
-    (when-let [table-file (get-in @model [db-name :schemas schema table-name :table-file])]
-      (let [field-map (index-table-fields table-file)]
-        (swap! model assoc-in [db-name :schemas schema table-name :fields] field-map)))))
-
-(defn- list-schemas
-  "List schema directory names for a database. Returns seq of strings, or [nil] for schema-less."
-  [^File databases-dir db-name->dir db-name]
-  (let [^File db (db-dir databases-dir db-name->dir db-name)
-        ^File schemas-dir (io/file db "schemas")
-        ^File tables-dir (io/file db "tables")]
-    (cond-> []
-      (.isDirectory schemas-dir)
-      (into (map #(.getName ^File %))
-            (filter #(.isDirectory ^File %) (.listFiles schemas-dir)))
-      (.isDirectory tables-dir)
-      (conj nil))))
-
-(defn- init-schema-model
-  "Build the initial schema model with db-file paths and ::not-indexed for each schema.
-
-   Schema model shape:
-     {db-name {:db-file \"path/to/db.yaml\"
-               :schemas {schema ::not-indexed
-                                | {table {:table-file \"path\" :fields ::not-indexed | {field \"path\"}}}}}}
-
-   Two levels of laziness:
-   1. Schema → tables: populated when the schema is first accessed
-   2. Table → fields: populated when that table's fields are first accessed"
-  [^File databases-dir db-name->dir db-file-index]
-  (atom
-   (into {}
-         (for [[db-name _dir-name] db-name->dir]
-           [db-name {:db-file (get db-file-index db-name)
-                     :schemas (into {}
-                                    (for [schema (list-schemas databases-dir db-name->dir db-name)]
-                                      [schema ::not-indexed]))}]))))
-
-(p.types/defprotocol+ ISchemaModelDebug
-  "Non exported protocol to get the schema of the SerdesSource. Useful for debugging and asserting on the schema model
-  built up during serdes."
-  (schema-model [_] "Deref and return the schema model. See [[init-schema-model]] for details of this structure."))
-
-(deftype SerdesSource [databases-dir assets-index db-name->dir
-                       ;; See init-schema-model for shape documentation
-                       schema-model]
-  source/SchemaSource
-  (resolve-database [_ db-name]
-    (when-let [file (get-in @schema-model [db-name :db-file])]
-      (load-yaml file)))
-
-  (resolve-table [_ [db schema table-name :as _table-path]]
-    (ensure-schema-indexed! databases-dir db-name->dir db schema schema-model)
-    (when-let [path (get-in @schema-model [db :schemas schema table-name :table-file])]
-      (load-yaml path)))
-
-  (resolve-field [_ [db schema table-name field :as _field-path]]
-    (ensure-fields-indexed! databases-dir db-name->dir db schema table-name schema-model)
-    (when-let [path (get-in @schema-model [db :schemas schema table-name :fields field])]
-      (load-yaml path)))
-
-  (fields-for-table [_ [db schema table-name :as _table-path]]
-    (ensure-fields-indexed! databases-dir db-name->dir db schema table-name schema-model)
-    (when-let [entry (get-in @schema-model [db :schemas schema table-name])]
-      (let [fields (:fields entry)]
-        (when (map? fields)
-          (into #{} (map (fn [field-name] [db schema table-name field-name])) (keys fields))))))
-
-  (all-field-paths [_]
-    (doseq [[db-name {:keys [schemas]}] @schema-model
-            [schema tables] schemas
-            :when (= tables ::not-indexed)]
-      (ensure-schema-indexed! databases-dir db-name->dir db-name schema schema-model))
-    (doseq [[db-name {:keys [schemas]}] @schema-model
-            [schema tables] schemas
-            :when (map? tables)
-            [table-name entry] tables
-            :when (= (:fields entry) ::not-indexed)]
-      (ensure-fields-indexed! databases-dir db-name->dir db-name schema table-name schema-model))
-    (into #{}
-          (for [[db {:keys [schemas]}] @schema-model
-                [schema tables] schemas
-                :when (map? tables)
-                [table-name {:keys [fields]}] tables
-                :when (map? fields)
-                field-name (keys fields)]
-            [db schema table-name field-name])))
-
-  (all-database-names [_]
-    (keys @schema-model))
-
-  (all-table-paths [_]
-    (doseq [[db-name {:keys [schemas]}] @schema-model
-            [schema _] schemas]
-      (ensure-schema-indexed! databases-dir db-name->dir db-name schema schema-model))
-    (into []
-          (for [[db {:keys [schemas]}] @schema-model
-                [schema tables] schemas
-                :when (map? tables)
-                table-name (keys tables)]
-            [db schema table-name])))
-
-  (tables-for-database [_ db-name]
-    (doseq [[schema _] (:schemas (get @schema-model db-name))]
-      (ensure-schema-indexed! databases-dir db-name->dir db-name schema schema-model))
-    (into []
-          (for [[schema tables] (:schemas (get @schema-model db-name))
-                :when (map? tables)
-                table-name (keys tables)]
-            [db-name schema table-name])))
-
+(deftype SerdesSource [databases-dir assets-index]
   source/AssetsSource
   (resolve-card [_ entity-id]
     (when-let [file (get-in assets-index [:card entity-id])]
@@ -530,31 +278,16 @@
 
   (resolve-measure [_ entity-id]
     (when-let [file (get-in assets-index [:measure entity-id])]
-      (load-yaml file)))
-  ISchemaModelDebug
-  (schema-model [_] (deref schema-model)))
+      (load-yaml file))))
 
 (defn make-source
   "Create a MetadataSource for a serdes export directory.
    The databases-dir for field resolution is export-dir/databases."
   [export-dir]
   (let [databases-dir (io/file export-dir "databases")
-        {:keys [index db-name->dir]} (build-file-index export-dir)
-        db-files      (:database index)
+        index         (build-file-index export-dir)
         assets-index  (dissoc index :database)]
-    (->SerdesSource databases-dir assets-index db-name->dir
-                    (init-schema-model databases-dir db-name->dir db-files))))
-
-(defn make-database-source
-  "Create a MetadataSource for a directory that IS the databases directory.
-   The directory should contain database subdirectories directly (e.g., `Sample Database/`).
-   This source only resolves databases, tables, and fields — not cards."
-  [databases-dir]
-  (let [{:keys [index db-name->dir]} (build-database-dir-index databases-dir)
-        databases-dir (io/file databases-dir)
-        db-files      (:database index)]
-    (->SerdesSource databases-dir {} db-name->dir
-                    (init-schema-model databases-dir db-name->dir db-files))))
+    (->SerdesSource databases-dir assets-index)))
 
 (defn source-index
   "Get the assets index from a SerdesSource. Returns a flat map of

--- a/enterprise/backend/src/metabase_enterprise/checker/format/serdes_schema.clj
+++ b/enterprise/backend/src/metabase_enterprise/checker/format/serdes_schema.clj
@@ -1,0 +1,375 @@
+(ns metabase-enterprise.checker.format.serdes-schema
+  "Serdes export format — directory structure, path parsing, entity loading.
+
+   Directory structure (on disk, names may be slugified):
+     databases/<db-dir>/<db-dir>.yaml
+     databases/<db-dir>/schemas/<schema-dir>/tables/<table-dir>/<table-dir>.yaml
+     databases/<db-dir>/schemas/<schema-dir>/tables/<table-dir>/fields/<field>.yaml
+     databases/<db-dir>/tables/<table-dir>/<table-dir>.yaml           # schema-less
+     databases/<db-dir>/tables/<table-dir>/fields/<field>.yaml        # schema-less
+     collections/<entity-id>_<slug>/<entity-id>_<slug>.yaml
+     collections/.../cards/<entity-id>_<slug>.yaml
+     collections/.../dashboards/<entity-id>_<slug>.yaml
+
+   Directory names may differ from entity names (e.g. `analytics_data_warehouse`
+   for \"Analytics Data Warehouse\", or `orders` for \"ORDERS\" in H2).
+
+   ## Lazy resolution cache
+
+   The `SerdesSource` maintains a single lazily-populated cache atom that maps
+   real entity names (from YAML) to file locations:
+
+     {db-name                                     ; real name, e.g. \"Analytics Data Warehouse\"
+       {schema                                    ; real name or nil for schema-less
+         ::not-indexed                            ; schema exists but tables not yet walked
+         | {table-name                            ; real name from YAML
+              {:table-file \"path/to/table.yaml\" ; path string to the table YAML
+               :fields ::not-indexed              ; fields not yet walked for this table
+                     | {field-name \"path\" ...}}}}} ; real name → field YAML path
+
+   Two levels of laziness:
+   1. Schema → tables: realized when any table in that schema is resolved
+      (via `resolve-table`, `resolve-field`, `fields-for-table`) or when
+      `tables-for-database` is called. Walks the schema's `tables/` directory
+      and reads each table's `name:` from YAML via fast regex.
+   2. Table → fields: realized when `resolve-field` or `fields-for-table` is
+      called for that specific table. Walks the table's `fields/` directory
+      and reads each field's `name:` via fast regex. Other tables in the same
+      schema are unaffected.
+
+   The `db-name->dir` map (built at startup from ~40 database YAMLs) handles the
+   database name → directory name translation. Schema and table name → directory
+   name translation is handled by case-insensitive directory matching during
+   schema indexing."
+  (:require
+   [clojure.java.io :as io]
+   [clojure.string :as str]
+   [metabase-enterprise.checker.source :as source]
+   [metabase.util.yaml :as yaml]
+   [potemkin.types :as p.types])
+  (:import
+   (java.io File)
+   (java.util Locale)))
+
+(set! *warn-on-reflection* true)
+
+(defn load-yaml
+  "Load and parse a YAML file."
+  [path]
+  (yaml/parse-string (slurp path)))
+
+(defn- db-dir
+  "Resolve a real database name to its directory on disk."
+  ^File [^File databases-dir db-name->dir db-name]
+  (let [dir-name (get db-name->dir db-name db-name)]
+    (io/file databases-dir dir-name)))
+
+;;; ===========================================================================
+;;; MetadataSource Implementation
+;;;
+;;; Returns raw YAML data - the checker handles conversion to lib format.
+;;; This keeps format knowledge here, lib knowledge in checker.
+;;; ===========================================================================
+
+(defn- resolve-schema-name
+  "Resolve a real schema name to the key used in the model.
+
+   Schema names are the one entity type with no canonical YAML file — the directory
+   name is the filesystem key, and the real name comes from the `schema:` field in
+   table YAMLs. These may differ (e.g. dir=`public`, real=`PUBLIC` for H2).
+
+   Strategy:
+   1. Exact match in the model's :schemas
+   2. Case-insensitive match (handles H2-style uppercasing)
+   3. nil for schema-less databases
+
+   To change schema resolution in the future, modify this function."
+  [model db-name schema]
+  (let [schemas (:schemas (get model db-name))
+        lower (fn [s] (.toLowerCase (str s) Locale/US))]
+    (cond
+      (contains? schemas schema) schema
+      schema (let [lowered (lower schema)]
+               (some (fn [k] (when (and (string? k) (= (lower k) lowered)) k))
+                     (keys schemas)))
+      :else (when (contains? schemas nil) nil))))
+
+(defn quick-extract
+  "Extract a field from YAML using regex (fast) with full parse fallback."
+  [file-path field-name pattern]
+  (try
+    (let [content (slurp file-path)]
+      (if-let [[_ value] (re-find pattern content)]
+        (str/trim value)
+        (get (yaml/parse-string content) (keyword field-name))))
+    (catch Exception _ nil)))
+
+(defn- read-yaml-schema
+  "Read the `schema:` field from a YAML file using regex (fast).
+   Returns nil if not found or if the value is `null`."
+  [^File yaml-file]
+  (when (.exists yaml-file)
+    (let [v (quick-extract (.getPath yaml-file) "schema" #"(?m)^schema:\s*(\S+)")]
+      (when (and v (not= v "null"))
+        v))))
+
+(defn- read-yaml-name
+  "Read the `name:` field from a YAML file using regex (fast).
+   Falls back to `fallback` if the file doesn't exist or can't be read."
+  [^File yaml-file ^String fallback]
+  (if (.exists yaml-file)
+    (or (quick-extract (.getPath yaml-file) "name" #"(?m)^name:\s*(.+)")
+        fallback)
+    fallback))
+
+(defn- table-real-name
+  "Read the real table name from its YAML file via regex. Falls back to dir name."
+  [^File table-dir]
+  (let [dir-name (.getName table-dir)
+        ^File yaml (io/file table-dir (str dir-name ".yaml"))]
+    (read-yaml-name yaml dir-name)))
+
+(defn- index-schema-tables
+  "Walk a single schema's tables directory and return:
+   {:real-schema-name string-or-nil  ; the real schema name from YAML (may differ from dir name)
+    :tables {real-table-name {:table-file \"path\", :fields ::not-indexed} ...}}
+   Reads real table names from YAMLs via fast regex.
+   Fields are NOT indexed here — they are indexed lazily per-table."
+  [^File tables-dir]
+  (when (.isDirectory tables-dir)
+    (let [real-schema (volatile! nil)
+          tables (into {}
+                       (keep (fn [^File td]
+                               (when (.isDirectory td)
+                                 (let [table-name (table-real-name td)
+                                       dir-name   (.getName td)
+                                       ^File yaml (io/file td (str dir-name ".yaml"))]
+                                   (when (.exists yaml)
+                                     (when-not @real-schema
+                                       (vreset! real-schema (read-yaml-schema yaml)))
+                                     [table-name {:table-file (.getPath yaml) :fields ::not-indexed}])))))
+                       (.listFiles tables-dir))]
+      {:real-schema-name @real-schema
+       :tables           tables})))
+
+(defn- ensure-schema-indexed!
+  "Ensure a schema's tables are indexed in the model. No-op if already done.
+
+   Resolves the requested schema name to a model key (possibly case-insensitive),
+   walks the table directories, reads real names from YAMLs, and stores the results.
+   If the real schema name (from the table YAML `schema:` field) differs from the
+   directory name, the model entry is re-keyed under the real name."
+  [^File databases-dir db-name->dir db-name schema model]
+  (let [model-key (resolve-schema-name @model db-name schema)]
+    (when (= ::not-indexed (get-in @model [db-name :schemas model-key]))
+      (let [^File db (db-dir databases-dir db-name->dir db-name)
+            ^File tables-dir (if model-key
+                               (io/file db "schemas" model-key "tables")
+                               (io/file db "tables"))
+            {:keys [real-schema-name tables]} (index-schema-tables tables-dir)
+            tables       (or tables {})
+            ;; The real schema name (from YAML) is the canonical key.
+            ;; Falls back to model-key (dir name) or the requested name.
+            final-key    (or real-schema-name model-key schema)]
+        (swap! model (fn [m]
+                       (cond-> m
+                         ;; Remove old key if re-keying
+                         (and model-key (not= model-key final-key))
+                         (update-in [db-name :schemas] dissoc model-key)
+                         ;; Store under canonical name
+                         true
+                         (assoc-in [db-name :schemas final-key] tables))))))))
+
+(defn- field-real-name
+  "Read the real field name from its YAML file via regex. Falls back to filename without extension."
+  [^File field-yaml]
+  (let [fname (.getName field-yaml)
+        fallback (str/replace fname #"\.yaml$" "")]
+    (read-yaml-name field-yaml fallback)))
+
+(defn- index-table-fields
+  "Walk a table's fields/ directory and return a map of:
+   {real-field-name File ...}
+   Reads real field names from YAMLs via fast regex.
+   Skips FieldValues and FieldUserSettings files."
+  [table-file-path]
+  (let [^File table-dir (.getParentFile (io/file table-file-path))
+        ^File fields-dir (io/file table-dir "fields")]
+    (if (.isDirectory fields-dir)
+      (into {}
+            (keep (fn [^File f]
+                    (let [fname (.getName f)]
+                      (when (and (.isFile f)
+                                 (str/ends-with? fname ".yaml")
+                                 (not (str/includes? fname "___")))
+                        [(field-real-name f) (.getPath f)]))))
+            (.listFiles fields-dir))
+      {})))
+
+(defn- ensure-fields-indexed!
+  "Ensure a table's fields are indexed in the model. No-op if already done."
+  [^File databases-dir db-name->dir db-name schema table-name model]
+  (ensure-schema-indexed! databases-dir db-name->dir db-name schema model)
+  (when (= ::not-indexed (get-in @model [db-name :schemas schema table-name :fields]))
+    (when-let [table-file (get-in @model [db-name :schemas schema table-name :table-file])]
+      (let [field-map (index-table-fields table-file)]
+        (swap! model assoc-in [db-name :schemas schema table-name :fields] field-map)))))
+
+(defn- index-schema-dir
+  "Walk a databases directory and index databases, segments, and measures.
+   Reads ~40 database YAMLs for real names, plus a handful of segment/measure YAMLs
+   for entity_ids. Tables and fields are resolved on demand from the filesystem.
+
+   When `include-segments-measures?` is true, also walks table directories
+   to find segment and measure YAMLs (for export dirs). Set to false for
+   schema-only dirs to avoid walking thousands of table directories.
+
+   Returns {:entries [...]
+            :db-name->dir {real-db-name dir-name}}."
+  [schema-dir]
+  (let [schema-dir   (io/file schema-dir)
+        db-name->dir (volatile! {})
+        entries      (volatile! [])]
+    (doseq [^File db-dir (.listFiles schema-dir)
+            :when (.isDirectory db-dir)]
+      (let [dir-name (.getName db-dir)
+            db-yaml  (io/file db-dir (str dir-name ".yaml"))
+            db-name  (read-yaml-name db-yaml dir-name)]
+        (vswap! db-name->dir assoc db-name dir-name)
+        (vswap! entries conj {:kind :database :ref db-name
+                              :file (if (.exists db-yaml) (.getPath db-yaml) (.getPath db-dir))})))
+    {:entries      @entries
+     :db-name->dir @db-name->dir}))
+
+(defn build-database-dir-index
+  "Build index of databases from a schema directory.
+   Tables and fields are resolved on demand.
+
+   Returns `{:index {:database {name file-path}} :db-name->dir {real-name dir-name}}`."
+  [databases-dir]
+  (let [{:keys [entries db-name->dir]} (index-schema-dir databases-dir)]
+    {:index        (reduce (fn [idx {:keys [kind ref file]}]
+                             (assoc-in idx [kind ref] file))
+                           {}
+                           entries)
+     :db-name->dir db-name->dir}))
+
+(p.types/defprotocol+ ISchemaModelDebug
+  "Non exported protocol to get the schema of the SerdesSource. Useful for debugging and asserting on the schema model
+  built up during serdes."
+  (schema-model [_] "Deref and return the schema model. See [[init-schema-model]] for details of this structure."))
+
+(deftype SerdesSchemaSource [databases-dir db-name->dir
+                             ;; See init-schema-model for shape documentation
+                             schema-model]
+  source/SchemaSource
+  (resolve-database [_ db-name]
+    (when-let [file (get-in @schema-model [db-name :db-file])]
+      (load-yaml file)))
+
+  (resolve-table [_ [db schema table-name :as _table-path]]
+    (ensure-schema-indexed! databases-dir db-name->dir db schema schema-model)
+    (when-let [path (get-in @schema-model [db :schemas schema table-name :table-file])]
+      (load-yaml path)))
+
+  (resolve-field [_ [db schema table-name field :as _field-path]]
+    (ensure-fields-indexed! databases-dir db-name->dir db schema table-name schema-model)
+    (when-let [path (get-in @schema-model [db :schemas schema table-name :fields field])]
+      (load-yaml path)))
+
+  (fields-for-table [_ [db schema table-name :as _table-path]]
+    (ensure-fields-indexed! databases-dir db-name->dir db schema table-name schema-model)
+    (when-let [entry (get-in @schema-model [db :schemas schema table-name])]
+      (let [fields (:fields entry)]
+        (when (map? fields)
+          (into #{} (map (fn [field-name] [db schema table-name field-name])) (keys fields))))))
+
+  (all-field-paths [_]
+    (doseq [[db-name {:keys [schemas]}] @schema-model
+            [schema tables] schemas
+            :when (= tables ::not-indexed)]
+      (ensure-schema-indexed! databases-dir db-name->dir db-name schema schema-model))
+    (doseq [[db-name {:keys [schemas]}] @schema-model
+            [schema tables] schemas
+            :when (map? tables)
+            [table-name entry] tables
+            :when (= (:fields entry) ::not-indexed)]
+      (ensure-fields-indexed! databases-dir db-name->dir db-name schema table-name schema-model))
+    (into #{}
+          (for [[db {:keys [schemas]}] @schema-model
+                [schema tables] schemas
+                :when (map? tables)
+                [table-name {:keys [fields]}] tables
+                :when (map? fields)
+                field-name (keys fields)]
+            [db schema table-name field-name])))
+
+  (all-database-names [_]
+    (keys @schema-model))
+
+  (all-table-paths [_]
+    (doseq [[db-name {:keys [schemas]}] @schema-model
+            [schema _] schemas]
+      (ensure-schema-indexed! databases-dir db-name->dir db-name schema schema-model))
+    (into []
+          (for [[db {:keys [schemas]}] @schema-model
+                [schema tables] schemas
+                :when (map? tables)
+                table-name (keys tables)]
+            [db schema table-name])))
+
+  (tables-for-database [_ db-name]
+    (doseq [[schema _] (:schemas (get @schema-model db-name))]
+      (ensure-schema-indexed! databases-dir db-name->dir db-name schema schema-model))
+    (into []
+          (for [[schema tables] (:schemas (get @schema-model db-name))
+                :when (map? tables)
+                table-name (keys tables)]
+            [db-name schema table-name])))
+
+  ISchemaModelDebug
+  (schema-model [_] (deref schema-model)))
+
+(defn- list-schemas
+  "List schema directory names for a database. Returns seq of strings, or [nil] for schema-less."
+  [^File databases-dir db-name->dir db-name]
+  (let [^File db (db-dir databases-dir db-name->dir db-name)
+        ^File schemas-dir (io/file db "schemas")
+        ^File tables-dir (io/file db "tables")]
+    (cond-> []
+      (.isDirectory schemas-dir)
+      (into (map #(.getName ^File %))
+            (filter #(.isDirectory ^File %) (.listFiles schemas-dir)))
+      (.isDirectory tables-dir)
+      (conj nil))))
+
+(defn- init-schema-model
+  "Build the initial schema model with db-file paths and ::not-indexed for each schema.
+
+   Schema model shape:
+     {db-name {:db-file \"path/to/db.yaml\"
+               :schemas {schema ::not-indexed
+                                | {table {:table-file \"path\" :fields ::not-indexed | {field \"path\"}}}}}}
+
+   Two levels of laziness:
+   1. Schema → tables: populated when the schema is first accessed
+   2. Table → fields: populated when that table's fields are first accessed"
+  [^File databases-dir db-name->dir db-file-index]
+  (atom
+   (into {}
+         (for [[db-name _dir-name] db-name->dir]
+           [db-name {:db-file (get db-file-index db-name)
+                     :schemas (into {}
+                                    (for [schema (list-schemas databases-dir db-name->dir db-name)]
+                                      [schema ::not-indexed]))}]))))
+
+(defn make-database-source
+  "Create a MetadataSource for a directory that IS the databases directory.
+   The directory should contain database subdirectories directly (e.g., `Sample Database/`).
+   This source only resolves databases, tables, and fields — not cards."
+  [databases-dir]
+  (let [{:keys [index db-name->dir]} (build-database-dir-index databases-dir)
+        databases-dir (io/file databases-dir)
+        db-files      (:database index)]
+    (->SerdesSchemaSource databases-dir db-name->dir
+                          (init-schema-model databases-dir db-name->dir db-files))))

--- a/enterprise/backend/src/metabase_enterprise/checker/semantic.clj
+++ b/enterprise/backend/src/metabase_enterprise/checker/semantic.clj
@@ -11,7 +11,7 @@
    - `(setup export-dir schema-dir)` + `(check-one ctx entity-id)` — REPL workflow"
   (:require
    [clojure.string :as str]
-   [metabase-enterprise.checker.format.serdes :as serdes]
+   [metabase-enterprise.checker.format.serdes-assets :as serdes]
    [metabase-enterprise.checker.provider :as provider]
    [metabase-enterprise.checker.store :as store]
    [metabase-enterprise.dependencies.analysis :as deps.analysis]
@@ -770,7 +770,10 @@
 (comment
   ;; REPL workflow:
   (check "/Users/dan/projects/work/stats-remote-sync"
-         "/tmp/metadata/metadata/databases")
+         "/Users/dan/projects/work/exports-root/metadata/metadata/databases")
+
+  (check "/Users/dan/projects/work/representations/examples/v1"
+         "/Users/dan/projects/work/yaml-checked-files-v1/exports/sqlite-based/databases")
   (setup
    "/Users/dan/projects/work/stats-remote-sync"
    "/Users/dan/projects/work/stats-remote-sync/databases")

--- a/enterprise/backend/src/metabase_enterprise/checker/semantic.clj
+++ b/enterprise/backend/src/metabase_enterprise/checker/semantic.clj
@@ -770,16 +770,14 @@
 
 (comment
   ;; REPL workflow:
-  (time
-   (check "/Users/dan/projects/work/stats-remote-sync"
-          "/Users/dan/projects/work/exports-root/metadata/metadata/databases"))
+  (check "/Users/dan/projects/work/stats-remote-sync"
+         "/Users/dan/projects/work/exports-root/metadata/metadata/databases")
 
-  (time
-   (->> (check "/Users/dan/projects/work/representations/examples/v1"
-               "/Users/dan/projects/work/yaml-checked-files-v1/exports/sqlite-based/databases")
-        (into {} (filter (fn [[_id stuff]]
-                           (letfn [(bad [x] ((some-fn :bad-refs :unresolved :native-errors) x))]
-                             (bad stuff)))))))
+  (->> (check "/Users/dan/projects/work/representations/examples/v1"
+              "/Users/dan/projects/work/yaml-checked-files-v1/exports/sqlite-based/databases")
+       (into {} (filter (fn [[_id stuff]]
+                          (letfn [(bad [x] ((some-fn :bad-refs :unresolved :native-errors) x))]
+                            (bad stuff))))))
   (setup
    "/Users/dan/projects/work/stats-remote-sync"
    "/Users/dan/projects/work/stats-remote-sync/databases")

--- a/enterprise/backend/src/metabase_enterprise/checker/semantic.clj
+++ b/enterprise/backend/src/metabase_enterprise/checker/semantic.clj
@@ -11,7 +11,8 @@
    - `(setup export-dir schema-dir)` + `(check-one ctx entity-id)` — REPL workflow"
   (:require
    [clojure.string :as str]
-   [metabase-enterprise.checker.format.serdes-assets :as serdes]
+   [metabase-enterprise.checker.format.serdes-assets :as serdes-assets]
+   [metabase-enterprise.checker.format.serdes-schema :as serdes.schema]
    [metabase-enterprise.checker.provider :as provider]
    [metabase-enterprise.checker.store :as store]
    [metabase-enterprise.dependencies.analysis :as deps.analysis]
@@ -717,9 +718,9 @@
   "Build schema and assets sources from `schema-dir` and `export-dir`,
    and a merged assets index (cards, dashboards, segments, etc.)."
   [export-dir schema-dir]
-  (let [schema-source (serdes/make-database-source schema-dir)
-        assets-source (serdes/make-source export-dir)
-        index         (serdes/source-index assets-source)]
+  (let [schema-source (serdes.schema/make-database-source schema-dir)
+        assets-source (serdes-assets/make-source export-dir)
+        index         (serdes-assets/source-index assets-source)]
     {:schema-source schema-source :assets-source assets-source :index index}))
 
 (defn check
@@ -769,11 +770,16 @@
 
 (comment
   ;; REPL workflow:
-  (check "/Users/dan/projects/work/stats-remote-sync"
-         "/Users/dan/projects/work/exports-root/metadata/metadata/databases")
+  (time
+   (check "/Users/dan/projects/work/stats-remote-sync"
+          "/Users/dan/projects/work/exports-root/metadata/metadata/databases"))
 
-  (check "/Users/dan/projects/work/representations/examples/v1"
-         "/Users/dan/projects/work/yaml-checked-files-v1/exports/sqlite-based/databases")
+  (time
+   (->> (check "/Users/dan/projects/work/representations/examples/v1"
+               "/Users/dan/projects/work/yaml-checked-files-v1/exports/sqlite-based/databases")
+        (into {} (filter (fn [[_id stuff]]
+                           (letfn [(bad [x] ((some-fn :bad-refs :unresolved :native-errors) x))]
+                             (bad stuff)))))))
   (setup
    "/Users/dan/projects/work/stats-remote-sync"
    "/Users/dan/projects/work/stats-remote-sync/databases")

--- a/enterprise/backend/test/metabase_enterprise/checker/format/serdes_assets_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/checker/format/serdes_assets_test.clj
@@ -1,9 +1,9 @@
-(ns metabase-enterprise.checker.format.serdes-test
+(ns metabase-enterprise.checker.format.serdes-assets-test
   "Tests for the serdes format module — YAML extraction, file indexing, and source resolution."
   (:require
    [clojure.java.io :as io]
    [clojure.test :refer [deftest is testing]]
-   [metabase-enterprise.checker.format.serdes :as serdes]
+   [metabase-enterprise.checker.format.serdes-assets :as serdes]
    [metabase-enterprise.checker.source :as source]
    [metabase.util.yaml :as yaml]))
 
@@ -262,7 +262,7 @@
 ;;; Cache shape and lazy resolution
 ;;; ===========================================================================
 
-(def ^:private not-indexed :metabase-enterprise.checker.format.serdes/not-indexed)
+(def ^:private not-indexed ::serdes/not-indexed)
 
 (deftest schema-model-shape-test
   (testing "schema model starts with ::not-indexed for each schema, populates lazily"

--- a/enterprise/backend/test/metabase_enterprise/checker/format/serdes_assets_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/checker/format/serdes_assets_test.clj
@@ -1,5 +1,5 @@
 (ns metabase-enterprise.checker.format.serdes-assets-test
-  "Tests for the serdes format module — YAML extraction, file indexing, and source resolution."
+  "Tests for the serdes assets format module — YAML extraction, file indexing, and assets source resolution."
   (:require
    [clojure.java.io :as io]
    [clojure.test :refer [deftest is testing]]
@@ -70,95 +70,25 @@
 
 (deftest build-file-index-databases-test
   (testing "build-file-index indexes databases from fixtures"
-    (let [{:keys [index]} (serdes/build-file-index (fixtures-path))]
+    (let [index (serdes/build-file-index (fixtures-path))]
       (is (contains? (:database index) "Test Database"))
       (is (contains? (:database index) "SQLite DB")))))
 
 (deftest build-file-index-cards-test
   (testing "build-file-index indexes cards by entity_id"
-    (let [{:keys [index]} (serdes/build-file-index (fixtures-path))]
+    (let [index (serdes/build-file-index (fixtures-path))]
       (is (contains? (:card index) "simple-orders"))
       (is (contains? (:card index) "native-orders"))
       (is (contains? (:card index) "orders-with-products")))))
 
 (deftest build-file-index-no-duplicates-test
   (testing "fixture index has no duplicates"
-    (let [{:keys [index]} (serdes/build-file-index (fixtures-path))]
+    (let [index (serdes/build-file-index (fixtures-path))]
       (is (nil? (:duplicates index))))))
 
-(deftest build-database-dir-index-test
-  (testing "build-database-dir-index indexes databases and provides db-name->dir mapping"
-    (let [db-dir (str (fixtures-path) "/databases")
-          {:keys [index db-name->dir]} (serdes/build-database-dir-index db-dir)]
-      (is (contains? (:database index) "Test Database"))
-      (is (contains? (:database index) "SQLite DB"))
-      (is (contains? db-name->dir "Test Database"))
-      (is (contains? db-name->dir "SQLite DB"))
-      ;; Tables are NOT in the index — they're resolved on demand
-      (is (nil? (:table index)))
-      ;; Should not contain cards (databases dir has no collections)
-      (is (nil? (:card index))))))
-
 ;;; ===========================================================================
-;;; db-name->dir mapping tests
+;;; AssetsSource protocol — resolution tests
 ;;; ===========================================================================
-
-(deftest db-name-to-dir-mapping-test
-  (testing "db-name->dir maps real database names to directory names"
-    (with-temp-dir
-      (fn [dir]
-        ;; Create a database with a slugified directory name but real name in YAML
-        (write-yaml! dir "databases" "my_fancy_db" "my_fancy_db.yaml"
-                     {:name "My Fancy DB" :engine "h2"})
-        (let [{:keys [db-name->dir]} (serdes/build-database-dir-index (str dir "/databases"))]
-          (is (= "my_fancy_db" (get db-name->dir "My Fancy DB")))))))
-
-  (testing "db-name->dir includes ALL databases, not just some"
-    (with-temp-dir
-      (fn [dir]
-        (doseq [i (range 10)]
-          (let [slug (str "db_" i)]
-            (write-yaml! dir "databases" slug (str slug ".yaml")
-                         {:name (str "Database " i) :engine "h2"})))
-        (let [{:keys [db-name->dir]} (serdes/build-database-dir-index (str dir "/databases"))]
-          (is (= 10 (count db-name->dir)))
-          (doseq [i (range 10)]
-            (is (= (str "db_" i) (get db-name->dir (str "Database " i))))))))))
-
-;;; ===========================================================================
-;;; SchemaSource protocol — on-demand resolution tests
-;;; ===========================================================================
-
-(deftest source-resolves-database-test
-  (testing "SerdesSource resolves databases by name"
-    (let [source (serdes/make-source (fixtures-path))
-          db     (source/resolve-database source "Test Database")]
-      (is (some? db))
-      (is (= "Test Database" (:name db))))))
-
-(deftest source-resolves-table-on-demand-test
-  (testing "SerdesSource resolves tables by path on demand (no pre-indexing)"
-    (let [source (serdes/make-source (fixtures-path))
-          table  (source/resolve-table source ["Test Database" "public" "orders"])]
-      (is (some? table))
-      (is (= "orders" (:name table))))
-    (testing "schema-less tables"
-      (let [source (serdes/make-source (fixtures-path))
-            table  (source/resolve-table source ["SQLite DB" nil "orders"])]
-        (is (some? table))
-        (is (= "orders" (:name table)))))))
-
-(deftest source-resolves-field-on-demand-test
-  (testing "SerdesSource resolves fields by path on demand"
-    (let [source (serdes/make-source (fixtures-path))
-          field  (source/resolve-field source ["Test Database" "public" "orders" "id"])]
-      (is (some? field))
-      (is (= "id" (:name field))))
-    (testing "schema-less fields"
-      (let [source (serdes/make-source (fixtures-path))
-            field  (source/resolve-field source ["SQLite DB" nil "orders" "id"])]
-        (is (some? field))
-        (is (= "id" (:name field)))))))
 
 (deftest source-resolves-card-test
   (testing "SerdesSource resolves cards by entity-id"
@@ -170,169 +100,21 @@
 (deftest source-returns-nil-for-unknown-test
   (testing "SerdesSource returns nil for unknown entities"
     (let [source (serdes/make-source (fixtures-path))]
-      (is (nil? (source/resolve-database source "Nonexistent")))
-      (is (nil? (source/resolve-table source ["DB" "x" "y"])))
-      (is (nil? (source/resolve-field source ["DB" "x" "y" "z"])))
       (is (nil? (source/resolve-card source "no-such-card"))))))
 
 ;;; ===========================================================================
-;;; fields-for-table and all-table-paths — on-demand enumeration
-;;; ===========================================================================
-
-(deftest fields-for-table-test
-  (testing "fields-for-table returns field paths for a table"
-    (let [source (serdes/make-source (fixtures-path))
-          fields (source/fields-for-table source ["Test Database" "public" "orders"])]
-      (is (set? fields))
-      (is (contains? fields ["Test Database" "public" "orders" "id"]))
-      (is (contains? fields ["Test Database" "public" "orders" "total"]))))
-  (testing "fields-for-table works for schema-less tables"
-    (let [source (serdes/make-source (fixtures-path))
-          fields (source/fields-for-table source ["SQLite DB" nil "orders"])]
-      (is (set? fields))
-      (is (contains? fields ["SQLite DB" nil "orders" "id"]))))
-  (testing "fields-for-table returns nil for unknown table"
-    (let [source (serdes/make-source (fixtures-path))]
-      (is (nil? (source/fields-for-table source ["Nope" "x" "y"]))))))
-
-(deftest all-table-paths-test
-  (testing "all-table-paths enumerates all tables across databases"
-    (let [source (serdes/make-source (fixtures-path))
-          tables (source/all-table-paths source)]
-      (is (seq tables))
-      (is (some #(= ["Test Database" "public" "orders"] %) tables))
-      (is (some #(= ["SQLite DB" nil "orders"] %) tables)))))
-
-(deftest all-database-names-test
-  (testing "all-database-names returns database names"
-    (let [source (serdes/make-source (fixtures-path))]
-      (is (= #{"Test Database" "SQLite DB"} (set (source/all-database-names source)))))))
-
-;;; ===========================================================================
-;;; Slugified directory names — critical correctness tests
-;;; ===========================================================================
-
-(deftest slugified-db-dir-resolves-correctly-test
-  (testing "databases with slugified directory names resolve correctly"
-    (with-temp-dir
-      (fn [dir]
-        (let [db-dir (str dir "/databases")]
-          ;; Create a database with slugified dir but real name in YAML
-          (write-yaml! dir "databases" "analytics_data_warehouse" "analytics_data_warehouse.yaml"
-                       {:name "Analytics Data Warehouse" :engine "postgres"})
-          ;; Create a table under it
-          (write-yaml! dir "databases" "analytics_data_warehouse" "schemas" "public" "tables" "orders" "orders.yaml"
-                       {:name "orders" :schema "public"
-                        :serdes/meta [{:id "Analytics Data Warehouse" :model "Database"}
-                                      {:id "public" :model "Schema"}
-                                      {:id "orders" :model "Table"}]})
-          ;; Create a field
-          (write-yaml! dir "databases" "analytics_data_warehouse" "schemas" "public" "tables" "orders" "fields" "id.yaml"
-                       {:name "id" :base_type "type/Integer"
-                        :serdes/meta [{:id "Analytics Data Warehouse" :model "Database"}
-                                      {:id "public" :model "Schema"}
-                                      {:id "orders" :model "Table"}
-                                      {:id "id" :model "Field"}]})
-          (let [source (serdes/make-database-source db-dir)]
-            ;; Database resolves by real name
-            (is (some? (source/resolve-database source "Analytics Data Warehouse")))
-            ;; Table resolves using real db name
-            (is (some? (source/resolve-table source ["Analytics Data Warehouse" "public" "orders"])))
-            ;; Field resolves using real db name
-            (let [field (source/resolve-field source ["Analytics Data Warehouse" "public" "orders" "id"])]
-              (is (some? field))
-              (is (= "id" (:name field))))
-            ;; fields-for-table works
-            (let [fields (source/fields-for-table source ["Analytics Data Warehouse" "public" "orders"])]
-              (is (contains? fields ["Analytics Data Warehouse" "public" "orders" "id"])))))))))
-
-;;; ===========================================================================
-;;; Performance guards — indexing should NOT parse field/table YAMLs
-;;; ===========================================================================
-
-(deftest index-does-not-contain-tables-or-fields-test
-  (testing "the file index only contains databases — tables and fields are resolved on demand"
-    (let [db-dir (str (fixtures-path) "/databases")
-          {:keys [index]} (serdes/build-database-dir-index db-dir)]
-      (is (seq (:database index)) "databases should be in the index")
-      (is (nil? (:table index)) "tables should NOT be in the index")
-      (is (nil? (:field index)) "fields should NOT be in the index"))))
-
-;;; ===========================================================================
-;;; Cache shape and lazy resolution
-;;; ===========================================================================
-
-(def ^:private not-indexed ::serdes/not-indexed)
-
-(deftest schema-model-shape-test
-  (testing "schema model starts with ::not-indexed for each schema, populates lazily"
-    (with-temp-dir
-      (fn [dir]
-        (write-yaml! dir "databases" "db" "db.yaml" {:name "DB" :engine "h2"})
-        (write-yaml! dir "databases" "db" "schemas" "s1" "tables" "t1" "t1.yaml"
-                     {:name "T1" :schema "s1"})
-        (write-yaml! dir "databases" "db" "schemas" "s1" "tables" "t1" "fields" "f1.yaml"
-                     {:name "F1" :base_type "type/Integer"})
-        (write-yaml! dir "databases" "db" "schemas" "s2" "tables" "t2" "t2.yaml"
-                     {:name "T2" :schema "s2"})
-        (write-yaml! dir "databases" "db" "schemas" "s2" "tables" "t2" "fields" "f2.yaml"
-                     {:name "F2" :base_type "type/Text"})
-        (let [source (serdes/make-database-source (str dir "/databases"))]
-          ;; Initial: db-file set, all schemas ::not-indexed
-          (is (=? {"DB" {:db-file string?
-                         :schemas {"s1" not-indexed
-                                   "s2" not-indexed}}}
-                  (serdes/schema-model source)))
-          ;; After resolving a table in s1: s1 indexed with tables, s2 untouched
-          (source/resolve-table source ["DB" "s1" "T1"])
-          (is (=? {"DB" {:schemas {"s1" {"T1" {:table-file string?
-                                               :fields     not-indexed}}
-                                   "s2" not-indexed}}}
-                  (serdes/schema-model source)))
-          ;; After resolving fields for T1: T1 fields indexed, s2 still untouched
-          (source/fields-for-table source ["DB" "s1" "T1"])
-          (is (=? {"DB" {:schemas {"s1" {"T1" {:table-file string?
-                                               :fields     {"F1" string?}}}
-                                   "s2" not-indexed}}}
-                  (serdes/schema-model source))))))))
-
-(deftest case-insensitive-schema-resolution-test
-  (testing "schemas with different casing on disk vs YAML resolve correctly"
-    (with-temp-dir
-      (fn [dir]
-        ;; Dir name is lowercase, YAML schema is uppercase (H2 convention)
-        (write-yaml! dir "databases" "db" "db.yaml" {:name "DB" :engine "h2"})
-        (write-yaml! dir "databases" "db" "schemas" "public" "tables" "orders" "orders.yaml"
-                     {:name "ORDERS" :schema "PUBLIC"})
-        (write-yaml! dir "databases" "db" "schemas" "public" "tables" "orders" "fields" "id.yaml"
-                     {:name "ID" :base_type "type/Integer"})
-        (let [source (serdes/make-database-source (str dir "/databases"))]
-          ;; Resolve by real names (uppercase) — schema re-keys from "public" to "PUBLIC"
-          (is (some? (source/resolve-table source ["DB" "PUBLIC" "ORDERS"])))
-          (is (some? (source/resolve-field source ["DB" "PUBLIC" "ORDERS" "ID"])))
-          (is (=? {"DB" {:schemas {"PUBLIC" {"ORDERS" {:fields {"ID" string?}}}}}}
-                  (serdes/schema-model source))))))))
-
-;;; ===========================================================================
-;;; Segments and measures — indexed from export dir, NOT schema dir
+;;; Segments and measures — indexed from export dir
 ;;; ===========================================================================
 
 (deftest export-dir-indexes-segments-and-measures-test
   (testing "build-file-index (export dir) finds segments and measures under databases/"
-    (let [{:keys [index]} (serdes/build-file-index (fixtures-path))]
+    (let [index (serdes/build-file-index (fixtures-path))]
       (is (contains? (:segment index) "big-orders-segment")
           "segment from with-schema table should be indexed")
       (is (contains? (:segment index) "recent-orders-segment")
           "segment from schema-less table should be indexed")
       (is (contains? (:measure index) "total-revenue-measure")
           "measure should be indexed"))))
-
-(deftest schema-dir-does-not-index-segments-test
-  (testing "build-database-dir-index (schema dir) does NOT index segments or measures"
-    (let [db-dir (str (fixtures-path) "/databases")
-          {:keys [index]} (serdes/build-database-dir-index db-dir)]
-      (is (nil? (:segment index)) "schema dir should not contain segments")
-      (is (nil? (:measure index)) "schema dir should not contain measures"))))
 
 (deftest segments-resolve-from-export-source-test
   (testing "segments can be resolved from the export source"
@@ -359,7 +141,7 @@
   (testing "build-file-index on empty directory returns empty index"
     (with-temp-dir
       (fn [dir]
-        (let [{:keys [index]} (serdes/build-file-index dir)]
+        (let [index (serdes/build-file-index dir)]
           (is (nil? (:database index)))
           (is (nil? (:card index))))))))
 
@@ -377,16 +159,16 @@
           (.mkdirs (.getParentFile f2))
           (spit f1 (format card-yaml-template "Card A" "dup-id" "dup-id"))
           (spit f2 (format card-yaml-template "Card B" "dup-id" "dup-id"))
-          (let [{:keys [index]} (serdes/build-file-index dir)]
+          (let [index (serdes/build-file-index dir)]
             (is (seq (:duplicates index)) "Should detect duplicate entity_ids")
             (is (= "dup-id" (:ref (first (:duplicates index)))))))))))
 
 (deftest source-index-accessor-test
-  (testing "source-index returns the assets index (no databases — those are in the schema model)"
+  (testing "source-index returns the assets index (no databases — those are in the schema source)"
     (let [source (serdes/make-source (fixtures-path))
           index  (serdes/source-index source)]
       (is (map? index))
-      (is (not (contains? index :database)) "databases are in the schema model, not the assets index")
+      (is (not (contains? index :database)) "databases are in the schema source, not the assets index")
       (is (contains? index :card)))))
 
 (deftest all-card-ids-test

--- a/enterprise/backend/test/metabase_enterprise/checker/format/serdes_schema_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/checker/format/serdes_schema_test.clj
@@ -1,0 +1,263 @@
+(ns metabase-enterprise.checker.format.serdes-schema-test
+  "Tests for the serdes schema format module — database/table/field resolution and lazy indexing."
+  (:require
+   [clojure.java.io :as io]
+   [clojure.test :refer :all]
+   [metabase-enterprise.checker.format.serdes-schema :as serdes-schema]
+   [metabase-enterprise.checker.source :as source]
+   [metabase.util.yaml :as yaml]))
+
+(set! *warn-on-reflection* true)
+
+;;; ===========================================================================
+;;; Helpers
+;;; ===========================================================================
+
+(def ^:private fixtures-dir "test_resources/yaml_checks")
+
+(defn- fixtures-path []
+  (let [f (io/file fixtures-dir)]
+    (if (.isAbsolute f)
+      fixtures-dir
+      (.getPath (io/file (System/getProperty "user.dir") fixtures-dir)))))
+
+(defn- with-temp-dir
+  "Create a temp directory, call (f dir-path), then clean up."
+  [f]
+  (let [dir (java.io.File/createTempFile "serdes-test" "")]
+    (.delete dir)
+    (.mkdirs dir)
+    (try
+      (f (.getPath dir))
+      (finally
+        (doseq [fl (reverse (file-seq dir))]
+          (.delete ^java.io.File fl))))))
+
+(defn- write-yaml!
+  "Write a YAML file, creating parent directories as needed."
+  [dir & path-and-data]
+  (let [data      (last path-and-data)
+        path-segs (butlast path-and-data)
+        ^java.io.File file (apply io/file dir (map str path-segs))]
+    (.mkdirs (.getParentFile file))
+    (spit file (yaml/generate-string data))
+    (.getPath file)))
+
+(deftest build-database-dir-index-test
+  (testing "build-database-dir-index indexes databases and provides db-name->dir mapping"
+    (let [db-dir (str (fixtures-path) "/databases")
+          {:keys [index db-name->dir]} (serdes-schema/build-database-dir-index db-dir)]
+      (is (contains? (:database index) "Test Database"))
+      (is (contains? (:database index) "SQLite DB"))
+      (is (contains? db-name->dir "Test Database"))
+      (is (contains? db-name->dir "SQLite DB"))
+      ;; Tables are NOT in the index — they're resolved on demand
+      (is (nil? (:table index)))
+      ;; Should not contain cards (databases dir has no collections)
+      (is (nil? (:card index))))))
+
+;;; ===========================================================================
+;;; db-name->dir mapping tests
+;;; ===========================================================================
+
+(deftest db-name-to-dir-mapping-test
+  (testing "db-name->dir maps real database names to directory names"
+    (with-temp-dir
+      (fn [dir]
+        ;; Create a database with a slugified directory name but real name in YAML
+        (write-yaml! dir "databases" "my_fancy_db" "my_fancy_db.yaml"
+                     {:name "My Fancy DB" :engine "h2"})
+        (let [{:keys [db-name->dir]} (serdes-schema/build-database-dir-index (str dir "/databases"))]
+          (is (= "my_fancy_db" (get db-name->dir "My Fancy DB")))))))
+
+  (testing "db-name->dir includes ALL databases, not just some"
+    (with-temp-dir
+      (fn [dir]
+        (doseq [i (range 10)]
+          (let [slug (str "db_" i)]
+            (write-yaml! dir "databases" slug (str slug ".yaml")
+                         {:name (str "Database " i) :engine "h2"})))
+        (let [{:keys [db-name->dir]} (serdes-schema/build-database-dir-index (str dir "/databases"))]
+          (is (= 10 (count db-name->dir)))
+          (doseq [i (range 10)]
+            (is (= (str "db_" i) (get db-name->dir (str "Database " i))))))))))
+
+;;; ===========================================================================
+;;; SchemaSource protocol — on-demand resolution tests
+;;; ===========================================================================
+
+(deftest source-resolves-database-test
+  (testing "SerdesSchemaSource resolves databases by name"
+    (let [source (serdes-schema/make-database-source (str (fixtures-path) "/databases"))
+          db     (source/resolve-database source "Test Database")]
+      (is (some? db))
+      (is (= "Test Database" (:name db))))))
+
+(deftest source-resolves-table-on-demand-test
+  (testing "SerdesSchemaSource resolves tables by path on demand (no pre-indexing)"
+    (let [source (serdes-schema/make-database-source (str (fixtures-path) "/databases"))
+          table  (source/resolve-table source ["Test Database" "public" "orders"])]
+      (is (some? table))
+      (is (= "orders" (:name table))))
+    (testing "schema-less tables"
+      (let [source (serdes-schema/make-database-source (str (fixtures-path) "/databases"))
+            table  (source/resolve-table source ["SQLite DB" nil "orders"])]
+        (is (some? table))
+        (is (= "orders" (:name table)))))))
+
+(deftest source-resolves-field-on-demand-test
+  (testing "SerdesSchemaSource resolves fields by path on demand"
+    (let [source (serdes-schema/make-database-source (str (fixtures-path) "/databases"))
+          field  (source/resolve-field source ["Test Database" "public" "orders" "id"])]
+      (is (some? field))
+      (is (= "id" (:name field))))
+    (testing "schema-less fields"
+      (let [source (serdes-schema/make-database-source (str (fixtures-path) "/databases"))
+            field  (source/resolve-field source ["SQLite DB" nil "orders" "id"])]
+        (is (some? field))
+        (is (= "id" (:name field)))))))
+
+(deftest source-returns-nil-for-unknown-test
+  (testing "SerdesSchemaSource returns nil for unknown entities"
+    (let [source (serdes-schema/make-database-source (str (fixtures-path) "/databases"))]
+      (is (nil? (source/resolve-database source "Nonexistent")))
+      (is (nil? (source/resolve-table source ["DB" "x" "y"])))
+      (is (nil? (source/resolve-field source ["DB" "x" "y" "z"]))))))
+
+;;; ===========================================================================
+;;; fields-for-table and all-table-paths — on-demand enumeration
+;;; ===========================================================================
+
+(deftest fields-for-table-test
+  (testing "fields-for-table returns field paths for a table"
+    (let [source (serdes-schema/make-database-source (str (fixtures-path) "/databases"))
+          fields (source/fields-for-table source ["Test Database" "public" "orders"])]
+      (is (set? fields))
+      (is (contains? fields ["Test Database" "public" "orders" "id"]))
+      (is (contains? fields ["Test Database" "public" "orders" "total"]))))
+  (testing "fields-for-table works for schema-less tables"
+    (let [source (serdes-schema/make-database-source (str (fixtures-path) "/databases"))
+          fields (source/fields-for-table source ["SQLite DB" nil "orders"])]
+      (is (set? fields))
+      (is (contains? fields ["SQLite DB" nil "orders" "id"]))))
+  (testing "fields-for-table returns nil for unknown table"
+    (let [source (serdes-schema/make-database-source (str (fixtures-path) "/databases"))]
+      (is (nil? (source/fields-for-table source ["Nope" "x" "y"]))))))
+
+(deftest all-table-paths-test
+  (testing "all-table-paths enumerates all tables across databases"
+    (let [source (serdes-schema/make-database-source (str (fixtures-path) "/databases"))
+          tables (source/all-table-paths source)]
+      (is (seq tables))
+      (is (some #(= ["Test Database" "public" "orders"] %) tables))
+      (is (some #(= ["SQLite DB" nil "orders"] %) tables)))))
+
+(deftest all-database-names-test
+  (testing "all-database-names returns database names"
+    (let [source (serdes-schema/make-database-source (str (fixtures-path) "/databases"))]
+      (is (= #{"Test Database" "SQLite DB"} (set (source/all-database-names source)))))))
+
+;;; ===========================================================================
+;;; Slugified directory names — critical correctness tests
+;;; ===========================================================================
+
+(deftest slugified-db-dir-resolves-correctly-test
+  (testing "databases with slugified directory names resolve correctly"
+    (with-temp-dir
+      (fn [dir]
+        (let [db-dir (str dir "/databases")]
+          ;; Create a database with slugified dir but real name in YAML
+          (write-yaml! dir "databases" "analytics_data_warehouse" "analytics_data_warehouse.yaml"
+                       {:name "Analytics Data Warehouse" :engine "postgres"})
+          ;; Create a table under it
+          (write-yaml! dir "databases" "analytics_data_warehouse" "schemas" "public" "tables" "orders" "orders.yaml"
+                       {:name "orders" :schema "public"
+                        :serdes/meta [{:id "Analytics Data Warehouse" :model "Database"}
+                                      {:id "public" :model "Schema"}
+                                      {:id "orders" :model "Table"}]})
+          ;; Create a field
+          (write-yaml! dir "databases" "analytics_data_warehouse" "schemas" "public" "tables" "orders" "fields" "id.yaml"
+                       {:name "id" :base_type "type/Integer"
+                        :serdes/meta [{:id "Analytics Data Warehouse" :model "Database"}
+                                      {:id "public" :model "Schema"}
+                                      {:id "orders" :model "Table"}
+                                      {:id "id" :model "Field"}]})
+          (let [source (serdes-schema/make-database-source db-dir)]
+            ;; Database resolves by real name
+            (is (some? (source/resolve-database source "Analytics Data Warehouse")))
+            ;; Table resolves using real db name
+            (is (some? (source/resolve-table source ["Analytics Data Warehouse" "public" "orders"])))
+            ;; Field resolves using real db name
+            (let [field (source/resolve-field source ["Analytics Data Warehouse" "public" "orders" "id"])]
+              (is (some? field))
+              (is (= "id" (:name field))))
+            ;; fields-for-table works
+            (let [fields (source/fields-for-table source ["Analytics Data Warehouse" "public" "orders"])]
+              (is (contains? fields ["Analytics Data Warehouse" "public" "orders" "id"])))))))))
+
+;;; ===========================================================================
+;;; Performance guards — indexing should NOT parse field/table YAMLs
+;;; ===========================================================================
+
+(deftest index-does-not-contain-tables-or-fields-test
+  (testing "the file index only contains databases — tables and fields are resolved on demand"
+    (let [db-dir (str (fixtures-path) "/databases")
+          {:keys [index]} (serdes-schema/build-database-dir-index db-dir)]
+      (is (seq (:database index)) "databases should be in the index")
+      (is (nil? (:table index)) "tables should NOT be in the index")
+      (is (nil? (:field index)) "fields should NOT be in the index"))))
+
+;;; ===========================================================================
+;;; Cache shape and lazy resolution
+;;; ===========================================================================
+
+(def ^:private not-indexed ::serdes-schema/not-indexed)
+
+(deftest schema-model-shape-test
+  (testing "schema model starts with ::not-indexed for each schema, populates lazily"
+    (with-temp-dir
+      (fn [dir]
+        (write-yaml! dir "databases" "db" "db.yaml" {:name "DB" :engine "h2"})
+        (write-yaml! dir "databases" "db" "schemas" "s1" "tables" "t1" "t1.yaml"
+                     {:name "T1" :schema "s1"})
+        (write-yaml! dir "databases" "db" "schemas" "s1" "tables" "t1" "fields" "f1.yaml"
+                     {:name "F1" :base_type "type/Integer"})
+        (write-yaml! dir "databases" "db" "schemas" "s2" "tables" "t2" "t2.yaml"
+                     {:name "T2" :schema "s2"})
+        (write-yaml! dir "databases" "db" "schemas" "s2" "tables" "t2" "fields" "f2.yaml"
+                     {:name "F2" :base_type "type/Text"})
+        (let [source (serdes-schema/make-database-source (str dir "/databases"))]
+          ;; Initial: db-file set, all schemas ::not-indexed
+          (is (=? {"DB" {:db-file string?
+                         :schemas {"s1" not-indexed
+                                   "s2" not-indexed}}}
+                  (serdes-schema/schema-model source)))
+          ;; After resolving a table in s1: s1 indexed with tables, s2 untouched
+          (source/resolve-table source ["DB" "s1" "T1"])
+          (is (=? {"DB" {:schemas {"s1" {"T1" {:table-file string?
+                                               :fields     not-indexed}}
+                                   "s2" not-indexed}}}
+                  (serdes-schema/schema-model source)))
+          ;; After resolving fields for T1: T1 fields indexed, s2 still untouched
+          (source/fields-for-table source ["DB" "s1" "T1"])
+          (is (=? {"DB" {:schemas {"s1" {"T1" {:table-file string?
+                                               :fields     {"F1" string?}}}
+                                   "s2" not-indexed}}}
+                  (serdes-schema/schema-model source))))))))
+
+(deftest case-insensitive-schema-resolution-test
+  (testing "schemas with different casing on disk vs YAML resolve correctly"
+    (with-temp-dir
+      (fn [dir]
+        ;; Dir name is lowercase, YAML schema is uppercase (H2 convention)
+        (write-yaml! dir "databases" "db" "db.yaml" {:name "DB" :engine "h2"})
+        (write-yaml! dir "databases" "db" "schemas" "public" "tables" "orders" "orders.yaml"
+                     {:name "ORDERS" :schema "PUBLIC"})
+        (write-yaml! dir "databases" "db" "schemas" "public" "tables" "orders" "fields" "id.yaml"
+                     {:name "ID" :base_type "type/Integer"})
+        (let [source (serdes-schema/make-database-source (str dir "/databases"))]
+          ;; Resolve by real names (uppercase) — schema re-keys from "public" to "PUBLIC"
+          (is (some? (source/resolve-table source ["DB" "PUBLIC" "ORDERS"])))
+          (is (some? (source/resolve-field source ["DB" "PUBLIC" "ORDERS" "ID"])))
+          (is (=? {"DB" {:schemas {"PUBLIC" {"ORDERS" {:fields {"ID" string?}}}}}}
+                  (serdes-schema/schema-model source))))))))

--- a/enterprise/backend/test/metabase_enterprise/checker/semantic_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/checker/semantic_test.clj
@@ -6,7 +6,7 @@
   (:require
    [clojure.java.io :as io]
    [clojure.test :refer [deftest is testing]]
-   [metabase-enterprise.checker.format.serdes :as serdes-format]
+   [metabase-enterprise.checker.format.serdes-assets :as serdes-format]
    [metabase-enterprise.checker.provider :as provider]
    [metabase-enterprise.checker.semantic :as checker]
    [metabase-enterprise.checker.source :as source]

--- a/enterprise/backend/test/metabase_enterprise/checker/semantic_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/checker/semantic_test.clj
@@ -7,6 +7,7 @@
    [clojure.java.io :as io]
    [clojure.test :refer [deftest is testing]]
    [metabase-enterprise.checker.format.serdes-assets :as serdes-format]
+   [metabase-enterprise.checker.format.serdes-schema :as serdes-schema]
    [metabase-enterprise.checker.provider :as provider]
    [metabase-enterprise.checker.semantic :as checker]
    [metabase-enterprise.checker.source :as source]
@@ -30,14 +31,18 @@
       test-fixtures-dir
       (.getPath (io/file (System/getProperty "user.dir") test-fixtures-dir)))))
 
-(defn- make-test-source []
-  (serdes-format/make-source (fixtures-path)))
+(defn- make-test-sources
+  "Create both schema and assets sources from fixtures.
+   Returns [schema-source assets-source]."
+  []
+  [(serdes-schema/make-database-source (str (fixtures-path) "/databases"))
+   (serdes-format/make-source (fixtures-path))])
 
-(defn- check-all [source]
-  (checker/check-entities source source (serdes-format/source-index source)))
+(defn- check-all [[schema-source assets-source]]
+  (checker/check-entities schema-source assets-source (serdes-format/source-index assets-source)))
 
-(defn- check-specific [source entity-ids]
-  (checker/check-entities source source (serdes-format/source-index source) entity-ids))
+(defn- check-specific [[schema-source assets-source] entity-ids]
+  (checker/check-entities schema-source assets-source (serdes-format/source-index assets-source) entity-ids))
 
 ;;; ===========================================================================
 ;;; Tests Using Real YAML Files
@@ -45,20 +50,20 @@
 
 (deftest source-index-test
   (testing "Source correctly indexes databases and cards; tables/fields are on-demand"
-    (let [source (make-test-source)
-          index  (serdes-format/source-index source)]
-      ;; Databases are in the schema model, not the assets index
-      (is (= #{"Test Database" "SQLite DB"} (set (source/all-database-names source))))
+    (let [[schema-source assets-source] (make-test-sources)
+          index  (serdes-format/source-index assets-source)]
+      ;; Databases are in the schema source
+      (is (= #{"Test Database" "SQLite DB"} (set (source/all-database-names schema-source))))
       ;; Cards are in the assets index
       (is (= 5 (count (:card index))) "Should have 5 cards")
-      ;; Tables and fields are resolved on demand
-      (is (= 4 (count (source/all-table-paths source))) "Should have 4 tables via source")
-      (is (= 11 (count (source/all-field-paths source))) "Should have 11 fields via source"))))
+      ;; Tables and fields are resolved on demand via schema source
+      (is (= 4 (count (source/all-table-paths schema-source))) "Should have 4 tables via source")
+      (is (= 11 (count (source/all-field-paths schema-source))) "Should have 11 fields via source"))))
 
 (deftest simple-mbql-query-test
   (testing "Simple MBQL query on orders table validates successfully"
-    (let [source (make-test-source)
-          results (check-all source)
+    (let [sources (make-test-sources)
+          results (check-all sources)
           result (get results "simple-orders")]
       (is (some? result) "Card should be found")
       (is (= "Simple Orders" (:name result)) "Card name should match")
@@ -70,8 +75,8 @@
 
 (deftest native-query-test
   (testing "Native SQL query validates successfully"
-    (let [source (make-test-source)
-          results (check-all source)
+    (let [sources (make-test-sources)
+          results (check-all sources)
           result (get results "native-orders")]
       (is (some? result) "Card should be found")
       (is (= "Native Orders" (:name result)) "Card name should match")
@@ -80,8 +85,8 @@
 
 (deftest mbql-with-joins-test
   (testing "MBQL query with joins validates successfully"
-    (let [source (make-test-source)
-          results (check-all source)
+    (let [sources (make-test-sources)
+          results (check-all sources)
           result (get results "orders-with-products")]
       (is (some? result) "Card should be found")
       (is (= "Orders With Products" (:name result)) "Card name should match")
@@ -94,8 +99,8 @@
 
 (deftest all-cards-checked-test
   (testing "All cards in fixtures are checked"
-    (let [source (make-test-source)
-          results (check-all source)]
+    (let [sources (make-test-sources)
+          results (check-all sources)]
       (is (>= (count results) 5) "Should check at least 5 cards")
       (is (contains? results "simple-orders"))
       (is (contains? results "native-orders"))
@@ -112,14 +117,14 @@
 
 (deftest schemaless-database-index-test
   (testing "Schema-less databases are indexed correctly with nil schema"
-    (let [source (make-test-source)]
-      (is (= #{"Test Database" "SQLite DB"} (set (source/all-database-names source))))
-      (is (= 4 (count (source/all-table-paths source))) "Should have 4 tables via source"))))
+    (let [[schema-source _] (make-test-sources)]
+      (is (= #{"Test Database" "SQLite DB"} (set (source/all-database-names schema-source))))
+      (is (= 4 (count (source/all-table-paths schema-source))) "Should have 4 tables via source"))))
 
 (deftest schemaless-query-test
   (testing "Query on schema-less database validates successfully"
-    (let [source (make-test-source)
-          results (check-all source)
+    (let [sources (make-test-sources)
+          results (check-all sources)
           result (get results "schemaless-query")]
       (is (some? result) "Card should be found")
       (is (= "Schemaless Query" (:name result)) "Card name should match")
@@ -136,9 +141,9 @@
 
 (deftest fk-in-field-metadata-test
   (testing "FK target in field metadata is resolved to integer ID"
-    (let [source (make-test-source)
-          index (serdes-format/source-index source)
-          provider (provider/make-provider (store/make-store source source index))
+    (let [[schema-source assets-source] (make-test-sources)
+          index (serdes-format/source-index assets-source)
+          provider (provider/make-provider (store/make-store schema-source assets-source index))
           ;; Get the product_id field which has FK to products.id
           fields (lib.metadata.protocols/metadatas
                   provider {:lib/type :metadata/column})
@@ -150,8 +155,8 @@
 
 (deftest fk-in-result-metadata-test
   (testing "FK target in card result_metadata is resolved to integer ID"
-    (let [source (make-test-source)
-          results (check-all source)
+    (let [sources (make-test-sources)
+          results (check-all sources)
           result (get results "orders-with-fk")]
       (is (some? result) "Card should be found")
       (is (= "Orders With FK" (:name result)) "Card name should match")
@@ -242,8 +247,8 @@
 
 (deftest check-specific-cards-test
   (testing "Can check specific cards by entity-id"
-    (let [source (make-test-source)
-          results (check-specific source ["simple-orders" "native-orders"])]
+    (let [sources (make-test-sources)
+          results (check-specific sources ["simple-orders" "native-orders"])]
       (is (>= (count results) 2) "Should check at least 2 cards")
       (is (contains? results "simple-orders"))
       (is (contains? results "native-orders"))
@@ -1211,5 +1216,5 @@
   (fixtures-path)
 
   ;; Manually check all cards in fixtures
-  (def source (make-test-source))
-  (check-all source))
+  (def sources (make-test-sources))
+  (check-all sources))


### PR DESCRIPTION
We have two protocols for the checker: one related to schema (dbs, tables, fields) and one related to assets (cards, dashboards, documents, segments, measures, etc).

Both of these are serdes based right now. So we made one namespace `format/serdes.clj` that new how to interact with both. But now we want to vary the schema one. Why?: currently serdes schema is atrocious on stats. There are ~500,000 files in 40,000 folders.

```
❯ pwd
/Users/dan/projects/work/exports-root/metadata/metadata/databases

❯ find . -type d | wc -l
   44308

❯ find . -type f | wc -l
  563458
```

If you do this naively, it can take 13 minutes to run the checker as it parses 500,000 files for information that is not necessary. So the vast complication of the checker is how to only load tables, and then only load fields of tables it actually needs so that it doesn't parse half a million files for no reason.

But the size of the information is quite reasonable. The checker can just keep it all in memory no problem. So let's split this into serdes-assets (will remain unchanged) and a new schema implementation will appear that is vastly simpler.

The protocol is:

```
(defprotocol SchemaSource
  "Resolve database schema references to entity data."

  (resolve-database [this db-name]
    "Resolve database by name. Returns map with :name, :engine, :settings or nil.")

  (resolve-table [this table-path]
    "Resolve table by [db schema table]. Returns map with :name, :schema, :display-name, etc. or nil.")

  (resolve-field [this field-path]
    "Resolve field by [db schema table field]. Returns map with :name, :base-type, :semantic-type, etc. or nil.")

  (fields-for-table [this table-path]
    "Return a set of field paths belonging to the given table path [db schema table].")

  (all-field-paths [this]
    "Return all known field paths.")

  (all-database-names [this]
    "Return all known database names.")

  (all-table-paths [this]
    "Return all known table paths.")

  (tables-for-database [this db-name]
    "Return table paths belonging to the given database name."))
```
A few of the problems:
- we munge names so folders don't matter. Everything has a file explaining the real name of the thing except for schema. So the field is in file `/Users/dan/projects/work/exports-root/metadata/metadata/databases/sample_database/schemas/public/tables/people/fields/address.yaml`. It has an "address" of `["Sample Database" "PUBLIC" "PEOPLE" "ADDRESS"]`. The db folder is munged to `sample_database` But there's a file describing the name so we can index and save it. This is not true of schema. So we have to just guess and reconstitute this information.
```
sample_database
├── sample_database.yaml ;; this yaml file gives the link of sample_database munged folder name so "Sample Database"
└── schemas
    └── public  ;; schemas are not a real thing in metabase. no file exists giving the real link
        └── tables
            ├── accounts
            │   ├── accounts.yaml ;; gives link to munged account folder name to "ACCOUNTS" 
            │   ├── fields
            │   │   ├── active_subscription.yaml
            │   │   ├── active_subscription___fieldvalues.yaml
            │   │   ├── canceled_at.yaml
            │   │   ├── country.yaml
            │   │   ├── country___fieldvalues.yaml
            │   │   ├── created_at.yaml
            │   │   ├── email.yaml
            │   │   ├── email___fieldvalues.yaml
            │   │   ├── first_name.yaml
            │   │   ├── id.yaml
            │   │   ├── last_name.yaml
            │   │   ├── last_name___fieldvalues.yaml
            │   │   ├── latitude.yaml
            │   │   ├── legacy_plan.yaml
            │   │   ├── legacy_plan___fieldvalues.yaml
            │   │   ├── longitude.yaml
            │   │   ├── plan.yaml
            │   │   ├── plan___fieldvalues.yaml
            │   │   ├── seats.yaml
            │   │   ├── seats___fieldvalues.yaml
            │   │   ├── source.yaml
            │   │   ├── source___fieldvalues.yaml
            │   │   ├── trial_converted.yaml
            │   │   ├── trial_converted___fieldvalues.yaml
            │   │   └── trial_ends_at.yaml
```

Because there are so many folders, the index does a lot of probing to make sure to not load too much. But this is not related to data size but sheer quantity of files. Changing the format lets us skip this.
```
(defn- init-schema-model
  "Build the initial schema model with db-file paths and ::not-indexed for each schema.

   Schema model shape:
     {db-name {:db-file \"path/to/db.yaml\"
               :schemas {schema ::not-indexed
                                | {table {:table-file \"path\" :fields ::not-indexed | {field \"path\"}}}}}}

   Two levels of laziness:
   1. Schema → tables: populated when the schema is first accessed
   2. Table → fields: populated when that table's fields are first accessed"
  [^File databases-dir db-name->dir db-file-index]
  (atom
   (into {}
         (for [[db-name _dir-name] db-name->dir]
           [db-name {:db-file (get db-file-index db-name)
                     :schemas (into {}
                                    (for [schema (list-schemas databases-dir db-name->dir db-name)]
                                      [schema ::not-indexed]))}]))))
```

So what's the point? This doesn't do anything?
This will make the followon new format trivial to add. Listing tables and fields is trivial from a blob that groups it that way. The hard part, frankly, is hitting so many yaml files.