### PR TITLE
fix: pricing ui should reflect 1m free tokens

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot/api.clj
@@ -11,9 +11,9 @@
 
 (def ^:private metabot-usage-response-schema
   [:map
-   [:is-locked [:maybe boolean?]]
+   [:is_locked [:maybe boolean?]]
    [:tokens [:maybe int?]]
-   [:updated-at [:maybe :string]]])
+   [:updated_at [:maybe :string]]])
 
 (defn- meter-value
   [meters meter-key]
@@ -41,7 +41,7 @@
   (perms/check-has-application-permission :setting)
   (let [meter (some-> (premium-features/token-status)
                       meter-entry)]
-    {:is-locked   (:is-locked meter)
+    {:is_locked   (:is-locked meter)
      :tokens      (:meter-value meter)
-     :free-tokens (:meter-free-units meter)
-     :updated-at  (:meter-updated-at meter)}))
+     :free_tokens (:meter-free-units meter)
+     :updated_at  (:meter-updated-at meter)}))

--- a/enterprise/backend/src/metabase_enterprise/metabot/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot/api.clj
@@ -41,6 +41,7 @@
   (perms/check-has-application-permission :setting)
   (let [meter (some-> (premium-features/token-status)
                       meter-entry)]
-    {:is-locked  (:is-locked meter)
-     :tokens     (:meter-value meter)
-     :updated-at (:meter-updated-at meter)}))
+    {:is-locked   (:is-locked meter)
+     :tokens      (:meter-value meter)
+     :free-tokens (:meter-free-units meter)
+     :updated-at  (:meter-updated-at meter)}))

