### PR TITLE
BOT-1354 Bump retention of ai_usage_log data from 3 to 6 months

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot/task/ai_usage_trimmer.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot/task/ai_usage_trimmer.clj
@@ -1,5 +1,5 @@
 (ns metabase-enterprise.metabot.task.ai-usage-trimmer
-  "Scheduled task to delete old ai_usage_log rows (older than 3 months)."
+  "Scheduled task to delete old ai_usage_log rows (older than 6 months)."
   (:require
    [clojurewerkz.quartzite.jobs :as jobs]
    [clojurewerkz.quartzite.schedule.cron :as cron]
@@ -16,7 +16,7 @@
 (def ^:private trimmer-job-key (jobs/key "metabase.task.metabot.ai-usage-trimmer.job"))
 (def ^:private trimmer-trigger-key (triggers/key "metabase.task.metabot.ai-usage-trimmer.trigger"))
 
-(def ^:private retention-months 3)
+(def ^:private retention-months 6)
 
 (defn- trim-old-usage-data!
   []


### PR DESCRIPTION
Closes [BOT-1354: Bump retention of ai_usage_log data from 3 to 6 months](https://linear.app/metabase/issue/BOT-1354/bump-retention-of-ai-usage-log-data-from-3-to-6-months)

https://metaboat.slack.com/archives/C096M2BBGHH/p1776445154403009

### Description

We'd like to use the `ai_usage_log` table as our source for token usage analytics so that billing, ai usage controls, and ai usage analytics are all pulling from the same table. Update the `ai-usage-trimmer` to retain 6 months of data so we have more historical data for usage analytics. We can adjust the retention later if it turns out we need more or less data.

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
