### PR TITLE
BOT-1298 Add defenterprise for validate-metabot-provider!

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/metabot/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/metabot/settings.clj
@@ -1,8 +1,12 @@
 (ns metabase-enterprise.metabot.settings
-  "Enterprise-only metabot settings for usage limits."
+  "Enterprise-only metabot settings for usage limits and managed provider validation."
   (:require
+   [clojure.string :as str]
+   [metabase.metabot.provider-util :as provider-util]
+   [metabase.metabot.settings :as metabot.settings]
+   [metabase.premium-features.core :as premium-features :refer [defenterprise]]
    [metabase.settings.core :as setting :refer [defsetting]]
-   [metabase.util.i18n :refer [deferred-tru]]))
+   [metabase.util.i18n :refer [deferred-tru tru]]))
 
 (def ^:private valid-limit-units #{:tokens :messages})
 
@@ -48,3 +52,58 @@
   :encryption :no
   :export?    true
   :doc        false)
+
+;;; ----------------------------------------- Managed Provider Validation -----------------------------------------
+
+(def ^:private proxied-providers-and-models
+  "Providers and models that can be used via the metabase managed AI proxy.
+
+  The keys of this map must be a subset of the direct providers."
+  {"anthropic" #{"claude-sonnet-4-6"}})
+
+(defn- validate-metabase-managed-provider!
+  "Validate that `value` is a `metabase/provider/model` string whose inner provider and
+  model are in the [[proxied-providers-and-models]] allow-list. Throws on invalid input."
+  [value]
+  (when-not (provider-util/metabase-provider? value)
+    (throw (ex-info (tru "Invalid metabase managed AI provider {0}. Must start with {1}/."
+                         (pr-str value) provider-util/metabase-provider-prefix)
+                    {:status-code 400
+                     :value       value})))
+  (let [inner-provider    (provider-util/provider-and-model->provider value)
+        inner-model       (provider-util/provider-and-model->model value)
+        allowed-providers (sort (keys proxied-providers-and-models))
+        allowed-models    (get proxied-providers-and-models inner-provider)]
+    (when-not (contains? proxied-providers-and-models inner-provider)
+      (throw (ex-info (tru "Unsupported provider {0} for metabase managed AI. Supported providers: {1}"
+                           (pr-str inner-provider)
+                           (str/join ", " allowed-providers))
+                      {:status-code 400
+                       :provider    inner-provider
+                       :supported   (set (keys proxied-providers-and-models))})))
+    (when (str/blank? inner-model)
+      (throw (ex-info (tru "Model name is required. Expected format: metabase/provider/model, e.g. {0}"
+                           (pr-str metabot.settings/default-metabase-llm-metabot-provider))
+                      {:status-code 400
+                       :value       value})))
+    (when-not (contains? allowed-models inner-model)
+      (throw (ex-info (tru "Unsupported model {0} for metabase managed provider {1}. Supported models: {2}"
+                           (pr-str inner-model)
+                           (pr-str inner-provider)
+                           (str/join ", " (sort allowed-models)))
+                      {:status-code 400
+                       :provider    inner-provider
+                       :model       inner-model
+                       :supported   allowed-models})))))
+
+(defenterprise validate-metabot-provider!
+  "EE implementation: validates both direct and metabase-managed providers when the
+  `:metabase-ai-managed` or `:metabot-v3` feature is present."
+  :feature :none
+  [value]
+  (metabot.settings/validate-llm-provider-type! value)
+  (if (and (provider-util/metabase-provider? value)
+           (or (premium-features/has-feature? :metabase-ai-managed)
+               (premium-features/has-feature? :metabot-v3)))
+    (validate-metabase-managed-provider! value)
+    (metabot.settings/validate-direct-provider! value)))

--- a/enterprise/backend/test/metabase_enterprise/internal_stats/metabot_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/internal_stats/metabot_test.clj
@@ -77,27 +77,28 @@
       (t/with-clock clock
         (try
           ;; -- AI proxy conversations (metabase/ prefix) --
-          (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
-                                             "metabase/anthropic/claude-sonnet-4-6"]
-            ;; conv-1: yesterday, one model
-            (send-message! conv-1 "What is 2+2?" model 100 50)
-            (backdate-messages! conv-1 yesterday)
+          (mt/with-premium-features #{:metabase-ai-managed}
+            (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
+                                               "metabase/anthropic/claude-sonnet-4-6"]
+              ;; conv-1: yesterday, one model
+              (send-message! conv-1 "What is 2+2?" model 100 50)
+              (backdate-messages! conv-1 yesterday)
 
-            ;; conv-2: yesterday, same model different usage
-            (send-message! conv-2 "Tell me a joke" model 200 80)
-            (backdate-messages! conv-2 yesterday)
+              ;; conv-2: yesterday, same model different usage
+              (send-message! conv-2 "Tell me a joke" model 200 80)
+              (backdate-messages! conv-2 yesterday)
 
-            ;; conv-3: two days ago — out of window
-            (send-message! conv-3 "Old question" model 999 999)
-            (backdate-messages! conv-3 two-days-ago)
+              ;; conv-3: two days ago — out of window
+              (send-message! conv-3 "Old question" model 999 999)
+              (backdate-messages! conv-3 two-days-ago)
 
-            ;; conv-4: today — in rolling window
-            (send-message! conv-4 "Today's question" model 888 888)
-            (backdate-messages! conv-4 today)
+              ;; conv-4: today — in rolling window
+              (send-message! conv-4 "Today's question" model 888 888)
+              (backdate-messages! conv-4 today)
 
-            ;; conv-6: today, same model — exercises rolling aggregation
-            (send-message! conv-6 "Another today question" model 100 100)
-            (backdate-messages! conv-6 today))
+              ;; conv-6: today, same model — exercises rolling aggregation
+              (send-message! conv-6 "Another today question" model 100 100)
+              (backdate-messages! conv-6 today)))
 
           ;; -- BYOK conversation (no metabase/ prefix) --
           (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
@@ -177,10 +178,11 @@
           conv-id (str (random-uuid))]
       (t/with-clock clock
         (try
-          (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
-                                             "metabase/anthropic/claude-sonnet-4-6"]
-            (send-message! conv-id "Hello" "claude-sonnet-4-6" 500 100)
-            (backdate-messages! conv-id today))
+          (mt/with-premium-features #{:metabase-ai-managed}
+            (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
+                                               "metabase/anthropic/claude-sonnet-4-6"]
+              (send-message! conv-id "Hello" "claude-sonnet-4-6" 500 100)
+              (backdate-messages! conv-id today)))
           (let [stats (sut/metabot-stats)]
             (testing "returns rolling keys when only today has data"
               (is (= {"anthropic:claude-sonnet-4-6:tokens" 600}
@@ -200,10 +202,11 @@
           conv-id   (str (random-uuid))]
       (t/with-clock clock
         (try
-          (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
-                                             "metabase/anthropic/claude-sonnet-4-6"]
-            (send-message! conv-id "Hello" "claude-sonnet-4-6" 1000 250)
-            (backdate-messages! conv-id yesterday))
+          (mt/with-premium-features #{:metabase-ai-managed}
+            (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
+                                               "metabase/anthropic/claude-sonnet-4-6"]
+              (send-message! conv-id "Hello" "claude-sonnet-4-6" 1000 250)
+              (backdate-messages! conv-id yesterday)))
           (let [stats (sut/metabot-stats)]
             (is (= {"anthropic:claude-sonnet-4-6:tokens" 1250}
                    (:metabot-usage stats))))
@@ -245,10 +248,11 @@
                         (constantly "metabase/openrouter/anthropic/claude-haiku-4-5")]
             (send-message! conv-1 "Q1" "anthropic/claude-haiku-4-5" 100 50)
             (backdate-messages! conv-1 yesterday))
-          (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
-                                             "metabase/anthropic/claude-sonnet-4-6"]
-            (send-message! conv-2 "Q2" "claude-sonnet-4-6" 200 80)
-            (backdate-messages! conv-2 yesterday))
+          (mt/with-premium-features #{:metabase-ai-managed}
+            (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
+                                               "metabase/anthropic/claude-sonnet-4-6"]
+              (send-message! conv-2 "Q2" "claude-sonnet-4-6" 200 80)
+              (backdate-messages! conv-2 yesterday)))
           (with-redefs [metabot.settings/llm-metabot-provider
                         (constantly "metabase/openai/gpt-4o")]
             (send-message! conv-3 "Q3" "gpt-4o" 300 120)
@@ -307,25 +311,26 @@
           tables    [{:name "Orders" :fields [{:name "id"} {:name "total"}]}]]
       (t/with-clock clock
         (try
-          (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
-                                             "metabase/anthropic/claude-sonnet-4-6"]
-            ;; Yesterday's generation
-            (generate-example-questions! tables model 400 100)
+          (mt/with-premium-features #{:metabase-ai-managed}
+            (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
+                                               "metabase/anthropic/claude-sonnet-4-6"]
+              ;; Yesterday's generation
+              (generate-example-questions! tables model 400 100)
 
-            (testing "ai_usage_log row is created with ai_proxied = true"
-              (is (=? [{:ai_proxied true
-                        :total_tokens 500}]
-                      (t2/select :model/AiUsageLog :id [:> baseline]))))
+              (testing "ai_usage_log row is created with ai_proxied = true"
+                (is (=? [{:ai_proxied true
+                          :total_tokens 500}]
+                        (t2/select :model/AiUsageLog :id [:> baseline]))))
 
-            ;; backdate so it lands in yesterday's window
-            (t2/update! :model/AiUsageLog {:id [:> baseline]}
-                        {:created_at yesterday})
+              ;; backdate so it lands in yesterday's window
+              (t2/update! :model/AiUsageLog {:id [:> baseline]}
+                          {:created_at yesterday})
 
-            ;; Today's generation — exercises rolling usage
-            (let [before-today (max-usage-log-id)]
-              (generate-example-questions! tables model 200 60)
-              (t2/update! :model/AiUsageLog {:id [:> before-today]}
-                          {:created_at today})))
+              ;; Today's generation — exercises rolling usage
+              (let [before-today (max-usage-log-id)]
+                (generate-example-questions! tables model 200 60)
+                (t2/update! :model/AiUsageLog {:id [:> before-today]}
+                            {:created_at today}))))
 
           (testing "metabot-stats includes yesterday totals and today's rolling usage"
             (is (=? {:metabot-tokens             500
@@ -371,17 +376,18 @@
           conv-id   (str (random-uuid))]
       (t/with-clock clock
         (try
-          (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
-                                             "metabase/anthropic/claude-sonnet-4-6"]
-            ;; Chat conversation
-            (send-message! conv-id "What is 2+2?" model 200 50)
-            (backdate-messages! conv-id yesterday)
+          (mt/with-premium-features #{:metabase-ai-managed}
+            (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
+                                               "metabase/anthropic/claude-sonnet-4-6"]
+              ;; Chat conversation
+              (send-message! conv-id "What is 2+2?" model 200 50)
+              (backdate-messages! conv-id yesterday)
 
-            ;; Example question generation (no conversation)
-            (generate-example-questions! tables model 300 100)
-            (t2/update! :model/AiUsageLog {:id [:> baseline]
-                                           :source "example-question-generation"}
-                        {:created_at yesterday}))
+              ;; Example question generation (no conversation)
+              (generate-example-questions! tables model 300 100)
+              (t2/update! :model/AiUsageLog {:id [:> baseline]
+                                             :source "example-question-generation"}
+                          {:created_at yesterday})))
 
           (testing "metabot-stats includes both chat and example question generation"
             ;; chat: 250, eqg: 400 → total 650

--- a/enterprise/backend/test/metabase_enterprise/llm/startup_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/llm/startup_test.clj
@@ -1,0 +1,58 @@
+(ns metabase-enterprise.llm.startup-test
+  (:require
+   [clojure.test :refer [deftest is testing use-fixtures]]
+   [metabase.llm.startup :as llm.startup]
+   [metabase.metabot.settings :as metabot.settings]
+   [metabase.premium-features.core :as premium-features]
+   [metabase.settings.core :as setting]
+   [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]))
+
+(use-fixtures :once (fixtures/initialize :db))
+
+(deftest check-and-sync-settings-on-startup-syncs-legacy-metabot-default-test
+  (mt/with-premium-features #{:metabot-v3}
+    (mt/discard-setting-changes [llm-metabot-provider]
+      (mt/with-temporary-raw-setting-values [llm-metabot-provider nil]
+        (with-redefs [premium-features/canonically-has-feature?
+                      (fn [feature]
+                        (case feature
+                          :metabot-v3 true
+                          :metabase-ai-managed false))
+                      metabot.settings/llm-metabot-configured? (constantly false)]
+          (llm.startup/check-and-sync-settings-on-startup!)
+          (is (= metabot.settings/default-metabase-llm-metabot-provider
+                 (metabot.settings/llm-metabot-provider))))))))
+
+(deftest check-and-sync-settings-on-startup-feature-permutations-test
+  (doseq [legacy-result [nil false true]
+          managed-result [nil false true]]
+    (testing (format ":metabot-v3=%s :metabase-ai-managed=%s" legacy-result managed-result)
+      (mt/with-premium-features #{:metabot-v3}
+        (mt/discard-setting-changes [llm-metabot-provider]
+          (mt/with-temporary-raw-setting-values [llm-metabot-provider nil]
+            (with-redefs [premium-features/canonically-has-feature?
+                          (fn [feature]
+                            (case feature
+                              :metabot-v3 legacy-result
+                              :metabase-ai-managed managed-result))
+                          metabot.settings/llm-metabot-configured? (constantly false)]
+              (llm.startup/check-and-sync-settings-on-startup!)
+              (is (= (case [legacy-result managed-result]
+                       [true false] metabot.settings/default-metabase-llm-metabot-provider
+                       nil)
+                     (setting/db-stored-value :llm-metabot-provider))))))))))
+
+(deftest check-and-sync-settings-on-startup-syncs-blank-provider-test
+  (mt/with-premium-features #{:metabot-v3}
+    (mt/discard-setting-changes [llm-metabot-provider]
+      (mt/with-temporary-raw-setting-values [llm-metabot-provider ""]
+        (with-redefs [premium-features/canonically-has-feature?
+                      (fn [feature]
+                        (case feature
+                          :metabot-v3 true
+                          :metabase-ai-managed false))
+                      metabot.settings/llm-metabot-configured? (constantly false)]
+          (llm.startup/check-and-sync-settings-on-startup!)
+          (is (= metabot.settings/default-metabase-llm-metabot-provider
+                 (metabot.settings/llm-metabot-provider))))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot/api/entity_analysis_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot/api/entity_analysis_test.clj
@@ -1,0 +1,26 @@
+(ns metabase-enterprise.metabot.api.entity-analysis-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.metabot.core :as metabot]
+   [metabase.metabot.settings :as metabot.settings]
+   [metabase.premium-features.core :as premium-features]
+   [metabase.test :as mt]))
+
+(deftest analyze-chart-returns-free-trial-limit-error-when-managed-provider-is-locked-test
+  (mt/with-premium-features #{:metabase-ai-managed}
+    (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
+                                       "metabase/anthropic/claude-sonnet-4-6"]
+      (with-redefs [premium-features/token-status
+                    (constantly {:meters {:anthropic:claude-sonnet-4-6:tokens {:meter-value 1000000
+                                                                               :is-locked   true}}})
+                    metabot/analyze-chart
+                    (fn [& _]
+                      (throw (ex-info "should not call analyze-chart" {})))]
+        (let [response (mt/user-http-request :rasta :post 402 "ai-entity-analysis/analyze-chart"
+                                             {:image_base64 "base64encodedimage"
+                                              :name         "Sales Trend"
+                                              :description  "Quarterly sales data"})]
+          (is (= "You've used all of your included AI service tokens. To keep using AI features, end your trial early and start your subscription, or add your own AI provider API key."
+                 (if (map? response)
+                   (:message response)
+                   response))))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot/api/metabot_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot/api/metabot_test.clj
@@ -1,0 +1,72 @@
+(ns metabase-enterprise.metabot.api.metabot-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.metabot.settings :as metabot.settings]
+   [metabase.metabot.suggested-prompts :as metabot.suggested-prompts]
+   [metabase.premium-features.core :as premium-features]
+   [metabase.test :as mt]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(deftest metabot-put-skips-prompt-regeneration-when-managed-provider-is-locked-test
+  (mt/dataset test-data
+    (let [model-query {:type :query, :database (mt/id), :query {:source-table (mt/id :products)}}]
+      (mt/with-premium-features #{:metabase-ai-managed}
+        (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
+                                           "metabase/anthropic/claude-sonnet-4-6"]
+          (mt/with-temp [:model/Collection {collection-id :id} {:name "Collection"}
+                         :model/Metabot {metabot-id :id} {:name "Test Metabot"
+                                                          :collection_id collection-id}
+                         :model/Card {card-id :id} {:name "Test Model Card"
+                                                    :type :model
+                                                    :dataset_query model-query}
+                         :model/MetabotPrompt {prompt-id :id} {:metabot_id metabot-id
+                                                               :prompt "existing prompt"
+                                                               :model :model
+                                                               :card_id card-id}]
+            (with-redefs [premium-features/token-status
+                          (constantly {:meters {:anthropic:claude-sonnet-4-6:tokens {:meter-value 1000000
+                                                                                     :is-locked   true}}})
+                          metabot.suggested-prompts/delete-all-metabot-prompts
+                          (fn [& _]
+                            (throw (ex-info "should not delete prompts" {})))
+                          metabot.suggested-prompts/generate-sample-prompts
+                          (fn [& _]
+                            (throw (ex-info "should not generate prompts" {})))]
+              (let [response (mt/user-http-request :crowberto :put 200
+                                                   (format "metabot/metabot/%d" metabot-id)
+                                                   {:collection_id nil})]
+                (is (nil? (:collection_id response)))
+                (is (= #{prompt-id}
+                       (t2/select-pks-set :model/MetabotPrompt :metabot_id metabot-id)))))))))))
+
+(deftest metabot-prompt-regenerate-returns-free-trial-limit-error-when-managed-provider-is-locked-test
+  (mt/dataset test-data
+    (let [model-query {:type :query, :database (mt/id), :query {:source-table (mt/id :products)}}]
+      (mt/with-premium-features #{:metabase-ai-managed}
+        (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
+                                           "metabase/anthropic/claude-sonnet-4-6"]
+          (mt/with-temp [:model/Metabot {metabot-id :id} {:name "Test Metabot"}
+                         :model/Card {card-id :id} {:name "Test Model Card"
+                                                    :type :model
+                                                    :dataset_query model-query}
+                         :model/MetabotPrompt {prompt-id :id} {:metabot_id metabot-id
+                                                               :prompt "existing prompt"
+                                                               :model :model
+                                                               :card_id card-id}]
+            (with-redefs [premium-features/token-status
+                          (constantly {:meters {:anthropic:claude-sonnet-4-6:tokens {:meter-value 1000000
+                                                                                     :is-locked   true}}})
+                          metabot.suggested-prompts/delete-all-metabot-prompts
+                          (fn [& _]
+                            (throw (ex-info "should not delete prompts" {})))
+                          metabot.suggested-prompts/generate-sample-prompts
+                          (fn [& _]
+                            (throw (ex-info "should not generate prompts" {})))]
+              (let [response (mt/user-http-request :crowberto :post 402
+                                                   (format "metabot/metabot/%d/prompt-suggestions/regenerate" metabot-id))]
+                (is (= "You've used all of your included AI service tokens. To keep using AI features, end your trial early and start your subscription, or add your own AI provider API key."
+                       (:message response))))
+              (is (= #{prompt-id}
+                     (t2/select-pks-set :model/MetabotPrompt :metabot_id metabot-id))))))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot/api_test.clj
@@ -2,9 +2,16 @@
   (:require
    [clj-http.client :as http]
    [clojure.test :refer :all]
+   [metabase.api.common :as mb.api]
+   [metabase.llm.settings :as llm.settings]
+   [metabase.metabot.api :as api]
+   [metabase.metabot.config :as metabot.config]
+   [metabase.metabot.self :as metabot.self]
+   [metabase.metabot.settings :as metabot.settings]
    [metabase.premium-features.core :as premium-features]
    [metabase.test :as mt]
-   [metabase.util.json :as json]))
+   [metabase.util.json :as json]
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -60,3 +67,167 @@
 (deftest usage-permissions-test
   (mt/with-premium-features #{:metabot-v3}
     (mt/user-http-request :rasta :get 403 "ee/metabot/usage")))
+
+;;; ---------------------------------------- Managed Provider Tests ----------------------------------------
+;;; Tests that set llm-metabot-provider to a metabase/ prefixed value require the EE
+;;; implementation of validate-metabot-provider! to be on the classpath.
+
+(deftest settings-get-returns-metabase-models-without-api-key-test
+  (mt/with-premium-features #{:metabase-ai-managed}
+    (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider "metabase/anthropic/claude-sonnet-4-6"]
+      (with-redefs [metabot.self/list-models (fn
+                                               ([provider]
+                                                (is false (str "unexpected list-models call: " provider)))
+                                               ([provider opts]
+                                                (is (= "anthropic" provider))
+                                                (is (= {:ai-proxy? true} opts))
+                                                {:models [{:id "claude-haiku-4-5" :display_name "Claude Haiku 4.5"}
+                                                          {:id "claude-sonnet-4-6" :display_name "Claude Sonnet 4.6"}
+                                                          {:id "claude-opus-4-1" :display_name "Claude Opus 4.1"}]}))]
+        (is (= {:value  "metabase/anthropic/claude-sonnet-4-6"
+                :models [{:id "anthropic/claude-haiku-4-5" :display_name "Claude Haiku 4.5"}
+                         {:id "anthropic/claude-sonnet-4-6" :display_name "Claude Sonnet 4.6"}
+                         {:id "anthropic/claude-opus-4-1" :display_name "Claude Opus 4.1"}]}
+               (mt/user-http-request :crowberto :get 200 "metabot/settings"
+                                     :provider "metabase")))))))
+
+(deftest settings-put-updates-metabase-provider-without-api-key-test
+  (mt/with-premium-features #{:metabase-ai-managed}
+    (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider "anthropic/claude-haiku-4-5"]
+      (with-redefs [metabot.self/list-models (fn
+                                               ([provider]
+                                                (is false (str "unexpected list-models call: " provider)))
+                                               ([provider opts]
+                                                (is (= "anthropic" provider))
+                                                (is (= {:ai-proxy? true} opts))
+                                                {:models [{:id "claude-haiku-4-5" :display_name "Claude Haiku 4.5"}
+                                                          {:id "claude-sonnet-4-6" :display_name "Claude Sonnet 4.6"}
+                                                          {:id "claude-opus-4-1" :display_name "Claude Opus 4.1"}]}))]
+        (is (= {:value  "metabase/anthropic/claude-sonnet-4-6"
+                :models [{:id "anthropic/claude-haiku-4-5" :display_name "Claude Haiku 4.5"}
+                         {:id "anthropic/claude-sonnet-4-6" :display_name "Claude Sonnet 4.6"}
+                         {:id "anthropic/claude-opus-4-1" :display_name "Claude Opus 4.1"}]}
+               (mt/user-http-request :crowberto :put 200 "metabot/settings"
+                                     {:provider "metabase"
+                                      :model    "anthropic/claude-sonnet-4-6"})))
+        (is (= "metabase/anthropic/claude-sonnet-4-6"
+               (metabot.settings/llm-metabot-provider)))))))
+
+(deftest settings-put-defaults-empty-metabase-model-test
+  (mt/with-premium-features #{:metabase-ai-managed}
+    (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider "anthropic/claude-haiku-4-5"]
+      (with-redefs [metabot.self/list-models (fn
+                                               ([provider]
+                                                (is false (str "unexpected list-models call: " provider)))
+                                               ([provider opts]
+                                                (is (= "anthropic" provider))
+                                                (is (= {:ai-proxy? true} opts))
+                                                {:models [{:id "claude-haiku-4-5" :display_name "Claude Haiku 4.5"}
+                                                          {:id "claude-sonnet-4-6" :display_name "Claude Sonnet 4.6"}
+                                                          {:id "claude-opus-4-1" :display_name "Claude Opus 4.1"}]}))]
+        (is (= {:value  "metabase/anthropic/claude-sonnet-4-6"
+                :models [{:id "anthropic/claude-haiku-4-5" :display_name "Claude Haiku 4.5"}
+                         {:id "anthropic/claude-sonnet-4-6" :display_name "Claude Sonnet 4.6"}
+                         {:id "anthropic/claude-opus-4-1" :display_name "Claude Opus 4.1"}]}
+               (mt/user-http-request :crowberto :put 200 "metabot/settings"
+                                     {:provider "metabase"
+                                      :model    ""})))
+        (is (= "metabase/anthropic/claude-sonnet-4-6"
+               (metabot.settings/llm-metabot-provider)))))))
+
+(deftest settings-put-api-key-switches-from-metabase-to-provider-default-model-test
+  (mt/with-premium-features #{:metabase-ai-managed}
+    (mt/with-temp-env-var-value! [mb-llm-anthropic-api-key nil]
+      (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider "metabase/anthropic/claude-sonnet-4-6"
+                                         llm.settings/llm-anthropic-api-key    nil]
+        (let [calls (atom 0)]
+          (with-redefs [metabot.self/list-models (fn [provider {:keys [api-key]}]
+                                                   (swap! calls inc)
+                                                   (is (= "anthropic" provider))
+                                                   (is (= "sk-ant-valid" api-key))
+                                                   (is (nil? (llm.settings/llm-anthropic-api-key))
+                                                       "verification should happen before saving the key")
+                                                   {:models [{:id "claude-sonnet-4-6"
+                                                              :display_name "Claude Sonnet 4.6"
+                                                              :group "Sonnet"}
+                                                             {:id "claude-opus-4-1"
+                                                              :display_name "Claude Opus 4.1"
+                                                              :group "Opus"}]})]
+            (is (= {:value  "anthropic/claude-sonnet-4-6"
+                    :models [{:id "claude-opus-4-1"
+                              :display_name "Claude Opus 4.1"
+                              :group "Opus"}
+                             {:id "claude-sonnet-4-6"
+                              :display_name "Claude Sonnet 4.6"
+                              :group "Sonnet"}]}
+                   (mt/user-http-request :crowberto :put 200 "metabot/settings"
+                                         {:provider "anthropic"
+                                          :api-key  "sk-ant-valid"})))
+            (is (= 1 @calls)
+                "should verify before saving and reuse the verified response")
+            (is (= "anthropic/claude-sonnet-4-6"
+                   (metabot.settings/llm-metabot-provider))
+                "switching away from the managed provider should pick the anthropic default model")
+            (is (= "sk-ant-valid"
+                   (llm.settings/llm-anthropic-api-key)))))))))
+
+(deftest metabot-provider-without-api-key-is-configured-test
+  (mt/with-premium-features #{:metabase-ai-managed}
+    (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider "metabase/anthropic/claude-sonnet-4-6"
+                                       llm.settings/llm-proxy-base-url      "https://proxy.example.com"
+                                       llm.settings/llm-anthropic-api-key    nil
+                                       llm.settings/llm-openai-api-key       nil
+                                       llm.settings/llm-openrouter-api-key   nil]
+      (is (true? (metabot.settings/llm-metabot-configured?))))))
+
+(defn- store-and-check!
+  "Helper: call store-native-parts! with the given provider setting, return the stored message."
+  [provider]
+  (binding [mb.api/*current-user-id* (mt/user->id :crowberto)]
+    (let [conv-id (str (random-uuid))]
+      (try
+        (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider provider]
+          (#'api/store-native-parts!
+           conv-id "internal"
+           [{:type :start :id "msg-1"}
+            {:type :text :text "Hello"}
+            {:type :usage :model "claude-sonnet-4-6" :usage {:promptTokens 100 :completionTokens 50}}
+            {:type :data :data-type "state" :data {:step 1}}
+            {:type :finish}])
+          (t2/select-one :model/MetabotMessage :conversation_id conv-id))
+        (finally
+          (t2/delete! :model/MetabotMessage :conversation_id conv-id)
+          (t2/delete! :model/MetabotConversation :id conv-id))))))
+
+(deftest store-native-parts-ai-proxy-test
+  (testing "metabase/ provider prefix sets ai_proxied true and stores bare model names"
+    (mt/with-premium-features #{:metabase-ai-managed}
+      (let [msg (store-and-check! "metabase/anthropic/claude-sonnet-4-6")]
+        (is (true? (:ai_proxied msg)))
+        (is (= {:claude-sonnet-4-6 {:prompt 100 :completion 50}}
+               (:usage msg))
+            "usage keys should be bare model names, not metabase/anthropic/..."))))
+
+  (testing "BYOK provider (no metabase/ prefix) sets ai_proxied false"
+    (let [msg (store-and-check! "anthropic/claude-sonnet-4-6")]
+      (is (false? (:ai_proxied msg)))
+      (is (= {:claude-sonnet-4-6 {:prompt 100 :completion 50}}
+             (:usage msg))))))
+
+(deftest agent-streaming-returns-free-trial-limit-error-when-managed-provider-is-locked-test
+  (mt/with-premium-features #{:metabase-ai-managed}
+    (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
+                                       "metabase/anthropic/claude-sonnet-4-6"]
+      (with-redefs [premium-features/token-status             (constantly {:meters {:anthropic:claude-sonnet-4-6:tokens {:meter-value 1000000
+                                                                                                                         :is-locked   true}}})
+                    metabot.config/check-metabot-enabled!     (constantly nil)
+                    api/store-aiservice-messages!             (fn [& _]
+                                                                (throw (ex-info "should not store messages" {})))
+                    api/native-agent-streaming-request        (fn [& _]
+                                                                (throw (ex-info "should not call agent" {})))]
+        (mt/user-http-request :rasta :post 402 "metabot/agent-streaming"
+                              {:message         "test message"
+                               :context         {}
+                               :conversation_id (str (random-uuid))
+                               :history         []
+                               :state           {}})))))

--- a/enterprise/backend/test/metabase_enterprise/metabot/settings_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot/settings_test.clj
@@ -1,0 +1,77 @@
+(ns metabase-enterprise.metabot.settings-test
+  (:require
+   [clojure.test :refer [deftest is testing use-fixtures]]
+   [metabase.llm.settings :as llm.settings]
+   [metabase.metabot.settings :as metabot.settings]
+   [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]))
+
+(use-fixtures :once (fixtures/initialize :db))
+
+;;; ---------------------------------------- Managed Provider Configured Tests ----------------------------------------
+
+(deftest metabot-configured-with-metabase-provider-and-proxy-url-test
+  (testing "returns true when metabase-proxied provider and proxy URL is set"
+    (mt/with-premium-features #{:metabase-ai-managed}
+      (mt/with-temporary-setting-values [llm-metabot-provider "metabase/anthropic/claude-sonnet-4-6"
+                                         llm-proxy-base-url   "https://proxy.example.com"]
+        (is (true? (metabot.settings/llm-metabot-configured?)))))))
+
+(deftest metabot-configured-with-metabase-provider-no-proxy-url-test
+  (testing "returns false when metabase-proxied provider and no proxy URL"
+    (mt/with-premium-features #{:metabase-ai-managed}
+      (mt/with-temporary-setting-values [llm-metabot-provider "metabase/anthropic/claude-sonnet-4-6"
+                                         llm-proxy-base-url   nil]
+        (is (false? (metabot.settings/llm-metabot-configured?)))))))
+
+(deftest metabot-configured-proxy-url-not-fallback-for-direct-provider-test
+  (testing "proxy URL alone does not make a direct provider configured"
+    (mt/with-premium-features #{:metabase-ai-managed}
+      (with-redefs [llm.settings/llm-anthropic-api-key (constantly nil)]
+        (mt/with-temporary-setting-values [llm-metabot-provider "anthropic/claude-sonnet-4-6"
+                                           llm-proxy-base-url   "https://proxy.example.com"]
+          (is (false? (metabot.settings/llm-metabot-configured?))))))))
+
+;;; ----------------------------------- Managed Provider Validation Tests -------------------------------------------
+
+(deftest validate-metabot-provider-rejects-unknown-metabase-managed-provider-test
+  (testing "rejects unknown inner provider under metabase/ prefix"
+    (mt/with-premium-features #{:metabase-ai-managed}
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"Unsupported provider \"foobar\" for metabase managed AI"
+           (metabot.settings/llm-metabot-provider! "metabase/foobar/some-model"))))))
+
+(deftest validate-metabot-provider-rejects-direct-only-provider-as-managed-openai-test
+  (testing "rejects openai under metabase/ prefix (not in the managed allow-list)"
+    (mt/with-premium-features #{:metabase-ai-managed}
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"Unsupported provider \"openai\" for metabase managed AI"
+           (metabot.settings/llm-metabot-provider! "metabase/openai/gpt-4.1-mini"))))))
+
+(deftest validate-metabot-provider-rejects-direct-only-provider-as-managed-openrouter-test
+  (testing "rejects openrouter under metabase/ prefix (not in the managed allow-list)"
+    (mt/with-premium-features #{:metabase-ai-managed}
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"Unsupported provider \"openrouter\" for metabase managed AI"
+           (metabot.settings/llm-metabot-provider! "metabase/openrouter/anthropic/claude-haiku-4-5"))))))
+
+(deftest validate-metabot-provider-rejects-unsupported-metabase-managed-model-test
+  (testing "rejects unsupported model for an allowed metabase managed provider"
+    (mt/with-premium-features #{:metabase-ai-managed}
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"Unsupported model \"claude-haiku-4-5\" for metabase managed provider \"anthropic\""
+           (metabot.settings/llm-metabot-provider! "metabase/anthropic/claude-haiku-4-5"))))))
+
+(deftest validate-metabot-provider-rejects-metabase-prefix-without-model-test
+  (testing "rejects metabase/provider with no model"
+    (mt/with-premium-features #{:metabase-ai-managed}
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"Model name is required"
+           (metabot.settings/llm-metabot-provider! "metabase/anthropic/"))))))
+
+(deftest validate-metabot-provider-accepts-allowed-metabase-managed-provider-and-model-test
+  (testing "accepts allow-listed metabase managed provider/model"
+    (mt/with-premium-features #{:metabase-ai-managed}
+      (mt/with-temporary-setting-values [llm-metabot-provider "metabase/anthropic/claude-sonnet-4-6"]
+        (is (= "metabase/anthropic/claude-sonnet-4-6" (metabot.settings/llm-metabot-provider)))))))

--- a/enterprise/backend/test/metabase_enterprise/metabot/task/suggested_prompts_generator_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot/task/suggested_prompts_generator_test.clj
@@ -1,0 +1,39 @@
+(ns metabase-enterprise.metabot.task.suggested-prompts-generator-test
+  (:require
+   [clojure.test :refer [deftest is]]
+   [metabase.lib.convert :as lib.convert]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
+   [metabase.metabot.config :as metabot.config]
+   [metabase.metabot.example-question-generator :as metabot.example-question-generator]
+   [metabase.metabot.settings :as metabot.settings]
+   [metabase.metabot.task.suggested-prompts-generator :as metabot.task.suggested-prompts-generator]
+   [metabase.premium-features.core :as premium-features]
+   [metabase.test :as mt]
+   [toucan2.core :as t2]))
+
+(deftest suggested-prompts-generator-skips-generation-when-managed-provider-is-locked-test
+  (mt/with-premium-features #{:content-verification :metabase-ai-managed}
+    (mt/with-empty-h2-app-db!
+      (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
+                                         "metabase/anthropic/claude-sonnet-4-6"]
+        (let [original-metabot (t2/select-one :model/Metabot
+                                              :entity_id (get-in metabot.config/metabot-config
+                                                                 [metabot.config/internal-metabot-id :entity-id]))
+              mp (mt/metadata-provider)
+              query (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
+                        lib.convert/->legacy-MBQL)]
+          (mt/with-model-cleanup [:model/MetabotPrompt]
+            (mt/with-temp [:model/Card
+                           {card-id :id}
+                           {:type :model
+                            :dataset_query query}]
+              (t2/update! :model/Metabot (:id original-metabot) {:use_verified_content false})
+              (with-redefs [premium-features/token-status
+                            (constantly {:meters {:anthropic:claude-sonnet-4-6:tokens {:meter-value 1000000
+                                                                                       :is-locked   true}}})
+                            metabot.example-question-generator/generate-example-questions
+                            (fn [& _]
+                              (throw (ex-info "should not generate prompts" {})))]
+                (#'metabot.task.suggested-prompts-generator/maybe-generate-suggested-prompts!)
+                (is (empty? (t2/select :model/MetabotPrompt :card_id card-id)))))))))))

--- a/enterprise/backend/test/metabase_enterprise/slackbot/streaming_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/slackbot/streaming_test.clj
@@ -1,0 +1,63 @@
+(ns metabase-enterprise.slackbot.streaming-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.metabot.persistence :as metabot.persistence]
+   [metabase.premium-features.core :as premium-features]
+   [metabase.slackbot.client :as slackbot.client]
+   [metabase.slackbot.events :as slackbot.events]
+   [metabase.slackbot.streaming :as slackbot.streaming]
+   [metabase.slackbot.test-util :as tu]
+   [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
+   [metabase.util :as u]))
+
+(use-fixtures :once (fixtures/initialize :db))
+
+(deftest slackbot-posts-free-trial-limit-error-when-managed-provider-is-locked-test
+  (let [posted-message (atom nil)
+        event          {:channel "C1" :ts "123.456" :channel_type "im"}]
+    (mt/with-premium-features #{:metabase-ai-managed}
+      (mt/with-temporary-setting-values [llm-metabot-provider
+                                         "metabase/anthropic/claude-sonnet-4-6"]
+        (with-redefs [premium-features/token-status
+                      (constantly {:meters {:anthropic:claude-sonnet-4-6:tokens {:meter-value 1000000
+                                                                                 :is-locked   true}}})
+                      slackbot.events/event->reply-context
+                      (constantly {:channel "C1" :thread_ts "123.456"})
+                      slackbot.events/dm?
+                      (constantly true)
+                      slackbot.client/post-thread-reply
+                      (fn [_ message-ctx text & _]
+                        (reset! posted-message {:message-ctx message-ctx :text text})
+                        {:ok true})]
+          (slackbot.streaming/send-response {:token "xoxb-test"} event)
+          (is (= {:message-ctx {:channel "C1" :thread_ts "123.456"}
+                  :text        "You've used all of your included AI service tokens. To keep using AI features, end your trial early and start your subscription, or add your own AI provider API key."}
+                 @posted-message)))))))
+
+(deftest slackbot-streaming-sets-ai-proxied-on-messages-test
+  (testing "store-message! receives ai-proxy? = true for metabase/ prefixed provider"
+    (tu/with-slackbot-setup
+      (let [event-body tu/base-dm-event
+            store-opts (atom [])]
+        (tu/with-slackbot-mocks
+          {:ai-text "Hello!"}
+          (fn [{:keys [stop-stream-calls]}]
+            (mt/with-premium-features #{:metabase-ai-managed}
+              (mt/with-temporary-setting-values [llm-metabot-provider "metabase/anthropic/claude-sonnet-4-6"]
+                (with-redefs [premium-features/token-status
+                              (constantly nil)
+                              metabot.persistence/store-message!
+                              (fn [_conv-id _profile-id _messages & {:as opts}]
+                                (swap! store-opts conj opts)
+                                nil)]
+                  (mt/client :post 200 "metabot/slack/events"
+                             (tu/slack-request-options event-body)
+                             event-body)
+                  (u/poll {:thunk      #(>= (count @stop-stream-calls) 1)
+                           :done?      true?
+                           :timeout-ms 5000}))))
+            (testing "user + assistant store-message! calls both received ai-proxy? = true"
+              (is (=? [{:ai-proxy? true}
+                       {:ai-proxy? true}]
+                      @store-opts)))))))))

--- a/src/metabase/metabot/settings.clj
+++ b/src/metabase/metabot/settings.clj
@@ -109,12 +109,12 @@
   "Default provider/model used for Metabot when no explicit model is selected."
   (str "anthropic/" default-anthropic-llm-metabot-model))
 
-(def default-llm-metabot-model-by-provider
+(def ^:private default-llm-metabot-model-by-provider
   "Default model payload keyed by provider for `PUT /api/metabot/settings`.
 
   Values match the shape expected in the request body for each provider: direct providers use a bare model ID, while the
   managed `metabase` provider uses the proxied `provider/model` form."
-  {"anthropic"                       default-anthropic-llm-metabot-model
+  {"anthropic"                            default-anthropic-llm-metabot-model
    provider-util/metabase-provider-prefix default-llm-metabot-provider})
 
 (def default-metabase-llm-metabot-provider
@@ -124,6 +124,15 @@
 (def supported-metabot-providers
   "Set of supported LLM provider prefixes for the `llm-metabot-provider` setting."
   (conj direct-providers provider-util/metabase-provider-prefix))
+
+(defn default-model-for-provider
+  "Return the default request-model payload for a provider.
+
+  When `provider` is nil, fall back to the global default provider/model string."
+  [provider]
+  (if (nil? provider)
+    default-llm-metabot-provider
+    (get default-llm-metabot-model-by-provider provider)))
 
 (defn validate-llm-provider-type!
   "Validate that `value` is a string. Throws with `:status-code 400` otherwise."
@@ -154,15 +163,6 @@
       (throw (ex-info (tru "Model name is required. Expected format: provider/model, e.g. \"anthropic/claude-haiku-4-5\"")
                       {:status-code 400
                        :value       value})))))
-
-(defn default-model-for-provider
-  "Return the default request-model payload for a provider.
-
-  When `provider` is nil, fall back to the global default provider/model string."
-  [provider]
-  (if (nil? provider)
-    default-llm-metabot-provider
-    (get default-llm-metabot-model-by-provider provider)))
 
 (defenterprise validate-metabot-provider!
   "Validate that `value` has the format `provider/model` with a supported provider prefix.

--- a/src/metabase/metabot/settings.clj
+++ b/src/metabase/metabot/settings.clj
@@ -3,6 +3,7 @@
    [clojure.string :as str]
    [metabase.llm.settings :as llm.settings]
    [metabase.metabot.provider-util :as provider-util]
+   [metabase.premium-features.core :refer [defenterprise]]
    [metabase.settings.core :as setting :refer [defsetting]]
    [metabase.util.i18n :refer [deferred-tru tru]]))
 
@@ -120,17 +121,18 @@
   "Managed-provider version of [[default-llm-metabot-provider]]."
   (str provider-util/metabase-provider-prefix "/" default-llm-metabot-provider))
 
-(def ^:private proxied-providers-and-models
-  "Providers and models that can be used via the metabase managed AI proxy.
-
-  The keys of this map must be a subset of the [[direct-providers]]."
-  {"anthropic" #{"claude-sonnet-4-6"}})
-
 (def supported-metabot-providers
   "Set of supported LLM provider prefixes for the `llm-metabot-provider` setting."
   (conj direct-providers provider-util/metabase-provider-prefix))
 
-(defn- validate-direct-provider!
+(defn validate-llm-provider-type!
+  "Validate that `value` is a string. Throws with `:status-code 400` otherwise."
+  [value]
+  (when-not (string? value)
+    (throw (ex-info (tru "Metabot provider must be a string, got: {0}" (pr-str value))
+                    {:status-code 400}))))
+
+(defn validate-direct-provider!
   "Validate that `value` is a `provider/model` string for one of the [[direct-providers]]
   (i.e. *not* using the `metabase/` proxy prefix). Throws on invalid input."
   [value]
@@ -153,40 +155,6 @@
                       {:status-code 400
                        :value       value})))))
 
-(defn- validate-metabase-managed-provider!
-  "Validate that `value` is a `metabase/provider/model` string whose inner provider and
-  model are in the [[proxied-providers-and-models]] allow-list. Throws on invalid input."
-  [value]
-  (when-not (provider-util/metabase-provider? value)
-    (throw (ex-info (tru "Invalid metabase managed AI provider {0}. Must start with {1}/."
-                         (pr-str value) provider-util/metabase-provider-prefix)
-                    {:status-code 400
-                     :value       value})))
-  (let [inner-provider    (provider-util/provider-and-model->provider value)
-        inner-model       (provider-util/provider-and-model->model value)
-        allowed-providers (sort (keys proxied-providers-and-models))
-        allowed-models    (get proxied-providers-and-models inner-provider)]
-    (when-not (contains? proxied-providers-and-models inner-provider)
-      (throw (ex-info (tru "Unsupported provider {0} for metabase managed AI. Supported providers: {1}"
-                           (pr-str inner-provider)
-                           (str/join ", " allowed-providers))
-                      {:status-code 400
-                       :provider    inner-provider
-                       :supported   (set (keys proxied-providers-and-models))})))
-    (when (str/blank? inner-model)
-      (throw (ex-info (tru "Model name is required. Expected format: metabase/provider/model, e.g. {0}"
-                           (pr-str default-metabase-llm-metabot-provider))
-                      {:status-code 400
-                       :value       value})))
-    (when-not (contains? allowed-models inner-model)
-      (throw (ex-info (tru "Unsupported model {0} for metabase managed provider {1}. Supported models: {2}"
-                           (pr-str inner-model)
-                           (pr-str inner-provider)
-                           (str/join ", " (sort allowed-models)))
-                      {:status-code 400
-                       :provider    inner-provider
-                       :model       inner-model
-                       :supported   allowed-models})))))
 (defn default-model-for-provider
   "Return the default request-model payload for a provider.
 
@@ -196,18 +164,15 @@
     default-llm-metabot-provider
     (get default-llm-metabot-model-by-provider provider)))
 
-(defn- validate-metabot-provider!
+(defenterprise validate-metabot-provider!
   "Validate that `value` has the format `provider/model` with a supported provider prefix.
-  Dispatches to [[validate-metabase-managed-provider!]] when `value` uses the
-  `metabase/` proxy prefix and to [[validate-direct-provider!]] otherwise.
+  In OSS, only direct providers are supported. In EE (with `:metabase-ai-managed` or
+  `:metabot-v3`), the `metabase/` managed provider prefix is also supported.
   Throws an exception with `:status-code 400` on invalid input."
+  metabase-enterprise.metabot.settings
   [value]
-  (when-not (string? value)
-    (throw (ex-info (tru "Metabot provider must be a string, got: {0}" (pr-str value))
-                    {:status-code 400})))
-  (if (provider-util/metabase-provider? value)
-    (validate-metabase-managed-provider! value)
-    (validate-direct-provider! value)))
+  (validate-llm-provider-type! value)
+  (validate-direct-provider! value))
 
 (defsetting llm-metabot-provider
   (deferred-tru "The AI provider and model for Metabot. Format: provider/model-name, e.g. `anthropic/claude-haiku-4-5`, `openai/gpt-4.1-mini`, `openrouter/anthropic/claude-haiku-4-5`.")

--- a/src/metabase/metabot/settings.clj
+++ b/src/metabase/metabot/settings.clj
@@ -105,7 +105,7 @@
   "Default Anthropic model used for Metabot when no explicit model is selected."
   "claude-sonnet-4-6")
 
-(def default-llm-metabot-provider
+(def ^:private default-llm-metabot-provider
   "Default provider/model used for Metabot when no explicit model is selected."
   (str "anthropic/" default-anthropic-llm-metabot-model))
 

--- a/test/metabase/llm/startup_test.clj
+++ b/test/metabase/llm/startup_test.clj
@@ -11,35 +11,37 @@
 (use-fixtures :once (fixtures/initialize :db))
 
 (deftest check-and-sync-settings-on-startup-syncs-legacy-metabot-default-test
-  (mt/discard-setting-changes [llm-metabot-provider]
-    (mt/with-temporary-raw-setting-values [llm-metabot-provider nil]
-      (with-redefs [premium-features/canonically-has-feature?
-                    (fn [feature]
-                      (case feature
-                        :metabot-v3 true
-                        :metabase-ai-managed false))
-                    metabot.settings/llm-metabot-configured? (constantly false)]
-        (llm.startup/check-and-sync-settings-on-startup!)
-        (is (= metabot.settings/default-metabase-llm-metabot-provider
-               (metabot.settings/llm-metabot-provider)))))))
+  (mt/with-premium-features #{:metabot-v3}
+    (mt/discard-setting-changes [llm-metabot-provider]
+      (mt/with-temporary-raw-setting-values [llm-metabot-provider nil]
+        (with-redefs [premium-features/canonically-has-feature?
+                      (fn [feature]
+                        (case feature
+                          :metabot-v3 true
+                          :metabase-ai-managed false))
+                      metabot.settings/llm-metabot-configured? (constantly false)]
+          (llm.startup/check-and-sync-settings-on-startup!)
+          (is (= metabot.settings/default-metabase-llm-metabot-provider
+                 (metabot.settings/llm-metabot-provider))))))))
 
 (deftest check-and-sync-settings-on-startup-feature-permutations-test
   (doseq [legacy-result [nil false true]
           managed-result [nil false true]]
     (testing (format ":metabot-v3=%s :metabase-ai-managed=%s" legacy-result managed-result)
-      (mt/discard-setting-changes [llm-metabot-provider]
-        (mt/with-temporary-raw-setting-values [llm-metabot-provider nil]
-          (with-redefs [premium-features/canonically-has-feature?
-                        (fn [feature]
-                          (case feature
-                            :metabot-v3 legacy-result
-                            :metabase-ai-managed managed-result))
-                        metabot.settings/llm-metabot-configured? (constantly false)]
-            (llm.startup/check-and-sync-settings-on-startup!)
-            (is (= (case [legacy-result managed-result]
-                     [true false] metabot.settings/default-metabase-llm-metabot-provider
-                     nil)
-                   (setting/db-stored-value :llm-metabot-provider)))))))))
+      (mt/with-premium-features #{:metabot-v3}
+        (mt/discard-setting-changes [llm-metabot-provider]
+          (mt/with-temporary-raw-setting-values [llm-metabot-provider nil]
+            (with-redefs [premium-features/canonically-has-feature?
+                          (fn [feature]
+                            (case feature
+                              :metabot-v3 legacy-result
+                              :metabase-ai-managed managed-result))
+                          metabot.settings/llm-metabot-configured? (constantly false)]
+              (llm.startup/check-and-sync-settings-on-startup!)
+              (is (= (case [legacy-result managed-result]
+                       [true false] metabot.settings/default-metabase-llm-metabot-provider
+                       nil)
+                     (setting/db-stored-value :llm-metabot-provider))))))))))
 
 (deftest check-and-sync-settings-on-startup-does-not-overwrite-configured-byok-test
   (mt/discard-setting-changes [llm-metabot-provider]
@@ -68,14 +70,15 @@
                (metabot.settings/llm-metabot-provider)))))))
 
 (deftest check-and-sync-settings-on-startup-syncs-blank-provider-test
-  (mt/discard-setting-changes [llm-metabot-provider]
-    (mt/with-temporary-raw-setting-values [llm-metabot-provider ""]
-      (with-redefs [premium-features/canonically-has-feature?
-                    (fn [feature]
-                      (case feature
-                        :metabot-v3 true
-                        :metabase-ai-managed false))
-                    metabot.settings/llm-metabot-configured? (constantly false)]
-        (llm.startup/check-and-sync-settings-on-startup!)
-        (is (= metabot.settings/default-metabase-llm-metabot-provider
-               (metabot.settings/llm-metabot-provider)))))))
+  (mt/with-premium-features #{:metabot-v3}
+    (mt/discard-setting-changes [llm-metabot-provider]
+      (mt/with-temporary-raw-setting-values [llm-metabot-provider ""]
+        (with-redefs [premium-features/canonically-has-feature?
+                      (fn [feature]
+                        (case feature
+                          :metabot-v3 true
+                          :metabase-ai-managed false))
+                      metabot.settings/llm-metabot-configured? (constantly false)]
+          (llm.startup/check-and-sync-settings-on-startup!)
+          (is (= metabot.settings/default-metabase-llm-metabot-provider
+                 (metabot.settings/llm-metabot-provider))))))))

--- a/test/metabase/llm/startup_test.clj
+++ b/test/metabase/llm/startup_test.clj
@@ -53,8 +53,9 @@
                         :metabase-ai-managed false))
                     metabot.settings/llm-metabot-configured? (constantly true)]
         (llm.startup/check-and-sync-settings-on-startup!)
-        (is (= metabot.settings/default-llm-metabot-provider
-               (metabot.settings/llm-metabot-provider)))))))
+        (is (= @#'metabot.settings/default-llm-metabot-provider
+               (metabot.settings/llm-metabot-provider)))
+        (is (nil? (setting/db-stored-value :llm-metabot-provider)))))))
 
 (deftest check-and-sync-settings-on-startup-does-not-overwrite-explicit-provider-test
   (mt/discard-setting-changes [llm-metabot-provider]

--- a/test/metabase/llm/startup_test.clj
+++ b/test/metabase/llm/startup_test.clj
@@ -10,39 +10,6 @@
 
 (use-fixtures :once (fixtures/initialize :db))
 
-(deftest check-and-sync-settings-on-startup-syncs-legacy-metabot-default-test
-  (mt/with-premium-features #{:metabot-v3}
-    (mt/discard-setting-changes [llm-metabot-provider]
-      (mt/with-temporary-raw-setting-values [llm-metabot-provider nil]
-        (with-redefs [premium-features/canonically-has-feature?
-                      (fn [feature]
-                        (case feature
-                          :metabot-v3 true
-                          :metabase-ai-managed false))
-                      metabot.settings/llm-metabot-configured? (constantly false)]
-          (llm.startup/check-and-sync-settings-on-startup!)
-          (is (= metabot.settings/default-metabase-llm-metabot-provider
-                 (metabot.settings/llm-metabot-provider))))))))
-
-(deftest check-and-sync-settings-on-startup-feature-permutations-test
-  (doseq [legacy-result [nil false true]
-          managed-result [nil false true]]
-    (testing (format ":metabot-v3=%s :metabase-ai-managed=%s" legacy-result managed-result)
-      (mt/with-premium-features #{:metabot-v3}
-        (mt/discard-setting-changes [llm-metabot-provider]
-          (mt/with-temporary-raw-setting-values [llm-metabot-provider nil]
-            (with-redefs [premium-features/canonically-has-feature?
-                          (fn [feature]
-                            (case feature
-                              :metabot-v3 legacy-result
-                              :metabase-ai-managed managed-result))
-                          metabot.settings/llm-metabot-configured? (constantly false)]
-              (llm.startup/check-and-sync-settings-on-startup!)
-              (is (= (case [legacy-result managed-result]
-                       [true false] metabot.settings/default-metabase-llm-metabot-provider
-                       nil)
-                     (setting/db-stored-value :llm-metabot-provider))))))))))
-
 (deftest check-and-sync-settings-on-startup-does-not-overwrite-configured-byok-test
   (mt/discard-setting-changes [llm-metabot-provider]
     (mt/with-temporary-raw-setting-values [llm-metabot-provider nil]
@@ -69,17 +36,3 @@
         (llm.startup/check-and-sync-settings-on-startup!)
         (is (= "openai/gpt-4.1-mini"
                (metabot.settings/llm-metabot-provider)))))))
-
-(deftest check-and-sync-settings-on-startup-syncs-blank-provider-test
-  (mt/with-premium-features #{:metabot-v3}
-    (mt/discard-setting-changes [llm-metabot-provider]
-      (mt/with-temporary-raw-setting-values [llm-metabot-provider ""]
-        (with-redefs [premium-features/canonically-has-feature?
-                      (fn [feature]
-                        (case feature
-                          :metabot-v3 true
-                          :metabase-ai-managed false))
-                      metabot.settings/llm-metabot-configured? (constantly false)]
-          (llm.startup/check-and-sync-settings-on-startup!)
-          (is (= metabot.settings/default-metabase-llm-metabot-provider
-                 (metabot.settings/llm-metabot-provider))))))))

--- a/test/metabase/metabot/api/entity_analysis_test.clj
+++ b/test/metabase/metabot/api/entity_analysis_test.clj
@@ -2,8 +2,6 @@
   (:require
    [clojure.test :refer :all]
    [metabase.metabot.core :as metabot]
-   [metabase.metabot.settings :as metabot.settings]
-   [metabase.premium-features.core :as premium-features]
    [metabase.test :as mt]))
 
 (deftest analyze-chart-test
@@ -18,22 +16,3 @@
                                                                :timestamp "2023-04-15"}]})]
         (is (= {:summary "This chart shows a steady increase in sales over time, with a notable peak in Q4."}
                response))))))
-
-(deftest analyze-chart-returns-free-trial-limit-error-when-managed-provider-is-locked-test
-  (mt/with-premium-features #{:metabase-ai-managed}
-    (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
-                                       "metabase/anthropic/claude-sonnet-4-6"]
-      (with-redefs [premium-features/token-status
-                    (constantly {:meters {:anthropic:claude-sonnet-4-6:tokens {:meter-value 1000000
-                                                                               :is-locked   true}}})
-                    metabot/analyze-chart
-                    (fn [& _]
-                      (throw (ex-info "should not call analyze-chart" {})))]
-        (let [response (mt/user-http-request :rasta :post 402 "ai-entity-analysis/analyze-chart"
-                                             {:image_base64 "base64encodedimage"
-                                              :name         "Sales Trend"
-                                              :description  "Quarterly sales data"})]
-          (is (= "You've used all of your included AI service tokens. To keep using AI features, end your trial early and start your subscription, or add your own AI provider API key."
-                 (if (map? response)
-                   (:message response)
-                   response))))))))

--- a/test/metabase/metabot/api/entity_analysis_test.clj
+++ b/test/metabase/metabot/api/entity_analysis_test.clj
@@ -20,19 +20,20 @@
                response))))))
 
 (deftest analyze-chart-returns-free-trial-limit-error-when-managed-provider-is-locked-test
-  (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
-                                     "metabase/anthropic/claude-sonnet-4-6"]
-    (with-redefs [premium-features/token-status
-                  (constantly {:meters {:anthropic:claude-sonnet-4-6:tokens {:meter-value 1000000
-                                                                             :is-locked   true}}})
-                  metabot/analyze-chart
-                  (fn [& _]
-                    (throw (ex-info "should not call analyze-chart" {})))]
-      (let [response (mt/user-http-request :rasta :post 402 "ai-entity-analysis/analyze-chart"
-                                           {:image_base64 "base64encodedimage"
-                                            :name         "Sales Trend"
-                                            :description  "Quarterly sales data"})]
-        (is (= "You've used all of your included AI service tokens. To keep using AI features, end your trial early and start your subscription, or add your own AI provider API key."
-               (if (map? response)
-                 (:message response)
-                 response)))))))
+  (mt/with-premium-features #{:metabase-ai-managed}
+    (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
+                                       "metabase/anthropic/claude-sonnet-4-6"]
+      (with-redefs [premium-features/token-status
+                    (constantly {:meters {:anthropic:claude-sonnet-4-6:tokens {:meter-value 1000000
+                                                                               :is-locked   true}}})
+                    metabot/analyze-chart
+                    (fn [& _]
+                      (throw (ex-info "should not call analyze-chart" {})))]
+        (let [response (mt/user-http-request :rasta :post 402 "ai-entity-analysis/analyze-chart"
+                                             {:image_base64 "base64encodedimage"
+                                              :name         "Sales Trend"
+                                              :description  "Quarterly sales data"})]
+          (is (= "You've used all of your included AI service tokens. To keep using AI features, end your trial early and start your subscription, or add your own AI provider API key."
+                 (if (map? response)
+                   (:message response)
+                   response))))))))

--- a/test/metabase/metabot/api/metabot_test.clj
+++ b/test/metabase/metabot/api/metabot_test.clj
@@ -6,11 +6,9 @@
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.metabot.example-question-generator :as metabot.example-question-generator]
-   [metabase.metabot.settings :as metabot.settings]
    [metabase.metabot.suggested-prompts :as metabot.suggested-prompts]
    [metabase.permissions.core :as perms]
    [metabase.permissions.models.permissions-group :as perms-group]
-   [metabase.premium-features.core :as premium-features]
    [metabase.test :as mt]
    [toucan2.core :as t2]))
 
@@ -273,68 +271,6 @@
                    (:message (mt/user-http-request :crowberto :put 402
                                                    (format "metabot/metabot/%d" metabot-id)
                                                    {:use_verified_content true}))))))))))
-
-(deftest metabot-put-skips-prompt-regeneration-when-managed-provider-is-locked-test
-  (mt/dataset test-data
-    (let [model-query {:type :query, :database (mt/id), :query {:source-table (mt/id :products)}}]
-      (mt/with-premium-features #{:metabase-ai-managed}
-        (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
-                                           "metabase/anthropic/claude-sonnet-4-6"]
-          (mt/with-temp [:model/Collection {collection-id :id} {:name "Collection"}
-                         :model/Metabot {metabot-id :id} {:name "Test Metabot"
-                                                          :collection_id collection-id}
-                         :model/Card {card-id :id} {:name "Test Model Card"
-                                                    :type :model
-                                                    :dataset_query model-query}
-                         :model/MetabotPrompt {prompt-id :id} {:metabot_id metabot-id
-                                                               :prompt "existing prompt"
-                                                               :model :model
-                                                               :card_id card-id}]
-            (with-redefs [premium-features/token-status
-                          (constantly {:meters {:anthropic:claude-sonnet-4-6:tokens {:meter-value 1000000
-                                                                                     :is-locked   true}}})
-                          metabot.suggested-prompts/delete-all-metabot-prompts
-                          (fn [& _]
-                            (throw (ex-info "should not delete prompts" {})))
-                          metabot.suggested-prompts/generate-sample-prompts
-                          (fn [& _]
-                            (throw (ex-info "should not generate prompts" {})))]
-              (let [response (mt/user-http-request :crowberto :put 200
-                                                   (format "metabot/metabot/%d" metabot-id)
-                                                   {:collection_id nil})]
-                (is (nil? (:collection_id response)))
-                (is (= #{prompt-id}
-                       (t2/select-pks-set :model/MetabotPrompt :metabot_id metabot-id)))))))))))
-
-(deftest metabot-prompt-regenerate-returns-free-trial-limit-error-when-managed-provider-is-locked-test
-  (mt/dataset test-data
-    (let [model-query {:type :query, :database (mt/id), :query {:source-table (mt/id :products)}}]
-      (mt/with-premium-features #{:metabase-ai-managed}
-        (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
-                                           "metabase/anthropic/claude-sonnet-4-6"]
-          (mt/with-temp [:model/Metabot {metabot-id :id} {:name "Test Metabot"}
-                         :model/Card {card-id :id} {:name "Test Model Card"
-                                                    :type :model
-                                                    :dataset_query model-query}
-                         :model/MetabotPrompt {prompt-id :id} {:metabot_id metabot-id
-                                                               :prompt "existing prompt"
-                                                               :model :model
-                                                               :card_id card-id}]
-            (with-redefs [premium-features/token-status
-                          (constantly {:meters {:anthropic:claude-sonnet-4-6:tokens {:meter-value 1000000
-                                                                                     :is-locked   true}}})
-                          metabot.suggested-prompts/delete-all-metabot-prompts
-                          (fn [& _]
-                            (throw (ex-info "should not delete prompts" {})))
-                          metabot.suggested-prompts/generate-sample-prompts
-                          (fn [& _]
-                            (throw (ex-info "should not generate prompts" {})))]
-              (let [response (mt/user-http-request :crowberto :post 402
-                                                   (format "metabot/metabot/%d/prompt-suggestions/regenerate" metabot-id))]
-                (is (= "You've used all of your included AI service tokens. To keep using AI features, end your trial early and start your subscription, or add your own AI provider API key."
-                       (:message response))))
-              (is (= #{prompt-id}
-                     (t2/select-pks-set :model/MetabotPrompt :metabot_id metabot-id))))))))))
 
 (deftest metabot-prompt-regeneration-on-config-change-test
   (mt/dataset test-data

--- a/test/metabase/metabot/api/metabot_test.clj
+++ b/test/metabase/metabot/api/metabot_test.clj
@@ -277,62 +277,64 @@
 (deftest metabot-put-skips-prompt-regeneration-when-managed-provider-is-locked-test
   (mt/dataset test-data
     (let [model-query {:type :query, :database (mt/id), :query {:source-table (mt/id :products)}}]
-      (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
-                                         "metabase/anthropic/claude-sonnet-4-6"]
-        (mt/with-temp [:model/Collection {collection-id :id} {:name "Collection"}
-                       :model/Metabot {metabot-id :id} {:name "Test Metabot"
-                                                        :collection_id collection-id}
-                       :model/Card {card-id :id} {:name "Test Model Card"
-                                                  :type :model
-                                                  :dataset_query model-query}
-                       :model/MetabotPrompt {prompt-id :id} {:metabot_id metabot-id
-                                                             :prompt "existing prompt"
-                                                             :model :model
-                                                             :card_id card-id}]
-          (with-redefs [premium-features/token-status
-                        (constantly {:meters {:anthropic:claude-sonnet-4-6:tokens {:meter-value 1000000
-                                                                                   :is-locked   true}}})
-                        metabot.suggested-prompts/delete-all-metabot-prompts
-                        (fn [& _]
-                          (throw (ex-info "should not delete prompts" {})))
-                        metabot.suggested-prompts/generate-sample-prompts
-                        (fn [& _]
-                          (throw (ex-info "should not generate prompts" {})))]
-            (let [response (mt/user-http-request :crowberto :put 200
-                                                 (format "metabot/metabot/%d" metabot-id)
-                                                 {:collection_id nil})]
-              (is (nil? (:collection_id response)))
-              (is (= #{prompt-id}
-                     (t2/select-pks-set :model/MetabotPrompt :metabot_id metabot-id))))))))))
+      (mt/with-premium-features #{:metabase-ai-managed}
+        (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
+                                           "metabase/anthropic/claude-sonnet-4-6"]
+          (mt/with-temp [:model/Collection {collection-id :id} {:name "Collection"}
+                         :model/Metabot {metabot-id :id} {:name "Test Metabot"
+                                                          :collection_id collection-id}
+                         :model/Card {card-id :id} {:name "Test Model Card"
+                                                    :type :model
+                                                    :dataset_query model-query}
+                         :model/MetabotPrompt {prompt-id :id} {:metabot_id metabot-id
+                                                               :prompt "existing prompt"
+                                                               :model :model
+                                                               :card_id card-id}]
+            (with-redefs [premium-features/token-status
+                          (constantly {:meters {:anthropic:claude-sonnet-4-6:tokens {:meter-value 1000000
+                                                                                     :is-locked   true}}})
+                          metabot.suggested-prompts/delete-all-metabot-prompts
+                          (fn [& _]
+                            (throw (ex-info "should not delete prompts" {})))
+                          metabot.suggested-prompts/generate-sample-prompts
+                          (fn [& _]
+                            (throw (ex-info "should not generate prompts" {})))]
+              (let [response (mt/user-http-request :crowberto :put 200
+                                                   (format "metabot/metabot/%d" metabot-id)
+                                                   {:collection_id nil})]
+                (is (nil? (:collection_id response)))
+                (is (= #{prompt-id}
+                       (t2/select-pks-set :model/MetabotPrompt :metabot_id metabot-id)))))))))))
 
 (deftest metabot-prompt-regenerate-returns-free-trial-limit-error-when-managed-provider-is-locked-test
   (mt/dataset test-data
     (let [model-query {:type :query, :database (mt/id), :query {:source-table (mt/id :products)}}]
-      (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
-                                         "metabase/anthropic/claude-sonnet-4-6"]
-        (mt/with-temp [:model/Metabot {metabot-id :id} {:name "Test Metabot"}
-                       :model/Card {card-id :id} {:name "Test Model Card"
-                                                  :type :model
-                                                  :dataset_query model-query}
-                       :model/MetabotPrompt {prompt-id :id} {:metabot_id metabot-id
-                                                             :prompt "existing prompt"
-                                                             :model :model
-                                                             :card_id card-id}]
-          (with-redefs [premium-features/token-status
-                        (constantly {:meters {:anthropic:claude-sonnet-4-6:tokens {:meter-value 1000000
-                                                                                   :is-locked   true}}})
-                        metabot.suggested-prompts/delete-all-metabot-prompts
-                        (fn [& _]
-                          (throw (ex-info "should not delete prompts" {})))
-                        metabot.suggested-prompts/generate-sample-prompts
-                        (fn [& _]
-                          (throw (ex-info "should not generate prompts" {})))]
-            (let [response (mt/user-http-request :crowberto :post 402
-                                                 (format "metabot/metabot/%d/prompt-suggestions/regenerate" metabot-id))]
-              (is (= "You've used all of your included AI service tokens. To keep using AI features, end your trial early and start your subscription, or add your own AI provider API key."
-                     (:message response))))
-            (is (= #{prompt-id}
-                   (t2/select-pks-set :model/MetabotPrompt :metabot_id metabot-id)))))))))
+      (mt/with-premium-features #{:metabase-ai-managed}
+        (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
+                                           "metabase/anthropic/claude-sonnet-4-6"]
+          (mt/with-temp [:model/Metabot {metabot-id :id} {:name "Test Metabot"}
+                         :model/Card {card-id :id} {:name "Test Model Card"
+                                                    :type :model
+                                                    :dataset_query model-query}
+                         :model/MetabotPrompt {prompt-id :id} {:metabot_id metabot-id
+                                                               :prompt "existing prompt"
+                                                               :model :model
+                                                               :card_id card-id}]
+            (with-redefs [premium-features/token-status
+                          (constantly {:meters {:anthropic:claude-sonnet-4-6:tokens {:meter-value 1000000
+                                                                                     :is-locked   true}}})
+                          metabot.suggested-prompts/delete-all-metabot-prompts
+                          (fn [& _]
+                            (throw (ex-info "should not delete prompts" {})))
+                          metabot.suggested-prompts/generate-sample-prompts
+                          (fn [& _]
+                            (throw (ex-info "should not generate prompts" {})))]
+              (let [response (mt/user-http-request :crowberto :post 402
+                                                   (format "metabot/metabot/%d/prompt-suggestions/regenerate" metabot-id))]
+                (is (= "You've used all of your included AI service tokens. To keep using AI features, end your trial early and start your subscription, or add your own AI provider API key."
+                       (:message response))))
+              (is (= #{prompt-id}
+                     (t2/select-pks-set :model/MetabotPrompt :metabot_id metabot-id))))))))))
 
 (deftest metabot-prompt-regeneration-on-config-change-test
   (mt/dataset test-data

--- a/test/metabase/metabot/api_test.clj
+++ b/test/metabase/metabot/api_test.clj
@@ -5,7 +5,6 @@
    [clojure.test :refer :all]
    [compojure.response]
    [medley.core :as m]
-   [metabase.api.common :as mb.api]
    [metabase.config.core :as config]
    [metabase.lib.convert :as lib.convert]
    [metabase.lib.core :as lib]
@@ -20,7 +19,6 @@
    [metabase.metabot.self.openrouter :as openrouter]
    [metabase.metabot.settings :as metabot.settings]
    [metabase.metabot.test-util :as mut]
-   [metabase.premium-features.core :as premium-features]
    [metabase.search.test-util :as search.tu]
    [metabase.server.instance :as server.instance]
    [metabase.server.streaming-response :as sr]
@@ -269,25 +267,6 @@
              (mt/user-http-request :crowberto :get 200 "metabot/settings"
                                    :provider "openrouter"))))))
 
-(deftest settings-get-returns-metabase-models-without-api-key-test
-  (mt/with-premium-features #{:metabase-ai-managed}
-    (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider "metabase/anthropic/claude-sonnet-4-6"]
-      (with-redefs [metabot.self/list-models (fn
-                                               ([provider]
-                                                (is false (str "unexpected list-models call: " provider)))
-                                               ([provider opts]
-                                                (is (= "anthropic" provider))
-                                                (is (= {:ai-proxy? true} opts))
-                                                {:models [{:id "claude-haiku-4-5" :display_name "Claude Haiku 4.5"}
-                                                          {:id "claude-sonnet-4-6" :display_name "Claude Sonnet 4.6"}
-                                                          {:id "claude-opus-4-1" :display_name "Claude Opus 4.1"}]}))]
-        (is (= {:value  "metabase/anthropic/claude-sonnet-4-6"
-                :models [{:id "anthropic/claude-haiku-4-5" :display_name "Claude Haiku 4.5"}
-                         {:id "anthropic/claude-sonnet-4-6" :display_name "Claude Sonnet 4.6"}
-                         {:id "anthropic/claude-opus-4-1" :display_name "Claude Opus 4.1"}]}
-               (mt/user-http-request :crowberto :get 200 "metabot/settings"
-                                     :provider "metabase")))))))
-
 (deftest settings-put-updates-provider-test
   (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider "anthropic/claude-haiku-4-5"
                                      llm.settings/llm-openai-api-key      "sk-valid"]
@@ -309,50 +288,6 @@
                                     :model    "gpt-4.1-mini"})))
       (is (= "openai/gpt-4.1-mini"
              (metabot.settings/llm-metabot-provider))))))
-
-(deftest settings-put-updates-metabase-provider-without-api-key-test
-  (mt/with-premium-features #{:metabase-ai-managed}
-    (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider "anthropic/claude-haiku-4-5"]
-      (with-redefs [metabot.self/list-models (fn
-                                               ([provider]
-                                                (is false (str "unexpected list-models call: " provider)))
-                                               ([provider opts]
-                                                (is (= "anthropic" provider))
-                                                (is (= {:ai-proxy? true} opts))
-                                                {:models [{:id "claude-haiku-4-5" :display_name "Claude Haiku 4.5"}
-                                                          {:id "claude-sonnet-4-6" :display_name "Claude Sonnet 4.6"}
-                                                          {:id "claude-opus-4-1" :display_name "Claude Opus 4.1"}]}))]
-        (is (= {:value  "metabase/anthropic/claude-sonnet-4-6"
-                :models [{:id "anthropic/claude-haiku-4-5" :display_name "Claude Haiku 4.5"}
-                         {:id "anthropic/claude-sonnet-4-6" :display_name "Claude Sonnet 4.6"}
-                         {:id "anthropic/claude-opus-4-1" :display_name "Claude Opus 4.1"}]}
-               (mt/user-http-request :crowberto :put 200 "metabot/settings"
-                                     {:provider "metabase"
-                                      :model    "anthropic/claude-sonnet-4-6"})))
-        (is (= "metabase/anthropic/claude-sonnet-4-6"
-               (metabot.settings/llm-metabot-provider)))))))
-
-(deftest settings-put-defaults-empty-metabase-model-test
-  (mt/with-premium-features #{:metabase-ai-managed}
-    (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider "anthropic/claude-haiku-4-5"]
-      (with-redefs [metabot.self/list-models (fn
-                                               ([provider]
-                                                (is false (str "unexpected list-models call: " provider)))
-                                               ([provider opts]
-                                                (is (= "anthropic" provider))
-                                                (is (= {:ai-proxy? true} opts))
-                                                {:models [{:id "claude-haiku-4-5" :display_name "Claude Haiku 4.5"}
-                                                          {:id "claude-sonnet-4-6" :display_name "Claude Sonnet 4.6"}
-                                                          {:id "claude-opus-4-1" :display_name "Claude Opus 4.1"}]}))]
-        (is (= {:value  "metabase/anthropic/claude-sonnet-4-6"
-                :models [{:id "anthropic/claude-haiku-4-5" :display_name "Claude Haiku 4.5"}
-                         {:id "anthropic/claude-sonnet-4-6" :display_name "Claude Sonnet 4.6"}
-                         {:id "anthropic/claude-opus-4-1" :display_name "Claude Opus 4.1"}]}
-               (mt/user-http-request :crowberto :put 200 "metabot/settings"
-                                     {:provider "metabase"
-                                      :model    ""})))
-        (is (= "metabase/anthropic/claude-sonnet-4-6"
-               (metabot.settings/llm-metabot-provider)))))))
 
 (deftest settings-put-verifies-and-saves-api-keys-test
   (mt/with-temp-env-var-value! [mb-llm-anthropic-api-key nil]
@@ -406,42 +341,6 @@
               "rotating an API key should not reset the selected model")
           (is (= "sk-ant-valid"
                  (llm.settings/llm-anthropic-api-key))))))))
-
-(deftest settings-put-api-key-switches-from-metabase-to-provider-default-model-test
-  (mt/with-premium-features #{:metabase-ai-managed}
-    (mt/with-temp-env-var-value! [mb-llm-anthropic-api-key nil]
-      (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider "metabase/anthropic/claude-sonnet-4-6"
-                                         llm.settings/llm-anthropic-api-key    nil]
-        (let [calls (atom 0)]
-          (with-redefs [metabot.self/list-models (fn [provider {:keys [api-key]}]
-                                                   (swap! calls inc)
-                                                   (is (= "anthropic" provider))
-                                                   (is (= "sk-ant-valid" api-key))
-                                                   (is (nil? (llm.settings/llm-anthropic-api-key))
-                                                       "verification should happen before saving the key")
-                                                   {:models [{:id "claude-sonnet-4-6"
-                                                              :display_name "Claude Sonnet 4.6"
-                                                              :group "Sonnet"}
-                                                             {:id "claude-opus-4-1"
-                                                              :display_name "Claude Opus 4.1"
-                                                              :group "Opus"}]})]
-            (is (= {:value  "anthropic/claude-sonnet-4-6"
-                    :models [{:id "claude-opus-4-1"
-                              :display_name "Claude Opus 4.1"
-                              :group "Opus"}
-                             {:id "claude-sonnet-4-6"
-                              :display_name "Claude Sonnet 4.6"
-                              :group "Sonnet"}]}
-                   (mt/user-http-request :crowberto :put 200 "metabot/settings"
-                                         {:provider "anthropic"
-                                          :api-key  "sk-ant-valid"})))
-            (is (= 1 @calls)
-                "should verify before saving and reuse the verified response")
-            (is (= "anthropic/claude-sonnet-4-6"
-                   (metabot.settings/llm-metabot-provider))
-                "switching away from the managed provider should pick the anthropic default model")
-            (is (= "sk-ant-valid"
-                   (llm.settings/llm-anthropic-api-key)))))))))
 
 (deftest settings-put-blank-model-does-not-reset-when-provider-is-unchanged-test
   (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider "anthropic/claude-opus-4-1"
@@ -534,15 +433,6 @@
   (mt/user-http-request :rasta :put 403 "metabot/settings"
                         {:provider "anthropic"
                          :model    "claude-haiku-4-5"}))
-
-(deftest metabot-provider-without-api-key-is-configured-test
-  (mt/with-premium-features #{:metabase-ai-managed}
-    (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider "metabase/anthropic/claude-sonnet-4-6"
-                                       llm.settings/llm-proxy-base-url      "https://proxy.example.com"
-                                       llm.settings/llm-anthropic-api-key    nil
-                                       llm.settings/llm-openai-api-key       nil
-                                       llm.settings/llm-openrouter-api-key   nil]
-      (is (true? (metabot.settings/llm-metabot-configured?))))))
 
 (deftest endpoints-require-authentication-test
   (testing "Metabot v3 endpoints require authentication"
@@ -674,41 +564,6 @@
            (into [] (#'api/combine-text-parts-xf)
                  [{:type :text, :text "solo"}])))))
 
-(defn- store-and-check!
-  "Helper: call store-native-parts! with the given provider setting, return the stored message."
-  [provider]
-  (binding [mb.api/*current-user-id* (mt/user->id :crowberto)]
-    (let [conv-id (str (random-uuid))]
-      (try
-        (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider provider]
-          (#'api/store-native-parts!
-           conv-id "internal"
-           [{:type :start :id "msg-1"}
-            {:type :text :text "Hello"}
-            ;; SSE usage parts carry bare model names (from provider API response)
-            {:type :usage :model "claude-sonnet-4-6" :usage {:promptTokens 100 :completionTokens 50}}
-            {:type :data :data-type "state" :data {:step 1}}
-            {:type :finish}])
-          (t2/select-one :model/MetabotMessage :conversation_id conv-id))
-        (finally
-          (t2/delete! :model/MetabotMessage :conversation_id conv-id)
-          (t2/delete! :model/MetabotConversation :id conv-id))))))
-
-(deftest store-native-parts-ai-proxy-test
-  (testing "metabase/ provider prefix sets ai_proxied true and stores bare model names"
-    (mt/with-premium-features #{:metabase-ai-managed}
-      (let [msg (store-and-check! "metabase/anthropic/claude-sonnet-4-6")]
-        (is (true? (:ai_proxied msg)))
-        (is (= {:claude-sonnet-4-6 {:prompt 100 :completion 50}}
-               (:usage msg))
-            "usage keys should be bare model names, not metabase/anthropic/..."))))
-
-  (testing "BYOK provider (no metabase/ prefix) sets ai_proxied false"
-    (let [msg (store-and-check! "anthropic/claude-sonnet-4-6")]
-      (is (false? (:ai_proxied msg)))
-      (is (= {:claude-sonnet-4-6 {:prompt 100 :completion 50}}
-             (:usage msg))))))
-
 (deftest strip-tool-output-bloat-test
   (testing "strips transient keys from tool-output results, keeping only :output"
     (is (= {:type :tool-output :id "call-1" :result {:output "<result>XML</result>"}}
@@ -824,21 +679,3 @@
               "metabot-id should not be nil")
           (is (= test-metabot-id (:metabot-id @captured-args))
               "metabot-id should match the input metabot_id"))))))
-
-(deftest agent-streaming-returns-free-trial-limit-error-when-managed-provider-is-locked-test
-  (mt/with-premium-features #{:metabase-ai-managed}
-    (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
-                                       "metabase/anthropic/claude-sonnet-4-6"]
-      (with-redefs [premium-features/token-status             (constantly {:meters {:anthropic:claude-sonnet-4-6:tokens {:meter-value 1000000
-                                                                                                                         :is-locked   true}}})
-                    metabot.config/check-metabot-enabled!     (constantly nil)
-                    api/store-aiservice-messages!             (fn [& _]
-                                                                (throw (ex-info "should not store messages" {})))
-                    api/native-agent-streaming-request        (fn [& _]
-                                                                (throw (ex-info "should not call agent" {})))]
-        (mt/user-http-request :rasta :post 402 "metabot/agent-streaming"
-                              {:message         "test message"
-                               :context         {}
-                               :conversation_id (str (random-uuid))
-                               :history         []
-                               :state           {}})))))

--- a/test/metabase/metabot/api_test.clj
+++ b/test/metabase/metabot/api_test.clj
@@ -270,22 +270,23 @@
                                    :provider "openrouter"))))))
 
 (deftest settings-get-returns-metabase-models-without-api-key-test
-  (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider "metabase/anthropic/claude-sonnet-4-6"]
-    (with-redefs [metabot.self/list-models (fn
-                                             ([provider]
-                                              (is false (str "unexpected list-models call: " provider)))
-                                             ([provider opts]
-                                              (is (= "anthropic" provider))
-                                              (is (= {:ai-proxy? true} opts))
-                                              {:models [{:id "claude-haiku-4-5" :display_name "Claude Haiku 4.5"}
-                                                        {:id "claude-sonnet-4-6" :display_name "Claude Sonnet 4.6"}
-                                                        {:id "claude-opus-4-1" :display_name "Claude Opus 4.1"}]}))]
-      (is (= {:value  "metabase/anthropic/claude-sonnet-4-6"
-              :models [{:id "anthropic/claude-haiku-4-5" :display_name "Claude Haiku 4.5"}
-                       {:id "anthropic/claude-sonnet-4-6" :display_name "Claude Sonnet 4.6"}
-                       {:id "anthropic/claude-opus-4-1" :display_name "Claude Opus 4.1"}]}
-             (mt/user-http-request :crowberto :get 200 "metabot/settings"
-                                   :provider "metabase"))))))
+  (mt/with-premium-features #{:metabase-ai-managed}
+    (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider "metabase/anthropic/claude-sonnet-4-6"]
+      (with-redefs [metabot.self/list-models (fn
+                                               ([provider]
+                                                (is false (str "unexpected list-models call: " provider)))
+                                               ([provider opts]
+                                                (is (= "anthropic" provider))
+                                                (is (= {:ai-proxy? true} opts))
+                                                {:models [{:id "claude-haiku-4-5" :display_name "Claude Haiku 4.5"}
+                                                          {:id "claude-sonnet-4-6" :display_name "Claude Sonnet 4.6"}
+                                                          {:id "claude-opus-4-1" :display_name "Claude Opus 4.1"}]}))]
+        (is (= {:value  "metabase/anthropic/claude-sonnet-4-6"
+                :models [{:id "anthropic/claude-haiku-4-5" :display_name "Claude Haiku 4.5"}
+                         {:id "anthropic/claude-sonnet-4-6" :display_name "Claude Sonnet 4.6"}
+                         {:id "anthropic/claude-opus-4-1" :display_name "Claude Opus 4.1"}]}
+               (mt/user-http-request :crowberto :get 200 "metabot/settings"
+                                     :provider "metabase")))))))
 
 (deftest settings-put-updates-provider-test
   (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider "anthropic/claude-haiku-4-5"
@@ -310,46 +311,48 @@
              (metabot.settings/llm-metabot-provider))))))
 
 (deftest settings-put-updates-metabase-provider-without-api-key-test
-  (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider "anthropic/claude-haiku-4-5"]
-    (with-redefs [metabot.self/list-models (fn
-                                             ([provider]
-                                              (is false (str "unexpected list-models call: " provider)))
-                                             ([provider opts]
-                                              (is (= "anthropic" provider))
-                                              (is (= {:ai-proxy? true} opts))
-                                              {:models [{:id "claude-haiku-4-5" :display_name "Claude Haiku 4.5"}
-                                                        {:id "claude-sonnet-4-6" :display_name "Claude Sonnet 4.6"}
-                                                        {:id "claude-opus-4-1" :display_name "Claude Opus 4.1"}]}))]
-      (is (= {:value  "metabase/anthropic/claude-sonnet-4-6"
-              :models [{:id "anthropic/claude-haiku-4-5" :display_name "Claude Haiku 4.5"}
-                       {:id "anthropic/claude-sonnet-4-6" :display_name "Claude Sonnet 4.6"}
-                       {:id "anthropic/claude-opus-4-1" :display_name "Claude Opus 4.1"}]}
-             (mt/user-http-request :crowberto :put 200 "metabot/settings"
-                                   {:provider "metabase"
-                                    :model    "anthropic/claude-sonnet-4-6"})))
-      (is (= "metabase/anthropic/claude-sonnet-4-6"
-             (metabot.settings/llm-metabot-provider))))))
+  (mt/with-premium-features #{:metabase-ai-managed}
+    (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider "anthropic/claude-haiku-4-5"]
+      (with-redefs [metabot.self/list-models (fn
+                                               ([provider]
+                                                (is false (str "unexpected list-models call: " provider)))
+                                               ([provider opts]
+                                                (is (= "anthropic" provider))
+                                                (is (= {:ai-proxy? true} opts))
+                                                {:models [{:id "claude-haiku-4-5" :display_name "Claude Haiku 4.5"}
+                                                          {:id "claude-sonnet-4-6" :display_name "Claude Sonnet 4.6"}
+                                                          {:id "claude-opus-4-1" :display_name "Claude Opus 4.1"}]}))]
+        (is (= {:value  "metabase/anthropic/claude-sonnet-4-6"
+                :models [{:id "anthropic/claude-haiku-4-5" :display_name "Claude Haiku 4.5"}
+                         {:id "anthropic/claude-sonnet-4-6" :display_name "Claude Sonnet 4.6"}
+                         {:id "anthropic/claude-opus-4-1" :display_name "Claude Opus 4.1"}]}
+               (mt/user-http-request :crowberto :put 200 "metabot/settings"
+                                     {:provider "metabase"
+                                      :model    "anthropic/claude-sonnet-4-6"})))
+        (is (= "metabase/anthropic/claude-sonnet-4-6"
+               (metabot.settings/llm-metabot-provider)))))))
 
 (deftest settings-put-defaults-empty-metabase-model-test
-  (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider "anthropic/claude-haiku-4-5"]
-    (with-redefs [metabot.self/list-models (fn
-                                             ([provider]
-                                              (is false (str "unexpected list-models call: " provider)))
-                                             ([provider opts]
-                                              (is (= "anthropic" provider))
-                                              (is (= {:ai-proxy? true} opts))
-                                              {:models [{:id "claude-haiku-4-5" :display_name "Claude Haiku 4.5"}
-                                                        {:id "claude-sonnet-4-6" :display_name "Claude Sonnet 4.6"}
-                                                        {:id "claude-opus-4-1" :display_name "Claude Opus 4.1"}]}))]
-      (is (= {:value  "metabase/anthropic/claude-sonnet-4-6"
-              :models [{:id "anthropic/claude-haiku-4-5" :display_name "Claude Haiku 4.5"}
-                       {:id "anthropic/claude-sonnet-4-6" :display_name "Claude Sonnet 4.6"}
-                       {:id "anthropic/claude-opus-4-1" :display_name "Claude Opus 4.1"}]}
-             (mt/user-http-request :crowberto :put 200 "metabot/settings"
-                                   {:provider "metabase"
-                                    :model    ""})))
-      (is (= "metabase/anthropic/claude-sonnet-4-6"
-             (metabot.settings/llm-metabot-provider))))))
+  (mt/with-premium-features #{:metabase-ai-managed}
+    (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider "anthropic/claude-haiku-4-5"]
+      (with-redefs [metabot.self/list-models (fn
+                                               ([provider]
+                                                (is false (str "unexpected list-models call: " provider)))
+                                               ([provider opts]
+                                                (is (= "anthropic" provider))
+                                                (is (= {:ai-proxy? true} opts))
+                                                {:models [{:id "claude-haiku-4-5" :display_name "Claude Haiku 4.5"}
+                                                          {:id "claude-sonnet-4-6" :display_name "Claude Sonnet 4.6"}
+                                                          {:id "claude-opus-4-1" :display_name "Claude Opus 4.1"}]}))]
+        (is (= {:value  "metabase/anthropic/claude-sonnet-4-6"
+                :models [{:id "anthropic/claude-haiku-4-5" :display_name "Claude Haiku 4.5"}
+                         {:id "anthropic/claude-sonnet-4-6" :display_name "Claude Sonnet 4.6"}
+                         {:id "anthropic/claude-opus-4-1" :display_name "Claude Opus 4.1"}]}
+               (mt/user-http-request :crowberto :put 200 "metabot/settings"
+                                     {:provider "metabase"
+                                      :model    ""})))
+        (is (= "metabase/anthropic/claude-sonnet-4-6"
+               (metabot.settings/llm-metabot-provider)))))))
 
 (deftest settings-put-verifies-and-saves-api-keys-test
   (mt/with-temp-env-var-value! [mb-llm-anthropic-api-key nil]
@@ -405,39 +408,40 @@
                  (llm.settings/llm-anthropic-api-key))))))))
 
 (deftest settings-put-api-key-switches-from-metabase-to-provider-default-model-test
-  (mt/with-temp-env-var-value! [mb-llm-anthropic-api-key nil]
-    (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider "metabase/anthropic/claude-sonnet-4-6"
-                                       llm.settings/llm-anthropic-api-key nil]
-      (let [calls (atom 0)]
-        (with-redefs [metabot.self/list-models (fn [provider {:keys [api-key]}]
-                                                 (swap! calls inc)
-                                                 (is (= "anthropic" provider))
-                                                 (is (= "sk-ant-valid" api-key))
-                                                 (is (nil? (llm.settings/llm-anthropic-api-key))
-                                                     "verification should happen before saving the key")
-                                                 {:models [{:id "claude-sonnet-4-6"
-                                                            :display_name "Claude Sonnet 4.6"
-                                                            :group "Sonnet"}
-                                                           {:id "claude-opus-4-1"
-                                                            :display_name "Claude Opus 4.1"
-                                                            :group "Opus"}]})]
-          (is (= {:value  "anthropic/claude-sonnet-4-6"
-                  :models [{:id "claude-opus-4-1"
-                            :display_name "Claude Opus 4.1"
-                            :group "Opus"}
-                           {:id "claude-sonnet-4-6"
-                            :display_name "Claude Sonnet 4.6"
-                            :group "Sonnet"}]}
-                 (mt/user-http-request :crowberto :put 200 "metabot/settings"
-                                       {:provider "anthropic"
-                                        :api-key  "sk-ant-valid"})))
-          (is (= 1 @calls)
-              "should verify before saving and reuse the verified response")
-          (is (= "anthropic/claude-sonnet-4-6"
-                 (metabot.settings/llm-metabot-provider))
-              "switching away from the managed provider should pick the anthropic default model")
-          (is (= "sk-ant-valid"
-                 (llm.settings/llm-anthropic-api-key))))))))
+  (mt/with-premium-features #{:metabase-ai-managed}
+    (mt/with-temp-env-var-value! [mb-llm-anthropic-api-key nil]
+      (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider "metabase/anthropic/claude-sonnet-4-6"
+                                         llm.settings/llm-anthropic-api-key    nil]
+        (let [calls (atom 0)]
+          (with-redefs [metabot.self/list-models (fn [provider {:keys [api-key]}]
+                                                   (swap! calls inc)
+                                                   (is (= "anthropic" provider))
+                                                   (is (= "sk-ant-valid" api-key))
+                                                   (is (nil? (llm.settings/llm-anthropic-api-key))
+                                                       "verification should happen before saving the key")
+                                                   {:models [{:id "claude-sonnet-4-6"
+                                                              :display_name "Claude Sonnet 4.6"
+                                                              :group "Sonnet"}
+                                                             {:id "claude-opus-4-1"
+                                                              :display_name "Claude Opus 4.1"
+                                                              :group "Opus"}]})]
+            (is (= {:value  "anthropic/claude-sonnet-4-6"
+                    :models [{:id "claude-opus-4-1"
+                              :display_name "Claude Opus 4.1"
+                              :group "Opus"}
+                             {:id "claude-sonnet-4-6"
+                              :display_name "Claude Sonnet 4.6"
+                              :group "Sonnet"}]}
+                   (mt/user-http-request :crowberto :put 200 "metabot/settings"
+                                         {:provider "anthropic"
+                                          :api-key  "sk-ant-valid"})))
+            (is (= 1 @calls)
+                "should verify before saving and reuse the verified response")
+            (is (= "anthropic/claude-sonnet-4-6"
+                   (metabot.settings/llm-metabot-provider))
+                "switching away from the managed provider should pick the anthropic default model")
+            (is (= "sk-ant-valid"
+                   (llm.settings/llm-anthropic-api-key)))))))))
 
 (deftest settings-put-blank-model-does-not-reset-when-provider-is-unchanged-test
   (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider "anthropic/claude-opus-4-1"
@@ -692,11 +696,12 @@
 
 (deftest store-native-parts-ai-proxy-test
   (testing "metabase/ provider prefix sets ai_proxied true and stores bare model names"
-    (let [msg (store-and-check! "metabase/anthropic/claude-sonnet-4-6")]
-      (is (true? (:ai_proxied msg)))
-      (is (= {:claude-sonnet-4-6 {:prompt 100 :completion 50}}
-             (:usage msg))
-          "usage keys should be bare model names, not metabase/anthropic/...")))
+    (mt/with-premium-features #{:metabase-ai-managed}
+      (let [msg (store-and-check! "metabase/anthropic/claude-sonnet-4-6")]
+        (is (true? (:ai_proxied msg)))
+        (is (= {:claude-sonnet-4-6 {:prompt 100 :completion 50}}
+               (:usage msg))
+            "usage keys should be bare model names, not metabase/anthropic/..."))))
 
   (testing "BYOK provider (no metabase/ prefix) sets ai_proxied false"
     (let [msg (store-and-check! "anthropic/claude-sonnet-4-6")]
@@ -821,18 +826,19 @@
               "metabot-id should match the input metabot_id"))))))
 
 (deftest agent-streaming-returns-free-trial-limit-error-when-managed-provider-is-locked-test
-  (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
-                                     "metabase/anthropic/claude-sonnet-4-6"]
-    (with-redefs [premium-features/token-status             (constantly {:meters {:anthropic:claude-sonnet-4-6:tokens {:meter-value 1000000
-                                                                                                                       :is-locked   true}}})
-                  metabot.config/check-metabot-enabled!     (constantly nil)
-                  api/store-aiservice-messages!             (fn [& _]
-                                                              (throw (ex-info "should not store messages" {})))
-                  api/native-agent-streaming-request        (fn [& _]
-                                                              (throw (ex-info "should not call agent" {})))]
-      (mt/user-http-request :rasta :post 402 "metabot/agent-streaming"
-                            {:message         "test message"
-                             :context         {}
-                             :conversation_id (str (random-uuid))
-                             :history         []
-                             :state           {}}))))
+  (mt/with-premium-features #{:metabase-ai-managed}
+    (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
+                                       "metabase/anthropic/claude-sonnet-4-6"]
+      (with-redefs [premium-features/token-status             (constantly {:meters {:anthropic:claude-sonnet-4-6:tokens {:meter-value 1000000
+                                                                                                                         :is-locked   true}}})
+                    metabot.config/check-metabot-enabled!     (constantly nil)
+                    api/store-aiservice-messages!             (fn [& _]
+                                                                (throw (ex-info "should not store messages" {})))
+                    api/native-agent-streaming-request        (fn [& _]
+                                                                (throw (ex-info "should not call agent" {})))]
+        (mt/user-http-request :rasta :post 402 "metabot/agent-streaming"
+                              {:message         "test message"
+                               :context         {}
+                               :conversation_id (str (random-uuid))
+                               :history         []
+                               :state           {}})))))

--- a/test/metabase/metabot/settings_test.clj
+++ b/test/metabase/metabot/settings_test.clj
@@ -76,20 +76,6 @@
       (is (boolean? (metabot.settings/embedded-metabot-enabled?)))
       (is (string? (metabot.settings/llm-metabot-provider))))))
 
-(deftest metabot-configured-with-metabase-provider-and-proxy-url-test
-  (testing "returns true when metabase-proxied provider and proxy URL is set"
-    (mt/with-premium-features #{:metabase-ai-managed}
-      (mt/with-temporary-setting-values [llm-metabot-provider "metabase/anthropic/claude-sonnet-4-6"
-                                         llm-proxy-base-url   "https://proxy.example.com"]
-        (is (true? (metabot.settings/llm-metabot-configured?)))))))
-
-(deftest metabot-configured-with-metabase-provider-no-proxy-url-test
-  (testing "returns false when metabase-proxied provider and no proxy URL"
-    (mt/with-premium-features #{:metabase-ai-managed}
-      (mt/with-temporary-setting-values [llm-metabot-provider "metabase/anthropic/claude-sonnet-4-6"
-                                         llm-proxy-base-url   nil]
-        (is (false? (metabot.settings/llm-metabot-configured?)))))))
-
 (deftest metabot-configured-with-direct-provider-and-api-key-test
   (testing "returns true when direct provider has API key set"
     (mt/with-temporary-setting-values [llm-metabot-provider  "anthropic/claude-sonnet-4-6"
@@ -104,14 +90,11 @@
 
 (deftest metabot-configured-proxy-url-not-fallback-for-direct-provider-test
   (testing "proxy URL alone does not make a direct provider configured"
-    (mt/with-premium-features #{:metabase-ai-managed}
-      (with-redefs [llm.settings/llm-anthropic-api-key (constantly nil)]
-        (mt/with-temporary-setting-values [llm-metabot-provider "anthropic/claude-sonnet-4-6"
-                                           llm-proxy-base-url   "https://proxy.example.com"]
-          (is (false? (metabot.settings/llm-metabot-configured?))))))))
+    (with-redefs [llm.settings/llm-anthropic-api-key (constantly nil)]
+      (mt/with-temporary-setting-values [llm-metabot-provider "anthropic/claude-sonnet-4-6"]
+        (is (false? (metabot.settings/llm-metabot-configured?)))))))
 
 ;;; ------------------------------------------- validate-metabot-provider! Tests -------------------------------------------
-;; The validator is private; exercise it through the setting setter.
 
 (deftest validate-metabot-provider-rejects-non-string-test
   (testing "rejects non-string input"
@@ -131,41 +114,12 @@
          clojure.lang.ExceptionInfo #"Model name is required"
          (metabot.settings/llm-metabot-provider! "anthropic/")))))
 
-(deftest validate-metabot-provider-rejects-unknown-metabase-managed-provider-test
-  (testing "rejects unknown inner provider under metabase/ prefix"
-    (mt/with-premium-features #{:metabase-ai-managed}
+(deftest validate-metabot-provider-rejects-metabase-prefix-without-metabase-ai-managed-test
+  (testing "rejects metabase/ prefix without :metabase-ai-managed or :metabot-v3 feature"
+    (mt/with-premium-features #{}
       (is (thrown-with-msg?
-           clojure.lang.ExceptionInfo #"Unsupported provider \"foobar\" for metabase managed AI"
-           (metabot.settings/llm-metabot-provider! "metabase/foobar/some-model"))))))
-
-(deftest validate-metabot-provider-rejects-direct-only-provider-as-managed-openai-test
-  (testing "rejects openai under metabase/ prefix (not in the managed allow-list)"
-    (mt/with-premium-features #{:metabase-ai-managed}
-      (is (thrown-with-msg?
-           clojure.lang.ExceptionInfo #"Unsupported provider \"openai\" for metabase managed AI"
-           (metabot.settings/llm-metabot-provider! "metabase/openai/gpt-4.1-mini"))))))
-
-(deftest validate-metabot-provider-rejects-direct-only-provider-as-managed-openrouter-test
-  (testing "rejects openrouter under metabase/ prefix (not in the managed allow-list)"
-    (mt/with-premium-features #{:metabase-ai-managed}
-      (is (thrown-with-msg?
-           clojure.lang.ExceptionInfo #"Unsupported provider \"openrouter\" for metabase managed AI"
-           (metabot.settings/llm-metabot-provider! "metabase/openrouter/anthropic/claude-haiku-4-5"))))))
-
-(deftest validate-metabot-provider-rejects-unsupported-metabase-managed-model-test
-  (testing "rejects unsupported model for an allowed metabase managed provider"
-    (mt/with-premium-features #{:metabase-ai-managed}
-      (is (thrown-with-msg?
-           clojure.lang.ExceptionInfo
-           #"Unsupported model \"claude-haiku-4-5\" for metabase managed provider \"anthropic\""
-           (metabot.settings/llm-metabot-provider! "metabase/anthropic/claude-haiku-4-5"))))))
-
-(deftest validate-metabot-provider-rejects-metabase-prefix-without-model-test
-  (testing "rejects metabase/provider with no model"
-    (mt/with-premium-features #{:metabase-ai-managed}
-      (is (thrown-with-msg?
-           clojure.lang.ExceptionInfo #"Model name is required"
-           (metabot.settings/llm-metabot-provider! "metabase/anthropic/"))))))
+           clojure.lang.ExceptionInfo #"Must not start with metabase/"
+           (metabot.settings/llm-metabot-provider! "metabase/anthropic/claude-sonnet-4-6"))))))
 
 (deftest validate-metabot-provider-accepts-valid-direct-anthropic-test
   (testing "accepts valid direct anthropic provider string"
@@ -181,9 +135,3 @@
   (testing "accepts valid direct openrouter provider string"
     (mt/with-temporary-setting-values [llm-metabot-provider "openrouter/anthropic/claude-haiku-4-5"]
       (is (= "openrouter/anthropic/claude-haiku-4-5" (metabot.settings/llm-metabot-provider))))))
-
-(deftest validate-metabot-provider-accepts-allowed-metabase-managed-provider-and-model-test
-  (testing "accepts allow-listed metabase managed provider/model"
-    (mt/with-premium-features #{:metabase-ai-managed}
-      (mt/with-temporary-setting-values [llm-metabot-provider "metabase/anthropic/claude-sonnet-4-6"]
-        (is (= "metabase/anthropic/claude-sonnet-4-6" (metabot.settings/llm-metabot-provider)))))))

--- a/test/metabase/metabot/task/suggested_prompts_generator_test.clj
+++ b/test/metabase/metabot/task/suggested_prompts_generator_test.clj
@@ -80,7 +80,7 @@
               (t2/update! :model/Metabot (:id original-metabot) {:use_verified_content false}))))))))
 
 (deftest suggested-prompts-generator-skips-generation-when-managed-provider-is-locked-test
-  (mt/with-premium-features #{:content-verification}
+  (mt/with-premium-features #{:content-verification :metabase-ai-managed}
     (mt/with-empty-h2-app-db!
       (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
                                          "metabase/anthropic/claude-sonnet-4-6"]

--- a/test/metabase/metabot/task/suggested_prompts_generator_test.clj
+++ b/test/metabase/metabot/task/suggested_prompts_generator_test.clj
@@ -6,9 +6,7 @@
    [metabase.lib.metadata :as lib.metadata]
    [metabase.metabot.config :as metabot.config]
    [metabase.metabot.example-question-generator :as metabot.example-question-generator]
-   [metabase.metabot.settings :as metabot.settings]
    [metabase.metabot.task.suggested-prompts-generator :as metabot.task.suggested-prompts-generator]
-   [metabase.premium-features.core :as premium-features]
    [metabase.test :as mt]
    [toucan2.core :as t2]))
 
@@ -76,31 +74,5 @@
                     (let [prompts (t2/select :model/MetabotPrompt :card_id card-id)]
                       (is (seq prompts))))))
 
-            ;; Reset metabot state
+              ;; Reset metabot state
               (t2/update! :model/Metabot (:id original-metabot) {:use_verified_content false}))))))))
-
-(deftest suggested-prompts-generator-skips-generation-when-managed-provider-is-locked-test
-  (mt/with-premium-features #{:content-verification :metabase-ai-managed}
-    (mt/with-empty-h2-app-db!
-      (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
-                                         "metabase/anthropic/claude-sonnet-4-6"]
-        (let [original-metabot (t2/select-one :model/Metabot
-                                              :entity_id (get-in metabot.config/metabot-config
-                                                                 [metabot.config/internal-metabot-id :entity-id]))
-              mp (mt/metadata-provider)
-              query (-> (lib/query mp (lib.metadata/table mp (mt/id :orders)))
-                        lib.convert/->legacy-MBQL)]
-          (mt/with-model-cleanup [:model/MetabotPrompt]
-            (mt/with-temp [:model/Card
-                           {card-id :id}
-                           {:type :model
-                            :dataset_query query}]
-              (t2/update! :model/Metabot (:id original-metabot) {:use_verified_content false})
-              (with-redefs [premium-features/token-status
-                            (constantly {:meters {:anthropic:claude-sonnet-4-6:tokens {:meter-value 1000000
-                                                                                       :is-locked   true}}})
-                            metabot.example-question-generator/generate-example-questions
-                            (fn [& _]
-                              (throw (ex-info "should not generate prompts" {})))]
-                (#'metabot.task.suggested-prompts-generator/maybe-generate-suggested-prompts!)
-                (is (empty? (t2/select :model/MetabotPrompt :card_id card-id)))))))))))

--- a/test/metabase/slackbot/streaming_test.clj
+++ b/test/metabase/slackbot/streaming_test.clj
@@ -155,23 +155,24 @@
 (deftest slackbot-posts-free-trial-limit-error-when-managed-provider-is-locked-test
   (let [posted-message (atom nil)
         event          {:channel "C1" :ts "123.456" :channel_type "im"}]
-    (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
-                                       "metabase/anthropic/claude-sonnet-4-6"]
-      (with-redefs [premium-features/token-status
-                    (constantly {:meters {:anthropic:claude-sonnet-4-6:tokens {:meter-value 1000000
-                                                                               :is-locked   true}}})
-                    slackbot.events/event->reply-context
-                    (constantly {:channel "C1" :thread_ts "123.456"})
-                    slackbot.events/dm?
-                    (constantly true)
-                    slackbot.client/post-thread-reply
-                    (fn [_ message-ctx text & _]
-                      (reset! posted-message {:message-ctx message-ctx :text text})
-                      {:ok true})]
-        (slackbot.streaming/send-response {:token "xoxb-test"} event)
-        (is (= {:message-ctx {:channel "C1" :thread_ts "123.456"}
-                :text        "You've used all of your included AI service tokens. To keep using AI features, end your trial early and start your subscription, or add your own AI provider API key."}
-               @posted-message))))))
+    (mt/with-premium-features #{:metabase-ai-managed}
+      (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
+                                         "metabase/anthropic/claude-sonnet-4-6"]
+        (with-redefs [premium-features/token-status
+                      (constantly {:meters {:anthropic:claude-sonnet-4-6:tokens {:meter-value 1000000
+                                                                                 :is-locked   true}}})
+                      slackbot.events/event->reply-context
+                      (constantly {:channel "C1" :thread_ts "123.456"})
+                      slackbot.events/dm?
+                      (constantly true)
+                      slackbot.client/post-thread-reply
+                      (fn [_ message-ctx text & _]
+                        (reset! posted-message {:message-ctx message-ctx :text text})
+                        {:ok true})]
+          (slackbot.streaming/send-response {:token "xoxb-test"} event)
+          (is (= {:message-ctx {:channel "C1" :thread_ts "123.456"}
+                  :text        "You've used all of your included AI service tokens. To keep using AI features, end your trial early and start your subscription, or add your own AI provider API key."}
+                 @posted-message)))))))
 
 (deftest slackbot-streaming-sets-ai-proxied-on-messages-test
   (testing "store-message! receives ai-proxy? = true for metabase/ prefixed provider"
@@ -181,19 +182,20 @@
         (tu/with-slackbot-mocks
           {:ai-text "Hello!"}
           (fn [{:keys [stop-stream-calls]}]
-            (mt/with-temporary-setting-values [llm-metabot-provider "metabase/anthropic/claude-sonnet-4-6"]
-              (with-redefs [premium-features/token-status
-                            (constantly nil)
-                            metabot.persistence/store-message!
-                            (fn [_conv-id _profile-id _messages & {:as opts}]
-                              (swap! store-opts conj opts)
-                              nil)]
-                (mt/client :post 200 "metabot/slack/events"
-                           (tu/slack-request-options event-body)
-                           event-body)
-                (u/poll {:thunk      #(>= (count @stop-stream-calls) 1)
-                         :done?      true?
-                         :timeout-ms 5000})))
+            (mt/with-premium-features #{:metabase-ai-managed}
+              (mt/with-temporary-setting-values [llm-metabot-provider "metabase/anthropic/claude-sonnet-4-6"]
+                (with-redefs [premium-features/token-status
+                              (constantly nil)
+                              metabot.persistence/store-message!
+                              (fn [_conv-id _profile-id _messages & {:as opts}]
+                                (swap! store-opts conj opts)
+                                nil)]
+                  (mt/client :post 200 "metabot/slack/events"
+                             (tu/slack-request-options event-body)
+                             event-body)
+                  (u/poll {:thunk      #(>= (count @stop-stream-calls) 1)
+                           :done?      true?
+                           :timeout-ms 5000}))))
             (testing "user + assistant store-message! calls both received ai-proxy? = true"
               (is (=? [{:ai-proxy? true}
                        {:ai-proxy? true}]

--- a/test/metabase/slackbot/streaming_test.clj
+++ b/test/metabase/slackbot/streaming_test.clj
@@ -2,10 +2,7 @@
   (:require
    [clojure.test :refer :all]
    [metabase.metabot.persistence :as metabot.persistence]
-   [metabase.metabot.settings :as metabot.settings]
-   [metabase.premium-features.core :as premium-features]
    [metabase.slackbot.client :as slackbot.client]
-   [metabase.slackbot.events :as slackbot.events]
    [metabase.slackbot.persistence :as slackbot.persistence]
    [metabase.slackbot.streaming :as slackbot.streaming]
    [metabase.slackbot.test-util :as tu]
@@ -151,55 +148,6 @@
                   (is (= 1 (count blocks)))
                   (is (= "metabot_feedback" (:block_id (first blocks))))
                   (is (= "feedback_buttons" (:type (first (:elements (first blocks)))))))))))))))
-
-(deftest slackbot-posts-free-trial-limit-error-when-managed-provider-is-locked-test
-  (let [posted-message (atom nil)
-        event          {:channel "C1" :ts "123.456" :channel_type "im"}]
-    (mt/with-premium-features #{:metabase-ai-managed}
-      (mt/with-temporary-setting-values [metabot.settings/llm-metabot-provider
-                                         "metabase/anthropic/claude-sonnet-4-6"]
-        (with-redefs [premium-features/token-status
-                      (constantly {:meters {:anthropic:claude-sonnet-4-6:tokens {:meter-value 1000000
-                                                                                 :is-locked   true}}})
-                      slackbot.events/event->reply-context
-                      (constantly {:channel "C1" :thread_ts "123.456"})
-                      slackbot.events/dm?
-                      (constantly true)
-                      slackbot.client/post-thread-reply
-                      (fn [_ message-ctx text & _]
-                        (reset! posted-message {:message-ctx message-ctx :text text})
-                        {:ok true})]
-          (slackbot.streaming/send-response {:token "xoxb-test"} event)
-          (is (= {:message-ctx {:channel "C1" :thread_ts "123.456"}
-                  :text        "You've used all of your included AI service tokens. To keep using AI features, end your trial early and start your subscription, or add your own AI provider API key."}
-                 @posted-message)))))))
-
-(deftest slackbot-streaming-sets-ai-proxied-on-messages-test
-  (testing "store-message! receives ai-proxy? = true for metabase/ prefixed provider"
-    (tu/with-slackbot-setup
-      (let [event-body tu/base-dm-event
-            store-opts (atom [])]
-        (tu/with-slackbot-mocks
-          {:ai-text "Hello!"}
-          (fn [{:keys [stop-stream-calls]}]
-            (mt/with-premium-features #{:metabase-ai-managed}
-              (mt/with-temporary-setting-values [llm-metabot-provider "metabase/anthropic/claude-sonnet-4-6"]
-                (with-redefs [premium-features/token-status
-                              (constantly nil)
-                              metabot.persistence/store-message!
-                              (fn [_conv-id _profile-id _messages & {:as opts}]
-                                (swap! store-opts conj opts)
-                                nil)]
-                  (mt/client :post 200 "metabot/slack/events"
-                             (tu/slack-request-options event-body)
-                             event-body)
-                  (u/poll {:thunk      #(>= (count @stop-stream-calls) 1)
-                           :done?      true?
-                           :timeout-ms 5000}))))
-            (testing "user + assistant store-message! calls both received ai-proxy? = true"
-              (is (=? [{:ai-proxy? true}
-                       {:ai-proxy? true}]
-                      @store-opts)))))))))
 
 (deftest slackbot-streaming-sets-ai-proxied-false-for-byok-test
   (testing "store-message! receives ai-proxy? = false for direct BYOK provider"


### PR DESCRIPTION
Closes [BOT-1298: Move metabase managed ai code into ee](https://linear.app/metabase/issue/BOT-1298/move-metabase-managed-ai-code-into-ee)

### Description

Add a `defenterprise` for `validate-metabot-provider!` to ensure that only an EE jar with the required features supports setting a metabase managed llm provider. The `proxy-base-url` is already guarded with a `:feature` check, but this is an extra guardrail to prevent configuring a metabase provider on OSS.

Additional small refactor:

* Make `default-llm-metabot-model-by-provider` private
* Make `default-llm-metabot-provider` private


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
