### PR TITLE
Fix issues with Codex MCP search + query pagination/row limit semantics

### DIFF
--- a/src/metabase/agent_api/api.clj
+++ b/src/metabase/agent_api/api.clj
@@ -416,7 +416,7 @@
     {:query       (update-in query-map [:stages last-idx] dissoc :limit)
      :total-limit total-limit}))
 
-(defn- compute-page-items
+(defn- remaining-page-rows
   "Rows to request for this page, respecting the user's total cap.
    Returns at most page-size, and never more than remaining rows under the cap."
   [total-limit page]
@@ -477,7 +477,7 @@
             {:query query :total-limit (:limit pagination) :page (:page pagination)})
           (let [{:keys [query total-limit]} (extract-total-limit (evaluate-program-for-execution body))]
             {:query query :total-limit total-limit :page 1}))
-        items           (compute-page-items total-limit page)
+        items           (remaining-page-rows total-limit page)
         mbql5-with-page (apply-page-to-query query page items)]
     (qp.streaming/streaming-response
      [rff :api]

--- a/src/metabase/agent_api/api.clj
+++ b/src/metabase/agent_api/api.clj
@@ -382,17 +382,11 @@
         result        (metabot-construct/execute-program source-entity nil program)]
     (get-in result [:structured-output :query])))
 
-(defn- strip-query-for-serialization
-  "JSON round-trip a lib query to strip lib metadata, yielding a plain MBQL 5 map
-  that can be serialized into a continuation token and passed to the QP."
-  [query]
-  (json/decode+kw (json/encode query)))
-
 (defn- evaluate-program-for-execution
-  "Evaluate a program and return a stripped MBQL 5 query map suitable for serialization
-  and QP execution (see [[strip-query-for-serialization]])."
+  "Evaluate a program and return a plain MBQL 5 query map suitable for serialization
+  into a continuation token and execution by the QP."
   [program]
-  (strip-query-for-serialization (evaluate-program-to-live-query program)))
+  (lib/prepare-for-serialization (evaluate-program-to-live-query program)))
 
 (api.macros/defendpoint :post "/v2/construct-query" :- ::construct-query-response
   "Construct an MBQL query from a structured agent-lib program.
@@ -435,15 +429,14 @@
 
 (defn- extract-total-limit
   "Pull the user's :limit off a live lib query's last stage and return
-   {:query <stripped-limitless-query> :total-limit <int>}. The :limit is removed
+   {:query <serializable-limitless-query> :total-limit <int>}. The :limit is removed
    because it is enforced via pagination in the application layer, and capped at
-   the combined query endpoint's hard maximum. The returned :query is run through
-   [[strip-query-for-serialization]] so downstream code and continuation tokens
-   see a consistent plain-map form."
+   the combined query endpoint's hard maximum. The returned :query is prepared for
+   serialization so it can round-trip through a continuation token."
   [live-query]
   (let [user-limit  (lib/current-limit live-query)
         total-limit (min (or user-limit default-query-row-limit) max-total-row-limit)]
-    {:query       (strip-query-for-serialization (lib/limit live-query nil))
+    {:query       (lib/prepare-for-serialization (lib/limit live-query nil))
      :total-limit total-limit}))
 
 (defn- rows-before-page
@@ -466,10 +459,10 @@
        (< (rows-before-page (inc page)) total-limit)))
 
 (defn- apply-page-to-query
-  "Set `:page` on the last stage of a serialized MBQL 5 query map. Operates on the
-  stripped (post-[[strip-query-for-serialization]]) form because the continuation-token
-  path only has that shape available — rehydrating to a live lib query here would
-  require a metadata provider we don't currently plumb through the token."
+  "Set `:page` on the last stage of a plain MBQL 5 query map (lib metadata already
+  stripped). Operates on the plain-map form because the continuation-token path only
+  has that shape available — rehydrating to a live lib query here would require a
+  metadata provider we don't currently plumb through the token."
   [query-map page items]
   (let [stages   (:stages query-map)
         last-idx (dec (count stages))]

--- a/src/metabase/agent_api/api.clj
+++ b/src/metabase/agent_api/api.clj
@@ -427,17 +427,14 @@
   [token]
   (-> token u/decode-base64 json/decode+kw))
 
-(defn- extract-total-limit
-  "Pull the user's :limit off a live lib query's last stage and return
-   {:query <serializable-limitless-query> :total-limit <int>}. The :limit is removed
-   because it is enforced via pagination in the application layer, and capped at
-   the combined query endpoint's hard maximum. The returned :query is prepared for
-   serialization so it can round-trip through a continuation token."
+(defn- total-row-limit
+  "The user's requested :limit, defaulted when absent and capped at the combined
+   endpoint's hard maximum. This is the app-level total-row budget enforced across
+   paginated responses; each page's QP-level cap comes from `:page.items`, which
+   `remaining-page-rows` clamps to respect this total."
   [live-query]
-  (let [user-limit  (lib/current-limit live-query)
-        total-limit (min (or user-limit default-query-row-limit) max-total-row-limit)]
-    {:query       (lib/prepare-for-serialization (lib/limit live-query nil))
-     :total-limit total-limit}))
+  (min (or (lib/current-limit live-query) default-query-row-limit)
+       max-total-row-limit))
 
 (defn- rows-before-page
   "Total rows consumed by the pages preceding `page`. Single source of truth for
@@ -459,10 +456,10 @@
        (< (rows-before-page (inc page)) total-limit)))
 
 (defn- apply-page-to-query
-  "Set `:page` on the last stage of a plain MBQL 5 query map (lib metadata already
-  stripped). Operates on the plain-map form because the continuation-token path only
-  has that shape available — rehydrating to a live lib query here would require a
-  metadata provider we don't currently plumb through the token."
+  "Set `:page` on the last stage of a serialized MBQL 5 query map. Operates on the
+  plain-map form because the continuation-token path only has that shape available —
+  rehydrating to a live lib query here would require a metadata provider we don't
+  currently plumb through the token."
   [query-map page items]
   (let [stages   (:stages query-map)
         last-idx (dec (count stages))]
@@ -494,14 +491,16 @@
 
 (defn- initial-page-state
   "Normalize the two /v2/query entry points into a single {:query :total-limit :page}
-   shape. A fresh program evaluates + extracts the user's :limit; a continuation token
-   carries that state from a prior response."
+   shape. A fresh program evaluates the user's program and computes a total-row budget
+   from its `:limit`; a continuation token carries that state from a prior response."
   [body]
   (if-let [token (:continuation_token body)]
     (let [{:keys [query pagination]} (decode-continuation-token token)]
       {:query query :total-limit (:limit pagination) :page (:page pagination)})
-    (let [{:keys [query total-limit]} (extract-total-limit (evaluate-program-to-live-query body))]
-      {:query query :total-limit total-limit :page 1})))
+    (let [live-query (evaluate-program-to-live-query body)]
+      {:query       (lib/prepare-for-serialization live-query)
+       :total-limit (total-row-limit live-query)
+       :page        1})))
 
 (api.macros/defendpoint :post "/v2/query"
   :- (streaming-response/streaming-response-schema ::query-response)

--- a/src/metabase/agent_api/api.clj
+++ b/src/metabase/agent_api/api.clj
@@ -10,6 +10,7 @@
    [metabase.api.macros.scope :as scope]
    [metabase.api.routes.common :as api.routes.common]
    [metabase.auth-identity.core :as auth-identity]
+   [metabase.lib.core :as lib]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.metabot.core :as metabot]
    [metabase.metabot.tools.construct :as metabot-construct]
@@ -367,19 +368,29 @@
   rejected here."
   #{"table" "card" "dataset" "metric"})
 
