### PR TITLE
GDGT-2077 chore: add observability to transform inspector

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -3344,7 +3344,8 @@
   enterprise/transforms-inspector
   {:team "Gadget"
    :api  #{metabase-enterprise.transforms-inspector.api}
-   :uses #{api
+   :uses #{analytics
+           api
            driver
            events
            lib
@@ -3352,6 +3353,7 @@
            query-processor
            server
            sql-tools
+           tracing
            transforms
            transforms-base
            util}

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -3344,7 +3344,7 @@
   enterprise/transforms-inspector
   {:team "Gadget"
    :api  #{metabase-enterprise.transforms-inspector.api}
-   :uses #{analytics
+   :uses #{analytics-interface
            api
            driver
            events

--- a/enterprise/backend/src/metabase_enterprise/transforms_inspector/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms_inspector/api.clj
@@ -2,6 +2,7 @@
   (:require
    [metabase-enterprise.transforms-inspector.core :as inspector]
    [metabase-enterprise.transforms-inspector.schema :as inspector.schema]
+   [metabase.analytics.prometheus :as prometheus]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.api.routes.common :refer [+auth]]
@@ -12,7 +13,9 @@
    [metabase.query-processor.schema :as qp.schema]
    [metabase.query-processor.streaming :as qp.streaming]
    [metabase.server.core :as server]
+   [metabase.tracing.core :as tracing]
    [metabase.transforms.core :as transforms.core]
+   [metabase.util :as u]
    [metabase.util.malli.schema :as ms]))
 
 (set! *warn-on-reflection* true)
