### PR TITLE
fix(sdk): scope SDK-themed Mantine CSS variables to .mb-wrapper to prevent leakage to :root

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/styles-tests.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/styles-tests.cy.spec.tsx
@@ -640,6 +640,49 @@ describe("scenarios > embedding-sdk > styles", () => {
         expectElementToHaveNoAppliedCssRules(tag);
       }
     });
+
+    it("SDK-themed Mantine CSS variables should be scoped to .mb-wrapper and not leak to :root", () => {
+      const SDK_BRAND_HEX = "#bada55";
+
+      cy.mount(
+        <MetabaseProvider
+          authConfig={DEFAULT_SDK_AUTH_PROVIDER_CONFIG}
+          theme={defineMetabaseTheme({ colors: { brand: SDK_BRAND_HEX } })}
+        >
+          <StaticQuestion questionId={ORDERS_QUESTION_ID} />
+        </MetabaseProvider>,
+      );
+
+      getSdkRoot().findByText("Product ID").should("exist");
+
+      const MANTINE_VAR = "--mantine-color-brand-0";
+
+      cy.get(".mb-wrapper")
+        .first()
+        .then(($wrapper) => {
+          const wrapperValue = getComputedStyle($wrapper[0])
+            .getPropertyValue(MANTINE_VAR)
+            .trim()
+            .toLowerCase();
+
+          expect(
+            wrapperValue,
+            `${MANTINE_VAR} must be set on .mb-wrapper from SDK theme`,
+          ).to.not.equal("");
+
+          cy.document().then((doc) => {
+            const rootValue = getComputedStyle(doc.documentElement)
+              .getPropertyValue(MANTINE_VAR)
+              .trim()
+              .toLowerCase();
+
+            expect(
+              rootValue,
+              `SDK-derived ${MANTINE_VAR}=${wrapperValue} must NOT leak to :root (found ${rootValue || "<empty>"})`,
+            ).to.not.equal(wrapperValue);
+          });
+        });
+    });
   });
 });
 

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkThemeProvider.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkThemeProvider.tsx
@@ -38,7 +38,10 @@ export const SdkThemeProvider = ({ theme, children }: Props) => {
             withGlobalClasses: withGlobalClasses ?? isInstanceToRender,
           }}
         >
-          <ThemeProvider theme={themeOverride}>
+          <ThemeProvider
+            theme={themeOverride}
+            cssVariablesSelector=".mb-wrapper"
+          >
             {isInstanceToRender && <GlobalSdkCssVariables />}
 
             {children}

--- a/frontend/test/__support__/storybook.tsx
+++ b/frontend/test/__support__/storybook.tsx
@@ -75,13 +75,9 @@ export const SdkVisualizationWrapper = ({
   theme?: MetabaseTheme;
   initialStore?: State;
 }) => (
-  <Box fz="0.875rem">
+  <Box fz="0.875rem" className="mb-wrapper" data-mantine-color-scheme="light">
     <VisualizationWrapper initialStore={initialStore}>
-      <SdkThemeProvider theme={theme}>
-        <div className="mb-wrapper" data-mantine-color-scheme="light">
-          {children}
-        </div>
-      </SdkThemeProvider>
+      <SdkThemeProvider theme={theme}>{children}</SdkThemeProvider>
     </VisualizationWrapper>
   </Box>
 );
@@ -120,13 +116,17 @@ export const SdkVisualizationStory = ({
   theme,
 }: IsomorphicVisualizationStoryProps & { theme?: MetabaseTheme }) => {
   return (
-    // @ts-expect-error story file
-    <Box w={1000} h={600} bg={theme?.colors?.background}>
+    <Box
+      w={1000}
+      h={600}
+      // @ts-expect-error story file
+      bg={theme?.colors?.background}
+      className="mb-wrapper"
+      data-mantine-color-scheme="light"
+    >
       <VisualizationWrapper>
         <SdkThemeProvider theme={theme}>
-          <div className="mb-wrapper" data-mantine-color-scheme="light">
-            <Visualization rawSeries={rawSeries} width={500} />
-          </div>
+          <Visualization rawSeries={rawSeries} width={500} />
         </SdkThemeProvider>
       </VisualizationWrapper>
     </Box>

--- a/frontend/test/__support__/storybook.tsx
+++ b/frontend/test/__support__/storybook.tsx
@@ -77,7 +77,11 @@ export const SdkVisualizationWrapper = ({
 }) => (
   <Box fz="0.875rem">
     <VisualizationWrapper initialStore={initialStore}>
-      <SdkThemeProvider theme={theme}>{children}</SdkThemeProvider>
+      <SdkThemeProvider theme={theme}>
+        <div className="mb-wrapper" data-mantine-color-scheme="light">
+          {children}
+        </div>
+      </SdkThemeProvider>
     </VisualizationWrapper>
   </Box>
 );
@@ -120,7 +124,9 @@ export const SdkVisualizationStory = ({
     <Box w={1000} h={600} bg={theme?.colors?.background}>
       <VisualizationWrapper>
         <SdkThemeProvider theme={theme}>
-          <Visualization rawSeries={rawSeries} width={500} />
+          <div className="mb-wrapper" data-mantine-color-scheme="light">
+            <Visualization rawSeries={rawSeries} width={500} />
+          </div>
         </SdkThemeProvider>
       </VisualizationWrapper>
     </Box>


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #72956
Scope SDK-themed Mantine CSS variables to .mb-wrapper to prevent leakage to :root.

This is bugfix, the regression was introduced in #71629

The fix:
<img width="652" height="1328" alt="image" src="https://github.com/user-attachments/assets/83f7bb51-0b26-4548-a9e9-39e162302d5d" />


How to verify:
- i added a e2e test
- build uberjar, and use it in Shoppy locally, ensure styles are not leaked anymore