-(defn- evaluate-program-for-execution
-  "Resolve a program's source entity, evaluate the program via agent-lib, and return a
-  plain MBQL 5 query map. The JSON round-trip strips lib metadata so the query can be
-  serialized into a continuation token."
+(defn- evaluate-program-to-live-query
+  "Resolve a program's source entity, evaluate the program via agent-lib, and return
+  the live lib query (with lib metadata attached)."
   [program]
   (let [source-type (get-in program [:source :type])]
     (api/check (contains? allowed-program-source-types source-type)
                [400 (str "top-level program source must be one of: "
                          (str/join ", " (sort allowed-program-source-types)))]))
   (let [source-entity (metabot-construct/program-source->source-entity (:source program))
-        result        (metabot-construct/execute-program source-entity nil program)
-        pmbql         (get-in result [:structured-output :query])]
-    (json/decode+kw (json/encode pmbql))))
+        result        (metabot-construct/execute-program source-entity nil program)]
+    (get-in result [:structured-output :query])))
+
+(defn- strip-query-for-serialization
+  "JSON round-trip a lib query to strip lib metadata, yielding a plain MBQL 5 map
+  that can be serialized into a continuation token and passed to the QP."
+  [query]
+  (json/decode+kw (json/encode query)))
+
+(defn- evaluate-program-for-execution
+  "Evaluate a program and return a stripped MBQL 5 query map suitable for serialization
+  and QP execution (see [[strip-query-for-serialization]])."
+  [program]
+  (strip-query-for-serialization (evaluate-program-to-live-query program)))
 
 (api.macros/defendpoint :post "/v2/construct-query" :- ::construct-query-response
   "Construct an MBQL query from a structured agent-lib program.
@@ -421,16 +432,16 @@
   (-> token u/decode-base64 json/decode+kw))
 
 (defn- extract-total-limit
-  "Pull the user's :limit from an evaluated MBQL 5 query's last stage and return
-   {:query <stripped-query> :total-limit <int>}. The :limit is removed from the
-   stage because it is enforced via pagination in the application layer, and capped
-   at the combined query endpoint's hard maximum."
-  [query-map]
-  (let [stages      (:stages query-map)
-        last-idx    (dec (count stages))
-        user-limit  (get-in stages [last-idx :limit])
+  "Pull the user's :limit off a live lib query's last stage and return
+   {:query <stripped-limitless-query> :total-limit <int>}. The :limit is removed
+   because it is enforced via pagination in the application layer, and capped at
+   the combined query endpoint's hard maximum. The returned :query is run through
+   [[strip-query-for-serialization]] so downstream code and continuation tokens
+   see a consistent plain-map form."
+  [live-query]
+  (let [user-limit  (lib/current-limit live-query)
         total-limit (min (or user-limit default-query-row-limit) max-total-row-limit)]
-    {:query       (update-in query-map [:stages last-idx] dissoc :limit)
+    {:query       (strip-query-for-serialization (lib/limit live-query nil))
      :total-limit total-limit}))
 
 (defn- remaining-page-rows
@@ -440,7 +451,10 @@
   (max 0 (min page-size (- total-limit (* (dec page) page-size)))))
 
 (defn- apply-page-to-query
-  "Apply :page clause to the last stage of a MBQL 5 query map."
+  "Set `:page` on the last stage of a serialized MBQL 5 query map. Operates on the
+  stripped (post-[[strip-query-for-serialization]]) form because the continuation-token
+  path only has that shape available — rehydrating to a live lib query here would
+  require a metadata provider we don't currently plumb through the token."
   [query-map page items]
   (let [stages   (:stages query-map)
         last-idx (dec (count stages))]
@@ -492,7 +506,7 @@
         (if-let [token (:continuation_token body)]
           (let [{:keys [query pagination]} (decode-continuation-token token)]
             {:query query :total-limit (:limit pagination) :page (:page pagination)})
-          (let [{:keys [query total-limit]} (extract-total-limit (evaluate-program-for-execution body))]
+          (let [{:keys [query total-limit]} (extract-total-limit (evaluate-program-to-live-query body))]
             {:query query :total-limit total-limit :page 1}))
         items           (remaining-page-rows total-limit page)
         mbql5-with-page (apply-page-to-query query page items)]

--- a/src/metabase/agent_api/api.clj
+++ b/src/metabase/agent_api/api.clj
@@ -423,9 +423,19 @@
       u/encode-base64))
 
 (defn- decode-continuation-token
-  "Decode a base64-encoded continuation token into {:query ... :pagination ...}."
+  "Decode a base64-encoded continuation token into {:query ... :pagination ...}.
+   The token is client-supplied, so sanity-check the pagination ints to turn
+   garbage into a 400 rather than a downstream 500. This is robustness, not a
+   security boundary — a caller can always issue a fresh program to run any
+   query they want."
   [token]
-  (-> token u/decode-base64 json/decode+kw))
+  (let [decoded (-> token u/decode-base64 json/decode+kw)
+        {:keys [limit page]} (:pagination decoded)]
+    (api/check (and (int? limit) (pos? limit))
+               [400 "Invalid continuation token: limit must be a positive integer"])
+    (api/check (and (int? page) (pos? page))
+               [400 "Invalid continuation token: page must be a positive integer"])
+    decoded))
 
 (defn- total-row-limit
   "The user's requested :limit, defaulted when absent and capped at the combined

--- a/src/metabase/agent_api/api.clj
+++ b/src/metabase/agent_api/api.clj
@@ -303,15 +303,17 @@
   "Defensive coercion for `/v1/search`'s query arguments. Some MCP clients (notably
    Codex) serialize array args through a string layer, so a caller that intended to
    send `[\"orders\"]` may actually send `\"[\\\"orders\\\"]\"`. Accept either shape:
-   an array is returned as-is; a string that parses as a JSON array is unwrapped;
-   any other string is treated as a single-element query."
+   an array is returned as-is; a string that parses as a JSON array of non-blank
+   strings is unwrapped; any other string is treated as a single-element query."
   [v]
   (cond
     (nil? v)        nil
     (sequential? v) v
     (string? v)     (or (try
                           (let [parsed (json/decode+kw v)]
-                            (when (sequential? parsed) parsed))
+                            (when (and (sequential? parsed)
+                                       (every? #(and (string? %) (not (str/blank? %))) parsed))
+                              parsed))
                           (catch Exception _ nil))
                         [v])
     :else           v))
@@ -444,11 +446,24 @@
     {:query       (strip-query-for-serialization (lib/limit live-query nil))
      :total-limit total-limit}))
 
+(defn- rows-before-page
+  "Total rows consumed by the pages preceding `page`. Single source of truth for
+   the page-size * (page - 1) arithmetic used by both sizing and pagination-exit."
+  [page]
+  (* (dec page) page-size))
+
 (defn- remaining-page-rows
   "Rows to request for this page, respecting the user's total cap.
    Returns at most page-size, and never more than remaining rows under the cap."
   [total-limit page]
-  (max 0 (min page-size (- total-limit (* (dec page) page-size)))))
+  (max 0 (min page-size (- total-limit (rows-before-page page)))))
+
+(defn- more-pages-available?
+  "True when this page was filled to its requested size *and* the total cap still
+   has room for more rows — i.e. we should emit a continuation token."
+  [page total-limit rows-returned items]
+  (and (= rows-returned items)
+       (< (rows-before-page (inc page)) total-limit)))
 
 (defn- apply-page-to-query
   "Set `:page` on the last stage of a serialized MBQL 5 query map. Operates on the
@@ -484,6 +499,17 @@
    [:continuation [:map [:continuation_token ms/NonBlankString]]]
    [:program      ::program-request]])
 
