### PR TITLE
BOT-1321 Backport code to populate ai_usage_log table from #71699

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1002,8 +1002,7 @@
 
   internal-stats
   {:team "UX West"
-   :api  #{metabase.internal-stats.core
-           metabase.internal-stats.metabot}
+   :api  #{metabase.internal-stats.core}
    :uses #{app-db
            models
            util}
@@ -1197,7 +1196,6 @@
               config
               documents
               driver
-              internal-stats
               legacy-mbql
               lib
               lib-be
@@ -1224,7 +1222,8 @@
               transforms-base
               util
               warehouses}
-   :model-exports #{:model/MetabotMessage}
+   :model-exports #{:model/AiUsageLog
+                    :model/MetabotMessage}
    :model-imports #{:model/Card
                     :model/Collection
                     :model/Dashboard
@@ -2980,7 +2979,7 @@
               util
               enterprise/dependencies
               enterprise/transforms-python}
-   :model-imports #{:model/Card :model/Transform}}
+   :model-imports #{:model/AiUsageLog :model/Card :model/Transform}}
 
   enterprise/permission-debug
   {:team "UX West"

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -2965,7 +2965,8 @@
 
   enterprise/metabot
   {:team    "Metabot"
-   :api     #{metabase-enterprise.metabot.api}
+   :api     #{metabase-enterprise.metabot.api
+              metabase-enterprise.metabot.init}
    :friends #{enterprise/agent-api
               slackbot
               mcp
@@ -2976,6 +2977,7 @@
               models
               permissions
               premium-features
+              task
               util
               enterprise/dependencies
               enterprise/transforms-python}

--- a/enterprise/backend/src/metabase_enterprise/core/init.clj
+++ b/enterprise/backend/src/metabase_enterprise/core/init.clj
@@ -13,6 +13,7 @@
    [metabase-enterprise.database-replication.init]
    [metabase-enterprise.dependencies.init]
    [metabase-enterprise.gsheets.init]
+   [metabase-enterprise.metabot.init]
    [metabase-enterprise.remote-sync.init]
    [metabase-enterprise.scim.init]
    [metabase-enterprise.security-center.init]

--- a/enterprise/backend/src/metabase_enterprise/metabot/init.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot/init.clj
@@ -1,0 +1,3 @@
+(ns metabase-enterprise.metabot.init
+  (:require
+   [metabase-enterprise.metabot.task.ai-usage-trimmer]))

--- a/enterprise/backend/src/metabase_enterprise/metabot/task/ai_usage_trimmer.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot/task/ai_usage_trimmer.clj
@@ -1,0 +1,44 @@
+(ns metabase-enterprise.metabot.task.ai-usage-trimmer
+  "Scheduled task to delete old ai_usage_log rows (older than 3 months)."
+  (:require
+   [clojurewerkz.quartzite.jobs :as jobs]
+   [clojurewerkz.quartzite.schedule.cron :as cron]
+   [clojurewerkz.quartzite.triggers :as triggers]
+   [metabase.task.core :as task]
+   [metabase.util.log :as log]
+   [toucan2.core :as t2])
+  (:import
+   (java.sql Timestamp)
+   (org.quartz DisallowConcurrentExecution)))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private trimmer-job-key (jobs/key "metabase.task.metabot.ai-usage-trimmer.job"))
+(def ^:private trimmer-trigger-key (triggers/key "metabase.task.metabot.ai-usage-trimmer.trigger"))
+
+(def ^:private retention-months 3)
+
+(defn- trim-old-usage-data!
+  []
+  (log/info "Trimming old AI usage log data.")
+  (let [cutoff (Timestamp/valueOf (.minusMonths (java.time.LocalDateTime/now) retention-months))
+        deleted (t2/delete! :model/AiUsageLog {:where [:< :created_at cutoff]})]
+    (log/infof "AI usage log cleanup complete. Deleted %d rows." (or deleted 0))))
+
+(task/defjob ^{DisallowConcurrentExecution true
+               :doc "Delete old ai_usage_log rows"}
+  AiUsageTrimmer [_ctx]
+  (trim-old-usage-data!))
+
+(defmethod task/init! ::AiUsageTrimmer
+  [_]
+  (let [job (jobs/build
+             (jobs/of-type AiUsageTrimmer)
+             (jobs/with-identity trimmer-job-key))
+        trigger (triggers/build
+                 (triggers/with-identity trimmer-trigger-key)
+                 (triggers/start-now)
+                 (triggers/with-schedule
+                   ;; daily at 23:14:37
+                  (cron/cron-schedule "37 14 23 * * ?")))]
+    (task/schedule-task! job trigger)))

