### PR TITLE
Gdgt 2303 saving question to a dashboard fails

### DIFF
--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -429,6 +429,7 @@ export interface CreateCardRequest {
   collection_position?: number | null;
   result_metadata?: Field[] | null;
   cache_ttl?: number | null;
+  size?: { width: number; height: number };
 }
 
 export interface CreateCardFromCsvRequest {

--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -12,6 +12,7 @@ import type { Collection, CollectionId, LastEditInfo } from "./collection";
 import type {
   DashCardId,
   Dashboard,
+  DashboardCardSize,
   DashboardId,
   DashboardTabId,
 } from "./dashboard";
@@ -429,7 +430,7 @@ export interface CreateCardRequest {
   collection_position?: number | null;
   result_metadata?: Field[] | null;
   cache_ttl?: number | null;
-  size?: { width: number; height: number };
+  size?: DashboardCardSize;
 }
 
 export interface CreateCardFromCsvRequest {

--- a/frontend/src/metabase-types/api/dashboard.ts
+++ b/frontend/src/metabase-types/api/dashboard.ts
@@ -133,6 +133,15 @@ export type DashboardCardLayoutAttrs = {
   size_y: number;
 };
 
+export type DashboardCardPosition = Pick<
+  DashboardCardLayoutAttrs,
+  "col" | "row"
+>;
+export type DashboardCardSize = Pick<
+  DashboardCardLayoutAttrs,
+  "size_x" | "size_y"
+>;
+
 export type DashCardVisualizationSettings = {
   [key: string]: unknown;
   virtual_card?: VirtualCard;

--- a/frontend/src/metabase/dashboard/sections.ts
+++ b/frontend/src/metabase/dashboard/sections.ts
@@ -3,14 +3,13 @@ import { t } from "ttag";
 import { GRID_WIDTH } from "metabase/utils/dashboard_grid";
 import type {
   DashboardCardLayoutAttrs,
+  DashboardCardPosition,
+  DashboardCardSize,
   VirtualCard,
   VirtualDashboardCard,
 } from "metabase-types/api";
 
 import { createVirtualCard } from "./utils";
-
-type Position = Pick<DashboardCardLayoutAttrs, "col" | "row">;
-type Size = Pick<DashboardCardLayoutAttrs, "size_x" | "size_y">;
 
 type SectionDashboardCardAttrs = Partial<VirtualDashboardCard> &
   DashboardCardLayoutAttrs & {
@@ -18,7 +17,9 @@ type SectionDashboardCardAttrs = Partial<VirtualDashboardCard> &
     visualization_settings: { virtual_card: VirtualCard };
   };
 
-type LayoutFn = (position: Position) => Array<SectionDashboardCardAttrs>;
+type LayoutFn = (
+  position: DashboardCardPosition,
+) => Array<SectionDashboardCardAttrs>;
 
 // Note: these values are used in analytics and should not be changed
 export type SectionId =
@@ -67,7 +68,9 @@ function createPlaceholderDashCard(
 }
 
 function createScalarDashCardPlaceholder(
-  opts: Partial<VirtualDashboardCard> & Position & Partial<Size>,
+  opts: Partial<VirtualDashboardCard> &
+    DashboardCardPosition &
+    Partial<DashboardCardSize>,
 ): SectionDashboardCardAttrs {
   return createPlaceholderDashCard({
     size_x: SCALAR_CARD_WIDTH,

--- a/frontend/src/metabase/entities/questions.js
+++ b/frontend/src/metabase/entities/questions.js
@@ -212,6 +212,7 @@ export const Questions = createEntity({
     "collection_preview",
     "result_metadata",
     "delete_old_dashcards",
+    "size",
   ],
 
   getAnalyticsMetadata([object], { action }, getState) {

--- a/frontend/src/metabase/query_builder/actions/core/core.ts
+++ b/frontend/src/metabase/query_builder/actions/core/core.ts
@@ -382,7 +382,7 @@ async function reduxCreateQuestion(
     Questions.actions.create({
       ...question.card(),
       dashboard_tab_id: options?.dashboardTabId,
-      ...(size && { size }),
+      ...(size && { size_x: size.width, size_y: size.height }),
     }),
   );
   return question.setCard(Questions.HACK_getObjectFromAction(action));

--- a/frontend/src/metabase/query_builder/actions/core/core.ts
+++ b/frontend/src/metabase/query_builder/actions/core/core.ts
@@ -22,6 +22,7 @@ import { entityCompatibleQuery } from "metabase/utils/entities";
 import { createThunkAction } from "metabase/utils/redux";
 import { isNotNull } from "metabase/utils/types";
 import * as Urls from "metabase/utils/urls";
+import { getDefaultSize } from "metabase/visualizations";
 import { getCardAfterVisualizationClick } from "metabase/visualizations/lib/utils";
 import * as Lib from "metabase-lib";
 import Question from "metabase-lib/v1/Question";
@@ -375,10 +376,13 @@ async function reduxCreateQuestion(
   dispatch: Dispatch,
   options?: OnCreateOptions,
 ) {
+  const display = question.display();
+  const size = getDefaultSize(display);
   const action = await dispatch(
     Questions.actions.create({
       ...question.card(),
       dashboard_tab_id: options?.dashboardTabId,
+      ...(size && { size }),
     }),
   );
   return question.setCard(Questions.HACK_getObjectFromAction(action));

--- a/frontend/src/metabase/utils/dashboard_grid.js
+++ b/frontend/src/metabase/utils/dashboard_grid.js
@@ -20,6 +20,7 @@ export const GRID_COLUMNS = {
   mobile: 1,
 };
 
+/** @type {{ width: number, height: number }} */
 export const DEFAULT_CARD_SIZE = DEFAULT_CARD_SIZE_JSON;
 
 export const MIN_ROW_HEIGHT = 40;

--- a/frontend/src/metabase/utils/dashboard_grid.js
+++ b/frontend/src/metabase/utils/dashboard_grid.js
@@ -1,6 +1,8 @@
 // NOTE: If we make changes to the algorithm or default values below we should change
 // [the backend version](https://github.com/metabase/metabase/blob/master/src/metabase/dashboards/autoplace.clj).
 
+import { DEFAULT_CARD_SIZE_JSON } from "cljs/metabase.dashboards.constants";
+
 // If you change this, please change `default-grid-width` in
 // https://github.com/metabase/metabase/blob/master/src/metabase/dashboards/autoplace.clj
 export const GRID_WIDTH = 24;
@@ -18,9 +20,7 @@ export const GRID_COLUMNS = {
   mobile: 1,
 };
 
-// If you change this, please change `default-card-size` in
-// https://github.com/metabase/metabase/blob/master/src/metabase/dashboards/autoplace.clj
-export const DEFAULT_CARD_SIZE = { width: 4, height: 4 };
+export const DEFAULT_CARD_SIZE = DEFAULT_CARD_SIZE_JSON;
 
 export const MIN_ROW_HEIGHT = 40;
 

--- a/src/metabase/dashboards/autoplace.clj
+++ b/src/metabase/dashboards/autoplace.clj
@@ -36,7 +36,10 @@
   easier for the caller.
   "
   ([cards display-type]
-   (let [{:keys [width height]} (:default (get dashboard.constants/card-size-defaults display-type))]
+   (let [{default-width :width default-height :height} dashboard.constants/default-card-size
+         {:keys [width height]
+          :or   {width  default-width
+                 height default-height}} (:default (get dashboard.constants/card-size-defaults display-type))]
      (get-position-for-new-dashcard cards
                                     width
                                     height

--- a/src/metabase/dashboards/autoplace.clj
+++ b/src/metabase/dashboards/autoplace.clj
@@ -36,14 +36,9 @@
   easier for the caller.
   "
   ([cards display-type]
-   (let [{default-width :width default-height :height} dashboard.constants/default-card-size
-         {:keys [width height]
-          :or   {width  default-width
-                 height default-height}} (:default (get dashboard.constants/card-size-defaults display-type))]
-     (get-position-for-new-dashcard cards
-                                    width
-                                    height
-                                    default-grid-width)))
+   (let [{:keys [width height]} (merge dashboard.constants/default-card-size
+                                       (:default (get dashboard.constants/card-size-defaults display-type)))]
+     (get-position-for-new-dashcard cards width height default-grid-width)))
   ([cards size-x size-y grid-width]
    (let [dashboard-tab-id (:dashboard_tab_id (first cards))]
      (first

--- a/src/metabase/dashboards/constants.cljc
+++ b/src/metabase/dashboards/constants.cljc
@@ -4,6 +4,11 @@
   "Default width of a dashboard"
   24)
 
+(def default-card-size
+  "Fallback card size used when a visualization type has no entry in `card-size-defaults`
+  (e.g. custom viz plugins). Exposed to the FE via `DEFAULT_CARD_SIZE_JSON`."
+  {:width 4 :height 4})
+
 (def card-size-defaults
   "Default card sizes per visualization type"
   {:table       {:min {:width 4 :height 3} :default {:width 12 :height 9}}
@@ -35,3 +40,7 @@
 #?(:cljs (def ^:export CARD_SIZE_DEFAULTS_JSON
            "Default card sizes per visualization type as a json object suitable for the FE"
            (clj->js card-size-defaults)))
+
+#?(:cljs (def ^:export DEFAULT_CARD_SIZE_JSON
+           "Fallback card size as a json object suitable for the FE"
+           (clj->js default-card-size)))

--- a/src/metabase/dashboards/constants.cljc
+++ b/src/metabase/dashboards/constants.cljc
@@ -5,8 +5,7 @@
   24)
 
 (def default-card-size
-  "Fallback card size used when a visualization type has no entry in `card-size-defaults`
-  (e.g. custom viz plugins). Exposed to the FE via `DEFAULT_CARD_SIZE_JSON`."
+  "Fallback card size used when a visualization type has no entry in `card-size-defaults`"
   {:width 4 :height 4})
 
 (def card-size-defaults

--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -878,9 +878,9 @@
             cards-on-first-tab (or (when first-tab
                                      (:cards first-tab))
                                    dashcards)
-            new-spot (if-let [{:keys [width height]} size]
+            new-spot (if-let [{:keys [size_x size_y]} size]
                        (autoplace/get-position-for-new-dashcard
-                        cards-on-first-tab width height autoplace/default-grid-width)
+                        cards-on-first-tab size_x size_y autoplace/default-grid-width)
                        (autoplace/get-position-for-new-dashcard
                         cards-on-first-tab (:display card)))]
         (t2/insert! :model/DashboardCard (assoc new-spot

--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -868,7 +868,7 @@
 
 ;;; ----------------------------------------------- Creating Cards ----------------------------------------------------
 
-(defn- autoplace-dashcard-for-card! [dashboard-id maybe-dashboard-tab-id card]
+(defn- autoplace-dashcard-for-card! [dashboard-id maybe-dashboard-tab-id card size]
   (let [dashboard (t2/hydrate (t2/select-one :model/Dashboard dashboard-id) :dashcards [:tabs :tab-cards])
         {:keys [dashcards tabs]} dashboard
         tabs (remove #(when maybe-dashboard-tab-id (not= maybe-dashboard-tab-id (:id %))) tabs)
@@ -878,7 +878,11 @@
             cards-on-first-tab (or (when first-tab
                                      (:cards first-tab))
                                    dashcards)
-            new-spot (autoplace/get-position-for-new-dashcard cards-on-first-tab (:display card))]
+            new-spot (if-let [{:keys [width height]} size]
+                       (autoplace/get-position-for-new-dashcard
+                        cards-on-first-tab width height autoplace/default-grid-width)
+                       (autoplace/get-position-for-new-dashcard
+                        cards-on-first-tab (:display card)))]
         (t2/insert! :model/DashboardCard (assoc new-spot
                                                 :dashboard_tab_id (some-> first-tab :id)
                                                 :card_id (:id card)
@@ -933,7 +937,7 @@
                (not new-dashboard-id))))
     ;; we'll end up unarchived and a dashboard card => make sure we autoplace
     (when (and on-dashboard-after? (not archived-after?))
-      (autoplace-dashcard-for-card! new-dashboard-id dashboard-tab-id card-before-update))
+      (autoplace-dashcard-for-card! new-dashboard-id dashboard-tab-id card-before-update nil))
 
     (when (and
            ;; we start out as a DQ, and
@@ -1013,7 +1017,7 @@
                                                   (collections/check-non-remote-synced-dependencies <>))))]
      (let [{:keys [dashboard_id]} card]
        (when (and dashboard_id autoplace-dashboard-questions?)
-         (autoplace-dashcard-for-card! dashboard_id (:dashboard_tab_id input-card-data) card)))
+         (autoplace-dashcard-for-card! dashboard_id (:dashboard_tab_id input-card-data) card (:size input-card-data))))
      (when-not delay-event?
        (events/publish-event! :event/card-create {:object card :user-id (:id creator)}))
      (when metadata-future

--- a/src/metabase/queries_rest/api/card.clj
+++ b/src/metabase/queries_rest/api/card.clj
@@ -542,7 +542,10 @@
    [:result_metadata        {:optional true} [:maybe analyze/ResultsMetadata]]
    [:cache_ttl              {:optional true} [:maybe ms/PositiveInt]]
    [:dashboard_id           {:optional true} [:maybe ms/PositiveInt]]
-   [:dashboard_tab_id       {:optional true} [:maybe ms/PositiveInt]]])
+   [:dashboard_tab_id       {:optional true} [:maybe ms/PositiveInt]]
+   [:size                   {:optional true} [:maybe [:map
+                                                      [:width  ms/PositiveInt]
+                                                      [:height ms/PositiveInt]]]]])
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen

--- a/src/metabase/queries_rest/api/card.clj
+++ b/src/metabase/queries_rest/api/card.clj
@@ -544,8 +544,8 @@
    [:dashboard_id           {:optional true} [:maybe ms/PositiveInt]]
    [:dashboard_tab_id       {:optional true} [:maybe ms/PositiveInt]]
    [:size                   {:optional true} [:maybe [:map
-                                                      [:width  ms/PositiveInt]
-                                                      [:height ms/PositiveInt]]]]])
+                                                      [:size_x ms/PositiveInt]
+                                                      [:size_y ms/PositiveInt]]]]])
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen

