### PR TITLE
Fix dashboard qb action violation

### DIFF
--- a/frontend/src/metabase/dashboard/reducers-typed.ts
+++ b/frontend/src/metabase/dashboard/reducers-typed.ts
@@ -10,7 +10,6 @@ import {
 } from "metabase/api";
 import { Dashboards } from "metabase/entities/dashboards";
 import { Questions } from "metabase/entities/questions";
-import { REVERT_TO_REVISION } from "metabase/query_builder/actions";
 import {
   INITIALIZE,
   RESET,
@@ -19,7 +18,10 @@ import {
   initialize,
   reset,
 } from "metabase/redux/dashboard";
-import { NAVIGATE_BACK_TO_DASHBOARD } from "metabase/redux/query-builder";
+import {
+  NAVIGATE_BACK_TO_DASHBOARD,
+  REVERT_CARD_TO_REVISION,
+} from "metabase/redux/query-builder";
 import type {
   DashboardSidebarName,
   StoreDashboard,
@@ -441,7 +443,7 @@ export const dashcardData = createReducer(
         },
       )
       .addCase<string, { type: string; payload: Revision }>(
-        REVERT_TO_REVISION,
+        REVERT_CARD_TO_REVISION,
         (state, action) => {
           const { id } = action.payload;
           if (id != null) {

--- a/frontend/src/metabase/query_builder/actions/core/core.ts
+++ b/frontend/src/metabase/query_builder/actions/core/core.ts
@@ -8,6 +8,7 @@ import { loadMetadataForCard } from "metabase/questions/actions";
 import { openUrl } from "metabase/redux/app";
 import {
   API_UPDATE_QUESTION,
+  REVERT_CARD_TO_REVISION,
   SOFT_RELOAD_CARD,
   clearQueryResult,
   onCloseSidebars,
@@ -349,9 +350,8 @@ export const setParameterValueToDefault = createThunkAction(
   },
 );
 
-export const REVERT_TO_REVISION = "metabase/qb/REVERT_TO_REVISION";
 export const revertToRevision = createThunkAction(
-  REVERT_TO_REVISION,
+  REVERT_CARD_TO_REVISION,
   (cardId, revision) => {
     return async (dispatch) => {
       await entityCompatibleQuery(

--- a/frontend/src/metabase/redux/query-builder.ts
+++ b/frontend/src/metabase/redux/query-builder.ts
@@ -94,6 +94,8 @@ export const API_UPDATE_QUESTION = "metabase/qb/API_UPDATE_QUESTION";
 export const RESET_QB = "metabase/qb/RESET_QB";
 export const resetQB = createAction(RESET_QB);
 
+export const REVERT_CARD_TO_REVISION = "metabase/qb/REVERT_CARD_TO_REVISION";
+
 export const SET_PARAMETER_VALUE = "metabase/qb/SET_PARAMETER_VALUE";
 export const setParameterValue = createAction(
   SET_PARAMETER_VALUE,


### PR DESCRIPTION
Fixes 1 violation.

Renamed to `REVERT_CARD_TO_REVISION` to differentiate from dashboards REVERT_TO_REVISION