+(defn- initial-page-state
+  "Normalize the two /v2/query entry points into a single {:query :total-limit :page}
+   shape. A fresh program evaluates + extracts the user's :limit; a continuation token
+   carries that state from a prior response."
+  [body]
+  (if-let [token (:continuation_token body)]
+    (let [{:keys [query pagination]} (decode-continuation-token token)]
+      {:query query :total-limit (:limit pagination) :page (:page pagination)})
+    (let [{:keys [query total-limit]} (extract-total-limit (evaluate-program-to-live-query body))]
+      {:query query :total-limit total-limit :page 1})))
+
 (api.macros/defendpoint :post "/v2/query"
   :- (streaming-response/streaming-response-schema ::query-response)
   "Execute a structured program and stream the results, with continuation-token pagination.
@@ -502,12 +528,7 @@
   [_route-params
    _query-params
    body :- ::query-request]
-  (let [{:keys [query total-limit page]}
-        (if-let [token (:continuation_token body)]
-          (let [{:keys [query pagination]} (decode-continuation-token token)]
-            {:query query :total-limit (:limit pagination) :page (:page pagination)})
-          (let [{:keys [query total-limit]} (extract-total-limit (evaluate-program-to-live-query body))]
-            {:query query :total-limit total-limit :page 1}))
+  (let [{:keys [query total-limit page]} (initial-page-state body)
         items           (remaining-page-rows total-limit page)
         mbql5-with-page (apply-page-to-query query page items)]
     (qp.streaming/streaming-response
@@ -518,8 +539,7 @@
         rff
         (fn [result]
           (assoc result :continuation_token
-                 (when (and (= (:row_count result) items)
-                            (< (* page page-size) total-limit))
+                 (when (more-pages-available? page total-limit (:row_count result) items)
                    (generate-continuation-token query total-limit page)))))))))
 
 ;;; ------------------------------------------------- Execute Query --------------------------------------------------

--- a/src/metabase/agent_api/api.clj
+++ b/src/metabase/agent_api/api.clj
@@ -298,6 +298,23 @@
      :field-id    field-id
      :limit       (or (request/limit) default-field-values-limit)})))
 
+(defn- coerce-query-list
+  "Defensive coercion for `/v1/search`'s query arguments. Some MCP clients (notably
+   Codex) serialize array args through a string layer, so a caller that intended to
+   send `[\"orders\"]` may actually send `\"[\\\"orders\\\"]\"`. Accept either shape:
+   an array is returned as-is; a string that parses as a JSON array is unwrapped;
+   any other string is treated as a single-element query."
+  [v]
+  (cond
+    (nil? v)        nil
+    (sequential? v) v
+    (string? v)     (or (try
+                          (let [parsed (json/decode+kw v)]
+                            (when (sequential? parsed) parsed))
+                          (catch Exception _ nil))
+                        [v])
+    :else           v))
+
 (api.macros/defendpoint :post "/v1/search" :- ::search-response
   "Search for tables and metrics.
 
@@ -316,13 +333,13 @@
    :- [:map
        [:term_queries {:optional true
                        :tool/description "Keyword search queries as an array of strings, for example [\"orders\", \"revenue\"]."}
-        [:maybe [:sequential ms/NonBlankString]]]
+        [:maybe [:or [:sequential ms/NonBlankString] ms/NonBlankString]]]
        [:semantic_queries {:optional true
                            :tool/description "Natural-language search queries as an array of strings, for example [\"how much revenue did we make\"]."}
-        [:maybe [:sequential ms/NonBlankString]]]]]
+        [:maybe [:or [:sequential ms/NonBlankString] ms/NonBlankString]]]]]
   (let [results (metabot-search/search
-                 {:term-queries     (or term-queries [])
-                  :semantic-queries (or semantic-queries [])
+                 {:term-queries     (or (coerce-query-list term-queries) [])
+                  :semantic-queries (or (coerce-query-list semantic-queries) [])
                   :entity-types     ["table" "metric"]
                   :limit            (or (request/limit) 50)})]
     {:data        results

--- a/src/metabase/agent_api/api.clj
+++ b/src/metabase/agent_api/api.clj
@@ -307,21 +307,18 @@
    :tool  {:name "search"
            :description (str "Search for tables and metrics in Metabase. "
                              "Use term_queries for keyword search or semantic_queries for natural language search. "
-                             "Both arguments must be JSON arrays of strings.")
-           :annotations {:read-only? true}
-           ;; Surface validation errors to clients instead of silently reshaping stringified arrays,
-           ;; so mis-shaped calls get clear feedback rather than coerced success.
-           :strict-input-shape? true}}
+                             "Both arguments are arrays of strings, for example term_queries: [\"orders\", \"revenue\"].")
+           :annotations {:read-only? true}}}
   [_route-params
    _query-params
    {term-queries     :term_queries
     semantic-queries :semantic_queries}
    :- [:map
        [:term_queries {:optional true
-                       :tool/description "Keyword search queries as a JSON array of strings, for example [\"orders\", \"revenue\"]."}
+                       :tool/description "Keyword search queries as an array of strings, for example [\"orders\", \"revenue\"]."}
         [:maybe [:sequential ms/NonBlankString]]]
        [:semantic_queries {:optional true
-                           :tool/description "Natural-language search queries as a JSON array of strings, for example [\"how much revenue did we make\"]."}
+                           :tool/description "Natural-language search queries as an array of strings, for example [\"how much revenue did we make\"]."}
         [:maybe [:sequential ms/NonBlankString]]]]]
   (let [results (metabot-search/search
                  {:term-queries     (or term-queries [])

--- a/src/metabase/agent_api/api.clj
+++ b/src/metabase/agent_api/api.clj
@@ -35,13 +35,18 @@
   30)
 
 (def ^:private ^:const default-query-row-limit
-  "Default row limit for table queries when no limit is specified."
+  "Default row cap when :limit is omitted from a table query request."
   200)
 
-(def ^:private ^:const max-query-row-limit
-  "Hard cap on rows returned by the combined query endpoint, keeping result sets lean for LLM context windows.
-   Agents can paginate via continuation tokens for more."
+(def ^:private ^:const page-size
+  "Rows returned per page when paginating the combined query endpoint via continuation tokens.
+   Also used as the query processor's per-call row constraint."
   200)
+
+(def ^:private ^:const max-total-row-limit
+  "Ceiling on the user-requested :limit for the combined query endpoint. Agents can paginate
+   through up to this many rows across pages."
+  2000)
 
 ;;; ---------------------------------------------------- Helpers ------------------------------------------------------
 
@@ -300,15 +305,24 @@
   Reciprocal Rank Fusion when both query types are provided."
   {:scope metabot/agent-search
    :tool  {:name "search"
-           :description "Search for tables and metrics in Metabase. Use term_queries for keyword search or semantic_queries for natural language search."
-           :annotations {:read-only? true}}}
+           :description (str "Search for tables and metrics in Metabase. "
+                             "Use term_queries for keyword search or semantic_queries for natural language search. "
+                             "Both arguments must be JSON arrays of strings.")
+           :annotations {:read-only? true}
+           ;; Surface validation errors to clients instead of silently reshaping stringified arrays,
+           ;; so mis-shaped calls get clear feedback rather than coerced success.
+           :strict-input-shape? true}}
   [_route-params
    _query-params
    {term-queries     :term_queries
     semantic-queries :semantic_queries}
    :- [:map
-       [:term_queries     {:optional true} [:maybe [:sequential ms/NonBlankString]]]
-       [:semantic_queries {:optional true} [:maybe [:sequential ms/NonBlankString]]]]]
+       [:term_queries {:optional true
+                       :tool/description "Keyword search queries as a JSON array of strings, for example [\"orders\", \"revenue\"]."}
+        [:maybe [:sequential ms/NonBlankString]]]
+       [:semantic_queries {:optional true
+                           :tool/description "Natural-language search queries as a JSON array of strings, for example [\"how much revenue did we make\"]."}
+        [:maybe [:sequential ms/NonBlankString]]]]]
   (let [results (metabot-search/search
                  {:term-queries     (or term-queries [])
                   :semantic-queries (or semantic-queries [])
@@ -379,10 +393,11 @@
 ;;; ------------------------------------------------- Combined Query -------------------------------------------------
 
 (defn- generate-continuation-token
-  "Build a base64-encoded continuation token containing the query and next-page pagination info."
-  [query-map limit page]
+  "Build a base64-encoded continuation token carrying the query and next-page pagination info.
+   :limit is the user's total row cap across all pages, not the per-page size."
+  [query-map total-limit page]
   (-> {:query      query-map
-       :pagination {:limit limit :page (inc page)}}
+       :pagination {:limit total-limit :page (inc page)}}
       json/encode
       u/encode-base64))
 
@@ -391,13 +406,24 @@
   [token]
   (-> token u/decode-base64 json/decode+kw))
 
-(defn- query-page-size
-  "Determine the per-page row limit for an evaluated MBQL 5 query, taking the
-  user-supplied limit (from the last stage) when present and capping at the
-  combined query endpoint's hard maximum."
+(defn- extract-total-limit
+  "Pull the user's :limit from an evaluated MBQL 5 query's last stage and return
+   {:query <stripped-query> :total-limit <int>}. The :limit is removed from the
+   stage because it is enforced via pagination in the application layer, and capped
+   at the combined query endpoint's hard maximum."
   [query-map]
-  (let [user-limit (-> query-map :stages last :limit)]
-    (min (or user-limit default-query-row-limit) max-query-row-limit)))
+  (let [stages      (:stages query-map)
+        last-idx    (dec (count stages))
+        user-limit  (get-in stages [last-idx :limit])
+        total-limit (min (or user-limit default-query-row-limit) max-total-row-limit)]
+    {:query       (update-in query-map [:stages last-idx] dissoc :limit)
+     :total-limit total-limit}))
+
+(defn- compute-page-items
+  "Rows to request for this page, respecting the user's total cap.
+   Returns at most page-size, and never more than remaining rows under the cap."
+  [total-limit page]
+  (max 0 (min page-size (- total-limit (* (dec page) page-size)))))
 
 (defn- apply-page-to-query
   "Apply :page clause to the last stage of a MBQL 5 query map."
@@ -416,11 +442,12 @@
                            :context     :agent})))
 
 (defn- prepare-combined-query
-  "Apply the tighter row cap used by the combined query endpoint."
+  "Apply the tighter row cap used by the combined query endpoint. Each page is bounded
+   by page-size; the user's total-limit is enforced separately via pagination."
   [query]
   (assoc (prepare-agent-query query)
-         :constraints {:max-results           max-query-row-limit
-                       :max-results-bare-rows max-query-row-limit}))
+         :constraints {:max-results           page-size
+                       :max-results-bare-rows page-size}))
 
 (mr/def ::query-request
   "Request body for /v2/query. Accepts either a structured program or a continuation_token."
@@ -447,13 +474,14 @@
   [_route-params
    _query-params
    body :- ::query-request]
-  (let [{:keys [query limit page]}
+  (let [{:keys [query total-limit page]}
         (if-let [token (:continuation_token body)]
           (let [{:keys [query pagination]} (decode-continuation-token token)]
-            {:query query :limit (:limit pagination) :page (:page pagination)})
-          (let [query (evaluate-program-for-execution body)]
-            {:query query :limit (query-page-size query) :page 1}))
-        mbql5-with-page (apply-page-to-query query page limit)]
+            {:query query :total-limit (:limit pagination) :page (:page pagination)})
+          (let [{:keys [query total-limit]} (extract-total-limit (evaluate-program-for-execution body))]
+            {:query query :total-limit total-limit :page 1}))
+        items           (compute-page-items total-limit page)
+        mbql5-with-page (apply-page-to-query query page items)]
     (qp.streaming/streaming-response
      [rff :api]
       (qp/process-query
@@ -462,8 +490,9 @@
         rff
         (fn [result]
           (assoc result :continuation_token
-                 (when (= (:row_count result) limit)
-                   (generate-continuation-token query limit page)))))))))
+                 (when (and (= (:row_count result) items)
+                            (< (* page page-size) total-limit))
+                   (generate-continuation-token query total-limit page)))))))))
 
 ;;; ------------------------------------------------- Execute Query --------------------------------------------------
 

