### PR TITLE
Usage-metadata: composite segment candidates

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
@@ -137,6 +137,7 @@
    "SourceDimensionDaily"
    "SourceDimensionProfileDaily"
    "SourceMetricDaily"
+   "SourceSegmentCompositeDaily"
    "SourceSegmentDaily"
    "SupportAccessGrantLog"
    "TaskHistory"

--- a/enterprise/backend/test/metabase_enterprise/serialization/models/entity_id_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/models/entity_id_test.clj
@@ -109,6 +109,7 @@
     :model/SourceDimensionDaily
     :model/SourceDimensionProfileDaily
     :model/SourceMetricDaily
+    :model/SourceSegmentCompositeDaily
     :model/SourceSegmentDaily
     :model/SupportAccessGrantLog
     :model/TaskHistory

--- a/resources/migrations/061/20260421_usage_metadata_composite_rollups.yaml
+++ b/resources/migrations/061/20260421_usage_metadata_composite_rollups.yaml
@@ -1,0 +1,80 @@
+databaseChangeLog:
+  - changeSet:
+      id: v61.c3f8a2
+      author: johnswanson
+      comment: Create source_segment_composite_daily for whole-:and filter baskets
+      changes:
+        - createTable:
+            tableName: source_segment_composite_daily
+            remarks: Daily source-scoped composite segment usage rollups (whole :and baskets)
+            columns:
+              - column:
+                  name: id
+                  type: bigint
+                  autoIncrement: true
+                  remarks: Surrogate primary key
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: source_type
+                  type: varchar(16)
+                  remarks: Owning source kind for direct or projected facts, or null for canonical mixed facts
+              - column:
+                  name: source_id
+                  type: int
+                  remarks: Owning table or card ID for direct or projected facts, or null for canonical mixed facts
+              - column:
+                  name: ownership_mode
+                  type: varchar(16)
+                  remarks: Ownership attribution mode such as direct, projected, or mixed
+                  constraints:
+                    nullable: false
+              - column:
+                  name: clause
+                  type: ${text.type}
+                  remarks: Canonical serialized representation of the whole :and filter clause
+                  constraints:
+                    nullable: false
+              - column:
+                  name: atom_fingerprints
+                  type: ${text.type}
+                  remarks: Sorted JSON array of canonical serialized atom clauses contained in the basket
+                  constraints:
+                    nullable: false
+              - column:
+                  name: atom_count
+                  type: int
+                  remarks: Number of atomic predicates in the basket
+                  constraints:
+                    nullable: false
+              - column:
+                  name: bucket_date
+                  type: date
+                  remarks: UTC day covered by the rollup row
+                  constraints:
+                    nullable: false
+              - column:
+                  name: count
+                  type: int
+                  remarks: Number of observations for this composite fact on the bucket day
+                  constraints:
+                    nullable: false
+
+  - changeSet:
+      id: v61.e71b4d
+      author: johnswanson
+      comment: Add source_segment_composite_daily bucket/source index
+      changes:
+        - createIndex:
+            indexName: idx_source_segment_composite_daily_bucket_source
+            tableName: source_segment_composite_daily
+            columns:
+              - column:
+                  name: bucket_date
+              - column:
+                  name: source_type
+              - column:
+                  name: source_id
+              - column:
+                  name: ownership_mode

--- a/resources/migrations/061/20260421_usage_metadata_composite_rollups.yaml
+++ b/resources/migrations/061/20260421_usage_metadata_composite_rollups.yaml
@@ -10,7 +10,7 @@ databaseChangeLog:
             columns:
               - column:
                   name: id
-                  type: bigint
+                  type: int
                   autoIncrement: true
                   remarks: Surrogate primary key
                   constraints:
@@ -18,7 +18,7 @@ databaseChangeLog:
                     nullable: false
               - column:
                   name: source_type
-                  type: varchar(16)
+                  type: varchar(256)
                   remarks: Owning source kind for direct or projected facts, or null for canonical mixed facts
               - column:
                   name: source_id
@@ -26,7 +26,7 @@ databaseChangeLog:
                   remarks: Owning table or card ID for direct or projected facts, or null for canonical mixed facts
               - column:
                   name: ownership_mode
-                  type: varchar(16)
+                  type: varchar(256)
                   remarks: Ownership attribution mode such as direct, projected, or mixed
                   constraints:
                     nullable: false

--- a/src/metabase/lib/core.cljc
+++ b/src/metabase/lib/core.cljc
@@ -99,6 +99,7 @@
    [metabase.lib.query :as lib.query]
    [metabase.lib.query.test-spec :as lib.query.test-spec]
    [metabase.lib.ref :as lib.ref]
+   [metabase.lib.referenced-columns :as lib.referenced-columns]
    [metabase.lib.remove-replace :as lib.remove-replace]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.aggregation :as lib.schema.aggregation]
@@ -207,6 +208,7 @@
          lib.query/keep-me
          lib.query.test-spec/keep-me
          lib.ref/keep-me
+         lib.referenced-columns/keep-me
          lib.remove-replace/keep-me
          lib.schema/keep-me
          metabase.lib.schema.util/keep-me
@@ -1423,7 +1425,6 @@
   dependent-metadata
   expression-clause
   expression-parts
-  referenced-columns
   string-filter-clause
   string-filter-parts
   number-filter-clause
@@ -1553,6 +1554,8 @@
   field-ref-id
   field-ref-name
   ref]
+ [lib.referenced-columns
+  referenced-columns]
  [lib.remove-replace
   remove-clause
   remove-join

--- a/src/metabase/lib/core.cljc
+++ b/src/metabase/lib/core.cljc
@@ -668,6 +668,17 @@
     stage-number :- :int]
    (lib.filter/filters a-query stage-number)))
 
+(mu/defn atomic-filters :- [:maybe [:ref ::lib.schema/filters]]
+  "Like [[filters]], but with any top-level `:and` clauses recursively flattened so the result is a
+  list of atomic (non-`:and`) boolean filter clauses. The conjunction of the returned list is
+  logically equivalent to the conjunction of [[filters]].
+
+  **Code Health:** Healthy. This is a core API."
+  ([a-query] (atomic-filters a-query -1))
+  ([a-query      :- ::lib.schema/query
+    stage-number :- :int]
+   (lib.filter/atomic-filters a-query stage-number)))
+
 (mu/defn filterable-columns :- [:maybe [:sequential ::lib.schema.metadata/column]]
   "Returns column metadata for all the columns that could be used for filtering on the target stage of `a-query`.
 
@@ -1412,6 +1423,7 @@
   dependent-metadata
   expression-clause
   expression-parts
+  referenced-columns
   string-filter-clause
   string-filter-parts
   number-filter-clause

--- a/src/metabase/lib/fe_util.cljc
+++ b/src/metabase/lib/fe_util.cljc
@@ -193,41 +193,6 @@
     expression-clause :- [:or ::lib.schema.expression/expression ExpressionArg ExpressionParts]]
    (expression-parts-method query stage-index expression-clause)))
 
-(defn- column-metadata?
-  [x]
-  (and (map? x) (= :metadata/column (:lib/type x))))
-
-(defn- expression-parts-map?
-  [x]
-  (and (map? x) (= :mbql/expression-parts (:lib/type x))))
-
-(defn- referenced-columns* [parts]
-  (cond
-    (column-metadata? parts)      [parts]
-    (expression-parts-map? parts) (into [] (mapcat referenced-columns*) (:args parts))
-    :else                         []))
-
-(mu/defn referenced-columns :- [:sequential ::lib.schema.metadata/column]
-  "Returns the column-metadata leaves referenced by `x`, where `x` is a clause (filter, aggregation,
-  expression) or a column-metadata map, resolved relative to the target stage of `query`.
-
-  Columns appear in traversal order; duplicates are NOT removed — callers may `distinct` if
-  dedup semantics are needed.
-
-  Throws if `x` is neither an MBQL clause nor a `:metadata/column` map. Schema validation is
-  off in production, so the runtime check is the gate.
-
-  Lives here because the implementation is built on [[expression-parts]]"
-  ([query x] (referenced-columns query -1 x))
-  ([query        :- ::lib.schema/query
-    stage-number :- :int
-    x]
-   (when-not (or (column-metadata? x) (lib.util/clause? x))
-     (throw (ex-info "referenced-columns: expected an MBQL clause or :metadata/column"
-                     {:dispatch-value (lib.dispatch/dispatch-value x)
-                      :input          x})))
-   (referenced-columns* (expression-parts query stage-number x))))
-
 (defn- case-or-if-expression?
   [clause]
   (and (vector? clause)

--- a/src/metabase/lib/fe_util.cljc
+++ b/src/metabase/lib/fe_util.cljc
@@ -193,6 +193,41 @@
     expression-clause :- [:or ::lib.schema.expression/expression ExpressionArg ExpressionParts]]
    (expression-parts-method query stage-index expression-clause)))
 
+(defn- column-metadata?
+  [x]
+  (and (map? x) (= :metadata/column (:lib/type x))))
+
+(defn- expression-parts-map?
+  [x]
+  (and (map? x) (= :mbql/expression-parts (:lib/type x))))
+
+(defn- referenced-columns* [parts]
+  (cond
+    (column-metadata? parts)      [parts]
+    (expression-parts-map? parts) (into [] (mapcat referenced-columns*) (:args parts))
+    :else                         []))
+
+(mu/defn referenced-columns :- [:sequential ::lib.schema.metadata/column]
+  "Returns the column-metadata leaves referenced by `x`, where `x` is a clause (filter, aggregation,
+  expression) or a column-metadata map, resolved relative to the target stage of `query`.
+
+  Columns appear in traversal order; duplicates are NOT removed — callers may `distinct` if
+  dedup semantics are needed.
+
+  Throws if `x` is neither an MBQL clause nor a `:metadata/column` map. Schema validation is
+  off in production, so the runtime check is the gate.
+
+  Lives here because the implementation is built on [[expression-parts]]"
+  ([query x] (referenced-columns query -1 x))
+  ([query        :- ::lib.schema/query
+    stage-number :- :int
+    x]
+   (when-not (or (column-metadata? x) (lib.util/clause? x))
+     (throw (ex-info "referenced-columns: expected an MBQL clause or :metadata/column"
+                     {:dispatch-value (lib.dispatch/dispatch-value x)
+                      :input          x})))
+   (referenced-columns* (expression-parts query stage-number x))))
+
 (defn- case-or-if-expression?
   [clause]
   (and (vector? clause)

--- a/src/metabase/lib/filter.cljc
+++ b/src/metabase/lib/filter.cljc
@@ -477,6 +477,21 @@
     stage-number :- [:maybe :int]]
    (perf/not-empty (:filters (lib.util/query-stage query (clojure.core/or stage-number -1))))))
 
+(defn- flatten-and-clause
+  [a-filter]
+  (if (lib.util/clause-of-type? a-filter :and)
+    (into [] (mapcat flatten-and-clause) (drop 2 a-filter))
+    [a-filter]))
+
+(mu/defn atomic-filters :- [:maybe [:ref ::lib.schema/filters]]
+  "Like [[filters]], but with any top-level `:and` clauses recursively flattened so the result is a
+  list of atomic (non-`:and`) boolean filter clauses. The conjunction of the returned list is
+  logically equivalent to the conjunction of [[filters]]."
+  ([query :- ::lib.schema/query] (atomic-filters query nil))
+  ([query        :- ::lib.schema/query
+    stage-number :- [:maybe :int]]
+   (perf/not-empty (into [] (mapcat flatten-and-clause) (filters query stage-number)))))
+
 (defn- leading-ref
   "Returns the first argument of `a-filter` if it is a reference clause, nil otherwise."
   [a-filter]

--- a/src/metabase/lib/normalize.cljc
+++ b/src/metabase/lib/normalize.cljc
@@ -13,7 +13,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :as perf :refer [some]]))
+   [metabase.util.performance :refer [some]]))
 
 (defn- lib-type [x]
   (when (map? x)
@@ -31,18 +31,6 @@
    :metadata/measure  ::lib.schema.metadata/measure
    :metadata/segment  ::lib.schema.metadata/segment
    :metadata/metric   ::lib.schema.metadata/metric})
