### PR TITLE
Improve checker

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/dependencies/analysis.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/analysis.clj
@@ -54,11 +54,15 @@
         driver            (:engine (lib.metadata/database metadata-provider))
         query             (lib/query metadata-provider query)
         output-fields     (returned-columns driver query)
+        ;; Group by the user-visible column name (the alias when present),
+        ;; not the underlying column's `:name` — otherwise `t1.name AS a` and
+        ;; `t2.name AS b` look like duplicates because both have `:name "name"`.
+        output-name       #(or (:lib/desired-column-alias %) (:name %))
         duplicated-fields (->> output-fields
-                               (group-by :name)
+                               (group-by output-name)
                                vals
                                (keep #(when (> (count %) 1)
-                                        (lib/duplicate-column-error (-> % first :name))))
+                                        (lib/duplicate-column-error (output-name (first %)))))
                                seq)]
     (cond-> (check-query driver query)
       duplicated-fields (into duplicated-fields))))

--- a/enterprise/backend/src/metabase_enterprise/dependencies/native_validation.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/native_validation.clj
@@ -259,29 +259,33 @@
 (mu/defn validate-native-query
   "Compiles a (native) query and validates that the fields and tables it refers to really exist.
 
-   Returns a set of errors, each enriched with source entity information when possible."
+   Returns a set of errors, each enriched with source entity information when possible.
+   Returns empty set for queries with table-type template tags since the actual
+   table (and therefore columns) is unknown at check time."
   [driver :- :keyword
    query  :- ::lib.schema/query]
-  (into #{}
-        (comp
-         ;; Strip :unknown source attribution — consumers should not distinguish between
-         ;; "we tried and couldn't determine the source" vs "no source info available".
-         (map #(cond-> % (= :unknown (:source-entity-type %)) (dissoc :source-entity-type :source-entity-id)))
-         ;; Remove errors referencing table placeholder names
-         (remove #(some-> (:name %) (str/starts-with? table-placeholder-prefix))))
-        (if (has-substitutable-template-tags? query)
-          (if-let [compiled (compile-toplevel-query query)]
-            (let [errors (validate-with-sources driver compiled true)]
+  (if (has-table-template-tags? query)
+    #{}
+    (into #{}
+          (comp
+           ;; Strip :unknown source attribution — consumers should not distinguish between
+           ;; "we tried and couldn't determine the source" vs "no source info available".
+           (map #(cond-> % (= :unknown (:source-entity-type %)) (dissoc :source-entity-type :source-entity-id)))
+           ;; Remove errors referencing table placeholder names
+           (remove #(some-> (:name %) (str/starts-with? table-placeholder-prefix))))
+          (if (has-substitutable-template-tags? query)
+            (if-let [compiled (compile-toplevel-query query)]
+              (let [errors (validate-with-sources driver compiled true)]
+                (if (empty? errors)
+                  errors
+                  (fallback-enrich driver compiled errors)))
+              ;; Fallback: cards with placeholder collision
+              (driver/validate-native-query-fields driver (compile-query query)))
+            (let [compiled (compile-query query)
+                  errors   (validate-with-sources driver compiled false)]
               (if (empty? errors)
                 errors
-                (fallback-enrich driver compiled errors)))
-            ;; Fallback: cards with placeholder collision
-            (driver/validate-native-query-fields driver (compile-query query)))
-          (let [compiled (compile-query query)
-                errors   (validate-with-sources driver compiled false)]
-            (if (empty? errors)
-              errors
-              (fallback-enrich driver compiled errors))))))
+                (fallback-enrich driver compiled errors)))))))
 
 (defn- has-table-template-tags?
   "Returns true if the query has any table-type template tags."

--- a/enterprise/backend/src/metabase_enterprise/dependencies/native_validation.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/native_validation.clj
@@ -256,6 +256,11 @@
               errors)
         errors))))
 
+(defn- has-table-template-tags?
+  "Returns true if the query has any table-type template tags."
+  [query]
+  (some #(= (:type %) :table) (lib/all-template-tags query)))
+
 (mu/defn validate-native-query
   "Compiles a (native) query and validates that the fields and tables it refers to really exist.
 
@@ -286,11 +291,6 @@
               (if (empty? errors)
                 errors
                 (fallback-enrich driver compiled errors)))))))