--- a/src/metabase/api/macros/defendpoint/tools_manifest.clj
+++ b/src/metabase/api/macros/defendpoint/tools_manifest.clj
@@ -247,6 +247,8 @@
         task-support  (:task-support tool-md)
         scope         (get-in form [:metadata :scope])
         body-schema   (get-in form [:params :body :schema])
+        ;; Opt-out for tools that want raw schema errors to reach the client unchanged —
+        ;; e.g. tools whose argument coercion would mask useful validation feedback.
         strict-input? (:strict-input-shape? tool-md)]
     (cond-> {:name        tool-name
              :description description

--- a/src/metabase/api/macros/defendpoint/tools_manifest.clj
+++ b/src/metabase/api/macros/defendpoint/tools_manifest.clj
@@ -233,19 +233,19 @@
 (defn endpoint->tool-definition
   "Convert a single endpoint info + prefix to a tool definition map."
   [prefix {:keys [form]}]
-  (let [method        (:method form)
-        route-path    (get-in form [:route :path])
-        tool-md       (get-in form [:metadata :tool])
-        tool-name     (:name tool-md)
-        _             (assert (string? tool-name) "Tool :name must be a string")
-        description   (or (:description tool-md)
-                          (:docstr form))
-        full-path     (str prefix (route-path->endpoint-path route-path))
-        input-schema  (merge-input-schemas form)
-        resp-schema   (response-schema->json-schema (:response-schema form))
-        annotations   (infer-annotations method (:annotations tool-md))
-        task-support  (:task-support tool-md)
-        scope         (get-in form [:metadata :scope])]
+  (let [method       (:method form)
+        route-path   (get-in form [:route :path])
+        tool-md      (get-in form [:metadata :tool])
+        tool-name    (:name tool-md)
+        _            (assert (string? tool-name) "Tool :name must be a string")
+        description  (or (:description tool-md)
+                         (:docstr form))
+        full-path    (str prefix (route-path->endpoint-path route-path))
+        input-schema (merge-input-schemas form)
+        resp-schema  (response-schema->json-schema (:response-schema form))
+        annotations  (infer-annotations method (:annotations tool-md))
+        task-support (:task-support tool-md)
+        scope        (get-in form [:metadata :scope])]
     (cond-> {:name        tool-name
              :description description
              :endpoint    {:method (u/upper-case-en (name method))

--- a/src/metabase/api/macros/defendpoint/tools_manifest.clj
+++ b/src/metabase/api/macros/defendpoint/tools_manifest.clj
@@ -233,19 +233,21 @@
 (defn endpoint->tool-definition
   "Convert a single endpoint info + prefix to a tool definition map."
   [prefix {:keys [form]}]
-  (let [method       (:method form)
-        route-path   (get-in form [:route :path])
-        tool-md      (get-in form [:metadata :tool])
-        tool-name    (:name tool-md)
-        _            (assert (string? tool-name) "Tool :name must be a string")
-        description  (or (:description tool-md)
-                         (:docstr form))
-        full-path    (str prefix (route-path->endpoint-path route-path))
-        input-schema (merge-input-schemas form)
-        resp-schema  (response-schema->json-schema (:response-schema form))
-        annotations  (infer-annotations method (:annotations tool-md))
-        task-support (:task-support tool-md)
-        scope        (get-in form [:metadata :scope])]
+  (let [method        (:method form)
+        route-path    (get-in form [:route :path])
+        tool-md       (get-in form [:metadata :tool])
+        tool-name     (:name tool-md)
+        _             (assert (string? tool-name) "Tool :name must be a string")
+        description   (or (:description tool-md)
+                          (:docstr form))
+        full-path     (str prefix (route-path->endpoint-path route-path))
+        input-schema  (merge-input-schemas form)
+        resp-schema   (response-schema->json-schema (:response-schema form))
+        annotations   (infer-annotations method (:annotations tool-md))
+        task-support  (:task-support tool-md)
+        scope         (get-in form [:metadata :scope])
+        body-schema   (get-in form [:params :body :schema])
+        strict-input? (:strict-input-shape? tool-md)]
     (cond-> {:name        tool-name
              :description description
              :endpoint    {:method (u/upper-case-en (name method))
@@ -254,7 +256,9 @@
       resp-schema       (assoc :responseSchema resp-schema)
       (seq annotations) (assoc :annotations annotations)
       task-support      (assoc :execution {:taskSupport (name task-support)})
-      (string? scope)   (assoc :scope scope))))
+      (string? scope)   (assoc :scope scope)
+      body-schema       (assoc :body-schema body-schema)
+      strict-input?     (assoc :strict-input-shape? true))))
 
 (defn check-tool-uniqueness
   "Throws if `tools` contains duplicate `:name` values. The exception message lists each

--- a/src/metabase/api/macros/defendpoint/tools_manifest.clj
+++ b/src/metabase/api/macros/defendpoint/tools_manifest.clj
@@ -245,11 +245,7 @@
         resp-schema   (response-schema->json-schema (:response-schema form))
         annotations   (infer-annotations method (:annotations tool-md))
         task-support  (:task-support tool-md)
-        scope         (get-in form [:metadata :scope])
-        body-schema   (get-in form [:params :body :schema])
-        ;; Opt-out for tools that want raw schema errors to reach the client unchanged —
-        ;; e.g. tools whose argument coercion would mask useful validation feedback.
-        strict-input? (:strict-input-shape? tool-md)]
+        scope         (get-in form [:metadata :scope])]
     (cond-> {:name        tool-name
              :description description
              :endpoint    {:method (u/upper-case-en (name method))
@@ -258,9 +254,7 @@
       resp-schema       (assoc :responseSchema resp-schema)
       (seq annotations) (assoc :annotations annotations)
       task-support      (assoc :execution {:taskSupport (name task-support)})
-      (string? scope)   (assoc :scope scope)
-      body-schema       (assoc :body-schema body-schema)
-      strict-input?     (assoc :strict-input-shape? true))))
+      (string? scope)   (assoc :scope scope))))
 
 (defn check-tool-uniqueness
   "Throws if `tools` contains duplicate `:name` values. The exception message lists each

--- a/src/metabase/mcp/tools.clj
+++ b/src/metabase/mcp/tools.clj
@@ -4,6 +4,8 @@
   (:require
    [clojure.core.async :as a]
    [clojure.string :as str]
+   [malli.core :as mc]
+   [malli.transform :as mtx]
    [metabase.agent-api.api :as agent-api]
    [metabase.api-scope.core :as api-scope]
    [metabase.api.common :as api]
@@ -12,7 +14,8 @@
    [metabase.config.core :as config]
    [metabase.server.streaming-response :as streaming-response]
    [metabase.util :as u]
-   [metabase.util.json :as json])
+   [metabase.util.json :as json]
+   [metabase.util.malli.registry :as mr])
   (:import
    (java.io ByteArrayOutputStream)
    (java.net URLEncoder)
@@ -76,6 +79,49 @@
   (if config/is-dev?
     (build-tool-index (:tools (manifest)))
     @tool-index-delay))
+
+(defn- parse-json-if-matches
+  "Return `value` parsed as JSON when it's a string that parses into a value matching `pred`,
+   otherwise return `value` unchanged. Used by [[stringified-json-transformer]]."
+  [value pred]
+  (if (and (string? value) (seq value))
+    (try
+      (let [parsed (json/decode+kw value)]
+        (if (pred parsed) parsed value))
+      (catch Exception _ value))
+    value))
+
+(def ^:private stringified-json-transformer
+  "Malli transformer that parses JSON-encoded collection strings into their structured form.
+   Built-in `string-transformer`/`json-transformer` handle scalars but not `\"[...]\"` → vector
+   or `\"{...}\"` → map — some MCP clients stringify structured args, so we add that here."
+  (mtx/transformer
+   {:decoders {:vector     {:compile (fn [_ _] #(parse-json-if-matches % sequential?))}
+               :sequential {:compile (fn [_ _] #(parse-json-if-matches % sequential?))}
+               :map        {:compile (fn [_ _] #(parse-json-if-matches % map?))}
+               :map-of     {:compile (fn [_ _] #(parse-json-if-matches % map?))}}}))
+
+(def ^:private argument-decode-transformer
+  (mtx/transformer
+   (mtx/string-transformer)
+   (mtx/json-transformer)
+   stringified-json-transformer))
+
+(defn- body-decoder
+  "Cached Malli decoder for a tool's body schema, applied before the defendpoint
+   machinery performs its own validation."
+  [schema]
+  (mr/cached ::body-decoder schema
+             #(mc/decoder schema argument-decode-transformer)))
+
+(defn- coerce-body-arguments
+  "Decode body arguments against the tool's Malli body schema. Tools marked
+   `:strict-input-shape?` opt out so validation errors reach the client unchanged."
+  [tool-def arguments]
+  (if-let [schema (and (not (:strict-input-shape? tool-def))
+                       (:body-schema tool-def))]
+    ((body-decoder schema) arguments)
+    arguments))
 
 ;;; ------------------------------------------------- Tool Dispatch -------------------------------------------------
 
@@ -179,8 +225,10 @@
         method                (keyword (u/lower-case-en method))
         [resolved-path
          remaining-args]      (interpolate-path path arguments)
-        api-path              (strip-api-prefix resolved-path)]
-    (invoke-agent-api method api-path token-scopes remaining-args)))
+        api-path              (strip-api-prefix resolved-path)
+        body-args             (cond-> remaining-args
+                                (= :post method) (->> (coerce-body-arguments tool-def)))]
+    (invoke-agent-api method api-path token-scopes body-args)))
 
 (defn call-tool
   "Dispatch an MCP `tools/call` request to the appropriate handler.

--- a/src/metabase/mcp/tools.clj
+++ b/src/metabase/mcp/tools.clj
@@ -123,6 +123,38 @@
     ((body-decoder schema) arguments)
     arguments))
 
+(defn- format-validation-detail
+  "Flatten a defendpoint schema-error map — humanized by `malli.error`, whose leaves
+   are vectors of message strings and whose intermediate nodes may be nested maps —
+   into a compact `field: msg, msg; field: msg` rendering for MCP error text."
+  [errors-map]
+  (->> errors-map
+       (map (fn [[k v]]
+              (str (name k) ": "
+                   (cond
+                     (map? v)        (format-validation-detail v)
+                     (sequential? v) (str/join ", " v)
+                     :else           (str v)))))
+       (str/join "; ")))
+
+(defn- extract-error-message
+  "Pull the best human-readable string out of an agent-api error response. Agent-api
+   returns `:specific-errors`/`:errors` for schema-validation 400s (see
+   [[metabase.api.macros/decode-and-validate-params]]) and `:message`/`:error` for
+   other failures — surfacing the validation detail turns \"Invalid body\" into an
+   actionable message for MCP clients."
+  [response]
+  (let [{msg :message :keys [specific-errors errors error]} (:body response)
+        detail (cond
+                 (seq specific-errors) (format-validation-detail specific-errors)
+                 (seq errors)          (format-validation-detail errors))]
+    (cond
+      (and msg detail) (str msg " (" detail ")")
+      detail           detail
+      msg              msg
+      error            error
+      :else            (str "Agent API error: " (:status response)))))
+
 ;;; ------------------------------------------------- Tool Dispatch -------------------------------------------------
 
 (defn- text-content
@@ -167,7 +199,11 @@
      (deliver result (if (instance? StreamingResponse resp-body)
                        (capture-streaming-response resp-body)
                        response)))
-   (fn [error] (deliver result {:status 500 :body {:message (ex-message error)}}))))
+   (fn [error]
+     (let [{:keys [status-code] :as data} (ex-data error)]
+       (deliver result {:status (or status-code 500)
+                        :body   (merge (select-keys data [:errors :specific-errors])
+                                       {:message (or (ex-message error) "Internal error")})})))))
 
 (defn- invoke-agent-api
   "Invoke an Agent API endpoint with a synthetic Ring request.
@@ -189,9 +225,7 @@
         (text-content (:body response))
 
         :else
-        (error-content (or (some-> response :body :message)
-                           (some-> response :body :error)
-                           (str "Agent API error: " (:status response))))))))
+        (error-content (extract-error-message response))))))
 
 (defn- interpolate-path
   "Replace `{param}` placeholders in `path` with values from `arguments`.

--- a/src/metabase/mcp/tools.clj
+++ b/src/metabase/mcp/tools.clj
@@ -4,8 +4,6 @@
   (:require
    [clojure.core.async :as a]
    [clojure.string :as str]
-   [malli.core :as mc]
-   [malli.transform :as mtx]
    [metabase.agent-api.api :as agent-api]
    [metabase.api-scope.core :as api-scope]
    [metabase.api.common :as api]
@@ -14,8 +12,7 @@
    [metabase.config.core :as config]
    [metabase.server.streaming-response :as streaming-response]
    [metabase.util :as u]
-   [metabase.util.json :as json]
-   [metabase.util.malli.registry :as mr])
+   [metabase.util.json :as json])
   (:import
    (java.io ByteArrayOutputStream)
    (java.net URLEncoder)
@@ -79,49 +76,6 @@
   (if config/is-dev?
     (build-tool-index (:tools (manifest)))
     @tool-index-delay))
