### PR TITLE
Add joins support to construct_query Agent API

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -159,15 +159,21 @@
               metabase.agent-api.init}
    :uses    #{api
               auth-identity
+              dashboards
+              events
               lib
               llm
               metabot
+              queries
               query-processor
               request
               server
               settings
               util}
-   :model-imports #{:model/User}}
+   :model-imports #{:model/Card
+                    :model/Dashboard
+                    :model/DashboardCard
+                    :model/User}}
 
   analytics
   {:team "UX West"

--- a/resources/metabot/prompts/tools/construct_notebook_query.md
+++ b/resources/metabot/prompts/tools/construct_notebook_query.md
@@ -82,6 +82,14 @@ There are 3 query types based on what data source and operations you need:
    - Available fields: All fields from source + related tables (auto-joined)
    - Note: No aggregations - this returns row-level data
 
+**Joining tables:**
+When data spans multiple related tables, use `joins` to combine them in a single query.
+- Only tables with foreign key relationships can be joined. Check `related_tables` from `get_table`.
+- Join conditions (ON clause) are automatic based on FK/PK relationships.
+- Strategy defaults to `left-join`. Use `inner-join` only when you need to exclude unmatched rows.
+- Field IDs from joined tables (obtained via `get_table` on the joined table) work in filters, group_by, aggregations, and fields.
+- Example: Orders with product categories: `{"table_id": 1, "joins": [{"table_id": 4}], "aggregations": [{"function": "count"}], "group_by": [{"field_id": "t4-1"}]}`
+
 **Temporal grouping (`field_granularity` for `group_by`):**
 When grouping by date/time fields, specify how to group:
 - `year`: 2024-01-15T12:13:14 → 2024
@@ -142,14 +150,14 @@ Note: Metabase will automatically map data to chart aesthetics (axes, labels). Y
 - **No post-aggregation filtering (HAVING clause)**: Cannot filter on count, sum, avg, etc.
   - ❌ "Find items appearing more than once" → Cannot filter count > 1
   - ✅ Instead: Group by item, count, sort descending, limit 100 (frequent items appear at top)
-- No joins, unions, subqueries, or combining multiple sources
+- No unions, subqueries, or combining multiple sources
 - No field calculations (e.g., field_a / field_b, field_a + field_b)
 - No window functions, cohort analysis, or advanced analytics
 - Filters are combined with AND logic; values within a filter use OR logic
 
 **When NOT to use this tool:**
 - Post-aggregation filtering needed (e.g., "categories where total sales > $10k")
-- Joins or complex SQL required
+- Complex SQL required (e.g., window functions, subqueries)
 - Field calculations or transformations needed
 - User explicitly requests SQL
 

--- a/src/metabase/agent_api/api.clj
+++ b/src/metabase/agent_api/api.clj
@@ -500,6 +500,20 @@
    [:field ::field]
    [:direction [:enum {:encode/tool-api-request keyword} "asc" "desc"]]])
 
