### PR TITLE
[mage] The serdes API changed; make `mage analytics:finalize` match it

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/audit_app/analytics_dev.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_app/analytics_dev.clj
@@ -198,7 +198,8 @@
     (try
       (let [opts {:targets (serialization/make-targets-of-type "Collection" [collection-id])
                   :no-settings true :no-transforms true}
-            report (serdes/with-cache (serialization/store! (serialization/extract opts) (.getPath temp-path)))]
+            report (serdes/with-cache (serialization/store! (serialization/extract opts)
+                                                            (serialization/file-writer (.getPath temp-path))))]
         (log/info "Export complete:" (count (:seen report)) "entities exported")
         (when (seq (:errors report))
           (log/warn "Export had errors:" (:errors report)))

--- a/enterprise/backend/src/metabase_enterprise/serialization/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/core.clj
@@ -5,6 +5,7 @@
    [metabase-enterprise.serialization.v2.ingest]
    [metabase-enterprise.serialization.v2.load]
    [metabase-enterprise.serialization.v2.storage]
+   [metabase-enterprise.serialization.v2.storage.files]
    [metabase-enterprise.serialization.v2.storage.util]
    [potemkin :as p]))
 
@@ -14,6 +15,7 @@
   metabase-enterprise.serialization.v2.ingest/keep-me
   metabase-enterprise.serialization.v2.load/keep-me
   metabase-enterprise.serialization.v2.storage/keep-me
+  metabase-enterprise.serialization.v2.storage.files/keep-me
   metabase-enterprise.serialization.v2.storage.util/keep-me)
 
 (p/import-vars
@@ -36,6 +38,8 @@
   load-metabase!]
  [metabase-enterprise.serialization.v2.storage
   store!]
+ [metabase-enterprise.serialization.v2.storage.files
+  file-writer]
  [metabase-enterprise.serialization.v2.storage.util
   resolve-storage-path
   slugify-name])


### PR DESCRIPTION
### Description

Mage calls some of the serdes functionality from Metabase to implement
the `analytics:*` tasks. The interface for `store!` changed as part of
the "Jekyll mode" project to use a more flexible `ExportWriter`
interface rather than explicit path names.

That caused the Mage task to throw an `IllegalArgumentException` since
one cannot call `ExportWriter` methods on a string.

### How to verify

`mage analytics:finalize` throws `IllegalArgumentException` before this change, but it works now.

### Checklist

- ~~Tests have been added/updated to cover changes in this PR~~
- ~~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~~