-
-(defn- parse-json-if-matches
-  "Return `value` parsed as JSON when it's a string that parses into a value matching `pred`,
-   otherwise return `value` unchanged. Used by [[stringified-json-transformer]]."
-  [value pred]
-  (if (and (string? value) (seq value))
-    (try
-      (let [parsed (json/decode+kw value)]
-        (if (pred parsed) parsed value))
-      (catch Exception _ value))
-    value))
-
-(def ^:private stringified-json-transformer
-  "Malli transformer that parses JSON-encoded collection strings into their structured form.
-   Built-in `string-transformer`/`json-transformer` handle scalars but not `\"[...]\"` → vector
-   or `\"{...}\"` → map — some MCP clients stringify structured args, so we add that here."
-  (mtx/transformer
-   {:decoders {:vector     {:compile (fn [_ _] #(parse-json-if-matches % sequential?))}
-               :sequential {:compile (fn [_ _] #(parse-json-if-matches % sequential?))}
-               :map        {:compile (fn [_ _] #(parse-json-if-matches % map?))}
-               :map-of     {:compile (fn [_ _] #(parse-json-if-matches % map?))}}}))
-
-(def ^:private argument-decode-transformer
-  (mtx/transformer
-   (mtx/string-transformer)
-   (mtx/json-transformer)
-   stringified-json-transformer))
-
-(defn- body-decoder
-  "Cached Malli decoder for a tool's body schema, applied before the defendpoint
-   machinery performs its own validation."
-  [schema]
-  (mr/cached ::body-decoder schema
-             #(mc/decoder schema argument-decode-transformer)))
-
-(defn- coerce-body-arguments
-  "Decode body arguments against the tool's Malli body schema. Tools marked
-   `:strict-input-shape?` opt out so validation errors reach the client unchanged."
-  [tool-def arguments]
-  (if-let [schema (and (not (:strict-input-shape? tool-def))
-                       (:body-schema tool-def))]
-    ((body-decoder schema) arguments)
-    arguments))
 
 (defn- format-validation-detail
   "Flatten a defendpoint schema-error map — humanized by `malli.error`, whose leaves
@@ -259,10 +213,8 @@
         method                (keyword (u/lower-case-en method))
         [resolved-path
          remaining-args]      (interpolate-path path arguments)
-        api-path              (strip-api-prefix resolved-path)
-        body-args             (cond-> remaining-args
-                                (= :post method) (->> (coerce-body-arguments tool-def)))]
-    (invoke-agent-api method api-path token-scopes body-args)))
+        api-path              (strip-api-prefix resolved-path)]
+    (invoke-agent-api method api-path token-scopes remaining-args)))
 
 (defn call-tool
   "Dispatch an MCP `tools/call` request to the appropriate handler.

--- a/test/metabase/agent_api/api_test.clj
+++ b/test/metabase/agent_api/api_test.clj
@@ -444,6 +444,26 @@
                                   {:source     {:type "table" :id (mt/id :orders)}
                                    :operations [["limit" 1000]]})))))
 
+(defn- make-continuation-token [pagination]
+  (-> {:query {:database (mt/id) :stages [{:source-table (mt/id :orders)}]}
+       :pagination pagination}
+      json/encode
+      u/encode-base64))
+
+(deftest continuation-token-validation-test
+  (testing "Malformed pagination ints in a continuation token produce a 400, not a 500.
+            This is robustness — the token isn't a trust boundary, since a caller can
+            always issue a fresh program."
+    (doseq [[label pagination] [["zero limit"         {:limit 0      :page 1}]
+                                ["negative limit"     {:limit -10    :page 1}]
+                                ["non-integer limit"  {:limit "lots" :page 1}]
+                                ["zero page"          {:limit 200    :page 0}]
+                                ["negative page"      {:limit 200    :page -1}]
+                                ["non-integer page"   {:limit 200    :page "next"}]]]
+      (testing label
+        (mt/user-http-request :rasta :post 400 "agent/v2/query"
+                              {:continuation_token (make-continuation-token pagination)})))))
+
 (deftest combined-query-metric-test
   (mt/with-temp [:model/Card metric {:name          "Test Metric"
                                      :type          :metric

--- a/test/metabase/agent_api/api_test.clj
+++ b/test/metabase/agent_api/api_test.clj
@@ -6,6 +6,7 @@
    [environ.core :as env]
    [java-time.api :as t]
    [medley.core :as m]
+   [metabase.agent-api.api :as agent-api.api]
    [metabase.agent-api.settings :as agent-api.settings]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
@@ -229,6 +230,22 @@
                    :total_count 1}
                   (mt/user-http-request :rasta :post 200 "agent/v1/search"
                                         {:term_queries ["AgentSearchTestTable"]}))))))))
+
+(deftest coerce-query-list-test
+  (let [coerce #'agent-api.api/coerce-query-list]
+    (testing "arrays pass through unchanged"
+      (is (= ["orders" "revenue"] (coerce ["orders" "revenue"]))))
+    (testing "nil stays nil"
+      (is (nil? (coerce nil))))
+    (testing "a bare string becomes a single-element list"
+      (is (= ["orders"] (coerce "orders"))))
+    (testing "a JSON-stringified array of strings is unwrapped"
+      (is (= ["orders" "revenue"] (coerce "[\"orders\", \"revenue\"]"))))
+    (testing "JSON arrays with non-string elements are not unwrapped — they fall back to a literal single query so that downstream :sequential NonBlankString validation is never bypassed"
+      (is (= ["[1, 2]"] (coerce "[1, 2]")))
+      (is (= ["[\"\"]"] (coerce "[\"\"]"))))
+    (testing "non-JSON strings become a single-element list"
+      (is (= ["not json ["] (coerce "not json ["))))))
 
 (defn- decode-query
   "Decode a base64-encoded query response to a Clojure map, then normalize it so lib functions work."

--- a/test/metabase/agent_api/api_test.clj
+++ b/test/metabase/agent_api/api_test.clj
@@ -376,7 +376,7 @@
                   (:measures table))))))))
 
 (deftest combined-query-test
-  (testing "Returns results for a table query"
+  (testing "Returns results for a table query that fits in a single page"
     (let [table-id (mt/id :orders)
           field-id (visible-field-id table-id "ID")
           response (mt/user-http-request :rasta :post 202 "agent/v2/query"
@@ -385,27 +385,29 @@
                                                        ["limit" 5]]})]
       (is (=? {:status             "completed"
                :row_count          5
-               :continuation_token string?
+               :continuation_token nil?
                :data               {:cols sequential?
                                     :rows (fn [rows] (= 5 (count rows)))}}
               response))))
 