--- a/test/metabase/dashboards/autoplace_test.clj
+++ b/test/metabase/dashboards/autoplace_test.clj
@@ -46,3 +46,10 @@
   (testing "should not place card over the right edge of the grid"
     (is (= (pos {:col 0 :row 1})
            (get-position [(pos {:col 0 :row 0 :size_x 5 :size_y 1})])))))
+
+(deftest get-position-for-new-dashcard-falls-back-to-default-size
+  (testing "unknown display types (e.g. custom viz plugins) fall back to default-card-size instead of NPE"
+    (is (= {:col 0 :row 0 :size_x 4 :size_y 4 :dashboard_tab_id nil}
+           (autoplace/get-position-for-new-dashcard [] :custom:Calendar-Heatmap)))
+    (is (= {:col 0 :row 0 :size_x 4 :size_y 4 :dashboard_tab_id nil}
+           (autoplace/get-position-for-new-dashcard [] nil)))))

--- a/test/metabase/queries_rest/api/card_test.clj
+++ b/test/metabase/queries_rest/api/card_test.clj
@@ -4095,7 +4095,21 @@
     (testing "We can't create a dashboard internal card with a non-null :collection_position"
       (mt/user-http-request :crowberto :post 400 "card" (assoc (card-with-name-and-query)
                                                                :dashboard_id dash-id
-                                                               :collection_position 5)))))
+                                                               :collection_position 5)))
+    (testing "An explicit :size overrides the display-type default when autoplacing"
+      (let [card-id (:id (mt/user-http-request :crowberto :post 200 "card"
+                                               (assoc (card-with-name-and-query)
+                                                      :dashboard_id dash-id
+                                                      :size {:width 8 :height 5})))
+            dashcard (t2/select-one :model/DashboardCard :dashboard_id dash-id :card_id card-id)]
+        (is (= 8 (:size_x dashcard)))
+        (is (= 5 (:size_y dashcard)))))
+    (testing ":size is not persisted on the Card itself"
+      (let [card (mt/user-http-request :crowberto :post 200 "card"
+                                       (assoc (card-with-name-and-query)
+                                              :dashboard_id dash-id
+                                              :size {:width 3 :height 3}))]
+        (is (not (contains? card :size)))))))
 
 (deftest dashboard-internal-card-updates
   (mt/with-temp [:model/Collection {coll-id :id} {}

--- a/test/metabase/queries_rest/api/card_test.clj
+++ b/test/metabase/queries_rest/api/card_test.clj
@@ -4100,7 +4100,7 @@
       (let [card-id (:id (mt/user-http-request :crowberto :post 200 "card"
                                                (assoc (card-with-name-and-query)
                                                       :dashboard_id dash-id
-                                                      :size {:width 8 :height 5})))
+                                                      :size {:size_x 8 :size_y 5})))
             dashcard (t2/select-one :model/DashboardCard :dashboard_id dash-id :card_id card-id)]
         (is (= 8 (:size_x dashcard)))
         (is (= 5 (:size_y dashcard)))))
@@ -4108,7 +4108,7 @@
       (let [card (mt/user-http-request :crowberto :post 200 "card"
                                        (assoc (card-with-name-and-query)
                                               :dashboard_id dash-id
-                                              :size {:width 3 :height 3}))]
+                                              :size {:size_x 3 :size_y 3}))]
         (is (not (contains? card :size)))))))
 
 (deftest dashboard-internal-card-updates


### PR DESCRIPTION
Closes [GDGT-2303: Saving question to a dashboard fails](https://linear.app/metabase/issue/GDGT-2303/saving-question-to-a-dashboard-fails)

### Description

The table with card sizes only has entries for built-in viz keywords (:table, :bar, etc.). For custom viz, the lookup returns nil, so width/height destructure to nil. The solution is:
1. add a `default card size` to mirror the existing fallback on FE
2. expose this default to FE, so we don't need to sync it manually in the future

### How to verify
1. Create a new question -> set a viz type to custom viz
3. Try to save it to a dashboard

### Demo

https://github.com/user-attachments/assets/fc38ad4b-aa17-452b-99dd-4554269c2349


