### PR TITLE
feat: rotate encryption for custom_viz_plugin

### DIFF
--- a/src/metabase/app_db/encryption.clj
+++ b/src/metabase/app_db/encryption.clj
@@ -41,6 +41,19 @@
         (t2/update! :conn conn :secret
                     {:id id}
                     {:value (encrypt-bytes-fn value)}))
+      ;; `custom_viz_plugin.access_token` is declared on an enterprise model, so we can't reference the
+      ;; model keyword from this OSS namespace. Read and write via the raw table instead, decrypting and
+      ;; re-encrypting the stored ciphertext directly — we don't need the JSON round-trip because the
+      ;; value is opaque to this code.
+      (doseq [{:keys [id access_token]} (t2/select [:custom_viz_plugin :id :access_token])]
+        (when access_token
+          (let [plaintext (encryption/maybe-decrypt access_token)]
+            (when (encryption/possibly-encrypted-string? plaintext)
+              (throw (ex-info (trs "Can''t decrypt custom_viz_plugin.access_token with MB_ENCRYPTION_SECRET_KEY")
+                              {:custom-viz-plugin-id id})))
+            (t2/update! :conn conn :custom_viz_plugin
+                        {:id id}
+                        {:access_token (encrypt-str-fn plaintext)}))))
       (t2/delete! :conn conn :model/QueryCache))))
 
 (defn encrypt-db

--- a/test/metabase/cmd/rotate_encryption_key_test.clj
+++ b/test/metabase/cmd/rotate_encryption_key_test.clj
@@ -51,7 +51,9 @@
           user-id            (atom nil)
           secret-val         "surprise!"
           secret-id-enc      (atom nil)
-          secret-id-unenc    (atom nil)]
+          secret-id-unenc    (atom nil)
+          plugin-token       {:token "secret-token"}
+          plugin-id          (atom nil)]
       (mt/test-drivers #{:postgres :h2 :mysql}
         (let [data-source (dump-to-h2-test/persistent-data-source driver/*driver* db-name)]
           ;; `database.details` use mi/transform-encrypted-json as transformation
@@ -103,7 +105,15 @@
                                                                                    :kind       "password"
                                                                                    :value      (.getBytes secret-val StandardCharsets/UTF_8)
                                                                                    :creator_id @user-id}))]
-                  (reset! secret-id-enc (u/the-id secret))))
+                  (reset! secret-id-enc (u/the-id secret)))
+                (when config/ee-available?
+                  (let [plugin (first (t2/insert-returning-instances! :model/CustomVizPlugin
+                                                                      {:repo_url     "https://github.com/test/rotate"
+                                                                       :identifier   "rotate-test"
+                                                                       :display_name "rotate-test"
+                                                                       :status       :active
+                                                                       :access_token plugin-token}))]
+                    (reset! plugin-id (u/the-id plugin)))))
 
               (testing "rotating with the same key is a noop"
                 (encryption-test/with-secret-key k1
@@ -129,13 +139,21 @@
                   (encryption-test/with-secret-key k2
                     (is (= "unencrypted value" (t2/select-one-fn :value :model/Setting :key "nocrypt")))
                     (is (= {:db "/tmp/test.db"} (t2/select-one-fn :details :model/Database :id 1)))
-                    (is (mt/secret-value-equals? secret-val (t2/select-one-fn :value :model/Secret :id @secret-id-unenc)))))
+                    (is (mt/secret-value-equals? secret-val (t2/select-one-fn :value :model/Secret :id @secret-id-unenc)))
+                    (when config/ee-available?
+                      (is (= plugin-token
+                             (t2/select-one-fn :access_token :model/CustomVizPlugin :id @plugin-id))
+                          "CustomVizPlugin.access_token should round-trip under the new key"))))
                 (testing "but not with old key"
                   (encryption-test/with-secret-key k1
                     (is (not= "unencrypted value" (t2/select-one-fn :value :model/Setting :key "nocrypt")))
                     (is (not= "{\"db\":\"/tmp/test.db\"}" (t2/select-one-fn :details :model/Database :id 1)))
                     (is (not (mt/secret-value-equals? secret-val
-                                                      (t2/select-one-fn :value :model/Secret :id @secret-id-unenc)))))))
+                                                      (t2/select-one-fn :value :model/Secret :id @secret-id-unenc))))
+                    (when config/ee-available?
+                      (is (not= plugin-token
+                                (t2/select-one-fn :access_token :model/CustomVizPlugin :id @plugin-id))
+                          "CustomVizPlugin.access_token should NOT round-trip under the old key")))))
 
               (testing "full rollback when a database details looks encrypted with a different key than the current one"
                 (encryption-test/with-secret-key k3


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-2270/security-audit-l-4-access-token-not-re-encrypted-by-rotate-encryption