### PR TITLE
Fix chart drill broken e2e test

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/drillthroughs/chart_drill.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/drillthroughs/chart_drill.cy.spec.js
@@ -36,10 +36,13 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
 
     H.queryBuilderMain().within(() => {
       cy.findByLabelText("Legend").findByText("Gadget").should("exist");
-      H.echartsContainer().findByText("January 2026").should("exist");
+      H.echartsContainer()
+        .should("contain.text", "July 2025")
+        .and("contain.text", "January 2026");
     });
 
     cy.wait(100); // wait to avoid grabbing the svg before the chart redraws
+    cy.log("Zoom-in on the left side, which corresponds to July 2025");
     cy.findByTestId("query-visualization-root") // drag across to filter
       .trigger("mousedown", 120, 200)
       .trigger("mousemove", 230, 200)
@@ -53,7 +56,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
     );
 
     H.queryBuilderMain().within(() => {
-      H.echartsContainer().findByText("June 5, 2025"); // more granular axis labels
+      H.echartsContainer().contains(/June \d{1,2}, 2025/); // more granular axis labels
 
       // confirm that product category is still broken out
       cy.findByLabelText("Legend").within(() => {


### PR DESCRIPTION
Resolves DEV-1833

Fixes a test that was quarantined when we updated the Sample Database dates in https://github.com/metabase/metabase/pull/72701.

### Stress test
https://github.com/metabase/metabase/actions/runs/24659878695 :heavy_check_mark:  (x50)