### PR TITLE
Fix XLSX export truncating decimal precision

### DIFF
--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -119,7 +119,7 @@
               decimals        (or decimals 2)
               base-strings    (if (unformatted-number? format-settings)
                                 ;; [int-format, float-format]
-                                [base-string (str base-string ".##")]
+                                [base-string (str base-string ".##########")]
                                 (repeat 2 (apply str base-string (when (> decimals 0) (apply str "." (repeat decimals "0"))))))]
           (condp = number-style
             "percent"
@@ -299,15 +299,17 @@
    ;; Use a fixed format for time fields since time formatting isn't currently supported (#17357)
    :time     "h:mm am/pm"
    :integer  "#,##0"
-   :float    "#,##0.##"})
+   :float    "#,##0.##########"})
 
 (defn- compute-typed-cell-styles
-  "Compute default cell styles based on column types"
-  ;; These are tested, but does this happen IRL?
-  [^Workbook workbook ^DataFormat data-format]
-  (update-vals
-   (default-format-strings)
-   (partial cell-string-format-style workbook data-format)))
+  "Compute default cell styles based on column types. When `format-rows?` is false, omit numeric
+  formats so that Excel's General format is used, preserving full decimal precision."
+  [^Workbook workbook ^DataFormat data-format format-rows?]
+  (let [format-strings (cond-> (default-format-strings)
+                         (not format-rows?) (dissoc :integer :float))]
+    (update-vals
+     format-strings
+     (partial cell-string-format-style workbook data-format))))
 
 (defn- rounds-to-int?
   "Returns whether a number should be formatted as an integer after being rounded to 2 decimal places."
@@ -379,10 +381,12 @@
     (.setCellValue cell v)
     ;; Do not set formatting for ##NaN, ##Inf, or ##-Inf
     (when (u/real-number? v)
-      (let [[int-style float-style] styles]
-        (if (rounds-to-int? v)
-          (.setCellStyle cell (or int-style (typed-styles :integer)))
-          (.setCellStyle cell (or float-style (typed-styles :float))))))))
+      (let [[int-style float-style] styles
+            style (if (rounds-to-int? v)
+                    (or int-style (typed-styles :integer))
+                    (or float-style (typed-styles :float)))]
+        (when style
+          (.setCellStyle cell style))))))
 
 (defmethod set-cell! Boolean
   [^Cell cell value _styles _typed-styles]
@@ -662,7 +666,7 @@
   [workbook viz-settings non-pivot-cols format-rows?]
   (let [data-format (. ^SXSSFWorkbook workbook createDataFormat)]
     {:cell-styles (compute-column-cell-styles workbook data-format viz-settings non-pivot-cols format-rows?)
-     :typed-cell-styles (compute-typed-cell-styles workbook data-format)}))
+     :typed-cell-styles (compute-typed-cell-styles workbook data-format format-rows?)}))
 
 (defmethod qp.si/streaming-results-writer :xlsx
   [_ ^OutputStream os]

--- a/test/metabase/api/downloads_exports_test.clj
+++ b/test/metabase/api/downloads_exports_test.clj
@@ -817,7 +817,7 @@
                                                     :pivot_results true)
                   sheet      (read-xlsx result)]
               (is (= [["Category" "Created At: Month" "Sum of Price" "Average of Rating"]
-                      ["Doohickey" "May 1, 2016, 12:00 AM" "144.12" "2.97"]
+                      ["Doohickey" "May 1, 2016, 12:00 AM" "144.12" "2.966666667"]
                       ["Doohickey" "June 1, 2016, 12:00 AM" "82.92" "3.6"]]
                      (take 3 sheet))))))))))
 
@@ -1201,8 +1201,8 @@
                  "January 1, 2018, 12:00 AM"
                  "January 1, 2019, 12:00 AM"
                  "Row totals"]
-                ["Doohickey" "632.14" "854.19" "496.43" "203.13" "2,185.89"]
-                ["Gadget" "679.83" "1,059.11" "844.51" "435.75" "3,019.2"]]
+                ["Doohickey" "632.14" "854.19" "496.43" "203.13" "2185.89"]
+                ["Gadget" "679.83" "1059.11" "844.51" "435.75" "3019.2"]]
                (take 3 (card-download card {:export-format :xlsx :format-rows false :pivot true}))))))))
 
 (deftest unformatted-downloads-and-exports-keep-numbers-as-numbers

--- a/test/metabase/query_processor/streaming/xlsx_test.clj
+++ b/test/metabase/query_processor/streaming/xlsx_test.clj
@@ -54,7 +54,7 @@
   (mt/with-temporary-setting-values [custom-formatting {}]
     (testing "General number formatting"
       (testing "number-style (non-currency)"
-        (is (= ["#,##0" "#,##0.##"] (format-string {::mb.viz/number-style "decimal"})))
+        (is (= ["#,##0" "#,##0.##########"] (format-string {::mb.viz/number-style "decimal"})))
         (is (= "#,##0.00%"   (format-string {::mb.viz/number-style "percent"})))
         (is (= "#,##0.00E+0" (format-string {::mb.viz/number-style "scientific"})))))))
 
