### PR TITLE
Expose query prop on StaticQuestion and InteractiveQuestion

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -345,7 +345,7 @@ const configs = [
   },
   {
     files: [
-      "**/*.unit.spec.*",
+      "**/*.spec.*",
       "frontend/lint/**/*",
       "**/*.stories.*",
       "**/stories-data.*",

--- a/frontend/src/embedding-sdk-bundle/components/public/CreateQuestion/CreateQuestion.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/CreateQuestion/CreateQuestion.tsx
@@ -2,7 +2,7 @@ import { withPublicComponentWrapper } from "embedding-sdk-bundle/components/priv
 
 import {
   InteractiveQuestion,
-  type InteractiveQuestionProps,
+  type InteractiveQuestionBaseProps,
 } from "../InteractiveQuestion";
 
 /**
@@ -11,8 +11,8 @@ import {
  * @category CreateQuestion
  */
 export type CreateQuestionProps = Omit<
-  Partial<InteractiveQuestionProps>,
-  "questionId" | "children"
+  Partial<InteractiveQuestionBaseProps>,
+  "children"
 >;
 
 const CreateQuestionInner = (props: CreateQuestionProps = {}) => (

--- a/frontend/src/embedding-sdk-bundle/components/public/InteractiveQuestion/InteractiveQuestion.schema.ts
+++ b/frontend/src/embedding-sdk-bundle/components/public/InteractiveQuestion/InteractiveQuestion.schema.ts
@@ -2,9 +2,12 @@ import * as Yup from "yup";
 
 import type { FunctionSchema } from "embedding-sdk-bundle/types/schema";
 
-import type { InteractiveQuestionProps } from "./InteractiveQuestion";
+import type { InteractiveQuestionInternalProps } from "./InteractiveQuestion";
 
-const propsSchema: Yup.SchemaOf<InteractiveQuestionProps> = Yup.object({
+// Typed against the internal shape so runtime validation still accepts the
+// `query` prop used by the `useMetabot` hook. The public API (see
+// `InteractiveQuestionProps`) intentionally doesn't expose `query` to users.
+const propsSchema: Yup.SchemaOf<InteractiveQuestionInternalProps> = Yup.object({
   children: Yup.mixed().optional(),
   className: Yup.mixed().optional(),
   componentPlugins: Yup.object({

--- a/frontend/src/embedding-sdk-bundle/components/public/InteractiveQuestion/InteractiveQuestion.schema.ts
+++ b/frontend/src/embedding-sdk-bundle/components/public/InteractiveQuestion/InteractiveQuestion.schema.ts
@@ -31,7 +31,12 @@ const propsSchema: Yup.SchemaOf<InteractiveQuestionProps> = Yup.object({
   })
     .optional()
     .noUnknown(),
-  questionId: Yup.mixed().required(),
+  questionId: Yup.mixed().when(["token", "query"], {
+    is: (token: unknown, query: unknown) =>
+      token !== undefined || query !== undefined,
+    then: (schema) => schema.optional(),
+    otherwise: (schema) => schema.required(),
+  }),
   token: Yup.mixed().optional(),
   query: Yup.mixed().optional(),
   style: Yup.mixed().optional(),

--- a/frontend/src/embedding-sdk-bundle/components/public/InteractiveQuestion/InteractiveQuestion.schema.ts
+++ b/frontend/src/embedding-sdk-bundle/components/public/InteractiveQuestion/InteractiveQuestion.schema.ts
@@ -33,6 +33,7 @@ const propsSchema: Yup.SchemaOf<InteractiveQuestionProps> = Yup.object({
     .noUnknown(),
   questionId: Yup.mixed().required(),
   token: Yup.mixed().optional(),
+  query: Yup.mixed().optional(),
   style: Yup.mixed().optional(),
   targetCollection: Yup.mixed().optional(),
   targetDashboardId: Yup.mixed().optional(),

--- a/frontend/src/embedding-sdk-bundle/components/public/InteractiveQuestion/InteractiveQuestion.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/InteractiveQuestion/InteractiveQuestion.tsx
@@ -149,11 +149,6 @@ const _InteractiveQuestionWrapped = withPublicComponentWrapper(
   { supportsGuestEmbed: false },
 );
 
-/**
- * Public-facing component — TypeScript contract excludes the internal `query`
- * prop. Runtime still accepts it (the schema passes it through), but it is
- * not part of the SDK's public API.
- */
 export const InteractiveQuestion = Object.assign(
   _InteractiveQuestionWrapped as FC<InteractiveQuestionProps>,
   subComponents,
@@ -162,8 +157,7 @@ export const InteractiveQuestion = Object.assign(
 
 /**
  * Same runtime component as {@link InteractiveQuestion}, typed to accept the
- * internal `query` prop. For use by the `useMetabot` hook and internal tests
- * only. Not re-exported from the public SDK package entry point.
+ * internal `query` prop. For use in internal tests only.
  */
 export const _InteractiveQuestionInternal = Object.assign(
   _InteractiveQuestionWrapped as FC<InteractiveQuestionInternalProps>,

--- a/frontend/src/embedding-sdk-bundle/components/public/InteractiveQuestion/InteractiveQuestion.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/InteractiveQuestion/InteractiveQuestion.tsx
@@ -1,3 +1,4 @@
+import type { FC } from "react";
 import { useMemo } from "react";
 
 import { withPublicComponentWrapper } from "embedding-sdk-bundle/components/private/PublicComponentWrapper";
@@ -30,7 +31,10 @@ import {
   SdkQuestion,
   type SdkQuestionProps,
 } from "embedding-sdk-bundle/components/public/SdkQuestion/SdkQuestion";
-import type { SdkQuestionEntityPublicProps } from "embedding-sdk-bundle/types/question";
+import type {
+  SdkQuestionEntityInternalProps,
+  SdkQuestionEntityPublicProps,
+} from "embedding-sdk-bundle/types/question";
 import { deserializeCardFromQuery } from "metabase/utils/card";
 
 import { QuestionAlertsButton } from "../notifications/QuestionAlertsButton";
@@ -53,6 +57,13 @@ export type InteractiveQuestionBaseProps = Omit<
  */
 export type InteractiveQuestionProps = InteractiveQuestionBaseProps &
   SdkQuestionEntityPublicProps;
+
+/**
+ * Internal type that includes the `query` prop used by the `useMetabot` hook.
+ * Not re-exported from the public SDK package entry point.
+ */
+export type InteractiveQuestionInternalProps = InteractiveQuestionBaseProps &
+  SdkQuestionEntityInternalProps;
 
 /**
  * @interface
@@ -93,7 +104,7 @@ export type InteractiveQuestionComponents = {
 function InteractiveQuestionInner({
   query,
   ...rest
-}: InteractiveQuestionProps) {
+}: InteractiveQuestionInternalProps) {
   const deserializedCard = useMemo(
     () => (query ? deserializeCardFromQuery(query) : undefined),
     [query],
@@ -133,10 +144,29 @@ const subComponents: InteractiveQuestionComponents = {
   SqlParametersList: SqlParametersList,
 };
 
+const _InteractiveQuestionWrapped = withPublicComponentWrapper(
+  _InteractiveQuestion,
+  { supportsGuestEmbed: false },
+);
+
+/**
+ * Public-facing component — TypeScript contract excludes the internal `query`
+ * prop. Runtime still accepts it (the schema passes it through), but it is
+ * not part of the SDK's public API.
+ */
 export const InteractiveQuestion = Object.assign(
-  withPublicComponentWrapper(_InteractiveQuestion, {
-    supportsGuestEmbed: false,
-  }),
+  _InteractiveQuestionWrapped as FC<InteractiveQuestionProps>,
+  subComponents,
+  { schema: interactiveQuestionSchema },
+);
+
+/**
+ * Same runtime component as {@link InteractiveQuestion}, typed to accept the
+ * internal `query` prop. For use by the `useMetabot` hook and internal tests
+ * only. Not re-exported from the public SDK package entry point.
+ */
+export const _InteractiveQuestionInternal = Object.assign(
+  _InteractiveQuestionWrapped as FC<InteractiveQuestionInternalProps>,
   subComponents,
   { schema: interactiveQuestionSchema },
 );

--- a/frontend/src/embedding-sdk-bundle/components/public/InteractiveQuestion/InteractiveQuestion.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/InteractiveQuestion/InteractiveQuestion.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from "react";
+
 import { withPublicComponentWrapper } from "embedding-sdk-bundle/components/private/PublicComponentWrapper";
 import { SdkInternalNavigationBackButton } from "embedding-sdk-bundle/components/private/SdkInternalNavigation/SdkInternalNavigationBackButton";
 import {
@@ -28,20 +30,29 @@ import {
   SdkQuestion,
   type SdkQuestionProps,
 } from "embedding-sdk-bundle/components/public/SdkQuestion/SdkQuestion";
+import type { SdkQuestionEntityPublicProps } from "embedding-sdk-bundle/types/question";
+import { deserializeCardFromQuery } from "metabase/utils/card";
 
 import { QuestionAlertsButton } from "../notifications/QuestionAlertsButton";
 
 import { interactiveQuestionSchema } from "./InteractiveQuestion.schema";
+
+export type InteractiveQuestionBaseProps = Omit<
+  SdkQuestionProps,
+  | "token"
+  | "questionId"
+  | "getClickActionMode"
+  | "navigateToNewCard"
+  | "backToDashboard"
+>;
 
 /**
  * @interface
  * @expand
  * @category InteractiveQuestion
  */
-export type InteractiveQuestionProps = Omit<
-  SdkQuestionProps,
-  "token" | "getClickActionMode" | "navigateToNewCard" | "backToDashboard"
->;
+export type InteractiveQuestionProps = InteractiveQuestionBaseProps &
+  SdkQuestionEntityPublicProps;
 
 /**
  * @interface
@@ -79,9 +90,26 @@ export type InteractiveQuestionComponents = {
   SqlParametersList: typeof SqlParametersList;
 };
 
-export const _InteractiveQuestion = (props: InteractiveQuestionProps) => (
-  <SdkQuestion {...props} />
-);
+function InteractiveQuestionInner({
+  query,
+  questionId,
+  ...rest
+}: InteractiveQuestionProps) {
+  const deserializedCard = useMemo(
+    () => (query ? deserializeCardFromQuery(query) : undefined),
+    [query],
+  );
+
+  return (
+    <SdkQuestion
+      {...rest}
+      questionId={questionId ?? null}
+      deserializedCard={deserializedCard}
+    />
+  );
+}
+
+export const _InteractiveQuestion = InteractiveQuestionInner;
 
 const subComponents: InteractiveQuestionComponents = {
   BackButton: BackButton,

--- a/frontend/src/embedding-sdk-bundle/components/public/InteractiveQuestion/InteractiveQuestion.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/InteractiveQuestion/InteractiveQuestion.tsx
@@ -92,7 +92,6 @@ export type InteractiveQuestionComponents = {
 
 function InteractiveQuestionInner({
   query,
-  questionId,
   ...rest
 }: InteractiveQuestionProps) {
   const deserializedCard = useMemo(
@@ -100,13 +99,7 @@ function InteractiveQuestionInner({
     [query],
   );
 
-  return (
-    <SdkQuestion
-      {...rest}
-      questionId={questionId ?? null}
-      deserializedCard={deserializedCard}
-    />
-  );
+  return <SdkQuestion {...rest} deserializedCard={deserializedCard} />;
 }
 
 export const _InteractiveQuestion = InteractiveQuestionInner;

--- a/frontend/src/embedding-sdk-bundle/components/public/InteractiveQuestion/InteractiveQuestion.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/InteractiveQuestion/InteractiveQuestion.tsx
@@ -157,9 +157,9 @@ export const InteractiveQuestion = Object.assign(
 
 /**
  * Same runtime component as {@link InteractiveQuestion}, typed to accept the
- * internal `query` prop. For use in internal tests only.
+ * internal `query` prop. This component is intended for internal use only.
  */
-export const _InteractiveQuestionInternal = Object.assign(
+export const InteractiveQuestionInternal = Object.assign(
   _InteractiveQuestionWrapped as FC<InteractiveQuestionInternalProps>,
   subComponents,
   { schema: interactiveQuestionSchema },

--- a/frontend/src/embedding-sdk-bundle/components/public/InteractiveQuestion/InteractiveQuestion.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/InteractiveQuestion/InteractiveQuestion.unit.spec.tsx
@@ -570,11 +570,11 @@ async function findModal() {
 
 describe('questionId: "new"', () => {
   interface SetupOpts {
-    questionId?: SdkQuestionId;
+    questionId: SdkQuestionId;
     dataPicker?: EmbeddingDataPicker;
   }
 
-  async function setup({ questionId, dataPicker }: SetupOpts = {}) {
+  async function setup({ questionId, dataPicker }: SetupOpts) {
     setupDatabasesEndpoints([TEST_DB]);
     setupCollectionByIdEndpoint({
       collections: [createMockCollection({ id: 1 })],

--- a/frontend/src/embedding-sdk-bundle/components/public/InteractiveQuestion/InteractiveQuestion.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/InteractiveQuestion/InteractiveQuestion.unit.spec.tsx
@@ -692,7 +692,6 @@ describe("InteractiveQuestion — query prop", () => {
     await setup();
 
     expect(screen.getByTestId("query-visualization-root")).toBeVisible();
-    // screen.debug(undefined, Infinity);
     expect(
       within(screen.getByTestId("table-root")).getByText(
         TEST_COLUMN.display_name,

--- a/frontend/src/embedding-sdk-bundle/components/public/InteractiveQuestion/InteractiveQuestion.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/InteractiveQuestion/InteractiveQuestion.unit.spec.tsx
@@ -57,7 +57,10 @@ import {
 } from "metabase-types/api/mocks";
 import { createMockNotification } from "metabase-types/api/mocks/notification";
 
-import { InteractiveQuestion } from "./InteractiveQuestion";
+import {
+  InteractiveQuestion,
+  _InteractiveQuestionInternal,
+} from "./InteractiveQuestion";
 
 const TEST_DB_ID = 1;
 const TEST_DB = createMockDatabase({ id: TEST_DB_ID });
@@ -664,10 +667,13 @@ describe("InteractiveQuestion — query prop", () => {
       collections: [createMockCollection({ id: 1 })],
     });
 
-    renderWithSDKProviders(<InteractiveQuestion query={QUERY_PROP} />, {
-      componentProviderProps: { authConfig: createMockSdkConfig() },
-      storeInitialState: state,
-    });
+    renderWithSDKProviders(
+      <_InteractiveQuestionInternal query={QUERY_PROP} />,
+      {
+        componentProviderProps: { authConfig: createMockSdkConfig() },
+        storeInitialState: state,
+      },
+    );
 
     await waitForLoaderToBeRemoved();
   }

--- a/frontend/src/embedding-sdk-bundle/components/public/InteractiveQuestion/InteractiveQuestion.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/InteractiveQuestion/InteractiveQuestion.unit.spec.tsx
@@ -648,9 +648,11 @@ describe('questionId: "new"', () => {
 describe("InteractiveQuestion — query prop", () => {
   const QUERY_PROP = utf8_to_b64url(
     JSON.stringify({
-      database: TEST_DB_ID,
-      type: "query",
-      query: { "source-table": TEST_TABLE_ID },
+      dataset_query: {
+        database: TEST_DB_ID,
+        type: "query",
+        query: { "source-table": TEST_TABLE_ID },
+      },
     }),
   );
 
@@ -661,7 +663,15 @@ describe("InteractiveQuestion — query prop", () => {
     setupAdhocQueryMetadataEndpoint(
       createMockCardQueryMetadata({ databases: [TEST_DB] }),
     );
-    setupCardDataset({ dataset: TEST_DATASET });
+    // Needs >1 row so Question.maybeResetDisplay doesn't force scalar.
+    setupCardDataset({
+      dataset: createMockDataset({
+        data: createMockDatasetData({
+          cols: [TEST_COLUMN],
+          rows: [["Test Row"], ["Test Row 2"]],
+        }),
+      }),
+    });
     setupCollectionByIdEndpoint({
       collections: [createMockCollection({ id: 1 })],
     });
@@ -685,13 +695,14 @@ describe("InteractiveQuestion — query prop", () => {
     await setup();
 
     expect(screen.getByTestId("query-visualization-root")).toBeVisible();
+    // screen.debug(undefined, Infinity);
     expect(
       within(screen.getByTestId("table-root")).getByText(
         TEST_COLUMN.display_name,
       ),
     ).toBeVisible();
     expect(
-      within(screen.getByRole("gridcell")).getByText("Test Row"),
+      within(screen.getAllByRole("gridcell")[0]).getByText("Test Row"),
     ).toBeVisible();
   });
 });

--- a/frontend/src/embedding-sdk-bundle/components/public/InteractiveQuestion/InteractiveQuestion.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/InteractiveQuestion/InteractiveQuestion.unit.spec.tsx
@@ -6,7 +6,9 @@ import {
 } from "__support__/enterprise";
 import {
   findRequests,
+  setupAdhocQueryMetadataEndpoint,
   setupAlertsEndpoints,
+  setupCardDataset,
   setupCardEndpoints,
   setupCardQueryEndpoints,
   setupCardQueryMetadataEndpoint,
@@ -31,6 +33,7 @@ import {
   waitForLoaderToBeRemoved,
   within,
 } from "__support__/ui";
+import { validateFunctionSchema } from "embedding-sdk-bundle/lib/validate-function-schema";
 import { renderWithSDKProviders } from "embedding-sdk-bundle/test/__support__/ui";
 import { createMockSdkConfig } from "embedding-sdk-bundle/test/mocks/config";
 import { setupSdkState } from "embedding-sdk-bundle/test/server-mocks/sdk-init";
@@ -38,6 +41,7 @@ import type { SdkQuestionId } from "embedding-sdk-bundle/types/question";
 import { createMockModelResult } from "metabase/browse/models/test-utils";
 import { reinitialize } from "metabase/plugins";
 import type { EmbeddingDataPicker } from "metabase/redux/store/embedding-data-picker";
+import { utf8_to_b64url } from "metabase/utils/encoding";
 import type { CardId, CollectionType, TokenFeatures } from "metabase-types/api";
 import {
   createMockCard,
@@ -636,5 +640,51 @@ describe('questionId: "new"', () => {
     ).not.toBeInTheDocument();
     expect(withinPopover.getByText("Raw Data")).toBeVisible();
     expect(withinPopover.getByText("Models")).toBeVisible();
+  });
+});
+
+describe("InteractiveQuestion — query prop", () => {
+  const QUERY_PROP = utf8_to_b64url(
+    JSON.stringify({
+      database: TEST_DB_ID,
+      type: "query",
+      query: { "source-table": TEST_TABLE_ID },
+    }),
+  );
+
+  async function setup() {
+    const { state } = setupSdkState();
+
+    setupNotificationChannelsEndpoints({ email: { configured: false } } as any);
+    setupAdhocQueryMetadataEndpoint(
+      createMockCardQueryMetadata({ databases: [TEST_DB] }),
+    );
+    setupCardDataset({ dataset: TEST_DATASET });
+    setupCollectionByIdEndpoint({
+      collections: [createMockCollection({ id: 1 })],
+    });
+
+    renderWithSDKProviders(<InteractiveQuestion query={QUERY_PROP} />, {
+      componentProviderProps: { authConfig: createMockSdkConfig() },
+      storeInitialState: state,
+    });
+
+    await waitForLoaderToBeRemoved();
+  }
+
+  beforeAll(() => {
+    mockGetBoundingClientRect();
+  });
+
+  it("should render a visualization when given a valid query base64 string", async () => {
+    await setup();
+    expect(screen.getByTestId("query-visualization-root")).toBeVisible();
+  });
+
+  it("should reject schema if none of questionId, token, or query is provided", () => {
+    const { validateParameters } = validateFunctionSchema(
+      InteractiveQuestion.schema,
+    );
+    expect(validateParameters([{}]).success).toBe(false);
   });
 });

--- a/frontend/src/embedding-sdk-bundle/components/public/InteractiveQuestion/InteractiveQuestion.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/InteractiveQuestion/InteractiveQuestion.unit.spec.tsx
@@ -58,7 +58,7 @@ import { createMockNotification } from "metabase-types/api/mocks/notification";
 
 import {
   InteractiveQuestion,
-  _InteractiveQuestionInternal,
+  InteractiveQuestionInternal,
 } from "./InteractiveQuestion";
 
 const TEST_DB_ID = 1;
@@ -676,13 +676,10 @@ describe("InteractiveQuestion — query prop", () => {
       collections: [createMockCollection({ id: 1 })],
     });
 
-    renderWithSDKProviders(
-      <_InteractiveQuestionInternal query={QUERY_PROP} />,
-      {
-        componentProviderProps: { authConfig: createMockSdkConfig() },
-        storeInitialState: state,
-      },
-    );
+    renderWithSDKProviders(<InteractiveQuestionInternal query={QUERY_PROP} />, {
+      componentProviderProps: { authConfig: createMockSdkConfig() },
+      storeInitialState: state,
+    });
 
     await waitForLoaderToBeRemoved();
   }

--- a/frontend/src/embedding-sdk-bundle/components/public/InteractiveQuestion/InteractiveQuestion.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/InteractiveQuestion/InteractiveQuestion.unit.spec.tsx
@@ -33,7 +33,6 @@ import {
   waitForLoaderToBeRemoved,
   within,
 } from "__support__/ui";
-import { validateFunctionSchema } from "embedding-sdk-bundle/lib/validate-function-schema";
 import { renderWithSDKProviders } from "embedding-sdk-bundle/test/__support__/ui";
 import { createMockSdkConfig } from "embedding-sdk-bundle/test/mocks/config";
 import { setupSdkState } from "embedding-sdk-bundle/test/server-mocks/sdk-init";
@@ -117,7 +116,7 @@ const setup = async ({
 }: SetupOpts = {}) => {
   setupNotificationChannelsEndpoints({
     email: { configured: isEmailSetup },
-  } as any);
+  });
 
   const user = createMockUser({
     id: USER_ID,
@@ -658,7 +657,7 @@ describe("InteractiveQuestion — query prop", () => {
   async function setup() {
     const { state } = setupSdkState();
 
-    setupNotificationChannelsEndpoints({ email: { configured: false } } as any);
+    setupNotificationChannelsEndpoints({ email: { configured: false } });
     setupAdhocQueryMetadataEndpoint(
       createMockCardQueryMetadata({ databases: [TEST_DB] }),
     );
@@ -684,13 +683,15 @@ describe("InteractiveQuestion — query prop", () => {
 
   it("should render a visualization when given a valid query base64 string", async () => {
     await setup();
-    expect(screen.getByTestId("query-visualization-root")).toBeVisible();
-  });
 
-  it("should reject schema if none of questionId, token, or query is provided", () => {
-    const { validateParameters } = validateFunctionSchema(
-      InteractiveQuestion.schema,
-    );
-    expect(validateParameters([{}]).success).toBe(false);
+    expect(screen.getByTestId("query-visualization-root")).toBeVisible();
+    expect(
+      within(screen.getByTestId("table-root")).getByText(
+        TEST_COLUMN.display_name,
+      ),
+    ).toBeVisible();
+    expect(
+      within(screen.getByRole("gridcell")).getByText("Test Row"),
+    ).toBeVisible();
   });
 });

--- a/frontend/src/embedding-sdk-bundle/components/public/InteractiveQuestion/InteractiveQuestion.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/InteractiveQuestion/InteractiveQuestion.unit.spec.tsx
@@ -5,10 +5,7 @@ import {
   setupEnterprisePlugins,
 } from "__support__/enterprise";
 import {
-  findRequests,
-  setupAdhocQueryMetadataEndpoint,
   setupAlertsEndpoints,
-  setupCardDataset,
   setupCardEndpoints,
   setupCardQueryEndpoints,
   setupCardQueryMetadataEndpoint,
@@ -33,71 +30,37 @@ import {
   waitForLoaderToBeRemoved,
   within,
 } from "__support__/ui";
+import { addAlertModalTests } from "embedding-sdk-bundle/components/public/question/shared-tests/alert-modal.spec";
+import { addAlertsButtonTests } from "embedding-sdk-bundle/components/public/question/shared-tests/alerts-button.spec";
+import type { SetupOpts } from "embedding-sdk-bundle/components/public/question/shared-tests/constants.spec";
+import {
+  TEST_COLUMN,
+  TEST_DATASET,
+  TEST_DB,
+  TEST_TABLE,
+} from "embedding-sdk-bundle/components/public/question/shared-tests/constants.spec";
+import { addQueryPropTests } from "embedding-sdk-bundle/components/public/question/shared-tests/query-prop.spec";
 import { renderWithSDKProviders } from "embedding-sdk-bundle/test/__support__/ui";
 import { createMockSdkConfig } from "embedding-sdk-bundle/test/mocks/config";
 import { setupSdkState } from "embedding-sdk-bundle/test/server-mocks/sdk-init";
 import type { SdkQuestionId } from "embedding-sdk-bundle/types/question";
 import { createMockModelResult } from "metabase/browse/models/test-utils";
-import { reinitialize } from "metabase/plugins";
 import type { EmbeddingDataPicker } from "metabase/redux/store/embedding-data-picker";
-import { utf8_to_b64url } from "metabase/utils/encoding";
-import type { CardId, CollectionType, TokenFeatures } from "metabase-types/api";
 import {
   createMockCard,
   createMockCardQueryMetadata,
   createMockCollection,
-  createMockColumn,
-  createMockDatabase,
-  createMockDataset,
-  createMockDatasetData,
-  createMockTable,
   createMockTokenFeatures,
   createMockUser,
 } from "metabase-types/api/mocks";
-import { createMockNotification } from "metabase-types/api/mocks/notification";
 
 import {
   InteractiveQuestion,
   InteractiveQuestionInternal,
 } from "./InteractiveQuestion";
 
-const TEST_DB_ID = 1;
-const TEST_DB = createMockDatabase({ id: TEST_DB_ID });
-
-const TEST_TABLE_ID = 1;
-const TEST_TABLE = createMockTable({ id: TEST_TABLE_ID, db_id: TEST_DB_ID });
-
-const TEST_COLUMN = createMockColumn({
-  display_name: "Test Column",
-  name: "Test Column",
-});
-
-const TEST_DATASET = createMockDataset({
-  data: createMockDatasetData({
-    cols: [TEST_COLUMN],
-    rows: [["Test Row"]],
-  }),
-});
-
-const TEST_CARD_ID: CardId = 1 as const;
-
+const TEST_CARD_ID = 1;
 const USER_ID = 999;
-
-interface SetupOpts {
-  title?: string | boolean;
-  withChartTypeSelector?: boolean;
-  withDownloads?: boolean;
-  withAlerts?: boolean;
-  isEmailSetup?: boolean;
-  canManageSubscriptions?: boolean;
-  isSuperuser?: boolean;
-  isModel?: boolean;
-  notifications?: ReturnType<typeof createMockNotification>[];
-  collectionType?: CollectionType;
-  tokenFeatures?: Partial<TokenFeatures>;
-  enterprisePlugins?: Parameters<typeof setupEnterpriseOnlyPlugin>[0][];
-  children?: React.ReactNode;
-}
 
 const setup = async ({
   title,
@@ -214,7 +177,14 @@ const setup = async ({
   await waitForLoaderToBeRemoved();
 };
 
+addQueryPropTests({ Component: InteractiveQuestionInternal });
+
 describe("InteractiveQuestion", () => {
+  addAlertsButtonTests(setup, {
+    customComponent: InteractiveQuestion.AlertsButton,
+  });
+  addAlertModalTests(setup, { userId: USER_ID });
+
   beforeAll(() => {
     mockGetBoundingClientRect();
   });
@@ -273,180 +243,6 @@ describe("InteractiveQuestion", () => {
     });
   });
 
-  describe("alerts button with different Metabase version configurations", () => {
-    beforeEach(() => {
-      reinitialize();
-    });
-
-    // eslint-disable-next-line jest/no-disabled-tests -- Fix this in EMB-1184, when we can test SDK with API keys
-    describe.skip("OSS (Open Source Software)", () => {
-      it("should not show the alert button in OSS regardless of settings", async () => {
-        // Don't setup enterprise plugin for OSS
-        await setup({
-          withAlerts: true,
-          isEmailSetup: true,
-          canManageSubscriptions: true,
-          isModel: false,
-          tokenFeatures: {}, // No embedding_sdk feature
-        });
-
-        expect(
-          within(screen.getByRole("gridcell")).getByText("Test Row"),
-        ).toBeVisible();
-        expect(
-          screen.queryByRole("button", { name: "Alerts" }),
-        ).not.toBeInTheDocument();
-      });
-    });
-
-    // eslint-disable-next-line jest/no-disabled-tests -- Fix this in EMB-1184, when we can test SDK with API keys
-    describe.skip("EE (Enterprise Edition) without embedding_sdk token feature", () => {
-      it("should not show the alert button when plugin is enabled but token feature is missing", async () => {
-        await setup({
-          withAlerts: true,
-          isEmailSetup: true,
-          canManageSubscriptions: true,
-          isModel: false,
-          enterprisePlugins: ["sdk_notifications"],
-          tokenFeatures: {}, // No embedding_sdk feature
-        });
-
-        expect(
-          within(screen.getByRole("gridcell")).getByText("Test Row"),
-        ).toBeVisible();
-        expect(
-          screen.queryByRole("button", { name: "Alerts" }),
-        ).not.toBeInTheDocument();
-      });
-    });
-
-    describe("EE with embedding_sdk token feature", () => {
-      it("should show the alert button when plugin and token feature are both enabled", async () => {
-        await setup({
-          withAlerts: true,
-          isEmailSetup: true,
-          canManageSubscriptions: true,
-          isModel: false,
-          enterprisePlugins: ["sdk_notifications"],
-        });
-
-        expect(
-          within(screen.getByRole("gridcell")).getByText("Test Row"),
-        ).toBeVisible();
-        expect(screen.getByRole("button", { name: "Alerts" })).toBeVisible();
-      });
-
-      it("should show the alert button for custom layouts when withAlerts is true", async () => {
-        await setup({
-          withAlerts: true,
-          isEmailSetup: true,
-          canManageSubscriptions: true,
-          isModel: false,
-          enterprisePlugins: ["sdk_notifications"],
-          children: (
-            <div>
-              <span>Custom Layout</span>
-              <InteractiveQuestion.AlertsButton />
-            </div>
-          ),
-        });
-
-        expect(screen.getByText("Custom Layout")).toBeVisible();
-        expect(screen.getByRole("button", { name: "Alerts" })).toBeVisible();
-      });
-
-      it("should not show the alert button for custom layouts when withAlerts is false", async () => {
-        await setup({
-          withAlerts: false,
-          isEmailSetup: true,
-          canManageSubscriptions: true,
-          isModel: false,
-          enterprisePlugins: ["sdk_notifications"],
-          children: (
-            <div>
-              <span>Custom Layout</span>
-              <InteractiveQuestion.AlertsButton />
-            </div>
-          ),
-        });
-
-        expect(screen.getByText("Custom Layout")).toBeVisible();
-        expect(
-          screen.queryByRole("button", { name: "Alerts" }),
-        ).not.toBeInTheDocument();
-      });
-
-      it("should not show the alert button when withAlerts is false", async () => {
-        await setup({
-          withAlerts: false,
-          isEmailSetup: true,
-          canManageSubscriptions: true,
-          enterprisePlugins: ["sdk_notifications"],
-        });
-
-        expect(
-          screen.queryByRole("button", { name: "Alerts" }),
-        ).not.toBeInTheDocument();
-      });
-
-      it("should not show the alert button when email is not configured", async () => {
-        await setup({
-          withAlerts: true,
-          isEmailSetup: false,
-          canManageSubscriptions: true,
-          enterprisePlugins: ["sdk_notifications"],
-        });
-
-        expect(
-          screen.queryByRole("button", { name: "Alerts" }),
-        ).not.toBeInTheDocument();
-      });
-
-      it("should not show the alert button when user cannot manage subscriptions and is not admin", async () => {
-        await setup({
-          withAlerts: true,
-          isEmailSetup: true,
-          isSuperuser: false,
-          canManageSubscriptions: false,
-          enterprisePlugins: ["sdk_notifications", "application_permissions"],
-          tokenFeatures: { embedding_sdk: true, advanced_permissions: true },
-        });
-
-        expect(
-          screen.queryByRole("button", { name: "Alerts" }),
-        ).not.toBeInTheDocument();
-      });
-
-      it("should not show the alert button for models", async () => {
-        await setup({
-          withAlerts: true,
-          isEmailSetup: true,
-          canManageSubscriptions: true,
-          isModel: true,
-          enterprisePlugins: ["sdk_notifications"],
-        });
-
-        expect(
-          screen.queryByRole("button", { name: "Alerts" }),
-        ).not.toBeInTheDocument();
-      });
-
-      it("should not show the alert button for analytics collection", async () => {
-        await setup({
-          withAlerts: true,
-          isEmailSetup: true,
-          canManageSubscriptions: true,
-          collectionType: "instance-analytics",
-          enterprisePlugins: ["sdk_notifications"],
-        });
-
-        expect(
-          screen.queryByRole("button", { name: "Alerts" }),
-        ).not.toBeInTheDocument();
-      });
-    });
-  });
-
   it("should not show alerts and downloads buttons when editing the question", async () => {
     await setup({
       withDownloads: true,
@@ -479,100 +275,7 @@ describe("InteractiveQuestion", () => {
       screen.queryByRole("button", { name: "Download results" }),
     ).not.toBeInTheDocument();
   });
-
-  describe("alert modal", () => {
-    it("should show alert list modal when there are existing alerts", async () => {
-      await setup({
-        withAlerts: true,
-        isEmailSetup: true,
-        canManageSubscriptions: true,
-        isModel: false,
-        enterprisePlugins: ["sdk_notifications"],
-        notifications: [createMockNotification()],
-      });
-
-      expect(
-        within(screen.getByRole("gridcell")).getByText("Test Row"),
-      ).toBeVisible();
-
-      await userEvent.click(screen.getByRole("button", { name: "Alerts" }));
-
-      // Verify the alert list modal appears, not the create modal
-      const withinModal = within(await findModal());
-
-      // Show the alert list modal title
-      expect(
-        await withinModal.findByRole("heading", { name: "Edit alerts" }),
-      ).toBeVisible();
-
-      // Should show the button to create a new alert in the list modal
-      expect(withinModal.getByText("New alert")).toBeVisible();
-
-      // Should NOT show the create alert form fields
-      expect(
-        withinModal.queryByText("What do you want to be alerted about?"),
-      ).not.toBeInTheDocument();
-    });
-
-    it("should not show email selector on the SDK and use current logged in user as the recipient", async () => {
-      await setup({
-        withAlerts: true,
-        isEmailSetup: true,
-        canManageSubscriptions: true,
-        isModel: false,
-        enterprisePlugins: ["sdk_notifications"],
-      });
-
-      expect(
-        within(screen.getByRole("gridcell")).getByText("Test Row"),
-      ).toBeVisible();
-      await userEvent.click(screen.getByRole("button", { name: "Alerts" }));
-
-      const withinModal = within(await findModal());
-      expect(
-        withinModal.getByRole("heading", { name: "New alert" }),
-      ).toBeVisible();
-      expect(
-        withinModal.getByText("What do you want to be alerted about?"),
-      ).toBeVisible();
-      expect(
-        withinModal.getByText("When do you want to check this?"),
-      ).toBeVisible();
-      // Email selector is within this section, checking only the header is fine
-      expect(
-        withinModal.queryByText("Where do you want to send the results?"),
-      ).not.toBeInTheDocument();
-      expect(withinModal.getByText("More options")).toBeVisible();
-      await userEvent.click(withinModal.getByRole("button", { name: "Done" }));
-
-      const createNotificationRequest = (await findRequests("POST")).find(
-        (postRequest) =>
-          postRequest.url === "http://localhost/api/notification",
-      );
-      // Checks that we're using the current logged in user as the sole recipient
-      expect(createNotificationRequest?.body).toMatchObject({
-        handlers: [
-          {
-            channel_type: "channel/email",
-            recipients: [
-              {
-                details: null,
-                type: "notification-recipient/user",
-                user_id: USER_ID,
-              },
-            ],
-          },
-        ],
-      });
-      // So that when we assert this value, we know we won't accidentally match the default mock ID
-      expect(USER_ID).not.toBe(1);
-    });
-  });
 });
-
-async function findModal() {
-  return await screen.findByRole("dialog");
-}
 
 describe('questionId: "new"', () => {
   interface SetupOpts {
@@ -642,63 +345,5 @@ describe('questionId: "new"', () => {
     ).not.toBeInTheDocument();
     expect(withinPopover.getByText("Raw Data")).toBeVisible();
     expect(withinPopover.getByText("Models")).toBeVisible();
-  });
-});
-
-describe("InteractiveQuestion — query prop", () => {
-  const QUERY_PROP = utf8_to_b64url(
-    JSON.stringify({
-      dataset_query: {
-        database: TEST_DB_ID,
-        type: "query",
-        query: { "source-table": TEST_TABLE_ID },
-      },
-    }),
-  );
-
-  async function setup() {
-    const { state } = setupSdkState();
-
-    setupNotificationChannelsEndpoints({ email: { configured: false } });
-    setupAdhocQueryMetadataEndpoint(
-      createMockCardQueryMetadata({ databases: [TEST_DB] }),
-    );
-    // Needs >1 row so Question.maybeResetDisplay doesn't force scalar.
-    setupCardDataset({
-      dataset: createMockDataset({
-        data: createMockDatasetData({
-          cols: [TEST_COLUMN],
-          rows: [["Test Row"], ["Test Row 2"]],
-        }),
-      }),
-    });
-    setupCollectionByIdEndpoint({
-      collections: [createMockCollection({ id: 1 })],
-    });
-
-    renderWithSDKProviders(<InteractiveQuestionInternal query={QUERY_PROP} />, {
-      componentProviderProps: { authConfig: createMockSdkConfig() },
-      storeInitialState: state,
-    });
-
-    await waitForLoaderToBeRemoved();
-  }
-
-  beforeAll(() => {
-    mockGetBoundingClientRect();
-  });
-
-  it("should render a visualization when given a valid query base64 string", async () => {
-    await setup();
-
-    expect(screen.getByTestId("query-visualization-root")).toBeVisible();
-    expect(
-      within(screen.getByTestId("table-root")).getByText(
-        TEST_COLUMN.display_name,
-      ),
-    ).toBeVisible();
-    expect(
-      within(screen.getAllByRole("gridcell")[0]).getByText("Test Row"),
-    ).toBeVisible();
   });
 });

--- a/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.schema.ts
+++ b/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.schema.ts
@@ -2,9 +2,12 @@ import * as Yup from "yup";
 
 import type { FunctionSchema } from "embedding-sdk-bundle/types/schema";
 
-import type { StaticQuestionProps } from "./StaticQuestion";
+import type { StaticQuestionInternalProps } from "./StaticQuestion";
 
-const propsSchema: Yup.SchemaOf<StaticQuestionProps> = Yup.object({
+// Typed against the internal shape so runtime validation still accepts the
+// `query` prop used by the `useMetabot` hook. The public API (see
+// `StaticQuestionProps`) intentionally doesn't expose `query` to users.
+const propsSchema: Yup.SchemaOf<StaticQuestionInternalProps> = Yup.object({
   children: Yup.mixed().optional(),
   className: Yup.mixed().optional(),
   height: Yup.mixed().optional(),

--- a/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.schema.ts
+++ b/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.schema.ts
@@ -10,8 +10,9 @@ const propsSchema: Yup.SchemaOf<StaticQuestionProps> = Yup.object({
   height: Yup.mixed().optional(),
   initialSqlParameters: Yup.mixed().optional(),
   hiddenParameters: Yup.mixed().optional(),
-  questionId: Yup.mixed().when("token", {
-    is: (token: unknown) => token !== undefined,
+  questionId: Yup.mixed().when(["token", "query"], {
+    is: (token: unknown, query: unknown) =>
+      token !== undefined || query !== undefined,
     then: (schema) => schema.optional(),
     otherwise: (schema) => schema.required(),
   }),

--- a/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.schema.ts
+++ b/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.schema.ts
@@ -16,6 +16,7 @@ const propsSchema: Yup.SchemaOf<StaticQuestionProps> = Yup.object({
     otherwise: (schema) => schema.required(),
   }),
   token: Yup.mixed().optional(),
+  query: Yup.mixed().optional(),
   style: Yup.mixed().optional(),
   title: Yup.mixed().optional(),
   width: Yup.mixed().optional(),

--- a/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.tsx
@@ -1,4 +1,4 @@
-import { type PropsWithChildren, useMemo } from "react";
+import { type FC, type PropsWithChildren, useMemo } from "react";
 
 import { FlexibleSizeComponent } from "embedding-sdk-bundle/components/private/FlexibleSizeComponent";
 import { withPublicComponentWrapper } from "embedding-sdk-bundle/components/private/PublicComponentWrapper";
@@ -32,7 +32,10 @@ import { QuestionAlertsButton } from "embedding-sdk-bundle/components/public/not
 import { useNormalizeGuestEmbedQuestionOrDashboardComponentProps } from "embedding-sdk-bundle/hooks/private/use-normalize-guest-embed-question-or-dashboard-component-props";
 import { useSdkSelector } from "embedding-sdk-bundle/store";
 import { getIsGuestEmbed } from "embedding-sdk-bundle/store/selectors";
-import type { SdkQuestionEntityPublicProps } from "embedding-sdk-bundle/types/question";
+import type {
+  SdkQuestionEntityInternalProps,
+  SdkQuestionEntityPublicProps,
+} from "embedding-sdk-bundle/types/question";
 import { Box, Group, Stack } from "metabase/ui";
 import { deserializeCardFromQuery } from "metabase/utils/card";
 import { getEmbeddingMode } from "metabase/visualizations/click-actions/lib/modes";
@@ -42,12 +45,7 @@ import type Question from "metabase-lib/v1/Question";
 
 import { staticQuestionSchema } from "./StaticQuestion.schema";
 
-/**
- * @interface
- * @expand
- * @category StaticQuestion
- */
-export type StaticQuestionProps = PropsWithChildren<
+type StaticQuestionBaseProps = PropsWithChildren<
   Pick<
     SdkQuestionProps,
     | "withChartTypeSelector"
@@ -61,8 +59,22 @@ export type StaticQuestionProps = PropsWithChildren<
     | "withAlerts"
     | "title"
   >
-> &
+>;
+
+/**
+ * @interface
+ * @expand
+ * @category StaticQuestion
+ */
+export type StaticQuestionProps = StaticQuestionBaseProps &
   SdkQuestionEntityPublicProps;
+
+/**
+ * Internal type that includes the `query` prop used by the `useMetabot` hook.
+ * Not re-exported from the public SDK package entry point.
+ */
+export type StaticQuestionInternalProps = StaticQuestionBaseProps &
+  SdkQuestionEntityInternalProps;
 
 /**
  * @interface
@@ -88,16 +100,22 @@ export type StaticQuestionComponents = {
 };
 
 const StaticQuestionInner = (
-  props: StaticQuestionProps,
+  props: StaticQuestionInternalProps,
 ): JSX.Element | null => {
+  // `query` is an internal prop consumed by the `useMetabot` hook. The
+  // normalization hook is typed against the public props; cast around it so its
+  // public contract stays narrow.
+  const query = (props as { query?: string }).query;
+
   // Normalize props for Guest Embed usage (e.g. enforce withDownloads in OSS).
   const normalizedProps =
-    useNormalizeGuestEmbedQuestionOrDashboardComponentProps(props);
+    useNormalizeGuestEmbedQuestionOrDashboardComponentProps(
+      props as StaticQuestionProps,
+    );
 
   const {
     questionId,
     token,
-    query,
     withChartTypeSelector,
     height,
     width,
@@ -218,10 +236,28 @@ const subComponents: StaticQuestionComponents = {
   SqlParametersList: SqlParametersList,
 };
 
+const _StaticQuestionWrapped = withPublicComponentWrapper(StaticQuestionInner, {
+  supportsGuestEmbed: true,
+});
+
+/**
+ * Public-facing component — TypeScript contract excludes the internal `query`
+ * prop. Runtime still accepts it (the schema passes it through), but it is
+ * not part of the SDK's public API.
+ */
 export const StaticQuestion = Object.assign(
-  withPublicComponentWrapper(StaticQuestionInner, {
-    supportsGuestEmbed: true,
-  }),
+  _StaticQuestionWrapped as FC<StaticQuestionProps>,
+  subComponents,
+  { schema: staticQuestionSchema },
+);
+
+/**
+ * Same runtime component as {@link StaticQuestion}, typed to accept the
+ * internal `query` prop. For use by the `useMetabot` hook and internal tests
+ * only. Not re-exported from the public SDK package entry point.
+ */
+export const _StaticQuestionInternal = Object.assign(
+  _StaticQuestionWrapped as FC<StaticQuestionInternalProps>,
   subComponents,
   { schema: staticQuestionSchema },
 );

--- a/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.tsx
@@ -102,10 +102,7 @@ export type StaticQuestionComponents = {
 const StaticQuestionInner = (
   props: StaticQuestionInternalProps,
 ): JSX.Element | null => {
-  // `query` is an internal prop consumed by the `useMetabot` hook. The
-  // normalization hook is typed against the public props; cast around it so its
-  // public contract stays narrow.
-  const query = (props as { query?: string }).query;
+  const query = props.query;
 
   // Normalize props for Guest Embed usage (e.g. enforce withDownloads in OSS).
   const normalizedProps =
@@ -240,11 +237,6 @@ const _StaticQuestionWrapped = withPublicComponentWrapper(StaticQuestionInner, {
   supportsGuestEmbed: true,
 });
 
-/**
- * Public-facing component — TypeScript contract excludes the internal `query`
- * prop. Runtime still accepts it (the schema passes it through), but it is
- * not part of the SDK's public API.
- */
 export const StaticQuestion = Object.assign(
   _StaticQuestionWrapped as FC<StaticQuestionProps>,
   subComponents,
@@ -253,8 +245,7 @@ export const StaticQuestion = Object.assign(
 
 /**
  * Same runtime component as {@link StaticQuestion}, typed to accept the
- * internal `query` prop. For use by the `useMetabot` hook and internal tests
- * only. Not re-exported from the public SDK package entry point.
+ * internal `query` prop. For use in internal tests only.
  */
 export const _StaticQuestionInternal = Object.assign(
   _StaticQuestionWrapped as FC<StaticQuestionInternalProps>,

--- a/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.tsx
@@ -1,4 +1,4 @@
-import type { PropsWithChildren } from "react";
+import { type PropsWithChildren, useMemo } from "react";
 
 import { FlexibleSizeComponent } from "embedding-sdk-bundle/components/private/FlexibleSizeComponent";
 import { withPublicComponentWrapper } from "embedding-sdk-bundle/components/private/PublicComponentWrapper";
@@ -34,6 +34,7 @@ import { useSdkSelector } from "embedding-sdk-bundle/store";
 import { getIsGuestEmbed } from "embedding-sdk-bundle/store/selectors";
 import type { SdkQuestionEntityPublicProps } from "embedding-sdk-bundle/types/question";
 import { Box, Group, Stack } from "metabase/ui";
+import { deserializeCardFromQuery } from "metabase/utils/card";
 import { getEmbeddingMode } from "metabase/visualizations/click-actions/lib/modes";
 import { EmbeddingSdkStaticMode } from "metabase/visualizations/click-actions/modes/EmbeddingSdkStaticMode";
 import type { ClickActionModeGetter } from "metabase/visualizations/types";
@@ -96,6 +97,7 @@ const StaticQuestionInner = (
   const {
     questionId,
     token,
+    query,
     withChartTypeSelector,
     height,
     width,
@@ -108,6 +110,11 @@ const StaticQuestionInner = (
     title = false, // Hidden by default for backwards-compatibility.
     children,
   } = normalizedProps;
+
+  const deserializedCard = useMemo(
+    () => (query ? deserializeCardFromQuery(query) : undefined),
+    [query],
+  );
 
   const isGuestEmbed = useSdkSelector(getIsGuestEmbed);
 
@@ -129,6 +136,7 @@ const StaticQuestionInner = (
     <SdkQuestion
       questionId={questionId ?? null}
       token={token}
+      deserializedCard={deserializedCard}
       getClickActionMode={getClickActionMode}
       navigateToNewCard={null}
       initialSqlParameters={initialSqlParameters}

--- a/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.tsx
@@ -134,7 +134,7 @@ const StaticQuestionInner = (
 
   return (
     <SdkQuestion
-      questionId={questionId ?? null}
+      questionId={questionId}
       token={token}
       deserializedCard={deserializedCard}
       getClickActionMode={getClickActionMode}

--- a/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.tsx
@@ -245,9 +245,9 @@ export const StaticQuestion = Object.assign(
 
 /**
  * Same runtime component as {@link StaticQuestion}, typed to accept the
- * internal `query` prop. For use in internal tests only.
+ * internal `query` prop. This component is intended for internal use only.
  */
-export const _StaticQuestionInternal = Object.assign(
+export const StaticQuestionInternal = Object.assign(
   _StaticQuestionWrapped as FC<StaticQuestionInternalProps>,
   subComponents,
   { schema: staticQuestionSchema },

--- a/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.unit.spec.tsx
@@ -26,7 +26,6 @@ import {
   waitForLoaderToBeRemoved,
   within,
 } from "__support__/ui";
-import { validateFunctionSchema } from "embedding-sdk-bundle/lib/validate-function-schema";
 import { renderWithSDKProviders } from "embedding-sdk-bundle/test/__support__/ui";
 import { createMockSdkConfig } from "embedding-sdk-bundle/test/mocks/config";
 import { setupSdkState } from "embedding-sdk-bundle/test/server-mocks/sdk-init";
@@ -599,13 +598,15 @@ describe("StaticQuestion — query prop", () => {
 
   it("should render a visualization when given a valid query base64 string", async () => {
     await setup();
-    expect(screen.getByTestId("query-visualization-root")).toBeVisible();
-  });
 
-  it("should reject schema if none of questionId, token, or query is provided", () => {
-    const { validateParameters } = validateFunctionSchema(
-      StaticQuestion.schema,
-    );
-    expect(validateParameters([{}]).success).toBe(false);
+    expect(screen.getByTestId("query-visualization-root")).toBeVisible();
+    expect(
+      within(screen.getByTestId("table-root")).getByText(
+        TEST_COLUMN.display_name,
+      ),
+    ).toBeVisible();
+    expect(
+      within(screen.getByRole("gridcell")).getByText("Test Row"),
+    ).toBeVisible();
   });
 });

--- a/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.unit.spec.tsx
@@ -3,7 +3,9 @@ import userEvent from "@testing-library/user-event";
 import { setupEnterpriseOnlyPlugin } from "__support__/enterprise";
 import {
   findRequests,
+  setupAdhocQueryMetadataEndpoint,
   setupAlertsEndpoints,
+  setupCardDataset,
   setupCardEndpoints,
   setupCardQueryEndpoints,
   setupCardQueryMetadataEndpoint,
@@ -24,10 +26,12 @@ import {
   waitForLoaderToBeRemoved,
   within,
 } from "__support__/ui";
+import { validateFunctionSchema } from "embedding-sdk-bundle/lib/validate-function-schema";
 import { renderWithSDKProviders } from "embedding-sdk-bundle/test/__support__/ui";
 import { createMockSdkConfig } from "embedding-sdk-bundle/test/mocks/config";
 import { setupSdkState } from "embedding-sdk-bundle/test/server-mocks/sdk-init";
 import { reinitialize } from "metabase/plugins";
+import { utf8_to_b64url } from "metabase/utils/encoding";
 import type { CardId, CollectionType, TokenFeatures } from "metabase-types/api";
 import {
   createMockCard,
@@ -559,3 +563,49 @@ describe("StaticQuestion", () => {
 async function findModal() {
   return await screen.findByRole("dialog");
 }
+
+describe("StaticQuestion — query prop", () => {
+  const QUERY_PROP = utf8_to_b64url(
+    JSON.stringify({
+      database: TEST_DB_ID,
+      type: "query",
+      query: { "source-table": TEST_TABLE_ID },
+    }),
+  );
+
+  async function setup() {
+    const { state } = setupSdkState();
+
+    setupNotificationChannelsEndpoints({ email: { configured: false } } as any);
+    setupAdhocQueryMetadataEndpoint(
+      createMockCardQueryMetadata({ databases: [TEST_DB] }),
+    );
+    setupCardDataset({ dataset: TEST_DATASET });
+    setupCollectionByIdEndpoint({
+      collections: [createMockCollection({ id: 1 })],
+    });
+
+    renderWithSDKProviders(<StaticQuestion query={QUERY_PROP} />, {
+      componentProviderProps: { authConfig: createMockSdkConfig() },
+      storeInitialState: state,
+    });
+
+    await waitForLoaderToBeRemoved();
+  }
+
+  beforeAll(() => {
+    mockGetBoundingClientRect();
+  });
+
+  it("should render a visualization when given a valid query base64 string", async () => {
+    await setup();
+    expect(screen.getByTestId("query-visualization-root")).toBeVisible();
+  });
+
+  it("should reject schema if none of questionId, token, or query is provided", () => {
+    const { validateParameters } = validateFunctionSchema(
+      StaticQuestion.schema,
+    );
+    expect(validateParameters([{}]).success).toBe(false);
+  });
+});

--- a/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.unit.spec.tsx
@@ -1,11 +1,6 @@
-import userEvent from "@testing-library/user-event";
-
 import { setupEnterpriseOnlyPlugin } from "__support__/enterprise";
 import {
-  findRequests,
-  setupAdhocQueryMetadataEndpoint,
   setupAlertsEndpoints,
-  setupCardDataset,
   setupCardEndpoints,
   setupCardQueryEndpoints,
   setupCardQueryMetadataEndpoint,
@@ -26,65 +21,31 @@ import {
   waitForLoaderToBeRemoved,
   within,
 } from "__support__/ui";
+import { addAlertModalTests } from "embedding-sdk-bundle/components/public/question/shared-tests/alert-modal.spec";
+import { addAlertsButtonTests } from "embedding-sdk-bundle/components/public/question/shared-tests/alerts-button.spec";
+import type { SetupOpts } from "embedding-sdk-bundle/components/public/question/shared-tests/constants.spec";
+import {
+  TEST_COLUMN,
+  TEST_DATASET,
+  TEST_DB,
+  TEST_TABLE,
+} from "embedding-sdk-bundle/components/public/question/shared-tests/constants.spec";
+import { addQueryPropTests } from "embedding-sdk-bundle/components/public/question/shared-tests/query-prop.spec";
 import { renderWithSDKProviders } from "embedding-sdk-bundle/test/__support__/ui";
 import { createMockSdkConfig } from "embedding-sdk-bundle/test/mocks/config";
 import { setupSdkState } from "embedding-sdk-bundle/test/server-mocks/sdk-init";
-import { reinitialize } from "metabase/plugins";
-import { utf8_to_b64url } from "metabase/utils/encoding";
-import type { CardId, CollectionType, TokenFeatures } from "metabase-types/api";
 import {
   createMockCard,
   createMockCardQueryMetadata,
   createMockCollection,
-  createMockColumn,
-  createMockDatabase,
-  createMockDataset,
-  createMockDatasetData,
-  createMockTable,
   createMockTokenFeatures,
   createMockUser,
 } from "metabase-types/api/mocks";
-import { createMockNotification } from "metabase-types/api/mocks/notification";
 
 import { StaticQuestion, StaticQuestionInternal } from "./StaticQuestion";
 
-const TEST_DB_ID = 1;
-const TEST_DB = createMockDatabase({ id: TEST_DB_ID });
-
-const TEST_TABLE_ID = 1;
-const TEST_TABLE = createMockTable({ id: TEST_TABLE_ID, db_id: TEST_DB_ID });
-
-const TEST_COLUMN = createMockColumn({
-  display_name: "Test Column",
-  name: "Test Column",
-});
-
-const TEST_DATASET = createMockDataset({
-  data: createMockDatasetData({
-    cols: [TEST_COLUMN],
-    rows: [["Test Row"]],
-  }),
-});
-
-const TEST_CARD_ID: CardId = 1 as const;
-
+const TEST_CARD_ID = 1;
 const USER_ID = 999;
-
-interface SetupOpts {
-  title?: string | boolean;
-  withChartTypeSelector?: boolean;
-  withDownloads?: boolean;
-  withAlerts?: boolean;
-  isEmailSetup?: boolean;
-  canManageSubscriptions?: boolean;
-  isSuperuser?: boolean;
-  isModel?: boolean;
-  notifications?: ReturnType<typeof createMockNotification>[];
-  collectionType?: CollectionType;
-  tokenFeatures?: Partial<TokenFeatures>;
-  enterprisePlugins?: Parameters<typeof setupEnterpriseOnlyPlugin>[0][];
-  children?: React.ReactNode;
-}
 
 const setup = async ({
   title,
@@ -103,7 +64,7 @@ const setup = async ({
 }: SetupOpts = {}) => {
   setupNotificationChannelsEndpoints({
     email: { configured: isEmailSetup },
-  } as any);
+  });
 
   const user = createMockUser({
     id: USER_ID,
@@ -192,7 +153,12 @@ const setup = async ({
   await waitForLoaderToBeRemoved();
 };
 
+addQueryPropTests({ Component: StaticQuestionInternal });
+
 describe("StaticQuestion", () => {
+  addAlertsButtonTests(setup, { customComponent: StaticQuestion.AlertsButton });
+  addAlertModalTests(setup, { userId: USER_ID });
+
   beforeAll(() => {
     mockGetBoundingClientRect();
   });
@@ -272,182 +238,6 @@ describe("StaticQuestion", () => {
       ).toBeVisible();
     });
 
-    describe("alerts button with different Metabase version configurations", () => {
-      beforeEach(() => {
-        reinitialize();
-      });
-
-      // eslint-disable-next-line jest/no-disabled-tests -- Fix this in EMB-1184, when we can test SDK with API keys
-      describe.skip("OSS (Open Source Software)", () => {
-        it("should not show the alert button in OSS regardless of settings", async () => {
-          // Don't setup enterprise plugin for OSS
-          await setup({
-            withAlerts: true,
-            isEmailSetup: true,
-            canManageSubscriptions: true,
-            isModel: false,
-            tokenFeatures: {}, // No embedding_sdk feature
-          });
-
-          expect(
-            within(screen.getByRole("gridcell")).getByText("Test Row"),
-          ).toBeVisible();
-          expect(
-            screen.queryByRole("button", { name: "Alerts" }),
-          ).not.toBeInTheDocument();
-        });
-      });
-
-      // eslint-disable-next-line jest/no-disabled-tests -- Fix this in EMB-1184, when we can test SDK with API keys
-      describe.skip("EE (Enterprise Edition) without embedding_sdk token feature", () => {
-        it("should not show the alert button when plugin is enabled but token feature is missing", async () => {
-          await setup({
-            withAlerts: true,
-            isEmailSetup: true,
-            canManageSubscriptions: true,
-            isModel: false,
-            enterprisePlugins: ["sdk_notifications"],
-            tokenFeatures: {}, // No embedding_sdk feature
-          });
-
-          expect(
-            within(screen.getByRole("gridcell")).getByText("Test Row"),
-          ).toBeVisible();
-          expect(
-            screen.queryByRole("button", { name: "Alerts" }),
-          ).not.toBeInTheDocument();
-        });
-      });
-
-      describe("EE with embedding_sdk token feature", () => {
-        it("should show the alert button when plugin and token feature are both enabled", async () => {
-          await setup({
-            withAlerts: true,
-            isEmailSetup: true,
-            canManageSubscriptions: true,
-            isModel: false,
-            enterprisePlugins: ["sdk_notifications"],
-          });
-
-          expect(
-            within(screen.getByRole("gridcell")).getByText("Test Row"),
-          ).toBeVisible();
-          expect(
-            await screen.findByRole("button", { name: "Alerts" }),
-          ).toBeVisible();
-        });
-
-        it("should show the alert button for custom layouts when withAlerts is true", async () => {
-          await setup({
-            withAlerts: true,
-            isEmailSetup: true,
-            canManageSubscriptions: true,
-            isModel: false,
-            enterprisePlugins: ["sdk_notifications"],
-            children: (
-              <div>
-                <span>Custom Layout</span>
-                <StaticQuestion.AlertsButton />
-              </div>
-            ),
-          });
-
-          expect(screen.getByText("Custom Layout")).toBeVisible();
-          expect(screen.getByRole("button", { name: "Alerts" })).toBeVisible();
-        });
-
-        it("should not show the alert button for custom layouts when withAlerts is false", async () => {
-          await setup({
-            withAlerts: false,
-            isEmailSetup: true,
-            canManageSubscriptions: true,
-            isModel: false,
-            enterprisePlugins: ["sdk_notifications"],
-            children: (
-              <div>
-                <span>Custom Layout</span>
-                <StaticQuestion.AlertsButton />
-              </div>
-            ),
-          });
-
-          expect(screen.getByText("Custom Layout")).toBeVisible();
-          expect(
-            screen.queryByRole("button", { name: "Alerts" }),
-          ).not.toBeInTheDocument();
-        });
-
-        it("should not show the alert button when withAlerts is false", async () => {
-          await setup({
-            withAlerts: false,
-            isEmailSetup: true,
-            canManageSubscriptions: true,
-            enterprisePlugins: ["sdk_notifications"],
-          });
-
-          expect(
-            screen.queryByRole("button", { name: "Alerts" }),
-          ).not.toBeInTheDocument();
-        });
-
-        it("should not show the alert button when email is not configured", async () => {
-          await setup({
-            withAlerts: true,
-            isEmailSetup: false,
-            canManageSubscriptions: true,
-            enterprisePlugins: ["sdk_notifications"],
-          });
-
-          expect(
-            screen.queryByRole("button", { name: "Alerts" }),
-          ).not.toBeInTheDocument();
-        });
-
-        it("should not show the alert button when user cannot manage subscriptions and is not admin", async () => {
-          await setup({
-            withAlerts: true,
-            isEmailSetup: true,
-            isSuperuser: false,
-            canManageSubscriptions: false,
-            enterprisePlugins: ["sdk_notifications", "application_permissions"],
-            tokenFeatures: { embedding_sdk: true, advanced_permissions: true },
-          });
-
-          expect(
-            screen.queryByRole("button", { name: "Alerts" }),
-          ).not.toBeInTheDocument();
-        });
-
-        it("should not show the alert button for models", async () => {
-          await setup({
-            withAlerts: true,
-            isEmailSetup: true,
-            canManageSubscriptions: true,
-            isModel: true,
-            enterprisePlugins: ["sdk_notifications"],
-          });
-
-          expect(
-            screen.queryByRole("button", { name: "Alerts" }),
-          ).not.toBeInTheDocument();
-        });
-
-        it("should not show the alert button for analytics collection", async () => {
-          await setup({
-            withAlerts: true,
-            isEmailSetup: true,
-            canManageSubscriptions: true,
-            collectionType: "instance-analytics",
-            enterprisePlugins: ["sdk_notifications"],
-          });
-
-          expect(
-            screen.queryByRole("button", { name: "Alerts" }),
-          ).not.toBeInTheDocument();
-        });
-      });
-    });
-
     it("should show the TopBar when multiple UI elements are provided", async () => {
       await setup({
         title: "My Title",
@@ -463,160 +253,5 @@ describe("StaticQuestion", () => {
       expect(screen.getByText("My Title")).toBeVisible();
       expect(screen.getByTestId("chart-type-selector-button")).toBeVisible();
     });
-  });
-
-  describe("alert modal", () => {
-    it("should show alert list modal when there are existing alerts", async () => {
-      await setup({
-        withAlerts: true,
-        isEmailSetup: true,
-        canManageSubscriptions: true,
-        isModel: false,
-        enterprisePlugins: ["sdk_notifications"],
-        notifications: [createMockNotification()],
-      });
-
-      expect(
-        within(screen.getByRole("gridcell")).getByText("Test Row"),
-      ).toBeVisible();
-
-      await userEvent.click(
-        await screen.findByRole("button", { name: "Alerts" }),
-      );
-
-      // Verify the alert list modal appears, not the create modal
-      const withinModal = within(await findModal());
-
-      // Show the alert list modal title
-      expect(
-        await withinModal.findByRole("heading", { name: "Edit alerts" }),
-      ).toBeVisible();
-
-      // Should show the button to create a new alert in the list modal
-      expect(withinModal.getByText("New alert")).toBeVisible();
-
-      // Should NOT show the create alert form fields
-      expect(
-        withinModal.queryByText("What do you want to be alerted about?"),
-      ).not.toBeInTheDocument();
-    });
-
-    it("should not show email selector on the SDK and use current logged in user as the recipient", async () => {
-      await setup({
-        withAlerts: true,
-        isEmailSetup: true,
-        canManageSubscriptions: true,
-        isModel: false,
-        enterprisePlugins: ["sdk_notifications"],
-      });
-
-      expect(
-        within(screen.getByRole("gridcell")).getByText("Test Row"),
-      ).toBeVisible();
-      await userEvent.click(
-        await screen.findByRole("button", { name: "Alerts" }),
-      );
-
-      const withinModal = within(await findModal());
-      expect(
-        withinModal.getByRole("heading", { name: "New alert" }),
-      ).toBeVisible();
-      expect(
-        withinModal.getByText("What do you want to be alerted about?"),
-      ).toBeVisible();
-      expect(
-        withinModal.getByText("When do you want to check this?"),
-      ).toBeVisible();
-      // Email selector is within this section, checking only the header is fine
-      expect(
-        withinModal.queryByText("Where do you want to send the results?"),
-      ).not.toBeInTheDocument();
-      expect(withinModal.getByText("More options")).toBeVisible();
-      await userEvent.click(withinModal.getByRole("button", { name: "Done" }));
-
-      const createNotificationRequest = (await findRequests("POST")).find(
-        (postRequest) =>
-          postRequest.url === "http://localhost/api/notification",
-      );
-      // Checks that we're using the current logged in user as the sole recipient
-      expect(createNotificationRequest?.body).toMatchObject({
-        handlers: [
-          {
-            channel_type: "channel/email",
-            recipients: [
-              {
-                details: null,
-                type: "notification-recipient/user",
-                user_id: USER_ID,
-              },
-            ],
-          },
-        ],
-      });
-      // So that when we assert this value, we know we won't accidentally match the default mock ID
-      expect(USER_ID).not.toBe(1);
-    });
-  });
-});
-
-async function findModal() {
-  return await screen.findByRole("dialog");
-}
-
-describe("StaticQuestion — query prop", () => {
-  const QUERY_PROP = utf8_to_b64url(
-    JSON.stringify({
-      dataset_query: {
-        database: TEST_DB_ID,
-        type: "query",
-        query: { "source-table": TEST_TABLE_ID },
-      },
-    }),
-  );
-
-  async function setup() {
-    const { state } = setupSdkState();
-
-    setupNotificationChannelsEndpoints({ email: { configured: false } } as any);
-    setupAdhocQueryMetadataEndpoint(
-      createMockCardQueryMetadata({ databases: [TEST_DB] }),
-    );
-    // Needs >1 row so Question.maybeResetDisplay doesn't force scalar.
-    setupCardDataset({
-      dataset: createMockDataset({
-        data: createMockDatasetData({
-          cols: [TEST_COLUMN],
-          rows: [["Test Row"], ["Test Row 2"]],
-        }),
-      }),
-    });
-    setupCollectionByIdEndpoint({
-      collections: [createMockCollection({ id: 1 })],
-    });
-
-    renderWithSDKProviders(<StaticQuestionInternal query={QUERY_PROP} />, {
-      componentProviderProps: { authConfig: createMockSdkConfig() },
-      storeInitialState: state,
-    });
-
-    await waitForLoaderToBeRemoved();
-  }
-
-  beforeAll(() => {
-    mockGetBoundingClientRect();
-  });
-
-  it("should render a visualization when given a valid query base64 string", async () => {
-    await setup();
-
-    expect(screen.getByTestId("query-visualization-root")).toBeVisible();
-    expect(
-      within(screen.getByTestId("table-root")).getByText(
-        TEST_COLUMN.display_name,
-      ),
-    ).toBeVisible();
-    expect(
-      within(screen.getAllByRole("gridcell")[0]).getByText("Test Row"),
-    ).toBeVisible();
   });
 });

--- a/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.unit.spec.tsx
@@ -47,7 +47,7 @@ import {
 } from "metabase-types/api/mocks";
 import { createMockNotification } from "metabase-types/api/mocks/notification";
 
-import { StaticQuestion } from "./StaticQuestion";
+import { StaticQuestion, _StaticQuestionInternal } from "./StaticQuestion";
 
 const TEST_DB_ID = 1;
 const TEST_DB = createMockDatabase({ id: TEST_DB_ID });
@@ -585,7 +585,7 @@ describe("StaticQuestion — query prop", () => {
       collections: [createMockCollection({ id: 1 })],
     });
 
-    renderWithSDKProviders(<StaticQuestion query={QUERY_PROP} />, {
+    renderWithSDKProviders(<_StaticQuestionInternal query={QUERY_PROP} />, {
       componentProviderProps: { authConfig: createMockSdkConfig() },
       storeInitialState: state,
     });

--- a/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.unit.spec.tsx
@@ -566,9 +566,11 @@ async function findModal() {
 describe("StaticQuestion — query prop", () => {
   const QUERY_PROP = utf8_to_b64url(
     JSON.stringify({
-      database: TEST_DB_ID,
-      type: "query",
-      query: { "source-table": TEST_TABLE_ID },
+      dataset_query: {
+        database: TEST_DB_ID,
+        type: "query",
+        query: { "source-table": TEST_TABLE_ID },
+      },
     }),
   );
 
@@ -579,7 +581,15 @@ describe("StaticQuestion — query prop", () => {
     setupAdhocQueryMetadataEndpoint(
       createMockCardQueryMetadata({ databases: [TEST_DB] }),
     );
-    setupCardDataset({ dataset: TEST_DATASET });
+    // Needs >1 row so Question.maybeResetDisplay doesn't force scalar.
+    setupCardDataset({
+      dataset: createMockDataset({
+        data: createMockDatasetData({
+          cols: [TEST_COLUMN],
+          rows: [["Test Row"], ["Test Row 2"]],
+        }),
+      }),
+    });
     setupCollectionByIdEndpoint({
       collections: [createMockCollection({ id: 1 })],
     });
@@ -606,7 +616,7 @@ describe("StaticQuestion — query prop", () => {
       ),
     ).toBeVisible();
     expect(
-      within(screen.getByRole("gridcell")).getByText("Test Row"),
+      within(screen.getAllByRole("gridcell")[0]).getByText("Test Row"),
     ).toBeVisible();
   });
 });

--- a/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/StaticQuestion/StaticQuestion.unit.spec.tsx
@@ -46,7 +46,7 @@ import {
 } from "metabase-types/api/mocks";
 import { createMockNotification } from "metabase-types/api/mocks/notification";
 
-import { StaticQuestion, _StaticQuestionInternal } from "./StaticQuestion";
+import { StaticQuestion, StaticQuestionInternal } from "./StaticQuestion";
 
 const TEST_DB_ID = 1;
 const TEST_DB = createMockDatabase({ id: TEST_DB_ID });
@@ -594,7 +594,7 @@ describe("StaticQuestion — query prop", () => {
       collections: [createMockCollection({ id: 1 })],
     });
 
-    renderWithSDKProviders(<_StaticQuestionInternal query={QUERY_PROP} />, {
+    renderWithSDKProviders(<StaticQuestionInternal query={QUERY_PROP} />, {
       componentProviderProps: { authConfig: createMockSdkConfig() },
       storeInitialState: state,
     });

--- a/frontend/src/embedding-sdk-bundle/components/public/question/shared-tests/alert-modal.spec.ts
+++ b/frontend/src/embedding-sdk-bundle/components/public/question/shared-tests/alert-modal.spec.ts
@@ -1,0 +1,111 @@
+import userEvent from "@testing-library/user-event";
+
+import { findRequests } from "__support__/server-mocks";
+import { screen, within } from "__support__/ui";
+import { createMockNotification } from "metabase-types/api/mocks/notification";
+
+import type { SetupOpts } from "./constants.spec";
+
+type Setup = (opts?: SetupOpts) => Promise<void>;
+
+async function findModal() {
+  return await screen.findByRole("dialog");
+}
+
+export function addAlertModalTests(
+  setup: Setup,
+  { userId }: { userId: number },
+) {
+  describe("alert modal", () => {
+    it("should show alert list modal when there are existing alerts", async () => {
+      await setup({
+        withAlerts: true,
+        isEmailSetup: true,
+        canManageSubscriptions: true,
+        isModel: false,
+        enterprisePlugins: ["sdk_notifications"],
+        notifications: [createMockNotification()],
+      });
+
+      expect(
+        within(screen.getByRole("gridcell")).getByText("Test Row"),
+      ).toBeVisible();
+
+      await userEvent.click(
+        await screen.findByRole("button", { name: "Alerts" }),
+      );
+
+      // Verify the alert list modal appears, not the create modal
+      const withinModal = within(await findModal());
+
+      // Show the alert list modal title
+      expect(
+        await withinModal.findByRole("heading", { name: "Edit alerts" }),
+      ).toBeVisible();
+
+      // Should show the button to create a new alert in the list modal
+      expect(withinModal.getByText("New alert")).toBeVisible();
+
+      // Should NOT show the create alert form fields
+      expect(
+        withinModal.queryByText("What do you want to be alerted about?"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("should not show email selector on the SDK and use current logged in user as the recipient", async () => {
+      await setup({
+        withAlerts: true,
+        isEmailSetup: true,
+        canManageSubscriptions: true,
+        isModel: false,
+        enterprisePlugins: ["sdk_notifications"],
+      });
+
+      expect(
+        within(screen.getByRole("gridcell")).getByText("Test Row"),
+      ).toBeVisible();
+      await userEvent.click(
+        await screen.findByRole("button", { name: "Alerts" }),
+      );
+
+      const withinModal = within(await findModal());
+      expect(
+        withinModal.getByRole("heading", { name: "New alert" }),
+      ).toBeVisible();
+      expect(
+        withinModal.getByText("What do you want to be alerted about?"),
+      ).toBeVisible();
+      expect(
+        withinModal.getByText("When do you want to check this?"),
+      ).toBeVisible();
+      // Email selector is within this section, checking only the header is fine
+      expect(
+        withinModal.queryByText("Where do you want to send the results?"),
+      ).not.toBeInTheDocument();
+      expect(withinModal.getByText("More options")).toBeVisible();
+      await userEvent.click(withinModal.getByRole("button", { name: "Done" }));
+
+      const createNotificationRequest = (await findRequests("POST")).find(
+        (postRequest) =>
+          postRequest.url === "http://localhost/api/notification",
+      );
+      // Checks that we're using the current logged in user as the sole recipient
+      expect(createNotificationRequest?.body).toMatchObject({
+        handlers: [
+          {
+            channel_type: "channel/email",
+            recipients: [
+              {
+                details: null,
+                type: "notification-recipient/user",
+                user_id: userId,
+              },
+            ],
+          },
+        ],
+      });
+      // So that when we assert this value, we know we won't accidentally match the default mock ID
+      expect(userId).not.toBe(1);
+    });
+  });
+}

--- a/frontend/src/embedding-sdk-bundle/components/public/question/shared-tests/alerts-button.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/question/shared-tests/alerts-button.spec.tsx
@@ -1,0 +1,190 @@
+import type { ComponentType } from "react";
+
+import { screen, within } from "__support__/ui";
+import { reinitialize } from "metabase/plugins";
+
+import type { SetupOpts } from "./constants.spec";
+
+type Setup = (opts?: SetupOpts) => Promise<void>;
+
+export function addAlertsButtonTests(
+  setup: Setup,
+  { customComponent: AlertsButton }: { customComponent: ComponentType },
+) {
+  // eslint-disable-next-line metabase/no-literal-metabase-strings -- test description
+  describe("alerts button with different Metabase version configurations", () => {
+    beforeEach(() => {
+      reinitialize();
+    });
+
+    // Fix this in EMB-1184, when we can test SDK with API keys
+    describe.skip("OSS (Open Source Software)", () => {
+      it("should not show the alert button in OSS regardless of settings", async () => {
+        // Don't setup enterprise plugin for OSS
+        await setup({
+          withAlerts: true,
+          isEmailSetup: true,
+          canManageSubscriptions: true,
+          isModel: false,
+          tokenFeatures: {}, // No embedding_sdk feature
+        });
+
+        expect(
+          within(screen.getByRole("gridcell")).getByText("Test Row"),
+        ).toBeVisible();
+        expect(
+          screen.queryByRole("button", { name: "Alerts" }),
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    // Fix this in EMB-1184, when we can test SDK with API keys
+    describe.skip("EE (Enterprise Edition) without embedding_sdk token feature", () => {
+      it("should not show the alert button when plugin is enabled but token feature is missing", async () => {
+        await setup({
+          withAlerts: true,
+          isEmailSetup: true,
+          canManageSubscriptions: true,
+          isModel: false,
+          enterprisePlugins: ["sdk_notifications"],
+          tokenFeatures: {}, // No embedding_sdk feature
+        });
+
+        expect(
+          within(screen.getByRole("gridcell")).getByText("Test Row"),
+        ).toBeVisible();
+        expect(
+          screen.queryByRole("button", { name: "Alerts" }),
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    describe("EE with embedding_sdk token feature", () => {
+      it("should show the alert button when plugin and token feature are both enabled", async () => {
+        await setup({
+          withAlerts: true,
+          isEmailSetup: true,
+          canManageSubscriptions: true,
+          isModel: false,
+          enterprisePlugins: ["sdk_notifications"],
+        });
+
+        expect(
+          within(screen.getByRole("gridcell")).getByText("Test Row"),
+        ).toBeVisible();
+        expect(
+          await screen.findByRole("button", { name: "Alerts" }),
+        ).toBeVisible();
+      });
+
+      it("should show the alert button for custom layouts when withAlerts is true", async () => {
+        await setup({
+          withAlerts: true,
+          isEmailSetup: true,
+          canManageSubscriptions: true,
+          isModel: false,
+          enterprisePlugins: ["sdk_notifications"],
+          children: (
+            <div>
+              <span>Custom Layout</span>
+              <AlertsButton />
+            </div>
+          ),
+        });
+
+        expect(screen.getByText("Custom Layout")).toBeVisible();
+        expect(screen.getByRole("button", { name: "Alerts" })).toBeVisible();
+      });
+
+      it("should not show the alert button for custom layouts when withAlerts is false", async () => {
+        await setup({
+          withAlerts: false,
+          isEmailSetup: true,
+          canManageSubscriptions: true,
+          isModel: false,
+          enterprisePlugins: ["sdk_notifications"],
+          children: (
+            <div>
+              <span>Custom Layout</span>
+              <AlertsButton />
+            </div>
+          ),
+        });
+
+        expect(screen.getByText("Custom Layout")).toBeVisible();
+        expect(
+          screen.queryByRole("button", { name: "Alerts" }),
+        ).not.toBeInTheDocument();
+      });
+
+      it("should not show the alert button when withAlerts is false", async () => {
+        await setup({
+          withAlerts: false,
+          isEmailSetup: true,
+          canManageSubscriptions: true,
+          enterprisePlugins: ["sdk_notifications"],
+        });
+
+        expect(
+          screen.queryByRole("button", { name: "Alerts" }),
+        ).not.toBeInTheDocument();
+      });
+
+      it("should not show the alert button when email is not configured", async () => {
+        await setup({
+          withAlerts: true,
+          isEmailSetup: false,
+          canManageSubscriptions: true,
+          enterprisePlugins: ["sdk_notifications"],
+        });
+
+        expect(
+          screen.queryByRole("button", { name: "Alerts" }),
+        ).not.toBeInTheDocument();
+      });
+
+      it("should not show the alert button when user cannot manage subscriptions and is not admin", async () => {
+        await setup({
+          withAlerts: true,
+          isEmailSetup: true,
+          isSuperuser: false,
+          canManageSubscriptions: false,
+          enterprisePlugins: ["sdk_notifications", "application_permissions"],
+          tokenFeatures: { embedding_sdk: true, advanced_permissions: true },
+        });
+
+        expect(
+          screen.queryByRole("button", { name: "Alerts" }),
+        ).not.toBeInTheDocument();
+      });
+
+      it("should not show the alert button for models", async () => {
+        await setup({
+          withAlerts: true,
+          isEmailSetup: true,
+          canManageSubscriptions: true,
+          isModel: true,
+          enterprisePlugins: ["sdk_notifications"],
+        });
+
+        expect(
+          screen.queryByRole("button", { name: "Alerts" }),
+        ).not.toBeInTheDocument();
+      });
+
+      it("should not show the alert button for analytics collection", async () => {
+        await setup({
+          withAlerts: true,
+          isEmailSetup: true,
+          canManageSubscriptions: true,
+          collectionType: "instance-analytics",
+          enterprisePlugins: ["sdk_notifications"],
+        });
+
+        expect(
+          screen.queryByRole("button", { name: "Alerts" }),
+        ).not.toBeInTheDocument();
+      });
+    });
+  });
+}

--- a/frontend/src/embedding-sdk-bundle/components/public/question/shared-tests/constants.spec.ts
+++ b/frontend/src/embedding-sdk-bundle/components/public/question/shared-tests/constants.spec.ts
@@ -1,0 +1,46 @@
+import type { setupEnterpriseOnlyPlugin } from "__support__/enterprise";
+import type { CollectionType, TokenFeatures } from "metabase-types/api";
+import {
+  createMockColumn,
+  createMockDatabase,
+  createMockDataset,
+  createMockDatasetData,
+  createMockTable,
+} from "metabase-types/api/mocks";
+import type { createMockNotification } from "metabase-types/api/mocks/notification";
+
+const TEST_DB_ID = 1;
+export const TEST_DB = createMockDatabase({ id: TEST_DB_ID });
+
+export const TEST_TABLE = createMockTable({
+  id: 1,
+  db_id: TEST_DB_ID,
+});
+
+export const TEST_COLUMN = createMockColumn({
+  display_name: "Test Column",
+  name: "Test Column",
+});
+
+export const TEST_DATASET = createMockDataset({
+  data: createMockDatasetData({
+    cols: [TEST_COLUMN],
+    rows: [["Test Row"]],
+  }),
+});
+
+export interface SetupOpts {
+  title?: string | boolean;
+  withChartTypeSelector?: boolean;
+  withDownloads?: boolean;
+  withAlerts?: boolean;
+  isEmailSetup?: boolean;
+  canManageSubscriptions?: boolean;
+  isSuperuser?: boolean;
+  isModel?: boolean;
+  notifications?: ReturnType<typeof createMockNotification>[];
+  collectionType?: CollectionType;
+  tokenFeatures?: Partial<TokenFeatures>;
+  enterprisePlugins?: Parameters<typeof setupEnterpriseOnlyPlugin>[0][];
+  children?: React.ReactNode;
+}

--- a/frontend/src/embedding-sdk-bundle/components/public/question/shared-tests/query-prop.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/question/shared-tests/query-prop.spec.tsx
@@ -1,0 +1,88 @@
+import {
+  setupAdhocQueryMetadataEndpoint,
+  setupCardDataset,
+  setupCollectionByIdEndpoint,
+  setupNotificationChannelsEndpoints,
+} from "__support__/server-mocks";
+import {
+  mockGetBoundingClientRect,
+  screen,
+  waitForLoaderToBeRemoved,
+  within,
+} from "__support__/ui";
+import { renderWithSDKProviders } from "embedding-sdk-bundle/test/__support__/ui";
+import { createMockSdkConfig } from "embedding-sdk-bundle/test/mocks/config";
+import { setupSdkState } from "embedding-sdk-bundle/test/server-mocks/sdk-init";
+import { utf8_to_b64url } from "metabase/utils/encoding";
+import {
+  createMockCardQueryMetadata,
+  createMockCollection,
+  createMockDataset,
+  createMockDatasetData,
+} from "metabase-types/api/mocks";
+
+import { TEST_COLUMN, TEST_DB, TEST_TABLE } from "./constants.spec";
+
+export function addQueryPropTests({
+  Component,
+}: {
+  Component: (props: { query: string }) => React.ReactNode;
+}) {
+  describe("query prop", () => {
+    const QUERY_PROP = utf8_to_b64url(
+      JSON.stringify({
+        dataset_query: {
+          database: TEST_DB.id,
+          type: "query",
+          query: { "source-table": TEST_TABLE.id },
+        },
+      }),
+    );
+
+    async function setup() {
+      const { state } = setupSdkState();
+
+      setupNotificationChannelsEndpoints({ email: { configured: false } });
+      setupAdhocQueryMetadataEndpoint(
+        createMockCardQueryMetadata({ databases: [TEST_DB] }),
+      );
+      // Needs >1 row so Question.maybeResetDisplay doesn't force scalar.
+      setupCardDataset({
+        dataset: createMockDataset({
+          data: createMockDatasetData({
+            cols: [TEST_COLUMN],
+            rows: [["Test Row"], ["Test Row 2"]],
+          }),
+        }),
+      });
+      setupCollectionByIdEndpoint({
+        collections: [createMockCollection({ id: 1 })],
+      });
+
+      renderWithSDKProviders(<Component query={QUERY_PROP} />, {
+        componentProviderProps: { authConfig: createMockSdkConfig() },
+        storeInitialState: state,
+      });
+
+      await waitForLoaderToBeRemoved();
+    }
+
+    beforeAll(() => {
+      mockGetBoundingClientRect();
+    });
+
+    it("should render a visualization when given a valid query base64 string", async () => {
+      await setup();
+
+      expect(screen.getByTestId("query-visualization-root")).toBeVisible();
+      expect(
+        within(screen.getByTestId("table-root")).getByText(
+          TEST_COLUMN.display_name,
+        ),
+      ).toBeVisible();
+      expect(
+        within(screen.getAllByRole("gridcell")[0]).getByText("Test Row"),
+      ).toBeVisible();
+    });
+  });
+}

--- a/frontend/src/embedding-sdk-bundle/types/question.ts
+++ b/frontend/src/embedding-sdk-bundle/types/question.ts
@@ -52,6 +52,7 @@ export type SdkQuestionEntityPublicProps =
        */
       questionId: SdkQuestionId | null;
       token?: never;
+      query?: never;
     }
   | {
       questionId?: never;
@@ -59,6 +60,17 @@ export type SdkQuestionEntityPublicProps =
        * A valid JWT token for the guest embed.
        */
       token: SdkEntityToken | null;
+      query?: never;
+    }
+  | {
+      questionId?: never;
+      token?: never;
+      /**
+       * A base64-encoded query, as returned by `/api/agent/v1/construct-query`,
+       * or a Metabot `navigate_to` path (e.g. `/question#<base64>`).
+       * The `question#` prefix is stripped automatically when present.
+       */
+      query: string;
     };
 
 export interface SdkQuestionState {

--- a/frontend/src/embedding-sdk-bundle/types/question.ts
+++ b/frontend/src/embedding-sdk-bundle/types/question.ts
@@ -61,15 +61,17 @@ export type SdkQuestionEntityPublicProps =
        */
       token: SdkEntityToken | null;
       query?: never;
-    }
+    };
+
+/**
+ * Internal type that adds the `query` prop used by the `useMetabot` hook. Not
+ * re-exported from the public SDK package entry point.
+ */
+export type SdkQuestionEntityInternalProps =
+  | SdkQuestionEntityPublicProps
   | {
       questionId?: never;
       token?: never;
-      /**
-       * A base64-encoded query, as returned by `/api/agent/v1/construct-query`,
-       * or a Metabot `navigate_to` path (e.g. `/question#<base64>`).
-       * The `question#` prefix is stripped automatically when present.
-       */
       query: string;
     };
 

--- a/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.unit.spec.tsx
+++ b/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.unit.spec.tsx
@@ -186,7 +186,6 @@ describe("CreateOrEditQuestionAlertModalWithQuestion", () => {
     expect(scheduleTypeSelect).toHaveValue("weekly");
     expect(screen.getByTestId("select-weekday")).toHaveValue("Monday");
 
-    // screen.debug(undefined, Infinity);
     // Verify time is 2:00pm
     const timeSelector = screen.getByTestId("select-time");
     expect(timeSelector).toHaveValue("2:00");

--- a/frontend/src/metabase/utils/card.ts
+++ b/frontend/src/metabase/utils/card.ts
@@ -108,7 +108,7 @@ export function deserializeCardFromQuery(query: string): Card {
     return decoded as Card;
   }
 
-  return { dataset_query: decoded } as unknown as Card;
+  return { dataset_query: decoded } as Card;
 }
 
 export function deserializeCard(serializedCard: string) {

--- a/frontend/src/metabase/utils/card.ts
+++ b/frontend/src/metabase/utils/card.ts
@@ -2,7 +2,11 @@ import querystring from "querystring";
 
 import _ from "underscore";
 
-import { b64hash_to_utf8, utf8_to_b64url } from "metabase/utils/encoding";
+import {
+  b64hash_to_utf8,
+  b64url_to_utf8,
+  utf8_to_b64url,
+} from "metabase/utils/encoding";
 import { stableStringify } from "metabase/utils/objects";
 import { normalize } from "metabase-lib/v1/queries/utils/normalize";
 import type { Card, ParameterValuesMap, UnsavedCard } from "metabase-types/api";
@@ -84,6 +88,27 @@ export function serializeCardForUrl(
 
 export function deserializeCardFromUrl(serialized: string): Card {
   return JSON.parse(b64hash_to_utf8(serialized));
+}
+
+/**
+ * Converts a base64-encoded query string into a Card suitable for `deserializedCard`.
+ *
+ * Accepts:
+ * - Raw base64 from `/api/agent/v1/construct-query`
+ * - A Metabot `navigate_to` path like `/question#<base64>` (prefix is stripped)
+ */
+export function deserializeCardFromQuery(query: string): Card {
+  // Strip /question# or question# or # prefix, then decode as URL-safe base64
+  const base64 = query.replace(/^\/question#|^question#|^#/, "");
+  const decoded = JSON.parse(b64url_to_utf8(base64));
+
+  // Embedding Metabot wraps the query: { dataset_query: ... }
+  // API returns the raw query directly.
+  if (decoded.dataset_query) {
+    return decoded as Card;
+  }
+
+  return { dataset_query: decoded } as unknown as Card;
 }
 
 export function deserializeCard(serializedCard: string) {

--- a/frontend/src/metabase/utils/card.ts
+++ b/frontend/src/metabase/utils/card.ts
@@ -91,24 +91,12 @@ export function deserializeCardFromUrl(serialized: string): Card {
 }
 
 /**
- * Converts a base64-encoded query string into a Card suitable for `deserializedCard`.
- *
- * Accepts:
- * - Raw base64 from `/api/agent/v1/construct-query`
- * - A Metabot `navigate_to` path like `/question#<base64>` (prefix is stripped)
+ * Converts a Metabot `navigate_to` path like `/question#<base64>` into a
+ * Card suitable for `deserializedCard`.
  */
 export function deserializeCardFromQuery(query: string): Card {
-  // Strip /question# or question# or # prefix, then decode as URL-safe base64
-  const base64 = query.replace(/^\/question#|^question#|^#/, "");
-  const decoded = JSON.parse(b64url_to_utf8(base64));
-
-  // Embedding Metabot wraps the query: { dataset_query: ... }
-  // API returns the raw query directly.
-  if (decoded.dataset_query) {
-    return decoded as Card;
-  }
-
-  return { dataset_query: decoded } as Card;
+  const base64 = query.replace(/^\/question#/, "");
+  return JSON.parse(b64url_to_utf8(base64));
 }
 
 export function deserializeCard(serializedCard: string) {

--- a/frontend/src/metabase/utils/card.unit.spec.ts
+++ b/frontend/src/metabase/utils/card.unit.spec.ts
@@ -1,4 +1,5 @@
 import {
+  deserializeCardFromQuery,
   deserializeCardFromUrl,
   serializeCardForUrl,
 } from "metabase/utils/card";
@@ -8,10 +9,21 @@ import {
   utf8_to_b64,
   utf8_to_b64url,
 } from "metabase/utils/encoding";
+import type { Card, UnsavedCard } from "metabase-types/api";
 
 const CARD_ID = 31;
 
 // TODO Atte Keinänen 8/5/17: Create a reusable version `getCard` for reducing test code duplication
+interface GetCardOpts {
+  newCard?: boolean;
+  hasOriginalCard?: boolean;
+  isNative?: boolean;
+  database?: number;
+  display?: string;
+  queryFields?: Record<string, unknown>;
+  table?: number;
+}
+
 const getCard = ({
   newCard = false,
   hasOriginalCard = false,
@@ -20,7 +32,7 @@ const getCard = ({
   display = "table",
   queryFields = {},
   table = undefined,
-}) => {
+}: GetCardOpts = {}): Card | UnsavedCard => {
   const savedCardFields = {
     name: "Example Saved Question",
     description: "For satisfying your craving for information",
@@ -51,7 +63,7 @@ const getCard = ({
     },
     ...(newCard ? {} : savedCardFields),
     ...(hasOriginalCard ? { original_card_id: CARD_ID } : {}),
-  };
+  } as Card | UnsavedCard;
 };
 
 describe("lib/card", () => {
@@ -90,6 +102,48 @@ describe("lib/card", () => {
         "original_card_id",
         CARD_ID,
       );
+    });
+  });
+
+  describe("deserializeCardFromQuery", () => {
+    const MBQL_QUERY = {
+      database: 1,
+      type: "query",
+      query: { "source-table": 2 },
+    };
+    const RAW_B64 = utf8_to_b64url(JSON.stringify(MBQL_QUERY));
+    const WRAPPED_B64 = utf8_to_b64url(
+      JSON.stringify({ dataset_query: MBQL_QUERY }),
+    );
+
+    it("should wrap a raw pMBQL query in { dataset_query: ... }", () => {
+      expect(deserializeCardFromQuery(RAW_B64)).toEqual({
+        dataset_query: MBQL_QUERY,
+      });
+    });
+
+    it("should strip /question# prefix and wrap the payload", () => {
+      expect(deserializeCardFromQuery(`/question#${RAW_B64}`)).toEqual({
+        dataset_query: MBQL_QUERY,
+      });
+    });
+
+    it("should strip question# prefix (no leading slash) and wrap the payload", () => {
+      expect(deserializeCardFromQuery(`question#${RAW_B64}`)).toEqual({
+        dataset_query: MBQL_QUERY,
+      });
+    });
+
+    it("should strip # prefix and wrap the payload", () => {
+      expect(deserializeCardFromQuery(`#${RAW_B64}`)).toEqual({
+        dataset_query: MBQL_QUERY,
+      });
+    });
+
+    it("should return a payload already containing dataset_query as-is", () => {
+      expect(deserializeCardFromQuery(WRAPPED_B64)).toEqual({
+        dataset_query: MBQL_QUERY,
+      });
     });
   });
 });

--- a/frontend/src/metabase/utils/card.unit.spec.ts
+++ b/frontend/src/metabase/utils/card.unit.spec.ts
@@ -13,7 +13,6 @@ import type { Card, UnsavedCard } from "metabase-types/api";
 
 const CARD_ID = 31;
 
-// TODO Atte Keinänen 8/5/17: Create a reusable version `getCard` for reducing test code duplication
 interface GetCardOpts {
   newCard?: boolean;
   hasOriginalCard?: boolean;
@@ -24,6 +23,7 @@ interface GetCardOpts {
   table?: number;
 }
 
+// TODO Atte Keinänen 8/5/17: Create a reusable version `getCard` for reducing test code duplication
 const getCard = ({
   newCard = false,
   hasOriginalCard = false,
@@ -111,39 +111,17 @@ describe("lib/card", () => {
       type: "query",
       query: { "source-table": 2 },
     };
-    const RAW_B64 = utf8_to_b64url(JSON.stringify(MBQL_QUERY));
-    const WRAPPED_B64 = utf8_to_b64url(
-      JSON.stringify({ dataset_query: MBQL_QUERY }),
-    );
+    const CARD_PAYLOAD = {
+      dataset_query: MBQL_QUERY,
+      display: "bar",
+      visualization_settings: {},
+    };
+    const WRAPPED_B64 = utf8_to_b64url(JSON.stringify(CARD_PAYLOAD));
 
-    it("should wrap a raw pMBQL query in { dataset_query: ... }", () => {
-      expect(deserializeCardFromQuery(RAW_B64)).toEqual({
-        dataset_query: MBQL_QUERY,
-      });
-    });
-
-    it("should strip /question# prefix and wrap the payload", () => {
-      expect(deserializeCardFromQuery(`/question#${RAW_B64}`)).toEqual({
-        dataset_query: MBQL_QUERY,
-      });
-    });
-
-    it("should strip question# prefix (no leading slash) and wrap the payload", () => {
-      expect(deserializeCardFromQuery(`question#${RAW_B64}`)).toEqual({
-        dataset_query: MBQL_QUERY,
-      });
-    });
-
-    it("should strip # prefix and wrap the payload", () => {
-      expect(deserializeCardFromQuery(`#${RAW_B64}`)).toEqual({
-        dataset_query: MBQL_QUERY,
-      });
-    });
-
-    it("should return a payload already containing dataset_query as-is", () => {
-      expect(deserializeCardFromQuery(WRAPPED_B64)).toEqual({
-        dataset_query: MBQL_QUERY,
-      });
+    it("should strip /question# prefix and decode the payload", () => {
+      expect(deserializeCardFromQuery(`/question#${WRAPPED_B64}`)).toEqual(
+        CARD_PAYLOAD,
+      );
     });
   });
 });


### PR DESCRIPTION
closes EMB-1585

### Description

This PR is the stepping stone for the upcoming PRs. Especially `StaticQuestionInternal` and `InteractiveQuestionInternal`. These 2 components will be used in the next PRs.
### How to verify

I mean, just trust me, bro, or you could render `StaticQuestionInternal` (or the interactive version) with `query` prop which would look like `/question#<base64>` and see how it will render. I've already done this in the last PR which contains all the storybook for useMetabot hook which will inherently use these components under the hood.

### Demo

<img width="2467" height="1023" alt="image" src="https://github.com/user-attachments/assets/266952d2-893a-4773-bab0-70ad786fdb15" />

Here's the code part that they will be used later
<img width="832" height="661" alt="image" src="https://github.com/user-attachments/assets/0de26f62-0d9d-444c-a35d-394356c42eda" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
