### PR TITLE
Move DataPermission types into metabase-types

### DIFF
--- a/enterprise/frontend/src/embedding-sdk-package/cli/utils/get-permission-groups.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/cli/utils/get-permission-groups.ts
@@ -1,11 +1,9 @@
 import {
   DataPermission,
   DataPermissionValue,
-} from "metabase/admin/permissions/types";
-import type {
-  DatabasePermissions,
-  GroupsPermissions,
-  Table,
+  type DatabasePermissions,
+  type GroupsPermissions,
+  type Table,
 } from "metabase-types/api";
 
 type Options = {

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/ImpersonationModal/ImpersonationModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/ImpersonationModal/ImpersonationModal.tsx
@@ -5,11 +5,7 @@ import { push } from "react-router-redux";
 import { useAsyncFn, useMount } from "react-use";
 
 import { updateDataPermission } from "metabase/admin/permissions/permissions";
-import {
-  DataPermission,
-  DataPermissionType,
-  DataPermissionValue,
-} from "metabase/admin/permissions/types";
+import { DataPermissionType } from "metabase/admin/permissions/types";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { useDatabaseQuery } from "metabase/common/hooks";
 import { getParentPath } from "metabase/hoc/ModalRoute";
@@ -25,7 +21,12 @@ import { useEnterpriseSelector } from "metabase-enterprise/redux";
 import { ImpersonationApi } from "metabase-enterprise/services";
 import { fetchUserAttributes } from "metabase-enterprise/shared/reducer";
 import { getUserAttributes } from "metabase-enterprise/shared/selectors";
-import type { Impersonation, UserAttributeKey } from "metabase-types/api";
+import {
+  DataPermission,
+  DataPermissionValue,
+  type Impersonation,
+  type UserAttributeKey,
+} from "metabase-types/api";
 
 import { ImpersonationModalView } from "./ImpersonationModalView";
 

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/graph.ts
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/graph.ts
@@ -2,10 +2,6 @@ import _ from "underscore";
 
 import type { EntityId } from "metabase/admin/permissions/types";
 import {
-  DataPermission,
-  DataPermissionValue,
-} from "metabase/admin/permissions/types";
-import {
   isSchemaEntityId,
   isTableEntityId,
 } from "metabase/admin/permissions/utils/data-entity-id";
@@ -16,7 +12,12 @@ import {
   updateEntityPermission,
 } from "metabase/admin/permissions/utils/graph";
 import type Database from "metabase-lib/v1/metadata/Database";
-import type { GroupsPermissions, NativePermissions } from "metabase-types/api";
+import {
+  DataPermission,
+  DataPermissionValue,
+  type GroupsPermissions,
+  type NativePermissions,
+} from "metabase-types/api";
 
 export function shouldRestrictNativeQueryPermissions(
   permissions: GroupsPermissions,

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/graph.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/graph.unit.spec.ts
@@ -1,10 +1,10 @@
+import Database from "metabase-lib/v1/metadata/Database";
+import Schema from "metabase-lib/v1/metadata/Schema";
 import {
   DataPermission,
   DataPermissionValue,
-} from "metabase/admin/permissions/types";
-import Database from "metabase-lib/v1/metadata/Database";
-import Schema from "metabase-lib/v1/metadata/Schema";
-import type { SchemasPermissions } from "metabase-types/api";
+  type SchemasPermissions,
+} from "metabase-types/api";
 import { createMockDatabase, createMockSchema } from "metabase-types/api/mocks";
 
 import { upgradeViewPermissionsIfNeeded } from "./graph";

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js
@@ -1,7 +1,6 @@
 import { push } from "react-router-redux";
 import { t } from "ttag";
 
-import { DataPermissionValue } from "metabase/admin/permissions/types";
 import {
   getDatabaseFocusPermissionsUrl,
   getGroupFocusPermissionsUrl,
@@ -19,6 +18,7 @@ import {
   PLUGIN_REDUCERS,
 } from "metabase/plugins";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
+import { DataPermissionValue } from "metabase-types/api";
 
 import { ImpersonationModal } from "./components/ImpersonationModal";
 import {

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/reducer.ts
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/reducer.ts
@@ -7,16 +7,17 @@ import {
   SAVE_DATA_PERMISSIONS,
   UPDATE_DATA_PERMISSION,
 } from "metabase/admin/permissions/permissions";
-import {
-  DataPermission,
-  DataPermissionValue,
-  type EntityId,
-} from "metabase/admin/permissions/types";
+import type { EntityId } from "metabase/admin/permissions/types";
 import {
   DATABASES_BASE_PATH,
   GROUPS_BASE_PATH,
 } from "metabase/admin/permissions/utils/urls";
-import type { GroupId, Impersonation } from "metabase-types/api";
+import {
+  DataPermission,
+  DataPermissionValue,
+  type GroupId,
+  type Impersonation,
+} from "metabase-types/api";
 
 export const getImpersonatedPostAction = (
   entityId: EntityId,

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/data-model-permission.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/data-model-permission.ts
@@ -7,9 +7,7 @@ import {
   getPermissionWarningModal,
 } from "metabase/admin/permissions/selectors/confirmations";
 import {
-  DataPermission,
   DataPermissionType,
-  DataPermissionValue,
   type EntityId,
   type PermissionOption,
   type PermissionSectionConfig,
@@ -24,7 +22,12 @@ import {
   getTablesPermission,
 } from "metabase/admin/permissions/utils/graph";
 import { getGroupFocusPermissionsUrl } from "metabase/admin/permissions/utils/urls";
-import type { Group, GroupsPermissions } from "metabase-types/api";
+import {
+  DataPermission,
+  DataPermissionValue,
+  type Group,
+  type GroupsPermissions,
+} from "metabase-types/api";
 
 export const DATA_MODEL_PERMISSION_OPTIONS: Record<string, PermissionOption> = {
   none: {

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/data-model-permission.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/data-model-permission.unit.spec.ts
@@ -1,6 +1,9 @@
 import type { SpecialGroupType } from "metabase/admin/permissions/types";
-import { DataPermissionValue } from "metabase/admin/permissions/types";
-import type { Group, GroupsPermissions } from "metabase-types/api";
+import {
+  DataPermissionValue,
+  type Group,
+  type GroupsPermissions,
+} from "metabase-types/api";
 
 import {
   DATA_MODEL_PERMISSION_OPTIONS,

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/details-permission.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/details-permission.ts
@@ -7,15 +7,18 @@ import {
   getPermissionWarningModal,
 } from "metabase/admin/permissions/selectors/confirmations";
 import {
-  DataPermission,
   DataPermissionType,
-  DataPermissionValue,
   type EntityId,
   type PermissionOption,
   type PermissionSectionConfig,
   type PermissionSubject,
 } from "metabase/admin/permissions/types";
-import type { Group, GroupsPermissions } from "metabase-types/api";
+import {
+  DataPermission,
+  DataPermissionValue,
+  type Group,
+  type GroupsPermissions,
+} from "metabase-types/api";
 
 export const DETAILS_PERMISSION_OPTIONS: Record<string, PermissionOption> = {
   no: {

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/details-permission.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/details-permission.unit.spec.ts
@@ -1,5 +1,8 @@
-import { DataPermissionValue } from "metabase/admin/permissions/types";
-import type { Group, GroupsPermissions } from "metabase-types/api";
+import {
+  DataPermissionValue,
+  type Group,
+  type GroupsPermissions,
+} from "metabase-types/api";
 
 import {
   DETAILS_PERMISSION_OPTIONS,

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/download-permission.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/download-permission.ts
@@ -7,9 +7,7 @@ import {
   getPermissionWarningModal,
 } from "metabase/admin/permissions/selectors/confirmations";
 import {
-  DataPermission,
   DataPermissionType,
-  DataPermissionValue,
   type EntityId,
   type PermissionOption,
   type PermissionSectionConfig,
@@ -23,7 +21,12 @@ import {
   getTablesPermission,
 } from "metabase/admin/permissions/utils/graph";
 import { getGroupFocusPermissionsUrl } from "metabase/admin/permissions/utils/urls";
-import type { Group, GroupsPermissions } from "metabase-types/api";
+import {
+  DataPermission,
+  DataPermissionValue,
+  type Group,
+  type GroupsPermissions,
+} from "metabase-types/api";
 
 const getTooltipMessage = (isAdmin: boolean, isBlockedAccess: boolean) => {
   if (isAdmin) {

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/download-permission.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/download-permission.unit.spec.ts
@@ -1,5 +1,8 @@
-import { DataPermissionValue } from "metabase/admin/permissions/types";
-import type { Group, GroupsPermissions } from "metabase-types/api";
+import {
+  DataPermissionValue,
+  type Group,
+  type GroupsPermissions,
+} from "metabase-types/api";
 
 import {
   DOWNLOAD_PERMISSION_OPTIONS,

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/index.ts
@@ -1,12 +1,15 @@
 import type {
-  DataPermissionValue,
   EntityId,
   PermissionSectionConfig,
   PermissionSubject,
   SpecialGroupType,
 } from "metabase/admin/permissions/types";
 import { isNotNull } from "metabase/utils/types";
-import type { Group, GroupsPermissions } from "metabase-types/api";
+import type {
+  DataPermissionValue,
+  Group,
+  GroupsPermissions,
+} from "metabase-types/api";
 
 import { buildDataModelPermission } from "./data-model-permission";
 import { buildDetailsPermission } from "./details-permission";

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/index.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/index.unit.spec.ts
@@ -1,6 +1,9 @@
-import { DataPermissionValue } from "metabase/admin/permissions/types";
 import { PLUGIN_TRANSFORMS } from "metabase/plugins";
-import type { Group, GroupsPermissions } from "metabase-types/api";
+import {
+  DataPermissionValue,
+  type Group,
+  type GroupsPermissions,
+} from "metabase-types/api";
 
 import { getFeatureLevelDataPermissions } from "./index";
 

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/transforms-permission.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/transforms-permission.ts
@@ -7,16 +7,19 @@ import {
   getPermissionWarningModal,
 } from "metabase/admin/permissions/selectors/confirmations";
 import {
-  DataPermission,
   DataPermissionType,
-  DataPermissionValue,
   type EntityId,
   type PermissionOption,
   type PermissionSectionConfig,
   type PermissionSubject,
 } from "metabase/admin/permissions/types";
 import { getSchemasPermission } from "metabase/admin/permissions/utils/graph";
-import type { Group, GroupsPermissions } from "metabase-types/api";
+import {
+  DataPermission,
+  DataPermissionValue,
+  type Group,
+  type GroupsPermissions,
+} from "metabase-types/api";
 
 export const TRANSFORMS_PERMISSION_OPTIONS: Record<string, PermissionOption> = {
   no: {

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/transforms-permission.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/transforms-permission.unit.spec.ts
@@ -1,5 +1,8 @@
-import { DataPermissionValue } from "metabase/admin/permissions/types";
-import type { Group, GroupsPermissions } from "metabase-types/api";
+import {
+  DataPermissionValue,
+  type Group,
+  type GroupsPermissions,
+} from "metabase-types/api";
 
 import {
   TRANSFORMS_PERMISSION_OPTIONS,

--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/actions.js
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/actions.js
@@ -6,17 +6,14 @@ import {
   UPDATE_DATA_PERMISSION,
   updateDataPermission,
 } from "metabase/admin/permissions/permissions";
-import {
-  DataPermission,
-  DataPermissionType,
-  DataPermissionValue,
-} from "metabase/admin/permissions/types";
+import { DataPermissionType } from "metabase/admin/permissions/types";
 import {
   combineReducers,
   createAction,
   createThunkAction,
   handleActions,
 } from "metabase/redux";
+import { DataPermission, DataPermissionValue } from "metabase-types/api";
 
 import { getPolicyKey, getPolicyKeyFromParams } from "./utils";
 

--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/confirmations.ts
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/confirmations.ts
@@ -1,10 +1,8 @@
 import { t } from "ttag";
 
-import {
-  DataPermissionValue,
-  type EntityId,
-} from "metabase/admin/permissions/types";
+import type { EntityId } from "metabase/admin/permissions/types";
 import { hasPermissionValueInGraph } from "metabase/admin/permissions/utils/graph";
+import { DataPermissionValue } from "metabase-types/api";
 import type { GroupsPermissions } from "metabase-types/api/permissions";
 
 export function getSandboxedTableWarningModal(

--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/index.js
@@ -2,7 +2,6 @@ import { push } from "react-router-redux";
 import { t } from "ttag";
 import _ from "underscore";
 
-import { DataPermissionValue } from "metabase/admin/permissions/types";
 import {
   getDatabaseFocusPermissionsUrl,
   getGroupFocusPermissionsUrl,
@@ -20,6 +19,7 @@ import {
   PLUGIN_REDUCERS,
 } from "metabase/plugins";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
+import { DataPermissionValue } from "metabase-types/api";
 
 import sandboxingReducer from "./actions";
 import { LoginAttributesWidget } from "./components/LoginAttributesWidget/LoginAttributesWidget";

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantCollectionPermissionsPage/selectors.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantCollectionPermissionsPage/selectors.tsx
@@ -11,10 +11,7 @@ import type {
 } from "metabase/admin/permissions/selectors/collection-permissions";
 import { buildCollectionTree } from "metabase/admin/permissions/selectors/collection-permissions";
 import { getPermissionWarningModal } from "metabase/admin/permissions/selectors/confirmations";
-import type {
-  DataPermissionValue,
-  PermissionEditorType,
-} from "metabase/admin/permissions/types";
+import type { PermissionEditorType } from "metabase/admin/permissions/types";
 import {
   Collections,
   ROOT_COLLECTION,
@@ -32,6 +29,7 @@ import type {
   Collection,
   CollectionId,
   CollectionPermissions,
+  DataPermissionValue,
   Group as GroupType,
 } from "metabase-types/api";
 

--- a/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantSpecificCollectionPermissionsPage/selectors.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/components/TenantSpecificCollectionPermissionsPage/selectors.tsx
@@ -10,10 +10,7 @@ import type {
   CollectionSidebarType,
 } from "metabase/admin/permissions/selectors/collection-permissions";
 import { getPermissionWarningModal } from "metabase/admin/permissions/selectors/confirmations";
-import type {
-  DataPermissionValue,
-  PermissionEditorType,
-} from "metabase/admin/permissions/types";
+import type { PermissionEditorType } from "metabase/admin/permissions/types";
 import { findCollectionById } from "metabase/common/utils/collections";
 import {
   Collections,
@@ -31,6 +28,7 @@ import {
 import type {
   CollectionId,
   CollectionPermissions,
+  DataPermissionValue,
   Group as GroupType,
 } from "metabase-types/api";
 

--- a/frontend/src/metabase-types/api/mocks/permissions.ts
+++ b/frontend/src/metabase-types/api/mocks/permissions.ts
@@ -1,13 +1,11 @@
 import {
   DataPermission,
   DataPermissionValue,
-} from "metabase/admin/permissions/types";
-import type {
-  Database,
-  Group,
-  GroupsPermissions,
-  Impersonation,
-  PermissionsGraph,
+  type Database,
+  type Group,
+  type GroupsPermissions,
+  type Impersonation,
+  type PermissionsGraph,
 } from "metabase-types/api";
 
 export const createMockPermissionsGraph = ({

--- a/frontend/src/metabase-types/api/permissions.ts
+++ b/frontend/src/metabase-types/api/permissions.ts
@@ -1,8 +1,4 @@
 import type {
-  DataPermission,
-  DataPermissionValue,
-} from "metabase/admin/permissions/types";
-import type {
   CollectionId,
   DatabaseId,
   SchemaName,
@@ -11,6 +7,40 @@ import type {
 
 import type { GroupId } from "./group";
 import type { UserAttributeKey } from "./user";
+
+export enum DataPermission {
+  VIEW_DATA = "view-data",
+  CREATE_QUERIES = "create-queries",
+  DOWNLOAD = "download",
+  DATA_MODEL = "data-model",
+  DETAILS = "details",
+  TRANSFORMS = "transforms",
+  COLLECTIONS = "collections",
+}
+
+export enum DataPermissionValue {
+  BLOCKED = "blocked",
+  CONTROLLED = "controlled",
+  IMPERSONATED = "impersonated",
+  LEGACY_NO_SELF_SERVICE = "legacy-no-self-service",
+  NO = "no",
+  QUERY_BUILDER = "query-builder",
+  QUERY_BUILDER_AND_NATIVE = "query-builder-and-native",
+  SANDBOXED = "sandboxed",
+  UNRESTRICTED = "unrestricted",
+  // download specific values
+  NONE = "none",
+  LIMITED = "limited",
+  FULL = "full",
+  // details specific values
+  YES = "yes",
+  // data model specific values
+  ALL = "all",
+  //collections
+  WRITE = "write",
+  READ = "read",
+  //NONE = "none", //shared with download above
+}
 
 export type PermissionsGraph = {
   groups: GroupsPermissions;

--- a/frontend/src/metabase/admin/permissions/components/DataPermissionsHelp/DataPermissionsHelp.tsx
+++ b/frontend/src/metabase/admin/permissions/components/DataPermissionsHelp/DataPermissionsHelp.tsx
@@ -1,7 +1,6 @@
 import { jt, t } from "ttag";
 
 import { PermissionHelpDescription } from "metabase/admin/permissions/components/PermissionHelpDescription";
-import { DataPermissionValue } from "metabase/admin/permissions/types";
 import { ExternalLink } from "metabase/common/components/ExternalLink";
 import { useDocsUrl } from "metabase/common/hooks";
 import { PLUGIN_TRANSFORMS } from "metabase/plugins";
@@ -18,6 +17,7 @@ import {
   Title,
   rem,
 } from "metabase/ui";
+import { DataPermissionValue } from "metabase-types/api";
 
 import { hasPermissionValueInGraph } from "../../utils/graph/data-permissions";
 

--- a/frontend/src/metabase/admin/permissions/components/PermissionsConfirm.tsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsConfirm.tsx
@@ -5,9 +5,9 @@ import type {
   GroupPermissionsDiff,
   PermissionsGraphDiff,
 } from "metabase/admin/permissions/types";
-import { DataPermissionValue } from "metabase/admin/permissions/types";
 import CS from "metabase/css/core/index.css";
 import { Tooltip } from "metabase/ui";
+import { DataPermissionValue } from "metabase-types/api";
 
 const GroupName = ({ group }: { group: GroupPermissionsDiff }) => (
   <span className={CS.textBrand}>{group.name}</span>

--- a/frontend/src/metabase/admin/permissions/types.ts
+++ b/frontend/src/metabase/admin/permissions/types.ts
@@ -5,6 +5,12 @@ import type { State } from "metabase/redux/store";
 import type { IconName } from "metabase/ui";
 import type { ColorName } from "metabase/ui/colors/types";
 import type { GroupId } from "metabase-types/api";
+import {
+  DataPermission,
+  DataPermissionValue,
+} from "metabase-types/api/permissions";
+
+export { DataPermission, DataPermissionValue };
 
 export type GroupRouteParams = {
   groupId?: number;
@@ -65,16 +71,6 @@ export type EntityId = DatabaseEntityId &
 
 export type EntityWithGroupId = EntityId & { groupId: number };
 
-export enum DataPermission {
-  VIEW_DATA = "view-data",
-  CREATE_QUERIES = "create-queries",
-  DOWNLOAD = "download",
-  DATA_MODEL = "data-model",
-  DETAILS = "details",
-  TRANSFORMS = "transforms",
-  COLLECTIONS = "collections",
-}
-
 export enum DataPermissionType {
   ACCESS = "access",
   NATIVE = "native",
@@ -83,30 +79,6 @@ export enum DataPermissionType {
   DATA_MODEL = "data-model",
   TRANSFORMS = "transforms",
   COLLECTIONS = "collections",
-}
-
-export enum DataPermissionValue {
-  BLOCKED = "blocked",
-  CONTROLLED = "controlled",
-  IMPERSONATED = "impersonated",
-  LEGACY_NO_SELF_SERVICE = "legacy-no-self-service",
-  NO = "no",
-  QUERY_BUILDER = "query-builder",
-  QUERY_BUILDER_AND_NATIVE = "query-builder-and-native",
-  SANDBOXED = "sandboxed",
-  UNRESTRICTED = "unrestricted",
-  // download specific values
-  NONE = "none",
-  LIMITED = "limited",
-  FULL = "full",
-  // details specific values
-  YES = "yes",
-  // data model specific values
-  ALL = "all",
-  //collections
-  WRITE = "write",
-  READ = "read",
-  //NONE = "none", //shared with download above
 }
 
 export type DatabasePermissionsDiff = {

--- a/frontend/src/metabase/admin/permissions/utils/graph/data-permissions/get.ts
+++ b/frontend/src/metabase/admin/permissions/utils/graph/data-permissions/get.ts
@@ -6,12 +6,12 @@ import type {
   SchemaEntityId,
   TableEntityId,
 } from "metabase/admin/permissions/types";
+import { PLUGIN_ADVANCED_PERMISSIONS } from "metabase/plugins";
 import {
   DataPermission,
   DataPermissionValue,
-} from "metabase/admin/permissions/types";
-import { PLUGIN_ADVANCED_PERMISSIONS } from "metabase/plugins";
-import type { GroupsPermissions } from "metabase-types/api";
+  type GroupsPermissions,
+} from "metabase-types/api";
 
 // permission that do not have a nested schemas/native key
 const flatPermissions = new Set([

--- a/frontend/src/metabase/admin/permissions/utils/graph/data-permissions/has.ts
+++ b/frontend/src/metabase/admin/permissions/utils/graph/data-permissions/has.ts
@@ -1,8 +1,6 @@
 import _ from "underscore";
 
 import type {
-  DataPermission,
-  DataPermissionValue,
   DatabaseEntityId,
   EntityWithGroupId,
   SchemaEntityId,
@@ -10,6 +8,8 @@ import type {
 import { isSchemaEntityId } from "metabase/admin/permissions/utils/data-entity-id";
 import type {
   ConcreteTableId,
+  DataPermission,
+  DataPermissionValue,
   DatabasePermissions,
   GroupPermissions,
   GroupsPermissions,

--- a/frontend/src/metabase/admin/permissions/utils/graph/data-permissions/has.unit.spec.ts
+++ b/frontend/src/metabase/admin/permissions/utils/graph/data-permissions/has.unit.spec.ts
@@ -1,11 +1,11 @@
 import _ from "underscore";
 
+import { PLUGIN_ADVANCED_PERMISSIONS } from "metabase/plugins";
 import {
   DataPermission,
   DataPermissionValue,
-} from "metabase/admin/permissions/types";
-import { PLUGIN_ADVANCED_PERMISSIONS } from "metabase/plugins";
-import type { GroupsPermissions } from "metabase-types/api";
+  type GroupsPermissions,
+} from "metabase-types/api";
 
 import { hasPermissionValueInSubgraph } from "./has";
 

--- a/frontend/src/metabase/admin/permissions/utils/graph/data-permissions/update.ts
+++ b/frontend/src/metabase/admin/permissions/utils/graph/data-permissions/update.ts
@@ -8,10 +8,6 @@ import type {
   TableEntityId,
 } from "metabase/admin/permissions/types";
 import {
-  DataPermission,
-  DataPermissionValue,
-} from "metabase/admin/permissions/types";
-import {
   isSchemaEntityId,
   isTableEntityId,
 } from "metabase/admin/permissions/utils/data-entity-id";
@@ -22,7 +18,11 @@ import {
 import { PLUGIN_DATA_PERMISSIONS } from "metabase/plugins";
 import type Database from "metabase-lib/v1/metadata/Database";
 import type Table from "metabase-lib/v1/metadata/Table";
-import type { GroupsPermissions } from "metabase-types/api";
+import {
+  DataPermission,
+  DataPermissionValue,
+  type GroupsPermissions,
+} from "metabase-types/api";
 
 import {
   getFieldsPermission,

--- a/frontend/src/metabase/admin/permissions/utils/graph/data-permissions/utils.ts
+++ b/frontend/src/metabase/admin/permissions/utils/graph/data-permissions/utils.ts
@@ -1,5 +1,5 @@
-import { DataPermissionValue } from "metabase/admin/permissions/types";
 import { PLUGIN_ADVANCED_PERMISSIONS } from "metabase/plugins";
+import { DataPermissionValue } from "metabase-types/api";
 
 export const isRestrictivePermission = (value: DataPermissionValue) =>
   value === DataPermissionValue.NO ||

--- a/frontend/src/metabase/dashboard/components/DashboardSubscriptionsSidebar/AddEditSidebar/AddEditEmailSidebar.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardSubscriptionsSidebar/AddEditSidebar/AddEditEmailSidebar.tsx
@@ -3,7 +3,6 @@ import { useEffect } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
-import { DataPermissionValue } from "metabase/admin/permissions/types";
 import {
   type ScheduleChangeProp,
   SchedulePicker,
@@ -22,13 +21,14 @@ import type { DraftDashboardSubscription } from "metabase/redux/store";
 import { canAccessSettings, getUser } from "metabase/selectors/user";
 import { Icon, Title } from "metabase/ui";
 import type { UiParameter } from "metabase-lib/v1/parameters/types";
-import type {
-  Channel,
-  ChannelApiResponse,
-  ChannelSpec,
-  Dashboard,
-  ScheduleSettings,
-  User,
+import {
+  type Channel,
+  type ChannelApiResponse,
+  type ChannelSpec,
+  type Dashboard,
+  DataPermissionValue,
+  type ScheduleSettings,
+  type User,
 } from "metabase-types/api";
 
 import { CaveatMessage } from "./CaveatMessage";

--- a/frontend/src/metabase/plugins/oss/permissions.ts
+++ b/frontend/src/metabase/plugins/oss/permissions.ts
@@ -1,23 +1,23 @@
 import type { ReactNode } from "react";
 
-import {
-  type DataPermission,
-  DataPermissionValue,
-  type DatabaseEntityId,
-  type EntityId,
-  type PermissionSubject,
-  type SpecialGroupType,
+import type {
+  DatabaseEntityId,
+  EntityId,
+  PermissionSubject,
+  SpecialGroupType,
 } from "metabase/admin/permissions/types";
 import type { State } from "metabase/redux/store";
 import { getUserIsAdmin } from "metabase/selectors/user";
 import type Database from "metabase-lib/v1/metadata/Database";
 import type {
+  DataPermission,
   Dataset,
   Group,
   GroupPermissions,
   GroupsPermissions,
   User,
 } from "metabase-types/api";
+import { DataPermissionValue } from "metabase-types/api";
 
 import type { PluginGroupManagersType } from "../types";
 


### PR DESCRIPTION
Fixes a dashboard violations and 2 metabase-types violations. 

Longterm, I think permissions needs to be extracted out of admin, but it's a bigger job.

The embedding change is just updating imports