### PR TITLE
Fix Metrics Viewer "No compatible dimensions" error

### DIFF
--- a/e2e/test/scenarios/metrics/metrics-explorer.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/metrics-explorer.cy.spec.ts
@@ -1597,6 +1597,38 @@ describe("scenarios > metrics > explorer", () => {
     });
   });
 
+  describe("Dimension filters", () => {
+    beforeEach(() => {
+      interceptDatasetQuery();
+      H.MetricsViewer.goToViewer();
+    });
+
+    it("should not show 'No compatible dimensions' after deleting and retyping an expression with metrics in a different order (UXW-3748)", () => {
+      cy.log("Create expression: Count of orders + Count of products");
+      addMetricMath([
+        { metricName: "Count of orders" },
+        "+",
+        { metricName: "Count of products" },
+      ]);
+      cy.wait("@dataset");
+      H.MetricsViewer.getMetricVisualization().should("be.visible");
+
+      cy.log(
+        "Re-enter the formula editor, delete the whole expression, retype with metrics in the opposite order",
+      );
+      H.MetricsViewer.searchInput().clear();
+      addMetricMath([
+        { metricName: "Count of products" },
+        "+",
+        { metricName: "Count of orders" },
+      ]);
+      cy.wait("@dataset");
+
+      cy.log("Expression should run without 'No compatible dimensions' error");
+      H.MetricsViewer.getMetricVisualization().should("be.visible");
+    });
+  });
+
   describe("metric math", () => {
     beforeEach(() => {
       interceptDatasetQuery();

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/metricTokenHighlight.ts
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/metricTokenHighlight.ts
@@ -55,7 +55,7 @@ class MetricIdentity extends RangeValue {
   constructor(
     readonly sourceId: MetricSourceId,
     readonly definition: MetricDefinition | null,
-    readonly slotIndex: number,
+    readonly slotIndex: number | undefined,
   ) {
     super();
   }

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/useFormulaEditor.ts
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/MetricSearchInput/useFormulaEditor.ts
@@ -381,14 +381,6 @@ export function useFormulaEditor({
         : replaceFrom;
       const metricTo = metricFrom + metricName.length;
 
-      const existingIdentities = readMetricIdentities(view);
-      const nextSlotIndex =
-        existingIdentities.length > 0
-          ? Math.max(...existingIdentities.map((i) => i.slotIndex)) + 1
-          : 0;
-
-      const definition = definitionsRef.current[sourceId]?.definition ?? null;
-
       // Dispatch through the view (not setEditText) — the value-prop sync
       // in @uiw/react-codemirror does a full doc replacement that destroys
       // all RangeSet-tracked identities.
@@ -399,8 +391,7 @@ export function useFormulaEditor({
           from: metricFrom,
           to: metricTo,
           sourceId,
-          definition,
-          slotIndex: nextSlotIndex,
+          definition: null,
         }),
       });
 

--- a/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.ts
+++ b/frontend/src/metabase/metrics-viewer/components/MetricSearch/utils.ts
@@ -1000,7 +1000,7 @@ export type MetricIdentityEntry = {
   from: number;
   to: number;
   definition: MetricDefinition | null;
-  slotIndex: number;
+  slotIndex?: number;
 };
 
 export function stripDefinitionProjections(
@@ -1032,7 +1032,7 @@ export function applyTrackedDefinitions(
 ): ApplyTrackedDefinitionsResult {
   const identityByPosition = new Map<
     string,
-    { definition: MetricDefinition | null; slotIndex: number }
+    { definition: MetricDefinition | null; slotIndex: number | undefined }
   >();
   for (const identity of trackedIdentities) {
     identityByPosition.set(getPositionKey(identity.from, identity.to), {
@@ -1060,13 +1060,12 @@ export function applyTrackedDefinitions(
       const newSlotIndex = newSlotCounter++;
       const key = getPositionKey(visit.positioned.from, visit.positioned.to);
       const tracked = identityByPosition.get(key);
-
-      if (tracked) {
-        slotMapping.set(tracked.slotIndex, newSlotIndex);
-      }
-
       if (!tracked) {
         return;
+      }
+
+      if (tracked.slotIndex != null) {
+        slotMapping.set(tracked.slotIndex, newSlotIndex);
       }
 
       if (visit.kind === "standalone") {

--- a/frontend/src/metabase/metrics-viewer/components/MetricsViewerTabs/MetricsViewerTabContent/MetricsViewerTabContent.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricsViewerTabs/MetricsViewerTabContent/MetricsViewerTabContent.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useMemo } from "react";
 
-import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
-import { Center, Flex, Stack } from "metabase/ui";
+import { Box, Flex, Stack } from "metabase/ui";
 import { getObjectKeys, getObjectValues } from "metabase/utils/objects";
 import { isNotNull } from "metabase/utils/types";
 import type { DimensionMetadata, MetricDefinition } from "metabase-lib/metric";
@@ -27,6 +26,7 @@ import type { DimensionFilterValue } from "../../../utils/dimension-filters";
 import type { MetricSlot } from "../../../utils/metric-slots";
 import { buildDimensionItemsFromDefinitions } from "../../../utils/series";
 import { DISPLAY_TYPE_REGISTRY, getTabConfig } from "../../../utils/tab-config";
+import { DimensionPillBar } from "../../DimensionPillBar";
 import { MetricControls } from "../../MetricControls";
 import { MetricsViewerVisualization } from "../../MetricsViewerVisualization";
 
@@ -185,34 +185,25 @@ export function MetricsViewerTabContent({
     DISPLAY_TYPE_REGISTRY[tab.display].supportsStacking && rawSeries.length > 1;
 
   const isTimeTab = tab.type === "time";
+
+  const tabConfig = getTabConfig(tab.type);
+  const hasAnyOptions = dimensionItems.some((item) =>
+    item.type === "expression"
+      ? item.metricSources.some((s) => s.availableOptions.length > 0)
+      : item.availableOptions.length > 0,
+  );
+  const hideDimensionPill = tabConfig.minDimensions === 0 && !hasAnyOptions;
+
   const mappedDimensionCount = getObjectValues(tab.dimensionMapping).filter(
     isNotNull,
   ).length;
   const dimensionRemoveHandler =
     mappedDimensionCount > 1 ? onDimensionRemove : undefined;
 
-  if (queriesAreLoading || queriesError) {
-    return (
-      <Center h="100%">
-        <LoadingAndErrorWrapper
-          loading={queriesAreLoading}
-          error={queriesError}
-        />
-      </Center>
-    );
-  }
-
-  if (rawSeries.length === 0) {
-    return null;
-  }
-
   return (
-    <Stack flex="1 0 auto" gap="md">
+    <Stack flex="1 0 auto" gap={0}>
       <MetricsViewerVisualization
         rawSeries={rawSeries}
-        dimensionItems={dimensionItems}
-        onDimensionChange={onDimensionChange}
-        onDimensionRemove={dimensionRemoveHandler}
         onBrush={isTimeTab ? handleBrush : undefined}
         definitions={definitions}
         formulaEntities={formulaEntities}
@@ -220,9 +211,20 @@ export function MetricsViewerTabContent({
         tab={tab}
         onTabUpdate={onTabUpdate}
         cardIdToEntityIndex={cardIdToEntityIndex}
+        queriesAreLoading={queriesAreLoading}
+        queriesError={queriesError}
       />
+      {!hideDimensionPill && (
+        <Box mt="sm">
+          <DimensionPillBar
+            items={dimensionItems}
+            onDimensionChange={onDimensionChange}
+            onDimensionRemove={dimensionRemoveHandler}
+          />
+        </Box>
+      )}
       {definitionForControls && (
-        <Flex justify="center" align="center">
+        <Flex mt="md" justify="center" align="center">
           <MetricControls
             definition={definitionForControls}
             displayType={tab.display}

--- a/frontend/src/metabase/metrics-viewer/components/MetricsViewerVisualization/MetricsViewerVisualization.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricsViewerVisualization/MetricsViewerVisualization.tsx
@@ -2,18 +2,13 @@ import { useMemo } from "react";
 import { noop } from "underscore";
 
 import { DebouncedFrame } from "metabase/common/components/DebouncedFrame";
-import type { DimensionPillBarItem } from "metabase/metrics-viewer/components/DimensionPillBar";
-import { DimensionPillBar } from "metabase/metrics-viewer/components/DimensionPillBar";
-import {
-  DISPLAY_TYPE_REGISTRY,
-  getTabConfig,
-} from "metabase/metrics-viewer/utils";
+import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
+import { DISPLAY_TYPE_REGISTRY } from "metabase/metrics-viewer/utils";
 import { MetricsViewerClickActionsMode } from "metabase/metrics-viewer/utils/MetricsViewerClickActionsMode";
 import { getGridColumns } from "metabase/metrics-viewer/utils/grid-columns";
 import type { MetricSlot } from "metabase/metrics-viewer/utils/metric-slots";
-import { Flex, SimpleGrid, Stack, useElementSize } from "metabase/ui";
+import { Center, Flex, SimpleGrid, Stack, useElementSize } from "metabase/ui";
 import Visualization from "metabase/visualizations/components/Visualization";
-import type { DimensionMetadata } from "metabase-lib/metric";
 import type { CardId, SingleSeries } from "metabase-types/api";
 
 import type {
@@ -27,9 +22,6 @@ import S from "./MetricsViewerVisualization.module.css";
 
 type MetricsViewerVisualizationProps = {
   rawSeries: SingleSeries[];
-  dimensionItems: DimensionPillBarItem[];
-  onDimensionChange: (slotIndex: number, dimension: DimensionMetadata) => void;
-  onDimensionRemove?: (slotIndex: number) => void;
   onBrush?: (range: { start: number; end: number }) => void;
   className?: string;
   definitions: Record<MetricSourceId, MetricsViewerDefinitionEntry>;
@@ -39,13 +31,12 @@ type MetricsViewerVisualizationProps = {
   onTabUpdate: (updates: Partial<MetricsViewerTabState>) => void;
   cardIdToEntityIndex: Record<CardId, number>;
   interactive?: boolean;
+  queriesAreLoading: boolean;
+  queriesError: string | null;
 };
 
 export function MetricsViewerVisualization({
   rawSeries,
-  dimensionItems,
-  onDimensionChange,
-  onDimensionRemove,
   onBrush,
   className,
   definitions,
@@ -55,6 +46,8 @@ export function MetricsViewerVisualization({
   onTabUpdate,
   cardIdToEntityIndex,
   interactive = true,
+  queriesAreLoading,
+  queriesError,
 }: MetricsViewerVisualizationProps) {
   const { ref, width } = useElementSize();
   const cols = getGridColumns(width, rawSeries.length);
@@ -82,13 +75,20 @@ export function MetricsViewerVisualization({
     ],
   );
 
-  const tabConfig = getTabConfig(tab.type);
-  const hasAnyOptions = dimensionItems.some((item) =>
-    item.type === "expression"
-      ? item.metricSources.some((s) => s.availableOptions.length > 0)
-      : item.availableOptions.length > 0,
-  );
-  const hideDimensionPill = tabConfig.minDimensions === 0 && !hasAnyOptions;
+  if (queriesAreLoading || queriesError) {
+    return (
+      <Center h="100%">
+        <LoadingAndErrorWrapper
+          loading={queriesAreLoading}
+          error={queriesError}
+        />
+      </Center>
+    );
+  }
+
+  if (rawSeries.length === 0) {
+    return null;
+  }
 
   return (
     <Flex
@@ -136,14 +136,6 @@ export function MetricsViewerVisualization({
             onChangeCardAndRun={noop}
           />
         </DebouncedFrame>
-      )}
-
-      {!hideDimensionPill && (
-        <DimensionPillBar
-          items={dimensionItems}
-          onDimensionChange={onDimensionChange}
-          onDimensionRemove={onDimensionRemove}
-        />
       )}
     </Flex>
   );


### PR DESCRIPTION
Closes [UXW-3748](https://linear.app/metabase/issue/UXW-3748/metrics-viewer-shows-no-compatible-dimensions-even-when-there-are)

### Description

Previously, when calling `addMetricIdentity`, we calculated a `nextSlotIndex`. If a metric was deleted, then a new metric added, the `nextSlotIndex` could collide with a previously deleted metric's `slotIndex`, causing us to improperly assign the deleted metric's dimension mapping to the newly added metric.

The fix is simple - we know when we call `addMetricIdentity` that there is no existing dimension mapping to preserve (this is a new metric instance, and you can't assign dimension mappings while editing in the formula bar). So we simply make `slotIndex` optional on MetricIdentity and don't assign a `nextSlotIndex` in `addMetricIdentity` to avoid collisions.

This PR also ensures DimensionPillBar is visible even during an error state so that the user can recover from or better understand incompatible dimension errors.

### How to verify

Follow the steps in the demo.

### Demo

[Loom](https://www.loom.com/share/4ac74cee21f845efb3eddb175339f1b1)

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
