### PR TITLE
plugins loaded for checker

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -2753,8 +2753,10 @@
   {:team "Graphy"
    ;; todo: add ability to prevent usage (transitive even) of app db
    :api  #{}
-   :uses #{lib
+   :uses #{classloader
+           lib
            models
+           plugins
            query-processor
            sql-tools
            util

--- a/enterprise/backend/src/metabase_enterprise/checker/cli.clj
+++ b/enterprise/backend/src/metabase_enterprise/checker/cli.clj
@@ -7,7 +7,9 @@
    [clojure.java.io :as io]
    [clojure.string :as str]
    [clojure.tools.cli :as cli]
-   [metabase-enterprise.checker.semantic :as checker]))
+   [metabase-enterprise.checker.semantic :as checker]
+   [metabase.classloader.core :as classloader]
+   [metabase.plugins.core :as plugins]))
 
 (set! *warn-on-reflection* true)
 
@@ -148,4 +150,8 @@
       :else
       (do
         (validate-directory! export)
+        ;; Drivers are jar-loaded plugins; install the dynamic classloader and
+        ;; load them so query validation can resolve driver multimethods.
+        (classloader/the-classloader)
+        (plugins/load-plugins!)
         (run-checker export options)))))


### PR DESCRIPTION
bad before:

```
transform: tedst (entity_id: yzcA7FDddui5iQ0fqy1Os)
  bad ref: {:type :validation-exception-error, :message "Could not load :clickhouse driver."}
transform: test clickhouse transform (entity_id: woEjhkTPuqZOJU3zO20Ol)
  bad ref: {:type :validation-exception-error, :message "Could not load :clickhouse driver."}
transform: test transform (entity_id: o6Ai0q3bK8fFjw2ZNexrq)
  bad ref: {:type :validation-exception-error, :message "Could not load :clickhouse driver."}

```

afterwards, should be fine