### PR TITLE
UXW-3775 open Metric Viewer in the same tab

### DIFF
--- a/e2e/test/scenarios/data-studio/data-studio-metrics.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-studio-metrics.cy.spec.ts
@@ -272,7 +272,6 @@ describe("scenarios > data studio > library > metrics", () => {
     cy.log("Verify View link opens in new tab");
     H.DataStudio.Metrics.moreMenu().click();
     H.DataStudio.Metrics.exploreLink()
-      .should("have.attr", "target", "_blank")
       .should("have.attr", "href")
       .and("match", /\/explore\?metricId=\d+/);
   });

--- a/frontend/src/metabase/data-studio/common/components/MoreMenu/MoreMenu.tsx
+++ b/frontend/src/metabase/data-studio/common/components/MoreMenu/MoreMenu.tsx
@@ -49,7 +49,6 @@ export function MoreMenu({
             <Menu.Item
               component={Link}
               to={previewUrl}
-              target="_blank"
               leftSection={<Icon name="share" />}
             >
               {previewLabel ?? t`Preview`}

--- a/frontend/src/metabase/metrics/components/MetricHeader/MetricToolbar/MetricToolbar.tsx
+++ b/frontend/src/metabase/metrics/components/MetricHeader/MetricToolbar/MetricToolbar.tsx
@@ -114,7 +114,6 @@ function MetricToolbarButtons({
         <Button
           component={ForwardRefLink}
           to={Urls.exploreMetric(card.id)}
-          target="_blank"
           leftSection={<Icon name="external" />}
           data-testid="explore-link"
         >


### PR DESCRIPTION
Closes UXW-3775

### Description

This changes UX of opening Metric Viewer using Metric / Measure > Explore to happen in the same tab.

Most likely I will have to adapt some e2e tests, but this can be reviewed already.

### Demo

https://www.loom.com/share/64432ac5e920438aa795beee81baa2dc

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