-
-(defn- seqs->vecs
-  "Recursively convert non-map-entry `seq?` nodes (e.g. LazySeqs from `json/decode+kw`) to vectors.
-  Some MBQL clause schemas dispatch via `:tuple`, which only matches vectors — a nested LazySeq
-  would silently skip clause-specific `:decode/normalize` handlers."
-  [x]
-  (perf/postwalk
-   (fn [node]
-     (if (and (seq? node) (not (map-entry? node)))
-       (vec node)
-       node))
-   x))
 
 (defn- infer-schema [x]
   (cond
@@ -101,8 +89,7 @@
    (normalize schema x nil))
 
   ([schema x {:keys [throw?], :or {throw? false}, :as _options}]
-   (let [x      (seqs->vecs x)
-         schema (or schema (infer-schema x))
+   (let [schema (or schema (infer-schema x))
          thunk  (^:once fn* []
                   ((coercer schema) x))]
      (if throw?

--- a/src/metabase/lib/normalize.cljc
+++ b/src/metabase/lib/normalize.cljc
@@ -13,7 +13,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.performance :refer [some]]))
+   [metabase.util.performance :as perf :refer [some]]))
 
 (defn- lib-type [x]
   (when (map? x)
@@ -31,6 +31,18 @@
    :metadata/measure  ::lib.schema.metadata/measure
    :metadata/segment  ::lib.schema.metadata/segment
    :metadata/metric   ::lib.schema.metadata/metric})
+
+(defn- seqs->vecs
+  "Recursively convert non-map-entry `seq?` nodes (e.g. LazySeqs from `json/decode+kw`) to vectors.
+  Some MBQL clause schemas dispatch via `:tuple`, which only matches vectors — a nested LazySeq
+  would silently skip clause-specific `:decode/normalize` handlers."
+  [x]
+  (perf/postwalk
+   (fn [node]
+     (if (and (seq? node) (not (map-entry? node)))
+       (vec node)
+       node))
+   x))
 
 (defn- infer-schema [x]
   (cond
@@ -89,7 +101,8 @@
    (normalize schema x nil))
 
   ([schema x {:keys [throw?], :or {throw? false}, :as _options}]
-   (let [schema (or schema (infer-schema x))
+   (let [x      (seqs->vecs x)
+         schema (or schema (infer-schema x))
          thunk  (^:once fn* []
                   ((coercer schema) x))]
      (if throw?

--- a/src/metabase/lib/referenced_columns.cljc
+++ b/src/metabase/lib/referenced_columns.cljc
@@ -1,0 +1,46 @@
+(ns metabase.lib.referenced-columns
+  "The natural home for `referenced-columns` would be next to `returned-columns` and friends in
+  `metabase.lib.metadata.calculation`, but the implementation is built on
+  [[metabase.lib.fe-util/expression-parts]], and requiring [[metabase.lib.fe-util]] from there
+  would create a dependency cycle. So it lives in its own namespace downstream of `fe-util`
+  instead."
+  (:require
+   [metabase.lib.dispatch :as lib.dispatch]
+   [metabase.lib.fe-util :as lib.fe-util]
+   [metabase.lib.schema :as lib.schema]
+   [metabase.lib.schema.metadata :as lib.schema.metadata]
+   [metabase.lib.util :as lib.util]
+   [metabase.util.malli :as mu]))
+
+(defn- column-metadata?
+  [x]
+  (and (map? x) (= :metadata/column (:lib/type x))))
+
+(defn- expression-parts-map?
+  [x]
+  (and (map? x) (= :mbql/expression-parts (:lib/type x))))
+
+(defn- referenced-columns* [parts]
+  (cond
+    (column-metadata? parts)      [parts]
+    (expression-parts-map? parts) (into [] (mapcat referenced-columns*) (:args parts))
+    :else                         []))
+
+(mu/defn referenced-columns :- [:sequential ::lib.schema.metadata/column]
+  "Returns the column-metadata leaves referenced by `x`, where `x` is a clause (filter, aggregation,
+  expression) or a column-metadata map, resolved relative to the target stage of `query`.
+
+  Columns appear in traversal order; duplicates are NOT removed — callers may `distinct` if
+  dedup semantics are needed.
+
+  Throws if `x` is neither an MBQL clause nor a `:metadata/column` map. Schema validation is
+  off in production, so the runtime check is the gate."
+  ([query x] (referenced-columns query -1 x))
+  ([query        :- ::lib.schema/query
+    stage-number :- :int
+    x]
+   (when-not (or (column-metadata? x) (lib.util/clause? x))
+     (throw (ex-info "referenced-columns: expected an MBQL clause or :metadata/column"
+                     {:dispatch-value (lib.dispatch/dispatch-value x)
+                      :input          x})))
+   (referenced-columns* (lib.fe-util/expression-parts query stage-number x))))

--- a/src/metabase/lib/schema/mbql_clause.cljc
+++ b/src/metabase/lib/schema/mbql_clause.cljc
@@ -94,9 +94,12 @@
 
 (defn- normalize-clause [x]
   (when (sequential? x)
-    (if ((some-fn map? nil?) (second x))
-      x
-      (into [(first x) {:lib/uuid (str (random-uuid))}] (rest x)))))
+    ;; Coerce non-vector sequentials (e.g. LazySeqs from `json/decode+kw`) to vectors so downstream
+    ;; `:tuple` schemas match.
+    (let [x (if (vector? x) x (vec x))]
+      (if ((some-fn map? nil?) (second x))
+        x
+        (into [(first x) {:lib/uuid (str (random-uuid))}] (rest x))))))
 
 ;;; TODO: Support options more nicely - these don't allow for overriding the options, but we have a few cases where that
 ;;; is necessary. See for example the inclusion of `string-filter-options` in [[metabase.lib.filter]].

--- a/src/metabase/models/resolution.clj
+++ b/src/metabase/models/resolution.clj
@@ -131,6 +131,7 @@
     :model/SourceDimensionDaily              metabase.usage-metadata.models.source-dimension-daily
     :model/SourceDimensionProfileDaily       metabase.usage-metadata.models.source-dimension-profile-daily
     :model/SourceMetricDaily                 metabase.usage-metadata.models.source-metric-daily
+    :model/SourceSegmentCompositeDaily       metabase.usage-metadata.models.source-segment-composite-daily
     :model/SourceSegmentDaily                metabase.usage-metadata.models.source-segment-daily
     :model/User                              metabase.users.models.user
     :model/UserKeyValue                      metabase.user-key-value.models.user-key-value

--- a/src/metabase/usage_metadata/batch.clj
+++ b/src/metabase/usage_metadata/batch.clj
@@ -7,6 +7,7 @@
    [metabase.usage-metadata.models.source-dimension-daily]
    [metabase.usage-metadata.models.source-dimension-profile-daily]
    [metabase.usage-metadata.models.source-metric-daily]
+   [metabase.usage-metadata.models.source-segment-composite-daily]
    [metabase.usage-metadata.models.source-segment-daily]
    [metabase.usage-metadata.settings :as usage-metadata.settings]
    [metabase.usage-metadata.store :as usage-metadata.store]
@@ -25,6 +26,7 @@
 
 (def ^:private rollup-models
   [:model/SourceSegmentDaily
+   :model/SourceSegmentCompositeDaily
    :model/SourceMetricDaily
    :model/SourceDimensionDaily
    :model/SourceDimensionProfileDaily])
@@ -127,6 +129,15 @@
    :predicate      predicate
    :bucket_date    bucket-date})
 
+(defn- composite-row [bucket-date {:keys [source-type source-id ownership-mode clause atom-fingerprints atom-count]}]
+  {:source_type       source-type
+   :source_id         source-id
+   :ownership_mode    ownership-mode
+   :clause            clause
+   :atom_fingerprints (json/encode atom-fingerprints)
+   :atom_count        atom-count
+   :bucket_date       bucket-date})
+
 (defn- metric-row [bucket-date {:keys [source-type source-id ownership-mode agg agg-field-id temporal-field-id temporal-unit]}]
   {:source_type       source-type
    :source_id         source-id
@@ -153,16 +164,18 @@
 
 (defn- accumulate-query-result [stats bucket-date n result]
   (if (= :ok (:status result))
-    (let [{:keys [segments metrics dimensions]} (:facts result)
+    (let [{:keys [segments composites metrics dimensions]} (:facts result)
           add-rows (fn [acc rows row-fn]
                      (reduce (fn [m fact] (aggregate-row m (row-fn bucket-date fact) n))
                              acc
                              rows))]
       (-> stats
           (update :segment-tuples   + (* n (count segments)))
+          (update :composite-tuples + (* n (count composites)))
           (update :metric-tuples    + (* n (count metrics)))
           (update :dimension-tuples + (* n (count dimensions)))
           (update :segments   add-rows segments   segment-row)
+          (update :composites add-rows composites composite-row)
           (update :metrics    add-rows metrics    metric-row)
           (update :dimensions add-rows dimensions dimension-row)))
     (add-skip stats (:reason result) n)))
@@ -254,11 +267,13 @@
                            :query-execution-rows (reduce + 0 (vals hash->count))
                            :joined-rows          0
                            :segment-tuples       0
+                           :composite-tuples     0
                            :metric-tuples        0
                            :dimension-tuples     0
                            :profile-observations 0
                            :skipped-rows         {}
                            :segments             {}
+                           :composites           {}
                            :metrics              {}
                            :dimensions           {}
                            :seen-hashes          #{}}
@@ -285,6 +300,7 @@
          dimension-rows   (counts->rows (:dimensions day-stats))
          profile-rows     (profile-rows-for-dimensions bucket-date dimension-rows)
          payload          {:segments   (counts->rows (:segments day-stats))
+                           :composites (counts->rows (:composites day-stats))
                            :metrics    (counts->rows (:metrics day-stats))
                            :dimensions dimension-rows
                            :profiles   profile-rows}]
@@ -294,6 +310,7 @@
      (assoc day-stats
             :watermark-advanced? advance-watermark?
             :segment-rollup-rows (count (:segments payload))
+            :composite-rollup-rows (count (:composites payload))
             :metric-rollup-rows (count (:metrics payload))
             :dimension-rollup-rows (count (:dimensions payload))
             :profile-observations (count (:profiles payload))))))

--- a/src/metabase/usage_metadata/core.clj
+++ b/src/metabase/usage_metadata/core.clj
@@ -39,6 +39,16 @@
   [opts :- ::opts]
   (insights/implicit-dimensions opts))
 
+(mu/defn suggested-segments :- [:sequential :map]
+  "Top implicit composite-segment candidates across the window — closed frequent itemsets of size 2..5
+  mined from `source_segment_composite_daily`. Itemsets whose atom-set matches a saved Segment's
+  definition are filtered out.
+
+  Each result is `{:clause <mbql :and clause>, :atom-count <int>, :source <source-map>,
+                   :support <long>, :support-ratio <double>, :count <long>}`."
+  [opts :- ::opts]
+  (insights/suggested-segments-for-owner opts))
+
 (mu/defn profile-observations :- [:sequential :map]
   "Top profile observations (e.g. `:single-value`, `:all-null`, `:low-cardinality`) recorded for dimensions surfaced by
   usage-metadata, ranked by usage count.

--- a/src/metabase/usage_metadata/core.clj
+++ b/src/metabase/usage_metadata/core.clj
@@ -19,40 +19,90 @@
    [:limit        {:optional true} [:maybe pos-int?]]])
 
 (mu/defn implicit-segments :- [:sequential :map]
-  "Top implicit (ad-hoc, not-saved-as-a-Segment) filter patterns, ranked by usage count across the window.
+  "Filter predicates users have run ad-hoc that aren't already saved as Segments — surface candidates
+  for promotion to first-class Segments.
 
-  Each result is `{:predicate <mbql-clause>, :source {:type :id :name :display-name}, :fields [<field-map>...], :count <long>}`."
+  Each result describes one observed predicate:
+
+    :predicate  The MBQL filter clause as it appeared in queries (decoded from canonical storage).
+    :source     The table or card the predicate was applied to.
+    :fields     Field metadata for every field referenced inside the predicate, populated from the
+                Field index. Empty `:fields` rows are dropped.
+    :count      Number of query executions in the window whose stage used this exact predicate."
   [opts :- ::opts]
   (insights/implicit-segments opts))
 
 (mu/defn implicit-metrics :- [:sequential :map]
-  "Top implicit (ad-hoc, not-saved-as-a-Metric-card) aggregation patterns, ranked by usage count.
+  "Aggregation patterns users have run ad-hoc that aren't already saved as Metric cards — surface
+  candidates for promotion to first-class Metrics.
 
-  Each result is `{:source <source-map>, :aggregation {:type :field :temporal-field :temporal-unit}, :count <long>}`."
+  Each result describes one observed aggregation:
+
+    :source       The table or card the aggregation was applied to.
+    :aggregation  Shape of the aggregation:
+                    :type           — primitive op (`:sum`, `:count`, `:avg`, …). Composite
+                                      aggregations and saved-metric refs are excluded upstream.
+                    :field          — the aggregated column's metadata (or nil for `:count`).
+                    :temporal-field — the temporal breakout column, if any (joins this aggregation
+                                      to a time dimension; nil means an untimed aggregation).
+                    :temporal-unit  — bucket of the temporal breakout (`:day`, `:month`, …).
+    :count        Number of executions whose stage used this aggregation shape."
   [opts :- ::opts]
   (insights/implicit-metrics opts))
 
 (mu/defn implicit-dimensions :- [:sequential :map]
-  "Top dimensions used in breakouts across the window, ranked by usage count.
+  "Columns users have grouped by (breakouts) across the window — surface candidates for promotion
+  to first-class dimensions or pre-aggregations.
 
-  Each result is `{:source <source-map>, :dimension {:field :temporal-unit :binning}, :count <long>}`."
+  Each result describes one observed breakout:
+
+    :source     The table or card the breakout was applied to.
+    :dimension  Shape of the breakout:
+                  :field         — the broken-out column's metadata.
+                  :temporal-unit — temporal bucket (`:day`, `:month`, …) if the breakout was
+                                   temporally bucketed; nil otherwise.
+                  :binning       — decoded binning spec (`:num-bins`, `:bin-width`, `:strategy`)
+                                   if the breakout was binned; nil otherwise.
+    :count      Number of executions whose stage broke out by this exact shape."
   [opts :- ::opts]
   (insights/implicit-dimensions opts))
 
 (mu/defn suggested-segments :- [:sequential :map]
-  "Top implicit composite-segment candidates across the window — closed frequent itemsets of size 2..5
-  mined from `source_segment_composite_daily`. Itemsets whose atom-set matches a saved Segment's
-  definition are filtered out.
+  "Composite (`:and`) segment definitions that recur across a source's query history. Mined via
+  Apriori FIM over composite rollup baskets: each basket is the atom-set of one stage's top-level
+  `:and`. Itemsets whose atom-set matches a saved Segment's definition are filtered out, so the
+  results are genuinely ad-hoc.
 
-  Each result is `{:clause <mbql :and clause>, :atom-count <int>, :source <source-map>,
-                   :support <long>, :support-ratio <double>, :count <long>}`."
+  Each result describes one suggestion:
+
+    :clause        Reconstructed `[:and ...]` MBQL clause built from the itemset's atoms — what a
+                   caller would offer the user to save as a new Segment.
+    :itemset-size  Number of atomic predicates the suggestion combines (`k` in FIM terms; 2..5).
+                   Not the size of the baskets it was mined from — those can be larger.
+    :source        The table or card the suggestion is attributed to. Suggestions live within a
+                   single source; cross-source composites are not mined.
+    :support       Weighted count of baskets containing ALL the itemset's atoms (basket weight is
+                   the rollup row's execution count). Primary ranking key.
+    :support-ratio Fraction of baskets-touching-any-atom that also contain the full itemset. Guards
+                   against an individually popular atom dragging a co-occurrence that doesn't
+                   actually travel together."
   [opts :- ::opts]
   (insights/suggested-segments-for-owner opts))
 
 (mu/defn profile-observations :- [:sequential :map]
-  "Top profile observations (e.g. `:single-value`, `:all-null`, `:low-cardinality`) recorded for dimensions surfaced by
-  usage-metadata, ranked by usage count.
+  "Profile observations recorded for dimensions surfaced by usage-metadata — `:single-value`,
+  `:all-null`, `:low-cardinality` — useful for spotting low-value columns or columns whose
+  cardinality makes them suitable as facets.
 
-  Each result is `{:source <source-map>, :field <field-map>, :basis <keyword>, :observation {:type :value}, :count <long>}`."
+  Each result describes one observation:
+
+    :source       The table or card the field lives on.
+    :field        Field metadata for the column the observation is about.
+    :basis        Where the observation came from (e.g. `:fingerprint`).
+    :observation  Shape `{:type <keyword> :value <opaque>}`. `:type` is the observation kind;
+                  `:value` carries kind-specific detail (e.g. distinct count for
+                  `:low-cardinality`).
+    :count        Number of executions in the window that surfaced this observation for this
+                  field."
   [opts :- ::opts]
   (insights/profile-observations opts))

