### PR TITLE
Show the MCP URL in the admin panel

### DIFF
--- a/frontend/src/metabase/common/components/CopyButton/CopyButton.tsx
+++ b/frontend/src/metabase/common/components/CopyButton/CopyButton.tsx
@@ -46,14 +46,18 @@ export const CopyButton = ({
   );
 
   return (
-    <div className={className} style={style} data-testid="copy-button">
+    <div
+      className={className}
+      data-testid="copy-button"
+      onClick={onCopyValue}
+      onKeyDown={copyOnEnter}
+      style={style}
+    >
       <Tooltip
         label={<Text fw={700} c="inherit">{t`Copied!`}</Text>}
         opened={clipboard.copied}
       >
-        <span onClick={onCopyValue} onKeyDown={copyOnEnter}>
-          {target}
-        </span>
+        <span>{target}</span>
       </Tooltip>
     </div>
   );

--- a/frontend/src/metabase/metabot/components/MetabotAdmin/MCPServerUrlSection.module.css
+++ b/frontend/src/metabase/metabot/components/MetabotAdmin/MCPServerUrlSection.module.css
@@ -1,0 +1,4 @@
+.input {
+  font-family: monospace;
+  font-size: 0.75rem;
+}

--- a/frontend/src/metabase/metabot/components/MetabotAdmin/MCPServerUrlSection.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotAdmin/MCPServerUrlSection.tsx
@@ -1,30 +1,18 @@
 import { t } from "ttag";
 
 import { SettingHeader } from "metabase/admin/settings/components/SettingHeader";
-import { useAdminSetting } from "metabase/api/utils";
-import { useMetadataToasts } from "metabase/metadata/hooks";
-import { ActionIcon, Box, Icon, TextInput, Tooltip } from "metabase/ui";
+import { CopyTextInput } from "metabase/common/components/CopyTextInput";
+import { Box } from "metabase/ui";
 
 import S from "./MCPServerUrlSection.module.css";
+import { useMCPServerURL } from "./utils";
 
 export function McpServerUrlSection() {
-  const { sendSuccessToast, sendErrorToast } = useMetadataToasts();
-  const { value: siteUrl } = useAdminSetting("site-url");
+  const mcpServerUrl = useMCPServerURL();
 
-  if (!siteUrl) {
+  if (!mcpServerUrl) {
     return null;
   }
-
-  const mcpServerUrl = `${siteUrl}/api/mcp`;
-
-  const onCopyClick = async () => {
-    try {
-      await navigator.clipboard.writeText(mcpServerUrl);
-      sendSuccessToast(t`MCP server URL copied to clipboard`);
-    } catch {
-      sendErrorToast(t`Error copying the MCP server URL to clipboard.`);
-    }
-  };
 
   return (
     <Box>
@@ -33,21 +21,14 @@ export function McpServerUrlSection() {
         title={t`MCP server URL`}
         description={t`This is the MCP server URL you can use to connect.`}
       />
-      <TextInput
-        c="text-primary"
-        readOnly
-        mt="md"
+      <CopyTextInput
         value={mcpServerUrl}
-        rightSection={
-          <Tooltip label={t`Copy to clipboard`}>
-            <ActionIcon h="sm" onClick={onCopyClick}>
-              <Icon name="copy" size="1rem" />
-            </ActionIcon>
-          </Tooltip>
-        }
         classNames={{
           input: S.input,
         }}
+        readOnly
+        mt="md"
+        c="text-primary"
       />
     </Box>
   );

--- a/frontend/src/metabase/metabot/components/MetabotAdmin/MCPServerUrlSection.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotAdmin/MCPServerUrlSection.tsx
@@ -1,0 +1,54 @@
+import { t } from "ttag";
+
+import { SettingHeader } from "metabase/admin/settings/components/SettingHeader";
+import { useAdminSetting } from "metabase/api/utils";
+import { useMetadataToasts } from "metabase/metadata/hooks";
+import { ActionIcon, Box, Icon, TextInput, Tooltip } from "metabase/ui";
+
+import S from "./MCPServerUrlSection.module.css";
+
+export function McpServerUrlSection() {
+  const { sendSuccessToast, sendErrorToast } = useMetadataToasts();
+  const { value: siteUrl } = useAdminSetting("site-url");
+
+  if (!siteUrl) {
+    return null;
+  }
+
+  const mcpServerUrl = `${siteUrl}/api/mcp`;
+
+  const onCopyClick = async () => {
+    try {
+      await navigator.clipboard.writeText(mcpServerUrl);
+      sendSuccessToast(t`MCP server URL copied to clipboard`);
+    } catch {
+      sendErrorToast(t`Error copying the MCP server URL to clipboard.`);
+    }
+  };
+
+  return (
+    <Box>
+      <SettingHeader
+        id="custom-mcp-origins"
+        title={t`MCP server URL`}
+        description={t`This is the MCP server URL you can use to connect.`}
+      />
+      <TextInput
+        c="text-primary"
+        readOnly
+        mt="md"
+        value={mcpServerUrl}
+        rightSection={
+          <Tooltip label={t`Copy to clipboard`}>
+            <ActionIcon h="sm" onClick={onCopyClick}>
+              <Icon name="copy" size="1rem" />
+            </ActionIcon>
+          </Tooltip>
+        }
+        classNames={{
+          input: S.input,
+        }}
+      />
+    </Box>
+  );
+}

--- a/frontend/src/metabase/metabot/components/MetabotAdmin/MCPServerUrlSection.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotAdmin/MCPServerUrlSection.unit.spec.tsx
@@ -1,4 +1,3 @@
-import { waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import {
@@ -43,39 +42,16 @@ describe("McpServerUrlSection", () => {
     expect(await screen.findByDisplayValue(MCP_URL)).toBeInTheDocument();
   });
 
-  it("renders nothing when site-url is not set", async () => {
+  it("renders nothing when site-url is not set", () => {
     setup({ siteUrl: undefined });
-    await waitFor(
-      () => {
-        expect(screen.queryByDisplayValue(MCP_URL)).not.toBeInTheDocument();
-      },
-      { timeout: 10 },
-    );
+    expect(screen.queryByDisplayValue(MCP_URL)).not.toBeInTheDocument();
   });
 
-  it("shows a success tooltip after successfully copying the URL", async () => {
+  it("can copy the MCP server URL to the clipboard", async () => {
     setup();
     await userEvent.click(
       await screen.findByRole("img", { name: /copy icon/i }),
     );
-    expect(
-      await screen.findByText("MCP server URL copied to clipboard"),
-    ).toBeInTheDocument();
-  });
-
-  it("shows an error tooltip when copying the URL fails", async () => {
-    jest
-      .spyOn(navigator.clipboard, "writeText")
-      .mockRejectedValueOnce(new Error("Permission denied"));
-
-    setup();
-
-    await userEvent.click(
-      await screen.findByRole("img", { name: /copy icon/i }),
-    );
-
-    expect(
-      await screen.findByText("Error copying the MCP server URL to clipboard."),
-    ).toBeInTheDocument();
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(MCP_URL);
   });
 });

--- a/frontend/src/metabase/metabot/components/MetabotAdmin/MCPServerUrlSection.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotAdmin/MCPServerUrlSection.unit.spec.tsx
@@ -1,0 +1,81 @@
+import { waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import {
+  setupPropertiesEndpoints,
+  setupSettingsEndpoints,
+  setupUpdateSettingEndpoint,
+} from "__support__/server-mocks";
+import { mockSettings } from "__support__/settings";
+import { renderWithProviders, screen } from "__support__/ui";
+import { UndoListing } from "metabase/common/components/UndoListing";
+import { createMockState } from "metabase/redux/store/mocks";
+import { createMockSettings } from "metabase-types/api/mocks";
+
+import { McpServerUrlSection } from "./MCPServerUrlSection";
+
+const SITE_URL = "https://metabase.example.com";
+const MCP_URL = `${SITE_URL}/api/mcp`;
+
+function setup({ siteUrl = SITE_URL }: { siteUrl?: string | undefined } = {}) {
+  const settings = createMockSettings({ "site-url": siteUrl });
+
+  setupPropertiesEndpoints(settings);
+  setupSettingsEndpoints([]);
+  setupUpdateSettingEndpoint();
+
+  renderWithProviders(
+    <div>
+      <McpServerUrlSection />
+      <UndoListing />
+    </div>,
+    {
+      storeInitialState: createMockState({
+        settings: mockSettings(settings),
+      }),
+    },
+  );
+}
+
+describe("McpServerUrlSection", () => {
+  it("uses site-url to construct and display the MCP server URL", async () => {
+    setup();
+    expect(await screen.findByDisplayValue(MCP_URL)).toBeInTheDocument();
+  });
+
+  it("renders nothing when site-url is not set", async () => {
+    setup({ siteUrl: undefined });
+    await waitFor(
+      () => {
+        expect(screen.queryByDisplayValue(MCP_URL)).not.toBeInTheDocument();
+      },
+      { timeout: 10 },
+    );
+  });
+
+  it("shows a success tooltip after successfully copying the URL", async () => {
+    setup();
+    await userEvent.click(
+      await screen.findByRole("img", { name: /copy icon/i }),
+    );
+    expect(
+      await screen.findByText("MCP server URL copied to clipboard"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows an error tooltip when copying the URL fails", async () => {
+    jest
+      .spyOn(navigator.clipboard, "writeText")
+      .mockRejectedValueOnce(new Error("Permission denied"));
+
+    setup();
+
+    await userEvent.click(
+      await screen.findByRole("img", { name: /copy icon/i }),
+    );
+
+    expect(
+      await screen.findByText("Error copying the MCP server URL to clipboard."),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/metabot/components/MetabotAdmin/McpAppsSettings.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotAdmin/McpAppsSettings.tsx
@@ -8,6 +8,8 @@ import { ExternalLink } from "metabase/common/components/ExternalLink";
 import { useDocsUrl } from "metabase/common/hooks";
 import { Box, Flex, Stack, Switch, Text, TextInput } from "metabase/ui";
 
+import { McpServerUrlSection } from "./MCPServerUrlSection";
+
 const getMcpClients = () =>
   [
     {
@@ -65,15 +67,14 @@ export const McpAppsSettings = ({ id }: { id?: string }) => {
         )}`
       }
     >
-      {isEnabled ? (
+      {isEnabled && (
         <Stack gap="lg">
           <CommonMcpClientsSection />
 
           <CustomMcpOriginsSection />
         </Stack>
-      ) : (
-        <></>
       )}
+      <McpServerUrlSection />
     </SettingsSection>
   );
 };

--- a/frontend/src/metabase/metabot/components/MetabotAdmin/utils.ts
+++ b/frontend/src/metabase/metabot/components/MetabotAdmin/utils.ts
@@ -2,6 +2,7 @@ import type { FetchBaseQueryError } from "@reduxjs/toolkit/query";
 import type { FormikErrors } from "formik";
 import { P, isMatching } from "ts-pattern";
 
+import { useAdminSetting } from "metabase/api/utils";
 import { getLocation } from "metabase/selectors/routing";
 import { useSelector } from "metabase/utils/redux";
 import type { MetabotProvider } from "metabase-types/api";
@@ -160,3 +161,13 @@ export const handleFieldError = <Values>(
     throw { data: error };
   }
 };
+
+export function useMCPServerURL() {
+  const { value: siteUrl } = useAdminSetting("site-url");
+
+  if (!siteUrl) {
+    return null;
+  }
+
+  return `${siteUrl}/api/mcp`;
+}


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/BOT-1293/show-the-mcp-url-in-the-admin-panel

### How to verify
- Go to Admin > AI > MCP server section
- You should see the new subsection with the MCP server URL

### Demo
Before:
<img width="829" height="580" alt="image" src="https://github.com/user-attachments/assets/d8db3ac0-94a3-4e8c-857d-d7bd52422b26" />

After:
<img width="835" height="662" alt="image" src="https://github.com/user-attachments/assets/20e79ea0-15b9-429c-9678-8127ebbef543" />

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml) 
