### PR TITLE
Fix broken e2e tests after the Mantine upgrade

### DIFF
--- a/e2e/test/scenarios/admin/databases/database-writable-connection.cy.spec.ts
+++ b/e2e/test/scenarios/admin/databases/database-writable-connection.cy.spec.ts
@@ -359,11 +359,11 @@ function performTableEdit() {
 
 function enableGlobalModelPersistence() {
   cy.visit("/admin/performance/models");
-  cy.findByText("Disabled").click();
+  cy.findByLabelText("Disabled").click({ force: true });
 }
 
 function enableModelPersistence() {
-  cy.findByText("Model persistence").click();
+  cy.findByLabelText("Model persistence").click({ force: true });
 }
 
 function enablePersistenceForModel(modelId: CardId) {

--- a/e2e/test/scenarios/data-studio/transforms/transforms.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/transforms/transforms.cy.spec.ts
@@ -3393,7 +3393,7 @@ describe("scenarios > admin > transforms > runs", () => {
       getStartAtFilterWidget().click();
       H.popover().within(() => {
         cy.findByText("Relative date range…").click();
-        cy.findByText("Include today").click();
+        cy.findByLabelText("Include today").click();
         cy.button("Apply").click();
       });
       getStartAtFilterWidget()
@@ -3437,7 +3437,7 @@ describe("scenarios > admin > transforms > runs", () => {
       getEndAtFilterWidget().click();
       H.popover().within(() => {
         cy.findByText("Relative date range…").click();
-        cy.findByText("Include today").click();
+        cy.findByLabelText("Include today").click();
         cy.button("Apply").click();
       });
       getEndAtFilterWidget()


### PR DESCRIPTION
Resolves DEV-1838
Also resolves "transforms" test "should be able to filter runs" that was in the quarantine when @npfitz merged #72710 so the failure was hidden from him.

## Stress-test

- https://github.com/metabase/metabase/actions/runs/24717219858/job/72296661969
- https://github.com/metabase/metabase/actions/runs/24716865412/job/72295459800