### PR TITLE
Use sql.u/quote-name and sql.u/escape-sql for DDL across all drivers

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -1078,7 +1078,7 @@
         dataset-id (DatasetId/of project-id schema)]
     (when-not (.getDataset client dataset-id (u/varargs BigQuery$DatasetOption))
       ;; Dataset doesn't exist, try to create it
-      (let [sql [[(format "CREATE SCHEMA IF NOT EXISTS `%s`;" schema)]]]
+      (let [sql [[(format "CREATE SCHEMA IF NOT EXISTS %s;" (sql.u/quote-name :bigquery-cloud-sdk :schema schema))]]]
         (driver/execute-raw-queries! driver conn-spec sql)))))
 
 (defmethod driver/schema-exists? :bigquery-cloud-sdk

--- a/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
+++ b/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
@@ -350,7 +350,7 @@
 
 (defmethod driver/create-schema-if-needed! :clickhouse
   [driver conn-spec schema]
-  (let [sql [[(format "CREATE DATABASE IF NOT EXISTS `%s`;" schema)]]]
+  (let [sql [[(format "CREATE DATABASE IF NOT EXISTS %s;" (sql.u/quote-name :clickhouse :schema schema))]]]
     (driver/execute-raw-queries! driver conn-spec sql)))
 
 #_{:clj-kondo/ignore [:deprecated-var]}

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -1067,17 +1067,23 @@
       (throw (ex-info "Snowflake database configuration is missing required 'warehouse' setting"
                       {:database-id (:id database) :step :init})))
     ;; Snowflake RBAC: create schema -> create role -> grant privileges to role -> create user -> grant role to user
-    (doseq [sql [(format "CREATE SCHEMA IF NOT EXISTS \"%s\".\"%s\"" db-name schema-name)
-                 (format "CREATE ROLE IF NOT EXISTS \"%s\"" role-name)
-                 (format "GRANT USAGE ON DATABASE \"%s\" TO ROLE \"%s\"" db-name role-name)
-                 (format "GRANT USAGE ON WAREHOUSE \"%s\" TO ROLE \"%s\"" warehouse role-name)
-                 (format "GRANT USAGE ON SCHEMA \"%s\".\"%s\" TO ROLE \"%s\"" db-name schema-name role-name)
-                 (format "GRANT ALL PRIVILEGES ON SCHEMA \"%s\".\"%s\" TO ROLE \"%s\"" db-name schema-name role-name)
-                 (format "GRANT ALL ON FUTURE TABLES IN SCHEMA \"%s\".\"%s\" TO ROLE \"%s\"" db-name schema-name role-name)
-                 (format "CREATE USER IF NOT EXISTS \"%s\" PASSWORD = '%s' MUST_CHANGE_PASSWORD = FALSE DEFAULT_ROLE = \"%s\""
-                         (:user read-user) (:password read-user) role-name)
-                 (format "GRANT ROLE \"%s\" TO USER \"%s\"" role-name (:user read-user))]]
-      (jdbc/execute! conn-spec [sql]))
+    (let [qdb    (sql.u/quote-name :snowflake :field db-name)
+          qsch   (sql.u/quote-name :snowflake :field schema-name)
+          qrole  (sql.u/quote-name :snowflake :field role-name)
+          qwh    (sql.u/quote-name :snowflake :field warehouse)
+          quser  (sql.u/quote-name :snowflake :field (:user read-user))
+          esc-pw (sql.u/escape-sql (:password read-user) :ansi)]
+      (doseq [sql [(format "CREATE SCHEMA IF NOT EXISTS %s.%s" qdb qsch)
+                   (format "CREATE ROLE IF NOT EXISTS %s" qrole)
+                   (format "GRANT USAGE ON DATABASE %s TO ROLE %s" qdb qrole)
+                   (format "GRANT USAGE ON WAREHOUSE %s TO ROLE %s" qwh qrole)
+                   (format "GRANT USAGE ON SCHEMA %s.%s TO ROLE %s" qdb qsch qrole)
+                   (format "GRANT ALL PRIVILEGES ON SCHEMA %s.%s TO ROLE %s" qdb qsch qrole)
+                   (format "GRANT ALL ON FUTURE TABLES IN SCHEMA %s.%s TO ROLE %s" qdb qsch qrole)
+                   (format "CREATE USER IF NOT EXISTS %s PASSWORD = '%s' MUST_CHANGE_PASSWORD = FALSE DEFAULT_ROLE = %s"
+                           quser esc-pw qrole)
+                   (format "GRANT ROLE %s TO USER %s" qrole quser)]]
+        (jdbc/execute! conn-spec [sql])))
     {:schema           schema-name
      :database_details (assoc read-user :role role-name :use-password true)}))
 
