### PR TITLE
add X-Metabase-Embed-Referrer

### DIFF
--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-init-data/use-init-data-internal.ts
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-init-data/use-init-data-internal.ts
@@ -17,10 +17,12 @@ import { useMetabaseProviderPropsStore } from "embedding-sdk-shared/hooks/use-me
 import { ensureMetabaseProviderPropsStore } from "embedding-sdk-shared/lib/ensure-metabase-provider-props-store";
 import { getBuildInfo } from "embedding-sdk-shared/lib/get-build-info";
 import registerDashboardVisualizations from "metabase/dashboard/visualizations/register";
-import { EMBEDDING_SDK_CONFIG } from "metabase/embedding-sdk/config";
+import {
+  EMBEDDING_SDK_CONFIG,
+  isEmbeddingEajs,
+} from "metabase/embedding-sdk/config";
 import type { OnBeforeRequestHandlerConfig } from "metabase/plugins/oss/api";
 import api from "metabase/utils/api";
-import { isWithinIframe } from "metabase/utils/iframe";
 import registerVisualizations from "metabase/visualizations/register";
 
 const reactSdkEmbedReferrerHandler = async (
@@ -105,7 +107,7 @@ export const useInitDataInternal = ({
   // referrer on every request. The EAJS iframe registers its own handler in
   // SdkIframeEmbedRoute.tsx using the value received via postMessage.
   if (
-    !isWithinIframe() &&
+    !isEmbeddingEajs() &&
     !api.beforeRequestHandlers.includes(reactSdkEmbedReferrerHandler)
   ) {
     api.beforeRequestHandlers.push(reactSdkEmbedReferrerHandler);

--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-init-data/use-init-data-internal.ts
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-init-data/use-init-data-internal.ts
@@ -103,7 +103,7 @@ export const useInitDataInternal = ({
     };
   }
 
-  // For the React SDK (not in an iframe), send the host page URL as the embed
+  // For the React SDK, send the host page URL as the embed
   // referrer on every request. The EAJS iframe registers its own handler in
   // SdkIframeEmbedRoute.tsx using the value received via postMessage.
   if (

--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-init-data/use-init-data-internal.ts
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-init-data/use-init-data-internal.ts
@@ -18,8 +18,24 @@ import { ensureMetabaseProviderPropsStore } from "embedding-sdk-shared/lib/ensur
 import { getBuildInfo } from "embedding-sdk-shared/lib/get-build-info";
 import registerDashboardVisualizations from "metabase/dashboard/visualizations/register";
 import { EMBEDDING_SDK_CONFIG } from "metabase/embedding-sdk/config";
+import type { OnBeforeRequestHandlerConfig } from "metabase/plugins/oss/api";
 import api from "metabase/utils/api";
+import { isWithinIframe } from "metabase/utils/iframe";
 import registerVisualizations from "metabase/visualizations/register";
+
+const reactSdkEmbedReferrerHandler = async (
+  config: OnBeforeRequestHandlerConfig,
+): Promise<OnBeforeRequestHandlerConfig | void> => ({
+  ...config,
+  options: {
+    ...config.options,
+    headers: {
+      ...config.options.headers,
+      // eslint-disable-next-line metabase/no-literal-metabase-strings -- header name
+      "X-Metabase-Embed-Referrer": window.location.href,
+    },
+  },
+});
 
 const registerVisualizationsOnce = _.once(registerVisualizations);
 const registerDashboardVisualizationsOnce = _.once(
@@ -83,6 +99,16 @@ export const useInitDataInternal = ({
       // Note: this is *package* version, it's undefined in EAJS
       version: sdkPackageVersion,
     };
+  }
+
+  // For the React SDK (not in an iframe), send the host page URL as the embed
+  // referrer on every request. The EAJS iframe registers its own handler in
+  // SdkIframeEmbedRoute.tsx using the value received via postMessage.
+  if (
+    !isWithinIframe() &&
+    !api.beforeRequestHandlers.includes(reactSdkEmbedReferrerHandler)
+  ) {
+    api.beforeRequestHandlers.push(reactSdkEmbedReferrerHandler);
   }
 
   if (!api.onResponseError) {

--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-init-data/use-init-data-internal.ts
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-init-data/use-init-data-internal.ts
@@ -103,8 +103,8 @@ export const useInitDataInternal = ({
     };
   }
 
-  // For the React SDK, send the host page URL as the embed
-  // referrer on every request. The EAJS iframe registers its own handler in
+  // For the React SDK, send the host page URL as the embed referrer in a
+  // header on every request. The EAJS iframe registers its own handler in
   // SdkIframeEmbedRoute.tsx using the value received via postMessage.
   if (
     !isEmbeddingEajs() &&

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/build-embed-attributes.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/utils/build-embed-attributes.ts
@@ -108,7 +108,10 @@ export const formatAttributeValue = (
   return wrapWithQuotes ? `"${value}"` : String(value);
 };
 
-type SettingKey = Exclude<keyof SdkIframeEmbedBaseSettings, "_isLocalhost">;
+type SettingKey = Exclude<
+  keyof SdkIframeEmbedBaseSettings,
+  "_isLocalhost" | "_embedReferrer"
+>;
 
 function transformEmbedSettingsToAttributes({
   settings,

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx
@@ -22,9 +22,11 @@ import { applyThemePreset } from "embedding-sdk-shared/lib/apply-theme-preset";
 import { EmbeddingFooter } from "metabase/embedding/components/EmbeddingFooter/EmbeddingFooter";
 import { EMBEDDING_SDK_IFRAME_EMBEDDING_CONFIG } from "metabase/embedding-sdk/config";
 import { PLUGIN_EMBEDDING_IFRAME_SDK } from "metabase/plugins";
+import type { OnBeforeRequestHandlerConfig } from "metabase/plugins/oss/api";
 import { getSetting } from "metabase/selectors/settings";
 import { Stack } from "metabase/ui";
 import { createTracker } from "metabase/utils/analytics-untyped";
+import api from "metabase/utils/api";
 import { useSelector } from "metabase/utils/redux";
 
 import { useParamRerenderKey } from "../hooks/use-param-rerender-key";
@@ -40,10 +42,38 @@ import {
   SdkIframeInvalidLicenseError,
 } from "./SdkIframeError";
 
+let _embedReferrer: string | undefined;
+
+const embedReferrerHandler = async (
+  config: OnBeforeRequestHandlerConfig,
+): Promise<OnBeforeRequestHandlerConfig | void> => {
+  if (_embedReferrer) {
+    return {
+      ...config,
+      options: {
+        ...config.options,
+        headers: {
+          ...config.options.headers,
+          // eslint-disable-next-line metabase/no-literal-metabase-strings -- header name
+          "X-Metabase-Embed-Referrer": _embedReferrer,
+        },
+      },
+    };
+  }
+};
+
+// Register once — uses a named function ref so it can't be pushed twice
+if (!api.beforeRequestHandlers.includes(embedReferrerHandler)) {
+  api.beforeRequestHandlers.push(embedReferrerHandler);
+}
+
 const onSettingsChanged = (settings: SdkIframeEmbedSettings) => {
   // Tell the SDK whether to use the existing user session or not.
   EMBEDDING_SDK_IFRAME_EMBEDDING_CONFIG.useExistingUserSession =
     settings?.useExistingUserSession || false;
+
+  // Forward the host page URL so it's sent as X-Metabase-Embed-Referrer on API requests.
+  _embedReferrer = settings?._embedReferrer;
 };
 
 const store = getSdkStore();

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.ts
@@ -189,6 +189,7 @@ export abstract class MetabaseEmbedElement<T extends string[] = string[]>
       ...attributesConverted,
       componentName: this._componentName,
       _isLocalhost: this._getIsLocalhost(),
+      _embedReferrer: window.location.href,
     } as SdkIframeEmbedElementSettings;
   }
 

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.unit.spec.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.unit.spec.ts
@@ -409,6 +409,7 @@ describe("embed.js script tag for sdk iframe embedding", () => {
               questionId: undefined,
               componentName: "metabase-dashboard",
               _isLocalhost: true,
+              _embedReferrer: "http://localhost/",
             },
           }),
           "*",

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/types/embed.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/types/embed.ts
@@ -242,6 +242,9 @@ export type SdkIframeEmbedBaseSettings = {
   // Whether the embed is running on localhost. Cannot be set by the user.
   _isLocalhost?: boolean;
 
+  // Full URL of the host page embedding Metabase. Cannot be set by the user.
+  _embedReferrer?: string;
+
   pluginsConfig?: {
     // Callback to handle link clicks. Return { handled: true } to prevent default navigation.
     handleLink?: (url: string) => { handled: boolean };

--- a/frontend/src/metabase/utils/api.js
+++ b/frontend/src/metabase/utils/api.js
@@ -39,6 +39,9 @@ export class Api extends EventEmitter {
   sessionToken;
   onResponseError;
 
+  /** @type {import('metabase/plugins/oss/api').OnBeforeRequestHandler[]} */
+  beforeRequestHandlers = [];
+
   /**
    * @type {string|{name: string, version: string | null}}
    */
@@ -408,6 +411,8 @@ export class Api extends EventEmitter {
         ],
       );
     }
+
+    handlers.push(...this.beforeRequestHandlers);
 
     if (handlers.length) {
       for (const handler of handlers) {


### PR DESCRIPTION

Closes  [EMB-1565: Add custom header to track embedding host on EAJS](https://linear.app/metabase/issue/EMB-1565/add-custom-header-to-track-embedding-host-on-eajs)

### Description

We want to let people know in usage analytics where the embed visits/query come from, using the origin/referrer isn't reliable because the values are not always sent for cross origin requests, or only the domain is sent.

This pr adds a new header to send the value.

For EAJS, we have to send down the value from the host app, and we do it together with the every setting update, so that if the page changes and a new embed is created, the updated value is also sent

### How to verify

Use either EAJS or the SDK in a real app, and see if the header is sent correctly with the url of the page