### PR TITLE
Fix streaming encryption padding oracle: AES/CBC → AES/GCM

### DIFF
--- a/src/metabase/util/encryption.clj
+++ b/src/metabase/util/encryption.clj
@@ -1,6 +1,6 @@
 (ns metabase.util.encryption
-  "Utility functions for encrypting and decrypting strings using AES256 CBC + HMAC SHA512 and the
-  `MB_ENCRYPTION_SECRET_KEY` env var.
+  "Utility functions for encrypting and decrypting strings using AES256 CBC + HMAC SHA512 (at-rest) and
+  AES256-GCM (streaming) with the `MB_ENCRYPTION_SECRET_KEY` env var.
 
   You can generate a new key with something like
 
@@ -25,11 +25,12 @@
    [ring.util.codec :as codec])
   (:import (java.io ByteArrayInputStream InputStream SequenceInputStream)
            (javax.crypto Cipher CipherInputStream)
-           (javax.crypto.spec SecretKeySpec IvParameterSpec)))
+           (javax.crypto.spec GCMParameterSpec IvParameterSpec SecretKeySpec)))
 
 (set! *warn-on-reflection* true)
 
-(def ^:private ^:const aes-streaming-spec "AES/CBC/PKCS5Padding")
+(def ^:private ^:const aes-cbc-streaming-spec "AES/CBC/PKCS5Padding")
+(def ^:private ^:const aes-streaming-spec "AES/GCM/NoPadding")
 
 (defn secret-key->hash
   "Generate a 64-byte byte array hash of `secret-key` using 100,000 iterations of PBKDF2+SHA512."
@@ -110,8 +111,8 @@
                      {:algorithm :aes256-cbc-hmac-sha512}))))
 
 (defn encrypt-stream
-  "Wraps a plaintext input stream into an input stream that encrypts it using AES256 CBC.
-  The encryption format is slightly different for streams vs. fixed length data"
+  "Wraps a plaintext input stream into an input stream that encrypts it using AES256-GCM (authenticated encryption).
+  The encryption format is slightly different for streams vs. fixed length data."
   {:added "0.53.0"}
   (^InputStream [^InputStream input-stream]
    (encrypt-stream default-secret-key input-stream))
@@ -119,8 +120,8 @@
    (let [spec aes-streaming-spec
          spec-header (codecs/to-bytes (format "%-32s" spec))
          cipher (Cipher/getInstance spec)
-         iv (nonce/random-bytes 16)]
-     (.init cipher Cipher/ENCRYPT_MODE (SecretKeySpec. (bytes/slice secret-key 32 64) "AES") (IvParameterSpec. iv))
+         iv (nonce/random-bytes 12)]
+     (.init cipher Cipher/ENCRYPT_MODE (SecretKeySpec. (bytes/slice secret-key 32 64) "AES") (GCMParameterSpec. 128 iv))
      (SequenceInputStream. (ByteArrayInputStream. (bytes/concat spec-header iv)) (CipherInputStream. input-stream cipher)))))
 
 (defn encrypt-for-stream
@@ -133,23 +134,32 @@
      (.readAllBytes encrypted))))
 
 (defn maybe-decrypt-stream
-  "Wraps a possibly-encrypted input stream into a new input stream that decrypts it if necessary."
+  "Wraps a possibly-encrypted input stream into a new input stream that decrypts it if necessary.
+  Supports both AES-GCM (v0.54.0+) and legacy AES-CBC (v0.53.0) encrypted streams."
   {:added "0.53.0"}
   (^InputStream [^InputStream input-stream]
    (maybe-decrypt-stream default-secret-key input-stream))
   (^InputStream [secret-key ^InputStream input-stream]
    (let [spec-array (byte-array 32)
          spec-array-length (.read input-stream spec-array)
-         spec (str/trim (codecs/bytes->str spec-array))]
+         spec (str/trim (codecs/bytes->str spec-array))
+         aes-key (SecretKeySpec. (bytes/slice secret-key 32 64) "AES")]
      (cond
        (= spec-array-length -1)
        input-stream
 
        (and (= spec-array-length 32) (= spec aes-streaming-spec))
        (let [cipher (Cipher/getInstance spec)
+             iv (byte-array 12)
+             _ (.read input-stream iv)]
+         (.init cipher Cipher/DECRYPT_MODE aes-key (GCMParameterSpec. 128 iv))
+         (CipherInputStream. input-stream cipher))
+
+       (and (= spec-array-length 32) (= spec aes-cbc-streaming-spec))
+       (let [cipher (Cipher/getInstance spec)
              iv (byte-array 16)
              _ (.read input-stream iv)]
-         (.init cipher Cipher/DECRYPT_MODE (SecretKeySpec. (bytes/slice secret-key 32 64) "AES") (IvParameterSpec. iv))
+         (.init cipher Cipher/DECRYPT_MODE aes-key (IvParameterSpec. iv))
          (CipherInputStream. input-stream cipher))
 
        :else

--- a/test/metabase/util/encryption_test.clj
+++ b/test/metabase/util/encryption_test.clj
@@ -164,3 +164,43 @@
     (testing "When secret is not set, it does not encrypt the stream"
       (let [encrypted (encryption/maybe-encrypt-for-stream nil (codecs/to-bytes "test string"))]
         (is (= "test string" (codecs/bytes->str encrypted)))))))
+
+(deftest ^:parallel stream-gcm-authentication-test
+  (testing "GCM detects tampered ciphertext"
+    (let [encrypted (encryption/encrypt-for-stream secret (codecs/to-bytes "secret data"))
+          ;; Flip a bit in the ciphertext (after the 32-byte header + 12-byte IV = byte 44+)
+          tampered (aclone encrypted)]
+      (when (> (alength tampered) 50)
+        (aset-byte tampered 50 (unchecked-byte (bit-xor (aget tampered 50) 0xFF)))
+        (is (thrown? Exception
+                     (with-open [stream (encryption/maybe-decrypt-stream secret (ByteArrayInputStream. tampered))]
+                       ;; Must read fully to trigger GCM auth tag verification
+                       (org.apache.commons.io.IOUtils/toByteArray stream)))))))
+  (testing "GCM detects wrong key"
+    (let [encrypted (encryption/encrypt-for-stream secret (codecs/to-bytes "secret data"))]
+      (is (thrown? Exception
+                   (with-open [stream (encryption/maybe-decrypt-stream secret-2 (ByteArrayInputStream. encrypted))]
+                     (org.apache.commons.io.IOUtils/toByteArray stream)))))))
+
+(deftest ^:parallel stream-backward-compatibility-test
+  (testing "Data encrypted with legacy AES-CBC can still be decrypted"
+    ;; Simulate legacy CBC encryption by directly using the old format
+    (let [plaintext "backward compat test"
+          plain-bytes (codecs/to-bytes plaintext)
+          spec "AES/CBC/PKCS5Padding"
+          spec-header (codecs/to-bytes (format "%-32s" spec))
+          cipher (javax.crypto.Cipher/getInstance spec)
+          iv (buddy.core.nonce/random-bytes 16)
+          aes-key (javax.crypto.spec.SecretKeySpec. (buddy.core.bytes/slice secret 32 64) "AES")]
+      (.init cipher javax.crypto.Cipher/ENCRYPT_MODE aes-key (javax.crypto.spec.IvParameterSpec. iv))
+      (let [ciphertext (.doFinal cipher plain-bytes)
+            legacy-blob (byte-array (+ 32 16 (alength ciphertext)))]
+        (System/arraycopy spec-header 0 legacy-blob 0 32)
+        (System/arraycopy iv 0 legacy-blob 32 16)
+        (System/arraycopy ciphertext 0 legacy-blob 48 (alength ciphertext))
+        (with-open [stream (encryption/maybe-decrypt-stream secret (ByteArrayInputStream. legacy-blob))]
+          (is (= plaintext (codecs/bytes->str (org.apache.commons.io.IOUtils/toByteArray stream))))))))
+  (testing "New GCM header is written by encrypt-stream"
+    (let [encrypted (encryption/encrypt-for-stream secret (codecs/to-bytes "test"))
+          header (String. encrypted 0 32)]
+      (is (= "AES/GCM/NoPadding" (clojure.string/trim header))))))


### PR DESCRIPTION
## Summary

- Switch streaming encryption from `AES/CBC/PKCS5Padding` to `AES/GCM/NoPadding` (authenticated encryption)
- The CBC mode without HMAC is vulnerable to padding oracle attacks — GCM provides both confidentiality and integrity
- Backward compatible: existing AES/CBC-encrypted streams are still decryptable via the 32-byte spec header

## Changes

- `src/metabase/util/encryption.clj`:
  - `encrypt-stream` now uses AES/GCM with 12-byte IV and 128-bit auth tag
  - `maybe-decrypt-stream` supports both GCM (new) and CBC (legacy) based on the spec header
  - Import `GCMParameterSpec`

- `test/metabase/util/encryption_test.clj`:
  - `stream-gcm-authentication-test`: verifies tampered ciphertext and wrong-key are rejected
  - `stream-backward-compatibility-test`: verifies legacy CBC data can still be decrypted, and new streams use GCM header

## Test plan

- [ ] Run `metabase.util.encryption-test` — all existing + new tests should pass
- [ ] Verify new encryption uses GCM header (`AES/GCM/NoPadding`)
- [ ] Verify legacy CBC-encrypted data still decrypts correctly
- [ ] Verify tampered GCM ciphertext throws on decryption

🤖 Generated with [Claude Code](https://claude.com/claude-code)