--- a/src/metabase/usage_metadata/core.clj
+++ b/src/metabase/usage_metadata/core.clj
@@ -1,108 +1,41 @@
 (ns metabase.usage-metadata.core
-  "Public API for usage-metadata rollups. Internal consumers should call the fns here rather than reaching into
-  `metabase.usage-metadata.insights`; this boundary pins the opts shape and return shape for future consumers."
+  "Public API for usage-metadata rollups."
   (:require
    [metabase.usage-metadata.insights :as insights]
-   [metabase.util.malli :as mu]
-   [metabase.util.malli.registry :as mr]))
+   [metabase.usage-metadata.schema :as usage-metadata.schema]
+   [metabase.util.malli :as mu]))
 
 (set! *warn-on-reflection* true)
 
-(mr/def ::source-type [:enum :table :card])
-
-(mr/def ::opts
-  [:map {:closed true}
-   [:source-type  {:optional true} [:maybe ::source-type]]
-   [:source-id    {:optional true} [:maybe pos-int?]]
-   [:bucket-start {:optional true} [:maybe :time/local-date]]
-   [:bucket-end   {:optional true} [:maybe :time/local-date]]
-   [:limit        {:optional true} [:maybe pos-int?]]])
-
-(mu/defn implicit-segments :- [:sequential :map]
+(mu/defn implicit-segments :- [:sequential ::usage-metadata.schema/implicit-segment]
   "Filter predicates users have run ad-hoc that aren't already saved as Segments — surface candidates
-  for promotion to first-class Segments.
-
-  Each result describes one observed predicate:
-
-    :predicate  The MBQL filter clause as it appeared in queries (decoded from canonical storage).
-    :source     The table or card the predicate was applied to.
-    :fields     Field metadata for every field referenced inside the predicate, populated from the
-                Field index. Empty `:fields` rows are dropped.
-    :count      Number of query executions in the window whose stage used this exact predicate."
-  [opts :- ::opts]
+  for promotion to first-class Segments."
+  [opts :- ::usage-metadata.schema/opts]
   (insights/implicit-segments opts))
 
-(mu/defn implicit-metrics :- [:sequential :map]
+(mu/defn implicit-metrics :- [:sequential ::usage-metadata.schema/implicit-metric]
   "Aggregation patterns users have run ad-hoc that aren't already saved as Metric cards — surface
-  candidates for promotion to first-class Metrics.
-
-  Each result describes one observed aggregation:
-
-    :source       The table or card the aggregation was applied to.
-    :aggregation  Shape of the aggregation:
-                    :type           — primitive op (`:sum`, `:count`, `:avg`, …). Composite
-                                      aggregations and saved-metric refs are excluded upstream.
-                    :field          — the aggregated column's metadata (or nil for `:count`).
-                    :temporal-field — the temporal breakout column, if any (joins this aggregation
-                                      to a time dimension; nil means an untimed aggregation).
-                    :temporal-unit  — bucket of the temporal breakout (`:day`, `:month`, …).
-    :count        Number of executions whose stage used this aggregation shape."
-  [opts :- ::opts]
+  candidates for promotion to first-class Metrics."
+  [opts :- ::usage-metadata.schema/opts]
   (insights/implicit-metrics opts))
 
-(mu/defn implicit-dimensions :- [:sequential :map]
+(mu/defn implicit-dimensions :- [:sequential ::usage-metadata.schema/implicit-dimension]
   "Columns users have grouped by (breakouts) across the window — surface candidates for promotion
-  to first-class dimensions or pre-aggregations.
-
-  Each result describes one observed breakout:
-
-    :source     The table or card the breakout was applied to.
-    :dimension  Shape of the breakout:
-                  :field         — the broken-out column's metadata.
-                  :temporal-unit — temporal bucket (`:day`, `:month`, …) if the breakout was
-                                   temporally bucketed; nil otherwise.
-                  :binning       — decoded binning spec (`:num-bins`, `:bin-width`, `:strategy`)
-                                   if the breakout was binned; nil otherwise.
-    :count      Number of executions whose stage broke out by this exact shape."
-  [opts :- ::opts]
+  to first-class dimensions or pre-aggregations."
+  [opts :- ::usage-metadata.schema/opts]
   (insights/implicit-dimensions opts))
 
-(mu/defn suggested-segments :- [:sequential :map]
+(mu/defn suggested-segments :- [:sequential ::usage-metadata.schema/suggested-segment]
   "Composite (`:and`) segment definitions that recur across a source's query history. Mined via
   Apriori FIM over composite rollup baskets: each basket is the atom-set of one stage's top-level
   `:and`. Itemsets whose atom-set matches a saved Segment's definition are filtered out, so the
-  results are genuinely ad-hoc.
-
-  Each result describes one suggestion:
-
-    :clause        Reconstructed `[:and ...]` MBQL clause built from the itemset's atoms — what a
-                   caller would offer the user to save as a new Segment.
-    :itemset-size  Number of atomic predicates the suggestion combines (`k` in FIM terms; 2..5).
-                   Not the size of the baskets it was mined from — those can be larger.
-    :source        The table or card the suggestion is attributed to. Suggestions live within a
-                   single source; cross-source composites are not mined.
-    :support       Weighted count of baskets containing ALL the itemset's atoms (basket weight is
-                   the rollup row's execution count). Primary ranking key.
-    :support-ratio Fraction of baskets-touching-any-atom that also contain the full itemset. Guards
-                   against an individually popular atom dragging a co-occurrence that doesn't
-                   actually travel together."
-  [opts :- ::opts]
+  results are genuinely ad-hoc."
+  [opts :- ::usage-metadata.schema/opts]
   (insights/suggested-segments-for-owner opts))
 
-(mu/defn profile-observations :- [:sequential :map]
+(mu/defn profile-observations :- [:sequential ::usage-metadata.schema/profile-observation]
   "Profile observations recorded for dimensions surfaced by usage-metadata — `:single-value`,
   `:all-null`, `:low-cardinality` — useful for spotting low-value columns or columns whose
-  cardinality makes them suitable as facets.
-
-  Each result describes one observation:
-
-    :source       The table or card the field lives on.
-    :field        Field metadata for the column the observation is about.
-    :basis        Where the observation came from (e.g. `:fingerprint`).
-    :observation  Shape `{:type <keyword> :value <opaque>}`. `:type` is the observation kind;
-                  `:value` carries kind-specific detail (e.g. distinct count for
-                  `:low-cardinality`).
-    :count        Number of executions in the window that surfaced this observation for this
-                  field."
-  [opts :- ::opts]
+  cardinality makes them suitable as facets."
+  [opts :- ::usage-metadata.schema/opts]
   (insights/profile-observations opts))

--- a/src/metabase/usage_metadata/extract.clj
+++ b/src/metabase/usage_metadata/extract.clj
@@ -142,6 +142,26 @@
         (mapcat (partial segment-facts-for-clause query stage-number))
         (or (lib/filters query stage-number) [])))
 
+(defn- atomic-filter-clauses
+  "If `clause` is an `:and`, flatten it into its atomic sub-clauses by way of
+  `lib/expression-parts` (the one transparent window into an MBQL clause) and
+  `lib/expression-clause` (the reverse). Anything else is returned as a single
+  atom."
+  [query stage-number clause]
+  (if-not (lib/clause-of-type? clause :and)
+    [clause]
+    (if-let [parts (expression-parts-safe query stage-number clause)]
+      (into []
+            (mapcat (fn [arg]
+                      (when-let [child (try
+                                         (lib/expression-clause arg)
+                                         (catch Throwable e
+                                           (log/debugf e "usage-metadata: expression-clause failed (stage %s)" stage-number)
+                                           nil))]
+                        (atomic-filter-clauses query stage-number child))))
+            (:args parts))
+      [clause])))
+
 ;; Allowlist of primitive aggregation operators we will record. Sourced from
 ;; `metabase.lib.schema.aggregation` (see `::aggregation-clause-tag`).
 ;; Composite aggregations (`:-`, `:+`, `:case`, etc.) and references to
@@ -166,6 +186,50 @@
     :cum-sum
     :sum-where
     :var})
+
+(defn- composite-facts-for-stage
+  "Emit at most one composite fact per stage, treating the stage's top-level filter list as a single
+  implicit-`:and` basket. We flatten any explicit `:and` children so the basket's atom membership matches
+  the atom rollup's per-atom facts. Stages with fewer than two atoms are skipped (the atom rollup already
+  captures single predicates)."
+  [query stage-number]
+  (let [top-filters (or (lib/filters query stage-number) [])
+        atoms       (into [] (mapcat (partial atomic-filter-clauses query stage-number)) top-filters)
+        atom-count  (count atoms)]
+    (when (>= atom-count 2)
+      (let [root-owner       (query-source-table-or-card query)
+            synthetic-and    (lib/expression-clause :and atoms nil)
+            canonical-clause (canonicalize-for-storage synthetic-and)
+            canonical-atoms  (vec (sort (map canonicalize-for-storage atoms)))
+            field-refs       (into []
+                                   (comp (mapcat (fn [atom-clause]
+                                                   (participants-from-parts
+                                                    root-owner
+                                                    (expression-parts-safe query stage-number atom-clause))))
+                                         (distinct))
+                                   atoms)
+            owners           (set (map :owner field-refs))
+            base             {:clause            canonical-clause
+                              :atom-fingerprints canonical-atoms
+                              :atom-count        atom-count}]
+        (cond
+          (empty? field-refs)
+          []
+
+          (= 1 (count owners))
+          [(merge (first owners) base {:ownership-mode :direct})]
+
+          :else
+          (into [(merge base {:source-type nil :source-id nil :ownership-mode :mixed})]
+                (map (fn [owner] (merge owner base {:ownership-mode :projected})))
+                owners))))))
+
+(defn- temporal-breakout
+  [breakout]
+  (when-let [temporal-unit (lib/raw-temporal-bucket breakout)]
+    (when-let [field-id (some-> breakout lib/all-field-ids not-empty first)]
+      {:temporal-field-id field-id
+       :temporal-unit     temporal-unit})))
 
 (defn- metric-bases
   [query stage-number aggregation]
@@ -260,11 +324,13 @@
   "Extract fact-level usage tuples from a normalized MBQL query."
   [query]
   (reduce
-   (fn [{:keys [segments metrics dimensions]} stage-number]
+   (fn [{:keys [segments composites metrics dimensions]} stage-number]
      {:segments   (into segments (segment-facts-for-stage query stage-number))
+      :composites (into composites (composite-facts-for-stage query stage-number))
       :metrics    (into metrics (metric-facts-for-stage query stage-number))
       :dimensions (into dimensions (dimension-facts-for-stage query stage-number))})
-   {:segments []
-    :metrics []
+   {:segments   []
+    :composites []
+    :metrics    []
     :dimensions []}
    (range (lib/stage-count query))))

--- a/src/metabase/usage_metadata/extract.clj
+++ b/src/metabase/usage_metadata/extract.clj
@@ -224,13 +224,6 @@
                 (map (fn [owner] (merge owner base {:ownership-mode :projected})))
                 owners))))))
 
