### PR TITLE
fix: switching between internal and embedded metabot scrolls

### DIFF
--- a/e2e/test/scenarios/metabot/ai-controls.cy.spec.ts
+++ b/e2e/test/scenarios/metabot/ai-controls.cy.spec.ts
@@ -27,7 +27,7 @@ describe("AI Controls > Metabot access and customization", () => {
         "updatePermissions",
       );
 
-      cy.visit("/admin/metabot/1/usage-controls/ai-feature-access");
+      cy.visit("/admin/metabot/usage-controls/ai-feature-access");
 
       cy.wait("@getPermissions");
 
@@ -119,7 +119,7 @@ describe("AI Controls > Metabot access and customization", () => {
     it("should save a custom Metabot name", () => {
       cy.intercept("PUT", "/api/setting/metabot-name").as("saveName");
 
-      cy.visit("/admin/metabot/1/customization");
+      cy.visit("/admin/metabot/customization");
 
       cy.findByRole("heading", { name: "Customization", level: 1 }).should(
         "be.visible",
@@ -140,7 +140,7 @@ describe("AI Controls > Metabot access and customization", () => {
     it("should upload a custom Metabot icon and show the illustrations section", () => {
       cy.intercept("PUT", "/api/setting/metabot-icon").as("saveIcon");
 
-      cy.visit("/admin/metabot/1/customization");
+      cy.visit("/admin/metabot/customization");
 
       H.main().findByText("AI agent's icon").should("be.visible");
       cy.findByRole("button", { name: "Upload a custom icon" }).should(
@@ -187,7 +187,7 @@ describe("AI Controls > Metabot access and customization", () => {
         "saveIllustrations",
       );
 
-      cy.visit("/admin/metabot/1/customization");
+      cy.visit("/admin/metabot/customization");
 
       H.main().findByText("Metabot illustrations").should("be.visible");
 
@@ -259,7 +259,7 @@ describe("AI Controls > Metabot access and customization", () => {
         "savePrompt",
       );
 
-      cy.visit("/admin/metabot/1/system-prompts/metabot-chat");
+      cy.visit("/admin/metabot/system-prompts/metabot-chat");
 
       cy.findByRole("heading", {
         name: "AI chat prompt instructions",
@@ -286,7 +286,7 @@ describe("AI Controls > Metabot access and customization", () => {
         "saveSqlPrompt",
       );
 
-      cy.visit("/admin/metabot/1/system-prompts/sql-generation");
+      cy.visit("/admin/metabot/system-prompts/sql-generation");
 
       cy.findByRole("heading", {
         name: "SQL generation prompt instructions",
@@ -312,7 +312,7 @@ describe("AI Controls > Metabot access and customization", () => {
 });
 
 describe("AI controls > AI usage limits", () => {
-  const AI_USAGE_LIMITS_URL = "/admin/metabot/1/usage-controls/ai-usage-limits";
+  const AI_USAGE_LIMITS_URL = "/admin/metabot/usage-controls/ai-usage-limits";
 
   beforeEach(() => {
     H.restore();
@@ -657,7 +657,7 @@ describe("AI Controls > Tenant usage limits", () => {
   });
 
   it("should allow updating tenant limits when tenants are enabled", () => {
-    cy.visit("/admin/metabot/1/usage-controls/ai-usage-limits");
+    cy.visit("/admin/metabot/usage-controls/ai-usage-limits");
 
     cy.findByRole("tab", { name: "Specific tenants" }).click();
 

--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/nav.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/nav.tsx
@@ -3,7 +3,6 @@ import { t } from "ttag";
 import { AdminNavItem } from "metabase/admin/components/AdminNav";
 import { UpsellGem } from "metabase/common/components/upsells/components";
 import { useSetting } from "metabase/common/hooks";
-import { FIXED_METABOT_IDS } from "metabase/metabot/constants";
 
 export function getAiControlsNavItems() {
   return <AiControlsNavItems />;
@@ -31,18 +30,18 @@ function AiControlsNavItems() {
       >
         <AdminNavItem
           label={t`Access`}
-          path={`/admin/metabot/${FIXED_METABOT_IDS.DEFAULT}/usage-controls/ai-feature-access`}
+          path="/admin/metabot/usage-controls/ai-feature-access"
           disabled={!isConfigured}
         />
         <AdminNavItem
           label={t`Limits`}
-          path={`/admin/metabot/${FIXED_METABOT_IDS.DEFAULT}/usage-controls/ai-usage-limits`}
+          path="/admin/metabot/usage-controls/ai-usage-limits"
         />
       </AdminNavItem>
       <AdminNavItem
         icon="palette"
         label={t`Customization`}
-        path={`/admin/metabot/${FIXED_METABOT_IDS.DEFAULT}/customization`}
+        path="/admin/metabot/customization"
         disabled={!isConfigured}
       />
       <AdminNavItem
@@ -53,17 +52,17 @@ function AiControlsNavItems() {
       >
         <AdminNavItem
           label={t`AI chat`}
-          path={`/admin/metabot/${FIXED_METABOT_IDS.DEFAULT}/system-prompts/metabot-chat`}
+          path="/admin/metabot/system-prompts/metabot-chat"
           disabled={!isConfigured}
         />
         <AdminNavItem
           label={t`Natural language queries`}
-          path={`/admin/metabot/${FIXED_METABOT_IDS.DEFAULT}/system-prompts/natural-language-queries`}
+          path="/admin/metabot/system-prompts/natural-language-queries"
           disabled={!isConfigured}
         />
         <AdminNavItem
           label={t`SQL generation`}
-          path={`/admin/metabot/${FIXED_METABOT_IDS.DEFAULT}/system-prompts/sql-generation`}
+          path="/admin/metabot/system-prompts/sql-generation"
           disabled={!isConfigured}
         />
       </AdminNavItem>
@@ -77,19 +76,19 @@ function AiControlsUpsellNavItems() {
       <AdminNavItem
         icon="lock"
         label={t`Usage controls`}
-        path={`/admin/metabot/${FIXED_METABOT_IDS.DEFAULT}/usage-controls/ai-feature-access`}
+        path="/admin/metabot/usage-controls/ai-feature-access"
         rightSection={<UpsellGem.New size={14} />}
       />
       <AdminNavItem
         icon="palette"
         label={t`Customization`}
-        path={`/admin/metabot/${FIXED_METABOT_IDS.DEFAULT}/customization`}
+        path="/admin/metabot/customization"
         rightSection={<UpsellGem.New size={14} />}
       />
       <AdminNavItem
         icon="document"
         label={t`System prompts`}
-        path={`/admin/metabot/${FIXED_METABOT_IDS.DEFAULT}/system-prompts/metabot-chat`}
+        path="/admin/metabot/system-prompts/metabot-chat"
         rightSection={<UpsellGem.New size={14} />}
       />
     </>

--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/routes.tsx
@@ -22,32 +22,32 @@ export function getAiControlsRoutes() {
     <Route component={RequireMetabotConfigured}>
       <Route
         key="ai-feature-access"
-        path=":metabotId/usage-controls/ai-feature-access"
+        path="usage-controls/ai-feature-access"
         component={MetabotFeatureAccessPage}
       />
       <Route
         key="ai-usage-limits"
-        path=":metabotId/usage-controls/ai-usage-limits"
+        path="usage-controls/ai-usage-limits"
         component={MetabotUsageLimitsPage}
       />
       <Route
         key="customization"
-        path=":metabotId/customization"
+        path="customization"
         component={MetabotCustomizationPage}
       />
       <Route
         key="system-prompts-metabot-chat"
-        path=":metabotId/system-prompts/metabot-chat"
+        path="system-prompts/metabot-chat"
         component={MetabotChatPromptPage}
       />
       <Route
         key="system-prompts-natural-language-queries"
-        path=":metabotId/system-prompts/natural-language-queries"
+        path="system-prompts/natural-language-queries"
         component={NaturalLanguagePromptPage}
       />
       <Route
         key="system-prompts-sql-generation"
-        path=":metabotId/system-prompts/sql-generation"
+        path="system-prompts/sql-generation"
         component={SqlGenerationPromptPage}
       />
     </Route>
@@ -59,17 +59,17 @@ export function getAiControlsUpsellRoutes() {
     <>
       <Route
         key="ai-feature-access"
-        path=":metabotId/usage-controls/ai-feature-access"
+        path="usage-controls/ai-feature-access"
         component={MetabotFeatureAccessUpsellPage}
       />
       <Route
         key="customization"
-        path=":metabotId/customization"
+        path="customization"
         component={MetabotCustomizationUpsellPage}
       />
       <Route
         key="system-prompts"
-        path=":metabotId/system-prompts/metabot-chat"
+        path="system-prompts/metabot-chat"
         component={MetabotSystemPromptsUpsellPage}
       />
     </>

--- a/frontend/src/metabase/admin/ai/AISettingsPage.tsx
+++ b/frontend/src/metabase/admin/ai/AISettingsPage.tsx
@@ -23,21 +23,21 @@ import { McpAppsSettings } from "./McpAppsSettings";
 import { MetabotSettingsPanel } from "./MetabotSettingsPanel";
 import { MetabotSetup } from "./MetabotSetup";
 
-type MetabotTabValue = "embedded" | "internal";
+type MetabotTabId =
+  | typeof FIXED_METABOT_IDS.DEFAULT
+  | typeof FIXED_METABOT_IDS.EMBEDDED;
 
 const SETUP_SECTION_ID = "setup";
 const METABOT_SECTION_ID = "metabot";
 const MCP_SECTION_ID = "mcp";
 const AGENT_API_SECTION_ID = "agent-api";
 const AI_FEATURES_ENABLED_SECTION_ID = "ai-features-enabled";
-
-const DEFAULT_METABOT_PATH = `/admin/metabot/${FIXED_METABOT_IDS.DEFAULT}`;
-const EMBEDDED_METABOT_PATH = `/admin/metabot/${FIXED_METABOT_IDS.EMBEDDED}`;
+const METABOT_SETTINGS_PATH = "/admin/metabot";
+const METABOT_ID_QUERY_PARAM = "metabot_id";
 
 export function AISettingsPage() {
   const {
-    location: { pathname },
-    params,
+    location: { query },
   } = useRouter();
 
   const isConfigured = !!useSetting("llm-metabot-configured?");
@@ -51,9 +51,12 @@ export function AISettingsPage() {
   } = useAdminSetting("ai-features-enabled?");
   const areAiFeaturesEnabled = aiFeaturesEnabledValue !== false;
 
-  const selectedTab = getSelectedMetabotTab(params.metabotId, pathname, {
-    hasEmbedding,
-  });
+  const selectedMetabotId = getSelectedMetabotId(
+    query?.[METABOT_ID_QUERY_PARAM],
+    {
+      hasEmbedding,
+    },
+  );
 
   const handleAiFeaturesEnabledChange = async (checked: boolean) => {
     await updateAiSetting({
@@ -74,7 +77,7 @@ export function AISettingsPage() {
             <MetabotSettingsSection
               hasEmbedding={hasEmbedding}
               id={METABOT_SECTION_ID}
-              selectedTab={selectedTab}
+              selectedMetabotId={selectedMetabotId}
             />
           </DisabledSection>
           <Divider />
@@ -149,38 +152,40 @@ function AgentApiSettingsSection({ disabled }: { disabled: boolean }) {
 function MetabotSettingsSection({
   hasEmbedding,
   id,
-  selectedTab,
+  selectedMetabotId,
 }: {
   hasEmbedding: boolean;
   id: string;
-  selectedTab: MetabotTabValue;
+  selectedMetabotId: MetabotTabId;
 }) {
   const { data, isLoading, error } = useListMetabotsQuery();
-  const activeMetabotId =
-    selectedTab === "embedded"
-      ? FIXED_METABOT_IDS.EMBEDDED
-      : FIXED_METABOT_IDS.DEFAULT;
-  const activeMetabot = data?.items.find((m) => m.id === activeMetabotId);
+  const activeMetabot = data?.items.find((m) => m.id === selectedMetabotId);
   const showTabs = hasEmbedding;
 
   return (
     <SettingsSection id={id} title={t`Metabot settings`}>
       {showTabs && (
-        <Tabs value={selectedTab}>
+        <Tabs value={String(selectedMetabotId)}>
           <Tabs.List>
             <Tabs.Tab
               renderRoot={(props) => (
-                <Link {...props} to={getMetabotTabPath("internal")} />
+                <Link
+                  {...props}
+                  to={getMetabotTabPath(FIXED_METABOT_IDS.DEFAULT)}
+                />
               )}
-              value="internal"
+              value={String(FIXED_METABOT_IDS.DEFAULT)}
             >
               {t`Internal`}
             </Tabs.Tab>
             <Tabs.Tab
               renderRoot={(props) => (
-                <Link {...props} to={getMetabotTabPath("embedded")} />
+                <Link
+                  {...props}
+                  to={getMetabotTabPath(FIXED_METABOT_IDS.EMBEDDED)}
+                />
               )}
-              value="embedded"
+              value={String(FIXED_METABOT_IDS.EMBEDDED)}
             >
               {t`Embedded`}
             </Tabs.Tab>
@@ -257,29 +262,26 @@ function DisabledSection({
   );
 }
 
-function getSelectedMetabotTab(
+function getSelectedMetabotId(
   metabotId: string | undefined,
-  pathname: string,
   {
     hasEmbedding,
   }: {
     hasEmbedding: boolean;
   },
-): MetabotTabValue {
-  if (
-    (metabotId === String(FIXED_METABOT_IDS.EMBEDDED) ||
-      pathname === EMBEDDED_METABOT_PATH) &&
-    hasEmbedding
-  ) {
-    return "embedded";
+): MetabotTabId {
+  if (metabotId === String(FIXED_METABOT_IDS.EMBEDDED) && hasEmbedding) {
+    return FIXED_METABOT_IDS.EMBEDDED;
   }
 
-  return "internal";
+  return FIXED_METABOT_IDS.DEFAULT;
 }
 
-function getMetabotTabPath(tab: MetabotTabValue) {
-  const pathname =
-    tab === "embedded" ? EMBEDDED_METABOT_PATH : DEFAULT_METABOT_PATH;
-
-  return `${pathname}#${METABOT_SECTION_ID}`;
+function getMetabotTabPath(metabotId: MetabotTabId) {
+  return {
+    pathname: METABOT_SETTINGS_PATH,
+    query: {
+      [METABOT_ID_QUERY_PARAM]: String(metabotId),
+    },
+  };
 }

--- a/frontend/src/metabase/admin/ai/AISettingsPage.unit.spec.tsx
+++ b/frontend/src/metabase/admin/ai/AISettingsPage.unit.spec.tsx
@@ -218,7 +218,7 @@ describe("AISettingsPage", () => {
   it("keeps the embedded deep link working by selecting the embedded tab", async () => {
     await setup({
       enableEmbedding: true,
-      initialRoute: `/admin/metabot/${FIXED_METABOT_IDS.EMBEDDED}#metabot`,
+      initialRoute: `/admin/metabot?metabot_id=${FIXED_METABOT_IDS.EMBEDDED}`,
     });
 
     expect(
@@ -261,6 +261,21 @@ describe("AISettingsPage", () => {
         name: "Pick a different collection",
       }),
     ).toBeInTheDocument();
+  });
+
+  it("switches tabs using a query param without changing the pathname", async () => {
+    const { history } = await setup({
+      enableEmbedding: true,
+      initialRoute: "/admin/metabot",
+    });
+
+    await userEvent.click(screen.getByRole("tab", { name: "Embedded" }));
+
+    expect(history?.getCurrentLocation()).toMatchObject({
+      pathname: "/admin/metabot",
+      query: { metabot_id: String(FIXED_METABOT_IDS.EMBEDDED) },
+      hash: "",
+    });
   });
 
   it("persists disable ai features", async () => {

--- a/frontend/src/metabase/admin/ai/MetabotNavPane.unit.spec.tsx
+++ b/frontend/src/metabase/admin/ai/MetabotNavPane.unit.spec.tsx
@@ -104,15 +104,15 @@ describe("MetabotNavPane", () => {
       screen.getByRole("link", { name: /Usage controls/ }),
     ).toHaveAttribute(
       "href",
-      "/admin/metabot/1/usage-controls/ai-feature-access",
+      "/admin/metabot/usage-controls/ai-feature-access",
     );
     expect(screen.getByRole("link", { name: /Customization/ })).toHaveAttribute(
       "href",
-      "/admin/metabot/1/customization",
+      "/admin/metabot/customization",
     );
     expect(
       screen.getByRole("link", { name: /System prompts/ }),
-    ).toHaveAttribute("href", "/admin/metabot/1/system-prompts/metabot-chat");
+    ).toHaveAttribute("href", "/admin/metabot/system-prompts/metabot-chat");
   });
 
   it("displays the usage auditing upsell link when audit app is available and ai controls is unavailable", async () => {

--- a/frontend/src/metabase/admin/ai/utils.ts
+++ b/frontend/src/metabase/admin/ai/utils.ts
@@ -3,8 +3,6 @@ import type { FormikErrors } from "formik";
 import { P, isMatching } from "ts-pattern";
 
 import { useAdminSetting } from "metabase/api/utils";
-import { useSelector } from "metabase/redux";
-import { getLocation } from "metabase/selectors/routing";
 import type { MetabotProvider } from "metabase-types/api";
 
 type ApiKeylessProviders = "metabase";
@@ -108,12 +106,6 @@ export function parseProviderAndModel(value: string | null | undefined) {
   }
 
   return { provider, model };
-}
-
-export function useMetabotIdPath() {
-  const location = useSelector(getLocation);
-  const metabotId = Number(location?.pathname?.split("/").pop());
-  return Number.isNaN(metabotId) ? null : metabotId;
 }
 
 // https://redux-toolkit.js.org/rtk-query/usage/error-handling

--- a/frontend/src/metabase/admin/routes.tsx
+++ b/frontend/src/metabase/admin/routes.tsx
@@ -272,7 +272,6 @@ export const getRoutes = (
           <Route key="index-layout" component={MetabotAdminLayout}>
             <IndexRoute key="index" component={AISettingsPage} />
             <Route key="mcp" path="mcp" component={McpSettingsPage} />
-            <Route key="metabot" path=":metabotId" component={AISettingsPage} />
           </Route>
           <Route
             key="layout"


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #72824
Closes [BOT-1355: Switching between "Internal" and "Embedded" Metabot tabs in Admin causes scroll](https://linear.app/metabase/issue/BOT-1355/switching-between-internal-and-embedded-metabot-tabs-in-admin-causes)

### Description

Don't scroll if we're changing /metabot/1 to /metabot/2 since it's on the same screen.

### How to verify

1. Go to AI settings
2. Click "Embedded" and then "Internal" metabot

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
