### PR TITLE
Fix admin > people pagination race conditions

### DIFF
--- a/e2e/test/scenarios/admin-2/people.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/people.cy.spec.js
@@ -549,41 +549,50 @@ describe("scenarios > admin > people", () => {
       beforeEach(() => {
         generateUsers(NEW_USERS);
 
-        cy.intercept("GET", "/api/user*").as("users");
+        cy.intercept("GET", "/api/user?query*").as("users");
         cy.intercept("GET", "/api/permissions/membership").as("memberships");
       });
 
       it("should allow paginating people forward and backward", () => {
         const PAGE_SIZE = 25;
 
+        const footer = () =>
+          cy
+            .findByTestId("people-list-footer")
+            .scrollIntoView()
+            .should("be.visible");
+
         cy.visit("/admin/people");
-
-        // Total
-        // eslint-disable-next-line metabase/no-unscoped-text-selectors -- deprecated usage
-        cy.findByText(`${NEW_TOTAL_USERS} people found`);
-
-        // Page 1
-        // eslint-disable-next-line metabase/no-unscoped-text-selectors -- deprecated usage
-        cy.findByText(`1 - ${PAGE_SIZE}`);
-        assertTableRowsCount(PAGE_SIZE);
-        cy.findByLabelText("Previous page").should("be.disabled");
-
-        cy.findByTestId("next-page-btn").click();
+        cy.findByTestId("admin-panel")
+          .findByText("Loading...")
+          .should("not.exist");
         cy.wait("@users");
 
-        // Page 2
-        cy.findByTestId("people-list-footer")
-          .findByText(`${PAGE_SIZE + 1} - ${NEW_TOTAL_USERS}`)
-          .should("be.visible");
-        assertTableRowsCount(NEW_TOTAL_USERS % PAGE_SIZE);
-        cy.findByLabelText("Next page").should("be.disabled");
-
-        cy.findByLabelText("Previous page").click();
-
-        // Page 1
-        // eslint-disable-next-line metabase/no-unscoped-text-selectors -- deprecated usage
-        cy.findByText(`1 - ${PAGE_SIZE}`);
+        cy.log("Page 1");
         assertTableRowsCount(PAGE_SIZE);
+        footer()
+          .should("contain", `${NEW_TOTAL_USERS} people found`)
+          .and("contain", `1 - ${PAGE_SIZE}`);
+
+        footer().within(() => {
+          cy.findByLabelText("Previous page").should("be.disabled");
+
+          cy.findByLabelText("Next page").click();
+          cy.wait("@users");
+        });
+
+        cy.log("Page 2");
+        assertTableRowsCount(NEW_TOTAL_USERS % PAGE_SIZE);
+        footer().should("contain", `${PAGE_SIZE + 1} - ${NEW_TOTAL_USERS}`);
+
+        cy.log("Back to the Page 1");
+        footer().within(() => {
+          cy.findByLabelText("Next page").should("be.disabled");
+          cy.findByLabelText("Previous page").click();
+        });
+
+        assertTableRowsCount(PAGE_SIZE);
+        footer().should("contain", `1 - ${PAGE_SIZE}`);
       });
 
       it("should allow paginating group members forward and backward", () => {

--- a/frontend/src/metabase/admin/people/containers/PeopleListingApp/PeopleListingApp.tsx
+++ b/frontend/src/metabase/admin/people/containers/PeopleListingApp/PeopleListingApp.tsx
@@ -82,11 +82,14 @@ export function PeopleListingApp({
     }
   };
 
+  // Only reset status if it actually needs changing. Calling `updateStatus`
+  // unconditionally triggers `setPage(0)`, which races any in-flight
+  // pagination clicks when this effect re-fires on query resolution.
   useEffect(() => {
-    if (!hasDeactivatedUsers) {
-      updateStatus("active");
+    if (!hasDeactivatedUsers && status !== ACTIVE_STATUS.active) {
+      updateStatus(ACTIVE_STATUS.active);
     }
-  }, [hasDeactivatedUsers, updateStatus]);
+  }, [hasDeactivatedUsers, status, updateStatus]);
 
   const pageTitle = useMemo(() => {
     if (!isUsingTenants) {

--- a/frontend/src/metabase/admin/people/hooks/use-people-query.ts
+++ b/frontend/src/metabase/admin/people/hooks/use-people-query.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { usePagination } from "metabase/common/hooks/use-pagination";
 import { SEARCH_DEBOUNCE_DURATION } from "metabase/utils/constants";
@@ -20,7 +20,17 @@ export const usePeopleQuery = (pageSize: number, tenancy: UserTenancy) => {
 
   const [searchText, setSearchText] = useState("");
 
+  // Skip the mount-fire of this effect. Otherwise its trailing `setPage(0)`
+  // races any pagination clicks that land within SEARCH_DEBOUNCE_DURATION
+  // of mount and silently snaps the user back to page 0.
+  const isInitialMountRef = useRef(true);
+
   useEffect(() => {
+    if (isInitialMountRef.current) {
+      isInitialMountRef.current = false;
+      return;
+    }
+
     const timerId = setTimeout(() => {
       const searchText =
         searchInputValue.length >= MIN_SEARCH_LENGTH ? searchInputValue : "";

--- a/frontend/src/metabase/common/hooks/use-pagination.ts
+++ b/frontend/src/metabase/common/hooks/use-pagination.ts
@@ -8,7 +8,7 @@ export const usePagination = (initialPage = 0) => {
     [setPage],
   );
   const handlePreviousPage = useCallback(
-    () => setPage((prev) => prev - 1),
+    () => setPage((prev) => Math.max(0, prev - 1)),
     [setPage],
   );
 

--- a/frontend/src/metabase/common/hooks/use-pagination.unit.spec.ts
+++ b/frontend/src/metabase/common/hooks/use-pagination.unit.spec.ts
@@ -13,4 +13,19 @@ describe("usePagination", () => {
     act(() => result.current.resetPage());
     expect(result.current.page).toEqual(initialPage);
   });
+
+  // Defensive floor guard: the UI normally disables "Previous" on page 0, but
+  // fast/automated interactions can fire a click before the disabled state
+  // lands, which previously sent offset=-pageSize to the backend. See DEV-1835.
+  it("should not decrement 'page' below 0 when 'handlePreviousPage' is called on page 0", () => {
+    const { result } = renderHook(() => usePagination());
+
+    expect(result.current.page).toEqual(0);
+
+    act(() => result.current.handlePreviousPage());
+    expect(result.current.page).toEqual(0);
+
+    act(() => result.current.handlePreviousPage());
+    expect(result.current.page).toEqual(0);
+  });
 });


### PR DESCRIPTION
Resolves DEV-1834
Resolves DEV-1835

## Summary

Fix two mount-time `setPage(0)` races in the admin people page that could wipe a pagination click landing within the first ~300ms of mount. Also clamp `handlePreviousPage` so it can't decrement below 0.

  - `usePeopleQuery`: the debounced search effect armed a 300ms timer on mount whose
  trailing `setPage(0)` would overwrite any early pagination. Skip the mount-fire.
  - `PeopleListingApp`: the "force status to active" effect called `updateStatus` (which
  resets page) even when status was already active. Only fire when it actually needs to
  change.
  - `usePagination`: `handlePreviousPage` had no floor guard, letting rapid clicks near
  page 0 send `offset=-pageSize` and 500 the backend. Clamp to 0.

Bug predates tenants by 4 years (2021) but got much easier to hit recently as more mount-time queries widened the race window.