-
-(defn- has-table-template-tags?
-  "Returns true if the query has any table-type template tags."
-  [query]
-  (some #(= (:type %) :table) (lib/all-template-tags query)))
 
 (mu/defn native-result-metadata
   "Compiles a (native) query and calculates its result metadata.

--- a/enterprise/backend/test/metabase_enterprise/dependencies/native_validation_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/native_validation_test.clj
@@ -555,3 +555,46 @@
           dupes  (filter #(= :duplicate-column (:type %)) errors)]
       (is (= [{:type :duplicate-column :name "TOTAL"}] dupes)
           (str "Expected one :duplicate-column error, got: " (pr-str dupes))))))
+
+;;; ===========================================================================
+;;; Derived-table / CTE column resolution
+;;;
+;;; Columns defined in inline derived tables (subqueries in FROM) or by
+;;; window functions in CTEs must resolve correctly when the outer SELECT
+;;; aliases them to a different name. A mutation bug in sql_tools.py's
+;;; _find_returned_fields caused the source column's alias to be overwritten
+;;; with the outer alias, breaking resolution for later references to the
+;;; same column.
+;;; ===========================================================================
+
+(deftest ^:parallel derived-table-column-with-alias-test
+  (testing "column from derived table resolves when aliased to a different name"
+    (let [mp     (deps.tu/default-metadata-provider)
+          driver (:engine (lib.metadata/database mp))]
+      (validates? mp driver 4 #{})
+      (testing "simple derived table"
+        (is (empty? (deps.native-validation/validate-native-query driver
+                                                                  (fake-query mp "SELECT datum AS b FROM (SELECT 1 AS datum) DQ")))))
+      (testing "multiple references to derived-table column with different aliases"
+        (is (empty? (deps.native-validation/validate-native-query driver
+                                                                  (fake-query mp "SELECT datum AS b, datum - 1 AS d FROM (SELECT 1 AS datum) DQ")))))
+      (testing "derived table from GENERATE_SERIES with expressions"
+        (is (empty? (deps.native-validation/validate-native-query driver
+                                                                  (fake-query mp
+                                                                              "SELECT TO_CHAR(datum, 'yyyymmdd') AS a, datum AS b, datum + 1 AS c
+                         FROM (SELECT SEQUENCE.DAY AS datum
+                               FROM GENERATE_SERIES(0, 100) AS SEQUENCE (DAY)
+                               GROUP BY SEQUENCE.DAY) DQ"))))))))
+
+(deftest ^:parallel cte-window-function-column-test
+  (testing "column defined by window function in CTE resolves in outer query"
+    (let [mp     (deps.tu/default-metadata-provider)
+          driver (:engine (lib.metadata/database mp))]
+      (is (empty? (deps.native-validation/validate-native-query driver
+                                                                (fake-query mp
+                                                                            "WITH ranked AS (
+                         SELECT ID, TOTAL,
+                                LAG(TOTAL) OVER (ORDER BY ID) AS prev_total
+                         FROM ORDERS)
+                       SELECT prev_total AS source, TOTAL AS target
+                       FROM ranked")))))))

--- a/enterprise/backend/test/metabase_enterprise/dependencies/native_validation_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/native_validation_test.clj
@@ -1,6 +1,7 @@
 (ns metabase-enterprise.dependencies.native-validation-test
   (:require
    [clojure.test :refer :all]
+   [metabase-enterprise.dependencies.analysis :as deps.analysis]
    [metabase-enterprise.dependencies.native-validation :as deps.native-validation]
    [metabase-enterprise.dependencies.test-util :as deps.tu]
    [metabase.driver.sql :as driver.sql]
@@ -516,3 +517,41 @@
                                                {:source-entity-type :card
                                                 :source-entity-id 1234})})
                (deps.native-validation/validate-native-query driver query)))))))
+
+;;; ===========================================================================
+;;; Transform duplicate-column detection
+;;;
+;;; The :transform check in deps.analysis groups output fields by their
+;;; user-visible name (the alias when present), not the underlying column's
+;;; :name. Otherwise `t1.name AS user_name` and `t2.name AS venue_name` would
+;;; look like duplicates because both columns have :name "name".
+;;; ===========================================================================
+
+(defn- mp-with-transform [native-sql]
+  (let [query     (lib/->legacy-MBQL (lib/native-query meta/metadata-provider native-sql))
+        transform {:id     1
+                   :name   "tx"
+                   :source {:type :query :query query}
+                   :target {:type :table :schema "public" :name "out"}}]
+    (lib.tu/mock-metadata-provider meta/metadata-provider {:transforms [transform]})))
+
+(deftest ^:parallel transform-aliased-name-columns-not-duplicate-test
+  (testing "two `xxx.name` columns aliased to distinct names are NOT flagged as duplicates"
+    (let [mp     (mp-with-transform
+                  "SELECT u.NAME AS user_name, v.NAME AS venue_name
+                   FROM CHECKINS c
+                   JOIN USERS u ON c.USER_ID = u.ID
+                   JOIN VENUES v ON c.VENUE_ID = v.ID")
+          errors (deps.analysis/check-entity mp :transform 1)
+          dupes  (filter #(= :duplicate-column (:type %)) errors)]
+      (is (empty? dupes)
+          (str "Expected no :duplicate-column errors, got: " (pr-str dupes))))))
+
+(deftest ^:parallel transform-real-duplicate-still-flagged-test
+  (testing "a genuine output-name collision IS still flagged"
+    (let [mp     (mp-with-transform
+                  "SELECT TOTAL, SUBTOTAL AS total FROM ORDERS")
+          errors (deps.analysis/check-entity mp :transform 1)
+          dupes  (filter #(= :duplicate-column (:type %)) errors)]
+      (is (= [{:type :duplicate-column :name "TOTAL"}] dupes)
+          (str "Expected one :duplicate-column error, got: " (pr-str dupes))))))

--- a/enterprise/backend/test/metabase_enterprise/dependencies/native_validation_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/native_validation_test.clj
@@ -598,3 +598,14 @@
                          FROM ORDERS)
                        SELECT prev_total AS source, TOTAL AS target
                        FROM ranked")))))))
+
+(deftest ^:parallel table-template-tag-skipped-test
+  (testing "queries with table-type template tags are skipped (table is dynamic)"
+    (let [mp     (deps.tu/default-metadata-provider)
+          driver (:engine (lib.metadata/database mp))
+          query  (-> (lib/native-query mp "SELECT * FROM {{my_table}}")
+                     (lib/with-template-tags {"my_table" {:type         :table
+                                                          :name         "my_table"
+                                                          :display-name "My Table"
+                                                          :table-id     1}}))]
+      (is (empty? (deps.native-validation/validate-native-query driver query))))))

--- a/resources/python-sources/sql_tools.py
+++ b/resources/python-sources/sql_tools.py
@@ -1013,6 +1013,11 @@ class FieldReferenceWalker:
             alias = expr.alias
             for result in inner_results:
                 if "col" in result:
+                    # Shallow-copy before overwriting alias — the same dict may
+                    # be referenced as a source-column by other scopes. Mutating
+                    # it replaces the inner alias (e.g. "datum") with the outer
+                    # alias (e.g. "b"), breaking column resolution upstream.
+                    result["col"] = dict(result["col"])
                     result["col"]["alias"] = alias
             return inner_results
 
@@ -1374,8 +1379,10 @@ class FieldReferenceWalker:
                                 "source_columns": source_ref
                             }
                         }]
-                # Return custom_field as-is to preserve structure
-                return [{"col": source_column}]
+                # Copy before returning — callers may mutate the alias
+                # (e.g. _find_returned_fields sets alias for outer SELECT AS),
+                # and source_column is shared with the source's returned_fields.
+                return [{"col": dict(source_column)}]
             # For composite_field, etc.: return as-is to preserve structure
             else:
                 return [{"col": source_column}]


### PR DESCRIPTION
fixes for checkerThree checker bug fixes that eliminate ~50 false positives when validating native SQL transforms, plus tests for each.

  ### 1. Duplicate-column false positive on aliased columns

  `analysis.clj` — Transform duplicate-column detection grouped output columns by `:name` (the underlying column name) instead of `:lib/desired-column-alias` (the user-visible alias). `SELECT
  u.name AS user_name, v.name AS venue_name` was flagged as having duplicate `name` columns.

  **Fix:** group by `(or :lib/desired-column-alias :name)`.

  ### 2. Derived-table / CTE column alias mutation

  `sql_tools.py` — `_find_returned_fields` in our sqlglot wrapper mutated shared source dicts when processing `SELECT datum AS b`, overwriting the inner alias `"datum"` with the outer alias
  `"b"`. Later references to `datum` in the same query couldn't resolve because the source now said `"b"`.

  **Fix:** shallow-copy dicts before overwriting alias in both `_find_returned_fields` and `_get_column`.

  Eliminated **48 false positives** across 3 transforms:
  - `dim_dates`: 1 → 0 errors
  - `self_hosted_daily_stats_ping_monthly_usage`: 47 → 0 errors
  - `pa-events-to-sankey`: 4 → 3 errors (1 CTE column fixed; 3 remaining are an unresolved table, not a column issue)

  ### 3. Table-type template tag validation

  `native_validation.clj` — Queries with `{{table_one}}`-style table template tags were being validated even though the actual table is dynamic and unknown. `native-result-metadata` already
  skipped these but `validate-native-query` did not, causing a syntax error when the unresolved table-id path vector was substituted into SQL.

  **Fix:** early-return `#{}` from `validate-native-query` when table template tags are present.

  ## Tests added

  All in `native_validation_test.clj`:

  - `transform-aliased-name-columns-not-duplicate-test` — aliased columns from joined tables not flagged as dupes
  - `transform-real-duplicate-still-flagged-test` — genuine dupes still caught
  - `derived-table-column-with-alias-test` — derived table columns resolve with different aliases
  - `cte-window-function-column-test` — LAG/window function columns in CTEs resolve correctly
  - `table-template-tag-skipped-test` — table template tags skip validation