### PR TITLE
[MBQL Lib] Define ::external-query malli schema for External MBQL 5

### DIFF
--- a/src/metabase/lib/schema.cljc
+++ b/src/metabase/lib/schema.cljc
@@ -546,6 +546,22 @@
      :source-table ":source-table is not allowed in the top level of a query, only in MBQL stages"
      :type         ":type is not allowed in MBQL 5, use :lib/type instead."})])
 
+(defn- remove-lib-uuid [options]
+  (update options 2 (fn [m] (vec (remove #{[:lib/uuid ::common/uuid]} m)))))
+
+(mr/def ::external-query
+  "Schema for \"External MBQL\" 5 query."
+  [:schema {:registry {::id/database :string
+                       ::id/card :string
+                       ::id/segment :string
+                       ::id/measure :string
+                       ::id/snippet :string
+                       ::id/schema [:or nil? :string]
+                       ::id/table [:cat ::id/database ::id/schema :string]
+                       ::id/field [:cat ::id/database ::id/schema :string :string]
+                       ::common/options (remove-lib-uuid (mr/schema ::common/options))}}
+   [:ref ::query]])
+
 (defn native-only-query?
   "Whether MBQL 5 `query` only has a single native stage (and is thus pure-native). This is the equivalent of the old
   `:type :native` queries in MBQL <= 4."

--- a/src/metabase/lib/schema.cljc
+++ b/src/metabase/lib/schema.cljc
@@ -557,9 +557,14 @@
                        ::id/schema [:or nil? :string]
                        ::id/table [:cat ::id/database ::id/schema :string]
                        ::id/field [:cat ::id/database ::id/schema :string [:+ :string]]
+                       ;; this spec has a :multi clause that assumes field IDs
+                       ;; must be integers. the 3 in the update call refers to
+                       ;; the :multi; if that gets moved, this'll need to change
                        :mbql.clause/field (update (mr/schema :mbql.clause/field) 3
                                                   conj [:dispatch-type/sequential
                                                         ::ref/field.id])
+                       ;; similarly we need to get rid of the :lib/uuid key of
+                       ;; a map that's nested in position 2 of an :and schema:
                        ::common/options (update (mr/schema ::common/options) 2
                                                 mut/dissoc :lib/uuid)}}
    [:ref ::query]])

--- a/src/metabase/lib/schema.cljc
+++ b/src/metabase/lib/schema.cljc
@@ -8,6 +8,7 @@
   future we can deprecate that namespace and eventually do away with it entirely."
   (:refer-clojure :exclude [ref every? some select-keys empty? get-in])
   (:require
+   [malli.util :as mut]
    [medley.core :as m]
    [metabase.lib.options :as lib.options]
    [metabase.lib.schema.actions :as actions]
@@ -546,9 +547,6 @@
      :source-table ":source-table is not allowed in the top level of a query, only in MBQL stages"
      :type         ":type is not allowed in MBQL 5, use :lib/type instead."})])
 
-(defn- remove-lib-uuid [options]
-  (update options 2 (fn [m] (vec (remove #{[:lib/uuid ::common/uuid]} m)))))
-
 (mr/def ::external-query
   "Schema for \"External MBQL\" 5 query."
   [:schema {:registry {::id/database :string
@@ -558,8 +556,12 @@
                        ::id/snippet :string
                        ::id/schema [:or nil? :string]
                        ::id/table [:cat ::id/database ::id/schema :string]
-                       ::id/field [:cat ::id/database ::id/schema :string :string]
-                       ::common/options (remove-lib-uuid (mr/schema ::common/options))}}
+                       ::id/field [:cat ::id/database ::id/schema :string [:+ :string]]
+                       :mbql.clause/field (update (mr/schema :mbql.clause/field) 3
+                                                  conj [:dispatch-type/sequential
+                                                        ::ref/field.id])
+                       ::common/options (update (mr/schema ::common/options) 2
+                                                mut/dissoc :lib/uuid)}}
    [:ref ::query]])
 
 (defn native-only-query?

--- a/src/metabase/lib/schema/ref.cljc
+++ b/src/metabase/lib/schema/ref.cljc
@@ -207,6 +207,7 @@
             ;; doesn't return something that matches.
             :error/message "Invalid :field clause ID or name: must be a string or integer"}
     [:dispatch-type/integer ::field.id]
+    [:dispatch-type/sequential ::field.id]
     [:dispatch-type/string ::field.literal]]])
 
 (lib.hierarchy/derive :field ::ref)

