### PR TITLE
Fix broken link fragment in guest-embedding.md

### DIFF
--- a/docs/embedding/guest-embedding.md
+++ b/docs/embedding/guest-embedding.md
@@ -278,7 +278,7 @@ If you rename a dashboard filter that's used as a locked parameter, update the m
 
 The values for a locked parameter in your JWT should match your filter's values exactly. The best way to set multiple locked parameters, or pass multiple values to a single locked parameter, is to pick a filter value under **Preview locked parameters** in the embed wizard and copy the server code that Metabase generates.
 
-Multiple locked parameters combine with `AND`, not `OR`. If you only want to apply a subset of the locked parameters for a given token, pass `[]` for the ones you want to skip (see [pass an empty array](#to-turn-off-a-locked-parameter-pass-an-empty-array-as-its-value)).
+Multiple locked parameters combine with `AND`, not `OR`. If you only want to apply a subset of the locked parameters for a given token, pass `[]` for the ones you want to skip (see [pass an empty array](#pass-an-empty-array-to-turn-off-a-locked-parameter)).
 
 ## Locked parameters limit the values available to other editable parameters
 


### PR DESCRIPTION
### Description

Fix broken link fragment in guest-embedding.md.

### Demo

#### before

```
lychee docs --config ./.lychee/config.toml --offline
Issues found in 1 input. Find details below.

[docs/embedding/guest-embedding.md]:
   [ERROR] file:///.../metabase/docs/embedding/guest-embedding.md#to-turn-off-a-locked-parameter-pass-an-empty-array-as-its-value | Cannot find fragment: Fragment not found in document. Check if fragment exists or page structure

🔍 4417 Total (in 0s) ✅ 3468 OK 🚫 1 Error 👻 948 Excluded
```

#### after
```
lychee docs --config ./.lychee/config.toml --offline
🔍 4417 Total (in 0s) ✅ 3469 OK 🚫 0 Errors 👻 948 Excluded
```
### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
