### PR TITLE
Upgrade Netty to 4.2.10.Final — fix HTTP/2 DoS and HTTP/1.1 request smuggling

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -90,8 +90,8 @@
                                              :git/sha "ffc4edc482c057cd9412c62f018a41e9140c618b"
                                              :git/url "https://github.com/eerohele/pp"}
   io.github.metabase/macaw                  {:mvn/version "0.2.36"}             ; Parse native SQL queries
-  io.netty/netty-codec-http                 {:mvn/version "4.2.9.Final"}        ; override of transitive dep from aws s3
-  io.netty/netty-codec-http2                {:mvn/version "4.2.9.Final"}        ; override of transitive dep from aws s3
+  io.netty/netty-codec-http                 {:mvn/version "4.2.10.Final"}       ; override of transitive dep from aws s3
+  io.netty/netty-codec-http2                {:mvn/version "4.2.10.Final"}       ; override of transitive dep from aws s3
   io.prometheus/simpleclient_hotspot        {:mvn/version "0.16.0"}             ; prometheus jvm collector
   junegunn/grouper                          {:mvn/version "0.1.1"}              ; Batch processing helper
   kixi/stats                                {:mvn/version "0.5.7"               ; Various statistic measures implemented as transducers

--- a/modules/drivers/bigquery-cloud-sdk/deps.edn
+++ b/modules/drivers/bigquery-cloud-sdk/deps.edn
@@ -25,5 +25,5 @@
   ;; was 1.71.0. bumping to 77
   io.grpc/grpc-netty-shaded              {:mvn/version "1.77.0"}
   ;; matches those in athena
-  io.netty/netty-common                  {:mvn/version "4.2.7.Final"}
-  io.netty/netty-buffer                  {:mvn/version "4.2.7.Final"}}}
+  io.netty/netty-common                  {:mvn/version "4.2.10.Final"}
+  io.netty/netty-buffer                  {:mvn/version "4.2.10.Final"}}}


### PR DESCRIPTION
## Summary

- Upgrade all direct Netty dependencies to 4.2.10.Final
- Fixes **CVE-2026-33871** (CVSS 7.5): HTTP/2 CONTINUATION frame flood DoS — zero-byte frames bypass existing size mitigations
- Fixes **CVE-2026-33870** (CVSS 7.5): HTTP/1.1 chunked transfer encoding request smuggling

## Changes

| File | Dependency | From | To |
|------|-----------|------|-----|
| `deps.edn` | `io.netty/netty-codec-http` | 4.2.9.Final | 4.2.10.Final |
| `deps.edn` | `io.netty/netty-codec-http2` | 4.2.9.Final | 4.2.10.Final |
| `modules/drivers/bigquery-cloud-sdk/deps.edn` | `io.netty/netty-common` | 4.2.7.Final | 4.2.10.Final |
| `modules/drivers/bigquery-cloud-sdk/deps.edn` | `io.netty/netty-buffer` | 4.2.7.Final | 4.2.10.Final |

## Notes

- The shaded Netty 4.1.127 inside `athena-jdbc-3.7.0.jar` is a transitive dependency from the Athena JDBC driver and cannot be updated here — it requires an upstream release.
- Found by nvd-clojure CVE scanning.

## Test plan

- [ ] Verify `clj -A:deps tree` resolves Netty 4.2.10.Final
- [ ] Run existing test suite — no behavioral changes expected (version bump only)
- [ ] Spot-check BigQuery driver tests if CI environment supports it

🤖 Generated with [Claude Code](https://claude.com/claude-code)