### PR TITLE
Add a step to show fk tables in publish flow from Library

### DIFF
--- a/e2e/test/scenarios/data-studio/data-studio-library.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-studio-library.cy.spec.ts
@@ -130,6 +130,8 @@ describe("scenarios > data studio > library", () => {
         select: true,
       });
 
+      H.modal().button("Publish this table").click();
+
       cy.log("Verify the table is published");
       H.DataStudio.Tables.overviewPage().should("exist");
       H.DataStudio.Tables.header().findByDisplayValue("Orders").should("exist");
@@ -217,6 +219,7 @@ describe("scenarios > data studio > library", () => {
       H.entityPickerModalItem(1, "Sample Database").click();
       H.entityPickerModalItem(2, "Orders").click();
       H.entityPickerModal().button("Publish").click();
+      H.modal().button("Publish this table").click();
 
       cy.log("Navigate back to Library via breadcrumbs");
       H.DataStudio.breadcrumbs().findByRole("link", { name: "Data" }).click();

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/LibraryPage/PublishTableModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/LibraryPage/PublishTableModal.tsx
@@ -40,10 +40,9 @@ export function PublishTableModal({
 
   const handlePublish = () => {
     if (selectedTable) {
-      const table = selectedTable;
       setSelectedTable(null);
       onClose();
-      onPublished(table);
+      onPublished(selectedTable);
     }
   };
 

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/LibraryPage/PublishTableModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/LibraryPage/PublishTableModal.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { t } from "ttag";
 
 import {
@@ -5,10 +6,8 @@ import {
   type OmniPickerItem,
   type OmniPickerTableItem,
 } from "metabase/common/components/Pickers";
-import { trackDataStudioTablePublished } from "metabase/data-studio/analytics";
-import { useMetadataToasts } from "metabase/metadata/hooks/useMetadataToasts";
-import { usePublishTablesMutation } from "metabase-enterprise/api/table";
-import { isConcreteTableId } from "metabase-types/api";
+
+import { PublishTablesModal } from "../components/PublishTablesModal";
 
 interface PublishTableModalProps {
   opened: boolean;
@@ -24,20 +23,32 @@ export function PublishTableModal({
   onClose,
   onPublished,
 }: PublishTableModalProps) {
-  const { sendSuccessToast } = useMetadataToasts();
-  const [publishTables] = usePublishTablesMutation();
+  const [selectedTable, setSelectedTable] =
+    useState<OmniPickerTableItem | null>(null);
 
-  const onConfirm = async (item: OmniPickerItem) => {
+  const handlePickerConfirm = (item: OmniPickerItem) => {
     if (!isTableItem(item)) {
       return;
     }
-    await publishTables({ table_ids: [item.id] }).unwrap(); // unwrap() allows EntityPicker's error handling to take over
+    setSelectedTable(item);
+  };
+
+  const handleClose = () => {
+    setSelectedTable(null);
     onClose();
-    sendSuccessToast(t`Published`);
-    if (isConcreteTableId(item.id)) {
-      trackDataStudioTablePublished(item.id);
+  };
+
+  const handlePublish = () => {
+    if (selectedTable) {
+      const table = selectedTable;
+      setSelectedTable(null);
+      onClose();
+      onPublished(table);
     }
-    onPublished(item);
+  };
+
+  const handlePublishModalClose = () => {
+    setSelectedTable(null);
   };
 
   if (!opened) {
@@ -46,6 +57,17 @@ export function PublishTableModal({
 
   const shouldDisableItem = (item: OmniPickerItem) =>
     item.model === "table" && "is_published" in item && !!item.is_published;
+
+  if (selectedTable) {
+    return (
+      <PublishTablesModal
+        isOpened
+        tableIds={[selectedTable.id]}
+        onPublish={handlePublish}
+        onClose={handlePublishModalClose}
+      />
+    );
+  }
 
   return (
     <EntityPickerModal
@@ -61,8 +83,8 @@ export function PublishTableModal({
         confirmButtonText: t`Publish`,
       }}
       isDisabledItem={shouldDisableItem}
-      onChange={onConfirm}
-      onClose={onClose}
+      onChange={handlePickerConfirm}
+      onClose={handleClose}
     />
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/LibraryPage/PublishTableModal.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/LibraryPage/PublishTableModal.unit.spec.tsx
@@ -1,0 +1,133 @@
+import userEvent from "@testing-library/user-event";
+
+import {
+  setupPublishTablesEndpoint,
+  setupTableSelectionInfoEndpoint,
+} from "__support__/server-mocks";
+import { renderWithProviders, screen, waitFor } from "__support__/ui";
+import type { OmniPickerItem } from "metabase/common/components/Pickers";
+import type { BulkTableSelectionInfo } from "metabase-types/api";
+import {
+  createMockBulkTableInfo,
+  createMockBulkTableSelectionInfo,
+} from "metabase-types/api/mocks";
+
+import { PublishTableModal } from "./PublishTableModal";
+
+jest.mock("metabase/common/components/Pickers/EntityPicker", () => ({
+  ...jest.requireActual(
+    "metabase/common/components/Pickers/EntityPicker/types",
+  ),
+  EntityPickerModal: ({
+    onChange,
+    onClose,
+  }: {
+    onChange: (item: OmniPickerItem) => void;
+    onClose: () => void;
+  }) => (
+    <div data-testid="entity-picker-modal">
+      <button
+        onClick={() =>
+          onChange({
+            model: "table",
+            id: 1,
+            name: "ORDERS",
+            database_id: 1,
+          } as OmniPickerItem)
+        }
+      >
+        Select Orders
+      </button>
+      <button onClick={onClose}>Close picker</button>
+    </div>
+  ),
+}));
+
+interface SetupOpts {
+  opened?: boolean;
+  selectionInfo?: BulkTableSelectionInfo;
+}
+
+function setup({
+  opened = true,
+  selectionInfo = createMockBulkTableSelectionInfo({
+    selected_table: createMockBulkTableInfo({
+      id: 1,
+      display_name: "Orders",
+    }),
+  }),
+}: SetupOpts = {}) {
+  const onClose = jest.fn();
+  const onPublished = jest.fn();
+
+  setupTableSelectionInfoEndpoint(selectionInfo);
+  setupPublishTablesEndpoint();
+
+  renderWithProviders(
+    <PublishTableModal
+      opened={opened}
+      onClose={onClose}
+      onPublished={onPublished}
+    />,
+  );
+
+  return { onClose, onPublished };
+}
+
+describe("PublishTableModal", () => {
+  it("should show the entity picker initially", () => {
+    setup();
+    expect(screen.getByTestId("entity-picker-modal")).toBeInTheDocument();
+  });
+
+  it("should show the publish confirmation modal after selecting a table and call onClose and onPublished on publish", async () => {
+    const { onClose, onPublished } = setup();
+    await userEvent.click(screen.getByText("Select Orders"));
+    expect(await screen.findByText("Publish Orders?")).toBeInTheDocument();
+    await userEvent.click(screen.getByText("Publish this table"));
+    await waitFor(() => expect(onPublished).toHaveBeenCalled());
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("should show FK remapping warning when table has unpublished upstream tables", async () => {
+    setup({
+      selectionInfo: createMockBulkTableSelectionInfo({
+        selected_table: createMockBulkTableInfo({
+          id: 1,
+          display_name: "Orders",
+        }),
+        unpublished_upstream_tables: [
+          createMockBulkTableInfo({
+            id: 2,
+            display_name: "Products",
+          }),
+          createMockBulkTableInfo({
+            id: 3,
+            display_name: "People",
+          }),
+        ],
+      }),
+    });
+    await userEvent.click(screen.getByText("Select Orders"));
+    expect(
+      await screen.findByText("Publish Orders and the tables it depends on?"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Products")).toBeInTheDocument();
+    expect(screen.getByText("People")).toBeInTheDocument();
+  });
+
+  it("should return to picker when publish modal is closed", async () => {
+    setup();
+    await userEvent.click(screen.getByText("Select Orders"));
+    expect(await screen.findByText("Publish Orders?")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByText("Cancel"));
+    expect(screen.getByTestId("entity-picker-modal")).toBeInTheDocument();
+  });
+
+  it("should call onClose when entity picker is closed", async () => {
+    const { onClose } = setup();
+    await userEvent.click(screen.getByText("Close picker"));
+    expect(onClose).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes UXW-3148

### Description
Adds the publish table modal to the ux flow when publishing a table from the library

### How to verify
1. Go to the library
2. In the menu, choose publish a table and pick a table for fk relations that are not published
3. You should see a confirmation modal for publishing the table, with relation tables being displayed as well.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
