### PR TITLE
Delete e2e reproduction for #57132

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
@@ -1330,33 +1330,6 @@ describe("issue 56771", () => {
   });
 });
 
-describe("issue 57132", () => {
-  beforeEach(() => {
-    H.restore();
-    cy.signInAsAdmin();
-
-    cy.intercept("POST", "/api/dataset", function (req) {
-      req.continue((res) => {
-        // remove description from the CATEGORY column
-        const index = res.body.data.cols.findIndex(
-          (col) => col.name === "CATEGORY",
-        );
-        delete res.body.data.cols[index].description;
-      });
-    });
-  });
-
-  it("should render more values when hovering colum header without description (metabase#57132)", () => {
-    H.openProductsTable();
-    H.tableInteractive().findByText("Category").realHover();
-
-    cy.log("The popover should be wide enough to show at least some values");
-    H.popover()
-      .findByText(/^Doohickey, Gadget, Gizmo/)
-      .should("be.visible");
-  });
-});
-
 describe("issue 52333", () => {
   const baseQuery = `
 SELECT *


### PR DESCRIPTION
This PR deletes one of the flakiest reproductions in our test suite because it was an overkill to write an e2e test for this in the first place. For the reference, the original issue was #57132 and the fix was adding a hard coded min-width of 220px. There's no way to reliably test this using e2e.

This should either be a component test or a visual regression test.
But it provides low enough value (and high pain) that it makes sense to delete it, imo.

https://app.trunk.io/metabase/flaky-tests/repo/56d8e0ad-ae87-4941-a147-3082557f1178/test/9c5a5f59-c380-5678-b462-28750abfba36