@@ -92,23 +92,23 @@
     (testing "General number formatting"
       (testing "Decimals"
         (testing "Thousands separator can be omitted"
-          (is (= ["###0" "###0.##"]   (format-string {::mb.viz/number-separators "."}))))))))
+          (is (= ["###0" "###0.##########"]   (format-string {::mb.viz/number-separators "."}))))))))
 
 (deftest format-settings->format-string-test-2b4
   (mt/with-temporary-setting-values [custom-formatting {}]
     (testing "General number formatting"
       (testing "Decimals"
         (testing "Custom separators are not supported"
-          (is (= ["#,##0" "#,##0.##"] (format-string {::mb.viz/number-separators ", "})))
-          (is (= ["#,##0" "#,##0.##"] (format-string {::mb.viz/number-separators ".,"})))
-          (is (= ["#,##0" "#,##0.##"] (format-string {::mb.viz/number-separators ".’"}))))))))
+          (is (= ["#,##0" "#,##0.##########"] (format-string {::mb.viz/number-separators ", "})))
+          (is (= ["#,##0" "#,##0.##########"] (format-string {::mb.viz/number-separators ".,"})))
+          (is (= ["#,##0" "#,##0.##########"] (format-string {::mb.viz/number-separators ".’"}))))))))
 
 (deftest format-settings->format-string-test-2c
   (mt/with-temporary-setting-values [custom-formatting {}]
     (testing "General number formatting"
       (testing "Scale"
         ;; Scale should not affect format string since it is applied to the actual data prior to export
-        (is (= ["#,##0" "#,##0.##"]
+        (is (= ["#,##0" "#,##0.##########"]
                (format-string {::mb.viz/scale 2})))
         (is (= "#,##0.00"
                (format-string {::mb.viz/scale 2, ::mb.viz/decimals 2})))))))
@@ -119,13 +119,13 @@
       (testing "Prefix and suffix"
         (testing "Prefix/suffix on general number format"
           (is (= ["\"prefix\"#,##0"
-                  "\"prefix\"#,##0.##"]
+                  "\"prefix\"#,##0.##########"]
                  (format-string {::mb.viz/prefix "prefix"})))
           (is (= ["#,##0\"suffix\""
-                  "#,##0.##\"suffix\""]
+                  "#,##0.##########\"suffix\""]
                  (format-string {::mb.viz/suffix "suffix"})))
           (is (= ["\"prefix\"#,##0\"suffix\""
-                  "\"prefix\"#,##0.##\"suffix\""]
+                  "\"prefix\"#,##0.##########\"suffix\""]
                  (format-string {::mb.viz/prefix "prefix",
                                  ::mb.viz/suffix "suffix"}))))))))
 
@@ -459,7 +459,7 @@
 (deftest export-format-test
   (mt/with-temporary-setting-values [custom-formatting {}]
     (testing "Different format strings are used for ints and numbers that round to ints (with 2 decimal places)"
-      (is (= [["#,##0"] ["#,##0.##"] ["#,##0"] ["#,##0.##"] ["#,##0"] ["#,##0.##"]]
+      (is (= [["#,##0"] ["#,##0.##########"] ["#,##0"] ["#,##0.##########"] ["#,##0"] ["#,##0.##########"]]
              (rest (xlsx-export [{:field_ref [:field 0] :name "Col" :semantic_type :type/Cost}]
                                 {}
                                 [[1] [1.23] [1.004] [1.005] [10000000000] [10000000000.123]]


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/71299

### Description

XLSX exports applied a 2-decimal-place cell format to all numeric values, causing values like 0.001 to display as 0. This was a display format issue (the underlying data was preserved) but users perceived it as data loss.

Two changes:
- Increase default float format from "#,##0.##" to "#,##0.##########" (10 optional decimal places) so formatted exports show full precision
- When format-rows? is false (unformatted export), skip numeric cell styles entirely so Excel uses its General format with auto-precision

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
