### PR TITLE
purge cache on plugin delete

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/api.clj
@@ -194,6 +194,7 @@
   (api/check-superuser)
   (let [plugin (api/check-404 (t2/select-one :model/CustomVizPlugin :id id))]
     (t2/delete! :model/CustomVizPlugin :id id)
+    (cache/purge-plugin-cache! plugin)
     (events/publish-event! :event/custom-viz-plugin-delete {:object  plugin
                                                             :user-id api/*current-user-id*})
     nil))

--- a/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/cache.clj
+++ b/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/cache.clj
@@ -67,6 +67,14 @@
         (swap! local-snapshots assoc id snapshot)
         snapshot))))
 
+(defn purge-plugin-cache!
+  "Evict all cached state for a deleted plugin: the in-memory snapshot and the
+   on-disk bare git repository (which may contain auth credentials in its config)."
+  [{:keys [id repo_url access_token]}]
+  (swap! local-snapshots dissoc id)
+  (when-not (str/starts-with? (str repo_url) "dev://")
+    (rs.git/purge-cached-repo! repo_url access_token)))
+
 ;;; ------------------------------------------------ Paths ------------------------------------------------
 
 (def ^:private ^:const bundle-rel-path "index.js")

--- a/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/settings.clj
@@ -5,7 +5,7 @@
    [metabase.util.i18n :refer [deferred-tru]]))
 
 (defsetting custom-viz-plugin-dev-mode-enabled
-  (deferred-tru "Whether custom visualization plugin dev mode is enabled. When false, the dev endpoints (POST /dev, PUT /:id/dev-url, GET /:id/dev-sse) are disabled.")
+  (deferred-tru "Whether custom visualization plugin dev mode is enabled. When false, the dev endpoints are disabled.")
   :type       :boolean
   :visibility :public
   :setter     :none

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/source/git.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/source/git.clj
@@ -441,6 +441,13 @@
   (swap! jgit dissoc (.getPath repo-path))
   (FileUtils/deleteDirectory repo-path))
 
+(defn purge-cached-repo!
+  "Purges a cached git repository from memory and disk given the remote URL and token.
+   Intended for cleanup when a plugin is deleted."
+  [^String remote-url ^String token]
+  (let [path (repo-path {:remote-url remote-url :token token})]
+    (clear-cached-repo! path)))
+
 (defn- get-jgit [^File path {:keys [remote-url token] :as args}]
   (if-let [obj (get @jgit (.getPath path))]
     obj


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-2262/security-audit-m-4-git-snapshot-not-purged-on-plugin-delete