### PR TITLE
fix: token stats

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot/api.clj
@@ -1,7 +1,10 @@
 (ns metabase-enterprise.metabot.api
   "Enterprise-only Metabot API routes."
   (:require
+   [clojure.string :as str]
    [metabase.api.macros :as api.macros]
+   [metabase.metabot.provider-util :as provider-util]
+   [metabase.metabot.settings :as metabot.settings]
    [metabase.permissions.core :as perms]
    [metabase.premium-features.core :as premium-features]))
 
@@ -10,12 +13,31 @@
    [:tokens [:maybe int?]]
    [:updated-at [:maybe :string]]])
 
+(defn- meter-value
+  [meters meter-key]
+  (or (some-> meter-key keyword meters)
+      (some-> meter-key meters)))
+
+(defn- default-metabase-meter-key
+  []
+  (some-> metabot.settings/default-metabase-llm-metabot-provider
+          provider-util/strip-metabase-prefix
+          (str/replace-first "/" ":")
+          (str ":tokens")))
+
+(defn- meter-entry
+  [token-status]
+  (let [meters      (:meters token-status)
+        default-key (default-metabase-meter-key)]
+    (meter-value meters default-key)))
+
 (api.macros/defendpoint :get "/usage"
   :- metabot-usage-response-schema
   "Fetch current Metabot token usage for the current billing period."
   [_route-params
    _query-params]
   (perms/check-has-application-permission :setting)
-  (let [token-status (premium-features/token-status)]
-    {:tokens     (some-> token-status :meters :metabot-tokens :meter-value)
-     :updated-at (some-> token-status :meters :metabot-tokens :meter-updated-at)}))
+  (let [meter (some-> (premium-features/token-status)
+                      meter-entry)]
+    {:tokens     (:meter-value meter)
+     :updated-at (:meter-updated-at meter)}))

--- a/enterprise/backend/test/metabase_enterprise/metabot/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot/api_test.clj
@@ -47,8 +47,8 @@
 
 (deftest usage-get-returns-token-status-usage-test
   (mt/with-premium-features #{:metabot-v3}
-    (with-redefs [premium-features/token-status (constantly {:meters {:metabot-tokens {:meter-value      12345
-                                                                                       :meter-updated-at "2026-04-02T19:29:12Z"}}})]
+    (with-redefs [premium-features/token-status (constantly {:meters {:anthropic:claude-sonnet-4-6:tokens {:meter-value      12345
+                                                                                                           :meter-updated-at "2026-04-02T19:29:12Z"}}})]
       (is (= {:tokens 12345
               :updated-at "2026-04-02T19:29:12Z"}
              (mt/user-http-request :crowberto :get 200 "ee/metabot/usage"))))))


### PR DESCRIPTION
Closes [BOT-1348: Usage doesn't update in metabase app](https://linear.app/metabase/issue/BOT-1348/usage-doesnt-update-in-metabase-app)

### Description

Usage was using the wrong meter name, now it uses the correct one.

### How to verify

1. Use metabot a bit
2. Wait an hour
3. See the usage updated

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