-  (testing "Continuation token returns next page of results"
-    (let [table-id (mt/id :orders)
-          field-id (visible-field-id table-id "ID")
-          page1    (mt/user-http-request :rasta :post 202 "agent/v2/query"
-                                         {:source     {:type "table" :id table-id}
-                                          :operations [["order-by" ["field" field-id]]
-                                                       ["limit" 5]]})
-          page2    (mt/user-http-request :rasta :post 202 "agent/v2/query"
-                                         {:continuation_token (:continuation_token page1)})]
-      (is (=? {:row_count          5
+  (testing "Continuation token returns next page of results when the total limit exceeds the page size"
+    (let [table-id   (mt/id :orders)
+          field-id   (visible-field-id table-id "ID")
+          page-size  200
+          total-rows 250
+          page1      (mt/user-http-request :rasta :post 202 "agent/v2/query"
+                                           {:source     {:type "table" :id table-id}
+                                            :operations [["order-by" ["field" field-id]]
+                                                         ["limit" total-rows]]})
+          page2      (mt/user-http-request :rasta :post 202 "agent/v2/query"
+                                           {:continuation_token (:continuation_token page1)})]
+      (is (=? {:row_count          page-size
                :continuation_token string?
-               :data               {:rows (fn [rows] (= 5 (count rows)))}}
+               :data               {:rows (fn [rows] (= page-size (count rows)))}}
               page1))
-      (is (=? {:row_count          5
-               :continuation_token string?
-               :data               {:rows (fn [rows] (= 5 (count rows)))}}
+      (is (=? {:row_count          (- total-rows page-size)
+               :continuation_token nil?
+               :data               {:rows (fn [rows] (= (- total-rows page-size) (count rows)))}}
               page2))
       (is (not= (get-in page1 [:data :rows])
                 (get-in page2 [:data :rows]))
@@ -418,7 +420,7 @@
                                   {:source     {:type "table" :id (mt/id :orders)}
                                    :operations [["aggregate" ["count"]]]}))))
 
-  (testing "Constraint cap limits results to 200 rows"
+  (testing "Per-page cap limits a single page to 200 rows even when the total limit is higher"
     (is (=? {:status    "completed"
              :row_count (fn [n] (<= n 200))}
             (mt/user-http-request :rasta :post 202 "agent/v2/query"

--- a/test/metabase/mcp/api_test.clj
+++ b/test/metabase/mcp/api_test.clj
@@ -183,19 +183,24 @@
           (is (string? (:description tool)))
           (is (map? (:inputSchema tool)))))
       (testing "search description guides clients toward the expected array shape"
-        (let [tools-by-name (into {} (map (juxt :name identity)) tools)
-              search-tool   (get tools-by-name "search")
+        (let [tools-by-name   (into {} (map (juxt :name identity)) tools)
+              search-tool     (get tools-by-name "search")
               property-schema (fn [tool-name property-name]
                                 (or (get-in tools-by-name [tool-name :inputSchema :properties property-name])
                                     (get-in tools-by-name [tool-name :inputSchema :properties (keyword property-name)])))
-              one-of-types  (fn [schema]
-                              (set (keep :type (:oneOf schema))))
-              array-branch  (fn [schema]
-                              (some #(when (= "array" (:type %)) %) (:oneOf schema)))]
+              collect-leaves  (fn collect-leaves [schema]
+                                (cond
+                                  (nil? schema)         []
+                                  (:oneOf schema)       (mapcat collect-leaves (:oneOf schema))
+                                  (:anyOf schema)       (mapcat collect-leaves (:anyOf schema))
+                                  :else                 [schema]))
+              leaf-types      (fn [schema] (set (keep :type (collect-leaves schema))))
+              array-branch    (fn [schema]
+                                (some #(when (= "array" (:type %)) %) (collect-leaves schema)))]
           (is (str/includes? (:description search-tool) "arrays of strings"))
-          (is (= #{"array" "null"} (one-of-types (property-schema "search" "term_queries"))))
+          (is (contains? (leaf-types (property-schema "search" "term_queries")) "array"))
           (is (= "string" (get-in (array-branch (property-schema "search" "term_queries")) [:items :type])))
-          (is (= #{"array" "null"} (one-of-types (property-schema "search" "semantic_queries"))))
+          (is (contains? (leaf-types (property-schema "search" "semantic_queries")) "array"))
           (is (= "string" (get-in (array-branch (property-schema "search" "semantic_queries")) [:items :type]))))))))
 
 (deftest ping-test

--- a/test/metabase/mcp/api_test.clj
+++ b/test/metabase/mcp/api_test.clj
@@ -264,7 +264,6 @@
             message        (:text (first (:content result)))]
         (is (= 200 (:status response)))
         (is (true? (:isError result)))
-        (is (str/starts-with? message "Invalid body"))
         (is (str/includes? message "term_queries")))))
 
   (testing "search returns actionable error for singleton semantic query strings"
@@ -278,7 +277,6 @@
             message        (:text (first (:content result)))]
         (is (= 200 (:status response)))
         (is (true? (:isError result)))
-        (is (str/starts-with? message "Invalid body"))
         (is (str/includes? message "semantic_queries")))))
 
   (testing "search coerces JSON-stringified arrays so clients that serialize args through a string layer still work"

--- a/test/metabase/mcp/api_test.clj
+++ b/test/metabase/mcp/api_test.clj
@@ -184,12 +184,19 @@
           (is (map? (:inputSchema tool)))))
       (testing "search description guides clients toward the expected array shape"
         (let [tools-by-name (into {} (map (juxt :name identity)) tools)
-              property-desc (fn [tool-name property-name]
-                              (or (get-in tools-by-name [tool-name :inputSchema :properties property-name :description])
-                                  (get-in tools-by-name [tool-name :inputSchema :properties (keyword property-name) :description])))]
-          (is (str/includes? (get-in tools-by-name ["search" :description]) "JSON arrays of strings"))
-          (is (str/includes? (property-desc "search" "term_queries") "JSON array of strings"))
-          (is (str/includes? (property-desc "search" "semantic_queries") "JSON array of strings")))))))
+              search-tool   (get tools-by-name "search")
+              property-schema (fn [tool-name property-name]
+                                (or (get-in tools-by-name [tool-name :inputSchema :properties property-name])
+                                    (get-in tools-by-name [tool-name :inputSchema :properties (keyword property-name)])))
+              one-of-types  (fn [schema]
+                              (set (keep :type (:oneOf schema))))
+              array-branch  (fn [schema]
+                              (some #(when (= "array" (:type %)) %) (:oneOf schema)))]
+          (is (str/includes? (:description search-tool) "arrays of strings"))
+          (is (= #{"array" "null"} (one-of-types (property-schema "search" "term_queries"))))
+          (is (= "string" (get-in (array-branch (property-schema "search" "term_queries")) [:items :type])))
+          (is (= #{"array" "null"} (one-of-types (property-schema "search" "semantic_queries"))))
+          (is (= "string" (get-in (array-branch (property-schema "search" "semantic_queries")) [:items :type]))))))))
 
 (deftest ping-test
   (testing "ping returns empty result"
@@ -246,31 +253,35 @@
           (is (contains? search-data :data))
           (is (contains? search-data :total_count))))))
 
-  (testing "search rejects singleton string arguments"
+  (testing "search returns actionable error for singleton string arguments"
     (search.tu/with-legacy-search
       (let [[session-id _] (initialize!)
             response       (mcp-request (jsonrpc-request "tools/call"
                                                          {:name      "search"
                                                           :arguments {:term_queries "orders"}})
                                         {"mcp-session-id" session-id})
-            result         (get-in response [:body :result])]
+            result         (get-in response [:body :result])
+            message        (:text (first (:content result)))]
         (is (= 200 (:status response)))
         (is (true? (:isError result)))
-        (is (= "Invalid body" (:text (first (:content result))))))))
+        (is (str/starts-with? message "Invalid body"))
+        (is (str/includes? message "term_queries")))))
 
-  (testing "search rejects singleton semantic query strings"
+  (testing "search returns actionable error for singleton semantic query strings"
     (search.tu/with-legacy-search
       (let [[session-id _] (initialize!)
             response       (mcp-request (jsonrpc-request "tools/call"
                                                          {:name      "search"
                                                           :arguments {:semantic_queries "orders table"}})
                                         {"mcp-session-id" session-id})
-            result         (get-in response [:body :result])]
+            result         (get-in response [:body :result])
+            message        (:text (first (:content result)))]
         (is (= 200 (:status response)))
         (is (true? (:isError result)))
-        (is (= "Invalid body" (:text (first (:content result))))))))
+        (is (str/starts-with? message "Invalid body"))
+        (is (str/includes? message "semantic_queries")))))
 
