### PR TITLE
Fix missing synced/official icons on collection bookmarks

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/collections/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/collections/utils.ts
@@ -4,6 +4,7 @@ import type {
 } from "metabase/collections/types";
 import { getLibraryCollectionType } from "metabase/data-studio/utils";
 import type { ItemWithCollection } from "metabase/plugins";
+import type { ColorName } from "metabase/ui/colors/types";
 import type { IconData, ObjectWithModel } from "metabase/utils/icon";
 import { getIconBase } from "metabase/utils/icon";
 import type {
@@ -92,7 +93,8 @@ export const getIcon = (
     ) {
       return {
         name: OFFICIAL_COLLECTION.icon,
-        color: OFFICIAL_COLLECTION.color,
+        color: `var(--mb-color-${OFFICIAL_COLLECTION.color})` as ColorName,
+        tooltip: OFFICIAL_COLLECTION.tooltips?.default,
       };
     }
   }

--- a/enterprise/frontend/src/metabase-enterprise/collections/utils.ts
+++ b/enterprise/frontend/src/metabase-enterprise/collections/utils.ts
@@ -4,7 +4,6 @@ import type {
 } from "metabase/collections/types";
 import { getLibraryCollectionType } from "metabase/data-studio/utils";
 import type { ItemWithCollection } from "metabase/plugins";