-(defn- temporal-breakout
-  [breakout]
-  (when-let [temporal-unit (lib/raw-temporal-bucket breakout)]
-    (when-let [field-id (some-> breakout lib/all-field-ids not-empty first)]
-      {:temporal-field-id field-id
-       :temporal-unit     temporal-unit})))
-
 (defn- metric-bases
   [query stage-number aggregation]
   (let [root-owner (query-source-table-or-card query)

--- a/src/metabase/usage_metadata/extract.clj
+++ b/src/metabase/usage_metadata/extract.clj
@@ -64,33 +64,33 @@
     :else
     nil))
 
-(defn- column-metadata?
-  [x]
-  (and (map? x) (= :metadata/column (:lib/type x))))
-
-(defn- participants-from-parts
-  [root-owner parts]
-  (letfn [(walk [node]
-            (cond
-              (column-metadata? node)
-              (when-let [field-id (:id node)]
-                (when (pos-int? field-id)
-                  (when-let [owner (owner-from-metadata root-owner node)]
-                    [{:field-id field-id :owner owner}])))
-
-              (and (map? node) (= :mbql/expression-parts (:lib/type node)))
-              (mapcat walk (:args node))
-
-              :else
-              nil))]
-    (-> (walk parts) distinct vec)))
-
-(defn- expression-parts-safe
+(defn- referenced-columns-safe
   [query stage-number clause]
   (try
-    (lib/expression-parts query stage-number clause)
+    (lib/referenced-columns query stage-number clause)
     (catch Throwable e
-      (log/debugf e "usage-metadata: expression-parts failed (stage %s)" stage-number)
+      (log/debugf e "usage-metadata: referenced-columns failed (stage %s)" stage-number)
+      nil)))
+
+(defn- field-participants-of-clause
+  "For one MBQL clause, returns distinct `{:field-id ... :owner ...}` maps for each referenced
+  column whose `:id` resolves to a real Field and has a derivable owner."
+  [query stage-number root-owner clause]
+  (into []
+        (comp (keep (fn [col]
+                      (when-let [field-id (:id col)]
+                        (when (pos-int? field-id)
+                          (when-let [owner (owner-from-metadata root-owner col)]
+                            {:field-id field-id :owner owner})))))
+              (distinct))
+        (referenced-columns-safe query stage-number clause)))
+
+(defn- aggregation-operator-safe
+  [query stage-number aggregation]
+  (try
+    (:operator (lib/expression-parts query stage-number aggregation))
+    (catch Throwable e
+      (log/debugf e "usage-metadata: aggregation operator extraction failed (stage %s)" stage-number)
       nil)))
 
 (defn- breakout-column-safe
@@ -104,8 +104,7 @@
 (defn- segment-facts-for-clause
   [query stage-number clause]
   (let [root-owner (query-source-table-or-card query)
-        parts      (expression-parts-safe query stage-number clause)
-        field-refs (participants-from-parts root-owner parts)
+        field-refs (field-participants-of-clause query stage-number root-owner clause)
         owners     (set (map :owner field-refs))
         predicate  (canonicalize-for-storage clause)]
     (cond
@@ -142,26 +141,6 @@
         (mapcat (partial segment-facts-for-clause query stage-number))
         (or (lib/filters query stage-number) [])))
 
-(defn- atomic-filter-clauses
-  "If `clause` is an `:and`, flatten it into its atomic sub-clauses by way of
-  `lib/expression-parts` (the one transparent window into an MBQL clause) and
-  `lib/expression-clause` (the reverse). Anything else is returned as a single
-  atom."
-  [query stage-number clause]
-  (if-not (lib/clause-of-type? clause :and)
-    [clause]
-    (if-let [parts (expression-parts-safe query stage-number clause)]
-      (into []
-            (mapcat (fn [arg]
-                      (when-let [child (try
-                                         (lib/expression-clause arg)
-                                         (catch Throwable e
-                                           (log/debugf e "usage-metadata: expression-clause failed (stage %s)" stage-number)
-                                           nil))]
-                        (atomic-filter-clauses query stage-number child))))
-            (:args parts))
-      [clause])))
-
 ;; Allowlist of primitive aggregation operators we will record. Sourced from
 ;; `metabase.lib.schema.aggregation` (see `::aggregation-clause-tag`).
 ;; Composite aggregations (`:-`, `:+`, `:case`, etc.) and references to
@@ -189,23 +168,19 @@
 
 (defn- composite-facts-for-stage
   "Emit at most one composite fact per stage, treating the stage's top-level filter list as a single
-  implicit-`:and` basket. We flatten any explicit `:and` children so the basket's atom membership matches
-  the atom rollup's per-atom facts. Stages with fewer than two atoms are skipped (the atom rollup already
-  captures single predicates)."
+  implicit-`:and` basket. `lib/atomic-filters` flattens any explicit `:and` children so the basket's
+  atom membership matches the atom rollup's per-atom facts. Stages with fewer than two atoms are
+  skipped (the atom rollup already captures single predicates)."
   [query stage-number]
-  (let [top-filters (or (lib/filters query stage-number) [])
-        atoms       (into [] (mapcat (partial atomic-filter-clauses query stage-number)) top-filters)
-        atom-count  (count atoms)]
+  (let [atoms      (or (lib/atomic-filters query stage-number) [])
+        atom-count (count atoms)]
     (when (>= atom-count 2)
       (let [root-owner       (query-source-table-or-card query)
             synthetic-and    (apply lib/and atoms)
             canonical-clause (canonicalize-for-storage synthetic-and)
             canonical-atoms  (vec (sort (map canonicalize-for-storage atoms)))
             field-refs       (into []
-                                   (comp (mapcat (fn [atom-clause]
-                                                   (participants-from-parts
-                                                    root-owner
-                                                    (expression-parts-safe query stage-number atom-clause))))
+                                   (comp (mapcat (partial field-participants-of-clause query stage-number root-owner))
                                          (distinct))
                                    atoms)
             owners           (set (map :owner field-refs))
@@ -227,9 +202,8 @@
 (defn- metric-bases
   [query stage-number aggregation]
   (let [root-owner (query-source-table-or-card query)
-        parts      (expression-parts-safe query stage-number aggregation)
-        agg-type   (:operator parts)
-        field-refs (participants-from-parts root-owner parts)
+        agg-type   (aggregation-operator-safe query stage-number aggregation)
+        field-refs (field-participants-of-clause query stage-number root-owner aggregation)
         owners     (set (map :owner field-refs))]
     (cond
       ;; Skip composite aggregations and saved-metric references — only record

--- a/src/metabase/usage_metadata/extract.clj
+++ b/src/metabase/usage_metadata/extract.clj
@@ -198,7 +198,7 @@
         atom-count  (count atoms)]
     (when (>= atom-count 2)
       (let [root-owner       (query-source-table-or-card query)
-            synthetic-and    (lib/expression-clause :and atoms nil)
+            synthetic-and    (apply lib/and atoms)
             canonical-clause (canonicalize-for-storage synthetic-and)
             canonical-atoms  (vec (sort (map canonicalize-for-storage atoms)))
             field-refs       (into []

--- a/src/metabase/usage_metadata/insights.clj
+++ b/src/metabase/usage_metadata/insights.clj
@@ -8,6 +8,7 @@
    [metabase.usage-metadata.models.source-dimension-daily]
    [metabase.usage-metadata.models.source-dimension-profile-daily]
    [metabase.usage-metadata.models.source-metric-daily]
+   [metabase.usage-metadata.models.source-segment-composite-daily]
    [metabase.usage-metadata.models.source-segment-daily]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
@@ -143,6 +144,37 @@
                {:where    where
                 :group-by [:source_type :source_id :field_id :temporal_unit :binning]
                 :order-by [[:total_count :desc]]})))
+
+(defn- decode-atom-fingerprints [x]
+  (cond
+    (sequential? x) (vec x)
+    (string? x)     (vec (json/decode x))
+    :else           []))
+
+(defn- grouped-composite-rows
+  "Group + sum `source_segment_composite_daily` counts for a source filter.
+
+  Each returned row carries the whole-clause JSON, the atom-fingerprint array, and the summed count
+  across the window — the input shape expected by the FIM pass."
+  [{:keys [source-type source-id bucket-start bucket-end]}]
+  (let [where (cond-> [:and
+                       [:in :ownership_mode ["direct" "projected"]]]
+                source-type  (conj [:= :source_type (name source-type)])
+                source-id    (conj [:= :source_id source-id])
+                bucket-start (conj [:>= :bucket_date bucket-start])
+                bucket-end   (conj [:<= :bucket_date bucket-end]))]
+    (->> (t2/select [:model/SourceSegmentCompositeDaily
+                     :source_type
+                     :source_id
+                     :clause
+                     :atom_fingerprints
+                     :atom_count
+                     [[:sum :count] :total_count]]
+                    {:where    where
+                     :group-by [:source_type :source_id :clause :atom_fingerprints :atom_count]
+                     :order-by [[:total_count :desc]]})
+         (mapv (fn [row]
+                 (update row :atom_fingerprints decode-atom-fingerprints))))))
 
 (defn- grouped-profile-rows
   "Group + sum `source_dimension_profile_daily` counts for a source filter."
@@ -336,6 +368,198 @@
                          :count     total_count}))))
             (take limit))
            rows))))
+
+(def ^:private fim-absolute-support-floor 2)
+(def ^:private fim-relative-support-floor 0.2)
+(def ^:private fim-k-min 2)
+(def ^:private fim-k-max 5)
+(def ^:private fim-default-limit 20)
+
+(defn- rows->baskets
+  "Project rollup rows to `{:atoms #{...} :count n}` baskets for mining."
+  [rows]
+  (into []
+        (keep (fn [{:keys [atom_fingerprints total_count]}]
+                (when (>= (count atom_fingerprints) fim-k-min)
+                  {:atoms (set atom_fingerprints)
+                   :count total_count})))
+        rows))
+
+(defn- itemset-support
+  [baskets itemset]
+  (reduce (fn [acc {:keys [atoms count]}]
+            (if (every? atoms itemset)
+              (+ acc count)
+              acc))
+          0
+          baskets))
+
+(defn- any-atom-support
+  "Number of baskets containing at least one atom of `itemset` (denominator for the relative support check)."
+  [baskets itemset]
+  (reduce (fn [acc {:keys [atoms count]}]
+            (if (some atoms itemset)
+              (+ acc count)
+              acc))
+          0
+          baskets))
+
+(defn- frequent-singletons
+  [baskets absolute-floor]
+  (let [counts (reduce (fn [m {:keys [atoms count]}]
+                         (reduce (fn [m a] (update m a (fnil + 0) count)) m atoms))
+                       {}
+                       baskets)]
+    (into {}
+          (filter (fn [[_ n]] (>= n absolute-floor)))
+          counts)))
+
+(defn- apriori-join
+  "Generate k+1 candidate itemsets by joining k-itemsets sharing a k-1 prefix."
+  [lk-vecs]
+  (let [by-prefix (group-by (fn [is] (subvec is 0 (dec (count is)))) lk-vecs)]
+    (into #{}
+          (mapcat (fn [group]
+                    (for [a group
+                          b group
+                          :when (neg? (compare (peek a) (peek b)))]
+                      (conj a (peek b)))))
+          (vals by-prefix))))
+
+(defn- has-all-k-subsets?
+  [lk-set candidate]
+  (let [n (count candidate)]
+    (every? (fn [i]
+              (let [sub (into (subvec candidate 0 i) (subvec candidate (inc i)))]
+                (contains? lk-set sub)))
+            (range n))))
+
+(defn- mine-itemsets
+  "Apriori up to size `fim-k-max`. Returns `{itemset-vec support}` for itemsets of size ≥ `fim-k-min`."
+  [baskets]
+  (let [singletons (frequent-singletons baskets fim-absolute-support-floor)
+        l1-vecs    (vec (sort (map vector (keys singletons))))]
+    (loop [lk       l1-vecs
+           k        1
+           acc      {}]
+      (if (or (empty? lk) (>= k fim-k-max))
+        acc
+        (let [lk-set     (set lk)
+              candidates (apriori-join lk)
+              pruned     (into [] (filter (partial has-all-k-subsets? lk-set)) candidates)
+              counted    (into {}
+                               (keep (fn [c]
+                                       (let [s (itemset-support baskets (set c))]
+                                         (when (>= s fim-absolute-support-floor) [c s]))))
+                               pruned)
+              next-k     (inc k)
+              acc        (if (>= next-k fim-k-min)
+                           (merge acc counted)
+                           acc)]
+          (recur (vec (sort (keys counted))) next-k acc))))))
+
+(defn- closed-only
+  "Keep only itemsets that have no proper superset of equal support — the closed frequent itemsets."
+  [itemset->support]
+  (let [entries (vec itemset->support)]
+    (into {}
+          (remove (fn [[is sup]]
+                    (let [is-set (set is)
+                          is-n   (count is)]
+                      (some (fn [[other other-sup]]
+                              (and (= sup other-sup)
+                                   (> (count other) is-n)
+                                   (every? (set other) is-set)))
+                            entries))))
+          entries)))
+
+(defn- relative-support-ok?
+  [baskets itemset support]
+  (let [denom (any-atom-support baskets itemset)]
+    (or (zero? denom)
+        (>= (/ support (double denom)) fim-relative-support-floor))))
+
+(defn- rebuild-and-clause
+  [fingerprints]
+  (let [atoms (into []
+                    (keep decode-predicate)
+                    fingerprints)]
+    (when (>= (count atoms) fim-k-min)
+      (into [:and] atoms))))
+
+(defn- existing-composite-atomsets*
+  [[source-type source-id]]
+  (let [where     (cond-> [:and [:= :archived false]]
+                    (and (= source-type :table) source-id) (conj [:= :table_id source-id]))
+        segments  (t2/select [:model/Segment :id :table_id :definition] {:where where})
+        table-ids (into #{} (comp (keep :table_id) (filter pos-int?)) segments)
+        table->db (when (seq table-ids)
+                    (into {}
+                          (map (juxt :id :db_id))
+                          (t2/select [:model/Table :id :db_id] :id [:in table-ids])))]
+    (lib-be/with-metadata-provider-cache
+      (into #{}
+            (mapcat (fn [{:keys [table_id definition]}]
+                      (when (and (pos-int? table_id) (seq definition))
+                        (when-let [db-id (get table->db table_id)]
+                          (let [facts (:composites (extract-facts db-id definition))]
+                            (for [{:keys [atom-fingerprints]} facts
+                                  :when (>= (count atom-fingerprints) fim-k-min)]
+                              [:table table_id (set atom-fingerprints)]))))))
+            segments))))
+
+(def ^:private existing-composite-atomsets*-memo
+  (memoize/ttl existing-composite-atomsets* :ttl/threshold cache-ttl-ms))
+
+(defn- existing-composite-atomsets
+  "Set of `[source-type source-id #{atom-fingerprint ...}]` tuples for non-archived Segments whose
+  definitions are whole-:and baskets. Used to filter out suggestions that already exist as saved Segments."
+  [{:keys [source-type source-id]}]
+  (existing-composite-atomsets*-memo [source-type source-id]))
+
+(defn suggested-segments-for-owner
+  "Top implicit composite segment candidates for an owner — closed frequent itemsets (size 2..5) of
+  atom fingerprints that recur above the absolute + relative support thresholds across composite
+  rollup baskets in the window.
+
+  Itemsets whose atom-set equals an existing non-archived Segment's definition are filtered out.
+
+  Returns a ranked sequence of:
+    {:clause <mbql :and clause>
+     :atom-count <int>
+     :source {:type :id :name :display-name}
+     :support <long>        ; weighted basket count containing the itemset
+     :support-ratio <double>; support / baskets-with-any-of-its-atoms
+     :count <long>}"
+  ([] (suggested-segments-for-owner {}))
+  ([{:keys [limit] :or {limit fim-default-limit} :as opts}]
+   (let [rows          (grouped-composite-rows opts)
+         by-source     (group-by (juxt :source_type :source_id) rows)
+         source-idx    (build-source-index (keys by-source))
+         candidates    (into []
+                             (mapcat (fn [[[source-type source-id] source-rows]]
+                                       (when-let [source (source-idx [source-type source-id])]
+                                         (let [baskets  (rows->baskets source-rows)
+                                               existing (existing-composite-atomsets {:source-type source-type
+                                                                                      :source-id   source-id})
+                                               mined    (closed-only (mine-itemsets baskets))]
+                                           (for [[itemset-vec support] mined
+                                                 :let  [itemset (set itemset-vec)]
+                                                 :when (and (relative-support-ok? baskets itemset-vec support)
+                                                            (not (contains? existing [source-type source-id itemset])))
+                                                 :let  [clause (rebuild-and-clause itemset-vec)
+                                                        denom  (any-atom-support baskets itemset-vec)]
+                                                 :when clause]
+                                             {:clause        clause
+                                              :atom-count    (count itemset-vec)
+                                              :source        source
+                                              :support       support
+                                              :support-ratio (if (pos? denom) (/ support (double denom)) 0.0)
+                                              :count         support})))))
+                             by-source)]
+     (into []
+           (take limit)
+           (sort-by (juxt (comp - :support) (comp - :atom-count)) candidates)))))
 
 (defn profile-observations
   "Top dimension profile observations recorded across usage-metadata rollups."

--- a/src/metabase/usage_metadata/insights.clj
+++ b/src/metabase/usage_metadata/insights.clj
@@ -2,6 +2,7 @@
   "Read-side helpers over usage-metadata rollups — consumer of the batch pipeline."
   (:require
    [clojure.core.memoize :as memoize]
+   [clojure.walk :as walk]
    [metabase.lib-be.core :as lib-be]
    [metabase.lib.core :as lib]
    [metabase.usage-metadata.extract :as usage-metadata.extract]
@@ -16,11 +17,26 @@
 
 (set! *warn-on-reflection* true)
 
+(defn- seqs->vecs
+  "Recursively convert non-map-entry `seq?` nodes to vectors.
+  `json/decode+kw` returns LazySeqs for JSON arrays, and `lib/normalize` only
+  reliably normalizes some clause tags (e.g. `:=`) from a LazySeq — others
+  (e.g. `:>`) silently pass through with string operators. Forcing vectors
+  before normalize is the simplest fix."
+  [x]
+  (walk/postwalk
+   (fn [node]
+     (if (and (seq? node) (not (map-entry? node)))
+       (vec node)
+       node))
+   x))
+
 (defn- decode-predicate
   "Parse a canonicalized predicate JSON string back into an MBQL 5 clause."
   [predicate-json]
   (some-> predicate-json
           json/decode+kw
+          seqs->vecs
           lib/normalize))
 
 (defn- decode-binning
@@ -485,7 +501,7 @@
                     (keep decode-predicate)
                     fingerprints)]
     (when (>= (count atoms) fim-k-min)
-      (into [:and] atoms))))
+      (lib/expression-clause :and atoms nil))))
 
 (defn- existing-composite-atomsets*
   [[source-type source-id]]

--- a/src/metabase/usage_metadata/insights.clj
+++ b/src/metabase/usage_metadata/insights.clj
@@ -534,19 +534,37 @@
   (existing-composite-atomsets*-memo [source-type source-id]))
 
 (defn suggested-segments-for-owner
-  "Top implicit composite segment candidates for an owner — closed frequent itemsets (size 2..5) of
-  atom fingerprints that recur above the absolute + relative support thresholds across composite
-  rollup baskets in the window.
+  "Suggest composite (`:and`) segment definitions that recur across a source's query history but
+  have not been saved as Segments yet. Implemented as Apriori FIM over composite rollup baskets:
+  each rollup row is a basket whose items are the atomic predicates of one stage's top-level `:and`.
+  We mine closed frequent itemsets and reconstruct each surviving itemset as an `:and` MBQL clause.
 
-  Itemsets whose atom-set equals an existing non-archived Segment's definition are filtered out.
+  Each returned map describes one suggestion:
 
-  Returns a ranked sequence of:
-    {:clause <mbql :and clause>
-     :atom-count <int>
-     :source {:type :id :name :display-name}
-     :support <long>        ; weighted basket count containing the itemset
-     :support-ratio <double>; support / baskets-with-any-of-its-atoms
-     :count <long>}"
+    :clause         The reconstructed `[:and ...]` MBQL clause. This is what a caller would offer
+                    the user to save as a new Segment. Built via `lib/expression-clause`, so it's a
+                    proper normalized MBQL value, not a hand-rolled vector.
+
+    :itemset-size   How many atomic predicates the suggestion combines (`k` in FIM terms). Bounded
+                    by `fim-k-min`/`fim-k-max` (2..5). NOTE: not the size of the source baskets the
+                    itemset was mined from — those can be larger.
+
+    :source         The table or card the suggestion is attributed to: `{:type :id :name
+                    :display-name ...}`. A suggestion lives within a single source; cross-source
+                    composites aren't mined.
+
+    :support        Weighted count of baskets that contain ALL the itemset's atoms. The basket
+                    weight is the rollup row's `:count`, i.e. number of executions — so a
+                    suggestion with `:support 12` was observed across baskets representing 12 query
+                    executions. Used as the primary ranking key.
+
+    :support-ratio  `support / any-atom-support`, i.e. the fraction of baskets-touching-any-atom
+                    that also contain the FULL itemset. Guards against an individually popular
+                    atom dragging a co-occurrence that doesn't really travel together. Floor:
+                    `fim-relative-support-floor`.
+
+  Results are sorted by `:support` desc, then by `:itemset-size` desc — at equal support, larger
+  recurring `:and`s rank higher, since they encode more user intent. Truncated to `:limit`."
   ([] (suggested-segments-for-owner {}))
   ([{:keys [limit] :or {limit fim-default-limit} :as opts}]
    (let [rows          (grouped-composite-rows opts)
@@ -567,15 +585,14 @@
                                                         denom  (any-atom-support baskets itemset-vec)]
                                                  :when clause]
                                              {:clause        clause
-                                              :atom-count    (count itemset-vec)
+                                              :itemset-size  (count itemset-vec)
                                               :source        source
                                               :support       support
-                                              :support-ratio (if (pos? denom) (/ support (double denom)) 0.0)
-                                              :count         support})))))
+                                              :support-ratio (if (pos? denom) (/ support (double denom)) 0.0)})))))
                              by-source)]
      (into []
            (take limit)
-           (sort-by (juxt (comp - :support) (comp - :atom-count)) candidates)))))
+           (sort-by (juxt (comp - :support) (comp - :itemset-size)) candidates)))))
 
 (defn profile-observations
   "Top dimension profile observations recorded across usage-metadata rollups."

--- a/src/metabase/usage_metadata/insights.clj
+++ b/src/metabase/usage_metadata/insights.clj
@@ -11,8 +11,10 @@
    [metabase.usage-metadata.models.source-metric-daily]
    [metabase.usage-metadata.models.source-segment-composite-daily]
    [metabase.usage-metadata.models.source-segment-daily]
+   [metabase.usage-metadata.schema :as usage-metadata.schema]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
+   [metabase.util.malli :as mu]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
@@ -291,20 +293,13 @@
   []
   (existing-metric-signatures*-memo ::all))
 
