### PR TITLE
[search] Correctly set the default search filters for in-place searches

### DIFF
--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -174,12 +174,10 @@
    :command-palette {:filter-items-in-personal-collection "exclude-others"}})
 
 (defn filter-default
-  "Get the default value for the given filter in the given context. Is non-contextual for legacy search."
-  [engine context filter-key]
+  "Get the default value for the given filter in the given context."
+  [_engine context filter-key]
   (let [fetch (fn [ctx] (when ctx (-> filter-defaults-by-context (get ctx) (get filter-key))))]
-    (if (= engine :search.engine/in-place)
-      (fetch :default)
-      (or (fetch context) (fetch :default)))))
+    (or (fetch context) (fetch :default))))
 
 ;; This gets called *a lot* during a search request, so we'll almost certainly need to optimize it. Maybe just TTL.
 (defn weights

--- a/test/metabase/search/api_test.clj
+++ b/test/metabase/search/api_test.clj
@@ -26,7 +26,7 @@
    [metabase.warehouses.models.database :as database]
    [toucan2.core :as t2]))
 
-(use-fixtures :once (fixtures/initialize :db))
+(use-fixtures :once (fixtures/initialize :db :test-users :test-users-personal-collections))
 
 (comment
   ;; We need this to ensure the engine hierarchy is registered
@@ -1563,7 +1563,60 @@
                (search :rasta "exclude"))))
       (testing "getting models should return only models that are applied"
         (is (= #{"dashboard" "collection"}
-               (get-available-models :q search-term :filter_items_in_personal_collection "exclude")))))))
+               (get-available-models :q search-term :filter_items_in_personal_collection "exclude"))))
+      (testing "admin exclude-others excludes other users' personal collection items"
+        (is (= #{["dashboard" dash-public]
+                 ["dashboard" dash-sub-public]
+                 ["collection" coll-sub-public]
+                 ["dataset" model-crowberto]
+                 ["dataset" model-sub-crowberto]
+                 ["collection" coll-sub-crowberto]}
+               (search :crowberto "exclude-others"))))
+      (testing "non-admin exclude-others sees own personal items plus public"
+        (is (= #{["dashboard" dash-public]
+                 ["dashboard" dash-sub-public]
+                 ["collection" coll-sub-public]
+                 ["card" card-rasta]
+                 ["card" card-sub-rasta]
+                 ["collection" coll-sub-rasta]}
+               (search :rasta "exclude-others"))))
+      (testing "admin only-mine"
+        (is (= #{["dataset" model-crowberto]
+                 ["dataset" model-sub-crowberto]
+                 ["collection" coll-sub-crowberto]}
+               (search :crowberto "only-mine"))))
+      (testing "non-admin only-mine"
+        (is (= #{["card" card-rasta]
+                 ["card" card-sub-rasta]
+                 ["collection" coll-sub-rasta]}
+               (search :rasta "only-mine"))))
+      (testing "search-app context default excludes others' personal collections for admin"
+        (let [search-with-context (fn [user]
+                                    (->> (mt/user-http-request user :get 200 "search"
+                                                               :q search-term
+                                                               :context "search-app")
+                                         :data
+                                         (map (juxt :model :id))
+                                         set))]
+          (is (not (contains? (search-with-context :crowberto) ["card" card-rasta]))
+              "Admin should not see rasta's card in search-app context with default filter")
+          (is (not (contains? (search-with-context :crowberto) ["card" card-sub-rasta]))
+              "Admin should not see rasta's sub-collection card in search-app context with default filter")
+          (is (contains? (search-with-context :crowberto) ["dataset" model-crowberto])
+              "Admin should still see their own personal collection items")))
+      (testing "in-place engine: search-app context default should still exclude others' personal collections (#UXW-3238)"
+        (search.tu/with-legacy-search
+          (let [search-with-context (fn [user]
+                                      (->> (mt/user-http-request user :get 200 "search"
+                                                                 :q search-term
+                                                                 :context "search-app")
+                                           :data
+                                           (map (juxt :model :id))
+                                           set))]
+            (is (not (contains? (search-with-context :crowberto) ["card" card-rasta]))
+                "Admin should not see rasta's card even with in-place engine")
+            (is (not (contains? (search-with-context :crowberto) ["card" card-sub-rasta]))
+                "Admin should not see rasta's sub-collection card even with in-place engine")))))))
 
 (deftest collection-effective-parent-test
   (mt/with-temp [:model/Collection coll-1  {:name "Collection 1"}

--- a/test/metabase/search/config_test.clj
+++ b/test/metabase/search/config_test.clj
@@ -17,6 +17,8 @@
            (search.config/filter-default search-engine :command-palette :filter-items-in-personal-collection)))
     (is (= "exclude-others"
            (search.config/filter-default search-engine :search-app :filter-items-in-personal-collection))))
-  (testing "Legacy search does not support overrides"
-    (is (= "all"
-           (search.config/filter-default :search.engine/in-place :command-palette :filter-items-in-personal-collection)))))
+  (testing "Legacy search should respect context overrides (#UXW-3238)"
+    (is (= "exclude-others"
+           (search.config/filter-default :search.engine/in-place :command-palette :filter-items-in-personal-collection)))
+    (is (= "exclude-others"
+           (search.config/filter-default :search.engine/in-place :search-app :filter-items-in-personal-collection)))))


### PR DESCRIPTION
Closes UXW-3238.

### Description

MySQL doesn't support the AppDB full-text search and relies on the
`in-place` engine. That engine did not previously support contextual
filtering defaults, so the default-off toggle on the search app for
"Search all personal collections" was not respected, and results
from other people's personal collections were always shown, regardless
of the toggle.

The in-place engine does support the right filter option, but it wasn't
being set to `"except-others"` in any context, only set to `"all"` when
the toggle was enabled.

### How to verify

See the new unit tests, or try the following **with a MySQL appdb**:

1. Have a different user with things in their personal collection
2. Log in as an admin
3. Do a search that should find one of the other user's personal items.
    - _It should be visible in the quick search results, which show `all`._
4. Open the search app page
5. It's not visible anymore...
6. ... until you enable the `Show all personal collections` toggle.

### Demo

<img width="1959" height="1009" alt="2026-04-20-160253_1959x1009_scrot" src="https://github.com/user-attachments/assets/1aa79ad6-481f-4d8e-9ad9-25bb7b4236a7" />
<img width="1954" height="1026" alt="2026-04-20-160304_1954x1026_scrot" src="https://github.com/user-attachments/assets/75abec3f-e712-4b7f-a2a9-9037e84974e2" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