--- a/enterprise/backend/test/metabase_enterprise/metabot/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot/api_test.clj
@@ -48,9 +48,11 @@
 (deftest usage-get-returns-token-status-usage-test
   (mt/with-premium-features #{:metabot-v3}
     (with-redefs [premium-features/token-status (constantly {:meters {:anthropic:claude-sonnet-4-6:tokens {:meter-value      12345
+                                                                                                           :meter-free-units 1337
                                                                                                            :meter-updated-at "2026-04-02T19:29:12Z"}}})]
-      (is (= {:tokens 12345
-              :updated-at "2026-04-02T19:29:12Z"
+      (is (= {:tokens       12345
+              :free-tokens  1337
+              :updated-at   "2026-04-02T19:29:12Z"
               :is-locked nil}
              (mt/user-http-request :crowberto :get 200 "ee/metabot/usage"))))))
 

--- a/enterprise/backend/test/metabase_enterprise/metabot/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot/api_test.clj
@@ -51,10 +51,11 @@
                                                                                                            :meter-free-units 1337
                                                                                                            :meter-updated-at "2026-04-02T19:29:12Z"}}})]
       (is (= {:tokens       12345
-              :free-tokens  1337
-              :updated-at   "2026-04-02T19:29:12Z"
-              :is-locked nil}
-             (mt/user-http-request :crowberto :get 200 "ee/metabot/usage"))))))
+              :free_tokens  1337
+              :updated_at   "2026-04-02T19:29:12Z"
+              :is_locked    nil}
+             (-> (mt/user-http-request :crowberto :get 200 "ee/metabot/usage")
+                 (update :updated_at str)))))))
 
 (deftest usage-permissions-test
   (mt/with-premium-features #{:metabot-v3}

--- a/enterprise/frontend/src/metabase-enterprise/api/metabot.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/metabot.ts
@@ -2,6 +2,7 @@ import { EnterpriseApi } from "./api";
 
 export type MetabotUsageResponse = {
   tokens: number | null;
+  "free-tokens": number | null;
   "updated-at": string | null;
   "is-locked": boolean;
 };

--- a/enterprise/frontend/src/metabase-enterprise/api/metabot.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/metabot.ts
@@ -2,9 +2,9 @@ import { EnterpriseApi } from "./api";
 
 export type MetabotUsageResponse = {
   tokens: number | null;
-  "free-tokens": number | null;
-  "updated-at": string | null;
-  "is-locked": boolean;
+  free_tokens: number | null;
+  updated_at: string | null;
+  is_locked: boolean;
 };
 
 export const metabotApi = EnterpriseApi.injectEndpoints({

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabaseAIProviderSetup.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabaseAIProviderSetup.tsx
@@ -317,14 +317,14 @@ function MetabaseManagedProviderCard({
   handleDisconnect: VoidFunction;
 }) {
   const { data: metabotUsage } = useGetMetabotUsageQuery();
-  const isLocked = metabotUsage?.["is-locked"];
+  const isLocked = metabotUsage?.is_locked;
   const totalCost = getMetabaseUsageCost(metabotUsage, pricing);
   const [refreshTokenStatus] = useRefreshTokenStatusMutation();
   useEffect(() => {
     refreshTokenStatus();
   }, [refreshTokenStatus]);
 
-  const freeTokens = metabotUsage?.["free-tokens"] ?? 0;
+  const freeTokens = metabotUsage?.free_tokens ?? 0;
   const tokens = metabotUsage?.tokens ?? 0;
   const hasFreeTokens = freeTokens > 0 && tokens <= freeTokens;
 
@@ -511,7 +511,7 @@ export function getMetabaseUsageCost(
     return 0;
   }
 
-  const { tokens, "free-tokens": freeTokens } = usage;
+  const { tokens, free_tokens: freeTokens } = usage;
   if (!tokens) {
     return 0;
   }

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabaseAIProviderSetup.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabaseAIProviderSetup.tsx
@@ -1,8 +1,11 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { match } from "ts-pattern";
 import { jt, t } from "ttag";
 
-import { useUpdateMetabotSettingsMutation } from "metabase/api";
+import {
+  useRefreshTokenStatusMutation,
+  useUpdateMetabotSettingsMutation,
+} from "metabase/api";
 import { getErrorMessage } from "metabase/api/utils";
 import { useSetting } from "metabase/common/hooks";
 import { useMetabotSetupContext } from "metabase/metabot/components/MetabotAdmin/MetabotSetup";
@@ -314,7 +317,10 @@ function MetabaseManagedProviderCard({
 }) {
   const { data: metabotUsage } = useGetMetabotUsageQuery();
   const isLocked = metabotUsage?.["is-locked"];
-  const totalCost = getMetabaseUsageCost(metabotUsage?.tokens, pricing);
+  const totalCost = getMetabaseUsageCost(metabotUsage, pricing);
+  const [refreshTokenStatus] = useRefreshTokenStatusMutation();
+
+  useEffect(refreshTokenStatus, [refreshTokenStatus]);
 
   return (
     <Stack gap="md">

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabaseAIProviderSetup.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabaseAIProviderSetup.tsx
@@ -28,6 +28,7 @@ import {
 import { formatNumber } from "metabase/utils/formatting";
 import { useSelector } from "metabase/utils/redux";
 import {
+  type MetabotUsageResponse,
   useGetMetabotUsageQuery,
   useRemoveCloudAddOnMutation,
 } from "metabase-enterprise/api";
@@ -319,8 +320,13 @@ function MetabaseManagedProviderCard({
   const isLocked = metabotUsage?.["is-locked"];
   const totalCost = getMetabaseUsageCost(metabotUsage, pricing);
   const [refreshTokenStatus] = useRefreshTokenStatusMutation();
+  useEffect(() => {
+    refreshTokenStatus();
+  }, [refreshTokenStatus]);
 
-  useEffect(refreshTokenStatus, [refreshTokenStatus]);
+  const freeTokens = metabotUsage?.["free-tokens"] ?? 0;
+  const tokens = metabotUsage?.tokens ?? 0;
+  const hasFreeTokens = freeTokens > 0 && tokens <= freeTokens;
 
   return (
     <Stack gap="md">
@@ -335,6 +341,7 @@ function MetabaseManagedProviderCard({
       {match({
         hasMetabaseManagedAiProviderFeature,
         isLocked,
+        hasFreeTokens,
       })
         .with({ hasMetabaseManagedAiProviderFeature: false }, () => null)
         .with({ isLocked: true }, () => (
@@ -352,28 +359,56 @@ function MetabaseManagedProviderCard({
             />
           </Flex>
         ))
-        .otherwise(() => (
-          <>
-            <Text c="text-secondary" lh="1">{t`Current billing cycle`}</Text>
-            <MetabaseUsageRow
-              label={t`Total tokens`}
-              value={formatNumber(metabotUsage?.tokens ?? 0)}
-            />
-            {!isLoadingPricing && pricing ? (
-              <MetabasePricingRow pricing={pricing} />
-            ) : (
-              <Flex align="center" justify="space-between" gap="md">
-                <Skeleton h="1rem" w="7rem" />
-                <Box flex={1} h={1} bg="border" />
-                <Skeleton h="1rem" w="8rem" />
-              </Flex>
-            )}
-            <MetabaseUsageRow
-              label={t`Total cost`}
-              value={formatMetabaseCost(totalCost)}
-            />
-          </>
-        ))}
+        .with(
+          { hasMetabaseManagedAiProviderFeature: true, hasFreeTokens: true },
+          () => (
+            <>
+              <Text c="text-secondary" lh="1">{t`Included use`}</Text>
+              <MetabaseUsageRow
+                label={t`Free trial tokens`}
+                value={`${formatNumber(tokens)} / ${formatNumber(freeTokens)}`}
+              />
+              {!isLoadingPricing && pricing ? (
+                <MetabasePricingRow
+                  pricing={pricing}
+                  label={t`Price per token afterward`}
+                />
+              ) : (
+                <Flex align="center" justify="space-between" gap="md">
+                  <Skeleton h="1rem" w="7rem" />
+                  <Box flex={1} h={1} bg="border" />
+                  <Skeleton h="1rem" w="8rem" />
+                </Flex>
+              )}
+            </>
+          ),
+        )
+        .with(
+          { hasMetabaseManagedAiProviderFeature: true, hasFreeTokens: false },
+          () => (
+            <>
+              <Text c="text-secondary" lh="1">{t`Current billing cycle`}</Text>
+              <MetabaseUsageRow
+                label={t`Total tokens`}
+                value={formatNumber(tokens)}
+              />
+              {!isLoadingPricing && pricing ? (
+                <MetabasePricingRow pricing={pricing} />
+              ) : (
+                <Flex align="center" justify="space-between" gap="md">
+                  <Skeleton h="1rem" w="7rem" />
+                  <Box flex={1} h={1} bg="border" />
+                  <Skeleton h="1rem" w="8rem" />
+                </Flex>
+              )}
+              <MetabaseUsageRow
+                label={t`Total cost`}
+                value={formatMetabaseCost(totalCost)}
+              />
+            </>
+          ),
+        )
+        .exhaustive()}
     </Stack>
   );
 }
@@ -398,15 +433,17 @@ function MetabaseUsageRow({ label, value }: { label: string; value: string }) {
 }
 
 function MetabasePricingRow({
+  label,
   pricing,
 }: {
+  label?: string;
   pricing: MetabaseManagedAiPricing;
 }) {
   return (
     <Flex align="center" justify="space-between" gap="md">
       <Text lh="1">
         <Flex align="center" gap="sm">
-          {t`Price per token`}
+          {label ?? t`Price per token`}
           <Tooltip
             label={t`Tokens are chunks of text used by AI models. Usage includes both prompts and responses.`}
             multiline
@@ -437,14 +474,18 @@ function MetabasePricingRow({
   );
 }
 
-function MetabasePricingText({
+export function MetabasePricingText({
   pricing,
 }: {
   pricing: MetabaseManagedAiPricing;
 }) {
   return (
     <Group gap="xs" align="center">
-      <Text lh="1">{t`Price per token - ${pricing.price} per ${pricing.unit} tokens`}</Text>
+      <Text lh="1">
+        {pricing.freeUnits
+          ? t`You get ${pricing.freeUnits} tokens for free. Price per token afterward - ${pricing.price} per ${pricing.unit} tokens`
+          : t`Price per token - ${pricing.price} per ${pricing.unit} tokens`}
+      </Text>
       <Tooltip
         label={t`Tokens are chunks of text used by AI models. Usage includes both prompts and responses.`}
         multiline
@@ -462,13 +503,21 @@ function MetabasePricingText({
   );
 }
 
-function getMetabaseUsageCost(
-  tokens: number | null | undefined,
+export function getMetabaseUsageCost(
+  usage: MetabotUsageResponse | undefined,
   pricing: MetabaseManagedAiPricing | null,
 ) {
-  if (!tokens || !pricing) {
+  if (!usage || !pricing) {
     return 0;
   }
 
-  return (tokens / pricing.unitCount) * pricing.pricePerUnit;
+  const { tokens, "free-tokens": freeTokens } = usage;
+  if (!tokens) {
+    return 0;
+  }
+
+  return (
+    (Math.max(0, tokens - (freeTokens ?? 0)) / pricing.unitCount) *
+    pricing.pricePerUnit
+  );
 }

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabaseAIProviderSetup.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabaseAIProviderSetup.unit.spec.ts
@@ -1,0 +1,75 @@
+import { createElement } from "react";
+
+import { render, screen } from "__support__/ui";
+import type { MetabotUsageResponse } from "metabase-enterprise/api";
+
+import type { MetabaseManagedAiPricing } from "../../useMetabaseManagedAiPricing";
+
+import {
+  MetabasePricingText,
+  getMetabaseUsageCost,
+} from "./MetabaseAIProviderSetup";
+
+const PRICING: MetabaseManagedAiPricing = {
+  price: "$3.00",
+  unit: "1M",
+  pricePerUnit: 3,
+  unitCount: 1_000_000,
+  freeUnits: null,
+};
+
+function createUsage(tokens: number, freeTokens: number): MetabotUsageResponse {
+  return {
+    tokens,
+    "free-tokens": freeTokens,
+    "updated-at": null,
+  };
+}
+
+describe("getMetabaseUsageCost", () => {
+  it.each([
+    { tokens: 100, freeTokens: 100 },
+    { tokens: 50, freeTokens: 100 },
+  ])(
+    "returns 0 when tokens ($tokens) are less than or equal to free tokens ($freeTokens)",
+    ({ tokens, freeTokens }) => {
+      expect(
+        getMetabaseUsageCost(createUsage(tokens, freeTokens), PRICING),
+      ).toBe(0);
+    },
+  );
+
+  it("calculates cost only for tokens above the free allocation", () => {
+    expect(
+      getMetabaseUsageCost(createUsage(3_000_000, 1_000_000), PRICING),
+    ).toBe(6);
+  });
+});
+
+describe("MetabasePricingText", () => {
+  it("shows the free-token pricing message when free units are available", () => {
+    render(
+      createElement(MetabasePricingText, {
+        pricing: { ...PRICING, freeUnits: "1M" },
+      }),
+    );
+
+    expect(
+      screen.getByText(
+        "You get 1M tokens for free. Price per token afterward - $3.00 per 1M tokens",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the standard pricing message when no free units are available", () => {
+    render(
+      createElement(MetabasePricingText, {
+        pricing: { ...PRICING, freeUnits: null },
+      }),
+    );
+
+    expect(
+      screen.getByText("Price per token - $3.00 per 1M tokens"),
+    ).toBeInTheDocument();
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabaseAIProviderSetup.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabaseAIProviderSetup.unit.spec.ts
@@ -21,8 +21,9 @@ const PRICING: MetabaseManagedAiPricing = {
 function createUsage(tokens: number, freeTokens: number): MetabotUsageResponse {
   return {
     tokens,
-    "free-tokens": freeTokens,
-    "updated-at": null,
+    free_tokens: freeTokens,
+    updated_at: null,
+    is_locked: false,
   };
 }
 

--- a/enterprise/frontend/src/metabase-enterprise/metabot/useMetabaseManagedAiPricing.ts
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/useMetabaseManagedAiPricing.ts
@@ -18,6 +18,7 @@ export type MetabaseManagedAiPricing = {
   unit: string;
   pricePerUnit: number;
   unitCount: number;
+  freeUnits: string | null;
 };
 
 type UseMetabaseManagedAiPricingResult = {
@@ -63,11 +64,16 @@ function getMetabaseManagedAiPricing(
     addOn.default_total_units * METABASE_MANAGED_AI_UNIT_MULTIPLIER;
   const pricePerUnit =
     addOn.default_price_per_unit * METABASE_MANAGED_AI_UNIT_MULTIPLIER;
+  const freeUnits =
+    addOn.free_units && addOn.free_units > 0
+      ? formatNumber(addOn.free_units, COMPACT_NUMBER_FORMAT_OPTIONS)
+      : null;
 
   return {
     price: formatMetabaseCost(pricePerUnit),
     unit: formatNumber(unitCount, COMPACT_NUMBER_FORMAT_OPTIONS),
     pricePerUnit,
     unitCount,
+    freeUnits,
   };
 }

--- a/frontend/src/metabase-types/api/store.ts
+++ b/frontend/src/metabase-types/api/store.ts
@@ -73,6 +73,7 @@ export interface ICloudAddOnProduct {
   short_name: string;
   token_features: TokenFeature[];
   trial_days: number | null;
+  free_units: number | null;
 }
 
 export type GetCloudAddOnsResponse = ICloudAddOnProduct[];

--- a/frontend/src/metabase/metabot/components/MetabotAdmin/MetabotSetup.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotAdmin/MetabotSetup.unit.spec.tsx
@@ -82,6 +82,7 @@ const DEFAULT_RESPONSES: Record<MetabotProvider, MetabotSettingsResponse> = {
 type MetabotUsageQuota = {
   "is-locked"?: boolean;
   tokens: number | null;
+  "free-tokens"?: number | null;
   updated_at: string | null;
 };
 
@@ -881,7 +882,7 @@ describe("MetabotSetup", () => {
     expect(screen.getByText("$4.25 per 1M tokens")).toBeInTheDocument();
   });
 
-  it("shows usage summary for the connected Metabase provider", async () => {
+  it("shows included usage for the connected Metabase provider while still within the free limit", async () => {
     const updatedAt = "2026-04-02T19:29:12Z";
     await setup({
       isHosted: true,
@@ -891,6 +892,31 @@ describe("MetabotSetup", () => {
       metabotUsageQuotas: [
         {
           tokens: 250000,
+          "free-tokens": 1000000,
+          updated_at: updatedAt,
+        },
+      ],
+    });
+
+    expect(await screen.findByText("Included use")).toBeInTheDocument();
+    expect(screen.getByText("Free trial tokens")).toBeInTheDocument();
+    expect(screen.getByText("250,000 / 1,000,000")).toBeInTheDocument();
+    expect(screen.getByText("Price per token afterward")).toBeInTheDocument();
+    expect(screen.queryByText("Current billing cycle")).not.toBeInTheDocument();
+    expect(screen.queryByText("Total tokens")).not.toBeInTheDocument();
+  });
+
+  it("shows the normal usage summary for the connected Metabase provider after free tokens run out", async () => {
+    const updatedAt = "2026-04-02T19:29:12Z";
+    await setup({
+      isHosted: true,
+      savedProviderValue: "metabase/anthropic/claude-sonnet-4-6",
+      tokenStatusFeatures: ["metabase-ai-managed"],
+      metabasePricePerUnit: 4.25,
+      metabotUsageQuotas: [
+        {
+          tokens: 1250000,
+          "free-tokens": 1000000,
           updated_at: updatedAt,
         },
       ],
@@ -899,11 +925,16 @@ describe("MetabotSetup", () => {
     expect(
       await screen.findByText("Current billing cycle"),
     ).toBeInTheDocument();
-    expect(await screen.findByText("250,000")).toBeInTheDocument();
+    expect(await screen.findByText("1,250,000")).toBeInTheDocument();
     expect(screen.queryByText("Unavailable")).not.toBeInTheDocument();
     expect(screen.getByText("Total tokens")).toBeInTheDocument();
     expect(screen.getByText("Total cost")).toBeInTheDocument();
+    expect(screen.getByText("Price per token")).toBeInTheDocument();
     expect(screen.getByText("$1.06")).toBeInTheDocument();
+    expect(screen.queryByText("Included use")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Price per token afterward"),
+    ).not.toBeInTheDocument();
   });
 
   it("disconnects when clicking use a different AI provider from the locked managed-provider state", async () => {

--- a/frontend/src/metabase/metabot/components/MetabotAdmin/MetabotSetup.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotAdmin/MetabotSetup.unit.spec.tsx
@@ -80,9 +80,9 @@ const DEFAULT_RESPONSES: Record<MetabotProvider, MetabotSettingsResponse> = {
 };
 
 type MetabotUsageQuota = {
-  "is-locked"?: boolean;
+  is_locked?: boolean;
   tokens: number | null;
-  "free-tokens"?: number | null;
+  free_tokens?: number | null;
   updated_at: string | null;
 };
 
@@ -892,7 +892,7 @@ describe("MetabotSetup", () => {
       metabotUsageQuotas: [
         {
           tokens: 250000,
-          "free-tokens": 1000000,
+          free_tokens: 1000000,
           updated_at: updatedAt,
         },
       ],
@@ -916,7 +916,7 @@ describe("MetabotSetup", () => {
       metabotUsageQuotas: [
         {
           tokens: 1250000,
-          "free-tokens": 1000000,
+          free_tokens: 1000000,
           updated_at: updatedAt,
         },
       ],
@@ -944,7 +944,7 @@ describe("MetabotSetup", () => {
       tokenStatusFeatures: ["metabase-ai-managed"],
       metabotUsageQuotas: [
         {
-          "is-locked": true,
+          is_locked: true,
           tokens: 250000,
           updated_at: "2026-04-02T19:29:12Z",
         },
@@ -999,7 +999,7 @@ describe("MetabotSetup", () => {
       tokenStatusFeatures: ["metabase-ai-managed"],
       metabotUsageQuotas: [
         {
-          "is-locked": true,
+          is_locked: true,
           tokens: 250000,
           updated_at: "2026-04-02T19:29:12Z",
         },

--- a/frontend/test/__support__/server-mocks/metabot.ts
+++ b/frontend/test/__support__/server-mocks/metabot.ts
@@ -167,6 +167,7 @@ type SetupMetabaseManagedAiEndpointsOptions = {
   metabotUsageQuota?: {
     "is-locked"?: boolean;
     tokens: number | null;
+    "free-tokens"?: number | null;
     updated_at: string | null;
   } | null;
   purchaseCloudAddOnResponse?: number | { status: number; body: unknown };
@@ -183,6 +184,7 @@ export function setupMetabaseManagedAiEndpoints({
   fetchMock.get("path:/api/ee/metabot/usage", {
     "is-locked": metabotUsageQuota?.["is-locked"] ?? false,
     tokens: metabotUsageQuota?.tokens ?? null,
+    "free-tokens": metabotUsageQuota?.["free-tokens"] ?? null,
     updated_at: metabotUsageQuota?.updated_at ?? null,
   });
 

--- a/frontend/test/__support__/server-mocks/metabot.ts
+++ b/frontend/test/__support__/server-mocks/metabot.ts
@@ -165,9 +165,9 @@ type SetupMetabaseManagedAiEndpointsOptions = {
   billingPeriodMonths?: number;
   metabasePricePerUnit?: number;
   metabotUsageQuota?: {
-    "is-locked"?: boolean;
+    is_locked?: boolean;
     tokens: number | null;
-    "free-tokens"?: number | null;
+    free_tokens?: number | null;
     updated_at: string | null;
   } | null;
   purchaseCloudAddOnResponse?: number | { status: number; body: unknown };
@@ -182,9 +182,9 @@ export function setupMetabaseManagedAiEndpoints({
   removeCloudAddOnResponse = 200,
 }: SetupMetabaseManagedAiEndpointsOptions = {}) {
   fetchMock.get("path:/api/ee/metabot/usage", {
-    "is-locked": metabotUsageQuota?.["is-locked"] ?? false,
+    is_locked: metabotUsageQuota?.is_locked ?? false,
     tokens: metabotUsageQuota?.tokens ?? null,
-    "free-tokens": metabotUsageQuota?.["free-tokens"] ?? null,
+    free_tokens: metabotUsageQuota?.free_tokens ?? null,
     updated_at: metabotUsageQuota?.updated_at ?? null,
   });
 


### PR DESCRIPTION
Closes [BOT-1358: Pricing UI should reflect 1M free tokens](https://linear.app/metabase/issue/BOT-1358/pricing-ui-should-reflect-1m-free-tokens)
Closes [CLO-5330: Force token check when visiting MB's meter pages](https://linear.app/metabase/issue/CLO-5330/force-token-check-when-visiting-mbs-meter-pages)

### Description

Pricing UI now reflects free tokens. Also forces token refresh when visiting AI admin settings.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Set your sub to have free limits on metabase-ai-managed
2. Go to AI settings

### Demo

<img width="901" height="382" alt="image" src="https://github.com/user-attachments/assets/ad665098-3078-4fc7-b093-8cbb8eb0a59b" />

<img width="850" height="462" alt="image" src="https://github.com/user-attachments/assets/ece07707-64a4-46cb-b0e6-a5884d521d46" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