-(defn implicit-segments
+(mu/defn implicit-segments :- [:sequential ::usage-metadata.schema/implicit-segment]
   "Top implicit segments recorded across usage-metadata rollups.
 
   Predicates that correspond to *existing* saved Segments are filtered out — only truly
-  ad-hoc filter patterns are returned.
-
-  Returns a flat ranked sequence of:
-    {:predicate <mbql-clause>
-     :source {:type :id :name :display-name}
-     :fields [{:id :name :display-name} ...]
-     :count <long>}"
-  ([]
-   (implicit-segments {}))
-  ([{:keys [limit] :or {limit 10} :as opts}]
+  ad-hoc filter patterns are returned."
+  ([] (implicit-segments {}))
+  ([{:keys [limit] :or {limit 10} :as opts} :- ::usage-metadata.schema/opts]
    (let [existing    (existing-segment-predicates opts)
          raw-rows    (remove (fn [{:keys [source_type source_id predicate]}]
                                (contains? existing [source_type source_id predicate]))
@@ -333,14 +328,13 @@
             (take limit))
            enriched))))
 
-(defn implicit-metrics
+(mu/defn implicit-metrics :- [:sequential ::usage-metadata.schema/implicit-metric]
   "Top implicit metrics recorded across usage-metadata rollups.
 
   Aggregations that correspond to *existing* saved Metrics (Cards of type `metric`) are
   filtered out — only truly ad-hoc aggregation patterns are returned."
-  ([]
-   (implicit-metrics {}))
-  ([{:keys [limit] :or {limit 10} :as opts}]
+  ([] (implicit-metrics {}))
+  ([{:keys [limit] :or {limit 10} :as opts} :- ::usage-metadata.schema/opts]
    (let [existing   (existing-metric-signatures)
          rows       (remove (fn [{:keys [source_type source_id agg_type agg_field_id temporal_field_id temporal_unit]}]
                               (contains? existing [source_type source_id agg_type agg_field_id temporal_field_id temporal_unit]))
@@ -362,11 +356,10 @@
             (take limit))
            rows))))
 
-(defn implicit-dimensions
+(mu/defn implicit-dimensions :- [:sequential ::usage-metadata.schema/implicit-dimension]
   "Top implicit dimensions recorded across usage-metadata rollups."
-  ([]
-   (implicit-dimensions {}))
-  ([{:keys [limit] :or {limit 10} :as opts}]
+  ([] (implicit-dimensions {}))
+  ([{:keys [limit] :or {limit 10} :as opts} :- ::usage-metadata.schema/opts]
    (let [rows       (grouped-dimension-rows opts)
          source-idx (build-source-index
                      (into #{} (map (juxt :source_type :source_id)) rows))
@@ -533,39 +526,20 @@
   [{:keys [source-type source-id]}]
   (existing-composite-atomsets*-memo [source-type source-id]))
 
-(defn suggested-segments-for-owner
+(mu/defn suggested-segments-for-owner :- [:sequential ::usage-metadata.schema/suggested-segment]
   "Suggest composite (`:and`) segment definitions that recur across a source's query history but
   have not been saved as Segments yet. Implemented as Apriori FIM over composite rollup baskets:
   each rollup row is a basket whose items are the atomic predicates of one stage's top-level `:and`.
   We mine closed frequent itemsets and reconstruct each surviving itemset as an `:and` MBQL clause.
 
-  Each returned map describes one suggestion:
-
-    :clause         The reconstructed MBQL clause. This is what a caller would offer
-                    the user to save as a new Segment.
-
-    :itemset-size   How many atomic predicates the suggestion combines (`k` in FIM terms). Bounded
-                    by `fim-k-min`/`fim-k-max` (2..5). NOTE: not the size of the source baskets the
-                    itemset was mined from — those can be larger.
-
-    :source         The table or card the suggestion is attributed to: `{:type :id :name
-                    :display-name ...}`. A suggestion lives within a single source; cross-source
-                    composites aren't mined.
-
-    :support        Weighted count of baskets that contain ALL the itemset's atoms. The basket
-                    weight is the rollup row's `:count`, i.e. number of executions — so a
-                    suggestion with `:support 12` was observed across baskets representing 12 query
-                    executions. Used as the primary ranking key.
-
-    :support-ratio  `support / any-atom-support`, i.e. the fraction of baskets-touching-any-atom
-                    that also contain the FULL itemset. Guards against an individually popular
-                    atom dragging a co-occurrence that doesn't really travel together. Floor:
-                    `fim-relative-support-floor`.
+  `:itemset-size` is bounded by `fim-k-min`/`fim-k-max` (2..5). `:support` is the weighted count of
+  baskets containing ALL of the itemset's atoms (basket weight = the rollup row's `:count`).
+  `:support-ratio` is `support / any-atom-support` and is floored by `fim-relative-support-floor`.
 
   Results are sorted by `:support` desc, then by `:itemset-size` desc — at equal support, larger
   recurring `:and`s rank higher, since they encode more user intent. Truncated to `:limit`."
   ([] (suggested-segments-for-owner {}))
-  ([{:keys [limit] :or {limit fim-default-limit} :as opts}]
+  ([{:keys [limit] :or {limit fim-default-limit} :as opts} :- ::usage-metadata.schema/opts]
    (let [rows          (grouped-composite-rows opts)
          by-source     (group-by (juxt :source_type :source_id) rows)
          source-idx    (build-source-index (keys by-source))
@@ -593,11 +567,10 @@
            (take limit)
            (sort-by (juxt (comp - :support) (comp - :itemset-size)) candidates)))))
 
-(defn profile-observations
+(mu/defn profile-observations :- [:sequential ::usage-metadata.schema/profile-observation]
   "Top dimension profile observations recorded across usage-metadata rollups."
-  ([]
-   (profile-observations {}))
-  ([{:keys [limit] :or {limit 10} :as opts}]
+  ([] (profile-observations {}))
+  ([{:keys [limit] :or {limit 10} :as opts} :- ::usage-metadata.schema/opts]
    (let [rows       (grouped-profile-rows opts)
          source-idx (build-source-index
                      (into #{} (map (juxt :source_type :source_id)) rows))

--- a/src/metabase/usage_metadata/insights.clj
+++ b/src/metabase/usage_metadata/insights.clj
@@ -308,7 +308,7 @@
                           {:predicate (::decoded row)
                            :source    source
                            :fields    fields
-                           :count     (:total_count row)})))))
+                           :count     (long (:total_count row))})))))
             (take limit))
            enriched))))
 
@@ -336,7 +336,7 @@
                                      :field          (field-idx agg_field_id)
                                      :temporal-field (field-idx temporal_field_id)
                                      :temporal-unit  temporal_unit}
-                       :count       total_count})))
+                       :count       (long total_count)})))
             (take limit))
            rows))))
 
