### PR TITLE
fix: do not disable agent api and mcp when not configured

### DIFF
--- a/frontend/src/metabase/metabot/components/MetabotAdmin/AISettingsPage.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotAdmin/AISettingsPage.tsx
@@ -18,7 +18,7 @@ import {
   PLUGIN_EMBEDDING_SDK,
 } from "metabase/plugins";
 import { useRouter } from "metabase/router/useRouter";
-import { Flex, Stack, Switch, Tabs } from "metabase/ui";
+import { Divider, Flex, Stack, Switch, Tabs } from "metabase/ui";
 import type { MetabotInfo } from "metabase-types/api";
 
 import { McpAppsSettings } from "./McpAppsSettings";
@@ -102,29 +102,31 @@ export function AISettingsPage() {
         <>
           <MetabotSetup id={SETUP_SECTION_ID} />
           <DisabledSection disabled={!isConfigured}>
-            <Stack gap="lg">
-              <MetabotSettingsSection
-                hasEmbedding={hasEmbedding}
-                id={METABOT_SECTION_ID}
-                selectedTab={selectedTab}
-              />
-
-              <McpAppsSettings id={MCP_SECTION_ID} />
-
-              <ToggleSettingsSection
-                checked={isAgentApiEnabled}
-                description={jt`Enable external access to the Agent API. ${(
-                  <ExternalLink key="docs" href={agentApiDocsUrl}>
-                    {t`Learn more`}
-                  </ExternalLink>
-                )}`}
-                disabled={isUpdatingAgentApi}
-                id={AGENT_API_SECTION_ID}
-                onChange={handleAgentApiChange}
-                title={t`Agent API`}
-              />
-            </Stack>
+            <MetabotSettingsSection
+              hasEmbedding={hasEmbedding}
+              id={METABOT_SECTION_ID}
+              selectedTab={selectedTab}
+            />
           </DisabledSection>
+          <Divider />
+          <Stack gap="lg">
+            <McpAppsSettings id={MCP_SECTION_ID} />
+
+            <ToggleSettingsSection
+              checked={isAgentApiEnabled}
+              description={jt`Enable external access to the Agent API. ${(
+                <ExternalLink key="docs" href={agentApiDocsUrl}>
+                  {t`Learn more`}
+                </ExternalLink>
+              )}`}
+              disabled={isUpdatingAgentApi}
+              id={AGENT_API_SECTION_ID}
+              onChange={handleAgentApiChange}
+              title={t`Agent API`}
+            />
+          </Stack>
+
+          <Divider />
         </>
       )}
 

--- a/frontend/src/metabase/metabot/components/MetabotAdmin/AISettingsPage.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotAdmin/AISettingsPage.unit.spec.tsx
@@ -131,6 +131,7 @@ describe("AISettingsPage", () => {
     expect(screen.getByText("Metabot settings")).toBeInTheDocument();
     expect(screen.getByText("Enable Metabot")).toBeInTheDocument();
     expect(screen.getByText("MCP server")).toBeInTheDocument();
+    expect(screen.getByText("Agent API")).toBeInTheDocument();
 
     expect(
       screen.getByText("Enable Metabot", {
@@ -138,11 +139,15 @@ describe("AISettingsPage", () => {
       }),
     ).toBeInTheDocument();
     expect(
-      screen.getByText("MCP server", {
+      screen.queryByText("MCP server", {
         selector: '[aria-disabled="true"] *',
       }),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Agent API")).toBeInTheDocument();
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Agent API", {
+        selector: '[aria-disabled="true"] *',
+      }),
+    ).not.toBeInTheDocument();
   });
 
   it("shows docs links for MCP and Agent API", async () => {


### PR DESCRIPTION
Closes [BOT-1333: MCP toggle requires Anthropic key to enable](https://linear.app/metabase/issue/BOT-1333/mcp-toggle-requires-anthropic-key-to-enable)

### Description

The section was accidentally hidden when no llm is configured. It was not a requirement for the features to be enabled.

### How to verify

1. Disconnect from the LLM provider

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