@@ -1093,10 +1099,14 @@
       (throw (ex-info "Snowflake database configuration is missing required 'db' (database name) setting"
                       {:database-id (:id database) :step :destroy})))
     ;; Drop in reverse order of creation: schema (CASCADE handles tables) -> user -> role
-    (doseq [sql [(format "DROP SCHEMA IF EXISTS \"%s\".\"%s\" CASCADE" db-name schema-name)
-                 (format "DROP USER IF EXISTS \"%s\"" username)
-                 (format "DROP ROLE IF EXISTS \"%s\"" role-name)]]
-      (jdbc/execute! conn-spec [sql]))))
+    (let [qdb   (sql.u/quote-name :snowflake :field db-name)
+          qsch  (sql.u/quote-name :snowflake :field schema-name)
+          quser (sql.u/quote-name :snowflake :field username)
+          qrole (sql.u/quote-name :snowflake :field role-name)]
+      (doseq [sql [(format "DROP SCHEMA IF EXISTS %s.%s CASCADE" qdb qsch)
+                   (format "DROP USER IF EXISTS %s" quser)
+                   (format "DROP ROLE IF EXISTS %s" qrole)]]
+        (jdbc/execute! conn-spec [sql])))))
 
 (defmethod driver/grant-workspace-read-access! :snowflake
   [_driver database workspace tables]

--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -709,25 +709,30 @@
         ;; H2 embeds credentials in the :db connection string, so we need to build a new one
         original-db (:db (driver.conn/effective-details database))
         new-db      (replace-credentials original-db username password)]
