### PR TITLE
Fix a new broken test that snuck in while Snowflake was quarantined

### DIFF
--- a/test/metabase/driver/sql/parameters/substitute_test.clj
+++ b/test/metabase/driver/sql/parameters/substitute_test.clj
@@ -1,5 +1,6 @@
 (ns ^:mb/driver-tests metabase.driver.sql.parameters.substitute-test
   (:require
+   [clojure.set :as set]
    [clojure.string :as str]
    [clojure.test :refer :all]
    [java-time.api :as t]
@@ -125,7 +126,8 @@
 
 (deftest ^:parallel substitute-field-filter-for-nested-field-test
   (testing "field filter for a nested field (with parent-id) should include parent field name in identifier (#47003)"
-    (mt/test-drivers (sql-parameters-engines)
+    (mt/test-drivers (set/intersection (sql-parameters-engines)
+                                       (mt/normal-drivers-with-feature :nested-field-columns))
       (let [;; Use high IDs that won't collide with existing test metadata
             parent-field-id 999901
             nested-field-id 999902


### PR DESCRIPTION
Fixes DEV-1818.

### Description

Restrict a new test to only run on drivers that support the necessary features. Snowflake was wrongly included in the set, and it doesn't support nested fields like e.g. BigQuery or Athena do.

### How to verify

Test fix.

### Checklist

- ~~Tests have been added/updated to cover changes in this PR~~
- ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