-  (testing "search rejects JSON-stringified arrays"
+  (testing "search coerces JSON-stringified arrays so clients that serialize args through a string layer still work"
     (search.tu/with-legacy-search
       (let [[session-id _] (initialize!)
             response       (mcp-request (jsonrpc-request "tools/call"
@@ -279,8 +290,10 @@
                                         {"mcp-session-id" session-id})
             result         (get-in response [:body :result])]
         (is (= 200 (:status response)))
-        (is (true? (:isError result)))
-        (is (= "Invalid body" (:text (first (:content result)))))))))
+        (is (nil? (:isError result)))
+        (let [search-data (json/decode+kw (:text (first (:content result))))]
+          (is (contains? search-data :data))
+          (is (contains? search-data :total_count)))))))
 
 (deftest tools-call-query-coerces-stringified-structured-args-test
   (testing "query accepts JSON-stringified order_by arguments"

--- a/test/metabase/mcp/api_test.clj
+++ b/test/metabase/mcp/api_test.clj
@@ -181,7 +181,15 @@
       (testing "each tool has a description and inputSchema"
         (doseq [tool tools]
           (is (string? (:description tool)))
-          (is (map? (:inputSchema tool))))))))
+          (is (map? (:inputSchema tool)))))
+      (testing "search description guides clients toward the expected array shape"
+        (let [tools-by-name (into {} (map (juxt :name identity)) tools)
+              property-desc (fn [tool-name property-name]
+                              (or (get-in tools-by-name [tool-name :inputSchema :properties property-name :description])
+                                  (get-in tools-by-name [tool-name :inputSchema :properties (keyword property-name) :description])))]
+          (is (str/includes? (get-in tools-by-name ["search" :description]) "JSON arrays of strings"))
+          (is (str/includes? (property-desc "search" "term_queries") "JSON array of strings"))
+          (is (str/includes? (property-desc "search" "semantic_queries") "JSON array of strings")))))))
 
 (deftest ping-test
   (testing "ping returns empty result"
@@ -236,7 +244,56 @@
         (is (= "text" (:type (first (:content result)))))
         (let [search-data (json/decode+kw (:text (first (:content result))))]
           (is (contains? search-data :data))
-          (is (contains? search-data :total_count)))))))
+          (is (contains? search-data :total_count))))))
+
+  (testing "search rejects singleton string arguments"
+    (search.tu/with-legacy-search
+      (let [[session-id _] (initialize!)
+            response       (mcp-request (jsonrpc-request "tools/call"
+                                                         {:name      "search"
+                                                          :arguments {:term_queries "orders"}})
+                                        {"mcp-session-id" session-id})
+            result         (get-in response [:body :result])]
+        (is (= 200 (:status response)))
+        (is (true? (:isError result)))
+        (is (= "Invalid body" (:text (first (:content result))))))))
+
+  (testing "search rejects singleton semantic query strings"
+    (search.tu/with-legacy-search
+      (let [[session-id _] (initialize!)
+            response       (mcp-request (jsonrpc-request "tools/call"
+                                                         {:name      "search"
+                                                          :arguments {:semantic_queries "orders table"}})
+                                        {"mcp-session-id" session-id})
+            result         (get-in response [:body :result])]
+        (is (= 200 (:status response)))
+        (is (true? (:isError result)))
+        (is (= "Invalid body" (:text (first (:content result))))))))
+
+  (testing "search rejects JSON-stringified arrays"
+    (search.tu/with-legacy-search
+      (let [[session-id _] (initialize!)
+            response       (mcp-request (jsonrpc-request "tools/call"
+                                                         {:name      "search"
+                                                          :arguments {:term_queries "[\"orders\"]"}})
+                                        {"mcp-session-id" session-id})
+            result         (get-in response [:body :result])]
+        (is (= 200 (:status response)))
+        (is (true? (:isError result)))
+        (is (= "Invalid body" (:text (first (:content result)))))))))
+
+(deftest tools-call-query-coerces-stringified-structured-args-test
+  (testing "query accepts JSON-stringified order_by arguments"
+    (let [[session-id _] (initialize!)
+          table-id       (mt/id :orders)
+          query-data     (call-tool session-id "query"
+                                    {:table_id table-id
+                                     :order_by (format "[{\"field\":{\"field_id\":\"t%d-0\"},\"direction\":\"asc\"}]"
+                                                       table-id)
+                                     :limit    5})]
+      (is (= "completed" (:status query-data)))
+      (is (= 5 (:row_count query-data)))
+      (is (seq (get-in query-data [:json_query :stages 0 :order-by]))))))
 
 ;;; ------------------------------------------------ SSE Transport -------------------------------------------------
 

