### PR TITLE
Add spacing above buttons in new collection modal

### DIFF
--- a/frontend/src/metabase/collections/components/CreateCollectionForm/CreateCollectionForm.tsx
+++ b/frontend/src/metabase/collections/components/CreateCollectionForm/CreateCollectionForm.tsx
@@ -20,6 +20,7 @@ import { Collections } from "metabase/entities/collections";
 import { Form, FormProvider } from "metabase/forms";
 import { PLUGIN_TENANTS } from "metabase/plugins";
 import type { State } from "metabase/redux/store";
+import { Flex } from "metabase/ui";
 import * as Errors from "metabase/utils/errors";
 import { connect } from "metabase/utils/redux";
 import type { Collection } from "metabase-types/api";
@@ -142,6 +143,7 @@ function CreateCollectionForm({
                 filterPersonalCollections={filterPersonalCollections}
                 entityType="collection"
                 onCollectionSelect={setSelectedParentCollection}
+                mb="1rem"
               />
             )}
             {showAuthorityLevelPicker && !isParentTenantCollection && (
@@ -149,10 +151,12 @@ function CreateCollectionForm({
             )}
             <FormFooter>
               <FormErrorMessage inline />
-              {!!onCancel && (
-                <Button type="button" onClick={onCancel}>{t`Cancel`}</Button>
-              )}
-              <FormSubmitButton title={t`Create`} disabled={!dirty} primary />
+              <Flex style={{ flexShrink: 1 }} justify="flex-end" gap="sm">
+                {!!onCancel && (
+                  <Button type="button" onClick={onCancel}>{t`Cancel`}</Button>
+                )}
+                <FormSubmitButton title={t`Create`} disabled={!dirty} primary />
+              </Flex>
             </FormFooter>
           </Form>
         );


### PR DESCRIPTION
### Description

Fixes [UXW-3787](https://linear.app/metabase/issue/UXW-3787/add-spacing-above-buttons-in-new-collection-modal).

Added `mb="1rem"` to the collection picker and wrapped Cancel + Create in a `Flex gap="sm"`, mirroring the "New dashboard" dialog's spacing.

### How to verify

- [ ] Click **New → Collection**. Confirm there is visible spacing between the "Collection it's saved in" picker and the Cancel/Create buttons.
- [ ] On an enterprise/EE build, confirm there is also visible spacing between the picker and the "Collection type" (Regular/Official) toggle.

### Demo

<img width="500" alt="image" src="https://github.com/user-attachments/assets/50e4e09f-d84b-4048-aab7-7f222d692d7a" />

### Checklist

n/a
