### PR TITLE
add analytics events for custom viz plugin

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/custom-viz.cy.spec.ts
+++ b/e2e/test/scenarios/visualizations-charts/custom-viz.cy.spec.ts
@@ -107,6 +107,8 @@ describe("admin > custom visualizations", () => {
     });
 
     it("should add a plugin via the form and show it in the list", () => {
+      H.resetSnowplow();
+      H.enableTracking();
       H.setupCustomVizRepo();
       H.visitCustomVizSettings();
 
@@ -124,6 +126,11 @@ describe("admin > custom visualizations", () => {
 
       // Should redirect to list and show the plugin
       H.main().findByText("demo-viz").should("be.visible");
+      H.expectUnstructuredSnowplowEvent({
+        event: "custom_viz_plugin_created",
+        result: "success",
+      });
+      H.expectNoBadSnowplowEvents();
     });
 
     it("should display manifest information and commit SHA after registration", () => {
@@ -235,6 +242,8 @@ describe("admin > custom visualizations", () => {
       });
 
       it("should update commit after refetch", () => {
+        H.resetSnowplow();
+        H.enableTracking();
         H.setupCustomVizPlugin().then((plugin: CustomVizPlugin) => {
           const initialCommit = plugin.resolved_commit;
           if (initialCommit == null) {
@@ -276,10 +285,16 @@ describe("admin > custom visualizations", () => {
               .findByText(new RegExp(`Commit: ${newCommit.slice(0, 8)}`))
               .should("be.visible");
           });
+          H.expectUnstructuredSnowplowEvent({
+            event: "custom_viz_plugin_refreshed",
+          });
+          H.expectNoBadSnowplowEvents();
         });
       });
 
       it("should update pinned version via edit form", () => {
+        H.resetSnowplow();
+        H.enableTracking();
         H.setupCustomVizPlugin().then((plugin: CustomVizPlugin) => {
           H.visitCustomVizEditForm(plugin.id);
 
@@ -294,6 +309,10 @@ describe("admin > custom visualizations", () => {
 
           cy.wait("@pluginUpdate").then(({ request }) => {
             expect(request.body.pinned_version).to.equal("main");
+          });
+          H.expectUnstructuredSnowplowEvent({
+            event: "custom_viz_plugin_updated",
+            result: "success",
           });
 
           const invalidPinnedVersion = "definitely-not-a-real-ref-zzz";
@@ -328,6 +347,7 @@ describe("admin > custom visualizations", () => {
             "have.value",
             invalidPinnedVersion,
           );
+          H.expectNoBadSnowplowEvents();
         });
       });
     });
@@ -338,6 +358,8 @@ describe("admin > custom visualizations", () => {
       });
 
       it("disabled plugin should fall back to default display and hide from chart type selector", () => {
+        H.resetSnowplow();
+        H.enableTracking();
         H.setupCustomVizPlugin().then(() => {
           // Single-value question (Count of Orders) — demo-viz requires
           // exactly one row with one numeric column.
@@ -361,6 +383,10 @@ describe("admin > custom visualizations", () => {
           H.main().findByText("demo-viz").realHover();
           cy.findByRole("button", { name: "Plugin actions" }).click();
           H.popover().findByText("Disable").click();
+          H.expectUnstructuredSnowplowEvent({
+            event: "custom_viz_plugin_toggled",
+            event_detail: "disabled",
+          });
 
           // Menu should now show "Enable" instead of "Disable"
           H.main().findByText("demo-viz").realHover();
@@ -374,6 +400,7 @@ describe("admin > custom visualizations", () => {
           // Custom viz section should not appear in chart type selector
           cy.findByTestId("viz-type-button").click();
           cy.findByText("Custom visualizations").should("not.exist");
+          H.expectNoBadSnowplowEvents();
         });
       });
     });
@@ -384,6 +411,8 @@ describe("admin > custom visualizations", () => {
       });
 
       it("question should fall back when plugin is deleted", () => {
+        H.resetSnowplow();
+        H.enableTracking();
         H.setupCustomVizPlugin().then(() => {
           H.createQuestion(
             {
@@ -407,6 +436,9 @@ describe("admin > custom visualizations", () => {
           H.main()
             .findByText("You don't have any custom visualizations.")
             .should("be.visible");
+          H.expectUnstructuredSnowplowEvent({
+            event: "custom_viz_plugin_deleted",
+          });
 
           // Visit the question — should fall back to table
           H.visitQuestion("@deleteCardId");
@@ -415,6 +447,7 @@ describe("admin > custom visualizations", () => {
           // Custom viz section should not appear in chart type selector
           cy.findByTestId("viz-type-button").click();
           cy.findByText("Custom visualizations").should("not.exist");
+          H.expectNoBadSnowplowEvents();
         });
       });
     });
@@ -455,6 +488,8 @@ describe("admin > custom visualizations", () => {
     }
 
     it("renders the selected custom viz for the question", () => {
+      H.resetSnowplow();
+      H.enableTracking();
       H.visitQuestion("@questionId");
       switchToDemoViz();
 
@@ -466,6 +501,8 @@ describe("admin > custom visualizations", () => {
         .should("be.visible");
       // Default threshold from getDefault
       H.main().findByText("Threshold: 0").should("be.visible");
+      H.expectUnstructuredSnowplowEvent({ event: "custom_viz_selected" });
+      H.expectNoBadSnowplowEvents();
     });
 
     it("persists the selected custom viz and its settings across reloads", () => {

--- a/enterprise/frontend/src/metabase-enterprise/custom_viz/analytics.ts
+++ b/enterprise/frontend/src/metabase-enterprise/custom_viz/analytics.ts
@@ -1,0 +1,27 @@
+import { trackSimpleEvent } from "metabase/utils/analytics";
+
+export const trackCustomVizPluginCreated = (result: "success" | "failure") => {
+  trackSimpleEvent({ event: "custom_viz_plugin_created", result });
+};
+
+export const trackCustomVizPluginUpdated = (result: "success" | "failure") => {
+  trackSimpleEvent({ event: "custom_viz_plugin_updated", result });
+};
+
+export const trackCustomVizPluginDeleted = () => {
+  trackSimpleEvent({ event: "custom_viz_plugin_deleted" });
+};
+
+export const trackCustomVizPluginToggled = (
+  event_detail: "enabled" | "disabled",
+) => {
+  trackSimpleEvent({ event: "custom_viz_plugin_toggled", event_detail });
+};
+
+export const trackCustomVizPluginRefreshed = () => {
+  trackSimpleEvent({ event: "custom_viz_plugin_refreshed" });
+};
+
+export const trackCustomVizSelected = () => {
+  trackSimpleEvent({ event: "custom_viz_selected" });
+};

--- a/enterprise/frontend/src/metabase-enterprise/custom_viz/components/CustomVizListItem.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/custom_viz/components/CustomVizListItem.tsx
@@ -19,6 +19,11 @@ import {
 } from "metabase-enterprise/api";
 import type { CustomVizPlugin, CustomVizPluginId } from "metabase-types/api";
 
+import {
+  trackCustomVizPluginRefreshed,
+  trackCustomVizPluginToggled,
+} from "../analytics";
+
 import { CustomVizIcon } from "./CustomVizIcon";
 import S from "./CustomVizListItem.module.css";
 
@@ -44,10 +49,12 @@ export function CustomVizListItem({ plugin, onDelete }: Props) {
 
   const handleToggleEnabled = useCallback(async () => {
     await updatePlugin({ id: plugin.id, enabled: !plugin.enabled });
+    trackCustomVizPluginToggled(plugin.enabled ? "disabled" : "enabled");
   }, [plugin.id, plugin.enabled, updatePlugin]);
 
   const handleRefresh = useCallback(async () => {
     await refreshPlugin(plugin.id);
+    trackCustomVizPluginRefreshed();
   }, [plugin.id, refreshPlugin]);
 
   return (

--- a/enterprise/frontend/src/metabase-enterprise/custom_viz/components/CustomVizPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/custom_viz/components/CustomVizPage.tsx
@@ -24,6 +24,11 @@ import {
   useUpdateCustomVizPluginMutation,
 } from "metabase-enterprise/api";
 
+import {
+  trackCustomVizPluginCreated,
+  trackCustomVizPluginUpdated,
+} from "../analytics";
+
 type Props = {
   params?: {
     id?: string;
@@ -73,17 +78,29 @@ export function CustomVizPage({ params }: Props) {
   const handleSubmit = useCallback(
     async (values: FormState) => {
       if (isEdit && plugin) {
-        await updatePlugin({
-          id: plugin.id,
-          access_token: values.accessToken || undefined,
-          pinned_version: values.pinnedVersion || null,
-        }).unwrap();
+        try {
+          await updatePlugin({
+            id: plugin.id,
+            access_token: values.accessToken || undefined,
+            pinned_version: values.pinnedVersion || null,
+          }).unwrap();
+          trackCustomVizPluginUpdated("success");
+        } catch (error) {
+          trackCustomVizPluginUpdated("failure");
+          throw error;
+        }
       } else {
-        await createPlugin({
-          repo_url: values.repoUrl,
-          access_token: values.accessToken || undefined,
-          pinned_version: values.pinnedVersion || null,
-        }).unwrap();
+        try {
+          await createPlugin({
+            repo_url: values.repoUrl,
+            access_token: values.accessToken || undefined,
+            pinned_version: values.pinnedVersion || null,
+          }).unwrap();
+          trackCustomVizPluginCreated("success");
+        } catch (error) {
+          trackCustomVizPluginCreated("failure");
+          throw error;
+        }
       }
       dispatch(push(Urls.customViz()));
     },

--- a/enterprise/frontend/src/metabase-enterprise/custom_viz/components/ManageCustomVizPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/custom_viz/components/ManageCustomVizPage.tsx
@@ -11,6 +11,8 @@ import {
 } from "metabase-enterprise/api";
 import type { CustomVizPluginId } from "metabase-types/api";
 
+import { trackCustomVizPluginDeleted } from "../analytics";
+
 import { CustomVizListItem } from "./CustomVizListItem";
 import S from "./ManageCustomVizPage.module.css";
 
@@ -26,6 +28,7 @@ export function ManageCustomVizPage() {
   const handleDelete = useCallback(
     async (id: CustomVizPluginId) => {
       await deletePlugin(id).unwrap();
+      trackCustomVizPluginDeleted();
     },
     [deletePlugin],
   );

--- a/enterprise/frontend/src/metabase-enterprise/custom_viz/custom-viz-plugins.ts
+++ b/enterprise/frontend/src/metabase-enterprise/custom_viz/custom-viz-plugins.ts
@@ -31,6 +31,7 @@ import type {
 } from "metabase-types/api";
 import { isCustomVizDisplay } from "metabase-types/guards/visualization";
 
+import { trackCustomVizSelected } from "./analytics";
 import { applyDefaultVisualizationProps } from "./custom-viz-common";
 import { ensureVizApi } from "./custom-viz-globals";
 
@@ -178,6 +179,7 @@ export function useAutoLoadCustomVizPlugin(display: string | undefined): {
     if (!plugin) {
       return;
     }
+    trackCustomVizSelected();
     load(plugin);
   }, [display, plugins, load]);
 

--- a/frontend/src/metabase-types/analytics/event.ts
+++ b/frontend/src/metabase-types/analytics/event.ts
@@ -6,3 +6,43 @@ export type SimpleEventSchema = {
   result?: string | null;
   event_detail?: string | null;
 };
+
+type ValidateEvent<
+  T extends SimpleEventSchema &
+    Record<Exclude<keyof T, keyof SimpleEventSchema>, never>,
+> = T;
+
+export type CustomVizPluginCreatedEvent = ValidateEvent<{
+  event: "custom_viz_plugin_created";
+  result: "success" | "failure";
+}>;
+
+export type CustomVizPluginUpdatedEvent = ValidateEvent<{
+  event: "custom_viz_plugin_updated";
+  result: "success" | "failure";
+}>;
+
+export type CustomVizPluginDeletedEvent = ValidateEvent<{
+  event: "custom_viz_plugin_deleted";
+}>;
+
+export type CustomVizPluginToggledEvent = ValidateEvent<{
+  event: "custom_viz_plugin_toggled";
+  event_detail: "enabled" | "disabled";
+}>;
+
+export type CustomVizPluginRefreshedEvent = ValidateEvent<{
+  event: "custom_viz_plugin_refreshed";
+}>;
+
+export type CustomVizSelectedEvent = ValidateEvent<{
+  event: "custom_viz_selected";
+}>;
+
+export type CustomVizEvent =
+  | CustomVizPluginCreatedEvent
+  | CustomVizPluginUpdatedEvent
+  | CustomVizPluginDeletedEvent
+  | CustomVizPluginToggledEvent
+  | CustomVizPluginRefreshedEvent
+  | CustomVizSelectedEvent;


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-2308/snowplow-tracking

### Description

Added new events

```
   export type CustomVizEvent =
     | CustomVizPluginCreatedEvent
     | CustomVizPluginUpdatedEvent
     | CustomVizPluginDeletedEvent
     | CustomVizPluginToggledEvent
     | CustomVizPluginRefreshedEvent
     | CustomVizSelectedEvent;
```


### How to verify

Follow the assertions added to e2e tests

### Demo

<img width="1894" height="1086" alt="image" src="https://github.com/user-attachments/assets/bcd8641d-1c1c-495d-8147-5eacc73724e9" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
