### PR TITLE
GDGT-2305 respect sub paths for custom viz assets

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/custom_viz/custom-viz-plugins.ts
+++ b/enterprise/frontend/src/metabase-enterprise/custom_viz/custom-viz-plugins.ts
@@ -12,6 +12,7 @@ import { useToast } from "metabase/common/hooks";
 import { useEmbeddingEntityContext } from "metabase/embedding/context";
 import { useColorScheme } from "metabase/ui";
 import type { IconData } from "metabase/utils/icon";
+import { getSubpathSafeUrl } from "metabase/utils/urls";
 import visualizations, { registerVisualization } from "metabase/visualizations";
 import {
   getCustomPluginIdentifier,
@@ -89,7 +90,9 @@ function useCustomVizDevReload(
       return;
     }
 
-    const sseUrl = `/api/ee/custom-viz-plugin/${plugin.id}/dev-sse`;
+    const sseUrl = getSubpathSafeUrl(
+      `/api/ee/custom-viz-plugin/${plugin.id}/dev-sse`,
+    );
 
     const eventSource = new EventSource(sseUrl);
 
@@ -257,7 +260,10 @@ export async function loadCustomVizPlugin(
   ensureVizApi();
 
   try {
-    const bundleUrl = new URL(plugin.bundle_url, window.location.origin);
+    const bundleUrl = new URL(
+      getSubpathSafeUrl(plugin.bundle_url),
+      window.location.origin,
+    );
     if (cacheBustSuffix) {
       bundleUrl.searchParams.set("t", Date.now().toString());
     } else if (plugin.resolved_commit) {

--- a/frontend/src/metabase/visualizations/custom-visualizations/custom-viz-utils.ts
+++ b/frontend/src/metabase/visualizations/custom-visualizations/custom-viz-utils.ts
@@ -1,5 +1,6 @@
 import type { OptionsType } from "metabase/utils/formatting/types";
 import { formatValue as internalFormatValue } from "metabase/utils/formatting/value";
+import { getSubpathSafeUrl } from "metabase/utils/urls";
 import type {
   CustomVizPluginId,
   CustomVizPluginRuntime,
@@ -24,7 +25,9 @@ export function getPluginAssetUrl(
   if (!assetPath) {
     return undefined;
   }
-  return `/api/ee/custom-viz-plugin/${pluginId}/asset?path=${encodeURIComponent(assetPath)}`;
+  return getSubpathSafeUrl(
+    `/api/ee/custom-viz-plugin/${pluginId}/asset?path=${encodeURIComponent(assetPath)}`,
+  );
 }
 
 export function getCustomPluginIdentifier(


### PR DESCRIPTION
Closes [GDGT-2305: Test/fix assets on subpath-hosted instances](https://linear.app/metabase/issue/GDGT-2305/testfix-assets-on-subpath-hosted-instances)

### Description
Wraps assets urls with subpath helper in order to respect self-hosted instances which declare the sub-path (Site URL)