@@ -358,7 +358,7 @@
                          :dimension {:field         field
                                      :temporal-unit temporal_unit
                                      :binning       (decode-binning binning)}
-                         :count     total_count}))))
+                         :count     (long total_count)}))))
             (take limit))
            rows))))
 
@@ -369,13 +369,16 @@
 (def ^:private fim-default-limit 20)
 
 (defn- rows->baskets
-  "Project rollup rows to `{:atoms #{...} :count n}` baskets for mining."
+  "Project rollup rows to `{:atoms #{...} :count n}` baskets for mining.
+
+  Coerces `total_count` to `long` so downstream FIM math (and the `:support` field) stays
+  integer — MariaDB/MySQL return `SUM(int_col)` as `BigDecimal`."
   [rows]
   (into []
         (keep (fn [{:keys [atom_fingerprints total_count]}]
                 (when (>= (count atom_fingerprints) fim-k-min)
                   {:atoms (set atom_fingerprints)
-                   :count total_count})))
+                   :count (long total_count)})))
         rows))
 
 (defn- itemset-support
@@ -571,6 +574,6 @@
                          :basis       source_basis
                          :observation {:type  observation_type
                                        :value observation_value}
-                         :count       total_count}))))
+                         :count       (long total_count)}))))
             (take limit))
            rows))))

--- a/src/metabase/usage_metadata/insights.clj
+++ b/src/metabase/usage_metadata/insights.clj
@@ -2,7 +2,6 @@
   "Read-side helpers over usage-metadata rollups — consumer of the batch pipeline."
   (:require
    [clojure.core.memoize :as memoize]
-   [clojure.walk :as walk]
    [metabase.lib-be.core :as lib-be]
    [metabase.lib.core :as lib]
    [metabase.usage-metadata.extract :as usage-metadata.extract]
@@ -19,26 +18,11 @@
 
 (set! *warn-on-reflection* true)
 
-(defn- seqs->vecs
-  "Recursively convert non-map-entry `seq?` nodes to vectors.
-  `json/decode+kw` returns LazySeqs for JSON arrays, and `lib/normalize` only
-  reliably normalizes some clause tags (e.g. `:=`) from a LazySeq — others
-  (e.g. `:>`) silently pass through with string operators. Forcing vectors
-  before normalize is the simplest fix."
-  [x]
-  (walk/postwalk
-   (fn [node]
-     (if (and (seq? node) (not (map-entry? node)))
-       (vec node)
-       node))
-   x))
-
 (defn- decode-predicate
   "Parse a canonicalized predicate JSON string back into an MBQL 5 clause."
   [predicate-json]
   (some-> predicate-json
           json/decode+kw
-          seqs->vecs
           lib/normalize))
 
 (defn- decode-binning

--- a/src/metabase/usage_metadata/insights.clj
+++ b/src/metabase/usage_metadata/insights.clj
@@ -501,7 +501,7 @@
                     (keep decode-predicate)
                     fingerprints)]
     (when (>= (count atoms) fim-k-min)
-      (lib/expression-clause :and atoms nil))))
+      (lib/simplify-compound-filter (apply lib/and atoms)))))
 
 (defn- existing-composite-atomsets*
   [[source-type source-id]]
@@ -541,9 +541,8 @@
 
   Each returned map describes one suggestion:
 
-    :clause         The reconstructed `[:and ...]` MBQL clause. This is what a caller would offer
-                    the user to save as a new Segment. Built via `lib/expression-clause`, so it's a
-                    proper normalized MBQL value, not a hand-rolled vector.
+    :clause         The reconstructed MBQL clause. This is what a caller would offer
+                    the user to save as a new Segment.
 
     :itemset-size   How many atomic predicates the suggestion combines (`k` in FIM terms). Bounded
                     by `fim-k-min`/`fim-k-max` (2..5). NOTE: not the size of the source baskets the

--- a/src/metabase/usage_metadata/models/source_segment_composite_daily.clj
+++ b/src/metabase/usage_metadata/models/source_segment_composite_daily.clj
@@ -1,0 +1,13 @@
+(ns metabase.usage-metadata.models.source-segment-composite-daily
+  (:require
+   [metabase.models.interface :as mi]
+   [methodical.core :as methodical]
+   [toucan2.core :as t2]))
+
+(methodical/defmethod t2/table-name :model/SourceSegmentCompositeDaily [_model] :source_segment_composite_daily)
+
+(t2/deftransforms :model/SourceSegmentCompositeDaily
+  {:source_type    mi/transform-keyword
+   :ownership_mode mi/transform-keyword})
+
+(derive :model/SourceSegmentCompositeDaily :metabase/model)

--- a/src/metabase/usage_metadata/schema.clj
+++ b/src/metabase/usage_metadata/schema.clj
@@ -1,0 +1,112 @@
+(ns metabase.usage-metadata.schema
+  "Shared malli schemas for usage-metadata public API inputs and results.
+
+  These are the shape contracts pinned at the `metabase.usage-metadata.core` boundary and
+  enforced inside `metabase.usage-metadata.insights` producers."
+  (:require
+   [metabase.util.malli.registry :as mr]))
+
+(mr/def ::source-type [:enum :table :card])
+
+(mr/def ::opts
+  [:map {:closed true}
+   [:source-type  {:optional true, :description "Restrict to a specific source kind."}
+    [:maybe ::source-type]]
+   [:source-id    {:optional true, :description "Restrict to a specific source id."}
+    [:maybe pos-int?]]
+   [:bucket-start {:optional true, :description "Inclusive lower bound on rollup bucket_date."}
+    [:maybe :time/local-date]]
+   [:bucket-end   {:optional true, :description "Inclusive upper bound on rollup bucket_date."}
+    [:maybe :time/local-date]]
+   [:limit        {:optional true, :description "Maximum number of results to return."}
+    [:maybe pos-int?]]])
+
+(mr/def ::source
+  [:map
+   [:type         ::source-type]
+   [:id           pos-int?]
+   [:name         [:maybe :string]]
+   [:display-name [:maybe :string]]
+   ;; :db-id / :schema are present only on :table sources.
+   [:db-id        {:optional true} [:maybe pos-int?]]
+   [:schema       {:optional true} [:maybe :string]]])
+
+(mr/def ::field
+  [:map
+   [:id           pos-int?]
+   [:name         [:maybe :string]]
+   [:display-name [:maybe :string]]])
+
+(mr/def ::mbql-clause
+  [:fn {:error/message "expected an MBQL clause"}
+   (fn [x] (and (vector? x) (keyword? (first x))))])
+
+(mr/def ::implicit-segment
+  [:map {:closed true}
+   [:predicate {:description "The MBQL filter clause as it appeared in queries, decoded from canonical storage."}
+    [:maybe ::mbql-clause]]
+   [:source    {:description "The table or card the predicate was applied to."}
+    ::source]
+   [:fields    {:description "Field metadata for every field referenced inside the predicate. Rows with no resolvable fields are dropped upstream."}
+    [:sequential {:min 1} ::field]]
+   [:count     {:description "Number of query executions in the window whose stage used this exact predicate."}
+    pos-int?]])
+
+(mr/def ::implicit-metric
+  [:map {:closed true}
+   [:source      {:description "The table or card the aggregation was applied to."}
+    ::source]
+   [:aggregation [:map {:closed true}
+                  [:type           {:description "Primitive op (`:sum`, `:count`, `:avg`, …). Composite aggregations and saved-metric refs are excluded upstream."}
+                   :keyword]
+                  [:field          {:description "The aggregated column's metadata (nil for `:count`)."}
+                   [:maybe ::field]]
+                  [:temporal-field {:description "The temporal breakout column joined to this aggregation, if any. nil means an untimed aggregation."}
+                   [:maybe ::field]]
+                  [:temporal-unit  {:description "Bucket of the temporal breakout (`:day`, `:month`, …)."}
+                   [:maybe :keyword]]]]
+   [:count       {:description "Number of executions whose stage used this aggregation shape."}
+    pos-int?]])
+
+(mr/def ::implicit-dimension
+  [:map {:closed true}
+   [:source    {:description "The table or card the breakout was applied to."}
+    ::source]
+   [:dimension [:map {:closed true}
+                [:field         {:description "The broken-out column's metadata."}
+                 ::field]
+                [:temporal-unit {:description "Temporal bucket (`:day`, `:month`, …) if the breakout was temporally bucketed; nil otherwise."}
+                 [:maybe :keyword]]
+                [:binning       {:description "Decoded binning spec (`:num-bins`, `:bin-width`, `:strategy`) if the breakout was binned; nil otherwise."}
+                 [:maybe :map]]]]
+   [:count     {:description "Number of executions whose stage broke out by this exact shape."}
+    pos-int?]])
+
+(mr/def ::suggested-segment
+  [:map {:closed true}
+   [:clause        {:description "Reconstructed `[:and ...]` MBQL clause built from the itemset's atoms — what a caller would offer the user to save as a new Segment."}
+    ::mbql-clause]
+   [:itemset-size  {:description "Number of atomic predicates the suggestion combines (`k` in FIM terms; 2..5 bounded by `fim-k-min`/`fim-k-max`). NOT the size of the source baskets the itemset was mined from — those can be larger."}
+    pos-int?]
+   [:source        {:description "The table or card the suggestion is attributed to. Suggestions live within a single source; cross-source composites are not mined."}
+    ::source]
+   [:support       {:description "Weighted count of baskets containing ALL the itemset's atoms (basket weight is the rollup row's execution count). Primary ranking key."}
+    pos-int?]
+   [:support-ratio {:description "Fraction of baskets-touching-any-atom that also contain the full itemset. Guards against an individually popular atom dragging a co-occurrence that doesn't actually travel together. Floored by `fim-relative-support-floor`."}
+    number?]])
+
+(mr/def ::profile-observation
+  [:map {:closed true}
+   [:source      {:description "The table or card the field lives on."}
+    ::source]
+   [:field       {:description "Field metadata for the column the observation is about."}
+    ::field]
+   [:basis       {:description "Where the observation came from (e.g. `:fingerprint`)."}
+    :keyword]
+   [:observation [:map {:closed true}
+                  [:type  {:description "Observation kind (`:single-value`, `:all-null`, `:low-cardinality`)."}
+                   :keyword]
+                  [:value {:description "Kind-specific detail (e.g. the distinct count for `:low-cardinality`)."}
+                   :any]]]
+   [:count       {:description "Number of executions in the window that surfaced this observation for this field."}
+    pos-int?]])

--- a/src/metabase/usage_metadata/store.clj
+++ b/src/metabase/usage_metadata/store.clj
@@ -3,6 +3,7 @@
    [metabase.usage-metadata.models.source-dimension-daily]
    [metabase.usage-metadata.models.source-dimension-profile-daily]
    [metabase.usage-metadata.models.source-metric-daily]
+   [metabase.usage-metadata.models.source-segment-composite-daily]
    [metabase.usage-metadata.models.source-segment-daily]
    [toucan2.core :as t2]))
 
@@ -21,6 +22,7 @@
   "Delete all rollup rows for `bucket-date` across the usage metadata daily tables."
   [bucket-date]
   (t2/delete! :model/SourceSegmentDaily :bucket_date bucket-date)
+  (t2/delete! :model/SourceSegmentCompositeDaily :bucket_date bucket-date)
   (t2/delete! :model/SourceMetricDaily :bucket_date bucket-date)
   (t2/delete! :model/SourceDimensionDaily :bucket_date bucket-date)
   (t2/delete! :model/SourceDimensionProfileDaily :bucket_date bucket-date)
@@ -30,6 +32,13 @@
   "Insert daily segment rollup rows."
   [rows]
   (chunked-insert! :model/SourceSegmentDaily rows)
