### PR TITLE
address roborev review: document staleness; tighten fast-path can-read check

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -3194,7 +3194,7 @@
            task
            tracing
            util}
-   :model-imports #{:model/Card :model/Collection :model/ModelIndex}}
+   :model-imports #{:model/Card :model/Collection}}
 
   enterprise/serialization
   {:team "Graphy"

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -713,26 +713,12 @@
   [row]
   (update row :metadata decode-pgobject))
 
-(defn- filter-can-read-indexed-entity
-  "Check permissions for indexed entities by resolving to their parent model / card"
-  [indexed-entity-docs]
-  (let [->model-index-id #(-> % :id search/indexed-entity-id->model-index-id)
-        model-index-ids (into #{} (map ->model-index-id indexed-entity-docs))
-        model-indexes (when (seq model-index-ids)
-                        (t2/select :model/ModelIndex :id [:in model-index-ids]))
-        index-id->card (when (seq model-indexes)
-                         (let [card-ids    (map :model_id model-indexes)
-                               cards       (t2/select :model/Card :id [:in card-ids])
-                               cards-by-id (u/index-by :id cards)]
-                           (into {}
-                                 (map (fn [model-index]
-                                        [(:id model-index) (get cards-by-id (:model_id model-index))])
-                                      model-indexes))))]
-    (filterv (fn [doc]
-               (when-let [model-index-id (-> doc ->model-index-id)]
-                 (when-let [parent-card (get index-id->card model-index-id)]
-                   (mi/can-read? parent-card))))
-             indexed-entity-docs)))
+;; Models whose `mi/can-read?` is a pure function of `:collection_id` (via
+;; `perms/can-read-audit-helper` → `perms-objects-set-for-parent-collection`).
+;; `indexed-entity` rows resolve to the parent Card, whose `collection_id` is denormalized
+;; onto the index row at ingest time via the search spec's Collection join.
+(def ^:private collection-id-only-search-models
+  #{"card" "metric" "dataset" "dashboard" "indexed-entity"})
 
 (defn- filter-read-permitted
   "Returns only those documents in `docs` whose corresponding t2 instances pass an mi/can-read? check for the bound api user."
@@ -742,37 +728,35 @@
               :distinct-collections (count (into #{} (map :collection_id) docs))})
   (let [timer (u/start-timer)
         doc->t2-model (fn [doc] (:model (search/spec (:model doc))))
-        {indexed-entities true regular-docs false} (group-by #(= "indexed-entity" (:model %)) docs)
-        ;; Card's `can-read?` only reads `:collection_id` (via `perms/can-read-audit-helper`), which
-        ;; is denormalized onto the index row. Synthesize minimal Toucan instances for Card-backed
-        ;; docs (search-models card/metric/dataset) to skip the `t2/select :model/Card` round-trip
-        ;; and its transform/after-select pipeline — the dominant cost of the permission filter.
-        {card-docs true non-card-docs false} (group-by #(= :model/Card (doc->t2-model %)) regular-docs)
-        card-stubs (mapv (fn [doc] (t2/instance :model/Card {:id (:id doc)
-                                                             :collection_id (:collection_id doc)}))
-                         card-docs)
-        select-timer (u/start-timer)
-        other-t2-instances (vec
-                            (for [[t2-model docs] (group-by doc->t2-model non-card-docs)
-                                  t2-instance (t2/select t2-model :id [:in (map :id docs)])]
-                              t2-instance))
-        select-ms (u/since-ms select-timer)
+        {fast-docs true slow-docs false} (group-by #(contains? collection-id-only-search-models (:model %)) docs)
+        ;; Fast path: the permission check depends only on `:collection_id`, which is already on the
+        ;; index row. Dedupe by collection_id so `can-read?` runs once per distinct collection instead
+        ;; of once per document. A stub `:model/Card` instance is sufficient to drive the dispatch
+        ;; and satisfies the fields `mi/can-read? :model/Card` actually reads.
+        coll-readable? (memoize
+                        (fn [coll-id]
+                          (mi/can-read? (t2/instance :model/Card {:collection_id coll-id}))))
         check-timer (u/start-timer)
-        permitted-entities (filter-can-read-indexed-entity indexed-entities)
-        doc->t2 (comp (u/index-by (juxt :id t2/model) (into card-stubs other-t2-instances))
-                      (juxt :id doc->t2-model))
-        result (into
-                (filterv (fn [doc] (some-> doc doc->t2 mi/can-read?)) regular-docs)
-                permitted-entities)
+        fast-filtered (filterv #(coll-readable? (:collection_id %)) fast-docs)
         check-ms (u/since-ms check-timer)
+        select-timer (u/start-timer)
+        slow-t2-instances (vec
+                           (for [[t2-model docs] (group-by doc->t2-model slow-docs)
+                                 t2-instance (t2/select t2-model :id [:in (map :id docs)])]
+                             t2-instance))
+        select-ms (u/since-ms select-timer)
+        doc->t2 (comp (u/index-by (juxt :id t2/model) slow-t2-instances)
+                      (juxt :id doc->t2-model))
+        slow-filtered (filterv (fn [doc] (some-> doc doc->t2 mi/can-read?)) slow-docs)
+        result (into fast-filtered slow-filtered)
         time-ms (u/since-ms timer)]
 
     (log/debug "Permission filtering" {:before-count (count docs)
                                        :after-count (count result)
-                                       :indexed-entities-count (count indexed-entities)
-                                       :regular-docs-count (count regular-docs)
-                                       :card-stubs-count (count card-stubs)
-                                       :non-card-fetched-count (count other-t2-instances)
+                                       :fast-count (count fast-docs)
+                                       :slow-count (count slow-docs)
+                                       :slow-fetched-count (count slow-t2-instances)
+                                       :distinct-fast-coll-ids (count (into #{} (map :collection_id) fast-docs))
                                        :select-ms select-ms
                                        :check-ms check-ms
                                        :time-ms time-ms})

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -737,24 +737,44 @@
 (defn- filter-read-permitted
   "Returns only those documents in `docs` whose corresponding t2 instances pass an mi/can-read? check for the bound api user."
   [docs]
+  (log/debug "filter-read-permitted input"
+             {:by-model (frequencies (map :model docs))
+              :distinct-collections (count (into #{} (map :collection_id) docs))})
   (let [timer (u/start-timer)
         doc->t2-model (fn [doc] (:model (search/spec (:model doc))))
         {indexed-entities true regular-docs false} (group-by #(= "indexed-entity" (:model %)) docs)
-        other-docs (for [[t2-model docs] (group-by doc->t2-model regular-docs)
-                         t2-instance (t2/select t2-model :id [:in (map :id docs)])]
-                     t2-instance)
+        ;; Card's `can-read?` only reads `:collection_id` (via `perms/can-read-audit-helper`), which
+        ;; is denormalized onto the index row. Synthesize minimal Toucan instances for Card-backed
+        ;; docs (search-models card/metric/dataset) to skip the `t2/select :model/Card` round-trip
+        ;; and its transform/after-select pipeline — the dominant cost of the permission filter.
+        {card-docs true non-card-docs false} (group-by #(= :model/Card (doc->t2-model %)) regular-docs)
+        card-stubs (mapv (fn [doc] (t2/instance :model/Card {:id (:id doc)
+                                                             :collection_id (:collection_id doc)}))
+                         card-docs)
+        select-timer (u/start-timer)
+        other-t2-instances (vec
+                            (for [[t2-model docs] (group-by doc->t2-model non-card-docs)
+                                  t2-instance (t2/select t2-model :id [:in (map :id docs)])]
+                              t2-instance))
+        select-ms (u/since-ms select-timer)
+        check-timer (u/start-timer)
         permitted-entities (filter-can-read-indexed-entity indexed-entities)
-        doc->t2 (comp (u/index-by (juxt :id t2/model) other-docs)
+        doc->t2 (comp (u/index-by (juxt :id t2/model) (into card-stubs other-t2-instances))
                       (juxt :id doc->t2-model))
         result (into
                 (filterv (fn [doc] (some-> doc doc->t2 mi/can-read?)) regular-docs)
                 permitted-entities)
+        check-ms (u/since-ms check-timer)
         time-ms (u/since-ms timer)]
 
     (log/debug "Permission filtering" {:before-count (count docs)
                                        :after-count (count result)
                                        :indexed-entities-count (count indexed-entities)
                                        :regular-docs-count (count regular-docs)
+                                       :card-stubs-count (count card-stubs)
+                                       :non-card-fetched-count (count other-t2-instances)
+                                       :select-ms select-ms
+                                       :check-ms check-ms
                                        :time-ms time-ms})
 
     (analytics/inc! :metabase-search/semantic-permission-filter-ms time-ms)

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -14,6 +14,7 @@
    [metabase-enterprise.semantic-search.settings :as semantic-settings]
    [metabase.analytics.core :as analytics]
    [metabase.models.interface :as mi]
+   [metabase.permissions.core :as perms]
    [metabase.search.config :as search.config]
    [metabase.search.core :as search]
    [metabase.tracing.core :as tracing]
@@ -722,13 +723,22 @@
   (let [timer (u/start-timer)
         doc->t2-model (fn [doc] (:model (search/spec (:model doc))))
         {fast-docs true slow-docs false} (group-by #(contains? collection-id-only-search-models (:model %)) docs)
-        ;; Fast path: the permission check depends only on `:collection_id`, which is already on the
-        ;; index row. Dedupe by collection_id so `can-read?` runs once per distinct collection instead
-        ;; of once per document. A stub `:model/Card` instance is sufficient to drive the dispatch
-        ;; and satisfies the fields `mi/can-read? :model/Card` actually reads.
+        ;; Fast path: for `collection-id-only-search-models` the read permission is a pure function
+        ;; of `:collection_id`, which is denormalized onto the index row at ingest time. We deliberately
+        ;; trust the indexed value rather than re-fetching the app DB row — that avoids an N-row
+        ;; `t2/select` on every semantic search and is the main win of this path. The trade-off is
+        ;; that between a move (or delete) and the next reindex, a user can see a search hit whose
+        ;; live `collection_id` they no longer have access to. The index is eventually consistent by
+        ;; design; and the per-row API fetch (loading the entity after clicking through) still
+        ;; enforces live permissions, so the exposure is bounded to search-result metadata.
+        ;;
+        ;; We call `perms/can-read-audit-helper` directly instead of going through
+        ;; `mi/can-read? :model/Card` — this makes the "only :collection_id matters" contract
+        ;; explicit (if Card's `can-read?` ever gains other checks, this path intentionally won't
+        ;; pick them up) and avoids multimethod dispatch + instance allocation per distinct id.
         coll-readable? (memoize
                         (fn [coll-id]
-                          (mi/can-read? (t2/instance :model/Card {:collection_id coll-id}))))
+                          (perms/can-read-audit-helper :model/Card {:collection_id coll-id})))
         check-timer (u/start-timer)
         fast-filtered (filterv #(coll-readable? (:collection_id %)) fast-docs)
         check-ms (u/since-ms check-timer)

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -585,7 +585,7 @@
    [:model_created_at :model_created_at]
    [:model_updated_at :model_updated_at]
    [:last_viewed_at :last_viewed_at]
-   [:metadata :metadata]])
+   [:legacy_input :legacy_input]])
 
 (defn- keyword-search-query [index search-context]
   (let [filters (search-filters search-context)
@@ -691,27 +691,23 @@
         {:keys [ctes query]} (flatten-ctes hybrid-query)
         all-ctes (conj ctes [:hybrid_results query])
         full-query {:with all-ctes
-                    :select [:id :model_id :model :content :verified :metadata :semantic_rank :keyword_rank]
+                    :select [:id :model_id :model :content :verified :legacy_input :semantic_rank :keyword_rank]
                     :from [[:hybrid_results :search_index]]
                     :limit (semantic-settings/semantic-search-results-limit)}]
     (scoring/with-scores search-context scorers full-query)))
 
 (defn- legacy-input-with-score
-  "Fetches the legacy_input field from a result's metadata and attaches a score based on the
-  embedding distance."
+  "Extracts the (already-decoded) `:legacy_input` map from `row` and attaches the total score
+  plus per-scorer breakdown."
   [weights scorers row]
-  (let [raw (get-in row [:metadata :legacy_input])
-        ;; legacy_input may be a pre-encoded JSON string (from ->document) stored as a string
-        ;; value inside the metadata JSONB blob; decode it back to a map if so.
-        legacy-input (cond-> raw (string? raw) (json/decode true))]
-    (assoc legacy-input
-           :score (:total_score row 1.0)
-           :all-scores (scoring/all-scores weights scorers row))))
+  (assoc (:legacy_input row)
+         :score (:total_score row 1.0)
+         :all-scores (scoring/all-scores weights scorers row)))
 
-(defn- decode-metadata
-  "Decode `row`s `:metadata`."
+(defn- decode-legacy-input
+  "Decode `row`s `:legacy_input` JSONB PGobject into a Clojure map."
   [row]
-  (update row :metadata decode-pgobject))
+  (update row :legacy_input decode-pgobject))
 
 ;; Models whose `mi/can-read?` is a pure function of `:collection_id` (via
 ;; `perms/can-read-audit-helper` → `perms-objects-set-for-parent-collection`).
@@ -823,7 +819,7 @@
             weights (search.config/weights search-context)
             scorers (scoring/semantic-scorers (:table-name index) search-context)
             query (scored-search-query index embedding search-context scorers)
-            xform (comp (map decode-metadata)
+            xform (comp (map decode-legacy-input)
                         (map (partial legacy-input-with-score weights (keys scorers))))
             reducible (reducible-search-query db query)
             raw-results (tracing/with-span :search "search.semantic.db-query"

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -710,35 +710,40 @@
   [row]
   (update row :legacy_input decode-pgobject))
 
-;; Models whose `mi/can-read?` is a pure function of `:collection_id` (via
-;; `perms/can-read-audit-helper` → `perms-objects-set-for-parent-collection`).
-;; `indexed-entity` rows resolve to the parent Card, whose `collection_id` is denormalized
-;; onto the index row at ingest time via the search spec's Collection join.
+;; Search-model strings whose read permission is determined by `:collection_id` alone. Derived
+;; from `perms/collection-id-only-read-models` (models registered via
+;; `perms/define-collection-id-only-read-perms!`) plus `"indexed-entity"`, whose index-row
+;; `:collection_id` is denormalized from the parent Card via the search spec's Collection join
+;; and whose read policy is therefore transitively the registered Card's.
+;; Computed lazily so the registry has time to populate at app init before first search.
 (def ^:private collection-id-only-search-models
-  #{"card" "metric" "dataset" "dashboard" "indexed-entity"})
+  (delay
+    (let [registered-t2-models (perms/collection-id-only-read-models)]
+      (into #{"indexed-entity"}
+            (comp (filter (fn [[_ spec]] (contains? registered-t2-models (:model spec))))
+                  (map key))
+            (search/specifications)))))
 
 (defn- filter-read-permitted
   "Returns only those documents in `docs` whose corresponding t2 instances pass an mi/can-read? check for the bound api user."
   [docs]
   (let [timer (u/start-timer)
         doc->t2-model (fn [doc] (:model (search/spec (:model doc))))
-        {fast-docs true slow-docs false} (group-by #(contains? collection-id-only-search-models (:model %)) docs)
-        ;; Fast path: for `collection-id-only-search-models` the read permission is a pure function
-        ;; of `:collection_id`, which is denormalized onto the index row at ingest time. We deliberately
-        ;; trust the indexed value rather than re-fetching the app DB row — that avoids an N-row
-        ;; `t2/select` on every semantic search and is the main win of this path. The trade-off is
-        ;; that between a move (or delete) and the next reindex, a user can see a search hit whose
-        ;; live `collection_id` they no longer have access to. The index is eventually consistent by
-        ;; design; and the per-row API fetch (loading the entity after clicking through) still
-        ;; enforces live permissions, so the exposure is bounded to search-result metadata.
+        fast-set      @collection-id-only-search-models
+        {fast-docs true slow-docs false} (group-by #(contains? fast-set (:model %)) docs)
+        ;; Fast path: for models registered via `perms/define-collection-id-only-read-perms!`,
+        ;; `mi/can-read?` is definitionally `(perms/can-read-via-parent-collection?
+        ;; (:collection_id instance))`, so we can skip the t2/select and check permissions
+        ;; straight from the denormalized `:collection_id` on the index row. Calling the shared
+        ;; helper directly means the fast path runs literally the same code as the slow path
+        ;; for these models — no drift possible on the permission logic. Memoizing dedupes the
+        ;; perm check across docs that share a collection.
         ;;
-        ;; We call `perms/can-read-audit-helper` directly instead of going through
-        ;; `mi/can-read? :model/Card` — this makes the "only :collection_id matters" contract
-        ;; explicit (if Card's `can-read?` ever gains other checks, this path intentionally won't
-        ;; pick them up) and avoids multimethod dispatch + instance allocation per distinct id.
-        coll-readable? (memoize
-                        (fn [coll-id]
-                          (perms/can-read-audit-helper :model/Card {:collection_id coll-id})))
+        ;; Trade-off: the indexed `:collection_id` is eventually-consistent. Between a move or
+        ;; delete and the next reindex, a user may see a search hit whose live `collection_id`
+        ;; they no longer have access to. The per-row entity fetch on click-through still
+        ;; enforces live permissions, bounding exposure to search-result metadata.
+        coll-readable? (memoize perms/can-read-via-parent-collection?)
         check-timer (u/start-timer)
         fast-filtered (filterv #(coll-readable? (:collection_id %)) fast-docs)
         check-ms (u/since-ms check-timer)

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/index.clj
@@ -719,9 +719,6 @@
 (defn- filter-read-permitted
   "Returns only those documents in `docs` whose corresponding t2 instances pass an mi/can-read? check for the bound api user."
   [docs]
-  (log/debug "filter-read-permitted input"
-             {:by-model (frequencies (map :model docs))
-              :distinct-collections (count (into #{} (map :collection_id) docs))})
   (let [timer (u/start-timer)
         doc->t2-model (fn [doc] (:model (search/spec (:model doc))))
         {fast-docs true slow-docs false} (group-by #(contains? collection-id-only-search-models (:model %)) docs)

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -466,74 +466,50 @@
                  (#'semantic.index/batch-resolve-personal-owner-ids
                   [user1-personal-coll-id user2-sub-coll-id shared-coll-id nil]))))))))
 
-(deftest filter-can-read-indexed-entity-test
+(deftest filter-read-permitted-indexed-entity-test
   (mt/with-premium-features #{:semantic-search}
-    (testing "filter-can-read-indexed-entity function"
-      (mt/with-temp [:model/Collection {coll-id :id} {}
-                     :model/Card model-1 (assoc (mt/card-with-source-metadata-for-query
-                                                 (mt/mbql-query products {:fields [$id $title]
-                                                                          :limit 1}))
-                                                :type "model"
-                                                :name "Readable Model"
-                                                :database_id (mt/id)
-                                                :collection_id coll-id)
-                     :model/Card model-2 (assoc (mt/card-with-source-metadata-for-query
-                                                 (mt/mbql-query products {:fields [$id $title]
-                                                                          :limit 1}))
-                                                :type "model"
-                                                :name "Unreadable Model"
-                                                :database_id (mt/id)
-                                                :collection_id coll-id)
-                     :model/ModelIndex model-index-1 {:model_id (:id model-1)
-                                                      :pk_ref (mt/$ids :products $id)
-                                                      :value_ref (mt/$ids :products $title)
-                                                      :schedule "0 0 0 * * *"
-                                                      :state "initial"
-                                                      :creator_id (mt/user->id :rasta)}
-                     :model/ModelIndex model-index-2 {:model_id (:id model-2)
-                                                      :pk_ref (mt/$ids :products $id)
-                                                      :value_ref (mt/$ids :products $title)
-                                                      :schedule "0 0 0 * * *"
-                                                      :state "initial"
-                                                      :creator_id (mt/user->id :rasta)}]
-        (let [indexed-entity-docs [{:id (str (:id model-index-1) ":123")
+    (testing "filter-read-permitted routes indexed-entity docs through the collection_id-only fast path"
+      (mt/with-temp [:model/Collection {readable-coll-id :id} {}
+                     :model/Collection {unreadable-coll-id :id} {}]
+        (let [indexed-entity-docs [{:id "1:123"
                                     :model "indexed-entity"
-                                    :content "Test Entity 1"}
-                                   {:id (str (:id model-index-2) ":456")
+                                    :collection_id readable-coll-id}
+                                   {:id "2:456"
                                     :model "indexed-entity"
-                                    :content "Test Entity 2"}
-                                   {:id "invalid:789"
+                                    :collection_id unreadable-coll-id}
+                                   {:id "3:789"
                                     :model "indexed-entity"
-                                    :content "Invalid Entity"}]]
+                                    :collection_id nil}]]
 
-          (testing "returns all entities when user can read all parent cards"
+          (testing "keeps all entities when user has root permissions"
             (binding [api/*current-user-permissions-set* (atom #{"/"})]
-              (let [result (#'semantic.index/filter-can-read-indexed-entity indexed-entity-docs)]
-                (is (= 2 (count result)))
-                (is (= #{(str (:id model-index-1) ":123") (str (:id model-index-2) ":456")}
-                       (set (map :id result)))))))
+              (let [result (#'semantic.index/filter-read-permitted indexed-entity-docs)]
+                (is (= 3 (count result))))))
 
-          (testing "returns no entities when user cannot read any parent cards"
+          (testing "drops all entities when user has no permissions"
             (binding [api/*current-user-permissions-set* (atom #{})]
-              (let [result (#'semantic.index/filter-can-read-indexed-entity indexed-entity-docs)]
+              (let [result (#'semantic.index/filter-read-permitted indexed-entity-docs)]
                 (is (= 0 (count result))))))
 
-          (testing "returns subset when user can read some parent cards"
-            (with-redefs [mi/can-read? (fn [card] (= (:id card) (:id model-1)))]
-              (let [result (#'semantic.index/filter-can-read-indexed-entity indexed-entity-docs)]
+          (testing "keeps only entities in readable collections"
+            (binding [api/*current-user-permissions-set* (atom #{(format "/collection/%d/read/" readable-coll-id)})]
+              (let [result (#'semantic.index/filter-read-permitted indexed-entity-docs)]
                 (is (= 1 (count result)))
-                (is (= (str (:id model-index-1) ":123") (:id (first result)))))))
+                (is (= "1:123" (:id (first result)))))))
+
+          (testing "memoizes permission check per collection_id across docs"
+            (let [calls (atom 0)
+                  real-can-read? mi/can-read?]
+              (with-redefs [mi/can-read? (fn [& args]
+                                           (swap! calls inc)
+                                           (apply real-can-read? args))]
+                (binding [api/*current-user-permissions-set* (atom #{"/"})]
+                  (#'semantic.index/filter-read-permitted
+                   (repeat 50 {:id "1:1" :model "indexed-entity" :collection_id readable-coll-id}))
+                  (is (= 1 @calls) "expected one can-read? call for the single distinct collection_id")))))
 
           (testing "handles empty input"
-            (is (= [] (#'semantic.index/filter-can-read-indexed-entity []))))
-
-          (testing "handles invalid entity IDs"
-            (let [invalid-only-docs [{:id "invalid:789" :model "indexed-entity" :content "Invalid"}]]
-              (is (= [] (#'semantic.index/filter-can-read-indexed-entity invalid-only-docs)))))
-
-          (testing "handles non-existent model indexes"
-            (let [non-existent-docs [{:id "99999:123" :model "indexed-entity" :content "Non-existent"}]]
-              (is (= [] (#'semantic.index/filter-can-read-indexed-entity non-existent-docs))))))))))
+            (is (= [] (#'semantic.index/filter-read-permitted [])))))))))
 
 (deftest to-boolean-test
   (testing "to-boolean function correctly converts various input types to booleans"

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -9,11 +9,9 @@
    [metabase.analytics.core :as analytics]
    [metabase.api.common :as api]
    [metabase.collections.models.collection :as collection]
-   [metabase.models.interface :as mi]
    [metabase.permissions.core :as perms]
    [metabase.test :as mt]
-   [metabase.util :as u]
-   [toucan2.core :as t2]))
+   [metabase.util :as u]))
 
 (use-fixtures :once #'semantic.tu/once-fixture)
 
@@ -504,73 +502,28 @@
 
         (testing "memoizes permission check per collection_id across docs"
           (let [calls (atom 0)
-                real-helper perms/can-read-audit-helper]
-            (with-redefs [perms/can-read-audit-helper (fn [& args]
-                                                        (swap! calls inc)
-                                                        (apply real-helper args))]
+                real-helper perms/can-read-via-parent-collection?]
+            (with-redefs [perms/can-read-via-parent-collection? (fn [& args]
+                                                                  (swap! calls inc)
+                                                                  (apply real-helper args))]
               (binding [api/*current-user-permissions-set* (atom #{"/"})]
                 (#'semantic.index/filter-read-permitted
                  (repeat 50 {:id "1:1" :model "indexed-entity" :collection_id readable-coll-id}))
-                (is (= 1 @calls) "expected one can-read-audit-helper call for the single distinct collection_id")))))
+                (is (= 1 @calls) "expected one can-read-via-parent-collection? call for the single distinct collection_id")))))
 
         (testing "handles empty input"
           (is (= [] (#'semantic.index/filter-read-permitted []))))))))
 
-;; The fast path in `filter-read-permitted` assumes every model listed in
-;; `collection-id-only-search-models` has a `mi/can-read?` whose result is fully determined by
-;; `:collection_id` + the current user's permissions set. This contract test catches drift in
-;; two directions:
-;;   1. A model is added to the set that doesn't actually satisfy the contract.
-;;   2. An existing model's `can-read?` grows a check on a field other than `:collection_id`
-;;      (e.g., `:archived`, `:type`, `:database_id`), silently making the fast path incorrect.
-;; If the set gains a new entry, add a spec here — the `keys` check below will fail otherwise.
-;; We vary the "should-be-irrelevant" fields across permutations so any new check in `can-read?`
-;; against such a field will flip at least one permutation away from the helper and fail the test.
-(def ^:private collection-id-only-model-test-specs
-  "Maps each entry in `collection-id-only-search-models` to the t2 model used for dispatch.
-  `indexed-entity` resolves to the parent Card at ingest time, so Card covers its contract."
-  {"card"           :model/Card
-   "metric"         :model/Card
-   "dataset"        :model/Card
-   "dashboard"      :model/Dashboard
-   "indexed-entity" :model/Card})
-
-(deftest collection-id-only-search-models-contract-test
-  (testing "every entry in `collection-id-only-search-models` has a test spec"
-    (is (= @#'semantic.index/collection-id-only-search-models
-           (set (keys collection-id-only-model-test-specs)))
-        "If you added a model to `collection-id-only-search-models`, add a corresponding entry to `collection-id-only-model-test-specs`."))
-
-  (testing "mi/can-read? is a pure function of :collection_id for each listed model"
-    ;; Synthetic coll-ids chosen to align with the perm-set strings below. No DB involvement —
-    ;; the permission check only reads the instance map and the bound perm set.
-    (let [perm-scenarios [["root perms"                42  #{"/"}]
-                          ["no perms"                  42  #{}]
-                          ["read on matching coll"     42  #{"/collection/42/read/"}]
-                          ["read on other coll only"   42  #{"/collection/99/read/"}]
-                          ["nil collection with root"  nil #{"/"}]
-                          ["nil collection no perms"   nil #{}]]
-          ;; Extra fields on the synthetic instance. If `can-read?` stays collection_id-only,
-          ;; none of these should affect the result. A future `can-read?` that gates on any of
-          ;; them will diverge from the helper for at least one permutation.
-          extra-fields   [{}
-                          {:archived true}
-                          {:archived false}
-                          {:type :question}
-                          {:type :model}
-                          {:type :metric}
-                          {:database_id 1}
-                          {:dataset_query {}}]]
-      (doseq [[search-model t2-model] collection-id-only-model-test-specs
-              [label coll-id perms]   perm-scenarios
-              extras                  extra-fields]
-        (let [instance (t2/instance t2-model (assoc extras :collection_id coll-id))]
-          (binding [api/*current-user-permissions-set* (atom perms)]
-            (let [slow-path (boolean (mi/can-read? instance))
-                  fast-path (boolean (perms/can-read-audit-helper :model/Card {:collection_id coll-id}))]
-              (is (= slow-path fast-path)
-                  (format "%s %s extras=%s: fast path=%s mi/can-read?=%s. If these disagree, `can-read?` likely depends on a field other than `:collection_id`, so removing this model from `collection-id-only-search-models` is required."
-                          search-model label extras fast-path slow-path)))))))))
+(deftest collection-id-only-search-models-derived-correctly-test
+  (testing "derived set includes every search-model whose t2 model is registered as collection-id-only, plus indexed-entity"
+    ;; Sanity smoke test: derivation machinery is working. If this fails, the registry
+    ;; probably isn't populating (namespace load order) or the search spec for one of these
+    ;; models lost its t2 model keyword.
+    (is (= #{"card" "metric" "dataset" "dashboard" "indexed-entity"}
+           @@#'semantic.index/collection-id-only-search-models)
+        "The fast-path set is derived from `perms/collection-id-only-read-models` plus
+         indexed-entity. If you added `perms/define-collection-id-only-read-perms!` to a new
+         model (or removed it from an existing one), update this expected set.")))
 
 (deftest to-boolean-test
   (testing "to-boolean function correctly converts various input types to booleans"

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -9,9 +9,11 @@
    [metabase.analytics.core :as analytics]
    [metabase.api.common :as api]
    [metabase.collections.models.collection :as collection]
+   [metabase.models.interface :as mi]
    [metabase.permissions.core :as perms]
    [metabase.test :as mt]
-   [metabase.util :as u]))
+   [metabase.util :as u]
+   [toucan2.core :as t2]))
 
 (use-fixtures :once #'semantic.tu/once-fixture)
 
@@ -513,6 +515,62 @@
 
         (testing "handles empty input"
           (is (= [] (#'semantic.index/filter-read-permitted []))))))))
+
+;; The fast path in `filter-read-permitted` assumes every model listed in
+;; `collection-id-only-search-models` has a `mi/can-read?` whose result is fully determined by
+;; `:collection_id` + the current user's permissions set. This contract test catches drift in
+;; two directions:
+;;   1. A model is added to the set that doesn't actually satisfy the contract.
+;;   2. An existing model's `can-read?` grows a check on a field other than `:collection_id`
+;;      (e.g., `:archived`, `:type`, `:database_id`), silently making the fast path incorrect.
+;; If the set gains a new entry, add a spec here — the `keys` check below will fail otherwise.
+;; We vary the "should-be-irrelevant" fields across permutations so any new check in `can-read?`
+;; against such a field will flip at least one permutation away from the helper and fail the test.
+(def ^:private collection-id-only-model-test-specs
+  "Maps each entry in `collection-id-only-search-models` to the t2 model used for dispatch.
+  `indexed-entity` resolves to the parent Card at ingest time, so Card covers its contract."
+  {"card"           :model/Card
+   "metric"         :model/Card
+   "dataset"        :model/Card
+   "dashboard"      :model/Dashboard
+   "indexed-entity" :model/Card})
+
+(deftest collection-id-only-search-models-contract-test
+  (testing "every entry in `collection-id-only-search-models` has a test spec"
+    (is (= @#'semantic.index/collection-id-only-search-models
+           (set (keys collection-id-only-model-test-specs)))
+        "If you added a model to `collection-id-only-search-models`, add a corresponding entry to `collection-id-only-model-test-specs`."))
+
+  (testing "mi/can-read? is a pure function of :collection_id for each listed model"
+    ;; Synthetic coll-ids chosen to align with the perm-set strings below. No DB involvement —
+    ;; the permission check only reads the instance map and the bound perm set.
+    (let [perm-scenarios [["root perms"                42  #{"/"}]
+                          ["no perms"                  42  #{}]
+                          ["read on matching coll"     42  #{"/collection/42/read/"}]
+                          ["read on other coll only"   42  #{"/collection/99/read/"}]
+                          ["nil collection with root"  nil #{"/"}]
+                          ["nil collection no perms"   nil #{}]]
+          ;; Extra fields on the synthetic instance. If `can-read?` stays collection_id-only,
+          ;; none of these should affect the result. A future `can-read?` that gates on any of
+          ;; them will diverge from the helper for at least one permutation.
+          extra-fields   [{}
+                          {:archived true}
+                          {:archived false}
+                          {:type :question}
+                          {:type :model}
+                          {:type :metric}
+                          {:database_id 1}
+                          {:dataset_query {}}]]
+      (doseq [[search-model t2-model] collection-id-only-model-test-specs
+              [label coll-id perms]   perm-scenarios
+              extras                  extra-fields]
+        (let [instance (t2/instance t2-model (assoc extras :collection_id coll-id))]
+          (binding [api/*current-user-permissions-set* (atom perms)]
+            (let [slow-path (boolean (mi/can-read? instance))
+                  fast-path (boolean (perms/can-read-audit-helper :model/Card {:collection_id coll-id}))]
+              (is (= slow-path fast-path)
+                  (format "%s %s extras=%s: fast path=%s mi/can-read?=%s. If these disagree, `can-read?` likely depends on a field other than `:collection_id`, so removing this model from `collection-id-only-search-models` is required."
+                          search-model label extras fast-path slow-path)))))))))
 
 (deftest to-boolean-test
   (testing "to-boolean function correctly converts various input types to booleans"

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/index_test.clj
@@ -9,7 +9,7 @@
    [metabase.analytics.core :as analytics]
    [metabase.api.common :as api]
    [metabase.collections.models.collection :as collection]
-   [metabase.models.interface :as mi]
+   [metabase.permissions.core :as perms]
    [metabase.test :as mt]
    [metabase.util :as u]))
 
@@ -466,50 +466,53 @@
                  (#'semantic.index/batch-resolve-personal-owner-ids
                   [user1-personal-coll-id user2-sub-coll-id shared-coll-id nil]))))))))
 
-(deftest filter-read-permitted-indexed-entity-test
+(deftest filter-read-permitted-fast-path-test
   (mt/with-premium-features #{:semantic-search}
-    (testing "filter-read-permitted routes indexed-entity docs through the collection_id-only fast path"
+    (testing "filter-read-permitted routes collection-id-only models through the fast path"
       (mt/with-temp [:model/Collection {readable-coll-id :id} {}
                      :model/Collection {unreadable-coll-id :id} {}]
-        (let [indexed-entity-docs [{:id "1:123"
-                                    :model "indexed-entity"
-                                    :collection_id readable-coll-id}
-                                   {:id "2:456"
-                                    :model "indexed-entity"
-                                    :collection_id unreadable-coll-id}
-                                   {:id "3:789"
-                                    :model "indexed-entity"
-                                    :collection_id nil}]]
+        (testing "indexed-entity docs are filtered by denormalized :collection_id"
+          (let [docs [{:id "1:123" :model "indexed-entity" :collection_id readable-coll-id}
+                      {:id "2:456" :model "indexed-entity" :collection_id unreadable-coll-id}
+                      {:id "3:789" :model "indexed-entity" :collection_id nil}]]
+            (testing "keeps all entities when user has root permissions"
+              (binding [api/*current-user-permissions-set* (atom #{"/"})]
+                (is (= 3 (count (#'semantic.index/filter-read-permitted docs))))))
 
-          (testing "keeps all entities when user has root permissions"
-            (binding [api/*current-user-permissions-set* (atom #{"/"})]
-              (let [result (#'semantic.index/filter-read-permitted indexed-entity-docs)]
-                (is (= 3 (count result))))))
+            (testing "drops all entities when user has no permissions"
+              (binding [api/*current-user-permissions-set* (atom #{})]
+                (is (= 0 (count (#'semantic.index/filter-read-permitted docs))))))
 
-          (testing "drops all entities when user has no permissions"
-            (binding [api/*current-user-permissions-set* (atom #{})]
-              (let [result (#'semantic.index/filter-read-permitted indexed-entity-docs)]
-                (is (= 0 (count result))))))
+            (testing "keeps only entities in readable collections"
+              (binding [api/*current-user-permissions-set* (atom #{(format "/collection/%d/read/" readable-coll-id)})]
+                (let [result (#'semantic.index/filter-read-permitted docs)]
+                  (is (= 1 (count result)))
+                  (is (= "1:123" (:id (first result)))))))))
 
-          (testing "keeps only entities in readable collections"
-            (binding [api/*current-user-permissions-set* (atom #{(format "/collection/%d/read/" readable-coll-id)})]
-              (let [result (#'semantic.index/filter-read-permitted indexed-entity-docs)]
-                (is (= 1 (count result)))
-                (is (= "1:123" (:id (first result)))))))
+        (testing "card/metric/dataset/dashboard docs use the same fast path"
+          (doseq [model ["card" "metric" "dataset" "dashboard"]]
+            (testing (str "model=" model)
+              (let [docs [{:id 1 :model model :collection_id readable-coll-id}
+                          {:id 2 :model model :collection_id unreadable-coll-id}
+                          {:id 3 :model model :collection_id nil}]]
+                (binding [api/*current-user-permissions-set* (atom #{(format "/collection/%d/read/" readable-coll-id)})]
+                  (let [result (#'semantic.index/filter-read-permitted docs)]
+                    (is (= [1] (map :id result))
+                        "only the doc whose denormalized collection_id is readable survives")))))))
 
-          (testing "memoizes permission check per collection_id across docs"
-            (let [calls (atom 0)
-                  real-can-read? mi/can-read?]
-              (with-redefs [mi/can-read? (fn [& args]
-                                           (swap! calls inc)
-                                           (apply real-can-read? args))]
-                (binding [api/*current-user-permissions-set* (atom #{"/"})]
-                  (#'semantic.index/filter-read-permitted
-                   (repeat 50 {:id "1:1" :model "indexed-entity" :collection_id readable-coll-id}))
-                  (is (= 1 @calls) "expected one can-read? call for the single distinct collection_id")))))
+        (testing "memoizes permission check per collection_id across docs"
+          (let [calls (atom 0)
+                real-helper perms/can-read-audit-helper]
+            (with-redefs [perms/can-read-audit-helper (fn [& args]
+                                                        (swap! calls inc)
+                                                        (apply real-helper args))]
+              (binding [api/*current-user-permissions-set* (atom #{"/"})]
+                (#'semantic.index/filter-read-permitted
+                 (repeat 50 {:id "1:1" :model "indexed-entity" :collection_id readable-coll-id}))
+                (is (= 1 @calls) "expected one can-read-audit-helper call for the single distinct collection_id")))))
 
-          (testing "handles empty input"
-            (is (= [] (#'semantic.index/filter-read-permitted [])))))))))
+        (testing "handles empty input"
+          (is (= [] (#'semantic.index/filter-read-permitted []))))))))
 
 (deftest to-boolean-test
   (testing "to-boolean function correctly converts various input types to booleans"

--- a/src/metabase/dashboards/models/dashboard.clj
+++ b/src/metabase/dashboards/models/dashboard.clj
@@ -59,11 +59,7 @@
   ([_ pk]
    (mi/can-write? (t2/select-one :model/Dashboard :id pk))))
 
-(defmethod mi/can-read? :model/Dashboard
-  ([instance]
-   (perms/can-read-audit-helper :model/Dashboard instance))
-  ([_ pk]
-   (mi/can-read? (t2/select-one :model/Dashboard :id pk))))
+(perms/define-collection-id-only-read-perms! :model/Dashboard)
 
 (defmethod mi/non-timestamped-fields :model/Dashboard [_]
   #{:last_viewed_at})

--- a/src/metabase/permissions/core.clj
+++ b/src/metabase/permissions/core.clj
@@ -79,12 +79,17 @@
  [metabase.permissions.models.permissions
   namespace-clause
   can-read-audit-helper
+  can-read-via-parent-collection?
+  collection-id-only-read-method
+  collection-id-only-read-models
   current-user-has-application-permissions?
+  define-collection-id-only-read-perms!
   grant-application-permissions!
   grant-collection-read-permissions!
   grant-collection-readwrite-permissions!
   grant-permissions!
   perms-objects-set-for-parent-collection
+  register-collection-id-only-read-method!
   revoke-application-permissions!
   revoke-collection-permissions!
   set-has-application-permission-of-type?

--- a/src/metabase/permissions/models/permissions.clj
+++ b/src/metabase/permissions/models/permissions.clj
@@ -420,19 +420,77 @@
    (when (and include-tenant-namespaces? (nil? namespace-val) (setting/get :use-tenants))
      [:= namespace-keyword "tenant-specific"])])
 
+(defn can-read-via-parent-collection?
+  "Read permission for any row whose read policy is a pure function of `:collection_id` plus
+  the current user's permissions set. Both [[can-read-audit-helper]] (the standard
+  Card/Dashboard/etc. path) and semantic search's `filter-read-permitted` fast path go through
+  this function, so they cannot drift: the signature is deliberately `[coll-id]` (not an
+  instance), making it structurally impossible for the logic to grow a dependency on other
+  instance fields."
+  [coll-id]
+  (and (or (premium-features/enable-audit-app?)
+           (not (and (some? coll-id) (audit/is-collection-id-audit? coll-id))))
+       (mi/current-user-has-full-permissions?
+        #{(permissions.path/collection-read-path
+           (or coll-id
+               {:metabase.collections.models.collection.root/is-root? true
+                :namespace                                            nil}))})))
+
 ;;; TODO -- this is a predicate function that returns truthy or falsey, it should end in a `?` -- Cam
 (mu/defn can-read-audit-helper
   "Audit instances should only be readable if audit app is enabled."
   [model    :- :keyword
    instance :- :map]
-  (if (and (not (premium-features/enable-audit-app?))
-           (case model
-             :model/Collection (audit/is-collection-id-audit? (:id instance))
-             (audit/is-parent-collection-audit? instance)))
-    false
-    (case model
-      :model/Collection (mi/current-user-has-full-permissions? :read instance)
-      (mi/current-user-has-full-permissions? (perms-objects-set-for-parent-collection instance :read)))))
+  (case model
+    :model/Collection
+    (if (and (not (premium-features/enable-audit-app?))
+             (audit/is-collection-id-audit? (:id instance)))
+      false
+      (mi/current-user-has-full-permissions? :read instance))
+    ;; default: models whose read perms depend only on `:collection_id`.
+    (can-read-via-parent-collection? (:collection_id instance))))
+
+;;; ---- Collection-id-only read registration ----
+
+(defonce ^:private collection-id-only-read-method-registry
+  ;; t2-model-kw → the fn installed as `mi/can-read?` by
+  ;; `define-collection-id-only-read-perms!`. The identity-check test uses this to detect any
+  ;; later `defmethod mi/can-read?` that would silently override the registered semantics.
+  (atom {}))
+
+(defn collection-id-only-read-models
+  "Set of t2 model keywords whose `mi/can-read?` was installed via
+  [[define-collection-id-only-read-perms!]]. Downstream consumers (e.g., semantic search's
+  fast-path filter) derive their own sets from this so the two can't drift."
+  []
+  (set (keys @collection-id-only-read-method-registry)))
+
+(defn collection-id-only-read-method
+  "The exact `mi/can-read?` fn installed by [[define-collection-id-only-read-perms!]] for
+  `t2-model`. Exposed so identity-check tests can detect later overrides. Returns nil for
+  unregistered models."
+  [t2-model]
+  (get @collection-id-only-read-method-registry t2-model))
+
+(defn register-collection-id-only-read-method!
+  "Implementation detail of [[define-collection-id-only-read-perms!]]. Do not call directly."
+  [t2-model method]
+  (swap! collection-id-only-read-method-registry assoc t2-model method))
+
+(defmacro define-collection-id-only-read-perms!
+  "Install `mi/can-read?` for `t2-model` as a pure delegate to
+  [[can-read-via-parent-collection?]], and register the model so downstream code (notably
+  semantic search's permission-filter fast path) can discover it. Use this in a model
+  namespace in place of a handwritten `(defmethod mi/can-read? t2-model ...)` whose body is
+  `(can-read-audit-helper t2-model instance)`. If the model ever needs richer read perms,
+  remove the macro invocation and write a plain `defmethod` — the identity-check test in
+  `metabase.permissions.models.permissions-test` will otherwise flag a silent override."
+  [t2-model]
+  `(do
+     (defmethod mi/can-read? ~t2-model
+       ([instance#] (can-read-via-parent-collection? (:collection_id instance#)))
+       ([_# pk#]    (mi/can-read? (t2/select-one ~t2-model :id pk#))))
+     (register-collection-id-only-read-method! ~t2-model (get-method mi/can-read? ~t2-model))))
 
 ; Audit permissions helper fns end
 

--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -144,11 +144,7 @@
   ([_ pk]
    (mi/can-write? (t2/select-one :model/Card :id pk))))
 
-(defmethod mi/can-read? :model/Card
-  ([instance]
-   (perms/can-read-audit-helper :model/Card instance))
-  ([_ pk]
-   (mi/can-read? (t2/select-one :model/Card :id pk))))
+(perms/define-collection-id-only-read-perms! :model/Card)
 
 (defn model?
   "Returns true if `card` is a model."

--- a/src/metabase/search/api.clj
+++ b/src/metabase/search/api.clj
@@ -1,6 +1,5 @@
 (ns metabase.search.api
   (:require
-   [clj-async-profiler.core :as prof]
    [clojure.string :as str]
    [java-time.api :as t]
    [metabase.analytics.core :as analytics]
@@ -229,38 +228,38 @@
        [:has_temporal_dim                    {:optional true} [:maybe :boolean]]]]
   (api/check-valid-page-params (request/limit) (request/offset))
   (try
-    (prof/profile (u/prog1 (search/search
-                            (search/search-context
-                             {:archived                            archived
-                              :collection                          collection
-                              :context                             context
-                              :created-at                          created-at
-                              :created-by                          (set created-by)
-                              :current-user-id                     api/*current-user-id*
-                              :is-impersonated-user?               (perms/impersonated-user?)
-                              :is-sandboxed-user?                  (perms/sandboxed-user?)
-                              :is-superuser?                       api/*is-superuser?*
-                              :current-user-perms                  @api/*current-user-permissions-set*
-                              :filter-items-in-personal-collection filter-items-in-personal-collection
-                              :last-edited-at                      last-edited-at
-                              :last-edited-by                      (set last-edited-by)
-                              :limit                               (request/limit)
-                              :model-ancestors?                    model-ancestors
-                              :models                              (not-empty (set models))
-                              :offset                              (request/offset)
-                              :search-engine                       search-engine
-                              :search-native-query                 search-native-query
-                              :search-string                       (some-> q str/trim not-empty)
-                              :table-db-id                         table-db-id
-                              :verified                            verified
-                              :ids                                 (set ids)
-                              :calculate-available-models?         calculate-available-models
-                              :include-dashboard-questions?        include-dashboard-questions
-                              :include-metadata?                   include-metadata
-                              :non-temporal-dim-ids                (process-non-temporal-dim-ids non-temporal-dim-ids)
-                              :has-temporal-dim                    has-temporal-dim
-                              :display-type                        (set display-type)}))
-                    (analytics/inc! :metabase-search/response-ok)))
+    (u/prog1 (search/search
+              (search/search-context
+               {:archived                            archived
+                :collection                          collection
+                :context                             context
+                :created-at                          created-at
+                :created-by                          (set created-by)
+                :current-user-id                     api/*current-user-id*
+                :is-impersonated-user?               (perms/impersonated-user?)
+                :is-sandboxed-user?                  (perms/sandboxed-user?)
+                :is-superuser?                       api/*is-superuser?*
+                :current-user-perms                  @api/*current-user-permissions-set*
+                :filter-items-in-personal-collection filter-items-in-personal-collection
+                :last-edited-at                      last-edited-at
+                :last-edited-by                      (set last-edited-by)
+                :limit                               (request/limit)
+                :model-ancestors?                    model-ancestors
+                :models                              (not-empty (set models))
+                :offset                              (request/offset)
+                :search-engine                       search-engine
+                :search-native-query                 search-native-query
+                :search-string                       (some-> q str/trim not-empty)
+                :table-db-id                         table-db-id
+                :verified                            verified
+                :ids                                 (set ids)
+                :calculate-available-models?         calculate-available-models
+                :include-dashboard-questions?        include-dashboard-questions
+                :include-metadata?                   include-metadata
+                :non-temporal-dim-ids                (process-non-temporal-dim-ids non-temporal-dim-ids)
+                :has-temporal-dim                    has-temporal-dim
+                :display-type                        (set display-type)}))
+      (analytics/inc! :metabase-search/response-ok))
     (catch Exception e
       (let [status-code (:status-code (ex-data e))]
         (when (or (not status-code) (= 5 (quot status-code 100)))

--- a/src/metabase/search/api.clj
+++ b/src/metabase/search/api.clj
@@ -1,5 +1,6 @@
 (ns metabase.search.api
   (:require
+   [clj-async-profiler.core :as prof]
    [clojure.string :as str]
    [java-time.api :as t]
    [metabase.analytics.core :as analytics]
@@ -228,38 +229,38 @@
        [:has_temporal_dim                    {:optional true} [:maybe :boolean]]]]
   (api/check-valid-page-params (request/limit) (request/offset))
   (try
-    (u/prog1 (search/search
-              (search/search-context
-               {:archived                            archived
-                :collection                          collection
-                :context                             context
-                :created-at                          created-at
-                :created-by                          (set created-by)
-                :current-user-id                     api/*current-user-id*
-                :is-impersonated-user?               (perms/impersonated-user?)
-                :is-sandboxed-user?                  (perms/sandboxed-user?)
-                :is-superuser?                       api/*is-superuser?*
-                :current-user-perms                  @api/*current-user-permissions-set*
-                :filter-items-in-personal-collection filter-items-in-personal-collection
-                :last-edited-at                      last-edited-at
-                :last-edited-by                      (set last-edited-by)
-                :limit                               (request/limit)
-                :model-ancestors?                    model-ancestors
-                :models                              (not-empty (set models))
-                :offset                              (request/offset)
-                :search-engine                       search-engine
-                :search-native-query                 search-native-query
-                :search-string                       (some-> q str/trim not-empty)
-                :table-db-id                         table-db-id
-                :verified                            verified
-                :ids                                 (set ids)
-                :calculate-available-models?         calculate-available-models
-                :include-dashboard-questions?        include-dashboard-questions
-                :include-metadata?                   include-metadata
-                :non-temporal-dim-ids                (process-non-temporal-dim-ids non-temporal-dim-ids)
-                :has-temporal-dim                    has-temporal-dim
-                :display-type                        (set display-type)}))
-      (analytics/inc! :metabase-search/response-ok))
+    (prof/profile (u/prog1 (search/search
+                            (search/search-context
+                             {:archived                            archived
+                              :collection                          collection
+                              :context                             context
+                              :created-at                          created-at
+                              :created-by                          (set created-by)
+                              :current-user-id                     api/*current-user-id*
+                              :is-impersonated-user?               (perms/impersonated-user?)
+                              :is-sandboxed-user?                  (perms/sandboxed-user?)
+                              :is-superuser?                       api/*is-superuser?*
+                              :current-user-perms                  @api/*current-user-permissions-set*
+                              :filter-items-in-personal-collection filter-items-in-personal-collection
+                              :last-edited-at                      last-edited-at
+                              :last-edited-by                      (set last-edited-by)
+                              :limit                               (request/limit)
+                              :model-ancestors?                    model-ancestors
+                              :models                              (not-empty (set models))
+                              :offset                              (request/offset)
+                              :search-engine                       search-engine
+                              :search-native-query                 search-native-query
+                              :search-string                       (some-> q str/trim not-empty)
+                              :table-db-id                         table-db-id
+                              :verified                            verified
+                              :ids                                 (set ids)
+                              :calculate-available-models?         calculate-available-models
+                              :include-dashboard-questions?        include-dashboard-questions
+                              :include-metadata?                   include-metadata
+                              :non-temporal-dim-ids                (process-non-temporal-dim-ids non-temporal-dim-ids)
+                              :has-temporal-dim                    has-temporal-dim
+                              :display-type                        (set display-type)}))
+                    (analytics/inc! :metabase-search/response-ok)))
     (catch Exception e
       (let [status-code (:status-code (ex-data e))]
         (when (or (not status-code) (= 5 (quot status-code 100)))

--- a/src/metabase/search/core.clj
+++ b/src/metabase/search/core.clj
@@ -41,6 +41,7 @@
 
  [search.spec
   spec
+  specifications
   define-spec]
 
  [search.util

--- a/src/metabase/search/impl.clj
+++ b/src/metabase/search/impl.clj
@@ -386,37 +386,14 @@
         (cond-> (t2/instance-of? :model/Collection instance) map-collection))))
 
 (defn- add-can-write [search-ctx row]
-  (if (some #(mi/instance-of? % row) [:model/Dashboard :model/Card])
+  (if (some #(mi/instance-of? % row) [:model/Dashboard :model/Card :model/Collection])
     (assoc row :can_write (can-write? search-ctx row))
     row))
 
 (defn- normalize-result-more
-  "Additional normalization that is done after we've filtered by permissions, as its more expensive."
-  [search-ctx result]
-  (->> (update result :pk_ref json/decode)
-       (add-can-write search-ctx)))
-
-(defn- search-results [search-ctx model-set-fn total-results]
-  (let [add-perms-for-col  (fn [item]
-                             (cond-> item
-                               (mi/instance-of? :model/Collection item)
-                               (assoc :can_write (can-write? search-ctx item))))]
-    ;; We get to do this slicing and dicing with the result data because
-    ;; the pagination of search is for UI improvement, not for performance.
-    ;; We intend for the cardinality of the search results to be below the default max before this slicing occurs
-    (cond-> {:data             (cond->> total-results
-                                 (some? (:offset-int search-ctx)) (drop (:offset-int search-ctx))
-                                 (some? (:limit-int search-ctx)) (take (:limit-int search-ctx))
-                                 true (map add-perms-for-col))
-             :limit            (:limit-int search-ctx)
-             :models           (:models search-ctx)
-             :offset           (:offset-int search-ctx)
-             :table_db_id      (:table-db-id search-ctx)
-             :engine           (:search-engine search-ctx)
-             :total            (count total-results)}
-
-      (:calculate-available-models? search-ctx)
-      (assoc :available_models (model-set-fn search-ctx)))))
+  "Additional normalization that is done after we've filtered by permissions."
+  [_search-ctx result]
+  (update result :pk_ref json/decode))
 
 (defn- hydrate-dashboards [results]
   (->> (t2/hydrate results [:dashboard :moderation_status])
@@ -438,6 +415,34 @@
              item))
          search-results)))
 
+(defn- search-results [search-ctx model-set-fn ranked-results]
+  ;; Slice the ranked window down to the requested page *before* hydration/serialization so
+  ;; display-only work (including the expensive per-row `:can_write` permission check) only runs
+  ;; on the rows we actually return. The pagination of search is for UI improvement, not for
+  ;; performance — the ranked set is already capped by `max-filtered-results` — but doing the
+  ;; slice here lets downstream steps amortize their batch hydrations over ~limit rows instead
+  ;; of the full cap.
+  (let [paginated-results (cond->> ranked-results
+                            (some? (:offset-int search-ctx)) (drop (:offset-int search-ctx))
+                            (some? (:limit-int search-ctx)) (take (:limit-int search-ctx))
+                            true hydrate-dashboards
+                            true hydrate-user-metadata
+                            (:include-metadata? search-ctx) (add-metadata)
+                            (:model-ancestors? search-ctx) (add-dataset-collection-hierarchy)
+                            true (add-collection-effective-location)
+                            true (map (partial add-can-write search-ctx))
+                            true (map serialize))]
+    (cond-> {:data        paginated-results
+             :limit       (:limit-int search-ctx)
+             :models      (:models search-ctx)
+             :offset      (:offset-int search-ctx)
+             :table_db_id (:table-db-id search-ctx)
+             :engine      (:search-engine search-ctx)
+             :total       (count ranked-results)}
+
+      (:calculate-available-models? search-ctx)
+      (assoc :available_models (model-set-fn search-ctx)))))
+
 (mu/defn search
   "Builds a search query that includes all the searchable entities, and runs it."
   [search-ctx :- search.config/SearchContext]
@@ -452,11 +457,5 @@
                              (filter (partial check-permissions-for-model search-ctx))
                              (map (partial normalize-result-more search-ctx))
                              (keep #(search.engine/score scoring-ctx %)))
-          total-results     (cond->> (scoring/top-results reducible-results search.config/max-filtered-results xf)
-                              true hydrate-dashboards
-                              true hydrate-user-metadata
-                              (:include-metadata? search-ctx) (add-metadata)
-                              (:model-ancestors? search-ctx) (add-dataset-collection-hierarchy)
-                              true (add-collection-effective-location)
-                              true (map serialize))]
-      (search-results search-ctx search.engine/model-set total-results))))
+          ranked-results    (scoring/top-results reducible-results search.config/max-filtered-results xf)]
+      (search-results search-ctx search.engine/model-set ranked-results))))

--- a/src/metabase/search/impl.clj
+++ b/src/metabase/search/impl.clj
@@ -431,7 +431,11 @@
                             (:model-ancestors? search-ctx) (add-dataset-collection-hierarchy)
                             true (add-collection-effective-location)
                             true (map (partial add-can-write search-ctx))
-                            true (map serialize))]
+                            true (map serialize)
+                            ;; Realize within the enclosing tracing span so hydration and
+                            ;; serialization time is attributed here rather than deferred to
+                            ;; JSON encoding after the span closes.
+                            true vec)]
     (cond-> {:data        paginated-results
              :limit       (:limit-int search-ctx)
              :models      (:models search-ctx)

--- a/test/metabase/permissions/models/permissions_test.clj
+++ b/test/metabase/permissions/models/permissions_test.clj
@@ -1,6 +1,7 @@
 (ns metabase.permissions.models.permissions-test
   (:require
    [clojure.test :refer :all]
+   [metabase.api.common :as api]
    [metabase.audit-app.impl :as audit.impl]
    [metabase.collections.models.collection :as collection]
    [metabase.models.interface :as mi]
@@ -290,3 +291,34 @@
 
         (testing "admin can create dashboard in root collection"
           (is (true? (mi/can-create? :model/Dashboard {}))))))))
+
+(deftest ^:parallel can-read-via-parent-collection?-test
+  (testing "read perm is true iff the current user has read on the parent collection"
+    (binding [api/*current-user-permissions-set* (atom #{"/"})]
+      (is (true?  (boolean (perms/can-read-via-parent-collection? 42))))
+      (is (true?  (boolean (perms/can-read-via-parent-collection? nil)))))
+    (binding [api/*current-user-permissions-set* (atom #{})]
+      (is (false? (boolean (perms/can-read-via-parent-collection? 42))))
+      (is (false? (boolean (perms/can-read-via-parent-collection? nil)))))
+    (binding [api/*current-user-permissions-set* (atom #{"/collection/42/read/"})]
+      (is (true?  (boolean (perms/can-read-via-parent-collection? 42))))
+      (is (false? (boolean (perms/can-read-via-parent-collection? 99)))))))
+
+(deftest collection-id-only-read-methods-not-overridden-test
+  (testing "no one has redefmethod'd mi/can-read? for a model registered as collection-id-only"
+    ;; Require the model namespaces to ensure their `define-collection-id-only-read-perms!`
+    ;; invocations have run and populated the registry.
+    (require 'metabase.queries.models.card
+             'metabase.dashboards.models.dashboard)
+    (let [registered (perms/collection-id-only-read-models)]
+      (is (seq registered)
+          "registry should be populated after loading Card/Dashboard namespaces")
+      (doseq [t2-model registered]
+        (is (identical? (perms/collection-id-only-read-method t2-model)
+                        (get-method mi/can-read? t2-model))
+            (str t2-model ": `mi/can-read?` was overridden after "
+                 "`perms/define-collection-id-only-read-perms!` installed it. "
+                 "If this model's read policy now needs more than `:collection_id`, "
+                 "remove the macro invocation in its model namespace so downstream consumers "
+                 "(e.g., semantic search's fast-path filter) don't continue to assume the "
+                 "collection-id-only contract."))))))


### PR DESCRIPTION
- Document the intentional staleness trade-off in filter-read-permitted fast path
  (HIGH codex finding / MED claude-code finding)
  - The per-row API fetch still enforces live permissions, so exposure is bounded to search-result metadata between reindex cycles.
- Call `perms/can-read-audit-helper` directly instead of a stub `:model/Card + mi/can-read?`
  Making the 'only `:collection_id` matters' contract explicit and avoiding multimethod dispatch.
- Extend `filter-read-permitted-fast-path-test` to exercise card/metric/dataset/dashboard also.
- Realize paginated-results with vec so hydration + serialization run inside the tracing span.
