### PR TITLE
Move api to shared

### DIFF
--- a/frontend/lint/module-boundaries.mjs
+++ b/frontend/lint/module-boundaries.mjs
@@ -40,7 +40,7 @@ const elements = [
     pattern: "frontend/src/metabase-lib/*/**",
   }),
   createElement({ type: "basic", name: "ui", enforceOutgoing: true }),
-  createElement({ type: "basic", name: "api" }),
+  createElement({ type: "shared", name: "api" }),
   // shared
   createElement({ type: "shared", name: "common", enforceOutgoing: true }),
   createElement({ type: "shared", name: "querying" }),

--- a/frontend/src/metabase/admin/people/containers/NewUserModal.tsx
+++ b/frontend/src/metabase/admin/people/containers/NewUserModal.tsx
@@ -11,6 +11,7 @@ import * as Urls from "metabase/utils/urls";
 import type { User as UserType } from "metabase-types/api";
 
 import { UserForm } from "../forms/UserForm";
+import { storeTemporaryPassword } from "../people";
 
 interface NewUserModalProps {
   onClose: () => void;
@@ -26,17 +27,21 @@ export const NewUserModal = ({
   const [createUser] = useCreateUserMutation();
 
   const handleSubmit = async (vals: Partial<UserType>) => {
+    const password = MetabaseSettings.isEmailConfigured()
+      ? undefined
+      : generatePassword();
     const user = await createUser({
       ...vals,
       email: vals.email ?? "",
       first_name: vals.first_name ?? undefined,
       last_name: vals.last_name ?? undefined,
       login_attributes: vals.login_attributes || undefined,
-      ...(MetabaseSettings.isEmailConfigured()
-        ? {}
-        : { password: generatePassword() }),
+      ...(password ? { password } : {}),
     }).unwrap();
 
+    if (password) {
+      dispatch(storeTemporaryPassword({ id: user.id, password }));
+    }
     dispatch(push(Urls.newUserSuccess(user)));
   };
 

--- a/frontend/src/metabase/api/user.ts
+++ b/frontend/src/metabase/api/user.ts
@@ -1,4 +1,3 @@
-import { storeTemporaryPassword } from "metabase/admin/people/people";
 import { userUpdated } from "metabase/redux/user";
 import type {
   CreateUserRequest,
@@ -58,13 +57,6 @@ export const userApi = Api.injectEndpoints({
           listTag("tenant"),
           listTag("permissions-group"),
         ]),
-      onQueryStarted: (request, { dispatch, queryFulfilled }) =>
-        handleQueryFulfilled(queryFulfilled, (user) => {
-          if (request.password) {
-            const payload = { id: user.id, password: request.password };
-            dispatch(storeTemporaryPassword(payload));
-          }
-        }),
     }),
     updatePassword: builder.mutation<void, UpdatePasswordRequest>({
       query: ({ id, old_password, password }) => ({
@@ -72,9 +64,6 @@ export const userApi = Api.injectEndpoints({
         url: `/api/user/${id}/password`,
         body: { old_password, password },
       }),
-      onQueryStarted: ({ id, password }, { dispatch }) => {
-        dispatch(storeTemporaryPassword({ id, password }));
-      },
       invalidatesTags: (_, error, { id }) =>
         invalidateTags(error, [listTag("user"), idTag("user", id)]),
     }),


### PR DESCRIPTION
We should make api a shared module.

If we do this, it fixes all violations the PR addresses (it doesn't fix the PLUGIN_API ones). More importantly, I think it is in the direction we want to go which is pushing api files up closer to features. Some may even live in features if they're only used in that one feature.

It fixes 10 violations immediately.


This also fixes the only other violation. Instead of calling the redux action in the api, I moved it to where the api is used. you could argue it's a bit of duplication having to remember to do two things, but in this case I think it's worth being explicit, even if it's clunky, rather than adding middleware listeners or other indirection which would likely be more confusing. If it was an api used in many places I'd do something different, but it's just used in two places and the other location was already doing the exact thing I'm adding in.