### PR TITLE
GDGT-2310: use db-routing's own db-routing-enabled?

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -2263,7 +2263,6 @@
    ;; :model/TransformRun directly. Remove once the module is agnostic to global
    ;; versus workspace transforms. See https://linear.app/metabase/issue/BOT-1143
    :model-imports #{:model/Database
-                    :model/DatabaseRouter
                     :model/Table
                     :model/Transform
                     :model/TransformRun}

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -2267,7 +2267,8 @@
                     :model/Table
                     :model/Transform
                     :model/TransformRun}
-   :uses #{driver
+   :uses #{database-routing
+           driver
            events
            lib
            lib-be

--- a/src/metabase/transforms_base/util.clj
+++ b/src/metabase/transforms_base/util.clj
@@ -6,6 +6,7 @@
   (:require
    [clojure.string :as str]
    [java-time.api :as t]
+   [metabase.database-routing.core :as database-routing]
    [metabase.driver :as driver]
    [metabase.driver.sql.normalize :as sql.normalize]
    [metabase.events.core :as events]
@@ -723,18 +724,11 @@
   (when-let [table-name (:name table)]
     (str/starts-with? (u/lower-case-en table-name) transform-temp-table-prefix)))
 
-(defn db-routing-enabled?
-  "Returns whether or not the given database is either a router or destination database"
-  [db-or-id]
-  (or (t2/exists? :model/DatabaseRouter :database_id (u/the-id db-or-id))
-      (some->> (:router-database-id db-or-id)
-               (t2/exists? :model/DatabaseRouter :database_id))))
-
 (defn throw-if-db-routing-enabled!
   "Throws if the database has routing enabled. Call before any driver operations to get a
    clear error message rather than a confusing driver-level failure."
   [transform database]
-  (when (db-routing-enabled? database)
+  (when (database-routing/db-routing-enabled? database)
     (throw (ex-info (i18n/tru "Failed to run the transform ({0}) because the database ({1}) has database routing turned on. Running transforms on databases with db routing enabled is not supported."
                               (:name transform)
                               (:name database))

--- a/test/metabase/transforms/jobs_test.clj
+++ b/test/metabase/transforms/jobs_test.clj
@@ -4,6 +4,7 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [clojure.tools.logging :as log]
+   [metabase.config.core :as config]
    [metabase.driver :as driver]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
@@ -426,30 +427,31 @@
                      (is (mt/received-email-body? :crowberto #"transform0")))))))))))))
 
 (deftest get-plan-ignores-unrelated-routing-enabled-transforms-test
-  (testing "get-plan must not scan unrelated transforms on routing-enabled databases"
-    ;; Regression: a transform on a routing-enabled database is unrunnable (by design), but historically
-    ;; `get-plan` would fetch *every* transform in the system and call `table-dependencies` on each to
-    ;; build a global dependency graph. The routing-enabled transform would throw during that scan,
-    ;; taking down the whole scheduler and sending a misleading failure email naming the zombie
-    ;; transform — even when no job was asking to run it.
-    (mt/with-premium-features #{:database-routing :transforms-basic}
-      (let [mp (mt/metadata-provider)]
-        (mt/with-temp [:model/Database       _destination {:engine             :h2
-                                                           :router_database_id (mt/id)
-                                                           :details            {:destination_database true}}
-                       :model/DatabaseRouter _            {:database_id    (mt/id)
-                                                           :user_attribute "db_name"}
-                       ;; Zombie transform on a routing-enabled database, NOT tagged to any job.
-                       :model/Transform      _zombie      {:name       "zombie-transform"
-                                                           :source     {:type  :query
-                                                                        :query (lib/native-query mp "SELECT 1")}
-                                                           :creator_id (mt/user->id :crowberto)
-                                                           :target     {:type     "table"
-                                                                        :database (mt/id)
-                                                                        :schema   "PUBLIC"
-                                                                        :name     "zombie_out"}}]
-          (testing "get-plan with empty transform-ids must not throw on unrelated zombies"
-            (is (empty? (:order (#'jobs/get-plan #{}))))))))))
+  (when config/ee-available?
+    (testing "get-plan must not scan unrelated transforms on routing-enabled databases"
+     ;; Regression: a transform on a routing-enabled database is unrunnable (by design), but historically
+     ;; `get-plan` would fetch *every* transform in the system and call `table-dependencies` on each to
+     ;; build a global dependency graph. The routing-enabled transform would throw during that scan,
+     ;; taking down the whole scheduler and sending a misleading failure email naming the zombie
+     ;; transform — even when no job was asking to run it.
+      (mt/with-premium-features #{:database-routing :transforms-basic}
+        (let [mp (mt/metadata-provider)]
+          (mt/with-temp [:model/Database       _destination {:engine             :h2
+                                                             :router_database_id (mt/id)
+                                                             :details            {:destination_database true}}
+                         :model/DatabaseRouter _            {:database_id    (mt/id)
+                                                             :user_attribute "db_name"}
+                        ;; Zombie transform on a routing-enabled database, NOT tagged to any job.
+                         :model/Transform      _zombie      {:name       "zombie-transform"
+                                                             :source     {:type  :query
+                                                                          :query (lib/native-query mp "SELECT 1")}
+                                                             :creator_id (mt/user->id :crowberto)
+                                                             :target     {:type     "table"
+                                                                          :database (mt/id)
+                                                                          :schema   "PUBLIC"
+                                                                          :name     "zombie_out"}}]
+            (testing "get-plan with empty transform-ids must not throw on unrelated zombies"
+              (is (empty? (:order (#'jobs/get-plan #{})))))))))))
 
 (deftest run-transforms!-race-condition-test
   ;; Previously a race would ensure one transform run got the duplicate key error and aborted.

--- a/test/metabase/transforms_base/util_test.clj
+++ b/test/metabase/transforms_base/util_test.clj
@@ -1,6 +1,7 @@
 (ns metabase.transforms-base.util-test
   (:require
    [clojure.test :refer :all]
+   [metabase.config.core :as config]
    [metabase.test :as mt]
    [metabase.transforms-base.util :as transforms-base.u]))
 
@@ -14,13 +15,14 @@
         (is (nil? (transforms-base.u/throw-if-db-routing-enabled!
                    {:name "OSS transform"}
                    (mt/db)))))))
-  (testing "with :database-routing premium feature enabled, the check throws on a routing-enabled database"
-    (mt/with-premium-features #{:database-routing}
-      (mt/with-temp [:model/DatabaseRouter _ {:database_id    (mt/id)
-                                              :user_attribute "db_name"}]
-        (is (thrown-with-msg?
-             clojure.lang.ExceptionInfo
-             #".*database routing turned on"
-             (transforms-base.u/throw-if-db-routing-enabled!
-              {:name "Routing transform"}
-              (mt/db))))))))
+  (when config/ee-available?
+    (testing "with :database-routing premium feature enabled, the check throws on a routing-enabled database"
+      (mt/with-premium-features #{:database-routing}
+        (mt/with-temp [:model/DatabaseRouter _ {:database_id    (mt/id)
+                                                :user_attribute "db_name"}]
+          (is (thrown-with-msg?
+               clojure.lang.ExceptionInfo
+               #".*database routing turned on"
+               (transforms-base.u/throw-if-db-routing-enabled!
+                {:name "Routing transform"}
+                (mt/db)))))))))

--- a/test/metabase/transforms_base/util_test.clj
+++ b/test/metabase/transforms_base/util_test.clj
@@ -1,0 +1,26 @@
+(ns metabase.transforms-base.util-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.test :as mt]
+   [metabase.transforms-base.util :as transforms-base.u]))
+
+(set! *warn-on-reflection* true)
+
+(deftest throw-if-db-routing-enabled!-oss-test
+  (testing "on OSS (no :database-routing premium feature) the check is a no-op, even when a DatabaseRouter record exists"
+    (mt/with-premium-features #{}
+      (mt/with-temp [:model/DatabaseRouter _ {:database_id    (mt/id)
+                                              :user_attribute "db_name"}]
+        (is (nil? (transforms-base.u/throw-if-db-routing-enabled!
+                   {:name "OSS transform"}
+                   (mt/db)))))))
+  (testing "with :database-routing premium feature enabled, the check throws on a routing-enabled database"
+    (mt/with-premium-features #{:database-routing}
+      (mt/with-temp [:model/DatabaseRouter _ {:database_id    (mt/id)
+                                              :user_attribute "db_name"}]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #".*database routing turned on"
+             (transforms-base.u/throw-if-db-routing-enabled!
+              {:name "Routing transform"}
+              (mt/db))))))))

--- a/test/metabase/transforms_base/util_test.clj
+++ b/test/metabase/transforms_base/util_test.clj
@@ -8,13 +8,11 @@
 (set! *warn-on-reflection* true)
 
 (deftest throw-if-db-routing-enabled!-oss-test
-  (testing "on OSS (no :database-routing premium feature) the check is a no-op, even when a DatabaseRouter record exists"
+  (testing "on OSS (no :database-routing premium feature) the check is a no-op"
     (mt/with-premium-features #{}
-      (mt/with-temp [:model/DatabaseRouter _ {:database_id    (mt/id)
-                                              :user_attribute "db_name"}]
-        (is (nil? (transforms-base.u/throw-if-db-routing-enabled!
-                   {:name "OSS transform"}
-                   (mt/db)))))))
+      (is (nil? (transforms-base.u/throw-if-db-routing-enabled!
+                 {:name "OSS transform"}
+                 (mt/db))))))
   (when config/ee-available?
     (testing "with :database-routing premium feature enabled, the check throws on a routing-enabled database"
       (mt/with-premium-features #{:database-routing}


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #72764
Closes https://linear.app/metabase/issue/GDGT-2310/bug-transforms-crash-on-oss-edition-db-routing-enabled-tries-to-load