-import type { ColorName } from "metabase/ui/colors/types";
 import type { IconData, ObjectWithModel } from "metabase/utils/icon";
 import { getIconBase } from "metabase/utils/icon";
 import type {
@@ -93,7 +92,7 @@ export const getIcon = (
     ) {
       return {
         name: OFFICIAL_COLLECTION.icon,
-        color: `var(--mb-color-${OFFICIAL_COLLECTION.color})` as ColorName,
+        color: OFFICIAL_COLLECTION.color,
         tooltip: OFFICIAL_COLLECTION.tooltips?.default,
       };
     }

--- a/enterprise/frontend/src/metabase-enterprise/collections/utils.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/collections/utils.unit.spec.tsx
@@ -88,7 +88,11 @@ describe("Collections plugin utils", () => {
       it("should return the correct icon for an official collection", () => {
         expect(
           getIcon({ model: "collection", authority_level: "official" }),
-        ).toEqual({ name: "official_collection", color: "saturated-yellow" });
+        ).toEqual({
+          name: "official_collection",
+          color: "var(--mb-color-saturated-yellow)",
+          tooltip: "Official collection",
+        });
       });
 
       it("should return the correct icon for a remote synced collection", () => {

--- a/enterprise/frontend/src/metabase-enterprise/collections/utils.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/collections/utils.unit.spec.tsx
@@ -90,7 +90,7 @@ describe("Collections plugin utils", () => {
           getIcon({ model: "collection", authority_level: "official" }),
         ).toEqual({
           name: "official_collection",
-          color: "var(--mb-color-saturated-yellow)",
+          color: "saturated-yellow",
           tooltip: "Official collection",
         });
       });

--- a/frontend/src/metabase-types/api/bookmark.ts
+++ b/frontend/src/metabase-types/api/bookmark.ts
@@ -29,6 +29,10 @@ export interface Bookmark {
    * Defined only when bookmark.type is "card"
    */
   card_type?: CardType;
+  /**
+   * Defined only when bookmark.type is "collection"
+   */
+  is_remote_synced?: boolean;
 }
 
 export interface BookmarkOrdering {

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BookmarkList/BookmarkList.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BookmarkList/BookmarkList.tsx
@@ -15,14 +15,13 @@ import { CollapseSection } from "metabase/common/components/CollapseSection";
 import { Sortable } from "metabase/common/components/Sortable";
 import GrabberS from "metabase/css/components/grabber.module.css";
 import { Bookmarks } from "metabase/entities/bookmarks";
-import { getCollectionIcon } from "metabase/entities/collections/utils";
 import { PLUGIN_COLLECTIONS } from "metabase/plugins";
 import { connect, useSelector } from "metabase/redux";
 import { getIsTenantUser } from "metabase/selectors/user";
 import { Icon, Tooltip } from "metabase/ui";
 import { getIcon } from "metabase/utils/icon";
 import * as Urls from "metabase/utils/urls";
-import type { Bookmark, Collection } from "metabase-types/api";
+import type { Bookmark } from "metabase-types/api";
 
 import { SidebarHeading } from "../../MainNavbar.styled";
 import type { SelectedItem } from "../../types";
@@ -86,20 +85,15 @@ const BookmarkItem = ({
   const url = Urls.bookmark(bookmark);
   const isTenantUser = useSelector(getIsTenantUser);
 
-  const icon =
-    bookmark.type === "collection"
-      ? getCollectionIcon(
-          {
-            authority_level:
-              bookmark.authority_level as Collection["authority_level"],
-            is_remote_synced: bookmark.is_remote_synced,
-          },
-          { isTenantUser },
-        )
-      : getIcon({
-          model: getBookmarkModel(bookmark),
-          display: bookmark.display,
-        });
+  const icon = getIcon(
+    {
+      model: getBookmarkModel(bookmark),
+      display: bookmark.display,
+      authority_level: bookmark.authority_level,
+      is_remote_synced: bookmark.is_remote_synced,
+    },
+    { isTenantUser },
+  );
   const onRemove = () => onDeleteBookmark(bookmark);
 
   const isIrregularCollection =

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BookmarkList/BookmarkList.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BookmarkList/BookmarkList.tsx
@@ -15,12 +15,14 @@ import { CollapseSection } from "metabase/common/components/CollapseSection";
 import { Sortable } from "metabase/common/components/Sortable";
 import GrabberS from "metabase/css/components/grabber.module.css";
 import { Bookmarks } from "metabase/entities/bookmarks";
+import { getCollectionIcon } from "metabase/entities/collections/utils";
 import { PLUGIN_COLLECTIONS } from "metabase/plugins";
-import { connect } from "metabase/redux";
+import { connect, useSelector } from "metabase/redux";
+import { getIsTenantUser } from "metabase/selectors/user";
 import { Icon, Tooltip } from "metabase/ui";
 import { getIcon } from "metabase/utils/icon";
 import * as Urls from "metabase/utils/urls";
-import type { Bookmark } from "metabase-types/api";
+import type { Bookmark, Collection } from "metabase-types/api";
 
 import { SidebarHeading } from "../../MainNavbar.styled";
 import type { SelectedItem } from "../../types";
@@ -82,11 +84,22 @@ const BookmarkItem = ({
 }: BookmarkItemProps) => {
   const isSelected = isBookmarkSelected(bookmark, selectedItem);
   const url = Urls.bookmark(bookmark);
+  const isTenantUser = useSelector(getIsTenantUser);
 
-  const icon = getIcon({
-    model: getBookmarkModel(bookmark),
-    display: bookmark.display,
-  });
+  const icon =
+    bookmark.type === "collection"
+      ? getCollectionIcon(
+          {
+            authority_level:
+              bookmark.authority_level as Collection["authority_level"],
+            is_remote_synced: bookmark.is_remote_synced,
+          },
+          { isTenantUser },
+        )
+      : getIcon({
+          model: getBookmarkModel(bookmark),
+          display: bookmark.display,
+        });
   const onRemove = () => onDeleteBookmark(bookmark);
 
   const isIrregularCollection =

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BookmarkList/BookmarkList.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BookmarkList/BookmarkList.unit.spec.tsx
@@ -1,8 +1,14 @@
 import type { ComponentProps } from "react";
 import { times } from "underscore";
 
-import { renderWithProviders, screen } from "__support__/ui";
-import { createMockBookmark } from "metabase-types/api/mocks";
+import { setupEnterprisePlugins } from "__support__/enterprise";
+import { mockSettings } from "__support__/settings";
+import { renderWithProviders, screen, within } from "__support__/ui";
+import { createMockState } from "metabase/redux/store/mocks";
+import {
+  createMockBookmark,
+  createMockTokenFeatures,
+} from "metabase-types/api/mocks";
 
 import BookmarkList from "./BookmarkList";
 
@@ -13,6 +19,17 @@ const mockProps: ComponentProps<typeof BookmarkList> = {
   onToggle: jest.fn(),
   initialState: "expanded",
 };
+
+const enterpriseState = createMockState({
+  settings: mockSettings({
+    "token-features": createMockTokenFeatures({
+      remote_sync: true,
+      official_collections: true,
+      audit_app: true,
+    }),
+  }),
+});
+setupEnterprisePlugins();
 
 const createBookmarks = (howMany: number) => {
   return times(howMany, (i) => {
@@ -49,5 +66,39 @@ describe("BookmarkList", () => {
     });
 
     expect(screen.queryByLabelText("grabber icon")).not.toBeInTheDocument();
+  });
+
+  describe("collection bookmark icons (enterprise)", () => {
+    it.each([
+      {
+        name: "Synced",
+        icon: "synced_collection",
+        overrides: { is_remote_synced: true },
+      },
+      {
+        name: "Official",
+        icon: "official_collection",
+        overrides: { authority_level: "official" },
+      },
+      { name: "Regular", icon: "folder", overrides: {} },
+    ])(
+      "renders the $icon icon for $name collection bookmarks",
+      ({ name, icon, overrides }) => {
+        renderWithProviders(
+          <BookmarkList
+            {...mockProps}
+            bookmarks={[
+              createMockBookmark({ type: "collection", name, ...overrides }),
+            ]}
+          />,
+          { storeInitialState: enterpriseState },
+        );
+
+        const row = screen.getByText(name).closest("a");
+        expect(
+          within(row as HTMLElement).getByLabelText(`${icon} icon`),
+        ).toBeInTheDocument();
+      },
+    );
   });
 });

--- a/frontend/src/metabase/ui/components/icons/Icon/Icon.tsx
+++ b/frontend/src/metabase/ui/components/icons/Icon/Icon.tsx
@@ -5,12 +5,24 @@ import cx from "classnames";
 import type { MouseEvent, ReactNode, SVGAttributes } from "react";
 import { forwardRef } from "react";
 
+import { ALL_COLOR_NAMES } from "metabase/ui/colors/constants/color-names";
 import type { ColorName } from "metabase/ui/colors/types";
 
 import { Tooltip } from "../../overlays/Tooltip";
 
 import type { IconName } from "./icons";
 import { Icons } from "./icons";
+
+const PALETTE_KEYS = new Set<string>(ALL_COLOR_NAMES);
+
+/**
+ * Mantine's `Box` forwards the `color` prop to the SVG as a presentation
+ * attribute, so it only honors valid CSS color strings — bare palette keys
+ * like `"saturated-yellow"` are silently ignored. Resolve known palette keys
+ * to their `--mb-color-*` CSS variables; pass other strings through.
+ */
+const resolveIconColor = (color: string | undefined) =>
+  color != null && PALETTE_KEYS.has(color) ? `var(--mb-color-${color})` : color;
 
 const defaultSize = 16;
 
@@ -37,6 +49,13 @@ export const Icon = forwardRef<SVGSVGElement, IconProps>(function Icon(
   ref,
 ) {
   const IconComponent = (Icons[name] ?? Icons["unknown"]).component;
+
+  // Box forwards `color` as a raw SVG presentation attribute, so palette keys
+  // like "saturated-yellow" don't render — only valid CSS color strings do.
+  // Resolve known palette keys to their `--mb-color-*` CSS variables.
+  if ("color" in restProps) {
+    restProps.color = resolveIconColor(restProps.color) as ColorName;
+  }
 
   const icon = (
     <Box

--- a/frontend/src/metabase/utils/icon.ts
+++ b/frontend/src/metabase/utils/icon.ts
@@ -67,6 +67,7 @@ export const modelIconMap: Record<IconModel, IconName> = {
 export type IconData = {
   name: IconName;
   color?: ColorName;
+  tooltip?: string;
 };
 
 /** get an Icon for any entity object, doesn't depend on the entity system */

--- a/src/metabase/bookmarks/models/bookmark.clj
+++ b/src/metabase/bookmarks/models/bookmark.clj
@@ -31,14 +31,15 @@
   id. This is required for the frontend entity loading system and does not refer to any particular bookmark id,
   although the compound key can be inferred from it."
   [:map {:closed true}
-   [:id                               :string]
+   [:id                                  :string]
    [:type [:enum "card" "collection" "dashboard" "document"]]
-   [:item_id                          ms/PositiveInt]
-   [:name                             ms/NonBlankString]
-   [:authority_level {:optional true} [:maybe :string]]
-   [:card_type       {:optional true} [:maybe ::queries.schema/card-type]]
-   [:description     {:optional true} [:maybe :string]]
-   [:display         {:optional true} [:maybe :string]]])
+   [:item_id                             ms/PositiveInt]
+   [:name                                ms/NonBlankString]
+   [:authority_level    {:optional true} [:maybe :string]]
+   [:is_remote_synced   {:optional true} :boolean]
+   [:card_type          {:optional true} [:maybe ::queries.schema/card-type]]
+   [:description        {:optional true} [:maybe :string]]
+   [:display            {:optional true} [:maybe :string]]])
 
 (mu/defn- normalize-bookmark-result :- BookmarkResult
   "Normalizes bookmark results. Bookmarks are left joined against the card, collection, dashboard, and document tables, but only
@@ -59,7 +60,7 @@
                             (:card_type normalized-result) (update :card_type keyword))]
     (-> normalized-result
         (select-keys [:item_id :type :name :card_type :description :display
-                      :authority_level])
+                      :authority_level :is_remote_synced])
         (assoc :id id-str))))
 
 (defn- bookmarks-union-query
@@ -118,10 +119,11 @@
                        [:dashboard.name             (mdb/qualify :model/Dashboard :name)]
                        [:dashboard.description      (mdb/qualify :model/Dashboard :description)]
                        [:dashboard.archived         (mdb/qualify :model/Dashboard :archived)]
-                       [:collection.name            (mdb/qualify :model/Collection  :name)]
-                       [:collection.authority_level (mdb/qualify :model/Collection :authority_level)]
-                       [:collection.description     (mdb/qualify :model/Collection :description)]
-                       [:collection.archived        (mdb/qualify :model/Collection :archived)]
+                       [:collection.name              (mdb/qualify :model/Collection  :name)]
+                       [:collection.authority_level   (mdb/qualify :model/Collection :authority_level)]
+                       [:collection.is_remote_synced  (mdb/qualify :model/Collection :is_remote_synced)]
+                       [:collection.description       (mdb/qualify :model/Collection :description)]
+                       [:collection.archived          (mdb/qualify :model/Collection :archived)]
                        [:document.name (mdb/qualify :model/Document :name)]
                        [:document.archived (mdb/qualify :model/Document :archived)]]
         left-joins [[:report_card :card] [:= :bookmark.card_id :card.id]

--- a/test/metabase/bookmarks/api_test.clj
+++ b/test/metabase/bookmarks/api_test.clj
@@ -75,6 +75,15 @@
       :else
       (throw (ex-info "Unknown type" {:user-id user-id :model model})))))
 