+  nil)
+
+(defn insert-composite-rollups!
+  "Insert daily composite segment (whole-:and basket) rollup rows."
+  [rows]
+  (when (seq rows)
+    (t2/insert! :model/SourceSegmentCompositeDaily rows))
   nil)
 
 (defn insert-metric-rollups!
@@ -52,10 +61,11 @@
 
 (defn replace-day!
   "Replace all rollup rows for `bucket-date` in one transaction."
-  [bucket-date {:keys [segments metrics dimensions profiles]}]
+  [bucket-date {:keys [segments composites metrics dimensions profiles]}]
   (t2/with-transaction [_conn]
     (delete-day! bucket-date)
     (insert-segment-rollups! segments)
+    (insert-composite-rollups! composites)
     (insert-metric-rollups! metrics)
     (insert-dimension-rollups! dimensions)
     (insert-dimension-profile-rollups! profiles))

--- a/test/metabase/cmd/copy_test.clj
+++ b/test/metabase/cmd/copy_test.clj
@@ -60,6 +60,7 @@
     :model/SourceDimensionDaily
     :model/SourceDimensionProfileDaily
     :model/SourceMetricDaily
+    :model/SourceSegmentCompositeDaily
     :model/SourceSegmentDaily
     :model/SupportAccessGrantLog
     :model/TaskHistory

--- a/test/metabase/lib/normalize_test.cljc
+++ b/test/metabase/lib/normalize_test.cljc
@@ -104,6 +104,13 @@
                            "aggregation"  [["count" {}]]
                            "filters"      [["=" {} ["field" {} 1] 4]]}]})))))
 
+(deftest ^:parallel lazy-seq-input-test
+  (testing "Seq input (e.g. LazySeqs from json/decode+kw) normalizes"
+    (is (=? [:= {:lib/uuid string?} [:field {:lib/uuid string?} 1] 4]
+            (lib/normalize '("=" {} ("field" {} 1) 4))))
+    (is (=? [:> {:lib/uuid string?} [:field {:lib/uuid string?} 1] 0]
+            (lib/normalize '(">" {} ("field" {} 1) 0))))))
+
 (deftest ^:parallel normalize-from-json-test
   (let [query '{:lib/type     "mbql/query"
                 :lib/metadata nil

--- a/test/metabase/usage_metadata/batch_test.clj
+++ b/test/metabase/usage_metadata/batch_test.clj
@@ -12,6 +12,7 @@
    [metabase.usage-metadata.models.source-dimension-daily]
    [metabase.usage-metadata.models.source-dimension-profile-daily]
    [metabase.usage-metadata.models.source-metric-daily]
+   [metabase.usage-metadata.models.source-segment-composite-daily]
    [metabase.usage-metadata.models.source-segment-daily]
    [metabase.usage-metadata.settings :as usage-metadata.settings]
    [metabase.usage-metadata.store :as usage-metadata.store]
@@ -144,6 +145,39 @@
         (delete-query! query-hash)
         (delete-query-executions-for-day! bucket-date)
         (delete-day! bucket-date)))))
+
+(defn- composite-orders-query []
+  (mt/mbql-query orders
+    {:filter [:and
+              [:= $orders.product_id 1]
+              [:> $orders.subtotal 0]]
+     :aggregation [[:count]]}))
+
+(deftest process-day!-composite-segment-test
+  (testing "a top-level :and filter writes both atom rollup rows AND one composite rollup row"
+    (let [bucket-date  (t/local-date "2026-04-13")
+          valid-query  (composite-orders-query)
+          query-hash   (lib-be.hash/query-hash valid-query)
+          execution-at (t/offset-date-time "2026-04-13T12:00Z")]
+      (try
+        (delete-query-executions-for-day! bucket-date)
+        (delete-day! bucket-date)
+        (insert-query! query-hash valid-query)
+        (insert-query-execution! query-hash execution-at)
+        (let [result (usage-metadata.batch/process-day! bucket-date)]
+          (is (= 2 (:segment-tuples result)))
+          (is (= 1 (:composite-tuples result))
+              "one composite fact per execution for the two-atom :and clause")
+          (is (= 2 (t2/count :model/SourceSegmentDaily :bucket_date bucket-date)))
+          (is (= 1 (t2/count :model/SourceSegmentCompositeDaily :bucket_date bucket-date)))
+          (let [composite (t2/select-one :model/SourceSegmentCompositeDaily :bucket_date bucket-date)]
+            (is (= :direct (:ownership_mode composite)))
+            (is (= 2 (:atom_count composite)))
+            (is (= 1 (:count composite)))))
+        (finally
+          (delete-query! query-hash)
+          (delete-query-executions-for-day! bucket-date)
+          (delete-day! bucket-date))))))
 
 (deftest process-day!-cross-source-predicate-test
   (let [bucket-date  (t/local-date "2026-04-13")

--- a/test/metabase/usage_metadata/batch_test.clj
+++ b/test/metabase/usage_metadata/batch_test.clj
@@ -147,11 +147,14 @@
         (delete-day! bucket-date)))))
 
 (defn- composite-orders-query []
-  (mt/mbql-query orders
-    {:filter [:and
-              [:= $orders.product_id 1]
-              [:> $orders.subtotal 0]]
-     :aggregation [[:count]]}))
+  (let [mp         (lib-be/application-database-metadata-provider (mt/id))
+        orders     (lib.metadata/table mp (mt/id :orders))
+        product-id (lib.metadata/field mp (mt/id :orders :product_id))
+        subtotal   (lib.metadata/field mp (mt/id :orders :subtotal))]
+    (-> (lib/query mp orders)
+        (lib/filter (lib/and (lib/= product-id 1)
+                             (lib/> subtotal 0)))
+        (lib/aggregate (lib/count)))))
 
 (deftest process-day!-composite-segment-test
   (testing "a top-level :and filter writes both atom rollup rows AND one composite rollup row"

--- a/test/metabase/usage_metadata/core_test.clj
+++ b/test/metabase/usage_metadata/core_test.clj
@@ -4,13 +4,43 @@
    [metabase.usage-metadata.core :as usage-metadata]
    [metabase.usage-metadata.insights :as insights]))
 
+(def ^:private sample-segment
+  {:predicate [:= [:field 1 nil] 1]
+   :source    {:type :card, :id 99, :name "Q", :display-name "Q"}
+   :fields    [{:id 1, :name "f", :display-name "F"}]
+   :count     1})
+
+(def ^:private sample-metric
+  {:source      {:type :table, :id 42, :name "T", :display-name "T", :db-id 1, :schema nil}
+   :aggregation {:type :count, :field nil, :temporal-field nil, :temporal-unit nil}
+   :count       1})
+
+(def ^:private sample-dimension
+  {:source    {:type :table, :id 42, :name "T", :display-name "T", :db-id 1, :schema nil}
+   :dimension {:field {:id 1, :name "f", :display-name "F"}, :temporal-unit nil, :binning nil}
+   :count     1})
+
+(def ^:private sample-suggested-segment
+  {:clause        [:and [:= [:field 1 nil] 1] [:> [:field 2 nil] 0]]
+   :itemset-size  2
+   :source        {:type :table, :id 42, :name "T", :display-name "T", :db-id 1, :schema nil}
+   :support       3
+   :support-ratio 1.0})
+
+(def ^:private sample-profile-observation
+  {:source      {:type :table, :id 42, :name "T", :display-name "T", :db-id 1, :schema nil}
+   :field       {:id 1, :name "f", :display-name "F"}
+   :basis       :fingerprint
+   :observation {:type :low-cardinality, :value 5}
+   :count       1})
+
 (deftest implicit-segments-delegate-to-insights-test
   (let [captured-args (atom nil)]
     (with-redefs [insights/implicit-segments
                   (fn [opts]
                     (reset! captured-args opts)
-                    [{:count 1}])]
-      (is (= [{:count 1}]
+                    [sample-segment])]
+      (is (= [sample-segment]
              (usage-metadata/implicit-segments {:source-type :card, :source-id 99, :limit 3})))
       (is (= {:source-type :card, :source-id 99, :limit 3}
              @captured-args)))))
@@ -20,8 +50,8 @@
     (with-redefs [insights/implicit-metrics
                   (fn [opts]
                     (reset! captured-args opts)
-                    [{:count 1}])]
-      (is (= [{:count 1}]
+                    [sample-metric])]
+      (is (= [sample-metric]
              (usage-metadata/implicit-metrics {:source-type :table, :source-id 42, :limit 7})))
       (is (= {:source-type :table, :source-id 42, :limit 7}
              @captured-args)))))
@@ -31,8 +61,30 @@
     (with-redefs [insights/implicit-dimensions
                   (fn [opts]
                     (reset! captured-args opts)
-                    [{:count 1}])]
-      (is (= [{:count 1}]
+                    [sample-dimension])]
+      (is (= [sample-dimension]
              (usage-metadata/implicit-dimensions {:source-type :table, :source-id 42, :limit 9})))
       (is (= {:source-type :table, :source-id 42, :limit 9}
+             @captured-args)))))
+
+(deftest suggested-segments-delegate-to-insights-test
+  (let [captured-args (atom nil)]
+    (with-redefs [insights/suggested-segments-for-owner
+                  (fn [opts]
+                    (reset! captured-args opts)
+                    [sample-suggested-segment])]
+      (is (= [sample-suggested-segment]
+             (usage-metadata/suggested-segments {:source-type :table, :source-id 42, :limit 5})))
+      (is (= {:source-type :table, :source-id 42, :limit 5}
+             @captured-args)))))
+
+(deftest profile-observations-delegate-to-insights-test
+  (let [captured-args (atom nil)]
+    (with-redefs [insights/profile-observations
+                  (fn [opts]
+                    (reset! captured-args opts)
+                    [sample-profile-observation])]
+      (is (= [sample-profile-observation]
+             (usage-metadata/profile-observations {:source-type :table, :source-id 42, :limit 4})))
+      (is (= {:source-type :table, :source-id 42, :limit 4}
              @captured-args)))))

--- a/test/metabase/usage_metadata/extract_test.clj
+++ b/test/metabase/usage_metadata/extract_test.clj
@@ -123,6 +123,56 @@
     (is (= {:source-type :card, :source-id 1, :ownership-mode :direct, :field-id (meta/id :checkins :user-id)}
            (select-keys (first rows) [:source-type :source-id :ownership-mode :field-id])))))
 
