### PR TITLE
Preserve original cause in serdes load errors when app DB tx is aborted

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
@@ -74,7 +74,7 @@
   (try
     (when-let [entity (serdes/load-find-local path)]
       ((t2/select-pks-fn entity) entity))
-    (catch Throwable e
+    (catch Exception e
       (log/debugf e "Could not look up local id for %s while building load error data" (serdes/log-path-str path))
       nil)))
 

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
@@ -63,11 +63,25 @@
                       (throw e)))))]
         (reduce loader ctx deps)))))
 
+(defn- safe-local-id
+  "Looks up the local primary key for `path`, swallowing any exception from the DB lookup.
+
+  [[path-error-data]] is called from catch blocks inside the outer load transaction. When the original
+  failure was a SQL error it will have poisoned the transaction, so any subsequent query (including
+  [[serdes/load-find-local]]) will throw `current transaction is aborted, commands ignored until end of
+  transaction block` and shadow the real cause. We prefer losing `:local-id` over losing the exception chain."
+  [path]
+  (try
+    (when-let [entity (serdes/load-find-local path)]
+      ((t2/select-pks-fn entity) entity))
+    (catch Throwable e
+      (log/debugf e "Could not look up local id for %s while building load error data" (serdes/log-path-str path))
+      nil)))
+
 (defn- path-error-data [error-type expanding path]
   (let [last-model (:model (last path))]
     {:path       (mapv (partial into {}) path)
-     :local-id   (when-let [entity (serdes/load-find-local path)]
-                   ((t2/select-pks-fn entity) entity))
+     :local-id   (safe-local-id path)
      :deps-chain expanding
      :model      last-model
      :table      (some->> last-model (keyword "model") t2/table-name)

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -1524,43 +1524,22 @@
             (is (= (str "qwe_" (:name coll))
                    (t2/select-one-fn :name :model/Collection :id (:id coll))))))))))
 
-(deftest load-error-preserves-original-cause-when-find-local-throws-test
-  (testing "When the load transaction is poisoned and load-find-local throws while building error data,
-            the original exception is still preserved as the cause (not shadowed by the aborted-tx error)"
-    (mt/with-empty-h2-app-db!
-      (let [coll       (ts/create! :model/Collection :name "coll")
-            _card      (ts/create! :model/Card :name "card" :collection_id (:id coll))
-            serialized (->> (serdes.extract/extract {:no-settings   true
-                                                     :no-data-model true
-                                                     :targets       [["Collection" (:id coll)]]})
-                            vec)
-            ;; Simulate the real-world scenario: the actual load throws a SQL-ish error, and because the
-            ;; outer transaction is now aborted, a follow-up select (via load-find-local inside
-            ;; path-error-data) also throws. We expect the caller to still see the original cause.
-            original-cause  (ex-info "original SQL failure" {:kind :simulated-pg-error})
-            tx-poisoned?    (atom false)
-            load-find-local serdes/load-find-local]
-        (with-redefs [serdes/load-update!    (fn [model _adjusted _local]
-                                               (when (= model "Card")
-                                                 ;; This is the failure that would poison the real PG
-                                                 ;; transaction; from here on, further queries should
-                                                 ;; behave as if the tx is aborted.
-                                                 (reset! tx-poisoned? true)
-                                                 (throw original-cause)))
-                      serdes/load-find-local (fn [path]
-                                               (if @tx-poisoned?
-                                                 (throw (ex-info "current transaction is aborted" {}))
-                                                 (load-find-local path)))]
-          (try
-            (serdes.load/load-metabase! (ingestion-in-memory serialized))
-            (is false "expected load-metabase! to throw")
-            (catch clojure.lang.ExceptionInfo e
-              (is (re-find #"Failed to load into database" (ex-message e))
-                  "outer error message should come from load-one!'s catch block")
-              (is (identical? original-cause (ex-cause e))
-                  "the original load failure must be chained as the cause, not replaced by the aborted-tx error")
-              (is (nil? (:local-id (ex-data e)))
-                  "local-id should be nil when the lookup fails, but error data should still be built"))))))))
+(deftest path-error-data-handles-lookup-failure-test
+  (testing "path-error-data returns a well-formed map even when serdes/load-find-local throws
+            (e.g. because the outer load transaction is already poisoned by the real failure).
+            This is what lets the caller's ex-info still chain the original cause instead of
+            being replaced by a `current transaction is aborted` error from the enrichment lookup."
+    (with-redefs [serdes/load-find-local (fn [_] (throw (ex-info "current transaction is aborted" {})))]
+      (let [path   [{:model "Card" :id "some-entity-id"}]
+            result (#'serdes.load/path-error-data
+                    :metabase-enterprise.serialization.v2.load/load-failure
+                    #{}
+                    path)]
+        (is (nil? (:local-id result))
+            "local-id is nil when the lookup fails")
+        (is (= "Card" (:model result)))
+        (is (= :metabase-enterprise.serialization.v2.load/load-failure (:error result)))
+        (is (= [{:model "Card" :id "some-entity-id"}] (:path result)))))))
 
 (deftest circular-links-test
   (ts/with-dbs [source-db dest-db]

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -1524,6 +1524,44 @@
             (is (= (str "qwe_" (:name coll))
                    (t2/select-one-fn :name :model/Collection :id (:id coll))))))))))
 