--- a/src/metabase/lib/schema/ref.cljc
+++ b/src/metabase/lib/schema/ref.cljc
@@ -207,7 +207,6 @@
             ;; doesn't return something that matches.
             :error/message "Invalid :field clause ID or name: must be a string or integer"}
     [:dispatch-type/integer ::field.id]
-    [:dispatch-type/sequential ::field.id]
     [:dispatch-type/string ::field.literal]]])
 
 (lib.hierarchy/derive :field ::ref)

--- a/test/metabase/lib/schema_test.cljc
+++ b/test/metabase/lib/schema_test.cljc
@@ -412,6 +412,8 @@
   ;; this one is not valid according to the internal schema because it
   ;; uses a string tuple for the field instead of an integer.
   (is (mr/explain ::lib.schema/query basic-external-query))
+  ;; if these fail, it's likely because the :mbql.clause/field or ::common/options
+  ;; schemas changed; see the comment in ::lib.schema/external-query for details.
   (is (not (me/humanize (mr/explain ::lib.schema/external-query
                                     basic-external-query))))
   (is (not (me/humanize (mr/explain ::lib.schema/external-query

--- a/test/metabase/lib/schema_test.cljc
+++ b/test/metabase/lib/schema_test.cljc
@@ -2,7 +2,6 @@
   (:require
    #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))
    [clojure.test :refer [are deftest is testing]]
-   #?@(:clj ([clj-yaml.core :as yaml]))
    [malli.error :as me]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata.protocols]
@@ -10,8 +9,7 @@
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.util :as lib.schema.util]
    [metabase.lib.schema.util-test :as lib.schema.util-test]
-   [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :as mp]))
+   [metabase.util.malli.registry :as mr]))
 
 (comment
   metabase.lib.metadata.protocols/keep-me ; so `:metabase.lib.metadata.protocols/metadata-provider` gets loaded
@@ -365,53 +363,56 @@
          (me/humanize (mr/explain ::lib.schema/query
                                   {:lib/type :mbql/query, :database 2378, :stages [{:lib/type :mbql.stage/mbql}]})))))
 
-(def times #{:year-of-era :quarter-of-year :month-of-year :week-of-year-iso :unix-seconds
-             :week-of-year-us :week-of-year-instance :day-of-month :day-of-week :iso :us
-             :day-of-week-iso :hour-of-day :minute-of-hour :second-of-minute :day :instance})
+;; these two queries are taken from the representations repository
+(def basic-external-query
+  {:lib/type :mbql/query
+   :database "Sample Database"
+   :stages [{:lib/type :mbql.stage/mbql
+             :source-table ["Sample Database" "PUBLIC" "ORDERS"]
+             :aggregation [[:sum {} [:field {:base-type :type/Float}
+                                     ["Sample Database" "PUBLIC" "ORDERS" "TOTAL"]]]]}]})
 
