### PR TITLE
Remove misleading config file section about MB_PREMIUM_EMBEDDING_TOKEN

### DIFF
--- a/docs/configuring-metabase/config-file.md
+++ b/docs/configuring-metabase/config-file.md
@@ -274,14 +274,6 @@ config:
 
 But you can set any of the Admin settings with the config file (for a list of settings, check out the [config file template](./config-template.md)). You can also browse the list of [environment variable](./environment-variables.md) to see what you can configure (though note that not all environment variables can be set via the config file.)
 
-## Loading a new Metabase from a config file
-
-Since loading from a config file is a Pro/Enterprise feature: for new installations, you'll need to supply Metabase with a token using the `MB_PREMIUM_EMBEDDING_TOKEN` environment variable.
-
-```sh
-MB_PREMIUM_EMBEDDING_TOKEN="[your token]" java --add-opens java.base/java.nio=ALL-UNNAMED -jar metabase.jar
-```
-
 ## Further reading
 
 - [Config file template](./config-template.md)


### PR DESCRIPTION
Per https://github.com/metabase/metabase/issues/72813, this section is not precisely correct, and it's possible to use the config file even without a token being set.

In addition to the changes here, it could be worth mentioning the `premium-embedding-token` setting in addition to, or instead of `MB_PREMIUM_EMBEDDING_TOKEN`. Or, create a doc that we can quickly reference to explain the two options for setting the token.