### PR TITLE
Gdgt 2299 hide nested custom visualizations nav when dev mode setting is off

### DIFF
--- a/frontend/src/metabase/admin/routes.tsx
+++ b/frontend/src/metabase/admin/routes.tsx
@@ -1,3 +1,4 @@
+import type { Store } from "@reduxjs/toolkit";
 import { Fragment } from "react";
 import {
   IndexRedirect,
@@ -76,7 +77,7 @@ import {
 } from "./utils";
 
 export const getRoutes = (
-  store: { getState: () => State },
+  store: Store<State>,
   CanAccessSettings: RouteComponent,
   IsAdmin: RouteComponent,
 ) => {

--- a/frontend/src/metabase/admin/routes.tsx
+++ b/frontend/src/metabase/admin/routes.tsx
@@ -235,7 +235,7 @@ export const getRoutes = (
 
         {/* SETTINGS */}
         <Route path="settings" component={createAdminRouteGuard("settings")}>
-          {getSettingsRoutes()}
+          {getSettingsRoutes(store)}
         </Route>
         {/* PERMISSIONS */}
         <Route path="permissions" component={IsAdmin}>

--- a/frontend/src/metabase/admin/settings/components/SettingsNav/CustomVisualizationsNav.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsNav/CustomVisualizationsNav.tsx
@@ -1,0 +1,45 @@
+import { t } from "ttag";
+
+import { UpsellGem } from "metabase/common/components/upsells/components";
+import { useHasTokenFeature, useSetting } from "metabase/common/hooks";
+import { Flex } from "metabase/ui";
+
+import { SettingsNavItem } from "./SettingsNavItem";
+
+export const CustomVisualizationsNav = () => {
+  const hasCustomViz = useHasTokenFeature("custom-viz");
+  const customVizDevModeEnabled = useSetting(
+    "custom-viz-plugin-dev-mode-enabled",
+  );
+
+  const isFull = hasCustomViz && customVizDevModeEnabled;
+
+  return (
+    <SettingsNavItem
+      path={isFull ? undefined : "custom-visualizations"}
+      folderPattern="custom-visualizations"
+      label={
+        <Flex gap="sm" align="center">
+          <span>{t`Custom visualizations`}</span>
+          {!hasCustomViz && <UpsellGem />}
+        </Flex>
+      }
+      icon="bar"
+    >
+      {isFull && (
+        <>
+          <SettingsNavItem
+            key="manage"
+            path="custom-visualizations"
+            label={t`Manage visualizations`}
+          />
+          <SettingsNavItem
+            key="dev"
+            path="custom-visualizations/development"
+            label={t`Development`}
+          />
+        </>
+      )}
+    </SettingsNavItem>
+  );
+};

--- a/frontend/src/metabase/admin/settings/components/SettingsNav/SettingsNav.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsNav/SettingsNav.tsx
@@ -1,20 +1,16 @@
-import { useDisclosure } from "@mantine/hooks";
-import React, { type ReactElement } from "react";
+import React from "react";
 import { t } from "ttag";
 
-import {
-  AdminNavItem,
-  type AdminNavItemProps,
-  AdminNavWrapper,
-} from "metabase/admin/components/AdminNav";
+import { AdminNavWrapper } from "metabase/admin/components/AdminNav";
 import { UpsellGem } from "metabase/common/components/upsells/components/UpsellGem";
 import { useHasTokenFeature, useSetting } from "metabase/common/hooks";
 import { PLUGIN_REMOTE_SYNC } from "metabase/plugins";
-import { getLocation } from "metabase/selectors/routing";
 import { getUserIsAdmin } from "metabase/selectors/user";
 import { Divider, Flex } from "metabase/ui";
 import { useSelector } from "metabase/utils/redux";
 
+import { CustomVisualizationsNav } from "./CustomVisualizationsNav";
+import { SettingsNavItem } from "./SettingsNavItem";
 import { UpdatesNavItem } from "./UpdatesNavItem";
 
 const NavDivider = () => <Divider my="sm" />;
@@ -28,10 +24,6 @@ export function SettingsNav() {
   const hasScim = useHasTokenFeature("scim");
   const hasPythonTransforms = useHasTokenFeature("transforms-python");
   const isHosted = useSetting("is-hosted?");
-  const hasCustomViz = useHasTokenFeature("custom-viz");
-  const customVizDevModeEnabled = useSetting(
-    "custom-viz-plugin-dev-mode-enabled",
-  );
   const isAdmin = useSelector(getUserIsAdmin);
 
   return (
@@ -69,36 +61,7 @@ export function SettingsNav() {
         icon="globe"
       />
       {/* do not allow users with "Settings access" permissions to access custom viz pages */}
-      {isAdmin && (
-        <SettingsNavItem
-          path={!hasCustomViz ? "custom-visualizations" : undefined}
-          folderPattern="custom-visualizations"
-          label={
-            <Flex gap="sm" align="center">
-              <span>{t`Custom visualizations`}</span>
-              {!hasCustomViz && <UpsellGem />}
-            </Flex>
-          }
-          icon="bar"
-        >
-          {hasCustomViz && [
-            <SettingsNavItem
-              key="manage"
-              path="custom-visualizations"
-              label={t`Manage visualizations`}
-            />,
-            ...(customVizDevModeEnabled
-              ? [
-                  <SettingsNavItem
-                    key="dev"
-                    path="custom-visualizations/development"
-                    label={t`Development`}
-                  />,
-                ]
-              : []),
-          ]}
-        </SettingsNavItem>
-      )}
+      {isAdmin && <CustomVisualizationsNav />}
       <SettingsNavItem path="maps" label={t`Maps`} icon="pinmap" />
       <SettingsNavItem
         path={!hasWhitelabel ? "whitelabel" : undefined}
@@ -153,77 +116,5 @@ export function SettingsNav() {
         icon="cloud"
       />
     </AdminNavWrapper>
-  );
-}
-
-/**
- * Find the child whose path is the best (longest) prefix match for the current
- * pathname, or null if no child matches at all. An exact match always wins.
- */
-const findBestMatchingChild = (
-  children: ReactElement[],
-  pathname: string,
-): ReactElement | null => {
-  let best: ReactElement | null = null;
-  let bestLen = 0;
-
-  for (const child of children) {
-    const childPath = child?.props?.path as string | undefined;
-    if (!childPath) {
-      continue;
-    }
-    const full = `/admin/settings/${childPath}`;
-    if (pathname === full || pathname.startsWith(`${full}/`)) {
-      if (full.length > bestLen) {
-        best = child;
-        bestLen = full.length;
-      }
-    }
-  }
-
-  return best;
-};
-
-export function SettingsNavItem({
-  path,
-  folderPattern,
-  active: activeOverride,
-  children: childrenProp,
-  ...navItemProps
-}: AdminNavItemProps & { active?: boolean }) {
-  const children = React.Children.toArray(childrenProp) as ReactElement[];
-  const currentPath: string = useSelector(getLocation)?.pathname ?? "";
-  const [isOpen, { toggle: toggleOpen }] = useDisclosure(
-    folderPattern ? currentPath.includes(folderPattern) : false,
-  );
-
-  const bestChild = findBestMatchingChild(children, currentPath);
-  const hasActiveDescendant = bestChild != null;
-
-  const fullPath = `/admin/settings/${path}`;
-  const showActive =
-    activeOverride ??
-    ((!isOpen && hasActiveDescendant) || currentPath === fullPath);
-
-  return (
-    <AdminNavItem
-      data-testid={`settings-sidebar-link`}
-      path={path ? `/admin/settings/${path}` : ""}
-      folderPattern={folderPattern}
-      opened={isOpen}
-      active={showActive}
-      onClick={toggleOpen}
-      {...navItemProps}
-    >
-      {children.length > 0
-        ? children.map((child) =>
-            child?.props?.path
-              ? React.cloneElement(child, {
-                  active: child === bestChild,
-                } as any)
-              : child,
-          )
-        : childrenProp}
-    </AdminNavItem>
   );
 }

--- a/frontend/src/metabase/admin/settings/components/SettingsNav/SettingsNav.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsNav/SettingsNav.unit.spec.tsx
@@ -155,7 +155,7 @@ describe("SettingsNav", () => {
     });
     await userEvent.click(customVizNavItem);
 
-    expect(screen.getByText("Manage visualizations")).toBeInTheDocument();
+    expect(screen.queryByText("Manage visualizations")).not.toBeInTheDocument();
     expect(screen.queryByText("Development")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/admin/settings/components/SettingsNav/SettingsNavItem.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsNav/SettingsNavItem.tsx
@@ -1,0 +1,81 @@
+import { useDisclosure } from "@mantine/hooks";
+import React, { type ReactElement } from "react";
+
+import {
+  AdminNavItem,
+  type AdminNavItemProps,
+} from "metabase/admin/components/AdminNav";
+import { getLocation } from "metabase/selectors/routing";
+import { useSelector } from "metabase/utils/redux";
+
+/**
+ * Find the child whose path is the best (longest) prefix match for the current
+ * pathname, or null if no child matches at all. An exact match always wins.
+ */
+const findBestMatchingChild = (
+  children: ReactElement[],
+  pathname: string,
+): ReactElement | null => {
+  let best: ReactElement | null = null;
+  let bestLen = 0;
+
+  for (const child of children) {
+    const childPath = child?.props?.path as string | undefined;
+    if (!childPath) {
+      continue;
+    }
+    const full = `/admin/settings/${childPath}`;
+    if (pathname === full || pathname.startsWith(`${full}/`)) {
+      if (full.length > bestLen) {
+        best = child;
+        bestLen = full.length;
+      }
+    }
+  }
+
+  return best;
+};
+
+export function SettingsNavItem({
+  path,
+  folderPattern,
+  active: activeOverride,
+  children: childrenProp,
+  ...navItemProps
+}: AdminNavItemProps & { active?: boolean }) {
+  const children = React.Children.toArray(childrenProp) as ReactElement[];
+  const currentPath: string = useSelector(getLocation)?.pathname ?? "";
+  const [isOpen, { toggle: toggleOpen }] = useDisclosure(
+    folderPattern ? currentPath.includes(folderPattern) : false,
+  );
+
+  const bestChild = findBestMatchingChild(children, currentPath);
+  const hasActiveDescendant = bestChild != null;
+
+  const fullPath = `/admin/settings/${path}`;
+  const showActive =
+    activeOverride ??
+    ((!isOpen && hasActiveDescendant) || currentPath === fullPath);
+
+  return (
+    <AdminNavItem
+      data-testid={`settings-sidebar-link`}
+      path={path ? `/admin/settings/${path}` : ""}
+      folderPattern={folderPattern}
+      opened={isOpen}
+      active={showActive}
+      onClick={toggleOpen}
+      {...navItemProps}
+    >
+      {children.length > 0
+        ? children.map((child) =>
+            child?.props?.path
+              ? React.cloneElement(child, {
+                  active: child === bestChild,
+                } as any)
+              : child,
+          )
+        : childrenProp}
+    </AdminNavItem>
+  );
+}

--- a/frontend/src/metabase/admin/settings/components/SettingsNav/UpdatesNavItem.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsNav/UpdatesNavItem.tsx
@@ -6,7 +6,7 @@ import { Indicator } from "metabase/ui";
 import { useSelector } from "metabase/utils/redux";
 import { newVersionAvailable } from "metabase/utils/version";
 
-import { SettingsNavItem } from "./SettingsNav";
+import { SettingsNavItem } from "./SettingsNavItem";
 
 export function UpdatesNavItem() {
   const { data: versionInfo } = useGetVersionInfoQuery();

--- a/frontend/src/metabase/admin/settings/components/SettingsNav/index.ts
+++ b/frontend/src/metabase/admin/settings/components/SettingsNav/index.ts
@@ -1,1 +1,2 @@
 export * from "./SettingsNav";
+export * from "./SettingsNavItem";

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/CustomVisualizationsSettingsPage.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/CustomVisualizationsSettingsPage.tsx
@@ -2,7 +2,7 @@ import { t } from "ttag";
 
 import { SettingsPageWrapper } from "metabase/admin/components/SettingsSection";
 import { UpsellCustomViz } from "metabase/admin/upsells";
-import { useHasTokenFeature, useSetting } from "metabase/common/hooks";
+import { useHasTokenFeature } from "metabase/common/hooks";
 import { PLUGIN_CUSTOM_VIZ } from "metabase/plugins";
 
 export function CustomVisualizationsManagePage() {
@@ -39,7 +39,6 @@ export function CustomVisualizationsFormPage({
 
 export function CustomVisualizationsDevelopmentPage() {
   const hasCustomViz = useHasTokenFeature("custom-viz");
-  const devModeEnabled = useSetting("custom-viz-plugin-dev-mode-enabled");
 
   if (!hasCustomViz) {
     return (
@@ -48,10 +47,5 @@ export function CustomVisualizationsDevelopmentPage() {
       </SettingsPageWrapper>
     );
   }
-
-  if (!devModeEnabled) {
-    return null;
-  }
-
   return <PLUGIN_CUSTOM_VIZ.CustomVizDevPage />;
 }

--- a/frontend/src/metabase/admin/settings/tests/setup.tsx
+++ b/frontend/src/metabase/admin/settings/tests/setup.tsx
@@ -172,7 +172,9 @@ export const setup = async ({
   }
 
   renderWithProviders(
-    <Route path="admin/settings">{getSettingsRoutes()}</Route>,
+    <Route path="admin/settings">
+      {getSettingsRoutes({ getState: () => store })}
+    </Route>,
     {
       storeInitialState: store,
       withRouter: true,

--- a/frontend/src/metabase/admin/settings/tests/setup.tsx
+++ b/frontend/src/metabase/admin/settings/tests/setup.tsx
@@ -1,3 +1,4 @@
+import { render as testingLibraryRender } from "@testing-library/react";
 import fetchMock from "fetch-mock";
 import { Route } from "react-router";
 
@@ -21,7 +22,7 @@ import {
 } from "__support__/server-mocks";
 import { setupWebhookChannelsEndpoint } from "__support__/server-mocks/channel";
 import { mockSettings } from "__support__/settings";
-import { renderWithProviders, screen } from "__support__/ui";
+import { getTestStoreAndWrapper, screen } from "__support__/ui";
 import { getSettingsRoutes } from "metabase/admin/settingsRoutes";
 import { createMockState } from "metabase/redux/store/mocks";
 import type { TokenFeature, TokenFeatures } from "metabase-types/api";
@@ -157,7 +158,7 @@ export const setup = async ({
     is_superuser: isAdmin,
   });
 
-  const store = createMockState({
+  const initialState = createMockState({
     currentUser: user,
     settings: mockSettings(settings),
   });
@@ -171,15 +172,15 @@ export const setup = async ({
     setupTokenStatusEndpoint({ valid: hasTokenFeatures });
   }
 
-  renderWithProviders(
-    <Route path="admin/settings">
-      {getSettingsRoutes({ getState: () => store })}
-    </Route>,
-    {
-      storeInitialState: store,
-      withRouter: true,
-      initialRoute: `/admin/settings${initialRoute}`,
-    },
+  const { wrapper, store } = getTestStoreAndWrapper({
+    storeInitialState: initialState,
+    withRouter: true,
+    initialRoute: `/admin/settings${initialRoute}`,
+  });
+
+  testingLibraryRender(
+    <Route path="admin/settings">{getSettingsRoutes(store)}</Route>,
+    { wrapper },
   );
 
   await screen.findByTestId("admin-layout-content");

--- a/frontend/src/metabase/admin/settingsRoutes.tsx
+++ b/frontend/src/metabase/admin/settingsRoutes.tsx
@@ -1,3 +1,4 @@
+import type { Store } from "@reduxjs/toolkit";
 import { IndexRedirect, IndexRoute, Route } from "react-router";
 
 import { AdminSettingsLayout } from "metabase/common/components/AdminLayout/AdminSettingsLayout";

--- a/frontend/src/metabase/admin/settingsRoutes.tsx
+++ b/frontend/src/metabase/admin/settingsRoutes.tsx
@@ -7,7 +7,9 @@ import {
   PLUGIN_REMOTE_SYNC,
   PLUGIN_TRANSFORMS_PYTHON,
 } from "metabase/plugins";
+import type { State } from "metabase/redux/store";
 import { IsAdmin } from "metabase/route-guards";
+import { getSetting } from "metabase/selectors/settings";
 
 import { GoogleAuthForm } from "./settings/auth/components/GoogleAuthForm";
 import { SettingsLdapForm } from "./settings/components/SettingsLdapForm";
@@ -31,86 +33,95 @@ import { UpdatesSettingsPage } from "./settings/components/SettingsPages/Updates
 import { UploadSettingsPage } from "./settings/components/SettingsPages/UploadSettingsPage";
 import { WebhooksSettingsPage } from "./settings/components/SettingsPages/WebhooksSettingsPage";
 
-export const getSettingsRoutes = () => (
-  <Route
-    component={({ children }) => (
-      <AdminSettingsLayout sidebar={<SettingsNav />}>
-        {children}
-      </AdminSettingsLayout>
-    )}
-  >
-    <IndexRedirect to="general" />
-    <Route path="general" component={GeneralSettingsPage} />
-    <Route path="updates" component={UpdatesSettingsPage} />
-    <Route path="email" component={EmailSettingsPage} />
-    <Route path="slack" component={SlackSettingsPage} />
-    <Route path="webhooks" component={WebhooksSettingsPage} />
+export const getSettingsRoutes = (store: { getState: () => State }) => {
+  const devModeEnabled = getSetting(
+    store.getState(),
+    "custom-viz-plugin-dev-mode-enabled",
+  );
+
+  return (
     <Route
-      path="authentication"
-      component={() => <AuthenticationSettingsPage tab="authentication" />}
-    />
-    <Route
-      path="authentication/user-provisioning"
-      component={() => <AuthenticationSettingsPage tab="user-provisioning" />}
-    />
-    <Route
-      path="authentication/api-keys"
-      component={() => <AuthenticationSettingsPage tab="api-keys" />}
-    />
-    <Route path="authentication/google" component={GoogleAuthForm} />
-    <Route path="authentication/ldap" component={SettingsLdapForm} />
-    <Route
-      path="authentication/saml"
-      component={() => <PLUGIN_AUTH_PROVIDERS.SettingsSAMLForm />}
-    />
-    <Route
-      path="authentication/jwt"
-      component={() => <PLUGIN_AUTH_PROVIDERS.SettingsJWTForm />}
-    />
-    <Route
-      path="authentication/oidc"
-      component={() => <PLUGIN_AUTH_PROVIDERS.SettingsOIDCForm />}
-    />
-    <Route
-      path="remote-sync"
-      component={() => <PLUGIN_REMOTE_SYNC.RemoteSyncSettings />}
-    />
-    <Route path="maps" component={MapsSettingsPage} />
-    <Route path="localization" component={LocalizationSettingsPage} />
-    <Route
-      path="custom-visualizations"
-      /* do not allow users with "Settings access" permissions to access custom viz pages */
-      component={IsAdmin}
+      component={({ children }) => (
+        <AdminSettingsLayout sidebar={<SettingsNav />}>
+          {children}
+        </AdminSettingsLayout>
+      )}
     >
-      <IndexRoute component={CustomVisualizationsManagePage} />
-      <Route path="new" component={CustomVisualizationsFormPage} />
-      <Route path="edit/:id" component={CustomVisualizationsFormPage} />
+      <IndexRedirect to="general" />
+      <Route path="general" component={GeneralSettingsPage} />
+      <Route path="updates" component={UpdatesSettingsPage} />
+      <Route path="email" component={EmailSettingsPage} />
+      <Route path="slack" component={SlackSettingsPage} />
+      <Route path="webhooks" component={WebhooksSettingsPage} />
       <Route
-        path="development"
-        component={CustomVisualizationsDevelopmentPage}
+        path="authentication"
+        component={() => <AuthenticationSettingsPage tab="authentication" />}
       />
+      <Route
+        path="authentication/user-provisioning"
+        component={() => <AuthenticationSettingsPage tab="user-provisioning" />}
+      />
+      <Route
+        path="authentication/api-keys"
+        component={() => <AuthenticationSettingsPage tab="api-keys" />}
+      />
+      <Route path="authentication/google" component={GoogleAuthForm} />
+      <Route path="authentication/ldap" component={SettingsLdapForm} />
+      <Route
+        path="authentication/saml"
+        component={() => <PLUGIN_AUTH_PROVIDERS.SettingsSAMLForm />}
+      />
+      <Route
+        path="authentication/jwt"
+        component={() => <PLUGIN_AUTH_PROVIDERS.SettingsJWTForm />}
+      />
+      <Route
+        path="authentication/oidc"
+        component={() => <PLUGIN_AUTH_PROVIDERS.SettingsOIDCForm />}
+      />
+      <Route
+        path="remote-sync"
+        component={() => <PLUGIN_REMOTE_SYNC.RemoteSyncSettings />}
+      />
+      <Route path="maps" component={MapsSettingsPage} />
+      <Route path="localization" component={LocalizationSettingsPage} />
+      <Route
+        path="custom-visualizations"
+        /* do not allow users with "Settings access" permissions to access custom viz pages */
+        component={IsAdmin}
+      >
+        <IndexRoute component={CustomVisualizationsManagePage} />
+        <Route path="new" component={CustomVisualizationsFormPage} />
+        <Route path="edit/:id" component={CustomVisualizationsFormPage} />
+        {devModeEnabled && (
+          <Route
+            path="development"
+            component={CustomVisualizationsDevelopmentPage}
+          />
+        )}
+      </Route>
+      <Route path="uploads" component={UploadSettingsPage} />
+      <Route
+        path="python-runner"
+        component={PLUGIN_TRANSFORMS_PYTHON.PythonRunnerSettingsPage}
+      />
+      <Route path="public-sharing" component={PublicSharingSettingsPage} />
+      <Route path="license" component={LicenseSettingsPage} />
+      <Route path="appearance" component={() => <AppearanceSettingsPage />} />
+      <Route
+        path="whitelabel"
+        component={() => <AppearanceSettingsPage tab="branding" />}
+      />
+      <Route
+        path="whitelabel/branding"
+        component={() => <AppearanceSettingsPage tab="branding" />}
+      />
+      <Route
+        path="whitelabel/conceal-metabase"
+        component={() => <AppearanceSettingsPage tab="conceal-metabase" />}
+      />
+      <Route path="cloud" component={CloudSettingsPage} />
+      <Route path="*" component={NotFound} />
     </Route>
-    <Route path="uploads" component={UploadSettingsPage} />
-    <Route
-      path="python-runner"
-      component={PLUGIN_TRANSFORMS_PYTHON.PythonRunnerSettingsPage}
-    />
-    <Route path="public-sharing" component={PublicSharingSettingsPage} />
-    <Route path="license" component={LicenseSettingsPage} />
-    <Route path="appearance" component={() => <AppearanceSettingsPage />} />
-    <Route
-      path="whitelabel"
-      component={() => <AppearanceSettingsPage tab="branding" />}
-    />
-    <Route
-      path="whitelabel/branding"
-      component={() => <AppearanceSettingsPage tab="branding" />}
-    />
-    <Route
-      path="whitelabel/conceal-metabase"
-      component={() => <AppearanceSettingsPage tab="conceal-metabase" />}
-    />
-    <Route path="cloud" component={CloudSettingsPage} />
-    <Route path="*" component={NotFound} />
-  </Route>
-);
+  );
+};

--- a/frontend/src/metabase/admin/settingsRoutes.tsx
+++ b/frontend/src/metabase/admin/settingsRoutes.tsx
@@ -33,7 +33,7 @@ import { UpdatesSettingsPage } from "./settings/components/SettingsPages/Updates
 import { UploadSettingsPage } from "./settings/components/SettingsPages/UploadSettingsPage";
 import { WebhooksSettingsPage } from "./settings/components/SettingsPages/WebhooksSettingsPage";
 
-export const getSettingsRoutes = (store: { getState: () => State }) => {
+export const getSettingsRoutes = (store: Store<State>) => {
   const devModeEnabled = getSetting(
     store.getState(),
     "custom-viz-plugin-dev-mode-enabled",


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/pull/72620/changes#r3092394679

### Description
Omits nested "Manage visualizations" if `custom-viz-plugin-dev-mode-enabled` setting is disabled. Additionally, provides 404 guard instead of empty content rendering - addressing this comment https://github.com/metabase/metabase/pull/72620/changes#r3092394679

### Demo

Before:
<img width="1728" height="781" alt="image" src="https://github.com/user-attachments/assets/b7f2c045-c4e2-4829-a613-52a17b00f296" />


After: 
<img width="1725" height="735" alt="image" src="https://github.com/user-attachments/assets/4dac9b25-fb33-4ec4-8f8d-78089b537734" />
