### PR TITLE
Added a resource picker to embedding theme preview

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-theme-editor/theme-editor.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-theme-editor/theme-editor.cy.spec.ts
@@ -307,5 +307,45 @@ describe(
         H.main().findByText("Theme preview").should("be.visible");
       });
     });
+
+    describe("preview picker", () => {
+      beforeEach(() => {
+        H.updateSetting("enable-embedding-simple", true);
+        H.updateSetting("show-simple-embed-terms", false);
+      });
+
+      it("defaults to a dashboard and can switch to a question", () => {
+        createThemeViaApi("Picker test").then((theme) => {
+          visitThemeEditor(theme.id);
+        });
+
+        cy.log("picker button shows the default dashboard name");
+        H.main()
+          .findByLabelText("Change preview resource")
+          .should("be.visible")
+          .and("contain", "Orders in a dashboard");
+
+        cy.log("preview renders the dashboard web component");
+        H.main().find("metabase-dashboard").should("exist");
+
+        cy.log("opens the entity picker modal");
+        H.main().findByLabelText("Change preview resource").click();
+
+        H.entityPickerModal().within(() => {
+          cy.findByText("Select data to preview").should("be.visible");
+          cy.findByText("Our analytics").click();
+          cy.findByText("Orders, Count").click();
+        });
+
+        cy.log("picker button updates to the selected question");
+        H.main()
+          .findByLabelText("Change preview resource")
+          .should("contain", "Orders, Count");
+
+        cy.log("preview switches to the question web component");
+        H.main().find("metabase-question").should("exist");
+        H.main().find("metabase-dashboard").should("not.exist");
+      });
+    });
   },
 );