--- a/enterprise/backend/src/metabase_enterprise/metabot/usage.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot/usage.clj
@@ -1,0 +1,31 @@
+(ns metabase-enterprise.metabot.usage
+  "Enterprise implementation of metabot usage logging."
+  (:require
+   [metabase.api.common :as api]
+   [metabase.premium-features.core :refer [defenterprise]]
+   [metabase.util.log :as log]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(defenterprise log-ai-usage!
+  "Record an LLM API call in the ai_usage_log table."
+  :feature :none
+  [{:keys [source model prompt-tokens completion-tokens
+           user-id tenant-id conversation-id profile-id request-id]}]
+  (when-not (= "user-intent-classification" source)
+    (try
+      (let [total-tokens (+ prompt-tokens completion-tokens)]
+        (t2/insert! :model/AiUsageLog
+                    {:source            source
+                     :model             model
+                     :prompt_tokens     prompt-tokens
+                     :completion_tokens completion-tokens
+                     :total_tokens      total-tokens
+                     :user_id           (or user-id api/*current-user-id*)
+                     :tenant_id         (or tenant-id (some-> api/*current-user* deref :tenant_id))
+                     :conversation_id   conversation-id
+                     :profile_id        (some-> profile-id name)
+                     :request_id        request-id}))
+      (catch Exception e
+        (log/warn e "Failed to log LLM usage to ai_usage_log")))))

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
@@ -57,7 +57,8 @@
 
 (def excluded-models
   "List of models which are not going to be serialized ever."
-  ["AnalysisFinding"
+  ["AiUsageLog"
+   "AnalysisFinding"
    "AnalysisFindingError"
    "ApiKey"
    "ApplicationPermissionsRevision"

--- a/enterprise/backend/test/metabase_enterprise/metabot/usage_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot/usage_test.clj
@@ -1,0 +1,100 @@
+(ns metabase-enterprise.metabot.usage-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [metabase.metabot.usage :as usage]
+   [metabase.test :as mt]
+   [toucan2.core :as t2]))
+
+;;; ------------------------------------------------ log-ai-usage! ------------------------------------------------
+
+(deftest log-ai-usage!-records-usage-test
+  (mt/with-premium-features #{:ai-controls}
+    (testing "log-ai-usage! inserts a row into ai_usage_log"
+      (let [user-id (mt/user->id :rasta)]
+        (mt/with-test-user :rasta
+          (let [before-count (t2/count :model/AiUsageLog :user_id user-id :source "log-test")]
+            (usage/log-ai-usage!
+             {:source            "log-test"
+              :model             "anthropic/claude-test"
+              :prompt-tokens     100
+              :completion-tokens 50})
+            (try
+              (is (= (inc before-count)
+                     (t2/count :model/AiUsageLog :user_id user-id :source "log-test")))
+              (let [row (t2/select-one :model/AiUsageLog :user_id user-id :source "log-test"
+                                       {:order-by [[:id :desc]]})]
+                (is (= "anthropic/claude-test" (:model row)))
+                (is (= 100 (:prompt_tokens row)))
+                (is (= 50 (:completion_tokens row)))
+                (is (= 150 (:total_tokens row)))
+                (is (= user-id (:user_id row))))
+              (finally
+                (t2/delete! :model/AiUsageLog :user_id user-id :source "log-test")))))))))
+
+(deftest log-ai-usage!-skips-intent-classification-test
+  (mt/with-premium-features #{:ai-controls}
+    (testing "log-ai-usage! skips user-intent-classification source"
+      (let [user-id (mt/user->id :rasta)]
+        (mt/with-test-user :rasta
+          (let [before-count (t2/count :model/AiUsageLog :user_id user-id
+                                       :source "user-intent-classification")]
+            (usage/log-ai-usage!
+             {:source            "user-intent-classification"
+              :model             "anthropic/claude-test"
+              :prompt-tokens     10
+              :completion-tokens 5})
+            (is (= before-count
+                   (t2/count :model/AiUsageLog :user_id user-id
+                             :source "user-intent-classification")))))))))
+
+(deftest log-ai-usage!-defaults-user-id-from-binding-test
+  (mt/with-premium-features #{:ai-controls}
+    (testing "log-ai-usage! uses api/*current-user-id* when user-id not provided"
+      (let [user-id (mt/user->id :rasta)]
+        (mt/with-test-user :rasta
+          (usage/log-ai-usage!
+           {:source            "binding-test"
+            :model             "test/model"
+            :prompt-tokens     1
+            :completion-tokens 1})
+          (try
+            (let [row (t2/select-one :model/AiUsageLog :source "binding-test"
+                                     {:order-by [[:id :desc]]})]
+              (is (= user-id (:user_id row))))
+            (finally
+              (t2/delete! :model/AiUsageLog :source "binding-test"))))))))
+
+(deftest log-ai-usage!-converts-profile-id-keyword-test
+  (mt/with-premium-features #{:ai-controls}
+    (testing "log-ai-usage! converts keyword profile-id to string"
+      (mt/with-test-user :rasta
+        (usage/log-ai-usage!
+         {:source            "profile-test"
+          :model             "test/model"
+          :prompt-tokens     1
+          :completion-tokens 1
+          :profile-id        :internal})
+        (try
+          (let [row (t2/select-one :model/AiUsageLog :source "profile-test"
+                                   {:order-by [[:id :desc]]})]
+            (is (= "internal" (:profile_id row))))
+          (finally
+            (t2/delete! :model/AiUsageLog :source "profile-test")))))))
+
+(deftest log-ai-usage!-explicit-user-id-test
+  (mt/with-premium-features #{:ai-controls}
+    (testing "log-ai-usage! uses explicitly passed user-id over bound value"
+      (let [crowberto-id (mt/user->id :crowberto)]
+        (mt/with-test-user :rasta
+          (usage/log-ai-usage!
+           {:source            "explicit-user-test"
+            :model             "test/model"
+            :prompt-tokens     1
+            :completion-tokens 1
+            :user-id           crowberto-id})
+          (try
+            (let [row (t2/select-one :model/AiUsageLog :source "explicit-user-test"
+                                     {:order-by [[:id :desc]]})]
+              (is (= crowberto-id (:user_id row))))
+            (finally
+              (t2/delete! :model/AiUsageLog :source "explicit-user-test"))))))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/models/entity_id_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/models/entity_id_test.clj
@@ -32,7 +32,8 @@
   - not exported in serialization; or
   - exported as a child of something else (eg. timeline_event under timeline)
   so they don't need a generated entity_id."
-  #{:model/AnalysisFinding
+  #{:model/AiUsageLog
+    :model/AnalysisFinding
     :model/AnalysisFindingError
     :model/ApiKey
     :model/AuthIdentity

--- a/resources/migrations/060/20260415_ai_usage_log.yaml
+++ b/resources/migrations/060/20260415_ai_usage_log.yaml
@@ -1,0 +1,104 @@
+## Backport of ai_usage_log table from v61
+
+databaseChangeLog:
+  - logicalFilePath: migrations/060_update_migrations.yaml
+
+  - changeSet:
+      id: v60.gresdvx
+      author: nvoxland
+      comment: Create the ai_usage_log
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            changeSetExecuted:
+              id: v61.gresdvx
+              author: nvoxland
+              changeLogFile: migrations/061/20260330_ai_usage_log.yaml
+      changes:
+        - createTable:
+            tableName: ai_usage_log
+            remarks: Universal ledger for all LLM API call usage tracking
+            columns:
+              - column:
+                  name: id
+                  type: bigint
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: ${timestamp_type}
+                  defaultValueComputed: current_timestamp
+                  constraints:
+                    nullable: false
+                  remarks: 'When the LLM call was made'
+              - column:
+                  name: source
+                  type: varchar(100)
+                  constraints:
+                    nullable: false
+                  remarks: 'Origin of the LLM call, e.g. agent, slackbot, document-gen, intent-classification, example-question-gen, oss-sql-gen, semantic-search-embedding'
+              - column:
+                  name: model
+                  type: varchar(255)
+                  constraints:
+                    nullable: false
+                  remarks: 'Full model identifier, e.g. anthropic/claude-sonnet-4-20250514'
+              - column:
+                  name: prompt_tokens
+                  type: int
+                  constraints:
+                    nullable: false
+                  remarks: 'Number of input/prompt tokens'
+              - column:
+                  name: completion_tokens
+                  type: int
+                  constraints:
+                    nullable: false
+                  remarks: 'Number of output/completion tokens'
+              - column:
+                  name: total_tokens
+                  type: int
+                  constraints:
+                    nullable: false
+                  remarks: 'Sum of prompt_tokens + completion_tokens'
+              - column:
+                  name: user_id
+                  type: int
+                  remarks: 'Metabase user who triggered the call. NULL for system/background calls.'
+              - column:
+                  name: tenant_id
+                  type: int
+                  remarks: 'Snapshot of user tenant at request time. NULL for non-tenant users.'
+              - column:
+                  name: conversation_id
+                  type: varchar(36)
+                  remarks: 'Reference to metabot_conversation. NULL for non-conversational calls.'
+              - column:
+                  name: profile_id
+                  type: varchar(100)
+                  remarks: 'AI profile used, e.g. nlq, sql, slackbot'
+              - column:
+                  name: request_id
+                  type: varchar(36)
+                  remarks: 'UUID for correlating with Snowplow events'
+
+  - changeSet:
+      id: v60.8g8esw
+      author: nvoxland
+      comment: Index on ai_usage_log.user_id
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            changeSetExecuted:
+              id: v61.8g8esw
+              author: nvoxland
+              changeLogFile: migrations/061/20260330_ai_usage_log.yaml
+      changes:
+        - createIndex:
+            indexName: idx_ai_usage_log_user_id
+            tableName: ai_usage_log
+            columns:
+              - column:
+                  name: user_id

--- a/resources/migrations/060/20260415_ai_usage_log_ai_proxied.yaml
+++ b/resources/migrations/060/20260415_ai_usage_log_ai_proxied.yaml
@@ -1,0 +1,18 @@
+## Track whether ai_usage_log entries were routed through the AI proxy
+
+databaseChangeLog:
+  - logicalFilePath: migrations/060_update_migrations.yaml
+  - changeSet:
+      id: v60.kdhxne
+      author: mappleby
+      comment: Add ai_proxied flag to ai_usage_log to track proxy vs BYOK routing
+      changes:
+        - addColumn:
+            tableName: ai_usage_log
+            columns:
+              - column:
+                  name: ai_proxied
+                  type: ${boolean.type}
+                  remarks: Whether this call was routed through the Metabase Cloud AI proxy (true) or directly via BYOK keys (false). Null for rows created before this migration.
+                  constraints:
+                    nullable: true

--- a/src/metabase/llm/api.clj
+++ b/src/metabase/llm/api.clj
@@ -237,6 +237,11 @@
                 ;; for some reason, :source convention is snake_case and :tag is (mostly) kebab
                 :source              "oss_metabot"
                 :tag                 "oss-sqlgen"})
+              (metabot/log-ai-usage!
+               {:source            "oss-sql-gen"
+                :model             (:model usage)
+                :prompt-tokens     (:prompt usage)
+                :completion-tokens (:completion usage)})
               (track-sqlgen-event!
                {:duration-ms (u/since-ms start-timer)
                 :result "success"

--- a/src/metabase/metabot/core.clj
+++ b/src/metabase/metabot/core.clj
@@ -2,12 +2,15 @@
   "API namespace for the `metabase.metabot` module."
   (:require
    [metabase.metabot.provider-util]
+   [metabase.metabot.usage]
    [potemkin :as p]))
 
 (p/import-vars
  [metabase.metabot.provider-util
   metabase-provider?
-  provider-and-model->provider])
+  provider-and-model->provider]
+ [metabase.metabot.usage
+  log-ai-usage!])
 
 ;; TODO: Port analyze-chart to use the native LLM infrastructure
 ;; instead of the deleted `metabase.metabot.client`.

--- a/src/metabase/metabot/models/ai_usage_log.clj
+++ b/src/metabase/metabot/models/ai_usage_log.clj
@@ -1,0 +1,9 @@
+(ns metabase.metabot.models.ai-usage-log
+  (:require
+   [methodical.core :as methodical]
+   [toucan2.core :as t2]))
+
+(methodical/defmethod t2/table-name :model/AiUsageLog [_model] :ai_usage_log)
+
+(doto :model/AiUsageLog
+  (derive :metabase/model))

--- a/src/metabase/metabot/self.clj
+++ b/src/metabase/metabot/self.clj
@@ -18,6 +18,7 @@
    [metabase.metabot.self.core :as core]
    [metabase.metabot.self.openai :as openai]
    [metabase.metabot.self.openrouter :as openrouter]
+   [metabase.metabot.usage :as usage]
    [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.o11y :refer [with-span]]))
@@ -178,7 +179,15 @@
                  :request-id          (some-> request-id analytics/uuid->ai-service-hex-uuid)
                  :session-id          session-id
                  :source              source
-                 :tag                 tag})))
+                 :tag                 tag})
+               (usage/log-ai-usage!
+                {:source            (or tag source "unknown")
+                 :model             model
+                 :prompt-tokens     prompt
+                 :completion-tokens completion
+                 :conversation-id   session-id
+                 :profile-id        profile-id
+                 :request-id        request-id})))
            part))))
 
 (defn- report-tool-usage-xf

--- a/src/metabase/metabot/usage.clj
+++ b/src/metabase/metabot/usage.clj
@@ -1,11 +1,27 @@
 (ns metabase.metabot.usage
-  "Deprecated: use [[metabase.internal-stats.metabot]] instead."
-  (:require
-   [metabase.internal-stats.metabot :as internal-stats.metabot]))
+  "LLM usage logging.
 
-(defn metabot-stats
-  "Calculate total Metabot token usage over a window of the previous UTC day 00:00-23:59.
-   Deprecated: use [[metabase.internal-stats.metabot/metabot-stats]] instead."
-  {:deprecated "0.56.0"}
-  []
-  (internal-stats.metabot/metabot-stats))
+  [[log-ai-usage!]] records each LLM call to the `ai_usage_log` table (EE only).
+  In OSS, no usage is logged."
+  (:require
+   [metabase.premium-features.core :refer [defenterprise-schema]]
+   [metabase.util.malli.schema :as ms]))
+
+(def ^:private usage-map-schema
+  [:map
+   [:source            :string]
+   [:model             :string]
+   [:prompt-tokens     [:int {:min 0}]]
+   [:completion-tokens [:int {:min 0}]]
+   [:user-id           {:optional true} [:maybe ms/PositiveInt]]
+   [:tenant-id         {:optional true} [:maybe ms/PositiveInt]]
+   [:conversation-id   {:optional true} [:maybe :string]]
+   [:profile-id        {:optional true} [:maybe :keyword]]
+   [:request-id        {:optional true} [:maybe :string]]])
+
+(defenterprise-schema log-ai-usage! :- :any
+  "Record an LLM API call in the ai_usage_log table.
+  In OSS, this is a no-op."
+  metabase-enterprise.metabot.usage
+  [_usage-map :- usage-map-schema]
+  nil)

--- a/src/metabase/models/resolution.clj
+++ b/src/metabase/models/resolution.clj
@@ -58,6 +58,7 @@
     :model/Metabot                           metabase.metabot.models.metabot
     :model/MetabotConversation               metabase.metabot.models.metabot-conversation
     :model/MetabotMessage                    metabase.metabot.models.metabot-message
+    :model/AiUsageLog                        metabase.metabot.models.ai-usage-log
     :model/MetabotPrompt                     metabase.metabot.models.metabot-prompt
     :model/ModelIndex                        metabase.indexed-entities.models.model-index
     :model/ModelIndexValue                   metabase.indexed-entities.models.model-index

--- a/test/metabase/cmd/copy_test.clj
+++ b/test/metabase/cmd/copy_test.clj
@@ -25,7 +25,8 @@
 
 (def ^:private models-to-exclude
   "Models that should *not* be migrated in `load-from-h2`."
-  #{:model/AnalysisFinding
+  #{:model/AiUsageLog
+    :model/AnalysisFinding
     :model/AnalysisFindingError
     :model/ApiKey
     :model/CacheConfig


### PR DESCRIPTION
Refs [BOT-1230: Ensure that example question generation (`metabot.example-question-generator`) uses the configured model (BYOM or Metabase) and is billed properly](https://linear.app/metabase/issue/BOT-1230/ensure-that-example-question-generation-metabotexample-question)
Refs [BOT-1321: Use `ai_usage_log` for billing token reporting](https://linear.app/metabase/issue/BOT-1321/use-ai-usage-log-for-billing-token-reporting)

https://metaboat.slack.com/archives/C0AP8MCUE4U/p1776268073914229

See also
* #72651
* #72662
* #71699

### Description

Backport code to populate ai_usage_log table from #71699

This does not include any of the usage enforcement or limits checking, just the code to populate (and trim) the ai_usage_log table so it can be used for reporting token usage to harbormaster when :metabase-ai-managed is enabled.

### Demo

```
> (t2/select :model/AiUsageLog)
[(toucan2.instance/instance
  :model/AiUsageLog
  {:ai_proxied nil,
   :total_tokens 19116,
   :completion_tokens 40,
   :conversation_id "9ebebc8c-b02d-fb0d-89d3-7fb8b8bc723b",
   :source "agent",
   :id 1,
   :user_id 3,
   :profile_id "internal",
   :tenant_id nil,
   :prompt_tokens 19076,
   :created_at #t "2026-04-16T22:57:36.066781Z",
   :request_id "9373b216-7e31-47ea-b049-9c7c5bc5facc",
  :model "anthropic/claude-sonnet-4-6"})]
```

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
