### PR TITLE
Allow empty column aliases

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
@@ -1575,3 +1575,23 @@ describe("issue 56094", () => {
     H.queryBuilderFooterDisplayToggle().should("exist");
   });
 });
+
+describe("issue 57685", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsNormalUser();
+    H.createNativeQuestion(
+      {
+        display: "table",
+        native: {
+          query: 'SELECT id as "" FROM PRODUCTS',
+        },
+      },
+      { visitQuestion: true },
+    );
+  });
+
+  it("should handle empty column names without error (metabase#57685)", () => {
+    cy.findByTestId("visualization-root").icon("warning").should("not.exist");
+  });
+});

--- a/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/visualizations-tabular-reproductions.cy.spec.js
@@ -1593,5 +1593,11 @@ describe("issue 57685", () => {
 
   it("should handle empty column names without error (metabase#57685)", () => {
     cy.findByTestId("visualization-root").icon("warning").should("not.exist");
+
+    cy.findByTestId("qb-header-action-panel")
+      .findByText("Explore results")
+      .click();
+
+    H.tableInteractive().should("be.visible");
   });
 });

--- a/frontend/src/metabase/data-grid/constants.ts
+++ b/frontend/src/metabase/data-grid/constants.ts
@@ -11,3 +11,4 @@ export const FOOTER_HEIGHT = 30;
 export const PINNED_BORDER_SEPARATOR_WIDTH = 3;
 export const DATASET_INDEX_ATTRIBUTE_NAME = "data-dataset-index";
 export const VIRTUAL_INDEX_ATTRIBUTE_NAME = "data-index";
+export const FALLBACK_ID_FOR_EMPTY_COLUMN_NAME = "\0_EMPTY_COLUMN_ID";

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.tsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.tsx
@@ -27,6 +27,7 @@ import {
 import DashboardS from "metabase/css/dashboard.module.css";
 import { DataGrid, type DataGridStylesProps } from "metabase/data-grid";
 import {
+  FALLBACK_ID_FOR_EMPTY_COLUMN_NAME,
   FOOTER_HEIGHT,
   HEADER_HEIGHT,
   ROW_HEIGHT,
@@ -505,6 +506,10 @@ export const TableInteractiveInner = forwardRef(function TableInteractiveInner(
         align = columnSettings["text_align"];
         id = col.name;
         sortDirection = getColumnSortDirection(columnIndex);
+      }
+
+      if (id === "") {
+        id = `${FALLBACK_ID_FOR_EMPTY_COLUMN_NAME}:${columnIndex}`;
       }
 
       const translatedColumnName = tc(columnName);

--- a/src/metabase/lib/util/unique_name_generator.cljc
+++ b/src/metabase/lib/util/unique_name_generator.cljc
@@ -2,7 +2,6 @@
   (:require
    #?@(:cljs
        (["crc-32" :as CRC32]))
-   [metabase.lib.schema.common :as lib.schema.common]
    [metabase.util :as u]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]))
@@ -31,7 +30,7 @@
         (recur (str \0 s))
         s))))
 
-(mu/defn truncate-alias :- [:string {:min 1, :max 60}]
+(mu/defn truncate-alias :- [:string {:max 60}]
   "Truncate string `s` if it is longer than [[truncate-alias-max-length-bytes]] and append a hex-encoded CRC-32
   checksum of the original string. Truncated string is truncated to [[truncate-alias-max-length-bytes]]
   minus [[truncated-alias-hash-suffix-length]] characters so the resulting string is
@@ -43,7 +42,7 @@
   ([s]
    (truncate-alias s truncate-alias-max-length-bytes))
 
-  ([s         :- ::lib.schema.common/non-blank-string
+  ([s         :- :string
     max-bytes :- [:int {:min 0}]]
    (if (<= (u/string-byte-count s) max-bytes)
      s
@@ -68,11 +67,11 @@
    ;; (f str) => unique-str
    [:=>
     [:cat :string]
-    ::lib.schema.common/non-blank-string]
+    :string]
    ;; (f id str) => unique-str
    [:=>
     [:cat :any :string]
-    ::lib.schema.common/non-blank-string]])
+    :string]])
 
 (mu/defn- untruncated-unique-alias :- :string
   [original :- :string

--- a/src/metabase/util/honey_sql_2.clj
+++ b/src/metabase/util/honey_sql_2.clj
@@ -151,7 +151,7 @@
   This function automatically unnests any Identifiers passed as arguments, removes nils, and converts all args to
   strings."
   [identifier-type :- IdentifierType
-   & components    :- [:* {:min 1} [:maybe [:or :keyword ms/NonBlankString [:fn identifier?]]]]]
+   & components    :- [:* {:min 1} [:maybe [:or :keyword :string [:fn identifier?]]]]]
   [::identifier
    identifier-type
    (vec (for [component components

--- a/test/metabase/query_processor/nested_queries_test.clj
+++ b/test/metabase/query_processor/nested_queries_test.clj
@@ -1757,3 +1757,17 @@
                          (lib/limit 3))]
       (is (=? (mt/rows (qp/process-query base-query))
               (mt/rows (qp/process-query (lib/append-stage base-query))))))))
+
+(deftest ^:parallel empty-column-alias-test
+  (testing "can query a card that has an empty column alias (#57685)"
+    (let [mp (mt/metadata-provider)
+          card-query (lib/native-query mp "select id as \"\" from orders limit 2")]
+      #_{:clj-kondo/ignore [:discouraged-var]}
+      (mt/with-temp [:model/Card card {:dataset_query card-query}]
+        (let [query (->> (lib/query mp (lib.metadata/card mp (:id card)))
+                         lib/append-stage
+                         qp/process-query)]
+          (is (= [[1] [2]]
+                 (mt/rows query)))
+          (is (= ""
+                 (-> query :data :results_metadata :columns first :name))))))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/57685

### Description

Allows empty column aliases. Follow up to https://github.com/metabase/metabase/pull/58621

### How to verify

1. See steps in original issue.
2. You should be able to see the query results
3. Save it as a question
4. Go to the question and then click "Explore results"
5. You should still be able to see the results

### Demo

todo

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