-    (jdbc/with-db-transaction [t-conn (sql-jdbc.conn/db->pooled-connection-spec (:id database))]
-      (with-open [^Statement stmt (.createStatement ^Connection (:connection t-conn))]
-        (doseq [sql [(format "CREATE USER IF NOT EXISTS \"%s\" PASSWORD '%s'" username password)
-                     (format "CREATE SCHEMA IF NOT EXISTS \"%s\" AUTHORIZATION \"%s\"" schema-name username)
-                     (format "GRANT ALL ON SCHEMA \"%s\" TO \"%s\"" schema-name username)]]
-          (.addBatch ^Statement stmt ^String sql))
-        (.executeBatch ^Statement stmt)))
+    (let [quoted-user   (sql.u/quote-name :h2 :field username)
+          quoted-schema (sql.u/quote-name :h2 :schema schema-name)
+          escaped-pw    (sql.u/escape-sql password :ansi)]
+      (jdbc/with-db-transaction [t-conn (sql-jdbc.conn/db->pooled-connection-spec (:id database))]
+        (with-open [^Statement stmt (.createStatement ^Connection (:connection t-conn))]
+          (doseq [sql [(format "CREATE USER IF NOT EXISTS %s PASSWORD '%s'" quoted-user escaped-pw)
+                       (format "CREATE SCHEMA IF NOT EXISTS %s AUTHORIZATION %s" quoted-schema quoted-user)
+                       (format "GRANT ALL ON SCHEMA %s TO %s" quoted-schema quoted-user)]]
+            (.addBatch ^Statement stmt ^String sql))
+          (.executeBatch ^Statement stmt))))
     {:schema           schema-name
      :database_details {:db new-db}}))
 
 (defmethod driver/destroy-workspace-isolation! :h2
   [_driver database workspace]
-  (let [schema-name (driver.u/workspace-isolation-namespace-name workspace)
-        username    (driver.u/workspace-isolation-user-name workspace)]
+  (let [schema-name    (driver.u/workspace-isolation-namespace-name workspace)
+        username       (driver.u/workspace-isolation-user-name workspace)
+        quoted-user    (sql.u/quote-name :h2 :field username)
+        quoted-schema  (sql.u/quote-name :h2 :schema schema-name)]
     (jdbc/with-db-transaction [t-conn (sql-jdbc.conn/db->pooled-connection-spec (:id database))]
       (with-open [^Statement stmt (.createStatement ^Connection (:connection t-conn))]
         (doseq [sql [;; CASCADE drops all objects (tables, etc.) in the schema
-                     (format "DROP SCHEMA IF EXISTS \"%s\" CASCADE" schema-name)
-                     (format "DROP USER IF EXISTS \"%s\"" username)]]
+                     (format "DROP SCHEMA IF EXISTS %s CASCADE" quoted-schema)
+                     (format "DROP USER IF EXISTS %s" quoted-user)]]
           (.addBatch ^Statement stmt ^String sql))
         (.executeBatch ^Statement stmt)))))
 

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -1244,19 +1244,21 @@
   (let [db-name          (driver.u/workspace-isolation-namespace-name workspace)
         user             (driver.u/workspace-isolation-user-name workspace)
         password         (driver.u/random-workspace-password)
-        escaped-password (sql.u/escape-sql password :ansi)]
+        escaped-password (sql.u/escape-sql password :ansi)
+        quoted-db        (sql.u/quote-name :mysql :field db-name)
+        quoted-user      (sql.u/quote-name :mysql :field user)]
     (jdbc/with-db-transaction [t-conn (sql-jdbc.conn/db->pooled-connection-spec (:id database))]
       (let [user-sql (if (mysql-user-exists? t-conn user)
-                       (format "ALTER USER `%s`@'%%' IDENTIFIED BY '%s'"
-                               user escaped-password)
-                       (format "CREATE USER `%s`@'%%' IDENTIFIED BY '%s'"
-                               user escaped-password))]
+                       (format "ALTER USER %s@'%%' IDENTIFIED BY '%s'"
+                               quoted-user escaped-password)
+                       (format "CREATE USER %s@'%%' IDENTIFIED BY '%s'"
+                               quoted-user escaped-password))]
         (with-open [^Statement stmt (.createStatement ^Connection (:connection t-conn))]
           (doseq [sql [;; Create the isolated database
-                       (format "CREATE DATABASE IF NOT EXISTS `%s`" db-name)
+                       (format "CREATE DATABASE IF NOT EXISTS %s" quoted-db)
                        user-sql
                        ;; Grant all privileges on the isolated database
-                       (format "GRANT ALL PRIVILEGES ON `%s`.* TO `%s`@'%%'" db-name user)]]
+                       (format "GRANT ALL PRIVILEGES ON %s.* TO %s@'%%'" quoted-db quoted-user)]]
             (.addBatch ^Statement stmt ^String sql))
           (.executeBatch ^Statement stmt))))
     {:schema           db-name
@@ -1264,13 +1266,15 @@
 
 (defmethod driver/destroy-workspace-isolation! :mysql
   [_driver database workspace]
-  (let [db-name  (:schema workspace)
-        username (-> workspace :database_details :user)]
+  (let [db-name    (:schema workspace)
+        username   (-> workspace :database_details :user)
+        quoted-db  (sql.u/quote-name :mysql :field db-name)
+        quoted-user (sql.u/quote-name :mysql :field username)]
     (jdbc/with-db-transaction [t-conn (sql-jdbc.conn/db->pooled-connection-spec (:id database))]
       (with-open [^Statement stmt (.createStatement ^Connection (:connection t-conn))]
-        (doseq [sql (cond-> [(format "DROP DATABASE IF EXISTS `%s`" db-name)]
+        (doseq [sql (cond-> [(format "DROP DATABASE IF EXISTS %s" quoted-db)]
                       (mysql-user-exists? t-conn username)
-                      (conj (format "DROP USER IF EXISTS `%s`@'%%'" username)))]
+                      (conj (format "DROP USER IF EXISTS %s@'%%'" quoted-user)))]
           (.addBatch ^Statement stmt ^String sql))
         (.executeBatch ^Statement stmt)))))
 


### PR DESCRIPTION
## Summary

- Switch H2, MySQL, Snowflake, ClickHouse, and BigQuery workspace isolation and schema DDL from manual identifier quoting (backticks, double-quotes) to the driver-aware library functions `sql.u/quote-name` and `sql.u/escape-sql`
- Consistent with how PostgreSQL and other drivers already handle this (see #72671)

## Changes

| Driver | Functions | Quoting |
|--------|-----------|---------|
| **H2** | `init/destroy-workspace-isolation!` | `quote-name :h2`, `escape-sql :ansi` for password |
| **MySQL** | `init/destroy-workspace-isolation!` | `quote-name :mysql :field` for user/schema/db |
| **Snowflake** | `init/destroy-workspace-isolation!` | `quote-name :snowflake :field` for all identifiers, `escape-sql :ansi` for password |
| **ClickHouse** | `create-schema-if-needed!` | `quote-name :clickhouse :schema` |
| **BigQuery** | `create-schema-if-needed!` | `quote-name :bigquery-cloud-sdk :schema` |

## Notes

- This is the companion to #72671 which covers PostgreSQL and ClickHouse `init/destroy-workspace-isolation!`
- All files already had `sql.u` in their `:require` — no new dependencies added
- Manual backtick/double-quote patterns replaced with driver-aware quoting that handles special characters correctly

## Test plan

- [ ] Run workspace isolation tests for H2, MySQL, Snowflake drivers
- [ ] Run ClickHouse and BigQuery `create-schema-if-needed!` tests
- [ ] Verify quoted identifiers match each driver's expected quoting style

🤖 Generated with [Claude Code](https://claude.com/claude-code)