+(deftest ^:parallel composite-extraction-single-owner-test
+  (testing "a top-level :and clause produces exactly one composite fact on a single-owner query"
+    (let [query (lib/filter (lib.tu/venues-query)
+                            (lib/and (lib/= (meta/field-metadata :venues :price) 4)
+                                     (lib/> (meta/field-metadata :venues :id) 10)))
+          facts (:composites (extract/extract-usage-facts query))]
+      (is (= 1 (count facts)))
+      (let [{:keys [source-type source-id ownership-mode clause atom-fingerprints atom-count]} (first facts)]
+        (is (= :table source-type))
+        (is (= (meta/id :venues) source-id))
+        (is (= :direct ownership-mode))
+        (is (= 2 atom-count))
+        (is (= 2 (count atom-fingerprints)))
+        (is (= atom-fingerprints (vec (sort atom-fingerprints)))
+            "atom-fingerprints should be sorted for stable basket identity")
+        (is (= "and" (first (decode-json clause))))
+        (testing "atom fingerprints round-trip to canonical atom JSON"
+          (is (= #{"=" ">"} (set (map (comp first decode-json) atom-fingerprints)))))))))
+
+(deftest ^:parallel composite-extraction-single-atom-is-skipped-test
+  (testing "single-atom top-level filters emit NO composite (atom rollup already captures them)"
+    (let [query (lib/filter (lib.tu/venues-query)
+                            (lib/= (meta/field-metadata :venues :price) 4))]
+      (is (empty? (:composites (extract/extract-usage-facts query)))))))
+
+(deftest ^:parallel composite-extraction-accumulated-filters-combine-into-one-basket-test
+  (testing "two separate lib/filter calls form a single composite basket (the stage's implicit :and)"
+    (let [query (-> (lib.tu/venues-query)
+                    (lib/filter (lib/= (meta/field-metadata :venues :price) 4))
+                    (lib/filter (lib/> (meta/field-metadata :venues :id) 10)))
+          facts (:composites (extract/extract-usage-facts query))]
+      (is (= 1 (count facts)))
+      (is (= 2 (:atom-count (first facts)))))))
+
+(deftest ^:parallel composite-extraction-multi-owner-test
+  (testing ":and spanning multiple owners yields :mixed + per-owner :projected composite facts"
+    (let [query (lib/filter (lib.tu/query-with-join)
+                            (lib/and (lib/= (meta/field-metadata :venues :price) 1)
+                                     (lib/= (lib/with-join-alias (meta/field-metadata :categories :name) "Cat") "Pizza")))
+          facts (:composites (extract/extract-usage-facts query))]
+      (is (= 3 (count facts)))
+      (is (= 1 (count (filter #(= :mixed (:ownership-mode %)) facts))))
+      (is (= #{{:source-type :table, :source-id (meta/id :venues),      :ownership-mode :projected}
+               {:source-type :table, :source-id (meta/id :categories),  :ownership-mode :projected}}
+             (set (map #(select-keys % [:source-type :source-id :ownership-mode])
+                       (filter #(= :projected (:ownership-mode %)) facts)))))
+      (testing "all projected rows share the same clause+atom fingerprints as the mixed row"
+        (let [fingerprints (into #{} (map (juxt :clause :atom-fingerprints)) facts)]
+          (is (= 1 (count fingerprints))))))))
+
 (deftest ^:parallel cross-source-predicate-produces-mixed-and-projected-test
   (let [query (-> (lib.tu/query-with-join)
                   (lib/filter (lib/= (meta/field-metadata :venues :category-id)

--- a/test/metabase/usage_metadata/insights_test.clj
+++ b/test/metabase/usage_metadata/insights_test.clj
@@ -8,6 +8,63 @@
 
 (use-fixtures :once (fixtures/initialize :db))
 
+(def ^:private mine-itemsets         @#'insights/mine-itemsets)
+(def ^:private closed-only            @#'insights/closed-only)
+(def ^:private itemset-support        @#'insights/itemset-support)
+(def ^:private any-atom-support       @#'insights/any-atom-support)
+
+(deftest ^:parallel itemset-support-counts-containing-baskets-weighted-by-count-test
+  (let [baskets [{:atoms #{:a :b :c} :count 3}
+                 {:atoms #{:a :b}     :count 2}
+                 {:atoms #{:a :c}     :count 1}
+                 {:atoms #{:b}        :count 4}]]
+    (testing "support = sum of basket counts for baskets containing ALL atoms in the itemset"
+      (is (= 5 (itemset-support baskets #{:a :b})))
+      (is (= 4 (itemset-support baskets #{:a :c})))
+      (is (= 3 (itemset-support baskets #{:a :b :c})))
+      (is (= 0 (itemset-support baskets #{:z}))))
+    (testing "any-atom-support = sum of basket counts for baskets containing ANY atom in the itemset"
+      (is (= 10 (any-atom-support baskets #{:a :b})))
+      (is (= 6  (any-atom-support baskets #{:a}))))
+    (testing "a basket contributes to an itemset's support exactly once per its own count"
+      (doseq [basket baskets]
+        (let [contributes? (every? (:atoms basket) #{:a :b})]
+          (is (= (if contributes? (:count basket) 0)
+                 (itemset-support [basket] #{:a :b}))))))))
+
+(deftest ^:parallel mine-itemsets-worked-example-test
+  (testing "design-doc worked example: baskets {a1,a2,a3}+{a1,a2,a4} yield the {a1,a2} closed itemset"
+    (let [baskets [{:atoms #{:a1 :a2 :a3} :count 1}
+                   {:atoms #{:a1 :a2 :a4} :count 1}]
+          mined   (mine-itemsets baskets)
+          closed  (closed-only mined)]
+      (is (= {[:a1 :a2] 2} mined)
+          "absolute support floor of 2 keeps only the pair that co-occurs in both baskets")
+      (is (= {[:a1 :a2] 2} closed)
+          "closed filter has nothing to collapse when only one itemset survives"))))
+
+(deftest ^:parallel closed-only-drops-subsumed-itemsets-of-equal-support-test
+  (testing "if {a,b} and {a,b,c} have equal support, closed filter drops the smaller subset"
+    (is (= {[:a :b :c] 2}
+           (closed-only {[:a :b]     2
+                         [:a :b :c]  2}))))
+  (testing "subsets with strictly greater support are preserved"
+    (is (= {[:a :b]     5
+            [:a :b :c]  2}
+           (closed-only {[:a :b]     5
+                         [:a :b :c]  2}))))
+  (testing "unrelated itemsets are untouched"
+    (is (= {[:a :b] 3 [:c :d] 3}
+           (closed-only {[:a :b] 3 [:c :d] 3})))))
+
+(deftest ^:parallel mine-itemsets-respects-size-bounds-test
+  (testing "only itemsets of size ≥ fim-k-min (2) appear in output — no singletons"
+    (let [baskets [{:atoms #{:a :b} :count 5}]
+          mined   (mine-itemsets baskets)]
+      (is (every? #(>= (count %) 2) (keys mined)))
+      (is (not (contains? mined [:a])))
+      (is (not (contains? mined [:b]))))))
+
 (deftest existing-segment-predicates-cached-test
   (testing "existing-segment-predicates is TTL-memoized — repeated calls with the same opts hit the DB once"
     (let [segment-selects (atom 0)

--- a/test/metabase/usage_metadata/insights_test.clj
+++ b/test/metabase/usage_metadata/insights_test.clj
@@ -2,16 +2,28 @@
   (:require
    [clojure.core.memoize :as memoize]
    [clojure.test :refer :all]
+   [java-time.api :as t]
+   [metabase.lib-be.core :as lib-be]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
+   [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
+   [metabase.usage-metadata.extract :as usage-metadata.extract]
    [metabase.usage-metadata.insights :as insights]
+   [metabase.usage-metadata.models.source-segment-composite-daily]
+   [metabase.util.json :as json]
    [toucan2.core :as t2]))
 
 (use-fixtures :once (fixtures/initialize :db))
 
-(def ^:private mine-itemsets         @#'insights/mine-itemsets)
-(def ^:private closed-only            @#'insights/closed-only)
-(def ^:private itemset-support        @#'insights/itemset-support)
-(def ^:private any-atom-support       @#'insights/any-atom-support)
+(def ^:private mine-itemsets               @#'insights/mine-itemsets)
+(def ^:private closed-only                 @#'insights/closed-only)
+(def ^:private itemset-support             @#'insights/itemset-support)
+(def ^:private any-atom-support            @#'insights/any-atom-support)
+(def ^:private rebuild-and-clause          @#'insights/rebuild-and-clause)
+(def ^:private relative-support-ok?        @#'insights/relative-support-ok?)
+(def ^:private existing-composite-atomsets @#'insights/existing-composite-atomsets)
+(def ^:private composite-atomsets-memo     @#'insights/existing-composite-atomsets*-memo)
 
 (deftest ^:parallel itemset-support-counts-containing-baskets-weighted-by-count-test
   (let [baskets [{:atoms #{:a :b :c} :count 3}
@@ -98,3 +110,139 @@
         (existing-fn)
         (is (= 1 @card-selects)))
       (memoize/memo-clear! memo-var))))
+
+;;; ---------- composite-segment read-path tests ----------
+
+(deftest ^:parallel rebuild-and-clause-test
+  (let [fp-a "[\"=\",{},[\"field\",{},1],1]"
+        fp-b "[\">\",{},[\"field\",{},2],0]"]
+    (testing "builds a properly-shaped :and MBQL clause from atom fingerprints"
+      (is (lib/clause-of-type? (rebuild-and-clause [fp-a fp-b]) :and)))
+    (testing "returns nil below fim-k-min (2) atoms"
+      (is (nil? (rebuild-and-clause [])))
+      (is (nil? (rebuild-and-clause [fp-a]))))
+    (testing "returns nil when decode-predicate drops everything below the floor"
+      (is (nil? (rebuild-and-clause [nil nil])))
+      (is (nil? (rebuild-and-clause [fp-a nil]))))))
+
+(deftest ^:parallel relative-support-ok?-test
+  (testing "ratio above 0.2 floor → true"
+    (let [baskets [{:atoms #{:a :b} :count 4}
+                   {:atoms #{:a :c} :count 1}]]
+      (is (relative-support-ok? baskets [:a :b] 4))))
+  (testing "ratio below 0.2 floor → false"
+    (let [baskets [{:atoms #{:a :b} :count 1}
+                   {:atoms #{:a :c} :count 4}
+                   {:atoms #{:b :c} :count 5}]]
+      (is (not (relative-support-ok? baskets [:a :b] 1)))))
+  (testing "zero denominator → true (boundary)"
+    (is (relative-support-ok? [] [:z] 0))))
+
+(def ^:private composite-test-bucket-date (t/local-date "2099-01-01"))
+
+(defn- composite-orders-query []
+  (let [mp        (lib-be/application-database-metadata-provider (mt/id))
+        orders    (lib.metadata/table mp (mt/id :orders))
+        prod-id   (lib.metadata/field mp (mt/id :orders :product_id))
+        subtotal  (lib.metadata/field mp (mt/id :orders :subtotal))]
+    (-> (lib/query mp orders)
+        (lib/filter (lib/and (lib/= prod-id 1)
+                             (lib/> subtotal 0))))))
+
+(defn- composite-fact-for-orders []
+  (->> (composite-orders-query)
+       usage-metadata.extract/extract-usage-facts
+       :composites
+       (filter (fn [{:keys [source-type ownership-mode]}]
+                 (and (= :table source-type) (= :direct ownership-mode))))
+       first))
+
+(defn- seed-composite-row!
+  [{:keys [source-type source-id clause atom-fingerprints atom-count]} cnt]
+  (t2/insert! :model/SourceSegmentCompositeDaily
+              {:source_type       source-type
+               :source_id         source-id
+               :ownership_mode    :direct
+               :clause            clause
+               :atom_fingerprints (json/encode atom-fingerprints)
+               :atom_count        atom-count
+               :bucket_date       composite-test-bucket-date
+               :count             cnt}))
+
+(defn- cleanup-composite-rows! []
+  (t2/delete! :model/SourceSegmentCompositeDaily :bucket_date composite-test-bucket-date))
+
+(defn- composite-opts [source-id]
+  {:source-type  :table
+   :source-id    source-id
+   :bucket-start composite-test-bucket-date
+   :bucket-end   composite-test-bucket-date})
+
+(deftest suggested-segments-for-owner-happy-path-test
+  (cleanup-composite-rows!)
+  (memoize/memo-clear! composite-atomsets-memo)
+  (let [fact (composite-fact-for-orders)
+        opts (composite-opts (mt/id :orders))]
+    (try
+      (seed-composite-row! fact 3)
+      (let [results (insights/suggested-segments-for-owner opts)]
+        (testing "candidate is returned when no saved Segment matches"
+          (is (seq results)))
+        (testing "top candidate is a valid :and MBQL clause attributed to the right source"
+          (let [{:keys [clause atom-count source]} (first results)]
+            (is (lib/clause-of-type? clause :and))
+            (is (= (:atom-count fact) atom-count))
+            (is (= :table (:type source)))
+            (is (= (mt/id :orders) (:id source))))))
+      (finally
+        (cleanup-composite-rows!)
+        (memoize/memo-clear! composite-atomsets-memo)))))
+
+(deftest suggested-segments-for-owner-skips-saved-segment-match-test
+  (cleanup-composite-rows!)
+  (memoize/memo-clear! composite-atomsets-memo)
+  (let [fact (composite-fact-for-orders)
+        opts (composite-opts (mt/id :orders))]
+    (try
+      (seed-composite-row! fact 3)
+      (testing "precondition: candidate is present without a saved Segment"
+        (is (seq (insights/suggested-segments-for-owner opts))))
+      (memoize/memo-clear! composite-atomsets-memo)
+      (mt/with-temp [:model/Segment _seg {:table_id   (mt/id :orders)
+                                          :definition (composite-orders-query)}]
+        (let [results (insights/suggested-segments-for-owner opts)]
+          (testing "candidate is filtered out when a saved Segment has the same atom-set"
+            (is (not-any? (fn [{:keys [source atom-count]}]
+                            (and (= :table (:type source))
+                                 (= (mt/id :orders) (:id source))
+                                 (= (:atom-count fact) atom-count)))
+                          results)))))
+      (finally
+        (cleanup-composite-rows!)
+        (memoize/memo-clear! composite-atomsets-memo)))))
+
+(deftest existing-composite-atomsets-cached-test
+  (testing "existing-composite-atomsets is TTL-memoized — repeated calls hit the DB once"
+    (memoize/memo-clear! composite-atomsets-memo)
+    (let [segment-selects (atom 0)
+          real-select     t2/select]
+      (try
+        (with-redefs [t2/select (fn [& args]
+                                  (when (and (sequential? (first args))
+                                             (= :model/Segment (ffirst args)))
+                                    (swap! segment-selects inc))
+                                  (apply real-select args))]
+          (existing-composite-atomsets {:source-type :table :source-id (mt/id :orders)})
+          (existing-composite-atomsets {:source-type :table :source-id (mt/id :orders)})
+          (is (= 1 @segment-selects)))
+        (finally
+          (memoize/memo-clear! composite-atomsets-memo))))))
+
+(deftest suggested-segments-for-owner-empty-when-no-rows-test
+  (cleanup-composite-rows!)
+  (memoize/memo-clear! composite-atomsets-memo)
+  (try
+    (is (= [] (insights/suggested-segments-for-owner
+               (composite-opts (mt/id :orders)))))
+    (finally
+      (memoize/memo-clear! composite-atomsets-memo))))

--- a/test/metabase/usage_metadata/insights_test.clj
+++ b/test/metabase/usage_metadata/insights_test.clj
@@ -189,9 +189,9 @@
         (testing "candidate is returned when no saved Segment matches"
           (is (seq results)))
         (testing "top candidate is a valid :and MBQL clause attributed to the right source"
-          (let [{:keys [clause atom-count source]} (first results)]
+          (let [{:keys [clause itemset-size source]} (first results)]
             (is (lib/clause-of-type? clause :and))
-            (is (= (:atom-count fact) atom-count))
+            (is (= (:atom-count fact) itemset-size))
             (is (= :table (:type source)))
             (is (= (mt/id :orders) (:id source))))))
       (finally
@@ -212,10 +212,10 @@
                                           :definition (composite-orders-query)}]
         (let [results (insights/suggested-segments-for-owner opts)]
           (testing "candidate is filtered out when a saved Segment has the same atom-set"
-            (is (not-any? (fn [{:keys [source atom-count]}]
+            (is (not-any? (fn [{:keys [source itemset-size]}]
                             (and (= :table (:type source))
                                  (= (mt/id :orders) (:id source))
-                                 (= (:atom-count fact) atom-count)))
+                                 (= (:atom-count fact) itemset-size)))
                           results)))))
       (finally
         (cleanup-composite-rows!)


### PR DESCRIPTION
Adds a composite rollup sibling to `source_segment_daily` that keys on the whole stage-level filter basket (not individual filters), then runs Frequent Itemset Mining (Apriori, size 2..5, closed itemsets only) at read time to surface recurring sub-baskets as candidate implicit segments.

The atom rollup answers *"which single predicates are popular?"*; the composite rollup + FIM answers *"which composite filter should we suggest saving as a Segment?"*, including cases where queries share a common 2–3 atom core but differ in per-query tails (different date windows, different IDs, etc.) that whole-basket dedupe would miss.

- `source_segment_composite_daily` stores one row per stage filter basket per owner per day. No powerset expansion at write time; storage is `O(queries)`.
- `insights/suggested-segments-for-owner` mines closed frequent itemsets over a rolling window, reconstructs `[:and ...]` clauses, and filters out itemsets that match an already-saved `:model/Segment` definition.
- FIM parameters are hard-coded for v1 (abs-floor=2, rel-floor=0.2, k∈[2,5], top-k=20); elevate to settings if tuning becomes a need.