### PR TITLE
add tracking for stack series

### DIFF
--- a/e2e/test/scenarios/metrics/metrics-explorer.cy.spec.ts
+++ b/e2e/test/scenarios/metrics/metrics-explorer.cy.spec.ts
@@ -1182,6 +1182,10 @@ describe("scenarios > metrics > explorer", () => {
       H.MetricsViewer.assertVizType("Line");
       cy.findByTestId("chart-layout-picker").should("be.visible");
       cy.findByLabelText("Stack layout").click();
+      H.expectUnstructuredSnowplowEvent({
+        event: "stack_series_enabled",
+        triggered_from: "metrics_viewer",
+      });
 
       cy.log("should split the chart into separate panels");
       H.splitPanelAxisLines().should("have.length", 2);

--- a/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
@@ -740,90 +740,107 @@ describe("scenarios > visualizations > line chart", () => {
     });
   });
 
-  it("should split series into panels and render each series in its own panel", () => {
-    H.visitQuestionAdhoc({
-      dataset_query: {
-        type: "query",
-        query: {
-          "source-table": ORDERS_ID,
-          aggregation: [
-            ["sum", ["field", ORDERS.TOTAL, null]],
-            ["avg", ["field", ORDERS.QUANTITY, null]],
-          ],
-          breakout: [
-            ["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }],
-          ],
+  describe("with tracking", () => {
+    beforeEach(() => {
+      cy.signInAsAdmin();
+      H.resetSnowplow();
+      H.enableTracking();
+    });
+
+    afterEach(() => {
+      H.expectNoBadSnowplowEvents();
+    });
+
+    it("should split series into panels and render each series in its own panel", () => {
+      H.visitQuestionAdhoc({
+        dataset_query: {
+          type: "query",
+          query: {
+            "source-table": ORDERS_ID,
+            aggregation: [
+              ["sum", ["field", ORDERS.TOTAL, null]],
+              ["avg", ["field", ORDERS.QUANTITY, null]],
+            ],
+            breakout: [
+              ["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }],
+            ],
+          },
+          database: SAMPLE_DB_ID,
         },
-        database: SAMPLE_DB_ID,
-      },
-      display: "line",
-    });
-
-    cy.findAllByTestId("legend-item").should("have.length", 2);
-
-    H.openVizSettingsSidebar();
-    H.leftSidebar().within(() => {
-      cy.findByText("Display").click();
-      cy.findByText("Stack series").click();
-    });
-
-    H.echartsContainer().within(() => {
-      cy.findByText("60,000").should("be.visible");
-      cy.findByText("8").should("be.visible");
-    });
-
-    H.splitPanelAxisLines().should("have.length", 2);
-
-    H.cartesianChartCircleWithColor("#88BF4D");
-    H.cartesianChartCircleWithColor("#A989C5");
-
-    // Change series color while split panels are active
-    H.leftSidebar().findByText("Data").click();
-    H.openSeriesSettings("Sum of Total");
-
-    H.popover().within(() => {
-      cy.findByTestId("color-selector-button").button().click();
-    });
-
-    H.popover()
-      .should("have.length", 2)
-      .last()
-      .within(() => {
-        cy.findByLabelText("#EF8C8C").realClick();
+        display: "line",
       });
 
-    H.popover().within(() => {
-      cy.icon("bar").click();
+      cy.findAllByTestId("legend-item").should("have.length", 2);
+
+      H.openVizSettingsSidebar();
+      H.leftSidebar().within(() => {
+        cy.findByText("Display").click();
+        cy.findByText("Stack series").click();
+      });
+
+      H.expectUnstructuredSnowplowEvent({
+        event: "stack_series_enabled",
+        triggered_from: "viz_settings",
+      });
+
+      H.echartsContainer().within(() => {
+        cy.findByText("60,000").should("be.visible");
+        cy.findByText("8").should("be.visible");
+      });
+
+      H.splitPanelAxisLines().should("have.length", 2);
+
+      H.cartesianChartCircleWithColor("#88BF4D");
+      H.cartesianChartCircleWithColor("#A989C5");
+
+      // Change series color while split panels are active
+      H.leftSidebar().findByText("Data").click();
+      H.openSeriesSettings("Sum of Total");
+
+      H.popover().within(() => {
+        cy.findByTestId("color-selector-button").button().click();
+      });
+
+      H.popover()
+        .should("have.length", 2)
+        .last()
+        .within(() => {
+          cy.findByLabelText("#EF8C8C").realClick();
+        });
+
+      H.popover().within(() => {
+        cy.icon("bar").click();
+      });
+
+      H.popover().within(() => {
+        cy.findByText("Formatting").click();
+        cy.findByPlaceholderText("$").type("$").blur();
+      });
+
+      H.leftSidebar().within(() => {
+        cy.button("Done").click();
+      });
+
+      H.echartsContainer().findByText("$60,000").should("be.visible");
+
+      // Tooltip
+      H.cartesianChartCircle().first().trigger("mousemove");
+      H.assertEChartsTooltip({
+        rows: [
+          { name: "Sum of Total", value: "$52.76" },
+          { name: "Average of Quantity", value: "2" },
+        ],
+        blurAfter: true,
+      });
+
+      // Brush
+      cy.findByTestId("query-visualization-root")
+        .trigger("mousedown", 180, 200)
+        .trigger("mousemove", 180, 200)
+        .trigger("mouseup", 400, 200);
+
+      H.chartPathWithFillColor("#EF8C8C").should("be.visible");
+      H.cartesianChartCircleWithColor("#A989C5");
     });
-
-    H.popover().within(() => {
-      cy.findByText("Formatting").click();
-      cy.findByPlaceholderText("$").type("$").blur();
-    });
-
-    H.leftSidebar().within(() => {
-      cy.button("Done").click();
-    });
-
-    H.echartsContainer().findByText("$60,000").should("be.visible");
-
-    // Tooltip
-    H.cartesianChartCircle().first().trigger("mousemove");
-    H.assertEChartsTooltip({
-      rows: [
-        { name: "Sum of Total", value: "$52.76" },
-        { name: "Average of Quantity", value: "2" },
-      ],
-      blurAfter: true,
-    });
-
-    // Brush
-    cy.findByTestId("query-visualization-root")
-      .trigger("mousedown", 180, 200)
-      .trigger("mousemove", 180, 200)
-      .trigger("mouseup", 400, 200);
-
-    H.chartPathWithFillColor("#EF8C8C").should("be.visible");
-    H.cartesianChartCircleWithColor("#A989C5");
   });
 });

--- a/frontend/src/metabase/metrics-viewer/analytics.ts
+++ b/frontend/src/metabase/metrics-viewer/analytics.ts
@@ -64,3 +64,10 @@ export const trackMetricsViewerDimensionTabRemoved = () => {
     event: "metrics_viewer_dimension_tab_removed",
   });
 };
+
+export const trackStackedSeriesEnabled = () => {
+  trackSimpleEvent({
+    event: "stack_series_enabled",
+    triggered_from: "metrics_viewer",
+  });
+};

--- a/frontend/src/metabase/metrics-viewer/components/MetricControls/ChartLayoutPicker/ChartLayoutPicker.tsx
+++ b/frontend/src/metabase/metrics-viewer/components/MetricControls/ChartLayoutPicker/ChartLayoutPicker.tsx
@@ -1,5 +1,6 @@
 import { t } from "ttag";
 
+import { trackStackedSeriesEnabled } from "metabase/metrics-viewer/analytics";
 import { ActionIcon, Flex, Icon, Tooltip } from "metabase/ui";
 
 import S from "./ChartLayoutPicker.module.css";
@@ -41,7 +42,10 @@ export function ChartLayoutPicker({
           w="2rem"
           variant={isStacked ? "filled" : "subtle"}
           bg={isStacked ? "background-primary" : undefined}
-          onClick={() => onToggle(true)}
+          onClick={() => {
+            onToggle(true);
+            trackStackedSeriesEnabled();
+          }}
           aria-label={t`Stack layout`}
           className={isStacked ? S.selected : undefined}
         >

--- a/frontend/src/metabase/visualizations/analytics.ts
+++ b/frontend/src/metabase/visualizations/analytics.ts
@@ -22,3 +22,10 @@ export const trackClickActionPerformed = (action: RegularClickAction) => {
     });
   }
 };
+
+export const trackStackedSeriesEnabled = () => {
+  trackSimpleEvent({
+    event: "stack_series_enabled",
+    triggered_from: "viz_settings",
+  });
+};

--- a/frontend/src/metabase/visualizations/lib/settings/graph.ts
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.ts
@@ -6,6 +6,7 @@ import {
   getMaxDimensionsSupported,
   getMaxMetricsSupported,
 } from "metabase/visualizations";
+import { trackStackedSeriesEnabled } from "metabase/visualizations/analytics";
 import {
   ChartSettingEnumToggle,
   type ChartSettingEnumToggleProps,
@@ -403,6 +404,11 @@ export const SPLIT_PANELS_SETTINGS: VisualizationSettingsDefinitions = {
       return visibleDisplays.length <= 1;
     },
     readDependencies: ["graph.metrics", "graph.dimensions", "series"],
+    onUpdate: (value) => {
+      if (value === true) {
+        trackStackedSeriesEnabled();
+      }
+    },
   },
 };
 


### PR DESCRIPTION
### Description

Adds event tracking to the fancy new stacked series viz option that is present in the metrics explorer and in the query builder

### How to verify
1. Have an instance on with tracking enabled. 
2. Set up a multi series question and go to display -> Stack Series. 
3. You should see an event come through when it is enabled (no event on disabled).
4. Go to the metrics viewer and add more than 1 metric to view
5. Click the stack option in the controls on the bottom of the screen. You should see an event come through.


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