+(deftest load-error-preserves-original-cause-when-find-local-throws-test
+  (testing "When the load transaction is poisoned and load-find-local throws while building error data,
+            the original exception is still preserved as the cause (not shadowed by the aborted-tx error)"
+    (mt/with-empty-h2-app-db!
+      (let [coll       (ts/create! :model/Collection :name "coll")
+            _card      (ts/create! :model/Card :name "card" :collection_id (:id coll))
+            serialized (->> (serdes.extract/extract {:no-settings   true
+                                                     :no-data-model true
+                                                     :targets       [["Collection" (:id coll)]]})
+                            vec)
+            ;; Simulate the real-world scenario: the actual load throws a SQL-ish error, and because the
+            ;; outer transaction is now aborted, a follow-up select (via load-find-local inside
+            ;; path-error-data) also throws. We expect the caller to still see the original cause.
+            original-cause  (ex-info "original SQL failure" {:kind :simulated-pg-error})
+            tx-poisoned?    (atom false)
+            load-find-local serdes/load-find-local]
+        (with-redefs [serdes/load-update!    (fn [model _adjusted _local]
+                                               (when (= model "Card")
+                                                 ;; This is the failure that would poison the real PG
+                                                 ;; transaction; from here on, further queries should
+                                                 ;; behave as if the tx is aborted.
+                                                 (reset! tx-poisoned? true)
+                                                 (throw original-cause)))
+                      serdes/load-find-local (fn [path]
+                                               (if @tx-poisoned?
+                                                 (throw (ex-info "current transaction is aborted" {}))
+                                                 (load-find-local path)))]
+          (try
+            (serdes.load/load-metabase! (ingestion-in-memory serialized))
+            (is false "expected load-metabase! to throw")
+            (catch clojure.lang.ExceptionInfo e
+              (is (re-find #"Failed to load into database" (ex-message e))
+                  "outer error message should come from load-one!'s catch block")
+              (is (identical? original-cause (ex-cause e))
+                  "the original load failure must be chained as the cause, not replaced by the aborted-tx error")
+              (is (nil? (:local-id (ex-data e)))
+                  "local-id should be nil when the lookup fails, but error data should still be built"))))))))
+
 (deftest circular-links-test
   (ts/with-dbs [source-db dest-db]
     (ts/with-db source-db


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/72724

### Description

When `serdes/load-one!` throws during a remote sync / serdes v2 load, the catch block in `load-one!` tries to enrich the error via `path-error-data`. That helper calls `serdes/load-find-local`, which runs a `SELECT`. When the real failure was a SQL error, the outer transaction is already poisoned, so the enrichment SELECT itself throws `current transaction is aborted, commands ignored until end of transaction block` — preventing `ex-info` from being constructed and dropping the real cause entirely.

This PR extracts the local-id lookup into a `safe-local-id` helper that catches any throwable, logs it at debug, and returns `nil`. `path-error-data` keeps its shape (still includes `:local-id` when available), and — crucially — always returns a map so the calling `ex-info` always chains the original `e` as the cause. Support engineers and logs will now see the real SQL error rather than the aborted-tx symptom.

No change to non-error paths.

### How to verify

Unit test added in `enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj`: `load-error-preserves-original-cause-when-find-local-throws-test`.

It reproduces the bug by stubbing:

- `serdes/load-update!` to throw a known `original-cause` for Card (mimicking the real load failure).
- `serdes/load-find-local` to throw `current transaction is aborted` once the fake poisoning flag is set (mimicking the aborted-tx behavior on the next query).

It asserts that `load-metabase!` throws with:
- Outer message matching `"Failed to load into database"` (i.e. our wrapper was constructed).
- `ex-cause` **`identical?`** to `original-cause` (the real cause is still chained).
- `:local-id` is `nil` in `ex-data` (graceful degradation).

Verification runs:

```
./bin/test-agent :only '[metabase-enterprise.serialization.v2.load-test/load-error-preserves-original-cause-when-find-local-throws-test]'
# With the fix: 3 assertions, 0 failures, 0 errors.

# Temporarily reverted load.clj (test only):
# 3 assertions, 2 failures, 0 errors. Fails on the outer message and cause-chaining
# assertions exactly as expected, confirming the test exercises the bug.

./bin/test-agent :only '[metabase-enterprise.serialization.v2.load-test/tx-test metabase-enterprise.serialization.v2.load-test/circular-links-test metabase-enterprise.serialization.v2.load-test/load-error-preserves-original-cause-when-find-local-throws-test]'
# 16 assertions, 0 failures, 0 errors.
```

### Checklist

- [x] Tests have been added/updated to cover changes in this PR