--- a/frontend/src/metabase/admin/embedding/components/ThemeEditor/PreviewPanel.tsx
+++ b/frontend/src/metabase/admin/embedding/components/ThemeEditor/PreviewPanel.tsx
@@ -19,7 +19,7 @@ export function PreviewPanel({ settings }: { settings: MetabaseTheme }) {
 
   const [selectedResource, setSelectedResource] =
     useState<PreviewResource | null>(null);
-  const { resource: defaultResource, isLoading: isDefaultLoading } =
+  const { resource: defaultResource, isLoading: isDefaultResourceLoading } =
     useDefaultPreviewResource();
 
   const resource = selectedResource ?? defaultResource;
@@ -43,7 +43,7 @@ export function PreviewPanel({ settings }: { settings: MetabaseTheme }) {
             isEnabled={isSimpleEmbeddingEnabled}
             isTermsAccepted={isTermsAccepted}
           />
-        ) : isDefaultLoading ? (
+        ) : isDefaultResourceLoading ? (
           <Center h="100%">
             <Loader />
           </Center>

--- a/frontend/src/metabase/admin/embedding/components/ThemeEditor/PreviewPanel.tsx
+++ b/frontend/src/metabase/admin/embedding/components/ThemeEditor/PreviewPanel.tsx
@@ -1,11 +1,15 @@
+import { useState } from "react";
 import { t } from "ttag";
 
 import { useSetting } from "metabase/common/hooks";
 import type { MetabaseTheme } from "metabase/embedding-sdk/theme";
-import { Box, Flex, Text } from "metabase/ui";
+import { Box, Center, Flex, Loader, Text } from "metabase/ui";
 
-import { DashboardPreviewLoader } from "./DashboardPreview";
 import { EnableEmbeddingPrompt } from "./EnableEmbeddingPrompt";
+import { PreviewResourcePicker } from "./PreviewResourcePicker";
+import { ResourcePreview } from "./ResourcePreview";
+import type { PreviewResource } from "./types";
+import { useDefaultPreviewResource } from "./use-default-preview-resource";
 
 export function PreviewPanel({ settings }: { settings: MetabaseTheme }) {
   const isSimpleEmbeddingEnabled = useSetting("enable-embedding-simple");
@@ -13,19 +17,44 @@ export function PreviewPanel({ settings }: { settings: MetabaseTheme }) {
 
   const isEmbeddingReady = isSimpleEmbeddingEnabled && isTermsAccepted;
 
+  const [selectedResource, setSelectedResource] =
+    useState<PreviewResource | null>(null);
+  const { resource: defaultResource, isLoading: isDefaultLoading } =
+    useDefaultPreviewResource();
+
+  const resource = selectedResource ?? defaultResource;
+
   return (
     <Flex direction="column" flex={1} bg="background-secondary">
       <Box p="xl" pb="sm">
-        <Text fw={700} fz="xl">{t`Theme preview`}</Text>
+        <Flex align="center" justify="space-between" gap="md">
+          <Text fw={700} fz="xl">{t`Theme preview`}</Text>
+          {isEmbeddingReady && resource && (
+            <PreviewResourcePicker
+              resource={resource}
+              onChange={setSelectedResource}
+            />
+          )}
+        </Flex>
       </Box>
       <Box flex={1} p="xl" pt="sm" style={{ overflow: "hidden" }}>
-        {isEmbeddingReady ? (
-          <DashboardPreviewLoader theme={settings} />
-        ) : (
+        {!isEmbeddingReady ? (
           <EnableEmbeddingPrompt
             isEnabled={isSimpleEmbeddingEnabled}
             isTermsAccepted={isTermsAccepted}
           />
+        ) : isDefaultLoading ? (
+          <Center h="100%">
+            <Loader />
+          </Center>
+        ) : resource ? (
+          <ResourcePreview theme={settings} resource={resource} />
+        ) : (
+          <Center h="100%">
+            <Text c="text-secondary">
+              {t`Create a dashboard or question to preview this theme.`}
+            </Text>
+          </Center>
         )}
       </Box>
     </Flex>

--- a/frontend/src/metabase/admin/embedding/components/ThemeEditor/PreviewPanel.unit.spec.tsx
+++ b/frontend/src/metabase/admin/embedding/components/ThemeEditor/PreviewPanel.unit.spec.tsx
@@ -1,0 +1,80 @@
+import {
+  setupRecentViewsEndpoints,
+  setupSearchEndpoints,
+} from "__support__/server-mocks";
+import { mockSettings } from "__support__/settings";
+import { renderWithProviders, screen } from "__support__/ui";
+import type { MetabaseTheme } from "metabase/embedding-sdk/theme";
+import { createMockState } from "metabase/redux/store/mocks";
+import { createMockSearchResult } from "metabase-types/api/mocks";
+
+import { PreviewPanel } from "./PreviewPanel";
+import type { PreviewResource } from "./types";
+
+jest.mock("./ResourcePreview", () => ({
+  ResourcePreview: ({ resource }: { resource: PreviewResource }) => (
+    <div
+      data-testid="resource-preview"
+      data-resource-model={resource.model}
+      data-resource-id={resource.id}
+    >
+      {resource.name}
+    </div>
+  ),
+}));
+
+const setup = ({
+  searchItems = [],
+}: {
+  searchItems?: Parameters<typeof setupSearchEndpoints>[0];
+} = {}) => {
+  setupRecentViewsEndpoints([]);
+  setupSearchEndpoints(searchItems);
+
+  const storeInitialState = createMockState({
+    settings: mockSettings({
+      "enable-embedding-simple": true,
+      "show-simple-embed-terms": false,
+    }),
+  });
+
+  return renderWithProviders(<PreviewPanel settings={{} as MetabaseTheme} />, {
+    storeInitialState,
+  });
+};
+
+describe("PreviewPanel", () => {
+  it("falls back to a question when no dashboard exists", async () => {
+    setup({
+      searchItems: [
+        createMockSearchResult({
+          id: 200,
+          model: "card",
+          name: "Only question",
+        }),
+      ],
+    });
+
+    const preview = await screen.findByTestId("resource-preview");
+    expect(preview).toHaveAttribute("data-resource-model", "card");
+    expect(preview).toHaveAttribute("data-resource-id", "200");
+    expect(preview).toHaveTextContent("Only question");
+    expect(
+      screen.getByRole("button", { name: /change preview resource/i }),
+    ).toHaveTextContent("Only question");
+  });
+
+  it("shows the empty-state message when no resource is available", async () => {
+    setup({ searchItems: [] });
+
+    expect(
+      await screen.findByText(
+        "Create a dashboard or question to preview this theme.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("resource-preview")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /change preview resource/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/admin/embedding/components/ThemeEditor/PreviewPanel.unit.spec.tsx
+++ b/frontend/src/metabase/admin/embedding/components/ThemeEditor/PreviewPanel.unit.spec.tsx
@@ -60,7 +60,7 @@ describe("PreviewPanel", () => {
     expect(preview).toHaveAttribute("data-resource-id", "200");
     expect(preview).toHaveTextContent("Only question");
     expect(
-      screen.getByRole("button", { name: /change preview resource/i }),
+      screen.getByRole("button", { name: "Change preview resource" }),
     ).toHaveTextContent("Only question");
   });
 
@@ -74,7 +74,7 @@ describe("PreviewPanel", () => {
     ).toBeInTheDocument();
     expect(screen.queryByTestId("resource-preview")).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: /change preview resource/i }),
+      screen.queryByRole("button", { name: "Change preview resource" }),
     ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/admin/embedding/components/ThemeEditor/PreviewResourcePicker.tsx
+++ b/frontend/src/metabase/admin/embedding/components/ThemeEditor/PreviewResourcePicker.tsx
@@ -14,11 +14,7 @@ interface PreviewResourcePickerProps {
   onChange: (resource: PreviewResource) => void;
 }
 
-const SELECTABLE_MODELS: OmniPickerItem["model"][] = [
-  "dashboard",
-  "card",
-  "collection",
-];
+const SELECTABLE_MODELS: OmniPickerItem["model"][] = ["dashboard", "card"];
 
 export function PreviewResourcePicker({
   resource,

--- a/frontend/src/metabase/admin/embedding/components/ThemeEditor/PreviewResourcePicker.tsx
+++ b/frontend/src/metabase/admin/embedding/components/ThemeEditor/PreviewResourcePicker.tsx
@@ -1,0 +1,75 @@
+import { useDisclosure } from "@mantine/hooks";
+import { t } from "ttag";
+
+import {
+  EntityPickerModal,
+  type OmniPickerItem,
+} from "metabase/common/components/Pickers";
+import { Button, Icon } from "metabase/ui";
+
+import type { PreviewResource } from "./types";
+
+interface PreviewResourcePickerProps {
+  resource: PreviewResource;
+  onChange: (resource: PreviewResource) => void;
+}
+
+const SELECTABLE_MODELS: OmniPickerItem["model"][] = [
+  "dashboard",
+  "card",
+  "collection",
+];
+
+export function PreviewResourcePicker({
+  resource,
+  onChange,
+}: PreviewResourcePickerProps) {
+  const [isPickerOpen, { open: openPicker, close: closePicker }] =
+    useDisclosure(false);
+
+  const handleChange = (item: OmniPickerItem) => {
+    if (
+      (item.model === "dashboard" || item.model === "card") &&
+      typeof item.id === "number"
+    ) {
+      onChange({
+        model: item.model,
+        id: item.id,
+        name: item.name,
+      });
+      closePicker();
+    }
+  };
+
+  return (
+    <>
+      <Button
+        variant="default"
+        rightSection={<Icon name="chevrondown" size={12} />}
+        onClick={openPicker}
+        aria-label={t`Change preview resource`}
+      >
+        {resource.name}
+      </Button>
+
+      {isPickerOpen && (
+        <EntityPickerModal
+          title={t`Select data to preview`}
+          models={SELECTABLE_MODELS}
+          value={{ id: resource.id, model: resource.model }}
+          onChange={handleChange}
+          onClose={closePicker}
+          isSelectableItem={isSelectableItem}
+          options={{
+            hasConfirmButtons: false,
+            hasPersonalCollections: true,
+            hasRootCollection: true,
+          }}
+        />
+      )}
+    </>
+  );
+}
+
+const isSelectableItem = (item: OmniPickerItem) =>
+  item.model === "dashboard" || item.model === "card";

--- a/frontend/src/metabase/admin/embedding/components/ThemeEditor/ResourcePreview.tsx
+++ b/frontend/src/metabase/admin/embedding/components/ThemeEditor/ResourcePreview.tsx
@@ -6,8 +6,8 @@ import {
   useRef,
   useState,
 } from "react";
+import { match } from "ts-pattern";
 
-import { useSearchQuery } from "metabase/api";
 import { useSetting } from "metabase/common/hooks";
 import { METABASE_CONFIG_IS_PROXY_FIELD_NAME } from "metabase/embedding/embedding-iframe-sdk/constants";
 import { setupConfigWatcher } from "metabase/embedding/embedding-iframe-sdk/embed";
@@ -16,6 +16,7 @@ import type { MetabaseTheme } from "metabase/embedding-sdk/theme";
 import { Box, Center, Loader } from "metabase/ui";
 
 import S from "./PreviewPanel.module.css";
+import type { PreviewResource } from "./types";
 
 declare global {
   interface Window {
@@ -25,31 +26,12 @@ declare global {
   }
 }
 
-export function DashboardPreviewLoader({ theme }: { theme: MetabaseTheme }) {
-  const { data: searchResults } = useSearchQuery({
-    models: ["dashboard"],
-    limit: 1,
-  });
-
-  const dashboardId = searchResults?.data?.[0]?.id as number | undefined;
-
-  if (!dashboardId) {
-    return (
-      <Center h="100%">
-        <Loader />
-      </Center>
-    );
-  }
-
-  return <DashboardPreview theme={theme} dashboardId={dashboardId} />;
-}
-
-function DashboardPreview({
+export function ResourcePreview({
   theme,
-  dashboardId,
+  resource,
 }: {
   theme: MetabaseTheme;
-  dashboardId: number;
+  resource: PreviewResource;
 }) {
   const [isLoading, setIsLoading] = useState(true);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -93,10 +75,12 @@ function DashboardPreview({
     [],
   );
 
+  const { componentName, attributes } = getResourceElement(resource);
+
   // Track loading state via the "ready" event on the web component
   useEffect(() => {
     if (containerRef.current) {
-      const embed = containerRef.current.querySelector("metabase-dashboard");
+      const embed = containerRef.current.querySelector(componentName);
       const handleReady = () => setIsLoading(false);
 
       if (embed) {
@@ -105,7 +89,7 @@ function DashboardPreview({
         return () => embed.removeEventListener("ready", handleReady);
       }
     }
-  }, [dashboardId]);
+  }, [componentName, resource.id]);
 
   return (
     <Box
@@ -115,9 +99,7 @@ function DashboardPreview({
       pos="relative"
       style={{ backgroundColor: theme?.colors?.background }}
     >
-      {createElement("metabase-dashboard", {
-        "dashboard-id": String(dashboardId),
-      })}
+      {createElement(componentName, attributes)}
 
       {isLoading && (
         <Box
@@ -136,3 +118,20 @@ function DashboardPreview({
     </Box>
   );
 }
+
+const getResourceElement = (
+  resource: PreviewResource,
+): {
+  componentName: "metabase-dashboard" | "metabase-question";
+  attributes: Record<string, string>;
+} =>
+  match(resource)
+    .with({ model: "dashboard" }, ({ id }) => ({
+      componentName: "metabase-dashboard" as const,
+      attributes: { "dashboard-id": String(id) },
+    }))
+    .with({ model: "card" }, ({ id }) => ({
+      componentName: "metabase-question" as const,
+      attributes: { "question-id": String(id) },
+    }))
+    .exhaustive();

--- a/frontend/src/metabase/admin/embedding/components/ThemeEditor/types.ts
+++ b/frontend/src/metabase/admin/embedding/components/ThemeEditor/types.ts
@@ -1,0 +1,3 @@
+export type PreviewResource =
+  | { model: "dashboard"; id: number; name: string }
+  | { model: "card"; id: number; name: string };

--- a/frontend/src/metabase/admin/embedding/components/ThemeEditor/use-default-preview-resource.ts
+++ b/frontend/src/metabase/admin/embedding/components/ThemeEditor/use-default-preview-resource.ts
@@ -1,34 +1,47 @@
 import { useMemo } from "react";
 
-import { useSearchQuery } from "metabase/api";
+import { useListRecentsQuery, useSearchQuery } from "metabase/api";
 
 import type { PreviewResource } from "./types";
 
 /**
  * Resolves a default resource to show in the theme preview: the most recently
- * viewed dashboard, falling back to the most recently viewed question if no
- * dashboards exist.
+ * viewed dashboard, falling back to the most recently viewed question. If the
+ * user has no recent views (e.g. fresh install), falls back to any existing
+ * dashboard, then any existing question.
  */
 export function useDefaultPreviewResource(): {
   resource: PreviewResource | null;
   isLoading: boolean;
 } {
-  const { data: dashboards, isLoading: isDashboardLoading } = useSearchQuery({
-    models: ["dashboard"],
-    limit: 1,
+  const { data: recents, isLoading: isRecentsLoading } = useListRecentsQuery({
+    context: ["views"],
   });
+
+  const recentResource = useMemo(() => pickRecentResource(recents), [recents]);
+
+  const shouldFallback = !isRecentsLoading && recentResource == null;
+
+  const { data: dashboards, isLoading: isDashboardLoading } = useSearchQuery(
+    { models: ["dashboard"], limit: 1 },
+    { skip: !shouldFallback },
+  );
 
   const dashboard = dashboards?.data?.[0];
   const hasDashboard = dashboard != null && typeof dashboard.id === "number";
 
   const { data: questions, isLoading: isQuestionLoading } = useSearchQuery(
     { models: ["card"], limit: 1 },
-    { skip: isDashboardLoading || hasDashboard },
+    { skip: !shouldFallback || isDashboardLoading || hasDashboard },
   );
 
   const question = questions?.data?.[0];
 
   return useMemo(() => {
+    if (recentResource) {
+      return { resource: recentResource, isLoading: false };
+    }
+
     if (hasDashboard && typeof dashboard.id === "number") {
       return {
         resource: {
@@ -53,13 +66,35 @@ export function useDefaultPreviewResource(): {
 
     return {
       resource: null,
-      isLoading: isDashboardLoading || isQuestionLoading,
+      isLoading: isRecentsLoading || isDashboardLoading || isQuestionLoading,
     };
   }, [
+    recentResource,
     hasDashboard,
     dashboard,
     question,
+    isRecentsLoading,
     isDashboardLoading,
     isQuestionLoading,
   ]);
+}
+
+function pickRecentResource(
+  recents: { model: string; id: number; name: string }[] | undefined,
+): PreviewResource | null {
+  if (!recents?.length) {
+    return null;
+  }
+
+  const dashboard = recents.find((item) => item.model === "dashboard");
+  if (dashboard) {
+    return { model: "dashboard", id: dashboard.id, name: dashboard.name };
+  }
+
+  const card = recents.find((item) => item.model === "card");
+  if (card) {
+    return { model: "card", id: card.id, name: card.name };
+  }
+
+  return null;
 }

--- a/frontend/src/metabase/admin/embedding/components/ThemeEditor/use-default-preview-resource.ts
+++ b/frontend/src/metabase/admin/embedding/components/ThemeEditor/use-default-preview-resource.ts
@@ -1,0 +1,65 @@
+import { useMemo } from "react";
+
+import { useSearchQuery } from "metabase/api";
+
+import type { PreviewResource } from "./types";
+
+/**
+ * Resolves a default resource to show in the theme preview: the most recently
+ * viewed dashboard, falling back to the most recently viewed question if no
+ * dashboards exist.
+ */
+export function useDefaultPreviewResource(): {
+  resource: PreviewResource | null;
+  isLoading: boolean;
+} {
+  const { data: dashboards, isLoading: isDashboardLoading } = useSearchQuery({
+    models: ["dashboard"],
+    limit: 1,
+  });
+
+  const dashboard = dashboards?.data?.[0];
+  const hasDashboard = dashboard != null && typeof dashboard.id === "number";
+
+  const { data: questions, isLoading: isQuestionLoading } = useSearchQuery(
+    { models: ["card"], limit: 1 },
+    { skip: isDashboardLoading || hasDashboard },
+  );
+
+  const question = questions?.data?.[0];
+
+  return useMemo(() => {
+    if (hasDashboard && typeof dashboard.id === "number") {
+      return {
+        resource: {
+          model: "dashboard",
+          id: dashboard.id,
+          name: dashboard.name,
+        },
+        isLoading: false,
+      };
+    }
+
+    if (question && typeof question.id === "number") {
+      return {
+        resource: {
+          model: "card",
+          id: question.id,
+          name: question.name,
+        },
+        isLoading: false,
+      };
+    }
+
+    return {
+      resource: null,
+      isLoading: isDashboardLoading || isQuestionLoading,
+    };
+  }, [
+    hasDashboard,
+    dashboard,
+    question,
+    isDashboardLoading,
+    isQuestionLoading,
+  ]);
+}

--- a/frontend/src/metabase/admin/embedding/components/ThemeEditor/use-default-preview-resource.ts
+++ b/frontend/src/metabase/admin/embedding/components/ThemeEditor/use-default-preview-resource.ts
@@ -14,9 +14,10 @@ export function useDefaultPreviewResource(): {
   resource: PreviewResource | null;
   isLoading: boolean;
 } {
-  const { data: recents, isLoading: isRecentsLoading } = useListRecentsQuery({
-    context: ["views"],
-  });
+  const { data: recents = [], isLoading: isRecentsLoading } =
+    useListRecentsQuery({
+      context: ["views"],
+    });
 
   const recentResource = useMemo(() => pickRecentResource(recents), [recents]);
 
@@ -80,12 +81,8 @@ export function useDefaultPreviewResource(): {
 }
 
 function pickRecentResource(
-  recents: { model: string; id: number; name: string }[] | undefined,
+  recents: { model: string; id: number; name: string }[],
 ): PreviewResource | null {
-  if (!recents?.length) {
-    return null;
-  }
-
   const dashboard = recents.find((item) => item.model === "dashboard");
   if (dashboard) {
     return { model: "dashboard", id: dashboard.id, name: dashboard.name };

--- a/frontend/src/metabase/admin/embedding/components/ThemeEditor/use-default-preview-resource.unit.spec.tsx
+++ b/frontend/src/metabase/admin/embedding/components/ThemeEditor/use-default-preview-resource.unit.spec.tsx
@@ -1,0 +1,131 @@
+import {
+  setupRecentViewsEndpoints,
+  setupSearchEndpoints,
+} from "__support__/server-mocks";
+import { renderHookWithProviders, waitFor } from "__support__/ui";
+import {
+  createMockRecentCollectionItem,
+  createMockSearchResult,
+} from "metabase-types/api/mocks";
+
+import { useDefaultPreviewResource } from "./use-default-preview-resource";
+
+const setup = ({
+  recents = [],
+  searchItems = [],
+}: {
+  recents?: Parameters<typeof setupRecentViewsEndpoints>[0];
+  searchItems?: Parameters<typeof setupSearchEndpoints>[0];
+} = {}) => {
+  setupRecentViewsEndpoints(recents);
+  setupSearchEndpoints(searchItems);
+
+  return renderHookWithProviders(() => useDefaultPreviewResource(), {});
+};
+
+describe("useDefaultPreviewResource", () => {
+  it("returns the most recently viewed dashboard when available", async () => {
+    const { result } = setup({
+      recents: [
+        createMockRecentCollectionItem({
+          id: 42,
+          model: "dashboard",
+          name: "Recent dashboard",
+        }),
+        createMockRecentCollectionItem({
+          id: 7,
+          model: "card",
+          name: "Recent question",
+        }),
+      ],
+    });
+
+    await waitFor(() => {
+      expect(result.current.resource).toEqual({
+        model: "dashboard",
+        id: 42,
+        name: "Recent dashboard",
+      });
+    });
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("falls back to the most recently viewed question when no dashboard is in recents", async () => {
+    const { result } = setup({
+      recents: [
+        createMockRecentCollectionItem({
+          id: 9,
+          model: "card",
+          name: "Recent question",
+        }),
+      ],
+    });
+
+    await waitFor(() => {
+      expect(result.current.resource).toEqual({
+        model: "card",
+        id: 9,
+        name: "Recent question",
+      });
+    });
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("falls back to search for a dashboard when recents is empty", async () => {
+    const { result } = setup({
+      recents: [],
+      searchItems: [
+        createMockSearchResult({
+          id: 100,
+          model: "dashboard",
+          name: "Some dashboard",
+        }),
+        createMockSearchResult({
+          id: 101,
+          model: "card",
+          name: "Some question",
+        }),
+      ],
+    });
+
+    await waitFor(() => {
+      expect(result.current.resource).toEqual({
+        model: "dashboard",
+        id: 100,
+        name: "Some dashboard",
+      });
+    });
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("falls back to search for a question when recents is empty and no dashboards exist", async () => {
+    const { result } = setup({
+      recents: [],
+      searchItems: [
+        createMockSearchResult({
+          id: 200,
+          model: "card",
+          name: "Only question",
+        }),
+      ],
+    });
+
+    await waitFor(() => {
+      expect(result.current.resource).toEqual({
+        model: "card",
+        id: 200,
+        name: "Only question",
+      });
+    });
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("returns a null resource when no recents and no searchable content exist", async () => {
+    const { result } = setup({ recents: [], searchItems: [] });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.resource).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes [EMB-953: Add a preview picker to switch EAJS experiences and resources in theme editor preview](https://linear.app/metabase/issue/EMB-953/add-a-preview-picker-to-switch-eajs-experiences-and-resources-in-theme)

<img width="1767" height="966" alt="SCR-20260421-mqbc" src="https://github.com/user-attachments/assets/63e2de24-29ba-4d89-a818-f70ee03a2457" />
