### PR TITLE
🤖 backported "don't consider advisories active on dev" 

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/security_center/matching.clj
+++ b/enterprise/backend/src/metabase_enterprise/security_center/matching.clj
@@ -33,13 +33,15 @@
         nil))))
 
 (defn- version-in-range?
-  "True if `version` is >= min and < fixed."
-  [^Semver version {:keys [min fixed]}]
-  (let [^Semver min-v   (parse-version min)
-        ^Semver fixed-v (parse-version fixed)]
-    (and min-v fixed-v
-         (.isGreaterThanOrEqualTo version min-v)
-         (.isLowerThan version fixed-v))))
+  "True if `version` is >= min and < fixed. A nil `version` (e.g. vLOCAL_DEV or
+   vUNKNOWN, which don't parse) is treated as not in any range."
+  [version {:keys [min fixed]}]
+  (when version
+    (let [^Semver min-v   (parse-version min)
+          ^Semver fixed-v (parse-version fixed)]
+      (and min-v fixed-v
+           (.isGreaterThanOrEqualTo ^Semver version min-v)
+           (.isLowerThan ^Semver version fixed-v)))))
 
 (defn- affected-by-version?
   "True if `version` falls in any of the affected version ranges."
@@ -98,12 +100,14 @@
 ;;; ------------------------------------------- Advisory Evaluation ------------------------------------------------
 
 (mu/defn evaluate-advisory :- ::schema/match-status
-  "Pure evaluation: given an advisory, instance version, and query result, return the resolved match status.
-   Does not perform I/O — call [[execute-matching-query!]] separately to obtain `query-result`.
-   `query-result` is true (matched), false (no match), or :error."
-  [advisory         :- [:map [:affected_versions ::schema/affected-versions]]
-   instance-version :- [:maybe [:fn #(instance? Semver %)]]
-   query-result     :- QueryResult]
+  "Resolve a match status from a version-range check and a matching-query result.
+
+     query-result = :error → :error
+     query-result = false  → :not_affected
+     in-range?    = true   → :active
+     otherwise             → :resolved"
+  [in-range?    :- boolean?
+   query-result :- QueryResult]
   (cond
     (= query-result :error)
     :error
@@ -111,24 +115,28 @@
     (not query-result)
     :not_affected
 
-    (or (nil? instance-version)
-        (affected-by-version? instance-version (:affected_versions advisory)))
+    in-range?
     :active
 
     :else
     :resolved))
 
 (defn evaluate-advisory!
-  "Evaluate a single advisory: run matching query, resolve status, update DB.
-   2-arity takes a pre-parsed instance version to avoid re-parsing in batch."
+  "Evaluate a single advisory: run the matching query, resolve the status, and
+   update the DB. 2-arity takes a pre-parsed instance version to avoid re-parsing
+   in batch.
+
+   Short-circuits entirely (no query, no DB update) when the version is outside
+   every affected range and the advisory is already in a terminal state."
   ([advisory]
    (evaluate-advisory! advisory (parse-version (:tag config/mb-version-info))))
   ([advisory instance-version]
-   (let [query-result (execute-matching-query! (:matching_query advisory))
-         match-status (evaluate-advisory advisory instance-version query-result)]
-     (t2/update! :model/SecurityAdvisory (:id advisory)
-                 {:match_status      match-status
-                  :last_evaluated_at (mi/now)}))))
+   (let [in-range? (affected-by-version? instance-version (:affected_versions advisory))]
+     (when-not (and (not in-range?) (#{:resolved :not_affected} (:match_status advisory)))
+       (let [match-status (evaluate-advisory in-range? (execute-matching-query! (:matching_query advisory)))]
+         (t2/update! :model/SecurityAdvisory (:id advisory)
+                     {:match_status      match-status
+                      :last_evaluated_at (mi/now)}))))))
 
 (defn evaluate-all-advisories!
   "Re-evaluate all non-acknowledged advisories, plus any acknowledged advisories

--- a/enterprise/backend/test/metabase_enterprise/security_center/matching_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/security_center/matching_test.clj
@@ -4,6 +4,7 @@
    [java-time.api :as t]
    [metabase-enterprise.security-center.matching :as matching]
    [metabase.app-db.core :as mdb]
+   [metabase.config.core :as config]
    [metabase.models.interface :as mi]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
@@ -30,57 +31,60 @@
       nil
       "")))
 
-(deftest ^:parallel evaluate-advisory-test
-  (let [v             matching/parse-version
-        single-range  {:affected_versions [{:min "1.57.0" :fixed "1.57.16"}]}
-        multi-range   {:affected_versions [{:min "1.57.0" :fixed "1.57.16"}
-                                           {:min "1.58.0" :fixed "1.58.10"}]}
-        narrow-range  {:affected_versions [{:min "0.50.0" :fixed "0.50.2"}]}]
-    (testing "query result takes priority over version"
-      (are [expected version query-result]
-           (= expected (matching/evaluate-advisory single-range version query-result))
-        :not_affected (v "1.57.5")  false
-        :not_affected (v "1.57.16") false
-        :error        (v "1.57.5")  :error
-        :error        (v "1.57.16") :error))
-    (testing "single range — version determines active vs resolved"
-      (are [expected version]
-           (= expected (matching/evaluate-advisory single-range version true))
-        :active   (v "1.57.0")      ; at min boundary
-        :active   (v "1.57.5")      ; mid-range
-        :active   (v "1.57.15")     ; one patch before fixed
-        :resolved (v "1.57.16")     ; at fixed boundary
-        :resolved (v "1.57.17")     ; one patch after fixed
-        :resolved (v "1.57.20")     ; well past fixed
-        :resolved (v "1.56.0")      ; before range
-        :resolved (v "1.59.0")      ; past range
-        :resolved (v "0.57.5")))    ; OSS doesn't match EE range
-    (testing "nil version (LOCAL_DEV) → active when query matches"
-      (is (= :active (matching/evaluate-advisory single-range nil true))))
-    (testing "nil version + no match → not_affected"
-      (is (= :not_affected (matching/evaluate-advisory single-range nil false))))
-    (testing "nil version + error → error"
-      (is (= :error (matching/evaluate-advisory single-range nil :error))))
-    (testing "multiple ranges"
-      (are [expected version]
-           (= expected (matching/evaluate-advisory multi-range version true))
-        :active   (v "1.57.5")      ; in first range
-        :active   (v "1.58.3")      ; in second range
-        :active   (v "1.58.0")      ; at second range min boundary
-        :resolved (v "1.57.20")     ; between ranges (patched for first, before second)
-        :resolved (v "1.58.10")     ; at second range fixed boundary
-        :resolved (v "1.59.0")))    ; past all ranges
+#_:clj-kondo/ignore
+(deftest ^:parallel affected-by-version?-test
+  (let [v            matching/parse-version
+        in-range?    @#'matching/affected-by-version?
+        single-range [{:min "1.57.0" :fixed "1.57.16"}]
+        multi-range  [{:min "1.57.0" :fixed "1.57.16"}
+                      {:min "1.58.0" :fixed "1.58.10"}]
+        narrow-range [{:min "0.50.0" :fixed "0.50.2"}]]
+    (testing "single range — inclusive min, exclusive fixed"
+      (are [expected version] (= expected (in-range? (v version) single-range))
+        true  "1.57.0"                  ; at min boundary
+        true  "1.57.5"                  ; mid-range
+        true  "1.57.15"                 ; one patch before fixed
+        false "1.57.16"                 ; at fixed boundary
+        false "1.57.17"                 ; one patch after fixed
+        false "1.56.0"                  ; before range
+        false "1.59.0"                  ; past range
+        false "0.57.5"))                ; OSS doesn't match EE range
+    (testing "multiple ranges — any range counts"
+      (are [expected version] (= expected (in-range? (v version) multi-range))
+        true  "1.57.5"                  ; in first range
+        true  "1.58.3"                  ; in second range
+        true  "1.58.0"                  ; at second range min boundary
+        false "1.57.20"                 ; between ranges
+        false "1.58.10"                 ; at second range fixed
+        false "1.59.0"))                ; past all ranges
     (testing "narrow patch range [0.50.0, 0.50.2)"
-      (are [expected version]
-           (= expected (matching/evaluate-advisory narrow-range version true))
-        :active   (v "0.50.0")      ; at min
-        :active   (v "0.50.1")      ; mid-range
-        :resolved (v "0.50.2")      ; at fixed
-        :resolved (v "1.0.0")))     ; major version jump
-    (testing "pre-release of fixed version is still affected"
-      (is (= :active (matching/evaluate-advisory single-range (v "1.57.16-beta") true))))
-    (testing "empty affected_versions — query matches but no ranges → resolved"
-      (is (= :resolved (matching/evaluate-advisory {:affected_versions []} (v "1.57.5") true))))))
+      (are [expected version] (= expected (in-range? (v version) narrow-range))
+        true  "0.50.0"
+        true  "0.50.1"
+        false "0.50.2"
+        false "1.0.0"))
+    (testing "pre-release of fixed version is still in range"
+      (is (true? (in-range? (v "1.57.16-beta") single-range))))
+    (testing "empty affected_versions → never in range"
+      (is (false? (in-range? (v "1.57.5") []))))
+    (testing "nil version (vLOCAL_DEV / vUNKNOWN parse to nil) → never in range"
+      (is (nil? (v "vLOCAL_DEV")))
+      (is (nil? (v "vUNKNOWN")))
+      (is (false? (in-range? nil single-range)))
+      (is (false? (in-range? nil multi-range)))
+      (is (false? (in-range? nil []))))))
+
+(deftest ^:parallel evaluate-advisory-test
+  (testing ":error query-result propagates regardless of in-range?"
+    (is (= :error (matching/evaluate-advisory true  :error)))
+    (is (= :error (matching/evaluate-advisory false :error))))
+  (testing "falsey query-result → :not_affected regardless of in-range?"
+    (is (= :not_affected (matching/evaluate-advisory true  false)))
+    (is (= :not_affected (matching/evaluate-advisory false false))))
+  (testing "query matched + in-range → :active"
+    (is (= :active (matching/evaluate-advisory true true))))
+  (testing "query matched + out-of-range → :resolved (was affected, now past the fix)"
+    (is (= :resolved (matching/evaluate-advisory false true)))))
 
 (deftest execute-matching-query-test
   (testing "nil query means affects all — returns true"
@@ -116,58 +120,175 @@
         (is (pos? (t2/count :model/User)))))))
 
 (deftest evaluate-advisory!-test
-  (testing "query matches + version in range → active"
-    (mt/with-temp [:model/SecurityAdvisory advisory
-                   {:advisory_id       "SC-MATCH-001"
-                    :severity          "critical"
-                    :title             "Test"
+  (with-redefs [config/mb-version-info {:tag "v1.55.0"}]
+    (testing "query matches + version in range → active"
+      (mt/with-temp [:model/SecurityAdvisory advisory
+                     {:advisory_id       "SC-MATCH-001"
+                      :severity          "critical"
+                      :title             "Test"
+                      :description       "Test"
+                      :remediation       "Upgrade"
+                      :affected_versions [{:min "0.1.0" :fixed "99.99.99"}]
+                      :matching_query    {:default {:select [1] :from [:core_user] :limit 1}}
+                      :match_status      "not_affected"
+                      :published_at      #t "2026-03-24T00:00:00Z"
+                      :updated_at        #t "2026-03-24T00:00:00Z"}]
+        (matching/evaluate-advisory! advisory)
+        (is (=? {:match_status     :active
+                 :last_evaluated_at some?}
+                (t2/select-one :model/SecurityAdvisory :id (:id advisory))))))
+    (testing "query doesn't match → not_affected"
+      (mt/with-temp [:model/SecurityAdvisory advisory
+                     {:advisory_id       "SC-MATCH-002"
+                      :severity          "high"
+                      :title             "Test"
+                      :description       "Test"
+                      :remediation       "Upgrade"
+                      :affected_versions [{:min "0.1.0" :fixed "99.99.99"}]
+                      :matching_query    {:default {:select [1] :from [:core_user]
+                                                    :where [:= :email "nonexistent@example.com"] :limit 1}}
+                      :match_status      "active"
+                      :published_at      #t "2026-03-24T00:00:00Z"
+                      :updated_at        #t "2026-03-24T00:00:00Z"}]
+        (matching/evaluate-advisory! advisory)
+        (is (=? {:match_status :not_affected}
+                (t2/select-one :model/SecurityAdvisory :id (:id advisory))))))
+    (testing "nil matching_query (affects all) + version in range → active"
+      (mt/with-temp [:model/SecurityAdvisory advisory
+                     {:advisory_id       "SC-MATCH-003"
+                      :severity          "medium"
+                      :title             "Test"
+                      :description       "Test"
+                      :remediation       "Upgrade"
+                      :affected_versions [{:min "0.1.0" :fixed "99.99.99"}]
+                      :matching_query    nil
+                      :match_status      "not_affected"
+                      :published_at      #t "2026-03-24T00:00:00Z"
+                      :updated_at        #t "2026-03-24T00:00:00Z"}]
+        (matching/evaluate-advisory! advisory)
+        (is (=? {:match_status :active}
+                (t2/select-one :model/SecurityAdvisory :id (:id advisory))))))
+    (testing "query error → error status persisted"
+      (mt/with-temp [:model/SecurityAdvisory advisory
+                     {:advisory_id       "SC-MATCH-004"
+                      :severity          "low"
+                      :title             "Test"
+                      :description       "Test"
+                      :remediation       "Upgrade"
+                      :affected_versions [{:min "0.1.0" :fixed "99.99.99"}]
+                      :matching_query    {:default {:select [1] :from [:nonexistent_table] :limit 1}}
+                      :match_status      "not_affected"
+                      :published_at      #t "2026-03-24T00:00:00Z"
+                      :updated_at        #t "2026-03-24T00:00:00Z"}]
+        (matching/evaluate-advisory! advisory)
+        (is (=? {:match_status      :error
+                 :last_evaluated_at some?}
+                (t2/select-one :model/SecurityAdvisory :id (:id advisory))))))
+  ;; Out-of-range: current instance version is not covered by [0.0.1, 0.0.2).
+  ;; The matching_query in these tests would throw if executed — that's how we
+  ;; verify the short-circuit actually avoids running the query.
+    (let [past #t "2020-01-01T00:00:00Z"]
+      (testing "out-of-range + already :resolved → skip entirely (query not run, timestamp preserved)"
+        (mt/with-temp [:model/SecurityAdvisory advisory
+                       {:advisory_id       "SC-MATCH-SKIP-001"
+                        :severity          "high"
+                        :title             "Test"
+                        :description       "Test"
+                        :remediation       "Upgrade"
+                        :affected_versions [{:min "0.0.1" :fixed "0.0.2"}]
+                        :matching_query    {:default {:select [1] :from [:nonexistent_table] :limit 1}}
+                        :match_status      "resolved"
+                        :last_evaluated_at past
+                        :published_at      #t "2026-03-24T00:00:00Z"
+                        :updated_at        #t "2026-03-24T00:00:00Z"}]
+          (matching/evaluate-advisory! advisory)
+          (let [reloaded (t2/select-one :model/SecurityAdvisory :id (:id advisory))]
+            (is (= :resolved (:match_status reloaded)))
+            (is (= (t/instant past) (t/instant (:last_evaluated_at reloaded)))))))
+      (testing "out-of-range + already :not_affected → skip entirely"
+        (mt/with-temp [:model/SecurityAdvisory advisory
+                       {:advisory_id       "SC-MATCH-SKIP-002"
+                        :severity          "low"
+                        :title             "Test"
+                        :description       "Test"
+                        :remediation       "Upgrade"
+                        :affected_versions [{:min "0.0.1" :fixed "0.0.2"}]
+                        :matching_query    {:default {:select [1] :from [:nonexistent_table] :limit 1}}
+                        :match_status      "not_affected"
+                        :last_evaluated_at past
+                        :published_at      #t "2026-03-24T00:00:00Z"
+                        :updated_at        #t "2026-03-24T00:00:00Z"}]
+          (matching/evaluate-advisory! advisory)
+          (let [reloaded (t2/select-one :model/SecurityAdvisory :id (:id advisory))]
+            (is (= :not_affected (:match_status reloaded)))
+            (is (= (t/instant past) (t/instant (:last_evaluated_at reloaded))))))))
+    (testing "out-of-range + :active + query match → transitions to :resolved"
+      (mt/with-temp [:model/SecurityAdvisory advisory
+                     {:advisory_id       "SC-MATCH-RESOLVE-001"
+                      :severity          "high"
+                      :title             "Test"
+                      :description       "Test"
+                      :remediation       "Upgrade"
+                      :affected_versions [{:min "0.0.1" :fixed "0.0.2"}]
+                      :matching_query    {:default {:select [1] :from [:core_user] :limit 1}}
+                      :match_status      "active"
+                      :published_at      #t "2026-03-24T00:00:00Z"
+                      :updated_at        #t "2026-03-24T00:00:00Z"}]
+        (matching/evaluate-advisory! advisory)
+        (is (=? {:match_status      :resolved
+                 :last_evaluated_at some?}
+                (t2/select-one :model/SecurityAdvisory :id (:id advisory))))))
+  ;; vLOCAL_DEV / vUNKNOWN both parse to nil. An unparseable instance version
+  ;; must never produce :active — we cannot claim an instance is affected when
+  ;; we can't even compare its version to the affected ranges.
+    (doseq [tag ["vLOCAL_DEV" "vUNKNOWN"]]
+      (testing (str "unparseable instance version " (pr-str tag) " never yields :active")
+        (is (nil? (matching/parse-version tag)))
+        (mt/with-temp [:model/SecurityAdvisory advisory
+                       {:advisory_id       (str "SC-MATCH-NIL-VER-" tag)
+                        :severity          "high"
+                        :title             "Test"
+                        :description       "Test"
+                        :remediation       "Upgrade"
+                      ;; Range that would normally match any realistic version.
+                        :affected_versions [{:min "0.1.0" :fixed "99.99.99"}]
+                        :matching_query    {:default {:select [1] :from [:core_user] :limit 1}}
+                        :match_status      "unknown"
+                        :published_at      #t "2026-03-24T00:00:00Z"
+                        :updated_at        #t "2026-03-24T00:00:00Z"}]
+          (matching/evaluate-advisory! advisory (matching/parse-version tag))
+          (let [reloaded (t2/select-one :model/SecurityAdvisory :id (:id advisory))]
+            (is (not= :active (:match_status reloaded)))))))))
+
+(deftest evaluate-all-advisories!-test
+  (with-redefs [config/mb-version-info {:tag "v1.55.0"}]
+    (mt/with-temp [:model/SecurityAdvisory _active
+                   {:advisory_id       "SC-EVAL-001"
+                    :severity          "high"
+                    :title             "Active advisory"
                     :description       "Test"
                     :remediation       "Upgrade"
                     :affected_versions [{:min "0.1.0" :fixed "99.99.99"}]
                     :matching_query    {:default {:select [1] :from [:core_user] :limit 1}}
                     :match_status      "not_affected"
                     :published_at      #t "2026-03-24T00:00:00Z"
-                    :updated_at        #t "2026-03-24T00:00:00Z"}]
-      (matching/evaluate-advisory! advisory)
-      (is (=? {:match_status     :active
-               :last_evaluated_at some?}
-              (t2/select-one :model/SecurityAdvisory :id (:id advisory))))))
-  (testing "query doesn't match → not_affected"
-    (mt/with-temp [:model/SecurityAdvisory advisory
-                   {:advisory_id       "SC-MATCH-002"
-                    :severity          "high"
-                    :title             "Test"
+                    :updated_at        #t "2026-03-24T00:00:00Z"}
+                   :model/SecurityAdvisory _not-affected
+                   {:advisory_id       "SC-EVAL-002"
+                    :severity          "medium"
+                    :title             "Not affected advisory"
                     :description       "Test"
                     :remediation       "Upgrade"
                     :affected_versions [{:min "0.1.0" :fixed "99.99.99"}]
                     :matching_query    {:default {:select [1] :from [:core_user]
                                                   :where [:= :email "nonexistent@example.com"] :limit 1}}
-                    :match_status      "active"
-                    :published_at      #t "2026-03-24T00:00:00Z"
-                    :updated_at        #t "2026-03-24T00:00:00Z"}]
-      (matching/evaluate-advisory! advisory)
-      (is (=? {:match_status :not_affected}
-              (t2/select-one :model/SecurityAdvisory :id (:id advisory))))))
-  (testing "nil matching_query (affects all) + version in range → active"
-    (mt/with-temp [:model/SecurityAdvisory advisory
-                   {:advisory_id       "SC-MATCH-003"
-                    :severity          "medium"
-                    :title             "Test"
-                    :description       "Test"
-                    :remediation       "Upgrade"
-                    :affected_versions [{:min "0.1.0" :fixed "99.99.99"}]
-                    :matching_query    nil
                     :match_status      "not_affected"
                     :published_at      #t "2026-03-24T00:00:00Z"
-                    :updated_at        #t "2026-03-24T00:00:00Z"}]
-      (matching/evaluate-advisory! advisory)
-      (is (=? {:match_status :active}
-              (t2/select-one :model/SecurityAdvisory :id (:id advisory))))))
-  (testing "query error → error status persisted"
-    (mt/with-temp [:model/SecurityAdvisory advisory
-                   {:advisory_id       "SC-MATCH-004"
+                    :updated_at        #t "2026-03-24T00:00:00Z"}
+                   :model/SecurityAdvisory _erroring
+                   {:advisory_id       "SC-EVAL-003"
                     :severity          "low"
-                    :title             "Test"
+                    :title             "Erroring advisory"
                     :description       "Test"
                     :remediation       "Upgrade"
                     :affected_versions [{:min "0.1.0" :fixed "99.99.99"}]
@@ -175,75 +296,35 @@
                     :match_status      "not_affected"
                     :published_at      #t "2026-03-24T00:00:00Z"
                     :updated_at        #t "2026-03-24T00:00:00Z"}]
-      (matching/evaluate-advisory! advisory)
-      (is (=? {:match_status      :error
-               :last_evaluated_at some?}
-              (t2/select-one :model/SecurityAdvisory :id (:id advisory)))))))
-
-(deftest evaluate-all-advisories!-test
-  (mt/with-temp [:model/SecurityAdvisory _active
-                 {:advisory_id       "SC-EVAL-001"
-                  :severity          "high"
-                  :title             "Active advisory"
-                  :description       "Test"
-                  :remediation       "Upgrade"
-                  :affected_versions [{:min "0.1.0" :fixed "99.99.99"}]
-                  :matching_query    {:default {:select [1] :from [:core_user] :limit 1}}
-                  :match_status      "not_affected"
-                  :published_at      #t "2026-03-24T00:00:00Z"
-                  :updated_at        #t "2026-03-24T00:00:00Z"}
-                 :model/SecurityAdvisory _not-affected
-                 {:advisory_id       "SC-EVAL-002"
-                  :severity          "medium"
-                  :title             "Not affected advisory"
-                  :description       "Test"
-                  :remediation       "Upgrade"
-                  :affected_versions [{:min "0.1.0" :fixed "99.99.99"}]
-                  :matching_query    {:default {:select [1] :from [:core_user]
-                                                :where [:= :email "nonexistent@example.com"] :limit 1}}
-                  :match_status      "not_affected"
-                  :published_at      #t "2026-03-24T00:00:00Z"
-                  :updated_at        #t "2026-03-24T00:00:00Z"}
-                 :model/SecurityAdvisory _erroring
-                 {:advisory_id       "SC-EVAL-003"
-                  :severity          "low"
-                  :title             "Erroring advisory"
-                  :description       "Test"
-                  :remediation       "Upgrade"
-                  :affected_versions [{:min "0.1.0" :fixed "99.99.99"}]
-                  :matching_query    {:default {:select [1] :from [:nonexistent_table] :limit 1}}
-                  :match_status      "not_affected"
-                  :published_at      #t "2026-03-24T00:00:00Z"
-                  :updated_at        #t "2026-03-24T00:00:00Z"}]
-    (matching/evaluate-all-advisories!)
-    (let [fetch (fn [id] (t2/select-one :model/SecurityAdvisory :advisory_id id))
-          past #t "2020-01-01T00:00:00Z"]
-      (testing "each advisory gets the correct status and timestamp"
-        (is (=? {:match_status      :active
-                 :last_evaluated_at some?}
-                (fetch "SC-EVAL-001")))
-        (is (=? {:match_status      :not_affected
-                 :last_evaluated_at some?}
-                (fetch "SC-EVAL-002")))
-        (is (=? {:match_status      :error
-                 :last_evaluated_at some?}
-                (fetch "SC-EVAL-003"))))
-      (testing "acknowledged + active advisories are still re-evaluated"
-        (t2/update! :model/SecurityAdvisory {:advisory_id "SC-EVAL-001"}
-                    {:acknowledged_at (mi/now) :acknowledged_by (mt/user->id :rasta)
-                     :last_evaluated_at past})
-        (matching/evaluate-all-advisories!)
-        (is (not= past (:last_evaluated_at (fetch "SC-EVAL-001")))))
-      (testing "acknowledged + not_affected advisories are skipped"
-        (t2/update! :model/SecurityAdvisory {:advisory_id "SC-EVAL-002"}
-                    {:acknowledged_at (mi/now) :acknowledged_by (mt/user->id :rasta)
-                     :last_evaluated_at past})
-        (matching/evaluate-all-advisories!)
-        (is (= (t/instant past)
-               (t/instant (:last_evaluated_at (fetch "SC-EVAL-002"))))))
-      (testing "acknowledged + error advisories are still re-evaluated"
-        (t2/update! :model/SecurityAdvisory {:advisory_id "SC-EVAL-003"}
-                    {:acknowledged_at (mi/now) :acknowledged_by (mt/user->id :rasta)
-                     :last_evaluated_at past})
-        (matching/evaluate-all-advisories!)
-        (is (not= past (:last_evaluated_at (fetch "SC-EVAL-003"))))))))
+      (matching/evaluate-all-advisories!)
+      (let [fetch (fn [id] (t2/select-one :model/SecurityAdvisory :advisory_id id))
+            past #t "2020-01-01T00:00:00Z"]
+        (testing "each advisory gets the correct status and timestamp"
+          (is (=? {:match_status      :active
+                   :last_evaluated_at some?}
+                  (fetch "SC-EVAL-001")))
+          (is (=? {:match_status      :not_affected
+                   :last_evaluated_at some?}
+                  (fetch "SC-EVAL-002")))
+          (is (=? {:match_status      :error
+                   :last_evaluated_at some?}
+                  (fetch "SC-EVAL-003"))))
+        (testing "acknowledged + active advisories are still re-evaluated"
+          (t2/update! :model/SecurityAdvisory {:advisory_id "SC-EVAL-001"}
+                      {:acknowledged_at (mi/now) :acknowledged_by (mt/user->id :rasta)
+                       :last_evaluated_at past})
+          (matching/evaluate-all-advisories!)
+          (is (not= past (:last_evaluated_at (fetch "SC-EVAL-001")))))
+        (testing "acknowledged + not_affected advisories are skipped"
+          (t2/update! :model/SecurityAdvisory {:advisory_id "SC-EVAL-002"}
+                      {:acknowledged_at (mi/now) :acknowledged_by (mt/user->id :rasta)
+                       :last_evaluated_at past})
+          (matching/evaluate-all-advisories!)
+          (is (= (t/instant past)
+                 (t/instant (:last_evaluated_at (fetch "SC-EVAL-002"))))))
+        (testing "acknowledged + error advisories are still re-evaluated"
+          (t2/update! :model/SecurityAdvisory {:advisory_id "SC-EVAL-003"}
+                      {:acknowledged_at (mi/now) :acknowledged_by (mt/user->id :rasta)
+                       :last_evaluated_at past})
+          (matching/evaluate-all-advisories!)
+          (is (not= past (:last_evaluated_at (fetch "SC-EVAL-003")))))))))

--- a/enterprise/backend/test/metabase_enterprise/security_center/task/sync_advisories_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/security_center/task/sync_advisories_test.clj
@@ -4,6 +4,7 @@
    [metabase-enterprise.security-center.fetch :as fetch]
    [metabase-enterprise.security-center.matching :as matching]
    [metabase-enterprise.security-center.task.sync-advisories :as sync-advisories]
+   [metabase.config.core :as config]
    [metabase.premium-features.core :as premium-features]
    [metabase.test :as mt]
    [toucan2.core :as t2]))
@@ -37,23 +38,24 @@
 
 (deftest sync-and-evaluate-e2e-test
   (testing "full flow: sync-and-evaluate! runs matching queries and updates match_status"
-    (mt/with-premium-features #{:admin-security-center}
-      (mt/test-helpers-set-global-values!
-        (mt/with-temp [:model/SecurityAdvisory advisory
-                       {:advisory_id       "SC-E2E-001"
-                        :severity          "critical"
-                        :title             "E2E test advisory"
-                        :description       "Tests the full sync-and-evaluate flow"
-                        :remediation       "Upgrade"
-                        :affected_versions [{:min "0.1.0" :fixed "99.99.99"}]
-                        :matching_query    {:default {:select [[1 :one]]}}
-                       ;; query returns rows unconditionally — tests the full evaluate flow
-                        :match_status      "not_affected"
-                        :published_at      #t "2026-03-24T00:00:00Z"
-                        :updated_at        #t "2026-03-24T00:00:00Z"}]
-          (mt/with-dynamic-fn-redefs [premium-features/security-center-enabled? (constantly true)
-                                      fetch/sync-advisories!                    (constantly nil)]
-            (#'sync-advisories/sync-and-evaluate!)
-            (let [updated (t2/select-one :model/SecurityAdvisory (:id advisory))]
-              (is (= :active (:match_status updated)))
-              (is (some? (:last_evaluated_at updated))))))))))
+    (with-redefs [config/mb-version-info {:tag "v1.55.0"}]
+      (mt/with-premium-features #{:admin-security-center}
+        (mt/test-helpers-set-global-values!
+          (mt/with-temp [:model/SecurityAdvisory advisory
+                         {:advisory_id       "SC-E2E-001"
+                          :severity          "critical"
+                          :title             "E2E test advisory"
+                          :description       "Tests the full sync-and-evaluate flow"
+                          :remediation       "Upgrade"
+                          :affected_versions [{:min "0.1.0" :fixed "99.99.99"}]
+                          :matching_query    {:default {:select [[1 :one]]}}
+                          ;; query returns rows unconditionally — tests the full evaluate flow
+                          :match_status      "not_affected"
+                          :published_at      #t "2026-03-24T00:00:00Z"
+                          :updated_at        #t "2026-03-24T00:00:00Z"}]
+            (mt/with-dynamic-fn-redefs [premium-features/security-center-enabled? (constantly true)
+                                        fetch/sync-advisories!                    (constantly nil)]
+              (#'sync-advisories/sync-and-evaluate!)
+              (let [updated (t2/select-one :model/SecurityAdvisory (:id advisory))]
+                (is (= :active (:match_status updated)))
+                (is (some? (:last_evaluated_at updated)))))))))))


### PR DESCRIPTION
Manual backport of https://github.com/metabase/metabase/pull/72943