@@ -23,8 +26,16 @@
    Returns structural metadata and available lens types."
   [{:keys [id]} :- [:map [:id ms/PositiveInt]]]
   (let [transform (api/read-check :model/Transform id)
-        result    (do (transforms.core/check-feature-enabled! transform)
-                      (inspector/discover-lenses transform))]
+        _         (transforms.core/check-feature-enabled! transform)
+        result    (tracing/with-span :transforms "transforms.inspector.discover"
+                    {:transform/id id}
+                    (try
+                      (let [r (inspector/discover-lenses transform)]
+                        (prometheus/inc! :metabase-transforms/inspector-discovery {:status "ok"})
+                        r)
+                      (catch Throwable t
+                        (prometheus/inc! :metabase-transforms/inspector-discovery {:status "error"})
+                        (throw t))))]
     (events/publish-event! :event/transform-inspect-discover
                            {:object  transform
                             :user-id api/*current-user-id*})
@@ -40,8 +51,19 @@
                             [:lens-id ms/NonBlankString]]
    params :- [:map-of :keyword :any]]
   (let [transform (api/read-check :model/Transform id)
-        result    (do (transforms.core/check-feature-enabled! transform)
-                      (inspector/get-lens transform lens-id params))]
+        _         (transforms.core/check-feature-enabled! transform)
+        result    (tracing/with-span :transforms "transforms.inspector.lens"
+                    {:transform/id      id
+                     :inspector/lens-id lens-id}
+                    (try
+                      (let [r (inspector/get-lens transform lens-id params)]
+                        (prometheus/inc! :metabase-transforms/inspector-lens
+                                         {:lens-type lens-id :status "ok"})
+                        r)
+                      (catch Throwable t
+                        (prometheus/inc! :metabase-transforms/inspector-lens
+                                         {:lens-type lens-id :status "error"})
+                        (throw t))))]
     (events/publish-event! :event/transform-inspect-lens
                            {:object  transform
                             :user-id api/*current-user-id*
@@ -70,13 +92,30 @@
                 :lens-id      lens-id
                 :lens-params  lens-params}]
       (qp.streaming/streaming-response [rff :api]
-        (qp/process-query
-         (-> query
-             (update-in [:middleware :js-int-to-string?] (fnil identity true))
-             (assoc :constraints (qp.constraints/default-query-constraints))
-             (update :info merge info)
-             qp/userland-query)
-         rff)))))
+        (let [timer (u/start-timer)]
+          (tracing/with-span :transforms "transforms.inspector.query"
+            {:transform/id      id
+             :inspector/lens-id lens-id}
+            (try
+              (let [result (qp/process-query
+                            (-> query
+                                (update-in [:middleware :js-int-to-string?] (fnil identity true))
+                                (assoc :constraints (qp.constraints/default-query-constraints))
+                                (update :info merge info)
+                                qp/userland-query)
+                            rff)
+                    ;; qp/process-query can signal failure by returning {:status :failed}
+                    ;; instead of throwing — see qp.streaming/-streaming-response.
+                    status (if (= :failed (:status result)) "error" "ok")]
+                (prometheus/observe! :metabase-transforms/inspector-query-duration-ms
+                                     {:lens-type lens-id :status status}
+                                     (u/since-ms timer))
+                result)
+              (catch Throwable t
+                (prometheus/observe! :metabase-transforms/inspector-query-duration-ms
+                                     {:lens-type lens-id :status "error"}
+                                     (u/since-ms timer))
+                (throw t)))))))))
 
 (def ^{:arglists '([request respond raise])} routes
   "`/api/ee/transforms` routes."

--- a/enterprise/backend/src/metabase_enterprise/transforms_inspector/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms_inspector/api.clj
@@ -22,13 +22,26 @@
 
 (set! *warn-on-reflection* true)
 
-(defn- lens-label
-  "Clamp `lens-id` (a user-controlled path param) to a registered lens type or
-   \"unknown\" to bound the cardinality of the `:lens-type` metric label."
+(defn- known-lens-id?
+  "True if `lens-id` matches a registered lens type (including drill lenses)."
   [lens-id]
-  (if (some #(= (name %) lens-id) (lens.core/registered-lens-types true))
-    lens-id
-    "unknown"))
+  (contains? (set (map name (lens.core/registered-lens-types true))) lens-id))
+
+(defn- lens-type-label
+  "Clamp `lens-id` (a user-controlled path param) to its registered form or
+   \"unknown\", bounding the cardinality of the `:lens-type` metric label."
+  [lens-id]
+  (if (known-lens-id? lens-id) lens-id "unknown"))
+
+(defn- lens-labels
+  "Return clamped `:lens-type` and `:complexity` metric labels for `lens-id`.
+   For unregistered lens-ids both fall back to \"unknown\"."
+  [lens-id]
+  (let [known? (known-lens-id? lens-id)]
+    {:lens-type  (if known? lens-id "unknown")
+     :complexity (if known?
+                   (-> (lens.core/lens-metadata (keyword lens-id) {}) :complexity :level name)
+                   "unknown")}))
 
 (api.macros/defendpoint :get "/:id/inspect"
   :- ::inspector.schema/discovery-response
@@ -70,11 +83,11 @@
                     (try
                       (let [r (inspector/get-lens transform lens-id params)]
                         (prometheus/inc! :metabase-transforms/inspector-lens
-                                         {:lens-type (lens-label lens-id) :status "ok"})
+                                         (assoc (lens-labels lens-id) :status "ok"))
                         r)
                       (catch Throwable t
                         (prometheus/inc! :metabase-transforms/inspector-lens
-                                         {:lens-type (lens-label lens-id) :status "error"})
+                                         (assoc (lens-labels lens-id) :status "error"))
                         (throw t))))]
     (events/publish-event! :event/transform-inspect-lens
                            {:object  transform
@@ -120,12 +133,12 @@
                     ;; instead of throwing — see qp.streaming/-streaming-response.
                     status (if (= :failed (:status result)) "error" "ok")]
                 (prometheus/observe! :metabase-transforms/inspector-query-duration-ms
-                                     {:lens-type (lens-label lens-id) :status status}
+                                     {:lens-type (lens-type-label lens-id) :status status}
                                      (u/since-ms timer))
                 result)
               (catch Throwable t
                 (prometheus/observe! :metabase-transforms/inspector-query-duration-ms
-                                     {:lens-type (lens-label lens-id) :status "error"}
+                                     {:lens-type (lens-type-label lens-id) :status "error"}
                                      (u/since-ms timer))
                 (throw t)))))))))
 

--- a/enterprise/backend/src/metabase_enterprise/transforms_inspector/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms_inspector/api.clj
@@ -1,6 +1,7 @@
 (ns metabase-enterprise.transforms-inspector.api
   (:require
    [metabase-enterprise.transforms-inspector.core :as inspector]
+   [metabase-enterprise.transforms-inspector.lens.core :as lens.core]
    [metabase-enterprise.transforms-inspector.schema :as inspector.schema]
    [metabase.analytics.prometheus :as prometheus]
    [metabase.api.common :as api]
@@ -14,11 +15,20 @@
    [metabase.query-processor.streaming :as qp.streaming]
    [metabase.server.core :as server]
    [metabase.tracing.core :as tracing]
+   [metabase.transforms-base.util :as transforms-base.u]
    [metabase.transforms.core :as transforms.core]
    [metabase.util :as u]
    [metabase.util.malli.schema :as ms]))
 
 (set! *warn-on-reflection* true)
+
+(defn- lens-label
+  "Clamp `lens-id` (a user-controlled path param) to a registered lens type or
+   \"unknown\" to bound the cardinality of the `:lens-type` metric label."
+  [lens-id]
+  (if (some #(= (name %) lens-id) (lens.core/registered-lens-types true))
+    lens-id
+    "unknown"))
 
 (api.macros/defendpoint :get "/:id/inspect"
   :- ::inspector.schema/discovery-response
@@ -28,7 +38,8 @@
   (let [transform (api/read-check :model/Transform id)
         _         (transforms.core/check-feature-enabled! transform)
         result    (tracing/with-span :transforms "transforms.inspector.discover"
-                    {:transform/id id}
+                    {:transform/id          id
+                     :transform/source-type (name (transforms-base.u/transform-source-type (:source transform)))}
                     (try
                       (let [r (inspector/discover-lenses transform)]
                         (prometheus/inc! :metabase-transforms/inspector-discovery {:status "ok"})
@@ -53,16 +64,17 @@
   (let [transform (api/read-check :model/Transform id)
         _         (transforms.core/check-feature-enabled! transform)
         result    (tracing/with-span :transforms "transforms.inspector.lens"
-                    {:transform/id      id
-                     :inspector/lens-id lens-id}
+                    {:transform/id          id
+                     :transform/source-type (name (transforms-base.u/transform-source-type (:source transform)))
+                     :inspector/lens-id     lens-id}
                     (try
                       (let [r (inspector/get-lens transform lens-id params)]
                         (prometheus/inc! :metabase-transforms/inspector-lens
-                                         {:lens-type lens-id :status "ok"})
+                                         {:lens-type (lens-label lens-id) :status "ok"})
                         r)
                       (catch Throwable t
                         (prometheus/inc! :metabase-transforms/inspector-lens
-                                         {:lens-type lens-id :status "error"})
+                                         {:lens-type (lens-label lens-id) :status "error"})
                         (throw t))))]
     (events/publish-event! :event/transform-inspect-lens
                            {:object  transform
@@ -108,12 +120,12 @@
                     ;; instead of throwing — see qp.streaming/-streaming-response.
                     status (if (= :failed (:status result)) "error" "ok")]
                 (prometheus/observe! :metabase-transforms/inspector-query-duration-ms
-                                     {:lens-type lens-id :status status}
+                                     {:lens-type (lens-label lens-id) :status status}
                                      (u/since-ms timer))
                 result)
               (catch Throwable t
                 (prometheus/observe! :metabase-transforms/inspector-query-duration-ms
-                                     {:lens-type lens-id :status "error"}
+                                     {:lens-type (lens-label lens-id) :status "error"}
                                      (u/since-ms timer))
                 (throw t)))))))))
 

--- a/enterprise/backend/src/metabase_enterprise/transforms_inspector/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms_inspector/api.clj
@@ -11,6 +11,7 @@
    [metabase.events.core :as events]
    [metabase.query-processor.core :as qp]
    [metabase.query-processor.middleware.constraints :as qp.constraints]
+   [metabase.query-processor.pipeline :as qp.pipeline]
    [metabase.query-processor.schema :as qp.schema]
    [metabase.query-processor.streaming :as qp.streaming]
    [metabase.server.core :as server]
@@ -42,6 +43,19 @@
      :complexity (if known?
                    (-> (lens.core/lens-metadata (keyword lens-id) {}) :complexity :level name)
                    "unknown")}))
+
+(defn- query-result->status-label
+  "Classify a `qp/process-query` outcome for the `:status` Prometheus label.
+   `canceled?` short-circuits to \"canceled\"; otherwise the keyword in
+   `(:status result)` decides. Unknown keywords fall through to
+   \"unknown\" as a drift sentinel."
+  [canceled? result]
+  (cond
+    (or canceled? (nil? result))      "canceled"
+    (= :completed (:status result))   "ok"
+    (= :failed (:status result))      "error"
+    (= :interrupted (:status result)) "interrupted"
+    :else                             "unknown"))
 
 (api.macros/defendpoint :get "/:id/inspect"
   :- ::inspector.schema/discovery-response
@@ -129,9 +143,13 @@
                                 (update :info merge info)
                                 qp/userland-query)
                             rff)
-                    ;; qp/process-query can signal failure by returning {:status :failed}
-                    ;; instead of throwing — see qp.streaming/-streaming-response.
-                    status (if (= :failed (:status result)) "error" "ok")]
+                    ;; Pass `(qp.pipeline/canceled?)` because `qp.streaming/-streaming-response`
+                    ;; synthesizes `{:status :canceled}` *after* this body returns — it never
+                    ;; appears on `result` from inside the streaming body, so we read the chan
+                    ;; directly. The chan is bound by the streaming-response wrapper for the
+                    ;; duration of this body. `:failed` / `:interrupted` come from
+                    ;; qp.middleware.catch-exceptions.
+                    status (query-result->status-label (qp.pipeline/canceled?) result)]
                 (prometheus/observe! :metabase-transforms/inspector-query-duration-ms
                                      {:lens-type (lens-type-label lens-id) :status status}
                                      (u/since-ms timer))

--- a/enterprise/backend/src/metabase_enterprise/transforms_inspector/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms_inspector/api.clj
@@ -3,7 +3,7 @@
    [metabase-enterprise.transforms-inspector.core :as inspector]
    [metabase-enterprise.transforms-inspector.lens.core :as lens.core]
    [metabase-enterprise.transforms-inspector.schema :as inspector.schema]
-   [metabase.analytics.prometheus :as prometheus]
+   [metabase.analytics-interface.core :as analytics]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.api.routes.common :refer [+auth]]
@@ -69,10 +69,10 @@
                      :transform/source-type (name (transforms-base.u/transform-source-type (:source transform)))}
                     (try
                       (let [r (inspector/discover-lenses transform)]
-                        (prometheus/inc! :metabase-transforms/inspector-discovery {:status "ok"})
+                        (analytics/inc! :metabase-transforms/inspector-discovery {:status "ok"})
                         r)
                       (catch Throwable t
-                        (prometheus/inc! :metabase-transforms/inspector-discovery {:status "error"})
+                        (analytics/inc! :metabase-transforms/inspector-discovery {:status "error"})
                         (throw t))))]
     (events/publish-event! :event/transform-inspect-discover
                            {:object  transform
@@ -96,12 +96,12 @@
                      :inspector/lens-id     lens-id}
                     (try
                       (let [r (inspector/get-lens transform lens-id params)]
-                        (prometheus/inc! :metabase-transforms/inspector-lens
-                                         (assoc (lens-labels lens-id) :status "ok"))
+                        (analytics/inc! :metabase-transforms/inspector-lens
+                                        (assoc (lens-labels lens-id) :status "ok"))
                         r)
                       (catch Throwable t
-                        (prometheus/inc! :metabase-transforms/inspector-lens
-                                         (assoc (lens-labels lens-id) :status "error"))
+                        (analytics/inc! :metabase-transforms/inspector-lens
+                                        (assoc (lens-labels lens-id) :status "error"))
                         (throw t))))]
     (events/publish-event! :event/transform-inspect-lens
                            {:object  transform
@@ -150,14 +150,14 @@
                     ;; duration of this body. `:failed` / `:interrupted` come from
                     ;; qp.middleware.catch-exceptions.
                     status (query-result->status-label (qp.pipeline/canceled?) result)]
-                (prometheus/observe! :metabase-transforms/inspector-query-duration-ms
-                                     {:lens-type (lens-type-label lens-id) :status status}
-                                     (u/since-ms timer))
+                (analytics/observe! :metabase-transforms/inspector-query-duration-ms
+                                    {:lens-type (lens-type-label lens-id) :status status}
+                                    (u/since-ms timer))
                 result)
               (catch Throwable t
-                (prometheus/observe! :metabase-transforms/inspector-query-duration-ms
-                                     {:lens-type (lens-type-label lens-id) :status "error"}
-                                     (u/since-ms timer))
+                (analytics/observe! :metabase-transforms/inspector-query-duration-ms
+                                    {:lens-type (lens-type-label lens-id) :status "error"}
+                                    (u/since-ms timer))
                 (throw t)))))))))
 
 (def ^{:arglists '([request respond raise])} routes

--- a/enterprise/backend/src/metabase_enterprise/transforms_inspector/lens/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms_inspector/lens/core.clj
@@ -108,7 +108,7 @@
                          vec)))
    nil))
 
-(defn- registered-lens-types
+(defn registered-lens-types
   "Return registered lens types in priority order, optionally filtering drill lenses."
   ([]
    (registered-lens-types false))

--- a/enterprise/backend/test/metabase_enterprise/transforms_inspector/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms_inspector/api_test.clj
@@ -2,6 +2,7 @@
   "Tests for transform inspector endpoints at /api/ee/transforms/:id/inspect*."
   (:require
    [clojure.test :refer :all]
+   [metabase.analytics.prometheus-test :as prometheus-test]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.permissions.models.permissions-group :as perms-group]
@@ -91,3 +92,93 @@
               (is (some? (:errors (mt/user-http-request :lucky :post 400
                                                         (format "ee/transforms/%d/inspect/generic-summary/query" transform-id)
                                                         {})))))))))))
+
+;;; -------------------------------------------------- Metrics --------------------------------------------------
+
+(deftest inspect-metrics-discovery-test
+  (mt/with-premium-features #{:transforms-basic :transforms-python}
+    (testing "GET /api/ee/transforms/:id/inspect bumps inspector-discovery{status=ok}"
+      (mt/with-prometheus-system! [_ system]
+        (mt/with-temp [:model/Transform {transform-id :id} {}]
+          (mt/with-data-analyst-role! (mt/user->id :lucky)
+            (mt/with-db-perm-for-group! (perms-group/all-users) (mt/id) :perms/transforms :yes
+              (mt/user-http-request :lucky :get 200
+                                    (format "ee/transforms/%d/inspect" transform-id))
+              (is (prometheus-test/approx= 1 (mt/metric-value system :metabase-transforms/inspector-discovery
+                                                              {:status "ok"}))))))))))
+
+(deftest inspect-metrics-lens-success-test
+  (mt/with-premium-features #{:transforms-basic :transforms-python}
+    (testing "GET /api/ee/transforms/:id/inspect/:lens-id bumps inspector-lens{status=ok}"
+      (mt/with-prometheus-system! [_ system]
+        (mt/with-temp [:model/Transform {transform-id :id} {}]
+          (mt/with-data-analyst-role! (mt/user->id :lucky)
+            (mt/with-db-perm-for-group! (perms-group/all-users) (mt/id) :perms/transforms :yes
+              (mt/user-http-request :lucky :get 200
+                                    (format "ee/transforms/%d/inspect/generic-summary" transform-id))
+              (is (prometheus-test/approx= 1 (mt/metric-value system :metabase-transforms/inspector-lens
+                                                              {:lens-type "generic-summary"
+                                                               :status    "ok"}))))))))))
+
+(deftest inspect-metrics-lens-error-test
+  (mt/with-premium-features #{:transforms-basic :transforms-python}
+    (testing "404 from non-applicable lens bumps inspector-lens{status=error}"
+      (mt/with-prometheus-system! [_ system]
+        (mt/with-temp [:model/Transform {transform-id :id} {}]
+          (mt/with-data-analyst-role! (mt/user->id :lucky)
+            (mt/with-db-perm-for-group! (perms-group/all-users) (mt/id) :perms/transforms :yes
+              (mt/user-http-request :lucky :get 404
+                                    (format "ee/transforms/%d/inspect/no-such-lens" transform-id))
+              (is (prometheus-test/approx= 1 (mt/metric-value system :metabase-transforms/inspector-lens
+                                                              {:lens-type "no-such-lens"
+                                                               :status    "error"}))))))))))
+
+(deftest ^:mb/driver-tests inspect-metrics-query-duration-test
+  (mt/with-premium-features #{:transforms-basic :transforms-python}
+    (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)
+      (testing "POST /api/ee/transforms/:id/inspect/:lens-id/query records duration histogram"
+        (mt/with-prometheus-system! [_ system]
+          (mt/with-temp [:model/Transform {transform-id :id} {}]
+            (mt/with-data-analyst-role! (mt/user->id :lucky)
+              (mt/with-db-perm-for-group! (perms-group/all-users) (mt/id) :perms/transforms :yes
+                (let [mp    (mt/metadata-provider)
+                      query (lib/aggregate (lib/query mp (lib.metadata/table mp (mt/id :orders))) (lib/count))]
+                  (mt/user-http-request :lucky :post 202
+                                        (format "ee/transforms/%d/inspect/generic-summary/query" transform-id)
+                                        {:query query})
+                  (is (pos? (:count (mt/metric-value system :metabase-transforms/inspector-query-duration-ms
+                                                     {:lens-type "generic-summary" :status "ok"})))))))))))))
+
+(deftest inspect-metrics-query-failure-test
+  (mt/with-premium-features #{:transforms-basic :transforms-python}
+    (testing "POST .../query bumps inspector-query-duration-ms{status=error} when the QP returns {:status :failed}"
+      (mt/with-prometheus-system! [_ system]
+        (mt/with-temp [:model/Transform {transform-id :id} {}]
+          (mt/with-data-analyst-role! (mt/user->id :lucky)
+            (mt/with-db-perm-for-group! (perms-group/all-users) (mt/id) :perms/transforms :yes
+              (mt/user-http-request :lucky :post
+                                    (format "ee/transforms/%d/inspect/generic-summary/query" transform-id)
+                                    {:query {:database (mt/id)
+                                             :type     :query
+                                             :query    {:source-table 99999999}}})
+              (is (pos? (:count (mt/metric-value system :metabase-transforms/inspector-query-duration-ms
+                                                 {:lens-type "generic-summary" :status "error"}))))
+              (is (zero? (:count (mt/metric-value system :metabase-transforms/inspector-query-duration-ms
+                                                  {:lens-type "generic-summary" :status "ok"})))))))))))
+
+(deftest inspect-metrics-scope-test
+  (mt/with-premium-features #{:transforms-basic :transforms-python}
+    (testing "Permission-denied failures do NOT bump inspector counters"
+      (mt/with-prometheus-system! [_ system]
+        (mt/with-temp [:model/Transform {transform-id :id} {}]
+          (mt/user-http-request :rasta :get 403
+                                (format "ee/transforms/%d/inspect" transform-id))
+          (mt/user-http-request :rasta :get 403
+                                (format "ee/transforms/%d/inspect/generic-summary" transform-id))
+          (is (prometheus-test/approx= 0 (mt/metric-value system :metabase-transforms/inspector-discovery
+                                                          {:status "ok"})))
+          (is (prometheus-test/approx= 0 (mt/metric-value system :metabase-transforms/inspector-discovery
+                                                          {:status "error"})))
+          (is (prometheus-test/approx= 0 (mt/metric-value system :metabase-transforms/inspector-lens
+                                                          {:lens-type "generic-summary"
+                                                           :status    "ok"}))))))))

--- a/enterprise/backend/test/metabase_enterprise/transforms_inspector/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms_inspector/api_test.clj
@@ -112,8 +112,9 @@
           (is (prometheus-test/approx= 0 (mt/metric-value system :metabase-transforms/inspector-discovery
                                                           {:status "error"})))
           (is (prometheus-test/approx= 0 (mt/metric-value system :metabase-transforms/inspector-lens
-                                                          {:lens-type "generic-summary"
-                                                           :status    "ok"}))))
+                                                          {:lens-type  "generic-summary"
+                                                           :complexity "fast"
+                                                           :status     "ok"}))))
         (mt/with-data-analyst-role! (mt/user->id :lucky)
           (mt/with-db-perm-for-group! (perms-group/all-users) (mt/id) :perms/transforms :yes
             (testing "GET /api/ee/transforms/:id/inspect bumps inspector-discovery{status=ok}"
@@ -121,20 +122,22 @@
                                     (format "ee/transforms/%d/inspect" transform-id))
               (is (prometheus-test/approx= 1 (mt/metric-value system :metabase-transforms/inspector-discovery
                                                               {:status "ok"}))))
-            (testing "GET /api/ee/transforms/:id/inspect/:lens-id bumps inspector-lens{status=ok}"
+            (testing "GET /api/ee/transforms/:id/inspect/:lens-id bumps inspector-lens{status=ok} with complexity label"
               (mt/user-http-request :lucky :get 200
                                     (format "ee/transforms/%d/inspect/generic-summary" transform-id))
               (is (prometheus-test/approx= 1 (mt/metric-value system :metabase-transforms/inspector-lens
-                                                              {:lens-type "generic-summary"
-                                                               :status    "ok"}))))
-            (testing "404 from non-applicable lens bumps inspector-lens{status=error,lens-type=unknown}"
-              ;; Unknown lens-ids clamp to \"unknown\" to prevent Prometheus cardinality
-              ;; explosion from arbitrary path-param values.
+                                                              {:lens-type  "generic-summary"
+                                                               :complexity "fast"
+                                                               :status     "ok"}))))
+            (testing "404 from non-applicable lens bumps inspector-lens{lens-type=unknown,complexity=unknown,status=error}"
+              ;; Unknown lens-ids clamp both :lens-type and :complexity to \"unknown\" to prevent
+              ;; Prometheus cardinality explosion from arbitrary path-param values.
               (mt/user-http-request :lucky :get 404
                                     (format "ee/transforms/%d/inspect/no-such-lens" transform-id))
               (is (prometheus-test/approx= 1 (mt/metric-value system :metabase-transforms/inspector-lens
-                                                              {:lens-type "unknown"
-                                                               :status    "error"}))))
+                                                              {:lens-type  "unknown"
+                                                               :complexity "unknown"
+                                                               :status     "error"}))))
             ;; Run the failure case before the success case so we can assert that a QP {:status :failed}
             ;; bumps the error bucket but NOT the ok bucket — the specific regression covered by the
             ;; streaming-error-path fix in api.clj (detecting :failed status from qp/process-query).

--- a/enterprise/backend/test/metabase_enterprise/transforms_inspector/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms_inspector/api_test.clj
@@ -127,11 +127,13 @@
               (is (prometheus-test/approx= 1 (mt/metric-value system :metabase-transforms/inspector-lens
                                                               {:lens-type "generic-summary"
                                                                :status    "ok"}))))
-            (testing "404 from non-applicable lens bumps inspector-lens{status=error}"
+            (testing "404 from non-applicable lens bumps inspector-lens{status=error,lens-type=unknown}"
+              ;; Unknown lens-ids clamp to \"unknown\" to prevent Prometheus cardinality
+              ;; explosion from arbitrary path-param values.
               (mt/user-http-request :lucky :get 404
                                     (format "ee/transforms/%d/inspect/no-such-lens" transform-id))
               (is (prometheus-test/approx= 1 (mt/metric-value system :metabase-transforms/inspector-lens
-                                                              {:lens-type "no-such-lens"
+                                                              {:lens-type "unknown"
                                                                :status    "error"}))))
             ;; Run the failure case before the success case so we can assert that a QP {:status :failed}
             ;; bumps the error bucket but NOT the ok bucket — the specific regression covered by the

--- a/enterprise/backend/test/metabase_enterprise/transforms_inspector/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms_inspector/api_test.clj
@@ -95,82 +95,14 @@
 
 ;;; -------------------------------------------------- Metrics --------------------------------------------------
 
-(deftest inspect-metrics-discovery-test
+;; All metric assertions share one `with-prometheus-system!` (expensive to boot).
+;; Each `testing` block uses a distinct (metric, labels) combo, so no `prometheus/clear!` is
+;; needed to flush the metrics.
+(deftest inspect-metrics-test
   (mt/with-premium-features #{:transforms-basic :transforms-python}
-    (testing "GET /api/ee/transforms/:id/inspect bumps inspector-discovery{status=ok}"
-      (mt/with-prometheus-system! [_ system]
-        (mt/with-temp [:model/Transform {transform-id :id} {}]
-          (mt/with-data-analyst-role! (mt/user->id :lucky)
-            (mt/with-db-perm-for-group! (perms-group/all-users) (mt/id) :perms/transforms :yes
-              (mt/user-http-request :lucky :get 200
-                                    (format "ee/transforms/%d/inspect" transform-id))
-              (is (prometheus-test/approx= 1 (mt/metric-value system :metabase-transforms/inspector-discovery
-                                                              {:status "ok"}))))))))))
-
-(deftest inspect-metrics-lens-success-test
-  (mt/with-premium-features #{:transforms-basic :transforms-python}
-    (testing "GET /api/ee/transforms/:id/inspect/:lens-id bumps inspector-lens{status=ok}"
-      (mt/with-prometheus-system! [_ system]
-        (mt/with-temp [:model/Transform {transform-id :id} {}]
-          (mt/with-data-analyst-role! (mt/user->id :lucky)
-            (mt/with-db-perm-for-group! (perms-group/all-users) (mt/id) :perms/transforms :yes
-              (mt/user-http-request :lucky :get 200
-                                    (format "ee/transforms/%d/inspect/generic-summary" transform-id))
-              (is (prometheus-test/approx= 1 (mt/metric-value system :metabase-transforms/inspector-lens
-                                                              {:lens-type "generic-summary"
-                                                               :status    "ok"}))))))))))
-
-(deftest inspect-metrics-lens-error-test
-  (mt/with-premium-features #{:transforms-basic :transforms-python}
-    (testing "404 from non-applicable lens bumps inspector-lens{status=error}"
-      (mt/with-prometheus-system! [_ system]
-        (mt/with-temp [:model/Transform {transform-id :id} {}]
-          (mt/with-data-analyst-role! (mt/user->id :lucky)
-            (mt/with-db-perm-for-group! (perms-group/all-users) (mt/id) :perms/transforms :yes
-              (mt/user-http-request :lucky :get 404
-                                    (format "ee/transforms/%d/inspect/no-such-lens" transform-id))
-              (is (prometheus-test/approx= 1 (mt/metric-value system :metabase-transforms/inspector-lens
-                                                              {:lens-type "no-such-lens"
-                                                               :status    "error"}))))))))))
-
-(deftest ^:mb/driver-tests inspect-metrics-query-duration-test
-  (mt/with-premium-features #{:transforms-basic :transforms-python}
-    (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)
-      (testing "POST /api/ee/transforms/:id/inspect/:lens-id/query records duration histogram"
-        (mt/with-prometheus-system! [_ system]
-          (mt/with-temp [:model/Transform {transform-id :id} {}]
-            (mt/with-data-analyst-role! (mt/user->id :lucky)
-              (mt/with-db-perm-for-group! (perms-group/all-users) (mt/id) :perms/transforms :yes
-                (let [mp    (mt/metadata-provider)
-                      query (lib/aggregate (lib/query mp (lib.metadata/table mp (mt/id :orders))) (lib/count))]
-                  (mt/user-http-request :lucky :post 202
-                                        (format "ee/transforms/%d/inspect/generic-summary/query" transform-id)
-                                        {:query query})
-                  (is (pos? (:count (mt/metric-value system :metabase-transforms/inspector-query-duration-ms
-                                                     {:lens-type "generic-summary" :status "ok"})))))))))))))
-
-(deftest inspect-metrics-query-failure-test
-  (mt/with-premium-features #{:transforms-basic :transforms-python}
-    (testing "POST .../query bumps inspector-query-duration-ms{status=error} when the QP returns {:status :failed}"
-      (mt/with-prometheus-system! [_ system]
-        (mt/with-temp [:model/Transform {transform-id :id} {}]
-          (mt/with-data-analyst-role! (mt/user->id :lucky)
-            (mt/with-db-perm-for-group! (perms-group/all-users) (mt/id) :perms/transforms :yes
-              (mt/user-http-request :lucky :post
-                                    (format "ee/transforms/%d/inspect/generic-summary/query" transform-id)
-                                    {:query {:database (mt/id)
-                                             :type     :query
-                                             :query    {:source-table 99999999}}})
-              (is (pos? (:count (mt/metric-value system :metabase-transforms/inspector-query-duration-ms
-                                                 {:lens-type "generic-summary" :status "error"}))))
-              (is (zero? (:count (mt/metric-value system :metabase-transforms/inspector-query-duration-ms
-                                                  {:lens-type "generic-summary" :status "ok"})))))))))))
-
-(deftest inspect-metrics-scope-test
-  (mt/with-premium-features #{:transforms-basic :transforms-python}
-    (testing "Permission-denied failures do NOT bump inspector counters"
-      (mt/with-prometheus-system! [_ system]
-        (mt/with-temp [:model/Transform {transform-id :id} {}]
+    (mt/with-prometheus-system! [_ system]
+      (mt/with-temp [:model/Transform {transform-id :id} {}]
+        (testing "Permission-denied failures do NOT bump inspector counters"
           (mt/user-http-request :rasta :get 403
                                 (format "ee/transforms/%d/inspect" transform-id))
           (mt/user-http-request :rasta :get 403
@@ -181,4 +113,44 @@
                                                           {:status "error"})))
           (is (prometheus-test/approx= 0 (mt/metric-value system :metabase-transforms/inspector-lens
                                                           {:lens-type "generic-summary"
-                                                           :status    "ok"}))))))))
+                                                           :status    "ok"}))))
+        (mt/with-data-analyst-role! (mt/user->id :lucky)
+          (mt/with-db-perm-for-group! (perms-group/all-users) (mt/id) :perms/transforms :yes
+            (testing "GET /api/ee/transforms/:id/inspect bumps inspector-discovery{status=ok}"
+              (mt/user-http-request :lucky :get 200
+                                    (format "ee/transforms/%d/inspect" transform-id))
+              (is (prometheus-test/approx= 1 (mt/metric-value system :metabase-transforms/inspector-discovery
+                                                              {:status "ok"}))))
+            (testing "GET /api/ee/transforms/:id/inspect/:lens-id bumps inspector-lens{status=ok}"
+              (mt/user-http-request :lucky :get 200
+                                    (format "ee/transforms/%d/inspect/generic-summary" transform-id))
+              (is (prometheus-test/approx= 1 (mt/metric-value system :metabase-transforms/inspector-lens
+                                                              {:lens-type "generic-summary"
+                                                               :status    "ok"}))))
+            (testing "404 from non-applicable lens bumps inspector-lens{status=error}"
+              (mt/user-http-request :lucky :get 404
+                                    (format "ee/transforms/%d/inspect/no-such-lens" transform-id))
+              (is (prometheus-test/approx= 1 (mt/metric-value system :metabase-transforms/inspector-lens
+                                                              {:lens-type "no-such-lens"
+                                                               :status    "error"}))))
+            ;; Run the failure case before the success case so we can assert that a QP {:status :failed}
+            ;; bumps the error bucket but NOT the ok bucket — the specific regression covered by the
+            ;; streaming-error-path fix in api.clj (detecting :failed status from qp/process-query).
+            (testing "POST .../query bumps inspector-query-duration-ms{status=error} when the QP returns {:status :failed}"
+              (mt/user-http-request :lucky :post
+                                    (format "ee/transforms/%d/inspect/generic-summary/query" transform-id)
+                                    {:query {:database (mt/id)
+                                             :type     :query
+                                             :query    {:source-table 99999999}}})
+              (is (pos? (:count (mt/metric-value system :metabase-transforms/inspector-query-duration-ms
+                                                 {:lens-type "generic-summary" :status "error"}))))
+              (is (zero? (:count (mt/metric-value system :metabase-transforms/inspector-query-duration-ms
+                                                  {:lens-type "generic-summary" :status "ok"})))))
+            (testing "POST .../query bumps inspector-query-duration-ms{status=ok} on success"
+              (let [mp    (mt/metadata-provider)
+                    query (lib/aggregate (lib/query mp (lib.metadata/table mp (mt/id :orders))) (lib/count))]
+                (mt/user-http-request :lucky :post 202
+                                      (format "ee/transforms/%d/inspect/generic-summary/query" transform-id)
+                                      {:query query})
+                (is (pos? (:count (mt/metric-value system :metabase-transforms/inspector-query-duration-ms
+                                                   {:lens-type "generic-summary" :status "ok"}))))))))))))

--- a/enterprise/backend/test/metabase_enterprise/transforms_inspector/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms_inspector/api_test.clj
@@ -2,6 +2,7 @@
   "Tests for transform inspector endpoints at /api/ee/transforms/:id/inspect*."
   (:require
    [clojure.test :refer :all]
+   [metabase-enterprise.transforms-inspector.api :as transforms-inspector.api]
    [metabase.analytics.prometheus-test :as prometheus-test]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
@@ -159,3 +160,20 @@
                                       {:query query})
                 (is (pos? (:count (mt/metric-value system :metabase-transforms/inspector-query-duration-ms
                                                    {:lens-type "generic-summary" :status "ok"}))))))))))))
+
+(deftest query-result->status-label-test
+  (let [classify #'transforms-inspector.api/query-result->status-label]
+    (testing "canceled-chan signal beats anything else, including a completed result"
+      (is (= "canceled" (classify true {:status :completed})))
+      (is (= "canceled" (classify true nil)))
+      (is (= "canceled" (classify true {:status :failed}))))
+    (testing "nil result inside the streaming body means QP short-circuited on cancel"
+      (is (= "canceled" (classify false nil))))
+    (testing "QP outcome keywords map to their labels"
+      (is (= "ok"          (classify false {:status :completed})))
+      (is (= "error"       (classify false {:status :failed})))
+      (is (= "interrupted" (classify false {:status :interrupted}))))
+    (testing "any unrecognised :status keyword falls through to the drift sentinel"
+      (is (= "unknown" (classify false {:status :weird-new-value})))
+      (is (= "unknown" (classify false {})))
+      (is (= "unknown" (classify false {:status nil}))))))

--- a/enterprise/backend/test/metabase_enterprise/transforms_inspector/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms_inspector/api_test.clj
@@ -108,14 +108,14 @@
                                 (format "ee/transforms/%d/inspect" transform-id))
           (mt/user-http-request :rasta :get 403
                                 (format "ee/transforms/%d/inspect/generic-summary" transform-id))
-          (is (prometheus-test/approx= 0 (mt/metric-value system :metabase-transforms/inspector-discovery
-                                                          {:status "ok"})))
-          (is (prometheus-test/approx= 0 (mt/metric-value system :metabase-transforms/inspector-discovery
-                                                          {:status "error"})))
-          (is (prometheus-test/approx= 0 (mt/metric-value system :metabase-transforms/inspector-lens
-                                                          {:lens-type  "generic-summary"
-                                                           :complexity "fast"
-                                                           :status     "ok"}))))
+          (is (== 0 (mt/metric-value system :metabase-transforms/inspector-discovery
+                                     {:status "ok"})))
+          (is (== 0 (mt/metric-value system :metabase-transforms/inspector-discovery
+                                     {:status "error"})))
+          (is (== 0 (mt/metric-value system :metabase-transforms/inspector-lens
+                                     {:lens-type  "generic-summary"
+                                      :complexity "fast"
+                                      :status     "ok"}))))
         (mt/with-data-analyst-role! (mt/user->id :lucky)
           (mt/with-db-perm-for-group! (perms-group/all-users) (mt/id) :perms/transforms :yes
             (testing "GET /api/ee/transforms/:id/inspect bumps inspector-discovery{status=ok}"

--- a/enterprise/backend/test/metabase_enterprise/transforms_inspector/lens/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms_inspector/lens/core_test.clj
@@ -188,6 +188,24 @@
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Lens data not available"
                           (lens.core/get-lens {:has-joins? false} "join-analysis")))))
 
+;;; -------------------------------------------------- registered-lens-types --------------------------------------------------
+
+(deftest registered-lens-types-test
+  (testing "arity-0 returns registered non-drill lens types"
+    (let [types (set (lens.core/registered-lens-types))]
+      (is (contains? types :generic-summary))
+      (is (contains? types :join-analysis))
+      (is (contains? types :column-comparison))
+      (testing "drill lenses are excluded"
+        (is (not (contains? types :unmatched-rows))))))
+  (testing "arity-1 true includes drill lenses"
+    (let [types (set (lens.core/registered-lens-types true))]
+      (is (contains? types :unmatched-rows))
+      (is (contains? types :generic-summary))))
+  (testing "arity-1 false matches arity-0"
+    (is (= (lens.core/registered-lens-types)
+           (lens.core/registered-lens-types false)))))
+
 ;;; -------------------------------------------------- register-lens! --------------------------------------------------
 
 (deftest register-lens-idempotent-test

--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -522,7 +522,7 @@
                         :labels [:status]})
    (prometheus/counter :metabase-transforms/inspector-lens
                        {:description "Transform Inspector lens retrievals."
-                        :labels [:lens-type :status]})
+                        :labels [:lens-type :complexity :status]})
    (prometheus/histogram :metabase-transforms/inspector-query-duration-ms
                          {:description "Duration in ms of Transform Inspector lens query execution."
                           :labels [:lens-type :status]

--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -517,6 +517,17 @@
    (prometheus/counter :metabase-transforms/python-api-calls-total
                        {:description "Total number of Python runner API calls."
                         :labels [:status]})
+   (prometheus/counter :metabase-transforms/inspector-discovery
+                       {:description "Transform Inspector lens discovery calls."
+                        :labels [:status]})
+   (prometheus/counter :metabase-transforms/inspector-lens
+                       {:description "Transform Inspector lens retrievals."
+                        :labels [:lens-type :status]})
+   (prometheus/histogram :metabase-transforms/inspector-query-duration-ms
+                         {:description "Duration in ms of Transform Inspector lens query execution."
+                          :labels [:lens-type :status]
+                          ;; 1ms -> 10 minutes
+                          :buckets [1 500 1000 5000 10000 30000 60000 120000 300000 600000]})
    (prometheus/counter :metabase-token-check/attempt
                        {:description "Total number of token checks. Includes a status label."
                         :labels [:status]})

--- a/src/metabase/tracing/core.clj
+++ b/src/metabase/tracing/core.clj
@@ -11,7 +11,7 @@
      (tracing/with-span :my-feature \"my-op\" {} (do-stuff))
 
    ## Built-in Groups
-     :qp, :sync, :tasks, :search, :api, :db-user, :db-app, :events, :quartz
+     :qp, :sync, :tasks, :search, :api, :db-user, :db-app, :events, :quartz, :transforms
 
    ## Configuration
      MB_TRACING_ENABLED=true   MB_TRACING_ENDPOINT=host:4317
@@ -59,6 +59,7 @@
 (register-group! :db-app  "Application/system database operations: sessions, settings, QE writes")
 (register-group! :events  "Event system: view logging, audit, notifications")
 (register-group! :quartz  "Quartz scheduler internals: trigger acquisition, locks, heartbeats, JDBC")
+(register-group! :transforms "Transform pipeline: jobs, stages, inspector")
 
 (defn registered-groups
   "Return a map of all registered trace groups."


### PR DESCRIPTION
### Description

Transform Inspector lacks Prometheus metrics and tracing spans. While audit events exist, we want to add more complete observability over the inspector endpoints for monitoring usage & performance.

We are adding the following:
* Prometheus counter inspector-discovery with label {status}
* Prometheus counter metabase-transforms/inspector-lens with labels {lens_type, complexity, status}
* Prometheus histogram metabase-transforms/inspector-query-duration-ms with labels {lens_type, status}
* Spans with the attributes `transform/id`, `inspector/source-type`, `transform/source-type` where they are relevant information

### Technical Considerations
1. I added the `source-type` scope for spans covering the `discover` and `lens` endpoints because their cost from the `build-context` may vary based on the transform's source type. The `query` endpoint should not require this as it's always generated MBQL against a target table regardless of source type - the query's target database is probably more relevant but requires an additional data fetch so I've left it out for now.

2. I noticed there's a repeated `try/catch` + prom.inc shape across the handlers but I've deferred extracting a helper for now, generally prefer to do so once we need that pattern across more than 1 request handler file. 

3. `lens-id` in the lens endpoint is only validated by `NonBlankString`, and it's possible for unregistered values to be input by a client which could lead to unbounded cardinality in Prometheus (since we are storing `lens-id` as `lens-type` label). I've added helpers to ensure these values are limited to registered lens types or `unknown` otherwise.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