--- a/test/metabase/mcp/api_test.clj
+++ b/test/metabase/mcp/api_test.clj
@@ -253,31 +253,18 @@
           (is (contains? search-data :data))
           (is (contains? search-data :total_count))))))
 
-  (testing "search returns actionable error for singleton string arguments"
+  (testing "search accepts a singleton string as a one-element query list"
     (search.tu/with-legacy-search
       (let [[session-id _] (initialize!)
             response       (mcp-request (jsonrpc-request "tools/call"
                                                          {:name      "search"
                                                           :arguments {:term_queries "orders"}})
                                         {"mcp-session-id" session-id})
-            result         (get-in response [:body :result])
-            message        (:text (first (:content result)))]
+            result         (get-in response [:body :result])]
         (is (= 200 (:status response)))
-        (is (true? (:isError result)))
-        (is (str/includes? message "term_queries")))))
-
-  (testing "search returns actionable error for singleton semantic query strings"
-    (search.tu/with-legacy-search
-      (let [[session-id _] (initialize!)
-            response       (mcp-request (jsonrpc-request "tools/call"
-                                                         {:name      "search"
-                                                          :arguments {:semantic_queries "orders table"}})
-                                        {"mcp-session-id" session-id})
-            result         (get-in response [:body :result])
-            message        (:text (first (:content result)))]
-        (is (= 200 (:status response)))
-        (is (true? (:isError result)))
-        (is (str/includes? message "semantic_queries")))))
+        (is (nil? (:isError result)))
+        (let [search-data (json/decode+kw (:text (first (:content result))))]
+          (is (contains? search-data :data))))))
 
   (testing "search coerces JSON-stringified arrays so clients that serialize args through a string layer still work"
     (search.tu/with-legacy-search
@@ -292,19 +279,6 @@
         (let [search-data (json/decode+kw (:text (first (:content result))))]
           (is (contains? search-data :data))
           (is (contains? search-data :total_count)))))))
-
-(deftest tools-call-query-coerces-stringified-structured-args-test
-  (testing "query accepts JSON-stringified order_by arguments"
-    (let [[session-id _] (initialize!)
-          table-id       (mt/id :orders)
-          query-data     (call-tool session-id "query"
-                                    {:table_id table-id
-                                     :order_by (format "[{\"field\":{\"field_id\":\"t%d-0\"},\"direction\":\"asc\"}]"
-                                                       table-id)
-                                     :limit    5})]
-      (is (= "completed" (:status query-data)))
-      (is (= 5 (:row_count query-data)))
-      (is (seq (get-in query-data [:json_query :stages 0 :order-by]))))))
 
 ;;; ------------------------------------------------ SSE Transport -------------------------------------------------
 


### PR DESCRIPTION
- Reworks query pagination to have separate `page-size` and `max-total-row-limit` constants, as well as some other small fixes to pagination semantics
- Relaxes the input schema for search — Codex persistently was trying to send a stringified JSON array, rather than just an array of strings. Not a problem for Claude so seems to be something harness-specific. I've relaxed the tool to accept either.
- Expands search tool descriptions to include usage examples
- Returns better errors on schema validation failures