-;; maybe there's a way to get lib.normalize to do this, and it gets most field
-;; references, but it misses fields inside expressions like :concat/:substring.
-;; normalize is meant to convert from frontend requests, and we're converting
-;; from yaml on disk, so maybe it's better to make our own thing vs trying to
-;; wedge it into lib.normalize.
-(defn normalize [schema]
-  (lib.normalize/normalize
-   (mp/prewalk (fn [x]
-                 ;; ("field" {} ("Sample Database" "PUBLIC" "PRODUCTS" "TITLE"))
-                 ;; ->
-                 ;; [:field {} ["Sample Database" "PUBLIC" "PRODUCTS" "TITLE"]]
-                 (cond (and (seq? x) (string? (first x)) (map? (second x)))
-                       (into [(keyword (first x))] (rest x))
-                       (and (string? x) (re-find #"^type/" x)) (keyword x)
-                       (and (string? x) (times (keyword x))) (times (keyword x))
-                       (seq? x) (vec x)
-                       :else x))
-               schema)))
-
-(def sample-external-query
+(def native-external-query
   {:lib/type :mbql/query
    :database "Sample Database"
    :stages
-   [{:lib/type :mbql.stage/mbql
-     :source-table ["Sample Database" "PUBLIC" "ORDERS"]
-     :aggregation
-     [[:sum {} [:field {:base-type :type/Float}
-                ["Sample Database" "PUBLIC" "ORDERS" "TOTAL"]]]]}]})
+   [{:lib/type :mbql.stage/native
+     :native "SELECT *
+                FROM ORDERS
+               WHERE TOTAL > {{min_total}}
+                 AND CREATED_AT > {{after_date}}
+                 AND USER_ID = {{user_id}}
+                 AND {{is_active}}"
+     :template-tags {"min_total" {:type :number
+                                  :name "min_total"
+                                  :id "aa000001-0000-0000-0000-000000000001"
+                                  :display-name "Minimum Total"
+                                  :default 50
+                                  :required true
+                                  :sectionid "number"}
+                     "after_date" {:type :date
+                                   :name "after_date"
+                                   :id "aa000002-0000-0000-0000-000000000002"
+                                   :display-name "After Date"
+                                   :default "2024-01-01"
+                                   :sectionid "date"}
+                     "user_id" {:type :text
+                                :name "user_id"
+                                :id "aa000003-0000-0000-0000-000000000003"
+                                :display-name "User ID"
+                                :default "1"}
+                     "is_active" {:type :boolean
+                                  :name "is_active"
+                                  :id "aa000004-0000-0000-0000-000000000004"
+                                  :display-name "Is Active"
+                                  :default true
+                                  :sectionid "boolean"}}}]})
 
-#?(:clj
-   (deftest ^:parallel external-test
-     (testing "basic example query validates"
-       ;; this one is not valid according to the internal schema because it
-       ;; uses a string tuple for the field instead of an integer.
-       (is (mr/explain ::lib.schema/query sample-external-query))
-       (is (not (me/humanize (mr/explain ::lib.schema/external-query
-                                         sample-external-query)))))
-     (testing "representation example queries validate"
-       (let [examples-dir "../representations/examples/v1/collections/main/queries"]
-         ;; skip these tests when you don't have a representations checkout
-         (when (.exists (java.io.File. examples-dir))
-           (doseq [f (.listFiles (java.io.File. examples-dir))]
-             (let [query (normalize
-                          (:dataset_query (yaml/parse-string (slurp f))))]
-               (is (not (me/humanize (mr/explain ::lib.schema/external-query query)))
-                   (str f)))))))))
+(deftest ^:parallel external-test
+  ;; this one is not valid according to the internal schema because it
+  ;; uses a string tuple for the field instead of an integer.
+  (is (mr/explain ::lib.schema/query basic-external-query))
+  (is (not (me/humanize (mr/explain ::lib.schema/external-query
+                                    basic-external-query))))
+  (is (not (me/humanize (mr/explain ::lib.schema/external-query
+                                    native-external-query)))))

--- a/test/metabase/lib/schema_test.cljc
+++ b/test/metabase/lib/schema_test.cljc
@@ -2,6 +2,7 @@
   (:require
    #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))
    [clojure.test :refer [are deftest is testing]]
+   #?@(:clj ([clj-yaml.core :as yaml]))
    [malli.error :as me]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata.protocols]
@@ -9,7 +10,8 @@
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.util :as lib.schema.util]
    [metabase.lib.schema.util-test :as lib.schema.util-test]