+(mr/def ::join-strategy
+  [:enum {:encode/tool-api-request keyword}
+   "left-join" "right-join" "inner-join" "full-join"])
+
+(mr/def ::join-spec
+  [:and
+   [:map
+    [:table_id {:description "ID of the table to join. Must have a FK relationship with the source or a previously joined table."}
+     ms/PositiveInt]
+    [:strategy {:optional true
+                :description "Join strategy. Defaults to left-join."}
+     [:maybe ::join-strategy]]]
+   [:map {:encode/tool-api-request #(update-keys % metabot.u/safe->kebab-case-en)}]])
+
 (mr/def ::construct-query-table-request
   "Request schema for constructing a query from a table.
 
@@ -509,10 +523,14 @@
    - aggregations: Aggregation functions (sum, count, avg, etc.). Use sort_order on the aggregation to order by it.
    - group_by: Fields to group by, with optional temporal granularity
    - order_by: Order by regular fields only. To order by an aggregation result, use sort_order on the aggregation instead.
-   - limit: Maximum rows to return"
+   - limit: Maximum rows to return
+   - joins: Tables to join via FK relationships"
   [:and
    [:map
     [:table_id ms/PositiveInt]
+    [:joins        {:optional true
+                    :description "Tables to join via FK relationships. Call get_table to find related_tables. Field IDs from joined tables work in filters, group_by, and aggregations."}
+     [:maybe [:sequential ::join-spec]]]
     [:filters      {:optional true} [:maybe [:sequential ::filter]]]
     [:fields       {:optional true} [:maybe [:sequential ::field]]]
     [:aggregations {:optional true} [:maybe [:sequential ::aggregation]]]
@@ -586,7 +604,10 @@
            :description (str "Construct a query against a Metabase table or metric. "
                              "Returns an opaque query string that can be executed with execute_query.\n\n"
                              "For table queries: provide table_id. "
-                             "Supports filters, fields, aggregations, group_by, order_by, and limit.\n\n"
+                             "Supports filters, fields, aggregations, group_by, order_by, limit, and joins.\n\n"
+                             "Joins: add related tables via foreign key relationships. "
+                             "Call get_table to find related_tables and their field IDs. "
+                             "Field IDs from joined tables work in filters, group_by, and aggregations.\n\n"
                              "For metric queries: provide metric_id. "
                              "Supports only filters and group_by (aggregation is defined by the metric).\n\n"
                              "Provide either table_id or metric_id, not both.")

--- a/src/metabase/agent_api/api.clj
+++ b/src/metabase/agent_api/api.clj
@@ -10,6 +10,8 @@
    [metabase.api.macros.scope :as scope]
    [metabase.api.routes.common :as api.routes.common]
    [metabase.auth-identity.core :as auth-identity]
+   [metabase.dashboards.autoplace :as autoplace]
+   [metabase.events.core :as events]
    [metabase.lib.schema.temporal-bucketing :as lib.schema.temporal-bucketing]
    [metabase.metabot.core :as metabot]
    [metabase.metabot.tools.deftool :as deftool]
@@ -18,6 +20,7 @@
    [metabase.metabot.tools.filters :as metabot-filters]
    [metabase.metabot.tools.search :as metabot-search]
    [metabase.metabot.util :as metabot.u]
+   [metabase.queries.models.card :as card]
    [metabase.query-processor.core :as qp]
    [metabase.query-processor.streaming :as qp.streaming]
    [metabase.request.core :as request]
@@ -737,6 +740,118 @@
                   json/decode+kw)]
     (qp.streaming/streaming-response [rff :api]
       (qp/process-query (prepare-combined-query query) rff))))
+
+;;; ------------------------------------------------- Create Question ------------------------------------------------
+
+(mr/def ::create-question-request
+  [:map
+   [:name                   ms/NonBlankString]
+   [:query                  ms/NonBlankString]
+   [:display                {:optional true} [:maybe :string]]
+   [:description            {:optional true} [:maybe :string]]
+   [:collection_id          {:optional true} [:maybe ms/PositiveInt]]
+   [:visualization_settings {:optional true} [:maybe :map]]])
+
+(mr/def ::create-question-response
+  [:map
+   [:id            ms/PositiveInt]
+   [:name          ms/NonBlankString]
+   [:display       :string]
+   [:collection_id [:maybe ms/PositiveInt]]
+   [:description   [:maybe :string]]])
+
+(api.macros/defendpoint :post "/v1/question" :- ::create-question-response
+  "Save a previously constructed query as a named question (card).
+
+  The `query` parameter should be a base64-encoded string returned by construct_query.
+  Optionally specify display type, description, collection, and visualization settings."
+  {:scope metabot/agent-question-create
+   :tool  {:name "create_question"
+           :description (str "Save a query as a named question in Metabase. "
+                             "Pass the base64 query string from construct_query. "
+                             "Optionally set display type (table, bar, line, pie, etc.), "
+                             "description, and target collection.")}}
+  [_route-params
+   _query-params
+   {:keys [query display description collection_id visualization_settings]
+    question-name :name}
+   :- ::create-question-request]
+  (let [dataset-query (-> query u/decode-base64 json/decode+kw)
+        card          (card/create-card!
+                       {:name                   question-name
+                        :dataset_query          dataset-query
+                        :display                (keyword (or display "table"))
+                        :description            description
+                        :collection_id          collection_id
+                        :visualization_settings (or visualization_settings {})}
+                       {:id api/*current-user-id*})]
+    {:id            (:id card)
+     :name          (:name card)
+     :display       (clojure.core/name (:display card))
+     :collection_id (:collection_id card)
+     :description   (:description card)}))
+
+;;; ------------------------------------------------ Create Dashboard -----------------------------------------------
+
+(mr/def ::create-dashboard-request
+  [:map
+   [:name          ms/NonBlankString]
+   [:description   {:optional true} [:maybe :string]]
+   [:collection_id {:optional true} [:maybe ms/PositiveInt]]
+   [:question_ids  {:optional true} [:maybe [:sequential ms/PositiveInt]]]])
+
+(mr/def ::create-dashboard-response
+  [:map
+   [:id            ms/PositiveInt]
+   [:name          ms/NonBlankString]
+   [:collection_id [:maybe ms/PositiveInt]]
+   [:description   [:maybe :string]]
+   [:dashcard_ids  [:sequential ms/PositiveInt]]])
+
+(api.macros/defendpoint :post "/v1/dashboard" :- ::create-dashboard-response
+  "Create a new dashboard, optionally populated with saved questions.
+
+  Pass `question_ids` to add existing saved questions as cards on the dashboard.
+  Cards are automatically positioned on the grid based on their display type."
+  {:scope metabot/agent-dashboard-create
+   :tool  {:name "create_dashboard"
+           :description (str "Create a dashboard in Metabase. "
+                             "Optionally pass question_ids to add saved questions as cards. "
+                             "Cards are auto-positioned on the dashboard grid.")}}
+  [_route-params
+   _query-params
+   {:keys [description collection_id question_ids]
+    dashboard-name :name}
+   :- ::create-dashboard-request]
+  (api/create-check :model/Dashboard {:collection_id collection_id})
+  (let [cards (when (seq question_ids)
+                (mapv #(api/read-check :model/Card %) question_ids))
+        dash  (t2/with-transaction [_conn]
+                (let [dash (first (t2/insert-returning-instances!
+                                   :model/Dashboard
+                                   {:name          dashboard-name
+                                    :description   description
+                                    :parameters    []
+                                    :creator_id    api/*current-user-id*
+                                    :collection_id collection_id}))]
+                  (when (seq cards)
+                    (reduce (fn [placed card]
+                              (let [display  (or (:display card) :table)
+                                    position (autoplace/get-position-for-new-dashcard placed display)]
+                                (t2/insert-returning-instance!
+                                 :model/DashboardCard
+                                 (merge position {:dashboard_id (:id dash)
+                                                  :card_id      (:id card)}))
+                                (conj placed position)))
+                            []
+                            cards))
+                  dash))]
+    (events/publish-event! :event/dashboard-create {:object dash :user-id api/*current-user-id*})
+    {:id           (:id dash)
+     :name         (:name dash)
+     :collection_id (:collection_id dash)
+     :description  (:description dash)
+     :dashcard_ids (mapv :id (t2/select :model/DashboardCard :dashboard_id (:id dash)))}))
 
 ;;; ------------------------------------------------- Authentication -------------------------------------------------
 ;;

--- a/src/metabase/agent_api/api.clj
+++ b/src/metabase/agent_api/api.clj
@@ -20,7 +20,7 @@
    [metabase.metabot.tools.filters :as metabot-filters]
    [metabase.metabot.tools.search :as metabot-search]
    [metabase.metabot.util :as metabot.u]
-   [metabase.queries.models.card :as card]
+   [metabase.queries.core :as queries]
    [metabase.query-processor.core :as qp]
    [metabase.query-processor.streaming :as qp.streaming]
    [metabase.request.core :as request]
@@ -777,7 +777,7 @@
     question-name :name}
    :- ::create-question-request]
   (let [dataset-query (-> query u/decode-base64 json/decode+kw)
-        card          (card/create-card!
+        card          (queries/create-card!
                        {:name                   question-name
                         :dataset_query          dataset-query
                         :display                (keyword (or display "table"))

--- a/src/metabase/metabot/core.clj
+++ b/src/metabase/metabot/core.clj
@@ -11,7 +11,9 @@
   metabase-provider?
   provider-and-model->provider]
  [metabase.metabot.scope
+  agent-dashboard-create
   agent-metric-read
+  agent-question-create
   agent-query-construct
   agent-query-execute
   agent-search

--- a/src/metabase/metabot/scope.clj
+++ b/src/metabase/metabot/scope.clj
@@ -34,6 +34,10 @@
 (api-scope/defscope agent-query-execute "agent:query:execute"
   (deferred-tru "Execute queries"))
 
+;; Question (saved cards via Agent API)
+(api-scope/defscope agent-question-create "agent:question:create"
+  (deferred-tru "Create saved questions"))
+
 ;; Transforms
 (api-scope/defscope agent-transforms-read "agent:transforms:read"
   (deferred-tru "View transforms"))
@@ -143,7 +147,7 @@
   "Map from metabot permission type to the wildcard scope strings granted when
   that permission is `:yes`."
   {:permission/metabot-sql-generation #{"agent:sql:*" "agent:transforms:*" "agent:snippets:*"}
-   :permission/metabot-nlq            #{"agent:notebook:*" "agent:query:*" "agent:table:*" "agent:metric:*"}
+   :permission/metabot-nlq            #{"agent:notebook:*" "agent:query:*" "agent:table:*" "agent:metric:*" "agent:question:*"}
    :permission/metabot-other-tools    #{"agent:viz:*" "agent:dashboard:*" "agent:document:*" "agent:alert:*"}})
 
 (def always-granted-scopes

--- a/src/metabase/metabot/tools/filters.clj
+++ b/src/metabase/metabot/tools/filters.clj
@@ -556,22 +556,96 @@
     :else
     (throw (ex-info "Either table-id or model-id must be provided" {:agent-error? true :status-code 400}))))
 
+(defn- add-joins
+  "Add explicit joins to the query. Conditions auto-detected from FK/PK relationships.
+   Throws if no FK relationship exists, or if the same table is joined twice."
+  [query joins]
+  (let [table-ids (mapv :table-id joins)]
+    (when (not= (count table-ids) (count (set table-ids)))
+      (throw (ex-info "Cannot join the same table more than once"
+                      {:agent-error? true :status-code 400})))
+    (reduce
+     (fn [q {:keys [table-id strategy]}]
+       (let [table-meta (try
+                          (lib.metadata/table q table-id)
+                          (catch Exception _
+                            (throw (ex-info (str "No table found with table_id " table-id)
+                                            {:agent-error? true :status-code 404}))))
+             conditions (lib/suggested-join-conditions q -1 table-meta)]
+         (when (empty? conditions)
+           (throw (ex-info (str "Cannot join table " table-id
+                                " (" (lib/display-name q table-meta) ")"
+                                ": no foreign key relationship found.")
+                           {:agent-error? true :status-code 400})))
+         (lib/join q (lib/join-clause table-meta conditions
+                                      (or strategy :left-join)))))
+     query
+     joins)))
+
+(defn- build-multi-table-resolver
+  "Build a field ID resolver that handles field IDs from the source table
+   or any joined table. Source table fields use the standard resolve-column.
+   Joined table fields use two-phase resolution: positional index in the
+   standalone table's columns, then identity match by :id in the post-join
+   visible-columns (which carry the correct :lib/join-alias metadata)."
+  [base-query post-join-query source-table-id joined-table-ids]
+  (let [source-prefix (metabot.tools.u/table-field-id-prefix source-table-id)
+        source-cols   (vec (lib/visible-columns base-query))
+        joined-cols   (into {}
+                            (map (fn [tid]
+                                   [tid (vec (lib/visible-columns
+                                              (metabot.tools.u/table-query tid)))]))
+                            joined-table-ids)
+        post-join-vis (lib/visible-columns post-join-query)
+        valid-ids     (into #{source-table-id} joined-table-ids)]
+    (fn [{:keys [field-id] :as item}]
+      (let [{:keys [model-tag model-id field-index]}
+            (or (metabot.tools.u/parse-field-id field-id)
+                (throw (ex-info (str "Invalid field_id format: " field-id)
+                                {:agent-error? true :status-code 400})))]
+        (when (not= model-tag "t")
+          (throw (ex-info (str "field " field-id " is not a table field")
+                          {:agent-error? true :status-code 400})))
+        (when-not (contains? valid-ids model-id)
+          (throw (ex-info (str "field " field-id " refers to table " model-id
+                               " which is not the source or a joined table")
+                          {:agent-error? true :status-code 400})))
+        (if (= model-id source-table-id)
+          (metabot.tools.u/resolve-column item source-prefix source-cols)
+          (let [standalone-cols (get joined-cols model-id)
+                standalone-col (or (get standalone-cols field-index)
+                                   (throw (ex-info (str "field " field-id " not found - no column at index " field-index)
+                                                   {:agent-error? true :status-code 404
+                                                    :field-id field-id})))
+                matched        (first (filter #(and (= (:id %) (:id standalone-col))
+                                                    (= (:lib/source %) :source/joins))
+                                              post-join-vis))]
+            (if matched
+              (assoc item :column matched)
+              (throw (ex-info (str "field " field-id " could not be resolved in joined query")
+                              {:agent-error? true :status-code 400})))))))))
+
 (defn- query-datasource*
-  [{:keys [fields filters aggregations group-by order-by limit] :as arguments}]
+  [{:keys [fields filters aggregations group-by order-by limit joins] :as arguments}]
   (let [[filter-field-id-prefix base-query] (resolve-datasource arguments)
-        visible-cols (lib/visible-columns base-query)
-        resolve-visible-column #(metabot.tools.u/resolve-column % filter-field-id-prefix visible-cols)
+        query-with-joins (if (seq joins) (add-joins base-query joins) base-query)
+        visible-cols (lib/visible-columns query-with-joins)
+        resolve-visible-column (if (seq joins)
+                                 (build-multi-table-resolver base-query query-with-joins
+                                                             (:table-id arguments)
+                                                             (mapv :table-id joins))
+                                 #(metabot.tools.u/resolve-column % filter-field-id-prefix visible-cols))
         resolve-order-by-column (fn [{:keys [field direction]}] {:field (resolve-visible-column field) :direction direction})
         projection (map (comp (juxt filter-bucketed-column (fn [{:keys [column bucket]}]
                                                              (let [column (cond-> column
                                                                             bucket (assoc :unit bucket))]
-                                                               (lib/display-name base-query -1 column :long))))
+                                                               (lib/display-name query-with-joins -1 column :long))))
                               resolve-visible-column)
                         fields)
         all-aggregations (map (partial resolve-aggregation-column resolve-visible-column) aggregations)
         all-filters (map #(if (:segment-id %) % (resolve-visible-column %)) filters)
         reduce-query (fn [query f coll] (reduce f query coll))
-        query (-> base-query
+        query (-> query-with-joins
                   (reduce-query (fn [query [expr-or-column expr-name]]
                                   (lib/expression query expr-name expr-or-column))
                                 (filter (comp expression? first) projection))

--- a/test/metabase/agent_api/api_test.clj
+++ b/test/metabase/agent_api/api_test.clj
@@ -470,3 +470,90 @@
                    :total_count 1}
                   (mt/user-http-request :rasta :post 200 "agent/v1/search"
                                         {:term_queries ["AgentSearchTestMetric"]}))))))))
+
+;;; ------------------------------------------------ Create Question Tests -------------------------------------------
+
+(deftest create-question-test
+  (testing "Creates a saved question from a constructed query"
+    (let [construct-resp (mt/user-http-request :rasta :post 200 "agent/v1/construct-query"
+                                               {:table_id (mt/id :orders) :limit 10})
+          create-resp    (mt/user-http-request :rasta :post 200 "agent/v1/question"
+                                               {:name  "Agent Test Question"
+                                                :query (:query construct-resp)})]
+      (is (=? {:id            pos?
+               :name          "Agent Test Question"
+               :display       "table"
+               :collection_id nil
+               :description   nil}
+              create-resp))
+      (is (t2/exists? :model/Card :id (:id create-resp)))
+      (t2/delete! :model/Card :id (:id create-resp))))
+
+  (testing "Creates a question with optional fields"
+    (mt/with-temp [:model/Collection {coll-id :id} {:name "Agent Question Collection"}]
+      (let [construct-resp (mt/user-http-request :rasta :post 200 "agent/v1/construct-query"
+                                                 {:table_id (mt/id :orders) :limit 10})
+            create-resp    (mt/user-http-request :rasta :post 200 "agent/v1/question"
+                                                 {:name          "Agent Question With Options"
+                                                  :query         (:query construct-resp)
+                                                  :display       "bar"
+                                                  :description   "A test question"
+                                                  :collection_id coll-id})]
+        (is (=? {:id            pos?
+                 :name          "Agent Question With Options"
+                 :display       "bar"
+                 :collection_id coll-id
+                 :description   "A test question"}
+                create-resp))
+        (t2/delete! :model/Card :id (:id create-resp))))))
+
+;;; ----------------------------------------------- Create Dashboard Tests ------------------------------------------
+
+(deftest create-dashboard-test
+  (testing "Creates an empty dashboard"
+    (let [resp (mt/user-http-request :rasta :post 200 "agent/v1/dashboard"
+                                     {:name "Agent Test Dashboard"})]
+      (is (=? {:id            pos?
+               :name          "Agent Test Dashboard"
+               :collection_id nil
+               :description   nil
+               :dashcard_ids  []}
+              resp))
+      (t2/delete! :model/Dashboard :id (:id resp))))
+
+  (testing "Creates a dashboard with questions"
+    (mt/with-temp [:model/Card {card1-id :id} {:name          "DashQ1"
+                                               :dataset_query (orders-count-query)
+                                               :display       :table}
+                   :model/Card {card2-id :id} {:name          "DashQ2"
+                                               :dataset_query (orders-count-query)
+                                               :display       :bar}]
+      (let [resp (mt/user-http-request :rasta :post 200 "agent/v1/dashboard"
+                                       {:name         "Dashboard With Questions"
+                                        :description  "Test dashboard"
+                                        :question_ids [card1-id card2-id]})]
+        (is (=? {:id           pos?
+                 :name         "Dashboard With Questions"
+                 :description  "Test dashboard"
+                 :dashcard_ids #(= 2 (count %))}
+                resp))
+        ;; Verify dashcards reference the correct cards and have valid positions
+        (let [dashcards (t2/select :model/DashboardCard :dashboard_id (:id resp))]
+          (is (= #{card1-id card2-id} (set (map :card_id dashcards))))
+          (is (every? #(and (nat-int? (:col %)) (nat-int? (:row %))
+                            (pos? (:size_x %)) (pos? (:size_y %)))
+                      dashcards)))
+        (t2/delete! :model/Dashboard :id (:id resp)))))
+
+  (testing "Creates a dashboard in a specific collection"
+    (mt/with-temp [:model/Collection {coll-id :id} {:name "Agent Dashboard Collection"}]
+      (let [resp (mt/user-http-request :rasta :post 200 "agent/v1/dashboard"
+                                       {:name          "Collection Dashboard"
+                                        :collection_id coll-id})]
+        (is (= coll-id (:collection_id resp)))
+        (t2/delete! :model/Dashboard :id (:id resp)))))
+
+  (testing "Returns 404 when a question_id does not exist"
+    (mt/user-http-request :rasta :post 404 "agent/v1/dashboard"
+                          {:name         "Bad Dashboard"
+                           :question_ids [999999]})))

--- a/test/metabase/agent_api/api_test.clj
+++ b/test/metabase/agent_api/api_test.clj
@@ -378,6 +378,105 @@
       (let [decoded (decode-query response)]
         (is (seq (lib/filters decoded)) "Query should have filters")))))
 
+;;; ------------------------------------------------ Join Tests ---------------------------------------------------
+
+(deftest construct-query-with-joins-test
+  (testing "Basic join - Orders JOIN Products"
+    (let [response (mt/user-http-request :rasta :post 200 "agent/v1/construct-query"
+                                         {:table_id (mt/id :orders)
+                                          :joins    [{:table_id (mt/id :products)}]
+                                          :limit    10})
+          decoded  (decode-query response)
+          joins    (lib/joins decoded)]
+      (is (= 1 (count joins)))
+      (is (= :left-join (:strategy (first joins))))
+      (is (= "Products" (:alias (first joins))))))
+
+  (testing "Filter on joined column"
+    (let [cat-field-id (visible-field-id (mt/id :products) "Category")
+          response     (mt/user-http-request :rasta :post 200 "agent/v1/construct-query"
+                                             {:table_id (mt/id :orders)
+                                              :joins    [{:table_id (mt/id :products)}]
+                                              :filters  [{:field_id  cat-field-id
+                                                          :operation "equals"
+                                                          :value     "Gadget"}]
+                                              :limit    10})
+          decoded      (decode-query response)]
+      (is (= 1 (count (lib/filters decoded))) "Should have one filter")
+      (is (= 1 (count (lib/joins decoded))) "Should have one join")))
+
+  (testing "Aggregation + group-by on joined column"
+    (let [cat-field-id (visible-field-id (mt/id :products) "Category")
+          response     (mt/user-http-request :rasta :post 200 "agent/v1/construct-query"
+                                             {:table_id     (mt/id :orders)
+                                              :joins        [{:table_id (mt/id :products)}]
+                                              :aggregations [{:function "count"}]
+                                              :group_by     [{:field_id cat-field-id}]})
+          decoded      (decode-query response)]
+      (is (= 1 (count (lib/aggregations decoded))))
+      (is (= 1 (count (lib/breakouts decoded))))))
+
+  (testing "Explicit join strategy"
+    (let [response (mt/user-http-request :rasta :post 200 "agent/v1/construct-query"
+                                         {:table_id (mt/id :orders)
+                                          :joins    [{:table_id (mt/id :products)
+                                                      :strategy "inner-join"}]
+                                          :limit    10})
+          decoded  (decode-query response)
+          joins    (lib/joins decoded)]
+      (is (= :inner-join (:strategy (first joins))))))
+
+  (testing "Multiple joins"
+    (let [response (mt/user-http-request :rasta :post 200 "agent/v1/construct-query"
+                                         {:table_id (mt/id :orders)
+                                          :joins    [{:table_id (mt/id :products)}
+                                                     {:table_id (mt/id :people)}]
+                                          :limit    10})
+          decoded  (decode-query response)
+          joins    (lib/joins decoded)]
+      (is (= 2 (count joins)))
+      (is (= :left-join (:strategy (first joins))))
+      (is (= :left-join (:strategy (second joins))))))
+
+  (testing "No FK relationship returns 400"
+    (let [response (mt/user-http-request :rasta :post 400 "agent/v1/construct-query"
+                                         {:table_id (mt/id :products)
+                                          :joins    [{:table_id (mt/id :people)}]
+                                          :limit    10})]
+      (is (re-find #"no foreign key relationship" response))))
+
+  (testing "Non-existent join table returns 404"
+    (is (mt/user-http-request :rasta :post 404 "agent/v1/construct-query"
+                              {:table_id (mt/id :orders)
+                               :joins    [{:table_id 999999}]
+                               :limit    10})))
+
+  (testing "Duplicate table joins return 400"
+    (let [response (mt/user-http-request :rasta :post 400 "agent/v1/construct-query"
+                                         {:table_id (mt/id :orders)
+                                          :joins    [{:table_id (mt/id :products)}
+                                                     {:table_id (mt/id :products)}]
+                                          :limit    10})]
+      (is (re-find #"same table more than once" response)))))
+
+(deftest construct-and-execute-with-joins-test
+  (testing "End-to-end: construct joined query then execute"
+    (let [cat-field-id   (visible-field-id (mt/id :products) "Category")
+          construct-resp (mt/user-http-request :rasta :post 200 "agent/v1/construct-query"
+                                               {:table_id     (mt/id :orders)
+                                                :joins        [{:table_id (mt/id :products)}]
+                                                :aggregations [{:function "count"}]
+                                                :group_by     [{:field_id cat-field-id}]})
+          execute-resp   (mt/user-http-request :rasta :post 202 "agent/v1/execute"
+                                               {:query (:query construct-resp)})]
+      (is (=? {:status    "completed"
+               :row_count pos?
+               :data      {:cols (fn [cols]
+                                   (and (seq cols)
+                                        (every? :name cols)))
+                           :rows (fn [rows] (pos? (count rows)))}}
+              execute-resp)))))
+
 (deftest get-table-details-with-measures-test
   (let [measure-def (-> (lib/query (mt/metadata-provider)
                                    (lib.metadata/table (mt/metadata-provider) (mt/id :orders)))


### PR DESCRIPTION
## Context

This is a **proof-of-concept** built in a background terminal while testing the MCP create workflow (PR #72742). Not intended for merge if AIQL joins covers this - just sharing the approach for reference.

Alexander mentioned Mihael is working on joins via AIQL, which may overlap or supersede this. Sharing for visibility so the team can see one possible implementation approach.

## Summary

- Adds a `joins` parameter to `construct_query` so LLMs can answer multi-table analytical questions in a single tool call instead of 5+ separate queries
- Join conditions auto-detected from FK/PK relationships (via `lib/suggested-join-conditions`)
- Field IDs from joined tables (obtained via `get_table`) work in filters, group_by, aggregations, etc.
- Rejects: missing FK relationships (400), non-existent tables (404), duplicate table joins (400)

## How it works

The LLM calls `get_table` to discover `related_tables`, then passes joined table IDs:

```json
{
  "table_id": 42,
  "joins": [{"table_id": 50}, {"table_id": 66, "strategy": "inner-join"}],
  "aggregations": [{"function": "count"}],
  "group_by": [{"field_id": "t50-5"}]
}
```

The hardest part is field ID resolution: field IDs use per-table positional indexes (`t50-3` = table 50, column at index 3), but after joining, `lib/visible-columns` returns a flat list across all tables. The solution is two-phase resolution - look up by index in the standalone table's columns, then identity-match by `:id` in the post-join visible-columns to get the column with correct `:lib/join-alias` metadata.

## Test plan

- [x] Basic join (Orders JOIN Products) - verify join clause with left-join strategy
- [x] Filter on joined column (Products.CATEGORY = "Gadget")
- [x] Aggregation + group-by on joined column
- [x] Explicit join strategy (inner-join)
- [x] Multiple joins (Products + People)
- [x] No FK relationship returns 400
- [x] Non-existent join table returns 404
- [x] Duplicate table joins return 400
- [x] End-to-end construct + execute with joins
- [x] All 23 existing agent API tests pass (151 assertions, 0 failures)