### PR TITLE
Add cursor deeplink button in admin UI for MCP setup

### DIFF
--- a/e2e/test/scenarios/metabot/mcp-apps-settings.cy.spec.ts
+++ b/e2e/test/scenarios/metabot/mcp-apps-settings.cy.spec.ts
@@ -1,0 +1,55 @@
+const { H } = cy;
+
+describe("admin > MCP apps settings > Cursor install link", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+  });
+
+  it("shows 'Install in Cursor' link only when the Cursor and VS Code switch is enabled", () => {
+    cy.visit("/admin/metabot");
+
+    H.main().within(() => {
+      cy.findByText("Supported MCP clients").scrollIntoView();
+
+      cy.log("link is hidden by default");
+      cy.findByRole("link", { name: "Install in Cursor" }).should("not.exist");
+
+      cy.log("enable Cursor and VS Code");
+      cy.findByRole("switch", { name: /cursor and vs code/i }).click({
+        force: true,
+      });
+
+      cy.log("link appears with a valid Cursor deeplink");
+      cy.findByRole("link", { name: "Install in Cursor" })
+        .should("be.visible")
+        .invoke("attr", "href")
+        .should((href) => {
+          expect(href).to.be.a("string");
+          expect(href).to.match(
+            /^cursor:\/\/anysphere\.cursor-deeplink\/mcp\/install\?/,
+          );
+
+          const query = (href as string).split("?", 2)[1];
+          const params = new URLSearchParams(query);
+
+          expect(params.get("name")).to.eq("Metabase");
+          const config = params.get("config");
+
+          expect(config).to.be.a("string");
+
+          const decoded = JSON.parse(atob(config as string));
+
+          expect(decoded.url).to.eq(`${Cypress.config("baseUrl")}/api/mcp`);
+        });
+
+      cy.log("disable Cursor and VS Code");
+      cy.findByRole("switch", { name: /cursor and vs code/i }).click({
+        force: true,
+      });
+
+      cy.log("link is hidden again");
+      cy.findByRole("link", { name: "Install in Cursor" }).should("not.exist");
+    });
+  });
+});

--- a/frontend/src/metabase/metabot/components/MetabotAdmin/CursorInstallLink.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotAdmin/CursorInstallLink.tsx
@@ -1,0 +1,38 @@
+import { t } from "ttag";
+
+import { Anchor } from "metabase/ui";
+
+import { useMCPServerURL } from "./utils";
+
+const CURSOR_DEEPLINK = {
+  url: "cursor://anysphere.cursor-deeplink/mcp/install",
+  // eslint-disable-next-line metabase/no-literal-metabase-strings -- Cursor MCP registration name, not user-facing
+  mcpName: "Metabase",
+} as const;
+
+function buildCursorInstallUrl(mcpUrl: string): string {
+  const params = new URLSearchParams({
+    name: CURSOR_DEEPLINK.mcpName,
+    config: window.btoa(JSON.stringify({ url: mcpUrl })),
+  });
+  return `${CURSOR_DEEPLINK.url}?${params.toString()}`;
+}
+
+export function CursorInstallLink() {
+  const mcpUrl = useMCPServerURL();
+
+  if (!mcpUrl) {
+    return null;
+  }
+
+  return (
+    <Anchor
+      href={buildCursorInstallUrl(mcpUrl)}
+      fz="sm"
+      w="fit-content"
+      onClick={(event) => event.stopPropagation()}
+    >
+      {t`Install in Cursor`}
+    </Anchor>
+  );
+}

--- a/frontend/src/metabase/metabot/components/MetabotAdmin/CursorInstallLink.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotAdmin/CursorInstallLink.tsx
@@ -10,15 +10,16 @@ const CURSOR_DEEPLINK = {
   mcpName: "Metabase",
 } as const;
 
-function buildCursorInstallUrl(mcpUrl: string): string {
+const buildCursorInstallUrl = (mcpUrl: string): string => {
   const params = new URLSearchParams({
     name: CURSOR_DEEPLINK.mcpName,
     config: window.btoa(JSON.stringify({ url: mcpUrl })),
   });
-  return `${CURSOR_DEEPLINK.url}?${params.toString()}`;
-}
 
-export function CursorInstallLink() {
+  return `${CURSOR_DEEPLINK.url}?${params.toString()}`;
+};
+
+export const CursorInstallLink = () => {
   const mcpUrl = useMCPServerURL();
 
   if (!mcpUrl) {
@@ -35,4 +36,4 @@ export function CursorInstallLink() {
       {t`Install in Cursor`}
     </Anchor>
   );
-}
+};

--- a/frontend/src/metabase/metabot/components/MetabotAdmin/McpAppsSettings.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotAdmin/McpAppsSettings.tsx
@@ -8,9 +8,10 @@ import { ExternalLink } from "metabase/common/components/ExternalLink";
 import { useDocsUrl } from "metabase/common/hooks";
 import { Box, Flex, Stack, Switch, Text, TextInput } from "metabase/ui";
 
+import { CursorInstallLink } from "./CursorInstallLink";
 import { McpServerUrlSection } from "./MCPServerUrlSection";
 
-const getMcpClients = () =>
+const getMcpClients = (enabledClients: string[]) =>
   [
     {
       key: "claude",
@@ -18,7 +19,13 @@ const getMcpClients = () =>
     },
     {
       key: "cursor-vscode",
-      label: t`Cursor and VS Code`,
+      label: (
+        <Stack gap="xs">
+          <span>{t`Cursor and VS Code`}</span>
+
+          {enabledClients.includes("cursor-vscode") && <CursorInstallLink />}
+        </Stack>
+      ),
     },
     {
       key: "chatgpt",
@@ -80,8 +87,6 @@ export const McpAppsSettings = ({ id }: { id?: string }) => {
 };
 
 function CommonMcpClientsSection() {
-  const mcpClients = getMcpClients();
-
   const { value: savedValue, updateSetting } = useAdminSetting(
     "mcp-apps-cors-enabled-clients",
   );
@@ -89,6 +94,8 @@ function CommonMcpClientsSection() {
   const [enabledClients, setEnabledClients] = useState<string[]>(
     savedValue ?? [],
   );
+
+  const mcpClients = getMcpClients(enabledClients);
 
   const handleToggle = useCallback(
     (clientKey: string, checked: boolean) => {


### PR DESCRIPTION
Add cursor deeplink button in admin UI for MCP setup.

Design:
<img width="2248" height="752" alt="image" src="https://github.com/user-attachments/assets/9c834a1d-fe27-48d0-93f6-e4eb2dc15ca3" />

In UI:
<img width="814" height="640" alt="image" src="https://github.com/user-attachments/assets/7f0d7dcf-d2d9-49fd-964e-092c2999bf6f" />

In Cursor:
<img width="1306" height="1226" alt="image" src="https://github.com/user-attachments/assets/5e67dfea-3541-4d4d-a7d5-bc5ab79ec32f" />


How to test:
- have Cursor on your machine
- locally run MB
- go to admin/ui
- scroll to the `Cursor and VS Code` switch and toggle it
- click the `Install in Cursor` link 
- it will open an new `Install MCP server`` configuration tab in Cursor
- click `install`
- click `connect` to authorize the MCP in Metabase Instance
- now you can ask Cursor things like `Search for the orders table in Metabase. Query it. Return the rows, or a filtered/paginated version if there are many.`