-   [metabase.util.malli.registry :as mr]))
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.performance :as mp]))
 
 (comment
   metabase.lib.metadata.protocols/keep-me ; so `:metabase.lib.metadata.protocols/metadata-provider` gets loaded
@@ -362,3 +364,54 @@
   (is (= {:stages [["Initial MBQL stage must have either :source-table or :source-card (but not both)"]]}
          (me/humanize (mr/explain ::lib.schema/query
                                   {:lib/type :mbql/query, :database 2378, :stages [{:lib/type :mbql.stage/mbql}]})))))
+
+(def times #{:year-of-era :quarter-of-year :month-of-year :week-of-year-iso :unix-seconds
+             :week-of-year-us :week-of-year-instance :day-of-month :day-of-week :iso :us
+             :day-of-week-iso :hour-of-day :minute-of-hour :second-of-minute :day :instance})
+
+;; maybe there's a way to get lib.normalize to do this, and it gets most field
+;; references, but it misses fields inside expressions like :concat/:substring.
+;; normalize is meant to convert from frontend requests, and we're converting
+;; from yaml on disk, so maybe it's better to make our own thing vs trying to
+;; wedge it into lib.normalize.
+(defn normalize [schema]
+  (lib.normalize/normalize
+   (mp/prewalk (fn [x]
+                 ;; ("field" {} ("Sample Database" "PUBLIC" "PRODUCTS" "TITLE"))
+                 ;; ->
+                 ;; [:field {} ["Sample Database" "PUBLIC" "PRODUCTS" "TITLE"]]
+                 (cond (and (seq? x) (string? (first x)) (map? (second x)))
+                       (into [(keyword (first x))] (rest x))
+                       (and (string? x) (re-find #"^type/" x)) (keyword x)
+                       (and (string? x) (times (keyword x))) (times (keyword x))
+                       (seq? x) (vec x)
+                       :else x))
+               schema)))
+
+(def sample-external-query
+  {:lib/type :mbql/query
+   :database "Sample Database"
+   :stages
+   [{:lib/type :mbql.stage/mbql
+     :source-table ["Sample Database" "PUBLIC" "ORDERS"]
+     :aggregation
+     [[:sum {} [:field {:base-type :type/Float}
+                ["Sample Database" "PUBLIC" "ORDERS" "TOTAL"]]]]}]})
+
+#?(:clj
+   (deftest ^:parallel external-test
+     (testing "basic example query validates"
+       ;; this one is not valid according to the internal schema because it
+       ;; uses a string tuple for the field instead of an integer.
+       (is (mr/explain ::lib.schema/query sample-external-query))
+       (is (not (me/humanize (mr/explain ::lib.schema/external-query
+                                         sample-external-query)))))
+     (testing "representation example queries validate"
+       (let [examples-dir "../representations/examples/v1/collections/main/queries"]
+         ;; skip these tests when you don't have a representations checkout
+         (when (.exists (java.io.File. examples-dir))
+           (doseq [f (.listFiles (java.io.File. examples-dir))]
+             (let [query (normalize
+                          (:dataset_query (yaml/parse-string (slurp f))))]
+               (is (not (me/humanize (mr/explain ::lib.schema/external-query query)))
+                   (str f)))))))))


### PR DESCRIPTION
### Description

Using a nested :registry allows us to override the few differences
between internal and external MBQL without constructing an entire
separate tree of the whole ::query schema.

I've added tests to validate all the sample queries in the representations
repository. We have to do some normalization for these queries because
they're getting deserialized from yaml and thus end up having strings
where they should have keywords and lists where they should have vectors.

I found what looks like an oversight in one of the representations queries
where it was missing a lib/type field: https://github.com/metabase/representations/pull/23

### Open Questions

These tests are skipped if you don't have a representations checkout.
I've copied one of the queries into the test. Maybe we should just copy
all of them over into the test suite instead?

I've kept the normalization for these queries in the test suite
because it seems to be specific to the yaml deserialization process
and not really anything inherent in the external format, but it could
be argued that belongs in src/. This is run on top of the existing
lib.normalize process, which is intended specifically for queries
coming in from the frontend.
