### PR TITLE
Add no writable databases state to transforms pages

### DIFF
--- a/e2e/test/scenarios/data-studio/transforms/transforms.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/transforms/transforms.cy.spec.ts
@@ -32,7 +32,7 @@ const TARGET_SCHEMA = "Schema A";
 const TARGET_SCHEMA_2 = "Schema B";
 const CUSTOM_SCHEMA = "custom_schema";
 
-describe("scenarios > admin > transforms", () => {
+describe("scenarios > admin > transforms", { tags: ["@external"] }, () => {
   beforeEach(() => {
     H.restore("postgres-writable");
     H.resetTestTable({ type: "postgres", table: "many_schemas" });
@@ -3766,26 +3766,15 @@ describe("scenarios > admin > transforms", () => {
     H.expectNoBadSnowplowEvents();
   });
 
-  it("should not pick the only database when it is disabled in SQL editor", () => {
+  it("should show a message when no supported databases are available", () => {
     cy.log("create a new transform");
     visitTransformListPage();
-    cy.button("Create a transform").click();
-    H.popover().findByText("SQL query").click();
-
-    cy.findByTestId("gui-builder-data")
-      .findByText("Select a database")
-      .should("be.visible");
-  });
-
-  it("should not pick the only database when it is disabled in Python editor", () => {
-    cy.log("create a new transform");
-    visitTransformListPage();
-    cy.button("Create a transform").click();
-    H.popover().findByText("Python script").click();
-
-    cy.findByTestId("python-transform-top-bar")
-      .findByText("Select a database")
-      .should("be.visible");
+    cy.findByRole("heading", {
+      name: "To use transforms, you need a writable database connection",
+    }).should("exist");
+    cy.findByRole("link", { name: "View your database connections" }).should(
+      "exist",
+    );
   });
 });
 
@@ -4226,62 +4215,70 @@ describe("scenarios > data studio > transforms > permissions > oss", () => {
   );
 });
 
-describe("scenarios > data studio > transforms > permissions > pro-self-hosted", () => {
-  beforeEach(() => {
-    H.restore();
-    cy.signInAsAdmin();
-  });
-
-  it("should have transforms available in self-hosted pro without upsell gem icon", () => {
-    H.activateToken("pro-self-hosted").then(() => {
-      cy.log("ensure that transform permissions are not shown");
-      cy.visit(`/admin/permissions/data/group/${ALL_USERS_GROUP_ID}`);
-
-      //Check that a known header is present
-      cy.findByRole("columnheader", { name: "Database name" }).should(
-        "be.visible",
-      );
-      //Ensure transform permissions are not displayed
-      cy.findByRole("columnheader", { name: /Transforms/ }).should("not.exist");
-
-      cy.log("Visit data studio page");
-      cy.visit("/data-studio");
-      H.DataStudio.nav().should("be.visible");
-
-      cy.log("Verify Transforms menu item is visible");
-      H.DataStudio.nav().findByText("Transforms").should("be.visible");
-
-      cy.log("Verify no upsell gem icon is displayed in Transforms menu item");
-      H.DataStudio.nav()
-        .findByText("Transforms")
-        .closest("a")
-        .within(() => {
-          cy.findByTestId("upsell-gem").should("not.exist");
-        });
-
-      cy.log("Verify transforms page is accessible");
-      H.DataStudio.nav().findByText("Transforms").click();
-      H.DataStudio.Transforms.enableTransformPage()
-        .findByRole("button", { name: "Enable transforms" })
-        .click();
-      H.DataStudio.Transforms.list().should("be.visible");
-
-      cy.log("Verify can create transforms in pro-self-hosted");
-      cy.button("Create a transform").should("be.visible");
-
-      cy.log("transform permissions should now be visible");
-      H.goToAdmin();
-      H.appBar().findByRole("link", { name: "Permissions" }).click();
-      cy.findByRole("menuitem", { name: "All Users" }).click();
-
-      //Check that a known header is present
-      cy.findByRole("columnheader", { name: "Database name" }).should(
-        "be.visible",
-      );
-      //Ensure transform permissions are displayed
-      cy.findByRole("columnheader", { name: /Transforms/ })
-        .scrollIntoView()
-        .should("be.visible");
+describe(
+  "scenarios > data studio > transforms > permissions > pro-self-hosted",
+  { tags: ["@external"] },
+  () => {
+    beforeEach(() => {
+      H.restore("postgres-writable");
+      cy.signInAsAdmin();
     });
-  });
-});
+
+    it("should have transforms available in self-hosted pro without upsell gem icon", () => {
+      H.activateToken("pro-self-hosted").then(() => {
+        cy.log("ensure that transform permissions are not shown");
+        cy.visit(`/admin/permissions/data/group/${ALL_USERS_GROUP_ID}`);
+
+        //Check that a known header is present
+        cy.findByRole("columnheader", { name: "Database name" }).should(
+          "be.visible",
+        );
+        //Ensure transform permissions are not displayed
+        cy.findByRole("columnheader", { name: /Transforms/ }).should(
+          "not.exist",
+        );
+
+        cy.log("Visit data studio page");
+        cy.visit("/data-studio");
+        H.DataStudio.nav().should("be.visible");
+
+        cy.log("Verify Transforms menu item is visible");
+        H.DataStudio.nav().findByText("Transforms").should("be.visible");
+
+        cy.log(
+          "Verify no upsell gem icon is displayed in Transforms menu item",
+        );
+        H.DataStudio.nav()
+          .findByText("Transforms")
+          .closest("a")
+          .within(() => {
+            cy.findByTestId("upsell-gem").should("not.exist");
+          });
+
+        cy.log("Verify transforms page is accessible");
+        H.DataStudio.nav().findByText("Transforms").click();
+        H.DataStudio.Transforms.enableTransformPage()
+          .findByRole("button", { name: "Enable transforms" })
+          .click();
+        H.DataStudio.Transforms.list().should("be.visible");
+
+        cy.log("Verify can create transforms in pro-self-hosted");
+        cy.button("Create a transform").should("be.visible");
+
+        cy.log("transform permissions should now be visible");
+        H.goToAdmin();
+        H.appBar().findByRole("link", { name: "Permissions" }).click();
+        cy.findByRole("menuitem", { name: "All Users" }).click();
+
+        //Check that a known header is present
+        cy.findByRole("columnheader", { name: "Database name" }).should(
+          "be.visible",
+        );
+        //Ensure transform permissions are displayed
+        cy.findByRole("columnheader", { name: /Transforms/ })
+          .scrollIntoView()
+          .should("be.visible");
+      });
+    });
+  },
+);

--- a/e2e/test/scenarios/data-studio/transforms/transforms.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/transforms/transforms.cy.spec.ts
@@ -4150,13 +4150,13 @@ function checkSortingOrder(transformNames: string[]) {
 
 describe("scenarios > data studio > transforms > permissions > oss", () => {
   beforeEach(() => {
-    H.restore();
+    H.restore("postgres-writable");
     cy.signInAsAdmin();
   });
 
   it(
     "should be able to enable transforms in OSS without upsell gem icon",
-    { tags: "@OSS" },
+    { tags: ["@OSS", "@external"] },
     () => {
       cy.log("ensure that transform permissions are not shown");
       cy.visit(`/admin/permissions/data/group/${ALL_USERS_GROUP_ID}`);

--- a/frontend/src/metabase/data-studio/app/pages/TransformsSectionLayout/TransformsSectionLayout.tsx
+++ b/frontend/src/metabase/data-studio/app/pages/TransformsSectionLayout/TransformsSectionLayout.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { t } from "ttag";
 
+import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { useSetting } from "metabase/common/hooks";
 import { usePageTitle } from "metabase/hooks/use-page-title";
 import { PLUGIN_TRANSFORMS } from "metabase/plugins";
@@ -23,7 +24,7 @@ export function TransformsSectionLayout({
   const shouldShowUpsell = useSelector(getShouldShowTransformsUpsell);
   const isTransformsEnabled = useSetting("transforms-enabled");
   const isHosted = useSetting("is-hosted?");
-  const { transformsDatabases, isLoadingDatabases } =
+  const { transformsDatabases, isLoadingDatabases, databasesError } =
     useTransformSupportedDbs();
 
   if (shouldShowUpsell) {
@@ -40,5 +41,15 @@ export function TransformsSectionLayout({
     );
   }
 
-  return <SectionLayout>{children}</SectionLayout>;
+  return (
+    <SectionLayout>
+      <LoadingAndErrorWrapper
+        loading={isLoadingDatabases}
+        error={databasesError}
+        noWrapper
+      >
+        {children}
+      </LoadingAndErrorWrapper>
+    </SectionLayout>
+  );
 }

--- a/frontend/src/metabase/data-studio/app/pages/TransformsSectionLayout/TransformsSectionLayout.tsx
+++ b/frontend/src/metabase/data-studio/app/pages/TransformsSectionLayout/TransformsSectionLayout.tsx
@@ -5,7 +5,7 @@ import { useSetting } from "metabase/common/hooks";
 import { usePageTitle } from "metabase/hooks/use-page-title";
 import { PLUGIN_TRANSFORMS } from "metabase/plugins";
 import { useSelector } from "metabase/redux";
-import { useTransformPermissions } from "metabase/transforms/hooks/use-transform-permissions";
+import { useTransformSupportedDbs } from "metabase/transforms/hooks/use-transform-supported-dbs";
 import { EnableTransformsPage } from "metabase/transforms/pages/EnableTransformsPage/EnableTransformsPage";
 import { NoWritableDatabasesEmptyState } from "metabase/transforms/pages/NoWritableDatabasesEmptyState";
 import { getShouldShowTransformsUpsell } from "metabase/transforms/selectors";
@@ -23,7 +23,8 @@ export function TransformsSectionLayout({
   const shouldShowUpsell = useSelector(getShouldShowTransformsUpsell);
   const isTransformsEnabled = useSetting("transforms-enabled");
   const isHosted = useSetting("is-hosted?");
-  const { transformsDatabases, isLoadingDatabases } = useTransformPermissions();
+  const { transformsDatabases, isLoadingDatabases } =
+    useTransformSupportedDbs();
 
   if (shouldShowUpsell) {
     return <PLUGIN_TRANSFORMS.TransformsUpsellPage />;

--- a/frontend/src/metabase/data-studio/app/pages/TransformsSectionLayout/TransformsSectionLayout.tsx
+++ b/frontend/src/metabase/data-studio/app/pages/TransformsSectionLayout/TransformsSectionLayout.tsx
@@ -5,7 +5,9 @@ import { useSetting } from "metabase/common/hooks";
 import { usePageTitle } from "metabase/hooks/use-page-title";
 import { PLUGIN_TRANSFORMS } from "metabase/plugins";
 import { useSelector } from "metabase/redux";
+import { useTransformPermissions } from "metabase/transforms/hooks/use-transform-permissions";
 import { EnableTransformsPage } from "metabase/transforms/pages/EnableTransformsPage/EnableTransformsPage";
+import { NoWritableDatabasesEmptyState } from "metabase/transforms/pages/NoWritableDatabasesEmptyState";
 import { getShouldShowTransformsUpsell } from "metabase/transforms/selectors";
 
 import { SectionLayout } from "../../components/SectionLayout";
@@ -21,11 +23,20 @@ export function TransformsSectionLayout({
   const shouldShowUpsell = useSelector(getShouldShowTransformsUpsell);
   const isTransformsEnabled = useSetting("transforms-enabled");
   const isHosted = useSetting("is-hosted?");
+  const { transformsDatabases, isLoadingDatabases } = useTransformPermissions();
 
   if (shouldShowUpsell) {
     return <PLUGIN_TRANSFORMS.TransformsUpsellPage />;
   } else if (!isTransformsEnabled && !isHosted) {
     return <EnableTransformsPage />;
+  }
+
+  if (!isLoadingDatabases && transformsDatabases?.length === 0) {
+    return (
+      <SectionLayout>
+        <NoWritableDatabasesEmptyState />
+      </SectionLayout>
+    );
   }
 
   return <SectionLayout>{children}</SectionLayout>;

--- a/frontend/src/metabase/data-studio/app/pages/TransformsSectionLayout/TransformsSectionLayout.unit.spec.tsx
+++ b/frontend/src/metabase/data-studio/app/pages/TransformsSectionLayout/TransformsSectionLayout.unit.spec.tsx
@@ -31,6 +31,7 @@ const setup = ({
   transformsEnabled = false,
   isAdmin = false,
   isStoreUser = false,
+  canAccessDbDetails = false,
   databases = [],
 }: {
   isHosted?: boolean;
@@ -38,6 +39,7 @@ const setup = ({
   transformsEnabled?: boolean;
   isAdmin?: boolean;
   isStoreUser?: boolean;
+  canAccessDbDetails?: boolean;
   databases?: Database[];
 } = {}) => {
   setupUserMetabotPermissionsEndpoint();
@@ -84,7 +86,10 @@ const setup = ({
     {
       storeInitialState: createMockState({
         settings,
-        currentUser,
+        currentUser: createMockUser({
+          is_superuser: isAdmin,
+          permissions: { can_access_db_details: canAccessDbDetails },
+        }),
       }),
       withRouter: true,
       initialRoute: path,
@@ -208,7 +213,23 @@ describe("TransformSectionLayout", () => {
       expect(link).toHaveAttribute("href", "/admin/databases");
     });
 
-    it("should not show the 'View your database connections' button for non-admin users", async () => {
+    it("should show the 'View your database connections' button for users with manage database permission", async () => {
+      setup({
+        transformsEnabled: true,
+        isAdmin: false,
+        canAccessDbDetails: true,
+        databases: [],
+      });
+
+      await assertNoWritableDatabasesEmptyState();
+      expect(
+        screen.getByRole("link", {
+          name: "View your database connections",
+        }),
+      ).toBeInTheDocument();
+    });
+
+    it("should not show the 'View your database connections' button for non-admin users without manage database permission", async () => {
       setup({
         transformsEnabled: true,
         isAdmin: false,

--- a/frontend/src/metabase/data-studio/app/pages/TransformsSectionLayout/TransformsSectionLayout.unit.spec.tsx
+++ b/frontend/src/metabase/data-studio/app/pages/TransformsSectionLayout/TransformsSectionLayout.unit.spec.tsx
@@ -1,3 +1,5 @@
+import { Route } from "react-router";
+
 import { setupEnterpriseOnlyPlugin } from "__support__/enterprise";
 import {
   setupDatabaseListEndpoint,
@@ -9,8 +11,10 @@ import {
 import { mockSettings } from "__support__/settings";
 import { renderWithProviders, screen } from "__support__/ui";
 import { createMockState } from "metabase/redux/store/mocks";
+import type { Database } from "metabase-types/api";
 import {
   createMockSettings,
+  createMockDatabase,
   createMockTokenFeatures,
   createMockUser,
 } from "metabase-types/api/mocks";
@@ -27,14 +31,17 @@ const setup = ({
   transformsEnabled = false,
   isAdmin = false,
   isStoreUser = false,
+  databases = [],
 }: {
   isHosted?: boolean;
   hasTransformFeature?: boolean;
   transformsEnabled?: boolean;
   isAdmin?: boolean;
   isStoreUser?: boolean;
+  databases?: Database[];
 } = {}) => {
   setupUserMetabotPermissionsEndpoint();
+  setupDatabaseListEndpoint(databases);
 
   const storeUserEmail = "store-user@example.com";
   const currentUser = createMockUser({ is_superuser: isAdmin });
@@ -65,13 +72,22 @@ const setup = ({
     setupEnterpriseOnlyPlugin("transforms");
   }
 
+  const path = "/transforms";
+
   renderWithProviders(
-    <TransformsSectionLayout>List of transforms</TransformsSectionLayout>,
+    <Route
+      path={path}
+      component={() => (
+        <TransformsSectionLayout>List of transforms</TransformsSectionLayout>
+      )}
+    />,
     {
       storeInitialState: createMockState({
         settings,
         currentUser,
       }),
+      withRouter: true,
+      initialRoute: path,
     },
   );
 };
@@ -90,9 +106,10 @@ describe("TransformSectionLayout", () => {
         await screen.findByRole("button", { name: "Enable transforms" }),
       ).toBeInTheDocument();
     });
-    it("should show allow you into transforms if transforms are enabled", async () => {
+    it("should show allow you into transforms if transforms are enabled and writable databases exist", async () => {
       setup({
         transformsEnabled: true,
+        databases: [createMockDatabase({ transforms_permissions: "write" })],
       });
 
       await assertInApp();
@@ -106,7 +123,11 @@ describe("TransformSectionLayout", () => {
     });
 
     it("Should only allow you into transforms if you transforms are enabled", async () => {
-      setup({ hasTransformFeature: true, transformsEnabled: true });
+      setup({
+        hasTransformFeature: true,
+        transformsEnabled: true,
+        databases: [createMockDatabase({ transforms_permissions: "write" })],
+      });
       await assertInApp();
     });
   });
@@ -128,8 +149,78 @@ describe("TransformSectionLayout", () => {
     });
 
     it("should show you the app if the instance is hosted and the transform feature is present", async () => {
-      setup({ isHosted: true, hasTransformFeature: true });
+      setup({
+        isHosted: true,
+        hasTransformFeature: true,
+        databases: [createMockDatabase({ transforms_permissions: "write" })],
+      });
       await assertInApp();
+    });
+  });
+
+  describe("No writable databases", () => {
+    it("should show empty state when no databases are writable or supported", async () => {
+      setup({
+        transformsEnabled: true,
+        databases: [
+          createMockDatabase({ id: 1, transforms_permissions: "none" }),
+          createMockDatabase({
+            id: 2,
+            transforms_permissions: "write",
+            is_sample: true,
+          }),
+          createMockDatabase({
+            id: 3,
+            transforms_permissions: "write",
+            router_database_id: 99,
+          }),
+          createMockDatabase({
+            id: 4,
+            transforms_permissions: "write",
+            is_audit: true,
+          }),
+        ],
+      });
+
+      await assertNoWritableDatabasesEmptyState();
+    });
+
+    it("should show empty state when transforms are enabled and the database list is empty", async () => {
+      setup({
+        transformsEnabled: true,
+        databases: [],
+      });
+
+      await assertNoWritableDatabasesEmptyState();
+    });
+
+    it("should show the 'View your database connections' button linking to admin databases for admin users", async () => {
+      setup({
+        transformsEnabled: true,
+        isAdmin: true,
+        databases: [],
+      });
+
+      await assertNoWritableDatabasesEmptyState();
+      const link = screen.getByRole("link", {
+        name: "View your database connections",
+      });
+      expect(link).toHaveAttribute("href", "/admin/databases");
+    });
+
+    it("should not show the 'View your database connections' button for non-admin users", async () => {
+      setup({
+        transformsEnabled: true,
+        isAdmin: false,
+        databases: [],
+      });
+
+      await assertNoWritableDatabasesEmptyState();
+      expect(
+        screen.queryByRole("link", {
+          name: "View your database connections",
+        }),
+      ).not.toBeInTheDocument();
     });
   });
 });
@@ -139,4 +230,11 @@ const assertInApp = async () =>
 const assertEnableScreen = async () =>
   expect(
     await screen.findByText("Customize and clean up your data"),
+  ).toBeInTheDocument();
+
+const assertNoWritableDatabasesEmptyState = async () =>
+  expect(
+    await screen.findByText(
+      "To use transforms, you need a writable database connection",
+    ),
   ).toBeInTheDocument();

--- a/frontend/src/metabase/data-studio/app/pages/TransformsSectionLayout/TransformsSectionLayout.unit.spec.tsx
+++ b/frontend/src/metabase/data-studio/app/pages/TransformsSectionLayout/TransformsSectionLayout.unit.spec.tsx
@@ -1,3 +1,4 @@
+import fetchMock from "fetch-mock";
 import { Route } from "react-router";
 
 import { setupEnterpriseOnlyPlugin } from "__support__/enterprise";
@@ -13,13 +14,20 @@ import { renderWithProviders, screen } from "__support__/ui";
 import { createMockState } from "metabase/redux/store/mocks";
 import type { Database } from "metabase-types/api";
 import {
-  createMockSettings,
+  COMMON_DATABASE_FEATURES,
   createMockDatabase,
+  createMockSettings,
   createMockTokenFeatures,
   createMockUser,
 } from "metabase-types/api/mocks";
 
 import { TransformsSectionLayout } from "./TransformsSectionLayout";
+
+const createTransformSupportedDatabase = (opts?: Partial<Database>) =>
+  createMockDatabase({
+    features: [...COMMON_DATABASE_FEATURES, "transforms/table"],
+    ...opts,
+  });
 
 jest.mock("metabase/nav/components/AppSwitcher", () => ({
   AppSwitcher: () => "App Switcher",
@@ -33,6 +41,7 @@ const setup = ({
   isStoreUser = false,
   canAccessDbDetails = false,
   databases = [],
+  databasesError = false,
 }: {
   isHosted?: boolean;
   hasTransformFeature?: boolean;
@@ -41,9 +50,14 @@ const setup = ({
   isStoreUser?: boolean;
   canAccessDbDetails?: boolean;
   databases?: Database[];
+  databasesError?: boolean;
 } = {}) => {
   setupUserMetabotPermissionsEndpoint();
-  setupDatabaseListEndpoint(databases);
+  if (databasesError) {
+    fetchMock.get("path:/api/database", 500);
+  } else {
+    setupDatabaseListEndpoint(databases);
+  }
 
   const storeUserEmail = "store-user@example.com";
   const currentUser = createMockUser({ is_superuser: isAdmin });
@@ -67,7 +81,6 @@ const setup = ({
   });
   const settings = mockSettings(settingsValues);
 
-  setupDatabaseListEndpoint([]);
   setupPropertiesEndpoints(settingsValues);
 
   if (isHosted || hasTransformFeature) {
@@ -80,7 +93,9 @@ const setup = ({
     <Route
       path={path}
       component={() => (
-        <TransformsSectionLayout>List of transforms</TransformsSectionLayout>
+        <TransformsSectionLayout>
+          <div>List of transforms</div>
+        </TransformsSectionLayout>
       )}
     />,
     {
@@ -114,7 +129,9 @@ describe("TransformSectionLayout", () => {
     it("should show allow you into transforms if transforms are enabled and writable databases exist", async () => {
       setup({
         transformsEnabled: true,
-        databases: [createMockDatabase({ transforms_permissions: "write" })],
+        databases: [
+          createTransformSupportedDatabase({ transforms_permissions: "write" }),
+        ],
       });
 
       await assertInApp();
@@ -131,7 +148,9 @@ describe("TransformSectionLayout", () => {
       setup({
         hasTransformFeature: true,
         transformsEnabled: true,
-        databases: [createMockDatabase({ transforms_permissions: "write" })],
+        databases: [
+          createTransformSupportedDatabase({ transforms_permissions: "write" }),
+        ],
       });
       await assertInApp();
     });
@@ -157,7 +176,9 @@ describe("TransformSectionLayout", () => {
       setup({
         isHosted: true,
         hasTransformFeature: true,
-        databases: [createMockDatabase({ transforms_permissions: "write" })],
+        databases: [
+          createTransformSupportedDatabase({ transforms_permissions: "write" }),
+        ],
       });
       await assertInApp();
     });
@@ -241,6 +262,20 @@ describe("TransformSectionLayout", () => {
         screen.queryByRole("link", {
           name: "View your database connections",
         }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("should show an error UI (not the empty state) when the databases request fails", async () => {
+      setup({
+        transformsEnabled: true,
+        databasesError: true,
+      });
+
+      expect(await screen.findByText(/error/i)).toBeInTheDocument();
+      expect(
+        screen.queryByText(
+          "To use transforms, you need a writable database connection",
+        ),
       ).not.toBeInTheDocument();
     });
   });

--- a/frontend/src/metabase/transforms/hooks/use-transform-permissions.ts
+++ b/frontend/src/metabase/transforms/hooks/use-transform-permissions.ts
@@ -3,7 +3,7 @@ import { useMemo } from "react";
 import { useListDatabasesQuery } from "metabase/api/database";
 import type { Database, Transform } from "metabase-types/api";
 
-import { sourceDatabaseId } from "../utils";
+import { doesDatabaseSupportTransforms, sourceDatabaseId } from "../utils";
 
 export const canEditTransform = (
   transform: Transform,
@@ -25,7 +25,11 @@ export const useTransformPermissions = ({
   } = useListDatabasesQuery({ include_analytics: true });
 
   const transformsDatabases = useMemo(() => {
-    return databases?.data.filter((d) => d.transforms_permissions === "write");
+    return databases?.data.filter(
+      (d) =>
+        d.transforms_permissions === "write" &&
+        doesDatabaseSupportTransforms(d),
+    );
   }, [databases]);
 
   const readOnly = useMemo(() => {

--- a/frontend/src/metabase/transforms/hooks/use-transform-permissions.ts
+++ b/frontend/src/metabase/transforms/hooks/use-transform-permissions.ts
@@ -3,7 +3,7 @@ import { useMemo } from "react";
 import { useListDatabasesQuery } from "metabase/api/database";
 import type { Database, Transform } from "metabase-types/api";
 
-import { doesDatabaseSupportTransforms, sourceDatabaseId } from "../utils";
+import { sourceDatabaseId } from "../utils";
 
 export const canEditTransform = (
   transform: Transform,
@@ -25,11 +25,7 @@ export const useTransformPermissions = ({
   } = useListDatabasesQuery({ include_analytics: true });
 
   const transformsDatabases = useMemo(() => {
-    return databases?.data.filter(
-      (d) =>
-        d.transforms_permissions === "write" &&
-        doesDatabaseSupportTransforms(d),
-    );
+    return databases?.data.filter((d) => d.transforms_permissions === "write");
   }, [databases]);
 
   const readOnly = useMemo(() => {

--- a/frontend/src/metabase/transforms/hooks/use-transform-supported-dbs.ts
+++ b/frontend/src/metabase/transforms/hooks/use-transform-supported-dbs.ts
@@ -1,0 +1,23 @@
+import { useMemo } from "react";
+
+import { useListDatabasesQuery } from "metabase/api/database";
+
+import { doesDatabaseSupportTransforms } from "../utils";
+
+export const useTransformSupportedDbs = () => {
+  const {
+    data: databases,
+    isLoading: isLoadingDatabases,
+    error: databasesError,
+  } = useListDatabasesQuery();
+
+  const transformsDatabases = useMemo(() => {
+    return databases?.data.filter((d) => doesDatabaseSupportTransforms(d));
+  }, [databases]);
+
+  return {
+    transformsDatabases,
+    isLoadingDatabases,
+    databasesError,
+  };
+};

--- a/frontend/src/metabase/transforms/pages/NoWritableDatabasesEmptyState/NoWritableDatabasesEmptyState.tsx
+++ b/frontend/src/metabase/transforms/pages/NoWritableDatabasesEmptyState/NoWritableDatabasesEmptyState.tsx
@@ -4,13 +4,16 @@ import { t } from "ttag";
 import { DataStudioBreadcrumbs } from "metabase/data-studio/common/components/DataStudioBreadcrumbs";
 import { PageContainer } from "metabase/data-studio/common/components/PageContainer";
 import { PaneHeader } from "metabase/data-studio/common/components/PaneHeader";
-import { getUserIsAdmin } from "metabase/selectors/user";
+import { getUser, getUserIsAdmin } from "metabase/selectors/user";
 import { Button, Center, Icon, Stack, Text, Title } from "metabase/ui";
 import { useSelector } from "metabase/utils/redux";
 import * as Urls from "metabase/utils/urls";
 
 export function NoWritableDatabasesEmptyState() {
   const isAdmin = useSelector(getUserIsAdmin);
+  const user = useSelector(getUser);
+  const canAccessDatabases =
+    isAdmin || user?.permissions?.can_access_db_details;
 
   return (
     <PageContainer data-testid="no-writable-databases-empty-state">
@@ -29,7 +32,7 @@ export function NoWritableDatabasesEmptyState() {
           <Text ta="center" c="text-secondary">
             {t`None of your connected databases have a writable connection. Either edit the connection on the database you want to enable transforms on, or connect to a different database.`}
           </Text>
-          {isAdmin && (
+          {canAccessDatabases && (
             <Button
               component={Link}
               to={Urls.viewDatabases()}

--- a/frontend/src/metabase/transforms/pages/NoWritableDatabasesEmptyState/NoWritableDatabasesEmptyState.tsx
+++ b/frontend/src/metabase/transforms/pages/NoWritableDatabasesEmptyState/NoWritableDatabasesEmptyState.tsx
@@ -1,0 +1,43 @@
+import { Link } from "react-router";
+import { t } from "ttag";
+
+import { DataStudioBreadcrumbs } from "metabase/data-studio/common/components/DataStudioBreadcrumbs";
+import { PageContainer } from "metabase/data-studio/common/components/PageContainer";
+import { PaneHeader } from "metabase/data-studio/common/components/PaneHeader";
+import { getUserIsAdmin } from "metabase/selectors/user";
+import { Button, Center, Icon, Stack, Text, Title } from "metabase/ui";
+import { useSelector } from "metabase/utils/redux";
+import * as Urls from "metabase/utils/urls";
+
+export function NoWritableDatabasesEmptyState() {
+  const isAdmin = useSelector(getUserIsAdmin);
+
+  return (
+    <PageContainer data-testid="no-writable-databases-empty-state">
+      <PaneHeader
+        breadcrumbs={
+          <DataStudioBreadcrumbs>{t`Transforms`}</DataStudioBreadcrumbs>
+        }
+      />
+      <Center flex={1}>
+        <Stack align="center" maw="30rem" gap="md">
+          <Icon name="database" size={48} c="text-tertiary" />
+          <Title
+            order={3}
+            ta="center"
+          >{t`To use transforms, you need a writable database connection`}</Title>
+          <Text ta="center" c="text-secondary">
+            {t`None of your connected databases have a writable connection. Either edit the connection on the database you want to enable transforms on, or connect to a different database.`}
+          </Text>
+          {isAdmin && (
+            <Button
+              component={Link}
+              to={Urls.viewDatabases()}
+              variant="filled"
+            >{t`View your database connections`}</Button>
+          )}
+        </Stack>
+      </Center>
+    </PageContainer>
+  );
+}

--- a/frontend/src/metabase/transforms/pages/NoWritableDatabasesEmptyState/NoWritableDatabasesEmptyState.tsx
+++ b/frontend/src/metabase/transforms/pages/NoWritableDatabasesEmptyState/NoWritableDatabasesEmptyState.tsx
@@ -4,10 +4,10 @@ import { t } from "ttag";
 import { DataStudioBreadcrumbs } from "metabase/data-studio/common/components/DataStudioBreadcrumbs";
 import { PageContainer } from "metabase/data-studio/common/components/PageContainer";
 import { PaneHeader } from "metabase/data-studio/common/components/PaneHeader";
+import { useSelector } from "metabase/redux";
 import { getUser, getUserIsAdmin } from "metabase/selectors/user";
 import { Button, Center, Icon, Stack, Text, Title } from "metabase/ui";
-import { useSelector } from "metabase/utils/redux";
-import * as Urls from "metabase/utils/urls";
+import * as Urls from "metabase/urls";
 
 export function NoWritableDatabasesEmptyState() {
   const isAdmin = useSelector(getUserIsAdmin);

--- a/frontend/src/metabase/transforms/pages/NoWritableDatabasesEmptyState/index.ts
+++ b/frontend/src/metabase/transforms/pages/NoWritableDatabasesEmptyState/index.ts
@@ -1,0 +1,1 @@
+export { NoWritableDatabasesEmptyState } from "./NoWritableDatabasesEmptyState";


### PR DESCRIPTION
Closes UXW-3017

### Description
Adds a new state for the transform pages to inform users if they don't have any writable DBs. Also updates the useTransformPermissions hook to add  a check for isValidTransformDatabase.

### How to verify
1. Set up an instance that has transforms enabled, but no databases that you can write to (you can simulate this by enabling DB routing on databases)
2. The transform pages should now show you a page explaining the situation with a link to the databases page.
3. If you're not an admin, or you don't have a manage database permission, you should not see that link

### Demo

<img width="1395" height="933" alt="image" src="https://github.com/user-attachments/assets/77706d2d-4dcd-4067-9a78-240e2c7dc005" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
