### PR TITLE
Harden workspace isolation DDL against SQL injection in PostgreSQL and ClickHouse

### DIFF
--- a/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
+++ b/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
@@ -373,15 +373,18 @@
 
 (defmethod driver/init-workspace-isolation! :clickhouse
   [_driver database workspace]
-  (let [db-name   (driver.u/workspace-isolation-namespace-name workspace)
-        read-user {:user     (driver.u/workspace-isolation-user-name workspace)
-                   :password (driver.u/random-workspace-password)}]
+  (let [db-name          (driver.u/workspace-isolation-namespace-name workspace)
+        read-user        {:user     (driver.u/workspace-isolation-user-name workspace)
+                          :password (driver.u/random-workspace-password)}
+        escaped-password (sql.u/escape-sql (:password read-user) :backslashes)
+        quoted-db        (sql.u/quote-name :clickhouse :schema db-name)
+        quoted-user      (sql.u/quote-name :clickhouse :field (:user read-user))]
     (jdbc/with-db-transaction [t-conn (sql-jdbc.conn/db->pooled-connection-spec (:id database))]
       (with-open [stmt (.createStatement ^Connection (:connection t-conn))]
-        (doseq [sql [(format "CREATE DATABASE IF NOT EXISTS `%s`" db-name)
-                     (format "CREATE USER IF NOT EXISTS `%s` IDENTIFIED BY '%s'"
-                             (:user read-user) (:password read-user))
-                     (format "GRANT ALL ON `%s`.* TO `%s`" db-name (:user read-user))]]
+        (doseq [sql [(format "CREATE DATABASE IF NOT EXISTS %s" quoted-db)
+                     (format "CREATE USER IF NOT EXISTS %s IDENTIFIED BY '%s'"
+                             quoted-user escaped-password)
+                     (format "GRANT ALL ON %s.* TO %s" quoted-db quoted-user)]]
           (.addBatch ^Statement stmt ^String sql))
         (.executeBatch ^Statement stmt)))
     {:schema           db-name
@@ -407,13 +410,15 @@
 
 (defmethod driver/destroy-workspace-isolation! :clickhouse
   [_driver database workspace]
-  (let [db-name  (driver.u/workspace-isolation-namespace-name workspace)
-        username (driver.u/workspace-isolation-user-name workspace)]
+  (let [db-name      (driver.u/workspace-isolation-namespace-name workspace)
+        username     (driver.u/workspace-isolation-user-name workspace)
+        quoted-db    (sql.u/quote-name :clickhouse :schema db-name)
+        quoted-user  (sql.u/quote-name :clickhouse :field username)]
     (jdbc/with-db-transaction [t-conn (sql-jdbc.conn/db->pooled-connection-spec (:id database))]
       (with-open [stmt (.createStatement ^Connection (:connection t-conn))]
         (doseq [sql [;; DROP DATABASE cascades to all tables within it
-                     (format "DROP DATABASE IF EXISTS `%s`" db-name)
-                     (format "DROP USER IF EXISTS `%s`" username)]]
+                     (format "DROP DATABASE IF EXISTS %s" quoted-db)
+                     (format "DROP USER IF EXISTS %s" quoted-user)]]
           (.addBatch ^Statement stmt ^String sql))
         (.executeBatch ^Statement stmt)))))
 

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -1331,9 +1331,7 @@
         value (nippy/thaw-from-in! data-input)]
     (doto (PGobject.) (.setType type) (.setValue value))))
 
-;;; +----------------------------------------------------------------------------------------------------------------+
-;;; |                                         Workspace Isolation                                                    |
-;;; +----------------------------------------------------------------------------------------------------------------+
+;;; ------------------------------------------ Workspace Isolation ------------------------------------------
 
 (defn- user-exists?
   "Check if a PostgreSQL user exists. Uses pg_user which also works in Redshift."
@@ -1342,26 +1340,29 @@
 
 (defmethod driver/init-workspace-isolation! :postgres
   [_driver database workspace]
-  (let [schema-name (driver.u/workspace-isolation-namespace-name workspace)
-        read-user   {:user     (driver.u/workspace-isolation-user-name workspace)
-                     :password (driver.u/random-workspace-password)}]
+  (let [schema-name      (driver.u/workspace-isolation-namespace-name workspace)
+        read-user        {:user     (driver.u/workspace-isolation-user-name workspace)
+                          :password (driver.u/random-workspace-password)}
+        escaped-password (sql.u/escape-sql (:password read-user) :ansi)
+        quoted-schema    (sql.u/quote-name :postgres :schema schema-name)
+        quoted-user      (sql.u/quote-name :postgres :field (:user read-user))]
     (jdbc/with-db-transaction [t-conn (sql-jdbc.conn/db->pooled-connection-spec (:id database))]
       ;; Create user if not exists, otherwise update password
       ;; PostgreSQL doesn't support CREATE USER IF NOT EXISTS, so we need to check first
       (let [user-sql (if (user-exists? t-conn (:user read-user))
-                       (format "ALTER USER \"%s\" WITH PASSWORD '%s'" (:user read-user) (:password read-user))
-                       (format "CREATE USER \"%s\" WITH PASSWORD '%s'" (:user read-user) (:password read-user)))]
+                       (format "ALTER USER %s WITH PASSWORD '%s'" quoted-user escaped-password)
+                       (format "CREATE USER %s WITH PASSWORD '%s'" quoted-user escaped-password))]
         (with-open [^Statement stmt (.createStatement ^Connection (:connection t-conn))]
           (doseq [sql [;; PostgreSQL supports IF NOT EXISTS for schemas
-                       (format "CREATE SCHEMA IF NOT EXISTS \"%s\"" schema-name)
+                       (format "CREATE SCHEMA IF NOT EXISTS %s" quoted-schema)
                        user-sql
                        ;; grant schema access (CREATE to create tables, USAGE to access them)
                        ;; GRANT is idempotent in PostgreSQL
-                       (format "GRANT ALL PRIVILEGES ON SCHEMA \"%s\" TO \"%s\"" schema-name (:user read-user))
+                       (format "GRANT ALL PRIVILEGES ON SCHEMA %s TO %s" quoted-schema quoted-user)
                        ;; grant all privileges on future tables created in this schema (by admin)
-                       (format "ALTER DEFAULT PRIVILEGES IN SCHEMA \"%s\" GRANT ALL ON TABLES TO \"%s\"" schema-name (:user read-user))
+                       (format "ALTER DEFAULT PRIVILEGES IN SCHEMA %s GRANT ALL ON TABLES TO %s" quoted-schema quoted-user)
                        ;; grant role membership to admin so DROP OWNED BY works during cleanup
-                       (format "GRANT \"%s\" TO CURRENT_USER" (:user read-user))]]
+                       (format "GRANT %s TO CURRENT_USER" quoted-user)]]
             (.addBatch ^Statement stmt ^String sql))
           (.executeBatch ^Statement stmt))))
     {:schema           schema-name
@@ -1369,14 +1370,16 @@
 
 (defmethod driver/destroy-workspace-isolation! :postgres
   [_driver database workspace]
-  (let [schema-name (:schema workspace)
-        username    (-> workspace :database_details :user)]
+  (let [schema-name    (:schema workspace)
+        username       (-> workspace :database_details :user)
+        quoted-schema  (sql.u/quote-name :postgres :schema schema-name)
+        quoted-user    (sql.u/quote-name :postgres :field username)]
     (jdbc/with-db-transaction [t-conn (sql-jdbc.conn/db->pooled-connection-spec (:id database))]
       (with-open [^Statement stmt (.createStatement ^Connection (:connection t-conn))]
-        (doseq [sql (cond-> [(format "DROP SCHEMA IF EXISTS \"%s\" CASCADE" schema-name)]
+        (doseq [sql (cond-> [(format "DROP SCHEMA IF EXISTS %s CASCADE" quoted-schema)]
                       (user-exists? t-conn username)
-                      (into [(format "DROP OWNED BY \"%s\"" username)
-                             (format "DROP USER IF EXISTS \"%s\"" username)]))]
+                      (into [(format "DROP OWNED BY %s" quoted-user)
+                             (format "DROP USER IF EXISTS %s" quoted-user)]))]
           (.addBatch ^Statement stmt ^String sql))
         (.executeBatch ^Statement stmt)))))
 


### PR DESCRIPTION
## Summary

- Replace raw `"%s"` format strings with `sql.u/quote-name` for identifiers and `sql.u/escape-sql` for passwords in workspace isolation DDL
- Affects `init-workspace-isolation!` and `destroy-workspace-isolation!` for both PostgreSQL and ClickHouse drivers
- While current inputs are internally generated, the raw format pattern is fragile and would become exploitable if the password charset or identifier generation ever changes

## Changes

- `src/metabase/driver/postgres.clj`:
  - `init-workspace-isolation!`: `quote-name :postgres` for schema/user, `escape-sql :ansi` for password
  - `destroy-workspace-isolation!`: `quote-name :postgres` for schema/user
  - Matches the pattern already used in `grant-workspace-read-access!`

- `modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj`:
  - `init-workspace-isolation!`: `quote-name :clickhouse` for db/user, `escape-sql :backslashes` for password
  - `destroy-workspace-isolation!`: `quote-name :clickhouse` for db/user

## Notes

- MySQL and SQL Server already had `escape-sql` calls for passwords — this brings PostgreSQL and ClickHouse in line
- Found by SpotBugs `SQL_INJECTION_JDBC` rule
- Minor: normalized the "Workspace Isolation" section header in `postgres.clj` from box style to single-line dashed style, consistent with `clickhouse.clj`

## Test plan

- [ ] Run workspace isolation tests for PostgreSQL driver
- [ ] Run workspace isolation tests for ClickHouse driver
- [ ] Verify DDL statements are correctly quoted (identifiers double-quoted for Postgres, backtick-quoted for ClickHouse)

🤖 Generated with [Claude Code](https://claude.com/claude-code)