### PR TITLE
[match] Update replace-in implementation to use replace-lite

### DIFF
--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -127,7 +127,7 @@
     ;; if we've specified `old-alias`, then update ANY `:field` clause using it to `new-alias` instead.
     old-alias
     (lib.util.match/replace-in join [:conditions]
-      (field :guard #(and (lib.util/field-clause? %) (= (lib.join.util/current-join-alias %) old-alias)))
+      (field :guard (and (lib.util/field-clause? field) (= (lib.join.util/current-join-alias field) old-alias)))
       (with-join-alias field new-alias))
 
     ;; otherwise if `old-alias` is `nil`, then add (or remove!) `new-alias` to the RHS of any binary

--- a/src/metabase/lib/util/match.clj
+++ b/src/metabase/lib/util/match.clj
@@ -617,14 +617,6 @@
   ;; macros that power this macro directly
   `(replace* ~x ~patterns-and-results))
 
-(defmacro replace-in
-  "Like `replace`, but only replaces things in the part of `x` in the keypath `ks` (i.e. the way to `update-in` works.)"
-  {:style/indent :defn}
-  [x ks & patterns-and-results]
-  `(metabase.lib.util.match.impl/update-in-unless-empty ~x ~ks (fn [x#] (replace* x# ~patterns-and-results))))
-
-;; TODO - it would be useful to have something like a `replace-all` function as well
-
 (defmacro replace-lite
   "Walk `form` recursively and replace all patterns matched with `match-lite` by the respective return expressions. The
   same pattern options are supported, and `&parents` and `&match` anaphors are available in the same way."
@@ -639,3 +631,11 @@
                                             '&parents))))
       ~form
       ~(when contains-&parents? []))))
+
+(defmacro replace-in
+  "Like `replace-lite`, but only replaces things in the part of `x` in the keypath `ks` (i.e. the way to `update-in` works.)"
+  {:style/indent :defn}
+  [x ks & patterns-and-results]
+  `(metabase.lib.util.match.impl/update-in-unless-empty ~x ~ks (fn [x#] (replace-lite x# ~@patterns-and-results))))
+
+;; TODO - it would be useful to have something like a `replace-all` function as well

--- a/src/metabase/lib/util/match/impl.cljc
+++ b/src/metabase/lib/util/match/impl.cljc
@@ -1,8 +1,8 @@
 (ns metabase.lib.util.match.impl
   "Internal implementation of the MBQL `match` and `replace` macros. Don't use these directly."
-  (:refer-clojure :exclude [mapv get-in])
+  (:refer-clojure :exclude [mapv get-in empty?])
   (:require
-   [metabase.util.performance :refer [mapv get-in]]))
+   [metabase.util.performance :refer [mapv get-in empty?]]))
 
 ;; have to do this at runtime because we don't know if a symbol is a class or pred or whatever when we compile the macro
 (defn match-with-pred-or-class
@@ -66,7 +66,7 @@
 (defn update-in-unless-empty
   "Like `update-in`, but only updates in the existing value is non-empty."
   [m ks f]
-  (if-not (seq (get-in m ks))
+  (if (empty? (get-in m ks))
     m
     (update-in m ks f)))
 


### PR DESCRIPTION
This is the last step before getting rid of old core.match-based implementations of `lib.util.match/match` and `replace`.