+(deftest synced-collection-bookmark-test
+  (testing "GET /api/bookmark returns is_remote_synced: true for remote-synced collection bookmarks"
+    (mt/with-temp [:model/Collection synced-coll {:name "Synced" :is_remote_synced true}]
+      (bookmark-models (mt/user->id :rasta) synced-coll)
+      (is (true? (->> (mt/user-http-request :rasta :get 200 "bookmark")
+                      (filter #(= (:name %) "Synced"))
+                      first
+                      :is_remote_synced))))))
+
 (deftest bookmarks-on-archived-items-test
   (testing "POST /api/bookmark/:model/:model-id"
     (mt/with-temp [:model/Collection archived-collection {:name "Test Collection"


### PR DESCRIPTION
### Description

Fixes [UXW-2105](https://linear.app/metabase/issue/UXW-2105/bookmarked-synced-collections-dont-have-the-synced-collection-icon).

Bookmarked collections now get the same icon treatment as rows in the sidebar Collections tree:

- Remote-synced collections → `synced_collection` icon.
- Official collections → yellow star icon + color + "Official collection" tooltip.
- Regular collections → default folder icon (unchanged).

**Cause:**
- Backend didn't return `is_remote_synced` on bookmark payloads.
- Enterprise `getIcon` didn't return a tooltip for official collections, and its color wasn't a valid Mantine theme key.

**Fix:**
- `GET /api/bookmark` now returns `is_remote_synced` for collection bookmarks.
- `BookmarkList` forwards `authority_level` + `is_remote_synced` to `getIcon`.
- Enterprise `getIcon` adds the `"Official collection"` tooltip and resolves the color via `var(--mb-color-saturated-yellow)` (CSS variable, not the deprecated `color()` helper).
- `IconData` now allows a `tooltip?: string` so the icon wrapper picks it up automatically.

### How to verify

- [ ] Bookmark a remote-synced collection → `synced_collection` icon.
- [ ] Bookmark an Official collection → yellow star + "Official collection" tooltip on hover.
- [ ] Bookmark a regular collection → default folder icon.
- [ ] Non-collection bookmarks (cards, dashboards, documents) unchanged.

### Demo

### Before

<img width="300" alt="image" src="https://github.com/user-attachments/assets/b66d4487-61d8-4733-8dc9-ff504280989d" />

#### After

<img width="200" alt="image" src="https://github.com/user-attachments/assets/ea2671bb-98cf-499c-9a6a-fed09f8b5163" />
<img width="200" alt="image" src="https://github.com/user-attachments/assets/d65c107e-a53c-4d6f-b029-3289747772f1" />


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
