### PR TITLE
Fix metabot button overlap on transform screen

### DIFF
--- a/e2e/test/scenarios/metrics/metrics-editing.cy.spec.js
+++ b/e2e/test/scenarios/metrics/metrics-editing.cy.spec.js
@@ -515,7 +515,8 @@ describe("scenarios > metrics > editing", () => {
 
       cy.viewport(800, 600);
       H.getNotebookStep("summarize").within(() => {
-        cy.findByText("Formula").should("be.visible");
+        // We need the scroll because of the viewport change, the next findByText is technically off the screen without it
+        cy.findByText("Formula").should("be.visible").scrollIntoView({});
         cy.findAllByText("Default time dimension")
           .filter(":visible")
           .should("have.length", 1);

--- a/frontend/src/metabase/data-studio/common/components/PaneHeader/PaneHeader.module.css
+++ b/frontend/src/metabase/data-studio/common/components/PaneHeader/PaneHeader.module.css
@@ -1,4 +1,4 @@
-.ProfileLink {
+.ButtonGroup {
   /* This is to keep the app switcher position a consistent space away
      from the right when the window is smaller than the data studio
      typically allows. Once we have a more responsive data studio layout

--- a/frontend/src/metabase/data-studio/common/components/PaneHeader/PaneHeader.tsx
+++ b/frontend/src/metabase/data-studio/common/components/PaneHeader/PaneHeader.tsx
@@ -48,12 +48,12 @@ export const PaneHeader = ({
 }: PaneHeaderProps) => {
   return (
     <Stack gap={0} pt="xs" {...rest}>
-      <Flex mb="lg" mt="md" w="100%">
+      <Flex mb="lg" mt="md" w="100%" h="xl">
         {breadcrumbs}
 
-        <Group ml="auto" gap="md">
+        <Group ml="auto" gap="md" className={S.ButtonGroup}>
           {showMetabotButton && <MetabotDataStudioButton />}
-          {showAppSwitcher && <AppSwitcher className={S.ProfileLink} />}
+          {showAppSwitcher && <AppSwitcher />}
         </Group>
       </Flex>
       <Group


### PR DESCRIPTION
### Description
Small adjustment to stop the Data Studio Panel header Metabot button from overlapping with the App Switcher. Honestly I hate this fix, but it's required because the Table page has a minimum width and we want the App Switcher to stay stuck to the top right corner of the screen.

### How to verify
1. Open the Data Studio and go to the transform page. Make sure you can see the metabot button
2. Resize the window. When it gets small enough, The button group should switch to fixed positioning, but the transition should be seemless

### Demo


https://github.com/user-attachments/assets/f234fc88-2db5-423c-a9a4-83ad133c680d



### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~
