### PR TITLE
Implement JWT handling in SSO: add request-jwt function, refactor JWT request handling, and update tests for POST requests with JWT in JSON body

### DIFF
--- a/docs/people-and-groups/authenticating-with-jwt.md
+++ b/docs/people-and-groups/authenticating-with-jwt.md
@@ -22,6 +22,8 @@ Assuming your site is localhost serving on port 3000:
 5. In the event of a successful sign-in, your authentication app should issue a GET request to your Metabase endpoint with the token and the "return to" URI: `http://localhost:3000/auth/sso?jwt=TOKEN_GOES_HERE&return_to=/question/1-superb-question`.
 6. Metabase verifies the JSON Web Token, logs the person in, then redirects the person to their original destination, `/question/1-superb-question`.
 
+As an alternative to putting the JWT in the URL query string (which some environments log or cache), you can send the same token in the body of a `POST` request to `/auth/sso` with `Content-Type: application/json` and a JSON body like `{"jwt": "TOKEN_GOES_HERE"}`. You can still pass `return_to` as a query parameter on that URL (for example `POST /auth/sso?return_to=/question/1-superb-question`). The login behavior is otherwise the same as the GET flow.
+
 ## Set up JWT authentication
 
 Navigate to the **Admin**>**Settings** section of the Admin area, then click on the **Authentication > JWT** tab.

--- a/enterprise/backend/src/metabase_enterprise/sso/api/interface.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/api/interface.clj
@@ -4,7 +4,7 @@
    [metabase.util.i18n :refer [tru]]))
 
 (defn request-jwt
-  "JWT from the request query string (`:params`), form body, or JSON body (`:body`), in that order."
+  "JWT from the request `:params` (which includes both query string and form body) or JSON body (`:body`), in that order."
   [req]
   (or (get-in req [:params :jwt])
       (get-in req [:body :jwt])))

--- a/enterprise/backend/src/metabase_enterprise/sso/api/interface.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/api/interface.clj
@@ -3,6 +3,12 @@
    [metabase-enterprise.sso.settings :as ee-sso-settings]
    [metabase.util.i18n :refer [tru]]))
 
+(defn request-jwt
+  "JWT from the request query string (`:params`), form body, or JSON body (`:body`), in that order."
+  [req]
+  (or (get-in req [:params :jwt])
+      (get-in req [:body :jwt])))
+
 (defn- select-sso-backend
   [req]
   (let [preferred-method (get-in req [:params :preferred_method])]
@@ -13,7 +19,7 @@
                          (throw (ex-info "Invalid auth method"
                                          {:preferred-method preferred-method
                                           :available        [:jwt :saml]})))
-      (contains? (:params req) :jwt) :jwt
+      (some? (request-jwt req)) :jwt
       :else :saml)))
 
 (defn- sso-backend

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
@@ -71,13 +71,15 @@
           (when redirect
             (str return-to-param redirect))))))
 
-(defmethod sso.i/sso-get :jwt
-  [{{:keys [jwt redirect]} :params, :as request}]
+(defn- handle-jwt-sso-request
+  [request]
   (premium-features/assert-has-feature :sso-jwt (tru "JWT-based authentication"))
-  (let [result (session-data jwt request)
+  (let [jwt (sso.i/request-jwt request)
+        result (session-data jwt request)
         is-react-sdk? (embed.util/has-react-sdk-header? request)
         is-embedded-analytics-js? (embed.util/has-embedded-analytics-js-header? request)
-        is-modular-embedding? (or is-react-sdk? is-embedded-analytics-js?)]
+        is-modular-embedding? (or is-react-sdk? is-embedded-analytics-js?)
+        redirect (get-in request [:params :redirect])]
     (cond
       ;; Embedding feature checks
       (and is-react-sdk? (not (embed.settings/enable-embedding-sdk)))
@@ -104,8 +106,10 @@
       :else
       (redirect-to-idp (sso-settings/jwt-identity-provider-uri) redirect))))
 
+(defmethod sso.i/sso-get :jwt
+  [request]
+  (handle-jwt-sso-request request))
+
 (defmethod sso.i/sso-post :jwt
-  [_]
-  (throw
-   (ex-info (tru "POST not valid for JWT SSO requests")
-            {:status "error-post-jwt-not-valid" :status-code 501})))
+  [request]
+  (handle-jwt-sso-request request))

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
@@ -177,6 +177,13 @@
                                                       :return_to default-redirect-uri)]
             (is (not (sso.test-setup/successful-login? response)))))
 
+        (testing "with SAML and JWT configured, a POST without jwt in JSON body dispatches to SAML (not JWT login)"
+          (let [response (client/client-real-response :post 401 "/auth/sso"
+                                                      {:request-options {:redirect-strategy :none}}
+                                                      {}
+                                                      :return_to default-redirect-uri)]
+            (is (not (sso.test-setup/successful-login? response)))))
+
         (testing "with SAML and JWT configured, a GET request with preferred_method=jwt should sign in via JWT"
           (let [response (client/client-real-response :get 302 "/auth/sso"
                                                       {:request-options {:redirect-strategy :none}}
@@ -226,6 +233,33 @@
                                                     :exp        (+ (buddy-util/now) 3600)
                                                     :iat        (buddy-util/now)}
                                                    default-jwt-secret))]
+        (is (sso.test-setup/successful-login? response))
+        (testing "redirect URI"
+          (is
+           (= default-redirect-uri
+              (get-in response [:headers "Location"]))))
+        (testing "login attributes"
+          (is
+           (= {"extra" "keypairs", "are" "also present"}
+              (t2/select-one-fn :jwt_attributes :model/User :email "rasta@metabase.com"))))))))
+
+(deftest post-jwt-body-happy-path-test
+  (testing "Happy path login via POST /auth/sso with JSON body {:jwt ...}, same behavior as GET with query param"
+    (with-jwt-default-setup!
+      (let [jwt-payload (jwt/sign
+                         {:email      "rasta@metabase.com"
+                          :first_name "Rasta"
+                          :last_name  "Toucan"
+                          :extra      "keypairs"
+                          :are        "also present"
+                          :iss        "issuer"
+                          :exp        (+ (buddy-util/now) 3600)
+                          :iat        (buddy-util/now)}
+                         default-jwt-secret)
+            response    (client/client-real-response :post 302 "/auth/sso"
+                                                     {:request-options {:redirect-strategy :none}}
+                                                     {:jwt jwt-payload}
+                                                     :return_to default-redirect-uri)]
         (is (sso.test-setup/successful-login? response))
         (testing "redirect URI"
           (is
@@ -974,7 +1008,14 @@
           (testing "with hash header (legacy usage)"
             (is (=? expected-body
                     (:body (do-request {"x-metabase-client" "embedding-sdk-react"
-                                        "x-metabase-sdk-jwt-hash" (token-utils/generate-token)}))))))))))
+                                        "x-metabase-sdk-jwt-hash" (token-utils/generate-token)})))))
+          (testing "POST /auth/sso with jwt in JSON body matches GET behavior"
+            (let [do-post (fn [headers]
+                            (client/client-real-response :post 200 "/auth/sso"
+                                                         {:request-options {:headers headers}}
+                                                         {:jwt jwt-payload}))]
+              (is (=? expected-body
+                      (:body (do-post {"x-metabase-client" "embedding-sdk-react"})))))))))))
 
 (deftest jwt-token-not-configured-test
   (testing "should not return a session token when jwt is not configured"


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/47486
It's just making the JWT auth to work with POST along GET requests


Added by @npretto: this would unlock https://linear.app/metabase/issue/EMB-1645/support-passing-embed-jwt-in-post-body