### PR TITLE
add missing e2e tests

### DIFF
--- a/e2e/test/scenarios/admin/custom-viz/custom-viz.cy.spec.ts
+++ b/e2e/test/scenarios/admin/custom-viz/custom-viz.cy.spec.ts
@@ -600,7 +600,7 @@ describe("admin > custom visualizations", () => {
     });
 
     it("falls back to the default viz on an embedded question", () => {
-      cy.get<number>("@questionId").then((questionId) => {
+      cy.get<CardId>("@questionId").then((questionId) => {
         cy.request("PUT", `/api/card/${questionId}`, {
           enable_embedding: true,
         });
@@ -1165,6 +1165,18 @@ describe("admin > custom visualizations", () => {
       });
       cy.get("@documentId").then((documentId) => {
         cy.request("POST", `/api/bookmark/document/${documentId}`);
+      });
+    });
+
+    it("renders the custom-viz icon in the entity picker data-source modal", () => {
+      H.startNewQuestion();
+      H.miniPickerBrowseAll().click();
+
+      H.entityPickerModal().within(() => {
+        H.entityPickerModalItem(0, "Our analytics").click();
+        H.entityPickerModalItem(1, ICON_QUESTION_NAME)
+          .find(PLUGIN_ICON_SELECTOR)
+          .should("exist");
       });
     });
 

--- a/e2e/test/scenarios/admin/custom-viz/custom-viz.cy.spec.ts
+++ b/e2e/test/scenarios/admin/custom-viz/custom-viz.cy.spec.ts
@@ -113,6 +113,10 @@ describe("admin > custom visualizations", () => {
       H.getAddVisualizationLink().click();
 
       cy.findByLabelText(/Repository URL/).type(H.CUSTOM_VIZ_REPO_URL);
+      cy.log(
+        "It should not be possible to add the plugin until the user understands the risks",
+      );
+      cy.findByRole("button", { name: /Save/ }).should("be.disabled");
       cy.findByLabelText(/I understand/).click();
       H.interceptPluginCreate();
       cy.findByRole("button", { name: /Save/ }).click();
@@ -1433,6 +1437,13 @@ describe("admin > custom visualizations", () => {
         .find(pluginPath)
         .should("have.attr", "transform")
         .and("match", /rotate\(-180/);
+
+      cy.log(
+        "When the dev server is stopped, the visualization should revert to the default",
+      );
+      cy.task("stopCustomVizDevServer", devServerPid);
+      cy.reload();
+      H.main().findByText("18,760").should("be.visible");
     });
   });
 });

--- a/e2e/test/scenarios/admin/custom-viz/custom-viz.cy.spec.ts
+++ b/e2e/test/scenarios/admin/custom-viz/custom-viz.cy.spec.ts
@@ -599,6 +599,21 @@ describe("admin > custom visualizations", () => {
       cy.findByTestId("table-root").should("be.visible");
     });
 
+    it("falls back to the default viz on an embedded question", () => {
+      cy.get<number>("@questionId").then((questionId) => {
+        cy.request("PUT", `/api/card/${questionId}`, {
+          enable_embedding: true,
+        });
+
+        H.visitEmbeddedPage({
+          resource: { question: questionId },
+          params: {},
+        });
+      });
+
+      cy.findByTestId("table-root").should("be.visible");
+    });
+
     it("calls onClick when the viz fires a click", () => {
       H.visitQuestion("@questionId");
       switchToDemoViz();
@@ -707,6 +722,23 @@ describe("admin > custom visualizations", () => {
 
       createCustomVizDashboard().then(({ body: dashcard }) => {
         H.visitPublicDashboard(Number(checkNotNull(dashcard.dashboard_id)));
+      });
+
+      H.getDashboardCard().findByTestId("table-root").should("be.visible");
+    });
+
+    it("falls back to the default viz on an embedded dashboard", () => {
+      createCustomVizDashboard().then(({ body: dashcard }) => {
+        const dashboardId = Number(checkNotNull(dashcard.dashboard_id));
+
+        cy.request("PUT", `/api/dashboard/${dashboardId}`, {
+          enable_embedding: true,
+        });
+
+        H.visitEmbeddedPage({
+          resource: { dashboard: dashboardId },
+          params: {},
+        });
       });
 
       H.getDashboardCard().findByTestId("table-root").should("be.visible");


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-2306/leftover-tests

### Description

# Leftover tests

Anything left in the [Testing Plan](https://linear.app/metabase/document/testing-plan-a20deeecd665):

- [X] ~`click on instructions shouldn't raise 500`~
- [X] `Submit button is disabled when "I understand" checkbox is not checked`
- [X] `Also when the plugin was provided in dev mode`
- [X] `Embedding`
  - [X] `Public question with custom viz is rendered with defaultDisplay`
  - [X] `Public dashboard with custom viz question is rendered with defaultDisplay`
- [x] entity picker (e.g. data source modal in QB)


### How to verify


### Demo

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
